### PR TITLE
fix(desktop): resume conversation across restarts + make /new reset the session

### DIFF
--- a/.changeset/desktop-resume-session.md
+++ b/.changeset/desktop-resume-session.md
@@ -1,0 +1,33 @@
+---
+"@moxxy/cli": patch
+"@moxxy/desktop": patch
+"@moxxy/desktop-host": patch
+"@moxxy/desktop-ipc-contract": patch
+---
+
+Desktop: resume a workspace's conversation + model context across app
+restarts, and make `/new` actually start a fresh session.
+
+The desktop owns and kills its `moxxy serve` child on quit, and each launch
+spawned a bare `serve` that minted a brand-new empty session — so the model
+forgot the whole conversation and the transcript collapsed to just the
+post-restart message (the TUI didn't have this because its long-lived daemon
+survives a window close). Now each per-workspace runner is given a sticky
+session id (its desk id) so it resumes `~/.moxxy/sessions/<id>.jsonl` if present
+and starts fresh under that id on first run.
+
+- New `SetupOptions.sessionId` / `BuildSessionArgs.sessionId`: "resume-if-present"
+  (distinct from `resumeSessionId`, which errors when the log is missing — for
+  an explicit `moxxy resume <id>`).
+- `serve` reads `MOXXY_SESSION_ID`; the desktop `RunnerSupervisor`/`RunnerPool`
+  pass the workspace's desk id through to it.
+- Renderer: the runner replays its FULL history on every attach (and re-attach
+  after a reconnect), so the chat runtime now de-dupes ingested events by id
+  (`seenIds`, kept in lockstep across live append, replay, and pagination). This
+  makes a resumed replay idempotent and also fixes a latent bug where a transient
+  reconnect to a still-alive runner could duplicate the transcript.
+- `/new` now works on its own (previously it did nothing in the desktop — only
+  `/clear` was handled). It clears the transcript AND resets the runner via a
+  new `session.newSession` IPC → `RunnerSupervisor.resetSession()`, which wipes
+  the persisted session log and restarts so the model context truly resets and
+  doesn't resurrect on the next launch.

--- a/apps/desktop/src/chat/command-palette/CommandPalette.tsx
+++ b/apps/desktop/src/chat/command-palette/CommandPalette.tsx
@@ -77,11 +77,19 @@ export function CommandPalette({ workspaceId, onClose }: Props): JSX.Element {
         name: command.name,
         args: argString,
       });
-      // 'clear' is a side-effect-only directive — wipe transcript
-      // BEFORE dispatching, otherwise the result card would land in
+      // Session-action directives are side-effect-only. Wipe the transcript
+      // BEFORE dispatching the notice card below, otherwise it would land in
       // the cleared transcript and immediately disappear.
       if (result.kind === 'session-action' && result.action === 'clear') {
         chatStore.clear(workspaceId);
+      } else if (result.kind === 'session-action' && result.action === 'new') {
+        // `/new`: clear the transcript AND reset the runner to a fresh, empty
+        // session — dropping the model's context and the persisted history so
+        // it doesn't resurrect on the next launch. Without the runner reset,
+        // clearing only the renderer would leave the model still primed with
+        // the old conversation (and a restart would replay it back).
+        chatStore.clear(workspaceId);
+        await api().invoke('session.newSession', { workspaceId });
       }
       // Don't render an action_result block for pure side-effects /
       // noops; the empty header bar that we used to leave in the

