### PR TITLE
ci(release): open a desktop release PR instead of pushing to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,12 @@ name: Release
 # `desktop-v<version>` tag and dispatches release-desktop.yml. See that step
 # for why it dispatches rather than relying on the tag-push trigger.
 #
-# The desktop also AUTO-BUMPS: when desktop-relevant code (apps/desktop +
-# desktop-host / desktop-ipc-contract / desktop-ui / chat-model) changes after
-# its last release, the "Auto-bump desktop on source change" step increments the
-# patch version and commits it, so merging a desktop PR ships a release with no
+# The desktop also auto-proposes releases: when desktop-relevant code
+# (apps/desktop + desktop-host / desktop-ipc-contract / desktop-ui / chat-model)
+# changes after its last release, the "Open desktop release PR" step opens (and
+# keeps updating) a one-line `auto/desktop-release` PR that bumps the patch
+# version. Merging that PR lands the bump on main, and the cut step above ships
+# the release — so cutting a desktop release is a one-click merge, never a
 # hand-edited version. It defers to explicit/changeset-driven bumps.
 #
 # Mode 2 runs through `scripts/safe-publish.mjs` rather than the default
@@ -106,60 +108,6 @@ jobs:
       # also makes release-desktop's `startsWith(github.ref, 'refs/tags/
       # desktop-v')` gate pass — so the GitHub Release publishes exactly as a
       # manual `git push origin desktop-v*` would.
