### PR TITLE
fix(desktop): move deb packageName under build.deb (electron-builder schema)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -89,8 +89,10 @@
       "category": "Utility",
       "maintainer": "MoxxyAI <noreply@moxxy.ai>",
       "icon": "public/logo.png",
-      "packageName": "moxxy-desktop",
       "artifactName": "moxxy-desktop-${version}-${arch}.${ext}"
+    },
+    "deb": {
+      "packageName": "moxxy-desktop"
     },
     "win": {
       "target": "nsis",


### PR DESCRIPTION
## Problem

The desktop build (from #14, now on main) fails at electron-builder **config validation**, on all three runners:

```
⨯ Invalid configuration object...
 - configuration.linux has an unknown property 'packageName'.
```

#14 put `packageName` under `build.linux`. electron-builder 25.1.8's `.d.ts` lists it on `CommonLinuxOptions`, but the **runtime `scheme.json`** only allows `packageName` on `DebOptions` — so validation rejects `linux.packageName`.

## Fix

Move it to a `build.deb` block:

```jsonc
"linux": { ... "artifactName": "moxxy-desktop-${version}-${arch}.${ext}" },
"deb":   { "packageName": "moxxy-desktop" }
```

Confirmed against `scheme.json`: `deb` is a valid root key (→ `DebOptions`), and `DebOptions` has `packageName` (which is exactly where `FpmTarget` reads `options.packageName`). `linux.artifactName` and root `executableName` stay — both schema-valid (they weren't flagged).

## Verified

`pnpm build` 53/53 (desktop electron-vite bundle builds). electron-builder packaging can't run here, but the config is now schema-valid per `scheme.json`.