### PR TITLE
fix(plugins-admin): guard CLI install against npm arg injection + refresh tech-debt journal

### DIFF
--- a/.changeset/plugins-admin-install-hardening.md
+++ b/.changeset/plugins-admin-install-hardening.md
@@ -1,0 +1,10 @@
+---
+"@moxxy/cli": patch
+---
+
+Harden `moxxy plugins install`/`remove` against argument injection: the imperative
+install/uninstall path now rejects a flag-like spec (a leading `-`, e.g. `-g` or
+`--registry=…`) before handing it to `npm`, while still accepting the legitimate
+`name@version`, git (`github:`/`git+`/`https://`), and local-path specs. Internal
+cleanup: the duplicated `NPM_NAME_RE` / `diffSnapshot` / `PluginSnapshot` are hoisted
+into one shared module in `@moxxy/plugin-plugins-admin`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,31 @@ Run `pnpm check:deps` to verify after structural changes.
 - **Use `defineX(spec): XDef` factories.** They `Object.freeze` the spec and (for `definePlugin`) stamp `__moxxy: 'plugin'` and a default `version`.
 - **Add a changeset to EVERY PR — CI enforces it.** Run `pnpm changeset` (or hand-write `.changeset/<name>.md`) and pick the bump for `@moxxy/cli` / `@moxxy/sdk` / `@moxxy/desktop`. No changeset → no version bump → nothing ships. The `Changeset present` CI job fails any PR without one. For a change that releases nothing (docs / CI / tests), say so on purpose with `pnpm changeset --empty`. See [Releasing](#releasing-changesets).
 
+### Tech debt is a standing job — own it like a CTO
+
+`TECH_DEBT.md` is a **living journal**, not an archive. You are expected to actively keep
+it valid and to chip away at it as you work — treat reducing debt as part of every task,
+not a separate chore someone else does.
+
+- **Read it before non-trivial work.** Whenever you start something more than a one-line
+  edit, skim `TECH_DEBT.md` first. If your task touches an area with an open item, prefer
+  to resolve that item as part of the work.
+- **Every change retires at least one item.** Each time you ship a change, pick one entry
+  off the ledger and close it (or knock out a quick win nearby). Remove resolved entries —
+  don't let them rot — and move the one-liner into the "Resolved ledger" so the journal
+  keeps a record.
+- **Write new debt down the moment you see it.** If you introduce a shortcut, notice a
+  duplication, or spot a gap, add it to the appropriate P1/P2/P3 section with concrete
+  `file:line` evidence and a severity. Debt you can't fix now still gets recorded now.
+- **Bigger implementations trigger a re-audit.** For any sizeable feature or refactor,
+  re-audit the subsystem you touched and refresh the relevant `TECH_DEBT.md` items — verify
+  the open ones are still accurate, mark what your work resolved, and add what it exposed.
+  The goal is that the file is always trustworthy and up to date.
+- **Make the CTO call on pacing.** Always carve out time for a quick win or two; periodically
+  *propose* a bigger debt-reduction effort to the user when the payoff justifies it (e.g. the
+  desktop dual-persistence unification or the runner/thin-client retype). Balance shipping
+  features against keeping the codebase healthy — and say so explicitly when you defer.
+
 ### Don't
 
 - **Don't add a dependency without justification.** The framework is intended to be light. Built-ins use only Node stdlib + `zod` + `ulid` + `jiti`. Plugin authors can add their own — but core/SDK stays minimal.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -1,172 +1,178 @@
-# Tech debt — code-quality audit follow-ups
+# Tech debt — living journal
 
-Backlog from the May 2026 plugin-by-plugin code-quality audit (38-agent analysis →
-18-agent fix sweep). The **safe high-value subset** is already done and lives on
-branch `refactor/code-quality-sweep` (commits `74359b8` SDK foundation, `e5690d6`
-adoption + fixes). This file tracks what was **deliberately deferred** and what
-fix agents **blocked** as unsafe to do mechanically.
+This file is the repo's standing tech-debt ledger. **Treat it as a journal, not an
+archive:** every code change should retire at least one entry here, bigger pieces of
+work should re-audit the area they touch and refresh the relevant items, and new debt
+you introduce or notice gets written down the moment you see it. See AGENTS.md →
+"Tech debt is a standing job" for the working rule.
 
-Audit scoring snapshot: every package averaged ≥ 3.57/5; the default blocks
-(`compactor-summarize`, `cache-strategy-stable-prefix`, `mode-default`) were
-near-exemplary. 206 findings (18 high · 67 medium · 121 low). 11 of 18 highs are
-fixed; the remaining 7 are below (design-change or large test-suite work).
+**Origin:** the May 2026 plugin-by-plugin code-quality audit (38-agent analysis →
+18-agent fix sweep). The safe high-value subset shipped on `refactor/code-quality-sweep`
+(merged, PR #6). What remains below is what was deliberately deferred, what was blocked
+as unsafe to do mechanically, and debt accrued since.
+
+**Last refreshed:** 2026-06-08 — re-verified every open item against `HEAD` and folded
+in findings from the desktop-resume / claude-code-provider / plugins-admin work that
+landed after the original audit. All prior "✅ DONE" items were re-checked and confirmed
+still in place (no regressions); they're collapsed into the ledger at the bottom. The same
+pass also **retired the plugins-admin CLI install-hardening + dedup items** (former P2
+#7/#8 — see the ledger) as the first chip-away under the new journal rule.
 
 ---
 
-## P1 — High, deferred (design or large effort)
+## P1 — High
 
-### 1. Promote runtime session capabilities onto the contract — ⚠️ MOSTLY DONE
+### 1. Runner/thin-client: retype channel handlers to the SDK contract — ⚠️ PARTIALLY DONE
 **Findings:** plugin-cli #4, plugin-telegram #6, cross-cut 2.4 (all **high**).
-**Done:** added `CredentialResolver`, `McpAdminView`/`McpServerStatusView` to `@moxxy/sdk`,
-exposed `readyProviders?`/`credentialResolver?`/`mcpAdmin?` as typed optional members on
-`SessionLike` and as declared fields on core's `Session`, and **deleted every `as unknown as`
-cast** (8 sites across cli/plugin-cli/plugin-telegram + core's own `getInfo` self-cast).
-The host now sets them type-checked; channels read them type-checked.
-**Remaining (deferred — the genuine runner/thin-client coupling):** the channel handlers are still
-typed against the *concrete* `@moxxy/core` `Session`, not the `ClientSession`/`SessionLike` contract,
-so they would not yet compile against a `RemoteSession`. Retype `picker-handlers`/`use-mcp-status`/
-`run-slash`/telegram handler params to the SDK contract (now that it carries the capabilities) and
-verify graceful degradation when a `RemoteSession` leaves them undefined. Do this alongside the
-runner/thin-client work, not standalone.
+**Done:** `CredentialResolver`, `McpAdminView`/`McpServerStatusView` live on `@moxxy/sdk`;
+`SessionLike` carries optional `readyProviders?`/`credentialResolver?`/`mcpAdmin?`
+(`packages/sdk/src/session-like.ts:245-249`). The cli handlers now import
+`ClientSession as Session` from `@moxxy/sdk` and read the capabilities through optional
+chaining (`plugin-cli/src/.../picker-handlers.ts`, `use-mcp-status.ts`, `run-slash.ts`).
+**Remaining (deferred — the genuine coupling):** `ClientSession` still exposes the full
+concrete registry surface (providers/modes/tools/commands/…), so the handlers would not
+yet compile against a bare `RemoteSession`. Retype the handler params to the minimal
+`SessionLike` slice they actually use and verify graceful degradation when a
+`RemoteSession` leaves a capability undefined. Do this alongside the runner/thin-client
+work, not standalone. (The `RemoteSession` casts at `desktop-host/src/ipc/session.ts:105`
+and `ipc/shared.ts:164` are the same seam — see P3.)
 
-### 2. Tests for security-critical code with zero coverage — ✅ DONE
-**Findings:** vault #10/#11, plugin-cli #5, plugin-mcp #14 (all **high**). Added on this branch (+85 tests):
-- `plugin-vault/src/keysource.test.ts` + `store.canary.test.ts` (+17): full key-resolution precedence
-  (env→keytar→disk→prompt), env keys NOT persisted, keytar↔disk cross-backfill, `resolvedName`, disk-key
-  mode `0o600`; canary write/verify, wrong-passphrase `VaultPassphraseError` with recovery hint,
-  legacy-vault backfill.
-- `plugin-cli/src/components/chat/pair-events.test.ts` (+24): tool↔result pairing, orphan-at-turn-boundary
-  synthesis (the forever-pulsing-dot guard), skill grouping + continuation, compact live-aggregation,
-  subagent lifecycle, `isSettled`/`countToolCalls`/`blocksEquivalent`.
-- `plugin-mcp/src/admin/*.test.ts` (+44 across 6 files): config-io atomic round-trip + Zod-discard of
-  corrupt files, runtime collision/lazy/`getOrConnect` retry/`refreshServerCache` rollback, add dup-guard
-  + hot-attach + skill side-effect, remove, test, skill frontmatter YAML.
+### 2. Desktop persists every conversation twice — pick one source of truth — 🔴 NEW
+**Found 2026-06-08 (the "NDJSON-vs-replay redundancy" follow-up, now characterized).**
+Every committed event is written to disk in **two** independent stores:
+- runner session log — `~/.moxxy/sessions/<id>.jsonl`, replayed on attach
+  (`runner/src/server.ts:184`; `desktop-host/src/runner-supervisor.ts:79,435`);
+- desktop NDJSON chat-log — `~/.moxxy/chats/<workspaceId>.jsonl`
+  (`desktop-host/src/chat-log.ts:30-33`), loaded by
+  `apps/desktop/src/lib/chat-store/store.ts:187`.
 
-No bugs surfaced — the security paths behave correctly under test.
+Two concrete defects fall out of the redundancy:
+- **Desync window on `/new`.** Reset wipes both via two separate IPC calls
+  (`CommandPalette.tsx:91-92`: `chatStore.clear()` then `session.newSession`). If the
+  second fails or the app dies between them, the renderer is cleared but the runner is
+  still primed → old context resurrects on the next turn/restart.
+- **Unbounded NDJSON growth.** On restart `seenIds` starts empty; the runner replays its
+  full history on attach; each replayed event misses `seenIds`, so `dispatch` re-appends
+  it to the NDJSON log (`store.ts:317-326`). `loadOlder` dedups only on read
+  (`store.ts:240-243`), so the on-disk file bloats by a full copy every restart.
 
-### 3. Collapse the duplicate RFC 8628 device-flow in plugin-oauth — ✅ DONE
-**Finding:** oauth #12 (**high**). Extracted the shared RFC 8628 device-authorization request +
-poll-response classification into `src/oauth/device-flow-shared.ts`
-(`requestDeviceAuthorization`, `classifyDeviceTokenResponse`). The legacy `runDeviceCodeFlow` and
-the `rfc8628DeviceFlow` adapter now both call it; each keeps only its genuine difference (the legacy
-flow appends `client_id`/`client_secret` on the poll; the adapter reports ms vs the legacy's
-seconds). Behavior preserved, 22/22 oauth tests green. `openai-device-flow.ts` is a distinct
-non-RFC-8628 protocol (two-step authorization_code exchange) and correctly stays separate.
+**Action:** decide the single source of truth. The runner already persists + replays the
+full history, so the desktop NDJSON store is arguably entirely redundant — either drop it
+and read from the runner replay, or stop re-persisting replayed events and make `/new` a
+single atomic reset. **Whichever way: this path has zero tests** — no `store.test.ts`, and
+`resetSession`/`newSession`/`deleteSession` in `runner-supervisor.ts` are uncovered. Add
+tests for append-on-dispatch, the restart double-append, `loadOlder` dedup, and the
+`/new` dual-clear as part of the fix.
 
 ---
 
 ## P2 — Medium
 
-### 4. Plugin `version` literals are hardcoded and wrong — ✅ DONE (discovered/installed path)
-**Cross-cut 2.9.** `PluginLoader.load` now stamps the manifest's `packageVersion` over the
-hardcoded `definePlugin` literal, so discovered/installed plugins (the ones `moxxy plugins list`
-shows) report their real `package.json` version (+regression test in `discovery.test.ts`). The
-~30 placeholder literals are now ignored on that path — they need not be maintained.
-**Remaining (minor):** bundled plugins registered directly via `registerStatic` (no manifest at
-register time) still carry their literal. Harmless — they're the framework's own packages; their
-"version" is the framework version. Could stamp from a known framework version if it ever matters.
+### 3. Shared HTTP-channel server base — OPEN
+**Cross-cut 1.4.** `readRequestBody` + `bearerTokenMatches` are shared (done), but each
+HTTP surface still rolls its own `createServer`/`listen`/health/routing
+(`plugin-channel-http/src/channel.ts:60`, `plugin-channel-web/src/channel.ts:180`,
+`plugin-webhooks/src/server.ts:63`). **Action:** an optional `HttpChannelServer` base in
+the SDK so they differ only in routing. (Larger refactor, lower payoff than the helpers
+already hoisted.)
 
-### 5. Make embedders & isolators first-class swappable blocks — ✅ DONE
-**Cross-cut 2.10 + user decision (make them exchangeable, not hardcoded).** The earlier "removed the
-vestigial manifest" change was superseded — instead of cementing them as hardcoded, both are being
-promoted to first-class contributable, registry-backed, swappable blocks.
+### 4. Unify tunnel subprocess management + make webhooks use `TunnelProviderDef` — OPEN
+**Cross-cut 1.5.** Three near-identical spawn-CLI-and-parse-URL impls
+(`plugin-channel-web/src/cloudflared.ts:19-70`, `…/ngrok.ts:19-70`,
+`plugin-webhooks/src/tunnel.ts:50-98`); webhooks ignores the existing `TunnelProviderDef`
+contract entirely and rolls its own `startTunnel()`. **Action:** hoist a
+`spawnCliTunnel({cmd,args,urlRegex})` helper; make webhooks consume registered
+`TunnelProviderDef`s.
 
-**Embedders — ✅ DONE:** added `EmbedderDef` + `defineEmbedder` + `PluginSpec.embedders` + the
-`'embedder'` plugin kind to `@moxxy/sdk`; added a single-active `EmbedderRegistry` to `@moxxy/core`
-with host + session wiring (+registry test). `MemoryStore` now resolves its embedder *lazily* (accepts
-a `() => EmbeddingProvider | null` resolver) so the registry-selected embedder — not known until
-plugins load — drives recall without forcing the store to be built after the session. The two
-first-party embedders (`openai`, `transformers`) and the built-in `tfidf` (from plugin-memory) now
-contribute `EmbedderDef`s + ship a discovery `definePlugin` entry + `kind: 'embedder'` manifest; the
-CLI's `selectEmbedder` activates the configured one from the registry by name (lazy-registering the
-bundled first-party ones on demand so onnx still loads only when selected). A user can now install a
-custom `kind: 'embedder'` plugin and pick it via `embeddings.provider: '<name>'`.
+### 5. Finish MoxxyError adoption / HTTP-status classification — OPEN (partial)
+**Cross-cut 1.7, 1.13, 2.6.** `classifyHttpStatus` exists (`sdk/src/errors.ts:255`) and is
+applied across oauth token-exchange, device-flow, and the stt/provider packages. Remaining
+bare `throw new Error` worth migrating (small, high-signal — the bulk of the repo's other
+raw throws are internal registry/broker invariants that should stay plain):
+- oauth input/usage validation — `plugin-oauth/src/tools.ts:114,146`.
+- vault config-resolution throws (user-facing) — `plugin-vault/src/placeholder.ts:20`,
+  `index.ts:150`, `store.ts:164,186`.
+- desktop self-update **security** failures (signature/hash/unsafe-path) throw raw Error —
+  `desktop-host/src/app-update/stager.ts:258-302`; candidates for a typed error code.
 
-**Isolators — ✅ DONE:** added a core `IsolatorRegistry` (a plain collection — exported as
-`ContributedIsolatorRegistry`) populated by `PluginSpec.isolators` via host wiring, exposed as
-`session.isolators` (+registry test). After plugin discovery and BEFORE the security layer's `onInit`
-wraps tools, the CLI bridges `session.isolators` into `plugin-security`'s `IsolatorRegistry`. The
-three first-party isolators now contribute their `Isolator` + ship a discovery `definePlugin` entry +
-`kind: 'isolator'` manifest. Selection stays config-driven (`security.isolator`): a contributed
-isolator is registered-but-inert and never auto-activated, so installing one can't silently weaken
-the sandbox. A user can install a custom `kind: 'isolator'` plugin and opt in by name.
-
-### 6. Add a tool/abort `MoxxyErrorCode` — ✅ DONE
-Added `TOOL_ERROR` (tool handler failure) and `ABORTED` (cancelled / timeout kill) to
-`MoxxyErrorCode`. Re-tagged the `INTERNAL` placeholders: abort-before-start + the Bash timeout →
-`ABORTED` (4 sites; the timeout was previously mis-tagged `NETWORK_TIMEOUT`, which made it falsely
-retryable); generic tool failures across tools-builtin + plugin-computer-control → `TOOL_ERROR`
-(24 sites). No exhaustive `switch` on the code exists, so adding members is safe.
-
-### 7. Shared HTTP-channel server base
-**Cross-cut 1.4.** `readRequestBody` + `bearerTokenMatches` are now shared (done), but each HTTP
-surface still rolls its own `createServer`/`listen`/health/routing (`plugin-channel-http`,
-`plugin-channel-web`, `plugin-webhooks`). **Action:** an optional `HttpChannelServer` base in the SDK
-so they differ only in routing. (Deferred — larger refactor, lower payoff than the helpers already hoisted.)
-
-### 8. Unify tunnel subprocess management + make webhooks use `TunnelProviderDef`
-**Cross-cut 1.5.** Three near-identical spawn-CLI-and-parse-URL impls (`channel-web/cloudflared.ts`,
-`channel-web/ngrok.ts`, `webhooks/tunnel.ts`); webhooks ignores the existing `TunnelProviderDef`
-contract entirely. **Action:** hoist a `spawnCliTunnel({cmd,args,urlRegex})` helper; make webhooks
-consume registered `TunnelProviderDef`s instead of its bespoke `tunnel.ts`.
-
-### 9. `runSingleShotTurn` mode-helper — ✅ DONE
-**Cross-cut 1.9.** Added `runSingleShotTurn(ctx, messages, { maxTokens? })` to SDK `mode-helpers`
-(compaction + elision → `provider_request` → `collectProviderStream({ includeTools: false })` →
-`error`/`provider_response`). Collapsed the duplicated blocks onto it (e.g. `mode-deep-research`
-query + synthesis). As a side effect the single-shot turns now run `runElisionIfNeeded` like every
-other turn (the consistency the finding wanted). All mode suites green.
-
-### 10. Finish MoxxyError adoption / HTTP-status classification
-**Cross-cut 1.7, 1.13, 2.6.** The clear user-facing throws were converted. Remaining: oauth
-input/usage-validation throws (`tools.ts:~114,~146`), browser sidecar-internal throws (cross the
-JSON-RPC boundary as strings — low value), and any remaining `throw new Error` in handler bodies.
-Route remaining non-OK HTTP paths through `classifyHttpStatus`. Optionally lint-ban bare
-`throw new Error` inside handler bodies.
-
-### 11. Persisted-config read validation parity — ✅ DONE
-**Cross-cut 2.12.** provider-admin + mcp (Phase 2) and now `plugin-channel-web/tunnel-settings.ts`
-Zod-validate their persisted-config reads (`safeParse`, discard on failure). The remaining
-`JSON.parse(...) as T` sites are line/wire-protocol parses (session-log events, MCP/JSON-RPC frames,
-SSE, package.json) — not persisted-config reads — so they're out of this finding's scope.
+### 6. Mode loop scaffolding is copy-pasted across mode-default and mode-goal — 🔴 NEW
+**Found 2026-06-08.** The mode-slimming PR (#93) collapsed the mode list but left the
+per-iteration loop duplicated: `mode-default/src/turn-iterator.ts:168-272` vs
+`mode-goal/src/goal-loop.ts:333-436`. `executeToolUses` differs only in comments/whitespace;
+`emitRequestsAndDetectStuck` differs only in error strings; the provider-request/response +
+overflow/reactive-compaction block (`turn-iterator.ts:67-127` vs `goal-loop.ts:128-182`)
+is near-identical. Critically, the **orphan-tool-result / stuck-loop fix** (load-bearing —
+the comments literally say "See the same fix in mode-tool-use") is copy-pasted, so any fix
+must be hand-mirrored. **Action:** hoist the shared iteration scaffolding into an SDK
+`mode-helpers` building block (per the repo's "prefer swappable blocks" guideline) so both
+modes compose it. **Severity med.**
 
 ---
 
 ## P3 — Low / per-package nits
 
-121 low-severity findings remain (naming, comment hygiene, minor KISS). Not individually tracked here —
-they're low-risk polish. Notable clusters worth a future pass:
-- ✅ DONE — `plugin-embeddings-transformers`: `TransformersEmbedder.name` is now `transformers:<model>`
-  (was a static `'transformers'`), so different models get distinct cache namespaces in
-  `CachedEmbeddingProvider` / the memory `EmbeddingIndex` (cross-cut 1.11).
-- `plugin-memory` could wrap its raw embedder in the SDK `CachedEmbeddingProvider` instead of the
-  parallel `EmbeddingIndex` cache (cross-cut 1.11). **Deferred:** now that the atomic-write +
-  recall-race bugs are fixed in `EmbeddingIndex`, this is pure dedup of caching logic — and it would
-  refactor the (subtle, mutex-guarded) recall path for low remaining value. Not worth the risk
-  standalone; fold in if the recall path is touched for another reason.
-- Spurious/again-audited `@moxxy/core` prod deps: removed from webhooks/scheduler; **kept** on
-  plugin-subagents/plugin-view (their `*.test.ts` import core — devDep is correct) and on
-  plugin-cli/plugin-telegram (real core imports: `loadUsageStats`, `PermissionEngine`, `savePreferences`,
-  `clearUsageStats`, `newTurnId`). To fully sever the channel→core dep, hoist those provider-neutral
-  helpers into `@moxxy/sdk` (cross-cut 2.14) — deferred.
+### 7. plugin-memory caches embeddings via a parallel `EmbeddingIndex` — OPEN
+**Cross-cut 1.11.** `plugin-memory/src/store.ts:6,88-96` still uses its own `EmbeddingIndex`
+cache instead of the SDK `CachedEmbeddingProvider`. **Deferred:** now that the atomic-write +
+recall-race bugs are fixed, this is pure dedup of caching logic over a subtle mutex-guarded
+recall path — low value, real risk. Fold in only if the recall path is touched anyway.
+
+### 8. Channel→core prod dependency — OPEN
+`plugin-cli`/`plugin-telegram` keep real `@moxxy/core` prod imports (`savePreferences`,
+`clearUsageStats`, `newTurnId`, `loadUsageStats`, `PermissionEngine` — e.g.
+`plugin-cli/src/session/run-slash.ts:2`, `plugin-telegram/src/channel/turn-runner.ts:2`).
+To fully sever channel→core, hoist these provider-neutral helpers into `@moxxy/sdk`
+(cross-cut 2.14). (`plugin-subagents`/`plugin-view` keep core as a **dev**Dep only — their
+`*.test.ts` import core; correct, leave them.)
+
+### 9. Small casts / hardcoded values — NEW, low
+- **Type the exec allowlist.** `plugin-security/src/broker.ts:343` reads
+  `(caps as unknown as { commands? }).commands` — a forward-compat field not on
+  `CapabilitySpec`. It gates the **exec allowlist**, so it's worth typing properly on
+  `CapabilitySpec` to retire the cast on a security path.
+- **Anthropic SDK casts.** `plugin-provider-anthropic/src/provider.ts:236,367` — a
+  hand-rolled `requestBody: Record<string, unknown>` cast to the SDK's `stream` params, and
+  a `countTokens` shim cast. Defeats compile-time checking on the request hot path;
+  inherited by the claude-code provider.
+- **Hardcoded model descriptors.** `plugin-provider-anthropic/src/provider.ts:51-55`
+  hardcodes the model list (incl. `claude-opus-4-7` at 800k context) and re-exports it to
+  `plugin-provider-claude-code/src/index.ts:11`, so the subscription provider inherits the
+  API-key provider's model set verbatim. Drift-prone; should be derived/config.
+
+---
+
+## Resolved ledger (verified still in place 2026-06-08)
+
+Collapsed from full write-ups; each was re-checked against `HEAD` and confirmed — no
+regressions. Restore the detail from git history (`TECH_DEBT.md` @ `b014c3a`) if needed.
+
+- **plugins-admin CLI install hardening + dedup** (2026-06-08, was P2 #7/#8). The imperative
+  `installPluginPackage`/`removePluginPackage` now reject a flag-like spec via
+  `assertSafeNpmSpec` (a leading `-` is argument injection) — and crucially still accept the
+  git/path specs the original "just apply `NPM_NAME_RE`" idea would have broken. `NPM_NAME_RE`,
+  `diffSnapshot`, and `PluginSnapshot` are hoisted into `plugin-plugins-admin/src/shared.ts`
+  (no more `install.ts`/`toggle.ts` copy-paste). +9 tests.
+- **Security tests for zero-coverage paths** (vault keysource/canary, mcp admin ×6, the
+  tool↔result pairing guard). The pairing test moved to `chat-model/src/pair-events.test.ts`.
+- **RFC 8628 device-flow dedup** → `plugin-oauth/src/oauth/device-flow-shared.ts`.
+- **Plugin `version` stamped from the manifest** in `PluginLoader.load` (`core/src/plugins/loader.ts:57`).
+- **Embedders & isolators are first-class swappable blocks** (`EmbedderRegistry` +
+  `defineEmbedder`; `IsolatorRegistry`/`ContributedIsolatorRegistry` + `session.isolators`).
+- **`TOOL_ERROR` + `ABORTED` `MoxxyErrorCode`s** (`sdk/src/errors.ts:53-54`).
+- **`runSingleShotTurn` SDK helper** used by `mode-deep-research`.
+- **Zod-validated persisted-config reads** in provider-admin, mcp, channel-web tunnel-settings.
+- **Model-scoped transformers embedder name** (`transformers:<model>`).
 
 ---
 
 ## Blocked items (fix agents declined to do mechanically — sound calls)
 
-- **B1.** oauth: collapse legacy `runDeviceCodeFlow` onto the rfc8628 adapter — ✅ resolved via a
-  shared-helper extraction (P1 #3 DONE) rather than a full collapse, preserving each flow's genuine difference.
-- **B2.** tools-builtin / computer-control: no tool/platform `MoxxyErrorCode` exists; used `INTERNAL`. → ✅ resolved (P2 #6 DONE: added `TOOL_ERROR`/`ABORTED`, re-tagged).
-- **B3.** plugin-cli/plugin-telegram: kept `@moxxy/core` dep (real imports remain). → P3.
-- **B4.** plugin-subagents/plugin-view: kept `@moxxy/core` **dev**Dep — `*.test.ts` import `collectTurn` /
-  `defaultViewRenderer` / `Session` from core. (The audit's "zero core imports in src" premise missed test files.)
-- **B5.** plugin-cli/plugin-telegram off-contract session casts — deferred. → P1 #1.
-- **B6.** mcp `wrap.ts` `throw new Error('aborted')` ×3 — internal abort control-flow, not user-facing; left as-is.
-- **B7.** browser sidecar-internal throws and the two `new Error(String(err))` normalizers — left
-  (errors cross JSON-RPC as strings; no user-facing code value). → P2 #10.
-- **B8.** oauth `tools.ts` missing-URL throws — input validation, not the HTTP/network class targeted. → P2 #10.
+- **B6.** mcp `wrap.ts` `throw new Error('aborted')` ×3 — internal abort control-flow, not
+  user-facing; left as-is.
+- **B7.** browser sidecar-internal throws + `new Error(String(err))` normalizers — errors
+  cross JSON-RPC as strings; no user-facing code value. → folded into P2 #5.
 
 ---
 
-*Full per-package reports + cross-cut themes were produced by the audit workflow
+*Original per-package reports + cross-cut themes came from the audit workflow
 (`.claude/wf-quality-audit.js`); the fix sweep is `.claude/wf-apply-fixes.js`.*

--- a/packages/plugin-plugins-admin/src/install.ts
+++ b/packages/plugin-plugins-admin/src/install.ts
@@ -2,6 +2,9 @@ import { spawn } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { defineTool, moxxyPath, writeFileAtomic, z } from '@moxxy/sdk';
+import { assertSafeNpmSpec, diffSnapshot, NPM_NAME_RE, type PluginSnapshot } from './shared.js';
+
+export type { PluginSnapshot } from './shared.js';
 
 /**
  * Where third-party plugins installed at runtime live. The CLI's
@@ -13,7 +16,6 @@ export function userPluginsDir(): string {
   return moxxyPath('plugins');
 }
 
-const NPM_NAME_RE = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
 const VERSION_RE = /^[0-9a-z.~^*<=>-]+$/i;
 
 export interface InstallPluginDeps {
@@ -28,15 +30,6 @@ export interface InstallPluginDeps {
    * package brought in. Returns names per kind.
    */
   readonly snapshot: () => PluginSnapshot;
-}
-
-export interface PluginSnapshot {
-  readonly tools: ReadonlyArray<string>;
-  readonly agents: ReadonlyArray<string>;
-  readonly providers: ReadonlyArray<string>;
-  readonly modes: ReadonlyArray<string>;
-  readonly compactors: ReadonlyArray<string>;
-  readonly channels: ReadonlyArray<string>;
 }
 
 export interface InstallPluginPackageOptions {
@@ -76,16 +69,17 @@ export interface RemovePluginPackageResult {
 export async function installPluginPackage(
   opts: InstallPluginPackageOptions,
 ): Promise<InstallPluginPackageResult> {
+  const spec = assertSafeNpmSpec(opts.packageName);
   const dir = userPluginsDir();
   await ensurePackageJson(dir);
   const { exitCode, stderr } = await runNpm(
-    ['install', '--prefix', dir, '--no-fund', '--no-audit', '--save', opts.packageName],
+    ['install', '--prefix', dir, '--no-fund', '--no-audit', '--save', spec],
     opts.signal,
   );
   if (exitCode !== 0) {
     throw new Error(`npm install failed (exit ${exitCode}): ${truncate(stderr, 400)}`);
   }
-  return { installed: opts.packageName, dir };
+  return { installed: spec, dir };
 }
 
 /**
@@ -94,16 +88,17 @@ export async function installPluginPackage(
 export async function removePluginPackage(
   opts: RemovePluginPackageOptions,
 ): Promise<RemovePluginPackageResult> {
+  const spec = assertSafeNpmSpec(opts.packageName);
   const dir = userPluginsDir();
   await ensurePackageJson(dir);
   const { exitCode, stderr } = await runNpm(
-    ['uninstall', '--prefix', dir, '--no-fund', '--no-audit', '--save', opts.packageName],
+    ['uninstall', '--prefix', dir, '--no-fund', '--no-audit', '--save', spec],
     opts.signal,
   );
   if (exitCode !== 0) {
     throw new Error(`npm uninstall failed (exit ${exitCode}): ${truncate(stderr, 400)}`);
   }
-  return { removed: opts.packageName, dir };
+  return { removed: spec, dir };
 }
 
 export function buildInstallPluginTool(deps: InstallPluginDeps) {
@@ -257,16 +252,6 @@ function runNpm(
       resolve({ exitCode: code ?? -1, stdout, stderr });
     });
   });
-}
-
-function diffSnapshot(before: PluginSnapshot, after: PluginSnapshot): Record<string, ReadonlyArray<string>> {
-  const out: Record<string, ReadonlyArray<string>> = {};
-  for (const key of ['tools', 'agents', 'providers', 'modes', 'compactors', 'channels'] as const) {
-    const b = new Set(before[key]);
-    const added = after[key].filter((n) => !b.has(n));
-    if (added.length > 0) out[key] = added;
-  }
-  return out;
 }
 
 function truncate(s: string, n: number): string {

--- a/packages/plugin-plugins-admin/src/shared.test.ts
+++ b/packages/plugin-plugins-admin/src/shared.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { assertSafeNpmSpec, diffSnapshot, NPM_NAME_RE, type PluginSnapshot } from './shared.js';
+import { installPluginPackage, removePluginPackage } from './install.js';
+
+describe('assertSafeNpmSpec', () => {
+  it('accepts the legitimate spec shapes (npm name, version, git, path)', () => {
+    for (const spec of [
+      '@moxxy/agent-researcher',
+      'left-pad',
+      '@scope/pkg@1.2.3',
+      'github:moxxy-ai/some-plugin',
+      'git+https://example.com/p.git',
+      'https://example.com/p.tgz',
+      './local/plugin',
+      '/abs/path/plugin',
+      '~/plugin',
+    ]) {
+      expect(assertSafeNpmSpec(spec)).toBe(spec.trim());
+    }
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(assertSafeNpmSpec('  left-pad  ')).toBe('left-pad');
+  });
+
+  it('rejects an empty / whitespace-only spec', () => {
+    expect(() => assertSafeNpmSpec('')).toThrow(/non-empty/);
+    expect(() => assertSafeNpmSpec('   ')).toThrow(/non-empty/);
+  });
+
+  it('rejects a flag-like spec (argument injection)', () => {
+    for (const evil of ['-g', '--prefix=/tmp/evil', '--registry=http://evil', '-f']) {
+      expect(() => assertSafeNpmSpec(evil)).toThrow(/option, not a package/);
+    }
+  });
+});
+
+describe('installPluginPackage / removePluginPackage reject injection before spawning npm', () => {
+  it('installPluginPackage refuses a flag-like spec', async () => {
+    await expect(installPluginPackage({ packageName: '--registry=http://evil' })).rejects.toThrow(
+      /option, not a package/,
+    );
+  });
+
+  it('removePluginPackage refuses a flag-like spec', async () => {
+    await expect(removePluginPackage({ packageName: '-g' })).rejects.toThrow(/option, not a package/);
+  });
+});
+
+describe('NPM_NAME_RE', () => {
+  it('matches bare and scoped names, rejects spaces and versions', () => {
+    expect(NPM_NAME_RE.test('left-pad')).toBe(true);
+    expect(NPM_NAME_RE.test('@moxxy/plugin-browser')).toBe(true);
+    expect(NPM_NAME_RE.test('NOT VALID')).toBe(false);
+    expect(NPM_NAME_RE.test('pkg@1.2.3')).toBe(false);
+  });
+});
+
+describe('diffSnapshot', () => {
+  const empty: PluginSnapshot = {
+    tools: [],
+    agents: [],
+    providers: [],
+    modes: [],
+    compactors: [],
+    channels: [],
+  };
+
+  it('returns only the kinds with additions', () => {
+    const after: PluginSnapshot = { ...empty, tools: ['a', 'b'], modes: ['m'] };
+    expect(diffSnapshot(empty, after)).toEqual({ tools: ['a', 'b'], modes: ['m'] });
+  });
+
+  it('reports nothing when after is a subset of before', () => {
+    const before: PluginSnapshot = { ...empty, tools: ['a', 'b'] };
+    const after: PluginSnapshot = { ...empty, tools: ['a'] };
+    expect(diffSnapshot(before, after)).toEqual({});
+  });
+});

--- a/packages/plugin-plugins-admin/src/shared.ts
+++ b/packages/plugin-plugins-admin/src/shared.ts
@@ -1,0 +1,56 @@
+/**
+ * Helpers shared by the plugins-admin install/uninstall and enable/disable
+ * tools (formerly duplicated verbatim across `install.ts` and `toggle.ts`).
+ */
+
+/** A bare or scoped npm package name with no version/spec suffix. */
+export const NPM_NAME_RE = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
+/** Names of registered contributions, grouped by kind. */
+export interface PluginSnapshot {
+  readonly tools: ReadonlyArray<string>;
+  readonly agents: ReadonlyArray<string>;
+  readonly providers: ReadonlyArray<string>;
+  readonly modes: ReadonlyArray<string>;
+  readonly compactors: ReadonlyArray<string>;
+  readonly channels: ReadonlyArray<string>;
+}
+
+/**
+ * Guard an install/uninstall spec before it is handed to `npm` as a CLI
+ * argument. `installPluginPackage` accepts more than a bare name — `name@version`,
+ * `github:`/`git+`/`https://`/`ssh://` git specs, and local paths — so it cannot
+ * validate against {@link NPM_NAME_RE}. What it MUST stop is a spec that npm would
+ * parse as an OPTION instead of a package: none of the legitimate spec shapes start
+ * with `-`, so a leading dash is an argument-injection attempt (e.g. `-g`,
+ * `--prefix=/`, `--registry=…`). `spawn` runs npm without a shell, so this is not a
+ * shell-injection risk — but an injected flag could still change install behavior.
+ *
+ * Throws on an empty or flag-like spec; returns the trimmed spec otherwise.
+ */
+export function assertSafeNpmSpec(spec: string): string {
+  const trimmed = spec.trim();
+  if (trimmed.length === 0) {
+    throw new Error('plugin spec must be a non-empty package name, git spec, or path');
+  }
+  if (trimmed.startsWith('-')) {
+    throw new Error(
+      `refusing plugin spec "${spec}": leading "-" would be parsed by npm as an option, not a package`,
+    );
+  }
+  return trimmed;
+}
+
+/** Contributions present in `after` but not `before`, grouped by kind. */
+export function diffSnapshot(
+  before: PluginSnapshot,
+  after: PluginSnapshot,
+): Record<string, ReadonlyArray<string>> {
+  const out: Record<string, ReadonlyArray<string>> = {};
+  for (const key of ['tools', 'agents', 'providers', 'modes', 'compactors', 'channels'] as const) {
+    const b = new Set(before[key]);
+    const added = after[key].filter((n) => !b.has(n));
+    if (added.length > 0) out[key] = added;
+  }
+  return out;
+}

--- a/packages/plugin-plugins-admin/src/toggle.ts
+++ b/packages/plugin-plugins-admin/src/toggle.ts
@@ -1,7 +1,5 @@
 import { defineTool, z } from '@moxxy/sdk';
-import type { PluginSnapshot } from './install.js';
-
-const NPM_NAME_RE = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+import { diffSnapshot, NPM_NAME_RE, type PluginSnapshot } from './shared.js';
 
 export interface PluginToggleDeps {
   /**
@@ -70,17 +68,4 @@ export function buildEnablePluginTool(deps: PluginToggleDeps) {
       return { enabled: packageName, registered: diffSnapshot(before, after) };
     },
   });
-}
-
-function diffSnapshot(
-  before: PluginSnapshot,
-  after: PluginSnapshot,
-): Record<string, ReadonlyArray<string>> {
-  const out: Record<string, ReadonlyArray<string>> = {};
-  for (const key of ['tools', 'agents', 'providers', 'modes', 'compactors', 'channels'] as const) {
-    const b = new Set(before[key]);
-    const added = after[key].filter((n) => !b.has(n));
-    if (added.length > 0) out[key] = added;
-  }
-  return out;
 }


### PR DESCRIPTION
## What

Two things, both off the freshly-refreshed `TECH_DEBT.md`:

### 1. Security fix — `moxxy plugins install/remove` argument injection (TECH_DEBT P2 #7)
`installPluginPackage`/`removePluginPackage` (the imperative path behind `moxxy plugins install`) shelled the raw caller-supplied spec straight to `npm` with no validation. The `install_plugin` **tool** guards with `NPM_NAME_RE`, but the CLI function bypassed it, so a spec like `-g` or `--registry=http://evil` was forwarded to npm as an **option** rather than a package — argument injection. (No shell is used, so this was never shell-injection.)

New `assertSafeNpmSpec` rejects an empty or leading-`-` spec **while still accepting** the legitimate `name@version`, git (`github:`/`git+`/`https://`/`ssh://`), and local-path specs — note that simply "apply `NPM_NAME_RE`" (the original TODO) would have *broken* those valid install shapes, which is why the guard is dash-based instead.

### 2. Dedup (TECH_DEBT P2 #8)
`NPM_NAME_RE`, `diffSnapshot`, and `PluginSnapshot` were copy-pasted across `install.ts` and `toggle.ts` in the newly-folded package. Hoisted into one `shared.ts`.

### 3. Tech-debt journal refresh (docs)
- Re-verified every open `TECH_DEBT.md` item against `HEAD`; all prior "DONE" items confirmed still in place (no regressions) and collapsed into a resolved ledger.
- Folded in post-audit findings: desktop dual-persistence redundancy (P1), mode-default/mode-goal loop duplication (P2 #6), Anthropic-provider casts/model list (P3).
- Added an `AGENTS.md` rule making `TECH_DEBT.md` a **living journal** — read it before non-trivial work, retire ≥1 item per change, log new debt on sight, re-audit during bigger work, own debt like a CTO. This PR is the first chip-away under that rule.

## Tests
+9 tests (`shared.test.ts`): `assertSafeNpmSpec` accepts all legit spec shapes, trims, and rejects empty/flag-like specs; `installPluginPackage`/`removePluginPackage` reject injection **before** spawning npm; `diffSnapshot` + `NPM_NAME_RE` behavior.

## Verification
- `pnpm build` — 52/52 ✅
- `pnpm -r typecheck` — clean ✅
- `pnpm lint` — 0 errors ✅
- `pnpm check:deps` — no violations ✅
- `pnpm --filter @moxxy/plugin-plugins-admin test` — 27/27 ✅

## Changeset
`@moxxy/cli` patch (plugins-admin is `private`/bundled into the CLI binary).

## Not in this PR (proposed follow-ups, see TECH_DEBT.md)
- **P1 #2 desktop dual-persistence** — runner session log vs desktop NDJSON chat-log are two durable copies (desync window on `/new`, unbounded NDJSON growth on restart). High-stakes but architectural + the path is untested + can't be verified without driving the desktop app; wants its own PR.
- **P2 #6 mode-default/mode-goal loop dedup** — the load-bearing stuck-loop fix is copy-pasted; should become a shared SDK block.