### PR TITLE
fix(desktop): relative asset paths + node on PATH for all CLI spawns

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -26,7 +26,7 @@
         flex-direction: column; align-items: center; justify-content: center;
         gap: 1.25rem; }
       #splash-fallback .mark { width: 160px; height: 160px;
-        background: url('/avatar.gif') center/contain no-repeat;
+        background: url('./avatar.gif') center/contain no-repeat;
         animation: splash-bob 2.2s ease-in-out infinite; }
       #splash-fallback .label { font-size: 0.85rem; color: #475569;
         letter-spacing: 0.04em; font-family: 'JetBrains Mono', monospace; }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { asset } from '@/lib/asset';
 import {
   ConnectionBridge,
   isConnected,
@@ -209,7 +210,7 @@ function ReconnectBanner({ label }: { readonly label: string }): JSX.Element {
       }}
     >
       <img
-        src="/avatar.gif"
+        src={asset('avatar.gif')}
         alt=""
         aria-hidden="true"
         className="moxxy-avatar-loader moxxy-avatar-loader--sm"

--- a/apps/desktop/src/Splash.tsx
+++ b/apps/desktop/src/Splash.tsx
@@ -6,6 +6,7 @@
  */
 
 import './styles.css';
+import { asset } from '@/lib/asset';
 
 export function Splash({
   message = 'Starting moxxy…',
@@ -31,7 +32,7 @@ export function Splash({
       }}
     >
       <img
-        src="/avatar.gif"
+        src={asset('avatar.gif')}
         alt=""
         aria-hidden="true"
         className="moxxy-avatar-loader"

--- a/apps/desktop/src/chat/chat-surface/EmptyState.tsx
+++ b/apps/desktop/src/chat/chat-surface/EmptyState.tsx
@@ -1,3 +1,4 @@
+import { asset } from '@/lib/asset';
 export function EmptyState({ ready }: { readonly ready: boolean }): JSX.Element {
   return (
     <div
@@ -11,7 +12,7 @@ export function EmptyState({ ready }: { readonly ready: boolean }): JSX.Element 
     >
       <div>
         <img
-          src="/avatar.gif"
+          src={asset('avatar.gif')}
           alt=""
           aria-hidden="true"
           className={ready ? '' : 'moxxy-avatar-loader'}

--- a/apps/desktop/src/lib/asset.ts
+++ b/apps/desktop/src/lib/asset.ts
@@ -1,0 +1,15 @@
+/**
+ * Resolve a `public/` asset URL that works in BOTH the dev server and the
+ * packaged `file://` build.
+ *
+ * Vite serves `public/` at the dev-server root (`/avatar.gif`) but in a
+ * production build the renderer is loaded from `file://…/dist/index.html`
+ * with a relative base (`./`). A hard-coded absolute `"/avatar.gif"` in JSX
+ * is a string literal Vite never rewrites, so under `file://` it resolves to
+ * the filesystem root and 404s — that's the broken logos/avatars in the
+ * packaged app. Prefixing `import.meta.env.BASE_URL` (`/` in dev, `./` in the
+ * package) makes it resolve relative to the document in both.
+ */
+export function asset(name: string): string {
+  return `${import.meta.env.BASE_URL}${name.replace(/^\/+/, '')}`;
+}

--- a/apps/desktop/src/onboarding/chrome/Shell.tsx
+++ b/apps/desktop/src/onboarding/chrome/Shell.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Icon } from '@/lib/Icon';
+import { asset } from '@/lib/asset';
 
 export function Shell({
   steps,
@@ -40,7 +41,7 @@ export function Shell({
       >
         <header style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
           <img
-            src="/logo.png"
+            src={asset('logo.png')}
             alt=""
             aria-hidden
             width={32}

--- a/apps/desktop/src/onboarding/chrome/primitives.tsx
+++ b/apps/desktop/src/onboarding/chrome/primitives.tsx
@@ -7,6 +7,7 @@
  */
 
 import { Icon } from '@/lib/Icon';
+import { asset } from '@/lib/asset';
 import { primaryBtnStyle, secondaryBtnStyle } from './styles';
 
 // ---- StepCard -------------------------------------------------------------
@@ -142,7 +143,7 @@ export function Pulse({ label }: { readonly label: string }): JSX.Element {
       }}
     >
       <img
-        src="/avatar.gif"
+        src={asset('avatar.gif')}
         alt=""
         aria-hidden
         className="moxxy-avatar-loader moxxy-avatar-loader--sm"

--- a/apps/desktop/src/onboarding/steps/DoneStep.tsx
+++ b/apps/desktop/src/onboarding/steps/DoneStep.tsx
@@ -4,6 +4,7 @@
  */
 
 import { usePrefs } from '@/lib/usePrefs';
+import { asset } from '@/lib/asset';
 import { Icon } from '@/lib/Icon';
 import { PrimaryButton } from '../chrome';
 
@@ -24,7 +25,7 @@ export function DoneStep({ onComplete }: { readonly onComplete: () => void }): J
       }}
     >
       <img
-        src="/avatar.gif"
+        src={asset('avatar.gif')}
         alt=""
         aria-hidden
         style={{ width: 200, height: 'auto', imageRendering: 'pixelated' }}

--- a/apps/desktop/src/onboarding/steps/WelcomeStep.tsx
+++ b/apps/desktop/src/onboarding/steps/WelcomeStep.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Icon } from '@/lib/Icon';
+import { asset } from '@/lib/asset';
 import { PrimaryButton } from '../chrome';
 
 export function WelcomeStep({ onNext }: { readonly onNext: () => void }): JSX.Element {
@@ -13,7 +14,7 @@ export function WelcomeStep({ onNext }: { readonly onNext: () => void }): JSX.El
       style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center', gap: 18 }}
     >
       <img
-        src="/avatar.gif"
+        src={asset('avatar.gif')}
         alt=""
         aria-hidden
         className="moxxy-avatar-loader"

--- a/apps/desktop/src/settings/skills/heroes.tsx
+++ b/apps/desktop/src/settings/skills/heroes.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Icon } from '@/lib/Icon';
+import { asset } from '@/lib/asset';
 
 export function EmptyHero({
   onCreate,
@@ -25,7 +26,7 @@ export function EmptyHero({
     >
       <div>
         <img
-          src="/avatar.gif"
+          src={asset('avatar.gif')}
           alt=""
           aria-hidden
           style={{ width: 140, height: 'auto', imageRendering: 'pixelated', marginBottom: 14 }}
@@ -94,7 +95,7 @@ export function LoadingHero(): JSX.Element {
       }}
     >
       <img
-        src="/avatar.gif"
+        src={asset('avatar.gif')}
         alt=""
         aria-hidden
         className="moxxy-avatar-loader moxxy-avatar-loader--sm"

--- a/apps/desktop/src/shell/workspace-sidebar/Logo.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/Logo.tsx
@@ -1,3 +1,4 @@
+import { asset } from '@/lib/asset';
 /**
  * Sidebar masthead — the pixel-art MoxxyAI mark plus the "Workspaces"
  * wordmark stacked beside it. Sits flush at the top of the dark rail.
@@ -13,7 +14,7 @@ export function Logo(): JSX.Element {
       }}
     >
       <img
-        src="/logo.png"
+        src={asset('logo.png')}
         alt="MoxxyAI Workspaces"
         width={32}
         height={32}

--- a/packages/desktop-host/src/cli-resolver.ts
+++ b/packages/desktop-host/src/cli-resolver.ts
@@ -70,6 +70,27 @@ export function augmentedPaths(): string[] {
   return out;
 }
 
+/**
+ * Build the PATH to use when SPAWNING the moxxy CLI / npm from the desktop.
+ *
+ * macOS Finder/Dock launches don't inherit the shell PATH, so `node` — which
+ * moxxy's (and npm's) `#!/usr/bin/env node` shebang needs, and which lives in
+ * the SAME bin dir as the resolved `moxxy`/`npm` (nvm, homebrew, global npm) —
+ * isn't found by the child. Without this, `moxxy serve` exits 127 and
+ * `moxxy login <provider>` dies with "env: node: No such file or directory".
+ *
+ * Prepend the caller-supplied dirs (typically the resolved binary's own
+ * directory) plus the known install locations, then the inherited PATH.
+ */
+export function spawnPath(extraDirs: ReadonlyArray<string> = []): string {
+  const dirs = [
+    ...extraDirs,
+    ...augmentedPaths(),
+    ...(process.env.PATH ?? '').split(delimiter),
+  ].filter(Boolean);
+  return [...new Set(dirs)].join(delimiter);
+}
+
 function isReadableFile(p: string): boolean {
   try {
     return statSync(p).isFile();

--- a/packages/desktop-host/src/installer.ts
+++ b/packages/desktop-host/src/installer.ts
@@ -10,8 +10,9 @@
  */
 
 import { spawn } from 'node:child_process';
+import { dirname } from 'node:path';
 import { type BrowserWindow } from 'electron';
-import { augmentedPaths } from './cli-resolver';
+import { augmentedPaths, resolveMoxxyCli, spawnPath } from './cli-resolver';
 import { assertSafeProviderName } from './security';
 
 export interface NodeProbe {
@@ -85,6 +86,9 @@ export async function installMoxxyCli(window: BrowserWindow): Promise<number> {
   return new Promise<number>((resolve, reject) => {
     const proc = spawn(npm, ['install', '-g', '@moxxy/cli'], {
       stdio: ['ignore', 'pipe', 'pipe'],
+      // npm is itself a `#!/usr/bin/env node` shebang; a GUI-launched app
+      // lacks the shell PATH, so put node's dir (= npm's dir) on PATH.
+      env: { ...process.env, PATH: spawnPath([dirname(npm)]) },
     });
     proc.stdout?.on('data', (b: Buffer) => stream(window, b.toString()));
     proc.stderr?.on('data', (b: Buffer) => stream(window, b.toString()));
@@ -108,18 +112,25 @@ export async function runProviderLogin(
   window: BrowserWindow,
 ): Promise<number> {
   assertSafeProviderName(provider);
-  const { resolveMoxxyCli, augmentedPaths } = await import('./cli-resolver');
   const cli = resolveMoxxyCli({ extraPaths: augmentedPaths() });
   if (!cli) throw new Error('moxxy CLI not found — run the install step first');
 
   emit(window, `$ moxxy login ${provider}`);
 
+  // GUI launches lack the shell PATH, so moxxy's `#!/usr/bin/env node`
+  // shebang can't find node → `moxxy login` died with
+  // "env: node: No such file or directory". Put node's dir (= the resolved
+  // CLI's dir) + the known install locations on PATH for the OAuth child.
+  const cliDir = cli.kind === 'direct' ? dirname(cli.bin) : dirname(cli.entry);
+  const env = { ...process.env, PATH: spawnPath([cliDir]) };
+
   return new Promise<number>((resolve, reject) => {
     const proc =
       cli.kind === 'direct'
-        ? spawn(cli.bin, ['login', provider], { stdio: ['ignore', 'pipe', 'pipe'] })
+        ? spawn(cli.bin, ['login', provider], { stdio: ['ignore', 'pipe', 'pipe'], env })
         : spawn('node', [cli.entry, 'login', provider], {
             stdio: ['ignore', 'pipe', 'pipe'],
+            env,
           });
     proc.stdout?.on('data', (b: Buffer) => stream(window, b.toString()));
     proc.stderr?.on('data', (b: Buffer) => stream(window, b.toString()));

--- a/packages/desktop-host/src/onboarding.ts
+++ b/packages/desktop-host/src/onboarding.ts
@@ -15,6 +15,7 @@ import type { OnboardingStatus } from '@moxxy/desktop-ipc-contract';
 import {
   augmentedPaths,
   resolveMoxxyCli,
+  spawnPath,
   type CliInvocation,
 } from './cli-resolver';
 import { assertSafeProviderName } from './security';
@@ -80,10 +81,14 @@ export async function saveProviderKey(provider: string, secret: string): Promise
 
 function runCli(cli: CliInvocation, args: string[], stdin?: string): Promise<void> {
   return new Promise<void>((resolve, reject) => {
+    // GUI launches lack the shell PATH; put node's dir (= the resolved CLI's
+    // dir) on PATH so moxxy's `#!/usr/bin/env node` shebang resolves.
+    const cliDir = cli.kind === 'direct' ? path.dirname(cli.bin) : path.dirname(cli.entry);
+    const env = { ...process.env, PATH: spawnPath([cliDir]) };
     const child =
       cli.kind === 'direct'
-        ? spawn(cli.bin, args, { stdio: ['pipe', 'pipe', 'pipe'] })
-        : spawn('node', [cli.entry, ...args], { stdio: ['pipe', 'pipe', 'pipe'] });
+        ? spawn(cli.bin, args, { stdio: ['pipe', 'pipe', 'pipe'], env })
+        : spawn('node', [cli.entry, ...args], { stdio: ['pipe', 'pipe', 'pipe'], env });
     let stderr = '';
     child.stderr?.on('data', (b: Buffer) => {
       stderr += b.toString();

--- a/packages/desktop-host/src/provider-discovery.ts
+++ b/packages/desktop-host/src/provider-discovery.ts
@@ -19,7 +19,7 @@ import { spawn } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
-import { resolveMoxxyCli, augmentedPaths } from './cli-resolver';
+import { resolveMoxxyCli, augmentedPaths, spawnPath } from './cli-resolver';
 
 interface StoredProvider {
   readonly kind: 'openai-compat';
@@ -59,13 +59,19 @@ function vaultGet(key: string): Promise<string> {
       reject(new Error('moxxy CLI not on PATH'));
       return;
     }
+    // GUI launches lack the shell PATH; put node's dir (= the resolved CLI's
+    // dir) on PATH so moxxy's `#!/usr/bin/env node` shebang resolves.
+    const cliDir = cli.kind === 'direct' ? path.dirname(cli.bin) : path.dirname(cli.entry);
+    const env = { ...process.env, PATH: spawnPath([cliDir]) };
     const child =
       cli.kind === 'direct'
         ? spawn(cli.bin, ['vault', 'get', key], {
             stdio: ['ignore', 'pipe', 'pipe'],
+            env,
           })
         : spawn('node', [cli.entry, 'vault', 'get', key], {
             stdio: ['ignore', 'pipe', 'pipe'],
+            env,
           });
     let stdout = '';
     let stderr = '';

--- a/packages/desktop-host/src/runner-supervisor.ts
+++ b/packages/desktop-host/src/runner-supervisor.ts
@@ -36,6 +36,7 @@ import type {
 import {
   augmentedPaths,
   resolveMoxxyCli,
+  spawnPath,
   type CliInvocation,
 } from './cli-resolver';
 import { redactSecrets } from './security';
@@ -311,8 +312,14 @@ export class RunnerSupervisor extends EventEmitter {
   }
 
   private spawnServe(cli: CliInvocation): ChildProcess {
+    const cliDir = cli.kind === 'direct' ? path.dirname(cli.bin) : path.dirname(cli.entry);
     const env = {
       ...process.env,
+      // GUI launches lack the shell PATH, so moxxy's `#!/usr/bin/env node`
+      // shebang can't find node → serve exits 127 and the desktop loops on
+      // "Lost the runner. Reconnecting…". Put node's dir (= the resolved
+      // CLI's dir) + the known install locations on PATH.
+      PATH: spawnPath([cliDir]),
       MOXXY_RUNNER_SOCKET: this.socketPath,
       // Desktop owns the UI; we don't need the co-attached web
       // surface, and binding its fixed port (4040) breaks the moment


### PR DESCRIPTION
Two packaged-app (`file://`) failures the installed macOS build hit.

## 1. Broken logos / avatars

Components hard-coded **absolute** `src="/logo.png"` / `src="/avatar.gif"`. Vite doesn't rewrite string literals, so under `file://` they resolve to the filesystem root and 404 (the broken onboarding-header logo in the screenshot).

- New `src/lib/asset.ts` → `asset(name)` prefixes `import.meta.env.BASE_URL` (`/` in dev, `./` packaged).
- Swept **all 10** refs across 9 components + `index.html`'s inline `url('/avatar.gif')`. Built `index.html` now emits `./avatar.gif` / `./logo.png`.

## 2. `node` not found for spawned CLIs (serve 127 / codex login)

A macOS app launched from Finder/Dock **doesn't inherit the shell PATH**, so moxxy's `#!/usr/bin/env node` shebang failed:
- `moxxy serve` → exit **127** → endless *"Lost the runner. Reconnecting…"*
- `moxxy login openai-codex` → **`env: node: No such file or directory`**

Added `cli-resolver.spawnPath()` — resolved-CLI dir (where `node` co-lives in nvm/homebrew/global installs) + the known install dirs + inherited PATH — and applied it to **every** moxxy/npm spawn:
- `runner-supervisor.spawnServe` (serve)
- `installer.runProviderLogin` (login — **this fixes codex OAuth**) + `installMoxxyCli` (npm)
- `provider-discovery.vaultGet` (`moxxy vault get`)
- `onboarding.runCli` (`moxxy vault set`, status checks)

**Chats are covered transitively:** the runner (`serve`) is now spawned with the right PATH, and the tool/subagent processes it spawns inherit its env. (`lsof` sites use a base-PATH system tool; `probeNode` uses an absolute node path — neither needs this.)

## Verify

Build 53/53 · typecheck clean · desktop-host tests 43/43 · lint 0 errors · dep-cruiser clean. Real test is the next packaged build: logos render, the runner connects, and `moxxy login openai-codex` opens the browser.