### PR TITLE
fix(desktop): Windows onboarding stuck on Node.js check

### DIFF
--- a/packages/desktop-host/src/cli-resolver.test.ts
+++ b/packages/desktop-host/src/cli-resolver.test.ts
@@ -3,7 +3,12 @@ import { mkdtempSync, writeFileSync, mkdirSync, chmodSync, realpathSync } from '
 import path from 'node:path';
 import os from 'node:os';
 
-import { resolveMoxxyCli } from './cli-resolver';
+import {
+  resolveMoxxyCli,
+  executableCandidates,
+  augmentedPaths,
+  findExecutable,
+} from './cli-resolver';
 
 let tmp: string;
 const originalEnv = { ...process.env };
@@ -113,5 +118,60 @@ describe('vi sanity', () => {
     process.env.PATH = '/foo';
     expect(process.env.PATH).toBe('/foo');
     vi.restoreAllMocks();
+  });
+});
+
+describe('executableCandidates (Windows .exe / PATHEXT resolution)', () => {
+  it('returns just the bare name off Windows', () => {
+    expect(executableCandidates('node', 'linux')).toEqual(['node']);
+    expect(executableCandidates('node', 'darwin')).toEqual(['node']);
+  });
+
+  it('expands to PATHEXT variants on Windows (so node → node.exe, npm → npm.cmd)', () => {
+    const got = executableCandidates('node', 'win32', '.COM;.EXE;.BAT;.CMD');
+    expect(got).toEqual(['node', 'node.com', 'node.exe', 'node.bat', 'node.cmd']);
+    expect(executableCandidates('npm', 'win32', '.EXE;.CMD')).toContain('npm.cmd');
+  });
+
+  it('falls back to a default PATHEXT when the env var is absent', () => {
+    expect(executableCandidates('node', 'win32', undefined)).toContain('node.exe');
+  });
+
+  it('uses an already-extensioned name verbatim', () => {
+    expect(executableCandidates('node.exe', 'win32')).toEqual(['node.exe']);
+  });
+});
+
+describe('augmentedPaths', () => {
+  it('includes the standard Windows Node install dirs (stale-PATH re-check)', () => {
+    process.env['ProgramFiles'] = 'C:\\Program Files';
+    process.env.LOCALAPPDATA = 'C:\\Users\\me\\AppData\\Local';
+    const paths = augmentedPaths('win32');
+    expect(paths).toContain(path.join('C:\\Program Files', 'nodejs'));
+    expect(paths).toContain(path.join('C:\\Users\\me\\AppData\\Local', 'Programs', 'nodejs'));
+  });
+
+  it('includes the homebrew/usr-local dirs on macOS', () => {
+    expect(augmentedPaths('darwin')).toEqual(expect.arrayContaining(['/opt/homebrew/bin']));
+  });
+
+  it('adds no platform dirs on linux', () => {
+    delete process.env.HOME;
+    expect(augmentedPaths('linux')).toEqual([]);
+  });
+});
+
+describe('findExecutable', () => {
+  it('finds a bare-name binary in an extra dir (POSIX)', () => {
+    if (process.platform === 'win32') return; // bare name only resolves off Windows
+    const bin = path.join(tmp, 'mybin');
+    writeFileSync(bin, '#!/bin/sh\necho v1');
+    chmodSync(bin, 0o755);
+    const found = findExecutable('mybin', [tmp]);
+    expect(found && path.basename(found)).toBe('mybin');
+  });
+
+  it('returns null when the binary is absent', () => {
+    expect(findExecutable('definitely-not-here', [tmp])).toBeNull();
   });
 });

--- a/packages/desktop-host/src/cli-resolver.ts
+++ b/packages/desktop-host/src/cli-resolver.ts
@@ -67,15 +67,31 @@ export function resolveMoxxyCli(opts: ResolveOptions = {}): CliInvocation | null
 }
 
 /**
- * Directories where a working `moxxy` install commonly lives that
- * are not always on a GUI-launch PATH. The supervisor passes these
- * as `extraPaths` so a user with moxxy in nvm + a desktop launched
- * from Finder still resolves it.
+ * Directories where a working `moxxy` / `node` / `npm` commonly lives that
+ * are not always on a GUI-launch PATH. The supervisor + onboarding probe pass
+ * these as `extraPaths` so a user with moxxy in nvm + a desktop launched from
+ * Finder still resolves it — and, critically on Windows, so a Node installed
+ * AFTER the desktop launched is found on the next "re-check" even though the
+ * running process's PATH never picked up the installer's SYSTEM-PATH edit.
  */
