### PR TITLE
fix(desktop): macOS app name shows 'MoxxyAI Workspaces' not 'moxxy-desktop'

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -60,7 +60,6 @@
   "build": {
     "appId": "ai.moxxy.desktop",
     "productName": "MoxxyAI Workspaces",
-    "executableName": "moxxy-desktop",
     "afterPack": "build/after-pack.cjs",
     "directories": {
       "output": "release"
@@ -79,7 +78,11 @@
     "mac": {
       "category": "public.app-category.productivity",
       "target": "dmg",
-      "icon": "public/logo.png"
+      "icon": "public/logo.png",
+      "extendInfo": {
+        "CFBundleName": "MoxxyAI Workspaces",
+        "CFBundleDisplayName": "MoxxyAI Workspaces"
+      }
     },
     "linux": {
       "target": [
@@ -89,6 +92,7 @@
       "category": "Utility",
       "maintainer": "MoxxyAI <noreply@moxxy.ai>",
       "icon": "public/logo.png",
+      "executableName": "moxxy-desktop",
       "artifactName": "moxxy-desktop-${version}-${arch}.${ext}"
     },
     "deb": {


### PR DESCRIPTION
macOS showed the app as **moxxy-desktop** (menu bar / Dock / About). Cause: `executableName: "moxxy-desktop"` was set at the **top level** (#14, to get a clean Linux binary), and on macOS that bleeds into the app identity.

Fix:
- Move `executableName` to **`build.linux`** only — keeps the clean `.deb`/AppImage binary + `.desktop` + icon names, while macOS keeps its `productName`-based default.
- Add **`build.mac.extendInfo`** forcing `CFBundleName` + `CFBundleDisplayName` = `MoxxyAI Workspaces` (the Info.plist keys the macOS app menu / Dock read).

Config-only; `pnpm build` green. Real verification is the next packaged build's menu/Dock name.