### PR TITLE
chore(desktop): bump version to 0.0.6

### DIFF
--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @moxxy/desktop
 
+## 0.0.6
+
+### Minor Changes
+
+- Self-update: the desktop now hot-updates its JS layers (renderer + main + preload + IPC contract) as one Ed25519-signed app bundle, activated by an immutable bootstrap loader — no reinstall. Rare native/Electron bumps fall back to electron-updater (Tier 2). Signature + SHA-256 + host-pin verified in the immutable floor; a boot-probe reverts a bundle that fails to render. See `docs/desktop-self-update.md`.
+
 ## 0.0.5
 
 ### Patch Changes

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@moxxy/desktop",
   "private": true,
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "moxxy desktop — Electron app that connects to moxxy via @moxxy/runner and renders a TUI-equivalent chat surface.",
   "homepage": "https://moxxy.ai",
   "author": "Michal Makowski <michal.makowski97@gmail.com>",


### PR DESCRIPTION
Bumps `@moxxy/desktop` **0.0.5 → 0.0.6** for the first release that carries the self-update mechanism (merged in #56).

- `apps/desktop/package.json` → `0.0.6`
- `CHANGELOG.md` — `## 0.0.6` entry

Cutting the `desktop-v0.0.6` tag after this merges will have CI sign the `0.0.6` app bundle (using the `MOXXY_UPDATE_SIGNING_KEY` secret); a `0.0.5` client that checks for updates will then see `0.0.6` and offer the hot-update. Remember the release must be **Published** (not left as a draft) for clients to fetch the assets.