### PR TITLE
fix(desktop): confirm hot-update health from main (DOM), not the renderer heartbeat

### DIFF
--- a/.changeset/desktop-update-confirm.md
+++ b/.changeset/desktop-update-confirm.md
@@ -1,0 +1,15 @@
+---
+"@moxxy/desktop": patch
+---
+
+Fix desktop self-update never sticking ("downloads but stays on the old version").
+
+The boot-probe required the renderer's `app.appBooted` IPC heartbeat to land within
+15s to mark a hot-updated bundle healthy; in packaged builds that heartbeat doesn't
+reliably land, so the probe poisoned **every** healthy update and reverted to the
+floor (confirmed from on-disk state: `bad.json` had poisoned every staged version and
+`confirmed.json` never existed). The probe now confirms a healthy render from the
+**main process** by inspecting the renderer DOM — `index.html` ships a static
+`#splash-fallback` inside `#root` that React replaces on mount, so its absence is a
+renderer-cooperation-free health signal. The IPC heartbeat is kept only as a fast
+path; a genuine white-screen (never renders) is still poisoned and reverted.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -43,35 +43,32 @@ yet compile against a bare `RemoteSession`. Retype the handler params to the min
 work, not standalone. (The `RemoteSession` casts at `desktop-host/src/ipc/session.ts:105`
 and `ipc/shared.ts:164` are the same seam — see P3.)
 
-### 2. Desktop persists every conversation twice — pick one source of truth — ⚠️ PARTIALLY DONE
-**Found 2026-06-08 (the "NDJSON-vs-replay redundancy" follow-up).** Every committed event
-is written to disk in **two** independent stores:
-- runner session log — `~/.moxxy/sessions/<id>.jsonl`, replayed in full on every attach
-  (`runner/src/server.ts:184` — always replays from seq 0);
+### 2. Desktop persists every conversation twice — pick one source of truth — 🔴 NEW
+**Found 2026-06-08 (the "NDJSON-vs-replay redundancy" follow-up, now characterized).**
+Every committed event is written to disk in **two** independent stores:
+- runner session log — `~/.moxxy/sessions/<id>.jsonl`, replayed on attach
+  (`runner/src/server.ts:184`; `desktop-host/src/runner-supervisor.ts:79,435`);
 - desktop NDJSON chat-log — `~/.moxxy/chats/<workspaceId>.jsonl`
-  (`desktop-host/src/chat-log.ts`), the renderer's windowed mirror.
+  (`desktop-host/src/chat-log.ts:30-33`), loaded by
+  `apps/desktop/src/lib/chat-store/store.ts:187`.
 
-**Fixed (2026-06-08):** the **unbounded NDJSON growth** defect. Because the runner replays
-the full history on every restart and the renderer re-appends each replayed event, the
-NDJSON log used to grow by a complete copy of the conversation per restart — and since
-`loadSegment`'s cursor is a line index, the doubled file also corrupted scroll-up
-pagination. `appendEvents` is now **idempotent by event id** (lazy file-path-keyed id cache),
-so the log holds one copy and its cursors stay stable. +5 chat-log tests.
+Two concrete defects fall out of the redundancy:
+- **Desync window on `/new`.** Reset wipes both via two separate IPC calls
+  (`CommandPalette.tsx:91-92`: `chatStore.clear()` then `session.newSession`). If the
+  second fails or the app dies between them, the renderer is cleared but the runner is
+  still primed → old context resurrects on the next turn/restart.
+- **Unbounded NDJSON growth.** On restart `seenIds` starts empty; the runner replays its
+  full history on attach; each replayed event misses `seenIds`, so `dispatch` re-appends
+  it to the NDJSON log (`store.ts:317-326`). `loadOlder` dedups only on read
+  (`store.ts:240-243`), so the on-disk file bloats by a full copy every restart.
 
