### PR TITLE
fix(desktop): ship type:module marker so hot-update bundles load as ESM

### DIFF
--- a/.changeset/desktop-update-esm-marker.md
+++ b/.changeset/desktop-update-esm-marker.md
@@ -1,0 +1,24 @@
+---
+"@moxxy/desktop-host": patch
+"@moxxy/desktop": patch
+---
+
+Fix desktop self-update failing to load every override ("Cannot use import
+statement outside a module").
+
+The hot-update bundle ships only `dist/**` + `dist-electron/**`, so a staged
+bundle under `<userData>/app/<version>/` had **no `package.json` above its
+main**. The real main (`dist-electron/main/index.js`) is emitted as an ES module
+(`import` syntax), and Electron's bundled Node (v20, no ESM syntax
+auto-detection) decides ESM-vs-CJS from the nearest `package.json#type` — with
+none reachable it defaults to CommonJS and the bootstrap's `import()` threw
+`Cannot use import statement outside a module`. Every staged version
+(0.0.28/29/31/32) loaded this way got poisoned and the app silently reverted to
+the baked floor. The floor itself loads fine only because the packaged `.app`
+carries the desktop `package.json` (`"type":"module"`).
+
+`buildAppBundle` now ships a minimal `{"type":"module"}` `package.json` at the
+bundle root (signed into the bundle), and the stager writes the same marker at
+extract time when a bundle lacks one — so already-published bundles are also
+rescued on re-stage. The single marker is sourced from one constant shared by
+the producer and the stager so they can't drift.

--- a/packages/desktop-host/src/app-update/build.ts
+++ b/packages/desktop-host/src/app-update/build.ts
@@ -12,6 +12,7 @@ import { createHash, createPrivateKey, sign as cryptoSign } from 'node:crypto';
 import { gzipSync } from 'node:zlib';
 
 import { type AppManifest, canonicalManifestBytes } from './manifest.js';
