### PR TITLE
fix(desktop): bundle @moxxy/ipc-server-ws into the packaged main + load it lazily

### DIFF
--- a/.changeset/fix-desktop-ws-bridge-bundling.md
+++ b/.changeset/fix-desktop-ws-bridge-bundling.md
@@ -1,0 +1,9 @@
+---
+"@moxxy/desktop": patch
+---
+
+Fix packaged-app boot crash: bundle `@moxxy/ipc-server-ws` into the main-process output and load it lazily.
+
+PR #120 added a top-level static import of `@moxxy/ipc-server-ws` to the Electron main but never added the package to `BUNDLED_WORKSPACE_DEPS`, so `externalizeDepsPlugin` left a bare specifier in `dist-electron/main/index.js` that cannot resolve in the packaged app (electron-builder ships only `dist`/`dist-electron`, no node_modules). Every packaged 0.0.33 build — and the Tier-1 hot-update bundle built from the same tree — crashed at main-process load with MODULE_NOT_FOUND, which would also have re-poisoned self-update overrides.
+
+Two-layer fix: `@moxxy/ipc-server-ws` is now in `BUNDLED_WORKSPACE_DEPS` (with `ws`'s optional native accelerators `bufferutil`/`utf-8-validate` kept external — `ws` falls back to JS implementations), and the bridge is loaded via a guarded dynamic `import()` only when `MOXXY_WS_BRIDGE=1` (the shell-updater pattern), so the opt-in bridge can never take down boot again. Verified on a real packaged build: boots clean, and with `MOXXY_WS_BRIDGE=1` the bridge listens.

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -17,6 +17,7 @@ const BUNDLED_WORKSPACE_DEPS = [
   '@moxxy/plugin-stt-whisper-codex',
   '@moxxy/desktop-ipc-contract',
   '@moxxy/desktop-host',
+  '@moxxy/ipc-server-ws',
 ];
 
 /**
@@ -27,8 +28,13 @@ const BUNDLED_WORKSPACE_DEPS = [
  * required — keep it out of the bundle (its NAPI-RS loader reassigns
  * `commonjsRequire`, which Rollup can't inline) and let it resolve (or
  * gracefully fail) at runtime.
+ *
+ * `bufferutil` / `utf-8-validate` are `ws`'s optional native accelerators
+ * (`ws` rides in via the bundled `@moxxy/ipc-server-ws`). `ws` requires them
+ * inside try/catch and falls back to its JS implementations, so leaving them
+ * external-and-absent in the packaged app is safe and intended.
  */
-const EXTERNAL_NATIVE = ['@napi-rs/keyring'];
+const EXTERNAL_NATIVE = ['@napi-rs/keyring', 'bufferutil', 'utf-8-validate'];
 
 /**
  * electron-vite manages three build targets (main / preload / renderer)

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -44,7 +44,12 @@ import {
   type LoopbackServer,
 } from '@moxxy/desktop-host';
 import type { DeepLinkPayload } from '@moxxy/desktop-ipc-contract';
-import { WebSocketCommandBus, startWsBridge } from '@moxxy/ipc-server-ws';
+// Value imports of @moxxy/ipc-server-ws are lazy + guarded (see the bridge
+// block below): the bridge is opt-in, and a top-level static import would make
+// boot itself depend on the module resolving — the exact failure that bricked
+// the 0.0.33 build when the package wasn't in BUNDLED_WORKSPACE_DEPS.
+// Type-only imports are erased at build time and carry no such risk.
+import type { WebSocketCommandBus } from '@moxxy/ipc-server-ws';
 import type { TransportServer } from '@moxxy/runner';
 
 import { resolveWsBridgeConfig } from './ws-bridge.js';
@@ -769,9 +774,20 @@ app.whenReady().then(async () => {
   // clients / the mobile app) is opt-in via MOXXY_WS_BRIDGE; when enabled, the
   // SAME handler bodies are registered onto it too. Register handlers BEFORE the
   // server starts accepting so an early client connection sees a populated bus.
+  // The bridge module is lazy-imported and fully guarded (the shell-updater
+  // pattern): the bridge is optional, so a module that fails to load must
+  // degrade to "bridge off", never take down the app.
   const electronBus = new ElectronCommandBus();
   const wsConfig = resolveWsBridgeConfig(app.getPath('userData'));
-  const wsBus = wsConfig ? new WebSocketCommandBus() : null;
+  let wsBridge: typeof import('@moxxy/ipc-server-ws') | null = null;
+  if (wsConfig) {
+    try {
+      wsBridge = await import('@moxxy/ipc-server-ws');
+    } catch (e) {
+      console.error('[moxxy] WebSocket bridge unavailable (module failed to load):', e);
+    }
+  }
+  const wsBus: WebSocketCommandBus | null = wsBridge ? new wsBridge.WebSocketCommandBus() : null;
   registerIpcHandlers(wsBus ? [electronBus, wsBus] : [electronBus], pool, desks, {
     update: {
       publicKeyPem: BUNDLED_UPDATE_PUBLIC_KEY,
@@ -780,10 +796,10 @@ app.whenReady().then(async () => {
       manifestUrl: process.env.MOXXY_UPDATE_URL,
     },
   });
-  if (wsBus && wsConfig) {
+  if (wsBridge && wsBus && wsConfig) {
     wsEventBus.addSink(wsBus);
     try {
-      wsServer = await startWsBridge(wsBus, wsConfig);
+      wsServer = await wsBridge.startWsBridge(wsBus, wsConfig);
       console.log(`[moxxy] WebSocket bridge listening on ${wsServer.address}`);
     } catch (e) {
       console.error('[moxxy] WebSocket bridge failed to start:', e);


### PR DESCRIPTION
## Release blocker for desktop 0.0.33

**Do not publish the `desktop-v0.0.33` draft release until it is rebuilt from this fix.**

PR #120 added a top-level static import of `@moxxy/ipc-server-ws` to `electron/main/index.ts` (evaluated at module load regardless of `MOXXY_WS_BRIDGE`) but did not add the package to `BUNDLED_WORKSPACE_DEPS` in `electron.vite.config.ts`. `externalizeDepsPlugin` therefore left a bare `@moxxy/ipc-server-ws` specifier in `dist-electron/main/index.js`, which cannot resolve in the packaged app (electron-builder ships only `dist`/`dist-electron`, no node_modules — the exact MODULE_NOT_FOUND failure the config's own comment documents).

Blast radius of the unfixed build:
- fresh installs of a packaged 0.0.33 crash at main-process boot with no fallback (this is the bootstrap floor)
- the Tier-1 hot-update bundle built from the same `dist-electron` fails to load as an override, gets marked bad, and reverts — re-poisoning self-update right after #115/#119 fixed it

## Fix (two layers)

1. **Bundle it**: `@moxxy/ipc-server-ws` added to `BUNDLED_WORKSPACE_DEPS`. `ws`'s optional native accelerators (`bufferutil`, `utf-8-validate`) stay external alongside `@napi-rs/keyring` — `ws` requires them inside try/catch and falls back to its JS implementations, so external-and-absent is safe (verified in the emitted chunk).
2. **Never let the optional bridge gate boot**: the static import is replaced with a guarded dynamic `import()` executed only when `MOXXY_WS_BRIDGE=1` (same pattern as `shell-updater.ts`), so even a future bundling regression degrades to bridge-off with an error log instead of a boot crash. Type-only imports remain static (erased at build).

## Verification

- `pnpm build` (58/58), desktop `typecheck` + `test` (12/12) green
- packaged with `electron-builder --dir`; emitted `dist-electron/main` contains **zero** bare `@moxxy/*` specifiers
- launched the packaged .app: boots clean (renderer served, tray up, process stable)
- launched with `MOXXY_WS_BRIDGE=1 MOXXY_WS_PORT=18841`: `[moxxy] WebSocket bridge listening on ws://127.0.0.1:18841`

Found by the 2026-06-09 main-branch audit (finding B1, adversarially verified).