### PR TITLE
fix(desktop): idempotent chat-log append — stop NDJSON growth on restart (TECH_DEBT P1 #2)

### DIFF
--- a/.changeset/desktop-chatlog-idempotent-append.md
+++ b/.changeset/desktop-chatlog-idempotent-append.md
@@ -1,0 +1,11 @@
+---
+"@moxxy/desktop": patch
+---
+
+Stop the desktop chat-log from growing without bound on every restart. The runner
+replays a conversation's full event history to the renderer on each attach, and the
+renderer re-appended every replayed event to its NDJSON mirror
+(`~/.moxxy/chats/<workspace>.jsonl`), so the file grew by a complete copy of the
+conversation per restart — which also shifted `loadSegment`'s line-index cursors and
+corrupted scroll-up pagination. `appendEvents` is now idempotent by event id, so the
+log keeps exactly one copy and its pagination cursors stay stable.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -37,32 +37,35 @@ yet compile against a bare `RemoteSession`. Retype the handler params to the min
 work, not standalone. (The `RemoteSession` casts at `desktop-host/src/ipc/session.ts:105`
 and `ipc/shared.ts:164` are the same seam — see P3.)
 
-### 2. Desktop persists every conversation twice — pick one source of truth — 🔴 NEW
-**Found 2026-06-08 (the "NDJSON-vs-replay redundancy" follow-up, now characterized).**
-Every committed event is written to disk in **two** independent stores:
-- runner session log — `~/.moxxy/sessions/<id>.jsonl`, replayed on attach
-  (`runner/src/server.ts:184`; `desktop-host/src/runner-supervisor.ts:79,435`);
+### 2. Desktop persists every conversation twice — pick one source of truth — ⚠️ PARTIALLY DONE
+**Found 2026-06-08 (the "NDJSON-vs-replay redundancy" follow-up).** Every committed event
+is written to disk in **two** independent stores:
+- runner session log — `~/.moxxy/sessions/<id>.jsonl`, replayed in full on every attach
+  (`runner/src/server.ts:184` — always replays from seq 0);
 - desktop NDJSON chat-log — `~/.moxxy/chats/<workspaceId>.jsonl`
-  (`desktop-host/src/chat-log.ts:30-33`), loaded by
-  `apps/desktop/src/lib/chat-store/store.ts:187`.
+  (`desktop-host/src/chat-log.ts`), the renderer's windowed mirror.
 
-Two concrete defects fall out of the redundancy:
-- **Desync window on `/new`.** Reset wipes both via two separate IPC calls
-  (`CommandPalette.tsx:91-92`: `chatStore.clear()` then `session.newSession`). If the
-  second fails or the app dies between them, the renderer is cleared but the runner is
-  still primed → old context resurrects on the next turn/restart.
-- **Unbounded NDJSON growth.** On restart `seenIds` starts empty; the runner replays its
-  full history on attach; each replayed event misses `seenIds`, so `dispatch` re-appends
-  it to the NDJSON log (`store.ts:317-326`). `loadOlder` dedups only on read
-  (`store.ts:240-243`), so the on-disk file bloats by a full copy every restart.
+**Fixed (2026-06-08):** the **unbounded NDJSON growth** defect. Because the runner replays
+the full history on every restart and the renderer re-appends each replayed event, the
+NDJSON log used to grow by a complete copy of the conversation per restart — and since
+`loadSegment`'s cursor is a line index, the doubled file also corrupted scroll-up
+pagination. `appendEvents` is now **idempotent by event id** (lazy file-path-keyed id cache),
+so the log holds one copy and its cursors stay stable. +5 chat-log tests.
 
-**Action:** decide the single source of truth. The runner already persists + replays the
-full history, so the desktop NDJSON store is arguably entirely redundant — either drop it
-and read from the runner replay, or stop re-persisting replayed events and make `/new` a
-single atomic reset. **Whichever way: this path has zero tests** — no `store.test.ts`, and
-`resetSession`/`newSession`/`deleteSession` in `runner-supervisor.ts` are uncovered. Add
-tests for append-on-dispatch, the restart double-append, `loadOlder` dedup, and the
-`/new` dual-clear as part of the fix.
+**Remaining (the real decision):** the redundancy itself. The runner replay already
+delivers the complete history to the renderer on every attach, so the desktop NDJSON store
+is arguably entirely redundant — dropping it (read history from the runner replay only)
+would also kill the redundant on-restart append IPC and the `/new` desync below. Counter-risk:
+legacy localStorage→NDJSON-migrated chats may live ONLY in NDJSON, not in any runner session
+log, so a naive drop loses early-adopter history. **Needs a product call + desktop-app
+verification — not a mechanical change.**
+
+**Also remaining (lives on `fix/desktop-resume-session`, not yet on main):** the **`/new`
+desync window**. Reset wipes the renderer + NDJSON and resets the runner via separate IPC
+calls; if one fails or the app dies between them, the two desync and old context resurrects.
+Make `/new` reset the runner FIRST and only clear the renderer/NDJSON on success (or a single
+atomic IPC). Fold this in when that branch lands. The renderer `chat-store/store.ts`
+persistence path is also still untested (`store.test.ts` absent).
 
 ---
 

--- a/packages/desktop-host/src/chat-log.test.ts
+++ b/packages/desktop-host/src/chat-log.test.ts
@@ -71,6 +71,58 @@ describe('chat-log NDJSON backend', () => {
     expect((await loadSegment('w2', null, 10)).events.map((e) => (e as { text: string }).text)).toEqual(['m5', 'm6']);
   });
 
+  it('is idempotent by event id — a replayed history is not duplicated', async () => {
+    // First "session": three events land live.
+    await appendEvents('w1', [ev(0), ev(1), ev(2)]);
+    // Simulate a restart: the runner replays the full history (same ids) and
+    // the renderer re-appends every event. None should be written twice.
+    await appendEvents('w1', [ev(0), ev(1), ev(2)]);
+    await appendEvents('w1', [ev(0), ev(1), ev(2)]);
+    const seg = await loadSegment('w1', null, 10);
+    expect(seg.events.map((e) => (e as { text: string }).text)).toEqual(['m0', 'm1', 'm2']);
+    expect(seg.prevCursor).toBeNull();
+  });
+
+  it('writes only the fresh events when a batch overlaps the log', async () => {
+    await appendEvents('w1', [ev(0), ev(1)]);
+    // A batch that replays e1 and adds e2 + e3 — only e2/e3 are new.
+    await appendEvents('w1', [ev(1), ev(2), ev(3)]);
+    const seg = await loadSegment('w1', null, 10);
+    expect(seg.events.map((e) => (e as { text: string }).text)).toEqual(['m0', 'm1', 'm2', 'm3']);
+  });
+
+  it('keeps the pagination cursor stable across a re-appended history', async () => {
+    await appendEvents('w1', Array.from({ length: 10 }, (_, i) => ev(i)));
+    const before = await loadSegment('w1', null, 4);
+    // Re-append the whole history (restart replay) — line count must not grow,
+    // so the line-index cursor still points at the same boundary.
+    await appendEvents('w1', Array.from({ length: 10 }, (_, i) => ev(i)));
+    const after = await loadSegment('w1', null, 4);
+    expect(after.events.map((e) => (e as { text: string }).text)).toEqual(
+      before.events.map((e) => (e as { text: string }).text),
+    );
+    expect(after.prevCursor).toBe(before.prevCursor);
+  });
+
+  it('clearLog resets idempotency so the same ids can be written again', async () => {
+    await appendEvents('w1', [ev(0), ev(1)]);
+    await clearLog('w1');
+    await appendEvents('w1', [ev(0), ev(1)]);
+    const seg = await loadSegment('w1', null, 10);
+    expect(seg.events.map((e) => (e as { text: string }).text)).toEqual(['m0', 'm1']);
+  });
+
+  it('dedupes against events already on disk from a previous process (cold cache)', async () => {
+    // Write the log directly, as a prior process would, so the in-memory cache
+    // never saw these ids — appendEvents must hydrate from the file and dedupe.
+    const fs = await import('node:fs/promises');
+    const file = path.join(dir, 'w3.jsonl');
+    await fs.writeFile(file, [ev(0), ev(1)].map((e) => JSON.stringify(e)).join('\n') + '\n');
+    await appendEvents('w3', [ev(0), ev(1), ev(2)]);
+    const seg = await loadSegment('w3', null, 10);
+    expect(seg.events.map((e) => (e as { text: string }).text)).toEqual(['m0', 'm1', 'm2']);
+  });
+
   it('skips corrupt lines instead of losing the transcript', async () => {
     await appendEvents('w1', [ev(0)]);
     const file = path.join(dir, 'w1.jsonl');

--- a/packages/desktop-host/src/chat-log.ts
+++ b/packages/desktop-host/src/chat-log.ts
@@ -32,6 +32,33 @@ function fileFor(workspaceId: string): string {
   return path.join(chatsDir(), `${safe}.jsonl`);
 }
 
+/**
+ * Per-log set of event ids already written, so {@link appendEvents} is
+ * idempotent by id without re-reading the whole file each turn. Keyed by the
+ * resolved FILE PATH (not the workspace id) so tests pointing `MOXXY_CHATS_DIR`
+ * at different tmp dirs never share a cache entry.
+ *
+ * Why idempotent: on every desktop restart the runner replays its FULL event
+ * history to each attaching client (runner attach replays from seq 0), and the
+ * renderer re-appends every replayed event here. Without dedup the NDJSON log
+ * grew by a complete copy of the conversation on each restart — and because
+ * {@link loadSegment}'s cursor is a line index, a doubled file also corrupted
+ * scroll-up pagination. Deduping by id keeps the log one copy and its cursors
+ * stable. (The runner session log remains the source of truth on replay; this
+ * file is the renderer's windowed mirror.)
+ */
+const writtenIds = new Map<string, Set<string>>();
+
+async function knownIds(workspaceId: string): Promise<Set<string>> {
+  const key = fileFor(workspaceId);
+  let set = writtenIds.get(key);
+  if (!set) {
+    set = new Set((await readLines(workspaceId)).map((e) => e.id));
+    writtenIds.set(key, set);
+  }
+  return set;
+}
+
 async function readLines(workspaceId: string): Promise<MoxxyEvent[]> {
   let body: string;
   try {
@@ -51,16 +78,21 @@ async function readLines(workspaceId: string): Promise<MoxxyEvent[]> {
   return out;
 }
 
-/** Append committed events to the workspace's log. No-op for an empty
- *  batch; creates the dir lazily on first write. */
+/** Append committed events to the workspace's log, skipping any whose id is
+ *  already on disk (idempotent — see {@link writtenIds}). No-op for an empty
+ *  batch or one that is wholly duplicate; creates the dir lazily on first write. */
 export async function appendEvents(
   workspaceId: string,
   events: ReadonlyArray<MoxxyEvent>,
 ): Promise<void> {
   if (events.length === 0) return;
+  const seen = await knownIds(workspaceId);
+  const fresh = events.filter((e) => !seen.has(e.id));
+  if (fresh.length === 0) return;
   await mkdir(chatsDir(), { recursive: true });
-  const lines = events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+  const lines = fresh.map((e) => JSON.stringify(e)).join('\n') + '\n';
   await appendFile(fileFor(workspaceId), lines, 'utf8');
+  for (const e of fresh) seen.add(e.id);
 }
 
 /**
@@ -80,8 +112,10 @@ export async function loadSegment(
   return { events: all.slice(start, end), prevCursor: start > 0 ? start : null };
 }
 
-/** Truncate a workspace's log (Clear conversation). */
+/** Truncate a workspace's log (Clear conversation). Also drops the
+ *  idempotency cache so re-adding the same ids writes them again. */
 export async function clearLog(workspaceId: string): Promise<void> {
+  writtenIds.delete(fileFor(workspaceId));
   try {
     await rm(fileFor(workspaceId));
   } catch {
@@ -118,6 +152,9 @@ export async function migrate(
     }
     try {
       await handle.writeFile(lines, 'utf8');
+      // Force a re-hydrate of the idempotency cache from the freshly-seeded
+      // file, in case a live append had already cached this log as empty.
+      writtenIds.delete(fileFor(workspaceId));
     } finally {
       await handle.close();
     }


### PR DESCRIPTION
## The bug (TECH_DEBT P1 #2 — the desktop dual-persistence high item)

The desktop keeps a conversation in **two** durable stores: the runner session log (`~/.moxxy/sessions/<id>.jsonl`) and the renderer's NDJSON mirror (`~/.moxxy/chats/<workspace>.jsonl`). The runner **always replays the full history from seq 0 on every attach** (`runner/src/server.ts:184`), and the renderer re-appended every replayed event to its NDJSON mirror.

Result on every desktop **restart**:
1. **Unbounded growth** — the NDJSON file grew by a *complete copy* of the conversation each time.
2. **Corrupted pagination** — `loadSegment`'s cursor is a **line index**, so a doubled file made scroll-up ("load older") jump to the wrong place.

## The fix

`appendEvents` is now **idempotent by event id**: a lazily-hydrated, **file-path-keyed** id cache (so different tmp/test dirs never collide) lets it skip any event already on disk in O(batch) — it never re-reads the whole file per turn. The log keeps exactly one copy and its cursors stay stable.

- `clearLog` drops the cache so the same ids can be written again after a Clear.
- `migrate` invalidates the cache after seeding, defending the legacy-migrate-vs-live-append ordering.

This stays inside the current architecture: the runner session log remains the source of truth on replay; the NDJSON file is the renderer's windowed mirror.

## Tests
+5 `chat-log.test.ts` cases (12 total, all green): idempotent across a simulated restart-replay; fresh-only when a batch overlaps; **cursor stability** across a re-appended history; `clearLog` resets idempotency; and **cold-cache** dedup (file pre-seeded by a "previous process", in-memory cache empty).

## Verification
- `pnpm --filter @moxxy/desktop-host test` — 142/142 ✅ (chat-log 12/12)
- `pnpm build` — 52/52 ✅ · `pnpm -r typecheck` clean ✅ · `pnpm lint` 0 errors ✅

## Changeset
`@moxxy/desktop` patch (desktop-host is bundled into the desktop app).

## Explicitly NOT in this PR (still tracked under TECH_DEBT P1 #2)
- **The redundancy itself.** The runner replay already delivers full history, so the NDJSON store is arguably droppable — but a naive drop would lose legacy localStorage→NDJSON-migrated chats that may exist *only* in NDJSON. Needs a product call + desktop-app verification.
- **The `/new` desync window.** That reset path lives on the unmerged `fix/desktop-resume-session` branch, not on `main`; fold the "reset runner first, clear renderer on success" fix in when that branch lands.
- The renderer `chat-store/store.ts` persistence path remains untested (no `store.test.ts`).