### PR TITLE
feat(provider): add claude-code provider (Claude Pro/Max OAuth)

### DIFF
--- a/.changeset/add-claude-code-provider.md
+++ b/.changeset/add-claude-code-provider.md
@@ -1,0 +1,21 @@
+---
+"@moxxy/plugin-provider-claude-code": minor
+"@moxxy/plugin-provider-anthropic": minor
+"@moxxy/cli": minor
+"@moxxy/sdk": minor
+---
+
+Add a `claude-code` provider so Claude Pro/Max subscribers can use moxxy with
+their subscription instead of a pay-as-you-go API key.
+
+- New `@moxxy/plugin-provider-claude-code`: talks to the standard Anthropic
+  Messages API with a Claude Code OAuth bearer token (`anthropic-beta:
+  oauth-2025-04-20` + the required "You are Claude Code…" system preamble).
+- Two ways to authenticate: paste a token from `claude setup-token` (or set
+  `CLAUDE_CODE_OAUTH_TOKEN`), or run `moxxy login claude-code` for an
+  interactive out-of-band OAuth sign-in. Access tokens refresh automatically.
+- `@moxxy/plugin-provider-anthropic`: `AnthropicProvider` gained an OAuth mode
+  (bearer auth + system preamble + refresh-on-401); the API-key path is
+  unchanged.
+- `@moxxy/sdk`: `ProviderAuthContext` gained an optional `prompt()` so auth
+  flows can ask the user to paste a code/token (used by the out-of-band flow).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ If you're a Claude Code agent or any other autonomous agent: read this file firs
 @moxxy/isolator-subprocess        subprocess Isolator (kernel-enforced process boundary)
 @moxxy/isolator-wasm              WebAssembly Isolator (zero ambient authority; experimental)
 @moxxy/plugin-provider-openai-codex  ChatGPT OAuth provider (Responses API)
