### PR TITLE
fix(channel-http): eliminate EADDRINUSE flake via ephemeral test ports

### DIFF
--- a/.changeset/http-channel-ephemeral-port.md
+++ b/.changeset/http-channel-ephemeral-port.md
@@ -1,0 +1,9 @@
+---
+"@moxxy/plugin-channel-http": patch
+---
+
+Fix flaky `EADDRINUSE` in the HTTP channel tests. `HttpChannel` now exposes the
+actually-bound port via `boundPort` (the OS-assigned one when started with
+`port: 0`), and the integration/attach tests bind an ephemeral port and read it
+back instead of guessing a random port in 50000–59999 — which occasionally
+collided when test files ran in parallel (seen on CI Node 22.x).

--- a/packages/plugin-channel-http/src/attach.test.ts
+++ b/packages/plugin-channel-http/src/attach.test.ts
@@ -68,11 +68,10 @@ describe('HttpChannel attached to a runner', () => {
     server = await startRunnerServer(buildRunnerSession(), { socketPath });
     remote = await connectRemoteSession({ socketPath, role: 'http' });
 
-    const port = 50000 + Math.floor(Math.random() * 10000);
-    const channel = new HttpChannel({ port, host: '127.0.0.1', allowedTools: [] });
+    const channel = new HttpChannel({ port: 0, host: '127.0.0.1', allowedTools: [] });
     handle = await channel.start({ session: remote });
 
-    const res = await fetch(`http://127.0.0.1:${port}/v1/turn`, {
+    const res = await fetch(`http://127.0.0.1:${channel.boundPort}/v1/turn`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ prompt: 'say hi' }),

--- a/packages/plugin-channel-http/src/channel.ts
+++ b/packages/plugin-channel-http/src/channel.ts
@@ -39,6 +39,14 @@ export class HttpChannel implements Channel<HttpStartOpts> {
   private readonly authToken: string | null;
   private readonly logger: HttpChannelOptions['logger'];
   private server: Server | null = null;
+  private boundPortValue = 0;
+
+  /** The actual TCP port the server bound to after {@link start}. Equals the
+   *  configured port, or the OS-assigned one when `port: 0` (ephemeral) — so
+   *  callers (and tests) can address the server without guessing a free port. */
+  get boundPort(): number {
+    return this.boundPortValue;
+  }
 
   constructor(opts: HttpChannelOptions = {}) {
     this.port = opts.port ?? 3737;
@@ -82,9 +90,11 @@ export class HttpChannel implements Channel<HttpStartOpts> {
     const listening = new Promise<void>((resolve, reject) => {
       server.once('error', reject);
       server.listen(this.port, this.host, () => {
+        const addr = server.address();
+        this.boundPortValue = typeof addr === 'object' && addr ? addr.port : this.port;
         this.logger?.info?.('http channel listening', {
           host: this.host,
-          port: this.port,
+          port: this.boundPortValue,
           authEnabled: this.authToken !== null,
         });
         resolve();

--- a/packages/plugin-channel-http/src/integration.test.ts
+++ b/packages/plugin-channel-http/src/integration.test.ts
@@ -60,20 +60,12 @@ function buildSession(opts: { withTranscriber?: string } = {}): Session {
   return session;
 }
 
-async function pickPort(channel: HttpChannel): Promise<{ baseUrl: string; handle: ChannelHandle }> {
-  // Use port 0 to let the OS assign a free port; HttpChannel ignores 0 and
-  // uses its default. Override by passing a high random port instead.
-  const port = 50000 + Math.floor(Math.random() * 10000);
-  // Reconstruct with the chosen port.
-  const real = new HttpChannel({
-    port,
-    host: '127.0.0.1',
-    authToken: TOKEN,
-    allowedTools: ['Read', 'Glob'],
-  });
-  Object.assign(channel, real);
+async function startChannel(channel: HttpChannel): Promise<{ baseUrl: string; handle: ChannelHandle }> {
+  // The channel was created with port: 0 — the OS assigns a free ephemeral port,
+  // read back from `boundPort`. No random-port guessing, so no EADDRINUSE flake
+  // when test files run in parallel.
   const handle = await channel.start({ session: buildSession() });
-  return { baseUrl: `http://127.0.0.1:${port}`, handle };
+  return { baseUrl: `http://127.0.0.1:${channel.boundPort}`, handle };
 }
 
 let channel: HttpChannel;
@@ -86,7 +78,7 @@ beforeEach(async () => {
     authToken: TOKEN,
     allowedTools: ['Read', 'Glob'],
   });
-  const started = await pickPort(channel);
+  const started = await startChannel(channel);
   baseUrl = started.baseUrl;
   handle = started.handle;
 });
@@ -189,21 +181,14 @@ describe('HttpChannel /v1/turn/audio integration', () => {
   beforeEach(async () => {
     audioChannel = new HttpChannel({
       port: 0,
-      authToken: TOKEN,
-      allowedTools: ['Read', 'Glob'],
-    });
-    const port = 50000 + Math.floor(Math.random() * 10000);
-    const real = new HttpChannel({
-      port,
       host: '127.0.0.1',
       authToken: TOKEN,
       allowedTools: ['Read', 'Glob'],
     });
-    Object.assign(audioChannel, real);
     audioHandle = await audioChannel.start({
       session: buildSession({ withTranscriber: 'transcribed voice content' }),
     });
-    audioBaseUrl = `http://127.0.0.1:${port}`;
+    audioBaseUrl = `http://127.0.0.1:${audioChannel.boundPort}`;
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Problem

CI failed intermittently (e.g. PR #120, **Node 22.x only** — 20.x/24.x passed) on:

```
× HttpChannel integration > POST /v1/turn rejects malformed body with 400
  → listen EADDRINUSE: address already in use 127.0.0.1:57087
```

`HttpChannel` already honors `port: 0` (`opts.port ?? 3737` keeps `0`), but it never exposed the OS-assigned port — so `integration.test.ts` and `attach.test.ts` instead picked a **random** port `50000 + random*10000` (plus an `Object.assign` hack to swap it in). When vitest runs those two test files in parallel they occasionally land on the same port → `EADDRINUSE`. Pre-existing flake, surfaced by runner timing.

## Fix

- `HttpChannel` now records the actually-bound port from `server.address()` after `listen` and exposes it via a `boundPort` getter.
- The integration + attach tests bind an **ephemeral port (`port: 0`)** and read `channel.boundPort` for the base URL — no random-port guessing, no `Object.assign`. OS-assigned ports are unique, so the collision can't happen.

## Verification

- Ran `@moxxy/plugin-channel-http` tests 5× back-to-back — all green, no `EADDRINUSE`.
- Full workspace `build` / `typecheck` / `test`: 58 / 114 / 111 tasks green; lint clean.