### PR TITLE
chore(dx): Claude skill library + harness hooks + README self-build story

### DIFF
--- a/.changeset/claude-skills-hooks.md
+++ b/.changeset/claude-skills-hooks.md
@@ -1,0 +1,4 @@
+---
+---
+
+Docs/tooling only: Claude Code skill library (`.claude/skills/`) + hooks (`.claude/settings.json`, `.claude/hooks/`). Releases nothing.

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,12 @@
+# Claude Code hooks for this repo
+
+Wired in `.claude/settings.json`. Design rule: **signal, not ceremony** — every
+hook must be near-free on the paths that don't need it.
+
+| Hook | Event | Cost | What it does |
+|---|---|---|---|
+| `gate-on-stop.sh` | Stop | ~10 ms clean / ~0.3–5 s dirty (warm turbo) | In a **linked worktree** with a **dirty tree**, runs `pnpm -w typecheck`; on failure blocks the stop (exit 2) with the first errors on stderr so the agent fixes before declaring done. Silent otherwise. Escape hatch: `MOXXY_SKIP_GATE=1`. |
+| `changeset-reminder.sh` | PostToolUse (`Edit\|MultiEdit\|Write`) | ~20–40 ms | If the edited file is under `packages/*` or `apps/*` and the branch carries no `.changeset/*.md` vs `origin/main`, prints a one-line reminder (exit 0, advisory, once per HEAD). |
+
+Build/lint/test stay manual — see `.claude/skills/run-the-gate/SKILL.md`.
+Scripts are POSIX sh; deps: git + pnpm (+ jq if present, grep fallback).

--- a/.claude/hooks/changeset-reminder.sh
+++ b/.claude/hooks/changeset-reminder.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# PostToolUse hook (Edit|Write): one-line changeset reminder. ADVISORY ONLY —
+# always exits 0, never blocks, prints at most one line.
+#
+# Purpose: every PR needs a `.changeset/*.md` (CI's "Changeset present" job
+# fails without one). When a package/app source file is edited and the branch
+# carries no changeset yet (vs origin/main, including untracked files), remind
+# once per state — not per edit (a marker keyed on HEAD keeps it quiet).
+#
+# Cost (measured 2026-06-10): ~20-40 ms (a few git plumbing calls; jq if
+# present, grep fallback otherwise; no pnpm, no network).
+
+# --- extract the edited file path from the hook's stdin JSON ---------------
+input=$(cat 2>/dev/null) || exit 0
+if command -v jq >/dev/null 2>&1; then
+  file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+else
+  file=$(printf '%s' "$input" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*:[[:space:]]*"//; s/"$//')
+fi
+[ -n "$file" ] || exit 0
+
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Only source under packages/* or apps/* counts as "shippable" change.
+rel=${file#"$root"/}
+case "$rel" in
+  packages/*|apps/*) ;;
+  *) exit 0 ;;
+esac
+
+# A changeset already on this branch (committed vs origin/main, staged, or
+# untracked)? README.md is the template, not a changeset.
+base=$(git merge-base origin/main HEAD 2>/dev/null) || base=""
+committed=""
+[ -n "$base" ] && committed=$(git diff --name-only --diff-filter=AM "$base"...HEAD -- '.changeset/*.md' 2>/dev/null | grep -v 'README\.md$')
+pending=$(git status --porcelain '.changeset/*.md' 2>/dev/null | grep -v 'README\.md' )
+[ -n "$committed$pending" ] && exit 0
+
+# Remind once per HEAD, not on every edit. (Use --git-dir: in a linked
+# worktree $root/.git is a pointer FILE, not a directory.)
+gitdir=$(git rev-parse --absolute-git-dir 2>/dev/null) || exit 0
+marker="$gitdir/moxxy-changeset-reminded"
+head=$(git rev-parse HEAD 2>/dev/null)
+[ -f "$marker" ] && [ "$(cat "$marker" 2>/dev/null)" = "$head" ] && exit 0
+printf '%s' "$head" > "$marker" 2>/dev/null
+
+echo "Reminder: no .changeset/*.md on this branch yet — every PR needs one (hand-write it; empty '---/---' header for no-release changes). See .claude/skills/add-a-changeset/SKILL.md."
+exit 0

--- a/.claude/hooks/gate-on-stop.sh
+++ b/.claude/hooks/gate-on-stop.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Stop hook: don't let an agent declare "done" with a broken typecheck.
+#
+# Purpose: when the agent stops with uncommitted changes in a git worktree,
+# run the turbo-cached `pnpm -w typecheck` and, on failure, block the stop
+# (exit 2) with a short summary on stderr so the failure feeds back to the
+# agent. Build/lint/test stay the agent's job (see the run-the-gate skill);
+# this hook only catches the cheapest, highest-signal breakage.
+#
+# Cost (measured 2026-06-10 on this repo):
+#   - clean tree / not a worktree / MOXXY_SKIP_GATE=1: ~10 ms (git calls only)
+#   - dirty tree, warm turbo cache: ~0.3-5 s
+#   - dirty tree, cold cache: up to ~60 s (hence the 180 s hook timeout)
+#
+# Escape hatch: MOXXY_SKIP_GATE=1 skips everything (use for docs-only stops
+# or when iterating on intentionally-broken code).
+
+[ "${MOXXY_SKIP_GATE:-}" = "1" ] && exit 0
+
+# Not a git checkout at all -> nothing to gate.
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+# Only gate LINKED worktrees (the repo convention is feature work in
+# .claude/worktrees/<name>); in the main checkout, stay silent.
+git_dir=$(git rev-parse --git-dir 2>/dev/null)
+common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
+[ "$git_dir" = "$common_dir" ] && exit 0
+
+# Clean tree -> the work (if any) is committed; trust CI from here.
+[ -z "$(git status --porcelain 2>/dev/null)" ] && exit 0
+
+out=$(pnpm -w typecheck 2>&1)
+status=$?
+[ "$status" -eq 0 ] && exit 0
+
+{
+  echo "Typecheck is broken in this worktree (pnpm -w typecheck, exit $status)."
+  echo "Fix it before stopping. First errors:"
+  # TS errors first; fall back to the tail if the failure isn't tsc-shaped.
+  errs=$(printf '%s\n' "$out" | grep -E 'error TS[0-9]+|: error' | head -15)
+  if [ -n "$errs" ]; then printf '%s\n' "$errs"; else printf '%s\n' "$out" | tail -15; fi
+  echo "(escape hatch: MOXXY_SKIP_GATE=1)"
+} >&2
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/gate-on-stop.sh",
+            "timeout": 180
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/changeset-reminder.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,55 @@
+# Claude Code skill library — moxxy
+
+One thin SKILL.md per task; read only what the task needs. Frontmatter
+`description` is the discovery trigger. Deep workflows stay in
+`.claude/agents/*`; these skills are the repo-true checklists + commands.
+
+<!-- To regenerate the table: for d in .claude/skills/*/; do awk -F': ' '/^name:/{n=$2} /^description:/{print "| "n" | "$2" |"}' "$d/SKILL.md"; done -->
+
+## Dev loop
+
+| Skill | Trigger |
+|---|---|
+| run-the-gate | Run build/typecheck/lint/test/deps before reporting done or opening a PR |
+| fix-a-failing-test | Fastest reproduce loop for one failing vitest suite/test |
+| rebase-and-resolve | Rebase onto latest main + resolve conflicts (incl. the TECH_DEBT.md hazard) |
+| open-a-pr | PR conventions: worktree branch, changeset, title format, no AI attribution |
+| add-a-changeset | The CI-required changeset: which packages, which bump, empty changesets |
+| run-the-cli | Run the locally-built moxxy binary for manual smokes / one-shot turns |
+
+## Extend the system
+
+| Skill | Trigger |
+|---|---|
+| add-a-plugin | New @moxxy/plugin-* package + discovery/bundling wiring |
+| add-a-tool | New model-callable tool: schema, permission, handler, secrets rules |
+| add-a-provider | New LLMProvider (model API / auth scheme) |
+| add-a-channel | New surface that drives a Session (TUI/Telegram/HTTP/WS-style) |
+| add-a-mode | New loop strategy (like default/goal/research) |
+| add-a-compactor | New context-compaction strategy |
+| add-a-cache-strategy | New prompt-cache breakpoint placement |
+| add-an-isolator | New capability Isolator (worker/subprocess/wasm/…) |
+| add-an-embedder | New embeddings provider for memory/recall |
+| add-a-skill-builtin | New Markdown skill in moxxy's own skills-builtin |
+| add-a-slash-command | New /command on the chat surfaces |
+| add-an-ipc-command | New desktop IPC command (contract + validation + host + WS/mobile) |
+| change-runner-protocol | Runner wire-protocol changes + RUNNER_PROTOCOL_VERSION bump rule |
+
+## Verify / debug
+
+| Skill | Trigger |
+|---|---|
+| verify-desktop-packaged | Packaged-app smoke: electron-builder --dir + launch + WS-bridge check |
+| verify-mobile | Expo PoC verification without a device (tests + export proof + pairing) |
+| debug-self-update | Tier-1 hot-update misbehavior via <userData>/app state files + boot-log |
+| debug-session-logs | Resume/desync/duplication issues in session JSONL + chat NDJSON |
+| debug-ws-bridge | WS bridge auth/origin/port/token failures (desktop + moxxy mobile) |
+
+## Process
+
+| Skill | Trigger |
+|---|---|
+| tech-debt-journal | Operating TECH_DEBT.md: read-before-work, retire ≥1, A-intake |
+| audit-wave | Deep audit pattern: parallel agents → adversarial verify → fix waves |
+| release-flow | Changesets → Version PR → safe-publish → desktop draft → self-update |
+| security-invariants | Load-bearing security rules every change must preserve |

--- a/.claude/skills/add-a-cache-strategy/SKILL.md
+++ b/.claude/skills/add-a-cache-strategy/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: add-a-cache-strategy
+description: Build a CacheStrategy (prompt-cache breakpoint placement) — use when changing where provider cache breakpoints go.
+---
+
+# Add a cache strategy
+
+Full workflow: **`.claude/agents/cache-strategy-author.md`**. Reference:
+`packages/cache-strategy-stable-prefix` (default; `none` = opt-out).
+
+Contract:
+- `defineCacheStrategy({ name, plan })`; `plan()` returns provider-neutral
+  `CacheHint`s: `{ target: 'tools' | 'system' | { messageIndex } }`. The
+  provider expresses them (Anthropic → `cache_control`).
+- **`plan()` MUST be deterministic for identical inputs.** A non-deterministic
+  breakpoint shifts the cached prefix between calls and silently defeats the
+  cache — you pay 1.25x writes for 0 reads.
+- **Respect `CacheStrategyContext.volatileTailMessageCount`** (A42): modes mark
+  per-iteration nudges volatile; place the rolling-tail breakpoint on the last
+  STABLE message, never on volatile tail content.
+- One strategy is active per session; registered like compactors
+  (`definePlugin({ cacheStrategies: [...] })` + `builtins.ts`), first
+  registered auto-activates.
+
+Test: assert breakpoint stability across repeated `plan()` calls with the same
+log, and that adding a volatile tail message does NOT move the tail breakpoint
+(`cache-strategy-stable-prefix/src/*.test.ts` has the pattern).
+
+Background on the token-efficiency direction (elision, recall, lazy tools):
+TECH_DEBT.md + `~/.claude/plans/i-d-like-to-improve-reflective-bear.md`.

--- a/.claude/skills/add-a-changeset/SKILL.md
+++ b/.claude/skills/add-a-changeset/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: add-a-changeset
+description: Add the changeset every PR requires (CI-enforced) and pick the right packages/bump — use on every PR, including docs-only ones.
+---
+
+# Add a changeset
+
+Every PR needs a `.changeset/*.md` — the CI job "Changeset present" fails the
+PR without one. Changesets drive ALL releases: npm publish, version bumps, AND
+the desktop installer.
+
+Hand-write `.changeset/<kebab-name>.md` (note: bare `pnpm changeset` does NOT
+work here — @changesets/cli isn't a workspace dep; it's `pnpm dlx
+@changesets/cli` or, simpler, write the file yourself):
+
+```md
+---
+'@moxxy/sdk': patch
+'@moxxy/cli': patch
+---
+
+One-line summary of the change (becomes the changelog entry).
+```
+
+Which packages to name:
+- **Published to npm:** only `@moxxy/sdk` and `@moxxy/cli`. Everything else is
+  `private` and tsup-bundled into the CLI binary — a change in any bundled
+  package (core, plugins, modes, …) ships via a **`@moxxy/cli`** bump.
+- **SDK type/API surface changed** → also name `@moxxy/sdk` (minor for new
+  exports, patch for fixes).
+- **`@moxxy/desktop`** is private but rides changesets: naming it cuts a
+  desktop installer release; a cli/sdk bump cascades a patch to it
+  automatically (`updateInternalDependencies: patch`).
+- **Releases nothing** (docs / CI / tests / .claude tooling) → empty changeset:
+  a file with an empty `---\n---` header + a summary line (or
+  `pnpm dlx @changesets/cli --empty`).
+
+Bump norms: `patch` for fixes/internal work, `minor` for new user-facing
+features or new SDK exports, `major` never so far (pre-1.0).
+
+Details: AGENTS.md → "Releasing (changesets)"; pipeline: release-flow skill.

--- a/.claude/skills/add-a-channel/SKILL.md
+++ b/.claude/skills/add-a-channel/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: add-a-channel
+description: Build a new Channel (a surface that drives a Session — TUI/Telegram/HTTP/WS-style) — use when adding a new way to talk to moxxy.
+---
+
+# Add a channel
+
+Full workflow: **`.claude/agents/channel-author.md`**. Repo-specific rules:
+
+- `defineChannel({ name, start, subcommands })`. Channels are the ONE plugin
+  kind allowed to import `@moxxy/core` (`Session`, `runTurn`,
+  `createDeferredPermissionResolver`).
+- **Filter event subscribers by `turnId`** — the shared `session.log` fans out
+  to every listener; concurrent turns cross-contaminate without it.
+- **Auth/pairing**: use the SDK channel-auth helpers — `resolveChannelToken`
+  ({ envVar, fileName, dir? } → env → config → generated secret persisted to
+  `~/.moxxy/<fileName>`), `rotateChannelToken`, and the bearer handshake
+  (Authorization header or `moxxy.bearer.<encoded>` WS subprotocol). Query
+  tokens off by default (A27). Browser-origin requests: default-deny unless
+  allow-listed.
+- **Validate every inbound frame/body with zod** before it touches the session
+  (A8); drop invalid/oversized input with a rate-limited warning.
+- **EADDRINUSE**: never kill the port holder without verifying its `ps`
+  command line carries a moxxy marker (A7); otherwise fall back to an
+  ephemeral port and log both ports.
+- **Permission prompts**: deny-by-default headless; interactive surfaces use
+  `createDeferredPermissionResolver`. Gate EVERY session-reaching path behind
+  pairing — Telegram's callback handlers once skipped it (A46).
+- `subcommands` give `moxxy channels <name> pair|status|...` for free;
+  `bin.ts` knows nothing about specific channels.
+- `/new` must call `SessionLike.reset?.()` and surface failure — a
+  mirror-only clear desyncs seq-contiguous ingest (A10).
+
+Reference impls: `plugin-channel-http` (auth + allow-list),
+`plugin-channel-mobile` (WS bridge + QR pairing), `plugin-telegram` (TOFU
+pairing). Register in `builtins.ts`; gate + changeset.

--- a/.claude/skills/add-a-compactor/SKILL.md
+++ b/.claude/skills/add-a-compactor/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: add-a-compactor
+description: Build a Compactor (context-window compaction strategy) — use when changing how old turns get summarized/elided.
+---
+
+# Add a compactor
+
+Full workflow: **`.claude/agents/compactor-author.md`**. Reference:
+`packages/compactor-summarize` (the default).
+
+Checklist:
+- `defineCompactor({ name, compact })`; register via a plugin
+  (`definePlugin({ compactors: [...] })`) — registry-swappable, first
+  registered auto-activates.
+- **Never mutate the event log.** Compaction appends a `compaction` event with
+  `replacedRange`; selectors honor it as a pure fold.
+- **Track the high-water mark**: resume after the prior
+  `CompactionEvent.replacedRange[1]` — re-scanning from index 0 layers nested
+  summaries.
+- **Summarize with the session's own provider/model** (handed in through
+  `CompactContext`); if no provider is reachable, fall back to an HONEST,
+  labeled digest with a one-time warning — never fabricate. `tokensSaved`
+  must come from real char deltas, not invented multipliers (A42b).
+- Compaction interacts with elision + cache strategy: shifting the prefix
+  invalidates the prompt cache, so compact at turn boundaries and keep
+  outputs deterministic where possible.
+
+Test pattern: feed a scripted log, assert the compaction event's range +
+that a second compact() doesn't re-summarize the summary
+(`compactor-summarize/src/*.test.ts`).

