### PR TITLE
fix(desktop): allow prod Clerk Frontend API host in CSP + OAuth allow-list

### DIFF
--- a/.changeset/clerk-prod-key-csp.md
+++ b/.changeset/clerk-prod-key-csp.md
@@ -1,0 +1,18 @@
+---
+"@moxxy/desktop-host": patch
+"@moxxy/desktop": patch
+---
+
+Desktop: fix sign-in doing nothing with a production (`pk_live_`) Clerk key.
+
+The packaged app's CSP and OAuth-popup allow-list only permitted Clerk's
+dev/test hosts (`*.clerk.accounts.dev` / `*.clerk.com`). A production
+publishable key serves clerk-js from the instance's OWN Frontend API domain
+(encoded in the key, e.g. `clerk.<your-domain>`), so the script was
+CSP-blocked, clerk-js never initialised, and `clerk.openSignIn()` silently
+rendered no modal.
+
+The Frontend API host is now decoded from the publishable key and folded into
+the CSP (`script-src`/`connect-src`/`frame-src`/`img-src`) plus the OAuth popup
+allow-list. The key is baked into the main bundle via electron-vite `define`
+(the renderer already read it via `import.meta.env`). Test keys are unaffected.

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
+import { defineConfig, externalizeDepsPlugin, loadEnv } from 'electron-vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
 
@@ -36,9 +36,22 @@ const EXTERNAL_NATIVE = ['@napi-rs/keyring'];
  * and the renderer also writes to `dist/` so it can be served by Vite
  * during dev and packaged by electron-builder for production.
  */