-      # Auto-bump the desktop on a source change so a release happens without a
-      # hand-edited version. When the CURRENT desktop version is already
-      # released (its `desktop-v<version>` tag exists) and any desktop-relevant
-      # path has changed since that tag, bump the patch version and commit it to
-      # main — the "Cut desktop release" step below then tags + dispatches.
-      #
-      # Defers to explicit bumps: a version that is NOT yet tagged is a pending
-      # release (a manual bump, or a changeset-driven one) and is left for the
-      # cut step. A pending changeset that already targets @moxxy/desktop is also
-      # honored (we skip, so changesets owns the bump). So this never
-      # double-bumps. The bump commit is pushed with GITHUB_TOKEN, which by
-      # design does NOT re-trigger this workflow — so we tag + dispatch in THIS
-      # same run (the cut step) rather than waiting for a re-run.
-      - name: Auto-bump desktop on source change
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          version="$(node -p "require('./apps/desktop/package.json').version")"
-          tag="desktop-v$version"
-
-          # A pending changeset for the desktop will bump it via the Version PR —
-          # don't race it.
-          if ls .changeset/*.md >/dev/null 2>&1 && \
-             grep -lE '"@moxxy/desktop"\s*:' .changeset/*.md >/dev/null 2>&1; then
-            echo "A pending changeset targets @moxxy/desktop — letting changesets drive the bump."
-            exit 0
-          fi
-
-          # Fetch the current version's release tag; its absence means this
-          # version hasn't shipped yet (pending) — leave it for the cut step.
-          if ! git fetch --quiet origin "refs/tags/$tag:refs/tags/$tag" 2>/dev/null; then
-            echo "$version is not yet released ($tag missing) — pending; cut step will handle it."
-            exit 0
-          fi
-
-          # Has any desktop-relevant code changed since that release?
-          paths="apps/desktop packages/desktop-host packages/desktop-ipc-contract packages/desktop-ui packages/chat-model"
-          if git diff --quiet "$tag" HEAD -- $paths; then
-            echo "No desktop changes since $tag — nothing to release."
-            exit 0
-          fi
-
-          # Bump the patch version (formatting-preserving: only the version
-          # string is rewritten) and commit it back to main.
-          new="$(node -e "const v=require('./apps/desktop/package.json').version.split('.').map(Number); v[2]+=1; console.log(v.join('.'))")"
-          echo "Desktop changed since $tag — bumping $version → $new and releasing."
-          node -e "const fs=require('fs'),f='apps/desktop/package.json';let s=fs.readFileSync(f,'utf8');s=s.replace(/\"version\":\s*\"[^\"]+\"/, '\"version\": \"$new\"');fs.writeFileSync(f,s)"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add apps/desktop/package.json
-          git commit -m "chore(desktop): auto-bump to $new"
-          git push origin HEAD:main
-
       - name: Cut desktop release on version bump
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -175,3 +123,67 @@ jobs:
           git tag "$tag"
           git push origin "$tag"
           gh workflow run release-desktop.yml --ref "$tag"
+
+      # Auto-OPEN A PR that bumps the desktop when its code changed since the
+      # last release — so a release needs only a one-click merge, never a
+      # hand-edited version. Runs AFTER the cut step so the cut step reads the
+      # committed (released) version, not the bump we stage here.
+      #
+      # Acts only when the current version is already released (tag exists) and a
+      # desktop-relevant path changed since that tag. Defers to in-flight bumps:
+      # an untagged version (pending manual/changeset bump → the cut step ships
+      # it) and a pending changeset already targeting @moxxy/desktop are both
+      # skipped, so it never competes. Merging the opened PR lands the bump on
+      # main, and the cut step above releases it on that run.
+      - name: Stage desktop bump on source change
+        id: deskbump
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./apps/desktop/package.json').version")"
+          tag="desktop-v$version"
+
+          if ls .changeset/*.md >/dev/null 2>&1 && \
+             grep -lE '"@moxxy/desktop"\s*:' .changeset/*.md >/dev/null 2>&1; then
+            echo "A pending changeset targets @moxxy/desktop — letting changesets drive the bump."
+            echo "bump=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if ! git fetch --quiet origin "refs/tags/$tag:refs/tags/$tag" 2>/dev/null; then
+            echo "$version is not yet released ($tag missing) — pending; cut step will handle it."
+            echo "bump=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          paths="apps/desktop packages/desktop-host packages/desktop-ipc-contract packages/desktop-ui packages/chat-model"
+          if git diff --quiet "$tag" HEAD -- $paths; then
+            echo "No desktop changes since $tag — nothing to release."
+            echo "bump=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+
+          new="$(node -e "const v=require('./apps/desktop/package.json').version.split('.').map(Number); v[2]+=1; console.log(v.join('.'))")"
+          echo "Desktop changed since $tag — staging bump $version → $new for a release PR."
+          # Formatting-preserving: only the version string is rewritten.
+          node -e "const fs=require('fs'),f='apps/desktop/package.json';let s=fs.readFileSync(f,'utf8');s=s.replace(/\"version\":\s*\"[^\"]+\"/, '\"version\": \"$new\"');fs.writeFileSync(f,s)"
+          echo "new=$new" >> "$GITHUB_OUTPUT"
+          echo "bump=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open desktop release PR
+        if: steps.deskbump.outputs.bump == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: auto/desktop-release
+          base: main
+          add-paths: apps/desktop/package.json
+          commit-message: "chore(desktop): release v${{ steps.deskbump.outputs.new }}"
+          title: "chore(desktop): release v${{ steps.deskbump.outputs.new }}"
+          body: |
+            Automated desktop release bump — desktop-relevant code changed since
+            the last release (`apps/desktop` + desktop-host / desktop-ipc-contract
+            / desktop-ui / chat-model).
+
+            Merging this bumps `@moxxy/desktop` to
+            **${{ steps.deskbump.outputs.new }}**; the release workflow then tags
+            `desktop-v${{ steps.deskbump.outputs.new }}` and builds + publishes the
+            installers (and the self-update bundle).
+
+            This PR auto-updates as more desktop changes land — just merge when
+            you want to cut the release.
+          delete-branch: true


### PR DESCRIPTION
## Why
The auto-bump from #62 pushed the version bump **directly to `main`** and branch protection rejected it:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
! [remote rejected] HEAD -> main (protected branch hook declined)
```

So no `0.0.8` release happened. This replaces the direct push with a **PR**, which works **within** branch protection — no override / weakening of `main` needed. It's the same pattern as the changesets "Version Packages" PR your repo already uses.

## What changed
- **Removed** the `git push origin HEAD:main` auto-bump step.
- **Added** (after the existing cut step): *Stage desktop bump on source change* → *Open desktop release PR* (`peter-evans/create-pull-request`). When desktop-relevant code changed since the last release, it opens/updates a one-line **`auto/desktop-release`** PR bumping the patch version.

## Flow now
1. You merge a desktop PR → release.yml opens/updates `auto/desktop-release` (bump 0.0.7 → 0.0.8).
2. You merge `auto/desktop-release` → the existing **Cut desktop release** step tags `desktop-v0.0.8` + builds/publishes.

So it's a **one-click merge** to cut a release — never a hand-edited version. The PR auto-updates as more desktop changes land. Same guards as before (skips an untagged/pending version, and a pending `@moxxy/desktop` changeset). Ordered after the cut step so the cut step reads the committed version, not the staged bump.

## After merging this
The pending `0.0.7 → 0.0.8` bump (the one that failed to push) will be re-proposed as an `auto/desktop-release` PR on the next release.yml run — merge it to ship 0.0.8.

## If you ever want zero clicks
Either allow the `github-actions` bot to bypass branch protection on `main`, or enable auto-merge on the `auto/desktop-release` PR. The PR approach (one merge) is the safer default.