--- a/.claude/skills/add-a-mode/SKILL.md
+++ b/.claude/skills/add-a-mode/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: add-a-mode
+description: Build a new mode (loop strategy) package like default/goal/research — use when adding a new agentic-loop behavior.
+---
+
+# Add a mode
+
+Full workflow: **`.claude/agents/loop-strategy-author.md`**. Existing modes:
+`mode-default` (ReAct), `mode-goal` (autonomous auto-approve), 
+`mode-deep-research` (fan-out + synthesis). The FIRST registered mode
+auto-activates — registration order in `packages/cli/src/setup/builtins.ts`
+matters.
+
+Checklist:
+- `defineMode({ name, run })` in a new `packages/mode-<name>/` package
+  (add-a-plugin skill for scaffolding/wiring).
+- **Compose the SDK loop helpers** — do not hand-roll the tool batch loop:
+  `executeToolUses` + `emitRequestsAndDetectStuck` (`sdk/src/tool-dispatch.ts`,
+  parameterized by your `StuckLoopReport`) carry the load-bearing
+  orphaned-tool_call_requested fix; `collectProviderStream`,
+  `projectMessagesFromLog`, `runSingleShotTurn` for the provider side.
+- **Auto-approve must still consult policy**: call the resolver's prompt-free
+  `policyCheck` before allowing (A3, goal-mode lesson) — replacing the
+  resolver with unconditional-allow discards the user's
+  `~/.moxxy/permissions.json` deny rules.
+- **Skip whitespace-only assistant messages** when emitting (A26) — empty text
+  blocks wedge provider replays.
+- Volatile per-iteration nudges: mark them via
+  `CacheStrategyContext.volatileTailMessageCount` so they don't defeat the
+  stable-prefix cache (A42).
+- Overflow → reactive compaction handling: copy the pattern from
+  `mode-default`'s loop (currently per-mode by design).
+- `zod` used at runtime ⇒ `dependencies`, not dev (A21).
+
+Tests: mode packages have full loop tests with FakeProvider — mirror
+`packages/mode-goal/src/*.test.ts` (incl. a deny-under-auto-approve case).

