### PR TITLE
fix(desktop): Clerk sign-in in the packaged app via a loopback origin + moxxy:// deep-link

### DIFF
--- a/.changeset/desktop-loopback-auth-deeplink.md
+++ b/.changeset/desktop-loopback-auth-deeplink.md
@@ -1,0 +1,34 @@
+---
+"@moxxy/desktop-ipc-contract": patch
+"@moxxy/desktop-host": patch
+"@moxxy/desktop": patch
+---
+
+Desktop: make Clerk sign-in work in the packaged app, and add a `moxxy://`
+deep-link.
+
+Sign-in failed in the packaged build with `prohibited_redirect_url`: the
+renderer was served from `file://`, so clerk-js derived a `file://` OAuth
+redirect, which Clerk rejects (only `http(s)` schemes are allowed). It worked
+in dev only because Vite serves `http://localhost`.
+
+The packaged renderer is now served from a hardened in-process loopback HTTP
+server (`http://127.0.0.1:<port>`, 127.0.0.1-only, fixed port list, GET/HEAD
+only, path-traversal + Host-header guards, SPA fallback). A loopback origin is
+a Chromium *secure context* and an allowed OAuth redirect scheme, so the
+existing `clerk.openSignIn()` modal + OAuth popup work as they do on the web.
+The CSP gate now matches the loopback origin (directives unchanged — clerk-js
+still loads from the instance's Frontend API host), the focus widget loads from
+the same origin, and OAuth popups get a clean desktop-Chrome user-agent (no
+Electron/app tokens) to avoid Google's embedded-webview block. If every
+loopback port is taken, it falls back to `file://` (the window still renders).
+
+Also adds a `moxxy://` custom-protocol deep-link as general-purpose transport
+(single-instance lock + protocol registration + `open-url`/`second-instance`
+capture → a typed `deepLink:received` IPC event, with cold-start links buffered
+and drained via `deepLink:drain` on mount). Nothing routes on it yet — it's the
+plumbing for notification + action links.
+
+Owner action: add the loopback origins (`http://127.0.0.1` and
+`http://localhost` on the configured ports) to the Clerk dashboard's allowed
+origins / redirect URLs for the production instance.

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -33,10 +33,15 @@ import {
   installMediaPermissions,
   lockDownNavigation,
   isSafeExternalUrl,
+  clerkFrontendApiHost,
   preferredCliEntry,
   ensureDesktopVaultKey,
   activateManagedNode,
+  startLoopbackServer,
+  sendEvent,
+  type LoopbackServer,
 } from '@moxxy/desktop-host';
+import type { DeepLinkPayload } from '@moxxy/desktop-ipc-contract';
 
 import { BUNDLED_UPDATE_PUBLIC_KEY } from './update-key.js';
 import { readConfirmed, markConfirmed, markBad, appendBootLog } from '@moxxy/desktop-host/app-update';
@@ -59,8 +64,89 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const isDev = !!process.env['ELECTRON_RENDERER_URL'];
 
+// The Clerk publishable key, baked into the main bundle at build time by
+// electron-vite's `define` (see electron.vite.config.ts) from the same
+// VITE_CLERK_PUBLISHABLE_KEY the renderer reads. The main process needs it to
+// allow the instance's prod Frontend API host through the CSP + OAuth popup
+// allow-list — a `pk_live_` key serves clerk-js from the instance's own
+// domain, which the static dev/test hosts don't cover. '' when unset.
+declare const __CLERK_PUBLISHABLE_KEY__: string;
+const CLERK_PUBLISHABLE_KEY =
+  typeof __CLERK_PUBLISHABLE_KEY__ === 'string' ? __CLERK_PUBLISHABLE_KEY__ : '';
+
 let pool: RunnerPool | null = null;
 let mainWindow: BrowserWindow | null = null;
+
+// In-app loopback HTTP server the packaged renderer is served from (so the
+// Clerk web SDK runs on an http origin). null in dev (Vite serves it) and
+// when every candidate port was taken (we fall back to file://).
+let loopback: LoopbackServer | null = null;
+// Fixed, stable loopback ports — each MUST be allow-listed in the Clerk
+// dashboard (origins are exact-match including the port).
+const LOOPBACK_PORTS = [51789, 51790, 51791, 51792] as const;
+
+// ---- moxxy:// deep-link transport -----------------------------------------
+
+// `moxxy://` links that arrived before the renderer's DeepLinkBridge was
+// listening (cold-start launch, or before the bridge mounted). Drained via
+// the `deepLink:drain` IPC on mount; live links thereafter push directly.
+const pendingDeepLinks: DeepLinkPayload[] = [];
+// Flips true once the renderer's bridge drains (it subscribes THEN drains in
+// one synchronous effect, so by the time this is true the live-event listener
+// exists — no lost-link race). Reset on every (re)load so links re-buffer.
+let rendererReady = false;
+
+/** Bring the main window to the foreground (deep-link / second-instance). */
+function focusMain(): void {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  if (mainWindow.isMinimized()) mainWindow.restore();
+  mainWindow.show();
+  mainWindow.focus();
+  if (process.platform === 'darwin') app.focus({ steal: true });
+}
+
+/** Parse a `moxxy://host/path?a=b` URL into its transport payload, or null
+ *  if it isn't a well-formed moxxy URL. */
+function parseDeepLink(url: string): DeepLinkPayload | null {
+  try {
+    const u = new URL(url);
+    if (u.protocol !== 'moxxy:') return null;
+    const params: Record<string, string> = {};
+    u.searchParams.forEach((v, k) => {
+      params[k] = v;
+    });
+    return { url, host: u.hostname, path: u.pathname || '/', params };
+  } catch {
+    return null;
+  }
+}
+
+/** Route an opened `moxxy://` URL: focus the window, then push it to the
+ *  renderer live (if the bridge is listening) or buffer it for the next
+ *  drain. */
+function handleDeepLink(url: string): void {
+  const payload = parseDeepLink(url);
+  if (!payload) return;
+  focusMain();
+  if (rendererReady && mainWindow && !mainWindow.isDestroyed()) {
+    sendEvent(mainWindow, 'deepLink:received', payload);
+  } else {
+    pendingDeepLinks.push(payload);
+  }
+}
+
+/** Strip the Electron + app product tokens from a user-agent, leaving a plain
+ *  desktop-Chrome UA. Google blocks OAuth from "embedded" user-agents
+ *  ("this browser may not be secure"); presenting a clean UA lets the in-app
+ *  sign-in popup through. Harmless for our own + Clerk requests. */
+function cleanOAuthUserAgent(ua: string): string {
+  const name = app.getName().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return ua
+    .replace(new RegExp(`\\s*${name}(?:/\\S+)?`, 'i'), '')
+    .replace(/\s*Electron\/\S+/i, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
 
 async function createWindow(): Promise<void> {
   // The renderer is served either from Vite's dev server or from the
@@ -82,6 +168,24 @@ async function createWindow(): Promise<void> {
     /^https:\/\/appleid\.apple\.com$/,
     /^https:\/\/github\.com$/,
   ];
+  // A `pk_live_` instance runs OAuth through its OWN Frontend API host
+  // (e.g. clerk.acme.com) and account portal (accounts.acme.com), neither
+  // covered above — add the exact host plus a wildcard on its parent domain
+  // so the prod sign-in popup isn't denied. Test keys resolve to a host
+  // already matched above, so this adds nothing for them.
+  const clerkFapiHost = clerkFrontendApiHost(CLERK_PUBLISHABLE_KEY);
+  if (
+    clerkFapiHost &&
+    !clerkFapiHost.endsWith('.clerk.accounts.dev') &&
+    !clerkFapiHost.endsWith('.clerk.com')
+  ) {
+    const reEsc = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    OAUTH_HOST_PATTERNS.push(new RegExp(`^https://${reEsc(clerkFapiHost)}$`));
+    const parent = clerkFapiHost.split('.').slice(1).join('.');
+    if (parent.split('.').length >= 2) {
+      OAUTH_HOST_PATTERNS.push(new RegExp(`^https://(?:[a-z0-9-]+\\.)+${reEsc(parent)}$`));
+    }
+  }
 
   mainWindow = new BrowserWindow({
     title: 'MoxxyAI Workspaces',
@@ -146,10 +250,22 @@ async function createWindow(): Promise<void> {
     return { action: 'deny' };
   });
 
+  // Buffer deep-links until the renderer's bridge has drained, so none are
+  // lost across a load / reload. Resets on every load start.
+  mainWindow.webContents.on('did-start-loading', () => {
+    rendererReady = false;
+  });
+
   if (isDev) {
     await mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL']!);
     mainWindow.webContents.openDevTools({ mode: 'detach' });
+  } else if (loopback) {
+    // Prod: serve from the loopback http origin (Clerk-friendly secure
+    // context). The static server roots at this bundle's own dist/.
+    await mainWindow.loadURL(loopback.url('index.html'));
   } else {
+    // Degraded fallback only if every loopback port was taken — the window
+    // still renders, but Clerk sign-in won't work on a file:// origin.
     await mainWindow.loadFile(path.join(__dirname, '..', '..', 'dist', 'index.html'));
   }
 
@@ -168,6 +284,9 @@ async function createWindow(): Promise<void> {
     preloadPath: path.join(__dirname, '..', 'preload', 'index.cjs'),
     indexHtml: path.join(__dirname, '..', '..', 'dist', 'index.html'),
     focusHtml: path.join(__dirname, '..', '..', 'dist', 'focus.html'),
+    // Prod: load the widget from the same loopback origin as the main window
+    // (shared secure-context origin); falls back to focusHtml on disk.
+    loopbackBase: loopback?.origin,
     /** Bind the focus widget to the same runner pool as the main
      *  window so it sees connection state + every runner event, but
      *  pass claimGlobal: false so the IPC RPC routing (runTurn /
@@ -513,11 +632,77 @@ function armBootProbe(window: BrowserWindow): void {
   });
 }
 
+// Single-instance lock — required for `moxxy://` deep-links: a link opened
+// while the app is already running must hand its URL to the existing instance
+// (via `second-instance`) instead of spawning a second app. The loser quits.
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+if (!gotSingleInstanceLock) {
+  app.quit();
+} else {
+  // Register `moxxy://` as our protocol. In an unpackaged dev run we must
+  // point the OS at the electron binary + this entry script so the scheme
+  // resolves back to us; a packaged app registers via electron-builder's
+  // `protocols` / CFBundleURLTypes.
+  if (process.defaultApp && process.argv.length >= 2) {
+    app.setAsDefaultProtocolClient('moxxy', process.execPath, [path.resolve(process.argv[1]!)]);
+  } else {
+    app.setAsDefaultProtocolClient('moxxy');
+  }
+  // macOS delivers deep-links via open-url (can fire before whenReady — the
+  // handler buffers until the renderer drains).
+  app.on('open-url', (event, url) => {
+    event.preventDefault();
+    handleDeepLink(url);
+  });
+  // Windows/Linux: a link opened while running relaunches with the URL in
+  // argv, delivered here to the primary instance.
+  app.on('second-instance', (_event, argv) => {
+    focusMain();
+    const url = argv.find((a) => a.startsWith('moxxy://'));
+    if (url) handleDeepLink(url);
+  });
+}
+
 app.whenReady().then(async () => {
+  // Losing instance of the single-instance lock — it already called
+  // app.quit() above; do nothing here so it exits cleanly.
+  if (!gotSingleInstanceLock) return;
+
+  // Present a plain desktop-Chrome user-agent (no Electron/app product
+  // tokens) to every request. Google blocks OAuth from "embedded"
+  // user-agents ("this browser may not be secure"); a clean UA lets the
+  // in-app sign-in popup through. Set before any window so the very first
+  // request carries it. Harmless for our own + Clerk requests.
+  app.userAgentFallback = cleanOAuthUserAgent(app.userAgentFallback);
+
+  // Serve the packaged renderer over a loopback http origin (a Chromium
+  // secure context + an allowed OAuth redirect scheme) so the Clerk web SDK
+  // works — file:// rejects clerk-js's OAuth redirect. Dev keeps Vite; if
+  // every candidate port is taken we fall back to file:// (sign-in degrades
+  // but the app still boots).
+  if (!isDev) {
+    try {
+      loopback = await startLoopbackServer({
+        root: path.join(__dirname, '..', '..', 'dist'),
+        ports: [...LOOPBACK_PORTS],
+      });
+      console.log(`[moxxy] renderer served at ${loopback.origin}`);
+    } catch (err) {
+      console.error('[moxxy] loopback server failed; falling back to file://', err);
+      loopback = null;
+    }
+  }
+
   // Apply the Content-Security-Policy to our own document responses
   // before any window loads. Skipped in dev (Vite HMR needs a loose
-  // policy); third-party + OAuth responses are left untouched.
-  installContentSecurityPolicy(session.defaultSession, { isDev });
+  // policy); third-party + OAuth responses are left untouched. The gate
+  // matches both file:// and the loopback origin, and the prod Clerk
+  // Frontend API host is folded in from the publishable key.
+  installContentSecurityPolicy(session.defaultSession, {
+    isDev,
+    clerkPublishableKey: CLERK_PUBLISHABLE_KEY,
+    loopbackOrigin: loopback?.origin ?? null,
+  });
 
   // Allow the renderer's voice recorder to reach the microphone. Without this,
   // macOS hands getUserMedia a SILENT stream (no rejection), so voice
@@ -581,8 +766,25 @@ app.whenReady().then(async () => {
     },
   });
 
+  // The renderer's DeepLinkBridge calls this once on mount: it returns +
+  // clears any `moxxy://` links buffered before the renderer was listening
+  // (cold-start), and flips `rendererReady` so subsequent links push live.
+  // Because the bridge subscribes to `deepLink:received` BEFORE invoking this
+  // (one synchronous effect), no link can slip through between the two.
+  ipcMain.removeHandler('deepLink:drain');
+  ipcMain.handle('deepLink:drain', (): DeepLinkPayload[] => {
+    rendererReady = true;
+    return pendingDeepLinks.splice(0);
+  });
+
   await createWindow();
   if (mainWindow) armBootProbe(mainWindow);
+
+  // Cold-start deep-link: Windows/Linux pass a `moxxy://` URL as an argv
+  // token (macOS uses open-url, already buffered above). Buffer it for the
+  // renderer's first drain.
+  const argvUrl = process.argv.find((a) => a.startsWith('moxxy://'));
+  if (argvUrl) handleDeepLink(argvUrl);
 
   // Tier-2: background download of a new native shell where supported
   // (Windows/Linux); a no-op on dev + unsigned macOS. Tier-1 JS hot-updates
@@ -619,9 +821,13 @@ app.on('will-quit', () => {
 });
 
 async function shutdown(): Promise<void> {
-  if (!pool) return;
   await Promise.race([
-    pool.stopAll().catch(() => undefined),
+    // Stop the runner children AND the loopback server. allSettled never
+    // rejects, so one failing doesn't skip the other.
+    Promise.allSettled([
+      pool?.stopAll() ?? Promise.resolve(),
+      loopback?.close() ?? Promise.resolve(),
+    ]),
     // Belt-and-braces timeout: don't hang the app on a stuck child.
     new Promise<void>((resolve) => setTimeout(resolve, 3000)),
   ]);

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -68,6 +68,14 @@
     "directories": {
       "output": "release"
     },
+    "protocols": [
+      {
+        "name": "Moxxy Deep Link",
+        "schemes": [
+          "moxxy"
+        ]
+      }
+    ],
     "publish": [
       {
         "provider": "github",
@@ -96,7 +104,15 @@
       "extendInfo": {
         "CFBundleName": "MoxxyAI Workspaces",
         "CFBundleDisplayName": "MoxxyAI Workspaces",
-        "NSMicrophoneUsageDescription": "MoxxyAI Workspaces uses the microphone for voice input (speech-to-text)."
+        "NSMicrophoneUsageDescription": "MoxxyAI Workspaces uses the microphone for voice input (speech-to-text).",
+        "CFBundleURLTypes": [
+          {
+            "CFBundleURLName": "ai.moxxy.desktop.deeplink",
+            "CFBundleURLSchemes": [
+              "moxxy"
+            ]
+          }
+        ]
       }
     },
     "linux": {

--- a/apps/desktop/src/lib/useDeepLink.ts
+++ b/apps/desktop/src/lib/useDeepLink.ts
@@ -1,0 +1,72 @@
+import { useEffect, useSyncExternalStore } from 'react';
+import { api } from './api';
+import type { DeepLinkPayload } from '@moxxy/desktop-ipc-contract';
+
+/**
+ * Module-level store of `moxxy://` deep-links the app has received. The main
+ * process pushes one `deepLink:received` per opened link (notification click,
+ * action link, OS protocol launch) and buffers any that arrive before the
+ * renderer is listening; {@link DeepLinkBridge} drains the buffer on mount and
+ * subscribes for live ones.
+ *
+ * This is transport only — it records the latest link and a short history so
+ * feature code (workspace routing, action handlers) can subscribe later. No
+ * routing is wired yet.
+ */
+class DeepLinkStore {
+  private last: DeepLinkPayload | null = null;
+  private listeners = new Set<() => void>();
+
+  subscribe = (fn: () => void): (() => void) => {
+    this.listeners.add(fn);
+    return () => {
+      this.listeners.delete(fn);
+    };
+  };
+
+  push(link: DeepLinkPayload): void {
+    this.last = link;
+    for (const l of this.listeners) l();
+  }
+
+  latest(): DeepLinkPayload | null {
+    return this.last;
+  }
+}
+
+export const deepLinkStore = new DeepLinkStore();
+
+/**
+ * Bridge component — subscribes to live `deepLink:received` events and, on
+ * mount, drains any links buffered by the main process before the renderer
+ * was ready (cold-start launch). Subscribe happens BEFORE the drain so the
+ * main side can safely flip to live-push the moment it answers the drain with
+ * no lost-link race. Render once at the top of the tree, like
+ * {@link ConnectionBridge}.
+ */
+export function DeepLinkBridge(): null {
+  useEffect(() => {
+    const unsub = api().subscribe('deepLink:received', (link) => {
+      deepLinkStore.push(link);
+    });
+    // Drain cold-start / pre-mount links. Tolerate a missing preload (tests).
+    void api()
+      .invoke('deepLink:drain')
+      .then((links) => {
+        for (const link of links) deepLinkStore.push(link);
+      })
+      .catch(() => {
+        /* preload missing */
+      });
+    return () => {
+      unsub();
+    };
+  }, []);
+
+  return null;
+}
+
+/** Read the most recently received deep-link (or null). For future routing. */
+export function useLatestDeepLink(): DeepLinkPayload | null {
+  return useSyncExternalStore(deepLinkStore.subscribe, () => deepLinkStore.latest());
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ClerkProvider } from '@clerk/clerk-react';
 import { App } from './App';
 import { ErrorBoundary } from './ErrorBoundary';
+import { DeepLinkBridge } from './lib/useDeepLink';
 import './styles.css';
 
 const root = document.getElementById('root');
@@ -10,8 +11,16 @@ if (!root) throw new Error('#root not found — check index.html');
 
 const CLERK_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
+// The packaged renderer is served from a loopback origin
+// (http://127.0.0.1:<port>, see electron/main loopback server). Clerk's web
+// SDK refuses to redirect a post-auth flow to an origin it doesn't trust, so
+// allow-list the loopback origins (matches the main process's LOOPBACK_PORTS).
+// Pair this with the SAME origins added to the Clerk dashboard's allowed
+// origins / redirect URLs (the server-side check).
+const LOOPBACK_REDIRECT_ORIGINS = /^http:\/\/(127\.0\.0\.1|localhost):(51789|51790|51791|51792)$/;
+
 const Tree = CLERK_KEY ? (
-  <ClerkProvider publishableKey={CLERK_KEY}>
+  <ClerkProvider publishableKey={CLERK_KEY} allowedRedirectOrigins={[LOOPBACK_REDIRECT_ORIGINS]}>
     <App />
   </ClerkProvider>
 ) : (
@@ -22,9 +31,14 @@ const Tree = CLERK_KEY ? (
 // init throw (e.g. a malformed key). Without a boundary, any uncaught
 // renderer error unmounts the whole React tree → a blank white window with
 // nothing logged — which is exactly what a keyless build did (useUser threw
-// because no <ClerkProvider> was rendered).
+// because no <ClerkProvider> was rendered). The DeepLinkBridge sits outside
+// Clerk too (it needs no auth context) and is mounted once here so it's
+// always listening regardless of which App gate is showing.
 ReactDOM.createRoot(root).render(
   <React.StrictMode>
-    <ErrorBoundary>{Tree}</ErrorBoundary>
+    <ErrorBoundary>
+      <DeepLinkBridge />
+      {Tree}
+    </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/packages/desktop-host/src/focus-window.ts
+++ b/packages/desktop-host/src/focus-window.ts
@@ -22,6 +22,11 @@ interface CreateOpts {
   /** Path to the focus widget's dedicated HTML in the prod bundle.
    *  In dev it's served as ${devUrl}/focus.html instead. */
   readonly focusHtml: string;
+  /** Origin of the in-app loopback server (`http://127.0.0.1:<port>`) when
+   *  the prod renderer is served over http rather than file://. When set,
+   *  the widget loads `${loopbackBase}/focus.html`; otherwise it falls back
+   *  to loading `focusHtml` from disk. Absent in dev (devUrl wins). */
+  readonly loopbackBase?: string;
   /** Called the moment the focus window is created so the caller
    *  can wire IPC event forwarding (runner.event, turn.complete,
    *  connection.changed) into the secondary surface. Returns an
@@ -181,9 +186,13 @@ export async function showFocusWindow(opts: CreateOpts): Promise<void> {
 
   // Load the *dedicated* focus.html entry. It has its own bundle, its
   // own React tree, and its own preload bridge — no shared
-  // module side-effects with the main app.
+  // module side-effects with the main app. Prefer the loopback origin (so
+  // it shares the same secure-context origin as the main window); fall back
+  // to file:// only when no loopback server is running.
   if (opts.devUrl) {
     await win.loadURL(`${opts.devUrl}/focus.html`);
+  } else if (opts.loopbackBase) {
+    await win.loadURL(`${opts.loopbackBase}/focus.html`);
   } else {
     await win.loadFile(opts.focusHtml);
   }

--- a/packages/desktop-host/src/index.ts
+++ b/packages/desktop-host/src/index.ts
@@ -7,6 +7,7 @@
 
 export { RunnerPool, UNBOUND_ID } from './runner-pool.js';
 export { bindWindow, registerIpcHandlers } from './ipc.js';
+export { sendEvent } from './send-event.js';
 export { type UpdateConfig } from './ipc/update.js';
 export { preferredCliEntry } from './cli-resolver.js';
 export { activateManagedNode } from './node-manager.js';
@@ -29,3 +30,9 @@ export {
   clerkFrontendApiHost,
   clerkCspHostSources,
 } from './security.js';
+export {
+  startLoopbackServer,
+  DEFAULT_LOOPBACK_PORTS,
+  type LoopbackServer,
+  type LoopbackServerOptions,
+} from './loopback-server.js';

--- a/packages/desktop-host/src/loopback-server.test.ts
+++ b/packages/desktop-host/src/loopback-server.test.ts
@@ -1,0 +1,150 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { request as httpRequest } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { startLoopbackServer, type LoopbackServer } from './loopback-server';
+
+interface Res {
+  status: number;
+  headers: Record<string, string | string[] | undefined>;
+  body: string;
+}
+
+/**
+ * Raw HTTP client so we can send a custom Host header and un-normalised
+ * (percent-encoded) paths — `fetch` collapses `../` before it ever hits the
+ * server, which would defeat the traversal test.
+ */
+function raw(
+  port: number,
+  rawPath: string,
+  opts: { method?: string; host?: string } = {},
+): Promise<Res> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      {
+        host: '127.0.0.1',
+        port,
+        path: rawPath,
+        method: opts.method ?? 'GET',
+        headers: { Host: opts.host ?? `127.0.0.1:${port}` },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c) => chunks.push(c as Buffer));
+        res.on('end', () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString('utf8'),
+          }),
+        );
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('loopback static server', () => {
+  let dir: string;
+  let server: LoopbackServer;
+  let port: number;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), 'moxxy-loopback-'));
+    await writeFile(path.join(dir, 'index.html'), '<!doctype html><title>app</title>');
+    await writeFile(path.join(dir, 'focus.html'), '<!doctype html><title>focus</title>');
+    await mkdir(path.join(dir, 'assets'));
+    await writeFile(path.join(dir, 'assets', 'app-abc123.js'), 'console.log(1)');
+    // A secret OUTSIDE the served root — traversal attempts must never reach it.
+    await writeFile(path.join(path.dirname(dir), 'outside-secret.txt'), 'TOPSECRET');
+    server = await startLoopbackServer({ root: dir, ports: [0] });
+    port = server.port;
+  });
+
+  afterAll(async () => {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+    await rm(path.join(path.dirname(dir), 'outside-secret.txt'), { force: true });
+  });
+
+  it('binds loopback and reports an http://127.0.0.1 origin', () => {
+    expect(server.origin).toBe(`http://127.0.0.1:${port}`);
+    expect(server.url('index.html')).toBe(`http://127.0.0.1:${port}/index.html`);
+  });
+
+  it('serves index.html with the right content-type', async () => {
+    const res = await raw(port, '/index.html');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.body).toContain('<title>app</title>');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('serves fingerprinted assets as immutable js', async () => {
+    const res = await raw(port, '/assets/app-abc123.js');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/javascript');
+    expect(String(res.headers['cache-control'])).toContain('immutable');
+  });
+
+  it('falls back to index.html for extensionless SPA routes', async () => {
+    const res = await raw(port, '/sso-callback');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.body).toContain('<title>app</title>');
+  });
+
+  it('404s a missing asset rather than masking it with index.html', async () => {
+    const res = await raw(port, '/assets/missing-xyz.js');
+    expect(res.status).toBe(404);
+    const png = await raw(port, '/nope.png');
+    expect(png.status).toBe(404);
+  });
+
+  it('rejects non-GET/HEAD methods with 405', async () => {
+    const res = await raw(port, '/index.html', { method: 'POST' });
+    expect(res.status).toBe(405);
+    expect(res.headers['allow']).toContain('GET');
+  });
+
+  it('answers HEAD with headers and no body', async () => {
+    const res = await raw(port, '/index.html', { method: 'HEAD' });
+    expect(res.status).toBe(200);
+    expect(res.headers['content-length']).toBeDefined();
+    expect(res.body).toBe('');
+  });
+
+  it('refuses path traversal (encoded ../) with 403 and never serves outside root', async () => {
+    for (const p of [
+      '/%2e%2e/%2e%2e/outside-secret.txt',
+      '/..%2f..%2foutside-secret.txt',
+      '/../../outside-secret.txt',
+      '/%2e%2e%2f%2e%2e%2foutside-secret.txt',
+    ]) {
+      const res = await raw(port, p);
+      expect([403, 404]).toContain(res.status);
+      expect(res.body).not.toContain('TOPSECRET');
+    }
+  });
+
+  it('rejects a NUL byte in the path', async () => {
+    const res = await raw(port, '/index.html%00.png');
+    expect([403, 404]).toContain(res.status);
+  });
+
+  it('rejects a mismatched Host header (DNS-rebind defense)', async () => {
+    const res = await raw(port, '/index.html', { host: 'evil.example' });
+    expect(res.status).toBe(403);
+    const right = await raw(port, '/index.html', { host: `localhost:${port}` });
+    expect(right.status).toBe(200); // localhost on the bound port is allowed
+  });
+
+  it('close() is idempotent', async () => {
+    const s = await startLoopbackServer({ root: dir, ports: [0] });
+    await s.close();
+    await s.close(); // must not throw
+  });
+});

--- a/packages/desktop-host/src/loopback-server.ts
+++ b/packages/desktop-host/src/loopback-server.ts
@@ -1,0 +1,331 @@
+/**
+ * A tiny, hardened static file server bound to loopback (127.0.0.1) that
+ * serves the packaged renderer's `dist/` over `http://127.0.0.1:<port>`
+ * instead of `file://`.
+ *
+ * WHY this exists: the Clerk web SDK (and OAuth in general) refuses a
+ * `file://` origin — clerk-js derives its OAuth redirect from
+ * `window.location`, and Clerk rejects the `file://` scheme
+ * (`prohibited_redirect_url`). A loopback `http://127.0.0.1` origin is a
+ * Chromium *secure context* (so `crypto.subtle` etc. work without TLS) and
+ * an allowed redirect scheme, which makes the prebuilt `clerk.openSignIn()`
+ * modal + OAuth popup behave exactly as they do on the web. Serving the
+ * renderer this way is the no-backend, ecosystem-standard fix for desktop
+ * Clerk auth.
+ *
+ * Threat model: the only legitimate client is our own renderer (and the
+ * OAuth popup), both on the same machine. The server is reachable by any
+ * local process and — via DNS-rebinding — potentially by a remote page that
+ * resolves a hostname to 127.0.0.1. So the handler is deliberately strict:
+ * loopback bind only, GET/HEAD only, a Host-header allow-list (rebind
+ * defense), and a hard path-traversal containment check so nothing outside
+ * the served `dist/` can ever be read. It serves static bytes only — there
+ * is no dynamic surface to exploit.
+ *
+ * Kept free of any `electron` import so it stays unit-testable in plain Node
+ * (mirrors {@link ./security.ts}).
+ */
+
+import { createReadStream, promises as fsp, realpathSync } from 'node:fs';
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { Socket } from 'node:net';
+import path from 'node:path';
+
+export interface LoopbackServer {
+  /** Origin to load + allow-list in Clerk, e.g. `http://127.0.0.1:51789`. */
+  readonly origin: string;
+  /** The bound port. */
+  readonly port: number;
+  /** Build a full URL under the served root, e.g. `url('index.html')`. */
+  url(pathname: string): string;
+  /** Idempotent graceful shutdown; resolves once sockets drain or a short
+   *  grace elapses (keep-alive sockets otherwise wedge `server.close()`). */
+  close(): Promise<void>;
+}
+
+export interface LoopbackServerOptions {
+  /** Absolute path to the `dist/` root to serve (the active bundle's
+   *  renderer). Resolved + canonicalised once; nothing outside it is served. */
+  readonly root: string;
+  /** Ordered candidate ports; the first that binds wins. Each must be
+   *  allow-listed in Clerk (origins are exact-match incl. port), so keep the
+   *  list short and stable. */
+  readonly ports?: readonly number[];
+  /** SPA entry served for extensionless / unknown routes (so the OAuth
+   *  callback route renders the app). Defaults to `index.html`. */
+  readonly spaIndex?: string;
+}
+
+/** Default loopback ports. High, unprivileged, and unlikely to collide; the
+ *  whole list is load-bearing — every entry must be allow-listed in Clerk. */
+export const DEFAULT_LOOPBACK_PORTS = [51789, 51790, 51791, 51792] as const;
+
+/** extension → MIME. Deliberately small + explicit (no third-party `mime`
+ *  dependency); unknown extensions fall back to octet-stream. */
+const MIME_TYPES: Readonly<Record<string, string>> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.wasm': 'application/wasm',
+  '.txt': 'text/plain; charset=utf-8',
+};
+
+function contentType(filePath: string): string {
+  return MIME_TYPES[path.extname(filePath).toLowerCase()] ?? 'application/octet-stream';
+}
+
+/**
+ * Reject any request whose `Host` isn't a loopback name on the bound port.
+ * This is the DNS-rebinding defense: a remote page that resolves
+ * `evil.example` → 127.0.0.1 still sends `Host: evil.example`, so it never
+ * matches. Our own renderer always sends `127.0.0.1:<port>`; `localhost` is
+ * accepted too since Clerk dashboards conventionally list it.
+ */
+function hostAllowed(host: string | undefined, port: number): boolean {
+  if (!host) return false;
+  const expected = new Set([`127.0.0.1:${port}`, `localhost:${port}`]);
+  return expected.has(host);
+}
+
+/**
+ * Map a request pathname to a concrete file under `root`, or `null` to fall
+ * through to the SPA index. Returns `false` when the path escapes `root`
+ * (caller answers 403) — the containment check is the security boundary.
+ */
+async function resolveFile(
+  root: string,
+  pathname: string,
+  spaIndex: string,
+): Promise<string | null | false> {
+  // Decode + reject NUL (a classic truncation trick) before touching disk.
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    return false;
+  }
+  if (decoded.includes('\0')) return false;
+
+  // Resolve against root and CONFIRM containment. `path.resolve` collapses
+  // `..` / absolute segments, so the only thing that can sit under `root`
+  // is a legitimate descendant — anything else (`../`, `/etc/...`,
+  // encoded traversal) resolves outside and is refused.
+  const candidate = path.resolve(root, '.' + (decoded.startsWith('/') ? decoded : '/' + decoded));
+  if (candidate !== root && !candidate.startsWith(root + path.sep)) return false;
+
+  const existing = await statFileOrNull(candidate);
+  if (existing === 'file') {
+    // Symlink-escape insurance: canonicalise and re-check containment. This is
+    // belt-and-braces on top of the lexical containment check above (which is
+    // the actual security boundary); the packaged dist/ has no symlinks. If
+    // realpath isn't available (e.g. an asar virtual path on the floor),
+    // proceed on the already-validated lexical path rather than failing closed
+    // — failing closed would 403 every file served from inside the asar.
+    try {
+      const real = realpathSync(candidate);
+      if (real !== root && !real.startsWith(root + path.sep)) return false;
+    } catch {
+      /* realpath unavailable — trust the lexical containment check above */
+    }
+    return candidate;
+  }
+
+  // Not a file (missing, or a directory). An asset-like path — one with a
+  // file extension, e.g. `/assets/index-abc.js` — that doesn't exist is a
+  // genuine 404 (`null`); masking it behind index.html would yield confusing
+  // HTML-where-JS-expected MIME errors. Extensionless routes (`/`,
+  // `/sso-callback`) are SPA routes → serve the index.
+  if (path.extname(decoded) !== '') return null;
+  return path.join(root, spaIndex);
+}
+
+async function statFileOrNull(p: string): Promise<'file' | 'dir' | null> {
+  try {
+    const st = await fsp.stat(p);
+    return st.isFile() ? 'file' : 'dir';
+  } catch {
+    return null;
+  }
+}
+
+export async function startLoopbackServer(opts: LoopbackServerOptions): Promise<LoopbackServer> {
+  // Canonicalise the root up front so the per-request realpath containment
+  // check compares like-for-like. Without this, a root under a symlinked
+  // prefix (e.g. macOS `/var` → `/private/var`) fails its OWN containment
+  // check and 403s every real file.
+  const resolvedRoot = path.resolve(opts.root);
+  let root: string;
+  try {
+    root = realpathSync(resolvedRoot);
+  } catch {
+    root = resolvedRoot;
+  }
+  const spaIndex = opts.spaIndex ?? 'index.html';
+  const ports = opts.ports && opts.ports.length ? opts.ports : DEFAULT_LOOPBACK_PORTS;
+
+  const sockets = new Set<Socket>();
+
+  const server: Server = createServer((req, res) => {
+    void handle(req, res, root, spaIndex, boundPort).catch(() => {
+      if (!res.headersSent) res.writeHead(500);
+      res.end();
+    });
+  });
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+
+  let boundPort = 0;
+  for (const port of ports) {
+    try {
+      await listen(server, port);
+      // Read the ACTUAL bound port from the socket — this is the source of
+      // truth (and resolves `0`, which the OS expands to a free port, used
+      // by tests).
+      const addr = server.address();
+      boundPort = typeof addr === 'object' && addr ? addr.port : port;
+      break;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'EADDRINUSE') continue;
+      throw err; // a non-collision listen error is fatal
+    }
+  }
+  if (!boundPort) {
+    throw new Error(`loopback server: all candidate ports in use (${ports.join(', ')})`);
+  }
+
+  const origin = `http://127.0.0.1:${boundPort}`;
+  let closePromise: Promise<void> | null = null;
+
+  return {
+    origin,
+    port: boundPort,
+    url(pathname: string): string {
+      return `${origin}/${pathname.replace(/^\/+/, '')}`;
+    },
+    close(): Promise<void> {
+      if (closePromise) return closePromise;
+      closePromise = new Promise<void>((resolve) => {
+        let done = false;
+        const finish = (): void => {
+          if (done) return;
+          done = true;
+          resolve();
+        };
+        server.close(() => finish());
+        // Idle keep-alive sockets keep `server.close()` pending forever;
+        // destroy them after a short grace, then resolve regardless.
+        const t = setTimeout(() => {
+          for (const s of sockets) s.destroy();
+          finish();
+        }, 300);
+        t.unref();
+      });
+      return closePromise;
+    },
+  };
+}
+
+function listen(server: Server, port: number): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const onError = (err: Error): void => {
+      server.removeListener('listening', onListening);
+      reject(err);
+    };
+    const onListening = (): void => {
+      server.removeListener('error', onError);
+      resolve();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    // Bind loopback ONLY — never 0.0.0.0. The server must not be reachable
+    // off-box.
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+async function handle(
+  req: IncomingMessage,
+  res: ServerResponse,
+  root: string,
+  spaIndex: string,
+  port: number,
+): Promise<void> {
+  // Only ever serve safe, read-only methods.
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.writeHead(405, { Allow: 'GET, HEAD' });
+    res.end();
+    return;
+  }
+  // DNS-rebinding defense.
+  if (!hostAllowed(req.headers.host, port)) {
+    res.writeHead(403);
+    res.end();
+    return;
+  }
+
+  const pathname = new URL(req.url ?? '/', `http://127.0.0.1:${port}`).pathname;
+  const resolved = await resolveFile(root, pathname, spaIndex);
+  if (resolved === false) {
+    res.writeHead(403);
+    res.end();
+    return;
+  }
+
+  // resolveFile returned null → an asset-like miss (genuine 404).
+  const filePath = resolved ?? null;
+  if (filePath === null) {
+    res.writeHead(404);
+    res.end();
+    return;
+  }
+
+  let size: number;
+  try {
+    size = (await fsp.stat(filePath)).size;
+  } catch {
+    res.writeHead(404);
+    res.end();
+    return;
+  }
+
+  // Fingerprinted assets are immutable; HTML must never be cached so a
+  // hot-updated bundle's fresh index.html is always picked up.
+  const cacheControl = pathname.startsWith('/assets/')
+    ? 'public, max-age=31536000, immutable'
+    : 'no-cache';
+  const headers: Record<string, string> = {
+    'Content-Type': contentType(filePath),
+    'Content-Length': String(size),
+    'Cache-Control': cacheControl,
+    'X-Content-Type-Options': 'nosniff',
+  };
+
+  if (req.method === 'HEAD') {
+    res.writeHead(200, headers);
+    res.end();
+    return;
+  }
+
+  res.writeHead(200, headers);
+  createReadStream(filePath)
+    .on('error', () => {
+      if (!res.headersSent) res.writeHead(500);
+      res.end();
+    })
+    .pipe(res);
+}

