### PR TITLE
fix(plugin-cli): simplify /plugins tabs, clean modal header, scrollable slash list

### DIFF
--- a/.changeset/plugins-picker-polish.md
+++ b/.changeset/plugins-picker-polish.md
@@ -1,0 +1,16 @@
+---
+"@moxxy/cli": patch
+---
+
+Polish the TUI: simplify the `/plugins` picker and make slash autocomplete
+scrollable.
+
+- `/plugins` now uses a few basic tabs — **Providers, Modes, Channels, Tools,
+  Others, Installable** — instead of one tab per contribution kind. Disabled
+  plugins live under "Others" with an `[off]` badge. Heading is just "Plugins".
+- Modal headers no longer paint a filled background band (it rendered as dark
+  "bars" on many terminals) — the title + tabs sit as clean text, with the
+  active tab marked by an inverse pill.
+- The `/` slash-command dropdown is no longer capped at 8 entries: it shows a
+  scrolling window over the full command set (with `↑ N more` / `↓ N more`),
+  so every command is reachable with ↑↓.

--- a/packages/plugin-cli/src/components/Modal.tsx
+++ b/packages/plugin-cli/src/components/Modal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Text, useInput } from 'ink';
-import { Border, Colors } from '../theme.js';
+import { Border } from '../theme.js';
 
 export interface ModalTab {
   readonly id: string;
@@ -115,96 +115,51 @@ export const Modal: React.FC<ModalProps> = ({
   );
 };
 
-const BAND_BG = Colors.chrome;       // mid-tone gray fill for the heading row
-const ACTIVE_TAB_BG = 'white';       // inverse pill that pops off the gray band
+const ACTIVE_TAB_BG = 'white';       // inverse pill marking the current tab
 const ACTIVE_TAB_FG = 'black';
-const INACTIVE_TAB_FG = 'white';     // visible-but-quiet against the gray band
+const INACTIVE_TAB_FG = 'white';
 
 /**
- * Full-row gray heading band carrying the title and optional tabs.
- * The band sits flush against the box borders (no outer padding) and
- * carries its own internal padding so the title has breathing room
- * without indenting the band itself.
+ * Clean heading row carrying the title and optional tabs as plain text on
+ * the terminal background — no filled band (which rendered as dark "bars" on
+ * many terminals). A `marginTop` separates it from the top border.
  *
- * Width is computed from `process.stdout.columns` minus the 2 border
- * cells. The min floor (20) is a safety net for narrow terminals;
- * Ink truncates beyond the box width anyway.
- *
- * Tabs render inline on the band:
- * - Active tab → inverse white pill (white bg, black bold) — pops off
- *   the gray band so it reads as the current view at a glance.
- * - Inactive tab → gray-on-gray cell with plain white text — the band
- *   bg is preserved so the row feels like one cohesive surface.
+ * Tabs render inline after the title:
+ * - Active tab → inverse white pill (white bg, black bold) so the current
+ *   view reads at a glance.
+ * - Inactive tab → plain text, separated by a few spaces.
  */
 const HeaderBand: React.FC<{
   title: string;
   tabs: ReadonlyArray<ModalTab> | undefined;
   activeTabId: string | undefined;
 }> = ({ title, tabs, activeTabId }) => {
-  const termWidth = process.stdout.columns ?? 80;
-  const innerWidth = Math.max(20, termWidth - 2);
-
-  // Internal padding lives inside the band so the title and tabs feel
-  // like proper inset "chips" rather than text glued to the band edge.
-  // Title: 6 cells of band on each side. Tabs: 4 cells of pill bg on
-  // each side. Inter-tab gap: 4 band cells so adjacent tabs read as
-  // distinct chips, not a continuous strip.
-  const titleText = `      ${title}      `;
-  let used = titleText.length;
-
   const tabNodes: React.ReactNode[] = [];
   if (tabs && tabs.length > 0) {
     tabs.forEach((tab, i) => {
-      if (i > 0) {
-        tabNodes.push(
-          <Text key={`gap-${tab.id}`} backgroundColor={BAND_BG}>
-            {'  '}
-          </Text>,
-        );
-        used += 2;
-      }
+      if (i > 0) tabNodes.push(<Text key={`gap-${tab.id}`}>{'   '}</Text>);
       const focused = tab.id === activeTabId;
-      const label = ` ${tab.label} `;
       tabNodes.push(
         focused ? (
           <Text key={tab.id} backgroundColor={ACTIVE_TAB_BG} color={ACTIVE_TAB_FG} bold>
-            {label}
+            {` ${tab.label} `}
           </Text>
         ) : (
-          <Text key={tab.id} backgroundColor={BAND_BG} color={INACTIVE_TAB_FG}>
-            {label}
+          <Text key={tab.id} color={INACTIVE_TAB_FG}>
+            {tab.label}
           </Text>
         ),
       );
-      used += label.length;
     });
   }
 
-  const trailingPadding = ' '.repeat(Math.max(0, innerWidth - used));
-  // Full-width blank band row used as vertical padding above and below
-  // the content row so the heading reads as a proper title block, not a
-  // single tight line. `height={1}` is required — without it Ink can
-  // collapse a Box whose only child is a whitespace `Text` to zero
-  // height, which would surface as a dark gap between the border and
-  // the band.
-  const blankBandRow = ' '.repeat(innerWidth);
-  const renderBlankRow = (key: string): React.ReactElement => (
-    <Box key={key} width="100%" height={1}>
-      <Text backgroundColor={BAND_BG}>{blankBandRow}</Text>
-    </Box>
-  );
-
   return (
-    <Box flexDirection="column" width="100%">
-      {renderBlankRow('top')}
-      <Box width="100%" height={1}>
-        <Text backgroundColor={BAND_BG} color="white" bold>
-          {titleText}
-        </Text>
-        {tabNodes}
-        <Text backgroundColor={BAND_BG}>{trailingPadding}</Text>
-      </Box>
-      {renderBlankRow('bottom')}
+    <Box width="100%" paddingX={1} marginTop={1}>
+      <Text color="white" bold>
+        {title}
+      </Text>
+      {tabNodes.length > 0 ? <Text>{'     '}</Text> : null}
+      {tabNodes}
     </Box>
   );
 };

--- a/packages/plugin-cli/src/components/PromptInput.tsx
+++ b/packages/plugin-cli/src/components/PromptInput.tsx
@@ -100,7 +100,8 @@ export const PromptInput: React.FC<PromptInputProps> = ({
 
   const slashEligible = state.buffer.startsWith('/') && !state.buffer.includes('\n');
   const slashMatches: ReadonlyArray<SlashCommand> = slashEligible
-    ? matchSlash(state.buffer, slashCommands)
+    ? // No cap — the dropdown windows/scrolls the full match set itself.
+      matchSlash(state.buffer, slashCommands, Number.MAX_SAFE_INTEGER)
     : [];
   const slashMatchesRef = useRef(slashMatches);
   slashMatchesRef.current = slashMatches;

--- a/packages/plugin-cli/src/components/SlashCommands.tsx
+++ b/packages/plugin-cli/src/components/SlashCommands.tsx
@@ -85,15 +85,30 @@ export function matchSlash(
 /**
  * Inline autocomplete dropdown rendered above the prompt input when the
  * buffer starts with `/`. `cursor` is the index of the highlighted entry.
+ *
+ * The list scrolls: it shows a window of at most `maxVisible` rows that
+ * follows the cursor (with `↑ N more` / `↓ N more` markers), so the full
+ * command set is reachable with ↑↓ instead of being truncated.
  */
 export const SlashSuggestions: React.FC<{
   matches: ReadonlyArray<SlashCommand>;
   cursor: number;
-}> = ({ matches, cursor }) => {
+  maxVisible?: number;
+}> = ({ matches, cursor, maxVisible = 8 }) => {
   if (matches.length === 0) return null;
+  let start = 0;
+  if (matches.length > maxVisible) {
+    const half = Math.floor(maxVisible / 2);
+    start = Math.min(Math.max(0, cursor - half), matches.length - maxVisible);
+  }
+  const end = Math.min(matches.length, start + maxVisible);
+  const moreAbove = start;
+  const moreBelow = matches.length - end;
   return (
     <Box flexDirection="column">
-      {matches.map((m, i) => {
+      {moreAbove > 0 ? <Text dimColor>{`  ↑ ${moreAbove} more`}</Text> : null}
+      {matches.slice(start, end).map((m, idx) => {
+        const i = start + idx;
         const focused = i === cursor;
         return (
           <Box key={m.name}>
@@ -103,7 +118,8 @@ export const SlashSuggestions: React.FC<{
           </Box>
         );
       })}
-      <Text dimColor>  tab to complete · enter to send · esc to dismiss</Text>
+      {moreBelow > 0 ? <Text dimColor>{`  ↓ ${moreBelow} more`}</Text> : null}
+      <Text dimColor>  ↑↓ navigate · tab to complete · enter to send · esc to dismiss</Text>
     </Box>
   );
 };

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -274,26 +274,19 @@ export interface OpenPluginsPickerDeps {
   setSystemNotice: (msg: string | null) => void;
 }
 
-/** Maps a plugin's primary contribution kind to a friendly picker tab. */
+/** Maps a plugin's primary contribution kind to one of a few basic picker
+ *  tabs. Everything that isn't a provider / mode / channel / tool lands in
+ *  "Others" (embedders, voice, isolators, compactors, cache strategies, …). */
 const PLUGIN_KIND_TAB: Record<string, { id: string; label: string }> = {
   provider: { id: 'providers', label: 'Providers' },
   mode: { id: 'modes', label: 'Modes' },
   channel: { id: 'channels', label: 'Channels' },
-  tool: { id: 'tools', label: 'Tools & Agents' },
-  agent: { id: 'tools', label: 'Tools & Agents' },
-  command: { id: 'tools', label: 'Tools & Agents' },
-  embedder: { id: 'memory', label: 'Memory' },
-  transcriber: { id: 'voice', label: 'Voice' },
-  synthesizer: { id: 'voice', label: 'Voice' },
-  isolator: { id: 'security', label: 'Security' },
-  compactor: { id: 'context', label: 'Context' },
-  cacheStrategy: { id: 'context', label: 'Context' },
+  tool: { id: 'tools', label: 'Tools' },
+  agent: { id: 'tools', label: 'Tools' },
+  command: { id: 'tools', label: 'Tools' },
 };
-const OTHER_TAB = { id: 'other', label: 'Other' };
-const PLUGIN_TAB_ORDER = [
-  'providers', 'modes', 'channels', 'tools', 'memory',
-  'voice', 'context', 'security', 'other', 'disabled', 'installable',
-];
+const OTHER_TAB = { id: 'others', label: 'Others' };
+const PLUGIN_TAB_ORDER = ['providers', 'modes', 'channels', 'tools', 'others'];
 
 function shortPluginName(name: string): string {
   return name.replace(/^@moxxy\/(?:plugin-|mode-|compactor-|cache-strategy-)?/, '');
@@ -337,32 +330,28 @@ export function openPluginsPicker(deps: OpenPluginsPickerDeps): void {
       badgeColor: 'green',
     });
   }
+  // Disabled plugins have no live contribution kind to group by, so they live
+  // under "Others" with an [off] badge — still discoverable + re-enableable.
+  for (const name of [...disabled].sort()) {
+    ensureTab(OTHER_TAB.id, OTHER_TAB.label).options.push({
+      id: `${name}::enable`,
+      label: shortPluginName(name),
+      description: name,
+      badge: 'off',
+      badgeColor: 'gray',
+    });
+  }
 
   const tabs: ListPickerTab[] = [];
   for (const id of PLUGIN_TAB_ORDER) {
     const t = byTab.get(id);
-    if (t && t.options.length) {
-      tabs.push({ id, label: `${t.label} (${t.options.length})`, options: t.options });
-    }
-  }
-  if (disabled.length > 0) {
-    tabs.push({
-      id: 'disabled',
-      label: `Disabled (${disabled.length})`,
-      options: [...disabled].sort().map((name) => ({
-        id: `${name}::enable`,
-        label: shortPluginName(name),
-        description: name,
-        badge: 'off',
-        badgeColor: 'gray' as const,
-      })),
-    });
+    if (t && t.options.length) tabs.push({ id, label: t.label, options: t.options });
   }
   const installable = catalog.filter((e) => !installed.has(e.packageName));
   if (installable.length > 0) {
     tabs.push({
       id: 'installable',
-      label: `Installable (${installable.length})`,
+      label: 'Installable',
       options: installable.map((e) => ({
         id: `${e.id}::install`,
         label: e.label,
@@ -379,7 +368,7 @@ export function openPluginsPicker(deps: OpenPluginsPickerDeps): void {
   }
   deps.setPicker({
     kind: 'plugins',
-    title: 'Plugins — Enter toggles · Tab switches kind',
+    title: 'Plugins',
     tabs,
     searchable: true,
     searchPlaceholder: 'filter plugins',


### PR DESCRIPTION
TUI polish follow-ups to the `/plugins` picker (from #93), based on feedback while running it locally.

## Changes

**1. `/plugins` — fewer, basic tabs.** Was one tab per contribution kind (Providers, Modes, Channels, Tools & Agents, Memory, Voice, Context, Other, Installable). Now: **Providers · Modes · Channels · Tools · Others · Installable**. Everything that isn't a provider/mode/channel/tool lands in "Others"; disabled plugins (which have no live kind to group by) also live under "Others" with an `[off]` badge. Heading is just **"Plugins"**.

**2. Clean modal header — no more dark bars.** The shared `Modal` `HeaderBand` painted the whole heading row with a gray fill (`Colors.chrome`), which renders as dark/black bars on many terminals (gaps between tabs, blank padding rows). It's now plain text on the terminal background; the active tab is still marked by an inverse white pill. Affects every modal header (`/model`, `/mcp`, `/skills`, `/plugins`).

**3. Scrollable `/` slash-command list.** The autocomplete was capped at 8 entries with no scroll, so commands past the cap were unreachable (you had to remember the name). It now windows/scrolls the full match set (`↑ N more` / `↓ N more`) and the cursor moves through everything.

## Notes

- `pnpm build` 51/51 · plugin-cli 63 tests · lint 0 errors.
- TUI rendering can't be screenshotted headlessly here; verified via build + tests + reading the Ink layout. The before-state is the attached screenshot in the discussion.

Before (tabs + bars):
```
Plugins — Enter toggles · Tab [▮]Providers Modes[▮] Channels … Memory[▮] Voice[▮] Context[▮] Other[▮] Installable
```
After:
```
Plugins   [Providers] Modes Channels Tools Others Installable
```