### PR TITLE
feat(update): moxxy update CLI, TUI version banner, observable desktop self-update

### DIFF
--- a/.changeset/update-flows.md
+++ b/.changeset/update-flows.md
@@ -1,0 +1,24 @@
+---
+"@moxxy/cli": minor
+"@moxxy/plugin-cli": minor
+"@moxxy/desktop-ipc-contract": minor
+"@moxxy/desktop-host": minor
+"@moxxy/desktop": patch
+---
+
+Update flows: a real `moxxy update`, a TUI "new version" nudge, and observable desktop self-update.
+
+- **CLI** — new `moxxy update` command: checks the npm registry, detects how the
+  CLI was installed (npm/pnpm/yarn/bun, global or local), and runs the matching
+  upgrade after a confirm. `--check`/`--dry-run` report-only, `--yes` to skip the
+  prompt. Source checkouts get git advice instead of an install.
+- **TUI** — surfaces a newer published `@moxxy/cli` as a one-line, auto-dismissing
+  banner and shows the running version in the status line. The check is cached
+  (~12h) and fully non-blocking on startup. (Also fixes the `version` prop being
+  dropped before it reached the view.)
+- **Desktop self-update** — the previously-silent fall-back-to-the-floor is now
+  observable: a persistent boot-decision log under `<userData>/app/boot-log.json`,
+  a reason for every gate that rejects a staged bundle, and a Settings → Dashboard
+  → Diagnostics readout. The renderer's boot confirmation is hardened (retry +
+  reported failure) so a flaky heartbeat can't make the boot-probe revert a
+  healthy update. Adds the `app.updateDiagnostics` / `app.bootHeartbeatFailed` IPC.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://moxxy.ai">
-    <img src="https://moxxy.ai/moxxy-head-256.png" alt="moxxy" width="128" />
+    <img src="https://moxxy.ai/moxxy-head-256.png" alt="moxxy" width="120" />
   </a>
 </p>
 
@@ -8,12 +8,12 @@
 
 <p align="center">
   <strong>The agent framework where every block is swappable.</strong><br/>
-  Bring your own model. Bring your own loop. Bring your own tools.
+  Bring your own model. Bring your own loop. Bring your own tools — and run it from your terminal, your desktop, or a phone.
 </p>
 
 <p align="center">
-  <a href="https://github.com/moxxy-ai/new_moxxy/actions/workflows/ci.yml">
-    <img src="https://github.com/moxxy-ai/new_moxxy/actions/workflows/ci.yml/badge.svg" alt="CI" />
+  <a href="https://github.com/moxxy-ai/moxxy/actions/workflows/ci.yml">
+    <img src="https://github.com/moxxy-ai/moxxy/actions/workflows/ci.yml/badge.svg" alt="CI" />
   </a>
   <a href="https://nodejs.org">
     <img src="https://img.shields.io/badge/node-%3E%3D20.10-brightgreen?logo=node.js&logoColor=white" alt="Node ≥20.10" />
@@ -27,22 +27,60 @@
   <a href="#-license">
     <img src="https://img.shields.io/badge/license-TBD-lightgrey" alt="License" />
   </a>
-  <a href="#-contributing">
-    <img src="https://img.shields.io/badge/PRs-welcome-brightgreen" alt="PRs welcome" />
-  </a>
 </p>
 
 <p align="center">
-  <a href="#-installation">Install</a>
+  <a href="#-get-started">Get started</a>
   &nbsp;·&nbsp;
-  <a href="#-quickstart">Quickstart</a>
+  <a href="#-why-moxxy">Why moxxy</a>
   &nbsp;·&nbsp;
-  <a href="https://moxxy.ai">Docs</a>
+  <a href="#-see-it-in-action">See it</a>
+  &nbsp;·&nbsp;
+  <a href="https://docs.moxxy.ai">Docs</a>
   &nbsp;·&nbsp;
   <a href="#-channels">Channels</a>
   &nbsp;·&nbsp;
   <a href="#-developer-guide">Developer guide</a>
 </p>
+
+<!--
+  HERO DEMO  ▸ replace the placehold.co src below with a real GIF/MP4.
+  WHAT TO SHOW: a ~20–30s loop — `moxxy init` → ask a question in the TUI →
+  the agent runs a tool (e.g. edits a file / runs a command) → streams the answer.
+  Suggested size: 1280×640. Drop the file at assets/hero-demo.gif and point src there.
+-->
+<p align="center">
+  <a href="#-see-it-in-action">
+    <img src="https://placehold.co/1280x640/0d1117/58a6ff.png?text=moxxy+%E2%80%94+30-second+demo" alt="moxxy demo" width="760" />
+  </a>
+</p>
+
+---
+
+## 🚀 Get started
+
+```sh
+npm install -g @moxxy/cli      # or: npx @moxxy/cli init
+```
+
+```sh
+moxxy init      # interactive: choose a provider, paste an API key (stored in the vault)
+moxxy           # launch the interactive TUI
+```
+
+One-shot, straight from the shell:
+
+```sh
+moxxy -p "summarize the README in three bullets"
+```
+
+Already running? Keep it current:
+
+```sh
+moxxy update    # checks npm and upgrades in place (the TUI also nudges you when a new version ships)
+```
+
+**Requirements:** Node.js ≥ 20.10 and an API key for a supported provider (Anthropic, OpenAI, or ChatGPT/Claude via OAuth). `moxxy --help` lists every command.
 
 ---
 
@@ -50,56 +88,66 @@
 
 Most agent frameworks lock you in. One LLM provider. One loop topology. One frontend. One opinionated way the agent should behave.
 
-**moxxy doesn't.** Every block is a plugin. Swap Anthropic for OpenAI. Swap the default loop for the `goal` (auto-approve) or `research` mode. Drive the agent from your terminal, from Telegram, from an HTTP endpoint, or all three at once on the same Session.
+**moxxy doesn't.** Every block is a plugin. Swap Anthropic for OpenAI. Swap the default loop for `goal` (autonomous, auto-approve) or `research` (parallel fan-out + cited synthesis). Drive the same Session from your terminal, the desktop app, Telegram, or an HTTP endpoint — at the same time. Install a package and it's auto-discovered; nothing to wire by hand.
+
+<p align="center">
+  <img src="assets/moxxy-mascot.gif" alt="moxxy mascot" width="150" />
+</p>
 
 |   |   |
 |---|---|
 | 🧩 **Truly modular** | Every block is a swappable plugin: provider, loop strategy, tools, compactor, cache strategy, channel. |
 | 🔌 **Plug-and-play** | Install a package, it's auto-discovered. Hot-reload without restarting. |
-| 🤖 **Multi-channel** | TUI, Telegram, HTTP. One Session, many surfaces. |
-| 🎙 **Voice in** | Send Telegram voice notes or POST raw audio to the HTTP channel. Whisper plugin ships with the framework; swap to Deepgram or local whisper.cpp by registering a different `Transcriber`. |
+| 🤖 **Multi-channel** | TUI, desktop app, Telegram, HTTP. One Session, many surfaces. |
+| 🎙 **Voice in** | Telegram voice notes or POST raw audio to the HTTP channel. Whisper ships built-in; swap to Deepgram or local whisper.cpp by registering a different `Transcriber`. |
 | 🔐 **Secrets done right** | Built-in AES-256-GCM vault. OS keychain by default, passphrase fallback. |
 | 🧠 **Long-term memory** | Journal-based with vector recall. TF-IDF ships built-in; swap to OpenAI embeddings. |
 | 🛠 **Type-safe SDK** | Zero-runtime-dep `@moxxy/sdk` is the contract. Author plugins with full IDE support. |
-| ⏰ **Always-on** | `moxxy service install` turns any channel into a launchd / systemd background service, or `moxxy serve --background` runs everything in one shared-session process. |
-| 🔔 **Webhooks** | Any external system can fire prompts: verified (HMAC / bearer), filtered (header + JSON-path include/exclude), idempotent. Auto-tunneled with `cloudflared` for a one-command public URL. |
+| ⏰ **Always-on** | `moxxy service install` turns any channel into a launchd / systemd service, or `moxxy serve --background` runs everything in one shared-session process. |
+| 🔔 **Webhooks** | Any system can fire prompts: verified (HMAC / bearer), filtered, idempotent. Auto-tunneled with `cloudflared` for a one-command public URL. |
 | 🪪 **Permissions** | Every tool call gated. Allow-always rules learned per tool over time. |
-| 🛡 **Pluggable isolation** | Opt-in capability sandboxing. Tools declare what they need (fs paths, hosts, time / memory); an `Isolator` enforces. `inproc` ships built-in; `worker` / `subprocess` / `wasm` / `docker` drop in behind the same interface. Off by default. |
+| 🛡 **Pluggable isolation** | Opt-in capability sandboxing. Tools declare what they need (fs paths, hosts, time / memory); an `Isolator` enforces. `inproc` built-in; `worker` / `subprocess` / `wasm` / `docker` drop in behind the same interface. Off by default. |
 
-## 🚀 Installation
+---
 
-```sh
-npm install -g @moxxy/cli
-```
+## 🎬 See it in action
 
-Or run it without installing:
+<table>
+<tr>
+<td width="50%" valign="top">
 
-```sh
-npx @moxxy/cli init
-```
+**In your terminal**
 
-**Requirements**: Node.js ≥ 20.10. An API key for a supported provider (Anthropic, OpenAI, or ChatGPT via OAuth).
+<!--
+  TUI DEMO  ▸ replace src with a real GIF.
+  WHAT TO SHOW: the Ink TUI — boot splash → type a prompt → streamed answer
+  with a tool block expanding → the bottom status line (provider · model · context bar).
+  Suggested size: 1200×675. Drop at assets/tui-demo.gif and point src there.
+-->
+<img src="https://placehold.co/1200x675/0d1117/c9d1d9.png?text=moxxy+TUI+demo" alt="moxxy TUI" />
 
-## ⚡ Quickstart
+`moxxy` — a fast, keyboard-driven terminal UI. Slash commands, live tool output, voice input, `/mode` to switch loops.
 
-```sh
-moxxy init      # interactive: choose provider, paste API key (goes into the vault)
-moxxy           # launch the interactive TUI
-```
+</td>
+<td width="50%" valign="top">
 
-One-shot from the command line:
+**On your desktop**
 
-```sh
-moxxy -p "summarize the README in three bullets"
-```
+<!--
+  DESKTOP DEMO  ▸ replace src with a real GIF.
+  WHAT TO SHOW: the Electron app — multiple workspaces in the sidebar, a chat
+  turn streaming, maybe the Settings → Dashboard "update" panel.
+  Suggested size: 1200×675. Drop at assets/desktop-demo.gif and point src there.
+-->
+<img src="https://placehold.co/1200x675/0d1117/c9d1d9.png?text=moxxy+Desktop+demo" alt="moxxy Desktop" />
 
-Resume a previous conversation:
+A native workspace app (Electron) that attaches to the same runner — multiple workspaces, hot self-updates, no reinstall.
 
-```sh
-moxxy resume
-```
+</td>
+</tr>
+</table>
 
-That's it. `moxxy --help` lists every command; `moxxy <command> --help` shows per-command details.
+---
 
 ## 📺 Channels
 
@@ -107,8 +155,9 @@ Run your agent through whatever surface fits the task:
 
 | Channel | What it does | Command |
 |---|---|---|
