### PR TITLE
feat(desktop): self-update — hot-update the JS app without reinstalling

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -98,6 +98,28 @@ jobs:
       - name: Build workspace
         run: pnpm build
 
+      # Tier-1 self-update assets: a gzipped {renderer + main + preload + IPC}
+      # bundle and an Ed25519-signed manifest, so the SAME dist that gets
+      # packaged below can also be hot-installed by existing clients without a
+      # reinstall. OS-independent JS → built once, on the Linux leg. Skipped when
+      # the signing key isn't configured (forks / PRs) — the floor still ships.
+      - name: Build + sign app update bundle
+        if: matrix.os == 'ubuntu-latest' && env.MOXXY_UPDATE_SIGNING_KEY != ''
+        env:
+          MOXXY_UPDATE_SIGNING_KEY: ${{ secrets.MOXXY_UPDATE_SIGNING_KEY }}
+          MOXXY_BUNDLE_NOTES: ${{ github.ref_name }}
+        run: node scripts/build-app-bundle.mjs
+
+      - name: Upload app update bundle
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-update-bundle
+          path: |
+            apps/desktop/release/update/moxxy-app-manifest.json
+            apps/desktop/release/update/moxxy-app-bundle-*.json.gz
+          if-no-files-found: ignore
+
       # Bundle a self-contained, pinned moxxy CLI INTO the app so the desktop
       # never depends on a globally-installed moxxy (or a system node — it's
       # run via Electron's Node). electron-builder ships resources/moxxy-cli
@@ -189,6 +211,8 @@ jobs:
             apps/desktop/release/*.exe
             apps/desktop/release/*.deb
             apps/desktop/release/*.AppImage
+            apps/desktop/release/*.yml
+            apps/desktop/release/*.blockmap
           if-no-files-found: ignore
 
   release:
@@ -204,6 +228,11 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
+      # NOTE: self-update needs PUBLISHED assets. The release is created as a
+      # DRAFT (human review of the unsigned build); the moxxy-app-manifest.json /
+      # bundle (Tier-1) and the electron-updater latest*.yml feed (Tier-2) only
+      # become downloadable via `releases/latest/download/...` once a human
+      # PUBLISHES this release. So: review → Publish → clients can update.
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,9 +58,9 @@ If you're a Claude Code agent or any other autonomous agent: read this file firs
 @moxxy/chat-model  UI-neutral chat model: event→block fold (tool/skill/subagent grouping) + format helpers + markdown AST + a chunked append log; shared by the Ink TUI and the desktop
 @moxxy/cli         the `moxxy` binary
 
-apps/desktop                 Electron desktop app — attaches to @moxxy/runner, renders a TUI-equivalent chat surface
+apps/desktop                 Electron desktop app — attaches to @moxxy/runner, renders a TUI-equivalent chat surface. Self-updates its JS layers (renderer+main+preload+IPC) via a signed app bundle behind an immutable bootstrap loader (electron/main/bootstrap.ts) — no reinstall; native-shell bumps go through electron-updater (Tier 2). See docs/desktop-self-update.md.
 @moxxy/desktop-ipc-contract  typed IPC boundary (channel names + payloads + Zod validation) shared by the desktop's main / preload / renderer
-@moxxy/desktop-host          the desktop's Electron main process: runner pool + supervisor, session driver, IPC handlers, append-only NDJSON chat log, security gates
+@moxxy/desktop-host          the desktop's Electron main process: runner pool + supervisor, session driver, IPC handlers, append-only NDJSON chat log, security gates, and the self-update gate/stager (the node-only @moxxy/desktop-host/app-update subpath baked into the bootstrap)
 @moxxy/desktop-ui            framework-light, dependency-free React UI primitives (single-file SVG Icon set, Modal/ConfirmModal portal, Skeleton placeholders); shared by the renderer and a future web channel
 ```
 

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -42,7 +42,15 @@ export default defineConfig({
     build: {
       outDir: 'dist-electron/main',
       rollupOptions: {
-        input: { index: path.resolve('electron/main/index.ts') },
+        // `bootstrap` is the packaged entry (package.json#main) — a tiny,
+        // dependency-free loader that picks which app bundle's `index.js` (the
+        // real main) to run. It imports no workspace deps, so Rollup keeps it
+        // out of `index.js`'s chunk graph and it stays the immutable "floor"
+        // that hot-updates can never replace.
+        input: {
+          index: path.resolve('electron/main/index.ts'),
+          bootstrap: path.resolve('electron/main/bootstrap.ts'),
+        },
         external: EXTERNAL_NATIVE,
       },
     },

--- a/apps/desktop/electron/main/bootstrap.ts
+++ b/apps/desktop/electron/main/bootstrap.ts
@@ -1,0 +1,122 @@
+/**
+ * Immutable bootstrap entry — the "floor".
+ *
+ * The packaged app's `package.json#main` points here, so this is the ONE piece
+ * of the desktop that a hot-update can never replace. Its sole job: choose which
+ * app bundle to run, then load that bundle's real main.
+ *
+ * "App bundle" = renderer + main + preload + IPC contract, shipped and activated
+ * TOGETHER. The bootstrap prefers a verified, user-updated bundle under
+ * `<userData>/app/<version>/` over the one baked into this `.app`, falling back
+ * to the baked floor whenever anything is missing, unverified, incompatible, or
+ * crashes on load. Because both sides of every IPC/protocol come from the same
+ * bundle, protocol changes ride a hot-update with no version skew.
+ *
+ * The real main resolves its preload + renderer paths relative to its own
+ * `import.meta.dirname`, so loading the userData copy automatically picks up that
+ * copy's preload + `dist/` — no per-path rewiring needed here.
+ *
+ * The verify-before-load GATE (Ed25519 signature, compatibility) lives in
+ * `@moxxy/desktop-host/app-update` and is BAKED into this file by electron-vite,
+ * so the thing deciding what to run is part of the floor an attacker can't
+ * replace — never the hot-updatable `index.js`.
+ */
+import { app } from 'electron';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  resolveActiveBundle,
+  recoverFromFailedBoot,
+  writeBreadcrumb,
+  markBad,
+  setupNativeResolution,
+} from '@moxxy/desktop-host/app-update';
+
+import { BUNDLED_UPDATE_PUBLIC_KEY } from './update-key.js';
+
+/** Dir holding this bootstrap + the baked floor `index.js` (…/dist-electron/main). */
+const floorMainDir = import.meta.dirname;
+/** The floor bundle root: the dir that contains `dist-electron/` + `dist/`. */
+const floorRoot = path.join(floorMainDir, '..', '..');
+const floorEntry = path.join(floorMainDir, 'index.js');
+
+/** Load a real main entry for its side effects (it drives the whole app). */
+async function load(entry: string): Promise<void> {
+  await import(pathToFileURL(entry).href);
+}
+
+async function boot(): Promise<void> {
+  // Let a userData bundle resolve the shell's optional native deps (keychain).
+  setupNativeResolution(floorRoot);
+
+  let entry = floorEntry;
+  let overrideVersion: string | null = null;
+
+  // Self-update is packaged-only; in dev the renderer is served from Vite and
+  // there is no userData bundle to prefer.
+  if (app.isPackaged) {
+    try {
+      const userData = app.getPath('userData');
+      // Poison a bundle that loaded last launch but never confirmed healthy
+      // (white-screen / async crash), rolling `active` back to the last good one.
+      const recovery = recoverFromFailedBoot(userData);
+      if (recovery.poisoned) {
+        console.warn(
+          `[moxxy] bootstrap: bundle ${recovery.poisoned} never confirmed healthy; poisoned` +
+            (recovery.rolledBackTo ? `, rolled back to ${recovery.rolledBackTo}` : ', using floor'),
+        );
+      }
+      const picked = resolveActiveBundle({
+        userDataDir: userData,
+        publicKeyPem: BUNDLED_UPDATE_PUBLIC_KEY,
+        shell: { electron: process.versions.electron, nodeAbi: process.versions.modules ?? '' },
+      });
+      if (picked) {
+        entry = path.join(picked.root, 'dist-electron', 'main', 'index.js');
+        overrideVersion = picked.version;
+        // Tell the running main which bundle it is — drives `app.updateInfo` and
+        // the boot-probe (the real main confirms a healthy boot for this version).
+        process.env.MOXXY_APP_BUNDLE_ROOT = picked.root;
+        process.env.MOXXY_APP_BUNDLE_VERSION = picked.version;
+        // Breadcrumb BEFORE load: if this version then crashes before it can
+        // confirm itself healthy, the next launch sees an unconfirmed attempt
+        // and poisons it.
+        writeBreadcrumb(userData, picked.version);
+      }
+    } catch {
+      // Any resolution failure → run the floor.
+      entry = floorEntry;
+      overrideVersion = null;
+    }
+  }
+
+  try {
+    await load(entry);
+  } catch (err) {
+    if (overrideVersion) {
+      // The override's main threw while loading — poison it so it's never picked
+      // again, then recover on the floor in the same launch.
+      try {
+        markBad(app.getPath('userData'), overrideVersion);
+      } catch {
+        /* best effort */
+      }
+      delete process.env.MOXXY_APP_BUNDLE_ROOT;
+      delete process.env.MOXXY_APP_BUNDLE_VERSION;
+      console.error(
+        `[moxxy] bootstrap: app bundle ${overrideVersion} failed to load; reverting to floor:`,
+        err,
+      );
+      await load(floorEntry);
+    } else {
+      throw err;
+    }
+  }
+}
+
+void boot().catch((err) => {
+  // The floor itself failing to load is unrecoverable — surface it loudly rather
+  // than dying with a silent unhandled rejection.
+  console.error('[moxxy] bootstrap: failed to load app main:', err);
+  app.quit();
+});

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -35,6 +35,10 @@ import {
   preferredCliEntry,
 } from '@moxxy/desktop-host';
 
+import { BUNDLED_UPDATE_PUBLIC_KEY } from './update-key.js';
+import { readConfirmed, markBad } from '@moxxy/desktop-host/app-update';
+import { initShellUpdater } from './shell-updater.js';
+
 // In a packaged build there is no global `moxxy` (and a GUI launch has no
 // shell PATH / system `node`). Point the CLI resolver at a self-contained,
 // pinned CLI run via Electron's own Node (ELECTRON_RUN_AS_NODE), preferring a
