### PR TITLE
refactor(core): readability & quality cleanup

### DIFF
--- a/packages/core/src/plugins/discovery.ts
+++ b/packages/core/src/plugins/discovery.ts
@@ -3,6 +3,13 @@ import * as path from 'node:path';
 import { moxxyPackageSchema, type ResolvedPluginManifest } from '@moxxy/sdk';
 import type { Logger } from '../logger.js';
 
+/**
+ * Maximum number of directory levels to climb when collecting `node_modules`
+ * roots from the cwd upward. Bounds the walk so discovery never traverses all
+ * the way to the filesystem root on a deeply-nested cwd.
+ */
+const MAX_NODE_MODULES_WALK_DEPTH = 8;
+
 export interface DiscoveryOptions {
   readonly cwd: string;
   readonly logger: Logger;
@@ -37,7 +44,7 @@ export async function discoverPlugins(opts: DiscoveryOptions): Promise<ReadonlyA
 async function candidateRoots(cwd: string): Promise<string[]> {
   const out: string[] = [];
   let cursor = path.resolve(cwd);
-  for (let i = 0; i < 8; i++) {
+  for (let i = 0; i < MAX_NODE_MODULES_WALK_DEPTH; i++) {
     out.push(path.join(cursor, 'node_modules'));
     const parent = path.dirname(cursor);
     if (parent === cursor) break;

--- a/packages/core/src/plugins/host.ts
+++ b/packages/core/src/plugins/host.ts
@@ -277,7 +277,7 @@ export class PluginHost implements PluginHostHandle {
   private applyPlugin(plugin: Plugin, manifest?: ResolvedPluginManifest): LoadedRecord {
     const toolNames = (plugin.tools ?? []).map((t: ToolDef) => t.name);
     const providerNames = (plugin.providers ?? []).map((p: ProviderDef) => p.name);
-    const modeNames = (plugin.modes ?? []).map((l: ModeDef) => l.name);
+    const modeNames = (plugin.modes ?? []).map((m: ModeDef) => m.name);
     const compactorNames = (plugin.compactors ?? []).map((c: CompactorDef) => c.name);
     const cacheStrategyNames = (plugin.cacheStrategies ?? []).map((c: CacheStrategyDef) => c.name);
     const viewRendererNames = (plugin.viewRenderers ?? []).map((v: ViewRendererDef) => v.name);
@@ -294,7 +294,7 @@ export class PluginHost implements PluginHostHandle {
 
     for (const tool of plugin.tools ?? []) this.opts.tools.register(tool);
     for (const provider of plugin.providers ?? []) this.opts.providers.register(provider);
-    for (const loop of plugin.modes ?? []) this.opts.modes.register(loop);
+    for (const mode of plugin.modes ?? []) this.opts.modes.register(mode);
     for (const compactor of plugin.compactors ?? []) this.opts.compactors.register(compactor);
     for (const cacheStrategy of plugin.cacheStrategies ?? [])
       this.opts.cacheStrategies.register(cacheStrategy);

--- a/packages/core/src/registries/modes.ts
+++ b/packages/core/src/registries/modes.ts
@@ -1,7 +1,7 @@
 import type { ModeDef } from '@moxxy/sdk';
 
 export class ModeRegistry {
-  private readonly strategies = new Map<string, ModeDef>();
+  private readonly modes = new Map<string, ModeDef>();
   private active: string | null = null;
   private readonly changeListeners = new Set<() => void>();
 
@@ -14,53 +14,53 @@ export class ModeRegistry {
   }
 
   /**
-   * Register a strategy. Throws on duplicate — use `replace()` for
+   * Register a mode. Throws on duplicate — use `replace()` for
    * overwrite. Auto-activates on first registration (modes need a default
    * for any session to work).
    */
-  register(strategy: ModeDef): void {
-    if (this.strategies.has(strategy.name)) {
-      throw new Error(`Mode already registered: ${strategy.name}`);
+  register(mode: ModeDef): void {
+    if (this.modes.has(mode.name)) {
+      throw new Error(`Mode already registered: ${mode.name}`);
     }
-    this.strategies.set(strategy.name, strategy);
-    if (!this.active) this.activate(strategy);
+    this.modes.set(mode.name, mode);
+    if (!this.active) this.activate(mode);
   }
 
-  replace(strategy: ModeDef): void {
-    this.strategies.set(strategy.name, strategy);
-    if (!this.active) this.activate(strategy);
+  replace(mode: ModeDef): void {
+    this.modes.set(mode.name, mode);
+    if (!this.active) this.activate(mode);
   }
 
   /**
-   * Remove a strategy. If it was active, the active slot is cleared —
+   * Remove a mode. If it was active, the active slot is cleared —
    * callers must `setActive()` explicitly rather than silently picking
-   * some arbitrary "next" strategy.
+   * some arbitrary "next" mode.
    */
   unregister(name: string): void {
-    this.strategies.delete(name);
+    this.modes.delete(name);
     if (this.active === name) this.active = null;
   }
 
   list(): ReadonlyArray<ModeDef> {
-    return [...this.strategies.values()];
+    return [...this.modes.values()];
   }
 
   setActive(name: string): void {
-    const strategy = this.strategies.get(name);
-    if (!strategy) throw new Error(`Mode not registered: ${name}`);
-    this.activate(strategy);
+    const mode = this.modes.get(name);
+    if (!mode) throw new Error(`Mode not registered: ${name}`);
+    this.activate(mode);
   }
 
   getActive(): ModeDef {
     if (!this.active) throw new Error('No active mode registered.');
-    const s = this.strategies.get(this.active);
-    if (!s) throw new Error(`Active mode missing: ${this.active}`);
-    return s;
+    const mode = this.modes.get(this.active);
+    if (!mode) throw new Error(`Active mode missing: ${this.active}`);
+    return mode;
   }
 
-  private activate(strategy: ModeDef): void {
-    if (this.active === strategy.name) return;
-    this.active = strategy.name;
+  private activate(mode: ModeDef): void {
+    if (this.active === mode.name) return;
+    this.active = mode.name;
     for (const fn of this.changeListeners) fn();
   }
 }

--- a/packages/core/src/requirements.ts
+++ b/packages/core/src/requirements.ts
@@ -165,7 +165,7 @@ export class RequirementRegistry {
           : null;
       }
       case 'mode': {
-        const def = this.opts.modes.list().find((l) => l.name === name);
+        const def = this.opts.modes.list().find((m) => m.name === name);
         return def ? { kind, name, active: activeModeName(this.opts.modes) === name } : null;
       }
       case 'compactor': {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -360,11 +360,10 @@ export class Session implements ClientSession, SessionRuntime {
  * `~/.moxxy/permissions.json`, that decision short-circuits the
  * resolver's prompt path. Otherwise the resolver runs as usual.
  *
- * The wrapper preserves the original resolver's identity for
- * `instanceof`-style checks (e.g. `abortAll` on the deferred resolver)
- * by re-exposing every property via Proxy — wait, simpler: we proxy
- * just `check`. Callers that need the underlying resolver's methods
- * still reach them via the prototype chain we copy in.
+ * The wrapper is a Proxy that intercepts only `check`; every other
+ * property (e.g. `abortAll` and any channel-specific helpers) passes
+ * straight through to the underlying resolver, so callers reach those
+ * methods exactly as before.
  */
 function wrapWithPolicy(
   inner: PermissionResolver,

--- a/packages/core/src/skills/loader.ts
+++ b/packages/core/src/skills/loader.ts
@@ -18,11 +18,10 @@ export interface DiscoveredSkill extends Skill {
 }
 
 export async function discoverSkills(opts: SkillLoadOptions = {}): Promise<ReadonlyArray<DiscoveredSkill>> {
-  const home = os.homedir();
   const sources: Array<{ dir: string; scope: SkillScope }> = [];
   if (opts.builtinDir) sources.push({ dir: opts.builtinDir, scope: 'builtin' });
   for (const dir of opts.pluginDirs ?? []) sources.push({ dir, scope: 'plugin' });
-  const userDir = opts.userDir ?? path.join(home, '.moxxy', 'skills');
+  const userDir = opts.userDir ?? defaultUserSkillsDir();
   sources.push({ dir: userDir, scope: 'user' });
   if (opts.projectDir) sources.push({ dir: opts.projectDir, scope: 'project' });
 


### PR DESCRIPTION
Behavior-preserving readability and quality cleanups, scoped entirely to `packages/core`. No public API/signature changes, no logic changes, no dependency changes, no test changes.

## Changes

- **`session.ts`** — Rewrote the `wrapWithPolicy` JSDoc. It previously contained a stream-of-consciousness passage ("by re-exposing every property via Proxy — wait, simpler: we proxy just check") that described a wrong implementation, then corrected itself, and referenced a "prototype chain we copy in" that the code never does. Now states plainly that the Proxy intercepts only `check` and passes every other property straight through. Comment-only.
- **`registries/modes.ts`** — Aligned internal identifiers with the Mode vocabulary. Renamed the private `strategies` Map to `modes`, the `strategy`/`s` locals to `mode`, and fixed two docstrings that still said "strategy". The field is private and nothing outside the file references it.
- **`plugins/host.ts`** — Renamed leftover `loop`/`l` mode-wiring identifiers in `applyPlugin`: `(l: ModeDef) => l.name` to `(m) => m.name`, and `for (const loop of plugin.modes ...)` to `for (const mode ...)`.
- **`requirements.ts`** — Renamed the stale `l` parameter in `targetInfo`'s `case 'mode'` lookup to `m`, matching the adjacent kind-appropriate single letters.
- **`skills/loader.ts`** — Deduped the inlined user-skills path in `discoverSkills` against the existing `defaultUserSkillsDir()` helper (identical expression), removing the now-unused `const home` local. `os` remains imported/used by the helper.
- **`plugins/discovery.ts`** — Named the `node_modules` walk-depth magic number, extracting `i < 8` to a documented `MAX_NODE_MODULES_WALK_DEPTH` module constant. Value unchanged (8).

## Verification (all green)

- `pnpm --filter @moxxy/core build` — `packages/core build: Done`
- `pnpm --filter @moxxy/core typecheck` — clean (`tsc --noEmit`, no errors)
- `pnpm --filter @moxxy/core test` — **29 test files, 188 tests passed**
- `pnpm exec eslint <each changed file>` — **0 errors, 0 warnings**

Note: a wider `...@moxxy/core` build surfaced a pre-existing dependency-ordering failure in the unrelated `@moxxy/plugin-marketplace` package (missing `@moxxy/plugin-plugins-admin` dist); `@moxxy/core` itself builds clean and is the only package touched here.