### PR TITLE
refactor(tools-builtin): readability & quality cleanup

### DIFF
--- a/packages/tools-builtin/src/edit.ts
+++ b/packages/tools-builtin/src/edit.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs';
 import { MoxxyError, defineTool, writeFileAtomic, z } from '@moxxy/sdk';
-import { resolveSafe } from './util.js';
+import { resolvePath } from './util.js';
 
 export const editTool = defineTool({
   name: 'Edit',
@@ -25,7 +25,7 @@ export const editTool = defineTool({
     },
   },
   async handler({ file_path, old_string, new_string, replace_all }, ctx) {
-    const resolved = resolveSafe(ctx.cwd, file_path);
+    const resolved = resolvePath(ctx.cwd, file_path);
     // Bail before reading/writing if the turn was already aborted: a partial
     // write here would corrupt the user's file for no benefit.
     if (ctx.signal.aborted) {
@@ -33,8 +33,14 @@ export const editTool = defineTool({
     }
     const original = await fs.readFile(resolved, 'utf8');
     let updated: string;
+    // Number of replace_all occurrences, derived from the same split that
+    // produces `updated` so large files are only split once. -1 when the
+    // single-replacement branch ran (occurrence count is always 1 there).
+    let replaceAllOccurrences = -1;
     if (replace_all) {
-      updated = original.split(old_string).join(new_string);
+      const parts = original.split(old_string);
+      updated = parts.join(new_string);
+      replaceAllOccurrences = parts.length - 1;
       if (updated === original)
         throw new MoxxyError({ code: 'TOOL_ERROR', message: `old_string not found in ${resolved}` });
     } else {
@@ -53,9 +59,7 @@ export const editTool = defineTool({
     // Atomic whole-file write (tmp + rename) so a crash/abort mid-write can't
     // leave a truncated file.
     await writeFileAtomic(resolved, updated);
-    const occurrences = replace_all
-      ? (original.split(old_string).length - 1)
-      : 1;
+    const occurrences = replace_all ? replaceAllOccurrences : 1;
     return `edited ${resolved}: ${occurrences} replacement${occurrences === 1 ? '' : 's'}`;
   },
 });

--- a/packages/tools-builtin/src/glob.ts
+++ b/packages/tools-builtin/src/glob.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { defineTool, z } from '@moxxy/sdk';
-import { clampString, globToRegExp, resolveSafe } from './util.js';
+import { clampString, globToRegExp, IGNORED_DIR_NAMES, resolvePath } from './util.js';
 
 export const globTool = defineTool({
   name: 'Glob',
@@ -25,7 +25,7 @@ export const globTool = defineTool({
     },
   },
   async handler({ pattern, cwd, max }, ctx) {
-    const baseDir = resolveSafe(ctx.cwd, cwd ?? '.');
+    const baseDir = resolvePath(ctx.cwd, cwd ?? '.');
     const matches: string[] = [];
     for await (const entry of fsGlob(baseDir, pattern, ctx.signal)) {
       matches.push(entry);
@@ -79,7 +79,7 @@ async function* walk(
   }
   for (const entry of entries) {
     if (signal.aborted) return;
-    if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === 'dist' || entry.name === '.turbo') continue;
+    if (IGNORED_DIR_NAMES.has(entry.name)) continue;
     const full = path.join(cursor, entry.name);
     let isDir = entry.isDirectory();
     let isFile = entry.isFile();

--- a/packages/tools-builtin/src/grep.ts
+++ b/packages/tools-builtin/src/grep.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { MoxxyError, defineTool, z } from '@moxxy/sdk';
-import { clampString, globToRegExp, resolveSafe } from './util.js';
+import { clampString, globToRegExp, IGNORED_DIR_NAMES, resolvePath } from './util.js';
 
 export const grepTool = defineTool({
   name: 'Grep',
@@ -27,7 +27,7 @@ export const grepTool = defineTool({
     },
   },
   async handler({ pattern, cwd, glob, caseInsensitive, maxMatches }, ctx) {
-    const baseDir = resolveSafe(ctx.cwd, cwd ?? '.');
+    const baseDir = resolvePath(ctx.cwd, cwd ?? '.');
     let re: RegExp;
     try {
       re = new RegExp(pattern, caseInsensitive ? 'i' : '');
@@ -64,7 +64,7 @@ async function walk(
   }
   for (const entry of entries) {
     if (signal.aborted || matches.length >= max) return;
-    if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === 'dist' || entry.name === '.turbo') continue;
+    if (IGNORED_DIR_NAMES.has(entry.name)) continue;
     const full = path.join(cursor, entry.name);
     if (entry.isDirectory()) {
       await walk(root, full, re, fileRe, matches, max, signal);

--- a/packages/tools-builtin/src/read-handler.ts
+++ b/packages/tools-builtin/src/read-handler.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs';
 import type { BrokeredFs } from '@moxxy/sdk';
-import { clampString, resolveSafe } from './util.js';
+import { clampString, resolvePath } from './util.js';
 
 /**
  * Pure handler module for the Read tool. Lives in its own file so the
@@ -25,7 +25,7 @@ export interface ReadCtxLike {
 
 export async function readHandler(input: ReadInput, ctx: ReadCtxLike): Promise<string> {
   const { file_path, offset = 0, limit = 2000 } = input;
-  const resolved = resolveSafe(ctx.cwd, file_path);
+  const resolved = resolvePath(ctx.cwd, file_path);
   // Use the brokered fs when the isolator provides one. The broker
   // re-validates the path against the tool's declared `caps.fs.read`
   // on the parent side, so reads outside the cap are denied at the

--- a/packages/tools-builtin/src/util.ts
+++ b/packages/tools-builtin/src/util.ts
@@ -41,6 +41,13 @@ export function resolveWithinCwd(cwd: string, target: string): string {
  */
 export const resolveSafe = resolvePath;
 
+/**
+ * Directory names skipped during recursive traversal by the Glob and Grep
+ * tools — build outputs and VCS metadata that are never useful search targets.
+ * Kept in one place so the two walkers stay in sync.
+ */
+export const IGNORED_DIR_NAMES = new Set(['node_modules', '.git', 'dist', '.turbo']);
+
 export function clampString(s: string, max: number): string {
   if (s.length <= max) return s;
   return s.slice(0, max) + `\n... [truncated ${s.length - max} chars]`;

--- a/packages/tools-builtin/src/write.ts
+++ b/packages/tools-builtin/src/write.ts
@@ -1,5 +1,5 @@
 import { MoxxyError, defineTool, writeFileAtomic, z } from '@moxxy/sdk';
-import { resolveSafe } from './util.js';
+import { resolvePath } from './util.js';
 
 export const writeTool = defineTool({
   name: 'Write',
@@ -22,7 +22,7 @@ export const writeTool = defineTool({
     },
   },
   async handler({ file_path, content }, ctx) {
-    const resolved = resolveSafe(ctx.cwd, file_path);
+    const resolved = resolvePath(ctx.cwd, file_path);
     // Bail before touching disk if the turn was already aborted: a partial
     // write here would corrupt the user's file for no benefit.
     if (ctx.signal.aborted) {


### PR DESCRIPTION
## Summary

Three behavior-preserving readability/quality cleanups, scoped entirely to `packages/tools-builtin`. No public API/signature changes, no logic changes, no dependency changes, no test-expectation changes.

- **Dedupe the identical ignored-directory conditional in Grep and Glob via a named constant.** `grep.ts` and `glob.ts` each contained a byte-for-byte identical `if (entry.name === 'node_modules' || ... === '.turbo') continue;`, duplicating four magic strings and the skip logic. Extracted `export const IGNORED_DIR_NAMES = new Set([...])` into `util.ts` and replaced both conditionals with `if (IGNORED_DIR_NAMES.has(entry.name)) continue;`. The intent (skip build/VCS dirs during traversal) is now named and the list lives in one place.
- **Stop internal callers from using the package's own `@deprecated` `resolveSafe` alias.** `util.ts` marks `resolveSafe` as deprecated ("Use `resolvePath` ... kept as a thin alias so external callers still compile"), yet all five internal handlers imported and called it. Switched `read-handler.ts`, `grep.ts`, `glob.ts`, `edit.ts`, and `write.ts` to import/call the canonical `resolvePath`. Since `resolveSafe` is literally `export const resolveSafe = resolvePath`, the references are an exact rename. The exported alias and its backward-compat test in `index.test.ts` are left untouched, so external callers and the public API are unaffected.
- **Avoid splitting the file contents twice when counting `replace_all` occurrences in Edit.** The handler computed `original.split(old_string).join(new_string)` and then separately recomputed `original.split(old_string).length - 1` for the count. Captured the split once into `parts` and derived both the updated string and the count from it. Result is identical, just computed once.

All changes are behavior-preserving.

## Verification (all green)

- `pnpm --filter @moxxy/tools-builtin build` — Done, no errors
- `pnpm --filter @moxxy/tools-builtin typecheck` — `tsc --noEmit` clean
- `pnpm --filter @moxxy/tools-builtin test` — Test Files 2 passed (2), Tests 26 passed (26), including the `resolveSafe` backward-compat alias test
- `pnpm exec eslint` on all six changed files — exit 0, 0 errors (no warnings)