### PR TITLE
fix(ci): don't cut a desktop release tag during the Version-PR run

### DIFF
--- a/.changeset/fix-desktop-release-premature-tag.md
+++ b/.changeset/fix-desktop-release-premature-tag.md
@@ -1,0 +1,11 @@
+---
+---
+
+chore(ci): stop the release pipeline from cutting a desktop tag during a
+Version-PR (mode-1) run. `changesets/action`'s `version` command bumps
+`apps/desktop/package.json` in the working tree before the "Cut desktop release"
+step reads it, so the step tagged `desktop-v<next>` prematurely while the build
+job (checking out the un-bumped commit) shipped lower-versioned artifacts — and
+no `moxxy-app-bundle-<next>.json.gz` — under that tag, 404-ing the self-updater.
+Gate the cut on `hasChangesets == 'false'` and pin the desktop build/guard
+checkouts to the cut tag. CI-only; releases nothing.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
         run: pnpm build
 
       - name: Create Release PR or publish
+        id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm dlx @changesets/cli@2.27.10 version
@@ -88,16 +89,26 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Decide whether to cut a desktop release. The desktop version on main is
-      # the source of truth: if there is no `desktop-v<version>` tag yet, this
-      # bump hasn't been released. (On a mode-1 run that only opens the Version
-      # PR, main still carries the old, already-tagged version, so this is a
-      # cheap no-op.) Pushing the tag here gives the build + GitHub Release a
-      # stable name; the desktop jobs below are gated by the `release` output,
-      # NOT by the tag — so there's no cross-workflow dispatch to coax past
-      # GitHub's "GITHUB_TOKEN tag pushes don't start runs" guard.
+      # Decide whether to cut a desktop release. The desktop version COMMITTED on
+      # main is the source of truth: if there is no `desktop-v<version>` tag yet,
+      # this bump hasn't been released. Pushing the tag here gives the build +
+      # GitHub Release a stable name; the desktop jobs below are gated by the
+      # `release` output, NOT by the tag — so there's no cross-workflow dispatch
+      # to coax past GitHub's "GITHUB_TOKEN tag pushes don't start runs" guard.
+      #
+      # GUARD (`hasChangesets == 'false'`): only run on a publish run, never on a
+      # mode-1 run that just opened/updated the Version PR. In mode 1 the `version`
+      # command above has ALREADY bumped apps/desktop/package.json IN THE WORKING
+      # TREE to the next, still-unreleased version — reading it here would tag
+      # `desktop-v<next>` prematurely while the desktop-build job (which checks out
+      # the un-bumped commit) ships lower-versioned artifacts under that tag. That
+      # is exactly how desktop-v0.0.17 ended up carrying 0.0.16 builds (and a
+      # missing moxxy-app-bundle-0.0.17.json.gz → updater 404). When
+      # `hasChangesets == 'false'` the Version PR has merged (or there was nothing
+      # to version): the working tree equals main HEAD, so the version is real.
       - name: Cut desktop release on version bump
         id: cut
+        if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           version="$(node -p "require('./apps/desktop/package.json').version")"
           tag="desktop-v$version"
@@ -126,7 +137,11 @@ jobs:
     if: needs.version-publish.outputs.desktop-release == 'true'
     runs-on: ubuntu-latest
     steps:
+      # Check out the EXACT tagged commit, not main's HEAD — so the guard scans
+      # (and every desktop job builds from) precisely what ships under this tag.
       - uses: actions/checkout@v4
+        with:
+          ref: desktop-v${{ needs.version-publish.outputs.desktop-version }}
       # A pk_live_ Clerk key must never live in the repo (only the public
       # pk_test_ belongs in .env.example). Fail loudly if one slips in.
       - name: Scan for a live Clerk key
@@ -154,7 +169,12 @@ jobs:
           - os: ubuntu-latest
             artifact: deb-appimage
     steps:
+      # Build from the EXACT tagged commit so artifact versions (installers, the
+      # self-update bundle name, and the manifest) always match the
+      # desktop-v<version> tag — never main's HEAD, which may have moved on.
       - uses: actions/checkout@v4
+        with:
+          ref: desktop-v${{ needs.version-publish.outputs.desktop-version }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Problem

Updating the desktop app fails with **`bundle download failed (HTTP 404) [v0.0.16]`**.

The combined release pipeline (`release.yml`) cut **`desktop-v0.0.17`** carrying **`0.0.16`** artifacts, with **no** `moxxy-app-bundle-0.0.17.json.gz`. The self-updater picks the highest `desktop-v*` tag (`0.0.17`), derives the bundle asset name from it, and 404s on a file that was never built.

## Root cause

The "Cut desktop release" step reads `apps/desktop/package.json` from the **working tree**. On a **mode-1** run (pending changesets), the preceding `changesets/action` `version` command has already bumped that file to the next, still-unreleased version. So the step tagged `desktop-v<next>` prematurely, while `desktop-build` (which checks out the un-bumped commit) produced lower-versioned artifacts and a manifest pointing at the previous version.

Run log proof (first run of the new pipeline, #83 merge):

> `Desktop bumped to 0.0.17 with no desktop-v0.0.17 tag — releasing.`

…while `main`'s `apps/desktop/package.json` was — and still is — `0.0.16`.

## Fix

- **Gate the cut** on `steps.changesets.outputs.hasChangesets == 'false'` — only tag when the working tree equals `main` HEAD (Version PR merged, or nothing to version), never mid-bump.
- **Pin** `desktop-build` and `desktop-guard` checkouts to `ref: desktop-v<version>`, so built artifacts can never diverge from the tag again.

## Remediation already applied (outside this PR)

The corrupt **`desktop-v0.0.17`** release + tag and the stale **`desktop-v0.0.15`** draft were deleted, so the newest desktop release is the consistent **`v0.0.16`** and existing clients update cleanly again.

## Changeset

Empty (CI-only; releases nothing).