### PR TITLE
fix(cli): drop install deprecation warnings (keytar→@napi-rs/keyring, lazy ML/browser)

### DIFF
--- a/.changeset/swap-keytar-lean-install.md
+++ b/.changeset/swap-keytar-lean-install.md
@@ -1,0 +1,12 @@
+---
+"@moxxy/cli": patch
+---
+
+Remove the two `npm install` deprecation warnings (`prebuild-install`, `boolean`) and slim the default install.
+
+`@moxxy/cli` no longer installs heavy native optional dependencies by default:
+
+- **keytar → `@napi-rs/keyring`**: keytar pulls the deprecated `prebuild-install`; `@napi-rs/keyring` ships per-platform NAPI prebuilds with no install scripts. OS-keychain unlock for the vault is preserved (it still falls back to the disk key / passphrase when the native binary is unavailable).
+- **`@huggingface/transformers` and `playwright` are now install-on-demand** (dropped from `optionalDependencies`). Both were already loaded via guarded dynamic `import()`; the local-embeddings and browser features degrade gracefully and prompt to install when first used. This is what pulled `boolean` (via `onnxruntime-node` → `global-agent`).
+
+Net effect: `npx @moxxy/cli` installs only `@moxxy/sdk`, `zod`, and `@napi-rs/keyring` — no deprecation warnings, smaller and faster.

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -21,12 +21,14 @@ const BUNDLED_WORKSPACE_DEPS = [
 
 /**
  * Native / optional modules that must stay external even though they ride
- * in on a bundled workspace dep. `keytar` is loaded via a guarded dynamic
- * `import('keytar')` (plugin-vault falls back to a disk/passphrase key
- * when it is absent), so it is never statically required — keep it out of
- * the bundle and let it resolve (or gracefully fail) at runtime.
+ * in on a bundled workspace dep. `@napi-rs/keyring` is loaded via a guarded
+ * dynamic `import('@napi-rs/keyring')` (plugin-vault falls back to a
+ * disk/passphrase key when it is absent), so it is never statically
+ * required — keep it out of the bundle (its NAPI-RS loader reassigns
+ * `commonjsRequire`, which Rollup can't inline) and let it resolve (or
+ * gracefully fail) at runtime.
  */
-const EXTERNAL_NATIVE = ['keytar'];
+const EXTERNAL_NATIVE = ['@napi-rs/keyring'];
 
 /**
  * electron-vite manages three build targets (main / preload / renderer)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -62,9 +62,7 @@
     "zod": "catalog:"
   },
   "optionalDependencies": {
-    "@huggingface/transformers": "^3.0.0",
-    "keytar": "^7.9.0",
-    "playwright": "^1.40.0"
+    "@napi-rs/keyring": "^1.3.0"
   },
   "devDependencies": {
     "@clack/prompts": "catalog:",

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -18,11 +18,14 @@ const here = path.dirname(fileURLToPath(import.meta.url));
  *                     discovered third-party plugins share it with the builtins
  *   - zod             sdk's peer dep; must be the SAME instance the builtins and
  *                     third-party plugins use, or cross-boundary schemas diverge
- *   - keytar          native module, cannot be bundled (vault degrades to disk key)
- *   - playwright      huge; optional (browser plugin throws a clear hint if absent)
- *   - @huggingface/transformers  huge; optional (embedder falls back to TF-IDF)
- * keytar/playwright/transformers are loaded via dynamic import() with graceful
- * fallback already; @moxxy/sdk + zod ship as real runtime dependencies.
+ *   - @napi-rs/keyring  native module, cannot be bundled (vault degrades to disk key);
+ *                       shipped as an optionalDependency
+ *   - playwright      huge; install-on-demand (browser plugin throws a clear hint if absent)
+ *   - @huggingface/transformers  huge; install-on-demand (embedder falls back to TF-IDF)
+ * All three are loaded via dynamic import() with graceful fallback already, so
+ * playwright/transformers stay external (bundled plugins import them lazily)
+ * even though they are no longer installed by default; @moxxy/sdk + zod ship as
+ * real runtime dependencies.
  */
 export default defineConfig({
   entry: {
@@ -50,7 +53,7 @@ export default defineConfig({
   clean: true,
   dts: false, // a binary ships no types; `tsc --noEmit` still typechecks
   shims: false, // code uses import.meta.url directly; no __dirname shims
-  external: ['@moxxy/sdk', 'zod', 'keytar', 'playwright', '@huggingface/transformers'],
+  external: ['@moxxy/sdk', 'zod', '@napi-rs/keyring', 'playwright', '@huggingface/transformers'],
   // Several bundled CJS deps (ulid, jiti, …) call require() for node builtins.
   // ESM output has no `require`, so esbuild's __require stub throws. Inject a
   // real createRequire-backed `require` so those calls resolve. esbuild keeps

--- a/packages/plugin-vault/package.json
+++ b/packages/plugin-vault/package.json
@@ -2,7 +2,7 @@
   "name": "@moxxy/plugin-vault",
   "private": true,
   "version": "0.0.2",
-  "description": "Encrypted secret storage for moxxy. AES-256-GCM at rest. Master key from OS keychain (keytar) or passphrase fallback.",
+  "description": "Encrypted secret storage for moxxy. AES-256-GCM at rest. Master key from OS keychain (@napi-rs/keyring) or passphrase fallback.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -33,7 +33,7 @@
     "zod": "catalog:"
   },
   "optionalDependencies": {
-    "keytar": "^7.9.0"
+    "@napi-rs/keyring": "^1.3.0"
   },
   "devDependencies": {
     "@moxxy/tsconfig": "workspace:*",

--- a/packages/plugin-vault/src/keysource.test.ts
+++ b/packages/plugin-vault/src/keysource.test.ts
@@ -6,14 +6,15 @@ import { createCombinedKeySource, createStaticKeySource } from './keysource.js';
 import { generateSalt } from './crypto.js';
 
 // ---------------------------------------------------------------------------
-// Fake keytar.
+// Fake @napi-rs/keyring.
 //
-// keysource.ts reaches the OS keychain via a *dynamic* `import('keytar')`.
-// We replace that module with an in-memory store so the tests never touch the
-// real macOS/Linux/Windows keychain. The mock factory must not close over
-// outer mutable bindings directly (vi.mock is hoisted above them), so we keep
-// the backing store on a stable object created inside the factory and expose
-// it through the mocked module's own helpers.
+// keysource.ts reaches the OS keychain via a *dynamic* `import('@napi-rs/keyring')`
+// and its synchronous `Entry` class. We replace that module with an in-memory
+// store so the tests never touch the real macOS/Linux/Windows keychain. Like
+// the real library, `getPassword()` THROWS when no entry exists (rather than
+// returning null). The mock factory must not close over outer mutable bindings
+// directly (vi.mock is hoisted above them), so the backing store lives on a
+// stable object the class methods read at call time.
 // ---------------------------------------------------------------------------
 const keytarState: { store: Map<string, string>; failGet: boolean; failSet: boolean } = {
   store: new Map(),
@@ -21,15 +22,23 @@ const keytarState: { store: Map<string, string>; failGet: boolean; failSet: bool
   failSet: false,
 };
 
-vi.mock('keytar', () => ({
-  getPassword: vi.fn(async (svc: string, acct: string) => {
-    if (keytarState.failGet) throw new Error('keychain locked');
-    return keytarState.store.get(`${svc}:${acct}`) ?? null;
-  }),
-  setPassword: vi.fn(async (svc: string, acct: string, password: string) => {
-    if (keytarState.failSet) throw new Error('keychain refused');
-    keytarState.store.set(`${svc}:${acct}`, password);
-  }),
+vi.mock('@napi-rs/keyring', () => ({
+  Entry: class {
+    private readonly mapKey: string;
+    constructor(service: string, account: string) {
+      this.mapKey = `${service}:${account}`;
+    }
+    getPassword(): string {
+      if (keytarState.failGet) throw new Error('keychain locked');
+      const v = keytarState.store.get(this.mapKey);
+      if (v == null) throw new Error('No matching entry found in secure storage');
+      return v;
+    }
+    setPassword(password: string): void {
+      if (keytarState.failSet) throw new Error('keychain refused');
+      keytarState.store.set(this.mapKey, password);
+    }
+  },
 }));
 
 const KEYTAR_KEY = 'moxxy:vault-master-key';
@@ -134,7 +143,7 @@ describe('createCombinedKeySource', () => {
     const key = await src.obtain(generateSalt());
 
     expect(key.toString('base64')).toBe(keytarVal);
-    expect(src.name).toBe('keytar');
+    expect(src.name).toBe('keychain');
 
     // Disk is backfilled with the keytar value (overwriting the stale disk val).
     const onDisk = await waitForFile(diskKeyPath, keytarVal);

--- a/packages/plugin-vault/src/keysource.ts
+++ b/packages/plugin-vault/src/keysource.ts
@@ -2,8 +2,8 @@ import { promises as fs } from 'node:fs';
 import { writeFileAtomic, moxxyPath } from '@moxxy/sdk';
 import { deriveKey } from './crypto.js';
 
-const KEYTAR_SERVICE = 'moxxy';
-const KEYTAR_ACCOUNT = 'vault-master-key';
+const KEYCHAIN_SERVICE = 'moxxy';
+const KEYCHAIN_ACCOUNT = 'vault-master-key';
 
 export interface MasterKeySource {
   /** Returns the raw 32-byte AES key. May open a keychain or prompt the user. */
@@ -16,13 +16,18 @@ export interface MasterKeySource {
 export interface CombinedKeySourceOptions {
   readonly passphrasePrompt: () => Promise<string>;
   readonly envVar?: string;
+  /**
+   * Skip the OS keychain (`@napi-rs/keyring`) entirely, using only the disk
+   * cache + passphrase. Named `disableKeytar` for backwards compatibility —
+   * the underlying keychain library is now `@napi-rs/keyring`, not keytar.
+   */
   readonly disableKeytar?: boolean;
   /**
-   * Disk fallback for the master key, used when keytar isn't installed
-   * or refuses to bind to a keychain (common on headless Linux). Stored
-   * as base64 at this path with mode 0o600 — less secure than the OS
-   * keychain, but means the user types their passphrase ONCE instead of
-   * every run. Set to false to disable.
+   * Disk fallback for the master key, used when the OS keychain isn't
+   * available (no native binary, or it refuses to bind — common on headless
+   * Linux). Stored as base64 at this path with mode 0o600 — less secure than
+   * the OS keychain, but means the user types their passphrase ONCE instead
+   * of every run. Set to false to disable.
    *
    * Default: `~/.moxxy/vault.key`.
    */
@@ -32,21 +37,21 @@ export interface CombinedKeySourceOptions {
 /**
  * Resolves the vault master key in priority order:
  *   1. `MOXXY_VAULT_PASSPHRASE` env var (derive on each call — no persistence).
- *   2. OS keychain via keytar.
+ *   2. OS keychain via `@napi-rs/keyring`.
  *   3. On-disk cached key at `~/.moxxy/vault.key` (mode 0600).
  *   4. Interactive passphrase prompt.
  *
- * The first successful prompt persists the derived key to BOTH keytar (if
- * available) and the disk cache so subsequent runs are silent. The chosen
+ * The first successful prompt persists the derived key to BOTH the OS keychain
+ * (if available) and the disk cache so subsequent runs are silent. The chosen
  * source's name is exposed via `.name` so `moxxy doctor` can surface it
- * ("vault unlocked via keytar" / "via ~/.moxxy/vault.key").
+ * ("vault unlocked via keychain" / "via ~/.moxxy/vault.key").
  */
 export function createCombinedKeySource(opts: CombinedKeySourceOptions): MasterKeySource {
   let resolvedName = 'unknown';
   const diskPath = resolveDiskPath(opts.diskKeyPath);
 
   const persistKey = async (keyB64: string): Promise<void> => {
-    if (!opts.disableKeytar) await tryKeytarSet(keyB64);
+    if (!opts.disableKeytar) await tryKeychainSet(keyB64);
     if (diskPath) await tryDiskSet(diskPath, keyB64);
   };
 
@@ -63,10 +68,10 @@ export function createCombinedKeySource(opts: CombinedKeySourceOptions): MasterK
       }
 
       if (!opts.disableKeytar) {
-        const fromKeychain = await tryKeytarGet();
+        const fromKeychain = await tryKeychainGet();
         if (fromKeychain) {
-          resolvedName = 'keytar';
-          // Backfill the disk cache so a future keytar outage doesn't
+          resolvedName = 'keychain';
+          // Backfill the disk cache so a future keychain outage doesn't
           // suddenly force a passphrase prompt.
           if (diskPath) void tryDiskSet(diskPath, fromKeychain);
           return Buffer.from(fromKeychain, 'base64');
@@ -77,8 +82,8 @@ export function createCombinedKeySource(opts: CombinedKeySourceOptions): MasterK
         const fromDisk = await tryDiskGet(diskPath);
         if (fromDisk) {
           resolvedName = `file:${diskPath}`;
-          // Backfill keytar if it became available since the file was written.
-          if (!opts.disableKeytar) void tryKeytarSet(fromDisk);
+          // Backfill the keychain if it became available since the file was written.
+          if (!opts.disableKeytar) void tryKeychainSet(fromDisk);
           return Buffer.from(fromDisk, 'base64');
         }
       }
@@ -119,29 +124,38 @@ async function tryDiskSet(filePath: string, value: string): Promise<void> {
   }
 }
 
-async function tryKeytarGet(): Promise<string | null> {
+/**
+ * Minimal shape of the `@napi-rs/keyring` `Entry` we rely on. The library is
+ * a dynamic, optional import: it ships prebuilt native binaries per platform,
+ * but if it isn't installed (or its binary is missing) we fall back to the
+ * disk cache / passphrase rather than failing. Unlike keytar, `getPassword()`
+ * is synchronous and THROWS when no entry exists — both are handled by the
+ * surrounding try/catch.
+ */
+interface KeyringEntry {
+  getPassword(): string;
+  setPassword(password: string): void;
+}
+type KeyringModule = {
+  Entry?: new (service: string, account: string) => KeyringEntry;
+};
+
+async function tryKeychainGet(): Promise<string | null> {
   try {
-    const mod = (await import('keytar')) as {
-      getPassword?: (svc: string, acct: string) => Promise<string | null>;
-      default?: { getPassword: (svc: string, acct: string) => Promise<string | null> };
-    };
-    const fn = mod.getPassword ?? mod.default?.getPassword;
-    if (!fn) return null;
-    return await fn(KEYTAR_SERVICE, KEYTAR_ACCOUNT);
+    const mod = (await import('@napi-rs/keyring')) as KeyringModule;
+    if (!mod.Entry) return null;
+    return new mod.Entry(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT).getPassword() || null;
   } catch {
+    // Not installed, no stored entry, or keychain locked — fall back.
     return null;
   }
 }
 
-async function tryKeytarSet(value: string): Promise<void> {
+async function tryKeychainSet(value: string): Promise<void> {
   try {
-    const mod = (await import('keytar')) as {
-      setPassword?: (svc: string, acct: string, password: string) => Promise<void>;
-      default?: { setPassword: (svc: string, acct: string, password: string) => Promise<void> };
-    };
-    const fn = mod.setPassword ?? mod.default?.setPassword;
-    if (!fn) return;
-    await fn(KEYTAR_SERVICE, KEYTAR_ACCOUNT, value);
+    const mod = (await import('@napi-rs/keyring')) as KeyringModule;
+    if (!mod.Entry) return;
+    new mod.Entry(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT).setPassword(value);
   } catch {
     // Best-effort; keychain failures must not break the vault.
   }

--- a/packages/plugin-vault/src/store.ts
+++ b/packages/plugin-vault/src/store.ts
@@ -34,7 +34,7 @@ export class VaultPassphraseError extends Error {
       `Wrong vault passphrase for ${filePath}.\n` +
         `  If you've forgotten it, wipe the vault and key cache, then re-run \`moxxy init\`:\n` +
         `    rm ${filePath} ~/.moxxy/vault.key\n` +
-        `  (If keytar is installed, also clear the entry: \`security delete-generic-password -s moxxy\` on macOS.)\n` +
+        `  (If the OS keychain holds a cached key, also clear it: \`security delete-generic-password -s moxxy\` on macOS.)\n` +
         `  Or set MOXXY_VAULT_PASSPHRASE to a known value to skip the prompt entirely.`,
     );
     this.name = 'VaultPassphraseError';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,15 +456,9 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)
     optionalDependencies:
-      '@huggingface/transformers':
-        specifier: ^3.0.0
-        version: 3.8.1
-      keytar:
-        specifier: ^7.9.0
-        version: 7.9.0
-      playwright:
-        specifier: ^1.40.0
-        version: 1.60.0
+      '@napi-rs/keyring':
+        specifier: ^1.3.0
+        version: 1.3.0
 
   packages/compactor-summarize:
     dependencies:
@@ -1624,9 +1618,9 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)
     optionalDependencies:
-      keytar:
-        specifier: ^7.9.0
-        version: 7.9.0
+      '@napi-rs/keyring':
+        specifier: ^1.3.0
+        version: 1.3.0
 
   packages/plugin-view:
     dependencies:
@@ -3032,6 +3026,87 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    resolution: {integrity: sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    resolution: {integrity: sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    resolution: {integrity: sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    resolution: {integrity: sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    resolution: {integrity: sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    resolution: {integrity: sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    resolution: {integrity: sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    resolution: {integrity: sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    resolution: {integrity: sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    resolution: {integrity: sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    resolution: {integrity: sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.3.0':
+    resolution: {integrity: sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==}
+    engines: {node: '>= 10'}
+
   '@npmcli/fs@2.1.2':
     resolution: {integrity: sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -3991,9 +4066,6 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
-
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
@@ -4256,10 +4328,6 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
-
-  deep-extend@0.6.0:
-    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
-    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -4629,10 +4697,6 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
-    engines: {node: '>=6'}
-
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -4830,9 +4894,6 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
-
-  github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -5096,9 +5157,6 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
-
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -5333,9 +5391,6 @@ packages:
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
-
-  keytar@7.9.0:
-    resolution: {integrity: sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -5749,9 +5804,6 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
-  mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -5778,9 +5830,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
-
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -5805,9 +5854,6 @@ packages:
 
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
-
-  node-addon-api@4.3.0:
-    resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
 
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
@@ -6111,12 +6157,6 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
-    engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
-
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -6193,10 +6233,6 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
-
-  rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
-    hasBin: true
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -6530,12 +6566,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
-
-  simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
   simple-swizzle@0.2.4:
     resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
@@ -6662,10 +6692,6 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
-  strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
-
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -6709,9 +6735,6 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
-
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
@@ -6867,9 +6890,6 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
-
-  tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   turbo@2.9.12:
     resolution: {integrity: sha512-lCPgus1NuTiBdaITWqzSH/Ff6HVL8HHGBtOXHg1dHRfcshN79XkygSdh0M6g8b0td91ILLG5MTkLOkp5UvyPJw==}
@@ -8554,6 +8574,58 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring@1.3.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.3.0
+      '@napi-rs/keyring-darwin-x64': 1.3.0
+      '@napi-rs/keyring-freebsd-x64': 1.3.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.3.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.3.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-musl': 1.3.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.3.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.3.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.3.0
+    optional: true
+
   '@npmcli/fs@2.1.2':
     dependencies:
       '@gar/promisify': 1.1.3
@@ -9720,9 +9792,6 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
-  chownr@1.1.4:
-    optional: true
-
   chownr@2.0.0: {}
 
   chownr@3.0.0: {}
@@ -9941,9 +10010,6 @@ snapshots:
       mimic-response: 3.1.0
 
   deep-eql@5.0.2: {}
-
-  deep-extend@0.6.0:
-    optional: true
 
   deep-is@0.1.4: {}
 
@@ -10456,9 +10522,6 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.8
 
-  expand-template@2.0.3:
-    optional: true
-
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
@@ -10705,9 +10768,6 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  github-from-package@0.0.0:
-    optional: true
 
   github-slugger@2.0.0: {}
 
@@ -11132,9 +11192,6 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@1.3.8:
-    optional: true
-
   ini@4.1.1: {}
 
   ink@5.2.1(@types/react@18.3.28)(react@18.3.1):
@@ -11358,12 +11415,6 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-
-  keytar@7.9.0:
-    dependencies:
-      node-addon-api: 4.3.0
-      prebuild-install: 7.1.3
-    optional: true
 
   keyv@4.5.4:
     dependencies:
@@ -12045,9 +12096,6 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  mkdirp-classic@0.5.3:
-    optional: true
-
   mkdirp@1.0.4: {}
 
   mlly@1.8.2:
@@ -12071,9 +12119,6 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  napi-build-utils@2.0.0:
-    optional: true
-
   natural-compare@1.4.0: {}
 
   negotiator@0.6.4: {}
@@ -12091,9 +12136,6 @@ snapshots:
       semver: 7.8.0
 
   node-addon-api@1.7.2:
-    optional: true
-
-  node-addon-api@4.3.0:
     optional: true
 
   node-api-version@0.2.1:
@@ -12403,22 +12445,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prebuild-install@7.1.3:
-    dependencies:
-      detect-libc: 2.1.2
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.92.0
-      pump: 3.0.4
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.4
-      tunnel-agent: 0.6.0
-    optional: true
-
   prelude-ls@1.2.1: {}
 
   prettier@3.8.3: {}
@@ -12492,14 +12518,6 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
-
-  rc@1.2.8:
-    dependencies:
-      deep-extend: 0.6.0
-      ini: 1.3.8
-      minimist: 1.2.8
-      strip-json-comments: 2.0.1
-    optional: true
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -13040,16 +13058,6 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1:
-    optional: true
-
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
-    optional: true
-
   simple-swizzle@0.2.4:
     dependencies:
       is-arrayish: 0.3.4
@@ -13179,9 +13187,6 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
-  strip-json-comments@2.0.1:
-    optional: true
-
   strip-json-comments@3.1.1: {}
 
   style-to-js@1.1.21:
@@ -13233,14 +13238,6 @@ snapshots:
   symbol-tree@3.2.4: {}
 
   tapable@2.3.3: {}
-
-  tar-fs@2.1.4:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.4
-      tar-stream: 2.2.0
-    optional: true
 
   tar-stream@2.2.0:
     dependencies:
@@ -13400,11 +13397,6 @@ snapshots:
       get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
-
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
-    optional: true
 
   turbo@2.9.12:
     optionalDependencies:


### PR DESCRIPTION
## Problem

`npx @moxxy/cli init` printed two npm deprecation warnings:

```
npm warn deprecated prebuild-install@7.1.3: No longer maintained...
npm warn deprecated boolean@3.2.0: Package no longer supported...
```

Both come from heavy **native optional dependencies** that npm installs by default:
- `prebuild-install` ← `keytar`
- `boolean` ← `@huggingface/transformers` → `onnxruntime-node` → `global-agent`

## Fix (the "swap + lazy" option)

- **keytar → `@napi-rs/keyring`** for the vault's OS-keychain. It ships per-platform NAPI prebuilds (no install scripts, no `prebuild-install`). Its `Entry.getPassword()` is synchronous and *throws* when absent — `keysource.ts` adapts via try/catch. **OS-keychain unlock is preserved**, with the same disk-key / passphrase fallback.
- **Drop `@huggingface/transformers` + `playwright` from `optionalDependencies`** → install-on-demand. Both were already guarded dynamic `import()`s; tsup keeps them `external` so the bundled plugins still lazy-load them, and the features degrade with a clear hint until installed.
- **Desktop:** externalize `@napi-rs/keyring` in `electron.vite.config.ts` (its NAPI loader reassigns `commonjsRequire`, which Rollup can't inline) — mirrors how keytar was handled.

## Result

`npx @moxxy/cli` now installs only `@moxxy/sdk` + `zod` + `@napi-rs/keyring` (which pulls only platform prebuilt binaries — verified: no `prebuild-install`, no `boolean`). No deprecation warnings; smaller, faster install.

## Verification

Build 53/53 · typecheck 101/101 · tests 100/100 · lint 0 errors · dep-cruiser clean. Vault's 11 keysource tests updated to mock `@napi-rs/keyring`'s sync `Entry` and pass.

Changeset: patch-bump `@moxxy/cli` (its published `optionalDependencies` changed).