### PR TITLE
feat(oauth): open browser on provider sign-in (no device-code copying)

### DIFF
--- a/.changeset/login-browser-flag.md
+++ b/.changeset/login-browser-flag.md
@@ -1,0 +1,7 @@
+---
+"@moxxy/cli": patch
+---
+
+`moxxy login`: add a `--browser` flag that forces the loopback/browser OAuth flow even when stdin isn't a TTY.
+
+Previously a GUI host (the desktop app) that spawned `moxxy login <provider>` with piped stdio got the headless device-code flow — the user had to open a URL and type a code by hand. With `--browser`, the CLI runs the loopback flow that opens the system browser automatically and catches the localhost callback, so no copying is needed. (`--no-browser` still forces device-code.)

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -42,6 +42,7 @@ function buildHelp(session: Session | null): string {
       {
         title: 'FLAGS',
         rows: [
+          ['--browser', 'force the loopback/browser flow even without a TTY (opens the browser automatically)'],
           ['--no-browser', 'force the headless device-code flow (auto when no TTY)'],
         ],
       },
@@ -110,11 +111,17 @@ async function loginProvider(argv: ParsedArgv, providerName: string): Promise<nu
   // flow that's about to start.
   await vault.open();
 
-  // Headless mode triggers when:
-  //   - stdin isn't a TTY (CI, ssh -T, docker exec without -t), OR
+  // Headless (device-code) mode triggers when:
   //   - the user passes `--no-browser` (e.g. running on a remote box and
-  //     wanting to complete the flow from their laptop's browser).
-  const headless = hasBoolFlag(argv, 'no-browser') || process.stdin.isTTY !== true;
+  //     wanting to complete the flow from their laptop's browser), OR
+  //   - stdin isn't a TTY (CI, ssh -T, docker exec without -t) AND the
+  //     caller didn't force the browser flow with `--browser`.
+  // `--browser` lets a GUI host (the desktop app) spawn `moxxy login` with
+  // piped stdio yet still get the loopback flow that opens the browser
+  // automatically — no manual code copying.
+  const headless =
+    hasBoolFlag(argv, 'no-browser') ||
+    (!hasBoolFlag(argv, 'browser') && process.stdin.isTTY !== true);
   const ctx = buildProviderAuthContext(vault, { headless });
 
   try {

--- a/packages/desktop-host/src/installer.ts
+++ b/packages/desktop-host/src/installer.ts
@@ -115,7 +115,7 @@ export async function runProviderLogin(
   const cli = resolveMoxxyCli({ extraPaths: augmentedPaths() });
   if (!cli) throw new Error('moxxy CLI not found — run the install step first');
 
-  emit(window, `$ moxxy login ${provider}`);
+  emit(window, `$ moxxy login ${provider} --browser`);
 
   // GUI launches lack the shell PATH, so moxxy's `#!/usr/bin/env node`
   // shebang can't find node → `moxxy login` died with
@@ -124,15 +124,21 @@ export async function runProviderLogin(
   const cliDir = cli.kind === 'direct' ? dirname(cli.bin) : dirname(cli.entry);
   const env = { ...process.env, PATH: spawnPath([cliDir]) };
 
+  // `--browser` forces the loopback flow (which opens the system browser
+  // automatically + catches the localhost callback) instead of the headless
+  // device-code flow `moxxy login` would otherwise pick because we spawn it
+  // with piped stdio (no TTY). The desktop is a GUI — no code copying.
+  const loginArgs = ['login', provider, '--browser'];
+
   return new Promise<number>((resolve, reject) => {
     let proc;
     if (cli.kind === 'direct') {
-      proc = spawn(cli.bin, ['login', provider], { stdio: ['ignore', 'pipe', 'pipe'], env });
+      proc = spawn(cli.bin, loginArgs, { stdio: ['ignore', 'pipe', 'pipe'], env });
     } else {
       // No system `node` on a GUI launch — run the bundled CLI with
       // Electron's own Node (ELECTRON_RUN_AS_NODE), merged onto the PATH env.
       const { command, env: nodeEnv } = nodeLauncher();
-      proc = spawn(command, [cli.entry, 'login', provider], {
+      proc = spawn(command, [cli.entry, ...loginArgs], {
         stdio: ['ignore', 'pipe', 'pipe'],
         env: { ...env, ...nodeEnv },
       });


### PR DESCRIPTION
## Problem

On the codex (and any OAuth) sign-in, the desktop showed the **headless device-code flow** — open a URL, type a code by hand:

```
Sign in to ChatGPT Pro/Plus (headless / device code flow)
1. open: https://auth.openai.com/codex/device
2. Enter this code: UWYK-7TENE
```

`moxxy login` picks headless when stdin isn't a TTY — and the desktop spawns it with piped stdio. But the desktop is a GUI; it can open a browser.

## Fix

- **`moxxy login --browser`**: new flag forces the **loopback flow** even without a TTY. `plugin-oauth` then opens the system browser automatically and catches the `http://localhost` callback — no code copying. (`--no-browser` still forces device-code; both documented in `--help`.)
- **desktop `runProviderLogin`**: passes `--browser`.

## Result

Clicking **Sign in with openai-codex** opens your browser straight to the OAuth page; on approval it redirects to localhost and the token lands in the vault. No copy/paste.

Verified: cli + desktop-host build/typecheck/tests green. (Bundled CLI picks this up on the next desktop build, since the desktop ships the repo CLI.)

Pairs with #25 (activate provider after sign-in so onboarding stops looping).