### PR TITLE
feat(plugin-virtual-office): self-contained virtual-office channel (no core seam)

### DIFF
--- a/.changeset/virtual-office-revival.md
+++ b/.changeset/virtual-office-revival.md
@@ -1,0 +1,29 @@
+---
+'@moxxy/plugin-virtual-office': minor
+'@moxxy/cli': patch
+---
+
+Revive the Virtual Office as a standalone, opt-in channel — `@moxxy/plugin-virtual-office`.
+
+**`@moxxy/plugin-virtual-office` (new):** the office is its OWN channel
+(`defineChannel`), not an extension of the generic HTTP channel and not a core
+seam. `moxxy virtual-office` stands up the office's own HTTP + SSE server, which
+serves the multi-agent surface: the office-agent runtime (per-agent EventLog /
+sessionId / allowed-tools registry), the unified-timeline SSE stream (with the
+`sensitive`-envelope drop so tokens/secrets never reach the wire), the graveyard,
+and the agent CRUD/run/stop/reset/history routes. The channel is its own security
+boundary — it bearer-auths every route with the shared `bearerTokenMatches` /
+`resolveChannelToken` helpers (env `MOXXY_VIRTUAL_OFFICE_TOKEN` → config → a
+generated, persisted secret), zod-validates request bodies, and size-caps the
+agent-run/image path (10 MB per image, 4 images max) before parse. Pass
+`channels.virtual-office.interactivePermissions: true` to route tool checks
+through the out-of-band `POST /v1/permissions/{id}/decision` flow (the channel
+installs the `HttpPermissionBroker` as its resolver). Opt-in: nothing runs unless
+the channel is invoked.
+
+**`@moxxy/cli` (patch):** register the office plugin as a builtin so
+`moxxy virtual-office` is available; it stays inert until invoked.
+
+No changes to `@moxxy/sdk`, `@moxxy/core`, or `@moxxy/plugin-channel-http` — the
+office reuses only the generic channel-auth/body-read helpers that already exist
+on `@moxxy/sdk`, so there is no extension contract in core or the HTTP channel.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -452,6 +452,13 @@ recall path — low value, real risk. Fold in only if the recall path is touched
 To fully sever channel→core, hoist these provider-neutral helpers into `@moxxy/sdk`
 (cross-cut 2.14). (`plugin-subagents`/`plugin-view` keep core as a **dev**Dep only — their
 `*.test.ts` import core; correct, leave them.)
+**2026-06-10 — new instance (now in `@moxxy/plugin-virtual-office`):** the Virtual Office is
+its own channel (its own HTTP+SSE server), and it carries a `@moxxy/core` prod dep —
+`office-agent-runtime.ts` constructs `EventLog`/`newSessionId`/`newTurnId` per agent and
+`channel.ts` casts `ClientSession`→core `Session` to drive `mode.run(ctx)` against a per-agent
+EventLog. `plugin-channel-http` is untouched (`@moxxy/core` is a **dev**Dep there, as on main).
+Same provider-neutral primitives as above — folds into the same SDK-hoist action. Until then
+it's a correct, declared dep (check:deps clean).
 
 ### 8. Small casts / hardcoded values — NEW, low
 - **Type the exec allowlist.** `plugin-security/src/broker.ts:343` reads
@@ -552,6 +559,47 @@ graph) is intact; the two operate on different graphs and don't conflict.
   RunnerMethod RPCs if the TUI ever needs to validate/save drafts. (d) loop body steps are
   excluded from the main DAG scheduler via a `loopBodyIds` set; if a future feature needs a
   step to be both a loop body AND independently scheduled, that exclusion must be revisited.
+
+### 12. Virtual Office — independent channel plugin (its own HTTP+WS server), no core seam — UPDATED, 2026-06-10
+The Virtual Office lives in its own package, **`@moxxy/plugin-virtual-office`**, as a
+**standalone channel** (`defineChannel` → `channels: [virtualOfficeChannelDef]`) — NOT an
+extension of `plugin-channel-http` and NOT a core seam. `moxxy virtual-office` stands up the
+office's own HTTP + SSE server (`channel.ts`): it owns its bearer-auth boundary (the generic
+`bearerTokenMatches` / `resolveChannelToken` SDK helpers — `MOXXY_VIRTUAL_OFFICE_TOKEN` → config
+→ a generated `~/.moxxy/virtual-office-token`), its body-size guards, and its crash-safe SSE
+helper, and serves ALL office code itself (runtime, permission broker, envelope normalizer, the
+`sensitive`-envelope drop, the ~10 routes in `routes.ts`). `@moxxy/sdk`, `@moxxy/core`, and
+`plugin-channel-http` are exactly as on main — the office reuses only the pre-existing generic
+channel-auth/body-read helpers, so there is no extension contract anywhere in core/sdk/the HTTP
+channel (the earlier `HttpExtension` seam was removed per the user directive). Opt-in = the
+channel being invoked; pass `channels.virtual-office.interactivePermissions: true` to install
+the `HttpPermissionBroker` as the channel's resolver (out-of-band
+`POST /v1/permissions/{id}/decision`).
+
+Known duplication (tracked, accepted): the office stands up its own `node:http` server +
+SSE, the same shape `plugin-channel-http` / `plugin-webhooks` / the mobile bridge each carry.
+This is the deliberate trade the directive chose (a separate channel over a shared core seam).
+If a generic, non-office WS/HTTP-serving helper is ever hoisted into a shared package, the
+office server can adopt it; do NOT add anything office-specific to a shared package.
+
+Per the original revival spec, three pieces were **consciously descoped for v1** and are
+tracked here so they aren't silently forgotten:
+- **Synthesizer auto-integration** — no automatic roll-up of office-agent outputs back into
+  the parent session's context. A run's result lives only in the agent's own EventLog /
+  graveyard entry; the operator (or a future synthesizer block) must thread it back manually.
+- **Per-agent MCP servers** — the reference branch had `/v1/agents/{id}/mcp*` routes
+  (add/list/remove/test). Dropped for v1; office agents share the session's tool registry
+  (optionally narrowed by `allowed_tools`). Re-add the MCP routes when per-agent MCP is needed.
+- **Persistent agent snapshots across restarts** — live agents are not serialized. On
+  channel/session restart the runtime only *projects* archived agents + completed runtime
+  subagents from the persisted session log into the graveyard (read-only history); it does
+  not resurrect a running agent. A live agent in flight at shutdown is archived as `stopped`.
+
+Placement note: the office is its own self-contained channel (per the user directive — no
+office-specific code in `plugin-channel-http`, no core seam). If the separately-ported
+workflows-builder ever needs the same multi-agent pool, factor a shared agent-pool
+abstraction then — **do not** pre-abstract or touch `plugin-workflows` now.
+**Severity low** (additive; the whole surface is off unless the channel is invoked).
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -104,6 +104,7 @@
     "@moxxy/plugin-telegram": "workspace:*",
     "@moxxy/plugin-usage-stats": "workspace:*",
     "@moxxy/plugin-vault": "workspace:*",
+    "@moxxy/plugin-virtual-office": "workspace:*",
     "@moxxy/plugin-webhooks": "workspace:*",
     "@moxxy/plugin-workflows": "workspace:*",
     "@moxxy/runner": "workspace:*",

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -23,6 +23,7 @@ import { buildTelegramPlugin } from '@moxxy/plugin-telegram';
 import { buildMcpAdminPluginWithApi } from '@moxxy/plugin-mcp';
 import { cliPlugin } from '@moxxy/plugin-cli';
 import { httpChannelPlugin } from '@moxxy/plugin-channel-http';
+import { virtualOfficePlugin } from '@moxxy/plugin-virtual-office';
 import { buildWebChannelPlugin } from '@moxxy/plugin-channel-web';
 import { mobileChannelPlugin } from '@moxxy/plugin-channel-mobile';
 import { browserPlugin } from '@moxxy/plugin-browser';
@@ -93,6 +94,7 @@ export const BUILTIN_REQUIREMENT_DECISIONS: Readonly<Record<string, BuiltinRequi
   '@moxxy/memory-consolidate': { hardRequirements: true, reason: 'requires @moxxy/plugin-memory contributions' },
   '@moxxy/plugin-cli': { hardRequirements: false, reason: 'TUI channel is standalone' },
   '@moxxy/plugin-channel-http': { hardRequirements: false, reason: 'HTTP channel is standalone' },
+  '@moxxy/plugin-virtual-office': { hardRequirements: false, reason: 'standalone Virtual Office channel; inert unless invoked' },
   '@moxxy/plugin-channel-web': { hardRequirements: false, reason: 'web surface is standalone; token auto-generated' },
   '@moxxy/plugin-channel-mobile': { hardRequirements: false, reason: 'mobile WS bridge is standalone; token auto-generated' },
   '@moxxy/plugin-telegram': { hardRequirements: false, reason: 'vault is injected by bootstrap closure' },
