### PR TITLE
feat(cli): vault passphrase as a styled init step under the logo

### DIFF
--- a/.changeset/vault-passphrase-init-step.md
+++ b/.changeset/vault-passphrase-init-step.md
@@ -1,0 +1,7 @@
+---
+"@moxxy/cli": patch
+---
+
+`moxxy init`: collect the vault passphrase as a styled first step instead of a bare prompt.
+
+On a first run the vault needs a passphrase to derive its encryption key. Previously this fired as an unstyled `readline` prompt *before* the wizard (and before the logo). It's now a `@clack/prompts` `password` step — rendered under the moxxy logo, with a short description — so it reads as the first pre-requirement step of setup, consistent with the rest of the wizard. Threaded via a new `SetupOptions.passphrasePrompt`; headless `init` is unaffected (still uses `MOXXY_VAULT_PASSPHRASE` / the non-TTY guard).

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -8,6 +8,8 @@ import { cliVersion } from '../version.js';
 import { runSetupWizard } from '../wizard/run-setup-wizard.js';
 import { buildProviderAuthContext } from '../wizard/auth-context.js';
 import { renderLogo } from '../logo.js';
+import { cancel, isCancel, note, password } from '@clack/prompts';
+import { colors } from '../colors.js';
 import type { ProviderAuthKind } from '@moxxy/plugin-cli';
 import { MoxxyError, type ProviderDef } from '@moxxy/sdk';
 
@@ -23,31 +25,35 @@ import { MoxxyError, type ProviderDef } from '@moxxy/sdk';
  * enough to make it appear here; no CLI-side branch table.
  */
 export async function runInitCommand(argv: ParsedArgv): Promise<number> {
+  const interactive = Boolean(process.stdin.isTTY);
+
   // `skipProviderActivation` is critical here: without it, the activation
   // loop calls `vault.get()` for every candidate provider, which opens the
-  // vault, which on a first-time-no-keytar install triggers an invisible
-  // readline passphrase prompt that hangs the wizard. The init flow is
-  // *itself* what populates the vault — running activation pre-mount is
-  // both pointless and a UX trap.
+  // vault and would fire the passphrase prompt before the wizard even
+  // starts. The init flow is *itself* what populates the vault — running
+  // activation pre-mount is both pointless and a UX trap.
+  //
+  // `passphrasePrompt` (TTY only) swaps the vault's bare readline prompt for
+  // a @clack/prompts step, so the first-run passphrase reads as part of the
+  // setup wizard rather than an unstyled prompt before it.
   const { session, vault } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
     skipProviderActivation: true,
+    ...(interactive ? { passphrasePrompt: promptVaultPassphrase } : {}),
   });
 
-  if (!process.stdin.isTTY) {
+  if (!interactive) {
     return await runHeadlessInit(session, vault);
   }
 
-  // Pre-warm the vault BEFORE starting the wizard. A first-time install
-  // (no keytar entry yet) needs to prompt for a passphrase via readline;
-  // doing that mid-clack would garble the rendering. Opening here while
-  // the terminal is in cooked mode keeps the prompt clean.
-  await vault.open();
-
-  // Banner above the wizard intro. The clack `intro()` line will land
-  // immediately under this with a `┌` corner, giving the impression that
-  // the whole flow flows out of the moxxy logo.
+  // Logo first, so the whole flow reads as one screen: the (first-run only)
+  // vault passphrase step and the wizard's `intro()` both render beneath it.
   process.stdout.write(renderLogo());
+
+  // Open the vault as the first pre-requirement step. On a first run (no env
+  // var, OS keychain, or disk key) this invokes `promptVaultPassphrase`;
+  // otherwise it unlocks silently and the wizard starts immediately.
+  await vault.open();
 
   const providerDefs = session.providers.list();
   const defsByName = new Map(providerDefs.map((d) => [d.name, d] as const));
@@ -158,6 +164,34 @@ async function runHeadlessInit(
   }
   process.stderr.write(`moxxy init: saved ${saved} key(s) to vault.\n`);
   return 0;
+}
+
+/**
+ * First-run vault passphrase, styled to match the setup wizard. The vault
+ * encrypts API keys at rest; on first run a passphrase derives the master key
+ * (then cached in the OS keychain / `~/.moxxy/vault.key` so later runs are
+ * silent). TTY-only — headless init relies on `MOXXY_VAULT_PASSPHRASE` and the
+ * vault's own non-TTY guard, so this is never wired up there.
+ */
+async function promptVaultPassphrase(): Promise<string> {
+  note(
+    [
+      'moxxy keeps your API keys in a local encrypted vault.',
+      "Choose a passphrase to protect it — it's cached in your OS keychain",
+      `(or ${colors.dim('~/.moxxy/vault.key')}) so you won't be asked again.`,
+      `Tip: set ${colors.bold('MOXXY_VAULT_PASSPHRASE')} to skip this prompt.`,
+    ].join('\n'),
+    'Step 0 — Vault passphrase',
+  );
+  const value = await password({
+    message: 'Set a vault passphrase',
+    validate: (v) => (v && v.trim().length > 0 ? undefined : 'Enter a passphrase (esc to cancel).'),
+  });
+  if (isCancel(value)) {
+    cancel('Setup cancelled. Run `moxxy init` again when you are ready.');
+    process.exit(1);
+  }
+  return (value as string).trim();
 }
 
 function providerAuthKind(def: ProviderDef): ProviderAuthKind {

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -49,7 +49,10 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
   });
   progress({ kind: 'config-loaded', sources: sources.length });
 
