### PR TITLE
fix(desktop): runner never starts on Windows — named pipes, not .sock paths

### DIFF
--- a/packages/desktop-host/src/runner-pool.test.ts
+++ b/packages/desktop-host/src/runner-pool.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { socketFor, UNBOUND_ID } from './runner-pool';
+
+const orig = { ...process.env };
+beforeEach(() => {
+  process.env = { ...orig };
+  delete process.env.MOXXY_RUNNER_SOCKET;
+});
+afterEach(() => {
+  process.env = orig;
+});
+
+describe('socketFor — platform-correct runner address', () => {
+  it('uses a Windows NAMED PIPE for the unbound runner (not a .sock path)', () => {
+    // A raw `C:\…\serve.sock` can't be bound on Windows → `moxxy serve` exits.
+    expect(socketFor(UNBOUND_ID, 'win32')).toBe('\\\\.\\pipe\\moxxy-serve');
+  });
+
+  it('uses a distinct named pipe per workspace on Windows', () => {
+    expect(socketFor('ws-1', 'win32')).toBe('\\\\.\\pipe\\moxxy-serve-ws-1');
+  });
+
+  it('sanitizes unsafe characters out of the Windows pipe name', () => {
+    // Path separators / colons in a workspace id can't appear in a pipe name.
+    expect(socketFor('a/b\\c:d', 'win32')).toBe('\\\\.\\pipe\\moxxy-serve-a_b_c_d');
+  });
+
+  it('honors MOXXY_RUNNER_SOCKET override for the unbound runner on Windows', () => {
+    process.env.MOXXY_RUNNER_SOCKET = '\\\\.\\pipe\\custom';
+    expect(socketFor(UNBOUND_ID, 'win32')).toBe('\\\\.\\pipe\\custom');
+  });
+
+  it('keeps the ~/.moxxy/*.sock filesystem layout on POSIX', () => {
+    expect(socketFor(UNBOUND_ID, 'linux')).toBe(path.join(homedir(), '.moxxy', 'serve.sock'));
+    expect(socketFor('ws-1', 'darwin')).toBe(
+      path.join(homedir(), '.moxxy', 'desktop', 'sockets', 'serve-ws-1.sock'),
+    );
+  });
+});

--- a/packages/desktop-host/src/runner-pool.ts
+++ b/packages/desktop-host/src/runner-pool.ts
@@ -16,6 +16,8 @@ import { EventEmitter } from 'node:events';
 import { homedir } from 'node:os';
 import path from 'node:path';
 
+import { platformSocket } from '@moxxy/runner';
+
 import { RunnerSupervisor } from './runner-supervisor';
 
 /** Workspace id used for the "no workspace bound" runner. Stable across
@@ -124,12 +126,23 @@ export class RunnerPool extends EventEmitter {
  * `~/.moxxy/serve.sock` path so external tools (TUI, `moxxy attach`)
  * keep working when the user hasn't bound a workspace yet.
  */
