### PR TITLE
fix(desktop): voice transcription 'no speech detected' (silent mic on macOS)

### DIFF
--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -16,5 +16,10 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <!-- Microphone access for voice input (speech-to-text). Without this a
+         hardened-runtime signed build is denied the mic and recordings come
+         back silent. Pairs with NSMicrophoneUsageDescription in package.json. -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
   </dict>
 </plist>

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -30,6 +30,7 @@ import {
   showFocusWindow,
   toggleFocusWindow,
   installContentSecurityPolicy,
+  installMediaPermissions,
   lockDownNavigation,
   isSafeExternalUrl,
   preferredCliEntry,
@@ -459,6 +460,12 @@ app.whenReady().then(async () => {
   // before any window loads. Skipped in dev (Vite HMR needs a loose
   // policy); third-party + OAuth responses are left untouched.
   installContentSecurityPolicy(session.defaultSession, { isDev });
+
+  // Allow the renderer's voice recorder to reach the microphone. Without this,
+  // macOS hands getUserMedia a SILENT stream (no rejection), so voice
+  // transcription comes back empty ("No speech detected"). Pairs with the
+  // NSMicrophoneUsageDescription + audio-input entitlement in the build config.
+  installMediaPermissions(session.defaultSession);
 
   // Reap any orphan runners from a previous crashed desktop process
   // before we try to spawn new ones. Without this, the first workspace

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -51,7 +51,7 @@ if (app.isPackaged && !process.env.MOXXY_CLI_ENTRY) {
   const entry = preferredCliEntry(app.getPath('userData'), process.resourcesPath);
   if (entry) process.env.MOXXY_CLI_ENTRY = entry;
 }
-import { ipcMain, Tray, Menu, nativeImage, globalShortcut, session, shell } from 'electron';
+import { ipcMain, Tray, Menu, nativeImage, globalShortcut, session, shell, systemPreferences } from 'electron';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -463,9 +463,16 @@ app.whenReady().then(async () => {
 
   // Allow the renderer's voice recorder to reach the microphone. Without this,
   // macOS hands getUserMedia a SILENT stream (no rejection), so voice
-  // transcription comes back empty ("No speech detected"). Pairs with the
-  // NSMicrophoneUsageDescription + audio-input entitlement in the build config.
-  installMediaPermissions(session.defaultSession);
+  // transcription comes back empty ("No speech detected"). The macOS OS-level
+  // request is injected here (electron stays out of desktop-host's pure security
+  // helpers); pairs with NSMicrophoneUsageDescription + the audio-input
+  // entitlement in the build config.
+  installMediaPermissions(session.defaultSession, {
+    askForMicAccess:
+      process.platform === 'darwin'
+        ? () => systemPreferences.askForMediaAccess('microphone')
+        : undefined,
+  });
 
   // Reap any orphan runners from a previous crashed desktop process
   // before we try to spawn new ones. Without this, the first workspace

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -94,7 +94,8 @@
       "entitlementsInherit": "build/entitlements.mac.plist",
       "extendInfo": {
         "CFBundleName": "MoxxyAI Workspaces",
-        "CFBundleDisplayName": "MoxxyAI Workspaces"
+        "CFBundleDisplayName": "MoxxyAI Workspaces",
+        "NSMicrophoneUsageDescription": "MoxxyAI Workspaces uses the microphone for voice input (speech-to-text)."
       }
     },
     "linux": {

--- a/apps/desktop/src/lib/audioToPcm16.test.ts
+++ b/apps/desktop/src/lib/audioToPcm16.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { pcm16Peak } from './audioToPcm16';
+
+/** Build a PCM16 LE byte buffer from signed 16-bit samples. */
+function pcm(samples: number[]): Uint8Array {
+  const buf = new Int16Array(samples);
+  return new Uint8Array(buf.buffer);
+}
+
+describe('pcm16Peak', () => {
+  it('reports 0 for a fully silent buffer (the mic-access failure case)', () => {
+    expect(pcm16Peak(pcm([0, 0, 0, 0]))).toBe(0);
+  });
+
+  it('reports near 1 for a full-scale sample', () => {
+    expect(pcm16Peak(pcm([0, 32767, -1234]))).toBeCloseTo(1, 2);
+  });
+
+  it('stays below the 0.005 silence threshold for dither-level noise', () => {
+    // A handful of ±1..±50 samples — what a denied/muted mic effectively yields.
+    expect(pcm16Peak(pcm([1, -2, 3, -1, 50, -10]))).toBeLessThan(0.005);
+  });
+
+  it('rises above the silence threshold for audible speech-level samples', () => {
+    // ~ -30 dBFS — quiet but clearly present speech.
+    expect(pcm16Peak(pcm([1000, -1200, 800]))).toBeGreaterThan(0.005);
+  });
+
+  it('handles an empty buffer without throwing', () => {
+    expect(pcm16Peak(new Uint8Array(0))).toBe(0);
+  });
+});

--- a/apps/desktop/src/lib/audioToPcm16.ts
+++ b/apps/desktop/src/lib/audioToPcm16.ts
@@ -56,6 +56,22 @@ export async function audioToPcm16(blob: Blob): Promise<Uint8Array> {
   return new Uint8Array(pcm.buffer, pcm.byteOffset, pcm.byteLength);
 }
 
+/**
+ * Largest absolute sample (0..1) in a PCM16 LE buffer. Used to distinguish a
+ * SILENT capture (mic access denied / muted / wrong input device — the audio
+ * track resolved but carries only zeros) from genuine silence the user could
+ * fix by speaking up, so the UI can point at the real cause.
+ */
+export function pcm16Peak(bytes: Uint8Array): number {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let peak = 0;
+  for (let i = 0; i + 1 < bytes.byteLength; i += 2) {
+    const s = Math.abs(view.getInt16(i, true));
+    if (s > peak) peak = s;
+  }
+  return peak / 0x8000;
+}
+
 /** Base64-encode a Uint8Array without spilling the entire string into
  *  a single `String.fromCharCode(...)` call (which blows the V8 stack
  *  past ~120 KB). Chunks the conversion so multi-second clips work. */

--- a/apps/desktop/src/lib/useVoiceRecorder.ts
+++ b/apps/desktop/src/lib/useVoiceRecorder.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from './api';
 import { toErrorMessage } from './errors';
-import { audioToPcm16, uint8ArrayToBase64, MOXXY_PCM16_24KHZ_MIME } from './audioToPcm16';
+import { audioToPcm16, pcm16Peak, uint8ArrayToBase64, MOXXY_PCM16_24KHZ_MIME } from './audioToPcm16';
 
 /**
  * Push-to-record voice capture, shared by the composer (appends the
@@ -96,6 +96,14 @@ export function useVoiceRecorder(opts: VoiceRecorderOptions): UseVoiceRecorder {
         const pcm = await audioToPcm16(blob);
         if (pcm.length === 0) {
           fail('No speech detected — try again');
+          return;
+        }
+        // A captured-but-silent clip means the mic track resolved yet carried
+        // only zeros — almost always mic access denied / muted / wrong input
+        // device, NOT "you didn't speak". Surface that instead of a useless
+        // round-trip to the transcriber (which would just return empty text).
+        if (pcm16Peak(pcm) < 0.005) {
+          fail('No sound from the microphone — check microphone access and the selected input device.');
           return;
         }
         const text = await api().invoke('session.transcribe', {

--- a/packages/desktop-host/src/index.ts
+++ b/packages/desktop-host/src/index.ts
@@ -21,6 +21,7 @@ export {
 } from './focus-window.js';
 export {
   installContentSecurityPolicy,
+  installMediaPermissions,
   lockDownNavigation,
   isSafeExternalUrl,
 } from './security.js';

--- a/packages/desktop-host/src/security.ts
+++ b/packages/desktop-host/src/security.ts
@@ -9,6 +9,7 @@
  * the diagnostics the renderer is allowed to see.
  */
 
+import { systemPreferences } from 'electron';
 import type { BrowserWindow, Session } from 'electron';
 
 // ---- IPC input validation -------------------------------------------------
@@ -168,4 +169,44 @@ export function installContentSecurityPolicy(
       },
     });
   });
+}
+
+/**
+ * Let the renderer capture the microphone for voice input.
+ *
+ * The renderer is a Chromium page, so `getUserMedia` needs the web-layer
+ * `media` permission AND, on macOS, OS-level microphone access (TCC). The
+ * macOS trap: without this, `getUserMedia` does NOT reject — it resolves with a
+ * SILENT stream, so recordings transcribe to empty text and the UI shows a
+ * misleading "No speech detected" (an auth failure would instead throw). On
+ * macOS we trigger the system prompt via {@link systemPreferences.askForMediaAccess}
+ * and grant from its result; this also requires `NSMicrophoneUsageDescription`
+ * in Info.plist (package.json#build.mac.extendInfo) and, on a hardened-runtime
+ * signed build, the `com.apple.security.device.audio-input` entitlement. Other
+ * platforms grant the media request directly. Non-media requests keep the prior
+ * allow-by-default behaviour.
+ */
+export function installMediaPermissions(session: Session): void {
+  session.setPermissionRequestHandler((_wc, permission, callback) => {
+    // getUserMedia surfaces as the `media` permission in the request handler
+    // (`audioCapture`/`videoCapture` only appear in the check handler below).
+    if (permission === 'media') {
+      if (process.platform === 'darwin') {
+        // Triggers the macOS mic prompt (first run) and reflects the user's
+        // System Settings → Privacy → Microphone choice thereafter.
+        void systemPreferences
+          .askForMediaAccess('microphone')
+          .then((granted) => callback(granted))
+          .catch(() => callback(false));
+        return;
+      }
+      callback(true);
+      return;
+    }
+    // Preserve Electron's prior default (no handler ⇒ grant) for the rest.
+    callback(true);
+  });
+  // Chromium also CHECKS permission synchronously before requesting it; approve
+  // so getUserMedia isn't short-circuited before the request handler runs.
+  session.setPermissionCheckHandler(() => true);
 }

