### PR TITLE
fix(release): point cli/sdk repository.url at moxxy-ai/moxxy (unblock provenance)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,11 +24,11 @@
   ],
   "homepage": "https://moxxy.ai",
   "bugs": {
-    "url": "https://github.com/moxxy-ai/new_moxxy/issues"
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/moxxy-ai/new_moxxy.git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
     "directory": "packages/cli"
   },
   "author": "Michal Makowski <michal.makowski97@gmail.com>",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -24,11 +24,11 @@
   ],
   "homepage": "https://moxxy.ai",
   "bugs": {
-    "url": "https://github.com/moxxy-ai/new_moxxy/issues"
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/moxxy-ai/new_moxxy.git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
     "directory": "packages/sdk"
   },
   "author": "Michal Makowski <michal.makowski97@gmail.com>",


### PR DESCRIPTION
## Problem

The 0.1.3 publish failed at the registry:

```
npm error 422 Unprocessable Entity - PUT .../@moxxy%2fsdk
Error verifying sigstore provenance bundle: Failed to validate repository
information: package.json: "repository.url" is
"git+https://github.com/moxxy-ai/new_moxxy.git", expected to match
"https://github.com/moxxy-ai/moxxy" from provenance
```

The repo was renamed **new_moxxy → moxxy**, but `repository.url` (and `bugs.url`) in `@moxxy/cli` and `@moxxy/sdk` still pointed at the old name. `--provenance` makes sigstore validate `repository.url` against the repo that produced the build, so the mismatch rejected the publish.

## Fix

Point `repository.url` + `bugs.url` at `moxxy-ai/moxxy` in both published packages. These are the only two tracked files referencing the old name.

## No changeset (intentional)

cli/sdk are already bumped to **0.1.3** in the repo, but the publish failed at provenance so **0.1.3 is still free on npm** (`npm view ... 0.1.3` → 404; `latest` is still the broken 0.1.2). Merging this re-runs the release **publish** phase: `safe-publish.mjs` sees 0.1.3 isn't on npm and ships it with the corrected URL. (If 0.1.3 were somehow tombstoned, safe-publish auto-bumps past it.)

## After merge

0.1.3 publishes with correct, npm-installable deps **and** valid provenance, and becomes `latest` — fixing `npx @moxxy/cli init`. The broken 0.1.2 should still be `npm deprecate`d (needs your 2FA OTP).