### PR TITLE
fix(desktop): provider install fails on Windows (vault passphrase prompt)

### DIFF
--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -34,6 +34,7 @@ import {
   lockDownNavigation,
   isSafeExternalUrl,
   preferredCliEntry,
+  ensureDesktopVaultKey,
 } from '@moxxy/desktop-host';
 
 import { BUNDLED_UPDATE_PUBLIC_KEY } from './update-key.js';
@@ -473,6 +474,12 @@ app.whenReady().then(async () => {
         ? () => systemPreferences.askForMediaAccess('microphone')
         : undefined,
   });
+
+  // Seed a disk-backed vault key on a fresh setup so saving a provider key /
+  // `moxxy login` works without an interactive passphrase prompt the desktop
+  // can't answer — the first provider install otherwise fails on Windows (no OS
+  // keychain) with "vault: passphrase required but no interactive terminal".
+  ensureDesktopVaultKey();
 
   // Reap any orphan runners from a previous crashed desktop process
   // before we try to spawn new ones. Without this, the first workspace

--- a/packages/desktop-host/src/index.ts
+++ b/packages/desktop-host/src/index.ts
@@ -9,6 +9,7 @@ export { RunnerPool, UNBOUND_ID } from './runner-pool.js';
 export { bindWindow, registerIpcHandlers } from './ipc.js';
 export { type UpdateConfig } from './ipc/update.js';
 export { preferredCliEntry } from './cli-resolver.js';
+export { ensureDesktopVaultKey } from './vault-key.js';
 export { DeskStore } from './desks.js';
 export { sweepStaleSockets } from './sweep-sockets.js';
 export {

--- a/packages/desktop-host/src/vault-key.test.ts
+++ b/packages/desktop-host/src/vault-key.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { ensureDesktopVaultKey } from './vault-key';
+
+// moxxyPath resolves under ~/.moxxy via MOXXY_HOME / HOME; point it at a temp dir.
+let tmp: string;
+const orig = { ...process.env };
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(os.tmpdir(), 'vault-key-'));
+  process.env = { ...orig };
+  // moxxyHome honors MOXXY_HOME; set both for safety across resolutions.
+  process.env.MOXXY_HOME = path.join(tmp, '.moxxy');
+  process.env.HOME = tmp;
+  process.env.USERPROFILE = tmp;
+});
+
+afterEach(() => {
+  process.env = orig;
+});
+
+function keyPath(): string {
+  return path.join(process.env.MOXXY_HOME!, 'vault.key');
+}
+function vaultPath(): string {
+  return path.join(process.env.MOXXY_HOME!, 'vault.json');
+}
+
+describe('ensureDesktopVaultKey', () => {
+  it('seeds a 32-byte base64 master key (0600) on a fresh setup', () => {
+    expect(existsSync(keyPath())).toBe(false);
+    ensureDesktopVaultKey();
+    expect(existsSync(keyPath())).toBe(true);
+    const key = Buffer.from(readFileSync(keyPath(), 'utf8').trim(), 'base64');
+    expect(key.length).toBe(32);
+  });
+
+  it('does NOT overwrite an existing vault.key', () => {
+    mkdirSync(process.env.MOXXY_HOME!, { recursive: true });
+    writeFileSync(keyPath(), 'existing-key\n');
+    ensureDesktopVaultKey();
+    expect(readFileSync(keyPath(), 'utf8')).toBe('existing-key\n');
+  });
+
+  it('does NOT seed when a vault.json already exists (keyed by keychain/passphrase)', () => {
+    mkdirSync(process.env.MOXXY_HOME!, { recursive: true });
+    writeFileSync(vaultPath(), '{}');
+    ensureDesktopVaultKey();
+    expect(existsSync(keyPath())).toBe(false);
+  });
+
+  it('is idempotent — a second call leaves the first key intact', () => {
+    ensureDesktopVaultKey();
+    const first = readFileSync(keyPath(), 'utf8');
+    ensureDesktopVaultKey();
+    expect(readFileSync(keyPath(), 'utf8')).toBe(first);
+  });
+});