--- a/packages/desktop-host/src/security.ts
+++ b/packages/desktop-host/src/security.ts
@@ -9,7 +9,6 @@
  * the diagnostics the renderer is allowed to see.
  */
 
-import { systemPreferences } from 'electron';
 import type { BrowserWindow, Session } from 'electron';
 
 // ---- IPC input validation -------------------------------------------------
@@ -179,23 +178,32 @@ export function installContentSecurityPolicy(
  * macOS trap: without this, `getUserMedia` does NOT reject — it resolves with a
  * SILENT stream, so recordings transcribe to empty text and the UI shows a
  * misleading "No speech detected" (an auth failure would instead throw). On
- * macOS we trigger the system prompt via {@link systemPreferences.askForMediaAccess}
- * and grant from its result; this also requires `NSMicrophoneUsageDescription`
- * in Info.plist (package.json#build.mac.extendInfo) and, on a hardened-runtime
- * signed build, the `com.apple.security.device.audio-input` entitlement. Other
- * platforms grant the media request directly. Non-media requests keep the prior
- * allow-by-default behaviour.
+ * macOS we ask the OS for mic access via the injected `askForMicAccess`
+ * (the caller wires `systemPreferences.askForMediaAccess('microphone')` — kept
+ * OUT of this module so the pure security helpers don't drag the electron
+ * runtime into unit tests) and grant from its result; this also requires
+ * `NSMicrophoneUsageDescription` in Info.plist (package.json#build.mac.extendInfo)
+ * and, on a hardened-runtime signed build, the
+ * `com.apple.security.device.audio-input` entitlement. Other platforms grant the
+ * media request directly. Non-media requests keep the prior allow-by-default
+ * behaviour.
  */
-export function installMediaPermissions(session: Session): void {
+export interface MediaPermissionDeps {
+  /** macOS only: request OS-level microphone access (returns granted?). Omit
+   *  elsewhere — the media request is then granted directly. */
+  readonly askForMicAccess?: () => Promise<boolean>;
+}
+
+export function installMediaPermissions(session: Session, deps: MediaPermissionDeps = {}): void {
   session.setPermissionRequestHandler((_wc, permission, callback) => {
     // getUserMedia surfaces as the `media` permission in the request handler
     // (`audioCapture`/`videoCapture` only appear in the check handler below).
     if (permission === 'media') {
-      if (process.platform === 'darwin') {
+      if (deps.askForMicAccess) {
         // Triggers the macOS mic prompt (first run) and reflects the user's
         // System Settings → Privacy → Microphone choice thereafter.
-        void systemPreferences
-          .askForMediaAccess('microphone')
+        void deps
+          .askForMicAccess()
           .then((granted) => callback(granted))
           .catch(() => callback(false));
         return;


### PR DESCRIPTION
## Symptom
Voice transcription on the desktop always fails with **"No speech detected"**, even while speaking.

## Root cause
The transcribe call *succeeds* but returns empty text — so the audio reaching the transcriber is silent (an auth/creds failure would `throw` and surface a login hint instead, not "no speech detected").

On macOS, the renderer's `getUserMedia` **does not reject** when the app lacks microphone permission — Chromium resolves the stream but delivers **silence**. The desktop had **no microphone-permission infrastructure at all**:
- no `NSMicrophoneUsageDescription` in Info.plist (so macOS never prompts / grants),
- no `com.apple.security.device.audio-input` entitlement,
- no media permission handler in the main process.

So every recording was silent → empty transcript → misleading "No speech detected".

## Fix
- **`installMediaPermissions`** (desktop-host `security.ts`, called in `whenReady`): grants the renderer's `media` permission and, on macOS, triggers the system mic prompt via `systemPreferences.askForMediaAccess('microphone')`, granting from its result.
- **Info.plist `NSMicrophoneUsageDescription`** + **`com.apple.security.device.audio-input`** entitlement so macOS will prompt for and allow mic access (the entitlement covers future hardened-runtime signed builds; the usage string is what unblocks today's unsigned build).
- **Renderer diagnostics**: detect a captured-but-silent clip (`pcm16Peak`) and show an actionable **"No sound from the microphone — check microphone access and the selected input device"** instead of the misleading "no speech detected" — and skip the wasted transcribe round-trip. This also disambiguates future reports (silent mic vs. audio-captured-but-Codex-found-nothing).

## Verification
- `pnpm build` / `typecheck` clean; desktop-host **101** + desktop **49** tests pass (+5 for the silence detector).
- Couldn't exercise the live mic here. After installing this build, macOS should prompt for microphone access on first voice use; if it was previously denied, enable it under **System Settings → Privacy & Security → Microphone**.

### If it still fails after this
The new message distinguishes the cases:
- **"No sound from the microphone…"** → still a mic access/device problem (check the Privacy pane + input device).
- **"No speech detected"** → audio *was* captured but Codex returned empty (a different, downstream issue worth a follow-up).