-export function augmentedPaths(): string[] {
+export function augmentedPaths(platform: NodeJS.Platform = process.platform): string[] {
   const out: string[] = [];
-  if (process.platform === 'darwin') {
+  if (platform === 'darwin') {
     out.push('/usr/local/bin', '/opt/homebrew/bin');
+  } else if (platform === 'win32') {
+    // The official Node installer drops node.exe / npm.cmd in <ProgramFiles>\nodejs
+    // and edits the SYSTEM PATH — which a process started before the install
+    // never sees. Consult the standard install dirs directly so the onboarding
+    // "Install Node → re-check" loop clears without an app restart.
+    for (const key of ['ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432']) {
+      const base = process.env[key];
+      if (base) out.push(path.join(base, 'nodejs'));
+    }
+    const localAppData = process.env.LOCALAPPDATA;
+    if (localAppData) out.push(path.join(localAppData, 'Programs', 'nodejs'));
+    // nvm-windows keeps the active version behind this "current" symlink.
+    const nvmSymlink = process.env.NVM_SYMLINK;
+    if (nvmSymlink) out.push(nvmSymlink);
   }
   const home = process.env.HOME;
   if (home) {
@@ -163,15 +179,40 @@ function isReadableFile(p: string): boolean {
 }
 
 /**
+ * Filenames to try for executable `name` on `platform`. On Windows an
+ * executable carries an extension (`node.exe`, `npm.cmd`), so a bare `node`
+ * NEVER resolves — expand to the PATHEXT variants. Elsewhere the bare name IS
+ * the executable. If `name` already has an extension it's used verbatim.
+ */
+export function executableCandidates(
+  name: string,
+  platform: NodeJS.Platform = process.platform,
+  pathext: string | undefined = process.env.PATHEXT,
+): string[] {
+  if (platform !== 'win32' || path.extname(name)) return [name];
+  const exts = (pathext ?? '.COM;.EXE;.BAT;.CMD')
+    .split(';')
+    .map((e) => e.trim())
+    .filter(Boolean)
+    .map((e) => (e.startsWith('.') ? e : `.${e}`).toLowerCase());
+  // Bare name first (a few tools ship extensionless), then the PATHEXT variants.
+  return [name, ...exts.map((e) => name + e)];
+}
+
+/**
  * First `name` found in PATH (plus `extra` dirs), or null. Used both to resolve
- * `moxxy` and — by the installer — to locate `node`/`npm` on a GUI-launch PATH.
+ * `moxxy` and — by the installer/onboarding probe — to locate `node`/`npm` on a
+ * GUI-launch PATH. Tries the platform's executable extensions (Windows).
  */
 export function findExecutable(name: string, extra: ReadonlyArray<string>): string | null {
   const pathEnv = process.env.PATH ?? '';
   const dirs = pathEnv.split(delimiter).concat(extra).filter(Boolean);
+  const candidates = executableCandidates(name);
   for (const dir of dirs) {
-    const candidate = path.join(dir, name);
-    if (isReadableFile(candidate)) return candidate;
+    for (const candidate of candidates) {
+      const full = path.join(dir, candidate);
+      if (isReadableFile(full)) return full;
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Symptom
On **Windows**, the onboarding wizard is stuck on the **Node.js check**. The user didn't have Node, followed the guide, installed it, clicked **re-check** — still reported as not installed.

## Root cause
`probeNode` could **never** detect Node on Windows:

1. **Wrong filename.** `findExecutable('node', …)` did `path.join(dir, 'node')` and stat'd it — but the Windows binary is **`node.exe`**, so it always returned null. (Same for `npm` → `npm.cmd`.)
2. **Stale PATH on re-check.** `augmentedPaths()` had no Windows entries. The official Node installer writes `C:\Program Files\nodejs` to the **SYSTEM** PATH, but a process started *before* the install never sees that edit — so even after installing, "re-check" couldn't find Node via the running app's PATH.

(The follow-on `cli` step is satisfied by the bundled CLI via `MOXXY_CLI_ENTRY`, so npm isn't actually needed — the node check was the only blocker.)

## Fix
- **`findExecutable`** now tries the platform's executable extensions via `PATHEXT` (`node.exe`, `npm.cmd`, …) through a new pure `executableCandidates()` helper.
- **`augmentedPaths`** adds the standard Windows Node install dirs — `<ProgramFiles>\nodejs`, `<ProgramFiles(x86)>\nodejs`, `<ProgramW6432>\nodejs`, `%LOCALAPPDATA%\Programs\nodejs`, and the nvm-windows `NVM_SYMLINK` — so **"Install Node → re-check" clears without restarting the app**, despite the stale process PATH.

## Verification
- `pnpm build` / `typecheck` / lint clean; desktop-host **110** tests pass (**+9**: `executableCandidates` PATHEXT expansion, Windows `augmentedPaths`, `findExecutable`).
- Couldn't exercise a real Windows box here — the new tests assert the platform logic by passing the platform/PATHEXT explicitly (no global stubbing).

Note: versioning is handled separately (the open 0.0.7 bump PR). This fix is logic-only.