### PR TITLE
fix(security,stability): audit wave 3 — A5/A6/A11/A12/A13

### DIFF
--- a/.changeset/browser-ssrf-guard.md
+++ b/.changeset/browser-ssrf-guard.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/plugin-browser': patch
+---
+
+Security: `browser_session.goto` now enforces the same SSRF guard as `web_fetch`. The `assertPublicUrl` check (loopback, RFC-1918, link-local incl. the 169.254.169.254 metadata endpoint, CGNAT, multicast, IPv6 ULA/link-local, with hostname resolution) moved into a shared `ssrf-guard` module and runs in the parent before the goto RPC, again inside the Playwright sidecar's dispatch (defence in depth), and on every top-level/iframe navigation via context route interception — so a page can't redirect itself into a private origin after a legitimate goto. Subresource requests are not filtered; this residual risk is documented in the tool description.

--- a/.changeset/mobile-qr-bind-host.md
+++ b/.changeset/mobile-qr-bind-host.md
@@ -1,0 +1,5 @@
+---
+"@moxxy/plugin-channel-mobile": patch
+---
+
+`moxxy mobile` no longer prints an unconnectable QR in the default config. The server binds loopback by default (deliberate security posture, unchanged) but the QR advertised the machine's LAN IP — an address nothing was listening on, so a real phone got connection refused. The connect URL now advertises exactly what is reachable: the loopback default prints `ws://127.0.0.1:<port>` (works for simulators on the same machine) plus a hint that a real device needs the explicit LAN opt-in or a tunnel; a wildcard bind (`0.0.0.0`/`::`) advertises the LAN IP; an explicit bind host is advertised verbatim; the tunnel path is unchanged. Also adds `MOXXY_MOBILE_HOST` (env → `channels.mobile.bindHost` config → loopback default, matching the channel's token/tunnel convention) and updates `apps/mobile/README.md` to document simulator-via-loopback vs phone-via-opt-in/tunnel.

--- a/.changeset/provider-test-vault-key.md
+++ b/.changeset/provider-test-vault-key.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/plugin-provider-admin': patch
+---
+
+Security: `provider_test` no longer takes the plaintext API key as model-visible tool input. It now takes the NAME of a vault secret (`keyName`, e.g. `DEEPSEEK_API_KEY`) and resolves the key at call time via `ctx.getSecret`, so the plaintext never enters the model context, the session log, or the desktop NDJSON log. Missing-secret and no-vault cases return actionable guidance (`/vault set <NAME> <key>`); the add-provider skill and `provider_add`'s returned note were updated to route endpoint verification through the vault name.

--- a/.changeset/safe-publish-topo-order.md
+++ b/.changeset/safe-publish-topo-order.md
@@ -1,0 +1,6 @@
+---
+---
+
+Release-infra only (scripts/ is unversioned — no package bump): `scripts/safe-publish.mjs` can no longer permanently ship a broken `@moxxy/cli`.
+
+It used to publish in `readdirSync` order, so `cli` (whose `workspace:*` dep pnpm rewrites to an EXACT `@moxxy/sdk` pin at pack time) could publish before `sdk`; if `sdk` then tombstone-bumped (npm history shows real walked gaps), `cli` was live and pinned to a version that will never exist. Now: (1) publishable packages are topologically sorted over their `workspace:` dependency graph — dependencies publish first, so a tombstone bump persisted to the dependency's package.json is exactly what the dependent's pack rewrites against; (2) dependents of a hard-failed publish are blocked (reported, exit 1) instead of shipped broken; (3) a post-publish consistency check `npm view`s every package published in the run and verifies each shipped `@moxxy/*` pin exists on the registry, failing loudly otherwise. Adds `--dry-run`/`--help`, and unit tests for the pure helpers (`pnpm test:scripts`, chained into root `pnpm test`).

--- a/.changeset/workflow-cycle-guard.md
+++ b/.changeset/workflow-cycle-guard.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/cli': patch
+---
+
+Guard `afterWorkflow` triggers against cycles. Mutual triggers (A↔B, or longer loops) used to re-fire each other forever, burning provider tokens. Each run now carries its trigger chain on the `workflow_completed` event: re-fires that would revisit a workflow already in the chain, or exceed a depth cap of 8, are refused with a clear warning. On top of that, trigger sync statically detects cycles in the `afterWorkflow` graph, warns once naming the cycle, and disables auto-refire for its members (they remain runnable manually or on schedule).

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -70,12 +70,17 @@ Full report incl. the medium/low backlog and refuted findings:
   calls to the session's current resolver chain — race-free for concurrent fires, no
   shared-session mutation); empty list = full tool set (now documented), and the
   tool/setup-guide text says fires run on the ACTIVE session, not an isolated one.
-- **A5 [high, security] `browser_session.goto` has no SSRF guard** — scheme check only
-  (`browser-session.ts:35`, sidecar `dispatch.ts:85`) while the comment claims parity with
-  `web_fetch`'s `assertPublicUrl`; metadata/private IPs reachable + `text`/`html`/`eval`.
+- **A5 [high, security] `browser_session.goto` has no SSRF guard** — ✅ FIXED (this PR):
+  `assertPublicUrl` hoisted into a shared `plugin-browser/src/ssrf-guard.ts` and enforced
+  in the parent goto handler, in the sidecar's goto dispatch (defence in depth), and via a
+  context-level `route()` interceptor that blocks in-page/redirect navigations to private
+  origins; subresource requests stay unfiltered (residual risk documented in the tool
+  description instead of a parity claim).
 - **A6 [high, security-adjacent] `provider_test` takes the raw API key as model-visible
-  tool input** (`plugin-provider-admin/src/index.ts:82-85`) — into model context + session
-  logs; should take a vault key name resolved via `ctx.getSecret`.
+  tool input** — ✅ FIXED (this PR): plaintext `apiKey` input removed outright; the tool
+  takes a vault `keyName` resolved at call time via `ctx.getSecret` (actionable
+  missing-secret/no-vault messages), and the add-provider skill + provider_add guidance
+  now route verification through the vault name.
 - **A7 [high, stability] channel-web kills whatever holds its port** — ✅ FIXED (this PR):
   channel EADDRINUSE recovery and the runner's protocol-mismatch recovery both verify the
   holder's `ps` command line carries a moxxy marker before any TERM/KILL (CLI now sets
@@ -103,16 +108,22 @@ Full report incl. the medium/low backlog and refuted findings:
   in lockstep, re-arming seq-0 ingest) and truncate the persistence JSONL (same hook fixes
   local `/new` resurrecting on `--resume`); TUI/Telegram call `reset()` and surface an error
   instead of claiming success when it fails.
-- **A11 [high, stability] `afterWorkflow` triggers have no cycle detection** — mutual
-  A↔B triggers loop forever (`cli/src/setup/workflows.ts:184-188`), spawning subagents and
-  burning provider tokens each round; `inFlight` clears before the next completion lands.
-- **A12 [high, stability] `safe-publish.mjs` publish-order/tombstone hazard** — readdir
-  order publishes cli before sdk with an exact `@moxxy/sdk` pin; a tombstone bump after
-  cli ships leaves it pinned to a version that will never exist (npm history shows real
-  tombstone gaps). Topo-order + re-pin dependents.
-- **A13 [high, PoC-scoped] default `moxxy mobile` prints an unconnectable QR** — binds
-  `127.0.0.1` (`plugin-channel-mobile/src/channel.ts:66`) but the QR advertises the LAN IP
-  (`channel.ts:115`); the README documents this exact flow as working.
+- **A11 [high, stability] `afterWorkflow` triggers have no cycle detection** — ✅ FIXED
+  (this PR): a per-run trigger chain now rides the `workflow_completed` payload (re-fires
+  that revisit a chain member or exceed depth 8 are refused with a warning), and static SCC
+  detection at trigger-sync time disables auto-refire for cycle members
+  (`cli/src/setup/workflows.ts`).
+- **A12 [high, stability] `safe-publish.mjs` publish-order/tombstone hazard** — ✅ FIXED
+  (this PR): publishes in topo order over `workspace:` deps (so a dependency's tombstone
+  bump, persisted to its package.json, is exactly what a later dependent pins at pack
+  time), blocks dependents of a failed publish, and a post-publish `npm view` check
+  verifies every shipped `@moxxy/*` pin exists on the registry (loud + exit 1 otherwise);
+  helpers unit-tested via `pnpm test:scripts`.
+- **A13 [high, PoC-scoped] default `moxxy mobile` prints an unconnectable QR** — ✅ FIXED
+  (this PR): the QR now advertises exactly what is bound (loopback default →
+  `ws://127.0.0.1` + a printed hint that a real phone needs `MOXXY_MOBILE_HOST`/`bindHost`
+  opt-in or a tunnel; wildcard bind → LAN IP; tunnel path unchanged), keeping the
+  loopback-by-default security posture; `apps/mobile/README.md` updated to match.
 
 ---
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -22,11 +22,21 @@ session over the WebSocket bridge and prints a **QR code** (+ URL + token) to
 scan. It's also included in `moxxy serve --all`.
 
 ```sh
-moxxy mobile                       # LAN — prints a QR for ws://<lan-ip>:8765
-# reachable beyond the LAN via a tunnel (your choice), in moxxy.config.ts:
-#   channels: { mobile: { tunnel: 'cloudflared' } }   // or 'ngrok'
-# or: MOXXY_MOBILE_TUNNEL=cloudflared moxxy mobile     → prints a wss://… QR
+moxxy mobile                       # loopback (default) — QR for ws://127.0.0.1:8765,
+                                   # reachable only from THIS machine (simulators)
+
+# real phone on the same Wi-Fi: opt in to a LAN bind (token-gated, plain ws://)
+MOXXY_MOBILE_HOST=0.0.0.0 moxxy mobile   # QR advertises your LAN IP
+#   or in moxxy.config.ts: channels: { mobile: { bindHost: '0.0.0.0' } }
+
+# beyond the LAN (and TLS-encrypted): a tunnel — prints a wss://… QR
+MOXXY_MOBILE_TUNNEL=cloudflared moxxy mobile          # or 'ngrok'
+#   or in moxxy.config.ts: channels: { mobile: { tunnel: 'cloudflared' } }
 ```
+
+The QR always advertises an address the bridge is actually listening on: the
+loopback default is for simulators on the same machine; a real device needs
+the explicit host opt-in or a tunnel (the CLI prints this hint under the QR).
 
 **B) The desktop app** (mirrors your desktop workspaces): launch it with
 `MOXXY_WS_BRIDGE=1` (token persisted at `<userData>/ws-token`, or `MOXXY_WS_TOKEN`).

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build": "turbo run build",
     "typecheck": "turbo run typecheck",
     "lint": "eslint .",
-    "test": "turbo run test",
+    "test": "turbo run test && pnpm run test:scripts",
+    "test:scripts": "node --test scripts/*.test.mjs",
     "test:watch": "turbo run test:watch --concurrency=1",
     "check:deps": "depcruise --config .dependency-cruiser.cjs packages apps/desktop/electron",
     "clean": "turbo run clean && rm -rf node_modules .turbo"

