### PR TITLE
fix(desktop): bake Clerk key before build + add renderer ErrorBoundary (white screen)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -72,13 +72,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # The desktop bundles its workspace deps, so the rest of the repo
-      # must be built first (turbo handles ordering + cache).
-      - name: Build workspace
-        run: pnpm build
-
-      # Bake the Clerk publishable key into the build — Vite inlines
-      # VITE_CLERK_PUBLISHABLE_KEY at build time, so it must be present now.
+      # Bake the Clerk publishable key BEFORE building. `pnpm build` runs
+      # electron-vite, which INLINES VITE_CLERK_PUBLISHABLE_KEY into the
+      # renderer bundle — so .env must already exist here. Provisioning it
+      # after the build is a no-op (the bundle is baked, and the package
+      # step only repackages dist/), which is exactly how shipped builds
+      # ended up keyless and white-screened (useUser threw with no
+      # <ClerkProvider>).
       # Prefer the CLERK_PUBLISHABLE_KEY repo secret (set a pk_live_ key
       # there for real releases); fall back to the public pk_test_ key in
       # .env.example so forks / PR builds without the secret still build.
@@ -95,6 +95,12 @@ jobs:
             echo "CLERK_PUBLISHABLE_KEY not set; falling back to the public test key in .env.example."
             cp apps/desktop/.env.example apps/desktop/.env
           fi
+
+      # The desktop bundles its workspace deps, so the rest of the repo
+      # must be built first (turbo handles ordering + cache). .env above is
+      # in place, so electron-vite bakes the Clerk key into the renderer.
+      - name: Build workspace
+        run: pnpm build
 
       # electron-builder reads the per-OS targets from apps/desktop's
       # package.json#build and emits to apps/desktop/release/.

--- a/apps/desktop/src/ErrorBoundary.tsx
+++ b/apps/desktop/src/ErrorBoundary.tsx
@@ -1,0 +1,100 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface Props {
+  readonly children: ReactNode;
+}
+interface State {
+  readonly error: Error | null;
+  readonly componentStack: string | null;
+}
+
+/**
+ * Top-level renderer error boundary. Without one, any uncaught error during
+ * render makes React 18 unmount the whole tree — leaving a blank white window
+ * with nothing on screen and (in a packaged build) nothing the user can see.
+ *
+ * This renders the error inline instead, with a Reload button, and logs it to
+ * the console (which `electron/main` forwards to its log file). Styled with
+ * plain inline styles so it works even if the app stylesheet failed to load.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  override state: State = { error: null, componentStack: null };
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    this.setState({ componentStack: info.componentStack ?? null });
+    // A blank screen with nothing logged is the worst failure mode — make
+    // it loud. electron/main mirrors renderer console errors to its log.
+    console.error('[moxxy-desktop] renderer crashed:', error, info.componentStack);
+  }
+
+  override render(): ReactNode {
+    const { error, componentStack } = this.state;
+    if (!error) return this.props.children;
+
+    return (
+      <div
+        role="alert"
+        style={{
+          position: 'fixed',
+          inset: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 16,
+          padding: '48px 40px',
+          overflow: 'auto',
+          background: 'rgb(252, 252, 255)',
+          color: '#0f172a',
+          fontFamily: "'Inter', -apple-system, system-ui, sans-serif",
+        }}
+      >
+        <div style={{ fontSize: 18, fontWeight: 700 }}>MoxxyAI Workspaces hit an error</div>
+        <div style={{ fontSize: 14, color: '#475569' }}>
+          The app failed to render. You can reload, or report this with the details below.
+        </div>
+        <pre
+          style={{
+            margin: 0,
+            padding: 16,
+            borderRadius: 10,
+            background: '#0f172a',
+            color: '#e2e8f0',
+            fontSize: 12,
+            lineHeight: 1.5,
+            fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            maxHeight: '50vh',
+            overflow: 'auto',
+          }}
+        >
+          {error.message}
+          {error.stack ? `\n\n${error.stack}` : ''}
+          {componentStack ? `\n\nComponent stack:${componentStack}` : ''}
+        </pre>
+        <div>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            style={{
+              height: 40,
+              padding: '0 20px',
+              borderRadius: 10,
+              border: 'none',
+              background: 'linear-gradient(135deg, #ec4899, #8b5cf6)',
+              color: '#fff',
+              fontWeight: 600,
+              fontSize: 14,
+              cursor: 'pointer',
+            }}
+          >
+            Reload
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { ClerkProvider } from '@clerk/clerk-react';
 import { App } from './App';
+import { ErrorBoundary } from './ErrorBoundary';
 import './styles.css';
 
 const root = document.getElementById('root');
@@ -17,4 +18,13 @@ const Tree = CLERK_KEY ? (
   <App />
 );
 
-ReactDOM.createRoot(root).render(<React.StrictMode>{Tree}</React.StrictMode>);
+// ErrorBoundary sits OUTSIDE ClerkProvider so it also catches a provider
+// init throw (e.g. a malformed key). Without a boundary, any uncaught
+// renderer error unmounts the whole React tree → a blank white window with
+// nothing logged — which is exactly what a keyless build did (useUser threw
+// because no <ClerkProvider> was rendered).
+ReactDOM.createRoot(root).render(
+  <React.StrictMode>
+    <ErrorBoundary>{Tree}</ErrorBoundary>
+  </React.StrictMode>,
+);


### PR DESCRIPTION
## Symptom

Installed macOS app shows a **white screen after the splash**. DevTools console:

```
Error: useUser can only be used within the <ClerkProvider /> component.
    at Onboarding (...)
```

## Root cause (two layers)

**1. The renderer shipped with no Clerk key.** `release-desktop.yml` provisioned `apps/desktop/.env` **after** `pnpm build`:

```
Build workspace   (pnpm build → electron-vite INLINES VITE_CLERK_PUBLISHABLE_KEY)  ← key undefined here
Provision .env    (creates .env)                                                   ← too late
Package installers (electron-builder repackages dist/, no rebuild)                 ← ships keyless bundle
```

So the key was provisioned but never consumed — the bundle was already baked keyless.

**2. A keyless build hard-crashes.** `main.tsx` only wraps `<ClerkProvider>` when `CLERK_KEY` is set; otherwise it renders bare `<App/>`. But `Onboarding` (and `ProfilePill`/`ProfileView`) call `useUser()` unconditionally → throws without a provider. With **no error boundary**, React 18 tears down the whole tree → blank white window, nothing logged.

It worked in dev only because the dev server has `.env` (key present).

## Fix

- **`release-desktop.yml`**: provision `.env` **before** `Build workspace`, so electron-vite bakes the key into the renderer bundle.
- **`ErrorBoundary`** (new, top-level, outside `ClerkProvider`): renders a readable error + **Reload** instead of a silent white screen for any renderer throw — including a missing/invalid Clerk key. So this failure mode can never be invisible again.

## Verify

After merge, re-run **Release Desktop** (or push a `desktop-v*` tag). The renderer bundle will contain the key (the `pk_test` fallback, or the `CLERK_PUBLISHABLE_KEY` secret if set) → `<ClerkProvider>` present → no crash. Desktop typecheck + `pnpm build` (53/53) green locally; full electron-builder packaging only runs in CI.

Note: this needs **#18** (deb schema) merged too for the Linux packaging to complete.