--- a/.claude/skills/add-a-plugin/SKILL.md
+++ b/.claude/skills/add-a-plugin/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: add-a-plugin
+description: Create a new @moxxy/plugin-* package (workspace or user-scope) and wire it for discovery — use when adding any new plugin to moxxy.
+---
+
+# Add a plugin
+
+Full workflow with scaffold templates: **`.claude/agents/plugin-author.md`** —
+read it; this skill is the wiring checklist.
+
+User-scope (no workspace edits): `moxxy plugins new <name>` →
+`~/.moxxy/plugins/<name>/`, then `moxxy plugins reload`.
+
+Workspace plugin — `packages/plugin-<thing>/`:
+
+1. `package.json`: name `@moxxy/plugin-<thing>`, `"private": true`,
+   `"type": "module"`, manifest `"moxxy": { "plugin": { "entry": "./src/index.ts" } }`,
+   dep on `@moxxy/sdk` (`workspace:*`). Runtime deps (e.g. `zod`) go in
+   `dependencies`, NOT devDependencies — audit items A20/A21 were exactly that
+   bug.
+2. `src/index.ts`: `definePlugin({ name, tools, providers, channels,
+   compactors, cacheStrategies, isolators, commands, hooks, skillsDir, ... })`.
+3. Register: add the package to `packages/cli/package.json` dependencies AND
+   import/instantiate it in `packages/cli/src/setup/builtins.ts` (in-repo
+   plugins are statically registered there; tsup auto-bundles every workspace
+   dep into the binary — only sdk/zod/keyring/playwright/transformers stay
+   external, see `packages/cli/tsup.config.ts`).
+4. `pnpm check:deps` — invariants: plugins MAY import `@moxxy/core` only if
+   they're channels; loop-runtime plugins (modes/compactors/providers) must
+   not. Core never imports a plugin — pass services via closure
+   (`buildXPlugin(deps)` pattern, see `buildSynthesizeSkillPlugin`).
+5. Lifecycle hooks must be WIRED, not just declared (`onEvent` needs the
+   subscribe→dispatch wiring; `onShutdown` needs `Session.close()`).
+6. Gate + changeset (`@moxxy/cli` patch/minor — plugins ship inside it).
+
+Make new cross-cutting strategies registry-backed swappable blocks (mirror
+CompactorRegistry), not hardcoded behavior.