-export function socketFor(id: string): string {
+export function socketFor(id: string, platform: NodeJS.Platform = process.platform): string {
+  // platformSocket() owns the unix-path-vs-Windows-named-pipe split (a raw
+  // .sock path can't be bound on Windows). The unbound runner derives the same
+  // address as the runner's own default (runnerSocketPath) so an external
+  // `moxxy tui` / attach still finds it; bound workspaces get a distinct one.
   if (id === UNBOUND_ID) {
-    return process.env.MOXXY_RUNNER_SOCKET ?? path.join(homedir(), '.moxxy', 'serve.sock');
+    return (
+      process.env.MOXXY_RUNNER_SOCKET ??
+      platformSocket('serve', path.join(homedir(), '.moxxy', 'serve.sock'), platform)
+    );
   }
-  // Workspace-bound sockets sit under ~/.moxxy/desktop/sockets/ so a
-  // single deleted workspace's stale .sock doesn't pollute the home
-  // dir's top level.
-  return path.join(homedir(), '.moxxy', 'desktop', 'sockets', `serve-${id}.sock`);
+  // Workspace-bound sockets sit under ~/.moxxy/desktop/sockets/ on unix so a
+  // single deleted workspace's stale .sock doesn't pollute the home dir's top
+  // level; on Windows they become `\\.\pipe\moxxy-serve-<id>`.
+  return platformSocket(
+    `serve-${id}`,
+    path.join(homedir(), '.moxxy', 'desktop', 'sockets', `serve-${id}.sock`),
+    platform,
+  );
 }

--- a/packages/desktop-host/src/runner-supervisor.ts
+++ b/packages/desktop-host/src/runner-supervisor.ts
@@ -26,6 +26,8 @@ import { Socket } from 'node:net';
 
 import {
   connectRemoteSession,
+  isNamedPipe,
+  platformSocket,
   type RemoteSession,
 } from '@moxxy/runner';
 
@@ -60,8 +62,12 @@ export class RunnerSupervisor extends EventEmitter {
   private cwd: string | null = null;
 
   constructor(
+    // The pool passes socketFor() explicitly; this default keeps a bare
+    // supervisor correct too. platformSocket() gives a named pipe on Windows
+    // (a raw .sock can't bind there, so `moxxy serve` would exit → "lost the
+    // runner").
     private readonly socketPath: string = process.env.MOXXY_RUNNER_SOCKET ??
-      path.join(homedir(), '.moxxy', 'serve.sock'),
+      platformSocket('serve', path.join(homedir(), '.moxxy', 'serve.sock')),
   ) {
     super();
   }
@@ -336,6 +342,9 @@ export class RunnerSupervisor extends EventEmitter {
   }
 
   private ensureSocketDir(): void {
+    // Named pipes (Windows) have no parent directory — `mkdirSync('\\.\pipe')`
+    // would throw. Nothing to create.
+    if (isNamedPipe(this.socketPath)) return;
     const dir = path.dirname(this.socketPath);
     if (!existsSync(dir)) {
       try {
@@ -347,6 +356,9 @@ export class RunnerSupervisor extends EventEmitter {
   }
 
   private cleanupStaleSocket(): void {
+    // Named pipes (Windows) aren't filesystem entries and self-clean when the
+    // owning process exits — there's nothing to unlink.
+    if (isNamedPipe(this.socketPath)) return;
     if (existsSync(this.socketPath)) {
       try {
         unlinkSync(this.socketPath);

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -9,7 +9,7 @@ export {
   createUnixSocketServer,
   connectUnixSocket,
 } from './unix-socket.js';
-export { runnerSocketPath, isRunnerUp } from './socket-path.js';
+export { runnerSocketPath, isRunnerUp, platformSocket, isNamedPipe } from './socket-path.js';
 export { RunnerServer, startRunnerServer } from './server.js';
 export {
   RemoteSession,

--- a/packages/runner/src/socket-path.test.ts
+++ b/packages/runner/src/socket-path.test.ts
@@ -1,7 +1,7 @@
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { runnerSocketPath, isRunnerUp } from './socket-path.js';
+import { runnerSocketPath, isRunnerUp, platformSocket, isNamedPipe } from './socket-path.js';
 import { createUnixSocketServer } from './unix-socket.js';
 import type { TransportServer } from './transport.js';
 
@@ -31,6 +31,39 @@ describe('runnerSocketPath', () => {
     } else {
       expect(runnerSocketPath()).toBe(path.join(os.homedir(), '.moxxy', 'serve.sock'));
     }
+  });
+});
+
+describe('platformSocket — the OS socket-address split', () => {
+  it('returns a Windows named pipe (NOT the .sock path) on win32', () => {
+    expect(platformSocket('serve', '/home/u/.moxxy/serve.sock', 'win32')).toBe(
+      '\\\\.\\pipe\\moxxy-serve',
+    );
+  });
+
+  it('returns the supplied filesystem path on unix/macOS', () => {
+    expect(platformSocket('serve', '/home/u/.moxxy/serve.sock', 'linux')).toBe(
+      '/home/u/.moxxy/serve.sock',
+    );
+    expect(platformSocket('serve', '/Users/u/.moxxy/serve.sock', 'darwin')).toBe(
+      '/Users/u/.moxxy/serve.sock',
+    );
+  });
+
+  it('sanitizes the name into a single legal pipe segment on Windows', () => {
+    expect(platformSocket('serve-a/b\\c:d', '/x', 'win32')).toBe('\\\\.\\pipe\\moxxy-serve-a_b_c_d');
+  });
+});
+
+describe('isNamedPipe', () => {
+  it('recognizes Windows pipe addresses', () => {
+    expect(isNamedPipe('\\\\.\\pipe\\moxxy-serve')).toBe(true);
+    expect(isNamedPipe('//./pipe/moxxy-serve')).toBe(true);
+  });
+
+  it('rejects filesystem socket paths', () => {
+    expect(isNamedPipe('/home/u/.moxxy/serve.sock')).toBe(false);
+    expect(isNamedPipe('C:\\Users\\u\\.moxxy\\serve.sock')).toBe(false);
   });
 });
 

--- a/packages/runner/src/socket-path.ts
+++ b/packages/runner/src/socket-path.ts
@@ -11,11 +11,42 @@ import path from 'node:path';
  * `MOXXY_RUNNER_SOCKET` overrides it - useful for tests and for running
  * multiple isolated runners on one machine.
  */
+/**
+ * THE single source of truth for the OS difference in runner IPC addressing.
+ *
+ * Map a logical runner NAME to a platform-correct endpoint: a Windows NAMED PIPE
+ * (`\\.\pipe\moxxy-<name>`) or, on unix/macOS, the supplied filesystem socket
+ * path. A raw filesystem `.sock` path is NOT a valid Windows pipe name — binding
+ * it makes `moxxy serve` fail to start (it exits, and the desktop reports "lost
+ * the runner" / "not connected"). Both the listening side (`moxxy serve`) and
+ * every client (CLI, desktop pool/supervisor) MUST derive their address from
+ * here so they always agree, instead of hand-rolling `if (win32)` branches.
+ */
+export function platformSocket(
+  name: string,
+  posixPath: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform === 'win32') {
+    // The Windows pipe namespace is flat — sanitize the name to one safe segment.
+    return `\\\\.\\pipe\\moxxy-${name.replace(/[^A-Za-z0-9_-]/g, '_')}`;
+  }
+  return posixPath;
+}
+
+/**
+ * True for a Windows named-pipe address. Such endpoints have NO parent directory
+ * and are NOT filesystem entries (they self-clean when the owning process
+ * exits), so callers must skip `mkdir`/`unlink`/`chmod`/`existsSync` on them.
+ */
+export function isNamedPipe(address: string): boolean {
+  return address.startsWith('\\\\.\\pipe\\') || address.startsWith('//./pipe/');
+}
+
 export function runnerSocketPath(): string {
   const override = process.env.MOXXY_RUNNER_SOCKET;
   if (override) return override;
-  if (process.platform === 'win32') return '\\\\.\\pipe\\moxxy-serve';
-  return path.join(os.homedir(), '.moxxy', 'serve.sock');
+  return platformSocket('serve', path.join(os.homedir(), '.moxxy', 'serve.sock'));
 }
 
 /**


### PR DESCRIPTION
## The actual root cause (found via deep multi-agent analysis)

The desktop's runner (`moxxy serve`) **never starts on Windows.** The desktop addressed its runner socket with a raw **filesystem path** on all platforms:

```
~/.moxxy/serve.sock            (unbound)
~/.moxxy/desktop/sockets/serve-<id>.sock   (per workspace)
```

On Windows, Node IPC "sockets" are **named pipes** — a path like `C:\Users\…\serve.sock` is **not a valid pipe name**, so `net.listen()` fails, `moxxy serve` exits 1, and the desktop reports **"lost the runner when starting moxxy serve" / "not connected to a runner."** This is the systemic Windows failure behind the onboarding problems.

The runner package *had* a correct Windows branch (`runnerSocketPath` → `\\.\pipe\moxxy-serve`), but the desktop's `runner-pool.ts` `socketFor()` and `runner-supervisor.ts` **hardcoded the `.sock` path and never used it** (no `win32` branch).

## The fix — one platform-aware primitive (the split you asked for)

Centralized the OS difference into a **single source of truth** in `@moxxy/runner` instead of scattered `if (win32)` branches:

- **`platformSocket(name, posixPath)`** → `\\.\pipe\moxxy-<name>` on Windows, the filesystem path on unix/macOS.
- **`isNamedPipe(addr)`** → true for pipe addresses (which have no parent dir and aren't files).

Everything derives from it so the listener and all clients agree:
- `runnerSocketPath()` (CLI/serve), the desktop `socketFor(id)` (unbound + per-workspace), and the supervisor default.
- The supervisor's `ensureSocketDir`/`cleanupStaleSocket` now no-op on pipe addresses (pipes self-clean on process exit; `mkdirSync('\\.\pipe')` would throw). The bind side (`unix-socket.ts`) already no-ops fs on win32.

## Verification
- `@moxxy/runner` 36 tests + `@moxxy/desktop-host` 120 tests, typecheck + lint clean. **+14 tests**: `platformSocket` returns a pipe on win32 / path on unix+mac, name sanitization, `isNamedPipe` detection, and `socketFor` per-platform (unbound + per-workspace + override + sanitized id).
- Can't run Windows here, but the named-pipe form is exactly what Node docs require (IPC paths *must* be `\\?\pipe\`/`\\.\pipe\`) and what `runnerSocketPath` already used for the CLI.

## Relationship to the other Windows PRs
This is the **highest-priority** Windows fix — without the runner, nothing connects. It's independent of and complementary to the OAuth fixes (#73 IPv6 callback, #71 reconnect-retry, #68 URL-quoting). All should ship together in the next desktop release.