### PR TITLE
fix(voice): treat an empty transcript as a valid result, not a provider error

### DIFF
--- a/.claude/agents/synthesizer-author.md
+++ b/.claude/agents/synthesizer-author.md
@@ -1,0 +1,166 @@
+---
+name: synthesizer-author
+description: Build a text-to-speech Synthesizer plugin (ElevenLabs / OpenAI TTS / local engine / ...).
+---
+
+# Synthesizer author — implement a `Synthesizer` (text-to-speech)
+
+A Synthesizer is the symmetric counterpart to a `Transcriber`: it turns text into spoken audio. Read-aloud surfaces — the desktop's speaker button, a future voice channel — call `session.synthesizers.tryGetActive()?.synthesize(text)` and play the bytes. When no synthesizer is active the caller falls back to the OS voice (`speechSynthesis`), so adding one is purely additive — you never break the no-TTS default.
+
+The SDK contract (`@moxxy/sdk`):
+
+```ts
+interface Synthesizer {
+  readonly name: string;                               // short, stable, e.g. 'elevenlabs'
+  synthesize(text: string, opts?: SynthesizeOptions): Promise<SynthesisResult>;
+}
+
+interface SynthesisResult {
+  readonly audio: Uint8Array;   // encoded bytes ready to play (mp3 / wav / ogg)
+  readonly mimeType: string;    // e.g. 'audio/mpeg', 'audio/wav', 'audio/ogg'
+}
+
+interface SynthesizeOptions {
+  readonly voice?: string;      // voice id/name when the backend supports selection
+  readonly language?: string;   // BCP-47 hint, e.g. 'en', 'pl'
+  readonly rate?: number;       // speaking-rate multiplier (1.0 = normal)
+  readonly signal?: AbortSignal;
+}
+```
+
+There is **no shipped synthesizer plugin yet** — TTS is wired end-to-end (the SDK type, `SynthesizerRegistry`, the desktop `session.synthesize` IPC, the `set_voice`/`list_voices` admin tools) but ships with zero backends, so the OS voice is the default. You are writing the first one. The `Transcriber` siblings — `@moxxy/plugin-stt-whisper` and `@moxxy/plugin-stt-whisper-codex` — are the closest reference for the HTTP + auth shape.
+
+## The `SynthesizerDef` + `create(ctx)` factory
+
+A plugin contributes `SynthesizerDef`s via `PluginSpec.synthesizers`. Note the asymmetry with `TranscriberDef`: a transcriber's factory is `createClient(config)`, but a synthesizer's is `create(ctx)` and receives a `SynthesizerCreateContext`:
+
+```ts
+interface SynthesizerCreateContext {
+  readonly config: Record<string, unknown>;                       // from setActive(name, config)
+  readonly getSecret?: (name: string) => Promise<string | null>;  // vault-backed
+}
+```
+
+**Read your API key via `ctx.getSecret`, never `process.env`.** It's the same vault-backed resolver wired into tool contexts, so the key never enters the model's context. Resolve it lazily (inside `synthesize`, cached) so `create` stays cheap and synchronous.
+
+```ts
+import {
+  defineSynthesizer,
+  definePlugin,
+  classifyHttpStatus,
+  classifyNetworkError,
+  MoxxyError,
+  type Synthesizer,
+  type SynthesizerCreateContext,
+  type SynthesizeOptions,
+  type SynthesisResult,
+} from '@moxxy/sdk';
+
+const ELEVENLABS_PROVIDER_ID = 'elevenlabs';
+
+class ElevenLabsSynthesizer implements Synthesizer {
+  readonly name = 'elevenlabs';
+  private key: string | null = null;
+  constructor(private readonly ctx: SynthesizerCreateContext) {}
+
+  async synthesize(text: string, opts: SynthesizeOptions = {}): Promise<SynthesisResult> {
+    this.key ??= (await this.ctx.getSecret?.('ELEVENLABS_API_KEY')) ?? null;
+    if (!this.key) {
+      throw new MoxxyError({
+        code: 'AUTH_NO_CREDENTIALS',
+        message: 'No ElevenLabs API key. Run `moxxy vault set ELEVENLABS_API_KEY`.',
+        hint: 'moxxy vault set ELEVENLABS_API_KEY',
+        context: { provider: ELEVENLABS_PROVIDER_ID },
+      });
+    }
+    const voice = opts.voice ?? (this.ctx.config.voice as string | undefined) ?? 'Rachel';
+    const url = `https://api.elevenlabs.io/v1/text-to-speech/${voice}`;
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method: 'POST',
+        headers: { 'xi-api-key': this.key, 'content-type': 'application/json', accept: 'audio/mpeg' },
+        body: JSON.stringify({ text, model_id: 'eleven_multilingual_v2' }),
+        signal: opts.signal,
+      });
+    } catch (err) {
+      const network = classifyNetworkError(err, { provider: ELEVENLABS_PROVIDER_ID, url });
+      if (network) throw network;
+      throw err;
+    }
+    if (!res.ok) {
+      const classified = classifyHttpStatus(res.status, {
+        provider: ELEVENLABS_PROVIDER_ID,
+        url,
+        body: await res.text(),
+      });
+      if (classified) throw classified;
+      throw new MoxxyError({
+        code: 'PROVIDER_BAD_REQUEST',
+        message: `ElevenLabs returned HTTP ${res.status}.`,
+        context: { provider: ELEVENLABS_PROVIDER_ID, url, status: res.status },
+      });
+    }
+    return { audio: new Uint8Array(await res.arrayBuffer()), mimeType: 'audio/mpeg' };
+  }
+}
+
+export const elevenLabsDef = defineSynthesizer({
+  name: 'elevenlabs',
+  displayName: 'ElevenLabs',
+  create: (ctx) => new ElevenLabsSynthesizer(ctx),
+});
+
+export default definePlugin({
+  name: '@moxxy/plugin-tts-elevenlabs',
+  version: '0.0.0',
+  synthesizers: [elevenLabsDef],
+});
+```
+
+Reuse the SDK's `classifyHttpStatus` / `classifyNetworkError` — the same helpers the Whisper transcribers use — so a bad key becomes `AUTH_DENIED`, a 429 becomes a rate-limit error, etc., instead of leaking the raw vendor body.
+
+## Registry behavior — auto-adopt-first + lazy build
+
+`SynthesizerRegistry` is **not** wired like `TranscriberRegistry`. Two differences that matter:
+
+- **`autoAdoptFirst: true`** — the first synthesizer registered becomes active automatically. A user who asks the agent to author an ElevenLabs plugin gets read-aloud through it immediately, with no explicit activate step. (Transcribers require an explicit `setActive`.)
+- **`buildOnRead: true`** — because `active` can be set before any instance is built, the active synthesizer is (re)built lazily on the first `getActive()`. Keep `create()` side-effect-free and cheap; it may run more than once.
+
+`getActive()` *throws* when none is active; read-aloud surfaces use **`tryGetActive()`** and fall back to the OS voice on `null`. There is at most one active synthesizer.
+
+## The agent switches voices via `set_voice` — you write no activation code
+
+There is no settings UI. The agent controls TTS through the built-in `@moxxy/voice-admin` tools:
+
+- `list_voices` → `{ active, available }`, where `available` is `['system', ...registered names]` and `'system'` means the OS voice.
+- `set_voice({ synthesizer })` → activate a registered name, or `'system'` to `clearActive()` (back to the OS voice).
+
+Because of auto-adopt-first, a freshly authored/installed plugin is already active on load; `set_voice` is only for switching afterward. **Don't write your own activation step** — just register the def.
+
+## Empty / contract hygiene (the STT lesson, applied to TTS)
+
+The Codex transcriber once *threw* on a benign empty transcript and every caller's graceful path went dead. Mirror the fix on the TTS side:
+
+- A genuine failure (missing key, HTTP error, network) → throw a **classified `MoxxyError`**. Callers already degrade to the OS voice via `tryGetActive()`, so a throw is safe and visible.
+- Always set `mimeType` to what you actually return — don't hardcode `audio/mpeg` if you switched a config to wav. The desktop plays the bytes by that declared type.
+- Honor `opts.signal`: read-aloud is cancellable, so pass the abort signal into `fetch` to free the socket.
+
+## Ship + discover
+
+- **Built-in:** add the def to a plugin and register it in the CLI's `setup`.
+- **Third-party / self-authored:** drop the `@moxxy/plugin-tts-*` package under `~/.moxxy/plugins` — auto-discovery picks it up and (being first) auto-adopts it. The naming convention is `@moxxy/plugin-tts-<vendor>` (mirrors `plugin-stt-*` for speech-to-text).
+
+If the plugin needs a credential to work, declare a `synthesizer` requirement (plus the vault key it needs) so `moxxy doctor` / onboarding can surface a friendly gap — see the requirements guide; `'synthesizer'` is a first-class `RequirementKind`.
+
+## Tests
+
+Mirror `plugin-stt-whisper-codex/src/index.test.ts`: stand up a local `http.createServer`, point the synthesizer at it via injected config/baseURL, drive `synthesize('hello')`, and assert (a) the request shape (auth header, body), (b) the returned `{ audio, mimeType }`, and (c) that a non-2xx maps to a classified `MoxxyError` rather than leaking the raw body. No real vendor account needed.
+
+## Don't
+
+- **Don't read keys from `process.env`.** Use `ctx.getSecret` so the key stays out of the model's context and rides the vault.
+- **Don't do heavy work in `create()`.** It runs lazily on read and may re-run; resolve the key and open connections inside `synthesize`.
+- **Don't write an activation step.** Auto-adopt-first activates the first registered synthesizer; `set_voice` handles switching.
+- **Don't assume the output is MP3.** Set `mimeType` to what you actually return.
+- **Don't forget `opts.signal`.** Pass it to `fetch` so a cancelled read-aloud frees the socket.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ Run `pnpm check:deps` to verify after structural changes.
 | Create a new `@moxxy/plugin-*` package | `.claude/agents/plugin-author.md` |
 | Add one tool to a plugin | `.claude/agents/tool-author.md` |
 | Implement an `LLMProvider` for a new model API | `.claude/agents/provider-author.md` |
+| Build a text-to-speech `Synthesizer` plugin (ElevenLabs / OpenAI TTS / local) | `.claude/agents/synthesizer-author.md` |
 | Build a new loop strategy | `.claude/agents/loop-strategy-author.md` |
 | Build a new `Compactor` | `.claude/agents/compactor-author.md` |
 | Build a new `CacheStrategy` (prompt-cache breakpoints) | `.claude/agents/cache-strategy-author.md` |

--- a/apps/desktop/src/lib/useVoiceRecorder.ts
+++ b/apps/desktop/src/lib/useVoiceRecorder.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from './api';
+import { toErrorMessage } from './errors';
 import { audioToPcm16, uint8ArrayToBase64, MOXXY_PCM16_24KHZ_MIME } from './audioToPcm16';
 
 /**
@@ -84,17 +85,38 @@ export function useVoiceRecorder(opts: VoiceRecorderOptions): UseVoiceRecorder {
       setPhase('transcribing');
       try {
         const blob = new Blob([...chunks], { type: mimeType });
+        // Nothing captured (an instant tap, a muted mic) — don't round-trip
+        // empty audio to the transcriber; just tell the user plainly.
+        if (blob.size === 0) {
+          fail('No speech detected — try again');
+          return;
+        }
         // PCM16 mono 24 kHz — the format moxxy's Codex transcriber
         // expects; AudioContext stands in for the TUI's ffmpeg step.
         const pcm = await audioToPcm16(blob);
+        if (pcm.length === 0) {
+          fail('No speech detected — try again');
+          return;
+        }
         const text = await api().invoke('session.transcribe', {
           audioBase64: uint8ArrayToBase64(pcm),
           mimeType: MOXXY_PCM16_24KHZ_MIME,
         });
-        if (text?.trim()) onTranscriptRef.current(text.trim());
-        setPhase('idle');
+        const trimmed = text?.trim();
+        if (trimmed) {
+          onTranscriptRef.current(trimmed);
+          setPhase('idle');
+        } else {
+          // A well-formed but empty transcript means the clip held no
+          // intelligible speech. Surface a hint instead of silently dropping it
+          // (mirrors the TUI's "voice: empty transcript" notice).
+          fail('No speech detected — try again');
+        }
       } catch (e) {
-        fail(e instanceof Error ? e.message : 'transcription failed');
+        // Decode the IPC error envelope so the user sees a clean message
+        // (a login hint, a network error, …) rather than the raw
+        // `MOXXY_IPC_ERR:{…}` wire encoding Electron would otherwise surface.
+        fail(toErrorMessage(e));
       }
     },
     [fail, setPhase],

--- a/packages/plugin-stt-whisper-codex/src/index.test.ts
+++ b/packages/plugin-stt-whisper-codex/src/index.test.ts
@@ -171,7 +171,7 @@ describe('CodexOAuthTranscriber', () => {
     }
   });
 
-  it('rejects non-2xx and empty transcript responses', async () => {
+  it('rejects non-2xx and malformed responses, and treats an empty transcript as a valid empty result', async () => {
     const vault = await makeVault();
     await persistCodexTokens(vault, {
       access: 'access-token',
@@ -192,17 +192,34 @@ describe('CodexOAuthTranscriber', () => {
       await badServer.close();
     }
 
+    // A well-formed 200 with an all-whitespace transcript means "no intelligible
+    // speech" — a valid empty RESULT, not an error. Callers (TUI/desktop/Telegram/
+    // HTTP) all have their own empty-text path; the transcriber must not throw past
+    // them.
     const emptyServer = await startServer((_request, res) => {
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ text: '   ' }));
     });
     try {
       const transcriber = new CodexOAuthTranscriber({ vault, baseUrl: emptyServer.baseUrl });
-      await expect(transcriber.transcribe(new Uint8Array([1]), { mimeType: 'audio/wav' }))
-        .rejects
-        .toThrow(/empty transcript/);
+      const result = await transcriber.transcribe(new Uint8Array([1]), { mimeType: 'audio/wav' });
+      expect(result.text).toBe('');
     } finally {
       await emptyServer.close();
+    }
+
+    // A 200 that's missing the `text` field IS a contract violation → throw.
+    const malformedServer = await startServer((_request, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ notText: 1 }));
+    });
+    try {
+      const transcriber = new CodexOAuthTranscriber({ vault, baseUrl: malformedServer.baseUrl });
+      await expect(transcriber.transcribe(new Uint8Array([1]), { mimeType: 'audio/wav' }))
+        .rejects
+        .toThrow(/missing a text field/);
+    } finally {
+      await malformedServer.close();
     }
   });
 });

--- a/packages/plugin-stt-whisper-codex/src/transcriber.ts
+++ b/packages/plugin-stt-whisper-codex/src/transcriber.ts
@@ -104,19 +104,28 @@ export class CodexOAuthTranscriber implements Transcriber {
       });
     }
 
-    const text =
-      payload && typeof payload === 'object' && typeof (payload as { text?: unknown }).text === 'string'
-        ? (payload as { text: string }).text.trim()
-        : '';
-    if (!text) {
+    // A 200 with a string `text` field is a SUCCESS even when that string is
+    // empty/whitespace — that just means the clip held no intelligible speech
+    // (silence, a clipped tap, a muted mic). Return `{ text: '' }` so callers
+    // take their graceful "no speech" path (the TUI shows a notice, the desktop
+    // a hint, Telegram/HTTP their own empty-text replies) instead of treating a
+    // normal outcome as a provider failure — every caller already guards on an
+    // empty transcript, and this is the one backend that used to throw past
+    // them. Only a response MISSING the `text` field (or whose `text` isn't a
+    // string) is a real contract violation worth throwing on.
+    if (
+      !payload ||
+      typeof payload !== 'object' ||
+      typeof (payload as { text?: unknown }).text !== 'string'
+    ) {
       throw new MoxxyError({
         code: 'PROVIDER_UNKNOWN_RESPONSE',
-        message: 'Codex transcription returned an empty transcript.',
+        message: 'Codex transcription response was missing a text field.',
         context: { provider: CODEX_PROVIDER_ID, url: this.endpoint },
       });
     }
 
-    return { text };
+    return { text: (payload as { text: string }).text.trim() };
   }
 
   private async loadTokens(): Promise<CodexTokens> {


### PR DESCRIPTION
## Problem

Voice transcription failed with a raw error envelope leaking to the user:

```
Error invoking remote method 'session.transcribe': Error: MOXXY_IPC_ERR:{"code":"runner-error","message":"Codex transcription returned an empty transcript."}
```

The Codex transcriber threw `PROVIDER_UNKNOWN_RESPONSE` whenever the `/transcribe` endpoint returned a `200` with an empty/whitespace `text` field — i.e. when the clip held no intelligible speech (silence, a clipped tap, a muted mic). That throw propagated through the desktop IPC layer and surfaced as the raw `MOXXY_IPC_ERR:{…}` envelope.

Every caller (TUI, desktop, Telegram, HTTP) **already** has its own empty-text branch — the Codex backend was the lone outlier throwing past all of them, leaving those graceful paths as dead code.

## Changes

**Codex transcriber** (`transcriber.ts`)
- A well-formed `200` with a string `text` is now a **success**, returning `{ text: '' }` when empty.
- Only throws when the `text` field is genuinely missing or non-string (a real contract violation).
- Aligns Codex with the generic Whisper transcriber (which never threw) and the documented `TranscriptionResult` contract. This single change fixes the error across all four surfaces.

**Desktop voice recorder** (`useVoiceRecorder.ts`) — defense in depth
- Decodes the IPC envelope via `toErrorMessage`, so a raw `MOXXY_IPC_ERR:{…}` can never reach the user again (real errors show a clean message, e.g. the `moxxy login openai-codex` hint).
- Guards zero-length captured audio before the round-trip.
- Shows a friendly "No speech detected — try again" hint for empty transcripts (mirrors the TUI's notice) instead of a scary error or silence.

**Tests** (`index.test.ts`)
- Asserts empty `{ text: '   ' }` now resolves to `{ text: '' }`.
- Adds a malformed-response case (missing `text` field) that still throws.

**Synthesizer authoring agent** (new)
- TTS was wired end-to-end (`SynthesizerDef`, `SynthesizerRegistry` with auto-adopt-first, the `session.synthesize` IPC, the `set_voice`/`list_voices` admin tools) but had **no authoring agent**, unlike its Transcriber sibling.
- Adds `.claude/agents/synthesizer-author.md` (full guide with accurate APIs, an ElevenLabs reference impl, and a "don'ts" section carrying forward the empty/throw lesson from this bug) + an `AGENTS.md` table row.

## Verification

- `pnpm build` → 55/55
- typecheck clean
- `@moxxy/plugin-stt-whisper-codex` tests → 7/7
- `@moxxy/desktop` tests → 44/44
- eslint clean on touched files