### PR TITLE
fix(desktop): un-poison a bundle version on explicit reinstall (hot-update never sticks)

### DIFF
--- a/.changeset/desktop-update-poison-stuck.md
+++ b/.changeset/desktop-update-poison-stuck.md
@@ -1,0 +1,13 @@
+---
+"@moxxy/desktop": patch
+---
+
+fix(desktop): a hot-update that failed to boot once could never be installed
+again. The bootstrap poisons a bundle version (adds it to `bad.json`) when its
+renderer doesn't confirm a healthy mount in time, but nothing ever cleared that
+mark — so every later "download + restart" re-staged the same version,
+`resolveActiveBundle` rejected it as poisoned, and the app silently fell back to
+the packaged floor ("downloads, but restart still shows the old version").
+`downloadAndStage` now clears the poison mark for the version it installs, since
+an explicit user (re)install is a deliberate retry; the boot-probe still
+re-poisons a genuinely broken bundle, so this only ever grants one fresh attempt.

--- a/packages/desktop-host/src/app-update/index.ts
+++ b/packages/desktop-host/src/app-update/index.ts
@@ -29,6 +29,7 @@ export {
   setActiveVersion,
   readBadVersions,
   markBad,
+  unmarkBad,
   writeBreadcrumb,
   readBreadcrumb,
   markConfirmed,

--- a/packages/desktop-host/src/app-update/resolve.test.ts
+++ b/packages/desktop-host/src/app-update/resolve.test.ts
@@ -13,6 +13,7 @@ import {
   setActiveVersion,
   readActiveVersion,
   markBad,
+  unmarkBad,
   readBadVersions,
   writeBreadcrumb,
   markConfirmed,
@@ -123,6 +124,35 @@ describe('markBad', () => {
     markBad(tmp, '0.0.6');
     expect(readBadVersions(tmp).has('0.0.6')).toBe(true);
     expect(resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL })).toBeNull();
+  });
+});
+
+describe('unmarkBad', () => {
+  it('removes a version from the bad set so a reinstall can load it again', () => {
+    installBundle('0.0.6');
+    markBad(tmp, '0.0.6'); // poisoned by a prior failed boot
+    expect(readBadVersions(tmp).has('0.0.6')).toBe(true);
+
+    // Re-stage it (markBad cleared `active`, so point it back as a reinstall would).
+    setActiveVersion(tmp, '0.0.6');
+    unmarkBad(tmp, '0.0.6');
+
+    expect(readBadVersions(tmp).has('0.0.6')).toBe(false);
+    // The previously-wedged version is loadable again.
+    expect(resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL })?.version).toBe(
+      '0.0.6',
+    );
+  });
+
+  it('leaves other poisoned versions intact and is a no-op when not poisoned', () => {
+    markBad(tmp, '0.0.5');
+    markBad(tmp, '0.0.6');
+    unmarkBad(tmp, '0.0.6');
+    expect(readBadVersions(tmp).has('0.0.6')).toBe(false);
+    expect(readBadVersions(tmp).has('0.0.5')).toBe(true);
+    // No-op for a version that was never poisoned.
+    unmarkBad(tmp, '9.9.9');
+    expect(readBadVersions(tmp).has('0.0.5')).toBe(true);
   });
 });
 

--- a/packages/desktop-host/src/app-update/resolve.ts
+++ b/packages/desktop-host/src/app-update/resolve.ts
@@ -112,6 +112,19 @@ export function markBad(userDataDir: string, version: string): void {
   }
 }
 
+/** Clear a version's poison mark. Called when the user EXPLICITLY (re)installs
+ *  that version, so a one-off failed boot — e.g. a slow first render that tripped
+ *  the boot-probe, or a transient white-screen — can't wedge it as permanently
+ *  unloadable: without this, the freshly re-staged copy is rejected by
+ *  {@link resolveActiveBundle} on the very next launch and the app silently stays
+ *  on the floor forever. The boot-probe still re-poisons the version if the fresh
+ *  copy is genuinely broken, so this only ever grants ONE more attempt. */
+export function unmarkBad(userDataDir: string, version: string): void {
+  const bad = readBadVersions(userDataDir);
+  if (!bad.delete(version)) return; // not poisoned → nothing to rewrite
+  writeJsonAtomic(badPath(userDataDir), { versions: [...bad] });
+}
+
 export function writeBreadcrumb(userDataDir: string, version: string, now = Date.now()): void {
   writeJsonAtomic(breadcrumbPath(userDataDir), { version, ts: now });
 }

--- a/packages/desktop-host/src/app-update/stager.test.ts
+++ b/packages/desktop-host/src/app-update/stager.test.ts
@@ -6,7 +6,7 @@ import os from 'node:os';
 
 import { buildAppBundle } from './build';
 import { checkForUpdate, downloadAndStage, isAllowedUpdateHost } from './stager';
