### PR TITLE
fix(cli): serve binds even with no provider (fixes desktop reconnect loop)

### DIFF
--- a/.changeset/serve-tolerate-no-provider.md
+++ b/.changeset/serve-tolerate-no-provider.md
@@ -1,0 +1,7 @@
+---
+"@moxxy/cli": patch
+---
+
+`moxxy serve` now boots even when no provider key is configured.
+
+Previously `serve` activated a provider at startup and exited 1 with `AUTH_NO_CREDENTIALS` when none was found — *before* binding its socket. Clients (notably the desktop app) then looped forever on "lost the runner / reconnecting" and could never connect to add a provider. `serve` now boots with `tolerateNoProvider` (matching `channels` / `login`): it binds the socket with no active provider, and turns fail with a clear "no provider" error until one is configured.

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -219,7 +219,16 @@ async function runServeForeground(
   except: Set<string>,
   all: boolean,
 ): Promise<number> {
-  const setup = await bootSessionWithConfig(argv, { skipKeyPrompt: true });
+  // tolerateNoProvider: the runner must come up and bind its socket even when
+  // no provider key is configured yet — otherwise `serve` exits 1
+  // (AUTH_NO_CREDENTIALS) before binding, and clients (e.g. the desktop) loop
+  // forever on "lost the runner / reconnecting" instead of being able to
+  // connect and walk the user through adding a provider. Turns still fail with
+  // a clear "no provider" error until one is configured.
+  const setup = await bootSessionWithConfig(argv, {
+    skipKeyPrompt: true,
+    tolerateNoProvider: true,
+  });
   const { session, vault, config, scheduler, webhooks } = setup;
   const setupHandle: SetupHandle = { scheduler, webhooks };
 


### PR DESCRIPTION
## Problem

A fresh desktop install loops forever on **"Lost the runner. Reconnecting…"** (`moxxy serve exited before binding … code=1`). Reproduced with the published CLI:

```
$ moxxy serve
error [AUTH_NO_CREDENTIALS]  No API key found for provider 'anthropic'.
```

`serve` activated a provider at startup and **exited 1 before binding its socket** when no key was configured. The desktop can't connect, so it never reaches the `connectedWithoutProvider` state that would route the user into onboarding to add one.

## Fix

`serve.ts` now boots with `tolerateNoProvider: true` (matching `channels` / `login`): it binds the socket with **no active provider**; turns fail with a clear "no provider" error until one is set. The desktop then connects → `connectedWithoutProvider` → **Onboarding** (already implemented in `App.tsx`).

## Verified

Built the CLI and ran `serve` with an empty vault + no `ANTHROPIC_API_KEY`: it now **binds and stays up as a bare runner** (previously exit 1).

## ⚠️ Important: this must reach the user's *global* moxxy

The desktop spawns the user's **globally-installed** `moxxy` (e.g. `~/.nvm/.../bin/moxxy`), not a bundled copy. So this fix only helps once it's **published (0.1.4)** and the user runs `npm i -g @moxxy/cli@latest`. Longer term we should bundle/pin the CLI inside the desktop app so it never depends on the global version.