### PR TITLE
feat: persistent goal-mode indicator across TUI and desktop

### DIFF
--- a/.changeset/goal-mode-visual-indicator.md
+++ b/.changeset/goal-mode-visual-indicator.md
@@ -1,0 +1,17 @@
+---
+"@moxxy/sdk": minor
+"@moxxy/cli": minor
+---
+
+Make an active mode visually obvious while it's running.
+
+Modes can now advertise a presentation `badge` (`ModeDef.badge`), surfaced on
+`SessionInfo.activeModeBadge` so every channel sees it over the wire. Goal mode
+declares one, so activating it now shows a persistent indicator the user can't
+miss — even mid-loop, when the usual mode footer is replaced by the "Thinking"
+marker:
+
+- **TUI** — a reverse-video `GOAL` pill stays pinned to the status line for the
+  whole run, alongside the busy spinner.
+- **Desktop** — a persistent accent banner above the composer plus an accented
+  Mode chip, both lit/cleared the moment the mode switches.

--- a/apps/desktop/src/chat/Composer.tsx
+++ b/apps/desktop/src/chat/Composer.tsx
@@ -12,9 +12,11 @@ import { Icon } from '@moxxy/desktop-ui';
 import { api } from '@/lib/api';
 import { useQueuedTurns } from '@/lib/useChat';
 import { useVoiceRecorder } from '@/lib/useVoiceRecorder';
+import { useActiveModeBadge } from '@/lib/useActiveModeBadge';
 import { chatStore } from '@/lib/chatStore';
 import { AgentPicker } from './AgentPicker';
 import { SESSION_INFO_REFRESH_EVENT } from './agent-picker/types';
+import { ModeBanner } from './composer/ModeBanner';
 import { ContextMeter } from './ContextMeter';
 import { CommandPalette } from './CommandPalette';
 import { FILE_INSERT_EVENT, type FileInsertDetail } from '@/shell/WorkspaceFiles';
