### PR TITLE
fix(sdk): keep auto-compaction/elision alive on unlisted model ids

### DIFF
--- a/.changeset/auto-elision-unlisted-model.md
+++ b/.changeset/auto-elision-unlisted-model.md
@@ -1,0 +1,20 @@
+---
+"@moxxy/sdk": patch
+"@moxxy/cli": patch
+---
+
+Fix auto-compaction and auto-elision silently disabling on unrecognised model
+ids — the agent could grow its context unbounded and lose earlier context.
+
+`runCompactionIfNeeded` and `runElisionIfNeeded` resolved the model's context
+window via an exact `provider.models.find(m => m.id === ctx.model)` and bailed
+to a permanent no-op when it missed. But `config.model` is a free-form string
+and providers serve ids that aren't in their fixed descriptor list (a newer
+release like `claude-opus-4-8`, a dated id, or a runtime provider-admin model),
+so any such id turned BOTH context-management features off for the whole
+session. A shared `resolveModelContext` now falls back to the provider's first
+descriptor — exactly what the TUI context meter already did — so compaction and
+elision stay active on unlisted ids. The reactive overflow recovery
+(`runCompactionIfNeeded(ctx, { force: true })`) also now runs even when no
+window can be resolved at all, so an over-context turn compacts-and-retries
+instead of dying.

--- a/packages/sdk/src/compactor-helpers.test.ts
+++ b/packages/sdk/src/compactor-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   estimateContextTokens,
   isContextOverflowError,
   runCompactionIfNeeded,
+  runElisionIfNeeded,
   type CompactorDef,
   type EmittedEvent,
   type EventLogReader,
@@ -131,6 +132,58 @@ describe('runCompactionIfNeeded', () => {
     expect(ctx.emitted[0]).toMatchObject({ type: 'error', kind: 'retryable' });
   });
 
