### PR TITLE
refactor(runner): readability & quality cleanup

### DIFF
--- a/packages/runner/src/remote-session.ts
+++ b/packages/runner/src/remote-session.ts
@@ -405,8 +405,7 @@ export class RemoteSession implements ClientSession {
 
   private makeTranscribersView(): TranscribersClientView {
     // Transcription is a server-side capability; a thin client routes audio
-    // through runTurn attachments instead. Report "none" so voice degrades
-    // gracefully rather than pretending to have a local backend.
+    // through runTurn attachments instead.
     // When the runner has an active transcriber, expose a proxy whose
     // transcribe() ships the audio to the runner over the `transcribe` RPC.
     // Channel code (`tryGetActive()?.transcribe(bytes)`) is unchanged - audio
@@ -733,14 +732,14 @@ async function unlinkSocket(socketPath: string): Promise<void> {
 }
 
 /** Connect, retrying with linear backoff to ride over a brief runner hiccup. */
-async function connectWithRetry(socketPath: string, attempts: number): Promise<Transport> {
+async function connectWithRetry(socketPath: string, retries: number): Promise<Transport> {
   let lastErr: unknown;
-  for (let i = 0; i <= attempts; i++) {
+  for (let i = 0; i <= retries; i++) {
     try {
       return await connectUnixSocket(socketPath);
     } catch (err) {
       lastErr = err;
-      if (i < attempts) await new Promise((r) => setTimeout(r, 100 * (i + 1)));
+      if (i < retries) await new Promise((r) => setTimeout(r, 100 * (i + 1)));
     }
   }
   throw lastErr;

--- a/packages/runner/src/server.ts
+++ b/packages/runner/src/server.ts
@@ -135,7 +135,7 @@ export class RunnerServer {
     peer.handle(RunnerMethod.ModeSetActive, (raw) => this.handleModeSetActive(raw));
     peer.handle(RunnerMethod.ProviderSetActive, (raw) => this.handleProviderSetActive(raw));
     peer.handle(RunnerMethod.PermissionAddAllow, (raw) => this.handlePermissionAddAllow(raw));
-    peer.handle(RunnerMethod.CommandRun, (raw) => this.handleCommandRun(client, raw));
+    peer.handle(RunnerMethod.CommandRun, (raw) => this.handleCommandRun(raw));
     peer.handle(RunnerMethod.Transcribe, (raw) => this.handleTranscribe(raw));
     peer.handle(RunnerMethod.McpListServers, () => this.handleMcpListServers());
     peer.handle(RunnerMethod.McpEnableAndAttach, (raw) =>
@@ -255,11 +255,7 @@ export class RunnerServer {
     const { name, config } = providerSetActiveParamsSchema.parse(raw);
     // Mirror the in-process picker: resolve credentials (the CLI stashes a
     // resolver on the session at boot), drop any cached instance, re-activate.
-    const resolver = (
-      this.session as unknown as {
-        credentialResolver?: (n: string) => Promise<Record<string, unknown>>;
-      }
-    ).credentialResolver;
+    const resolver = this.session.credentialResolver;
     const cfg = config ?? (resolver ? await resolver(name) : {});
     const def = this.session.providers.list().find((p) => p.name === name);
     if (def) this.session.providers.replace(def);
@@ -274,14 +270,10 @@ export class RunnerServer {
     return {};
   }
 
-  private async handleCommandRun(
-    client: ConnectedClient,
-    raw: unknown,
-  ): Promise<CommandRunResult> {
+  private async handleCommandRun(raw: unknown): Promise<CommandRunResult> {
     const { name, args, channel } = commandRunParamsSchema.parse(raw);
     const cmd = this.session.commands.get(name);
     if (!cmd) return { kind: 'error', message: `unknown command: /${name}` };
-    void client;
     const result = await cmd.handler({
       channel,
       sessionId: this.session.id,
@@ -310,9 +302,9 @@ export class RunnerServer {
     const candidates = this.transcribeCandidates();
     if (candidates.length === 0) throw new Error('no active transcriber on the runner');
     let lastErr: unknown = new Error('no active transcriber on the runner');
-    for (const def of candidates) {
+    for (const name of candidates) {
       try {
-        const transcriber = this.session.transcribers.setActive(def.name);
+        const transcriber = this.session.transcribers.setActive(name);
         const result = await transcriber.transcribe(audio, opts);
         // Surface the change so remote clients observe activeTranscriber
         // tracking the one that actually worked.
@@ -329,15 +321,11 @@ export class RunnerServer {
    *  - First the active one (if any) — respects an explicit host /
    *    user choice.
    *  - Then every other registered transcriber. */
-  private transcribeCandidates(): ReadonlyArray<{ readonly name: string }> {
+  private transcribeCandidates(): ReadonlyArray<string> {
     const activeName = this.session.transcribers.getActiveName();
-    const all = this.session.transcribers.list();
-    if (!activeName) return all.map((d) => ({ name: d.name }));
-    const head = all.find((d) => d.name === activeName);
-    const tail = all.filter((d) => d.name !== activeName);
-    return head
-      ? [{ name: head.name }, ...tail.map((d) => ({ name: d.name }))]
-      : tail.map((d) => ({ name: d.name }));
+    const names = this.session.transcribers.list().map((d) => d.name);
+    if (!activeName || !names.includes(activeName)) return names;
+    return [activeName, ...names.filter((n) => n !== activeName)];
   }
 
   // --- MCP (delegates to session.mcpAdmin if the plugin is loaded) ----------


### PR DESCRIPTION
Behavior-preserving readability and quality cleanups, scoped entirely to `packages/runner`.

## Changes

- **Remove unsafe `as unknown as` cast on `Session.credentialResolver`** (`server.ts`, `handleProviderSetActive`). The core `Session` publicly declares `credentialResolver?: CredentialResolver` where `CredentialResolver = (providerName: string) => Promise<Record<string, unknown>>`, which is exactly the inline cast's shape. Replaced the cast with a direct, type-checked `const resolver = this.session.credentialResolver;`. This matches the explicit intent stated in `core/session.ts` (these fields are declared "rather than monkey-patched on via `as unknown as` — so the host and channels get type-checked access").

- **Simplify `transcribeCandidates` to a names array** (`server.ts`). Changed the return type from `ReadonlyArray<{ readonly name: string }>` to `ReadonlyArray<string>`, removing the repeated `.map((d) => ({ name: d.name }))` wrapping. The single caller only read `.name`. Ordering (active first, then the rest) and the "active name not in the registered list → return the full list" branch are preserved via `!names.includes(activeName)`. Caller loop updated to iterate names.

- **Remove the unused `client` parameter from `handleCommandRun`** (`server.ts`). The parameter was only discarded via `void client;`. Dropped the parameter and the `void` line, and updated the single registration site. Private method — no public API change.

- **Fix stale/misleading comment in `makeTranscribersView`** (`remote-session.ts`). Removed the contradictory 'Report "none"…' sentence describing superseded behavior; the actual implementation returns the active transcriber name and a working proxy, which the remaining comment block already describes accurately. Comment-only.

- **Rename `connectWithRetry`'s misleading `attempts` parameter to `retries`** (`remote-session.ts`). The loop runs `for (let i = 0; i <= attempts; i++)` (i.e. retries + 1 attempts) and is fed by the `connectRetries` option ("Retry the initial connect this many times"). Renamed the local parameter to `retries` to match both the loop semantics and the public option name. Local rename; no behavior change.

All changes are behavior-preserving: no public API/signature changes, no logic changes, no dependency or test-expectation changes.

## Verification (all green)

- `turbo run build --filter=@moxxy/runner` — 5/5 tasks successful
- `turbo run typecheck --filter=@moxxy/runner` — 5/5 tasks successful
- `turbo run test --filter=@moxxy/runner` — 31 passed (4 test files)
- `eslint packages/runner/src/server.ts packages/runner/src/remote-session.ts` — exit 0, 0 errors / 0 warnings