### PR TITLE
feat(desktop): chat image paste, auto-grow composer, and focus-mode fullscreen fix

### DIFF
--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -172,6 +172,67 @@ async function createWindow(): Promise<void> {
   };
   bindMainWindowMinimize(mainWindow, focusOpts);
 
+  // Focus mode floats a tiny always-on-top widget over your desktop.
+  // On macOS, native fullscreen puts the main window in its own Space;
+  // spawning the floating widget there never surfaces the bar and instead
+  // wedges the app — the main window's controls vanish and it won't close
+  // (needs a force-quit). So focus mode is unavailable while the main
+  // window is fullscreen: the menu items grey out and every handler
+  // (including the global shortcut, which has no disabled state) no-ops.
+  const focusModeAvailable = (): boolean =>
+    !(
+      process.platform === 'darwin' &&
+      !!mainWindow &&
+      !mainWindow.isDestroyed() &&
+      mainWindow.isFullScreen()
+    );
+
+  const openMainAndCloseFocus = (): void => {
+    closeFocusWindow();
+    if (!mainWindow || mainWindow.isDestroyed()) return;
+    if (mainWindow.isMinimized()) mainWindow.restore();
+    mainWindow.show();
+    mainWindow.focus();
+    // macOS: ensure the app is foregrounded even if the window
+    // was hidden behind another Space.
+    if (process.platform === 'darwin') app.focus({ steal: true });
+  };
+
+  const requestFocusToggle = (): void => {
+    if (!focusModeAvailable()) return;
+    void toggleFocusWindow(focusOpts);
+  };
+
+  // (Re)build the tray context menu + application menu, greying out the
+  // focus-mode entries whenever focus mode isn't currently available.
+  const applyMenus = (): void => {
+    const focusEnabled = focusModeAvailable();
+    if (trayInstance) {
+      trayInstance.setContextMenu(
+        Menu.buildFromTemplate([
+          // Heading row — disabled item that just labels the menu so
+          // the user knows which app this tray belongs to. macOS dims
+          // disabled items so it reads as a header.
+          { label: 'MoxxyAI Workspaces', enabled: false },
+          { type: 'separator' },
+          { label: 'Open main window', click: openMainAndCloseFocus },
+          { label: 'Toggle focus mode', enabled: focusEnabled, click: requestFocusToggle },
+          { type: 'separator' },
+          { role: 'quit' },
+        ]),
+      );
+    }
+    installApplicationMenu(requestFocusToggle, openMainAndCloseFocus, focusEnabled);
+  };
+
+  // Entering fullscreen drops any open widget and disables the toggles;
+  // leaving re-enables them.
+  mainWindow.on('enter-full-screen', () => {
+    closeFocusWindow();
+    applyMenus();
+  });
+  mainWindow.on('leave-full-screen', applyMenus);
+
   // Tray menu — toggle the widget, restore the main window, quit.
   if (!trayInstance) {
     try {
@@ -214,29 +275,10 @@ async function createWindow(): Promise<void> {
       // failures + missing PNGs both hit this path).
       if (raw.isEmpty()) trayInstance.setTitle('moxxy');
       trayInstance.setToolTip('MoxxyAI Workspaces');
-      const openMainAndCloseFocus = (): void => {
-        closeFocusWindow();
-        if (!mainWindow || mainWindow.isDestroyed()) return;
-        if (mainWindow.isMinimized()) mainWindow.restore();
-        mainWindow.show();
-        mainWindow.focus();
-        // macOS: ensure the app is foregrounded even if the window
-        // was hidden behind another Space.
-        if (process.platform === 'darwin') app.focus({ steal: true });
-      };
-      trayInstance.setContextMenu(
-        Menu.buildFromTemplate([
-          // Heading row — disabled item that just labels the menu so
-          // the user knows which app this tray belongs to. macOS dims
-          // disabled items so it reads as a header.
-          { label: 'MoxxyAI Workspaces', enabled: false },
-          { type: 'separator' },
-          { label: 'Open main window', click: openMainAndCloseFocus },
-          { label: 'Toggle focus mode', click: () => void toggleFocusWindow(focusOpts) },
-          { type: 'separator' },
-          { role: 'quit' },
-        ]),
-      );
+      // The context menu is built by applyMenus() below (and rebuilt on
+      // fullscreen changes) so the focus-mode item can grey out when the
+      // main window is fullscreen.
+      //
       // We intentionally do NOT bind a left-click → toggle handler
       // here. A bare tray click should just open the menu (the OS
       // default). Focus mode is summoned explicitly via the menu's
@@ -250,6 +292,10 @@ async function createWindow(): Promise<void> {
       console.error('[moxxy] tray init failed:', err);
     }
   }
+
+  // Install the tray + application menus now. Focus mode is enabled
+  // unless the window already launched into fullscreen.
+  applyMenus();
 
   ipcMain.removeHandler('focus.close');
   ipcMain.handle('focus.close', () => {
@@ -269,25 +315,13 @@ async function createWindow(): Promise<void> {
     resizeFocusWindow(width, height);
   });
 
-  // App menu — "View → Focus Mode" with a keyboard shortcut.
-  installApplicationMenu(
-    () => void toggleFocusWindow(focusOpts),
-    () => {
-      closeFocusWindow();
-      if (!mainWindow || mainWindow.isDestroyed()) return;
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.show();
-      mainWindow.focus();
-      if (process.platform === 'darwin') app.focus({ steal: true });
-    },
-  );
-
   // System-wide shortcut so the user can summon the widget even when
   // moxxy isn't the focused app. Cmd+Shift+M on mac / Ctrl+Shift+M
   // elsewhere — the same chord the menu shows.
   try {
     globalShortcut.unregister('CommandOrControl+Shift+M');
     globalShortcut.register('CommandOrControl+Shift+M', () => {
+      if (!focusModeAvailable()) return;
       void toggleFocusWindow(focusOpts).then(() => {
         if (!mainWindow?.isVisible()) void showFocusWindow(focusOpts);
       });
@@ -300,6 +334,7 @@ async function createWindow(): Promise<void> {
 function installApplicationMenu(
   toggleFocus: () => void,
   openMain: () => void,
+  focusEnabled: boolean,
 ): void {
   const isMac = process.platform === 'darwin';
   const template: Electron.MenuItemConstructorOptions[] = [
@@ -347,6 +382,7 @@ function installApplicationMenu(
         {
           label: 'Toggle Focus Mode',
           accelerator: 'CommandOrControl+Shift+M',
+          enabled: focusEnabled,
           click: toggleFocus,
         },
         { type: 'separator' },

--- a/apps/desktop/src/chat/Composer.tsx
+++ b/apps/desktop/src/chat/Composer.tsx
@@ -1,8 +1,10 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
+  type ClipboardEvent,
   type KeyboardEvent,
 } from 'react';
 import { Icon } from '@/lib/Icon';
@@ -18,10 +20,35 @@ import { ToolChip } from './composer/ToolChip';
 import { QueuedChip } from './composer/QueuedChip';
 import { AttachmentChip } from './composer/AttachmentChip';
 import { sendBtn } from './composer/composer-styles';
+import { toErrorMessage } from '@/lib/errors';
 
 interface ComposerAttachment {
   readonly path: string;
   readonly name: string;
+}
+
+/** Past this height the composer textarea stops growing and scrolls
+ *  internally (≈ 8 lines at the composer's font/line metrics). */
+const MAX_TEXTAREA_HEIGHT = 190;
+
+/** Read a Blob/File as base64 (no `data:` prefix) so image bytes can
+ *  ride across IPC. FileReader streams large blobs without the
+ *  binary-string pitfalls of `btoa(String.fromCharCode(...))`. */
+function fileToBase64(file: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error ?? new Error('read failed'));
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== 'string') {
+        reject(new Error('unexpected FileReader result'));
+        return;
+      }
+      const comma = result.indexOf(',');
+      resolve(comma >= 0 ? result.slice(comma + 1) : result);
+    };
+    reader.readAsDataURL(file);
+  });
 }
 
 interface ComposerProps {
@@ -50,6 +77,10 @@ interface ComposerProps {
  * Tooling chips: Attach (file picker → appends a file: reference to
  * the draft) and Voice (push-to-record with MediaRecorder, transcribed
  * via the runner's active transcriber — disabled if none is set).
+ *
+ * Pasting an image (e.g. a screenshot) attaches it: the bytes are
+ * persisted to a temp file by the main process and added as a regular
+ * attachment chip. The textarea also auto-grows to fit the draft.
  */
 export function Composer({
   ready,
@@ -63,6 +94,9 @@ export function Composer({
   const [draft, setDraft] = useState('');
   const [hasTranscriber, setHasTranscriber] = useState(false);
   const [noTranscriberMsg, setNoTranscriberMsg] = useState<string | null>(null);
+  /** Transient error surfaced under the composer when a pasted image
+   *  can't be attached (too large / unreadable). */
+  const [attachError, setAttachError] = useState<string | null>(null);
   const voice = useVoiceRecorder({
     onTranscript: (t) => setDraft((d) => (d ? `${d.trimEnd()} ${t}` : t)),
   });
@@ -120,12 +154,61 @@ export function Composer({
     };
   }, [ready]);
 
+  // Auto-grow: size the textarea to its content so the composer
+  // expands as the draft gains lines — whether from a Shift+Enter
+  // newline or a long line soft-wrapping. Reset to 'auto' before
+  // measuring so it also shrinks back when the draft is cleared or
+  // trimmed. Capped at MAX_TEXTAREA_HEIGHT, past which it scrolls.
+  useLayoutEffect(() => {
+    const ta = taRef.current;
+    if (!ta) return;
+    ta.style.height = 'auto';
+    ta.style.height = `${Math.min(MAX_TEXTAREA_HEIGHT, ta.scrollHeight)}px`;
+  }, [draft]);
+
   const submit = useCallback(() => {
     if (!canSubmit) return;
     onSend(draft, attachments.length > 0 ? attachments : undefined);
     setDraft('');
     setAttachments([]);
   }, [canSubmit, draft, attachments, onSend]);
+
+  /** Persist a pasted/dropped image blob to a temp file via the main
+   *  process, then add the returned path as a regular attachment so it
+   *  rides the same send pipeline as picked files. */
+  const attachImageFile = useCallback(async (file: File): Promise<void> => {
+    try {
+      const dataBase64 = await fileToBase64(file);
+      const att = await api().invoke('session.saveImageAttachment', {
+        dataBase64,
+        mediaType: file.type,
+        ...(file.name ? { name: file.name } : {}),
+      });
+      addAttachment(att);
+      taRef.current?.focus();
+    } catch (err) {
+      setAttachError(toErrorMessage(err));
+      window.setTimeout(() => setAttachError(null), 3000);
+    }
+  }, []);
+
+  const onPaste = useCallback(
+    (e: ClipboardEvent<HTMLTextAreaElement>): void => {
+      // Grab image blobs off the clipboard (screenshots, copied images).
+      // If there are none, fall through to the browser's default paste so
+      // text keeps working untouched.
+      const images = Array.from(e.clipboardData.items).filter(
+        (it) => it.kind === 'file' && it.type.startsWith('image/'),
+      );
+      if (images.length === 0) return;
+      e.preventDefault();
+      for (const item of images) {
+        const file = item.getAsFile();
+        if (file) void attachImageFile(file);
+      }
+    },
+    [attachImageFile],
+  );
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
     // Enter alone submits; Shift+Enter inserts a newline (the browser
@@ -249,6 +332,7 @@ export function Composer({
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
         onKeyDown={onKeyDown}
+        onPaste={onPaste}
         placeholder={
           compacting
             ? 'Compacting context…'
@@ -259,10 +343,12 @@ export function Composer({
                 : 'Waiting for runner…'
         }
         disabled={!ready || compacting}
-        rows={Math.min(8, Math.max(1, draft.split('\n').length))}
+        rows={1}
         style={{
           width: '100%',
           resize: 'none',
+          maxHeight: MAX_TEXTAREA_HEIGHT,
+          overflowY: 'auto',
           padding: '4px 6px 6px',
           fontSize: 14.5,
           lineHeight: 1.55,
@@ -329,7 +415,7 @@ export function Composer({
           </button>
         )}
       </div>
-      {(voice.errorReason ?? noTranscriberMsg) && (
+      {(voice.errorReason ?? noTranscriberMsg ?? attachError) && (
         <p
           role="status"
           style={{
@@ -339,7 +425,7 @@ export function Composer({
             color: 'var(--color-red)',
           }}
         >
-          {voice.errorReason ?? noTranscriberMsg}
+          {voice.errorReason ?? noTranscriberMsg ?? attachError}
         </p>
       )}
       {actionsOpen && (

--- a/packages/desktop-host/src/attachments.test.ts
+++ b/packages/desktop-host/src/attachments.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFile, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import { persistImageBlob } from './attachments';
+
+/** Temp files persistImageBlob writes; cleaned up after each test. */
+const written: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(written.map((p) => unlink(p).catch(() => {})));
+  written.length = 0;
+});
+
+const b64 = (bytes: Buffer): string => bytes.toString('base64');
+
+describe('persistImageBlob', () => {
+  it('writes the bytes to a temp file and returns a path + name', async () => {
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]); // PNG magic
+    const att = await persistImageBlob(b64(bytes), 'image/png');
+    written.push(att.path);
+
+    expect(path.extname(att.path)).toBe('.png');
+    expect(att.name).toBe('pasted-image.png');
+    const onDisk = await readFile(att.path);
+    expect(onDisk.equals(bytes)).toBe(true);
+  });
+
+  it('keeps the source filename when one is given', async () => {
+    const att = await persistImageBlob(b64(Buffer.from([1, 2, 3])), 'image/jpeg', 'shot.jpg');
+    written.push(att.path);
+    expect(att.name).toBe('shot.jpg');
+    // Extension on disk follows the media type, not the display name.
+    expect(path.extname(att.path)).toBe('.jpg');
+  });
+
+  it('gives each blob a unique path so repeated pastes never collide', async () => {
+    const a = await persistImageBlob(b64(Buffer.from([1])), 'image/png');
+    const b = await persistImageBlob(b64(Buffer.from([1])), 'image/png');
+    written.push(a.path, b.path);
+    expect(a.path).not.toBe(b.path);
+  });
+
+  it('rejects non-image media types', async () => {
+    await expect(
+      persistImageBlob(b64(Buffer.from('hello')), 'text/plain'),
+    ).rejects.toThrow(/only images/i);
+  });
+
+  it('rejects an empty blob', async () => {
+    await expect(persistImageBlob('', 'image/png')).rejects.toThrow(/empty/i);
+  });
+
+  it('rejects blobs over the size cap', async () => {
+    const tooBig = Buffer.alloc(8 * 1024 * 1024 + 1);
+    await expect(persistImageBlob(b64(tooBig), 'image/png')).rejects.toThrow(/too large/i);
+  });
+});

--- a/packages/desktop-host/src/attachments.ts
+++ b/packages/desktop-host/src/attachments.ts
@@ -8,9 +8,15 @@
  * effectively ignored. This reads the file in the main process and builds the
  * correct attachment — images as `image`, everything text-like as `file` —
  * skipping anything binary, oversized, or unreadable.
+ *
+ * It also owns {@link persistImageBlob}: pasted/dropped images arrive as raw
+ * bytes (no path), so we stash them in a temp file and hand back a path the
+ * same {@link buildAttachments} pipeline can read on the next turn.
  */
 
-import { readFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, readdir, stat, unlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import type { UserPromptAttachment } from '@moxxy/sdk';
 
@@ -56,4 +62,69 @@ export async function buildAttachments(
     }
   }
   return out;
+}
+
+/** MIME type → file extension for the image blobs we accept on paste. */
+const IMAGE_EXTENSIONS: Readonly<Record<string, string>> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/bmp': 'bmp',
+};
+
+/** Where pasted/dropped image blobs land before a turn reads them. */
+const ATTACHMENT_TMP_DIR = path.join(os.tmpdir(), 'moxxy-attachments');
+/** Sweep temp attachments older than this so pastes don't accumulate. */
+const ATTACHMENT_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Persist a base64 image blob the renderer pasted or dropped (it can't touch
+ * the filesystem) to a temp file, returning a `{ path, name }` the existing
+ * attachment pipeline ships unchanged. Throws if the blob isn't an accepted
+ * image type or exceeds {@link MAX_IMAGE_BYTES} — the renderer surfaces the
+ * message as a transient notice.
+ */
+export async function persistImageBlob(
+  dataBase64: string,
+  mediaType: string,
+  name?: string,
+): Promise<{ path: string; name: string }> {
+  const ext = IMAGE_EXTENSIONS[mediaType.toLowerCase()];
+  if (!ext) throw new Error(`Can't attach ${mediaType || 'this'} — only images can be pasted.`);
+  const buf = Buffer.from(dataBase64, 'base64');
+  if (buf.byteLength === 0) throw new Error('Pasted image was empty.');
+  if (buf.byteLength > MAX_IMAGE_BYTES) {
+    throw new Error(
+      `Image is too large to attach (max ${Math.round(MAX_IMAGE_BYTES / (1024 * 1024))} MB).`,
+    );
+  }
+  await mkdir(ATTACHMENT_TMP_DIR, { recursive: true });
+  void pruneOldAttachments();
+  const filePath = path.join(ATTACHMENT_TMP_DIR, `${randomUUID()}.${ext}`);
+  await writeFile(filePath, buf);
+  const display = name && name.trim().length > 0 ? name : `pasted-image.${ext}`;
+  return { path: filePath, name: display };
+}
+
+/** Best-effort sweep of stale temp attachments. Never throws — a failed
+ *  prune just means the next save tries again. */
+async function pruneOldAttachments(): Promise<void> {
+  try {
+    const now = Date.now();
+    const entries = await readdir(ATTACHMENT_TMP_DIR);
+    await Promise.all(
+      entries.map(async (entry) => {
+        const full = path.join(ATTACHMENT_TMP_DIR, entry);
+        try {
+          const info = await stat(full);
+          if (now - info.mtimeMs > ATTACHMENT_TTL_MS) await unlink(full);
+        } catch {
+          /* already gone / racing another sweep */
+        }
+      }),
+    );
+  } catch {
+    /* dir missing or unreadable — nothing to prune */
+  }
 }

--- a/packages/desktop-host/src/ipc/session.ts
+++ b/packages/desktop-host/src/ipc/session.ts
@@ -16,6 +16,7 @@
 import { dialog, BrowserWindow as BrowserWindowApi } from 'electron';
 
 import type { RunnerPool } from '../runner-pool';
+import { persistImageBlob } from '../attachments.js';
 import {
   drivers,
   getInProcessPlugins,
@@ -134,4 +135,10 @@ export function registerSessionHandlers(pool: RunnerPool): void {
     if (result.canceled || result.filePaths.length === 0) return null;
     return result.filePaths[0]!;
   });
+  handle('session.saveImageAttachment', async ({ dataBase64, mediaType, name }) =>
+    // The renderer can't write files, so a pasted/dropped image's bytes
+    // are stashed to a temp file here; the returned path then rides the
+    // same attachment pipeline as a picked file.
+    persistImageBlob(dataBase64, mediaType, name),
+  );
 }

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -355,6 +355,18 @@ export interface IpcCommands {
   /** Open a native file picker and return the absolute path the user
    *  chose. Null when cancelled. */
   'session.pickAttachment': () => Promise<string | null>;
+  /** Persist a pasted/dropped image blob (the renderer can't write
+   *  files) to a temp file the agent can read, and return it as a
+   *  {@link PromptAttachment} ready to ship on the next turn. Rejects
+   *  if the image exceeds the attachment size cap. */
+  'session.saveImageAttachment': (args: {
+    /** Base64-encoded image bytes (no `data:` prefix). */
+    dataBase64: string;
+    /** MIME type from the clipboard blob, e.g. `image/png`. */
+    mediaType: string;
+    /** Optional source filename; a friendly default is used otherwise. */
+    name?: string;
+  }) => Promise<PromptAttachment>;
 
   // ---- Workspace filesystem browsing ------------------------------------
   /** List one directory inside the workspace's cwd. Relative paths


### PR DESCRIPTION
Three desktop-app fixes reported together, all scoped to the chat surface and the focus widget.

## 1. Paste images into chat
Pasting an image (e.g. a screenshot) now attaches it. On `paste`, the composer pulls image blobs off the clipboard, reads them as base64, and hands them to a new `session.saveImageAttachment` IPC. The main process persists the bytes to a temp file and returns a `{ path, name }` `PromptAttachment`, so the pasted image rides the **exact same send pipeline** as a file picked via *Attach* (no contract changes downstream).

- Non-image / oversized blobs are rejected with a transient notice; the cap mirrors `buildAttachments`' existing 8 MB image limit, so nothing is silently dropped at turn time.
- Temp files land in `os.tmpdir()/moxxy-attachments` and are swept after 24h so pastes don't accumulate.
- Pasting plain text is untouched (the handler only intercepts when image blobs are present).

## 2. Auto-grow composer
The textarea now grows to fit its content via `scrollHeight`, capped at ~8 lines (then scrolls). This replaces the `split('\n').length` heuristic, which only counted hard newlines and left long **soft-wrapped** lines clipped to one row.

## 3. Focus mode no longer wedges the app in fullscreen
On macOS, native fullscreen puts the main window in its own Space. Spawning the always-on-top focus widget there never surfaced the bar and instead hid the main window's controls, leaving the app unclosable (force-quit required).

Focus mode is now unavailable while the main window is fullscreen:
- The tray and **View → Toggle Focus Mode** items grey out (menus rebuilt on `enter`/`leave-full-screen`).
- Every entry point — tray, app menu, and the global `Cmd+Shift+M` shortcut (which has no disabled state to honor) — no-ops.
- Entering fullscreen also dismisses any open widget.

## Testing
- New `persistImageBlob` unit tests (type/empty/size-cap rejection + happy path + unique paths).
- `pnpm build` (53/53), `pnpm typecheck` (101/101), `pnpm test` (100/100), `pnpm lint` (0 errors) all green. No new lint warnings introduced.

All touched packages (`@moxxy/desktop`, `@moxxy/desktop-host`, `@moxxy/desktop-ipc-contract`) are private, so no changeset is needed.