-**Remaining (the real decision):** the redundancy itself. The runner replay already
-delivers the complete history to the renderer on every attach, so the desktop NDJSON store
-is arguably entirely redundant — dropping it (read history from the runner replay only)
-would also kill the redundant on-restart append IPC and the `/new` desync below. Counter-risk:
-legacy localStorage→NDJSON-migrated chats may live ONLY in NDJSON, not in any runner session
-log, so a naive drop loses early-adopter history. **Needs a product call + desktop-app
-verification — not a mechanical change.**
-
-**Also remaining (lives on `fix/desktop-resume-session`, not yet on main):** the **`/new`
-desync window**. Reset wipes the renderer + NDJSON and resets the runner via separate IPC
-calls; if one fails or the app dies between them, the two desync and old context resurrects.
-Make `/new` reset the runner FIRST and only clear the renderer/NDJSON on success (or a single
-atomic IPC). Fold this in when that branch lands. The renderer `chat-store/store.ts`
-persistence path is also still untested (`store.test.ts` absent).
+**Action:** decide the single source of truth. The runner already persists + replays the
+full history, so the desktop NDJSON store is arguably entirely redundant — either drop it
+and read from the runner replay, or stop re-persisting replayed events and make `/new` a
+single atomic reset. **Whichever way: this path has zero tests** — no `store.test.ts`, and
+`resetSession`/`newSession`/`deleteSession` in `runner-supervisor.ts` are uncovered. Add
+tests for append-on-dispatch, the restart double-append, `loadOlder` dedup, and the
+`/new` dual-clear as part of the fix.
 
 ---
 
