### PR TITLE
fix(desktop): 'not connected to a runner' right after Codex OAuth login

### DIFF
--- a/apps/desktop/src/lib/runner-retry.test.ts
+++ b/apps/desktop/src/lib/runner-retry.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { retryWhileReconnecting } from './runner-retry';
+
+const NOT_CONNECTED = { code: 'not-connected' };
+const isReconnecting = (e: unknown): boolean =>
+  !!e && typeof e === 'object' && (e as { code?: string }).code === 'not-connected';
+
+// Deterministic clock + no real waiting.
+function fakeTime(start = 0): { now: () => number; sleep: (ms: number) => Promise<void> } {
+  let t = start;
+  return { now: () => t, sleep: async (ms: number) => { t += ms; } };
+}
+
+describe('retryWhileReconnecting', () => {
+  it('returns immediately on success without retrying', async () => {
+    const action = vi.fn().mockResolvedValue('ok');
+    const { now, sleep } = fakeTime();
+    expect(await retryWhileReconnecting(action, { isReconnecting, now, sleep })).toBe('ok');
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries across a reconnect gap, then succeeds', async () => {
+    const action = vi
+      .fn()
+      .mockRejectedValueOnce(NOT_CONNECTED)
+      .mockRejectedValueOnce(NOT_CONNECTED)
+      .mockResolvedValue('connected');
+    const { now, sleep } = fakeTime();
+    expect(await retryWhileReconnecting(action, { isReconnecting, now, sleep })).toBe('connected');
+    expect(action).toHaveBeenCalledTimes(3);
+  });
+
+  it('rethrows a non-reconnect error immediately (no retry)', async () => {
+    const other = { code: 'invalid-payload', message: 'bad' };
+    const action = vi.fn().mockRejectedValue(other);
+    const { now, sleep } = fakeTime();
+    await expect(retryWhileReconnecting(action, { isReconnecting, now, sleep })).rejects.toBe(other);
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after the timeout, rethrowing the last not-connected error', async () => {
+    const action = vi.fn().mockRejectedValue(NOT_CONNECTED);
+    const { now, sleep } = fakeTime();
+    await expect(
+      retryWhileReconnecting(action, { isReconnecting, now, sleep, timeoutMs: 5_000, intervalMs: 1_000 }),
+    ).rejects.toBe(NOT_CONNECTED);
+    // 5s budget / 1s interval → ~6 attempts before the deadline trips.
+    expect(action.mock.calls.length).toBeGreaterThanOrEqual(5);
+    expect(action.mock.calls.length).toBeLessThanOrEqual(7);
+  });
+});

--- a/apps/desktop/src/lib/runner-retry.ts
+++ b/apps/desktop/src/lib/runner-retry.ts
@@ -1,0 +1,36 @@
+/**
+ * Run `action`, retrying ONLY while it fails because the runner link is
+ * (re)connecting — never on any other error.
+ *
+ * The desktop's runner connection can be momentarily down: e.g. right after the
+ * OAuth browser detour the `moxxy serve` socket sometimes drops (notably on
+ * Windows, where the long idle window over a named pipe is fragile), and the
+ * supervisor re-establishes it within a few seconds. A command fired into that
+ * gap throws `not-connected`; rather than fail the action the user just
+ * completed, we wait across the reconnect and retry.
+ */
+export async function retryWhileReconnecting<T>(
+  action: () => Promise<T>,
+  opts: {
+    /** True iff the error means "runner not connected yet" (worth retrying). */
+    isReconnecting: (e: unknown) => boolean;
+    timeoutMs?: number;
+    intervalMs?: number;
+    sleep?: (ms: number) => Promise<void>;
+    now?: () => number;
+  },
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+  const intervalMs = opts.intervalMs ?? 1_000;
+  const sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  const now = opts.now ?? ((): number => Date.now());
+  const deadline = now() + timeoutMs;
+  for (;;) {
+    try {
+      return await action();
+    } catch (e) {
+      if (!opts.isReconnecting(e) || now() >= deadline) throw e;
+      await sleep(intervalMs);
+    }
+  }
+}

--- a/apps/desktop/src/onboarding/steps/ProviderStep.tsx
+++ b/apps/desktop/src/onboarding/steps/ProviderStep.tsx
@@ -7,8 +7,9 @@
  */
 
 import { useEffect, useState } from 'react';
-import { toErrorMessage } from '@/lib/errors';
+import { decodeError, toErrorMessage } from '@/lib/errors';
 import { api } from '@/lib/api';
+import { retryWhileReconnecting } from '@/lib/runner-retry';
 import { StepCard, Nav, PrimaryButton, SuccessRow, inputStyle } from '../chrome';
 
 export function ProviderStep({
@@ -83,8 +84,17 @@ export function ProviderStep({
   // activeProvider — the app's `connectedWithoutProvider` gate never clears and
   // onboarding loops forever. setProvider re-resolves the credential from the
   // vault and makes the runner usable; the gate then drops on its own.
+  //
+  // The runner link can be MID-RECONNECT here: the OAuth flow takes the user on
+  // a long browser detour, and on Windows the runner socket sometimes drops over
+  // that window — the supervisor re-establishes within a few seconds, but a
+  // setProvider fired into the gap throws "not connected to a runner". So retry
+  // across a reconnect (only on that specific error) instead of failing the
+  // whole login the user just completed.
   const activateProvider = async (): Promise<void> => {
-    await api().invoke('session.setProvider', { provider });
+    await retryWhileReconnecting(() => api().invoke('session.setProvider', { provider }), {
+      isReconnecting: (e) => decodeError(e).code === 'not-connected',
+    });
   };
 
   const saveKey = async (): Promise<void> => {


### PR DESCRIPTION
## Symptom
On Windows, the Codex OAuth login now opens + completes successfully, but **right after auth** the app throws **"not connected to a runner."**

## Root cause
After OAuth completes, `ProviderStep.activateProvider()` calls `session.setProvider` to activate the provider on the running runner. That handler throws `not-connected` when the runner's `RemoteSession` is null **at that instant**.

The OAuth browser detour takes ~a minute, and over that idle window the `moxxy serve` link drops (notably on Windows — the named-pipe connection is fragile over a long idle). The supervisor re-establishes it within a few seconds (it blocks on `session.onClose()`, then respawns + reconnects), but the `setProvider` fired immediately on the OAuth callback lands in that **reconnect gap** → hard failure of the login the user just finished.

## Fix
`activateProvider` now **retries across the reconnect** — only on the `not-connected` error code, polling every 1s for up to 30s — instead of failing instantly. The supervisor reconnects well within that window, so the provider activates and onboarding proceeds.

Extracted as a small, pure, testable helper `retryWhileReconnecting()` (renderer `lib/`), which retries **only** the reconnect error and rethrows anything else immediately.

## Verification
- Typecheck + lint clean; **53** desktop tests (**+4**): succeeds first-try without retry; retries across a reconnect gap then succeeds; rethrows a non-reconnect error immediately; gives up after the timeout.

## Note
This tolerates the transient drop (the right user-facing fix). The deeper question of *why* the runner link drops during a long idle on Windows is a separate runtime characteristic — the supervisor already auto-reconnects, and post-onboarding the connection UI surfaces reconnects normally; this just makes the one direct (non-UI-gated) `setProvider` call resilient to it.