### PR TITLE
fix(desktop): clean deb naming + ad-hoc sign macOS app (DMG not 'damaged')

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -136,6 +136,19 @@ jobs:
           body: |
             MoxxyAI Workspaces desktop build.
 
-            **Unsigned** — macOS Gatekeeper and Windows SmartScreen will warn on
-            first launch (right-click → Open on macOS; "More info → Run anyway"
-            on Windows). Signed builds will follow once signing secrets are set.
+            **Unsigned (ad-hoc signed only)** — these builds are not notarized,
+            so Gatekeeper / SmartScreen will warn on first launch.
+
+            **macOS:** right-click the app → **Open**, then confirm. If macOS
+            still says the app "is damaged" or "can't be opened", clear the
+            download quarantine and launch:
+
+            ```sh
+            xattr -dr com.apple.quarantine "/Applications/MoxxyAI Workspaces.app"
+            ```
+
+            **Windows:** "More info → Run anyway" on the SmartScreen prompt.
+
+            A clean, prompt-free install needs a Developer ID certificate +
+            notarization (set the signing secrets and drop
+            `CSC_IDENTITY_AUTO_DISCOVERY=false`).

--- a/apps/desktop/build/after-pack.cjs
+++ b/apps/desktop/build/after-pack.cjs
@@ -1,0 +1,34 @@
+// Ad-hoc code-sign the macOS .app before it's wrapped into the DMG.
+//
+// Builds here are unsigned (no Developer ID — see CSC_IDENTITY_AUTO_DISCOVERY
+// in release-desktop.yml). On Apple Silicon a quarantined app with NO
+// signature at all is reported as "is damaged and can't be opened" — a state
+// the user cannot clear from the UI. An ad-hoc signature (`codesign -s -`)
+// downgrades that to the normal "unverified developer" prompt, which users
+// CAN bypass (right-click → Open, or System Settings → Privacy & Security →
+// Open Anyway).
+//
+// This is not a substitute for real signing: a clean install with no prompt
+// requires a Developer ID certificate + notarization (provide CSC_LINK /
+// CSC_KEY_PASSWORD / APPLE_ID* secrets and drop CSC_IDENTITY_AUTO_DISCOVERY).
+//
+// electron-builder runs afterPack after the app is packed but before the DMG
+// target is built, so the DMG ends up containing the signed app.
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+exports.default = async function afterPack(context) {
+  if (context.electronPlatformName !== 'darwin') return;
+
+  const appBundle = fs.readdirSync(context.appOutDir).find((e) => e.endsWith('.app'));
+  if (!appBundle) {
+    console.warn(`afterPack: no .app found in ${context.appOutDir}; skipping ad-hoc signing`);
+    return;
+  }
+
+  const appPath = path.join(context.appOutDir, appBundle);
+  console.log(`afterPack: ad-hoc signing ${appPath}`);
+  // --deep so the nested Electron frameworks / helpers are signed too.
+  execFileSync('codesign', ['--force', '--deep', '--sign', '-', appPath], { stdio: 'inherit' });
+};

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -60,6 +60,7 @@
   "build": {
     "appId": "ai.moxxy.desktop",
     "productName": "MoxxyAI Workspaces",
+    "executableName": "moxxy-desktop",
     "directories": {
       "output": "release"
     },
@@ -86,7 +87,9 @@
       ],
       "category": "Utility",
       "maintainer": "MoxxyAI <noreply@moxxy.ai>",
-      "icon": "public/logo.png"
+      "icon": "public/logo.png",
+      "packageName": "moxxy-desktop",
+      "artifactName": "moxxy-desktop-${version}-${arch}.${ext}"
     },
     "win": {
       "target": "nsis",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -61,6 +61,7 @@
     "appId": "ai.moxxy.desktop",
     "productName": "MoxxyAI Workspaces",
     "executableName": "moxxy-desktop",
+    "afterPack": "build/after-pack.cjs",
     "directories": {
       "output": "release"
     },


### PR DESCRIPTION
Two more desktop-release build failures, both downstream of the earlier metadata fix.

## 1. Linux `.deb` — fatal

```
Parent directory does not exist: .../release/@moxxy - cannot write to
.../release/@moxxy/desktop_0.0.2_amd64.deb
```

electron-builder's default deb `artifactName` is `${name}_${version}_${arch}`, and `${name}` is the **scoped** package name `@moxxy/desktop` — the `/` makes fpm write into a nonexistent `release/@moxxy/` dir. The deb's `--name` also fell back to `productName` (`MoxxyAI Workspaces` → caps + space, an invalid Debian name; fpm only downcased it with a warning).

Fix (in `package.json#build`):
- `executableName: moxxy-desktop` — clean binary / icon / `.desktop` names.
- `linux.artifactName: moxxy-desktop-${version}-${arch}.${ext}` — no `/`.
- `linux.packageName: moxxy-desktop` — valid lowercase Debian package name.

## 2. macOS `.dmg` — "file is corrupted / damaged"

Builds are unsigned, and with `CSC_IDENTITY_AUTO_DISCOVERY=false` electron-builder 25.x skips signing **entirely** (no ad-hoc fallback — verified in `macPackager.sign`). A quarantined arm64 app with no signature reports *"is damaged and can't be opened"*, which can't be cleared from the UI.

Fix:
- `build/after-pack.cjs`: ad-hoc `codesign -s -` the `.app` before the DMG is assembled, downgrading "damaged" → the bypassable "unverified developer" prompt.
- Release notes: right-click → Open + `xattr -dr com.apple.quarantine` fallback; note that a prompt-free install needs Developer ID + notarization (secrets).

## Test

Re-tag (`desktop-v*`) or re-run the workflow. Cannot fully exercise electron-builder here (downloads Electron + fpm), but JSON/config validated and the afterPack hook syntax-checks.