### PR TITLE
refactor(config): readability & quality cleanup

### DIFF
--- a/packages/config/src/loader.ts
+++ b/packages/config/src/loader.ts
@@ -32,6 +32,8 @@ const USER_CONFIG_NAMES = [
   'config.mjs',
   'config.cjs',
 ];
+// Cap upward filesystem traversal when searching for a project config.
+const MAX_CONFIG_SEARCH_DEPTH = 12;
 
 export async function loadConfig(opts: LoadConfigOptions): Promise<LoadedConfig> {
   const sources: Array<{ scope: 'project' | 'user' | 'explicit'; path: string }> = [];
@@ -98,11 +100,15 @@ async function loadOne(filePath: string): Promise<MoxxyConfig> {
 
 let cachedJiti: ((id: string) => unknown) | null = null;
 
+type JitiFactory = (cwd: string, opts?: unknown) => (id: string) => unknown;
+
 async function getJiti(cwd: string): Promise<((id: string) => unknown) | null> {
   if (cachedJiti) return cachedJiti;
   try {
     const mod = await import('jiti');
-    const factory = (mod as { createJiti?: (cwd: string, opts?: unknown) => (id: string) => unknown; default?: (cwd: string, opts?: unknown) => (id: string) => unknown }).createJiti ?? (mod as { default?: (cwd: string, opts?: unknown) => (id: string) => unknown }).default;
+    const factory =
+      (mod as { createJiti?: JitiFactory; default?: JitiFactory }).createJiti ??
+      (mod as { default?: JitiFactory }).default;
     if (!factory) return null;
     cachedJiti = factory(cwd, { interopDefault: true });
     return cachedJiti;
@@ -121,7 +127,7 @@ function extractDefault(mod: unknown): unknown {
 
 async function findUpward(startDir: string, names: ReadonlyArray<string>): Promise<string | null> {
   let cursor = path.resolve(startDir);
-  for (let i = 0; i < 12; i++) {
+  for (let i = 0; i < MAX_CONFIG_SEARCH_DEPTH; i++) {
     const found = await findFile(cursor, names);
     if (found) return found;
     const parent = path.dirname(cursor);

--- a/packages/config/src/merge.ts
+++ b/packages/config/src/merge.ts
@@ -1,7 +1,7 @@
 import type { MoxxyConfig } from './schema.js';
 
 /**
- * Deep-merge two configs. Later wins on scalars; arrays are concatenated;
+ * Deep-merge any number of configs in order. Later wins on scalars; arrays are concatenated;
  * objects are merged key-by-key.
  *
  * Precedence (highest → lowest): CLI flags → project config → user config → defaults.

--- a/packages/config/src/plugin.ts
+++ b/packages/config/src/plugin.ts
@@ -28,6 +28,9 @@ const scopeSchemaOptional = scopeSchema.optional().default('project');
 
 const USER_YAML = (): string => moxxyPath('config.yaml');
 
+// Cap upward filesystem traversal when searching for a project config.
+const MAX_CONFIG_SEARCH_DEPTH = 12;
+
 async function findScopePath(scope: Scope, cwd: string): Promise<string | null> {
   if (scope === 'user') {
     const yaml = USER_YAML();
@@ -40,7 +43,7 @@ async function findScopePath(scope: Scope, cwd: string): Promise<string | null> 
   }
   // Project scope: walk upward looking for moxxy.config.yaml first, .yml second.
   let cursor = path.resolve(cwd);
-  for (let i = 0; i < 12; i++) {
+  for (let i = 0; i < MAX_CONFIG_SEARCH_DEPTH; i++) {
     for (const name of ['moxxy.config.yaml', 'moxxy.config.yml']) {
       const candidate = path.join(cursor, name);
       try {
@@ -70,10 +73,7 @@ async function readDoc(filePath: string): Promise<{ doc: import('yaml').Document
 
 function parseDotPath(p: string): Array<string | number> {
   if (!p) return [];
-  return p.split('.').map((seg) => {
-    const asNum = /^\d+$/.test(seg) ? Number(seg) : seg;
-    return asNum as string | number;
-  });
+  return p.split('.').map((seg) => (/^\d+$/.test(seg) ? Number(seg) : seg));
 }
 
 function parseValue(raw: string): unknown {


### PR DESCRIPTION
Behavior-preserving readability/quality cleanups, scoped entirely to `packages/config`. No public API, signature, logic, or dependency changes.

## Changes

- **`loader.ts` — name the jiti factory type.** Extracted the triplicated inline factory signature `(cwd: string, opts?: unknown) => (id: string) => unknown` into a module-level `JitiFactory` type alias and reformatted the previously ~250-char single-line cast. Identical inferred type and runtime behavior.
- **`loader.ts` & `plugin.ts` — name the magic depth limit.** Replaced the bare literal `12` (max parent directories to walk) in `findUpward` (loader) and the project-scope walk in `findScopePath` (plugin) with a named `MAX_CONFIG_SEARCH_DEPTH = 12` constant per file. Value and loop behavior unchanged.
- **`plugin.ts` — clean up `parseDotPath`.** Dropped the redundant trailing `as string | number` cast (the ternary already infers `string | number`) and collapsed the map callback to a single expression. Numeric-looking segments still become numbers; everything else stays a string.
- **`merge.ts` — fix misleading docstring.** `mergeConfigs(...configs)` is variadic, so "Deep-merge two configs" was inaccurate; reworded to "Deep-merge any number of configs in order." Merge semantics description is unchanged.

## Verification (all green)

- `pnpm --filter "...@moxxy/config" build` → `packages/config build: Done` (the package compiled cleanly; the only failures in the recursive run were pre-existing, unrelated dependency-ordering errors in other packages outside scope).
- `pnpm --filter @moxxy/config typecheck` → passed.
- `pnpm --filter @moxxy/config test` → 4 files, 29/29 tests passed.
- `pnpm exec eslint packages/config/src/{loader,plugin,merge}.ts` → 0 errors, 0 warnings.