@@ -413,6 +417,43 @@ function installApplicationMenu(
 
 let trayInstance: Tray | null = null;
 
+/** How long a hot-updated bundle has to confirm a healthy render before the
+ *  probe assumes it white-screened and reverts to the floor. Generous so a slow
+ *  cold start / Clerk network round-trip can't false-trip it. */
+const BOOT_PROBE_TIMEOUT_MS = 15_000;
+
+/**
+ * In-session safety net for a hot-updated bundle: if the renderer loads but its
+ * React tree never mounts (white-screen) — so `app.appBooted` never fires and no
+ * `confirmed.json` lands — poison this version and relaunch. The bootstrap then
+ * picks the previous-good bundle (or the floor). A no-op on the bundled floor
+ * (no override version), and on the bundled floor we never re-arm, so there's no
+ * relaunch loop. The cross-launch `recoverFromFailedBoot` is the belt to this
+ * braces — either one alone recovers the app.
+ */
+function armBootProbe(window: BrowserWindow): void {
+  const version = process.env.MOXXY_APP_BUNDLE_VERSION;
+  if (!version) return; // running the floor — nothing to probe
+  const userData = app.getPath('userData');
+  window.webContents.once('did-finish-load', () => {
+    setTimeout(() => {
+      if (window.isDestroyed()) return;
+      if (readConfirmed(userData) === version) return; // confirmed healthy
+      console.error(
+        `[moxxy] boot-probe: bundle ${version} did not confirm a healthy render in ` +
+          `${BOOT_PROBE_TIMEOUT_MS}ms; reverting to the previous bundle`,
+      );
+      try {
+        markBad(userData, version);
+      } catch {
+        /* best effort */
+      }
+      app.relaunch();
+      app.quit();
+    }, BOOT_PROBE_TIMEOUT_MS);
+  });
+}
+
 app.whenReady().then(async () => {
   // Apply the Content-Security-Policy to our own document responses
   // before any window loads. Skipped in dev (Vite HMR needs a loose
@@ -448,9 +489,22 @@ app.whenReady().then(async () => {
     await pool.getOrCreate(UNBOUND_ID, null);
     pool.setActive(UNBOUND_ID);
   }
-  registerIpcHandlers(pool, desks);
+  registerIpcHandlers(pool, desks, {
+    update: {
+      publicKeyPem: BUNDLED_UPDATE_PUBLIC_KEY,
+      // Dev/test escape hatch: point the updater at a local manifest. Ignored in
+      // packaged builds (the handler pins the source) so it can't be abused.
+      manifestUrl: process.env.MOXXY_UPDATE_URL,
+    },
+  });
 
   await createWindow();
+  if (mainWindow) armBootProbe(mainWindow);
+
+  // Tier-2: background download of a new native shell where supported
+  // (Windows/Linux); a no-op on dev + unsigned macOS. Tier-1 JS hot-updates
+  // (the common case) are independent of this.
+  initShellUpdater();
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) void createWindow();

--- a/apps/desktop/electron/main/shell-updater.ts
+++ b/apps/desktop/electron/main/shell-updater.ts
@@ -1,0 +1,51 @@
+/**
+ * Tier-2 updates: replacing the native shell (Electron/Chromium/Node or a
+ * changed native-module ABI) — the rare case a JS hot-update (Tier-1) can't
+ * cover. Uses electron-updater against the same GitHub Releases feed the app
+ * already publishes to (`package.json#build.publish`).
+ *
+ *   - Windows / Linux: background download + install on the next quit
+ *     ("Restart to update"), surfaced by electron-updater's own notification.
+ *   - macOS: a NO-OP here. Squirrel.Mac refuses to apply an update unless the
+ *     app is Developer-ID-signed + notarized, which these builds are not. Until
+ *     signing lands, macOS shell updates are notify-only — surfaced by the
+ *     Tier-1 "needs a full app update" banner, which links to the release page.
+ *
+ * Everything is lazy-imported and fully guarded: if electron-updater isn't
+ * present (e.g. not packaged) or the check fails (offline), the app keeps
+ * running and Tier-1 hot-updates are unaffected.
+ */
+
+import { app } from 'electron';
+
+export function initShellUpdater(): void {
+  // Packaged only (no feed in dev), and not on unsigned macOS.
+  if (!app.isPackaged || process.platform === 'darwin') return;
+
+  void (async () => {
+    try {
+      const mod = (await import('electron-updater')) as {
+        autoUpdater?: ElectronAutoUpdater;
+        default?: { autoUpdater?: ElectronAutoUpdater };
+      };
+      const autoUpdater = mod.autoUpdater ?? mod.default?.autoUpdater;
+      if (!autoUpdater) return;
+
+      // Download in the background; install when the user next quits. Combined
+      // with electron-updater's notification this is "update arrives silently,
+      // applies on restart" — no manual download/reinstall.
+      autoUpdater.autoDownload = true;
+      autoUpdater.autoInstallOnAppQuit = true;
+      await autoUpdater.checkForUpdatesAndNotify();
+    } catch (err) {
+      console.warn('[moxxy] shell updater unavailable (Tier-1 hot-updates still work):', err);
+    }
+  })();
+}
+
+/** The slice of electron-updater's autoUpdater we touch. */
+interface ElectronAutoUpdater {
+  autoDownload: boolean;
+  autoInstallOnAppQuit: boolean;
+  checkForUpdatesAndNotify(): Promise<unknown>;
+}

--- a/apps/desktop/electron/main/update-key.ts
+++ b/apps/desktop/electron/main/update-key.ts
@@ -17,4 +17,7 @@
  * The PEM must be the literal multi-line block, including the
  * -----BEGIN/END PUBLIC KEY----- lines.
  */
-export const BUNDLED_UPDATE_PUBLIC_KEY = '';
+export const BUNDLED_UPDATE_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAALQzzfvrq54zt+cgfcisTH5F25gO2dSFkw8UW3eS0Uw=
+-----END PUBLIC KEY-----
+`;

--- a/apps/desktop/electron/main/update-key.ts
+++ b/apps/desktop/electron/main/update-key.ts
@@ -1,0 +1,20 @@
+/**
+ * Baked Ed25519 PUBLIC key (SPKI PEM) — the root of trust for desktop
+ * self-updates. The bootstrap loads a hot-updated app bundle ONLY if its
+ * manifest carries a valid signature from the matching private key (held by the
+ * release owner as the `MOXXY_UPDATE_SIGNING_KEY` CI secret).
+ *
+ * EMPTY string ⇒ self-update is DISABLED: the bootstrap always runs the bundled
+ * floor and the in-app updater refuses to download. This is the safe default —
+ * an unconfigured build can never be tricked into loading an unsigned bundle.
+ *
+ * To enable self-updates, generate ONE keypair and paste the public SPKI PEM
+ * below (keep the private key secret, add it as `MOXXY_UPDATE_SIGNING_KEY`):
+ *
+ *   openssl genpkey -algorithm ed25519 -out moxxy-update.key
+ *   openssl pkey -in moxxy-update.key -pubout          # paste the output below
+ *
+ * The PEM must be the literal multi-line block, including the
+ * -----BEGIN/END PUBLIC KEY----- lines.
+ */
+export const BUNDLED_UPDATE_PUBLIC_KEY = '';

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
     "directory": "apps/desktop"
   },
   "type": "module",
-  "main": "dist-electron/main/index.js",
+  "main": "dist-electron/main/bootstrap.js",
   "scripts": {
     "dev": "electron-vite dev",
     "build": "electron-vite build",
@@ -35,6 +35,7 @@
     "@moxxy/plugin-vault": "workspace:*",
     "@moxxy/runner": "workspace:*",
     "@moxxy/sdk": "workspace:*",
+    "electron-updater": "^6.8.3",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-markdown": "^9.0.1",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -16,7 +16,9 @@ import { WorkspaceSidebar, type View } from './shell/WorkspaceSidebar';
 import { ContextRail } from './shell/ContextRail';
 import { WorkflowsPanel } from './workflows/WorkflowsPanel';
 import { SettingsPanel } from './settings/SettingsPanel';
+import { UpdateBanner } from './shell/UpdateBanner';
 import { Splash } from './Splash';
+import { api } from './lib/api';
 
 /**
  * Top-level shell. Three layers of gating, in order:
@@ -52,6 +54,12 @@ export function App(): JSX.Element {
   useEffect(() => {
     chatStore.setActive(activeWorkspaceId);
   }, [activeWorkspaceId]);
+
+  // Boot-probe heartbeat: the React tree mounted, so a hot-updated bundle is
+  // healthy — tell main to confirm it (no-op on the bundled floor). Fired once.
+  useEffect(() => {
+    void api().invoke('app.appBooted').catch(() => undefined);
+  }, []);
 
   // First-run gate. Block on prefs loading so we never flash the
   // main UI before deciding whether onboarding is needed.
@@ -132,6 +140,7 @@ export function App(): JSX.Element {
     <div className="app-shell">
       <ConnectionBridge />
       <ChatStoreBridge />
+      <UpdateBanner />
       <WorkspaceSidebar view={view} onView={setView} />
       {view === 'chat' && (
         <>

--- a/apps/desktop/src/lib/useAppUpdate.ts
+++ b/apps/desktop/src/lib/useAppUpdate.ts
@@ -1,0 +1,111 @@
+/**
+ * Renderer-side state machine for the dashboard self-update flow, shared by the
+ * About → Updates panel and the launch banner.
+ *
+ * Drives the three IPC commands (`app.updateInfo` / `app.checkUpdate` /
+ * `app.updateDashboard`) and subscribes to `app.update.progress` so the UI can
+ * show a bar while the bundle downloads. The actual download/verify/install all
+ * happen main-side; this only orchestrates and reflects status.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  AppUpdateCheck,
+  AppUpdateInfo,
+  AppUpdateProgress,
+} from '@moxxy/desktop-ipc-contract';
+import { api } from '@/lib/api';
+import { toErrorMessage } from '@/lib/errors';
+
+export type UpdateState =
+  | 'idle'
+  | 'checking'
+  | 'uptodate'
+  | 'available' // newer + compatible → can hot-update
+  | 'incompatible' // newer but needs a full app/shell update
+  | 'unavailable' // not configured / dev / offline
+  | 'updating'
+  | 'staged' // installed; relaunch to apply
+  | 'error';
+
+export interface UseAppUpdate {
+  info: AppUpdateInfo | null;
+  check: AppUpdateCheck | null;
+  state: UpdateState;
+  progress: AppUpdateProgress | null;
+  error: string | null;
+  stagedVersion: string | null;
+  runCheck: () => Promise<void>;
+  runUpdate: () => Promise<void>;
+  relaunch: () => void;
+}
+
+export function useAppUpdate(opts: { autoCheck?: boolean } = {}): UseAppUpdate {
+  const [info, setInfo] = useState<AppUpdateInfo | null>(null);
+  const [check, setCheck] = useState<AppUpdateCheck | null>(null);
+  const [state, setState] = useState<UpdateState>('idle');
+  const [progress, setProgress] = useState<AppUpdateProgress | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [stagedVersion, setStagedVersion] = useState<string | null>(null);
+  const autoChecked = useRef(false);
+
+  useEffect(() => {
+    void api()
+      .invoke('app.updateInfo')
+      .then(setInfo)
+      .catch(() => setInfo(null));
+  }, []);
+
+  useEffect(() => {
+    const off = api().subscribe('app.update.progress', (p: AppUpdateProgress) => setProgress(p));
+    return off;
+  }, []);
+
+  const runCheck = useCallback(async (): Promise<void> => {
+    setState('checking');
+    setError(null);
+    try {
+      const c = await api().invoke('app.checkUpdate');
+      setCheck(c);
+      if (c.error) setState('unavailable');
+      else if (!c.available) setState('uptodate');
+      else if (!c.compatible) setState('incompatible');
+      else setState('available');
+    } catch (e) {
+      setError(toErrorMessage(e));
+      setState('error');
+    }
+  }, []);
+
+  const runUpdate = useCallback(async (): Promise<void> => {
+    setState('updating');
+    setError(null);
+    setProgress(null);
+    try {
+      const r = await api().invoke('app.updateDashboard');
+      if (r.ok && r.version) {
+        setStagedVersion(r.version);
+        setState('staged');
+      } else {
+        setError(r.error ?? 'Update failed.');
+        setState('error');
+      }
+    } catch (e) {
+      setError(toErrorMessage(e));
+      setState('error');
+    }
+  }, []);
+
+  const relaunch = useCallback((): void => {
+    void api().invoke('app.relaunch').catch(() => undefined);
+  }, []);
+
+  useEffect(() => {
+    if (opts.autoCheck && !autoChecked.current) {
+      autoChecked.current = true;
+      void runCheck();
+    }
+  }, [opts.autoCheck, runCheck]);
+
+  return { info, check, state, progress, error, stagedVersion, runCheck, runUpdate, relaunch };
+}

--- a/apps/desktop/src/settings/AboutTab.tsx
+++ b/apps/desktop/src/settings/AboutTab.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from 'react';
 import { api } from '@/lib/api';
 import { toErrorMessage } from '@/lib/errors';
 import { Section } from './settings-primitives';
+import { DashboardUpdateSection } from './DashboardUpdateSection';
 
 export function AboutTab(): JSX.Element {
   const [info, setInfo] = useState<{ version: string | null; path: string | null } | null>(null);
@@ -64,10 +65,12 @@ export function AboutTab(): JSX.Element {
   };
 
   return (
-    <Section
-      title="moxxy CLI"
-      description="The desktop runs a bundled moxxy CLI. Update to the latest published version without reinstalling the app."
-    >
+    <>
+      <DashboardUpdateSection />
+      <Section
+        title="moxxy CLI"
+        description="The desktop runs a bundled moxxy CLI. Update to the latest published version without reinstalling the app."
+      >
       <div
         style={{
           display: 'flex',
@@ -165,6 +168,7 @@ export function AboutTab(): JSX.Element {
           </pre>
         )}
       </div>
-    </Section>
+      </Section>
+    </>
   );
 }

--- a/apps/desktop/src/settings/DashboardUpdateSection.tsx
+++ b/apps/desktop/src/settings/DashboardUpdateSection.tsx
@@ -1,0 +1,188 @@
+/**
+ * About → "Dashboard" section: shows the app bundle (renderer + main + IPC) the
+ * desktop is currently running and lets the user pull a newer one WITHOUT
+ * reinstalling. A hot-update — the bundled binary is never exchanged; only the
+ * JS bundle under userData is swapped, taking effect on the next launch.
+ *
+ * The download/verify/install runs main-side (signature-checked); this is the
+ * front end of {@link useAppUpdate}.
+ */
+
+import { api } from '@/lib/api';
+import { useAppUpdate, type UpdateState } from '@/lib/useAppUpdate';
+import { Section } from './settings-primitives';
+
+function statusLine(state: UpdateState, latest: string | null): string | null {
+  switch (state) {
+    case 'checking':
+      return 'Checking for updates…';
+    case 'uptodate':
+      return 'You’re on the latest dashboard.';
+    case 'available':
+      return `Version ${latest} is available.`;
+    case 'incompatible':
+      return 'A newer version needs a full app update (reinstall).';
+    case 'unavailable':
+      return null; // shown via the check.error / muted note instead
+    case 'updating':
+      return 'Installing…';
+    case 'staged':
+      return 'Installed. Relaunch to apply.';
+    case 'error':
+      return null;
+    default:
+      return null;
+  }
+}
+
+export function DashboardUpdateSection(): JSX.Element {
+  const { info, check, state, progress, error, stagedVersion, runCheck, runUpdate, relaunch } =
+    useAppUpdate();
+
+  const configured = info?.channelConfigured ?? false;
+  const pct =
+    progress?.total && progress.received != null
+      ? Math.min(100, Math.round((progress.received / progress.total) * 100))
+      : null;
+  const status = statusLine(state, check?.latestVersion ?? null);
+
+  return (
+    <Section
+      title="Dashboard"
+      description="The desktop UI + app code update on their own — no reinstall. A new version downloads in the background and applies on the next launch."
+    >
+      <div style={card}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+          <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-text-muted)' }}>
+            Version
+          </span>
+          <span
+            className="mono"
+            style={{ fontSize: 13.5, fontWeight: 700, color: 'var(--color-text)' }}
+          >
+            {info ? info.version : '…'}
+          </span>
+          {info && (
+            <span style={badge(info.source === 'updated')}>
+              {info.source === 'updated' ? 'updated' : 'bundled'}
+            </span>
+          )}
+        </div>
+
+        {!configured && info && (
+          <p style={{ margin: 0, fontSize: 12.5, color: 'var(--color-text-dim)', lineHeight: 1.5 }}>
+            Automatic updates aren’t configured for this build. New versions are installed by
+            downloading the app.
+          </p>
+        )}
+
+        {status && (
+          <p
+            style={{
+              margin: 0,
+              fontSize: 12.5,
+              fontWeight: 600,
+              color: state === 'staged' || state === 'available' ? 'var(--color-green)' : 'var(--color-text-muted)',
+            }}
+          >
+            {status}
+          </p>
+        )}
+
+        {state === 'updating' && (
+          <div style={{ height: 6, borderRadius: 999, background: 'var(--color-card-border)', overflow: 'hidden' }}>
+            <div
+              style={{
+                height: '100%',
+                width: pct != null ? `${pct}%` : '40%',
+                background: 'var(--color-primary)',
+                transition: 'width 160ms',
+              }}
+            />
+          </div>
+        )}
+
+        {error && (
+          <p role="alert" style={{ margin: 0, fontSize: 12.5, color: 'var(--color-red)', lineHeight: 1.5 }}>
+            {error}
+          </p>
+        )}
+
+        <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+          {state === 'staged' ? (
+            <button type="button" data-testid="relaunch-app" style={primaryBtn(false)} onClick={relaunch}>
+              Relaunch now
+            </button>
+          ) : state === 'available' ? (
+            <button
+              type="button"
+              data-testid="update-dashboard"
+              style={primaryBtn(false)}
+              onClick={() => void runUpdate()}
+            >
+              Update dashboard
+            </button>
+          ) : state === 'incompatible' && check?.releaseUrl ? (
+            <button
+              type="button"
+              style={primaryBtn(false)}
+              onClick={() => void api().invoke('onboarding.openExternal', { url: check.releaseUrl! })}
+            >
+              Get the update
+            </button>
+          ) : (
+            <button
+              type="button"
+              data-testid="check-update"
+              style={primaryBtn(state === 'checking' || state === 'updating' || !configured)}
+              disabled={state === 'checking' || state === 'updating' || !configured}
+              onClick={() => void runCheck()}
+            >
+              {state === 'checking' ? 'Checking…' : 'Check for updates'}
+            </button>
+          )}
+        </div>
+
+        {stagedVersion && state === 'staged' && (
+          <p style={{ margin: 0, fontSize: 11.5, color: 'var(--color-text-dim)' }}>
+            v{stagedVersion} will load on the next start.
+          </p>
+        )}
+      </div>
+    </Section>
+  );
+}
+
+const card: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+  padding: '16px 18px',
+  background: 'var(--color-card-bg)',
+  border: '1px solid var(--color-card-border)',
+  borderRadius: 14,
+};
+
+const primaryBtn = (disabled: boolean): React.CSSProperties => ({
+  alignSelf: 'flex-start',
+  padding: '9px 16px',
+  fontSize: 13,
+  fontWeight: 600,
+  borderRadius: 10,
+  color: '#fff',
+  border: 'none',
+  background: disabled ? 'var(--color-card-border-strong)' : 'var(--color-primary)',
+  cursor: disabled ? 'default' : 'pointer',
+  transition: 'background 140ms',
+});
+
+const badge = (updated: boolean): React.CSSProperties => ({
+  fontSize: 10.5,
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: 0.4,
+  padding: '2px 7px',
+  borderRadius: 999,
+  color: updated ? 'var(--color-green)' : 'var(--color-text-dim)',
+  background: updated ? 'rgba(34,197,94,0.12)' : 'var(--color-card-border)',
+});

--- a/apps/desktop/src/shell/UpdateBanner.tsx
+++ b/apps/desktop/src/shell/UpdateBanner.tsx
@@ -1,0 +1,133 @@
+/**
+ * Top-of-window banner that surfaces a dashboard update found by the launch
+ * auto-check. Stays out of the way: it only appears when there's something to
+ * act on (a compatible hot-update, an in-progress install, a staged update
+ * waiting for relaunch, or a Tier-2 "needs a full app update" notice) and can be
+ * dismissed. The heavy lifting lives in {@link useAppUpdate}.
+ */
+
+import { useState } from 'react';
+import { api } from '@/lib/api';
+import { useAppUpdate } from '@/lib/useAppUpdate';
+
+export function UpdateBanner(): JSX.Element | null {
+  const { check, state, progress, error, stagedVersion, runUpdate, relaunch } = useAppUpdate({
+    autoCheck: true,
+  });
+  const [dismissed, setDismissed] = useState(false);
+
+  const visible =
+    !dismissed && (state === 'available' || state === 'updating' || state === 'staged' || state === 'incompatible');
+  if (!visible) return null;
+
+  const pct =
+    progress?.total && progress.received != null
+      ? Math.min(100, Math.round((progress.received / progress.total) * 100))
+      : null;
+
+  let body: JSX.Element;
+  if (state === 'available') {
+    body = (
+      <>
+        <span>
+          Dashboard update <strong>v{check?.latestVersion}</strong> available
+          {check?.notes ? ` — ${check.notes}` : ''}
+        </span>
+        <button type="button" style={primaryBtn} onClick={() => void runUpdate()}>
+          Update
+        </button>
+      </>
+    );
+  } else if (state === 'updating') {
+    body = (
+      <span>
+        Updating dashboard… {pct != null ? `${pct}%` : (progress?.message ?? '')}
+      </span>
+    );
+  } else if (state === 'staged') {
+    body = (
+      <>
+        <span>
+          Updated to <strong>v{stagedVersion}</strong>. Relaunch to apply.
+        </span>
+        <button type="button" style={primaryBtn} onClick={relaunch}>
+          Relaunch
+        </button>
+      </>
+    );
+  } else {
+    // incompatible → Tier-2 (full app update)
+    body = (
+      <>
+        <span>A new version needs a full app update.</span>
+        {check?.releaseUrl && (
+          <button
+            type="button"
+            style={primaryBtn}
+            onClick={() =>
+              void api().invoke('onboarding.openExternal', { url: check.releaseUrl! })
+            }
+          >
+            Get update
+          </button>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <div role="status" style={wrap}>
+      {body}
+      {error && <span style={{ color: 'var(--color-red)' }}>{error}</span>}
+      {state !== 'updating' && (
+        <button
+          type="button"
+          aria-label="Dismiss"
+          style={dismissBtn}
+          onClick={() => setDismissed(true)}
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  );
+}
+
+const wrap: React.CSSProperties = {
+  position: 'fixed',
+  top: 10,
+  left: '50%',
+  transform: 'translateX(-50%)',
+  zIndex: 60,
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 12,
+  padding: '8px 12px',
+  background: 'var(--color-card-bg)',
+  border: '1px solid var(--color-card-border)',
+  borderRadius: 12,
+  boxShadow: '0 18px 36px -18px rgba(15, 23, 42, 0.3)',
+  fontSize: 13,
+  color: 'var(--color-text)',
+  maxWidth: '80vw',
+};
+
+const primaryBtn: React.CSSProperties = {
+  padding: '5px 12px',
+  fontSize: 12.5,
+  fontWeight: 600,
+  borderRadius: 8,
+  color: '#fff',
+  background: 'var(--color-primary)',
+  cursor: 'pointer',
+  border: 'none',
+};
+
+const dismissBtn: React.CSSProperties = {
+  padding: '2px 6px',
+  fontSize: 12,
+  color: 'var(--color-text-dim)',
+  background: 'transparent',
+  border: 'none',
+  cursor: 'pointer',
+};

--- a/docs/desktop-self-update.md
+++ b/docs/desktop-self-update.md
@@ -1,0 +1,147 @@
+# Desktop self-update (hot-update the app without reinstalling)
+
+The **MoxxyAI Workspaces** desktop updates itself **without making users download
+and reinstall a new binary** for the common case. Most of the app is JavaScript —
+only the Electron/Chromium/Node shell is a true binary — so a release ships as a
+small signed JS bundle that the app verifies and swaps in on the next launch.
+
+This is the same trust model the app already uses to update the bundled
+`@moxxy/cli` (install into writable userData, prefer it over the bundled copy):
+here it's the desktop's **own** renderer + main + preload + IPC contract.
+
+---
+
+## Two tiers
+
+| | What changes | Mechanism | User experience |
+|---|---|---|---|
+| **Tier 1** (≈ every release) | renderer, main process, preload, **IPC/protocol**, any JS | Signed **app bundle** downloaded into `<userData>/app/<version>/`, activated on next launch | Banner → "Update" → relaunch. **No binary download.** |
+| **Tier 2** (rare) | Electron / Chromium / Node version, native-module ABI | `electron-updater` against GitHub Releases | Win/Linux: background download + install on restart. macOS: notify + open release page (until signed). |
+
+Tier 1 covers protocol/IPC changes safely because the renderer and the main
+process that talk to each other always come from the **same** bundle — there's
+never a version skew. You can rename/add/remove IPC commands freely.
+
+---
+
+## How Tier 1 works
+
+```
+package.json#main → dist-electron/main/bootstrap.js   ← the immutable "floor" (in the signed .app)
+                         │
+                         │ verify + pick
+                         ▼
+   <userData>/app/<version>/dist-electron/main/index.js   ← hot-updatable bundle (if present + valid)
+        else  <app>/dist-electron/main/index.js           ← bundled floor
+```
+
+1. **Bootstrap (`apps/desktop/electron/main/bootstrap.ts`)** is the only piece a
+   hot-update can never replace. It picks which bundle's real `index.js` to load,
+   verifying first. The verify/resolve logic + the baked public key are inlined
+   into `bootstrap.js`, so the gate lives in the part an attacker can't swap.
+2. **The real main** resolves its preload + renderer relative to its own
+   `import.meta.dirname`, so loading the userData copy automatically uses that
+   copy's preload + `dist/`. The whole bundle moves together.
+3. **The updater** (`@moxxy/desktop-host/app-update`, surfaced via the
+   `app.checkUpdate` / `app.updateDashboard` IPC and the About → Dashboard panel
+   + launch banner) fetches the manifest, verifies it, downloads + integrity-checks
+   the bundle, extracts it atomically, and flips `active.json`.
+4. **Boot-probe rollback** — the renderer pings `app.appBooted` once it renders;
+   a bundle that loads but never confirms (white-screen / crash) is poisoned and
+   the previous-good bundle (or the floor) is used. Both an in-session timer and
+   a next-launch check (`recoverFromFailedBoot`) cover this.
+
+### Security model
+
+- **Ed25519 signature** over the manifest (baked public key) — the root of trust.
+- **SHA-256** of the gzipped bundle, bound by the signed manifest.
+- **HTTPS + host-pin** to GitHub + its asset CDN; the update SOURCE is resolved
+  main-side only (the renderer never supplies a URL).
+- **Compatibility gate** (`minElectron`, optional `nodeAbi`) — an incompatible
+  bundle is treated as a Tier-2 (shell) update, never loaded as JS.
+- **Off by default:** with no public key baked in, the app always runs the floor
+  and the updater refuses to download. A build can't be tricked into loading an
+  unsigned bundle.
+
+---
+
+## Enabling it (one-time, owner)
+
+Self-update ships **disabled** until you bake a signing key.
+
+### 1. Generate the keypair
+
+```sh
+openssl genpkey -algorithm ed25519 -out moxxy-update.key   # PRIVATE — keep secret
+openssl pkey -in moxxy-update.key -pubout                  # PUBLIC — paste below
+```
+
+### 2. Bake the public key
+
+Paste the public SPKI PEM (the whole `-----BEGIN/END PUBLIC KEY-----` block) into
+`apps/desktop/electron/main/update-key.ts`:
+
+```ts
+export const BUNDLED_UPDATE_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEA...
+-----END PUBLIC KEY-----
+`;
+```
+
+### 3. Add the private key as a CI secret
+
+In GitHub → Settings → Secrets → Actions, add **`MOXXY_UPDATE_SIGNING_KEY`** =
+the contents of `moxxy-update.key`. The release workflow signs the manifest with
+it (and skips the bundle if it's absent — forks/PRs still build).
+
+### 4. Publish the release
+
+`release-desktop.yml` builds + signs the bundle and uploads
+`moxxy-app-manifest.json` + `moxxy-app-bundle-<version>.json.gz` (Tier 1) and the
+`latest*.yml` + blockmaps (Tier 2) on each `desktop-v*` tag.
+
+> **The release must be PUBLISHED, not left as a draft.** Clients fetch via
+> `releases/latest/download/...`, which only resolves to published releases. The
+> workflow creates a draft for review; **Publish** it to turn updates on.
+
+For Tier-2 auto-apply on macOS, also complete `docs/desktop-code-signing.md`
+(Developer ID signing + notarization). Until then macOS Tier-2 is notify-only.
+
+---
+
+## Verifying locally
+
+The full build → stage → load round-trip (including a renamed IPC command, to
+prove protocol changes ride Tier 1) is covered by the unit/integration tests:
+
+```sh
+pnpm --filter @moxxy/desktop-host test app-update
+```
+
+To exercise the publisher against a real `dist/`:
+
+```sh
+pnpm --filter @moxxy/desktop build
+MOXXY_UPDATE_SIGNING_KEY="$(cat moxxy-update.key)" node scripts/build-app-bundle.mjs
+# → apps/desktop/release/update/{moxxy-app-manifest.json, moxxy-app-bundle-<v>.json.gz}
+```
+
+A packaged end-to-end check (build vN, install vN+1 via a local manifest, confirm
+relaunch picks up the new bundle, corrupt it and confirm rollback) uses the
+`MOXXY_UPDATE_URL` dev override (honored only in non-packaged / dev runs).
+
+---
+
+## Files
+
+- `apps/desktop/electron/main/bootstrap.ts` — the immutable floor / loader.
+- `apps/desktop/electron/main/update-key.ts` — the baked public key.
+- `apps/desktop/electron/main/shell-updater.ts` — Tier-2 (electron-updater).
+- `packages/desktop-host/src/app-update/` — manifest + verify + resolve + stager +
+  build, exposed as the `@moxxy/desktop-host/app-update` subpath (node-builtins
+  only, baked into the bootstrap).
+- `packages/desktop-host/src/ipc/update.ts` — the `app.*` update IPC handlers.
+- `apps/desktop/src/settings/DashboardUpdateSection.tsx`,
+  `apps/desktop/src/shell/UpdateBanner.tsx`, `apps/desktop/src/lib/useAppUpdate.ts`
+  — the UI.
+- `scripts/build-app-bundle.mjs` — the CI publisher.

--- a/packages/desktop-host/package.json
+++ b/packages/desktop-host/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./app-update": {
+      "types": "./dist/app-update/index.d.ts",
+      "import": "./dist/app-update/index.js"
     }
   },
   "files": [

--- a/packages/desktop-host/src/app-update/build.ts
+++ b/packages/desktop-host/src/app-update/build.ts
@@ -1,0 +1,64 @@
+/**
+ * The publisher side: turn a built `dist/` + `dist-electron/` tree into the two
+ * release assets a client needs — the gzipped bundle payload and the signed
+ * manifest that authenticates it.
+ *
+ * Pure (node built-ins only) and shared by the `scripts/build-app-bundle.mjs`
+ * CLI and the integration test, so "what gets signed/produced" and "what the
+ * stager + bootstrap verify" can never drift apart.
+ */
+
+import { createHash, createPrivateKey, sign as cryptoSign } from 'node:crypto';
+import { gzipSync } from 'node:zlib';
+
+import { type AppManifest, canonicalManifestBytes } from './manifest.js';
+
+export interface BuildInput {
+  version: string;
+  minElectron: string;
+  /** `''` ⇒ ABI wildcard. */
+  nodeAbi: string;
+  /** Absolute HTTPS URL the bundle will be published at. */
+  bundleUrl: string;
+  /** Ed25519 PRIVATE key (PEM). */
+  privateKeyPem: string;
+  /** Bundle contents: dist-relative POSIX path → raw bytes. */
+  files: Record<string, Buffer>;
+  releaseUrl?: string;
+  notes?: string;
+}
+
+export interface BuildOutput {
+  manifest: AppManifest;
+  manifestJson: string;
+  bundleGz: Buffer;
+}
+
+export function buildAppBundle(input: BuildInput): BuildOutput {
+  const filesB64: Record<string, string> = {};
+  for (const [rel, buf] of Object.entries(input.files)) {
+    filesB64[rel] = buf.toString('base64');
+  }
+  const payload = JSON.stringify({ version: input.version, files: filesB64 });
+  const bundleGz = gzipSync(Buffer.from(payload, 'utf8'));
+  const sha256 = createHash('sha256').update(bundleGz).digest('hex');
+
+  const signed = {
+    version: input.version,
+    minElectron: input.minElectron,
+    nodeAbi: input.nodeAbi,
+    sha256,
+    bundleUrl: input.bundleUrl,
+  };
+  const signature = cryptoSign(
+    null,
+    canonicalManifestBytes(signed),
+    createPrivateKey(input.privateKeyPem),
+  ).toString('base64');
+
+  const manifest: AppManifest = { ...signed, signature };
+  if (input.releaseUrl) manifest.releaseUrl = input.releaseUrl;
+  if (input.notes) manifest.notes = input.notes;
+
+  return { manifest, manifestJson: JSON.stringify(manifest, null, 2), bundleGz };
+}

--- a/packages/desktop-host/src/app-update/index.ts
+++ b/packages/desktop-host/src/app-update/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure, dependency-free (node built-ins only) self-update surface, exposed as
+ * the `@moxxy/desktop-host/app-update` subpath so the immutable bootstrap can
+ * import + bake it WITHOUT pulling in the electron-coupled rest of desktop-host.
+ *
+ * Split intentionally:
+ *   - manifest.ts          — the signed document + Ed25519 verification (the trust root)
+ *   - resolve.ts           — the load-time gate + on-disk bundle state (active/bad/breadcrumb)
+ *   - native-resolution.ts — make the shell's optional native deps resolvable from a bundle
+ *   - stager.ts            — download → verify → atomically install a bundle (Phase 2)
+ */
+
+export {
+  type AppManifest,
+  SIGNED_FIELDS,
+  canonicalManifestBytes,
+  verifyManifestSignature,
+  parseManifest,
+} from './manifest.js';
+
+export {
+  type ShellInfo,
+  type ResolvedBundle,
+  type ResolveOpts,
+  isSafeVersion,
+  appUpdateDir,
+  bundleRoot,
+  readActiveVersion,
+  setActiveVersion,
+  readBadVersions,
+  markBad,
+  writeBreadcrumb,
+  readBreadcrumb,
+  markConfirmed,
+  readConfirmed,
+  compareSemver,
+  isCompatible,
+  resolveActiveBundle,
+  recoverFromFailedBoot,
+  type BootRecovery,
+  pruneBundles,
+} from './resolve.js';
+
+export { setupNativeResolution } from './native-resolution.js';
+
+export {
+  type StagerDeps,
+  type CheckResult,
+  type Progress,
+  type ProgressPhase,
+  isAllowedUpdateHost,
+  checkForUpdate,
+  downloadAndStage,
+} from './stager.js';
+
+export { type BuildInput, type BuildOutput, buildAppBundle } from './build.js';

--- a/packages/desktop-host/src/app-update/manifest.test.ts
+++ b/packages/desktop-host/src/app-update/manifest.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { generateKeyPairSync, sign as cryptoSign } from 'node:crypto';
+
+import {
+  type AppManifest,
+  canonicalManifestBytes,
+  parseManifest,
+  verifyManifestSignature,
+} from './manifest';
+
+/** Produce a signed manifest for an ad-hoc Ed25519 keypair. */
+function signed(overrides: Partial<AppManifest> = {}): {
+  manifest: AppManifest;
+  publicKeyPem: string;
+} {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const base: Omit<AppManifest, 'signature'> = {
+    version: '0.0.6',
+    minElectron: '33.0.0',
+    nodeAbi: '115',
+    sha256: 'a'.repeat(64),
+    bundleUrl: 'https://example.com/bundle.json.gz',
+    ...overrides,
+  };
+  const signature = cryptoSign(null, canonicalManifestBytes(base), privateKey).toString('base64');
+  const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+  return { manifest: { ...base, signature }, publicKeyPem };
+}
+
+describe('verifyManifestSignature', () => {
+  it('accepts a manifest signed by the matching key', () => {
+    const { manifest, publicKeyPem } = signed();
+    expect(verifyManifestSignature(manifest, publicKeyPem)).toBe(true);
+  });
+
+  it('rejects when a signed field is tampered after signing', () => {
+    const { manifest, publicKeyPem } = signed();
+    expect(verifyManifestSignature({ ...manifest, sha256: 'b'.repeat(64) }, publicKeyPem)).toBe(
+      false,
+    );
+    expect(
+      verifyManifestSignature({ ...manifest, bundleUrl: 'https://evil.test/x' }, publicKeyPem),
+    ).toBe(false);
+  });
+
+  it('rejects a signature from a different key', () => {
+    const { manifest } = signed();
+    const { publicKeyPem: otherKey } = signed();
+    expect(verifyManifestSignature(manifest, otherKey)).toBe(false);
+  });
+
+  it('rejects when no public key is configured (updates disabled)', () => {
+    const { manifest } = signed();
+    expect(verifyManifestSignature(manifest, '')).toBe(false);
+  });
+
+  it('never throws on a malformed key or signature', () => {
+    const { manifest } = signed();
+    expect(verifyManifestSignature({ ...manifest, signature: 'not-base64!!' }, 'garbage')).toBe(
+      false,
+    );
+  });
+});
+
+describe('parseManifest', () => {
+  it('parses a well-formed manifest and lowercases the hash', () => {
+    const { manifest } = signed({ sha256: 'A'.repeat(64) });
+    const parsed = parseManifest(JSON.stringify(manifest));
+    expect(parsed?.version).toBe('0.0.6');
+    expect(parsed?.sha256).toBe('a'.repeat(64));
+  });
+
+  it('keeps optional presentational fields', () => {
+    const { manifest } = signed();
+    const parsed = parseManifest(
+      JSON.stringify({ ...manifest, releaseUrl: 'https://x.test', notes: 'hi' }),
+    );
+    expect(parsed?.releaseUrl).toBe('https://x.test');
+    expect(parsed?.notes).toBe('hi');
+  });
+
+  it('returns null on bad json, missing fields, or a non-hex sha256', () => {
+    expect(parseManifest('{')).toBeNull();
+    expect(parseManifest('{}')).toBeNull();
+    const { manifest } = signed();
+    expect(parseManifest(JSON.stringify({ ...manifest, sha256: 'short' }))).toBeNull();
+    expect(parseManifest(JSON.stringify({ ...manifest, version: '' }))).toBeNull();
+  });
+});

--- a/packages/desktop-host/src/app-update/manifest.ts
+++ b/packages/desktop-host/src/app-update/manifest.ts
@@ -1,0 +1,109 @@
+/**
+ * The app-bundle manifest: the small signed document that names a hot-updatable
+ * desktop bundle, gates its compatibility, and binds it to a verified payload.
+ *
+ * This module is the root of the self-update trust model and is deliberately
+ * dependency-free (node built-ins only) so it can be baked, verbatim, into the
+ * immutable bootstrap (`apps/desktop/electron/main/bootstrap.ts`) AND reused by
+ * the download-side stager — the same canonicalization + verification on both
+ * the publisher and the loader.
+ *
+ * Trust chain: the manifest is Ed25519-signed by the release owner's private key
+ * (the `MOXXY_UPDATE_SIGNING_KEY` CI secret); the matching public key is baked
+ * into the bootstrap. The signature covers the bundle's `sha256`, so verifying
+ * the (tiny) manifest transitively authenticates the (large) bundle without
+ * signing the bundle directly.
+ */
+
+import { createPublicKey, verify as cryptoVerify } from 'node:crypto';
+
+export interface AppManifest {
+  /** Bundle version — also the on-disk dir name under `<userData>/app/<version>`. */
+  version: string;
+  /** Minimum Electron version (semver `x.y.z`) the bundle's main needs. */
+  minElectron: string;
+  /** Required Node/Electron ABI (`process.versions.modules`) — guards native
+   *  module skew. `''` is a wildcard ("any ABI"); the desktop's only native dep
+   *  is optional + unpackaged, so Electron-version gating normally suffices. */
+  nodeAbi: string;
+  /** SHA-256 (hex) of the gzipped bundle payload. */
+  sha256: string;
+  /** Ed25519 signature (base64) over {@link canonicalManifestBytes}. */
+  signature: string;
+  /** HTTPS URL of the gzipped bundle asset. */
+  bundleUrl: string;
+  /** Human-facing release page (optional). */
+  releaseUrl?: string;
+  /** Short release notes shown in the Updates UI (optional). */
+  notes?: string;
+}
+
+/**
+ * Fields covered by the signature, in fixed order — the canonical signing
+ * payload. The signature intentionally does NOT cover `releaseUrl`/`notes`
+ * (presentational) but DOES cover `bundleUrl` + `sha256` (so neither the source
+ * nor the payload can be swapped). Adding a security-relevant field means adding
+ * it HERE — the signer and verifier share this one list.
+ */
+export const SIGNED_FIELDS = [
+  'version',
+  'minElectron',
+  'nodeAbi',
+  'sha256',
+  'bundleUrl',
+] as const;
+
+type SignedField = (typeof SIGNED_FIELDS)[number];
+
+/** Deterministic bytes the signature is computed/verified over. */
+export function canonicalManifestBytes(m: Pick<AppManifest, SignedField>): Buffer {
+  const ordered: Record<string, string> = {};
+  for (const k of SIGNED_FIELDS) ordered[k] = String(m[k] ?? '');
+  return Buffer.from(JSON.stringify(ordered), 'utf8');
+}
+
+/**
+ * True iff `m.signature` is a valid Ed25519 signature over the canonical bytes
+ * for `publicKeyPem` (an SPKI PEM). Returns false — never throws — on any
+ * malformed key/signature so the caller can simply fall back to the floor.
+ */
+export function verifyManifestSignature(m: AppManifest, publicKeyPem: string): boolean {
+  if (!publicKeyPem || !m.signature) return false;
+  try {
+    const key = createPublicKey(publicKeyPem);
+    return cryptoVerify(null, canonicalManifestBytes(m), key, Buffer.from(m.signature, 'base64'));
+  } catch {
+    return false;
+  }
+}
+
+const HEX64 = /^[0-9a-f]{64}$/i;
+
+/** Parse + shape-check a manifest JSON string. Returns null on anything off so
+ *  a corrupt/hostile manifest is treated as "no update", not a crash. */
+export function parseManifest(json: string): AppManifest | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (!raw || typeof raw !== 'object') return null;
+  const m = raw as Record<string, unknown>;
+  const str = (v: unknown): v is string => typeof v === 'string' && v.length > 0;
+  // nodeAbi may be '' (the wildcard: "any ABI") but must be a string.
+  if (!str(m.version) || !str(m.minElectron) || typeof m.nodeAbi !== 'string') return null;
+  if (!str(m.sha256) || !HEX64.test(m.sha256)) return null;
+  if (!str(m.signature) || !str(m.bundleUrl)) return null;
+  const out: AppManifest = {
+    version: m.version,
+    minElectron: m.minElectron,
+    nodeAbi: m.nodeAbi as string,
+    sha256: m.sha256.toLowerCase(),
+    signature: m.signature,
+    bundleUrl: m.bundleUrl,
+  };
+  if (str(m.releaseUrl)) out.releaseUrl = m.releaseUrl;
+  if (str(m.notes)) out.notes = m.notes;
+  return out;
+}

--- a/packages/desktop-host/src/app-update/native-resolution.ts
+++ b/packages/desktop-host/src/app-update/native-resolution.ts
@@ -1,0 +1,38 @@
+/**
+ * A hot-updated bundle's main lives under `<userData>/app/<version>/` and has no
+ * `node_modules` of its own. Everything it needs is inlined into its `index.js`
+ * EXCEPT two bare specifiers: `electron` (always injected by the runtime) and
+ * the OPTIONAL native `@napi-rs/keyring` (loaded via a guarded dynamic import,
+ * with a passphrase fallback). To let that optional native dep still resolve
+ * from the shell's ABI-matched copy, append the shell's `node_modules` to the
+ * module search path.
+ *
+ * Node built-ins only (so this is safe to bake into the bootstrap). Append, not
+ * prepend, so nothing a bundle ships can be shadowed; fully guarded so a missing
+ * dir or an absent internal API is a harmless no-op.
+ */
+
+import { existsSync } from 'node:fs';
+import path, { delimiter } from 'node:path';
+import Module from 'node:module';
+
+export function setupNativeResolution(floorRoot: string): void {
+  try {
+    const candidates = [
+      path.join(floorRoot, 'node_modules'),
+      // electron-builder unpacks native modules beside app.asar.
+      path.join(floorRoot, '..', 'app.asar.unpacked', 'node_modules'),
+    ].filter((p) => existsSync(p));
+    if (candidates.length === 0) return;
+
+    const extra = candidates.join(delimiter);
+    process.env.NODE_PATH = process.env.NODE_PATH
+      ? `${process.env.NODE_PATH}${delimiter}${extra}`
+      : extra;
+    // Re-seed the global module paths from the updated NODE_PATH. `_initPaths`
+    // is internal/undocumented — guarded so a Node that drops it can't break boot.
+    (Module as unknown as { _initPaths?: () => void })._initPaths?.();
+  } catch {
+    /* best effort — keychain degrades to the passphrase fallback if unresolved */
+  }
+}

--- a/packages/desktop-host/src/app-update/resolve.test.ts
+++ b/packages/desktop-host/src/app-update/resolve.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { generateKeyPairSync, sign as cryptoSign } from 'node:crypto';
+import path from 'node:path';
+import os from 'node:os';
+
+import { type AppManifest, canonicalManifestBytes } from './manifest';
+import {
+  type ShellInfo,
+  bundleRoot,
+  appUpdateDir,
+  resolveActiveBundle,
+  setActiveVersion,
+  readActiveVersion,
+  markBad,
+  readBadVersions,
+  writeBreadcrumb,
+  markConfirmed,
+  recoverFromFailedBoot,
+  isCompatible,
+  compareSemver,
+  isSafeVersion,
+  pruneBundles,
+} from './resolve';
+
+let tmp: string;
+const SHELL: ShellInfo = { electron: '33.4.11', nodeAbi: '115' };
+
+const keys = generateKeyPairSync('ed25519');
+const PUBKEY = keys.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+
+function manifestFor(version: string, over: Partial<AppManifest> = {}): AppManifest {
+  const base: Omit<AppManifest, 'signature'> = {
+    version,
+    minElectron: '33.0.0',
+    nodeAbi: '115',
+    sha256: 'a'.repeat(64),
+    bundleUrl: 'https://example.com/b.json.gz',
+    ...over,
+  };
+  const signature = cryptoSign(null, canonicalManifestBytes(base), keys.privateKey).toString(
+    'base64',
+  );
+  return { ...base, signature };
+}
+
+/** Lay down a fully-valid installed bundle at `<userData>/app/<version>/`. */
+function installBundle(version: string, over: Partial<AppManifest> = {}): void {
+  const root = bundleRoot(tmp, version);
+  mkdirSync(path.join(root, 'dist-electron', 'main'), { recursive: true });
+  writeFileSync(path.join(root, 'dist-electron', 'main', 'index.js'), '// main');
+  writeFileSync(path.join(root, 'manifest.json'), JSON.stringify(manifestFor(version, over)));
+  setActiveVersion(tmp, version);
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(os.tmpdir(), 'app-resolve-'));
+});
+
+describe('resolveActiveBundle', () => {
+  it('returns the installed bundle when signature + compat + layout all pass', () => {
+    installBundle('0.0.6');
+    const r = resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL });
+    expect(r).toEqual({ root: bundleRoot(tmp, '0.0.6'), version: '0.0.6' });
+  });
+
+  it('falls back to floor (null) when no key is configured', () => {
+    installBundle('0.0.6');
+    expect(resolveActiveBundle({ userDataDir: tmp, publicKeyPem: '', shell: SHELL })).toBeNull();
+  });
+
+  it('falls back when there is no active bundle', () => {
+    expect(resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL })).toBeNull();
+  });
+
+  it('falls back when the active version is poisoned', () => {
+    installBundle('0.0.6');
+    markBad(tmp, '0.0.6');
+    expect(resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL })).toBeNull();
+  });
+
+  it('rejects a bundle whose manifest is signed by a different key', () => {
+    const other = generateKeyPairSync('ed25519');
+    const otherPub = other.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+    installBundle('0.0.6');
+    expect(
+      resolveActiveBundle({ userDataDir: tmp, publicKeyPem: otherPub, shell: SHELL }),
+    ).toBeNull();
+  });
+
+  it('rejects when the manifest version does not match the active version', () => {
+    const root = bundleRoot(tmp, '0.0.6');
+    mkdirSync(path.join(root, 'dist-electron', 'main'), { recursive: true });
+    writeFileSync(path.join(root, 'dist-electron', 'main', 'index.js'), '// main');
+    // manifest says 9.9.9 but it lives in the 0.0.6 dir / active points at 0.0.6
+    writeFileSync(path.join(root, 'manifest.json'), JSON.stringify(manifestFor('9.9.9')));
+    setActiveVersion(tmp, '0.0.6');
+    expect(resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL })).toBeNull();
+  });
+
+  it('rejects an incompatible bundle (needs a newer shell)', () => {
+    installBundle('0.0.6', { minElectron: '40.0.0' });
+    expect(resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL })).toBeNull();
+  });
+
+  it('rejects on a Node ABI mismatch', () => {
+    installBundle('0.0.6', { nodeAbi: '999' });
+    expect(resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL })).toBeNull();
+  });
+
+  it('rejects when the real main is missing on disk', () => {
+    const root = bundleRoot(tmp, '0.0.6');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(path.join(root, 'manifest.json'), JSON.stringify(manifestFor('0.0.6')));
+    setActiveVersion(tmp, '0.0.6');
+    expect(resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL })).toBeNull();
+  });
+});
+
+describe('markBad', () => {
+  it('adds to the bad set and clears active when it pointed there', () => {
+    installBundle('0.0.6');
+    markBad(tmp, '0.0.6');
+    expect(readBadVersions(tmp).has('0.0.6')).toBe(true);
+    expect(resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL })).toBeNull();
+  });
+});
+
+describe('recoverFromFailedBoot (boot-probe rollback)', () => {
+  it('does nothing for a fresh install (no breadcrumb for the active version)', () => {
+    installBundle('0.0.6'); // active = 0.0.6, no breadcrumb yet
+    const r = recoverFromFailedBoot(tmp);
+    expect(r.poisoned).toBeNull();
+    expect(readActiveVersion(tmp)).toBe('0.0.6');
+  });
+
+  it('does nothing when the active version confirmed healthy', () => {
+    installBundle('0.0.6');
+    writeBreadcrumb(tmp, '0.0.6'); // it was attempted…
+    markConfirmed(tmp, '0.0.6'); // …and confirmed
+    expect(recoverFromFailedBoot(tmp).poisoned).toBeNull();
+    expect(readActiveVersion(tmp)).toBe('0.0.6');
+  });
+
+  it('poisons a version that was attempted but never confirmed, falling to floor', () => {
+    installBundle('0.0.6');
+    writeBreadcrumb(tmp, '0.0.6'); // attempted last launch, no confirm
+    const r = recoverFromFailedBoot(tmp);
+    expect(r.poisoned).toBe('0.0.6');
+    expect(r.rolledBackTo).toBeNull();
+    expect(readBadVersions(tmp).has('0.0.6')).toBe(true);
+    expect(readActiveVersion(tmp)).toBeNull(); // → floor
+  });
+
+  it('rolls back to the last confirmed-good bundle when one is still installed', () => {
+    installBundle('0.0.6');
+    markConfirmed(tmp, '0.0.6'); // 0.0.6 booted fine earlier
+    installBundle('0.0.7'); // then user updated to 0.0.7 (active = 0.0.7)
+    writeBreadcrumb(tmp, '0.0.7'); // 0.0.7 was attempted but white-screened
+    const r = recoverFromFailedBoot(tmp);
+    expect(r.poisoned).toBe('0.0.7');
+    expect(r.rolledBackTo).toBe('0.0.6');
+    expect(readActiveVersion(tmp)).toBe('0.0.6');
+    // and the rolled-back-to bundle still resolves
+    expect(resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL })?.version).toBe(
+      '0.0.6',
+    );
+  });
+});
+
+describe('helpers', () => {
+  it('compareSemver orders by major.minor.patch', () => {
+    expect(compareSemver('33.4.11', '33.0.0')).toBe(1);
+    expect(compareSemver('33.0.0', '33.0.0')).toBe(0);
+    expect(compareSemver('32.9.9', '33.0.0')).toBe(-1);
+    expect(compareSemver('33.4.11-beta.1', '33.4.11')).toBe(0);
+  });
+
+  it('isCompatible needs both the Electron floor and an exact ABI', () => {
+    const m = manifestFor('0.0.6');
+    expect(isCompatible(m, SHELL)).toBe(true);
+    expect(isCompatible(m, { electron: '32.0.0', nodeAbi: '115' })).toBe(false);
+    expect(isCompatible(m, { electron: '33.4.11', nodeAbi: '116' })).toBe(false);
+  });
+
+  it('isCompatible treats an empty manifest nodeAbi as a wildcard', () => {
+    const m = manifestFor('0.0.6', { nodeAbi: '' });
+    expect(isCompatible(m, { electron: '33.4.11', nodeAbi: '115' })).toBe(true);
+    expect(isCompatible(m, { electron: '33.4.11', nodeAbi: 'anything' })).toBe(true);
+    expect(isCompatible(m, { electron: '32.0.0', nodeAbi: '115' })).toBe(false);
+  });
+
+  it('isSafeVersion blocks traversal + separators', () => {
+    expect(isSafeVersion('0.0.6')).toBe(true);
+    expect(isSafeVersion('1.2.3-rc.1')).toBe(true);
+    expect(isSafeVersion('../etc')).toBe(false);
+    expect(isSafeVersion('a/b')).toBe(false);
+    expect(isSafeVersion('..')).toBe(false);
+  });
+
+  it('pruneBundles keeps the listed versions and removes other bundle dirs', () => {
+    installBundle('0.0.5');
+    installBundle('0.0.6');
+    installBundle('0.0.7');
+    pruneBundles(tmp, ['0.0.7', '0.0.6']);
+    expect(existsSync(bundleRoot(tmp, '0.0.5'))).toBe(false);
+    expect(existsSync(bundleRoot(tmp, '0.0.6'))).toBe(true);
+    expect(existsSync(bundleRoot(tmp, '0.0.7'))).toBe(true);
+  });
+
+  it('pruneBundles never removes non-bundle dirs (no manifest.json)', () => {
+    const stray = path.join(appUpdateDir(tmp), '0.0.9');
+    mkdirSync(stray, { recursive: true });
+    writeFileSync(path.join(stray, 'note.txt'), 'not a bundle');
+    pruneBundles(tmp, []);
+    expect(existsSync(stray)).toBe(true);
+  });
+});

