### PR TITLE
fix(stability): audit wave 2 — session.reset RPC + leak-proof CLI probe sessions (A9/A10)

### DIFF
--- a/.changeset/cli-probe-sessions.md
+++ b/.changeset/cli-probe-sessions.md
@@ -1,0 +1,15 @@
+---
+'@moxxy/cli': patch
+---
+
+Stop CLI probe/light-boot sessions from leaking daemons. A new `probeSession`
+helper boots throwaway sessions with `skipInitHooks` (no scheduler poller, no
+webhooks listener — those now start exactly once, in the real session that
+owns them) and `disableSessionPersistence`, and guarantees the probe is closed
+before returning. Previously `moxxy <channel>` self-host booted three sessions
+and the orphaned probe won the webhooks port bind, so incoming webhooks ran
+turns on an abandoned session and duplicate scheduler pollers raced on the
+schedule store. Converted: the TUI needs-init probe, the `moxxy <command>`
+channel-existence probe, the channel-dispatch light-boots (`moxxy <channel>` /
+`moxxy channels …`), `moxxy schedule` store ops, the schedule-setup telegram
+check, and `moxxy plugins list`.

--- a/.changeset/session-reset-rpc.md
+++ b/.changeset/session-reset-rpc.md
@@ -1,0 +1,9 @@
+---
+"@moxxy/sdk": patch
+"@moxxy/core": patch
+"@moxxy/runner": patch
+"@moxxy/plugin-cli": patch
+"@moxxy/plugin-telegram": patch
+---
+
+`/new` now truly resets the session everywhere (audit A10). New `session.reset` runner RPC (protocol v3) + optional `SessionLike.reset()` capability: the runner aborts in-flight turns and clears its authoritative event log; the log's new `EventLog.onClear` listeners broadcast a `session.reset` notification so every attached mirror clears in lockstep (re-arming seq-0 ingest instead of silently rejecting all further events) and truncate the persisted session JSONL so wiped history can't resurrect on `--resume` — fixing the same resurrection bug for local `/new`. The TUI and Telegram `/new` paths call `reset()` (falling back to `log.clear()` when the capability is absent) and report an error instead of claiming "history cleared" when the reset RPC fails.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -87,16 +87,22 @@ Full report incl. the medium/low backlog and refuted findings:
   created post-bind + given an error handler (ws re-emits server errors → was a second
   crash path), and `bin.ts` installs last-resort guards (`process-guards.ts`: log+survive
   unhandledRejection, log+flush+exit 1 on uncaughtException).
-- **A9 [high, stability] CLI probe/light-boot sessions leak daemons** — three paths
-  (`run-tui.ts:228`, `bin.ts:236`, `run-channel.ts:34`) boot sessions without
-  `skipInitHooks` and never close them; an orphaned probe steals the webhooks port and
-  duplicate scheduler pollers race. `start-registered-channel.ts:41-48` shows the rule.
+- **A9 [high, stability] CLI probe/light-boot sessions leak daemons** — ✅ FIXED (this
+  PR): new `probeSession(opts, read)` in `cli/src/setup.ts` forces `skipInitHooks` +
+  `disableSessionPersistence` and closes the session in a `finally` (onShutdown fires even
+  when `read` throws); converted `run-tui.ts` (needs-init probe), `bin.ts`
+  (channel-existence probe), `run-channel.ts` + `channels.ts` (registry light-boots —
+  wizard runs inside the probe, the headless path boots the real daemon-owning session
+  after the probe closes), `schedule.ts` store ops, and `setup-cmd.ts`/`plugins.ts list`
+  reads. Still open (milder, one-shot processes that exit promptly): `moxxy -p`,
+  `schedule run`, `doctor`, `login`/`init` boot full sessions and never `close()`.
 - **A10 [high, stability] `/new` on attached clients is cosmetic and bricks the mirror** —
-  no reset RPC in `runner/src/protocol.ts`; TUI/Telegram clear only the local mirror
-  (`remote-session.ts:254-258`), runner context survives, and post-clear seq-contiguity
-  (`core/src/events/log.ts:87`) rejects all further events. Local `/new` also keeps
-  appending to the same JSONL → wiped history resurrects on `--resume`. Needs a
-  `session.reset` RunnerMethod.
+  ✅ FIXED (this PR): new `session.reset` RunnerMethod (protocol v3) + `SessionLike.reset?()`
+  capability — the runner aborts in-flight turns and clears its authoritative log, whose new
+  `EventLog.onClear` listeners broadcast a `session.reset` notification (every mirror clears
+  in lockstep, re-arming seq-0 ingest) and truncate the persistence JSONL (same hook fixes
+  local `/new` resurrecting on `--resume`); TUI/Telegram call `reset()` and surface an error
+  instead of claiming success when it fails.
 - **A11 [high, stability] `afterWorkflow` triggers have no cycle detection** — mutual
   A↔B triggers loop forever (`cli/src/setup/workflows.ts:184-188`), spawning subagents and
   burning provider tokens each round; `inFlight` clears before the next completion lands.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -23,7 +23,7 @@ import { runSessionsCommand } from './commands/sessions.js';
 import { runSecurityCommand } from './commands/security.js';
 import { runSelfUpdateCommand } from './commands/self-update.js';
 import { runUpdateCommand } from './commands/update.js';
-import { setupSessionWithConfig } from './setup.js';
+import { probeSession } from './setup.js';
 import { renderLogo } from './logo.js';
 import { colors } from './colors.js';
 import { cliVersion } from './version.js';