+  it('still resolves a context window for a model id not in the descriptor list', async () => {
+    // Regression: an unlisted model id (e.g. a newer release the provider's
+    // fixed descriptor list doesn't enumerate) used to make shouldCompact never
+    // run, silently disabling auto-compaction for the whole session.
+    let observedWindow = -1;
+    const compactor: CompactorDef = {
+      name: 'inspect',
+      shouldCompact: (_log, budget) => {
+        observedWindow = budget.contextWindow;
+        return false;
+      },
+      compact: async () => {
+        throw new Error('should not run');
+      },
+    };
+    const ctx = makeCtx({
+      compactor,
+      model: 'claude-opus-4-7', // the listed descriptor
+      contextWindow: 800_000,
+      ctxModelId: 'claude-opus-4-8', // …but the session runs an unlisted id
+    });
+    await runCompactionIfNeeded(ctx);
+    // Falls back to models[0].contextWindow instead of bailing.
+    expect(observedWindow).toBe(800_000);
+  });
+
+  it('force-compacts even when the provider exposes no usable context window', async () => {
+    // Reactive overflow recovery: the provider already said the prompt is too
+    // big, so a missing/zero window must NOT block the forced compaction.
+    const compact = vi.fn(async () => ({
+      type: 'compaction' as const,
+      replacedRange: [0, 1] as [number, number],
+      summary: 'summary',
+      tokensSaved: 500,
+    }));
+    const compactor: CompactorDef = { name: 'gated', shouldCompact: () => false, compact };
+    const ctx = makeCtx({ compactor, emptyModels: true });
+    const did = await runCompactionIfNeeded(ctx, { force: true });
+    expect(did).toBe(true);
+    expect(compact).toHaveBeenCalledOnce();
+  });
+
+  it('is a no-op (non-force) when the provider exposes no usable context window', async () => {
+    const compact = vi.fn();
+    const shouldCompact = vi.fn().mockReturnValue(true);
+    const ctx = makeCtx({ compactor: { name: 'x', shouldCompact, compact }, emptyModels: true });
+    const did = await runCompactionIfNeeded(ctx);
+    expect(did).toBe(false);
+    expect(shouldCompact).not.toHaveBeenCalled();
+    expect(compact).not.toHaveBeenCalled();
+  });
+
   it('force compacts even when shouldCompact returns false', async () => {
     const compact = vi.fn(async () => ({
       type: 'compaction' as const,
@@ -172,11 +225,50 @@ describe('isContextOverflowError', () => {
   });
 });
 
+describe('runElisionIfNeeded', () => {
+  // Six completed turns of bulky prompts, none matching ctx.turnId (so all are
+  // "completed"). With keepRecentTurns=4 the two oldest turns are elidable.
+  const bulkyTurns: MoxxyEvent[] = Array.from({ length: 6 }, (_, i) =>
+    event(i, {
+      type: 'user_prompt',
+      turnId: asTurnId(`turn-${i}`),
+      source: 'user',
+      text: 'x'.repeat(400),
+    }),
+  );
+
+  it('elides old turns for a model id not in the descriptor list', async () => {
+    // Regression: an unlisted model id used to disable elision entirely, so the
+    // context grew unbounded and the agent lost its earlier context. With the
+    // models[0] fallback the elision high-water mark advances as expected.
+    const ctx = makeCtx({
+      compactor: null,
+      events: bulkyTurns,
+      model: 'listed-model',
+      ctxModelId: 'unlisted-model-xyz',
+      contextWindow: 1_000, // estimate (~600 tok) is well over 0.3 * window (300)
+    });
+    await runElisionIfNeeded(ctx);
+    expect(ctx.emitted.some((e) => e.type === 'elision')).toBe(true);
+  });
+
+  it('is a no-op when the provider exposes no usable context window', async () => {
+    const ctx = makeCtx({ compactor: null, events: bulkyTurns, emptyModels: true });
+    await runElisionIfNeeded(ctx);
+    expect(ctx.emitted).toHaveLength(0);
+  });
+});
+
 interface MakeCtxOpts {
   readonly compactor: CompactorDef | null;
   readonly model?: string;
   readonly contextWindow?: number;
   readonly events?: ReadonlyArray<MoxxyEvent>;
+  /** Set ctx.model to an id the provider's descriptor list does NOT contain,
+   *  so `models.find(...)` misses and the models[0] fallback must kick in. */
+  readonly ctxModelId?: string;
+  /** Give the provider an empty descriptor list (no usable context window). */
+  readonly emptyModels?: boolean;
 }
 
 function makeCtx(opts: MakeCtxOpts): ModeContext & { emitted: EmittedEvent[] } {
@@ -186,14 +278,16 @@ function makeCtx(opts: MakeCtxOpts): ModeContext & { emitted: EmittedEvent[] } {
   const log = reader(events);
   const provider = {
     name: 'fake',
-    models: [
-      {
-        id: opts.model ?? 'fake-model',
-        contextWindow: opts.contextWindow ?? 100_000,
-        supportsTools: true,
-        supportsStreaming: true,
-      },
-    ],
+    models: opts.emptyModels
+      ? []
+      : [
+          {
+            id: opts.model ?? 'fake-model',
+            contextWindow: opts.contextWindow ?? 100_000,
+            supportsTools: true,
+            supportsStreaming: true,
+          },
+        ],
     stream: async function* () { /* unused */ },
     countTokens: async () => 0,
   } as unknown as LLMProvider;
@@ -202,7 +296,9 @@ function makeCtx(opts: MakeCtxOpts): ModeContext & { emitted: EmittedEvent[] } {
   const ctx = {
     sessionId: sid,
     turnId: tid,
-    model: opts.model ?? 'fake-model',
+    // ctx.model may intentionally differ from the descriptor id to exercise the
+    // unlisted-model fallback.
+    model: opts.ctxModelId ?? opts.model ?? 'fake-model',
     provider,
     tools: { list: () => [], get: () => undefined, execute: async () => undefined },
     skills: { list: () => [], get: () => undefined, byName: () => undefined, filterByTriggers: () => [] },

--- a/packages/sdk/src/compactor-helpers.ts
+++ b/packages/sdk/src/compactor-helpers.ts
@@ -92,6 +92,31 @@ function safeJsonLen(v: unknown): number {
 }
 
 /**
+ * Resolve the active model's context window for the proactive
+ * compaction / elision thresholds.
+ *
+ * `config.model` is a free-form, unvalidated string, and providers happily
+ * serve ids that aren't in their fixed descriptor list — a newer release
+ * (`claude-opus-4-8`), a dated id, or a model registered at runtime via
+ * provider-admin. So an exact `models.find(m => m.id === ctx.model)` often
+ * MISSES, and both auto-compaction and auto-elision used to silently turn into
+ * permanent no-ops for the whole session (the context then grows unbounded and
+ * the agent "loses its context"). Falling back to the provider's first
+ * descriptor — exactly what the TUI context meter already does
+ * (`resolveContextWindow` in @moxxy/plugin-cli) — keeps both features alive on
+ * an unrecognised id. Returns null only when the provider exposes no usable
+ * window at all (no models / a zero window).
+ */
+export function resolveModelContext(
+  ctx: ModeContext,
+): { readonly contextWindow: number; readonly reserveForOutput: number } | null {
+  const descriptor = ctx.provider.models.find((m) => m.id === ctx.model) ?? ctx.provider.models[0];
+  const contextWindow = descriptor?.contextWindow;
+  if (!contextWindow || contextWindow <= 0) return null;
+  return { contextWindow, reserveForOutput: descriptor?.maxOutputTokens ?? 0 };
+}
+
+/**
  * Auto-compaction hook every mode calls once per iteration, right
  * before building messages for the next provider call. Reads the
  * active model's real `contextWindow` (not a magic max-int sentinel),
@@ -101,9 +126,8 @@ function safeJsonLen(v: unknown): number {
  * already honors compaction events, so the next provider call sees
  * the summarized prefix automatically.
  *
- * Designed to be tolerant: no compactor, no model descriptor, no
- * contextWindow, or a compactor throw all degrade to a no-op so a
- * compactor bug can't kill the turn. Failures emit a non-fatal
+ * Designed to be tolerant: no compactor or a compactor throw degrade to a
+ * no-op so a compactor bug can't kill the turn. Failures emit a non-fatal
  * `error` event for observability.
  */
 export async function runCompactionIfNeeded(
@@ -113,20 +137,22 @@ export async function runCompactionIfNeeded(
   const compactor = ctx.compactor;
   if (!compactor) return false;
 
-  // Resolve the active model's descriptor so we use the *real* context
-  // window. `Number.MAX_SAFE_INTEGER` (the old /compact behavior) made
-  // threshold-based compactors always look comfortable, even at 99%.
-  const descriptor = ctx.provider.models.find((m) => m.id === ctx.model);
-  const contextWindow = descriptor?.contextWindow;
-  if (!contextWindow || contextWindow <= 0) return false;
+  // Resolve the active model's real context window (with a models[0] fallback
+  // for unlisted ids). A reactive `force` compaction must still run when the
+  // window can't be resolved — the provider has already told us the prompt
+  // overflowed — so only the proactive threshold path requires a window. The
+  // shipped compactor ignores `contextWindow` inside `compact()`, so the
+  // sentinel below only affects `shouldCompact`, which `force` bypasses.
+  const resolved = resolveModelContext(ctx);
+  if (!resolved && !opts.force) return false;
 
   const events = ctx.log.slice();
   if (events.length === 0) return false;
 
   const budget = {
-    contextWindow,
+    contextWindow: resolved?.contextWindow ?? Number.MAX_SAFE_INTEGER,
     estimatedTokens: estimateContextTokens(ctx.log),
-    reserveForOutput: descriptor?.maxOutputTokens ?? 0,
+    reserveForOutput: resolved?.reserveForOutput ?? 0,
   } as const;
 
   // `force` skips the threshold gate — used reactively after the provider

--- a/packages/sdk/src/elision-helpers.ts
+++ b/packages/sdk/src/elision-helpers.ts
@@ -1,4 +1,4 @@
-import { estimateContextTokens } from './compactor-helpers.js';
+import { estimateContextTokens, resolveModelContext } from './compactor-helpers.js';
 import { toolResultBytes } from './elision-state.js';
 import type { EmittedEvent, MoxxyEvent } from './events.js';
 import type { ElisionSettings, ModeContext } from './mode.js';
@@ -60,9 +60,12 @@ export async function runElisionIfNeeded(ctx: ModeContext): Promise<void> {
     const s = resolveElisionSettings(ctx.elision);
     if (!s.enabled) return;
 
-    const descriptor = ctx.provider.models.find((m) => m.id === ctx.model);
-    const contextWindow = descriptor?.contextWindow;
-    if (!contextWindow || contextWindow <= 0) return;
+    // Resolve the model's real context window, with a models[0] fallback for
+    // ids not in the provider's fixed descriptor list — otherwise an
+    // unrecognised model id silently disabled elision for the whole session.
+    const resolved = resolveModelContext(ctx);
+    if (!resolved) return;
+    const contextWindow = resolved.contextWindow;
 
     // Gate: below this fill the whole history fits comfortably — eliding would
     // only add missed-context risk for no token benefit.


### PR DESCRIPTION
## Problem

The agent does not automatically unwind its context (elide/compact) on demand and sometimes loses context entirely.

**Root cause:** `runCompactionIfNeeded` and `runElisionIfNeeded` both resolve the model's context window with an exact lookup:

```ts
const descriptor = ctx.provider.models.find((m) => m.id === ctx.model);
const contextWindow = descriptor?.contextWindow;
if (!contextWindow || contextWindow <= 0) return; // ← permanent no-op
```

But `config.model` is a free-form, unvalidated string, and providers happily serve ids that aren't in their fixed descriptor list — a newer release (`claude-opus-4-8`), a dated id, or a model registered at runtime via provider-admin. The Anthropic / claude-code providers only enumerate `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`. So whenever the active id isn't one of those exact strings, `.find` misses, the window is `undefined`, and **both auto-compaction and auto-elision become permanent no-ops for the entire session** → the context grows unbounded and the agent "loses its context" (which matches the user's "sometimes").

Worse, the reactive overflow recovery `runCompactionIfNeeded(ctx, { force: true })` checks `force` *after* the descriptor guard, so an over-context turn dies instead of compacting-and-retrying.

This was masked because the TUI context meter uses a *different* resolver (`resolveContextWindow` in `@moxxy/plugin-cli`) that already falls back to `models[0]` — so the meter looked healthy while the features were off.

## Fix

- New shared `resolveModelContext(ctx)` in `@moxxy/sdk` that falls back to `provider.models[0]` when the exact id isn't found — mirroring the TUI meter. Used by both helpers, so an unlisted model id no longer disables either feature.
- The reactive `force` compaction now runs even when no window can be resolved at all (empty descriptor list) — the provider already told us the prompt overflowed, so compact regardless. (The shipped compactor ignores `contextWindow` inside `compact()`; only the `shouldCompact` threshold uses it, and `force` bypasses that.)

## Tests

5 new tests in `compactor-helpers.test.ts` (harness extended with `ctxModelId` for an id/descriptor mismatch and `emptyModels` for no usable window):
- compaction resolves the `models[0]` window for an unlisted id,
- `force` compacts with no usable window; non-`force` stays a no-op,
- elision fires for an unlisted id; stays a no-op with no usable window.

Full suite green: build 52/52, typecheck 101/101, lint 0 errors, test 99/99.

## Note

This is one of two context-related bugs reported together. The other — the **desktop** app losing conversation/context across a kill+restart (the runner spawns a fresh empty session instead of resuming) — is a separate, larger change tracked independently.