@@ -135,6 +137,10 @@ export function Composer({
   const autoApprove = useSyncExternalStore(chatStore.subscribe, () =>
     chatStore.getAutoApprove(workspaceId),
   );
+  // Presentation badge of the active mode (goal mode advertises one). When
+  // set, the composer wears a persistent accent banner so the user always
+  // knows an autonomous mode is driving the session.
+  const modeBadge = useActiveModeBadge(workspaceId);
 
   // The context rail's file tree fires a CustomEvent when the user
   // clicks a file. We treat it as an attachment, not text — the
@@ -340,6 +346,7 @@ export function Composer({
         gap: 10,
       }}
     >
+      {modeBadge && <ModeBanner badge={modeBadge} />}
       {(attachments.length > 0 || queued.length > 0) && (
         <div
           style={{

--- a/apps/desktop/src/chat/agent-picker/AgentPicker.tsx
+++ b/apps/desktop/src/chat/agent-picker/AgentPicker.tsx
@@ -74,10 +74,14 @@ export function AgentPicker({
     setInfo((cur) => (cur ? { ...cur, activeMode: next } : cur));
     try {
       await api().invoke('session.setMode', { workspaceId, mode: next });
-      refresh();
     } catch {
-      refresh();
+      /* fall through — the refresh below restores the true value */
     }
+    // Canonical "mode changed" signal: this picker's own listener re-reads
+    // (confirming the flip + the new badge), and the composer's goal banner
+    // lights up / clears — so a chip-driven switch behaves like the Goal
+    // button, which already dispatches this event.
+    window.dispatchEvent(new CustomEvent(SESSION_INFO_REFRESH_EVENT));
   };
 
   const onPickProviderModel = async (
@@ -112,6 +116,7 @@ export function AgentPicker({
         label="Mode"
         value={info.activeMode ?? ''}
         options={[...info.modes]}
+        badge={info.activeModeBadge}
         disabled={disabled || info.modes.length === 0}
         onChange={(v) => void onMode(v)}
       />

--- a/apps/desktop/src/chat/agent-picker/ChipSelect.tsx
+++ b/apps/desktop/src/chat/agent-picker/ChipSelect.tsx
@@ -1,22 +1,38 @@
+import type { ModeBadge } from './types';
+
+/** Accent + tinted fill per tone, matched to the composer's ModeBanner so the
+ *  chip and banner read as one signal: amber for attention, cyan for info. */
+function badgeAccent(tone: ModeBadge['tone']): { readonly accent: string; readonly soft: string } {
+  return tone === 'info'
+    ? { accent: 'var(--color-accent-strong)', soft: 'rgba(34, 211, 238, 0.10)' }
+    : { accent: 'var(--color-amber)', soft: 'rgba(245, 158, 11, 0.10)' };
+}
+
 /**
  * The Mode chip — a flat native-select chip. Modes have no sub-list to
  * disclose, so the styled chip overlays a transparent native `<select>`
  * for the actual picking + a11y / keyboard behaviour.
+ *
+ * When the active mode advertises a `badge` (e.g. goal mode), the chip wears
+ * a matching accent border + tinted fill so it's visibly "hot" — reinforcing
+ * the composer's mode banner.
  */
-
 export function ChipSelect({
   label,
   value,
   options,
+  badge,
   disabled,
   onChange,
 }: {
   readonly label: string;
   readonly value: string;
   readonly options: ReadonlyArray<string>;
+  readonly badge?: ModeBadge | null;
   readonly disabled: boolean;
   readonly onChange: (next: string) => void;
 }): JSX.Element {
+  const accent = badge ? badgeAccent(badge.tone) : null;
   return (
     <label
       className="btn-chip"
@@ -26,9 +42,9 @@ export function ChipSelect({
         padding: '6px 10px',
         fontSize: 12.5,
         color: 'var(--color-text-muted)',
-        border: '1px solid var(--color-card-border)',
+        border: `1px solid ${accent?.accent ?? 'var(--color-card-border)'}`,
         borderRadius: 10,
-        background: '#fff',
+        background: accent ? accent.soft : '#fff',
         display: 'inline-flex',
         alignItems: 'center',
         gap: 6,
@@ -41,7 +57,7 @@ export function ChipSelect({
       <span
         style={{
           fontWeight: 600,
-          color: 'var(--color-text)',
+          color: accent?.accent ?? 'var(--color-text)',
           maxWidth: 120,
           whiteSpace: 'nowrap',
           overflow: 'hidden',

--- a/apps/desktop/src/chat/agent-picker/types.ts
+++ b/apps/desktop/src/chat/agent-picker/types.ts
@@ -13,11 +13,22 @@ export interface ProviderInfo {
   readonly models: ReadonlyArray<{ readonly id: string }>;
 }
 
+/**
+ * Presentation hint the active mode advertises (subset of the SDK's
+ * `ModeBadge`). When present the composer renders a persistent accent banner
+ * + an accented Mode chip so an autonomous mode (goal mode) is unmistakable.
+ */
+export interface ModeBadge {
+  readonly label: string;
+  readonly tone?: 'attention' | 'info';
+}
+
 export interface SessionInfo {
   readonly providers: ReadonlyArray<ProviderInfo>;
   readonly modes: ReadonlyArray<string>;
   readonly activeProvider: string | null;
   readonly activeMode: string | null;
+  readonly activeModeBadge: ModeBadge | null;
 }
 
 /**

--- a/apps/desktop/src/chat/composer/ModeBanner.tsx
+++ b/apps/desktop/src/chat/composer/ModeBanner.tsx
@@ -1,0 +1,66 @@
+/**
+ * Persistent banner shown at the top of the composer while a "badged" mode
+ * is active (currently goal mode). It's the most prominent of the desktop's
+ * goal-mode signals — a full-width accent strip the user can't miss, so they
+ * always know the agent is driving itself. The Mode chip picks up a matching
+ * accent; this strip explains what that state means.
+ *
+ * Driven entirely by the mode's advertised badge (label + tone), so any
+ * future autonomous mode lights it up without touching this file.
+ */
+
+import type { ModeBadge } from '@/chat/agent-picker/types';
+
+/** Palette per tone: attention = amber (autonomous, heads-up), info = the
+ *  brand cyan accent for a quieter highlight. */
+function toneStyle(tone: ModeBadge['tone']): {
+  readonly accent: string;
+  readonly soft: string;
+} {
+  if (tone === 'info') {
+    return { accent: 'var(--color-accent-strong)', soft: 'rgba(34, 211, 238, 0.12)' };
+  }
+  return { accent: 'var(--color-amber)', soft: 'rgba(245, 158, 11, 0.13)' };
+}
+
+export function ModeBanner({ badge }: { readonly badge: ModeBadge }): JSX.Element {
+  const { accent, soft } = toneStyle(badge.tone);
+  return (
+    <div
+      role="status"
+      data-testid="mode-banner"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '7px 10px',
+        marginBottom: 6,
+        fontSize: 12.5,
+        color: 'var(--color-text)',
+        background: soft,
+        border: `1px solid ${accent}`,
+        borderRadius: 9,
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          flex: '0 0 auto',
+          padding: '1px 7px',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: 0.4,
+          color: '#fff',
+          background: accent,
+          borderRadius: 'var(--radius-pill)',
+        }}
+      >
+        {badge.label}
+      </span>
+      <span>
+        {badge.label} mode active — the agent keeps working autonomously toward your
+        objective.
+      </span>
+    </div>
+  );
+}

--- a/apps/desktop/src/lib/useActiveModeBadge.ts
+++ b/apps/desktop/src/lib/useActiveModeBadge.ts
@@ -1,0 +1,42 @@
+/**
+ * Tracks the active mode's presentation badge for a workspace so the composer
+ * can surface a persistent "you're in this mode" banner. Mirrors the
+ * AgentPicker's fetch-on-mount + refresh-on-event pattern, but exposes only
+ * the badge — the banner doesn't care about providers/models.
+ *
+ * Reactivity hinges on SESSION_INFO_REFRESH_EVENT: both the Goal button
+ * (Composer.startGoal) and the Mode chip (AgentPicker.onMode) dispatch it
+ * after switching the mode, so the banner appears/disappears immediately
+ * without waiting for a remount.
+ */
+
+import { useEffect, useState } from 'react';
+import { api } from '@/lib/api';
+import {
+  SESSION_INFO_REFRESH_EVENT,
+  type ModeBadge,
+} from '@/chat/agent-picker/types';
+
+export function useActiveModeBadge(workspaceId: string): ModeBadge | null {
+  const [badge, setBadge] = useState<ModeBadge | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchBadge = (): void => {
+      void api()
+        .invoke('session.info', { workspaceId })
+        .then((raw) => {
+          if (!cancelled) setBadge(raw?.activeModeBadge ?? null);
+        })
+        .catch(() => {});
+    };
+    fetchBadge();
+    window.addEventListener(SESSION_INFO_REFRESH_EVENT, fetchBadge);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(SESSION_INFO_REFRESH_EVENT, fetchBadge);
+    };
+  }, [workspaceId]);
+
+  return badge;
+}

--- a/packages/core/src/session.test.ts
+++ b/packages/core/src/session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { definePlugin } from '@moxxy/sdk';
+import { defineMode, definePlugin } from '@moxxy/sdk';
 import { Session } from './session.js';
 
 describe('Session', () => {
@@ -85,6 +85,7 @@ describe('Session', () => {
     // Bare session: nothing active yet, all lists empty, no transcriber.
     expect(info.activeProvider).toBeNull();
     expect(info.activeMode).toBeNull();
+    expect(info.activeModeBadge).toBeNull();
     expect(info.providers).toEqual([]);
     expect(info.modes).toEqual([]);
     expect(info.tools).toEqual([]);
@@ -93,6 +94,26 @@ describe('Session', () => {
     expect(info.hasTranscriber).toBe(false);
     // The snapshot must survive a JSON round-trip (it crosses the wire).
     expect(JSON.parse(JSON.stringify(info))).toEqual(info);
+  });
+
+  it('getInfo surfaces the active mode badge (and null for unbadged modes)', () => {
+    const s = new Session({ cwd: '/tmp', silent: true });
+    // First registration auto-activates — a badged mode lights up the snapshot
+    // so channels can render a persistent indicator (e.g. goal mode).
+    s.modes.register(
+      defineMode({
+        name: 'goal',
+        badge: { label: 'GOAL', tone: 'attention' },
+        run: async function* () {},
+      }),
+    );
+    expect(s.getInfo().activeModeBadge).toEqual({ label: 'GOAL', tone: 'attention' });
+
+    // Switching to a mode with no badge clears it back to null.
+    s.modes.register(defineMode({ name: 'plain', run: async function* () {} }));
+    s.modes.setActive('plain');
+    expect(s.getInfo().activeMode).toBe('plain');
+    expect(s.getInfo().activeModeBadge).toBeNull();
   });
 
   it('exposes runTurn as a method (SessionLike conformance)', () => {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -316,8 +316,13 @@ export class Session implements ClientSession, SessionRuntime {
    */
   getInfo(): SessionInfo {
     let activeMode: string | null = null;
+    let activeModeBadge: SessionInfo['activeModeBadge'] = null;
     try {
-      activeMode = this.modes.getActive().name;
+      const mode = this.modes.getActive();
+      activeMode = mode.name;
+      // Surface the active mode's presentation hint so channels can render a
+      // persistent badge (e.g. goal mode) without hard-coding mode names.
+      activeModeBadge = mode.badge ? { label: mode.badge.label, ...(mode.badge.tone ? { tone: mode.badge.tone } : {}) } : null;
     } catch {
       // No mode active yet (registry empty pre-boot) - report null.
     }
@@ -341,6 +346,7 @@ export class Session implements ClientSession, SessionRuntime {
           (p as { supportsLiveModelDiscovery?: boolean }).supportsLiveModelDiscovery === true,
       })),
       activeMode,
+      activeModeBadge,
       modes: this.modes.list().map((m) => m.name),
       tools: this.tools.list().map((t) => ({
         name: t.name,

--- a/packages/mode-goal/src/index.ts
+++ b/packages/mode-goal/src/index.ts
@@ -9,6 +9,10 @@ export { GOAL_MODE_NAME } from './constants.js';
 export const goalMode = defineMode({
   name: GOAL_MODE_NAME,
   description: 'Autonomous goal loop: works across many turns until it calls goal_complete (tools auto-approved)',
+  // Goal mode auto-approves tools and keeps working unattended, so channels
+  // surface a persistent accent badge while it's active — the user must always
+  // know the agent is driving itself.
+  badge: { label: 'GOAL', tone: 'attention' },
   run: runGoalMode,
 });
 

--- a/packages/plugin-cli/src/components/StatusLine.tsx
+++ b/packages/plugin-cli/src/components/StatusLine.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
+import type { ModeBadge } from '@moxxy/sdk';
 import { formatElapsed } from '@moxxy/chat-model';
-import { Colors, Glyphs, contextColor } from '../theme.js';
+import { Colors, Glyphs, contextColor, badgeBackground } from '../theme.js';
 import { Spinner } from './Spinner.js';
 import { ModeFooter } from './ModeFooter.js';
 
@@ -15,6 +16,13 @@ export interface StatusLineProps {
    * hint); replaced by the "Thinking" marker while a turn is in flight.
    */
   readonly modeName: string;
+  /**
+   * Presentation badge for the active mode, when it declares one (e.g. goal
+   * mode). Unlike `modeName` this stays pinned to the left *even while a turn
+   * is in flight*, so an autonomous mode is always visible — the whole point
+   * being the user must never lose track that the agent is driving itself.
+   */
+  readonly modeBadge?: ModeBadge | null;
   /** Active provider name — rendered as a badge on the right. */
   readonly provider: string;
   /** Active model id — dim, after the badge. */
@@ -38,6 +46,7 @@ export const StatusLine: React.FC<StatusLineProps> = ({
   busyStartedAt,
   queueCount,
   modeName,
+  modeBadge,
   provider,
   model,
   mcp,
@@ -48,18 +57,37 @@ export const StatusLine: React.FC<StatusLineProps> = ({
   const showQueue = (queueCount ?? 0) > 0;
   const showMcp = !!(mcp && mcp.enabled > 0);
   const showCtx = !!(contextWindow && contextWindow > 0);
+  const queuedTail = showQueue ? (
+    <>
+      <Text dimColor>{'  '}</Text>
+      <Text dimColor>{`${Glyphs.contextUp} ${queueCount} queued`}</Text>
+    </>
+  ) : null;
   return (
     <Box justifyContent="space-between">
       <Box>
-        {busy ? (
+        {modeBadge ? (
+          // Badged (autonomous) mode: the pill is pinned left at all times,
+          // with the busy marker / idle hint trailing it — so the user always
+          // sees the mode even mid-run, when a plain footer would be hidden.
+          <>
+            <ModeBadgePill badge={modeBadge} />
+            <Text>{' '}</Text>
+            {busy ? (
+              <>
+                <BusyMarker startedAt={busyStartedAt!} />
+                {queuedTail}
+              </>
+            ) : (
+              <Text color={Colors.chrome} dimColor>
+                {'Esc stops · shift+tab to change'}
+              </Text>
+            )}
+          </>
+        ) : busy ? (
           <>
             <BusyMarker startedAt={busyStartedAt!} />
-            {showQueue ? (
-              <>
-                <Text dimColor>{'  '}</Text>
-                <Text dimColor>{`${Glyphs.contextUp} ${queueCount} queued`}</Text>
-              </>
-            ) : null}
+            {queuedTail}
           </>
         ) : (
           <ModeFooter modeName={modeName} />
@@ -88,6 +116,17 @@ export const StatusLine: React.FC<StatusLineProps> = ({
 
 const ProviderBadge: React.FC<{ name: string }> = ({ name }) => (
   <Text backgroundColor={Colors.chrome} color="black" bold>{` ${name} `}</Text>
+);
+
+/**
+ * Reverse-video pill for a badged mode (e.g. ` GOAL `). The accent
+ * background is the mode's most prominent signal — it reads as "this
+ * session is in a special, autonomous state" at a glance.
+ */
+const ModeBadgePill: React.FC<{ badge: ModeBadge }> = ({ badge }) => (
+  <Text backgroundColor={badgeBackground(badge.tone)} color="black" bold>
+    {` ${badge.label} `}
+  </Text>
 );
 
 const BusyMarker: React.FC<{ startedAt: number }> = ({ startedAt }) => {

--- a/packages/plugin-cli/src/session/SessionView.tsx
+++ b/packages/plugin-cli/src/session/SessionView.tsx
@@ -10,6 +10,7 @@ import { estimateContextTokens } from '../context-estimate.js';
 import {
   buildSlashSuggestions,
   clearTerminalScreen,
+  getModeBadge,
   getModeName,
   resolveActiveDescriptor,
   resolveActiveModel,
@@ -145,6 +146,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
   // this stays well under a millisecond even on busy logs.
   const contextUsed = estimateContextTokens(session.log);
   const modeName = getModeName(session);
+  const modeBadge = getModeBadge(session);
 
   // Shift+Tab (and /mode) advance to the next registered mode, wrapping
   // around. Mirrors the model/loop picker's persistence so the choice
@@ -354,6 +356,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
         }
         queueCount={turn.queueCount}
         modeName={modeName}
+        modeBadge={modeBadge}
         provider={providerName}
         model={activeModel}
         mcp={mcpStatus}

--- a/packages/plugin-cli/src/session/helpers.ts
+++ b/packages/plugin-cli/src/session/helpers.ts
@@ -1,4 +1,4 @@
-import type { ClientSession as Session } from '@moxxy/sdk';
+import type { ClientSession as Session, ModeBadge } from '@moxxy/sdk';
 import {
   BUILTIN_SLASH_COMMANDS,
   type SlashCommand,
@@ -60,6 +60,20 @@ export function getModeName(session: Session): string {
     return session.modes.getActive().name;
   } catch {
     return '(none)';
+  }
+}
+
+/**
+ * Presentation badge for the active mode, if it declares one. Sourced from
+ * the serializable `getInfo()` snapshot rather than `modes.getActive().badge`
+ * so it also resolves over the thin-client transport (a `RemoteSession`'s
+ * mode objects are name-only stubs). `null` when no badge / no active mode.
+ */
+export function getModeBadge(session: Session): ModeBadge | null {
+  try {
+    return session.getInfo().activeModeBadge;
+  } catch {
+    return null;
   }
 }
 

--- a/packages/plugin-cli/src/theme.ts
+++ b/packages/plugin-cli/src/theme.ts
@@ -59,3 +59,12 @@ export function contextColor(pct: number): typeof Colors[keyof typeof Colors] | 
   if (pct >= 60) return Colors.busy;
   return undefined;
 }
+
+/**
+ * Background color for a persistent mode badge (reverse-video pill, black
+ * text). `attention` — magenta — for autonomous modes the user must always
+ * notice (e.g. goal mode); anything else falls back to gray chrome.
+ */
+export function badgeBackground(tone: 'attention' | 'info' | undefined): string {
+  return tone === 'attention' ? Colors.mode : Colors.chrome;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -255,6 +255,7 @@ export type {
   PluginHostHandle,
   ModeContext,
   ModeDef,
+  ModeBadge,
   ElisionSettings,
   ApprovalResolver,
   ApprovalRequest,

--- a/packages/sdk/src/mode.ts
+++ b/packages/sdk/src/mode.ts
@@ -135,6 +135,28 @@ export interface ApprovalResolver {
   confirm(req: ApprovalRequest): Promise<ApprovalDecision>;
 }
 
+/**
+ * Optional presentation hint a mode can advertise so channels render a
+ * persistent, accent-coloured badge while it is active — even mid-run,
+ * when the usual mode footer is hidden behind a "Thinking" marker. This
+ * lets a high-autonomy mode (e.g. goal mode, which auto-approves tools and
+ * keeps working unattended) always be obvious to the user. Modes that omit
+ * it get the plain `mode: <name>` footer treatment.
+ *
+ * Carried on {@link SessionInfo.activeModeBadge} so thin clients (desktop
+ * over RPC) see it too — keep it plain data (it crosses the wire).
+ */
+export interface ModeBadge {
+  /** Short, uppercase label for the badge (e.g. "GOAL"). Keep it tiny. */
+  readonly label: string;
+  /**
+   * Accent tone each channel maps to its palette. `attention` for
+   * elevated / autonomous modes the user must always notice; `info` for a
+   * quieter highlight. Defaults to `info` when omitted.
+   */
+  readonly tone?: 'attention' | 'info';
+}
+
 export interface ModeDef {
   readonly name: string;
   /**
@@ -143,5 +165,10 @@ export interface ModeDef {
    * memorising plugin internals. Keep short — the picker truncates.
    */
   readonly description?: string;
+  /**
+   * Optional presentation hint. When set, channels surface a persistent
+   * accent badge while this mode is active. See {@link ModeBadge}.
+   */
+  readonly badge?: ModeBadge;
   run(ctx: ModeContext): AsyncIterable<MoxxyEvent>;
 }

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -1,7 +1,7 @@
 import type { MoxxyEvent, UserPromptAttachment } from './events.js';
 import type { SessionId, TurnId } from './ids.js';
 import type { EventLogReader } from './log.js';
-import type { ApprovalResolver } from './mode.js';
+import type { ApprovalResolver, ModeBadge } from './mode.js';
 import type { PermissionResolver } from './permission.js';
 import type { ModelDescriptor } from './provider.js';
 import type { ToolCompactPresentation } from './tool.js';
@@ -96,6 +96,13 @@ export interface SessionInfo {
   readonly activeProvider: string | null;
   readonly providers: ReadonlyArray<ProviderInfo>;
   readonly activeMode: string | null;
+  /**
+   * Presentation hint for the active mode, when it advertises one (see
+   * {@link ModeBadge}). Lets channels render a persistent accent badge for
+   * autonomous modes like goal mode. `null` when no mode is active or the
+   * active mode declares no badge.
+   */
+  readonly activeModeBadge: ModeBadge | null;
   readonly modes: ReadonlyArray<string>;
   readonly tools: ReadonlyArray<ToolInfo>;
   readonly skills: ReadonlyArray<SkillInfo>;


### PR DESCRIPTION
## Why

Activating goal mode had no clear, lasting signal — and worse, while the goal loop is *running* the TUI replaces the mode footer with the "Thinking" marker, so there was **zero** indication you were in goal mode mid-loop. Goal mode auto-approves tools and drives the session itself, so the user should always be able to tell at a glance.

## What

The treatment is driven off **mode metadata** (not a hard-coded `"goal"` check), so any future autonomous mode lights up the same way:

- **SDK** — `ModeDef` gains an optional `badge` (`{ label, tone }`), surfaced on `SessionInfo.activeModeBadge` so every channel sees it over the wire (incl. thin clients).
- **Core** — `getInfo()` reads the active mode's badge. Goal mode declares `{ label: 'GOAL', tone: 'attention' }`.
- **TUI** — a reverse-video `GOAL` pill is pinned to the status line for the whole run, beside the busy spinner. Sourced from `getInfo()` so it also resolves over the `RemoteSession` transport (whose mode objects are name-only stubs).
- **Desktop** — a persistent accent banner above the composer + an accented Mode chip, both lit/cleared the moment the mode switches. `AgentPicker.onMode` now dispatches the canonical session-info refresh event so a chip-driven switch behaves like the Goal button.

## Verification

Full repo green: build **55/55**, typecheck **105/105**, lint **0 errors**, test **103/103** (added a `getInfo` badge test covering badged + unbadged modes). Changeset included (`@moxxy/sdk` + `@moxxy/cli` minor) since the SDK API is public.