@@ -211,6 +213,9 @@ export function buildBuiltinsCore(args: BuildBuiltinsArgs): BuiltBuiltinsCore {
     // aggregate). Surfaced in the /usage panel; reset via /usage clear.
     { name: '@moxxy/plugin-usage-stats', plugin: buildUsageStatsPlugin() },
     { name: '@moxxy/plugin-channel-http', plugin: httpChannelPlugin },
+    // Standalone Virtual Office channel: `moxxy virtual-office` stands up its
+    // own HTTP+SSE server. Opt-in — inert unless that channel is invoked.
+    { name: '@moxxy/plugin-virtual-office', plugin: virtualOfficePlugin },
     {
       name: '@moxxy/plugin-channel-web',
       plugin: buildWebChannelPlugin({

--- a/packages/plugin-virtual-office/package.json
+++ b/packages/plugin-virtual-office/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@moxxy/plugin-virtual-office",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Virtual Office for moxxy: a standalone, opt-in channel running its own HTTP+SSE server for a multi-agent surface (office agents, unified timeline, graveyard, interactive permissions). No core seam; the HTTP channel stays generic.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist .turbo"
+  },
+  "moxxy": {
+    "plugin": {
+      "entry": "./dist/index.js",
+      "kind": "channel"
+    }
+  },
+  "dependencies": {
+    "@moxxy/core": "workspace:*",
+    "@moxxy/sdk": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@moxxy/mode-default": "workspace:*",
+    "@moxxy/testing": "workspace:*",
+    "@moxxy/tools-builtin": "workspace:*",
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugin-virtual-office/src/channel.test.ts
+++ b/packages/plugin-virtual-office/src/channel.test.ts
@@ -1,0 +1,309 @@
+/**
+ * End-to-end test of the standalone Virtual Office CHANNEL: the channel boots
+ * its own HTTP+SSE server on an ephemeral port, then real HTTP requests drive
+ * the office surface via fetch. This proves the office runs entirely on its own
+ * server — no generic HTTP channel, no core seam — and is its own security
+ * boundary: it bearer-auths every route, zod-validates its bodies, caps the
+ * agent-run/image path, and drops `sensitive` envelopes off the SSE stream.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { Session, autoAllowResolver, silentLogger } from '@moxxy/core';
+import { defineProvider, definePlugin } from '@moxxy/sdk';
+import { FakeProvider, textReply } from '@moxxy/testing';
+import { defaultModePlugin } from '@moxxy/mode-default';
+import { builtinToolsPlugin } from '@moxxy/tools-builtin';
+import { VirtualOfficeChannel } from './channel.js';
+import { handleEvents, type OfficeRequestContext } from './routes.js';
+import { OfficeAgentRuntime } from './office-agent-runtime.js';
+import type { VirtualOfficeEnvelope } from './virtual-office-events.js';
+import type { ChannelHandle } from '@moxxy/sdk';
+
+const TOKEN = 'office-token-123';
+
+function buildSession(): Session {
+  const provider = new FakeProvider({ script: [textReply('office agent did the work')] });
+  const session = new Session({
+    cwd: process.cwd(),
+    logger: silentLogger,
+    permissionResolver: autoAllowResolver,
+  });
+  session.pluginHost.registerStatic(
+    definePlugin({
+      name: 'office-channel-shim',
+      providers: [
+        defineProvider({
+          name: provider.name,
+          models: [...provider.models],
+          createClient: () => provider,
+        }),
+      ],
+    }),
+  );
+  session.providers.setActive(provider.name);
+  session.pluginHost.registerStatic(builtinToolsPlugin);
+  session.pluginHost.registerStatic(defaultModePlugin);
+  return session;
+}
+
+describe('Virtual Office standalone channel', () => {
+  let channel: VirtualOfficeChannel;
+  let handle: ChannelHandle;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    channel = new VirtualOfficeChannel({ port: 0, authToken: TOKEN });
+    handle = await channel.start({ session: buildSession() });
+    baseUrl = `http://127.0.0.1:${channel.boundPort}`;
+  });
+
+  afterEach(async () => {
+    await handle.stop();
+  });
+
+  function auth(extra: Record<string, string> = {}): Record<string, string> {
+    return { authorization: `Bearer ${TOKEN}`, ...extra };
+  }
+
+  it('binds an ephemeral port and answers health unauthenticated', async () => {
+    expect(channel.boundPort).toBeGreaterThan(0);
+    const res = await fetch(`${baseUrl}/v1/health`);
+    expect(res.status).toBe(200);
+    expect((await res.json()).listener).toBe('virtual-office');
+  });
+
+  it('rejects office routes without a Bearer token (401) — auth enforced by the channel', async () => {
+    const res = await fetch(`${baseUrl}/v1/agents`);
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /v1/agents lists the live session agent', async () => {
+    const res = await fetch(`${baseUrl}/v1/agents`, { headers: auth() });
+    expect(res.status).toBe(200);
+    const agents = (await res.json()) as Array<{ id: string }>;
+    expect(agents[0]?.id).toBe('session');
+  });
+
+  it('creates an agent, runs it via the FakeProvider, surfaces SSE envelopes, then dismisses into the graveyard', async () => {
+    const controller = new AbortController();
+    const sse = await fetch(`${baseUrl}/v1/events/stream`, { headers: auth(), signal: controller.signal });
+    expect(sse.status).toBe(200);
+    expect(sse.headers.get('content-type')).toContain('text/event-stream');
+    const reader = sse.body!.getReader();
+    const decoder = new TextDecoder();
+    const seen: Array<{ event_type: string; agent_id: string }> = [];
+    const pump = (async () => {
+      try {
+        let buf = '';
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          const frames = buf.split('\n\n');
+          buf = frames.pop() ?? '';
+          for (const frame of frames) {
+            const line = frame.split('\n').find((l) => l.startsWith('data: '));
+            if (!line) continue;
+            try {
+              seen.push(JSON.parse(line.slice(6)));
+            } catch {
+              /* skip non-JSON frames (e.g. ': connected') */
+            }
+          }
+        }
+      } catch {
+        /* aborted */
+      }
+    })();
+
+    const created = await fetch(`${baseUrl}/v1/agents`, {
+      method: 'POST',
+      headers: auth({ 'content-type': 'application/json' }),
+      body: JSON.stringify({ name: 'researcher' }),
+    });
+    expect(created.status).toBe(200);
+    const agent = (await created.json()) as { id: string; kind: string };
+    expect(agent.kind).toBe('office_agent');
+
+    const run = await fetch(`${baseUrl}/v1/agents/${agent.id}/runs`, {
+      method: 'POST',
+      headers: auth({ 'content-type': 'application/json' }),
+      body: JSON.stringify({ task: 'do the research' }),
+    });
+    expect(run.status).toBe(200);
+    expect((await run.json()).status).toBe('running');
+
+    const start = Date.now();
+    while (!seen.some((e) => e.event_type === 'run.completed' && e.agent_id === agent.id)) {
+      if (Date.now() - start > 2000) throw new Error('timed out waiting for run.completed envelope');
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(seen.some((e) => e.event_type === 'message.final' && e.agent_id === agent.id)).toBe(true);
+
+    controller.abort();
+    await pump;
+
+    const dismissed = await fetch(`${baseUrl}/v1/agents/${agent.id}`, { method: 'DELETE', headers: auth() });
+    expect(dismissed.status).toBe(200);
+
+    const grave = await fetch(`${baseUrl}/v1/graveyard`, { headers: auth() });
+    const entries = (await grave.json()) as Array<{ agentId: string; outcome: string }>;
+    expect(entries.some((e) => e.agentId === agent.id)).toBe(true);
+
+    const after = await fetch(`${baseUrl}/v1/agents`, { headers: auth() });
+    const ids = ((await after.json()) as Array<{ id: string }>).map((a) => a.id);
+    expect(ids).toEqual(['session']);
+  });
+
+  it('rejects a malformed agent-run body (400 from the office zod schema)', async () => {
+    const created = await fetch(`${baseUrl}/v1/agents`, {
+      method: 'POST',
+      headers: auth({ 'content-type': 'application/json' }),
+      body: JSON.stringify({ name: 'x' }),
+    });
+    const agent = (await created.json()) as { id: string };
+    const res = await fetch(`${baseUrl}/v1/agents/${agent.id}/runs`, {
+      method: 'POST',
+      headers: auth({ 'content-type': 'application/json' }),
+      body: JSON.stringify({ notTask: 1 }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('bad_request');
+  });
+
+  it('rejects an oversized image attachment (400)', async () => {
+    const created = await fetch(`${baseUrl}/v1/agents`, {
+      method: 'POST',
+      headers: auth({ 'content-type': 'application/json' }),
+      body: JSON.stringify({ name: 'vision' }),
+    });
+    const agent = (await created.json()) as { id: string };
+    // 11 MB of base64 'A' decodes to > 10 MB — past the per-image cap but well
+    // under the run body cap, so this exercises the schema's size refinement.
+    const oversized = 'A'.repeat(11 * 1024 * 1024 + 16);
+    const res = await fetch(`${baseUrl}/v1/agents/${agent.id}/runs`, {
+      method: 'POST',
+      headers: auth({ 'content-type': 'application/json' }),
+      body: JSON.stringify({
+        task: 'inspect',
+        attachments: [{ kind: 'image', content: oversized, mediaType: 'image/png' }],
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('404s unknown routes (behind auth)', async () => {
+    const res = await fetch(`${baseUrl}/v1/does-not-exist`, { headers: auth() });
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe('not_found');
+  });
+
+  it('tears down the server on stop()', async () => {
+    const port = channel.boundPort;
+    await handle.stop();
+    await expect(fetch(`http://127.0.0.1:${port}/v1/health`)).rejects.toThrow();
+    // start a fresh one for the afterEach teardown to no-op cleanly
+    channel = new VirtualOfficeChannel({ port: 0, authToken: TOKEN });
+    handle = await channel.start({ session: buildSession() });
+  });
+});
+
+describe('Virtual Office interactive permissions', () => {
+  it('404s the decision endpoint when interactive permissions are off', async () => {
+    const channel = new VirtualOfficeChannel({ port: 0, authToken: TOKEN });
+    const handle = await channel.start({ session: buildSession() });
+    try {
+      const res = await fetch(`http://127.0.0.1:${channel.boundPort}/v1/permissions/perm-1/decision`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${TOKEN}`, 'content-type': 'application/json' },
+        body: JSON.stringify({ mode: 'allow' }),
+      });
+      expect(res.status).toBe(404);
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  it('installs the interactive broker as the channel resolver when enabled', async () => {
+    const channel = new VirtualOfficeChannel({ port: 0, authToken: TOKEN, interactivePermissions: true });
+    const handle = await channel.start({ session: buildSession() });
+    try {
+      expect(channel.permissionResolver.name).toBe('http-interactive');
+      // An unknown request id resolves to 404 (broker has no such pending request).
+      const res = await fetch(`http://127.0.0.1:${channel.boundPort}/v1/permissions/perm-x/decision`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${TOKEN}`, 'content-type': 'application/json' },
+        body: JSON.stringify({ mode: 'allow' }),
+      });
+      expect(res.status).toBe(404);
+      expect((await res.json()).error).toBe('not_found');
+    } finally {
+      await handle.stop();
+    }
+  });
+});
+
+describe('Virtual Office SSE timeline sensitivity', () => {
+  it('drops envelopes flagged sensitive and never leaks their payload', async () => {
+    const session = buildSession();
+    const runtime = new OfficeAgentRuntime(session, silentLogger);
+
+    // A minimal fake OfficeRequestContext whose openEventStream records sends.
+    const sent: string[] = [];
+    let closeResolve: (() => void) | undefined;
+    const closed = new Promise<void>((resolve) => {
+      closeResolve = resolve;
+    });
+    const ctx = {
+      session,
+      runtime,
+      broker: null,
+      req: {} as IncomingMessage,
+      res: {} as ServerResponse,
+      pathname: '/v1/events/stream',
+      pathSegment: () => '',
+      readBody: async () => '',
+      reply: () => undefined,
+      openEventStream: () => ({
+        send: (data: unknown) => {
+          sent.push(JSON.stringify(data));
+        },
+        closed,
+      }),
+      logger: silentLogger,
+    } as unknown as OfficeRequestContext;
+
+    const done = handleEvents(ctx, runtime, silentLogger);
+    await new Promise((r) => setTimeout(r, 5));
+
+    const secret = 'SUPER-SECRET-TOKEN-do-not-leak';
+    const publicEnvelope: VirtualOfficeEnvelope = {
+      agent_id: 'session',
+      run_id: null,
+      parent_run_id: null,
+      sequence: 1,
+      event_type: 'office_agent.created',
+      payload: { hello: 'world' },
+      sensitive: false,
+    };
+    const sensitiveEnvelope: VirtualOfficeEnvelope = {
+      agent_id: 'session',
+      run_id: null,
+      parent_run_id: null,
+      sequence: 2,
+      event_type: 'secret.leak',
+      payload: { token: secret },
+      sensitive: true,
+    };
+    (runtime as unknown as { emit: (e: VirtualOfficeEnvelope) => void }).emit(publicEnvelope);
+    (runtime as unknown as { emit: (e: VirtualOfficeEnvelope) => void }).emit(sensitiveEnvelope);
+
+    closeResolve?.();
+    await done;
+
+    const body = sent.join('\n');
+    expect(body).toContain('office_agent.created');
+    expect(body).not.toContain(secret);
+    expect(body).not.toContain('secret.leak');
+  });
+});

--- a/packages/plugin-virtual-office/src/channel.ts
+++ b/packages/plugin-virtual-office/src/channel.ts
@@ -1,0 +1,265 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { bearerTokenMatches, readRequestBody } from '@moxxy/sdk';
+import type {
+  Channel,
+  ChannelHandle,
+  ChannelStartOptsBase,
+  ClientSession,
+  PermissionResolver,
+} from '@moxxy/sdk';
+import type { Session as CoreSession } from '@moxxy/core';
+import { OfficeAgentRuntime } from './office-agent-runtime.js';
+import { HttpPermissionBroker } from './permission-broker.js';
+import {
+  OFFICE_ROUTES,
+  type OfficeEventStream,
+  type OfficeLogger,
+  type OfficeRequestContext,
+} from './routes.js';
+
+/**
+ * The Virtual Office is its OWN channel: a self-contained HTTP + SSE server
+ * standing up the multi-agent office surface (agents, unified timeline,
+ * graveyard, interactive permissions). It deliberately does NOT extend the
+ * generic `@moxxy/plugin-channel-http` — per the user directive the office is a
+ * separate, opt-in channel that only runs when invoked (`moxxy virtual-office`).
+ *
+ * The channel is its own security boundary: it bearer-auths every route (the
+ * same generic `bearerTokenMatches` helper the HTTP/web/mobile channels use),
+ * zod-validates request bodies inside its handlers, caps the agent-run body, and
+ * drops `sensitive`-flagged envelopes before they reach the SSE wire.
+ */
+
+export interface VirtualOfficeChannelOptions {
+  readonly port?: number;
+  readonly host?: string;
+  /** Bearer token required on every route. If unset, auth is disabled (dev-only). */
+  readonly authToken?: string;
+  /**
+   * Route tool-permission checks through an out-of-band HTTP decision flow
+   * (`POST /v1/permissions/{id}/decision`) instead of upfront allow-listing.
+   * When set the channel installs the {@link HttpPermissionBroker} as its
+   * resolver, so each tool check becomes an interactive HTTP exchange.
+   */
+  readonly interactivePermissions?: boolean;
+  readonly logger?: {
+    info?(msg: string, meta?: Record<string, unknown>): void;
+    warn?(msg: string, meta?: Record<string, unknown>): void;
+  };
+}
+
+export interface VirtualOfficeStartOpts extends ChannelStartOptsBase {
+  readonly session: ClientSession;
+}
+
+const NOT_FOUND = { error: 'not_found', message: 'no such route' } as const;
+
+export class VirtualOfficeChannel implements Channel<VirtualOfficeStartOpts> {
+  readonly name = 'virtual-office';
+  readonly permissionResolver: PermissionResolver;
+  private readonly port: number;
+  private readonly host: string;
+  private readonly authToken: string | null;
+  private readonly logger: VirtualOfficeChannelOptions['logger'];
+  private readonly broker: HttpPermissionBroker | null;
+  private server: Server | null = null;
+  private runtime: OfficeAgentRuntime | null = null;
+  private boundPortValue = 0;
+
+  /** The actual TCP port the server bound to after {@link start} — equals the
+   *  configured port, or the OS-assigned one when `port: 0` (ephemeral), so
+   *  tests/callers can address the server without guessing a free port. */
+  get boundPort(): number {
+    return this.boundPortValue;
+  }
+
+  constructor(opts: VirtualOfficeChannelOptions = {}) {
+    this.port = opts.port ?? 3939;
+    this.host = opts.host ?? '127.0.0.1';
+    this.authToken = opts.authToken ?? null;
+    this.logger = opts.logger;
+    this.broker = opts.interactivePermissions ? new HttpPermissionBroker() : null;
+    // With interactive permissions the broker IS the resolver; otherwise the
+    // office defers to whatever resolver the session already carries (the CLI's
+    // channel-launch wiring), so it never silently relaxes the session policy.
+    this.permissionResolver =
+      this.broker ?? { name: 'virtual-office-passthrough', check: async () => ({ mode: 'deny', reason: 'no resolver' }) };
+  }
+
+  async start(startOpts: VirtualOfficeStartOpts): Promise<ChannelHandle> {
+    const session = startOpts.session;
+    // The runtime + broker need the concrete core Session (its EventLog, mode/
+    // provider registries); the ClientSession surface is a structural subset.
+    // This is the same cast channels use internally.
+    const coreSession = session as unknown as CoreSession;
+    this.broker?.attachSession(coreSession);
+    this.runtime = new OfficeAgentRuntime(coreSession, this.logger as OfficeLogger, this.broker);
+    const runtime = this.runtime;
+    const broker = this.broker;
+    const logger = this.logger as OfficeLogger | undefined;
+
+    const server = createServer((req, res) => {
+      this.handle(req, res, { session, runtime, broker, logger }).catch((err) => {
+        this.logger?.warn?.('virtual-office handler threw', { err: errMsg(err) });
+        if (!res.headersSent) {
+          res.writeHead(500, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ error: 'internal', message: errMsg(err) }));
+        } else {
+          try { res.end(); } catch { /* ignore */ }
+        }
+      });
+    });
+    this.server = server;
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(this.port, this.host, () => {
+        const addr = server.address();
+        this.boundPortValue = typeof addr === 'object' && addr ? addr.port : this.port;
+        this.logger?.info?.('virtual-office channel listening', {
+          host: this.host,
+          port: this.boundPortValue,
+          authEnabled: this.authToken !== null,
+          interactivePermissions: this.broker !== null,
+        });
+        resolve();
+      });
+    });
+
+    const running = new Promise<void>((resolve) => {
+      server.once('close', () => resolve());
+    });
+
+    return {
+      running,
+      stop: async () => {
+        this.broker?.abortAll('Virtual Office stopped');
+        if (this.runtime) {
+          await this.runtime.archiveLiveAgents('session_closed').catch(() => undefined);
+        }
+        this.runtime = null;
+        await new Promise<void>((resolve) => {
+          if (!this.server) return resolve();
+          this.server.close(() => resolve());
+          this.server = null;
+        });
+      },
+    };
+  }
+
+  private async handle(
+    req: IncomingMessage,
+    res: ServerResponse,
+    deps: {
+      session: ClientSession;
+      runtime: OfficeAgentRuntime;
+      broker: HttpPermissionBroker | null;
+      logger: OfficeLogger | undefined;
+    },
+  ): Promise<void> {
+    const rawUrl = req.url ?? '/';
+    const pathname = rawUrl.split('?')[0] ?? rawUrl;
+
+    // Health is the only unauthenticated route — it leaks nothing and lets an
+    // uptime probe confirm the listener is alive.
+    if (req.method === 'GET' && (pathname === '/v1/health' || pathname === '/health')) {
+      reply(res, 200, { status: 'ok', listener: 'virtual-office' });
+      return;
+    }
+
+    // The channel is its own security boundary: bearer-auth EVERY office route
+    // (constant-time compare of the full `Bearer <token>` header) before any
+    // body is read or handler runs.
+    if (!this.checkAuth(req)) {
+      reply(res, 401, { error: 'unauthorized' });
+      return;
+    }
+
+    const route = OFFICE_ROUTES.find((r) => r.method === req.method && r.match(pathname));
+    if (!route) {
+      reply(res, 404, NOT_FOUND);
+      return;
+    }
+
+    const ctx = this.buildContext(req, res, pathname, deps);
+    await route.handle(ctx);
+  }
+
+  private checkAuth(req: IncomingMessage): boolean {
+    if (!this.authToken) return true;
+    return bearerTokenMatches(req.headers.authorization, `Bearer ${this.authToken}`);
+  }
+
+  private buildContext(
+    req: IncomingMessage,
+    res: ServerResponse,
+    pathname: string,
+    deps: {
+      session: ClientSession;
+      runtime: OfficeAgentRuntime;
+      broker: HttpPermissionBroker | null;
+      logger: OfficeLogger | undefined;
+    },
+  ): OfficeRequestContext {
+    const segments = pathname.split('/');
+    return {
+      session: deps.session,
+      runtime: deps.runtime,
+      broker: deps.broker,
+      req,
+      res,
+      pathname,
+      ...(deps.logger ? { logger: deps.logger } : {}),
+      pathSegment: (n: number) => segments[n] ?? '',
+      readBody: async (max = 64 * 1024) => (await readRequestBody(req, max)).toString('utf8'),
+      reply: (status: number, body: unknown) => reply(res, status, body),
+      openEventStream: () => openEventStream(res, this.logger as OfficeLogger | undefined),
+    };
+  }
+}
+
+function reply(res: ServerResponse, status: number, body: unknown): void {
+  if (res.headersSent) return;
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Open a crash-safe Server-Sent Events stream on the response. `send` swallows
+ * write failures (a hung-up client must not crash the office), and `closed`
+ * resolves when the socket closes so the handler can unsubscribe its listeners.
+ */
+function openEventStream(res: ServerResponse, logger?: OfficeLogger): OfficeEventStream {
+  res.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive',
+  });
+  // Prime the stream so proxies flush headers immediately.
+  try { res.write(': connected\n\n'); } catch { /* ignore */ }
+
+  let resolveClosed: () => void;
+  const closed = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+  const onClose = (): void => resolveClosed();
+  res.on('close', onClose);
+
+  return {
+    send: (data: unknown) => {
+      try {
+        res.write(`data: ${JSON.stringify(data)}\n\n`);
+      } catch (err) {
+        logger?.warn('virtual-office SSE write failed', { err: errMsg(err) });
+      }
+    },
+    closed: closed.finally(() => {
+      res.off('close', onClose);
+      try { res.end(); } catch { /* ignore */ }
+    }),
+  };
+}

--- a/packages/plugin-virtual-office/src/index.ts
+++ b/packages/plugin-virtual-office/src/index.ts
@@ -1,0 +1,90 @@
+import { defineChannel, definePlugin, resolveChannelToken, type Plugin } from '@moxxy/sdk';
+import { VirtualOfficeChannel, type VirtualOfficeChannelOptions } from './channel.js';
+
+export {
+  VirtualOfficeChannel,
+  type VirtualOfficeChannelOptions,
+  type VirtualOfficeStartOpts,
+} from './channel.js';
+export {
+  OFFICE_ROUTES,
+  handleEvents,
+  type OfficeRoute,
+  type OfficeRequestContext,
+  type OfficeEventStream,
+  type OfficeLogger,
+} from './routes.js';
+export {
+  OfficeAgentRuntime,
+  type OfficeAgentCreateInput,
+  type OfficeAgentHistory,
+  type OfficeRunStart,
+  type VirtualOfficeAgent,
+  type OfficeGraveyardEntry,
+} from './office-agent-runtime.js';
+export {
+  HttpPermissionBroker,
+  PERMISSION_REQUESTED_SUBTYPE,
+  PERMISSION_RESOLVED_SUBTYPE,
+} from './permission-broker.js';
+export {
+  eventToVirtualOfficeEnvelope,
+  type VirtualOfficeEnvelope,
+} from './virtual-office-events.js';
+
+const TOKEN_FILE = 'virtual-office-token';
+
+function asNumber(v: unknown): number | undefined {
+  return typeof v === 'number' ? v : undefined;
+}
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+function asBool(v: unknown): boolean | undefined {
+  return typeof v === 'boolean' ? v : undefined;
+}
+
+/**
+ * Resolve the office channel's bearer token via the shared channel-auth
+ * convention (env `MOXXY_VIRTUAL_OFFICE_TOKEN` → `channels.virtual-office.token`
+ * config → a generated secret persisted at `~/.moxxy/virtual-office-token`), so
+ * the surface is never accidentally unauthenticated.
+ */
+export function resolveVirtualOfficeToken(configured?: string): string {
+  return resolveChannelToken({ configured, envVar: 'MOXXY_VIRTUAL_OFFICE_TOKEN', fileName: TOKEN_FILE });
+}
+
+/**
+ * The Virtual Office as a self-contained channel: `moxxy virtual-office` stands
+ * up its own HTTP + SSE server (no dependency on `@moxxy/plugin-channel-http`
+ * and no core extension seam) serving the office surface — agents, unified
+ * timeline, graveyard, and (opt-in) interactive permissions. Opt-in: it only
+ * runs when the channel is invoked, and it bearer-auths every route itself.
+ */
+export const virtualOfficeChannelDef = defineChannel({
+  name: 'virtual-office',
+  description:
+    'Standalone multi-agent Virtual Office channel — its own HTTP+SSE server (agents, unified timeline, graveyard, interactive permissions). Bearer-token auth.',
+  create: (deps) => {
+    const opts = deps.options ?? {};
+    const channelOpts: VirtualOfficeChannelOptions = {
+      authToken: resolveVirtualOfficeToken(asString(opts.authToken) ?? asString(opts.token)),
+      ...(asNumber(opts.port) !== undefined ? { port: asNumber(opts.port) } : {}),
+      ...(asString(opts.host) !== undefined ? { host: asString(opts.host) } : {}),
+      ...(asBool(opts.interactivePermissions) !== undefined
+        ? { interactivePermissions: asBool(opts.interactivePermissions) }
+        : {}),
+      logger: deps.logger,
+    };
+    return new VirtualOfficeChannel(channelOpts);
+  },
+  isAvailable: async () => ({ ok: true }),
+});
+
+export const virtualOfficePlugin: Plugin = definePlugin({
+  name: '@moxxy/plugin-virtual-office',
+  version: '0.0.0',
+  channels: [virtualOfficeChannelDef],
+});
+
+export default virtualOfficePlugin;

--- a/packages/plugin-virtual-office/src/office-agent-runtime.test.ts
+++ b/packages/plugin-virtual-office/src/office-agent-runtime.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from 'vitest';
+import { EventLog, Session, autoAllowResolver, silentLogger } from '@moxxy/core';
+import { asPluginId, defineProvider, definePlugin, defineTool } from '@moxxy/sdk';
+import { z } from 'zod';
+import { FakeProvider, textReply, toolUseReply } from '@moxxy/testing';
+import { defaultModePlugin } from '@moxxy/mode-default';
+import { builtinToolsPlugin } from '@moxxy/tools-builtin';
+import { OfficeAgentRuntime } from './office-agent-runtime.js';
+import { HttpPermissionBroker } from './permission-broker.js';
+
+function buildSession(log?: EventLog): Session {
+  const provider = new FakeProvider({
+    script: [textReply('office agent completed the task')],
+  });
+  const session = new Session({
+    cwd: process.cwd(),
+    logger: silentLogger,
+    permissionResolver: autoAllowResolver,
+    ...(log ? { log } : {}),
+  });
+  session.pluginHost.registerStatic(
+    definePlugin({
+      name: 'office-agent-runtime-test-provider',
+      providers: [
+        defineProvider({
+          name: provider.name,
+          models: [...provider.models],
+          createClient: () => provider,
+        }),
+      ],
+    }),
+  );
+  session.providers.setActive(provider.name);
+  session.pluginHost.registerStatic(builtinToolsPlugin);
+  session.pluginHost.registerStatic(defaultModePlugin);
+  return session;
+}
+
+async function waitForLog(
+  session: Session,
+  predicate: () => boolean,
+  timeoutMs = 1_000,
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error('timed out waiting for office log');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+describe('OfficeAgentRuntime persistence', () => {
+  it('persists office agent lifecycle and run history as session plugin events', async () => {
+    const session = buildSession();
+    const runtime = new OfficeAgentRuntime(session, silentLogger);
+
+    const agent = await runtime.create({ name: 'researcher' });
+    runtime.startRun(agent.id, 'research the repo');
+
+    await waitForLog(session, () =>
+      session.log.ofType('plugin_event').some((event) => event.subtype === 'office_agent.message_final'),
+    );
+
+    const subtypes = session.log.ofType('plugin_event').map((event) => event.subtype);
+    expect(subtypes).toEqual(
+      expect.arrayContaining([
+        'office_agent.created',
+        'office_agent.run_started',
+        'office_agent.message_final',
+        'office_agent.run_completed',
+      ]),
+    );
+  });
+
+  it('lists the live session plus created office agents', async () => {
+    const session = buildSession();
+    const runtime = new OfficeAgentRuntime(session, silentLogger);
+
+    await runtime.create({ name: 'first' });
+    await runtime.create({ name: 'second' });
+
+    const ids = runtime.list().map((agent) => agent.id);
+    expect(ids[0]).toBe('session');
+    expect(ids).toHaveLength(3);
+    expect(runtime.list().filter((agent) => agent.kind === 'office_agent')).toHaveLength(2);
+  });
+
+  it('stores image attachments on office agent user prompts and history', async () => {
+    const session = buildSession();
+    const runtime = new OfficeAgentRuntime(session, silentLogger);
+
+    const agent = await runtime.create({ name: 'vision' });
+    runtime.startRun(agent.id, 'inspect this image', [
+      {
+        kind: 'image',
+        content: 'aW1hZ2U=',
+        mediaType: 'image/png',
+        name: 'screenshot.png',
+      },
+    ]);
+
+    await waitForLog(session, () =>
+      session.log.ofType('plugin_event').some((event) => event.subtype === 'office_agent.run_started'),
+    );
+
+    expect(runtime.history(agent.id)?.messages[0]).toMatchObject({
+      role: 'user',
+      text: 'inspect this image',
+      attachments: [
+        {
+          kind: 'image',
+          content: 'aW1hZ2U=',
+          mediaType: 'image/png',
+          name: 'screenshot.png',
+        },
+      ],
+    });
+    const runStarted = session.log.ofType('plugin_event').find((event) => event.subtype === 'office_agent.run_started');
+    expect(runStarted?.payload).toMatchObject({
+      envelope: {
+        payload: {
+          task: 'inspect this image',
+          attachments: [
+            {
+              kind: 'image',
+              content: 'aW1hZ2U=',
+              mediaType: 'image/png',
+              name: 'screenshot.png',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('archives dismissed office agents with chat and log history', async () => {
+    const session = buildSession();
+    const runtime = new OfficeAgentRuntime(session, silentLogger);
+
+    const agent = await runtime.create({ name: 'qa' });
+    runtime.startRun(agent.id, 'check the release');
+    await waitForLog(session, () =>
+      session.log.ofType('plugin_event').some((event) => event.subtype === 'office_agent.message_final'),
+    );
+
+    await runtime.dismiss(agent.id);
+
+    const graveyard = runtime.graveyard();
+    expect(graveyard).toHaveLength(1);
+    expect(graveyard[0]).toMatchObject({
+      agentId: agent.id,
+      agentName: 'qa',
+      outcome: 'stopped',
+      isSubagent: false,
+      task: 'check the release',
+      lastMessage: expect.stringContaining('office agent completed'),
+    });
+    expect(graveyard[0].chatHistory.map((message) => message.role)).toEqual(['user', 'assistant']);
+    expect(graveyard[0].logHistory.map((item) => item.eventType)).toEqual(
+      expect.arrayContaining(['run.started', 'message.final', 'run.completed']),
+    );
+    // The dismissed agent leaves the live list.
+    expect(runtime.list().map((entry) => entry.id)).toEqual(['session']);
+  });
+
+  it('projects unarchived office agents from a restored session log into graveyard, not live agents', async () => {
+    const session = buildSession();
+    const runtime = new OfficeAgentRuntime(session, silentLogger);
+
+    const agent = await runtime.create({ name: 'analyst' });
+    runtime.startRun(agent.id, 'summarise context');
+    await waitForLog(session, () =>
+      session.log.ofType('plugin_event').some((event) => event.subtype === 'office_agent.message_final'),
+    );
+
+    const restoredSession = buildSession(new EventLog(session.log.toJSON()));
+    const restoredRuntime = new OfficeAgentRuntime(restoredSession, silentLogger);
+
+    expect(restoredRuntime.list().map((entry) => entry.id)).toEqual(['session']);
+    expect(restoredRuntime.graveyard()).toEqual([
+      expect.objectContaining({
+        agentId: agent.id,
+        agentName: 'analyst',
+        outcome: 'stopped',
+        task: 'summarise context',
+      }),
+    ]);
+  });
+
+  it('projects completed runtime subagents from a restored session log into graveyard', async () => {
+    const session = buildSession();
+    const turnId = session.startTurn().turnId;
+
+    await session.log.append({
+      type: 'plugin_event',
+      sessionId: session.id,
+      turnId,
+      source: 'plugin',
+      pluginId: asPluginId('@moxxy/subagents'),
+      subtype: 'subagent_started',
+      payload: {
+        label: 'agent-polityka-iran',
+        childSessionId: 'child-iran',
+        prompt: 'Zbadaj relacje Trump-Iran',
+        mode: 'tool-use',
+      },
+    });
+    await session.log.append({
+      type: 'plugin_event',
+      sessionId: session.id,
+      turnId,
+      source: 'plugin',
+      pluginId: asPluginId('@moxxy/subagents'),
+      subtype: 'subagent_tool_call',
+      payload: {
+        label: 'agent-polityka-iran',
+        childSessionId: 'child-iran',
+        name: 'web_fetch',
+        input: { url: 'https://example.com' },
+        callId: 'call-1',
+      },
+    });
+    await session.log.append({
+      type: 'plugin_event',
+      sessionId: session.id,
+      turnId,
+      source: 'plugin',
+      pluginId: asPluginId('@moxxy/subagents'),
+      subtype: 'subagent_completed',
+      payload: {
+        label: 'agent-polityka-iran',
+        childSessionId: 'child-iran',
+        text: 'Iran result',
+        stopReason: 'stop',
+      },
+    });
+
+    const runtime = new OfficeAgentRuntime(buildSession(new EventLog(session.log.toJSON())), silentLogger);
+
+    expect(runtime.graveyard()).toEqual([
+      expect.objectContaining({
+        agentId: 'child-iran',
+        agentName: 'agent-polityka-iran',
+        outcome: 'completed',
+        isSubagent: true,
+        task: 'Zbadaj relacje Trump-Iran',
+        lastMessage: 'Iran result',
+      }),
+    ]);
+    expect(runtime.graveyard()[0].logHistory.map((item) => item.eventType)).toEqual(
+      expect.arrayContaining(['subagent.spawned', 'primitive.invoked', 'subagent.completed']),
+    );
+  });
+
+  it('routes office-agent tool permissions through the HTTP permission broker', async () => {
+    const provider = new FakeProvider({
+      script: [toolUseReply('web_fetch', { url: 'https://example.com' }, 'call-1'), textReply('done')],
+    });
+    const session = new Session({
+      cwd: process.cwd(),
+      logger: silentLogger,
+      permissionResolver: autoAllowResolver,
+    });
+    session.pluginHost.registerStatic(
+      definePlugin({
+        name: 'office-agent-permission-test-provider',
+        providers: [
+          defineProvider({
+            name: provider.name,
+            models: [...provider.models],
+            createClient: () => provider,
+          }),
+        ],
+      }),
+    );
+    session.providers.setActive(provider.name);
+    session.pluginHost.registerStatic(defaultModePlugin);
+    session.tools.register(
+      defineTool({
+        name: 'web_fetch',
+        description: 'Fetch a URL',
+        inputSchema: z.object({ url: z.string() }),
+        handler: () => 'fetched',
+      }),
+    );
+
+    const broker = new HttpPermissionBroker();
+    broker.attachSession(session);
+    session.setPermissionResolver(broker);
+    const runtime = new OfficeAgentRuntime(session, silentLogger, broker);
+
+    const agent = await runtime.create({ name: 'researcher' });
+    runtime.startRun(agent.id, 'search the web');
+
+    await waitForLog(session, () =>
+      session.log.ofType('plugin_event').some((event) => event.subtype === 'permission.requested'),
+    );
+
+    const request = session.log
+      .ofType('plugin_event')
+      .find((event) => event.subtype === 'permission.requested');
+    expect(request?.payload).toMatchObject({
+      agent_id: agent.id,
+      tool_name: 'web_fetch',
+    });
+    const requestId = (request?.payload as { request_id?: string } | undefined)?.request_id;
+    expect(requestId).toBeTruthy();
+
+    expect(await broker.decide(requestId!, { mode: 'allow_session', reason: 'test allow' })).toBe(true);
+
+    await waitForLog(session, () =>
+      session.log.ofType('plugin_event').some((event) => event.subtype === 'office_agent.message_final'),
+    );
+    expect(
+      session.log.ofType('plugin_event').some((event) => event.subtype === 'permission.resolved'),
+    ).toBe(true);
+  });
+});

--- a/packages/plugin-virtual-office/src/office-agent-runtime.ts
+++ b/packages/plugin-virtual-office/src/office-agent-runtime.ts
@@ -1,0 +1,867 @@
+import { EventLog, newSessionId, newTurnId, type Session } from '@moxxy/core';
+import { asPluginId } from '@moxxy/sdk';
+import type {
+  EmittedEvent,
+  EventLogReader,
+  ModeContext,
+  MoxxyEvent,
+  ToolDef,
+  ToolRegistry,
+  TurnId,
+  UserPromptAttachment,
+} from '@moxxy/sdk';
+import { eventToVirtualOfficeEnvelope, type VirtualOfficeEnvelope } from './virtual-office-events.js';
+import type { HttpPermissionBroker } from './permission-broker.js';
+
+const VIRTUAL_OFFICE_PLUGIN_ID = asPluginId('@moxxy/virtual-office');
+
+export interface OfficeAgentCapabilities {
+  run: boolean;
+  stop: boolean;
+  dismiss: boolean;
+  reset: boolean;
+}
+
+export interface VirtualOfficeAgent {
+  id: string;
+  name: string;
+  provider_id: string;
+  model_id: string;
+  status: 'idle' | 'running' | 'stopping' | 'error';
+  persona: string | null;
+  template: string;
+  created_at: string;
+  kind: 'session' | 'office_agent';
+  origin: 'moxxy_session' | 'virtual_office';
+  parent_id: string | null;
+  capabilities: OfficeAgentCapabilities;
+}
+
+export interface OfficeAgentCreateInput {
+  name?: string;
+  agent_type?: string;
+  instructions?: string;
+  model?: string;
+  allowed_tools?: string[];
+}
+
+export interface OfficeRunStart {
+  agent_id: string;
+  run_id: string | null;
+  task: string;
+  status: 'running';
+  attachments?: ReadonlyArray<UserPromptAttachment>;
+}
+
+export interface OfficeRunOptions {
+  systemPrompt?: string;
+}
+
+export interface OfficeAgentHistory {
+  messages: Array<{
+    role: 'user' | 'assistant';
+    text: string;
+    run_id: string | null;
+    timestamp: number;
+    attachments?: ReadonlyArray<UserPromptAttachment>;
+  }>;
+}
+
+export interface OfficeGraveyardChatMessage {
+  id: string;
+  agentId: string;
+  runId: string | null;
+  state: 'done';
+  role: 'user' | 'assistant';
+  text: string;
+  timestamp: number;
+  attachments?: ReadonlyArray<UserPromptAttachment>;
+}
+
+export interface OfficeGraveyardLogItem {
+  id: string;
+  agentId: string;
+  eventType: string;
+  summary: string;
+  severity: 'info' | 'warn' | 'error' | 'success' | 'progress';
+  timestamp: number;
+}
+
+export interface OfficeGraveyardEntry {
+  id: string;
+  agentId: string;
+  agentName: string | null;
+  runId: string | null;
+  outcome: 'completed' | 'failed' | 'stopped';
+  timestamp: number;
+  isSubagent: boolean;
+  task: string | null;
+  lastMessage: string | null;
+  recentLogs: string[];
+  chatHistory: OfficeGraveyardChatMessage[];
+  logHistory: OfficeGraveyardLogItem[];
+}
+
+type Listener = (envelope: VirtualOfficeEnvelope) => void;
+
+interface OfficeAgentState {
+  readonly id: string;
+  readonly sessionId: ReturnType<typeof newSessionId>;
+  readonly createdAt: string;
+  readonly log: EventLog;
+  readonly name: string;
+  readonly providerId: string;
+  readonly modelId: string;
+  readonly instructions: string | null;
+  readonly allowedTools: ReadonlyArray<string> | null;
+  readonly events: VirtualOfficeEnvelope[];
+  status: VirtualOfficeAgent['status'];
+  activeController: AbortController | null;
+  activeTurnId: string | null;
+}
+
+interface PersistedOfficeEnvelope {
+  envelope: VirtualOfficeEnvelope;
+  ts: number;
+  entry: OfficeGraveyardEntry | null;
+}
+
+export class OfficeAgentRuntime {
+  private readonly agents = new Map<string, OfficeAgentState>();
+  private readonly archivedEntries: OfficeGraveyardEntry[];
+  private readonly listeners = new Set<Listener>();
+  private nextId: number;
+  private nextSequence = 0;
+
+  constructor(
+    private readonly session: Session,
+    private readonly logger?: { warn(msg: string, meta?: Record<string, unknown>): void },
+    private readonly permissionBroker?: HttpPermissionBroker | null,
+  ) {
+    const persisted = readPersistedOfficeEnvelopes(session.log.toJSON());
+    this.archivedEntries = [
+      ...projectArchivedAgents(persisted),
+      ...projectRuntimeSubagents(session.log.toJSON()),
+    ].sort((a, b) => a.timestamp - b.timestamp);
+    this.nextId = nextOfficeAgentId(persisted);
+  }
+
+  list(): VirtualOfficeAgent[] {
+    return [this.sessionAgent(), ...[...this.agents.values()].map((agent) => this.snapshot(agent))];
+  }
+
+  get(id: string): VirtualOfficeAgent | null {
+    if (id === 'session') return this.sessionAgent();
+    const agent = this.agents.get(id);
+    return agent ? this.snapshot(agent) : null;
+  }
+
+  async create(input: OfficeAgentCreateInput): Promise<VirtualOfficeAgent> {
+    const { providerId, modelId } = activeProviderInfo(this.session);
+    const id = `office-agent-${String(this.nextId++).padStart(4, '0')}`;
+    const name = normalizeName(input.name) ?? input.agent_type ?? `agent-${id.slice(-4)}`;
+    const agent: OfficeAgentState = {
+      id,
+      sessionId: newSessionId(),
+      createdAt: new Date().toISOString(),
+      log: new EventLog(),
+      name,
+      providerId,
+      modelId: input.model ?? modelId,
+      instructions: normalizeOptional(input.instructions),
+      allowedTools: Array.isArray(input.allowed_tools) && input.allowed_tools.length > 0
+        ? [...input.allowed_tools]
+        : null,
+      events: [],
+      status: 'idle',
+      activeController: null,
+      activeTurnId: null,
+    };
+    this.agents.set(id, agent);
+    this.permissionBroker?.registerAgentSession(String(agent.sessionId), id);
+    const snapshot = this.snapshot(agent);
+    await this.emitLifecycle(agent, 'office_agent.created', { agent: snapshot });
+    return snapshot;
+  }
+
+  async dismiss(id: string): Promise<boolean> {
+    if (id === 'session') return false;
+    const agent = this.agents.get(id);
+    if (!agent) return false;
+    if (agent.activeController) {
+      agent.activeController.abort('office agent dismissed');
+    }
+    const entry = this.archiveEntry(agent, 'stopped');
+    await this.emitLifecycle(agent, 'office_agent.archived', { agent_id: id, entry });
+    this.archivedEntries.push(entry);
+    this.permissionBroker?.unregisterAgentSession(String(agent.sessionId));
+    this.agents.delete(id);
+    await this.emitLifecycle(null, 'office_agent.dismissed', { agent_id: id });
+    return true;
+  }
+
+  async archiveLiveAgents(reason = 'session_closed'): Promise<void> {
+    for (const agent of [...this.agents.values()]) {
+      if (agent.activeController) {
+        agent.activeController.abort(reason);
+      }
+      const entry = this.archiveEntry(agent, 'stopped');
+      await this.emitLifecycle(agent, 'office_agent.archived', { agent_id: agent.id, reason, entry });
+      this.archivedEntries.push(entry);
+      this.permissionBroker?.unregisterAgentSession(String(agent.sessionId));
+      this.agents.delete(agent.id);
+    }
+  }
+
+  stop(id: string): 'stopped' | 'unsupported' | 'not_found' | 'not_running' {
+    if (id === 'session') return 'unsupported';
+    const agent = this.agents.get(id);
+    if (!agent) return 'not_found';
+    if (!agent.activeController || agent.status !== 'running') return 'not_running';
+    agent.status = 'stopping';
+    agent.activeController.abort('office agent stopped');
+    void this.emitLifecycle(agent, 'office_agent.updated', { agent: this.snapshot(agent) });
+    return 'stopped';
+  }
+
+  reset(id: string): VirtualOfficeAgent | null {
+    if (id === 'session') return this.sessionAgent();
+    const agent = this.agents.get(id);
+    if (!agent) return null;
+    if (agent.activeController) agent.activeController.abort('office agent reset');
+    agent.log.clear();
+    agent.status = 'idle';
+    agent.activeController = null;
+    agent.activeTurnId = null;
+    agent.events.length = 0;
+    const snapshot = this.snapshot(agent);
+    void this.emitLifecycle(agent, 'office_agent.updated', { agent: snapshot });
+    return snapshot;
+  }
+
+  history(id: string): OfficeAgentHistory | null {
+    const agent = this.agents.get(id);
+    if (!agent) return null;
+    return { messages: messagesFromLog(agent.log, id) };
+  }
+
+  graveyard(): OfficeGraveyardEntry[] {
+    return [...this.archivedEntries];
+  }
+
+  startRun(
+    id: string,
+    task: string,
+    attachments: ReadonlyArray<UserPromptAttachment> = [],
+    options?: OfficeRunOptions,
+  ): OfficeRunStart | 'not_found' | 'already_running' {
+    if (id === 'session') return 'not_found';
+    const agent = this.agents.get(id);
+    if (!agent) return 'not_found';
+    if (agent.status === 'running' || agent.status === 'stopping') return 'already_running';
+    const turnId = newTurnId();
+    const controller = new AbortController();
+    agent.status = 'running';
+    agent.activeController = controller;
+    agent.activeTurnId = String(turnId);
+    void this.emitLifecycle(agent, 'office_agent.updated', { agent: this.snapshot(agent) });
+
+    const unsubscribe = agent.log.subscribe(async (event) => {
+      const envelope = eventToVirtualOfficeEnvelope(event, id);
+      if (!envelope) return;
+      await this.recordEnvelope(agent, envelope, event.turnId);
+    });
+
+    void this.runAgentTurn(agent, turnId, task, attachments, controller.signal, options)
+      .then(async (result) => {
+        if (result !== 'completed') return;
+        await this.recordEnvelope(agent, {
+          agent_id: id,
+          run_id: String(turnId),
+          parent_run_id: null,
+          sequence: this.nextSequence++,
+          event_type: 'run.completed',
+          payload: {},
+          sensitive: false,
+        }, turnId);
+      })
+      .catch((err) => {
+        this.logger?.warn('office agent run failed', {
+          agentId: id,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(() => {
+        unsubscribe();
+        if (this.agents.get(id) !== agent) return;
+        if (agent.activeController === controller) {
+          agent.activeController = null;
+          agent.activeTurnId = null;
+          agent.status = agent.status === 'error' ? 'error' : 'idle';
+          void this.emitLifecycle(agent, 'office_agent.updated', { agent: this.snapshot(agent) });
+        }
+      });
+
+    return {
+      agent_id: id,
+      run_id: String(turnId),
+      task,
+      status: 'running',
+      ...(attachments.length > 0 ? { attachments } : {}),
+    };
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private async runAgentTurn(
+    agent: OfficeAgentState,
+    turnId: ReturnType<typeof newTurnId>,
+    task: string,
+    attachments: ReadonlyArray<UserPromptAttachment>,
+    signal: AbortSignal,
+    options?: OfficeRunOptions,
+  ): Promise<'completed' | 'failed'> {
+    const effectiveSignal = AbortSignal.any([this.session.signal, signal]);
+    await agent.log.append({
+      type: 'user_prompt',
+      sessionId: agent.sessionId,
+      turnId,
+      source: 'user',
+      text: task,
+      ...(attachments.length > 0 ? { attachments } : {}),
+    });
+    const mode = this.session.modes.getActive();
+    const toolRegistry = agent.allowedTools
+      ? buildAllowedToolsRegistry(this.session.tools as unknown as ToolRegistry, new Set(agent.allowedTools))
+      : (this.session.tools as unknown as ToolRegistry);
+    const systemPrompt = mergeSystemPrompt(agent.instructions, options?.systemPrompt);
+    const ctx: ModeContext = {
+      sessionId: agent.sessionId,
+      turnId,
+      model: agent.modelId,
+      ...(systemPrompt ? { systemPrompt } : {}),
+      provider: this.session.providers.getActive(),
+      tools: toolRegistry,
+      skills: this.session.skills,
+      log: agent.log as unknown as EventLogReader,
+      compactor: this.session.compactors.getActive(),
+      cacheStrategy: this.session.cacheStrategies.getActive(),
+      permissions: this.session.resolver,
+      ...(this.session.approvalResolver ? { approval: this.session.approvalResolver } : {}),
+      hooks: this.session.dispatcher,
+      pluginHost: this.session.pluginHost,
+      signal: effectiveSignal,
+      emit: (event: EmittedEvent): Promise<MoxxyEvent> => agent.log.append(event),
+    };
+    const turnCtx = { ...this.session.appContext(), turnId, iteration: 0 };
+    try {
+      await this.session.dispatcher.dispatchTurnStart(turnCtx);
+      for await (const _ of mode.run(ctx)) void _;
+      await this.session.dispatcher.dispatchTurnEnd(turnCtx);
+      return 'completed';
+    } catch (err) {
+      agent.status = effectiveSignal.aborted ? 'idle' : 'error';
+      await agent.log.append({
+        type: effectiveSignal.aborted ? 'abort' : 'error',
+        sessionId: agent.sessionId,
+        turnId,
+        source: 'system',
+        ...(effectiveSignal.aborted
+          ? { reason: String(effectiveSignal.reason ?? 'aborted') }
+          : { kind: 'fatal', message: err instanceof Error ? err.message : String(err) }),
+      } as EmittedEvent);
+      return 'failed';
+    }
+  }
+
+  private sessionAgent(): VirtualOfficeAgent {
+    const { providerId, modelId } = activeProviderInfo(this.session);
+    return {
+      id: 'session',
+      name: 'session',
+      provider_id: providerId,
+      model_id: modelId,
+      status: 'idle',
+      persona: null,
+      template: 'moxxy-session',
+      created_at: new Date(0).toISOString(),
+      kind: 'session',
+      origin: 'moxxy_session',
+      parent_id: null,
+      capabilities: {
+        run: true,
+        stop: false,
+        dismiss: false,
+        reset: true,
+      },
+    };
+  }
+
+  private snapshot(agent: OfficeAgentState): VirtualOfficeAgent {
+    return {
+      id: agent.id,
+      name: agent.name,
+      provider_id: agent.providerId,
+      model_id: agent.modelId,
+      status: agent.status,
+      persona: agent.instructions,
+      template: 'office-agent',
+      created_at: agent.createdAt,
+      kind: 'office_agent',
+      origin: 'virtual_office',
+      parent_id: 'session',
+      capabilities: {
+        run: true,
+        stop: true,
+        dismiss: true,
+        reset: true,
+      },
+    };
+  }
+
+  private async emitLifecycle(
+    agent: OfficeAgentState | null,
+    eventType: string,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
+    const envelope = {
+      agent_id: agent?.id ?? (typeof payload.agent_id === 'string' ? payload.agent_id : 'session'),
+      run_id: null,
+      parent_run_id: null,
+      sequence: this.nextSequence++,
+      event_type: eventType,
+      payload,
+      sensitive: false,
+    };
+    await this.recordEnvelope(agent, envelope, newTurnId());
+  }
+
+  private emit(envelope: VirtualOfficeEnvelope): void {
+    for (const listener of [...this.listeners]) listener(envelope);
+  }
+
+  private async recordEnvelope(
+    agent: OfficeAgentState | null,
+    envelope: VirtualOfficeEnvelope,
+    turnId: TurnId,
+  ): Promise<void> {
+    if (agent) agent.events.push(envelope);
+    await this.session.log.append({
+      type: 'plugin_event',
+      sessionId: this.session.id,
+      turnId,
+      source: 'plugin',
+      pluginId: VIRTUAL_OFFICE_PLUGIN_ID,
+      subtype: officeSubtype(envelope.event_type),
+      payload: { envelope, entry: readEntryPayload(envelope.payload) },
+    });
+    this.emit(envelope);
+  }
+
+  private archiveEntry(
+    agent: OfficeAgentState,
+    outcome: OfficeGraveyardEntry['outcome'],
+  ): OfficeGraveyardEntry {
+    return buildGraveyardEntryFromEnvelopes(agent.id, agent.name, agent.events, Date.now(), outcome, false);
+  }
+}
+
+export function activeProviderInfo(session: Session): {
+  providerId: string;
+  modelId: string;
+} {
+  const activeName = session.providers.getActiveName();
+  const providers = session.providers.list();
+  const activeDef = providers.find((provider) => provider.name === activeName) ?? providers[0];
+  return {
+    providerId: activeDef?.name ?? activeName ?? 'none',
+    modelId: activeDef?.models[0]?.id ?? 'default',
+  };
+}
+
+function normalizeName(name: string | undefined): string | null {
+  const trimmed = name?.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, 64);
+}
+
+function normalizeOptional(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function mergeSystemPrompt(...parts: ReadonlyArray<string | null | undefined>): string | undefined {
+  const text = parts
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part))
+    .join('\n\n');
+  return text || undefined;
+}
+
+function messagesFromLog(log: EventLog, agentId: string): OfficeAgentHistory['messages'] {
+  const messages: OfficeAgentHistory['messages'] = [];
+  for (const event of log.toJSON()) {
+    if (event.type === 'user_prompt') {
+      messages.push({
+        role: 'user' as const,
+        text: event.text,
+        run_id: String(event.turnId),
+        timestamp: event.ts,
+        ...(event.attachments && event.attachments.length > 0 ? { attachments: event.attachments } : {}),
+      });
+      continue;
+    }
+    if (event.type === 'assistant_message') {
+      messages.push({
+        role: 'assistant' as const,
+        text: event.content,
+        run_id: String(event.turnId),
+        timestamp: event.ts,
+      });
+    }
+  }
+  return messages.filter((message) => message.text.trim().length > 0 && agentId.length > 0);
+}
+
+function buildAllowedToolsRegistry(registry: ToolRegistry, allowed: ReadonlySet<string>): ToolRegistry {
+  return {
+    list(): ReadonlyArray<ToolDef> {
+      return registry.list().filter((tool) => allowed.has(tool.name));
+    },
+    get(name: string): ToolDef | undefined {
+      return allowed.has(name) ? registry.get(name) : undefined;
+    },
+    execute(name: string, input: unknown, signal: AbortSignal, opts?: Parameters<ToolRegistry['execute']>[3]): Promise<unknown> {
+      if (!allowed.has(name)) throw new Error(`tool not allowed for office agent: ${name}`);
+      return registry.execute(name, input, signal, opts);
+    },
+  };
+}
+
+function officeSubtype(eventType: string): string {
+  if (eventType.startsWith('office_agent.')) return eventType;
+  return `office_agent.${eventType.replace(/\./g, '_')}`;
+}
+
+function readEntryPayload(payload: Record<string, unknown>): OfficeGraveyardEntry | null {
+  const entry = payload.entry;
+  return isOfficeGraveyardEntry(entry) ? entry : null;
+}
+
+function readPersistedOfficeEnvelopes(events: ReadonlyArray<MoxxyEvent>): PersistedOfficeEnvelope[] {
+  const out: PersistedOfficeEnvelope[] = [];
+  for (const event of events) {
+    if (event.type !== 'plugin_event') continue;
+    if (String(event.pluginId) !== String(VIRTUAL_OFFICE_PLUGIN_ID)) continue;
+    if (!event.payload || typeof event.payload !== 'object') continue;
+    const payload = event.payload as Record<string, unknown>;
+    const envelope = payload.envelope;
+    if (!isVirtualOfficeEnvelope(envelope)) continue;
+    out.push({
+      envelope,
+      ts: event.ts,
+      entry: isOfficeGraveyardEntry(payload.entry) ? payload.entry : null,
+    });
+  }
+  return out;
+}
+
+function projectArchivedAgents(persisted: ReadonlyArray<PersistedOfficeEnvelope>): OfficeGraveyardEntry[] {
+  const grouped = new Map<string, PersistedOfficeEnvelope[]>();
+  const archived = new Map<string, OfficeGraveyardEntry>();
+  for (const item of persisted) {
+    const agentId = item.envelope.agent_id;
+    if (!agentId.startsWith('office-agent-')) continue;
+    const list = grouped.get(agentId) ?? [];
+    list.push(item);
+    grouped.set(agentId, list);
+    if (item.envelope.event_type === 'office_agent.archived' && item.entry) {
+      archived.set(agentId, item.entry);
+    }
+  }
+
+  const entries: OfficeGraveyardEntry[] = [];
+  for (const [agentId, items] of grouped) {
+    const archivedEntry = archived.get(agentId);
+    if (archivedEntry) {
+      entries.push(archivedEntry);
+      continue;
+    }
+    const envelopes = items.map((item) => item.envelope);
+    const name = readAgentName(envelopes) ?? agentId;
+    const timestamp = items.at(-1)?.ts ?? Date.now();
+    entries.push(buildGraveyardEntryFromEnvelopes(agentId, name, envelopes, timestamp, 'stopped', false));
+  }
+  return entries.sort((a, b) => a.timestamp - b.timestamp);
+}
+
+function projectRuntimeSubagents(events: ReadonlyArray<MoxxyEvent>): OfficeGraveyardEntry[] {
+  const grouped = new Map<string, { envelopes: VirtualOfficeEnvelope[]; timestamps: number[] }>();
+  for (const event of events) {
+    if (event.type !== 'plugin_event') continue;
+    if (String(event.pluginId) !== '@moxxy/subagents') continue;
+    const envelope = eventToVirtualOfficeEnvelope(event, 'session');
+    if (!envelope) continue;
+    const current = grouped.get(envelope.agent_id) ?? { envelopes: [], timestamps: [] };
+    current.envelopes.push(envelope);
+    current.timestamps.push(event.ts);
+    grouped.set(envelope.agent_id, current);
+  }
+
+  const entries: OfficeGraveyardEntry[] = [];
+  for (const [agentId, item] of grouped) {
+    const terminal = [...item.envelopes].reverse().find(
+      (event) => event.event_type === 'subagent.completed' || event.event_type === 'subagent.failed',
+    );
+    if (!terminal) continue;
+    const outcome = terminal.event_type === 'subagent.failed' ? 'failed' : 'completed';
+    const timestamp = item.timestamps.at(-1) ?? Date.now();
+    entries.push(buildGraveyardEntryFromEnvelopes(
+      agentId,
+      readSubagentName(item.envelopes) ?? agentId,
+      item.envelopes,
+      timestamp,
+      outcome,
+      true,
+    ));
+  }
+  return entries.sort((a, b) => a.timestamp - b.timestamp);
+}
+
+function nextOfficeAgentId(persisted: ReadonlyArray<PersistedOfficeEnvelope>): number {
+  let max = 0;
+  for (const item of persisted) {
+    const match = /^office-agent-(\d+)$/.exec(item.envelope.agent_id);
+    if (!match) continue;
+    max = Math.max(max, Number(match[1]));
+  }
+  return max + 1;
+}
+
+function buildGraveyardEntryFromEnvelopes(
+  agentId: string,
+  agentName: string | null,
+  envelopes: ReadonlyArray<VirtualOfficeEnvelope>,
+  timestamp: number,
+  outcome: OfficeGraveyardEntry['outcome'],
+  isSubagent: boolean,
+): OfficeGraveyardEntry {
+  const chatHistory = buildChatHistory(agentId, envelopes, timestamp);
+  const logHistory = buildLogHistory(agentId, envelopes, timestamp);
+  const runId = [...envelopes].reverse().find((event) => event.run_id)?.run_id ?? null;
+  const task = [...chatHistory].reverse()
+    .find((message) => message.role === 'user' && (!runId || message.runId === runId))?.text ?? null;
+  const lastMessage = [...chatHistory].reverse().find((message) => message.text.trim())?.text ?? null;
+  const recentLogs = logHistory.slice(-5).map((item) => item.summary);
+  return {
+    id: `${agentId}-${runId ?? 'no-run'}-${timestamp}`,
+    agentId,
+    agentName,
+    runId,
+    outcome,
+    timestamp,
+    isSubagent,
+    task,
+    lastMessage,
+    recentLogs,
+    chatHistory,
+    logHistory,
+  };
+}
+
+function buildChatHistory(
+  agentId: string,
+  envelopes: ReadonlyArray<VirtualOfficeEnvelope>,
+  fallbackTs: number,
+): OfficeGraveyardChatMessage[] {
+  const messages: OfficeGraveyardChatMessage[] = [];
+  envelopes.forEach((event, index) => {
+    if (event.event_type === 'run.started') {
+      const task = typeof event.payload.task === 'string' ? event.payload.task : '';
+      if (!task.trim()) return;
+      messages.push({
+        id: `${agentId}:${event.run_id ?? 'run'}:user:${index}`,
+        agentId,
+        runId: event.run_id ?? null,
+        state: 'done',
+        role: 'user',
+        text: task,
+        timestamp: fallbackTs + index,
+        ...readEnvelopeAttachments(event),
+      });
+      return;
+    }
+    if (event.event_type === 'subagent.spawned') {
+      const task = typeof event.payload.prompt === 'string' ? event.payload.prompt : '';
+      if (!task.trim()) return;
+      messages.push({
+        id: `${agentId}:${event.run_id ?? 'run'}:user:${index}`,
+        agentId,
+        runId: event.run_id ?? null,
+        state: 'done',
+        role: 'user',
+        text: task,
+        timestamp: fallbackTs + index,
+      });
+      return;
+    }
+    if (event.event_type === 'message.final') {
+      const content = typeof event.payload.content === 'string' ? event.payload.content : '';
+      if (!content.trim()) return;
+      messages.push({
+        id: `${agentId}:${event.run_id ?? 'run'}:assistant:${index}`,
+        agentId,
+        runId: event.run_id ?? null,
+        state: 'done',
+        role: 'assistant',
+        text: content,
+        timestamp: fallbackTs + index,
+      });
+    }
+    if (event.event_type === 'subagent.completed' || event.event_type === 'subagent.failed') {
+      const content =
+        typeof event.payload.result === 'string'
+          ? event.payload.result
+          : typeof event.payload.error === 'string'
+            ? event.payload.error
+            : '';
+      if (!content.trim()) return;
+      messages.push({
+        id: `${agentId}:${event.run_id ?? 'run'}:assistant:${index}`,
+        agentId,
+        runId: event.run_id ?? null,
+        state: 'done',
+        role: 'assistant',
+        text: content,
+        timestamp: fallbackTs + index,
+      });
+    }
+  });
+  return messages;
+}
+
+function readEnvelopeAttachments(event: VirtualOfficeEnvelope): { attachments?: ReadonlyArray<UserPromptAttachment> } {
+  const raw = event.payload.attachments;
+  if (!Array.isArray(raw)) return {};
+  const attachments = raw.filter(isUserPromptAttachment);
+  return attachments.length > 0 ? { attachments } : {};
+}
+
+function isUserPromptAttachment(value: unknown): value is UserPromptAttachment {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return (
+    (record.kind === 'stdin' || record.kind === 'file' || record.kind === 'image' || record.kind === 'audio') &&
+    typeof record.content === 'string' &&
+    (record.name === undefined || typeof record.name === 'string') &&
+    (record.mediaType === undefined || typeof record.mediaType === 'string')
+  );
+}
+
+function buildLogHistory(
+  agentId: string,
+  envelopes: ReadonlyArray<VirtualOfficeEnvelope>,
+  fallbackTs: number,
+): OfficeGraveyardLogItem[] {
+  return envelopes.map((event, index) => ({
+    id: `${agentId}:${event.sequence}:${index}`,
+    agentId,
+    eventType: event.event_type,
+    summary: summarizeEnvelope(event),
+    severity: event.event_type.endsWith('.failed') ? 'error' : 'info',
+    timestamp: fallbackTs + index,
+  }));
+}
+
+function summarizeEnvelope(event: VirtualOfficeEnvelope): string {
+  const text = (key: string): string => (typeof event.payload[key] === 'string' ? String(event.payload[key]) : '');
+  switch (event.event_type) {
+    case 'run.started':
+      return `Run started${text('task') ? `: ${text('task')}` : ''}`;
+    case 'run.completed':
+      return 'Run completed';
+    case 'run.failed':
+      return `Run failed${text('error') ? `: ${text('error')}` : ''}`;
+    case 'message.final':
+      return 'Message complete';
+    case 'primitive.invoked':
+      return `${text('name') || 'primitive'} invoked`;
+    case 'primitive.completed':
+      return `${text('name') || 'primitive'} done`;
+    case 'primitive.failed':
+      return `${text('name') || 'primitive'} failed`;
+    case 'skill.invoked':
+      return `Skill: ${text('skill_id') || text('name') || 'unknown'}`;
+    case 'office_agent.created': {
+      const name = readAgentName([event]);
+      return `Office agent created${name ? `: ${name}` : ''}`;
+    }
+    case 'office_agent.archived':
+      return 'Office agent archived';
+    case 'office_agent.dismissed':
+      return 'Office agent dismissed';
+    case 'subagent.spawned':
+      return `Subagent spawned${text('child_name') ? `: ${text('child_name')}` : ''}`;
+    case 'subagent.completed':
+      return `Subagent completed${text('child_name') ? `: ${text('child_name')}` : ''}`;
+    case 'subagent.failed':
+      return `Subagent failed${text('error') ? `: ${text('error')}` : ''}`;
+    default:
+      return event.event_type;
+  }
+}
+
+function readAgentName(envelopes: ReadonlyArray<VirtualOfficeEnvelope>): string | null {
+  for (const event of envelopes) {
+    const agent = event.payload.agent;
+    if (!agent || typeof agent !== 'object') continue;
+    const name = (agent as Record<string, unknown>).name;
+    if (typeof name === 'string' && name.trim()) return name;
+  }
+  return null;
+}
+
+function readSubagentName(envelopes: ReadonlyArray<VirtualOfficeEnvelope>): string | null {
+  for (const event of envelopes) {
+    const name = event.payload.child_name;
+    if (typeof name === 'string' && name.trim()) return name;
+    const label = event.payload.label;
+    if (typeof label === 'string' && label.trim()) return label;
+  }
+  return null;
+}
+
+function isVirtualOfficeEnvelope(value: unknown): value is VirtualOfficeEnvelope {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.agent_id === 'string' &&
+    (record.run_id === null || typeof record.run_id === 'string' || record.run_id === undefined) &&
+    (record.parent_run_id === null || typeof record.parent_run_id === 'string' || record.parent_run_id === undefined) &&
+    typeof record.sequence === 'number' &&
+    typeof record.event_type === 'string' &&
+    !!record.payload &&
+    typeof record.payload === 'object' &&
+    typeof record.sensitive === 'boolean'
+  );
+}
+
+function isOfficeGraveyardEntry(value: unknown): value is OfficeGraveyardEntry {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === 'string' &&
+    typeof record.agentId === 'string' &&
+    (record.agentName === null || typeof record.agentName === 'string') &&
+    (record.runId === null || typeof record.runId === 'string') &&
+    (record.outcome === 'completed' || record.outcome === 'failed' || record.outcome === 'stopped') &&
+    typeof record.timestamp === 'number' &&
+    typeof record.isSubagent === 'boolean' &&
+    Array.isArray(record.recentLogs) &&
+    Array.isArray(record.chatHistory) &&
+    Array.isArray(record.logHistory)
+  );
+}

--- a/packages/plugin-virtual-office/src/permission-broker.test.ts
+++ b/packages/plugin-virtual-office/src/permission-broker.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { Session, silentLogger } from '@moxxy/core';
+import { asToolCallId, type PendingToolCall, type PermissionContext } from '@moxxy/sdk';
+import {
+  HttpPermissionBroker,
+  PERMISSION_REQUESTED_SUBTYPE,
+  PERMISSION_RESOLVED_SUBTYPE,
+} from './permission-broker.js';
+
+function buildSession(): Session {
+  return new Session({ cwd: process.cwd(), logger: silentLogger });
+}
+
+function call(name = 'web_fetch'): PendingToolCall {
+  return { name, callId: asToolCallId('call-1'), input: { url: 'https://example.com' } };
+}
+
+function context(session: Session, overrides: Partial<PermissionContext> = {}): PermissionContext {
+  return {
+    sessionId: session.id,
+    toolDescription: 'Fetch a URL',
+    ...overrides,
+  } as PermissionContext;
+}
+
+describe('HttpPermissionBroker', () => {
+  it('denies when no session is attached', async () => {
+    const broker = new HttpPermissionBroker();
+    const decision = await broker.check(call(), { sessionId: 'orphan' } as PermissionContext);
+    expect(decision.mode).toBe('deny');
+  });
+
+  it('publishes a permission.requested event and stays pending until decided', async () => {
+    const session = buildSession();
+    const broker = new HttpPermissionBroker();
+    broker.attachSession(session);
+
+    let resolved = false;
+    const pending = broker.check(call(), context(session)).then((decision) => {
+      resolved = true;
+      return decision;
+    });
+
+    // Give the broker a tick to append the request event.
+    await new Promise((r) => setTimeout(r, 10));
+    const request = session.log
+      .ofType('plugin_event')
+      .find((event) => event.subtype === PERMISSION_REQUESTED_SUBTYPE);
+    expect(request?.payload).toMatchObject({ agent_id: 'session', tool_name: 'web_fetch' });
+    const requestId = (request?.payload as { request_id?: string }).request_id;
+    expect(requestId).toBeTruthy();
+    expect(resolved).toBe(false);
+
+    expect(await broker.decide(requestId!, { mode: 'allow', reason: 'ok' })).toBe(true);
+    const decision = await pending;
+    expect(decision.mode).toBe('allow');
+    expect(resolved).toBe(true);
+
+    expect(
+      session.log.ofType('plugin_event').some((event) => event.subtype === PERMISSION_RESOLVED_SUBTYPE),
+    ).toBe(true);
+  });
+
+  it('tags requests with the office agent id registered for the calling session', async () => {
+    const session = buildSession();
+    const broker = new HttpPermissionBroker();
+    broker.attachSession(session);
+    broker.registerAgentSession('office-session-99', 'office-agent-0007');
+
+    void broker.check(call(), context(session, { sessionId: 'office-session-99' as PermissionContext['sessionId'] }));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const request = session.log
+      .ofType('plugin_event')
+      .find((event) => event.subtype === PERMISSION_REQUESTED_SUBTYPE);
+    expect(request?.payload).toMatchObject({ agent_id: 'office-agent-0007' });
+
+    broker.abortAll();
+  });
+
+  it('remembers allow_session decisions and short-circuits subsequent checks for that tool', async () => {
+    const session = buildSession();
+    const broker = new HttpPermissionBroker();
+    broker.attachSession(session);
+
+    const first = broker.check(call(), context(session));
+    await new Promise((r) => setTimeout(r, 10));
+    const requestId = (
+      session.log.ofType('plugin_event').find((e) => e.subtype === PERMISSION_REQUESTED_SUBTYPE)
+        ?.payload as { request_id?: string }
+    ).request_id;
+    await broker.decide(requestId!, { mode: 'allow_session' });
+    await first;
+
+    // A second check for the same tool resolves immediately without a new event.
+    const before = session.log.ofType('plugin_event').filter((e) => e.subtype === PERMISSION_REQUESTED_SUBTYPE).length;
+    const second = await broker.check(call(), context(session));
+    expect(second.mode).toBe('allow_session');
+    const after = session.log.ofType('plugin_event').filter((e) => e.subtype === PERMISSION_REQUESTED_SUBTYPE).length;
+    expect(after).toBe(before);
+  });
+
+  it('returns false when deciding an unknown request id', async () => {
+    const session = buildSession();
+    const broker = new HttpPermissionBroker();
+    broker.attachSession(session);
+    expect(await broker.decide('perm-does-not-exist', { mode: 'allow' })).toBe(false);
+  });
+
+  it('abortAll denies every pending request', async () => {
+    const session = buildSession();
+    const broker = new HttpPermissionBroker();
+    broker.attachSession(session);
+
+    const pending = broker.check(call(), context(session));
+    await new Promise((r) => setTimeout(r, 10));
+    broker.abortAll('shutting down');
+    const decision = await pending;
+    expect(decision.mode).toBe('deny');
+    expect(decision.reason).toBe('shutting down');
+  });
+});

--- a/packages/plugin-virtual-office/src/permission-broker.ts
+++ b/packages/plugin-virtual-office/src/permission-broker.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from 'node:crypto';
+import { newTurnId, type Session } from '@moxxy/core';
+import {
+  asPluginId,
+  type PendingToolCall,
+  type PermissionContext,
+  type PermissionDecision,
+  type PermissionResolver,
+} from '@moxxy/sdk';
+
+export const PERMISSION_REQUESTED_SUBTYPE = 'permission.requested';
+export const PERMISSION_RESOLVED_SUBTYPE = 'permission.resolved';
+
+const PERMISSION_PLUGIN_ID = asPluginId('@moxxy/plugin-virtual-office');
+
+type PendingPermission = {
+  readonly call: PendingToolCall;
+  readonly agentId: string;
+  readonly resolve: (decision: PermissionDecision) => void;
+};
+
+/**
+ * A {@link PermissionResolver} that turns each tool-permission check into an
+ * out-of-band HTTP exchange: the request is published as a `permission.requested`
+ * session event (which the office SSE stream surfaces), and the resolver Promise
+ * stays pending until the client POSTs a decision to
+ * `/v1/permissions/:requestId/decision` (routed through {@link decide}).
+ *
+ * Only wired in when the channel is started with `interactivePermissions: true`.
+ * Without that opt-in the channel keeps its allow-list / deny-by-default story,
+ * so the existing HTTP behavior is unchanged.
+ */
+export class HttpPermissionBroker implements PermissionResolver {
+  readonly name = 'http-interactive';
+  private session: Session | null = null;
+  private readonly pending = new Map<string, PendingPermission>();
+  private readonly allowSessionTools = new Set<string>();
+  private readonly agentBySessionId = new Map<string, string>();
+
+  attachSession(session: Session): void {
+    this.session = session;
+    this.registerAgentSession(String(session.id), 'session');
+  }
+
+  registerAgentSession(sessionId: string, agentId: string): void {
+    this.agentBySessionId.set(sessionId, agentId);
+  }
+
+  unregisterAgentSession(sessionId: string): void {
+    this.agentBySessionId.delete(sessionId);
+  }
+
+  async check(call: PendingToolCall, ctx: PermissionContext): Promise<PermissionDecision> {
+    if (this.allowSessionTools.has(call.name)) {
+      return { mode: 'allow_session', reason: 'allow_session previously granted' };
+    }
+    if (!this.session) {
+      return { mode: 'deny', reason: 'HTTP permission broker is not attached to a session' };
+    }
+
+    const requestId = `perm-${randomUUID()}`;
+    const agentId = this.agentBySessionId.get(ctx.sessionId) ?? 'session';
+    await this.session.log.append({
+      type: 'plugin_event',
+      sessionId: this.session.id,
+      turnId: newTurnId(),
+      source: 'plugin',
+      pluginId: PERMISSION_PLUGIN_ID,
+      subtype: PERMISSION_REQUESTED_SUBTYPE,
+      payload: {
+        request_id: requestId,
+        agent_id: agentId,
+        tool_name: call.name,
+        tool_description: ctx.toolDescription ?? null,
+        call: {
+          call_id: String(call.callId ?? ''),
+          name: call.name,
+          input: call.input,
+        },
+        created_at: new Date().toISOString(),
+      },
+    });
+
+    return new Promise<PermissionDecision>((resolve) => {
+      this.pending.set(requestId, { call, agentId, resolve });
+    });
+  }
+
+  async decide(requestId: string, decision: PermissionDecision): Promise<boolean> {
+    const pending = this.pending.get(requestId);
+    if (!pending || !this.session) return false;
+    this.pending.delete(requestId);
+
+    if (decision.mode === 'allow_session' || decision.mode === 'allow_always') {
+      this.allowSessionTools.add(pending.call.name);
+    }
+    if (decision.mode === 'allow_always') {
+      await this.session.permissions
+        .addAllow({ name: pending.call.name, reason: 'allow_always via Virtual Office' })
+        .catch(() => undefined);
+    }
+
+    pending.resolve(decision);
+    await this.session.log.append({
+      type: 'plugin_event',
+      sessionId: this.session.id,
+      turnId: newTurnId(),
+      source: 'plugin',
+      pluginId: PERMISSION_PLUGIN_ID,
+      subtype: PERMISSION_RESOLVED_SUBTYPE,
+      payload: {
+        request_id: requestId,
+        agent_id: pending.agentId,
+        tool_name: pending.call.name,
+        mode: decision.mode,
+        reason: decision.reason ?? null,
+      },
+    });
+    return true;
+  }
+
+  abortAll(reason = 'permission broker stopped'): void {
+    for (const [requestId, pending] of [...this.pending.entries()]) {
+      this.pending.delete(requestId);
+      pending.resolve({ mode: 'deny', reason });
+    }
+  }
+}

--- a/packages/plugin-virtual-office/src/routes.ts
+++ b/packages/plugin-virtual-office/src/routes.ts
@@ -1,0 +1,591 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { z } from 'zod';
+import type {
+  ClientSession,
+  ModelDescriptor,
+  ProviderDef,
+  UserPromptAttachment,
+} from '@moxxy/sdk';
+import type { OfficeAgentRuntime } from './office-agent-runtime.js';
+import { eventToVirtualOfficeEnvelope, type VirtualOfficeEnvelope } from './virtual-office-events.js';
+import type { HttpPermissionBroker } from './permission-broker.js';
+
+export type OfficeLogger = { warn(msg: string, meta?: Record<string, unknown>): void };
+
+/** A crash-safe SSE writer handed to the events route by the channel. */
+export interface OfficeEventStream {
+  /** Write one JSON envelope as an SSE `data:` frame; never throws. */
+  send(data: unknown): void;
+  /** Resolves when the client disconnects (and the stream is torn down). */
+  readonly closed: Promise<void>;
+}
+
+/**
+ * Per-request context the channel hands each office route. It mirrors the
+ * generic shape a network channel provides — the live session, the office
+ * runtime + (optional) permission broker, the raw req/res, path helpers, a
+ * size-capped body reader, a JSON `reply`, and a crash-safe SSE opener. The
+ * channel has already enforced bearer auth before any route sees this.
+ */
+export interface OfficeRequestContext {
+  readonly session: ClientSession;
+  readonly runtime: OfficeAgentRuntime;
+  readonly broker: HttpPermissionBroker | null;
+  readonly req: IncomingMessage;
+  readonly res: ServerResponse;
+  readonly pathname: string;
+  readonly logger?: OfficeLogger;
+  /** Path segment by index (`/v1/agents/abc` → `pathSegment(3) === 'abc'`). */
+  pathSegment(n: number): string;
+  /** Read the body as UTF-8, rejecting once `max` bytes (default 64 KiB) is exceeded. */
+  readBody(max?: number): Promise<string>;
+  /** Send a JSON response with the given status. */
+  reply(status: number, body: unknown): void;
+  /** Begin a crash-safe SSE stream on the response. */
+  openEventStream(): OfficeEventStream;
+}
+
+export interface OfficeRoute {
+  readonly method: 'GET' | 'POST' | 'DELETE';
+  match(pathname: string): boolean;
+  handle(ctx: OfficeRequestContext): Promise<void>;
+}
+
+// Virtual Office attachment caps. A single base64-encoded image is bounded at
+// 10 MB of decoded bytes; an agent run carries at most 4 of them. The body cap
+// covers four maxed-out base64 images (4/3 expansion) plus 1 MB of slack for
+// the surrounding JSON, so the body-size guard rejects abuse before we ever
+// `JSON.parse` it.
+const IMAGE_ATTACHMENT_MAX = 10 * 1024 * 1024;
+const AGENT_RUN_BODY_MAX = 4 * Math.ceil((IMAGE_ATTACHMENT_MAX * 4) / 3) + 1024 * 1024;
+
+const imageAttachmentSchema = z
+  .object({
+    kind: z.literal('image'),
+    content: z.string().min(1),
+    mediaType: z.enum(['image/png', 'image/jpeg', 'image/webp', 'image/gif']),
+    name: z.string().optional(),
+  })
+  .superRefine((attachment, ctx) => {
+    const size = Buffer.from(attachment.content, 'base64').length;
+    if (size > IMAGE_ATTACHMENT_MAX) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'image attachment exceeds 10 MB',
+        path: ['content'],
+      });
+    }
+  });
+
+const agentRunRequestSchema = z.object({
+  task: z.string().min(1),
+  attachments: z.array(imageAttachmentSchema).max(4).optional(),
+});
+
+const agentCreateRequestSchema = z.object({
+  name: z.string().optional(),
+  agent_type: z.string().optional(),
+  instructions: z.string().optional(),
+  model: z.string().optional(),
+  allowed_tools: z.array(z.string()).optional(),
+});
+
+const permissionDecisionSchema = z.object({
+  mode: z.enum(['allow', 'allow_session', 'allow_always', 'deny']),
+  reason: z.string().optional(),
+});
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * The Virtual Office route table, ordered most-specific-first within each
+ * method. The channel matches by `method` + `match(pathname)` AFTER its bearer
+ * check, then hands the matched route an {@link OfficeRequestContext}. Every
+ * handler that mutates state validates its own body with zod; the agent-run /
+ * image path is additionally size-capped before parse.
+ */
+export const OFFICE_ROUTES: ReadonlyArray<OfficeRoute> = [
+  {
+    method: 'GET',
+    match: (p) => p === '/v1/graveyard',
+    async handle(ctx) {
+      ctx.reply(200, ctx.runtime.graveyard());
+    },
+  },
+  {
+    method: 'GET',
+    match: (p) => p === '/v1/agents',
+    async handle(ctx) {
+      ctx.reply(200, ctx.runtime.list());
+    },
+  },
+  {
+    method: 'POST',
+    match: (p) => p === '/v1/agents',
+    async handle(ctx) {
+      let input: z.infer<typeof agentCreateRequestSchema>;
+      try {
+        const raw = await ctx.readBody();
+        input = agentCreateRequestSchema.parse(raw.trim() ? JSON.parse(raw) : {});
+      } catch (err) {
+        ctx.reply(400, { error: 'bad_request', message: errMsg(err) });
+        return;
+      }
+      ctx.reply(200, await ctx.runtime.create(input));
+    },
+  },
+  {
+    method: 'GET',
+    match: (p) => /^\/v1\/agents\/[^/]+$/.test(p),
+    async handle(ctx) {
+      const agent = ctx.runtime.get(ctx.pathSegment(3));
+      if (!agent) {
+        ctx.reply(404, { error: 'not_found', message: 'agent not found' });
+        return;
+      }
+      ctx.reply(200, agent);
+    },
+  },
+  {
+    method: 'DELETE',
+    match: (p) => /^\/v1\/agents\/[^/]+$/.test(p),
+    async handle(ctx) {
+      const id = ctx.pathSegment(3);
+      if (id === 'session') {
+        ctx.reply(409, { error: 'unsupported', message: 'the active moxxy session cannot be dismissed' });
+        return;
+      }
+      const dismissed = await ctx.runtime.dismiss(id);
+      if (!dismissed) {
+        ctx.reply(404, { error: 'not_found', message: 'agent not found' });
+        return;
+      }
+      ctx.reply(200, { ok: true });
+    },
+  },
+  {
+    method: 'POST',
+    match: (p) => /^\/v1\/agents\/[^/]+\/runs$/.test(p),
+    async handle(ctx) {
+      await handleAgentRun(ctx);
+    },
+  },
+  {
+    method: 'POST',
+    match: (p) => /^\/v1\/agents\/[^/]+\/stop$/.test(p),
+    async handle(ctx) {
+      const result = ctx.runtime.stop(ctx.pathSegment(3));
+      if (result === 'unsupported') {
+        ctx.reply(409, {
+          error: 'unsupported',
+          message: 'the active moxxy session cannot be stopped through this endpoint',
+        });
+        return;
+      }
+      if (result === 'not_found') {
+        ctx.reply(404, { error: 'not_found', message: 'agent not found' });
+        return;
+      }
+      if (result === 'not_running') {
+        ctx.reply(409, { error: 'not_running', message: 'agent has no active run' });
+        return;
+      }
+      ctx.reply(200, { ok: true });
+    },
+  },
+  {
+    method: 'GET',
+    match: (p) => /^\/v1\/agents\/[^/]+\/history$/.test(p),
+    async handle(ctx) {
+      const id = ctx.pathSegment(3);
+      if (id === 'session') {
+        ctx.reply(200, historyFromSessionLog(ctx.session, readHistoryLimit(ctx)));
+        return;
+      }
+      const history = ctx.runtime.history(id);
+      if (!history) {
+        ctx.reply(404, { error: 'not_found', message: 'agent not found' });
+        return;
+      }
+      ctx.reply(200, history);
+    },
+  },
+  {
+    method: 'POST',
+    match: (p) => /^\/v1\/agents\/[^/]+\/reset$/.test(p),
+    async handle(ctx) {
+      const id = ctx.pathSegment(3) || 'session';
+      const agent = ctx.runtime.reset(id);
+      if (!agent) {
+        ctx.reply(404, { error: 'not_found', message: 'agent not found' });
+        return;
+      }
+      ctx.reply(200, { agent_name: agent.name, status: agent.status });
+    },
+  },
+  {
+    method: 'GET',
+    match: (p) => p === '/v1/events/stream',
+    async handle(ctx) {
+      await handleEvents(ctx, ctx.runtime, ctx.logger);
+    },
+  },
+  {
+    method: 'POST',
+    match: (p) => /^\/v1\/permissions\/[^/]+\/decision$/.test(p),
+    async handle(ctx) {
+      if (!ctx.broker) {
+        ctx.reply(404, { error: 'not_found', message: 'interactive permissions are not enabled' });
+        return;
+      }
+      let body: z.infer<typeof permissionDecisionSchema>;
+      try {
+        const raw = await ctx.readBody();
+        body = permissionDecisionSchema.parse(JSON.parse(raw));
+      } catch (err) {
+        ctx.reply(400, { error: 'bad_request', message: errMsg(err) });
+        return;
+      }
+      const ok = await ctx.broker.decide(ctx.pathSegment(3), body);
+      if (!ok) {
+        ctx.reply(404, { error: 'not_found', message: 'permission request not found' });
+        return;
+      }
+      ctx.reply(200, { ok: true });
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Agent-run handling (size-capped body, attachment materialization).
+// ---------------------------------------------------------------------------
+
+async function handleAgentRun(ctx: OfficeRequestContext): Promise<void> {
+  const runtime = ctx.runtime;
+  // Size-cap the body BEFORE parsing: an agent run may carry up to four 10 MB
+  // base64 images, so the cap is generous but finite — anything past it is
+  // rejected at the transport rather than buffered into memory.
+  let body: z.infer<typeof agentRunRequestSchema>;
+  try {
+    const raw = await ctx.readBody(AGENT_RUN_BODY_MAX);
+    body = agentRunRequestSchema.parse(JSON.parse(raw));
+  } catch (err) {
+    ctx.reply(400, { error: 'bad_request', message: errMsg(err) });
+    return;
+  }
+
+  const agentId = ctx.pathSegment(3) || 'session';
+  const attachments = body.attachments ?? [];
+
+  if (agentId !== 'session') {
+    const agent = runtime.get(agentId);
+    if (!agent) {
+      ctx.reply(404, { error: 'not_found', message: 'agent not found' });
+      return;
+    }
+    if (
+      imageAttachments(attachments).length > 0 &&
+      !supportsImageAttachments(ctx.session, agent.provider_id, agent.model_id)
+    ) {
+      ctx.reply(400, {
+        error: 'unsupported_attachments',
+        message: `model ${agent.provider_id}::${agent.model_id} does not support image attachments`,
+      });
+      return;
+    }
+    let toolSystemPrompt: string | undefined;
+    try {
+      toolSystemPrompt = await imageAttachmentToolHint(ctx.session, attachments);
+    } catch (err) {
+      ctx.logger?.warn('virtual office attachment materialization failed', { err: errMsg(err) });
+      ctx.reply(500, {
+        error: 'attachment_materialization_failed',
+        message: 'failed to prepare image attachments for tools',
+      });
+      return;
+    }
+    const started = runtime.startRun(
+      agentId,
+      body.task,
+      attachments,
+      toolSystemPrompt ? { systemPrompt: toolSystemPrompt } : undefined,
+    );
+    if (started === 'not_found') {
+      ctx.reply(404, { error: 'not_found', message: 'agent not found' });
+      return;
+    }
+    if (started === 'already_running') {
+      ctx.reply(409, { error: 'already_running', message: 'agent already has an active run' });
+      return;
+    }
+    ctx.reply(200, started);
+    return;
+  }
+
+  // The `session` pseudo-agent runs against the channel's live session.
+  if (imageAttachments(attachments).length > 0 && !supportsImageAttachments(ctx.session)) {
+    const modelInfo = activeModelInfo(ctx.session);
+    ctx.reply(400, {
+      error: 'unsupported_attachments',
+      message: `model ${modelInfo.providerId}::${modelInfo.modelId} does not support image attachments`,
+    });
+    return;
+  }
+
+  let toolSystemPrompt: string | undefined;
+  try {
+    toolSystemPrompt = await imageAttachmentToolHint(ctx.session, attachments);
+  } catch (err) {
+    ctx.logger?.warn('virtual office attachment materialization failed', { err: errMsg(err) });
+    ctx.reply(500, {
+      error: 'attachment_materialization_failed',
+      message: 'failed to prepare image attachments for tools',
+    });
+    return;
+  }
+
+  void (async () => {
+    try {
+      for await (const event of ctx.session.runTurn(body.task, {
+        ...(attachments.length > 0 ? { attachments } : {}),
+        ...(toolSystemPrompt ? { systemPrompt: toolSystemPrompt } : {}),
+      })) {
+        void event;
+      }
+    } catch (err) {
+      ctx.logger?.warn('virtual office run failed', { err: errMsg(err) });
+    }
+  })();
+
+  ctx.reply(200, {
+    agent_id: agentId,
+    run_id: null,
+    task: body.task,
+    status: 'running',
+    ...(attachments.length > 0 ? { attachments } : {}),
+  });
+}
+
+/**
+ * Server-Sent Events stream of the unified Virtual Office timeline. Both the
+ * live session log and the office runtime are normalized into
+ * {@link VirtualOfficeEnvelope}s; envelopes flagged `sensitive` (tokens,
+ * secrets) are dropped before write so they never reach the wire — a flag that
+ * is office-envelope-specific and therefore enforced here.
+ */
+export async function handleEvents(
+  ctx: OfficeRequestContext,
+  runtime: OfficeAgentRuntime,
+  logger?: OfficeLogger,
+): Promise<void> {
+  const stream = ctx.openEventStream();
+
+  const writeEnvelope = (envelope: VirtualOfficeEnvelope): void => {
+    // Honor the producer's `sensitive` flag: such payloads (e.g. secrets) must
+    // never stream to clients. The channel's `send` is already crash-safe (a
+    // failed write is logged + dropped), so this only adds the office-specific
+    // sensitivity drop.
+    if (envelope.sensitive) return;
+    stream.send(envelope);
+  };
+
+  const unsubscribe = ctx.session.log.subscribe((event) => {
+    const envelope = eventToVirtualOfficeEnvelope(event, 'session');
+    if (!envelope) return;
+    writeEnvelope(envelope);
+  });
+  const unsubscribeOffice = runtime.subscribe((envelope) => {
+    writeEnvelope(envelope);
+  });
+  void logger;
+
+  try {
+    await stream.closed;
+  } finally {
+    unsubscribe();
+    unsubscribeOffice();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Office-specific helpers (model capabilities, attachment materialization,
+// session-log history projection).
+// ---------------------------------------------------------------------------
+
+function readHistoryLimit(ctx: OfficeRequestContext): number {
+  const url = new URL(ctx.req.url ?? '/', 'http://localhost');
+  const raw = Number(url.searchParams.get('limit') ?? 50);
+  if (!Number.isInteger(raw) || raw < 1) return 50;
+  return Math.min(raw, 500);
+}
+
+function activeModelInfo(
+  session: ClientSession,
+  providerId?: string,
+  modelId?: string,
+): { provider: ProviderDef | null; providerId: string; model: ModelDescriptor | null; modelId: string } {
+  const activeName = session.providers.getActiveName();
+  const providers = session.providers.list();
+  const provider =
+    providers.find((entry) => entry.name === providerId) ??
+    providers.find((entry) => entry.name === activeName) ??
+    providers[0] ??
+    null;
+  const model = provider?.models.find((entry) => entry.id === modelId) ?? provider?.models[0] ?? null;
+  return {
+    provider,
+    providerId: provider?.name ?? providerId ?? activeName ?? 'none',
+    model,
+    modelId: model?.id ?? modelId ?? 'default',
+  };
+}
+
+type ImagePromptAttachment = UserPromptAttachment & {
+  kind: 'image';
+  content: string;
+  mediaType: string;
+  name?: string;
+};
+
+interface MaterializedImageAttachment {
+  readonly name: string;
+  readonly mediaType: string;
+  readonly path: string;
+}
+
+function imageAttachments(
+  attachments: ReadonlyArray<UserPromptAttachment> | undefined,
+): ReadonlyArray<ImagePromptAttachment> {
+  return (attachments ?? []).filter(
+    (attachment): attachment is ImagePromptAttachment => attachment.kind === 'image',
+  );
+}
+
+function supportsImageAttachments(session: ClientSession, providerId?: string, modelId?: string): boolean {
+  return activeModelInfo(session, providerId, modelId).model?.supportsImages === true;
+}
+
+/**
+ * Write base64 image attachments to per-session media files so tools that need a
+ * local path (rather than inline bytes) can reach them. Returns a system-prompt
+ * hint listing the materialized paths, or undefined when there are no images.
+ */
+async function imageAttachmentToolHint(
+  session: ClientSession,
+  attachments: ReadonlyArray<UserPromptAttachment>,
+): Promise<string | undefined> {
+  const images = imageAttachments(attachments);
+  if (images.length === 0) return undefined;
+
+  const dir = path.join(moxxyHome(), 'media', String(session.id));
+  await mkdir(dir, { recursive: true });
+
+  const files: MaterializedImageAttachment[] = [];
+  for (const [index, attachment] of images.entries()) {
+    const filename = attachmentFilename(attachment, index);
+    const filePath = path.join(dir, filename);
+    await writeFile(filePath, Buffer.from(attachment.content, 'base64'), { flag: 'wx' });
+    files.push({
+      name: safeAttachmentDisplayName(attachment.name, filename),
+      mediaType: attachment.mediaType,
+      path: filePath,
+    });
+  }
+
+  const lines = files.map((file, index) => `${index + 1}. ${file.name}: ${file.path} (${file.mediaType})`);
+  return [
+    'Virtual Office uploaded image attachments are also available as local file paths for tools:',
+    ...lines,
+    '',
+    'Use these paths only when a tool or skill requires a local image path. The images are already attached inline for visual understanding.',
+  ].join('\n');
+}
+
+function moxxyHome(): string {
+  const configured = process.env.MOXXY_HOME?.trim();
+  return configured ? configured : path.join(homedir(), '.moxxy');
+}
+
+function attachmentFilename(attachment: ImagePromptAttachment, index: number): string {
+  const base = safeAttachmentBaseName(attachment.name, index);
+  return `${String(index + 1).padStart(2, '0')}-${randomUUID()}-${base}${extensionForMediaType(attachment.mediaType)}`;
+}
+
+function safeAttachmentBaseName(name: string | undefined, index: number): string {
+  const fallback = `image-${index + 1}`;
+  const parsed = path.parse(path.basename(name ?? fallback)).name || fallback;
+  const safe = parsed
+    .normalize('NFKD')
+    .replace(/[^\w.-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 80);
+  return safe || fallback;
+}
+
+function safeAttachmentDisplayName(name: string | undefined, fallback: string): string {
+  const normalized = (name ?? fallback).replace(/\\/g, '/');
+  return path.basename(normalized) || fallback;
+}
+
+function extensionForMediaType(mediaType: string): string {
+  switch (mediaType) {
+    case 'image/jpeg':
+      return '.jpg';
+    case 'image/webp':
+      return '.webp';
+    case 'image/gif':
+      return '.gif';
+    case 'image/png':
+    default:
+      return '.png';
+  }
+}
+
+interface SessionHistoryMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  text: string;
+  content: string;
+  run_id: string | null;
+  timestamp: number;
+  created_at: string;
+  attachments?: ReadonlyArray<UserPromptAttachment>;
+}
+
+function historyFromSessionLog(session: ClientSession, limit: number): { messages: SessionHistoryMessage[] } {
+  const messages: SessionHistoryMessage[] = [];
+  for (const event of session.log.toJSON()) {
+    if (event.type === 'user_prompt') {
+      messages.push({
+        id: String(event.id),
+        role: 'user',
+        text: event.text,
+        content: event.text,
+        run_id: String(event.turnId),
+        timestamp: event.ts,
+        created_at: new Date(event.ts).toISOString(),
+        ...(event.attachments && event.attachments.length > 0 ? { attachments: event.attachments } : {}),
+      });
+      continue;
+    }
+    if (event.type === 'assistant_message') {
+      messages.push({
+        id: String(event.id),
+        role: 'assistant',
+        text: event.content,
+        content: event.content,
+        run_id: String(event.turnId),
+        timestamp: event.ts,
+        created_at: new Date(event.ts).toISOString(),
+      });
+    }
+  }
+  return { messages: messages.filter((message) => message.text.trim().length > 0).slice(-limit) };
+}

--- a/packages/plugin-virtual-office/src/virtual-office-events.test.ts
+++ b/packages/plugin-virtual-office/src/virtual-office-events.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from 'vitest';
+import { asEventId, asPluginId, asSessionId, asTurnId, type MoxxyEvent } from '@moxxy/sdk';
+import { eventToVirtualOfficeEnvelope } from './virtual-office-events.js';
+
+describe('eventToVirtualOfficeEnvelope', () => {
+  it('maps command session actions for Virtual Office clients', () => {
+    const event: MoxxyEvent = {
+      id: asEventId('evt-1'),
+      seq: 3,
+      ts: 123,
+      sessionId: asSessionId('sess-1'),
+      turnId: asTurnId('turn-1'),
+      source: 'plugin',
+      type: 'plugin_event',
+      pluginId: asPluginId('@moxxy/plugin-commands'),
+      subtype: 'command.session_action',
+      payload: {
+        command: '/new',
+        action: 'new',
+        target: 'session',
+        origin_channel: 'tui',
+        origin_id: 'tui-1',
+      },
+    };
+
+    expect(eventToVirtualOfficeEnvelope(event)).toEqual({
+      agent_id: 'session',
+      run_id: 'turn-1',
+      parent_run_id: null,
+      sequence: 3,
+      event_type: 'command.session_action',
+      payload: {
+        command: '/new',
+        action: 'new',
+        target: 'session',
+        origin_channel: 'tui',
+        origin_id: 'tui-1',
+      },
+      sensitive: false,
+    });
+  });
+
+  it('maps runtime subagent lifecycle events to the child session id', () => {
+    const started: MoxxyEvent = {
+      id: asEventId('evt-sub-start'),
+      seq: 10,
+      ts: 123,
+      sessionId: asSessionId('sess-1'),
+      turnId: asTurnId('turn-parent'),
+      source: 'plugin',
+      type: 'plugin_event',
+      pluginId: asPluginId('@moxxy/subagents'),
+      subtype: 'subagent_started',
+      payload: {
+        label: 'agent-polityka-iran',
+        childSessionId: 'child-iran',
+        prompt: 'Zbadaj najnowsze informacje o Iranie',
+        mode: 'tool-use',
+        model: 'gpt-5.5',
+      },
+    };
+
+    expect(eventToVirtualOfficeEnvelope(started)).toEqual({
+      agent_id: 'child-iran',
+      run_id: 'turn-parent',
+      parent_run_id: 'turn-parent',
+      sequence: 10,
+      event_type: 'subagent.spawned',
+      payload: {
+        label: 'agent-polityka-iran',
+        childSessionId: 'child-iran',
+        prompt: 'Zbadaj najnowsze informacje o Iranie',
+        mode: 'tool-use',
+        model: 'gpt-5.5',
+        parent_agent_id: 'session',
+        child_name: 'agent-polityka-iran',
+      },
+      sensitive: false,
+    });
+  });
+
+  it('maps runtime subagent progress events to Office-friendly event types', () => {
+    const base = {
+      id: asEventId('evt-sub'),
+      ts: 123,
+      sessionId: asSessionId('sess-1'),
+      turnId: asTurnId('turn-parent'),
+      source: 'plugin' as const,
+      type: 'plugin_event' as const,
+      pluginId: asPluginId('@moxxy/subagents'),
+    };
+
+    const chunk = eventToVirtualOfficeEnvelope({
+      ...base,
+      id: asEventId('evt-sub-chunk'),
+      seq: 11,
+      subtype: 'subagent_chunk',
+      payload: { label: 'researcher', childSessionId: 'child-a', delta: 'partial answer' },
+    });
+    const toolCall = eventToVirtualOfficeEnvelope({
+      ...base,
+      id: asEventId('evt-sub-tool'),
+      seq: 12,
+      subtype: 'subagent_tool_call',
+      payload: { label: 'researcher', childSessionId: 'child-a', name: 'web_fetch', input: { url: 'https://example.com' }, callId: 'call-1' },
+    });
+    const toolResult = eventToVirtualOfficeEnvelope({
+      ...base,
+      id: asEventId('evt-sub-tool-result'),
+      seq: 13,
+      subtype: 'subagent_tool_result',
+      payload: { label: 'researcher', childSessionId: 'child-a', callId: 'call-1', ok: true, output: 'ok' },
+    });
+    const completed = eventToVirtualOfficeEnvelope({
+      ...base,
+      id: asEventId('evt-sub-complete'),
+      seq: 14,
+      subtype: 'subagent_completed',
+      payload: { label: 'researcher', childSessionId: 'child-a', text: 'final answer', stopReason: 'stop' },
+    });
+    const aborted = eventToVirtualOfficeEnvelope({
+      ...base,
+      id: asEventId('evt-sub-abort'),
+      seq: 15,
+      subtype: 'subagent_abort',
+      payload: { label: 'researcher', childSessionId: 'child-a', reason: 'cancelled' },
+    });
+
+    expect(chunk).toMatchObject({
+      agent_id: 'child-a',
+      event_type: 'message.delta',
+      payload: { content: 'partial answer', child_name: 'researcher' },
+    });
+    expect(toolCall).toMatchObject({
+      agent_id: 'child-a',
+      event_type: 'primitive.invoked',
+      payload: { name: 'web_fetch', call_id: 'call-1' },
+    });
+    expect(toolResult).toMatchObject({
+      agent_id: 'child-a',
+      event_type: 'primitive.completed',
+      payload: { call_id: 'call-1', output: 'ok' },
+    });
+    expect(completed).toMatchObject({
+      agent_id: 'child-a',
+      event_type: 'subagent.completed',
+      payload: { result: 'final answer', child_name: 'researcher' },
+    });
+    expect(aborted).toMatchObject({
+      agent_id: 'child-a',
+      event_type: 'subagent.failed',
+      payload: { error: 'cancelled', child_name: 'researcher' },
+    });
+  });
+
+  it('maps provider request and response to thinking activity events', () => {
+    const request: MoxxyEvent = {
+      id: asEventId('evt-provider-request'),
+      seq: 20,
+      ts: 123,
+      sessionId: asSessionId('sess-1'),
+      turnId: asTurnId('turn-1'),
+      source: 'model',
+      type: 'provider_request',
+      provider: 'openai-codex',
+      model: 'gpt-5.5',
+      inputTokens: 1234,
+    };
+    const response: MoxxyEvent = {
+      id: asEventId('evt-provider-response'),
+      seq: 21,
+      ts: 124,
+      sessionId: asSessionId('sess-1'),
+      turnId: asTurnId('turn-1'),
+      source: 'model',
+      type: 'provider_response',
+      provider: 'openai-codex',
+      model: 'gpt-5.5',
+      inputTokens: 1234,
+      outputTokens: 55,
+    };
+
+    expect(eventToVirtualOfficeEnvelope(request)).toMatchObject({
+      agent_id: 'session',
+      run_id: 'turn-1',
+      event_type: 'thinking.started',
+      payload: {
+        provider: 'openai-codex',
+        model: 'gpt-5.5',
+        input_tokens: 1234,
+      },
+    });
+    expect(eventToVirtualOfficeEnvelope(response)).toMatchObject({
+      agent_id: 'session',
+      run_id: 'turn-1',
+      event_type: 'thinking.completed',
+      payload: {
+        provider: 'openai-codex',
+        model: 'gpt-5.5',
+        input_tokens: 1234,
+        output_tokens: 55,
+      },
+    });
+  });
+
+  it('preserves user prompt image attachments for Virtual Office resume previews', () => {
+    const event: MoxxyEvent = {
+      id: asEventId('evt-user-with-image'),
+      seq: 40,
+      ts: 123,
+      sessionId: asSessionId('sess-1'),
+      turnId: asTurnId('turn-1'),
+      source: 'user',
+      type: 'user_prompt',
+      text: 'describe this',
+      attachments: [
+        {
+          kind: 'image',
+          content: 'aW1hZ2U=',
+          mediaType: 'image/png',
+          name: 'diagram.png',
+        },
+      ],
+    };
+
+    expect(eventToVirtualOfficeEnvelope(event)).toMatchObject({
+      agent_id: 'session',
+      run_id: 'turn-1',
+      event_type: 'run.started',
+      payload: {
+        task: 'describe this',
+        attachments: [
+          {
+            kind: 'image',
+            content: 'aW1hZ2U=',
+            mediaType: 'image/png',
+            name: 'diagram.png',
+          },
+        ],
+      },
+    });
+  });
+
+  it('maps denied tool calls to failed primitive activity', () => {
+    const event: MoxxyEvent = {
+      id: asEventId('evt-tool-denied'),
+      seq: 30,
+      ts: 123,
+      sessionId: asSessionId('sess-1'),
+      turnId: asTurnId('turn-1'),
+      source: 'tool',
+      type: 'tool_call_denied',
+      callId: 'call-1',
+      decidedBy: 'resolver',
+      reason: 'not allowed',
+    };
+
+    expect(eventToVirtualOfficeEnvelope(event)).toEqual({
+      agent_id: 'session',
+      run_id: 'turn-1',
+      parent_run_id: null,
+      sequence: 30,
+      event_type: 'primitive.failed',
+      payload: {
+        call_id: 'call-1',
+        error: 'not allowed',
+      },
+      sensitive: false,
+    });
+  });
+
+  it('maps workflow lifecycle plugin events for Office workflow highlighting', () => {
+    const base = {
+      id: asEventId('evt-workflow'),
+      seq: 50,
+      ts: 123,
+      sessionId: asSessionId('sess-1'),
+      turnId: asTurnId('turn-workflow'),
+      source: 'plugin' as const,
+      type: 'plugin_event' as const,
+      pluginId: asPluginId('@moxxy/plugin-workflows'),
+    };
+
+    expect(eventToVirtualOfficeEnvelope({
+      ...base,
+      subtype: 'workflow_started',
+      payload: { name: 'daily-digest', steps: 2 },
+    })).toMatchObject({
+      agent_id: 'session',
+      event_type: 'workflow.started',
+      payload: { name: 'daily-digest', steps: 2 },
+    });
+    expect(eventToVirtualOfficeEnvelope({
+      ...base,
+      seq: 51,
+      subtype: 'workflow_step_started',
+      payload: { id: 'collect', label: 'Collect' },
+    })).toMatchObject({
+      event_type: 'workflow.step.started',
+      payload: { id: 'collect', label: 'Collect' },
+    });
+    expect(eventToVirtualOfficeEnvelope({
+      ...base,
+      seq: 52,
+      subtype: 'workflow_step_awaiting_input',
+      payload: { id: 'collect', label: 'Collect', childSessionId: 'child-wf', preview: 'What brief?' },
+    })).toMatchObject({
+      event_type: 'workflow.step.awaiting_input',
+      payload: { id: 'collect', childSessionId: 'child-wf' },
+    });
+    expect(eventToVirtualOfficeEnvelope({
+      ...base,
+      seq: 53,
+      subtype: 'workflow_paused',
+      payload: { runId: 'run-01', stepId: 'collect', childSessionId: 'child-wf' },
+    })).toMatchObject({
+      event_type: 'workflow.paused',
+      payload: { runId: 'run-01', childSessionId: 'child-wf' },
+    });
+    expect(eventToVirtualOfficeEnvelope({
+      ...base,
+      seq: 54,
+      subtype: 'workflow_completed',
+      payload: { name: 'daily-digest', output: 'done' },
+    })).toMatchObject({
+      event_type: 'workflow.completed',
+      payload: { name: 'daily-digest', output: 'done' },
+    });
+  });
+});

--- a/packages/plugin-virtual-office/src/virtual-office-events.ts
+++ b/packages/plugin-virtual-office/src/virtual-office-events.ts
@@ -1,0 +1,315 @@
+import { type MoxxyEvent } from '@moxxy/sdk';
+
+const COMMAND_SESSION_ACTION_SUBTYPE = 'command.session_action';
+const COMMAND_STATE_CHANGED_SUBTYPE = 'command.state_changed';
+const PERMISSION_REQUESTED_SUBTYPE = 'permission.requested';
+const PERMISSION_RESOLVED_SUBTYPE = 'permission.resolved';
+
+/**
+ * Uniform event shape served on the Virtual Office SSE stream. Every raw
+ * `MoxxyEvent` (and a handful of plugin sub-events) is normalized into this
+ * envelope so the office client renders one timeline regardless of which agent
+ * — the live session, an office agent, or a runtime subagent — produced it.
+ *
+ * `sensitive` lets a producer mark an envelope as carrying material that must
+ * never reach the wire (tokens, secrets); the SSE handler drops those. Nothing
+ * here populates it today, but the flag is honored at the boundary so future
+ * producers can opt a payload out without touching the transport.
+ */
+export interface VirtualOfficeEnvelope {
+  agent_id: string;
+  run_id: string | null;
+  parent_run_id: string | null;
+  sequence: number;
+  event_type: string;
+  payload: Record<string, unknown>;
+  sensitive: boolean;
+}
+
+export function eventToVirtualOfficeEnvelope(
+  event: MoxxyEvent,
+  agentId = 'session',
+): VirtualOfficeEnvelope | null {
+  const base = {
+    agent_id: agentId,
+    run_id: String(event.turnId),
+    parent_run_id: null,
+    sequence: event.seq,
+    sensitive: false,
+  };
+  switch (event.type) {
+    case 'user_prompt':
+      return {
+        ...base,
+        event_type: 'run.started',
+        payload: {
+          task: event.text,
+          ...(event.attachments && event.attachments.length > 0 ? { attachments: event.attachments } : {}),
+        },
+      };
+    case 'assistant_chunk':
+      return { ...base, event_type: 'message.delta', payload: { content: event.delta } };
+    case 'assistant_message':
+      return { ...base, event_type: 'message.final', payload: { content: event.content } };
+    case 'tool_call_requested':
+      return {
+        ...base,
+        event_type: 'primitive.invoked',
+        payload: { name: event.name, input: event.input, call_id: String(event.callId) },
+      };
+    case 'tool_result':
+      return {
+        ...base,
+        event_type: event.ok ? 'primitive.completed' : 'primitive.failed',
+        payload: {
+          call_id: String(event.callId),
+          ...(event.ok ? { output: event.output } : { error: event.error?.message }),
+        },
+      };
+    case 'tool_call_denied':
+      return {
+        ...base,
+        event_type: 'primitive.failed',
+        payload: { call_id: String(event.callId), error: event.reason },
+      };
+    case 'skill_invoked':
+      return { ...base, event_type: 'skill.invoked', payload: { skill_id: event.skillId, name: event.name } };
+    case 'provider_request':
+      return {
+        ...base,
+        event_type: 'thinking.started',
+        payload: {
+          provider: event.provider,
+          model: event.model,
+          ...(typeof event.inputTokens === 'number' ? { input_tokens: event.inputTokens } : {}),
+        },
+      };
+    case 'provider_response':
+      return {
+        ...base,
+        event_type: 'thinking.completed',
+        payload: {
+          provider: event.provider,
+          model: event.model,
+          ...(typeof event.inputTokens === 'number' ? { input_tokens: event.inputTokens } : {}),
+          ...(typeof event.outputTokens === 'number' ? { output_tokens: event.outputTokens } : {}),
+          ...(typeof event.cacheReadTokens === 'number' ? { cache_read_tokens: event.cacheReadTokens } : {}),
+          ...(typeof event.cacheCreationTokens === 'number' ? { cache_creation_tokens: event.cacheCreationTokens } : {}),
+        },
+      };
+    case 'plugin_event':
+      return pluginEventToVirtualOfficeEnvelope(event, base);
+    case 'abort':
+      return { ...base, event_type: 'run.failed', payload: { error: event.reason } };
+    case 'error':
+      return { ...base, event_type: 'run.failed', payload: { error: event.message } };
+    default:
+      return null;
+  }
+}
+
+function pluginEventToVirtualOfficeEnvelope(
+  event: Extract<MoxxyEvent, { type: 'plugin_event' }>,
+  base: Omit<VirtualOfficeEnvelope, 'event_type' | 'payload'>,
+): VirtualOfficeEnvelope | null {
+  if (
+    event.subtype === COMMAND_SESSION_ACTION_SUBTYPE &&
+    isCommandSessionActionPayload(event.payload)
+  ) {
+    return {
+      ...base,
+      event_type: COMMAND_SESSION_ACTION_SUBTYPE,
+      payload: { ...event.payload },
+    };
+  }
+  if (
+    event.subtype === COMMAND_STATE_CHANGED_SUBTYPE &&
+    isCommandStateChangedPayload(event.payload)
+  ) {
+    return {
+      ...base,
+      event_type: COMMAND_STATE_CHANGED_SUBTYPE,
+      payload: { ...event.payload },
+    };
+  }
+  if (
+    (event.subtype === PERMISSION_REQUESTED_SUBTYPE || event.subtype === PERMISSION_RESOLVED_SUBTYPE) &&
+    event.payload &&
+    typeof event.payload === 'object' &&
+    !Array.isArray(event.payload)
+  ) {
+    const payload = event.payload as Record<string, unknown>;
+    return {
+      ...base,
+      agent_id: typeof payload.agent_id === 'string' ? payload.agent_id : base.agent_id,
+      run_id: null,
+      event_type: event.subtype,
+      payload: { ...payload },
+    };
+  }
+  // Workflow plugin events are passed through (the workflows feature is ported
+  // separately); when no workflow plugin is loaded this branch is simply never
+  // taken. Keeping the translation here means the office timeline highlights
+  // workflow progress the moment that plugin starts emitting.
+  const workflowEventType = workflowSubtypeToEventType(event.subtype);
+  if (workflowEventType) {
+    const payload = event.payload && typeof event.payload === 'object' && !Array.isArray(event.payload)
+      ? (event.payload as Record<string, unknown>)
+      : {};
+    return {
+      ...base,
+      event_type: workflowEventType,
+      payload: { ...payload },
+    };
+  }
+  if (typeof event.subtype !== 'string' || !event.subtype.startsWith('subagent_')) return null;
+  const payload = event.payload && typeof event.payload === 'object'
+    ? (event.payload as Record<string, unknown>)
+    : {};
+  const childSessionId = typeof payload.childSessionId === 'string' && payload.childSessionId.trim()
+    ? payload.childSessionId
+    : null;
+  const childName =
+    typeof payload.label === 'string'
+      ? payload.label
+      : childSessionId
+        ? childSessionId
+        : 'subagent';
+  if (!childSessionId) return null;
+  const subagentBase = {
+    ...base,
+    agent_id: childSessionId,
+    parent_run_id: base.run_id,
+  };
+  const subagentPayload = {
+    ...payload,
+    parent_agent_id: base.agent_id,
+    child_name: childName,
+  };
+  if (event.subtype === 'subagent_started') {
+    return {
+      ...subagentBase,
+      event_type: 'subagent.spawned',
+      payload: subagentPayload,
+    };
+  }
+  if (event.subtype === 'subagent_chunk') {
+    const content = typeof payload.delta === 'string' ? payload.delta : '';
+    return {
+      ...subagentBase,
+      event_type: 'message.delta',
+      payload: { ...subagentPayload, content, delta: content },
+    };
+  }
+  if (event.subtype === 'subagent_tool_call') {
+    return {
+      ...subagentBase,
+      event_type: 'primitive.invoked',
+      payload: {
+        ...subagentPayload,
+        name: typeof payload.name === 'string' ? payload.name : 'tool',
+        input: payload.input,
+        call_id: typeof payload.callId === 'string' ? payload.callId : String(payload.callId ?? ''),
+      },
+    };
+  }
+  if (event.subtype === 'subagent_tool_result') {
+    const ok = payload.ok === true;
+    return {
+      ...subagentBase,
+      event_type: ok ? 'primitive.completed' : 'primitive.failed',
+      payload: {
+        ...subagentPayload,
+        call_id: typeof payload.callId === 'string' ? payload.callId : String(payload.callId ?? ''),
+        ...(ok ? { output: payload.output } : { error: normalizeError(payload.error) }),
+      },
+    };
+  }
+  if (event.subtype === 'subagent_completed') {
+    const failed = payload.stopReason === 'error' || typeof payload.error === 'string';
+    return {
+      ...subagentBase,
+      event_type: failed ? 'subagent.failed' : 'subagent.completed',
+      payload: {
+        ...subagentPayload,
+        ...(typeof payload.text === 'string' ? { result: payload.text } : {}),
+        ...(typeof payload.error === 'string' ? { error: payload.error } : {}),
+      },
+    };
+  }
+  if (event.subtype === 'subagent_error' || event.subtype === 'subagent_abort') {
+    return {
+      ...subagentBase,
+      event_type: 'subagent.failed',
+      payload: {
+        ...subagentPayload,
+        error: typeof payload.message === 'string'
+          ? payload.message
+          : typeof payload.reason === 'string'
+            ? payload.reason
+            : 'subagent failed',
+      },
+    };
+  }
+  return null;
+}
+
+function workflowSubtypeToEventType(subtype: string): string | null {
+  switch (subtype) {
+    case 'workflow_started':
+      return 'workflow.started';
+    case 'workflow_step_started':
+      return 'workflow.step.started';
+    case 'workflow_step_completed':
+      return 'workflow.step.completed';
+    case 'workflow_step_skipped':
+      return 'workflow.step.skipped';
+    case 'workflow_step_failed':
+      return 'workflow.step.failed';
+    case 'workflow_step_awaiting_input':
+      return 'workflow.step.awaiting_input';
+    case 'workflow_paused':
+      return 'workflow.paused';
+    case 'workflow_resumed':
+      return 'workflow.resumed';
+    case 'workflow_completed':
+      return 'workflow.completed';
+    case 'workflow_failed':
+      return 'workflow.failed';
+    default:
+      return null;
+  }
+}
+
+function normalizeError(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (typeof value === 'string') return value;
+  if (value && typeof value === 'object' && 'message' in value) {
+    const message = (value as { message?: unknown }).message;
+    if (typeof message === 'string') return message;
+  }
+  return value == null ? 'unknown error' : String(value);
+}
+
+function isCommandSessionActionPayload(value: unknown): value is Record<string, unknown> {
+  return isCommandPayloadBase(value) && (value as Record<string, unknown>).action === 'new';
+}
+
+function isCommandStateChangedPayload(value: unknown): value is Record<string, unknown> {
+  if (!isCommandPayloadBase(value)) return false;
+  const record = value as Record<string, unknown>;
+  if (record.action === 'model_changed') return typeof record.model === 'string';
+  if (record.action === 'loop_changed') return typeof record.loop === 'string';
+  return false;
+}
+
+function isCommandPayloadBase(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.command === 'string' &&
+    record.target === 'session' &&
+    typeof record.origin_channel === 'string' &&
+    typeof record.origin_id === 'string'
+  );
+}

--- a/packages/plugin-virtual-office/tsconfig.json
+++ b/packages/plugin-virtual-office/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/plugin-virtual-office/vitest.config.ts
+++ b/packages/plugin-virtual-office/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -540,6 +540,9 @@ importers:
       '@moxxy/plugin-view':
         specifier: workspace:*
         version: link:../plugin-view
+      '@moxxy/plugin-virtual-office':
+        specifier: workspace:*
+        version: link:../plugin-virtual-office
       '@moxxy/plugin-webhooks':
         specifier: workspace:*
         version: link:../plugin-webhooks
@@ -1902,6 +1905,43 @@ importers:
       '@moxxy/core':
         specifier: workspace:*
         version: link:../core
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
+  packages/plugin-virtual-office:
+    dependencies:
+      '@moxxy/core':
+        specifier: workspace:*
+        version: link:../core
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
+    devDependencies:
+      '@moxxy/mode-default':
+        specifier: workspace:*
+        version: link:../mode-default
+      '@moxxy/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@moxxy/tools-builtin':
+        specifier: workspace:*
+        version: link:../tools-builtin
       '@moxxy/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig


### PR DESCRIPTION
Revives the multi-agent **virtual office** as a **standalone channel** in its own `@moxxy/plugin-virtual-office` package — no `http-extensions` seam in core/sdk, and `plugin-channel-http` is untouched (per your directive).

> ⚠️ Open for your review — not auto-merged.

## Shape
- `moxxy virtual-office` (a `defineChannel` channel) stands up the office's **own** `node:http` + SSE server on `start()` (configurable `port`/`host`, ephemeral via `port:0`), instantiates `OfficeAgentRuntime` (+ `HttpPermissionBroker` when `interactivePermissions` is set, installed as the session resolver), and tears it all down on `stop()`.
- It is its **own security boundary**: only `/health` is unauthenticated; every other route is bearer-checked (the generic `bearerTokenMatches`) before any body read; bodies are zod-validated; the agent-run/image path is size-capped (≤4 images ≤10MB, capped before parse); the SSE stream is crash-safe and **drops `sensitive` envelopes**. Token via the shared `resolveChannelToken` (`MOXXY_VIRTUAL_OFFICE_TOKEN` → config → generated `~/.moxxy/virtual-office-token`).
- Reuses **only** pre-existing generic SDK channel helpers. **Nothing office-specific is added to any shared package.**

## No core/sdk changes
`git diff origin/main -- packages/sdk packages/core packages/plugin-channel-http` is **empty** — the earlier `HttpExtension` seam (registry in core, contract in sdk, dispatch in the HTTP channel) is fully removed. The office is self-contained.

## Tradeoff (tracked in TECH_DEBT #12)
The office stands up its own HTTP+SSE server — the same shape `plugin-channel-http`/`plugin-webhooks`/the mobile bridge each carry. That duplication is the deliberate choice this directive made (a separate channel over a shared core seam); if a generic WS/HTTP-serving helper is ever hoisted, the office can adopt it.

## Verification
- `@moxxy/plugin-virtual-office`: 31 tests (channel 11 — ephemeral bind, bearer-401, create→run via FakeProvider→SSE→dismiss→graveyard, zod-400, oversized-attachment-400, stop-teardown, interactive-permissions on/off, sensitive-not-leaked; runtime 7; events 7; broker 6)
- Rebased on post-#142 main; gate (exit codes): build 59/59, typecheck 116/116, test 114/114, lint 0 errors, check:deps 0 violations
- Changeset: `@moxxy/plugin-virtual-office` minor (new) + `@moxxy/cli` patch (builtin channel registration)
- Consciously descoped for v1 (TECH_DEBT #12): synthesizer auto-integration, per-agent MCP servers, persistent live-agent snapshots