### PR TITLE
fix(desktop): creating a workspace bounces back to "Connect a provider"

### DIFF
--- a/packages/runner/src/integration.test.ts
+++ b/packages/runner/src/integration.test.ts
@@ -6,6 +6,7 @@
  */
 import os from 'node:os';
 import path from 'node:path';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { afterEach, describe, expect, it } from 'vitest';
 import { Session, autoAllowResolver, silentLogger } from '@moxxy/core';
 import {
@@ -224,6 +225,66 @@ describe('runner end-to-end', () => {
       session: remote,
     });
     expect(result).toEqual({ kind: 'text', text: 'pong' });
+  });
+
+  it('persists the picked provider to preferences so the next runner inherits it', async () => {
+    // Regression: a remote `providers.setActive` only mutated THIS runner's
+    // in-memory state. The desktop spawns one `moxxy serve` PER workspace, so
+    // creating a workspace after connecting a (non-default) provider booted a
+    // fresh runner that defaulted back to `anthropic`, found no key, came up
+    // `connected` but provider-less, and bounced the user to "Connect a
+    // provider". The runner must persist the pick to ~/.moxxy/preferences.json
+    // (like the TUI / Telegram pickers) so the next runner picks it up.
+    const home = await mkdtemp(path.join(os.tmpdir(), 'moxxy-prefs-'));
+    const prevHome = process.env.HOME;
+    const prevUserProfile = process.env.USERPROFILE;
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    try {
+      const socketPath = tmpSocket();
+      const provider = new FakeProvider({ script: [textReply('hi')] });
+      const session = buildSession(provider);
+      // A second provider to switch to — `fake` is active at boot.
+      session.pluginHost.registerStatic(
+        definePlugin({
+          name: 'runner-test-second-provider',
+          providers: [
+            defineProvider({
+              name: 'fake2',
+              models: [...provider.models],
+              createClient: () => provider,
+            }),
+          ],
+        }),
+      );
+      const server = await startRunnerServer(session, { socketPath });
+      servers.push(server);
+      const remote = await attach(socketPath);
+
+      remote.providers.setActive('fake2');
+      await waitFor(() => session.providers.getActiveName() === 'fake2');
+
+      // savePreferences is fire-and-forget inside the handler, so poll the
+      // file until the async write lands.
+      const prefsPath = path.join(home, '.moxxy', 'preferences.json');
+      const deadline = Date.now() + 2000;
+      let persisted: { providerName?: string } = {};
+      while (persisted.providerName !== 'fake2' && Date.now() < deadline) {
+        try {
+          persisted = JSON.parse(await readFile(prefsPath, 'utf8')) as { providerName?: string };
+        } catch {
+          /* not written yet */
+        }
+        if (persisted.providerName !== 'fake2') await new Promise((r) => setTimeout(r, 5));
+      }
+      expect(persisted.providerName).toBe('fake2');
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevUserProfile;
+      await rm(home, { recursive: true, force: true });
+    }
   });
 
   it('broadcasts a turn started by one client to other attached clients', async () => {

--- a/packages/runner/src/server.ts
+++ b/packages/runner/src/server.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Session } from '@moxxy/core';
-import { newTurnId } from '@moxxy/core';
+import { newTurnId, savePreferences } from '@moxxy/core';
 import type {
   ApprovalDecision,
   ApprovalRequest,
@@ -263,6 +263,16 @@ export class RunnerServer {
     const def = this.session.providers.list().find((p) => p.name === name);
     if (def) this.session.providers.replace(def);
     this.session.providers.setActive(name, cfg);
+    // Persist the pick to ~/.moxxy/preferences.json so it survives to the NEXT
+    // freshly-spawned runner. Without this, a remote client (e.g. the desktop)
+    // that switches provider only mutates THIS runner's in-memory state — so
+    // spawning another runner (the desktop spawns one `moxxy serve` per
+    // workspace) boots back on the default provider with no key, comes up
+    // `connected` but provider-less, and bounces the user to "Connect a
+    // provider". Mirrors the TUI / Telegram pickers, which already persist.
+    // Best-effort: savePreferences swallows its own write errors and never
+    // throws, so a read-only home can't fail the setActive RPC.
+    void savePreferences({ providerName: name });
     this.broadcastInfo();
     return {};
   }


### PR DESCRIPTION
## The bug

On the desktop app: connect a provider successfully, then create a workspace (desk) — and you're thrown back to the **"Connect a provider"** onboarding screen.

## Root cause

The desktop spawns **one `moxxy serve` per workspace** (`RunnerPool`). Connecting a provider runs `onboarding.saveProviderKey`, which:
1. `moxxy vault set <PROVIDER>_API_KEY` — durable ✓
2. `session.providers.setActive(provider)` over RPC → the runner's `handleProviderSetActive`

But step 2 only set the provider **in the current runner's memory** — it never wrote `providerName` to `~/.moxxy/preferences.json`.

So creating a workspace spawned a **fresh** `moxxy serve`. On boot it tries `config.provider?.name ?? 'anthropic'`, and `applyPreferences` reads `preferences.json#providerName` — which was empty. With `tolerateNoProvider`, the new runner came up `connected` but provider-less, so the renderer's `connectedWithoutProvider` gate (`App.tsx`) bounced the user back to onboarding.

Not truly Windows-specific — it bites whenever the connected provider isn't the default `anthropic` (e.g. OpenAI/Codex). The TUI `/model` picker and Telegram already persist via `savePreferences`; the runner's RPC path was the one that didn't.

## The fix

`packages/runner/src/server.ts` — `handleProviderSetActive` now persists the pick:

```ts
this.session.providers.setActive(name, cfg);
void savePreferences({ providerName: name });   // survives to the next spawned runner
```

This is the single RPC chokepoint both desktop paths (`onboarding.saveProviderKey` **and** `session.setProvider`) route through, mirroring the other channels. Best-effort: `savePreferences` swallows its own write errors and never throws, so a read-only home can't fail the `setActive` RPC.

## Tests

- New integration test drives `providers.setActive` over RPC and asserts `preferences.json#providerName` is written. **Verified it fails without the fix, passes with it.**
- Green: `build` (55/55), `typecheck` (105/105), and `runner` (37), `desktop-host` (120), `core` (196), `cli` (62) test suites.