### PR TITLE
fix(desktop): activate provider after onboarding adds it (stop the loop)

### DIFF
--- a/apps/desktop/src/onboarding/steps/ProviderStep.tsx
+++ b/apps/desktop/src/onboarding/steps/ProviderStep.tsx
@@ -77,6 +77,16 @@ export function ProviderStep({
     return off;
   }, []);
 
+  // After a credential lands in the vault, tell the RUNNING runner to activate
+  // this provider. The runner booted with no active provider (no creds existed
+  // yet, so `serve` tolerated it), so without this it never gains an
+  // activeProvider — the app's `connectedWithoutProvider` gate never clears and
+  // onboarding loops forever. setProvider re-resolves the credential from the
+  // vault and makes the runner usable; the gate then drops on its own.
+  const activateProvider = async (): Promise<void> => {
+    await api().invoke('session.setProvider', { provider });
+  };
+
   const saveKey = async (): Promise<void> => {
     if (!secret.trim()) return;
     setSaving(true);
@@ -87,6 +97,7 @@ export function ProviderStep({
         secret: secret.trim(),
       });
       setSecret('');
+      await activateProvider();
       setDone(true);
     } catch (e) {
       setError(toErrorMessage(e));
@@ -101,8 +112,12 @@ export function ProviderStep({
     setLoginLog([]);
     try {
       const code = await api().invoke('onboarding.runProviderLogin', { provider });
-      if (code === 0) setDone(true);
-      else setError(`moxxy login exit ${code}`);
+      if (code !== 0) {
+        setError(`moxxy login exit ${code}`);
+        return;
+      }
+      await activateProvider();
+      setDone(true);
     } catch (e) {
       setError(toErrorMessage(e));
     } finally {

--- a/packages/desktop-host/src/ipc/session.ts
+++ b/packages/desktop-host/src/ipc/session.ts
@@ -49,11 +49,15 @@ export function registerSessionHandlers(pool: RunnerPool): void {
     const session = mustRemote(pool, workspaceId);
     session.providers.setActive(provider);
     await waitForSessionState(session, (info) => info.activeProvider === provider);
+    // Re-emit the connection phase so the renderer sees the new activeProvider
+    // — otherwise the onboarding `connectedWithoutProvider` gate never clears.
+    resolveSupervisor(pool, workspaceId)?.refreshConnectedInfo();
   });
   handle('session.setMode', async ({ workspaceId, mode }) => {
     const session = mustRemote(pool, workspaceId);
     session.modes.setActive(mode);
     await waitForSessionState(session, (info) => info.activeMode === mode);
+    resolveSupervisor(pool, workspaceId)?.refreshConnectedInfo();
   });
   handle('session.runCommand', async ({ workspaceId, name, args }) => {
     const session = mustRemote(pool, workspaceId);

--- a/packages/desktop-host/src/runner-supervisor.ts
+++ b/packages/desktop-host/src/runner-supervisor.ts
@@ -113,6 +113,29 @@ export class RunnerSupervisor extends EventEmitter {
     return this.session;
   }
 
+  /**
+   * Re-read the runner's session info and re-emit the `connected` phase, so
+   * the renderer sees state that changed mid-session — notably `activeProvider`
+   * after a `setProvider` (the runner boots with no provider during onboarding;
+   * without this re-emit the app's `connectedWithoutProvider` gate never clears
+   * and onboarding loops). No-op unless currently connected.
+   */
+  refreshConnectedInfo(): void {
+    if (!this.session || this.currentPhase.phase !== 'connected') return;
+    try {
+      const info = this.session.getInfo();
+      this.setPhase({
+        phase: 'connected',
+        socket: this.socketPath,
+        sessionId: String(info.sessionId ?? '(unknown)'),
+        activeProvider: info.activeProvider ?? null,
+        activeMode: info.activeMode ?? null,
+      });
+    } catch {
+      /* session torn down mid-refresh — the run loop re-derives the phase */
+    }
+  }
+
   /** Kick the loop out of a backoff wait so the user's Retry button
    *  is responsive. No-op when already trying. */
   forceRetry(): void {


### PR DESCRIPTION
## Problem

After adding a provider in onboarding (OAuth or API key), **"Continue" did nothing and onboarding looped**.

The runner boots with no active provider (`serve` tolerates it so the desktop can connect → onboarding). But after the credential lands in the vault, **nothing told the runner to activate the provider** — `activeProvider` stayed `null`, so `App`'s `connectedWithoutProvider` gate never cleared.

Two bugs:
1. `ProviderStep` never called `session.setProvider` after saving the credential.
2. Even if it had, the supervisor builds the `connected` phase **once at attach** and blocks on `onClose` — it never re-emits when `activeProvider` changes, so the renderer would still see `null`.

## Fix

- **`ProviderStep`**: after `saveProviderKey` / `runProviderLogin` succeeds, call `session.setProvider(provider)` to activate it on the running runner (re-resolves the credential from the vault).
- **`RunnerSupervisor.refreshConnectedInfo()`**: re-reads `session.getInfo()` and re-emits the `connected` phase.
- **`ipc session.setProvider` / `setMode`**: call `refreshConnectedInfo()` after the change settles → renderer sees the new `activeProvider` → the gate clears → shell renders.

## Verified
desktop-host build + typecheck + tests (43) green; desktop typecheck green.

Next: open the browser automatically on the codex OAuth click (use the loopback flow, not headless device-code) — separate follow-up.