-| **TUI** | Grok-style interactive terminal UI | `moxxy` |
-| **Telegram** | Message your agent from anywhere; voice notes get transcribed and run as turns; pairs with a 6-digit code | `moxxy telegram` |
+| **TUI** | Interactive terminal UI | `moxxy` |
+| **Desktop** | Native multi-workspace app (Electron) | [download](https://moxxy.ai) |
+| **Telegram** | Message your agent from anywhere; voice notes transcribed and run as turns; pairs with a 6-digit code | `moxxy telegram` |
 | **HTTP** | `POST /v1/turn` (JSON, SSE streaming) or `POST /v1/turn/audio` (raw bytes, iOS Shortcut friendly), bearer-token auth | `moxxy channels http` |
 | **Cron** | Time-driven prompts (cron expressions or one-shot ISO timestamps) | `moxxy schedule add …` |
 | **Webhooks** | External systems fire prompts on signed POST. HMAC + bearer + filter rules. | `moxxy serve` (auto-starts the listener) |
@@ -130,17 +179,17 @@ Logs land in `~/.moxxy/services/<name>.log`; units survive reboots.
 
 ## 🧩 What's in the box
 
-- **Providers**: Anthropic, OpenAI, Codex (ChatGPT OAuth). Add your own with one `defineProvider({})`.
+- **Providers**: Anthropic, OpenAI, Codex (ChatGPT OAuth), Claude (Pro/Max OAuth). Add your own with one `defineProvider({})`.
 - **Loop strategies**: `default` (Claude-Code-style ReAct loop), `goal` (autonomous auto-approve loop — runs across turns until `goal_complete`), `research` (plan queries → parallel subagent fan-out → cited synthesis). Switch in the TUI with `/mode`.
 - **Built-in tools**: Read, Edit, Write, Bash, Grep, Glob, WebFetch, plus computer-control (macOS) and browser-session (Playwright).
-- **Prompt caching**: `@moxxy/cache-strategy-stable-prefix` places deterministic cache breakpoints (static tools/system/stable-prefix + a rolling tail) so the inner iterations of a turn read the prompt from cache instead of paying full price. A `CacheStrategy` is provider-neutral (Anthropic `cache_control` today); swap it or disable caching with the `none` strategy. Inspect savings live with `/usage`.
+- **Prompt caching**: `@moxxy/cache-strategy-stable-prefix` places deterministic cache breakpoints (static tools/system/stable-prefix + a rolling tail) so the inner iterations of a turn read the prompt from cache instead of paying full price. Provider-neutral; swap it or disable with the `none` strategy. Inspect savings live with `/usage`.
 - **MCP**: register any Model Context Protocol server as a tool source.
 - **Skills**: prompt-only Markdown files. The agent can author new skills for itself when no existing skill fits.
 - **Memory**: long-term journal + STM event-log selectors. TF-IDF vector recall built in; swap to OpenAI embeddings via `@moxxy/plugin-embeddings-openai`.
-- **Webhooks**: `@moxxy/plugin-webhooks` ships a verified HTTP listener, include/exclude filters (headers + JSON paths), delivery idempotency, and a `cloudflared`/`ngrok` tunnel helper. Vendor-neutral — the agent walks the user through provider specifics conversationally.
-- **Voice in (STT)**: `@moxxy/plugin-stt-whisper` ships an OpenAI Whisper `Transcriber`. Wire it once and every channel with audio input (Telegram voice notes, HTTP `/v1/turn/audio`) routes through it. Swap to Deepgram, AssemblyAI, or a local `whisper.cpp` by registering a different `Transcriber`.
+- **Webhooks**: `@moxxy/plugin-webhooks` ships a verified HTTP listener, include/exclude filters (headers + JSON paths), delivery idempotency, and a `cloudflared`/`ngrok` tunnel helper.
+- **Voice in (STT)**: `@moxxy/plugin-stt-whisper` ships an OpenAI Whisper `Transcriber`. Wire it once and every channel with audio input routes through it. Swap to Deepgram, AssemblyAI, or local `whisper.cpp` by registering a different `Transcriber`.
 - **Vault**: AES-256-GCM at rest. Reference secrets in config as `${vault:KEY}`.
-- **Security / isolation**: `@moxxy/plugin-security` — opt-in capability sandboxing. Tools declare an `isolation: { capabilities }` spec on `defineTool({...})` (fs path globs, net host allowlist, env keys, `timeMs`, `memMb`); when enabled, an `Isolator` enforces those bounds at every call. Ships `none` (passthrough) and `inproc` (in-process caps + timeout) isolators; stronger modes (`worker_threads`, subprocess, wasm, Docker, …) register through the same SDK interface. Off by default — enable via `moxxy init` or `security.enabled: true`. Inspect with `moxxy security audit|status|isolators`.
+- **Security / isolation**: `@moxxy/plugin-security` — opt-in capability sandboxing. Tools declare an `isolation: { capabilities }` spec on `defineTool({...})` (fs path globs, net host allowlist, env keys, `timeMs`, `memMb`); when enabled, an `Isolator` enforces those bounds at every call. Ships `none` + `inproc`; stronger modes (`worker_threads`, subprocess, wasm, Docker) register through the same SDK interface. Off by default — enable via `moxxy init` or `security.enabled: true`.
 
 ## 📚 Docs
 
@@ -270,7 +319,7 @@ export default defineConfig({
 apps/desktop                        ← Electron desktop app (attaches to @moxxy/runner)
 @moxxy/desktop-ipc-contract         ← typed desktop IPC boundary (channels + payloads + Zod validation + error envelope)
 @moxxy/desktop-host                 ← desktop Electron main process (runner pool/supervisor, IPC, NDJSON chat log, security)
-@moxxy/desktop-ui                    ← framework-light React UI primitives (Icon set, Modal, Skeleton); shared by the renderer
+@moxxy/desktop-ui                   ← framework-light React UI primitives (Icon set, Modal, Skeleton); shared by the renderer
 ```
 
 The hard invariant: `@moxxy/sdk` has zero internal deps; `@moxxy/core` doesn't import any plugin. Enforced in CI via `pnpm check:deps`.
@@ -279,7 +328,8 @@ The hard invariant: `@moxxy/sdk` has zero internal deps; `@moxxy/core` doesn't i
 
 ```
 packages/        publishable @moxxy/* packages
-apps/            runnable examples (example-basic, example-cli, fixture-recorder, docs)
+apps/            desktop app, docs site, fixture-recorder
+assets/          README media (mascot + demo gifs)
 tooling/         shared tsconfig + eslint + vitest preset
 .claude/agents/  AI-agent author guides (skill, plugin, tool, channel, provider, compactor, cache strategy, …)
 AGENTS.md        index for AI agents working in this repo

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -11,7 +11,13 @@ you introduce or notice gets written down the moment you see it. See AGENTS.md �
 (merged, PR #6). What remains below is what was deliberately deferred, what was blocked
 as unsafe to do mechanically, and debt accrued since.
 
-**Last refreshed:** 2026-06-08 — re-verified every open item against `HEAD` and folded
+**Last refreshed:** 2026-06-09 — the "update flows" work (CLI `moxxy update` + TUI version
+banner + desktop self-update observability) **retired the self-update typed-error sub-bullet
+of P1 #5** (re-scoped as won't-fix-by-design — see it) and closed the long-standing
+*silent* desktop fall-back-to-the-floor by adding a persisted boot-decision log; the one
+remaining piece (confirming the runtime root cause on a packaged build) is logged as #10.
+
+2026-06-08 — re-verified every open item against `HEAD` and folded
 in findings from the desktop-resume / claude-code-provider / plugins-admin work that
 landed after the original audit. All prior "✅ DONE" items were re-checked and confirmed
 still in place (no regressions); they're collapsed into the ledger at the bottom. The same
@@ -92,8 +98,13 @@ raw throws are internal registry/broker invariants that should stay plain):
 - oauth input/usage validation — `plugin-oauth/src/tools.ts:114,146`.
 - vault config-resolution throws (user-facing) — `plugin-vault/src/placeholder.ts:20`,
   `index.ts:150`, `store.ts:164,186`.
-- desktop self-update **security** failures (signature/hash/unsafe-path) throw raw Error —
-  `desktop-host/src/app-update/stager.ts:258-302`; candidates for a typed error code.
+- ~~desktop self-update **security** failures (signature/hash/unsafe-path) throw raw Error —
+  `desktop-host/src/app-update/stager.ts`; candidates for a typed error code.~~ **RETIRED
+  2026-06-09 (won't-fix by design).** `app-update/*` is intentionally dependency-free (node
+  built-ins only) so it can be baked verbatim into the immutable bootstrap — importing the
+  SDK error types there would break that constraint. The throw *messages* are already
+  surfaced to the renderer as `error` strings, and the new boot-log now records a structured
+  reject **reason** per gate (see #10), which covers the diagnosability this bullet was after.
 
 ### 6. Mode loop scaffolding is copy-pasted across mode-default and mode-goal — 🔴 NEW
 **Found 2026-06-08.** The mode-slimming PR (#93) collapsed the mode list but left the
@@ -138,6 +149,21 @@ To fully sever channel→core, hoist these provider-neutral helpers into `@moxxy
   hardcodes the model list (incl. `claude-opus-4-7` at 800k context) and re-exports it to
   `plugin-provider-claude-code/src/index.ts:11`, so the subscription provider inherits the
   API-key provider's model set verbatim. Drift-prone; should be derived/config.
+
+### 10. Desktop self-update: confirm the runtime root cause of "downloads but reverts" — 🔴 NEW
+**Found 2026-06-09.** The publishing side is provably healthy (latest `desktop-v*` is signed
++ verifies against the baked key; the pure resolve/stage/build path is test-covered). The
+user-reported failure — *updates, relaunches, still old* — therefore lives in the runtime
+confirmation path, which used to fall back to the floor **silently** (`console.*` only, in a
+packaged app no one sees). This pass made it observable: a persisted boot-decision log
+(`app-update/boot-log.ts` → `<userData>/app/boot-log.json`), a reject **reason** per gate
+(`resolveActiveBundleDetailed`), an `app.updateDiagnostics` IPC + Settings → Dashboard
+readout, and a hardened renderer heartbeat (retry + `app.bootHeartbeatFailed`). **Remaining:**
+confirm the actual cause on a real packaged two-version update via the new Diagnostics panel
+(suspects, in order: heartbeat never confirmed → 15s boot-probe revert; staged-main import
+throw; a resolve gate). Once the log names it on a real build, apply the targeted fix and
+prune whichever of the belt/braces (cross-launch recovery vs. in-session probe vs. heartbeat
+retry) is then redundant. **Severity med** (can't be closed from the dev box — needs a build).
 
 ---
 

--- a/apps/desktop/electron/main/bootstrap.ts
+++ b/apps/desktop/electron/main/bootstrap.ts
@@ -25,10 +25,11 @@ import { app } from 'electron';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import {
-  resolveActiveBundle,
+  resolveActiveBundleDetailed,
   recoverFromFailedBoot,
   writeBreadcrumb,
   markBad,
+  appendBootLog,
   setupNativeResolution,
 } from '@moxxy/desktop-host/app-update';
 
@@ -57,18 +58,22 @@ async function load(entry: string): Promise<void> {
   await import(pathToFileURL(entry).href);
 }
 
+/** Shell identity stamped onto every boot-log entry, for cross-launch context. */
+const shell = { electron: process.versions.electron, nodeAbi: process.versions.modules ?? '' };
+
 async function boot(): Promise<void> {
   // Let a userData bundle resolve the shell's optional native deps (keychain).
   setupNativeResolution(floorRoot);
 
   let entry = floorEntry;
   let overrideVersion: string | null = null;
+  let userData: string | null = null;
 
   // Self-update is packaged-only; in dev the renderer is served from Vite and
   // there is no userData bundle to prefer.
   if (app.isPackaged) {
     try {
-      const userData = app.getPath('userData');
+      userData = app.getPath('userData');
       // Poison a bundle that loaded last launch but never confirmed healthy
       // (white-screen / async crash), rolling `active` back to the last good one.
       const recovery = recoverFromFailedBoot(userData);
@@ -77,13 +82,23 @@ async function boot(): Promise<void> {
           `[moxxy] bootstrap: bundle ${recovery.poisoned} never confirmed healthy; poisoned` +
             (recovery.rolledBackTo ? `, rolled back to ${recovery.rolledBackTo}` : ', using floor'),
         );
+        appendBootLog(userData, {
+          phase: 'recover',
+          picked: recovery.poisoned,
+          reason: 'unconfirmed-previous-boot',
+          ...(recovery.rolledBackTo ? { recoveredTo: recovery.rolledBackTo } : {}),
+          ...shell,
+        });
       }
-      const picked = resolveActiveBundle({
+      // Detailed resolve so a fall-to-floor records WHY (the reject reason) —
+      // turning a previously-silent revert into a copy-pasteable diagnostic.
+      const resolved = resolveActiveBundleDetailed({
         userDataDir: userData,
         publicKeyPem: BUNDLED_UPDATE_PUBLIC_KEY,
-        shell: { electron: process.versions.electron, nodeAbi: process.versions.modules ?? '' },
+        shell,
       });
-      if (picked) {
+      if (resolved.bundle) {
+        const picked = resolved.bundle;
         entry = path.join(picked.root, 'dist-electron', 'main', 'index.js');
         overrideVersion = picked.version;
         // Tell the running main which bundle it is — drives `app.updateInfo` and
@@ -94,11 +109,19 @@ async function boot(): Promise<void> {
         // confirm itself healthy, the next launch sees an unconfirmed attempt
         // and poisons it.
         writeBreadcrumb(userData, picked.version);
+        appendBootLog(userData, { phase: 'boot', picked: picked.version, ...shell });
+      } else {
+        // `disabled`/`no-active` are the normal "nothing staged" cases; anything
+        // else is a staged bundle we declined — exactly what we want visible.
+        appendBootLog(userData, { phase: 'boot', picked: 'floor', reason: resolved.reason, ...shell });
       }
-    } catch {
+    } catch (err) {
       // Any resolution failure → run the floor.
       entry = floorEntry;
       overrideVersion = null;
+      if (userData) {
+        appendBootLog(userData, { phase: 'boot', picked: 'floor', reason: 'resolve-threw', error: messageOf(err), ...shell });
+      }
     }
   }
 
@@ -113,6 +136,11 @@ async function boot(): Promise<void> {
       } catch {
         /* best effort */
       }
+      // Record the ACTUAL import error (previously console-only, so invisible in
+      // a packaged build) — this is the prime suspect for "updates but reverts".
+      if (userData) {
+        appendBootLog(userData, { phase: 'load-error', picked: overrideVersion, error: messageOf(err), ...shell });
+      }
       delete process.env.MOXXY_APP_BUNDLE_ROOT;
       delete process.env.MOXXY_APP_BUNDLE_VERSION;
       console.error(
@@ -124,6 +152,10 @@ async function boot(): Promise<void> {
       throw err;
     }
   }
+}
+
+function messageOf(e: unknown): string {
+  return e instanceof Error ? `${e.message}` : String(e);
 }
 
 void boot().catch((err) => {

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -39,7 +39,7 @@ import {
 } from '@moxxy/desktop-host';
 
 import { BUNDLED_UPDATE_PUBLIC_KEY } from './update-key.js';
-import { readConfirmed, markBad } from '@moxxy/desktop-host/app-update';
+import { readConfirmed, markBad, appendBootLog } from '@moxxy/desktop-host/app-update';
 import { initShellUpdater } from './shell-updater.js';
 
 // In a packaged build there is no global `moxxy` (and a GUI launch has no
@@ -444,6 +444,7 @@ function armBootProbe(window: BrowserWindow): void {
   const version = process.env.MOXXY_APP_BUNDLE_VERSION;
   if (!version) return; // running the floor — nothing to probe
   const userData = app.getPath('userData');
+  const shell = { electron: process.versions.electron, nodeAbi: process.versions.modules ?? '' };
   window.webContents.once('did-finish-load', () => {
     setTimeout(() => {
       if (window.isDestroyed()) return;
@@ -452,6 +453,14 @@ function armBootProbe(window: BrowserWindow): void {
         `[moxxy] boot-probe: bundle ${version} did not confirm a healthy render in ` +
           `${BOOT_PROBE_TIMEOUT_MS}ms; reverting to the previous bundle`,
       );
+      // Record the revert BEFORE relaunching so the next launch's Diagnostics
+      // panel shows why the update didn't stick (the renderer never confirmed).
+      appendBootLog(userData, {
+        phase: 'probe',
+        picked: version,
+        reason: 'no-confirm-within-timeout',
+        ...shell,
+      });
       try {
         markBad(userData, version);
       } catch {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -56,9 +56,35 @@ export function App(): JSX.Element {
   }, [activeWorkspaceId]);
 
   // Boot-probe heartbeat: the React tree mounted, so a hot-updated bundle is
-  // healthy — tell main to confirm it (no-op on the bundled floor). Fired once.
+  // healthy — tell main to confirm it (no-op on the bundled floor). A SINGLE
+  // swallowed invoke here was the prime suspect for "updates but reverts to the
+  // old version": if this confirm never lands (e.g. it races IPC registration),
+  // the 15s boot-probe poisons a perfectly healthy bundle and relaunches onto
+  // the floor. So retry with backoff, and if every attempt fails, report it so
+  // the failure is recorded in the boot-log rather than masquerading as a revert.
   useEffect(() => {
-    void api().invoke('app.appBooted').catch(() => undefined);
+    let cancelled = false;
+    const delays = [0, 500, 1500, 4000]; // ~6s of attempts, well within the probe's 15s
+    void (async () => {
+      let lastError = 'unknown';
+      for (const delay of delays) {
+        if (cancelled) return;
+        if (delay) await new Promise((r) => setTimeout(r, delay));
+        try {
+          await api().invoke('app.appBooted');
+          return; // confirmed
+        } catch (e) {
+          lastError = e instanceof Error ? e.message : String(e);
+        }
+      }
+      if (cancelled) return;
+      await api()
+        .invoke('app.bootHeartbeatFailed', { error: lastError })
+        .catch(() => undefined);
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // First-run gate. Block on prefs loading so we never flash the

--- a/apps/desktop/src/lib/useAppUpdate.ts
+++ b/apps/desktop/src/lib/useAppUpdate.ts
@@ -11,6 +11,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type {
   AppUpdateCheck,
+  AppUpdateDiagnostics,
   AppUpdateInfo,
   AppUpdateProgress,
 } from '@moxxy/desktop-ipc-contract';
@@ -35,8 +36,10 @@ export interface UseAppUpdate {
   progress: AppUpdateProgress | null;
   error: string | null;
   stagedVersion: string | null;
+  diagnostics: AppUpdateDiagnostics | null;
   runCheck: () => Promise<void>;
   runUpdate: () => Promise<void>;
+  loadDiagnostics: () => Promise<void>;
   relaunch: () => void;
 }
 
@@ -47,6 +50,7 @@ export function useAppUpdate(opts: { autoCheck?: boolean } = {}): UseAppUpdate {
   const [progress, setProgress] = useState<AppUpdateProgress | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [stagedVersion, setStagedVersion] = useState<string | null>(null);
+  const [diagnostics, setDiagnostics] = useState<AppUpdateDiagnostics | null>(null);
   const autoChecked = useRef(false);
 
   useEffect(() => {
@@ -96,6 +100,14 @@ export function useAppUpdate(opts: { autoCheck?: boolean } = {}): UseAppUpdate {
     }
   }, []);
 
+  const loadDiagnostics = useCallback(async (): Promise<void> => {
+    try {
+      setDiagnostics(await api().invoke('app.updateDiagnostics'));
+    } catch {
+      setDiagnostics(null);
+    }
+  }, []);
+
   const relaunch = useCallback((): void => {
     void api().invoke('app.relaunch').catch(() => undefined);
   }, []);
@@ -107,5 +119,17 @@ export function useAppUpdate(opts: { autoCheck?: boolean } = {}): UseAppUpdate {
     }
   }, [opts.autoCheck, runCheck]);
 
-  return { info, check, state, progress, error, stagedVersion, runCheck, runUpdate, relaunch };
+  return {
+    info,
+    check,
+    state,
+    progress,
+    error,
+    stagedVersion,
+    diagnostics,
+    runCheck,
+    runUpdate,
+    loadDiagnostics,
+    relaunch,
+  };
 }

--- a/apps/desktop/src/settings/DashboardUpdateSection.tsx
+++ b/apps/desktop/src/settings/DashboardUpdateSection.tsx
@@ -36,8 +36,19 @@ function statusLine(state: UpdateState, latest: string | null): string | null {
 }
 
 export function DashboardUpdateSection(): JSX.Element {
-  const { info, check, state, progress, error, stagedVersion, runCheck, runUpdate, relaunch } =
-    useAppUpdate();
+  const {
+    info,
+    check,
+    state,
+    progress,
+    error,
+    stagedVersion,
+    diagnostics,
+    runCheck,
+    runUpdate,
+    loadDiagnostics,
+    relaunch,
+  } = useAppUpdate();
 
   const configured = info?.channelConfigured ?? false;
   const pct =
@@ -151,10 +162,71 @@ export function DashboardUpdateSection(): JSX.Element {
             v{stagedVersion} will load on the next start.
           </p>
         )}
+
+        {/* Troubleshooting: if an update "downloads but the app stays old", the
+            boot-log here names the exact reason (the previously-silent revert). */}
+        <details
+          style={{ marginTop: 2 }}
+          onToggle={(e) => {
+            if ((e.currentTarget as HTMLDetailsElement).open) void loadDiagnostics();
+          }}
+        >
+          <summary style={{ cursor: 'pointer', fontSize: 12, color: 'var(--color-text-dim)' }}>
+            Diagnostics
+          </summary>
+          {diagnostics ? (
+            <div style={{ marginTop: 8, display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <div style={{ fontSize: 11.5, color: 'var(--color-text-dim)', lineHeight: 1.6 }}>
+                running <b className="mono">{diagnostics.running}</b> · active{' '}
+                <span className="mono">{diagnostics.active ?? '—'}</span> · confirmed{' '}
+                <span className="mono">{diagnostics.confirmed ?? '—'}</span>
+                <br />
+                staged <span className="mono">{diagnostics.staged.join(', ') || '—'}</span> · bad{' '}
+                <span className="mono">{diagnostics.bad.join(', ') || '—'}</span>
+              </div>
+              <pre style={logBox}>
+                {diagnostics.log.length === 0
+                  ? '(no boot-log entries yet)'
+                  : diagnostics.log
+                      .map(
+                        (e) =>
+                          `${new Date(e.ts).toISOString()}  ${e.phase.padEnd(11)} ${e.picked ?? ''}` +
+                          (e.reason ? `  reason=${e.reason}` : '') +
+                          (e.recoveredTo ? `  → ${e.recoveredTo}` : '') +
+                          (e.error ? `  error=${e.error}` : ''),
+                      )
+                      .join('\n')}
+              </pre>
+              <button
+                type="button"
+                style={{ ...primaryBtn(false), background: 'var(--color-card-border-strong)' }}
+                onClick={() => void navigator.clipboard.writeText(JSON.stringify(diagnostics, null, 2)).catch(() => undefined)}
+              >
+                Copy diagnostics
+              </button>
+            </div>
+          ) : (
+            <p style={{ marginTop: 8, fontSize: 11.5, color: 'var(--color-text-dim)' }}>Loading…</p>
+          )}
+        </details>
       </div>
     </Section>
   );
 }
+
+const logBox: React.CSSProperties = {
+  margin: 0,
+  padding: '10px 12px',
+  maxHeight: 220,
+  overflow: 'auto',
+  fontSize: 11,
+  lineHeight: 1.5,
+  whiteSpace: 'pre',
+  background: 'var(--color-card-bg)',
+  border: '1px solid var(--color-card-border)',
+  borderRadius: 10,
+  color: 'var(--color-text-muted)',
+};
 
 const card: React.CSSProperties = {
   display: 'flex',

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -9,7 +9,7 @@ export default defineConfig({
       description: 'Block-based, modular agentic loop framework for TypeScript.',
       tagline: 'Block-based agentic loop framework.',
       social: {
-        github: 'https://github.com/moxxy-ai/new_moxxy',
+        github: 'https://github.com/moxxy-ai/moxxy',
       },
       sidebar: [
         {

--- a/apps/docs/src/content/docs/guides/security.md
+++ b/apps/docs/src/content/docs/guides/security.md
@@ -162,7 +162,7 @@ The CLI ships five out of the box:
 
 Further isolators register through the same SDK `Isolator` interface —
 no plugin changes needed. See
-[`.claude/agents/isolator-author.md`](https://github.com/moxxy-ai/new_moxxy/blob/main/.claude/agents/isolator-author.md)
+[`.claude/agents/isolator-author.md`](https://github.com/moxxy-ai/moxxy/blob/main/.claude/agents/isolator-author.md)
 for the implementation guide.
 
 ### When to pick `worker`
@@ -353,6 +353,6 @@ will refuse to run.
 
 ## See also
 
-- [`.claude/agents/isolator-author.md`](https://github.com/moxxy-ai/new_moxxy/blob/main/.claude/agents/isolator-author.md) — author guide for new Isolator impls
-- [`packages/plugin-security/src/cap-check.ts`](https://github.com/moxxy-ai/new_moxxy/blob/main/packages/plugin-security/src/cap-check.ts) — capability validation source
-- [`packages/sdk/src/isolation.ts`](https://github.com/moxxy-ai/new_moxxy/blob/main/packages/sdk/src/isolation.ts) — SDK type definitions
+- [`.claude/agents/isolator-author.md`](https://github.com/moxxy-ai/moxxy/blob/main/.claude/agents/isolator-author.md) — author guide for new Isolator impls
+- [`packages/plugin-security/src/cap-check.ts`](https://github.com/moxxy-ai/moxxy/blob/main/packages/plugin-security/src/cap-check.ts) — capability validation source
+- [`packages/sdk/src/isolation.ts`](https://github.com/moxxy-ai/moxxy/blob/main/packages/sdk/src/isolation.ts) — SDK type definitions

--- a/apps/docs/src/content/docs/packages/isolator-worker.md
+++ b/apps/docs/src/content/docs/packages/isolator-worker.md
@@ -112,6 +112,6 @@ defeat the strength claim.
 
 ## See also
 
-- [`.claude/agents/isolator-author.md`](https://github.com/moxxy-ai/new_moxxy/blob/main/.claude/agents/isolator-author.md) — author guide for new isolators
+- [`.claude/agents/isolator-author.md`](https://github.com/moxxy-ai/moxxy/blob/main/.claude/agents/isolator-author.md) — author guide for new isolators
 - [Security & isolation guide](/guides/security/) — user-facing overview
 - [`@moxxy/plugin-security`](./plugin-security/) — the host plugin

--- a/apps/docs/src/content/docs/packages/plugin-security.md
+++ b/apps/docs/src/content/docs/packages/plugin-security.md
@@ -122,7 +122,7 @@ const { plugin } = buildSecurityPlugin({
 });
 ```
 
-See [`.claude/agents/isolator-author.md`](https://github.com/moxxy-ai/new_moxxy/blob/main/.claude/agents/isolator-author.md)
+See [`.claude/agents/isolator-author.md`](https://github.com/moxxy-ai/moxxy/blob/main/.claude/agents/isolator-author.md)
 for the full author guide — particularly the section on **handler
 marshalling**, which is the hard problem any out-of-process isolator
 must solve before its strength claim is real.

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,28 @@
+# README media
+
+Assets referenced by the top-level `README.md`. The three demo slots currently
+point at [placehold.co](https://placehold.co) placeholders — swap each for a real
+GIF (or MP4) and update the `src` in `README.md`.
+
+| File to add | README slot | What it should show | Suggested size |
+|---|---|---|---|
+| `hero-demo.gif` | top hero (under the nav) | ~20–30s loop: `moxxy init` → ask a question in the TUI → the agent runs a tool (edit a file / run a command) → streamed answer. The "wow, it just works" clip. | 1280×640 |
+| `tui-demo.gif` | "See it in action" → left | The Ink TUI: boot splash → type a prompt → streamed reply with a tool block expanding → bottom status line (provider · model · context bar · version). | 1200×675 |
+| `desktop-demo.gif` | "See it in action" → right | The Electron app: workspaces in the sidebar, a chat turn streaming, optionally Settings → Dashboard showing the in-app update. | 1200×675 |
+
+Already present:
+
+- `moxxy-mascot.gif` — the moxxy character animation (brand accent in the "Why moxxy?" section). Copied from `apps/desktop/public/new-animation.gif`.
+
+## Capturing the TUI
+
+No screen-capture tooling is committed. The easiest reproducible route is
+[`vhs`](https://github.com/charmbracelet/vhs):
+
+```sh
+brew install vhs
+vhs assets/tui.tape       # writes assets/tui-demo.gif
+```
+
+(See `tui.tape` for the script.) Or record any terminal with `asciinema` /
+QuickTime and export to GIF.

--- a/assets/tui.tape
+++ b/assets/tui.tape
@@ -1,0 +1,25 @@
+# VHS tape for the moxxy TUI demo GIF.
+#   brew install vhs   &&   vhs assets/tui.tape
+# Produces assets/tui-demo.gif. Tweak the prompt/timings to taste.
+# Docs: https://github.com/charmbracelet/vhs
+
+Output assets/tui-demo.gif
+
+Set Shell "bash"
+Set FontSize 18
+Set Width 1200
+Set Height 675
+Set Theme "Dracula"
+Set Padding 24
+
+# Assumes `moxxy` is on PATH and a provider is already configured (`moxxy init`).
+Type "moxxy"
+Enter
+Sleep 4s
+
+Type "list the TypeScript files in this folder and summarize what they do"
+Sleep 1s
+Enter
+
+# Give the turn time to stream + run a tool or two.
+Sleep 12s

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,8 +21,8 @@
   <a href="https://www.typescriptlang.org">
     <img src="https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white" alt="TypeScript" />
   </a>
-  <a href="https://github.com/moxxy-ai/new_moxxy/actions/workflows/ci.yml">
-    <img src="https://github.com/moxxy-ai/new_moxxy/actions/workflows/ci.yml/badge.svg" alt="CI" />
+  <a href="https://github.com/moxxy-ai/moxxy/actions/workflows/ci.yml">
+    <img src="https://github.com/moxxy-ai/moxxy/actions/workflows/ci.yml/badge.svg" alt="CI" />
   </a>
 </p>
 
@@ -221,7 +221,7 @@ Full documentation lives at [docs.moxxy.ai](https://docs.moxxy.ai): concepts, re
 
 ## Contributing
 
-PRs welcome. The issue tracker and author guides live in the [moxxy monorepo](https://github.com/moxxy-ai/new_moxxy).
+PRs welcome. The issue tracker and author guides live in the [moxxy monorepo](https://github.com/moxxy-ai/moxxy).
 
 ## License
 

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -22,6 +22,7 @@ import { runServeCommand } from './commands/serve.js';
 import { runSessionsCommand } from './commands/sessions.js';
 import { runSecurityCommand } from './commands/security.js';
 import { runSelfUpdateCommand } from './commands/self-update.js';
+import { runUpdateCommand } from './commands/update.js';
 import { setupSessionWithConfig } from './setup.js';
 import { renderLogo } from './logo.js';
 import { colors } from './colors.js';
@@ -54,6 +55,7 @@ const SECTIONS: ReadonlyArray<{ readonly title: string; readonly rows: ReadonlyA
       ['login <provider>', 'OAuth sign-in for providers that don\'t use API keys'],
       ['login status|logout', 'inspect / remove stored OAuth credentials'],
       ['doctor [--check-keys]', 'diagnose config, vault, providers, channels, memory'],
+      ['update [--check|--yes]', 'upgrade the moxxy CLI to the latest published version'],
     ],
   },
   {
@@ -195,6 +197,7 @@ const COMMANDS: Record<string, CommandHandler> = {
   mcp: runMcpCommand,
   schedule: runScheduleCommand,
   doctor: runDoctorCommand,
+  update: runUpdateCommand,
   prompt: runPromptCommand,
   tui: runTuiCommand,
   resume: runResumeCommand,

--- a/packages/cli/src/commands/run-tui.ts
+++ b/packages/cli/src/commands/run-tui.ts
@@ -80,8 +80,24 @@ import { argvToSetupOptions, hasBoolFlag, stringFlag } from '../argv-helpers.js'
 import { chooseClientMode } from './client-mode.js';
 import type { ParsedArgv } from '../argv.js';
 import { cliVersion } from '../version.js';
+import { readCachedCheck, refreshCheck } from '../update/check.js';
+import { detectInstall } from '../update/detect-install.js';
 import { runInitCommand } from './init.js';
 import type { Session } from '@moxxy/core';
+
+/**
+ * Cheap, non-blocking "is there a newer @moxxy/cli?" for the TUI banner.
+ * Reads only the cached answer (instant, no network on the startup path) and
+ * kicks a background refresh so the cache is warm next launch. Returns nothing
+ * for a source checkout (don't nag devs) or when there's no newer version.
+ */
+function resolveUpdateNotice(version: string | undefined): { latest: string } | undefined {
+  if (!version) return undefined;
+  if (detectInstall().manager === 'workspace') return undefined;
+  void refreshCheck(version).catch(() => undefined); // warm the cache for next time
+  const cached = readCachedCheck(version);
+  return cached?.updateAvailable ? { latest: cached.latest } : undefined;
+}
 
 /**
  * `moxxy tui`. Three modes:
@@ -148,6 +164,7 @@ async function runAttachedTui(argv: ParsedArgv, tuiOpts: RunTuiOpts): Promise<nu
   const prefs = await loadPreferences();
   const effectiveModel = stringFlag(argv, 'model') ?? prefs.model;
   const version = cliVersion();
+  const updateNotice = resolveUpdateNotice(version);
 
   let shuttingDown = false;
   const shutdown = async (): Promise<void> => {
@@ -169,6 +186,7 @@ async function runAttachedTui(argv: ParsedArgv, tuiOpts: RunTuiOpts): Promise<nu
       },
       ...(effectiveModel ? { model: effectiveModel } : {}),
       ...(version ? { version } : {}),
+      ...(updateNotice ? { updateAvailable: updateNotice } : {}),
       // Land directly in the (replayed) conversation rather than the splash.
       resumed: true,
     }),
@@ -238,6 +256,7 @@ async function runSelfHostedTui(
 
   const effectiveModel = stringFlag(argv, 'model') ?? (await loadPreferences()).model;
   const version = cliVersion();
+  const updateNotice = resolveUpdateNotice(version);
 
   // Capture the resolved session + optional runner so shutdown can fire
   // `onShutdown` hooks and release the socket.
@@ -312,6 +331,7 @@ async function runSelfHostedTui(
       },
       ...(effectiveModel ? { model: effectiveModel } : {}),
       ...(version ? { version } : {}),
+      ...(updateNotice ? { updateAvailable: updateNotice } : {}),
       ...(tuiOpts.resumeSessionId ? { resumed: true } : {}),
     }),
   );

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import { runUpdateCommand, type UpdateDeps } from './update.js';
+import type { ParsedArgv } from '../argv.js';
+import type { InstallInfo } from '../update/detect-install.js';
+import type { CliUpdateCheck } from '../update/check.js';
+
+function argv(flags: Record<string, string | boolean> = {}): ParsedArgv {
+  return { command: 'update', flags, positional: [] };
+}
+
+const npmGlobal: InstallInfo = {
+  manager: 'npm',
+  global: true,
+  pkg: '@moxxy/cli',
+  cmd: ['npm', 'install', '-g', '@moxxy/cli@latest'],
+  installPath: '/usr/local/lib/node_modules/@moxxy/cli',
+};
+
+const workspace: InstallInfo = {
+  manager: 'workspace',
+  global: false,
+  pkg: '@moxxy/cli',
+  cmd: [],
+  installPath: '/repo/packages/cli',
+};
+
+/** Capture stdout + record any command that would have run. */
+function harness(over: Partial<UpdateDeps> = {}) {
+  let out = '';
+  const ran: string[][] = [];
+  const deps: UpdateDeps = {
+    current: '0.5.3',
+    detect: () => npmGlobal,
+    run: async (cmd) => {
+      ran.push([...cmd]);
+      return 0;
+    },
+    interactive: false,
+    out: (s) => {
+      out += s;
+    },
+    ...over,
+  };
+  return { deps, ran, get out() {
+    return out;
+  } };
+}
+
+const available = (latest = '0.5.5', current = '0.5.3'): CliUpdateCheck => ({
+  current,
+  latest,
+  updateAvailable: true,
+});
+
+describe('runUpdateCommand', () => {
+  it('--help prints help and does nothing', async () => {
+    const h = harness({ check: async () => available() });
+    const code = await runUpdateCommand(argv({ help: true }), h.deps);
+    expect(code).toBe(0);
+    expect(h.ran).toHaveLength(0);
+    expect(h.out).toBe(''); // help goes to process.stdout directly, not our `out`
+  });
+
+  it('reports up-to-date and does not run', async () => {
+    const h = harness({ check: async () => ({ current: '0.5.5', latest: '0.5.5', updateAvailable: false }) });
+    const code = await runUpdateCommand(argv(), h.deps);
+    expect(code).toBe(0);
+    expect(h.ran).toHaveLength(0);
+    expect(h.out).toMatch(/latest/i);
+  });
+
+  it('--check reports the command but never runs it', async () => {
+    const h = harness({ check: async () => available() });
+    const code = await runUpdateCommand(argv({ check: true }), h.deps);
+    expect(code).toBe(0);
+    expect(h.ran).toHaveLength(0);
+    expect(h.out).toContain('npm install -g @moxxy/cli@latest');
+    expect(h.out).toMatch(/0\.5\.3.*0\.5\.5/s);
+  });
+
+  it('--yes runs the detected upgrade command', async () => {
+    const h = harness({ check: async () => available() });
+    const code = await runUpdateCommand(argv({ yes: true }), h.deps);
+    expect(code).toBe(0);
+    expect(h.ran).toEqual([['npm', 'install', '-g', '@moxxy/cli@latest']]);
+  });
+
+  it('propagates a non-zero exit code from the upgrade', async () => {
+    const h = harness({ check: async () => available(), run: async () => 1 });
+    const code = await runUpdateCommand(argv({ yes: true }), h.deps);
+    expect(code).toBe(1);
+  });
+
+  it('non-interactive without --yes prints the command but does not run it', async () => {
+    const h = harness({ check: async () => available(), interactive: false });
+    const code = await runUpdateCommand(argv(), h.deps);
+    expect(code).toBe(0);
+    expect(h.ran).toHaveLength(0);
+    expect(h.out).toMatch(/--yes/);
+  });
+
+  it('interactive confirm=yes runs; confirm=no does not', async () => {
+    const yes = harness({ check: async () => available(), interactive: true, promptConfirm: async () => true });
+    expect(await runUpdateCommand(argv(), yes.deps)).toBe(0);
+    expect(yes.ran).toHaveLength(1);
+
+    const no = harness({ check: async () => available(), interactive: true, promptConfirm: async () => false });
+    expect(await runUpdateCommand(argv(), no.deps)).toBe(0);
+    expect(no.ran).toHaveLength(0);
+  });
+
+  it('a source checkout advises git, never installs', async () => {
+    const h = harness({ check: async () => available(), detect: () => workspace });
+    const code = await runUpdateCommand(argv({ yes: true }), h.deps);
+    expect(code).toBe(0);
+    expect(h.ran).toHaveLength(0);
+    expect(h.out).toMatch(/git pull/);
+  });
+
+  it('offline (null check) degrades to a manual hint, returns 0', async () => {
+    const h = harness({ check: async () => null });
+    const code = await runUpdateCommand(argv(), h.deps);
+    expect(code).toBe(0);
+    expect(h.ran).toHaveLength(0);
+    expect(h.out).toContain('npm install -g @moxxy/cli@latest');
+  });
+});

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,0 +1,158 @@
+/**
+ * `moxxy update` — check npm for a newer `@moxxy/cli` and upgrade in place.
+ *
+ * Detects how moxxy was installed (npm / pnpm / yarn / bun, global or local)
+ * and runs the matching upgrade command after confirming. Flags:
+ *   --check / --dry-run   report current → latest + the command, don't run it
+ *   --yes, -y             skip the confirmation prompt
+ * In a non-interactive shell with no `--yes`, it prints the command instead of
+ * running it (so a script never triggers an unattended global install).
+ *
+ * The version check is fail-soft: offline / registry errors degrade to a hint,
+ * never an error.
+ */
+
+import { spawn } from 'node:child_process';
+import { confirm, isCancel } from '@clack/prompts';
+
+import type { ParsedArgv } from '../argv.js';
+import { confirmedYes, hasBoolFlag, helpRequested } from '../argv-helpers.js';
+import { printError } from '../errors.js';
+import { colors } from '../colors.js';
+import { cliVersion } from '../version.js';
+import { formatHelp } from './help-format.js';
+import { checkForCliUpdate, type CliUpdateCheck } from '../update/check.js';
+import { detectInstall, formatCmd, type InstallInfo } from '../update/detect-install.js';
+
+const HELP = formatHelp({
+  title: 'moxxy update',
+  tagline: 'update the moxxy CLI to the latest published version',
+  sections: [
+    {
+      title: 'USAGE',
+      rows: [
+        ['moxxy update', 'check npm + upgrade (asks before running)'],
+        ['moxxy update --check', 'report current vs latest, print the command, do nothing'],
+        ['moxxy update --yes', 'upgrade without the confirmation prompt'],
+      ],
+    },
+    {
+      title: 'NOTES',
+      notes: [
+        'Detects npm / pnpm / yarn / bun (global or local) and runs the matching upgrade.',
+        'From a source checkout, update with git instead — nothing is installed.',
+      ],
+    },
+  ],
+});
+
+/** Run a command, inheriting stdio so the user watches npm/pnpm output live. */
+async function runCommand(cmd: ReadonlyArray<string>): Promise<number> {
+  const [bin, ...args] = cmd;
+  if (!bin) return 1;
+  return new Promise<number>((resolve) => {
+    const proc = spawn(bin, args, {
+      stdio: 'inherit',
+      // npm/pnpm/yarn/bun are `.cmd` shims on Windows — needs a shell to launch.
+      shell: process.platform === 'win32',
+    });
+    proc.on('error', () => resolve(127));
+    proc.on('exit', (code) => resolve(code ?? 1));
+  });
+}
+
+/** Injectable seams so the command is testable without network / spawning. */
+export interface UpdateDeps {
+  current?: string | undefined;
+  check?: (current: string | undefined) => Promise<CliUpdateCheck | null>;
+  detect?: () => InstallInfo;
+  run?: (cmd: ReadonlyArray<string>) => Promise<number>;
+  /** Override TTY detection (defaults to stdin.isTTY). */
+  interactive?: boolean;
+  /** Override the confirm prompt (defaults to a clack confirm). */
+  promptConfirm?: (message: string) => Promise<boolean>;
+  out?: (s: string) => void;
+}
+
+export async function runUpdateCommand(argv: ParsedArgv, deps: UpdateDeps = {}): Promise<number> {
+  if (helpRequested(argv) || argv.positional[0] === 'help') {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  const out = deps.out ?? ((s: string) => process.stdout.write(s));
+  const current = deps.current ?? cliVersion();
+  const checkOnly = hasBoolFlag(argv, 'check') || hasBoolFlag(argv, 'dry-run');
+  const check = deps.check ?? ((c) => checkForCliUpdate(c, { force: true }));
+  const detect = deps.detect ?? (() => detectInstall());
+  const run = deps.run ?? runCommand;
+
+  out(colors.dim('Checking for updates…\n'));
+  const result = await check(current);
+
+  if (!result) {
+    // Offline / registry error — degrade to a manual hint, not a failure.
+    const info = detect();
+    out(colors.dim(`Could not reach the npm registry. Current version: ${current ?? 'unknown'}.\n`));
+    if (info.manager !== 'workspace') {
+      out(colors.dim('To update manually:\n  ') + colors.bold(formatCmd(info.cmd)) + '\n');
+    }
+    return 0;
+  }
+
+  if (!result.updateAvailable) {
+    out(colors.green('✓ ') + `You're on the latest moxxy (v${result.current}).\n`);
+    return 0;
+  }
+
+  out(
+    `Update available: ${colors.dim('v' + result.current)} → ${colors.bold(colors.green('v' + result.latest))}\n`,
+  );
+
+  const info = detect();
+  if (info.manager === 'workspace') {
+    out(
+      colors.dim(
+        'You\'re running moxxy from a source checkout — nothing to install.\n' +
+          'Update with: ',
+      ) + colors.bold('git pull') + colors.dim(' && pnpm install && pnpm build') + '\n',
+    );
+    return 0;
+  }
+
+  const cmdStr = formatCmd(info.cmd);
+  out(colors.dim('Will run: ') + colors.bold(cmdStr) + '\n');
+
+  if (checkOnly) return 0;
+
+  // Decide whether to actually run the upgrade.
+  const interactive = deps.interactive ?? Boolean(process.stdin.isTTY);
+  let proceed = confirmedYes(argv);
+  if (!proceed) {
+    if (!interactive) {
+      out(colors.dim('Re-run with --yes to apply, or run the command above yourself.\n'));
+      return 0;
+    }
+    const ask = deps.promptConfirm ?? defaultConfirm;
+    proceed = await ask(`Run \`${cmdStr}\` now?`);
+    if (!proceed) {
+      out(colors.dim('Skipped. Run the command above when you\'re ready.\n'));
+      return 0;
+    }
+  }
+
+  out(colors.dim(`\n$ ${cmdStr}\n`));
+  const code = await run(info.cmd);
+  if (code === 0) {
+    out('\n' + colors.green('✓ ') + `Updated to v${result.latest}. Restart moxxy to use it.\n`);
+    return 0;
+  }
+  printError(`update command exited with code ${code}`);
+  return code || 1;
+}
+
+async function defaultConfirm(message: string): Promise<boolean> {
+  const answer = await confirm({ message });
+  if (isCancel(answer)) return false;
+  return answer === true;
+}

--- a/packages/cli/src/update/check.test.ts
+++ b/packages/cli/src/update/check.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { checkForCliUpdate, readCachedCheck, refreshCheck, compareSemver, CACHE_TTL_MS } from './check.js';
+
+function tmpCacheFile(): string {
+  return path.join(mkdtempSync(path.join(os.tmpdir(), 'mox-update-')), 'update-check.json');
+}
+
+/** A fetch stub that returns the npm `/latest` manifest for a given version. */
+function stubFetch(version: string | null, status = 200): typeof fetch {
+  return (async () =>
+    version === null
+      ? new Response('nope', { status: status === 200 ? 500 : status })
+      : new Response(JSON.stringify({ version }), { status: 200 })) as unknown as typeof fetch;
+}
+
+describe('compareSemver', () => {
+  it('orders by major.minor.patch and ignores prerelease', () => {
+    expect(compareSemver('0.5.5', '0.5.3')).toBe(1);
+    expect(compareSemver('0.5.3', '0.5.5')).toBe(-1);
+    expect(compareSemver('1.0.0', '1.0.0')).toBe(0);
+    expect(compareSemver('0.5.5-beta.1', '0.5.5')).toBe(0);
+  });
+});
+
+describe('checkForCliUpdate', () => {
+  it('reports an available update when latest > current', async () => {
+    const r = await checkForCliUpdate('0.5.3', {
+      force: true,
+      cacheFile: tmpCacheFile(),
+      fetchImpl: stubFetch('0.5.5'),
+    });
+    expect(r).toEqual({ current: '0.5.3', latest: '0.5.5', updateAvailable: true });
+  });
+
+  it('reports up-to-date when current >= latest', async () => {
+    const r = await checkForCliUpdate('0.5.5', {
+      force: true,
+      cacheFile: tmpCacheFile(),
+      fetchImpl: stubFetch('0.5.5'),
+    });
+    expect(r?.updateAvailable).toBe(false);
+  });
+
+  it('returns null when current version is unknown', async () => {
+    expect(await checkForCliUpdate(undefined, { fetchImpl: stubFetch('0.5.5') })).toBeNull();
+  });
+
+  it('serves a fresh cache without refetching', async () => {
+    const cacheFile = tmpCacheFile();
+    writeFileSync(cacheFile, JSON.stringify({ checkedAt: 1000, latest: '9.9.9' }));
+    let fetched = false;
+    const r = await checkForCliUpdate('0.5.3', {
+      cacheFile,
+      now: 1000 + CACHE_TTL_MS - 1,
+      fetchImpl: (async () => {
+        fetched = true;
+        return new Response(JSON.stringify({ version: '0.5.5' }));
+      }) as unknown as typeof fetch,
+    });
+    expect(fetched).toBe(false);
+    expect(r?.latest).toBe('9.9.9');
+  });
+
+  it('refetches + recaches when the cache is stale', async () => {
+    const cacheFile = tmpCacheFile();
+    writeFileSync(cacheFile, JSON.stringify({ checkedAt: 1000, latest: '0.0.1' }));
+    const r = await checkForCliUpdate('0.5.3', {
+      cacheFile,
+      now: 1000 + CACHE_TTL_MS + 1,
+      fetchImpl: stubFetch('0.5.5'),
+    });
+    expect(r?.latest).toBe('0.5.5');
+    expect(JSON.parse(readFileSync(cacheFile, 'utf8')).latest).toBe('0.5.5');
+  });
+
+  it('falls back to a stale cache when the refetch fails (offline)', async () => {
+    const cacheFile = tmpCacheFile();
+    writeFileSync(cacheFile, JSON.stringify({ checkedAt: 1000, latest: '0.5.4' }));
+    const r = await checkForCliUpdate('0.5.3', {
+      cacheFile,
+      now: 1000 + CACHE_TTL_MS + 1,
+      fetchImpl: stubFetch(null), // 500
+    });
+    expect(r?.latest).toBe('0.5.4');
+  });
+
+  it('returns null when offline with no cache', async () => {
+    const r = await checkForCliUpdate('0.5.3', {
+      force: true,
+      cacheFile: tmpCacheFile(),
+      fetchImpl: stubFetch(null),
+    });
+    expect(r).toBeNull();
+  });
+});
+
+describe('readCachedCheck / refreshCheck', () => {
+  it('readCachedCheck never hits the network and returns null without a cache', () => {
+    expect(readCachedCheck('0.5.3', { cacheFile: tmpCacheFile() })).toBeNull();
+  });
+
+  it('refreshCheck writes the cache for the next launch', async () => {
+    const cacheFile = tmpCacheFile();
+    await refreshCheck('0.5.3', { cacheFile, fetchImpl: stubFetch('0.5.5'), now: 42 });
+    const cached = readCachedCheck('0.5.3', { cacheFile });
+    expect(cached).toEqual({ current: '0.5.3', latest: '0.5.5', updateAvailable: true });
+  });
+});

--- a/packages/cli/src/update/check.ts
+++ b/packages/cli/src/update/check.ts
@@ -1,0 +1,141 @@
+/**
+ * "Is a newer @moxxy/cli published?" — shared by the `moxxy update` command and
+ * the TUI banner.
+ *
+ * The result is cached under `~/.moxxy/update-check.json` with a TTL so the TUI
+ * can render a banner from disk on every launch without hitting the network. The
+ * command bypasses the cache (the user explicitly asked). Everything here is
+ * fail-soft: a missing/corrupt cache or an offline registry yields `null`, never
+ * an error — a version check must never break the CLI or stall TUI startup.
+ */
+
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { readFileSync, writeFileSync, mkdirSync, renameSync } from 'node:fs';
+
+import { fetchLatest, type FetchLatestOpts } from './registry.js';
+
+export interface CliUpdateCheck {
+  current: string;
+  latest: string;
+  updateAvailable: boolean;
+}
+
+/** How long a cached latest-version answer is trusted before a refetch. */
+export const CACHE_TTL_MS = 12 * 60 * 60 * 1000; // 12h
+
+const PKG = '@moxxy/cli';
+
+interface CacheShape {
+  checkedAt: number;
+  latest: string;
+}
+
+function defaultCacheFile(): string {
+  return path.join(os.homedir(), '.moxxy', 'update-check.json');
+}
+
+/**
+ * Numeric major.minor.patch compare, ignoring any prerelease/build suffix.
+ * Returns >0 if `a` is newer than `b`. (A local copy so the CLI doesn't take a
+ * dependency on `@moxxy/desktop-host` just for this.)
+ */
+export function compareSemver(a: string, b: string): number {
+  const parse = (s: string): number[] =>
+    (s.split('-')[0] ?? '').split('.').map((n) => Number.parseInt(n, 10) || 0);
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < 3; i += 1) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+function readCache(file: string): CacheShape | null {
+  try {
+    const raw = JSON.parse(readFileSync(file, 'utf8')) as Partial<CacheShape>;
+    if (typeof raw.checkedAt === 'number' && typeof raw.latest === 'string') {
+      return { checkedAt: raw.checkedAt, latest: raw.latest };
+    }
+  } catch {
+    /* missing / malformed → treat as no cache */
+  }
+  return null;
+}
+
+function writeCache(file: string, value: CacheShape): void {
+  try {
+    mkdirSync(path.dirname(file), { recursive: true });
+    const tmp = `${file}.tmp-${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(value, null, 2));
+    renameSync(tmp, file);
+  } catch {
+    /* best effort — caching is an optimization, never a hard requirement */
+  }
+}
+
+export interface CheckOpts extends FetchLatestOpts {
+  /** Skip the cache and always hit the registry (the command does this). */
+  force?: boolean;
+  /** Override the cache file location (tests). */
+  cacheFile?: string;
+  /** Override "now" (tests). */
+  now?: number;
+}
+
+function shape(current: string | undefined, latest: string | null): CliUpdateCheck | null {
+  if (!current || !latest) return null;
+  return { current, latest, updateAvailable: compareSemver(latest, current) > 0 };
+}
+
+/**
+ * Read a previously-cached answer WITHOUT any network. Returns `null` when there
+ * is no cache (regardless of age) — callers that want freshness call
+ * {@link refreshCheck} in the background. Built for the TUI banner: instant, and
+ * never blocks startup on the network.
+ */
+export function readCachedCheck(current: string | undefined, opts: CheckOpts = {}): CliUpdateCheck | null {
+  const cache = readCache(opts.cacheFile ?? defaultCacheFile());
+  return shape(current, cache?.latest ?? null);
+}
+
+/**
+ * Fetch the latest version and update the cache. Fire-and-forget from the TUI to
+ * warm the cache for next launch; awaited by the command. Returns the shaped
+ * check (or `null` on a failed fetch — the cache is left untouched).
+ */
+export async function refreshCheck(current: string | undefined, opts: CheckOpts = {}): Promise<CliUpdateCheck | null> {
+  const latest = await fetchLatest(PKG, opts);
+  if (latest) {
+    writeCache(opts.cacheFile ?? defaultCacheFile(), {
+      checkedAt: opts.now ?? Date.now(),
+      latest,
+    });
+  }
+  return shape(current, latest);
+}
+
+/**
+ * The everyday check: serve a fresh-enough cached answer, otherwise refetch +
+ * recache. `force` always refetches. Fail-soft (`null` on no current version /
+ * offline with no usable cache).
+ */
+export async function checkForCliUpdate(
+  current: string | undefined,
+  opts: CheckOpts = {},
+): Promise<CliUpdateCheck | null> {
+  if (!current) return null;
+  const now = opts.now ?? Date.now();
+  const file = opts.cacheFile ?? defaultCacheFile();
+  if (!opts.force) {
+    const cache = readCache(file);
+    if (cache && now - cache.checkedAt < CACHE_TTL_MS) {
+      return shape(current, cache.latest);
+    }
+  }
+  const refreshed = await refreshCheck(current, { ...opts, cacheFile: file, now });
+  // If the refetch failed but we have ANY cached value, fall back to it rather
+  // than reporting "no info".
+  return refreshed ?? shape(current, readCache(file)?.latest ?? null);
+}

--- a/packages/cli/src/update/detect-install.test.ts
+++ b/packages/cli/src/update/detect-install.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { pathToFileURL } from 'node:url';
+
+import { detectInstall, formatCmd } from './detect-install.js';
+
+/** Build a file:// URL for a fake install path so detectInstall can resolve it. */
+function at(p: string): string {
+  return pathToFileURL(p).href;
+}
+
+describe('detectInstall', () => {
+  it('detects a workspace/source checkout (no install command)', () => {
+    const info = detectInstall({ fromUrl: at('/home/me/blocky/packages/cli/dist/commands/update.js') });
+    expect(info.manager).toBe('workspace');
+    expect(info.cmd).toEqual([]);
+  });
+
+  it('defaults to npm global', () => {
+    const info = detectInstall({
+      fromUrl: at('/usr/local/lib/node_modules/@moxxy/cli/dist/commands/update.js'),
+      userAgent: '',
+      cwd: '/home/me/project',
+    });
+    expect(info.manager).toBe('npm');
+    expect(info.global).toBe(true);
+    expect(formatCmd(info.cmd)).toBe('npm install -g @moxxy/cli@latest');
+  });
+
+  it('honors the npm_config_user_agent hint (pnpm)', () => {
+    const info = detectInstall({
+      fromUrl: at('/opt/whatever/@moxxy/cli/dist/commands/update.js'),
+      userAgent: 'pnpm/9.1.0 npm/? node/v20.10.0 linux x64',
+      cwd: '/home/me/project',
+    });
+    expect(info.manager).toBe('pnpm');
+    expect(formatCmd(info.cmd)).toBe('pnpm add -g @moxxy/cli@latest');
+  });
+
+  it('detects pnpm from the install path', () => {
+    const info = detectInstall({
+      fromUrl: at('/home/me/Library/pnpm/global/5/node_modules/@moxxy/cli/dist/commands/update.js'),
+      userAgent: '',
+      cwd: '/somewhere/else',
+    });
+    expect(info.manager).toBe('pnpm');
+  });
+
+  it('detects bun from the install path', () => {
+    const info = detectInstall({
+      fromUrl: at('/home/me/.bun/install/global/node_modules/@moxxy/cli/dist/commands/update.js'),
+      userAgent: '',
+      cwd: '/somewhere/else',
+    });
+    expect(info.manager).toBe('bun');
+    expect(formatCmd(info.cmd)).toBe('bun add -g @moxxy/cli@latest');
+  });
+
+  it('builds the yarn global form', () => {
+    const info = detectInstall({
+      fromUrl: at('/opt/x/@moxxy/cli/dist/commands/update.js'),
+      userAgent: 'yarn/1.22.19 npm/? node/v20',
+      cwd: '/p',
+    });
+    expect(formatCmd(info.cmd)).toBe('yarn global add @moxxy/cli@latest');
+  });
+
+  it('treats an install under the project node_modules as local (not -g)', () => {
+    const info = detectInstall({
+      fromUrl: at('/home/me/project/node_modules/@moxxy/cli/dist/commands/update.js'),
+      userAgent: '',
+      cwd: '/home/me/project',
+    });
+    expect(info.global).toBe(false);
+    expect(formatCmd(info.cmd)).toBe('npm install @moxxy/cli@latest');
+  });
+});

--- a/packages/cli/src/update/detect-install.ts
+++ b/packages/cli/src/update/detect-install.ts
@@ -1,0 +1,99 @@
+/**
+ * Figure out HOW `@moxxy/cli` was installed so `moxxy update` can run the right
+ * upgrade command. Best-effort + heuristic: we infer the package manager and
+ * whether it's a global install, then build the matching `<pm> <add> @moxxy/cli`
+ * invocation. When we can't tell, we default to the overwhelmingly-common case
+ * (`npm install -g`). A wrong guess is recoverable — the command prints what it
+ * will run and the user can decline.
+ *
+ * Pure path/string analysis (no spawning) so it's trivially testable with
+ * injected inputs.
+ */
+
+import { fileURLToPath } from 'node:url';
+
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun' | 'workspace';
+
+export interface InstallInfo {
+  manager: PackageManager;
+  /** True for a global install; false for project-local. Meaningless for 'workspace'. */
+  global: boolean;
+  /** The package to upgrade. */
+  pkg: string;
+  /** Command + args to upgrade to latest. Empty for 'workspace' (dev checkout). */
+  cmd: string[];
+  /** Resolved on-disk path of the running CLI, for diagnostics (or null). */
+  installPath: string | null;
+}
+
+const PKG = '@moxxy/cli';
+
+export interface DetectOpts {
+  /** The module URL to resolve from (defaults to this file — i.e. the CLI itself). */
+  fromUrl?: string;
+  /** `npm_config_user_agent` value (defaults to the env var). */
+  userAgent?: string;
+  /** Current working dir (defaults to `process.cwd()`). */
+  cwd?: string;
+}
+
+export function detectInstall(opts: DetectOpts = {}): InstallInfo {
+  const fromUrl = opts.fromUrl ?? import.meta.url;
+  const ua = opts.userAgent ?? process.env.npm_config_user_agent ?? '';
+  let installPath: string | null = null;
+  try {
+    installPath = fileURLToPath(fromUrl);
+  } catch {
+    installPath = null;
+  }
+  const p = (installPath ?? '').replace(/\\/g, '/');
+
+  // Running from the monorepo source (a dev checkout), not an installed package:
+  // there's nothing to `npm install` — the user updates via git.
+  if (p.includes('/packages/cli/')) {
+    return { manager: 'workspace', global: false, pkg: PKG, cmd: [], installPath };
+  }
+
+  const manager = inferManager(p, ua);
+  const global = looksGlobal(p, (opts.cwd ?? process.cwd()).replace(/\\/g, '/'));
+  return { manager, global, pkg: PKG, cmd: upgradeCmd(manager, global), installPath };
+}
+
+/** Manager from the user-agent hint first (most reliable when present), then
+ *  from telltale segments in the install path. */
+function inferManager(p: string, ua: string): Exclude<PackageManager, 'workspace'> {
+  const head = ua.split('/')[0]?.toLowerCase();
+  if (head === 'pnpm' || head === 'yarn' || head === 'bun' || head === 'npm') return head;
+  if (/(^|\/)\.?pnpm(\/|-global|$)|\/library\/pnpm\//i.test(p)) return 'pnpm';
+  if (/\/\.bun\//i.test(p)) return 'bun';
+  if (/\/\.?yarn\//i.test(p) || /\/\.config\/yarn\//i.test(p)) return 'yarn';
+  return 'npm';
+}
+
+/** A CLI install that lives outside the current project tree is a global one.
+ *  (Project-local CLI installs are rare; defaulting to global is the safe bet.) */
+function looksGlobal(p: string, cwd: string): boolean {
+  if (!p) return true;
+  if (p.includes(`${cwd}/node_modules/`)) return false; // project-local dep
+  return true;
+}
+
+function upgradeCmd(manager: Exclude<PackageManager, 'workspace'>, global: boolean): string[] {
+  const target = `${PKG}@latest`;
+  switch (manager) {
+    case 'pnpm':
+      return ['pnpm', 'add', ...(global ? ['-g'] : []), target];
+    case 'yarn':
+      return global ? ['yarn', 'global', 'add', target] : ['yarn', 'add', target];
+    case 'bun':
+      return ['bun', 'add', ...(global ? ['-g'] : []), target];
+    case 'npm':
+    default:
+      return ['npm', 'install', ...(global ? ['-g'] : []), target];
+  }
+}
+
+/** The command rendered as a copy-pasteable string. */
+export function formatCmd(cmd: ReadonlyArray<string>): string {
+  return cmd.join(' ');
+}

--- a/packages/cli/src/update/registry.ts
+++ b/packages/cli/src/update/registry.ts
@@ -1,0 +1,47 @@
+/**
+ * Ask the npm registry what the latest published `@moxxy/cli` is. Pure transport
+ * over global `fetch` — no `npm` dependency, no child process — so both the
+ * `moxxy update` command and the TUI's "new version" banner can call it cheaply.
+ *
+ * Fail-soft by contract: every error (offline, timeout, 404, malformed body)
+ * resolves to `null`, never throws. A version check must never break the CLI.
+ */
+
+const REGISTRY = 'https://registry.npmjs.org';
+const DEFAULT_PKG = '@moxxy/cli';
+const DEFAULT_TIMEOUT_MS = 4000;
+
+export interface FetchLatestOpts {
+  /** Override the fetch implementation (tests inject a stub). */
+  fetchImpl?: typeof fetch;
+  /** Abort the request after this many ms (default 4000). */
+  timeoutMs?: number;
+}
+
+/**
+ * The version under the `latest` dist-tag for `pkg`, or `null` if it can't be
+ * resolved. Uses the per-tag manifest endpoint
+ * (`/<pkg>/latest`) so we transfer a tiny document, not the full packument.
+ */
+export async function fetchLatest(
+  pkg: string = DEFAULT_PKG,
+  opts: FetchLatestOpts = {},
+): Promise<string | null> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const url = `${REGISTRY}/${pkg}/latest`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  try {
+    const res = await fetchImpl(url, {
+      signal: controller.signal,
+      headers: { accept: 'application/json' },
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { version?: unknown };
+    return typeof json.version === 'string' ? json.version : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/desktop-host/src/app-update/boot-log.test.ts
+++ b/packages/desktop-host/src/app-update/boot-log.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { appendBootLog, readBootLog, hasBootLog } from './boot-log';
+import { appUpdateDir } from './resolve';
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(os.tmpdir(), 'boot-log-'));
+});
+
+describe('boot-log', () => {
+  it('returns [] and reports absent when nothing is written', () => {
+    expect(readBootLog(tmp)).toEqual([]);
+    expect(hasBootLog(tmp)).toBe(false);
+  });
+
+  it('appends entries newest-last and stamps a ts', () => {
+    appendBootLog(tmp, { phase: 'boot', picked: '0.0.1' });
+    appendBootLog(tmp, { phase: 'boot', picked: 'floor', reason: 'no-active' });
+    const log = readBootLog(tmp);
+    expect(log).toHaveLength(2);
+    expect(log[0]?.picked).toBe('0.0.1');
+    expect(log[1]?.reason).toBe('no-active');
+    expect(typeof log[0]?.ts).toBe('number');
+    expect(hasBootLog(tmp)).toBe(true);
+  });
+
+  it('caps the log at 50 entries (rolling window)', () => {
+    for (let i = 0; i < 70; i += 1) appendBootLog(tmp, { phase: 'boot', picked: String(i) });
+    const log = readBootLog(tmp);
+    expect(log).toHaveLength(50);
+    // Oldest 20 dropped — newest retained, in order.
+    expect(log[0]?.picked).toBe('20');
+    expect(log[49]?.picked).toBe('69');
+  });
+
+  it('honors the limit argument (last N)', () => {
+    for (let i = 0; i < 10; i += 1) appendBootLog(tmp, { phase: 'boot', picked: String(i) });
+    const tail = readBootLog(tmp, 3);
+    expect(tail.map((e) => e.picked)).toEqual(['7', '8', '9']);
+  });
+
+  it('tolerates a malformed log file (returns [], does not throw)', () => {
+    mkdirSync(appUpdateDir(tmp), { recursive: true });
+    writeFileSync(path.join(appUpdateDir(tmp), 'boot-log.json'), '{ not json');
+    expect(readBootLog(tmp)).toEqual([]);
+    // A subsequent append recovers cleanly.
+    appendBootLog(tmp, { phase: 'confirm', picked: '1.0.0' });
+    expect(readBootLog(tmp)).toHaveLength(1);
+  });
+
+  it('drops entries that are not well-formed', () => {
+    mkdirSync(appUpdateDir(tmp), { recursive: true });
+    writeFileSync(
+      path.join(appUpdateDir(tmp), 'boot-log.json'),
+      JSON.stringify([{ ts: 1, phase: 'boot' }, { nope: true }, 'string', 42]),
+    );
+    expect(readBootLog(tmp)).toHaveLength(1);
+  });
+});

--- a/packages/desktop-host/src/app-update/boot-log.ts
+++ b/packages/desktop-host/src/app-update/boot-log.ts
@@ -1,0 +1,96 @@
+/**
+ * A tiny, persistent boot/update decision log — the missing observability for
+ * self-update. Every launch, the bootstrap + boot-probe + confirm IPC record
+ * what they decided and WHY, so a silent fall-back-to-the-floor (the
+ * "downloads but relaunches old" failure) is no longer invisible: the user can
+ * read the last decisions from `<userData>/app/boot-log.json` (surfaced in the
+ * in-app Updates → Diagnostics panel).
+ *
+ * Dependency-free (node built-ins only) and synchronous, exactly like the rest
+ * of the app-update module, because it is BAKED into the immutable bootstrap and
+ * must not delay or destabilize process start. Every operation is best-effort:
+ * a missing/corrupt/unwritable log never throws into the boot path.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { appUpdateDir } from './resolve.js';
+
+/** Which step of the launch/update lifecycle produced this entry. */
+export type BootLogPhase = 'boot' | 'recover' | 'probe' | 'confirm' | 'load-error';
+
+export interface BootLogEntry {
+  /** Epoch millis. Filled in by {@link appendBootLog} when omitted. */
+  ts: number;
+  phase: BootLogPhase;
+  /** The bundle version chosen, or `'floor'` when the baked app was loaded. */
+  picked?: string;
+  /** Why this decision was made (e.g. the resolve reject reason, probe revert). */
+  reason?: string;
+  /** The confirmed-good version `active` was rolled back to, if any. */
+  recoveredTo?: string;
+  /** A failure message (staged-main import throw, confirm IPC failure, …). */
+  error?: string;
+  /** `process.versions.electron` at decision time. */
+  electron?: string;
+  /** `process.versions.modules` (the Node ABI) at decision time. */
+  abi?: string;
+}
+
+/** Keep the log small — it is a rolling window of recent launches, not history. */
+const MAX_ENTRIES = 50;
+
+function logPath(userDataDir: string): string {
+  return path.join(appUpdateDir(userDataDir), 'boot-log.json');
+}
+
+/** tmp-write + rename so a crash mid-write can't corrupt the log. */
+function writeAtomic(p: string, value: unknown): void {
+  mkdirSync(path.dirname(p), { recursive: true });
+  const tmp = `${p}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, JSON.stringify(value, null, 2));
+  renameSync(tmp, p);
+}
+
+/** Read the raw log array, tolerating a missing or malformed file. */
+export function readBootLog(userDataDir: string, limit?: number): BootLogEntry[] {
+  let raw: string;
+  try {
+    raw = readFileSync(logPath(userDataDir), 'utf8');
+  } catch {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const entries = parsed.filter(
+    (e): e is BootLogEntry =>
+      !!e && typeof e === 'object' && typeof (e as BootLogEntry).ts === 'number' && typeof (e as BootLogEntry).phase === 'string',
+  );
+  return typeof limit === 'number' && limit >= 0 ? entries.slice(-limit) : entries;
+}
+
+/**
+ * Append one decision to the log (newest last), capped at {@link MAX_ENTRIES}.
+ * Never throws — a logging failure must not break the boot path.
+ */
+export function appendBootLog(userDataDir: string, entry: Partial<BootLogEntry> & { phase: BootLogPhase }): void {
+  try {
+    const existing = readBootLog(userDataDir);
+    const full: BootLogEntry = { ts: Date.now(), ...entry };
+    const next = [...existing, full].slice(-MAX_ENTRIES);
+    writeAtomic(logPath(userDataDir), next);
+  } catch {
+    /* best effort — observability must never destabilize launch */
+  }
+}
+
+/** True iff a boot log file exists (used by diagnostics to distinguish empty). */
+export function hasBootLog(userDataDir: string): boolean {
+  return existsSync(logPath(userDataDir));
+}

--- a/packages/desktop-host/src/app-update/index.ts
+++ b/packages/desktop-host/src/app-update/index.ts
@@ -8,6 +8,7 @@
  *   - resolve.ts           — the load-time gate + on-disk bundle state (active/bad/breadcrumb)
  *   - native-resolution.ts — make the shell's optional native deps resolvable from a bundle
  *   - stager.ts            — download → verify → atomically install a bundle (Phase 2)
+ *   - boot-log.ts          — persistent boot/update decision log (observability)
  */
 
 export {
@@ -37,10 +38,22 @@ export {
   compareSemver,
   isCompatible,
   resolveActiveBundle,
+  resolveActiveBundleDetailed,
+  type ResolveResult,
+  type ResolveRejectReason,
   recoverFromFailedBoot,
   type BootRecovery,
   pruneBundles,
+  listStagedVersions,
 } from './resolve.js';
+
+export {
+  type BootLogEntry,
+  type BootLogPhase,
+  appendBootLog,
+  readBootLog,
+  hasBootLog,
+} from './boot-log.js';
 
 export { setupNativeResolution } from './native-resolution.js';
 

--- a/packages/desktop-host/src/app-update/resolve-detailed.test.ts
+++ b/packages/desktop-host/src/app-update/resolve-detailed.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { generateKeyPairSync, sign as cryptoSign } from 'node:crypto';
+import path from 'node:path';
+import os from 'node:os';
+
+import { type AppManifest, canonicalManifestBytes } from './manifest';
+import {
+  type ShellInfo,
+  bundleRoot,
+  setActiveVersion,
+  markBad,
+  resolveActiveBundleDetailed,
+  listStagedVersions,
+} from './resolve';
+
+let tmp: string;
+const SHELL: ShellInfo = { electron: '33.4.11', nodeAbi: '115' };
+const keys = generateKeyPairSync('ed25519');
+const PUBKEY = keys.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+
+function manifestFor(version: string, over: Partial<AppManifest> = {}): AppManifest {
+  const base: Omit<AppManifest, 'signature'> = {
+    version,
+    minElectron: '33.0.0',
+    nodeAbi: '115',
+    sha256: 'a'.repeat(64),
+    bundleUrl: 'https://example.com/b.json.gz',
+    ...over,
+  };
+  const signature = cryptoSign(null, canonicalManifestBytes(base), keys.privateKey).toString('base64');
+  return { ...base, signature };
+}
+
+function installBundle(version: string, over: Partial<AppManifest> = {}): void {
+  const root = bundleRoot(tmp, version);
+  mkdirSync(path.join(root, 'dist-electron', 'main'), { recursive: true });
+  writeFileSync(path.join(root, 'dist-electron', 'main', 'index.js'), '// main');
+  writeFileSync(path.join(root, 'manifest.json'), JSON.stringify(manifestFor(version, over)));
+  setActiveVersion(tmp, version);
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(os.tmpdir(), 'app-resolve-detailed-'));
+});
+
+describe('resolveActiveBundleDetailed', () => {
+  it('returns the bundle (no reason) on the happy path', () => {
+    installBundle('0.0.6');
+    const r = resolveActiveBundleDetailed({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL });
+    expect(r.bundle).toEqual({ root: bundleRoot(tmp, '0.0.6'), version: '0.0.6' });
+    expect(r.reason).toBeUndefined();
+  });
+
+  it('names "disabled" when no key is configured', () => {
+    installBundle('0.0.6');
+    expect(resolveActiveBundleDetailed({ userDataDir: tmp, publicKeyPem: '', shell: SHELL })).toEqual({
+      bundle: null,
+      reason: 'disabled',
+    });
+  });
+
+  it('names "no-active" when nothing is staged', () => {
+    expect(
+      resolveActiveBundleDetailed({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL }).reason,
+    ).toBe('no-active');
+  });
+
+  it('names "poisoned" for a bad version', () => {
+    installBundle('0.0.6');
+    markBad(tmp, '0.0.6');
+    setActiveVersion(tmp, '0.0.6'); // markBad clears active; re-point to exercise the poison gate
+    expect(
+      resolveActiveBundleDetailed({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL }).reason,
+    ).toBe('poisoned');
+  });
+
+  it('names "manifest-missing" when the manifest is absent', () => {
+    const root = bundleRoot(tmp, '0.0.6');
+    mkdirSync(path.join(root, 'dist-electron', 'main'), { recursive: true });
+    writeFileSync(path.join(root, 'dist-electron', 'main', 'index.js'), '// main');
+    setActiveVersion(tmp, '0.0.6');
+    expect(
+      resolveActiveBundleDetailed({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL }).reason,
+    ).toBe('manifest-missing');
+  });
+
+  it('names "version-mismatch" when manifest.version ≠ active', () => {
+    const root = bundleRoot(tmp, '0.0.6');
+    mkdirSync(path.join(root, 'dist-electron', 'main'), { recursive: true });
+    writeFileSync(path.join(root, 'dist-electron', 'main', 'index.js'), '// main');
+    writeFileSync(path.join(root, 'manifest.json'), JSON.stringify(manifestFor('9.9.9')));
+    setActiveVersion(tmp, '0.0.6');
+    expect(
+      resolveActiveBundleDetailed({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL }).reason,
+    ).toBe('version-mismatch');
+  });
+
+  it('names "bad-signature" when signed by a different key', () => {
+    const other = generateKeyPairSync('ed25519');
+    const otherPub = other.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+    installBundle('0.0.6');
+    expect(
+      resolveActiveBundleDetailed({ userDataDir: tmp, publicKeyPem: otherPub, shell: SHELL }).reason,
+    ).toBe('bad-signature');
+  });
+
+  it('names "incompatible" when the shell is too old', () => {
+    installBundle('0.0.6', { minElectron: '99.0.0' });
+    expect(
+      resolveActiveBundleDetailed({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL }).reason,
+    ).toBe('incompatible');
+  });
+
+  it('names "main-missing" when dist-electron/main/index.js is absent', () => {
+    const root = bundleRoot(tmp, '0.0.6');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(path.join(root, 'manifest.json'), JSON.stringify(manifestFor('0.0.6')));
+    setActiveVersion(tmp, '0.0.6');
+    expect(
+      resolveActiveBundleDetailed({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL }).reason,
+    ).toBe('main-missing');
+  });
+});
+
+describe('listStagedVersions', () => {
+  it('returns [] when nothing is installed', () => {
+    expect(listStagedVersions(tmp)).toEqual([]);
+  });
+
+  it('lists installed bundle dirs (with a manifest), semver-sorted', () => {
+    installBundle('0.0.6');
+    installBundle('0.0.20');
+    installBundle('0.0.9');
+    expect(listStagedVersions(tmp)).toEqual(['0.0.6', '0.0.9', '0.0.20']);
+  });
+
+  it('ignores dirs without a manifest', () => {
+    installBundle('0.0.6');
+    mkdirSync(bundleRoot(tmp, '0.0.7'), { recursive: true }); // no manifest → not a bundle
+    expect(listStagedVersions(tmp)).toEqual(['0.0.6']);
+  });
+});

--- a/packages/desktop-host/src/app-update/resolve.ts
+++ b/packages/desktop-host/src/app-update/resolve.ts
@@ -188,8 +188,25 @@ export interface ResolveOpts {
   shell: ShellInfo;
 }
 
+/** Why {@link resolveActiveBundleDetailed} declined to load an override bundle.
+ *  Logged to the boot-log so a silent fall-to-floor names its exact cause. */
+export type ResolveRejectReason =
+  | 'disabled' // no signing key baked → self-update off
+  | 'no-active' // nothing staged
+  | 'poisoned' // active version is on the bad list
+  | 'manifest-missing' // no manifest.json under the bundle dir
+  | 'manifest-malformed' // manifest failed shape checks
+  | 'version-mismatch' // manifest.version ≠ active version
+  | 'bad-signature' // Ed25519 verification failed
+  | 'incompatible' // Electron/ABI floor not met (needs a shell update)
+  | 'main-missing'; // dist-electron/main/index.js absent on disk
+
+export type ResolveResult =
+  | { bundle: ResolvedBundle; reason?: undefined }
+  | { bundle: null; reason: ResolveRejectReason };
+
 /**
- * The gate. Returns the override bundle to load, or null to use the floor.
+ * The gate, with the reject reason exposed for observability.
  *
  * Order matters — cheapest + most-decisive checks first, signature before any
  * trust is extended, compatibility last:
@@ -197,26 +214,35 @@ export interface ResolveOpts {
  *   well-formed, and bound to the active version → signature valid →
  *   Electron/ABI compatible → real main exists on disk.
  */
-export function resolveActiveBundle(opts: ResolveOpts): ResolvedBundle | null {
+export function resolveActiveBundleDetailed(opts: ResolveOpts): ResolveResult {
   const { userDataDir, publicKeyPem, shell } = opts;
-  if (!publicKeyPem) return null; // self-update disabled → floor
+  if (!publicKeyPem) return { bundle: null, reason: 'disabled' };
 
   const version = readActiveVersion(userDataDir);
-  if (!version) return null;
-  if (readBadVersions(userDataDir).has(version)) return null;
+  if (!version) return { bundle: null, reason: 'no-active' };
+  if (readBadVersions(userDataDir).has(version)) return { bundle: null, reason: 'poisoned' };
 
   const root = bundleRoot(userDataDir, version);
   const manifestRaw = tryRead(path.join(root, 'manifest.json'));
-  if (!manifestRaw) return null;
+  if (!manifestRaw) return { bundle: null, reason: 'manifest-missing' };
   const manifest = parseManifest(manifestRaw);
-  if (!manifest || manifest.version !== version) return null;
-  if (!verifyManifestSignature(manifest, publicKeyPem)) return null;
-  if (!isCompatible(manifest, shell)) return null;
+  if (!manifest) return { bundle: null, reason: 'manifest-malformed' };
+  if (manifest.version !== version) return { bundle: null, reason: 'version-mismatch' };
+  if (!verifyManifestSignature(manifest, publicKeyPem)) return { bundle: null, reason: 'bad-signature' };
+  if (!isCompatible(manifest, shell)) return { bundle: null, reason: 'incompatible' };
 
   const mainEntry = path.join(root, 'dist-electron', 'main', 'index.js');
-  if (!existsSync(mainEntry)) return null;
+  if (!existsSync(mainEntry)) return { bundle: null, reason: 'main-missing' };
 
-  return { root, version };
+  return { bundle: { root, version } };
+}
+
+/**
+ * The gate. Returns the override bundle to load, or null to use the floor.
+ * Thin wrapper over {@link resolveActiveBundleDetailed} that drops the reason.
+ */
+export function resolveActiveBundle(opts: ResolveOpts): ResolvedBundle | null {
+  return resolveActiveBundleDetailed(opts).bundle;
 }
 
 export interface BootRecovery {
@@ -287,4 +313,20 @@ export function pruneBundles(userDataDir: string, keep: ReadonlyArray<string>): 
       /* best effort */
     }
   }
+}
+
+/** Installed bundle version dirs currently present under `<userData>/app/`
+ *  (those with a `manifest.json`). Read-only — used by the diagnostics IPC.
+ *  Tolerates a missing/partial `app/` dir. */
+export function listStagedVersions(userDataDir: string): string[] {
+  const dir = appUpdateDir(userDataDir);
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((name) => isSafeVersion(name) && existsSync(path.join(dir, name, 'manifest.json')))
+    .sort((a, b) => compareSemver(a, b));
 }

--- a/packages/desktop-host/src/ipc/update.ts
+++ b/packages/desktop-host/src/ipc/update.ts
@@ -20,6 +20,11 @@ import {
   markConfirmed,
   pruneBundles,
   readActiveVersion,
+  readConfirmed,
+  readBadVersions,
+  listStagedVersions,
+  appendBootLog,
+  readBootLog,
 } from '../app-update/index.js';
 import { sendEvent } from '../send-event';
 import { handle } from './shared';
@@ -134,8 +139,48 @@ export function registerUpdateHandlers(config: UpdateConfig): void {
     // The running override (if any) reached a healthy render — confirm it so the
     // boot-probe doesn't poison it. No-op on the bundled floor.
     const version = process.env.MOXXY_APP_BUNDLE_VERSION;
-    if (version && readActiveVersion(app.getPath('userData')) === version) {
-      markConfirmed(app.getPath('userData'), version);
+    if (!version) return;
+    const userData = app.getPath('userData');
+    const active = readActiveVersion(userData);
+    if (active === version) {
+      markConfirmed(userData, version);
+      appendBootLog(userData, { phase: 'confirm', picked: version, ...shellInfo() });
+    } else {
+      // The confirm arrived but the active pointer no longer matches the running
+      // bundle (e.g. a concurrent re-stage) — the probe would revert a bundle the
+      // user is actively running. Record it instead of silently dropping it.
+      appendBootLog(userData, {
+        phase: 'confirm',
+        picked: version,
+        reason: `active-pointer-mismatch (active=${active ?? 'none'})`,
+        ...shellInfo(),
+      });
     }
+  });
+
+  handle('app.bootHeartbeatFailed', async (args) => {
+    // The renderer couldn't deliver its boot heartbeat — make that visible so a
+    // confirm-path failure is diagnosable rather than masquerading as a revert.
+    const version = process.env.MOXXY_APP_BUNDLE_VERSION;
+    if (!version) return;
+    appendBootLog(app.getPath('userData'), {
+      phase: 'confirm',
+      picked: version,
+      reason: 'heartbeat-delivery-failed',
+      error: args.error,
+      ...shellInfo(),
+    });
+  });
+
+  handle('app.updateDiagnostics', async () => {
+    const userData = app.getPath('userData');
+    return {
+      running: runningVersion(),
+      active: readActiveVersion(userData),
+      confirmed: readConfirmed(userData),
+      bad: [...readBadVersions(userData)],
+      staged: listStagedVersions(userData),
+      log: readBootLog(userData, 30),
+    };
   });
 }

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -297,6 +297,37 @@ export interface AppUpdateProgress {
   message?: string;
 }
 
+/** One recorded boot/update decision (mirrors `BootLogEntry` in
+ *  `@moxxy/desktop-host/app-update`). The renderer only ever displays these. */
+export interface AppBootLogEntry {
+  ts: number;
+  phase: 'boot' | 'recover' | 'probe' | 'confirm' | 'load-error';
+  picked?: string;
+  reason?: string;
+  recoveredTo?: string;
+  error?: string;
+  electron?: string;
+  abi?: string;
+}
+
+/** Self-update troubleshooting snapshot: the on-disk pointer state plus the
+ *  recent boot-decision log, so a "downloaded but reverted" report is legible
+ *  (the Updates → Diagnostics panel renders + copies this). */
+export interface AppUpdateDiagnostics {
+  /** Bundle version the running process loaded (override or floor). */
+  running: string;
+  /** `active.json` pointer — the version the bootstrap intends to load next. */
+  active: string | null;
+  /** Last version that confirmed a healthy render. */
+  confirmed: string | null;
+  /** Versions poisoned by a failed/unconfirmed boot. */
+  bad: string[];
+  /** Bundle version dirs currently present under `<userData>/app/`. */
+  staged: string[];
+  /** Most-recent-last boot-decision entries. */
+  log: AppBootLogEntry[];
+}
+
 // ---------- Events the renderer subscribes to ------------------------------
 
 /**
@@ -380,6 +411,12 @@ export interface IpcCommands {
    *  the boot-probe so a hot-updated bundle is marked healthy (no-op on the
    *  bundled floor). */
   'app.appBooted': () => Promise<void>;
+  /** Renderer → main: the boot heartbeat could not be delivered (all retries
+   *  failed). Recorded to the boot-log so a confirm-path failure is visible
+   *  rather than silently letting the probe revert a healthy bundle. */
+  'app.bootHeartbeatFailed': (args: { error: string }) => Promise<void>;
+  /** Self-update troubleshooting snapshot (pointer state + recent boot log). */
+  'app.updateDiagnostics': () => Promise<AppUpdateDiagnostics>;
 
   'onboarding.status': () => Promise<OnboardingStatus>;
   /** Probe Node.js — used by the first wizard step before we offer

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -64,6 +64,10 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
   'app.updateDashboard': z.undefined(),
   'app.relaunch': z.undefined(),
   'app.appBooted': z.undefined(),
+  'app.updateDiagnostics': z.undefined(),
+  // Renderer-reported confirm failure — bound the message so a hostile renderer
+  // can't bloat the on-disk boot-log.
+  'app.bootHeartbeatFailed': z.object({ error: z.string().max(2048) }),
   'onboarding.openExternal': z.object({ url: httpUrl }),
   'onboarding.saveProviderKey': z.object({
     provider: providerName,

--- a/packages/plugin-cli/src/components/StatusLine.tsx
+++ b/packages/plugin-cli/src/components/StatusLine.tsx
@@ -33,6 +33,10 @@ export interface StatusLineProps {
   readonly contextUsed?: number;
   /** Active model's context window size. Required for the bar. */
   readonly contextWindow?: number;
+  /** Running CLI version — shown as a dim chip on the far right. */
+  readonly version?: string;
+  /** A newer published version, if any — turns the chip into an update hint. */
+  readonly updateLatest?: string;
 }
 
 /**
@@ -52,6 +56,8 @@ export const StatusLine: React.FC<StatusLineProps> = ({
   mcp,
   contextUsed,
   contextWindow,
+  version,
+  updateLatest,
 }) => {
   const busy = busyStartedAt != null;
   const showQueue = (queueCount ?? 0) > 0;
@@ -107,6 +113,16 @@ export const StatusLine: React.FC<StatusLineProps> = ({
           <>
             <Text dimColor>{`  ${Glyphs.midDot}  `}</Text>
             <ContextMeter used={contextUsed ?? 0} total={contextWindow!} />
+          </>
+        ) : null}
+        {version ? (
+          <>
+            <Text dimColor>{`  ${Glyphs.midDot}  `}</Text>
+            {updateLatest ? (
+              <Text color="yellow">{`v${version} ${Glyphs.contextUp}${updateLatest}`}</Text>
+            ) : (
+              <Text dimColor>{`v${version}`}</Text>
+            )}
           </>
         ) : null}
       </Box>

--- a/packages/plugin-cli/src/session/BootShell.tsx
+++ b/packages/plugin-cli/src/session/BootShell.tsx
@@ -20,6 +20,8 @@ export const InteractiveSession: React.FC<InteractiveSessionProps> = ({
   bootstrap,
   registerInteractiveResolver,
   model,
+  version,
+  updateAvailable,
   resumed,
 }) => {
   const [session, setSession] = useState<Session | null>(eagerSession ?? null);
@@ -112,6 +114,8 @@ export const InteractiveSession: React.FC<InteractiveSessionProps> = ({
       registerInteractiveResolver={registerInteractiveResolver}
       {...(initialPrompt ? { initialPrompt } : {})}
       {...(model ? { model } : {})}
+      {...(version ? { version } : {})}
+      {...(updateAvailable ? { updateAvailable } : {})}
     />
   );
 };

--- a/packages/plugin-cli/src/session/SessionView.tsx
+++ b/packages/plugin-cli/src/session/SessionView.tsx
@@ -35,6 +35,7 @@ interface SessionViewProps {
   readonly registerInteractiveResolver: InteractiveSessionProps['registerInteractiveResolver'];
   readonly model?: string;
   readonly version?: string;
+  readonly updateAvailable?: { readonly latest: string };
   /**
    * Prompt typed on the splash screen. Submitted automatically on mount
    * so the user's first message kicks off the first turn — they don't
@@ -47,6 +48,8 @@ export const SessionView: React.FC<SessionViewProps> = ({
   session,
   registerInteractiveResolver,
   model,
+  version,
+  updateAvailable,
   initialPrompt,
 }) => {
   const { exit } = useApp();
@@ -291,6 +294,17 @@ export const SessionView: React.FC<SessionViewProps> = ({
     // root lint config; re-add a disable directive here if it is.)
   }, [initialPrompt]);
 
+  // One-line "update available" banner, shown once on mount via the same
+  // auto-dismissing notice strip as voice/queue messages (clears on first
+  // submit). Skipped when an initial prompt is already running — that turn
+  // would clear it instantly anyway.
+  const firedUpdateNotice = useRef(false);
+  useEffect(() => {
+    if (firedUpdateNotice.current || !updateAvailable || initialPrompt) return;
+    firedUpdateNotice.current = true;
+    setSystemNotice(`✨ moxxy ${updateAvailable.latest} available — run \`moxxy update\``);
+  }, [updateAvailable, initialPrompt]);
+
   return (
     <Box flexDirection="column">
       <ChatView
@@ -362,6 +376,8 @@ export const SessionView: React.FC<SessionViewProps> = ({
         mcp={mcpStatus}
         contextUsed={contextUsed}
         {...(contextWindow ? { contextWindow } : {})}
+        {...(version ? { version } : {})}
+        {...(updateAvailable ? { updateLatest: updateAvailable.latest } : {})}
       />
     </Box>
   );

--- a/packages/plugin-cli/src/session/props.ts
+++ b/packages/plugin-cli/src/session/props.ts
@@ -48,6 +48,12 @@ export interface InteractiveSessionProps {
    */
   readonly version?: string;
   /**
+   * A newer published `@moxxy/cli` the caller discovered (cheaply, from a
+   * cached check). When set, the chat view shows a one-line, auto-dismissing
+   * "update available" notice. Omitted ⇒ no banner.
+   */
+  readonly updateAvailable?: { readonly latest: string };
+  /**
    * Skip the splash screen and land directly in the chat view. Used by
    * `moxxy resume` so the seeded event log is visible immediately
    * without the user having to type a first prompt.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -21,8 +21,8 @@
   <a href="https://www.typescriptlang.org">
     <img src="https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white" alt="TypeScript" />
   </a>
-  <a href="https://github.com/moxxy-ai/new_moxxy/actions/workflows/ci.yml">
-    <img src="https://github.com/moxxy-ai/new_moxxy/actions/workflows/ci.yml/badge.svg" alt="CI" />
+  <a href="https://github.com/moxxy-ai/moxxy/actions/workflows/ci.yml">
+    <img src="https://github.com/moxxy-ai/moxxy/actions/workflows/ci.yml/badge.svg" alt="CI" />
   </a>
 </p>
 
@@ -220,7 +220,7 @@ export default definePlugin({
 });
 ```
 
-Per-block author guides for skill, plugin, tool, channel, provider, loop strategy, compactor, and cache strategy live in the monorepo at [`.claude/agents/`](https://github.com/moxxy-ai/new_moxxy/tree/main/.claude/agents).
+Per-block author guides for skill, plugin, tool, channel, provider, loop strategy, compactor, and cache strategy live in the monorepo at [`.claude/agents/`](https://github.com/moxxy-ai/moxxy/tree/main/.claude/agents).
 
 ## Architectural rules
 


### PR DESCRIPTION
## Summary

Three update-related asks, built together, plus a README redesign.

### `moxxy update` (CLI)
A real self-upgrade command. Checks the npm registry, detects how the CLI was installed (npm / pnpm / yarn / bun, global or local), and runs the matching upgrade after a confirm. `--check`/`--dry-run` report-only, `--yes` skips the prompt; a source checkout gets git advice instead of an install. Backed by a shared, fail-soft version-check module (`registry.ts` / `check.ts` / `detect-install.ts`) with a 12h on-disk cache.

### TUI "update available" banner
Surfaces a newer published `@moxxy/cli` as a one-line, auto-dismissing notice and shows the running version in the status line. The check is cache-backed and fully non-blocking on startup. Also fixes the `version` prop being silently dropped at `BootShell` before it reached the view.

### Observable desktop self-update
The reported failure ("downloads, relaunches, still old") lives in the runtime confirmation path — the publishing side is provably healthy (latest `desktop-v*` is signed and verifies against the baked key; the resolve/stage/build path is test-covered). This made the previously **silent** fall-back-to-the-floor observable:

- persisted boot-decision log at `<userData>/app/boot-log.json`
- a reject **reason** per gate (`resolveActiveBundleDetailed`)
- `app.updateDiagnostics` IPC + a **Settings → Dashboard → Diagnostics** readout (copyable)
- hardened renderer heartbeat (retry + `app.bootHeartbeatFailed`) so a flaky confirm can't let the 15s boot-probe revert a healthy update

> Honest caveat: a packaged two-version self-update can't be fully reproduced from a dev box, so this leads with observability + the highest-probability hardening. Once shipped, the Diagnostics panel / `boot-log.json` will name the exact gate or import error on a real build, turning the remaining piece into a known cause (tracked as TECH_DEBT #10).

### README
Redesigned hero (demo slot → "Why moxxy" → "See it in action" → merged get-started), README media under `assets/`, and fixed **all** stale `moxxy-ai/new_moxxy` → `moxxy-ai/moxxy` references across README / CLI README / SDK README / docs site.

The three demo slots are `placehold.co` placeholders to be swapped for real GIFs — see `assets/README.md` for the spec of each.

## Tests & checks
`build` 52/52 · `typecheck` 101/101 · `check:deps` clean · `lint` 0 errors · `test` 99/99. New tests: `boot-log`, `resolveActiveBundleDetailed`, `listStagedVersions`, and the CLI update `check`/`detect`/command suites. `moxxy update --check` verified live (`v0.5.3 → v0.5.5`). Changeset included (`@moxxy/cli` minor + desktop packages, so a new `desktop-v*` release carrying the fix is cut). TECH_DEBT journal refreshed.