+@moxxy/plugin-provider-claude-code  Claude Pro/Max OAuth provider (Messages API, bearer token)
 @moxxy/plugin-provider-admin      register OpenAI-compatible providers at runtime
 @moxxy/plugin-oauth               generic OAuth 2.0 + PKCE / device-code
 @moxxy/plugin-stt-whisper         Whisper transcriber (voice in); `-codex` variant reuses ChatGPT creds

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ export default defineConfig({
 @moxxy/plugin-provider-anthropic    ← LLM provider
 @moxxy/plugin-provider-openai       ← LLM provider
 @moxxy/plugin-provider-openai-codex ← ChatGPT OAuth provider
+@moxxy/plugin-provider-claude-code  ← Claude Pro/Max OAuth provider
 @moxxy/plugin-provider-admin        ← register OpenAI-compatible providers at runtime
 @moxxy/plugin-mcp                   ← MCP servers as tool sources
 @moxxy/plugin-vault                 ← encrypted secrets

--- a/apps/docs/src/content/docs/guides/provider-oauth-login.md
+++ b/apps/docs/src/content/docs/guides/provider-oauth-login.md
@@ -3,10 +3,11 @@ title: Provider OAuth login
 description: moxxy login openai-codex — and how the generic OAuth plugin powers it.
 ---
 
-Most providers use API keys. The Codex provider
-(`@moxxy/plugin-provider-openai-codex`) uses ChatGPT Pro/Plus OAuth
-instead, and the generic `@moxxy/plugin-oauth` plugin handles the dance
-for any future provider that wires the same hook.
+Most providers use API keys. Two providers use a **subscription** instead:
+`openai-codex` (`@moxxy/plugin-provider-openai-codex`) for ChatGPT Pro/Plus,
+and `claude-code` (`@moxxy/plugin-provider-claude-code`) for Claude Pro/Max.
+The generic `@moxxy/plugin-oauth` plugin handles the dance for any provider
+that wires the same hook.
 
 ## Log in
 
@@ -58,6 +59,44 @@ Refresh tokens rotate on every refresh (single-use), so the provider's
 `onTokensRefreshed` callback writes the new bundle back to the vault
 before the next API call goes out. Lose that and you get one 401 then
 permanent failure.
+
+## Claude (Pro/Max) subscription — `claude-code`
+
+The `claude-code` provider talks to the **standard Anthropic Messages API**,
+but authenticates with a Claude Code OAuth token (a subscription credential)
+instead of an API key. Set it active with:
+
+```yaml
+# moxxy.config.yaml
+provider:
+  name: claude-code
+```
+
+Three ways to supply the token:
+
+```sh
+# 1. Paste a token from the Claude CLI (long-lived, ~1 year):
+export CLAUDE_CODE_OAUTH_TOKEN="$(claude setup-token)"
+
+# 2. Or store it interactively (also accepts a setup-token paste):
+moxxy login claude-code            # press Enter to sign in via browser,
+                                   # or paste a setup-token at the prompt
+
+# 3. Or set ANTHROPIC_AUTH_TOKEN (the SDK's native bearer var).
+```
+
+Unlike codex, Claude's OAuth is **out-of-band**: `moxxy login claude-code`
+opens your browser, you approve, then copy the `code#state` string back into
+the terminal (there's no loopback server). Tokens from the browser flow carry
+a refresh_token and renew automatically; a pasted `setup-token` is long-lived
+and simply re-run when it eventually expires.
+
+Under the hood the request adds `anthropic-beta: oauth-2025-04-20` and leads
+the system prompt with the Claude Code identity line — both required for the
+API to accept a subscription token.
+
+> **Heads-up:** Anthropic's consumer terms intend subscription tokens for
+> official Claude clients. Use this with that in mind.
 
 ## Using OAuth in your own plugin
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -96,6 +96,7 @@
     "@moxxy/plugin-provider-anthropic": "workspace:*",
     "@moxxy/plugin-provider-openai": "workspace:*",
     "@moxxy/plugin-provider-openai-codex": "workspace:*",
+    "@moxxy/plugin-provider-claude-code": "workspace:*",
     "@moxxy/plugin-scheduler": "workspace:*",
     "@moxxy/plugin-security": "workspace:*",
     "@moxxy/plugin-self-update": "workspace:*",

--- a/packages/cli/src/provider-credentials.ts
+++ b/packages/cli/src/provider-credentials.ts
@@ -5,14 +5,21 @@ import {
   readStoredTokens,
   type CodexTokens,
 } from '@moxxy/plugin-provider-openai-codex';
+import {
+  CLAUDE_CODE_PROVIDER_ID,
+  CLAUDE_TOKEN_ENV_VARS,
+  ensureFreshClaudeTokens,
+  refreshClaudeAccessToken,
+} from '@moxxy/plugin-provider-claude-code';
 import { resolveProviderApiKey, type ResolveOptions } from './provider-keys.js';
 
 /**
  * Provider-aware credential resolution. The existing API-key flow (vault →
- * env → prompt) is unchanged for all providers EXCEPT `openai-codex`, which
- * pulls the OAuth token bundle from the vault (under `oauth/openai-codex/*`)
- * and exposes both the tokens AND a writeback callback that persists
- * refreshed tokens before the next API call goes out.
+ * env → prompt) is unchanged for all providers EXCEPT the subscription-OAuth
+ * ones: `openai-codex` pulls a ChatGPT token bundle (under
+ * `oauth/openai-codex/*`), and `claude-code` pulls a Claude bearer (vault
+ * `oauth/claude-code/*` or a `CLAUDE_CODE_OAUTH_TOKEN` env var) — each
+ * exposing the live token plus a refresh hook the provider uses on a 401.
  */
 export async function resolveProviderCredentials(
   providerName: string,
@@ -20,8 +27,38 @@ export async function resolveProviderCredentials(
   opts: ResolveOptions = {},
 ): Promise<Record<string, unknown>> {
   if (providerName === 'openai-codex') return resolveOAuthCodex(vault);
+  if (providerName === CLAUDE_CODE_PROVIDER_ID) return resolveClaudeCode(vault);
   const { providerConfig } = await resolveProviderApiKey(providerName, vault, opts);
   return providerConfig;
+}
+
+/**
+ * Claude subscription credentials. Prefer the vault bundle written by
+ * `moxxy login claude-code` (refreshed proactively when near expiry); fall
+ * back to a `claude setup-token` env var for CI / non-interactive use. The
+ * `oauthRefresh` hook is wired only when a refresh_token is actually stored.
+ */
+async function resolveClaudeCode(vault: VaultStore): Promise<Record<string, unknown>> {
+  const fresh = await ensureFreshClaudeTokens(vault);
+  if (fresh) {
+    return {
+      oauthToken: fresh.accessToken,
+      ...(fresh.expiresAt !== undefined ? { oauthExpiresAt: fresh.expiresAt } : {}),
+      ...(fresh.canRefresh ? { oauthRefresh: () => refreshClaudeAccessToken(vault) } : {}),
+    };
+  }
+  for (const envVar of CLAUDE_TOKEN_ENV_VARS) {
+    const token = process.env[envVar];
+    if (token) return { oauthToken: token };
+  }
+  throw new MoxxyError({
+    code: 'AUTH_NO_CREDENTIALS',
+    message: 'No Claude subscription credentials found.',
+    hint:
+      'Run `moxxy login claude-code` to sign in with your Claude Pro/Max account, ' +
+      'or set CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token`.',
+    context: { provider: CLAUDE_CODE_PROVIDER_ID },
+  });
 }
 
 async function resolveOAuthCodex(vault: VaultStore): Promise<Record<string, unknown>> {

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -6,6 +6,7 @@ import type { MoxxyConfig } from '@moxxy/config';
 import { anthropicPlugin } from '@moxxy/plugin-provider-anthropic';
 import { openaiPlugin } from '@moxxy/plugin-provider-openai';
 import { openaiCodexPlugin } from '@moxxy/plugin-provider-openai-codex';
+import { claudeCodePlugin } from '@moxxy/plugin-provider-claude-code';
 import { buildWhisperPlugin } from '@moxxy/plugin-stt-whisper';
 import { buildWhisperCodexPlugin } from '@moxxy/plugin-stt-whisper-codex';
 import { builtinToolsPlugin } from '@moxxy/tools-builtin';
@@ -74,6 +75,7 @@ export const BUILTIN_REQUIREMENT_DECISIONS: Readonly<Record<string, BuiltinRequi
   '@moxxy/plugin-provider-anthropic': { hardRequirements: false, reason: 'provider is independently activatable' },
   '@moxxy/plugin-provider-openai': { hardRequirements: false, reason: 'provider is independently activatable' },
   '@moxxy/plugin-provider-openai-codex': { hardRequirements: false, reason: 'provider owns its OAuth flow' },
+  '@moxxy/plugin-provider-claude-code': { hardRequirements: false, reason: 'provider owns its OAuth flow' },
   '@moxxy/plugin-provider-admin': { hardRequirements: false, reason: 'provider registry access is injected by bootstrap closure' },
   '@moxxy/tools-builtin': { hardRequirements: false, reason: 'core tool pack has no plugin dependency' },
   '@moxxy/mode-tool-use': { hardRequirements: false, reason: 'mode has no plugin dependency' },
@@ -157,6 +159,7 @@ export function buildBuiltinsCore(args: BuildBuiltinsArgs): BuiltBuiltinsCore {
     { name: '@moxxy/plugin-provider-anthropic', plugin: anthropicPlugin },
     { name: '@moxxy/plugin-provider-openai', plugin: openaiPlugin },
     { name: '@moxxy/plugin-provider-openai-codex', plugin: openaiCodexPlugin },
+    { name: '@moxxy/plugin-provider-claude-code', plugin: claudeCodePlugin },
     { name: '@moxxy/tools-builtin', plugin: builtinToolsPlugin },
     { name: '@moxxy/mode-tool-use', plugin: toolUseModePlugin },
     { name: '@moxxy/mode-plan-execute', plugin: planExecuteModePlugin },

--- a/packages/cli/src/wizard/auth-context.ts
+++ b/packages/cli/src/wizard/auth-context.ts
@@ -5,8 +5,9 @@
  * dance is identical regardless of which provider plugin owns it.
  */
 
-import type { ProviderAuthContext, ProviderDef } from '@moxxy/sdk';
+import { MoxxyError, type ProviderAuthContext, type ProviderDef } from '@moxxy/sdk';
 import type { VaultStore } from '@moxxy/plugin-vault';
+import { isCancel, password, text } from '@clack/prompts';
 
 export interface BuildAuthContextOptions {
   readonly headless: boolean;
@@ -21,12 +22,26 @@ export function buildProviderAuthContext(
   return {
     headless: opts.headless,
     write: opts.write ?? ((s) => process.stdout.write(s)),
+    // A TTY-only single-line input used by out-of-band / paste flows (e.g.
+    // claude-code). Omitted in headless mode so those flows fail fast with a
+    // "set the env var instead" message rather than hanging on a dead stdin.
+    ...(opts.headless ? {} : { prompt: clackPrompt }),
     vault: {
       get: (key) => vault.get(key),
       set: (key, value, tags) => vault.set(key, value, tags ? [...tags] : undefined),
       delete: (key) => vault.delete(key),
     },
   };
+}
+
+async function clackPrompt(question: string, opts?: { readonly mask?: boolean }): Promise<string> {
+  const answer = opts?.mask
+    ? await password({ message: question })
+    : await text({ message: question });
+  if (isCancel(answer)) {
+    throw new MoxxyError({ code: 'AUTH_DENIED', message: 'Sign-in cancelled.' });
+  }
+  return typeof answer === 'string' ? answer : '';
 }
 
 /** True if the provider plugin advertises an OAuth login flow. */

--- a/packages/plugin-provider-anthropic/src/oauth-mode.test.ts
+++ b/packages/plugin-provider-anthropic/src/oauth-mode.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { ProviderEvent } from '@moxxy/sdk';
+import { AnthropicProvider } from './provider.js';
+
+/** Build a fake Anthropic SDK client that records `messages.stream` args. */
+function fakeClient(events: ReadonlyArray<unknown>): {
+  client: Anthropic;
+  calls: Array<{ system?: unknown; messages?: unknown }>;
+} {
+  const calls: Array<{ system?: unknown; messages?: unknown }> = [];
+  const client = {
+    messages: {
+      stream: (args: { system?: unknown; messages?: unknown }) => {
+        calls.push(args);
+        return (async function* () {
+          for (const e of events) yield e;
+        })();
+      },
+    },
+  } as unknown as Anthropic;
+  return { client, calls };
+}
+
+const DONE_EVENTS = [
+  { type: 'message_start', message: { usage: { input_tokens: 1, output_tokens: 0 } } },
+  { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 2 } },
+  { type: 'message_stop' },
+];
+
+async function drain(it: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const out: ProviderEvent[] = [];
+  for await (const e of it) out.push(e);
+  return out;
+}
+
+describe('AnthropicProvider OAuth mode', () => {
+  it('authenticates with a bearer token and suppresses the api key', () => {
+    const p = new AnthropicProvider({ oauthToken: 'tok-123', oauthBeta: ['oauth-2025-04-20'] });
+    const client = (p as unknown as { client: { apiKey: unknown; authToken: unknown } }).client;
+    // apiKey null => SDK omits x-api-key; authToken => Authorization: Bearer.
+    expect(client.apiKey).toBeNull();
+    expect(client.authToken).toBe('tok-123');
+    expect(p.name).toBe('anthropic');
+  });
+
+  it('honours a provider name override', () => {
+    const p = new AnthropicProvider({ oauthToken: 't', name: 'claude-code' });
+    expect(p.name).toBe('claude-code');
+  });
+
+  it('prepends the system preamble as the FIRST system block', async () => {
+    const { client, calls } = fakeClient(DONE_EVENTS);
+    const p = new AnthropicProvider({
+      oauthToken: 'tok',
+      systemPreamble: "You are Claude Code, Anthropic's official CLI for Claude.",
+      client,
+    });
+    const out = await drain(
+      p.stream({
+        model: 'claude-x',
+        messages: [
+          { role: 'system', content: [{ type: 'text', text: 'REAL SYSTEM' }] },
+          { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        ],
+      }),
+    );
+
+    const sys = calls[0]!.system as Array<{ type: string; text: string }>;
+    expect(Array.isArray(sys)).toBe(true);
+    expect(sys[0]).toEqual({
+      type: 'text',
+      text: "You are Claude Code, Anthropic's official CLI for Claude.",
+    });
+    expect(sys[1]!.text).toBe('REAL SYSTEM');
+    expect(out.at(-1)).toMatchObject({ type: 'message_end', stopReason: 'end_turn' });
+  });
+
+  it('apiKey mode is unchanged: system stays a bare string', async () => {
+    const { client, calls } = fakeClient([{ type: 'message_stop' }]);
+    const p = new AnthropicProvider({ apiKey: 'sk-test', client });
+    await drain(
+      p.stream({
+        model: 'm',
+        messages: [
+          { role: 'system', content: [{ type: 'text', text: 'REAL' }] },
+          { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        ],
+      }),
+    );
+    expect(calls[0]!.system).toBe('REAL');
+  });
+});

--- a/packages/plugin-provider-anthropic/src/provider.ts
+++ b/packages/plugin-provider-anthropic/src/provider.ts
@@ -14,6 +14,38 @@ export interface AnthropicProviderConfig {
   readonly baseURL?: string;
   readonly defaultModel?: string;
   readonly client?: Anthropic;
+  /**
+   * Override the reported provider name (used in error context). Defaults
+   * to `'anthropic'`. The `claude-code` subscription provider reuses this
+   * class with `name: 'claude-code'` so errors/metering attribute correctly.
+   */
+  readonly name?: string;
+  /**
+   * OAuth (Claude subscription) mode. When set, the client authenticates
+   * with `Authorization: Bearer <oauthToken>` instead of an `x-api-key`,
+   * and the request/response is otherwise the standard Messages API. Used
+   * by `@moxxy/plugin-provider-claude-code`; the plain `anthropic` provider
+   * leaves all of these unset and behaves exactly as before.
+   */
+  readonly oauthToken?: string;
+  /** `anthropic-beta` values sent with every OAuth-mode request (joined by `,`). */
+  readonly oauthBeta?: ReadonlyArray<string>;
+  /**
+   * Text injected as the FIRST system block in OAuth mode. Claude rejects
+   * subscription tokens unless the system prompt leads with the Claude Code
+   * identity line, so the provider prepends this ahead of the real system
+   * prompt (which follows as the next block).
+   */
+  readonly systemPreamble?: string;
+  /** Epoch-ms expiry of `oauthToken`, if known — drives proactive refresh. */
+  readonly oauthExpiresAt?: number;
+  /**
+   * Refresh callback. Returns a fresh access token (and its expiry). Invoked
+   * proactively just before a request when the current token is near expiry,
+   * and once more reactively if a request still comes back 401. Omit for
+   * non-refreshable tokens (e.g. a pasted `claude setup-token`).
+   */
+  readonly oauthRefresh?: () => Promise<{ readonly token: string; readonly expiresAt?: number }>;
 }
 
 export const anthropicModels: ReadonlyArray<ModelDescriptor> = [
@@ -23,19 +55,107 @@ export const anthropicModels: ReadonlyArray<ModelDescriptor> = [
 ];
 
 export class AnthropicProvider implements LLMProvider {
-  readonly name = 'anthropic';
+  readonly name: string;
   readonly models = anthropicModels;
-  private readonly client: Anthropic;
+  // Mutable so OAuth-mode refresh can swap in a client carrying the new
+  // bearer token; the plain apiKey client never changes after construction.
+  private client: Anthropic;
   private readonly defaultModel: string;
+  private readonly baseURL?: string;
+  // Present only in OAuth (Claude subscription) mode.
+  private readonly oauth?: {
+    readonly beta: ReadonlyArray<string>;
+    readonly systemPreamble?: string;
+    readonly refresh?: () => Promise<{ readonly token: string; readonly expiresAt?: number }>;
+  };
+  private oauthToken?: string;
+  private oauthExpiresAt?: number;
 
   constructor(config: AnthropicProviderConfig = {}) {
-    this.client =
-      config.client ??
-      new Anthropic({
-        apiKey: config.apiKey ?? process.env.ANTHROPIC_API_KEY,
-        ...(config.baseURL ? { baseURL: config.baseURL } : {}),
-      });
+    this.name = config.name ?? 'anthropic';
     this.defaultModel = config.defaultModel ?? 'claude-sonnet-4-6';
+    if (config.baseURL) this.baseURL = config.baseURL;
+
+    if (config.oauthToken) {
+      this.oauthToken = config.oauthToken;
+      this.oauthExpiresAt = config.oauthExpiresAt;
+      this.oauth = {
+        beta: config.oauthBeta ?? [],
+        ...(config.systemPreamble ? { systemPreamble: config.systemPreamble } : {}),
+        ...(config.oauthRefresh ? { refresh: config.oauthRefresh } : {}),
+      };
+      this.client = config.client ?? this.makeOauthClient(config.oauthToken);
+    } else {
+      this.client =
+        config.client ??
+        new Anthropic({
+          apiKey: config.apiKey ?? process.env.ANTHROPIC_API_KEY,
+          ...(config.baseURL ? { baseURL: config.baseURL } : {}),
+        });
+    }
+  }
+
+  /**
+   * Build an Anthropic client in OAuth (bearer) mode. `apiKey: null` stops
+   * the SDK from falling back to `ANTHROPIC_API_KEY` and suppresses the
+   * `x-api-key` header (its `apiKeyAuth()` returns `{}` when apiKey is null),
+   * so only `Authorization: Bearer <token>` goes out, plus the beta header.
+   */
+  private makeOauthClient(token: string): Anthropic {
+    const beta = this.oauth?.beta ?? [];
+    return new Anthropic({
+      apiKey: null,
+      authToken: token,
+      ...(beta.length > 0 ? { defaultHeaders: { 'anthropic-beta': beta.join(',') } } : {}),
+      ...(this.baseURL ? { baseURL: this.baseURL } : {}),
+    });
+  }
+
+  /** Proactively refresh the bearer token when it's within the skew window. */
+  private async ensureFreshOauth(): Promise<void> {
+    if (!this.oauth?.refresh) return;
+    if (this.oauthExpiresAt === undefined) return;
+    if (Date.now() + 60_000 < this.oauthExpiresAt) return;
+    await this.refreshOauthNow();
+  }
+
+  /** Force a token refresh and rebuild the client with the new bearer. */
+  private async refreshOauthNow(): Promise<void> {
+    if (!this.oauth?.refresh) throw new Error('no refresh callback');
+    const next = await this.oauth.refresh();
+    this.oauthToken = next.token;
+    this.oauthExpiresAt = next.expiresAt;
+    this.client = this.makeOauthClient(next.token);
+  }
+
+  /**
+   * Build the `system` request field. In OAuth mode the Claude Code identity
+   * preamble MUST lead, so we always emit block form with the preamble first;
+   * the real system prompt follows (carrying the cache breakpoint if set).
+   * In apiKey mode the behaviour is unchanged: a bare string, upgraded to a
+   * single cache-marked block only when a system cache hint is present.
+   */
+  private buildSystemParam(
+    system: string | undefined,
+    cacheSystem: boolean,
+  ): string | undefined | Array<{ type: 'text'; text: string; cache_control?: { type: 'ephemeral' } }> {
+    const preamble = this.oauth?.systemPreamble;
+    if (preamble) {
+      const blocks: Array<{ type: 'text'; text: string; cache_control?: { type: 'ephemeral' } }> = [
+        { type: 'text', text: preamble },
+      ];
+      if (system) {
+        blocks.push(
+          cacheSystem
+            ? { type: 'text', text: system, cache_control: { type: 'ephemeral' } }
+            : { type: 'text', text: system },
+        );
+      }
+      return blocks;
+    }
+    return cacheSystem && system
+      ? [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }]
+      : system;
   }
 
   async *stream(req: ProviderRequest): AsyncIterable<ProviderEvent> {
@@ -56,35 +176,69 @@ export class AnthropicProvider implements LLMProvider {
       req.tools && req.tools.length > 0
         ? toAnthropicTools(req.tools, { cacheLast: cacheTools })
         : undefined;
-    // To carry cache_control the system prompt must be sent in block form.
-    const systemParam =
-      cacheSystem && system
-        ? [{ type: 'text' as const, text: system, cache_control: { type: 'ephemeral' as const } }]
-        : system;
+    // OAuth mode prepends the Claude Code identity preamble as the first
+    // system block; apiKey mode keeps the prior string/cache-block behaviour.
+    const systemParam = this.buildSystemParam(system, cacheSystem);
     const model = req.model || this.defaultModel;
 
     yield { type: 'message_start', model };
 
-    let stream: AsyncIterable<unknown>;
-    try {
-      stream = this.client.messages.stream(
-        {
-          model,
-          max_tokens: req.maxTokens ?? 4096,
-          system: systemParam,
-          messages,
-          tools,
-          ...(req.temperature !== undefined ? { temperature: req.temperature } : {}),
-        } as Parameters<typeof this.client.messages.stream>[0],
-        // Pass the AbortSignal into the SDK request options so cancelling
-        // tears down the underlying HTTP request. Without this, Esc only
-        // stopped our loop while the model kept generating upstream.
-        req.signal ? { signal: req.signal } : undefined,
-      );
-    } catch (err) {
-      yield { type: 'error', ...toFriendlyError(err, { provider: 'anthropic' }) };
-      return;
+    // In OAuth mode refresh the bearer proactively when it's near expiry, so
+    // we don't fire a request on a token we already knew was about to die.
+    if (this.oauth) {
+      try {
+        await this.ensureFreshOauth();
+      } catch (err) {
+        yield { type: 'error', ...toFriendlyError(err, { provider: this.name }) };
+        return;
+      }
     }
+
+    const requestBody: Record<string, unknown> = {
+      model,
+      max_tokens: req.maxTokens ?? 4096,
+      system: systemParam,
+      messages,
+      tools,
+      ...(req.temperature !== undefined ? { temperature: req.temperature } : {}),
+    };
+
+    // A 401 always arrives before any SSE body, so in OAuth mode we can force
+    // a single refresh and replay the request with no risk of duplicate output.
+    try {
+      yield* this.streamOnce(requestBody, req.signal);
+    } catch (err) {
+      if (this.oauth?.refresh && isUnauthorized(err)) {
+        try {
+          await this.refreshOauthNow();
+          yield* this.streamOnce(requestBody, req.signal);
+          return;
+        } catch (retryErr) {
+          yield { type: 'error', ...toFriendlyError(retryErr, { provider: this.name }) };
+          return;
+        }
+      }
+      yield { type: 'error', ...toFriendlyError(err, { provider: this.name }) };
+    }
+  }
+
+  /**
+   * One streaming attempt. THROWS on transport/HTTP errors so `stream()` can
+   * decide whether to refresh-and-replay (OAuth 401) or surface the error;
+   * yields content events plus a terminal `message_end` on the happy path.
+   * Abort is terminal here (yields the abort error and returns).
+   */
+  private async *streamOnce(
+    requestBody: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+  ): AsyncIterable<ProviderEvent> {
+    const stream = this.client.messages.stream(
+      requestBody as unknown as Parameters<typeof this.client.messages.stream>[0],
+      // Pass the AbortSignal into the SDK request options so cancelling
+      // tears down the underlying HTTP request. Without this, Esc only
+      // stopped our loop while the model kept generating upstream.
+      signal ? { signal } : undefined,
+    );
 
     const pendingToolUses = new Map<string, { name: string; partial: string }>();
     // Anthropic's stream events carry a block `index` on every delta/stop;
@@ -98,7 +252,7 @@ export class AnthropicProvider implements LLMProvider {
 
     try {
       for await (const event of stream as AsyncIterable<AnthropicStreamEvent>) {
-        if (req.signal?.aborted) {
+        if (signal?.aborted) {
           yield { type: 'error', message: 'aborted', retryable: false };
           return;
         }
@@ -189,8 +343,14 @@ export class AnthropicProvider implements LLMProvider {
         }
       }
     } catch (err) {
-      yield { type: 'error', ...toFriendlyError(err, { provider: 'anthropic' }) };
-      return;
+      // A cancel surfaces as a thrown AbortError mid-await — report it as the
+      // clean terminal 'aborted' event. Every other error propagates so
+      // `stream()` can classify it (OAuth 401 → refresh+replay; else error).
+      if (signal?.aborted) {
+        yield { type: 'error', message: 'aborted', retryable: false };
+        return;
+      }
+      throw err;
     }
 
     yield { type: 'message_end', stopReason, usage };
@@ -199,17 +359,21 @@ export class AnthropicProvider implements LLMProvider {
   async countTokens(req: Pick<ProviderRequest, 'model' | 'messages' | 'system' | 'tools'>): Promise<number> {
     const { system, messages } = toAnthropicMessages(req.messages);
     const tools = req.tools && req.tools.length > 0 ? toAnthropicTools(req.tools) : undefined;
+    // Mirror stream(): in OAuth mode the request carries the identity preamble
+    // as an extra system block, so count it too for a faithful estimate.
+    const preamble = this.oauth?.systemPreamble;
+    const systemForCount = preamble ? `${preamble}\n\n${system ?? ''}` : system;
     try {
       const result = await (this.client.messages as unknown as { countTokens: (args: unknown) => Promise<{ input_tokens: number }> }).countTokens({
         model: req.model || this.defaultModel,
-        system,
+        system: systemForCount,
         messages,
         tools,
       });
       return result.input_tokens;
     } catch {
       const blob =
-        (system ?? '') +
+        (systemForCount ?? '') +
         messages.map((m) => JSON.stringify(m.content)).join('') +
         JSON.stringify(tools ?? []);
       return estimateTextTokens(blob);
@@ -266,4 +430,15 @@ function mapStopReason(s: string): StopReason {
   if (s === 'stop_sequence') return 'stop_sequence';
   if (s === 'end_turn') return 'end_turn';
   return 'error';
+}
+
+/**
+ * True when the SDK error is an HTTP 401. The Anthropic SDK throws
+ * `APIError` instances carrying a numeric `status`; an expired/revoked OAuth
+ * bearer is the only 401 we want to refresh-and-retry on.
+ */
+function isUnauthorized(err: unknown): boolean {
+  return typeof (err as { status?: unknown } | null | undefined)?.status === 'number'
+    ? (err as { status: number }).status === 401
+    : false;
 }

--- a/packages/plugin-provider-claude-code/package.json
+++ b/packages/plugin-provider-claude-code/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@moxxy/plugin-provider-claude-code",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Claude subscription (Pro/Max) LLMProvider plugin for moxxy. Talks to the standard Anthropic Messages API using a Claude Code OAuth token from `claude setup-token` or an in-app sign-in.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "moxxy": {
+    "plugin": {
+      "entry": "./dist/index.js",
+      "kind": "provider"
+    }
+  },
+  "dependencies": {
+    "@moxxy/sdk": "workspace:*",
+    "@moxxy/plugin-oauth": "workspace:*",
+    "@moxxy/plugin-provider-anthropic": "workspace:*"
+  },
+  "devDependencies": {
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  }
+}

--- a/packages/plugin-provider-claude-code/src/constants.ts
+++ b/packages/plugin-provider-claude-code/src/constants.ts
@@ -1,0 +1,46 @@
+/**
+ * Constants for the Claude subscription (Pro/Max) provider.
+ *
+ * These are the public Claude Code OAuth client parameters — the same values
+ * the `claude` CLI uses — so a token minted here interoperates with one from
+ * `claude setup-token`, and vice-versa. We never embed a client secret; the
+ * flow is PKCE + an out-of-band (manual paste) authorization code.
+ */
+
+/** Provider name in the registry / `/model` picker / `provider.name` config. */
+export const CLAUDE_CODE_PROVIDER_ID = 'claude-code';
+
+/** Human-readable upstream service, shown in `moxxy login` and the init wizard. */
+export const CLAUDE_CODE_SERVICE_NAME = 'Claude (Pro/Max subscription)';
+
+export const CLAUDE_AUTHORIZE_URL = 'https://claude.ai/oauth/authorize';
+export const CLAUDE_TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token';
+export const CLAUDE_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+/**
+ * Out-of-band redirect: after consent, Anthropic shows the user a
+ * `code#state` string to paste back into the terminal (no loopback server).
+ */
+export const CLAUDE_REDIRECT_URI = 'https://console.anthropic.com/oauth/code/callback';
+export const CLAUDE_SCOPES = ['org:create_api_key', 'user:profile', 'user:inference'] as const;
+
+/**
+ * `anthropic-beta` values sent with every request. `oauth-2025-04-20` is the
+ * flag that makes the Messages API accept a subscription bearer token at all;
+ * `claude-code-20250219` matches what the real CLI sends. Sent comma-joined.
+ */
+export const CLAUDE_OAUTH_BETA = ['oauth-2025-04-20', 'claude-code-20250219'] as const;
+
+/**
+ * Required first system block. Claude rejects a subscription token unless the
+ * system prompt leads with this exact identity line; moxxy's real system
+ * prompt is appended as the following block. (Verified against the working
+ * opencode / claude-code-router behaviour.)
+ */
+export const CLAUDE_CODE_SYSTEM = "You are Claude Code, Anthropic's official CLI for Claude.";
+
+/**
+ * Env vars a pasted/CI token can arrive through. `CLAUDE_CODE_OAUTH_TOKEN` is
+ * what `claude setup-token` documents; `ANTHROPIC_AUTH_TOKEN` is the
+ * SDK-native bearer var. Checked in this order.
+ */
+export const CLAUDE_TOKEN_ENV_VARS = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_AUTH_TOKEN'] as const;

--- a/packages/plugin-provider-claude-code/src/index.ts
+++ b/packages/plugin-provider-claude-code/src/index.ts
@@ -1,0 +1,48 @@
+import { defineProvider, definePlugin } from '@moxxy/sdk';
+import { anthropicModels } from '@moxxy/plugin-provider-anthropic';
+import { CLAUDE_CODE_PROVIDER_ID, CLAUDE_CODE_SERVICE_NAME } from './constants.js';
+import { createClaudeCodeClient, type ClaudeCodeProviderConfig } from './provider.js';
+import { claudeLogin, claudeLogout, claudeStatus } from './login.js';
+
+export const claudeCodeProviderDef = defineProvider({
+  name: CLAUDE_CODE_PROVIDER_ID,
+  // Same Claude models as the API-key `anthropic` provider — it's the same
+  // Messages API, only the credential differs.
+  models: [...anthropicModels],
+  createClient: (config) => createClaudeCodeClient(config as ClaudeCodeProviderConfig),
+  // No validateKey: an OAuth bearer is validated by the request itself, and
+  // an interactive paste/sign-in already proves the token round-trips.
+  auth: {
+    kind: 'oauth',
+    serviceName: CLAUDE_CODE_SERVICE_NAME,
+    login: claudeLogin,
+    logout: claudeLogout,
+    status: claudeStatus,
+  },
+});
+
+export const claudeCodePlugin = definePlugin({
+  name: '@moxxy/plugin-provider-claude-code',
+  version: '0.0.0',
+  providers: [claudeCodeProviderDef],
+});
+
+export default claudeCodePlugin;
+
+export {
+  CLAUDE_CODE_PROVIDER_ID,
+  CLAUDE_CODE_SERVICE_NAME,
+  CLAUDE_CODE_SYSTEM,
+  CLAUDE_OAUTH_BETA,
+  CLAUDE_TOKEN_ENV_VARS,
+} from './constants.js';
+export {
+  claudeLogin,
+  claudeLogout,
+  claudeStatus,
+  ensureFreshClaudeTokens,
+  refreshClaudeAccessToken,
+  type FreshClaudeTokens,
+} from './login.js';
+export { createClaudeCodeClient, type ClaudeCodeProviderConfig } from './provider.js';
+export { claudeOauthProfile } from './profile.js';

--- a/packages/plugin-provider-claude-code/src/login.test.ts
+++ b/packages/plugin-provider-claude-code/src/login.test.ts
@@ -1,0 +1,176 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { storeTokenSet, type OAuthVault } from '@moxxy/plugin-oauth';
+import type { ProviderAuthContext } from '@moxxy/sdk';
+import { CLAUDE_CLIENT_ID, CLAUDE_TOKEN_URL } from './constants.js';
+import {
+  claudeLogin,
+  claudeLogout,
+  claudeStatus,
+  ensureFreshClaudeTokens,
+  refreshClaudeAccessToken,
+  __setClaudeFetch,
+  __setClaudeOpenBrowser,
+} from './login.js';
+
+interface FakeVault extends OAuthVault {
+  readonly store: Map<string, string>;
+}
+
+function makeVault(): FakeVault {
+  const store = new Map<string, string>();
+  return {
+    store,
+    get: async (k) => store.get(k) ?? null,
+    set: async (k, v) => {
+      store.set(k, v);
+    },
+    delete: async (k) => store.delete(k),
+  };
+}
+
+function makeCtx(vault: OAuthVault, answers: string[]): ProviderAuthContext {
+  const queue = [...answers];
+  return {
+    vault,
+    headless: false,
+    write: () => {},
+    prompt: async () => queue.shift() ?? '',
+  };
+}
+
+function jsonResponse(obj: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => obj,
+    text: async () => JSON.stringify(obj),
+  } as unknown as Response;
+}
+
+const META = { clientId: CLAUDE_CLIENT_ID, tokenUrl: CLAUDE_TOKEN_URL };
+
+beforeEach(() => {
+  __setClaudeOpenBrowser(async () => {});
+  __setClaudeFetch(async () => {
+    throw new Error('unexpected fetch — a test forgot to stub __setClaudeFetch');
+  });
+});
+
+afterAll(() => {
+  __setClaudeFetch(fetch);
+});
+
+describe('claudeLogin', () => {
+  it('stores a pasted `setup-token` verbatim, with no refresh token', async () => {
+    const vault = makeVault();
+    const res = await claudeLogin(makeCtx(vault, ['sk-ant-oat-PASTED']));
+    expect(vault.store.get('oauth/claude-code/access_token')).toBe('sk-ant-oat-PASTED');
+    expect(vault.store.has('oauth/claude-code/refresh_token')).toBe(false);
+    expect(res).toEqual({});
+  });
+
+  it('runs the out-of-band flow and exchanges the pasted code for tokens', async () => {
+    const vault = makeVault();
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    __setClaudeFetch(async (url, init) => {
+      calls.push({ url: String(url), body: JSON.parse(String(init?.body ?? '{}')) });
+      return jsonResponse({
+        access_token: 'access-1',
+        refresh_token: 'refresh-1',
+        expires_in: 3600,
+        token_type: 'Bearer',
+        account: { email_address: 'me@example.com' },
+      });
+    });
+
+    // First prompt empty => browser flow; second prompt => the auth code.
+    const res = await claudeLogin(makeCtx(vault, ['', 'AUTHCODE']));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(CLAUDE_TOKEN_URL);
+    expect(calls[0]!.body).toMatchObject({
+      grant_type: 'authorization_code',
+      code: 'AUTHCODE',
+      client_id: CLAUDE_CLIENT_ID,
+      redirect_uri: 'https://console.anthropic.com/oauth/code/callback',
+    });
+    expect(typeof calls[0]!.body.code_verifier).toBe('string');
+    expect(vault.store.get('oauth/claude-code/access_token')).toBe('access-1');
+    expect(vault.store.get('oauth/claude-code/refresh_token')).toBe('refresh-1');
+    expect(vault.store.get('oauth/claude-code/extras')).toContain('me@example.com');
+    expect(res.accountId).toBe('me@example.com');
+  });
+
+  it('splits a pasted `code#state` and rejects a mismatched state', async () => {
+    const vault = makeVault();
+    // The internally-generated state will never equal "WRONG", so this must throw.
+    await expect(claudeLogin(makeCtx(vault, ['', 'THECODE#WRONGSTATE']))).rejects.toThrow(/state/i);
+  });
+
+  it('refuses without a TTY prompt', async () => {
+    const vault = makeVault();
+    const ctx: ProviderAuthContext = { vault, headless: true, write: () => {} };
+    await expect(claudeLogin(ctx)).rejects.toThrow(/interactive terminal/i);
+  });
+});
+
+describe('token lifecycle', () => {
+  it('ensureFreshClaudeTokens returns null when nothing is stored', async () => {
+    expect(await ensureFreshClaudeTokens(makeVault())).toBeNull();
+  });
+
+  it('ensureFreshClaudeTokens returns a non-expired token without refreshing', async () => {
+    const vault = makeVault();
+    await storeTokenSet(
+      vault,
+      'claude-code',
+      { accessToken: 'a', refreshToken: 'r', expiresAt: Date.now() + 3_600_000, tokenType: 'Bearer' },
+      META,
+    );
+    // __setClaudeFetch is the throwing default — proving no refresh happens.
+    const fresh = await ensureFreshClaudeTokens(vault);
+    expect(fresh).toMatchObject({ accessToken: 'a', canRefresh: true });
+  });
+
+  it('ensureFreshClaudeTokens refreshes + persists when expired', async () => {
+    const vault = makeVault();
+    await storeTokenSet(
+      vault,
+      'claude-code',
+      { accessToken: 'old', refreshToken: 'r-old', expiresAt: Date.now() - 1000, tokenType: 'Bearer' },
+      META,
+    );
+    __setClaudeFetch(async (_url, init) => {
+      expect(JSON.parse(String(init?.body ?? '{}'))).toMatchObject({
+        grant_type: 'refresh_token',
+        refresh_token: 'r-old',
+      });
+      return jsonResponse({ access_token: 'new', refresh_token: 'r-new', expires_in: 3600, token_type: 'Bearer' });
+    });
+    const fresh = await ensureFreshClaudeTokens(vault);
+    expect(fresh?.accessToken).toBe('new');
+    // Rotated refresh token persisted before returning.
+    expect(vault.store.get('oauth/claude-code/refresh_token')).toBe('r-new');
+  });
+
+  it('refreshClaudeAccessToken throws when no refresh_token is stored', async () => {
+    const vault = makeVault();
+    await storeTokenSet(vault, 'claude-code', { accessToken: 'a', tokenType: 'Bearer' }, META);
+    await expect(refreshClaudeAccessToken(vault)).rejects.toThrow(/refresh/i);
+  });
+
+  it('claudeStatus / claudeLogout report and clear stored creds', async () => {
+    const vault = makeVault();
+    const ctx = makeCtx(vault, []);
+    await storeTokenSet(
+      vault,
+      'claude-code',
+      { accessToken: 'a', expiresAt: Date.now() + 1000, tokenType: 'Bearer' },
+      { ...META, extras: { account_email: 'me@example.com' } },
+    );
+    const status = await claudeStatus(ctx);
+    expect(status).toMatchObject({ accountId: 'me@example.com' });
+    expect(await claudeLogout(ctx)).toBe(true);
+    expect(await claudeStatus(ctx)).toBeNull();
+  });
+});

--- a/packages/plugin-provider-claude-code/src/login.ts
+++ b/packages/plugin-provider-claude-code/src/login.ts
@@ -1,0 +1,292 @@
+/**
+ * Claude subscription login + token lifecycle.
+ *
+ * Claude's OAuth is an out-of-band (manual code-paste) authorization-code +
+ * PKCE flow whose token endpoint speaks JSON (not the form-encoded dialect
+ * the framework's `exchangeCodeForToken` / `refreshAccessToken` assume), so
+ * the HTTP exchange + refresh are implemented here. Everything else is reused
+ * from `@moxxy/plugin-oauth`: PKCE, the auth-URL builder, the browser opener,
+ * vault storage layout, and `parseTokenResponse`.
+ */
+
+import {
+  buildAuthUrl,
+  clearStoredCreds,
+  computeCodeChallenge,
+  generateCodeVerifier,
+  generateState,
+  isExpired,
+  openInBrowser,
+  parseTokenResponse,
+  readStoredCreds,
+  storeTokenSet,
+  type OAuthVault,
+  type TokenSet,
+} from '@moxxy/plugin-oauth';
+import { MoxxyError } from '@moxxy/sdk';
+import type {
+  ProviderAuthContext,
+  ProviderOAuthResult,
+  ProviderOAuthStatus,
+} from '@moxxy/sdk';
+import {
+  CLAUDE_AUTHORIZE_URL,
+  CLAUDE_CLIENT_ID,
+  CLAUDE_CODE_PROVIDER_ID,
+  CLAUDE_CODE_SERVICE_NAME,
+  CLAUDE_REDIRECT_URI,
+  CLAUDE_SCOPES,
+  CLAUDE_TOKEN_URL,
+} from './constants.js';
+
+const PASTE_PROMPT =
+  'Paste a token from `claude setup-token` (or press Enter to sign in via browser): ';
+const CODE_PROMPT = 'Paste the authorization code shown after you approve: ';
+
+/**
+ * Drive an interactive Claude sign-in. Two ways in, both through one command:
+ *   1. paste an existing `claude setup-token` token (stored verbatim), or
+ *   2. press Enter to run the browser out-of-band authorization-code flow.
+ * Needs `ctx.prompt` (a TTY); headless callers use `CLAUDE_CODE_OAUTH_TOKEN`.
+ */
+export async function claudeLogin(ctx: ProviderAuthContext): Promise<ProviderOAuthResult> {
+  if (!ctx.prompt) {
+    throw new MoxxyError({
+      code: 'OAUTH_FLOW_NOT_SUPPORTED',
+      message: 'Claude sign-in needs an interactive terminal.',
+      hint:
+        'Run `claude setup-token` and set CLAUDE_CODE_OAUTH_TOKEN, or run ' +
+        '`moxxy login claude-code` in a terminal.',
+      context: { provider: CLAUDE_CODE_PROVIDER_ID },
+    });
+  }
+
+  const pasted = (await ctx.prompt(PASTE_PROMPT, { mask: true })).trim();
+  if (pasted) {
+    // A `setup-token` is a long-lived bearer with no refresh token; store it
+    // as-is. `isExpired` treats a missing expiry as non-expiring.
+    await storeTokenSet(
+      ctx.vault,
+      CLAUDE_CODE_PROVIDER_ID,
+      { accessToken: pasted, tokenType: 'Bearer' },
+      { clientId: CLAUDE_CLIENT_ID, tokenUrl: CLAUDE_TOKEN_URL },
+    );
+    ctx.write('\nStored your Claude token.\n');
+    return {};
+  }
+
+  const verifier = generateCodeVerifier();
+  const challenge = computeCodeChallenge(verifier);
+  const state = generateState();
+  const authUrl = buildAuthUrl({
+    authUrl: CLAUDE_AUTHORIZE_URL,
+    clientId: CLAUDE_CLIENT_ID,
+    redirectUri: CLAUDE_REDIRECT_URI,
+    scopes: [...CLAUDE_SCOPES],
+    codeChallenge: challenge,
+    state,
+    extraAuthParams: { code: 'true' },
+  });
+
+  ctx.write(
+    `\nSign in to ${CLAUDE_CODE_SERVICE_NAME} to authorize moxxy.\n\n` +
+      `If your browser doesn't open automatically, paste this URL:\n\n  ${authUrl}\n\n` +
+      `After approving, copy the authorization code shown and paste it back here.\n\n`,
+  );
+  try {
+    await openBrowserImpl(authUrl);
+  } catch {
+    // Non-fatal — the user can open the URL surfaced above by hand.
+  }
+
+  const entered = (await ctx.prompt(CODE_PROMPT)).trim();
+  if (!entered) {
+    throw new MoxxyError({
+      code: 'AUTH_DENIED',
+      message: 'No authorization code entered — sign-in cancelled.',
+      context: { provider: CLAUDE_CODE_PROVIDER_ID },
+    });
+  }
+  // Anthropic returns `code#state`; verify the state to defeat CSRF.
+  const hash = entered.indexOf('#');
+  const code = hash >= 0 ? entered.slice(0, hash) : entered;
+  const returnedState = hash >= 0 ? entered.slice(hash + 1) : '';
+  if (returnedState && returnedState !== state) {
+    throw new MoxxyError({
+      code: 'AUTH_INVALID',
+      message: 'Authorization state mismatch — please run sign-in again.',
+      context: { provider: CLAUDE_CODE_PROVIDER_ID },
+    });
+  }
+
+  const { tokenSet, accountEmail } = await exchangeClaudeCode(code, returnedState || state, verifier);
+  await persistClaudeTokens(ctx.vault, tokenSet, accountEmail);
+  ctx.write(`\nSigned in to Claude${accountEmail ? ` as ${accountEmail}` : ''}.\n`);
+  return {
+    ...(accountEmail ? { accountId: accountEmail } : {}),
+    expiresAt: tokenSet.expiresAt ?? 0,
+  };
+}
+
+export async function claudeLogout(ctx: ProviderAuthContext): Promise<boolean> {
+  try {
+    return (await clearStoredCreds(ctx.vault, CLAUDE_CODE_PROVIDER_ID)) > 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function claudeStatus(ctx: ProviderAuthContext): Promise<ProviderOAuthStatus | null> {
+  const stored = await readStoredCreds(ctx.vault, CLAUDE_CODE_PROVIDER_ID);
+  if (!stored) return null;
+  return {
+    accountId: stored.extras.account_email ?? null,
+    expiresAt: stored.tokenSet.expiresAt ?? 0,
+    vaultKey: `oauth/${CLAUDE_CODE_PROVIDER_ID}/*`,
+  };
+}
+
+export interface FreshClaudeTokens {
+  readonly accessToken: string;
+  readonly expiresAt?: number;
+  /** True when a refresh_token is stored, so a 401 can be recovered. */
+  readonly canRefresh: boolean;
+}
+
+/**
+ * Read the stored Claude creds, refreshing first if the access token is near
+ * expiry and a refresh_token is available. Returns null when nothing is
+ * stored. Persists rotated tokens BEFORE returning so a crash can't strand a
+ * single-use refresh_token.
+ */
+export async function ensureFreshClaudeTokens(vault: OAuthVault): Promise<FreshClaudeTokens | null> {
+  const stored = await readStoredCreds(vault, CLAUDE_CODE_PROVIDER_ID);
+  if (!stored) return null;
+  const { tokenSet, extras } = stored;
+  if (tokenSet.refreshToken && isExpired(tokenSet)) {
+    const refreshed = await refreshAndPersist(vault, tokenSet.refreshToken, extras.account_email);
+    return { accessToken: refreshed.accessToken, ...(refreshed.expiresAt !== undefined ? { expiresAt: refreshed.expiresAt } : {}), canRefresh: true };
+  }
+  return {
+    accessToken: tokenSet.accessToken,
+    ...(tokenSet.expiresAt !== undefined ? { expiresAt: tokenSet.expiresAt } : {}),
+    canRefresh: tokenSet.refreshToken !== undefined,
+  };
+}
+
+/**
+ * Force a refresh of the stored Claude tokens and persist the rotated bundle.
+ * Used as the provider's reactive 401 recovery. Throws if no refresh_token is
+ * stored (e.g. a pasted `setup-token`).
+ */
+export async function refreshClaudeAccessToken(
+  vault: OAuthVault,
+): Promise<{ token: string; expiresAt?: number }> {
+  const stored = await readStoredCreds(vault, CLAUDE_CODE_PROVIDER_ID);
+  if (!stored?.tokenSet.refreshToken) {
+    throw new MoxxyError({
+      code: 'AUTH_EXPIRED',
+      message: 'Claude token expired and no refresh_token is stored.',
+      hint: 'Run `moxxy login claude-code` again, or refresh `CLAUDE_CODE_OAUTH_TOKEN` via `claude setup-token`.',
+      context: { provider: CLAUDE_CODE_PROVIDER_ID },
+    });
+  }
+  const refreshed = await refreshAndPersist(
+    vault,
+    stored.tokenSet.refreshToken,
+    stored.extras.account_email,
+  );
+  return { token: refreshed.accessToken, ...(refreshed.expiresAt !== undefined ? { expiresAt: refreshed.expiresAt } : {}) };
+}
+
+// --- internal HTTP (JSON dialect) -----------------------------------------
+
+interface ClaudeExchangeResult {
+  readonly tokenSet: TokenSet;
+  readonly accountEmail?: string;
+}
+
+/** Test seam so the exchange/refresh can run against a fake fetch. */
+let fetchImpl: typeof fetch = fetch;
+export function __setClaudeFetch(f: typeof fetch): void {
+  fetchImpl = f;
+}
+
+/** Test seam so the OOB login can run without launching a real browser. */
+let openBrowserImpl: (url: string) => Promise<void> = openInBrowser;
+export function __setClaudeOpenBrowser(f: (url: string) => Promise<void>): void {
+  openBrowserImpl = f;
+}
+
+async function exchangeClaudeCode(
+  code: string,
+  state: string,
+  verifier: string,
+): Promise<ClaudeExchangeResult> {
+  return postClaudeToken({
+    grant_type: 'authorization_code',
+    code,
+    state,
+    client_id: CLAUDE_CLIENT_ID,
+    redirect_uri: CLAUDE_REDIRECT_URI,
+    code_verifier: verifier,
+  });
+}
+
+async function refreshAndPersist(
+  vault: OAuthVault,
+  refreshToken: string,
+  priorEmail: string | undefined,
+): Promise<TokenSet> {
+  const { tokenSet, accountEmail } = await postClaudeToken({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: CLAUDE_CLIENT_ID,
+  });
+  // Claude rotates the refresh_token on every refresh; if a response ever
+  // omits one, keep the prior so we don't lock ourselves out.
+  const merged: TokenSet = tokenSet.refreshToken
+    ? tokenSet
+    : { ...tokenSet, refreshToken };
+  await persistClaudeTokens(vault, merged, accountEmail ?? priorEmail);
+  return merged;
+}
+
+async function persistClaudeTokens(
+  vault: OAuthVault,
+  tokenSet: TokenSet,
+  accountEmail: string | undefined,
+): Promise<void> {
+  await storeTokenSet(vault, CLAUDE_CODE_PROVIDER_ID, tokenSet, {
+    clientId: CLAUDE_CLIENT_ID,
+    tokenUrl: CLAUDE_TOKEN_URL,
+    ...(accountEmail ? { extras: { account_email: accountEmail } } : {}),
+  });
+}
+
+async function postClaudeToken(body: Record<string, string>): Promise<ClaudeExchangeResult> {
+  const res = await fetchImpl(CLAUDE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new MoxxyError({
+      code: res.status === 401 || res.status === 403 ? 'AUTH_DENIED' : 'AUTH_INVALID',
+      message: `Claude token endpoint returned HTTP ${res.status}: ${text.slice(0, 300)}`,
+      context: { provider: CLAUDE_CODE_PROVIDER_ID, status: res.status },
+    });
+  }
+  const json = (await res.json()) as Record<string, unknown>;
+  return { tokenSet: parseTokenResponse(json), ...extractAccountEmail(json) };
+}
+
+function extractAccountEmail(json: Record<string, unknown>): { accountEmail?: string } {
+  const account = json.account;
+  if (account && typeof account === 'object') {
+    const email = (account as { email_address?: unknown }).email_address;
+    if (typeof email === 'string' && email) return { accountEmail: email };
+  }
+  return {};
+}

--- a/packages/plugin-provider-claude-code/src/profile.ts
+++ b/packages/plugin-provider-claude-code/src/profile.ts
@@ -1,0 +1,27 @@
+/**
+ * `OAuthProviderProfile` for the Claude subscription provider. Unlike the
+ * codex profile this one does NOT drive `runOauthLogin` — Claude uses an
+ * out-of-band (manual code-paste) flow that the framework's loopback/device
+ * orchestrators don't model, so login lives in `login.ts`. The profile is
+ * still used for the parts the framework DOES own: `ensureFreshTokens`
+ * (refresh + persist) and the `storeTokenSet` metadata layout.
+ */
+
+import type { OAuthProviderProfile } from '@moxxy/plugin-oauth';
+import {
+  CLAUDE_AUTHORIZE_URL,
+  CLAUDE_CLIENT_ID,
+  CLAUDE_CODE_PROVIDER_ID,
+  CLAUDE_CODE_SERVICE_NAME,
+  CLAUDE_SCOPES,
+  CLAUDE_TOKEN_URL,
+} from './constants.js';
+
+export const claudeOauthProfile: OAuthProviderProfile = {
+  id: CLAUDE_CODE_PROVIDER_ID,
+  displayName: CLAUDE_CODE_SERVICE_NAME,
+  authUrl: CLAUDE_AUTHORIZE_URL,
+  tokenUrl: CLAUDE_TOKEN_URL,
+  clientId: CLAUDE_CLIENT_ID,
+  scopes: [...CLAUDE_SCOPES],
+};

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { claudeCodeProviderDef, createClaudeCodeClient } from './index.js';
+
+describe('claude-code provider definition', () => {
+  it('registers as an OAuth provider named claude-code with Claude models', () => {
+    expect(claudeCodeProviderDef.name).toBe('claude-code');
+    expect(claudeCodeProviderDef.auth?.kind).toBe('oauth');
+    expect(claudeCodeProviderDef.models.length).toBeGreaterThan(0);
+    expect(claudeCodeProviderDef.models.map((m) => m.id)).toContain('claude-sonnet-4-6');
+  });
+
+  it('builds an OAuth-mode client that reports the claude-code name', () => {
+    const client = createClaudeCodeClient({ oauthToken: 'tok' });
+    expect(client.name).toBe('claude-code');
+    const inner = (client as unknown as { client: { apiKey: unknown; authToken: unknown } }).client;
+    expect(inner.apiKey).toBeNull();
+    expect(inner.authToken).toBe('tok');
+  });
+});

--- a/packages/plugin-provider-claude-code/src/provider.ts
+++ b/packages/plugin-provider-claude-code/src/provider.ts
@@ -1,0 +1,34 @@
+/**
+ * The Claude subscription provider is the standard Anthropic Messages API
+ * with a bearer (OAuth) credential instead of an API key, so it reuses
+ * `AnthropicProvider` in OAuth mode rather than duplicating the streaming /
+ * tool-call event handling. This module just stamps in the Claude-specific
+ * constants (beta headers + the required identity preamble) and forwards the
+ * resolved token + refresh callback.
+ */
+
+import { AnthropicProvider } from '@moxxy/plugin-provider-anthropic';
+import { CLAUDE_CODE_PROVIDER_ID, CLAUDE_CODE_SYSTEM, CLAUDE_OAUTH_BETA } from './constants.js';
+
+export interface ClaudeCodeProviderConfig {
+  /** Claude Code OAuth access token (bearer). Resolved by the host. */
+  readonly oauthToken?: string;
+  /** Epoch-ms expiry of `oauthToken`, when known (drives proactive refresh). */
+  readonly oauthExpiresAt?: number;
+  /** Refresh callback wired by the host; omitted for non-refreshable tokens. */
+  readonly oauthRefresh?: () => Promise<{ readonly token: string; readonly expiresAt?: number }>;
+  /** Optional default model override. */
+  readonly defaultModel?: string;
+}
+
+export function createClaudeCodeClient(config: ClaudeCodeProviderConfig = {}): AnthropicProvider {
+  return new AnthropicProvider({
+    name: CLAUDE_CODE_PROVIDER_ID,
+    oauthBeta: [...CLAUDE_OAUTH_BETA],
+    systemPreamble: CLAUDE_CODE_SYSTEM,
+    ...(config.oauthToken ? { oauthToken: config.oauthToken } : {}),
+    ...(config.oauthExpiresAt !== undefined ? { oauthExpiresAt: config.oauthExpiresAt } : {}),
+    ...(config.oauthRefresh ? { oauthRefresh: config.oauthRefresh } : {}),
+    ...(config.defaultModel ? { defaultModel: config.defaultModel } : {}),
+  });
+}

--- a/packages/plugin-provider-claude-code/tsconfig.json
+++ b/packages/plugin-provider-claude-code/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/plugin-provider-claude-code/vitest.config.ts
+++ b/packages/plugin-provider-claude-code/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/packages/sdk/src/provider.ts
+++ b/packages/sdk/src/provider.ts
@@ -136,6 +136,15 @@ export interface ProviderAuthContext {
    * whether they're running inside a wizard or a one-shot command.
    */
   readonly write: (chunk: string) => void;
+  /**
+   * Optional single-line input prompt. Present when the host has an
+   * interactive TTY; absent in headless runs. Flows that need the user to
+   * paste something back — out-of-band / manual authorization-code flows,
+   * or an existing-token paste — call this; flows that capture the code via
+   * a loopback server (e.g. openai-codex) ignore it. Pass `{ mask: true }`
+   * for secrets so the host can hide the echoed characters.
+   */
+  readonly prompt?: (question: string, opts?: { readonly mask?: boolean }) => Promise<string>;
 }
 
 export interface ProviderOAuthResult {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,6 +383,9 @@ importers:
       '@moxxy/plugin-provider-anthropic':
         specifier: workspace:*
         version: link:../plugin-provider-anthropic
+      '@moxxy/plugin-provider-claude-code':
+        specifier: workspace:*
+        version: link:../plugin-provider-claude-code
       '@moxxy/plugin-provider-openai':
         specifier: workspace:*
         version: link:../plugin-provider-openai
@@ -1355,6 +1358,37 @@ importers:
       '@moxxy/mode-tool-use':
         specifier: workspace:*
         version: link:../mode-tool-use
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
+
+  packages/plugin-provider-claude-code:
+    dependencies:
+      '@moxxy/plugin-oauth':
+        specifier: workspace:*
+        version: link:../plugin-oauth
+      '@moxxy/plugin-provider-anthropic':
+        specifier: workspace:*
+        version: link:../plugin-provider-anthropic
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+    devDependencies:
       '@moxxy/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig


### PR DESCRIPTION
## What

Adds a `claude-code` provider so Claude **Pro/Max subscribers** can run moxxy with their subscription instead of a pay-as-you-go API key — the Claude equivalent of the existing `openai-codex` (ChatGPT subscription) provider.

It talks to the **standard Anthropic Messages API**, but authenticates with a Claude Code OAuth bearer token. Activate with:

```yaml
# moxxy.config.yaml
provider:
  name: claude-code
```

## Authenticating — two ways in

1. **Paste a `claude setup-token` token** (long-lived, ~1yr):
   ```sh
   export CLAUDE_CODE_OAUTH_TOKEN="$(claude setup-token)"
   ```
   (`ANTHROPIC_AUTH_TOKEN` also works.)
2. **`moxxy login claude-code`** — interactive out-of-band OAuth (browser → paste the `code#state` back). The same prompt also accepts a setup-token paste. Browser-flow tokens refresh automatically.

## Changes

- **`@moxxy/plugin-provider-claude-code`** (new package) — constants, OAuth profile, login/logout/status + the out-of-band flow, provider factory, tests.
- **`@moxxy/plugin-provider-anthropic`** — `AnthropicProvider` gained an OAuth mode: `Authorization: Bearer` + `apiKey:null`, `anthropic-beta: oauth-2025-04-20`, the required `You are Claude Code…` identity preamble as the **first** system block, proactive refresh + refresh-on-401. The API-key path is unchanged.
- **`@moxxy/sdk`** — `ProviderAuthContext` gained an optional `prompt?()` so auth flows can ask the user to paste a code/token.
- **CLI** — `claude-code` credential resolution (vault → `CLAUDE_CODE_OAUTH_TOKEN` env), clack-backed prompt wiring, builtins registration.
- Changeset + docs (`provider-oauth-login.md`, README/AGENTS).

## Why the new package implements its own token HTTP

Claude's OAuth token endpoint speaks **JSON** (not the form-encoded dialect of `plugin-oauth`'s `exchangeCodeForToken`/`refreshAccessToken`), and login is **out-of-band** (manual `code#state` paste — no loopback server). So the exchange/refresh/login live in the new package while reusing `plugin-oauth`'s PKCE, URL builder, vault storage, and `parseTokenResponse`.

## Verification

All green: `build 56/56` · `typecheck 108/108` · `lint 0 errors` · `test 106/106` (incl. 34 new) · `check:deps clean`.

Unit tests cover bearer-mode construction, identity-preamble-as-first-block, the out-of-band `code#state` exchange, refresh/rotation, env/vault resolution, and logout/status — no real token needed.

**Needs a real subscription token for manual e2e:** the auth mechanism is verified against opencode's working behavior (the widely-cited cedws gist is wrong about `x-api-key`; Bearer is correct). The only unverified knob is the exact `anthropic-beta` flag set — if a live call 401s, adjust `CLAUDE_OAUTH_BETA` in `constants.ts`.

> **ToS note:** Anthropic's consumer terms intend subscription OAuth tokens for official Claude clients. Implemented as requested; mirrors the existing `openai-codex` provider.