### PR TITLE
chore(desktop): bump version to 0.0.7

### DIFF
--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @moxxy/desktop
 
+## 0.0.7
+
+### Patch Changes
+
+- Fix voice transcription returning "No speech detected": grant the renderer microphone access (macOS `NSMicrophoneUsageDescription` + audio-input entitlement + a media permission handler that triggers the system mic prompt), since macOS otherwise hands `getUserMedia` a silent stream. A captured-but-silent clip now reports an actionable microphone-access message instead.
+
 ## 0.0.6
 
 ### Minor Changes

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@moxxy/desktop",
   "private": true,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "moxxy desktop — Electron app that connects to moxxy via @moxxy/runner and renders a TUI-equivalent chat surface.",
   "homepage": "https://moxxy.ai",
   "author": "Michal Makowski <michal.makowski97@gmail.com>",


### PR DESCRIPTION
Bumps `@moxxy/desktop` **0.0.6 → 0.0.7**.

- `apps/desktop/package.json` → `0.0.7`
- `CHANGELOG.md` — `## 0.0.7` entry (the voice-transcription microphone fix, #58)

Clean 2-file diff. Cut the `desktop-v0.0.7` tag after merge to have CI sign the `0.0.7` app bundle; a `0.0.6` client will then be offered the hot-update (the release must be **Published**, not a draft).