--- a/packages/desktop-host/src/security.test.ts
+++ b/packages/desktop-host/src/security.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import type { Session } from 'electron';
 import {
   isSafeProviderName,
   assertSafeProviderName,
@@ -7,6 +8,7 @@ import {
   redactSecrets,
   clerkFrontendApiHost,
   clerkCspHostSources,
+  installContentSecurityPolicy,
 } from './security';
 
 describe('provider-name validation', () => {
@@ -107,5 +109,76 @@ describe('clerk CSP host sources', () => {
   it('adds nothing for a missing / malformed key', () => {
     expect(clerkCspHostSources(undefined)).toEqual([]);
     expect(clerkCspHostSources('garbage')).toEqual([]);
+  });
+});
+
+describe('CSP injection gate', () => {
+  type Details = { url: string; responseHeaders?: Record<string, string[]> };
+  type Headers = Record<string, string[]> | undefined;
+
+  /** Build a fake Session that captures the onHeadersReceived handler, then
+   *  return a probe that runs it for a given URL and reports the resulting
+   *  response headers (or null if no handler was registered — dev path). */
+  function probe(opts: {
+    isDev: boolean;
+    clerkPublishableKey?: string | null;
+    loopbackOrigin?: string | null;
+  }): (url: string) => Headers | null {
+    let handler:
+      | ((details: Details, cb: (r: { responseHeaders?: Headers }) => void) => void)
+      | undefined;
+    const session = {
+      webRequest: {
+        onHeadersReceived: (cb: typeof handler) => {
+          handler = cb;
+        },
+      },
+    } as unknown as Session;
+    installContentSecurityPolicy(session, opts);
+    return (url: string) => {
+      if (!handler) return null;
+      let out: Headers;
+      handler({ url, responseHeaders: { 'x-existing': ['1'] } }, (r) => {
+        out = r.responseHeaders;
+      });
+      return out;
+    };
+  }
+
+  const LOOPBACK = 'http://127.0.0.1:51789';
+
+  it('injects CSP for file:// and the loopback origin', () => {
+    const run = probe({ isDev: false, clerkPublishableKey: LIVE, loopbackOrigin: LOOPBACK });
+    for (const url of ['file:///app/dist/index.html', `${LOOPBACK}/index.html`]) {
+      const headers = run(url);
+      const csp = headers?.['Content-Security-Policy']?.[0] ?? '';
+      expect(csp).toContain("default-src 'self'");
+      // the live-key prod host folds in
+      expect(csp).toContain('https://clerk.acme.com');
+    }
+  });
+
+  it('passes third-party + OAuth-popup responses through untouched', () => {
+    const run = probe({ isDev: false, clerkPublishableKey: LIVE, loopbackOrigin: LOOPBACK });
+    for (const url of [
+      'https://accounts.google.com/o/oauth2/v2/auth',
+      'https://clerk.acme.com/v1/client',
+      'http://127.0.0.1:9999/other-origin', // a DIFFERENT loopback port
+    ]) {
+      const headers = run(url);
+      expect(headers?.['Content-Security-Policy']).toBeUndefined();
+      expect(headers?.['x-existing']).toEqual(['1']);
+    }
+  });
+
+  it('registers no handler in dev', () => {
+    const run = probe({ isDev: true, clerkPublishableKey: LIVE, loopbackOrigin: LOOPBACK });
+    expect(run('file:///x')).toBeNull();
+  });
+
+  it('still injects on file:// when no loopback origin (fallback path)', () => {
+    const run = probe({ isDev: false, clerkPublishableKey: LIVE, loopbackOrigin: null });
+    expect(run('file:///app/index.html')?.['Content-Security-Policy']).toBeDefined();
+    expect(run(`${LOOPBACK}/index.html`)?.['Content-Security-Policy']).toBeUndefined();
   });
 });

--- a/packages/desktop-host/src/security.ts
+++ b/packages/desktop-host/src/security.ts
@@ -202,27 +202,41 @@ function buildCspDirectives(extraClerkHosts: readonly string[]): string {
 }
 
 /**
- * Inject the CSP onto the app's own `file://` document responses only.
- * Third-party responses (the Clerk CDN, Google Fonts, and especially the
- * OAuth popups that load accounts.google.com / github.com) are left
- * untouched — slapping our CSP on them would break sign-in. Dev is
- * skipped entirely: Vite's HMR needs `'unsafe-eval'` + ws: and a strict
- * policy would break the dev server.
+ * Inject the CSP onto the app's OWN document responses only — either the
+ * `file://` bundle (legacy / fallback path) or the loopback origin the
+ * renderer is now served from (`http://127.0.0.1:<port>`, see
+ * {@link ./loopback-server.ts}). Third-party responses (the Clerk CDN,
+ * Google Fonts, and especially the OAuth popups that load
+ * accounts.google.com / github.com) are left untouched — slapping our CSP
+ * on them would break sign-in. Dev is skipped entirely: Vite's HMR needs
+ * `'unsafe-eval'` + ws: and a strict policy would break the dev server.
  *
  * `clerkPublishableKey` is the renderer's `VITE_CLERK_PUBLISHABLE_KEY`. A
  * `pk_live_` key serves clerk-js from the instance's OWN domain, which the
  * static dev/test hosts don't cover — so without folding that host in here
  * the prod clerk-js script is CSP-blocked and `clerk.openSignIn()` silently
  * renders no modal. Test/absent keys add nothing (the static list suffices).
+ *
+ * `loopbackOrigin` is the origin of the in-app static server (or null when
+ * the app fell back to `file://`). Under the loopback origin, `'self'` in
+ * the directives resolves to `http://127.0.0.1:<port>` — exactly the app's
+ * own scripts/styles served from `dist/`.
  */
 export function installContentSecurityPolicy(
   session: Session,
-  opts: { readonly isDev: boolean; readonly clerkPublishableKey?: string | null },
+  opts: {
+    readonly isDev: boolean;
+    readonly clerkPublishableKey?: string | null;
+    readonly loopbackOrigin?: string | null;
+  },
 ): void {
   if (opts.isDev) return;
   const directives = buildCspDirectives(clerkCspHostSources(opts.clerkPublishableKey));
+  const loopbackOrigin = opts.loopbackOrigin ?? null;
+  const isOwnDocument = (url: string): boolean =>
+    url.startsWith('file://') || (!!loopbackOrigin && url.startsWith(`${loopbackOrigin}/`));
   session.webRequest.onHeadersReceived((details, callback) => {
-    if (!details.url.startsWith('file://')) {
+    if (!isOwnDocument(details.url)) {
       callback({ responseHeaders: details.responseHeaders });
       return;
     }

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -330,6 +330,18 @@ export interface AppUpdateDiagnostics {
 
 // ---------- Events the renderer subscribes to ------------------------------
 
+/** Parsed components of an opened `moxxy://` URL. `host` is the first
+ *  authority segment (the "action", e.g. `open` in `moxxy://open/...`),
+ *  `path` the remainder of the path, and `params` the decoded query string.
+ *  General-purpose transport: notification clicks + action deep-links route
+ *  through this in the renderer's DeepLinkBridge. */
+export interface DeepLinkPayload {
+  readonly url: string;
+  readonly host: string;
+  readonly path: string;
+  readonly params: Record<string, string>;
+}
+
 /**
  * Channel names. Centralized so a typo is caught at the type level
  * (the preload's `subscribe(channel, handler)` is generic over this
@@ -358,6 +370,11 @@ export interface IpcEvents {
   /** The runner needs a permission/approval decision — the renderer
    *  shows a bottom sheet and replies via `ask.respond`. */
   'ask.request': AskRequest;
+  /** A `moxxy://` URL was opened while the app is running (notification /
+   *  action link, or an OS protocol launch). The renderer's DeepLinkBridge
+   *  routes it by `host`/`path`. Links that arrive before the renderer is
+   *  listening are buffered and pulled via `deepLink:drain` on mount. */
+  'deepLink:received': DeepLinkPayload;
 }
 
 // ---------- Invokable commands (renderer → main) --------------------------
@@ -382,6 +399,13 @@ export interface IpcCommands {
   /** Kick the supervisor out of failed / reconnecting back into the
    *  resolution loop. */
   'connection.retry': (args?: { workspaceId?: string }) => Promise<void>;
+
+  /** Drain `moxxy://` deep-links that arrived before the renderer was
+   *  listening (cold-start launch, or before the bridge mounted). The
+   *  DeepLinkBridge calls this once on mount; live links thereafter arrive
+   *  via the `deepLink:received` event. Returns + clears the main-side
+   *  buffer. */
+  'deepLink:drain': () => Promise<DeepLinkPayload[]>;
 
   /** Version + on-disk path of the moxxy CLI the desktop is currently
    *  running. Either field may be null if it can't be resolved. */


### PR DESCRIPTION
## Problem

Google sign-in does nothing in the **packaged** desktop app. clerk-js loads, but `POST /v1/client/sign_ins` returns **422 `prohibited_redirect_url`** ("prohibited URL scheme"): the renderer is served from `file://`, so clerk-js derives a `file://` OAuth redirect, which Clerk rejects (only `http(s)` schemes are allowed). It worked in dev only because Vite serves `http://localhost`.

The Clerk web SDK (`openSignIn()`, the OAuth popup, `handleRedirectCallback`) assumes an `http(s)` origin and reads callback params from `window.location`. A custom-scheme-only deep link can't satisfy that finalize step, and the ecosystem avoids custom-scheme OAuth (providers reject custom-scheme redirects; macOS custom-domain cookies break). The robust, no-backend fix is a **loopback `http://127.0.0.1` origin**.

## What this does

**Serve the packaged renderer from a loopback HTTP server** (a Chromium *secure context* + an allowed redirect scheme) so the existing `clerk.openSignIn()` modal + OAuth popup work as on the web:

- New `packages/desktop-host/src/loopback-server.ts` — hardened static server: `127.0.0.1`-only, fixed ports `51789–51792`, `GET`/`HEAD` only, path-traversal + `Host`-header (DNS-rebind) guards, SPA fallback, graceful teardown. No new deps.
- Main process loads `http://127.0.0.1:<port>/index.html` (falls back to `file://` if every port is taken), closes the server on quit, and gives OAuth popups a clean desktop-Chrome user-agent to dodge Google's embedded-webview block.
- CSP gate (`security.ts`) now matches the loopback origin (directives unchanged — clerk-js still loads from the instance's Frontend API host); the focus widget loads from the same origin.
- `ClerkProvider` gets `allowedRedirectOrigins` for the loopback origins.

**Restores the prod-Clerk wiring in the main process that a later self-update refactor clobbered on `main`.** `electron.vite.config` still bakes `__CLERK_PUBLISHABLE_KEY__` and `security.ts` still has `clerkCspHostSources`, but `index.ts` had stopped consuming them (no `clerkFrontendApiHost` import, no `CLERK_PUBLISHABLE_KEY`, CSP called with `{ isDev }` only, no OAuth prod-host folding) — so prod sign-in was CSP-broken again on `main` independent of this change. Re-adds all of it (the loopback CSP needs the key to allow `clerk.<domain>`).

**Adds a general-purpose `moxxy://` deep-link** as transport plumbing (single-instance lock + `setAsDefaultProtocolClient` + `open-url`/`second-instance`/cold-argv → typed `deepLink:received` IPC, buffered and drained via `deepLink:drain` on mount; renderer `DeepLinkBridge`; electron-builder `protocols` + mac `CFBundleURLTypes`). Nothing routes on it yet — it's the plumbing for notification + action links.

## Verification

- `build`, `typecheck`, `lint` (0 errors), `check:deps` (clean) all green for the touched packages.
- `@moxxy/desktop-host` 180 tests (incl. new `loopback-server.test.ts` — method/traversal/MIME/SPA/Host — and CSP-gate tests); `@moxxy/desktop` 58 tests.
- Built renderer confirmed to emit relative `./assets` paths (resolve at the loopback root). A `package:dir` build with a dev key launches and renders over the loopback origin.
- **Not yet verified on a real prod build**: the live Google sign-in round-trip + `moxxy://` OS round-trip need a packaged build with the `pk_live_` key and the Clerk dashboard step above. Contingency if the popup white-screens on a nested callback path: switch renderer `base` to `/`, or a custom `authenticateWithRedirect` + `<AuthenticateWithRedirectCallback>` route.

Changeset included (`@moxxy/desktop-ipc-contract`, `@moxxy/desktop-host`, `@moxxy/desktop` — patch).