### PR TITLE
fix(oauth): Codex login authorization error on Windows (URL truncated at &)

### DIFF
--- a/packages/plugin-oauth/src/open-browser.test.ts
+++ b/packages/plugin-oauth/src/open-browser.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { browserOpenCommand } from './open-browser';
+
+// A realistic OAuth authorize URL: many `&`-separated params, which cmd.exe
+// treats as command separators unless the whole URL is quoted.
+const AUTH_URL =
+  'https://auth.openai.com/oauth/authorize?client_id=app_x&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback&response_type=code&scope=openid+profile&code_challenge=abc123&state=deadbeef';
+
+describe('browserOpenCommand', () => {
+  it('macOS uses `open` with the URL as a single arg', () => {
+    expect(browserOpenCommand(AUTH_URL, 'darwin')).toEqual({ cmd: 'open', args: [AUTH_URL] });
+  });
+
+  it('Linux uses `xdg-open` with the URL as a single arg', () => {
+    expect(browserOpenCommand(AUTH_URL, 'linux')).toEqual({ cmd: 'xdg-open', args: [AUTH_URL] });
+  });
+
+  it('Windows DOUBLE-QUOTES the URL so cmd.exe does not split it on `&`', () => {
+    const { cmd, args, verbatim } = browserOpenCommand(AUTH_URL, 'win32');
+    expect(cmd).toMatch(/cmd(\.exe)?$/i);
+    expect(verbatim).toBe(true);
+    expect(args.slice(0, 3)).toEqual(['/c', 'start', '""']);
+    // The whole URL — every `&` included — is inside one double-quoted token.
+    expect(args[3]).toBe(`"${AUTH_URL}"`);
+    // Sanity: the quoted arg still contains all the params after the first `&`.
+    expect(args[3]).toContain('redirect_uri');
+    expect(args[3]).toContain('code_challenge');
+    expect(args[3]).toContain('state=deadbeef');
+  });
+});

--- a/packages/plugin-oauth/src/open-browser.ts
+++ b/packages/plugin-oauth/src/open-browser.ts
@@ -4,8 +4,8 @@ import { spawn } from 'node:child_process';
  * Open a URL in the user's default browser. Platform-specific:
  *   macOS  → `open <url>`
  *   Linux  → `xdg-open <url>`
- *   Win32  → `cmd /c start "" <url>` (the empty quoted title is required
- *           so URLs starting with `"` don't confuse `start`)
+ *   Win32  → `cmd /c start "" "<url>"` (the URL DOUBLE-QUOTED + args passed
+ *           verbatim — see {@link browserOpenCommand})
  *
  * Returns once the helper process is spawned — it does NOT wait for the
  * browser itself, since the user's flow continues asynchronously via
@@ -13,9 +13,15 @@ import { spawn } from 'node:child_process';
  * so the caller can print it for the user to paste manually.
  */
 export async function openInBrowser(url: string): Promise<void> {
-  const { cmd, args } = chooseOpener(url);
+  const { cmd, args, verbatim } = browserOpenCommand(url);
   await new Promise<void>((resolve, reject) => {
-    const child = spawn(cmd, args, { stdio: 'ignore', detached: true });
+    const child = spawn(cmd, args, {
+      stdio: 'ignore',
+      detached: true,
+      // Windows only: keep cmd.exe from re-quoting our already-quoted URL,
+      // which would otherwise break the `&` escaping (see below).
+      ...(verbatim ? { windowsVerbatimArguments: true } : {}),
+    });
     child.once('error', reject);
     // `unref` so a misbehaving opener process can't keep the moxxy
     // process alive past its own lifetime.
@@ -26,9 +32,31 @@ export async function openInBrowser(url: string): Promise<void> {
   });
 }
 
-function chooseOpener(url: string): { cmd: string; args: string[] } {
-  if (process.platform === 'darwin') return { cmd: 'open', args: [url] };
-  if (process.platform === 'win32') return { cmd: 'cmd', args: ['/c', 'start', '""', url] };
+/**
+ * Resolve the platform's "open this URL in the default browser" command.
+ * Exported + `platform`-parameterized so the Windows quoting can be unit-tested
+ * without actually spawning a browser.
+ *
+ * Windows is the tricky one: `&` (and `|`, `<`, `>`, `^`) in a URL are cmd.exe
+ * command separators. `cmd /c start "" http://a?x=1&y=2` truncates the URL at
+ * the first `&`, so an OAuth authorize URL loses redirect_uri / code_challenge /
+ * state and the provider rejects the request ("authorization error"). Wrapping
+ * the URL in double quotes makes cmd treat it as one literal token; passing the
+ * args verbatim (`windowsVerbatimArguments`) stops Node from re-quoting and
+ * undoing that. The empty `""` is the required `start` window-title placeholder.
+ */
+export function browserOpenCommand(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+): { cmd: string; args: string[]; verbatim?: boolean } {
+  if (platform === 'darwin') return { cmd: 'open', args: [url] };
+  if (platform === 'win32') {
+    return {
+      cmd: process.env.ComSpec || 'cmd.exe',
+      args: ['/c', 'start', '""', `"${url}"`],
+      verbatim: true,
+    };
+  }
   // Linux + everything else assumes a Freedesktop-compliant `xdg-open`.
   return { cmd: 'xdg-open', args: [url] };
 }


### PR DESCRIPTION
## Symptom
Doing the **Codex OAuth login on Windows**, OpenAI returns an **authorization error**.

## Root cause
The browser opener (`plugin-oauth/open-browser.ts`) ran:

```
cmd /c start "" <url>      ← URL UNQUOTED
```

`cmd.exe` treats `&` (and `| < > ^`) as **command separators**. An OAuth authorize URL is full of them:

```
…/authorize?client_id=…&redirect_uri=…&response_type=code&scope=…&code_challenge=…&state=…
```

So cmd truncated the URL at the **first `&`**, opening only `…?client_id=…` and dropping `redirect_uri`, `code_challenge`, `state`, and `scope`. OpenAI received a malformed authorize request → **authorization error**. (macOS/Linux pass the URL as a single `argv`, so they were never affected — which is why it's Windows-only.)

## Fix
Double-quote the URL and pass the args **verbatim** so Node doesn't re-quote and undo it:

```
cmd /c start "" "<url>"    + windowsVerbatimArguments: true
```

cmd then treats the whole quoted URL as one literal token — `&` and all — and launches the complete authorize URL.

`browserOpenCommand()` is now exported + `platform`-parameterized so the quoting is unit-testable without spawning a browser.

## Verification
- Typecheck + lint clean; **25** plugin-oauth tests (+3): asserts the Windows command double-quotes the URL and keeps every param **after** the first `&` (`redirect_uri`, `code_challenge`, `state`) intact; macOS/Linux still pass the bare URL.

Ships in the next desktop build (the fix is in the bundled CLI's OAuth flow).