### PR TITLE
ci(release): broaden desktop auto-release trigger to the bundled-CLI footprint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,11 @@ name: Release
 # for why it dispatches rather than relying on the tag-push trigger.
 #
 # The desktop also auto-proposes releases: when desktop-relevant code
-# (apps/desktop + desktop-host / desktop-ipc-contract / desktop-ui / chat-model)
-# changes after its last release, the "Open desktop release PR" step opens (and
-# keeps updating) a one-line `auto/desktop-release` PR that bumps the patch
-# version. Merging that PR lands the bump on main, and the cut step above ships
+# (apps/desktop or any packages/** — the desktop ships its renderer/main AND a
+# bundled moxxy CLI that pulls in nearly every package) changes after its last
+# release, the "Open desktop release PR" step opens (and keeps updating) a
+# one-line `auto/desktop-release` PR that bumps the patch version. Merging that
+# PR lands the bump on main, and the cut step above ships
 # the release — so cutting a desktop release is a one-click merge, never a
 # hand-edited version. It defers to explicit/changeset-driven bumps.
 #
@@ -151,7 +152,12 @@ jobs:
             echo "$version is not yet released ($tag missing) — pending; cut step will handle it."
             echo "bump=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          paths="apps/desktop packages/desktop-host packages/desktop-ipc-contract packages/desktop-ui packages/chat-model"
+          # The desktop ships its own renderer/main AND a bundled moxxy CLI
+          # (resources/moxxy-cli = @moxxy/cli + nearly every package: providers,
+          # plugins, runner, sdk, modes). So any apps/desktop or packages/**
+          # change can alter what the desktop installs — watch them all, not just
+          # the UI packages (a fix in e.g. plugin-oauth must still cut a release).
+          paths="apps/desktop packages"
           if git diff --quiet "$tag" HEAD -- $paths; then
             echo "No desktop changes since $tag — nothing to release."
             echo "bump=false" >> "$GITHUB_OUTPUT"; exit 0


### PR DESCRIPTION
## Why
The desktop version didn't bump after the OAuth fix (#68). The auto-release only watched the **desktop-UI** packages (`apps/desktop` + `desktop-host` / `desktop-ipc-contract` / `desktop-ui` / `chat-model`). But #68 is in **`packages/plugin-oauth`**, which the desktop ships via its **bundled moxxy CLI** (`resources/moxxy-cli`). So the change was real-but-invisible to the trigger → no `auto/desktop-release` PR, version stuck at 0.0.9.

(Confirmed: `git diff desktop-v0.0.9..main` over the old watched paths is empty, even though plugin-oauth changed.)

## What changed
The desktop bundles `@moxxy/cli` — which pulls in nearly every package (providers, plugins, runner, sdk, modes) — so **any `apps/desktop` or `packages/**` change can alter what the desktop installs**. The trigger now watches:

```
paths="apps/desktop packages"
```

instead of the narrow UI-only list. (Per the chosen "broaden to the desktop's real footprint" — occasionally a test-only package change cuts a harmless extra release.)

## Bonus: ships the stranded OAuth fix
Merging this also unblocks **0.0.10**: the release run on this merge will see `plugin-oauth` changed since `desktop-v0.0.9` and open the `auto/desktop-release` PR (0.0.9 → 0.0.10). Merge that → `desktop-v0.0.10` builds + publishes with the Windows OAuth fix.

## Verification
- YAML validated. Workflow-only change; the auto-bump guards are unchanged (still skips an untagged/pending version and a pending `@moxxy/desktop` changeset).