--- a/apps/desktop/src/lib/chat-store/store.ts
+++ b/apps/desktop/src/lib/chat-store/store.ts
@@ -237,9 +237,14 @@ class ChatStore {
 
   private prependFresh(slot: Slot, events: ReadonlyArray<MoxxyEvent>): void {
     if (events.length === 0) return;
-    const have = new Set(slot.rt.log.toArray().map((e) => e.id));
-    const fresh = events.filter((e) => !have.has(e.id));
-    if (fresh.length > 0) slot.rt.log.prepend(fresh);
+    // `seenIds` is the authoritative membership set (kept in lockstep with the
+    // log by applyEvent + here), so a page that overlaps events already
+    // delivered by the runner's replay is de-duped without an O(n) rescan.
+    const fresh = events.filter((e) => !slot.rt.seenIds.has(e.id));
+    if (fresh.length > 0) {
+      slot.rt.log.prepend(fresh);
+      for (const e of fresh) slot.rt.seenIds.add(e.id);
+    }
   }
 
   // ---- write side --------------------------------------------------------

--- a/apps/desktop/src/lib/chatModel.test.ts
+++ b/apps/desktop/src/lib/chatModel.test.ts
@@ -87,6 +87,38 @@ describe('chat model runtime', () => {
     expect(ev).toMatchObject({ type: 'assistant_message', content: 'hi.' });
   });
 
+  it('drops a replayed/duplicate event by id (idempotent re-attach)', () => {
+    const rt = createRuntime();
+    const u = userPrompt('hello');
+    const a = assistant('hi.', 'end_turn');
+    expect(applyEvent(rt, u)).toBe(true);
+    expect(applyEvent(rt, a)).toBe(true);
+    expect(rt.log.length).toBe(2);
+    // Same ids arrive again (full-history replay on re-attach) → no-ops.
+    expect(applyEvent(rt, u)).toBe(false);
+    expect(applyEvent(rt, a)).toBe(false);
+    expect(rt.log.length).toBe(2);
+    expect(blocksOf(rt)).toHaveLength(2);
+  });
+
+  it('seeds seenIds from initial events so a replay of them is de-duped', () => {
+    const u = userPrompt('seeded');
+    const rt = createRuntime([u]);
+    expect(rt.log.length).toBe(1);
+    expect(applyEvent(rt, u)).toBe(false); // already seeded
+    expect(rt.log.length).toBe(1);
+  });
+
+  it('clear() resets seenIds so the same id can be re-added afterwards', () => {
+    const rt = createRuntime();
+    const u = userPrompt('x');
+    applyEvent(rt, u);
+    applyAction(rt, { type: 'clear' });
+    expect(rt.log.length).toBe(0);
+    expect(applyEvent(rt, u)).toBe(true); // not blocked by a stale seenId
+    expect(rt.log.length).toBe(1);
+  });
+
   it('renders a user_prompt event as a user block', () => {
     const rt = createRuntime();
     applyEvent(rt, userPrompt('hello'));

--- a/apps/desktop/src/lib/chatModel.ts
+++ b/apps/desktop/src/lib/chatModel.ts
@@ -126,6 +126,16 @@ const SUBAGENT_PLUGIN_ID = '@moxxy/subagents';
  *  identity; `log.version` changes only when a committed event lands. */
 export interface ChatRuntime {
   readonly log: ChunkedBlockLog<MoxxyEvent>;
+  /**
+   * Ids of every event already in the log — both appended (live / replay) and
+   * prepended (pagination). The runner replays its FULL history on every attach
+   * (and re-attach after a reconnect), and the renderer also seeds from the
+   * durable display log, so the same event can arrive twice. This set makes
+   * ingestion idempotent: a duplicate is dropped instead of re-rendered and
+   * re-persisted. Kept in lockstep with the log by `applyEvent` and the store's
+   * `prependFresh`.
+   */
+  readonly seenIds: Set<string>;
   extensions: Extension[];
   streamingText: string;
   activeTurnId: string | null;
@@ -137,6 +147,7 @@ export interface ChatRuntime {
 export function createRuntime(initialEvents: ReadonlyArray<MoxxyEvent> = []): ChatRuntime {
   return {
     log: new ChunkedBlockLog<MoxxyEvent>(128, initialEvents),
+    seenIds: new Set(initialEvents.map((e) => e.id)),
     extensions: [],
     streamingText: '',
     activeTurnId: null,
@@ -162,13 +173,24 @@ export function applyEvent(rt: ChatRuntime, event: MoxxyEvent): boolean {
     return true;
   }
   if (event.type === 'assistant_message') {
+    // Drop a replayed/duplicate message, but still clear any live streaming
+    // preview it corresponds to so a re-attach mid-reply doesn't strand it.
+    if (rt.seenIds.has(event.id)) {
+      if (rt.streamingText === '') return false;
+      rt.streamingText = '';
+      rt.rev += 1;
+      return true;
+    }
     rt.log.append(event);
+    rt.seenIds.add(event.id);
     rt.streamingText = '';
     rt.rev += 1;
     return true;
   }
   if (!isRenderedEvent(event)) return false;
+  if (rt.seenIds.has(event.id)) return false; // idempotent replay/reconnect
   rt.log.append(event);
+  rt.seenIds.add(event.id);
   rt.rev += 1;
   return true;
 }
@@ -193,7 +215,9 @@ export function applyAction(rt: ChatRuntime, action: ChatAction): boolean {
       // Commit any streamed text the provider never sealed with an
       // assistant_message, so the reply is never lost on turn end.
       if (rt.streamingText.trim()) {
-        rt.log.append(synthAssistantMessage(rt.streamingText, action.turnId));
+        const synth = synthAssistantMessage(rt.streamingText, action.turnId);
+        rt.log.append(synth);
+        rt.seenIds.add(synth.id);
       }
       rt.streamingText = '';
       rt.sending = false;
@@ -237,6 +261,7 @@ export function applyAction(rt: ChatRuntime, action: ChatAction): boolean {
     }
     case 'clear':
       rt.log.clear();
+      rt.seenIds.clear();
       rt.extensions = [];
       rt.streamingText = '';
       rt.activeTurnId = null;

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -225,9 +225,15 @@ async function runServeForeground(
   // forever on "lost the runner / reconnecting" instead of being able to
   // connect and walk the user through adding a provider. Turns still fail with
   // a clear "no provider" error until one is configured.
+  // A sticky session id (resume-if-present) can be injected via env — the
+  // desktop sets MOXXY_SESSION_ID to its per-workspace desk id so each runner
+  // resumes that workspace's conversation across app restarts instead of
+  // booting an empty session every launch.
+  const stickySessionId = process.env['MOXXY_SESSION_ID']?.trim();
   const setup = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
     tolerateNoProvider: true,
+    ...(stickySessionId ? { sessionId: stickySessionId } : {}),
   });
   const { session, vault, config, scheduler, webhooks } = setup;
   const setupHandle: SetupHandle = { scheduler, webhooks };

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -82,6 +82,7 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
     config,
     resolver: opts.resolver,
     resumeSessionId: opts.resumeSessionId,
+    sessionId: opts.sessionId,
     logger,
     isPluginDisabled: (pkg) => disabledPackages.has(pkg),
     // Surface vault secrets to tool handlers as `ctx.getSecret(name)`. The

--- a/packages/cli/src/setup/build-session.ts
+++ b/packages/cli/src/setup/build-session.ts
@@ -17,6 +17,12 @@ export interface BuildSessionArgs {
   readonly config: MoxxyConfig;
   readonly resolver?: PermissionResolver;
   readonly resumeSessionId?: string;
+  /**
+   * Sticky session id (resume-if-present). Use this exact id; restore its
+   * persisted log if one exists, otherwise start a fresh session under the same
+   * id. Ignored when `resumeSessionId` is set.
+   */
+  readonly sessionId?: string;
   readonly logger: Logger;
   /**
    * Vault-backed secret resolver, surfaced to every tool handler as
@@ -42,6 +48,10 @@ export async function buildSession(args: BuildSessionArgs): Promise<Session> {
     args.config.permissions?.policyPath ?? path.join(os.homedir(), '.moxxy', 'permissions.json');
   const permissionEngine = await PermissionEngine.load(userPolicyPath);
 
+  // The effective session id: an explicit `--resume <id>` (errors if missing),
+  // or a sticky `sessionId` (resume-if-present, fresh on first run). Both reuse
+  // the id so persistence appends continue the same `<id>.jsonl`.
+  const effectiveSessionId = args.resumeSessionId ?? args.sessionId;
   let restoredEvents: ReadonlyArray<MoxxyEvent> = [];
   if (args.resumeSessionId) {
     try {
@@ -56,6 +66,14 @@ export async function buildSession(args: BuildSessionArgs): Promise<Session> {
         context: { session_id: args.resumeSessionId },
         cause: err,
       });
+    }
+  } else if (args.sessionId) {
+    // Sticky resume: a missing log just means "first run with this id" — start
+    // fresh under it rather than erroring (unlike explicit `--resume`).
+    try {
+      restoredEvents = await restoreSessionEvents(args.sessionId);
+    } catch {
+      restoredEvents = [];
     }
   }
 
@@ -74,7 +92,7 @@ export async function buildSession(args: BuildSessionArgs): Promise<Session> {
     pluginDiscoveryPaths: [userPluginsDir, path.join(userPluginsDir, 'node_modules')],
     ...(args.isPluginDisabled ? { isPluginDisabled: args.isPluginDisabled } : {}),
     ...(args.secretResolver ? { secretResolver: args.secretResolver } : {}),
-    ...(args.resumeSessionId ? { sessionId: args.resumeSessionId as SessionId } : {}),
+    ...(effectiveSessionId ? { sessionId: effectiveSessionId as SessionId } : {}),
     // Seed restored events directly into the log so subscribers don't
     // re-fire side effects for historical events. New appends from this
     // point onward fire subscribers normally (and the persistence

--- a/packages/cli/src/setup/types.ts
+++ b/packages/cli/src/setup/types.ts
@@ -58,6 +58,16 @@ export interface SetupOptions {
    * the same file. Skip persistence entirely when this is null.
    */
   readonly resumeSessionId?: string;
+  /**
+   * Sticky session id: use this exact id for the session, resuming its
+   * persisted log if one exists and starting fresh under the same id if not.
+   * Unlike `resumeSessionId` (which errors if the log is missing — for an
+   * explicit `moxxy resume <id>`), this is "resume-if-present" and is safe on
+   * the first run. The desktop passes its per-workspace desk id here so killing
+   * and reopening the app continues the same conversation. Ignored when
+   * `resumeSessionId` is set.
+   */
+  readonly sessionId?: string;
   /** Disable session persistence (default: persistence is on). */
   readonly disableSessionPersistence?: boolean;
   /**

--- a/packages/desktop-host/src/ipc/session.ts
+++ b/packages/desktop-host/src/ipc/session.ts
@@ -76,6 +76,14 @@ export function registerSessionHandlers(pool: RunnerPool): void {
     await waitForSessionState(session, (info) => info.activeMode === mode);
     supervisor.refreshConnectedInfo();
   });
+  handle('session.newSession', async ({ workspaceId }) => {
+    // `/new`: reset the runner to a fresh, empty sticky session (the renderer
+    // clears its own transcript). resolveSupervisor (not resolveCtx) because a
+    // reset deliberately tears the RemoteSession down — requiring a live one
+    // would be self-defeating.
+    const sup = resolveSupervisor(pool, workspaceId);
+    if (sup) await sup.resetSession();
+  });
   handle('session.setAutoApprove', async ({ workspaceId, enabled }) => {
     const id = workspaceId ?? pool.activeWorkspaceId();
     if (!id) return;

--- a/packages/desktop-host/src/runner-pool.ts
+++ b/packages/desktop-host/src/runner-pool.ts
@@ -46,7 +46,11 @@ export class RunnerPool extends EventEmitter {
       return existing.supervisor;
     }
     const socketPath = socketFor(id);
-    const supervisor = new RunnerSupervisor(socketPath);
+    // Pass the workspace id as the runner's sticky session id so each
+    // workspace resumes its own conversation + model context across app
+    // restarts (the runner persists to ~/.moxxy/sessions/<id>.jsonl and
+    // resumes it next launch) instead of booting an empty session every time.
+    const supervisor = new RunnerSupervisor(socketPath, id);
     if (cwd) await supervisor.setCwd(cwd);
     this.entries.set(id, { id, supervisor });
     // Forward every supervisor's change event upward, tagged with the

--- a/packages/desktop-host/src/runner-supervisor.ts
+++ b/packages/desktop-host/src/runner-supervisor.ts
@@ -24,6 +24,7 @@ import path from 'node:path';
 import { EventEmitter } from 'node:events';
 import { Socket } from 'node:net';
 
+import { deleteSession } from '@moxxy/core';
 import {
   connectRemoteSession,
   isNamedPipe,
@@ -68,6 +69,14 @@ export class RunnerSupervisor extends EventEmitter {
     // runner").
     private readonly socketPath: string = process.env.MOXXY_RUNNER_SOCKET ??
       platformSocket('serve', path.join(homedir(), '.moxxy', 'serve.sock')),
+    /**
+     * Sticky session id for the spawned runner (resume-if-present). The pool
+     * passes the workspace's desk id so the runner resumes that workspace's
+     * conversation + model context across app restarts. Forwarded to `serve`
+     * as `MOXXY_SESSION_ID`. Undefined → the runner mints a fresh id (the old
+     * behavior, and what a bare supervisor uses).
+     */
+    private readonly sessionId?: string,
   ) {
     super();
   }
@@ -99,6 +108,42 @@ export class RunnerSupervisor extends EventEmitter {
       }
       this.forceRetry();
     }
+  }
+
+  /**
+   * Start a fresh conversation for this workspace (the `/new` command). With
+   * sticky sessions the runner resumes `~/.moxxy/sessions/<sessionId>.jsonl`
+   * every launch, so "new" must (1) tear the runner down, (2) delete that
+   * persisted log, and (3) respawn — the run loop comes back up and
+   * sticky-resume finds no file, yielding an empty session under the same id.
+   * Wiping the file (not just the in-memory log) is what makes the reset
+   * durable across the next app restart. The renderer clears its own transcript
+   * separately.
+   */
+  async resetSession(): Promise<void> {
+    const session = this.session;
+    this.session = null;
+    if (session) {
+      try {
+        await session.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    if (this.child) {
+      // Wait for the child to release its socket before deleting + respawning,
+      // mirroring setCwd — a bare kill races the respawn into EADDRINUSE.
+      await terminateChild(this.child);
+      this.child = null;
+    }
+    if (this.sessionId) {
+      try {
+        await deleteSession(this.sessionId);
+      } catch {
+        // Best-effort: a missing file just means there was nothing to clear.
+      }
+    }
+    this.forceRetry();
   }
 
   /** The directory the runner treats as its cwd (null when unbound). Used to
@@ -386,6 +431,8 @@ export class RunnerSupervisor extends EventEmitter {
         // ~/.moxxy) stays fully available — that's how the desktop "patches"
         // itself.
         MOXXY_NO_CORE_UPDATE: '1',
+        // Resume this workspace's conversation across restarts (see ctor).
+        ...(this.sessionId ? { MOXXY_SESSION_ID: this.sessionId } : {}),
       },
       ...(this.cwd ? { cwd: this.cwd } : {}),
     });

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -439,6 +439,11 @@ export interface IpcCommands {
   }) => Promise<void>;
   /** Switch the active mode. */
   'session.setMode': (args: { workspaceId?: string; mode: string }) => Promise<void>;
+  /** Start a fresh conversation (the `/new` command): wipe the workspace's
+   *  persisted runner session and restart it so the model context resets and
+   *  doesn't resurrect on the next app launch. The renderer clears its own
+   *  transcript separately. */
+  'session.newSession': (args: { workspaceId?: string }) => Promise<void>;
   /** Toggle auto-approve ("yolo") for the workspace's session: when
    *  enabled, tool calls are allowed WITHOUT showing the approval sheet.
    *  Goal mode turns this on for hands-off autonomous runs. Lives on the

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -77,6 +77,7 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
   }),
   'session.setProvider': z.object({ workspaceId: optionalWorkspace, provider: providerName }),
   'session.setMode': z.object({ workspaceId: optionalWorkspace, mode: z.string().min(1).max(64) }),
+  'session.newSession': z.object({ workspaceId: optionalWorkspace }),
   // A turn's prompt + optional attachments cross from the renderer into the
   // model. Bound the shape so a hostile renderer can't OOM the main process
   // with a giant prompt or a flood of attachment entries. The attachment


### PR DESCRIPTION
## Problems

Reported together; both are desktop session-lifecycle bugs (the TUI is unaffected because its long-lived `serve` daemon survives a window close).

1. **Killing/reopening the app loses the conversation + model context** — the transcript collapses to only the last message, and the agent forgets everything.
2. **`/new` does nothing on its own** (the user found `/clear` then `/new` "works"); it should clear everything and start a fresh session.

## Root cause (confirmed on disk)

The desktop owns and SIGKILLs its `moxxy serve` child on quit, then on the next launch spawns a bare `['serve']` that builds a brand-new `Session` with a fresh ULID and **empty** `EventLog` — it never passes a session id, so nothing is resumed. The user's `~/.moxxy/sessions/` had **9 session files, 8 of them 0 bytes** (one fresh empty session per launch). The resume machinery already existed (`buildSession` restores events + reuses the id); the desktop just never used it.

`/new` returns `{kind:'session-action', action:'new'}`, but the desktop command palette only handled `action:'clear'` — so `/new` was a no-op. And nothing ever reset the *runner's* server-side session from the desktop.

## Fix

**Sticky session per desk (resume-if-present):**
- New `SetupOptions.sessionId` / `BuildSessionArgs.sessionId` — use this exact id, restoring its log if present and starting fresh under it on first run (distinct from `resumeSessionId`, which errors when missing — for an explicit `moxxy resume <id>`).
- `serve` reads `MOXXY_SESSION_ID`; `RunnerSupervisor`/`RunnerPool` pass each workspace's desk id through. So killing + reopening resumes that workspace's `~/.moxxy/sessions/<deskId>.jsonl`.

**Idempotent replay (renderer):**
- The runner replays its *full* history on every attach (and re-attach after a reconnect). The chat runtime now de-dupes ingested events by id (`seenIds`, kept in lockstep across live append, replay, and pagination), so a resumed replay doesn't double the transcript. This also fixes a **latent bug**: a transient reconnect to a still-alive runner previously duplicated the transcript (the live event path appended with no id check).

**`/new` actually resets:**
- The palette now handles `action:'new'`: clears the transcript **and** calls a new `session.newSession` IPC → `RunnerSupervisor.resetSession()`, which tears the runner down, deletes the persisted session log, and restarts — so sticky-resume comes back up empty. Model context truly resets and doesn't resurrect on the next launch. (`/clear` is unchanged: scrollback-only.)

## Tests

3 new `chatModel.test.ts` cases (58 desktop tests pass): replayed/duplicate event dropped by id; `seenIds` seeded from initial events; `clear()` resets `seenIds`.

Full suite green: build 52/52, typecheck 101/101, lint 0 errors, test 99/99.

## Decision captured

Per the product decision in this thread: **sticky session per desk** — kill+reopen resumes the same conversation under the same id; `/new` starts fresh under that id.

## Follow-up (noted, not in scope)

With a durable runner, the renderer's separate NDJSON display log + pagination is now largely redundant with the runner's attach-replay. For very long (>50-event) histories there's a narrow ordering edge if the NDJSON `loadInitial` wins the race against replay; the underlying session data is always correct. A later change can retire/demote the NDJSON layer (or add a replay-complete boundary) — best verified by running the app.