--- a/packages/desktop-host/src/vault-key.ts
+++ b/packages/desktop-host/src/vault-key.ts
@@ -1,0 +1,45 @@
+/**
+ * Seed a disk-backed vault master key on a FRESH setup so the desktop's vault
+ * works without an interactive passphrase prompt — which the desktop can never
+ * answer.
+ *
+ * The desktop saves provider secrets by piping them into `moxxy vault set` over
+ * a non-TTY pipe (and uses an in-process vault for transcription). The vault key
+ * source resolves in order: `MOXXY_VAULT_PASSPHRASE` → OS keychain
+ * (`@napi-rs/keyring`) → on-disk cached key (`~/.moxxy/vault.key`) → interactive
+ * passphrase prompt. On a fresh install with no keychain available — notably the
+ * packaged Windows app, where the native keyring module isn't present — the
+ * first three all miss and it hits the prompt, which throws
+ * "vault: passphrase required but no interactive terminal", so the very first
+ * provider-key save (and `moxxy login`) fails.
+ *
+ * Seeding the on-disk key (step 3) ahead of time skips the prompt. We only seed
+ * when NO vault exists yet (neither `vault.key` NOR `vault.json`): if the vault
+ * is already keyed by the keychain or a passphrase, a random key would mismatch
+ * and lock the user out. The seed is the same 32-byte AES-256 master key the
+ * passphrase path persists, written 0600 — identical protection to the existing
+ * disk-cache fallback, just without the prompt. If the keychain later becomes
+ * available the key source backfills it from this file.
+ */
+
+import { randomBytes } from 'node:crypto';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { moxxyPath } from '@moxxy/sdk';
+
+/** AES-256 master key length, matching the vault's `deriveKey` output. */
+const KEY_BYTES = 32;
+
+export function ensureDesktopVaultKey(): void {
+  const keyPath = moxxyPath('vault.key');
+  const vaultPath = moxxyPath('vault.json');
+  // Don't touch an existing vault — only seed a truly fresh setup.
+  if (existsSync(keyPath) || existsSync(vaultPath)) return;
+  try {
+    mkdirSync(path.dirname(keyPath), { recursive: true });
+    writeFileSync(keyPath, `${randomBytes(KEY_BYTES).toString('base64')}\n`, { mode: 0o600 });
+  } catch {
+    // Best effort — if we can't write, the vault falls back to its prompt
+    // behaviour (unchanged), so this never makes things worse.
+  }
+}


### PR DESCRIPTION
## Symptom
On Windows, installing a provider (saving an API key) fails with a **Moxxy vault passphrase** error.

## Root cause
The desktop saves the secret by piping it into `moxxy vault set` over a **non-TTY pipe**. The vault master key resolves in order:

`MOXXY_VAULT_PASSPHRASE` → OS keychain (`@napi-rs/keyring`) → on-disk key (`~/.moxxy/vault.key`) → **interactive passphrase prompt**

On a fresh **packaged Windows** install the keychain native module isn't available, there's no env passphrase, and no disk key exists yet — so it falls to the prompt, which throws:

```
vault: passphrase required but no interactive terminal.
```

(The desktop is a GUI — there's no terminal for the spawned CLI to prompt in.)

## Fix
Seed a random **32-byte AES-256 master key** to `~/.moxxy/vault.key` on a fresh setup, before any vault op, so the vault unlocks via the **disk-key** path with no prompt (`ensureDesktopVaultKey()`, called in the main's `whenReady`).

- Only seeds when **neither `vault.key` nor `vault.json` exists**, so an existing keychain/passphrase-keyed vault is never clobbered (no lock-out).
- Same `0600` protection as the **existing disk-cache fallback** (which already caches the derived key to disk after the first passphrase) — no security downgrade vs. the realistic desktop flow, just without the impossible prompt.
- The OS keychain is still preferred when available, and gets backfilled from this file.
- Fixes both API-key save **and** `moxxy login` (OAuth), which hit the same vault.

## Verification
- Typecheck + lint clean; **114** desktop-host (+4) + 49 desktop tests.
- **Verified against the real keysource**: with the keychain disabled (modeling Windows) and a throwing prompt, `obtain()` **throws before seeding** (reproduces the bug) and **unlocks silently via the disk key after seeding** (32-byte key, no prompt).

## Note
This ships in the next desktop build; an already-installed build keeps the old behavior until updated. A user already wedged can also unset it by installing the new build (the seed runs on first launch).