@@ -109,17 +106,29 @@ raw throws are internal registry/broker invariants that should stay plain):
   surfaced to the renderer as `error` strings, and the new boot-log now records a structured
   reject **reason** per gate (see #10), which covers the diagnosability this bullet was after.
 
+### 6. Mode loop scaffolding is copy-pasted across mode-default and mode-goal — 🔴 NEW
+**Found 2026-06-08.** The mode-slimming PR (#93) collapsed the mode list but left the
+per-iteration loop duplicated: `mode-default/src/turn-iterator.ts:168-272` vs
+`mode-goal/src/goal-loop.ts:333-436`. `executeToolUses` differs only in comments/whitespace;
+`emitRequestsAndDetectStuck` differs only in error strings; the provider-request/response +
+overflow/reactive-compaction block (`turn-iterator.ts:67-127` vs `goal-loop.ts:128-182`)
+is near-identical. Critically, the **orphan-tool-result / stuck-loop fix** (load-bearing —
+the comments literally say "See the same fix in mode-tool-use") is copy-pasted, so any fix
+must be hand-mirrored. **Action:** hoist the shared iteration scaffolding into an SDK
+`mode-helpers` building block (per the repo's "prefer swappable blocks" guideline) so both
+modes compose it. **Severity med.**
+
 ---
 
 ## P3 — Low / per-package nits
 
-### 6. plugin-memory caches embeddings via a parallel `EmbeddingIndex` — OPEN
+### 7. plugin-memory caches embeddings via a parallel `EmbeddingIndex` — OPEN
 **Cross-cut 1.11.** `plugin-memory/src/store.ts:6,88-96` still uses its own `EmbeddingIndex`
 cache instead of the SDK `CachedEmbeddingProvider`. **Deferred:** now that the atomic-write +
 recall-race bugs are fixed, this is pure dedup of caching logic over a subtle mutex-guarded
 recall path — low value, real risk. Fold in only if the recall path is touched anyway.
 
-### 7. Channel→core prod dependency — OPEN
+### 8. Channel→core prod dependency — OPEN
 `plugin-cli`/`plugin-telegram` keep real `@moxxy/core` prod imports (`savePreferences`,
 `clearUsageStats`, `newTurnId`, `loadUsageStats`, `PermissionEngine` — e.g.
 `plugin-cli/src/session/run-slash.ts:2`, `plugin-telegram/src/channel/turn-runner.ts:2`).
@@ -127,7 +136,7 @@ To fully sever channel→core, hoist these provider-neutral helpers into `@moxxy
 (cross-cut 2.14). (`plugin-subagents`/`plugin-view` keep core as a **dev**Dep only — their
 `*.test.ts` import core; correct, leave them.)
 
-### 8. Small casts / hardcoded values — NEW, low
+### 9. Small casts / hardcoded values — NEW, low
 - **Type the exec allowlist.** `plugin-security/src/broker.ts:343` reads
   `(caps as unknown as { commands? }).commands` — a forward-compat field not on
   `CapabilitySpec`. It gates the **exec allowlist**, so it's worth typing properly on
@@ -141,20 +150,21 @@ To fully sever channel→core, hoist these provider-neutral helpers into `@moxxy
   `plugin-provider-claude-code/src/index.ts:11`, so the subscription provider inherits the
   API-key provider's model set verbatim. Drift-prone; should be derived/config.
 
-### 10. Desktop self-update: confirm the runtime root cause of "downloads but reverts" — 🔴 NEW
-**Found 2026-06-09.** The publishing side is provably healthy (latest `desktop-v*` is signed
-+ verifies against the baked key; the pure resolve/stage/build path is test-covered). The
-user-reported failure — *updates, relaunches, still old* — therefore lives in the runtime
-confirmation path, which used to fall back to the floor **silently** (`console.*` only, in a
-packaged app no one sees). This pass made it observable: a persisted boot-decision log
-(`app-update/boot-log.ts` → `<userData>/app/boot-log.json`), a reject **reason** per gate
-(`resolveActiveBundleDetailed`), an `app.updateDiagnostics` IPC + Settings → Dashboard
-readout, and a hardened renderer heartbeat (retry + `app.bootHeartbeatFailed`). **Remaining:**
-confirm the actual cause on a real packaged two-version update via the new Diagnostics panel
-(suspects, in order: heartbeat never confirmed → 15s boot-probe revert; staged-main import
-throw; a resolve gate). Once the log names it on a real build, apply the targeted fix and
-prune whichever of the belt/braces (cross-launch recovery vs. in-session probe vs. heartbeat
-retry) is then redundant. **Severity med** (can't be closed from the dev box — needs a build).
+### 10. Desktop self-update "downloads but reverts" — ROOT-CAUSED + FIXED, pending on-build verify
+**Found + fixed 2026-06-09.** Root-caused from the on-disk state on a real failing machine
+(no boot-log needed): in `<userData>/app/`, `bad.json` had poisoned **every** staged version
+(0.0.19/0.0.25/0.0.28/0.0.29) and `confirmed.json` had **never** existed — even 0.0.28, which
+runs fine *as the installed floor*, was poisoned when run as an override. So the bug was the
+**confirm step**: the boot-probe required the renderer's `app.appBooted` IPC heartbeat to land
+within 15s, and in packaged builds that heartbeat doesn't reliably land → the probe poisoned
+healthy bundles → self-update never stuck. **Fix:** `armBootProbe` now confirms from the MAIN
+process by polling the renderer DOM (`index.html` ships a static `#splash-fallback` inside
+`#root` that React replaces on mount — so "splash-fallback gone" is a renderer-cooperation-free
+health signal); the IPC heartbeat is kept only as a fast path. Plus the observability from this
+pass (boot-log, reject reasons, `app.updateDiagnostics` + Diagnostics UI). **Remaining:** verify
+on a real two-version update that 0.0.30+ now sticks (the fix lives in the *override's* main, so
+a user on the broken 0.0.28 floor recovers simply by updating to a fixed release). Once verified,
+consider dropping the now-redundant renderer-heartbeat path. **Severity med** (needs a build to close).
 
 ---
 
@@ -163,13 +173,6 @@ retry) is then redundant. **Severity med** (can't be closed from the dev box —
 Collapsed from full write-ups; each was re-checked against `HEAD` and confirmed — no
 regressions. Restore the detail from git history (`TECH_DEBT.md` @ `b014c3a`) if needed.
 
-- **Mode loop scaffolding hoisted to the SDK** (2026-06-08, was P2 #6). The load-bearing
-  stuck-loop orphan-result fix + the tool-batch abort path were copy-pasted across
-  `mode-default` and `mode-goal` (a fix to one had to be hand-mirrored). Both now compose
-  `executeToolUses` + `emitRequestsAndDetectStuck` from `@moxxy/sdk` (`tool-dispatch.ts`),
-  parameterized by a `StuckLoopReport` for each mode's wording + goal's `goal_stuck` event.
-  Pure refactor, no behavior change; mode-default 9/9 + mode-goal 10/10 green. (The outer
-  loop bodies stay per-mode by design — different strategies.)
 - **plugins-admin CLI install hardening + dedup** (2026-06-08, was P2 #7/#8). The imperative
   `installPluginPackage`/`removePluginPackage` now reject a flag-like spec via
   `assertSafeNpmSpec` (a leading `-` is argument injection) — and crucially still accept the

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -33,14 +33,13 @@ import {
   installMediaPermissions,
   lockDownNavigation,
   isSafeExternalUrl,
-  clerkFrontendApiHost,
   preferredCliEntry,
   ensureDesktopVaultKey,
   activateManagedNode,
 } from '@moxxy/desktop-host';
 
 import { BUNDLED_UPDATE_PUBLIC_KEY } from './update-key.js';
-import { readConfirmed, markBad, appendBootLog } from '@moxxy/desktop-host/app-update';
+import { readConfirmed, markConfirmed, markBad, appendBootLog } from '@moxxy/desktop-host/app-update';
 import { initShellUpdater } from './shell-updater.js';
 
 // In a packaged build there is no global `moxxy` (and a GUI launch has no
@@ -59,16 +58,6 @@ import { ipcMain, Tray, Menu, nativeImage, globalShortcut, session, shell, syste
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const isDev = !!process.env['ELECTRON_RENDERER_URL'];
-
-// The Clerk publishable key, baked into the main bundle at build time by
-// electron-vite's `define` (see electron.vite.config.ts) from the same
-// VITE_CLERK_PUBLISHABLE_KEY the renderer reads. The main process needs it to
-// allow the instance's prod Frontend API host through the CSP + OAuth popup
-// allow-list — a `pk_live_` key serves clerk-js from the instance's own
-// domain, which the static dev/test hosts don't cover. '' when unset.
-declare const __CLERK_PUBLISHABLE_KEY__: string;
-const CLERK_PUBLISHABLE_KEY =
-  typeof __CLERK_PUBLISHABLE_KEY__ === 'string' ? __CLERK_PUBLISHABLE_KEY__ : '';
 
 let pool: RunnerPool | null = null;
 let mainWindow: BrowserWindow | null = null;
@@ -93,24 +82,6 @@ async function createWindow(): Promise<void> {
     /^https:\/\/appleid\.apple\.com$/,
     /^https:\/\/github\.com$/,
   ];
-  // A `pk_live_` instance runs OAuth through its OWN Frontend API host
-  // (e.g. clerk.acme.com) and account portal (accounts.acme.com), neither
-  // covered above — add the exact host plus a wildcard on its parent domain
-  // so the prod sign-in popup isn't denied. Test keys resolve to a host
-  // already matched above, so this adds nothing for them.
-  const clerkFapiHost = clerkFrontendApiHost(CLERK_PUBLISHABLE_KEY);
-  if (
-    clerkFapiHost &&
-    !clerkFapiHost.endsWith('.clerk.accounts.dev') &&
-    !clerkFapiHost.endsWith('.clerk.com')
-  ) {
-    const reEsc = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    OAUTH_HOST_PATTERNS.push(new RegExp(`^https://${reEsc(clerkFapiHost)}$`));
-    const parent = clerkFapiHost.split('.').slice(1).join('.');
-    if (parent.split('.').length >= 2) {
-      OAUTH_HOST_PATTERNS.push(new RegExp(`^https://(?:[a-z0-9-]+\\.)+${reEsc(parent)}$`));
-    }
-  }
 
   mainWindow = new BrowserWindow({
     title: 'MoxxyAI Workspaces',
@@ -455,41 +426,80 @@ function installApplicationMenu(
 
 let trayInstance: Tray | null = null;
 
-/** How long a hot-updated bundle has to confirm a healthy render before the
- *  probe assumes it white-screened and reverts to the floor. Generous so a slow
- *  cold start / Clerk network round-trip can't false-trip it. */
+/** How long a hot-updated bundle has to prove a healthy render before the probe
+ *  assumes it white-screened and reverts to the floor. Generous so a slow cold
+ *  start / Clerk network round-trip can't false-trip it. */
 const BOOT_PROBE_TIMEOUT_MS = 15_000;
+/** How often the probe polls the renderer DOM for a healthy mount. */
+const BOOT_PROBE_POLL_MS = 1_500;
 
 /**
- * In-session safety net for a hot-updated bundle: if the renderer loads but its
- * React tree never mounts (white-screen) — so `app.appBooted` never fires and no
- * `confirmed.json` lands — poison this version and relaunch. The bootstrap then
- * picks the previous-good bundle (or the floor). A no-op on the bundled floor
- * (no override version), and on the bundled floor we never re-arm, so there's no
- * relaunch loop. The cross-launch `recoverFromFailedBoot` is the belt to this
- * braces — either one alone recovers the app.
+ * In-session safety net for a hot-updated bundle: confirm it reached a healthy
+ * render, else poison it and relaunch onto the previous-good bundle (or floor).
+ *
+ * Health is judged from the MAIN process by inspecting the renderer DOM — NOT by
+ * waiting for the renderer's `app.appBooted` IPC heartbeat. That heartbeat proved
+ * unreliable in packaged builds: it could fail to land on a perfectly healthy
+ * bundle, so the old "no heartbeat in 15s ⇒ poison" logic poisoned *every* update
+ * (see the boot-log / `bad.json` evidence) and self-update never stuck. The DOM
+ * check has no such dependency: `index.html` ships a static `#splash-fallback`
+ * inside `#root`, and React replaces it on mount — so "`#splash-fallback` is gone"
+ * is a direct, renderer-cooperation-free signal that the app rendered. The IPC
+ * heartbeat (`app.appBooted` → `confirmed.json`) is kept only as a fast path.
+ *
+ * No-op on the bundled floor (no override version), so there's no relaunch loop.
+ * The cross-launch `recoverFromFailedBoot` is the belt to this braces.
  */
 function armBootProbe(window: BrowserWindow): void {
   const version = process.env.MOXXY_APP_BUNDLE_VERSION;
   if (!version) return; // running the floor — nothing to probe
   const userData = app.getPath('userData');
   const shell = { electron: process.versions.electron, nodeAbi: process.versions.modules ?? '' };
+
   window.webContents.once('did-finish-load', () => {
-    setTimeout(() => {
+    const deadline = Date.now() + BOOT_PROBE_TIMEOUT_MS;
+
+    const reactMounted = async (): Promise<boolean> =>
+      window.webContents
+        .executeJavaScript(
+          // True once React has taken over #root (it replaces the static
+          // #splash-fallback on mount). Defensive: never throws into the probe.
+          "(()=>{try{return !!document.getElementById('root')" +
+            " && !document.getElementById('splash-fallback')" +
+            " && document.getElementById('root').childElementCount>0;}catch(e){return false;}})()",
+          true,
+        )
+        .catch(() => false);
+
+    const tick = async (): Promise<void> => {
       if (window.isDestroyed()) return;
-      if (readConfirmed(userData) === version) return; // confirmed healthy
+      // Fast path: the renderer's heartbeat already confirmed it.
+      if (readConfirmed(userData) === version) return;
+
+      if (await reactMounted()) {
+        // The bundle rendered — confirm from the main process, independent of the
+        // (flaky) renderer heartbeat that was poisoning healthy updates.
+        try {
+          markConfirmed(userData, version);
+        } catch {
+          /* best effort */
+        }
+        appendBootLog(userData, { phase: 'confirm', picked: version, reason: 'main-side-dom', ...shell });
+        return;
+      }
+
+      if (window.isDestroyed() || readConfirmed(userData) === version) return;
+      if (Date.now() < deadline) {
+        setTimeout(() => void tick(), BOOT_PROBE_POLL_MS);
+        return;
+      }
+
+      // Never rendered within the window — treat as a real white-screen.
       console.error(
-        `[moxxy] boot-probe: bundle ${version} did not confirm a healthy render in ` +
+        `[moxxy] boot-probe: bundle ${version} never rendered within ` +
           `${BOOT_PROBE_TIMEOUT_MS}ms; reverting to the previous bundle`,
       );
-      // Record the revert BEFORE relaunching so the next launch's Diagnostics
-      // panel shows why the update didn't stick (the renderer never confirmed).
-      appendBootLog(userData, {
-        phase: 'probe',
-        picked: version,
-        reason: 'no-confirm-within-timeout',
-        ...shell,
-      });
+      appendBootLog(userData, { phase: 'probe', picked: version, reason: 'no-render-within-timeout', ...shell });
       try {
         markBad(userData, version);
       } catch {
@@ -497,7 +507,9 @@ function armBootProbe(window: BrowserWindow): void {
       }
       app.relaunch();
       app.quit();
-    }, BOOT_PROBE_TIMEOUT_MS);
+    };
+
+    void tick();
   });
 }
 
@@ -505,10 +517,7 @@ app.whenReady().then(async () => {
   // Apply the Content-Security-Policy to our own document responses
   // before any window loads. Skipped in dev (Vite HMR needs a loose
   // policy); third-party + OAuth responses are left untouched.
-  installContentSecurityPolicy(session.defaultSession, {
-    isDev,
-    clerkPublishableKey: CLERK_PUBLISHABLE_KEY,
-  });
+  installContentSecurityPolicy(session.defaultSession, { isDev });
 
   // Allow the renderer's voice recorder to reach the microphone. Without this,
   // macOS hands getUserMedia a SILENT stream (no rejection), so voice


### PR DESCRIPTION
## The actual root cause of "update downloads but the app stays old"

Follow-up to #113. With #113's observability in hand, I pulled the on-disk self-update state off a real failing machine and it was conclusive:

- `<userData>/app/bad.json` had poisoned **every** staged version (`0.0.19`, `0.0.25`, `0.0.28`, `0.0.29`).
- `<userData>/app/confirmed.json` had **never existed**.
- Even `0.0.28` — which runs perfectly as the installed **floor** — was poisoned when run as an **override**.

Identical code, poisoned only as an override ⇒ the defect is the **confirm step**. The boot-probe required the renderer's `app.appBooted` IPC heartbeat to land within 15s to mark a hot-updated bundle healthy. In packaged builds that heartbeat doesn't reliably land, so the probe poisoned healthy bundles and reverted to the floor — self-update never stuck. (Publishing side and the bundles are fine; no crash reports; all assets present.)

## Fix

`armBootProbe` now confirms a healthy render **from the main process** by polling the renderer DOM, with no dependence on the renderer IPC: `index.html` ships a static `#splash-fallback` inside `#root` that React replaces on mount, so "`#splash-fallback` gone" is a direct health signal. The `app.appBooted` heartbeat is kept only as a fast path. A genuine white-screen (never renders within the window) is still poisoned and reverted.

The fix lives in the **override's own main**, so a user stuck on the broken floor recovers simply by updating to a release that contains it (the override's fixed probe confirms itself via the DOM and sticks).

> Note: 0.0.30 (from #113/#114) carries the observability but **not** this fix, so it would still poison. This ships as the next desktop release; updating straight to it from 0.0.28 works.

## Checks
Typecheck clean; desktop tests pass; changeset bumps `@moxxy/desktop` so a new `desktop-v*` release is cut. Verified on-build once 0.0.31 is out (tracked as TECH_DEBT #10).
