### PR TITLE
fix(desktop): self-update always 'up to date' — discover desktop release via GitHub API

### DIFF
--- a/apps/desktop/src/settings/DashboardUpdateSection.tsx
+++ b/apps/desktop/src/settings/DashboardUpdateSection.tsx
@@ -45,6 +45,9 @@ export function DashboardUpdateSection(): JSX.Element {
       ? Math.min(100, Math.round((progress.received / progress.total) * 100))
       : null;
   const status = statusLine(state, check?.latestVersion ?? null);
+  // Surface a failed check (404 / offline / bad signature) — previously these
+  // were swallowed and shown as "up to date".
+  const shownError = error ?? check?.error ?? null;
 
   return (
     <Section
@@ -102,9 +105,9 @@ export function DashboardUpdateSection(): JSX.Element {
           </div>
         )}
 
-        {error && (
+        {shownError && (
           <p role="alert" style={{ margin: 0, fontSize: 12.5, color: 'var(--color-red)', lineHeight: 1.5 }}>
-            {error}
+            {shownError}
           </p>
         )}
 

--- a/packages/desktop-host/src/app-update/roundtrip.test.ts
+++ b/packages/desktop-host/src/app-update/roundtrip.test.ts
@@ -54,7 +54,7 @@ describe('build → stage → resolve round-trip', () => {
 
     // check: a newer, compatible bundle is offered
     const check = await checkForUpdate(
-      { manifestUrl: MANIFEST_URL, currentVersion: '0.0.5', publicKeyPem: PUBKEY, shell: SHELL },
+      { repo: 'moxxy-ai/moxxy', manifestUrlOverride: MANIFEST_URL, currentVersion: '0.0.5', publicKeyPem: PUBKEY, shell: SHELL },
       { fetchImpl },
     );
     expect(check.available).toBe(true);
@@ -123,7 +123,7 @@ describe('build → stage → resolve round-trip', () => {
       files: FILES,
     });
     const check = await checkForUpdate(
-      { manifestUrl: MANIFEST_URL, currentVersion: '0.0.5', publicKeyPem: PUBKEY, shell: SHELL },
+      { repo: 'moxxy-ai/moxxy', manifestUrlOverride: MANIFEST_URL, currentVersion: '0.0.5', publicKeyPem: PUBKEY, shell: SHELL },
       { fetchImpl: stubFetch(manifestJson, bundleGz) },
     );
     expect(check.available).toBe(true);

--- a/packages/desktop-host/src/app-update/stager.test.ts
+++ b/packages/desktop-host/src/app-update/stager.test.ts
@@ -19,11 +19,11 @@ beforeEach(() => {
 });
 
 describe('isAllowedUpdateHost', () => {
-  it('allows GitHub + its release-asset CDN over https only', () => {
-    expect(isAllowedUpdateHost('https://github.com/o/r/releases/latest/download/m.json')).toBe(true);
+  it('allows GitHub (api/web) + its release-asset CDN over https only', () => {
+    expect(isAllowedUpdateHost('https://github.com/o/r/releases/download/desktop-v1/m.json')).toBe(true);
+    expect(isAllowedUpdateHost('https://api.github.com/repos/o/r/releases')).toBe(true);
     expect(isAllowedUpdateHost('https://objects.githubusercontent.com/x')).toBe(true);
     expect(isAllowedUpdateHost('https://release-assets.githubusercontent.com/x')).toBe(true);
-    expect(isAllowedUpdateHost('https://codeload.github.com/x')).toBe(true);
   });
 
   it('rejects other hosts, http, and junk', () => {
@@ -34,19 +34,63 @@ describe('isAllowedUpdateHost', () => {
   });
 });
 
-describe('checkForUpdate guards', () => {
-  it('returns "no update" without ever fetching a non-allowlisted manifest URL', async () => {
-    let fetched = false;
-    const fetchImpl = (async () => {
-      fetched = true;
-      return new Response('{}');
-    }) as unknown as typeof fetch;
+describe('checkForUpdate', () => {
+  it('reports an error (not silent "up to date") when the release API is unreachable', async () => {
+    const fetchImpl = (async () => new Response('nope', { status: 500 })) as unknown as typeof fetch;
     const res = await checkForUpdate(
-      { manifestUrl: 'https://evil.test/m.json', currentVersion: '0.0.5', publicKeyPem: PUBKEY, shell: SHELL },
+      { repo: 'moxxy-ai/moxxy', currentVersion: '0.0.5', publicKeyPem: PUBKEY, shell: SHELL },
       { fetchImpl },
     );
     expect(res.available).toBe(false);
-    expect(fetched).toBe(false);
+    expect(res.error).toBeTruthy(); // a real failure, surfaced — not masked as up-to-date
+  });
+
+  it('discovers the newest desktop-v* release via the API and offers its manifest', async () => {
+    const { manifest, manifestJson, bundleGz } = buildAppBundle({
+      version: '0.0.9',
+      minElectron: '33.0.0',
+      nodeAbi: '',
+      bundleUrl: 'https://github.com/moxxy-ai/moxxy/releases/download/desktop-v0.0.9/moxxy-app-bundle-0.0.9.json.gz',
+      privateKeyPem: PRIVKEY,
+      files: { 'dist/index.html': Buffer.from('x') },
+    });
+    const manifestAssetUrl =
+      'https://github.com/moxxy-ai/moxxy/releases/download/desktop-v0.0.9/moxxy-app-manifest.json';
+    const releasesJson = JSON.stringify([
+      // an unrelated, newer npm-package release (the one that breaks releases/latest)
+      { tag_name: '@moxxy/cli@9.9.9', draft: false, prerelease: false, assets: [] },
+      {
+        tag_name: 'desktop-v0.0.8',
+        draft: false,
+        prerelease: false,
+        assets: [{ name: 'moxxy-app-manifest.json', browser_download_url: 'https://github.com/x/old' }],
+      },
+      {
+        tag_name: 'desktop-v0.0.9',
+        draft: false,
+        prerelease: false,
+        assets: [
+          { name: 'moxxy-app-manifest.json', browser_download_url: manifestAssetUrl },
+          { name: 'moxxy-app-bundle-0.0.9.json.gz', browser_download_url: manifest.bundleUrl },
+        ],
+      },
+    ]);
+    const fetchImpl = (async (url: string | URL): Promise<Response> => {
+      const u = String(url);
+      if (u.startsWith('https://api.github.com/')) return new Response(releasesJson);
+      if (u === manifestAssetUrl) return new Response(manifestJson);
+      if (u === manifest.bundleUrl) return new Response(new Uint8Array(bundleGz));
+      return new Response('not found', { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const res = await checkForUpdate(
+      { repo: 'moxxy-ai/moxxy', currentVersion: '0.0.7', publicKeyPem: PUBKEY, shell: SHELL },
+      { fetchImpl },
+    );
+    expect(res.available).toBe(true);
+    expect(res.latestVersion).toBe('0.0.9'); // highest desktop-v*, not the cli release
+    expect(res.bundleUrl).toBe(manifest.bundleUrl);
+    expect(res.error).toBeUndefined();
   });
 });
 

--- a/packages/desktop-host/src/app-update/stager.ts
+++ b/packages/desktop-host/src/app-update/stager.ts
@@ -31,10 +31,10 @@ import {
   setActiveVersion,
 } from './resolve.js';
 
-/** Only these hosts (and subdomains) are ever fetched — GitHub + its release
- *  asset CDN. The manifest's `bundleUrl` is signed, so it can't be repointed,
- *  but we host-check it anyway as defense in depth. */
-const ALLOWED_HOSTS = [/^github\.com$/, /(^|\.)githubusercontent\.com$/, /^codeload\.github\.com$/];
+/** Only these hosts (and subdomains) are ever fetched — GitHub's API, web, and
+ *  release-asset CDN. `(^|\.)github\.com$` covers both `github.com` and
+ *  `api.github.com` (the releases API) without admitting `…github.com.evil`. */
+const ALLOWED_HOSTS = [/(^|\.)github\.com$/, /(^|\.)githubusercontent\.com$/];
 
 export function isAllowedUpdateHost(url: string): boolean {
   try {
@@ -57,41 +57,143 @@ export interface CheckResult {
   /** The running shell satisfies the bundle (false ⇒ a shell/Tier-2 update is needed). */
   compatible: boolean;
   manifest: AppManifest | null;
+  /** Where to download the bundle — the discovered release asset URL (preferred
+   *  over the manifest's signed `bundleUrl`, which integrity-binds via sha256). */
+  bundleUrl?: string;
   notes?: string;
   releaseUrl?: string;
+  /** Set when the check itself FAILED (offline, 404, bad signature, …) — distinct
+   *  from a successful "you're up to date" (available:false, no error). Without
+   *  this every failure masquerades as up-to-date. */
+  error?: string;
+}
+
+/** The newest published `desktop-v*` release + the asset URLs the updater needs. */
+interface DesktopRelease {
+  version: string;
+  manifestUrl: string;
+  bundleUrl?: string;
+}
+
+const DESKTOP_TAG_PREFIX = 'desktop-v';
+
+/**
+ * Find the newest published `desktop-v*` release via the GitHub Releases API and
+ * return its manifest + bundle asset URLs.
+ *
+ * Why the API and not `releases/latest/download/…`: GitHub's "latest release" is
+ * the most recent published release of the WHOLE repo — in a monorepo that also
+ * cuts `@moxxy/cli@x` npm releases, that's usually NOT the desktop, so the fixed
+ * `releases/latest/...` URL 404s. We instead pick the highest `desktop-v*` tag.
+ */
+async function resolveDesktopRelease(
+  repo: string,
+  fetchImpl: typeof fetch,
+): Promise<DesktopRelease | null> {
+  const api = `https://api.github.com/repos/${repo}/releases?per_page=30`;
+  if (!isAllowedUpdateHost(api)) return null;
+  let releases: unknown;
+  try {
+    const res = await fetchImpl(api, {
+      redirect: 'follow',
+      // GitHub's API rejects requests without a User-Agent.
+      headers: { accept: 'application/vnd.github+json', 'user-agent': 'moxxy-desktop' },
+    });
+    if (!res.ok) return null;
+    releases = await res.json();
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(releases)) return null;
+
+  const candidates = releases
+    .filter(
+      (r): r is { tag_name: string; assets: unknown } =>
+        !!r &&
+        typeof (r as { tag_name?: unknown }).tag_name === 'string' &&
+        !(r as { draft?: unknown }).draft &&
+        !(r as { prerelease?: unknown }).prerelease &&
+        (r as { tag_name: string }).tag_name.startsWith(DESKTOP_TAG_PREFIX),
+    )
+    .map((r) => ({
+      version: r.tag_name.slice(DESKTOP_TAG_PREFIX.length),
+      assets: Array.isArray(r.assets) ? (r.assets as Array<{ name?: unknown; browser_download_url?: unknown }>) : [],
+    }))
+    .filter((r) => isSafeVersion(r.version))
+    .sort((a, b) => compareSemver(a.version, b.version));
+
+  const latest = candidates[candidates.length - 1];
+  if (!latest) return null;
+
+  const assetUrl = (name: string): string | undefined => {
+    const a = latest.assets.find((x) => x && x.name === name && typeof x.browser_download_url === 'string');
+    return a?.browser_download_url as string | undefined;
+  };
+  const manifestUrl = assetUrl('moxxy-app-manifest.json');
+  if (!manifestUrl || !isAllowedUpdateHost(manifestUrl)) return null;
+
+  const out: DesktopRelease = { version: latest.version, manifestUrl };
+  const bundleUrl = assetUrl(`moxxy-app-bundle-${latest.version}.json.gz`);
+  if (bundleUrl && isAllowedUpdateHost(bundleUrl)) out.bundleUrl = bundleUrl;
+  return out;
 }
 
 /**
- * Fetch + verify the published manifest and compare it to the running version.
- * Never throws on a "no update" outcome (offline, 404, bad signature, same
- * version) — those return `available: false` so the UI stays quiet.
+ * Discover the latest desktop release, fetch + verify its manifest, and compare
+ * to the running version. Returns `available:false` for a genuine no-update, and
+ * `available:false` WITH an `error` when the check itself failed — so a 404 /
+ * offline / bad-signature can no longer masquerade as "up to date".
+ *
+ * `manifestUrlOverride` (dev/test only — the IPC handler passes it only when the
+ * app is NOT packaged) fetches a manifest directly and skips API discovery.
  */
 export async function checkForUpdate(
   opts: {
-    manifestUrl: string;
+    repo: string;
     currentVersion: string;
     publicKeyPem: string;
     shell: ShellInfo;
+    manifestUrlOverride?: string;
   },
   deps: StagerDeps = {},
 ): Promise<CheckResult> {
-  const none: CheckResult = { available: false, latestVersion: null, compatible: false, manifest: null };
-  const { manifestUrl, currentVersion, publicKeyPem, shell } = opts;
-  if (!publicKeyPem || !isAllowedUpdateHost(manifestUrl)) return none;
+  const none = (error?: string): CheckResult => ({
+    available: false,
+    latestVersion: null,
+    compatible: false,
+    manifest: null,
+    ...(error ? { error } : {}),
+  });
+  const { repo, currentVersion, publicKeyPem, shell, manifestUrlOverride } = opts;
+  if (!publicKeyPem) return none('Automatic updates are not configured for this build.');
 
   const fetchImpl = deps.fetchImpl ?? fetch;
+
+  let manifestUrl: string;
+  let bundleUrl: string | undefined;
+  if (manifestUrlOverride) {
+    manifestUrl = manifestUrlOverride; // dev override — not host-pinned
+  } else {
+    const release = await resolveDesktopRelease(repo, fetchImpl);
+    if (!release) return none('Could not find a published desktop release to update from.');
+    manifestUrl = release.manifestUrl;
+    bundleUrl = release.bundleUrl;
+  }
+
   let text: string;
   try {
     const res = await fetchImpl(manifestUrl, { redirect: 'follow' });
-    if (!res.ok) return none;
+    if (!res.ok) return none(`Update manifest not reachable (HTTP ${res.status}).`);
     text = await res.text();
   } catch {
-    return none;
+    return none('Could not reach the update server.');
   }
 
   const manifest = parseManifest(text);
-  if (!manifest) return none;
-  if (!verifyManifestSignature(manifest, publicKeyPem)) return none;
+  if (!manifest) return none('The update manifest was malformed.');
+  if (!verifyManifestSignature(manifest, publicKeyPem)) {
+    return none('The update manifest failed signature verification.');
+  }
 
   const newer = compareSemver(manifest.version, currentVersion) > 0;
   const result: CheckResult = {
@@ -99,6 +201,8 @@ export async function checkForUpdate(
     latestVersion: manifest.version,
     compatible: isCompatible(manifest, shell),
     manifest: newer ? manifest : null,
+    // Prefer the discovered release asset URL; fall back to the (signed) one.
+    bundleUrl: bundleUrl ?? manifest.bundleUrl,
   };
   if (manifest.notes) result.notes = manifest.notes;
   if (manifest.releaseUrl) result.releaseUrl = manifest.releaseUrl;
@@ -137,12 +241,17 @@ export async function downloadAndStage(
     userDataDir: string;
     manifest: AppManifest;
     publicKeyPem: string;
+    /** Where to fetch the bundle (the discovered release asset URL). Defaults to
+     *  the manifest's signed `bundleUrl`. Integrity is bound by `sha256` either
+     *  way, so a stale/wrong signed `bundleUrl` doesn't compromise safety. */
+    bundleUrl?: string;
     onProgress?: (p: Progress) => void;
   },
   deps: StagerDeps = {},
 ): Promise<{ version: string }> {
   const { userDataDir, manifest, publicKeyPem, onProgress } = opts;
   const report = onProgress ?? (() => {});
+  const downloadUrl = opts.bundleUrl ?? manifest.bundleUrl;
 
   if (!verifyManifestSignature(manifest, publicKeyPem)) {
     throw new Error('update manifest failed signature verification');
@@ -150,14 +259,14 @@ export async function downloadAndStage(
   if (!isSafeVersion(manifest.version)) {
     throw new Error(`unsafe bundle version: ${manifest.version}`);
   }
-  if (!isAllowedUpdateHost(manifest.bundleUrl)) {
+  if (!isAllowedUpdateHost(downloadUrl)) {
     throw new Error('update bundle is not hosted on an allowed origin');
   }
 
   // 1. Download the gzipped bundle, streaming progress.
   report({ phase: 'download', message: 'Downloading…' });
   const fetchImpl = deps.fetchImpl ?? fetch;
-  const res = await fetchImpl(manifest.bundleUrl, { redirect: 'follow' });
+  const res = await fetchImpl(downloadUrl, { redirect: 'follow' });
   if (!res.ok) throw new Error(`bundle download failed (HTTP ${res.status})`);
   const total = Number(res.headers.get('content-length')) || undefined;
   const gz = await readAll(res, total, (received) => report({ phase: 'download', received, total }));

--- a/packages/desktop-host/src/ipc/update.ts
+++ b/packages/desktop-host/src/ipc/update.ts
@@ -31,8 +31,8 @@ export interface UpdateConfig {
   manifestUrl?: string;
 }
 
-const DEFAULT_MANIFEST_URL =
-  'https://github.com/moxxy-ai/moxxy/releases/latest/download/moxxy-app-manifest.json';
+/** The GitHub repo whose `desktop-v*` releases the updater pulls from. */
+const GH_REPO = 'moxxy-ai/moxxy';
 
 function runningVersion(): string {
   return process.env.MOXXY_APP_BUNDLE_VERSION ?? app.getVersion();
@@ -48,10 +48,13 @@ function messageOf(e: unknown): string {
 
 export function registerUpdateHandlers(config: UpdateConfig): void {
   const { publicKeyPem } = config;
-  // The manifest URL only ever differs from the default in dev/test (never in a
-  // packaged build) so a shipped app can't be pointed at an attacker origin.
-  const manifestUrl = app.isPackaged ? DEFAULT_MANIFEST_URL : config.manifestUrl ?? DEFAULT_MANIFEST_URL;
+  // A manifest-URL override is honored ONLY in dev/test (never in a packaged
+  // build) so a shipped app can't be pointed at an attacker origin; in prod the
+  // updater discovers the latest desktop release from GH_REPO's API.
+  const manifestUrlOverride = app.isPackaged ? undefined : config.manifestUrl;
   const enabled = (): boolean => !!publicKeyPem && app.isPackaged;
+  const check = (currentVersion: string): ReturnType<typeof checkForUpdate> =>
+    checkForUpdate({ repo: GH_REPO, currentVersion, publicKeyPem, shell: shellInfo(), manifestUrlOverride });
 
   handle('app.updateInfo', async () => ({
     version: runningVersion(),
@@ -72,12 +75,7 @@ export function registerUpdateHandlers(config: UpdateConfig): void {
           : 'Updates run only in the packaged app.',
       };
     }
-    const res = await checkForUpdate({
-      manifestUrl,
-      currentVersion,
-      publicKeyPem,
-      shell: shellInfo(),
-    });
+    const res = await check(currentVersion);
     return {
       available: res.available,
       currentVersion,
@@ -85,6 +83,7 @@ export function registerUpdateHandlers(config: UpdateConfig): void {
       compatible: res.compatible,
       ...(res.notes ? { notes: res.notes } : {}),
       ...(res.releaseUrl ? { releaseUrl: res.releaseUrl } : {}),
+      ...(res.error ? { error: res.error } : {}),
     };
   });
 
@@ -95,14 +94,9 @@ export function registerUpdateHandlers(config: UpdateConfig): void {
     }
     const target = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0] ?? null;
 
-    const res = await checkForUpdate({
-      manifestUrl,
-      currentVersion,
-      publicKeyPem,
-      shell: shellInfo(),
-    });
+    const res = await check(currentVersion);
     if (!res.available || !res.manifest) {
-      return { ok: false, version: null, error: 'No update available.' };
+      return { ok: false, version: null, error: res.error ?? 'No update available.' };
     }
     if (!res.compatible) {
       return {
@@ -117,6 +111,7 @@ export function registerUpdateHandlers(config: UpdateConfig): void {
         userDataDir: app.getPath('userData'),
         manifest: res.manifest,
         publicKeyPem,
+        ...(res.bundleUrl ? { bundleUrl: res.bundleUrl } : {}),
         onProgress: (p) => {
           if (target) sendEvent(target, 'app.update.progress', p);
         },

--- a/scripts/build-app-bundle.mjs
+++ b/scripts/build-app-bundle.mjs
@@ -68,10 +68,16 @@ function main() {
     minElectron = `${ev.split('.')[0]}.0.0`;
   }
   const nodeAbi = process.env.MOXXY_BUNDLE_NODE_ABI ?? '';
+  // Per-TAG asset URLs (not `releases/latest/...`). In a monorepo that also cuts
+  // `@moxxy/cli@x` releases, GitHub's "latest release" is usually NOT the
+  // desktop, so `releases/latest/download/...` 404s. The desktop release is
+  // tagged `desktop-v<version>`; pin the asset URLs to it.
+  const tag = `desktop-v${version}`;
   const baseUrl =
     process.env.MOXXY_BUNDLE_BASE_URL ??
-    'https://github.com/moxxy-ai/moxxy/releases/latest/download';
-  const releaseUrl = process.env.MOXXY_RELEASE_URL ?? 'https://github.com/moxxy-ai/moxxy/releases/latest';
+    `https://github.com/moxxy-ai/moxxy/releases/download/${tag}`;
+  const releaseUrl =
+    process.env.MOXXY_RELEASE_URL ?? `https://github.com/moxxy-ai/moxxy/releases/tag/${tag}`;
   const bundleName = `moxxy-app-bundle-${version}.json.gz`;
   const bundleUrl = `${baseUrl}/${bundleName}`;
 


### PR DESCRIPTION
## Symptom
The in-app updater always says **"up to date"**, even when a newer desktop version is published.

## Root cause — three compounding bugs
1. **Wrong release.** The client fetched the manifest from `releases/latest/download/moxxy-app-manifest.json`. In this monorepo, GitHub's "latest release" is an **`@moxxy/cli@x` npm release**, not the desktop — so that URL **302s → 404**:
   ```
   releases/latest/download/... → @moxxy/cli@0.3.2 → 404
   ```
   The desktop manifest lives on the per-tag `desktop-v*` releases.
2. **The signed `bundleUrl` was also `releases/latest/...`** → it would 404 too, so even a found manifest couldn't download.
3. **All failures were swallowed as "up to date."** `checkForUpdate` returned `available: false` with no error for 404 / offline / bad-signature alike — indistinguishable from a genuine no-update.

(Signing itself was fine — the per-tag manifest's signature verifies against the baked key.)

## Fix
- **Discover the newest `desktop-v*` release via the GitHub Releases API** (`api.github.com/repos/…/releases`), pick the highest `desktop-v*` tag, and read the manifest from that release's asset — instead of the broken `releases/latest/...`.
- **Download the bundle from the discovered release asset URL** (per-tag), not the manifest's signed `bundleUrl`. `sha256` still binds integrity, so a stale/wrong signed `bundleUrl` is harmless — and this fixes the already-published 0.0.8 whose signed `bundleUrl` is wrong.
- **Surface real errors** — `checkForUpdate` now returns an `error` reason (404 / offline / bad signature), shown in About → Dashboard, instead of masquerading as "up to date".
- **Publisher** (`build-app-bundle.mjs`) now emits **per-tag** `bundleUrl` + `releaseUrl` so future manifests are correct.
- Host-pin now covers `api.github.com`.

## Verification
- Typecheck + lint clean; **111** desktop-host + **49** desktop tests (+2: API discovery picks the highest `desktop-v*` over an `@moxxy/cli@` release; failures surface an error).
- **Live API check** (built code, baked public key): a `0.0.7` client now reports
  ```
  available: true   latestVersion: 0.0.8   compatible: true   error: (none)
  bundleUrl: …/releases/download/desktop-v0.0.8/moxxy-app-bundle-0.0.8.json.gz
  ```

## Note
This ships in the **next** desktop build. Already-installed older builds use their old (broken) check code; this fix takes effect once a build containing it is installed — but from that point on, discovery is correct for all future releases.