### PR TITLE
fix(provider-claude-code): retry Anthropic's transient OAuth 500s

### DIFF
--- a/.changeset/claude-code-oauth-retry-transient-500.md
+++ b/.changeset/claude-code-oauth-retry-transient-500.md
@@ -1,0 +1,17 @@
+---
+"@moxxy/plugin-provider-claude-code": patch
+"@moxxy/cli": patch
+---
+
+Make `moxxy login claude-code` resilient to Anthropic's transient OAuth 500s.
+
+Anthropic's OAuth endpoints (`claude.ai/oauth/authorize` and the
+`console.anthropic.com/v1/oauth/token` exchange) intermittently return an
+`Internal server error` on the first hit — the identical request then succeeds
+on retry. The token-exchange 500 previously aborted the whole sign-in, forcing
+a full browser re-auth. `postClaudeToken` now retries transient failures
+(5xx / 429 / network errors) up to 3 attempts with a short backoff, while
+deterministic 4xx (bad/expired/already-used code, `invalid_grant`) still surface
+immediately. On exhaustion the error carries an actionable "wait and re-run"
+hint instead of a raw API dump. The browser sign-in instructions also note that
+the authorize page may need a "Try again" click on the first attempt.

--- a/packages/plugin-provider-claude-code/src/login.test.ts
+++ b/packages/plugin-provider-claude-code/src/login.test.ts
@@ -10,6 +10,7 @@ import {
   refreshClaudeAccessToken,
   __setClaudeFetch,
   __setClaudeOpenBrowser,
+  __setClaudeSleep,
 } from './login.js';
 
 interface FakeVault extends OAuthVault {
@@ -51,6 +52,7 @@ const META = { clientId: CLAUDE_CLIENT_ID, tokenUrl: CLAUDE_TOKEN_URL };
 
 beforeEach(() => {
   __setClaudeOpenBrowser(async () => {});
+  __setClaudeSleep(async () => {}); // don't actually back off under test
   __setClaudeFetch(async () => {
     throw new Error('unexpected fetch — a test forgot to stub __setClaudeFetch');
   });
@@ -99,6 +101,46 @@ describe('claudeLogin', () => {
     expect(vault.store.get('oauth/claude-code/refresh_token')).toBe('refresh-1');
     expect(vault.store.get('oauth/claude-code/extras')).toContain('me@example.com');
     expect(res.accountId).toBe('me@example.com');
+  });
+
+  it('retries a transient 5xx from the token endpoint and then succeeds', async () => {
+    const vault = makeVault();
+    let calls = 0;
+    __setClaudeFetch(async () => {
+      calls++;
+      if (calls < 3) return jsonResponse({ error: { type: 'api_error', message: 'Internal server error' } }, 500);
+      return jsonResponse({ access_token: 'access-after-retry', token_type: 'Bearer', expires_in: 3600 });
+    });
+
+    const res = await claudeLogin(makeCtx(vault, ['', 'AUTHCODE']));
+
+    expect(calls).toBe(3); // two 500s, third attempt wins
+    expect(vault.store.get('oauth/claude-code/access_token')).toBe('access-after-retry');
+    expect(res.expiresAt).toBeGreaterThan(0);
+  });
+
+  it('does NOT retry a deterministic 4xx — surfaces it immediately', async () => {
+    const vault = makeVault();
+    let calls = 0;
+    __setClaudeFetch(async () => {
+      calls++;
+      return jsonResponse({ error: { type: 'invalid_request', message: 'invalid_grant' } }, 400);
+    });
+
+    await expect(claudeLogin(makeCtx(vault, ['', 'AUTHCODE']))).rejects.toThrow(/HTTP 400/);
+    expect(calls).toBe(1);
+  });
+
+  it('gives a transient-retry hint after exhausting attempts on persistent 5xx', async () => {
+    const vault = makeVault();
+    let calls = 0;
+    __setClaudeFetch(async () => {
+      calls++;
+      return jsonResponse({ error: { type: 'api_error', message: 'Internal server error' } }, 500);
+    });
+
+    await expect(claudeLogin(makeCtx(vault, ['', 'AUTHCODE']))).rejects.toThrow(/after 3 attempts/);
+    expect(calls).toBe(3);
   });
 
   it('splits a pasted `code#state` and rejects a mismatched state', async () => {

--- a/packages/plugin-provider-claude-code/src/login.ts
+++ b/packages/plugin-provider-claude-code/src/login.ts
@@ -91,7 +91,9 @@ export async function claudeLogin(ctx: ProviderAuthContext): Promise<ProviderOAu
   ctx.write(
     `\nSign in to ${CLAUDE_CODE_SERVICE_NAME} to authorize moxxy.\n\n` +
       `If your browser doesn't open automatically, paste this URL:\n\n  ${authUrl}\n\n` +
-      `After approving, copy the authorization code shown and paste it back here.\n\n`,
+      `After approving, copy the authorization code shown and paste it back here.\n` +
+      `(Anthropic's sign-in page sometimes shows "Internal server error" on the\n` +
+      ` first attempt — just click "Try again" and it goes through.)\n\n`,
   );
   try {
     await openBrowserImpl(authUrl);
@@ -218,6 +220,22 @@ export function __setClaudeOpenBrowser(f: (url: string) => Promise<void>): void 
   openBrowserImpl = f;
 }
 
+/** Test seam so the retry backoff doesn't actually sleep under test. */
+let sleepImpl = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+export function __setClaudeSleep(f: (ms: number) => Promise<void>): void {
+  sleepImpl = f;
+}
+
+/**
+ * Anthropic's OAuth endpoints (both `claude.ai/oauth/authorize` and the token
+ * endpoint) intermittently return a transient HTTP 500 — the *same* request
+ * then succeeds on retry. So retry 5xx/429/network failures with a short
+ * backoff before giving up. 4xx (bad/expired/already-used code, invalid_grant)
+ * is deterministic and surfaced immediately, never retried.
+ */
+const TOKEN_POST_MAX_ATTEMPTS = 3;
+const TOKEN_POST_BACKOFF_MS = [600, 1800] as const;
+
 async function exchangeClaudeCode(
   code: string,
   state: string,
@@ -265,21 +283,48 @@ async function persistClaudeTokens(
 }
 
 async function postClaudeToken(body: Record<string, string>): Promise<ClaudeExchangeResult> {
-  const res = await fetchImpl(CLAUDE_TOKEN_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
+  let transient = '';
+  for (let attempt = 1; attempt <= TOKEN_POST_MAX_ATTEMPTS; attempt++) {
+    if (attempt > 1) await sleepImpl(TOKEN_POST_BACKOFF_MS[attempt - 2] ?? 1800);
+
+    let res: Response;
+    try {
+      res = await fetchImpl(CLAUDE_TOKEN_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      transient = `network error (${err instanceof Error ? err.message : String(err)})`;
+      continue;
+    }
+
+    if (res.ok) {
+      const json = (await res.json()) as Record<string, unknown>;
+      return { tokenSet: parseTokenResponse(json), ...extractAccountEmail(json) };
+    }
+
     const text = await res.text().catch(() => '');
-    throw new MoxxyError({
-      code: res.status === 401 || res.status === 403 ? 'AUTH_DENIED' : 'AUTH_INVALID',
-      message: `Claude token endpoint returned HTTP ${res.status}: ${text.slice(0, 300)}`,
-      context: { provider: CLAUDE_CODE_PROVIDER_ID, status: res.status },
-    });
+    // Deterministic client errors: surface immediately, don't burn retries.
+    if (res.status < 500 && res.status !== 429) {
+      throw new MoxxyError({
+        code: res.status === 401 || res.status === 403 ? 'AUTH_DENIED' : 'AUTH_INVALID',
+        message: `Claude token endpoint returned HTTP ${res.status}: ${text.slice(0, 300)}`,
+        context: { provider: CLAUDE_CODE_PROVIDER_ID, status: res.status },
+      });
+    }
+    // 5xx / 429 — Anthropic-side flake; loop and try the same request again.
+    transient = `HTTP ${res.status}: ${text.slice(0, 200)}`;
   }
-  const json = (await res.json()) as Record<string, unknown>;
-  return { tokenSet: parseTokenResponse(json), ...extractAccountEmail(json) };
+
+  throw new MoxxyError({
+    code: 'AUTH_INVALID',
+    message: `Claude token endpoint kept failing after ${TOKEN_POST_MAX_ATTEMPTS} attempts (last: ${transient}).`,
+    hint:
+      "Anthropic's OAuth endpoint is returning transient errors right now — " +
+      'wait a few seconds and run `moxxy login claude-code` again.',
+    context: { provider: CLAUDE_CODE_PROVIDER_ID },
+  });
 }
 
 function extractAccountEmail(json: Record<string, unknown>): { accountEmail?: string } {


### PR DESCRIPTION
## Problem

`moxxy login claude-code` fails on the first attempt with an `Internal server error`:

- The browser **authorize** page (`claude.ai/oauth/authorize`) renders *"Authorization failed / Internal server error / Try again"* on the first load.
- The **token-exchange** POST (`console.anthropic.com/v1/oauth/token`) returns `HTTP 500: {"type":"error","error":{"type":"api_error",...}}`, which aborted sign-in and forced a full browser re-auth.

The identical request succeeds on retry — i.e. this is **Anthropic-side transient flakiness, not a malformed request**. Our authorize URL and token body match the canonical Claude Code OAuth client params.

## Fix

- `postClaudeToken` now retries transient failures (**5xx / 429 / network errors**) up to 3 attempts with a 600ms→1800ms backoff, so the terminal-side token-exchange 500 self-heals instead of aborting the whole login.
- Deterministic **4xx** (bad/expired/already-used code, `invalid_grant`) still surface immediately — never retried.
- On exhaustion, the error carries an actionable *"wait and re-run"* hint instead of a raw API dump.
- The browser sign-in instructions now note that the authorize page may need a **"Try again"** click on the first attempt (that one we can't auto-retry — it's the user clicking the button).

## Tests

3 new tests in `login.test.ts` (with a `__setClaudeSleep` seam so the backoff doesn't actually delay the suite):
- retries a transient 5xx then succeeds,
- does **not** retry a deterministic 4xx,
- surfaces the transient-retry hint after exhausting attempts on persistent 5xx.

Full suite green: build 52/52, typecheck 101/101, lint 0 errors, package tests 14/14.