### PR TITLE
feat(mobile): port the full mobile app design onto the shared client architecture

### DIFF
--- a/.changeset/mobile-app-port-host.md
+++ b/.changeset/mobile-app-port-host.md
@@ -1,0 +1,8 @@
+---
+"@moxxy/plugin-channel-mobile": patch
+"@moxxy/desktop-ipc-contract": patch
+---
+
+Mobile app port (phase 2a, data layer): the mobile channel's `MobileSessionHost` now serves the full command subset the Expo app drives — `session.setMode` (re-broadcasts the connected phase so clients see the new mode), `session.newSession` (aborts in-flight turns, then `SessionLike.reset()` with a `log.clear()` fallback), `session.runCommand` (the session command registry, channel `'mobile'`), voice (`session.hasTranscriber` probes the transcriber registry; `session.transcribe` runs the active transcriber or fails with the new coded `not-supported` error), and workflows (`workflows.list` returns the typed empty list when the plugin is absent; `workflows.run` fails coded `not-supported`). `session.runTurn` now forwards the new `inlineAttachments` to the session (mobile clients can't reference host paths, so the payload itself crosses the wire).
+
+Contract additions (all additive): the `not-supported` `MoxxyIpcErrorCode` for capability-absent commands, `RunTurnArgs.inlineAttachments` (SDK `UserPromptAttachment` shape, size/count-bounded in validation), and boundary Zod schemas for `session.runCommand` (closing the audit-flagged gap — it was the one mutating session command without a schema, on desktop too), `workflows.run`, and `workflows.setEnabled`.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -492,9 +492,23 @@ consider dropping the now-redundant renderer-heartbeat path. **Severity med** (n
 - **`@moxxy/design-tokens` ships a `generateRootCss` the desktop doesn't consume yet** —
   `styles.css`'s `:root` stays the source of truth (zero visual risk). Parity is
   snapshot-tested; a later change can flip `styles.css` to inject the generated block.
-- **Mobile capabilities are no-ops in the PoC.** `apps/mobile` registers `configurePlatform({})`
-  — no voice/TTS/KV. A real build needs a `@moxxy/client-platform-expo` (Expo Audio/Speech/
-  AsyncStorage) mirroring `@moxxy/client-platform-web`.
+- ~~**Mobile capabilities are no-ops in the PoC.**~~ **SUPERSEDED 2026-06-10 (full app
+  port):** `apps/mobile` is no longer a PoC — the mobile-plugin design landed on the shared
+  architecture (expo-router + NativeWind, 28 components, useGatewayStore facade over
+  client-core, MobileSessionHost extensions). Platform access deliberately lives in the
+  app's own Expo hooks (image/document picker, clipboard, secure-store, expo-audio), NOT
+  client-core's platform registry — the registry's `AudioCapture` contract is a web-shaped
+  PCM16@24kHz pipeline that doesn't fit shipping a platform-native compressed clip to the
+  host transcriber. Reconcile the contract (or add a clip-based capability) if a second
+  native platform ever appears.
+- **Mobile-port residue (2026-06-10, low):** (a) the bearer-subprotocol encoder is
+  mirrored in `apps/mobile/src/hooks/useGatewaySocket.ts` (WsRpcClient needed a
+  close-on-replace lifecycle `makeWsApi` doesn't expose — same mirroring convention
+  client-transport-ws uses vs the SDK; converge if a third copy appears); (b) sending
+  attachments while a turn is in flight is refused with a visible error (inline payloads
+  can't ride client-core's path-based queue) — queue inline attachments host-side if this
+  bites; (c) `pairing.loadPairing` is a documented no-op (the WS bridge has no
+  pairing-code endpoint; the QR/`?t=` URL IS the pairing flow).
 **Severity low** (remaining items are opt-in / additive; desktop behavior unchanged).
 
 ---

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -17,10 +17,24 @@
       "permissions": ["android.permission.CAMERA"]
     },
     "plugins": [
+      "expo-router",
+      "expo-secure-store",
+      [
+        "expo-audio",
+        {
+          "microphonePermission": "Allow moxxy mobile to access your microphone for voice input."
+        }
+      ],
       [
         "expo-camera",
         {
           "cameraPermission": "Scan the connection QR shown by `moxxy mobile` to connect to your agent."
+        }
+      ],
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "Allow moxxy mobile to attach screenshots and photos to your messages."
         }
       ]
     ],

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,0 +1,29 @@
+import { Stack } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+import { LogBox } from 'react-native';
+import { GatewayProvider } from '@/hooks/useGatewayStore';
+import '../global.css';
+
+LogBox.ignoreLogs(['props.pointerEvents is deprecated. Use style.pointerEvents']);
+
+export default function Layout() {
+  return (
+    <GatewayProvider>
+      <StatusBar style="dark" />
+      <Stack
+        screenOptions={{
+          headerShown: false,
+          contentStyle: { backgroundColor: '#f1f2f9' },
+        }}
+      >
+        <Stack.Screen name="index" />
+        <Stack.Screen name="chat" />
+        <Stack.Screen name="sessions" />
+        <Stack.Screen name="permissions" />
+        <Stack.Screen name="goals" />
+        <Stack.Screen name="settings" />
+        <Stack.Screen name="workflows" />
+      </Stack>
+    </GatewayProvider>
+  );
+}

--- a/apps/mobile/app/chat.tsx
+++ b/apps/mobile/app/chat.tsx
@@ -1,0 +1,141 @@
+import { AskSheet } from '@/components/AskSheet';
+import { AppShell } from '@/components/AppShell';
+import { ChatList } from '@/components/ChatList';
+import { CompactContextSheet } from '@/components/CompactContextSheet';
+import { ComposerCard } from '@/components/ComposerCard';
+import { ConnectionBanner } from '@/components/ConnectionBanner';
+import { FloatingChatHeader } from '@/components/FloatingChatHeader';
+import { GoalSheet } from '@/components/GoalSheet';
+import { MobileMenuSheet } from '@/components/MobileMenuSheet';
+import { useGatewayStore } from '@/hooks/useGatewayStore';
+import { useMessageCopy } from '@/hooks/useMessageCopy';
+import { useMobileChrome } from '@/hooks/useMobileChrome';
+import { useWorkspaceCollapse } from '@/hooks/useWorkspaceCollapse';
+import { buildMobileMenuItems, buildWorkspaceMenuSections } from '@/navigation';
+import { textOf } from '@/utils/record';
+import { KeyboardAvoidingView, Platform, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+export default function ChatScreen() {
+  const { autoApprove, chat, compact, composer, goals, pairing, permissions, session, sessions, socketStatus } = useGatewayStore();
+  const chrome = useMobileChrome();
+  const messageCopy = useMessageCopy();
+  const pendingActions = permissions.pendingAsks.length + permissions.pendingPermissions.length;
+  const statusLabel = chat.sending ? 'Thinking' : session.connected ? 'Connected' : 'Offline';
+  const sessionLabel = textOf(session.session?.id, 'No active session');
+  const menuItems = buildMobileMenuItems(pendingActions);
+  const workspaceSections = buildWorkspaceMenuSections(sessions.workspaces, sessions.sessions, sessions.activeWorkspaceId);
+  const workspaceCollapse = useWorkspaceCollapse(workspaceSections);
+
+  return (
+    <AppShell>
+      <SafeAreaView className="relative flex-1 overflow-hidden" edges={['top', 'bottom']}>
+        <KeyboardAvoidingView
+          className="flex-1"
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          keyboardVerticalOffset={0}
+        >
+          <ChatList
+            items={chat.items}
+            sending={chat.sending}
+            copiedMessageId={messageCopy.copiedMessageId}
+            onCopyMessage={messageCopy.copyMessage}
+          />
+
+          {!session.connected ? (
+            <View className="absolute z-10" style={{ left: 16, position: 'absolute', right: 16, top: 76, zIndex: 10 }}>
+              <ConnectionBanner paired={Boolean(pairing.token)} connected={session.connected} status={socketStatus} />
+            </View>
+          ) : null}
+
+          {pendingActions > 0 && !composer.actionsOpen && !goals.open ? (
+            <View className="absolute z-20" style={{ bottom: 126, left: 16, position: 'absolute', right: 16, zIndex: 20 }}>
+              <AskSheet
+                asks={permissions.pendingAsks}
+                permissions={permissions.pendingPermissions}
+                onAskResponse={permissions.respondAsk}
+                onPermissionDecision={permissions.decidePermission}
+              />
+            </View>
+          ) : null}
+
+          {goals.open ? (
+            <View className="absolute z-40" style={{ bottom: 126, left: 16, position: 'absolute', right: 16, zIndex: 40 }}>
+              <GoalSheet
+                objective={goals.objective}
+                canStart={goals.canStart}
+                onObjectiveChange={goals.setObjective}
+                onStart={goals.startGoal}
+                onClose={() => goals.setOpen(false)}
+              />
+            </View>
+          ) : null}
+
+          {compact.confirmOpen ? (
+            <View className="absolute z-40" style={{ bottom: 126, left: 16, position: 'absolute', right: 16, zIndex: 40 }}>
+              <CompactContextSheet
+                open={compact.confirmOpen}
+                compacting={chat.compacting}
+                onCancel={compact.cancelCompact}
+                onConfirm={compact.confirmCompact}
+              />
+            </View>
+          ) : null}
+
+          <MobileMenuSheet
+            open={chrome.menuOpen}
+            items={menuItems}
+            connected={session.connected}
+            sessionLabel={sessionLabel}
+            modeLabel={session.activeMode ?? 'Mode'}
+            providerLabel={session.activeProvider ?? 'Provider'}
+            autoApprove={autoApprove.enabled}
+            workspaceSections={workspaceSections}
+            collapsedWorkspaceIds={workspaceCollapse.collapsedWorkspaceIds}
+            onSelectSession={sessions.selectWorkspace}
+            onNewSession={sessions.newSession}
+            onCommand={composer.runCommand}
+            onToggleWorkspace={workspaceCollapse.toggleWorkspace}
+            onClose={chrome.closeMenu}
+          />
+
+          <FloatingChatHeader
+            connected={session.connected}
+            statusLabel={statusLabel}
+            pendingActions={pendingActions}
+            onToggleMenu={chrome.toggleMenu}
+            onNewSession={sessions.newSession}
+            onToggleActions={() => composer.setActionsOpen(!composer.actionsOpen)}
+          />
+
+          <ComposerCard
+            text={composer.text}
+            sending={chat.sending}
+            compacting={chat.compacting}
+            autoApprove={autoApprove.enabled}
+            actionsOpen={composer.actionsOpen}
+            voicePhase={composer.voicePhase}
+            voiceError={composer.voiceError}
+            attachments={composer.attachments}
+            attachmentError={composer.attachmentError}
+            readOnly={session.readOnly}
+            usage={chat.usage}
+            onTextChange={composer.setText}
+            onSubmit={composer.submit}
+            onAbort={composer.abort}
+            onToggleActions={() => composer.setActionsOpen(!composer.actionsOpen)}
+            onGoal={() => goals.setOpen(true)}
+            onVoice={composer.transcribe}
+            onPickImage={composer.pickImageAttachment}
+            onPickFile={composer.pickDocumentAttachment}
+            onRemoveAttachment={composer.removeAttachment}
+            onToggleAutoApprove={() => autoApprove.setAutoApprove(!autoApprove.enabled)}
+            onNewSession={sessions.newSession}
+            onCompact={compact.requestCompact}
+            onCommand={composer.runCommand}
+          />
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    </AppShell>
+  );
+}

--- a/apps/mobile/app/goals.tsx
+++ b/apps/mobile/app/goals.tsx
@@ -1,0 +1,23 @@
+import { GoalSheet } from '@/components/GoalSheet';
+import { ScreenFrame } from '@/components/ScreenFrame';
+import { useGatewayStore } from '@/hooks/useGatewayStore';
+
+export default function GoalsScreen() {
+  const { goals, permissions, session } = useGatewayStore();
+  const pendingActions = permissions.pendingAsks.length + permissions.pendingPermissions.length;
+  return (
+    <ScreenFrame
+      title="Goals"
+      subtitle="Autonomous mode"
+      connected={session.connected}
+      pendingActions={pendingActions}
+    >
+      <GoalSheet
+        objective={goals.objective}
+        canStart={goals.canStart}
+        onObjectiveChange={goals.setObjective}
+        onStart={goals.startGoal}
+      />
+    </ScreenFrame>
+  );
+}

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,0 +1,5 @@
+import { Redirect } from 'expo-router';
+
+export default function HomeScreen() {
+  return <Redirect href="/chat" />;
+}

--- a/apps/mobile/app/permissions.tsx
+++ b/apps/mobile/app/permissions.tsx
@@ -1,0 +1,23 @@
+import { AskSheet } from '@/components/AskSheet';
+import { ScreenFrame } from '@/components/ScreenFrame';
+import { useGatewayStore } from '@/hooks/useGatewayStore';
+
+export default function PermissionsScreen() {
+  const { permissions, session } = useGatewayStore();
+  const pendingActions = permissions.pendingAsks.length + permissions.pendingPermissions.length;
+  return (
+    <ScreenFrame
+      title="Actions"
+      subtitle="Permissions and approvals"
+      connected={session.connected}
+      pendingActions={pendingActions}
+    >
+      <AskSheet
+        asks={permissions.pendingAsks}
+        permissions={permissions.pendingPermissions}
+        onAskResponse={permissions.respondAsk}
+        onPermissionDecision={permissions.decidePermission}
+      />
+    </ScreenFrame>
+  );
+}

--- a/apps/mobile/app/sessions.tsx
+++ b/apps/mobile/app/sessions.tsx
@@ -1,0 +1,23 @@
+import { ScreenFrame } from '@/components/ScreenFrame';
+import { SessionList } from '@/components/SessionList';
+import { useGatewayStore } from '@/hooks/useGatewayStore';
+
+export default function SessionsScreen() {
+  const { permissions, session, sessions } = useGatewayStore();
+  const pendingActions = permissions.pendingAsks.length + permissions.pendingPermissions.length;
+  return (
+    <ScreenFrame
+      title="Sessions"
+      subtitle="Workspaces"
+      connected={session.connected}
+      pendingActions={pendingActions}
+    >
+      <SessionList
+        workspaces={sessions.workspaces}
+        activeWorkspaceId={sessions.activeWorkspaceId}
+        onSelectWorkspace={sessions.selectWorkspace}
+        onNewSession={sessions.newSession}
+      />
+    </ScreenFrame>
+  );
+}

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -1,0 +1,63 @@
+import { ConnectionSettings } from '@/components/ConnectionSettings';
+import { QrScannerSheet } from '@/components/QrScannerSheet';
+import { ScreenFrame } from '@/components/ScreenFrame';
+import { useGatewayStore } from '@/hooks/useGatewayStore';
+import { useQrScanner } from '@/hooks/useQrScanner';
+import { buildPairingUiState } from '@/pairingUi';
+import { View } from 'react-native';
+import { useState } from 'react';
+
+export default function SettingsScreen() {
+  const { autoApprove, pairing, permissions, session, socketStatus } = useGatewayStore();
+  const qrScanner = useQrScanner(pairing.pairFromQrPayload);
+  const [manualPairingOpen, setManualPairingOpen] = useState(false);
+  const pairingUi = buildPairingUiState({
+    token: pairing.token,
+    scanning: qrScanner.processing,
+    permission: qrScanner.permission,
+  });
+  const pendingActions = permissions.pendingAsks.length + permissions.pendingPermissions.length;
+  return (
+    <View className="flex-1">
+      <ScreenFrame
+        title="Settings"
+        subtitle="Gateway and runtime"
+        connected={session.connected}
+        pendingActions={pendingActions}
+      >
+        <ConnectionSettings
+          gatewayUrl={pairing.gatewayUrl}
+          token={pairing.token}
+          code={pairing.code}
+          loading={pairing.loading}
+          error={pairing.error}
+          autoApprove={autoApprove.enabled}
+          socketStatus={socketStatus}
+          qrScanning={qrScanner.processing}
+          qrPermission={qrScanner.permission}
+          manualPairingOpen={manualPairingOpen}
+          activeMode={session.activeMode}
+          activeProvider={session.activeProvider}
+          onGatewayUrlChange={pairing.setGatewayUrl}
+          onScanQr={() => void qrScanner.openScanner()}
+          onToggleManualPairing={() => setManualPairingOpen((open) => !open)}
+          onRefreshPairing={pairing.loadPairing}
+          onPair={pairing.pair}
+          onDisconnect={pairing.disconnect}
+          onAutoApproveChange={autoApprove.setAutoApprove}
+        />
+      </ScreenFrame>
+      <QrScannerSheet
+        open={qrScanner.open}
+        processing={qrScanner.processing}
+        armed={qrScanner.armed}
+        permission={qrScanner.permission}
+        ui={pairingUi}
+        onRequestPermission={() => void qrScanner.requestPermission()}
+        onArmScanner={qrScanner.armScanner}
+        onScanned={(raw) => void qrScanner.handlePayload(raw)}
+        onCancel={qrScanner.closeScanner}
+      />
+    </View>
+  );
+}

--- a/apps/mobile/app/workflows.tsx
+++ b/apps/mobile/app/workflows.tsx
@@ -1,0 +1,24 @@
+import { ScreenFrame } from '@/components/ScreenFrame';
+import { WorkflowList } from '@/components/WorkflowList';
+import { useGatewayStore } from '@/hooks/useGatewayStore';
+import { useEffect } from 'react';
+
+export default function WorkflowsScreen() {
+  const { permissions, session, workflows } = useGatewayStore();
+  const pendingActions = permissions.pendingAsks.length + permissions.pendingPermissions.length;
+
+  useEffect(() => {
+    workflows.refresh();
+  }, [workflows.refresh]);
+
+  return (
+    <ScreenFrame
+      title="Workflows"
+      subtitle="Saved automations"
+      connected={session.connected}
+      pendingActions={pendingActions}
+    >
+      <WorkflowList workflows={workflows.workflows} onRefresh={workflows.refresh} onRun={workflows.run} />
+    </ScreenFrame>
+  );
+}

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -1,6 +1,9 @@
 module.exports = function (api) {
   api.cache(true);
   return {
-    presets: ['babel-preset-expo'],
+    presets: [
+      ['babel-preset-expo', { jsxImportSource: 'nativewind' }],
+      'nativewind/babel',
+    ],
   };
 };

--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -1,4 +1,1 @@
-import { registerRootComponent } from 'expo';
-import App from './src/App';
-
-registerRootComponent(App);
+import 'expo-router/entry';

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -6,6 +6,7 @@
 // points there), so their `.js`-authored relative specifiers resolve under
 // Metro exactly as under Node ESM.
 const { getDefaultConfig } = require('expo/metro-config');
+const { withNativeWind } = require('nativewind/metro');
 const path = require('node:path');
 
 const projectRoot = __dirname;
@@ -39,4 +40,9 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
   return resolve(context, moduleName, platform);
 };
 
-module.exports = config;
+// NativeWind last: it layers its CSS pipeline on top of the monorepo-aware
+// config above without disturbing the resolver overrides.
+module.exports = withNativeWind(config, {
+  input: './global.css',
+  typescriptEnvPath: './nativewind-env.d.ts',
+});

--- a/apps/mobile/nativewind-env.d.ts
+++ b/apps/mobile/nativewind-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="nativewind/types" />

--- a/apps/mobile/nativewind-preset.d.ts
+++ b/apps/mobile/nativewind-preset.d.ts
@@ -1,0 +1,7 @@
+// nativewind ships no types for its tailwind preset entry point.
+declare module 'nativewind/preset' {
+  import type { Config } from 'tailwindcss';
+
+  const preset: Config;
+  export default preset;
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,29 +1,51 @@
 {
   "name": "@moxxy/mobile",
   "private": true,
-  "version": "0.0.3",
-  "description": "Thin Expo (React Native) proof-of-concept that drives the moxxy chat loop through the shared @moxxy/client-core hooks over the desktop host's WebSocket bridge — proof the headless client layer runs unchanged on React Native.",
+"version": "0.0.3",
+  "description": "Expo (React Native) app that drives the moxxy chat loop through the shared @moxxy/client-core hooks over the desktop host's WebSocket bridge \u2014 expo-router + NativeWind UI on top of the headless client layer.",
   "main": "index.js",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
+    "@expo/metro-runtime": "~6.1.2",
     "@moxxy/client-core": "workspace:*",
     "@moxxy/client-transport-ws": "workspace:*",
     "@moxxy/design-tokens": "workspace:*",
+    "@moxxy/desktop-ipc-contract": "workspace:*",
     "@moxxy/sdk": "workspace:*",
     "expo": "~54.0.0",
-    "expo-camera": "~17.0.0",
-    "expo-status-bar": "~3.0.0",
+    "expo-audio": "~1.1.1",
+    "expo-camera": "~17.0.10",
+    "expo-clipboard": "~8.0.8",
+    "expo-constants": "~18.0.13",
+    "expo-document-picker": "~14.0.8",
+    "expo-file-system": "~19.0.23",
+    "expo-image-picker": "~17.0.11",
+    "expo-linking": "~8.0.12",
+    "expo-router": "~6.0.24",
+    "expo-secure-store": "~15.0.8",
+    "expo-status-bar": "~3.0.9",
+    "nativewind": "^4.2.5",
     "react": "19.1.0",
-    "react-native": "0.81.5"
+    "react-native": "0.81.5",
+    "react-native-css-interop": "^0.2.5",
+    "react-native-gesture-handler": "~2.28.0",
+    "react-native-reanimated": "~4.1.1",
+    "react-native-safe-area-context": "~5.6.2",
+    "react-native-screens": "~4.16.0",
+    "react-native-svg": "15.12.1",
+    "tailwindcss": "^3.4.19"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",
+    "@moxxy/vitest-preset": "workspace:*",
     "@types/react": "~19.1.0",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/apps/mobile/src/__tests__/clientFrames.test.ts
+++ b/apps/mobile/src/__tests__/clientFrames.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Ports the SPIRIT of the reference's mobile-client-frames tests: the builders
+ * now target the desktop IPC contract (typed `{ command, args }` frames for
+ * `MoxxyApi.invoke`) instead of raw gateway JSON, but the same intents map to
+ * the same builder names and the goal sequence keeps its strict order.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { MoxxyApi } from '@moxxy/desktop-ipc-contract';
+import {
+  buildAbortTurnFrame,
+  buildAskResponseFrame,
+  buildGoalFrames,
+  buildNewSessionFrame,
+  buildRunCommandFrame,
+  buildRunTurnFrame,
+  buildSetAutoApproveFrame,
+  buildSetModeFrame,
+  buildTranscribeFrame,
+  buildWorkflowListFrame,
+  buildWorkflowRunFrame,
+  invokeFrame,
+} from '../clientFrames';
+
+describe('mobile client frame builders', () => {
+  it('builds composer control frames with workspace context', () => {
+    expect(
+      buildRunTurnFrame({
+        workspaceId: 'workspace-1',
+        prompt: 'ship it',
+        attachments: [{ kind: 'file', name: 'notes.txt', content: 'hello' }],
+      }),
+    ).toEqual({
+      command: 'session.runTurn',
+      args: {
+        workspaceId: 'workspace-1',
+        prompt: 'ship it',
+        inlineAttachments: [{ kind: 'file', name: 'notes.txt', content: 'hello' }],
+      },
+    });
+    expect(buildAbortTurnFrame({ workspaceId: 'workspace-1', turnId: 'turn-1' })).toEqual({
+      command: 'session.abortTurn',
+      args: { workspaceId: 'workspace-1', turnId: 'turn-1' },
+    });
+    expect(buildTranscribeFrame({ audioBase64: 'AAAA', mimeType: 'audio/m4a' })).toEqual({
+      command: 'session.transcribe',
+      args: { audioBase64: 'AAAA', mimeType: 'audio/m4a' },
+    });
+  });
+
+  it('omits a null workspace and empty attachments so the host defaults apply', () => {
+    expect(buildRunTurnFrame({ workspaceId: null, prompt: 'hi', attachments: [] })).toEqual({
+      command: 'session.runTurn',
+      args: { prompt: 'hi' },
+    });
+    expect(buildNewSessionFrame({ workspaceId: null })).toEqual({
+      command: 'session.newSession',
+      args: {},
+    });
+  });
+
+  it('builds goal mode as mode switch, auto-approve, then runTurn', () => {
+    expect(buildGoalFrames({ workspaceId: 'workspace-1', objective: 'Finish the feature' })).toEqual([
+      { command: 'session.setMode', args: { workspaceId: 'workspace-1', mode: 'goal' } },
+      { command: 'session.setAutoApprove', args: { workspaceId: 'workspace-1', enabled: true } },
+      { command: 'session.runTurn', args: { workspaceId: 'workspace-1', prompt: 'Finish the feature' } },
+    ]);
+  });
+
+  it('builds ask, session, command, and auto-approve frames', () => {
+    expect(buildAskResponseFrame({ requestId: 'ask-1', response: { mode: 'allow_session' } })).toEqual({
+      command: 'ask.respond',
+      args: { requestId: 'ask-1', response: { mode: 'allow_session' } },
+    });
+    expect(buildSetAutoApproveFrame({ workspaceId: 'workspace-1', enabled: false })).toEqual({
+      command: 'session.setAutoApprove',
+      args: { workspaceId: 'workspace-1', enabled: false },
+    });
+    expect(buildSetModeFrame({ workspaceId: 'workspace-1', mode: 'research' })).toEqual({
+      command: 'session.setMode',
+      args: { workspaceId: 'workspace-1', mode: 'research' },
+    });
+    expect(buildRunCommandFrame({ workspaceId: 'workspace-1', name: 'compact', args: '--now' })).toEqual({
+      command: 'session.runCommand',
+      args: { workspaceId: 'workspace-1', name: 'compact', args: '--now' },
+    });
+  });
+
+  it('builds workflow list and run frames', () => {
+    expect(buildWorkflowListFrame()).toEqual({ command: 'workflows.list', args: undefined });
+    expect(buildWorkflowRunFrame({ name: 'codzienny-obrazek-email' })).toEqual({
+      command: 'workflows.run',
+      args: { name: 'codzienny-obrazek-email' },
+    });
+  });
+
+  it('invokeFrame dispatches the frame over the transport and returns the typed reply', async () => {
+    const invoke = vi.fn(async () => ({ turnId: 'turn-9' }));
+    const api = { invoke, subscribe: vi.fn() } as unknown as MoxxyApi;
+    const result = await invokeFrame(api, buildRunTurnFrame({ workspaceId: 'w1', prompt: 'go' }));
+    expect(result).toEqual({ turnId: 'turn-9' });
+    expect(invoke).toHaveBeenCalledWith('session.runTurn', { workspaceId: 'w1', prompt: 'go' });
+  });
+});

--- a/apps/mobile/src/__tests__/mobile-attachments.test.ts
+++ b/apps/mobile/src/__tests__/mobile-attachments.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPromptAttachment,
+  estimateBase64Bytes,
+  MAX_MOBILE_ATTACHMENT_BYTES,
+  summarizeAttachment,
+  validateAttachmentBytes,
+} from '../attachments';
+
+describe('mobile prompt attachments', () => {
+  it('builds image, document, and text attachments in the SDK prompt format', () => {
+    expect(buildPromptAttachment({
+      content: 'AQID',
+      mediaType: 'image/png',
+      name: 'screen.png',
+    })).toEqual({
+      kind: 'image',
+      content: 'AQID',
+      mediaType: 'image/png',
+      name: 'screen.png',
+    });
+
+    expect(buildPromptAttachment({
+      content: 'JVBERi0=',
+      mediaType: 'application/pdf',
+      name: 'report.pdf',
+    })).toEqual({
+      kind: 'document',
+      content: 'JVBERi0=',
+      mediaType: 'application/pdf',
+      name: 'report.pdf',
+    });
+
+    expect(buildPromptAttachment({
+      content: 'hello from phone',
+      mediaType: 'text/plain',
+      name: 'notes.txt',
+      text: true,
+    })).toEqual({
+      kind: 'file',
+      content: 'hello from phone',
+      name: 'notes.txt',
+      mediaType: 'text/plain',
+    });
+  });
+
+  it('estimates base64 payload size and blocks oversized inline uploads', () => {
+    expect(estimateBase64Bytes('AQID')).toBe(3);
+    expect(validateAttachmentBytes({ name: 'ok.png', bytes: 1024 })).toBeNull();
+    expect(validateAttachmentBytes({ name: 'huge.mov', bytes: 9 * 1024 * 1024 })).toContain('huge.mov');
+  });
+
+  it('caps inline mobile attachments at 8 MB', () => {
+    expect(MAX_MOBILE_ATTACHMENT_BYTES).toBe(8 * 1024 * 1024);
+    expect(validateAttachmentBytes({ name: 'edge.bin', bytes: MAX_MOBILE_ATTACHMENT_BYTES })).toBeNull();
+    expect(validateAttachmentBytes({ name: 'edge.bin', bytes: MAX_MOBILE_ATTACHMENT_BYTES + 1 })).toContain('8 MB');
+  });
+
+  it('summarizes chips for the composer without leaking base64 content', () => {
+    expect(summarizeAttachment({
+      kind: 'image',
+      content: 'AQID',
+      mediaType: 'image/png',
+      name: 'screen.png',
+    })).toEqual({
+      label: 'screen.png',
+      detail: 'Image',
+    });
+  });
+});

--- a/apps/mobile/src/__tests__/mobile-auto-approve-state.test.ts
+++ b/apps/mobile/src/__tests__/mobile-auto-approve-state.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAutoApproveState } from '../autoApproveState';
+
+describe('mobile auto-approve ui state', () => {
+  it('uses optimistic value immediately after the user toggles bypass mode', () => {
+    expect(resolveAutoApproveState({ upstream: false, optimistic: true })).toBe(true);
+    expect(resolveAutoApproveState({ upstream: true, optimistic: false })).toBe(false);
+  });
+
+  it('falls back to upstream snapshot when there is no optimistic value', () => {
+    expect(resolveAutoApproveState({ upstream: false, optimistic: null })).toBe(false);
+    expect(resolveAutoApproveState({ upstream: true, optimistic: null })).toBe(true);
+  });
+});

--- a/apps/mobile/src/__tests__/mobile-chat-messages.test.ts
+++ b/apps/mobile/src/__tests__/mobile-chat-messages.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { buildChatMessage } from '../chatMessages';
+
+describe('mobile chat message model', () => {
+  it('normalizes desktop-like user and assistant events', () => {
+    expect(buildChatMessage({ type: 'user_prompt', text: 'Build the plugin' })).toEqual({
+      kind: 'user',
+      label: null,
+      text: 'Build the plugin',
+    });
+
+    expect(buildChatMessage({ role: 'assistant', content: 'Done.' })).toEqual({
+      kind: 'assistant',
+      label: 'Assistant',
+      text: 'Done.',
+    });
+  });
+
+  it('keeps runtime events readable instead of dumping raw JSON', () => {
+    expect(buildChatMessage({ type: 'tool_call_requested', name: 'Read', path: '/tmp/a.ts' })).toEqual({
+      kind: 'tool',
+      label: 'Tool call',
+      text: 'Read',
+    });
+
+    expect(buildChatMessage({ type: 'unknown_event', nested: { noisy: true } })).toEqual({
+      kind: 'system',
+      label: 'unknown_event',
+      text: 'Event received',
+    });
+  });
+});

--- a/apps/mobile/src/__tests__/mobile-chat-transcript.test.ts
+++ b/apps/mobile/src/__tests__/mobile-chat-transcript.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import { buildChatTranscript } from '../chatTranscript';
+
+describe('mobile chat transcript model', () => {
+  it('folds streamed assistant chunks into one assistant message instead of event cards', () => {
+    const transcript = buildChatTranscript([
+      { id: 'u1', type: 'user_prompt', text: 'Powiedz OK' },
+      { id: 'c1', type: 'assistant_chunk', delta: 'O' },
+      { id: 'c2', type: 'assistant_chunk', delta: 'K' },
+      { id: 'pr1', type: 'provider_response', usage: { inputTokens: 10 } },
+    ]);
+
+    expect(transcript).toEqual([
+      { id: 'u1', kind: 'user', text: 'Powiedz OK' },
+      { id: 'assistant-stream:c1', kind: 'assistant', label: 'Assistant', text: 'OK', streaming: true },
+    ]);
+  });
+
+  it('treats event type as the source of truth when assistant chunks also carry a role', () => {
+    const transcript = buildChatTranscript([
+      { id: 'u1', type: 'user_prompt', text: 'Pisz' },
+      { id: 'c1', type: 'assistant_chunk', role: 'assistant', delta: 'Live ' },
+      { id: 'c2', type: 'assistant_chunk', role: 'assistant', delta: 'tekst' },
+    ]);
+
+    expect(transcript).toEqual([
+      { id: 'u1', kind: 'user', text: 'Pisz' },
+      { id: 'assistant-stream:c1', kind: 'assistant', label: 'Assistant', text: 'Live tekst', streaming: true },
+    ]);
+  });
+
+  it('uses the final assistant_message as the committed response and hides provider bookkeeping', () => {
+    const transcript = buildChatTranscript([
+      { id: 'u1', type: 'user_prompt', text: 'Powiedz OK' },
+      { id: 'c1', type: 'assistant_chunk', delta: 'O' },
+      { id: 'c2', type: 'assistant_chunk', delta: 'K' },
+      { id: 'pr1', type: 'provider_response', usage: { inputTokens: 10 } },
+      { id: 'a1', type: 'assistant_message', content: 'OK', stopReason: 'end_turn' },
+    ]);
+
+    expect(transcript).toEqual([
+      { id: 'u1', kind: 'user', text: 'Powiedz OK' },
+      { id: 'a1', kind: 'assistant', label: 'Assistant', text: 'OK', streaming: false, stopReason: 'end_turn' },
+    ]);
+  });
+
+  it('keeps user prompt attachments available for rendering in the chat', () => {
+    const transcript = buildChatTranscript([
+      {
+        id: 'u1',
+        type: 'user_prompt',
+        text: 'Przeanalizuj',
+        attachments: [
+          { kind: 'image', content: 'AQID', mediaType: 'image/png', name: 'screen.png' },
+        ],
+      },
+    ]);
+
+    expect(transcript).toEqual([
+      {
+        id: 'u1',
+        kind: 'user',
+        text: 'Przeanalizuj',
+        attachments: [
+          { kind: 'image', content: 'AQID', mediaType: 'image/png', name: 'screen.png' },
+        ],
+      },
+    ]);
+  });
+
+  it('collapses runtime tool events into one closed tool group by default', () => {
+    const transcript = buildChatTranscript([
+      { id: 'u1', type: 'user_prompt', text: 'Sprawdź pliki' },
+      { id: 't1', type: 'tool_call_requested', callId: 'call-1', name: 'Read', input: { path: 'a.ts' } },
+      { id: 't2', type: 'tool_result', callId: 'call-1', output: 'ok' },
+      { id: 't3', type: 'tool_call_requested', callId: 'call-2', name: 'Bash', input: { command: 'pwd' } },
+    ]);
+
+    expect(transcript).toEqual([
+      { id: 'u1', kind: 'user', text: 'Sprawdź pliki' },
+      {
+        id: 'tools:call-1',
+        kind: 'tool-group',
+        title: 'Tools',
+        collapsed: true,
+        summary: '1 ok · 1 running',
+        tools: [
+          { id: 'call-1', name: 'Read', status: 'ok', summary: 'path: a.ts' },
+          { id: 'call-2', name: 'Bash', status: 'running', summary: 'command: pwd' },
+        ],
+      },
+    ]);
+  });
+
+  it('keeps running and failed tool states visible from mixed lifecycle events', () => {
+    const transcript = buildChatTranscript([
+      { id: 'u1', type: 'user_prompt', text: 'Sprawdź' },
+      { id: 't1', type: 'tool_call_requested', callId: 'call-running', name: 'Read', input: { path: 'a.ts' } },
+      { id: 't2', type: 'tool_call_requested', callId: 'call-error', name: 'Bash', input: { command: 'bad' } },
+      { id: 't3', type: 'tool_result', callId: 'call-error', error: { message: 'boom', kind: 'threw' } },
+      { id: 't4', type: 'tool_call_requested', callId: 'call-is-error', name: 'Fetch', input: { url: 'https://example.com' } },
+      { id: 't5', type: 'tool_result', callId: 'call-is-error', isError: true, output: 'failed' },
+    ]);
+
+    expect(transcript).toEqual([
+      { id: 'u1', kind: 'user', text: 'Sprawdź' },
+      {
+        id: 'tools:call-running',
+        kind: 'tool-group',
+        title: 'Tools',
+        collapsed: true,
+        summary: '2 failed · 1 running',
+        tools: [
+          { id: 'call-running', name: 'Read', status: 'running', summary: 'path: a.ts' },
+          { id: 'call-error', name: 'Bash', status: 'error', summary: 'command: bad' },
+          { id: 'call-is-error', name: 'Fetch', status: 'error', summary: 'url: https://example.com' },
+        ],
+      },
+    ]);
+  });
+
+  it('pairs bridge-style tool ids with their results', () => {
+    const transcript = buildChatTranscript([
+      { id: 'u1', type: 'user_prompt', text: 'Sprawdź' },
+      { id: 't1', type: 'tool_call_requested', toolUseId: 'bridge-call', name: 'Read', input: { path: 'a.ts' } },
+      { id: 't2', type: 'tool_result', toolUseId: 'bridge-call', ok: true, output: 'ok' },
+    ]);
+
+    expect(transcript).toEqual([
+      { id: 'u1', kind: 'user', text: 'Sprawdź' },
+      {
+        id: 'tools:bridge-call',
+        kind: 'tool-group',
+        title: 'Tools',
+        collapsed: true,
+        summary: '1 ok',
+        tools: [
+          { id: 'bridge-call', name: 'Read', status: 'ok', summary: 'path: a.ts' },
+        ],
+      },
+    ]);
+  });
+
+  it('keeps one tool group when a skill event arrives between request and result', () => {
+    const transcript = buildChatTranscript([
+      { id: 'u1', type: 'user_prompt', text: 'Użyj skilla imagegen' },
+      { id: 't1', type: 'tool_call_requested', callId: 'call-1', name: 'Bash', input: { command: 'pwd' } },
+      { id: 's1', type: 'skill_invoked', title: 'imagegen', text: 'Using image generation skill' },
+      { id: 't2', type: 'tool_call_approved', callId: 'call-1', name: 'Bash' },
+      { id: 't3', type: 'tool_result', callId: 'call-1', ok: true, output: 'ok' },
+    ]);
+
+    const toolGroups = transcript.filter((item) => item.kind === 'tool-group');
+
+    expect(new Set(transcript.map((item) => item.id)).size).toBe(transcript.length);
+    expect(toolGroups).toEqual([
+      {
+        id: 'tools:call-1',
+        kind: 'tool-group',
+        title: 'Tools',
+        collapsed: true,
+        summary: '1 ok',
+        tools: [
+          { id: 'call-1', name: 'Bash', status: 'ok', summary: 'command: pwd' },
+        ],
+      },
+    ]);
+  });
+});

--- a/apps/mobile/src/__tests__/mobile-composer-ui.test.ts
+++ b/apps/mobile/src/__tests__/mobile-composer-ui.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { buildComposerUiState } from '../composerUi';
+
+describe('mobile composer ui model', () => {
+  it('mirrors the desktop composer affordances for an editable draft', () => {
+    expect(buildComposerUiState({
+      text: 'ship it',
+      sending: false,
+      compacting: false,
+      actionsOpen: false,
+      autoApprove: false,
+    })).toMatchObject({
+      placeholder: 'Send a message to the agent...',
+      canSubmit: true,
+      sendIcon: 'send',
+      sendTone: 'primary',
+      actionsTone: 'neutral',
+      disabled: false,
+    });
+  });
+
+  it('allows sending an attachment without forcing a text draft', () => {
+    expect(buildComposerUiState({
+      text: '',
+      attachmentCount: 1,
+      sending: false,
+      compacting: false,
+      actionsOpen: false,
+      autoApprove: false,
+    })).toMatchObject({
+      canSubmit: true,
+      sendTone: 'primary',
+      disabled: false,
+    });
+  });
+
+  it('locks the prompt and swaps the primary action while compacting or sending', () => {
+    expect(buildComposerUiState({
+      text: 'ship it',
+      sending: false,
+      compacting: true,
+      actionsOpen: false,
+      autoApprove: false,
+    })).toMatchObject({
+      placeholder: 'Compacting context...',
+      canSubmit: false,
+      disabled: true,
+    });
+
+    expect(buildComposerUiState({
+      text: '',
+      sending: true,
+      compacting: false,
+      actionsOpen: true,
+      autoApprove: true,
+    })).toMatchObject({
+      sendIcon: 'stop',
+      sendTone: 'danger',
+      actionsTone: 'active',
+    });
+  });
+
+  it('shows recording and transcribing feedback while voice input is active', () => {
+    expect(buildComposerUiState({
+      text: '',
+      sending: false,
+      compacting: false,
+      actionsOpen: false,
+      autoApprove: true,
+      voicePhase: 'recording',
+    })).toMatchObject({
+      statusLabel: 'Listening...',
+      voiceLabel: 'Stop',
+      voiceTone: 'recording',
+      actionsTone: 'active',
+    });
+
+    expect(buildComposerUiState({
+      text: '',
+      sending: false,
+      compacting: false,
+      actionsOpen: false,
+      autoApprove: false,
+      voicePhase: 'transcribing',
+    })).toMatchObject({
+      statusLabel: 'Transcribing...',
+      disabled: true,
+      voiceLabel: 'Transcribing',
+      voiceTone: 'transcribing',
+    });
+  });
+
+  it('moves bypass feedback from a text badge into the composer frame state', () => {
+    expect(buildComposerUiState({
+      text: '',
+      sending: false,
+      compacting: false,
+      actionsOpen: false,
+      autoApprove: true,
+    })).toMatchObject({
+      statusLabel: null,
+      bypassActive: true,
+      frameTone: 'bypass',
+      actionsTone: 'active',
+    });
+  });
+
+  it('locks composer while browsing an archived session', () => {
+    expect(buildComposerUiState({
+      text: 'continue',
+      sending: false,
+      compacting: false,
+      actionsOpen: false,
+      autoApprove: false,
+      readOnly: true,
+    })).toMatchObject({
+      placeholder: 'Archived session - select the live session to send.',
+      canSubmit: false,
+      disabled: true,
+      sendTone: 'disabled',
+    });
+  });
+});

--- a/apps/mobile/src/__tests__/mobile-console-filters.test.ts
+++ b/apps/mobile/src/__tests__/mobile-console-filters.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { shouldIgnoreConsoleMessage } from '../consoleFilters';
+
+describe('mobile console filters', () => {
+  it('filters the React Native Web pointerEvents deprecation warning', () => {
+    expect(shouldIgnoreConsoleMessage('props.pointerEvents is deprecated. Use style.pointerEvents')).toBe(true);
+  });
+
+  it('does not filter unrelated warnings', () => {
+    expect(shouldIgnoreConsoleMessage('Something else happened')).toBe(false);
+  });
+});

--- a/apps/mobile/src/__tests__/mobile-context-meter-ui.test.ts
+++ b/apps/mobile/src/__tests__/mobile-context-meter-ui.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { buildContextMeterUiState } from '../contextMeterUi';
+
+describe('mobile context meter ui model', () => {
+  it('mirrors the desktop context percentage calculation', () => {
+    expect(buildContextMeterUiState({
+      latestPrompt: 1024,
+      contextWindow: 20_480,
+    })).toMatchObject({
+      visible: true,
+      label: '5%',
+      fraction: 0.05,
+      fillPercent: 5,
+      tone: 'primary',
+    });
+  });
+
+  it('uses desktop warning thresholds for the context fill color', () => {
+    expect(buildContextMeterUiState({ latestPrompt: 7_000, contextWindow: 10_000 })).toMatchObject({
+      label: '70%',
+      tone: 'amber',
+    });
+    expect(buildContextMeterUiState({ latestPrompt: 9_000, contextWindow: 10_000 })).toMatchObject({
+      label: '90%',
+      tone: 'red',
+    });
+  });
+
+  it('hides the percent meter until the model context window is known', () => {
+    expect(buildContextMeterUiState({ latestPrompt: 1024, contextWindow: null })).toEqual({
+      visible: false,
+      label: 'Context',
+      fraction: null,
+      fillPercent: 0,
+      tone: 'neutral',
+    });
+  });
+});

--- a/apps/mobile/src/__tests__/mobile-message-actions.test.ts
+++ b/apps/mobile/src/__tests__/mobile-message-actions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { buildMessageActions } from '../messageActions';
+
+describe('mobile message actions', () => {
+  it('allows copying user and assistant message text', () => {
+    expect(buildMessageActions({ id: 'u1', kind: 'user', text: 'Cześć' })).toEqual({
+      copyText: 'Cześć',
+    });
+
+    expect(buildMessageActions({
+      id: 'a1',
+      kind: 'assistant',
+      label: 'Assistant',
+      text: 'Gotowe.',
+      streaming: false,
+    })).toEqual({
+      copyText: 'Gotowe.',
+    });
+  });
+
+  it('does not expose copy actions for empty or technical transcript blocks', () => {
+    expect(buildMessageActions({ id: 'u1', kind: 'user', text: '   ' })).toEqual({});
+    expect(buildMessageActions({
+      id: 'tools:t1',
+      kind: 'tool-group',
+      title: 'Tools',
+      collapsed: true,
+      summary: '1 ok',
+      tools: [{ id: 't1', name: 'Read', status: 'ok', summary: 'path: a.ts' }],
+    })).toEqual({});
+  });
+});

--- a/apps/mobile/src/__tests__/mobile-navigation.test.ts
+++ b/apps/mobile/src/__tests__/mobile-navigation.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBottomTabs,
+  buildComposerAttachmentActionItems,
+  applyWorkspaceCollapseToggles,
+  buildMobileMenuItems,
+  buildInitialCollapsedWorkspaceIds,
+  buildQuickActionItems,
+  buildRecentMenuSessions,
+  buildReturnToChatAction,
+  buildWorkspaceMenuSections,
+  filterRecentMenuSessions,
+  filterWorkspaceMenuSections,
+} from '../navigation';
+
+describe('mobile bottom navigation model', () => {
+  it('keeps the mobile tab bar compact, icon-led, and badge-aware', () => {
+    const tabs = buildBottomTabs(3);
+
+    expect(tabs).toHaveLength(5);
+    expect(tabs.map((tab) => tab.label)).toEqual(['Chat', 'Sessions', 'Actions', 'Goals', 'Settings']);
+    expect(tabs.map((tab) => tab.href)).toEqual(['/chat', '/sessions', '/permissions', '/goals', '/settings']);
+    expect(tabs.map((tab) => tab.icon)).toEqual(['message', 'sessions', 'actions', 'goals', 'settings']);
+    expect(tabs.find((tab) => tab.label === 'Actions')).toMatchObject({ badge: '3' });
+  });
+
+  it('does not render an empty actions badge', () => {
+    expect(buildBottomTabs(0).find((tab) => tab.label === 'Actions')?.badge).toBeNull();
+  });
+});
+
+describe('mobile chat chrome navigation model', () => {
+  it('keeps hamburger menu focused on full-screen app areas, not composer actions', () => {
+    const items = buildMobileMenuItems(2);
+
+    expect(items.map((item) => item.label)).toEqual(['Workflows', 'Settings', 'Gateway']);
+    expect(items.map((item) => item.icon)).toEqual(['workflows', 'settings', 'gateway']);
+    expect(items.map((item) => item.kind)).toEqual(['link', 'link', 'link']);
+    expect(items.find((item) => item.label === 'Workflows')).toMatchObject({ href: '/workflows' });
+    expect(items.map((item) => item.href)).not.toContain('/sessions');
+    expect(items.map((item) => item.label)).not.toContain('Sessions');
+    expect(items.map((item) => item.label)).not.toContain('Actions');
+    expect(items.map((item) => item.label)).not.toContain('Goals');
+  });
+
+  it('keeps the composer plus menu focused on runtime actions', () => {
+    const items = buildQuickActionItems(true);
+
+    expect(items.map((item) => item.id)).toEqual(['goal', 'autoApprove', 'compact', 'newSession']);
+    expect(items.map((item) => item.icon)).toEqual(['goals', 'bolt', 'actions', 'plus']);
+    expect(items.find((item) => item.id === 'autoApprove')).toMatchObject({
+      active: true,
+      label: 'Auto-approve ON',
+    });
+    expect(items.find((item) => item.id === 'compact')).toMatchObject({
+      id: 'compact',
+      label: 'Compact context',
+      requiresConfirmation: true,
+    });
+  });
+
+  it('keeps composer attachment actions short and leaves image paste to the input paste flow', () => {
+    const items = buildComposerAttachmentActionItems();
+
+    expect(items.map((item) => item.id)).toEqual(['attachImage', 'attachFile']);
+    expect(items.map((item) => item.label)).toEqual(['Photo or screenshot', 'File from phone']);
+    expect(items.map((item) => item.label)).not.toContain('Paste image');
+  });
+
+  it('builds a compact recent-session list for the full-screen hamburger menu', () => {
+    const sessions = buildRecentMenuSessions([
+      { id: 'live', name: 'new_moxxy', cwd: '/repo', eventCount: 0, live: true, readOnly: false },
+      { id: 'old-1', firstPrompt: 'Odpowiedz jednym słowem: OK', cwd: '/repo', eventCount: 12, live: false, readOnly: true },
+      { id: 'empty', name: 'new_moxxy', cwd: '/repo', eventCount: 0, live: false, readOnly: true },
+      { id: 'old-2', firstPrompt: 'Plan żywieniowy na dzień', cwd: '/diet', eventCount: 250, live: false, readOnly: true },
+    ], 'live', 2);
+
+    expect(sessions).toEqual([
+      expect.objectContaining({ id: 'live', title: 'new_moxxy', active: true, live: true, statusLabel: 'Active' }),
+      expect.objectContaining({ id: 'old-1', title: 'Odpowiedz jednym słowem: OK', active: false, live: false, statusLabel: null }),
+    ]);
+    expect(sessions.map((session) => session.id)).not.toContain('empty');
+  });
+
+  it('does not double-label live sessions in the hamburger menu', () => {
+    const sessions = buildRecentMenuSessions([
+      { id: 'live', name: 'new_moxxy', cwd: '/repo', eventCount: 0, live: true, readOnly: false },
+      { id: 'hydrated', firstPrompt: 'Hydrated session', cwd: '/repo', eventCount: 42, live: true, readOnly: false },
+    ], 'hydrated');
+
+    expect(sessions).toEqual([
+      expect.objectContaining({ id: 'live', dotTone: 'muted', statusLabel: null }),
+      expect.objectContaining({ id: 'hydrated', dotTone: 'active', statusLabel: 'Active' }),
+    ]);
+  });
+
+  it('filters recent sessions by title and workspace path', () => {
+    const sessions = buildRecentMenuSessions([
+      { id: 'diet', firstPrompt: 'Plan żywieniowy na dzień', cwd: '/Users/kamil/diet', eventCount: 20 },
+      { id: 'car', firstPrompt: 'BYD Sealion hotspot', cwd: '/Users/kamil/cars', eventCount: 8 },
+      { id: 'codex', firstPrompt: 'Moxxy mobile gateway', cwd: '/Users/kamil/new_moxxy', eventCount: 32 },
+    ], null);
+
+    expect(filterRecentMenuSessions(sessions, 'byd').map((session) => session.id)).toEqual(['car']);
+    expect(filterRecentMenuSessions(sessions, 'new_moxxy').map((session) => session.id)).toEqual(['codex']);
+    expect(filterRecentMenuSessions(sessions, '  ').map((session) => session.id)).toEqual(['diet', 'car', 'codex']);
+  });
+
+  it('lets the hamburger menu render every visible session when no limit is supplied', () => {
+    const sessions = Array.from({ length: 18 }, (_, index) => ({
+      id: `session-${index}`,
+      firstPrompt: `Prompt ${index}`,
+      cwd: '/repo',
+      eventCount: index + 1,
+      live: false,
+      readOnly: true,
+    }));
+
+    expect(buildRecentMenuSessions(sessions, null)).toHaveLength(18);
+  });
+
+  it('groups hamburger menu sessions under real desktop workspaces and puts unmatched sessions in Others', () => {
+    const sections = buildWorkspaceMenuSections([
+      {
+        id: 'desk-moxxy',
+        name: 'moxxy workspace',
+        cwd: '/Users/kamil/Downloads/moxxy workspace',
+        color: '#3b82f6',
+      },
+      {
+        id: 'desk-tata',
+        name: 'Tata',
+        cwd: '/Users/kamil/Downloads/Tata',
+        color: '#ef4444',
+      },
+    ], [
+      {
+        id: 'older',
+        firstPrompt: 'Przeanalizuj aplikację',
+        cwd: '/Users/kamil/Downloads/Tata',
+        eventCount: 10,
+        lastActivity: '2026-06-08T08:00:00.000Z',
+      },
+      {
+        id: 'active',
+        firstPrompt: 'Przeanalizuj strukturę aplikacji',
+        cwd: '/Users/kamil/Downloads/moxxy workspace',
+        eventCount: 40,
+        lastActivity: '2026-06-09T07:00:00.000Z',
+      },
+      {
+        id: 'unmatched',
+        firstPrompt: 'Stwórz viralowy film 9:16',
+        cwd: '/Users/kamil/new_moxxy',
+        eventCount: 12,
+        lastActivity: '2026-06-08T19:00:00.000Z',
+      },
+    ], 'active');
+
+    expect(sections).toEqual([
+      expect.objectContaining({
+        id: 'desk-moxxy',
+        title: 'moxxy workspace',
+        color: '#3b82f6',
+        active: true,
+        sessions: [
+          expect.objectContaining({ id: 'active', active: true, shortcutLabel: null }),
+        ],
+      }),
+      expect.objectContaining({
+        id: 'desk-tata',
+        title: 'Tata',
+        active: false,
+        sessions: [
+          expect.objectContaining({ id: 'older', shortcutLabel: null }),
+        ],
+      }),
+      expect.objectContaining({
+        id: 'others',
+        title: 'Others',
+        active: false,
+        sessions: [
+          expect.objectContaining({ id: 'unmatched', shortcutLabel: null }),
+        ],
+      }),
+    ]);
+    expect(sections.map((section) => section.title)).not.toContain('new_moxxy');
+  });
+
+  it('filters workspace menu sections by workspace title, path, and session title', () => {
+    const sections = buildWorkspaceMenuSections([
+      {
+        id: 'desk-tata',
+        name: 'Tata',
+        cwd: '/Users/kamil/Downloads/Tata',
+        color: '#ef4444',
+      },
+    ], [
+      { id: 'diet', firstPrompt: 'Plan żywieniowy na dzień', cwd: '/Users/kamil/feed-the-beast', eventCount: 20 },
+      { id: 'tata', firstPrompt: 'Syrop z kwiatów czarnego bzu', cwd: '/Users/kamil/Downloads/Tata', eventCount: 32 },
+    ], null);
+
+    expect(filterWorkspaceMenuSections(sections, 'feed').map((section) => section.id)).toEqual(['others']);
+    expect(filterWorkspaceMenuSections(sections, 'Tata').map((section) => section.sessions.map((session) => session.id))).toEqual([
+      ['tata'],
+    ]);
+    expect(filterWorkspaceMenuSections(sections, '  ').flatMap((section) => section.sessions.map((session) => session.id))).toEqual([
+      'tata',
+      'diet',
+    ]);
+  });
+
+  it('collapses overflow workspace sections while keeping the active workspace visible', () => {
+    const sections = Array.from({ length: 6 }, (_, index) => ({
+      id: `workspace-${index + 1}`,
+      title: `Workspace ${index + 1}`,
+      subtitle: `/workspace-${index + 1}`,
+      color: '#ec4899',
+      active: index === 4,
+      latestActivity: `2026-06-09T0${index}:00:00.000Z`,
+      sessions: [
+        {
+          id: `session-${index + 1}`,
+          title: `Session ${index + 1}`,
+          subtitle: `/workspace-${index + 1}`,
+          active: index === 4,
+          live: index === 4,
+          readOnly: false,
+          lastActivity: `2026-06-09T0${index}:00:00.000Z`,
+          shortcutLabel: null,
+        },
+      ],
+    }));
+
+    expect(buildInitialCollapsedWorkspaceIds(sections, 3)).toEqual(['workspace-3', 'workspace-4', 'workspace-6']);
+  });
+
+  it('collapses workspace sections with too many sessions even when the workspace list is short', () => {
+    const sections = [
+      workspaceSection('moxxy', 8, false),
+      workspaceSection('tata', 1, false),
+      workspaceSection('others', 75, false),
+      workspaceSection('active-heavy', 80, true),
+    ];
+
+    expect(buildInitialCollapsedWorkspaceIds(sections, 4)).toEqual(['others', 'active-heavy']);
+  });
+
+  it('keeps manual workspace collapse changes as toggles over the latest defaults', () => {
+    expect(applyWorkspaceCollapseToggles(['others', 'archive'], ['others', 'tata'])).toEqual([
+      'archive',
+      'tata',
+    ]);
+  });
+});
+
+function workspaceSection(id: string, sessionCount: number, active: boolean) {
+  return {
+    id,
+    title: id,
+    subtitle: `/${id}`,
+    color: '#ec4899',
+    active,
+    latestActivity: '2026-06-09T09:00:00.000Z',
+    sessions: Array.from({ length: sessionCount }, (_, index) => ({
+      id: `${id}-${index}`,
+      title: `${id} ${index}`,
+      subtitle: `/${id}`,
+      active: false,
+      live: false,
+      readOnly: true,
+      lastActivity: '2026-06-09T09:00:00.000Z',
+      shortcutLabel: null,
+    })),
+  };
+}
+
+describe('mobile auxiliary screen navigation', () => {
+  it('keeps a direct escape hatch back to chat from non-chat screens', () => {
+    expect(buildReturnToChatAction()).toEqual({
+      href: '/chat',
+      label: 'Chat',
+      icon: 'message',
+    });
+  });
+});

--- a/apps/mobile/src/__tests__/mobile-pairing-url.test.ts
+++ b/apps/mobile/src/__tests__/mobile-pairing-url.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { chooseGatewayUrlForPairing, deriveGatewayUrlFromExpoHost, normalizeGatewayUrl } from '../pairingUrl';
+import { parsePairingQrPayload } from '../pairingQr';
+import { splitConnectUrl } from '../boot';
+
+describe('mobile pairing bridge url', () => {
+  it('derives the bridge URL from the Expo Metro LAN host', () => {
+    expect(deriveGatewayUrlFromExpoHost('192.168.1.44:8081')).toBe('ws://192.168.1.44:8765');
+    expect(deriveGatewayUrlFromExpoHost('exp://10.0.0.8:8081')).toBe('ws://10.0.0.8:8765');
+  });
+
+  it('falls back to localhost only when the Expo host is unavailable', () => {
+    expect(deriveGatewayUrlFromExpoHost(null)).toBe('ws://127.0.0.1:8765');
+  });
+
+  it('normalizes manually entered bridge URLs to bare ws:// targets', () => {
+    expect(normalizeGatewayUrl('192.168.1.44:8765')).toBe('ws://192.168.1.44:8765');
+    expect(normalizeGatewayUrl('192.168.1.44')).toBe('ws://192.168.1.44:8765');
+    expect(normalizeGatewayUrl('ws://192.168.1.44:8765/')).toBe('ws://192.168.1.44:8765');
+    expect(normalizeGatewayUrl('ws://192.168.1.44:8765/?t=secret')).toBe('ws://192.168.1.44:8765');
+  });
+
+  it('maps pasted http(s) tunnel URLs onto the WebSocket schemes', () => {
+    expect(normalizeGatewayUrl('https://abc.trycloudflare.com')).toBe('wss://abc.trycloudflare.com');
+    expect(normalizeGatewayUrl('http://192.168.1.44:8765')).toBe('ws://192.168.1.44:8765');
+    expect(normalizeGatewayUrl('wss://abc.trycloudflare.com/?t=tok')).toBe('wss://abc.trycloudflare.com');
+  });
+
+  it('recovers the latest valid URL from a duplicated manual entry', () => {
+    expect(normalizeGatewayUrl('ws://wsws127.0.0.1:9999ws://127.0.0.1:8765')).toBe('ws://127.0.0.1:8765');
+  });
+
+  it('replaces a stored loopback URL when Expo exposes a LAN host', () => {
+    expect(chooseGatewayUrlForPairing('ws://127.0.0.1:8765', '192.168.1.44:8081')).toBe('ws://192.168.1.44:8765');
+    expect(chooseGatewayUrlForPairing('ws://localhost:8765', '192.168.1.44:8081')).toBe('ws://192.168.1.44:8765');
+    expect(chooseGatewayUrlForPairing('ws://10.0.0.2:8765', '192.168.1.44:8081')).toBe('ws://10.0.0.2:8765');
+  });
+});
+
+describe('mobile pairing QR payload', () => {
+  it('parses the channel QR (connect URL with an embedded ?t= token)', () => {
+    expect(parsePairingQrPayload('ws://192.168.1.7:8765/?t=s3cret')).toEqual({
+      gatewayUrl: 'ws://192.168.1.7:8765',
+      token: 's3cret',
+    });
+    expect(parsePairingQrPayload('wss://abc.trycloudflare.com/?t=tok%2Bx')).toEqual({
+      gatewayUrl: 'wss://abc.trycloudflare.com',
+      token: 'tok+x',
+    });
+  });
+
+  it('parses a tokenless connect URL (manual token entry follows)', () => {
+    expect(parsePairingQrPayload('ws://192.168.1.7:8765')).toEqual({
+      gatewayUrl: 'ws://192.168.1.7:8765',
+      token: null,
+    });
+  });
+
+  it('rejects QR payloads that are not Moxxy connect URLs', () => {
+    expect(() => parsePairingQrPayload('not-a-url')).toThrow('Invalid Moxxy pairing QR code');
+    expect(() => parsePairingQrPayload(JSON.stringify({
+      type: 'moxxy-mobile-gateway',
+      version: 1,
+      url: 'http://192.168.1.44:17902/mobile/v1',
+      code: '123456',
+    }))).toThrow('Invalid Moxxy pairing QR code');
+  });
+
+  it('agrees with the boot-time splitter on what the live WS URL is', () => {
+    const scanned = 'ws://192.168.1.7:8765/?t=s3cret';
+    const parsed = parsePairingQrPayload(scanned);
+    const split = splitConnectUrl(scanned);
+    expect(parsed.token).toBe(split.token);
+    expect(normalizeGatewayUrl(split.url)).toBe(parsed.gatewayUrl);
+  });
+});

--- a/apps/mobile/src/__tests__/mobile-qr-scan-gate.test.ts
+++ b/apps/mobile/src/__tests__/mobile-qr-scan-gate.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { createQrScanGate } from '../qrScanGate';
+
+describe('mobile QR scan gate', () => {
+  it('stays idle until the user arms scanning and then accepts only one QR payload', () => {
+    const gate = createQrScanGate();
+
+    expect(gate.tryAcquire()).toBe(false);
+
+    gate.arm();
+
+    expect(gate.tryAcquire()).toBe(true);
+    expect(gate.tryAcquire()).toBe(false);
+
+    gate.reset();
+
+    expect(gate.tryAcquire()).toBe(false);
+  });
+
+  it('does not scan automatically before the explicit scan action', async () => {
+    const gate = createQrScanGate();
+    const scanned: string[] = [];
+
+    async function handleScan(raw: string) {
+      if (!gate.tryAcquire()) return;
+      scanned.push(raw);
+    }
+
+    await handleScan('payload-1');
+    gate.arm();
+    await handleScan('payload-1');
+    await handleScan('payload-1');
+
+    expect(scanned).toEqual(['payload-1']);
+  });
+});

--- a/apps/mobile/src/__tests__/mobile-socket-lifecycle.test.ts
+++ b/apps/mobile/src/__tests__/mobile-socket-lifecycle.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { buildConnectionUi, shouldOfferRepair } from '../socketLifecycle';
+
+// The transport (`WsRpcClient`) owns reconnect/backoff, so the lifecycle
+// module reduces to status → UI projection. These tests pin the user-facing
+// contract per `WsClientStatus`.
+describe('mobile socket lifecycle ui', () => {
+  it('keeps the chat quiet while the socket is open', () => {
+    expect(buildConnectionUi('open')).toMatchObject({
+      tone: 'ok',
+      showBanner: false,
+      canSend: true,
+      shouldOfferRepair: false,
+    });
+  });
+
+  it('shows a pending banner during initial connect and transport-owned reconnects', () => {
+    expect(buildConnectionUi('connecting')).toMatchObject({
+      label: 'Connecting...',
+      tone: 'pending',
+      showBanner: true,
+      canSend: false,
+    });
+    expect(buildConnectionUi('reconnecting')).toMatchObject({
+      label: 'Reconnecting...',
+      tone: 'pending',
+      showBanner: true,
+      shouldOfferRepair: false,
+    });
+  });
+
+  it('offers re-pairing only for the terminal disconnect (reconnect budget exhausted)', () => {
+    expect(buildConnectionUi('disconnected')).toMatchObject({
+      tone: 'error',
+      showBanner: true,
+      canSend: false,
+      shouldOfferRepair: true,
+    });
+    expect(shouldOfferRepair('disconnected')).toBe(true);
+    expect(shouldOfferRepair('reconnecting')).toBe(false);
+    expect(shouldOfferRepair('closed')).toBe(false);
+  });
+
+  it('treats a deliberate close as quiet, not an error', () => {
+    expect(buildConnectionUi('closed')).toMatchObject({
+      tone: 'muted',
+      showBanner: false,
+      canSend: false,
+      shouldOfferRepair: false,
+    });
+  });
+});

--- a/apps/mobile/src/__tests__/mobile-thinking-indicator.test.ts
+++ b/apps/mobile/src/__tests__/mobile-thinking-indicator.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { shouldShowThinkingIndicator } from '../chatListState';
+
+describe('mobile thinking indicator state', () => {
+  it('shows thinking while a turn is active after tool events even if an older stream exists', () => {
+    expect(shouldShowThinkingIndicator({
+      sending: true,
+      items: [
+        { id: 'assistant-stream:old', kind: 'assistant', label: 'Assistant', text: 'Old stream', streaming: true },
+        { id: 'u2', kind: 'user', text: 'Cześć' },
+        {
+          id: 'tools:t1',
+          kind: 'tool-group',
+          title: 'Tools',
+          collapsed: true,
+          summary: '3 ok',
+          tools: [{ id: 't1', name: 'Read', status: 'ok', summary: 'path: a.ts' }],
+        },
+      ],
+    })).toBe(true);
+  });
+
+  it('does not render a duplicate thinking bubble while the latest assistant message is streaming', () => {
+    expect(shouldShowThinkingIndicator({
+      sending: true,
+      items: [
+        { id: 'u1', kind: 'user', text: 'Cześć' },
+        { id: 'assistant-stream:current', kind: 'assistant', label: 'Assistant', text: 'Piszę', streaming: true },
+      ],
+    })).toBe(false);
+  });
+
+  it('hides thinking when no turn is active', () => {
+    expect(shouldShowThinkingIndicator({
+      sending: false,
+      items: [{ id: 'u1', kind: 'user', text: 'Cześć' }],
+    })).toBe(false);
+  });
+});

--- a/apps/mobile/src/__tests__/mobile-tool-group-ui.test.ts
+++ b/apps/mobile/src/__tests__/mobile-tool-group-ui.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { buildToolGroupUi } from '../toolGroupUi';
+
+describe('mobile tool group ui', () => {
+  it('surfaces running as the primary collapsed status', () => {
+    expect(buildToolGroupUi([
+      { id: 'ok', name: 'Read', status: 'ok', summary: '' },
+      { id: 'run', name: 'Bash', status: 'running', summary: '' },
+    ])).toMatchObject({
+      statusLabel: 'running',
+      summary: '1 ok · 1 running',
+      pulse: true,
+    });
+  });
+
+  it('surfaces failed status before running', () => {
+    expect(buildToolGroupUi([
+      { id: 'run', name: 'Read', status: 'running', summary: '' },
+      { id: 'err', name: 'Bash', status: 'error', summary: '' },
+    ])).toMatchObject({
+      statusLabel: 'failed',
+      summary: '1 failed · 1 running',
+      pulse: false,
+    });
+  });
+});

--- a/apps/mobile/src/__tests__/protocol.test.ts
+++ b/apps/mobile/src/__tests__/protocol.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Ports the SPIRIT of the reference's mobile-protocol tests onto this app's
+ * state engine: event folding is composed from @moxxy/client-core's runtime
+ * (createRuntime/applyEvent — the same reducer the desktop uses), and
+ * `buildMobileState` presents those snapshots in the reference's MobileState
+ * shape. The local slice (transcription, errors) has its own tiny reducer.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { applyEvent, createRuntime, type ChatRuntime } from '@moxxy/client-core';
+import type { MoxxyEvent } from '@moxxy/sdk';
+import type { AskRequest } from '@moxxy/desktop-ipc-contract';
+import {
+  applyLocalFrame,
+  buildMobileState,
+  buildUsageRecord,
+  emptyLocalUiState,
+  emptyMobileState,
+  toAskResponse,
+  toPermissionMode,
+  type MobileStateSources,
+} from '../protocol';
+
+function event(fields: Record<string, unknown>): MoxxyEvent {
+  return fields as unknown as MoxxyEvent;
+}
+
+function chatOf(rt: ChatRuntime, overrides: Partial<MobileStateSources['chat']> = {}) {
+  return {
+    events: rt.log.toArray(),
+    streamingText: rt.streamingText,
+    sending: rt.sending,
+    activeTurnId: rt.activeTurnId,
+    compacting: false,
+    error: rt.error,
+    ...overrides,
+  };
+}
+
+const EMPTY_USAGE = {
+  latestPrompt: null,
+  perCall: [],
+  calls: 0,
+  totalInput: 0,
+  totalCacheRead: 0,
+  totalCacheCreation: 0,
+  totalOutput: 0,
+};
+
+function sources(overrides: Partial<MobileStateSources> = {}): MobileStateSources {
+  return {
+    connected: false,
+    workspaceId: null,
+    info: null,
+    chat: chatOf(createRuntime()),
+    queue: [],
+    usage: EMPTY_USAGE,
+    contextWindow: null,
+    asks: [],
+    autoApprove: false,
+    workflows: [],
+    local: emptyLocalUiState(),
+    ...overrides,
+  };
+}
+
+describe('mobile state presenter', () => {
+  it('presents the session snapshot and runtime sources without UI coupling', () => {
+    const rt = createRuntime();
+    applyEvent(rt, event({ id: 'u1', type: 'user_prompt', text: 'ship it' }));
+    rt.sending = true;
+    rt.activeTurnId = 'turn-1';
+    const state = buildMobileState(
+      sources({
+        connected: true,
+        workspaceId: 'workspace-1',
+        info: {
+          sessionId: 'session-1',
+          cwd: '/Users/dev/moxxy',
+          activeProvider: 'openai-codex',
+          activeMode: 'goal',
+          activeModeBadge: { label: 'Goal' },
+          commands: [{ name: 'compact', description: 'Compact the context' }],
+        },
+        chat: chatOf(rt, { streamingText: 'Working' }),
+        queue: [{ id: 'q-1', prompt: 'next' }],
+        usage: { ...EMPTY_USAGE, latestPrompt: 100, perCall: [100], calls: 1 },
+        contextWindow: 200_000,
+        autoApprove: true,
+        workflows: [{ name: 'daily-report', enabled: true }],
+      }),
+    );
+
+    expect(state.connected).toBe(true);
+    expect(state.activeWorkspaceId).toBe('workspace-1');
+    expect(state.workspaces).toEqual([{ id: 'workspace-1', name: 'moxxy', unread: false }]);
+    expect(state.sessions[0]).toMatchObject({
+      id: 'workspace-1',
+      live: true,
+      readOnly: false,
+      firstPrompt: 'ship it',
+      provider: 'openai-codex',
+    });
+    expect(state.session).toMatchObject({ id: 'session-1', readOnly: false });
+    expect(state.workflows).toEqual([{ name: 'daily-report', enabled: true }]);
+    expect(state.commands).toEqual([{ name: 'compact', description: 'Compact the context' }]);
+    expect(state.streamingText).toBe('Working');
+    expect(state.sending).toBe(true);
+    expect(state.activeTurnId).toBe('turn-1');
+    expect(state.queue).toEqual([{ id: 'q-1', prompt: 'next' }]);
+    expect(state.autoApprove).toBe(true);
+    expect(state.activeMode).toBe('goal');
+    expect(state.activeProvider).toBe('openai-codex');
+    expect(state.modeBadge).toEqual({ label: 'Goal' });
+    expect(state.usage).toMatchObject({ latestPrompt: 100, contextWindow: 200_000 });
+    expect(state.chatEvents).toHaveLength(1);
+  });
+
+  it('presents nothing before a workspace binds (empty shape parity)', () => {
+    expect(buildMobileState(sources())).toEqual(emptyMobileState());
+  });
+
+  it('keeps assistant chunks in live streaming text instead of committed chat events', () => {
+    const rt = createRuntime();
+    applyEvent(rt, event({ id: 'chunk-1', type: 'assistant_chunk', delta: 'Piszę ' }));
+    applyEvent(rt, event({ id: 'chunk-2', type: 'assistant_chunk', delta: 'odpowiedź' }));
+    const streaming = buildMobileState(sources({ workspaceId: 'w1', chat: chatOf(rt) }));
+    expect(streaming.chatEvents).toEqual([]);
+    expect(streaming.streamingText).toBe('Piszę odpowiedź');
+
+    applyEvent(
+      rt,
+      event({
+        id: 'assistant-1',
+        type: 'assistant_message',
+        content: 'Piszę odpowiedź',
+        stopReason: 'end_turn',
+      }),
+    );
+    const committed = buildMobileState(sources({ workspaceId: 'w1', chat: chatOf(rt) }));
+    expect(committed.streamingText).toBe('');
+    expect(committed.chatEvents).toMatchObject([
+      { id: 'assistant-1', type: 'assistant_message', content: 'Piszę odpowiedź' },
+    ]);
+  });
+
+  it('deduplicates replayed chat events by event id', () => {
+    const rt = createRuntime();
+    const msg = event({ id: 'event-1', type: 'assistant_message', content: 'Done', stopReason: 'end_turn' });
+    applyEvent(rt, msg);
+    applyEvent(rt, msg); // replay (reconnect) — must not duplicate
+    const state = buildMobileState(sources({ workspaceId: 'w1', chat: chatOf(rt) }));
+    expect(state.chatEvents).toHaveLength(1);
+  });
+
+  it('filters bookkeeping events out of the transcript', () => {
+    const rt = createRuntime();
+    applyEvent(rt, event({ id: 'p1', type: 'provider_request' }));
+    applyEvent(rt, event({ id: 'p2', type: 'mode_iteration' }));
+    applyEvent(rt, event({ id: 'u1', type: 'user_prompt', text: 'hello' }));
+    const state = buildMobileState(sources({ workspaceId: 'w1', chat: chatOf(rt) }));
+    expect(state.chatEvents).toMatchObject([{ id: 'u1', type: 'user_prompt' }]);
+  });
+
+  it('routes permission/approval prompts through pendingAsks (pendingPermissions stays empty)', () => {
+    const asks: AskRequest[] = [
+      { requestId: 'ask-1', workspaceId: 'w1', kind: 'permission', tool: { name: 'web_fetch', input: {} } },
+      { requestId: 'ask-2', workspaceId: 'w1', kind: 'approval' },
+    ];
+    const state = buildMobileState(sources({ workspaceId: 'w1', asks }));
+    expect(state.pendingPermissions).toEqual([]);
+    expect(state.pendingAsks).toMatchObject([
+      { requestId: 'ask-1', kind: 'permission' },
+      { requestId: 'ask-2', kind: 'approval' },
+    ]);
+  });
+
+  it('normalizes UI ask responses into the strict wire shape', () => {
+    expect(toPermissionMode('allow_once')).toBe('allow');
+    expect(toPermissionMode('allow_session')).toBe('allow_session');
+    expect(toPermissionMode('allow_always')).toBe('allow_always');
+    expect(toPermissionMode('nonsense')).toBe('deny');
+    expect(toAskResponse({ mode: 'allow_once', junk: 'dropped' })).toEqual({ mode: 'allow' });
+    expect(toAskResponse({ optionId: 'proceed', text: 'go on' })).toEqual({
+      optionId: 'proceed',
+      text: 'go on',
+    });
+  });
+
+  it('builds the usage record only once there is something to meter', () => {
+    expect(buildUsageRecord(EMPTY_USAGE, null)).toBeNull();
+    expect(buildUsageRecord(EMPTY_USAGE, 200_000)).toMatchObject({ contextWindow: 200_000 });
+    expect(
+      buildUsageRecord({ ...EMPTY_USAGE, latestPrompt: 1234, calls: 1 }, 200_000),
+    ).toMatchObject({ latestPrompt: 1234, contextWindow: 200_000 });
+  });
+
+  it('tracks the transcription lifecycle in the local slice', () => {
+    const started = applyLocalFrame(emptyLocalUiState(), { type: 'transcribe.started' });
+    expect(started.transcribing).toBe(true);
+    const done = applyLocalFrame(started, { type: 'transcribe.result', text: 'Cześć Moxxy' });
+    expect(done.transcribing).toBe(false);
+    expect(done.transcriptionText).toBe('Cześć Moxxy');
+    expect(done.transcriptionId).toBe('transcribe-1');
+    // A second result mints a NEW id so the composer consumes it again.
+    const again = applyLocalFrame(done, { type: 'transcribe.result', text: 'Jeszcze raz' });
+    expect(again.transcriptionId).toBe('transcribe-2');
+  });
+
+  it('collects errors and resets the local slice on a fresh connection', () => {
+    const errored = applyLocalFrame(emptyLocalUiState(), { type: 'error', message: 'boom' });
+    expect(errored.errors).toEqual(['boom']);
+    expect(errored.transcribing).toBe(false);
+    expect(applyLocalFrame(errored, { type: 'reset' })).toEqual(emptyLocalUiState());
+
+    const state = buildMobileState(sources({ workspaceId: 'w1', local: errored }));
+    expect(state.errors).toEqual(['boom']);
+  });
+});

--- a/apps/mobile/src/__tests__/smoke.test.ts
+++ b/apps/mobile/src/__tests__/smoke.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { tokens } from '@moxxy/design-tokens';
+import tailwindConfig from '../../tailwind.config';
+
+// Guards the tailwind ↔ design-tokens derivation: the NativeWind palette must
+// stay the projection of @moxxy/design-tokens, never drift into inline values.
+describe('tailwind config', () => {
+  const extend = tailwindConfig.theme.extend;
+
+  it('derives its colors from @moxxy/design-tokens', () => {
+    expect(extend.colors.appBg).toBe(tokens.color.appBg);
+    expect(extend.colors.primary).toBe(tokens.color.primary);
+    expect(extend.colors.primaryStrong).toBe(tokens.color.primaryStrong);
+    expect(extend.colors.muted).toBe(tokens.color.textMuted);
+    expect(extend.colors.dim).toBe(tokens.color.textDim);
+    expect(extend.colors.red).toBe(tokens.color.red);
+  });
+
+  it('derives radii, shadow, and fonts from the tokens', () => {
+    expect(extend.borderRadius.card).toBe(`${tokens.radius.card}px`);
+    expect(extend.borderRadius.pill).toBe(`${tokens.radius.pill}px`);
+    expect(extend.boxShadow.card).toBe(tokens.shadow.card);
+    expect(extend.fontFamily.sans).toEqual([tokens.font.sans]);
+  });
+
+  // Ported from the reference's mobile-theme test: pin the actual desktop
+  // light-theme values so a tokens-package edit that would silently restyle
+  // the mobile app shows up here as an explicit diff.
+  it('matches the desktop light theme palette', () => {
+    expect(extend.colors).toMatchObject({
+      appBg: '#f1f2f9',
+      cardBg: '#ffffff',
+      cardBorder: '#e3e5f0',
+      cardBorderStrong: '#cdd1e3',
+      text: '#0f172a',
+      muted: '#475569',
+      dim: '#94a3b8',
+      primary: '#ec4899',
+      primaryStrong: '#db2777',
+      primarySoft: '#fdf2f8',
+      accent: '#22d3ee',
+      green: '#10b981',
+      amber: '#f59e0b',
+      red: '#ef4444',
+    });
+    expect(extend.borderRadius).toMatchObject({
+      block: '8px',
+      card: '14px',
+      pill: '9999px',
+    });
+  });
+
+  it('scans Expo Router screens and reusable mobile components', () => {
+    expect(tailwindConfig.content).toEqual([
+      './app/**/*.{ts,tsx}',
+      './src/**/*.{ts,tsx}',
+    ]);
+  });
+});

--- a/apps/mobile/src/attachments.ts
+++ b/apps/mobile/src/attachments.ts
@@ -1,0 +1,133 @@
+/**
+ * Inline prompt-attachment helpers for the composer.
+ *
+ * `PromptAttachment` here is the SDK's `UserPromptAttachment` (`@moxxy/sdk`
+ * events.ts) — `{ kind: 'stdin'|'file'|'image'|'document'|'audio', content,
+ * name?, mediaType? }` — i.e. the inline shape `user_prompt` events carry and
+ * the shape this module builds from the pickers/clipboard. NOTE for the data
+ * layer: our desktop IPC contract's `session.runTurn` does NOT take inline
+ * attachments — it takes `{ path, name }` records (host file paths). A remote
+ * client must first persist each inline payload via
+ * `session.saveImageAttachment({ dataBase64, mediaType, name })` (allowed over
+ * the WS bridge precisely for this) and pass the returned `{ path, name }` to
+ * `session.runTurn`.
+ */
+
+import type { UserPromptAttachment } from '@moxxy/sdk';
+
+export type PromptAttachment = UserPromptAttachment;
+
+export interface BuildPromptAttachmentInput {
+  readonly content: string;
+  readonly mediaType?: string | null;
+  readonly name?: string | null;
+  readonly text?: boolean;
+}
+
+export interface AttachmentSummary {
+  readonly label: string;
+  readonly detail: string;
+}
+
+export const MAX_MOBILE_ATTACHMENT_BYTES = 8 * 1024 * 1024;
+
+export function buildPromptAttachment(input: BuildPromptAttachmentInput): PromptAttachment {
+  const mediaType = normalizeMediaType(input.mediaType);
+  const name = normalizeName(input.name, mediaType);
+  if (input.text) {
+    return {
+      kind: 'file',
+      content: input.content,
+      name,
+      ...(mediaType ? { mediaType } : {}),
+    };
+  }
+  if (mediaType?.startsWith('image/')) {
+    return { kind: 'image', content: input.content, mediaType, name };
+  }
+  if (mediaType === 'application/pdf') {
+    return { kind: 'document', content: input.content, mediaType, name };
+  }
+  return {
+    kind: 'file',
+    content: input.content,
+    name,
+    ...(mediaType ? { mediaType } : {}),
+  };
+}
+
+export function estimateBase64Bytes(base64: string): number {
+  const clean = base64.trim().replace(/^data:[^,]+,/, '');
+  if (clean.length === 0) return 0;
+  const padding = clean.endsWith('==') ? 2 : clean.endsWith('=') ? 1 : 0;
+  return Math.max(0, Math.floor((clean.length * 3) / 4) - padding);
+}
+
+export function validateAttachmentBytes(input: { readonly name?: string | null; readonly bytes: number }): string | null {
+  if (input.bytes <= MAX_MOBILE_ATTACHMENT_BYTES) return null;
+  const mb = Math.round(MAX_MOBILE_ATTACHMENT_BYTES / (1024 * 1024));
+  return `${input.name ?? 'Attachment'} is too large to attach from mobile (max ${mb} MB).`;
+}
+
+export function summarizeAttachment(attachment: PromptAttachment): AttachmentSummary {
+  return {
+    label: attachment.name ?? fallbackName(attachment),
+    detail: attachment.kind === 'image'
+      ? 'Image'
+      : attachment.kind === 'document'
+        ? 'Document'
+        : attachment.mediaType?.startsWith('text/')
+          ? 'Text'
+          : 'File',
+  };
+}
+
+export function inferMediaType(name: string | null | undefined): string | undefined {
+  const ext = name?.trim().toLowerCase().split('.').pop();
+  if (!ext) return undefined;
+  if (ext === 'png') return 'image/png';
+  if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg';
+  if (ext === 'webp') return 'image/webp';
+  if (ext === 'gif') return 'image/gif';
+  if (ext === 'pdf') return 'application/pdf';
+  if (['txt', 'md', 'json', 'ts', 'tsx', 'js', 'jsx', 'css', 'html', 'xml', 'csv', 'log', 'py', 'rb', 'go', 'rs', 'java', 'kt', 'swift', 'sql', 'yml', 'yaml'].includes(ext)) {
+    return 'text/plain';
+  }
+  return undefined;
+}
+
+export function isTextAttachmentMediaType(mediaType: string | null | undefined): boolean {
+  const normalized = normalizeMediaType(mediaType);
+  return Boolean(
+    normalized?.startsWith('text/') ||
+    normalized === 'application/json' ||
+    normalized === 'application/xml' ||
+    normalized === 'application/x-yaml',
+  );
+}
+
+export function stripDataUrlPrefix(value: string): string {
+  const comma = value.indexOf(',');
+  return value.startsWith('data:') && comma >= 0 ? value.slice(comma + 1) : value;
+}
+
+function normalizeMediaType(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim().toLowerCase();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeName(value: string | null | undefined, mediaType: string | undefined): string {
+  const trimmed = value?.trim();
+  if (trimmed && trimmed.length > 0) return trimmed.slice(0, 160);
+  return fallbackName({ kind: mediaType?.startsWith('image/') ? 'image' : mediaType === 'application/pdf' ? 'document' : 'file', mediaType });
+}
+
+function fallbackName(attachment: Pick<PromptAttachment, 'kind' | 'mediaType'>): string {
+  if (attachment.kind === 'image') {
+    if (attachment.mediaType === 'image/jpeg') return 'image.jpg';
+    if (attachment.mediaType === 'image/webp') return 'image.webp';
+    return 'image.png';
+  }
+  if (attachment.kind === 'document') return 'document.pdf';
+  return 'attachment.txt';
+}

--- a/apps/mobile/src/autoApproveState.ts
+++ b/apps/mobile/src/autoApproveState.ts
@@ -1,0 +1,8 @@
+export interface AutoApproveStateInput {
+  readonly upstream: boolean;
+  readonly optimistic: boolean | null;
+}
+
+export function resolveAutoApproveState(input: AutoApproveStateInput): boolean {
+  return input.optimistic ?? input.upstream;
+}

--- a/apps/mobile/src/boot.ts
+++ b/apps/mobile/src/boot.ts
@@ -1,9 +1,19 @@
 /**
  * Wire the shared client layer to React Native: a WebSocket transport pointed at
- * the desktop host's bridge, and (for this PoC) no platform capabilities — voice
- * capture, TTS, the legacy KV migration, and the event bus all degrade to
- * no-ops, exactly as the optional capability design intends. A real mobile build
- * would register Expo-backed implementations here instead.
+ * the desktop host's bridge.
+ *
+ * Platform capabilities stay EMPTY (`configurePlatform({})`) by design, not as
+ * a stub: this app follows the reference architecture where the platform
+ * surface lives in the app's own hooks, which call the Expo SDKs directly —
+ * `useAttachments` (expo-image-picker / document-picker / clipboard),
+ * `useVoiceRecorder` (expo-audio), `useQrScanner` (expo-camera),
+ * `useMessageCopy` (expo-clipboard), `storage` (expo-secure-store). None of
+ * them read client-core's `getPlatform()`, and the registry's contracts are
+ * web-shaped where they overlap (e.g. `AudioCapture` demands a PCM16@24kHz
+ * pipeline, while mobile ships the platform-native compressed clip to the
+ * runner's transcriber). client-core's optional-capability design means the
+ * few shared hooks that do consult the registry (TTS, legacy KV migration)
+ * degrade to their "unsupported" branch — exactly right for mobile today.
  *
  * The QR `moxxy mobile` prints embeds the pairing token as `?t=` (one scan
  * carries everything), but the token must NOT ride the live WS URL — query
@@ -15,6 +25,7 @@
 import { configureTransport } from '@moxxy/client-core/transport';
 import { configurePlatform } from '@moxxy/client-core/platform';
 import { makeWsApi } from '@moxxy/client-transport-ws';
+import { installConsoleFilters } from './consoleFilters';
 
 /** Split a scanned pairing URL into the bare WS URL + the embedded `?t=` token
  *  (regex, not `new URL` — Hermes' URL support is unreliable). */
@@ -34,6 +45,7 @@ export function splitConnectUrl(scanned: string): { url: string; token?: string 
 }
 
 export function bootMobile(rawUrl: string, token?: string): void {
+  installConsoleFilters();
   const split = splitConnectUrl(rawUrl);
   const effectiveToken = token ?? split.token;
   configureTransport(

--- a/apps/mobile/src/chatListState.ts
+++ b/apps/mobile/src/chatListState.ts
@@ -1,0 +1,12 @@
+import type { TranscriptItem } from './chatTranscript';
+
+interface ThinkingIndicatorInput {
+  readonly items: ReadonlyArray<TranscriptItem>;
+  readonly sending: boolean;
+}
+
+export function shouldShowThinkingIndicator(input: ThinkingIndicatorInput): boolean {
+  if (!input.sending) return false;
+  const lastItem = input.items[input.items.length - 1];
+  return !(lastItem?.kind === 'assistant' && lastItem.streaming);
+}

--- a/apps/mobile/src/chatMessages.ts
+++ b/apps/mobile/src/chatMessages.ts
@@ -1,0 +1,58 @@
+import { textOf } from './utils/record';
+
+export type ChatMessageKind = 'user' | 'assistant' | 'tool' | 'error' | 'system';
+
+export interface ChatMessage {
+  readonly kind: ChatMessageKind;
+  readonly label: string | null;
+  readonly text: string;
+}
+
+const TOOL_EVENT_TYPES = new Set([
+  'tool_call_requested',
+  'tool_call_started',
+  'tool_result',
+  'tool_call_completed',
+  'command',
+]);
+
+export function buildChatMessage(event: Record<string, unknown>): ChatMessage {
+  const rawKind = textOf(event.role, textOf(event.type, 'event'));
+  const text = firstText(event.text, event.content, event.message, event.body, event.summary);
+
+  if (rawKind === 'user' || rawKind === 'user_prompt') {
+    return { kind: 'user', label: null, text: text || 'User message' };
+  }
+
+  if (rawKind === 'assistant' || rawKind === 'assistant_message') {
+    return { kind: 'assistant', label: 'Assistant', text: text || 'Assistant response' };
+  }
+
+  if (TOOL_EVENT_TYPES.has(rawKind)) {
+    return {
+      kind: 'tool',
+      label: toolLabel(rawKind),
+      text: firstText(event.name, event.toolName, event.command, event.title) || 'Runtime action',
+    };
+  }
+
+  if (rawKind === 'error' || rawKind === 'abort' || rawKind === 'turn_error') {
+    return { kind: 'error', label: rawKind, text: text || 'The turn was interrupted.' };
+  }
+
+  return { kind: 'system', label: rawKind, text: text || 'Event received' };
+}
+
+function firstText(...values: unknown[]): string {
+  for (const value of values) {
+    const text = textOf(value);
+    if (text.trim().length > 0) return text;
+  }
+  return '';
+}
+
+function toolLabel(type: string): string {
+  if (type === 'tool_result' || type === 'tool_call_completed') return 'Tool result';
+  if (type === 'command') return 'Command';
+  return 'Tool call';
+}

--- a/apps/mobile/src/chatTranscript.ts
+++ b/apps/mobile/src/chatTranscript.ts
@@ -1,0 +1,360 @@
+/**
+ * Event-log → transcript projection: coalesces the raw moxxy event stream into
+ * the items the chat list renders (streamed assistant text folded into one
+ * bubble, tool lifecycle events folded into one collapsed group, runtime noise
+ * folded into a collapsed "Runtime" group).
+ *
+ * Event-name reconciliation against `MoxxyEvent` in `@moxxy/sdk` (events.ts):
+ * every primary type string here exists verbatim in the SDK — `user_prompt`,
+ * `assistant_chunk` (delta), `assistant_message` (content + stopReason),
+ * `tool_call_requested` / `tool_call_approved` / `tool_call_denied`,
+ * `tool_result` (ok / error{message,kind}), `error`, `abort`, and the hidden
+ * bookkeeping types (`provider_request`, `provider_response`, `mode_iteration`,
+ * `plugin_registered`). The extra strings the reference also accepted
+ * (`assistant`, `user`, `tool_call_started`, `tool_call_completed`, `command`,
+ * `turn_error`, `session_ready`) are NOT SDK events — they are kept as
+ * defensive aliases for bridge-side frames so an unknown-but-shaped record
+ * still renders sensibly. Inputs stay `Record<string, unknown>` because events
+ * arrive over the wire untyped.
+ */
+
+import { textOf } from './utils/record';
+import type { UserPromptAttachment as PromptAttachment } from '@moxxy/sdk';
+
+export type TranscriptItem =
+  | UserTranscriptItem
+  | AssistantTranscriptItem
+  | ToolGroupTranscriptItem
+  | ErrorTranscriptItem
+  | SystemGroupTranscriptItem;
+
+export interface UserTranscriptItem {
+  readonly id: string;
+  readonly kind: 'user';
+  readonly text: string;
+  readonly attachments?: ReadonlyArray<PromptAttachment>;
+}
+
+export interface AssistantTranscriptItem {
+  readonly id: string;
+  readonly kind: 'assistant';
+  readonly label: 'Assistant';
+  readonly text: string;
+  readonly streaming: boolean;
+  readonly stopReason?: string;
+}
+
+export interface ToolGroupTranscriptItem {
+  readonly id: string;
+  readonly kind: 'tool-group';
+  readonly title: 'Tools';
+  readonly collapsed: true;
+  readonly summary: string;
+  readonly tools: ReadonlyArray<ToolTranscriptItem>;
+}
+
+export interface ToolTranscriptItem {
+  readonly id: string;
+  readonly name: string;
+  readonly status: 'running' | 'ok' | 'error';
+  readonly summary: string;
+}
+
+export interface ErrorTranscriptItem {
+  readonly id: string;
+  readonly kind: 'error';
+  readonly label: string;
+  readonly text: string;
+}
+
+export interface SystemGroupTranscriptItem {
+  readonly id: string;
+  readonly kind: 'system-group';
+  readonly title: 'Runtime';
+  readonly collapsed: true;
+  readonly count: number;
+  readonly events: ReadonlyArray<SystemEventSummary>;
+}
+
+export interface SystemEventSummary {
+  readonly id: string;
+  readonly type: string;
+  readonly text: string;
+}
+
+const HIDDEN_EVENT_TYPES = new Set([
+  'provider_request',
+  'provider_response',
+  'mode_iteration',
+  'plugin_registered',
+  'session_ready',
+]);
+
+const TOOL_EVENT_TYPES = new Set([
+  'tool_call_requested',
+  'tool_call_started',
+  'tool_result',
+  'tool_call_completed',
+  'tool_call_approved',
+  'tool_call_denied',
+  'command',
+]);
+
+export function buildChatTranscript(
+  events: ReadonlyArray<Record<string, unknown>>,
+  streamingText = '',
+): TranscriptItem[] {
+  const items: TranscriptItem[] = [];
+  let assistantStreamId: string | null = null;
+  let assistantStreamText = '';
+  let tools: ToolTranscriptItem[] = [];
+  let systemEvents: SystemEventSummary[] = [];
+
+  const flushAssistant = (): void => {
+    if (!assistantStreamId || assistantStreamText.trim().length === 0) return;
+    items.push({
+      id: `assistant-stream:${assistantStreamId}`,
+      kind: 'assistant',
+      label: 'Assistant',
+      text: assistantStreamText,
+      streaming: true,
+    });
+    assistantStreamId = null;
+    assistantStreamText = '';
+  };
+
+  const flushTools = (): void => {
+    if (tools.length === 0) return;
+    items.push({
+      id: `tools:${tools[0]!.id}`,
+      kind: 'tool-group',
+      title: 'Tools',
+      collapsed: true,
+      summary: summarizeToolStatuses(tools),
+      tools,
+    });
+    tools = [];
+  };
+
+  const flushSystem = (): void => {
+    if (systemEvents.length === 0) return;
+    items.push({
+      id: `system:${systemEvents[0]!.id}`,
+      kind: 'system-group',
+      title: 'Runtime',
+      collapsed: true,
+      count: systemEvents.length,
+      events: systemEvents,
+    });
+    systemEvents = [];
+  };
+
+  for (let index = 0; index < events.length; index += 1) {
+    const event = events[index]!;
+    const type = eventType(event);
+
+    if (type === 'assistant_chunk') {
+      const delta = firstText(event.delta, event.text, event.content);
+      if (delta.length === 0) continue;
+      assistantStreamId = assistantStreamId ?? eventId(event, `chunk-${index}`);
+      assistantStreamText += delta;
+      continue;
+    }
+
+    if (HIDDEN_EVENT_TYPES.has(type)) continue;
+
+    if (type === 'assistant' || type === 'assistant_message') {
+      flushTools();
+      flushSystem();
+      assistantStreamId = null;
+      assistantStreamText = '';
+      items.push({
+        id: eventId(event, `assistant-${index}`),
+        kind: 'assistant',
+        label: 'Assistant',
+        text: firstText(event.content, event.text, event.message, event.body) || 'Assistant response',
+        streaming: false,
+        ...(textOf(event.stopReason).length > 0 ? { stopReason: textOf(event.stopReason) } : {}),
+      });
+      continue;
+    }
+
+    if (type === 'user' || type === 'user_prompt') {
+      flushAssistant();
+      flushTools();
+      flushSystem();
+      items.push({
+        id: eventId(event, `user-${index}`),
+        kind: 'user',
+        text: firstText(event.text, event.content, event.message, event.body) || 'User message',
+        ...(promptAttachments(event).length > 0 ? { attachments: promptAttachments(event) } : {}),
+      });
+      continue;
+    }
+
+    if (TOOL_EVENT_TYPES.has(type)) {
+      flushAssistant();
+      flushSystem();
+      tools = upsertTool(tools, event, type, index);
+      continue;
+    }
+
+    if (type === 'error' || type === 'abort' || type === 'turn_error') {
+      flushAssistant();
+      flushTools();
+      flushSystem();
+      items.push({
+        id: eventId(event, `error-${index}`),
+        kind: 'error',
+        label: type,
+        text: firstText(event.message, event.error, event.text, event.body) || 'The turn was interrupted.',
+      });
+      continue;
+    }
+
+    const text = firstText(event.message, event.text, event.content, event.summary, event.title);
+    if (text.length > 0) {
+      flushAssistant();
+      systemEvents.push({
+        id: eventId(event, `system-${index}`),
+        type,
+        text,
+      });
+    }
+  }
+
+  flushAssistant();
+  flushTools();
+  flushSystem();
+
+  if (streamingText.trim().length > 0) {
+    items.push({
+      id: 'assistant-stream:external',
+      kind: 'assistant',
+      label: 'Assistant',
+      text: streamingText,
+      streaming: true,
+    });
+  }
+
+  return items;
+}
+
+function promptAttachments(event: Record<string, unknown>): PromptAttachment[] {
+  if (!Array.isArray(event.attachments)) return [];
+  return event.attachments.filter(isPromptAttachment);
+}
+
+function isPromptAttachment(value: unknown): value is PromptAttachment {
+  if (!value || typeof value !== 'object') return false;
+  const item = value as Partial<PromptAttachment>;
+  return typeof item.kind === 'string' && typeof item.content === 'string';
+}
+
+function upsertTool(
+  tools: ReadonlyArray<ToolTranscriptItem>,
+  event: Record<string, unknown>,
+  type: string,
+  index: number,
+): ToolTranscriptItem[] {
+  const id = toolCallId(event) || `tool-${index}`;
+  const existing = tools.find((tool) => tool.id === id);
+  const status = toolStatus(type, event);
+  const next: ToolTranscriptItem = {
+    id,
+    name: firstText(event.name, event.toolName, event.command, event.title) || existing?.name || 'Tool',
+    status,
+    summary: summarizeToolInput(event.input) || existing?.summary || firstText(event.command, event.path, event.title),
+  };
+  if (!existing) return [...tools, next];
+  return tools.map((tool) =>
+    tool.id === id
+      ? {
+          ...tool,
+          name: next.name || tool.name,
+          status,
+          summary: next.summary || tool.summary,
+        }
+      : tool,
+  );
+}
+
+function toolStatus(type: string, event: Record<string, unknown>): ToolTranscriptItem['status'] {
+  if (type === 'tool_call_denied') return 'error';
+  if (type === 'tool_result' || type === 'tool_call_completed') {
+    if (event.ok === false || event.isError === true || hasErrorPayload(event.error)) return 'error';
+    return 'ok';
+  }
+  return 'running';
+}
+
+function summarizeToolStatuses(tools: ReadonlyArray<ToolTranscriptItem>): string {
+  const counts = tools.reduce(
+    (acc, tool) => {
+      acc[tool.status] += 1;
+      return acc;
+    },
+    { ok: 0, error: 0, running: 0 },
+  );
+  return [
+    counts.ok > 0 ? `${counts.ok} ok` : '',
+    counts.error > 0 ? `${counts.error} failed` : '',
+    counts.running > 0 ? `${counts.running} running` : '',
+  ].filter(Boolean).join(' · ');
+}
+
+function summarizeToolInput(value: unknown): string {
+  if (typeof value === 'string') return oneLine(value);
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return '';
+  return Object.entries(value as Record<string, unknown>)
+    .slice(0, 2)
+    .map(([key, val]) => `${key}: ${primitiveSummary(val)}`)
+    .join(' · ');
+}
+
+function primitiveSummary(value: unknown): string {
+  if (typeof value === 'string') return oneLine(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return `${value.length} items`;
+  if (typeof value === 'object') return 'object';
+  return '';
+}
+
+function eventType(event: Record<string, unknown>): string {
+  return textOf(event.type, textOf(event.role, 'event'));
+}
+
+function eventId(event: Record<string, unknown>, fallback: string): string {
+  return firstText(event.id, event.requestId, event.callId) || fallback;
+}
+
+function toolCallId(event: Record<string, unknown>): string {
+  return firstText(
+    event.callId,
+    event.toolCallId,
+    event.toolUseId,
+    event.tool_call_id,
+    event.tool_use_id,
+    event.id,
+  );
+}
+
+function hasErrorPayload(value: unknown): boolean {
+  if (textOf(value).length > 0) return true;
+  if (!value || typeof value !== 'object') return false;
+  const error = value as Record<string, unknown>;
+  return textOf(error.message, textOf(error.reason, textOf(error.kind))).length > 0;
+}
+
+function firstText(...values: unknown[]): string {
+  for (const value of values) {
+    const text = textOf(value);
+    if (text.trim().length > 0) return text;
+  }
+  return '';
+}
+
+function oneLine(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}

--- a/apps/mobile/src/clientFrames.ts
+++ b/apps/mobile/src/clientFrames.ts
@@ -1,0 +1,175 @@
+/**
+ * Typed builders for the commands the mobile app issues.
+ *
+ * The reference app spoke its own gateway protocol: fire-and-forget JSON
+ * frames over a raw socket. This port speaks the desktop IPC contract over
+ * JSON-RPC, so a "frame" here is a typed `{ command, args }` pair aimed at
+ * `MoxxyApi.invoke` — request/response instead of fire-and-forget. The builder
+ * names stay the reference's (`buildRunTurnFrame`, `buildGoalFrames`, …) so the
+ * hooks that consume them port over with minimal churn; `invokeFrame` is the
+ * one execution seam that sends a frame and returns the host's typed reply.
+ */
+
+import type {
+  IpcCommandName,
+  IpcCommands,
+  MoxxyApi,
+  UserPromptAttachment,
+} from '@moxxy/desktop-ipc-contract';
+
+/** Inline attachment payload shipped with a turn (base64 bytes or inline
+ *  text). Identical to the SDK's `UserPromptAttachment`, re-exported under the
+ *  reference app's name so the attachment modules bind unchanged. */
+export type PromptAttachment = UserPromptAttachment;
+
+export interface CommandFrame<K extends IpcCommandName = IpcCommandName> {
+  readonly command: K;
+  readonly args: Parameters<IpcCommands[K]>[0];
+}
+
+/** Send one frame over the transport and await the host's typed reply. */
+export function invokeFrame<K extends IpcCommandName>(
+  api: MoxxyApi,
+  frame: CommandFrame<K>,
+): ReturnType<IpcCommands[K]> {
+  const invoke = api.invoke as (command: K, args: unknown) => ReturnType<IpcCommands[K]>;
+  return invoke(frame.command, frame.args);
+}
+
+interface WorkspaceInput {
+  readonly workspaceId: string | null;
+}
+
+export interface RunTurnInput extends WorkspaceInput {
+  readonly prompt: string;
+  readonly attachments?: ReadonlyArray<PromptAttachment>;
+}
+
+export interface AbortTurnInput extends WorkspaceInput {
+  readonly turnId: string;
+}
+
+export interface AskResponseInput {
+  readonly requestId: string;
+  readonly response: Parameters<IpcCommands['ask.respond']>[0]['response'];
+}
+
+export interface AutoApproveInput extends WorkspaceInput {
+  readonly enabled: boolean;
+}
+
+export interface SetModeInput extends WorkspaceInput {
+  readonly mode: string;
+}
+
+export interface RunCommandInput extends WorkspaceInput {
+  readonly name: string;
+  readonly args: string;
+}
+
+export interface TranscribeInput {
+  readonly audioBase64: string;
+  readonly mimeType?: string;
+}
+
+export interface GoalInput extends WorkspaceInput {
+  readonly objective: string;
+}
+
+export interface WorkflowRunInput {
+  readonly name: string;
+}
+
+/** `null` workspace (nothing selected yet) → omit and let the host default. */
+function ws(workspaceId: string | null): { workspaceId?: string } {
+  return workspaceId ? { workspaceId } : {};
+}
+
+export function buildRunTurnFrame(input: RunTurnInput): CommandFrame<'session.runTurn'> {
+  return {
+    command: 'session.runTurn',
+    args: {
+      ...ws(input.workspaceId),
+      prompt: input.prompt,
+      ...(input.attachments && input.attachments.length > 0
+        ? { inlineAttachments: input.attachments }
+        : {}),
+    },
+  };
+}
+
+export function buildAbortTurnFrame(input: AbortTurnInput): CommandFrame<'session.abortTurn'> {
+  return {
+    command: 'session.abortTurn',
+    args: { ...ws(input.workspaceId), turnId: input.turnId },
+  };
+}
+
+export function buildAskResponseFrame(input: AskResponseInput): CommandFrame<'ask.respond'> {
+  return {
+    command: 'ask.respond',
+    args: { requestId: input.requestId, response: input.response },
+  };
+}
+
+export function buildSetAutoApproveFrame(
+  input: AutoApproveInput,
+): CommandFrame<'session.setAutoApprove'> {
+  return {
+    command: 'session.setAutoApprove',
+    args: { ...ws(input.workspaceId), enabled: input.enabled },
+  };
+}
+
+export function buildSetModeFrame(input: SetModeInput): CommandFrame<'session.setMode'> {
+  return {
+    command: 'session.setMode',
+    args: { ...ws(input.workspaceId), mode: input.mode },
+  };
+}
+
+export function buildRunCommandFrame(input: RunCommandInput): CommandFrame<'session.runCommand'> {
+  return {
+    command: 'session.runCommand',
+    args: { ...ws(input.workspaceId), name: input.name, args: input.args },
+  };
+}
+
+export function buildNewSessionFrame(input: WorkspaceInput): CommandFrame<'session.newSession'> {
+  return { command: 'session.newSession', args: ws(input.workspaceId) };
+}
+
+export function buildWorkflowListFrame(): CommandFrame<'workflows.list'> {
+  return { command: 'workflows.list', args: undefined };
+}
+
+export function buildWorkflowRunFrame(input: WorkflowRunInput): CommandFrame<'workflows.run'> {
+  return { command: 'workflows.run', args: { name: input.name } };
+}
+
+export function buildTranscribeFrame(input: TranscribeInput): CommandFrame<'session.transcribe'> {
+  return {
+    command: 'session.transcribe',
+    args: {
+      audioBase64: input.audioBase64,
+      ...(input.mimeType ? { mimeType: input.mimeType } : {}),
+    },
+  };
+}
+
+/** Goal mode = mode switch, then hands-off auto-approve, then the objective as
+ *  a turn — same three-step sequence the reference fired, but awaited in order
+ *  by the caller (each is a real request/response now). */
+export function buildGoalFrames(
+  input: GoalInput,
+): readonly [
+  CommandFrame<'session.setMode'>,
+  CommandFrame<'session.setAutoApprove'>,
+  CommandFrame<'session.runTurn'>,
+] {
+  return [
+    buildSetModeFrame({ workspaceId: input.workspaceId, mode: 'goal' }),
+    buildSetAutoApproveFrame({ workspaceId: input.workspaceId, enabled: true }),
+    buildRunTurnFrame({ workspaceId: input.workspaceId, prompt: input.objective }),
+  ];
+}

--- a/apps/mobile/src/components/AppShell.tsx
+++ b/apps/mobile/src/components/AppShell.tsx
@@ -1,0 +1,9 @@
+import { View, type ViewProps } from 'react-native';
+
+export function AppShell({ children, className = '', ...props }: ViewProps & { readonly className?: string }) {
+  return (
+    <View {...props} className={`h-screen min-h-screen flex-1 bg-appBg ${className}`}>
+      {children}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/ApprovalCard.tsx
+++ b/apps/mobile/src/components/ApprovalCard.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import { Pressable, ScrollView, Text, TextInput, View } from 'react-native';
+import { textOf } from '@/utils/record';
+import { MobileIcon } from './MobileIcon';
+
+interface ApprovalCardProps {
+  readonly ask: Record<string, unknown>;
+  readonly onRespond: (response: Record<string, unknown>) => void;
+}
+
+export function ApprovalCard({ ask, onRespond }: ApprovalCardProps) {
+  const approval = isRecord(ask.approval) ? ask.approval : ask;
+  const options = Array.isArray(approval.options) ? approval.options.filter(isRecord) : [];
+  const [textOption, setTextOption] = useState<Record<string, unknown> | null>(null);
+  const [text, setText] = useState('');
+
+  if (textOption) {
+    return (
+      <View className="gap-3 rounded-card border border-cardBorder bg-cardBg p-3 shadow-card">
+        <Text className="text-[15px] font-bold text-text">{textOf(textOption.label, 'Respond')}</Text>
+        <TextInput
+          value={text}
+          onChangeText={setText}
+          multiline
+          placeholder={textOf(textOption.textPrompt, 'Add details...')}
+          placeholderTextColor="#94a3b8"
+          className="min-h-24 rounded-block border border-cardBorder bg-cardBg px-3 py-2 text-[14px] text-text"
+        />
+        <View className="flex-row justify-end gap-2">
+          <Button label="Back" onPress={() => setTextOption(null)} />
+          <Button
+            label={textOf(textOption.label, 'Send')}
+            primary
+            disabled={text.trim().length === 0}
+            onPress={() => onRespond({ optionId: textOf(textOption.id), text: text.trim() })}
+          />
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View className="gap-3 rounded-card border border-cardBorder bg-cardBg p-3 shadow-card">
+      <View className="flex-row items-start gap-3">
+        <View className="h-9 w-9 items-center justify-center rounded-block bg-primarySoft">
+          <MobileIcon name="actions" size={17} strokeWidth={2.35} color="#db2777" />
+        </View>
+        <View className="min-w-0 flex-1">
+          <Text className="text-[15px] font-bold text-text">{textOf(approval.title, 'Approval required')}</Text>
+          <Text className="mt-0.5 text-[12px] leading-4 text-muted">The current turn is waiting for your decision.</Text>
+        </View>
+      </View>
+      <View>
+        {textOf(approval.body, textOf(approval.message, textOf(approval.description, textOf(approval.reason)))) ? (
+          <ScrollView className="rounded-block border border-cardBorder bg-appBg" style={{ maxHeight: 150 }}>
+            <Text className="p-3 text-[12px] leading-5 text-text">
+              {textOf(approval.body, textOf(approval.message, textOf(approval.description, textOf(approval.reason))))}
+            </Text>
+          </ScrollView>
+        ) : null}
+      </View>
+      <View className="flex-row flex-wrap justify-end gap-2">
+        {options.length > 0 ? (
+          options.map((option, index) => (
+            <Button
+              key={textOf(option.id, `option-${index}`)}
+              label={textOf(option.label, 'Choose')}
+              primary={option.id === approval.defaultOptionId}
+              danger={option.danger === true}
+              onPress={() => {
+                if (option.requestsText === true) setTextOption(option);
+                else onRespond({ optionId: textOf(option.id) });
+              }}
+            />
+          ))
+        ) : (
+          <>
+            <Button label="Deny" danger onPress={() => onRespond({ mode: 'deny' })} />
+            <Button label="Allow session" primary onPress={() => onRespond({ mode: 'allow_session' })} />
+          </>
+        )}
+      </View>
+    </View>
+  );
+}
+
+function Button({
+  label,
+  primary,
+  danger,
+  disabled,
+  onPress,
+}: {
+  readonly label: string;
+  readonly primary?: boolean;
+  readonly danger?: boolean;
+  readonly disabled?: boolean;
+  readonly onPress: () => void;
+}) {
+  const bg = primary ? 'bg-primary border-primary' : 'bg-cardBg border-cardBorder';
+  const color = primary ? 'text-white' : danger ? 'text-red' : 'text-muted';
+  return (
+    <Pressable className={`min-h-9 justify-center rounded-block border px-3 ${bg} ${disabled ? 'opacity-50' : ''}`} disabled={disabled} onPress={onPress}>
+      <Text className={`text-[13px] font-bold ${color}`}>{label}</Text>
+    </Pressable>
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/apps/mobile/src/components/AskSheet.tsx
+++ b/apps/mobile/src/components/AskSheet.tsx
@@ -1,0 +1,70 @@
+import { Text, View } from 'react-native';
+import { recordId, textOf } from '@/utils/record';
+import { ApprovalCard } from './ApprovalCard';
+import { PermissionCard } from './PermissionCard';
+
+interface AskSheetProps {
+  readonly asks: ReadonlyArray<Record<string, unknown>>;
+  readonly permissions: ReadonlyArray<Record<string, unknown>>;
+  readonly onAskResponse: (requestId: string, response: Record<string, unknown>) => void;
+  readonly onPermissionDecision: (permissionId: string, mode: 'allow_once' | 'allow_session' | 'allow_always' | 'deny') => void;
+}
+
+export function AskSheet(props: AskSheetProps) {
+  const total = props.asks.length + props.permissions.length;
+  if (total === 0) {
+    return (
+      <View className="mt-8 items-center rounded-card border border-cardBorder bg-cardBg px-5 py-8">
+        <Text className="text-center text-[16px] font-bold text-text">No pending actions</Text>
+        <Text className="mt-1 text-center text-[13px] text-muted">Approvals and permissions will appear here.</Text>
+      </View>
+    );
+  }
+
+  const firstAsk = props.asks[0];
+  const firstPermission = firstAsk ? null : props.permissions[0];
+  const extraCount = total - 1;
+
+  return (
+    <View className="gap-2">
+      {extraCount > 0 ? (
+        <View className="self-start rounded-pill bg-cardBg px-3 py-1.5">
+          <Text className="text-[11px] font-bold text-muted">+{extraCount} more pending</Text>
+        </View>
+      ) : null}
+      {firstAsk ? (
+        (() => {
+          const requestId = textOf(firstAsk.requestId, 'ask-0');
+          const kind = textOf(firstAsk.kind, 'permission');
+          return kind === 'approval' ? (
+          <ApprovalCard
+            key={requestId}
+            ask={firstAsk}
+            onRespond={(response) => props.onAskResponse(requestId, response)}
+          />
+        ) : (
+          <PermissionCard
+            key={requestId}
+            ask={firstAsk}
+            onRespond={(response) => props.onAskResponse(requestId, response)}
+          />
+        );
+        })()
+      ) : null}
+      {firstPermission ? (
+        (() => {
+          const id = recordId(firstPermission, 'permission-0');
+          return (
+          <PermissionCard
+            key={id}
+            ask={firstPermission}
+            onRespond={(response) =>
+              props.onPermissionDecision(id, textOf(response.mode, 'deny') as 'allow_once' | 'allow_session' | 'allow_always' | 'deny')
+            }
+          />
+          );
+        })()
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/BottomNav.tsx
+++ b/apps/mobile/src/components/BottomNav.tsx
@@ -1,0 +1,41 @@
+import { Link, usePathname } from 'expo-router';
+import { Pressable, Text, View } from 'react-native';
+import { buildBottomTabs } from '../navigation';
+import { MobileIcon } from './MobileIcon';
+
+export function BottomNav({ pendingActions = 0 }: { readonly pendingActions?: number }) {
+  const pathname = usePathname();
+  const items = buildBottomTabs(pendingActions);
+  return (
+    <View className="border-t border-cardBorder bg-cardBg/95 px-4 pb-3 pt-2">
+      <View className="flex-row items-center justify-between rounded-card border border-cardBorder bg-cardBg px-1.5 py-1.5 shadow-card">
+      {items.map((item) => {
+        const active = pathname === item.href || (pathname === '/' && item.href === '/chat');
+        return (
+          <Link key={item.href} href={item.href} asChild>
+            <Pressable
+              accessibilityRole="tab"
+              accessibilityState={{ selected: active }}
+              className={`relative min-h-14 flex-1 items-center justify-center rounded-card px-1 ${
+                active ? 'bg-primarySoft' : 'bg-transparent'
+              }`}
+            >
+              <View className={`h-7 w-7 items-center justify-center rounded-pill ${active ? 'bg-cardBg' : 'bg-transparent'}`}>
+                <MobileIcon name={item.icon} size={18} strokeWidth={2.4} color={active ? '#db2777' : '#64748b'} />
+              </View>
+              <Text className={`mt-0.5 text-[10px] font-bold ${active ? 'text-primaryStrong' : 'text-muted'}`}>
+                {item.label}
+              </Text>
+              {item.badge ? (
+                <View className="absolute right-2 top-1 min-w-5 items-center rounded-pill bg-red px-1.5 py-0.5">
+                  <Text className="text-[10px] font-black text-white">{item.badge}</Text>
+                </View>
+              ) : null}
+            </Pressable>
+          </Link>
+        );
+      })}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/ChatList.tsx
+++ b/apps/mobile/src/components/ChatList.tsx
@@ -1,0 +1,384 @@
+import { Pressable, ScrollView, Text, View } from 'react-native';
+import { useState } from 'react';
+import { summarizeAttachment } from '@/attachments';
+import type { AssistantTranscriptItem, SystemGroupTranscriptItem, ToolGroupTranscriptItem, TranscriptItem } from '@/chatTranscript';
+import type { PromptAttachment } from '@/clientFrames';
+import { shouldShowThinkingIndicator } from '@/chatListState';
+import { useChatListAutoScroll } from '@/hooks/useChatListAutoScroll';
+import { buildMessageActions } from '@/messageActions';
+import { buildToolGroupUi } from '@/toolGroupUi';
+import { MobileIcon } from './MobileIcon';
+import { ThinkingIndicator } from './ThinkingIndicator';
+
+interface ChatListProps {
+  readonly items: ReadonlyArray<TranscriptItem>;
+  readonly sending?: boolean;
+  readonly copiedMessageId?: string | null;
+  readonly onCopyMessage?: (messageId: string, text: string) => void;
+}
+
+export function ChatList({ items, sending = false, copiedMessageId = null, onCopyMessage }: ChatListProps) {
+  const autoScroll = useChatListAutoScroll(items, sending);
+  return (
+    <ScrollView
+      ref={autoScroll.scrollRef}
+      className="flex-1"
+      contentContainerClassName="gap-4 px-5 pb-5 pt-20"
+      contentContainerStyle={{ gap: 16, paddingBottom: 20, paddingHorizontal: 20, paddingTop: 82 }}
+      onContentSizeChange={autoScroll.scrollToEnd}
+    >
+      {items.length === 0 ? (
+        <View className="mt-20">
+          <Text className="text-[27px] font-black leading-9 text-text">Moxxy Mobile</Text>
+          <Text className="mt-3 text-[16px] leading-7 text-muted">
+            Wybierz sesję z menu albo napisz wiadomość, żeby sterować tym samym runtime z telefonu.
+          </Text>
+        </View>
+      ) : null}
+      {items.map((item) => (
+        <MessageBlock
+          key={item.id}
+          item={item}
+          copied={copiedMessageId === item.id}
+          onCopyMessage={onCopyMessage}
+        />
+      ))}
+      {shouldShowThinkingIndicator({ items, sending }) ? <ThinkingIndicator /> : null}
+    </ScrollView>
+  );
+}
+
+function MessageBlock({
+  item,
+  copied,
+  onCopyMessage,
+}: {
+  readonly item: TranscriptItem;
+  readonly copied: boolean;
+  readonly onCopyMessage?: (messageId: string, text: string) => void;
+}) {
+  if (item.kind === 'user') {
+    const actions = buildMessageActions(item);
+    return (
+      <View
+        style={{ alignItems: 'flex-end', alignSelf: 'flex-end', flexDirection: 'row', gap: 8, maxWidth: '88%' }}
+        testID="mobile-user-message"
+      >
+        <CopyMessageButton
+          copied={copied}
+          hidden={!actions.copyText}
+          tone="user"
+          onPress={() => actions.copyText ? onCopyMessage?.(item.id, actions.copyText) : undefined}
+        />
+        <View
+          testID="mobile-user-block"
+          style={{
+            backgroundColor: '#ec4899',
+            borderBottomLeftRadius: 16,
+            borderBottomRightRadius: 4,
+            borderTopLeftRadius: 16,
+            borderTopRightRadius: 16,
+            flexShrink: 1,
+            maxWidth: '100%',
+            paddingHorizontal: 16,
+            paddingVertical: 12,
+            shadowColor: '#ec4899',
+            shadowOffset: { width: 0, height: 6 },
+            shadowOpacity: 0.2,
+            shadowRadius: 14,
+          }}
+        >
+          <Text className="text-[15px] leading-6 text-white">{item.text}</Text>
+          {item.attachments && item.attachments.length > 0 ? (
+            <View style={{ gap: 5, marginTop: item.text.trim().length > 0 ? 10 : 0 }}>
+              {item.attachments.map((attachment, index) => (
+                <MessageAttachmentChip key={`${attachment.kind}:${attachment.name ?? index}:${index}`} attachment={attachment} />
+              ))}
+            </View>
+          ) : null}
+        </View>
+      </View>
+    );
+  }
+
+  if (item.kind === 'assistant') {
+    return <AssistantMessage copied={copied} message={item} onCopyMessage={onCopyMessage} />;
+  }
+
+  if (item.kind === 'tool-group') {
+    return <ToolGroupMessage group={item} />;
+  }
+
+  if (item.kind === 'system-group') {
+    return <SystemGroupMessage group={item} />;
+  }
+
+  return (
+    <View
+      className="rounded-block border border-cardBorder bg-cardBg"
+      style={{
+        alignSelf: 'center',
+        borderColor: '#fecaca',
+        borderRadius: 10,
+        borderWidth: 1,
+        maxWidth: '92%',
+        paddingHorizontal: 12,
+        paddingVertical: 8,
+      }}
+    >
+      <Text className="text-[12px] font-bold text-red">{item.label}</Text>
+      <Text className="mt-1 text-[13px] leading-5 text-muted">{item.text}</Text>
+    </View>
+  );
+}
+
+function MessageAttachmentChip({ attachment }: { readonly attachment: PromptAttachment }) {
+  const summary = summarizeAttachment(attachment);
+  return (
+    <View
+      style={{
+        alignItems: 'center',
+        alignSelf: 'flex-start',
+        backgroundColor: 'rgba(255,255,255,0.18)',
+        borderColor: 'rgba(255,255,255,0.28)',
+        borderRadius: 999,
+        borderWidth: 1,
+        flexDirection: 'row',
+        gap: 6,
+        maxWidth: '100%',
+        paddingHorizontal: 9,
+        paddingVertical: 5,
+      }}
+    >
+      <Text style={{ color: '#ffffff', fontSize: 10, fontWeight: '800', opacity: 0.78 }}>{summary.detail}</Text>
+      <Text style={{ color: '#ffffff', fontSize: 11, fontWeight: '800', maxWidth: 150 }} numberOfLines={1}>
+        {summary.label}
+      </Text>
+    </View>
+  );
+}
+
+function CopyMessageButton({
+  copied,
+  hidden,
+  tone,
+  onPress,
+}: {
+  readonly copied: boolean;
+  readonly hidden: boolean;
+  readonly tone: 'assistant' | 'user';
+  readonly onPress: () => void;
+}) {
+  if (hidden) return <View style={{ height: 32, width: 32 }} />;
+  const activeColor = copied ? '#16a34a' : tone === 'user' ? '#db2777' : '#64748b';
+  return (
+    <Pressable
+      accessibilityLabel={copied ? 'Message copied' : 'Copy message'}
+      accessibilityRole="button"
+      onPress={onPress}
+      style={{
+        alignItems: 'center',
+        backgroundColor: copied ? '#ecfdf5' : '#ffffff',
+        borderColor: copied ? '#bbf7d0' : '#e3e5f0',
+        borderRadius: 999,
+        borderWidth: 1,
+        height: 32,
+        justifyContent: 'center',
+        shadowColor: '#0f172a',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.08,
+        shadowRadius: 10,
+        width: 32,
+      }}
+    >
+      <MobileIcon name={copied ? 'check' : 'copy'} size={15} strokeWidth={2.4} color={activeColor} />
+    </Pressable>
+  );
+}
+
+function AssistantMessage({
+  copied,
+  message,
+  onCopyMessage,
+}: {
+  readonly copied: boolean;
+  readonly message: AssistantTranscriptItem;
+  readonly onCopyMessage?: (messageId: string, text: string) => void;
+}) {
+  const actions = buildMessageActions(message);
+  return (
+    <View
+      testID="mobile-assistant-block"
+      style={{ alignSelf: 'stretch', flexDirection: 'row', gap: 12, maxWidth: '96%' }}
+    >
+      <View
+        className="bg-primarySoft"
+        style={{ alignItems: 'center', borderRadius: 10, height: 34, justifyContent: 'center', width: 34 }}
+      >
+        <MobileIcon name="message" size={18} strokeWidth={2.35} color="#db2777" />
+      </View>
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <View style={{ alignItems: 'center', flexDirection: 'row', gap: 8 }}>
+          <Text className="text-[13px] font-bold text-text">{message.label}</Text>
+          {message.streaming ? (
+            <View className="rounded-pill bg-primarySoft px-2 py-0.5">
+              <Text className="text-[11px] font-bold text-primary">typing...</Text>
+            </View>
+          ) : null}
+          <View style={{ flex: 1 }} />
+          <CopyMessageButton
+            copied={copied}
+            hidden={!actions.copyText}
+            tone="assistant"
+            onPress={() => actions.copyText ? onCopyMessage?.(message.id, actions.copyText) : undefined}
+          />
+        </View>
+        <Text className="mt-1 text-[15px] leading-6 text-text">{message.text}</Text>
+        {!message.streaming && message.stopReason && message.stopReason !== 'end_turn' ? (
+          <Text className="mt-1 text-[10px] font-bold uppercase text-dim">stop: {message.stopReason.replace(/_/g, ' ')}</Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+function ToolGroupMessage({ group }: { readonly group: ToolGroupTranscriptItem }) {
+  const [open, setOpen] = useState(false);
+  const ui = buildToolGroupUi(group.tools);
+
+  return (
+    <View
+      style={{
+        alignSelf: 'stretch',
+        flexDirection: 'row',
+        gap: 12,
+        maxWidth: '96%',
+      }}
+    >
+      <View
+        style={{ alignItems: 'center', backgroundColor: ui.tint, borderRadius: 10, height: 34, justifyContent: 'center', width: 34 }}
+      >
+        <MobileIcon name="bolt" size={17} strokeWidth={2.35} color={ui.accent} />
+      </View>
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityState={{ expanded: open }}
+          onPress={() => setOpen((value) => !value)}
+          style={{ alignItems: 'center', flexDirection: 'row', gap: 8, minHeight: 34 }}
+        >
+          <Text className="text-[13px] font-bold text-text">{group.title}</Text>
+          <Text className="text-[11px] font-bold text-dim">{group.tools.length}</Text>
+          <View
+            style={{
+              alignItems: 'center',
+              backgroundColor: ui.tint,
+              borderRadius: 999,
+              flexDirection: 'row',
+              gap: 5,
+              paddingHorizontal: 8,
+              paddingVertical: 3,
+            }}
+          >
+            {ui.pulse ? (
+              <View
+                style={{
+                  backgroundColor: ui.accent,
+                  borderRadius: 999,
+                  height: 6,
+                  width: 6,
+                }}
+              />
+            ) : null}
+            <Text style={{ color: ui.accent, fontSize: 11, fontWeight: '800' }}>{ui.statusLabel}</Text>
+          </View>
+          <Text className="flex-1 text-[11px] font-medium text-dim" numberOfLines={1}>
+            {ui.summary || group.summary}
+          </Text>
+          <Text className="text-[16px] font-bold text-dim">{open ? '-' : '+'}</Text>
+        </Pressable>
+        {open ? (
+          <View className="mt-2 overflow-hidden rounded-block border border-cardBorder bg-cardBg">
+            {group.tools.map((tool, index) => (
+              <View
+                key={tool.id}
+                style={{
+                  borderTopColor: '#e3e5f0',
+                  borderTopWidth: index === 0 ? 0 : 1,
+                  paddingHorizontal: 10,
+                  paddingVertical: 8,
+                }}
+              >
+                <View style={{ alignItems: 'center', flexDirection: 'row', gap: 8 }}>
+                  <View
+                    style={{
+                      backgroundColor: statusColor(tool.status),
+                      borderRadius: 999,
+                      height: 7,
+                      width: 7,
+                    }}
+                  />
+                  <Text className="text-[12px] font-bold text-text">{tool.name}</Text>
+                  <Text className="text-[11px] font-bold text-dim">{statusLabel(tool.status)}</Text>
+                </View>
+                {tool.summary ? (
+                  <Text className="mt-1 text-[11px] leading-4 text-muted" numberOfLines={2}>
+                    {tool.summary}
+                  </Text>
+                ) : null}
+              </View>
+            ))}
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+function SystemGroupMessage({ group }: { readonly group: SystemGroupTranscriptItem }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <View style={{ alignSelf: 'stretch', flexDirection: 'row', gap: 12, maxWidth: '96%' }}>
+      <View className="h-[34px] w-[34px] items-center justify-center rounded-block bg-appBg">
+        <MobileIcon name="more" size={17} strokeWidth={2.35} color="#94a3b8" />
+      </View>
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityState={{ expanded: open }}
+          onPress={() => setOpen((value) => !value)}
+          style={{ alignItems: 'center', flexDirection: 'row', gap: 8, minHeight: 34 }}
+        >
+          <Text className="text-[12px] font-bold text-muted">{group.title}</Text>
+          <Text className="text-[11px] font-bold text-dim">{group.count} events</Text>
+          <Text className="flex-1 text-[11px] text-dim" numberOfLines={1}>
+            collapsed
+          </Text>
+          <Text className="text-[16px] font-bold text-dim">{open ? '-' : '+'}</Text>
+        </Pressable>
+        {open ? (
+          <View className="mt-2 rounded-block border border-cardBorder bg-cardBg px-3 py-2">
+            {group.events.map((event) => (
+              <View key={event.id} className="py-1">
+                <Text className="text-[11px] font-bold text-muted">{event.type}</Text>
+                <Text className="text-[11px] leading-4 text-dim">{event.text}</Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+function statusColor(status: 'running' | 'ok' | 'error'): string {
+  if (status === 'ok') return '#16a34a';
+  if (status === 'error') return '#ef4444';
+  return '#ec4899';
+}
+
+function statusLabel(status: 'running' | 'ok' | 'error'): string {
+  if (status === 'ok') return 'ok';
+  if (status === 'error') return 'failed';
+  return 'running';
+}

--- a/apps/mobile/src/components/CompactContextSheet.tsx
+++ b/apps/mobile/src/components/CompactContextSheet.tsx
@@ -1,0 +1,67 @@
+import { Pressable, Text, View } from 'react-native';
+import { MobileIcon } from './MobileIcon';
+
+interface CompactContextSheetProps {
+  readonly open: boolean;
+  readonly compacting: boolean;
+  readonly onCancel: () => void;
+  readonly onConfirm: () => void;
+}
+
+export function CompactContextSheet(props: CompactContextSheetProps) {
+  if (!props.open) return null;
+
+  return (
+    <View
+      className="rounded-card border border-cardBorder bg-cardBg p-4 shadow-card"
+      style={{ borderColor: '#e3e5f0', borderRadius: 16, borderWidth: 1, gap: 12 }}
+    >
+      <View style={{ alignItems: 'center', flexDirection: 'row', gap: 10 }}>
+        <View
+          style={{
+            alignItems: 'center',
+            backgroundColor: '#fdf2f8',
+            borderRadius: 12,
+            height: 38,
+            justifyContent: 'center',
+            width: 38,
+          }}
+        >
+          <MobileIcon name="actions" size={19} strokeWidth={2.45} color="#db2777" />
+        </View>
+        <View style={{ flex: 1 }}>
+          <Text className="text-[17px] font-black text-text">Compact context?</Text>
+          <Text className="mt-0.5 text-[12px] font-semibold text-muted">
+            Older turns will be summarized to free the model window.
+          </Text>
+        </View>
+      </View>
+
+      <Text className="text-[12px] leading-5 text-muted">
+        This locks the composer while Moxxy summarizes the current session. The smaller context is used on the next message.
+      </Text>
+
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <Pressable
+          accessibilityLabel="Cancel compaction"
+          className="flex-1 items-center justify-center rounded-block border border-cardBorder"
+          style={{ minHeight: 42 }}
+          onPress={props.onCancel}
+        >
+          <Text className="text-[13px] font-bold text-muted">Cancel</Text>
+        </Pressable>
+        <Pressable
+          accessibilityLabel="Confirm context compaction"
+          className="flex-1 items-center justify-center rounded-block bg-primary"
+          disabled={props.compacting}
+          style={{ minHeight: 42, opacity: props.compacting ? 0.65 : 1 }}
+          onPress={props.onConfirm}
+        >
+          <Text className="text-[13px] font-bold text-white">
+            {props.compacting ? 'Compacting...' : 'Compact now'}
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/ComposerActionMenu.tsx
+++ b/apps/mobile/src/components/ComposerActionMenu.tsx
@@ -1,0 +1,120 @@
+import { Pressable, Text, View } from 'react-native';
+import { buildComposerAttachmentActionItems, buildQuickActionItems, type ComposerAttachmentActionItem, type QuickActionItem } from '../navigation';
+import type { MobileIconName } from './MobileIcon';
+import { MobileIcon } from './MobileIcon';
+
+interface ComposerActionMenuProps {
+  readonly open: boolean;
+  readonly autoApprove: boolean;
+  readonly onToggleOpen: () => void;
+  readonly onGoal: () => void;
+  readonly onToggleAutoApprove: () => void;
+  readonly onNewSession: () => void;
+  readonly onCompact: () => void;
+  readonly onPickImage: () => void;
+  readonly onPickFile: () => void;
+  readonly onCommand: (name: string, args?: string) => void;
+}
+
+interface ComposerMenuItem {
+  readonly id: string;
+  readonly icon: MobileIconName;
+  readonly label: string;
+  readonly active?: boolean;
+}
+
+export function ComposerActionMenu(props: ComposerActionMenuProps) {
+  if (!props.open) return null;
+
+  const attachmentItems = buildComposerAttachmentActionItems();
+  const items = buildQuickActionItems(props.autoApprove);
+  const runAttachmentAction = (id: ComposerAttachmentActionItem['id']) => {
+    if (id === 'attachImage') {
+      props.onPickImage();
+    } else {
+      props.onPickFile();
+    }
+    props.onToggleOpen();
+  };
+  const runAction = (id: QuickActionItem['id']) => {
+    if (id === 'goal') {
+      props.onGoal();
+      props.onToggleOpen();
+      return;
+    }
+    if (id === 'autoApprove') {
+      props.onToggleAutoApprove();
+      props.onToggleOpen();
+      return;
+    }
+    if (id === 'compact') {
+      props.onCompact();
+      props.onToggleOpen();
+      return;
+    }
+    props.onNewSession();
+    props.onToggleOpen();
+  };
+
+  return (
+    <View
+      className="absolute z-20 rounded-card border border-cardBorder bg-cardBg shadow-card"
+      style={{
+        borderColor: '#e3e5f0',
+        borderRadius: 12,
+        borderWidth: 1,
+        bottom: 126,
+        left: 16,
+        padding: 4,
+        position: 'absolute',
+        width: 236,
+        zIndex: 20,
+      }}
+    >
+      <View className="flex-row items-center justify-between" style={{ alignItems: 'center', flexDirection: 'row', paddingHorizontal: 6, paddingVertical: 4 }}>
+        <Text className="text-[11px] font-black uppercase text-dim">Actions</Text>
+        <Pressable accessibilityLabel="Close actions" className="h-9 w-9 items-center justify-center rounded-pill" onPress={props.onToggleOpen}>
+          <MobileIcon name="x" size={18} color="#64748b" />
+        </Pressable>
+      </View>
+      <View style={{ gap: 4, paddingBottom: 4 }}>
+        {attachmentItems.map((item) => (
+          <MenuButton key={item.id} item={item} onPress={() => runAttachmentAction(item.id)} />
+        ))}
+      </View>
+      <View>
+        {items.map((item) => (
+          <MenuButton key={item.id} item={item} onPress={() => runAction(item.id)} />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function MenuButton({ item, onPress }: { readonly item: ComposerMenuItem | QuickActionItem | ComposerAttachmentActionItem; readonly onPress: () => void }) {
+  return (
+    <Pressable
+      className={item.active ? 'bg-primarySoft' : 'bg-transparent'}
+      style={{
+        alignItems: 'center',
+        borderRadius: 8,
+        flexDirection: 'row',
+        gap: 9,
+        minHeight: 40,
+        paddingHorizontal: 10,
+        width: '100%',
+      }}
+      onPress={onPress}
+    >
+      <View
+        className={item.active ? 'bg-cardBg' : 'bg-primarySoft'}
+        style={{ alignItems: 'center', borderRadius: 8, height: 28, justifyContent: 'center', width: 28 }}
+      >
+        <MobileIcon name={item.icon} size={15} strokeWidth={2.35} color={item.active ? '#db2777' : '#64748b'} />
+      </View>
+      <Text className={`flex-1 text-[13px] font-bold ${item.active ? 'text-primaryStrong' : 'text-text'}`}>
+        {item.label}
+      </Text>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/components/ComposerBar.tsx
+++ b/apps/mobile/src/components/ComposerBar.tsx
@@ -1,0 +1,57 @@
+import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+
+interface ComposerBarProps {
+  readonly text: string;
+  readonly onTextChange: (value: string) => void;
+  readonly onSubmit: () => void;
+}
+
+export function ComposerBar({ text, onTextChange, onSubmit }: ComposerBarProps) {
+  return (
+    <View style={styles.root}>
+      <TextInput
+        value={text}
+        onChangeText={onTextChange}
+        multiline
+        placeholder="Message"
+        placeholderTextColor="#6b7280"
+        style={styles.input}
+      />
+      <Pressable style={styles.button} onPress={onSubmit}>
+        <Text style={styles.buttonText}>Send</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flexDirection: 'row',
+    gap: 10,
+    alignItems: 'flex-end',
+  },
+  input: {
+    flex: 1,
+    minHeight: 46,
+    maxHeight: 120,
+    borderRadius: 6,
+    borderColor: '#4b5563',
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    color: '#f9fafb',
+    backgroundColor: '#0f172a',
+  },
+  button: {
+    minWidth: 76,
+    minHeight: 46,
+    borderRadius: 6,
+    backgroundColor: '#2563eb',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  buttonText: {
+    color: '#ffffff',
+    fontWeight: '800',
+  },
+});

--- a/apps/mobile/src/components/ComposerCard.tsx
+++ b/apps/mobile/src/components/ComposerCard.tsx
@@ -1,0 +1,266 @@
+import { Pressable, Text, TextInput, View } from 'react-native';
+import { summarizeAttachment } from '@/attachments';
+import { buildComposerUiState } from '@/composerUi';
+import type { PromptAttachment } from '@/clientFrames';
+import { ComposerActionMenu } from './ComposerActionMenu';
+import { ContextMeter } from './ContextMeter';
+import { MobileIcon } from './MobileIcon';
+
+interface ComposerCardProps {
+  readonly text: string;
+  readonly sending: boolean;
+  readonly compacting: boolean;
+  readonly autoApprove: boolean;
+  readonly actionsOpen: boolean;
+  readonly voicePhase: 'idle' | 'recording' | 'transcribing' | 'error';
+  readonly voiceError: string | null;
+  readonly attachments: ReadonlyArray<PromptAttachment>;
+  readonly attachmentError: string | null;
+  readonly readOnly?: boolean;
+  readonly usage: Record<string, unknown> | null;
+  readonly onTextChange: (value: string) => void;
+  readonly onSubmit: () => void;
+  readonly onAbort: () => void;
+  readonly onToggleActions: () => void;
+  readonly onGoal: () => void;
+  readonly onVoice: () => void;
+  readonly onPickImage: () => void;
+  readonly onPickFile: () => void;
+  readonly onRemoveAttachment: (index: number) => void;
+  readonly onToggleAutoApprove: () => void;
+  readonly onNewSession: () => void;
+  readonly onCompact: () => void;
+  readonly onCommand: (name: string, args?: string) => void;
+}
+
+export function ComposerCard(props: ComposerCardProps) {
+  const ui = buildComposerUiState({
+    text: props.text,
+    sending: props.sending,
+    compacting: props.compacting,
+    actionsOpen: props.actionsOpen,
+    autoApprove: props.autoApprove,
+    attachmentCount: props.attachments.length,
+    voicePhase: props.voicePhase,
+    readOnly: props.readOnly,
+  });
+  const sendBackground = ui.sendTone === 'danger'
+    ? '#ef4444'
+    : ui.sendTone === 'disabled'
+      ? '#e3e5f0'
+      : '#ec4899';
+  const sendIconColor = ui.sendTone === 'disabled' ? '#94a3b8' : '#ffffff';
+
+  return (
+    <View className="relative z-30 px-4 pb-3 pt-2" style={{ paddingBottom: 12, paddingHorizontal: 16, paddingTop: 8 }}>
+      <ComposerActionMenu
+        open={props.actionsOpen}
+        autoApprove={props.autoApprove}
+        onToggleOpen={props.onToggleActions}
+        onGoal={props.onGoal}
+        onToggleAutoApprove={props.onToggleAutoApprove}
+        onNewSession={props.onNewSession}
+        onCompact={props.onCompact}
+        onPickImage={props.onPickImage}
+        onPickFile={props.onPickFile}
+        onCommand={props.onCommand}
+      />
+
+      <View
+        className="rounded-card border border-cardBorder bg-cardBg shadow-card"
+        style={{
+          borderColor: ui.frameTone === 'bypass' ? '#ec4899' : '#e3e5f0',
+          borderRadius: 16,
+          borderWidth: ui.frameTone === 'bypass' ? 2 : 1,
+          paddingHorizontal: 12,
+          paddingVertical: 10,
+          shadowColor: ui.frameTone === 'bypass' ? '#ec4899' : '#0f172a',
+          shadowOffset: { width: 0, height: 10 },
+          shadowOpacity: ui.frameTone === 'bypass' ? 0.14 : 0.05,
+          shadowRadius: ui.frameTone === 'bypass' ? 22 : 14,
+        }}
+      >
+        {props.attachments.length > 0 ? (
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginBottom: 8 }}>
+            {props.attachments.map((attachment, index) => (
+              <AttachmentChip
+                key={`${attachment.kind}:${attachment.name ?? index}:${index}`}
+                attachment={attachment}
+                onRemove={() => props.onRemoveAttachment(index)}
+              />
+            ))}
+          </View>
+        ) : null}
+        {ui.bypassActive ? (
+          <View
+            style={{
+              alignItems: 'center',
+              backgroundColor: '#fdf2f8',
+              borderColor: '#ec4899',
+              borderRadius: 999,
+              borderWidth: 1,
+              height: 28,
+              justifyContent: 'center',
+              position: 'absolute',
+              right: 12,
+              top: -14,
+              width: 28,
+              zIndex: 2,
+            }}
+          >
+            <MobileIcon name="bolt" size={14} strokeWidth={2.6} color="#db2777" />
+          </View>
+        ) : null}
+        <TextInput
+          value={props.text}
+          onChangeText={props.onTextChange}
+          multiline
+          placeholder={ui.placeholder}
+          placeholderTextColor="#94a3b8"
+          editable={!ui.disabled}
+          className="text-text"
+          style={{
+            backgroundColor: 'transparent',
+            color: '#0f172a',
+            fontSize: 15,
+            lineHeight: 23,
+            maxHeight: 132,
+            minHeight: 48,
+            paddingHorizontal: 4,
+            paddingVertical: 4,
+          }}
+        />
+        {props.voiceError ? (
+          <Text className="mt-1 px-1 text-[12px] font-semibold text-red">
+            {props.voiceError}
+          </Text>
+        ) : null}
+        {props.attachmentError ? (
+          <Text className="mt-1 px-1 text-[12px] font-semibold text-red">
+            {props.attachmentError}
+          </Text>
+        ) : null}
+
+        <View className="flex-row flex-wrap items-center" style={{ alignItems: 'center', flexDirection: 'row', gap: 6, marginTop: 8 }}>
+          <Pressable
+            accessibilityLabel="Open actions"
+            className={ui.actionsTone === 'active' ? 'bg-primarySoft' : 'bg-cardBg'}
+            style={{
+              alignItems: 'center',
+              borderColor: ui.actionsTone === 'active' ? '#ec4899' : '#e3e5f0',
+              borderRadius: 10,
+              borderWidth: 1,
+              height: 38,
+              justifyContent: 'center',
+              width: 38,
+            }}
+            onPress={props.onToggleActions}
+          >
+            <MobileIcon name="plus" size={18} strokeWidth={2.35} color={ui.actionsTone === 'active' ? '#db2777' : '#475569'} />
+          </Pressable>
+
+          <Pressable
+            accessibilityLabel="Voice input"
+            style={{
+              alignItems: 'center',
+              backgroundColor: ui.voiceTone === 'recording' ? '#fdf2f8' : '#ffffff',
+              borderColor: ui.voiceTone === 'neutral' ? '#e3e5f0' : '#ec4899',
+              borderRadius: 10,
+              borderWidth: 1,
+              flexDirection: 'row',
+              gap: 6,
+              height: 38,
+              justifyContent: 'center',
+              paddingHorizontal: 10,
+            }}
+            onPress={props.onVoice}
+          >
+            <MobileIcon
+              name="mic"
+              size={16}
+              strokeWidth={2.35}
+              color={ui.voiceTone === 'neutral' ? '#475569' : '#db2777'}
+            />
+            <Text
+              className="text-[12px] font-bold"
+              style={{ color: ui.voiceTone === 'neutral' ? '#475569' : '#db2777' }}
+            >
+              {ui.voiceLabel}
+            </Text>
+          </Pressable>
+
+          <View style={{ flex: 1, minWidth: 8 }} />
+          {ui.statusLabel ? (
+            <View
+              className="rounded-pill bg-primarySoft"
+              style={{ alignItems: 'center', height: 28, justifyContent: 'center', paddingHorizontal: 9 }}
+            >
+              <Text className="text-[11px] font-bold text-primaryStrong">{ui.statusLabel}</Text>
+            </View>
+          ) : null}
+          <ContextMeter usage={props.usage} />
+
+          <Pressable
+            accessibilityLabel={props.sending ? 'Stop response' : 'Send message'}
+            disabled={!props.sending && !ui.canSubmit}
+            style={{
+              alignItems: 'center',
+              backgroundColor: sendBackground,
+              borderRadius: 12,
+              height: 38,
+              justifyContent: 'center',
+              shadowColor: '#ec4899',
+              shadowOffset: { width: 0, height: 8 },
+              shadowOpacity: ui.sendTone === 'disabled' ? 0 : 0.25,
+              shadowRadius: 14,
+              width: 38,
+            }}
+            onPress={props.sending ? props.onAbort : props.onSubmit}
+          >
+            <MobileIcon name={ui.sendIcon} size={17} strokeWidth={2.55} color={sendIconColor} />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function AttachmentChip({
+  attachment,
+  onRemove,
+}: {
+  readonly attachment: PromptAttachment;
+  readonly onRemove: () => void;
+}) {
+  const summary = summarizeAttachment(attachment);
+  return (
+    <View
+      style={{
+        alignItems: 'center',
+        backgroundColor: '#f8fafc',
+        borderColor: '#e3e5f0',
+        borderRadius: 999,
+        borderWidth: 1,
+        flexDirection: 'row',
+        gap: 6,
+        maxWidth: '100%',
+        minHeight: 30,
+        paddingLeft: 9,
+        paddingRight: 4,
+      }}
+    >
+      <Text className="text-[11px] font-bold text-muted">{summary.detail}</Text>
+      <Text className="max-w-[150px] text-[12px] font-bold text-text" numberOfLines={1}>
+        {summary.label}
+      </Text>
+      <Pressable
+        accessibilityLabel={`Remove ${summary.label}`}
+        accessibilityRole="button"
+        onPress={onRemove}
+        style={{ alignItems: 'center', height: 24, justifyContent: 'center', width: 24 }}
+      >
+        <MobileIcon name="x" size={13} strokeWidth={2.4} color="#64748b" />
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/ConnectionBanner.tsx
+++ b/apps/mobile/src/components/ConnectionBanner.tsx
@@ -1,0 +1,35 @@
+import { Link } from 'expo-router';
+import { Pressable, Text, View } from 'react-native';
+import { MobileIcon } from './MobileIcon';
+
+interface ConnectionBannerProps {
+  readonly paired: boolean;
+  readonly connected: boolean;
+  readonly status: string;
+}
+
+export function ConnectionBanner({ paired, connected, status }: ConnectionBannerProps) {
+  if (paired && connected) return null;
+
+  const title = paired ? 'Gateway reconnecting' : 'Pair the mobile app';
+  const body = paired
+    ? `Socket status: ${status}. Chat and sessions will sync when the gateway responds.`
+    : 'Open Settings to pair this device with the Mobile Gateway.';
+
+  return (
+    <View className="flex-row items-center gap-3 rounded-card border border-cardBorder bg-cardBg px-4 py-3 shadow-card">
+      <View className="h-10 w-10 items-center justify-center rounded-pill bg-primarySoft">
+        <MobileIcon name={paired ? 'wifi' : 'wifiOff'} size={19} strokeWidth={2.5} color="#db2777" />
+      </View>
+      <View className="min-w-0 flex-1">
+        <Text className="text-[14px] font-bold text-text">{title}</Text>
+        <Text className="mt-0.5 text-[12px] leading-4 text-muted">{body}</Text>
+      </View>
+      <Link href="/settings" asChild>
+        <Pressable className="min-h-10 justify-center rounded-block bg-primary px-3">
+          <Text className="text-[12px] font-black text-white">Settings</Text>
+        </Pressable>
+      </Link>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/ConnectionSettings.tsx
@@ -1,0 +1,126 @@
+import { Pressable, Switch, Text, TextInput, View } from 'react-native';
+import type { CameraPermissionState } from '../pairingUi';
+import { buildPairingUiState } from '../pairingUi';
+import { MobileIcon } from './MobileIcon';
+
+interface ConnectionSettingsProps {
+  readonly gatewayUrl: string;
+  readonly token: string | null;
+  readonly code: string;
+  readonly loading: boolean;
+  readonly error: string | null;
+  readonly autoApprove: boolean;
+  readonly socketStatus: string;
+  readonly qrScanning: boolean;
+  readonly qrPermission: CameraPermissionState;
+  readonly manualPairingOpen: boolean;
+  readonly activeMode?: string | null;
+  readonly activeProvider?: string | null;
+  readonly onGatewayUrlChange: (value: string) => void;
+  readonly onScanQr: () => void;
+  readonly onToggleManualPairing: () => void;
+  readonly onRefreshPairing: () => void;
+  readonly onPair: () => void;
+  readonly onDisconnect: () => void;
+  readonly onAutoApproveChange: (value: boolean) => void;
+}
+
+export function ConnectionSettings(props: ConnectionSettingsProps) {
+  const canPair = props.code.length > 0 && !props.loading;
+  const pairingUi = buildPairingUiState({
+    token: props.token,
+    scanning: props.qrScanning,
+    permission: props.qrPermission,
+  });
+  return (
+    <View className="gap-4">
+      <View className="gap-3 rounded-card border border-cardBorder bg-cardBg p-4 shadow-card">
+        <View className="flex-row items-center justify-between">
+          <Text className="text-[16px] font-bold text-text">Gateway</Text>
+          <View className={`rounded-pill px-2.5 py-1 ${props.token ? 'bg-green/10' : 'bg-amber/10'}`}>
+            <Text className={`text-[11px] font-black ${props.token ? 'text-green' : 'text-amber'}`}>
+              {pairingUi.statusLabel}
+            </Text>
+          </View>
+        </View>
+        <Pressable
+          className={`min-h-14 flex-row items-center justify-center gap-2 rounded-block ${pairingUi.scanButtonEnabled ? 'bg-primary' : 'bg-cardBorder'}`}
+          disabled={!pairingUi.scanButtonEnabled}
+          onPress={props.onScanQr}
+        >
+          <MobileIcon name="camera" color={pairingUi.scanButtonEnabled ? '#ffffff' : '#94a3b8'} size={21} />
+          <Text className={`text-[14px] font-black ${pairingUi.scanButtonEnabled ? 'text-white' : 'text-dim'}`}>
+            {pairingUi.scanButtonLabel}
+          </Text>
+        </Pressable>
+        <Pressable
+          className="min-h-11 flex-row items-center justify-between rounded-block border border-cardBorder bg-cardBg px-3"
+          onPress={props.onToggleManualPairing}
+        >
+          <Text className="text-[13px] font-bold text-muted">{pairingUi.manualPairingToggleLabel}</Text>
+          <Text className="text-[18px] font-black text-primaryStrong">{props.manualPairingOpen ? '-' : '+'}</Text>
+        </Pressable>
+        {props.manualPairingOpen || pairingUi.manualPairingVisible ? (
+          <View className="gap-3">
+            <TextInput
+              value={props.gatewayUrl}
+              onChangeText={props.onGatewayUrlChange}
+              autoCapitalize="none"
+              autoCorrect={false}
+              inputMode="url"
+              className="min-h-11 rounded-block border border-cardBorder bg-cardBg px-3 text-[14px] text-text"
+            />
+            <View className="items-center rounded-card bg-primarySoft px-4 py-4">
+              <Text className="text-[11px] font-black uppercase text-primaryStrong">Pairing code</Text>
+              <Text className="mt-1 text-[34px] font-black text-primaryStrong">{props.code || '------'}</Text>
+            </View>
+            <View className="flex-row gap-2">
+              <Pressable className="min-h-11 flex-1 items-center justify-center rounded-block border border-cardBorder bg-cardBg" onPress={props.onRefreshPairing}>
+                <Text className="text-[13px] font-bold text-muted">Refresh pairing</Text>
+              </Pressable>
+              <Pressable
+                className={`min-h-11 flex-1 items-center justify-center rounded-block ${canPair ? 'bg-primary' : 'bg-cardBorder'}`}
+                onPress={props.onPair}
+                disabled={!canPair}
+              >
+                <Text className="text-[13px] font-bold text-white">Pair</Text>
+              </Pressable>
+            </View>
+          </View>
+        ) : null}
+        {props.error ? (
+          <View className="rounded-block bg-red/10 px-3 py-2">
+            <Text className="text-[13px] font-semibold text-red">{props.error}</Text>
+          </View>
+        ) : null}
+        {props.token ? (
+          <Pressable className="min-h-11 items-center justify-center rounded-block bg-red" onPress={props.onDisconnect}>
+            <Text className="text-[13px] font-bold text-white">Disconnect</Text>
+          </Pressable>
+        ) : null}
+      </View>
+      <View className="gap-3 rounded-card border border-cardBorder bg-cardBg p-4 shadow-card">
+        <Text className="text-[16px] font-bold text-text">Runtime</Text>
+        <SettingRow label="Socket" value={props.socketStatus} />
+        <SettingRow label="Provider" value={props.activeProvider ?? 'Unknown'} />
+        <SettingRow label="Mode" value={props.activeMode ?? 'Unknown'} />
+        <View className="flex-row items-center justify-between">
+          <View className="mr-4 flex-1">
+            <Text className="text-[14px] font-bold text-text">Bypass mode</Text>
+            <Text className="text-[12px] leading-5 text-muted">Auto-approve tool calls for this workspace.</Text>
+          </View>
+          <Switch value={props.autoApprove} onValueChange={props.onAutoApproveChange} />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function SettingRow({ label, value }: { readonly label: string; readonly value: string }) {
+  return (
+    <View className="flex-row items-center justify-between border-b border-cardBorder py-2">
+      <Text className="text-[13px] font-semibold text-muted">{label}</Text>
+      <Text className="text-[13px] font-bold text-text">{value}</Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/ContextMeter.tsx
+++ b/apps/mobile/src/components/ContextMeter.tsx
@@ -1,0 +1,41 @@
+import { Text, View } from 'react-native';
+import { buildContextMeterUiState } from '../contextMeterUi';
+
+export function ContextMeter({ usage }: { readonly usage: Record<string, unknown> | null }) {
+  const prompt = typeof usage?.latestPrompt === 'number' ? usage.latestPrompt : null;
+  const contextWindow = typeof usage?.contextWindow === 'number' ? usage.contextWindow : null;
+  const ui = buildContextMeterUiState({ latestPrompt: prompt, contextWindow });
+  const fillColor = ui.tone === 'red' ? '#ef4444' : ui.tone === 'amber' ? '#f59e0b' : '#ec4899';
+
+  if (!ui.visible) {
+    return (
+      <View className="rounded-pill bg-appBg px-3 py-1">
+        <Text className="text-[11px] font-bold text-dim">Context</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-row items-center gap-2 rounded-pill bg-appBg px-3 py-1">
+      <View
+        style={{
+          backgroundColor: 'rgba(148, 163, 184, 0.22)',
+          borderRadius: 999,
+          height: 5,
+          overflow: 'hidden',
+          width: 30,
+        }}
+      >
+        <View
+          style={{
+            backgroundColor: fillColor,
+            borderRadius: 999,
+            height: '100%',
+            width: `${ui.fillPercent}%`,
+          }}
+        />
+      </View>
+      <Text className="text-[11px] font-bold tabular-nums text-dim">{ui.label}</Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/FloatingChatHeader.tsx
+++ b/apps/mobile/src/components/FloatingChatHeader.tsx
@@ -1,0 +1,98 @@
+import { Pressable, Text, View } from 'react-native';
+import { MobileIcon } from './MobileIcon';
+
+interface FloatingChatHeaderProps {
+  readonly connected: boolean;
+  readonly statusLabel: string;
+  readonly pendingActions: number;
+  readonly onToggleMenu: () => void;
+  readonly onNewSession: () => void;
+  readonly onToggleActions: () => void;
+}
+
+export function FloatingChatHeader({
+  connected,
+  statusLabel,
+  pendingActions,
+  onToggleMenu,
+  onNewSession,
+  onToggleActions,
+}: FloatingChatHeaderProps) {
+  return (
+    <View
+      className="z-30"
+      style={{
+        alignItems: 'center',
+        backgroundColor: '#fcfcff',
+        borderBottomColor: '#e3e5f0',
+        borderBottomWidth: 1,
+        flexDirection: 'row',
+        gap: 10,
+        height: 64,
+        left: 0,
+        paddingHorizontal: 16,
+        position: 'absolute',
+        right: 0,
+        top: 0,
+        zIndex: 30,
+      }}
+    >
+        <Pressable
+          accessibilityLabel="Open mobile menu"
+          className="items-center justify-center rounded-block bg-cardBg"
+          style={{ borderColor: '#e3e5f0', borderRadius: 10, borderWidth: 1, height: 40, width: 40 }}
+          onPress={onToggleMenu}
+        >
+          <MobileIcon name="menu" size={21} strokeWidth={2.4} color="#475569" />
+          {pendingActions > 0 ? (
+            <View
+              className="items-center rounded-pill bg-red"
+              style={{
+                minWidth: 20,
+                paddingHorizontal: 5,
+                paddingVertical: 1,
+                position: 'absolute',
+                right: -4,
+                top: -4,
+              }}
+            >
+              <Text className="text-[10px] font-black text-white">{pendingActions}</Text>
+            </View>
+          ) : null}
+        </Pressable>
+
+        <View
+          style={{ flex: 1, minWidth: 0 }}
+        >
+          <Text className="text-[18px] font-bold text-text">Chat</Text>
+          <View className="flex-row items-center gap-2">
+            <View className={`h-2.5 w-2.5 rounded-pill ${connected ? 'bg-green' : 'bg-amber'}`} />
+            <Text className="text-[12px] font-bold text-muted" numberOfLines={1}>
+              {statusLabel}
+            </Text>
+          </View>
+        </View>
+
+        <View
+          style={{ alignItems: 'center', flexDirection: 'row', gap: 6 }}
+        >
+          <Pressable
+            accessibilityLabel="New session"
+            className="items-center justify-center rounded-block"
+            style={{ borderRadius: 9, height: 36, width: 36 }}
+            onPress={onNewSession}
+          >
+            <MobileIcon name="edit" size={19} strokeWidth={2.3} color="#475569" />
+          </Pressable>
+          <Pressable
+            accessibilityLabel="More actions"
+            className="items-center justify-center rounded-block"
+            style={{ borderRadius: 9, height: 36, width: 36 }}
+            onPress={onToggleActions}
+          >
+            <MobileIcon name="more" size={20} strokeWidth={2.7} color="#475569" />
+          </Pressable>
+        </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/GoalSheet.tsx
+++ b/apps/mobile/src/components/GoalSheet.tsx
@@ -1,0 +1,42 @@
+import { Pressable, Text, TextInput, View } from 'react-native';
+import { MobileIcon } from './MobileIcon';
+
+interface GoalSheetProps {
+  readonly objective: string;
+  readonly canStart: boolean;
+  readonly onObjectiveChange: (value: string) => void;
+  readonly onStart: () => void;
+  readonly onClose?: () => void;
+}
+
+export function GoalSheet(props: GoalSheetProps) {
+  return (
+    <View className="gap-4 rounded-card border border-cardBorder bg-cardBg p-4 shadow-card">
+      <View className="flex-row items-center justify-between gap-3">
+        <Text className="text-[18px] font-black text-text">Start a goal</Text>
+        {props.onClose ? (
+          <Pressable accessibilityLabel="Close goal" className="h-10 w-10 items-center justify-center rounded-pill" onPress={props.onClose}>
+            <MobileIcon name="x" size={19} color="#64748b" />
+          </Pressable>
+        ) : null}
+      </View>
+      <TextInput
+        value={props.objective}
+        onChangeText={props.onObjectiveChange}
+        multiline
+        placeholder="Describe the objective to accomplish..."
+        placeholderTextColor="#94a3b8"
+        className="min-h-32 rounded-block border border-cardBorder bg-cardBg px-3 py-3 text-[14px] leading-5 text-text"
+      />
+      <Pressable
+        className={`min-h-11 items-center justify-center rounded-block ${
+          props.canStart ? 'bg-primary' : 'bg-cardBorder'
+        }`}
+        disabled={!props.canStart}
+        onPress={props.onStart}
+      >
+        <Text className="text-[13px] font-bold text-white">Start goal</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/MobileIcon.tsx
+++ b/apps/mobile/src/components/MobileIcon.tsx
@@ -1,0 +1,217 @@
+import Svg, { Circle, Line, Path, Polyline } from 'react-native-svg';
+import type { BottomTabItem, QuickActionItem } from '../navigation';
+
+export type MobileIconName =
+  | BottomTabItem['icon']
+  | QuickActionItem['icon']
+  | 'menu'
+  | 'folder'
+  | 'workflows'
+  | 'gateway'
+  | 'search'
+  | 'chevronDown'
+  | 'more'
+  | 'edit'
+  | 'copy'
+  | 'check'
+  | 'mic'
+  | 'send'
+  | 'stop'
+  | 'x'
+  | 'camera'
+  | 'wifi'
+  | 'wifiOff';
+
+interface MobileIconProps {
+  readonly name: MobileIconName;
+  readonly color: string;
+  readonly size?: number;
+  readonly strokeWidth?: number;
+}
+
+export function MobileIcon({ name, color, size = 20, strokeWidth = 2.35 }: MobileIconProps) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <IconPaths name={name} color={color} strokeWidth={strokeWidth} />
+    </Svg>
+  );
+}
+
+function sharedProps(color: string, strokeWidth: number) {
+  return {
+    stroke: color,
+    strokeWidth,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+  };
+}
+
+function IconPaths({ name, color, strokeWidth }: Required<Pick<MobileIconProps, 'name' | 'color' | 'strokeWidth'>>) {
+  const props = sharedProps(color, strokeWidth);
+  switch (name) {
+    case 'message':
+      return <Path {...props} d="M3 16.3c.2.8.1 1.4-.2 2.1L2 21l2.8-.8c.7-.2 1.3-.1 2 .2A10 10 0 1 0 3 16.3Z" />;
+    case 'sessions':
+      return (
+        <>
+          <Path {...props} d="m7 8 5-3 5 3-5 3-5-3Z" />
+          <Path {...props} d="m7 12 5 3 5-3" />
+          <Path {...props} d="m7 16 5 3 5-3" />
+        </>
+      );
+    case 'folder':
+      return (
+        <>
+          <Path {...props} d="M3.5 7.5a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-14a2 2 0 0 1-2-2v-10Z" />
+          <Path {...props} d="M3.5 10h18" />
+        </>
+      );
+    case 'actions':
+      return (
+        <>
+          <Circle {...props} cx="12" cy="12" r="9" />
+          <Path {...props} d="m8.5 12.2 2.4 2.4 5-5.4" />
+        </>
+      );
+    case 'goals':
+      return (
+        <>
+          <Path {...props} d="M5 21V4" />
+          <Path {...props} d="M5 5h11l-2 4 2 4H5" />
+        </>
+      );
+    case 'settings':
+      return (
+        <>
+          <Circle {...props} cx="12" cy="12" r="3" />
+          <Path {...props} d="M12 2v3" />
+          <Path {...props} d="M12 19v3" />
+          <Path {...props} d="M4.9 4.9 7 7" />
+          <Path {...props} d="m17 17 2.1 2.1" />
+          <Path {...props} d="M2 12h3" />
+          <Path {...props} d="M19 12h3" />
+          <Path {...props} d="m4.9 19.1 2.1-2.1" />
+          <Path {...props} d="m17 7 2.1-2.1" />
+        </>
+      );
+    case 'workflows':
+      return (
+        <>
+          <Path {...props} d="M5 7a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z" />
+          <Path {...props} d="M19 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z" />
+          <Path {...props} d="M5 21a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z" />
+          <Path {...props} d="M7 5h4a4 4 0 0 1 4 4v1" />
+          <Path {...props} d="M17 12h-4a4 4 0 0 0-4 4v1" />
+        </>
+      );
+    case 'gateway':
+      return (
+        <>
+          <Path {...props} d="M4 17.5V7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v10.5" />
+          <Path {...props} d="M8 21h8" />
+          <Path {...props} d="M12 17v4" />
+          <Path {...props} d="M8 10.5a6 6 0 0 1 8 0" />
+          <Path {...props} d="M10.5 13a2.5 2.5 0 0 1 3 0" />
+        </>
+      );
+    case 'search':
+      return (
+        <>
+          <Circle {...props} cx="10.5" cy="10.5" r="6.5" />
+          <Line {...props} x1="16" y1="16" x2="21" y2="21" />
+        </>
+      );
+    case 'chevronDown':
+      return <Path {...props} d="m6 9 6 6 6-6" />;
+    case 'menu':
+      return (
+        <>
+          <Line {...props} x1="5" y1="7" x2="19" y2="7" />
+          <Line {...props} x1="5" y1="12" x2="19" y2="12" />
+          <Line {...props} x1="5" y1="17" x2="15" y2="17" />
+        </>
+      );
+    case 'more':
+      return (
+        <>
+          <Circle {...props} cx="6" cy="12" r="1" />
+          <Circle {...props} cx="12" cy="12" r="1" />
+          <Circle {...props} cx="18" cy="12" r="1" />
+        </>
+      );
+    case 'edit':
+      return (
+        <>
+          <Path {...props} d="M12 20h9" />
+          <Path {...props} d="M16.5 3.5a2.1 2.1 0 0 1 3 3L8 18l-4 1 1-4 11.5-11.5Z" />
+        </>
+      );
+    case 'copy':
+      return (
+        <>
+          <Path {...props} d="M8 8.5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-8a2 2 0 0 1-2-2v-10Z" />
+          <Path {...props} d="M4 14.5v-10a2 2 0 0 1 2-2h8" />
+        </>
+      );
+    case 'check':
+      return <Path {...props} d="m5 12.5 4.2 4.2L19 6.8" />;
+    case 'plus':
+      return (
+        <>
+          <Line {...props} x1="12" y1="5" x2="12" y2="19" />
+          <Line {...props} x1="5" y1="12" x2="19" y2="12" />
+        </>
+      );
+    case 'bolt':
+      return <Path {...props} d="M13 2 5 14h7l-1 8 8-12h-7l1-8Z" />;
+    case 'mic':
+      return (
+        <>
+          <Path {...props} d="M12 14a3 3 0 0 0 3-3V6a3 3 0 0 0-6 0v5a3 3 0 0 0 3 3Z" />
+          <Path {...props} d="M6 10.5a6 6 0 0 0 12 0" />
+          <Path {...props} d="M12 17v4" />
+          <Path {...props} d="M9 21h6" />
+        </>
+      );
+    case 'send':
+      return (
+        <>
+          <Path {...props} d="m4 12 16-7-7 16-2-7-7-2Z" />
+          <Path {...props} d="m11 14 4-4" />
+        </>
+      );
+    case 'stop':
+      return <Path {...props} d="M8 8h8v8H8z" />;
+    case 'x':
+      return (
+        <>
+          <Line {...props} x1="7" y1="7" x2="17" y2="17" />
+          <Line {...props} x1="17" y1="7" x2="7" y2="17" />
+        </>
+      );
+    case 'camera':
+      return (
+        <>
+          <Path {...props} d="M7 7h1.8L10 5h4l1.2 2H17a3 3 0 0 1 3 3v7a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3v-7a3 3 0 0 1 3-3Z" />
+          <Circle {...props} cx="12" cy="13" r="3.2" />
+        </>
+      );
+    case 'wifi':
+      return (
+        <>
+          <Path {...props} d="M5 12.5a10 10 0 0 1 14 0" />
+          <Path {...props} d="M8.5 16a5 5 0 0 1 7 0" />
+          <Circle {...props} cx="12" cy="19.5" r="0.8" />
+        </>
+      );
+    case 'wifiOff':
+      return (
+        <>
+          <Line {...props} x1="3" y1="3" x2="21" y2="21" />
+          <Path {...props} d="M8.5 16a5 5 0 0 1 6.2-.7" />
+          <Path {...props} d="M5 12.5a10 10 0 0 1 7.5-2.8" />
+          <Polyline {...props} points="12 19.5 12.01 19.5" />
+        </>
+      );
+  }
+}

--- a/apps/mobile/src/components/MobileMenuSheet.tsx
+++ b/apps/mobile/src/components/MobileMenuSheet.tsx
@@ -1,0 +1,339 @@
+import { Link } from 'expo-router';
+import { useEffect, useRef, useState } from 'react';
+import { Animated, Pressable, ScrollView, Text, TextInput, View } from 'react-native';
+import { useMobileMenuSearch } from '../hooks/useMobileMenuSearch';
+import type { MobileMenuItem, WorkspaceMenuSection, WorkspaceMenuSession } from '../navigation';
+import { MobileIcon } from './MobileIcon';
+
+interface MobileMenuSheetProps {
+  readonly open: boolean;
+  readonly items: ReadonlyArray<MobileMenuItem>;
+  readonly connected: boolean;
+  readonly sessionLabel: string;
+  readonly modeLabel: string;
+  readonly providerLabel: string;
+  readonly autoApprove: boolean;
+  readonly workspaceSections: ReadonlyArray<WorkspaceMenuSection>;
+  readonly collapsedWorkspaceIds: ReadonlyArray<string>;
+  readonly onSelectSession: (id: string) => void;
+  readonly onNewSession: (workspaceId?: string) => void;
+  readonly onCommand: (name: string, args?: string) => void;
+  readonly onToggleWorkspace: (workspaceId: string) => void;
+  readonly onClose: () => void;
+}
+
+export function MobileMenuSheet({
+  open,
+  items,
+  connected,
+  sessionLabel,
+  modeLabel,
+  providerLabel,
+  autoApprove,
+  workspaceSections,
+  collapsedWorkspaceIds,
+  onSelectSession,
+  onNewSession,
+  onCommand,
+  onToggleWorkspace,
+  onClose,
+}: MobileMenuSheetProps) {
+  const progress = useRef(new Animated.Value(open ? 1 : 0)).current;
+  const [rendered, setRendered] = useState(open);
+  const search = useMobileMenuSearch(workspaceSections);
+
+  useEffect(() => {
+    if (open) setRendered(true);
+    Animated.timing(progress, {
+      duration: open ? 240 : 160,
+      toValue: open ? 1 : 0,
+      useNativeDriver: true,
+    }).start(({ finished }) => {
+      if (finished && !open) setRendered(false);
+    });
+    if (!open) search.close();
+  }, [open, progress]);
+
+  if (!rendered) return null;
+  const collapsedSet = new Set(search.query.trim().length > 0 ? [] : collapsedWorkspaceIds);
+
+  const translateX = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [-28, 0],
+  });
+  const scale = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0.985, 1],
+  });
+
+  return (
+    <Animated.View
+      className="absolute inset-0 z-50 bg-appBg"
+      style={{
+        backgroundColor: '#f1f2f9',
+        bottom: 0,
+        left: 0,
+        opacity: progress,
+        position: 'absolute',
+        right: 0,
+        top: 0,
+        transform: [{ translateX }, { scale }],
+        zIndex: 50,
+      }}
+    >
+      <ScrollView className="flex-1" contentContainerStyle={{ paddingBottom: 96, paddingHorizontal: 20, paddingTop: 18 }}>
+        <View className="flex-row items-center justify-between gap-4">
+          <View className="min-w-0 flex-1">
+            <Text className="text-[30px] font-black leading-9 text-text">Moxxy</Text>
+            <View className="mt-1.5 flex-row items-center gap-2">
+              <View className={`h-2 w-2 rounded-pill ${connected ? 'bg-green' : 'bg-amber'}`} />
+              <Text className="text-[12px] font-bold text-muted">{connected ? 'Connected' : 'Waiting'}</Text>
+            </View>
+          </View>
+          <View
+            className="h-12 flex-row items-center gap-3 rounded-pill border border-cardBorder bg-cardBg px-3 shadow-card"
+            style={{ shadowOpacity: 0.12 }}
+          >
+            <Pressable accessibilityLabel="Search sessions" onPress={search.toggle}>
+              <MobileIcon name="search" size={22} strokeWidth={2.35} color="#0f172a" />
+            </Pressable>
+            <View className="h-9 w-9 items-center justify-center rounded-pill bg-primary">
+              <Text className="text-[13px] font-black text-white">MX</Text>
+            </View>
+          </View>
+        </View>
+
+        {search.open ? (
+          <View className="mt-5 rounded-pill border border-cardBorder bg-cardBg px-4 py-2 shadow-card" style={{ shadowOpacity: 0.1 }}>
+            <TextInput
+              value={search.query}
+              onChangeText={search.setQuery}
+              placeholder="Search sessions"
+              placeholderTextColor="#94a3b8"
+              autoCapitalize="none"
+              autoCorrect={false}
+              className="min-h-10 text-[17px] font-semibold text-text"
+            />
+          </View>
+        ) : null}
+
+        <View className="mt-8 gap-1">
+          {items.map((item) => (
+            <MenuActionRow
+              key={`${item.kind}-${item.label}`}
+              item={item}
+              onClose={onClose}
+              onCommand={onCommand}
+            />
+          ))}
+        </View>
+
+        <View className="mt-8">
+          <View className="mb-3 flex-row items-center justify-between">
+            <Text className="text-[17px] font-black text-muted">Projects</Text>
+            {autoApprove ? <Pill label="Bypass ON" /> : null}
+          </View>
+          <View>
+            {search.filteredSections.map((section) => (
+              <WorkspaceSection
+                key={section.id}
+                section={section}
+                collapsed={collapsedSet.has(section.id)}
+                onSelectSession={(sessionId) => {
+                  onSelectSession(sessionId);
+                  onClose();
+                }}
+                onNewSession={() => {
+                  onNewSession(section.id);
+                  onClose();
+                }}
+                onToggleCollapsed={() => onToggleWorkspace(section.id)}
+              />
+            ))}
+            {search.filteredSections.length === 0 ? (
+              <View className="rounded-block border border-cardBorder bg-cardBg px-4 py-4">
+                <Text className="text-[14px] font-bold text-text">No matching sessions</Text>
+                <Text className="mt-1 text-[12px] text-muted">Try a title or workspace path.</Text>
+              </View>
+            ) : null}
+          </View>
+        </View>
+      </ScrollView>
+
+      <Pressable
+        accessibilityLabel="Close mobile menu"
+        className="absolute bottom-6 right-5 min-h-12 flex-row items-center gap-3 rounded-pill bg-cardBg px-5 shadow-card"
+        style={{ bottom: 24, minHeight: 52, position: 'absolute', right: 20, shadowOpacity: 0.16 }}
+        onPress={onClose}
+      >
+        <MobileIcon name="edit" size={21} strokeWidth={2.35} color="#0f172a" />
+        <Text className="text-[18px] font-black text-text">Chat</Text>
+      </Pressable>
+      <Pressable
+        accessibilityLabel="New session from menu"
+        className="absolute bottom-6 left-5 h-12 w-12 items-center justify-center rounded-pill border border-cardBorder bg-cardBg shadow-card"
+        style={{ bottom: 24, left: 20, position: 'absolute', shadowOpacity: 0.14 }}
+        onPress={() => {
+          onNewSession();
+          onClose();
+        }}
+      >
+        <MobileIcon name="plus" size={22} strokeWidth={2.45} color="#db2777" />
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+function WorkspaceSection({
+  section,
+  collapsed,
+  onSelectSession,
+  onNewSession,
+  onToggleCollapsed,
+}: {
+  readonly section: WorkspaceMenuSection;
+  readonly collapsed: boolean;
+  readonly onSelectSession: (sessionId: string) => void;
+  readonly onNewSession: () => void;
+  readonly onToggleCollapsed: () => void;
+}) {
+  return (
+    <View className="mb-5">
+      <View className="mb-1 flex-row items-center gap-3">
+        <Pressable
+          accessibilityLabel={`${collapsed ? 'Expand' : 'Collapse'} workspace ${section.title}`}
+          className="min-w-0 flex-1 flex-row items-center gap-3 rounded-block"
+          style={{ paddingVertical: 4 }}
+          onPress={onToggleCollapsed}
+        >
+          <View className="h-8 w-8 items-center justify-center">
+            <MobileIcon name="folder" size={21} strokeWidth={2.15} color={section.active ? '#db2777' : '#64748b'} />
+          </View>
+          <View className="min-w-0 flex-1">
+            <Text className={`text-[17px] font-bold ${section.active ? 'text-text' : 'text-muted'}`} numberOfLines={1}>
+              {section.title}
+            </Text>
+          </View>
+          <View className="rounded-pill bg-cardBorder px-2 py-0.5">
+            <Text className="text-[10px] font-black text-muted">{section.sessions.length}</Text>
+          </View>
+          <View style={{ transform: [{ rotate: collapsed ? '-90deg' : '0deg' }] }}>
+            <MobileIcon name="chevronDown" size={16} strokeWidth={2.45} color="#64748b" />
+          </View>
+        </Pressable>
+        <Pressable
+          accessibilityLabel={`New session in ${section.title}`}
+          className="h-9 w-9 items-center justify-center rounded-pill"
+          onPress={onNewSession}
+        >
+          <MobileIcon name="plus" size={18} strokeWidth={2.4} color="#db2777" />
+        </Pressable>
+      </View>
+      {collapsed ? (
+        <Pressable
+          accessibilityLabel={`Expand workspace ${section.title}`}
+          className="ml-11 rounded-block px-3 py-2"
+          style={{ backgroundColor: section.active ? '#ffffff' : 'rgba(255,255,255,0.5)' }}
+          onPress={onToggleCollapsed}
+        >
+          <Text className="text-[12px] font-bold text-muted">
+            {section.sessions.length} {section.sessions.length === 1 ? 'session' : 'sessions'} hidden
+          </Text>
+        </Pressable>
+      ) : (
+        <View className="gap-0.5 pl-11">
+          {section.sessions.map((session) => (
+            <WorkspaceSessionRow key={session.id} session={session} onPress={() => onSelectSession(session.id)} />
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
+function WorkspaceSessionRow({
+  session,
+  onPress,
+}: {
+  readonly session: WorkspaceMenuSession;
+  readonly onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityLabel={`Open session ${session.title}`}
+      className="min-h-11 rounded-block"
+      style={{
+        backgroundColor: session.active ? '#ffffff' : 'transparent',
+        borderColor: session.active ? '#e3e5f0' : 'transparent',
+        borderWidth: session.active ? 1 : 0,
+        paddingHorizontal: session.active ? 12 : 0,
+        paddingVertical: 7,
+        shadowColor: '#0f172a',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: session.active ? 0.08 : 0,
+        shadowRadius: 10,
+      }}
+      onPress={onPress}
+    >
+      <View className="flex-row items-center gap-3">
+        <Text
+          className={`min-w-0 flex-1 text-[16px] leading-6 ${session.active ? 'font-bold text-text' : 'font-semibold text-text'}`}
+          numberOfLines={1}
+        >
+          {session.title}
+        </Text>
+        {session.shortcutLabel ? (
+          <View className="rounded-pill bg-cardBorder px-2 py-0.5">
+            <Text className="text-[11px] font-bold text-muted">{session.shortcutLabel}</Text>
+          </View>
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}
+
+function MenuActionRow({
+  item,
+  onClose,
+  onCommand,
+}: {
+  readonly item: MobileMenuItem;
+  readonly onClose: () => void;
+  readonly onCommand: (name: string, args?: string) => void;
+}) {
+  const content = (
+    <View className="min-h-12 flex-row items-center gap-4 rounded-block" style={{ paddingVertical: 6 }}>
+      <View className="h-9 w-9 items-center justify-center">
+        <MobileIcon name={item.icon} size={22} strokeWidth={2.25} color="#0f172a" />
+      </View>
+      <Text className="flex-1 text-[18px] font-bold text-text">{item.label}</Text>
+    </View>
+  );
+
+  if (item.kind === 'link' && item.href) {
+    return (
+      <Link href={item.href} asChild>
+        <Pressable onPress={onClose}>{content}</Pressable>
+      </Link>
+    );
+  }
+
+  return (
+    <Pressable
+      onPress={() => {
+        if (item.command) onCommand(item.command, item.commandArgs);
+        onClose();
+      }}
+    >
+      {content}
+    </Pressable>
+  );
+}
+
+function Pill({ label }: { readonly label: string }) {
+  return (
+    <View className="rounded-pill bg-primarySoft px-3 py-1">
+      <Text className="text-[11px] font-black text-primaryStrong">{label}</Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/PairingPanel.tsx
+++ b/apps/mobile/src/components/PairingPanel.tsx
@@ -1,0 +1,51 @@
+import { Pressable, Text, TextInput, View } from 'react-native';
+
+interface PairingPanelProps {
+  readonly gatewayUrl: string;
+  readonly code: string;
+  readonly token: string | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+  readonly onGatewayUrlChange: (value: string) => void;
+  readonly onLoadPairing: () => void;
+  readonly onPair: () => void;
+  readonly onDisconnect: () => void;
+}
+
+export function PairingPanel(props: PairingPanelProps) {
+  return (
+    <View className="gap-4 rounded-card border border-cardBorder bg-cardBg p-4 shadow-card">
+      <View>
+        <Text className="text-[17px] font-bold text-text">Pairing</Text>
+        <Text className="mt-1 text-[13px] leading-5 text-muted">
+          Connect this phone with the LAN gateway running beside Moxxy.
+        </Text>
+      </View>
+      <TextInput
+        value={props.gatewayUrl}
+        onChangeText={props.onGatewayUrlChange}
+        autoCapitalize="none"
+        autoCorrect={false}
+        inputMode="url"
+        className="min-h-11 rounded-block border border-cardBorder bg-cardBg px-3 text-[14px] text-text"
+      />
+      <View className="flex-row gap-2">
+        <Pressable className="min-h-11 flex-1 items-center justify-center rounded-block border border-cardBorder bg-cardBg" onPress={props.onLoadPairing} disabled={props.loading}>
+          <Text className="text-[13px] font-bold text-muted">Refresh code</Text>
+        </Pressable>
+        <Pressable className={`min-h-11 flex-1 items-center justify-center rounded-block ${props.code ? 'bg-primary' : 'bg-cardBorder'}`} onPress={props.onPair} disabled={!props.code}>
+          <Text className="text-[13px] font-bold text-white">Pair</Text>
+        </Pressable>
+      </View>
+      <View className="items-center rounded-card bg-primarySoft px-4 py-4">
+        <Text className="text-[34px] font-black text-primaryStrong">{props.code || '------'}</Text>
+      </View>
+      {props.token ? (
+        <Pressable className="min-h-10 items-center justify-center rounded-block border border-cardBorder bg-cardBg" onPress={props.onDisconnect}>
+          <Text className="text-[13px] font-bold text-muted">Disconnect</Text>
+        </Pressable>
+      ) : null}
+      {props.error ? <Text className="text-[13px] font-semibold text-red">{props.error}</Text> : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/PermissionCard.tsx
+++ b/apps/mobile/src/components/PermissionCard.tsx
@@ -1,0 +1,64 @@
+import { Pressable, Text, View } from 'react-native';
+import { textOf } from '@/utils/record';
+import { MobileIcon } from './MobileIcon';
+
+interface PermissionCardProps {
+  readonly ask: Record<string, unknown>;
+  readonly onRespond: (response: Record<string, unknown>) => void;
+}
+
+export function PermissionCard({ ask, onRespond }: PermissionCardProps) {
+  const tool = isRecord(ask.tool) ? ask.tool : ask;
+  const name = textOf(tool.name, textOf(ask.title, 'Permission required'));
+  const description = textOf(tool.description, textOf(ask.description, textOf(ask.reason, 'The agent needs approval.')));
+
+  return (
+    <View className="gap-3 rounded-card border border-cardBorder bg-cardBg p-3 shadow-card">
+      <View className="flex-row items-start gap-3">
+        <View className="h-9 w-9 items-center justify-center rounded-block bg-primarySoft">
+          <MobileIcon name="actions" size={17} strokeWidth={2.35} color="#db2777" />
+        </View>
+        <View className="min-w-0 flex-1">
+          <Text className="text-[15px] font-bold text-text" numberOfLines={1}>{name}</Text>
+          <Text className="mt-1 text-[13px] leading-5 text-muted">{description}</Text>
+        </View>
+      </View>
+      <View className="flex-row flex-wrap justify-end gap-2">
+        <DecisionButton label="Deny" tone="danger" onPress={() => onRespond({ mode: 'deny' })} />
+        <DecisionButton label="Allow once" tone="primary" onPress={() => onRespond({ mode: 'allow_once' })} />
+        <DecisionButton label="Allow session" onPress={() => onRespond({ mode: 'allow_session' })} />
+        <DecisionButton label="Always allow" onPress={() => onRespond({ mode: 'allow_always' })} />
+      </View>
+    </View>
+  );
+}
+
+function DecisionButton({
+  label,
+  tone = 'neutral',
+  onPress,
+}: {
+  readonly label: string;
+  readonly tone?: 'neutral' | 'primary' | 'danger';
+  readonly onPress: () => void;
+}) {
+  const cls = tone === 'primary'
+    ? 'border-primary bg-primary'
+    : tone === 'danger'
+      ? 'border-cardBorder bg-cardBg'
+      : 'border-cardBorder bg-cardBg';
+  const textCls = tone === 'primary'
+    ? 'text-white'
+    : tone === 'danger'
+      ? 'text-red'
+      : 'text-muted';
+  return (
+    <Pressable className={`min-h-9 justify-center rounded-block border px-3 ${cls}`} onPress={onPress}>
+      <Text className={`text-[13px] font-bold ${textCls}`}>{label}</Text>
+    </Pressable>
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/apps/mobile/src/components/PermissionSheet.tsx
+++ b/apps/mobile/src/components/PermissionSheet.tsx
@@ -1,0 +1,17 @@
+import { AskSheet } from './AskSheet';
+
+interface PermissionSheetProps {
+  readonly permissions: ReadonlyArray<Record<string, unknown>>;
+  readonly onDecision: (permissionId: string, mode: 'allow_once' | 'allow_session' | 'allow_always' | 'deny') => void;
+}
+
+export function PermissionSheet({ permissions, onDecision }: PermissionSheetProps) {
+  return (
+    <AskSheet
+      asks={[]}
+      permissions={permissions}
+      onAskResponse={() => undefined}
+      onPermissionDecision={onDecision}
+    />
+  );
+}

--- a/apps/mobile/src/components/QrScannerSheet.tsx
+++ b/apps/mobile/src/components/QrScannerSheet.tsx
@@ -1,0 +1,103 @@
+import { CameraView } from 'expo-camera';
+import { Pressable, Text, View } from 'react-native';
+import type { CameraPermissionState, PairingUiState } from '../pairingUi';
+import { MobileIcon } from './MobileIcon';
+
+interface QrScannerSheetProps {
+  readonly open: boolean;
+  readonly processing: boolean;
+  readonly armed: boolean;
+  readonly permission: CameraPermissionState;
+  readonly ui: PairingUiState;
+  readonly onRequestPermission: () => void;
+  readonly onArmScanner: () => void;
+  readonly onScanned: (raw: string) => void;
+  readonly onCancel: () => void;
+}
+
+export function QrScannerSheet({
+  open,
+  processing,
+  armed,
+  permission,
+  ui,
+  onRequestPermission,
+  onArmScanner,
+  onScanned,
+  onCancel,
+}: QrScannerSheetProps) {
+  if (!open) return null;
+
+  const canScan = permission === 'granted';
+  return (
+    <View
+      className="absolute inset-0 z-[80] bg-appBg px-5"
+      style={{ bottom: 0, left: 0, position: 'absolute', right: 0, top: 0, zIndex: 80 }}
+    >
+      <View className="flex-1 justify-center gap-5">
+        <View>
+          <Text className="text-[30px] font-black text-text">{ui.scannerTitle}</Text>
+          <Text className="mt-1 text-[14px] leading-6 text-muted">{ui.scannerHint}</Text>
+        </View>
+
+        <View className="overflow-hidden rounded-card border border-cardBorder bg-cardBg shadow-card" style={{ height: 360 }}>
+          {canScan ? (
+            <View className="flex-1">
+              <CameraView
+                facing="back"
+                onBarcodeScanned={armed && !processing ? (result) => onScanned(result.data) : undefined}
+                barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+                style={{ flex: 1 }}
+              />
+              <View className="absolute inset-0 items-center justify-center px-8">
+                <View className={`h-56 w-56 rounded-card border-2 ${armed ? 'border-primary' : 'border-white/80'}`} />
+              </View>
+              <View className="absolute bottom-4 left-4 right-4">
+                <Pressable
+                  className={`min-h-12 flex-row items-center justify-center gap-2 rounded-block ${armed || processing ? 'bg-primarySoft' : 'bg-primary'}`}
+                  disabled={armed || processing}
+                  onPress={onArmScanner}
+                >
+                  <MobileIcon name="camera" color={armed || processing ? '#db2777' : '#ffffff'} size={20} />
+                  <Text className={`text-[14px] font-black ${armed || processing ? 'text-primaryStrong' : 'text-white'}`}>
+                    {processing ? 'Pairing...' : armed ? 'Looking for QR...' : 'Scan QR code'}
+                  </Text>
+                </Pressable>
+              </View>
+            </View>
+          ) : (
+            <View className="flex-1 items-center justify-center px-6">
+              <Text className="text-center text-[16px] font-bold text-text">
+                {permission === 'denied' ? 'Camera access is blocked' : 'Camera permission is required'}
+              </Text>
+              <Text className="mt-2 text-center text-[13px] leading-5 text-muted">
+                Scan the QR code from your Mac to pair without typing the gateway address.
+              </Text>
+              {permission !== 'denied' ? (
+                <Pressable
+                  className="mt-5 min-h-11 items-center justify-center rounded-block bg-primary px-5"
+                  onPress={onRequestPermission}
+                >
+                  <Text className="text-[13px] font-black text-white">Allow camera</Text>
+                </Pressable>
+              ) : null}
+            </View>
+          )}
+        </View>
+
+        {processing ? (
+          <View className="rounded-card bg-primarySoft px-4 py-3">
+            <Text className="text-center text-[13px] font-black text-primaryStrong">Pairing...</Text>
+          </View>
+        ) : null}
+
+        <Pressable
+          className="min-h-12 items-center justify-center rounded-block border border-cardBorder bg-cardBg"
+          onPress={onCancel}
+        >
+          <Text className="text-[14px] font-black text-muted">Cancel</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/ScreenFrame.tsx
+++ b/apps/mobile/src/components/ScreenFrame.tsx
@@ -1,0 +1,41 @@
+import { ScrollView, View, type ViewProps } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { AppShell } from './AppShell';
+import { TopBar } from './TopBar';
+
+interface ScreenFrameProps extends ViewProps {
+  readonly title: string;
+  readonly subtitle?: string;
+  readonly connected?: boolean;
+  readonly pendingActions?: number;
+  readonly scroll?: boolean;
+}
+
+export function ScreenFrame({
+  children,
+  title,
+  subtitle,
+  connected,
+  pendingActions: _pendingActions,
+  scroll = true,
+  ...props
+}: ScreenFrameProps) {
+  const content = scroll ? (
+    <ScrollView className="flex-1" contentContainerClassName="gap-4 px-4 py-4">
+      {children}
+    </ScrollView>
+  ) : (
+    <View className="flex-1 gap-4 px-4 py-4" {...props}>
+      {children}
+    </View>
+  );
+
+  return (
+    <AppShell>
+      <SafeAreaView className="flex-1" edges={['top', 'bottom']}>
+        <TopBar title={title} subtitle={subtitle} connected={connected} />
+        {content}
+      </SafeAreaView>
+    </AppShell>
+  );
+}

--- a/apps/mobile/src/components/SessionHeader.tsx
+++ b/apps/mobile/src/components/SessionHeader.tsx
@@ -1,0 +1,43 @@
+import { Text, View } from 'react-native';
+import { textOf } from '@/utils/record';
+
+interface SessionHeaderProps {
+  readonly connected: boolean;
+  readonly session: Record<string, unknown> | null;
+  readonly agents: ReadonlyArray<Record<string, unknown>>;
+  readonly activeMode?: string | null;
+  readonly activeProvider?: string | null;
+}
+
+export function SessionHeader({
+  connected,
+  session,
+  agents,
+  activeMode,
+  activeProvider,
+}: SessionHeaderProps) {
+  return (
+    <View className="rounded-card border border-cardBorder bg-cardBg p-4 shadow-card">
+      <View className="flex-row items-center gap-2">
+        <View className={`h-2.5 w-2.5 rounded-pill ${connected ? 'bg-green' : 'bg-amber'}`} />
+        <Text className="text-[13px] font-bold text-muted">{connected ? 'Connected' : 'Waiting for gateway'}</Text>
+      </View>
+      <Text className="mt-2 text-[17px] font-bold text-text">
+        {textOf(session?.id, 'No active session')}
+      </Text>
+      <View className="mt-3 flex-row flex-wrap gap-2">
+        <Pill label={activeProvider ?? 'Provider'} />
+        <Pill label={activeMode ?? 'Mode'} />
+        <Pill label={`${agents.length} agent${agents.length === 1 ? '' : 's'}`} />
+      </View>
+    </View>
+  );
+}
+
+function Pill({ label }: { readonly label: string }) {
+  return (
+    <View className="rounded-pill bg-primarySoft px-3 py-1">
+      <Text className="text-[11px] font-bold text-primaryStrong">{label}</Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/SessionList.tsx
+++ b/apps/mobile/src/components/SessionList.tsx
@@ -1,0 +1,36 @@
+import { Pressable, Text, View } from 'react-native';
+import { SessionRow } from './SessionRow';
+
+interface SessionListProps {
+  readonly workspaces: ReadonlyArray<Record<string, unknown>>;
+  readonly activeWorkspaceId: string | null;
+  readonly onSelectWorkspace: (id: string) => void;
+  readonly onNewSession: () => void;
+}
+
+export function SessionList(props: SessionListProps) {
+  return (
+    <View className="gap-3">
+      {props.workspaces.length === 0 ? (
+        <View className="rounded-card border border-cardBorder bg-cardBg p-5">
+          <Text className="text-[15px] font-bold text-text">No workspaces</Text>
+          <Text className="mt-1 text-[13px] text-muted">Start Moxxy desktop or TUI to expose sessions.</Text>
+        </View>
+      ) : null}
+      {props.workspaces.map((workspace, index) => {
+        const id = typeof workspace.id === 'string' ? workspace.id : `workspace-${index}`;
+        return (
+          <SessionRow
+            key={id}
+            workspace={workspace}
+            active={props.activeWorkspaceId === id}
+            onPress={props.onSelectWorkspace}
+          />
+        );
+      })}
+      <Pressable className="min-h-12 items-center justify-center rounded-card border border-cardBorder bg-cardBg" onPress={props.onNewSession}>
+        <Text className="text-[13px] font-bold text-muted">New session</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/SessionRow.tsx
+++ b/apps/mobile/src/components/SessionRow.tsx
@@ -1,0 +1,62 @@
+import { Pressable, Text, View } from 'react-native';
+import { boolOf, recordId, textOf } from '@/utils/record';
+
+interface SessionRowProps {
+  readonly workspace: Record<string, unknown>;
+  readonly active: boolean;
+  readonly onPress: (id: string) => void;
+}
+
+export function SessionRow({ workspace, active, onPress }: SessionRowProps) {
+  const id = recordId(workspace, '');
+  const name = textOf(workspace.firstPrompt, textOf(workspace.name, textOf(workspace.label, 'Workspace')));
+  const cwd = textOf(workspace.cwd, textOf(workspace.path, ''));
+  const unread = boolOf(workspace.unread);
+  const live = boolOf(workspace.live);
+  const readOnly = boolOf(workspace.readOnly);
+  const eventCount = typeof workspace.eventCount === 'number' ? workspace.eventCount : null;
+  const lastActivity = textOf(workspace.lastActivity);
+
+  return (
+    <Pressable
+      className={`min-h-16 rounded-card border px-4 py-3 ${
+        active ? 'border-primary bg-primarySoft' : 'border-cardBorder bg-cardBg'
+      }`}
+      onPress={() => id && onPress(id)}
+    >
+      <View className="flex-row items-center gap-3">
+        <View className={`h-2.5 w-2.5 rounded-pill ${unread ? 'bg-primary' : active ? 'bg-green' : 'bg-cardBorderStrong'}`} />
+        <View className="min-w-0 flex-1">
+          <Text className="text-[15px] font-bold text-text">{name}</Text>
+          {cwd ? <Text className="truncate text-[12px] text-muted">{cwd}</Text> : null}
+          <View className="mt-2 flex-row flex-wrap gap-1.5">
+            {eventCount !== null ? <Badge label={`${eventCount} events`} /> : null}
+            {lastActivity ? <Badge label={formatDate(lastActivity)} /> : null}
+            {live ? <Badge label="Live" active /> : null}
+            {readOnly ? <Badge label="Archive" /> : null}
+          </View>
+        </View>
+        {active ? <Text className="text-[11px] font-bold text-primaryStrong">Active</Text> : null}
+      </View>
+    </Pressable>
+  );
+}
+
+function Badge({ label, active }: { readonly label: string; readonly active?: boolean }) {
+  return (
+    <View className={`rounded-pill px-2 py-0.5 ${active ? 'bg-green' : 'bg-appBg'}`}>
+      <Text className={`text-[10px] font-bold ${active ? 'text-white' : 'text-muted'}`}>{label}</Text>
+    </View>
+  );
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    month: 'short',
+  });
+}

--- a/apps/mobile/src/components/StreamingAssistant.tsx
+++ b/apps/mobile/src/components/StreamingAssistant.tsx
@@ -1,0 +1,22 @@
+import { Text, View } from 'react-native';
+import { MobileIcon } from './MobileIcon';
+
+export function StreamingAssistant({ text }: { readonly text: string }) {
+  return (
+    <View style={{ alignSelf: 'stretch', flexDirection: 'row', gap: 12, maxWidth: '96%' }}>
+      <View
+        className="bg-primarySoft"
+        style={{ alignItems: 'center', borderRadius: 10, height: 34, justifyContent: 'center', width: 34 }}
+      >
+        <MobileIcon name="message" size={18} strokeWidth={2.35} color="#db2777" />
+      </View>
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <View className="flex-row items-center gap-2">
+          <Text className="text-[13px] font-bold text-text">Assistant</Text>
+          <View className="h-1.5 w-1.5 rounded-pill bg-primary" />
+        </View>
+        <Text className="mt-1 text-[15px] leading-6 text-text">{text}</Text>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/ThinkingIndicator.tsx
+++ b/apps/mobile/src/components/ThinkingIndicator.tsx
@@ -1,0 +1,50 @@
+import { Animated, Text, View } from 'react-native';
+import { useThinkingDots } from '@/hooks/useThinkingDots';
+import { MobileIcon } from './MobileIcon';
+
+export function ThinkingIndicator() {
+  const dotOpacity = useThinkingDots();
+
+  return (
+    <View
+      accessibilityLabel="Assistant is thinking"
+      style={{ alignItems: 'center', alignSelf: 'flex-start', flexDirection: 'row', gap: 10 }}
+      testID="mobile-thinking-indicator"
+    >
+      <View
+        className="bg-primarySoft"
+        style={{ alignItems: 'center', borderRadius: 10, height: 34, justifyContent: 'center', width: 34 }}
+      >
+        <MobileIcon name="message" size={18} strokeWidth={2.35} color="#db2777" />
+      </View>
+      <View
+        className="rounded-block border border-cardBorder bg-cardBg"
+        style={{
+          alignItems: 'center',
+          borderRadius: 10,
+          borderWidth: 1,
+          flexDirection: 'row',
+          gap: 8,
+          paddingHorizontal: 12,
+          paddingVertical: 8,
+        }}
+      >
+        <Text className="text-[13px] font-bold text-muted">Thinking</Text>
+        <View style={{ flexDirection: 'row', gap: 3 }}>
+          {dotOpacity.map((opacity, index) => (
+            <Animated.View
+              key={index}
+              style={{
+                backgroundColor: '#ec4899',
+                borderRadius: 999,
+                height: 5,
+                opacity,
+                width: 5,
+              }}
+            />
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/TopBar.tsx
+++ b/apps/mobile/src/components/TopBar.tsx
@@ -1,0 +1,36 @@
+import { Link } from 'expo-router';
+import { Pressable, Text, View } from 'react-native';
+import { buildReturnToChatAction } from '../navigation';
+import { MobileIcon } from './MobileIcon';
+
+interface TopBarProps {
+  readonly title: string;
+  readonly subtitle?: string;
+  readonly connected?: boolean;
+  readonly showChatAction?: boolean;
+}
+
+export function TopBar({ title, subtitle, connected, showChatAction = true }: TopBarProps) {
+  const action = buildReturnToChatAction();
+  return (
+    <View className="min-h-16 flex-row items-center gap-3 border-b border-cardBorder bg-cardBg px-5">
+      <View className={`h-2.5 w-2.5 rounded-pill ${connected ? 'bg-green' : 'bg-amber'}`} />
+      <View className="min-w-0 flex-1">
+        <Text className="text-[18px] font-bold text-text">{title}</Text>
+        {subtitle ? <Text className="truncate text-[12px] text-muted">{subtitle}</Text> : null}
+      </View>
+      {showChatAction ? (
+        <Link href={action.href} asChild>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Back to chat"
+            className="min-h-10 flex-row items-center justify-center gap-2 rounded-pill border border-cardBorder bg-cardBg px-3 shadow-card"
+          >
+            <MobileIcon name={action.icon} size={17} strokeWidth={2.4} color="#db2777" />
+            <Text className="text-[13px] font-black text-primaryStrong">{action.label}</Text>
+          </Pressable>
+        </Link>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/WorkflowList.tsx
+++ b/apps/mobile/src/components/WorkflowList.tsx
@@ -1,0 +1,71 @@
+import { Pressable, Text, View } from 'react-native';
+import type { MobileWorkflow } from '../hooks/useWorkflows';
+import { MobileIcon } from './MobileIcon';
+
+interface WorkflowListProps {
+  readonly workflows: ReadonlyArray<MobileWorkflow>;
+  readonly onRefresh: () => void;
+  readonly onRun: (name: string) => void;
+}
+
+export function WorkflowList({ workflows, onRefresh, onRun }: WorkflowListProps) {
+  return (
+    <View className="gap-3">
+      <Pressable
+        className="min-h-12 flex-row items-center justify-center gap-2 rounded-card border border-cardBorder bg-cardBg"
+        onPress={onRefresh}
+      >
+        <MobileIcon name="workflows" size={18} strokeWidth={2.35} color="#475569" />
+        <Text className="text-[13px] font-bold text-muted">Refresh workflows</Text>
+      </Pressable>
+
+      {workflows.length === 0 ? (
+        <View className="rounded-card border border-cardBorder bg-cardBg p-5 shadow-card" style={{ shadowOpacity: 0.08 }}>
+          <Text className="text-[16px] font-black text-text">No workflows visible</Text>
+          <Text className="mt-1 text-[13px] leading-5 text-muted">
+            Start Moxxy with the workflows plugin enabled, then refresh this list.
+          </Text>
+        </View>
+      ) : null}
+
+      {workflows.map((workflow) => (
+        <View
+          key={workflow.name}
+          className="rounded-card border border-cardBorder bg-cardBg p-4 shadow-card"
+          style={{ shadowOpacity: 0.08 }}
+        >
+          <View className="flex-row items-start gap-3">
+            <View className={`mt-1.5 h-2 w-2 rounded-pill ${workflow.enabled ? 'bg-green' : 'bg-cardBorderStrong'}`} />
+            <View className="min-w-0 flex-1">
+              <Text className="text-[16px] font-black leading-6 text-text">{workflow.name}</Text>
+              {workflow.description ? (
+                <Text className="mt-1 text-[13px] leading-5 text-muted">{workflow.description}</Text>
+              ) : null}
+              <View className="mt-3 flex-row flex-wrap gap-2">
+                <Badge label={workflow.enabled ? 'Enabled' : 'Disabled'} tone={workflow.enabled ? 'green' : 'muted'} />
+                {workflow.scope ? <Badge label={workflow.scope} tone="muted" /> : null}
+                <Badge label={`${workflow.steps} steps`} tone="muted" />
+                {workflow.triggers ? <Badge label={workflow.triggers} tone="muted" /> : null}
+              </View>
+            </View>
+          </View>
+          <Pressable
+            className="mt-4 min-h-11 flex-row items-center justify-center gap-2 rounded-pill bg-primary px-4"
+            onPress={() => onRun(workflow.name)}
+          >
+            <MobileIcon name="send" size={17} strokeWidth={2.4} color="#ffffff" />
+            <Text className="text-[13px] font-black text-white">Run workflow</Text>
+          </Pressable>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function Badge({ label, tone }: { readonly label: string; readonly tone: 'green' | 'muted' }) {
+  return (
+    <View className={`rounded-pill px-3 py-1 ${tone === 'green' ? 'bg-green/10' : 'bg-appBg'}`}>
+      <Text className={`text-[11px] font-black ${tone === 'green' ? 'text-green' : 'text-muted'}`}>{label}</Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/composerUi.ts
+++ b/apps/mobile/src/composerUi.ts
@@ -1,0 +1,53 @@
+export interface ComposerUiInput {
+  readonly text: string;
+  readonly sending: boolean;
+  readonly compacting: boolean;
+  readonly actionsOpen: boolean;
+  readonly autoApprove: boolean;
+  readonly attachmentCount?: number;
+  readonly voicePhase?: 'idle' | 'recording' | 'transcribing' | 'error';
+  readonly readOnly?: boolean;
+}
+
+export interface ComposerUiState {
+  readonly placeholder: string;
+  readonly canSubmit: boolean;
+  readonly disabled: boolean;
+  readonly sendIcon: 'send' | 'stop';
+  readonly sendTone: 'primary' | 'danger' | 'disabled';
+  readonly actionsTone: 'neutral' | 'active';
+  readonly frameTone: 'neutral' | 'bypass';
+  readonly bypassActive: boolean;
+  readonly statusLabel: string | null;
+  readonly voiceLabel: 'Voice' | 'Stop' | 'Transcribing';
+  readonly voiceTone: 'neutral' | 'recording' | 'transcribing';
+}
+
+export function buildComposerUiState(input: ComposerUiInput): ComposerUiState {
+  const voicePhase = input.voicePhase ?? 'idle';
+  const disabled = input.compacting || input.readOnly === true || voicePhase === 'transcribing';
+  const canSubmit = (input.text.trim().length > 0 || (input.attachmentCount ?? 0) > 0) && !disabled;
+  return {
+    placeholder: input.readOnly
+      ? 'Archived session - select the live session to send.'
+      : input.compacting
+        ? 'Compacting context...'
+        : 'Send a message to the agent...',
+    canSubmit,
+    disabled,
+    sendIcon: input.sending ? 'stop' : 'send',
+    sendTone: input.sending ? 'danger' : canSubmit ? 'primary' : 'disabled',
+    actionsTone: input.actionsOpen || input.autoApprove ? 'active' : 'neutral',
+    frameTone: input.autoApprove ? 'bypass' : 'neutral',
+    bypassActive: input.autoApprove,
+    statusLabel: input.compacting
+      ? 'Compacting context...'
+      : voicePhase === 'recording'
+        ? 'Listening...'
+        : voicePhase === 'transcribing'
+          ? 'Transcribing...'
+          : null,
+    voiceLabel: voicePhase === 'recording' ? 'Stop' : voicePhase === 'transcribing' ? 'Transcribing' : 'Voice',
+    voiceTone: voicePhase === 'recording' ? 'recording' : voicePhase === 'transcribing' ? 'transcribing' : 'neutral',
+  };
+}

--- a/apps/mobile/src/consoleFilters.ts
+++ b/apps/mobile/src/consoleFilters.ts
@@ -1,0 +1,13 @@
+const POINTER_EVENTS_WARNING = 'props.pointerEvents is deprecated. Use style.pointerEvents';
+
+export function shouldIgnoreConsoleMessage(message: unknown): boolean {
+  return typeof message === 'string' && message.includes(POINTER_EVENTS_WARNING);
+}
+
+export function installConsoleFilters(): void {
+  const originalWarn = console.warn.bind(console);
+  console.warn = (...args: unknown[]) => {
+    if (shouldIgnoreConsoleMessage(args[0])) return;
+    originalWarn(...args);
+  };
+}

--- a/apps/mobile/src/contextMeterUi.ts
+++ b/apps/mobile/src/contextMeterUi.ts
@@ -1,0 +1,32 @@
+export interface ContextMeterUiInput {
+  readonly latestPrompt: number | null;
+  readonly contextWindow: number | null;
+}
+
+export interface ContextMeterUiState {
+  readonly visible: boolean;
+  readonly label: string;
+  readonly fraction: number | null;
+  readonly fillPercent: number;
+  readonly tone: 'neutral' | 'primary' | 'amber' | 'red';
+}
+
+export function buildContextMeterUiState(input: ContextMeterUiInput): ContextMeterUiState {
+  if (!input.contextWindow || input.contextWindow <= 0) {
+    return {
+      visible: false,
+      label: 'Context',
+      fraction: null,
+      fillPercent: 0,
+      tone: 'neutral',
+    };
+  }
+  const fraction = Math.max(0, Math.min(1, (input.latestPrompt ?? 0) / input.contextWindow));
+  return {
+    visible: true,
+    label: `${Math.round(fraction * 100)}%`,
+    fraction,
+    fillPercent: Math.round(fraction * 100),
+    tone: fraction >= 0.85 ? 'red' : fraction >= 0.6 ? 'amber' : 'primary',
+  };
+}

--- a/apps/mobile/src/hooks/storage.ts
+++ b/apps/mobile/src/hooks/storage.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useReducer } from 'react';
+import { Platform } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+
+type StorageState = readonly [loading: boolean, value: string | null];
+
+function reducer(_state: StorageState, value: string | null): StorageState {
+  return [false, value];
+}
+
+export async function setStorageItemAsync(key: string, value: string | null): Promise<void> {
+  if (Platform.OS === 'web') {
+    if (typeof localStorage === 'undefined') return;
+    if (value === null) localStorage.removeItem(key);
+    else localStorage.setItem(key, value);
+    return;
+  }
+  if (value === null) await SecureStore.deleteItemAsync(key);
+  else await SecureStore.setItemAsync(key, value);
+}
+
+export function useStorageState(key: string): readonly [StorageState, (value: string | null) => void] {
+  const [state, setState] = useReducer(reducer, [true, null] as StorageState);
+
+  useEffect(() => {
+    if (Platform.OS === 'web') {
+      setState(typeof localStorage === 'undefined' ? null : localStorage.getItem(key));
+      return;
+    }
+    SecureStore.getItemAsync(key).then(setState).catch(() => setState(null));
+  }, [key]);
+
+  const setValue = useCallback(
+    (value: string | null) => {
+      setState(value);
+      void setStorageItemAsync(key, value);
+    },
+    [key],
+  );
+
+  return [state, setValue];
+}

--- a/apps/mobile/src/hooks/useAttachments.ts
+++ b/apps/mobile/src/hooks/useAttachments.ts
@@ -1,0 +1,150 @@
+import { useCallback, useState } from 'react';
+import * as Clipboard from 'expo-clipboard';
+import * as DocumentPicker from 'expo-document-picker';
+import * as FileSystem from 'expo-file-system/legacy';
+import * as ImagePicker from 'expo-image-picker';
+import {
+  buildPromptAttachment,
+  estimateBase64Bytes,
+  inferMediaType,
+  isTextAttachmentMediaType,
+  stripDataUrlPrefix,
+  validateAttachmentBytes,
+  type PromptAttachment,
+} from '../attachments';
+
+const ERROR_RESET_MS = 3000;
+
+export function useAttachments(options: { readonly disabled?: boolean } = {}) {
+  const [attachments, setAttachments] = useState<ReadonlyArray<PromptAttachment>>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const fail = useCallback((message: string) => {
+    setError(message);
+    setTimeout(() => setError(null), ERROR_RESET_MS);
+  }, []);
+
+  const addAttachment = useCallback((attachment: PromptAttachment) => {
+    setAttachments((current) => {
+      const duplicate = current.some((item) =>
+        item.kind === attachment.kind &&
+        item.name === attachment.name &&
+        item.mediaType === attachment.mediaType &&
+        item.content === attachment.content,
+      );
+      return duplicate ? current : [...current, attachment];
+    });
+  }, []);
+
+  const pickImage = useCallback(async () => {
+    if (options.disabled) return;
+    try {
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ['images'],
+        allowsEditing: false,
+        allowsMultipleSelection: false,
+        base64: true,
+        quality: 0.92,
+      });
+      if (result.canceled || result.assets.length === 0) return;
+      const asset = result.assets[0]!;
+      const content = asset.base64 ?? await readBase64(asset.uri);
+      const bytes = asset.fileSize ?? estimateBase64Bytes(content);
+      const tooLarge = validateAttachmentBytes({ name: asset.fileName ?? 'image', bytes });
+      if (tooLarge) {
+        fail(tooLarge);
+        return;
+      }
+      addAttachment(buildPromptAttachment({
+        content,
+        mediaType: asset.mimeType ?? inferMediaType(asset.fileName) ?? 'image/jpeg',
+        name: asset.fileName ?? 'image.jpg',
+      }));
+    } catch (err) {
+      fail(err instanceof Error ? err.message : 'Could not attach image.');
+    }
+  }, [addAttachment, fail, options.disabled]);
+
+  const pickDocument = useCallback(async () => {
+    if (options.disabled) return;
+    try {
+      const result = await DocumentPicker.getDocumentAsync({ copyToCacheDirectory: true, multiple: false });
+      if (result.canceled || result.assets.length === 0) return;
+      const asset = result.assets[0]!;
+      const mediaType = asset.mimeType ?? inferMediaType(asset.name);
+      const name = asset.name || 'attachment';
+      if (isTextAttachmentMediaType(mediaType)) {
+        addAttachment(buildPromptAttachment({
+          content: await readText(asset),
+          mediaType,
+          name,
+          text: true,
+        }));
+        return;
+      }
+      if (mediaType?.startsWith('image/') || mediaType === 'application/pdf') {
+        const content = asset.base64 ?? await readBase64(asset.uri);
+        const bytes = asset.size ?? estimateBase64Bytes(content);
+        const tooLarge = validateAttachmentBytes({ name, bytes });
+        if (tooLarge) {
+          fail(tooLarge);
+          return;
+        }
+        addAttachment(buildPromptAttachment({ content, mediaType, name }));
+        return;
+      }
+      fail('Only images, PDFs, and text files can be attached from mobile right now.');
+    } catch (err) {
+      fail(err instanceof Error ? err.message : 'Could not attach file.');
+    }
+  }, [addAttachment, fail, options.disabled]);
+
+  const pasteImage = useCallback(async () => {
+    if (options.disabled) return;
+    try {
+      const image = await Clipboard.getImageAsync({ format: 'png' });
+      if (!image) {
+        fail('No image found in clipboard.');
+        return;
+      }
+      const content = stripDataUrlPrefix(image.data);
+      const tooLarge = validateAttachmentBytes({ name: 'clipboard-image.png', bytes: estimateBase64Bytes(content) });
+      if (tooLarge) {
+        fail(tooLarge);
+        return;
+      }
+      addAttachment(buildPromptAttachment({
+        content,
+        mediaType: 'image/png',
+        name: 'clipboard-image.png',
+      }));
+    } catch (err) {
+      fail(err instanceof Error ? err.message : 'Could not paste image.');
+    }
+  }, [addAttachment, fail, options.disabled]);
+
+  const removeAttachment = useCallback((index: number) => {
+    setAttachments((current) => current.filter((_, itemIndex) => itemIndex !== index));
+  }, []);
+
+  const clearAttachments = useCallback(() => setAttachments([]), []);
+
+  return {
+    attachments,
+    attachmentError: error,
+    pickImage,
+    pickDocument,
+    pasteImage,
+    removeAttachment,
+    clearAttachments,
+  };
+}
+
+async function readBase64(uri: string): Promise<string> {
+  return await FileSystem.readAsStringAsync(uri, { encoding: FileSystem.EncodingType.Base64 });
+}
+
+async function readText(asset: DocumentPicker.DocumentPickerAsset): Promise<string> {
+  if (asset.file && typeof asset.file.text === 'function') return await asset.file.text();
+  return await FileSystem.readAsStringAsync(asset.uri, { encoding: FileSystem.EncodingType.UTF8 });
+}

--- a/apps/mobile/src/hooks/useAutoApprove.ts
+++ b/apps/mobile/src/hooks/useAutoApprove.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { api, chatStore } from '@moxxy/client-core';
+import { resolveAutoApproveState } from '../autoApproveState';
+import { buildSetAutoApproveFrame, invokeFrame } from '../clientFrames';
+
+/**
+ * Auto-approve ("yolo") toggle. The optimistic value renders immediately; the
+ * upstream value is client-core's per-workspace flag, confirmed only after the
+ * host acknowledges the command. The flag lives on the host's session driver
+ * and resets if the runner restarts, so — like the reference — an enabled
+ * toggle is re-applied once per workspace on (re)connect.
+ */
+export function useAutoApprove(input: {
+  readonly workspaceId: string | null;
+  readonly enabled: boolean;
+  readonly connected: boolean;
+}) {
+  const lastApplied = useRef<boolean | null>(null);
+  const [optimistic, setOptimistic] = useState<boolean | null>(null);
+  const enabled = resolveAutoApproveState({ upstream: input.enabled, optimistic });
+  const { workspaceId } = input;
+
+  const setAutoApprove = useCallback(
+    (next: boolean) => {
+      lastApplied.current = next;
+      setOptimistic(next);
+      void invokeFrame(api(), buildSetAutoApproveFrame({ workspaceId, enabled: next }))
+        .then(() => {
+          if (workspaceId) chatStore.setAutoApprove(workspaceId, next);
+        })
+        .catch(() => {
+          setOptimistic(null);
+          lastApplied.current = null;
+        });
+    },
+    [workspaceId],
+  );
+
+  useEffect(() => {
+    setOptimistic(null);
+    lastApplied.current = null;
+  }, [workspaceId]);
+
+  useEffect(() => {
+    if (optimistic !== null && input.enabled === optimistic) setOptimistic(null);
+  }, [input.enabled, optimistic]);
+
+  useEffect(() => {
+    if (!input.connected || !workspaceId || !enabled) return;
+    if (lastApplied.current === true) return;
+    lastApplied.current = true;
+    void invokeFrame(api(), buildSetAutoApproveFrame({ workspaceId, enabled: true })).catch(() => {
+      lastApplied.current = null;
+    });
+  }, [enabled, input.connected, workspaceId]);
+
+  return {
+    enabled,
+    setAutoApprove,
+  };
+}

--- a/apps/mobile/src/hooks/useChatListAutoScroll.ts
+++ b/apps/mobile/src/hooks/useChatListAutoScroll.ts
@@ -1,0 +1,26 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { ScrollView } from 'react-native';
+import type { TranscriptItem } from '../chatTranscript';
+
+export function useChatListAutoScroll(items: ReadonlyArray<TranscriptItem>, sending: boolean) {
+  const scrollRef = useRef<ScrollView | null>(null);
+  const contentKey = useMemo(() => {
+    const last = items[items.length - 1];
+    const streamingText = last?.kind === 'assistant' && last.streaming ? last.text : '';
+    const toolSummary = last?.kind === 'tool-group' ? last.summary : '';
+    return `${items.length}:${last?.id ?? 'empty'}:${streamingText.length}:${toolSummary}:${sending ? 'sending' : 'idle'}`;
+  }, [items, sending]);
+
+  const scrollToEnd = () => {
+    requestAnimationFrame(() => {
+      scrollRef.current?.scrollToEnd({ animated: true });
+    });
+  };
+
+  useEffect(scrollToEnd, [contentKey]);
+
+  return {
+    scrollRef,
+    scrollToEnd,
+  };
+}

--- a/apps/mobile/src/hooks/useChatTranscript.ts
+++ b/apps/mobile/src/hooks/useChatTranscript.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import type { MobileState } from '../protocol';
+import { buildChatTranscript } from '../chatTranscript';
+
+export function useChatTranscript(state: MobileState) {
+  // chatEvents is reference-stable across streaming ticks (client-core keeps
+  // the committed-events array identity), so the fold only re-runs when a
+  // committed event lands or the live preview changes.
+  const items = useMemo(
+    () => buildChatTranscript(state.chatEvents, state.streamingText),
+    [state.chatEvents, state.streamingText],
+  );
+  return {
+    items,
+    events: state.chatEvents,
+    streamingText: state.streamingText,
+    sending: state.sending,
+    activeTurnId: state.activeTurnId,
+    queue: state.queue,
+    compacting: state.compacting,
+    usage: state.usage,
+    isEmpty: items.length === 0,
+  };
+}

--- a/apps/mobile/src/hooks/useCompactContext.ts
+++ b/apps/mobile/src/hooks/useCompactContext.ts
@@ -1,0 +1,33 @@
+import { useCallback, useState } from 'react';
+
+export function useCompactContext(input: {
+  readonly readOnly?: boolean;
+  /** The composer's command runner — `/compact` rides the same path so the
+   *  compaction lock + error surfacing live in one place. */
+  readonly runCommand: (name: string, args?: string) => void;
+}) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const { readOnly, runCommand } = input;
+
+  const requestCompact = useCallback(() => {
+    if (readOnly) return;
+    setConfirmOpen(true);
+  }, [readOnly]);
+
+  const cancelCompact = useCallback(() => {
+    setConfirmOpen(false);
+  }, []);
+
+  const confirmCompact = useCallback(() => {
+    if (readOnly) return;
+    runCommand('compact', '');
+    setConfirmOpen(false);
+  }, [readOnly, runCommand]);
+
+  return {
+    confirmOpen,
+    requestCompact,
+    cancelCompact,
+    confirmCompact,
+  };
+}

--- a/apps/mobile/src/hooks/useComposer.ts
+++ b/apps/mobile/src/hooks/useComposer.ts
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { api, chatStore, decodeError, toErrorMessage } from '@moxxy/client-core';
+import {
+  buildRunCommandFrame,
+  buildRunTurnFrame,
+  buildTranscribeFrame,
+  invokeFrame,
+} from '../clientFrames';
+import type { LocalFrame } from '../protocol';
+import { useAttachments } from './useAttachments';
+import { useVoiceRecorder } from './useVoiceRecorder';
+
+export function useComposer(options: {
+  readonly workspaceId: string | null;
+  readonly activeTurnId: string | null;
+  readonly transcriptionId?: string | null;
+  readonly transcriptionText?: string | null;
+  readonly readOnly?: boolean;
+  /** client-core's queue-aware sender (text-only turns). */
+  readonly send: (prompt: string) => Promise<void>;
+  /** client-core's abort, bound to the active turn. */
+  readonly abort: () => Promise<void>;
+  readonly dispatchLocal: (frame: LocalFrame) => void;
+}) {
+  const [text, setText] = useState('');
+  const [actionsOpen, setActionsOpen] = useState(false);
+  const lastTranscriptionIdRef = useRef<string | null>(null);
+  const attachments = useAttachments({ disabled: options.readOnly === true });
+  const { workspaceId, dispatchLocal } = options;
+
+  const voice = useVoiceRecorder({
+    disabled: options.readOnly === true,
+    onClip: (clip) => {
+      dispatchLocal({ type: 'transcribe.started' });
+      void invokeFrame(
+        api(),
+        buildTranscribeFrame({ audioBase64: clip.audioBase64, mimeType: clip.mimeType }),
+      )
+        .then((transcript) => dispatchLocal({ type: 'transcribe.result', text: transcript }))
+        .catch((e) => {
+          // `not-supported` = the host has no transcriber — say so plainly
+          // instead of surfacing a wire error.
+          const decoded = decodeError(e);
+          dispatchLocal({
+            type: 'error',
+            message:
+              decoded.code === 'not-supported'
+                ? 'Voice transcription is not available on this host.'
+                : decoded.message,
+          });
+          completeVoiceTranscription();
+        });
+    },
+  });
+  const {
+    complete: completeVoiceTranscription,
+    errorReason: voiceError,
+    phase: voicePhase,
+    toggle: toggleVoice,
+  } = voice;
+
+  useEffect(() => {
+    const id = options.transcriptionId ?? null;
+    const transcript = options.transcriptionText?.trim();
+    if (!id || id === lastTranscriptionIdRef.current) return;
+    lastTranscriptionIdRef.current = id;
+    if (transcript) {
+      setText((draft) => (draft.trim().length > 0 ? `${draft.trimEnd()} ${transcript}` : transcript));
+    }
+    completeVoiceTranscription();
+  }, [completeVoiceTranscription, options.transcriptionId, options.transcriptionText]);
+
+  const sendWithAttachments = useCallback(
+    async (prompt: string) => {
+      if (!workspaceId) return;
+      const current = chatStore.getChat(workspaceId);
+      if (current.compacting) return;
+      if (current.activeTurnId !== null || current.sending) {
+        // Inline payloads can't ride the (path-based) turn queue — refuse
+        // honestly rather than silently dropping the files.
+        dispatchLocal({
+          type: 'error',
+          message: 'Wait for the current reply before sending attachments.',
+        });
+        return;
+      }
+      try {
+        const { turnId } = await invokeFrame(
+          api(),
+          buildRunTurnFrame({ workspaceId, prompt, attachments: attachments.attachments }),
+        );
+        chatStore.dispatch(workspaceId, { type: 'send_started', turnId });
+      } catch (e) {
+        chatStore.dispatch(workspaceId, { type: 'send_failed', message: toErrorMessage(e) });
+      }
+    },
+    [attachments.attachments, dispatchLocal, workspaceId],
+  );
+
+  const submit = useCallback(() => {
+    const trimmed = text.trim();
+    if (options.readOnly) return;
+    if (!trimmed && attachments.attachments.length === 0) return;
+    if (attachments.attachments.length > 0) {
+      void sendWithAttachments(trimmed);
+    } else {
+      void options.send(trimmed);
+    }
+    setText('');
+    attachments.clearAttachments();
+  }, [attachments, options.readOnly, options.send, sendWithAttachments, text]);
+
+  const abort = useCallback(() => {
+    if (!options.activeTurnId) return;
+    void options.abort();
+  }, [options.abort, options.activeTurnId]);
+
+  const runCommand = useCallback(
+    (name: string, args = '') => {
+      if (options.readOnly) return;
+      setActionsOpen(false);
+      const target = workspaceId;
+      void (async () => {
+        // The compaction lock mirrors the desktop composer: locked while the
+        // runner summarizes, released whatever the outcome.
+        if (name === 'compact' && target) chatStore.setCompacting(target, true);
+        try {
+          const result = await invokeFrame(
+            api(),
+            buildRunCommandFrame({ workspaceId: target, name, args }),
+          );
+          if (result.kind === 'error') {
+            dispatchLocal({ type: 'error', message: result.message ?? `/${name} failed` });
+          } else if (
+            result.kind === 'session-action' &&
+            (result.action === 'new' || result.action === 'clear') &&
+            target
+          ) {
+            chatStore.clear(target);
+          }
+        } catch (e) {
+          dispatchLocal({ type: 'error', message: toErrorMessage(e) });
+        } finally {
+          if (name === 'compact' && target) chatStore.setCompacting(target, false);
+        }
+      })();
+    },
+    [dispatchLocal, options.readOnly, workspaceId],
+  );
+
+  const transcribe = useCallback(() => {
+    if (options.readOnly) return;
+    toggleVoice();
+  }, [options.readOnly, toggleVoice]);
+
+  return {
+    text,
+    setText,
+    submit,
+    abort,
+    actionsOpen,
+    setActionsOpen,
+    runCommand,
+    transcribe,
+    voicePhase,
+    voiceError,
+    attachments: attachments.attachments,
+    attachmentError: attachments.attachmentError,
+    pickImageAttachment: attachments.pickImage,
+    pickDocumentAttachment: attachments.pickDocument,
+    pasteImageAttachment: attachments.pasteImage,
+    removeAttachment: attachments.removeAttachment,
+  };
+}

--- a/apps/mobile/src/hooks/useGatewaySnapshot.ts
+++ b/apps/mobile/src/hooks/useGatewaySnapshot.ts
@@ -1,0 +1,7 @@
+import type { MobileState } from '../protocol';
+
+/** Identity hook kept for facade parity with the reference app — the snapshot
+ *  is already assembled by the provider via `buildMobileState`. */
+export function useGatewaySnapshot(state: MobileState): MobileState {
+  return state;
+}

--- a/apps/mobile/src/hooks/useGatewaySocket.ts
+++ b/apps/mobile/src/hooks/useGatewaySocket.ts
@@ -1,0 +1,127 @@
+/**
+ * Owns the live WebSocket JSON-RPC client and the `@moxxy/client-core`
+ * transport singleton.
+ *
+ * When pairing yields a (url, token) pair this hook builds a `WsRpcClient`,
+ * presents the token via the `Sec-WebSocket-Protocol` bearer entry (wave-5
+ * semantics — the secret never rides the URL), installs the client as the
+ * client-core transport (`configureTransport`), and tracks its lifecycle.
+ * Re-pairing closes the previous client before installing the next so a stale
+ * socket can't keep reconnect-looping in the background.
+ *
+ * `generation` bumps per fresh client — the provider keys the client-core
+ * bridges (`ChatStoreBridge`/`ConnectionBridge`) on it so their subscriptions
+ * re-attach to the new client. `refreshTick` bumps on every successful
+ * (re)connect — consumers refetch request/response state (session.info,
+ * workflows) that pushed events don't cover.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { configurePlatform, configureTransport } from '@moxxy/client-core';
+import type { MoxxyApi } from '@moxxy/desktop-ipc-contract';
+import {
+  WsRpcClient,
+  type WebSocketCtor,
+  type WsClientStatus,
+} from '@moxxy/client-transport-ws';
+
+export type GatewaySocketStatus = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'error';
+
+export interface GatewaySocketState {
+  readonly status: GatewaySocketStatus;
+  /** A transport is configured — client-core hooks/bridges may run. */
+  readonly ready: boolean;
+  /** Bumps per fresh client (re-pair). Key the bridges on it. */
+  readonly generation: number;
+  /** Bumps per successful (re)connect. Refetch snapshot-ish state on it. */
+  readonly refreshTick: number;
+}
+
+// NOTE: mirrors MOXXY_WS_SUBPROTOCOL / encodeWsBearerProtocol in @moxxy/sdk
+// (and the same mirror inside @moxxy/client-transport-ws's makeWsApi — the
+// encoder isn't exported there, and this app needs the raw WsRpcClient for
+// close-on-re-pair lifecycle that makeWsApi doesn't expose).
+const WS_SUBPROTOCOL = 'moxxy.v1';
+const WS_BEARER_PREFIX = 'moxxy.bearer.';
+
+function bearerProtocol(token: string): string {
+  const strict = encodeURIComponent(token).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+  return `${WS_BEARER_PREFIX}${strict}`;
+}
+
+function toMoxxyApi(client: WsRpcClient): MoxxyApi {
+  return {
+    invoke: ((command: string, ...args: unknown[]) =>
+      client.request(command, args[0])) as MoxxyApi['invoke'],
+    subscribe: ((channel: string, handler: (payload: unknown) => void) =>
+      client.on(channel, handler)) as MoxxyApi['subscribe'],
+  };
+}
+
+function mapStatus(status: WsClientStatus): GatewaySocketStatus {
+  switch (status) {
+    case 'connecting':
+      return 'connecting';
+    case 'open':
+      return 'connected';
+    case 'reconnecting':
+      return 'reconnecting';
+    case 'disconnected':
+      // Terminal: the reconnect budget is exhausted — re-pair to recover.
+      return 'error';
+    case 'closed':
+      return 'idle';
+  }
+}
+
+/** The one live client — module-level so a re-pair always closes its
+ *  predecessor even across provider remounts. */
+let activeClient: WsRpcClient | null = null;
+
+export function useGatewaySocket(wsUrl: string | null, token: string | null): GatewaySocketState {
+  const [status, setStatus] = useState<GatewaySocketStatus>('idle');
+  const [generation, setGeneration] = useState(0);
+  const [refreshTick, setRefreshTick] = useState(0);
+  const readyRef = useRef(false);
+
+  useEffect(() => {
+    if (!wsUrl || !token) {
+      activeClient?.close();
+      activeClient = null;
+      readyRef.current = false;
+      setStatus('idle');
+      return;
+    }
+    const ctor = (globalThis as unknown as { WebSocket?: WebSocketCtor }).WebSocket;
+    if (!ctor) {
+      setStatus('error');
+      return;
+    }
+    const client = new WsRpcClient(wsUrl, ctor, {
+      protocols: [WS_SUBPROTOCOL, bearerProtocol(token)],
+      onStatus: (next) => {
+        setStatus(mapStatus(next));
+        if (next === 'open') setRefreshTick((tick) => tick + 1);
+      },
+    });
+    activeClient?.close();
+    activeClient = client;
+    // No-op platform capabilities: voice capture / TTS / legacy-KV migration
+    // degrade exactly as the optional-capability design intends.
+    configurePlatform({});
+    configureTransport(toMoxxyApi(client));
+    readyRef.current = true;
+    setStatus('connecting');
+    setGeneration((value) => value + 1);
+    client.connect();
+    return () => {
+      client.close();
+      if (activeClient === client) activeClient = null;
+    };
+  }, [wsUrl, token]);
+
+  return { status, ready: readyRef.current && status !== 'idle', generation, refreshTick };
+}

--- a/apps/mobile/src/hooks/useGatewayStore.tsx
+++ b/apps/mobile/src/hooks/useGatewayStore.tsx
@@ -1,0 +1,250 @@
+/**
+ * The gateway facade — one context exposing the exact store shape the
+ * reference app's screens bind to (pairing / socketStatus / snapshot /
+ * session / sessions / permissions / workflows / composer / autoApprove /
+ * goals / compact / chat / chatEvents).
+ *
+ * Composition, not re-implementation: the live event folding, queue, usage
+ * accounting, and ask routing all come from `@moxxy/client-core` (its
+ * `ChatStoreBridge` / `ConnectionBridge` are mounted here, keyed by socket
+ * generation so a re-pair re-subscribes them on the fresh client). The
+ * `protocol.ts` presenter then projects those stores into the reference's
+ * `MobileState` so every component reads one stable shape.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useState,
+  useSyncExternalStore,
+  type PropsWithChildren,
+  type ReactElement,
+} from 'react';
+import {
+  api,
+  askStore,
+  chatStore,
+  ChatStoreBridge,
+  ConnectionBridge,
+  EMPTY_USAGE,
+  useActiveWorkspaceId,
+  useChat,
+  useContextUsage,
+  useQueuedTurns,
+} from '@moxxy/client-core';
+import type { SessionInfo } from '@moxxy/desktop-ipc-contract';
+import {
+  applyLocalFrame,
+  buildMobileState,
+  emptyLocalUiState,
+  type MobileState,
+} from '../protocol';
+import { normalizeGatewayUrl } from '../pairingUrl';
+import { usePairing, type PairingState } from './usePairing';
+import { useAutoApprove } from './useAutoApprove';
+import { useChatTranscript } from './useChatTranscript';
+import { useCompactContext } from './useCompactContext';
+import { useComposer } from './useComposer';
+import { useGatewaySnapshot } from './useGatewaySnapshot';
+import { useGatewaySocket, type GatewaySocketState } from './useGatewaySocket';
+import { useGoals } from './useGoals';
+import { usePermissions } from './usePermissions';
+import { useSessionSnapshot } from './useSessionSnapshot';
+import { useSessions } from './useSessions';
+import { useWorkflows } from './useWorkflows';
+
+/** session.info snapshot — fetched on (re)connect and after anything that can
+ *  change the active mode/provider (the push stream doesn't carry it). */
+function useSessionInfo(socket: GatewaySocketState, workspaceId: string | null, sending: boolean) {
+  const [info, setInfo] = useState<SessionInfo | null>(null);
+  const { ready } = socket;
+
+  const refresh = useCallback(() => {
+    if (!ready) return;
+    void api()
+      .invoke('session.info', workspaceId ? { workspaceId } : undefined)
+      .then((next) => setInfo(next))
+      .catch(() => {});
+  }, [ready, workspaceId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh, socket.refreshTick]);
+
+  // A settled turn may have switched mode/provider server-side (goal mode,
+  // slash commands) — refetch when sending flips off.
+  useEffect(() => {
+    if (!sending) refresh();
+  }, [refresh, sending]);
+
+  return { info, refresh };
+}
+
+function useGatewayStoreValue(pairing: PairingState, socket: GatewaySocketState) {
+  const workspaceId = useActiveWorkspaceId();
+  const chatHandle = useChat(workspaceId);
+  const { info, refresh: refreshInfo } = useSessionInfo(socket, workspaceId, chatHandle.sending);
+  const queue = useQueuedTurns(workspaceId);
+  const usage = useSyncExternalStore(chatStore.subscribe, () =>
+    workspaceId ? chatStore.getUsage(workspaceId) : EMPTY_USAGE,
+  );
+  const contextUsage = useContextUsage(workspaceId);
+  const asks = useSyncExternalStore(askStore.subscribe, askStore.getAll);
+  const autoApproveUpstream = useSyncExternalStore(chatStore.subscribe, () =>
+    workspaceId ? chatStore.getAutoApprove(workspaceId) : false,
+  );
+  const [local, dispatchLocal] = useReducer(applyLocalFrame, undefined, emptyLocalUiState);
+  const onError = useCallback(
+    (message: string) => dispatchLocal({ type: 'error', message }),
+    [],
+  );
+
+  // A fresh client (re-pair) starts from a clean local slice.
+  useEffect(() => {
+    dispatchLocal({ type: 'reset' });
+  }, [socket.generation]);
+
+  const workflowsState = useWorkflows({
+    ready: socket.ready,
+    refreshTick: socket.refreshTick,
+    onError,
+  });
+
+  const connected = socket.status === 'connected';
+  const state: MobileState = useMemo(
+    () =>
+      buildMobileState({
+        connected,
+        workspaceId,
+        info,
+        chat: chatHandle,
+        queue,
+        usage,
+        contextWindow: contextUsage.contextWindow,
+        asks,
+        autoApprove: autoApproveUpstream,
+        workflows: workflowsState.list,
+        local,
+      }),
+    [
+      asks,
+      autoApproveUpstream,
+      chatHandle,
+      connected,
+      contextUsage.contextWindow,
+      info,
+      local,
+      queue,
+      usage,
+      workflowsState.list,
+      workspaceId,
+    ],
+  );
+
+  const snapshot = useGatewaySnapshot(state);
+  const session = useSessionSnapshot(snapshot);
+  const sessions = useSessions(snapshot, { onError, refreshInfo });
+  const permissions = usePermissions(snapshot);
+  const chat = useChatTranscript(snapshot);
+  const composer = useComposer({
+    workspaceId: snapshot.activeWorkspaceId,
+    activeTurnId: snapshot.activeTurnId,
+    transcriptionId: snapshot.transcriptionId,
+    transcriptionText: snapshot.transcriptionText,
+    readOnly: session.readOnly,
+    send: chatHandle.send,
+    abort: chatHandle.abort,
+    dispatchLocal,
+  });
+  const compact = useCompactContext({
+    readOnly: session.readOnly,
+    runCommand: composer.runCommand,
+  });
+  const autoApprove = useAutoApprove({
+    workspaceId: snapshot.activeWorkspaceId,
+    enabled: snapshot.autoApprove,
+    connected: snapshot.connected,
+  });
+  const goals = useGoals({
+    workspaceId: snapshot.activeWorkspaceId,
+    onError,
+    refreshInfo,
+  });
+  const workflows = useMemo(
+    () => ({
+      workflows: workflowsState.workflows,
+      refresh: workflowsState.refresh,
+      run: workflowsState.run,
+    }),
+    [workflowsState.refresh, workflowsState.run, workflowsState.workflows],
+  );
+
+  return {
+    pairing,
+    socketStatus: socket.status,
+    snapshot,
+    session,
+    sessions,
+    permissions,
+    workflows,
+    composer,
+    autoApprove,
+    goals,
+    compact,
+    chat,
+    chatEvents: snapshot.chatEvents,
+  };
+}
+
+type GatewayStore = ReturnType<typeof useGatewayStoreValue>;
+
+const GatewayContext = createContext<GatewayStore | null>(null);
+
+function GatewayInner({
+  pairing,
+  socket,
+  children,
+}: PropsWithChildren<{ pairing: PairingState; socket: GatewaySocketState }>): ReactElement {
+  const value = useGatewayStoreValue(pairing, socket);
+  return <GatewayContext.Provider value={value}>{children}</GatewayContext.Provider>;
+}
+
+export function GatewayProvider({ children }: PropsWithChildren): ReactElement {
+  const pairing = usePairing();
+  const wsUrl = useMemo(
+    () => (pairing.token ? normalizeGatewayUrl(pairing.gatewayUrl) : null),
+    [pairing.gatewayUrl, pairing.token],
+  );
+  const socket = useGatewaySocket(wsUrl, pairing.token);
+  return (
+    <>
+      {socket.ready ? (
+        // Keyed by generation: a re-pair builds a new client, so the bridges
+        // must re-mount to re-subscribe their event channels on it.
+        <GatewayBridges key={socket.generation} />
+      ) : null}
+      <GatewayInner pairing={pairing} socket={socket}>
+        {children}
+      </GatewayInner>
+    </>
+  );
+}
+
+function GatewayBridges(): ReactElement {
+  return (
+    <>
+      <ChatStoreBridge />
+      <ConnectionBridge />
+    </>
+  );
+}
+
+export function useGatewayStore(): GatewayStore {
+  const value = useContext(GatewayContext);
+  if (!value) throw new Error('GatewayProvider is missing');
+  return value;
+}

--- a/apps/mobile/src/hooks/useGoals.ts
+++ b/apps/mobile/src/hooks/useGoals.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from 'react';
+import { api, chatStore, toErrorMessage } from '@moxxy/client-core';
+import { buildGoalFrames, invokeFrame } from '../clientFrames';
+
+export function useGoals(input: {
+  readonly workspaceId: string | null;
+  readonly onError: (message: string) => void;
+  readonly refreshInfo: () => void;
+}) {
+  const [objective, setObjective] = useState('');
+  const [open, setOpen] = useState(false);
+  const { workspaceId, onError, refreshInfo } = input;
+
+  const startGoal = useCallback(() => {
+    const trimmed = objective.trim();
+    if (!trimmed) return;
+    const [setMode, setYolo, runTurn] = buildGoalFrames({ workspaceId, objective: trimmed });
+    void (async () => {
+      try {
+        // Strictly ordered: the turn must start under goal mode + auto-approve.
+        await invokeFrame(api(), setMode);
+        await invokeFrame(api(), setYolo);
+        if (workspaceId) chatStore.setAutoApprove(workspaceId, true);
+        const { turnId } = await invokeFrame(api(), runTurn);
+        if (workspaceId) chatStore.dispatch(workspaceId, { type: 'send_started', turnId });
+        refreshInfo();
+      } catch (e) {
+        onError(toErrorMessage(e));
+      }
+    })();
+    setObjective('');
+    setOpen(false);
+  }, [objective, onError, refreshInfo, workspaceId]);
+
+  return {
+    objective,
+    setObjective,
+    open,
+    setOpen,
+    startGoal,
+    canStart: objective.trim().length > 0,
+  };
+}

--- a/apps/mobile/src/hooks/useMessageCopy.ts
+++ b/apps/mobile/src/hooks/useMessageCopy.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import * as Clipboard from 'expo-clipboard';
+
+const COPIED_RESET_MS = 1400;
+
+export function useMessageCopy() {
+  const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const copyMessage = useCallback(async (messageId: string, text: string) => {
+    if (text.trim().length === 0) return;
+    await Clipboard.setStringAsync(text);
+    setCopiedMessageId(messageId);
+
+    if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    resetTimerRef.current = setTimeout(() => {
+      setCopiedMessageId((current) => (current === messageId ? null : current));
+    }, COPIED_RESET_MS);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    };
+  }, []);
+
+  return {
+    copiedMessageId,
+    copyMessage,
+  };
+}

--- a/apps/mobile/src/hooks/useMobileChrome.ts
+++ b/apps/mobile/src/hooks/useMobileChrome.ts
@@ -1,0 +1,19 @@
+import { useCallback, useState } from 'react';
+
+export function useMobileChrome() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const toggleMenu = useCallback(() => {
+    setMenuOpen((open) => !open);
+  }, []);
+
+  const closeMenu = useCallback(() => {
+    setMenuOpen(false);
+  }, []);
+
+  return {
+    menuOpen,
+    toggleMenu,
+    closeMenu,
+  };
+}

--- a/apps/mobile/src/hooks/useMobileMenuSearch.ts
+++ b/apps/mobile/src/hooks/useMobileMenuSearch.ts
@@ -1,0 +1,22 @@
+import { useCallback, useMemo, useState } from 'react';
+import { filterWorkspaceMenuSections, type WorkspaceMenuSection } from '../navigation';
+
+export function useMobileMenuSearch(sections: ReadonlyArray<WorkspaceMenuSection>) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const filteredSections = useMemo(() => filterWorkspaceMenuSections(sections, query), [sections, query]);
+  const toggle = useCallback(() => setOpen((value) => !value), []);
+  const close = useCallback(() => {
+    setOpen(false);
+    setQuery('');
+  }, []);
+
+  return {
+    open,
+    query,
+    filteredSections,
+    setQuery,
+    toggle,
+    close,
+  };
+}

--- a/apps/mobile/src/hooks/usePairing.ts
+++ b/apps/mobile/src/hooks/usePairing.ts
@@ -1,0 +1,142 @@
+/**
+ * Pairing state for the WebSocket bridge.
+ *
+ * Wave-5 semantics: `moxxy mobile` prints ONE QR — a `ws://host:port/?t=TOKEN`
+ * URL. Scanning (or pasting) it splits the token out (`parsePairingQrPayload`
+ * / `splitConnectUrl`); the bare URL + token persist in secure storage and the
+ * token is later presented as the `Sec-WebSocket-Protocol` bearer entry, never
+ * on the live WS URL.
+ *
+ * The facade keeps the reference's `PairingState` shape so the settings UI
+ * binds unchanged — with adjusted semantics where the old gateway differed:
+ *   - manual pairing = paste the printed connect URL (token included as `?t=`)
+ *     into the gateway-URL field; the embedded token surfaces as `code` and
+ *     `pair()` adopts it. No server round-trip.
+ *   - `loadPairing()` only clears a stale error — the WS bridge has no
+ *     pairing-code endpoint; the code is derived locally from the typed URL.
+ */
+
+import Constants from 'expo-constants';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { splitConnectUrl } from '../boot';
+import { parsePairingQrPayload } from '../pairingQr';
+import { chooseGatewayUrlForPairing, normalizeGatewayUrl } from '../pairingUrl';
+import { useStorageState } from './storage';
+
+const TOKEN_KEY = 'moxxy.mobile.gateway.token';
+const URL_KEY = 'moxxy.mobile.gateway.url';
+
+export interface PairingState {
+  readonly gatewayUrl: string;
+  readonly token: string | null;
+  readonly code: string;
+  readonly loading: boolean;
+  readonly error: string | null;
+  readonly setGatewayUrl: (value: string) => void;
+  readonly loadPairing: () => Promise<void>;
+  readonly pair: () => Promise<void>;
+  readonly pairFromQrPayload: (raw: string) => Promise<void>;
+  readonly disconnect: () => void;
+}
+
+export function usePairing(): PairingState {
+  const [[tokenLoading, token], setToken] = useStorageState(TOKEN_KEY);
+  const [[urlLoading, storedUrl], setStoredUrl] = useStorageState(URL_KEY);
+  const expoHostUri = readExpoHostUri();
+  const [gatewayUrl, setGatewayUrlState] = useState(
+    chooseGatewayUrlForPairing(storedUrl, expoHostUri),
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!urlLoading) setGatewayUrlState(chooseGatewayUrlForPairing(storedUrl, expoHostUri));
+  }, [expoHostUri, storedUrl, urlLoading]);
+
+  // The token embedded in whatever the user typed/pasted — surfaced as the
+  // pairing "code" so the manual flow reads: paste printed URL → Pair.
+  const code = useMemo(() => splitConnectUrl(gatewayUrl.trim()).token ?? '', [gatewayUrl]);
+
+  const setGatewayUrl = useCallback(
+    (value: string) => {
+      setGatewayUrlState(value);
+      setStoredUrl(normalizeGatewayUrl(value));
+    },
+    [setStoredUrl],
+  );
+
+  // No pairing-code endpoint on the WS bridge — the affordance only clears a
+  // stale error (the code is derived locally from the typed URL).
+  const loadPairing = useCallback(async () => {
+    setError(null);
+  }, []);
+
+  const adopt = useCallback(
+    (url: string, nextToken: string) => {
+      const normalized = normalizeGatewayUrl(url);
+      setGatewayUrlState(normalized);
+      setStoredUrl(normalized);
+      setToken(nextToken);
+      setError(null);
+    },
+    [setStoredUrl, setToken],
+  );
+
+  const pair = useCallback(async () => {
+    if (!code) {
+      setError('Paste the full connect URL `moxxy mobile` prints (it carries the token as ?t=).');
+      return;
+    }
+    adopt(gatewayUrl, code);
+  }, [adopt, code, gatewayUrl]);
+
+  const pairFromQrPayload = useCallback(
+    async (raw: string) => {
+      setError(null);
+      try {
+        const target = parsePairingQrPayload(raw);
+        if (!target.token) {
+          setError('This QR has no token — scan the one `moxxy mobile` prints.');
+          return;
+        }
+        adopt(target.gatewayUrl, target.token);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Invalid Moxxy pairing QR code');
+      }
+    },
+    [adopt],
+  );
+
+  const disconnect = useCallback(() => {
+    setToken(null);
+  }, [setToken]);
+
+  return {
+    gatewayUrl,
+    token,
+    code,
+    loading: tokenLoading || urlLoading,
+    error,
+    setGatewayUrl,
+    loadPairing,
+    pair,
+    pairFromQrPayload,
+    disconnect,
+  };
+}
+
+function readExpoHostUri(): string | null {
+  const constants = Constants as unknown as {
+    expoConfig?: { hostUri?: string | null };
+    manifest2?: {
+      extra?: { expoClient?: { hostUri?: string | null }; expoGo?: { debuggerHost?: string | null } };
+    };
+    manifest?: { debuggerHost?: string | null };
+  };
+  return (
+    constants.expoConfig?.hostUri ??
+    constants.manifest2?.extra?.expoClient?.hostUri ??
+    constants.manifest2?.extra?.expoGo?.debuggerHost ??
+    constants.manifest?.debuggerHost ??
+    null
+  );
+}

--- a/apps/mobile/src/hooks/usePermissions.ts
+++ b/apps/mobile/src/hooks/usePermissions.ts
@@ -1,0 +1,30 @@
+import { useCallback } from 'react';
+import { askStore } from '@moxxy/client-core';
+import { toAskResponse, toPermissionMode, type MobileState } from '../protocol';
+
+/**
+ * Pending interactive prompts. On this transport BOTH permissions and
+ * approvals ride the unified ask channel (`ask.request` → `ask.respond`), so
+ * `pendingPermissions` is structurally empty and the AskSheet renders
+ * everything from `pendingAsks`. Responding goes through client-core's
+ * askStore, which drops the ask locally and replies to the host.
+ */
+export function usePermissions(state: MobileState) {
+  const respondAsk = useCallback((requestId: string, response: Record<string, unknown>) => {
+    askStore.respond(requestId, toAskResponse(response));
+  }, []);
+
+  const decidePermission = useCallback(
+    (permissionId: string, mode: 'allow_once' | 'allow_session' | 'allow_always' | 'deny') => {
+      askStore.respond(permissionId, { mode: toPermissionMode(mode) });
+    },
+    [],
+  );
+
+  return {
+    pendingPermissions: state.pendingPermissions,
+    pendingAsks: state.pendingAsks,
+    decidePermission,
+    respondAsk,
+  };
+}

--- a/apps/mobile/src/hooks/useQrScanner.ts
+++ b/apps/mobile/src/hooks/useQrScanner.ts
@@ -1,0 +1,82 @@
+import { useCallback, useRef, useState } from 'react';
+import { useCameraPermissions } from 'expo-camera';
+import type { CameraPermissionState } from '../pairingUi';
+import { createQrScanGate } from '../qrScanGate';
+
+export interface QrScannerState {
+  readonly open: boolean;
+  readonly processing: boolean;
+  readonly armed: boolean;
+  readonly permission: CameraPermissionState;
+  readonly openScanner: () => Promise<void>;
+  readonly armScanner: () => void;
+  readonly closeScanner: () => void;
+  readonly requestPermission: () => Promise<void>;
+  readonly handlePayload: (raw: string) => Promise<void>;
+}
+
+export function useQrScanner(onPayload: (raw: string) => Promise<void>): QrScannerState {
+  const [permission, requestCameraPermission] = useCameraPermissions();
+  const [open, setOpen] = useState(false);
+  const [processing, setProcessing] = useState(false);
+  const [armed, setArmed] = useState(false);
+  const scanGateRef = useRef(createQrScanGate());
+
+  const permissionState = cameraPermissionState(permission);
+
+  const requestPermission = useCallback(async () => {
+    await requestCameraPermission();
+  }, [requestCameraPermission]);
+
+  const openScanner = useCallback(async () => {
+    scanGateRef.current.reset();
+    setOpen(true);
+    setProcessing(false);
+    setArmed(false);
+    if (!permission?.granted && permission?.canAskAgain !== false) {
+      await requestCameraPermission();
+    }
+  }, [permission?.canAskAgain, permission?.granted, requestCameraPermission]);
+
+  const armScanner = useCallback(() => {
+    scanGateRef.current.arm();
+    setArmed(true);
+  }, []);
+
+  const closeScanner = useCallback(() => {
+    scanGateRef.current.reset();
+    setOpen(false);
+    setProcessing(false);
+    setArmed(false);
+  }, []);
+
+  const handlePayload = useCallback(async (raw: string) => {
+    if (!scanGateRef.current.tryAcquire()) return;
+    setArmed(false);
+    setProcessing(true);
+    try {
+      await onPayload(raw);
+      setOpen(false);
+    } finally {
+      setProcessing(false);
+    }
+  }, [onPayload]);
+
+  return {
+    open,
+    processing,
+    armed,
+    permission: permissionState,
+    openScanner,
+    armScanner,
+    closeScanner,
+    requestPermission,
+    handlePayload,
+  };
+}
+
+function cameraPermissionState(permission: { granted?: boolean; canAskAgain?: boolean } | null): CameraPermissionState {
+  if (!permission) return 'loading';
+  if (permission.granted) return 'granted';
+  return permission.canAskAgain === false ? 'denied' : 'undetermined';
+}

--- a/apps/mobile/src/hooks/useSessionSnapshot.ts
+++ b/apps/mobile/src/hooks/useSessionSnapshot.ts
@@ -1,0 +1,16 @@
+import type { MobileState } from '../protocol';
+
+export function useSessionSnapshot(state: MobileState) {
+  return {
+    activeWorkspaceId: state.activeWorkspaceId,
+    session: state.session,
+    readOnly: state.session?.readOnly === true,
+    agents: state.agents,
+    commands: state.commands,
+    connected: state.connected,
+    activeMode: state.activeMode,
+    activeProvider: state.activeProvider,
+    modeBadge: state.modeBadge,
+    errors: state.errors,
+  };
+}

--- a/apps/mobile/src/hooks/useSessions.ts
+++ b/apps/mobile/src/hooks/useSessions.ts
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+import { api, chatStore, connectionStore, toErrorMessage } from '@moxxy/client-core';
+import { buildNewSessionFrame, invokeFrame } from '../clientFrames';
+import type { MobileState } from '../protocol';
+
+export function useSessions(
+  state: MobileState,
+  deps: {
+    readonly onError: (message: string) => void;
+    readonly refreshInfo: () => void;
+  },
+) {
+  // The mobile host serves exactly one workspace, so selection is local
+  // bookkeeping (active stores) rather than a host command.
+  const selectWorkspace = useCallback((workspaceId: string) => {
+    chatStore.setActive(workspaceId);
+    connectionStore.setActive(workspaceId);
+  }, []);
+
+  const { onError, refreshInfo } = deps;
+  const activeWorkspaceId = state.activeWorkspaceId;
+  const newSession = useCallback(
+    (workspaceId?: string) => {
+      const target = workspaceId ?? activeWorkspaceId;
+      void (async () => {
+        try {
+          // Host-side reset first (authoritative — aborts turns, clears the
+          // runner log), then the local transcript, so a failure never leaves
+          // the UI pretending the history is gone.
+          await invokeFrame(api(), buildNewSessionFrame({ workspaceId: target }));
+          if (target) chatStore.clear(target);
+          refreshInfo();
+        } catch (e) {
+          onError(toErrorMessage(e));
+        }
+      })();
+    },
+    [activeWorkspaceId, onError, refreshInfo],
+  );
+
+  return {
+    activeWorkspaceId,
+    workspaces: state.workspaces,
+    sessions: state.sessions,
+    selectWorkspace,
+    newSession,
+  };
+}

--- a/apps/mobile/src/hooks/useThinkingDots.ts
+++ b/apps/mobile/src/hooks/useThinkingDots.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react';
+import { Animated, Platform } from 'react-native';
+
+export function useThinkingDots() {
+  const valuesRef = useRef([
+    new Animated.Value(0.35),
+    new Animated.Value(0.35),
+    new Animated.Value(0.35),
+  ]);
+
+  useEffect(() => {
+    const animations = valuesRef.current.map((value, index) =>
+      Animated.loop(
+        Animated.sequence([
+          Animated.delay(index * 140),
+          Animated.timing(value, {
+            duration: 320,
+            toValue: 1,
+            useNativeDriver: Platform.OS !== 'web',
+          }),
+          Animated.timing(value, {
+            duration: 320,
+            toValue: 0.35,
+            useNativeDriver: Platform.OS !== 'web',
+          }),
+          Animated.delay((valuesRef.current.length - index - 1) * 140),
+        ]),
+      ),
+    );
+    animations.forEach((animation) => animation.start());
+    return () => {
+      animations.forEach((animation) => animation.stop());
+    };
+  }, []);
+
+  return valuesRef.current;
+}

--- a/apps/mobile/src/hooks/useVoiceRecorder.ts
+++ b/apps/mobile/src/hooks/useVoiceRecorder.ts
@@ -1,0 +1,223 @@
+/**
+ * Expo-audio voice capture for the composer, ported from the reference app.
+ * It owns the phase machine (idle → recording → transcribing → error) and
+ * hands the recorded clip (base64 + mime) to `onClip`; the DATA layer ships it
+ * to the runner's transcriber and calls `complete()` when the transcript
+ * lands.
+ *
+ * Availability seam (adaptation): the runner may have no transcriber plugin
+ * (`session.hasTranscriber` → false). The data layer passes that down as
+ * `available`; when false the recorder reports itself unavailable — `toggle`/
+ * `start` surface a clear error instead of recording audio into the void.
+ *
+ * NOTE: this intentionally does NOT go through client-core's platform
+ * `AudioCapture` capability — that contract is a web-centric PCM16@24kHz
+ * pipeline, while the mobile architecture (like the reference) ships the
+ * platform-native compressed clip (m4a / webm) with its mime type and lets the
+ * runner-side transcriber decode it.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { MutableRefObject } from 'react';
+import { Platform } from 'react-native';
+import {
+  AudioModule,
+  RecordingPresets,
+  setAudioModeAsync,
+  useAudioRecorder,
+  useAudioRecorderState,
+} from 'expo-audio';
+import * as FileSystem from 'expo-file-system/legacy';
+
+export type VoicePhase = 'idle' | 'recording' | 'transcribing' | 'error';
+
+export interface RecordedAudioClip {
+  readonly audioBase64: string;
+  readonly mimeType: string;
+}
+
+interface UseVoiceRecorderOptions {
+  readonly disabled?: boolean;
+  /** Whether a transcriber backend exists (`session.hasTranscriber`).
+   *  Defaults to true; pass false to report the mic as unavailable. */
+  readonly available?: boolean;
+  readonly onClip: (clip: RecordedAudioClip) => void;
+}
+
+interface WebRecorderState {
+  readonly recorder: MediaRecorder;
+  readonly stream: MediaStream;
+  readonly chunks: Blob[];
+}
+
+const WEB_MIME_CANDIDATES = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4'];
+const NATIVE_MIME_TYPE = 'audio/m4a';
+const ERROR_RESET_MS = 2500;
+const UNAVAILABLE_REASON = 'Voice transcription is not available - the runner has no transcriber plugin.';
+
+export function useVoiceRecorder(options: UseVoiceRecorderOptions) {
+  const available = options.available !== false;
+  const nativeRecorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
+  const nativeState = useAudioRecorderState(nativeRecorder);
+  const [phase, setPhase] = useState<VoicePhase>('idle');
+  const [errorReason, setErrorReason] = useState<string | null>(null);
+  const phaseRef = useRef<VoicePhase>('idle');
+  const availableRef = useRef(available);
+  availableRef.current = available;
+  const webRecorderRef = useRef<WebRecorderState | null>(null);
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onClipRef = useRef(options.onClip);
+  onClipRef.current = options.onClip;
+
+  const setVoicePhase = useCallback((next: VoicePhase) => {
+    phaseRef.current = next;
+    setPhase(next);
+  }, []);
+
+  const fail = useCallback((reason: string) => {
+    setErrorReason(reason);
+    setVoicePhase('error');
+    if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+    errorTimerRef.current = setTimeout(() => {
+      setErrorReason(null);
+      setVoicePhase('idle');
+    }, ERROR_RESET_MS);
+  }, [setVoicePhase]);
+
+  const start = useCallback(async () => {
+    if (options.disabled || phaseRef.current !== 'idle') return;
+    if (!availableRef.current) {
+      fail(UNAVAILABLE_REASON);
+      return;
+    }
+    try {
+      if (Platform.OS === 'web') {
+        await startWebRecording(webRecorderRef);
+      } else {
+        const permission = await AudioModule.requestRecordingPermissionsAsync();
+        if (!permission.granted) {
+          fail('Microphone permission denied.');
+          return;
+        }
+        await setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true });
+        await nativeRecorder.prepareToRecordAsync();
+        nativeRecorder.record();
+      }
+      setVoicePhase('recording');
+      setErrorReason(null);
+    } catch (error) {
+      fail(error instanceof Error ? error.message : 'Microphone is not available.');
+    }
+  }, [fail, nativeRecorder, options.disabled, setVoicePhase]);
+
+  const stop = useCallback(async () => {
+    if (phaseRef.current !== 'recording') return;
+    setVoicePhase('transcribing');
+    try {
+      const clip = Platform.OS === 'web'
+        ? await stopWebRecording(webRecorderRef)
+        : await stopNativeRecording(nativeRecorder);
+      if (clip.audioBase64.length === 0) {
+        fail('No speech detected - try again.');
+        return;
+      }
+      onClipRef.current(clip);
+    } catch (error) {
+      fail(error instanceof Error ? error.message : 'Voice transcription failed.');
+    } finally {
+      if (Platform.OS !== 'web') {
+        await setAudioModeAsync({ allowsRecording: false }).catch(() => undefined);
+      }
+    }
+  }, [fail, nativeRecorder, setVoicePhase]);
+
+  const toggle = useCallback(() => {
+    if (phaseRef.current === 'recording' || nativeState.isRecording) {
+      void stop();
+      return;
+    }
+    if (phaseRef.current === 'idle') void start();
+  }, [nativeState.isRecording, start, stop]);
+
+  const complete = useCallback(() => {
+    if (phaseRef.current === 'transcribing') setVoicePhase('idle');
+  }, [setVoicePhase]);
+
+  useEffect(() => {
+    return () => {
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+      const web = webRecorderRef.current;
+      web?.stream.getTracks().forEach((track) => track.stop());
+      webRecorderRef.current = null;
+    };
+  }, []);
+
+  return {
+    available,
+    phase,
+    errorReason,
+    toggle,
+    start,
+    stop,
+    complete,
+  };
+}
+
+async function startWebRecording(ref: MutableRefObject<WebRecorderState | null>) {
+  if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+    throw new Error('Microphone capture is not available in this browser.');
+  }
+  if (typeof MediaRecorder === 'undefined') {
+    throw new Error('MediaRecorder is not available in this browser.');
+  }
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  const mimeType = pickWebMimeType();
+  const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+  const chunks: Blob[] = [];
+  recorder.addEventListener('dataavailable', (event) => {
+    if (event.data.size > 0) chunks.push(event.data);
+  });
+  recorder.start();
+  ref.current = { recorder, stream, chunks };
+}
+
+async function stopWebRecording(ref: MutableRefObject<WebRecorderState | null>): Promise<RecordedAudioClip> {
+  const active = ref.current;
+  if (!active) throw new Error('Voice recorder is not running.');
+  ref.current = null;
+  const blob = await new Promise<Blob>((resolve) => {
+    active.recorder.addEventListener('stop', () => {
+      active.stream.getTracks().forEach((track) => track.stop());
+      resolve(new Blob(active.chunks, { type: active.recorder.mimeType || 'audio/webm' }));
+    }, { once: true });
+    active.recorder.stop();
+  });
+  return {
+    audioBase64: await blobToBase64(blob),
+    mimeType: blob.type || 'audio/webm',
+  };
+}
+
+async function stopNativeRecording(nativeRecorder: ReturnType<typeof useAudioRecorder>): Promise<RecordedAudioClip> {
+  await nativeRecorder.stop();
+  const uri = nativeRecorder.uri;
+  if (!uri) throw new Error('Voice recorder did not produce an audio file.');
+  return {
+    audioBase64: await FileSystem.readAsStringAsync(uri, { encoding: FileSystem.EncodingType.Base64 }),
+    mimeType: NATIVE_MIME_TYPE,
+  };
+}
+
+function pickWebMimeType(): string | undefined {
+  return WEB_MIME_CANDIDATES.find((candidate) => MediaRecorder.isTypeSupported(candidate));
+}
+
+async function blobToBase64(blob: Blob): Promise<string> {
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(String(reader.result ?? ''));
+    reader.onerror = () => reject(reader.error ?? new Error('Could not read recorded audio.'));
+    reader.readAsDataURL(blob);
+  });
+  return dataUrl.includes(',') ? dataUrl.slice(dataUrl.indexOf(',') + 1) : dataUrl;
+}

--- a/apps/mobile/src/hooks/useWorkflows.ts
+++ b/apps/mobile/src/hooks/useWorkflows.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { api, decodeError } from '@moxxy/client-core';
+import { buildWorkflowListFrame, buildWorkflowRunFrame, invokeFrame } from '../clientFrames';
+
+export interface MobileWorkflow {
+  readonly name: string;
+  readonly description: string;
+  readonly enabled: boolean;
+  readonly scope: string;
+  readonly steps: number;
+  readonly triggers: string;
+}
+
+/**
+ * Workflows over `workflows.list` / `workflows.run`. The host returns the
+ * typed empty list when the workflows plugin isn't loaded, and `run` fails
+ * with the coded `not-supported` error — both degrade to an empty screen and
+ * a plain message instead of a crash.
+ */
+export function useWorkflows(input: {
+  readonly ready: boolean;
+  readonly refreshTick: number;
+  readonly onError: (message: string) => void;
+}) {
+  const [list, setList] = useState<ReadonlyArray<Record<string, unknown>>>([]);
+  const { ready, refreshTick, onError } = input;
+
+  const refresh = useCallback(() => {
+    if (!ready) return;
+    void invokeFrame(api(), buildWorkflowListFrame())
+      .then((summaries) => setList(summaries.map((summary) => ({ ...summary }))))
+      .catch(() => setList([]));
+  }, [ready]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh, refreshTick]);
+
+  const run = useCallback(
+    (name: string) => {
+      void invokeFrame(api(), buildWorkflowRunFrame({ name }))
+        .then((result) => {
+          if (!result.ok) onError(result.error ?? `Workflow ${name} failed`);
+        })
+        .catch((e) => {
+          const decoded = decodeError(e);
+          onError(
+            decoded.code === 'not-supported'
+              ? 'Workflows are not available on this host.'
+              : decoded.message,
+          );
+        });
+    },
+    [onError],
+  );
+
+  const workflows = useMemo(() => list.map(normalizeWorkflow), [list]);
+
+  return {
+    /** Raw records — feed `MobileState.workflows`. */
+    list,
+    workflows,
+    refresh,
+    run,
+  };
+}
+
+function normalizeWorkflow(value: Record<string, unknown>, index: number): MobileWorkflow {
+  return {
+    name: textOf(value.name, `workflow-${index + 1}`),
+    description: textOf(value.description, ''),
+    enabled: value.enabled === true,
+    scope: textOf(value.scope, ''),
+    steps: typeof value.steps === 'number' ? value.steps : 0,
+    triggers: textOf(value.triggers, ''),
+  };
+}
+
+function textOf(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.length > 0 ? value : fallback;
+}

--- a/apps/mobile/src/hooks/useWorkspaceCollapse.ts
+++ b/apps/mobile/src/hooks/useWorkspaceCollapse.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  applyWorkspaceCollapseToggles,
+  buildInitialCollapsedWorkspaceIds,
+  type WorkspaceMenuSection,
+} from '../navigation';
+
+export function useWorkspaceCollapse(
+  sections: ReadonlyArray<WorkspaceMenuSection>,
+  maxExpanded = 3,
+) {
+  const defaultCollapsedIds = useMemo(
+    () => buildInitialCollapsedWorkspaceIds(sections, maxExpanded),
+    [maxExpanded, sections],
+  );
+  const sectionIds = useMemo(() => sections.map((section) => section.id).join('\n'), [sections]);
+  const [toggledWorkspaceIds, setToggledWorkspaceIds] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    setToggledWorkspaceIds((current) => {
+      const validIds = new Set(sectionIds.split('\n').filter((id) => id.length > 0));
+      const next = new Set([...current].filter((id) => validIds.has(id)));
+      return sameSet(current, next) ? current : next;
+    });
+  }, [sectionIds]);
+
+  const collapsedWorkspaceIds = useMemo(
+    () => applyWorkspaceCollapseToggles(defaultCollapsedIds, [...toggledWorkspaceIds]),
+    [defaultCollapsedIds, toggledWorkspaceIds],
+  );
+
+  const toggleWorkspace = useCallback(
+    (workspaceId: string) => {
+      setToggledWorkspaceIds((current) => {
+        const next = new Set(current);
+        if (next.has(workspaceId)) next.delete(workspaceId);
+        else next.add(workspaceId);
+        return next;
+      });
+    },
+    [],
+  );
+
+  return {
+    collapsedWorkspaceIds,
+    toggleWorkspace,
+  };
+}
+
+function sameSet(left: Set<string>, right: Set<string>) {
+  if (left.size !== right.size) return false;
+  for (const value of left) {
+    if (!right.has(value)) return false;
+  }
+  return true;
+}

--- a/apps/mobile/src/messageActions.ts
+++ b/apps/mobile/src/messageActions.ts
@@ -1,0 +1,12 @@
+import type { TranscriptItem } from './chatTranscript';
+
+export interface MessageActions {
+  readonly copyText?: string;
+}
+
+export function buildMessageActions(item: TranscriptItem): MessageActions {
+  if ((item.kind === 'user' || item.kind === 'assistant') && item.text.trim().length > 0) {
+    return { copyText: item.text };
+  }
+  return {};
+}

--- a/apps/mobile/src/navigation.ts
+++ b/apps/mobile/src/navigation.ts
@@ -1,0 +1,298 @@
+export interface BottomTabItem {
+  readonly href: '/chat' | '/sessions' | '/permissions' | '/goals' | '/settings';
+  readonly label: 'Chat' | 'Sessions' | 'Actions' | 'Goals' | 'Settings';
+  readonly icon: 'message' | 'sessions' | 'actions' | 'goals' | 'settings';
+  readonly badge: string | null;
+}
+
+export interface MobileMenuItem {
+  readonly kind: 'link' | 'command';
+  readonly href?: '/settings' | '/workflows';
+  readonly command?: 'workflows';
+  readonly commandArgs?: string;
+  readonly label: 'Workflows' | 'Settings' | 'Gateway';
+  readonly icon: 'workflows' | 'settings' | 'gateway';
+  readonly badge: string | null;
+}
+
+export interface RecentMenuSession {
+  readonly id: string;
+  readonly title: string;
+  readonly subtitle: string;
+  readonly active: boolean;
+  readonly live: boolean;
+  readonly readOnly: boolean;
+  readonly dotTone: 'active' | 'muted';
+  readonly statusLabel: 'Active' | null;
+}
+
+export interface WorkspaceMenuSession {
+  readonly id: string;
+  readonly title: string;
+  readonly subtitle: string;
+  readonly active: boolean;
+  readonly live: boolean;
+  readonly readOnly: boolean;
+  readonly lastActivity: string;
+  readonly shortcutLabel: string | null;
+}
+
+export interface WorkspaceMenuSection {
+  readonly id: string;
+  readonly title: string;
+  readonly subtitle: string;
+  readonly color: string;
+  readonly active: boolean;
+  readonly latestActivity: string;
+  readonly sessions: ReadonlyArray<WorkspaceMenuSession>;
+}
+
+export interface QuickActionItem {
+  readonly id: 'goal' | 'autoApprove' | 'compact' | 'newSession';
+  readonly label: string;
+  readonly icon: 'goals' | 'bolt' | 'actions' | 'plus';
+  readonly active: boolean;
+  readonly requiresConfirmation?: boolean;
+}
+
+export interface ComposerAttachmentActionItem {
+  readonly id: 'attachImage' | 'attachFile';
+  readonly label: 'Photo or screenshot' | 'File from phone';
+  readonly icon: 'camera' | 'folder';
+  readonly active?: boolean;
+}
+
+export interface ReturnToChatAction {
+  readonly href: '/chat';
+  readonly label: 'Chat';
+  readonly icon: 'message';
+}
+
+const BASE_TABS: ReadonlyArray<Omit<BottomTabItem, 'badge'>> = [
+  { href: '/chat', label: 'Chat', icon: 'message' },
+  { href: '/sessions', label: 'Sessions', icon: 'sessions' },
+  { href: '/permissions', label: 'Actions', icon: 'actions' },
+  { href: '/goals', label: 'Goals', icon: 'goals' },
+  { href: '/settings', label: 'Settings', icon: 'settings' },
+];
+
+export function buildBottomTabs(pendingActions = 0): BottomTabItem[] {
+  return BASE_TABS.map((tab) => ({
+    ...tab,
+    badge: tab.href === '/permissions' && pendingActions > 0 ? String(pendingActions) : null,
+  }));
+}
+
+const MENU_ITEMS: ReadonlyArray<Omit<MobileMenuItem, 'badge'>> = [
+  { kind: 'link', href: '/workflows', label: 'Workflows', icon: 'workflows' },
+  { kind: 'link', href: '/settings', label: 'Settings', icon: 'settings' },
+  { kind: 'link', href: '/settings', label: 'Gateway', icon: 'gateway' },
+];
+
+export function buildMobileMenuItems(_pendingActions = 0): MobileMenuItem[] {
+  return MENU_ITEMS.map((item) => ({
+    ...item,
+    badge: null,
+  }));
+}
+
+export function buildRecentMenuSessions(
+  sessions: ReadonlyArray<Record<string, unknown>>,
+  activeSessionId: string | null,
+  limit = Number.POSITIVE_INFINITY,
+): RecentMenuSession[] {
+  return sessions
+    .filter(hasVisibleSessionContext)
+    .slice(0, limit)
+    .map((session, index) => {
+      const id = stringOf(session.id, `session-${index}`);
+      return {
+        id,
+        title: stringOf(session.firstPrompt, stringOf(session.name, id)),
+        subtitle: stringOf(session.cwd, ''),
+        active: id === activeSessionId,
+        live: session.live === true,
+        readOnly: session.readOnly === true,
+        dotTone: id === activeSessionId ? 'active' : 'muted',
+        statusLabel: id === activeSessionId ? 'Active' : null,
+      };
+    });
+}
+
+export function filterRecentMenuSessions(
+  sessions: ReadonlyArray<RecentMenuSession>,
+  query: string,
+): RecentMenuSession[] {
+  const normalized = query.trim().toLowerCase();
+  if (normalized.length === 0) return [...sessions];
+  return sessions.filter((session) => {
+    const haystack = `${session.title} ${session.subtitle}`.toLowerCase();
+    return haystack.includes(normalized);
+  });
+}
+
+export function buildWorkspaceMenuSections(
+  workspaces: ReadonlyArray<Record<string, unknown>>,
+  sessions: ReadonlyArray<Record<string, unknown>>,
+  activeSessionId: string | null,
+): WorkspaceMenuSection[] {
+  const realSections = workspaces
+    .filter(isVisibleWorkspace)
+    .map((workspace, index) => ({
+      id: stringOf(workspace.id, `workspace-${index}`),
+      title: stringOf(workspace.name, stringOf(workspace.title, `Workspace ${index + 1}`)),
+      subtitle: stringOf(workspace.cwd, ''),
+      color: stringOf(workspace.color, '#ec4899'),
+      sessions: [] as WorkspaceMenuSession[],
+    }));
+  const byWorkspace = new Map<string, {
+    id: string;
+    title: string;
+    subtitle: string;
+    color: string;
+    sessions: WorkspaceMenuSession[];
+  }>(realSections.map((section) => [section.id, section]));
+  const workspaceByCwd = new Map(
+    realSections
+      .filter((section) => section.subtitle.length > 0)
+      .map((section) => [section.subtitle, section.id]),
+  );
+  const others = {
+    id: 'others',
+    title: 'Others',
+    subtitle: 'Sessions outside desktop workspaces',
+    color: '#94a3b8',
+    sessions: [] as WorkspaceMenuSession[],
+  };
+
+  for (const raw of sessions.filter(hasVisibleSessionContext)) {
+    const id = stringOf(raw.id, '');
+    if (!id) continue;
+    const cwd = stringOf(raw.cwd, '');
+    const rawWorkspaceId = stringOf(raw.workspaceId, '');
+    const workspaceId = byWorkspace.has(rawWorkspaceId) ? rawWorkspaceId : workspaceByCwd.get(cwd) ?? 'others';
+    const workspace = byWorkspace.get(workspaceId) ?? others;
+    workspace.sessions.push({
+      id,
+      title: stringOf(raw.firstPrompt, stringOf(raw.name, id)),
+      subtitle: cwd,
+      active: id === activeSessionId,
+      live: raw.live === true,
+      readOnly: raw.readOnly === true,
+      lastActivity: stringOf(raw.lastActivity, ''),
+      shortcutLabel: null,
+    });
+    if (workspace.id === 'others') byWorkspace.set('others', workspace);
+  }
+
+  const sortedSections = [...byWorkspace.values()]
+    .map((workspace) => {
+      const sortedSessions = [...workspace.sessions]
+        .sort((a, b) => b.lastActivity.localeCompare(a.lastActivity));
+      return {
+        ...workspace,
+        active: sortedSessions.some((session) => session.active),
+        latestActivity: sortedSessions[0]?.lastActivity ?? '',
+        sessions: sortedSessions,
+      };
+    })
+    .filter((section) => section.sessions.length > 0 || section.id !== 'others');
+
+  return sortedSections;
+}
+
+export function filterWorkspaceMenuSections(
+  sections: ReadonlyArray<WorkspaceMenuSection>,
+  query: string,
+): WorkspaceMenuSection[] {
+  const normalized = query.trim().toLowerCase();
+  if (normalized.length === 0) return [...sections];
+  return sections
+    .map((section) => {
+      const sectionMatches = `${section.title} ${section.subtitle}`.toLowerCase().includes(normalized);
+      const sessions = sectionMatches
+        ? section.sessions
+        : section.sessions.filter((session) =>
+            `${session.title} ${session.subtitle}`.toLowerCase().includes(normalized),
+          );
+      return sessions.length > 0 ? { ...section, sessions } : null;
+    })
+    .filter((section): section is WorkspaceMenuSection => section !== null);
+}
+
+export function buildInitialCollapsedWorkspaceIds(
+  sections: ReadonlyArray<WorkspaceMenuSection>,
+  maxExpanded = 3,
+  maxSessionsWhenExpanded = 12,
+): string[] {
+  const expanded = new Set<string>();
+  for (const section of sections) {
+    if (section.active) expanded.add(section.id);
+  }
+  for (const section of sections) {
+    if (expanded.size >= maxExpanded) break;
+    expanded.add(section.id);
+  }
+  return sections
+    .filter((section) => {
+      if (section.sessions.length > maxSessionsWhenExpanded) return true;
+      if (!expanded.has(section.id)) return true;
+      return false;
+    })
+    .map((section) => section.id);
+}
+
+export function applyWorkspaceCollapseToggles(
+  defaultCollapsedIds: ReadonlyArray<string>,
+  toggledWorkspaceIds: ReadonlyArray<string>,
+): string[] {
+  const collapsed = new Set(defaultCollapsedIds);
+  for (const workspaceId of toggledWorkspaceIds) {
+    if (collapsed.has(workspaceId)) collapsed.delete(workspaceId);
+    else collapsed.add(workspaceId);
+  }
+  return [...collapsed];
+}
+
+function hasVisibleSessionContext(session: Record<string, unknown>): boolean {
+  if (session.live === true) return true;
+  const eventCount = typeof session.eventCount === 'number' ? session.eventCount : 0;
+  return eventCount > 0 && stringOf(session.firstPrompt, stringOf(session.name, '')).trim().length > 0;
+}
+
+function isVisibleWorkspace(workspace: Record<string, unknown>): boolean {
+  return stringOf(workspace.id, '').length > 0 && stringOf(workspace.name, stringOf(workspace.title, '')).trim().length > 0;
+}
+
+function stringOf(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.length > 0 ? value : fallback;
+}
+
+export function buildQuickActionItems(autoApprove = false): QuickActionItem[] {
+  return [
+    { id: 'goal', label: 'Start goal', icon: 'goals', active: false },
+    {
+      id: 'autoApprove',
+      label: autoApprove ? 'Auto-approve ON' : 'Auto-approve',
+      icon: 'bolt',
+      active: autoApprove,
+    },
+    { id: 'compact', label: 'Compact context', icon: 'actions', active: false, requiresConfirmation: true },
+    { id: 'newSession', label: 'New session', icon: 'plus', active: false },
+  ];
+}
+
+export function buildComposerAttachmentActionItems(): ComposerAttachmentActionItem[] {
+  return [
+    { id: 'attachImage', label: 'Photo or screenshot', icon: 'camera' },
+    { id: 'attachFile', label: 'File from phone', icon: 'folder' },
+  ];
+}
+
+export function buildReturnToChatAction(): ReturnToChatAction {
+  return {
+    href: '/chat',
+    label: 'Chat',
+    icon: 'message',
+  };
+}

--- a/apps/mobile/src/pairingQr.ts
+++ b/apps/mobile/src/pairingQr.ts
@@ -1,0 +1,43 @@
+/**
+ * QR-payload parsing, adapted to OUR pairing format. The reference app's
+ * gateway printed a JSON payload (`{type:'moxxy-mobile-gateway',…}`); moxxy's
+ * `plugin-channel-mobile` prints a QR whose payload is the connect URL itself
+ * with the pairing token embedded as `?t=` (one scan carries everything):
+ *
+ *   ws://192.168.1.7:8765/?t=<token>     (LAN)
+ *   wss://xyz.trycloudflare.com/?t=<token>  (tunnel)
+ *
+ * The parse splits that into the bare gateway URL + the token — mirroring
+ * `boot.splitConnectUrl`, which performs the same split right before the
+ * transport is configured (the token must never ride the live WS URL).
+ */
+
+import { normalizeGatewayUrl } from './pairingUrl';
+
+export interface PairingQrTarget {
+  readonly gatewayUrl: string;
+  readonly token: string | null;
+}
+
+export function parsePairingQrPayload(raw: string): PairingQrTarget {
+  const scanned = raw.trim();
+  // Not a URL (someone scanned a random QR, or an old JSON-payload QR).
+  if (!/^(?:wss?|https?):\/\/[^\s/?#]+/i.test(scanned)) {
+    throw new Error('Invalid Moxxy pairing QR code');
+  }
+
+  const match = /[?&]t=([^&#]+)/.exec(scanned);
+  let token: string | null = null;
+  if (match) {
+    try {
+      token = decodeURIComponent(match[1]!);
+    } catch {
+      token = match[1]!; // malformed escape — keep the raw value
+    }
+  }
+
+  return {
+    gatewayUrl: normalizeGatewayUrl(scanned),
+    token,
+  };
+}

--- a/apps/mobile/src/pairingUi.ts
+++ b/apps/mobile/src/pairingUi.ts
@@ -1,0 +1,33 @@
+export type CameraPermissionState = 'loading' | 'granted' | 'denied' | 'undetermined';
+
+export interface PairingUiInput {
+  readonly token: string | null;
+  readonly scanning: boolean;
+  readonly permission: CameraPermissionState;
+}
+
+export interface PairingUiState {
+  readonly statusLabel: 'Paired' | 'Not paired';
+  readonly scanButtonLabel: 'Scan QR code' | 'Scanning...' | 'Camera blocked';
+  readonly scanButtonEnabled: boolean;
+  readonly manualPairingVisible: boolean;
+  readonly manualPairingToggleLabel: 'Manual pairing';
+  readonly scannerTitle: 'Scan Moxxy QR';
+  readonly scannerHint: string;
+}
+
+export function buildPairingUiState(input: PairingUiInput): PairingUiState {
+  const paired = Boolean(input.token);
+  const permissionDenied = input.permission === 'denied';
+  return {
+    statusLabel: paired ? 'Paired' : 'Not paired',
+    scanButtonLabel: permissionDenied ? 'Camera blocked' : input.scanning ? 'Scanning...' : 'Scan QR code',
+    scanButtonEnabled: !permissionDenied,
+    manualPairingVisible: false,
+    manualPairingToggleLabel: 'Manual pairing',
+    scannerTitle: 'Scan Moxxy QR',
+    scannerHint: permissionDenied
+      ? 'Camera permission is required to scan the Moxxy pairing QR code.'
+      : 'Point your camera at the gateway QR, then tap Scan QR code.',
+  };
+}

--- a/apps/mobile/src/pairingUrl.ts
+++ b/apps/mobile/src/pairingUrl.ts
@@ -1,0 +1,91 @@
+/**
+ * Manual-entry helpers for the bridge ("gateway") URL.
+ *
+ * Adapted from the reference app's HTTP pairing-gateway helpers to OUR pairing
+ * transport: `moxxy mobile` / the desktop bridge listen on a plain WebSocket
+ * (default port 8765) and the QR payload is the connect URL itself with the
+ * pairing token riding as `?t=` (see `plugin-channel-mobile/src/tunnel.ts
+ * buildConnectUrl`). These helpers normalize whatever the user types or scans
+ * into a BARE `ws(s)://host[:port]` URL — token extraction is
+ * `parsePairingQrPayload` / `boot.splitConnectUrl`'s job.
+ *
+ * Parsing is regex-based, not `new URL` — Hermes' URL support is unreliable
+ * (same rationale as `boot.ts`).
+ */
+
+export const DEFAULT_BRIDGE_PORT = 8765;
+const LOCAL_BRIDGE_URL = `ws://127.0.0.1:${DEFAULT_BRIDGE_PORT}`;
+
+export function deriveGatewayUrlFromExpoHost(hostUri?: string | null): string {
+  const host = extractHost(hostUri);
+  return host ? `ws://${host}:${DEFAULT_BRIDGE_PORT}` : LOCAL_BRIDGE_URL;
+}
+
+export function chooseGatewayUrlForPairing(storedUrl: string | null | undefined, expoHostUri?: string | null): string {
+  const derivedUrl = deriveGatewayUrlFromExpoHost(expoHostUri);
+  if (!storedUrl) return derivedUrl;
+
+  const normalizedStored = normalizeGatewayUrl(storedUrl);
+  if (isLoopbackUrl(normalizedStored) && !isLoopbackUrl(derivedUrl)) return derivedUrl;
+  return normalizedStored;
+}
+
+/**
+ * Normalize a manually entered / scanned bridge URL to a bare `ws(s)://host[:port]`:
+ *   - `http(s)` schemes map to `ws(s)` (a tunnel URL pasted from the browser);
+ *   - a bare `host[:port]` gets `ws://` prepended;
+ *   - a bare `ws` host without a port gets the default bridge port (a `wss`
+ *     tunnel host stays portless — 443 is implied);
+ *   - path, query (incl. a stray `?t=` token), and hash are stripped;
+ *   - a garbled double-paste recovers the LAST valid absolute URL.
+ */
+export function normalizeGatewayUrl(value: string): string {
+  const recovered = recoverLatestAbsoluteUrl(value.trim());
+  if (!recovered) return LOCAL_BRIDGE_URL;
+
+  const withScheme = /^(?:wss?|https?):\/\//i.test(recovered) ? recovered : `ws://${recovered}`;
+  const match = /^(wss?|https?):\/\/([^\s/?#]+)/i.exec(withScheme);
+  if (!match) return LOCAL_BRIDGE_URL;
+
+  const scheme = mapScheme(match[1]!);
+  let host = match[2]!;
+  if (scheme === 'ws' && !/:\d+$/.test(host)) host = `${host}:${DEFAULT_BRIDGE_PORT}`;
+  return `${scheme}://${host}`;
+}
+
+function mapScheme(raw: string): 'ws' | 'wss' {
+  const lower = raw.toLowerCase();
+  return lower === 'https' || lower === 'wss' ? 'wss' : 'ws';
+}
+
+function recoverLatestAbsoluteUrl(value: string): string {
+  const matches = [...value.matchAll(/(?:wss?|https?):\/\//gi)];
+  for (let index = matches.length - 1; index >= 0; index -= 1) {
+    const start = matches[index]!.index;
+    if (typeof start !== 'number') continue;
+    const candidate = value.slice(start).trim();
+    if (/^(?:wss?|https?):\/\/[^\s/?#]+/i.test(candidate)) return candidate;
+    // Keep scanning older candidates.
+  }
+  return value;
+}
+
+export function isLoopbackUrl(value: string): boolean {
+  const host = hostOf(value);
+  if (!host) return false;
+  const bare = host.replace(/:\d+$/, '').replace(/^\[|\]$/g, '').toLowerCase();
+  return bare === 'localhost' || bare === '::1' || bare.startsWith('127.');
+}
+
+function hostOf(value: string): string | null {
+  const match = /^(?:wss?|https?):\/\/([^\s/?#]+)/i.exec(value.trim());
+  return match ? match[1]! : null;
+}
+
+function extractHost(hostUri?: string | null): string | null {
+  if (!hostUri) return null;
+  const withoutProtocol = hostUri.replace(/^[a-z]+:\/\//i, '');
+  const hostWithPort = withoutProtocol.split('/')[0] ?? '';
+  const host = hostWithPort.split(':')[0]!;
+  return host.length > 0 ? host : null;
+}

--- a/apps/mobile/src/protocol.ts
+++ b/apps/mobile/src/protocol.ts
@@ -1,0 +1,287 @@
+/**
+ * The mobile state model.
+ *
+ * `MobileState` keeps the reference app's field names verbatim so every screen
+ * binds unchanged — but where the reference rebuilt that state from scratch by
+ * folding raw gateway frames, this port COMPOSES `@moxxy/client-core`: the
+ * chat store already does the event folding (assistant_chunk → streamingText,
+ * id-dedup across replays, provider_response → usage, queue, compaction lock)
+ * and the ask store owns the pending permission/approval prompts. What lives
+ * here is therefore:
+ *
+ *   - the `MobileState` type + `emptyMobileState()` (the facade contract),
+ *   - `buildMobileState()` — a pure presenter from client-core snapshots
+ *     (plus the session.info fetch and the local UI slice) into that shape,
+ *   - a tiny `applyLocalFrame` reducer for the few bits no shared store owns
+ *     (voice-transcription lifecycle, surfaced errors),
+ *   - the ask-response normalizers that translate the reference UI's
+ *     `allow_once`-style decisions into the IPC contract's `PermissionMode`.
+ *
+ * Everything in this module is React-free and pure so the protocol tests can
+ * drive it directly.
+ */
+
+import type { AskRequest, AskResponse, PermissionMode } from '@moxxy/desktop-ipc-contract';
+
+export interface MobileState {
+  readonly connected: boolean;
+  readonly activeWorkspaceId: string | null;
+  readonly workspaces: ReadonlyArray<Record<string, unknown>>;
+  readonly sessions: ReadonlyArray<Record<string, unknown>>;
+  readonly session: Record<string, unknown> | null;
+  readonly agents: ReadonlyArray<Record<string, unknown>>;
+  readonly workflows: ReadonlyArray<Record<string, unknown>>;
+  readonly pendingPermissions: ReadonlyArray<Record<string, unknown>>;
+  readonly pendingAsks: ReadonlyArray<Record<string, unknown>>;
+  readonly commands: ReadonlyArray<Record<string, unknown>>;
+  readonly chatEvents: ReadonlyArray<Record<string, unknown>>;
+  readonly streamingText: string;
+  readonly sending: boolean;
+  readonly activeTurnId: string | null;
+  readonly queue: ReadonlyArray<Record<string, unknown>>;
+  readonly compacting: boolean;
+  readonly usage: Record<string, unknown> | null;
+  readonly autoApprove: boolean;
+  readonly activeMode: string | null;
+  readonly activeProvider: string | null;
+  readonly modeBadge: Record<string, unknown> | null;
+  readonly transcriptionId: string | null;
+  readonly transcriptionText: string | null;
+  readonly transcribing: boolean;
+  readonly errors: ReadonlyArray<string>;
+}
+
+export function emptyMobileState(): MobileState {
+  return {
+    connected: false,
+    activeWorkspaceId: null,
+    workspaces: [],
+    sessions: [],
+    session: null,
+    agents: [],
+    workflows: [],
+    pendingPermissions: [],
+    pendingAsks: [],
+    commands: [],
+    chatEvents: [],
+    streamingText: '',
+    sending: false,
+    activeTurnId: null,
+    queue: [],
+    compacting: false,
+    usage: null,
+    autoApprove: false,
+    activeMode: null,
+    activeProvider: null,
+    modeBadge: null,
+    transcriptionId: null,
+    transcriptionText: null,
+    transcribing: false,
+    errors: [],
+  };
+}
+
+// ---------- Local UI slice (state no shared store owns) ---------------------
+
+export interface LocalUiState {
+  readonly transcriptionId: string | null;
+  readonly transcriptionText: string | null;
+  readonly transcribing: boolean;
+  readonly errors: ReadonlyArray<string>;
+  /** Monotonic counter minting transcription ids (so the composer can tell a
+   *  fresh result from the one it already consumed). */
+  readonly seq: number;
+}
+
+export type LocalFrame =
+  | { readonly type: 'reset' }
+  | { readonly type: 'transcribe.started' }
+  | { readonly type: 'transcribe.result'; readonly id?: string; readonly text: string }
+  | { readonly type: 'error'; readonly message: string };
+
+const MAX_ERRORS = 20;
+
+export function emptyLocalUiState(): LocalUiState {
+  return { transcriptionId: null, transcriptionText: null, transcribing: false, errors: [], seq: 0 };
+}
+
+export function applyLocalFrame(state: LocalUiState, frame: LocalFrame): LocalUiState {
+  switch (frame.type) {
+    case 'reset':
+      return emptyLocalUiState();
+    case 'transcribe.started':
+      return { ...state, transcribing: true };
+    case 'transcribe.result': {
+      const seq = state.seq + 1;
+      return {
+        ...state,
+        transcriptionId: frame.id ?? `transcribe-${seq}`,
+        transcriptionText: frame.text,
+        transcribing: false,
+        seq,
+      };
+    }
+    case 'error':
+      return {
+        ...state,
+        transcribing: false,
+        errors: [...state.errors, frame.message].slice(-MAX_ERRORS),
+      };
+  }
+}
+
+// ---------- Presenter: client-core snapshots → MobileState ------------------
+
+/** The chat-store slice the presenter reads (structural — `UseChat` from
+ *  `@moxxy/client-core` satisfies it). */
+export interface ChatSourceState {
+  readonly events: ReadonlyArray<unknown>;
+  readonly streamingText: string;
+  readonly sending: boolean;
+  readonly activeTurnId: string | null;
+  readonly compacting: boolean;
+  readonly error: string | null;
+}
+
+/** chat-store usage accumulator (structural mirror of `UsageSnapshot`). */
+export interface UsageSourceState {
+  readonly latestPrompt: number | null;
+  readonly perCall: ReadonlyArray<number>;
+  readonly calls: number;
+  readonly totalInput: number;
+  readonly totalCacheRead: number;
+  readonly totalCacheCreation: number;
+  readonly totalOutput: number;
+}
+
+/** The slice of `SessionInfo` the presenter reads (structural — keeps test
+ *  fixtures small; the real snapshot satisfies it). */
+export interface SessionInfoLike {
+  readonly sessionId?: string;
+  readonly cwd?: string;
+  readonly activeProvider?: string | null;
+  readonly activeMode?: string | null;
+  readonly activeModeBadge?: { readonly label: string } | null;
+  readonly commands?: ReadonlyArray<{ readonly name: string; readonly description?: string }>;
+}
+
+export interface MobileStateSources {
+  readonly connected: boolean;
+  readonly workspaceId: string | null;
+  readonly info: SessionInfoLike | null;
+  readonly chat: ChatSourceState;
+  readonly queue: ReadonlyArray<{ readonly id: string; readonly prompt: string }>;
+  readonly usage: UsageSourceState;
+  /** Active model's context window (from `useContextUsage`), or null. */
+  readonly contextWindow: number | null;
+  readonly asks: ReadonlyArray<AskRequest>;
+  readonly autoApprove: boolean;
+  readonly workflows: ReadonlyArray<Record<string, unknown>>;
+  readonly local: LocalUiState;
+}
+
+export function buildMobileState(src: MobileStateSources): MobileState {
+  const workspaceId = src.workspaceId;
+  const info = src.info;
+  const name = workspaceName(info);
+  const session: Record<string, unknown> | null = workspaceId
+    ? {
+        id: info?.sessionId ?? workspaceId,
+        cwd: info?.cwd ?? '',
+        live: true,
+        readOnly: false,
+        provider: info?.activeProvider ?? null,
+      }
+    : null;
+  return {
+    connected: src.connected,
+    activeWorkspaceId: workspaceId,
+    workspaces: workspaceId ? [{ id: workspaceId, name, unread: false }] : [],
+    sessions: workspaceId
+      ? [
+          {
+            id: workspaceId,
+            name,
+            live: true,
+            readOnly: false,
+            firstPrompt: firstUserPrompt(src.chat.events),
+            provider: info?.activeProvider ?? null,
+          },
+        ]
+      : [],
+    session,
+    // The IPC contract exposes no agent catalog — present the honest empty
+    // list so the menu section simply doesn't render.
+    agents: [],
+    workflows: src.workflows,
+    // Permission prompts ride the unified ask channel (kind: 'permission'),
+    // so this list is structurally empty — AskSheet renders them from
+    // pendingAsks instead.
+    pendingPermissions: [],
+    pendingAsks: src.asks.map((ask) => ({ ...ask })),
+    commands: (info?.commands ?? []).map((command) => ({ ...command })),
+    chatEvents: src.chat.events as ReadonlyArray<Record<string, unknown>>,
+    streamingText: src.chat.streamingText,
+    sending: src.chat.sending,
+    activeTurnId: src.chat.activeTurnId,
+    queue: src.queue.map((turn) => ({ ...turn })),
+    compacting: src.chat.compacting,
+    usage: buildUsageRecord(src.usage, src.contextWindow),
+    autoApprove: src.autoApprove,
+    activeMode: info?.activeMode ?? null,
+    activeProvider: info?.activeProvider ?? null,
+    modeBadge: info?.activeModeBadge ? { ...info.activeModeBadge } : null,
+    transcriptionId: src.local.transcriptionId,
+    transcriptionText: src.local.transcriptionText,
+    transcribing: src.local.transcribing,
+    errors: src.chat.error ? [...src.local.errors, src.chat.error] : src.local.errors,
+  };
+}
+
+/** Mirror of the old gateway's usage record: the accumulator plus the resolved
+ *  context window, or null when there is nothing to meter yet. */
+export function buildUsageRecord(
+  usage: UsageSourceState,
+  contextWindow: number | null,
+): Record<string, unknown> | null {
+  if (usage.calls === 0 && usage.latestPrompt == null && contextWindow == null) return null;
+  return { ...usage, contextWindow };
+}
+
+function workspaceName(info: SessionInfoLike | null): string {
+  const cwd = info?.cwd ?? '';
+  const base = cwd.split('/').filter(Boolean).pop();
+  return base && base.length > 0 ? base : 'Moxxy';
+}
+
+function firstUserPrompt(events: ReadonlyArray<unknown>): string {
+  for (const event of events) {
+    const record = event as Record<string, unknown>;
+    if (record?.type === 'user_prompt' && typeof record.text === 'string' && record.text.length > 0) {
+      return record.text;
+    }
+  }
+  return '';
+}
+
+// ---------- Ask-response normalization --------------------------------------
+
+/** Reference UI decision modes → the contract's `PermissionMode` (the wire
+ *  schema is strict, so `allow_once` MUST become `allow`). */
+export function toPermissionMode(mode: string): PermissionMode {
+  if (mode === 'allow_once' || mode === 'allow') return 'allow';
+  if (mode === 'allow_session') return 'allow_session';
+  if (mode === 'allow_always') return 'allow_always';
+  return 'deny';
+}
+
+/** Normalize a loosely-shaped UI response (PermissionCard / ApprovalCard) into
+ *  the strict `AskResponse` the contract validates — only the known fields,
+ *  with the permission mode mapped. */
+export function toAskResponse(response: Record<string, unknown>): AskResponse {
+  const out: { mode?: PermissionMode; optionId?: string; text?: string } = {};
+  if (typeof response.mode === 'string') out.mode = toPermissionMode(response.mode);
+  if (typeof response.optionId === 'string') out.optionId = response.optionId;
+  if (typeof response.text === 'string' && response.text.length > 0) out.text = response.text;
+  return out;
+}

--- a/apps/mobile/src/qrScanGate.ts
+++ b/apps/mobile/src/qrScanGate.ts
@@ -1,0 +1,28 @@
+export interface QrScanGate {
+  readonly arm: () => void;
+  readonly tryAcquire: () => boolean;
+  readonly reset: () => void;
+}
+
+export function createQrScanGate(): QrScanGate {
+  let armed = false;
+  let acquired = false;
+
+  return {
+    arm() {
+      armed = true;
+      acquired = false;
+    },
+    tryAcquire() {
+      if (!armed) return false;
+      if (acquired) return false;
+      acquired = true;
+      armed = false;
+      return true;
+    },
+    reset() {
+      armed = false;
+      acquired = false;
+    },
+  };
+}

--- a/apps/mobile/src/socketLifecycle.ts
+++ b/apps/mobile/src/socketLifecycle.ts
@@ -1,0 +1,53 @@
+/**
+ * Connection-status UI helpers.
+ *
+ * REDUCED from the reference: its `shouldReconnectAfterClose` guarded a
+ * hand-rolled reconnect loop in `useGatewaySocket`. In moxxy the transport
+ * itself (`WsRpcClient` in `@moxxy/client-transport-ws`) owns reconnect with
+ * exponential backoff and reports a `WsClientStatus`
+ * (`connecting | open | reconnecting | disconnected | closed`, where
+ * `disconnected` is TERMINAL — the reconnect budget is exhausted and only a
+ * re-pair/rebuild recovers). What the UI still needs is purely presentational:
+ * map that status to a banner/label/tone and to "should we offer re-pairing".
+ */
+
+import type { WsClientStatus } from '@moxxy/client-transport-ws';
+
+export type ConnectionTone = 'ok' | 'pending' | 'error' | 'muted';
+
+export interface ConnectionUiState {
+  readonly label: string;
+  readonly tone: ConnectionTone;
+  /** Show the persistent connection banner over the chat. */
+  readonly showBanner: boolean;
+  /** Requests may be issued (the socket is live). */
+  readonly canSend: boolean;
+  /** Terminal failure — surface the "scan QR / re-pair" affordance. */
+  readonly shouldOfferRepair: boolean;
+}
+
+export function buildConnectionUi(status: WsClientStatus): ConnectionUiState {
+  switch (status) {
+    case 'open':
+      return { label: 'Connected', tone: 'ok', showBanner: false, canSend: true, shouldOfferRepair: false };
+    case 'connecting':
+      return { label: 'Connecting...', tone: 'pending', showBanner: true, canSend: false, shouldOfferRepair: false };
+    case 'reconnecting':
+      return { label: 'Reconnecting...', tone: 'pending', showBanner: true, canSend: false, shouldOfferRepair: false };
+    case 'disconnected':
+      return {
+        label: 'Connection lost - re-pair with the desktop QR to reconnect.',
+        tone: 'error',
+        showBanner: true,
+        canSend: false,
+        shouldOfferRepair: true,
+      };
+    case 'closed':
+      return { label: 'Disconnected', tone: 'muted', showBanner: false, canSend: false, shouldOfferRepair: false };
+  }
+}
+
+/** Terminal transport failure — the only state a manual re-pair fixes. */
+export function shouldOfferRepair(status: WsClientStatus): boolean {
+  return status === 'disconnected';
+}

--- a/apps/mobile/src/toolGroupUi.ts
+++ b/apps/mobile/src/toolGroupUi.ts
@@ -1,0 +1,32 @@
+import type { ToolTranscriptItem } from './chatTranscript';
+
+export interface ToolGroupUi {
+  readonly accent: string;
+  readonly tint: string;
+  readonly statusLabel: 'failed' | 'running' | 'ok';
+  readonly summary: string;
+  readonly pulse: boolean;
+}
+
+export function buildToolGroupUi(tools: ReadonlyArray<ToolTranscriptItem>): ToolGroupUi {
+  const counts = tools.reduce(
+    (acc, tool) => {
+      acc[tool.status] += 1;
+      return acc;
+    },
+    { ok: 0, error: 0, running: 0 },
+  );
+  const hasError = counts.error > 0;
+  const hasRunning = counts.running > 0;
+  return {
+    accent: hasError ? '#ef4444' : hasRunning ? '#ec4899' : '#16a34a',
+    tint: hasError ? '#fee2e2' : hasRunning ? '#fdf2f8' : '#ecfdf5',
+    statusLabel: hasError ? 'failed' : hasRunning ? 'running' : 'ok',
+    summary: [
+      counts.ok > 0 ? `${counts.ok} ok` : '',
+      counts.error > 0 ? `${counts.error} failed` : '',
+      counts.running > 0 ? `${counts.running} running` : '',
+    ].filter(Boolean).join(' · '),
+    pulse: hasRunning && !hasError,
+  };
+}

--- a/apps/mobile/src/utils/record.ts
+++ b/apps/mobile/src/utils/record.ts
@@ -1,0 +1,11 @@
+export function textOf(value: unknown, fallback = ''): string {
+  return typeof value === 'string' && value.length > 0 ? value : fallback;
+}
+
+export function boolOf(value: unknown, fallback = false): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+export function recordId(value: Record<string, unknown>, fallback: string): string {
+  return textOf(value.id, textOf(value.requestId, fallback));
+}

--- a/apps/mobile/tailwind.config.ts
+++ b/apps/mobile/tailwind.config.ts
@@ -1,0 +1,55 @@
+import type { Config } from 'tailwindcss';
+import nativeWindPreset from 'nativewind/preset';
+// By dist path, not the `@moxxy/design-tokens` specifier: Tailwind loads this
+// config through jiti, whose `require`-semantics resolution rejects the
+// package's import-only exports map.
+import { tokens } from '../../packages/design-tokens/dist/index.js';
+
+/**
+ * theme.extend is derived from @moxxy/design-tokens — the same source the
+ * desktop renderer projects to CSS variables. Mapping:
+ *   colors.*       ← tokens.color (muted/dim alias textMuted/textDim)
+ *   borderRadius.* ← tokens.radius (bare numbers; Tailwind wants `px`)
+ *   boxShadow.card ← tokens.shadow.card
+ *   fontFamily.*   ← tokens.font (already full CSS font stacks)
+ * Nothing is inlined here — if a value looks wrong, fix the tokens package.
+ */
+export default {
+  content: ['./app/**/*.{ts,tsx}', './src/**/*.{ts,tsx}'],
+  darkMode: 'class',
+  presets: [nativeWindPreset],
+  theme: {
+    extend: {
+      colors: {
+        appBg: tokens.color.appBg,
+        cardBg: tokens.color.cardBg,
+        cardBorder: tokens.color.cardBorder,
+        cardBorderStrong: tokens.color.cardBorderStrong,
+        text: tokens.color.text,
+        muted: tokens.color.textMuted,
+        dim: tokens.color.textDim,
+        primary: tokens.color.primary,
+        primaryStrong: tokens.color.primaryStrong,
+        primarySoft: tokens.color.primarySoft,
+        accent: tokens.color.accent,
+        accentStrong: tokens.color.accentStrong,
+        purple: tokens.color.purple,
+        green: tokens.color.green,
+        amber: tokens.color.amber,
+        red: tokens.color.red,
+      },
+      borderRadius: {
+        block: `${tokens.radius.block}px`,
+        card: `${tokens.radius.card}px`,
+        pill: `${tokens.radius.pill}px`,
+      },
+      boxShadow: {
+        card: tokens.shadow.card,
+      },
+      fontFamily: {
+        sans: [tokens.font.sans],
+        mono: [tokens.font.mono],
+      },
+    },
+  },
+} satisfies Config;

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -4,7 +4,21 @@
     "strict": true,
     "jsx": "react-jsx",
     "moduleResolution": "Bundler",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    }
   },
-  "include": ["index.js", "src/**/*", "*.config.js"]
+  "include": [
+    "index.js",
+    "app/**/*",
+    "src/**/*",
+    "*.config.js",
+    "tailwind.config.ts",
+    "nativewind-env.d.ts",
+    "nativewind-preset.d.ts",
+    "./nativewind-env.d.ts"
+  ]
 }

--- a/apps/mobile/vitest.config.mts
+++ b/apps/mobile/vitest.config.mts
@@ -1,0 +1,3 @@
+import preset from '@moxxy/vitest-preset';
+
+export default preset;

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -27,9 +27,10 @@ import type {
   ApprovalOption,
   PermissionMode,
   ModeBadge,
+  UserPromptAttachment,
 } from '@moxxy/sdk';
 
-export type { ApprovalRequest, ApprovalOption, PermissionMode, ModeBadge };
+export type { ApprovalRequest, ApprovalOption, PermissionMode, ModeBadge, UserPromptAttachment };
 
 /**
  * Window/event-bus key a thin client listens for to re-fetch `session.info`
@@ -85,6 +86,10 @@ export type { SessionInfo };
  *   - `invalid-payload` — runtime validation rejected the renderer's input.
  *   - `not-connected`   — no runner/session bound for the target workspace.
  *   - `no-workspace`    — no active workspace and none specified.
+ *   - `not-supported`   — the host lacks the OPTIONAL capability behind the
+ *                         command (no transcriber, workflows plugin not
+ *                         loaded). Clients treat this as "hide/disable the
+ *                         affordance", never as a failure to retry.
  *   - `runner-error`    — the runner/handler threw while doing the work.
  *   - `unknown`         — anything not otherwise classified.
  */
@@ -92,6 +97,7 @@ export type MoxxyIpcErrorCode =
   | 'invalid-payload'
   | 'not-connected'
   | 'no-workspace'
+  | 'not-supported'
   | 'runner-error'
   | 'unknown';
 
@@ -270,6 +276,15 @@ export interface RunTurnArgs {
   prompt: string;
   model?: string;
   attachments?: ReadonlyArray<PromptAttachment>;
+  /**
+   * Inline attachments for REMOTE clients (the mobile app) that cannot
+   * reference host filesystem paths: the payload itself crosses the wire
+   * (base64 bytes for image/document/audio, inline text for file/stdin) in
+   * the SDK's `UserPromptAttachment` shape, and the host forwards it to
+   * `session.runTurn`'s `attachments` option untouched. Path-based
+   * `attachments` stay the desktop's local-renderer path.
+   */
+  inlineAttachments?: ReadonlyArray<UserPromptAttachment>;
 }
 
 export interface RunTurnResult {

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -50,6 +50,23 @@ const optionalWorkspace = z.string().min(1).max(256).optional();
 /** ~30 MB of base64 — generous for a voice clip, bounded so a renderer
  *  can't OOM the main process with one transcribe call. */
 const MAX_AUDIO_BASE64 = 40_000_000;
+/** ~9 MB of payload per inline attachment (the mobile app caps picks at 8 MB
+ *  raw; base64 inflates ×4/3). Bounded so a hostile client can't OOM the host. */
+const MAX_INLINE_ATTACHMENT_CONTENT = 12_000_000;
+
+/** Slash-command name — a registry slug, never a path or shell text. */
+const commandName = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/, 'invalid command name');
+
+/** Workflow names come from workflow filenames — bounded, no traversal. */
+const workflowName = z
+  .string()
+  .min(1)
+  .max(200)
+  .refine((s) => !s.includes('..') && !s.includes('/') && !s.includes('\\'), 'invalid workflow name');
 
 export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
   // No-arg, but spawns a child process (npm install) — pin the payload to
@@ -101,7 +118,30 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
       )
       .max(64)
       .optional(),
+    // Inline attachments cross the wire as payload (remote/mobile clients) —
+    // bound both the entry count and per-entry content size.
+    inlineAttachments: z
+      .array(
+        z.object({
+          kind: z.enum(['stdin', 'file', 'image', 'document', 'audio']),
+          content: z.string().max(MAX_INLINE_ATTACHMENT_CONTENT),
+          name: z.string().max(1024).optional(),
+          mediaType: z.string().max(128).optional(),
+        }),
+      )
+      .max(8)
+      .optional(),
   }),
+  // Runs an arbitrary registered slash command — the audit flagged this as the
+  // one mutating session command without a schema, so lock the name to a
+  // registry slug and bound the free-text args.
+  'session.runCommand': z.object({
+    workspaceId: optionalWorkspace,
+    name: commandName,
+    args: z.string().max(10_000),
+  }),
+  'workflows.run': z.object({ name: workflowName }),
+  'workflows.setEnabled': z.object({ name: workflowName, enabled: z.boolean() }),
   // Security-sensitive: this bypasses the approval sheet, so validate it at
   // the boundary like the other dangerous commands.
   'session.setAutoApprove': z.object({ workspaceId: optionalWorkspace, enabled: z.boolean() }),

--- a/packages/plugin-channel-mobile/src/single-session-host.test.ts
+++ b/packages/plugin-channel-mobile/src/single-session-host.test.ts
@@ -24,10 +24,11 @@ class FakeBus implements CommandBus, EventSink {
   }
 }
 
-function fakeSession() {
+function fakeSession(overrides: Record<string, unknown> = {}) {
   const logSubs = new Set<(e: unknown) => void>();
   let permissionResolver: any = null;
   let approvalResolver: any = null;
+  let activeMode = 'default';
   const session = {
     id: 'sess-1',
     cwd: '/tmp',
@@ -37,6 +38,7 @@ function fakeSession() {
         logSubs.add(fn);
         return () => logSubs.delete(fn);
       },
+      clear: vi.fn(),
     },
     runTurn: vi.fn((_prompt: string, _opts?: unknown) =>
       (async function* () {
@@ -44,21 +46,39 @@ function fakeSession() {
       })(),
     ),
     getInfo: () => ({
+      sessionId: 'sess-1',
       providers: [],
       modes: [],
       activeProvider: 'openai',
-      activeMode: 'default',
+      activeMode,
       activeModeBadge: null,
     }),
+    modes: {
+      setActive: vi.fn((name: string) => {
+        activeMode = name;
+      }),
+    },
+    commands: {
+      get: (name: string) =>
+        name === 'echo'
+          ? {
+              name: 'echo',
+              description: 'echo back',
+              handler: async (ctx: { args: string }) => ({ kind: 'text', text: `echo:${ctx.args}` }),
+            }
+          : undefined,
+    },
     setPermissionResolver: (r: unknown) => {
       permissionResolver = r;
     },
     setApprovalResolver: (r: unknown) => {
       approvalResolver = r;
     },
+    ...overrides,
   };
   return {
     session: session as unknown as ClientSession,
+    raw: session,
     emit: (e: unknown) => logSubs.forEach((fn) => fn(e)),
     getPermissionResolver: () => permissionResolver,
     getApprovalResolver: () => approvalResolver,
@@ -104,6 +124,107 @@ describe('MobileSessionHost', () => {
     expect(evts.some((e) => e.payload.workspaceId === 'sess-1' && (e.payload.event as any).text === 'yo')).toBe(
       true,
     );
+  });
+
+  it('forwards inline attachments to session.runTurn (path attachments are ignored)', async () => {
+    const bus = new FakeBus();
+    const { session, raw } = fakeSession();
+    const host = new MobileSessionHost(bus, session);
+    host.register();
+    const inline = [{ kind: 'image', content: 'AAAA', name: 'shot.png', mediaType: 'image/png' }];
+    await bus.invoke('session.runTurn', { prompt: 'look', inlineAttachments: inline });
+    const opts = (raw.runTurn as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as {
+      attachments?: unknown;
+    };
+    expect(opts.attachments).toEqual(inline);
+  });
+
+  it('switches mode via session.setMode and re-broadcasts the connected phase', async () => {
+    const bus = new FakeBus();
+    const { session, raw } = fakeSession();
+    const host = new MobileSessionHost(bus, session);
+    host.register();
+    await bus.invoke('session.setMode', { mode: 'goal' });
+    expect((raw.modes as { setActive: ReturnType<typeof vi.fn> }).setActive).toHaveBeenCalledWith('goal');
+    const changed = bus.event('connection.changed');
+    expect(changed.some((e) => e.payload.phase.activeMode === 'goal')).toBe(true);
+  });
+
+  it('session.newSession prefers reset() and falls back to log.clear()', async () => {
+    const bus = new FakeBus();
+    const reset = vi.fn(async () => {});
+    const withReset = fakeSession({ reset });
+    new MobileSessionHost(bus, withReset.session).register();
+    await bus.invoke('session.newSession', {});
+    expect(reset).toHaveBeenCalled();
+
+    const bus2 = new FakeBus();
+    const withoutReset = fakeSession();
+    new MobileSessionHost(bus2, withoutReset.session).register();
+    await bus2.invoke('session.newSession', {});
+    expect((withoutReset.raw.log as { clear: ReturnType<typeof vi.fn> }).clear).toHaveBeenCalled();
+  });
+
+  it('runs a registered slash command and reports unknown ones as a typed error', async () => {
+    const bus = new FakeBus();
+    const { session } = fakeSession();
+    new MobileSessionHost(bus, session).register();
+    expect(await bus.invoke('session.runCommand', { name: 'echo', args: 'hi' })).toEqual({
+      kind: 'text',
+      text: 'echo:hi',
+    });
+    expect(await bus.invoke('session.runCommand', { name: 'nope', args: '' })).toEqual({
+      kind: 'error',
+      message: 'unknown command: /nope',
+    });
+  });
+
+  it('voice: hasTranscriber gates on the registry; transcribe is coded not-supported without one', async () => {
+    const bus = new FakeBus();
+    const { session } = fakeSession(); // no transcribers view at all
+    new MobileSessionHost(bus, session).register();
+    expect(await bus.invoke('session.hasTranscriber')).toBe(false);
+    await expect(bus.invoke('session.transcribe', { audioBase64: 'AAAA' })).rejects.toMatchObject({
+      code: 'not-supported',
+    });
+
+    const bus2 = new FakeBus();
+    const transcribe = vi.fn(async () => ({ text: 'hello moxxy' }));
+    const withStt = fakeSession({
+      transcribers: { tryGetActive: () => ({ name: 'whisper', transcribe }) },
+    });
+    new MobileSessionHost(bus2, withStt.session).register();
+    expect(await bus2.invoke('session.hasTranscriber')).toBe(true);
+    expect(await bus2.invoke('session.transcribe', { audioBase64: 'AAAA', mimeType: 'audio/m4a' })).toBe(
+      'hello moxxy',
+    );
+    expect(transcribe).toHaveBeenCalledWith(expect.any(Buffer), { mimeType: 'audio/m4a' });
+  });
+
+  it('workflows degrade when the plugin is absent and delegate when present', async () => {
+    const bus = new FakeBus();
+    const { session } = fakeSession(); // no workflows view
+    new MobileSessionHost(bus, session).register();
+    expect(await bus.invoke('workflows.list')).toEqual([]);
+    await expect(bus.invoke('workflows.setEnabled', { name: 'daily', enabled: true })).resolves.toBeUndefined();
+    await expect(bus.invoke('workflows.run', { name: 'daily' })).rejects.toMatchObject({
+      code: 'not-supported',
+    });
+
+    const bus2 = new FakeBus();
+    const view = {
+      list: vi.fn(async () => [
+        { name: 'daily', description: '', enabled: true, scope: 'user', steps: 1, triggers: 'on-demand' },
+      ]),
+      setEnabled: vi.fn(async () => {}),
+      run: vi.fn(async () => ({ ok: true, output: 'done', steps: [] })),
+    };
+    const withWorkflows = fakeSession({ workflows: view });
+    new MobileSessionHost(bus2, withWorkflows.session).register();
+    expect(await bus2.invoke('workflows.list')).toHaveLength(1);
+    await bus2.invoke('workflows.setEnabled', { name: 'daily', enabled: false });
+    expect(view.setEnabled).toHaveBeenCalledWith('daily', false);
+    expect(await bus2.invoke('workflows.run', { name: 'daily' })).toMatchObject({ ok: true });
   });
 
   it('routes a permission prompt through ask.request → ask.respond', async () => {

--- a/packages/plugin-channel-mobile/src/single-session-host.ts
+++ b/packages/plugin-channel-mobile/src/single-session-host.ts
@@ -26,6 +26,7 @@ import type {
   RunTurnResult,
 } from '@moxxy/desktop-ipc-contract';
 import type { CommandBus, EventSink } from '@moxxy/desktop-ipc-contract/bus';
+import { IpcError } from '@moxxy/desktop-ipc-contract/dispatch';
 
 export interface MobileHostOptions {
   /** Workspace id exposed to the client. Defaults to the session id. */
@@ -106,7 +107,59 @@ export class MobileSessionHost {
     this.bus.handle('session.setAutoApprove', async ({ enabled }) => {
       this.autoApprove = enabled;
     });
-    this.bus.handle('session.hasTranscriber', async () => false);
+    this.bus.handle('session.setMode', async ({ mode }) => {
+      this.session.modes.setActive(mode);
+      // Re-broadcast the phase so connected clients see the new activeMode
+      // without a session.info round-trip (mirrors the desktop supervisor's
+      // refreshConnectedInfo()).
+      this.bus.broadcast('connection.changed', { workspaceId: ws, phase: this.snapshot().phase });
+    });
+    this.bus.handle('session.newSession', async () => {
+      // `/new`: abort in-flight turns, then reset at the source. `reset()` is
+      // the authoritative seam (clears persistence too); a session without it
+      // degrades to clearing the live log — never silently no-op.
+      for (const controller of this.turns.values()) controller.abort();
+      if (this.session.reset) await this.session.reset();
+      else this.session.log.clear();
+    });
+    this.bus.handle('session.runCommand', async ({ name, args }) => {
+      const def = this.session.commands.get(name);
+      if (!def) return { kind: 'error', message: `unknown command: /${name}` } as const;
+      return await def.handler({
+        channel: 'mobile',
+        sessionId: this.session.getInfo().sessionId,
+        args,
+        session: this.session as unknown as Parameters<typeof def.handler>[0]['session'],
+      });
+    });
+    // Voice: served by the runner's active transcriber when one is registered.
+    // hasTranscriber is the capability probe (the app gates the mic on it);
+    // transcribe without one fails with the coded `not-supported` error so a
+    // client that skipped the probe still degrades instead of retrying.
+    this.bus.handle('session.hasTranscriber', async () => this.activeTranscriber() != null);
+    this.bus.handle('session.transcribe', async ({ audioBase64, mimeType }) => {
+      const transcriber = this.activeTranscriber();
+      if (!transcriber) {
+        throw new IpcError('not-supported', 'no transcriber is active on this session');
+      }
+      const audio = Buffer.from(audioBase64, 'base64');
+      const result = await transcriber.transcribe(audio, mimeType ? { mimeType } : undefined);
+      return result.text;
+    });
+    // Workflows: delegate to the session's optional WorkflowsView (present when
+    // @moxxy/plugin-workflows is wired — `moxxy mobile` runs the full CLI setup,
+    // so it normally is). Absent ⇒ list degrades to empty / setEnabled no-ops
+    // (desktop parity) and run fails coded so the UI can hide the surface.
+    this.bus.handle('workflows.list', async () => this.session.workflows?.list() ?? []);
+    this.bus.handle('workflows.setEnabled', async ({ name, enabled }) => {
+      if (this.session.workflows) await this.session.workflows.setEnabled(name, enabled);
+    });
+    this.bus.handle('workflows.run', async ({ name }) => {
+      if (!this.session.workflows) {
+        throw new IpcError('not-supported', 'workflows plugin not loaded on this session');
+      }
+      return await this.session.workflows.run(name);
+    });
     this.bus.handle('ask.respond', async ({ requestId, response }) => {
       this.answerAsk(requestId, response);
     });
@@ -154,6 +207,16 @@ export class MobileSessionHost {
 
   // ---- internals ----------------------------------------------------------
 
+  /** Active transcriber, or null. Guarded access — a thin/remote session may
+   *  leave the registry view undefined (capability-absent ≠ crash). */
+  private activeTranscriber() {
+    try {
+      return this.session.transcribers?.tryGetActive() ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   private snapshot(): ConnectionSnapshot {
     const info = this.session.getInfo();
     const phase: ConnectionPhase = {
@@ -175,9 +238,15 @@ export class MobileSessionHost {
     void (async () => {
       let error: string | null = null;
       try {
+        // Inline attachments (mobile) map straight onto the SDK's
+        // UserPromptAttachment shape; path-based desktop attachments have no
+        // meaning here (no shared filesystem) and are ignored.
         for await (const _event of this.session.runTurn(args.prompt, {
           signal: controller.signal,
           ...(args.model ? { model: args.model } : {}),
+          ...(args.inlineAttachments && args.inlineAttachments.length > 0
+            ? { attachments: args.inlineAttachments }
+            : {}),
         })) {
           void _event;
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,9 @@ importers:
 
   apps/mobile:
     dependencies:
+      '@expo/metro-runtime':
+        specifier: ~6.1.2
+        version: 6.1.2(expo@54.0.35)(react-dom@18.3.1(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@moxxy/client-core':
         specifier: workspace:*
         version: link:../../packages/client-core
@@ -269,34 +272,94 @@ importers:
       '@moxxy/design-tokens':
         specifier: workspace:*
         version: link:../../packages/design-tokens
+      '@moxxy/desktop-ipc-contract':
+        specifier: workspace:*
+        version: link:../../packages/desktop-ipc-contract
       '@moxxy/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
       expo:
         specifier: ~54.0.0
-        version: 54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+        version: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-audio:
+        specifier: ~1.1.1
+        version: 1.1.1(expo-asset@12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-camera:
-        specifier: ~17.0.0
-        version: 17.0.10(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        specifier: ~17.0.10
+        version: 17.0.10(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-clipboard:
+        specifier: ~8.0.8
+        version: 8.0.8(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-constants:
+        specifier: ~18.0.13
+        version: 18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))
+      expo-document-picker:
+        specifier: ~14.0.8
+        version: 14.0.8(expo@54.0.35)
+      expo-file-system:
+        specifier: ~19.0.23
+        version: 19.0.23(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))
+      expo-image-picker:
+        specifier: ~17.0.11
+        version: 17.0.11(expo@54.0.35)
+      expo-linking:
+        specifier: ~8.0.12
+        version: 8.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-router:
+        specifier: ~6.0.24
+        version: 6.0.24(227a4de6044da93a49c8b550e41f6cd3)
+      expo-secure-store:
+        specifier: ~15.0.8
+        version: 15.0.8(expo@54.0.35)
       expo-status-bar:
-        specifier: ~3.0.0
-        version: 3.0.9(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        specifier: ~3.0.9
+        version: 3.0.9(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      nativewind:
+        specifier: ^4.2.5
+        version: 4.2.5(beef0d520c79bfe26b55be4fd582eecc)
       react:
         specifier: 19.1.0
         version: 19.1.0
       react-native:
         specifier: 0.81.5
-        version: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)
+        version: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+      react-native-css-interop:
+        specifier: ^0.2.5
+        version: 0.2.5(beef0d520c79bfe26b55be4fd582eecc)
+      react-native-gesture-handler:
+        specifier: ~2.28.0
+        version: 2.28.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-reanimated:
+        specifier: ~4.1.1
+        version: 4.1.7(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-safe-area-context:
+        specifier: ~5.6.2
+        version: 5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-screens:
+        specifier: ~4.16.0
+        version: 4.16.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-svg:
+        specifier: 15.12.1
+        version: 15.12.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      tailwindcss:
+        specifier: ^3.4.19
+        version: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.0
         version: 7.29.7
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
       '@types/react':
         specifier: ~19.1.0
         version: 19.1.17
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@24.12.3)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
 
   packages/cache-strategy-stable-prefix:
     dependencies:
@@ -2078,6 +2141,10 @@ packages:
     resolution: {integrity: sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==}
     engines: {node: '>=14.13.1'}
 
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
@@ -2226,16 +2293,8 @@ packages:
     resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -2610,6 +2669,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-template-literals@7.29.7':
+    resolution: {integrity: sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-typescript@7.29.7':
     resolution: {integrity: sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==}
     engines: {node: '>=6.9.0'}
@@ -2724,6 +2789,10 @@ packages:
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
     engines: {node: '>= 8.9.0'}
+
+  '@egjs/hammerjs@2.0.17':
+    resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
+    engines: {node: '>=0.8.0'}
 
   '@electron/asar@3.4.1':
     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
@@ -3325,6 +3394,17 @@ packages:
       expo: '*'
     peerDependenciesMeta:
       expo:
+        optional: true
+
+  '@expo/metro-runtime@6.1.2':
+    resolution: {integrity: sha512-nvM+Qv45QH7pmYvP8JB1G8JpScrWND3KrMA6ZKe62cwwNiX/BjHU28Ear0v/4bQWXlOY0mv6B8CDIm8JxXde9g==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
         optional: true
 
   '@expo/metro@54.2.0':
@@ -3972,6 +4052,243 @@ packages:
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
+  '@radix-ui/primitive@1.1.4':
+    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
+
+  '@radix-ui/react-collection@1.1.9':
+    resolution: {integrity: sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.4':
+    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.16':
+    resolution: {integrity: sha512-l9ok83YBclEZhbjgzt76Hw733e6cvRKPNgO6GJ/IETlufXG9p+fRu2wlvpImQvR6xdJ8h7J8J2DBvsPEiEsKMw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.2':
+    resolution: {integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.12':
+    resolution: {integrity: sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.4':
+    resolution: {integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.9':
+    resolution: {integrity: sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.2':
+    resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.11':
+    resolution: {integrity: sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.6':
+    resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.5':
+    resolution: {integrity: sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.12':
+    resolution: {integrity: sha512-FvgPt1bRmg8Xt2QpF7NUZW3dE0ZQHGm41dAdgT2J2GJPoIXz+9Em3NobAxf4fupcxhgHu03E5CRiU2MWvObXyg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.0':
+    resolution: {integrity: sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.5':
+    resolution: {integrity: sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.14':
+    resolution: {integrity: sha512-D5jwp9JNuwDeCw3CYD2Fz+sSHo0droQjC8u75dJHe4aWr5q6yBiXZU+hurXnKudRgEpUkD5TsI6bjHPo5ThUxA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.2':
+    resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.2':
+    resolution: {integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@react-native-community/cli-clean@13.6.9':
     resolution: {integrity: sha512-7Dj5+4p9JggxuVNOjPbduZBAP1SUgNhLKVw5noBUzT/3ZpUZkDM+RCSwyoyg8xKWoE4OrdUAXwAFlMcFDPKykA==}
 
@@ -4018,15 +4335,31 @@ packages:
     resolution: {integrity: sha512-oF71cIH6je3fSLi6VPjjC3Sgyyn57JLHXs+mHWc9MoCiJJcM4nqsS5J38zv1XQ8d3zOW2JtHro+LF0tagj2bfQ==}
     engines: {node: '>= 20.19.4'}
 
+  '@react-native/babel-plugin-codegen@0.86.0':
+    resolution: {integrity: sha512-qdsABWNW7uTll90l4Vh03gjeyu3WVDi2CyiiyvYGMRDcoYbjbQi6df3BMAm9lQI2yslZ1T14LlDDAsgTwNxplA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
   '@react-native/babel-preset@0.81.5':
     resolution: {integrity: sha512-UoI/x/5tCmi+pZ3c1+Ypr1DaRMDLI3y+Q70pVLLVgrnC3DHsHRIbHcCHIeG/IJvoeFqFM2sTdhSOLJrf8lOPrA==}
     engines: {node: '>= 20.19.4'}
     peerDependencies:
       '@babel/core': '*'
 
+  '@react-native/babel-preset@0.86.0':
+    resolution: {integrity: sha512-bYQcWiPySNvF4dns9Ls9gMmwgq66ohvM9Fwc/Kn8r85t66UNHxch3p1QwPiSorDelFauZwJbgo9+ReibTgvpbA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+    peerDependencies:
+      '@babel/core': '*'
+
   '@react-native/codegen@0.81.5':
     resolution: {integrity: sha512-a2TDA03Up8lpSa9sh5VRGCQDXgCTOyDOFH+aqyinxp1HChG8uk89/G+nkJ9FPd0rqgi25eCTR16TWdS3b+fA6g==}
     engines: {node: '>= 20.19.4'}
+    peerDependencies:
+      '@babel/core': '*'
+
+  '@react-native/codegen@0.86.0':
+    resolution: {integrity: sha512-uTs9DBo3+/lUqinsGZK0FKJRBVClrwMXoZToaDxE1Q2SL2e55vs2GwyZfIKzPl5uJnbu4PfFMIp0/mLXLWUMuA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
     peerDependencies:
       '@babel/core': '*'
 
@@ -4058,6 +4391,20 @@ packages:
     resolution: {integrity: sha512-fB7M1CMOCIUudTRuj7kzxIBTVw2KXnsgbQ6+4cbqSxo8NmRRhA0Ul4ZUzZj3rFd3VznTL4Brmocv1oiN0bWZ8w==}
     engines: {node: '>= 20.19.4'}
 
+  '@react-native/js-polyfills@0.86.0':
+    resolution: {integrity: sha512-zYy/Cjd1VTnZ2iCNaG9bDF9C3l2ntESiPRscjIlI5FKugu6aeTwsDSv1aI8Bc4Kp3vEdoVg+UQhLAhE4svREaQ==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  '@react-native/metro-babel-transformer@0.86.0':
+    resolution: {integrity: sha512-SjKej3E5qIahqo/G+rSOrmJUQM44RyKtWtO+VfmKAAMoJWkBFomM22hTLKCIS5cdbIAJ9COAmU+KAi2wVSO0wQ==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+    peerDependencies:
+      '@babel/core': '*'
+
+  '@react-native/metro-config@0.86.0':
+    resolution: {integrity: sha512-7v+xbTeEci9ZcQ/Z1OqI4RXcqN69wSMDYL5BAMvOReZ7U04+aDQ0/SQhClYPn6x2/RxM4WzMKSAuNyLKqvYVtw==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
   '@react-native/normalize-colors@0.81.5':
     resolution: {integrity: sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g==}
 
@@ -4071,6 +4418,50 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@react-navigation/bottom-tabs@7.17.2':
+    resolution: {integrity: sha512-Ojo0LTUTqQhrjIwlA2yGpof0mSjdIri1tdIaqKnsFX8yAEyvMxy64Dkgp57sO/+Jy6Xzc/1yzcORYLx59W3cYA==}
+    peerDependencies:
+      '@react-navigation/native': ^7.3.0
+      react: '>= 18.2.0'
+      react-native: '*'
+      react-native-safe-area-context: '>= 4.0.0'
+      react-native-screens: '>= 4.0.0'
+
+  '@react-navigation/core@7.19.0':
+    resolution: {integrity: sha512-OEXT9sSx+md4bqBVvg0sfFfVjRWHK+E7YHXobB/IQ/l8jqP3ThCwZk0DhxYmjwEGmUcCCkquXMxDG+hgMDeDSg==}
+    peerDependencies:
+      react: '>= 18.2.0'
+
+  '@react-navigation/elements@2.9.22':
+    resolution: {integrity: sha512-n2u2ls34mvUVWLUpNYOWvE9agP5rGt/Fp7x8lo/oZnh03Bydr2HnGeovIWrt4OOI/p1gHor3PhWT+xhf10Xl7w==}
+    peerDependencies:
+      '@react-native-masked-view/masked-view': '>= 0.2.0'
+      '@react-navigation/native': ^7.3.0
+      react: '>= 18.2.0'
+      react-native: '*'
+      react-native-safe-area-context: '>= 4.0.0'
+    peerDependenciesMeta:
+      '@react-native-masked-view/masked-view':
+        optional: true
+
+  '@react-navigation/native-stack@7.17.2':
+    resolution: {integrity: sha512-a87vGNbQRCBLvudQELr16iYE7LO1lr828nkjdlkmVnvp16LDUb6cUXyCcC11bjEq0Dsf+azD9FL6zNnzIn52aQ==}
+    peerDependencies:
+      '@react-navigation/native': ^7.3.0
+      react: '>= 18.2.0'
+      react-native: '*'
+      react-native-safe-area-context: '>= 4.0.0'
+      react-native-screens: '>= 4.0.0'
+
+  '@react-navigation/native@7.3.0':
+    resolution: {integrity: sha512-ExKP2Y0d6e72JLEWEQFXmJe9QObjVWHYeKBUxaQm8ep+RbQbcBrbNOLrtN9Eb6tbGVGTVdzvAdQZbAYPh4dQww==}
+    peerDependencies:
+      react: '>= 18.2.0'
+      react-native: '*'
+
+  '@react-navigation/routers@7.5.6':
+    resolution: {integrity: sha512-tV/vSXX1va9xCXcqmLqr8qn56ygkwiC9tYoEEWfkqvTCh8LR9FEG7ZVzHBkzrQ/2hJQz+j/3KoglGSHXYrOK4w==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -4388,6 +4779,9 @@ packages:
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+
+  '@types/hammerjs@2.0.46':
+    resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -4814,6 +5208,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -4823,6 +5221,9 @@ packages:
 
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
+
+  array-timsort@1.0.3:
+    resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
@@ -4920,6 +5321,9 @@ packages:
   babel-plugin-syntax-hermes-parser@0.29.1:
     resolution: {integrity: sha512-2WFYnoWGdmih1I1J5eIqxATOeycOqRwYxAQBu3cUu/rhwInwHUg7k60AFNbuGjSDL8tje5GDrAnxzRLcu2pYcA==}
 
+  babel-plugin-syntax-hermes-parser@0.36.0:
+    resolution: {integrity: sha512-LhD0xdoedDw7ansQgXbB2DADLZIK/LRXuWNBPuVzMc5S2WK5GyT89tCM+cQzxFGO0mGyLK6D5TrVOJJzAoDy8Q==}
+
   babel-plugin-transform-flow-enums@0.0.2:
     resolution: {integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==}
 
@@ -4980,6 +5384,10 @@ packages:
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -5111,6 +5519,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase-css@2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
@@ -5160,6 +5572,10 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -5230,6 +5646,9 @@ packages:
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
@@ -5323,6 +5742,10 @@ packages:
   commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
+
+  comment-json@4.6.2:
+    resolution: {integrity: sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w==}
+    engines: {node: '>= 6'}
 
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
@@ -5439,6 +5862,10 @@ packages:
   css-selector-parser@3.3.0:
     resolution: {integrity: sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==}
 
+  css-tree@1.1.3:
+    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
+    engines: {node: '>=8.0.0'}
+
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
@@ -5515,6 +5942,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  decode-uri-component@0.2.2:
+    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
+    engines: {node: '>=0.10'}
+
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -5583,9 +6014,17 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  detect-libc@1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
@@ -5599,6 +6038,9 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -5968,6 +6410,14 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-audio@1.1.1:
+    resolution: {integrity: sha512-CPCpJ+0AEHdzWROc0f00Zh6e+irLSl2ALos/LPvxEeIcJw1APfBa4DuHPkL4CQCWsVe7EnUjFpdwpqsEUWcP0g==}
+    peerDependencies:
+      expo: '*'
+      expo-asset: '*'
+      react: '*'
+      react-native: '*'
+
   expo-camera@17.0.10:
     resolution: {integrity: sha512-w1RBw83mAGVk4BPPwNrCZyFop0VLiVSRE3c2V9onWbdFwonpRhzmB4drygG8YOUTl1H3wQvALJHyMPTbgsK1Jg==}
     peerDependencies:
@@ -5979,11 +6429,23 @@ packages:
       react-native-web:
         optional: true
 
+  expo-clipboard@8.0.8:
+    resolution: {integrity: sha512-VKoBkHIpZZDJTB0jRO4/PZskHdMNOEz3P/41tmM6fDuODMpqhvyWK053X0ebspkxiawJX9lX33JXHBCvVsTTOA==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
+
   expo-constants@18.0.13:
     resolution: {integrity: sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==}
     peerDependencies:
       expo: '*'
       react-native: '*'
+
+  expo-document-picker@14.0.8:
+    resolution: {integrity: sha512-3tyQKpPqWWFlI8p9RiMX1+T1Zge5mEKeBuXWp1h8PEItFMUDSiOJbQ112sfdC6Hxt8wSxreV9bCRl/NgBdt+fA==}
+    peerDependencies:
+      expo: '*'
 
   expo-file-system@19.0.23:
     resolution: {integrity: sha512-MeGkid9OeNILfT/qonaXHp4f2c15xaB28U/bcN7pqZej0Kx0+6+V7e9ZIXpPHm07zVatxA+QkMTPQEGfmvVOxA==}
@@ -5998,11 +6460,27 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-image-loader@6.0.0:
+    resolution: {integrity: sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==}
+    peerDependencies:
+      expo: '*'
+
+  expo-image-picker@17.0.11:
+    resolution: {integrity: sha512-/apkoyukDvsCHHb9fzP+F34A1uQqSzUtYH/2P/xJACNEwq+mwEXjXvVU8bzlJq6ih0Qo1+tpVivIa7B9kYSwOQ==}
+    peerDependencies:
+      expo: '*'
+
   expo-keep-awake@15.0.8:
     resolution: {integrity: sha512-YK9M1VrnoH1vLJiQzChZgzDvVimVoriibiDIFLbQMpjYBnvyfUeHJcin/Gx1a+XgupNXy92EQJLgI/9ZuXajYQ==}
     peerDependencies:
       expo: '*'
       react: '*'
+
+  expo-linking@8.0.12:
+    resolution: {integrity: sha512-FpXeIpFgZuxihwT9lBo86YD3y6LphBuAhN680MMxm/Y7fmsc57vimn2d3vFu68VI0+Z9w457t494mu2wvlgWTQ==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   expo-modules-autolinking@3.0.26:
     resolution: {integrity: sha512-WOaud6UKg16ciCOj8raKcMOoKFMHLXKI29U29yhgu1lf+Y7VxJyCktUcYo6AM+ccZ7zLD1uWZdMtgnpf+95OXA==}
@@ -6013,6 +6491,45 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  expo-router@6.0.24:
+    resolution: {integrity: sha512-KIssKXnwjrdCxPWC8GsMTfKTwng40VrCsO16O9x6fKlfUwBW8itxY9PpCGyQeMJkiEADa+DUhtrDgl+uHg4/DA==}
+    peerDependencies:
+      '@expo/metro-runtime': ^6.1.2
+      '@react-navigation/drawer': ^7.5.0
+      '@testing-library/react-native': '>= 12.0.0'
+      expo: '*'
+      expo-constants: ^18.0.13
+      expo-linking: ^8.0.12
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+      react-native-gesture-handler: '*'
+      react-native-reanimated: '*'
+      react-native-safe-area-context: '>= 5.4.0'
+      react-native-screens: '*'
+      react-native-web: '*'
+      react-server-dom-webpack: ~19.0.4 || ~19.1.5 || ~19.2.4
+    peerDependenciesMeta:
+      '@react-navigation/drawer':
+        optional: true
+      '@testing-library/react-native':
+        optional: true
+      react-dom:
+        optional: true
+      react-native-gesture-handler:
+        optional: true
+      react-native-reanimated:
+        optional: true
+      react-native-web:
+        optional: true
+      react-server-dom-webpack:
+        optional: true
+
+  expo-secure-store@15.0.8:
+    resolution: {integrity: sha512-lHnzvRajBu4u+P99+0GEMijQMFCOYpWRO4dWsXSuMt77+THPIGjzNvVKrGSl6mMrLsfVaKL8BpwYZLGlgA+zAw==}
+    peerDependencies:
+      expo: '*'
 
   expo-server@1.0.7:
     resolution: {integrity: sha512-mcmyML3oXcqFUXUxtdtCL1O00ztNI2v76d+MdniXRUgHNxIcHZ05zo+DqBaOOT6LQnPk4vA4YHqQl7iGUfRb3g==}
@@ -6130,6 +6647,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  filter-obj@1.1.0:
+    resolution: {integrity: sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==}
+    engines: {node: '>=0.10.0'}
 
   finalhandler@1.1.2:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
@@ -6267,6 +6788,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
@@ -6462,6 +6987,9 @@ packages:
   hermes-estree@0.35.0:
     resolution: {integrity: sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==}
 
+  hermes-estree@0.36.0:
+    resolution: {integrity: sha512-A1+8zn5oss2CFP7pKsOaxorQG6FNIz1WU1VDqruLPPZl3LVgeE2C5xfFg8Ow6/Ow4mSslLLtYP1J3n38eKyW9w==}
+
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
@@ -6474,9 +7002,15 @@ packages:
   hermes-parser@0.35.0:
     resolution: {integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==}
 
+  hermes-parser@0.36.0:
+    resolution: {integrity: sha512-GdpwMmH5x6IpC1cijvcvYnlPB60Mh6kTSF/NFdYV/j56gYdi+0RIakYs+eqOV+bbO0SW7mgVVGSsTJxyPQfo3w==}
+
   hermes-profile-transformer@0.0.6:
     resolution: {integrity: sha512-cnN7bQUm65UWOy6cbGcCcZ3rpwW8Q/j4OP5aWRhEry4Z2t2aR1cjrbp0BS+KiBN0smvP1caBgAuxutvyvJILzQ==}
     engines: {node: '>=8'}
+
+  hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
   hono@4.12.18:
     resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
@@ -6660,6 +7194,10 @@ packages:
 
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
 
   is-ci@3.0.1:
     resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
@@ -6853,6 +7391,10 @@ packages:
   jimp-compact@0.16.1:
     resolution: {integrity: sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww==}
 
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    hasBin: true
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -6976,10 +7518,22 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-darwin-arm64@1.27.0:
+    resolution: {integrity: sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.27.0:
+    resolution: {integrity: sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.32.0:
@@ -6988,17 +7542,36 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-freebsd-x64@1.27.0:
+    resolution: {integrity: sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
   lightningcss-freebsd-x64@1.32.0:
     resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
+  lightningcss-linux-arm-gnueabihf@1.27.0:
+    resolution: {integrity: sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm-gnueabihf@1.32.0:
     resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.27.0:
+    resolution: {integrity: sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
@@ -7007,12 +7580,26 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  lightningcss-linux-arm64-musl@1.27.0:
+    resolution: {integrity: sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.27.0:
+    resolution: {integrity: sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
@@ -7021,6 +7608,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  lightningcss-linux-x64-musl@1.27.0:
+    resolution: {integrity: sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
@@ -7028,10 +7622,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-win32-arm64-msvc@1.27.0:
+    resolution: {integrity: sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.27.0:
+    resolution: {integrity: sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.32.0:
@@ -7039,6 +7645,10 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
+
+  lightningcss@1.27.0:
+    resolution: {integrity: sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==}
+    engines: {node: '>= 12.0.0'}
 
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
@@ -7240,6 +7850,9 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  mdn-data@2.0.14:
+    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
 
@@ -7276,6 +7889,10 @@ packages:
     resolution: {integrity: sha512-sBqBkt6kNut/88bv+Ucvm4yqdPetbvAEsHzi3MAgJEifOSYYzX5Z5Kgw3TFOrwf/mHJTOBG2ONlaMHoyfP15TA==}
     engines: {node: '>=20.19.4'}
 
+  metro-babel-transformer@0.84.4:
+    resolution: {integrity: sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
   metro-cache-key@0.83.3:
     resolution: {integrity: sha512-59ZO049jKzSmvBmG/B5bZ6/dztP0ilp0o988nc6dpaDsU05Cl1c/lRf+yx8m9WW/JVgbmfO5MziBU559XjI5Zw==}
     engines: {node: '>=20.19.4'}
@@ -7283,6 +7900,10 @@ packages:
   metro-cache-key@0.83.7:
     resolution: {integrity: sha512-W1c2Nmx8MiJTJt+eWhMO08z9VKi3kZOaz99IYGdqeqDgY9j+yZjXl62rUav4Di0heZfh4/n2s722PqRL1OODeg==}
     engines: {node: '>=20.19.4'}
+
+  metro-cache-key@0.84.4:
+    resolution: {integrity: sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
 
   metro-cache@0.83.3:
     resolution: {integrity: sha512-3jo65X515mQJvKqK3vWRblxDEcgY55Sk3w4xa6LlfEXgQ9g1WgMh9m4qVZVwgcHoLy0a2HENTPCCX4Pk6s8c8Q==}
@@ -7292,6 +7913,10 @@ packages:
     resolution: {integrity: sha512-E9SRePXQ1Zvlj79VcOk57q7VC7rMHMFQ+jhmPHBiq+dJ0bJB5BL87lWZF6oh5X76Cci5tpDuQNaDwwuSCToEeg==}
     engines: {node: '>=20.19.4'}
 
+  metro-cache@0.84.4:
+    resolution: {integrity: sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
   metro-config@0.83.3:
     resolution: {integrity: sha512-mTel7ipT0yNjKILIan04bkJkuCzUUkm2SeEaTads8VfEecCh+ltXchdq6DovXJqzQAXuR2P9cxZB47Lg4klriA==}
     engines: {node: '>=20.19.4'}
@@ -7299,6 +7924,10 @@ packages:
   metro-config@0.83.7:
     resolution: {integrity: sha512-83mjWFbFOt2GeJ6pFIum5mSnc1uTsZJAtD8o4ej0s4NVsYsA7fB+pHvTfHhFrpeMONaobu2riKavkPei05Er/Q==}
     engines: {node: '>=20.19.4'}
+
+  metro-config@0.84.4:
+    resolution: {integrity: sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
 
   metro-core@0.83.3:
     resolution: {integrity: sha512-M+X59lm7oBmJZamc96usuF1kusd5YimqG/q97g4Ac7slnJ3YiGglW5CsOlicTR5EWf8MQFxxjDoB6ytTqRe8Hw==}
@@ -7308,6 +7937,10 @@ packages:
     resolution: {integrity: sha512-6yn3w1wnltT6RQl7p7YES2l95ArC+mWrOssEiH8p5/DDrJS65/szf9LsC9JrBv8c5DdvSY3V3f0GRYg0Ox7hCg==}
     engines: {node: '>=20.19.4'}
 
+  metro-core@0.84.4:
+    resolution: {integrity: sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
   metro-file-map@0.83.3:
     resolution: {integrity: sha512-jg5AcyE0Q9Xbbu/4NAwwZkmQn7doJCKGW0SLeSJmzNB9Z24jBe0AL2PHNMy4eu0JiKtNWHz9IiONGZWq7hjVTA==}
     engines: {node: '>=20.19.4'}
@@ -7315,6 +7948,10 @@ packages:
   metro-file-map@0.83.7:
     resolution: {integrity: sha512-+j0F1m+FQYVAQ6syf+mwhIPV5GoFQrkInX8bppuc50IzNsZbMrp8R5H/Sx/K2daQ3YEa9F/XwkeZT8gzJfgeCw==}
     engines: {node: '>=20.19.4'}
+
+  metro-file-map@0.84.4:
+    resolution: {integrity: sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
 
   metro-minify-terser@0.83.3:
     resolution: {integrity: sha512-O2BmfWj6FSfzBLrNCXt/rr2VYZdX5i6444QJU0fFoc7Ljg+Q+iqebwE3K0eTvkI6TRjELsXk1cjU+fXwAR4OjQ==}
@@ -7324,6 +7961,10 @@ packages:
     resolution: {integrity: sha512-MfJar2IS4tBRuLb9svwb0Gu5l9BsH+pcRm8eGcEi/wy8MzZinfinh5dFLt2nWkocnulIgtGB5NkFDdbXqMXKhQ==}
     engines: {node: '>=20.19.4'}
 
+  metro-minify-terser@0.84.4:
+    resolution: {integrity: sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
   metro-resolver@0.83.3:
     resolution: {integrity: sha512-0js+zwI5flFxb1ktmR///bxHYg7OLpRpWZlBBruYG8OKYxeMP7SV0xQ/o/hUelrEMdK4LJzqVtHAhBm25LVfAQ==}
     engines: {node: '>=20.19.4'}
@@ -7331,6 +7972,10 @@ packages:
   metro-resolver@0.83.7:
     resolution: {integrity: sha512-WSJIENlMcoSsuz66IfBHOkgfp3KJt2UW2TnEHPf1b8pIG2eEXNOVmo2+03A0H17WY2XGXWgxL0CG7FAopqgB1A==}
     engines: {node: '>=20.19.4'}
+
+  metro-resolver@0.84.4:
+    resolution: {integrity: sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
 
   metro-runtime@0.83.3:
     resolution: {integrity: sha512-JHCJb9ebr9rfJ+LcssFYA2x1qPYuSD/bbePupIGhpMrsla7RCwC/VL3yJ9cSU+nUhU4c9Ixxy8tBta+JbDeZWw==}
@@ -7340,6 +7985,10 @@ packages:
     resolution: {integrity: sha512-9GKkJURaB2iyYoEExKnedzAHzxmKtSi+k0tsZUvMoU27tBZJElchYt7JH/Ai/XzYAI9lCAaV7u5HZSI8J5Z+wQ==}
     engines: {node: '>=20.19.4'}
 
+  metro-runtime@0.84.4:
+    resolution: {integrity: sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
   metro-source-map@0.83.3:
     resolution: {integrity: sha512-xkC3qwUBh2psVZgVavo8+r2C9Igkk3DibiOXSAht1aYRRcztEZNFtAMtfSB7sdO2iFMx2Mlyu++cBxz/fhdzQg==}
     engines: {node: '>=20.19.4'}
@@ -7347,6 +7996,10 @@ packages:
   metro-source-map@0.83.7:
     resolution: {integrity: sha512-JgA1h7oc1a1jydBe1GhVFsUoMYo3wLPk7oRA32rjlDsq+sP2JLt9x2p2lWbNSxTm/u8NV4VRid3hvEJgcX8tKw==}
     engines: {node: '>=20.19.4'}
+
+  metro-source-map@0.84.4:
+    resolution: {integrity: sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
 
   metro-symbolicate@0.83.3:
     resolution: {integrity: sha512-F/YChgKd6KbFK3eUR5HdUsfBqVsanf5lNTwFd4Ca7uuxnHgBC3kR/Hba/RGkenR3pZaGNp5Bu9ZqqP52Wyhomw==}
@@ -7358,6 +8011,11 @@ packages:
     engines: {node: '>=20.19.4'}
     hasBin: true
 
+  metro-symbolicate@0.84.4:
+    resolution: {integrity: sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+    hasBin: true
+
   metro-transform-plugins@0.83.3:
     resolution: {integrity: sha512-eRGoKJU6jmqOakBMH5kUB7VitEWiNrDzBHpYbkBXW7C5fUGeOd2CyqrosEzbMK5VMiZYyOcNFEphvxk3OXey2A==}
     engines: {node: '>=20.19.4'}
@@ -7365,6 +8023,10 @@ packages:
   metro-transform-plugins@0.83.7:
     resolution: {integrity: sha512-Ss0FpBiZDjX2kwhukMDl5sNdYK8T/06IPqxNE4H6PTlRlfs9q11cef13c/xESY/Pm4VCkp1yJUZO3kXzvMxQFA==}
     engines: {node: '>=20.19.4'}
+
+  metro-transform-plugins@0.84.4:
+    resolution: {integrity: sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
 
   metro-transform-worker@0.83.3:
     resolution: {integrity: sha512-Ztekew9t/gOIMZX1tvJOgX7KlSLL5kWykl0Iwu2cL2vKMKVALRl1hysyhUw0vjpAvLFx+Kfq9VLjnHIkW32fPA==}
@@ -7374,6 +8036,10 @@ packages:
     resolution: {integrity: sha512-UegCo7ygB2fT64mRK2nbAjQVJ1zSwIIHy8d96jJv2nKZFDaViYBiughEdu5HM/Ceq0WN3LZrZk3zhl9aoiLYFw==}
     engines: {node: '>=20.19.4'}
 
+  metro-transform-worker@0.84.4:
+    resolution: {integrity: sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
   metro@0.83.3:
     resolution: {integrity: sha512-+rP+/GieOzkt97hSJ0MrPOuAH/jpaS21ZDvL9DJ35QYRDlQcwzcvUlGUf79AnQxq/2NPiS/AULhhM4TKutIt8Q==}
     engines: {node: '>=20.19.4'}
@@ -7382,6 +8048,11 @@ packages:
   metro@0.83.7:
     resolution: {integrity: sha512-SPaPEyvTsTmd0LpT7RaZciQyDw2i/JB7+iY9L5VfBo72+psescFxBqpI1TL9dnL+pmnfkU+l/J1mEEGLeF65EQ==}
     engines: {node: '>=20.19.4'}
+    hasBin: true
+
+  metro@0.84.4:
+    resolution: {integrity: sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
     hasBin: true
 
   micromark-core-commonmark@2.0.3:
@@ -7633,6 +8304,12 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nativewind@4.2.5:
+    resolution: {integrity: sha512-kKy2BG2xCca7tn3GZ65+sQ2aZH5T2hJ/sN/vlA1WSDu2YPn1rkdjsBOHy2TMv0I/au/HAuvgKIbX+LsSXvcf1Q==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      tailwindcss: '>3.3.0'
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -7758,9 +8435,17 @@ packages:
     resolution: {integrity: sha512-9M5kpuOLyTPogMtZiQUIxdAZxl7Dxs6tVBbJErSumsqGMuhVSoUbkfeZ3XNPpLpwBBtqY5QDUzGwggLHX3slQg==}
     engines: {node: '>=20.19.4'}
 
+  ob1@0.84.4:
+    resolution: {integrity: sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -8004,6 +8689,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -8040,6 +8729,18 @@ packages:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
 
+  postcss-import@15.1.0:
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-js@4.1.0:
+    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
+
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -8067,6 +8768,9 @@ packages:
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.4.49:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
@@ -8170,6 +8874,10 @@ packages:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
+  query-string@7.1.3:
+    resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
+    engines: {node: '>=6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -8203,11 +8911,26 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-fast-compare@3.2.2:
+    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+
+  react-freeze@1.0.4:
+    resolution: {integrity: sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=17.0.0'
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-is@19.2.7:
+    resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
 
   react-markdown@9.1.0:
     resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
@@ -8215,11 +8938,66 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
+  react-native-css-interop@0.2.5:
+    resolution: {integrity: sha512-V8/d9lBqn4w8m4d7dmwQPOFJB49bqga/9dmamfRHSGTQjGzrY/jAvDFOzSe+Ew2XuGz1ShVBD2cFIClFYasGyw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=18'
+      react-native: '*'
+      react-native-reanimated: '>=3.6.2'
+      react-native-safe-area-context: '*'
+      react-native-svg: '*'
+      tailwindcss: ~3
+    peerDependenciesMeta:
+      react-native-safe-area-context:
+        optional: true
+      react-native-svg:
+        optional: true
+
+  react-native-gesture-handler@2.28.0:
+    resolution: {integrity: sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
   react-native-is-edge-to-edge@1.3.1:
     resolution: {integrity: sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA==}
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  react-native-reanimated@4.1.7:
+    resolution: {integrity: sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==}
+    peerDependencies:
+      react: '*'
+      react-native: 0.78 - 0.82
+      react-native-worklets: 0.5 - 0.8
+
+  react-native-safe-area-context@5.6.2:
+    resolution: {integrity: sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  react-native-screens@4.16.0:
+    resolution: {integrity: sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  react-native-svg@15.12.1:
+    resolution: {integrity: sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  react-native-worklets@0.8.3:
+    resolution: {integrity: sha512-oCBJROyLU7yG/1R8s0INMflygTH71bx+5XcYkH0CM938TlhSoVbiunE1WVW5FZa51vwYqfLie/IXMX2s1Kh3eg==}
+    peerDependencies:
+      '@babel/core': '*'
+      '@react-native/metro-config': '*'
+      react: '*'
+      react-native: 0.81 - 0.85
 
   react-native@0.81.5:
     resolution: {integrity: sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==}
@@ -8246,6 +9024,36 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-virtuoso@4.18.7:
     resolution: {integrity: sha512-xNF5zDGEEIMB7cKwcen/pLig0YDf6OnfFrVgKFa7sHPf9fRem0CaLshyObbBcP88jzn0enavL39EgplgdyT21g==}
     peerDependencies:
@@ -8264,6 +9072,9 @@ packages:
     resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
     hasBin: true
 
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
@@ -8281,6 +9092,10 @@ packages:
 
   readdir-glob@1.1.3:
     resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -8551,6 +9366,11 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.6.3:
+    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -8585,11 +9405,21 @@ packages:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
 
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sf-symbols-typescript@2.2.0:
+    resolution: {integrity: sha512-TPbeg0b7ylrswdGCji8FRGFAKuqbpQlLbL8SOle3j1iHSs5Ob5mhvMAxWN2UItOjgALAB5Zp3fmMfj8mbWvXKw==}
+    engines: {node: '>=10'}
+
+  shallowequal@1.1.0:
+    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
 
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
@@ -8723,6 +9553,10 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  split-on-first@1.1.0:
+    resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
+    engines: {node: '>=6'}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -8747,6 +9581,9 @@ packages:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
 
+  standard-navigation@0.0.7:
+    resolution: {integrity: sha512-NCGLCNyuXrFOkGHxdNZFnpsehGtiq1oXbPhKl7ZuxFO5J//H2evqqOchmD4YwEUJnkjO4kH9Xp4hQX6hdAYCKQ==}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
@@ -8768,6 +9605,10 @@ packages:
 
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
+
+  strict-uri-encode@2.0.0:
+    resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
+    engines: {node: '>=4'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -8883,6 +9724,11 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tailwindcss@3.4.19:
+    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -9295,6 +10141,31 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-latest-callback@0.2.6:
+    resolution: {integrity: sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==}
+    peerDependencies:
+      react: '>=16.8'
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
@@ -9322,6 +10193,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
@@ -9546,6 +10423,9 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  warn-once@0.1.1:
+    resolution: {integrity: sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==}
 
   watskeburt@4.2.3:
     resolution: {integrity: sha512-uG9qtQYoHqAsnT711nG5iZc/8M5inSmkGCOp7pFaytKG2aTfIca7p//CjiVzAE4P7hzaYuCozMjNNaLgmhbK5g==}
@@ -9828,6 +10708,8 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 4.0.0
+
+  '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -10134,11 +11016,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -10166,7 +11044,7 @@ snapshots:
 
   '@babel/parser@7.29.3':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -10543,6 +11421,11 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -10605,8 +11488,8 @@ snapshots:
 
   '@babel/types@7.29.0':
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@babel/types@7.29.7':
     dependencies:
@@ -10676,6 +11559,10 @@ snapshots:
     dependencies:
       ajv: 6.15.0
       ajv-keywords: 3.5.2(ajv@6.15.0)
+
+  '@egjs/hammerjs@2.0.17':
+    dependencies:
+      '@types/hammerjs': 2.0.46
 
   '@electron/asar@3.4.1':
     dependencies:
@@ -11047,7 +11934,7 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@expo/cli@54.0.25(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)':
+  '@expo/cli@54.0.25(expo-router@6.0.24)(expo@54.0.35)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)':
     dependencies:
       '@0no-co/graphql.web': 1.2.0(graphql@15.8.0)
       '@expo/code-signing-certificates': 0.0.6
@@ -11058,11 +11945,11 @@ snapshots:
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
       '@expo/json-file': 10.2.0
       '@expo/metro': 54.2.0
-      '@expo/metro-config': 54.0.16(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
+      '@expo/metro-config': 54.0.16(expo@54.0.35)
       '@expo/osascript': 2.6.0
       '@expo/package-manager': 1.12.1
       '@expo/plist': 0.4.9
-      '@expo/prebuild-config': 54.0.8(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(typescript@5.9.3)
+      '@expo/prebuild-config': 54.0.8(expo@54.0.35)(typescript@5.9.3)
       '@expo/schema-utils': 0.1.8
       '@expo/spawn-async': 1.8.0
       '@expo/ws-tunnel': 1.0.6
@@ -11081,7 +11968,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       env-editor: 0.4.2
-      expo: 54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-server: 1.0.7
       freeport-async: 2.0.0
       getenv: 2.0.0
@@ -11114,7 +12001,8 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.20.0
     optionalDependencies:
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)
+      expo-router: 6.0.24(227a4de6044da93a49c8b550e41f6cd3)
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
       - graphql
@@ -11172,12 +12060,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/devtools@0.1.8(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+  '@expo/devtools@0.1.8(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       chalk: 4.1.2
     optionalDependencies:
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
 
   '@expo/env@2.0.11':
     dependencies:
@@ -11228,7 +12116,7 @@ snapshots:
       '@babel/code-frame': 7.29.7
       json5: 2.2.3
 
-  '@expo/metro-config@54.0.16(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))':
+  '@expo/metro-config@54.0.16(expo@54.0.35)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.7
@@ -11252,11 +12140,23 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@expo/metro-runtime@6.1.2(expo@54.0.35)(react-dom@18.3.1(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      anser: 1.4.10
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      pretty-format: 29.7.0
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+      stacktrace-parser: 0.1.11
+      whatwg-fetch: 3.6.20
+    optionalDependencies:
+      react-dom: 18.3.1(react@19.1.0)
 
   '@expo/metro@54.2.0':
     dependencies:
@@ -11298,7 +12198,7 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
-  '@expo/prebuild-config@54.0.8(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(typescript@5.9.3)':
+  '@expo/prebuild-config@54.0.8(expo@54.0.35)(typescript@5.9.3)':
     dependencies:
       '@expo/config': 12.0.13
       '@expo/config-plugins': 54.0.4
@@ -11307,7 +12207,7 @@ snapshots:
       '@expo/json-file': 10.2.0
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3
-      expo: 54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       resolve-from: 5.0.0
       semver: 7.8.0
       xml2js: 0.6.0
@@ -11335,11 +12235,11 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
-  '@expo/vector-icons@15.1.1(expo-font@14.0.12(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+  '@expo/vector-icons@15.1.1(expo-font@14.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      expo-font: 14.0.12(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-font: 14.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
 
   '@expo/ws-tunnel@1.0.6': {}
 
@@ -11818,16 +12718,13 @@ snapshots:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
-    optional: true
 
-  '@nodelib/fs.stat@2.0.5':
-    optional: true
+  '@nodelib/fs.stat@2.0.5': {}
 
   '@nodelib/fs.walk@1.2.8':
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
-    optional: true
 
   '@npmcli/fs@2.1.2':
     dependencies:
@@ -11889,6 +12786,212 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.1': {}
+
+  '@radix-ui/primitive@1.1.4': {}
+
+  '@radix-ui/react-collection@1.1.9(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 18.3.7(@types/react@19.1.17)
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-context@1.1.4(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-dialog@1.1.16(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.9(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.17)(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+      react-remove-scroll: 2.7.2(@types/react@19.1.17)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 18.3.7(@types/react@19.1.17)
+
+  '@radix-ui/react-direction@1.1.2(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-dismissable-layer@1.1.12(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 18.3.7(@types/react@19.1.17)
+
+  '@radix-ui/react-focus-guards@1.1.4(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-focus-scope@1.1.9(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 18.3.7(@types/react@19.1.17)
+
+  '@radix-ui/react-id@1.1.2(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-portal@1.1.11(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 18.3.7(@types/react@19.1.17)
+
+  '@radix-ui/react-presence@1.1.6(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 18.3.7(@types/react@19.1.17)
+
+  '@radix-ui/react-primitive@2.1.5(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 18.3.7(@types/react@19.1.17)
+
+  '@radix-ui/react-roving-focus@1.1.12(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.9(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 18.3.7(@types/react@19.1.17)
+
+  '@radix-ui/react-slot@1.2.0(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-slot@1.2.5(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-tabs@1.1.14(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.12(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 18.3.7(@types/react@19.1.17)
+
+  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
 
   '@react-native-community/cli-clean@13.6.9(encoding@0.1.13)':
     dependencies:
@@ -12059,6 +13162,14 @@ snapshots:
       - '@babel/core'
       - supports-color
 
+  '@react-native/babel-plugin-codegen@0.86.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@react-native/codegen': 0.86.0(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
   '@react-native/babel-preset@0.81.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -12109,6 +13220,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@react-native/babel-preset@0.86.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-regenerator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
+      '@react-native/babel-plugin-codegen': 0.86.0(@babel/core@7.29.7)
+      babel-plugin-syntax-hermes-parser: 0.36.0
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.7)
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@react-native/codegen@0.81.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -12119,7 +13268,17 @@ snapshots:
       nullthrows: 1.1.1
       yargs: 17.7.2
 
-  '@react-native/community-cli-plugin@0.81.5(@react-native-community/cli@13.6.9(encoding@0.1.13))':
+  '@react-native/codegen@0.86.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
+      hermes-parser: 0.36.0
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      tinyglobby: 0.2.16
+      yargs: 17.7.2
+
+  '@react-native/community-cli-plugin@0.81.5(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))':
     dependencies:
       '@react-native/dev-middleware': 0.81.5
       debug: 4.4.3
@@ -12130,6 +13289,7 @@ snapshots:
       semver: 7.8.0
     optionalDependencies:
       '@react-native-community/cli': 13.6.9(encoding@0.1.13)
+      '@react-native/metro-config': 0.86.0(@babel/core@7.29.7)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -12159,16 +13319,103 @@ snapshots:
 
   '@react-native/js-polyfills@0.81.5': {}
 
+  '@react-native/js-polyfills@0.86.0': {}
+
+  '@react-native/metro-babel-transformer@0.86.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@react-native/babel-preset': 0.86.0(@babel/core@7.29.7)
+      hermes-parser: 0.36.0
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@react-native/metro-config@0.86.0(@babel/core@7.29.7)':
+    dependencies:
+      '@react-native/js-polyfills': 0.86.0
+      '@react-native/metro-babel-transformer': 0.86.0(@babel/core@7.29.7)
+      metro-config: 0.84.4
+      metro-runtime: 0.84.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@react-native/normalize-colors@0.81.5': {}
 
-  '@react-native/virtualized-lists@0.81.5(@types/react@19.1.17)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+  '@react-native/virtualized-lists@0.81.5(@types/react@19.1.17)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.17
+
+  '@react-navigation/bottom-tabs@7.17.2(@react-navigation/native@7.3.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@react-navigation/elements': 2.9.22(@react-navigation/native@7.3.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native': 7.3.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      color: 4.2.3
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      sf-symbols-typescript: 2.2.0
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
+
+  '@react-navigation/core@7.19.0(react@19.1.0)':
+    dependencies:
+      '@react-navigation/routers': 7.5.6
+      escape-string-regexp: 4.0.0
+      fast-deep-equal: 3.1.3
+      nanoid: 3.3.12
+      query-string: 7.1.3
+      react: 19.1.0
+      react-is: 19.2.7
+      use-latest-callback: 0.2.6(react@19.1.0)
+      use-sync-external-store: 1.6.0(react@19.1.0)
+
+  '@react-navigation/elements@2.9.22(@react-navigation/native@7.3.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@react-navigation/native': 7.3.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      color: 4.2.3
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      use-latest-callback: 0.2.6(react@19.1.0)
+      use-sync-external-store: 1.6.0(react@19.1.0)
+
+  '@react-navigation/native-stack@7.17.2(@react-navigation/native@7.3.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@react-navigation/elements': 2.9.22(@react-navigation/native@7.3.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native': 7.3.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      color: 4.2.3
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      sf-symbols-typescript: 2.2.0
+      warn-once: 0.1.1
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
+
+  '@react-navigation/native@7.3.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@react-navigation/core': 7.19.0(react@19.1.0)
+      escape-string-regexp: 4.0.0
+      fast-deep-equal: 3.1.3
+      nanoid: 3.3.12
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+      standard-navigation: 0.0.7
+      use-latest-callback: 0.2.6(react@19.1.0)
+
+  '@react-navigation/routers@7.5.6':
+    dependencies:
+      nanoid: 3.3.12
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -12416,16 +13663,16 @@ snapshots:
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.4':
     dependencies:
       '@babel/parser': 7.29.7
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/cacheable-request@6.0.3':
     dependencies:
@@ -12453,6 +13700,8 @@ snapshots:
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 24.12.3
+
+  '@types/hammerjs@2.0.46': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -12526,6 +13775,11 @@ snapshots:
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
     dependencies:
       '@types/react': 18.3.28
+
+  '@types/react-dom@18.3.7(@types/react@19.1.17)':
+    dependencies:
+      '@types/react': 19.1.17
+    optional: true
 
   '@types/react@18.3.28':
     dependencies:
@@ -13027,6 +14281,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -13034,6 +14292,8 @@ snapshots:
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
+
+  array-timsort@1.0.3: {}
 
   asap@2.0.6: {}
 
@@ -13235,6 +14495,10 @@ snapshots:
     dependencies:
       hermes-parser: 0.29.1
 
+  babel-plugin-syntax-hermes-parser@0.36.0:
+    dependencies:
+      hermes-parser: 0.36.0
+
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.29.7):
     dependencies:
       '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
@@ -13260,7 +14524,7 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7)
 
-  babel-preset-expo@54.0.11(@babel/core@7.29.7)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-refresh@0.14.2):
+  babel-preset-expo@54.0.11(@babel/core@7.29.7)(@babel/runtime@7.29.2)(expo@54.0.35)(react-refresh@0.14.2):
     dependencies:
       '@babel/helper-module-imports': 7.29.7
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
@@ -13287,7 +14551,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -13323,6 +14587,8 @@ snapshots:
       open: 8.4.2
 
   big-integer@1.6.52: {}
+
+  binary-extensions@2.3.0: {}
 
   bl@4.1.0:
     dependencies:
@@ -13524,6 +14790,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase-css@2.0.1: {}
+
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
@@ -13564,6 +14832,18 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   check-error@2.1.3: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   chokidar@4.0.3:
     dependencies:
@@ -13633,6 +14913,8 @@ snapshots:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 7.2.0
+
+  client-only@0.0.1: {}
 
   cliui@6.0.0:
     dependencies:
@@ -13712,6 +14994,11 @@ snapshots:
 
   commander@9.5.0:
     optional: true
+
+  comment-json@4.6.2:
+    dependencies:
+      array-timsort: 1.0.3
+      esprima: 4.0.1
 
   common-ancestor-path@1.0.1: {}
 
@@ -13839,6 +15126,11 @@ snapshots:
 
   css-selector-parser@3.3.0: {}
 
+  css-tree@1.1.3:
+    dependencies:
+      mdn-data: 2.0.14
+      source-map: 0.6.1
+
   css-tree@2.2.1:
     dependencies:
       mdn-data: 2.0.28
@@ -13895,6 +15187,8 @@ snapshots:
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
+
+  decode-uri-component@0.2.2: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -13967,7 +15261,11 @@ snapshots:
 
   destroy@1.2.0: {}
 
+  detect-libc@1.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   detect-node@2.1.0: {}
 
@@ -13980,6 +15278,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  didyoumean@1.2.2: {}
 
   diff@8.0.4: {}
 
@@ -14481,49 +15781,85 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  expo-asset@12.0.13(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+  expo-asset@12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
-      expo: 54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-constants: 18.0.13(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-camera@17.0.10(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  expo-audio@1.1.1(expo-asset@12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-asset: 12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+
+  expo-camera@17.0.10(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       invariant: 2.2.4
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
 
-  expo-constants@18.0.13(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)):
+  expo-clipboard@8.0.8(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+
+  expo-constants@18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
       '@expo/config': 12.0.13
       '@expo/env': 2.0.11
-      expo: 54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-file-system@19.0.23(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)):
+  expo-document-picker@14.0.8(expo@54.0.35):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
-  expo-font@14.0.12(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  expo-file-system@19.0.23(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+
+  expo-font@14.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       fontfaceobserver: 2.3.0
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
 
-  expo-keep-awake@15.0.8(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react@19.1.0):
+  expo-image-loader@6.0.0(expo@54.0.35):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+
+  expo-image-picker@17.0.11(expo@54.0.35):
+    dependencies:
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-image-loader: 6.0.0(expo@54.0.35)
+
+  expo-keep-awake@15.0.8(expo@54.0.35)(react@19.1.0):
+    dependencies:
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
+
+  expo-linking@8.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      expo-constants: 18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+    transitivePeerDependencies:
+      - expo
+      - supports-color
 
   expo-modules-autolinking@3.0.26:
     dependencies:
@@ -14533,45 +15869,93 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
 
-  expo-modules-core@3.0.30(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  expo-modules-core@3.0.30(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       invariant: 2.2.4
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+
+  expo-router@6.0.24(227a4de6044da93a49c8b550e41f6cd3):
+    dependencies:
+      '@expo/metro-runtime': 6.1.2(expo@54.0.35)(react-dom@18.3.1(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@expo/schema-utils': 0.1.8
+      '@radix-ui/react-slot': 1.2.0(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-tabs': 1.1.14(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      '@react-navigation/bottom-tabs': 7.17.2(@react-navigation/native@7.3.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native': 7.3.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native-stack': 7.17.2(@react-navigation/native@7.3.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      client-only: 0.0.1
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))
+      expo-linking: 8.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-server: 1.0.7
+      fast-deep-equal: 3.1.3
+      invariant: 2.2.4
+      nanoid: 3.3.12
+      query-string: 7.1.3
+      react: 19.1.0
+      react-fast-compare: 3.2.2
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      semver: 7.6.3
+      server-only: 0.0.1
+      sf-symbols-typescript: 2.2.0
+      shallowequal: 1.1.0
+      use-latest-callback: 0.2.6(react@19.1.0)
+      vaul: 1.1.2(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+    optionalDependencies:
+      react-dom: 18.3.1(react@19.1.0)
+      react-native-gesture-handler: 2.28.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-reanimated: 4.1.7(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
+
+  expo-secure-store@15.0.8(expo@54.0.35):
+    dependencies:
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-server@1.0.7: {}
 
-  expo-status-bar@3.0.9(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  expo-status-bar@3.0.9(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
 
-  expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+  expo@54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@expo/cli': 54.0.25(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)
+      '@expo/cli': 54.0.25(expo-router@6.0.24)(expo@54.0.35)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)
       '@expo/config': 12.0.13
       '@expo/config-plugins': 54.0.4
-      '@expo/devtools': 0.1.8(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@expo/devtools': 0.1.8(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@expo/fingerprint': 0.15.5
       '@expo/metro': 54.2.0
-      '@expo/metro-config': 54.0.16(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
-      '@expo/vector-icons': 15.1.1(expo-font@14.0.12(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@expo/metro-config': 54.0.16(expo@54.0.35)
+      '@expo/vector-icons': 15.1.1(expo-font@14.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@ungap/structured-clone': 1.3.1
-      babel-preset-expo: 54.0.11(@babel/core@7.29.7)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-refresh@0.14.2)
-      expo-asset: 12.0.13(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-constants: 18.0.13(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))
-      expo-file-system: 19.0.23(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))
-      expo-font: 14.0.12(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      expo-keep-awake: 15.0.8(expo@54.0.35(@babel/core@7.29.7)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react@19.1.0)
+      babel-preset-expo: 54.0.11(@babel/core@7.29.7)(@babel/runtime@7.29.2)(expo@54.0.35)(react-refresh@0.14.2)
+      expo-asset: 12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))
+      expo-file-system: 19.0.23(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))
+      expo-font: 14.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-keep-awake: 15.0.8(expo@54.0.35)(react@19.1.0)
       expo-modules-autolinking: 3.0.26
-      expo-modules-core: 3.0.30(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-modules-core: 3.0.30(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       pretty-format: 29.7.0
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
       react-refresh: 0.14.2
       whatwg-url-without-unicode: 8.0.0-3
+    optionalDependencies:
+      '@expo/metro-runtime': 6.1.2(expo@54.0.35)(react-dom@18.3.1(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -14652,7 +16036,6 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
-    optional: true
 
   fast-json-stable-stringify@2.1.0: {}
 
@@ -14678,7 +16061,6 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
-    optional: true
 
   fb-watchman@2.0.2:
     dependencies:
@@ -14709,6 +16091,8 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  filter-obj@1.1.0: {}
 
   finalhandler@1.1.2:
     dependencies:
@@ -14871,6 +16255,8 @@ snapshots:
       hasown: 2.0.3
       math-intrinsics: 1.1.0
 
+  get-nonce@1.0.1: {}
+
   get-package-type@0.1.0: {}
 
   get-proto@1.0.1:
@@ -14896,7 +16282,6 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
-    optional: true
 
   glob-parent@6.0.2:
     dependencies:
@@ -15218,6 +16603,8 @@ snapshots:
 
   hermes-estree@0.35.0: {}
 
+  hermes-estree@0.36.0: {}
+
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
@@ -15234,10 +16621,18 @@ snapshots:
     dependencies:
       hermes-estree: 0.35.0
 
+  hermes-parser@0.36.0:
+    dependencies:
+      hermes-estree: 0.36.0
+
   hermes-profile-transformer@0.0.6:
     dependencies:
       source-map: 0.7.6
     optional: true
+
+  hoist-non-react-statics@3.3.2:
+    dependencies:
+      react-is: 16.13.1
 
   hono@4.12.18: {}
 
@@ -15432,6 +16827,10 @@ snapshots:
     optional: true
 
   is-arrayish@0.3.4: {}
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
 
   is-ci@3.0.1:
     dependencies:
@@ -15635,6 +17034,8 @@ snapshots:
 
   jimp-compact@0.16.1: {}
 
+  jiti@1.21.7: {}
+
   jiti@2.7.0: {}
 
   joi@17.13.3:
@@ -15759,35 +17160,80 @@ snapshots:
   lightningcss-android-arm64@1.32.0:
     optional: true
 
+  lightningcss-darwin-arm64@1.27.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.27.0:
     optional: true
 
   lightningcss-darwin-x64@1.32.0:
     optional: true
 
+  lightningcss-freebsd-x64@1.27.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.27.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
+  lightningcss-linux-arm64-gnu@1.27.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.27.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-x64-gnu@1.27.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.27.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.32.0:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.27.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.27.0:
     optional: true
 
   lightningcss-win32-x64-msvc@1.32.0:
     optional: true
+
+  lightningcss@1.27.0:
+    dependencies:
+      detect-libc: 1.0.3
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.27.0
+      lightningcss-darwin-x64: 1.27.0
+      lightningcss-freebsd-x64: 1.27.0
+      lightningcss-linux-arm-gnueabihf: 1.27.0
+      lightningcss-linux-arm64-gnu: 1.27.0
+      lightningcss-linux-arm64-musl: 1.27.0
+      lightningcss-linux-x64-gnu: 1.27.0
+      lightningcss-linux-x64-musl: 1.27.0
+      lightningcss-win32-arm64-msvc: 1.27.0
+      lightningcss-win32-x64-msvc: 1.27.0
 
   lightningcss@1.32.0:
     dependencies:
@@ -15898,7 +17344,7 @@ snapshots:
   magicast@0.5.2:
     dependencies:
       '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -16126,6 +17572,8 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  mdn-data@2.0.14: {}
+
   mdn-data@2.0.28: {}
 
   mdn-data@2.27.1: {}
@@ -16142,8 +17590,7 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
-  merge2@1.4.1:
-    optional: true
+  merge2@1.4.1: {}
 
   metro-babel-transformer@0.83.3:
     dependencies:
@@ -16164,11 +17611,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-babel-transformer@0.84.4:
+    dependencies:
+      '@babel/core': 7.29.7
+      flow-enums-runtime: 0.0.6
+      hermes-parser: 0.35.0
+      metro-cache-key: 0.84.4
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   metro-cache-key@0.83.3:
     dependencies:
       flow-enums-runtime: 0.0.6
 
   metro-cache-key@0.83.7:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
+  metro-cache-key@0.84.4:
     dependencies:
       flow-enums-runtime: 0.0.6
 
@@ -16187,6 +17648,15 @@ snapshots:
       flow-enums-runtime: 0.0.6
       https-proxy-agent: 7.0.6
       metro-core: 0.83.7
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-cache@0.84.4:
+    dependencies:
+      exponential-backoff: 3.1.3
+      flow-enums-runtime: 0.0.6
+      https-proxy-agent: 7.0.6
+      metro-core: 0.84.4
     transitivePeerDependencies:
       - supports-color
 
@@ -16220,6 +17690,21 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  metro-config@0.84.4:
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.84.4
+      metro-cache: 0.84.4
+      metro-core: 0.84.4
+      metro-runtime: 0.84.4
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   metro-core@0.83.3:
     dependencies:
       flow-enums-runtime: 0.0.6
@@ -16231,6 +17716,12 @@ snapshots:
       flow-enums-runtime: 0.0.6
       lodash.throttle: 4.1.1
       metro-resolver: 0.83.7
+
+  metro-core@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      lodash.throttle: 4.1.1
+      metro-resolver: 0.84.4
 
   metro-file-map@0.83.3:
     dependencies:
@@ -16260,12 +17751,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-file-map@0.84.4:
+    dependencies:
+      debug: 4.4.3
+      fb-watchman: 2.0.2
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      micromatch: 4.0.8
+      nullthrows: 1.1.1
+      walker: 1.0.8
+    transitivePeerDependencies:
+      - supports-color
+
   metro-minify-terser@0.83.3:
     dependencies:
       flow-enums-runtime: 0.0.6
       terser: 5.48.0
 
   metro-minify-terser@0.83.7:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      terser: 5.48.0
+
+  metro-minify-terser@0.84.4:
     dependencies:
       flow-enums-runtime: 0.0.6
       terser: 5.48.0
@@ -16278,12 +17788,21 @@ snapshots:
     dependencies:
       flow-enums-runtime: 0.0.6
 
+  metro-resolver@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
   metro-runtime@0.83.3:
     dependencies:
       '@babel/runtime': 7.29.2
       flow-enums-runtime: 0.0.6
 
   metro-runtime@0.83.7:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      flow-enums-runtime: 0.0.6
+
+  metro-runtime@0.84.4:
     dependencies:
       '@babel/runtime': 7.29.2
       flow-enums-runtime: 0.0.6
@@ -16317,6 +17836,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-source-map@0.84.4:
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      metro-symbolicate: 0.84.4
+      nullthrows: 1.1.1
+      ob1: 0.84.4
+      source-map: 0.5.7
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   metro-symbolicate@0.83.3:
     dependencies:
       flow-enums-runtime: 0.0.6
@@ -16339,6 +17872,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-symbolicate@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      metro-source-map: 0.84.4
+      nullthrows: 1.1.1
+      source-map: 0.5.7
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   metro-transform-plugins@0.83.3:
     dependencies:
       '@babel/core': 7.29.7
@@ -16351,6 +17895,17 @@ snapshots:
       - supports-color
 
   metro-transform-plugins@0.83.7:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      flow-enums-runtime: 0.0.6
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-transform-plugins@0.84.4:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
@@ -16395,6 +17950,26 @@ snapshots:
       metro-minify-terser: 0.83.7
       metro-source-map: 0.83.7
       metro-transform-plugins: 0.83.7
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro-transform-worker@0.84.4:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      flow-enums-runtime: 0.0.6
+      metro: 0.84.4
+      metro-babel-transformer: 0.84.4
+      metro-cache: 0.84.4
+      metro-cache-key: 0.84.4
+      metro-minify-terser: 0.84.4
+      metro-source-map: 0.84.4
+      metro-transform-plugins: 0.84.4
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - bufferutil
@@ -16482,6 +18057,52 @@ snapshots:
       metro-symbolicate: 0.83.7
       metro-transform-plugins: 0.83.7
       metro-transform-worker: 0.83.7
+      mime-types: 3.0.2
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.11
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.84.4:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      accepts: 2.0.0
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.35.0
+      image-size: 1.2.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.84.4
+      metro-cache: 0.84.4
+      metro-cache-key: 0.84.4
+      metro-config: 0.84.4
+      metro-core: 0.84.4
+      metro-file-map: 0.84.4
+      metro-resolver: 0.84.4
+      metro-runtime: 0.84.4
+      metro-source-map: 0.84.4
+      metro-symbolicate: 0.84.4
+      metro-transform-plugins: 0.84.4
+      metro-transform-worker: 0.84.4
       mime-types: 3.0.2
       nullthrows: 1.1.1
       serialize-error: 2.1.0
@@ -16885,6 +18506,20 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  nativewind@4.2.5(beef0d520c79bfe26b55be4fd582eecc):
+    dependencies:
+      comment-json: 4.6.2
+      debug: 4.4.3
+      react-native-css-interop: 0.2.5(beef0d520c79bfe26b55be4fd582eecc)
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - react
+      - react-native
+      - react-native-reanimated
+      - react-native-safe-area-context
+      - react-native-svg
+      - supports-color
+
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
@@ -16998,7 +18633,13 @@ snapshots:
     dependencies:
       flow-enums-runtime: 0.0.6
 
+  ob1@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
   object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
 
@@ -17268,6 +18909,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pify@2.3.0: {}
+
   pirates@4.0.7: {}
 
   pkce-challenge@5.0.1: {}
@@ -17298,6 +18941,27 @@ snapshots:
 
   pngjs@5.0.0: {}
 
+  postcss-import@15.1.0(postcss@8.5.14):
+    dependencies:
+      postcss: 8.5.14
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.12
+
+  postcss-js@4.1.0(postcss@8.5.14):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.14
+
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 1.21.7
+      postcss: 8.5.14
+      tsx: 4.21.0
+      yaml: 2.9.0
+
   postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
@@ -17316,6 +18980,8 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.4.49:
     dependencies:
@@ -17422,8 +19088,14 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
-  queue-microtask@1.2.3:
-    optional: true
+  query-string@7.1.3:
+    dependencies:
+      decode-uri-component: 0.2.2
+      filter-obj: 1.1.0
+      split-on-first: 1.1.0
+      strict-uri-encode: 2.0.0
+
+  queue-microtask@1.2.3: {}
 
   queue@6.0.2:
     dependencies:
@@ -17463,9 +19135,25 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-dom@18.3.1(react@19.1.0):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 19.1.0
+      scheduler: 0.23.2
+
+  react-fast-compare@3.2.2: {}
+
+  react-freeze@1.0.4(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+
+  react-is@16.13.1: {}
+
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-is@19.2.7: {}
 
   react-markdown@9.1.0(@types/react@18.3.28)(react@18.3.1):
     dependencies:
@@ -17485,21 +19173,96 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-native-is-edge-to-edge@1.3.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  react-native-css-interop@0.2.5(beef0d520c79bfe26b55be4fd582eecc):
+    dependencies:
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+      lightningcss: 1.27.0
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+      react-native-reanimated: 4.1.7(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      semver: 7.8.0
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
+    optionalDependencies:
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-svg: 15.12.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@egjs/hammerjs': 2.0.17
+      hoist-non-react-statics: 3.3.2
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+
+  react-native-is-edge-to-edge@1.3.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
 
-  react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0):
+  react-native-reanimated@4.1.7(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      semver: 7.8.0
+
+  react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+
+  react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-freeze: 1.0.4(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      warn-once: 0.1.1
+
+  react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      css-select: 5.2.2
+      css-tree: 1.1.3
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+      warn-once: 0.1.1
+
+  react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@react-native/metro-config': 0.86.0(@babel/core@7.29.7)
+      convert-source-map: 2.0.0
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+      semver: 7.8.0
+    transitivePeerDependencies:
+      - supports-color
+
+  react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.81.5
       '@react-native/codegen': 0.81.5(@babel/core@7.29.7)
-      '@react-native/community-cli-plugin': 0.81.5(@react-native-community/cli@13.6.9(encoding@0.1.13))
+      '@react-native/community-cli-plugin': 0.81.5(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))
       '@react-native/gradle-plugin': 0.81.5
       '@react-native/js-polyfills': 0.81.5
       '@react-native/normalize-colors': 0.81.5
-      '@react-native/virtualized-lists': 0.81.5(@types/react@19.1.17)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-native/virtualized-lists': 0.81.5(@types/react@19.1.17)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -17547,6 +19310,33 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.1.17)(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-style-singleton: 2.2.3(@types/react@19.1.17)(react@19.1.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  react-remove-scroll@2.7.2(@types/react@19.1.17)(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-remove-scroll-bar: 2.3.8(@types/react@19.1.17)(react@19.1.0)
+      react-style-singleton: 2.2.3(@types/react@19.1.17)(react@19.1.0)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.1.17)(react@19.1.0)
+      use-sidecar: 1.1.3(@types/react@19.1.17)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  react-style-singleton@2.2.3(@types/react@19.1.17)(react@19.1.0):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.1.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.17
+
   react-virtuoso@4.18.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -17563,6 +19353,10 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
 
   readable-stream@2.3.8:
     dependencies:
@@ -17595,6 +19389,10 @@ snapshots:
   readdir-glob@1.1.3:
     dependencies:
       minimatch: 5.1.9
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
 
   readdirp@4.1.2: {}
 
@@ -17873,8 +19671,7 @@ snapshots:
 
   retry@0.12.0: {}
 
-  reusify@1.1.0:
-    optional: true
+  reusify@1.1.0: {}
 
   rimraf@3.0.2:
     dependencies:
@@ -17937,7 +19734,6 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-    optional: true
 
   safe-buffer@5.1.2: {}
 
@@ -17968,6 +19764,8 @@ snapshots:
   semver-compare@1.0.0: {}
 
   semver@6.3.1: {}
+
+  semver@7.6.3: {}
 
   semver@7.7.4: {}
 
@@ -18031,9 +19829,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  server-only@0.0.1: {}
+
   set-blocking@2.0.0: {}
 
   setprototypeof@1.2.0: {}
+
+  sf-symbols-typescript@2.2.0: {}
+
+  shallowequal@1.1.0: {}
 
   sharp@0.33.5:
     dependencies:
@@ -18239,6 +20043,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  split-on-first@1.1.0: {}
+
   sprintf-js@1.0.3: {}
 
   sprintf-js@1.1.3: {}
@@ -18259,6 +20065,8 @@ snapshots:
     dependencies:
       type-fest: 0.7.1
 
+  standard-navigation@0.0.7: {}
+
   stat-mode@1.0.0: {}
 
   statuses@1.5.0: {}
@@ -18270,6 +20078,8 @@ snapshots:
   stream-buffers@2.2.0: {}
 
   stream-replace-string@2.0.0: {}
+
+  strict-uri-encode@2.0.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -18400,6 +20210,34 @@ snapshots:
       use-sync-external-store: 1.6.0(react@18.3.1)
 
   symbol-tree@3.2.4: {}
+
+  tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.14
+      postcss-import: 15.1.0(postcss@8.5.14)
+      postcss-js: 4.1.0(postcss@8.5.14)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.9.0)
+      postcss-nested: 6.2.0(postcss@8.5.14)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.12
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - tsx
+      - yaml
 
   tapable@2.3.3: {}
 
@@ -18769,9 +20607,32 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-callback-ref@1.3.3(@types/react@19.1.17)(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  use-latest-callback@0.2.6(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+
+  use-sidecar@1.1.3(@types/react@19.1.17)(react@19.1.0):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.1.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.17
+
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  use-sync-external-store@1.6.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   utf8-byte-length@1.0.5: {}
 
@@ -18784,6 +20645,15 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
+
+  vaul@1.1.2(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.16(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   verror@1.10.1:
     dependencies:
@@ -19064,6 +20934,8 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
+
+  warn-once@0.1.1: {}
 
   watskeburt@4.2.3: {}
 


### PR DESCRIPTION
Ports the complete mobile app design from the `mobile-plugin` branch into `apps/mobile`, rebuilt on the current architecture (per the audit-hardened stack) instead of the branch's bespoke gateway. The look & feel, screens, and features are preserved; the wire and state layers are ours.

## What's in the app
- **Six expo-router screens**: chat (transcript with tool groups, streaming bubble, thinking indicator, message copy, attachment chips), sessions, permissions (ApprovalCard/AskSheet), goals (goal mode = setMode→setAutoApprove→runTurn, strictly ordered), settings (pairing panel, QR scanner via expo-camera, connection settings), workflows (list/enable/run).
- **28 components ported verbatim** from the reference design — NativeWind 4 classNames unchanged because the tailwind theme is derived 1:1 from `@moxxy/design-tokens` (the palettes already matched hex-for-hex).
- **Composer**: attachments (image/document/clipboard, 8 MB cap), voice recorder UI (gated on host transcriber availability), action menu, auto-approve toggle, /new + /compact, context meter.

## Architecture (the port, not a copy)
- **Transport**: `@moxxy/client-transport-ws` `WsRpcClient` with the wave-5 bearer `Sec-WebSocket-Protocol` auth — the QR's `?t=` is a *pairing payload*, stripped before connect; reconnect backoff + the terminal `disconnected` state surface in the connection banner.
- **State**: `client-core`'s `chatStore`/`askStore`/bridges composed under the reference's `useGatewayStore` facade — `protocol.ts` is a pure presenter over `MobileState`, not a re-implemented event fold. 20+ hooks keep the reference's exact interfaces.
- **Host** (`MobileSessionHost`): adds `session.setMode`, `session.newSession` (via the #129 `session.reset`), `session.runCommand` (zod-validated at the shared dispatch choke point — also closes the audit-noted desktop schema gap), `session.hasTranscriber`/`transcribe`, `workflows.list/setEnabled/run`, and **inline attachments** forwarded to `runTurn` (remote clients can't reference host paths — they upload via `saveImageAttachment` or send inline). Every new command is capability-detectable with a typed `not-supported` code so the UI degrades gracefully (voice button hidden, workflows empty-state) on hosts without the feature.
- **Pure-logic modules + tests ported**: transcript coalescing, tool-group/composer/context-meter UI state, navigation builders, attachment pipeline, pairing URL parsing (adapted to our QR format, with a test pinning agreement with `boot.splitConnectUrl`).

## Verification
- `apps/mobile`: **17 test files / 85 tests** green; typecheck clean
- `plugin-channel-mobile` 23 (6 new host tests incl. capability-absent paths), `desktop-ipc-contract` 19, `ipc-server-ws` 28, `client-core` 41, `client-transport-ws` 10
- Rebased on post-#133 main; workspace gate: build 0 / typecheck 0 / test 0 / lint 0 (explicit exit codes)
- **`expo export` bundle proof: 1558 modules, clean** (NativeWind + expo-router + monorepo metro resolution end-to-end)
- Changeset: patches for `plugin-channel-mobile` + `desktop-ipc-contract`; TECH_DEBT shared-client item updated (PoC superseded; port residue logged honestly)

Real-device pairing remains the one manual verify (same as before the port).