### PR TITLE
fix(core): migrate legacy mode names so an old `mode: tool-use` can't crash boot

### DIFF
--- a/.changeset/legacy-mode-name-migration.md
+++ b/.changeset/legacy-mode-name-migration.md
@@ -1,0 +1,13 @@
+---
+"@moxxy/sdk": minor
+"@moxxy/cli": patch
+---
+
+Fix "Mode not registered: tool-use" after the mode rename. A mode name persisted
+anywhere (config `mode:`, `~/.moxxy/preferences.json`, a desktop workspace's
+stored mode, a runner `setMode` RPC, a mid-turn mode hand-off) is now funneled
+through a legacy-name map in `ModeRegistry.setActive`: it tries the literal name
+first and falls back to the current name (`tool-use`→`default`,
+`deep-research`→`research`; the removed `plan-execute`/`bmad`/`developer` →
+`default`). A validly-registered name is never overridden, and a genuinely
+unknown mode still throws. Exposes `migrateModeName(name)` from `@moxxy/sdk`.

--- a/packages/core/src/preferences.ts
+++ b/packages/core/src/preferences.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { writeFileAtomic } from '@moxxy/sdk';
+import { migrateModeName, writeFileAtomic } from '@moxxy/sdk';
 
 /**
  * User-level runtime preferences persisted at ~/.moxxy/preferences.json.
@@ -20,17 +20,6 @@ export interface MoxxyPreferences {
   readonly mode?: string;
 }
 
-/**
- * Legacy mode-name → current-name map. Mode strings were renamed
- * ("tool-use" → "default", "deep-research" → "research"); existing
- * ~/.moxxy/preferences.json files still carry the old names, so we
- * coerce them on read rather than silently dropping the user's choice.
- */
-const MODE_NAME_MIGRATIONS: Readonly<Record<string, string>> = {
-  'tool-use': 'default',
-  'deep-research': 'research',
-};
-
 export function preferencesPath(): string {
   return path.join(os.homedir(), '.moxxy', 'preferences.json');
 }
