### PR TITLE
feat(desktop): bundle a pinned moxxy CLI (run via Electron's Node), updatable

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -102,6 +102,15 @@ jobs:
       - name: Build workspace
         run: pnpm build
 
+      # Bundle a self-contained, pinned moxxy CLI INTO the app so the desktop
+      # never depends on a globally-installed moxxy (or a system node — it's
+      # run via Electron's Node). electron-builder ships resources/moxxy-cli
+      # via extraResources.
+      - name: Bundle moxxy CLI
+        run: |
+          rm -rf apps/desktop/resources/moxxy-cli
+          pnpm --filter @moxxy/cli --legacy deploy --prod apps/desktop/resources/moxxy-cli
+
       # electron-builder reads the per-OS targets from apps/desktop's
       # package.json#build and emits to apps/desktop/release/.
       - name: Package installers

--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -4,3 +4,4 @@ dist-electron
 release
 .turbo
 .vite
+resources/moxxy-cli/

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -14,8 +14,32 @@ import { app, BrowserWindow } from 'electron';
 // menu bar / Dock and Windows taskbar pick it up. Falls through to
 // the packaged productName for the bundled .app/.exe.
 app.setName('MoxxyAI Workspaces');
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+// In a packaged build there is no global `moxxy` (and a GUI launch has no
+// shell PATH / system `node`). Point the CLI resolver at a self-contained,
+// pinned CLI run via Electron's own Node (ELECTRON_RUN_AS_NODE), preferring a
+// version the user updated from within the app over the one bundled with this
+// release. Respects an explicit MOXXY_CLI_ENTRY override (dev / power users).
+if (app.isPackaged && !process.env.MOXXY_CLI_ENTRY) {
+  // Updatable copy (installed by the in-app "update CLI" action into writable
+  // userData) wins over the read-only copy bundled in resources, so users can
+  // move to a newer CLI without waiting for a full app update.
+  const updatedCli = path.join(
+    app.getPath('userData'),
+    'cli',
+    'node_modules',
+    '@moxxy',
+    'cli',
+    'dist',
+    'bin.js',
+  );
+  const bundledCli = path.join(process.resourcesPath, 'moxxy-cli', 'dist', 'bin.js');
+  const entry = [updatedCli, bundledCli].find((p) => existsSync(p));
+  if (entry) process.env.MOXXY_CLI_ENTRY = entry;
+}
 
 import {
   RunnerPool,

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,6 +22,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "bundle:cli": "rm -rf resources/moxxy-cli && pnpm --filter @moxxy/cli --legacy deploy --prod resources/moxxy-cli",
     "clean": "rm -rf dist dist-electron .turbo node_modules/.vite"
   },
   "dependencies": {
@@ -75,6 +76,12 @@
     "files": [
       "dist-electron/**",
       "dist/**"
+    ],
+    "extraResources": [
+      {
+        "from": "resources/moxxy-cli",
+        "to": "moxxy-cli"
+      }
     ],
     "mac": {
       "category": "public.app-category.productivity",

--- a/packages/desktop-host/src/cli-resolver.ts
+++ b/packages/desktop-host/src/cli-resolver.ts
@@ -91,6 +91,19 @@ export function spawnPath(extraDirs: ReadonlyArray<string> = []): string {
   return [...new Set(dirs)].join(delimiter);
 }
 
+/**
+ * How to launch a Node script from the desktop. In a packaged Electron app
+ * there is no system `node`, but the Electron binary runs as Node when
+ * ELECTRON_RUN_AS_NODE=1 — use that so the bundled CLI runs with zero external
+ * dependencies. Falls back to `node` (dev / tests / non-Electron).
+ */
+export function nodeLauncher(): { command: string; env: NodeJS.ProcessEnv } {
+  if (process.versions.electron) {
+    return { command: process.execPath, env: { ELECTRON_RUN_AS_NODE: '1' } };
+  }
+  return { command: 'node', env: {} };
+}
+
 function isReadableFile(p: string): boolean {
   try {
     return statSync(p).isFile();

--- a/packages/desktop-host/src/installer.ts
+++ b/packages/desktop-host/src/installer.ts
@@ -12,7 +12,7 @@
 import { spawn } from 'node:child_process';
 import { dirname } from 'node:path';
 import { type BrowserWindow } from 'electron';
-import { augmentedPaths, resolveMoxxyCli, spawnPath } from './cli-resolver';
+import { augmentedPaths, nodeLauncher, resolveMoxxyCli, spawnPath } from './cli-resolver';
 import { assertSafeProviderName } from './security';
 
 export interface NodeProbe {
@@ -125,13 +125,18 @@ export async function runProviderLogin(
   const env = { ...process.env, PATH: spawnPath([cliDir]) };
 
   return new Promise<number>((resolve, reject) => {
-    const proc =
-      cli.kind === 'direct'
-        ? spawn(cli.bin, ['login', provider], { stdio: ['ignore', 'pipe', 'pipe'], env })
-        : spawn('node', [cli.entry, 'login', provider], {
-            stdio: ['ignore', 'pipe', 'pipe'],
-            env,
-          });
+    let proc;
+    if (cli.kind === 'direct') {
+      proc = spawn(cli.bin, ['login', provider], { stdio: ['ignore', 'pipe', 'pipe'], env });
+    } else {
+      // No system `node` on a GUI launch — run the bundled CLI with
+      // Electron's own Node (ELECTRON_RUN_AS_NODE), merged onto the PATH env.
+      const { command, env: nodeEnv } = nodeLauncher();
+      proc = spawn(command, [cli.entry, 'login', provider], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...env, ...nodeEnv },
+      });
+    }
     proc.stdout?.on('data', (b: Buffer) => stream(window, b.toString()));
     proc.stderr?.on('data', (b: Buffer) => stream(window, b.toString()));
     proc.on('error', reject);

--- a/packages/desktop-host/src/onboarding.ts
+++ b/packages/desktop-host/src/onboarding.ts
@@ -14,6 +14,7 @@ import path from 'node:path';
 import type { OnboardingStatus } from '@moxxy/desktop-ipc-contract';
 import {
   augmentedPaths,
+  nodeLauncher,
   resolveMoxxyCli,
   spawnPath,
   type CliInvocation,
@@ -85,10 +86,18 @@ function runCli(cli: CliInvocation, args: string[], stdin?: string): Promise<voi
     // dir) on PATH so moxxy's `#!/usr/bin/env node` shebang resolves.
     const cliDir = cli.kind === 'direct' ? path.dirname(cli.bin) : path.dirname(cli.entry);
     const env = { ...process.env, PATH: spawnPath([cliDir]) };
-    const child =
-      cli.kind === 'direct'
-        ? spawn(cli.bin, args, { stdio: ['pipe', 'pipe', 'pipe'], env })
-        : spawn('node', [cli.entry, ...args], { stdio: ['pipe', 'pipe', 'pipe'], env });
+    let child;
+    if (cli.kind === 'direct') {
+      child = spawn(cli.bin, args, { stdio: ['pipe', 'pipe', 'pipe'], env });
+    } else {
+      // No system `node` on a GUI launch — run the bundled CLI with
+      // Electron's own Node (ELECTRON_RUN_AS_NODE), merged onto the PATH env.
+      const { command, env: nodeEnv } = nodeLauncher();
+      child = spawn(command, [cli.entry, ...args], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...env, ...nodeEnv },
+      });
+    }
     let stderr = '';
     child.stderr?.on('data', (b: Buffer) => {
       stderr += b.toString();

--- a/packages/desktop-host/src/provider-discovery.ts
+++ b/packages/desktop-host/src/provider-discovery.ts
@@ -19,7 +19,7 @@ import { spawn } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
-import { resolveMoxxyCli, augmentedPaths, spawnPath } from './cli-resolver';
+import { resolveMoxxyCli, augmentedPaths, nodeLauncher, spawnPath } from './cli-resolver';
 
 interface StoredProvider {
   readonly kind: 'openai-compat';
@@ -63,16 +63,21 @@ function vaultGet(key: string): Promise<string> {
     // dir) on PATH so moxxy's `#!/usr/bin/env node` shebang resolves.
     const cliDir = cli.kind === 'direct' ? path.dirname(cli.bin) : path.dirname(cli.entry);
     const env = { ...process.env, PATH: spawnPath([cliDir]) };
-    const child =
-      cli.kind === 'direct'
-        ? spawn(cli.bin, ['vault', 'get', key], {
-            stdio: ['ignore', 'pipe', 'pipe'],
-            env,
-          })
-        : spawn('node', [cli.entry, 'vault', 'get', key], {
-            stdio: ['ignore', 'pipe', 'pipe'],
-            env,
-          });
+    let child;
+    if (cli.kind === 'direct') {
+      child = spawn(cli.bin, ['vault', 'get', key], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env,
+      });
+    } else {
+      // No system `node` on a GUI launch — run the bundled CLI with
+      // Electron's own Node (ELECTRON_RUN_AS_NODE), merged onto the PATH env.
+      const { command, env: nodeEnv } = nodeLauncher();
+      child = spawn(command, [cli.entry, 'vault', 'get', key], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...env, ...nodeEnv },
+      });
+    }
     let stdout = '';
     let stderr = '';
     child.stdout.on('data', (b) => {

--- a/packages/desktop-host/src/runner-supervisor.ts
+++ b/packages/desktop-host/src/runner-supervisor.ts
@@ -35,6 +35,7 @@ import type {
 } from '@moxxy/desktop-ipc-contract';
 import {
   augmentedPaths,
+  nodeLauncher,
   resolveMoxxyCli,
   spawnPath,
   type CliInvocation,
@@ -331,10 +332,19 @@ export class RunnerSupervisor extends EventEmitter {
       stdio: ['ignore', 'pipe', 'pipe'],
     };
     if (this.cwd) spawnOpts.cwd = this.cwd;
-    const proc =
-      cli.kind === 'direct'
-        ? spawn(cli.bin, ['serve'], spawnOpts)
-        : spawn('node', [cli.entry, 'serve'], spawnOpts);
+    let proc: ChildProcess;
+    if (cli.kind === 'direct') {
+      proc = spawn(cli.bin, ['serve'], spawnOpts);
+    } else {
+      // No system `node` on a GUI launch — run the bundled CLI with
+      // Electron's own Node (ELECTRON_RUN_AS_NODE), merged onto the PATH
+      // env above. Falls back to plain `node` outside Electron.
+      const { command, env: nodeEnv } = nodeLauncher();
+      proc = spawn(command, [cli.entry, 'serve'], {
+        ...spawnOpts,
+        env: { ...env, ...nodeEnv },
+      });
+    }
 
     proc.stdout?.on('data', (chunk) => this.consumeLog('stdout', chunk));
     proc.stderr?.on('data', (chunk) => this.consumeLog('stderr', chunk));


### PR DESCRIPTION
## Why

The desktop spawned the user's **globally-installed** `moxxy` (`~/.nvm/.../bin/moxxy`). That's the root of the whack-a-mole: CLI fixes never reached the app without a separate `npm i -g @moxxy/cli@latest`, and a GUI launch (no shell PATH) couldn't even find `node` for the CLI's shebang. Now the desktop ships **its own pinned CLI** and runs it with **Electron's own Node** — zero dependency on a global install or system node.

## How

- **CI build job** (`release-desktop.yml`): new **Bundle moxxy CLI** step runs `pnpm --filter @moxxy/cli --legacy deploy --prod apps/desktop/resources/moxxy-cli` after `Build workspace`, staging a **self-contained** CLI (`dist/bin.js` + `node_modules/{@moxxy/sdk, zod, @napi-rs/keyring}`, ~24 MB). electron-builder ships it via `build.extraResources`. This bundles the **repo's current CLI = the newest version**. Also added a `bundle:cli` npm script for local packaging.
- **`cli-resolver.nodeLauncher()`**: under Electron, run node scripts via `process.execPath` + `ELECTRON_RUN_AS_NODE=1`. Every `'node'`-kind CLI spawn (`serve`, `login`, `vault get`, onboarding) uses it → no system `node` needed. Falls back to `node` in dev/tests.
- **electron main**: when packaged, set `MOXXY_CLI_ENTRY` to the bundled CLI.

## Updatable (your "update from the app" requirement)

The resolver **prefers a user-updated CLI in writable `userData/cli`** over the read-only bundled copy:
```
MOXXY_CLI_ENTRY (explicit) → userData/cli/node_modules/@moxxy/cli/dist/bin.js (updated) → resources/moxxy-cli (bundled)
```
So a future **"update CLI"** button just needs to `npm install @moxxy/cli@latest --prefix <userData>/cli` and restart the runner — the updated copy then wins, no full app update required. (The install IPC + settings button are the next PR; this lays the groundwork.)

## Verified

Validated the deploy + standalone run locally (self-contained CLI runs `serve` with no nvm on PATH). Build 53/53 · typecheck clean · desktop-host tests 43/43 · 0 lint errors. Full packaging (extraResources + ELECTRON_RUN_AS_NODE) runs in CI — that's the final verification.

> Depends on #21 (serve binds with no provider) to be fully usable end-to-end; the bundled CLI picks that up once #21 is on main.