### PR TITLE
fix(desktop): electron-builder metadata + inject Clerk key from secret

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -77,13 +77,24 @@ jobs:
       - name: Build workspace
         run: pnpm build
 
-      # The public dev Clerk key — safe to bake into a dev release.
-      - name: Provision .env (shell)
-        if: runner.os != 'Windows'
-        run: cp apps/desktop/.env.example apps/desktop/.env
-      - name: Provision .env (windows)
-        if: runner.os == 'Windows'
-        run: Copy-Item apps/desktop/.env.example apps/desktop/.env
+      # Bake the Clerk publishable key into the build — Vite inlines
+      # VITE_CLERK_PUBLISHABLE_KEY at build time, so it must be present now.
+      # Prefer the CLERK_PUBLISHABLE_KEY repo secret (set a pk_live_ key
+      # there for real releases); fall back to the public pk_test_ key in
+      # .env.example so forks / PR builds without the secret still build.
+      # `shell: bash` runs on all three runners (Windows included).
+      - name: Provision .env
+        shell: bash
+        env:
+          CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY }}
+        run: |
+          if [ -n "$CLERK_PUBLISHABLE_KEY" ]; then
+            echo "VITE_CLERK_PUBLISHABLE_KEY=$CLERK_PUBLISHABLE_KEY" > apps/desktop/.env
+            echo "Using CLERK_PUBLISHABLE_KEY secret."
+          else
+            echo "CLERK_PUBLISHABLE_KEY not set; falling back to the public test key in .env.example."
+            cp apps/desktop/.env.example apps/desktop/.env
+          fi
 
       # electron-builder reads the per-OS targets from apps/desktop's
       # package.json#build and emits to apps/desktop/release/.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -3,6 +3,14 @@
   "private": true,
   "version": "0.0.2",
   "description": "moxxy desktop — Electron app that connects to moxxy via @moxxy/runner and renders a TUI-equivalent chat surface.",
+  "homepage": "https://moxxy.ai",
+  "author": "Michal Makowski <michal.makowski97@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
+    "directory": "apps/desktop"
+  },
   "type": "module",
   "main": "dist-electron/main/index.js",
   "scripts": {
@@ -55,6 +63,13 @@
     "directories": {
       "output": "release"
     },
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "moxxy-ai",
+        "repo": "moxxy"
+      }
+    ],
     "files": [
       "dist-electron/**",
       "dist/**"


### PR DESCRIPTION
## Problems (desktop release build)

Two failures from `electron-builder`:

1. **Linux `.deb` (FpmTarget):**
   ```
   ⨯ Please specify project homepage, see .../#Metadata-homepage
     at FpmTarget.computeFpmMetaInfoOptions
   ```
   No top-level `homepage` in `apps/desktop/package.json`.

2. **macOS DMG:** DMG builds, then crashes generating auto-update metadata:
   ```
   • author is missed in the package.json
   • Cannot detect repository by .git/config. Please specify "repository" ...
   ⨯ Cannot read properties of null (reading 'provider')
     at createUpdateInfoTasks (updateInfoBuilder.ts:133)
   ```
   With no `repository` and no `publish` config, electron-builder can't resolve a publish provider and dereferences null.

## Fixes

**`apps/desktop/package.json`**
- Add `homepage`, `author`, `license` (clears the FpmTarget error + the author warning).
- Add `repository` and an explicit `build.publish` → `{ provider: github, owner: moxxy-ai, repo: moxxy }` so electron-builder stops probing `.git/config` and `createUpdateInfoTasks` has a provider. `--publish never` is unchanged, so nothing is uploaded — the provider only lets the metadata generate.

**`.github/workflows/release-desktop.yml`** (the Clerk key change)
- Replace the two OS-specific `cp .env.example .env` steps with one `shell: bash` step that writes `VITE_CLERK_PUBLISHABLE_KEY` from the **`CLERK_PUBLISHABLE_KEY`** repo secret, falling back to the public `pk_test_` key in `.env.example` when the secret is unset (forks / PR builds still build).
- The live key stays out of git, so the `guard` job stays green. Note: a publishable key ships in the client bundle regardless — the secret is about env separation, not confidentiality.

## To ship a production Clerk instance

Add repo secret **`CLERK_PUBLISHABLE_KEY`** = your `pk_live_...`. No secret → the public test key is used.

## No changeset

`@moxxy/desktop` is `private` and ships installers via the `desktop-v*` tag workflow, not npm.