### PR TITLE
feat(workflows): swappable DAG engine chaining skills/prompts/tools into saved pipelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ If you're a Claude Code agent or any other autonomous agent: read this file firs
 @moxxy/plugin-embeddings-transformers   on-device embeddings via xenova
 @moxxy/plugin-browser             web_fetch tool + Playwright sidecar (heavy)
 @moxxy/plugin-scheduler           cron/heartbeat: time-driven prompts + auto-scheduled skills
+@moxxy/plugin-workflows           swappable DAG engine: chain skills/prompts/tools into saved, schedulable pipelines
 @moxxy/plugin-security            opt-in capability isolation: Isolator interface + `none` / `inproc` impls
 @moxxy/isolator-worker            worker_threads-based Isolator (memory + time + JS-state isolation)
 @moxxy/isolator-subprocess        subprocess Isolator (kernel-enforced process boundary)

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ export default defineConfig({
 @moxxy/plugin-channel-http          ← HTTP channel (POST /v1/turn, /v1/turn/stream, /v1/turn/audio)
 @moxxy/plugin-scheduler             ← time-driven prompts
 @moxxy/plugin-webhooks              ← external-event triggers (verified HTTP listener + tunnels)
+@moxxy/plugin-workflows             ← swappable DAG engine: chain skills/prompts/tools into saved, schedulable pipelines
 @moxxy/plugin-security              ← opt-in capability isolation (Isolator interface + none/inproc impls)
 @moxxy/isolator-worker              ← worker_threads Isolator (memory + time + JS-state isolation)
 @moxxy/isolator-subprocess          ← subprocess Isolator (kernel-enforced process boundary)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -107,6 +107,7 @@
     "@moxxy/plugin-usage-stats": "workspace:*",
     "@moxxy/plugin-vault": "workspace:*",
     "@moxxy/plugin-webhooks": "workspace:*",
+    "@moxxy/plugin-workflows": "workspace:*",
     "@moxxy/runner": "workspace:*",
     "@moxxy/skills-builtin": "workspace:*",
     "@moxxy/tools-builtin": "workspace:*",

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -138,6 +138,7 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
 
   if (config.mode) session.modes.setActive(config.mode);
   if (config.compactor) session.compactors.setActive(config.compactor);
+  if (config.workflowExecutor) session.workflowExecutors.setActive(config.workflowExecutor);
   // Caching is on by default (stable-prefix auto-activates). `caching: false`
   // selects the no-op strategy; an explicit name overrides the default.
   if (config.context?.caching === false) {

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -55,7 +55,9 @@ import {
 import { workerIsolator } from '@moxxy/isolator-worker';
 import { subprocessIsolator } from '@moxxy/isolator-subprocess';
 import { wasmIsolator } from '@moxxy/isolator-wasm';
+import type { WorkflowStore } from '@moxxy/plugin-workflows';
 import { BUILTIN_SKILLS_DIR_RESOLVED } from './builtin-skills-dir.js';
+import { buildWorkflowsIntegration } from './workflows.js';
 
 export interface BuiltinEntry {
   readonly name: string;
@@ -101,6 +103,7 @@ export const BUILTIN_REQUIREMENT_DECISIONS: Readonly<Record<string, BuiltinRequi
   '@moxxy/synthesize-skill': { hardRequirements: false, reason: 'session access is injected by closure' },
   '@moxxy/plugin-scheduler': { hardRequirements: false, reason: 'runner and skills registry are injected by closure' },
   '@moxxy/plugin-webhooks': { hardRequirements: false, reason: 'runner is injected by closure' },
+  '@moxxy/plugin-workflows': { hardRequirements: false, reason: 'store, runner, and registries are injected by closure' },
   '@moxxy/plugin-security': { hardRequirements: false, reason: 'disabled by default and configured at runtime' },
   '@moxxy/plugin-config': { hardRequirements: false, reason: 'config applier is injected by bootstrap closure' },
   '@moxxy/plugin-usage-stats': { hardRequirements: false, reason: 'records usage via lifecycle hooks; no plugin dependency' },
@@ -127,6 +130,7 @@ export interface BuiltBuiltinsCore {
     readonly stop: () => Promise<void>;
   };
   readonly security: SecurityPluginHandle;
+  readonly workflows: { readonly store: WorkflowStore; readonly stop: () => void };
 }
 
 /**
@@ -365,6 +369,13 @@ export function buildBuiltinsCore(args: BuildBuiltinsArgs): BuiltBuiltinsCore {
     });
   entries.push({ name: '@moxxy/plugin-scheduler', plugin: schedulerPlugin });
 
+  // Workflows — saved DAGs of skills/prompts/tools. Reuses the scheduler store
+  // for time triggers (no new timer), the EventLog for afterWorkflow, and the
+  // subagent spawner for step execution. Stashes a `WorkflowsView` on the
+  // session (in onReady) backing the `/workflows` modal.
+  const workflows = buildWorkflowsIntegration({ session, scheduleStore, logger });
+  entries.push({ name: '@moxxy/plugin-workflows', plugin: workflows.plugin });
+
   // Webhooks — generic external-event triggers. Listens on its own port
   // (default 3738) and dispatches verified deliveries to runTurn via
   // the supplied runner. Agent-facing tools (webhook_create,
@@ -411,6 +422,7 @@ export function buildBuiltinsCore(args: BuildBuiltinsArgs): BuiltBuiltinsCore {
     scheduler: { store: scheduleStore, poller: schedulerPoller },
     webhooks: { store: webhookStore, config: webhookConfig, stop: stopWebhooks },
     security,
+    workflows: { store: workflows.store, stop: workflows.stop },
   };
 }
 

--- a/packages/cli/src/setup/workflows.ts
+++ b/packages/cli/src/setup/workflows.ts
@@ -1,0 +1,318 @@
+import { promises as fsp, type FSWatcher, watch as fsWatch } from 'node:fs';
+import * as path from 'node:path';
+import { createSubagentSpawner, type Session } from '@moxxy/core';
+import {
+  asPluginId,
+  moxxyPath,
+  writeFileAtomic,
+  type EmittedEvent,
+  type MoxxyEvent,
+  type Plugin,
+  type WorkflowRunResult,
+  type WorkflowsView,
+} from '@moxxy/sdk';
+import type { ScheduleStore } from '@moxxy/plugin-scheduler';
+import {
+  BUILTIN_WORKFLOWS_DIR,
+  WORKFLOWS_PLUGIN_NAME,
+  WorkflowStore,
+  buildWorkflowsPlugin,
+  defaultUserWorkflowsDir,
+  runWorkflow,
+} from '@moxxy/plugin-workflows';
+
+/**
+ * Wire the workflows plugin to the live Session. Mirrors the scheduler/webhooks
+ * wiring: build a `WorkflowStore`, an autonomous runner (a subagent spawner +
+ * the engine), a `WorkflowsView` for the `/workflows` modal, and the trigger
+ * subsystem — schedules are mirrored into the shared scheduler poller (zero new
+ * timers); `afterWorkflow` keys off the `workflow_completed` event; `fileChanged`
+ * uses fs.watch. Returns the plugin entry plus a `stop()` for the watchers.
+ */
+
+interface MiniLogger {
+  info?(msg: string, meta?: Record<string, unknown>): void;
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+  error?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface WorkflowsIntegration {
+  readonly plugin: Plugin;
+  readonly store: WorkflowStore;
+  stop(): void;
+}
+
+const PLUGIN_ID = asPluginId(WORKFLOWS_PLUGIN_NAME);
+
+export function buildWorkflowsIntegration(args: {
+  session: Session;
+  scheduleStore: ScheduleStore;
+  logger?: MiniLogger;
+}): WorkflowsIntegration {
+  const { session, scheduleStore, logger } = args;
+  const store = new WorkflowStore({
+    cwd: session.cwd,
+    builtinDir: BUILTIN_WORKFLOWS_DIR,
+    ...(logger ? { logger } : {}),
+  });
+
+  const watchers: FSWatcher[] = [];
+  const inFlight = new Set<string>();
+
+  // --- the autonomous runner: spawner + engine + inbox delivery ---
+  async function runNow(input: {
+    name: string;
+    inputs?: Record<string, unknown>;
+    trigger?: string;
+  }): Promise<WorkflowRunResult> {
+    const entry = await store.get(input.name);
+    if (!entry) return { ok: false, steps: [], output: '', error: `no workflow named "${input.name}"` };
+    if (inFlight.has(input.name)) {
+      return { ok: false, steps: [], output: '', error: `workflow "${input.name}" is already running` };
+    }
+    inFlight.add(input.name);
+    try {
+      const turnId = session.startTurn().turnId;
+      const spawner = createSubagentSpawner({
+        parentSession: session,
+        parentTurnId: turnId,
+        parentSignal: session.signal,
+        parentModel: activeModel(session),
+      });
+      const result = await runWorkflow(
+        entry.workflow,
+        {
+          spawner,
+          tools: session.tools,
+          lookup: {
+            skill: (n) => session.skills.byName(n),
+            workflow: (n) => store.lookup(n),
+          },
+          signal: session.signal,
+          ...(input.inputs ? { inputs: input.inputs } : {}),
+          trigger: input.trigger ?? 'auto',
+          now: () => Date.now(),
+          emit: (subtype, payload) =>
+            void session.log.append({
+              type: 'plugin_event',
+              sessionId: session.id,
+              turnId,
+              source: 'plugin',
+              pluginId: PLUGIN_ID,
+              subtype,
+              payload,
+            } as EmittedEvent),
+          ...(logger ? { logger } : {}),
+        },
+        { executor: session.workflowExecutors.getActive() },
+      );
+      await deliverToInbox(entry.workflow, result, logger);
+      return result;
+    } finally {
+      inFlight.delete(input.name);
+    }
+  }
+
+  // --- the /workflows modal view ---
+  const view: WorkflowsView = {
+    list: async () =>
+      (await store.list()).map((w) => ({
+        name: w.workflow.name,
+        description: w.workflow.description,
+        enabled: w.workflow.enabled,
+        scope: w.scope,
+        steps: w.workflow.steps.length,
+        triggers: triggerSummary(w.workflow.on),
+      })),
+    setEnabled: async (name, enabled) => {
+      await store.setEnabled(name, enabled);
+      await syncSchedules();
+    },
+    run: async (name) => {
+      const r = await runNow({ name, trigger: 'manual' });
+      return {
+        ok: r.ok,
+        output: r.output,
+        ...(r.error ? { error: r.error } : {}),
+        steps: r.steps.map((s) => ({ id: s.id, status: s.status, ...(s.error ? { error: s.error } : {}) })),
+      };
+    },
+  };
+
+  // --- triggers ---
+  async function syncSchedules(): Promise<void> {
+    const all = await store.list();
+    for (const { workflow } of all) {
+      const sched = workflow.enabled ? workflow.on?.schedule : undefined;
+      if (sched && (sched.cron || sched.runAt)) {
+        const runAt = typeof sched.runAt === 'string' ? Date.parse(sched.runAt) : sched.runAt;
+        await scheduleStore.syncWorkflowSchedule(workflow.name, {
+          id: '',
+          name: `wf-${workflow.name}`.slice(0, 120),
+          // The scheduled turn runs this prompt; the model calls workflow_run,
+          // whose engine drives the DAG. Scheduler writes the result to inbox.
+          prompt: `Run the "${workflow.name}" workflow now using the workflow_run tool, then briefly report what each step did.`,
+          ...(sched.cron ? { cron: sched.cron } : {}),
+          ...(runAt ? { runAt } : {}),
+          ...(sched.timeZone ? { timeZone: sched.timeZone } : {}),
+          enabled: true,
+          createdAt: 0,
+          source: 'workflow',
+          workflowName: workflow.name,
+        });
+      } else {
+        await scheduleStore.syncWorkflowSchedule(workflow.name, null);
+      }
+      // fileChanged / webhook triggers are recognized but auto-firing for them
+      // is wired separately (fileChanged below; webhook is a follow-up).
+      if (workflow.enabled && workflow.on?.webhook) {
+        logger?.warn?.('workflows: webhook triggers are not auto-fired yet; run on demand', {
+          workflow: workflow.name,
+        });
+      }
+    }
+  }
+
+  // afterWorkflow: when a workflow completes, fire any enabled workflow that
+  // lists it under `on.afterWorkflow`. Guards against direct self-trigger.
+  const unsubscribe = session.log.subscribe((event: MoxxyEvent) => {
+    if (event.type !== 'plugin_event' || event.subtype !== 'workflow_completed') return;
+    const completed = (event.payload as { name?: string } | undefined)?.name;
+    if (!completed) return;
+    void (async () => {
+      for (const { workflow } of await store.list()) {
+        if (!workflow.enabled || !workflow.on?.afterWorkflow) continue;
+        const deps = [workflow.on.afterWorkflow].flat();
+        if (deps.includes(completed) && workflow.name !== completed) {
+          logger?.info?.('workflows: afterWorkflow trigger', { workflow: workflow.name, after: completed });
+          await runNow({ name: workflow.name, trigger: `after:${completed}` }).catch((err) =>
+            logger?.warn?.('workflows: afterWorkflow run failed', {
+              workflow: workflow.name,
+              err: err instanceof Error ? err.message : String(err),
+            }),
+          );
+        }
+      }
+    })();
+  });
+
+  async function startFileWatchers(): Promise<void> {
+    for (const w of watchers.splice(0)) w.close();
+    const debounced = new Map<string, NodeJS.Timeout>();
+    for (const { workflow } of await store.list()) {
+      if (!workflow.enabled || !workflow.on?.fileChanged) continue;
+      for (const glob of [workflow.on.fileChanged].flat()) {
+        const base = globBaseDir(glob, session.cwd);
+        try {
+          const watcher = fsWatch(base, { recursive: true }, () => {
+            const prev = debounced.get(workflow.name);
+            if (prev) clearTimeout(prev);
+            const t = setTimeout(() => {
+              void runNow({ name: workflow.name, trigger: `fileChanged:${glob}` }).catch(() => {});
+            }, 600);
+            t.unref?.();
+            debounced.set(workflow.name, t);
+          });
+          watchers.push(watcher);
+        } catch (err) {
+          logger?.warn?.('workflows: cannot watch path', {
+            workflow: workflow.name,
+            base,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }
+  }
+
+  const built = buildWorkflowsPlugin({
+    store,
+    skills: session.skills,
+    tools: session.tools,
+    getActiveExecutor: () => session.workflowExecutors.getActive(),
+    appendEvent: (e) => session.log.append(e),
+    ...(logger ? { logger } : {}),
+    provider: () => safeActiveProvider(session),
+    listSkills: () => session.skills.list().map((s) => s.frontmatter.name),
+    listTools: () => session.tools.list().map((t) => t.name),
+    onChanged: syncSchedules,
+    runNow,
+    userDir: defaultUserWorkflowsDir(),
+    onReady: async () => {
+      session.workflows = view;
+      await syncSchedules();
+      await startFileWatchers();
+    },
+  });
+
+  return {
+    plugin: built.plugin,
+    store,
+    stop: () => {
+      unsubscribe();
+      for (const w of watchers.splice(0)) w.close();
+    },
+  };
+}
+
+function activeModel(session: Session): string {
+  return safeActiveProvider(session)?.models[0]?.id ?? 'claude-sonnet-4-6';
+}
+
+function safeActiveProvider(session: Session): ReturnType<Session['providers']['getActive']> | null {
+  try {
+    return session.providers.getActive();
+  } catch {
+    return null;
+  }
+}
+
+function triggerSummary(on: import('@moxxy/sdk').WorkflowTrigger | undefined): string {
+  if (!on) return 'on-demand';
+  const parts: string[] = [];
+  if (on.schedule?.cron) parts.push(`cron(${on.schedule.cron})`);
+  if (on.schedule?.runAt) parts.push('runAt');
+  if (on.afterWorkflow) parts.push(`after(${[on.afterWorkflow].flat().join(',')})`);
+  if (on.fileChanged) parts.push('fileChanged');
+  if (on.webhook) parts.push(`webhook(${on.webhook})`);
+  return parts.length > 0 ? parts.join('+') : 'on-demand';
+}
+
+/** Strip a glob down to its watchable base directory (everything before `*`). */
+function globBaseDir(glob: string, cwd: string): string {
+  const star = glob.indexOf('*');
+  const head = star >= 0 ? glob.slice(0, star) : glob;
+  const dir = head.includes('/') ? head.slice(0, head.lastIndexOf('/')) : '';
+  return path.resolve(cwd, dir || '.');
+}
+
+async function deliverToInbox(
+  workflow: import('@moxxy/sdk').Workflow,
+  result: WorkflowRunResult,
+  logger?: MiniLogger,
+): Promise<void> {
+  if (workflow.delivery && workflow.delivery.inbox === false) return;
+  try {
+    const dir = moxxyPath('inbox');
+    await fsp.mkdir(dir, { recursive: true });
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const file = path.join(dir, `${stamp}-${workflow.name}.md`);
+    const header = [
+      '---',
+      `workflow: ${workflow.name}`,
+      `firedAt: ${new Date().toISOString()}`,
+      workflow.delivery?.channel ? `channel: ${workflow.delivery.channel}` : null,
+      `outcome: ${result.ok ? 'ok' : 'error'}`,
+      '---',
+      '',
+    ]
+      .filter((l) => l !== null)
+      .join('\n');
+    const body = result.error ? `**error:** ${result.error}\n\n${result.output}` : result.output;
+    await writeFileAtomic(file, header + body + '\n');
+  } catch (err) {
+    logger?.warn?.('workflows: inbox delivery failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -121,6 +121,8 @@ export const moxxyConfigSchema = z.object({
   provider: providerSettingsSchema.optional(),
   mode: z.string().optional(),
   compactor: z.string().optional(),
+  /** Name of the active WorkflowExecutor block (default 'dag'). */
+  workflowExecutor: z.string().optional(),
   context: contextConfigSchema.optional(),
   systemPrompt: z.string().optional(),
   maxIterations: z.number().int().positive().optional(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export { Session, type SessionOptions } from './session.js';
 export { runTurn, collectTurn, type RunTurnOptions } from './run-turn.js';
+export { createSubagentSpawner, type SubagentRuntime } from './subagents.js';
 export {
   loadPreferences,
   savePreferences,

--- a/packages/core/src/plugins/host.ts
+++ b/packages/core/src/plugins/host.ts
@@ -18,6 +18,7 @@ import type {
   Isolator,
   ViewRendererDef,
   TunnelProviderDef,
+  WorkflowExecutorDef,
 } from '@moxxy/sdk';
 import type { Logger } from '../logger.js';
 import type { AgentRegistry } from '../registries/agents.js';
@@ -33,6 +34,7 @@ import type { ToolRegistry } from '../registries/tools.js';
 import type { TranscriberRegistry } from '../registries/transcribers.js';
 import type { EmbedderRegistry } from '../registries/embedders.js';
 import type { IsolatorRegistry } from '../registries/isolators.js';
+import type { WorkflowExecutorRegistry } from '../registries/workflow-executors.js';
 import type { HookDispatcherImpl } from './lifecycle.js';
 import type { RequirementRegistry } from '../requirements.js';
 import { discoverPlugins } from './discovery.js';
@@ -54,6 +56,7 @@ export interface PluginHostOptions {
   readonly transcribers: TranscriberRegistry;
   readonly embedders: EmbedderRegistry;
   readonly isolators: IsolatorRegistry;
+  readonly workflowExecutors: WorkflowExecutorRegistry;
   readonly requirements: RequirementRegistry;
   readonly dispatcher: HookDispatcherImpl;
   readonly loader?: PluginLoader;
@@ -124,6 +127,7 @@ interface LoadedRecord {
   readonly transcriberNames: ReadonlyArray<string>;
   readonly embedderNames: ReadonlyArray<string>;
   readonly isolatorNames: ReadonlyArray<string>;
+  readonly workflowExecutorNames: ReadonlyArray<string>;
 }
 
 export class PluginHost implements PluginHostHandle {
@@ -244,6 +248,8 @@ export class PluginHost implements PluginHostHandle {
     for (const transcriberName of record.transcriberNames) this.opts.transcribers.unregister(transcriberName);
     for (const embedderName of record.embedderNames) this.opts.embedders.unregister(embedderName);
     for (const isolatorName of record.isolatorNames) this.opts.isolators.unregister(isolatorName);
+    for (const wfxName of record.workflowExecutorNames)
+      this.opts.workflowExecutors.unregister(wfxName);
     this.loaded.delete(name);
     this.opts.requirements.unregisterPlugin(record.plugin.name);
     this.refreshDispatcher();
@@ -282,6 +288,9 @@ export class PluginHost implements PluginHostHandle {
     const transcriberNames = (plugin.transcribers ?? []).map((t: TranscriberDef) => t.name);
     const embedderNames = (plugin.embedders ?? []).map((e: EmbedderDef) => e.name);
     const isolatorNames = (plugin.isolators ?? []).map((i: Isolator) => i.name);
+    const workflowExecutorNames = (plugin.workflowExecutors ?? []).map(
+      (w: WorkflowExecutorDef) => w.name,
+    );
 
     for (const tool of plugin.tools ?? []) this.opts.tools.register(tool);
     for (const provider of plugin.providers ?? []) this.opts.providers.register(provider);
@@ -299,6 +308,8 @@ export class PluginHost implements PluginHostHandle {
     for (const transcriber of plugin.transcribers ?? []) this.opts.transcribers.register(transcriber);
     for (const embedder of plugin.embedders ?? []) this.opts.embedders.register(embedder);
     for (const isolator of plugin.isolators ?? []) this.opts.isolators.register(isolator);
+    for (const wfx of plugin.workflowExecutors ?? [])
+      this.opts.workflowExecutors.register(wfx);
 
     return {
       plugin,
@@ -316,6 +327,7 @@ export class PluginHost implements PluginHostHandle {
       transcriberNames,
       embedderNames,
       isolatorNames,
+      workflowExecutorNames,
     };
   }
 

--- a/packages/core/src/registries/workflow-executors.ts
+++ b/packages/core/src/registries/workflow-executors.ts
@@ -1,0 +1,46 @@
+import type { WorkflowExecutorDef } from '@moxxy/sdk';
+
+/**
+ * Registry of swappable workflow-execution strategies. Mirrors
+ * {@link ModeRegistry}: register throws on duplicate, auto-activates the
+ * first registration (so a session always has an executor once
+ * `@moxxy/plugin-workflows` loads its default `dag`), and `unregister`
+ * clears the active slot rather than silently picking a successor.
+ */
+export class WorkflowExecutorRegistry {
+  private readonly executors = new Map<string, WorkflowExecutorDef>();
+  private active: string | null = null;
+
+  register(def: WorkflowExecutorDef): void {
+    if (this.executors.has(def.name)) {
+      throw new Error(`Workflow executor already registered: ${def.name}`);
+    }
+    this.executors.set(def.name, def);
+    if (!this.active) this.active = def.name;
+  }
+
+  replace(def: WorkflowExecutorDef): void {
+    this.executors.set(def.name, def);
+    if (!this.active) this.active = def.name;
+  }
+
+  unregister(name: string): void {
+    this.executors.delete(name);
+    if (this.active === name) this.active = null;
+  }
+
+  list(): ReadonlyArray<WorkflowExecutorDef> {
+    return [...this.executors.values()];
+  }
+
+  setActive(name: string): void {
+    const def = this.executors.get(name);
+    if (!def) throw new Error(`Workflow executor not registered: ${name}`);
+    this.active = def.name;
+  }
+
+  getActive(): WorkflowExecutorDef | null {
+    if (!this.active) return null;
+    return this.executors.get(this.active) ?? null;
+  }
+}

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -29,6 +29,7 @@ import { CommandRegistry } from './registries/commands.js';
 import { TranscriberRegistry } from './registries/transcribers.js';
 import { EmbedderRegistry } from './registries/embedders.js';
 import { IsolatorRegistry } from './registries/isolators.js';
+import { WorkflowExecutorRegistry } from './registries/workflow-executors.js';
 import { RequirementRegistry } from './requirements.js';
 import { PermissionEngine } from './permissions/engine.js';
 import { autoAllowResolver } from './permissions/resolvers.js';
@@ -37,6 +38,7 @@ import type {
   CredentialResolver,
   ElisionSettings,
   McpAdminView,
+  WorkflowsView,
   PendingToolCall,
   PermissionContext,
   PermissionResolver,
@@ -94,6 +96,7 @@ export class Session implements ClientSession, SessionRuntime {
   readonly transcribers: TranscriberRegistry;
   readonly embedders: EmbedderRegistry;
   readonly isolators: IsolatorRegistry;
+  readonly workflowExecutors: WorkflowExecutorRegistry;
   readonly requirements: RequirementRegistry;
   readonly permissions: PermissionEngine;
   /** Current PermissionResolver. Update via `setPermissionResolver(r)`. */
@@ -123,6 +126,7 @@ export class Session implements ClientSession, SessionRuntime {
   readyProviders?: Set<string>;
   credentialResolver?: CredentialResolver;
   mcpAdmin?: McpAdminView;
+  workflows?: WorkflowsView;
   readonly dispatcher: HookDispatcherImpl;
   readonly pluginHost: PluginHost;
   private readonly controller = new AbortController();
@@ -152,6 +156,7 @@ export class Session implements ClientSession, SessionRuntime {
     this.transcribers = new TranscriberRegistry();
     this.embedders = new EmbedderRegistry();
     this.isolators = new IsolatorRegistry();
+    this.workflowExecutors = new WorkflowExecutorRegistry();
     this.requirements = new RequirementRegistry({
       tools: this.tools,
       providers: this.providers,
@@ -193,6 +198,7 @@ export class Session implements ClientSession, SessionRuntime {
       transcribers: this.transcribers,
       embedders: this.embedders,
       isolators: this.isolators,
+      workflowExecutors: this.workflowExecutors,
       requirements: this.requirements,
       dispatcher: this.dispatcher,
       loader: opts.pluginLoader,

--- a/packages/plugin-cli/src/components/WorkflowsPanel.tsx
+++ b/packages/plugin-cli/src/components/WorkflowsPanel.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { WorkflowsView, WorkflowSummaryView } from '@moxxy/sdk';
+import { Colors } from '../theme.js';
+import { Modal } from './Modal.js';
+import { useScrollableList } from './useScrollableList.js';
+
+export interface WorkflowsPanelProps {
+  /** Live workflows API stashed on the session, or null when unavailable. */
+  readonly view: WorkflowsView | null;
+  readonly onClose?: () => void;
+}
+
+const NAME_COL = 24;
+const SCOPE_COL = 9;
+const TRIG_COL = 20;
+const WINDOW = 12;
+
+/**
+ * Interactive `/workflows` modal. Lists every workflow with its
+ * enabled (●) / disabled (○) status; ↑↓ navigate, `d`/space toggle
+ * enable/disable, Enter / `r` run the focused workflow, Esc closes
+ * (owned by Modal). Run + toggle drive the session's `workflows` view,
+ * which is backed by the same engine the agent and scheduler use.
+ */
+export const WorkflowsPanel: React.FC<WorkflowsPanelProps> = ({ view, onClose }) => {
+  const [rows, setRows] = React.useState<ReadonlyArray<WorkflowSummaryView>>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [busy, setBusy] = React.useState(false);
+  const [status, setStatus] = React.useState<string | null>(null);
+
+  const reload = React.useCallback(async () => {
+    if (!view) {
+      setLoading(false);
+      return;
+    }
+    try {
+      const list = await view.list();
+      setRows([...list].sort((a, b) => a.name.localeCompare(b.name)));
+    } catch (err) {
+      setStatus(`failed to load: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [view]);
+
+  React.useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const active = !busy && !!view && rows.length > 0;
+
+  const run = React.useCallback(
+    async (wf: WorkflowSummaryView) => {
+      if (!view || busy) return;
+      if (!wf.enabled) {
+        setStatus(`"${wf.name}" is disabled — press d to enable it first.`);
+        return;
+      }
+      setBusy(true);
+      setStatus(`running "${wf.name}"…`);
+      try {
+        const result = await view.run(wf.name);
+        const marks = result.steps.map((s) => `${stepMark(s.status)}${s.id}`).join(' ');
+        setStatus(result.ok ? `✓ ${wf.name} completed — ${marks}` : `✗ ${wf.name} failed: ${result.error ?? ''} — ${marks}`);
+      } catch (err) {
+        setStatus(`✗ ${wf.name} errored: ${err instanceof Error ? err.message : String(err)}`);
+      } finally {
+        setBusy(false);
+        void reload();
+      }
+    },
+    [view, busy, reload],
+  );
+
+  const scroll = useScrollableList({
+    total: rows.length,
+    windowSize: WINDOW,
+    isActive: active,
+    onSelect: (i) => {
+      const wf = rows[i];
+      if (wf) void run(wf);
+    },
+  });
+
+  useInput(
+    (input) => {
+      const wf = rows[scroll.cursor];
+      if (!wf || !view) return;
+      if (input === 'd' || input === ' ') {
+        setBusy(true);
+        setStatus(`${wf.enabled ? 'disabling' : 'enabling'} "${wf.name}"…`);
+        void view
+          .setEnabled(wf.name, !wf.enabled)
+          .then(() => setStatus(`"${wf.name}" ${wf.enabled ? 'disabled ○' : 'enabled ●'}`))
+          .catch((err) => setStatus(`failed: ${err instanceof Error ? err.message : String(err)}`))
+          .finally(() => {
+            setBusy(false);
+            void reload();
+          });
+      } else if (input === 'r') {
+        void run(wf);
+      }
+    },
+    { isActive: active },
+  );
+
+  const termWidth = process.stdout.columns ?? 80;
+  const descWidth = Math.max(16, termWidth - NAME_COL - SCOPE_COL - TRIG_COL - 12);
+  const slice = rows.slice(scroll.visible.start, scroll.visible.end);
+  const subtitle =
+    rows.length === 0 ? 'none' : `${scroll.cursor + 1} of ${rows.length}  ·  ${rows.length} workflow${rows.length === 1 ? '' : 's'}`;
+  const hints = 'd enable/disable · Enter/r run · ↑↓ navigate · Esc close';
+
+  return (
+    <Modal title="Workflows" subtitle={subtitle} hints={hints} {...(onClose ? { onClose } : {})}>
+      {!view ? (
+        <Text dimColor>(workflows unavailable in this session)</Text>
+      ) : loading ? (
+        <Text dimColor>loading…</Text>
+      ) : rows.length === 0 ? (
+        <Text dimColor>
+          (no workflows — ask the agent to “create a workflow that…”, or scaffold one in chat)
+        </Text>
+      ) : null}
+      {scroll.canScrollUp ? <Text dimColor>{`  ↑ ${scroll.offset} more above`}</Text> : null}
+      {slice.map((wf, i) => {
+        const absoluteIndex = scroll.visible.start + i;
+        const focused = absoluteIndex === scroll.cursor;
+        return (
+          <Box key={wf.name}>
+            <Text {...(focused ? {} : { dimColor: true })}>{focused ? '› ' : '  '}</Text>
+            <Text color={wf.enabled ? Colors.active : undefined} dimColor={!wf.enabled}>
+              {wf.enabled ? '● ' : '○ '}
+            </Text>
+            <Box width={NAME_COL}>
+              <Text bold={focused}>{truncate(wf.name, NAME_COL - 1)}</Text>
+            </Box>
+            <Box width={SCOPE_COL}>
+              <Text dimColor>{wf.scope}</Text>
+            </Box>
+            <Box width={TRIG_COL}>
+              <Text dimColor wrap="truncate">{wf.triggers}</Text>
+            </Box>
+            <Box width={descWidth}>
+              <Text dimColor wrap="truncate">{oneLine(wf.description)}</Text>
+            </Box>
+          </Box>
+        );
+      })}
+      {scroll.canScrollDown ? (
+        <Text dimColor>{`  ↓ ${rows.length - scroll.visible.end} more below`}</Text>
+      ) : null}
+      {status ? (
+        <Box marginTop={1}>
+          <Text wrap="truncate-end">{status}</Text>
+        </Box>
+      ) : null}
+    </Modal>
+  );
+};
+
+function stepMark(status: string): string {
+  return status === 'completed' ? '✓' : status === 'skipped' ? '–' : status === 'failed' ? '✗' : '·';
+}
+
+function oneLine(s: string): string {
+  return s.replace(/[\r\n\t]+/g, ' ').replace(/  +/g, ' ').trim();
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + '…';
+}

--- a/packages/plugin-cli/src/session/OverlayOrNotice.tsx
+++ b/packages/plugin-cli/src/session/OverlayOrNotice.tsx
@@ -6,6 +6,7 @@ import { SkillsPanel } from '../components/SkillsPanel.js';
 import { ToolsPanel } from '../components/ToolsPanel.js';
 import { AgentsPanel } from '../components/AgentsPanel.js';
 import { UsagePanel } from '../components/UsagePanel.js';
+import { WorkflowsPanel } from '../components/WorkflowsPanel.js';
 import { Colors } from '../theme.js';
 import { deriveMcpServers } from './helpers.js';
 import type { Overlay } from './types.js';
@@ -40,6 +41,9 @@ export const OverlayOrNotice: React.FC<OverlayOrNoticeProps> = ({
   }
   if (overlay?.kind === 'tools') {
     return <ToolsPanel tools={session.tools.list()} onClose={onClose} />;
+  }
+  if (overlay?.kind === 'workflows') {
+    return <WorkflowsPanel view={session.workflows ?? null} onClose={onClose} />;
   }
   if (overlay?.kind === 'agents') {
     return (

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -28,6 +28,15 @@ export function runSlash(cmd: string, deps: SlashDeps): void {
   // First: route through the channel-agnostic command registry.
   // Plugins (/info, /clear, /new, /exit, /help, ...) and any
   // user-defined commands live here.
+  // `/workflows` opens an interactive TUI modal (list + enable/disable + run),
+  // intercepted BEFORE the command registry so the overlay wins here while
+  // non-TUI channels (which don't run this code) still get the text command.
+  if (name === 'workflows' || name === 'workflow' || name === 'flows') {
+    deps.setSystemNotice(null);
+    deps.setOverlay({ kind: 'workflows' });
+    return;
+  }
+
   const registered = deps.session.commands.get(name);
   if (registered) {
     void (async () => {

--- a/packages/plugin-cli/src/session/types.ts
+++ b/packages/plugin-cli/src/session/types.ts
@@ -12,6 +12,7 @@ export type Overlay =
   | { kind: 'tools' }
   | { kind: 'agents' }
   | { kind: 'usage' }
+  | { kind: 'workflows' }
   | null;
 
 export type Picker =

--- a/packages/plugin-scheduler/src/store.ts
+++ b/packages/plugin-scheduler/src/store.ts
@@ -18,7 +18,7 @@ import { isValidCron } from './cron.js';
  * adds/removes its own rows.
  */
 
-export const scheduleSourceSchema = z.enum(['manual', 'skill']);
+export const scheduleSourceSchema = z.enum(['manual', 'skill', 'workflow']);
 export type ScheduleSource = z.infer<typeof scheduleSourceSchema>;
 
 export const scheduleEntrySchema = z
@@ -48,6 +48,8 @@ export const scheduleEntrySchema = z
     source: scheduleSourceSchema.default('manual'),
     /** When source='skill': the skill name this schedule mirrors. */
     skillName: z.string().optional(),
+    /** When source='workflow': the workflow name this schedule fires. */
+    workflowName: z.string().optional(),
   })
   .superRefine((entry, ctx) => {
     if (!entry.cron && !entry.runAt) {
@@ -108,7 +110,7 @@ export class ScheduleStore {
 
   async create(
     input: Omit<ScheduleEntry, 'id' | 'createdAt' | 'enabled' | 'source'> &
-      Partial<Pick<ScheduleEntry, 'enabled' | 'source' | 'skillName'>>,
+      Partial<Pick<ScheduleEntry, 'enabled' | 'source' | 'skillName' | 'workflowName'>>,
   ): Promise<ScheduleEntry> {
     const entry: ScheduleEntry = scheduleEntrySchema.parse({
       ...input,
@@ -161,6 +163,25 @@ export class ScheduleStore {
       );
       if (entry) {
         filtered.push(scheduleEntrySchema.parse({ ...entry, source: 'skill', skillName }));
+      }
+      return filtered;
+    });
+  }
+
+  /**
+   * Replace the `source='workflow'` schedule for `workflowName` with the
+   * supplied entry, or remove it if `entry` is null. Mirrors
+   * {@link syncSkillSchedule}; manual/skill schedules are left untouched.
+   * Used by the workflows integration to mirror a workflow's `on.schedule`
+   * into the shared poller without a separate timer.
+   */
+  async syncWorkflowSchedule(workflowName: string, entry: ScheduleEntry | null): Promise<void> {
+    await this.mutate((schedules) => {
+      const filtered = schedules.filter(
+        (s) => !(s.source === 'workflow' && s.workflowName === workflowName),
+      );
+      if (entry) {
+        filtered.push(scheduleEntrySchema.parse({ ...entry, source: 'workflow', workflowName }));
       }
       return filtered;
     });

--- a/packages/plugin-workflows/package.json
+++ b/packages/plugin-workflows/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@moxxy/plugin-workflows",
+  "private": true,
+  "version": "0.0.1",
+  "description": "Workflows plugin for moxxy — a swappable DAG engine that chains skills/prompts/tools into saved, parameterized, schedulable/event-triggered pipelines.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "skills",
+    "workflows"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@moxxy/sdk": "workspace:*",
+    "ulid": "^2.3.0",
+    "yaml": "^2.6.0",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugin-workflows/src/command.ts
+++ b/packages/plugin-workflows/src/command.ts
@@ -1,0 +1,274 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import {
+  defineCommand,
+  writeFileAtomic,
+  type CommandContext,
+  type CommandDef,
+  type CommandOutput,
+  type WorkflowRunResult,
+} from '@moxxy/sdk';
+import { defaultUserWorkflowsDir } from './loader.js';
+import { serializeWorkflow } from './schema.js';
+import type { WorkflowStore } from './store.js';
+
+/**
+ * The `/workflows` slash command — the required TUI surface for managing
+ * flows. Lists every workflow with its enabled/disabled status, runs one on
+ * demand, toggles enable/disable, inspects the last run, validates, scaffolds
+ * a hand-editable starter (`new`), and deletes. Agentic creation lives in the
+ * `workflow_create` tool (just ask in chat); this command covers by-hand
+ * authoring and day-to-day management.
+ */
+
+export interface WorkflowCommandDeps {
+  readonly store: WorkflowStore;
+  /** Runs a workflow now (the autonomous runner). Absent → `run` is unavailable. */
+  readonly runNow?: (input: {
+    readonly name: string;
+    readonly inputs?: Record<string, unknown>;
+    readonly trigger?: string;
+  }) => Promise<WorkflowRunResult>;
+  readonly onChanged?: () => void | Promise<void>;
+  readonly runRecordDir?: string;
+  readonly userDir?: string;
+}
+
+const HELP = [
+  'Usage: /workflows <subcommand>',
+  '  list                 show all workflows (● enabled / ○ disabled)',
+  '  run <name>           run a workflow now',
+  '  enable <name>        enable a workflow',
+  '  disable <name>       disable a workflow (keeps it, stops triggers)',
+  '  inspect <name>       show the YAML + last run',
+  '  validate <name>      re-check schema / DAG / conditions',
+  '  new <name>           scaffold a starter YAML to edit by hand',
+  '  edit <name>          print the on-disk path of a workflow',
+  '  rm <name>            delete a user/project workflow',
+  '',
+  'Tip: to create one with the agent, just ask in chat — e.g.',
+  '  "create a workflow that fetches Dow Jones news and emails me a digest".',
+].join('\n');
+
+export function buildWorkflowsCommand(deps: WorkflowCommandDeps): CommandDef {
+  return defineCommand({
+    name: 'workflows',
+    description: 'List, run, enable/disable, inspect, and scaffold workflows.',
+    argumentHint: 'list | run <name> | enable <name> | disable <name> | inspect <name> | new <name> | rm <name>',
+    aliases: ['workflow', 'flows'],
+    handler: (ctx) => handle(deps, ctx),
+  });
+}
+
+async function handle(deps: WorkflowCommandDeps, ctx: CommandContext): Promise<CommandOutput> {
+  const [sub, ...rest] = ctx.args.trim().split(/\s+/).filter(Boolean);
+  const arg = rest.join(' ').trim();
+  try {
+    switch ((sub ?? 'list').toLowerCase()) {
+      case 'list':
+      case 'ls':
+        return await listCmd(deps);
+      case 'run':
+        return await runCmd(deps, arg);
+      case 'enable':
+        return await toggleCmd(deps, arg, true);
+      case 'disable':
+        return await toggleCmd(deps, arg, false);
+      case 'inspect':
+      case 'show':
+        return await inspectCmd(deps, arg);
+      case 'validate':
+        return await validateCmd(deps, arg);
+      case 'new':
+        return await newCmd(deps, arg);
+      case 'edit':
+      case 'path':
+        return await editCmd(deps, arg);
+      case 'rm':
+      case 'delete':
+        return await rmCmd(deps, arg);
+      case 'help':
+        return { kind: 'text', text: HELP };
+      default:
+        return { kind: 'error', message: `unknown subcommand "${sub}".\n\n${HELP}` };
+    }
+  } catch (err) {
+    return { kind: 'error', message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+async function listCmd(deps: WorkflowCommandDeps): Promise<CommandOutput> {
+  const all = await deps.store.list();
+  if (all.length === 0) {
+    return { kind: 'text', text: 'No workflows yet. `/workflows new <name>` to scaffold one, or ask the agent to "create a workflow that…".' };
+  }
+  const rows = [...all]
+    .sort((a, b) => a.workflow.name.localeCompare(b.workflow.name))
+    .map((w) => {
+      const mark = w.workflow.enabled ? '●' : '○';
+      const trig = triggerSummary(w.workflow.on);
+      return `  ${mark} ${w.workflow.name}  [${w.scope}]  ${w.workflow.steps.length} steps  ${trig}\n      ${w.workflow.description}`;
+    });
+  return {
+    kind: 'text',
+    text: `Workflows (● enabled · ○ disabled):\n${rows.join('\n')}`,
+  };
+}
+
+async function runCmd(deps: WorkflowCommandDeps, name: string): Promise<CommandOutput> {
+  if (!name) return { kind: 'error', message: 'usage: /workflows run <name>' };
+  const entry = await deps.store.get(name);
+  if (!entry) return { kind: 'error', message: `no workflow named "${name}".` };
+  if (!entry.workflow.enabled) return { kind: 'error', message: `workflow "${name}" is disabled — enable it first.` };
+  if (!deps.runNow) {
+    return { kind: 'text', text: `Ask the agent to run it: "run the ${name} workflow".` };
+  }
+  const result = await deps.runNow({ name, trigger: 'manual' });
+  const steps = result.steps.map((s) => `  ${statusMark(s.status)} ${s.id}${s.error ? ` — ${s.error}` : ''}`).join('\n');
+  const head = result.ok ? `✓ workflow "${name}" completed` : `✗ workflow "${name}" failed${result.error ? `: ${result.error}` : ''}`;
+  return { kind: 'text', text: `${head}\n${steps}\n\n${truncate(result.output, 1200)}` };
+}
+
+async function toggleCmd(deps: WorkflowCommandDeps, name: string, enabled: boolean): Promise<CommandOutput> {
+  if (!name) return { kind: 'error', message: `usage: /workflows ${enabled ? 'enable' : 'disable'} <name>` };
+  const updated = await deps.store.setEnabled(name, enabled);
+  if (!updated) return { kind: 'error', message: `no workflow named "${name}".` };
+  await deps.onChanged?.();
+  return { kind: 'text', text: `workflow "${name}" ${enabled ? 'enabled ●' : 'disabled ○'}.` };
+}
+
+async function inspectCmd(deps: WorkflowCommandDeps, name: string): Promise<CommandOutput> {
+  if (!name) return { kind: 'error', message: 'usage: /workflows inspect <name>' };
+  const entry = await deps.store.get(name);
+  if (!entry) return { kind: 'error', message: `no workflow named "${name}".` };
+  const lastRun = await readLastRun(deps.runRecordDir, name);
+  const yaml = serializeWorkflow(entry.workflow);
+  const parts = [`# ${name}  [${entry.scope}]  ${entry.path}`, '', yaml];
+  if (lastRun) parts.push('', '— last run —', lastRun);
+  return { kind: 'text', text: parts.join('\n') };
+}
+
+async function validateCmd(deps: WorkflowCommandDeps, name: string): Promise<CommandOutput> {
+  if (!name) return { kind: 'error', message: 'usage: /workflows validate <name>' };
+  const entry = await deps.store.get(name);
+  if (!entry) return { kind: 'error', message: `no workflow named "${name}" (it would have been skipped on load if invalid).` };
+  return { kind: 'text', text: `workflow "${name}" is valid (${entry.workflow.steps.length} steps).` };
+}
+
+async function newCmd(deps: WorkflowCommandDeps, name: string): Promise<CommandOutput> {
+  if (!name) return { kind: 'error', message: 'usage: /workflows new <name>' };
+  const slug = slugify(name);
+  if (!/^[a-z0-9][a-z0-9-]*$/i.test(slug)) return { kind: 'error', message: `"${name}" is not a valid workflow name.` };
+  const dir = deps.userDir ?? defaultUserWorkflowsDir();
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${slug}.yaml`);
+  try {
+    await fs.access(file);
+    return { kind: 'error', message: `${file} already exists — edit it, or pick another name.` };
+  } catch {
+    /* does not exist — good */
+  }
+  await writeFileAtomic(file, starterTemplate(slug));
+  await deps.onChanged?.();
+  return {
+    kind: 'text',
+    text: `Scaffolded ${file}\nEdit it by hand, then \`/workflows validate ${slug}\` and \`/workflows run ${slug}\`.`,
+  };
+}
+
+async function editCmd(deps: WorkflowCommandDeps, name: string): Promise<CommandOutput> {
+  if (!name) return { kind: 'error', message: 'usage: /workflows edit <name>' };
+  const entry = await deps.store.get(name);
+  if (!entry) return { kind: 'error', message: `no workflow named "${name}".` };
+  if (entry.scope !== 'user' && entry.scope !== 'project') {
+    return { kind: 'text', text: `${entry.path}\n(${entry.scope} workflow — edits should go to a user override.)` };
+  }
+  return { kind: 'text', text: entry.path };
+}
+
+async function rmCmd(deps: WorkflowCommandDeps, name: string): Promise<CommandOutput> {
+  if (!name) return { kind: 'error', message: 'usage: /workflows rm <name>' };
+  const res = await deps.store.delete(name);
+  if (!res.ok) return { kind: 'error', message: `cannot delete "${name}": ${res.reason}.` };
+  await deps.onChanged?.();
+  return { kind: 'text', text: `deleted workflow "${name}".` };
+}
+
+function statusMark(status: string): string {
+  return status === 'completed' ? '✓' : status === 'skipped' ? '–' : status === 'failed' ? '✗' : '·';
+}
+
+function triggerSummary(on: import('@moxxy/sdk').WorkflowTrigger | undefined): string {
+  if (!on) return 'on-demand';
+  const parts: string[] = [];
+  if (on.schedule?.cron) parts.push(`cron(${on.schedule.cron})`);
+  if (on.schedule?.runAt) parts.push('runAt');
+  if (on.afterWorkflow) parts.push(`after(${[on.afterWorkflow].flat().join(',')})`);
+  if (on.fileChanged) parts.push('fileChanged');
+  if (on.webhook) parts.push(`webhook(${on.webhook})`);
+  return parts.length > 0 ? parts.join('+') : 'on-demand';
+}
+
+async function readLastRun(dir: string | undefined, name: string): Promise<string | null> {
+  if (!dir) return null;
+  let files: string[];
+  try {
+    files = await fs.readdir(dir);
+  } catch {
+    return null;
+  }
+  const matches = files.filter((f) => f.includes(`-${name}-`) && f.endsWith('.jsonl')).sort();
+  const latest = matches[matches.length - 1];
+  if (!latest) return null;
+  try {
+    const raw = await fs.readFile(path.join(dir, latest), 'utf8');
+    const lines = raw.trim().split('\n').map((l) => JSON.parse(l) as Record<string, unknown>);
+    const run = lines.find((l) => l.kind === 'run');
+    const steps = lines.filter((l) => l.kind === 'step');
+    const head = `${run?.ok ? '✓' : '✗'} ${new Date(Number(run?.startedAt ?? 0)).toISOString()} (${String(run?.trigger ?? '?')})`;
+    const stepLines = steps.map((s) => `  ${statusMark(String(s.status))} ${String(s.id)}`).join('\n');
+    return `${head}\n${stepLines}`;
+  } catch {
+    return null;
+  }
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max)}\n… (truncated)` : s;
+}
+
+function slugify(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 60);
+}
+
+function starterTemplate(slug: string): string {
+  return `# Workflow: ${slug}
+# A DAG of steps. Each step has exactly one action: skill | prompt | tool | workflow.
+# Steps run once all their \`needs\` are satisfied — independent steps run in parallel.
+name: ${slug}
+description: Describe what this workflow does.
+enabled: true
+
+# Optional triggers (omit for on-demand only):
+# on:
+#   schedule: { cron: "0 8 * * 1-5", timeZone: "America/New_York" }
+#   afterWorkflow: some-other-workflow
+#   fileChanged: "./inbox/**"
+
+# Optional inputs (referenced as {{ inputs.<name> }}):
+# inputs:
+#   topic: { default: "markets", description: "What to analyze" }
+
+# delivery: { channel: inbox }   # also drop the final output into ~/.moxxy/inbox/
+
+steps:
+  - id: first
+    prompt: "Replace me. Reference inputs like {{ inputs.topic }}."
+
+  - id: second
+    needs: [first]
+    prompt: "Use the previous step's output:\\n{{ steps.first.output }}"
+    # when: '{{ steps.first.output }} is not empty'
+    # onError: continue
+`;
+}

--- a/packages/plugin-workflows/src/draft.ts
+++ b/packages/plugin-workflows/src/draft.ts
@@ -1,0 +1,77 @@
+import type { LLMProvider } from '@moxxy/sdk';
+import { parseWorkflowYaml, type WorkflowParseResult } from './schema.js';
+
+/**
+ * Draft a workflow YAML from a natural-language intent — the agentic
+ * authoring path behind `workflow_create`. Mirrors `draftSkill`: stream the
+ * active provider, extract the YAML block, validate it against the schema.
+ */
+
+export interface DraftWorkflowOptions {
+  readonly availableSkills?: ReadonlyArray<string>;
+  readonly availableTools?: ReadonlyArray<string>;
+  readonly maxTokens?: number;
+}
+
+function buildSystemPrompt(opts: DraftWorkflowOptions): string {
+  const skills = opts.availableSkills?.length
+    ? opts.availableSkills.join(', ')
+    : '(none registered — prefer `prompt` steps)';
+  const tools = opts.availableTools?.length ? opts.availableTools.join(', ') : '(none)';
+  return `You are a workflow author for the "moxxy" agent. Output ONLY a YAML document (optionally inside a \`\`\`yaml fence) — no prose.
+
+A workflow is a DAG of steps. Schema:
+- name: kebab-case slug (lowercase letters/numbers/hyphens, starts with a letter)
+- description: one sentence
+- on (optional triggers): { schedule: { cron: "m h dom mon dow", timeZone? }, afterWorkflow?, fileChanged?, webhook? }
+- inputs (optional): { <name>: { default: <value>, description? } }
+- delivery (optional): { channel?: "inbox", inbox?: true }
+- steps: array of steps, each with:
+    - id: slug, unique
+    - EXACTLY ONE action: skill: <name> | prompt: <text> | tool: <name> | workflow: <name>
+    - input: templated prompt for skill/prompt steps
+    - args: templated args object for tool/workflow steps
+    - needs: [ <upstream step ids> ]  (defines the DAG; omit for sources)
+    - when (optional): a condition like '{{ steps.x.output }} is not empty' or '{{ inputs.r }} == "US"' or '... contains "text"', joined by and/or
+    - onError (optional): fail | continue | retry ; retries (optional, 0-3)
+
+Templating: reference earlier results with {{ steps.<id>.output }}, inputs with {{ inputs.<name> }}, plus {{ trigger }} and {{ now }}.
+
+Steps with all their \`needs\` satisfied run in parallel, so use \`needs\` to express ordering and fan-out/fan-in.
+
+Available skills: ${skills}
+Available tools: ${tools}
+Prefer a named skill when one fits; otherwise use a \`prompt\` step. For "send/email/notify me" use a connected tool if available, else rely on delivery: { channel: inbox }.`;
+}
+
+export interface DraftedWorkflow {
+  readonly raw: string;
+  readonly parse: WorkflowParseResult;
+}
+
+export async function draftWorkflow(
+  provider: LLMProvider,
+  model: string,
+  intent: string,
+  signal: AbortSignal,
+  opts: DraftWorkflowOptions = {},
+): Promise<DraftedWorkflow> {
+  let accumulated = '';
+  for await (const event of provider.stream({
+    model,
+    system: buildSystemPrompt(opts),
+    messages: [{ role: 'user', content: [{ type: 'text', text: `Build a workflow for: ${intent}` }] }],
+    maxTokens: opts.maxTokens ?? 1500,
+    signal,
+  })) {
+    if (event.type === 'text_delta') accumulated += event.delta;
+    if (event.type === 'error') throw new Error(`workflow_create: provider error: ${event.message}`);
+  }
+  const raw = extractYamlBlock(accumulated);
+  return { raw, parse: parseWorkflowYaml(raw) };
+}
+
+function extractYamlBlock(s: string): string {
+  const fence = /```(?:ya?ml)?\n([\s\S]*?)```/.exec(s);
+  return (fence ? fence[1]! : s).trim();
+}

--- a/packages/plugin-workflows/src/engine.ts
+++ b/packages/plugin-workflows/src/engine.ts
@@ -1,0 +1,68 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { moxxyPath, type Workflow, type WorkflowExecutorDef, type WorkflowRunDeps, type WorkflowRunResult } from '@moxxy/sdk';
+import { ulid } from 'ulid';
+import { dagExecutor } from './executor/dag.js';
+
+/**
+ * Runs a workflow through the active executor and appends a JSONL run record
+ * to `~/.moxxy/workflow-runs/` for `/workflows inspect`. The executor itself
+ * is fs-free; record-keeping lives here so the executor stays unit-testable.
+ */
+
+export function defaultRunRecordDir(): string {
+  return moxxyPath('workflow-runs');
+}
+
+export interface RunWorkflowOptions {
+  /** Active executor; falls back to the built-in `dag`. */
+  readonly executor?: WorkflowExecutorDef | null;
+  /** Override the run-record directory (tests). Pass null to skip recording. */
+  readonly recordDir?: string | null;
+}
+
+export async function runWorkflow(
+  workflow: Workflow,
+  deps: WorkflowRunDeps,
+  opts: RunWorkflowOptions = {},
+): Promise<WorkflowRunResult> {
+  const executor = opts.executor ?? dagExecutor;
+  const startedAt = (deps.now ?? Date.now)();
+  const result = await executor.run(workflow, deps);
+  if (opts.recordDir !== null) {
+    await writeRunRecord(workflow, result, startedAt, executor.name, deps, opts.recordDir ?? defaultRunRecordDir()).catch(
+      (err) =>
+        deps.logger?.warn?.('workflow: failed to write run record', {
+          error: err instanceof Error ? err.message : String(err),
+        }),
+    );
+  }
+  return result;
+}
+
+async function writeRunRecord(
+  workflow: Workflow,
+  result: WorkflowRunResult,
+  startedAt: number,
+  executorName: string,
+  deps: WorkflowRunDeps,
+  dir: string,
+): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+  const stamp = new Date(startedAt).toISOString().replace(/[:.]/g, '-');
+  const file = path.join(dir, `${stamp}-${workflow.name}-${ulid().slice(-6)}.jsonl`);
+  const lines = [
+    JSON.stringify({
+      kind: 'run',
+      workflow: workflow.name,
+      executor: executorName,
+      startedAt,
+      trigger: deps.trigger ?? 'manual',
+      ok: result.ok,
+      ...(result.error ? { error: result.error } : {}),
+    }),
+    ...result.steps.map((s) => JSON.stringify({ kind: 'step', ...s })),
+    JSON.stringify({ kind: 'output', output: result.output }),
+  ];
+  await fs.writeFile(file, lines.join('\n') + '\n', 'utf8');
+}

--- a/packages/plugin-workflows/src/executor/dag.test.ts
+++ b/packages/plugin-workflows/src/executor/dag.test.ts
@@ -1,0 +1,264 @@
+import {
+  asSessionId,
+  type Skill,
+  type SubagentResult,
+  type SubagentSpec,
+  type SubagentSpawner,
+  type Workflow,
+  type WorkflowRunDeps,
+} from '@moxxy/sdk';
+import { describe, expect, it } from 'vitest';
+import { validateWorkflow } from '../schema.js';
+import { dagExecutor } from './dag.js';
+
+function wf(obj: Record<string, unknown>): Workflow {
+  const r = validateWorkflow(obj);
+  if (!r.ok || !r.workflow) throw new Error(`invalid test workflow: ${r.errors.join('; ')}`);
+  return r.workflow;
+}
+
+interface Harness {
+  readonly deps: WorkflowRunDeps;
+  readonly specs: SubagentSpec[];
+  readonly order: string[];
+  readonly toolCalls: Array<{ name: string; input: unknown }>;
+}
+
+function makeHarness(overrides: Partial<WorkflowRunDeps> = {}, skills: Record<string, string> = {}): Harness {
+  const specs: SubagentSpec[] = [];
+  const order: string[] = [];
+  const toolCalls: Array<{ name: string; input: unknown }> = [];
+  let clock = 1;
+
+  const spawn = async (spec: SubagentSpec): Promise<SubagentResult> => {
+    specs.push(spec);
+    order.push(spec.label ?? '?');
+    return {
+      label: spec.label ?? '?',
+      childSessionId: asSessionId('child'),
+      text: `OUT_${spec.label}`,
+      stopReason: 'end_turn',
+    };
+  };
+  const spawner: SubagentSpawner = {
+    spawn,
+    spawnAll: (list) => Promise.all(list.map(spawn)),
+  };
+
+  const fakeSkill = (name: string, body: string): Skill => ({
+    id: `user/${name}` as never,
+    path: `/tmp/${name}.md`,
+    scope: 'user',
+    frontmatter: { name, description: 'test skill', 'allowed-tools': ['Read'] },
+    body,
+  });
+
+  const deps: WorkflowRunDeps = {
+    spawner,
+    tools: {
+      get: () => ({}),
+      execute: async (name, input) => {
+        toolCalls.push({ name, input });
+        order.push(`tool:${name}`);
+        return `TOOL_${name}`;
+      },
+    },
+    lookup: {
+      skill: (n) => (skills[n] !== undefined ? fakeSkill(n, skills[n]!) : undefined),
+      workflow: () => undefined,
+    },
+    signal: new AbortController().signal,
+    now: () => clock++,
+    ...overrides,
+  };
+  return { deps, specs, order, toolCalls };
+}
+
+describe('dag executor', () => {
+  it('runs a linear chain and pipes output→input', async () => {
+    const h = makeHarness();
+    const result = await dagExecutor.run(
+      wf({
+        name: 'lin',
+        description: 'x',
+        steps: [
+          { id: 'fetch', prompt: 'go' },
+          { id: 'analyze', needs: ['fetch'], prompt: 'see {{ steps.fetch.output }}' },
+        ],
+      }),
+      h.deps,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.steps.map((s) => s.status)).toEqual(['completed', 'completed']);
+    const analyze = h.specs.find((s) => s.label === 'analyze')!;
+    expect(analyze.prompt).toBe('see OUT_fetch');
+    expect(result.output).toBe('OUT_analyze'); // sink
+  });
+
+  it('fans out in parallel and fans back in', async () => {
+    const h = makeHarness();
+    const result = await dagExecutor.run(
+      wf({
+        name: 'fan',
+        description: 'x',
+        steps: [
+          { id: 'fetch', prompt: 'go' },
+          { id: 'analyze', needs: ['fetch'], prompt: 'a {{ steps.fetch.output }}' },
+          { id: 'check', needs: ['fetch'], prompt: 'c {{ steps.fetch.output }}' },
+          {
+            id: 'email',
+            needs: ['analyze', 'check'],
+            tool: 'send',
+            args: { body: '{{ steps.analyze.output }}|{{ steps.check.output }}' },
+          },
+        ],
+      }),
+      h.deps,
+    );
+    expect(result.ok).toBe(true);
+    // fetch before the parallel pair; both before email's tool call.
+    expect(h.order.indexOf('fetch')).toBeLessThan(h.order.indexOf('analyze'));
+    expect(h.order.indexOf('fetch')).toBeLessThan(h.order.indexOf('check'));
+    expect(h.order.indexOf('analyze')).toBeLessThan(h.order.indexOf('tool:send'));
+    expect(h.order.indexOf('check')).toBeLessThan(h.order.indexOf('tool:send'));
+    expect(h.toolCalls[0]!.input).toEqual({ body: 'OUT_analyze|OUT_check' });
+  });
+
+  it('skips a step whose `when` is false but still runs its dependents', async () => {
+    const h = makeHarness();
+    const result = await dagExecutor.run(
+      wf({
+        name: 'when',
+        description: 'x',
+        steps: [
+          { id: 'a', prompt: 'go' },
+          { id: 'b', needs: ['a'], when: '{{ steps.a.output }} contains "ZZZ"', prompt: 'b' },
+          { id: 'c', needs: ['b'], prompt: 'c' },
+        ],
+      }),
+      h.deps,
+    );
+    expect(result.ok).toBe(true);
+    const byId = Object.fromEntries(result.steps.map((s) => [s.id, s.status]));
+    expect(byId).toEqual({ a: 'completed', b: 'skipped', c: 'completed' });
+  });
+
+  it('uses a skill body as the child system prompt + allowed tools', async () => {
+    const h = makeHarness({}, { 'web-research': 'RESEARCH PLAYBOOK' });
+    await dagExecutor.run(
+      wf({
+        name: 'sk',
+        description: 'x',
+        steps: [{ id: 's', skill: 'web-research', input: 'find news' }],
+      }),
+      h.deps,
+    );
+    const spec = h.specs[0]!;
+    expect(spec.systemPrompt).toBe('RESEARCH PLAYBOOK');
+    expect(spec.prompt).toBe('find news');
+    expect(spec.allowedTools).toEqual(['Read']);
+  });
+
+  it('aborts the workflow when a step fails with onError=fail', async () => {
+    const h = makeHarness({
+      tools: {
+        get: () => ({}),
+        execute: async () => {
+          throw new Error('boom');
+        },
+      },
+    });
+    const result = await dagExecutor.run(
+      wf({
+        name: 'fail',
+        description: 'x',
+        steps: [
+          { id: 'a', tool: 'x', onError: 'fail' },
+          { id: 'b', needs: ['a'], prompt: 'b' },
+        ],
+      }),
+      h.deps,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/boom/);
+    const byId = Object.fromEntries(result.steps.map((s) => [s.id, s.status]));
+    expect(byId.a).toBe('failed');
+    expect(byId.b).toBe('skipped'); // never ran
+  });
+
+  it('continues past a failed step when onError=continue', async () => {
+    const h = makeHarness({
+      tools: {
+        get: () => ({}),
+        execute: async () => {
+          throw new Error('boom');
+        },
+      },
+    });
+    const result = await dagExecutor.run(
+      wf({
+        name: 'cont',
+        description: 'x',
+        steps: [
+          { id: 'a', tool: 'x', onError: 'continue' },
+          { id: 'b', needs: ['a'], prompt: 'b' },
+        ],
+      }),
+      h.deps,
+    );
+    expect(result.ok).toBe(true); // tolerated
+    const byId = Object.fromEntries(result.steps.map((s) => [s.id, s.status]));
+    expect(byId.a).toBe('failed');
+    expect(byId.b).toBe('completed');
+  });
+
+  it('retries a flaky step up to `retries` times', async () => {
+    let attempts = 0;
+    const h = makeHarness({
+      tools: {
+        get: () => ({}),
+        execute: async () => {
+          attempts += 1;
+          if (attempts < 2) throw new Error('transient');
+          return 'recovered';
+        },
+      },
+    });
+    const result = await dagExecutor.run(
+      wf({
+        name: 'retry',
+        description: 'x',
+        steps: [{ id: 'a', tool: 'x', onError: 'retry', retries: 2 }],
+      }),
+      h.deps,
+    );
+    expect(result.ok).toBe(true);
+    expect(attempts).toBe(2);
+    expect(result.steps[0]!.status).toBe('completed');
+  });
+
+  it('runs a nested workflow and captures its output', async () => {
+    const inner = wf({ name: 'inner', description: 'x', steps: [{ id: 'i', prompt: 'hi' }] });
+    const h = makeHarness();
+    const deps: WorkflowRunDeps = { ...h.deps, lookup: { skill: () => undefined, workflow: (n) => (n === 'inner' ? inner : undefined) } };
+    const result = await dagExecutor.run(
+      wf({ name: 'outer', description: 'x', steps: [{ id: 'o', workflow: 'inner' }] }),
+      deps,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.steps[0]!.output).toBe('OUT_i');
+  });
+
+  it('emits lifecycle events', async () => {
+    const events: string[] = [];
+    const h = makeHarness({ emit: (subtype) => void events.push(subtype) });
+    await dagExecutor.run(
+      wf({ name: 'ev', description: 'x', steps: [{ id: 'a', prompt: 'go' }] }),
+      h.deps,
+    );
+    expect(events).toContain('workflow_started');
+    expect(events).toContain('workflow_step_started');
+    expect(events).toContain('workflow_step_completed');
+    expect(events).toContain('workflow_completed');
+  });
+});

--- a/packages/plugin-workflows/src/executor/dag.ts
+++ b/packages/plugin-workflows/src/executor/dag.ts
@@ -1,0 +1,329 @@
+import {
+  defineWorkflowExecutor,
+  type SubagentSpec,
+  type Workflow,
+  type WorkflowExecutorDef,
+  type WorkflowRunDeps,
+  type WorkflowRunResult,
+  type WorkflowStep,
+  type WorkflowStepResult,
+  type WorkflowStepStatus,
+} from '@moxxy/sdk';
+import { evalCondition, renderArgs, renderTemplate, type TemplateScope } from '../template.js';
+
+export const DAG_EXECUTOR_NAME = 'dag';
+const MAX_NESTING_DEPTH = 5;
+
+/**
+ * Default workflow executor: a parallel DAG runner.
+ *
+ * Steps with all dependencies settled run in waves of up to
+ * `workflow.concurrency`. A step whose `when` evaluates false is skipped (its
+ * dependents treat it as settled with empty output). On step failure the
+ * `onError` disposition decides whether to abort the workflow or continue past
+ * it (after `retries` extra attempts). Lifecycle is emitted as `plugin_event`s
+ * via `deps.emit`, mirroring plan-execute's `plan_step_*`.
+ *
+ * The executor is pure with respect to the filesystem — it returns the full
+ * per-step result set; persisting a run record is the engine/runner's job.
+ */
+
+type StepRuntimeStatus = 'pending' | WorkflowStepStatus;
+
+interface StepState {
+  status: StepRuntimeStatus;
+  output: string;
+  error?: string;
+  startedAt: number;
+  endedAt: number;
+}
+
+function nowFn(deps: WorkflowRunDeps): () => number {
+  return deps.now ?? (() => Date.now());
+}
+
+function resolveInputs(workflow: Workflow, deps: WorkflowRunDeps): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [name, spec] of Object.entries(workflow.inputs)) {
+    if (spec.default !== undefined) out[name] = spec.default;
+  }
+  for (const [name, value] of Object.entries(deps.inputs ?? {})) {
+    if (value !== undefined) out[name] = value;
+  }
+  return out;
+}
+
+function buildScope(
+  states: Map<string, StepState>,
+  inputs: Record<string, unknown>,
+  deps: WorkflowRunDeps,
+  nowIso: string,
+): TemplateScope {
+  const steps: Record<string, { output: string }> = {};
+  for (const [id, st] of states) steps[id] = { output: st.output };
+  return {
+    steps,
+    inputs,
+    ...(deps.trigger != null ? { trigger: deps.trigger } : {}),
+    now: nowIso,
+  };
+}
+
+async function runExecutor(workflow: Workflow, deps: WorkflowRunDeps): Promise<WorkflowRunResult> {
+  const now = nowFn(deps);
+  const inputs = resolveInputs(workflow, deps);
+  const states = new Map<string, StepState>();
+  for (const step of workflow.steps) {
+    states.set(step.id, { status: 'pending', output: '', startedAt: 0, endedAt: 0 });
+  }
+
+  await deps.emit?.('workflow_started', { name: workflow.name, steps: workflow.steps.length });
+
+  const settled = (id: string): boolean => {
+    const s = states.get(id)?.status;
+    return s === 'completed' || s === 'skipped' || s === 'failed';
+  };
+
+  let aborted = false;
+  let abortReason: string | undefined;
+
+  while (!aborted) {
+    if (deps.signal.aborted) {
+      abortReason = 'aborted';
+      break;
+    }
+
+    // 1. Resolve any newly-ready steps whose `when` is false → skip them.
+    //    Loop so a skip that unblocks another skip settles in one pass.
+    let skippedSomething = true;
+    while (skippedSomething) {
+      skippedSomething = false;
+      for (const step of workflow.steps) {
+        const st = states.get(step.id)!;
+        if (st.status !== 'pending') continue;
+        if (!step.needs.every(settled)) continue;
+        if (step.when == null) continue;
+        const scope = buildScope(states, inputs, deps, new Date(now()).toISOString());
+        let keep: boolean;
+        try {
+          keep = evalCondition(step.when, scope);
+        } catch (err) {
+          // A malformed condition that slipped past validation fails the step.
+          st.status = 'failed';
+          st.error = `when: ${err instanceof Error ? err.message : String(err)}`;
+          st.startedAt = st.endedAt = now();
+          await deps.emit?.('workflow_step_failed', { id: step.id, error: st.error });
+          if (step.onError !== 'continue') {
+            aborted = true;
+            abortReason = st.error;
+          }
+          skippedSomething = true;
+          continue;
+        }
+        if (!keep) {
+          st.status = 'skipped';
+          st.startedAt = st.endedAt = now();
+          await deps.emit?.('workflow_step_skipped', { id: step.id });
+          skippedSomething = true;
+        }
+      }
+      if (aborted) break;
+    }
+    if (aborted) break;
+
+    // 2. Gather ready executable steps (deps settled, when true / absent).
+    const ready = workflow.steps.filter((step) => {
+      const st = states.get(step.id)!;
+      return st.status === 'pending' && step.needs.every(settled);
+    });
+
+    if (ready.length === 0) {
+      const anyPending = [...states.values()].some((s) => s.status === 'pending');
+      if (anyPending) {
+        abortReason = 'workflow stalled — no runnable steps (check needs/when)';
+        aborted = true;
+      }
+      break;
+    }
+
+    // 3. Run a wave (cap at concurrency). Independent steps run together.
+    const wave = ready.slice(0, Math.max(1, workflow.concurrency));
+    const scope = buildScope(states, inputs, deps, new Date(now()).toISOString());
+    await Promise.all(
+      wave.map(async (step) => {
+        const st = states.get(step.id)!;
+        st.startedAt = now();
+        await deps.emit?.('workflow_step_started', {
+          id: step.id,
+          label: step.label ?? step.id,
+        });
+        const outcome = await runStep(step, scope, deps);
+        st.endedAt = now();
+        if (outcome.ok) {
+          st.status = 'completed';
+          st.output = outcome.output;
+          await deps.emit?.('workflow_step_completed', {
+            id: step.id,
+            preview: outcome.output.slice(0, 280),
+          });
+        } else {
+          st.status = 'failed';
+          st.error = outcome.error;
+          await deps.emit?.('workflow_step_failed', { id: step.id, error: outcome.error });
+          if (step.onError !== 'continue') {
+            aborted = true;
+            abortReason = `step "${step.id}" failed: ${outcome.error}`;
+          }
+        }
+      }),
+    );
+  }
+
+  const stepResults: WorkflowStepResult[] = workflow.steps.map((step) => {
+    const st = states.get(step.id)!;
+    return {
+      id: step.id,
+      status: st.status === 'pending' ? 'skipped' : st.status,
+      output: st.output,
+      ...(st.error ? { error: st.error } : {}),
+      startedAt: st.startedAt,
+      endedAt: st.endedAt,
+    };
+  });
+
+  // A run is "ok" when it reached the end without a hard abort. A failure on
+  // a step whose `onError` is `continue` is tolerated by the author, so it
+  // does not flip the run to failed — the per-step status still records it.
+  const ok = !aborted;
+  const output = sinkOutput(workflow, states);
+
+  if (ok) {
+    await deps.emit?.('workflow_completed', { name: workflow.name, output: output.slice(0, 280) });
+  } else {
+    await deps.emit?.('workflow_failed', { name: workflow.name, error: abortReason });
+  }
+
+  return {
+    ok,
+    steps: stepResults,
+    output,
+    ...(ok ? {} : { error: abortReason ?? 'workflow failed' }),
+  };
+}
+
+/** Concatenate the outputs of completed terminal (sink) steps. */
+function sinkOutput(workflow: Workflow, states: Map<string, StepState>): string {
+  const needed = new Set<string>();
+  for (const step of workflow.steps) for (const dep of step.needs) needed.add(dep);
+  const sinks = workflow.steps.filter((s) => !needed.has(s.id));
+  const completed = sinks
+    .map((s) => states.get(s.id))
+    .filter((st): st is StepState => st?.status === 'completed' && st.output.length > 0);
+  if (completed.length > 0) return completed.map((s) => s.output).join('\n\n');
+  // Fall back to the last completed step's output.
+  const lastCompleted = [...states.values()].filter((s) => s.status === 'completed').pop();
+  return lastCompleted?.output ?? '';
+}
+
+interface StepOutcome {
+  readonly ok: boolean;
+  readonly output: string;
+  readonly error?: string;
+}
+
+async function runStep(
+  step: WorkflowStep,
+  scope: TemplateScope,
+  deps: WorkflowRunDeps,
+): Promise<StepOutcome> {
+  const attempts = 1 + Math.max(0, step.retries);
+  let lastError = '';
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (deps.signal.aborted) return { ok: false, output: '', error: 'aborted' };
+    try {
+      const output = await runStepOnce(step, scope, deps);
+      return { ok: true, output };
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+      deps.logger?.warn?.('workflow step attempt failed', {
+        step: step.id,
+        attempt: attempt + 1,
+        error: lastError,
+      });
+    }
+  }
+  return { ok: false, output: '', error: lastError };
+}
+
+async function runStepOnce(
+  step: WorkflowStep,
+  scope: TemplateScope,
+  deps: WorkflowRunDeps,
+): Promise<string> {
+  const opts = deps.logger ? { logger: deps.logger } : {};
+
+  if (step.tool) {
+    const args = renderArgs(step.args ?? {}, scope, opts);
+    const result = await deps.tools.execute(step.tool, args, deps.signal);
+    return typeof result === 'string' ? result : JSON.stringify(result ?? '');
+  }
+
+  if (step.workflow) {
+    const nested = deps.lookup.workflow(step.workflow);
+    if (!nested) throw new Error(`nested workflow "${step.workflow}" not found`);
+    const depth = (deps.depth ?? 0) + 1;
+    if (depth > MAX_NESTING_DEPTH) {
+      throw new Error(`nested workflow depth exceeded ${MAX_NESTING_DEPTH}`);
+    }
+    const nestedInputs = renderArgs(step.args ?? {}, scope, opts) as Record<string, unknown>;
+    const result = await runExecutor(nested, {
+      ...deps,
+      inputs: nestedInputs,
+      depth,
+      trigger: `workflow:${step.workflow}`,
+    });
+    if (!result.ok) throw new Error(result.error ?? `nested workflow "${step.workflow}" failed`);
+    return result.output;
+  }
+
+  // skill / prompt → run a child agent and capture its final text.
+  const spec = buildSubagentSpec(step, scope, deps, opts);
+  const child = await deps.spawner.spawn(spec);
+  if (child.error) throw new Error(child.error.message);
+  return child.text;
+}
+
+function buildSubagentSpec(
+  step: WorkflowStep,
+  scope: TemplateScope,
+  deps: WorkflowRunDeps,
+  opts: { logger?: { warn?(msg: string, meta?: Record<string, unknown>): void } },
+): SubagentSpec {
+  const label = step.label ?? step.id;
+  const renderedInput = step.input ? renderTemplate(step.input, scope, opts) : '';
+
+  if (step.skill) {
+    const skill = deps.lookup.skill(step.skill);
+    if (!skill) throw new Error(`skill "${step.skill}" not found`);
+    const allowed = skill.frontmatter['allowed-tools'];
+    const prompt =
+      renderedInput ||
+      `Follow the "${skill.frontmatter.name}" playbook in your system prompt.`;
+    const spec: SubagentSpec = {
+      prompt,
+      systemPrompt: skill.body,
+      label,
+    };
+    if (allowed && allowed.length > 0) (spec as { allowedTools?: ReadonlyArray<string> }).allowedTools = allowed;
+    return spec;
+  }
+
+  // prompt step
+  return { prompt: renderTemplate(step.prompt ?? '', scope, opts), label };
+}
+
+export const dagExecutor: WorkflowExecutorDef = defineWorkflowExecutor({
+  name: DAG_EXECUTOR_NAME,
+  description: 'Parallel DAG runner: steps with settled dependencies run in waves up to `concurrency`.',
+  run: runExecutor,
+});

--- a/packages/plugin-workflows/src/index.ts
+++ b/packages/plugin-workflows/src/index.ts
@@ -1,0 +1,53 @@
+/**
+ * `@moxxy/plugin-workflows` — a swappable DAG engine that chains
+ * skills/prompts/tools into saved, parameterized, schedulable/event-triggered
+ * pipelines. Registered statically by the CLI via `buildWorkflowsPlugin`.
+ */
+
+export {
+  validateWorkflow,
+  parseWorkflowYaml,
+  serializeWorkflow,
+  workflowSchema,
+  SLUG_RE,
+  type WorkflowParseResult,
+} from './schema.js';
+
+export {
+  discoverWorkflows,
+  defaultUserWorkflowsDir,
+  defaultProjectWorkflowsDir,
+  type DiscoveredWorkflow,
+  type WorkflowScope,
+  type WorkflowLogger,
+  type WorkflowLoadOptions,
+} from './loader.js';
+
+export {
+  WorkflowStore,
+  type WorkflowStoreOptions,
+  type EditableScope,
+} from './store.js';
+
+export {
+  renderTemplate,
+  renderArgs,
+  evalCondition,
+  validateCondition,
+  ConditionSyntaxError,
+  type TemplateScope,
+  type RenderOptions,
+} from './template.js';
+
+export { dagExecutor, DAG_EXECUTOR_NAME } from './executor/dag.js';
+export { runWorkflow, defaultRunRecordDir, type RunWorkflowOptions } from './engine.js';
+export { draftWorkflow, type DraftWorkflowOptions, type DraftedWorkflow } from './draft.js';
+export {
+  buildWorkflowTools,
+  buildRunDeps,
+  WORKFLOWS_PLUGIN_NAME,
+  type WorkflowToolDeps,
+} from './tools.js';
+export { buildWorkflowsCommand, type WorkflowCommandDeps } from './command.js';
+export { buildWorkflowsPlugin, type BuildWorkflowsPluginOptions } from './plugin.js';
+export { BUILTIN_WORKFLOWS_DIR } from './paths.js';

--- a/packages/plugin-workflows/src/loader.ts
+++ b/packages/plugin-workflows/src/loader.ts
@@ -1,0 +1,89 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { Workflow } from '@moxxy/sdk';
+import { parseWorkflowYaml } from './schema.js';
+
+/**
+ * Discover workflow artifacts from disk, mirroring `discoverSkills`: scan
+ * builtin → plugin → user → project in priority order, later scopes
+ * overriding earlier ones by workflow name. Each `.yaml`/`.yml` file holds
+ * one workflow; invalid files are skipped with a logged warning.
+ */
+
+export type WorkflowScope = 'builtin' | 'plugin' | 'user' | 'project';
+
+export interface WorkflowLogger {
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+  info?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface DiscoveredWorkflow {
+  readonly workflow: Workflow;
+  readonly path: string;
+  readonly scope: WorkflowScope;
+}
+
+export interface WorkflowLoadOptions {
+  readonly projectDir?: string;
+  readonly userDir?: string;
+  readonly pluginDirs?: ReadonlyArray<string>;
+  readonly builtinDir?: string;
+  readonly logger?: WorkflowLogger;
+}
+
+export function defaultUserWorkflowsDir(): string {
+  return path.join(os.homedir(), '.moxxy', 'workflows');
+}
+
+export function defaultProjectWorkflowsDir(cwd: string): string {
+  return path.join(cwd, '.moxxy', 'workflows');
+}
+
+export async function discoverWorkflows(
+  opts: WorkflowLoadOptions = {},
+): Promise<ReadonlyArray<DiscoveredWorkflow>> {
+  const sources: Array<{ dir: string; scope: WorkflowScope }> = [];
+  if (opts.builtinDir) sources.push({ dir: opts.builtinDir, scope: 'builtin' });
+  for (const dir of opts.pluginDirs ?? []) sources.push({ dir, scope: 'plugin' });
+  sources.push({ dir: opts.userDir ?? defaultUserWorkflowsDir(), scope: 'user' });
+  if (opts.projectDir) sources.push({ dir: opts.projectDir, scope: 'project' });
+
+  const byName = new Map<string, DiscoveredWorkflow>();
+  for (const source of sources) {
+    for (const found of await loadDir(source.dir, source.scope, opts.logger)) {
+      byName.set(found.workflow.name, found);
+    }
+  }
+  return [...byName.values()];
+}
+
+async function loadDir(
+  dir: string,
+  scope: WorkflowScope,
+  logger?: WorkflowLogger,
+): Promise<ReadonlyArray<DiscoveredWorkflow>> {
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: DiscoveredWorkflow[] = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      out.push(...(await loadDir(path.join(dir, entry.name), scope, logger)));
+      continue;
+    }
+    if (!entry.isFile() || !/\.ya?ml$/i.test(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    const raw = await fs.readFile(full, 'utf8');
+    const result = parseWorkflowYaml(raw);
+    if (!result.ok || !result.workflow) {
+      logger?.warn?.('workflow: invalid file, skipping', { path: full, errors: result.errors });
+      continue;
+    }
+    out.push({ workflow: result.workflow, path: full, scope });
+  }
+  return out;
+}

--- a/packages/plugin-workflows/src/paths.ts
+++ b/packages/plugin-workflows/src/paths.ts
@@ -1,0 +1,13 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Directory holding the workflows shipped with this package (the sample
+ * `stock-market-digest.yaml`). Passed to the `WorkflowStore` as its
+ * `builtinDir`. When the CLI is bundled and this path doesn't exist at
+ * runtime, `discoverWorkflows` simply finds nothing there — no crash.
+ */
+export const BUILTIN_WORKFLOWS_DIR: string = path.resolve(__dirname, '../workflows');

--- a/packages/plugin-workflows/src/plugin.ts
+++ b/packages/plugin-workflows/src/plugin.ts
@@ -1,0 +1,92 @@
+import {
+  definePlugin,
+  type EmittedEvent,
+  type LLMProvider,
+  type Plugin,
+  type Skill,
+  type WorkflowExecutorDef,
+  type WorkflowRunResult,
+  type WorkflowToolRunner,
+} from '@moxxy/sdk';
+import { buildWorkflowsCommand } from './command.js';
+import { dagExecutor } from './executor/dag.js';
+import type { WorkflowLogger } from './loader.js';
+import { buildWorkflowTools, WORKFLOWS_PLUGIN_NAME, type WorkflowToolDeps } from './tools.js';
+import type { WorkflowStore } from './store.js';
+
+/**
+ * Assemble the workflows plugin. Mirrors `buildSchedulerPlugin`: the CLI
+ * supplies dependencies bound to the live `Session` (kept as SDK-typed
+ * closures so this package never imports `@moxxy/core`). Returns the plugin
+ * plus the shared `WorkflowStore` so the CLI can build the `WorkflowsView`
+ * (for the `/workflows` modal) and the autonomous runner against the same
+ * instance.
+ */
+export interface BuildWorkflowsPluginOptions {
+  readonly store: WorkflowStore;
+  readonly skills: { byName(name: string): Skill | undefined };
+  readonly tools: WorkflowToolRunner;
+  readonly getActiveExecutor: () => WorkflowExecutorDef | null;
+  readonly appendEvent?: (event: EmittedEvent) => unknown;
+  readonly logger?: WorkflowLogger;
+  readonly runRecordDir?: string | null;
+  readonly provider?: () => LLMProvider | null;
+  readonly draftModel?: string;
+  readonly listSkills?: () => ReadonlyArray<string>;
+  readonly listTools?: () => ReadonlyArray<string>;
+  /** Re-sync triggers after a create/update/delete/toggle. */
+  readonly onChanged?: () => void | Promise<void>;
+  /** Runs a workflow now (autonomous runner) — backs `/workflows run`. */
+  readonly runNow?: (input: {
+    readonly name: string;
+    readonly inputs?: Record<string, unknown>;
+    readonly trigger?: string;
+  }) => Promise<WorkflowRunResult>;
+  readonly userDir?: string;
+  /** Called once after the store has loaded on init (CLI installs view + triggers here). */
+  readonly onReady?: () => void | Promise<void>;
+}
+
+export function buildWorkflowsPlugin(opts: BuildWorkflowsPluginOptions): {
+  readonly plugin: Plugin;
+  readonly store: WorkflowStore;
+} {
+  const toolDeps: WorkflowToolDeps = {
+    store: opts.store,
+    skills: opts.skills,
+    tools: opts.tools,
+    getActiveExecutor: opts.getActiveExecutor,
+    ...(opts.appendEvent ? { appendEvent: opts.appendEvent } : {}),
+    ...(opts.logger ? { logger: opts.logger } : {}),
+    ...(opts.runRecordDir !== undefined ? { runRecordDir: opts.runRecordDir } : {}),
+    ...(opts.provider ? { provider: opts.provider } : {}),
+    ...(opts.draftModel ? { draftModel: opts.draftModel } : {}),
+    ...(opts.listSkills ? { listSkills: opts.listSkills } : {}),
+    ...(opts.listTools ? { listTools: opts.listTools } : {}),
+    ...(opts.onChanged ? { onChanged: opts.onChanged } : {}),
+  };
+
+  const command = buildWorkflowsCommand({
+    store: opts.store,
+    ...(opts.runNow ? { runNow: opts.runNow } : {}),
+    ...(opts.onChanged ? { onChanged: opts.onChanged } : {}),
+    ...(opts.runRecordDir ? { runRecordDir: opts.runRecordDir } : {}),
+    ...(opts.userDir ? { userDir: opts.userDir } : {}),
+  });
+
+  const plugin = definePlugin({
+    name: WORKFLOWS_PLUGIN_NAME,
+    version: '0.0.1',
+    tools: buildWorkflowTools(toolDeps),
+    workflowExecutors: [dagExecutor],
+    commands: [command],
+    hooks: {
+      onInit: async () => {
+        await opts.store.load();
+        await opts.onReady?.();
+      },
+    },
+  });
+
+  return { plugin, store: opts.store };
+}

--- a/packages/plugin-workflows/src/schema.test.ts
+++ b/packages/plugin-workflows/src/schema.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { parseWorkflowYaml, serializeWorkflow, validateWorkflow } from './schema.js';
+
+const VALID = `
+name: stock-digest
+description: Fetch news, analyze, email.
+on:
+  schedule: { cron: "0 8 * * 1-5" }
+inputs:
+  watchlist: { default: ["AAPL"] }
+steps:
+  - id: fetch_news
+    skill: web-research
+    input: "headlines"
+  - id: analyze
+    needs: [fetch_news]
+    prompt: "Analyze {{ steps.fetch_news.output }}"
+  - id: email
+    needs: [analyze]
+    when: "{{ steps.analyze.output }} is not empty"
+    tool: gmail_send
+    args: { to: "me", body: "{{ steps.analyze.output }}" }
+`;
+
+describe('workflow schema', () => {
+  it('parses a valid workflow and applies defaults', () => {
+    const r = parseWorkflowYaml(VALID);
+    expect(r.ok).toBe(true);
+    const wf = r.workflow!;
+    expect(wf.name).toBe('stock-digest');
+    expect(wf.version).toBe(1);
+    expect(wf.enabled).toBe(true);
+    expect(wf.concurrency).toBe(4);
+    expect(wf.steps).toHaveLength(3);
+    // step-level defaults
+    expect(wf.steps[0]!.needs).toEqual([]);
+    expect(wf.steps[0]!.onError).toBe('fail');
+    expect(wf.steps[0]!.retries).toBe(0);
+  });
+
+  it('round-trips through serialize → parse', () => {
+    const wf = parseWorkflowYaml(VALID).workflow!;
+    const reparsed = parseWorkflowYaml(serializeWorkflow(wf));
+    expect(reparsed.ok).toBe(true);
+    expect(reparsed.workflow!.name).toBe(wf.name);
+    expect(reparsed.workflow!.steps).toHaveLength(3);
+  });
+
+  it('rejects a cycle in `needs`', () => {
+    const r = validateWorkflow({
+      name: 'cyc',
+      description: 'x',
+      steps: [
+        { id: 'a', prompt: 'a', needs: ['b'] },
+        { id: 'b', prompt: 'b', needs: ['a'] },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/cycle/);
+  });
+
+  it('rejects duplicate step ids', () => {
+    const r = validateWorkflow({
+      name: 'dup',
+      description: 'x',
+      steps: [
+        { id: 'a', prompt: 'a' },
+        { id: 'a', prompt: 'a2' },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/duplicate step id/);
+  });
+
+  it('rejects a step with multiple actions', () => {
+    const r = validateWorkflow({
+      name: 'multi',
+      description: 'x',
+      steps: [{ id: 'a', prompt: 'a', skill: 'b' }],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/multiple actions/);
+  });
+
+  it('rejects a step with no action', () => {
+    const r = validateWorkflow({
+      name: 'none',
+      description: 'x',
+      steps: [{ id: 'a' }],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/exactly one action/);
+  });
+
+  it('rejects `needs` referencing an unknown step', () => {
+    const r = validateWorkflow({
+      name: 'unknown-need',
+      description: 'x',
+      steps: [{ id: 'a', prompt: 'a', needs: ['ghost'] }],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/unknown step "ghost"/);
+  });
+
+  it('rejects an invalid `when` condition', () => {
+    const r = validateWorkflow({
+      name: 'bad-when',
+      description: 'x',
+      steps: [{ id: 'a', prompt: 'a', when: 'this is gibberish' }],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/invalid `when`/);
+  });
+
+  it('rejects a non-slug name', () => {
+    const r = validateWorkflow({ name: 'Bad Name!', description: 'x', steps: [{ id: 'a', prompt: 'a' }] });
+    expect(r.ok).toBe(false);
+  });
+});

--- a/packages/plugin-workflows/src/schema.ts
+++ b/packages/plugin-workflows/src/schema.ts
@@ -1,0 +1,199 @@
+import type { Workflow } from '@moxxy/sdk';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import { z } from 'zod';
+import { validateCondition } from './template.js';
+
+/**
+ * Validation for workflow artifacts. The SDK owns the structural TS types
+ * ({@link Workflow} et al.); this module owns the zod schema that parses
+ * on-disk YAML into them, plus the DAG-integrity checks (unique ids, edges
+ * reference real steps, no cycles, exactly one action per step).
+ */
+
+const ACTION_KEYS = ['skill', 'prompt', 'tool', 'workflow'] as const;
+
+export const SLUG_RE = /^[a-z0-9][a-z0-9-]*$/i;
+const STEP_ID_RE = /^[a-z0-9][a-z0-9_-]*$/i;
+
+const stepSchema = z
+  .object({
+    id: z.string().min(1).max(80).regex(STEP_ID_RE, 'step id must be slug-like'),
+    skill: z.string().min(1).optional(),
+    prompt: z.string().min(1).optional(),
+    tool: z.string().min(1).optional(),
+    workflow: z.string().min(1).optional(),
+    input: z.string().optional(),
+    args: z.record(z.unknown()).optional(),
+    needs: z.array(z.string().min(1)).default([]),
+    when: z.string().min(1).optional(),
+    onError: z.enum(['fail', 'continue', 'retry']).default('fail'),
+    retries: z.number().int().min(0).max(3).default(0),
+    label: z.string().max(60).optional(),
+  })
+  .superRefine((step, ctx) => {
+    const present = ACTION_KEYS.filter((k) => step[k] != null);
+    if (present.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `step "${step.id}" needs exactly one action (${ACTION_KEYS.join(' | ')})`,
+        path: ['skill'],
+      });
+    } else if (present.length > 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `step "${step.id}" has multiple actions (${present.join(', ')}); pick one`,
+        path: [present[1]!],
+      });
+    }
+  });
+
+const triggerSchema = z
+  .object({
+    schedule: z
+      .object({
+        cron: z.string().optional(),
+        runAt: z.union([z.number().int(), z.string()]).optional(),
+        timeZone: z.string().optional(),
+      })
+      .optional(),
+    afterWorkflow: z.union([z.string(), z.array(z.string())]).optional(),
+    fileChanged: z.union([z.string(), z.array(z.string())]).optional(),
+    webhook: z.string().optional(),
+  })
+  .partial();
+
+const inputSpecSchema = z.object({
+  default: z.unknown().optional(),
+  description: z.string().optional(),
+});
+
+export const workflowSchema = z
+  .object({
+    name: z.string().min(1).max(120).regex(SLUG_RE, 'name must be slug-like'),
+    description: z.string().min(1),
+    version: z.number().int().default(1),
+    enabled: z.boolean().default(true),
+    inputs: z.record(inputSpecSchema).default({}),
+    on: triggerSchema.optional(),
+    delivery: z
+      .object({
+        channel: z.string().optional(),
+        inbox: z.boolean().default(true),
+      })
+      .optional(),
+    concurrency: z.number().int().min(1).max(8).default(4),
+    steps: z.array(stepSchema).min(1).max(40),
+  })
+  .superRefine((wf, ctx) => {
+    const ids = new Set<string>();
+    for (const step of wf.steps) {
+      if (ids.has(step.id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `duplicate step id "${step.id}"`,
+          path: ['steps'],
+        });
+      }
+      ids.add(step.id);
+    }
+    for (const step of wf.steps) {
+      for (const dep of step.needs) {
+        if (!ids.has(dep)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `step "${step.id}" needs unknown step "${dep}"`,
+            path: ['steps'],
+          });
+        }
+      }
+    }
+    const cycle = findCycle(wf.steps);
+    if (cycle) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `steps form a cycle: ${cycle.join(' → ')}`,
+        path: ['steps'],
+      });
+    }
+    for (const step of wf.steps) {
+      if (step.when == null) continue;
+      const err = validateCondition(step.when);
+      if (err) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `step "${step.id}" has an invalid \`when\` condition: ${err}`,
+          path: ['steps'],
+        });
+      }
+    }
+  });
+
+/** DFS cycle detection over `needs` edges. Returns the cycle path or null. */
+function findCycle(steps: ReadonlyArray<{ id: string; needs: ReadonlyArray<string> }>): string[] | null {
+  const byId = new Map(steps.map((s) => [s.id, s]));
+  const state = new Map<string, 'visiting' | 'done'>();
+  const stack: string[] = [];
+
+  const visit = (id: string): string[] | null => {
+    const s = state.get(id);
+    if (s === 'done') return null;
+    if (s === 'visiting') {
+      const from = stack.indexOf(id);
+      return [...stack.slice(from), id];
+    }
+    const step = byId.get(id);
+    if (!step) return null; // unknown dep already flagged elsewhere
+    state.set(id, 'visiting');
+    stack.push(id);
+    for (const dep of step.needs) {
+      const found = visit(dep);
+      if (found) return found;
+    }
+    stack.pop();
+    state.set(id, 'done');
+    return null;
+  };
+
+  for (const step of steps) {
+    const found = visit(step.id);
+    if (found) return found;
+  }
+  return null;
+}
+
+export interface WorkflowParseResult {
+  readonly ok: boolean;
+  readonly workflow?: Workflow;
+  /** One readable line per issue, e.g. `steps: step "a" needs unknown step "x"`. */
+  readonly errors: ReadonlyArray<string>;
+}
+
+function formatIssues(error: z.ZodError): string[] {
+  return error.issues.map((iss) => {
+    const path = iss.path.join('.') || '(root)';
+    return `${path}: ${iss.message}`;
+  });
+}
+
+/** Validate an already-parsed object against the workflow schema. */
+export function validateWorkflow(raw: unknown): WorkflowParseResult {
+  const parsed = workflowSchema.safeParse(raw);
+  if (!parsed.success) return { ok: false, errors: formatIssues(parsed.error) };
+  return { ok: true, workflow: parsed.data as Workflow, errors: [] };
+}
+
+/** Parse + validate a YAML document into a Workflow. */
+export function parseWorkflowYaml(text: string): WorkflowParseResult {
+  let doc: unknown;
+  try {
+    doc = parseYaml(text);
+  } catch (err) {
+    return { ok: false, errors: [`yaml: ${err instanceof Error ? err.message : String(err)}`] };
+  }
+  return validateWorkflow(doc);
+}
+
+/** Serialize a Workflow back to canonical YAML (for `workflow_create` writes). */
+export function serializeWorkflow(wf: Workflow): string {
+  return stringifyYaml(wf, { lineWidth: 0 });
+}

--- a/packages/plugin-workflows/src/store.test.ts
+++ b/packages/plugin-workflows/src/store.test.ts
@@ -1,0 +1,62 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { validateWorkflow } from './schema.js';
+import { WorkflowStore } from './store.js';
+
+let dir: string;
+let store: WorkflowStore;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-wf-'));
+  store = new WorkflowStore({ cwd: dir, userDir: path.join(dir, 'user'), projectDir: path.join(dir, 'project') });
+  await store.load();
+});
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+function sample(name: string) {
+  return validateWorkflow({ name, description: 'x', steps: [{ id: 'a', prompt: 'go' }] }).workflow!;
+}
+
+describe('WorkflowStore CRUD', () => {
+  it('creates, lists, and looks up a workflow', async () => {
+    const created = await store.create(sample('alpha'), 'user');
+    expect(created.scope).toBe('user');
+    expect(created.path.endsWith('alpha.yaml')).toBe(true);
+
+    const list = await store.list();
+    expect(list.map((w) => w.workflow.name)).toContain('alpha');
+    expect(store.lookup('alpha')?.name).toBe('alpha');
+
+    // persisted to disk and rediscovered by a fresh store
+    const fresh = new WorkflowStore({ cwd: dir, userDir: path.join(dir, 'user') });
+    await fresh.load();
+    expect((await fresh.get('alpha'))?.workflow.name).toBe('alpha');
+  });
+
+  it('rejects creating a duplicate name', async () => {
+    await store.create(sample('beta'), 'user');
+    await expect(store.create(sample('beta'), 'user')).rejects.toThrow(/already exists/);
+  });
+
+  it('toggles enabled and persists it', async () => {
+    await store.create(sample('gamma'), 'user');
+    const updated = await store.setEnabled('gamma', false);
+    expect(updated?.workflow.enabled).toBe(false);
+
+    const fresh = new WorkflowStore({ cwd: dir, userDir: path.join(dir, 'user') });
+    await fresh.load();
+    expect((await fresh.get('gamma'))?.workflow.enabled).toBe(false);
+  });
+
+  it('deletes a user workflow', async () => {
+    await store.create(sample('delta'), 'user');
+    const res = await store.delete('delta');
+    expect(res.ok).toBe(true);
+    expect(await store.get('delta')).toBeUndefined();
+  });
+});

--- a/packages/plugin-workflows/src/store.ts
+++ b/packages/plugin-workflows/src/store.ts
@@ -1,0 +1,174 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { writeFileAtomic, type Workflow } from '@moxxy/sdk';
+import {
+  defaultProjectWorkflowsDir,
+  defaultUserWorkflowsDir,
+  discoverWorkflows,
+  type DiscoveredWorkflow,
+  type WorkflowLogger,
+} from './loader.js';
+import { serializeWorkflow, validateWorkflow } from './schema.js';
+
+/**
+ * Owns the set of workflow artifacts: discovers them from disk on `load()`,
+ * keeps them in an in-memory name→workflow map (the "registry" role), and
+ * performs file CRUD for the authoring tools and the `/workflows` command.
+ *
+ * Builtin/plugin workflows are read-only; editing or toggling one writes a
+ * user-scope override (later scopes win in discovery) rather than mutating a
+ * package file.
+ */
+
+export type EditableScope = 'user' | 'project';
+
+export interface WorkflowStoreOptions {
+  readonly cwd: string;
+  readonly userDir?: string;
+  readonly projectDir?: string;
+  readonly builtinDir?: string;
+  readonly pluginDirs?: ReadonlyArray<string>;
+  readonly logger?: WorkflowLogger;
+}
+
+export class WorkflowStore {
+  private readonly byName = new Map<string, DiscoveredWorkflow>();
+  private readonly opts: WorkflowStoreOptions;
+  private loaded = false;
+
+  constructor(opts: WorkflowStoreOptions) {
+    this.opts = opts;
+  }
+
+  private userDir(): string {
+    return this.opts.userDir ?? defaultUserWorkflowsDir();
+  }
+
+  private projectDir(): string {
+    return this.opts.projectDir ?? defaultProjectWorkflowsDir(this.opts.cwd);
+  }
+
+  /** (Re)scan all sources and rebuild the in-memory map. */
+  async load(): Promise<void> {
+    const discovered = await discoverWorkflows({
+      userDir: this.userDir(),
+      projectDir: this.projectDir(),
+      ...(this.opts.builtinDir ? { builtinDir: this.opts.builtinDir } : {}),
+      ...(this.opts.pluginDirs ? { pluginDirs: this.opts.pluginDirs } : {}),
+      ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+    });
+    this.byName.clear();
+    for (const wf of discovered) this.byName.set(wf.workflow.name, wf);
+    this.loaded = true;
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (!this.loaded) await this.load();
+  }
+
+  async list(): Promise<ReadonlyArray<DiscoveredWorkflow>> {
+    await this.ensureLoaded();
+    return [...this.byName.values()];
+  }
+
+  async get(name: string): Promise<DiscoveredWorkflow | undefined> {
+    await this.ensureLoaded();
+    return this.byName.get(name);
+  }
+
+  /** Synchronous lookup for hot paths (executor). Assumes `load()` already ran. */
+  lookup(name: string): Workflow | undefined {
+    return this.byName.get(name)?.workflow;
+  }
+
+  /** Write a new workflow file and register it. Rejects duplicate names. */
+  async create(workflow: Workflow, scope: EditableScope): Promise<DiscoveredWorkflow> {
+    await this.ensureLoaded();
+    if (this.byName.has(workflow.name)) {
+      throw new Error(`workflow "${workflow.name}" already exists — use update instead`);
+    }
+    const dir = scope === 'project' ? this.projectDir() : this.userDir();
+    await fs.mkdir(dir, { recursive: true });
+    const file = await uniqueFilename(dir, workflow.name);
+    await writeFileAtomic(file, serializeWorkflow(workflow));
+    const entry: DiscoveredWorkflow = { workflow, path: file, scope };
+    this.byName.set(workflow.name, entry);
+    return entry;
+  }
+
+  /**
+   * Replace a workflow with a new definition. In-place rewrite for user/project
+   * workflows; a user-scope override for builtin/plugin ones.
+   */
+  async save(workflow: Workflow): Promise<DiscoveredWorkflow> {
+    await this.ensureLoaded();
+    const existing = this.byName.get(workflow.name);
+    const editable = existing && (existing.scope === 'user' || existing.scope === 'project');
+    if (existing && editable) {
+      await writeFileAtomic(existing.path, serializeWorkflow(workflow));
+      const entry: DiscoveredWorkflow = { ...existing, workflow };
+      this.byName.set(workflow.name, entry);
+      return entry;
+    }
+    // New, or overriding a read-only builtin/plugin workflow → write to user dir.
+    const dir = this.userDir();
+    await fs.mkdir(dir, { recursive: true });
+    const file = await uniqueFilename(dir, workflow.name);
+    await writeFileAtomic(file, serializeWorkflow(workflow));
+    const entry: DiscoveredWorkflow = { workflow, path: file, scope: 'user' };
+    this.byName.set(workflow.name, entry);
+    return entry;
+  }
+
+  /** Toggle a workflow's `enabled` flag, persisting the change. */
+  async setEnabled(name: string, enabled: boolean): Promise<DiscoveredWorkflow | null> {
+    await this.ensureLoaded();
+    const existing = this.byName.get(name);
+    if (!existing) return null;
+    return this.save({ ...existing.workflow, enabled });
+  }
+
+  /** Delete a user/project workflow file. Read-only scopes cannot be deleted. */
+  async delete(name: string): Promise<{ ok: boolean; reason?: string }> {
+    await this.ensureLoaded();
+    const existing = this.byName.get(name);
+    if (!existing) return { ok: false, reason: 'not found' };
+    if (existing.scope !== 'user' && existing.scope !== 'project') {
+      return { ok: false, reason: `cannot delete a ${existing.scope} workflow` };
+    }
+    await fs.rm(existing.path, { force: true });
+    this.byName.delete(name);
+    return { ok: true };
+  }
+}
+
+async function uniqueFilename(dir: string, base: string): Promise<string> {
+  const slug = slugify(base);
+  let candidate = path.join(dir, `${slug}.yaml`);
+  let n = 2;
+  while (await exists(candidate)) {
+    candidate = path.join(dir, `${slug}-${n}.yaml`);
+    n += 1;
+  }
+  return candidate;
+}
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Re-export for callers that only need the validation entry point. */
+export { validateWorkflow };

--- a/packages/plugin-workflows/src/template.test.ts
+++ b/packages/plugin-workflows/src/template.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { evalCondition, renderArgs, renderTemplate, validateCondition, type TemplateScope } from './template.js';
+
+const scope: TemplateScope = {
+  steps: { fetch: { output: 'AAPL up 3%' }, empty: { output: '   ' } },
+  inputs: { watchlist: ['AAPL', 'MSFT'], region: 'US' },
+  trigger: 'schedule',
+  now: '2026-05-28T08:00:00Z',
+  vars: { mood: 'bullish' },
+};
+
+describe('renderTemplate', () => {
+  it('substitutes step / input / trigger / now / vars refs', () => {
+    expect(renderTemplate('news: {{ steps.fetch.output }}', scope)).toBe('news: AAPL up 3%');
+    expect(renderTemplate('{{ inputs.region }}', scope)).toBe('US');
+    expect(renderTemplate('{{ trigger }} @ {{ now }}', scope)).toBe('schedule @ 2026-05-28T08:00:00Z');
+    expect(renderTemplate('{{ vars.mood }}', scope)).toBe('bullish');
+  });
+
+  it('JSON-stringifies non-string values', () => {
+    expect(renderTemplate('{{ inputs.watchlist }}', scope)).toBe('["AAPL","MSFT"]');
+  });
+
+  it('renders unknown refs as empty string', () => {
+    expect(renderTemplate('x{{ steps.missing.output }}y', scope)).toBe('xy');
+    expect(renderTemplate('x{{ inputs.nope }}y', scope)).toBe('xy');
+  });
+});
+
+describe('renderArgs', () => {
+  it('deep-renders string leaves', () => {
+    const out = renderArgs({ to: 'me', body: '{{ steps.fetch.output }}', nested: { x: ['{{ inputs.region }}'] } }, scope);
+    expect(out).toEqual({ to: 'me', body: 'AAPL up 3%', nested: { x: ['US'] } });
+  });
+});
+
+describe('evalCondition', () => {
+  it('handles contains / == / !=', () => {
+    expect(evalCondition('{{ steps.fetch.output }} contains "AAPL"', scope)).toBe(true);
+    expect(evalCondition('{{ steps.fetch.output }} contains "TSLA"', scope)).toBe(false);
+    expect(evalCondition('{{ inputs.region }} == "US"', scope)).toBe(true);
+    expect(evalCondition('{{ inputs.region }} != "EU"', scope)).toBe(true);
+  });
+
+  it('handles is empty / is not empty (whitespace-aware)', () => {
+    expect(evalCondition('{{ steps.fetch.output }} is not empty', scope)).toBe(true);
+    expect(evalCondition('{{ steps.empty.output }} is empty', scope)).toBe(true);
+    expect(evalCondition('{{ steps.missing.output }} is empty', scope)).toBe(true);
+  });
+
+  it('handles and / or with correct precedence', () => {
+    expect(evalCondition('{{ inputs.region }} == "US" and {{ steps.fetch.output }} contains "AAPL"', scope)).toBe(true);
+    expect(evalCondition('{{ inputs.region }} == "EU" and {{ steps.fetch.output }} contains "AAPL"', scope)).toBe(false);
+    expect(evalCondition('{{ inputs.region }} == "EU" or {{ steps.fetch.output }} contains "AAPL"', scope)).toBe(true);
+  });
+
+  it('accepts a bare (non-{{}}) ref on the LHS', () => {
+    expect(evalCondition('steps.fetch.output contains "AAPL"', scope)).toBe(true);
+  });
+
+  it('throws on malformed syntax', () => {
+    expect(() => evalCondition('nonsense here', scope)).toThrow();
+  });
+});
+
+describe('validateCondition', () => {
+  it('returns null for valid, a message for invalid', () => {
+    expect(validateCondition('{{ steps.x.output }} is empty')).toBeNull();
+    expect(validateCondition('blah blah')).toMatch(/unrecognized/);
+    expect(validateCondition('')).toMatch(/empty condition/);
+  });
+});

--- a/packages/plugin-workflows/src/template.ts
+++ b/packages/plugin-workflows/src/template.ts
@@ -1,0 +1,188 @@
+/**
+ * Safe, hand-written templating + condition evaluation for workflows.
+ *
+ * NO `eval` / `new Function` — same posture as the isolators security stance.
+ * Templates substitute `{{ ref }}` placeholders; conditions support a tiny,
+ * explicit grammar only. Anything outside the grammar is a syntax error
+ * surfaced at author time (`workflow_validate` / `workflow_create`).
+ */
+
+export interface TemplateScope {
+  /** Completed step outputs, keyed by step id. */
+  readonly steps: Record<string, { readonly output: string }>;
+  /** Resolved workflow inputs (defaults applied). */
+  readonly inputs: Record<string, unknown>;
+  /** What fired the run (`{{ trigger }}`). */
+  readonly trigger?: string;
+  /** ISO timestamp for `{{ now }}`. */
+  readonly now?: string;
+  /** Ad-hoc variables (`{{ vars.x }}`). */
+  readonly vars?: Record<string, unknown>;
+}
+
+const REF_RE = /\{\{\s*([^}]+?)\s*\}\}/g;
+
+function stringifyValue(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value);
+}
+
+/** Resolve a dotted reference (e.g. `steps.fetch.output`) to a raw value. */
+function resolveRef(ref: string, scope: TemplateScope): unknown {
+  const parts = ref.split('.').map((p) => p.trim());
+  const [head, ...rest] = parts;
+  switch (head) {
+    case 'trigger':
+      return scope.trigger ?? '';
+    case 'now':
+      return scope.now ?? '';
+    case 'steps': {
+      const id = rest[0];
+      if (!id) return undefined;
+      const out = scope.steps[id]?.output;
+      // `steps.x` and `steps.x.output` both resolve to the step's output.
+      return out ?? '';
+    }
+    case 'inputs':
+      return rest[0] ? scope.inputs[rest[0]] : undefined;
+    case 'vars':
+      return rest[0] ? scope.vars?.[rest[0]] : undefined;
+    default:
+      return undefined;
+  }
+}
+
+export interface RenderOptions {
+  readonly logger?: { warn?(msg: string, meta?: Record<string, unknown>): void };
+}
+
+/** Substitute every `{{ ref }}` in `text`. Unknown refs render empty. */
+export function renderTemplate(text: string, scope: TemplateScope, opts: RenderOptions = {}): string {
+  return text.replace(REF_RE, (_match, ref: string) => {
+    const value = resolveRef(ref.trim(), scope);
+    if (value === undefined) {
+      opts.logger?.warn?.('workflow template: unresolved reference', { ref: ref.trim() });
+      return '';
+    }
+    return stringifyValue(value);
+  });
+}
+
+/** Deep-render string leaves of an args object/array. */
+export function renderArgs(args: unknown, scope: TemplateScope, opts: RenderOptions = {}): unknown {
+  if (typeof args === 'string') return renderTemplate(args, scope, opts);
+  if (Array.isArray(args)) return args.map((v) => renderArgs(v, scope, opts));
+  if (args && typeof args === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(args as Record<string, unknown>)) {
+      out[k] = renderArgs(v, scope, opts);
+    }
+    return out;
+  }
+  return args;
+}
+
+// ----------------------------------------------------------------------------
+// Condition DSL
+// ----------------------------------------------------------------------------
+//
+//   <lhs> contains "literal"
+//   <lhs> == "literal"
+//   <lhs> != "literal"
+//   <lhs> is empty
+//   <lhs> is not empty
+//
+// joined by `and` / `or` (OR-of-ANDs; `and` binds tighter than `or`).
+// <lhs> is a `{{ ref }}` template or a bare dotted ref. Literals are
+// double-quoted; avoid embedding ` and `/` or ` inside a literal in v1.
+
+type Atom =
+  | { readonly kind: 'contains' | 'eq' | 'neq'; readonly lhs: string; readonly literal: string }
+  | { readonly kind: 'empty' | 'notEmpty'; readonly lhs: string };
+
+const ATOM_PATTERNS: ReadonlyArray<{ re: RegExp; build: (m: RegExpMatchArray) => Atom }> = [
+  { re: /^(.+?)\s+is\s+not\s+empty$/i, build: (m) => ({ kind: 'notEmpty', lhs: m[1]!.trim() }) },
+  { re: /^(.+?)\s+is\s+empty$/i, build: (m) => ({ kind: 'empty', lhs: m[1]!.trim() }) },
+  { re: /^(.+?)\s+contains\s+"(.*)"$/i, build: (m) => ({ kind: 'contains', lhs: m[1]!.trim(), literal: m[2]! }) },
+  { re: /^(.+?)\s+==\s+"(.*)"$/, build: (m) => ({ kind: 'eq', lhs: m[1]!.trim(), literal: m[2]! }) },
+  { re: /^(.+?)\s+!=\s+"(.*)"$/, build: (m) => ({ kind: 'neq', lhs: m[1]!.trim(), literal: m[2]! }) },
+];
+
+/** Split `expr` on a top-level connective word, ignoring quoted regions. */
+function splitTop(expr: string, connective: 'and' | 'or'): string[] {
+  const parts: string[] = [];
+  let depth = 0; // inside double-quotes when odd
+  let buf = '';
+  const words = expr.split(/(\s+)/); // keep whitespace tokens
+  for (const w of words) {
+    for (const ch of w) if (ch === '"') depth ^= 1;
+    if (depth === 0 && w.toLowerCase() === connective) {
+      parts.push(buf);
+      buf = '';
+    } else {
+      buf += w;
+    }
+  }
+  parts.push(buf);
+  return parts.map((p) => p.trim()).filter((p) => p.length > 0);
+}
+
+function parseAtom(text: string): Atom {
+  for (const { re, build } of ATOM_PATTERNS) {
+    const m = text.match(re);
+    if (m) return build(m);
+  }
+  throw new ConditionSyntaxError(`unrecognized condition clause: "${text}"`);
+}
+
+export class ConditionSyntaxError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConditionSyntaxError';
+  }
+}
+
+interface ParsedCondition {
+  /** OR of AND-groups. */
+  readonly orGroups: ReadonlyArray<ReadonlyArray<Atom>>;
+}
+
+function parseCondition(expr: string): ParsedCondition {
+  const trimmed = expr.trim();
+  if (!trimmed) throw new ConditionSyntaxError('empty condition');
+  const orGroups = splitTop(trimmed, 'or').map((group) => splitTop(group, 'and').map(parseAtom));
+  return { orGroups };
+}
+
+function evalAtom(atom: Atom, scope: TemplateScope): boolean {
+  const value = renderTemplate(atom.lhs.includes('{{') ? atom.lhs : `{{ ${atom.lhs} }}`, scope).trim();
+  switch (atom.kind) {
+    case 'empty':
+      return value === '';
+    case 'notEmpty':
+      return value !== '';
+    case 'contains':
+      return value.includes(atom.literal);
+    case 'eq':
+      return value === atom.literal;
+    case 'neq':
+      return value !== atom.literal;
+  }
+}
+
+/** Evaluate a condition against the scope. Throws on syntax error. */
+export function evalCondition(expr: string, scope: TemplateScope): boolean {
+  const { orGroups } = parseCondition(expr);
+  return orGroups.some((group) => group.every((atom) => evalAtom(atom, scope)));
+}
+
+/** Author-time check: returns an error message, or null when the syntax is valid. */
+export function validateCondition(expr: string): string | null {
+  try {
+    parseCondition(expr);
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}

--- a/packages/plugin-workflows/src/tools.ts
+++ b/packages/plugin-workflows/src/tools.ts
@@ -1,0 +1,346 @@
+import {
+  asPluginId,
+  defineTool,
+  MoxxyError,
+  z,
+  type EmittedEvent,
+  type LLMProvider,
+  type SessionId,
+  type Skill,
+  type ToolDef,
+  type TurnId,
+  type WorkflowEventSubtype,
+  type WorkflowExecutorDef,
+  type WorkflowRunDeps,
+  type WorkflowToolRunner,
+} from '@moxxy/sdk';
+import { draftWorkflow } from './draft.js';
+import { runWorkflow } from './engine.js';
+import { parseWorkflowYaml, serializeWorkflow } from './schema.js';
+import type { EditableScope, WorkflowStore } from './store.js';
+import type { WorkflowLogger } from './loader.js';
+
+export const WORKFLOWS_PLUGIN_NAME = '@moxxy/plugin-workflows';
+
+/**
+ * Dependencies the workflow tools close over. Supplied by the CLI wiring,
+ * which binds them to the live `Session` — keeping this package free of any
+ * `@moxxy/core` import (mirrors how `@moxxy/plugin-scheduler` takes an
+ * injected runner + an SDK `SkillRegistry`).
+ */
+export interface WorkflowToolDeps {
+  readonly store: WorkflowStore;
+  readonly skills: { byName(name: string): Skill | undefined };
+  readonly tools: WorkflowToolRunner;
+  readonly getActiveExecutor: () => WorkflowExecutorDef | null;
+  /** Bound to `session.log.append` so lifecycle events land on the log. */
+  readonly appendEvent?: (event: EmittedEvent) => unknown;
+  readonly logger?: WorkflowLogger;
+  /** Run-record directory, or null to skip recording (tests). */
+  readonly runRecordDir?: string | null;
+  /** Active provider for `workflow_create` drafting. */
+  readonly provider?: () => LLMProvider | null;
+  readonly draftModel?: string;
+  /** Skill/tool names surfaced to the drafter so it references real ones. */
+  readonly listSkills?: () => ReadonlyArray<string>;
+  readonly listTools?: () => ReadonlyArray<string>;
+  /** Called after a create/update/delete/toggle so triggers can re-sync. */
+  readonly onChanged?: () => void | Promise<void>;
+}
+
+const PLUGIN_ID = asPluginId(WORKFLOWS_PLUGIN_NAME);
+
+/**
+ * Build a {@link WorkflowRunDeps} for an in-turn run. The spawner comes from
+ * the tool context (only present inside a run-turn loop); lifecycle events are
+ * tagged to the current turn so the TUI threads them correctly.
+ */
+export function buildRunDeps(
+  deps: WorkflowToolDeps,
+  ctx: { sessionId: import('@moxxy/sdk').SessionId; turnId: import('@moxxy/sdk').TurnId; signal: AbortSignal; subagents: NonNullable<import('@moxxy/sdk').WorkflowRunDeps['spawner']> },
+  inputs: Record<string, unknown> | undefined,
+  trigger: string,
+): WorkflowRunDeps {
+  const emit = deps.appendEvent
+    ? (subtype: WorkflowEventSubtype, payload: unknown) =>
+        void deps.appendEvent!({
+          type: 'plugin_event',
+          sessionId: ctx.sessionId,
+          turnId: ctx.turnId,
+          source: 'plugin',
+          pluginId: PLUGIN_ID,
+          subtype,
+          payload,
+        } as EmittedEvent)
+    : undefined;
+  return {
+    spawner: ctx.subagents,
+    tools: deps.tools,
+    lookup: {
+      skill: (n) => deps.skills.byName(n),
+      workflow: (n) => deps.store.lookup(n),
+    },
+    signal: ctx.signal,
+    ...(inputs ? { inputs } : {}),
+    trigger,
+    now: () => Date.now(),
+    ...(emit ? { emit } : {}),
+    ...(deps.logger ? { logger: deps.logger } : {}),
+  };
+}
+
+export function buildWorkflowTools(deps: WorkflowToolDeps): ToolDef[] {
+  return [
+    runTool(deps),
+    listTool(deps),
+    getTool(deps),
+    validateTool(deps),
+    createTool(deps),
+    updateTool(deps),
+    setEnabledTool(deps),
+    deleteTool(deps),
+  ];
+}
+
+/** Append an artifact-change plugin_event (workflow_created/updated/deleted). */
+function emitChange(
+  deps: WorkflowToolDeps,
+  ctx: { sessionId: SessionId; turnId: TurnId },
+  subtype: string,
+  payload: unknown,
+): void {
+  deps.appendEvent?.({
+    type: 'plugin_event',
+    sessionId: ctx.sessionId,
+    turnId: ctx.turnId,
+    source: 'plugin',
+    pluginId: PLUGIN_ID,
+    subtype,
+    payload,
+  } as EmittedEvent);
+}
+
+function createTool(deps: WorkflowToolDeps): ToolDef {
+  return defineTool({
+    name: 'workflow_create',
+    description:
+      'Draft and persist a new workflow from a natural-language intent (the agentic ' +
+      'authoring path). Uses the active provider to generate a workflow YAML, validates ' +
+      'it (schema + DAG + conditions), writes it, and registers it. ALWAYS pass scope="user" ' +
+      '(default) unless the user explicitly asks to scope it to this project.',
+    inputSchema: z.object({
+      intent: z.string().min(1).describe('What the workflow should do. One or two sentences.'),
+      scope: z.enum(['user', 'project']).optional().default('user'),
+    }),
+    permission: { action: 'prompt' },
+    handler: async ({ intent, scope }, ctx) => {
+      const provider = deps.provider?.();
+      if (!provider) {
+        throw new MoxxyError({ code: 'PROVIDER_NOT_CONFIGURED', message: 'workflow_create: no active provider to draft with.' });
+      }
+      const model = deps.draftModel ?? provider.models[0]?.id ?? 'claude-sonnet-4-6';
+      const drafted = await draftWorkflow(provider, model, intent, ctx.signal, {
+        ...(deps.listSkills ? { availableSkills: deps.listSkills() } : {}),
+        ...(deps.listTools ? { availableTools: deps.listTools() } : {}),
+      });
+      if (!drafted.parse.ok || !drafted.parse.workflow) {
+        throw new MoxxyError({
+          code: 'TOOL_ERROR',
+          message:
+            `workflow_create: the model did not produce a valid workflow ` +
+            `(${drafted.parse.errors.join('; ')}). Try a more specific intent.`,
+        });
+      }
+      const created = await deps.store.create(drafted.parse.workflow, scope as EditableScope);
+      emitChange(deps, ctx, 'workflow_created', { name: created.workflow.name, scope });
+      await deps.onChanged?.();
+      return { name: created.workflow.name, scope: created.scope, path: created.path, steps: created.workflow.steps.length };
+    },
+  });
+}
+
+function updateTool(deps: WorkflowToolDeps): ToolDef {
+  return defineTool({
+    name: 'workflow_update',
+    description:
+      'Replace a saved workflow with new YAML (full document). Validates before writing. ' +
+      'Use workflow_get to fetch the current YAML, edit it, then pass it back here.',
+    inputSchema: z.object({
+      name: z.string().min(1),
+      yaml: z.string().min(1).describe('The complete new workflow YAML.'),
+    }),
+    permission: { action: 'prompt' },
+    handler: async ({ name, yaml }, ctx) => {
+      const parsed = parseWorkflowYaml(yaml);
+      if (!parsed.ok || !parsed.workflow) {
+        throw new MoxxyError({ code: 'TOOL_ERROR', message: `workflow_update: invalid YAML — ${parsed.errors.join('; ')}` });
+      }
+      if (parsed.workflow.name !== name) {
+        throw new MoxxyError({ code: 'TOOL_ERROR', message: `workflow_update: YAML name "${parsed.workflow.name}" must match "${name}".` });
+      }
+      const saved = await deps.store.save(parsed.workflow);
+      emitChange(deps, ctx, 'workflow_updated', { name });
+      await deps.onChanged?.();
+      return { name: saved.workflow.name, scope: saved.scope, path: saved.path };
+    },
+  });
+}
+
+function setEnabledTool(deps: WorkflowToolDeps): ToolDef {
+  return defineTool({
+    name: 'workflow_set_enabled',
+    description:
+      'Enable or disable a workflow. A disabled workflow keeps its definition but its ' +
+      'triggers never fire and it is excluded from auto-runs (it can still be run explicitly).',
+    inputSchema: z.object({ name: z.string().min(1), enabled: z.boolean() }),
+    permission: { action: 'prompt' },
+    handler: async ({ name, enabled }, ctx) => {
+      const updated = await deps.store.setEnabled(name, enabled);
+      if (!updated) throw new MoxxyError({ code: 'TOOL_ERROR', message: `workflow_set_enabled: no workflow "${name}".` });
+      emitChange(deps, ctx, 'workflow_updated', { name, enabled });
+      await deps.onChanged?.();
+      return { name, enabled };
+    },
+  });
+}
+
+function deleteTool(deps: WorkflowToolDeps): ToolDef {
+  return defineTool({
+    name: 'workflow_delete',
+    description: 'Delete a user/project workflow by name. Builtin/plugin workflows cannot be deleted.',
+    inputSchema: z.object({ name: z.string().min(1) }),
+    permission: { action: 'prompt' },
+    handler: async ({ name }, ctx) => {
+      const res = await deps.store.delete(name);
+      if (!res.ok) throw new MoxxyError({ code: 'TOOL_ERROR', message: `workflow_delete: ${res.reason}.` });
+      emitChange(deps, ctx, 'workflow_deleted', { name });
+      await deps.onChanged?.();
+      return { name, deleted: true };
+    },
+  });
+}
+
+function runTool(deps: WorkflowToolDeps): ToolDef {
+  return defineTool({
+    name: 'workflow_run',
+    description:
+      'Run a saved workflow now by name. Executes its DAG of skill/prompt/tool steps ' +
+      'via the active workflow executor, piping each step\'s output into the next, and ' +
+      'returns a per-step summary plus the final output. Pass `inputs` to override the ' +
+      'workflow\'s declared input defaults.',
+    inputSchema: z.object({
+      name: z.string().min(1).describe('Exact workflow name (see workflow_list).'),
+      inputs: z.record(z.unknown()).optional().describe('Input overrides for this run.'),
+    }),
+    permission: { action: 'prompt' },
+    handler: async ({ name, inputs }, ctx) => {
+      const entry = await deps.store.get(name);
+      if (!entry) {
+        const known = (await deps.store.list()).map((w) => w.workflow.name).join(', ');
+        throw new MoxxyError({
+          code: 'TOOL_ERROR',
+          message: `workflow_run: no workflow named "${name}". Known: ${known || '(none)'}.`,
+        });
+      }
+      if (!ctx.subagents) {
+        throw new MoxxyError({
+          code: 'INTERNAL',
+          message: 'workflow_run: no subagent spawner — must be invoked from a run-turn loop.',
+        });
+      }
+      const runDeps = buildRunDeps(
+        deps,
+        { sessionId: ctx.sessionId, turnId: ctx.turnId, signal: ctx.signal, subagents: ctx.subagents },
+        inputs,
+        'manual',
+      );
+      const result = await runWorkflow(entry.workflow, runDeps, {
+        executor: deps.getActiveExecutor(),
+        ...(deps.runRecordDir !== undefined ? { recordDir: deps.runRecordDir } : {}),
+      });
+      return {
+        ok: result.ok,
+        output: result.output,
+        steps: result.steps.map((s) => ({
+          id: s.id,
+          status: s.status,
+          ...(s.error ? { error: s.error } : {}),
+        })),
+        ...(result.error ? { error: result.error } : {}),
+      };
+    },
+  });
+}
+
+function listTool(deps: WorkflowToolDeps): ToolDef {
+  return defineTool({
+    name: 'workflow_list',
+    description: 'List all saved workflows with their status, scope, triggers, and step count.',
+    inputSchema: z.object({}),
+    permission: { action: 'allow' },
+    handler: async () => {
+      const all = await deps.store.list();
+      return {
+        workflows: all.map((w) => ({
+          name: w.workflow.name,
+          description: w.workflow.description,
+          enabled: w.workflow.enabled,
+          scope: w.scope,
+          steps: w.workflow.steps.length,
+          triggers: triggerSummary(w.workflow.on),
+        })),
+      };
+    },
+  });
+}
+
+function getTool(deps: WorkflowToolDeps): ToolDef {
+  return defineTool({
+    name: 'workflow_get',
+    description: 'Fetch one workflow by name as canonical YAML, plus its on-disk path and scope.',
+    inputSchema: z.object({ name: z.string().min(1) }),
+    permission: { action: 'allow' },
+    handler: async ({ name }) => {
+      const entry = await deps.store.get(name);
+      if (!entry) throw new MoxxyError({ code: 'TOOL_ERROR', message: `workflow_get: no workflow "${name}".` });
+      return { name: entry.workflow.name, scope: entry.scope, path: entry.path, yaml: serializeWorkflow(entry.workflow) };
+    },
+  });
+}
+
+function validateTool(deps: WorkflowToolDeps): ToolDef {
+  return defineTool({
+    name: 'workflow_validate',
+    description:
+      'Validate a workflow without running it — checks the schema, the DAG (unique ids, ' +
+      'edges, no cycles, one action per step), and `when` syntax. Pass `yaml` to validate ' +
+      'a draft, or `name` to validate a saved workflow.',
+    inputSchema: z
+      .object({
+        yaml: z.string().optional(),
+        name: z.string().optional(),
+      })
+      .refine((v) => v.yaml || v.name, { message: 'pass either `yaml` or `name`' }),
+    permission: { action: 'allow' },
+    handler: async ({ yaml, name }) => {
+      if (yaml) {
+        const r = parseWorkflowYaml(yaml);
+        return { ok: r.ok, errors: r.errors };
+      }
+      const entry = await deps.store.get(name!);
+      if (!entry) return { ok: false, errors: [`no workflow named "${name}"`] };
+      return { ok: true, errors: [] };
+    },
+  });
+}
+
+function triggerSummary(on: import('@moxxy/sdk').WorkflowTrigger | undefined): string {
+  if (!on) return 'on-demand';
+  const parts: string[] = [];
+  if (on.schedule?.cron) parts.push(`cron(${on.schedule.cron})`);
+  if (on.schedule?.runAt) parts.push('runAt');
+  if (on.afterWorkflow) parts.push(`after(${[on.afterWorkflow].flat().join(',')})`);
+  if (on.fileChanged) parts.push('fileChanged');
+  if (on.webhook) parts.push(`webhook(${on.webhook})`);
+  return parts.length > 0 ? parts.join(' + ') : 'on-demand';
+}

--- a/packages/plugin-workflows/tsconfig.json
+++ b/packages/plugin-workflows/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/plugin-workflows/vitest.config.ts
+++ b/packages/plugin-workflows/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/packages/plugin-workflows/workflows/stock-market-digest.yaml
+++ b/packages/plugin-workflows/workflows/stock-market-digest.yaml
@@ -1,0 +1,54 @@
+# Sample workflow shipped with @moxxy/plugin-workflows. Disabled by default —
+# enable it from the /workflows modal (press `d`) once you've connected a
+# delivery tool, or just use it as a template. It demonstrates fan-out
+# (analyze ∥ check_watchlist), fan-in (email needs both), a `when` guard, and
+# a schedule trigger.
+name: stock-market-digest
+description: Weekday mornings — fetch Dow Jones news, analyze sentiment, check a watchlist, and email a digest.
+enabled: false
+on:
+  schedule:
+    cron: "0 8 * * 1-5"
+    timeZone: "America/New_York"
+inputs:
+  watchlist:
+    default: ["AAPL", "MSFT", "NVDA"]
+    description: Tickers to check against the day's news.
+delivery:
+  channel: inbox
+steps:
+  - id: fetch_news
+    skill: web-research
+    input: "Fetch today's market-moving headlines from Dow Jones, WSJ, and other major outlets. Summarize the top items."
+
+  - id: analyze
+    needs: [fetch_news]
+    prompt: |
+      Analyze these headlines for overall market sentiment and the most notable movers.
+      Be concise — bullet points.
+
+      {{ steps.fetch_news.output }}
+
+  - id: check_watchlist
+    needs: [fetch_news]
+    prompt: |
+      For each ticker in {{ inputs.watchlist }}, note anything in today's news that affects it.
+      If a ticker isn't mentioned, say "no news".
+
+      {{ steps.fetch_news.output }}
+
+  - id: email
+    needs: [analyze, check_watchlist]
+    when: '{{ steps.analyze.output }} is not empty'
+    # Replace `gmail_send` with whatever delivery tool you've connected. If you
+    # have none, the result still lands in ~/.moxxy/inbox/ via delivery.channel.
+    tool: gmail_send
+    onError: continue
+    args:
+      subject: "Daily Market Digest"
+      body: |
+        ## Market sentiment
+        {{ steps.analyze.output }}
+
+        ## Watchlist
+        {{ steps.check_watchlist.output }}

--- a/packages/sdk/src/define.ts
+++ b/packages/sdk/src/define.ts
@@ -14,6 +14,7 @@ import type { ToolIsolationSpec } from './isolation.js';
 import type { TranscriberDef } from './transcriber.js';
 import type { ViewRendererDef } from './view-renderer.js';
 import type { TunnelProviderDef } from './tunnel.js';
+import type { WorkflowExecutorDef } from './workflow.js';
 import type { z } from 'zod';
 
 export function definePlugin(spec: PluginSpec): Plugin {
@@ -114,5 +115,9 @@ export function defineCommand(spec: CommandDef): CommandDef {
 }
 
 export function defineAgent(spec: AgentDef): AgentDef {
+  return Object.freeze(spec);
+}
+
+export function defineWorkflowExecutor(spec: WorkflowExecutorDef): WorkflowExecutorDef {
   return Object.freeze(spec);
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -50,6 +50,9 @@ export type {
   CredentialResolver,
   McpAdminView,
   McpServerStatusView,
+  WorkflowsView,
+  WorkflowSummaryView,
+  WorkflowRunView,
 } from './session-like.js';
 
 export type {
@@ -213,6 +216,23 @@ export {
 
 export type { Skill, SkillDef, SkillFrontmatter, SkillScope, SkillSchedule } from './skill.js';
 
+export type {
+  Workflow,
+  WorkflowStep,
+  WorkflowTrigger,
+  WorkflowStepErrorMode,
+  WorkflowInputSpec,
+  WorkflowDelivery,
+  WorkflowToolRunner,
+  WorkflowLookup,
+  WorkflowEventSubtype,
+  WorkflowRunDeps,
+  WorkflowStepStatus,
+  WorkflowStepResult,
+  WorkflowRunResult,
+  WorkflowExecutorDef,
+} from './workflow.js';
+
 export type { AgentDef } from './agent.js';
 
 export type {
@@ -305,6 +325,7 @@ export {
   defineEmbedder,
   defineCommand,
   defineAgent,
+  defineWorkflowExecutor,
 } from './define.js';
 
 export {

--- a/packages/sdk/src/plugin.ts
+++ b/packages/sdk/src/plugin.ts
@@ -13,8 +13,9 @@ import type { ToolDef } from './tool.js';
 import type { TranscriberDef } from './transcriber.js';
 import type { ViewRendererDef } from './view-renderer.js';
 import type { TunnelProviderDef } from './tunnel.js';
+import type { WorkflowExecutorDef } from './workflow.js';
 
-export type PluginKind = 'tools' | 'provider' | 'mode' | 'compactor' | 'cache-strategy' | 'view-renderer' | 'tunnel-provider' | 'mcp' | 'cli' | 'channel' | 'hooks' | 'agent' | 'command' | 'transcriber' | 'embedder' | 'isolator';
+export type PluginKind = 'tools' | 'provider' | 'mode' | 'compactor' | 'cache-strategy' | 'view-renderer' | 'tunnel-provider' | 'mcp' | 'cli' | 'channel' | 'hooks' | 'agent' | 'command' | 'transcriber' | 'embedder' | 'isolator' | 'workflow-executor';
 
 export interface PluginSpec {
   readonly name: string;
@@ -82,6 +83,13 @@ export interface PluginSpec {
    * pickers, raw-mode toggles) inside the channel itself.
    */
   readonly commands?: ReadonlyArray<CommandDef>;
+  /**
+   * Workflow-execution strategies contributed by the plugin. One is active per
+   * session (selected via `session.workflowExecutors.setActive(name)`); the
+   * active executor runs a workflow DAG. `@moxxy/plugin-workflows` ships the
+   * default `dag` executor.
+   */
+  readonly workflowExecutors?: ReadonlyArray<WorkflowExecutorDef>;
   readonly hooks?: LifecycleHooks;
   readonly skillsDir?: string;
 }

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -121,6 +121,37 @@ export interface McpAdminView {
   listServers(): Promise<ReadonlyArray<McpServerStatusView>>;
 }
 
+/** One workflow's summary for the `/workflows` modal. */
+export interface WorkflowSummaryView {
+  readonly name: string;
+  readonly description: string;
+  readonly enabled: boolean;
+  readonly scope: string;
+  readonly steps: number;
+  /** Human-readable trigger summary, e.g. `cron(0 8 * * *)` or `on-demand`. */
+  readonly triggers: string;
+}
+
+/** Result of running a workflow from the modal. */
+export interface WorkflowRunView {
+  readonly ok: boolean;
+  readonly output: string;
+  readonly error?: string;
+  readonly steps: ReadonlyArray<{ readonly id: string; readonly status: string; readonly error?: string }>;
+}
+
+/**
+ * The slice of the workflows API a channel needs to drive the `/workflows`
+ * modal (list, enable/disable toggle, run). Present on a local Session when
+ * `@moxxy/plugin-workflows` is wired; a `RemoteSession` leaves
+ * {@link SessionLike.workflows} undefined and the UI degrades gracefully.
+ */
+export interface WorkflowsView {
+  list(): Promise<ReadonlyArray<WorkflowSummaryView>>;
+  setEnabled(name: string, enabled: boolean): Promise<void>;
+  run(name: string): Promise<WorkflowRunView>;
+}
+
 /**
  * The session surface a `Channel` depends on, decoupled from whether the
  * session runs in-process (`@moxxy/core`'s `Session`) or is a thin-client
@@ -155,4 +186,6 @@ export interface SessionLike {
   credentialResolver?: CredentialResolver;
   /** MCP admin slice backing the MCP picker / status line. */
   mcpAdmin?: McpAdminView;
+  /** Workflows slice backing the `/workflows` modal. */
+  workflows?: WorkflowsView;
 }

--- a/packages/sdk/src/workflow.ts
+++ b/packages/sdk/src/workflow.ts
@@ -1,0 +1,165 @@
+/**
+ * Workflows — saved, parameterized, schedulable/event-triggered DAGs whose
+ * steps run a skill, a free-form prompt, a tool, or a nested workflow, piping
+ * each step's output into the next. A workflow is an *artifact* (authored like
+ * a skill, discovered from disk); the strategy that *executes* it is a
+ * swappable block — {@link WorkflowExecutorDef} — registered into the
+ * `WorkflowExecutorRegistry` and selected by name, mirroring modes/compactors.
+ *
+ * These are the shared structural types. The zod schema that validates
+ * on-disk YAML lives in `@moxxy/plugin-workflows`; its parsed output is
+ * assignable to {@link Workflow}.
+ */
+
+import type { Skill } from './skill.js';
+import type { SubagentSpawner } from './subagent.js';
+
+/** What fires a workflow. Omit `on` entirely for an on-demand-only workflow. */
+export interface WorkflowTrigger {
+  /** Cron / one-shot time trigger, dispatched by `@moxxy/plugin-scheduler`. */
+  readonly schedule?: {
+    readonly cron?: string;
+    readonly runAt?: number | string;
+    readonly timeZone?: string;
+  };
+  /** Run when the named workflow(s) complete successfully (EventLog-driven). */
+  readonly afterWorkflow?: string | ReadonlyArray<string>;
+  /** Run when files matching the glob(s) under cwd change (fs.watch-driven). */
+  readonly fileChanged?: string | ReadonlyArray<string>;
+  /** Named webhook provider whose delivery fires this workflow. */
+  readonly webhook?: string;
+}
+
+/** How a failed step is handled: abort the workflow, skip past it, or retry. */
+export type WorkflowStepErrorMode = 'fail' | 'continue' | 'retry';
+
+/**
+ * One node in the DAG. Exactly one *action* key is set
+ * (`skill` | `prompt` | `tool` | `workflow`). `input` is the templated prompt
+ * for skill/prompt actions; `args` are the templated arguments for
+ * tool/workflow actions. `needs` are the upstream step ids this step depends on.
+ */
+export interface WorkflowStep {
+  readonly id: string;
+  readonly skill?: string;
+  readonly prompt?: string;
+  readonly tool?: string;
+  readonly workflow?: string;
+  readonly input?: string;
+  readonly args?: Record<string, unknown>;
+  readonly needs: ReadonlyArray<string>;
+  /** Condition DSL; when it evaluates false the step is skipped. */
+  readonly when?: string;
+  readonly onError: WorkflowStepErrorMode;
+  readonly retries: number;
+  readonly label?: string;
+}
+
+export interface WorkflowInputSpec {
+  readonly default?: unknown;
+  readonly description?: string;
+}
+
+export interface WorkflowDelivery {
+  /** Soft hint for delivery target — e.g. "telegram", "inbox". */
+  readonly channel?: string;
+  /** Also drop the final output into `~/.moxxy/inbox/`. Default true. */
+  readonly inbox: boolean;
+}
+
+export interface Workflow {
+  readonly name: string;
+  readonly description: string;
+  readonly version: number;
+  /**
+   * When false the workflow is inert: triggers (schedule/event) never fire it
+   * and it is excluded from auto-runs, but it stays listable and can still be
+   * run explicitly. Toggled from the `/workflows` command.
+   */
+  readonly enabled: boolean;
+  readonly inputs: Record<string, WorkflowInputSpec>;
+  readonly on?: WorkflowTrigger;
+  readonly delivery?: WorkflowDelivery;
+  /** Max steps to run concurrently in one ready-set round. */
+  readonly concurrency: number;
+  readonly steps: ReadonlyArray<WorkflowStep>;
+}
+
+/** Minimal tool surface a step needs — structurally a subset of `ToolRegistry`. */
+export interface WorkflowToolRunner {
+  get(name: string): unknown | undefined;
+  execute(name: string, input: unknown, signal: AbortSignal): Promise<unknown>;
+}
+
+/** Look up sibling artifacts by name during a run. */
+export interface WorkflowLookup {
+  skill(name: string): Skill | undefined;
+  workflow(name: string): Workflow | undefined;
+}
+
+/** Lifecycle subtypes an executor emits as `plugin_event`s (mirrors plan_*). */
+export type WorkflowEventSubtype =
+  | 'workflow_started'
+  | 'workflow_step_started'
+  | 'workflow_step_completed'
+  | 'workflow_step_skipped'
+  | 'workflow_step_failed'
+  | 'workflow_completed'
+  | 'workflow_failed';
+
+/**
+ * Everything an executor needs to run a workflow, supplied by the caller.
+ * The in-turn `workflow_run` tool wires `spawner` from `ctx.subagents`; the
+ * autonomous runner builds one from an isolated session. Kept free of core
+ * imports so the executor stays in a plugin.
+ */
+export interface WorkflowRunDeps {
+  readonly spawner: SubagentSpawner;
+  readonly tools: WorkflowToolRunner;
+  readonly lookup: WorkflowLookup;
+  readonly signal: AbortSignal;
+  /** Resolved input values (defaults already applied) for this run. */
+  readonly inputs?: Record<string, unknown>;
+  /** Free-form description of what fired the run (for `{{ trigger }}`). */
+  readonly trigger?: string;
+  /** Wall-clock source. Injected so tests are deterministic. */
+  readonly now?: () => number;
+  /** Emit a workflow lifecycle event. No-op when omitted. */
+  readonly emit?: (subtype: WorkflowEventSubtype, payload: unknown) => void | Promise<void>;
+  readonly logger?: {
+    warn?(msg: string, meta?: Record<string, unknown>): void;
+    info?(msg: string, meta?: Record<string, unknown>): void;
+  };
+  /** Nested-workflow recursion depth; executors guard against runaway nesting. */
+  readonly depth?: number;
+}
+
+export type WorkflowStepStatus = 'completed' | 'skipped' | 'failed';
+
+export interface WorkflowStepResult {
+  readonly id: string;
+  readonly status: WorkflowStepStatus;
+  readonly output: string;
+  readonly error?: string;
+  readonly startedAt: number;
+  readonly endedAt: number;
+}
+
+export interface WorkflowRunResult {
+  readonly ok: boolean;
+  readonly steps: ReadonlyArray<WorkflowStepResult>;
+  /** Output of the terminal (sink) step(s) — what delivery sends. */
+  readonly output: string;
+  readonly error?: string;
+}
+
+/**
+ * A swappable workflow-execution strategy. v1 ships one (`dag`); a plugin can
+ * register alternatives (parallel-heavy, dry-run, …) and the active one is
+ * selected by name via `session.workflowExecutors.setActive(name)`.
+ */
+export interface WorkflowExecutorDef {
+  readonly name: string;
+  readonly description?: string;
+  run(workflow: Workflow, deps: WorkflowRunDeps): Promise<WorkflowRunResult>;
+}

--- a/packages/skills-builtin/skills/create-workflow.md
+++ b/packages/skills-builtin/skills/create-workflow.md
@@ -1,0 +1,71 @@
+---
+name: create-workflow
+description: Design and save a multi-step workflow — a DAG that chains skills, prompts, and tools into a reusable, schedulable pipeline.
+triggers:
+  - create a workflow
+  - create a flow
+  - build a workflow
+  - build a pipeline
+  - chain skills
+  - automate this
+  - set up a flow
+  - workflow that
+allowed-tools:
+  - workflow_create
+  - workflow_validate
+  - workflow_list
+  - workflow_get
+  - workflow_run
+---
+
+Use this skill when the user wants a reusable, multi-step pipeline — e.g. "create a flow that fetches Dow Jones news, analyzes it, checks my watchlist, then emails me a digest." A workflow is a DAG: each step runs a **skill**, a free-form **prompt**, a **tool**, or a nested **workflow**, and each step's output pipes into the next.
+
+## Pattern
+
+1. **Clarify the goal** — the steps, their order, any inputs, and a trigger (on-demand, a schedule, on a file change, or after another workflow). Keep questions to a minimum; infer sensible defaults.
+
+2. **Map steps to actions:**
+   - Prefer a **named skill** when one already fits a step (`workflow_list` shows skills indirectly; the system prompt lists skills). Otherwise use a **prompt** step.
+   - Use a **tool** step for a concrete action — sending a message, calling an API, writing a file. For "email/notify me", use a connected tool (e.g. a Gmail MCP tool) if available; otherwise set `delivery: { channel: inbox }` so the result lands in `~/.moxxy/inbox/`.
+   - Express ordering and parallelism with `needs`: steps whose `needs` are all satisfied run **in parallel**. Fan-in by listing several ids in `needs`.
+
+3. **Call `workflow_create`** with a one- or two-sentence `intent` describing the whole pipeline. It drafts the YAML, validates it (schema + DAG + conditions), writes it to `~/.moxxy/workflows/`, and registers it. Pass `scope: "project"` ONLY if the user asked to scope it to this repo.
+
+4. **Show and offer to run** — summarize the steps and triggers. Offer `workflow_run` for a smoke test. The user can also manage flows from the `/workflows` modal (list, enable/disable, run).
+
+## Templating (reference earlier results)
+
+- `{{ steps.<id>.output }}` — a prior step's output
+- `{{ inputs.<name>}}` — a declared input
+- `{{ trigger }}`, `{{ now }}`
+
+## Conditions (`when:`)
+
+A step runs only if its `when` is true. Grammar: `<ref> contains "x"`, `<ref> == "x"`, `<ref> != "x"`, `<ref> is empty`, `<ref> is not empty`, joined by `and` / `or`. Example: `when: '{{ steps.check.output }} contains "ALERT"'`.
+
+## Example shape
+
+```yaml
+name: stock-market-digest
+description: Weekday mornings — Dow Jones news → sentiment → watchlist → email.
+on:
+  schedule: { cron: "0 8 * * 1-5", timeZone: "America/New_York" }
+steps:
+  - id: fetch_news
+    skill: web-research
+    input: "Fetch today's market-moving headlines from Dow Jones / WSJ."
+  - id: analyze
+    needs: [fetch_news]
+    prompt: "Analyze sentiment & notable movers:\n{{ steps.fetch_news.output }}"
+  - id: email
+    needs: [analyze]
+    when: '{{ steps.analyze.output }} is not empty'
+    tool: gmail_send
+    args: { to: "me", subject: "Daily Market Digest", body: "{{ steps.analyze.output }}" }
+```
+
+## Tips
+
+- A workflow with no `on:` block is on-demand only (run it with `workflow_run` or `/workflows run <name>`).
+- Set `onError: continue` on a non-critical step so one failure doesn't abort the whole pipeline; use `retries: N` for flaky steps.
+- To edit by hand instead, tell the user to run `/workflows new <name>` for a starter file, or `/workflows edit <name>` to find the path.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,6 +377,9 @@ importers:
       '@moxxy/plugin-webhooks':
         specifier: workspace:*
         version: link:../plugin-webhooks
+      '@moxxy/plugin-workflows':
+        specifier: workspace:*
+        version: link:../plugin-workflows
       '@moxxy/runner':
         specifier: workspace:*
         version: link:../runner
@@ -1554,6 +1557,37 @@ importers:
       ulid:
         specifier: ^2.3.0
         version: 2.4.0
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
+    devDependencies:
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)
+
+  packages/plugin-workflows:
+    dependencies:
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      ulid:
+        specifier: ^2.3.0
+        version: 2.4.0
+      yaml:
+        specifier: ^2.6.0
+        version: 2.9.0
       zod:
         specifier: 'catalog:'
         version: 3.25.76


### PR DESCRIPTION
## What this adds

**workflows** — saved, named, parameterized, schedulable/event-triggered **DAGs** whose steps run a **skill**, a free-form **prompt**, a **tool**, or a **nested workflow**, piping each step's output into the next. Steps whose `needs` are satisfied run **in parallel** (fan-out / fan-in).

A workflow is essentially a *saved, schedulable `plan-execute` pipeline made of skills*. Both the user and the agent can author them.

```yaml
name: stock-market-digest
on: { schedule: { cron: "0 8 * * 1-5", timeZone: "America/New_York" } }
steps:
  - id: fetch_news
    skill: web-research
    input: "Fetch today's market-moving Dow Jones / WSJ headlines."
  - id: analyze
    needs: [fetch_news]
    prompt: "Analyze sentiment & movers:\n{{ steps.fetch_news.output }}"
  - id: check_watchlist
    needs: [fetch_news]            # runs in parallel with analyze
    skill: ticker-check
    input: "Check {{ inputs.watchlist }} against:\n{{ steps.fetch_news.output }}"
  - id: email
    needs: [analyze, check_watchlist]   # fan-in
    when: '{{ steps.analyze.output }} is not empty'
    tool: gmail_send
    args: { subject: "Daily Market Digest", body: "{{ steps.analyze.output }}" }
```

## Highlights

- **Swappable block** — `WorkflowExecutorDef` is registry-backed (mirrors `ModeRegistry`), selected via `config.workflowExecutor`; v1 ships the default `dag` executor, a plugin can replace it.
- **New package `@moxxy/plugin-workflows`** (private, bundled into the CLI): zod schema with DAG / cycle / `when` validation, a **safe** template + condition DSL (no `eval`), YAML discovery + `WorkflowStore` CRUD, the `dag` executor (parallel waves, `when`-skip, `onError`/`retries`, nested workflows), engine + JSONL run records, an LLM drafter, eight tools, and the `/workflows` command.
- **Authoring both ways** — agentic (`create-workflow` skill → `workflow_create` drafts + validates + saves YAML) and by hand (`/workflows new <name>` scaffolds a starter file).
- **Required `/workflows` TUI modal** — lists every flow with `●` enabled / `○` disabled; `d` toggles enable/disable, `Enter`/`r` runs, `Esc` closes. Rendered as an overlay like `/skills`, intercepted before the command registry so non-TUI channels still get the text command.
- **Triggers** — schedule reuses the existing scheduler poller (new `syncWorkflowSchedule`, **no new timer**); `afterWorkflow` keys off the `workflow_completed` event; `fileChanged` via `fs.watch`. Results land in `~/.moxxy/inbox/`.

## Verification

- `build` 51/51 · `typecheck` 96/96 · `test` 95/95 (incl. 32 new plugin-workflows tests) · `check:deps` clean (plugin depends only on `@moxxy/sdk`).
- Bundled CLI boots; runtime smoke confirms all 8 tools, the `/workflows` command + aliases, and the active `dag` executor register at boot.

## Caveats

- **Webhook triggers are deferred** (recognized, logs a "run on demand" warning); schedule + afterWorkflow + fileChanged are wired.
- The sample `stock-market-digest.yaml` ships **disabled**; its email step uses a placeholder `gmail_send` tool — swap in a connected delivery tool, or results still land in the inbox.
