### PR TITLE
fix(modes): synthesize tool_result on stuck-loop trip so tool calls don't orphan

### DIFF
--- a/.changeset/stuck-loop-orphan-tool-result.md
+++ b/.changeset/stuck-loop-orphan-tool-result.md
@@ -1,0 +1,6 @@
+---
+"@moxxy/cli": patch
+"@moxxy/desktop": patch
+---
+
+Fix tool calls getting stuck "running" forever (flipping to error only on the next message). When the stuck-loop detector tripped, `mode-tool-use` (the default mode) and `mode-goal` ended the turn after emitting `tool_call_requested` but before running the call — orphaning it with no `tool_result`. The turn still completed (re-enabling the composer), so the orphaned call spun indefinitely until the next `user_prompt` swept it into an error. Both modes now synthesize a failed result for every already-emitted request before bailing, matching the abort path and the already-correct plan-execute/developer modes. This also stops the provider from rejecting the unresolved tool-use block on the following turn.

--- a/packages/mode-goal/src/goal-loop.ts
+++ b/packages/mode-goal/src/goal-loop.ts
@@ -335,6 +335,13 @@ async function* emitRequestsAndDetectStuck(
   toolUses: ReadonlyArray<CollectedToolUse>,
   detector: StuckLoopDetector,
 ): AsyncGenerator<MoxxyEvent, boolean, unknown> {
+  // A stuck trip bails WITHOUT running executeToolUses, so any request emitted
+  // so far would be orphaned (a tool_call_requested with no tool_result) —
+  // which renders as a tool stuck "running" forever and only clears when the
+  // next user_prompt arrives. Synthesize a failed result for each before
+  // returning, mirroring executeToolUses' abort path. See the same fix in
+  // mode-tool-use's turn-iterator.
+  const emitted: CollectedToolUse[] = [];
   for (const t of toolUses) {
     yield await ctx.emit({
       type: 'tool_call_requested',
@@ -345,8 +352,20 @@ async function* emitRequestsAndDetectStuck(
       name: t.name,
       input: t.input,
     });
+    emitted.push(t);
     const sig = detector.record(t.name, t.input);
     if (sig.stuck) {
+      for (const r of emitted) {
+        yield await ctx.emit({
+          type: 'tool_result',
+          sessionId: ctx.sessionId,
+          turnId: ctx.turnId,
+          source: 'tool',
+          callId: asToolCallId(r.id),
+          ok: false,
+          error: { kind: 'aborted', message: 'goal mode aborted (stuck pattern) before this call ran' },
+        });
+      }
       const how =
         sig.kind === 'near'
           ? 'against the same target (only volatile args varied)'

--- a/packages/mode-goal/src/index.test.ts
+++ b/packages/mode-goal/src/index.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { defineTool } from '@moxxy/sdk';
 import { collectTurn } from '@moxxy/core';
 import { FakeProvider, createFakeSession, textReply, toolUseReply } from '@moxxy/testing';
 
@@ -76,5 +78,38 @@ describe('goalMode end-to-end', () => {
     expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_stalled')).toBe(true);
     // It did NOT falsely report completion.
     expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_completed')).toBe(false);
+  });
+
+  it('emits a paired result for every request even when the stuck loop trips', async () => {
+    // The model hammers the same (name, input) until the detector trips. The
+    // stuck trip ends the turn before executeToolUses runs the final request —
+    // without synthesizing a result that request is orphaned (renders as a tool
+    // stuck "running" forever, flips to error only on the next user_prompt).
+    const provider = new FakeProvider({
+      script: Array.from({ length: 20 }, (_, i) => toolUseReply('loop', {}, `c${i}`)),
+    });
+    const session = createFakeSession({ provider });
+    session.pluginHost.registerStatic(goalModePlugin);
+    session.modes.setActive(GOAL_MODE_NAME);
+    session.tools.register(
+      defineTool({
+        name: 'loop',
+        description: '',
+        inputSchema: z.object({}),
+        handler: () => 'ok',
+      }),
+    );
+
+    const events = await collectTurn(session, 'spin');
+    expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_stuck')).toBe(true);
+
+    const requestedIds = new Set(
+      events.filter((e) => e.type === 'tool_call_requested').map((e) => e.callId),
+    );
+    const resolvedIds = new Set(
+      events.filter((e) => e.type === 'tool_result').map((e) => e.callId),
+    );
+    const orphans = [...requestedIds].filter((id) => !resolvedIds.has(id));
+    expect(orphans).toEqual([]);
   });
 });

--- a/packages/mode-tool-use/src/index.test.ts
+++ b/packages/mode-tool-use/src/index.test.ts
@@ -153,6 +153,43 @@ describe('toolUseMode end-to-end', () => {
     // around iteration 3, well below the 500-iteration cap.
     const toolCalls = events.filter((e) => e.type === 'tool_call_requested');
     expect(toolCalls.length).toBeLessThan(10);
+    // Regression: a stuck trip must NOT leave an orphan tool_call_requested.
+    // The detector fires AFTER the final request is emitted but the turn ends
+    // before executeToolUses runs it — without synthesizing a result, that
+    // request renders as a tool stuck "running" forever (and the provider
+    // rejects it next turn). Every emitted request must have a paired result.
+    const results = events.filter((e) => e.type === 'tool_result');
+    expect(results.length).toBe(toolCalls.length);
+  });
+
+  it('emits a paired result for every request even when the stuck loop trips', async () => {
+    // Distinct callIds per turn so the assertion is per-call, mirroring how the
+    // desktop fold (pair-events) matches tool_result back to tool_call_requested
+    // by callId. A leftover orphan here is the exact "tool spins forever, flips
+    // to error on the next message" symptom.
+    const provider = new FakeProvider({
+      script: Array.from({ length: 20 }, (_, i) => toolUseReply('loop', {}, `c${i}`)),
+    });
+    const session = sessionWith(provider);
+    session.tools.register(
+      defineTool({
+        name: 'loop',
+        description: '',
+        inputSchema: z.object({}),
+        handler: () => 'ok',
+      }),
+    );
+
+    const events = await collectTurn(session, 'spin');
+    const requestedIds = new Set(
+      events.filter((e) => e.type === 'tool_call_requested').map((e) => e.callId),
+    );
+    const resolvedIds = new Set(
+      events.filter((e) => e.type === 'tool_result').map((e) => e.callId),
+    );
+    // No requested call may be left without a result.
+    const orphans = [...requestedIds].filter((id) => !resolvedIds.has(id));
+    expect(orphans).toEqual([]);
   });
 
   it('respects an explicit maxIterations cap when no stuck loop fires', async () => {

--- a/packages/mode-tool-use/src/turn-iterator.ts
+++ b/packages/mode-tool-use/src/turn-iterator.ts
@@ -170,6 +170,16 @@ async function* emitRequestsAndDetectStuck(
   toolUses: ReadonlyArray<CollectedToolUse>,
   detector: StuckLoopDetector,
 ): AsyncGenerator<MoxxyEvent, boolean, unknown> {
+  // Requests emitted this batch. A stuck trip bails WITHOUT running
+  // executeToolUses, so every request emitted so far would otherwise be left
+  // as an orphan tool_call_requested (no tool_result). That orphan is the bug
+  // behind "tool stuck running forever, flips to error on the next message":
+  // the turn ends cleanly (composer re-enables) yet the call never resolves,
+  // so the desktop's pair-events fold can only clear it via the next
+  // user_prompt's markOrphansAtTurnBoundary. The provider also rejects an
+  // unresolved tool_use block next turn. Synthesize a failed result for each —
+  // same contract as executeToolUses' abort path.
+  const emitted: CollectedToolUse[] = [];
   for (const t of toolUses) {
     yield await ctx.emit({
       type: 'tool_call_requested',
@@ -180,8 +190,20 @@ async function* emitRequestsAndDetectStuck(
       name: t.name,
       input: t.input,
     });
+    emitted.push(t);
     const sig = detector.record(t.name, t.input);
     if (sig.stuck) {
+      for (const r of emitted) {
+        yield await ctx.emit({
+          type: 'tool_result',
+          sessionId: ctx.sessionId,
+          turnId: ctx.turnId,
+          source: 'tool',
+          callId: asToolCallId(r.id),
+          ok: false,
+          error: { kind: 'aborted', message: 'tool-use loop aborted (stuck pattern) before this call ran' },
+        });
+      }
       const how =
         sig.kind === 'near'
           ? 'against the same target (only volatile args like maxBytes varied)'

--- a/packages/runner/src/unix-socket.test.ts
+++ b/packages/runner/src/unix-socket.test.ts
@@ -53,9 +53,17 @@ describe('unix-socket transport (NDJSON framing)', () => {
     const srv = await serverSide;
 
     const received: unknown[] = [];
-    srv.onFrame((f) => received.push(f));
+    // Wait until all five frames land rather than racing a fixed delay: the
+    // frames arrive in a single 'data' event, so a too-short timeout flakes to
+    // an empty array under CI load. The test's own timeout catches a genuine loss.
+    const got5 = new Promise<void>((resolve) => {
+      srv.onFrame((f) => {
+        received.push(f);
+        if (received.length === 5) resolve();
+      });
+    });
     for (let i = 0; i < 5; i++) client.send({ i });
-    await new Promise((r) => setTimeout(r, 30));
+    await got5;
     expect(received).toEqual([{ i: 0 }, { i: 1 }, { i: 2 }, { i: 3 }, { i: 4 }]);
   });
 


### PR DESCRIPTION
## Symptom

A tool call renders **"running" forever**, then flips to **error** the moment you send another message — and you can type a new message while it's still spinning.

## Root cause

The visible "flip to error" is just the safety net firing: the desktop fold (`pair-events.ts` `markOrphansAtTurnBoundary`) marks any tool still at `outcome: null` as a synthetic error when the next `user_prompt` arrives. And the composer re-enables (so you can type while it spins) because that's driven by the separate `runner.turn.complete` channel, **not** the event log.

The real bug: in **`mode-tool-use` (the default mode)** and **`mode-goal`**, `emitRequestsAndDetectStuck` emits `tool_call_requested` for the whole batch up front, then `return`s on a stuck-loop trip **without running `executeToolUses`** — leaving those requests orphaned (no matching `tool_result`). The turn still ends cleanly, so the call spins until the next prompt sweeps it into an error. The provider also rejects the unresolved `tool_use` block on the following turn.

This is a known class of bug — `mode-plan-execute` and `mode-developer` were already fixed for it (see the `execute-phase.ts` comment: *"exactly the infinite-loop shape the user hit"*). The fix just never reached the two main modes.

## Fix

Both modes now synthesize a failed `tool_result` (`kind: 'aborted'`) for every already-emitted request before bailing on a stuck trip, mirroring `executeToolUses`' abort path. Keeps the event log well-formed (no orphan `tool_call_requested`) and stops the provider rejection on the next turn.

## Tests

- Extended the `mode-tool-use` stuck test to assert `tool_result` count equals `tool_call_requested` count.
- New per-callId regression test in both `mode-tool-use` and `mode-goal` asserting no requested callId is left without a result after a stuck trip.
- Verified the new tests **fail without the fix** (`expected [ 'c2' ] to deeply equal []`) and pass with it.
- Full repo build GREEN (55/55), typecheck clean.

## Follow-up (not in this PR)

There's a related, separate desktop fragility: the renderer's `applyEvent` appends live `runner.event` IPC with no seq/gap detection (unlike the gap-safe main-process mirror), and its persistence is fed from that same stream — so any *dropped* `runner.event` (window teardown race, driver recreation on reconnect) permanently desyncs the renderer and could produce the same stuck-tool symptom. Worth hardening with renderer-side gap-detect + resync in a separate change.