### PR TITLE
fix(release): publish with pnpm so workspace:/catalog: protocols are rewritten

### DIFF
--- a/.changeset/fix-publish-with-pnpm.md
+++ b/.changeset/fix-publish-with-pnpm.md
@@ -1,0 +1,15 @@
+---
+"@moxxy/cli": patch
+"@moxxy/sdk": patch
+---
+
+Publish with `pnpm publish` instead of `npm publish` so pnpm's `workspace:*` and `catalog:` protocols are rewritten to concrete version ranges in the published `package.json`.
+
+The previous `npm publish` shipped those protocols verbatim, so `npx @moxxy/cli init` failed on a clean machine with:
+
+```
+npm error code EUNSUPPORTEDPROTOCOL
+npm error Unsupported URL Type "workspace:": workspace:*
+```
+
+Both `@moxxy/cli` (`dependencies."@moxxy/sdk": "workspace:*"`, `zod: "catalog:"`) and `@moxxy/sdk` (`peerDependencies.zod: "catalog:"`) were affected, so both are republished.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@ Run `pnpm check:deps` to verify after structural changes.
 - **Wire every lifecycle hook.** `onEvent` needs `EventLog.subscribe → dispatcher.dispatchEvent`. `onShutdown` needs `Session.close()`. Declaring a hook without dispatching it is a silent dead-letter (we shipped that bug once — don't repeat).
 - **Use `Session.setPermissionResolver(r)`** to swap resolvers. Never `(session as unknown as {resolver}).resolver = ...`.
 - **Use `defineX(spec): XDef` factories.** They `Object.freeze` the spec and (for `definePlugin`) stamp `__moxxy: 'plugin'` and a default `version`.
+- **Add a changeset to every PR that changes a published package.** Run `pnpm changeset` (or hand-write `.changeset/<name>.md`) and pick the bump for `@moxxy/cli` / `@moxxy/sdk`. No changeset → no version bump → nothing publishes. See [Releasing](#releasing-changesets).
 
 ### Don't
 
@@ -140,6 +141,17 @@ Run `pnpm check:deps` to verify after structural changes.
 - **Don't `--no-verify` git commits or bypass dep-cruiser.** Fix the underlying issue.
 
 ---
+
+## Releasing (changesets)
+
+Versioning and publishing are driven by **changesets** — there is no manual `npm version` / `npm publish`. **Every PR that changes a published package must include a changeset**; a PR without one bumps nothing and ships nothing.
+
+- **Published packages:** only `@moxxy/cli` and `@moxxy/sdk` (everything else is `private` and bundled into the CLI binary by tsup). A changeset only ever lists those two.
+- **Add one:** `pnpm changeset` → pick the package(s) + bump (patch / minor / major) + write a one-line summary. This drops a file in `.changeset/`. Commit it with your PR.
+- **What happens on merge to `main`** (`.github/workflows/release.yml`):
+  1. Pending changesets → `changesets/action` opens/updates a **"Version Packages" PR** that bumps `package.json` versions, writes changelogs, and deletes the consumed changesets.
+  2. Merge that Version PR → the workflow re-runs with no pending changesets and **publishes** via `scripts/safe-publish.mjs`.
+- **Publish uses `pnpm publish`, not `npm publish`** — pnpm rewrites the `workspace:*` and `catalog:` protocols to real version ranges. `npm publish` ships them verbatim and the tarball becomes uninstallable (`EUNSUPPORTEDPROTOCOL "workspace:"`). Don't change `safe-publish.mjs` back to `npm publish`.
 
 ## Quick commands
 

--- a/scripts/safe-publish.mjs
+++ b/scripts/safe-publish.mjs
@@ -16,7 +16,10 @@
  *   2. Skip a package whose current version is already on npm (visible).
  *      This matches the behaviour of `changesets publish` for unchanged
  *      packages, so it's safe to run on every CI invocation.
- *   3. Run `npm publish` for everything else. When the registry rejects
+ *   3. Run `pnpm publish` for everything else (pnpm rewrites the
+ *      `workspace:*` / `catalog:` protocols to real version ranges; plain
+ *      `npm publish` ships them verbatim and the tarball becomes
+ *      uninstallable). When the registry rejects
  *      the version as tombstoned the script bumps the patch number,
  *      writes the new version to package.json, and tries again. The bump
  *      loop is capped (MAX_BUMP_ATTEMPTS) so a misconfiguration cannot
@@ -84,9 +87,19 @@ function alreadyPublished(name, version) {
 }
 
 function tryPublish(dir) {
-  const args = ['publish', '--access', 'public'];
+  // Publish with `pnpm publish`, NOT `npm publish`. pnpm rewrites the
+  // pnpm-only `workspace:*` and `catalog:` protocols in `dependencies` /
+  // `peerDependencies` to concrete version ranges in the published
+  // package.json. `npm publish` ships those protocols verbatim, producing a
+  // tarball that npm itself cannot install (EUNSUPPORTEDPROTOCOL
+  // 'Unsupported URL Type "workspace:"').
+  //
+  // --no-git-checks: this script rewrites package.json in place when walking
+  //   past tombstoned versions, which dirties the working tree. pnpm's
+  //   default pre-publish git checks would otherwise abort the publish.
+  const args = ['publish', '--access', 'public', '--no-git-checks'];
   if (process.env.GITHUB_ACTIONS === 'true') args.push('--provenance');
-  const r = spawnSync('npm', args, {
+  const r = spawnSync('pnpm', args, {
     cwd: dir,
     encoding: 'utf8',
     env: process.env,


### PR DESCRIPTION
## Problem

`npx @moxxy/cli init` fails on a clean machine with:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

The published `@moxxy/cli@0.1.2` ships pnpm-only protocols in its runtime deps:

```
dependencies = { '@moxxy/sdk': 'workspace:*', zod: 'catalog:' }
```

npm can't resolve either. Root cause: `scripts/safe-publish.mjs` published with **`npm publish`**, which ships those protocols verbatim. Only **`pnpm publish`** rewrites them to concrete version ranges. `@moxxy/sdk@0.1.2` is broken the same way (`peerDependencies.zod: 'catalog:'`), and the cli pulls it in transitively.

## Fix

- **`scripts/safe-publish.mjs`**: `npm publish` → `pnpm publish --access public --no-git-checks` (keeps `--provenance` in CI). `--no-git-checks` because the script rewrites `package.json` in place when walking past tombstoned versions, which dirties the tree.
- **changeset**: patch-bump `@moxxy/cli` + `@moxxy/sdk` → `0.1.3` so both republish with rewritten protocols.
- **AGENTS.md**: document the changeset-per-PR rule + the release flow.

## Verified

`pnpm pack` on `packages/cli` (same prepack/postpack + protocol rewrite that `pnpm publish` runs) produces a clean tarball:

```
dependencies = { zod: '^3.24.0', '@moxxy/sdk': '0.1.2' }   # protocols rewritten
```

## Release path

Merging this PR → `changesets/action` opens a **Version Packages** PR (0.1.2 → 0.1.3). Merging *that* publishes 0.1.3 via the now-fixed `pnpm publish`.

The broken `0.1.2` releases should be `npm deprecate`d separately (needs 2FA OTP).