@@ -234,16 +234,20 @@ async function main(): Promise<number> {
   // channel disappeared mid-flow.
   let isChannel = false;
   try {
-    const { session } = await setupSessionWithConfig({
-      cwd: process.cwd(),
-      skipKeyPrompt: true,
-      tolerateNoProvider: true,
-      // We only need the channel registry here, never the provider.
-      // Activating it can hang or throw on hosts without a configured
-      // key, which would mask the real "unknown command" feedback.
-      skipProviderActivation: true,
-    });
-    isChannel = session.channels.has(argv.command);
+    // Throwaway probe (no init hooks/daemons, no persistence, closed
+    // before returning): we only need the channel registry here, never
+    // the provider. Activating it can hang or throw on hosts without a
+    // configured key, which would mask the real "unknown command"
+    // feedback.
+    isChannel = await probeSession(
+      {
+        cwd: process.cwd(),
+        skipKeyPrompt: true,
+        tolerateNoProvider: true,
+        skipProviderActivation: true,
+      },
+      ({ session }) => session.channels.has(argv.command),
+    );
   } catch {
     // Probe failed; fall through to "unknown command" so the user
     // gets a clear message rather than a confusing setup stack trace.

--- a/packages/cli/src/commands/channels.ts
+++ b/packages/cli/src/commands/channels.ts
@@ -1,7 +1,8 @@
 import type { ChannelDef, ChannelSubcommand } from '@moxxy/sdk';
-import { bootSessionWithConfig, helpRequested } from '../argv-helpers.js';
+import { argvToSetupOptions, helpRequested } from '../argv-helpers.js';
 import { printError } from '../errors.js';
 import type { ParsedArgv } from '../argv.js';
+import { probeSession } from '../setup.js';
 import { runChannelByName, runChannelSubcommand } from './run-channel.js';
 import { colors } from '../colors.js';
 
@@ -29,74 +30,90 @@ export async function runChannelsCommand(argv: ParsedArgv): Promise<number> {
   // provider. The previous flow inherited the full session boot from
   // `runChannelByName`, which threw "No working provider key" on
   // `moxxy channels telegram --help` despite the user having no need
-  // for a provider at all.
-  const { session, vault, config } = await bootSessionWithConfig(argv, {
-    skipKeyPrompt: true,
-    tolerateNoProvider: true,
-    skipProviderActivation: true,
-  });
+  // for a provider at all. probeSession additionally skips the init-hook
+  // daemons and closes the session before returning, so falling through
+  // to `runChannelByName` (which boots the REAL session) never leaves an
+  // orphaned session holding the webhooks port / a duplicate scheduler.
+  const outcome = await probeSession(
+    argvToSetupOptions(argv, {
+      skipKeyPrompt: true,
+      tolerateNoProvider: true,
+      skipProviderActivation: true,
+    }),
+    async ({ session, vault, config }): Promise<{ code: number } | 'run-channel'> => {
+      const def = session.channels.get(name);
+      if (!def) {
+        printError(
+          `unknown channel: ${name}\n  Available:\n` +
+            session.channels.list().map((d) => `    ${d.name} — ${d.description}\n`).join(''),
+        );
+        return { code: 2 };
+      }
 
-  const def = session.channels.get(name);
-  if (!def) {
-    printError(
-      `unknown channel: ${name}\n  Available:\n` +
-        session.channels.list().map((d) => `    ${d.name} — ${d.description}\n`).join(''),
-    );
-    return 2;
-  }
+      // No subcommand → either show help (--help/-h) or actually run the
+      // channel. Running falls through (after the probe closes) to the full
+      // provider-booting path.
+      if (!sub) {
+        if (helpRequested(argv)) {
+          process.stdout.write(formatChannelHelp(def));
+          return { code: 0 };
+        }
+        return 'run-channel';
+      }
 
-  // No subcommand → either show help (--help/-h) or actually run the
-  // channel. Running falls through to the full provider-booting path.
-  if (!sub) {
-    if (helpRequested(argv)) {
-      process.stdout.write(formatChannelHelp(def));
-      return 0;
-    }
-    return await runChannelByName(name, argv);
-  }
+      const subcommand = def.subcommands?.[sub];
+      if (!subcommand) {
+        const available = def.subcommands
+          ? Object.entries(def.subcommands)
+              .map(([n, c]) => `    ${name} ${n}  — ${c.description}\n`)
+              .join('')
+          : '    (none)\n';
+        printError(
+          `unknown '${name}' subcommand: ${sub}\n  Available subcommands:\n${available}`,
+        );
+        return { code: 2 };
+      }
 
-  const subcommand = def.subcommands?.[sub];
-  if (!subcommand) {
-    const available = def.subcommands
-      ? Object.entries(def.subcommands)
-          .map(([n, c]) => `    ${name} ${n}  — ${c.description}\n`)
-          .join('')
-      : '    (none)\n';
-    printError(
-      `unknown '${name}' subcommand: ${sub}\n  Available subcommands:\n${available}`,
-    );
-    return 2;
-  }
+      // Subcommand --help: print its description, don't run anything.
+      if (helpRequested(argv)) {
+        process.stdout.write(formatSubcommandHelp(name, sub, subcommand));
+        return { code: 0 };
+      }
 
-  // Subcommand --help: print its description, don't run anything.
-  if (helpRequested(argv)) {
-    process.stdout.write(formatSubcommandHelp(name, sub, subcommand));
-    return 0;
-  }
-
-  return await runChannelSubcommand(def, sub, {
-    session,
-    vault,
-    config,
-    argv: { ...argv, positional: rest },
-  });
+      return {
+        code: await runChannelSubcommand(def, sub, {
+          session,
+          vault,
+          config,
+          argv: { ...argv, positional: rest },
+        }),
+      };
+    },
+  );
+  if (outcome !== 'run-channel') return outcome.code;
+  return runChannelByName(name, argv);
 }
 
 async function runList(): Promise<number> {
   // Same as above: the list command doesn't need a provider; force
   // skipProviderActivation so `moxxy channels` is instant even when
-  // no API key is configured.
-  const { session, vault, config } = await bootSessionWithConfig(
-    { flags: {} },
-    { skipKeyPrompt: true, tolerateNoProvider: true, skipProviderActivation: true },
+  // no API key is configured. Probe semantics: no init-hook daemons,
+  // session closed before we print.
+  const { entries, config } = await probeSession(
+    argvToSetupOptions(
+      { flags: {} },
+      { skipKeyPrompt: true, tolerateNoProvider: true, skipProviderActivation: true },
+    ),
+    async ({ session, vault, config }) => ({
+      config,
+      entries: await session.channels.listWithAvailability({
+        cwd: process.cwd(),
+        vault,
+        logger: session.logger,
+        options: {},
+      }),
+    }),
   );
-  const deps = {
-    cwd: process.cwd(),
-    vault,
-    logger: session.logger,
-    options: {},
-  };
-  const entries = await session.channels.listWithAvailability(deps);
 
   // Layout: bold name + status label aligned in columns, then a dim
   // description below each. Subcommands indented under their parent.

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -12,7 +12,8 @@ import {
   setPluginEnabled,
 } from '@moxxy/plugin-plugins-admin';
 import type { ParsedArgv } from '../argv.js';
-import { bootSession, helpRequested } from '../argv-helpers.js';
+import { argvToSetupOptions, bootSession, helpRequested } from '../argv-helpers.js';
+import { probeSession } from '../setup.js';
 import { printError } from '../errors.js';
 import { runPluginNewCommand } from './plugin-new.js';
 import { colors } from '../colors.js';
@@ -73,12 +74,17 @@ export async function runPluginsCommand(argv: ParsedArgv): Promise<number> {
 }
 
 async function runList(argv: ParsedArgv): Promise<number> {
-  const session = await bootSession(argv, {
-    skipKeyPrompt: true,
-    tolerateNoProvider: true,
-    skipProviderActivation: true,
-  });
-  const loaded = session.pluginHost.list();
+  // Pure registry read — probe semantics (no init-hook daemons, session
+  // closed before we print). Plugin packages register before init hooks,
+  // so the listing is identical to a full boot's.
+  const loaded = await probeSession(
+    argvToSetupOptions(argv, {
+      skipKeyPrompt: true,
+      tolerateNoProvider: true,
+      skipProviderActivation: true,
+    }),
+    ({ session }) => session.pluginHost.list(),
+  );
   const disabled = await loadDisabledPackageNames();
   // "Installed" for catalog status = anything the host knows about: loaded
   // plugins plus disabled-but-present ones.

--- a/packages/cli/src/commands/run-channel.ts
+++ b/packages/cli/src/commands/run-channel.ts
@@ -1,9 +1,9 @@
 import { isRunnerUp } from '@moxxy/runner';
 import type { ChannelDef } from '@moxxy/sdk';
 import type { ParsedArgv } from '../argv.js';
-import { bootSessionWithConfig, hasBoolFlag } from '../argv-helpers.js';
+import { argvToSetupOptions, hasBoolFlag } from '../argv-helpers.js';
 import { printError } from '../errors.js';
-import type { SetupResult } from '../setup.js';
+import { probeSession, type SetupResult } from '../setup.js';
 import { runTuiWithBootstrap } from './run-tui.js';
 import { startRegisteredChannel } from './start-registered-channel.js';
 
@@ -29,42 +29,62 @@ export async function runChannelByName(name: string, argv: ParsedArgv): Promise<
   // default UI, not a cross-package concern.)
   if (name === 'tui') return runTuiWithBootstrap(argv);
 
-  // Light boot to read the channel registry without activating a provider:
-  // the interactive-command path (e.g. a setup wizard) does not run a turn.
-  const { session, vault, config } = await bootSessionWithConfig(argv, {
-    skipKeyPrompt: true,
-    tolerateNoProvider: true,
-    skipProviderActivation: true,
-  });
+  // Light boot (a probe: no init hooks/daemons, no persistence, closed before
+  // the headless runner below boots the REAL session) to read the channel
+  // registry without activating a provider: the interactive-command path
+  // (e.g. a setup wizard) does not run a turn.
+  const outcome = await probeSession(
+    argvToSetupOptions(argv, {
+      skipKeyPrompt: true,
+      tolerateNoProvider: true,
+      skipProviderActivation: true,
+    }),
+    async ({ session, vault, config }): Promise<{ code: number } | 'start-headless'> => {
+      const def = session.channels.get(name);
+      if (!def) {
+        printError(
+          `unknown channel: ${name}\n  Available:\n` +
+            session.channels.list().map((d) => `    ${d.name} - ${d.description}\n`).join(''),
+        );
+        return { code: 2 };
+      }
 
-  const def = session.channels.get(name);
-  if (!def) {
-    printError(
-      `unknown channel: ${name}\n  Available:\n` +
-        session.channels.list().map((d) => `    ${d.name} - ${d.description}\n`).join(''),
-    );
-    return 2;
-  }
+      // A channel may declare an interactive setup subcommand shown by default
+      // for TTY users. Bypass on:
+      //   - non-TTY (cron / systemd / piped)
+      //   - `--no-wizard` / `__skipWizard` (explicit opt-out / wizard hand-off,
+      //     so the recursive call doesn't trampoline back into the menu)
+      //   - `--standalone` (the user explicitly opts out of attaching)
+      //   - a runner already being up: the user wants to attach/run, not
+      //     configure, so go straight to the headless runner.
+      if (
+        def.interactiveCommand &&
+        process.stdin.isTTY === true &&
+        argv.flags['no-wizard'] !== true &&
+        argv.flags['__skipWizard'] !== true &&
+        !hasBoolFlag(argv, 'standalone') &&
+        !(await isRunnerUp())
+      ) {
+        // The wizard uses this (daemon-less) probe session directly; its
+        // `startChannel` hand-off recurses into runChannelByName, which boots
+        // its own real session — so the probe never needs init hooks.
+        return {
+          code: await runChannelSubcommand(def, def.interactiveCommand, {
+            session,
+            vault,
+            config,
+            argv,
+          }),
+        };
+      }
 
-  // A channel may declare an interactive setup subcommand shown by default
-  // for TTY users. Bypass on:
-  //   - non-TTY (cron / systemd / piped)
-  //   - `--no-wizard` / `__skipWizard` (explicit opt-out / wizard hand-off,
-  //     so the recursive call doesn't trampoline back into the menu)
-  //   - `--standalone` (the user explicitly opts out of attaching)
-  //   - a runner already being up: the user wants to attach/run, not
-  //     configure, so go straight to the headless runner.
-  if (
-    def.interactiveCommand &&
-    process.stdin.isTTY === true &&
-    argv.flags['no-wizard'] !== true &&
-    argv.flags['__skipWizard'] !== true &&
-    !hasBoolFlag(argv, 'standalone') &&
-    !(await isRunnerUp())
-  ) {
-    return runChannelSubcommand(def, def.interactiveCommand, { session, vault, config, argv });
-  }
+      return 'start-headless';
+    },
+  );
+  if (outcome !== 'start-headless') return outcome.code;
 
+  // Probe is closed; the headless path boots the real session (with init
+  // hooks, so the daemons run exactly once, in the session that owns them).
   return startRegisteredChannel(name, argv);
 }
 

--- a/packages/cli/src/commands/run-tui.ts
+++ b/packages/cli/src/commands/run-tui.ts
@@ -25,7 +25,7 @@ import {
 import { existsSync, unlinkSync } from 'node:fs';
 import { Socket } from 'node:net';
 import { spawn } from 'node:child_process';
-import { setupSession, setupSessionWithConfig, type BootStep } from '../setup.js';
+import { probeSession, setupSessionWithConfig, type BootStep } from '../setup.js';
 
 /** Best-effort recovery for "I had an older `moxxy serve` running
  *  at v1 and the new client is v2" scenarios. Kill whatever PID is
@@ -226,13 +226,19 @@ async function runSelfHostedTui(
     let needsInit = sources.length === 0;
     if (!needsInit) {
       try {
-        const probe = await setupSession({
-          ...argvToSetupOptions(argv),
-          tolerateNoProvider: true,
-          skipKeyPrompt: true,
-          disableSessionPersistence: true,
-        });
-        if (!probe.providers.getActiveName()) needsInit = true;
+        // Throwaway probe: "does a provider activate with the current
+        // config?". probeSession skips init hooks (no daemons) and closes
+        // the session before returning — the REAL session boots below with
+        // full init hooks.
+        const hasProvider = await probeSession(
+          {
+            ...argvToSetupOptions(argv),
+            tolerateNoProvider: true,
+            skipKeyPrompt: true,
+          },
+          ({ session }) => Boolean(session.providers.getActiveName()),
+        );
+        if (!hasProvider) needsInit = true;
       } catch {
         needsInit = true;
       }

--- a/packages/cli/src/commands/schedule.ts
+++ b/packages/cli/src/commands/schedule.ts
@@ -1,6 +1,6 @@
 import type { ParsedArgv } from '../argv.js';
 import { colors } from '../colors.js';
-import { setupSessionWithConfig } from '../setup.js';
+import { probeSession } from '../setup.js';
 import { SCHEDULE_HELP } from './schedule/help.js';
 import { runDaemon } from './schedule/daemon.js';
 import { runScheduleSetup } from './schedule/setup-cmd.js';
@@ -23,30 +23,36 @@ export async function runScheduleCommand(argv: ParsedArgv): Promise<number> {
   if (sub === 'setup') return await runScheduleSetup(argv);
   if (sub === 'daemon') return await runDaemon(argv);
 
-  // All non-daemon paths need the store but NOT the provider, so we
-  // can short-circuit setup if it ever offers that mode. For now,
-  // setupSessionWithConfig is the only setup entry — call it with
-  // tolerateNoProvider so 'moxxy schedule list' works pre-init.
-  const { scheduler } = await setupSessionWithConfig({
-    cwd: process.cwd(),
-    skipKeyPrompt: true,
-    tolerateNoProvider: true,
-  });
+  // `run` dispatches a real prompt — it boots its own full session.
+  if (sub === 'run') return runScheduleNow(argv);
 
-  switch (sub) {
-    case 'list':
-      return listSchedules(scheduler.store);
-    case 'add':
-      return addSchedule(scheduler.store, argv);
-    case 'remove':
-      return removeSchedule(scheduler.store, argv);
-    case 'enable':
-    case 'disable':
-      return toggleSchedule(scheduler.store, argv, sub);
-    case 'run':
-      return runScheduleNow(argv);
-    default:
-      process.stderr.write(colors.red(`unknown subcommand: ${sub}`) + '\n' + SCHEDULE_HELP);
-      return 2;
-  }
+  // All other non-daemon paths need the store but NOT the provider — and
+  // definitely not the init-hook daemons (a scheduler poller's first tick
+  // could fire a due schedule mid-`moxxy schedule list`, and the webhooks
+  // listener would steal the daemon's port). Probe: no init hooks, no
+  // persistence, session closed before returning. tolerateNoProvider keeps
+  // 'moxxy schedule list' working pre-init.
+  return probeSession(
+    {
+      cwd: process.cwd(),
+      skipKeyPrompt: true,
+      tolerateNoProvider: true,
+    },
+    async ({ scheduler }) => {
+      switch (sub) {
+        case 'list':
+          return listSchedules(scheduler.store);
+        case 'add':
+          return addSchedule(scheduler.store, argv);
+        case 'remove':
+          return removeSchedule(scheduler.store, argv);
+        case 'enable':
+        case 'disable':
+          return toggleSchedule(scheduler.store, argv, sub);
+        default:
+          process.stderr.write(colors.red(`unknown subcommand: ${sub}`) + '\n' + SCHEDULE_HELP);
+          return 2;
+      }
+    },
+  );
 }

--- a/packages/cli/src/commands/schedule/setup-cmd.ts
+++ b/packages/cli/src/commands/schedule/setup-cmd.ts
@@ -3,7 +3,7 @@ import * as os from 'node:os';
 import { PermissionEngine } from '@moxxy/core';
 import type { ParsedArgv } from '../../argv.js';
 import { colors } from '../../colors.js';
-import { setupSessionWithConfig } from '../../setup.js';
+import { probeSession } from '../../setup.js';
 import { installAndStartDaemon } from '../schedule-daemon-svc.js';
 
 const DEFAULT_HEADLESS_ALLOW_TOOLS = ['telegram_send_message', 'web_fetch'];
@@ -84,13 +84,19 @@ async function stepInstallDaemon(skipDaemon: boolean): Promise<void> {
 
 async function stepTelegramStatus(): Promise<void> {
   try {
-    const { vault } = await setupSessionWithConfig({
-      cwd: process.cwd(),
-      skipKeyPrompt: true,
-      tolerateNoProvider: true,
-    });
-    const hasToken = await vault.has('telegram_bot_token');
-    const chatRaw = await vault.get('telegram_authorized_chat_id');
+    // Probe (no init hooks/daemons, no persistence, closed before
+    // returning): we only need two vault reads here.
+    const { hasToken, chatRaw } = await probeSession(
+      {
+        cwd: process.cwd(),
+        skipKeyPrompt: true,
+        tolerateNoProvider: true,
+      },
+      async ({ vault }) => ({
+        hasToken: await vault.has('telegram_bot_token'),
+        chatRaw: await vault.get('telegram_authorized_chat_id'),
+      }),
+    );
     const hasChat = !!chatRaw;
     if (hasToken && hasChat) {
       process.stdout.write(

--- a/packages/cli/src/probe-session.test.ts
+++ b/packages/cli/src/probe-session.test.ts
@@ -1,0 +1,121 @@
+import * as os from 'node:os';
+import { describe, expect, it, vi } from 'vitest';
+import { Session, silentLogger } from '@moxxy/core';
+import { definePlugin } from '@moxxy/sdk';
+import { probeSession, type SetupOptions, type SetupResult } from './setup.js';
+
+/**
+ * Harness: a real `Session` with a spy plugin on its hook dispatcher, plus a
+ * fake boot fn that honours the one piece of the real
+ * `setupSessionWithConfig` contract under test here — init hooks are
+ * dispatched unless `skipInitHooks` is set (setup.ts line: `if
+ * (!opts.skipInitHooks) await session.dispatcher.dispatchInit(...)`).
+ */
+function makeHarness(): {
+  session: Session;
+  onInit: ReturnType<typeof vi.fn>;
+  onShutdown: ReturnType<typeof vi.fn>;
+  boot: (opts: SetupOptions) => Promise<SetupResult>;
+  bootCalls: SetupOptions[];
+} {
+  const onInit = vi.fn();
+  const onShutdown = vi.fn();
+  const session = new Session({ cwd: os.tmpdir(), logger: silentLogger });
+  session.dispatcher.setPlugins([
+    definePlugin({ name: 'spy-plugin', hooks: { onInit, onShutdown } }),
+  ]);
+  const bootCalls: SetupOptions[] = [];
+  const boot = async (opts: SetupOptions): Promise<SetupResult> => {
+    bootCalls.push(opts);
+    if (!opts.skipInitHooks) await session.dispatcher.dispatchInit(session.appContext());
+    return { session } as unknown as SetupResult;
+  };
+  return { session, onInit, onShutdown, boot, bootCalls };
+}
+
+describe('probeSession', () => {
+  it('forces skipInitHooks + disableSessionPersistence so a probe never starts init-hook daemons', async () => {
+    const h = makeHarness();
+    const answer = await probeSession(
+      { cwd: os.tmpdir(), tolerateNoProvider: true, skipKeyPrompt: true },
+      ({ session }) => session.channels.has('definitely-not-a-channel'),
+      h.boot,
+    );
+    expect(answer).toBe(false);
+    expect(h.bootCalls).toHaveLength(1);
+    expect(h.bootCalls[0]).toMatchObject({
+      // Caller flags pass through…
+      tolerateNoProvider: true,
+      skipKeyPrompt: true,
+      // …and the probe flags are forced on.
+      skipInitHooks: true,
+      disableSessionPersistence: true,
+    });
+    expect(h.onInit).not.toHaveBeenCalled();
+  });
+
+  it('forces the probe flags even when the caller explicitly turns them off', async () => {
+    const h = makeHarness();
+    await probeSession(
+      {
+        cwd: os.tmpdir(),
+        skipInitHooks: false,
+        disableSessionPersistence: false,
+      } as SetupOptions,
+      () => undefined,
+      h.boot,
+    );
+    expect(h.bootCalls[0]).toMatchObject({
+      skipInitHooks: true,
+      disableSessionPersistence: true,
+    });
+    expect(h.onInit).not.toHaveBeenCalled();
+  });
+
+  it('closes the probe session before returning the answer (onShutdown fires)', async () => {
+    const h = makeHarness();
+    const answer = await probeSession({ cwd: os.tmpdir() }, () => 42, h.boot);
+    expect(answer).toBe(42);
+    expect(h.onShutdown).toHaveBeenCalledTimes(1);
+    // Idempotence: a later close (e.g. a shared signal handler) is a no-op.
+    await h.session.close();
+    expect(h.onShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports an async read that uses the live session, closing only after it resolves', async () => {
+    const h = makeHarness();
+    const answer = await probeSession(
+      { cwd: os.tmpdir() },
+      async ({ session }) => {
+        // The session must not be shut down while read runs.
+        expect(h.onShutdown).not.toHaveBeenCalled();
+        return session.channels.list().length;
+      },
+      h.boot,
+    );
+    expect(answer).toBe(0);
+    expect(h.onShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the probe session even when read throws, and rethrows the original error', async () => {
+    const h = makeHarness();
+    await expect(
+      probeSession(
+        { cwd: os.tmpdir() },
+        () => {
+          throw new Error('boom');
+        },
+        h.boot,
+      ),
+    ).rejects.toThrow('boom');
+    expect(h.onShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('never lets a close failure mask the answer', async () => {
+    const close = vi.fn().mockRejectedValue(new Error('close failed'));
+    const boot = async (): Promise<SetupResult> =>
+      ({ session: { close } } as unknown as SetupResult);
+    await expect(probeSession({ cwd: os.tmpdir() }, () => 'ok', boot)).resolves.toBe('ok');
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -221,4 +221,41 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
   };
 }
 
+/**
+ * Boot a throwaway session purely to answer a question about the populated
+ * registries/config (does a channel exist? did a provider activate?), hand
+ * the answer back, and GUARANTEE the session is closed before returning.
+ *
+ * Probes always force:
+ *   - `skipInitHooks: true` — a probe must never start the init-time daemons
+ *     (scheduler poller, webhooks listener). Those belong to the REAL session
+ *     the caller boots afterwards; an orphaned probe winning the webhooks
+ *     port bind would silently starve the real session and route incoming
+ *     webhooks to an abandoned session.
+ *   - `disableSessionPersistence: true` — a probe never runs a turn, so it
+ *     must not litter `~/.moxxy/sessions` with empty logs.
+ *
+ * The session is closed (onShutdown hooks fire, then abort) in a `finally`,
+ * so closure holds even when `read` throws. Closing is best-effort: a
+ * cleanup failure never masks the probe's answer (or `read`'s own error).
+ *
+ * `boot` is injectable for tests only; production callers use the default.
+ */
+export async function probeSession<T>(
+  opts: SetupOptions,
+  read: (result: SetupResult) => T | Promise<T>,
+  boot: (opts: SetupOptions) => Promise<SetupResult> = setupSessionWithConfig,
+): Promise<T> {
+  const result = await boot({
+    ...opts,
+    skipInitHooks: true,
+    disableSessionPersistence: true,
+  });
+  try {
+    return await read(result);
+  } finally {
+    await result.session.close('probe-complete').catch(() => undefined);
+  }
+}
+
 export { createAllowListResolver, createCallbackResolver, denyByDefaultResolver };

--- a/packages/core/src/events/log.test.ts
+++ b/packages/core/src/events/log.test.ts
@@ -134,6 +134,54 @@ describe('EventLog', () => {
     expect(seen).toEqual([ev.seq]);
   });
 
+  it('clear empties the log, fires onClear, and re-arms ingest at seq 0', async () => {
+    const source = new EventLog();
+    const before = await source.append({
+      type: 'user_prompt',
+      sessionId: sid,
+      turnId: tid,
+      source: 'user',
+      text: 'pre-reset',
+    });
+
+    const mirror = new EventLog();
+    mirror.ingest(before);
+    const cleared = vi.fn();
+    const off = mirror.onClear(cleared);
+    mirror.clear();
+    expect(mirror.length).toBe(0);
+    expect(cleared).toHaveBeenCalledTimes(1);
+
+    // Post-reset events restart at seq 0 — an empty mirror accepts them.
+    source.clear();
+    const after = await source.append({
+      type: 'user_prompt',
+      sessionId: sid,
+      turnId: tid,
+      source: 'user',
+      text: 'post-reset',
+    });
+    expect(after.seq).toBe(0);
+    mirror.ingest(after);
+    expect(mirror.length).toBe(1);
+    expect(mirror.at(0)?.id).toBe(after.id);
+
+    off();
+    mirror.clear();
+    expect(cleared).toHaveBeenCalledTimes(1);
+  });
+
+  it('clear survives a throwing onClear listener', () => {
+    const log = new EventLog();
+    log.onClear(() => {
+      throw new Error('boom');
+    });
+    const ok = vi.fn();
+    log.onClear(ok);
+    expect(() => log.clear()).not.toThrow();
+    expect(ok).toHaveBeenCalledTimes(1);
+  });
+
   // ensure unused import is exercised for typecheck stability
   void z;
   void asToolCallId;

--- a/packages/core/src/events/log.ts
+++ b/packages/core/src/events/log.ts
@@ -13,6 +13,7 @@ export type EventListener = (event: MoxxyEvent) => void | Promise<void>;
 export class EventLog implements EventLogReader {
   private readonly events: MoxxyEvent[] = [];
   private readonly listeners = new Set<EventListener>();
+  private readonly clearListeners = new Set<() => void>();
   private readonly now: () => number;
 
   constructor(seed: ReadonlyArray<MoxxyEvent> = [], opts: { now?: () => number } = {}) {
@@ -97,19 +98,39 @@ export class EventLog implements EventLogReader {
   }
 
   /**
-   * Drop every event from the log. Used by `/new` (TUI) to start a
-   * fresh session without rebuilding the entire Session object — the
+   * Drop every event from the log. Used by `/new` to start a fresh
+   * session without rebuilding the entire Session object — the
    * registries, resolvers, and active provider stay; only the
-   * conversation context vanishes. Listeners are intentionally NOT
-   * notified: there's no "event removed" event in the schema, and any
-   * subscriber that wants to react to a wipe can observe the
-   * subsequent next-`user_prompt` arriving with seq=0.
+   * conversation context vanishes. Per-event listeners are NOT
+   * notified (there's no "event removed" event in the schema), but
+   * {@link onClear} subscribers fire — that's how the persistence
+   * sidecar truncates its JSONL (so `--resume` can't resurrect wiped
+   * history) and how the runner broadcasts a reset to attached
+   * mirrors, in lockstep with the wipe.
    *
    * Safe to call only when no turn is in flight — callers should abort
    * their AbortController and await any pending runTurn() first.
    */
   clear(): void {
     this.events.length = 0;
+    const snapshot = [...this.clearListeners];
+    for (const fn of snapshot) {
+      try {
+        fn();
+      } catch {
+        // A clear listener must not block the wipe.
+      }
+    }
+  }
+
+  /**
+   * Subscribe to {@link clear}. Fires synchronously after the events array
+   * empties, so a listener reading the log observes the post-wipe state.
+   * Returns the unsubscribe callback.
+   */
+  onClear(fn: () => void): () => void {
+    this.clearListeners.add(fn);
+    return () => this.clearListeners.delete(fn);
   }
 
   asReader(): EventLogReader {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -275,6 +275,19 @@ export class Session implements ClientSession, SessionRuntime {
   }
 
   /**
+   * `SessionLike.reset` — the authoritative `/new`. Clears the event log;
+   * the log's clear listeners propagate the wipe to whatever observes it
+   * (the persistence sidecar truncates its JSONL so `--resume` sees an
+   * empty session; a wrapping RunnerServer broadcasts a reset so attached
+   * mirrors clear in lockstep). Registries, resolvers, and the active
+   * provider survive — only the conversation context vanishes. Callers
+   * must abort any in-flight turn first (same contract as `log.clear()`).
+   */
+  async reset(): Promise<void> {
+    this.log.clear();
+  }
+
+  /**
    * Graceful shutdown: fire every plugin's `onShutdown` hook, then abort
    * the session. Idempotent — safe to call multiple times (subsequent
    * calls are no-ops once `closed` is set).

--- a/packages/core/src/sessions/persistence.test.ts
+++ b/packages/core/src/sessions/persistence.test.ts
@@ -67,6 +67,44 @@ describe('SessionPersistence', () => {
     detach();
   });
 
+  it('log.clear() truncates the JSONL so wiped history cannot resurrect on resume', async () => {
+    const dir = await makeTempDir();
+    const id = '01CLEARTRUNCATE00000000000';
+    const log = new EventLog();
+    const persistence = new SessionPersistence({ sessionId: id as never, cwd: '/tmp/p', dir });
+    const detach = persistence.attach(log);
+
+    await log.append({
+      type: 'user_prompt',
+      sessionId: id as never,
+      turnId: 't1' as never,
+      source: 'user',
+      text: 'wiped by /new',
+    });
+    await waitForCondition(async () => (await restoreEvents(id, dir)).length === 1);
+
+    // /new — the in-memory wipe must reach the sidecar.
+    log.clear();
+    await waitForCondition(async () => (await restoreEvents(id, dir)).length === 0);
+
+    // Post-reset events land in the fresh file from seq 0, so a later
+    // --resume restores exactly the new conversation (no duplicate seqs).
+    await log.append({
+      type: 'user_prompt',
+      sessionId: id as never,
+      turnId: 't2' as never,
+      source: 'user',
+      text: 'fresh start',
+    });
+    await waitForCondition(async () => (await restoreEvents(id, dir)).length === 1);
+    const restored = await restoreEvents(id, dir);
+    expect(restored).toHaveLength(1);
+    expect(restored[0]!.seq).toBe(0);
+    expect((restored[0] as { text?: string }).text).toBe('fresh start');
+
+    detach();
+  });
+
   it('two concurrent sessions both survive (no shared-index clobber)', async () => {
     const dir = await makeTempDir();
     const idA = '01AAAA00000000000000000001';
@@ -97,5 +135,19 @@ async function waitForFile(file: string): Promise<void> {
       if (Date.now() > deadline) throw new Error(`Timed out waiting for ${file}`);
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
+  }
+}
+
+/** Poll an async predicate until it holds (writes are queued + debounced). */
+async function waitForCondition(predicate: () => Promise<boolean>): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  for (;;) {
+    try {
+      if (await predicate()) return;
+    } catch {
+      // file may not exist yet — keep polling
+    }
+    if (Date.now() > deadline) throw new Error('Timed out waiting for condition');
+    await new Promise((resolve) => setTimeout(resolve, 10));
   }
 }

--- a/packages/core/src/sessions/persistence.ts
+++ b/packages/core/src/sessions/persistence.ts
@@ -89,6 +89,12 @@ export class SessionPersistence {
    * Subscribe to the log; returns the unsubscribe callback. The first
    * call also writes the initial index row so `moxxy resume` lists
    * the session before any events arrive.
+   *
+   * Also subscribes to the log's `clear()`, truncating the JSONL in
+   * lockstep so a `/new` wipe can't resurrect on `--resume`. The
+   * session keeps its id and file: post-reset events restart at seq 0
+   * in the same (now empty) JSONL, matching how the in-memory log
+   * reuses the same Session object.
    */
   attach(log: EventLog): () => void {
     void this.ensureDir()
@@ -99,9 +105,14 @@ export class SessionPersistence {
       if (this.closed) return;
       this.enqueueAppend(event);
     });
+    const unsubClear = log.onClear(() => {
+      if (this.closed) return;
+      this.enqueueTruncate();
+    });
     return () => {
       this.closed = true;
       unsub();
+      unsubClear();
       // Flush a final index write so lastActivity reflects the close
       // time even if no events arrived in the last debounce window.
       this.scheduleIndexWrite();
@@ -137,6 +148,23 @@ export class SessionPersistence {
     const line = JSON.stringify(event) + '\n';
     // never propagate a write error into the listener chain
     void this.writeQueue.run(() => fs.appendFile(this.logPath, line, 'utf8')).catch(() => undefined);
+  }
+
+  /**
+   * Mirror a `log.clear()` on disk: truncate the JSONL and reset the
+   * sidecar's counters. Rides the same write queue as appends, so
+   * pre-clear appends flush first and post-clear appends land in the
+   * fresh (empty) file — ordering matches the in-memory log exactly.
+   */
+  private enqueueTruncate(): void {
+    this.meta = {
+      ...this.meta,
+      eventCount: 0,
+      firstPrompt: null,
+      lastActivity: new Date().toISOString(),
+    };
+    this.scheduleIndexWrite();
+    void this.writeQueue.run(() => fs.writeFile(this.logPath, '', 'utf8')).catch(() => undefined);
   }
 
   private scheduleIndexWrite(): void {

--- a/packages/plugin-cli/src/session/SessionView.tsx
+++ b/packages/plugin-cli/src/session/SessionView.tsx
@@ -211,7 +211,6 @@ export const SessionView: React.FC<SessionViewProps> = ({
     // 'new': full session reset.
     const ctrl = turn.turnControllerRef.current;
     if (ctrl && !ctrl.signal.aborted) ctrl.abort('user reset');
-    session.log.clear();
     setOverlay(null);
     for (const p of permissions.pendingPermissions) {
       p.resolve({ mode: 'deny', reason: '/new — session reset' });
@@ -222,7 +221,28 @@ export const SessionView: React.FC<SessionViewProps> = ({
     setYolo(false);
     turn.queueRef.current = [];
     turn.setQueueCount(0);
-    if (notice) setSystemNotice(notice);
+    // Wipe the history at its source. `session.reset` is the authoritative
+    // path on both session kinds: a local Session clears its EventLog AND
+    // truncates the persistence sidecar (so --resume can't resurrect the
+    // wiped history); a RemoteSession asks the runner, which clears ITS log
+    // and re-syncs every attached mirror. Falling back to a mirror-only
+    // `log.clear()` would leave the runner's context intact and desync this
+    // mirror, so only claim success when the reset actually happened.
+    if (typeof session.reset === 'function') {
+      void session.reset().then(
+        () => {
+          if (notice) setSystemNotice(notice);
+        },
+        (err: unknown) => {
+          setSystemNotice(
+            `/new failed: ${err instanceof Error ? err.message : String(err)} — history NOT cleared`,
+          );
+        },
+      );
+    } else {
+      session.log.clear();
+      if (notice) setSystemNotice(notice);
+    }
   };
 
   const handleSubmit = async (text: string): Promise<void> => {

--- a/packages/plugin-telegram/src/channel/text-handler.ts
+++ b/packages/plugin-telegram/src/channel/text-handler.ts
@@ -138,12 +138,26 @@ async function performSessionAction(
     if (state.turnController && !state.turnController.signal.aborted) {
       state.turnController.abort('user reset');
     }
-    state.session.log.clear();
     deps.framePump.resetRenderer();
     cb.setYolo(false);
     cb.setAwaitingApprovalText(null);
     deps.approvalResolver.abortAll('session reset');
     deps.permissionResolver.abortAll('session reset');
+    // Wipe the history at its source. On a RemoteSession `reset()` asks the
+    // runner to clear its authoritative log (and persisted JSONL) and
+    // re-sync every attached mirror; on a local Session it clears the
+    // EventLog + truncates the sidecar. A mirror-only `log.clear()` would
+    // be cosmetic AND desync this client, so only claim success when the
+    // reset actually happened.
+    try {
+      if (typeof state.session.reset === 'function') await state.session.reset();
+      else state.session.log.clear();
+    } catch (err) {
+      await ctx.reply(
+        `⚠ /new failed: ${err instanceof Error ? err.message : String(err)} — history NOT cleared`,
+      );
+      return;
+    }
     await ctx.reply(`✓ ${notice ?? 'new session — conversation history cleared'}`);
   }
 }

--- a/packages/runner/src/integration.test.ts
+++ b/packages/runner/src/integration.test.ts
@@ -8,7 +8,13 @@ import os from 'node:os';
 import path from 'node:path';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { afterEach, describe, expect, it } from 'vitest';
-import { Session, autoAllowResolver, silentLogger } from '@moxxy/core';
+import {
+  Session,
+  SessionPersistence,
+  autoAllowResolver,
+  restoreSessionEvents,
+  silentLogger,
+} from '@moxxy/core';
 import {
   defineMode,
   definePlugin,
@@ -65,6 +71,20 @@ async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void
   const deadline = Date.now() + timeoutMs;
   while (!predicate()) {
     if (Date.now() > deadline) throw new Error('waitFor: condition not met in time');
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+/** Async-predicate variant of waitFor (persistence writes are queued + debounced). */
+async function waitForAsync(predicate: () => Promise<boolean>, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      if (await predicate()) return;
+    } catch {
+      // e.g. the JSONL doesn't exist yet — keep polling
+    }
+    if (Date.now() > deadline) throw new Error('waitForAsync: condition not met in time');
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
 }
@@ -446,6 +466,71 @@ describe('runner end-to-end', () => {
       mimeType: 'audio/ogg',
     });
     expect(result.text).toBe('transcribed on the runner');
+  });
+
+  it('session.reset clears the runner, every mirror, and the persisted JSONL', async () => {
+    // Regression for A10: /new on an attached client used to clear only the
+    // local mirror — the runner kept the full context (resurrecting it on the
+    // next provider call and replaying it on reattach), and the desynced
+    // mirror silently rejected every subsequent event (ingest only accepts
+    // contiguous seq). reset() must wipe the source of truth and re-sync
+    // every attached client.
+    const sessionsDir = await mkdtemp(path.join(os.tmpdir(), 'moxxy-reset-'));
+    try {
+      const socketPath = tmpSocket();
+      const session = buildSession(
+        new FakeProvider({ script: [textReply('first answer'), textReply('second answer')] }),
+      );
+      const persistence = new SessionPersistence({
+        sessionId: session.id,
+        cwd: session.cwd,
+        dir: sessionsDir,
+      });
+      const detach = persistence.attach(session.log);
+      const server = await startRunnerServer(session, { socketPath });
+      servers.push(server);
+
+      const driver = await attach(socketPath, 'driver');
+      const observer = await attach(socketPath, 'observer');
+
+      for await (const _event of driver.runTurn('say hi')) void _event;
+      await waitFor(() => observer.log.ofType('assistant_message').length > 0);
+      const preResetLen = session.log.length;
+      expect(preResetLen).toBeGreaterThan(0);
+      // The sidecar flushed the pre-reset history.
+      await waitForAsync(async () => (await restoreSessionEvents(session.id, sessionsDir)).length === preResetLen);
+
+      await driver.reset();
+
+      // Source of truth and BOTH mirrors are empty (the notification is
+      // broadcast before the RPC reply, but the observer rides a separate
+      // socket — poll it).
+      expect(session.log.length).toBe(0);
+      expect(driver.log.length).toBe(0);
+      await waitFor(() => observer.log.length === 0);
+      // --resume sees an empty session: the JSONL was truncated, not kept.
+      await waitForAsync(async () => (await restoreSessionEvents(session.id, sessionsDir)).length === 0);
+
+      // Post-reset events restart at seq 0 and every mirror ingests them —
+      // previously the cleared mirror rejected the whole stream forever.
+      for await (const _event of observer.runTurn('again')) void _event;
+      await waitFor(() => driver.log.ofType('assistant_message').length > 0);
+      expect(driver.log.at(0)?.seq).toBe(0);
+      expect(observer.log.at(0)?.seq).toBe(0);
+      const fresh = driver.log.ofType('assistant_message')[0] as AssistantMessageEvent | undefined;
+      expect(fresh?.content).toContain('second answer');
+
+      // The persisted file holds only the post-reset conversation.
+      const postLen = session.log.length;
+      await waitForAsync(async () => (await restoreSessionEvents(session.id, sessionsDir)).length === postLen);
+      const persisted = await restoreSessionEvents(session.id, sessionsDir);
+      expect(persisted[0]?.seq).toBe(0);
+      expect(JSON.stringify(persisted)).not.toContain('first answer');
+
+      detach();
+    } finally {
+      await rm(sessionsDir, { recursive: true, force: true });
+    }
   });
 
   it('keeps routing installed when a self-hosting client sets its own resolvers', async () => {

--- a/packages/runner/src/protocol.ts
+++ b/packages/runner/src/protocol.ts
@@ -21,8 +21,14 @@ import type {
  * the MCP-server admin + workflows panels remotely. Both families degrade
  * cleanly when the corresponding plugin isn't loaded on the runner — the
  * server returns an empty list / `null` rather than throwing.
+ *
+ * v3: adds `session.reset` (request) + `session.reset` (notification) so
+ * `/new` clears the runner's authoritative log — not just a client's local
+ * mirror — and every attached mirror clears in lockstep. Without it, a
+ * mirror-only clear desyncs seq-contiguous `ingest` and the mirror silently
+ * rejects every subsequent event.
  */
-export const RUNNER_PROTOCOL_VERSION = 2;
+export const RUNNER_PROTOCOL_VERSION = 3;
 
 /** Request methods. Client->server unless noted. */
 export const RunnerMethod = {
@@ -34,6 +40,14 @@ export const RunnerMethod = {
   RunTurn: 'runTurn',
   /** client->server: abort an in-flight turn. */
   Abort: 'abort',
+  /**
+   * client->server: `/new` — abort every in-flight turn, clear the runner's
+   * authoritative event log (and, via the log's clear listeners, truncate
+   * the persisted session JSONL so `--resume` can't resurrect the wiped
+   * history). The runner broadcasts the `session.reset` notification to ALL
+   * attached clients so every mirror clears in lockstep.
+   */
+  SessionReset: 'session.reset',
   /** client->server: declare which resolvers this client will answer. */
   SetResolver: 'setResolver',
   /** client->server: switch the active mode. */
@@ -75,6 +89,13 @@ export const RunnerNotification = {
   TurnComplete: 'turn.complete',
   /** The registry snapshot changed (plugin reload, mode switch, …). */
   InfoChanged: 'info.changed',
+  /**
+   * The runner's event log was reset (`/new` from any client, or a
+   * self-hosting channel clearing the local log directly). Mirrors MUST
+   * clear: post-reset events restart at seq 0, which a seq-contiguous
+   * mirror only accepts from an empty log.
+   */
+  SessionReset: 'session.reset',
 } as const;
 export type RunnerNotification = (typeof RunnerNotification)[keyof typeof RunnerNotification];
 

--- a/packages/runner/src/remote-session.ts
+++ b/packages/runner/src/remote-session.ts
@@ -189,6 +189,14 @@ export class RemoteSession implements ClientSession {
     this.peer.on(RunnerNotification.InfoChanged, (params) => {
       this.info = (params as InfoChangedNotification).info;
     });
+    this.peer.on(RunnerNotification.SessionReset, () => {
+      // The runner wiped its authoritative log (a /new from this client or
+      // any other). Clear the mirror in lockstep: `ingest` accepts only
+      // seq === mirror.length, so post-reset events restarting at seq 0 are
+      // accepted exactly when the mirror is empty again. The mirror's own
+      // clear listeners fire, letting channel UIs observe the wipe.
+      this.mirror.clear();
+    });
 
     // Server->client requests (the runner asks us to decide).
     this.peer.handle(RunnerMethod.PermissionCheck, (params) => {
@@ -252,9 +260,23 @@ export class RemoteSession implements ClientSession {
   }
 
   get log(): SessionLogReader & { clear(): void } {
-    // The mirror is a local EventLog - `clear()` resets THIS client's view
-    // (used by /new) without touching the runner's shared history.
+    // The mirror is a local EventLog. NOTE: `clear()` here resets THIS
+    // client's view only — it desyncs the mirror against the runner's live
+    // seq stream. For `/new`, call {@link reset} instead: the runner clears
+    // its authoritative log and notifies every mirror (including this one).
     return this.mirror;
+  }
+
+  /**
+   * `SessionLike.reset` — server-authoritative `/new`. The runner aborts
+   * in-flight turns, clears its log + persisted JSONL, and broadcasts
+   * `session.reset`; our mirror clears when that notification lands (it is
+   * sent before this RPC's reply on the same ordered socket, so the mirror
+   * is already empty by the time this resolves). Rejects when the runner is
+   * unreachable — callers must surface that instead of claiming success.
+   */
+  async reset(): Promise<void> {
+    await this.peer.request(RunnerMethod.SessionReset, {});
   }
 
   getInfo(): SessionInfo {

--- a/packages/runner/src/server.ts
+++ b/packages/runner/src/server.ts
@@ -76,6 +76,7 @@ export class RunnerServer {
   private readonly turnControllers = new Map<TurnId, AbortController>();
   private readonly scope = new AsyncLocalStorage<TurnScope>();
   private readonly logUnsub: () => void;
+  private readonly logClearUnsub: () => void;
   private readonly modesUnsub: () => void;
   /**
    * Resolvers for unscoped (local) turns - the fall-through path. Seeded from
@@ -96,6 +97,14 @@ export class RunnerServer {
     this.installRoutingResolvers();
     this.transport.onConnection((t) => this.onConnection(t));
     this.logUnsub = session.log.subscribe((event) => this.broadcastEvent(event));
+    // Mirror a log wipe to every attached client. Subscribing to the log's
+    // clear listener (rather than broadcasting inside handleSessionReset)
+    // covers BOTH reset paths — the session.reset RPC and a self-hosting
+    // channel clearing the local log directly — so mirrors can never desync
+    // against a wiped log whose next event restarts at seq 0.
+    this.logClearUnsub = session.log.onClear(() =>
+      this.broadcast(RunnerNotification.SessionReset, {}),
+    );
     // Mirror active-mode changes to clients — covers both the SetMode RPC and a
     // mode handing off to another mode post-turn.
     this.modesUnsub = session.modes.onActiveChange(() => this.broadcastInfo());
@@ -109,6 +118,7 @@ export class RunnerServer {
     if (this.closed) return;
     this.closed = true;
     this.logUnsub();
+    this.logClearUnsub();
     this.modesUnsub();
     for (const client of this.clients) client.peer.close();
     this.clients.clear();
@@ -133,6 +143,7 @@ export class RunnerServer {
     peer.handle(RunnerMethod.GetInfo, () => this.session.getInfo());
     peer.handle(RunnerMethod.RunTurn, (raw) => this.handleRunTurn(client, raw));
     peer.handle(RunnerMethod.Abort, (raw) => this.handleAbort(raw));
+    peer.handle(RunnerMethod.SessionReset, () => this.handleSessionReset());
     peer.handle(RunnerMethod.SetResolver, (raw) => this.handleSetResolver(client, raw));
     peer.handle(RunnerMethod.ModeSetActive, (raw) => this.handleModeSetActive(raw));
     peer.handle(RunnerMethod.ProviderSetActive, (raw) => this.handleProviderSetActive(raw));
@@ -236,6 +247,24 @@ export class RunnerServer {
   private handleAbort(raw: unknown): Record<string, never> {
     const params = abortParamsSchema.parse(raw);
     this.turnControllers.get(params.turnId as TurnId)?.abort('client requested abort');
+    return {};
+  }
+
+  /**
+   * `/new` from any attached client. Aborts every in-flight turn (whoever
+   * started it — the wipe is session-global), then clears the authoritative
+   * log. The clear cascades: the log's clear listeners broadcast the
+   * `session.reset` notification to all attached mirrors (wired in the
+   * ctor) and truncate the persistence sidecar's JSONL. An aborted turn may
+   * still flush a final event after the wipe; it lands in the fresh log at
+   * seq 0+ and is broadcast AFTER the reset notification (single ordered
+   * socket), so mirrors stay contiguous either way.
+   */
+  private handleSessionReset(): Record<string, never> {
+    for (const controller of this.turnControllers.values()) {
+      controller.abort('session reset');
+    }
+    this.session.log.clear();
     return {};
   }
 

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -236,6 +236,20 @@ export interface SessionLike {
   close(reason?: string): Promise<void>;
 
   /**
+   * Authoritative session reset (`/new`): wipe the conversation history at
+   * its source so it cannot resurrect. On an in-process `Session` this clears
+   * the real `EventLog` (and, via the log's clear listeners, truncates the
+   * persistence sidecar so `--resume` sees an empty session). On a
+   * `RemoteSession` it invokes the runner's `session.reset` RPC — the runner
+   * aborts in-flight turns, clears ITS log, and broadcasts a reset
+   * notification so every attached mirror clears in lockstep. Optional
+   * capability per the seam convention: callers MUST guard and fall back to
+   * `log.clear()` when absent, and MUST surface a rejection instead of
+   * claiming the history was cleared.
+   */
+  reset?(): Promise<void>;
+
+  /**
    * Live runtime capabilities present only on an in-process Session; a
    * `RemoteSession` thin client leaves them undefined, so callers MUST guard.
    * For plain display prefer the serializable {@link getInfo} snapshot — these


### PR DESCRIPTION
Fixes two adversarially-verified findings from the 2026-06-09 main-branch audit (intake in TECH_DEBT.md).

## A10 — `/new` on attached clients was cosmetic and bricked the mirror (stability, high)
- New `session.reset` RunnerMethod + `session.reset` server→client notification; **`RUNNER_PROTOCOL_VERSION` 2 → 3** (a stale daemon now fails the attach handshake loudly and is cleaned by the existing — now identity-gated — mismatch recovery).
- Server: aborts every in-flight turn, then `session.log.clear()`. The broadcast rides a new `EventLog.onClear` listener subscribed by the server, so a self-hosting channel clearing the local log directly re-syncs attached mirrors too. Ordering safe: clear broadcasts synchronously on the same ordered socket, so post-reset events land after the notification.
- Mirrors: clear on the notification and naturally re-arm at seq 0 (ingest contiguity preserved — the permanent post-`/new` event rejection is gone). `RemoteSession.log.clear()` docs now warn it desyncs and point to `reset()`.
- Persistence: `SessionPersistence` truncates the JSONL + resets sidecar meta on clear **through the same write-queue mutex as appends** (pre-clear appends flush → truncate → post-clear appends land in the fresh file), so `--resume` no longer resurrects wiped history — locally and attached. Truncation keeps the session id (matches `/new` keeping the same Session object); the desktop's id-rotating supervisor reset is a different layer, untouched and verified compiling.
- `SessionLike` gains optional `reset?()`; `Session` and `RemoteSession` implement it; TUI + Telegram `/new` capability-detect it and show **"/new failed: … — history NOT cleared"** on rejection instead of a false success notice.

## A9 — CLI probe/light-boot sessions leaked daemons (stability, high)
- New `probeSession<T>(opts, read)` helper force-merges `skipInitHooks: true` + `disableSessionPersistence: true` over caller options and guarantees `session.close()` in a `finally` (closure even when `read` throws; a close failure never masks the answer).
- All three audit-cited leaks converted (run-tui needs-init probe, bin.ts channel-existence probe, run-channel registry light-boot) **plus four more found in the sweep**: `channels.ts`, `schedule.ts` (a scheduler first-tick could fire a due schedule mid-`list`), `schedule/setup-cmd.ts`, `plugins.ts` list.
- Daemons (scheduler poller, webhooks listener) now start exactly once, in the real session; an orphaned probe can no longer steal the webhooks port. Remaining one-shot non-daemon leaks (`moxxy -p`, `doctor`, `login`/`init`) recorded in the journal entry.

## Verification
- New runner integration test: two attached clients + persistence → reset from one → server log + both mirrors empty, JSONL truncated, post-reset turn ingests from seq 0 on both, `--resume` sees empty.
- Suites: runner 38/38, core 204/204, sdk 124/124, plugin-cli 63/63, plugin-telegram 50/50, cli 98/98 (incl. 6 new probe tests). Rebased on post-#128 main; workspace gate: build 58/58, typecheck clean, tests 111/111, lint 0 errors.
- Changesets: patches for sdk (optional member), core, runner, plugin-cli, plugin-telegram, cli.
- TECH_DEBT intake A9/A10 marked ✅ FIXED.