+import { ESM_MARKER_PACKAGE_JSON } from './resolve.js';
 
 export interface BuildInput {
   version: string;
@@ -35,8 +36,21 @@ export interface BuildOutput {
 }
 
 export function buildAppBundle(input: BuildInput): BuildOutput {
+  // The bootstrap loads the bundle's `dist-electron/main/index.js` as an ES
+  // module (electron-vite emits it with `import` syntax). Node decides ESM-vs-CJS
+  // from the nearest `package.json#type`, and a staged bundle under
+  // `<userData>/app/<version>/` has NO package.json above its main — so without
+  // this marker Node parses the ESM main as CommonJS and every override dies with
+  // "Cannot use import statement outside a module", silently reverting to the
+  // floor. Ship a minimal `type:module` marker at the bundle root (only if a
+  // caller didn't already provide one) so the staged tree loads as ESM.
+  const files: Record<string, Buffer> = { ...input.files };
+  if (!files['package.json']) {
+    files['package.json'] = Buffer.from(ESM_MARKER_PACKAGE_JSON, 'utf8');
+  }
+
   const filesB64: Record<string, string> = {};
-  for (const [rel, buf] of Object.entries(input.files)) {
+  for (const [rel, buf] of Object.entries(files)) {
     filesB64[rel] = buf.toString('base64');
   }
   const payload = JSON.stringify({ version: input.version, files: filesB64 });

--- a/packages/desktop-host/src/app-update/resolve.ts
+++ b/packages/desktop-host/src/app-update/resolve.ts
@@ -50,6 +50,17 @@ export function appUpdateDir(userDataDir: string): string {
 export function bundleRoot(userDataDir: string, version: string): string {
   return path.join(appUpdateDir(userDataDir), version);
 }
+
+/**
+ * The minimal `package.json` that MUST sit at a staged bundle's root so Node
+ * loads the bundle's ES-module `dist-electron/main/index.js` as ESM. A staged
+ * bundle under `<userData>/app/<version>/` has no package.json above its main,
+ * so without this Node parses the ESM main as CommonJS and the bootstrap's
+ * `import()` throws "Cannot use import statement outside a module" — reverting
+ * to the floor on every override. Single-sourced here so the producer
+ * (`buildAppBundle`) and the stager safety-net can never disagree on it.
+ */
+export const ESM_MARKER_PACKAGE_JSON = `${JSON.stringify({ type: 'module' }, null, 2)}\n`;
 const activePath = (d: string): string => path.join(appUpdateDir(d), 'active.json');
 const badPath = (d: string): string => path.join(appUpdateDir(d), 'bad.json');
 const breadcrumbPath = (d: string): string => path.join(appUpdateDir(d), 'last-attempt.json');

--- a/packages/desktop-host/src/app-update/roundtrip.test.ts
+++ b/packages/desktop-host/src/app-update/roundtrip.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
 import { generateKeyPairSync } from 'node:crypto';
+import { gunzipSync } from 'node:zlib';
 import path from 'node:path';
 import os from 'node:os';
 
@@ -52,6 +53,13 @@ describe('build → stage → resolve round-trip', () => {
     });
     const fetchImpl = stubFetch(manifestJson, bundleGz);
 
+    // The SIGNED bundle itself carries the ESM marker (authenticated via sha256,
+    // not relying on the stager's unsigned safety-net) — see build.ts.
+    const payload = JSON.parse(gunzipSync(bundleGz).toString('utf8'));
+    expect(Buffer.from(payload.files['package.json'], 'base64').toString('utf8')).toContain(
+      '"type": "module"',
+    );
+
     // check: a newer, compatible bundle is offered
     const check = await checkForUpdate(
       { repo: 'moxxy-ai/moxxy', manifestUrlOverride: MANIFEST_URL, currentVersion: '0.0.5', publicKeyPem: PUBKEY, shell: SHELL },
@@ -78,6 +86,11 @@ describe('build → stage → resolve round-trip', () => {
       'real main',
     );
     expect(existsSync(path.join(root, 'manifest.json'))).toBe(true);
+
+    // The staged root MUST declare ESM, else Node parses the real main (emitted
+    // with `import` syntax) as CommonJS and the bootstrap's `import()` dies with
+    // "Cannot use import statement outside a module", silently reverting to floor.
+    expect(JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8')).type).toBe('module');
 
     // the bootstrap gate accepts it
     expect(resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL })).toEqual({

--- a/packages/desktop-host/src/app-update/stager.test.ts
+++ b/packages/desktop-host/src/app-update/stager.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, beforeEach } from 'vitest';
-import { mkdtempSync, existsSync } from 'node:fs';
-import { generateKeyPairSync } from 'node:crypto';
+import { mkdtempSync, existsSync, readFileSync } from 'node:fs';
+import { generateKeyPairSync, createHash, sign as cryptoSign, createPrivateKey } from 'node:crypto';
+import { gzipSync } from 'node:zlib';
 import path from 'node:path';
 import os from 'node:os';
 
 import { buildAppBundle } from './build';
+import { canonicalManifestBytes, type AppManifest } from './manifest';
 import { checkForUpdate, downloadAndStage, isAllowedUpdateHost } from './stager';
 import { bundleRoot, markBad, readBadVersions, readActiveVersion, type ShellInfo } from './resolve';
 
@@ -12,6 +14,27 @@ const SHELL: ShellInfo = { electron: '33.4.11', nodeAbi: '115' };
 const keys = generateKeyPairSync('ed25519');
 const PUBKEY = keys.publicKey.export({ type: 'spki', format: 'pem' }).toString();
 const PRIVKEY = keys.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+
+/** Build a signed bundle the OLD way — WITHOUT the ESM `package.json` marker the
+ *  current `buildAppBundle` injects — to exercise the stager's safety-net for
+ *  already-published bundles that predate the fix. */
+function buildLegacyBundle(
+  version: string,
+  files: Record<string, Buffer>,
+  bundleUrl: string,
+): { manifest: AppManifest; bundleGz: Buffer } {
+  const filesB64: Record<string, string> = {};
+  for (const [rel, buf] of Object.entries(files)) filesB64[rel] = buf.toString('base64');
+  const bundleGz = gzipSync(Buffer.from(JSON.stringify({ version, files: filesB64 }), 'utf8'));
+  const sha256 = createHash('sha256').update(bundleGz).digest('hex');
+  const signed = { version, minElectron: '33.0.0', nodeAbi: '', sha256, bundleUrl };
+  const signature = cryptoSign(
+    null,
+    canonicalManifestBytes(signed),
+    createPrivateKey(PRIVKEY),
+  ).toString('base64');
+  return { manifest: { ...signed, signature }, bundleGz };
+}
 
 let tmp: string;
 beforeEach(() => {
@@ -144,6 +167,28 @@ describe('downloadAndStage hardening', () => {
     await expect(
       downloadAndStage({ userDataDir: tmp, manifest, publicKeyPem: otherKey }, { fetchImpl }),
     ).rejects.toThrow(/signature/i);
+  });
+
+  it('writes a type:module marker for a legacy bundle that omits its own package.json', async () => {
+    // Reproduces the production "Cannot use import statement outside a module"
+    // failure: a published bundle whose ESM main has no package.json above it.
+    const url = 'https://github.com/moxxy-ai/moxxy/releases/download/desktop-v0.0.7/b.json.gz';
+    const { manifest, bundleGz } = buildLegacyBundle(
+      '0.0.7',
+      { 'dist/index.html': Buffer.from('x'), 'dist-electron/main/index.js': Buffer.from('// main') },
+      url,
+    );
+    const fetchImpl = (async () => new Response(new Uint8Array(bundleGz))) as unknown as typeof fetch;
+
+    await downloadAndStage(
+      { userDataDir: tmp, manifest, publicKeyPem: PUBKEY, bundleUrl: url },
+      { fetchImpl },
+    );
+
+    const pkg = JSON.parse(
+      readFileSync(path.join(bundleRoot(tmp, '0.0.7'), 'package.json'), 'utf8'),
+    );
+    expect(pkg.type).toBe('module'); // the staged tree now loads as ESM
   });
 
   it('clears a prior poison mark on the version it installs (un-wedges a reinstall)', async () => {

--- a/packages/desktop-host/src/app-update/stager.ts
+++ b/packages/desktop-host/src/app-update/stager.ts
@@ -23,6 +23,7 @@ import {
 } from './manifest.js';
 import {
   type ShellInfo,
+  ESM_MARKER_PACKAGE_JSON,
   appUpdateDir,
   bundleRoot,
   compareSemver,
@@ -304,6 +305,15 @@ export async function downloadAndStage(
       mkdirSync(path.dirname(dest), { recursive: true });
       writeFileSync(dest, Buffer.from(b64, 'base64'));
     }
+    // Guarantee the staged tree loads as ESM even for bundles produced before
+    // `buildAppBundle` started shipping the marker (e.g. an already-published
+    // release): the real main is ES-module syntax and nothing above it declares
+    // `type:module`, so without this Node parses it as CommonJS and the bootstrap
+    // can never load the override ("Cannot use import statement outside a
+    // module"). Skip if the bundle already carries its own package.json.
+    const pkgJsonPath = path.join(incoming, 'package.json');
+    if (!existsSync(pkgJsonPath)) writeFileSync(pkgJsonPath, ESM_MARKER_PACKAGE_JSON);
+
     // Write the verified manifest LAST so a half-extracted dir never looks valid.
     writeFileSync(path.join(incoming, 'manifest.json'), JSON.stringify(manifest, null, 2));
 


### PR DESCRIPTION
## Problem

Desktop self-update never sticks — diagnostics on a real machine show every staged override failing to evaluate and getting poisoned, so the app reverts to the baked floor on every launch:

```
load-error  0.0.31  error=Cannot use import statement outside a module
load-error  0.0.32  error=Cannot use import statement outside a module
…  bad 0.0.28, 0.0.29, 0.0.31, 0.0.32
```

This is a **third, distinct** root cause — separate from the heartbeat-confirm fix (#115) and the observability work (#113).

## Root cause

- The hot-update bundle ships only `dist/**` + `dist-electron/**`, so a staged bundle at `<userData>/app/<version>/` has **no `package.json` above its main**.
- The real main (`dist-electron/main/index.js`) is emitted as an **ES module** (`import` syntax).
- Node decides ESM-vs-CJS from the nearest `package.json#type`. **Electron 33.4.11 bundles Node 20, which has no ESM-syntax auto-detection** (unflagged only in Node 22.7+), so with no `type:module` reachable it defaults to **CommonJS** → `import()` throws.
- The baked floor loads only because the packaged `.app` carries the desktop `package.json` (`"type":"module"`); the userData copy doesn't.
- Doesn't reproduce on dev machines because they run Node ≥22 (auto-detect on), which masks the bug. Verified the exact failure by simulating a CommonJS scope under Node 20 semantics.

## Fix (`packages/desktop-host/src/app-update/`)

1. **`buildAppBundle` (build.ts)** — ships a minimal `{"type":"module"}` `package.json` at the bundle root, **signed into the bundle**, so the staged tree loads as ESM.
2. **`downloadAndStage` (stager.ts)** — writes the same marker at extract time when a bundle lacks one (defense-in-depth; rescues already-published bundles on re-stage).
3. Marker single-sourced as `ESM_MARKER_PACKAGE_JSON` in resolve.ts so producer and stager can't drift.

**Recovery without a new floor:** the marker rides *inside* the bundle payload, and the current floor's stager already writes every payload file — so a user stuck on the broken 0.0.31 floor recovers on the next download once a fixed release is published.

## Tests

- `roundtrip.test.ts` — asserts the signed bundle carries the marker (authenticated via sha256) **and** the staged tree declares `type:module`.
- `stager.test.ts` — `buildLegacyBundle` exercises the safety-net for bundles that predate the producer fix.
- desktop-host: **181/181 green**, lint clean, builds; production `dist` builder confirmed emitting the marker.

## Verify after merge

Ships in **0.0.33+**. On a real build, confirm the update completes — `confirmed.json` appears in `~/Library/Application Support/MoxxyAI Workspaces/app/` and the version flips to **UPDATED**.