### PR TITLE
feat(desktop): send all attached files to the model for analysis

### DIFF
--- a/apps/desktop/src/chat/blocks/EventBlockView.tsx
+++ b/apps/desktop/src/chat/blocks/EventBlockView.tsx
@@ -5,12 +5,7 @@ import { AssistantBlock } from './AssistantBlock';
 export function EventBlockView({ event }: { readonly event: MoxxyEvent }): JSX.Element | null {
   switch (event.type) {
     case 'user_prompt':
-      return (
-        <UserBlock
-          text={event.text}
-          attachments={event.attachments?.map((a) => a.name ?? a.kind)}
-        />
-      );
+      return <UserBlock text={event.text} attachments={event.attachments} />;
     case 'assistant_message':
       return <AssistantBlock text={event.content} streaming={false} stopReason={event.stopReason} />;
     case 'error':

--- a/apps/desktop/src/chat/blocks/UserBlock.tsx
+++ b/apps/desktop/src/chat/blocks/UserBlock.tsx
@@ -1,13 +1,84 @@
+import type { UserPromptAttachment } from '@moxxy/sdk';
 import { Icon } from '@moxxy/desktop-ui';
+
+/** Rough byte size of an attachment's payload, for the chip label. Base64
+ *  (image/document) decodes to ~3/4 its length; inline text is its own length. */
+function payloadBytes(att: UserPromptAttachment): number {
+  if (att.kind === 'image' || att.kind === 'document') {
+    return Math.floor((att.content.length * 3) / 4);
+  }
+  return att.content.length;
+}
+
+function humanSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function ImageThumb({ att }: { readonly att: UserPromptAttachment }): JSX.Element {
+  return (
+    <img
+      src={`data:${att.mediaType ?? 'image/png'};base64,${att.content}`}
+      alt={att.name ?? 'attached image'}
+      title={att.name}
+      style={{
+        maxWidth: 180,
+        maxHeight: 180,
+        borderRadius: 12,
+        border: '1px solid var(--color-card-border)',
+        objectFit: 'cover',
+        boxShadow: '0 6px 18px -12px rgba(0,0,0,0.5)',
+      }}
+    />
+  );
+}
+
+function FileChip({ att }: { readonly att: UserPromptAttachment }): JSX.Element {
+  const label = att.name ?? att.kind;
+  return (
+    <span
+      title={`${label} · ${humanSize(payloadBytes(att))}`}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '4px 10px',
+        background: '#fff',
+        border: '1px solid var(--color-primary)',
+        borderRadius: 999,
+        fontSize: 12,
+        color: 'var(--color-primary-strong)',
+        fontWeight: 600,
+        maxWidth: 280,
+      }}
+    >
+      <Icon name="attach" size={12} />
+      <span
+        className="mono"
+        style={{
+          maxWidth: 200,
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        {label}
+      </span>
+      <span style={{ opacity: 0.6, fontWeight: 500 }}>{humanSize(payloadBytes(att))}</span>
+    </span>
+  );
+}
 
 export function UserBlock({
   text,
   attachments,
 }: {
   readonly text: string;
-  readonly attachments?: ReadonlyArray<string>;
+  readonly attachments?: ReadonlyArray<UserPromptAttachment>;
 }): JSX.Element {
-  const hasAttachments = (attachments?.length ?? 0) > 0;
+  const items = attachments ?? [];
+  const hasAttachments = items.length > 0;
   return (
     <div
       data-testid="block-user"
@@ -21,39 +92,22 @@ export function UserBlock({
       }}
     >
       {hasAttachments && (
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, justifyContent: 'flex-end' }}>
-          {attachments!.map((name, i) => (
-            <span
-              key={`${name}-${i}`}
-              title={name}
-              style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 6,
-                padding: '4px 10px',
-                background: '#fff',
-                border: '1px solid var(--color-primary)',
-                borderRadius: 999,
-                fontSize: 12,
-                color: 'var(--color-primary-strong)',
-                fontWeight: 600,
-                maxWidth: 280,
-              }}
-            >
-              <Icon name="attach" size={12} />
-              <span
-                className="mono"
-                style={{
-                  maxWidth: 220,
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-              >
-                @{name}
-              </span>
-            </span>
-          ))}
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 6,
+            justifyContent: 'flex-end',
+            alignItems: 'flex-end',
+          }}
+        >
+          {items.map((att, i) =>
+            att.kind === 'image' ? (
+              <ImageThumb key={`${att.name ?? 'img'}-${i}`} att={att} />
+            ) : (
+              <FileChip key={`${att.name ?? att.kind}-${i}`} att={att} />
+            ),
+          )}
         </div>
       )}
       {(text.length > 0 || !hasAttachments) && (

--- a/packages/desktop-host/package.json
+++ b/packages/desktop-host/package.json
@@ -31,7 +31,8 @@
     "@moxxy/plugin-stt-whisper-codex": "workspace:*",
     "@moxxy/plugin-vault": "workspace:*",
     "@moxxy/runner": "workspace:*",
-    "@moxxy/sdk": "workspace:*"
+    "@moxxy/sdk": "workspace:*",
+    "officeparser": "~5.1.1"
   },
   "devDependencies": {
     "@moxxy/core": "workspace:*",

--- a/packages/desktop-host/src/attachments.test.ts
+++ b/packages/desktop-host/src/attachments.test.ts
@@ -1,17 +1,31 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { readFile, unlink } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, unlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
-import { persistImageBlob } from './attachments';
+import { buildAttachments, persistImageBlob } from './attachments';
 
 /** Temp files persistImageBlob writes; cleaned up after each test. */
 const written: string[] = [];
+/** Temp dirs buildAttachments tests write inputs into. */
+const tmpDirs: string[] = [];
 
 afterEach(async () => {
   await Promise.all(written.map((p) => unlink(p).catch(() => {})));
   written.length = 0;
+  await Promise.all(tmpDirs.map((d) => rm(d, { recursive: true, force: true }).catch(() => {})));
+  tmpDirs.length = 0;
 });
 
 const b64 = (bytes: Buffer): string => bytes.toString('base64');
+
+/** Write `bytes` to a fresh temp file named `name`, returning {path, name}. */
+async function tmpFile(name: string, bytes: Buffer | string): Promise<{ path: string; name: string }> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'moxxy-attach-test-'));
+  tmpDirs.push(dir);
+  const p = path.join(dir, name);
+  await writeFile(p, bytes);
+  return { path: p, name };
+}
 
 describe('persistImageBlob', () => {
   it('writes the bytes to a temp file and returns a path + name', async () => {
@@ -53,5 +67,70 @@ describe('persistImageBlob', () => {
   it('rejects blobs over the size cap', async () => {
     const tooBig = Buffer.alloc(8 * 1024 * 1024 + 1);
     await expect(persistImageBlob(b64(tooBig), 'image/png')).rejects.toThrow(/too large/i);
+  });
+});
+
+describe('buildAttachments', () => {
+  it('reads an image as a base64 image attachment', async () => {
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const out = await buildAttachments([await tmpFile('pic.png', bytes)]);
+    expect(out).toEqual([
+      { kind: 'image', content: bytes.toString('base64'), mediaType: 'image/png', name: 'pic.png' },
+    ]);
+  });
+
+  it('reads a PDF within the native limit as a base64 document', async () => {
+    const bytes = Buffer.from('%PDF-1.4\n…tiny pdf bytes…');
+    const out = await buildAttachments([await tmpFile('report.pdf', bytes)]);
+    expect(out).toEqual([
+      {
+        kind: 'document',
+        content: bytes.toString('base64'),
+        mediaType: 'application/pdf',
+        name: 'report.pdf',
+      },
+    ]);
+  });
+
+  it('detects a PDF by magic bytes even with a misleading extension', async () => {
+    const bytes = Buffer.from('%PDF-1.7\nstuff');
+    const out = await buildAttachments([await tmpFile('notes.dat', bytes)]);
+    expect(out[0]).toMatchObject({ kind: 'document', mediaType: 'application/pdf' });
+  });
+
+  it('inlines a small text/code file as a file attachment', async () => {
+    const out = await buildAttachments([await tmpFile('main.ts', 'export const x = 1;\n')]);
+    expect(out).toEqual([{ kind: 'file', content: 'export const x = 1;\n', name: 'main.ts' }]);
+  });
+
+  it('skips an unknown binary file (NUL bytes) rather than inlining garbage', async () => {
+    const bytes = Buffer.from([0x00, 0x01, 0x02, 0x00, 0xff]);
+    const out = await buildAttachments([await tmpFile('blob.bin', bytes)]);
+    expect(out).toEqual([]);
+  });
+
+  it('skips a corrupt Office file instead of failing the turn', async () => {
+    // Not a real OOXML zip — officeparser fails, so it is dropped.
+    const out = await buildAttachments([await tmpFile('broken.docx', 'not a real docx')]);
+    expect(out).toEqual([]);
+  });
+
+  it('falls back to a head excerpt + read-on-demand note for an oversized text file', async () => {
+    const big = 'A'.repeat(600 * 1024); // > 512 KB inline cap
+    const input = await tmpFile('huge.log', big);
+    const out = await buildAttachments([input]);
+    expect(out).toHaveLength(1);
+    const att = out[0]!;
+    expect(att.kind).toBe('file');
+    expect(att.name).toBe('huge.log');
+    // Only a preview is inlined, plus a note pointing at the original path.
+    expect(att.content.length).toBeLessThan(big.length);
+    expect(att.content).toContain(input.path);
+    expect(att.content).toMatch(/read_file|grep/i);
+  });
+
+  it('drops an unreadable path without throwing', async () => {
+    const out = await buildAttachments([{ path: '/no/such/file.txt', name: 'file.txt' }]);
+    expect(out).toEqual([]);
   });
 });

--- a/packages/desktop-host/src/attachments.ts
+++ b/packages/desktop-host/src/attachments.ts
@@ -2,12 +2,20 @@
  * Turn picked file paths into real {@link UserPromptAttachment}s.
  *
  * The renderer can only hand us a path (no fs access), but the model needs the
- * actual payload: base64 bytes for an image, inline text for a text/code file.
- * Earlier the desktop shipped the *path string* as the attachment `content`,
- * so the model saw `[file foo.png]\n/Users/…/foo.png` and the attachment was
- * effectively ignored. This reads the file in the main process and builds the
- * correct attachment — images as `image`, everything text-like as `file` —
- * skipping anything binary, oversized, or unreadable.
+ * actual payload. This reads the file in the main process and builds the right
+ * attachment so every file type reaches the model for analysis:
+ *
+ *   - images           → `image` (base64) — the model sees the pixels
+ *   - PDFs (≤32 MB)    → `document` (base64) — read natively (text + figures)
+ *   - Office / ODF     → `file` (text extracted via officeparser)
+ *   - text / code      → `file` (inline UTF-8)
+ *   - oversized files  → `file` with a head excerpt + a note pointing the agent
+ *                        at a path it can `read_file`/`grep` on demand
+ *                        (see {@link largeFileFallback})
+ *
+ * Anything truly binary/unsupported, or unreadable, is skipped (with a warn)
+ * rather than inlined as garbage. Earlier the desktop dropped every binary file
+ * silently, so PDFs/Word/Excel never reached the model at all.
  *
  * It also owns {@link persistImageBlob}: pasted/dropped images arrive as raw
  * bytes (no path), so we stash them in a temp file and hand back a path the
@@ -19,6 +27,7 @@ import { mkdir, readFile, readdir, stat, unlink, writeFile } from 'node:fs/promi
 import os from 'node:os';
 import path from 'node:path';
 import type { UserPromptAttachment } from '@moxxy/sdk';
+import { parseOfficeAsync } from 'officeparser';
 
 /** Image extensions we forward as inline base64 with a real mediaType. */
 const IMAGE_MEDIA_TYPES: Readonly<Record<string, string>> = {
@@ -30,33 +39,141 @@ const IMAGE_MEDIA_TYPES: Readonly<Record<string, string>> = {
   '.bmp': 'image/bmp',
 };
 
+/** Office / OpenDocument formats officeparser can extract text from. */
+const OFFICE_EXTENSIONS: ReadonlySet<string> = new Set([
+  '.docx',
+  '.xlsx',
+  '.pptx',
+  '.odt',
+  '.ods',
+  '.odp',
+]);
+
 /** Caps so a renderer-chosen file can't OOM the main process / blow the prompt. */
-const MAX_TEXT_BYTES = 512 * 1024; // 512 KB of text
+const MAX_TEXT_BYTES = 512 * 1024; // 512 KB inlined directly; larger → agentic fallback
 const MAX_IMAGE_BYTES = 8 * 1024 * 1024; // 8 MB image
+/** Anthropic's native PDF ceiling. Larger PDFs fall back to text extraction. */
+const MAX_PDF_NATIVE_BYTES = 32 * 1024 * 1024; // 32 MB
+/** How much of an oversized file we inline before pointing at the full copy. */
+const HEAD_EXCERPT_BYTES = 8 * 1024; // 8 KB preview
+
+function isPdf(buf: Buffer, ext: string): boolean {
+  return ext === '.pdf' || (buf.length >= 5 && buf.toString('latin1', 0, 5) === '%PDF-');
+}
+
+/** Extract plain text from an Office/ODF/PDF buffer. Returns null on failure
+ *  (corrupt / unsupported / empty) so the caller can skip rather than throw. */
+async function extractText(buf: Buffer, name: string): Promise<string | null> {
+  try {
+    const text = await parseOfficeAsync(buf, { outputErrorToConsole: false });
+    return typeof text === 'string' && text.trim().length > 0 ? text : null;
+  } catch (e) {
+    console.warn(`[attachments] could not extract text from ${name}: ${(e as Error).message}`);
+    return null;
+  }
+}
 
 export async function buildAttachments(
   files: ReadonlyArray<{ path: string; name: string }>,
 ): Promise<UserPromptAttachment[]> {
   const out: UserPromptAttachment[] = [];
   for (const f of files) {
-    const mediaType = IMAGE_MEDIA_TYPES[path.extname(f.path).toLowerCase()];
+    const ext = path.extname(f.path).toLowerCase();
     try {
       const buf = await readFile(f.path);
+      const mediaType = IMAGE_MEDIA_TYPES[ext];
+
+      // 1. Image → base64 the model can see.
       if (mediaType) {
-        if (buf.byteLength > MAX_IMAGE_BYTES) continue;
+        if (buf.byteLength > MAX_IMAGE_BYTES) {
+          console.warn(`[attachments] skipping ${f.name}: image exceeds ${MAX_IMAGE_BYTES} bytes`);
+          continue;
+        }
         out.push({ kind: 'image', content: buf.toString('base64'), mediaType, name: f.name });
-      } else {
-        // Text-like only: skip oversized and binary (NUL byte) files so we
-        // never inline garbage the model can't use.
-        if (buf.byteLength > MAX_TEXT_BYTES) continue;
-        if (buf.includes(0)) continue;
+        continue;
+      }
+
+      // 2. PDF → native document block if within the provider limit, else
+      //    extract text and fall back so even a huge PDF stays analyzable.
+      if (isPdf(buf, ext)) {
+        if (buf.byteLength <= MAX_PDF_NATIVE_BYTES) {
+          out.push({
+            kind: 'document',
+            content: buf.toString('base64'),
+            mediaType: 'application/pdf',
+            name: f.name,
+          });
+        } else {
+          const text = await extractText(buf, f.name);
+          if (text) out.push(await largeFileFallback(text, f.name, null));
+          else
+            console.warn(
+              `[attachments] skipping ${f.name}: PDF >${MAX_PDF_NATIVE_BYTES} bytes and no extractable text`,
+            );
+        }
+        continue;
+      }
+
+      // 3. Office / OpenDocument → extract text, inline or fall back by size.
+      if (OFFICE_EXTENSIONS.has(ext)) {
+        const text = await extractText(buf, f.name);
+        if (!text) continue; // already warned
+        if (Buffer.byteLength(text, 'utf8') <= MAX_TEXT_BYTES) {
+          out.push({ kind: 'file', content: text, name: f.name });
+        } else {
+          out.push(await largeFileFallback(text, f.name, null));
+        }
+        continue;
+      }
+
+      // 4. Text / code → inline, or fall back to the file itself when large.
+      if (buf.includes(0)) {
+        console.warn(`[attachments] skipping ${f.name}: looks binary / unsupported`);
+        continue;
+      }
+      if (buf.byteLength <= MAX_TEXT_BYTES) {
         out.push({ kind: 'file', content: buf.toString('utf8'), name: f.name });
+      } else {
+        // The original file is already readable text — point the agent at it
+        // rather than copying it into a temp file.
+        out.push(await largeFileFallback(buf.toString('utf8'), f.name, f.path));
       }
     } catch {
       // Unreadable (gone / permission) → drop it rather than fail the turn.
     }
   }
   return out;
+}
+
+/**
+ * Build a `file` attachment for content too large to inline every turn. The
+ * model gets a head excerpt plus a note telling it where the full text lives so
+ * it can `read_file`/`grep` the rest on demand (agentic retrieval — no
+ * embeddings). `sourcePath` is the original file when it's already readable
+ * text; otherwise (PDF/Office text extraction) we persist a temp `.txt` the
+ * same TTL sweep prunes.
+ */
+async function largeFileFallback(
+  fullText: string,
+  name: string,
+  sourcePath: string | null,
+): Promise<UserPromptAttachment> {
+  let readablePath = sourcePath;
+  if (!readablePath) {
+    await mkdir(ATTACHMENT_TMP_DIR, { recursive: true });
+    void pruneOldAttachments();
+    const safe = path.basename(name).replace(/[^\w.-]+/g, '_') || 'attachment';
+    readablePath = path.join(ATTACHMENT_TMP_DIR, `${randomUUID()}-${safe}.txt`);
+    await writeFile(readablePath, fullText, 'utf8');
+  }
+  const head = fullText.slice(0, HEAD_EXCERPT_BYTES);
+  const kb = Math.max(1, Math.round(fullText.length / 1024));
+  const approxTokens = Math.round(fullText.length / 4);
+  const note =
+    `\n\n[Preview only — "${name}" is large (~${kb} KB, ~${approxTokens} tokens); ` +
+    `the text above is just the beginning. The full text is saved at:\n  ${readablePath}\n` +
+    `Use your file tools (read_file with an offset, or grep) on that path to read or search the rest.]`;
+  return { kind: 'file', content: head + note, name };
 }
 
 /** MIME type → file extension for the image blobs we accept on paste. */

--- a/packages/desktop-host/src/ipc/session.ts
+++ b/packages/desktop-host/src/ipc/session.ts
@@ -152,13 +152,15 @@ export function registerSessionHandlers(pool: RunnerPool): void {
     const result = await dialog.showOpenDialog(window ?? null!, {
       title: 'Attach a file to the next prompt',
       properties: ['openFile'],
-      // Restrict to what the agent can actually use: images + text/code.
-      // buildAttachments is the real gate (it drops binary/oversized), but
-      // the filter steers the picker so the user doesn't pick a 4 GB video.
+      // Steer the picker toward what the agent can actually use: documents,
+      // images, and text/code. buildAttachments is the real gate (it reads the
+      // bytes and routes / drops as needed), but the filter keeps the user from
+      // picking a 4 GB video.
       filters: [
         {
           name: 'Attachable files',
           extensions: [
+            'pdf', 'docx', 'xlsx', 'pptx', 'odt', 'ods', 'odp',
             'png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp',
             'txt', 'md', 'markdown', 'json', 'yaml', 'yml', 'csv', 'tsv', 'log', 'sql',
             'js', 'jsx', 'ts', 'tsx', 'py', 'rb', 'go', 'rs', 'java', 'kt', 'c', 'h',
@@ -166,6 +168,7 @@ export function registerSessionHandlers(pool: RunnerPool): void {
             'xml', 'toml', 'ini', 'env', 'conf',
           ],
         },
+        { name: 'Documents', extensions: ['pdf', 'docx', 'xlsx', 'pptx', 'odt', 'ods', 'odp'] },
         { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp'] },
         { name: 'All files', extensions: ['*'] },
       ],

--- a/packages/plugin-provider-anthropic/src/provider.ts
+++ b/packages/plugin-provider-anthropic/src/provider.ts
@@ -17,9 +17,9 @@ export interface AnthropicProviderConfig {
 }
 
 export const anthropicModels: ReadonlyArray<ModelDescriptor> = [
-  { id: 'claude-opus-4-7', contextWindow: 800_000, maxOutputTokens: 8000, supportsTools: true, supportsStreaming: true, supportsImages: true },
-  { id: 'claude-sonnet-4-6', contextWindow: 200_000, maxOutputTokens: 8000, supportsTools: true, supportsStreaming: true, supportsImages: true },
-  { id: 'claude-haiku-4-5-20251001', contextWindow: 200_000, maxOutputTokens: 8000, supportsTools: true, supportsStreaming: true, supportsImages: true },
+  { id: 'claude-opus-4-7', contextWindow: 800_000, maxOutputTokens: 8000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'claude-sonnet-4-6', contextWindow: 200_000, maxOutputTokens: 8000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'claude-haiku-4-5-20251001', contextWindow: 200_000, maxOutputTokens: 8000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
 ];
 
 export class AnthropicProvider implements LLMProvider {

--- a/packages/plugin-provider-anthropic/src/translate.test.ts
+++ b/packages/plugin-provider-anthropic/src/translate.test.ts
@@ -26,6 +26,39 @@ describe('toAnthropicMessages', () => {
     expect(messages[1].content[0]).toMatchObject({ type: 'tool_use', id: 'c1', name: 'Read' });
   });
 
+  it('translates an image block to a base64 image source', () => {
+    const { messages } = toAnthropicMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'what is this?' },
+          { type: 'image', mediaType: 'image/png', data: 'AAAA' },
+        ],
+      },
+    ]);
+    expect(messages[0].content[1]).toEqual({
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'AAAA' },
+    });
+  });
+
+  it('translates a document block to a native base64 document with title', () => {
+    const { messages } = toAnthropicMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'summarize this' },
+          { type: 'document', mediaType: 'application/pdf', data: 'JVBERi0=', name: 'report.pdf' },
+        ],
+      },
+    ]);
+    expect(messages[0].content[1]).toEqual({
+      type: 'document',
+      source: { type: 'base64', media_type: 'application/pdf', data: 'JVBERi0=' },
+      title: 'report.pdf',
+    });
+  });
+
   it('merges adjacent tool_result messages into a user message', () => {
     const { messages } = toAnthropicMessages([
       { role: 'user', content: [{ type: 'text', text: 'q' }] },

--- a/packages/plugin-provider-anthropic/src/translate.ts
+++ b/packages/plugin-provider-anthropic/src/translate.ts
@@ -22,6 +22,12 @@ export type AnthropicContentBlock =
       type: 'image';
       source: { type: 'base64'; media_type: string; data: string };
       cache_control?: CacheControl;
+    }
+  | {
+      type: 'document';
+      source: { type: 'base64'; media_type: string; data: string };
+      title?: string;
+      cache_control?: CacheControl;
     };
 
 export interface AnthropicToolDef {
@@ -129,6 +135,13 @@ function toAnthropicBlock(block: ContentBlock): AnthropicContentBlock {
       return {
         type: 'image',
         source: { type: 'base64', media_type: block.mediaType, data: block.data },
+      };
+    case 'document':
+      // Native document support (PDF). Claude reads text + figures/layout.
+      return {
+        type: 'document',
+        source: { type: 'base64', media_type: block.mediaType, data: block.data },
+        ...(block.name ? { title: block.name } : {}),
       };
     case 'audio':
       // Anthropic's Messages API does not accept native audio yet. Channels

--- a/packages/plugin-provider-openai-codex/src/models.ts
+++ b/packages/plugin-provider-openai-codex/src/models.ts
@@ -7,12 +7,12 @@ import type { ModelDescriptor } from '@moxxy/sdk';
  * routes to ChatGPT-Pro/Plus subscribers without per-token billing.
  */
 export const codexModels: ReadonlyArray<ModelDescriptor> = [
-  { id: 'gpt-5.5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true },
-  { id: 'gpt-5.4', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true },
-  { id: 'gpt-5.4-mini', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true },
-  { id: 'gpt-5.3-codex', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true },
-  { id: 'gpt-5.3-codex-spark', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true },
-  { id: 'gpt-5.2', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true },
+  { id: 'gpt-5.5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-5.4', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-5.4-mini', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-5.3-codex', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-5.3-codex-spark', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-5.2', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
 ];
 
 export const DEFAULT_CODEX_MODEL = 'gpt-5.3-codex';

--- a/packages/plugin-provider-openai-codex/src/translate.test.ts
+++ b/packages/plugin-provider-openai-codex/src/translate.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { toResponsesInput } from './translate.js';
+
+describe('toResponsesInput', () => {
+  it('translates an image block to an input_image data URL', () => {
+    const input = toResponsesInput([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'what is this?' },
+          { type: 'image', mediaType: 'image/png', data: 'AAAA' },
+        ],
+      },
+    ]);
+    expect(input[0]).toEqual({
+      type: 'message',
+      role: 'user',
+      content: [
+        { type: 'input_text', text: 'what is this?' },
+        { type: 'input_image', image_url: 'data:image/png;base64,AAAA' },
+      ],
+    });
+  });
+
+  it('translates a document block to an input_file with data URL + filename', () => {
+    const input = toResponsesInput([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'summarize this' },
+          { type: 'document', mediaType: 'application/pdf', data: 'JVBERi0=', name: 'report.pdf' },
+        ],
+      },
+    ]);
+    expect(input[0]).toEqual({
+      type: 'message',
+      role: 'user',
+      content: [
+        { type: 'input_text', text: 'summarize this' },
+        { type: 'input_file', filename: 'report.pdf', file_data: 'data:application/pdf;base64,JVBERi0=' },
+      ],
+    });
+  });
+});

--- a/packages/plugin-provider-openai-codex/src/translate.ts
+++ b/packages/plugin-provider-openai-codex/src/translate.ts
@@ -14,7 +14,8 @@ type ResponsesInputItem =
 type ResponsesContent =
   | { type: 'input_text'; text: string }
   | { type: 'output_text'; text: string }
-  | { type: 'input_image'; image_url: string };
+  | { type: 'input_image'; image_url: string }
+  | { type: 'input_file'; filename?: string; file_data: string };
 
 interface ResponsesTool {
   type: 'function';
@@ -47,6 +48,12 @@ function contentBlocksToInputText(
       out.push(role === 'assistant' ? { type: 'output_text', text: block.text } : { type: 'input_text', text: block.text });
     } else if (block.type === 'image') {
       out.push({ type: 'input_image', image_url: `data:${block.mediaType};base64,${block.data}` });
+    } else if (block.type === 'document') {
+      out.push({
+        type: 'input_file',
+        ...(block.name ? { filename: block.name } : {}),
+        file_data: `data:${block.mediaType};base64,${block.data}`,
+      });
     }
   }
   return out;

--- a/packages/plugin-provider-openai/src/provider.ts
+++ b/packages/plugin-provider-openai/src/provider.ts
@@ -27,28 +27,28 @@ export interface OpenAIProviderConfig {
  */
 export const openAIModels: ReadonlyArray<ModelDescriptor> = [
   // GPT-5.5 family (released April 23, 2026): newest frontier class.
-  { id: 'gpt-5.5', contextWindow: 1_050_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true },
-  { id: 'gpt-5.5-pro', contextWindow: 1_050_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true },
+  { id: 'gpt-5.5', contextWindow: 1_050_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-5.5-pro', contextWindow: 1_050_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
 
   // GPT-5.4 family: cheaper general-purpose tier; -mini and -nano are the
   // new sweet-spot defaults for high-volume agentic workloads.
-  { id: 'gpt-5.4', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true },
-  { id: 'gpt-5.4-pro', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true },
-  { id: 'gpt-5.4-mini', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true },
-  { id: 'gpt-5.4-nano', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true },
+  { id: 'gpt-5.4', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-5.4-pro', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-5.4-mini', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-5.4-nano', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
 
   // GPT-5.3-Codex: agentic coding specialist. Vision-capable.
-  { id: 'gpt-5.3-codex', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true },
+  { id: 'gpt-5.3-codex', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
 
   // GPT-5.2 and GPT-5: prior reasoning models, configurable effort.
-  { id: 'gpt-5.2', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true },
-  { id: 'gpt-5', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true },
+  { id: 'gpt-5.2', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-5', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
 
   // GPT-4 family: kept for explicit-pin use cases.
-  // 4.1 is text-only; 4o/4o-mini/4-turbo are vision-capable.
+  // 4.1 is text-only; 4o/4o-mini are vision + document capable; 4-turbo predates file inputs.
   { id: 'gpt-4.1', contextWindow: 1_000_000, maxOutputTokens: 32_768, supportsTools: true, supportsStreaming: true },
-  { id: 'gpt-4o', contextWindow: 128_000, maxOutputTokens: 16_384, supportsTools: true, supportsStreaming: true, supportsImages: true },
-  { id: 'gpt-4o-mini', contextWindow: 128_000, maxOutputTokens: 16_384, supportsTools: true, supportsStreaming: true, supportsImages: true },
+  { id: 'gpt-4o', contextWindow: 128_000, maxOutputTokens: 16_384, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-4o-mini', contextWindow: 128_000, maxOutputTokens: 16_384, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
   { id: 'gpt-4-turbo', contextWindow: 128_000, maxOutputTokens: 4_096, supportsTools: true, supportsStreaming: true, supportsImages: true },
 ];
 

--- a/packages/plugin-provider-openai/src/translate.test.ts
+++ b/packages/plugin-provider-openai/src/translate.test.ts
@@ -60,6 +60,30 @@ describe('toOpenAIMessages', () => {
     ]);
   });
 
+  it('emits a file content part when a user message has a document', () => {
+    const out = toOpenAIMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'summarize this' },
+          { type: 'document', mediaType: 'application/pdf', data: 'JVBERi0=', name: 'report.pdf' },
+        ],
+      },
+    ]);
+    expect(out).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'summarize this' },
+          {
+            type: 'file',
+            file: { filename: 'report.pdf', file_data: 'data:application/pdf;base64,JVBERi0=' },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('keeps user content as plain text when no images are present', () => {
     const out = toOpenAIMessages([
       { role: 'user', content: [{ type: 'text', text: 'hello' }, { type: 'text', text: 'world' }] },

--- a/packages/plugin-provider-openai/src/translate.ts
+++ b/packages/plugin-provider-openai/src/translate.ts
@@ -3,7 +3,8 @@ import { zodToJsonSchema } from '@moxxy/sdk';
 
 export type OpenAIUserContentPart =
   | { type: 'text'; text: string }
-  | { type: 'image_url'; image_url: { url: string } };
+  | { type: 'image_url'; image_url: { url: string } }
+  | { type: 'file'; file: { filename?: string; file_data: string } };
 
 export interface OpenAIChatMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';
@@ -35,12 +36,13 @@ export function toOpenAIMessages(messages: ReadonlyArray<ProviderMessage>): Open
       continue;
     }
     if (msg.role === 'user') {
-      const hasImage = msg.content.some((c) => c.type === 'image');
-      if (hasImage) {
-        // Vision-capable user message: emit content as a parts array so
-        // base64 images ride alongside text. Non-vision OpenAI models
-        // will 400 on this shape — callers gate by `supportsImages` on
-        // the model descriptor before attaching images.
+      const hasRichPart = msg.content.some((c) => c.type === 'image' || c.type === 'document');
+      if (hasRichPart) {
+        // Vision/document user message: emit content as a parts array so
+        // base64 images and documents (PDFs) ride alongside text. Non-vision
+        // / non-document OpenAI models will 400 on this shape — callers gate
+        // by `supportsImages` / `supportsDocuments` on the model descriptor
+        // before attaching.
         const parts: OpenAIUserContentPart[] = [];
         for (const c of msg.content) {
           if (c.type === 'text') {
@@ -49,6 +51,14 @@ export function toOpenAIMessages(messages: ReadonlyArray<ProviderMessage>): Open
             parts.push({
               type: 'image_url',
               image_url: { url: `data:${c.mediaType};base64,${c.data}` },
+            });
+          } else if (c.type === 'document') {
+            parts.push({
+              type: 'file',
+              file: {
+                ...(c.name ? { filename: c.name } : {}),
+                file_data: `data:${c.mediaType};base64,${c.data}`,
+              },
             });
           }
         }

--- a/packages/sdk/src/compactor-helpers.ts
+++ b/packages/sdk/src/compactor-helpers.ts
@@ -58,8 +58,18 @@ export function estimateContextTokens(log: EventLogReader): number {
 
 function eventChars(e: MoxxyEvent): number {
   switch (e.type) {
-    case 'user_prompt':
-      return e.text.length;
+    case 'user_prompt': {
+      let n = e.text.length;
+      // Inlined text attachments (file/stdin — incl. text extracted from
+      // Office docs) cost real prompt tokens, so count them. Image/document
+      // bytes are tokenized specially by the provider; char-counting their
+      // base64 would wildly over-estimate (an 8 MB image ≈ millions of
+      // "tokens"), so skip those.
+      for (const att of e.attachments ?? []) {
+        if (att.kind === 'file' || att.kind === 'stdin') n += att.content.length;
+      }
+      return n;
+    }
     case 'assistant_message':
       return e.content.length;
     case 'tool_call_requested':

--- a/packages/sdk/src/events.ts
+++ b/packages/sdk/src/events.ts
@@ -13,19 +13,22 @@ export interface EventBase {
 }
 
 export interface UserPromptAttachment {
-  readonly kind: 'stdin' | 'file' | 'image' | 'audio';
+  readonly kind: 'stdin' | 'file' | 'image' | 'document' | 'audio';
   /**
-   * Inline payload. For images this is base64-encoded bytes; for audio it
-   * is either base64-encoded bytes (when the channel hands raw audio
-   * straight through to a model with `supportsAudio`) or the transcript
-   * (when the channel pre-transcribed via the session's Transcriber).
-   * Channels SHOULD set `name` to disambiguate the two; `mediaType` is
-   * required when carrying raw audio bytes.
+   * Inline payload. Depends on `kind`:
+   *   - `image` / `document` — base64-encoded bytes (a PDF is a `document`).
+   *   - `file` / `stdin` — inline UTF-8 text (a text/code file, or text
+   *     extracted from an Office doc). Oversized files carry a head excerpt
+   *     plus a note pointing at a path the agent can `read_file` on demand.
+   *   - `audio` — either base64-encoded bytes (when the channel hands raw
+   *     audio straight through to a model with `supportsAudio`) or the
+   *     transcript (when the channel pre-transcribed via the session's
+   *     Transcriber). Channels SHOULD set `name` to disambiguate the two.
    */
   readonly content: string;
   /** Human-readable label, e.g. the file path, `image.png`, or `voice.ogg`. */
   readonly name?: string;
-  /** MIME type — required for images and raw audio so providers translate correctly. */
+  /** MIME type — required for `image`, `document`, and raw `audio` so providers translate correctly. */
   readonly mediaType?: string;
 }
 

--- a/packages/sdk/src/mode-helpers.ts
+++ b/packages/sdk/src/mode-helpers.ts
@@ -267,6 +267,13 @@ export function projectMessages(
                 mediaType: att.mediaType ?? 'image/png',
                 data: att.content,
               });
+            } else if (att.kind === 'document') {
+              blocks.push({
+                type: 'document',
+                mediaType: att.mediaType ?? 'application/pdf',
+                data: att.content,
+                ...(att.name ? { name: att.name } : {}),
+              });
             } else {
               blocks.push({
                 type: 'text',

--- a/packages/sdk/src/provider.ts
+++ b/packages/sdk/src/provider.ts
@@ -10,7 +10,16 @@ export type ContentBlock =
   | { readonly type: 'tool_use'; readonly id: string; readonly name: string; readonly input: unknown }
   | { readonly type: 'tool_result'; readonly toolUseId: string; readonly content: string; readonly isError?: boolean }
   | { readonly type: 'image'; readonly mediaType: string; readonly data: string }
-  | { readonly type: 'audio'; readonly mediaType: string; readonly data: string };
+  | { readonly type: 'audio'; readonly mediaType: string; readonly data: string }
+  /**
+   * A document the model reads natively (e.g. a PDF). `data` is base64-encoded
+   * bytes and `mediaType` the document MIME (e.g. `application/pdf`). Providers
+   * that support documents translate it to their native shape (Anthropic
+   * `document`, OpenAI `file`, Responses `input_file`); those that don't degrade
+   * to a text placeholder. Text/Office files are inlined as `text` instead — only
+   * formats a model ingests as bytes become `document` blocks.
+   */
+  | { readonly type: 'document'; readonly mediaType: string; readonly data: string; readonly name?: string };
 
 /**
  * Provider-neutral instruction for where a prompt-cache breakpoint should be
@@ -68,6 +77,13 @@ export interface ModelDescriptor {
    * refuses or warns instead of silently dropping the bytes.
    */
   readonly supportsImages?: boolean;
+  /**
+   * Whether this model accepts `document` ContentBlocks (e.g. native PDF) in
+   * user messages. When false, the desktop reader extracts text instead of
+   * shipping the raw bytes, so the attachment still reaches the model — just
+   * without full-document fidelity (figures/layout).
+   */
+  readonly supportsDocuments?: boolean;
   /**
    * Whether this model accepts `audio` ContentBlocks in user messages
    * (GPT-4o, Gemini-Live-class models). When false, channels with audio

--- a/packages/sdk/src/token-efficiency.test.ts
+++ b/packages/sdk/src/token-efficiency.test.ts
@@ -457,3 +457,61 @@ describe('applyLazyTools', () => {
     expect(messages).toBe(baseMsgs); // same reference → byte-stable
   });
 });
+
+describe('attachment projection in projectMessagesFromLog', () => {
+  it('projects an image attachment to an image content block', () => {
+    const msgs = projectMessagesFromLog({
+      log: reader([
+        event(0, {
+          type: 'user_prompt',
+          turnId: t1,
+          source: 'user',
+          text: 'what is this?',
+          attachments: [{ kind: 'image', content: 'AAAA', mediaType: 'image/png', name: 'pic.png' }],
+        }),
+      ]),
+    });
+    expect(msgs[0].content).toEqual([
+      { type: 'text', text: 'what is this?' },
+      { type: 'image', mediaType: 'image/png', data: 'AAAA' },
+    ]);
+  });
+
+  it('projects a document attachment to a native document content block', () => {
+    const msgs = projectMessagesFromLog({
+      log: reader([
+        event(0, {
+          type: 'user_prompt',
+          turnId: t1,
+          source: 'user',
+          text: 'summarize this',
+          attachments: [
+            { kind: 'document', content: 'JVBERi0=', mediaType: 'application/pdf', name: 'r.pdf' },
+          ],
+        }),
+      ]),
+    });
+    expect(msgs[0].content).toEqual([
+      { type: 'text', text: 'summarize this' },
+      { type: 'document', mediaType: 'application/pdf', data: 'JVBERi0=', name: 'r.pdf' },
+    ]);
+  });
+
+  it('inlines a file attachment as a labeled text block', () => {
+    const msgs = projectMessagesFromLog({
+      log: reader([
+        event(0, {
+          type: 'user_prompt',
+          turnId: t1,
+          source: 'user',
+          text: 'review',
+          attachments: [{ kind: 'file', content: 'const x = 1;', name: 'a.ts' }],
+        }),
+      ]),
+    });
+    expect(msgs[0].content).toEqual([
+      { type: 'text', text: 'review' },
+      { type: 'text', text: '[file a.ts]\nconst x = 1;' },
+    ]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -570,6 +570,9 @@ importers:
       '@moxxy/sdk':
         specifier: workspace:*
         version: link:../sdk
+      officeparser:
+        specifier: ~5.1.1
+        version: 5.1.1
     devDependencies:
       '@moxxy/core':
         specifier: workspace:*
@@ -3478,6 +3481,9 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
   '@tootallnate/once@2.0.1':
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
@@ -3753,6 +3759,10 @@ packages:
 
   '@vscode/l10n@0.0.18':
     resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
+
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
@@ -4036,6 +4046,9 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
   builder-util-runtime@9.2.10:
     resolution: {integrity: sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==}
     engines: {node: '>=12.0.0'}
@@ -4254,6 +4267,10 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -4757,6 +4774,10 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
@@ -4833,6 +4854,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-type@16.5.4:
+    resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
+    engines: {node: '>=10'}
 
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
@@ -5938,6 +5963,9 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-ensure@0.0.0:
+    resolution: {integrity: sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==}
+
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
@@ -6000,6 +6028,10 @@ packages:
 
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
+
+  officeparser@5.1.1:
+    resolution: {integrity: sha512-trBCPmYQDFUCmch6YBxHhMFkDyhTl+vG8PDQHPOwRyeCDKnrrKpph2W7og7hg5T5RRF0yeyaOMasN7GZWbYuCA==}
+    hasBin: true
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
@@ -6155,6 +6187,10 @@ packages:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
     engines: {node: '>=12', npm: '>=6'}
 
+  peek-readable@4.1.0:
+    resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
+    engines: {node: '>=8'}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -6251,6 +6287,10 @@ packages:
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
 
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -6353,6 +6393,14 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readable-web-to-node-stream@3.0.4:
+    resolution: {integrity: sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==}
+    engines: {node: '>=8'}
 
   readdir-glob@1.1.3:
     resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
@@ -6776,6 +6824,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strtok3@6.3.0:
+    resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
+    engines: {node: '>=10'}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -6896,6 +6948,10 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  token-types@4.2.1:
+    resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
+    engines: {node: '>=10'}
+
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
@@ -6993,6 +7049,9 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
   typesafe-path@0.2.2:
     resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
@@ -7536,6 +7595,10 @@ packages:
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  yauzl@3.3.2:
+    resolution: {integrity: sha512-Md9ankxxN23wncAN8s7+Tn3Co52zLUPMtnrLAbVCnfG5d2tKBFfmygYSgXlqFgXObtzIgqkx7aNgDBpso9+4qA==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -8961,6 +9024,8 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@tokenizer/token@0.3.0': {}
+
   '@tootallnate/once@2.0.1': {}
 
   '@turbo/darwin-64@2.9.12':
@@ -9335,6 +9400,8 @@ snapshots:
       vscode-uri: 3.1.0
 
   '@vscode/l10n@0.0.18': {}
+
+  '@xmldom/xmldom@0.8.13': {}
 
   '@xmldom/xmldom@0.9.10': {}
 
@@ -9752,6 +9819,11 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   builder-util-runtime@9.2.10:
     dependencies:
       debug: 4.4.3
@@ -9981,6 +10053,13 @@ snapshots:
       readable-stream: 3.6.2
 
   concat-map@0.0.1: {}
+
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
 
   confbox@0.1.8: {}
 
@@ -10619,6 +10698,8 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  events@3.3.0: {}
+
   eventsource-parser@3.0.8: {}
 
   eventsource@3.0.7:
@@ -10718,6 +10799,12 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-type@16.5.4:
+    dependencies:
+      readable-web-to-node-stream: 3.0.4
+      strtok3: 6.3.0
+      token-types: 4.2.1
 
   filelist@1.0.6:
     dependencies:
@@ -12251,6 +12338,8 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-ensure@0.0.0: {}
+
   node-fetch-native@1.6.7: {}
 
   node-fetch@2.7.0(encoding@0.1.13):
@@ -12312,6 +12401,14 @@ snapshots:
       destr: 2.0.5
       node-fetch-native: 1.6.7
       ufo: 1.6.4
+
+  officeparser@5.1.1:
+    dependencies:
+      '@xmldom/xmldom': 0.8.13
+      concat-stream: 2.0.0
+      file-type: 16.5.4
+      node-ensure: 0.0.0
+      yauzl: 3.3.2
 
   ohash@2.0.11: {}
 
@@ -12491,6 +12588,8 @@ snapshots:
 
   pe-library@0.4.1: {}
 
+  peek-readable@4.1.0: {}
+
   pend@1.2.0: {}
 
   piccolore@0.1.3: {}
@@ -12565,6 +12664,8 @@ snapshots:
   prismjs@1.30.0: {}
 
   process-nextick-args@2.0.1: {}
+
+  process@0.11.10: {}
 
   progress@2.0.3: {}
 
@@ -12690,6 +12791,18 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readable-web-to-node-stream@3.0.4:
+    dependencies:
+      readable-stream: 4.7.0
 
   readdir-glob@1.1.3:
     dependencies:
@@ -13298,6 +13411,11 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strtok3@6.3.0:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      peek-readable: 4.1.0
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -13429,6 +13547,11 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  token-types@4.2.1:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
@@ -13531,6 +13654,8 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typedarray@0.0.6: {}
 
   typesafe-path@0.2.2: {}
 
@@ -14063,6 +14188,10 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+
+  yauzl@3.3.2:
+    dependencies:
+      pend: 1.2.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Problem

Attaching a file in the desktop app only worked for **images** and **plain text/code**. PDFs, Word, Excel, and other binaries were silently dropped by `buildAttachments`' NUL-byte guard (`if (buf.includes(0)) continue;`), so they never reached the model — and, having produced no attachment, left **no chip in the chat view** either. There was also no `document` content block anywhere in the SDK or the three providers.

## What this does

Every attachment now reaches the model, and each is rendered in chat.

- **SDK** — new `document` `ContentBlock`, a `supportsDocuments?` model flag, and a `'document'` `UserPromptAttachment` kind. `projectMessages` routes documents to the native block; the context-meter counts inlined text attachments but not base64 (which providers tokenize specially).
- **Providers (3)** — translate documents natively: Anthropic `document` block, OpenAI `file` content part, Codex/Responses `input_file`. `supportsDocuments` set on Claude + modern GPT models.
- **desktop-host** — `buildAttachments` now classifies instead of dropping: image → base64, **PDF (≤32 MB) → native document** (Claude reads it whole, figures and all), **Office/ODF → text extracted via `officeparser`**, text/code → inline. The picker now offers pdf/docx/xlsx/pptx/odt/ods/odp.
- **Desktop UI** — image **thumbnails** + **typed file chips** (icon, name, size) in the chat view.

### Large files (no embeddings)

Files up to ~100 pages go inline at full fidelity (native PDF cap = 100pp/32 MB; prompt caching makes re-sends cheap). Oversized files fall back to a head excerpt plus a note pointing the agent at a temp `.txt` it can `read_file`/`grep` on demand — lossless agentic retrieval, no vector index.

### Dependency note

`officeparser` is pinned `~5.1.1` **on purpose**: v5.2+/6/7 pull in `pdfjs-dist` then `tesseract.js` (a heavy WASM OCR engine) we don't need. 5.1.1 is pure-JS (`yauzl` + `@xmldom/xmldom`), vendors its own pdfjs build, and extracts docx/xlsx/pptx/odt/ods/odp + PDF text.

## Tests

Added/extended coverage for the three provider translators (`document` → native shape), `buildAttachments` classification + oversized fallback + binary/corrupt skips, and `projectMessages` projection. `build` (55/55), `typecheck` (105/105), `lint` (0 errors), and `test` (103/103) all green.

## Verification still to do

Manual: launch the desktop app on the Anthropic provider, attach a PDF, a `.docx`/`.xlsx`, and an image, and confirm each renders and the model answers from its content.