### PR TITLE
refactor(plugin-memory): readability & quality cleanup

### DIFF
--- a/packages/plugin-memory/src/consolidate.ts
+++ b/packages/plugin-memory/src/consolidate.ts
@@ -218,7 +218,8 @@ export async function consolidateMemory(
 }
 
 function extractJson(text: string): unknown {
-  // Find the first {...} block in the response. Some providers wrap in ```json ... ```.
+  // Take the span from the first `{` to the last `}` in the response. Some
+  // providers wrap the object in ```json ... ```, which we strip first.
   const fenced = /```(?:json)?\n?([\s\S]*?)```/.exec(text);
   const candidate = fenced ? fenced[1]! : text;
   const start = candidate.indexOf('{');

--- a/packages/plugin-memory/src/embedding-cache.ts
+++ b/packages/plugin-memory/src/embedding-cache.ts
@@ -63,7 +63,7 @@ export class EmbeddingIndex {
   }
 
   /**
-   * For each `(name, body)` pair, return either the cached vector (if the body
+   * For a `(name, body)` pair, return either the cached vector (if the body
    * hash matches) or `null` (miss). Callers re-embed the misses and call
    * `set()` with the fresh vectors.
    */

--- a/packages/plugin-memory/src/parse.ts
+++ b/packages/plugin-memory/src/parse.ts
@@ -2,6 +2,8 @@
 // @moxxy/core dependency). Mirrors packages/core/src/skills/parse.ts.
 
 const FRONTMATTER_FENCE = '---';
+const OPENING_FENCE_LF = FRONTMATTER_FENCE + '\n';
+const OPENING_FENCE_CRLF = FRONTMATTER_FENCE + '\r\n';
 
 export interface ParsedFile {
   frontmatter: Record<string, unknown>;
@@ -9,10 +11,10 @@ export interface ParsedFile {
 }
 
 export function parseMdFile(content: string): ParsedFile {
-  if (!content.startsWith(FRONTMATTER_FENCE + '\n') && !content.startsWith(FRONTMATTER_FENCE + '\r\n')) {
+  if (!content.startsWith(OPENING_FENCE_LF) && !content.startsWith(OPENING_FENCE_CRLF)) {
     return { frontmatter: {}, body: content };
   }
-  const fenceLen = content.startsWith(FRONTMATTER_FENCE + '\r\n') ? 5 : 4;
+  const fenceLen = content.startsWith(OPENING_FENCE_CRLF) ? OPENING_FENCE_CRLF.length : OPENING_FENCE_LF.length;
   const rest = content.slice(fenceLen);
   const m = /\r?\n---(?:\r?\n|$)/.exec(rest);
   if (!m) return { frontmatter: {}, body: content };

--- a/packages/plugin-memory/src/store/search.ts
+++ b/packages/plugin-memory/src/store/search.ts
@@ -21,9 +21,7 @@ export async function recallVector(
   // TF-IDF special-cases the persistent cache (vocab is corpus-wide).
   if (embedder instanceof TfIdfEmbedder) {
     embedder.fit([...corpus, query]);
-    const vectors = await embedder.embed([...corpus, query]);
-    const queryVec = vectors[vectors.length - 1]!;
-    return rankCosine(all, vectors.slice(0, all.length), queryVec, limit);
+    return rankAllFresh(all, corpus, query, limit, embedder);
   }
 
   // Neural embedders: consult the persistent cache, only embed misses + query.
@@ -46,14 +44,20 @@ export async function recallVector(
       const toEmbed = [...misses.map((m) => m.text), query];
       const fresh = await embedder.embed(toEmbed);
       const qVec = fresh[queryIdx]!;
+      // Map each missed corpus index to its freshly-embedded vector so the
+      // stitch loop below stays O(1) per entry instead of scanning `misses`.
+      const freshByEntryIndex = new Map<number, ReadonlyArray<number>>();
+      for (const [j, m] of misses.entries()) {
+        freshByEntryIndex.set(m.index, fresh[j]!);
+      }
       // Stitch results: cached + freshly-embedded
       const vecs: ReadonlyArray<number>[] = [];
       for (let i = 0; i < all.length; i++) {
-        vecs.push(cached[i] ?? fresh[misses.findIndex((m) => m.index === i)]!);
+        vecs.push(cached[i] ?? freshByEntryIndex.get(i)!);
       }
       // Persist fresh vectors
-      for (const m of misses) {
-        index.set(all[m.index]!.frontmatter.name, m.text, fresh[misses.indexOf(m)]!);
+      for (const [j, m] of misses.entries()) {
+        index.set(all[m.index]!.frontmatter.name, m.text, fresh[j]!);
       }
       index.prune(all.map((e) => e.frontmatter.name));
       await index.flush();
@@ -63,6 +67,18 @@ export async function recallVector(
   }
 
   // No cache configured — embed everything every time.
+  return rankAllFresh(all, corpus, query, limit, embedder);
+}
+
+// Embed `[...corpus, query]` in one batch, then cosine-rank the corpus against
+// the (last) query vector. Shared by the TF-IDF and no-cache branches.
+async function rankAllFresh(
+  all: ReadonlyArray<MemoryEntry>,
+  corpus: ReadonlyArray<string>,
+  query: string,
+  limit: number,
+  embedder: EmbeddingProvider,
+): Promise<ReadonlyArray<RankedMemory>> {
   const vectors = await embedder.embed([...corpus, query]);
   const queryVec = vectors[vectors.length - 1]!;
   return rankCosine(all, vectors.slice(0, all.length), queryVec, limit);


### PR DESCRIPTION
Behavior-preserving readability and quality cleanups scoped entirely to `packages/plugin-memory`. No public API/signature changes, no logic/behavior changes, no dependency changes, no test changes.

## Changes

- **parse.ts — name the frontmatter fence-length magic numbers.** Introduced `OPENING_FENCE_LF` / `OPENING_FENCE_CRLF` constants and replaced the `startsWith` checks plus the `fenceLen = ... ? 5 : 4` ternary with `OPENING_FENCE_CRLF.length` / `OPENING_FENCE_LF.length`. Self-documenting and stays correct if the fence ever changes.

- **store/search.ts — replace O(n) findIndex/indexOf scans in vector-recall miss stitching.** Built a `freshByEntryIndex` map (entry corpus index -> fresh vector) for the stitch loop and switched the persist loop to `for (const [j, m] of misses.entries())` using `fresh[j]`. Same output (`fresh[j]` is the vector for `misses[j]`), no longer quadratic in the miss count.

- **store/search.ts — dedupe the two identical embed-all-then-rank blocks.** The TF-IDF branch and the no-cache branch each embedded `[...corpus, query]`, took the last vector as the query vector, and `rankCosine`'d the corpus slice. Extracted a private async `rankAllFresh(all, corpus, query, limit, embedder)` helper called from both sites (TF-IDF still calls `embedder.fit(...)` first). Pure dedupe.

- **consolidate.ts — fix misleading extractJson comment.** The comment claimed it finds "the first `{...}` block", but the code takes the span from the first `{` to the **last** `}` after optionally stripping a ```json fence. Reworded to match the actual behavior.

- **embedding-cache.ts — fix misleading EmbeddingIndex.lookup docstring.** Changed "For each `(name, body)` pair..." to "For a `(name, body)` pair..." to match the single-pair signature returning one vector-or-null.

## Verification (all green)

- `pnpm turbo run build --filter=@moxxy/plugin-memory` — 2 successful, 2 total
- `pnpm --filter @moxxy/plugin-memory typecheck` — clean
- `pnpm --filter @moxxy/plugin-memory test` — 7 files, 53 tests passed
- `pnpm exec eslint <each changed file>` — exit 0, 0 errors, 0 warnings