--- a/packages/desktop-host/src/app-update/resolve.ts
+++ b/packages/desktop-host/src/app-update/resolve.ts
@@ -1,0 +1,277 @@
+/**
+ * The self-update GATE: given the desktop's writable userData, decide which app
+ * bundle to run — a verified, user-installed override under
+ * `<userData>/app/<version>/`, or null to mean "use the bundled floor".
+ *
+ * This runs inside the immutable bootstrap, so it is dependency-free (node
+ * built-ins only) and fully SYNCHRONOUS — it must not delay process start. Every
+ * failure mode (missing/poisoned/incompatible/unsigned/malformed) resolves to
+ * `null`, i.e. fall back to the floor. A bundle is only ever returned after its
+ * manifest's Ed25519 signature, version binding, and Electron/ABI compatibility
+ * all pass.
+ *
+ * On-disk layout under `<userData>/app/`:
+ *   active.json        { version }       — the version the bootstrap should load
+ *   bad.json           { versions: [] }  — versions poisoned by a failed boot
+ *   last-attempt.json  { version, ts }   — breadcrumb written before loading an override
+ *   confirmed.json     { version }       — last version that booted healthily
+ *   <version>/         the extracted bundle (dist/ + dist-electron/ + manifest.json)
+ */
+
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, rmSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+import { type AppManifest, parseManifest, verifyManifestSignature } from './manifest.js';
+
+export interface ShellInfo {
+  /** `process.versions.electron`. */
+  electron: string;
+  /** `process.versions.modules` — the Node ABI the shell provides. */
+  nodeAbi: string;
+}
+
+export interface ResolvedBundle {
+  /** Absolute bundle root (contains `dist/` + `dist-electron/`). */
+  root: string;
+  version: string;
+}
+
+/** A bundle version must be a safe path segment — no traversal, no separators —
+ *  since it names a directory under userData and comes from on-disk state. */
+const SAFE_VERSION = /^[A-Za-z0-9][A-Za-z0-9.+_-]{0,63}$/;
+
+export function isSafeVersion(v: string): boolean {
+  return SAFE_VERSION.test(v) && !v.includes('..');
+}
+
+export function appUpdateDir(userDataDir: string): string {
+  return path.join(userDataDir, 'app');
+}
+export function bundleRoot(userDataDir: string, version: string): string {
+  return path.join(appUpdateDir(userDataDir), version);
+}
+const activePath = (d: string): string => path.join(appUpdateDir(d), 'active.json');
+const badPath = (d: string): string => path.join(appUpdateDir(d), 'bad.json');
+const breadcrumbPath = (d: string): string => path.join(appUpdateDir(d), 'last-attempt.json');
+const confirmedPath = (d: string): string => path.join(appUpdateDir(d), 'confirmed.json');
+
+function tryRead(p: string): string | null {
+  try {
+    return readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+/** tmp-write + rename so a crash can't leave a half-written pointer. */
+function writeJsonAtomic(p: string, value: unknown): void {
+  mkdirSync(path.dirname(p), { recursive: true });
+  const tmp = `${p}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, JSON.stringify(value, null, 2));
+  renameSync(tmp, p);
+}
+
+export function readActiveVersion(userDataDir: string): string | null {
+  const raw = tryRead(activePath(userDataDir));
+  if (!raw) return null;
+  try {
+    const v = (JSON.parse(raw) as { version?: unknown }).version;
+    return typeof v === 'string' && isSafeVersion(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setActiveVersion(userDataDir: string, version: string): void {
+  writeJsonAtomic(activePath(userDataDir), { version });
+}
+
+export function readBadVersions(userDataDir: string): Set<string> {
+  const raw = tryRead(badPath(userDataDir));
+  if (!raw) return new Set();
+  try {
+    const arr = (JSON.parse(raw) as { versions?: unknown }).versions;
+    return new Set(Array.isArray(arr) ? arr.filter((v): v is string => typeof v === 'string') : []);
+  } catch {
+    return new Set();
+  }
+}
+
+/** Poison a version so it is never loaded again, and clear `active` if it points
+ *  there (so the next launch falls straight through to the floor). */
+export function markBad(userDataDir: string, version: string): void {
+  const bad = readBadVersions(userDataDir);
+  bad.add(version);
+  writeJsonAtomic(badPath(userDataDir), { versions: [...bad] });
+  if (readActiveVersion(userDataDir) === version) {
+    try {
+      rmSync(activePath(userDataDir), { force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+}
+
+export function writeBreadcrumb(userDataDir: string, version: string, now = Date.now()): void {
+  writeJsonAtomic(breadcrumbPath(userDataDir), { version, ts: now });
+}
+
+export function readBreadcrumb(userDataDir: string): { version: string; ts: number } | null {
+  const raw = tryRead(breadcrumbPath(userDataDir));
+  if (!raw) return null;
+  try {
+    const o = JSON.parse(raw) as { version?: unknown; ts?: unknown };
+    if (typeof o.version === 'string' && typeof o.ts === 'number') {
+      return { version: o.version, ts: o.ts };
+    }
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+export function markConfirmed(userDataDir: string, version: string): void {
+  writeJsonAtomic(confirmedPath(userDataDir), { version });
+}
+
+export function readConfirmed(userDataDir: string): string | null {
+  const raw = tryRead(confirmedPath(userDataDir));
+  if (!raw) return null;
+  try {
+    const v = (JSON.parse(raw) as { version?: unknown }).version;
+    return typeof v === 'string' ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Numeric major.minor.patch compare (ignores any prerelease/build suffix). */
+export function compareSemver(a: string, b: string): number {
+  const parse = (s: string): number[] =>
+    (s.split('-')[0] ?? '')
+      .split('.')
+      .map((n) => Number.parseInt(n, 10) || 0);
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < 3; i += 1) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/** True iff the running shell satisfies the bundle's Electron + ABI floor. A
+ *  false result means this update needs a NEW shell (Tier-2), not a JS swap. An
+ *  empty manifest `nodeAbi` is a wildcard (skip the ABI check). */
+export function isCompatible(m: AppManifest, shell: ShellInfo): boolean {
+  if (compareSemver(shell.electron, m.minElectron) < 0) return false;
+  return m.nodeAbi === '' || shell.nodeAbi === m.nodeAbi;
+}
+
+export interface ResolveOpts {
+  userDataDir: string;
+  /** Baked Ed25519 public key (SPKI PEM). Empty disables all overrides. */
+  publicKeyPem: string;
+  shell: ShellInfo;
+}
+
+/**
+ * The gate. Returns the override bundle to load, or null to use the floor.
+ *
+ * Order matters — cheapest + most-decisive checks first, signature before any
+ * trust is extended, compatibility last:
+ *   key configured → active version is safe + not poisoned → manifest present,
+ *   well-formed, and bound to the active version → signature valid →
+ *   Electron/ABI compatible → real main exists on disk.
+ */
+export function resolveActiveBundle(opts: ResolveOpts): ResolvedBundle | null {
+  const { userDataDir, publicKeyPem, shell } = opts;
+  if (!publicKeyPem) return null; // self-update disabled → floor
+
+  const version = readActiveVersion(userDataDir);
+  if (!version) return null;
+  if (readBadVersions(userDataDir).has(version)) return null;
+
+  const root = bundleRoot(userDataDir, version);
+  const manifestRaw = tryRead(path.join(root, 'manifest.json'));
+  if (!manifestRaw) return null;
+  const manifest = parseManifest(manifestRaw);
+  if (!manifest || manifest.version !== version) return null;
+  if (!verifyManifestSignature(manifest, publicKeyPem)) return null;
+  if (!isCompatible(manifest, shell)) return null;
+
+  const mainEntry = path.join(root, 'dist-electron', 'main', 'index.js');
+  if (!existsSync(mainEntry)) return null;
+
+  return { root, version };
+}
+
+export interface BootRecovery {
+  /** A version poisoned because it was loaded but never confirmed healthy. */
+  poisoned: string | null;
+  /** The confirmed-good version `active` was rolled back to (if available). */
+  rolledBackTo: string | null;
+}
+
+/**
+ * Detect a bundle that loaded last launch but never reached a healthy render
+ * (white-screen / async main crash) and poison it. The breadcrumb records the
+ * version the bootstrap last *attempted*; the app writes `confirmed` only after
+ * the renderer mounts. So `attempted === active && confirmed !== attempted`
+ * means "it failed to boot" — poison it, and roll `active` back to the last
+ * confirmed-good if that bundle is still installed.
+ *
+ * Gives a freshly-installed version exactly ONE chance (its breadcrumb is only
+ * written when it's actually loaded), then auto-recovers on the next launch.
+ * Runs in the bootstrap BEFORE {@link resolveActiveBundle}.
+ */
+export function recoverFromFailedBoot(userDataDir: string): BootRecovery {
+  const crumb = readBreadcrumb(userDataDir);
+  if (!crumb) return { poisoned: null, rolledBackTo: null };
+
+  const active = readActiveVersion(userDataDir);
+  const confirmed = readConfirmed(userDataDir);
+  if (!active || active !== crumb.version || confirmed === crumb.version) {
+    return { poisoned: null, rolledBackTo: null };
+  }
+
+  markBad(userDataDir, crumb.version); // also clears `active`
+  if (
+    confirmed &&
+    confirmed !== crumb.version &&
+    isSafeVersion(confirmed) &&
+    !readBadVersions(userDataDir).has(confirmed) &&
+    existsSync(path.join(bundleRoot(userDataDir, confirmed), 'manifest.json'))
+  ) {
+    setActiveVersion(userDataDir, confirmed);
+    return { poisoned: crumb.version, rolledBackTo: confirmed };
+  }
+  return { poisoned: crumb.version, rolledBackTo: null };
+}
+
+/**
+ * Drop installed bundle dirs except the ones in `keep` (typically the active +
+ * previous-good). Never touches the floor (which lives in resources, not here)
+ * and tolerates a partially-populated `app/` dir. Best-effort; runs at launch
+ * before resolution.
+ */
+export function pruneBundles(userDataDir: string, keep: ReadonlyArray<string>): void {
+  const dir = appUpdateDir(userDataDir);
+  const keepSet = new Set(keep);
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (!isSafeVersion(name)) continue; // only ever remove version dirs
+    if (keepSet.has(name)) continue;
+    if (!existsSync(path.join(dir, name, 'manifest.json'))) continue; // not a bundle dir
+    try {
+      rmSync(path.join(dir, name), { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+}

--- a/packages/desktop-host/src/app-update/roundtrip.test.ts
+++ b/packages/desktop-host/src/app-update/roundtrip.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { generateKeyPairSync } from 'node:crypto';
+import path from 'node:path';
+import os from 'node:os';
+
+import { buildAppBundle } from './build';
+import { checkForUpdate, downloadAndStage, type Progress } from './stager';
+import { resolveActiveBundle, bundleRoot, type ShellInfo } from './resolve';
+
+const SHELL: ShellInfo = { electron: '33.4.11', nodeAbi: '115' };
+const MANIFEST_URL = 'https://github.com/moxxy-ai/moxxy/releases/latest/download/moxxy-app-manifest.json';
+const BUNDLE_URL = 'https://github.com/moxxy-ai/moxxy/releases/latest/download/moxxy-app-bundle.json.gz';
+
+const keys = generateKeyPairSync('ed25519');
+const PUBKEY = keys.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+const PRIVKEY = keys.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+
+const FILES = {
+  'dist/index.html': Buffer.from('<!doctype html><title>moxxy</title>'),
+  'dist/assets/app-abc.js': Buffer.from('console.log("hi")'),
+  'dist/focus.html': Buffer.from('<!doctype html><title>focus</title>'),
+  'dist-electron/main/index.js': Buffer.from('// the real main'),
+  'dist-electron/preload/index.cjs': Buffer.from('// preload'),
+};
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(os.tmpdir(), 'app-roundtrip-'));
+});
+
+/** A fetch stub that serves the manifest + the gzipped bundle from memory. */
+function stubFetch(manifestJson: string, bundleGz: Buffer): typeof fetch {
+  return (async (url: string | URL): Promise<Response> => {
+    const u = String(url);
+    if (u === MANIFEST_URL) return new Response(manifestJson);
+    if (u === BUNDLE_URL) return new Response(new Uint8Array(bundleGz));
+    return new Response('not found', { status: 404 });
+  }) as unknown as typeof fetch;
+}
+
+describe('build → stage → resolve round-trip', () => {
+  it('installs a signed bundle that the loader then accepts', async () => {
+    const { manifest, manifestJson, bundleGz } = buildAppBundle({
+      version: '0.0.6',
+      minElectron: '33.0.0',
+      nodeAbi: '',
+      bundleUrl: BUNDLE_URL,
+      privateKeyPem: PRIVKEY,
+      files: FILES,
+      notes: 'New chat surface',
+    });
+    const fetchImpl = stubFetch(manifestJson, bundleGz);
+
+    // check: a newer, compatible bundle is offered
+    const check = await checkForUpdate(
+      { manifestUrl: MANIFEST_URL, currentVersion: '0.0.5', publicKeyPem: PUBKEY, shell: SHELL },
+      { fetchImpl },
+    );
+    expect(check.available).toBe(true);
+    expect(check.compatible).toBe(true);
+    expect(check.latestVersion).toBe('0.0.6');
+    expect(check.notes).toBe('New chat surface');
+
+    // apply: download, verify, extract, activate
+    const phases: Progress['phase'][] = [];
+    const { version } = await downloadAndStage(
+      { userDataDir: tmp, manifest, publicKeyPem: PUBKEY, onProgress: (p) => phases.push(p.phase) },
+      { fetchImpl },
+    );
+    expect(version).toBe('0.0.6');
+    expect(new Set(phases)).toEqual(new Set(['download', 'verify', 'extract', 'activate']));
+
+    // files landed with layout preserved + verified manifest written
+    const root = bundleRoot(tmp, '0.0.6');
+    expect(readFileSync(path.join(root, 'dist', 'index.html'), 'utf8')).toContain('moxxy');
+    expect(readFileSync(path.join(root, 'dist-electron', 'main', 'index.js'), 'utf8')).toContain(
+      'real main',
+    );
+    expect(existsSync(path.join(root, 'manifest.json'))).toBe(true);
+
+    // the bootstrap gate accepts it
+    expect(resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL })).toEqual({
+      root,
+      version: '0.0.6',
+    });
+  });
+
+  it('refuses to stage when the gzip hash does not match the signed manifest', async () => {
+    const { manifest, manifestJson } = buildAppBundle({
+      version: '0.0.6',
+      minElectron: '33.0.0',
+      nodeAbi: '',
+      bundleUrl: BUNDLE_URL,
+      privateKeyPem: PRIVKEY,
+      files: FILES,
+    });
+    // Serve a DIFFERENT (tampered) gzip than the one the manifest is signed over.
+    const tampered = buildAppBundle({
+      version: '0.0.6',
+      minElectron: '33.0.0',
+      nodeAbi: '',
+      bundleUrl: BUNDLE_URL,
+      privateKeyPem: PRIVKEY,
+      files: { ...FILES, 'dist-electron/main/index.js': Buffer.from('// EVIL main') },
+    }).bundleGz;
+    const fetchImpl = stubFetch(manifestJson, tampered);
+
+    await expect(
+      downloadAndStage({ userDataDir: tmp, manifest, publicKeyPem: PUBKEY }, { fetchImpl }),
+    ).rejects.toThrow(/hash/i);
+    // nothing activated
+    expect(resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL })).toBeNull();
+  });
+
+  it('checkForUpdate reports incompatible (needs shell update) but not available for a JS swap', async () => {
+    const { manifestJson, bundleGz } = buildAppBundle({
+      version: '0.0.9',
+      minElectron: '99.0.0',
+      nodeAbi: '',
+      bundleUrl: BUNDLE_URL,
+      privateKeyPem: PRIVKEY,
+      files: FILES,
+    });
+    const check = await checkForUpdate(
+      { manifestUrl: MANIFEST_URL, currentVersion: '0.0.5', publicKeyPem: PUBKEY, shell: SHELL },
+      { fetchImpl: stubFetch(manifestJson, bundleGz) },
+    );
+    expect(check.available).toBe(true);
+    expect(check.compatible).toBe(false); // → Tier-2 shell update
+  });
+});

--- a/packages/desktop-host/src/app-update/stager.test.ts
+++ b/packages/desktop-host/src/app-update/stager.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { mkdtempSync, existsSync } from 'node:fs';
+import { generateKeyPairSync } from 'node:crypto';
+import path from 'node:path';
+import os from 'node:os';
+
+import { buildAppBundle } from './build';
+import { checkForUpdate, downloadAndStage, isAllowedUpdateHost } from './stager';
+import { bundleRoot, type ShellInfo } from './resolve';
+
+const SHELL: ShellInfo = { electron: '33.4.11', nodeAbi: '115' };
+const keys = generateKeyPairSync('ed25519');
+const PUBKEY = keys.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+const PRIVKEY = keys.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(os.tmpdir(), 'app-stager-'));
+});
+
+describe('isAllowedUpdateHost', () => {
+  it('allows GitHub + its release-asset CDN over https only', () => {
+    expect(isAllowedUpdateHost('https://github.com/o/r/releases/latest/download/m.json')).toBe(true);
+    expect(isAllowedUpdateHost('https://objects.githubusercontent.com/x')).toBe(true);
+    expect(isAllowedUpdateHost('https://release-assets.githubusercontent.com/x')).toBe(true);
+    expect(isAllowedUpdateHost('https://codeload.github.com/x')).toBe(true);
+  });
+
+  it('rejects other hosts, http, and junk', () => {
+    expect(isAllowedUpdateHost('https://evil.test/m.json')).toBe(false);
+    expect(isAllowedUpdateHost('https://github.com.evil.test/m.json')).toBe(false);
+    expect(isAllowedUpdateHost('http://github.com/x')).toBe(false);
+    expect(isAllowedUpdateHost('not a url')).toBe(false);
+  });
+});
+
+describe('checkForUpdate guards', () => {
+  it('returns "no update" without ever fetching a non-allowlisted manifest URL', async () => {
+    let fetched = false;
+    const fetchImpl = (async () => {
+      fetched = true;
+      return new Response('{}');
+    }) as unknown as typeof fetch;
+    const res = await checkForUpdate(
+      { manifestUrl: 'https://evil.test/m.json', currentVersion: '0.0.5', publicKeyPem: PUBKEY, shell: SHELL },
+      { fetchImpl },
+    );
+    expect(res.available).toBe(false);
+    expect(fetched).toBe(false);
+  });
+});
+
+describe('downloadAndStage hardening', () => {
+  const GH = 'https://github.com/moxxy-ai/moxxy/releases/latest/download/b.json.gz';
+
+  it('refuses a bundle whose URL is not on an allowed host', async () => {
+    const { manifest } = buildAppBundle({
+      version: '0.0.6',
+      minElectron: '33.0.0',
+      nodeAbi: '',
+      bundleUrl: 'https://evil.test/b.json.gz',
+      privateKeyPem: PRIVKEY,
+      files: { 'dist/index.html': Buffer.from('x') },
+    });
+    await expect(
+      downloadAndStage({ userDataDir: tmp, manifest, publicKeyPem: PUBKEY }),
+    ).rejects.toThrow(/allowed origin/i);
+  });
+
+  it('refuses a bundle containing a path-traversal entry (defense in depth)', async () => {
+    const { manifest, bundleGz } = buildAppBundle({
+      version: '0.0.6',
+      minElectron: '33.0.0',
+      nodeAbi: '',
+      bundleUrl: GH,
+      privateKeyPem: PRIVKEY,
+      files: { '../escape.js': Buffer.from('pwned'), 'dist/index.html': Buffer.from('x') },
+    });
+    const fetchImpl = (async () => new Response(new Uint8Array(bundleGz))) as unknown as typeof fetch;
+    await expect(
+      downloadAndStage({ userDataDir: tmp, manifest, publicKeyPem: PUBKEY }, { fetchImpl }),
+    ).rejects.toThrow(/unsafe path/i);
+    // nothing got activated
+    expect(existsSync(bundleRoot(tmp, '0.0.6'))).toBe(false);
+  });
+
+  it('refuses to stage when the manifest signature is invalid', async () => {
+    const { manifest, bundleGz } = buildAppBundle({
+      version: '0.0.6',
+      minElectron: '33.0.0',
+      nodeAbi: '',
+      bundleUrl: GH,
+      privateKeyPem: PRIVKEY,
+      files: { 'dist/index.html': Buffer.from('x') },
+    });
+    const otherKey = generateKeyPairSync('ed25519')
+      .publicKey.export({ type: 'spki', format: 'pem' })
+      .toString();
+    const fetchImpl = (async () => new Response(new Uint8Array(bundleGz))) as unknown as typeof fetch;
+    await expect(
+      downloadAndStage({ userDataDir: tmp, manifest, publicKeyPem: otherKey }, { fetchImpl }),
+    ).rejects.toThrow(/signature/i);
+  });
+});

--- a/packages/desktop-host/src/app-update/stager.ts
+++ b/packages/desktop-host/src/app-update/stager.ts
@@ -1,0 +1,238 @@
+/**
+ * The download side of self-update: check the published manifest, then fetch,
+ * verify, and atomically install a bundle under `<userData>/app/<version>/` so
+ * the bootstrap can activate it on the next launch.
+ *
+ * Pure transport + crypto (node built-ins + global `fetch`) — no electron — so
+ * it unit-tests with an injected `fetchImpl`. Authenticity is enforced twice:
+ * here (so a bad download fails fast with a clear error) and authoritatively in
+ * the bootstrap at load time. The signed manifest binds the bundle via its
+ * `sha256`, and only allowlisted hosts are ever contacted.
+ */
+
+import { createHash } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
+import { gunzipSync } from 'node:zlib';
+import { existsSync, mkdirSync, writeFileSync, renameSync, rmSync } from 'node:fs';
+import path from 'node:path';
+
+import {
+  type AppManifest,
+  parseManifest,
+  verifyManifestSignature,
+} from './manifest.js';
+import {
+  type ShellInfo,
+  appUpdateDir,
+  bundleRoot,
+  compareSemver,
+  isCompatible,
+  isSafeVersion,
+  setActiveVersion,
+} from './resolve.js';
+
+/** Only these hosts (and subdomains) are ever fetched — GitHub + its release
+ *  asset CDN. The manifest's `bundleUrl` is signed, so it can't be repointed,
+ *  but we host-check it anyway as defense in depth. */
+const ALLOWED_HOSTS = [/^github\.com$/, /(^|\.)githubusercontent\.com$/, /^codeload\.github\.com$/];
+
+export function isAllowedUpdateHost(url: string): boolean {
+  try {
+    const u = new URL(url);
+    if (u.protocol !== 'https:') return false;
+    return ALLOWED_HOSTS.some((re) => re.test(u.hostname));
+  } catch {
+    return false;
+  }
+}
+
+export interface StagerDeps {
+  fetchImpl?: typeof fetch;
+}
+
+export interface CheckResult {
+  /** A newer, signature-valid bundle is published. */
+  available: boolean;
+  latestVersion: string | null;
+  /** The running shell satisfies the bundle (false ⇒ a shell/Tier-2 update is needed). */
+  compatible: boolean;
+  manifest: AppManifest | null;
+  notes?: string;
+  releaseUrl?: string;
+}
+
+/**
+ * Fetch + verify the published manifest and compare it to the running version.
+ * Never throws on a "no update" outcome (offline, 404, bad signature, same
+ * version) — those return `available: false` so the UI stays quiet.
+ */
+export async function checkForUpdate(
+  opts: {
+    manifestUrl: string;
+    currentVersion: string;
+    publicKeyPem: string;
+    shell: ShellInfo;
+  },
+  deps: StagerDeps = {},
+): Promise<CheckResult> {
+  const none: CheckResult = { available: false, latestVersion: null, compatible: false, manifest: null };
+  const { manifestUrl, currentVersion, publicKeyPem, shell } = opts;
+  if (!publicKeyPem || !isAllowedUpdateHost(manifestUrl)) return none;
+
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  let text: string;
+  try {
+    const res = await fetchImpl(manifestUrl, { redirect: 'follow' });
+    if (!res.ok) return none;
+    text = await res.text();
+  } catch {
+    return none;
+  }
+
+  const manifest = parseManifest(text);
+  if (!manifest) return none;
+  if (!verifyManifestSignature(manifest, publicKeyPem)) return none;
+
+  const newer = compareSemver(manifest.version, currentVersion) > 0;
+  const result: CheckResult = {
+    available: newer,
+    latestVersion: manifest.version,
+    compatible: isCompatible(manifest, shell),
+    manifest: newer ? manifest : null,
+  };
+  if (manifest.notes) result.notes = manifest.notes;
+  if (manifest.releaseUrl) result.releaseUrl = manifest.releaseUrl;
+  return result;
+}
+
+export type ProgressPhase = 'download' | 'verify' | 'extract' | 'activate';
+export interface Progress {
+  phase: ProgressPhase;
+  received?: number;
+  total?: number;
+  message?: string;
+}
+
+interface BundlePayload {
+  version: string;
+  files: Record<string, string>;
+}
+
+/** Reject any archive path that is absolute or escapes the bundle root. */
+function safeRelPath(rel: string): string | null {
+  if (!rel || rel.startsWith('/') || rel.includes('\\')) return null;
+  const norm = path.posix.normalize(rel);
+  if (norm.startsWith('..') || norm.startsWith('/') || path.posix.isAbsolute(norm)) return null;
+  if (norm.split('/').some((seg) => seg === '..')) return null;
+  return norm;
+}
+
+/**
+ * Download → integrity-check → extract → atomically install. Throws (with a
+ * human-readable message the UI surfaces) on any failure; on success the bundle
+ * is installed and marked active, ready for the next launch.
+ */
+export async function downloadAndStage(
+  opts: {
+    userDataDir: string;
+    manifest: AppManifest;
+    publicKeyPem: string;
+    onProgress?: (p: Progress) => void;
+  },
+  deps: StagerDeps = {},
+): Promise<{ version: string }> {
+  const { userDataDir, manifest, publicKeyPem, onProgress } = opts;
+  const report = onProgress ?? (() => {});
+
+  if (!verifyManifestSignature(manifest, publicKeyPem)) {
+    throw new Error('update manifest failed signature verification');
+  }
+  if (!isSafeVersion(manifest.version)) {
+    throw new Error(`unsafe bundle version: ${manifest.version}`);
+  }
+  if (!isAllowedUpdateHost(manifest.bundleUrl)) {
+    throw new Error('update bundle is not hosted on an allowed origin');
+  }
+
+  // 1. Download the gzipped bundle, streaming progress.
+  report({ phase: 'download', message: 'Downloading…' });
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const res = await fetchImpl(manifest.bundleUrl, { redirect: 'follow' });
+  if (!res.ok) throw new Error(`bundle download failed (HTTP ${res.status})`);
+  const total = Number(res.headers.get('content-length')) || undefined;
+  const gz = await readAll(res, total, (received) => report({ phase: 'download', received, total }));
+
+  // 2. Integrity: the gzip's hash must equal the signed manifest's.
+  report({ phase: 'verify', message: 'Verifying…' });
+  const digest = createHash('sha256').update(gz).digest('hex');
+  if (digest !== manifest.sha256) {
+    throw new Error('bundle hash does not match the signed manifest');
+  }
+
+  // 3. Decode the bundle.
+  let payload: BundlePayload;
+  try {
+    payload = JSON.parse(gunzipSync(gz).toString('utf8')) as BundlePayload;
+  } catch {
+    throw new Error('bundle payload is corrupt');
+  }
+  if (payload.version !== manifest.version || !payload.files || typeof payload.files !== 'object') {
+    throw new Error('bundle payload does not match its manifest');
+  }
+
+  // 4. Extract into a fresh incoming dir (never write in place).
+  report({ phase: 'extract', message: 'Installing…' });
+  const dir = appUpdateDir(userDataDir);
+  mkdirSync(dir, { recursive: true });
+  const incoming = path.join(dir, `${manifest.version}.incoming-${randomBytes(6).toString('hex')}`);
+  try {
+    mkdirSync(incoming, { recursive: true });
+    for (const [rel, b64] of Object.entries(payload.files)) {
+      const safe = safeRelPath(rel);
+      if (!safe) throw new Error(`unsafe path in bundle: ${rel}`);
+      const dest = path.join(incoming, safe);
+      mkdirSync(path.dirname(dest), { recursive: true });
+      writeFileSync(dest, Buffer.from(b64, 'base64'));
+    }
+    // Write the verified manifest LAST so a half-extracted dir never looks valid.
+    writeFileSync(path.join(incoming, 'manifest.json'), JSON.stringify(manifest, null, 2));
+
+    // 5. Activate: swap the dir into place, then flip the active pointer.
+    report({ phase: 'activate', message: 'Finishing…' });
+    const finalRoot = bundleRoot(userDataDir, manifest.version);
+    if (existsSync(finalRoot)) rmSync(finalRoot, { recursive: true, force: true });
+    renameSync(incoming, finalRoot);
+    setActiveVersion(userDataDir, manifest.version);
+  } finally {
+    if (existsSync(incoming)) rmSync(incoming, { recursive: true, force: true });
+  }
+
+  return { version: manifest.version };
+}
+
+/** Drain a fetch Response body into one Buffer, reporting cumulative bytes. */
+async function readAll(
+  res: Response,
+  _total: number | undefined,
+  onChunk: (received: number) => void,
+): Promise<Buffer> {
+  if (!res.body) {
+    const buf = Buffer.from(await res.arrayBuffer());
+    onChunk(buf.length);
+    return buf;
+  }
+  const reader = res.body.getReader();
+  const chunks: Buffer[] = [];
+  let received = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      const buf = Buffer.from(value);
+      chunks.push(buf);
+      received += buf.length;
+      onChunk(received);
+    }
+  }
+  return Buffer.concat(chunks);
+}

--- a/packages/desktop-host/src/index.ts
+++ b/packages/desktop-host/src/index.ts
@@ -7,6 +7,7 @@
 
 export { RunnerPool, UNBOUND_ID } from './runner-pool.js';
 export { bindWindow, registerIpcHandlers } from './ipc.js';
+export { type UpdateConfig } from './ipc/update.js';
 export { preferredCliEntry } from './cli-resolver.js';
 export { DeskStore } from './desks.js';
 export { sweepStaleSockets } from './sweep-sockets.js';

--- a/packages/desktop-host/src/ipc.ts
+++ b/packages/desktop-host/src/ipc.ts
@@ -32,6 +32,7 @@ import type { DeskStore } from './desks';
 import { sendEvent } from './send-event';
 import { drivers, publishDriver, unpublishDriver, whenDriverReady } from './ipc/shared';
 import { registerAppHandlers } from './ipc/app';
+import { registerUpdateHandlers, type UpdateConfig } from './ipc/update';
 import { registerAskHandlers } from './ipc/ask';
 import { registerConnectionHandlers } from './ipc/connection';
 import { registerOnboardingHandlers } from './ipc/onboarding';
@@ -44,9 +45,17 @@ import { registerSettingsHandlers } from './ipc/settings';
 import { registerVaultHandlers } from './ipc/vault';
 import { registerChatHandlers } from './ipc/chat';
 
-export function registerIpcHandlers(pool: RunnerPool, desks: DeskStore): void {
+export function registerIpcHandlers(
+  pool: RunnerPool,
+  desks: DeskStore,
+  opts: { readonly update?: UpdateConfig } = {},
+): void {
   registerAskHandlers();
   registerAppHandlers(pool);
+  // Self-update handlers. The baked signing key is supplied by the app's main
+  // (it owns `update-key.ts`); an empty/absent config means updates report as
+  // unavailable rather than erroring.
+  registerUpdateHandlers(opts.update ?? { publicKeyPem: '' });
   registerConnectionHandlers(pool);
   registerOnboardingHandlers(pool);
   registerSessionHandlers(pool);

--- a/packages/desktop-host/src/ipc/update.ts
+++ b/packages/desktop-host/src/ipc/update.ts
@@ -1,0 +1,146 @@
+/**
+ * Self-update IPC: report the running dashboard, check the published manifest,
+ * and download+install a newer dashboard bundle into the writable userData copy
+ * (the bootstrap activates it on the next launch). Mirrors the "Update CLI" flow
+ * in `./app.ts` — a hot-update with no installer.
+ *
+ * The update SOURCE is fixed here, main-side: the renderer triggers check/apply
+ * but never supplies a URL (see the `z.undefined()` schemas), so a compromised
+ * renderer can't redirect the loader at an attacker. The signing PUBLIC KEY is
+ * baked into the app and threaded in via {@link UpdateConfig}; an empty key (or
+ * a dev/unpackaged run) means self-update is reported as unavailable.
+ */
+
+import { app, BrowserWindow } from 'electron';
+
+import {
+  type ShellInfo,
+  checkForUpdate,
+  downloadAndStage,
+  markConfirmed,
+  pruneBundles,
+  readActiveVersion,
+} from '../app-update/index.js';
+import { sendEvent } from '../send-event';
+import { handle } from './shared';
+
+export interface UpdateConfig {
+  /** Baked Ed25519 public key (SPKI PEM). Empty ⇒ self-update disabled. */
+  publicKeyPem: string;
+  /** Manifest URL override (dev/test only). Defaults to the GitHub latest release. */
+  manifestUrl?: string;
+}
+
+const DEFAULT_MANIFEST_URL =
+  'https://github.com/moxxy-ai/moxxy/releases/latest/download/moxxy-app-manifest.json';
+
+function runningVersion(): string {
+  return process.env.MOXXY_APP_BUNDLE_VERSION ?? app.getVersion();
+}
+
+function shellInfo(): ShellInfo {
+  return { electron: process.versions.electron, nodeAbi: process.versions.modules ?? '' };
+}
+
+function messageOf(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+export function registerUpdateHandlers(config: UpdateConfig): void {
+  const { publicKeyPem } = config;
+  // The manifest URL only ever differs from the default in dev/test (never in a
+  // packaged build) so a shipped app can't be pointed at an attacker origin.
+  const manifestUrl = app.isPackaged ? DEFAULT_MANIFEST_URL : config.manifestUrl ?? DEFAULT_MANIFEST_URL;
+  const enabled = (): boolean => !!publicKeyPem && app.isPackaged;
+
+  handle('app.updateInfo', async () => ({
+    version: runningVersion(),
+    source: process.env.MOXXY_APP_BUNDLE_VERSION ? ('updated' as const) : ('bundled' as const),
+    channelConfigured: enabled(),
+  }));
+
+  handle('app.checkUpdate', async () => {
+    const currentVersion = runningVersion();
+    if (!enabled()) {
+      return {
+        available: false,
+        currentVersion,
+        latestVersion: null,
+        compatible: false,
+        error: app.isPackaged
+          ? 'Automatic updates are not configured for this build.'
+          : 'Updates run only in the packaged app.',
+      };
+    }
+    const res = await checkForUpdate({
+      manifestUrl,
+      currentVersion,
+      publicKeyPem,
+      shell: shellInfo(),
+    });
+    return {
+      available: res.available,
+      currentVersion,
+      latestVersion: res.latestVersion,
+      compatible: res.compatible,
+      ...(res.notes ? { notes: res.notes } : {}),
+      ...(res.releaseUrl ? { releaseUrl: res.releaseUrl } : {}),
+    };
+  });
+
+  handle('app.updateDashboard', async () => {
+    const currentVersion = runningVersion();
+    if (!enabled()) {
+      return { ok: false, version: null, error: 'Automatic updates are not available.' };
+    }
+    const target = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0] ?? null;
+
+    const res = await checkForUpdate({
+      manifestUrl,
+      currentVersion,
+      publicKeyPem,
+      shell: shellInfo(),
+    });
+    if (!res.available || !res.manifest) {
+      return { ok: false, version: null, error: 'No update available.' };
+    }
+    if (!res.compatible) {
+      return {
+        ok: false,
+        version: res.latestVersion,
+        error: 'This update needs a newer app version — a full reinstall is required.',
+      };
+    }
+
+    try {
+      const { version } = await downloadAndStage({
+        userDataDir: app.getPath('userData'),
+        manifest: res.manifest,
+        publicKeyPem,
+        onProgress: (p) => {
+          if (target) sendEvent(target, 'app.update.progress', p);
+        },
+      });
+      // Keep {active, previous} so a failed boot can roll back to the last-good.
+      pruneBundles(app.getPath('userData'), [version, currentVersion]);
+      return { ok: true, version };
+    } catch (e) {
+      return { ok: false, version: null, error: messageOf(e) };
+    }
+  });
+
+  handle('app.relaunch', async () => {
+    // Register a relaunch, then quit gracefully (before-quit reaps the runners).
+    app.relaunch();
+    app.quit();
+  });
+
+  handle('app.appBooted', async () => {
+    // The running override (if any) reached a healthy render — confirm it so the
+    // boot-probe doesn't poison it. No-op on the bundled floor.
+    const version = process.env.MOXXY_APP_BUNDLE_VERSION;
+    if (version && readActiveVersion(app.getPath('userData')) === version) {
+      markConfirmed(app.getPath('userData'), version);
+    }
+  });
+}

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -265,6 +265,38 @@ export interface RunTurnResult {
   turnId: string;
 }
 
+/** The app bundle ("dashboard") the desktop is currently running. */
+export interface AppUpdateInfo {
+  /** Running bundle version. */
+  version: string;
+  /** Whether it's the one baked into the .app or a hot-updated override. */
+  source: 'bundled' | 'updated';
+  /** True when this build has a signing key baked in (self-update enabled). */
+  channelConfigured: boolean;
+}
+
+/** Result of checking the published manifest for a newer dashboard. */
+export interface AppUpdateCheck {
+  /** A newer, signature-valid bundle is published. */
+  available: boolean;
+  currentVersion: string;
+  latestVersion: string | null;
+  /** False ⇒ the update needs a newer shell (a Tier-2 / installer update). */
+  compatible: boolean;
+  notes?: string;
+  releaseUrl?: string;
+  /** Set when the check itself failed (offline, not configured, …). */
+  error?: string;
+}
+
+/** Streamed progress while a dashboard update downloads + installs. */
+export interface AppUpdateProgress {
+  phase: 'download' | 'verify' | 'extract' | 'activate';
+  received?: number;
+  total?: number;
+  message?: string;
+}
+
 // ---------- Events the renderer subscribes to ------------------------------
 
 /**
@@ -289,6 +321,9 @@ export interface IpcEvents {
    *  stdout/stderr line; the invoke() also returns the final exit
    *  code so callers can short-circuit on success. */
   'onboarding.install.progress': string;
+  /** Streamed during `app.updateDashboard` — one event per download/verify/
+   *  extract/activate step so the Updates UI can show a progress bar. */
+  'app.update.progress': AppUpdateProgress;
   /** The runner needs a permission/approval decision — the renderer
    *  shows a bottom sheet and replies via `ask.respond`. */
   'ask.request': AskRequest;
@@ -326,6 +361,25 @@ export interface IpcCommands {
    *  `onboarding.install.progress`. Returns the exit code (0 = ok) and
    *  the post-update version. */
   'app.updateCli': () => Promise<{ code: number; version: string | null }>;
+
+  /** The dashboard (app bundle) the desktop is currently running. */
+  'app.updateInfo': () => Promise<AppUpdateInfo>;
+  /** Fetch + verify the published manifest and report whether a newer
+   *  dashboard is available (and whether it fits this shell). Never throws —
+   *  failures come back in `error`. */
+  'app.checkUpdate': () => Promise<AppUpdateCheck>;
+  /** Download + verify + install the latest compatible dashboard bundle into
+   *  the writable userData copy, streaming `app.update.progress`. On success
+   *  the new bundle activates on the next launch (the UI offers a relaunch).
+   *  The update SOURCE is resolved entirely main-side — the renderer passes no
+   *  URL. */
+  'app.updateDashboard': () => Promise<{ ok: boolean; version: string | null; error?: string }>;
+  /** Relaunch the app so a freshly-installed dashboard bundle takes effect. */
+  'app.relaunch': () => Promise<void>;
+  /** Renderer → main heartbeat: the React tree mounted past the splash. Clears
+   *  the boot-probe so a hot-updated bundle is marked healthy (no-op on the
+   *  bundled floor). */
+  'app.appBooted': () => Promise<void>;
 
   'onboarding.status': () => Promise<OnboardingStatus>;
   /** Probe Node.js — used by the first wizard step before we offer

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -56,6 +56,14 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
   // "nothing" so a hostile renderer can't smuggle args across.
   'app.cliInfo': z.undefined(),
   'app.updateCli': z.undefined(),
+  // Self-update: all no-arg. The update SOURCE (manifest/bundle URL) is resolved
+  // main-side only — a hostile renderer must never be able to point the loader
+  // at an attacker URL, so these accept nothing.
+  'app.updateInfo': z.undefined(),
+  'app.checkUpdate': z.undefined(),
+  'app.updateDashboard': z.undefined(),
+  'app.relaunch': z.undefined(),
+  'app.appBooted': z.undefined(),
   'onboarding.openExternal': z.object({ url: httpUrl }),
   'onboarding.saveProviderKey': z.object({
     provider: providerName,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       '@moxxy/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
+      electron-updater:
+        specifier: ^6.8.3
+        version: 6.8.3
       react:
         specifier: 'catalog:'
         version: 18.3.1
@@ -4037,6 +4040,10 @@ packages:
     resolution: {integrity: sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==}
     engines: {node: '>=12.0.0'}
 
+  builder-util-runtime@9.5.1:
+    resolution: {integrity: sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==}
+    engines: {node: '>=12.0.0'}
+
   builder-util@25.1.7:
     resolution: {integrity: sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==}
 
@@ -4530,6 +4537,9 @@ packages:
 
   electron-to-chromium@1.5.363:
     resolution: {integrity: sha512-VjUKPyWzGnT1fujlkEGC/BvN70Hh70KXtAqcmniXviYlJC/ivcT+BWGPyxWVbJZLfvtKR6dqg1L7T7pgAMBtWA==}
+
+  electron-updater@6.8.3:
+    resolution: {integrity: sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==}
 
   electron-vite@2.3.0:
     resolution: {integrity: sha512-lsN2FymgJlp4k6MrcsphGqZQ9fKRdJKasoaiwIrAewN1tapYI/KINLdfEL7n10LuF0pPSNf/IqjzZbB5VINctg==}
@@ -5493,8 +5503,15 @@ packages:
   lodash.difference@4.5.0:
     resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
 
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
   lodash.flatten@4.4.0:
     resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
@@ -6553,6 +6570,11 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.8.0:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
@@ -6826,6 +6848,9 @@ packages:
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -9734,6 +9759,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  builder-util-runtime@9.5.1:
+    dependencies:
+      debug: 4.4.3
+      sax: 1.6.0
+    transitivePeerDependencies:
+      - supports-color
+
   builder-util@25.1.7:
     dependencies:
       7zip-bin: 5.2.0
@@ -10263,6 +10295,19 @@ snapshots:
       - supports-color
 
   electron-to-chromium@1.5.363: {}
+
+  electron-updater@6.8.3:
+    dependencies:
+      builder-util-runtime: 9.5.1
+      fs-extra: 10.1.0
+      js-yaml: 4.1.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   electron-vite@2.3.0(vite@5.4.21(@types/node@22.19.18)):
     dependencies:
@@ -11507,7 +11552,11 @@ snapshots:
 
   lodash.difference@4.5.0: {}
 
+  lodash.escaperegexp@4.1.2: {}
+
   lodash.flatten@4.4.0: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.isplainobject@4.0.6: {}
 
@@ -12962,6 +13011,8 @@ snapshots:
 
   semver@6.3.1: {}
 
+  semver@7.7.4: {}
+
   semver@7.8.0: {}
 
   send@1.2.1:
@@ -13344,6 +13395,8 @@ snapshots:
       any-promise: 1.3.0
 
   tiny-inflate@1.0.3: {}
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 

--- a/scripts/build-app-bundle.mjs
+++ b/scripts/build-app-bundle.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * Produce the two desktop self-update release assets from the freshly-built
+ * renderer + main:
+ *
+ *   moxxy-app-bundle-<version>.json.gz   the gzipped {version, files:{path:b64}}
+ *   moxxy-app-manifest.json              the Ed25519-signed manifest
+ *
+ * "App bundle" = everything the immutable bootstrap LOADS — all of
+ * `apps/desktop/dist/` (renderer) + `apps/desktop/dist-electron/` (real main +
+ * preload), MINUS the bootstrap itself and sourcemaps. Shipped + activated as
+ * one unit so renderer/main/IPC always move together (skew-free protocol
+ * changes). Signed with the release owner's Ed25519 private key so the client
+ * only ever loads bundles it can authenticate.
+ *
+ * Run AFTER `pnpm build` (needs @moxxy/desktop-host/dist + apps/desktop/dist*).
+ *
+ * Env:
+ *   MOXXY_UPDATE_SIGNING_KEY   (required) Ed25519 PRIVATE key PEM
+ *   MOXXY_BUNDLE_BASE_URL      base of the published asset URLs
+ *                              (default: GitHub latest-release download URL)
+ *   MOXXY_RELEASE_URL          human release page (default: latest release)
+ *   MOXXY_BUNDLE_MIN_ELECTRON  override min Electron (default: <major>.0.0)
+ *   MOXXY_BUNDLE_NODE_ABI      required Electron ABI, '' = any (default: '')
+ *   MOXXY_BUNDLE_NOTES         short release notes for the Updates UI
+ *   MOXXY_BUNDLE_OUT_DIR       output dir (default: apps/desktop/release/update)
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Built output of the shared, tested builder — same code the integration test
+// and (transitively) the client verifier use, so producer + consumer can't drift.
+import { buildAppBundle } from '../packages/desktop-host/dist/app-update/index.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const desktopDir = path.join(repoRoot, 'apps', 'desktop');
+
+function readJson(p) {
+  return JSON.parse(readFileSync(p, 'utf8'));
+}
+
+/** Walk a dir, returning dist-relative POSIX paths of every file under it. */
+function walk(absDir, relPrefix, out) {
+  for (const name of readdirSync(absDir)) {
+    const abs = path.join(absDir, name);
+    const rel = `${relPrefix}/${name}`;
+    if (statSync(abs).isDirectory()) walk(abs, rel, out);
+    else out.push(rel);
+  }
+  return out;
+}
+
+function main() {
+  const privateKeyPem = process.env.MOXXY_UPDATE_SIGNING_KEY;
+  if (!privateKeyPem || !privateKeyPem.includes('PRIVATE KEY')) {
+    console.error(
+      'build-app-bundle: MOXXY_UPDATE_SIGNING_KEY (Ed25519 private key PEM) is required to sign the manifest.',
+    );
+    process.exit(1);
+  }
+
+  const version = readJson(path.join(desktopDir, 'package.json')).version;
+  let minElectron = process.env.MOXXY_BUNDLE_MIN_ELECTRON;
+  if (!minElectron) {
+    const ev = readJson(path.join(desktopDir, 'node_modules', 'electron', 'package.json')).version;
+    minElectron = `${ev.split('.')[0]}.0.0`;
+  }
+  const nodeAbi = process.env.MOXXY_BUNDLE_NODE_ABI ?? '';
+  const baseUrl =
+    process.env.MOXXY_BUNDLE_BASE_URL ??
+    'https://github.com/moxxy-ai/moxxy/releases/latest/download';
+  const releaseUrl = process.env.MOXXY_RELEASE_URL ?? 'https://github.com/moxxy-ai/moxxy/releases/latest';
+  const bundleName = `moxxy-app-bundle-${version}.json.gz`;
+  const bundleUrl = `${baseUrl}/${bundleName}`;
+
+  // Collect the bundle files: dist/** + dist-electron/**, minus the floor
+  // bootstrap + sourcemaps (runtime doesn't need maps; bootstrap is the floor).
+  const rels = [];
+  walk(path.join(desktopDir, 'dist'), 'dist', rels);
+  walk(path.join(desktopDir, 'dist-electron'), 'dist-electron', rels);
+  const files = {};
+  let bytes = 0;
+  for (const rel of rels) {
+    if (rel === 'dist-electron/main/bootstrap.js') continue;
+    if (rel.endsWith('.map')) continue;
+    const buf = readFileSync(path.join(desktopDir, rel));
+    files[rel] = buf;
+    bytes += buf.length;
+  }
+  if (!files['dist-electron/main/index.js'] || !files['dist/index.html']) {
+    console.error('build-app-bundle: dist/ or dist-electron/ not built — run `pnpm build` first.');
+    process.exit(1);
+  }
+
+  const { manifest, manifestJson, bundleGz } = buildAppBundle({
+    version,
+    minElectron,
+    nodeAbi,
+    bundleUrl,
+    privateKeyPem,
+    files,
+    releaseUrl,
+    notes: process.env.MOXXY_BUNDLE_NOTES,
+  });
+
+  const outDir = process.env.MOXXY_BUNDLE_OUT_DIR ?? path.join(desktopDir, 'release', 'update');
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(path.join(outDir, bundleName), bundleGz);
+  writeFileSync(path.join(outDir, 'moxxy-app-manifest.json'), manifestJson);
+
+  console.log(
+    `build-app-bundle: wrote ${Object.keys(files).length} files ` +
+      `(${(bytes / 1024).toFixed(0)} KiB raw → ${(bundleGz.length / 1024).toFixed(0)} KiB gz)\n` +
+      `  version=${version} minElectron=${minElectron} nodeAbi=${nodeAbi || '(any)'}\n` +
+      `  sha256=${manifest.sha256}\n` +
+      `  bundleUrl=${bundleUrl}\n` +
+      `  out=${outDir}`,
+  );
+}
+
+main();


### PR DESCRIPTION
## What

A **two-tier desktop self-updater** so releases land **without users downloading and installing new binaries** for the common case.

Most of the desktop is JavaScript (renderer, main process, preload, the IPC contract) — only the Electron/Chromium/Node shell is a true binary. So a release ships as a small signed JS bundle the app verifies and swaps in on the next launch.

### Tier 1 — JS hot-update (every normal release, no binary download)
The Electron entry is now a tiny **immutable bootstrap loader** (`electron/main/bootstrap.ts`, baked into the signed `.app`). It picks a verified bundle from `<userData>/app/<version>/` over the bundled floor and loads its real `index.js`. Renderer + main + preload + **IPC contract** ship and activate as **one bundle**, so protocol/IPC changes are skew-free — both sides always move together.

### Tier 2 — shell update (rare: Electron/Chromium/Node or native-ABI bump)
`electron-updater` against the existing GitHub Releases feed: background download + install on Windows/Linux; notify-only on unsigned macOS until Developer ID signing lands.

## Trust model
- **Ed25519** signature over the manifest (baked public key) — the root of trust
- **SHA-256** of the gzipped bundle, bound by the signed manifest
- **HTTPS + host-pin** to GitHub/its CDN; the update source is resolved main-side only (the renderer never supplies a URL)
- **Electron/ABI compat gate** — an incompatible bundle becomes a Tier-2 update, never loaded as JS
- Verified entirely in the **immutable floor** before any hot-updated code runs
- **Off by default** — with no baked key the app always runs the floor and refuses to download

Same trust model the app already uses for "Update CLI", so it works on today's *unsigned* macOS builds.

## Rollback safety
Boot-probe: the renderer pings `app.appBooted` once it renders; a bundle that loads but never confirms (white-screen/crash) is poisoned and the previous-good bundle (or floor) is used — both in-session (15s timer) and across launches (`recoverFromFailedBoot`).

## Verification
- `pnpm build` 55/55 · `typecheck` 105/105 · `lint` **0 errors** · `test` 103/103 suites
- **+33 tests** in `@moxxy/desktop-host` (101 total): signature verify/tamper, the resolve gate, a full **build→stage→load round-trip proving a renamed IPC command rides Tier 1**, boot-probe rollback, host-pin + path-traversal rejection
- Publisher smoke-tested against real `dist/` (6.8 MB → 5.8 MB gz, signed)
- `bootstrap.js` confirmed hermetic (node-only gate + baked key, zero `@moxxy/*` at runtime)

## To enable (owner, one-time) — ships **off** by default
1. `openssl genpkey -algorithm ed25519` → paste the **public** SPKI PEM into `electron/main/update-key.ts`
2. Add the **private** key as the `MOXXY_UPDATE_SIGNING_KEY` GitHub secret
3. **Publish** the desktop release (CI makes a draft; clients fetch via `releases/latest/download/`, which only resolves to published releases)

Full guide: `docs/desktop-self-update.md`.

## Not yet verified
- Packaged GUI click-through (needs a published signed release)
- Whether electron-builder bundles `electron-updater` into the asar — **degrades gracefully** to notify-only if absent, so it can't break the app