-import { bundleRoot, type ShellInfo } from './resolve';
+import { bundleRoot, markBad, readBadVersions, readActiveVersion, type ShellInfo } from './resolve';
 
 const SHELL: ShellInfo = { electron: '33.4.11', nodeAbi: '115' };
 const keys = generateKeyPairSync('ed25519');
@@ -144,5 +144,33 @@ describe('downloadAndStage hardening', () => {
     await expect(
       downloadAndStage({ userDataDir: tmp, manifest, publicKeyPem: otherKey }, { fetchImpl }),
     ).rejects.toThrow(/signature/i);
+  });
+
+  it('clears a prior poison mark on the version it installs (un-wedges a reinstall)', async () => {
+    const { manifest, bundleGz } = buildAppBundle({
+      version: '0.0.6',
+      minElectron: '33.0.0',
+      nodeAbi: '',
+      bundleUrl: GH,
+      privateKeyPem: PRIVKEY,
+      files: {
+        'dist/index.html': Buffer.from('x'),
+        'dist-electron/main/index.js': Buffer.from('// main'),
+      },
+    });
+    // A prior failed boot poisoned this version; without un-poisoning, the
+    // freshly re-staged copy would be rejected on the next launch forever.
+    markBad(tmp, '0.0.6');
+    expect(readBadVersions(tmp).has('0.0.6')).toBe(true);
+
+    const fetchImpl = (async () => new Response(new Uint8Array(bundleGz))) as unknown as typeof fetch;
+    const { version } = await downloadAndStage(
+      { userDataDir: tmp, manifest, publicKeyPem: PUBKEY },
+      { fetchImpl },
+    );
+
+    expect(version).toBe('0.0.6');
+    expect(readBadVersions(tmp).has('0.0.6')).toBe(false); // poison cleared
+    expect(readActiveVersion(tmp)).toBe('0.0.6'); // and activated
   });
 });

--- a/packages/desktop-host/src/app-update/stager.ts
+++ b/packages/desktop-host/src/app-update/stager.ts
@@ -29,6 +29,7 @@ import {
   isCompatible,
   isSafeVersion,
   setActiveVersion,
+  unmarkBad,
 } from './resolve.js';
 
 /** Only these hosts (and subdomains) are ever fetched — GitHub's API, web, and
@@ -312,6 +313,12 @@ export async function downloadAndStage(
     if (existsSync(finalRoot)) rmSync(finalRoot, { recursive: true, force: true });
     renameSync(incoming, finalRoot);
     setActiveVersion(userDataDir, manifest.version);
+    // The user explicitly chose to install this version — clear any prior poison
+    // mark so a one-off failed boot can't leave it permanently unloadable (the
+    // freshly-staged copy would otherwise be rejected as `bad` on the next launch
+    // and the app would silently stay on the floor). The boot-probe re-poisons it
+    // if this copy is genuinely broken, so this grants exactly one fresh attempt.
+    unmarkBad(userDataDir, manifest.version);
   } finally {
     if (existsSync(incoming)) rmSync(incoming, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Symptom

Updating the desktop app downloads the new bundle, but after restart you're still on the old version — repeatably.

## Root cause

Tier-1 self-update stages a bundle under `<userData>/app/<version>/` and the immutable bootstrap activates it on next launch via `resolveActiveBundle`. Two safety nets poison a version (add it to `bad.json`) if its renderer doesn't confirm a healthy mount in time:
- the in-session **boot-probe** (15s after `did-finish-load`), and
- the cross-launch **`recoverFromFailedBoot`**.

But **nothing ever clears `bad.json`**. So once a version is poisoned — a slow first render, a transient hiccup, one white-screen — every later *download + restart* re-stages the same version, `resolveActiveBundle` rejects it as poisoned, and the app silently runs the packaged floor. Result: "downloads, but restart still shows the old version," with no recovery short of wiping userData.

Verified the trust chain is fine (published manifest verifies against the baked key) and the build→stage→resolve happy path passes — so this poison-stuck loop is the defect, not signing/layout.

## Fix

`downloadAndStage` now calls a new `unmarkBad(userDataDir, version)` for the version it installs. An explicit user (re)install is a deliberate retry, so it clears any stale poison mark and grants the fresh copy one more attempt. The boot-probe still re-poisons a genuinely broken bundle, so the safety net is intact — this only ever grants **one** fresh attempt.

- `resolve.ts`: add `unmarkBad`
- `stager.ts`: clear the mark right after `setActiveVersion`
- `index.ts`: export `unmarkBad`
- tests: `unmarkBad` (removes/no-op/leaves-others) + `downloadAndStage` clears a prior mark

131 desktop-host tests pass; full workspace build green.

## Note
This ships in the next desktop release; it can't reach an already-installed binary. To recover a wedged install now: quit, `rm -rf "~/Library/Application Support/MoxxyAI Workspaces/app"`, relaunch, re-update.