### PR TITLE
chore: add missing changeset for document-attachment support

### DIFF
--- a/.changeset/attachments-to-model.md
+++ b/.changeset/attachments-to-model.md
@@ -1,0 +1,12 @@
+---
+"@moxxy/sdk": minor
+"@moxxy/cli": patch
+---
+
+Support sending documents (PDFs, Office/text) to the model. Adds a `document`
+`ContentBlock`, a `supportsDocuments` flag on `ModelDescriptor`, and a
+`'document'` `UserPromptAttachment` kind; `projectMessages` routes document
+attachments to the native block. The Anthropic, OpenAI, and Codex providers
+translate documents to their native shapes (Anthropic `document`, OpenAI
+`file`, Responses `input_file`), so attached files now reach the model for
+analysis instead of being dropped.


### PR DESCRIPTION
Follow-up to #79. That PR was squash-merged at its pre-changeset head SHA (GitHub's PR head pointer was lagging a few seconds behind the branch after the push), so the `.changeset/` entry was dropped from the squash and never reached `main`. The feature code is on `main`; only the changeset is missing — which means no version bump / npm publish / desktop release would fire for it.

This PR adds just that changeset:

- `@moxxy/sdk` → **minor** (new `document` `ContentBlock`, `supportsDocuments` flag, `'document'` attachment kind)
- `@moxxy/cli` → patch (re-bundles the SDK + providers)

`changeset status` confirms the bumps. No code changes — diff is the single `.changeset/*.md` file.