-  const { plugin: vaultPlugin, vault } = buildVaultPlugin({ disableKeytar: opts.disableKeytar });
+  const { plugin: vaultPlugin, vault } = buildVaultPlugin({
+    disableKeytar: opts.disableKeytar,
+    ...(opts.passphrasePrompt ? { passphrasePrompt: opts.passphrasePrompt } : {}),
+  });
 
   // MCP servers are now lazy-loaded: the admin plugin's onInit hook
   // reads ~/.moxxy/mcp.json and registers stub tools using each

--- a/packages/cli/src/setup/types.ts
+++ b/packages/cli/src/setup/types.ts
@@ -17,6 +17,14 @@ export interface SetupOptions {
   readonly configPath?: string;
   readonly skipUserConfig?: boolean;
   readonly disableKeytar?: boolean;
+  /**
+   * Custom prompt for the vault master-key passphrase (first run only, when
+   * no env var / OS keychain / disk key is present). When omitted the vault
+   * uses a bare `readline` prompt, or throws in a non-TTY. `moxxy init` passes
+   * a `@clack/prompts`-styled prompt so the passphrase step matches the rest
+   * of the setup wizard.
+   */
+  readonly passphrasePrompt?: () => Promise<string>;
   /** Skip the interactive API-key prompt when no key is found. Useful for headless tooling that wants a hard error instead of a hang. */
   readonly skipKeyPrompt?: boolean;
   /**


### PR DESCRIPTION
## What

`moxxy init` collected the vault passphrase as an **unstyled `readline` prompt** that fired *before* the wizard and before the logo:

```
moxxy vault needs a passphrase.
Pick one now (it's stored in your OS keychain if available).
Set MOXXY_VAULT_PASSPHRASE to skip this prompt.
passphrase:
```

It's now a **`@clack/prompts` `password` step**, rendered beneath the moxxy logo with a short description, so it reads as the first pre-requirement step of setup — consistent with the rest of the wizard.

## How

- New `SetupOptions.passphrasePrompt` threads a custom prompt into `buildVaultPlugin` (which already accepted one).
- `init.ts`: render the logo **first**, then `vault.open()` — which invokes the clack prompt only on a genuine first run (no `MOXXY_VAULT_PASSPHRASE` / OS keychain / disk key). Passed in **TTY mode only**; headless `init` is unchanged (still relies on the env var + the vault's non-TTY guard).
- The prompt shows a `note()` describing the vault + the `MOXXY_VAULT_PASSPHRASE` escape hatch, then a hidden `password()` input with validation.

## Notes

- Independent of the keytar→@napi-rs/keyring swap (#15) — different files; either can merge first.
- Verified: build 53/53 · typecheck 101/101 · cli tests 62/62 · lint 0 errors · dep-cruiser clean · `moxxy --help` renders.

Changeset: patch-bump `@moxxy/cli`.