### PR TITLE
feat(desktop): in-app "Update CLI" button

### DIFF
--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -14,32 +14,8 @@ import { app, BrowserWindow } from 'electron';
 // menu bar / Dock and Windows taskbar pick it up. Falls through to
 // the packaged productName for the bundled .app/.exe.
 app.setName('MoxxyAI Workspaces');
-import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-// In a packaged build there is no global `moxxy` (and a GUI launch has no
-// shell PATH / system `node`). Point the CLI resolver at a self-contained,
-// pinned CLI run via Electron's own Node (ELECTRON_RUN_AS_NODE), preferring a
-// version the user updated from within the app over the one bundled with this
-// release. Respects an explicit MOXXY_CLI_ENTRY override (dev / power users).
-if (app.isPackaged && !process.env.MOXXY_CLI_ENTRY) {
-  // Updatable copy (installed by the in-app "update CLI" action into writable
-  // userData) wins over the read-only copy bundled in resources, so users can
-  // move to a newer CLI without waiting for a full app update.
-  const updatedCli = path.join(
-    app.getPath('userData'),
-    'cli',
-    'node_modules',
-    '@moxxy',
-    'cli',
-    'dist',
-    'bin.js',
-  );
-  const bundledCli = path.join(process.resourcesPath, 'moxxy-cli', 'dist', 'bin.js');
-  const entry = [updatedCli, bundledCli].find((p) => existsSync(p));
-  if (entry) process.env.MOXXY_CLI_ENTRY = entry;
-}
 
 import {
   RunnerPool,
@@ -56,7 +32,20 @@ import {
   installContentSecurityPolicy,
   lockDownNavigation,
   isSafeExternalUrl,
+  preferredCliEntry,
 } from '@moxxy/desktop-host';
+
+// In a packaged build there is no global `moxxy` (and a GUI launch has no
+// shell PATH / system `node`). Point the CLI resolver at a self-contained,
+// pinned CLI run via Electron's own Node (ELECTRON_RUN_AS_NODE), preferring a
+// version the user updated from within the app over the one bundled with this
+// release. Respects an explicit MOXXY_CLI_ENTRY override (dev / power users).
+// The in-app "Update CLI" action re-points the same env var via the shared
+// preferredCliEntry() helper after installing into writable userData.
+if (app.isPackaged && !process.env.MOXXY_CLI_ENTRY) {
+  const entry = preferredCliEntry(app.getPath('userData'), process.resourcesPath);
+  if (entry) process.env.MOXXY_CLI_ENTRY = entry;
+}
 import { ipcMain, Tray, Menu, nativeImage, globalShortcut, session, shell } from 'electron';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/apps/desktop/src/settings/AboutTab.tsx
+++ b/apps/desktop/src/settings/AboutTab.tsx
@@ -1,0 +1,170 @@
+/**
+ * About / CLI tab — shows the version + on-disk path of the moxxy CLI the
+ * desktop is currently running, and an "Update CLI" button that pulls the
+ * latest published `@moxxy/cli` into the writable userData copy and
+ * restarts the runner so the new binary is used immediately.
+ *
+ * npm output streams to a log box via the same `onboarding.install.progress`
+ * event the onboarding install/login flows use. The bundled CLI keeps
+ * working if the update fails (e.g. npm not on PATH).
+ */
+
+import { useEffect, useState } from 'react';
+import { api } from '@/lib/api';
+import { toErrorMessage } from '@/lib/errors';
+import { Section } from './settings-primitives';
+
+export function AboutTab(): JSX.Element {
+  const [info, setInfo] = useState<{ version: string | null; path: string | null } | null>(null);
+  const [updating, setUpdating] = useState(false);
+  const [log, setLog] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [restarting, setRestarting] = useState(false);
+
+  const loadInfo = (): void => {
+    void api()
+      .invoke('app.cliInfo')
+      .then(setInfo)
+      .catch(() => setInfo({ version: null, path: null }));
+  };
+
+  useEffect(loadInfo, []);
+
+  // Reuse the install-progress channel so npm's stdout/stderr stream to
+  // the log box while the update runs.
+  useEffect(() => {
+    const off = api().subscribe('onboarding.install.progress', (line: string) => {
+      setLog((cur) => [...cur.slice(-80), line]);
+    });
+    return off;
+  }, []);
+
+  const runUpdate = async (): Promise<void> => {
+    setUpdating(true);
+    setError(null);
+    setRestarting(false);
+    setLog([]);
+    try {
+      const { code, version } = await api().invoke('app.updateCli');
+      if (code !== 0) {
+        setError(`npm install exited with code ${code}.`);
+        return;
+      }
+      setInfo((cur) => ({ version, path: cur?.path ?? null }));
+      setRestarting(true);
+      // The runner restart is fire-and-forgotten by the handler; re-read
+      // the resolved path/version shortly after so the panel reflects the
+      // re-pointed MOXXY_CLI_ENTRY.
+      loadInfo();
+    } catch (e) {
+      setError(toErrorMessage(e));
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  return (
+    <Section
+      title="moxxy CLI"
+      description="The desktop runs a bundled moxxy CLI. Update to the latest published version without reinstalling the app."
+    >
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 14,
+          padding: '16px 18px',
+          background: 'var(--color-card-bg)',
+          border: '1px solid var(--color-card-border)',
+          borderRadius: 14,
+        }}
+      >
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+            <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-text-muted)' }}>
+              CLI version
+            </span>
+            <span className="mono" style={{ fontSize: 13.5, fontWeight: 700, color: 'var(--color-text)' }}>
+              {info ? (info.version ?? 'unknown') : '…'}
+            </span>
+          </div>
+          {info?.path && (
+            <div
+              className="mono"
+              title={info.path}
+              style={{
+                fontSize: 11.5,
+                color: 'var(--color-text-dim)',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {info.path}
+            </div>
+          )}
+        </div>
+
+        {error && (
+          <p role="alert" style={{ margin: 0, fontSize: 12.5, color: 'var(--color-red)', lineHeight: 1.5 }}>
+            {error}
+            {/^npm not found/i.test(error) && (
+              <>
+                {' '}
+                Install Node.js to update from within the app; the bundled CLI keeps working otherwise.
+              </>
+            )}
+          </p>
+        )}
+
+        {restarting && !error && (
+          <p style={{ margin: 0, fontSize: 12.5, color: 'var(--color-green)', fontWeight: 600 }}>
+            Updated. Runner restarting with the new CLI…
+          </p>
+        )}
+
+        <button
+          type="button"
+          data-testid="update-cli"
+          onClick={() => void runUpdate()}
+          disabled={updating}
+          style={{
+            alignSelf: 'flex-start',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '9px 16px',
+            fontSize: 13,
+            fontWeight: 600,
+            borderRadius: 10,
+            color: '#fff',
+            background: updating ? 'var(--color-card-border-strong)' : 'var(--color-primary)',
+            cursor: updating ? 'default' : 'pointer',
+            transition: 'background 140ms',
+          }}
+        >
+          {updating ? 'Updating…' : 'Update CLI'}
+        </button>
+
+        {log.length > 0 && (
+          <pre
+            className="mono"
+            style={{
+              margin: 0,
+              padding: 10,
+              background: '#0f172a',
+              color: '#e2e8f0',
+              borderRadius: 10,
+              fontSize: 11,
+              maxHeight: 180,
+              overflow: 'auto',
+              whiteSpace: 'pre-wrap',
+            }}
+          >
+            {log.slice(-40).join('\n')}
+          </pre>
+        )}
+      </div>
+    </Section>
+  );
+}

--- a/apps/desktop/src/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/settings/SettingsPanel.tsx
@@ -6,15 +6,17 @@ import { SkillsView } from './SkillsView';
 import { ProvidersTab } from './ProvidersTab';
 import { McpTab } from './McpTab';
 import { VaultTab } from './VaultTab';
+import { AboutTab } from './AboutTab';
 import { SearchBox } from './settings-primitives';
 
-type Tab = 'providers' | 'mcp' | 'skills' | 'vault';
+type Tab = 'providers' | 'mcp' | 'skills' | 'vault' | 'about';
 
 const TABS: ReadonlyArray<{ id: Tab; label: string }> = [
   { id: 'providers', label: 'Providers' },
   { id: 'mcp', label: 'MCP' },
   { id: 'skills', label: 'Skills' },
   { id: 'vault', label: 'Vault' },
+  { id: 'about', label: 'About' },
 ];
 
 /**
@@ -114,7 +116,11 @@ export function SettingsPanel(): JSX.Element {
         </button>
       </header>
 
-      {s.error && (
+      {/* About is independent of the runner-backed settings slice — render
+          it without the shared loading / error chrome below. */}
+      {tab === 'about' && <AboutTab />}
+
+      {tab !== 'about' && s.error && (
         <div
           role="alert"
           style={{
@@ -135,7 +141,7 @@ export function SettingsPanel(): JSX.Element {
         </div>
       )}
 
-      {s.loading ? (
+      {tab === 'about' ? null : s.loading ? (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           <Skeleton.Card />
           <Skeleton.Card />

--- a/packages/desktop-host/src/cli-resolver.ts
+++ b/packages/desktop-host/src/cli-resolver.ts
@@ -28,6 +28,28 @@ export interface ResolveOptions {
   readonly extraPaths?: ReadonlyArray<string>;
 }
 
+/**
+ * The `dist/bin.js` path the desktop should run, preferring a writable,
+ * user-updated copy under `<userDataDir>/cli` over the read-only one
+ * bundled in resources. Mirrors the preference order the Electron main's
+ * boot block applies to `MOXXY_CLI_ENTRY`, factored out so the in-app
+ * "Update CLI" action can re-point at the freshly-installed copy without
+ * duplicating the path logic. Returns null when neither exists.
+ */
+export function preferredCliEntry(userDataDir: string, resourcesPath: string): string | null {
+  const updatedCli = path.join(
+    userDataDir,
+    'cli',
+    'node_modules',
+    '@moxxy',
+    'cli',
+    'dist',
+    'bin.js',
+  );
+  const bundledCli = path.join(resourcesPath, 'moxxy-cli', 'dist', 'bin.js');
+  return [updatedCli, bundledCli].find((p) => existsSync(p)) ?? null;
+}
+
 export function resolveMoxxyCli(opts: ResolveOptions = {}): CliInvocation | null {
   const envEntry = process.env.MOXXY_CLI_ENTRY;
   if (envEntry && isReadableFile(envEntry)) {

--- a/packages/desktop-host/src/index.ts
+++ b/packages/desktop-host/src/index.ts
@@ -7,6 +7,7 @@
 
 export { RunnerPool, UNBOUND_ID } from './runner-pool.js';
 export { bindWindow, registerIpcHandlers } from './ipc.js';
+export { preferredCliEntry } from './cli-resolver.js';
 export { DeskStore } from './desks.js';
 export { sweepStaleSockets } from './sweep-sockets.js';
 export {

--- a/packages/desktop-host/src/installer.ts
+++ b/packages/desktop-host/src/installer.ts
@@ -10,7 +10,8 @@
  */
 
 import { spawn } from 'node:child_process';
-import { dirname } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import path, { dirname } from 'node:path';
 import { type BrowserWindow } from 'electron';
 import { augmentedPaths, nodeLauncher, resolveMoxxyCli, spawnPath } from './cli-resolver';
 import { assertSafeProviderName } from './security';
@@ -88,6 +89,96 @@ export async function installMoxxyCli(window: BrowserWindow): Promise<number> {
       stdio: ['ignore', 'pipe', 'pipe'],
       // npm is itself a `#!/usr/bin/env node` shebang; a GUI-launched app
       // lacks the shell PATH, so put node's dir (= npm's dir) on PATH.
+      env: { ...process.env, PATH: spawnPath([dirname(npm)]) },
+    });
+    proc.stdout?.on('data', (b: Buffer) => stream(window, b.toString()));
+    proc.stderr?.on('data', (b: Buffer) => stream(window, b.toString()));
+    proc.on('error', reject);
+    proc.on('exit', (code) => resolve(code ?? -1));
+  });
+}
+
+/**
+ * Best-effort version of the moxxy CLI that the desktop currently runs.
+ *
+ * Resolves the active CLI the same way the supervisor does, then walks
+ * from the resolved entry/bin up to the owning `@moxxy/cli/package.json`
+ * and returns its `version`. Returns null on any failure — the caller
+ * (the About section) just shows "unknown" rather than erroring.
+ *
+ * Covers the two real shapes:
+ *   - `{kind:'node', entry}` — entry is `…/dist/bin.js`; package.json is
+ *     two dirs up (`…/@moxxy/cli/package.json`).
+ *   - `{kind:'direct', bin}` — bin is an npm shim under
+ *     `…/node_modules/.bin/moxxy` or a global; walk up looking for a
+ *     `@moxxy/cli/package.json`.
+ */
+export function getCliVersion(): string | null {
+  const cli = resolveMoxxyCli({ extraPaths: augmentedPaths() });
+  if (!cli) return null;
+  const start = cli.kind === 'direct' ? cli.bin : cli.entry;
+  return readVersionNearby(start);
+}
+
+/** Walk up from a file path looking for the @moxxy/cli package.json's
+ *  version. First tries the canonical "two dirs up from dist/bin.js"
+ *  layout, then scans ancestors for an `@moxxy/cli/package.json`. */
+function readVersionNearby(start: string): string | null {
+  // dist/bin.js → package.json two dirs up (the bundled / updated layout).
+  const direct = path.join(dirname(dirname(start)), 'package.json');
+  const fromDirect = readPackageVersion(direct, '@moxxy/cli');
+  if (fromDirect) return fromDirect;
+
+  // Otherwise walk ancestors for a node_modules/@moxxy/cli/package.json.
+  let cur = dirname(start);
+  for (let i = 0; i < 8; i += 1) {
+    const candidate = path.join(cur, 'node_modules', '@moxxy', 'cli', 'package.json');
+    const v = readPackageVersion(candidate, '@moxxy/cli');
+    if (v) return v;
+    const parent = dirname(cur);
+    if (parent === cur) break;
+    cur = parent;
+  }
+  return null;
+}
+
+function readPackageVersion(pkgPath: string, expectName: string): string | null {
+  try {
+    if (!existsSync(pkgPath)) return null;
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+      name?: unknown;
+      version?: unknown;
+    };
+    if (pkg.name !== expectName) return null;
+    return typeof pkg.version === 'string' ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Install the latest published `@moxxy/cli` into the desktop's writable
+ * `<userDataDir>/cli` prefix — producing
+ * `<userDataDir>/cli/node_modules/@moxxy/cli/dist/bin.js`, exactly the
+ * path the Electron main prefers over the read-only bundled copy.
+ *
+ * Mirrors {@link installMoxxyCli}: streams every stdout/stderr line to
+ * the renderer as `onboarding.install.progress`, resolves with the exit
+ * code (non-zero install failures resolve normally so the UI can react),
+ * and rejects only if npm isn't on PATH.
+ */
+export async function updateCli(userDataDir: string, window: BrowserWindow): Promise<number> {
+  const target = path.join(userDataDir, 'cli');
+  const npm = findExe('npm');
+  if (!npm) throw new Error('npm not found on PATH — install Node.js to update the CLI');
+
+  emit(window, `$ npm install @moxxy/cli@latest --prefix ${target}`);
+
+  return new Promise<number>((resolve, reject) => {
+    const proc = spawn(npm, ['install', '@moxxy/cli@latest', '--prefix', target], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      // GUI launches lack the shell PATH; npm's `#!/usr/bin/env node`
+      // shebang needs node, which lives in npm's own dir.
       env: { ...process.env, PATH: spawnPath([dirname(npm)]) },
     });
     proc.stdout?.on('data', (b: Buffer) => stream(window, b.toString()));

--- a/packages/desktop-host/src/ipc.ts
+++ b/packages/desktop-host/src/ipc.ts
@@ -30,6 +30,7 @@ import type { RunnerPool } from './runner-pool';
 import { SessionDriver } from './session-driver';
 import type { DeskStore } from './desks';
 import { drivers } from './ipc/shared';
+import { registerAppHandlers } from './ipc/app';
 import { registerAskHandlers } from './ipc/ask';
 import { registerConnectionHandlers } from './ipc/connection';
 import { registerOnboardingHandlers } from './ipc/onboarding';
@@ -44,6 +45,7 @@ import { registerChatHandlers } from './ipc/chat';
 
 export function registerIpcHandlers(pool: RunnerPool, desks: DeskStore): void {
   registerAskHandlers();
+  registerAppHandlers(pool);
   registerConnectionHandlers(pool);
   registerOnboardingHandlers(pool);
   registerSessionHandlers(pool);

--- a/packages/desktop-host/src/ipc/app.ts
+++ b/packages/desktop-host/src/ipc/app.ts
@@ -1,0 +1,44 @@
+/**
+ * App-level (non per-workspace) handlers: the in-app "Update CLI" flow.
+ *
+ * The desktop ships a pinned, bundled `@moxxy/cli` but also prefers a
+ * writable, user-updated copy under `<userData>/cli` (see the
+ * MOXXY_CLI_ENTRY block in the Electron main). These handlers expose the
+ * running CLI's version and let the user pull the latest published CLI
+ * into that writable location, then restart every runner so the new
+ * binary is used immediately — no full app update.
+ */
+
+import { app, BrowserWindow as BrowserWindowApi } from 'electron';
+
+import type { RunnerPool } from '../runner-pool';
+import { getCliVersion, updateCli } from '../installer';
+import { preferredCliEntry } from '../cli-resolver';
+import { handle } from './shared';
+
+export function registerAppHandlers(pool: RunnerPool): void {
+  handle('app.cliInfo', async () => ({
+    version: getCliVersion(),
+    path: process.env.MOXXY_CLI_ENTRY ?? null,
+  }));
+
+  handle('app.updateCli', async () => {
+    const target = BrowserWindowApi.getFocusedWindow() ?? BrowserWindowApi.getAllWindows()[0];
+    if (!target) throw new Error('no window to stream update progress to');
+
+    const userData = app.getPath('userData');
+    const code = await updateCli(userData, target);
+
+    if (code === 0) {
+      // Re-point at the freshly-installed copy if it now exists, using the
+      // same preference order as the boot block, then restart every runner
+      // so the supervision loop re-resolves the CLI and respawns `serve`
+      // against the new binary.
+      const entry = preferredCliEntry(userData, process.resourcesPath ?? '');
+      if (entry) process.env.MOXXY_CLI_ENTRY = entry;
+      await Promise.all(pool.list().map((e) => e.supervisor.restart()));
+    }
+
+    return { code, version: getCliVersion() };
+  });
+}

--- a/packages/desktop-host/src/runner-supervisor.ts
+++ b/packages/desktop-host/src/runner-supervisor.ts
@@ -142,6 +142,26 @@ export class RunnerSupervisor extends EventEmitter {
     this.retryNotify();
   }
 
+  /** Tear down the current runner (if any) and loop back to re-resolve
+   *  the CLI + respawn — used after the CLI is updated so the new
+   *  binary is picked up immediately, without a relaunch. */
+  async restart(): Promise<void> {
+    if (this.session) {
+      const s = this.session;
+      this.session = null;
+      try {
+        await s.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    if (this.child) {
+      this.child.kill();
+      this.child = null;
+    }
+    this.forceRetry();
+  }
+
   /** Run the supervision loop. Returns immediately; the loop runs
    *  in the background for the lifetime of the process. */
   async run(): Promise<void> {

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -266,6 +266,16 @@ export interface IpcCommands {
    *  resolution loop. */
   'connection.retry': (args?: { workspaceId?: string }) => Promise<void>;
 
+  /** Version + on-disk path of the moxxy CLI the desktop is currently
+   *  running. Either field may be null if it can't be resolved. */
+  'app.cliInfo': () => Promise<{ version: string | null; path: string | null }>;
+  /** Install the latest published `@moxxy/cli` into the writable
+   *  userData copy, then restart every runner so the new binary is
+   *  used immediately. Streams npm output via
+   *  `onboarding.install.progress`. Returns the exit code (0 = ok) and
+   *  the post-update version. */
+  'app.updateCli': () => Promise<{ code: number; version: string | null }>;
+
   'onboarding.status': () => Promise<OnboardingStatus>;
   /** Probe Node.js — used by the first wizard step before we offer
    *  the install. */

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -52,6 +52,10 @@ const optionalWorkspace = z.string().min(1).max(256).optional();
 const MAX_AUDIO_BASE64 = 40_000_000;
 
 export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
+  // No-arg, but spawns a child process (npm install) — pin the payload to
+  // "nothing" so a hostile renderer can't smuggle args across.
+  'app.cliInfo': z.undefined(),
+  'app.updateCli': z.undefined(),
   'onboarding.openExternal': z.object({ url: httpUrl }),
   'onboarding.saveProviderKey': z.object({
     provider: providerName,


### PR DESCRIPTION
Adds **Settings → About → Update CLI**, so the bundled CLI can be updated from within the app (the groundwork landed in #24: the resolver already prefers a writable `<userData>/cli` copy over the bundled one).

## What

- **`app.cliInfo`** IPC → current CLI version + resolved path (shown in the About tab).
- **`app.updateCli`** IPC → `npm install @moxxy/cli@latest --prefix <userData>/cli` (streams progress over the existing `onboarding.install.progress` event), then re-points `MOXXY_CLI_ENTRY` at the updated copy and **restarts every runner** so the new CLI is used immediately — no app reinstall. Returns the new version.
- **`cli-resolver.preferredCliEntry()`**: one shared updated→bundled path-preference helper, used by both the boot block and the post-update re-point (so they can't drift).
- **`RunnerSupervisor.restart()`**: tears down the current runner and loops back to re-resolve + respawn.
- **Settings → About tab**: version + path, an **Update CLI** button with a streaming npm log, spinner/disabled state, a "runner restarting…" note, and a readable "install Node.js to update" message when npm isn't found (the bundled CLI keeps working regardless).

## Notes
- Requires `npm` on PATH to update (graceful error otherwise). All touched packages are private → no changeset.
- Verified: full build 53/53 · typecheck clean · desktop-host tests 43/43 · lint 0 errors. (Actual `npm install` + electron packaging are the runtime/CI verification.)