### PR TITLE
fix(stability,security): audit wave 5 — A23–A31 (core event-log, WS-bridge/mobile hardening, runner socket)

### DIFF
--- a/.changeset/core-eventlog-hardening.md
+++ b/.changeset/core-eventlog-hardening.md
@@ -1,0 +1,11 @@
+---
+'@moxxy/core': patch
+'@moxxy/sdk': patch
+---
+
+Event-log and session-persistence hardening (audit wave 5):
+
+- `EventLog.ingest` no longer leaks async listener rejections as unhandled rejections — they are swallowed under the same non-fatal policy as `append()`.
+- Session event-log write failures are no longer silent: one structured warning per failure streak (path + error), a `SessionPersistence.degraded` flag, and a recovery log once writes succeed again.
+- `restoreEvents` re-sequences restored events to contiguous seq 0..n-1 around corrupt JSONL lines (warning with skip/re-sequence counts) and atomically repairs the on-disk file, so a single corrupt middle line no longer truncates attached-client replay or causes seq collisions on new appends.
+- `projectMessages` skips empty/whitespace-only assistant text blocks (keeping tool_use blocks), so tool-only turns — including historical wedged logs — no longer produce empty text blocks that providers reject.

--- a/.changeset/runner-socket-hardening.md
+++ b/.changeset/runner-socket-hardening.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/runner': patch
+---
+
+Harden the runner socket: the socket's parent directory is created/tightened to 0700 before listen (closing the chmod-after-listen window where another local user could connect), socket chmod failures are logged loudly instead of swallowed, and turn aborts are ownership-tracked — a cross-client abort is still allowed (shared-session model) but leaves an audit log naming both connection roles, with `MOXXY_RUNNER_STRICT_ABORT=1` opting into denial. On Windows the named pipe keeps the default DACL (Everyone gets read-only, no write); a one-time warning documents that gap.

--- a/.changeset/ws-bridge-hardening.md
+++ b/.changeset/ws-bridge-hardening.md
@@ -1,0 +1,16 @@
+---
+'@moxxy/ipc-server-ws': patch
+'@moxxy/client-transport-ws': patch
+'@moxxy/plugin-channel-mobile': patch
+'@moxxy/sdk': patch
+'@moxxy/desktop': patch
+---
+
+Harden the desktop/mobile WebSocket bridge (2026-06-09 audit, wave 5):
+
+- Reject browser-Origin upgrades unless allow-listed (`allowedOrigins`, default deny; native clients are unaffected).
+- Move the pairing token out of the URL: `Authorization: Bearer` or a `Sec-WebSocket-Protocol` bearer entry are the supported presentations; the legacy `?t=` query is opt-in (`allowQueryToken`, kept on only for the mobile channel's already-paired apps). The QR still carries the token, but the app strips it before connecting.
+- Token rotation end to end: `rotateChannelToken` (sdk, persisted with `createdAt` + 90-day staleness warning), `rotateAuthToken` on the live server (drops existing connections), `rotateWsBridgeToken` (desktop) and `MobileChannel.rotateToken`.
+- Backpressure + lifecycle: connection cap (default 8), slow-reader eviction (backlog above 4 MB past a 10s grace terminates the socket), and `close()` now terminates clients so desktop quit doesn't burn its shutdown timeout.
+- `WsRpcClient` no longer replays abandoned requests after reconnect (outbox cleared, queued requests rejected on disconnect) and stops reconnecting after a capped exponential backoff, surfacing a terminal `disconnected` status.
+- Hygiene: empty `MOXXY_WS_PORT` no longer binds an ephemeral port, the server reports the actually-bound port, and the desktop bridge reuses the shared sdk token persistence (userData location kept).

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -148,6 +148,16 @@ Full report incl. the medium/low backlog and refuted findings:
   limit (+4k margin) per stream during streaming, the rest drained-and-counted so the
   command still completes with its real exit code and the existing
   `... [truncated N chars]` marker reports the true overflow (`tools-builtin/src/bash.ts`).
+- **A18 [medium, stability] Single-use rotating refresh tokens (claude-code, openai-codex)
+  had no cross-process or cross-consumer serialization, and vault persistence was whole-file
+  last-writer-wins from an in-memory snapshot** — ✅ FIXED (this PR): refresh+persist now runs
+  under a per-credential lock (`withCredentialLock` in plugin-oauth: in-process mutex +
+  best-effort O_EXCL lockfile under `<moxxy home>/locks` with stale takeover) with re-read
+  coalescing (followers adopt the winner's rotated tokens; one IdP call) and an
+  invalid_grant→re-read-vault→retry-once recovery in ensureFreshTokens, the claude-code
+  refresh helpers, and CodexProvider (new `reloadTokens` hook); `VaultStore` now
+  read-merge-writes (mtime-gated disk sync, newer-`updatedAt`-wins per key) instead of
+  persisting its snapshot.
 - **A19 [medium, stability] `RunnerSupervisor.restart()` used bare `child.kill()` + immediate
   respawn** — ✅ FIXED (this PR): restart() now awaits the same graceful `terminateChild`
   (SIGTERM → 2s grace → SIGKILL, resolved on actual exit) every other teardown path uses, so
@@ -164,16 +174,72 @@ Full report incl. the medium/low backlog and refuted findings:
   now only decides version + pinned sha; guard/build jobs check out the sha, and the
   `desktop-v<version>` tag is pushed (idempotently, at that same sha) in `desktop-release`
   only after every build leg succeeds, preserving PR #85's tag↔artifact-match invariant.
-- **A18 [medium, stability] Single-use rotating refresh tokens (claude-code, openai-codex)
-  had no cross-process or cross-consumer serialization, and vault persistence was whole-file
-  last-writer-wins from an in-memory snapshot** — ✅ FIXED (this PR): refresh+persist now runs
-  under a per-credential lock (`withCredentialLock` in plugin-oauth: in-process mutex +
-  best-effort O_EXCL lockfile under `<moxxy home>/locks` with stale takeover) with re-read
-  coalescing (followers adopt the winner's rotated tokens; one IdP call) and an
-  invalid_grant→re-read-vault→retry-once recovery in ensureFreshTokens, the claude-code
-  refresh helpers, and CodexProvider (new `reloadTokens` hook); `VaultStore` now
-  read-merge-writes (mtime-gated disk sync, newer-`updatedAt`-wins per key) instead of
-  persisting its snapshot.
+- **A23 [medium, stability] `EventLog.ingest` discards async listener rejections** —
+  ✅ FIXED (this PR): the fire-and-forget dispatch now attaches a `.catch` to the listener's
+  promise (`Promise.resolve(fn(event)).catch`), swallowing rejections under the same
+  non-fatal policy as `append()`'s awaited try/catch instead of leaking an unhandled
+  rejection that can kill the process.
+- **A24 [medium, stability] session event-log persistence silently swallows write
+  failures** — ✅ FIXED (this PR): append/truncate queue failures now emit one loud
+  structured `logger.warn` per failure streak (path + op + error, injectable
+  `SessionPersistenceOpts.logger`, stderr JSON by default), latch a
+  `SessionPersistence.degraded` flag, and a subsequent successful write clears the latch
+  (logging recovery) and re-arms the warn-once gate.
+- **A25 [medium, stability] restored session logs never re-sequenced — one corrupt middle
+  line truncates every mirror's replay at the gap** — ✅ FIXED (this PR): `restoreEvents`
+  counts skipped corrupt lines, rewrites the in-memory events to contiguous seq 0..n-1
+  (order/ids preserved, so `EventLog.ingest`'s `seq === length` gate replays the full
+  post-gap history and `append` mints non-colliding seqs), warns with the counts, and
+  atomically rewrites the repaired JSONL on disk (safe: restore runs before
+  `SessionPersistence.attach`, so no write queue is live) so the next resume is clean.
+- **A26 [medium, stability] empty assistant_message (tool-only end_turn) projects as an
+  empty text block providers reject — wedges the session log** — ✅ FIXED (this PR) at the
+  projection layer: `projectMessages` (sdk/mode-helpers) now skips whitespace-only
+  `assistant_message` content while keeping the grouped `tool_use` blocks, which also
+  un-wedges historical logs. Residual: the emitting sites
+  (mode-default/mode-goal/mode-deep-research loops) still log the empty event — harmless
+  to providers now, but a source-side guard there is a cheap follow-up (out of this
+  wave's package scope).
+- **A27 [medium, security] WS-bridge auth hardening: no Origin validation, token in the
+  URL query, no rotation/expiry** — ✅ FIXED (this PR): upgrades carrying a browser
+  `Origin` header are rejected unless allow-listed (`allowedOrigins`, default deny;
+  native clients send none), the token now travels as `Authorization: Bearer` or a
+  `Sec-WebSocket-Protocol` `moxxy.bearer.<encoded>` entry (shared sdk channel-auth
+  helpers) with the legacy `?t=` query OFF by default (opt-in `allowQueryToken`; the
+  mobile channel keeps it for already-paired apps — the QR still embeds `?t=` as a
+  pairing payload, but the app strips it before connecting), and rotation exists end to
+  end: `rotateChannelToken` (sdk) + `rotateAuthToken` on the live server (terminates
+  existing connections) + `rotateWsBridgeToken` (desktop) / `MobileChannel.rotateToken`,
+  with a soft 90-day staleness warning from the persisted `createdAt`.
+- **A28 [medium, stability] WsRpcClient replays abandoned requests after reconnect and
+  reconnects forever with no surfaced failure** — ✅ FIXED (this PR): on disconnect every
+  in-flight AND queued request is rejected and the outbox cleared (no silent re-execution
+  of non-idempotent commands like runTurn), reconnects back off exponentially (1.5s → 30s)
+  and give up after a cap (default 10), surfacing a terminal `disconnected` status via
+  `onStatus`/`client.status`, after which requests reject immediately.
+- **A29 [medium, stability] WS-bridge server lifecycle/backpressure: unbounded send
+  buffering, no connection cap, close() waits out clients** — ✅ FIXED (this PR):
+  concurrent connections are capped at the handshake (default 8), every outbound frame
+  consults a `SlowReaderGuard` (a socket whose backlog stays above 4 MB past a 10s grace
+  is terminated — the grace tolerates one legitimately large frame in flight), and
+  `close()` terminates remaining sockets before closing the listener so desktop quit no
+  longer burns the 3s shutdown timeout.
+- **A30 [low, hygiene] WS-bridge config/dedup: empty `MOXXY_WS_PORT` binds an ephemeral
+  port, `address` reports the requested (not bound) port, desktop re-rolls token
+  persistence** — ✅ FIXED (this PR): empty/whitespace port env is treated as unset,
+  `address` is built from `wss.address()` (real bound port, so `port: 0` is honest),
+  and desktop's `loadOrCreateToken` is gone in favor of the shared sdk
+  `resolveChannelToken` (new `dir` option keeps the userData location; legacy plain-text
+  token files still read).
+- **A31 [medium, security] Runner socket unauthenticated: chmod-after-listen race +
+  swallowed failure, no Windows pipe ACL, cross-client abort untracked** — ✅ FIXED (this
+  PR): the socket's parent dir is secured 0700 BEFORE listen (fresh dirs born private,
+  owned pre-existing dirs tightened in place — layout unchanged since desktop-host
+  hardcodes the paths), socket chmod failures now log loudly instead of being swallowed,
+  and aborts are ownership-tracked: a cross-client abort stays allowed (shared-session
+  model) but emits an audit log with both roles, with `MOXXY_RUNNER_STRICT_ABORT=1`
+  opting into denial. Documented gap: win32 named pipes keep the default DACL (Everyone:
+  read-only, no write) — Node can't set an explicit ACL; a one-time warn states this.
 
 ---
 

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -49,8 +49,7 @@ import type { DeepLinkPayload } from '@moxxy/desktop-ipc-contract';
 // boot itself depend on the module resolving — the exact failure that bricked
 // the 0.0.33 build when the package wasn't in BUNDLED_WORKSPACE_DEPS.
 // Type-only imports are erased at build time and carry no such risk.
-import type { WebSocketCommandBus } from '@moxxy/ipc-server-ws';
-import type { TransportServer } from '@moxxy/runner';
+import type { WebSocketCommandBus, WebSocketBridgeServer } from '@moxxy/ipc-server-ws';
 
 import { resolveWsBridgeConfig } from './ws-bridge.js';
 
@@ -88,7 +87,9 @@ const CLERK_PUBLISHABLE_KEY =
 let pool: RunnerPool | null = null;
 let mainWindow: BrowserWindow | null = null;
 /** The optional WebSocket bridge server (remote/mobile clients). Closed on quit. */
-let wsServer: TransportServer | null = null;
+// Typed as the bridge server (not the bare TransportServer) so the host can
+// call `rotateWsBridgeToken(userData, wsServer)` to invalidate a leaked token.
+let wsServer: WebSocketBridgeServer | null = null;
 
 // In-app loopback HTTP server the packaged renderer is served from (so the
 // Clerk web SDK runs on an http origin). null in dev (Vite serves it) and

--- a/apps/desktop/electron/main/ws-bridge.test.ts
+++ b/apps/desktop/electron/main/ws-bridge.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveWsBridgeConfig, rotateWsBridgeToken, wsBridgeTokenFile } from './ws-bridge.js';
+
+const ENV_KEYS = [
+  'MOXXY_WS_BRIDGE',
+  'MOXXY_WS_TOKEN',
+  'MOXXY_WS_PORT',
+  'MOXXY_WS_HOST',
+  'MOXXY_WS_ALLOW_QUERY_TOKEN',
+] as const;
+
+let saved: Record<string, string | undefined>;
+let userData: string;
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of ENV_KEYS) delete process.env[k];
+  process.env.MOXXY_WS_BRIDGE = '1';
+  userData = fs.mkdtempSync(path.join(os.tmpdir(), 'moxxy-ws-bridge-'));
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  fs.rmSync(userData, { recursive: true, force: true });
+});
+
+describe('resolveWsBridgeConfig', () => {
+  it('returns null when the bridge flag is off', () => {
+    delete process.env.MOXXY_WS_BRIDGE;
+    expect(resolveWsBridgeConfig(userData)).toBeNull();
+  });
+
+  it('treats an EMPTY MOXXY_WS_PORT as unset (Number("") is 0 — an ephemeral bind)', () => {
+    process.env.MOXXY_WS_PORT = '';
+    expect(resolveWsBridgeConfig(userData)?.port).toBe(8765);
+    process.env.MOXXY_WS_PORT = '   ';
+    expect(resolveWsBridgeConfig(userData)?.port).toBe(8765);
+  });
+
+  it('uses an explicit numeric port and falls back on garbage', () => {
+    process.env.MOXXY_WS_PORT = '9001';
+    expect(resolveWsBridgeConfig(userData)?.port).toBe(9001);
+    process.env.MOXXY_WS_PORT = 'not-a-port';
+    expect(resolveWsBridgeConfig(userData)?.port).toBe(8765);
+  });
+
+  it('leaves the legacy ?t= query credential OFF unless explicitly enabled', () => {
+    expect(resolveWsBridgeConfig(userData)?.allowQueryToken).toBeUndefined();
+    process.env.MOXXY_WS_ALLOW_QUERY_TOKEN = '1';
+    expect(resolveWsBridgeConfig(userData)?.allowQueryToken).toBe(true);
+  });
+
+  it('prefers MOXXY_WS_TOKEN, otherwise persists a generated token under userData', () => {
+    process.env.MOXXY_WS_TOKEN = 'env-token';
+    expect(resolveWsBridgeConfig(userData)?.authToken).toBe('env-token');
+
+    delete process.env.MOXXY_WS_TOKEN;
+    const generated = resolveWsBridgeConfig(userData)?.authToken;
+    expect(generated).toMatch(/^[0-9a-f]{64}$/);
+    expect(fs.existsSync(wsBridgeTokenFile(userData))).toBe(true);
+    // Stable across restarts (same persisted pairing secret).
+    expect(resolveWsBridgeConfig(userData)?.authToken).toBe(generated);
+  });
+
+  it('keeps reading a legacy plain-text ws-token file (pre-shared-helper format)', () => {
+    fs.writeFileSync(wsBridgeTokenFile(userData), 'legacy-pairing-secret\n');
+    expect(resolveWsBridgeConfig(userData)?.authToken).toBe('legacy-pairing-secret');
+  });
+});
+
+describe('rotateWsBridgeToken', () => {
+  it('rewrites the persisted token and re-keys + drops clients on a live server', () => {
+    const original = resolveWsBridgeConfig(userData)?.authToken;
+    const calls: string[] = [];
+    const fakeServer = {
+      address: 'ws://127.0.0.1:1',
+      onConnection: () => undefined,
+      close: () => Promise.resolve(),
+      rotateAuthToken: (next: string) => calls.push(next),
+    };
+    const rotated = rotateWsBridgeToken(userData, fakeServer);
+    expect(rotated).not.toBe(original);
+    expect(calls).toEqual([rotated]);
+    // The next resolve picks up the rotated secret.
+    expect(resolveWsBridgeConfig(userData)?.authToken).toBe(rotated);
+  });
+
+  it('works without a live server (persists only)', () => {
+    const rotated = rotateWsBridgeToken(userData, null);
+    expect(resolveWsBridgeConfig(userData)?.authToken).toBe(rotated);
+  });
+});

