### PR TITLE
refactor(modes): hoist shared tool-batch loop helpers into the SDK (TECH_DEBT P2 #6)

### DIFF
--- a/.changeset/mode-loop-shared-helpers.md
+++ b/.changeset/mode-loop-shared-helpers.md
@@ -1,0 +1,12 @@
+---
+"@moxxy/sdk": minor
+---
+
+Hoist the duplicated tool-batch loop scaffolding out of `mode-default` and `mode-goal`
+into shared SDK helpers, so the load-bearing stuck-loop orphan-result fix lives in one
+place instead of being hand-mirrored across modes. `@moxxy/sdk` now exports
+`executeToolUses` (run a tool batch, synthesizing failed results + an abort on
+mid-batch cancel) and `emitRequestsAndDetectStuck` (emit `tool_call_requested`s, run the
+stuck detector, and on a trip synthesize a paired `tool_result` for every emitted call
+before the fatal error), parameterized by a `StuckLoopReport` for each mode's wording and
+goal mode's extra `goal_stuck` event. Pure refactor — no behavior change.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -95,29 +95,17 @@ raw throws are internal registry/broker invariants that should stay plain):
 - desktop self-update **security** failures (signature/hash/unsafe-path) throw raw Error —
   `desktop-host/src/app-update/stager.ts:258-302`; candidates for a typed error code.
 
-### 6. Mode loop scaffolding is copy-pasted across mode-default and mode-goal — 🔴 NEW
-**Found 2026-06-08.** The mode-slimming PR (#93) collapsed the mode list but left the
-per-iteration loop duplicated: `mode-default/src/turn-iterator.ts:168-272` vs
-`mode-goal/src/goal-loop.ts:333-436`. `executeToolUses` differs only in comments/whitespace;
-`emitRequestsAndDetectStuck` differs only in error strings; the provider-request/response +
-overflow/reactive-compaction block (`turn-iterator.ts:67-127` vs `goal-loop.ts:128-182`)
-is near-identical. Critically, the **orphan-tool-result / stuck-loop fix** (load-bearing —
-the comments literally say "See the same fix in mode-tool-use") is copy-pasted, so any fix
-must be hand-mirrored. **Action:** hoist the shared iteration scaffolding into an SDK
-`mode-helpers` building block (per the repo's "prefer swappable blocks" guideline) so both
-modes compose it. **Severity med.**
-
 ---
 
 ## P3 — Low / per-package nits
 
-### 7. plugin-memory caches embeddings via a parallel `EmbeddingIndex` — OPEN
+### 6. plugin-memory caches embeddings via a parallel `EmbeddingIndex` — OPEN
 **Cross-cut 1.11.** `plugin-memory/src/store.ts:6,88-96` still uses its own `EmbeddingIndex`
 cache instead of the SDK `CachedEmbeddingProvider`. **Deferred:** now that the atomic-write +
 recall-race bugs are fixed, this is pure dedup of caching logic over a subtle mutex-guarded
 recall path — low value, real risk. Fold in only if the recall path is touched anyway.
 
-### 8. Channel→core prod dependency — OPEN
+### 7. Channel→core prod dependency — OPEN
 `plugin-cli`/`plugin-telegram` keep real `@moxxy/core` prod imports (`savePreferences`,
 `clearUsageStats`, `newTurnId`, `loadUsageStats`, `PermissionEngine` — e.g.
 `plugin-cli/src/session/run-slash.ts:2`, `plugin-telegram/src/channel/turn-runner.ts:2`).
@@ -125,7 +113,7 @@ To fully sever channel→core, hoist these provider-neutral helpers into `@moxxy
 (cross-cut 2.14). (`plugin-subagents`/`plugin-view` keep core as a **dev**Dep only — their
 `*.test.ts` import core; correct, leave them.)
 
-### 9. Small casts / hardcoded values — NEW, low
+### 8. Small casts / hardcoded values — NEW, low
 - **Type the exec allowlist.** `plugin-security/src/broker.ts:343` reads
   `(caps as unknown as { commands? }).commands` — a forward-compat field not on
   `CapabilitySpec`. It gates the **exec allowlist**, so it's worth typing properly on
@@ -146,6 +134,13 @@ To fully sever channel→core, hoist these provider-neutral helpers into `@moxxy
 Collapsed from full write-ups; each was re-checked against `HEAD` and confirmed — no
 regressions. Restore the detail from git history (`TECH_DEBT.md` @ `b014c3a`) if needed.
 
+- **Mode loop scaffolding hoisted to the SDK** (2026-06-08, was P2 #6). The load-bearing
+  stuck-loop orphan-result fix + the tool-batch abort path were copy-pasted across
+  `mode-default` and `mode-goal` (a fix to one had to be hand-mirrored). Both now compose
+  `executeToolUses` + `emitRequestsAndDetectStuck` from `@moxxy/sdk` (`tool-dispatch.ts`),
+  parameterized by a `StuckLoopReport` for each mode's wording + goal's `goal_stuck` event.
+  Pure refactor, no behavior change; mode-default 9/9 + mode-goal 10/10 green. (The outer
+  loop bodies stay per-mode by design — different strategies.)
 - **plugins-admin CLI install hardening + dedup** (2026-06-08, was P2 #7/#8). The imperative
   `installPluginPackage`/`removePluginPackage` now reject a flag-like spec via
   `assertSafeNpmSpec` (a leading `-` is argument injection) — and crucially still accept the

--- a/packages/mode-default/src/turn-iterator.ts
+++ b/packages/mode-default/src/turn-iterator.ts
@@ -1,19 +1,17 @@
 import {
-  asToolCallId,
   buildSystemPromptWithSkills,
   collectProviderStream,
   createStuckLoopDetector,
-  dispatchToolCall,
+  emitRequestsAndDetectStuck,
+  executeToolUses,
   isContextOverflowError,
   projectMessages,
   runCompactionIfNeeded,
   runElisionIfNeeded,
   usageEventFields,
-  type CollectedToolUse,
   type ModeContext,
   type MoxxyEvent,
   type ProjectedMessages,
-  type StuckLoopDetector,
 } from '@moxxy/sdk';
 
 export const DEFAULT_MODE_NAME = 'default';
@@ -126,7 +124,14 @@ export async function* runDefaultMode(ctx: ModeContext): AsyncIterable<MoxxyEven
     // Clean provider call — reset the overflow-recovery budget.
     reactiveCompactions = 0;
 
-    const stuck = yield* emitRequestsAndDetectStuck(ctx, toolUses, detector);
+    const stuck = yield* emitRequestsAndDetectStuck(ctx, toolUses, detector, {
+      abortedResultMessage: 'default mode loop aborted (stuck pattern) before this call ran',
+      nearHint: 'against the same target (only volatile args like maxBytes varied)',
+      fatalMessage: ({ toolName, count, how }) =>
+        `default mode loop aborted — detected stuck pattern: tool "${toolName}" called ` +
+        `${count} times ${how}. The model is likely looping on the same call; ` +
+        `reset or rephrase.`,
+    });
     if (stuck) return;
 
     if (text || stopReason === 'end_turn' || toolUses.length === 0) {
@@ -161,114 +166,6 @@ export async function* runDefaultMode(ctx: ModeContext): AsyncIterable<MoxxyEven
     kind: 'fatal',
     message: `default mode loop exceeded maxIterations (${maxIterations})`,
   });
-}
-
-/** Emit tool_call_requested for each tool use and check the stuck-loop
- *  detector. Returns `true` when the detector tripped (caller should stop). */
-async function* emitRequestsAndDetectStuck(
-  ctx: ModeContext,
-  toolUses: ReadonlyArray<CollectedToolUse>,
-  detector: StuckLoopDetector,
-): AsyncGenerator<MoxxyEvent, boolean, unknown> {
-  // Requests emitted this batch. A stuck trip bails WITHOUT running
-  // executeToolUses, so every request emitted so far would otherwise be left
-  // as an orphan tool_call_requested (no tool_result). That orphan is the bug
-  // behind "tool stuck running forever, flips to error on the next message":
-  // the turn ends cleanly (composer re-enables) yet the call never resolves,
-  // so the desktop's pair-events fold can only clear it via the next
-  // user_prompt's markOrphansAtTurnBoundary. The provider also rejects an
-  // unresolved tool_use block next turn. Synthesize a failed result for each —
-  // same contract as executeToolUses' abort path.
-  const emitted: CollectedToolUse[] = [];
-  for (const t of toolUses) {
-    yield await ctx.emit({
-      type: 'tool_call_requested',
-      sessionId: ctx.sessionId,
-      turnId: ctx.turnId,
-      source: 'model',
-      callId: asToolCallId(t.id),
-      name: t.name,
-      input: t.input,
-    });
-    emitted.push(t);
-    const sig = detector.record(t.name, t.input);
-    if (sig.stuck) {
-      for (const r of emitted) {
-        yield await ctx.emit({
-          type: 'tool_result',
-          sessionId: ctx.sessionId,
-          turnId: ctx.turnId,
-          source: 'tool',
-          callId: asToolCallId(r.id),
-          ok: false,
-          error: { kind: 'aborted', message: 'default mode loop aborted (stuck pattern) before this call ran' },
-        });
-      }
-      const how =
-        sig.kind === 'near'
-          ? 'against the same target (only volatile args like maxBytes varied)'
-          : 'with identical input';
-      yield await ctx.emit({
-        type: 'error',
-        sessionId: ctx.sessionId,
-        turnId: ctx.turnId,
-        source: 'system',
-        kind: 'fatal',
-        message:
-          `default mode loop aborted — detected stuck pattern: tool "${t.name}" called ` +
-          `${sig.count} times ${how}. The model is likely looping on the same call; ` +
-          `reset or rephrase.`,
-      });
-      return true;
-    }
-  }
-  return false;
-}
-
-/** Execute tool uses, handling mid-batch abort. Returns `true` when the
- *  caller should `return` (abort observed). */
-async function* executeToolUses(
-  ctx: ModeContext,
-  toolUses: ReadonlyArray<CollectedToolUse>,
-  iteration: number,
-): AsyncGenerator<MoxxyEvent, boolean, unknown> {
-  // Tracks tool_call_requested events that haven't yet emitted a paired
-  // tool_result. On any early-exit (abort, unexpected throw), we synthesize
-  // results for the leftovers so the event log can't end with orphan
-  // tool_call_requested events.
-  const unresolved = new Set<string>(toolUses.map((t) => t.id));
-
-  for (const t of toolUses) {
-    if (ctx.signal.aborted) {
-      for (const orphanId of unresolved) {
-        yield await ctx.emit({
-          type: 'tool_result',
-          sessionId: ctx.sessionId,
-          turnId: ctx.turnId,
-          source: 'tool',
-          callId: asToolCallId(orphanId),
-          ok: false,
-          error: { kind: 'aborted', message: 'turn aborted before tool ran' },
-        });
-      }
-      unresolved.clear();
-      yield await ctx.emit({
-        type: 'abort',
-        sessionId: ctx.sessionId,
-        turnId: ctx.turnId,
-        source: 'system',
-        reason: 'signal aborted during tool execution',
-      });
-      return true;
-    }
-
-    try {
-      yield* dispatchToolCall(ctx, t, iteration);
-    } finally {
-      unresolved.delete(t.id);
-    }
-  }
-  return false;
 }
 
 function buildMessages(ctx: ModeContext): ProjectedMessages {

--- a/packages/mode-goal/src/goal-loop.ts
+++ b/packages/mode-goal/src/goal-loop.ts
@@ -1,19 +1,17 @@
 import {
-  asToolCallId,
   buildSystemPromptWithSkills,
   collectProviderStream,
   createStuckLoopDetector,
-  dispatchToolCall,
+  emitRequestsAndDetectStuck,
+  executeToolUses,
   isContextOverflowError,
   projectMessages,
   runCompactionIfNeeded,
   runElisionIfNeeded,
   usageEventFields,
-  type CollectedToolUse,
   type ModeContext,
   type MoxxyEvent,
   type PermissionResolver,
-  type StuckLoopDetector,
 } from '@moxxy/sdk';
 
 import { detectGoalTerminal } from './completion.js';
@@ -206,7 +204,24 @@ export async function* runGoalMode(ctx: ModeContext): AsyncIterable<MoxxyEvent> 
       return;
     }
 
-    const stuck = yield* emitRequestsAndDetectStuck(ctx, toolUses, detector);
+    const stuck = yield* emitRequestsAndDetectStuck(ctx, toolUses, detector, {
+      abortedResultMessage: 'goal mode aborted (stuck pattern) before this call ran',
+      nearHint: 'against the same target (only volatile args varied)',
+      extraOnStuck: ({ toolName, count, kind }) => [
+        {
+          type: 'plugin_event',
+          sessionId: ctx.sessionId,
+          turnId: ctx.turnId,
+          source: 'plugin',
+          pluginId: GOAL_PLUGIN_ID,
+          subtype: 'goal_stuck',
+          payload: { tool: toolName, count, kind },
+        },
+      ],
+      fatalMessage: ({ toolName, count, how }) =>
+        `goal mode aborted — stuck pattern: tool "${toolName}" called ${count} times ${how}. ` +
+        `The model is looping on the same call; send another message to redirect it.`,
+    });
     if (stuck) return;
 
     if (text || stopReason === 'end_turn' || toolUses.length === 0) {
@@ -326,111 +341,4 @@ export async function* runGoalMode(ctx: ModeContext): AsyncIterable<MoxxyEvent> 
 function composeSystemPrompts(user: string | undefined, layer: string): string {
   if (!user || user.trim() === '') return layer;
   return `${layer}\n\n---\n\n${user}`;
-}
-
-/** Emit tool_call_requested for each tool use and check the stuck-loop
- *  detector. Returns `true` when the detector tripped (caller should stop). */
-async function* emitRequestsAndDetectStuck(
-  ctx: ModeContext,
-  toolUses: ReadonlyArray<CollectedToolUse>,
-  detector: StuckLoopDetector,
-): AsyncGenerator<MoxxyEvent, boolean, unknown> {
-  // A stuck trip bails WITHOUT running executeToolUses, so any request emitted
-  // so far would be orphaned (a tool_call_requested with no tool_result) —
-  // which renders as a tool stuck "running" forever and only clears when the
-  // next user_prompt arrives. Synthesize a failed result for each before
-  // returning, mirroring executeToolUses' abort path. See the same fix in
-  // mode-tool-use's turn-iterator.
-  const emitted: CollectedToolUse[] = [];
-  for (const t of toolUses) {
-    yield await ctx.emit({
-      type: 'tool_call_requested',
-      sessionId: ctx.sessionId,
-      turnId: ctx.turnId,
-      source: 'model',
-      callId: asToolCallId(t.id),
-      name: t.name,
-      input: t.input,
-    });
-    emitted.push(t);
-    const sig = detector.record(t.name, t.input);
-    if (sig.stuck) {
-      for (const r of emitted) {
-        yield await ctx.emit({
-          type: 'tool_result',
-          sessionId: ctx.sessionId,
-          turnId: ctx.turnId,
-          source: 'tool',
-          callId: asToolCallId(r.id),
-          ok: false,
-          error: { kind: 'aborted', message: 'goal mode aborted (stuck pattern) before this call ran' },
-        });
-      }
-      const how =
-        sig.kind === 'near'
-          ? 'against the same target (only volatile args varied)'
-          : 'with identical input';
-      yield await ctx.emit({
-        type: 'plugin_event',
-        sessionId: ctx.sessionId,
-        turnId: ctx.turnId,
-        source: 'plugin',
-        pluginId: GOAL_PLUGIN_ID,
-        subtype: 'goal_stuck',
-        payload: { tool: t.name, count: sig.count, kind: sig.kind },
-      });
-      yield await ctx.emit({
-        type: 'error',
-        sessionId: ctx.sessionId,
-        turnId: ctx.turnId,
-        source: 'system',
-        kind: 'fatal',
-        message:
-          `goal mode aborted — stuck pattern: tool "${t.name}" called ${sig.count} times ${how}. ` +
-          `The model is looping on the same call; send another message to redirect it.`,
-      });
-      return true;
-    }
-  }
-  return false;
-}
-
-/** Execute tool uses, handling mid-batch abort. Returns `true` when the
- *  caller should stop (abort observed). Mirrors mode-tool-use. */
-async function* executeToolUses(
-  ctx: ModeContext,
-  toolUses: ReadonlyArray<CollectedToolUse>,
-  iteration: number,
-): AsyncGenerator<MoxxyEvent, boolean, unknown> {
-  const unresolved = new Set<string>(toolUses.map((t) => t.id));
-  for (const t of toolUses) {
-    if (ctx.signal.aborted) {
-      for (const orphanId of unresolved) {
-        yield await ctx.emit({
-          type: 'tool_result',
-          sessionId: ctx.sessionId,
-          turnId: ctx.turnId,
-          source: 'tool',
-          callId: asToolCallId(orphanId),
-          ok: false,
-          error: { kind: 'aborted', message: 'turn aborted before tool ran' },
-        });
-      }
-      unresolved.clear();
-      yield await ctx.emit({
-        type: 'abort',
-        sessionId: ctx.sessionId,
-        turnId: ctx.turnId,
-        source: 'system',
-        reason: 'signal aborted during tool execution',
-      });
-      return true;
-    }
-    try {
-      yield* dispatchToolCall(ctx, t, iteration);
-    } finally {
-      unresolved.delete(t.id);
-    }
-  }
-  return false;
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -183,7 +183,12 @@ export {
   type StuckLoopDetector,
   type StuckSignal,
 } from './mode-helpers.js';
-export { dispatchToolCall } from './tool-dispatch.js';
+export {
+  dispatchToolCall,
+  executeToolUses,
+  emitRequestsAndDetectStuck,
+  type StuckLoopReport,
+} from './tool-dispatch.js';
 
 export type { TokenBudget, CompactContext, CompactorDef } from './compactor.js';
 export {

--- a/packages/sdk/src/tool-dispatch.ts
+++ b/packages/sdk/src/tool-dispatch.ts
@@ -1,8 +1,8 @@
 import { asToolCallId } from './ids.js';
-import type { MoxxyEvent } from './events.js';
+import type { EmittedEvent, MoxxyEvent } from './events.js';
 import type { ModeContext } from './mode.js';
 import type { ToolCallVerdict } from './hooks.js';
-import type { CollectedToolUse } from './mode-helpers.js';
+import type { CollectedToolUse, StuckLoopDetector, StuckSignal } from './mode-helpers.js';
 
 /**
  * Execute a single tool-use end-to-end: dispatch `dispatchToolCall` hooks, run
@@ -11,7 +11,7 @@ import type { CollectedToolUse } from './mode-helpers.js';
  * don't need the events can drain it (`for await (const _ of …) {}`) — either
  * way the events reach the log via `ctx.emit`.
  *
- * Shared by every loop strategy (tool-use, plan-execute, developer, bmad) so
+ * Shared by every loop strategy (default, goal, and any contributed mode) so
  * the defensive outer try/catch below lives in ONE place. Without it, a throw
  * from a hook handler / permission resolver / the emit itself escapes the
  * generator and leaves this (and any later) call as an orphan
@@ -134,4 +134,137 @@ async function* emitDenied(
     ok: false,
     error: { kind: 'denied', message: reason },
   });
+}
+
+/**
+ * Run a batch of tool uses in order, handling mid-batch abort. On
+ * `ctx.signal.aborted` it synthesizes a failed `tool_result` for every
+ * not-yet-run call (so the log never ends on an orphan `tool_call_requested`),
+ * emits an `abort`, and returns `true` to tell the caller to stop. Returns
+ * `false` after a clean batch. Shared by every loop strategy so the
+ * orphan-on-abort guarantee lives in one place.
+ */
+export async function* executeToolUses(
+  ctx: ModeContext,
+  toolUses: ReadonlyArray<CollectedToolUse>,
+  iteration: number,
+): AsyncGenerator<MoxxyEvent, boolean, unknown> {
+  // Tracks tool_call_requested events that haven't yet emitted a paired
+  // tool_result. On any early-exit (abort) we synthesize results for the
+  // leftovers so the event log can't end with orphan tool_call_requested events.
+  const unresolved = new Set<string>(toolUses.map((t) => t.id));
+  for (const t of toolUses) {
+    if (ctx.signal.aborted) {
+      for (const orphanId of unresolved) {
+        yield await ctx.emit({
+          type: 'tool_result',
+          sessionId: ctx.sessionId,
+          turnId: ctx.turnId,
+          source: 'tool',
+          callId: asToolCallId(orphanId),
+          ok: false,
+          error: { kind: 'aborted', message: 'turn aborted before tool ran' },
+        });
+      }
+      unresolved.clear();
+      yield await ctx.emit({
+        type: 'abort',
+        sessionId: ctx.sessionId,
+        turnId: ctx.turnId,
+        source: 'system',
+        reason: 'signal aborted during tool execution',
+      });
+      return true;
+    }
+    try {
+      yield* dispatchToolCall(ctx, t, iteration);
+    } finally {
+      unresolved.delete(t.id);
+    }
+  }
+  return false;
+}
+
+/**
+ * How a loop strategy phrases its stuck-loop abort. The skeleton — emit a
+ * `tool_call_requested` per call, feed the detector, and on a trip synthesize a
+ * failed `tool_result` for every already-emitted call before a fatal error — is
+ * identical across strategies and lives in {@link emitRequestsAndDetectStuck};
+ * only the wording, and goal mode's extra `goal_stuck` plugin_event, vary.
+ */
+export interface StuckLoopReport {
+  /** Message on the synthesized failed `tool_result` for the calls emitted
+   *  before the trip (none of them ran). */
+  readonly abortedResultMessage: string;
+  /** Explanation for a `near` match (an `exact` match always reads
+   *  "with identical input"). */
+  readonly nearHint: string;
+  /** Build the fatal error message shown to the user. */
+  readonly fatalMessage: (info: { toolName: string; count: number; how: string }) => string;
+  /** Extra events to emit right before the fatal error — goal mode surfaces a
+   *  `goal_stuck` plugin_event here. */
+  readonly extraOnStuck?: (info: {
+    toolName: string;
+    count: number;
+    kind: StuckSignal['kind'];
+  }) => ReadonlyArray<EmittedEvent>;
+}
+
+/**
+ * Emit a `tool_call_requested` for each tool use and feed it to the stuck-loop
+ * detector. Returns `true` when the detector trips (caller should stop) — after
+ * synthesizing a failed `tool_result` for every request emitted this batch.
+ * That synthesis is load-bearing: a stuck trip bails WITHOUT running
+ * {@link executeToolUses}, so without it the emitted requests are left as orphan
+ * `tool_call_requested` events (which render as a tool stuck "running" forever
+ * and which the provider rejects next turn). Returns `false` when no trip fired.
+ */
+export async function* emitRequestsAndDetectStuck(
+  ctx: ModeContext,
+  toolUses: ReadonlyArray<CollectedToolUse>,
+  detector: StuckLoopDetector,
+  report: StuckLoopReport,
+): AsyncGenerator<MoxxyEvent, boolean, unknown> {
+  const emitted: CollectedToolUse[] = [];
+  for (const t of toolUses) {
+    yield await ctx.emit({
+      type: 'tool_call_requested',
+      sessionId: ctx.sessionId,
+      turnId: ctx.turnId,
+      source: 'model',
+      callId: asToolCallId(t.id),
+      name: t.name,
+      input: t.input,
+    });
+    emitted.push(t);
+    const sig = detector.record(t.name, t.input);
+    if (!sig.stuck) continue;
+    for (const r of emitted) {
+      yield await ctx.emit({
+        type: 'tool_result',
+        sessionId: ctx.sessionId,
+        turnId: ctx.turnId,
+        source: 'tool',
+        callId: asToolCallId(r.id),
+        ok: false,
+        error: { kind: 'aborted', message: report.abortedResultMessage },
+      });
+    }
+    const how = sig.kind === 'near' ? report.nearHint : 'with identical input';
+    if (report.extraOnStuck) {
+      for (const e of report.extraOnStuck({ toolName: t.name, count: sig.count, kind: sig.kind })) {
+        yield await ctx.emit(e);
+      }
+    }
+    yield await ctx.emit({
+      type: 'error',
+      sessionId: ctx.sessionId,
+      turnId: ctx.turnId,
+      source: 'system',
+      kind: 'fatal',
+      message: report.fatalMessage({ toolName: t.name, count: sig.count, how }),
+    });
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
## The debt (TECH_DEBT P2 #6)

`mode-default` and `mode-goal` each carried their **own copy** of the per-batch tool loop:
- `executeToolUses` — run the batch in order, and on mid-batch abort synthesize a failed `tool_result` for every not-yet-run call + emit `abort` (so the log never ends on an orphan `tool_call_requested`). **Byte-identical** between the two modes.
- `emitRequestsAndDetectStuck` — emit a `tool_call_requested` per call, feed the stuck-loop detector, and on a trip synthesize a paired failed `tool_result` for every emitted call before the fatal error. This is the **load-bearing orphan-result fix** (the "tool spins forever, flips to error on the next message" bug from #51).

A fix to one had to be hand-mirrored to the other — the duplicated comments literally said *"See the same fix in mode-tool-use"* (a mode that no longer exists). That's the exact hazard the [prefer-swappable-blocks](../blob/main/AGENTS.md) guideline targets.

## The change

Both helpers move into `@moxxy/sdk` (`tool-dispatch.ts`, alongside `dispatchToolCall`), exported as `executeToolUses` and `emitRequestsAndDetectStuck`. The only per-mode variation — wording + goal mode's extra `goal_stuck` plugin_event — is passed in via a small `StuckLoopReport` config:

```ts
yield* emitRequestsAndDetectStuck(ctx, toolUses, detector, {
  abortedResultMessage: '…',
  nearHint: '…',
  extraOnStuck: (…) => [ /* goal_stuck plugin_event */ ],   // goal only
  fatalMessage: ({ toolName, count, how }) => '…',
});
```

**Pure refactor — event sequences, ordering, and messages are unchanged.** The outer loop bodies (goal's nudges/token-budget/terminal-detection, default's overflow retry) legitimately differ per strategy and stay where they are; only the shared, dangerous-to-duplicate inner helpers were hoisted.

## Verification
The existing mode suites cover exactly these paths and pass unchanged:
- `mode-default` **9/9** — stuck-trip + **orphan-result pairing** (`results.length === toolCalls.length`), abort mid-stream, maxIterations cap, end_turn-with-tools.
- `mode-goal` **10/10** — stuck-trip orphan pairing **and** the `goal_stuck` plugin_event assertion, goal_completed, goal_stalled, auto-approve.
- `@moxxy/sdk` **124/124** · `pnpm build` **52/52** · `pnpm -r typecheck` clean · `pnpm lint` 0 errors · `pnpm check:deps` clean.

## Changeset
`@moxxy/sdk` minor (two new exported helpers + `StuckLoopReport`). No behavior change.