### PR TITLE
fix(desktop): set app name in bootstrap so self-update is actually loaded

### DIFF
--- a/.changeset/fix-desktop-update-userdata-name.md
+++ b/.changeset/fix-desktop-update-userdata-name.md
@@ -1,0 +1,13 @@
+---
+"@moxxy/desktop": patch
+---
+
+Fix self-update never taking effect: the immutable bootstrap read
+`app.getPath('userData')` before `app.setName('MoxxyAI Workspaces')` ran (that
+call lives in the later-loaded `index.js`). In a packaged build Electron derives
+`getName()` from the package `name` (`@moxxy/desktop`), not electron-builder's
+`productName`, so the loader looked for staged updates under a different userData
+directory than the one the updater writes to — making every downloaded update
+invisible and silently booting the baked floor instead. The bootstrap now sets
+the app name before resolving `userData`, so it and the updater agree. (Takes
+effect after one fresh installer; subsequent hot-updates then apply.)

--- a/apps/desktop/electron/main/bootstrap.ts
+++ b/apps/desktop/electron/main/bootstrap.ts
@@ -34,6 +34,18 @@ import {
 
 import { BUNDLED_UPDATE_PUBLIC_KEY } from './update-key.js';
 
+// MUST run before any `app.getPath('userData')` below. `userData` resolves to
+// `…/Application Support/<app.getName()>`, and in a packaged build Electron
+// derives `getName()` from the app package.json `name` (`@moxxy/desktop`), NOT
+// electron-builder's `productName`. The real main (`index.js`) calls
+// `app.setName('MoxxyAI Workspaces')` too — but it loads LATER, so without
+// setting the name HERE the bootstrap would read the self-update state
+// (active.json / staged bundles) from a DIFFERENT userData dir than the one the
+// updater writes to. That mismatch made every staged update invisible to the
+// loader, so the app silently kept booting the floor. Keep this string in sync
+// with `index.ts`.
+app.setName('MoxxyAI Workspaces');
+
 /** Dir holding this bootstrap + the baked floor `index.js` (…/dist-electron/main). */
 const floorMainDir = import.meta.dirname;
 /** The floor bundle root: the dir that contains `dist-electron/` + `dist/`. */


### PR DESCRIPTION
## Symptom
"Update + relaunch still doesn't get the newest version." The in-app updater downloads/stages a newer dashboard bundle, but after relaunch the app keeps running the baked floor — systematically, across releases.

## Root cause
The immutable bootstrap (`apps/desktop/electron/main/bootstrap.ts`) is `package.json#main`, so it runs **first** and calls `app.getPath('userData')` to find staged updates. But `app.setName('MoxxyAI Workspaces')` lives in `index.ts`, which the bootstrap loads **afterwards**.

`userData` = `…/Application Support/<app.getName()>`. In a packaged build Electron derives `getName()` from the app `package.json` `name` (`@moxxy/desktop`) — **not** electron-builder's `build.productName`/`CFBundleName` (those only fix the Dock/menu label). So:

- the **bootstrap** (before `setName`) reads `active.json` + staged bundles from one userData dir;
- the **updater/stager** (`ipc/update.ts`, runs in the main *after* `setName`) writes them to `…/MoxxyAI Workspaces/`.

The two diverge → the loader never sees the staged bundle → it always falls through to the floor. Everything else (prefs / vault / desks) works because the main writes those after `setName`, which is why only updates were affected.

## Verification (ruled out the server side)
I pulled the live `desktop-v0.0.19` release and confirmed it's healthy — tag ↔ `manifest.version` ↔ bundle asset all match, `sha256` matches, the bundle contains `dist-electron/main/index.js`, the signature verifies against the baked public key, and `minElectron: 33.0.0` is satisfied by the shipped Electron `^33.2.1`. So the artifacts were fine; the loader just looked in the wrong directory.

## Fix
Call `app.setName('MoxxyAI Workspaces')` in the bootstrap **before** it resolves `userData`, so the loader and the updater agree on the directory. The built `dist-electron/main/bootstrap.js` confirms `setName` now precedes the `getPath('userData')` calls.

## Caveat
The bootstrap is the immutable floor, so this fix only takes effect after a user installs **one fresh installer**. After that, the bundle the old main already staged is picked up, and subsequent hot-updates apply normally.

Includes a `@moxxy/desktop` changeset.