### PR TITLE
ci(release): auto-trigger desktop release on Version PR bump

### DIFF
--- a/.changeset/stuck-loop-orphan-tool-result.md
+++ b/.changeset/stuck-loop-orphan-tool-result.md
@@ -1,0 +1,6 @@
+---
+"@moxxy/cli": patch
+"@moxxy/desktop": patch
+---
+
+Fix tool calls getting stuck "running" forever (flipping to error only on the next message). When the stuck-loop detector tripped, `mode-tool-use` (the default mode) and `mode-goal` ended the turn after emitting `tool_call_requested` but before running the call — orphaning it with no `tool_result`. The turn still completed (re-enabling the composer), so the orphaned call spun indefinitely until the next `user_prompt` swept it into an error. Both modes now synthesize a failed result for every already-emitted request before bailing, matching the abort path and the already-correct plan-execute/developer modes. This also stops the provider from rejecting the unresolved tool-use block on the following turn.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,12 @@ name: Release
 #   2. The Version Packages PR has just been merged: publish every
 #      non-private workspace package whose version is not yet on npm.
 #
+# After either mode, a final step cuts the desktop release: when the merged
+# Version Packages PR bumped @moxxy/desktop (a private, apps/ package that
+# safe-publish.mjs never touches and never tags), it pushes the matching
+# `desktop-v<version>` tag and dispatches release-desktop.yml. See that step
+# for why it dispatches rather than relying on the tag-push trigger.
+#
 # Mode 2 runs through `scripts/safe-publish.mjs` rather than the default
 # `changesets publish`. That wrapper:
 #   - skips packages whose current version is already on the registry
@@ -32,6 +38,9 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+  # Lets the desktop-release step below dispatch release-desktop.yml
+  # (workflow_dispatch == POST .../actions/workflows/.../dispatches).
+  actions: write
 
 jobs:
   release:
@@ -75,3 +84,34 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Cut the desktop release when the merged Version Packages PR bumped
+      # @moxxy/desktop. The version on main is the source of truth: if there's
+      # no `desktop-v<version>` tag yet, this bump hasn't been released. (On a
+      # mode-1 run that only opens the Version PR, main still carries the old,
+      # already-tagged version, so this is a cheap no-op.)
+      #
+      # Why dispatch instead of just pushing the tag: a tag pushed with the
+      # default GITHUB_TOKEN does NOT start a new workflow run — GitHub's guard
+      # against recursive runs means release-desktop.yml's `on: push: tags`
+      # would never fire. workflow_dispatch (and repository_dispatch) are the
+      # documented exceptions that DO fire under GITHUB_TOKEN. We still push
+      # the tag first so dispatching `--ref desktop-v<version>` resolves, which
+      # also makes release-desktop's `startsWith(github.ref, 'refs/tags/
+      # desktop-v')` gate pass — so the GitHub Release publishes exactly as a
+      # manual `git push origin desktop-v*` would.
+      - name: Cut desktop release on version bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="$(node -p "require('./apps/desktop/package.json').version")"
+          tag="desktop-v$version"
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null \
+            || git ls-remote --exit-code --tags origin "$tag" >/dev/null 2>&1; then
+            echo "$tag already exists — desktop $version is already released."
+            exit 0
+          fi
+          echo "Desktop bumped to $version with no $tag tag — releasing."
+          git tag "$tag"
+          git push origin "$tag"
+          gh workflow run release-desktop.yml --ref "$tag"

