### PR TITLE
fix(desktop): ring spinner on splash + loading screen instead of the logo

### DIFF
--- a/.changeset/desktop-splash-spinner.md
+++ b/.changeset/desktop-splash-spinner.md
@@ -1,0 +1,5 @@
+---
+"@moxxy/desktop": patch
+---
+
+Replace the logo on the desktop cold-start splash and loading screen with a plain ring spinner. The brand mark read poorly blown up on those large, empty surfaces; a neutral brand-pink ring is cleaner. The load-bearing `#splash-fallback` element (the self-update boot-probe health signal) is unchanged — only the visual inside it.

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -25,14 +25,16 @@
       #splash-fallback { position: fixed; inset: 0; display: flex;
         flex-direction: column; align-items: center; justify-content: center;
         gap: 1.25rem; }
-      #splash-fallback .mark { width: 160px; height: 200px;
-        background: url('./new-animation.gif') center/contain no-repeat;
-        animation: splash-bob 2.2s ease-in-out infinite; }
+      /* Plain CSS ring spinner — no logo image (the brand mark read poorly
+         scaled-up on the cold-start splash). Pink head on a soft track. */
+      #splash-fallback .mark { width: 44px; height: 44px; border-radius: 50%;
+        border: 3px solid rgba(236, 72, 153, 0.18); border-top-color: #ec4899;
+        animation: splash-spin 0.8s linear infinite; }
       #splash-fallback .label { font-size: 0.85rem; color: #475569;
         letter-spacing: 0.04em; font-family: 'JetBrains Mono', monospace; }
-      @keyframes splash-bob {
-        0%, 100% { transform: translateY(0); }
-        50%      { transform: translateY(-8px); }
+      @keyframes splash-spin { to { transform: rotate(360deg); } }
+      @media (prefers-reduced-motion: reduce) {
+        #splash-fallback .mark { animation-duration: 1.6s; }
       }
     </style>
     <link rel="icon" type="image/png" href="/logo.png" />

--- a/apps/desktop/src/Splash.tsx
+++ b/apps/desktop/src/Splash.tsx
@@ -1,12 +1,10 @@
 /**
  * Full-screen splash — shown until the first ConnectionSnapshot
- * arrives. Uses the moxxy avatar as a gentle floating loader so the
- * cold-start moment feels like the brand instead of a generic ring
- * spinner.
+ * arrives. A plain ring spinner (brand pink) rather than the logo mark,
+ * which read poorly on this large, empty cold-start surface.
  */
 
 import './styles.css';
-import { asset } from '@/lib/asset';
 
 export function Splash({
   message = 'Getting things ready…',
@@ -31,19 +29,7 @@ export function Splash({
         color: 'var(--color-text)',
       }}
     >
-      <img
-        src={asset('new-animation.gif')}
-        alt=""
-        aria-hidden="true"
-        className="moxxy-avatar-loader"
-        width={160}
-        style={{
-          width: 160,
-          // Auto height keeps the portrait animation from being squashed
-          // into a square.
-          height: 'auto',
-        }}
-      />
+      <span className="moxxy-splash-spinner" aria-hidden="true" />
       <p
         className="mono"
         style={{

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -370,6 +370,24 @@ code, kbd, pre, .mono { font-family: var(--font-mono); }
   animation: moxxy-mini-bob 1.6s ease-in-out infinite;
 }
 
+/* Plain ring spinner for the cold-start splash / loading screen — the
+ * logo mark read poorly blown up on those large empty surfaces, so we
+ * use a neutral brand-pink ring there instead. Mirrors the inline CSS
+ * in index.html's #splash-fallback so both loaders look identical. */
+.moxxy-splash-spinner {
+  display: inline-block;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 3px solid color-mix(in srgb, var(--color-primary) 18%, transparent);
+  border-top-color: var(--color-primary);
+  animation: moxxy-splash-spin 0.8s linear infinite;
+}
+
+@keyframes moxxy-splash-spin {
+  to { transform: rotate(360deg); }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { animation-duration: 0.01ms !important; }
 }


### PR DESCRIPTION
The logo mark looked bad blown up on the large, empty cold-start splash and the connection loading screen. This swaps it for a plain brand-pink CSS ring spinner.

- `apps/desktop/index.html` `#splash-fallback`: the `.mark` is now a CSS ring spinner (inline CSS, no image) instead of the `new-animation.gif` background. The **`#splash-fallback` element is unchanged** — it's the load-bearing signal the self-update boot probe watches React replace (PR #115), so only the visual inside it changed.
- `apps/desktop/src/Splash.tsx` (the loading screen shown until the first connection snapshot, also used by ConnectionScreen's happy path): the `<img>` logo → `<span class="moxxy-splash-spinner">`; dropped the now-unused `asset` import.
- `styles.css`: new `.moxxy-splash-spinner` (brand-pink ring via `--color-primary`), mirroring the inline index.html CSS so both loaders are identical. Honors `prefers-reduced-motion` (the existing global rule).

Scope kept tight to the two surfaces flagged. The logo stays where it's a deliberate brand placement (ConnectionScreen *error* view, chat empty state, onboarding heroes).

Verified: `#splash-fallback` id intact; desktop typecheck/build/tests green (20/20).