### PR TITLE
fix(desktop): drop pnpm self-symlink from bundled CLI so macOS signing works

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -110,6 +110,15 @@ jobs:
         run: |
           rm -rf apps/desktop/resources/moxxy-cli
           pnpm --filter @moxxy/cli --legacy deploy --prod apps/desktop/resources/moxxy-cli
+          # pnpm `deploy` leaves a self-referential symlink for the deployed
+          # package itself at node_modules/.pnpm/node_modules/@moxxy/cli ->
+          # ../../../../packages/cli (the source workspace). It resolves fine
+          # here, but the moment electron-builder copies the bundle into the
+          # .app it dangles — and @electron/osx-sign walks the bundle with
+          # fs.stat (which follows symlinks), so signing dies on ENOENT and
+          # electron-builder masks it as "Above command failed, retrying 3 more
+          # times". Drop the one symlink that points outside the bundle.
+          rm -f apps/desktop/resources/moxxy-cli/node_modules/.pnpm/node_modules/@moxxy/cli
 
       # Developer ID signing + notarization turn on ONLY when the CSC_LINK
       # secret exists; otherwise the build stays ad-hoc/unsigned (today's

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "bundle:cli": "rm -rf resources/moxxy-cli && pnpm --filter @moxxy/cli --legacy deploy --prod resources/moxxy-cli",
+    "bundle:cli": "rm -rf resources/moxxy-cli && pnpm --filter @moxxy/cli --legacy deploy --prod resources/moxxy-cli && rm -f resources/moxxy-cli/node_modules/.pnpm/node_modules/@moxxy/cli",
     "clean": "rm -rf dist dist-electron .turbo node_modules/.vite"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

The **Release Desktop** workflow fails on the macOS runner during the **Package installers** step. The log shows:

```
• signing  file=release/mac-arm64/MoxxyAI Workspaces.app … identity=10A2CC44… 
• Above command failed, retrying 3 more times   (×4)
⨯ ENOENT: no such file or directory, stat
  '…/MoxxyAI Workspaces.app/Contents/Resources/moxxy-cli/node_modules/.pnpm/node_modules/@moxxy/cli'
```

It looks like a code-signing/credential problem (and the `CSC_KEY_PASSWORD is not defined` line is a tempting red herring), but signing never reaches a `codesign` call. The real failure is an `ENOENT` on a `stat`.

## Root cause

`pnpm --legacy deploy --prod` writes a **self-referential symlink** for the deployed package itself:

```
node_modules/.pnpm/node_modules/@moxxy/cli  ->  ../../../../packages/cli   (the source workspace)
```

This resolves fine at the `resources/moxxy-cli` stage, but the moment electron-builder copies the bundle into `MoxxyAI Workspaces.app/Contents/Resources/`, the relative link dangles. `@electron/osx-sign` enumerates the bundle with `fs.stat` (which **follows** symlinks), so it throws `ENOENT` on the broken link. electron-builder's `retry(signAsync, 3, 5000, 5000)` wrapper swallows the real error and prints "Above command failed, retrying 3 more times" until the retries are exhausted, then surfaces the raw `ENOENT`.

This is why **unsigned** builds pass (native `codesign --deep` in `after-pack.cjs` tolerates the broken link; the JS `fs.stat` walk in osx-sign does not).

## Fix

Delete that one out-of-bundle symlink right after the deploy — in both the CI **Bundle moxxy CLI** step and the local `bundle:cli` script. Verified against a reproduced bundle: it's the **only** symlink that escapes the bundle; the other 9 are internal and relocation-safe, and the CLI entrypoint (`dist/bin.js`) lives in the bundle root, so nothing depends on the removed self-reference.

> Note: removal is unconditional (`rm -f`), not a "delete broken symlinks" prune — in CI the link still *resolves* at the `resources/` stage and only breaks after the copy, so a conditional prune would be a no-op there.