--- a/apps/desktop/electron/main/ws-bridge.ts
+++ b/apps/desktop/electron/main/ws-bridge.ts
@@ -3,34 +3,25 @@
  *
  * The bridge exposes the SAME IPC contract the renderer uses to a remote client
  * (the mobile app), so it's OFF by default and gated behind `MOXXY_WS_BRIDGE=1`.
- * It is always token-authenticated: an explicit `MOXXY_WS_TOKEN` wins, otherwise
- * a 256-bit token is generated once and persisted (0600) under userData so the
- * same pairing secret survives restarts. Bind address defaults to loopback;
- * `MOXXY_WS_HOST=0.0.0.0` opts into LAN exposure (still token-gated).
+ * It is always token-authenticated via the SDK's shared channel-auth helper: an
+ * explicit `MOXXY_WS_TOKEN` wins, otherwise a 256-bit token is generated once
+ * and persisted (0600) under userData so the same pairing secret survives
+ * restarts. Bind address defaults to loopback; `MOXXY_WS_HOST=0.0.0.0` opts
+ * into LAN exposure (still token-gated).
+ *
+ * Hardening defaults (see `WebSocketBridgeOptions`): browser-Origin upgrades
+ * are rejected, the legacy `?t=` query credential is off (clients present the
+ * token via header/subprotocol; `MOXXY_WS_ALLOW_QUERY_TOKEN=1` re-enables it
+ * for legacy clients), and connection-cap/backpressure limits apply.
  */
 
-import { randomBytes } from 'node:crypto';
-import fs from 'node:fs';
 import path from 'node:path';
 
-import type { WebSocketBridgeOptions } from '@moxxy/ipc-server-ws';
+import { resolveChannelToken, rotateChannelToken } from '@moxxy/sdk';
+import type { WebSocketBridgeOptions, WebSocketBridgeServer } from '@moxxy/ipc-server-ws';
 
 const DEFAULT_PORT = 8765;
 const TOKEN_FILE = 'ws-token';
-
-function loadOrCreateToken(userDataDir: string): string {
-  const file = path.join(userDataDir, TOKEN_FILE);
-  try {
-    const existing = fs.readFileSync(file, 'utf8').trim();
-    if (existing) return existing;
-  } catch {
-    // not yet created
-  }
-  const token = randomBytes(32).toString('hex');
-  fs.mkdirSync(userDataDir, { recursive: true });
-  fs.writeFileSync(file, token, { mode: 0o600 });
-  return token;
-}
 
 /**
  * Returns the bridge options when enabled, or `null` when the bridge is off.
@@ -39,11 +30,43 @@ function loadOrCreateToken(userDataDir: string): string {
  */
 export function resolveWsBridgeConfig(userDataDir: string): WebSocketBridgeOptions | null {
   if (process.env.MOXXY_WS_BRIDGE !== '1') return null;
-  const token = process.env.MOXXY_WS_TOKEN?.trim() || loadOrCreateToken(userDataDir);
-  const port = Number(process.env.MOXXY_WS_PORT ?? DEFAULT_PORT);
+  const token = resolveChannelToken({
+    envVar: 'MOXXY_WS_TOKEN',
+    fileName: TOKEN_FILE,
+    dir: userDataDir,
+  });
+  // An empty/whitespace MOXXY_WS_PORT means "unset" — Number('') is 0, which
+  // would silently bind an ephemeral port nobody knows about.
+  const rawPort = process.env.MOXXY_WS_PORT?.trim();
+  const port = rawPort ? Number(rawPort) : DEFAULT_PORT;
   return {
     port: Number.isFinite(port) ? port : DEFAULT_PORT,
     authToken: token,
     ...(process.env.MOXXY_WS_HOST ? { host: process.env.MOXXY_WS_HOST } : {}),
+    ...(process.env.MOXXY_WS_ALLOW_QUERY_TOKEN === '1' ? { allowQueryToken: true } : {}),
   };
+}
+
+/**
+ * Rotate the bridge's pairing token: persist a fresh secret to the userData
+ * token file and (when the bridge is running) re-key the live server, which
+ * terminates every existing connection — a leaked token/QR stops working
+ * immediately. Returns the new token so the host can re-display pairing info.
+ * No UI calls this yet; it's the mechanism a settings surface would invoke.
+ *
+ * Note: if `MOXXY_WS_TOKEN` is set it takes precedence at next resolve — env
+ * tokens must be rotated at their source.
+ */
+export function rotateWsBridgeToken(
+  userDataDir: string,
+  server: WebSocketBridgeServer | null,
+): string {
+  const token = rotateChannelToken({ fileName: TOKEN_FILE, dir: userDataDir });
+  server?.rotateAuthToken(token);
+  return token;
+}
+
+/** Absolute path of the persisted bridge token file (for diagnostics). */
+export function wsBridgeTokenFile(userDataDir: string): string {
+  return path.join(userDataDir, TOKEN_FILE);
 }

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -10,7 +10,14 @@
     "verbatimModuleSyntax": true,
     "allowImportingTsExtensions": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      // Pin every type-land `import 'react'` (incl. react-virtuoso's and
