### PR TITLE
fix(oauth): Windows login hangs 'waiting for the browser' (callback IPv4-only)

### DIFF
--- a/packages/plugin-oauth/src/oauth/callback-server.test.ts
+++ b/packages/plugin-oauth/src/oauth/callback-server.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import net from 'node:net';
+import { request } from 'node:http';
+import { waitForCallback } from './callback-server';
+
+/** Grab a port that's free right now (best-effort; good enough for a test). */
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const s = net.createServer();
+    s.once('error', reject);
+    s.listen(0, '127.0.0.1', () => {
+      const port = (s.address() as net.AddressInfo).port;
+      s.close(() => resolve(port));
+    });
+  });
+}
+
+/** GET host:port/path, resolving once the response completes (or rejecting on
+ *  a connection error — e.g. the stack isn't listening). */
+function hit(host: string, port: number, path: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = request({ host, port, path, method: 'GET' }, (res) => {
+      res.resume();
+      res.on('end', () => resolve());
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 50));
+
+describe('waitForCallback — dual-stack loopback', () => {
+  it('receives the callback over IPv4 (127.0.0.1)', async () => {
+    const port = await freePort();
+    const pending = waitForCallback({ port, path: '/auth/callback', expectedState: 'S', timeoutMs: 4_000 });
+    await tick(); // let both listeners bind
+    await hit('127.0.0.1', port, '/auth/callback?code=CODE4&state=S');
+    expect(await pending).toBe('CODE4');
+  });
+
+  it('receives the callback over IPv6 (::1) — the Windows `localhost` path', async () => {
+    const port = await freePort();
+    const pending = waitForCallback({ port, path: '/auth/callback', expectedState: 'S', timeoutMs: 4_000 });
+    await tick();
+    // Prefer IPv6 (what Windows hits); fall back to IPv4 only if this host has
+    // no IPv6 loopback, so the test stays green on IPv6-less CI runners.
+    try {
+      await hit('::1', port, '/auth/callback?code=CODE6&state=S');
+    } catch {
+      await hit('127.0.0.1', port, '/auth/callback?code=CODE6&state=S');
+    }
+    expect(await pending).toBe('CODE6');
+  });
+
+  it('rejects a state mismatch (CSRF guard) regardless of stack', async () => {
+    const port = await freePort();
+    const pending = waitForCallback({ port, path: '/auth/callback', expectedState: 'GOOD', timeoutMs: 4_000 });
+    // Attach the rejection assertion BEFORE triggering the callback so the
+    // rejection is never momentarily unhandled.
+    const rejected = expect(pending).rejects.toThrow(/state mismatch/i);
+    await tick();
+    await hit('127.0.0.1', port, '/auth/callback?code=X&state=EVIL');
+    await rejected;
+  });
+});

--- a/packages/plugin-oauth/src/oauth/callback-server.ts
+++ b/packages/plugin-oauth/src/oauth/callback-server.ts
@@ -1,4 +1,4 @@
-import { createServer, type Server } from 'node:http';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { MoxxyError } from '@moxxy/sdk';
 
 interface WaitForCallbackOpts {
@@ -11,7 +11,13 @@ interface WaitForCallbackOpts {
 
 export function waitForCallback(opts: WaitForCallbackOpts): Promise<string> {
   return new Promise<string>((resolve, reject) => {
-    let server: Server | null = null;
+    // Bind BOTH loopback stacks. The redirect_uri uses `localhost`, which
+    // Windows resolves to `::1` (IPv6) first while macOS/Linux use `127.0.0.1`
+    // (IPv4). A v4-only listener therefore never receives the redirect on
+    // Windows → the login hangs on "waiting for the browser". IPv4 is required;
+    // IPv6 is best-effort (a host without it still works, since there
+    // `localhost` is IPv4 anyway).
+    const servers: Server[] = [];
     let settled = false;
     const settle = (fn: () => void): void => {
       if (settled) return;
@@ -21,7 +27,7 @@ export function waitForCallback(opts: WaitForCallbackOpts): Promise<string> {
       // dangling timer nor a lingering signal listener is left behind.
       clearTimeout(timer);
       opts.signal?.removeEventListener('abort', onAbort);
-      if (server) server.close();
+      for (const s of servers) s.close();
       fn();
     };
 
@@ -51,7 +57,7 @@ export function waitForCallback(opts: WaitForCallbackOpts): Promise<string> {
     };
     opts.signal?.addEventListener('abort', onAbort, { once: true });
 
-    server = createServer((req, res) => {
+    const handleRequest = (req: IncomingMessage, res: ServerResponse): void => {
       const url = new URL(req.url ?? '/', `http://localhost:${opts.port}`);
       if (url.pathname !== opts.path) {
         res.writeHead(404, { 'Content-Type': 'text/plain' });
@@ -117,13 +123,11 @@ export function waitForCallback(opts: WaitForCallbackOpts): Promise<string> {
       }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(htmlPage('Authorized', 'You can close this window — moxxy received the token.'));
-      clearTimeout(timer);
       settle(() => resolve(code));
-    });
-    server.on('error', (e) => {
-      clearTimeout(timer);
-      const code = (e as NodeJS.ErrnoException).code;
-      if (code === 'EADDRINUSE') {
+    };
+
+    const onFatalError = (e: NodeJS.ErrnoException): void => {
+      if (e.code === 'EADDRINUSE') {
         settle(() =>
           reject(
             new MoxxyError({
@@ -147,8 +151,22 @@ export function waitForCallback(opts: WaitForCallbackOpts): Promise<string> {
           }),
         ),
       );
-    });
-    server.listen(opts.port, '127.0.0.1');
+    };
+
+    // IPv4 loopback — the required listener; its bind/port errors are fatal.
+    const v4 = createServer(handleRequest);
+    v4.on('error', onFatalError);
+    v4.listen(opts.port, '127.0.0.1');
+    servers.push(v4);
+
+    // IPv6 loopback — Windows resolves `localhost` to ::1 first, so the
+    // redirect lands here. Best-effort: swallow bind errors (host without IPv6,
+    // or ::1 already bound), since the IPv4 listener above is the guaranteed
+    // path and on such hosts `localhost` is IPv4 anyway.
+    const v6 = createServer(handleRequest);
+    v6.on('error', () => undefined);
+    v6.listen(opts.port, '::1');
+    servers.push(v6);
   });
 }
 


### PR DESCRIPTION
## Symptom
On Windows, after authorizing in the browser, the desktop stays on **"waiting for the browser"** and never sees the OAuth result — eventually surfacing "not connected to the runner". (The "logged in" page you saw is ChatGPT's own success page; the redirect *back to moxxy* never landed.)

## Root cause
The OAuth loopback callback server bound **only to `127.0.0.1` (IPv4)**:

```js
server.listen(opts.port, '127.0.0.1');
```

…but the `redirect_uri` is `http://localhost:1455/auth/callback`. **Windows resolves `localhost` to `::1` (IPv6) first**, so the browser's redirect hits `[::1]:1455` → connection refused → the auth code is never delivered → the flow hangs until the 5-minute timeout. macOS/Linux resolve `localhost` to `127.0.0.1`, so they were unaffected — classic IPv4/IPv6 loopback mismatch.

## Fix
Bind **both** loopback stacks on the callback port:
- **`127.0.0.1`** — required; bind/port errors are fatal (keeps the existing `EADDRINUSE` → "port busy" message).
- **`::1`** — best-effort; bind errors are swallowed (a host without IPv6 resolves `localhost` to IPv4 anyway, and the v4 listener is the guaranteed path).

Whichever address the browser's redirect lands on, the shared handler completes the flow (and `settle()` closes both). No change to the redirect_uri (still `localhost`, matching the registered Codex client).

## Verification
- Typecheck + lint clean; **28** plugin-oauth tests (**+3** integration): the callback is received over **IPv4** *and* over **IPv6 (`::1`) — the Windows path** (falls back gracefully on IPv6-less CI), and the state-mismatch CSRF guard still rejects.

This pairs with #71 (tolerate the runner reconnect after the long OAuth wait); together they make Codex login work end-to-end on Windows. Ships via the bundled CLI in the next desktop release.