--- a/packages/cli/src/setup/workflows.test.ts
+++ b/packages/cli/src/setup/workflows.test.ts
@@ -1,0 +1,339 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { Session, silentLogger } from '@moxxy/core';
+import { asPluginId, type EmittedEvent } from '@moxxy/sdk';
+import { ScheduleStore } from '@moxxy/plugin-scheduler';
+import { WORKFLOWS_PLUGIN_NAME } from '@moxxy/plugin-workflows';
+import {
+  buildWorkflowsIntegration,
+  applyAfterWorkflowCycleGuard,
+  detectAfterWorkflowCycles,
+  fireAfterWorkflowDependents,
+  MAX_AFTER_WORKFLOW_CHAIN,
+  type AfterWorkflowNode,
+} from './workflows.js';
+
+// ---------------------------------------------------------------------------
+// helpers
+
+function wf(
+  name: string,
+  opts: { after?: string | string[]; enabled?: boolean } = {},
+): AfterWorkflowNode {
+  return {
+    name,
+    enabled: opts.enabled ?? true,
+    ...(opts.after ? { on: { afterWorkflow: opts.after } } : {}),
+  };
+}
+
+function captureLogger(): {
+  logger: { warn(msg: string): void; info(msg: string): void };
+  warns: string[];
+  infos: string[];
+} {
+  const warns: string[] = [];
+  const infos: string[] = [];
+  return {
+    logger: {
+      warn: (msg: string) => void warns.push(msg),
+      info: (msg: string) => void infos.push(msg),
+    },
+    warns,
+    infos,
+  };
+}
+
+/**
+ * Drive the trigger loop the way the live subscription does: each fired run
+ * "completes" and feeds its (extended) chain back into the dispatcher —
+ * exactly what the workflow_completed event round-trip does in production.
+ */
+async function simulateCompletion(args: {
+  completed: string;
+  chain: ReadonlyArray<string>;
+  workflows: ReadonlyArray<AfterWorkflowNode>;
+  disabled?: ReadonlySet<string>;
+  runs: string[];
+  logger?: { warn(msg: string): void; info(msg: string): void };
+}): Promise<void> {
+  await fireAfterWorkflowDependents({
+    completed: args.completed,
+    chain: args.chain,
+    workflows: args.workflows,
+    disabled: args.disabled ?? new Set(),
+    run: async ({ name, chain }) => {
+      args.runs.push(name);
+      await simulateCompletion({ ...args, completed: name, chain });
+    },
+    ...(args.logger ? { logger: args.logger } : {}),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// dynamic per-run chain guard
+
+describe('fireAfterWorkflowDependents', () => {
+  it('breaks an A<->B mutual trigger: each fires exactly once, then warns', async () => {
+    const workflows = [wf('a', { after: 'b' }), wf('b', { after: 'a' })];
+    const { logger, warns } = captureLogger();
+    const runs: string[] = [];
+
+    // "a" ran manually (empty chain) and completed.
+    await simulateCompletion({ completed: 'a', chain: [], workflows, runs, logger });
+
+    expect(runs).toEqual(['b']); // b fired once; the re-fire of a was refused
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain('trigger cycle');
+    expect(warns[0]).toContain('a -> b -> a');
+  });
+
+  it('breaks a three-node A->B->C->A cycle after each ran once', async () => {
+    const workflows = [
+      wf('a', { after: 'c' }),
+      wf('b', { after: 'a' }),
+      wf('c', { after: 'b' }),
+    ];
+    const { logger, warns } = captureLogger();
+    const runs: string[] = [];
+
+    await simulateCompletion({ completed: 'a', chain: [], workflows, runs, logger });
+
+    expect(runs).toEqual(['b', 'c']);
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain('a -> b -> c -> a');
+  });
+
+  it('runs a linear A->B->C chain to completion without warnings', async () => {
+    const workflows = [wf('b', { after: 'a' }), wf('c', { after: 'b' })];
+    const { logger, warns } = captureLogger();
+    const runs: string[] = [];
+
+    await simulateCompletion({ completed: 'a', chain: [], workflows, runs, logger });
+
+    expect(runs).toEqual(['b', 'c']);
+    expect(warns).toEqual([]);
+  });
+
+  it('caps non-cyclic chain depth at MAX_AFTER_WORKFLOW_CHAIN', async () => {
+    // w1 after w0, w2 after w1, ... — long but acyclic.
+    const workflows = Array.from({ length: 20 }, (_, i) => wf(`w${i}`, { after: `w${i - 1}` })).slice(1);
+    const { logger, warns } = captureLogger();
+    const runs: string[] = [];
+
+    await simulateCompletion({ completed: 'w0', chain: [], workflows, runs, logger });
+
+    // Completion of w0 starts the chain; each fire adds one completion. The
+    // cap refuses the fire that would make the chain exceed the limit.
+    expect(runs).toHaveLength(MAX_AFTER_WORKFLOW_CHAIN - 1);
+    expect(runs).toEqual(Array.from({ length: MAX_AFTER_WORKFLOW_CHAIN - 1 }, (_, i) => `w${i + 1}`));
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain(`depth cap of ${MAX_AFTER_WORKFLOW_CHAIN}`);
+  });
+
+  it('skips workflows the static cycle guard disabled (info, no run)', async () => {
+    const workflows = [wf('a', { after: 'b' }), wf('b', { after: 'a' })];
+    const { logger, warns, infos } = captureLogger();
+    const runs: string[] = [];
+
+    await simulateCompletion({
+      completed: 'a',
+      chain: [],
+      workflows,
+      disabled: new Set(['a', 'b']),
+      runs,
+      logger,
+    });
+
+    expect(runs).toEqual([]);
+    expect(warns).toEqual([]);
+    expect(infos.some((m) => m.includes('disabled by the cycle guard'))).toBe(true);
+  });
+
+  it('still refuses a direct self-trigger', async () => {
+    const workflows = [wf('a', { after: 'a' })];
+    const { logger, warns } = captureLogger();
+    const runs: string[] = [];
+
+    await simulateCompletion({ completed: 'a', chain: [], workflows, runs, logger });
+
+    expect(runs).toEqual([]);
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain('a -> a');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// static graph detection
+
+describe('detectAfterWorkflowCycles', () => {
+  it('finds a mutual A<->B cycle', () => {
+    const cycles = detectAfterWorkflowCycles([wf('a', { after: 'b' }), wf('b', { after: 'a' })]);
+    expect(cycles).toHaveLength(1);
+    expect([...cycles[0]!].sort()).toEqual(['a', 'b']);
+  });
+
+  it('finds a self-loop', () => {
+    expect(detectAfterWorkflowCycles([wf('a', { after: 'a' })])).toEqual([['a']]);
+  });
+
+  it('finds a longer cycle but not the acyclic tail hanging off it', () => {
+    const cycles = detectAfterWorkflowCycles([
+      wf('a', { after: 'c' }),
+      wf('b', { after: 'a' }),
+      wf('c', { after: 'b' }),
+      wf('tail', { after: 'c' }),
+    ]);
+    expect(cycles).toHaveLength(1);
+    expect([...cycles[0]!].sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('reports nothing for linear chains or fan-out', () => {
+    expect(
+      detectAfterWorkflowCycles([wf('b', { after: 'a' }), wf('c', { after: ['a', 'b'] })]),
+    ).toEqual([]);
+  });
+
+  it('ignores disabled workflows — a disabled node breaks the cycle', () => {
+    expect(
+      detectAfterWorkflowCycles([wf('a', { after: 'b' }), wf('b', { after: 'a', enabled: false })]),
+    ).toEqual([]);
+  });
+});
+
+describe('applyAfterWorkflowCycleGuard', () => {
+  it('disables cycle members and warns once per distinct cycle', () => {
+    const { logger, warns } = captureLogger();
+    const disabled = new Set<string>();
+    const warned = new Set<string>();
+    const workflows = [wf('a', { after: 'b' }), wf('b', { after: 'a' }), wf('c', { after: 'a' })];
+
+    applyAfterWorkflowCycleGuard({ workflows, disabled, warned, logger });
+    expect([...disabled].sort()).toEqual(['a', 'b']);
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain('auto-refire is disabled');
+
+    // Re-sync: same cycle does not warn again, set is rebuilt.
+    applyAfterWorkflowCycleGuard({ workflows, disabled, warned, logger });
+    expect(warns).toHaveLength(1);
+    expect([...disabled].sort()).toEqual(['a', 'b']);
+
+    // Breaking the cycle re-enables the members.
+    applyAfterWorkflowCycleGuard({
+      workflows: [wf('a'), wf('b', { after: 'a' }), wf('c', { after: 'a' })],
+      disabled,
+      warned,
+      logger,
+    });
+    expect(disabled.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// end-to-end through the live wiring: real Session + event log + runNow, with
+// a stub executor so no subagents/providers are involved. Verifies the chain
+// actually rides the workflow_completed payload across the event round-trip.
+
+describe('buildWorkflowsIntegration afterWorkflow wiring', () => {
+  const tempDirs: string[] = [];
+  const savedEnv = { HOME: process.env.HOME, MOXXY_HOME: process.env.MOXXY_HOME };
+
+  afterAll(async () => {
+    process.env.HOME = savedEnv.HOME;
+    process.env.MOXXY_HOME = savedEnv.MOXXY_HOME;
+    await Promise.all(tempDirs.splice(0).map((d) => fs.rm(d, { recursive: true, force: true })));
+  });
+
+  async function setup(workflowYamls: Record<string, string>): Promise<{
+    session: Session;
+    runs: string[];
+    stop: () => void;
+  }> {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-workflows-it-'));
+    tempDirs.push(cwd);
+    // Isolate every homedir-derived path (user workflows dir, inbox, run records).
+    process.env.HOME = cwd;
+    process.env.MOXXY_HOME = path.join(cwd, '.moxxy-home');
+
+    const projectDir = path.join(cwd, '.moxxy', 'workflows');
+    await fs.mkdir(projectDir, { recursive: true });
+    for (const [file, yaml] of Object.entries(workflowYamls)) {
+      await fs.writeFile(path.join(projectDir, file), yaml);
+    }
+
+    const session = new Session({ cwd, logger: silentLogger });
+    const runs: string[] = [];
+    session.workflowExecutors.register({
+      name: 'stub',
+      run: async (workflow, deps) => {
+        runs.push(workflow.name);
+        await deps.emit?.('workflow_completed', { name: workflow.name, output: '' });
+        return { ok: true, steps: [], output: '' };
+      },
+    });
+    const integration = buildWorkflowsIntegration({
+      session,
+      scheduleStore: new ScheduleStore({ file: path.join(cwd, 'schedules.json') }),
+    });
+    return { session, runs, stop: integration.stop };
+  }
+
+  function completedEvent(session: Session, name: string): EmittedEvent {
+    return {
+      type: 'plugin_event',
+      sessionId: session.id,
+      turnId: session.startTurn().turnId,
+      source: 'plugin',
+      pluginId: asPluginId(WORKFLOWS_PLUGIN_NAME),
+      subtype: 'workflow_completed',
+      payload: { name },
+    } as EmittedEvent;
+  }
+
+  const yaml = (name: string, after: string): string =>
+    [
+      `name: ${name}`,
+      'description: test workflow',
+      'on:',
+      `  afterWorkflow: ${after}`,
+      'delivery:',
+      '  inbox: false',
+      'steps:',
+      '  - id: s1',
+      '    prompt: hi',
+      '',
+    ].join('\n');
+
+  it('A<->B mutual trigger fires each dependent exactly once, then stops', async () => {
+    const { session, runs, stop } = await setup({
+      'wf-a.yaml': yaml('wf-a', 'wf-b'),
+      'wf-b.yaml': yaml('wf-b', 'wf-a'),
+    });
+    try {
+      await session.log.append(completedEvent(session, 'wf-a'));
+      await vi.waitFor(() => expect(runs).toContain('wf-b'));
+      // Let any (buggy) follow-on fires land before asserting quiescence.
+      await new Promise((r) => setTimeout(r, 100));
+      expect(runs).toEqual(['wf-b']);
+    } finally {
+      stop();
+    }
+  });
+
+  it('linear A->B->C chain runs each workflow once', async () => {
+    const { session, runs, stop } = await setup({
+      'wf-b.yaml': yaml('wf-b', 'wf-a'),
+      'wf-c.yaml': yaml('wf-c', 'wf-b'),
+    });
+    try {
+      await session.log.append(completedEvent(session, 'wf-a'));
+      await vi.waitFor(() => expect(runs).toContain('wf-c'));
+      await new Promise((r) => setTimeout(r, 100));
+      expect(runs).toEqual(['wf-b', 'wf-c']);
+    } finally {
+      stop();
+    }
+  });
+});

--- a/packages/cli/src/setup/workflows.ts
+++ b/packages/cli/src/setup/workflows.ts
@@ -8,6 +8,7 @@ import {
   type EmittedEvent,
   type MoxxyEvent,
   type Plugin,
+  type Workflow,
   type WorkflowRunResult,
   type WorkflowsView,
 } from '@moxxy/sdk';
@@ -44,6 +45,17 @@ export interface WorkflowsIntegration {
 
 const PLUGIN_ID = asPluginId(WORKFLOWS_PLUGIN_NAME);
 
+/**
+ * Max number of completions in one `afterWorkflow` causal chain before further
+ * re-fires are refused. Mirrors the executor's nesting guard
+ * (`MAX_NESTING_DEPTH` in plugin-workflows' dag executor) but for the
+ * event-driven trigger graph, which would otherwise recurse without bound.
+ */
+export const MAX_AFTER_WORKFLOW_CHAIN = 8;
+
+/** The trigger-relevant slice of a {@link Workflow} the cycle guards inspect. */
+export type AfterWorkflowNode = Pick<Workflow, 'name' | 'enabled' | 'on'>;
+
 export function buildWorkflowsIntegration(args: {
   session: Session;
   scheduleStore: ScheduleStore;
@@ -58,12 +70,23 @@ export function buildWorkflowsIntegration(args: {
 
   const watchers: FSWatcher[] = [];
   const inFlight = new Set<string>();
+  // Workflows whose afterWorkflow auto-refire is statically disabled because
+  // they sit on a trigger cycle (recomputed on every syncSchedules).
+  const cyclicTriggers = new Set<string>();
+  const warnedCycles = new Set<string>();
 
   // --- the autonomous runner: spawner + engine + inbox delivery ---
   async function runNow(input: {
     name: string;
     inputs?: Record<string, unknown>;
     trigger?: string;
+    /**
+     * The afterWorkflow causal chain that led to this run (oldest first).
+     * Carried per-run — NOT shared state — so concurrent independent fires
+     * can't poison each other; it rides the `workflow_completed` payload as
+     * `triggerChain` and is what lets the subscription below refuse cycles.
+     */
+    chain?: ReadonlyArray<string>;
   }): Promise<WorkflowRunResult> {
     const entry = await store.get(input.name);
     if (!entry) return { ok: false, steps: [], output: '', error: `no workflow named "${input.name}"` };
@@ -100,7 +123,12 @@ export function buildWorkflowsIntegration(args: {
               source: 'plugin',
               pluginId: PLUGIN_ID,
               subtype,
-              payload,
+              // Stamp the causal chain onto the completion event so the
+              // afterWorkflow subscription can detect cycles/depth per-run.
+              payload:
+                subtype === 'workflow_completed' && input.chain && input.chain.length > 0
+                  ? { ...(payload as Record<string, unknown>), triggerChain: [...input.chain] }
+                  : payload,
             } as EmittedEvent),
           ...(logger ? { logger } : {}),
         },
@@ -142,6 +170,14 @@ export function buildWorkflowsIntegration(args: {
   // --- triggers ---
   async function syncSchedules(): Promise<void> {
     const all = await store.list();
+    // Static cycle guard: warn once per cycle and disable auto-refire for its
+    // members (they stay runnable manually / on schedule).
+    applyAfterWorkflowCycleGuard({
+      workflows: all.map((w) => w.workflow),
+      disabled: cyclicTriggers,
+      warned: warnedCycles,
+      ...(logger ? { logger } : {}),
+    });
     for (const { workflow } of all) {
       const sched = workflow.enabled ? workflow.on?.schedule : undefined;
       if (sched && (sched.cron || sched.runAt)) {
@@ -174,26 +210,32 @@ export function buildWorkflowsIntegration(args: {
   }
 
   // afterWorkflow: when a workflow completes, fire any enabled workflow that
-  // lists it under `on.afterWorkflow`. Guards against direct self-trigger.
+  // lists it under `on.afterWorkflow`. Two cycle guards: the per-run trigger
+  // chain carried on the completion payload (refuses re-fires that would
+  // revisit a chain member or exceed MAX_AFTER_WORKFLOW_CHAIN), and the
+  // static `cyclicTriggers` set computed by syncSchedules.
   const unsubscribe = session.log.subscribe((event: MoxxyEvent) => {
     if (event.type !== 'plugin_event' || event.subtype !== 'workflow_completed') return;
-    const completed = (event.payload as { name?: string } | undefined)?.name;
+    const payload = event.payload as { name?: string; triggerChain?: unknown } | undefined;
+    const completed = payload?.name;
     if (!completed) return;
+    const chain = Array.isArray(payload?.triggerChain)
+      ? payload.triggerChain.filter((n): n is string => typeof n === 'string')
+      : [];
     void (async () => {
-      for (const { workflow } of await store.list()) {
-        if (!workflow.enabled || !workflow.on?.afterWorkflow) continue;
-        const deps = [workflow.on.afterWorkflow].flat();
-        if (deps.includes(completed) && workflow.name !== completed) {
-          logger?.info?.('workflows: afterWorkflow trigger', { workflow: workflow.name, after: completed });
-          await runNow({ name: workflow.name, trigger: `after:${completed}` }).catch((err) =>
-            logger?.warn?.('workflows: afterWorkflow run failed', {
-              workflow: workflow.name,
-              err: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
-      }
-    })();
+      await fireAfterWorkflowDependents({
+        completed,
+        chain,
+        workflows: (await store.list()).map((w) => w.workflow),
+        disabled: cyclicTriggers,
+        run: runNow,
+        ...(logger ? { logger } : {}),
+      });
+    })().catch((err) =>
+      logger?.warn?.('workflows: afterWorkflow dispatch failed', {
+        err: err instanceof Error ? err.message : String(err),
+      }),
+    );
   });
 
   async function startFileWatchers(): Promise<void> {
@@ -253,6 +295,147 @@ export function buildWorkflowsIntegration(args: {
       for (const w of watchers.splice(0)) w.close();
     },
   };
+}
+
+/**
+ * Find cycles in the `afterWorkflow` trigger graph among enabled workflows.
+ * Nodes are workflow names; an edge runs from a dependency to the workflow it
+ * re-fires (completion of `dep` triggers `dependent`). Returns one entry per
+ * strongly connected component that contains a cycle (size > 1, or a
+ * self-loop), listing its member workflows.
+ */
+export function detectAfterWorkflowCycles(
+  workflows: ReadonlyArray<AfterWorkflowNode>,
+): string[][] {
+  const enabled = new Map<string, AfterWorkflowNode>();
+  for (const w of workflows) if (w.enabled) enabled.set(w.name, w);
+  const edges = new Map<string, string[]>();
+  for (const name of enabled.keys()) edges.set(name, []);
+  for (const w of enabled.values()) {
+    for (const dep of [w.on?.afterWorkflow ?? []].flat()) {
+      if (enabled.has(dep)) edges.get(dep)!.push(w.name);
+    }
+  }
+
+  // Tarjan's SCC. Workflow graphs are tiny; recursion depth is not a concern.
+  let counter = 0;
+  const index = new Map<string, number>();
+  const lowlink = new Map<string, number>();
+  const onStack = new Set<string>();
+  const stack: string[] = [];
+  const cycles: string[][] = [];
+  const visit = (v: string): void => {
+    index.set(v, counter);
+    lowlink.set(v, counter);
+    counter++;
+    stack.push(v);
+    onStack.add(v);
+    for (const w of edges.get(v) ?? []) {
+      if (!index.has(w)) {
+        visit(w);
+        lowlink.set(v, Math.min(lowlink.get(v)!, lowlink.get(w)!));
+      } else if (onStack.has(w)) {
+        lowlink.set(v, Math.min(lowlink.get(v)!, index.get(w)!));
+      }
+    }
+    if (lowlink.get(v) === index.get(v)) {
+      const scc: string[] = [];
+      for (;;) {
+        const w = stack.pop()!;
+        onStack.delete(w);
+        scc.push(w);
+        if (w === v) break;
+      }
+      if (scc.length > 1 || (edges.get(v) ?? []).includes(v)) cycles.push(scc.reverse());
+    }
+  };
+  for (const name of enabled.keys()) if (!index.has(name)) visit(name);
+  return cycles;
+}
+
+/**
+ * Static cycle guard: rebuild `disabled` with every workflow that sits on an
+ * `afterWorkflow` cycle and warn loudly once per distinct cycle. Members stay
+ * runnable manually / on schedule — only the event-driven re-fire is cut.
+ */
+export function applyAfterWorkflowCycleGuard(args: {
+  workflows: ReadonlyArray<AfterWorkflowNode>;
+  /** Mutated: the set of workflow names whose auto-refire is disabled. */
+  disabled: Set<string>;
+  /** Mutated: cycle keys already warned about (so the warning fires once). */
+  warned: Set<string>;
+  logger?: MiniLogger;
+}): void {
+  const cycles = detectAfterWorkflowCycles(args.workflows);
+  args.disabled.clear();
+  for (const cycle of cycles) {
+    for (const name of cycle) args.disabled.add(name);
+    const key = [...cycle].sort().join(' -> ');
+    if (args.warned.has(key)) continue;
+    args.warned.add(key);
+    args.logger?.warn?.(
+      `workflows: afterWorkflow trigger cycle detected (${cycle.join(' -> ')} -> ${cycle[0]}); ` +
+        'auto-refire is disabled for these workflows — run them manually or break the cycle',
+      { cycle: [...cycle] },
+    );
+  }
+}
+
+/**
+ * Fire every enabled workflow whose `on.afterWorkflow` lists `completed`,
+ * unless doing so would revisit a workflow already on this run's trigger
+ * chain (a cycle), exceed {@link MAX_AFTER_WORKFLOW_CHAIN}, or hit a workflow
+ * the static cycle guard disabled. The chain is extended per fire and handed
+ * to `run`, which must carry it onto the next completion event.
+ */
+export async function fireAfterWorkflowDependents(args: {
+  completed: string;
+  chain: ReadonlyArray<string>;
+  workflows: ReadonlyArray<AfterWorkflowNode>;
+  disabled: ReadonlySet<string>;
+  run: (input: { name: string; trigger: string; chain: ReadonlyArray<string> }) => Promise<unknown>;
+  logger?: MiniLogger;
+}): Promise<void> {
+  const { completed, workflows, disabled, run, logger } = args;
+  const nextChain = [...args.chain, completed];
+  for (const workflow of workflows) {
+    if (!workflow.enabled || !workflow.on?.afterWorkflow) continue;
+    if (![workflow.on.afterWorkflow].flat().includes(completed)) continue;
+    if (disabled.has(workflow.name)) {
+      logger?.info?.('workflows: afterWorkflow auto-refire disabled by the cycle guard; skipping', {
+        workflow: workflow.name,
+        after: completed,
+      });
+      continue;
+    }
+    if (nextChain.includes(workflow.name)) {
+      logger?.warn?.(
+        `workflows: refusing afterWorkflow re-fire — trigger cycle ` +
+          `(${[...nextChain, workflow.name].join(' -> ')}); "${workflow.name}" already ran in this chain`,
+        { workflow: workflow.name, chain: [...nextChain] },
+      );
+      continue;
+    }
+    if (nextChain.length >= MAX_AFTER_WORKFLOW_CHAIN) {
+      logger?.warn?.(
+        `workflows: refusing afterWorkflow re-fire — chain depth cap of ${MAX_AFTER_WORKFLOW_CHAIN} ` +
+          `reached (${nextChain.join(' -> ')} -> ${workflow.name})`,
+        { workflow: workflow.name, chain: [...nextChain] },
+      );
+      continue;
+    }
+    logger?.info?.('workflows: afterWorkflow trigger', {
+      workflow: workflow.name,
+      after: completed,
+      depth: nextChain.length,
+    });
+    await run({ name: workflow.name, trigger: `after:${completed}`, chain: nextChain }).catch((err) =>
+      logger?.warn?.('workflows: afterWorkflow run failed', {
+        workflow: workflow.name,
+        err: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
 }
 
 function activeModel(session: Session): string {

--- a/packages/plugin-browser/src/browser-session.test.ts
+++ b/packages/plugin-browser/src/browser-session.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { PassThrough } from 'node:stream';
 import { asSessionId, asToolCallId, asTurnId } from '@moxxy/sdk';
 import type { ToolContext } from '@moxxy/sdk';
 import { buildBrowserSessionTool, closeBrowserSidecar, type SidecarStream } from './browser-session.js';
+import { setSsrfDnsResolver } from './ssrf-guard.js';
+
+// Hermetic DNS for the parent-side SSRF guard on `goto`: every hostname
+// "resolves" public so tests never hit real DNS.
+beforeEach(() => setSsrfDnsResolver(async () => ['93.184.216.34']));
+afterEach(() => setSsrfDnsResolver(null));
 
 /**
  * The sidecar is exercised via a fake `spawnFn` that drives a scripted
@@ -107,6 +113,48 @@ describe('browser_session tool (sidecar protocol)', () => {
     );
     expect(out).toBe(42);
     expect((receivedRequests[0]!.params as { expression: string }).expression).toBe('1 + 41');
+    await closeBrowserSidecar();
+  });
+});
+
+describe('browser_session SSRF guard (parent layer)', () => {
+  it.each([
+    'http://169.254.169.254/latest/meta-data/',
+    'http://localhost:3000/',
+    'http://10.0.0.5/internal',
+  ])('rejects goto %s before any RPC reaches the sidecar', async (url) => {
+    const { spawn, receivedRequests } = makeFakeSpawn(() => null);
+    const tool = buildBrowserSessionTool({ sidecarPath: '/fake.js', spawnFn: spawn });
+    await expect(
+      tool.handler({ action: { kind: 'goto', url } }, baseCtx()),
+    ).rejects.toThrow(/private|loopback/);
+    expect(receivedRequests).toHaveLength(0); // never sent to the sidecar
+    await closeBrowserSidecar();
+  });
+
+  it('rejects a hostname resolving to a private address', async () => {
+    setSsrfDnsResolver(async () => ['10.1.2.3']);
+    const { spawn, receivedRequests } = makeFakeSpawn(() => null);
+    const tool = buildBrowserSessionTool({ sidecarPath: '/fake.js', spawnFn: spawn });
+    await expect(
+      tool.handler({ action: { kind: 'goto', url: 'https://intranet.example.com/' } }, baseCtx()),
+    ).rejects.toThrow(/private|loopback/);
+    expect(receivedRequests).toHaveLength(0);
+    await closeBrowserSidecar();
+  });
+
+  it('allows a public URL through to the sidecar', async () => {
+    const { spawn, receivedRequests } = makeFakeSpawn((req) => {
+      if (req.method === 'goto') return { url: (req.params as { url: string }).url };
+      return null;
+    });
+    const tool = buildBrowserSessionTool({ sidecarPath: '/fake.js', spawnFn: spawn });
+    const out = await tool.handler(
+      { action: { kind: 'goto', url: 'https://example.com/' } },
+      baseCtx(),
+    );
+    expect(out).toEqual({ url: 'https://example.com/' });
+    expect(receivedRequests).toHaveLength(1);
     await closeBrowserSidecar();
   });
 });

--- a/packages/plugin-browser/src/browser-session.ts
+++ b/packages/plugin-browser/src/browser-session.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { MoxxyError, defineTool, z } from '@moxxy/sdk';
+import { assertPublicUrl, SsrfBlockedError } from './ssrf-guard.js';
 
 /**
  * Heavy-tier browser: spawns the Playwright sidecar over stdio JSON-RPC and
@@ -30,8 +31,11 @@ const actionSchema: z.ZodType<Action> = z.union([
   z.object({
     kind: z.literal('goto'),
     // `z.string().url()` accepts file:// and javascript: URLs, which would be
-    // forwarded verbatim to Playwright `page.goto`. Restrict to http(s) — the
-    // same scheme guard web_fetch enforces via assertPublicUrl.
+    // forwarded verbatim to Playwright `page.goto`. This refine is only a fast
+    // schema-level scheme check; the full SSRF guard (loopback/private/
+    // link-local/metadata IPs, DNS resolution — same `assertPublicUrl` as
+    // web_fetch) runs in the handler before the RPC AND again inside the
+    // sidecar's goto dispatch.
     url: z.string().url().refine((u) => /^https?:\/\//i.test(u), 'only http(s) URLs allowed'),
     waitUntil: z.enum(['load', 'domcontentloaded', 'networkidle']).optional(),
     timeoutMs: z.number().int().positive().max(120_000).optional(),
@@ -286,7 +290,9 @@ export function buildBrowserSessionTool(deps?: BrowserSessionDeps) {
   return defineTool({
     name: 'browser_session',
     description:
-      'Drive a real browser (Playwright). Use for pages that need JS execution, clicks, form fills, or screenshots. For simple GETs prefer web_fetch (no extra deps). Calls within a session share one page.',
+      'Drive a real browser (Playwright). Use for pages that need JS execution, clicks, form fills, or screenshots. For simple GETs prefer web_fetch (no extra deps). Calls within a session share one page. ' +
+      'Navigation is restricted to public http(s) origins: goto URLs and top-level/iframe navigations (including redirects) to loopback, private (RFC-1918), link-local/metadata, or CGNAT addresses are blocked. ' +
+      'Residual risk: subresource requests (img/fetch/script) issued by a loaded page are NOT filtered, so a hostile page can still send blind requests at internal services.',
     inputSchema: z.object({
       action: actionSchema,
     }),
@@ -321,6 +327,18 @@ export function buildBrowserSessionTool(deps?: BrowserSessionDeps) {
       try {
         switch (action.kind) {
           case 'goto':
+            // Parent-side SSRF guard — the same assertPublicUrl web_fetch uses
+            // (loopback/private/link-local/metadata blocked, hostname resolved).
+            // The sidecar re-checks in its goto dispatch (defence in depth, it
+            // is a separate process) and intercepts in-page navigations.
+            try {
+              await assertPublicUrl(action.url, 'browser_session');
+            } catch (err) {
+              if (err instanceof SsrfBlockedError) {
+                throw new MoxxyError({ code: 'INTERNAL', message: err.message });
+              }
+              throw err;
+            }
             return await call('goto', {
               url: action.url,
               waitUntil: action.waitUntil,

--- a/packages/plugin-browser/src/sidecar/dispatch.test.ts
+++ b/packages/plugin-browser/src/sidecar/dispatch.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dispatch, type SidecarState } from './dispatch.js';
+import type { Err, Ok, PlaywrightHandle } from './types.js';
+import { setSsrfDnsResolver } from '../ssrf-guard.js';
+
+/**
+ * Dispatch-level SSRF tests: the sidecar is a separate process that must not
+ * trust the parent to have validated `goto` URLs. The guard must fire BEFORE
+ * Playwright is touched — these tests run with `state.handle` unset for
+ * blocked URLs, so reaching `ensurePlaywright` (and its `import('playwright')`)
+ * would fail loudly.
+ */
+
+function makeFakeHandle(): { handle: PlaywrightHandle; gotos: string[] } {
+  const gotos: string[] = [];
+  let current = 'about:blank';
+  const handle: PlaywrightHandle = {
+    browser: { close: async () => {} },
+    context: { newPage: async () => ({}), close: async () => {} },
+    page: {
+      goto: async (url: string) => {
+        gotos.push(url);
+        current = url;
+        return undefined;
+      },
+      click: async () => {},
+      fill: async () => {},
+      textContent: async () => null,
+      content: async () => '',
+      screenshot: async () => Buffer.alloc(0),
+      evaluate: async () => undefined,
+      url: () => current,
+      close: async () => {},
+    },
+  };
+  return { handle, gotos };
+}
+
+function gotoReq(url: string): { id: string; method: string; params: { url: string } } {
+  return { id: 'r1', method: 'goto', params: { url } };
+}
+
+describe('sidecar dispatch goto SSRF guard', () => {
+  beforeEach(() => {
+    // Hermetic DNS: any hostname "resolves" public unless a test overrides.
+    setSsrfDnsResolver(async () => ['93.184.216.34']);
+  });
+  afterEach(() => {
+    setSsrfDnsResolver(null);
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    'http://169.254.169.254/latest/meta-data/',
+    'http://localhost:8080/',
+    'http://10.0.0.5/internal',
+    'file:///etc/passwd',
+  ])('rejects %s without launching a browser', async (url) => {
+    const state: SidecarState = { handle: null, pendingInstallNotice: null };
+    const reply = (await dispatch(state, gotoReq(url))) as Err;
+    expect(reply.ok).toBe(false);
+    expect(reply.error.kind).toBe('navigation');
+    expect(reply.error.message).toMatch(/loopback|private|scheme/);
+    expect(state.handle).toBeNull(); // never reached ensurePlaywright
+  });
+
+  it('rejects a hostname that resolves to a private address', async () => {
+    setSsrfDnsResolver(async () => ['192.168.0.10']);
+    const state: SidecarState = { handle: null, pendingInstallNotice: null };
+    const reply = (await dispatch(state, gotoReq('https://intranet.example.com/'))) as Err;
+    expect(reply.ok).toBe(false);
+    expect(reply.error.message).toMatch(/private|loopback/);
+  });
+
+  it('navigates a public URL on the (pre-seeded) page', async () => {
+    const { handle, gotos } = makeFakeHandle();
+    const state: SidecarState = { handle, pendingInstallNotice: null };
+    const reply = (await dispatch(state, gotoReq('https://example.com/'))) as Ok;
+    expect(reply.ok).toBe(true);
+    expect(reply.result).toEqual({ url: 'https://example.com/' });
+    expect(gotos).toEqual(['https://example.com/']);
+  });
+});

--- a/packages/plugin-browser/src/sidecar/dispatch.ts
+++ b/packages/plugin-browser/src/sidecar/dispatch.ts
@@ -3,6 +3,7 @@
  * one-to-one with the wire-format methods documented in `sidecar.ts`.
  */
 
+import { assertPublicUrl } from '../ssrf-guard.js';
 import { importPlaywright, launchWithAutoInstall } from './install.js';
 import {
   badParams,
@@ -71,18 +72,25 @@ async function dispatchInner(state: SidecarState, req: Req): Promise<Reply> {
       return { id: req.id, ok: true, result: { ready: true } };
     }
     case 'goto': {
-      const h = await ensurePlaywright(state, {});
       const { url, waitUntil, timeoutMs } = (req.params ?? {}) as {
         url: string;
         waitUntil?: 'load' | 'domcontentloaded' | 'networkidle';
         timeoutMs?: number;
       };
       if (!url) throw badParams('url is required');
-      // Defence-in-depth: the tool schema already restricts goto to http(s),
-      // but the sidecar is a distinct process driven over JSON-RPC, so re-check
-      // here rather than trust the caller to have validated. Blocks file:// /
-      // javascript: navigation.
-      if (!/^https?:\/\//i.test(url)) throw badParams('only http(s) URLs allowed');
+      // Defence-in-depth: the parent already runs the full SSRF guard before
+      // sending this RPC, but the sidecar is a distinct process driven over
+      // JSON-RPC, so re-check here rather than trust the caller to have
+      // validated. Blocks file:// / javascript: schemes AND loopback/private/
+      // link-local (incl. 169.254.169.254 metadata)/CGNAT targets, resolving
+      // hostnames. Runs BEFORE ensurePlaywright so a blocked URL never
+      // launches (or auto-installs) a browser.
+      try {
+        await assertPublicUrl(url, 'goto');
+      } catch (err) {
+        return { id: req.id, ok: false, error: { message: errMsg(err), kind: 'navigation' } };
+      }
+      const h = await ensurePlaywright(state, {});
       try {
         await h.page.goto(url, { waitUntil: waitUntil ?? 'domcontentloaded', timeout: timeoutMs ?? 30_000 });
       } catch (err) {

--- a/packages/plugin-browser/src/sidecar/install.ts
+++ b/packages/plugin-browser/src/sidecar/install.ts
@@ -5,6 +5,7 @@
  */
 
 import { spawn } from 'node:child_process';
+import { assertPublicUrl } from '../ssrf-guard.js';
 import type { BrowserKind, BrowserType, PageHandle, PlaywrightHandle } from './types.js';
 
 export interface LaunchResult {
@@ -73,8 +74,40 @@ export async function launchWithAutoInstall(
 async function launchOnce(browserType: BrowserType, headless: boolean): Promise<PlaywrightHandle> {
   const browser = await browserType.launch({ headless });
   const context = (await browser.newContext()) as PlaywrightHandle['context'];
+  await installNavigationSsrfGuard(context);
   const page = (await context.newPage()) as unknown as PageHandle;
   return { browser, context, page };
+}
+
+/**
+ * Block navigations to private/loopback origins for the lifetime of the
+ * context. The goto RPC is validated in the parent AND in dispatch, but a
+ * page reached via a legitimate public goto can then redirect or
+ * script-navigate itself to e.g. http://169.254.169.254/ — those navigations
+ * never pass through the RPC layer, so we intercept them here. Navigation
+ * requests (top-level + iframes, which covers HTTP redirect hops too) go
+ * through the same `assertPublicUrl` guard as web_fetch; everything else is
+ * passed through untouched so ordinary page loads don't pay a DNS round-trip
+ * per subresource.
+ *
+ * Residual risk (also stated in the browser_session tool description):
+ * SUBRESOURCE requests (img/fetch/script) from a loaded page are NOT
+ * filtered. The browser's same-origin policy stops the page reading those
+ * responses, but blind request side effects against internal services remain
+ * possible. Filtering every request was judged disproportionate for now.
+ */
+async function installNavigationSsrfGuard(context: PlaywrightHandle['context']): Promise<void> {
+  if (typeof context.route !== 'function') return; // loose projection: tolerate stubs without route()
+  await context.route('**/*', async (route) => {
+    const request = route.request();
+    if (!request.isNavigationRequest()) return route.continue();
+    try {
+      await assertPublicUrl(request.url(), 'browser_session navigation');
+    } catch {
+      return route.abort('blockedbyclient');
+    }
+    return route.continue();
+  });
 }
 
 function isMissingBrowserError(err: unknown): boolean {

--- a/packages/plugin-browser/src/sidecar/types.ts
+++ b/packages/plugin-browser/src/sidecar/types.ts
@@ -42,6 +42,19 @@ export interface PageHandle {
   close(): Promise<void>;
 }
 
+/** Minimal slice of Playwright's `Request` used by the navigation SSRF guard. */
+export interface RouteRequest {
+  url(): string;
+  isNavigationRequest(): boolean;
+}
+
+/** Minimal slice of Playwright's `Route` used by the navigation SSRF guard. */
+export interface RouteHandle {
+  request(): RouteRequest;
+  abort(errorCode?: string): Promise<void>;
+  continue(): Promise<void>;
+}
+
 export interface PlaywrightHandle {
   // Loosely typed so we can avoid importing the playwright types at compile time —
   // they're an optional peer dependency.
@@ -49,6 +62,8 @@ export interface PlaywrightHandle {
   readonly context: {
     newPage(): Promise<unknown>;
     close(): Promise<void>;
+    /** Optional because the type is a loose projection; real Playwright contexts always have it. */
+    route?(pattern: string, handler: (route: RouteHandle) => Promise<void> | void): Promise<void>;
   };
   readonly page: PageHandle;
 }

--- a/packages/plugin-browser/src/ssrf-guard.test.ts
+++ b/packages/plugin-browser/src/ssrf-guard.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { assertPublicUrl, isBlockedIp, setSsrfDnsResolver, SsrfBlockedError } from './ssrf-guard.js';
+
+afterEach(() => setSsrfDnsResolver(null));
+
+describe('assertPublicUrl (shared SSRF guard)', () => {
+  it('blocks the cloud metadata IP literal', async () => {
+    await expect(assertPublicUrl('http://169.254.169.254/latest/meta-data/')).rejects.toThrow(
+      /private|loopback/,
+    );
+  });
+
+  it('blocks localhost without consulting DNS', async () => {
+    setSsrfDnsResolver(async () => {
+      throw new Error('resolver should not be consulted for localhost');
+    });
+    await expect(assertPublicUrl('http://localhost:8080/admin')).rejects.toThrow(/loopback/);
+  });
+
+  it('blocks RFC-1918 literals', async () => {
+    await expect(assertPublicUrl('http://10.0.0.5/')).rejects.toThrow(/private|loopback/);
+    await expect(assertPublicUrl('http://192.168.1.1/')).rejects.toThrow(/private|loopback/);
+    await expect(assertPublicUrl('http://172.16.0.1/')).rejects.toThrow(/private|loopback/);
+  });
+
+  it('blocks IPv6 loopback / link-local / unique-local', async () => {
+    await expect(assertPublicUrl('http://[::1]:3000/')).rejects.toThrow(/private|loopback/);
+    await expect(assertPublicUrl('http://[fe80::1]/')).rejects.toThrow(/private|loopback/);
+    await expect(assertPublicUrl('http://[fd00::1]/')).rejects.toThrow(/private|loopback/);
+  });
+
+  it('blocks non-HTTP(S) schemes', async () => {
+    await expect(assertPublicUrl('file:///etc/passwd')).rejects.toThrow(/scheme/);
+    await expect(assertPublicUrl('javascript:alert(1)')).rejects.toThrow(/scheme/);
+  });
+
+  it('blocks a hostname that resolves to a private address', async () => {
+    setSsrfDnsResolver(async () => ['10.0.0.5']);
+    await expect(assertPublicUrl('https://intranet.example.com/')).rejects.toThrow(
+      /private|loopback/,
+    );
+  });
+
+  it('allows a public IP literal and a publicly-resolving hostname', async () => {
+    await expect(assertPublicUrl('https://93.184.216.34/')).resolves.toBeUndefined();
+    setSsrfDnsResolver(async () => ['93.184.216.34']);
+    await expect(assertPublicUrl('https://example.com/')).resolves.toBeUndefined();
+  });
+
+  it('throws SsrfBlockedError with the caller label prefixed', async () => {
+    const err = await assertPublicUrl('http://127.0.0.1/', 'browser_session').catch((e) => e);
+    expect(err).toBeInstanceOf(SsrfBlockedError);
+    expect((err as Error).message).toMatch(/^browser_session:/);
+  });
+});
+
+describe('isBlockedIp', () => {
+  it('blocks unparseable input', () => {
+    expect(isBlockedIp('not-an-ip')).toBe(true);
+  });
+  it('passes public v4 and v6', () => {
+    expect(isBlockedIp('93.184.216.34')).toBe(false);
+    expect(isBlockedIp('2606:2800:220:1:248:1893:25c8:1946')).toBe(false);
+  });
+  it('blocks v4-mapped private v6', () => {
+    expect(isBlockedIp('::ffff:192.168.1.1')).toBe(true);
+  });
+});

--- a/packages/plugin-browser/src/ssrf-guard.ts
+++ b/packages/plugin-browser/src/ssrf-guard.ts
@@ -1,0 +1,113 @@
+import { isIP } from 'node:net';
+import { lookup as dnsLookup } from 'node:dns/promises';
+
+/**
+ * Shared SSRF guard for every model-drivable navigation/fetch path in this
+ * plugin: `web_fetch` (initial URL + every redirect hop), `browser_session`'s
+ * goto (parent side), the sidecar's goto dispatch (child-process side), and
+ * the sidecar's in-page navigation interceptor.
+ *
+ * Blocks non-HTTP(S) schemes, loopback (incl. `localhost`/`*.localhost`),
+ * 0.0.0.0/8, RFC-1918 private ranges, link-local 169.254/16 (incl. the
+ * 169.254.169.254 cloud metadata endpoint), CGNAT 100.64/10, multicast/
+ * reserved, and IPv6 loopback/link-local/unique-local (+ v4-mapped). Hostnames
+ * are resolved so an internal DNS name (or rebinding) can't smuggle a private
+ * target past the literal-IP checks.
+ *
+ * NOTE: deliberately NO `@moxxy/sdk` import. The Playwright sidecar — a
+ * separate child process whose bundle must stay free of non-builtin deps —
+ * imports this module too. Parent-side callers wrap `SsrfBlockedError` into
+ * `MoxxyError` themselves.
+ */
+
+/** Thrown for every guard rejection (bad scheme, private/loopback target, unparseable URL). */
+export class SsrfBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SsrfBlockedError';
+  }
+}
+
+export type DnsResolver = (host: string) => Promise<ReadonlyArray<string>>;
+const defaultResolver: DnsResolver = async (host) =>
+  (await dnsLookup(host, { all: true })).map((a) => a.address);
+let resolver: DnsResolver = defaultResolver;
+
+/** Test seam: override DNS resolution so SSRF tests stay hermetic. Pass null to reset. */
+export function setSsrfDnsResolver(fn: DnsResolver | null): void {
+  resolver = fn ?? defaultResolver;
+}
+
+function isBlockedIpv4(ip: string): boolean {
+  const parts = ip.split('.').map((p) => Number(p));
+  if (parts.length !== 4 || parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) return true;
+  const [a, b] = parts as [number, number, number, number];
+  if (a === 0) return true; // 0.0.0.0/8 "this host"
+  if (a === 127) return true; // loopback
+  if (a === 10) return true; // private
+  if (a === 172 && b >= 16 && b <= 31) return true; // private
+  if (a === 192 && b === 168) return true; // private
+  if (a === 169 && b === 254) return true; // link-local incl. 169.254.169.254 metadata
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64/10
+  if (a >= 224) return true; // multicast / reserved
+  return false;
+}
+
+function isBlockedIpv6(ip: string): boolean {
+  const addr = ip.toLowerCase().replace(/^\[|\]$/g, '').split('%')[0]!; // strip zone id
+  if (addr === '::1' || addr === '::') return true; // loopback / unspecified
+  if (addr.startsWith('fe80')) return true; // link-local
+  if (addr.startsWith('fc') || addr.startsWith('fd')) return true; // unique-local fc00::/7
+  const v4mapped = addr.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (v4mapped) return isBlockedIpv4(v4mapped[1]!);
+  return false;
+}
+
+export function isBlockedIp(ip: string): boolean {
+  const kind = isIP(ip);
+  if (kind === 4) return isBlockedIpv4(ip);
+  if (kind === 6) return isBlockedIpv6(ip);
+  return true; // not a parseable IP → block
+}
+
+/**
+ * Reject `raw` unless it is an http(s) URL whose host is (and resolves to)
+ * a public address. `label` prefixes the error message so each caller's
+ * rejections stay attributable (e.g. "web_fetch", "browser_session").
+ */
+export async function assertPublicUrl(raw: string, label = 'request'): Promise<void> {
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    throw new SsrfBlockedError(`${label}: invalid URL: ${raw}`);
+  }
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+    throw new SsrfBlockedError(`${label}: refusing non-HTTP(S) scheme "${u.protocol}"`);
+  }
+  const host = u.hostname.replace(/^\[|\]$/g, '');
+  if (host === 'localhost' || host.endsWith('.localhost')) {
+    throw new SsrfBlockedError(`${label}: refusing to fetch loopback host "${host}"`);
+  }
+  if (isIP(host)) {
+    if (isBlockedIp(host))
+      throw new SsrfBlockedError(`${label}: refusing private/loopback address "${host}"`);
+    return;
+  }
+  // Resolve the name and block if it maps to a private range (internal name or
+  // DNS rebinding). Fail OPEN on resolution error: a name we can't resolve here
+  // the subsequent fetch can't reach either, so it's no SSRF vector.
+  let addrs: ReadonlyArray<string>;
+  try {
+    addrs = await resolver(host);
+  } catch {
+    return;
+  }
+  for (const addr of addrs) {
+    if (isBlockedIp(addr)) {
+      throw new SsrfBlockedError(
+        `${label}: host "${host}" resolves to a private/loopback address (${addr})`,
+      );
+    }
+  }
+}

--- a/packages/plugin-browser/src/web-fetch.ts
+++ b/packages/plugin-browser/src/web-fetch.ts
@@ -1,7 +1,11 @@
-import { isIP } from 'node:net';
-import { lookup as dnsLookup } from 'node:dns/promises';
 import { MoxxyError, defineTool, z } from '@moxxy/sdk';
 import { htmlToMarkdown, htmlToPlainText } from './html-extract.js';
+import {
+  assertPublicUrl,
+  setSsrfDnsResolver,
+  SsrfBlockedError,
+  type DnsResolver,
+} from './ssrf-guard.js';
 
 /**
  * Light-tier web fetch: a single HTTP GET (or HEAD) with HTML→text/markdown
@@ -21,95 +25,27 @@ const FETCH_TIMEOUT_MS_DEFAULT = 20_000;
 // --- SSRF guard -------------------------------------------------------------
 // web_fetch can be driven by the model, so it must not be a confused-deputy
 // that reaches loopback, RFC-1918, link-local (incl. the 169.254.169.254 cloud
-// metadata endpoint), or non-HTTP schemes. We validate the initial URL AND
-// every redirect hop (a public URL can 302 to an internal one).
+// metadata endpoint), or non-HTTP schemes. The guard itself lives in
+// `./ssrf-guard.js` (shared with browser_session and the Playwright sidecar);
+// here we validate the initial URL AND every redirect hop (a public URL can
+// 302 to an internal one).
 
-export type DnsResolver = (host: string) => Promise<ReadonlyArray<string>>;
-const defaultResolver: DnsResolver = async (host) =>
-  (await dnsLookup(host, { all: true })).map((a) => a.address);
-let resolver: DnsResolver = defaultResolver;
+export type { DnsResolver } from './ssrf-guard.js';
 
 /** Test seam: override DNS resolution so SSRF tests stay hermetic. Pass null to reset. */
 export function setWebFetchDnsResolver(fn: DnsResolver | null): void {
-  resolver = fn ?? defaultResolver;
+  setSsrfDnsResolver(fn);
 }
 
-function isBlockedIpv4(ip: string): boolean {
-  const parts = ip.split('.').map((p) => Number(p));
-  if (parts.length !== 4 || parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) return true;
-  const [a, b] = parts as [number, number, number, number];
-  if (a === 0) return true; // 0.0.0.0/8 "this host"
-  if (a === 127) return true; // loopback
-  if (a === 10) return true; // private
-  if (a === 172 && b >= 16 && b <= 31) return true; // private
-  if (a === 192 && b === 168) return true; // private
-  if (a === 169 && b === 254) return true; // link-local incl. 169.254.169.254 metadata
-  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64/10
-  if (a >= 224) return true; // multicast / reserved
-  return false;
-}
-
-function isBlockedIpv6(ip: string): boolean {
-  const addr = ip.toLowerCase().replace(/^\[|\]$/g, '').split('%')[0]!; // strip zone id
-  if (addr === '::1' || addr === '::') return true; // loopback / unspecified
-  if (addr.startsWith('fe80')) return true; // link-local
-  if (addr.startsWith('fc') || addr.startsWith('fd')) return true; // unique-local fc00::/7
-  const v4mapped = addr.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-  if (v4mapped) return isBlockedIpv4(v4mapped[1]!);
-  return false;
-}
-
-function isBlockedIp(ip: string): boolean {
-  const kind = isIP(ip);
-  if (kind === 4) return isBlockedIpv4(ip);
-  if (kind === 6) return isBlockedIpv6(ip);
-  return true; // not a parseable IP → block
-}
-
-async function assertPublicUrl(raw: string): Promise<void> {
-  let u: URL;
+/** Shared guard, with rejections re-thrown as MoxxyError for the tool surface. */
+async function assertPublicUrlForWebFetch(raw: string): Promise<void> {
   try {
-    u = new URL(raw);
-  } catch {
-    throw new MoxxyError({ code: 'INTERNAL', message: `web_fetch: invalid URL: ${raw}` });
-  }
-  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
-    throw new MoxxyError({
-      code: 'INTERNAL',
-      message: `web_fetch: refusing non-HTTP(S) scheme "${u.protocol}"`,
-    });
-  }
-  const host = u.hostname.replace(/^\[|\]$/g, '');
-  if (host === 'localhost' || host.endsWith('.localhost')) {
-    throw new MoxxyError({
-      code: 'INTERNAL',
-      message: `web_fetch: refusing to fetch loopback host "${host}"`,
-    });
-  }
-  if (isIP(host)) {
-    if (isBlockedIp(host))
-      throw new MoxxyError({
-        code: 'INTERNAL',
-        message: `web_fetch: refusing private/loopback address "${host}"`,
-      });
-    return;
-  }
-  // Resolve the name and block if it maps to a private range (internal name or
-  // DNS rebinding). Fail OPEN on resolution error: a name we can't resolve here
-  // the subsequent fetch can't reach either, so it's no SSRF vector.
-  let addrs: ReadonlyArray<string>;
-  try {
-    addrs = await resolver(host);
-  } catch {
-    return;
-  }
-  for (const addr of addrs) {
-    if (isBlockedIp(addr)) {
-      throw new MoxxyError({
-        code: 'INTERNAL',
-        message: `web_fetch: host "${host}" resolves to a private/loopback address (${addr})`,
-      });
+    await assertPublicUrl(raw, 'web_fetch');
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      throw new MoxxyError({ code: 'INTERNAL', message: err.message });
     }
+    throw err;
   }
 }
 
@@ -217,7 +153,7 @@ async function fetchFollowRedirects(
   for (let hop = 0; hop <= opts.maxRedirects; hop++) {
     // Re-validate on every hop — the initial URL AND each redirect target —
     // so a public URL can't 302 us into the internal network.
-    await assertPublicUrl(current);
+    await assertPublicUrlForWebFetch(current);
     const res = await fetch(current, {
       method: opts.method,
       headers: opts.headers,

--- a/packages/plugin-channel-mobile/src/channel.ts
+++ b/packages/plugin-channel-mobile/src/channel.ts
@@ -19,9 +19,11 @@ import type { TunnelHandle } from '@moxxy/sdk';
 import { MobileSessionHost } from './single-session-host.js';
 import { resolveMobileToken } from './token.js';
 import {
+  advertisedHost,
   buildConnectUrl,
-  lanHost,
+  isLoopbackHost,
   normalizeTunnelChoice,
+  resolveBindHost,
   tunnelProviderFor,
   type TunnelChoice,
 } from './tunnel.js';
@@ -34,7 +36,9 @@ export interface MobileStartOpts extends ChannelStartOptsBase {
 export interface MobileChannelOptions {
   /** TCP port (default 8765 — matches the desktop bridge + the Expo app's default). */
   readonly port?: number;
-  /** Bind address. Loopback by default; `0.0.0.0` exposes on the LAN (still token-gated). */
+  /** Bind address (`MOXXY_MOBILE_HOST` env overrides). Loopback by default —
+   *  good for simulators on this machine; `0.0.0.0` exposes on the LAN for a
+   *  real phone (still token-gated). */
   readonly bindHost?: string;
   /** Bearer token. Falls back to env / a persisted secret (see resolveMobileToken). */
   readonly token?: string;
@@ -63,7 +67,7 @@ export class MobileChannel implements Channel<MobileStartOpts> {
 
   constructor(opts: MobileChannelOptions = {}) {
     this.port = opts.port ?? DEFAULT_PORT;
-    this.bindHost = opts.bindHost ?? '127.0.0.1';
+    this.bindHost = resolveBindHost(opts.bindHost);
     this.token = resolveMobileToken(opts.token);
     this.tunnelChoice = normalizeTunnelChoice(opts.tunnel);
     this.logger = opts.logger;
@@ -102,7 +106,7 @@ export class MobileChannel implements Channel<MobileStartOpts> {
         tunnelUrl = this.tunnel.url;
         this.logger?.info?.('mobile tunnel open', { provider: provider.name, url: tunnelUrl });
       } catch (err) {
-        this.logger?.warn?.('mobile tunnel failed; using LAN URL', {
+        this.logger?.warn?.('mobile tunnel failed; using the local URL', {
           provider: provider.name,
           err: String(err),
         });
@@ -110,13 +114,26 @@ export class MobileChannel implements Channel<MobileStartOpts> {
     }
 
     // A QR (+ plain URL) the mobile app scans to connect — token embedded.
+    // The URL only ever advertises an address the server is reachable on:
+    // the tunnel URL, the LAN IP for a wildcard bind, or the bind host itself
+    // (the loopback default advertises 127.0.0.1 — simulators on this machine).
     const connectUrl = buildConnectUrl({
       tunnelUrl,
-      localHost: lanHost(this.bindHost),
+      localHost: advertisedHost(this.bindHost),
       port: this.port,
       token: this.token,
     });
-    await printConnectInfo(connectUrl, this.token);
+    const loopbackOnly = !tunnelUrl && isLoopbackHost(this.bindHost);
+    await printConnectInfo(
+      connectUrl,
+      this.token,
+      loopbackOnly
+        ? 'Bound to loopback — this QR only works on THIS machine (e.g. an iOS/Android\n' +
+          '  simulator). For a real phone: opt in to a LAN bind with MOXXY_MOBILE_HOST=0.0.0.0\n' +
+          "  (or channels.mobile.bindHost in moxxy.config.ts), or use a tunnel\n" +
+          "  (channels.mobile.tunnel: 'cloudflared' | 'ngrok', or MOXXY_MOBILE_TUNNEL)."
+        : undefined,
+    );
 
     let resolveRunning!: () => void;
     const running = new Promise<void>((resolve) => {

--- a/packages/plugin-channel-mobile/src/qr.ts
+++ b/packages/plugin-channel-mobile/src/qr.ts
@@ -6,7 +6,7 @@
 
 import QRCode from 'qrcode';
 
-export async function printConnectInfo(url: string, token: string): Promise<void> {
+export async function printConnectInfo(url: string, token: string, hint?: string): Promise<void> {
   let qr = '';
   try {
     qr = await QRCode.toString(url, { type: 'terminal', small: true });
@@ -20,6 +20,7 @@ export async function printConnectInfo(url: string, token: string): Promise<void
     qr,
     `  url:   ${url}`,
     `  token: ${token}`,
+    ...(hint ? ['', `  ℹ ${hint}`] : []),
     '',
   ];
   // CLI surface — intentional stdout.

--- a/packages/plugin-channel-mobile/src/tunnel.test.ts
+++ b/packages/plugin-channel-mobile/src/tunnel.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The QR / connect URL must never advertise an address the server isn't
+ * reachable on (audit A13: the loopback default used to print the LAN IP).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('node:os', () => ({
+  default: {
+    networkInterfaces: vi.fn(() => ({
+      lo0: [{ family: 'IPv4', internal: true, address: '127.0.0.1' }],
+      en0: [{ family: 'IPv4', internal: false, address: '192.168.1.42' }],
+    })),
+  },
+}));
+
+import os from 'node:os';
+import {
+  advertisedHost,
+  buildConnectUrl,
+  isLoopbackHost,
+  isWildcardHost,
+  lanHost,
+  resolveBindHost,
+} from './tunnel.js';
+
+const ifaces = vi.mocked(os.networkInterfaces);
+
+afterEach(() => {
+  delete process.env.MOXXY_MOBILE_HOST;
+});
+
+describe('resolveBindHost', () => {
+  it('defaults to loopback — LAN exposure stays an explicit opt-in', () => {
+    expect(resolveBindHost(undefined)).toBe('127.0.0.1');
+    expect(resolveBindHost('  ')).toBe('127.0.0.1');
+  });
+
+  it('uses the configured host when set', () => {
+    expect(resolveBindHost('0.0.0.0')).toBe('0.0.0.0');
+  });
+
+  it('lets MOXXY_MOBILE_HOST override config (env → config → default)', () => {
+    process.env.MOXXY_MOBILE_HOST = '192.168.1.42';
+    expect(resolveBindHost('0.0.0.0')).toBe('192.168.1.42');
+  });
+});
+
+describe('advertisedHost', () => {
+  it('advertises loopback for the default loopback bind (NOT the LAN IP)', () => {
+    expect(advertisedHost('127.0.0.1')).toBe('127.0.0.1');
+    expect(advertisedHost('localhost')).toBe('localhost');
+  });
+
+  it('advertises the LAN IP for a wildcard bind (the bind string is unconnectable)', () => {
+    expect(advertisedHost('0.0.0.0')).toBe('192.168.1.42');
+    expect(advertisedHost('::')).toBe('192.168.1.42');
+  });
+
+  it('falls back to loopback for a wildcard bind with no external interface', () => {
+    ifaces.mockReturnValueOnce({
+      lo0: [{ family: 'IPv4', internal: true, address: '127.0.0.1' }],
+    } as never);
+    expect(advertisedHost('0.0.0.0')).toBe('127.0.0.1');
+  });
+
+  it('advertises an explicitly configured host verbatim', () => {
+    expect(advertisedHost('192.168.1.7')).toBe('192.168.1.7');
+    expect(advertisedHost('my-laptop.local')).toBe('my-laptop.local');
+  });
+});
+
+describe('host classification', () => {
+  it('recognises loopback hosts', () => {
+    for (const h of ['127.0.0.1', '127.0.1.1', 'localhost', 'LOCALHOST', '::1']) {
+      expect(isLoopbackHost(h)).toBe(true);
+    }
+    expect(isLoopbackHost('192.168.1.42')).toBe(false);
+    expect(isLoopbackHost('0.0.0.0')).toBe(false);
+  });
+
+  it('recognises wildcard hosts', () => {
+    expect(isWildcardHost('0.0.0.0')).toBe(true);
+    expect(isWildcardHost('::')).toBe(true);
+    expect(isWildcardHost('127.0.0.1')).toBe(false);
+  });
+});
+
+describe('buildConnectUrl', () => {
+  it('default config: QR host matches the (loopback) bind host', () => {
+    const bindHost = resolveBindHost(undefined);
+    const url = buildConnectUrl({
+      tunnelUrl: null,
+      localHost: advertisedHost(bindHost),
+      port: 8765,
+      token: 'tok',
+    });
+    expect(url).toBe('ws://127.0.0.1:8765/?t=tok');
+  });
+
+  it('explicit host opt-in: QR advertises exactly what is bound', () => {
+    const url = buildConnectUrl({
+      tunnelUrl: null,
+      localHost: advertisedHost('192.168.1.7'),
+      port: 8765,
+      token: 'tok',
+    });
+    expect(url).toBe('ws://192.168.1.7:8765/?t=tok');
+  });
+
+  it('tunnel path unchanged: https tunnel → wss URL, token embedded', () => {
+    const url = buildConnectUrl({
+      tunnelUrl: 'https://example.trycloudflare.com',
+      localHost: advertisedHost('127.0.0.1'),
+      port: 8765,
+      token: 't k', // must be URL-encoded
+    });
+    expect(url).toBe('wss://example.trycloudflare.com/?t=t%20k');
+  });
+
+  it('lanHost falls back to the given host when no external interface exists', () => {
+    ifaces.mockReturnValueOnce({} as never);
+    expect(lanHost('127.0.0.1')).toBe('127.0.0.1');
+  });
+});

--- a/packages/plugin-channel-mobile/src/tunnel.ts
+++ b/packages/plugin-channel-mobile/src/tunnel.ts
@@ -25,6 +25,30 @@ export function tunnelProviderFor(choice: TunnelChoice): TunnelProviderDef | nul
   return null;
 }
 
+/**
+ * Bind address resolution, mirroring the channel's env → config → default
+ * convention (cf. MOXXY_MOBILE_TOKEN / MOXXY_MOBILE_TUNNEL). Loopback by
+ * default — exposing the bridge on the LAN is an explicit opt-in
+ * (`MOXXY_MOBILE_HOST=0.0.0.0` or `channels.mobile.bindHost`).
+ */
+export function resolveBindHost(configured?: string): string {
+  const v = (process.env.MOXXY_MOBILE_HOST ?? configured ?? '').trim();
+  return v.length > 0 ? v : '127.0.0.1';
+}
+
+/** Loopback addresses: only reachable from this machine (incl. simulators). */
+export function isLoopbackHost(host: string): boolean {
+  const h = host.trim().toLowerCase();
+  return h === 'localhost' || h === '::1' || h === '[::1]' || h.startsWith('127.');
+}
+
+/** Wildcard binds listen on every interface — the bind string itself is not a
+ *  connectable address, so the QR must advertise a real one instead. */
+export function isWildcardHost(host: string): boolean {
+  const h = host.trim().toLowerCase();
+  return h === '0.0.0.0' || h === '::' || h === '[::]';
+}
+
 /** First non-internal IPv4 address, so a phone on the same Wi-Fi can reach the
  *  bridge without a tunnel. Falls back to the bind host. */
 export function lanHost(fallback: string): string {
@@ -37,9 +61,23 @@ export function lanHost(fallback: string): string {
 }
 
 /**
+ * The host the QR / connect URL should advertise for a given bind address —
+ * never an address the server isn't actually reachable on:
+ *  - wildcard bind (0.0.0.0 / ::) → the machine's LAN IP (loopback fallback),
+ *    since the bind string itself is unconnectable;
+ *  - anything else (loopback default, an explicit LAN IP, a hostname) → the
+ *    bind host verbatim. In particular the loopback default advertises
+ *    127.0.0.1, NOT the LAN IP the server is not listening on.
+ */
+export function advertisedHost(bindHost: string): string {
+  if (isWildcardHost(bindHost)) return lanHost('127.0.0.1');
+  return bindHost;
+}
+
+/**
  * Build the WebSocket connect URL the mobile app uses — token embedded as the
  * `?t=` query the bridge accepts (so a scanned QR carries everything). A tunnel
- * URL (https) becomes `wss://`; the local path uses the LAN host.
+ * URL (https) becomes `wss://`; the local path uses the advertised host.
  */
 export function buildConnectUrl(opts: {
   tunnelUrl: string | null;

--- a/packages/plugin-provider-admin/src/index.test.ts
+++ b/packages/plugin-provider-admin/src/index.test.ts
@@ -1,10 +1,21 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import type { ProviderDef, ToolDef } from '@moxxy/sdk';
+import type { ProviderDef, ToolContext, ToolDef } from '@moxxy/sdk';
 import { buildProviderAdminPlugin, type ProviderRegistryLike } from './index.js';
 import { readProvidersConfig } from './store.js';
+
+// Stub ONLY the network probe; buildProviderDef stays real. Lets the
+// provider_test tests assert what key the validator received without ever
+// hitting a vendor endpoint.
+const validateMock = vi.hoisted(() =>
+  vi.fn(async (_key: string, _opts: { baseURL?: string }) => ({ ok: true as const })),
+);
+vi.mock('./factory.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./factory.js')>();
+  return { ...actual, validateOpenAICompatKey: validateMock };
+});
 
 class FakeRegistry implements ProviderRegistryLike {
   defs = new Map<string, ProviderDef>();
@@ -122,6 +133,75 @@ describe('provider_remove', () => {
   it('is a no-op when the slug is unknown', async () => {
     const removed = (await call('provider_remove', { name: 'never-existed' })) as { ok: boolean };
     expect(removed.ok).toBe(false);
+  });
+});
+
+describe('provider_test', () => {
+  const ctxWithSecret = (secrets: Record<string, string>): ToolContext =>
+    ({ getSecret: async (name: string) => secrets[name] ?? null }) as unknown as ToolContext;
+
+  function callTest(input: Record<string, unknown>, ctx: ToolContext): Promise<unknown> {
+    const tool = tools.get('provider_test')!;
+    const parsed = tool.inputSchema.parse(input);
+    return Promise.resolve(tool.handler(parsed, ctx));
+  }
+
+  beforeEach(() => validateMock.mockClear());
+
+  it('resolves the key from the vault via ctx.getSecret and probes with it', async () => {
+    const result = (await callTest(
+      { baseURL: 'https://api.z.ai/api/coding/paas/v4', keyName: 'ZAI_API_KEY' },
+      ctxWithSecret({ ZAI_API_KEY: 'sk-plaintext-secret' }),
+    )) as { ok: boolean };
+    expect(result.ok).toBe(true);
+    expect(validateMock).toHaveBeenCalledWith('sk-plaintext-secret', {
+      baseURL: 'https://api.z.ai/api/coding/paas/v4',
+    });
+    // The plaintext key must never leak into the model-visible tool result.
+    expect(JSON.stringify(result)).not.toContain('sk-plaintext-secret');
+  });
+
+  it('returns an actionable message when the vault has no such secret', async () => {
+    const result = (await callTest(
+      { baseURL: 'https://api.deepseek.com', keyName: 'DEEPSEEK_API_KEY' },
+      ctxWithSecret({}),
+    )) as { ok: boolean; message: string };
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('DEEPSEEK_API_KEY');
+    expect(result.message).toContain('/vault set DEEPSEEK_API_KEY');
+    expect(validateMock).not.toHaveBeenCalled();
+  });
+
+  it('fails gracefully when the session has no vault wired in', async () => {
+    const result = (await callTest(
+      { baseURL: 'https://api.deepseek.com', keyName: 'DEEPSEEK_API_KEY' },
+      {} as ToolContext,
+    )) as { ok: boolean; message: string };
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/vault/i);
+    expect(validateMock).not.toHaveBeenCalled();
+  });
+
+  it('does not accept a plaintext apiKey input (schema requires keyName)', () => {
+    const tool = tools.get('provider_test')!;
+    const bad = tool.inputSchema.safeParse({
+      baseURL: 'https://api.deepseek.com',
+      apiKey: 'sk-raw-key',
+    });
+    expect(bad.success).toBe(false);
+    // lower-case / non-env-shaped names are rejected too
+    const badName = tool.inputSchema.safeParse({
+      baseURL: 'https://api.deepseek.com',
+      keyName: 'not a name',
+    });
+    expect(badName.success).toBe(false);
+  });
+
+  it('description asserts the vault-name contract', () => {
+    const tool = tools.get('provider_test')!;
+    expect(tool.description).toContain('vault');
+    expect(tool.description).toMatch(/never enters the conversation/i);
+    expect(tool.description).not.toMatch(/supplied API key/i);
   });
 });
 

--- a/packages/plugin-provider-admin/src/index.ts
+++ b/packages/plugin-provider-admin/src/index.ts
@@ -80,8 +80,15 @@ const removeProviderInput = z.object({
 });
 
 const testProviderInput = z.object({
-  baseURL: z.string().url(),
-  apiKey: z.string().min(1),
+  baseURL: z.string().url().describe('Vendor API base URL to probe, e.g. https://api.deepseek.com.'),
+  keyName: z
+    .string()
+    .regex(/^[A-Z][A-Z0-9_]*$/)
+    .describe(
+      'NAME of the vault secret holding the API key (e.g. DEEPSEEK_API_KEY). The key is ' +
+        'resolved from the vault inside the tool — never ask the user for the plaintext key ' +
+        'and never pass one as a tool argument. Have them store it first: /vault set <NAME> <key>.',
+    ),
 });
 
 export function buildProviderAdminPlugin(opts: BuildProviderAdminPluginOptions): Plugin {
@@ -131,6 +138,7 @@ export function buildProviderAdminPlugin(opts: BuildProviderAdminPluginOptions):
             providerRegistry.unregister(entry.name);
             throw err;
           }
+          const vaultKeyName = entry.envVar ?? `${entry.name.toUpperCase()}_API_KEY`;
           return {
             ok: true,
             name: entry.name,
@@ -142,8 +150,9 @@ export function buildProviderAdminPlugin(opts: BuildProviderAdminPluginOptions):
             replaced: wasRegistered,
             note:
               `Provider "${entry.name}" is live in this session. ` +
-              `Have the USER store the API key by running: /vault set ${(entry.envVar ?? `${entry.name.toUpperCase()}_API_KEY`)} <key> ` +
+              `Have the USER store the API key by running: /vault set ${vaultKeyName} <key> ` +
               `— never ask them to paste the key to you. ` +
+              `Once stored, you can verify it with provider_test (baseURL + keyName "${vaultKeyName}") — it resolves the key from the vault itself. ` +
               `Switch with the /provider command or set provider.name in moxxy.config.ts.`,
           };
         },
@@ -192,12 +201,39 @@ export function buildProviderAdminPlugin(opts: BuildProviderAdminPluginOptions):
       defineTool({
         name: 'provider_test',
         description:
-          'Probe an OpenAI-compatible endpoint with the supplied API key by calling /v1/models. ' +
-          'Use BEFORE provider_add to confirm the baseURL + key are valid. Returns { ok: true } on success or ' +
+          'Probe an OpenAI-compatible endpoint by calling /v1/models. Takes the NAME of a vault ' +
+          'secret (e.g. ZAI_API_KEY) and resolves the API key via the vault inside the handler — ' +
+          'the plaintext key never enters the conversation or logs. Have the USER store the key ' +
+          'first with /vault set <NAME> <key>, then call this to confirm the baseURL + key are ' +
+          'valid (typically before provider_add). Returns { ok: true } on success or ' +
           '{ ok: false, message } with the vendor error verbatim.',
         inputSchema: testProviderInput,
         permission: { action: 'prompt' },
-        handler: async ({ baseURL, apiKey }) => validateOpenAICompatKey(apiKey, { baseURL }),
+        // The plaintext key is resolved HERE, at call time, via ctx.getSecret —
+        // it never appears as tool input/output, so it stays out of the model
+        // context, the runner session log, and the desktop NDJSON log.
+        handler: async ({ baseURL, keyName }, ctx) => {
+          if (!ctx.getSecret) {
+            return {
+              ok: false,
+              message:
+                'provider_test: this session has no secret vault wired in (ctx.getSecret is ' +
+                'unavailable), so the key cannot be resolved. Register the provider with ' +
+                'provider_add and have the user verify the key with `moxxy doctor` instead.',
+            };
+          }
+          const apiKey = await ctx.getSecret(keyName);
+          if (!apiKey) {
+            return {
+              ok: false,
+              message:
+                `provider_test: no vault secret named "${keyName}". Ask the USER to store it ` +
+                `by running: /vault set ${keyName} <key> — then call provider_test again with ` +
+                `keyName "${keyName}". Never ask them to paste the key into the conversation.`,
+            };
+          }
+          return validateOpenAICompatKey(apiKey, { baseURL });
+        },
       }),
     ],
     hooks: {

--- a/packages/skills-builtin/skills/add-provider.md
+++ b/packages/skills-builtin/skills/add-provider.md
@@ -80,9 +80,13 @@ After they run it you'll get a note confirming storage and the reference `${vaul
 
 ## 4. (Optional) Test the endpoint
 
-`provider_test` needs the plaintext key, which you don't have — so don't call it with the key yourself. To verify the endpoint, either:
-- ask the user to run a quick check themselves, or
-- skip ahead: after registering (step 5), have the user run `moxxy doctor`, which resolves `<SLUG>_API_KEY` from the vault and reports whether the provider's key is present.
+Once the user has stored the key (step 3), verify the baseURL + key with `provider_test` — it takes the vault key **name**, not the key, and resolves the plaintext internally so it never enters the conversation:
+
+```json
+{ "baseURL": "<base url>", "keyName": "<SLUG>_API_KEY" }
+```
+
+If it reports the secret is missing, the user hasn't run `/vault set <SLUG>_API_KEY <key>` yet — go back to step 3. Alternatively, after registering (step 5), the user can run `moxxy doctor`, which resolves `<SLUG>_API_KEY` from the vault and reports whether the provider's key is present.
 
 ## 5. Register the provider
 

--- a/scripts/safe-publish.mjs
+++ b/scripts/safe-publish.mjs
@@ -12,7 +12,15 @@
  *
  * What this script does:
  *
- *   1. Iterate the non-private workspace packages under `packages/`.
+ *   1. Iterate the non-private workspace packages under `packages/`, in
+ *      DEPENDENCY ORDER (topological sort over `workspace:` references
+ *      between publishable packages — dependencies publish before their
+ *      dependents). Order matters because `pnpm publish` rewrites
+ *      `workspace:*` to an EXACT pin on the dependency's local package.json
+ *      version at pack time: publishing sdk first means a tombstone bump of
+ *      sdk (written to its package.json on disk, step 3) is what a later
+ *      cli publish pins against. The old readdir order could ship cli pinned
+ *      to an sdk version that then bumped past a tombstone and never existed.
  *   2. Skip a package whose current version is already on npm (visible).
  *      This matches the behaviour of `changesets publish` for unchanged
  *      packages, so it's safe to run on every CI invocation.
@@ -24,24 +32,44 @@
  *      writes the new version to package.json, and tries again. The bump
  *      loop is capped (MAX_BUMP_ATTEMPTS) so a misconfiguration cannot
  *      run away.
- *   4. After all publishes are done, commit any tombstone-driven bumps
- *      back to the repository so the next release does not have to walk
- *      the same dead slots again. Only runs inside GitHub Actions.
- *   5. Create the `<pkg>@<ver>` git tag for each published package and
+ *   4. If a package fails to publish, its dependents are NOT published —
+ *      they are reported as `blocked` (and count as failures). Publishing
+ *      them anyway would ship exact pins on versions that never landed.
+ *   5. After all publishes, verify what actually shipped: for every package
+ *      published in this run, fetch its manifest from the registry and check
+ *      that every `@moxxy/*` dependency version it pinned EXISTS on npm.
+ *      A miss is loud and fatal (exit 1) — it means a broken, installable
+ *      package is live and the missing dependency version must be published
+ *      immediately.
+ *   6. Commit any tombstone-driven bumps back to the repository so the next
+ *      release does not have to walk the same dead slots again. Only runs
+ *      inside GitHub Actions.
+ *   7. Create the `<pkg>@<ver>` git tag for each published package and
  *      emit the `🦋  New tag: <pkg>@<ver>` lines, so `changesets/action`
  *      can push the tags and create GitHub releases. (The stock
  *      `changeset publish` creates these tags; this wrapper replaces it,
  *      so it must create them too — otherwise the action's tag push fails
  *      with "src refspec <tag> does not match any".)
  *
- * Exit codes: 0 on full success, 1 if anything failed for a reason other
- * than tombstone-exhaustion (those are reported but do not block the
- * overall workflow from moving on).
+ * Flags:
+ *   --dry-run   Print the resolved publish order (with each package's
+ *               workspace dependencies) and exit. No registry or git access.
+ *   --help      Usage.
+ *
+ * Exit codes: 0 on full success, 1 if any publish failed, was blocked by a
+ * failed dependency, or the post-publish dependency-consistency check found
+ * a pin on a version that is not on the registry.
+ *
+ * The pure helpers (topo sort, pin parsing, consistency check) are exported
+ * for the unit tests in `scripts/safe-publish.test.mjs` (run via the root
+ * `pnpm test:scripts`); importing this module never publishes — the main
+ * routine only runs when the script is invoked directly.
  */
 
 import { execSync, spawnSync } from 'node:child_process';
 import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const ROOT = resolve(process.cwd());
 const PACKAGES_DIR = join(ROOT, 'packages');
@@ -63,6 +91,10 @@ const ALREADY_PUBLISHED_PATTERNS = [
   /You cannot publish over the previously published versions: \d/i,
   /403 Forbidden.*already published/i,
 ];
+
+// Dependency fields that ship in the published manifest (devDependencies are
+// stripped / not installed by consumers, so they don't constrain order).
+const SHIPPED_DEP_FIELDS = ['dependencies', 'peerDependencies', 'optionalDependencies'];
 
 function readPkg(dir) {
   return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
@@ -93,9 +125,11 @@ function tryPublish(dir) {
   // Publish with `pnpm publish`, NOT `npm publish`. pnpm rewrites the
   // pnpm-only `workspace:*` and `catalog:` protocols in `dependencies` /
   // `peerDependencies` to concrete version ranges in the published
-  // package.json. `npm publish` ships those protocols verbatim, producing a
-  // tarball that npm itself cannot install (EUNSUPPORTEDPROTOCOL
-  // 'Unsupported URL Type "workspace:"').
+  // package.json (`workspace:*` becomes an EXACT pin on the local workspace
+  // dependency's version at pack time — which is why tombstone bumps are
+  // written to disk and dependencies publish first). `npm publish` ships
+  // those protocols verbatim, producing a tarball that npm itself cannot
+  // install (EUNSUPPORTEDPROTOCOL 'Unsupported URL Type "workspace:"').
   //
   // --no-git-checks: this script rewrites package.json in place when walking
   //   past tombstoned versions, which dirties the working tree. pnpm's
@@ -122,6 +156,142 @@ function listPublishablePackages() {
     .filter((dir) => existsSync(join(dir, 'package.json')))
     .map((dir) => ({ dir, pkg: readPkg(dir) }))
     .filter(({ pkg }) => !pkg.private && typeof pkg.name === 'string');
+}
+
+/**
+ * Names of OTHER publishable workspace packages this manifest depends on via
+ * the `workspace:` protocol, across every dependency field that ships.
+ * (Only `workspace:` refs matter: those are the pins pnpm rewrites from the
+ * local tree; a plain semver ref resolves from the registry regardless of
+ * publish order.)
+ */
+export function workspaceDepNames(pkg, publishableNames) {
+  const found = new Set();
+  for (const field of SHIPPED_DEP_FIELDS) {
+    for (const [dep, spec] of Object.entries(pkg[field] ?? {})) {
+      if (dep === pkg.name) continue;
+      if (!publishableNames.has(dep)) continue;
+      if (typeof spec === 'string' && spec.startsWith('workspace:')) found.add(dep);
+    }
+  }
+  return [...found].sort();
+}
+
+/**
+ * Topologically sort `[{ dir, pkg }]` so every package comes AFTER the
+ * publishable workspace dependencies it pins. Deterministic (name-sorted
+ * DFS). Throws on a dependency cycle — that's a workspace misconfiguration
+ * and publishing in any order would ship a pin that can't be satisfied yet.
+ */
+export function topoSortPackages(packages) {
+  const byName = new Map(packages.map((p) => [p.pkg.name, p]));
+  const names = new Set(byName.keys());
+  const depsOf = new Map(
+    packages.map((p) => [p.pkg.name, workspaceDepNames(p.pkg, names)]),
+  );
+  const sorted = [];
+  const done = new Set();
+  const visiting = new Set();
+  const visit = (name, chain) => {
+    if (done.has(name)) return;
+    if (visiting.has(name)) {
+      throw new Error(
+        `workspace dependency cycle between publishable packages: ${[...chain, name].join(' → ')}`,
+      );
+    }
+    visiting.add(name);
+    for (const dep of depsOf.get(name)) visit(dep, [...chain, name]);
+    visiting.delete(name);
+    done.add(name);
+    sorted.push(byName.get(name));
+  };
+  for (const name of [...names].sort()) visit(name, []);
+  return sorted;
+}
+
+/**
+ * Extract the `@moxxy/*` dependency pins from a SHIPPED manifest's
+ * dependency fields. Returns `{ name, spec, version }` per pin, where
+ * `version` is the concrete base version parsed out of the spec
+ * (`0.7.0` / `^0.7.0` / `~0.7.0` → `0.7.0`) or null when unparseable.
+ */
+export function moxxyDepPins(manifest) {
+  const pins = [];
+  for (const field of SHIPPED_DEP_FIELDS) {
+    for (const [name, spec] of Object.entries(manifest?.[field] ?? {})) {
+      if (!name.startsWith('@moxxy/')) continue;
+      const m = /(\d+\.\d+\.\d+(?:-[\w.-]+)?)/.exec(String(spec));
+      pins.push({ name, spec: String(spec), version: m ? m[1] : null });
+    }
+  }
+  return pins;
+}
+
+/**
+ * Post-publish consistency check (pure core — registry access is injected).
+ * For each package published in this run, read the manifest that actually
+ * shipped and verify every `@moxxy/*` pin points at a version that EXISTS on
+ * the registry. Returns a list of problems (empty = consistent).
+ *
+ * io: {
+ *   shippedManifest(name, version) → manifest object | null (unreadable),
+ *   versionExists(name, version) → boolean,
+ * }
+ */
+export async function findShippedDepProblems(published, io) {
+  const problems = [];
+  for (const { name, version } of published) {
+    const manifest = await io.shippedManifest(name, version);
+    if (manifest == null) {
+      problems.push({
+        pkg: `${name}@${version}`,
+        problem: 'could not read the published manifest from the registry',
+      });
+      continue;
+    }
+    for (const pin of moxxyDepPins(manifest)) {
+      if (pin.version == null) {
+        problems.push({
+          pkg: `${name}@${version}`,
+          problem: `unparseable dependency spec shipped: ${pin.name}@"${pin.spec}"`,
+        });
+        continue;
+      }
+      if (!(await io.versionExists(pin.name, pin.version))) {
+        problems.push({
+          pkg: `${name}@${version}`,
+          problem: `shipped pinned to ${pin.name}@${pin.version} (spec "${pin.spec}") which does NOT exist on the registry`,
+        });
+      }
+    }
+  }
+  return problems;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** `npm view <name>@<version> --json` with retries (registry propagation lag). */
+async function fetchShippedManifest(name, version, { attempts = 3, delayMs = 5000 } = {}) {
+  for (let i = 0; i < attempts; i += 1) {
+    const r = spawnSync('npm', ['view', `${name}@${version}`, '--json'], { encoding: 'utf8' });
+    if (r.status === 0 && r.stdout.trim()) {
+      try {
+        return JSON.parse(r.stdout);
+      } catch {
+        /* fall through to retry */
+      }
+    }
+    if (i < attempts - 1) await sleep(delayMs);
+  }
+  return null;
+}
+
+async function versionExistsWithRetry(name, version, { attempts = 3, delayMs = 5000 } = {}) {
+  for (let i = 0; i < attempts; i += 1) {
+    if (alreadyPublished(name, version)) return true;
+    if (i < attempts - 1) await sleep(delayMs);
+  }
+  return false;
 }
 
 function announceTag(name, version) {
@@ -175,97 +345,194 @@ function commitBumps(bumps) {
   }
 }
 
-const packages = listPublishablePackages();
-if (packages.length === 0) {
-  console.log('No publishable workspace packages found under packages/.');
-  process.exit(0);
+function printUsage() {
+  console.log(
+    [
+      'Usage: node scripts/safe-publish.mjs [--dry-run] [--help]',
+      '',
+      'Publishes the non-private packages under packages/ in dependency order,',
+      'skipping versions already on npm and auto-bumping past tombstoned slots.',
+      '',
+      '  --dry-run  print the resolved publish order and exit (no registry/git access)',
+      '  --help     this message',
+    ].join('\n'),
+  );
 }
 
-const results = [];
-const bumps = [];
+async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.includes('--help') || argv.includes('-h')) {
+    printUsage();
+    return 0;
+  }
+  const dryRun = argv.includes('--dry-run');
 
-for (const { dir, pkg } of packages) {
-  console.log(`\n=== ${pkg.name}@${pkg.version} ===`);
-
-  if (alreadyPublished(pkg.name, pkg.version)) {
-    console.log('  → already on npm, skipping');
-    results.push({ name: pkg.name, version: pkg.version, status: 'skipped' });
-    continue;
+  let ordered;
+  const packages = listPublishablePackages();
+  if (packages.length === 0) {
+    console.log('No publishable workspace packages found under packages/.');
+    return 0;
+  }
+  try {
+    ordered = topoSortPackages(packages);
+  } catch (err) {
+    console.error(`::error::${err instanceof Error ? err.message : String(err)}`);
+    return 1;
   }
 
-  let current = pkg;
-  let attempts = 0;
-  let outcome = null;
+  const publishableNames = new Set(ordered.map((p) => p.pkg.name));
 
-  while (attempts <= MAX_BUMP_ATTEMPTS) {
-    const r = tryPublish(dir);
-    if (r.code === 0) {
-      console.log(`  ✓ published ${current.name}@${current.version}`);
-      createGitTag(current.name, current.version);
-      announceTag(current.name, current.version);
-      outcome = { status: 'published', version: current.version };
-      break;
-    }
-
-    const tombstone = matchesAny(r.stderr, TOMBSTONE_PATTERNS);
-    const alreadyVisible = !tombstone && matchesAny(r.stderr, ALREADY_PUBLISHED_PATTERNS);
-
-    if (alreadyVisible) {
-      console.log(`  → ${current.name}@${current.version} is already on the registry, skipping`);
-      outcome = { status: 'skipped', version: current.version };
-      break;
-    }
-
-    if (!tombstone) {
-      console.error(`::error::publish failed for ${current.name}@${current.version}`);
-      console.error(r.stderr.trim());
-      outcome = { status: 'failed', version: current.version, error: r.stderr.slice(0, 800) };
-      break;
-    }
-
-    attempts += 1;
-    if (attempts > MAX_BUMP_ATTEMPTS) {
-      console.error(
-        `::error::${current.name}@${current.version} is tombstoned and ${MAX_BUMP_ATTEMPTS} consecutive bumps were also tombstoned. Bump manually.`,
+  if (dryRun) {
+    console.log('Publish order (dependencies first):');
+    for (const { pkg } of ordered) {
+      const deps = workspaceDepNames(pkg, publishableNames);
+      console.log(
+        `  ${pkg.name}@${pkg.version}${deps.length ? `  (after: ${deps.join(', ')})` : ''}`,
       );
-      outcome = { status: 'failed', version: current.version, error: 'tombstone-exhausted' };
-      break;
+    }
+    console.log('\nDry run — nothing was published.');
+    return 0;
+  }
+
+  const results = [];
+  const bumps = [];
+  // Packages whose publish failed (or was blocked) — their dependents must
+  // NOT publish, or they'd ship exact pins on versions that never landed.
+  const failedNames = new Set();
+
+  for (const { dir, pkg } of ordered) {
+    console.log(`\n=== ${pkg.name}@${pkg.version} ===`);
+
+    const blockedBy = workspaceDepNames(pkg, publishableNames).filter((d) => failedNames.has(d));
+    if (blockedBy.length > 0) {
+      console.error(
+        `::error::NOT publishing ${pkg.name}@${pkg.version}: workspace dependenc${blockedBy.length === 1 ? 'y' : 'ies'} ${blockedBy.join(', ')} failed to publish. ` +
+          'Publishing it would pin a dependency version that never shipped.',
+      );
+      results.push({ name: pkg.name, version: pkg.version, status: 'blocked' });
+      failedNames.add(pkg.name);
+      continue;
     }
 
-    const next = bumpPatch(current.version);
-    console.warn(
-      `::warning::${current.name}@${current.version} is tombstoned, bumping to ${next} (attempt ${attempts}/${MAX_BUMP_ATTEMPTS})`,
-    );
-    bumps.push({ dir, name: current.name, from: current.version, to: next });
-    current = { ...current, version: next };
-    writePkg(dir, current);
+    if (alreadyPublished(pkg.name, pkg.version)) {
+      console.log('  → already on npm, skipping');
+      results.push({ name: pkg.name, version: pkg.version, status: 'skipped' });
+      continue;
+    }
+
+    let current = pkg;
+    let attempts = 0;
+    let outcome = null;
+
+    while (attempts <= MAX_BUMP_ATTEMPTS) {
+      const r = tryPublish(dir);
+      if (r.code === 0) {
+        console.log(`  ✓ published ${current.name}@${current.version}`);
+        createGitTag(current.name, current.version);
+        announceTag(current.name, current.version);
+        outcome = { status: 'published', version: current.version };
+        break;
+      }
+
+      const tombstone = matchesAny(r.stderr, TOMBSTONE_PATTERNS);
+      const alreadyVisible = !tombstone && matchesAny(r.stderr, ALREADY_PUBLISHED_PATTERNS);
+
+      if (alreadyVisible) {
+        console.log(`  → ${current.name}@${current.version} is already on the registry, skipping`);
+        outcome = { status: 'skipped', version: current.version };
+        break;
+      }
+
+      if (!tombstone) {
+        console.error(`::error::publish failed for ${current.name}@${current.version}`);
+        console.error(r.stderr.trim());
+        outcome = { status: 'failed', version: current.version, error: r.stderr.slice(0, 800) };
+        break;
+      }
+
+      attempts += 1;
+      if (attempts > MAX_BUMP_ATTEMPTS) {
+        console.error(
+          `::error::${current.name}@${current.version} is tombstoned and ${MAX_BUMP_ATTEMPTS} consecutive bumps were also tombstoned. Bump manually.`,
+        );
+        outcome = { status: 'failed', version: current.version, error: 'tombstone-exhausted' };
+        break;
+      }
+
+      const next = bumpPatch(current.version);
+      console.warn(
+        `::warning::${current.name}@${current.version} is tombstoned, bumping to ${next} (attempt ${attempts}/${MAX_BUMP_ATTEMPTS})`,
+      );
+      bumps.push({ dir, name: current.name, from: current.version, to: next });
+      current = { ...current, version: next };
+      // Persisting the bump to package.json is load-bearing twice over: it is
+      // what the retried `pnpm publish` reads, AND what a later dependent's
+      // pack reads when rewriting its `workspace:*` pin to this new version.
+      writePkg(dir, current);
+    }
+
+    if (outcome.status === 'failed') failedNames.add(current.name);
+    results.push({ name: current.name, ...outcome });
   }
 
-  results.push({ name: current.name, ...outcome });
-}
-
-console.log('\n----- Publish summary -----');
-const longest = Math.max(...results.map((r) => r.name.length), 1);
-for (const r of results) {
-  console.log(`  ${r.status.padEnd(10)} ${r.name.padEnd(longest)} ${r.version}`);
-}
-
-// Consolidate per-package bumps to one entry per package (final version),
-// in case a package walked through several tombstones.
-const finalBumps = [];
-for (const b of bumps) {
-  const existing = finalBumps.find((x) => x.name === b.name);
-  if (existing) {
-    existing.to = b.to;
-  } else {
-    finalBumps.push({ ...b });
+  console.log('\n----- Publish summary -----');
+  const longest = Math.max(...results.map((r) => r.name.length), 1);
+  for (const r of results) {
+    console.log(`  ${r.status.padEnd(10)} ${r.name.padEnd(longest)} ${r.version}`);
   }
-}
-commitBumps(finalBumps);
 
-const failed = results.filter((r) => r.status === 'failed');
-if (failed.length > 0) {
-  console.error(`\n${failed.length} package(s) failed to publish.`);
-  process.exit(1);
+  // Consolidate per-package bumps to one entry per package (final version),
+  // in case a package walked through several tombstones.
+  const finalBumps = [];
+  for (const b of bumps) {
+    const existing = finalBumps.find((x) => x.name === b.name);
+    if (existing) {
+      existing.to = b.to;
+    } else {
+      finalBumps.push({ ...b });
+    }
+  }
+  commitBumps(finalBumps);
+
+  // Post-publish consistency check: every @moxxy/* pin that shipped in this
+  // run must exist on the registry. A miss means an installable-but-broken
+  // package is LIVE — fail loudly so a human publishes the missing version
+  // immediately (the dependent cannot be unshipped; npm slots are permanent).
+  const published = results.filter((r) => r.status === 'published');
+  let consistencyFailed = false;
+  if (published.length > 0) {
+    console.log('\n----- Post-publish dependency consistency check -----');
+    const problems = await findShippedDepProblems(published, {
+      shippedManifest: (name, version) => fetchShippedManifest(name, version),
+      versionExists: (name, version) => versionExistsWithRetry(name, version),
+    });
+    if (problems.length === 0) {
+      console.log('  ✓ every shipped @moxxy/* dependency pin exists on the registry');
+    } else {
+      consistencyFailed = true;
+      for (const p of problems) {
+        console.error(`::error::DEPENDENCY CONSISTENCY FAILURE: ${p.pkg} — ${p.problem}`);
+      }
+      console.error(
+        '::error::A published package references an @moxxy/* version that is not on npm. ' +
+          'It is LIVE and broken for installers. Publish the missing dependency version ' +
+          '(or bump + republish the dependent) IMMEDIATELY.',
+      );
+    }
+  }
+
+  const failed = results.filter((r) => r.status === 'failed' || r.status === 'blocked');
+  if (failed.length > 0 || consistencyFailed) {
+    if (failed.length > 0) console.error(`\n${failed.length} package(s) failed or were blocked.`);
+    return 1;
+  }
+  return 0;
 }
-process.exit(0);
+
+// Only publish when invoked directly (`node scripts/safe-publish.mjs`);
+// importing the module (unit tests) must stay side-effect free.
+const invokedDirectly =
+  process.argv[1] != null && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (invokedDirectly) {
+  process.exit(await main());
+}

--- a/scripts/safe-publish.test.mjs
+++ b/scripts/safe-publish.test.mjs
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for the pure helpers in safe-publish.mjs (topological publish
+ * order + post-publish dependency consistency). Run via the root
+ * `pnpm test:scripts` (chained into `pnpm test`). Importing safe-publish.mjs is
+ * side-effect free — the publish routine only runs when invoked directly.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  workspaceDepNames,
+  topoSortPackages,
+  moxxyDepPins,
+  findShippedDepProblems,
+} from './safe-publish.mjs';
+
+const pkg = (name, version, fields = {}) => ({ dir: `/x/${name}`, pkg: { name, version, ...fields } });
+
+test('workspaceDepNames: only workspace: refs to other publishable packages, shipped fields only', () => {
+  const manifest = {
+    name: '@moxxy/cli',
+    dependencies: {
+      '@moxxy/sdk': 'workspace:*', // counts
+      '@moxxy/private-thing': 'workspace:*', // not publishable → ignored
+      '@moxxy/registry-dep': '^1.0.0', // plain semver → ignored (no order constraint)
+      zod: '^3.24.0', // external → ignored
+    },
+    peerDependencies: { '@moxxy/peer': 'workspace:^' }, // counts
+    optionalDependencies: { '@moxxy/opt': 'workspace:*' }, // counts
+    devDependencies: { '@moxxy/devonly': 'workspace:*' }, // stripped at publish → ignored
+  };
+  const publishable = new Set(['@moxxy/cli', '@moxxy/sdk', '@moxxy/peer', '@moxxy/opt', '@moxxy/devonly', '@moxxy/registry-dep']);
+  assert.deepEqual(workspaceDepNames(manifest, publishable), ['@moxxy/opt', '@moxxy/peer', '@moxxy/sdk']);
+});
+
+test('topoSortPackages: dependencies publish before dependents regardless of readdir order', () => {
+  // readdir order would yield cli before sdk (alphabetical) — the exact A12 hazard.
+  const input = [
+    pkg('@moxxy/cli', '0.7.0', { dependencies: { '@moxxy/sdk': 'workspace:*' } }),
+    pkg('@moxxy/sdk', '0.7.0', {}),
+  ];
+  const order = topoSortPackages(input).map((p) => p.pkg.name);
+  assert.deepEqual(order, ['@moxxy/sdk', '@moxxy/cli']);
+});
+
+test('topoSortPackages: deterministic, deep chains ordered, unrelated packages name-sorted', () => {
+  const input = [
+    pkg('@moxxy/c', '1.0.0', { dependencies: { '@moxxy/b': 'workspace:*' } }),
+    pkg('@moxxy/zeta', '1.0.0', {}),
+    pkg('@moxxy/b', '1.0.0', { dependencies: { '@moxxy/a': 'workspace:*' } }),
+    pkg('@moxxy/a', '1.0.0', {}),
+  ];
+  const order = topoSortPackages(input).map((p) => p.pkg.name);
+  assert.deepEqual(order, ['@moxxy/a', '@moxxy/b', '@moxxy/c', '@moxxy/zeta']);
+  // Same input shuffled → same order.
+  const order2 = topoSortPackages([...input].reverse()).map((p) => p.pkg.name);
+  assert.deepEqual(order2, order);
+});
+
+test('topoSortPackages: throws loudly on a workspace dependency cycle', () => {
+  const input = [
+    pkg('@moxxy/a', '1.0.0', { dependencies: { '@moxxy/b': 'workspace:*' } }),
+    pkg('@moxxy/b', '1.0.0', { dependencies: { '@moxxy/a': 'workspace:*' } }),
+  ];
+  assert.throws(() => topoSortPackages(input), /cycle/);
+});
+
+test('moxxyDepPins: parses exact and ranged pins, flags unparseable specs', () => {
+  const pins = moxxyDepPins({
+    dependencies: {
+      '@moxxy/sdk': '0.7.0',
+      '@moxxy/other': '^1.2.3',
+      '@moxxy/weird': 'latest',
+      zod: '^3.24.0',
+    },
+    peerDependencies: { '@moxxy/peer': '~2.0.1-rc.1' },
+  });
+  assert.deepEqual(pins, [
+    { name: '@moxxy/sdk', spec: '0.7.0', version: '0.7.0' },
+    { name: '@moxxy/other', spec: '^1.2.3', version: '1.2.3' },
+    { name: '@moxxy/weird', spec: 'latest', version: null },
+    { name: '@moxxy/peer', spec: '~2.0.1-rc.1', version: '2.0.1-rc.1' },
+  ]);
+});
+
+test('findShippedDepProblems: clean when every shipped pin exists', async () => {
+  const problems = await findShippedDepProblems(
+    [{ name: '@moxxy/cli', version: '0.7.0' }],
+    {
+      shippedManifest: async () => ({ dependencies: { '@moxxy/sdk': '0.7.0', zod: '^3.24.0' } }),
+      versionExists: async (name, version) => name === '@moxxy/sdk' && version === '0.7.0',
+    },
+  );
+  assert.deepEqual(problems, []);
+});
+
+test('findShippedDepProblems: reports a pin on a version missing from the registry', async () => {
+  // The A12 scenario: cli shipped pinned to sdk@0.7.0 but sdk tombstone-bumped to 0.7.1.
+  const problems = await findShippedDepProblems(
+    [{ name: '@moxxy/cli', version: '0.7.0' }],
+    {
+      shippedManifest: async () => ({ dependencies: { '@moxxy/sdk': '0.7.0' } }),
+      versionExists: async (name, version) => !(name === '@moxxy/sdk' && version === '0.7.0'),
+    },
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0].problem, /@moxxy\/sdk@0\.7\.0/);
+  assert.match(problems[0].problem, /does NOT exist/);
+});
+
+test('findShippedDepProblems: unreadable manifest and unparseable spec are problems', async () => {
+  const problems = await findShippedDepProblems(
+    [
+      { name: '@moxxy/cli', version: '0.7.0' },
+      { name: '@moxxy/sdk', version: '0.7.0' },
+    ],
+    {
+      shippedManifest: async (name) =>
+        name === '@moxxy/cli' ? null : { dependencies: { '@moxxy/x': 'latest' } },
+      versionExists: async () => true,
+    },
+  );
+  assert.equal(problems.length, 2);
+  assert.match(problems[0].problem, /could not read/);
+  assert.match(problems[1].problem, /unparseable/);
+});


### PR DESCRIPTION
Fixes the last five adversarially-verified high findings from the 2026-06-09 main-branch audit (intake in TECH_DEBT.md). With #129, this completes A1–A13.

## A5 — `browser_session.goto` had no SSRF guard (security, high)
`assertPublicUrl` + IP-range logic hoisted into a shared `plugin-browser/src/ssrf-guard.ts` (deliberately sdk-free so the tsup-bundled sidecar stays builtin-only), enforced at **three layers**: parent before the RPC (blocked URLs never reach the sidecar), sidecar dispatch **before** `ensurePlaywright` (no browser launch for blocked URLs), and a context-level `route('**/*')` interceptor that validates navigation requests (top-level + iframe — covers HTTP redirect hops and in-page navigation) while letting subresources continue without per-request DNS cost. The false "same guard as web_fetch" comments are corrected; the residual blind-subresource risk is documented honestly in the tool description. `web_fetch` unchanged (15/15 tests untouched). +21 new tests.

## A6 — `provider_test` took the raw API key as model-visible input (security, high)
Input is now `{ baseURL, keyName }` (envVar-shaped name), resolved via `ctx.getSecret` in the handler — the key never enters model context or session logs. `apiKey` **removed outright** (the add-provider skill explicitly forbade using it, and no programmatic caller exists — a deprecated plaintext input would have preserved the leak channel). Missing secret → actionable `/vault set` guidance; tool description, `provider_add`'s note, and the add-provider skill all updated. +5 tests incl. plaintext-never-echoed.

## A11 — `afterWorkflow` triggers looped forever on cycles (stability, high)
Re-fires now carry a **per-run trigger chain** stamped onto the `workflow_completed` payload — re-entry into the chain (warning names the full cycle) or depth > 8 refuses. `syncSchedules` additionally runs **Tarjan SCC** over the enabled afterWorkflow graph and disables auto-refire for cycle members (warned once per cycle, re-enabled when the cycle is broken; manual/scheduled runs unaffected). +14 tests incl. an end-to-end A↔B through a real session/event log.

## A12 — `safe-publish.mjs` could ship a permanently broken cli (stability, high)
Publishable packages now **topo-sort over `workspace:` refs** (deps before dependents; loud failure on cycles); a failed dependency publish marks dependents `blocked` (transitively) instead of shipping them pinned to versions that never shipped; and a **post-publish consistency check** (`npm view` with propagation retries) verifies every shipped `@moxxy/*` pin exists on the registry, exiting 1 loudly if not. Pin behavior verified empirically: `pnpm pack` pins the on-disk dep version, and tombstone bumps persist on disk — so ordering makes pins correct by construction. All prior invariants (tombstone walking, `🦋 New tag:` lines, release.yml contract) preserved; new `--dry-run`/`--help`; 8 tests wired into root `pnpm test`.

## A13 — default `moxxy mobile` printed an unconnectable QR (PoC, high)
The QR now advertises **exactly what is bound**: loopback default → `ws://127.0.0.1` (simulators) + a hint that a real phone needs `MOXXY_MOBILE_HOST`/`bindHost` opt-in or a tunnel; wildcard bind → LAN IP; explicit host verbatim; tunnel path unchanged. Loopback-by-default security posture kept; README now documents simulator-vs-phone truthfully. +13 tests.

## Verification
- plugin-browser 40/40, plugin-provider-admin 22/22, plugin-channel-mobile 17/17, cli 102/102 (88 + 14 new), scripts 8/8
- Workspace gate: build 58/58, typecheck clean, lint 0 errors
- Changesets: patches for plugin-browser, plugin-provider-admin, cli, plugin-channel-mobile + empty changeset for scripts
- TECH_DEBT intake A5/A6/A11/A12/A13 marked ✅ FIXED

Note: may need a trivial rebase on TECH_DEBT.md after #129 merges (adjacent intake list items).