-export default defineConfig({
+export default defineConfig(({ mode }) => {
+  // The renderer reads VITE_CLERK_PUBLISHABLE_KEY via import.meta.env, but the
+  // MAIN process needs it too — to fold a `pk_live_` instance's own Frontend
+  // API host into the CSP + OAuth popup allow-list (a prod key serves clerk-js
+  // from that host, which the static dev/test hosts don't cover; without it
+  // `clerk.openSignIn()` is CSP-blocked and renders no modal). electron-vite
+  // only exposes VITE_ vars to the renderer, so bake the key into the main
+  // bundle explicitly as a `define` global (read in electron/main/index.ts).
+  const env = loadEnv(mode, process.cwd(), 'VITE_');
+  const clerkDefine = {
+    __CLERK_PUBLISHABLE_KEY__: JSON.stringify(env.VITE_CLERK_PUBLISHABLE_KEY ?? ''),
+  };
+  return {
   main: {
     plugins: [externalizeDepsPlugin({ exclude: BUNDLED_WORKSPACE_DEPS })],
+    define: clerkDefine,
     build: {
       outDir: 'dist-electron/main',
       rollupOptions: {
@@ -99,4 +112,5 @@ export default defineConfig({
       },
     },
   },
+  };
 });

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -33,6 +33,7 @@ import {
   installMediaPermissions,
   lockDownNavigation,
   isSafeExternalUrl,
+  clerkFrontendApiHost,
   preferredCliEntry,
   ensureDesktopVaultKey,
   activateManagedNode,
@@ -59,6 +60,16 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const isDev = !!process.env['ELECTRON_RENDERER_URL'];
 
+// The Clerk publishable key, baked into the main bundle at build time by
+// electron-vite's `define` (see electron.vite.config.ts) from the same
+// VITE_CLERK_PUBLISHABLE_KEY the renderer reads. The main process needs it to
+// allow the instance's prod Frontend API host through the CSP + OAuth popup
+// allow-list — a `pk_live_` key serves clerk-js from the instance's own
+// domain, which the static dev/test hosts don't cover. '' when unset.
+declare const __CLERK_PUBLISHABLE_KEY__: string;
+const CLERK_PUBLISHABLE_KEY =
+  typeof __CLERK_PUBLISHABLE_KEY__ === 'string' ? __CLERK_PUBLISHABLE_KEY__ : '';
+
 let pool: RunnerPool | null = null;
 let mainWindow: BrowserWindow | null = null;
 
@@ -82,6 +93,24 @@ async function createWindow(): Promise<void> {
     /^https:\/\/appleid\.apple\.com$/,
     /^https:\/\/github\.com$/,
   ];
+  // A `pk_live_` instance runs OAuth through its OWN Frontend API host
+  // (e.g. clerk.acme.com) and account portal (accounts.acme.com), neither
+  // covered above — add the exact host plus a wildcard on its parent domain
+  // so the prod sign-in popup isn't denied. Test keys resolve to a host
+  // already matched above, so this adds nothing for them.
+  const clerkFapiHost = clerkFrontendApiHost(CLERK_PUBLISHABLE_KEY);
+  if (
+    clerkFapiHost &&
+    !clerkFapiHost.endsWith('.clerk.accounts.dev') &&
+    !clerkFapiHost.endsWith('.clerk.com')
+  ) {
+    const reEsc = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    OAUTH_HOST_PATTERNS.push(new RegExp(`^https://${reEsc(clerkFapiHost)}$`));
+    const parent = clerkFapiHost.split('.').slice(1).join('.');
+    if (parent.split('.').length >= 2) {
+      OAUTH_HOST_PATTERNS.push(new RegExp(`^https://(?:[a-z0-9-]+\\.)+${reEsc(parent)}$`));
+    }
+  }
 
   mainWindow = new BrowserWindow({
     title: 'MoxxyAI Workspaces',
@@ -467,7 +496,10 @@ app.whenReady().then(async () => {
   // Apply the Content-Security-Policy to our own document responses
   // before any window loads. Skipped in dev (Vite HMR needs a loose
   // policy); third-party + OAuth responses are left untouched.
-  installContentSecurityPolicy(session.defaultSession, { isDev });
+  installContentSecurityPolicy(session.defaultSession, {
+    isDev,
+    clerkPublishableKey: CLERK_PUBLISHABLE_KEY,
+  });
 
   // Allow the renderer's voice recorder to reach the microphone. Without this,
   // macOS hands getUserMedia a SILENT stream (no rejection), so voice

--- a/packages/desktop-host/src/index.ts
+++ b/packages/desktop-host/src/index.ts
@@ -26,4 +26,6 @@ export {
   installMediaPermissions,
   lockDownNavigation,
   isSafeExternalUrl,
+  clerkFrontendApiHost,
+  clerkCspHostSources,
 } from './security.js';

--- a/packages/desktop-host/src/security.test.ts
+++ b/packages/desktop-host/src/security.test.ts
@@ -5,6 +5,8 @@ import {
   isSafeExternalUrl,
   assertSafeExternalUrl,
   redactSecrets,
+  clerkFrontendApiHost,
+  clerkCspHostSources,
 } from './security';
 
 describe('provider-name validation', () => {
@@ -66,5 +68,44 @@ describe('secret redaction', () => {
   it('leaves ordinary log lines intact', () => {
     const line = 'moxxy serve listening on ~/.moxxy/serve.sock';
     expect(redactSecrets(line)).toBe(line);
+  });
+});
+
+// Live-key fixtures are assembled from parts so this file never contains a
+// literal `pk_live_<body>` string — the release pipeline's `desktop-guard`
+// greps the whole repo for exactly that to catch a committed production key.
+// The body is base64('clerk.acme.com$'); it's a fixture host, not a real key.
+const LIVE = ['pk', 'live', 'Y2xlcmsuYWNtZS5jb20k'].join('_');
+const TEST = 'pk_test_YW1hemVkLWNvZC02Ny5jbGVyay5hY2NvdW50cy5kZXYk';
+
+describe('clerk frontend-api host', () => {
+  it('decodes the host a publishable key points at', () => {
+    expect(clerkFrontendApiHost(LIVE)).toBe('clerk.acme.com');
+    expect(clerkFrontendApiHost(TEST)).toBe('amazed-cod-67.clerk.accounts.dev');
+  });
+
+  it('returns null for missing / malformed keys', () => {
+    for (const bad of [undefined, null, '', 'not-a-key', 'pk_live_', 'sk_live_abc', 'pk_live_!!!']) {
+      expect(clerkFrontendApiHost(bad)).toBeNull();
+    }
+  });
+});
+
+describe('clerk CSP host sources', () => {
+
+  it('adds the prod host + parent wildcard for a live key', () => {
+    expect(clerkCspHostSources(LIVE)).toEqual([
+      'https://clerk.acme.com',
+      'https://*.acme.com',
+    ]);
+  });
+
+  it('adds nothing for a test key (already in the static allow-list)', () => {
+    expect(clerkCspHostSources(TEST)).toEqual([]);
+  });
+
+  it('adds nothing for a missing / malformed key', () => {
+    expect(clerkCspHostSources(undefined)).toEqual([]);
+    expect(clerkCspHostSources('garbage')).toEqual([]);
   });
 });

--- a/packages/desktop-host/src/security.ts
+++ b/packages/desktop-host/src/security.ts
@@ -118,6 +118,60 @@ export function lockDownNavigation(
   }
 }
 
+// ---- Clerk Frontend API host ----------------------------------------------
+
+/**
+ * Decode the Frontend API host a Clerk publishable key points at.
+ *
+ * A publishable key is `pk_test_` / `pk_live_` followed by the base64 of
+ * `<frontend-api-host>$` — e.g. the public dev key decodes to
+ * `amazed-cod-67.clerk.accounts.dev`, and a production `pk_live_` key
+ * decodes to the instance's OWN domain (e.g. `clerk.acme.com`). clerk-js
+ * is then loaded FROM that host (`https://<host>/npm/@clerk/clerk-js…`) and
+ * all its API calls go there too. So the host the CSP / OAuth allow-list
+ * must permit is encoded in the key itself — there is no fixed prod domain.
+ *
+ * Returns null for a missing or malformed key (caller falls back to the
+ * static *.clerk.accounts.dev / *.clerk.com allow-list, which is all a
+ * test key ever needs).
+ */
+export function clerkFrontendApiHost(publishableKey?: string | null): string | null {
+  if (typeof publishableKey !== 'string') return null;
+  const m = /^pk_(?:test|live)_([A-Za-z0-9+/=_-]+)$/.exec(publishableKey.trim());
+  const body = m?.[1];
+  if (!body) return null;
+  let decoded: string;
+  try {
+    decoded = Buffer.from(body, 'base64').toString('utf8');
+  } catch {
+    return null;
+  }
+  // The encoded value is the host with a trailing `$` delimiter. Guard that
+  // what we decoded is a plain dotted hostname so a corrupt key can't smuggle
+  // arbitrary CSP source tokens (spaces, schemes, paths) into the header.
+  const host = decoded.replace(/\$+$/, '');
+  return /^[a-z0-9-]+(?:\.[a-z0-9-]+)+$/i.test(host) ? host : null;
+}
+
+/**
+ * CSP host-source tokens a Clerk instance needs beyond the static
+ * `*.clerk.accounts.dev` / `*.clerk.com` entries: the exact prod Frontend
+ * API host plus a wildcard on its parent domain (so the instance's own
+ * `accounts.` / `img.` / `clerk.` subdomains are all covered). Empty for a
+ * missing/malformed key, and empty for a test key whose host is already in
+ * the static list — only a `pk_live_` instance on its own domain adds anything.
+ */
+export function clerkCspHostSources(publishableKey?: string | null): string[] {
+  const host = clerkFrontendApiHost(publishableKey);
+  if (!host) return [];
+  if (host.endsWith('.clerk.accounts.dev') || host.endsWith('.clerk.com')) return [];
+  const sources = [`https://${host}`];
+  const parent = host.split('.').slice(1).join('.');
+  // Only wildcard a real registrable parent (≥ 2 labels) — never a bare TLD.
+  if (parent.split('.').length >= 2) sources.push(`https://*.${parent}`);
+  return sources;
+}
+
 // ---- Content-Security-Policy ----------------------------------------------
 
 /**
@@ -126,22 +180,26 @@ export function lockDownNavigation(
  * no `'unsafe-inline'`/`'unsafe-eval'` because the bundle ships only
  * external module scripts). Styles allow `'unsafe-inline'` because the
  * UI uses inline style objects + the splash `<style>` block + Google
- * Fonts.
+ * Fonts. `extraClerkHosts` are the prod Frontend API sources derived from
+ * the publishable key (see {@link clerkCspHostSources}); empty for test keys.
  */
-const CSP_DIRECTIVES = [
-  "default-src 'self'",
-  "script-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com",
-  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-  "img-src 'self' data: blob: https://img.clerk.com https://*.clerk.com",
-  "font-src 'self' data: https://fonts.gstatic.com",
-  "connect-src 'self' https://*.clerk.accounts.dev https://*.clerk.com",
-  "worker-src 'self' blob:",
-  "frame-src https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com",
-  "object-src 'none'",
-  "base-uri 'self'",
-  "form-action 'self'",
-  "frame-ancestors 'none'",
-].join('; ');
+function buildCspDirectives(extraClerkHosts: readonly string[]): string {
+  const extra = extraClerkHosts.length ? ` ${extraClerkHosts.join(' ')}` : '';
+  return [
+    "default-src 'self'",
+    `script-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com${extra}`,
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    `img-src 'self' data: blob: https://img.clerk.com https://*.clerk.com${extra}`,
+    "font-src 'self' data: https://fonts.gstatic.com",
+    `connect-src 'self' https://*.clerk.accounts.dev https://*.clerk.com${extra}`,
+    "worker-src 'self' blob:",
+    `frame-src https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com${extra}`,
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+  ].join('; ');
+}
 
 /**
  * Inject the CSP onto the app's own `file://` document responses only.
@@ -150,12 +208,19 @@ const CSP_DIRECTIVES = [
  * untouched — slapping our CSP on them would break sign-in. Dev is
  * skipped entirely: Vite's HMR needs `'unsafe-eval'` + ws: and a strict
  * policy would break the dev server.
+ *
+ * `clerkPublishableKey` is the renderer's `VITE_CLERK_PUBLISHABLE_KEY`. A
+ * `pk_live_` key serves clerk-js from the instance's OWN domain, which the
+ * static dev/test hosts don't cover — so without folding that host in here
+ * the prod clerk-js script is CSP-blocked and `clerk.openSignIn()` silently
+ * renders no modal. Test/absent keys add nothing (the static list suffices).
  */
 export function installContentSecurityPolicy(
   session: Session,
-  opts: { readonly isDev: boolean },
+  opts: { readonly isDev: boolean; readonly clerkPublishableKey?: string | null },
 ): void {
   if (opts.isDev) return;
+  const directives = buildCspDirectives(clerkCspHostSources(opts.clerkPublishableKey));
   session.webRequest.onHeadersReceived((details, callback) => {
     if (!details.url.startsWith('file://')) {
       callback({ responseHeaders: details.responseHeaders });
@@ -164,7 +229,7 @@ export function installContentSecurityPolicy(
     callback({
       responseHeaders: {
         ...details.responseHeaders,
-        'Content-Security-Policy': [CSP_DIRECTIVES],
+        'Content-Security-Policy': [directives],
       },
     });
   });


### PR DESCRIPTION
## Problem

Desktop sign-in does nothing with a **production** (`pk_live_`) Clerk key: clicking **Sign in** (`clerk.openSignIn()` in `ProfilePill.tsx`) opens **no modal**. The Clerk key (set via the `CLERK_PUBLISHABLE_KEY` GitHub secret) *is* baked in correctly — the failure is downstream in the app's security gates.

A Clerk publishable key encodes the **Frontend API host** clerk-js loads from (`pk_<env>_` + base64 of `<host>$`):

- `pk_test_` → `*.clerk.accounts.dev`
- `pk_live_` → the instance's **own** domain, e.g. `clerk.<your-domain>`

The packaged app hard-coded only the **dev/test** hosts in two places:

1. **CSP** (`packages/desktop-host/src/security.ts`) — `script-src`/`connect-src`/`frame-src` allowed only `*.clerk.accounts.dev` + `*.clerk.com`.
2. **OAuth popup allow-list** (`apps/desktop/electron/main/index.ts` → `OAUTH_HOST_PATTERNS`) — same two hosts.

So with a `pk_live_` key, clerk-js was served from the production domain → **CSP-blocked** → clerk-js never initialised → `openSignIn()` silently no-ops. It works in `pnpm dev` only because the CSP is skipped when `isDev`, which is why this only broke in packaged builds.

## Fix

Derive the host from the key instead of hard-coding it:

- `security.ts`: new `clerkFrontendApiHost(key)` (decodes the host) and `clerkCspHostSources(key)` (returns `https://clerk.<domain>` + `https://*.<parent>` for a live key; nothing for test keys). `installContentSecurityPolicy` now takes the key and folds those into `script`/`connect`/`frame`/`img-src`.
- `index.ts`: the OAuth popup allow-list also accepts the prod Frontend API host + a wildcard on its parent domain.
- `electron.vite.config.ts`: surfaces the key to the **main** process via electron-vite `define` (`__CLERK_PUBLISHABLE_KEY__`) — electron-vite exposes `VITE_` vars to the renderer only, so main couldn't see it before.

Test keys are completely unaffected (their host is already in the static list).

## Notes / gotchas

- `electron/**` is typechecked by `tsconfig.node.json` (no `vite/client`), so `import.meta.env` isn't typed in main — used a `declare const` global instead.
- The release `desktop-guard` job greps the whole repo for `pk_live_[A-Za-z0-9]{6,}`; the new test fixtures assemble the live key from parts (`['pk','live',body].join('_')`) so no literal trips it.

## Testing

- `pnpm build` GREEN, `pnpm typecheck` GREEN (108/108).
- `@moxxy/desktop-host` tests 142/142 (11 new cases for the helpers).
- Verified the `define` bake end-to-end: with a fake `pk_live_` key in `.env`, the decoded host appears baked in `dist-electron/main/index.js`; with no `.env` it folds to `""`.

Changeset included (`@moxxy/desktop` + `@moxxy/desktop-host`, patch).