### PR TITLE
fix(ci): Bundle moxxy CLI step needs shell: bash (Windows rm -rf)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -107,6 +107,10 @@ jobs:
       # run via Electron's Node). electron-builder ships resources/moxxy-cli
       # via extraResources.
       - name: Bundle moxxy CLI
+        # `shell: bash` so `rm -rf` works on the Windows runner too (its
+        # default shell is PowerShell, where `rm -rf` is invalid). Git Bash
+        # ships on GitHub's windows-latest image.
+        shell: bash
         run: |
           rm -rf apps/desktop/resources/moxxy-cli
           pnpm --filter @moxxy/cli --legacy deploy --prod apps/desktop/resources/moxxy-cli


### PR DESCRIPTION
The `rm -rf` in the **Bundle moxxy CLI** step fails on the Windows runner (PowerShell: `A parameter cannot be found that matches parameter name 'rf'`). The `shell: bash` fix I'd pushed landed on #24's branch *after* #24 merged, so it never reached main — re-applying it here. Git Bash ships on `windows-latest`, matching the `Provision .env` step.