--- a/.claude/skills/add-a-provider/SKILL.md
+++ b/.claude/skills/add-a-provider/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: add-a-provider
+description: Implement an LLMProvider plugin for a new model API — use when adding support for a new LLM vendor or auth scheme.
+---
+
+# Add a provider
+
+Full workflow: **`.claude/agents/provider-author.md`**. Repo-specific contract
+points (each one was an audit finding — don't re-break them):
+
+- `defineProvider(spec)` with `createClient`; register via
+  `definePlugin({ providers: [...] })` + `packages/cli/src/setup/builtins.ts`.
+- **Compose SDK helpers**: `collectProviderStream`, `isRetryableError`,
+  `classifyHttpStatus` (map HTTP status → typed MoxxyError), `zodToJsonSchema`
+  for tool specs. Don't reimplement.
+- **`req.system` is ADDITIVE** (A38): deliver it in addition to system-role
+  messages (anthropic: extra uncached system block after the cache breakpoint;
+  openai: extra system message; codex: appended to `instructions`). Silently
+  dropping it kills hook-injected nudges.
+- **Honor `req.maxTokens` / `req.temperature`** or document-and-warn why not
+  (A36) — never a silent drop.
+- **Express `CacheHint`s** from the active CacheStrategy (anthropic →
+  `cache_control`). Keep expression deterministic.
+- **Model descriptors matter**: an unlisted model id must not silently fall
+  back to `models[0]` semantics (broke auto-elision once, PR #101). Report a
+  real model catalog + vendor slug for usage attribution (A37).
+- **Key resolution**: config.apiKey → vault → `<PROVIDER>_API_KEY` env →
+  prompt. OAuth/rotating tokens: serialize refresh+persist with
+  `withCredentialLock` from plugin-oauth (A18) — single-use refresh tokens
+  corrupt without it.
+- Retry transient 5xx on token endpoints (Anthropic OAuth 500s, PR #99).
+
+Runtime alternative: an OpenAI-compatible vendor needs NO code — the
+`provider_add` tool / add-provider skill registers it into
+`~/.moxxy/providers.json`.
+
+Test with `@moxxy/testing` record/replay (`MOXXY_FIXTURES=record` once, commit
+fixtures). Reference impls: `plugin-provider-anthropic` (API key + cache),
+`plugin-provider-claude-code` (OAuth bearer), `plugin-provider-openai-codex`
+(Responses API).

--- a/.claude/skills/add-a-skill-builtin/SKILL.md
+++ b/.claude/skills/add-a-skill-builtin/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: add-a-skill-builtin
+description: Add a Markdown skill to moxxy's own built-in skill set (packages/skills-builtin) — use when the moxxy agent should gain a new prompt-only capability.
+---
+
+# Add a built-in moxxy skill
+
+These are MOXXY's runtime skills (what the moxxy agent loads), not this
+`.claude/skills` library. Full authoring guide:
+**`.claude/agents/skill-author.md`**.
+
+Format — one flat file `packages/skills-builtin/skills/<name>.md`:
+
+```md
+---
+name: vault-setup
+description: One sentence — what + when (drives skill matching).
+triggers: ["set up vault", "store a secret"]
+allowed-tools: [vault_status, vault_list]
+---
+# Body: imperative prompt instructions. PROMPT-ONLY — never executable code.
+```
+
+Rules:
+- Skills are Claude Code-compatible MD + YAML frontmatter; resolution order is
+  project `./.moxxy/skills/` → user `~/.moxxy/skills/` (auto-synthesized
+  skills land here) → plugin `skillsDir` → `@moxxy/skills-builtin` (lowest
+  precedence — a user file with the same name shadows yours).
+- `triggers` are the match phrases; keep them concrete. No matching skill →
+  the loop synthesizes one (`synthesize_skill`), so missing triggers degrade
+  gracefully but burn a synthesis.
+- If the skill needs a secret, instruct the vault flow (`${vault:NAME}`
+  refs, never plaintext) — see `vault-setup.md` as the canonical example.
+- Plugin-owned skills: ship them in the plugin via
+  `definePlugin({ skillsDir })` instead of skills-builtin.
+
+Ship: `pnpm build` (the CLI bundles the builtin skills dir —
+`packages/cli/src/setup/builtin-skills-dir.ts` resolves it), smoke with
+`node packages/cli/dist/bin.js skills list`, changeset (`@moxxy/cli` patch).

--- a/.claude/skills/add-a-slash-command/SKILL.md
+++ b/.claude/skills/add-a-slash-command/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: add-a-slash-command
+description: Add a /slash command to moxxy's chat surfaces (TUI/desktop/Telegram) — use for new session-level user commands like /info or /compact.
+---
+
+# Add a slash command
+
+Built-ins live in `packages/plugin-commands/src/index.ts` (`/info`, `/clear`,
+`/new`, `/compact`, `/exit`, `/help`).
+
+```ts
+const myCmd: CommandDef = {           // CommandDef from @moxxy/sdk
+  name: 'mything',                    // → /mything
+  description: 'Shown in /help.',
+  handler: ({ session, args }) => {
+    // return { kind: 'text', text } or { kind: 'session-action', action, notice }
+  },
+};
+```
+
+Wire: add to the plugin's `commands: [...]` array (plugin-commands for
+general-purpose; your own plugin's `definePlugin({ commands })` for
+feature-scoped ones, e.g. vault's `/vault`).
+
+Rules:
+- Handlers receive the SESSION — type against the minimal structural slice you
+  need (see `SessionShape` in plugin-commands) and use optional chaining for
+  capabilities a `RemoteSession` may lack (TECH_DEBT P1 #1).
+- Commands run on every surface (TUI, desktop, Telegram) — no Ink/DOM
+  imports; return data, let the surface render.
+- Destructive actions must verify, not assume: `/new` calls
+  `SessionLike.reset?.()` and reports failure instead of claiming success
+  (A10).
+- `defineCommand` (SDK) freezes the spec — use it for new code.
+
+Test: `plugin-commands/src/commands.test.ts` pattern — fake session, assert
+the returned CommandOutput. Then gate + changeset (`@moxxy/cli`).

--- a/.claude/skills/add-a-tool/SKILL.md
+++ b/.claude/skills/add-a-tool/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: add-a-tool
+description: Add one model-callable tool to a plugin (schema, permission, handler, test) — use when the agent needs a new capability.
+---
+
+# Add a tool
+
+Full discipline + anatomy: **`.claude/agents/tool-author.md`**. Checklist:
+
+```ts
+import { defineTool, z } from '@moxxy/sdk';
+export const myTool = defineTool({
+  name: 'my_tool',
+  description: 'One sentence, verb first — the model reads this.',
+  inputSchema: z.object({ ... }),       // strict; no z.any()/z.unknown() at top level
+  permission: { action: 'prompt' },     // allow | deny | prompt — side effects ⇒ prompt
+  handler: async (input, ctx) => { ... },
+});
+```
+
+Rules that have bitten before:
+- **Respect `ctx.signal`** (abort) and **use `ctx.cwd`**, never `process.cwd()`.
+- **Never put secrets in tool inputs/outputs** — they transit the model's
+  context and persist in session logs. Take a vault key NAME and resolve via
+  `ctx.getSecret` (audit A6), or write secrets to a 0600 file and return the
+  path (A15). `${vault:NAME}` placeholders resolve at use time (A43).
+- **Don't bypass the permission engine** — no ad-hoc "is this safe" checks in
+  handlers; gating happens in dispatchToolCall + PermissionEngine + resolver.
+- Long output: clamp/truncate while streaming, don't buffer unboundedly (A17).
+- Subprocesses: spawn detached + signal the whole process group on
+  timeout/abort, SIGTERM → grace → SIGKILL (A16, `tools-builtin/src/bash.ts`).
+
+Wire it: add to the owning plugin's `definePlugin({ tools: [...] })`. New
+tool family with no home → new plugin (add-a-plugin skill).
+
+Test: colocated `*.test.ts`; call the handler directly with a fake ctx, plus
+one schema-rejects-bad-input case. Then `pnpm build` + changeset.

--- a/.claude/skills/add-an-embedder/SKILL.md
+++ b/.claude/skills/add-an-embedder/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: add-an-embedder
+description: Add an embedding provider (Embedder) for memory/recall — use when wiring a new embeddings API or on-device model.
+---
+
+# Add an embedder
+
+Existing impls: `plugin-embeddings-openai` (API) and
+`plugin-embeddings-transformers` (on-device, xenova).
+
+Checklist:
+- `defineEmbedder({ name, ... })` from `@moxxy/sdk`; contribute via
+  `definePlugin({ embedders: [...] })` → `EmbedderRegistry`; register in
+  `packages/cli/src/setup/builtins.ts`.
+- **Wrap with `CachedEmbeddingProvider`** (SDK) instead of rolling a cache —
+  and keep cache keys MODEL-SCOPED (`<vendor>:<model>`): unscoped keys
+  collided across models once (audit phase 5).
+- Heavy model deps (transformers) stay external to the CLI bundle — check
+  `packages/cli/tsup.config.ts` `external` before adding a native/huge dep.
+- Key resolution like providers: vault first, then env (add-a-provider skill).
+
+Consumer to know about: `plugin-memory` (TF-IDF/vector recall) still uses its
+own `EmbeddingIndex` cache — TECH_DEBT.md P3 #6; if you touch its recall path
+anyway, fold in `CachedEmbeddingProvider`.
+
+Test: deterministic vectors via a fake fetch / tiny fixture; assert cache
+hits skip the upstream call (`sdk/src/embedding-cache.ts` tests show the
+contract).

--- a/.claude/skills/add-an-ipc-command/SKILL.md
+++ b/.claude/skills/add-an-ipc-command/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: add-an-ipc-command
+description: Add a command to the desktop IPC contract (renderer↔main, also served over the WS bridge and to mobile) — use when the desktop/mobile UI needs a new backend call.
+---
+
+# Add an IPC command
+
+The contract is transport-neutral: one definition serves Electron IPC, the
+desktop's WS bridge, AND `moxxy mobile`. Checklist (in order):
+
+1. **Contract** — `packages/desktop-ipc-contract/src/index.ts`: add the
+   command to `IpcCommands` (name + payload/return types). Naming:
+   `<domain>.<verb>` (`session.runTurn`, `app.checkUpdate`).
+2. **Validation** — `packages/desktop-ipc-contract/src/validation.ts`: if the
+   command touches fs / child process / vault / openExternal / URLs, add a zod
+   schema. Compile-time types do NOT protect main from an XSS'd renderer;
+   only "dangerous" commands are listed, deliberately.
+3. **Handler** — `packages/desktop-host/src/ipc/<domain>.ts`: register inside
+   that domain's `register<Domain>Handlers(...)` via the shared `handle()`
+   choke point (`ipc/shared.ts:127`) — it runs validation + wraps errors into
+   the stable `MoxxyIpcError` envelope. Handlers register against the
+   `CommandBus` seam (`desktop-ipc-contract/src/bus.ts`) and never see the
+   transport.
+4. **Transports** — Electron bus + WS bridge (`@moxxy/ipc-server-ws`) reuse
+   the same registrars: nothing extra IF your handler is in a registrar both
+   call. **Mobile check**: `packages/plugin-channel-mobile/src/
+   single-session-host.ts` `register()` wires a curated subset — add yours
+   there if `moxxy mobile` clients need it (degrade gracefully if not).
+5. **Client** — renderer/mobile call through `MoxxyApi.invoke` /
+   `window.moxxy`; shared hooks live in `packages/client-core` (DOM-free!
+   platform specifics go through the capability registry).
+6. Main→renderer events instead: `IpcEvents` + `EventSink.broadcast` —
+   payloads carry `workspaceId` for client-side routing.
+
+Notes:
+- Renderer+main always ship in the same Tier-1 bundle, so renaming/removing
+  IPC commands is SAFE across self-update (no skew) — unlike the runner
+  protocol (see change-runner-protocol skill).
+- Test: validation cases in `validation.test.ts`, dispatch in
+  `dispatch.test.ts`; handler tests in desktop-host.

--- a/.claude/skills/add-an-isolator/SKILL.md
+++ b/.claude/skills/add-an-isolator/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: add-an-isolator
+description: Add a capability Isolator implementation (worker/subprocess/wasm/docker-style) — use when extending the opt-in plugin-security isolation.
+---
+
+# Add an isolator
+
+Full workflow: **`.claude/agents/isolator-author.md`**. Existing impls, in
+increasing strength: `isolator-worker` (worker_threads: memory/time/JS-state),
+`isolator-subprocess` (kernel process boundary), `isolator-wasm` (zero ambient
+authority, experimental). `@moxxy/plugin-security` owns the `Isolator`
+interface + the `none`/`inproc` baselines and the capability broker.
+
+Checklist:
+- Implement the `Isolator` interface from `@moxxy/plugin-security`; contribute
+  it via `definePlugin({ isolators: [myIsolator] })` (PluginSpec.isolators →
+  ContributedIsolatorRegistry → `session.isolators`).
+- Register in `packages/cli/src/setup/builtins.ts` like the existing three.
+- Isolation is **off by default** (opt-in per capability spec) — never make a
+  new isolator the silent default.
+- The broker gates exec allowlists and capability grants — keep all
+  policy decisions in the broker, the isolator only ENFORCES a boundary.
+- Time + memory limits must actually kill the workload (test both); a
+  subprocess isolator must signal the whole process group (the A16 lesson).
+- Audit CLI: `moxxy security audit` surfaces what's isolated — keep its
+  output truthful for the new isolator.
+
+Tests: each existing isolator package has boundary tests (state leakage,
+timeout kill, denied capability) — mirror `isolator-worker/src/*.test.ts`.

--- a/.claude/skills/audit-wave/SKILL.md
+++ b/.claude/skills/audit-wave/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: audit-wave
+description: Run the repo's audit→verify→fix-in-waves pattern (parallel area agents, adversarial verification, one PR per wave) — use for a deep quality/security pass or batch-fixing confirmed findings.
+---
+
+# Audit wave
+
+The pattern that produced A1–A47 (all fixed across PRs #126–#133). Worked
+example + method: `.claude/audits/main-audit-2026-06-09.md`.
+
+## Audit pass
+1. Pin a base sha; audit THAT, not a moving main.
+2. Fan out parallel area auditors (one per subsystem: core, sdk, each plugin
+   cluster, desktop, runner, CI/release…). **Every auditor reads TECH_DEBT.md
+   first** — "finding" means NOT already journaled.
+3. **Adversarial verification:** every critical/high finding goes to an
+   independent verifier explicitly instructed to REFUTE it (read the code,
+   prove it can't happen). Expect a real refute rate (~5/19 in the 06-09
+   audit) — unverified findings waste fix waves.
+4. Write the report to `.claude/audits/<name>.md`: confirmed findings with
+   file:line + blast radius + fix sketch; refuted findings WITH the refutation
+   (so the next audit doesn't re-raise them); medium/low backlog.
+5. Intake confirmed items into TECH_DEBT.md as A-numbered entries
+   (tech-debt-journal skill).
+
+## Fix waves
+- Group confirmed findings into coherent waves (~4-8 items: by subsystem or
+  theme), one worktree + branch + PR per wave (`git worktree add` under
+  `.claude/worktrees/`).
+- Within a wave, parallel fix agents are fine but serialize edits to shared
+  files (TECH_DEBT.md last, once, by the integrator).
+- Each fix: code + a pinning test + the TECH_DEBT entry flipped to
+  "✅ FIXED (this PR)" with the mechanism described.
+- Full gate per wave (run-the-gate skill) + changeset → PR → **merge on
+  green before cutting the next wave's worktree** (waves often touch
+  neighboring lines; stacking unmerged waves breeds conflicts).
+- Release blockers (an A1-class regression) jump the queue as their own
+  minimal PR.

--- a/.claude/skills/change-runner-protocol/SKILL.md
+++ b/.claude/skills/change-runner-protocol/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: change-runner-protocol
+description: Change the runner↔thin-client wire protocol (RunnerMethod, notifications) and bump RUNNER_PROTOCOL_VERSION correctly — use for any packages/runner protocol edit.
+---
+
+# Change the runner protocol
+
+The contract lives in `packages/runner/src/protocol.ts`
+(`RUNNER_PROTOCOL_VERSION`, currently 3; `RunnerMethod`; zod param schemas).
+Clients: TUI, desktop supervisor, anything using `connectRemoteSession`.
+
+Rules:
+- **Additive + tolerated by old peers** (new optional field, new method the
+  server can 404 cleanly) → NO bump needed.
+- **Incompatible** (changed semantics, required new method for correctness —
+  e.g. v3's `session.reset`, PR #129) → bump `RUNNER_PROTOCOL_VERSION` AND
+  document the change in the version-history docstring right above it
+  (`v2: ...`, `v3: ...` — keep the convention).
+- `attach` exchanges versions; mismatch fails LOUDLY server-side
+  (`server.ts:187`) — never let a stale peer limp along.
+
+Mismatch recovery expectations (`remote-session.ts:643+`): on "protocol
+mismatch" the CLIENT proactively kills the stale daemon and unlinks the
+socket — but only after verifying the holder's `ps` line carries a moxxy
+marker (never kill-by-port blind, A7); it also frees default port 4040 (web
+surface). Callers retry/self-host on a clean slate. Opt-outs:
+`skipMismatchRecovery`, injected transports skip it automatically. If you
+change attach/recovery, keep `MOXXY_RUNNER_STRICT_ABORT` and the
+socket-dir-0700-before-listen hardening intact (A31).
+
+Also update:
+- `RemoteSession` (client) + `server.ts` (server) + `SessionLike` optional
+  member if it's a new capability (capability-detection: clients must degrade
+  when the member is undefined, not crash).
+- Desktop: runner pool/supervisor in `packages/desktop-host` consumes the
+  protocol — check `runner-supervisor.ts`.
+- Tests: `packages/runner/src/integration.test.ts` pins the handshake +
+  per-method behavior; add a case for your change and a mismatch test if you
+  bumped.
+
+Changeset: `@moxxy/cli` (runner is bundled) + `@moxxy/desktop` if the desktop
+must pick it up.

--- a/.claude/skills/debug-self-update/SKILL.md
+++ b/.claude/skills/debug-self-update/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: debug-self-update
+description: Diagnose desktop self-update problems (update downloads but reverts, stuck on floor, rollback loops) from the on-disk state files — use for any Tier-1 hot-update misbehavior.
+---
+
+# Debug desktop self-update
+
+Full design: `docs/desktop-self-update.md`. State lives in `<userData>/app/`
+(macOS: `~/Library/Application Support/MoxxyAI Workspaces/app/`):
+
+| File | Meaning |
+|---|---|
+| `active.json` | which staged bundle the bootstrap should load |
+| `confirmed.json` | last version that PROVED healthy (DOM render confirmed) |
+| `bad.json` | poisoned versions — bootstrap refuses them forever |
+| `last-attempt.json` | breadcrumb written before loading an override; survives a crash |
+| `boot-log.json` | rolling 50-entry decision log: every boot/probe/confirm/reject + structured WHY |
+| `<version>/` | one dir per staged bundle |
+
+Read `boot-log.json` FIRST — reject reasons are structured:
+`bad-signature`, `file-tampered` (per-file sha256 map mismatch — the signed
+`files` map is re-verified at EVERY load; legacy pre-map manifests are
+grandfathered and not load-checked), version/ABI gate failures, probe
+timeouts.
+
+Classic signatures:
+- **Every staged version in `bad.json`, `confirmed.json` missing** → the
+  health confirm never lands. Was the renderer-heartbeat bug (PR #115); now
+  main polls the DOM (`#splash-fallback` replaced on React mount). Suspect
+  anything that delays first render >15s.
+- **Update "succeeds" then 404s on download** → release left as DRAFT. The
+  stager resolves the semver-highest PUBLISHED `desktop-v*` release via the
+  GitHub API (skips drafts/prereleases; never `releases/latest`). Publish it.
+- **Hot bundle fails but floor works** → externalized workspace dep (A1) —
+  see verify-desktop-packaged skill.
+
+Tools:
+- In-app: update dashboard → Diagnostics (`app.updateDiagnostics` IPC).
+- Tests: `pnpm --filter @moxxy/desktop-host test app-update` (full
+  build→stage→load round-trip incl. rollback).
+- Dev override: `MOXXY_UPDATE_URL` (non-packaged runs only, by design).
+- Recovery on a poisoned machine: delete `bad.json` + `active.json` to force
+  the floor, or stage a fixed release — the fix must live in the OVERRIDE's
+  main to stick.

--- a/.claude/skills/debug-session-logs/SKILL.md
+++ b/.claude/skills/debug-session-logs/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: debug-session-logs
+description: Inspect and repair session event logs and desktop chat NDJSON (resume bugs, lost context, duplicated history) — use when a conversation resumes wrong or a mirror desyncs.
+---
+
+# Debug session logs
+
+Two independent stores persist every desktop conversation (known debt,
+TECH_DEBT P1 #2):
+
+1. **Runner session log** — `~/.moxxy/sessions/<id>.jsonl`. Authoritative
+   append-only event log; replayed IN FULL from seq 0 on every attach.
+2. **Desktop chat NDJSON** — `~/.moxxy/chats/<workspaceId>.jsonl`
+   (`desktop-host/src/chat-log.ts`). The renderer's windowed mirror;
+   append is idempotent by event id (PR #107) with a byte-offset page index
+   (A40).
+
+What the runtime already self-heals (don't re-fix):
+- **Corrupt middle line** in a session log: `restoreEvents` skips it,
+  re-sequences in-memory events to contiguous seq 0..n-1, warns with counts,
+  and atomically REWRITES the repaired JSONL (A25). A truncated replay at a
+  gap means you're on a pre-A25 build.
+- **Write failures**: persistence latches a `degraded` flag + one structured
+  warn per failure streak (A24) — check stderr JSON.
+- **`/new` / session.reset**: aborts in-flight turns, clears the runner log,
+  broadcasts `session.reset` so every mirror clears in lockstep, truncates the
+  JSONL (protocol v3, A10). Old context resurrecting on `--resume` = reset
+  didn't reach the runner (renderer cleared first — the remaining desync
+  window, P1 #2).
+
+Inspect:
+```sh
+ls -lat ~/.moxxy/sessions/ | head            # newest session ids
+tail -3 ~/.moxxy/sessions/<id>.jsonl | jq .  # events: {seq, id, type, ...}
+jq -r .type ~/.moxxy/sessions/<id>.jsonl | sort | uniq -c   # shape of the log
+```
+
+Rules when fixing: the log is APPEND-ONLY (compaction/elision are events with
+`replacedRange`, selectors are pure folds); duplicated desktop history =
+id-dedup cache regression, not a reason to dedupe at render time.

--- a/.claude/skills/debug-ws-bridge/SKILL.md
+++ b/.claude/skills/debug-ws-bridge/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: debug-ws-bridge
+description: Diagnose WebSocket-bridge connection failures (desktop MOXXY_WS_BRIDGE or moxxy mobile) — auth rejects, origin denials, port/token confusion.
+---
+
+# Debug the WS bridge
+
+Two deployments of the same `@moxxy/ipc-server-ws` server:
+
+| | Enable | Token (precedence) | Default port |
+|---|---|---|---|
+| Desktop | `MOXXY_WS_BRIDGE=1` (guarded dynamic import — off = not even loaded) | `MOXXY_WS_TOKEN` env → `<userData>/ws-token` file (generated once) | 8765 (`MOXXY_WS_PORT`; empty string = unset, NOT port 0) |
+| `moxxy mobile` | the channel itself | `MOXXY_MOBILE_TOKEN` env → `channels.mobile.token` config → `~/.moxxy/mobile-token` | 8765 (`MOXXY_MOBILE_HOST` for LAN bind) |
+
+Auth handshake (sdk channel-auth helpers):
+- Token travels as `Authorization: Bearer <t>` **or** WS subprotocol
+  `moxxy.bearer.<encoded>` (browser clients can't set headers).
+- `?t=` query token is OFF by default (`MOXXY_WS_ALLOW_QUERY_TOKEN=1` re-enables;
+  the mobile QR embeds `?t=` only as a pairing payload — the app strips it).
+- Requests with a browser `Origin` header: default-DENY unless allow-listed
+  (`allowedOrigins`); native clients send none. "Works from node, 403 from a
+  web page" = this, working as intended.
+
+Checklist:
+```sh
+lsof -nP -iTCP:8765 -sTCP:LISTEN        # is it bound, and by whom
+cat "~/Library/Application Support/MoxxyAI Workspaces/ws-token"   # desktop token
+cat ~/.moxxy/mobile-token                # mobile pairing secret
+```
+- Token mismatch after "rotation": env token wins at every resolve — rotate it
+  at the source. Rotation (`rotateWsBridgeToken` / `rotateAuthToken`)
+  terminates all live connections by design.
+- Sudden disconnects under load: SlowReaderGuard kills sockets whose backlog
+  stays >4MB past 10s (A29); connection cap is 8 at the handshake.
+- Client gives up after ~10 backoff retries with terminal `disconnected`
+  status (A28) — that's the WsRpcClient, not the server.
+- Bound port is reported from `wss.address()` — trust the log line, not the
+  config.

--- a/.claude/skills/fix-a-failing-test/SKILL.md
+++ b/.claude/skills/fix-a-failing-test/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: fix-a-failing-test
+description: Locate, run, and filter a single failing vitest suite or test — use when a test fails and you need the fastest reproduce loop.
+---
+
+# Fix a failing test
+
+Tests are colocated: `packages/<pkg>/src/*.test.ts`, run by vitest per package.
+
+```sh
+pnpm --filter @moxxy/sdk test                  # one package's whole suite
+pnpm --filter @moxxy/sdk test stuck-loop       # only files matching "stuck-loop"
+pnpm --filter @moxxy/sdk test -t "repeats"     # only test TITLES matching
+pnpm --filter @moxxy/sdk exec vitest run src/stuck-loop.test.ts  # exact file
+```
+
+Gotchas:
+- Do **NOT** insert `--` before vitest flags (`pnpm ... test -- -t x` silently
+  drops the filter and runs everything). pnpm forwards args as-is.
+- `-t` matches test titles, positional args match file paths. "138 skipped,
+  0 passed" means your `-t` pattern matched nothing.
+- Root `pnpm test` additionally runs `pnpm test:scripts`
+  (`node --test scripts/*.test.mjs` — safe-publish helpers).
+
+Provider-shaped tests use `@moxxy/testing`:
+- `FakeProvider` for scripted turns; record/replay harness keyed by
+  `MOXXY_FIXTURES` = `replay` (default) | `record` | `passthrough`.
+- "Fixture missing" error → re-run that suite with `MOXXY_FIXTURES=record`
+  and a real key, commit the fixture.
+
+Conventions:
+- Network/port tests bind port 0 (ephemeral) — never a fixed port (EADDRINUSE
+  flake, fixed in PR #123). Follow that in new tests.
+- Desktop self-update suite: `pnpm --filter @moxxy/desktop-host test app-update`.
+- If a fix touches a package without tests for that path, add one — audit
+  waves repeatedly found zero-coverage regressions (see TECH_DEBT.md).

--- a/.claude/skills/open-a-pr/SKILL.md
+++ b/.claude/skills/open-a-pr/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: open-a-pr
+description: Open a PR following this repo's conventions (worktree branch, changeset, title format, no AI attribution) — use when work is ready for review.
+---
+
+# Open a PR
+
+Pre-flight, in order:
+
+1. Work lives in a dedicated worktree under `.claude/worktrees/<name>` on its
+   own branch — never commit on `main` directly.
+2. Rebase onto latest `origin/main` (see rebase-and-resolve skill).
+3. Run the full gate (see run-the-gate skill) — all green.
+4. A `.changeset/*.md` exists (see add-a-changeset skill) — CI hard-fails
+   without one.
+5. TECH_DEBT.md: retire ≥1 item or log what you saw (see tech-debt-journal
+   skill).
+
+```sh
+git push -u origin <branch>
+gh pr create --title "<type>(<scope>): <summary>" --body "$(cat <<'EOF'
+## What
+...
+
+## Why
+...
+
+## Verification
+- pnpm build / typecheck / test / lint / check:deps green
+- <manual verification if any>
+EOF
+)"
+```
+
+Conventions:
+- **Title:** conventional-commit style, matching history — `fix(desktop): ...`,
+  `feat(client): ...`, `chore(mobile): ...`, `docs(tech-debt): ...`,
+  `refactor(modes): ...`. Check `git log --oneline -20` for the house style.
+- **No AI attribution.** Never add `Co-Authored-By: Claude`, "Generated with
+  Claude Code", or any robot footer to commits or PR bodies. The user is the
+  sole author.
+- **Squash-merge is the norm** — one PR squashes to one commit on main titled
+  like the PR, so the PR title IS the future commit message. Make it carry the
+  whole story.
+- PR body says what was verified, not just what changed.

--- a/.claude/skills/rebase-and-resolve/SKILL.md
+++ b/.claude/skills/rebase-and-resolve/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: rebase-and-resolve
+description: Rebase a feature branch onto latest main and resolve conflicts safely — use at task start, before final verify, and whenever main has moved.
+---
+
+# Rebase and resolve
+
+Keep feature branches rebased onto latest main at task START and again BEFORE
+the final verify/PR — requested changes regress otherwise.
+
+```sh
+git fetch origin
+git rebase origin/main          # interactive -i is not available in this env
+# per conflict: edit, git add <file>, git rebase --continue
+```
+
+After any rebase that moved main:
+
+```sh
+pnpm install    # only if pnpm-lock.yaml changed
+pnpm build && pnpm test
+```
+
+## The TECH_DEBT.md hazard (learned the hard way)
+
+`TECH_DEBT.md` is the one file where a stale merge silently LIES: PRs #113/#115
+rebuilt it from a pre-#107/#108 base and resurrected two already-retired items.
+Rules when it conflicts (or when editing it on a long-lived branch):
+
+- **Rebase it against main FIRST, then re-apply your edits on top.** Never
+  resolve by keeping your branch's whole-file version.
+- **Keep the ✅ side.** If one side marks an item FIXED/retired and the other
+  still lists it open, the ✅ side wins (verify against the code if unsure).
+- Resolved entries move to the "Resolved ledger" — make sure the merge didn't
+  drop ledger lines.
+
+## Other conflict-prone files
+
+- `pnpm-lock.yaml`: don't hand-merge — take MAIN's version (during a rebase
+  that is `git checkout --ours pnpm-lock.yaml`; ours/theirs invert under
+  rebase), then `pnpm install` regenerates your deps into it.
+- `.changeset/*.md`: keep both sides' files; they're independent.
+- `CHANGELOG.md` / `package.json` versions: take main's (changesets owns them).

--- a/.claude/skills/release-flow/SKILL.md
+++ b/.claude/skills/release-flow/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: release-flow
+description: Understand/operate the release pipeline (changesets → Version PR → npm publish → desktop installers → self-update pickup) — use when shipping, debugging CI release jobs, or judging release impact.
+---
+
+# Release flow
+
+Everything ships via changesets; there is no manual `npm version`/`publish`.
+Pipeline (`.github/workflows/release.yml`):
+
+1. **PR merges to main with changesets** → `changesets/action` opens/updates
+   the **"Version Packages" PR** (bumps versions, writes changelogs, deletes
+   consumed changesets).
+2. **Version PR merges** → same workflow re-runs with no pending changesets →
+   publishes via `scripts/safe-publish.mjs`:
+   - publishes non-private packages (`@moxxy/sdk`, `@moxxy/cli`) in **topo
+     order over workspace deps**, skips versions already on npm, auto-bumps
+     past tombstoned slots (committing those bumps back to main), blocks
+     dependents of a failed publish, post-verifies every `@moxxy/*` pin
+     exists on the registry (A12). `--dry-run` prints the order.
+   - Uses `pnpm publish` NEVER `npm publish` — npm ships `workspace:`/
+     `catalog:` protocols verbatim → uninstallable tarball.
+3. **Desktop** (when the merged Version PR bumped `@moxxy/desktop`): the cut
+   step only DECIDES version + pinned sha (guarded by
+   `hasChangesets == 'false'` — reading the version mid-bump caused the
+   desktop-v0.0.17 mismatched-artifacts incident, PR #85). Matrix builds
+   (.dmg/.exe/.deb+AppImage) check out that sha; only after EVERY leg
+   succeeds does `desktop-release` push the `desktop-v<version>` tag
+   (**tag-after-build invariant** — a failed build must never burn the
+   version, A22) and create a **DRAFT** GitHub Release.
+4. **Human publishes the draft** → self-update goes live: the stager picks
+   the semver-highest PUBLISHED `desktop-v*` release (drafts/prereleases
+   skipped). Draft = no client updates, by design.
+
+Operating notes:
+- Tier-1 bundle signing needs the `MOXXY_UPDATE_SIGNING_KEY` secret (Linux
+  leg); absent (forks) the floor still ships, hot-update assets are skipped.
+- A broken draft (e.g. A1's 0.0.33): do NOT publish; fix, let the next
+  Version PR re-cut, delete the bad draft + tag.
+- npm publish needs the `NPM_TOKEN` secret; Version-PR mode works on
+  `GITHUB_TOKEN` alone.
+- Deeper: AGENTS.md → "Releasing", docs/desktop-self-update.md,
+  docs/desktop-code-signing.md.

--- a/.claude/skills/run-the-cli/SKILL.md
+++ b/.claude/skills/run-the-cli/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: run-the-cli
+description: Run the locally-built moxxy CLI for a manual smoke or one-shot turn — use to verify a change in the real binary, not just tests.
+---
+
+# Run the CLI locally
+
+The binary is tsup-bundled — **`pnpm build` first**, or your edits aren't in it.
+
+```sh
+node packages/cli/dist/bin.js --help              # cheapest smoke (CI runs this)
+node packages/cli/dist/bin.js plugins list         # boots plugin host, no API calls
+node packages/cli/dist/bin.js doctor --check-keys  # config / vault / providers / channels diagnosis
+node packages/cli/dist/bin.js channels             # registered channels + subcommands
+```
+
+One-shot turn (headless, deny-by-default permissions — allow tools explicitly):
+
+```sh
+ANTHROPIC_API_KEY=sk-... node packages/cli/dist/bin.js \
+  -p "list files" --allow-tools Read,Glob
+```
+
+Interactive TUI: `node packages/cli/dist/bin.js` (needs a real TTY — won't work
+from a non-interactive shell; ask the user to drive it for TUI-visual checks).
+
+Notes:
+- Key resolution order: `moxxy.config.ts` → vault (`~/.moxxy/vault.json`,
+  `MOXXY_VAULT_PASSPHRASE` unlocks headless) → `<PROVIDER>_API_KEY` env →
+  interactive prompt (TTY only).
+- Daemon/channels: `moxxy serve` runs the bare runner (unix socket);
+  `moxxy mobile` serves the WS bridge + QR. Stale daemon after a protocol
+  bump self-heals on next attach (see change-runner-protocol skill).
+- `moxxy plugins new <name>` scaffolds a user-scope plugin under
+  `~/.moxxy/plugins/`; `moxxy plugins reload` hot-loads it.
+- Env vars reference: README.md → "Environment variables".

--- a/.claude/skills/run-the-gate/SKILL.md
+++ b/.claude/skills/run-the-gate/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: run-the-gate
+description: Run the full pre-PR verification gate (build/typecheck/lint/test/deps) with turbo caching — use before reporting any code change done or opening a PR.
+---
+
+# Run the gate
+
+Always from the repo root — the root scripts go through `turbo run`, which gives
+graph ordering + caching. `pnpm -r <task>` bypasses the cache; don't use it.
+
+```sh
+pnpm build        # turbo run build   — MUST be green before reporting done
+pnpm typecheck    # turbo run typecheck
+pnpm lint         # eslint . (root, no turbo; warnings ok, errors fail)
+pnpm test         # turbo run test && node --test scripts/*.test.mjs
+pnpm check:deps   # dependency-cruiser invariants (sdk has no internal deps, core never imports plugins, no cycles)
+```
+
+All exit non-zero on failure. CI (`.github/workflows/ci.yml`) runs exactly these
+plus two smokes on Node 20/22/24:
+
+```sh
+node packages/cli/dist/bin.js --help
+node packages/cli/dist/bin.js plugins list
+```
+
+Gotchas:
+- **Rebuild before reporting done.** The CLI binary is tsup-bundled — source
+  edits don't reach `packages/cli/dist/bin.js` until `pnpm build`. "Tests pass"
+  is not "the app works".
+- Tests run provider calls from recorded fixtures (`MOXXY_FIXTURES=replay` is
+  the default; CI sets it explicitly). Never need an API key.
+- Warm turbo cache makes unchanged packages instant (~seconds for the whole
+  repo); first run in a fresh worktree is minutes.
+- A Stop hook already runs `pnpm -w typecheck` on dirty worktrees
+  (`.claude/hooks/gate-on-stop.sh`) — that is a backstop, not the gate.
+- CI also requires a changeset on every PR — see the add-a-changeset skill.

--- a/.claude/skills/security-invariants/SKILL.md
+++ b/.claude/skills/security-invariants/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: security-invariants
+description: The load-bearing security invariants every change must preserve (trust boundaries, secrets, kill-safety, URL schemes) — use when reviewing or writing any code that crosses a trust boundary.
+---
+
+# Security invariants (do not regress these)
+
+Each was a confirmed audit finding once. Citations = TECH_DEBT.md A-items.
+
+1. **Zod at every trust boundary.** Renderer→main IPC
+   (`desktop-ipc-contract/validation.ts`), inbound WS frames (A8), webhook
+   bodies, persisted JSON read back from disk (corrupt file ≠ empty file —
+   quarantine, don't clobber, A14). Compile-time types protect nothing at
+   runtime.
+2. **Never kill by port without identity.** Verify the holder's `ps` command
+   line carries a moxxy marker before TERM/KILL; otherwise fall back to an
+   ephemeral port (A7). The CLI sets `process.title = 'moxxy …'` to make this
+   work.
+3. **Vault name, not plaintext.** Secrets never transit model-visible tool
+   args/results or session logs: tools take a vault KEY NAME (A6), MCP/env
+   configs carry `${vault:NAME}` resolved at connect/use time (A43),
+   generated secrets go to 0600 files with a masked preview returned (A15).
+4. **Scheme allow-list for agent-authored URLs.** `isSafeViewUrl` (sdk):
+   https/http/mailto/tel + relative; `data:image/*` for img src only —
+   enforced at parse AND render (A44). Outbound fetches:
+   `assertPublicUrl` + DNS-pinned dispatcher so check and connect can't
+   diverge (SSRF/rebinding, A45); update sources are HTTPS + host
+   allow-listed.
+5. **Capability-detect, don't crash.** Remote/thin sessions expose optional
+   `SessionLike` members (`reset?`, `mcpAdmin?`, …) — feature-detect and
+   degrade; never cast a RemoteSession to the concrete Session.
+6. **Auto-approve still consults policy.** Prompt-free `policyCheck` runs
+   user deny rules in unattended modes (goal, webhooks) — auto-approve skips
+   the PROMPT, never the policy (A3, A4). And never bypass the permission
+   engine with ad-hoc handler checks.
+7. **Gate every session-reaching path behind auth/pairing** — including
+   secondary handlers like inline-button callbacks (A46) and browser-Origin
+   upgrades (default-deny, A27).
+8. **Signed bytes are verified bytes.** Self-update verifies the signed
+   per-file hash map at stage time AND every load (A2); don't add code paths
+   that execute staged content before verification.
+
+Smell test for new code: "what happens if the JSON/peer/renderer/model is
+malicious?" — if the answer is "it can't be", prove it with the validator.

--- a/.claude/skills/tech-debt-journal/SKILL.md
+++ b/.claude/skills/tech-debt-journal/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: tech-debt-journal
+description: Work the TECH_DEBT.md living journal correctly (read-before-work, retire ≥1 per change, log on sight) — use at the start and end of every non-trivial task.
+---
+
+# The tech-debt journal
+
+`TECH_DEBT.md` is a LIVING JOURNAL, not an archive. Canonical rule: AGENTS.md →
+"Tech debt is a standing job". The working loop:
+
+1. **Before non-trivial work:** skim TECH_DEBT.md. Task touches an area with
+   an open item → fold the fix into the work.
+2. **Every shipped change retires ≥1 item** (or a quick win nearby). Move the
+   retired entry's one-liner into the "Resolved ledger" — never just delete.
+3. **Log new debt the moment you see it** — P1/P2/P3 section, concrete
+   `file:line` evidence, severity. Debt you can't fix now still gets recorded
+   now.
+4. **Sizeable feature/refactor → re-audit the subsystem** you touched and
+   refresh its items.
+
+Conventions in the file:
+- **A-intake** (`A1`, `A2`, …): confirmed audit findings awaiting/receiving
+  fixes, numbered so `#1–#10` cross-refs stay stable. Fixed ones read
+  "✅ FIXED (this PR): …" with the mechanism. Fold them into P-sections or the
+  ledger as fixes land.
+- **P1/P2/P3** = high/medium/low standing items; ⚠️ PARTIALLY DONE carries an
+  explicit "Remaining:" scope.
+- "Last refreshed" header line: update it on a full-pass refresh, with a
+  one-paragraph summary of the pass.
+
+Hazards:
+- **Rebase TECH_DEBT.md against main BEFORE editing it on a long-lived
+  branch** — it's the one file where a stale base silently lies (PRs #113/#115
+  resurrected retired items). Merge rule: the ✅ side wins. See
+  rebase-and-resolve skill.
+- Append-only spirit: don't rewrite others' entries to say less; verify
+  against code before un-retiring anything.

--- a/.claude/skills/verify-desktop-packaged/SKILL.md
+++ b/.claude/skills/verify-desktop-packaged/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: verify-desktop-packaged
+description: Build and smoke-test a packaged desktop app (electron-builder --dir + launch + WS-bridge check) — use to verify desktop changes survive packaging, not just dev mode.
+---
+
+# Verify the desktop, packaged
+
+Dev mode lies: packaged builds resolve modules differently (externalized
+workspace deps caused the 0.0.33 boot-crash, A1/PR #126). Any change to
+`apps/desktop/electron/*` or a main-process workspace dep needs this.
+
+```sh
+pnpm build                                       # whole repo first (turbo)
+pnpm --filter @moxxy/desktop run package:dir     # electron-vite build + electron-builder --dir (no installer, fast)
+```
+
+Output: `apps/desktop/release/<platform>/` (macOS arm64:
+`apps/desktop/release/mac-arm64/MoxxyAI Workspaces.app`).
+
+Launch + smoke (macOS):
+
+```sh
+"apps/desktop/release/mac-arm64/MoxxyAI Workspaces.app/Contents/MacOS/MoxxyAI Workspaces" &
+# boots clean = no MODULE_NOT_FOUND in the terminal, window renders past splash
+```
+
+WS-bridge smoke (the PR #126 verification):
+
+```sh
+MOXXY_WS_BRIDGE=1 "apps/desktop/release/mac-arm64/MoxxyAI Workspaces.app/Contents/MacOS/MoxxyAI Workspaces" &
+sleep 8 && lsof -nP -iTCP:8765 -sTCP:LISTEN    # bridge must be listening
+```
+
+Gotchas:
+- New workspace import in `apps/desktop/electron/main/*`? It MUST be either
+  in `BUNDLED_WORKSPACE_DEPS` (`apps/desktop/electron.vite.config.ts`) or a
+  guarded dynamic `await import()` behind its feature flag — a bare external
+  specifier = packaged boot crash AND a poisoned hot-update bundle.
+- A prod dep used by `desktop-host` source must be in `dependencies`, not
+  devDependencies (A20).
+- `.env` with `VITE_CLERK_PUBLISHABLE_KEY` must exist BEFORE the build
+  (electron-vite inlines it); `cp apps/desktop/.env.example apps/desktop/.env`
+  for a test key.
+- Kill the app afterwards; check `<userData>/app/boot-log.json` if boot
+  behaved oddly (debug-self-update skill).

--- a/.claude/skills/verify-mobile/SKILL.md
+++ b/.claude/skills/verify-mobile/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: verify-mobile
+description: Verify the Expo mobile PoC and its WS pairing path without a physical device — use after touching apps/mobile or the shared client packages.
+---
+
+# Verify mobile
+
+`apps/mobile` is an Expo PoC over the SHARED client layer — most logic (and
+most risk) lives in the workspace packages, which have real tests:
+
+```sh
+pnpm --filter @moxxy/client-core test
+pnpm --filter @moxxy/client-transport-ws test
+pnpm --filter @moxxy/plugin-channel-mobile test
+pnpm --filter @moxxy/mobile typecheck          # the app itself has typecheck only
+```
+
+Bundle proof (catches Metro/RN-incompatible imports — Node built-ins, DOM —
+without a device):
+
+```sh
+cd apps/mobile && pnpm exec expo export --platform ios   # must complete with no resolution errors
+```
+
+Pairing flow (manual, simulator is enough):
+
+```sh
+node packages/cli/dist/bin.js mobile     # QR + ws://127.0.0.1:8765 + token (loopback default)
+# real phone on LAN needs opt-in: MOXXY_MOBILE_HOST=0.0.0.0 moxxy mobile (QR then advertises the LAN IP)
+cd apps/mobile && pnpm exec expo start   # Expo Go (SDK 54) → scan/connect → send a turn
+```
+
+Gotchas:
+- The QR's `?t=` token is a PAIRING payload only — the app strips it and
+  connects with the bearer subprotocol (A27). Don't re-enable query-token auth.
+- `@moxxy/client-core` + `client-transport-ws` must stay DOM-free/Node-free
+  (global WebSocket only) — that's what the export proof checks.
+- Platform capabilities (mic/TTS/KV) are no-ops in the PoC by design
+  (TECH_DEBT P3 #10) — don't "fix" that ad hoc; it needs a
+  client-platform-expo package.
+- More: `apps/mobile/README.md` (tunnel option included).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,13 @@ Run `pnpm check:deps` to verify after structural changes.
 | Reproduce and isolate a bug | `.claude/agents/bug-hunter.md` |
 | Identify gaps and propose improvements | `.claude/agents/self-improver.md` |
 
+**Skill library.** Beyond these deep workflows, `.claude/skills/` holds ~28 thin,
+task-scoped SKILL.md checklists (dev loop, every extension point, verify/debug
+recipes, process rules) — scan the index at `.claude/skills/README.md` and read
+only the one that matches your task. Claude Code hooks in `.claude/settings.json`
+(see `.claude/hooks/README.md`) backstop the typecheck gate and the changeset
+requirement automatically.
+
 ---
 
 ## Tech guardrails — do this, not that

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
   &nbsp;·&nbsp;
   <a href="#-channels">Channels</a>
   &nbsp;·&nbsp;
+  <a href="#-built-by-the-agent-it-runs">Built by itself</a>
+  &nbsp;·&nbsp;
   <a href="#-developer-guide">Developer guide</a>
 </p>
 
@@ -54,6 +56,23 @@
     <img src="https://placehold.co/1280x640/0d1117/58a6ff.png?text=moxxy+%E2%80%94+30-second+demo" alt="moxxy demo" width="760" />
   </a>
 </p>
+
+---
+
+## 🤖 Built by the agent it runs
+
+**~95% of moxxy is written by moxxy** — the agent builds the framework, and the framework runs the agent. (For comparison, Anthropic has said Claude writes ~80% of Claude Code.) That number isn't a gimmick or a license to ship slop; it's a forcing function for the opposite. When the machine that writes the code is the same machine you're shipping, *engineering discipline becomes the product*, and you get to apply it at a scale and speed a human-only team can't match.
+
+What that discipline looks like here, in practice:
+
+- **Adversarial self-review, not vibes.** Findings are produced by fan-out analysis agents and then handed to independent agents whose only job is to *refute* them — false positives die before they reach a human. A recent full-codebase audit ran dozens of agents this way, surfaced 47 confirmed issues across security, stability, performance and packaging, and fixed every one in verified, single-concern PRs.
+- **Every change runs the gate.** Build, typecheck, lint, and the full test suite (thousands of tests across ~50 packages) pass on three Node versions before anything merges — enforced in CI and locally by [git hooks](.claude/hooks/) so the agent can't declare done on a red tree.
+- **Real-world, not just mocked.** A one-press [live E2E workflow](.github/workflows/e2e-live.yml) drives the actual CLI against the real OpenAI API — a streaming turn, a tool round-trip, and a confirmed SSRF-guard refusal of a cloud-metadata address — so security and provider behavior are proven against production, not fixtures.
+- **The codebase teaches the next agent.** A living [tech-debt journal](TECH_DEBT.md) (retire-one-per-change), a [skill library](.claude/skills/) of thin, single-purpose playbooks, and [specialized agent definitions](.claude/agents/) mean each change leaves the repo *easier* to change correctly — compounding quality instead of eroding it.
+
+The result is delivery that's **faster** (parallel agents, hours not weeks), **cleaner** (one concern per PR, every claim cited to a file and line), and **more robust** (adversarial verification + live validation + a gate nothing skips) than a conventional pipeline — *because* the author is an agent held to a higher bar, not in spite of it.
+
+> Want to see the machinery? Start with [`.claude/skills/`](.claude/skills/), [`TECH_DEBT.md`](TECH_DEBT.md), and the [Developer guide](#-developer-guide).
 
 ---
 

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -433,6 +433,12 @@ raw throws are internal registry/broker invariants that should stay plain):
 
 ## P3 — Low / per-package nits
 
+### 0. Keep the Claude skill library current — STANDING
+**Added 2026-06-10.** `.claude/skills/` (28 thin task checklists + index) and the
+hooks in `.claude/settings.json` encode repo conventions and audit lessons; like
+this journal, they rot silently — when a convention, command, extension point, or
+invariant they reference changes, update the matching SKILL.md in the same PR.
+
 ### 6. plugin-memory caches embeddings via a parallel `EmbeddingIndex` — OPEN
 **Cross-cut 1.11.** `plugin-memory/src/store.ts:6,88-96` still uses its own `EmbeddingIndex`
 cache instead of the SDK `CachedEmbeddingProvider`. **Deferred:** now that the atomic-write +


### PR DESCRIPTION
Makes future agent (and human) work on this repo faster and harder to get wrong, and tells the self-authorship story honestly.

## Skill library — `.claude/skills/` (28 skills + index)
Thin, single-purpose `SKILL.md` playbooks (28–45 lines each) with sharp frontmatter `description` triggers, so an agent loads **only** what the task needs instead of one giant doc:
- **Dev loop (6):** run-the-gate, fix-a-failing-test (incl. the pnpm `-t` filter trap), rebase-and-resolve (the TECH_DEBT stale-base hazard + keep-the-✅-side rule), open-a-pr, add-a-changeset (published-vs-private, empty changesets), run-the-cli.
- **Extend the system (13):** add-a-{plugin,tool,provider,channel,mode,compactor,cache-strategy,isolator,embedder,skill-builtin,slash-command}, add-an-ipc-command (contract→validation→host→ws/mobile→client-core), change-runner-protocol (the v3 bump rule).
- **Verify/debug (5):** verify-desktop-packaged (PR #126 recipe), verify-mobile (expo export proof), debug-self-update (state-file table), debug-session-logs, debug-ws-bridge.
- **Process (4):** tech-debt-journal, audit-wave (the fan-out→adversarial-verify→fix-wave pattern this very effort used), release-flow, security-invariants (the 8 load-bearing rules, each cited to its audit item).
- Index: `.claude/skills/README.md` — one line per skill, grouped.

Every command in every skill was executed against the repo and every cited identifier grep-verified.

## Hooks — `.claude/settings.json` + `.claude/hooks/`
- **Stop → `gate-on-stop.sh`:** silent on a clean tree / main checkout; on a dirty linked worktree runs the turbo-cached `pnpm -w typecheck` and **blocks 'done' (exit 2) on a red tree** with the first TS errors on stderr. `MOXXY_SKIP_GATE=1` hatch. Measured ~0.3–0.5s warm; exit-2 path proven.
- **PostToolUse (Edit|MultiEdit|Write) → `changeset-reminder.sh`:** one-line advisory (never blocking) when a `packages/*`/`apps/*` edit has no changeset vs `origin/main`; once-per-HEAD, worktree-safe. ~90ms.
- This hands the mechanical gates to the harness so agents stop burning turns re-running checks by hand.

## README — '🤖 Built by the agent it runs'
A prominent section framing **~95% self-authorship** (vs Claude Code's ~80%) as *engineering discipline*, not slop: adversarial self-review (the 47-finding audit), a gate nothing skips, the live OpenAI E2E proof, and a self-teaching codebase (journal + skills + agents) — delivering faster, cleaner, more robust. Links to the real machinery.

## Verification
Rebased on current main (picks up the merged live-E2E workflow the README links). Gate: build 0, typecheck 0, lint 0; both hooks' exit-code paths tested; empty changeset parses clean. AGENTS.md gets a skill-library pointer; TECH_DEBT gets a standing 'keep the library current' entry.