+      // @clerk/clerk-react's .d.ts) to THIS package's @types/react. The
+      // workspace carries a second copy (@types/react@19 via apps/mobile's
+      // Expo SDK), and when pnpm binds a library's peer types to that copy,
+      // its components stop being assignable to our React-18 JSX (TS2786).
+      "react": ["./node_modules/@types/react"],
+      "react-dom": ["./node_modules/@types/react-dom"]
     }
   },
   "include": ["src/**/*"],

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -6,7 +6,7 @@
  * shared store/model/hook code path drives a live chat loop unchanged on RN.
  */
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import {
   FlatList,
   Pressable,
@@ -35,7 +35,7 @@ import { bootMobile } from './boot';
 const ENV_URL = process.env.EXPO_PUBLIC_MOXXY_WS_URL;
 const ENV_TOKEN = process.env.EXPO_PUBLIC_MOXXY_WS_TOKEN;
 
-export default function App(): JSX.Element {
+export default function App(): React.JSX.Element {
   const [connected, setConnected] = useState<boolean>(() => {
     if (ENV_URL) {
       bootMobile(ENV_URL, ENV_TOKEN);
@@ -48,7 +48,9 @@ export default function App(): JSX.Element {
     return (
       <ConnectScreen
         onConnect={(url) => {
-          bootMobile(url); // token is embedded in the scanned URL (?t=…)
+          // The scanned QR embeds the token as ?t=…; bootMobile strips it from
+          // the WS URL and presents it via the subprotocol bearer entry.
+          bootMobile(url);
           setConnected(true);
         }}
       />
@@ -65,7 +67,7 @@ export default function App(): JSX.Element {
 }
 
 /** Pair by scanning the QR `moxxy mobile` (or the desktop bridge) prints. */
-function ConnectScreen({ onConnect }: { onConnect: (url: string) => void }): JSX.Element {
+function ConnectScreen({ onConnect }: { onConnect: (url: string) => void }): React.JSX.Element {
   const [permission, requestPermission] = useCameraPermissions();
   const [scanned, setScanned] = useState(false);
 
@@ -112,7 +114,7 @@ function ConnectScreen({ onConnect }: { onConnect: (url: string) => void }): JSX
   );
 }
 
-function Chat(): JSX.Element {
+function Chat(): React.JSX.Element {
   const workspaceId = useActiveWorkspaceId();
   const { snapshot } = useConnection(workspaceId);
   const { events, streamingText, sending, send } = useChat(workspaceId);
@@ -174,7 +176,7 @@ function Chat(): JSX.Element {
 
 /** Permission/approval prompt — proves the ask path works over the bridge too.
  *  The interactive resolver in the host parks the runner until we respond. */
-function AskPrompt({ workspaceId }: { workspaceId: string | null }): JSX.Element | null {
+function AskPrompt({ workspaceId }: { workspaceId: string | null }): React.JSX.Element | null {
   const ask = useActiveAsk(workspaceId);
   if (!ask) return null;
 

--- a/apps/mobile/src/boot.ts
+++ b/apps/mobile/src/boot.ts
@@ -4,13 +4,40 @@
  * capture, TTS, the legacy KV migration, and the event bus all degrade to
  * no-ops, exactly as the optional capability design intends. A real mobile build
  * would register Expo-backed implementations here instead.
+ *
+ * The QR `moxxy mobile` prints embeds the pairing token as `?t=` (one scan
+ * carries everything), but the token must NOT ride the live WS URL — query
+ * strings leak through tunnel/proxy logs. So the scanned URL is split here:
+ * `?t=` is stripped and handed to the transport, which presents it via the
+ * `Sec-WebSocket-Protocol` bearer entry instead.
  */
 
 import { configureTransport } from '@moxxy/client-core/transport';
 import { configurePlatform } from '@moxxy/client-core/platform';
 import { makeWsApi } from '@moxxy/client-transport-ws';
 
-export function bootMobile(url: string, token?: string): void {
-  configureTransport(makeWsApi({ url, ...(token ? { token } : {}) }));
+/** Split a scanned pairing URL into the bare WS URL + the embedded `?t=` token
+ *  (regex, not `new URL` — Hermes' URL support is unreliable). */
+export function splitConnectUrl(scanned: string): { url: string; token?: string } {
+  const match = /[?&]t=([^&#]+)/.exec(scanned);
+  if (!match) return { url: scanned };
+  let token: string;
+  try {
+    token = decodeURIComponent(match[1]!);
+  } catch {
+    return { url: scanned }; // malformed escape — connect as-is
+  }
+  const url = scanned
+    .replace(/([?&])t=[^&#]*&?/, '$1')
+    .replace(/[?&]$/, '');
+  return { url, token };
+}
+
+export function bootMobile(rawUrl: string, token?: string): void {
+  const split = splitConnectUrl(rawUrl);
+  const effectiveToken = token ?? split.token;
+  configureTransport(
+    makeWsApi({ url: split.url, ...(effectiveToken ? { token: effectiveToken } : {}) }),
+  );
   configurePlatform({});
 }

--- a/packages/client-transport-ws/src/globals.d.ts
+++ b/packages/client-transport-ws/src/globals.d.ts
@@ -6,3 +6,5 @@
 
 declare function setTimeout(handler: () => void, ms?: number): number;
 declare function clearTimeout(handle: number | undefined): void;
+/** Console exists on every supported runtime (browser, RN/Hermes, Node). */
+declare const console: { warn(...args: unknown[]): void };

--- a/packages/client-transport-ws/src/index.ts
+++ b/packages/client-transport-ws/src/index.ts
@@ -7,29 +7,59 @@
  *   configureTransport(makeWsApi({ url: 'ws://192.168.1.5:8765', token }));
  *
  * `invoke` maps to a JSON-RPC request; `subscribe` registers a notification
- * handler for an event channel. The token is presented as a `?t=` query param
- * (the bridge also accepts an `Authorization: Bearer` header, which a browser /
- * RN `WebSocket` can't set).
+ * handler for an event channel. The token is presented as a
+ * `Sec-WebSocket-Protocol` bearer entry (`moxxy.bearer.<encoded>` alongside the
+ * `moxxy.v1` protocol) — the only header a browser/RN `WebSocket` can influence
+ * — so the secret never rides the URL (query strings leak through logs and
+ * shoulder-surfed QRs; the bridge rejects `?t=` unless legacy mode is enabled).
+ *
+ * NOTE: the protocol constants here mirror `MOXXY_WS_SUBPROTOCOL` /
+ * `encodeWsBearerProtocol` in `@moxxy/sdk` (this package must stay free of
+ * Node-flavoured deps to bundle under Metro, so it can't import them).
  */
 
 import type { MoxxyApi } from '@moxxy/desktop-ipc-contract';
-import { WsRpcClient, type WebSocketCtor } from './json-rpc-client.js';
+import {
+  WsRpcClient,
+  type WebSocketCtor,
+  type WsClientStatus,
+} from './json-rpc-client.js';
 
-export { WsRpcClient, type WebSocketCtor, type WebSocketLike } from './json-rpc-client.js';
+export {
+  WsRpcClient,
+  type WebSocketCtor,
+  type WebSocketLike,
+  type WsClientStatus,
+  type WsRpcClientOptions,
+} from './json-rpc-client.js';
+
+/** Mirrors `MOXXY_WS_SUBPROTOCOL` in `@moxxy/sdk`. */
+const WS_SUBPROTOCOL = 'moxxy.v1';
+/** Mirrors `MOXXY_WS_BEARER_PROTOCOL_PREFIX` in `@moxxy/sdk`. */
+const WS_BEARER_PREFIX = 'moxxy.bearer.';
+
+/** Encode the bearer token as a subprotocol entry — RFC 3986 strict percent
+ *  encoding keeps every output char a valid HTTP token char. Mirrors
+ *  `encodeWsBearerProtocol` in `@moxxy/sdk`. */
+function bearerProtocol(token: string): string {
+  const strict = encodeURIComponent(token).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+  return `${WS_BEARER_PREFIX}${strict}`;
+}
 
 export interface WsApiOptions {
-  /** Bridge URL, e.g. `ws://host:8765`. */
+  /** Bridge URL, e.g. `ws://host:8765` (no token in the URL). */
   readonly url: string;
-  /** Shared secret presented as `?t=<token>`. */
+  /** Shared secret, presented via the `Sec-WebSocket-Protocol` bearer entry. */
   readonly token?: string;
   /** Override the WebSocket implementation (defaults to the global one). */
   readonly WebSocket?: WebSocketCtor;
-}
-
-function withToken(url: string, token?: string): string {
-  if (!token) return url;
-  const sep = url.includes('?') ? '&' : '?';
-  return `${url}${sep}t=${encodeURIComponent(token)}`;
+  /** Observe transport lifecycle; the terminal `disconnected` status means the
+   *  reconnect budget is exhausted and the app should prompt a re-pair.
+   *  Defaults to a console.warn on `disconnected`. */
+  readonly onStatus?: (status: WsClientStatus) => void;
 }
 
 export function makeWsApi(opts: WsApiOptions): MoxxyApi {
@@ -38,7 +68,17 @@ export function makeWsApi(opts: WsApiOptions): MoxxyApi {
   if (!ctor) {
     throw new Error('makeWsApi: no WebSocket implementation available (pass opts.WebSocket)');
   }
-  const client = new WsRpcClient(withToken(opts.url, opts.token), ctor);
+  const onStatus =
+    opts.onStatus ??
+    ((status: WsClientStatus): void => {
+      if (status === 'disconnected') {
+        console.warn('[moxxy] ws transport gave up reconnecting — re-pair to continue');
+      }
+    });
+  const client = new WsRpcClient(opts.url, ctor, {
+    ...(opts.token ? { protocols: [WS_SUBPROTOCOL, bearerProtocol(opts.token)] } : {}),
+    onStatus,
+  });
   client.connect();
 
   return {

--- a/packages/client-transport-ws/src/json-rpc-client.test.ts
+++ b/packages/client-transport-ws/src/json-rpc-client.test.ts
@@ -1,6 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { encodeIpcError } from '@moxxy/desktop-ipc-contract';
-import { WsRpcClient, type WebSocketCtor, type WebSocketLike } from './json-rpc-client.js';
+import {
+  WsRpcClient,
+  type WebSocketCtor,
+  type WebSocketLike,
+  type WsClientStatus,
+  type WsRpcClientOptions,
+} from './json-rpc-client.js';
+import { makeWsApi } from './index.js';
 
 class FakeSocket implements WebSocketLike {
   sent: string[] = [];
@@ -9,7 +16,10 @@ class FakeSocket implements WebSocketLike {
   onclose: (() => void) | null = null;
   onerror: ((e: unknown) => void) | null = null;
   onmessage: ((ev: { data: unknown }) => void) | null = null;
-  constructor(public url: string) {}
+  constructor(
+    public url: string,
+    public protocols?: string | string[],
+  ) {}
   send(d: string): void {
     this.sent.push(d);
   }
@@ -29,18 +39,26 @@ class FakeSocket implements WebSocketLike {
   }
 }
 
-function makeClient(): { client: WsRpcClient; socket: FakeSocket } {
+function makeClient(opts: WsRpcClientOptions = {}): {
+  client: WsRpcClient;
+  socket: FakeSocket;
+  instances: FakeSocket[];
+} {
   const instances: FakeSocket[] = [];
   class CtorFake extends FakeSocket {
-    constructor(url: string) {
-      super(url);
+    constructor(url: string, protocols?: string | string[]) {
+      super(url, protocols);
       instances.push(this);
     }
   }
-  const client = new WsRpcClient('ws://x:1', CtorFake as unknown as WebSocketCtor);
+  const client = new WsRpcClient('ws://x:1', CtorFake as unknown as WebSocketCtor, opts);
   client.connect();
-  return { client, socket: instances[0]! };
+  return { client, socket: instances[0]!, instances };
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('WsRpcClient', () => {
   it('queues a request until open, then resolves on the matching response', async () => {
@@ -87,5 +105,97 @@ describe('WsRpcClient', () => {
     socket.close();
     await expect(p).rejects.toThrow('connection closed');
     client.close();
+  });
+
+  it('rejects QUEUED requests on disconnect and never replays them after reconnect', async () => {
+    vi.useFakeTimers();
+    const { client, socket, instances } = makeClient();
+    // Queued while connecting (never sent), then the link drops.
+    const p = client.request('session.runTurn', { text: 'do something' });
+    socket.close();
+    await expect(p).rejects.toThrow('connection closed');
+
+    // Reconnect: the abandoned runTurn must NOT be re-executed.
+    vi.advanceTimersByTime(60_000);
+    const next = instances[1]!;
+    next.open();
+    expect(next.sent).toEqual([]);
+    client.close();
+  });
+
+  it('passes the requested subprotocols to the WebSocket constructor', () => {
+    const { socket, client } = makeClient({ protocols: ['moxxy.v1', 'moxxy.bearer.abc'] });
+    expect(socket.protocols).toEqual(['moxxy.v1', 'moxxy.bearer.abc']);
+    client.close();
+  });
+
+  it('backs off, gives up after the attempt cap, and surfaces a terminal disconnect', async () => {
+    vi.useFakeTimers();
+    const statuses: WsClientStatus[] = [];
+    const { client, instances } = makeClient({
+      maxReconnectAttempts: 2,
+      onStatus: (s) => statuses.push(s),
+    });
+    // Drop the link three times: two reconnect attempts, then terminal.
+    instances[0]!.close();
+    vi.advanceTimersByTime(60_000);
+    expect(instances.length).toBe(2);
+    instances[1]!.close();
+    vi.advanceTimersByTime(60_000);
+    expect(instances.length).toBe(3);
+    instances[2]!.close();
+    vi.advanceTimersByTime(600_000);
+    expect(instances.length).toBe(3); // no further attempts
+
+    expect(client.status).toBe('disconnected');
+    expect(statuses).toContain('disconnected');
+    await expect(client.request('connection.activeWorkspace')).rejects.toThrow(
+      'transport disconnected',
+    );
+  });
+
+  it('resets the reconnect budget after a successful open', () => {
+    vi.useFakeTimers();
+    const { client, instances } = makeClient({ maxReconnectAttempts: 1 });
+    instances[0]!.close(); // attempt 1 scheduled
+    vi.advanceTimersByTime(60_000);
+    instances[1]!.open(); // success resets the budget
+    instances[1]!.close(); // a fresh drop gets a fresh attempt
+    vi.advanceTimersByTime(60_000);
+    expect(instances.length).toBe(3);
+    expect(client.status).not.toBe('disconnected');
+    client.close();
+  });
+});
+
+describe('makeWsApi', () => {
+  it('presents the token via the Sec-WebSocket-Protocol bearer entry, not the URL', () => {
+    const instances: FakeSocket[] = [];
+    class CtorFake extends FakeSocket {
+      constructor(url: string, protocols?: string | string[]) {
+        super(url, protocols);
+        instances.push(this);
+      }
+    }
+    makeWsApi({
+      url: 'ws://host:8765',
+      token: 'tok+en=1',
+      WebSocket: CtorFake as unknown as WebSocketCtor,
+    });
+    const socket = instances[0]!;
+    expect(socket.url).toBe('ws://host:8765'); // no ?t= in the URL
+    expect(socket.protocols).toEqual(['moxxy.v1', 'moxxy.bearer.tok%2Ben%3D1']);
+  });
+
+  it('omits subprotocols when no token is configured', () => {
+    const instances: FakeSocket[] = [];
+    class CtorFake extends FakeSocket {
+      constructor(url: string, protocols?: string | string[]) {
+        super(url, protocols);
+        instances.push(this);
+      }
+    }
+    makeWsApi({ url: 'ws://host:8765', WebSocket: CtorFake as unknown as WebSocketCtor });
+    expect(instances[0]!.protocols).toBeUndefined();
   });
 });

--- a/packages/client-transport-ws/src/json-rpc-client.ts
+++ b/packages/client-transport-ws/src/json-rpc-client.ts
@@ -10,6 +10,13 @@
  *   request      { id, method, params? }
  *   response     { id, result } | { id, error: { message, data? } }
  *   notification { method, params? }
+ *
+ * Disconnect semantics: when the link drops, every in-flight AND queued request
+ * is rejected and the outbox is cleared — a request issued against a dead link
+ * surfaces a transport error to its caller rather than silently re-executing
+ * after a reconnect (re-running a non-idempotent command like `runTurn` is the
+ * hazard). Reconnects back off exponentially and give up after a cap, surfacing
+ * a terminal `disconnected` status via {@link WsRpcClientOptions.onStatus}.
  */
 
 import { encodeIpcError, type MoxxyIpcError } from '@moxxy/desktop-ipc-contract';
@@ -25,10 +32,26 @@ export interface WebSocketLike {
   onmessage: ((ev: { data: unknown }) => void) | null;
 }
 
-export type WebSocketCtor = new (url: string) => WebSocketLike;
+export type WebSocketCtor = new (url: string, protocols?: string | string[]) => WebSocketLike;
+
+/** Connection lifecycle as seen by the owner of the client. `disconnected` is
+ *  terminal: the reconnect budget is exhausted and every further request
+ *  rejects immediately (re-pair / rebuild the client to recover). */
+export type WsClientStatus = 'connecting' | 'open' | 'reconnecting' | 'disconnected' | 'closed';
+
+export interface WsRpcClientOptions {
+  /** Subprotocols to request (e.g. the `moxxy.bearer.<token>` auth entry). */
+  readonly protocols?: readonly string[];
+  /** Reconnect attempts before giving up terminally. Default 10. */
+  readonly maxReconnectAttempts?: number;
+  /** Observe connection lifecycle transitions (incl. terminal `disconnected`). */
+  readonly onStatus?: (status: WsClientStatus) => void;
+}
 
 const WS_OPEN = 1;
-const RECONNECT_DELAY_MS = 1500;
+const RECONNECT_BASE_DELAY_MS = 1500;
+const RECONNECT_MAX_DELAY_MS = 30_000;
+const DEFAULT_MAX_RECONNECT_ATTEMPTS = 10;
 
 interface Pending {
   resolve: (value: unknown) => void;
@@ -52,21 +75,42 @@ export class WsRpcClient {
   private nextId = 1;
   private readonly pending = new Map<number, Pending>();
   private readonly notificationHandlers = new Map<string, Set<(params: unknown) => void>>();
-  /** Frames buffered while the socket isn't open yet; flushed on connect. */
+  /** Frames buffered while the socket isn't open yet; flushed on connect,
+   *  CLEARED on disconnect (their pendings are rejected — never replayed). */
   private readonly outbox: string[] = [];
   private closedByUser = false;
-  private reconnectTimer: number | undefined;
+  private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+  private reconnectAttempts = 0;
+  private currentStatus: WsClientStatus = 'connecting';
+  private readonly maxReconnectAttempts: number;
+  private readonly protocols: readonly string[] | undefined;
+  private readonly onStatus: ((status: WsClientStatus) => void) | undefined;
 
   constructor(
     private readonly url: string,
     private readonly ctor: WebSocketCtor,
-  ) {}
+    opts: WsRpcClientOptions = {},
+  ) {
+    this.protocols = opts.protocols;
+    this.maxReconnectAttempts = opts.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
+    this.onStatus = opts.onStatus;
+  }
+
+  /** The current lifecycle status (also pushed to `onStatus` on transitions). */
+  get status(): WsClientStatus {
+    return this.currentStatus;
+  }
 
   connect(): void {
-    if (this.socket || this.closedByUser) return;
-    const socket = new this.ctor(this.url);
+    if (this.socket || this.closedByUser || this.currentStatus === 'disconnected') return;
+    this.setStatus(this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
+    const socket = this.protocols?.length
+      ? new this.ctor(this.url, [...this.protocols])
+      : new this.ctor(this.url);
     this.socket = socket;
     socket.onopen = () => {
+      this.reconnectAttempts = 0;
+      this.setStatus('open');
       for (const frame of this.outbox.splice(0)) socket.send(frame);
     };
     socket.onmessage = (ev) => this.handleFrame(ev.data);
@@ -77,9 +121,13 @@ export class WsRpcClient {
   }
 
   /** Issue a request and await the reply. Rejects with the host's error (coded
-   *  envelope when available), or when the link drops before the reply. */
+   *  envelope when available), when the link drops before the reply, or
+   *  immediately once the transport is terminally disconnected/closed. */
   request(method: string, params?: unknown): Promise<unknown> {
     if (this.closedByUser) return Promise.reject(new Error('transport closed'));
+    if (this.currentStatus === 'disconnected') {
+      return Promise.reject(new Error('transport disconnected'));
+    }
     const id = this.nextId++;
     return new Promise<unknown>((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
@@ -111,6 +159,13 @@ export class WsRpcClient {
     if (this.reconnectTimer !== undefined) clearTimeout(this.reconnectTimer);
     this.socket?.close();
     this.socket = null;
+    this.setStatus('closed');
+  }
+
+  private setStatus(status: WsClientStatus): void {
+    if (this.currentStatus === status) return;
+    this.currentStatus = status;
+    this.onStatus?.(status);
   }
 
   private handleFrame(data: unknown): void {
@@ -152,15 +207,29 @@ export class WsRpcClient {
 
   private handleClose(): void {
     this.socket = null;
-    // Fail every in-flight request so callers can retry on the next connection.
+    // Fail every in-flight AND queued request, and drop the queued frames:
+    // callers must see a transport error — replaying a queued non-idempotent
+    // command (runTurn…) after reconnect would re-execute it behind their back.
     const dropped = new Error('connection closed');
     for (const waiter of this.pending.values()) waiter.reject(dropped);
     this.pending.clear();
+    this.outbox.length = 0;
     if (this.closedByUser) return;
-    // Reconnect; subscriptions persist so notifications resume.
+
+    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+      this.setStatus('disconnected');
+      return;
+    }
+    // Reconnect with exponential backoff; subscriptions persist so
+    // notifications resume on the next successful connection.
+    const delay = Math.min(
+      RECONNECT_BASE_DELAY_MS * 2 ** this.reconnectAttempts,
+      RECONNECT_MAX_DELAY_MS,
+    );
+    this.reconnectAttempts += 1;
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = undefined;
       this.connect();
-    }, RECONNECT_DELAY_MS);
+    }, delay);
   }
 }

--- a/packages/core/src/events/log.test.ts
+++ b/packages/core/src/events/log.test.ts
@@ -171,6 +171,43 @@ describe('EventLog', () => {
     expect(cleared).toHaveBeenCalledTimes(1);
   });
 
+  it('ingest survives a rejecting async listener (same swallow policy as append)', async () => {
+    const source = new EventLog();
+    const ev = await source.append({
+      type: 'user_prompt',
+      sessionId: sid,
+      turnId: tid,
+      source: 'user',
+      text: 'mirrored',
+    });
+
+    // append(): an async listener rejection is awaited + swallowed.
+    const appender = new EventLog();
+    appender.subscribe(async () => {
+      throw new Error('async boom (append)');
+    });
+    await expect(
+      appender.append({ type: 'user_prompt', sessionId: sid, turnId: tid, source: 'user', text: 'x' }),
+    ).resolves.toBeDefined();
+
+    // ingest(): the same rejection must NOT become an unhandled rejection
+    // (vitest fails the run on one), and ingestion must continue to later
+    // listeners and later events.
+    const mirror = new EventLog();
+    const seen: number[] = [];
+    mirror.subscribe(async () => {
+      throw new Error('async boom (ingest)');
+    });
+    mirror.subscribe((e) => {
+      seen.push(e.seq);
+    });
+    expect(() => mirror.ingest(ev)).not.toThrow();
+    expect(mirror.length).toBe(1);
+    expect(seen).toEqual([ev.seq]);
+    // Let the rejected listener promise settle inside this test's scope.
+    await new Promise((resolve) => setImmediate(resolve));
+  });
+
   it('clear survives a throwing onClear listener', () => {
     const log = new EventLog();
     log.onClear(() => {

--- a/packages/core/src/events/log.ts
+++ b/packages/core/src/events/log.ts
@@ -90,9 +90,15 @@ export class EventLog implements EventLogReader {
     const snapshot = [...this.listeners];
     for (const fn of snapshot) {
       try {
-        void fn(event);
+        // Fire-and-forget, but attach a rejection handler: an async listener
+        // that rejects must be swallowed the same way append()'s awaited
+        // try/catch swallows it — otherwise it surfaces as an unhandled
+        // rejection and (under Node's default policy) can kill the process.
+        void Promise.resolve(fn(event)).catch(() => {
+          // Mirror listeners must not break ingestion.
+        });
       } catch {
-        // Mirror listeners must not break ingestion.
+        // Mirror listeners must not break ingestion (synchronous throw).
       }
     }
   }

--- a/packages/core/src/sessions/persistence.test.ts
+++ b/packages/core/src/sessions/persistence.test.ts
@@ -3,7 +3,26 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { EventLog } from '../events/log.js';
+import type { Logger } from '../logger.js';
 import { SessionPersistence, readIndex, restoreEvents, type SessionMeta } from './persistence.js';
+
+interface CapturedLine {
+  readonly level: 'debug' | 'info' | 'warn' | 'error';
+  readonly msg: string;
+  readonly meta?: Record<string, unknown>;
+}
+
+function captureLogger(): { logger: Logger; lines: CapturedLine[] } {
+  const lines: CapturedLine[] = [];
+  const logger: Logger = {
+    debug: (msg, meta) => lines.push({ level: 'debug', msg, meta }),
+    info: (msg, meta) => lines.push({ level: 'info', msg, meta }),
+    warn: (msg, meta) => lines.push({ level: 'warn', msg, meta }),
+    error: (msg, meta) => lines.push({ level: 'error', msg, meta }),
+    child: () => logger,
+  };
+  return { logger, lines };
+}
 
 const tempDirs: string[] = [];
 
@@ -103,6 +122,103 @@ describe('SessionPersistence', () => {
     expect((restored[0] as { text?: string }).text).toBe('fresh start');
 
     detach();
+  });
+
+  it('warns once (not per event) on event-log write failure, recovers on success', async () => {
+    const dir = await makeTempDir();
+    const id = '01WRITEFAIL000000000000000';
+    // Make `<id>.jsonl` a DIRECTORY so fs.appendFile fails with EISDIR.
+    await fs.mkdir(path.join(dir, `${id}.jsonl`), { recursive: true });
+
+    const { logger, lines } = captureLogger();
+    const log = new EventLog();
+    const persistence = new SessionPersistence({ sessionId: id as never, cwd: '/tmp/p', dir, logger });
+    const detach = persistence.attach(log);
+
+    const prompt = (text: string) =>
+      log.append({ type: 'user_prompt', sessionId: id as never, turnId: 't1' as never, source: 'user', text });
+
+    await prompt('first failing write');
+    await prompt('second failing write');
+    await waitForCondition(() => Promise.resolve(persistence.degraded));
+    // Both appends failed, but the structured warning fired exactly once.
+    await waitForCondition(() =>
+      Promise.resolve(lines.some((l) => l.level === 'warn' && l.msg.includes('write failed'))),
+    );
+    const failureWarns = () =>
+      lines.filter((l) => l.level === 'warn' && l.msg.includes('write failed'));
+    expect(failureWarns()).toHaveLength(1);
+    expect(failureWarns()[0]!.meta).toMatchObject({ path: path.join(dir, `${id}.jsonl`) });
+    expect(failureWarns()[0]!.meta?.error).toBeTruthy();
+    expect(persistence.degraded).toBe(true);
+
+    // Remove the obstruction — the next successful write clears the degraded
+    // latch (re-arming warn-once) and logs a recovery line.
+    await fs.rmdir(path.join(dir, `${id}.jsonl`));
+    await prompt('now it works');
+    await waitForCondition(() => Promise.resolve(!persistence.degraded));
+    expect(lines.some((l) => l.level === 'info' && l.msg.includes('recovered'))).toBe(true);
+    expect(failureWarns()).toHaveLength(1);
+    // The surviving event was minted at seq 2 (the first two appends were
+    // lost to the failing disk) — restore re-sequences it to 0.
+    const restored = await restoreEvents(id, dir, captureLogger().logger);
+    expect(restored.map((e) => (e as { text?: string }).text)).toEqual(['now it works']);
+    expect(restored[0]!.seq).toBe(0);
+
+    detach();
+  });
+
+  it('restore re-sequences around a corrupt middle line and repairs the file on disk', async () => {
+    const dir = await makeTempDir();
+    const id = '01RESEQ0000000000000000000';
+    const mk = (seq: number, text: string) => ({
+      id: `e${seq}`,
+      seq,
+      ts: seq,
+      sessionId: id,
+      turnId: 't1',
+      source: 'user',
+      type: 'user_prompt',
+      text,
+    });
+    // seq 2's line was corrupted on disk; 3 and 4 are intact.
+    const lines = [
+      JSON.stringify(mk(0, 'zero')),
+      JSON.stringify(mk(1, 'one')),
+      '{this line was corrupted',
+      JSON.stringify(mk(3, 'three')),
+      JSON.stringify(mk(4, 'four')),
+    ];
+    await fs.writeFile(path.join(dir, `${id}.jsonl`), lines.join('\n') + '\n', 'utf8');
+
+    const { logger, lines: logged } = captureLogger();
+    const restored = await restoreEvents(id, dir, logger);
+
+    // Contiguous 0..n-1, order + ids + payloads preserved.
+    expect(restored.map((e) => e.seq)).toEqual([0, 1, 2, 3]);
+    expect(restored.map((e) => e.id)).toEqual(['e0', 'e1', 'e3', 'e4']);
+    expect(restored.map((e) => (e as { text?: string }).text)).toEqual([
+      'zero',
+      'one',
+      'three',
+      'four',
+    ]);
+    const gapWarn = logged.find((l) => l.level === 'warn');
+    expect(gapWarn?.meta).toMatchObject({ corruptLines: 1, resequencedEvents: 2 });
+
+    // Every restored event replays into a fresh mirror (ingest requires
+    // seq === length) — nothing after the gap is dropped.
+    const mirror = new EventLog();
+    for (const e of restored) mirror.ingest(e);
+    expect(mirror.length).toBe(4);
+    expect((mirror.at(3) as { text?: string } | undefined)?.text).toBe('four');
+
+    // The file was rewritten, so the NEXT restore is clean (no warning) and
+    // new appends (seq = length) line up with what's on disk.
+    const again = captureLogger();
+    const second = await restoreEvents(id, dir, again.logger);
+    expect(second.map((e) => e.seq)).toEqual([0, 1, 2, 3]);
+    expect(again.lines).toHaveLength(0);
   });
 
   it('two concurrent sessions both survive (no shared-index clobber)', async () => {

--- a/packages/core/src/sessions/persistence.ts
+++ b/packages/core/src/sessions/persistence.ts
@@ -21,6 +21,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { createMutex, writeFileAtomic, type Mutex, type MoxxyEvent, type SessionId } from '@moxxy/sdk';
 import type { EventLog } from '../events/log.js';
+import { createLogger, type Logger } from '../logger.js';
 
 export interface SessionMeta {
   readonly id: string;
@@ -43,6 +44,12 @@ export interface SessionPersistenceOpts {
   readonly providerName?: string;
   /** Currently-active model id — captured into the index for the picker. */
   readonly modelId?: string;
+  /**
+   * Structured logger for persistence-degradation warnings. Defaults to a
+   * stderr JSON logger — event-log write failures are the session's source
+   * of truth going dark, so they must be loud even when nothing injects one.
+   */
+  readonly logger?: Logger;
 }
 
 export function defaultSessionsDir(): string {
@@ -67,10 +74,18 @@ export class SessionPersistence {
    */
   private writeQueue: Mutex = createMutex();
   private closed = false;
+  private readonly logger: Logger;
+  /**
+   * Latched while event-log writes are failing. Doubles as the warn-once
+   * gate: only the first failure of a streak logs; a subsequent successful
+   * write clears the latch (and re-arms the warning).
+   */
+  private writeDegraded = false;
 
   constructor(opts: SessionPersistenceOpts) {
     this.dir = opts.dir ?? defaultSessionsDir();
     this.id = String(opts.sessionId);
+    this.logger = opts.logger ?? createLogger();
     this.logPath = path.join(this.dir, `${this.id}.jsonl`);
     const now = new Date().toISOString();
     this.meta = {
@@ -146,8 +161,42 @@ export class SessionPersistence {
     };
     this.scheduleIndexWrite();
     const line = JSON.stringify(event) + '\n';
-    // never propagate a write error into the listener chain
-    void this.writeQueue.run(() => fs.appendFile(this.logPath, line, 'utf8')).catch(() => undefined);
+    // Never propagate a write error into the listener chain — but never
+    // swallow it silently either: the JSONL is the session's source of
+    // truth, so a failing disk must at least be loud.
+    void this.writeQueue
+      .run(() => fs.appendFile(this.logPath, line, 'utf8'))
+      .then(() => this.noteWriteOk())
+      .catch((err: unknown) => this.noteWriteFailure('append', err));
+  }
+
+  /**
+   * True while event-log writes are failing (history is no longer being
+   * persisted). Cleared automatically by the next successful write.
+   */
+  get degraded(): boolean {
+    return this.writeDegraded;
+  }
+
+  private noteWriteOk(): void {
+    if (!this.writeDegraded) return;
+    this.writeDegraded = false;
+    this.logger.info('session event-log writes recovered', { path: this.logPath });
+  }
+
+  private noteWriteFailure(op: 'append' | 'truncate', err: unknown): void {
+    const alreadyDegraded = this.writeDegraded;
+    this.writeDegraded = true;
+    if (alreadyDegraded) return; // warn once per failure streak, not per event
+    this.logger.warn(
+      'session event-log write failed — history persistence degraded (resume will miss these events)',
+      {
+        op,
+        path: this.logPath,
+        sessionId: this.id,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
   }
 
   /**
@@ -164,7 +213,10 @@ export class SessionPersistence {
       lastActivity: new Date().toISOString(),
     };
     this.scheduleIndexWrite();
-    void this.writeQueue.run(() => fs.writeFile(this.logPath, '', 'utf8')).catch(() => undefined);
+    void this.writeQueue
+      .run(() => fs.writeFile(this.logPath, '', 'utf8'))
+      .then(() => this.noteWriteOk())
+      .catch((err: unknown) => this.noteWriteFailure('truncate', err));
   }
 
   private scheduleIndexWrite(): void {
@@ -263,12 +315,30 @@ export async function readIndex(dir = defaultSessionsDir()): Promise<SessionMeta
  * Restore a previously-persisted session's events. Returns the full
  * event array suitable for passing into `new EventLog(events)`.
  *
- * Skips malformed lines silently — a single corrupted append shouldn't
- * make the rest of the conversation unreadable.
+ * Skips malformed lines (a single corrupted append shouldn't make the
+ * rest of the conversation unreadable) and then RE-SEQUENCES the
+ * survivors to contiguous `seq` 0..n-1, preserving order and ids. This
+ * matters twice over:
+ *
+ *  - Mirror replay: `EventLog.ingest` accepts only `seq === length`, so
+ *    a gap left by one corrupt middle line would silently truncate every
+ *    attached client's history at that point.
+ *  - Future appends: `EventLog.append` mints `seq = events.length`, so a
+ *    gapped seed would mint colliding/out-of-order seqs.
+ *
+ * When anything was skipped or re-sequenced, the file is atomically
+ * rewritten with the repaired events so the NEXT resume starts clean —
+ * otherwise post-resume appends (seq = n-gap..) would interleave with the
+ * stale higher on-disk seqs forever. Safe ordering-wise: restore runs
+ * before `SessionPersistence.attach`, so no append queue is live yet.
+ * Note: compaction/elision events referencing seqs after a gap shift by
+ * the gap size — an accepted, logged trade-off versus losing all
+ * post-gap history.
  */
 export async function restoreEvents(
   sessionId: string,
   dir = defaultSessionsDir(),
+  logger: Logger = createLogger(),
 ): Promise<MoxxyEvent[]> {
   const logPath = path.join(dir, `${sessionId}.jsonl`);
   let raw: string;
@@ -278,12 +348,45 @@ export async function restoreEvents(
     throw new Error(`Session not found: ${sessionId}`);
   }
   const events: MoxxyEvent[] = [];
+  let corruptLines = 0;
   for (const line of raw.split('\n')) {
     if (!line.trim()) continue;
     try {
       events.push(JSON.parse(line) as MoxxyEvent);
     } catch {
-      // skip malformed line
+      corruptLines += 1;
+    }
+  }
+
+  // Re-sequence to contiguous 0..n-1 (order + ids preserved). A clean log is
+  // already contiguous, so this is a no-op in the common case.
+  let resequenced = 0;
+  for (let i = 0; i < events.length; i += 1) {
+    if (events[i]!.seq !== i) {
+      events[i] = { ...events[i]!, seq: i } as MoxxyEvent;
+      resequenced += 1;
+    }
+  }
+
+  if (corruptLines > 0 || resequenced > 0) {
+    logger.warn('session log restored with gaps — re-sequenced to keep full history replayable', {
+      sessionId,
+      path: logPath,
+      corruptLines,
+      resequencedEvents: resequenced,
+      restoredEvents: events.length,
+    });
+    try {
+      const repaired = events.map((e) => JSON.stringify(e) + '\n').join('');
+      await writeFileAtomic(logPath, repaired);
+    } catch (err) {
+      // Restore still succeeds — the in-memory log is repaired; only the
+      // next resume would re-run this same repair.
+      logger.warn('failed to rewrite repaired session log on disk', {
+        sessionId,
+        path: logPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
   return events;

--- a/packages/ipc-server-ws/src/auth.test.ts
+++ b/packages/ipc-server-ws/src/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { IncomingMessage } from 'node:http';
-import { checkWsAuth } from './auth.js';
+import { encodeWsBearerProtocol, MOXXY_WS_SUBPROTOCOL } from '@moxxy/sdk';
+import { checkWsAuth, checkWsOrigin } from './auth.js';
 
 function req(headers: Record<string, string>, url = '/'): IncomingMessage {
   return { headers, url } as unknown as IncomingMessage;
@@ -13,12 +14,33 @@ describe('checkWsAuth', () => {
     expect(checkWsAuth(req({ authorization: `Bearer ${token}` }), token)).toBe(true);
   });
 
-  it('accepts a matching ?t= query param (header-less clients)', () => {
-    expect(checkWsAuth(req({}, `/?t=${token}`), token)).toBe(true);
+  it('accepts the token via the Sec-WebSocket-Protocol bearer entry', () => {
+    const header = `${MOXXY_WS_SUBPROTOCOL}, ${encodeWsBearerProtocol(token)}`;
+    expect(checkWsAuth(req({ 'sec-websocket-protocol': header }), token)).toBe(true);
   });
 
-  it('rejects a wrong token', () => {
+  it('round-trips a token with reserved characters through the protocol entry', () => {
+    const weird = "a+b/c=d !'()*&%";
+    const header = encodeWsBearerProtocol(weird);
+    // Every char of the entry must be a valid HTTP token char (no separators).
+    expect(header).toMatch(/^[A-Za-z0-9._~%-]+$/);
+    expect(checkWsAuth(req({ 'sec-websocket-protocol': header }), weird)).toBe(true);
+  });
+
+  it('rejects a ?t= query param by default (legacy transport is opt-in)', () => {
+    expect(checkWsAuth(req({}, `/?t=${token}`), token)).toBe(false);
+  });
+
+  it('accepts a matching ?t= query param when explicitly enabled', () => {
+    expect(checkWsAuth(req({}, `/?t=${token}`), token, { allowQueryToken: true })).toBe(true);
+  });
+
+  it('rejects a wrong token on every presentation', () => {
     expect(checkWsAuth(req({ authorization: 'Bearer wrong' }), token)).toBe(false);
+    expect(
+      checkWsAuth(req({ 'sec-websocket-protocol': encodeWsBearerProtocol('wrong') }), token),
+    ).toBe(false);
+    expect(checkWsAuth(req({}, '/?t=wrong'), token, { allowQueryToken: true })).toBe(false);
   });
 
   it('rejects when no credentials are presented', () => {
@@ -27,6 +49,25 @@ describe('checkWsAuth', () => {
 
   it('never authenticates when the expected token is empty', () => {
     expect(checkWsAuth(req({ authorization: 'Bearer ' }), '')).toBe(false);
-    expect(checkWsAuth(req({}, '/?t=anything'), '')).toBe(false);
+    expect(checkWsAuth(req({}, '/?t=anything'), '', { allowQueryToken: true })).toBe(false);
+  });
+});
+
+describe('checkWsOrigin', () => {
+  it('passes requests without an Origin header (native clients)', () => {
+    expect(checkWsOrigin(req({}))).toBe(true);
+    expect(checkWsOrigin(req({}), ['http://app.example'])).toBe(true);
+  });
+
+  it('rejects any Origin by default (browser pages cannot omit it)', () => {
+    expect(checkWsOrigin(req({ origin: 'http://evil.example' }))).toBe(false);
+    expect(checkWsOrigin(req({ origin: 'http://localhost:5173' }))).toBe(false);
+  });
+
+  it('accepts an allow-listed Origin (case-insensitive), rejects others', () => {
+    const allowed = ['http://localhost:5173'];
+    expect(checkWsOrigin(req({ origin: 'http://localhost:5173' }), allowed)).toBe(true);
+    expect(checkWsOrigin(req({ origin: 'HTTP://LOCALHOST:5173' }), allowed)).toBe(true);
+    expect(checkWsOrigin(req({ origin: 'http://evil.example' }), allowed)).toBe(false);
   });
 });

--- a/packages/ipc-server-ws/src/auth.ts
+++ b/packages/ipc-server-ws/src/auth.ts
@@ -1,29 +1,72 @@
 /**
- * Bearer-token handshake for the WebSocket bridge. Reuses the SDK's
- * constant-time {@link bearerTokenMatches} (same comparator the HTTP/web
- * channels use) so a token guess can't be timed. Two presentations are
- * accepted because a browser/Expo `WebSocket` can't always set request headers:
- *   1. `Authorization: Bearer <token>` (preferred), and
- *   2. a `?t=<token>` query parameter (fallback).
+ * Bearer-token + Origin checks for the WebSocket bridge handshake. Reuses the
+ * SDK's constant-time {@link bearerGuard} (same comparator the HTTP/web
+ * channels use) so a token guess can't be timed. Token presentations, in
+ * preference order:
+ *   1. `Authorization: Bearer <token>` — native clients (Node `ws`, RN with
+ *      header support).
+ *   2. a `Sec-WebSocket-Protocol` entry `moxxy.bearer.<encoded-token>` — for
+ *      WebSocket implementations that cannot set request headers (browser /
+ *      React Native). See `encodeWsBearerProtocol` in `@moxxy/sdk`.
+ *   3. a `?t=<token>` query parameter — legacy only, OFF by default: query
+ *      strings leak through logs (tunnel providers, proxies) and shoulder-surfed
+ *      URLs. Enable via `allowQueryToken` only where an already-paired legacy
+ *      client must keep working.
+ *
+ * Origin: native clients send no `Origin` header and always pass that check; a
+ * browser-initiated connection (which always carries one) is rejected unless
+ * the origin is explicitly allow-listed — this stops a malicious webpage on the
+ * victim's machine from even attempting the token handshake.
  */
 
 import type { IncomingMessage } from 'node:http';
-import { bearerGuard } from '@moxxy/sdk';
+import { bearerGuard, tokenFromWsProtocolHeader } from '@moxxy/sdk';
 
 const BEARER = 'Bearer ';
 
-export function checkWsAuth(req: IncomingMessage, expected: string): boolean {
+export interface WsAuthOptions {
+  /** Accept the legacy `?t=<token>` query credential. Default false. */
+  readonly allowQueryToken?: boolean;
+}
+
+export function checkWsAuth(
+  req: IncomingMessage,
+  expected: string,
+  opts: WsAuthOptions = {},
+): boolean {
   // Shared pre-connection bearer handler — empty `expected` always denies.
   const guard = bearerGuard(expected);
 
   const auth = req.headers.authorization;
   if (auth && auth.startsWith(BEARER) && guard(auth.slice(BEARER.length))) return true;
 
-  try {
-    const url = new URL(req.url ?? '/', 'http://localhost');
-    if (guard(url.searchParams.get('t'))) return true;
-  } catch {
-    // Malformed request URL — treat as unauthenticated.
+  const fromProtocol = tokenFromWsProtocolHeader(req.headers['sec-websocket-protocol']);
+  if (fromProtocol !== null && guard(fromProtocol)) return true;
+
+  if (opts.allowQueryToken) {
+    try {
+      const url = new URL(req.url ?? '/', 'http://localhost');
+      if (guard(url.searchParams.get('t'))) return true;
+    } catch {
+      // Malformed request URL — treat as unauthenticated.
+    }
   }
   return false;
+}
+
+/**
+ * Reject browser-initiated upgrades: a request with an `Origin` header only
+ * passes when that origin is in `allowedOrigins` (case-insensitive). Requests
+ * WITHOUT an Origin header (native clients — the mobile app, Node `ws`) always
+ * pass; browsers cannot omit the header, so this cleanly fences off web pages
+ * probing `ws://127.0.0.1`.
+ */
+export function checkWsOrigin(
+  req: IncomingMessage,
+  allowedOrigins: readonly string[] = [],
+): boolean {
+  const origin = req.headers.origin;
+  if (!origin) return true;
+  const lower = origin.toLowerCase();
+  return allowedOrigins.some((allowed) => allowed.toLowerCase() === lower);
 }

--- a/packages/ipc-server-ws/src/index.ts
+++ b/packages/ipc-server-ws/src/index.ts
@@ -10,16 +10,21 @@
  *   // …on quit: await server.close();
  */
 
-import type { TransportServer } from '@moxxy/runner';
 import {
   createWebSocketTransportServer,
   type WebSocketBridgeOptions,
+  type WebSocketBridgeServer,
 } from './ws-transport.js';
 import type { WebSocketCommandBus } from './ws-command-bus.js';
 
-export { createWebSocketTransportServer, type WebSocketBridgeOptions } from './ws-transport.js';
+export {
+  createWebSocketTransportServer,
+  SlowReaderGuard,
+  type WebSocketBridgeOptions,
+  type WebSocketBridgeServer,
+} from './ws-transport.js';
 export { WebSocketCommandBus } from './ws-command-bus.js';
-export { checkWsAuth } from './auth.js';
+export { checkWsAuth, checkWsOrigin, type WsAuthOptions } from './auth.js';
 
 /**
  * Convenience: create the transport server and route every accepted connection
@@ -29,7 +34,7 @@ export { checkWsAuth } from './auth.js';
 export async function startWsBridge(
   bus: WebSocketCommandBus,
   opts: WebSocketBridgeOptions,
-): Promise<TransportServer> {
+): Promise<WebSocketBridgeServer> {
   const server = await createWebSocketTransportServer(opts);
   server.onConnection((transport) => bus.attach(transport));
   return server;

--- a/packages/ipc-server-ws/src/ws-transport.test.ts
+++ b/packages/ipc-server-ws/src/ws-transport.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import WebSocket from 'ws';
+import { encodeWsBearerProtocol, MOXXY_WS_SUBPROTOCOL } from '@moxxy/sdk';
+import {
+  createWebSocketTransportServer,
+  SlowReaderGuard,
+  type WebSocketBridgeServer,
+  type WebSocketBridgeOptions,
+} from './ws-transport.js';
+
+const TOKEN = 'integration-test-token';
+
+const servers: WebSocketBridgeServer[] = [];
+const sockets: WebSocket[] = [];
+
+afterEach(async () => {
+  for (const ws of sockets.splice(0)) ws.terminate();
+  await Promise.all(servers.splice(0).map((s) => s.close()));
+});
+
+async function startServer(
+  opts: Partial<WebSocketBridgeOptions> = {},
+): Promise<WebSocketBridgeServer> {
+  const server = await createWebSocketTransportServer({ port: 0, authToken: TOKEN, ...opts });
+  servers.push(server);
+  return server;
+}
+
+/** Connect a raw ws client; resolves on open, rejects on a refused handshake. */
+function connect(
+  url: string,
+  opts: { headers?: Record<string, string>; origin?: string; protocols?: string[] } = {},
+): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url, opts.protocols, {
+      headers: opts.headers,
+      origin: opts.origin,
+    });
+    sockets.push(ws);
+    ws.once('open', () => resolve(ws));
+    ws.once('error', reject);
+    ws.once('unexpected-response', (_req, res) =>
+      reject(new Error(`handshake rejected: ${res.statusCode}`)),
+    );
+  });
+}
+
+const bearerHeaders = { authorization: `Bearer ${TOKEN}` };
+
+describe('createWebSocketTransportServer', () => {
+  it('reports the ACTUAL bound port when asked for an ephemeral one', async () => {
+    const server = await startServer();
+    expect(server.address).toMatch(/^ws:\/\/127\.0\.0\.1:\d+$/);
+    expect(server.address.endsWith(':0')).toBe(false);
+    // The reported address must actually accept a connection.
+    await expect(connect(server.address, { headers: bearerHeaders })).resolves.toBeDefined();
+  });
+
+  it('accepts an Authorization: Bearer handshake', async () => {
+    const server = await startServer();
+    await expect(connect(server.address, { headers: bearerHeaders })).resolves.toBeDefined();
+  });
+
+  it('accepts the Sec-WebSocket-Protocol bearer entry and selects moxxy.v1', async () => {
+    const server = await startServer();
+    const ws = await connect(server.address, {
+      protocols: [MOXXY_WS_SUBPROTOCOL, encodeWsBearerProtocol(TOKEN)],
+    });
+    expect(ws.protocol).toBe(MOXXY_WS_SUBPROTOCOL);
+  });
+
+  it('rejects a ?t= query token by default, accepts it when enabled', async () => {
+    const server = await startServer();
+    await expect(connect(`${server.address}/?t=${TOKEN}`)).rejects.toThrow();
+
+    const legacy = await startServer({ allowQueryToken: true });
+    await expect(connect(`${legacy.address}/?t=${TOKEN}`)).resolves.toBeDefined();
+  });
+
+  it('rejects an authenticated upgrade that carries a browser Origin', async () => {
+    const server = await startServer();
+    await expect(
+      connect(server.address, { headers: bearerHeaders, origin: 'http://evil.example' }),
+    ).rejects.toThrow();
+  });
+
+  it('accepts an allow-listed Origin', async () => {
+    const server = await startServer({ allowedOrigins: ['http://app.example'] });
+    await expect(
+      connect(server.address, { headers: bearerHeaders, origin: 'http://app.example' }),
+    ).resolves.toBeDefined();
+  });
+
+  it('caps concurrent connections', async () => {
+    const server = await startServer({ maxConnections: 1 });
+    await connect(server.address, { headers: bearerHeaders });
+    await expect(connect(server.address, { headers: bearerHeaders })).rejects.toThrow();
+  });
+
+  it('frees a slot when a capped connection closes', async () => {
+    const server = await startServer({ maxConnections: 1 });
+    const first = await connect(server.address, { headers: bearerHeaders });
+    first.close();
+    await new Promise((r) => first.once('close', r));
+    await expect(connect(server.address, { headers: bearerHeaders })).resolves.toBeDefined();
+  });
+
+  it('close() terminates connected clients promptly instead of waiting them out', async () => {
+    const server = await startServer();
+    const ws = await connect(server.address, { headers: bearerHeaders });
+    const closed = new Promise<void>((r) => ws.once('close', () => r()));
+    const started = Date.now();
+    await server.close();
+    await closed;
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  it('rotateAuthToken re-keys the handshake and drops existing connections', async () => {
+    const server = await startServer();
+    const before = await connect(server.address, { headers: bearerHeaders });
+    const dropped = new Promise<void>((r) => before.once('close', () => r()));
+
+    server.rotateAuthToken('rotated-token');
+    await dropped; // the established connection is terminated
+
+    await expect(connect(server.address, { headers: bearerHeaders })).rejects.toThrow();
+    await expect(
+      connect(server.address, { headers: { authorization: 'Bearer rotated-token' } }),
+    ).resolves.toBeDefined();
+  });
+});
+
+describe('SlowReaderGuard', () => {
+  it('allows sends while the backlog stays under the limit', () => {
+    const guard = new SlowReaderGuard(100, 1000);
+    expect(guard.check(0, 0)).toBe('ok');
+    expect(guard.check(100, 500)).toBe('ok');
+    expect(guard.check(50, 10_000)).toBe('ok');
+  });
+
+  it('grants a grace window on the first over-limit observation', () => {
+    const guard = new SlowReaderGuard(100, 1000);
+    expect(guard.check(5000, 0)).toBe('ok'); // stall clock starts
+    expect(guard.check(5000, 999)).toBe('ok'); // still within grace
+    expect(guard.check(5000, 1000)).toBe('terminate'); // grace elapsed, still stalled
+  });
+
+  it('resets the stall clock once the reader drains below the limit', () => {
+    const guard = new SlowReaderGuard(100, 1000);
+    expect(guard.check(5000, 0)).toBe('ok');
+    expect(guard.check(10, 500)).toBe('ok'); // drained — clock resets
+    expect(guard.check(5000, 1500)).toBe('ok'); // new stall, new clock
+    expect(guard.check(5000, 2600)).toBe('terminate');
+  });
+});

--- a/packages/ipc-server-ws/src/ws-transport.ts
+++ b/packages/ipc-server-ws/src/ws-transport.ts
@@ -2,16 +2,56 @@
  * WebSocket implementation of the runner's {@link Transport} / {@link
  * TransportServer} — the network mirror of `createUnixSocketServer`. `ws`
  * already frames each message as one complete payload, so a frame is just one
- * JSON value: parse on the way in, stringify on the way out. Auth is enforced at
- * the HTTP upgrade handshake (`verifyClient`) so an unauthenticated client never
- * even opens a socket.
+ * JSON value: parse on the way in, stringify on the way out. Auth + Origin +
+ * connection-cap checks are enforced at the HTTP upgrade handshake
+ * (`verifyClient`) so a rejected client never even opens a socket.
+ *
+ * Backpressure policy (slow-reader eviction): `ws.send` buffers unboundedly
+ * for a peer that stops reading, so every outbound frame first consults a
+ * {@link SlowReaderGuard} — a connection whose send backlog stays above
+ * `maxBufferedBytes` for longer than a short grace window is terminated (the
+ * client reconnects and resyncs; an evicted reader has missed frames anyway).
+ * The grace window exists so one legitimately large frame (payloads may reach
+ * the 64 MB cap) in flight to a healthy reader doesn't trip the guard.
  */
 
 import type { IncomingMessage } from 'node:http';
 import { WebSocketServer, type WebSocket, type RawData } from 'ws';
 
+import { MOXXY_WS_SUBPROTOCOL } from '@moxxy/sdk';
 import type { Transport, TransportServer } from '@moxxy/runner';
-import { checkWsAuth } from './auth.js';
+import { checkWsAuth, checkWsOrigin } from './auth.js';
+
+const DEFAULT_MAX_CONNECTIONS = 8;
+const DEFAULT_MAX_BUFFERED_BYTES = 4 * 1024 * 1024;
+const DEFAULT_BUFFER_STALL_GRACE_MS = 10_000;
+
+/**
+ * The eviction policy, kept pure so it's unit-testable: report the socket's
+ * pre-send backlog on every send; once the backlog has stayed above the limit
+ * for the full grace window, the verdict flips to `terminate`. Draining below
+ * the limit resets the clock.
+ */
+export class SlowReaderGuard {
+  private stalledSinceMs: number | null = null;
+
+  constructor(
+    private readonly limitBytes: number = DEFAULT_MAX_BUFFERED_BYTES,
+    private readonly graceMs: number = DEFAULT_BUFFER_STALL_GRACE_MS,
+  ) {}
+
+  check(bufferedAmount: number, nowMs: number): 'ok' | 'terminate' {
+    if (bufferedAmount <= this.limitBytes) {
+      this.stalledSinceMs = null;
+      return 'ok';
+    }
+    if (this.stalledSinceMs === null) {
+      this.stalledSinceMs = nowMs;
+      return 'ok';
+    }
+    return nowMs - this.stalledSinceMs >= this.graceMs ? 'terminate' : 'ok';
+  }
+}
 
 /** Adapts a single `ws` socket to the runner's frame-oriented `Transport`. */
 class WsTransport implements Transport {
@@ -19,7 +59,10 @@ class WsTransport implements Transport {
   private closeHandler: ((err?: Error) => void) | null = null;
   private closeEmitted = false;
 
-  constructor(private readonly ws: WebSocket) {
+  constructor(
+    private readonly ws: WebSocket,
+    private readonly guard: SlowReaderGuard,
+  ) {
     ws.on('message', (data: RawData) => {
       let parsed: unknown;
       try {
@@ -34,7 +77,15 @@ class WsTransport implements Transport {
   }
 
   send(frame: unknown): void {
-    if (this.ws.readyState === this.ws.OPEN) this.ws.send(JSON.stringify(frame));
+    if (this.ws.readyState !== this.ws.OPEN) return;
+    if (this.guard.check(this.ws.bufferedAmount, Date.now()) === 'terminate') {
+      console.warn(
+        `[moxxy] ws bridge: evicting slow reader (${this.ws.bufferedAmount} bytes unread past grace)`,
+      );
+      this.ws.terminate();
+      return;
+    }
+    this.ws.send(JSON.stringify(frame));
   }
 
   onFrame(handler: (frame: unknown) => void): void {
@@ -57,7 +108,8 @@ class WsTransport implements Transport {
 }
 
 export interface WebSocketBridgeOptions {
-  /** TCP port to listen on. */
+  /** TCP port to listen on (`0` binds an ephemeral port — `address` reports
+   *  the actual bound one). */
   readonly port: number;
   /** Bind address. Defaults to loopback (`127.0.0.1`); set `0.0.0.0` to expose
    *  on the LAN (still token-gated; prefer a tunnel for off-network access). */
@@ -65,29 +117,82 @@ export interface WebSocketBridgeOptions {
   /** Shared secret required at the handshake. REQUIRED — an empty token throws,
    *  because this surface is reachable off-process. */
   readonly authToken: string;
+  /** Accept the legacy `?t=<token>` query credential. Default false — the token
+   *  belongs in the `Authorization` header or the `Sec-WebSocket-Protocol`
+   *  bearer entry, never the URL. */
+  readonly allowQueryToken?: boolean;
+  /** Browser origins allowed to connect. Default `[]`: every upgrade carrying
+   *  an `Origin` header (i.e. browser-initiated) is rejected; native clients
+   *  send no Origin and are unaffected. */
+  readonly allowedOrigins?: readonly string[];
+  /** Max concurrent connections (default 8); excess upgrades are rejected. */
+  readonly maxConnections?: number;
+  /** Slow-reader eviction threshold for the per-socket send backlog
+   *  (default 4 MB — see {@link SlowReaderGuard}). */
+  readonly maxBufferedBytes?: number;
+  /** How long the backlog may stay above the threshold before eviction
+   *  (default 10s). */
+  readonly bufferStallGraceMs?: number;
   /** Max bytes per frame. Defaults to 64 MB to cover the base64 audio cap. */
   readonly maxPayloadBytes?: number;
 }
 
+export interface WebSocketBridgeServer extends TransportServer {
+  /**
+   * Rotate the pairing credential on the LIVE server: new handshakes must
+   * present `next`, and every currently-connected client is terminated so a
+   * leaked old token can't keep an established session alive. Callers should
+   * persist `next` first (e.g. `rotateChannelToken` in `@moxxy/sdk`).
+   */
+  rotateAuthToken(next: string): void;
+}
+
 export async function createWebSocketTransportServer(
   opts: WebSocketBridgeOptions,
-): Promise<TransportServer> {
+): Promise<WebSocketBridgeServer> {
   if (!opts.authToken) {
     throw new Error(
       'createWebSocketTransportServer: authToken is required — this surface is network-reachable',
     );
   }
   const host = opts.host ?? '127.0.0.1';
+  const maxConnections = opts.maxConnections ?? DEFAULT_MAX_CONNECTIONS;
+  let currentToken = opts.authToken;
+  let connections = 0;
+
   const wss = new WebSocketServer({
     host,
     port: opts.port,
     maxPayload: opts.maxPayloadBytes ?? 64 * 1024 * 1024,
-    verifyClient: (info: { req: IncomingMessage }) => checkWsAuth(info.req, opts.authToken),
+    verifyClient: (info: { req: IncomingMessage }) => {
+      if (!checkWsOrigin(info.req, opts.allowedOrigins)) {
+        console.warn(
+          `[moxxy] ws bridge: rejected browser-origin upgrade (Origin: ${String(info.req.headers.origin)})`,
+        );
+        return false;
+      }
+      if (connections >= maxConnections) {
+        console.warn(`[moxxy] ws bridge: rejected upgrade — connection cap (${maxConnections}) reached`);
+        return false;
+      }
+      return checkWsAuth(info.req, currentToken, { allowQueryToken: opts.allowQueryToken });
+    },
+    // When the client offers subprotocols (the moxxy.bearer.* convention),
+    // select the moxxy protocol WITHOUT echoing the token-bearing entry back.
+    handleProtocols: (protocols: Set<string>) =>
+      protocols.has(MOXXY_WS_SUBPROTOCOL) ? MOXXY_WS_SUBPROTOCOL : false,
   });
 
   const connectionHandlers: Array<(t: Transport) => void> = [];
   wss.on('connection', (ws: WebSocket) => {
-    const transport = new WsTransport(ws);
+    connections += 1;
+    ws.once('close', () => {
+      connections -= 1;
+    });
+    const transport = new WsTransport(
+      ws,
+      new SlowReaderGuard(opts.maxBufferedBytes, opts.bufferStallGraceMs),
+    );
     for (const handler of connectionHandlers) handler(transport);
   });
 
@@ -96,13 +201,27 @@ export async function createWebSocketTransportServer(
     wss.once('listening', resolve);
   });
 
+  // Report the ACTUAL bound port — `opts.port` may be 0 (ephemeral).
+  const bound = wss.address();
+  const boundPort = typeof bound === 'object' && bound !== null ? bound.port : opts.port;
+
   return {
-    address: `ws://${host}:${opts.port}`,
+    address: `ws://${host}:${boundPort}`,
     onConnection(handler: (t: Transport) => void): void {
       connectionHandlers.push(handler);
     },
+    rotateAuthToken(next: string): void {
+      currentToken = next;
+      for (const client of wss.clients) client.terminate();
+    },
     close(): Promise<void> {
-      return new Promise<void>((resolve) => wss.close(() => resolve()));
+      // `wss.close` only stops the listener; it waits for clients to leave on
+      // their own. Quit is quit — terminate them so close resolves promptly
+      // instead of burning the host's shutdown timeout.
+      return new Promise<void>((resolve) => {
+        for (const client of wss.clients) client.terminate();
+        wss.close(() => resolve());
+      });
     },
   };
 }

--- a/packages/plugin-channel-mobile/src/channel.ts
+++ b/packages/plugin-channel-mobile/src/channel.ts
@@ -17,7 +17,7 @@ import { WebSocketCommandBus, startWsBridge } from '@moxxy/ipc-server-ws';
 import type { TunnelHandle } from '@moxxy/sdk';
 
 import { MobileSessionHost } from './single-session-host.js';
-import { resolveMobileToken } from './token.js';
+import { resolveMobileToken, rotateMobileToken } from './token.js';
 import {
   advertisedHost,
   buildConnectUrl,
@@ -58,7 +58,7 @@ export class MobileChannel implements Channel<MobileStartOpts> {
 
   private readonly port: number;
   private readonly bindHost: string;
-  private readonly token: string;
+  private token: string;
   private readonly tunnelChoice: TunnelChoice;
   private readonly logger: MobileChannelOptions['logger'];
   private host: MobileSessionHost | null = null;
@@ -82,6 +82,20 @@ export class MobileChannel implements Channel<MobileStartOpts> {
     };
   }
 
+  /**
+   * Rotate the pairing token: persist a fresh secret, re-key the live server
+   * (every connected app is terminated — a leaked QR/token stops working
+   * immediately), and return the new token so the caller can re-display
+   * pairing info. The printed QR also documents the manual path (delete
+   * `~/.moxxy/mobile-token` + restart). Env/config-supplied tokens take
+   * precedence at resolve time and must be rotated at their source.
+   */
+  rotateToken(): string {
+    this.token = rotateMobileToken();
+    this.server?.rotateAuthToken(this.token);
+    return this.token;
+  }
+
   async start(startOpts: MobileStartOpts): Promise<ChannelHandle> {
     const bus = new WebSocketCommandBus();
     const host = new MobileSessionHost(bus, startOpts.session);
@@ -93,6 +107,11 @@ export class MobileChannel implements Channel<MobileStartOpts> {
       port: this.port,
       host: this.bindHost,
       authToken: this.token,
+      // Back-compat ONLY: the QR this channel prints embeds the token as `?t=`
+      // (pairing payload); current apps strip it and authenticate via the
+      // Sec-WebSocket-Protocol bearer entry, but older installed builds still
+      // connect with the token in the WS URL.
+      allowQueryToken: true,
     });
     this.server = server;
     this.logger?.info?.('mobile channel listening', { address: server.address });

--- a/packages/plugin-channel-mobile/src/index.ts
+++ b/packages/plugin-channel-mobile/src/index.ts
@@ -9,7 +9,7 @@ import { MobileChannel } from './channel.js';
 
 export { MobileChannel, type MobileChannelOptions, type MobileStartOpts } from './channel.js';
 export { MobileSessionHost, type MobileHostOptions } from './single-session-host.js';
-export { resolveMobileToken } from './token.js';
+export { resolveMobileToken, rotateMobileToken } from './token.js';
 
 function asNumber(v: unknown): number | undefined {
   return typeof v === 'number' ? v : undefined;

--- a/packages/plugin-channel-mobile/src/qr.ts
+++ b/packages/plugin-channel-mobile/src/qr.ts
@@ -22,6 +22,9 @@ export async function printConnectInfo(url: string, token: string, hint?: string
     `  token: ${token}`,
     ...(hint ? ['', `  ℹ ${hint}`] : []),
     '',
+    '  (rotate the pairing token — invalidating this QR and every paired app —',
+    '   by deleting ~/.moxxy/mobile-token and restarting the channel)',
+    '',
   ];
   // CLI surface — intentional stdout.
   console.log(lines.join('\n'));

--- a/packages/plugin-channel-mobile/src/token.ts
+++ b/packages/plugin-channel-mobile/src/token.ts
@@ -5,12 +5,21 @@
  * SDK helper so every channel resolves auth the same way.
  */
 
-import { resolveChannelToken } from '@moxxy/sdk';
+import { resolveChannelToken, rotateChannelToken } from '@moxxy/sdk';
+
+const TOKEN_FILE = 'mobile-token';
 
 export function resolveMobileToken(configured?: string): string {
   return resolveChannelToken({
     configured,
     envVar: 'MOXXY_MOBILE_TOKEN',
-    fileName: 'mobile-token',
+    fileName: TOKEN_FILE,
   });
+}
+
+/** Rotate the persisted pairing secret (`~/.moxxy/mobile-token`) and return the
+ *  new token. Env/config-supplied tokens take precedence and must be rotated at
+ *  their source — see `rotateChannelToken`. */
+export function rotateMobileToken(): string {
+  return rotateChannelToken({ fileName: TOKEN_FILE });
 }

--- a/packages/plugin-channel-mobile/src/tunnel.ts
+++ b/packages/plugin-channel-mobile/src/tunnel.ts
@@ -75,9 +75,13 @@ export function advertisedHost(bindHost: string): string {
 }
 
 /**
- * Build the WebSocket connect URL the mobile app uses — token embedded as the
- * `?t=` query the bridge accepts (so a scanned QR carries everything). A tunnel
- * URL (https) becomes `wss://`; the local path uses the advertised host.
+ * Build the pairing URL the QR carries — the token rides as a `?t=` query so a
+ * single scan carries everything. This is a PAIRING payload, not the live WS
+ * URL: the app strips `?t=` before connecting and presents the token via the
+ * `Sec-WebSocket-Protocol` bearer entry instead (the channel keeps
+ * `allowQueryToken` on only for older app builds that still connect with the
+ * token in the URL). A tunnel URL (https) becomes `wss://`; the local path
+ * uses the advertised host.
  */
 export function buildConnectUrl(opts: {
   tunnelUrl: string | null;

--- a/packages/runner/src/integration.test.ts
+++ b/packages/runner/src/integration.test.ts
@@ -14,6 +14,7 @@ import {
   autoAllowResolver,
   restoreSessionEvents,
   silentLogger,
+  type Logger,
 } from '@moxxy/core';
 import {
   defineMode,
@@ -28,11 +29,14 @@ import { FakeProvider, textReply, toolUseReply } from '@moxxy/testing';
 import { defaultModePlugin } from '@moxxy/mode-default';
 import { startRunnerServer, type RunnerServer } from './server.js';
 import { connectRemoteSession, type RemoteSession } from './remote-session.js';
+import { connectUnixSocket } from './unix-socket.js';
+import { JsonRpcPeer } from './jsonrpc.js';
+import { RUNNER_PROTOCOL_VERSION, RunnerMethod } from './protocol.js';
 
-function buildSession(provider: FakeProvider): Session {
+function buildSession(provider: FakeProvider, logger: Logger = silentLogger): Session {
   const session = new Session({
     cwd: process.cwd(),
-    logger: silentLogger,
+    logger,
     permissionResolver: autoAllowResolver,
   });
   session.pluginHost.registerStatic(
@@ -368,6 +372,86 @@ describe('runner end-to-end', () => {
     controller.abort();
     // The turn must end rather than hang.
     await expect(drained).resolves.toBeUndefined();
+  });
+
+  it('logs an audit line for a cross-client abort and denies it under strict mode', async () => {
+    // Cross-client abort is allowed by design (TUI + desktop share ONE
+    // session, so aborting your own session from another client is
+    // legitimate) - but it must leave an audit trail naming both connections,
+    // and MOXXY_RUNNER_STRICT_ABORT=1 must deny it outright.
+    const warns: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const auditLogger: Logger = {
+      debug: () => {},
+      info: () => {},
+      warn: (msg, meta) => warns.push({ msg, ...(meta ? { meta } : {}) }),
+      error: () => {},
+      child: () => auditLogger,
+    };
+    const socketPath = tmpSocket();
+    const session = buildSession(new FakeProvider({ script: [textReply('unused')] }), auditLogger);
+    // A mode that blocks until the turn signal aborts, so the turn is still
+    // in flight when the second client fires its abort.
+    session.pluginHost.registerStatic(
+      definePlugin({
+        name: 'runner-test-cross-abort',
+        modes: [
+          defineMode({
+            name: 'wait-mode',
+
+            run: async function* (modeCtx) {
+              await new Promise<void>((resolve) => {
+                if (modeCtx.signal.aborted) return resolve();
+                modeCtx.signal.addEventListener('abort', () => resolve(), { once: true });
+              });
+            },
+          }),
+        ],
+      }),
+    );
+    session.modes.setActive('wait-mode');
+    const server = await startRunnerServer(session, { socketPath });
+    servers.push(server);
+
+    const driver = await attach(socketPath, 'driver');
+    const drained = (async () => {
+      for await (const _event of driver.runTurn('block')) void _event;
+    })();
+    // Learn the in-flight turnId from the authoritative log.
+    await waitFor(() => session.log.length > 0);
+    const turnId = session.log.at(0)!.turnId;
+
+    // A second client on its own connection (raw peer - RemoteSession only
+    // aborts turns it started itself).
+    const peer = new JsonRpcPeer(await connectUnixSocket(socketPath));
+    try {
+      await peer.request(RunnerMethod.Attach, {
+        protocolVersion: RUNNER_PROTOCOL_VERSION,
+        role: 'second-ui',
+        sinceSeq: 0,
+      });
+
+      process.env.MOXXY_RUNNER_STRICT_ABORT = '1';
+      try {
+        await expect(peer.request(RunnerMethod.Abort, { turnId })).rejects.toThrow(
+          /cross-client abort denied/,
+        );
+      } finally {
+        delete process.env.MOXXY_RUNNER_STRICT_ABORT;
+      }
+
+      // Default (shared-session) policy: the abort goes through...
+      await peer.request(RunnerMethod.Abort, { turnId });
+      await expect(drained).resolves.toBeUndefined();
+    } finally {
+      peer.close();
+    }
+
+    // ...and BOTH attempts left an audit line naming the two connections.
+    const audit = warns.filter((w) => w.msg === 'cross-client abort');
+    expect(audit.length).toBe(2);
+    for (const entry of audit) {
+      expect(entry.meta).toMatchObject({ turnId, ownerRole: 'driver', abortingRole: 'second-ui' });
+    }
   });
 
   it('routes an approval checkpoint to the turn-owning client', async () => {

--- a/packages/runner/src/server.ts
+++ b/packages/runner/src/server.ts
@@ -59,6 +59,12 @@ interface TurnScope {
   readonly turnId: TurnId;
 }
 
+/** An in-flight turn: its abort controller plus the connection that started it. */
+interface TurnEntry {
+  readonly controller: AbortController;
+  readonly owner: ConnectedClient;
+}
+
 /**
  * Exposes a {@link Session} over a transport so thin clients can attach.
  *
@@ -73,7 +79,7 @@ interface TurnScope {
  */
 export class RunnerServer {
   private readonly clients = new Set<ConnectedClient>();
-  private readonly turnControllers = new Map<TurnId, AbortController>();
+  private readonly turnControllers = new Map<TurnId, TurnEntry>();
   private readonly scope = new AsyncLocalStorage<TurnScope>();
   private readonly logUnsub: () => void;
   private readonly logClearUnsub: () => void;
@@ -142,7 +148,7 @@ export class RunnerServer {
     peer.handle(RunnerMethod.Attach, (raw) => this.handleAttach(client, raw));
     peer.handle(RunnerMethod.GetInfo, () => this.session.getInfo());
     peer.handle(RunnerMethod.RunTurn, (raw) => this.handleRunTurn(client, raw));
-    peer.handle(RunnerMethod.Abort, (raw) => this.handleAbort(raw));
+    peer.handle(RunnerMethod.Abort, (raw) => this.handleAbort(client, raw));
     peer.handle(RunnerMethod.SessionReset, () => this.handleSessionReset());
     peer.handle(RunnerMethod.SetResolver, (raw) => this.handleSetResolver(client, raw));
     peer.handle(RunnerMethod.ModeSetActive, (raw) => this.handleModeSetActive(raw));
@@ -170,7 +176,7 @@ export class RunnerServer {
     // Tear down any turns this client was driving - there's no one left to
     // answer their prompts or consume their output.
     for (const turnId of client.turns) {
-      this.turnControllers.get(turnId)?.abort('owning client disconnected');
+      this.turnControllers.get(turnId)?.controller.abort('owning client disconnected');
     }
   }
 
@@ -206,7 +212,7 @@ export class RunnerServer {
     const params = runTurnParamsSchema.parse(raw);
     const turnId = newTurnId();
     const controller = new AbortController();
-    this.turnControllers.set(turnId, controller);
+    this.turnControllers.set(turnId, { controller, owner: client });
     client.turns.add(turnId);
 
     const opts = {
@@ -244,9 +250,31 @@ export class RunnerServer {
     return { turnId };
   }
 
-  private handleAbort(raw: unknown): Record<string, never> {
+  private handleAbort(client: ConnectedClient, raw: unknown): Record<string, never> {
     const params = abortParamsSchema.parse(raw);
-    this.turnControllers.get(params.turnId as TurnId)?.abort('client requested abort');
+    const entry = this.turnControllers.get(params.turnId as TurnId);
+    if (!entry) return {};
+    if (entry.owner !== client) {
+      // Cross-client abort is ALLOWED by design: multiple clients (TUI +
+      // desktop) deliberately attach to the SAME shared session, so a user
+      // aborting their own session's turn from another client is legitimate.
+      // The audit's underlying concern - an unauthenticated local process
+      // attaching at all - is addressed at the transport layer (0700 socket
+      // directory, see unix-socket.ts), not by denying aborts here. We keep
+      // an audit trail instead; MOXXY_RUNNER_STRICT_ABORT=1 opts into denial
+      // for single-client deployments.
+      this.session.logger.warn('cross-client abort', {
+        turnId: params.turnId,
+        ownerRole: entry.owner.role,
+        abortingRole: client.role,
+      });
+      if (process.env.MOXXY_RUNNER_STRICT_ABORT === '1') {
+        throw new Error(
+          `turn ${params.turnId} was started by '${entry.owner.role}'; cross-client abort denied (MOXXY_RUNNER_STRICT_ABORT=1)`,
+        );
+      }
+    }
+    entry.controller.abort('client requested abort');
     return {};
   }
 
@@ -261,8 +289,8 @@ export class RunnerServer {
    * socket), so mirrors stay contiguous either way.
    */
   private handleSessionReset(): Record<string, never> {
-    for (const controller of this.turnControllers.values()) {
-      controller.abort('session reset');
+    for (const entry of this.turnControllers.values()) {
+      entry.controller.abort('session reset');
     }
     this.session.log.clear();
     return {};
@@ -531,7 +559,8 @@ export async function startRunnerServer(
   opts: { readonly socketPath?: string; readonly transport?: TransportServer } = {},
 ): Promise<RunnerServer> {
   const transport =
-    opts.transport ?? (await createUnixSocketServer(opts.socketPath ?? runnerSocketPath()));
+    opts.transport ??
+    (await createUnixSocketServer(opts.socketPath ?? runnerSocketPath(), session.logger));
   // DO NOT auto-activate any transcriber at boot. The TUI's
   // useVoiceInput depends on Codex specifically and would throw
   // "another transcriber is active" if we promoted something else

--- a/packages/runner/src/unix-socket.test.ts
+++ b/packages/runner/src/unix-socket.test.ts
@@ -2,8 +2,8 @@ import fs from 'node:fs';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
-import { createUnixSocketServer, connectUnixSocket } from './unix-socket.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createUnixSocketServer, connectUnixSocket, type SocketLogger } from './unix-socket.js';
 import type { Transport, TransportServer } from './transport.js';
 
 function tmpSocket(): string {
@@ -102,6 +102,68 @@ describe('unix-socket transport (NDJSON framing)', () => {
     client.send({ ok: 1 });
     expect(await got).toEqual({ ok: 1 });
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'creates the socket parent directory with mode 0700 before listening',
+    async () => {
+      const dir = path.join(os.tmpdir(), `moxxy-sockdir-${Math.random().toString(36).slice(2, 10)}`);
+      const socketPath = path.join(dir, 'serve.sock');
+      try {
+        const server = await createUnixSocketServer(socketPath);
+        servers.push(server);
+        // The freshly created parent dir is born private - other users can
+        // never reach the socket, even before any post-listen chmod.
+        expect(fs.statSync(dir).mode & 0o777).toBe(0o700);
+        // Belt-and-braces: the socket node itself is tightened too.
+        expect(fs.statSync(socketPath).mode & 0o777).toBe(0o600);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'tightens a pre-existing socket directory it owns to 0700',
+    async () => {
+      const dir = path.join(os.tmpdir(), `moxxy-sockdir-${Math.random().toString(36).slice(2, 10)}`);
+      fs.mkdirSync(dir, { mode: 0o755 });
+      const socketPath = path.join(dir, 'serve.sock');
+      try {
+        const server = await createUnixSocketServer(socketPath);
+        servers.push(server);
+        expect(fs.statSync(dir).mode & 0o777).toBe(0o700);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'logs loudly when chmod of the socket fails instead of swallowing it',
+    async () => {
+      const errors: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+      const logger: SocketLogger = {
+        warn: () => {},
+        error: (msg, meta) => errors.push({ msg, ...(meta ? { meta } : {}) }),
+      };
+      const socketPath = tmpSocket();
+      const spy = vi.spyOn(fs, 'chmodSync').mockImplementation(() => {
+        throw new Error('EPERM: injected chmod failure');
+      });
+      try {
+        const server = await createUnixSocketServer(socketPath, logger);
+        servers.push(server);
+      } finally {
+        spy.mockRestore();
+      }
+      const loud = errors.find((e) => e.msg.includes('failed to chmod runner socket'));
+      expect(loud).toBeDefined();
+      expect(loud?.meta).toMatchObject({
+        socketPath,
+        error: expect.stringContaining('injected chmod failure') as unknown,
+      });
+    },
+  );
 
   it('fires onClose when the peer disconnects', async () => {
     const socketPath = tmpSocket();

--- a/packages/runner/src/unix-socket.ts
+++ b/packages/runner/src/unix-socket.ts
@@ -3,6 +3,18 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { Transport, TransportServer } from './transport.js';
 
+/** Minimal logging surface the transport needs (structurally matches
+ *  `@moxxy/core`'s `Logger`, so `session.logger` plugs straight in). */
+export interface SocketLogger {
+  warn(msg: string, meta?: Record<string, unknown>): void;
+  error(msg: string, meta?: Record<string, unknown>): void;
+}
+
+const stderrLogger: SocketLogger = {
+  warn: (msg, meta) => process.stderr.write(`[moxxy-runner] WARN ${msg} ${meta ? JSON.stringify(meta) : ''}\n`),
+  error: (msg, meta) => process.stderr.write(`[moxxy-runner] ERROR ${msg} ${meta ? JSON.stringify(meta) : ''}\n`),
+};
+
 /**
  * NDJSON framing over a single `net.Socket`: one JSON value per line. Safe
  * because `JSON.stringify` never emits a raw newline, so `\n` is an
@@ -75,10 +87,31 @@ class NdjsonTransport implements Transport {
  * in use and we surface `EADDRINUSE`. Named pipes self-clean, so this only
  * runs on non-Windows.
  */
-export async function createUnixSocketServer(socketPath: string): Promise<TransportServer> {
+export async function createUnixSocketServer(
+  socketPath: string,
+  logger: SocketLogger = stderrLogger,
+): Promise<TransportServer> {
   if (process.platform !== 'win32') {
     await reclaimStaleSocket(socketPath);
-    fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+    // Secure the parent directory to 0700 BEFORE binding. The socket inherits
+    // the umask at bind time and is only chmod'd 0600 after `listen` returns,
+    // so without this there is a window where another local user could connect
+    // to a world-accessible socket. A 0700 parent closes that window
+    // structurally: the socket is unreachable by other users from birth,
+    // regardless of chmod timing. (The path LAYOUT is owned by the callers -
+    // desktop-host hardcodes ~/.moxxy/serve.sock and
+    // ~/.moxxy/desktop/sockets/serve-<id>.sock - so we tighten the existing
+    // dirs in place rather than moving the socket.)
+    secureSocketDir(path.dirname(socketPath), logger);
+  } else {
+    // Windows named pipes get NO explicit ACL here (Node's `net` cannot set a
+    // SECURITY_ATTRIBUTES DACL). The default DACL on a named pipe grants full
+    // control to the creating user, SYSTEM and Administrators, while Everyone
+    // and the anonymous logon get READ access only - so a foreign non-admin
+    // local user cannot WRITE (i.e. cannot issue JSON-RPC requests), but the
+    // pipe namespace (`\\.\pipe\`) is machine-global, not session-scoped, and
+    // we are relying on that default rather than enforcing an explicit ACL.
+    warnWindowsPipeAclOnce(logger, socketPath);
   }
 
   const connectionHandlers: Array<(t: Transport) => void> = [];
@@ -95,12 +128,19 @@ export async function createUnixSocketServer(socketPath: string): Promise<Transp
     });
   });
 
-  // Restrict to the owning user. No-op on Windows (named pipe ACLs differ).
+  // Restrict the socket itself to the owning user. Belt-and-braces: the 0700
+  // parent dir (above) is what actually prevents cross-user access; this just
+  // tightens the socket node too. No-op on Windows (named pipes, see above).
   if (process.platform !== 'win32') {
     try {
       fs.chmodSync(socketPath, 0o600);
-    } catch {
-      // Best effort - some filesystems reject chmod on sockets.
+    } catch (err) {
+      // Some filesystems reject chmod on sockets - the 0700 parent dir still
+      // protects the socket, but say so LOUDLY instead of swallowing it.
+      logger.error('failed to chmod runner socket to 0600', {
+        socketPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 
@@ -140,6 +180,49 @@ export function connectUnixSocket(socketPath: string): Promise<Transport> {
       resolve(new NdjsonTransport(socket));
     });
   });
+}
+
+/**
+ * Make the socket's parent directory private (0700) before the socket is
+ * created inside it. A freshly created dir is born 0700 (no chmod race at
+ * all); a pre-existing dir we own is tightened in place - still before
+ * `listen`, so the socket is never reachable by other users. Failures are
+ * loud: a socket dir we cannot secure is a real security signal, not noise.
+ */
+function secureSocketDir(dir: string, logger: SocketLogger): void {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try {
+    const st = fs.statSync(dir);
+    if ((st.mode & 0o077) === 0) return; // already private
+    if (typeof process.getuid === 'function' && st.uid !== process.getuid()) {
+      // A shared dir we don't own (e.g. /tmp in tests): chmod would fail with
+      // EPERM. The post-listen chmod 0600 of the socket itself is the only
+      // protection there - flag it rather than pretend it's secured.
+      logger.warn(
+        'runner socket directory is accessible to other users and not owned by this process; cannot tighten to 0700',
+        { dir },
+      );
+      return;
+    }
+    fs.chmodSync(dir, 0o700);
+  } catch (err) {
+    logger.error('failed to restrict runner socket directory to 0700', {
+      dir,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+let warnedWindowsPipeAcl = false;
+
+/** One-time honesty log for the documented win32 gap (see the listen site). */
+function warnWindowsPipeAclOnce(logger: SocketLogger, pipePath: string): void {
+  if (warnedWindowsPipeAcl) return;
+  warnedWindowsPipeAcl = true;
+  logger.warn(
+    'runner named pipe relies on the Windows default DACL (creator/SYSTEM/Administrators: full control; Everyone: read-only) - no explicit ACL is applied',
+    { pipePath },
+  );
 }
 
 async function reclaimStaleSocket(socketPath: string): Promise<void> {

--- a/packages/sdk/src/channel-auth.test.ts
+++ b/packages/sdk/src/channel-auth.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  resolveChannelToken,
+  rotateChannelToken,
+  encodeWsBearerProtocol,
+  tokenFromWsProtocolHeader,
+  MOXXY_WS_SUBPROTOCOL,
+} from './channel-auth.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'moxxy-channel-auth-'));
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('resolveChannelToken', () => {
+  it('generates and persists a token (JSON with createdAt, mode 0600)', () => {
+    const token = resolveChannelToken({ fileName: 'tok', dir });
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    const file = path.join(dir, 'tok');
+    const persisted = JSON.parse(fs.readFileSync(file, 'utf8')) as {
+      token: string;
+      createdAt: string;
+    };
+    expect(persisted.token).toBe(token);
+    expect(Number.isFinite(Date.parse(persisted.createdAt))).toBe(true);
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+    }
+    // Stable across resolves.
+    expect(resolveChannelToken({ fileName: 'tok', dir })).toBe(token);
+  });
+
+  it('reads a legacy plain-text token file', () => {
+    fs.writeFileSync(path.join(dir, 'tok'), 'legacy-secret\n');
+    expect(resolveChannelToken({ fileName: 'tok', dir })).toBe('legacy-secret');
+  });
+
+  it('warns (but still returns the token) when the persisted token is stale', () => {
+    const createdAt = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000).toISOString();
+    fs.writeFileSync(path.join(dir, 'tok'), JSON.stringify({ token: 'old-secret', createdAt }));
+    const warnings: string[] = [];
+    const token = resolveChannelToken({ fileName: 'tok', dir, warn: (m) => warnings.push(m) });
+    expect(token).toBe('old-secret');
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toMatch(/rotat/i);
+  });
+
+  it('does not warn for a fresh token', () => {
+    const warnings: string[] = [];
+    resolveChannelToken({ fileName: 'tok', dir, warn: (m) => warnings.push(m) });
+    resolveChannelToken({ fileName: 'tok', dir, warn: (m) => warnings.push(m) });
+    expect(warnings).toEqual([]);
+  });
+
+  it('prefers env, then configured, over the persisted file', () => {
+    process.env.MOXXY_TEST_CHANNEL_TOKEN = 'from-env';
+    try {
+      expect(
+        resolveChannelToken({
+          fileName: 'tok',
+          dir,
+          envVar: 'MOXXY_TEST_CHANNEL_TOKEN',
+          configured: 'from-config',
+        }),
+      ).toBe('from-env');
+    } finally {
+      delete process.env.MOXXY_TEST_CHANNEL_TOKEN;
+    }
+    expect(resolveChannelToken({ fileName: 'tok', dir, configured: 'from-config' })).toBe(
+      'from-config',
+    );
+  });
+});
+
+describe('rotateChannelToken', () => {
+  it('replaces the persisted token with a fresh secret', () => {
+    const original = resolveChannelToken({ fileName: 'tok', dir });
+    const rotated = rotateChannelToken({ fileName: 'tok', dir });
+    expect(rotated).not.toBe(original);
+    expect(rotated).toMatch(/^[0-9a-f]{64}$/);
+    expect(resolveChannelToken({ fileName: 'tok', dir })).toBe(rotated);
+  });
+
+  it('upgrades a legacy plain-text file to the JSON format', () => {
+    fs.writeFileSync(path.join(dir, 'tok'), 'legacy-secret');
+    rotateChannelToken({ fileName: 'tok', dir });
+    const raw = fs.readFileSync(path.join(dir, 'tok'), 'utf8');
+    expect(raw.trim().startsWith('{')).toBe(true);
+  });
+});
+
+describe('ws bearer protocol encoding', () => {
+  it('round-trips a hex token', () => {
+    const entry = encodeWsBearerProtocol('abc123');
+    expect(tokenFromWsProtocolHeader(`${MOXXY_WS_SUBPROTOCOL}, ${entry}`)).toBe('abc123');
+  });
+
+  it('round-trips reserved characters and emits only valid HTTP token chars', () => {
+    const token = "p@ss w0rd/+='!()*,";
+    const entry = encodeWsBearerProtocol(token);
+    expect(entry).toMatch(/^[A-Za-z0-9._~%-]+$/);
+    expect(tokenFromWsProtocolHeader(entry)).toBe(token);
+  });
+
+  it('returns null when no bearer entry is offered', () => {
+    expect(tokenFromWsProtocolHeader(undefined)).toBeNull();
+    expect(tokenFromWsProtocolHeader(MOXXY_WS_SUBPROTOCOL)).toBeNull();
+    expect(tokenFromWsProtocolHeader('')).toBeNull();
+  });
+
+  it('returns null for a malformed percent escape', () => {
+    expect(tokenFromWsProtocolHeader('moxxy.bearer.%zz')).toBeNull();
+  });
+});

--- a/packages/sdk/src/channel-auth.ts
+++ b/packages/sdk/src/channel-auth.ts
@@ -1,12 +1,18 @@
 /**
  * Standard auth toolkit for channels — so a new channel gets consistent
- * connection auth without re-rolling token handling. Two pieces:
+ * connection auth without re-rolling token handling. The pieces:
  *
  *   - {@link resolveChannelToken} — the standard `channels.<name>` token
  *     resolution (env → config → a generated, persisted secret). Never empty.
+ *   - {@link rotateChannelToken} — replace the persisted secret with a fresh
+ *     one (pairing-token rotation; old tokens stop authenticating).
  *   - {@link bearerGuard} — a pre-connection handler: a constant-time bearer
  *     check a channel runs at its accept point (a WebSocket handshake, an HTTP
  *     request) before admitting a client.
+ *   - {@link encodeWsBearerProtocol} / {@link tokenFromWsProtocolHeader} — the
+ *     `Sec-WebSocket-Protocol` token convention for WebSocket clients that
+ *     cannot set an `Authorization` header (browser / React Native), so the
+ *     secret stays out of the URL (query strings leak via logs and QR/stdout).
  *
  * Channels that expose a network surface (mobile WS bridge, HTTP, web) should
  * resolve their token with the former and gate connections with the latter,
@@ -16,9 +22,9 @@
 
 import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
+import { moxxyHome } from './fs-utils.js';
 import { bearerTokenMatches } from './http-utils.js';
 
 export interface ChannelTokenOptions {
@@ -26,35 +32,107 @@ export interface ChannelTokenOptions {
   readonly configured?: string;
   /** Env var checked first, e.g. `MOXXY_MOBILE_TOKEN`. */
   readonly envVar?: string;
-  /** File (under the moxxy home dir) to persist a generated token, e.g. `mobile-token`. */
+  /** File to persist a generated token, e.g. `mobile-token`. */
   readonly fileName: string;
+  /** Directory the token file lives under. Defaults to the moxxy home dir;
+   *  the desktop bridge passes its Electron `userData` dir here instead. */
+  readonly dir?: string;
+  /** Receives the stale-token warning (default: `console.warn`). */
+  readonly warn?: (msg: string) => void;
 }
 
-function moxxyHome(): string {
-  return process.env.MOXXY_HOME?.trim() || path.join(os.homedir(), '.moxxy');
+/** Persisted tokens older than this trigger a rotation warning (soft only —
+ *  silently breaking an existing pairing is worse than an old secret). */
+const STALE_TOKEN_MS = 90 * 24 * 60 * 60 * 1000;
+
+interface PersistedToken {
+  readonly token: string;
+  /** Epoch ms the token was created, when known (null for ageless reads). */
+  readonly createdAtMs: number | null;
+}
+
+function tokenFilePath(opts: Pick<ChannelTokenOptions, 'dir' | 'fileName'>): string {
+  return path.join(opts.dir ?? moxxyHome(), opts.fileName);
+}
+
+/** Read a persisted token. New files are JSON `{ token, createdAt }`; legacy
+ *  files are the bare token (age falls back to the file mtime, best-effort). */
+function readTokenFile(file: string): PersistedToken | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, 'utf8').trim();
+  } catch {
+    return null; // not yet created
+  }
+  if (!raw) return null;
+  if (raw.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(raw) as { token?: unknown; createdAt?: unknown };
+      if (typeof parsed.token !== 'string' || !parsed.token) return null;
+      const created = typeof parsed.createdAt === 'string' ? Date.parse(parsed.createdAt) : NaN;
+      return { token: parsed.token, createdAtMs: Number.isFinite(created) ? created : null };
+    } catch {
+      return null; // corrupt — regenerate
+    }
+  }
+  let createdAtMs: number | null = null;
+  try {
+    createdAtMs = fs.statSync(file).mtimeMs;
+  } catch {
+    // age unknown
+  }
+  return { token: raw, createdAtMs };
+}
+
+function writeTokenFile(file: string, token: string): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify({ token, createdAt: new Date().toISOString() })}\n`, {
+    mode: 0o600,
+  });
 }
 
 /**
  * Resolve a channel's auth token. Precedence: `envVar` → `configured` → a
- * 256-bit secret generated once and persisted (0600) under the moxxy home, so
- * the same pairing secret survives restarts. Never returns an empty string —
- * a network-reachable channel must always be authenticated.
+ * 256-bit secret generated once and persisted (0600, JSON with a `createdAt`)
+ * under `dir` (default: the moxxy home). Never returns an empty string — a
+ * network-reachable channel must always be authenticated.
+ *
+ * A persisted token older than ~90 days logs a rotation hint (via `warn`);
+ * there is no hard expiry, because silently breaking a pairing is worse.
  */
 export function resolveChannelToken(opts: ChannelTokenOptions): string {
   const fromEnv = (opts.envVar ? process.env[opts.envVar] : undefined)?.trim();
   if (fromEnv) return fromEnv;
   if (opts.configured && opts.configured.trim()) return opts.configured.trim();
 
-  const file = path.join(moxxyHome(), opts.fileName);
-  try {
-    const existing = fs.readFileSync(file, 'utf8').trim();
-    if (existing) return existing;
-  } catch {
-    // not yet created
+  const file = tokenFilePath(opts);
+  const existing = readTokenFile(file);
+  if (existing) {
+    if (existing.createdAtMs !== null && Date.now() - existing.createdAtMs > STALE_TOKEN_MS) {
+      const days = Math.floor((Date.now() - existing.createdAtMs) / (24 * 60 * 60 * 1000));
+      (opts.warn ?? console.warn)(
+        `[moxxy] channel token at ${file} is ${days} days old — consider rotating it ` +
+          `(rotateChannelToken / delete the file to regenerate; clients must re-pair).`,
+      );
+    }
+    return existing.token;
   }
+  return rotateChannelToken(opts);
+}
+
+/**
+ * Rotate the PERSISTED channel token: generate a fresh 256-bit secret, rewrite
+ * the token file (old token stops authenticating new connections), and return
+ * it. Callers that hold a live server must also re-key it and drop existing
+ * connections (the WS bridge exposes `rotateAuthToken` for exactly this).
+ *
+ * Note: only the file-persisted token rotates — a token supplied via `envVar`
+ * or channel config takes precedence at resolve time and must be rotated at
+ * its source.
+ */
+export function rotateChannelToken(opts: Pick<ChannelTokenOptions, 'dir' | 'fileName'>): string {
   const token = randomBytes(32).toString('hex');
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, token, { mode: 0o600 });
+  writeTokenFile(tokenFilePath(opts), token);
   return token;
 }
 
@@ -65,4 +143,39 @@ export function resolveChannelToken(opts: ChannelTokenOptions): string {
  */
 export function bearerGuard(expected: string): (presented: string | undefined | null) => boolean {
   return (presented) => (expected ? bearerTokenMatches(presented, expected) : false);
+}
+
+/** The moxxy WS application subprotocol a client requests (and the server
+ *  selects) when it also smuggles its bearer token as a protocol entry. */
+export const MOXXY_WS_SUBPROTOCOL = 'moxxy.v1';
+
+/** Prefix of the `Sec-WebSocket-Protocol` entry that carries the bearer token:
+ *  `moxxy.bearer.<rfc3986-strict-percent-encoded token>`. Percent-encoding
+ *  keeps every output character a valid HTTP token char. */
+export const MOXXY_WS_BEARER_PROTOCOL_PREFIX = 'moxxy.bearer.';
+
+/** Encode a bearer token as the WS subprotocol entry a header-less WebSocket
+ *  client (browser / React Native) sends alongside {@link MOXXY_WS_SUBPROTOCOL}. */
+export function encodeWsBearerProtocol(token: string): string {
+  const strict = encodeURIComponent(token).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+  return `${MOXXY_WS_BEARER_PROTOCOL_PREFIX}${strict}`;
+}
+
+/** Extract the bearer token from a `Sec-WebSocket-Protocol` request header
+ *  (comma-separated offer list), or null when no bearer entry is present. */
+export function tokenFromWsProtocolHeader(header: string | undefined): string | null {
+  if (!header) return null;
+  for (const entry of header.split(',')) {
+    const candidate = entry.trim();
+    if (!candidate.startsWith(MOXXY_WS_BEARER_PROTOCOL_PREFIX)) continue;
+    try {
+      return decodeURIComponent(candidate.slice(MOXXY_WS_BEARER_PROTOCOL_PREFIX.length));
+    } catch {
+      return null; // malformed escape — treat as unauthenticated
+    }
+  }
+  return null;
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -151,7 +151,12 @@ export { createMutex, type Mutex } from './mutex.js';
 export { readRequestBody, bearerTokenMatches } from './http-utils.js';
 export {
   resolveChannelToken,
+  rotateChannelToken,
   bearerGuard,
+  encodeWsBearerProtocol,
+  tokenFromWsProtocolHeader,
+  MOXXY_WS_SUBPROTOCOL,
+  MOXXY_WS_BEARER_PROTOCOL_PREFIX,
   type ChannelTokenOptions,
 } from './channel-auth.js';
 export {

--- a/packages/sdk/src/loop-helpers.test.ts
+++ b/packages/sdk/src/loop-helpers.test.ts
@@ -50,6 +50,107 @@ describe('projectMessagesFromLog', () => {
       content: [{ type: 'text', text: 'current prompt' }],
     });
   });
+
+  it('omits the empty text block from a tool-only assistant turn (keeps tool_use + results)', () => {
+    // Historical wedged-log shape: end_turn with tool calls and no prose
+    // produced an assistant_message with empty content. Providers (Anthropic)
+    // reject empty text blocks on the NEXT request — the projection must drop
+    // the block so even existing logs become valid again.
+    const log = reader([
+      event(0, { type: 'user_prompt', turnId: t1, source: 'user', text: 'run the tool' }),
+      event(1, {
+        type: 'tool_call_requested',
+        turnId: t1,
+        source: 'model',
+        callId: 'call-1',
+        name: 'do_thing',
+        input: { a: 1 },
+      }),
+      event(2, {
+        type: 'assistant_message',
+        turnId: t1,
+        source: 'model',
+        content: '',
+        stopReason: 'end_turn',
+      }),
+      event(3, {
+        type: 'tool_result',
+        turnId: t1,
+        source: 'tool',
+        callId: 'call-1',
+        ok: true,
+        output: 'done',
+      }),
+    ]);
+
+    const messages = projectMessagesFromLog({ log });
+
+    expect(messages.map((m) => m.role)).toEqual(['user', 'assistant', 'tool_result']);
+    expect(messages[1]!.content).toEqual([
+      { type: 'tool_use', id: 'call-1', name: 'do_thing', input: { a: 1 } },
+    ]);
+    // No empty text block anywhere in the projected conversation.
+    for (const m of messages) {
+      for (const block of m.content) {
+        if (block.type === 'text') expect(block.text.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('skips a whitespace-only assistant message even without tool calls', () => {
+    const log = reader([
+      event(0, { type: 'user_prompt', turnId: t1, source: 'user', text: 'hi' }),
+      event(1, {
+        type: 'assistant_message',
+        turnId: t1,
+        source: 'model',
+        content: '  \n',
+        stopReason: 'end_turn',
+      }),
+      event(2, { type: 'user_prompt', turnId: t2, source: 'user', text: 'still there?' }),
+    ]);
+
+    const messages = projectMessagesFromLog({ log });
+
+    expect(messages.map((m) => m.role)).toEqual(['user', 'user']);
+  });
+
+  it('still projects non-empty assistant messages alongside tool calls', () => {
+    const log = reader([
+      event(0, { type: 'user_prompt', turnId: t1, source: 'user', text: 'run it' }),
+      event(1, {
+        type: 'tool_call_requested',
+        turnId: t1,
+        source: 'model',
+        callId: 'call-2',
+        name: 'do_thing',
+        input: {},
+      }),
+      event(2, {
+        type: 'assistant_message',
+        turnId: t1,
+        source: 'model',
+        content: 'running it now',
+        stopReason: 'end_turn',
+      }),
+      event(3, {
+        type: 'tool_result',
+        turnId: t1,
+        source: 'tool',
+        callId: 'call-2',
+        ok: true,
+        output: 'ok',
+      }),
+    ]);
+
+    const messages = projectMessagesFromLog({ log });
+
+    expect(messages.map((m) => m.role)).toEqual(['user', 'assistant', 'assistant', 'tool_result']);
+    expect(messages[2]).toMatchObject({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'running it now' }],
+    });
+  });
 });
 
 function reader(events: ReadonlyArray<MoxxyEvent>): EventLogReader {

--- a/packages/sdk/src/mode-helpers.ts
+++ b/packages/sdk/src/mode-helpers.ts
@@ -296,6 +296,16 @@ export function projectMessages(
           recordStable(e.seq);
           break;
         }
+        // A tool-only turn can log an assistant_message with empty content
+        // (end_turn + tool calls, no prose). Projecting it as an empty text
+        // block makes some providers (Anthropic) reject the NEXT request and
+        // permanently wedges the session. Skip the block — the turn's
+        // tool_use blocks are projected from tool_call_requested events —
+        // which also un-wedges historical logs that already contain one.
+        if (e.content.trim().length === 0) {
+          recordStable(e.seq);
+          break;
+        }
         messages.push({ role: 'assistant', content: [{ type: 'text', text: e.content }] });
         recordStable(e.seq);
         break;


### PR DESCRIPTION
Fixes the remaining verified medium findings from the 2026-06-09 audit (intake A23–A31 in TECH_DEBT.md), plus two pre-existing typecheck breakages on main that turbo's cache had been masking.

## Core event-log (A23–A26)
- `EventLog.ingest` now contains **async listener rejections** under the same non-fatal policy as `append` (previously a process-killing unhandled rejection).
- **Persistence write failures warn once per failure streak** (structured op/path/sessionId/error) with a `degraded` flag + recovery logging — the source-of-truth log no longer fails silently.
- **Restored session logs are re-sequenced** to contiguous seq 0..n-1 (corrupt lines counted + warned; previously fully silent) and the repaired JSONL is rewritten atomically — a corrupt middle line no longer silently truncates every attached client's history or collides seqs on resume.
- **Whitespace-only assistant text blocks are filtered at the shared `projectMessages` projection** (tool_use blocks preserved) — tool-only turns can't wedge a session against providers that reject empty text blocks, and historical wedged logs become valid again.

## WS bridge + mobile hardening (A27–A30)
- **Origin validation**: browser-initiated upgrades (Origin header present) rejected unless explicitly allow-listed; native clients unaffected.
- **Token out of the URL**: `Authorization: Bearer` or a `Sec-WebSocket-Protocol` bearer entry (never echoed back); legacy `?t=` only behind `allowQueryToken` (desktop default OFF; the mobile channel keeps it for QR pairing, but the app strips it pre-connect and uses the subprotocol). Token files gain `createdAt` + a >90-day age warning, and a **rotation path** (`rotateChannelToken` / live `rotateAuthToken` terminating existing connections / `MobileChannel.rotateToken()`).
- **Backpressure + caps**: `maxConnections` (8) at the handshake; `SlowReaderGuard` terminates connections holding >4MB buffered for 10s; `TransportServer.close()` terminates remaining sockets so desktop quit stops burning the 3s shutdown timeout.
- **Client reconnect semantics**: disconnect rejects in-flight AND queued requests and clears the outbox (an abandoned `runTurn` can never silently re-execute after reconnect); exponential backoff with a 10-attempt budget → terminal `disconnected` status callers can observe.
- Hygiene: empty `MOXXY_WS_PORT` treated as unset (was an accidental ephemeral bind via `Number('') === 0`); `address` reports the real bound port; desktop's hand-rolled token persistence replaced by sdk `resolveChannelToken`.

## Runner socket (A31)
- Socket dir secured **0700 before listen** (fresh dirs born private — no chmod race; layout unchanged for desktop-host compat); socket chmod failures now log loudly instead of being swallowed; the win32 named-pipe default-DACL reality is documented with a one-time warning.
- In-flight turns track their initiating connection: **cross-client aborts are audit-logged** with both roles (allowed by design — TUI + desktop share sessions deliberately; the real boundary is the now-0700 transport), with `MOXXY_RUNNER_STRICT_ABORT=1` opt-in denial.

## Pre-existing main breakages fixed (masked by turbo cache until this branch touched the packages)
- `apps/mobile` typecheck: global `JSX` namespace gone under the Expo 54 / React 19 types from #124 → qualified as `React.JSX.Element`.
- `apps/desktop` renderer typecheck: dual `@types/react` (18.3 catalog vs 19.1 via apps/mobile) made Virtuoso/ClerkProvider unassignable (TS2786) → tsconfig `paths` pin every type-land `react` import to the package's own @types/react, with a comment explaining why.

## Verification
- Suites: core 207/207, sdk 138, runner 42/42, ipc-server-ws 28, client-transport-ws 10, plugin-channel-mobile 4, desktop 20 — plus mode suites re-run green against the new sdk
- Rebased on post-#131 main; workspace gate with explicit exit codes: build 58/58, **typecheck exit 0**, tests 111/111, lint exit 0
- Changesets: patches for core, sdk, runner, ipc-server-ws, client-transport-ws, plugin-channel-mobile, @moxxy/desktop
- TECH_DEBT intake A23–A31 appended + marked ✅ FIXED