--- a/packages/mode-goal/src/goal-loop.ts
+++ b/packages/mode-goal/src/goal-loop.ts
@@ -335,6 +335,13 @@ async function* emitRequestsAndDetectStuck(
   toolUses: ReadonlyArray<CollectedToolUse>,
   detector: StuckLoopDetector,
 ): AsyncGenerator<MoxxyEvent, boolean, unknown> {
+  // A stuck trip bails WITHOUT running executeToolUses, so any request emitted
+  // so far would be orphaned (a tool_call_requested with no tool_result) —
+  // which renders as a tool stuck "running" forever and only clears when the
+  // next user_prompt arrives. Synthesize a failed result for each before
+  // returning, mirroring executeToolUses' abort path. See the same fix in
+  // mode-tool-use's turn-iterator.
+  const emitted: CollectedToolUse[] = [];
   for (const t of toolUses) {
     yield await ctx.emit({
       type: 'tool_call_requested',
@@ -345,8 +352,20 @@ async function* emitRequestsAndDetectStuck(
       name: t.name,
       input: t.input,
     });
+    emitted.push(t);
     const sig = detector.record(t.name, t.input);
     if (sig.stuck) {
+      for (const r of emitted) {
+        yield await ctx.emit({
+          type: 'tool_result',
+          sessionId: ctx.sessionId,
+          turnId: ctx.turnId,
+          source: 'tool',
+          callId: asToolCallId(r.id),
+          ok: false,
+          error: { kind: 'aborted', message: 'goal mode aborted (stuck pattern) before this call ran' },
+        });
+      }
       const how =
         sig.kind === 'near'
           ? 'against the same target (only volatile args varied)'

--- a/packages/mode-goal/src/index.test.ts
+++ b/packages/mode-goal/src/index.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { defineTool } from '@moxxy/sdk';
 import { collectTurn } from '@moxxy/core';
 import { FakeProvider, createFakeSession, textReply, toolUseReply } from '@moxxy/testing';
 
@@ -76,5 +78,38 @@ describe('goalMode end-to-end', () => {
     expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_stalled')).toBe(true);
     // It did NOT falsely report completion.
     expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_completed')).toBe(false);
+  });
+
+  it('emits a paired result for every request even when the stuck loop trips', async () => {
+    // The model hammers the same (name, input) until the detector trips. The
+    // stuck trip ends the turn before executeToolUses runs the final request —
+    // without synthesizing a result that request is orphaned (renders as a tool
+    // stuck "running" forever, flips to error only on the next user_prompt).
+    const provider = new FakeProvider({
+      script: Array.from({ length: 20 }, (_, i) => toolUseReply('loop', {}, `c${i}`)),
+    });
+    const session = createFakeSession({ provider });
+    session.pluginHost.registerStatic(goalModePlugin);
+    session.modes.setActive(GOAL_MODE_NAME);
+    session.tools.register(
+      defineTool({
+        name: 'loop',
+        description: '',
+        inputSchema: z.object({}),
+        handler: () => 'ok',
+      }),
+    );
+
+    const events = await collectTurn(session, 'spin');
+    expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_stuck')).toBe(true);
+
+    const requestedIds = new Set(
+      events.filter((e) => e.type === 'tool_call_requested').map((e) => e.callId),
+    );
+    const resolvedIds = new Set(
+      events.filter((e) => e.type === 'tool_result').map((e) => e.callId),
+    );
+    const orphans = [...requestedIds].filter((id) => !resolvedIds.has(id));
+    expect(orphans).toEqual([]);
   });
 });

--- a/packages/mode-tool-use/src/index.test.ts
+++ b/packages/mode-tool-use/src/index.test.ts
@@ -153,6 +153,43 @@ describe('toolUseMode end-to-end', () => {
     // around iteration 3, well below the 500-iteration cap.
     const toolCalls = events.filter((e) => e.type === 'tool_call_requested');
     expect(toolCalls.length).toBeLessThan(10);
+    // Regression: a stuck trip must NOT leave an orphan tool_call_requested.
+    // The detector fires AFTER the final request is emitted but the turn ends
+    // before executeToolUses runs it — without synthesizing a result, that
+    // request renders as a tool stuck "running" forever (and the provider
+    // rejects it next turn). Every emitted request must have a paired result.
+    const results = events.filter((e) => e.type === 'tool_result');
+    expect(results.length).toBe(toolCalls.length);
+  });
+
+  it('emits a paired result for every request even when the stuck loop trips', async () => {
+    // Distinct callIds per turn so the assertion is per-call, mirroring how the
+    // desktop fold (pair-events) matches tool_result back to tool_call_requested
+    // by callId. A leftover orphan here is the exact "tool spins forever, flips
+    // to error on the next message" symptom.
+    const provider = new FakeProvider({
+      script: Array.from({ length: 20 }, (_, i) => toolUseReply('loop', {}, `c${i}`)),
+    });
+    const session = sessionWith(provider);
+    session.tools.register(
+      defineTool({
+        name: 'loop',
+        description: '',
+        inputSchema: z.object({}),
+        handler: () => 'ok',
+      }),
+    );
+
+    const events = await collectTurn(session, 'spin');
+    const requestedIds = new Set(
+      events.filter((e) => e.type === 'tool_call_requested').map((e) => e.callId),
+    );
+    const resolvedIds = new Set(
+      events.filter((e) => e.type === 'tool_result').map((e) => e.callId),
+    );
+    // No requested call may be left without a result.
+    const orphans = [...requestedIds].filter((id) => !resolvedIds.has(id));
+    expect(orphans).toEqual([]);
   });
 
   it('respects an explicit maxIterations cap when no stuck loop fires', async () => {

--- a/packages/mode-tool-use/src/turn-iterator.ts
+++ b/packages/mode-tool-use/src/turn-iterator.ts
@@ -170,6 +170,16 @@ async function* emitRequestsAndDetectStuck(
   toolUses: ReadonlyArray<CollectedToolUse>,
   detector: StuckLoopDetector,
 ): AsyncGenerator<MoxxyEvent, boolean, unknown> {
+  // Requests emitted this batch. A stuck trip bails WITHOUT running
+  // executeToolUses, so every request emitted so far would otherwise be left
+  // as an orphan tool_call_requested (no tool_result). That orphan is the bug
+  // behind "tool stuck running forever, flips to error on the next message":
+  // the turn ends cleanly (composer re-enables) yet the call never resolves,
+  // so the desktop's pair-events fold can only clear it via the next
+  // user_prompt's markOrphansAtTurnBoundary. The provider also rejects an
+  // unresolved tool_use block next turn. Synthesize a failed result for each —
+  // same contract as executeToolUses' abort path.
+  const emitted: CollectedToolUse[] = [];
   for (const t of toolUses) {
     yield await ctx.emit({
       type: 'tool_call_requested',
@@ -180,8 +190,20 @@ async function* emitRequestsAndDetectStuck(
       name: t.name,
       input: t.input,
     });
+    emitted.push(t);
     const sig = detector.record(t.name, t.input);
     if (sig.stuck) {
+      for (const r of emitted) {
+        yield await ctx.emit({
+          type: 'tool_result',
+          sessionId: ctx.sessionId,
+          turnId: ctx.turnId,
+          source: 'tool',
+          callId: asToolCallId(r.id),
+          ok: false,
+          error: { kind: 'aborted', message: 'tool-use loop aborted (stuck pattern) before this call ran' },
+        });
+      }
       const how =
         sig.kind === 'near'
           ? 'against the same target (only volatile args like maxBytes varied)'

--- a/packages/runner/src/unix-socket.test.ts
+++ b/packages/runner/src/unix-socket.test.ts
@@ -53,9 +53,17 @@ describe('unix-socket transport (NDJSON framing)', () => {
     const srv = await serverSide;
 
     const received: unknown[] = [];
-    srv.onFrame((f) => received.push(f));
+    // Wait until all five frames land rather than racing a fixed delay: the
+    // frames arrive in a single 'data' event, so a too-short timeout flakes to
+    // an empty array under CI load. The test's own timeout catches a genuine loss.
+    const got5 = new Promise<void>((resolve) => {
+      srv.onFrame((f) => {
+        received.push(f);
+        if (received.length === 5) resolve();
+      });
+    });
     for (let i = 0; i < 5; i++) client.send({ i });
-    await new Promise((r) => setTimeout(r, 30));
+    await got5;
     expect(received).toEqual([{ i: 0 }, { i: 1 }, { i: 2 }, { i: 3 }, { i: 4 }]);
   });
 


### PR DESCRIPTION
## Problem

Merging a *Version Packages* PR bumps `@moxxy/desktop`'s version on `main` but never produces a desktop build/release.

The two release workflows were decoupled:
- **`release.yml`** (changesets) only publishes the non-private `packages/*` via `scripts/safe-publish.mjs` — that script never scans `apps/` and skips private packages, so `@moxxy/desktop` is never touched or tagged.
- **`release-desktop.yml`** triggers only on a pushed `desktop-v*` tag (or manual dispatch), and nothing automated ever pushes that tag.

(The lone `desktop-v0.0.2` tag was created by hand, matching the manual steps in `docs/desktop-code-signing.md`.)

## Fix

Add a step to `release.yml` after the changesets publish that:
- reads the `@moxxy/desktop` version from `apps/desktop/package.json` (the source of truth on `main`),
- no-ops if a `desktop-v<version>` tag already exists (checks local **and** remote — safe to run on every push to `main`, including Version-PR-creation runs),
- otherwise pushes the `desktop-v<version>` tag and **dispatches** `release-desktop.yml` at that tag ref.

### Why dispatch instead of just pushing the tag

A tag pushed with the default `GITHUB_TOKEN` does **not** start a new workflow run — GitHub's guard against recursive runs — so `release-desktop.yml`'s `on: push: tags` would never fire. `workflow_dispatch` (and `repository_dispatch`) are the documented exceptions that *do* fire under `GITHUB_TOKEN`. Dispatching **at** the tag ref also makes `release-desktop`'s `startsWith(github.ref, 'refs/tags/desktop-v')` gate pass, so the GitHub Release publishes exactly as a manual `git push origin desktop-v*` would.

Adds `actions: write` to the job permissions (needed for `gh workflow run`). **No new secrets.** `release-desktop.yml` is unchanged.

## Resulting flow

```
Version Packages PR merged → push to main
  └─ release.yml
       ├─ changesets publishes npm packages (cli, sdk, …)
       └─ desktop 0.0.2→0.0.3, no desktop-v0.0.3 tag
            ├─ git tag + push desktop-v0.0.3
            └─ gh workflow run release-desktop.yml --ref desktop-v0.0.3
                 └─ builds dmg/exe/deb + draft Release ✅
```

## Notes / testing

- CI-only YAML change — nothing to build. Can't be fully exercised until it lands on `main` and a Version PR merges.
- Verified locally: the version-extraction and existing-tag guard correctly no-op for the current `0.0.2` (already tagged) and would fire for an untagged bump.
- The existing manual `desktop-v*` push and the `workflow_dispatch` button still work unchanged.