### PR TITLE
refactor(chat-model): readability & quality cleanup

### DIFF
--- a/packages/chat-model/src/format.ts
+++ b/packages/chat-model/src/format.ts
@@ -37,10 +37,14 @@ export function formatElapsed(ms: number): string {
 // event log if anyone wants the gory detail.
 const ARG_SUMMARY_MAX = 90;
 const VALUE_MAX = 28;
+// Cap for a top-level string argument (the whole input is one string).
+const STRING_ARG_MAX = 60;
+// Cap for the one-line preview of the latest call in a live-tools block.
+const PREVIEW_LINE_MAX = 100;
 
 export function summarizeArgs(input: unknown): string {
   if (input == null) return '';
-  if (typeof input === 'string') return truncate(oneLine(input), 60);
+  if (typeof input === 'string') return truncate(oneLine(input), STRING_ARG_MAX);
   if (typeof input !== 'object') return String(input);
   const entries = Object.entries(input as Record<string, unknown>);
   if (entries.length === 0) return '';
@@ -131,7 +135,7 @@ export function compactPreviewLine(call: LiveToolCall): string {
   if (key) {
     const input = call.request.input as Record<string, unknown> | null;
     const v = input?.[key];
-    if (typeof v === 'string') return truncate(oneLine(v), 100);
+    if (typeof v === 'string') return truncate(oneLine(v), PREVIEW_LINE_MAX);
   }
   return summarizeArgs(call.request.input);
 }

--- a/packages/chat-model/src/markdown/parse-blocks.ts
+++ b/packages/chat-model/src/markdown/parse-blocks.ts
@@ -140,13 +140,18 @@ function isTableSeparator(line: string): boolean {
   return /^\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?$/.test(trimmed);
 }
 
+function stripOuterPipes(s: string): string {
+  return s.trim().replace(/^\|/, '').replace(/\|$/, '');
+}
+
 function parseTableCells(line: string): string[] {
-  const trimmed = line.trim().replace(/^\|/, '').replace(/\|$/, '');
-  return trimmed.split('|').map((s) => s.trim());
+  return stripOuterPipes(line)
+    .split('|')
+    .map((s) => s.trim());
 }
 
 function parseTableAligns(sep: string): Align[] {
-  const cells = sep.trim().replace(/^\|/, '').replace(/\|$/, '').split('|');
+  const cells = stripOuterPipes(sep).split('|');
   return cells.map((c) => {
     const t = c.trim();
     const left = t.startsWith(':');

--- a/packages/chat-model/src/pair-events.ts
+++ b/packages/chat-model/src/pair-events.ts
@@ -1,4 +1,4 @@
-import type { MoxxyEvent, ToolCompactPresentation } from '@moxxy/sdk';
+import type { MoxxyEvent, PluginEvent, ToolCompactPresentation } from '@moxxy/sdk';
 import type {
   Block,
   LiveToolBlockData,
@@ -10,6 +10,67 @@ import type {
 import { oneLine } from './format.js';
 
 const SUBAGENT_PLUGIN_ID = '@moxxy/subagents';
+
+/**
+ * Fold a subagent `plugin_event` into the `subagents` map / `root` array.
+ * Subagent events render as one-line scope blocks so a fleet of children
+ * doesn't drown the main chat. Subagents always live at the top level — a
+ * spawned agent is a first-class actor, not a child of whatever skill
+ * spawned it — so this only ever pushes to `root` (never the open scope).
+ */
+function handleSubagentEvent(
+  e: PluginEvent,
+  subagents: Map<string, SubagentBlock>,
+  root: Block[],
+): void {
+  const payload = (e.payload ?? {}) as Record<string, unknown>;
+  const childSessionId = String(payload.childSessionId ?? '');
+  if (!childSessionId) return;
+  if (e.subtype === 'subagent_started') {
+    const block: SubagentBlock = {
+      kind: 'subagent',
+      id: e.id,
+      childSessionId,
+      label: String(payload.label ?? 'agent'),
+      startedAtMs: new Date(e.ts).getTime(),
+      completedAtMs: null,
+      toolCallCount: 0,
+      toolCalls: [],
+      stopReason: null,
+      finalPreview: null,
+      error: null,
+    };
+    subagents.set(childSessionId, block);
+    root.push(block);
+    return;
+  }
+  const block = subagents.get(childSessionId);
+  if (!block) return;
+  if (e.subtype === 'subagent_tool_call') {
+    block.toolCallCount += 1;
+    block.toolCalls.push({ name: String(payload.name ?? 'tool'), input: payload.input });
+    return;
+  }
+  if (e.subtype === 'subagent_completed') {
+    block.completedAtMs = new Date(e.ts).getTime();
+    block.stopReason = String(payload.stopReason ?? '');
+    const text = typeof payload.text === 'string' ? payload.text : '';
+    if (text) block.finalPreview = oneLine(text);
+    if (typeof payload.error === 'string') block.error = payload.error;
+    return;
+  }
+  if (e.subtype === 'subagent_error' || e.subtype === 'subagent_abort') {
+    block.completedAtMs = new Date(e.ts).getTime();
+    const reason =
+      (typeof payload.message === 'string' && payload.message) ||
+      (typeof payload.reason === 'string' && payload.reason) ||
+      'aborted';
+    block.error = reason;
+    return;
+  }
+  // chunk / tool_result / nested-grand-child: ignore at top level;
+  // the /agents modal exposes the raw stream when needed.
+}
 
 /**
  * Map of tool name → compact presentation metadata. Tool registries
@@ -229,56 +290,7 @@ export function pairToolEvents(
     // children doesn't drown the main chat. The SubagentSpawner emits
     // them as plugin_event with pluginId='@moxxy/subagents'.
     if (e.type === 'plugin_event' && e.pluginId === SUBAGENT_PLUGIN_ID) {
-      const payload = (e.payload ?? {}) as Record<string, unknown>;
-      const childSessionId = String(payload.childSessionId ?? '');
-      if (!childSessionId) continue;
-      if (e.subtype === 'subagent_started') {
-        const block: SubagentBlock = {
-          kind: 'subagent',
-          id: e.id,
-          childSessionId,
-          label: String(payload.label ?? 'agent'),
-          startedAtMs: new Date(e.ts).getTime(),
-          completedAtMs: null,
-          toolCallCount: 0,
-          toolCalls: [],
-          stopReason: null,
-          finalPreview: null,
-          error: null,
-        };
-        subagents.set(childSessionId, block);
-        // Subagents always render at the top level — a spawned agent is a
-        // first-class actor, not a child of whatever skill spawned it.
-        // Pushing to root (not pushBlock) keeps it out of the skill scope.
-        root.push(block);
-        continue;
-      }
-      const block = subagents.get(childSessionId);
-      if (!block) continue;
-      if (e.subtype === 'subagent_tool_call') {
-        block.toolCallCount += 1;
-        block.toolCalls.push({ name: String(payload.name ?? 'tool'), input: payload.input });
-        continue;
-      }
-      if (e.subtype === 'subagent_completed') {
-        block.completedAtMs = new Date(e.ts).getTime();
-        block.stopReason = String(payload.stopReason ?? '');
-        const text = typeof payload.text === 'string' ? payload.text : '';
-        if (text) block.finalPreview = oneLine(text);
-        if (typeof payload.error === 'string') block.error = payload.error;
-        continue;
-      }
-      if (e.subtype === 'subagent_error' || e.subtype === 'subagent_abort') {
-        block.completedAtMs = new Date(e.ts).getTime();
-        const reason =
-          (typeof payload.message === 'string' && payload.message) ||
-          (typeof payload.reason === 'string' && payload.reason) ||
-          'aborted';
-        block.error = reason;
-        continue;
-      }
-      // chunk / tool_result / nested-grand-child: ignore at top level;
-      // the /agents modal exposes the raw stream when needed.
+      handleSubagentEvent(e, subagents, root);
       continue;
     }
     pushBlock({ kind: 'event', id: e.id, event: e });


### PR DESCRIPTION
Three behavior-preserving readability improvements scoped entirely to `packages/chat-model`. No public API/signature, logic, dependency, or test-expectation changes.

## Changes

- **format.ts — name the two remaining truncation magic numbers.** The cap widths `ARG_SUMMARY_MAX` (90) and `VALUE_MAX` (28) were already hoisted into named constants, but two sibling limits stayed as bare literals. Introduced `STRING_ARG_MAX = 60` (top-level string arg in `summarizeArgs`) and `PREVIEW_LINE_MAX = 100` (one-line preview in `compactPreviewLine`) next to the existing ones and referenced them at those call sites. Numeric values unchanged, so output is identical.

- **markdown/parse-blocks.ts — dedupe outer-pipe stripping.** `parseTableCells` and `parseTableAligns` both performed the identical `trim` + `.replace(/^\|/, '').replace(/\|$/, '')` step. Extracted a tiny `stripOuterPipes()` helper and called it from both. The regexes are non-global, so there is no shared-state hazard; behavior is identical.

- **pair-events.ts — extract the subagent-event branch out of the oversized `pairToolEvents`.** The self-contained `plugin_event`/subagent branch (~50 lines) was moved into a focused module-level `handleSubagentEvent(e, subagents, root)` helper (its internal `continue`s became `return`s) and called from the loop. This shortens and clarifies the main event-folding loop without changing in-place mutation semantics or any output; it does not interact with `openScope`/`openLive`/`callTargets`.

## Verification (all green)

- `pnpm --filter @moxxy/chat-model build` — clean (tsc, no errors)
- `pnpm --filter @moxxy/chat-model typecheck` — clean (tsc --noEmit, no errors)
- `pnpm --filter @moxxy/chat-model test` — 2 files, 34 tests passed
- `pnpm exec eslint src/format.ts src/markdown/parse-blocks.ts src/pair-events.ts` — 0 errors, 0 warnings

Note: the broader `pnpm --filter "...@moxxy/chat-model" build` turbo run fails on unrelated upstream packages (`apps/desktop`, `plugin-cli`) in a fresh worktree checkout; that failure pre-exists on `main` and is independent of this change. The `@moxxy/chat-model` package and its real dependency (`@moxxy/sdk`) build cleanly.