@@ -46,8 +35,7 @@ export async function loadPreferences(): Promise<MoxxyPreferences> {
     const parsed = JSON.parse(raw) as unknown;
     if (parsed && typeof parsed === 'object') {
       const prefs = parsed as MoxxyPreferences;
-      const migrated = prefs.mode ? MODE_NAME_MIGRATIONS[prefs.mode] : undefined;
-      return migrated ? { ...prefs, mode: migrated } : prefs;
+      return prefs.mode ? { ...prefs, mode: migrateModeName(prefs.mode) } : prefs;
     }
     return {};
   } catch {

--- a/packages/core/src/registries/modes.test.ts
+++ b/packages/core/src/registries/modes.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { defineMode } from '@moxxy/sdk';
+import { ModeRegistry } from './modes.js';
+
+const mode = (name: string) => defineMode({ name, run: async function* () {} });
+
+describe('ModeRegistry legacy-name migration', () => {
+  it('resolves a legacy mode name to the current one on setActive', () => {
+    const reg = new ModeRegistry();
+    reg.register(mode('default'));
+    reg.register(mode('research'));
+
+    // Old names persisted in config/preferences/RPCs must not crash.
+    reg.setActive('tool-use');
+    expect(reg.getActive().name).toBe('default');
+
+    reg.setActive('deep-research');
+    expect(reg.getActive().name).toBe('research');
+
+    // Removed modes fall back to the default mode rather than throwing.
+    reg.setActive('plan-execute');
+    expect(reg.getActive().name).toBe('default');
+  });
+
+  it('still throws on a genuinely unknown mode (not a known legacy name)', () => {
+    const reg = new ModeRegistry();
+    reg.register(mode('default'));
+    expect(() => reg.setActive('totally-made-up')).toThrow(/Mode not registered: totally-made-up/);
+  });
+
+  it('passes a current name through unchanged', () => {
+    const reg = new ModeRegistry();
+    reg.register(mode('default'));
+    reg.register(mode('goal'));
+    reg.setActive('goal');
+    expect(reg.getActive().name).toBe('goal');
+  });
+});

--- a/packages/core/src/registries/modes.ts
+++ b/packages/core/src/registries/modes.ts
@@ -1,4 +1,4 @@
-import type { ModeDef } from '@moxxy/sdk';
+import { migrateModeName, type ModeDef } from '@moxxy/sdk';
 
 export class ModeRegistry {
   private readonly modes = new Map<string, ModeDef>();
@@ -46,7 +46,11 @@ export class ModeRegistry {
   }
 
   setActive(name: string): void {
-    const mode = this.modes.get(name);
+    // Prefer the literal name; only when it isn't registered fall back to the
+    // legacy-name map (e.g. a persisted "tool-use" → "default"). This never
+    // overrides a validly-registered name and keeps an old config / preference
+    // / setMode RPC value from crashing a session with "Mode not registered".
+    const mode = this.modes.get(name) ?? this.modes.get(migrateModeName(name));
     if (!mode) throw new Error(`Mode not registered: ${name}`);
     this.activate(mode);
   }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -348,6 +348,8 @@ export {
   defineWorkflowExecutor,
 } from './define.js';
 
+export { migrateModeName } from './mode.js';
+
 export {
   skillFrontmatterSchema,
   pluginManifestSchema,

--- a/packages/sdk/src/mode.ts
+++ b/packages/sdk/src/mode.ts
@@ -182,3 +182,25 @@ export interface ModeDef {
   readonly badge?: ModeBadge;
   run(ctx: ModeContext): AsyncIterable<MoxxyEvent>;
 }
+
+/**
+ * Legacy mode-name → current-name map for backward compatibility. Modes were
+ * renamed/slimmed: `tool-use`→`default`, `deep-research`→`research`, and the
+ * removed `plan-execute`/`bmad`/`developer` modes fall back to `default`. Any
+ * mode name arriving from persisted or external state — config files,
+ * `~/.moxxy/preferences.json`, a desktop workspace's stored mode, a runner
+ * `setMode` RPC — is funneled through {@link migrateModeName} so an old name
+ * resolves to the current one instead of crashing with "Mode not registered".
+ */
+const LEGACY_MODE_NAMES: Readonly<Record<string, string>> = {
+  'tool-use': 'default',
+  'deep-research': 'research',
+  'plan-execute': 'default',
+  bmad: 'default',
+  developer: 'default',
+};
+
+/** Map a possibly-legacy mode name to its current name (identity if unknown). */
+export function migrateModeName(name: string): string {
+  return LEGACY_MODE_NAMES[name] ?? name;
+}


### PR DESCRIPTION
Follow-up to the mode rename (#93, merged): any **persisted/external mode name** still saying `tool-use` (or a removed mode) crashed a session with:

```
error: Mode not registered: tool-use
```

Sources that bypass the preferences migration: a `mode:` line in `~/.moxxy/config.yaml` or a project config (`setup.ts`), a desktop workspace's stored mode (`session.setMode` IPC), a runner `setMode` RPC, a Telegram mode callback, or a mid-turn mode hand-off.

## Fix

Migrate legacy names at the chokepoint — `ModeRegistry.setActive` — so **every** caller is covered:

```ts
const mode = this.modes.get(name) ?? this.modes.get(migrateModeName(name));
if (!mode) throw new Error(`Mode not registered: ${name}`);
```

- **Literal name first**, legacy-map fallback only if unregistered — a validly-registered name is never overridden.
- Map: `tool-use`→`default`, `deep-research`→`research`; removed `plan-execute`/`bmad`/`developer`→`default`.
- A genuinely unknown mode (typo) still throws.
- `migrateModeName(name)` exported from `@moxxy/sdk`; `core/preferences.ts` routes through it (single source of truth).

## Verification

- New unit test `core/registries/modes.test.ts` (legacy→current, removed-mode fallback, unknown-still-throws, passthrough).
- **Ran the built binary** with `mode: tool-use` and `mode: plan-execute` configs → both boot cleanly, exit 0, no crash.
- `pnpm build` 51/51 · core 200 tests · sdk 119 tests green.