### PR TITLE
feat(workflows): visual builder GUI (phase 2) — shared model + desktop canvas + mobile editor

### DIFF
--- a/.changeset/workflows-builder-gui.md
+++ b/.changeset/workflows-builder-gui.md
@@ -1,0 +1,18 @@
+---
+"@moxxy/workflows-builder": minor
+"@moxxy/desktop": minor
+"@moxxy/mobile": patch
+"@moxxy/client-core": patch
+---
+
+Workflows visual builder GUI (phase 2 of 2): a drag-canvas on desktop + an outline editor on mobile, both built on one shared, DOM-free model.
+
+**New shared model — `@moxxy/workflows-builder`.** A genuinely DOM-free, RN-safe package (zero React, zero DOM, zero node built-ins — proven by the Expo iOS export) that both apps import. It holds: the canvas `BuilderState` + a typed `builderReducer`; pure operations (`addStep`/`removeStep`, `connectNeeds`/`disconnectNeeds`, `setBranchTargets`/`setSwitchCase`, `setLoopBody`/`setLoopExit`/`setLoopConfig`, `moveNode`/`setViewport`/`renameNode`/`updateNode`/`updateMeta`); a `serialize`↔`hydrate` pair that builds a `Workflow` object + `ui.layout` from the canvas and re-derives the node graph (incl. an auto-layout when `ui.layout` is absent); a dependency-free YAML codec scoped to the workflow shape (chosen over the `yaml` package, which reaches for `node:process`, so the RN bundle stays clean — authoritative validation is server-side); and the validate/save bridges that map `workflows.validateDraft` issues back onto the offending nodes. 32 unit tests cover operations, the serialize↔hydrate round-trip (loop body + exit + branches + layout), validation-error mapping, and the loop node's body/exit modeling.
+
+**The loop node's two-region visual model.** A `loop` node exposes (1) a BODY region — the steps that run inside the loop each iteration, toggled in the inspector and rendered as dashed "body" edges — and (2) a single EXIT edge to the next step, taken when the condition is met OR a body step errors, labeled "on done / error → next". The exit is modeled as the body-excluded step that `needs` the loop, so there's always exactly one exit edge and the on-disk schema is unchanged.
+
+**Desktop canvas (`apps/desktop/src/workflows/`).** `WorkflowsPanel` becomes a list↔builder switcher (keeping enable/disable + run-now + last-run, adding per-row Edit + New). The builder is a hand-rolled SVG drag-canvas (no react-flow — the graph is ≤40 nodes, so a graph lib's bundle cost wasn't justified): color-coded node cards per step kind, derived `needs`/branch/loop edges with labels, draggable nodes that persist x/y to `ui.layout`, a node inspector (edits each kind's action fields incl. the loop's body/exit/condition/maxIterations), an add-node palette, live validation that decorates the offending node, and Save (`validateDraft`→`save`). 7 testing-library tests.
+
+**Mobile editor (`apps/mobile/`).** New `app/workflow-edit.tsx` screen + `WorkflowEditor` component + `useWorkflowEditor` hook, consuming the same shared model over the mobile frame bridge (new `buildWorkflowValidateFrame`/`buildWorkflowSaveFrame`/`buildWorkflowDetailFrame`, wired to the `MobileSessionHost` handlers the engine added). v1 is an OUTLINE editor (a node list with the same operations, incl. the loop's body/exit/condition), not a touch-drag canvas — a graphical touch canvas was disproportionate for v1.
+
+**Shared IPC glue.** `client-core` gains `useWorkflowBuilder` (DOM-free) that drives `workflows.getRun`/`validateDraft`/`save` over the injected transport — the Electron preload bridge on desktop, the WebSocket bridge on mobile — so the validate/save flow is identical across platforms.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -527,7 +527,7 @@ consider dropping the now-redundant renderer-heartbeat path. **Severity med** (n
   pairing is needed.
 **Severity low** (remaining items are opt-in / additive; desktop behavior unchanged).
 
-### 11. Workflows engine ported + while-loop node — phase 1 of 2 (visual builder = phase 2) — NEW, low
+### 11. Workflows engine ported + while-loop node + visual builder GUI — phases 1 & 2 DONE — low
 **Introduced 2026-06-10** by the workflows-engine port. `@moxxy/plugin-workflows` now
 carries the logic steps (`bridge`/`condition`/`switch`), `format: json|plain`, branch
 fields, the persisted-only `ui.layout` schema, agentic YAML authoring (`workflow_create` +
@@ -543,9 +543,22 @@ graph) is intact; the two operate on different graphs and don't conflict.
   `MAX_NESTING_DEPTH` (structural) — a loop body that calls nested workflows still bottoms
   out at the depth cap, so no N×depth blow-up and no infinite loop is reachable. On cap it
   finishes with a "max iterations reached" note rather than hanging.
-- **Follow-ups (low):** (a) the **visual workflow builder GUI is phase 2** — only its IPC
-  seam shipped here (`workflows.validateDraft`/`save`/`getRun`, capability-detectable on
-  `WorkflowsView` + desktop-host + mobile host); nothing renders a canvas yet. (b)
+- **Phase 2 — visual builder GUI: DONE (2026-06-10).** New DOM-free, RN-safe shared model
+  `@moxxy/workflows-builder` (canvas state + reducer, pure ops, a dependency-free
+  Workflow↔YAML codec with auto-layout, and the validate/save error-mapping bridges; 32
+  tests). Desktop: `apps/desktop/src/workflows/` upgraded `WorkflowsPanel` to a list↔builder
+  switcher with a hand-rolled SVG drag-canvas (no react-flow — the graph is ≤40 nodes),
+  color-coded node cards, derived `needs`/branch/loop edges, a node inspector, an add-node
+  palette, live `validateDraft` decoration, and Save (7 panel tests). Mobile:
+  `apps/mobile/app/workflow-edit.tsx` + `WorkflowEditor`/`useWorkflowEditor` over the same
+  model and the mobile frame bridge. Shared `useWorkflowBuilder` in client-core drives the
+  IPC for both. The **loop node's two-region model** (body membership + the single
+  "on done / on error → next" exit edge) is shared, rendered, and round-trips through
+  serialize↔hydrate. Expo iOS export verifies the shared model bundles RN-clean.
+  **v1 descope:** the mobile builder is an OUTLINE editor (a node list with the same
+  operations), not a touch-drag canvas — touch dragging a node graph was disproportionate
+  for v1; revisit with `react-native-svg` + gesture-handler if a graphical mobile canvas is
+  wanted. (b)
   `awaitInput` is barred inside a `loop` body (would need mid-iteration checkpointing) — a
   body prompt that sets it fails loudly; lift only if a use-case appears. (c) the
   `RemoteSession` (TUI runner-RPC) leaves the three new builder methods undefined — wire

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -41,6 +41,7 @@
     "@moxxy/plugin-vault": "workspace:*",
     "@moxxy/runner": "workspace:*",
     "@moxxy/sdk": "workspace:*",
+    "@moxxy/workflows-builder": "workspace:*",
     "electron-updater": "^6.8.3",
     "qrcode": "^1.5.4",
     "react": "catalog:",

--- a/apps/desktop/src/workflows/NodeInspector.tsx
+++ b/apps/desktop/src/workflows/NodeInspector.tsx
@@ -1,0 +1,505 @@
+import { TextArea, TextInput } from '@moxxy/desktop-ui';
+import {
+  stepKindMeta,
+  type BuilderAction,
+  type BuilderNode,
+  type BuilderState,
+} from '@moxxy/workflows-builder';
+import type { WorkflowStepErrorMode } from '@moxxy/sdk';
+import { accentHex } from './accents';
+
+/**
+ * The right-hand inspector for the selected node. It edits the step's action
+ * field (the one matching its kind) plus the shared fields (label, needs,
+ * onError/retries). For branch + loop kinds it surfaces the structural editors:
+ *   - condition → then/else target multi-select
+ *   - switch    → per-case target lists + default
+ *   - loop      → BODY membership (which steps run inside), the EXIT target (the
+ *                 single "on done / on error → next" step), the EXIT/GOAL
+ *                 condition prompt, and maxIterations.
+ *
+ * All mutations go through the shared reducer; this component is presentation +
+ * interaction only.
+ */
+
+interface Props {
+  readonly state: BuilderState;
+  readonly node: BuilderNode;
+  readonly dispatch: (action: BuilderAction) => void;
+}
+
+const ERROR_MODES: WorkflowStepErrorMode[] = ['fail', 'continue', 'retry'];
+
+export function NodeInspector({ state, node, dispatch }: Props): JSX.Element {
+  const meta = stepKindMeta(node.kind);
+  const accent = accentHex(meta.accent);
+  const otherNodes = state.nodes.filter((n) => n.id !== node.id);
+  const errors = state.errors[node.id] ?? [];
+
+  const patch = (p: Parameters<typeof dispatchUpdate>[2]): void => dispatchUpdate(dispatch, node.id, p);
+
+  return (
+    <aside
+      data-testid="node-inspector"
+      style={{
+        width: 320,
+        flexShrink: 0,
+        overflowY: 'auto',
+        borderLeft: '1px solid var(--color-border)',
+        background: 'var(--color-bg-card)',
+        padding: '1rem',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.75rem',
+      }}
+    >
+      <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span style={{ fontSize: '0.7rem', fontWeight: 700, textTransform: 'uppercase', color: accent }}>
+          {meta.label}
+        </span>
+        <button
+          type="button"
+          data-testid="delete-node"
+          onClick={() => dispatch({ type: 'remove-step', id: node.id })}
+          style={pillBtn('var(--color-red)')}
+        >
+          Delete
+        </button>
+      </header>
+
+      <Field label="Step id">
+        <TextInput
+          value={node.id}
+          onChange={(e) => dispatch({ type: 'rename-node', from: node.id, to: e.target.value })}
+          data-testid="field-id"
+        />
+      </Field>
+      <Field label="Label">
+        <TextInput
+          value={node.label ?? ''}
+          placeholder="Human title"
+          onChange={(e) => patch({ label: e.target.value })}
+          data-testid="field-label"
+        />
+      </Field>
+
+      {renderAction(node, dispatch, patch)}
+
+      {node.kind === 'condition' && (
+        <>
+          <TargetPicker
+            label="then → (condition met)"
+            options={otherNodes}
+            selected={node.then ?? []}
+            onChange={(targets) => dispatch({ type: 'set-branch', nodeId: node.id, slot: 'then', targets })}
+            testid="branch-then"
+          />
+          <TargetPicker
+            label="else → (condition not met)"
+            options={otherNodes}
+            selected={node.else ?? []}
+            onChange={(targets) => dispatch({ type: 'set-branch', nodeId: node.id, slot: 'else', targets })}
+            testid="branch-else"
+          />
+        </>
+      )}
+
+      {node.kind === 'switch' && <SwitchEditor node={node} options={otherNodes} dispatch={dispatch} />}
+
+      {node.kind === 'loop' && <LoopEditor state={state} node={node} dispatch={dispatch} />}
+
+      {node.kind !== 'loop' && (
+        <NeedsPicker node={node} options={otherNodes} dispatch={dispatch} />
+      )}
+
+      <Field label="On error">
+        <select
+          value={node.onError}
+          data-testid="field-onerror"
+          onChange={(e) => patch({ onError: e.target.value as WorkflowStepErrorMode })}
+          style={selectStyle}
+        >
+          {ERROR_MODES.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+      </Field>
+      {node.onError === 'retry' && (
+        <Field label="Retries (0-3)">
+          <TextInput
+            type="number"
+            value={String(node.retries)}
+            onChange={(e) => patch({ retries: Number(e.target.value) })}
+            data-testid="field-retries"
+          />
+        </Field>
+      )}
+
+      {(node.kind === 'prompt' || node.kind === 'skill') && (
+        <label style={checkboxRow}>
+          <input
+            type="checkbox"
+            checked={node.awaitInput ?? false}
+            onChange={(e) => patch({ awaitInput: e.target.checked })}
+            data-testid="field-awaitinput"
+          />
+          Await operator input
+        </label>
+      )}
+
+      {errors.length > 0 && (
+        <div data-testid="node-errors" style={errorBox}>
+          {errors.map((msg, i) => (
+            <div key={i}>{msg}</div>
+          ))}
+        </div>
+      )}
+    </aside>
+  );
+}
+
+function renderAction(
+  node: BuilderNode,
+  _dispatch: (a: BuilderAction) => void,
+  patch: (p: Parameters<typeof dispatchUpdate>[2]) => void,
+): JSX.Element | null {
+  switch (node.kind) {
+    case 'prompt':
+      return (
+        <Field label="Prompt">
+          <TextArea rows={5} value={node.action} onChange={(e) => patch({ action: e.target.value })} data-testid="field-action" />
+        </Field>
+      );
+    case 'bridge':
+    case 'condition':
+    case 'switch':
+      return (
+        <Field label="Instruction">
+          <TextArea rows={4} value={node.action} onChange={(e) => patch({ action: e.target.value })} data-testid="field-action" />
+        </Field>
+      );
+    case 'skill':
+      return (
+        <>
+          <Field label="Skill name">
+            <TextInput value={node.action} onChange={(e) => patch({ action: e.target.value })} data-testid="field-action" />
+          </Field>
+          <Field label="Input">
+            <TextArea rows={3} value={node.input ?? ''} onChange={(e) => patch({ input: e.target.value })} data-testid="field-input" />
+          </Field>
+        </>
+      );
+    case 'tool':
+    case 'workflow':
+      return (
+        <>
+          <Field label={node.kind === 'tool' ? 'Tool name' : 'Workflow name'}>
+            <TextInput value={node.action} onChange={(e) => patch({ action: e.target.value })} data-testid="field-action" />
+          </Field>
+          <Field label="Args (JSON)">
+            <TextArea
+              rows={3}
+              value={JSON.stringify(node.args ?? {}, null, 2)}
+              onChange={(e) => {
+                try {
+                  patch({ args: JSON.parse(e.target.value) as Record<string, unknown> });
+                } catch {
+                  /* keep typing; invalid JSON is just not committed */
+                }
+              }}
+              data-testid="field-args"
+            />
+          </Field>
+        </>
+      );
+    case 'loop':
+      return null; // handled by LoopEditor
+  }
+}
+
+function LoopEditor({
+  state,
+  node,
+  dispatch,
+}: {
+  state: BuilderState;
+  node: BuilderNode;
+  dispatch: (a: BuilderAction) => void;
+}): JSX.Element {
+  const candidates = state.nodes.filter((n) => n.id !== node.id);
+  const body = node.loop?.body ?? [];
+  const exit = state.edges.find((e) => e.kind === 'loop-exit' && e.from === node.id)?.to ?? '';
+  const bodySet = new Set(body);
+  return (
+    <>
+      <Field label="EXIT / GOAL condition (met → stop the loop)">
+        <TextArea
+          rows={3}
+          value={node.loop?.condition ?? ''}
+          placeholder="Describe the goal that ENDS the loop."
+          onChange={(e) => dispatch({ type: 'set-loop-config', loopId: node.id, patch: { condition: e.target.value } })}
+          data-testid="loop-condition"
+        />
+      </Field>
+      <Field label="Max iterations (1-50)">
+        <TextInput
+          type="number"
+          value={String(node.loop?.maxIterations ?? 10)}
+          onChange={(e) =>
+            dispatch({ type: 'set-loop-config', loopId: node.id, patch: { maxIterations: Number(e.target.value) } })
+          }
+          data-testid="loop-max"
+        />
+      </Field>
+      <Field label="Body — steps that run INSIDE the loop, each iteration">
+        <div data-testid="loop-body" style={pickList}>
+          {candidates.length === 0 && <span style={emptyHint}>Add steps, then assign them here.</span>}
+          {candidates.map((c) => (
+            <label key={c.id} style={pickRow}>
+              <input
+                type="checkbox"
+                checked={bodySet.has(c.id)}
+                disabled={c.id === exit}
+                onChange={(e) => {
+                  const next = e.target.checked ? [...body, c.id] : body.filter((b) => b !== c.id);
+                  dispatch({ type: 'set-loop-body', loopId: node.id, body: next });
+                }}
+              />
+              {c.label || c.id}
+            </label>
+          ))}
+        </div>
+      </Field>
+      <Field label="Exit → next step (on done / on body error)">
+        <select
+          value={exit}
+          data-testid="loop-exit"
+          onChange={(e) => dispatch({ type: 'set-loop-exit', loopId: node.id, targetId: e.target.value || null })}
+          style={selectStyle}
+        >
+          <option value="">(loop ends the workflow)</option>
+          {candidates
+            .filter((c) => !bodySet.has(c.id))
+            .map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.label || c.id}
+              </option>
+            ))}
+        </select>
+      </Field>
+    </>
+  );
+}
+
+function SwitchEditor({
+  node,
+  options,
+  dispatch,
+}: {
+  node: BuilderNode;
+  options: BuilderNode[];
+  dispatch: (a: BuilderAction) => void;
+}): JSX.Element {
+  const cases = node.cases ?? {};
+  return (
+    <>
+      {Object.entries(cases).map(([caseId, targets]) => (
+        <div key={caseId} style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <span style={fieldLabel}>case · {caseId}</span>
+            <button
+              type="button"
+              onClick={() => dispatch({ type: 'remove-case', nodeId: node.id, caseId })}
+              style={pillBtn('var(--color-text-dim)')}
+            >
+              remove
+            </button>
+          </div>
+          <TargetPicker
+            label=""
+            options={options}
+            selected={targets}
+            onChange={(t) => dispatch({ type: 'set-case', nodeId: node.id, caseId, targets: t })}
+            testid={`case-${caseId}`}
+          />
+        </div>
+      ))}
+      <button
+        type="button"
+        data-testid="add-case"
+        onClick={() => {
+          const id = prompt('Case id (e.g. "high")');
+          if (id) dispatch({ type: 'set-case', nodeId: node.id, caseId: id, targets: [] });
+        }}
+        style={pillBtn('var(--color-primary)')}
+      >
+        + Add case
+      </button>
+      <TargetPicker
+        label="default →"
+        options={options}
+        selected={node.default ?? []}
+        onChange={(t) => dispatch({ type: 'set-branch', nodeId: node.id, slot: 'default', targets: t })}
+        testid="switch-default"
+      />
+    </>
+  );
+}
+
+function NeedsPicker({
+  node,
+  options,
+  dispatch,
+}: {
+  node: BuilderNode;
+  options: BuilderNode[];
+  dispatch: (a: BuilderAction) => void;
+}): JSX.Element {
+  const set = new Set(node.needs);
+  return (
+    <Field label="Needs (upstream dependencies)">
+      <div data-testid="needs-picker" style={pickList}>
+        {options.length === 0 && <span style={emptyHint}>No other steps yet.</span>}
+        {options.map((o) => (
+          <label key={o.id} style={pickRow}>
+            <input
+              type="checkbox"
+              checked={set.has(o.id)}
+              onChange={(e) =>
+                dispatch(
+                  e.target.checked
+                    ? { type: 'connect-needs', from: o.id, to: node.id }
+                    : { type: 'disconnect-needs', from: o.id, to: node.id },
+                )
+              }
+            />
+            {o.label || o.id}
+          </label>
+        ))}
+      </div>
+    </Field>
+  );
+}
+
+function TargetPicker({
+  label,
+  options,
+  selected,
+  onChange,
+  testid,
+}: {
+  label: string;
+  options: BuilderNode[];
+  selected: ReadonlyArray<string>;
+  onChange: (targets: string[]) => void;
+  testid: string;
+}): JSX.Element {
+  const set = new Set(selected);
+  return (
+    <Field label={label}>
+      <div data-testid={testid} style={pickList}>
+        {options.map((o) => (
+          <label key={o.id} style={pickRow}>
+            <input
+              type="checkbox"
+              checked={set.has(o.id)}
+              onChange={(e) =>
+                onChange(e.target.checked ? [...selected, o.id] : selected.filter((s) => s !== o.id))
+              }
+            />
+            {o.label || o.id}
+          </label>
+        ))}
+      </div>
+    </Field>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }): JSX.Element {
+  return (
+    <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      {label && <span style={fieldLabel}>{label}</span>}
+      {children}
+    </label>
+  );
+}
+
+function dispatchUpdate(
+  dispatch: (a: BuilderAction) => void,
+  id: string,
+  patch: {
+    label?: string;
+    action?: string;
+    input?: string;
+    args?: Record<string, unknown>;
+    onError?: WorkflowStepErrorMode;
+    retries?: number;
+    awaitInput?: boolean;
+  },
+): void {
+  dispatch({ type: 'update-node', id, patch });
+}
+
+const fieldLabel: React.CSSProperties = {
+  fontSize: '0.65rem',
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: '0.03em',
+  color: 'var(--color-text-dim)',
+};
+
+const selectStyle: React.CSSProperties = {
+  padding: '0.4rem 0.5rem',
+  border: '1px solid var(--color-border)',
+  borderRadius: 'var(--radius-block)',
+  background: 'var(--color-bg-card)',
+  fontSize: '0.82rem',
+};
+
+const pickList: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 3,
+  maxHeight: 160,
+  overflowY: 'auto',
+  border: '1px solid var(--color-border)',
+  borderRadius: 'var(--radius-block)',
+  padding: '0.4rem 0.5rem',
+};
+
+const pickRow: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  fontSize: '0.78rem',
+  color: 'var(--color-text)',
+};
+
+const checkboxRow: React.CSSProperties = { ...pickRow, fontWeight: 500 };
+
+const emptyHint: React.CSSProperties = { fontSize: '0.75rem', color: 'var(--color-text-dim)' };
+
+const errorBox: React.CSSProperties = {
+  fontSize: '0.72rem',
+  color: 'var(--color-red)',
+  background: 'color-mix(in oklab, var(--color-red) 8%, transparent)',
+  border: '1px solid var(--color-red)',
+  borderRadius: 'var(--radius-block)',
+  padding: '0.45rem 0.55rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 3,
+};
+
+function pillBtn(color: string): React.CSSProperties {
+  return {
+    fontSize: '0.68rem',
+    fontWeight: 600,
+    padding: '0.2rem 0.55rem',
+    color: 'var(--color-bg)',
+    background: color,
+    borderRadius: 'var(--radius-block)',
+  };
+}

--- a/apps/desktop/src/workflows/Palette.tsx
+++ b/apps/desktop/src/workflows/Palette.tsx
@@ -1,0 +1,37 @@
+import { STEP_KINDS, type BuilderAction, type StepKind } from '@moxxy/workflows-builder';
+import { accentHex } from './accents';
+
+/** The add-node palette: one chip per step kind, color-coded. */
+export function Palette({ dispatch }: { dispatch: (a: BuilderAction) => void }): JSX.Element {
+  const add = (kind: StepKind): void => dispatch({ type: 'add-step', input: { kind } });
+  return (
+    <div
+      data-testid="palette"
+      style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', alignItems: 'center' }}
+    >
+      <span style={{ fontSize: '0.65rem', fontWeight: 700, textTransform: 'uppercase', color: 'var(--color-text-dim)' }}>
+        Add step
+      </span>
+      {STEP_KINDS.map((k) => (
+        <button
+          key={k.kind}
+          type="button"
+          data-testid={`palette-add-${k.kind}`}
+          title={k.description}
+          onClick={() => add(k.kind)}
+          style={{
+            fontSize: '0.72rem',
+            fontWeight: 600,
+            padding: '0.25rem 0.6rem',
+            color: accentHex(k.accent),
+            background: 'var(--color-bg-card)',
+            border: `1.5px solid ${accentHex(k.accent)}`,
+            borderRadius: 'var(--radius-block)',
+          }}
+        >
+          + {k.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/desktop/src/workflows/WorkflowBuilder.tsx
+++ b/apps/desktop/src/workflows/WorkflowBuilder.tsx
@@ -1,0 +1,171 @@
+import { useEffect } from 'react';
+import { useWorkflowBuilder } from '@moxxy/client-core';
+import { TextInput } from '@moxxy/desktop-ui';
+import { WORKFLOW_ERROR_KEY } from '@moxxy/workflows-builder';
+import { WorkflowCanvas } from './WorkflowCanvas';
+import { NodeInspector } from './NodeInspector';
+import { Palette } from './Palette';
+
+/**
+ * The desktop visual builder: palette + drag canvas + node inspector, all
+ * driven by the shared `useWorkflowBuilder` hook (state/logic) so this layer is
+ * rendering + interaction only. Live-validates on edit (errors decorate nodes
+ * + the inspector); Save runs validateDraft → save through the IPC.
+ *
+ * `name === null` opens a blank canvas (new workflow); a name loads that
+ * workflow's YAML via `workflows.getRun` and hydrates the canvas.
+ */
+interface Props {
+  readonly name: string | null;
+  readonly onClose: () => void;
+  /** Called after a successful save so the list refreshes. */
+  readonly onSaved: () => void;
+}
+
+export function WorkflowBuilder({ name, onClose, onSaved }: Props): JSX.Element {
+  const builder = useWorkflowBuilder();
+  const { state, dispatch } = builder;
+
+  useEffect(() => {
+    void builder.load(name);
+    // load identity is stable per hook; re-run only when the target changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [name]);
+
+  const selectedNode = state.nodes.find((n) => n.id === state.selected) ?? null;
+  const workflowErrors = state.errors[WORKFLOW_ERROR_KEY] ?? [];
+
+  const onSave = async (): Promise<void> => {
+    const result = await builder.save();
+    if (result) onSaved();
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
+      <header
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.75rem',
+          padding: '0.75rem 1rem',
+          borderBottom: '1px solid var(--color-border)',
+        }}
+      >
+        <button type="button" data-testid="builder-back" onClick={onClose} style={ghostBtn}>
+          ← Back
+        </button>
+        <div style={{ display: 'flex', flexDirection: 'column', minWidth: 220 }}>
+          <span style={metaLabel}>workflow name (slug)</span>
+          <TextInput
+            value={state.meta.name}
+            data-testid="builder-name"
+            onChange={(e) => dispatch({ type: 'update-meta', patch: { name: e.target.value } })}
+          />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+          <span style={metaLabel}>description</span>
+          <TextInput
+            value={state.meta.description}
+            data-testid="builder-description"
+            onChange={(e) => dispatch({ type: 'update-meta', patch: { description: e.target.value } })}
+          />
+        </div>
+        <ValidityBadge valid={builder.valid} validating={builder.validating} />
+        <button
+          type="button"
+          data-testid="builder-save"
+          disabled={builder.saving || builder.valid === false}
+          onClick={() => void onSave()}
+          style={{
+            ...primaryBtn,
+            opacity: builder.saving || builder.valid === false ? 0.5 : 1,
+          }}
+        >
+          {builder.saving ? 'Saving…' : 'Save'}
+        </button>
+      </header>
+
+      <div style={{ padding: '0.6rem 1rem' }}>
+        <Palette dispatch={dispatch} />
+      </div>
+
+      {builder.error && (
+        <p role="alert" data-testid="builder-error" style={alertBox}>
+          {builder.error}
+        </p>
+      )}
+      {workflowErrors.length > 0 && (
+        <div data-testid="builder-workflow-errors" style={{ ...alertBox, flexDirection: 'column' }}>
+          {workflowErrors.map((msg, i) => (
+            <div key={i}>{msg}</div>
+          ))}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', flex: 1, minHeight: 0, gap: 0, padding: '0 1rem 1rem' }}>
+        <WorkflowCanvas state={state} dispatch={dispatch} />
+        {selectedNode && <NodeInspector state={state} node={selectedNode} dispatch={dispatch} />}
+      </div>
+    </div>
+  );
+}
+
+function ValidityBadge({ valid, validating }: { valid: boolean | null; validating: boolean }): JSX.Element {
+  const { label, color } = validating
+    ? { label: 'checking…', color: 'var(--color-text-dim)' }
+    : valid === true
+      ? { label: 'valid', color: 'var(--color-green)' }
+      : valid === false
+        ? { label: 'invalid', color: 'var(--color-red)' }
+        : { label: 'unsaved', color: 'var(--color-text-dim)' };
+  return (
+    <span
+      data-testid="validity-badge"
+      style={{
+        fontSize: '0.72rem',
+        fontWeight: 700,
+        color,
+        border: `1px solid ${color}`,
+        borderRadius: 'var(--radius-block)',
+        padding: '0.2rem 0.5rem',
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+const metaLabel: React.CSSProperties = {
+  fontSize: '0.6rem',
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  color: 'var(--color-text-dim)',
+};
+
+const primaryBtn: React.CSSProperties = {
+  fontSize: '0.8rem',
+  fontWeight: 600,
+  padding: '0.4rem 1rem',
+  color: 'var(--color-bg)',
+  background: 'var(--color-primary)',
+  borderRadius: 'var(--radius-block)',
+};
+
+const ghostBtn: React.CSSProperties = {
+  fontSize: '0.78rem',
+  color: 'var(--color-text-muted)',
+  border: '1px solid var(--color-border)',
+  borderRadius: 'var(--radius-block)',
+  padding: '0.3rem 0.7rem',
+};
+
+const alertBox: React.CSSProperties = {
+  margin: '0 1rem 0.5rem',
+  padding: '0.45rem 0.65rem',
+  border: '1px solid var(--color-red)',
+  background: 'color-mix(in oklab, var(--color-red) 10%, transparent)',
+  borderRadius: 'var(--radius-block)',
+  fontSize: '0.8rem',
+  display: 'flex',
+  gap: 4,
+};

--- a/apps/desktop/src/workflows/WorkflowCanvas.tsx
+++ b/apps/desktop/src/workflows/WorkflowCanvas.tsx
@@ -1,0 +1,290 @@
+import { useCallback, useRef, useState } from 'react';
+import {
+  stepKindMeta,
+  WORKFLOW_ERROR_KEY,
+  type BuilderAction,
+  type BuilderEdge,
+  type BuilderNode,
+  type BuilderState,
+} from '@moxxy/workflows-builder';
+import { accentHex } from './accents';
+
+/**
+ * The builder canvas: an absolute-positioned layer of draggable step-node
+ * cards over an SVG edge layer. Hand-rolled (no react-flow) to avoid pulling a
+ * heavy graph lib into the Electron bundle — the graph here is small (≤40
+ * steps) and the interactions are limited to drag + select.
+ *
+ * Edge legend:
+ *   - needs  : solid grey arrow (DAG dependency)
+ *   - then   : green, `else`: red, `case`: purple (+ label), `default`: grey
+ *   - loop-body : dashed purple — the step runs INSIDE the loop
+ *   - loop-exit : solid purple with the "on done / on error → next" label — the
+ *                 single edge a loop takes once its condition is met or a body
+ *                 step errors.
+ */
+
+const NODE_W = 200;
+const NODE_H = 88;
+const ANCHOR_OFFSET = NODE_H / 2;
+
+interface Props {
+  readonly state: BuilderState;
+  readonly dispatch: (action: BuilderAction) => void;
+}
+
+const EDGE_STYLE: Record<BuilderEdge['kind'], { color: string; dash?: string; label?: string }> = {
+  needs: { color: '#94a3b8' },
+  then: { color: '#10b981', label: 'then' },
+  else: { color: '#ef4444', label: 'else' },
+  case: { color: '#8b5cf6' },
+  default: { color: '#94a3b8', label: 'default' },
+  'loop-body': { color: '#8b5cf6', dash: '6 5', label: 'body' },
+  'loop-exit': { color: '#7c3aed', label: 'on done / error → next' },
+};
+
+export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
+  const surfaceRef = useRef<HTMLDivElement>(null);
+  const drag = useRef<{ id: string; dx: number; dy: number } | null>(null);
+  const [dragging, setDragging] = useState<string | null>(null);
+
+  const byId = new Map(state.nodes.map((n) => [n.id, n]));
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent, node: BuilderNode) => {
+      e.stopPropagation();
+      (e.target as Element).setPointerCapture?.(e.pointerId);
+      const rect = surfaceRef.current?.getBoundingClientRect();
+      const ox = rect ? e.clientX - rect.left : e.clientX;
+      const oy = rect ? e.clientY - rect.top : e.clientY;
+      drag.current = { id: node.id, dx: ox - node.x, dy: oy - node.y };
+      setDragging(node.id);
+      dispatch({ type: 'select', id: node.id });
+    },
+    [dispatch],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!drag.current) return;
+      const rect = surfaceRef.current?.getBoundingClientRect();
+      const ox = rect ? e.clientX - rect.left : e.clientX;
+      const oy = rect ? e.clientY - rect.top : e.clientY;
+      const x = Math.max(0, ox - drag.current.dx);
+      const y = Math.max(0, oy - drag.current.dy);
+      dispatch({ type: 'move-node', id: drag.current.id, x, y });
+    },
+    [dispatch],
+  );
+
+  const onPointerUp = useCallback(() => {
+    drag.current = null;
+    setDragging(null);
+  }, []);
+
+  const width = Math.max(900, ...state.nodes.map((n) => n.x + NODE_W + 80));
+  const height = Math.max(560, ...state.nodes.map((n) => n.y + NODE_H + 80));
+
+  return (
+    <div
+      ref={surfaceRef}
+      data-testid="workflow-canvas"
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onClick={() => dispatch({ type: 'select', id: null })}
+      style={{
+        position: 'relative',
+        flex: 1,
+        minHeight: 0,
+        overflow: 'auto',
+        background:
+          'var(--color-bg) radial-gradient(circle, var(--color-card-border) 1px, transparent 1px)',
+        backgroundSize: '24px 24px',
+        borderRadius: 'var(--radius-block)',
+        border: '1px solid var(--color-border)',
+      }}
+    >
+      <div style={{ position: 'relative', width, height }}>
+        <svg width={width} height={height} style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+          <defs>
+            {Object.entries(EDGE_STYLE).map(([kind, s]) => (
+              <marker
+                key={kind}
+                id={`arrow-${kind}`}
+                viewBox="0 0 10 10"
+                refX="9"
+                refY="5"
+                markerWidth="7"
+                markerHeight="7"
+                orient="auto-start-reverse"
+              >
+                <path d="M 0 0 L 10 5 L 0 10 z" fill={s.color} />
+              </marker>
+            ))}
+          </defs>
+          {state.edges.map((edge) => {
+            const from = byId.get(edge.from);
+            const to = byId.get(edge.to);
+            if (!from || !to) return null;
+            return <Edge key={edge.id} edge={edge} from={from} to={to} />;
+          })}
+        </svg>
+
+        {state.nodes.map((node) => (
+          <NodeCard
+            key={node.id}
+            node={node}
+            selected={state.selected === node.id}
+            dragging={dragging === node.id}
+            errors={state.errors[node.id]?.length ?? 0}
+            onPointerDown={(e) => onPointerDown(e, node)}
+          />
+        ))}
+
+        {state.nodes.length === 0 && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'grid',
+              placeItems: 'center',
+              color: 'var(--color-text-dim)',
+              fontSize: '0.9rem',
+            }}
+          >
+            Add a step from the palette to start building.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Edge({ edge, from, to }: { edge: BuilderEdge; from: BuilderNode; to: BuilderNode }): JSX.Element {
+  const style = EDGE_STYLE[edge.kind];
+  const x1 = from.x + NODE_W;
+  const y1 = from.y + ANCHOR_OFFSET;
+  const x2 = to.x;
+  const y2 = to.y + ANCHOR_OFFSET;
+  const midX = (x1 + x2) / 2;
+  const path = `M ${x1} ${y1} C ${midX} ${y1}, ${midX} ${y2}, ${x2} ${y2}`;
+  const label = edge.caseId ?? style.label;
+  return (
+    <g>
+      <path
+        d={path}
+        fill="none"
+        stroke={style.color}
+        strokeWidth={2}
+        strokeDasharray={style.dash}
+        markerEnd={`url(#arrow-${edge.kind})`}
+      />
+      {label && (
+        <text
+          x={midX}
+          y={(y1 + y2) / 2 - 6}
+          textAnchor="middle"
+          fontSize="10"
+          fill={style.color}
+          style={{ fontWeight: 600, paintOrder: 'stroke', stroke: 'var(--color-bg)', strokeWidth: 3 }}
+        >
+          {label}
+        </text>
+      )}
+    </g>
+  );
+}
+
+function NodeCard({
+  node,
+  selected,
+  dragging,
+  errors,
+  onPointerDown,
+}: {
+  node: BuilderNode;
+  selected: boolean;
+  dragging: boolean;
+  errors: number;
+  onPointerDown: (e: React.PointerEvent) => void;
+}): JSX.Element {
+  const meta = stepKindMeta(node.kind);
+  const accent = accentHex(meta.accent);
+  const isLoop = node.kind === 'loop';
+  return (
+    <div
+      data-testid={`wf-node-${node.id}`}
+      onPointerDown={onPointerDown}
+      onClick={(e) => e.stopPropagation()}
+      style={{
+        position: 'absolute',
+        left: node.x,
+        top: node.y,
+        width: NODE_W,
+        minHeight: NODE_H,
+        cursor: dragging ? 'grabbing' : 'grab',
+        userSelect: 'none',
+        background: 'var(--color-bg-card)',
+        borderStyle: 'solid',
+        borderWidth: '2px 2px 2px 5px',
+        borderColor: `${selected ? accent : errors > 0 ? 'var(--color-red)' : 'var(--color-border)'}`,
+        borderLeftColor: accent,
+        borderRadius: 'var(--radius-block)',
+        boxShadow: selected ? `0 4px 16px -6px ${accent}` : 'var(--color-card-shadow)',
+        padding: '0.5rem 0.65rem',
+        zIndex: selected ? 3 : 2,
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 6 }}>
+        <span
+          style={{
+            fontSize: '0.6rem',
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            letterSpacing: '0.04em',
+            color: accent,
+          }}
+        >
+          {meta.label}
+        </span>
+        {errors > 0 && (
+          <span
+            title={`${errors} validation issue(s)`}
+            style={{
+              fontSize: '0.6rem',
+              fontWeight: 700,
+              color: 'var(--color-red)',
+            }}
+          >
+            ⚠ {errors}
+          </span>
+        )}
+      </div>
+      <div style={{ fontWeight: 600, fontSize: '0.82rem', marginTop: 2, color: 'var(--color-text)' }}>
+        {node.label || node.id}
+      </div>
+      <div
+        className="mono"
+        style={{
+          fontSize: '0.66rem',
+          color: 'var(--color-text-dim)',
+          marginTop: 2,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {isLoop
+          ? `loop · ${node.loop?.body.length ?? 0} in body · max ${node.loop?.maxIterations ?? 10}`
+          : preview(node.action)}
+      </div>
+    </div>
+  );
+}
+
+function preview(text: string): string {
+  const t = (text ?? '').trim().replace(/\s+/g, ' ');
+  return t.length > 0 ? t : '(empty)';
+}
+
+export { WORKFLOW_ERROR_KEY };

--- a/apps/desktop/src/workflows/WorkflowsPanel.test.tsx
+++ b/apps/desktop/src/workflows/WorkflowsPanel.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Tests for the workflows builder panel. Locks down:
+ *   1. The list renders rows and "+ New" / per-row "Edit" open the builder.
+ *   2. The palette adds a node that renders on the canvas.
+ *   3. Editing a field in the inspector updates the node.
+ *   4. Loop body assignment wires a step into the loop.
+ *   5. Save runs validateDraft → save through the IPC.
+ *   6. A validation error decorates the node + surfaces in the inspector.
+ *
+ * The shared model is unit-tested in @moxxy/workflows-builder; here we assert
+ * the wiring (render ↔ reducer ↔ IPC) the panel is responsible for.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
+import { __setApiOverride } from '@moxxy/client-core';
+import type { MoxxyApi, WorkflowSummary } from '@moxxy/desktop-ipc-contract';
+import { WorkflowsPanel } from './WorkflowsPanel';
+
+interface Spy {
+  readonly invokes: Array<{ cmd: string; args: unknown }>;
+}
+
+function installApi(opts: {
+  list?: WorkflowSummary[];
+  validate?: (yaml: string) => { ok: boolean; errors: string[] };
+} = {}): Spy {
+  const invokes: Array<{ cmd: string; args: unknown }> = [];
+  const list = opts.list ?? [];
+  const validate = opts.validate ?? (() => ({ ok: true, errors: [] }));
+  __setApiOverride({
+    invoke: ((cmd: string, args: unknown) => {
+      invokes.push({ cmd, args });
+      if (cmd === 'workflows.list') return Promise.resolve(list);
+      if (cmd === 'workflows.validateDraft') {
+        return Promise.resolve(validate((args as { yaml: string }).yaml));
+      }
+      if (cmd === 'workflows.save') return Promise.resolve({ name: 'demo', scope: 'user', path: '/x.yaml' });
+      if (cmd === 'workflows.getRun') return Promise.resolve(null);
+      return Promise.resolve(undefined);
+    }) as never,
+    subscribe: (() => () => {}) as never,
+  } as MoxxyApi);
+  return { invokes };
+}
+
+afterEach(() => __setApiOverride(null));
+
+const sample: WorkflowSummary = {
+  name: 'daily-summary',
+  description: 'Rolls up the inbox',
+  enabled: true,
+  scope: 'global',
+  steps: 3,
+  triggers: 'on-demand',
+};
+
+describe('WorkflowsPanel — list mode', () => {
+  it('renders rows and opens the builder via Edit', async () => {
+    installApi({ list: [sample] });
+    render(<WorkflowsPanel />);
+    await screen.findByTestId('workflow-row-daily-summary');
+    fireEvent.click(screen.getByTestId('edit-workflow-daily-summary'));
+    expect(await screen.findByTestId('workflow-canvas')).toBeInTheDocument();
+  });
+
+  it('+ New opens an empty builder', async () => {
+    installApi({ list: [] });
+    render(<WorkflowsPanel />);
+    fireEvent.click(await screen.findByTestId('new-workflow'));
+    expect(await screen.findByTestId('workflow-canvas')).toBeInTheDocument();
+  });
+});
+
+describe('WorkflowsPanel — builder', () => {
+  async function openBuilder(spyOpts?: Parameters<typeof installApi>[0]): Promise<Spy> {
+    const spy = installApi({ list: [], ...spyOpts });
+    render(<WorkflowsPanel />);
+    fireEvent.click(await screen.findByTestId('new-workflow'));
+    await screen.findByTestId('workflow-canvas');
+    return spy;
+  }
+
+  it('adds a node from the palette and renders it', async () => {
+    await openBuilder();
+    fireEvent.click(screen.getByTestId('palette-add-prompt'));
+    expect(await screen.findByTestId('wf-node-prompt')).toBeInTheDocument();
+  });
+
+  it('edits a node field through the inspector', async () => {
+    await openBuilder();
+    fireEvent.click(screen.getByTestId('palette-add-prompt'));
+    await screen.findByTestId('wf-node-prompt');
+    // The node auto-selects on add → inspector is shown.
+    const action = await screen.findByTestId('field-action');
+    fireEvent.change(action, { target: { value: 'do the thing' } });
+    expect((action as HTMLTextAreaElement).value).toBe('do the thing');
+  });
+
+  it('assigns a step into a loop body', async () => {
+    await openBuilder();
+    fireEvent.click(screen.getByTestId('palette-add-loop'));
+    await screen.findByTestId('wf-node-loop');
+    fireEvent.click(screen.getByTestId('palette-add-bridge'));
+    await screen.findByTestId('wf-node-bridge');
+    // Re-select the loop to edit its body.
+    fireEvent.pointerDown(screen.getByTestId('wf-node-loop'));
+    const body = await screen.findByTestId('loop-body');
+    const checkbox = within(body).getByRole('checkbox');
+    fireEvent.click(checkbox);
+    expect((checkbox as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('saves through validateDraft → save', async () => {
+    const spy = await openBuilder();
+    fireEvent.click(screen.getByTestId('palette-add-prompt'));
+    await screen.findByTestId('wf-node-prompt');
+    fireEvent.change(await screen.findByTestId('field-action'), { target: { value: 'go' } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('builder-save'));
+    });
+    await waitFor(() => expect(spy.invokes.some((i) => i.cmd === 'workflows.save')).toBe(true));
+    expect(spy.invokes.some((i) => i.cmd === 'workflows.validateDraft')).toBe(true);
+  });
+
+  it('shows a validation error on the offending node', async () => {
+    await openBuilder({
+      validate: () => ({ ok: false, errors: ['steps: step "prompt" needs unknown step "ghost"'] }),
+    });
+    fireEvent.click(screen.getByTestId('palette-add-prompt'));
+    await screen.findByTestId('wf-node-prompt');
+    // The debounced live validation maps the error onto the node + inspector.
+    const errors = await screen.findByTestId('node-errors', undefined, { timeout: 2000 });
+    expect(errors.textContent).toContain('ghost');
+  });
+});

--- a/apps/desktop/src/workflows/WorkflowsPanel.tsx
+++ b/apps/desktop/src/workflows/WorkflowsPanel.tsx
@@ -1,13 +1,34 @@
+import { useState } from 'react';
 import { useWorkflows } from '@moxxy/client-core';
 import { Skeleton } from '@moxxy/desktop-ui';
+import { WorkflowBuilder } from './WorkflowBuilder';
 
 /**
- * List of workflows registered on the connected runner, with
- * enable/disable + run-now actions. The last run's per-step status
- * renders inline below the list.
+ * Workflows surface — two modes:
+ *   - list: the existing registry view with enable/disable + run-now + last-run
+ *     status, plus "New" and per-row "Edit" that open the visual builder.
+ *   - builder: the drag canvas (palette + nodes + edges + inspector + save).
+ *
+ * State/logic for the builder live in the shared `@moxxy/workflows-builder`
+ * model via `useWorkflowBuilder`; this panel only owns the mode toggle and
+ * wires the list's `refresh` so a save re-lists.
  */
 export function WorkflowsPanel(): JSX.Element {
   const wf = useWorkflows();
+  // `editing === undefined` → list; `null` → new workflow; string → edit by name.
+  const [editing, setEditing] = useState<string | null | undefined>(undefined);
+
+  if (editing !== undefined) {
+    return (
+      <WorkflowBuilder
+        name={editing}
+        onClose={() => setEditing(undefined)}
+        onSaved={() => {
+          void wf.refresh();
+        }}
+      />
+    );
+  }
 
   return (
     <main
@@ -20,23 +41,38 @@ export function WorkflowsPanel(): JSX.Element {
         gap: '1rem',
       }}
     >
-      <header style={{ display: 'flex', justifyContent: 'space-between' }}>
-        <h1 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 700 }}>
-          Workflows
-        </h1>
-        <button
-          type="button"
-          onClick={() => void wf.refresh()}
-          style={{
-            fontSize: '0.75rem',
-            color: 'var(--color-text-dim)',
-            border: '1px solid var(--color-border)',
-            borderRadius: 'var(--radius-block)',
-            padding: '0.2rem 0.55rem',
-          }}
-        >
-          Refresh
-        </button>
+      <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h1 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 700 }}>Workflows</h1>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <button
+            type="button"
+            data-testid="new-workflow"
+            onClick={() => setEditing(null)}
+            style={{
+              fontSize: '0.75rem',
+              fontWeight: 600,
+              color: 'var(--color-bg)',
+              background: 'var(--color-primary)',
+              borderRadius: 'var(--radius-block)',
+              padding: '0.25rem 0.7rem',
+            }}
+          >
+            + New
+          </button>
+          <button
+            type="button"
+            onClick={() => void wf.refresh()}
+            style={{
+              fontSize: '0.75rem',
+              color: 'var(--color-text-dim)',
+              border: '1px solid var(--color-border)',
+              borderRadius: 'var(--radius-block)',
+              padding: '0.2rem 0.55rem',
+            }}
+          >
+            Refresh
+          </button>
+        </div>
       </header>
       {wf.error && (
         <p
@@ -61,7 +97,7 @@ export function WorkflowsPanel(): JSX.Element {
         </div>
       ) : wf.list.length === 0 ? (
         <p style={{ color: 'var(--color-text-dim)' }}>
-          No workflows registered on this runner.
+          No workflows registered on this runner. Use <strong>+ New</strong> to build one.
         </p>
       ) : (
         <ul role="list" style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
@@ -75,7 +111,7 @@ export function WorkflowsPanel(): JSX.Element {
                 border: '1px solid var(--color-border)',
                 borderRadius: 'var(--radius-block)',
                 display: 'grid',
-                gridTemplateColumns: '1fr auto auto',
+                gridTemplateColumns: '1fr auto auto auto',
                 gap: '0.5rem',
                 alignItems: 'center',
               }}
@@ -97,6 +133,14 @@ export function WorkflowsPanel(): JSX.Element {
                   </div>
                 )}
               </div>
+              <button
+                type="button"
+                data-testid={`edit-workflow-${w.name}`}
+                onClick={() => setEditing(w.name)}
+                style={pill('var(--color-purple)')}
+              >
+                Edit
+              </button>
               <button
                 type="button"
                 onClick={() => void wf.setEnabled(w.name, !w.enabled)}

--- a/apps/desktop/src/workflows/accents.ts
+++ b/apps/desktop/src/workflows/accents.ts
@@ -1,0 +1,26 @@
+import type { StepKindMeta } from '@moxxy/workflows-builder';
+
+/**
+ * Map the shared model's semantic accent names to concrete desktop colors.
+ * The shared package stays platform-neutral (it only names a color); each UI
+ * resolves the name to its own palette. Falls back to the brand pink.
+ */
+const ACCENT_HEX: Record<StepKindMeta['accent'], string> = {
+  blue: '#3b82f6',
+  green: '#10b981',
+  purple: '#8b5cf6',
+  teal: '#14b8a6',
+  amber: '#f59e0b',
+  pink: '#ec4899',
+  cyan: '#06b6d4',
+  orange: '#f97316',
+};
+
+export function accentHex(accent: StepKindMeta['accent']): string {
+  return ACCENT_HEX[accent] ?? '#ec4899';
+}
+
+/** A translucent wash of the accent, for node card backgrounds. */
+export function accentWash(accent: StepKindMeta['accent']): string {
+  return `color-mix(in oklab, ${accentHex(accent)} 8%, white)`;
+}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -23,6 +23,7 @@ export default function Layout() {
         <Stack.Screen name="goals" />
         <Stack.Screen name="settings" />
         <Stack.Screen name="workflows" />
+        <Stack.Screen name="workflow-edit" />
       </Stack>
     </GatewayProvider>
   );

--- a/apps/mobile/app/workflow-edit.tsx
+++ b/apps/mobile/app/workflow-edit.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { ScreenFrame } from '@/components/ScreenFrame';
+import { WorkflowEditor } from '@/components/WorkflowEditor';
+import { useGatewayStore } from '@/hooks/useGatewayStore';
+import { useWorkflowEditor } from '@/hooks/useWorkflowEditor';
+
+/**
+ * The mobile visual builder screen — an outline editor over the shared
+ * `@moxxy/workflows-builder` model. `?name=<slug>` edits an existing workflow
+ * (loaded via `workflows.getRun`); no param opens a blank one. On save it
+ * navigates back to the list.
+ */
+export default function WorkflowEditScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ name?: string }>();
+  const name = typeof params.name === 'string' && params.name.length > 0 ? params.name : null;
+  const { permissions, session } = useGatewayStore();
+  const pendingActions = permissions.pendingAsks.length + permissions.pendingPermissions.length;
+  const editor = useWorkflowEditor();
+
+  useEffect(() => {
+    void editor.load(name);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [name]);
+
+  const onSave = (): void => {
+    void editor.save().then((ok) => {
+      if (ok) router.back();
+    });
+  };
+
+  return (
+    <ScreenFrame
+      title={name ? 'Edit workflow' : 'New workflow'}
+      subtitle="Visual builder"
+      connected={session.connected}
+      pendingActions={pendingActions}
+    >
+      <WorkflowEditor
+        state={editor.state}
+        dispatch={editor.dispatch}
+        valid={editor.valid}
+        validating={editor.validating}
+        saving={editor.saving}
+        saved={editor.saved}
+        error={editor.error}
+        onSave={onSave}
+      />
+    </ScreenFrame>
+  );
+}

--- a/apps/mobile/app/workflows.tsx
+++ b/apps/mobile/app/workflows.tsx
@@ -2,14 +2,21 @@ import { ScreenFrame } from '@/components/ScreenFrame';
 import { WorkflowList } from '@/components/WorkflowList';
 import { useGatewayStore } from '@/hooks/useGatewayStore';
 import { useEffect } from 'react';
+import { useRouter } from 'expo-router';
+import { workflowEditHref } from '@/workflowEditNav';
 
 export default function WorkflowsScreen() {
+  const router = useRouter();
   const { permissions, session, workflows } = useGatewayStore();
   const pendingActions = permissions.pendingAsks.length + permissions.pendingPermissions.length;
 
   useEffect(() => {
     workflows.refresh();
   }, [workflows.refresh]);
+
+  const onEdit = (name: string | null): void => {
+    router.push(workflowEditHref(name));
+  };
 
   return (
     <ScreenFrame
@@ -18,7 +25,12 @@ export default function WorkflowsScreen() {
       connected={session.connected}
       pendingActions={pendingActions}
     >
-      <WorkflowList workflows={workflows.workflows} onRefresh={workflows.refresh} onRun={workflows.run} />
+      <WorkflowList
+        workflows={workflows.workflows}
+        onRefresh={workflows.refresh}
+        onRun={workflows.run}
+        onEdit={onEdit}
+      />
     </ScreenFrame>
   );
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -18,6 +18,7 @@
     "@moxxy/design-tokens": "workspace:*",
     "@moxxy/desktop-ipc-contract": "workspace:*",
     "@moxxy/sdk": "workspace:*",
+    "@moxxy/workflows-builder": "workspace:*",
     "expo": "~54.0.0",
     "expo-audio": "~1.1.1",
     "expo-camera": "~17.0.10",

--- a/apps/mobile/src/__tests__/clientFrames.test.ts
+++ b/apps/mobile/src/__tests__/clientFrames.test.ts
@@ -17,8 +17,11 @@ import {
   buildSetAutoApproveFrame,
   buildSetModeFrame,
   buildTranscribeFrame,
+  buildWorkflowDetailFrame,
   buildWorkflowListFrame,
   buildWorkflowRunFrame,
+  buildWorkflowSaveFrame,
+  buildWorkflowValidateFrame,
   invokeFrame,
 } from '../clientFrames';
 
@@ -91,6 +94,21 @@ describe('mobile client frame builders', () => {
     expect(buildWorkflowRunFrame({ name: 'codzienny-obrazek-email' })).toEqual({
       command: 'workflows.run',
       args: { name: 'codzienny-obrazek-email' },
+    });
+  });
+
+  it('builds visual-builder frames (validate / save / detail)', () => {
+    expect(buildWorkflowValidateFrame({ yaml: 'name: x' })).toEqual({
+      command: 'workflows.validateDraft',
+      args: { yaml: 'name: x' },
+    });
+    expect(buildWorkflowSaveFrame({ yaml: 'name: x' })).toEqual({
+      command: 'workflows.save',
+      args: { yaml: 'name: x' },
+    });
+    expect(buildWorkflowDetailFrame({ name: 'refine-draft' })).toEqual({
+      command: 'workflows.getRun',
+      args: { name: 'refine-draft' },
     });
   });
 

--- a/apps/mobile/src/__tests__/workflow-editor.test.ts
+++ b/apps/mobile/src/__tests__/workflow-editor.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Mobile workflow-builder logic test. The shared reducer/serializer are
+ * exhaustively covered in @moxxy/workflows-builder; here we lock down the
+ * mobile-specific glue: the edit-nav href and that the mobile editor's
+ * operation sequence (add loop + body step, wire body/exit, configure) produces
+ * the YAML the host's save expects — exercised purely (no RN render), per the
+ * mobile test convention.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  addStep,
+  builderReducer,
+  emptyState,
+  serialize,
+  type BuilderState,
+} from '@moxxy/workflows-builder';
+import { workflowEditHref } from '../workflowEditNav';
+
+function reduce(state: BuilderState, ...actions: Parameters<typeof builderReducer>[1][]): BuilderState {
+  return actions.reduce(builderReducer, state);
+}
+
+describe('workflowEditHref', () => {
+  it('builds a blank-builder href with no name', () => {
+    expect(workflowEditHref(null)).toBe('/workflow-edit');
+  });
+  it('url-encodes the workflow name', () => {
+    expect(workflowEditHref('daily summary')).toBe('/workflow-edit?name=daily%20summary');
+  });
+});
+
+describe('mobile editor operation sequence → YAML', () => {
+  it('produces a valid loop workflow shape the host can save', () => {
+    let s = emptyState('refine-draft');
+    s = builderReducer(s, { type: 'update-meta', patch: { description: 'Refine until good.' } });
+    s = addStep(s, { kind: 'prompt', id: 'first_draft' });
+    s = builderReducer(s, { type: 'update-node', id: 'first_draft', patch: { action: 'Write a first draft.' } });
+    s = addStep(s, { kind: 'loop', id: 'refine', after: 'first_draft' });
+    s = addStep(s, { kind: 'bridge', id: 'improve' });
+    s = builderReducer(s, { type: 'update-node', id: 'improve', patch: { action: 'Improve. Return vars.draft.' } });
+    s = addStep(s, { kind: 'prompt', id: 'finish' });
+    s = builderReducer(s, { type: 'update-node', id: 'finish', patch: { action: 'Emit final.' } });
+
+    s = reduce(
+      s,
+      { type: 'set-loop-body', loopId: 'refine', body: ['improve'] },
+      { type: 'set-loop-exit', loopId: 'refine', targetId: 'finish' },
+      { type: 'set-loop-config', loopId: 'refine', patch: { condition: 'Good enough?', maxIterations: 5 } },
+    );
+
+    const { workflow, yaml } = serialize(s);
+    const loop = workflow.steps.find((st) => st.id === 'refine')!;
+    expect(loop.loop).toEqual({ body: ['improve'], condition: 'Good enough?', maxIterations: 5 });
+    // body + exit both scoped to the loop via needs
+    expect(workflow.steps.find((st) => st.id === 'improve')!.needs).toContain('refine');
+    expect(workflow.steps.find((st) => st.id === 'finish')!.needs).toContain('refine');
+    // exactly one loop-exit edge in the rendered graph
+    expect(s.edges.filter((e) => e.kind === 'loop-exit')).toHaveLength(1);
+    expect(yaml).toContain('name: refine-draft');
+    expect(yaml).toContain('maxIterations: 5');
+  });
+});

--- a/apps/mobile/src/clientFrames.ts
+++ b/apps/mobile/src/clientFrames.ts
@@ -80,6 +80,15 @@ export interface WorkflowRunInput {
   readonly name: string;
 }
 
+export interface WorkflowDraftInput {
+  /** Full workflow YAML to validate / persist. */
+  readonly yaml: string;
+}
+
+export interface WorkflowDetailInput {
+  readonly name: string;
+}
+
 /** `null` workspace (nothing selected yet) → omit and let the host default. */
 function ws(workspaceId: string | null): { workspaceId?: string } {
   return workspaceId ? { workspaceId } : {};
@@ -145,6 +154,25 @@ export function buildWorkflowListFrame(): CommandFrame<'workflows.list'> {
 
 export function buildWorkflowRunFrame(input: WorkflowRunInput): CommandFrame<'workflows.run'> {
   return { command: 'workflows.run', args: { name: input.name } };
+}
+
+// --- Visual builder (phase 2) — the host's MobileSessionHost wires these to
+//     the same WorkflowsView the desktop uses; the screen feature-checks via
+//     the coded `not-supported` error when the workflows plugin is absent.
+export function buildWorkflowValidateFrame(
+  input: WorkflowDraftInput,
+): CommandFrame<'workflows.validateDraft'> {
+  return { command: 'workflows.validateDraft', args: { yaml: input.yaml } };
+}
+
+export function buildWorkflowSaveFrame(input: WorkflowDraftInput): CommandFrame<'workflows.save'> {
+  return { command: 'workflows.save', args: { yaml: input.yaml } };
+}
+
+export function buildWorkflowDetailFrame(
+  input: WorkflowDetailInput,
+): CommandFrame<'workflows.getRun'> {
+  return { command: 'workflows.getRun', args: { name: input.name } };
 }
 
 export function buildTranscribeFrame(input: TranscribeInput): CommandFrame<'session.transcribe'> {

--- a/apps/mobile/src/components/WorkflowEditor.tsx
+++ b/apps/mobile/src/components/WorkflowEditor.tsx
@@ -1,0 +1,425 @@
+import { Pressable, Text, TextInput, View } from 'react-native';
+import {
+  STEP_KINDS,
+  stepKindMeta,
+  type BuilderAction,
+  type BuilderNode,
+  type BuilderState,
+  type StepKind,
+} from '@moxxy/workflows-builder';
+import type { WorkflowStepErrorMode } from '@moxxy/sdk';
+import { MobileIcon } from './MobileIcon';
+
+/**
+ * Mobile workflow editor — an OUTLINE editor over the shared builder model.
+ * Touch-dragging a node graph is disproportionate for v1, so the mobile UI is
+ * a vertical list of step cards with the SAME operations the desktop canvas
+ * exposes (add/remove step, set needs, edit the action, and the loop's body +
+ * exit + condition + maxIterations). All mutations go through the shared
+ * reducer; this component is presentation + touch interaction only.
+ *
+ * The loop card surfaces both connection regions explicitly: a BODY toggle list
+ * (steps that run inside the loop) and an EXIT picker (the single "on done / on
+ * error → next" step), mirroring the desktop canvas's two-region loop model.
+ */
+
+const ACCENT_HEX: Record<ReturnType<typeof stepKindMeta>['accent'], string> = {
+  blue: '#3b82f6',
+  green: '#10b981',
+  purple: '#8b5cf6',
+  teal: '#14b8a6',
+  amber: '#f59e0b',
+  pink: '#ec4899',
+  cyan: '#06b6d4',
+  orange: '#f97316',
+};
+
+const ERROR_MODES: WorkflowStepErrorMode[] = ['fail', 'continue', 'retry'];
+
+interface Props {
+  readonly state: BuilderState;
+  readonly dispatch: (action: BuilderAction) => void;
+  readonly valid: boolean | null;
+  readonly validating: boolean;
+  readonly saving: boolean;
+  readonly saved: boolean;
+  readonly error: string | null;
+  readonly onSave: () => void;
+}
+
+export function WorkflowEditor(props: Props) {
+  const { state, dispatch } = props;
+  return (
+    <View className="gap-4">
+      {/* Header: name + description */}
+      <View className="gap-3 rounded-card border border-cardBorder bg-cardBg p-4 shadow-card" style={{ shadowOpacity: 0.08 }}>
+        <FieldLabel>Workflow name (slug)</FieldLabel>
+        <TextInput
+          value={state.meta.name}
+          onChangeText={(name) => dispatch({ type: 'update-meta', patch: { name } })}
+          autoCapitalize="none"
+          placeholder="my-workflow"
+          placeholderTextColor="#94a3b8"
+          className="rounded-block border border-cardBorder bg-cardBg px-3 py-2 text-[14px] text-text"
+        />
+        <FieldLabel>Description</FieldLabel>
+        <TextInput
+          value={state.meta.description}
+          onChangeText={(description) => dispatch({ type: 'update-meta', patch: { description } })}
+          placeholder="What this workflow does"
+          placeholderTextColor="#94a3b8"
+          className="rounded-block border border-cardBorder bg-cardBg px-3 py-2 text-[14px] text-text"
+        />
+        <View className="flex-row items-center justify-between">
+          <ValidityBadge valid={props.valid} validating={props.validating} saved={props.saved} />
+          <Pressable
+            className={`min-h-11 flex-row items-center justify-center gap-2 rounded-pill px-5 ${
+              props.saving || props.valid === false ? 'bg-cardBorder' : 'bg-primary'
+            }`}
+            disabled={props.saving || props.valid === false}
+            onPress={props.onSave}
+          >
+            <MobileIcon name="check" size={16} color="#ffffff" strokeWidth={2.6} />
+            <Text className="text-[13px] font-black text-white">{props.saving ? 'Saving…' : 'Save'}</Text>
+          </Pressable>
+        </View>
+        {props.error ? (
+          <View className="rounded-block border border-red bg-red/10 px-3 py-2">
+            <Text className="text-[12px] font-bold text-red">{props.error}</Text>
+          </View>
+        ) : null}
+      </View>
+
+      {/* Palette */}
+      <View className="gap-2 rounded-card border border-cardBorder bg-cardBg p-4 shadow-card" style={{ shadowOpacity: 0.08 }}>
+        <FieldLabel>Add step</FieldLabel>
+        <View className="flex-row flex-wrap gap-2">
+          {STEP_KINDS.map((k) => (
+            <Pressable
+              key={k.kind}
+              testID={`mobile-palette-add-${k.kind}`}
+              className="rounded-pill border px-3 py-1.5"
+              style={{ borderColor: ACCENT_HEX[k.accent] }}
+              onPress={() => dispatch({ type: 'add-step', input: { kind: k.kind } })}
+            >
+              <Text className="text-[12px] font-black" style={{ color: ACCENT_HEX[k.accent] }}>
+                + {k.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+
+      {state.nodes.length === 0 ? (
+        <View className="rounded-card border border-cardBorder bg-cardBg p-5">
+          <Text className="text-[14px] text-muted">Add a step above to start building.</Text>
+        </View>
+      ) : null}
+
+      {state.nodes.map((node) => (
+        <StepCard key={node.id} state={state} node={node} dispatch={dispatch} />
+      ))}
+    </View>
+  );
+}
+
+function StepCard({
+  state,
+  node,
+  dispatch,
+}: {
+  state: BuilderState;
+  node: BuilderNode;
+  dispatch: (a: BuilderAction) => void;
+}) {
+  const meta = stepKindMeta(node.kind);
+  const accent = ACCENT_HEX[meta.accent];
+  const errors = state.errors[node.id] ?? [];
+  const others = state.nodes.filter((n) => n.id !== node.id);
+
+  const patch = (p: Parameters<typeof emitUpdate>[2]): void => emitUpdate(dispatch, node.id, p);
+
+  return (
+    <View
+      testID={`mobile-node-${node.id}`}
+      className="gap-3 rounded-card border border-cardBorder bg-cardBg p-4 shadow-card"
+      style={{ shadowOpacity: 0.08, borderLeftWidth: 5, borderLeftColor: accent }}
+    >
+      <View className="flex-row items-center justify-between">
+        <Text className="text-[11px] font-black uppercase" style={{ color: accent }}>
+          {meta.label}
+        </Text>
+        <Pressable testID={`mobile-delete-${node.id}`} onPress={() => dispatch({ type: 'remove-step', id: node.id })}>
+          <MobileIcon name="x" size={18} color="#ef4444" />
+        </Pressable>
+      </View>
+
+      <FieldLabel>Step id</FieldLabel>
+      <TextInput
+        value={node.id}
+        onChangeText={(to) => dispatch({ type: 'rename-node', from: node.id, to })}
+        autoCapitalize="none"
+        className="rounded-block border border-cardBorder bg-cardBg px-3 py-2 text-[13px] text-text"
+      />
+      <FieldLabel>Label</FieldLabel>
+      <TextInput
+        value={node.label ?? ''}
+        onChangeText={(label) => patch({ label })}
+        placeholder="Human title"
+        placeholderTextColor="#94a3b8"
+        className="rounded-block border border-cardBorder bg-cardBg px-3 py-2 text-[13px] text-text"
+      />
+
+      {node.kind !== 'loop' ? (
+        <>
+          <FieldLabel>{actionLabel(node.kind)}</FieldLabel>
+          <TextInput
+            testID={`mobile-action-${node.id}`}
+            value={node.action}
+            onChangeText={(action) => patch({ action })}
+            multiline={node.kind === 'prompt' || node.kind === 'bridge' || node.kind === 'condition' || node.kind === 'switch'}
+            placeholder={meta.description}
+            placeholderTextColor="#94a3b8"
+            className="min-h-11 rounded-block border border-cardBorder bg-cardBg px-3 py-2 text-[13px] text-text"
+          />
+        </>
+      ) : (
+        <LoopCard state={state} node={node} dispatch={dispatch} accent={accent} />
+      )}
+
+      {node.kind === 'condition' ? (
+        <>
+          <TogglePicker
+            label="then → (met)"
+            options={others}
+            selected={node.then ?? []}
+            onToggle={(id, on) => toggleBranch(dispatch, node, 'then', id, on)}
+          />
+          <TogglePicker
+            label="else → (not met)"
+            options={others}
+            selected={node.else ?? []}
+            onToggle={(id, on) => toggleBranch(dispatch, node, 'else', id, on)}
+          />
+        </>
+      ) : null}
+
+      {node.kind !== 'loop' ? (
+        <TogglePicker
+          label="Needs"
+          testID={`mobile-needs-${node.id}`}
+          options={others}
+          selected={node.needs}
+          onToggle={(id, on) =>
+            dispatch(on ? { type: 'connect-needs', from: id, to: node.id } : { type: 'disconnect-needs', from: id, to: node.id })
+          }
+        />
+      ) : null}
+
+      <FieldLabel>On error</FieldLabel>
+      <View className="flex-row gap-2">
+        {ERROR_MODES.map((m) => (
+          <Pressable
+            key={m}
+            className={`rounded-pill px-3 py-1.5 ${node.onError === m ? 'bg-primary' : 'bg-appBg'}`}
+            onPress={() => patch({ onError: m })}
+          >
+            <Text className={`text-[12px] font-bold ${node.onError === m ? 'text-white' : 'text-muted'}`}>{m}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      {errors.length > 0 ? (
+        <View testID={`mobile-errors-${node.id}`} className="rounded-block border border-red bg-red/10 px-3 py-2">
+          {errors.map((msg, i) => (
+            <Text key={i} className="text-[11px] text-red">
+              {msg}
+            </Text>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+function LoopCard({
+  state,
+  node,
+  dispatch,
+  accent,
+}: {
+  state: BuilderState;
+  node: BuilderNode;
+  dispatch: (a: BuilderAction) => void;
+  accent: string;
+}) {
+  const body = node.loop?.body ?? [];
+  const bodySet = new Set(body);
+  const exit = state.edges.find((e) => e.kind === 'loop-exit' && e.from === node.id)?.to ?? '';
+  const candidates = state.nodes.filter((n) => n.id !== node.id);
+  return (
+    <View className="gap-3">
+      <FieldLabel>Exit / goal condition (met → stop)</FieldLabel>
+      <TextInput
+        testID={`mobile-loop-condition-${node.id}`}
+        value={node.loop?.condition ?? ''}
+        onChangeText={(condition) => dispatch({ type: 'set-loop-config', loopId: node.id, patch: { condition } })}
+        multiline
+        placeholder="Describe the goal that ENDS the loop."
+        placeholderTextColor="#94a3b8"
+        className="min-h-16 rounded-block border border-cardBorder bg-cardBg px-3 py-2 text-[13px] text-text"
+      />
+      <FieldLabel>Max iterations (1-50)</FieldLabel>
+      <TextInput
+        value={String(node.loop?.maxIterations ?? 10)}
+        onChangeText={(v) => dispatch({ type: 'set-loop-config', loopId: node.id, patch: { maxIterations: Number(v) || 1 } })}
+        keyboardType="number-pad"
+        className="rounded-block border border-cardBorder bg-cardBg px-3 py-2 text-[13px] text-text"
+      />
+      <FieldLabel>Body — runs inside the loop each iteration</FieldLabel>
+      <View testID={`mobile-loop-body-${node.id}`} className="gap-2">
+        {candidates.length === 0 ? <Text className="text-[12px] text-muted">Add steps, then assign them here.</Text> : null}
+        {candidates.map((c) => {
+          const on = bodySet.has(c.id);
+          return (
+            <Pressable
+              key={c.id}
+              disabled={c.id === exit}
+              className={`flex-row items-center gap-2 rounded-block border px-3 py-2 ${on ? 'border-purple bg-purple/10' : 'border-cardBorder'}`}
+              style={{ borderColor: on ? accent : undefined }}
+              onPress={() =>
+                dispatch({
+                  type: 'set-loop-body',
+                  loopId: node.id,
+                  body: on ? body.filter((b) => b !== c.id) : [...body, c.id],
+                })
+              }
+            >
+              <MobileIcon name={on ? 'check' : 'plus'} size={15} color={on ? accent : '#94a3b8'} />
+              <Text className="text-[13px] text-text">{c.label || c.id}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+      <FieldLabel>Exit → next step (on done / body error)</FieldLabel>
+      <View className="gap-2">
+        <Pressable
+          className={`rounded-block border px-3 py-2 ${exit === '' ? 'border-primary bg-primary/10' : 'border-cardBorder'}`}
+          onPress={() => dispatch({ type: 'set-loop-exit', loopId: node.id, targetId: null })}
+        >
+          <Text className="text-[13px] text-text">(loop ends the workflow)</Text>
+        </Pressable>
+        {candidates
+          .filter((c) => !bodySet.has(c.id))
+          .map((c) => (
+            <Pressable
+              key={c.id}
+              testID={`mobile-loop-exit-${node.id}-${c.id}`}
+              className={`rounded-block border px-3 py-2 ${exit === c.id ? 'border-primary bg-primary/10' : 'border-cardBorder'}`}
+              onPress={() => dispatch({ type: 'set-loop-exit', loopId: node.id, targetId: c.id })}
+            >
+              <Text className="text-[13px] text-text">{c.label || c.id}</Text>
+            </Pressable>
+          ))}
+      </View>
+    </View>
+  );
+}
+
+function TogglePicker({
+  label,
+  options,
+  selected,
+  onToggle,
+  testID,
+}: {
+  label: string;
+  options: BuilderNode[];
+  selected: ReadonlyArray<string>;
+  onToggle: (id: string, on: boolean) => void;
+  testID?: string;
+}) {
+  const set = new Set(selected);
+  return (
+    <View className="gap-2" testID={testID}>
+      <FieldLabel>{label}</FieldLabel>
+      {options.length === 0 ? <Text className="text-[12px] text-muted">No other steps yet.</Text> : null}
+      <View className="flex-row flex-wrap gap-2">
+        {options.map((o) => {
+          const on = set.has(o.id);
+          return (
+            <Pressable
+              key={o.id}
+              className={`rounded-pill px-3 py-1.5 ${on ? 'bg-primary' : 'bg-appBg'}`}
+              onPress={() => onToggle(o.id, !on)}
+            >
+              <Text className={`text-[12px] font-bold ${on ? 'text-white' : 'text-muted'}`}>{o.label || o.id}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+function ValidityBadge({ valid, validating, saved }: { valid: boolean | null; validating: boolean; saved: boolean }) {
+  const { label, color } = saved
+    ? { label: 'saved', color: '#10b981' }
+    : validating
+      ? { label: 'checking…', color: '#94a3b8' }
+      : valid === true
+        ? { label: 'valid', color: '#10b981' }
+        : valid === false
+          ? { label: 'invalid', color: '#ef4444' }
+          : { label: 'unsaved', color: '#94a3b8' };
+  return (
+    <View testID="mobile-validity-badge" className="rounded-pill px-3 py-1" style={{ borderWidth: 1, borderColor: color }}>
+      <Text className="text-[12px] font-black" style={{ color }}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return <Text className="text-[10px] font-black uppercase tracking-wide text-muted">{children}</Text>;
+}
+
+function actionLabel(kind: StepKind): string {
+  switch (kind) {
+    case 'prompt':
+      return 'Prompt';
+    case 'skill':
+      return 'Skill name';
+    case 'tool':
+      return 'Tool name';
+    case 'workflow':
+      return 'Workflow name';
+    case 'bridge':
+    case 'condition':
+    case 'switch':
+      return 'Instruction';
+    default:
+      return 'Action';
+  }
+}
+
+function toggleBranch(
+  dispatch: (a: BuilderAction) => void,
+  node: BuilderNode,
+  slot: 'then' | 'else',
+  id: string,
+  on: boolean,
+): void {
+  const current = (slot === 'then' ? node.then : node.else) ?? [];
+  const targets = on ? [...current, id] : current.filter((t) => t !== id);
+  dispatch({ type: 'set-branch', nodeId: node.id, slot, targets });
+}
+
+function emitUpdate(
+  dispatch: (a: BuilderAction) => void,
+  id: string,
+  patch: { label?: string; action?: string; onError?: WorkflowStepErrorMode },
+): void {
+  dispatch({ type: 'update-node', id, patch });
+}

--- a/apps/mobile/src/components/WorkflowList.tsx
+++ b/apps/mobile/src/components/WorkflowList.tsx
@@ -6,11 +6,23 @@ interface WorkflowListProps {
   readonly workflows: ReadonlyArray<MobileWorkflow>;
   readonly onRefresh: () => void;
   readonly onRun: (name: string) => void;
+  /** Open the visual builder for a workflow (or a blank one when null). */
+  readonly onEdit?: (name: string | null) => void;
 }
 
-export function WorkflowList({ workflows, onRefresh, onRun }: WorkflowListProps) {
+export function WorkflowList({ workflows, onRefresh, onRun, onEdit }: WorkflowListProps) {
   return (
     <View className="gap-3">
+      {onEdit ? (
+        <Pressable
+          testID="mobile-new-workflow"
+          className="min-h-12 flex-row items-center justify-center gap-2 rounded-card bg-primary"
+          onPress={() => onEdit(null)}
+        >
+          <MobileIcon name="plus" size={18} strokeWidth={2.6} color="#ffffff" />
+          <Text className="text-[13px] font-black text-white">New workflow</Text>
+        </Pressable>
+      ) : null}
       <Pressable
         className="min-h-12 flex-row items-center justify-center gap-2 rounded-card border border-cardBorder bg-cardBg"
         onPress={onRefresh}
@@ -49,13 +61,25 @@ export function WorkflowList({ workflows, onRefresh, onRun }: WorkflowListProps)
               </View>
             </View>
           </View>
-          <Pressable
-            className="mt-4 min-h-11 flex-row items-center justify-center gap-2 rounded-pill bg-primary px-4"
-            onPress={() => onRun(workflow.name)}
-          >
-            <MobileIcon name="send" size={17} strokeWidth={2.4} color="#ffffff" />
-            <Text className="text-[13px] font-black text-white">Run workflow</Text>
-          </Pressable>
+          <View className="mt-4 flex-row gap-2">
+            {onEdit ? (
+              <Pressable
+                testID={`mobile-edit-${workflow.name}`}
+                className="min-h-11 flex-1 flex-row items-center justify-center gap-2 rounded-pill border border-purple px-4"
+                onPress={() => onEdit(workflow.name)}
+              >
+                <MobileIcon name="edit" size={16} strokeWidth={2.4} color="#8b5cf6" />
+                <Text className="text-[13px] font-black text-purple">Edit</Text>
+              </Pressable>
+            ) : null}
+            <Pressable
+              className="min-h-11 flex-1 flex-row items-center justify-center gap-2 rounded-pill bg-primary px-4"
+              onPress={() => onRun(workflow.name)}
+            >
+              <MobileIcon name="send" size={17} strokeWidth={2.4} color="#ffffff" />
+              <Text className="text-[13px] font-black text-white">Run</Text>
+            </Pressable>
+          </View>
         </View>
       ))}
     </View>

--- a/apps/mobile/src/hooks/useWorkflowEditor.ts
+++ b/apps/mobile/src/hooks/useWorkflowEditor.ts
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import { api, decodeError } from '@moxxy/client-core';
+import {
+  builderReducer,
+  emptyState,
+  hydrateYaml,
+  mapErrorsToNodes,
+  serialize,
+  type BuilderAction,
+  type BuilderState,
+} from '@moxxy/workflows-builder';
+import {
+  buildWorkflowDetailFrame,
+  buildWorkflowSaveFrame,
+  buildWorkflowValidateFrame,
+  invokeFrame,
+} from '../clientFrames';
+
+/**
+ * Mobile builder hook — the same shared `@moxxy/workflows-builder` model that
+ * powers the desktop canvas, driven over the mobile frame bridge instead of the
+ * Electron preload. The mobile UI is an OUTLINE editor (a node list with the
+ * same operations), so the hook exposes the reducer + the validate/save bridge;
+ * there is no canvas-specific state here.
+ *
+ * `validateDraft` / `save` / `getRun` are wired on the host's MobileSessionHost
+ * (the engine added them to the WorkflowsView pass-through). When the workflows
+ * plugin is absent the host throws the coded `not-supported` error, which we
+ * surface as a plain message rather than crashing the screen.
+ */
+export interface UseWorkflowEditor {
+  readonly state: BuilderState;
+  readonly dispatch: (action: BuilderAction) => void;
+  readonly valid: boolean | null;
+  readonly validating: boolean;
+  readonly saving: boolean;
+  readonly error: string | null;
+  readonly saved: boolean;
+  readonly load: (name: string | null) => Promise<void>;
+  readonly save: () => Promise<boolean>;
+}
+
+const VALIDATE_DEBOUNCE_MS = 500;
+
+export function useWorkflowEditor(): UseWorkflowEditor {
+  const [state, dispatch] = useReducer(builderReducer, undefined, () => emptyState());
+  const [valid, setValid] = useState<boolean | null>(null);
+  const [validating, setValidating] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  const toMessage = useCallback((e: unknown): string => {
+    const decoded = decodeError(e);
+    return decoded.code === 'not-supported'
+      ? 'The workflow builder is not available on this host.'
+      : decoded.message;
+  }, []);
+
+  const runValidation = useCallback(async (): Promise<boolean> => {
+    const snapshot = stateRef.current;
+    setValidating(true);
+    try {
+      const { yaml } = serialize(snapshot);
+      const result = await invokeFrame(api(), buildWorkflowValidateFrame({ yaml }));
+      dispatch({ type: 'apply-validation', errors: mapErrorsToNodes(result.errors, snapshot) });
+      setValid(result.ok);
+      setError(null);
+      return result.ok;
+    } catch (e) {
+      setError(toMessage(e));
+      setValid(null);
+      return false;
+    } finally {
+      setValidating(false);
+    }
+  }, [toMessage]);
+
+  useEffect(() => {
+    setSaved(false);
+    if (state.nodes.length === 0) {
+      setValid(null);
+      return;
+    }
+    const t = setTimeout(() => void runValidation(), VALIDATE_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [state.nodes, state.edges, state.meta, runValidation]);
+
+  const load = useCallback(
+    async (name: string | null) => {
+      setError(null);
+      setValid(null);
+      setSaved(false);
+      if (!name) {
+        dispatch({ type: 'load', state: emptyState() });
+        return;
+      }
+      try {
+        const detail = await invokeFrame(api(), buildWorkflowDetailFrame({ name }));
+        if (!detail) {
+          setError(`Workflow "${name}" was not found.`);
+          return;
+        }
+        dispatch({ type: 'load', state: hydrateYaml(detail.yaml) });
+      } catch (e) {
+        setError(toMessage(e));
+      }
+    },
+    [toMessage],
+  );
+
+  const save = useCallback(async (): Promise<boolean> => {
+    setSaving(true);
+    setError(null);
+    try {
+      const ok = await runValidation();
+      if (!ok) {
+        setError('Fix the highlighted issues before saving.');
+        return false;
+      }
+      const { yaml } = serialize(stateRef.current);
+      await invokeFrame(api(), buildWorkflowSaveFrame({ yaml }));
+      dispatch({ type: 'mark-saved' });
+      setSaved(true);
+      return true;
+    } catch (e) {
+      setError(toMessage(e));
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }, [runValidation, toMessage]);
+
+  return useMemo(
+    () => ({ state, dispatch, valid, validating, saving, error, saved, load, save }),
+    [state, valid, validating, saving, error, saved, load, save],
+  );
+}

--- a/apps/mobile/src/workflowEditNav.ts
+++ b/apps/mobile/src/workflowEditNav.ts
@@ -1,0 +1,10 @@
+/**
+ * Pure helper for the workflows → builder navigation. Building the
+ * `/workflow-edit` href (with an optional, URL-encoded `name` query) is the
+ * only non-trivial local logic the workflows screen owns, so it lives here as a
+ * testable function rather than inline in the component (mobile test convention:
+ * cover pure logic, not RN render).
+ */
+export function workflowEditHref(name: string | null): string {
+  return name ? `/workflow-edit?name=${encodeURIComponent(name)}` : '/workflow-edit';
+}

--- a/packages/client-core/package.json
+++ b/packages/client-core/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "@moxxy/chat-model": "workspace:*",
     "@moxxy/desktop-ipc-contract": "workspace:*",
-    "@moxxy/sdk": "workspace:*"
+    "@moxxy/sdk": "workspace:*",
+    "@moxxy/workflows-builder": "workspace:*"
   },
   "peerDependencies": {
     "react": "^18.2.0 || ^19.0.0"

--- a/packages/client-core/src/index.ts
+++ b/packages/client-core/src/index.ts
@@ -27,6 +27,7 @@ export * from './usePrefs.js';
 export * from './useSettings.js';
 export * from './useDesks.js';
 export * from './useWorkflows.js';
+export * from './useWorkflowBuilder.js';
 export * from './useOnboarding.js';
 export * from './useContextUsage.js';
 export * from './useAppUpdate.js';

--- a/packages/client-core/src/useWorkflowBuilder.test.tsx
+++ b/packages/client-core/src/useWorkflowBuilder.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * useWorkflowBuilder hook tests — drive the validate/save IPC through the fake
+ * api shim and assert the hook loads a workflow, validates on edit, maps errors
+ * onto nodes, and persists only when valid.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { __setApiOverride } from './transport.js';
+import { useWorkflowBuilder } from './useWorkflowBuilder.js';
+import { serialize, emptyState, addStep, updateNode, updateMeta } from '@moxxy/workflows-builder';
+import type { MoxxyApi } from '@moxxy/desktop-ipc-contract';
+
+function fakeApi(invoke: MoxxyApi['invoke']): MoxxyApi {
+  return { invoke, subscribe: () => () => {} };
+}
+
+afterEach(() => __setApiOverride(null));
+
+function sampleYaml(): string {
+  let s = emptyState('demo');
+  s = updateMeta(s, { description: 'demo' });
+  s = addStep(s, { kind: 'prompt', id: 'a' });
+  s = updateNode(s, 'a', { action: 'do a' });
+  return serialize(s).yaml;
+}
+
+describe('useWorkflowBuilder', () => {
+  it('loads a saved workflow by name via getRun', async () => {
+    const yaml = sampleYaml();
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === 'workflows.getRun') return { name: 'demo', scope: 'user', path: '/x.yaml', yaml };
+      if (cmd === 'workflows.validateDraft') return { ok: true, errors: [] };
+      throw new Error(`unexpected ${cmd}`);
+    });
+    __setApiOverride(fakeApi(invoke as unknown as MoxxyApi['invoke']));
+
+    const { result } = renderHook(() => useWorkflowBuilder());
+    await act(async () => {
+      await result.current.load('demo');
+    });
+    expect(result.current.state.nodes.map((n) => n.id)).toEqual(['a']);
+    expect(result.current.state.meta.name).toBe('demo');
+  });
+
+  it('validates on edit and maps errors onto nodes', async () => {
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === 'workflows.validateDraft') {
+        return { ok: false, errors: ['steps: step "a" needs unknown step "ghost"'] };
+      }
+      throw new Error(`unexpected ${cmd}`);
+    });
+    __setApiOverride(fakeApi(invoke as unknown as MoxxyApi['invoke']));
+
+    const { result } = renderHook(() => useWorkflowBuilder());
+    act(() => result.current.dispatch({ type: 'add-step', input: { kind: 'prompt', id: 'a' } }));
+    await waitFor(() => expect(result.current.valid).toBe(false));
+    expect(result.current.state.errors.a).toBeDefined();
+  });
+
+  it('save persists only when validation passes', async () => {
+    const saved = { name: 'demo', scope: 'user', path: '/x.yaml' };
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === 'workflows.validateDraft') return { ok: true, errors: [] };
+      if (cmd === 'workflows.save') return saved;
+      throw new Error(`unexpected ${cmd}`);
+    });
+    __setApiOverride(fakeApi(invoke as unknown as MoxxyApi['invoke']));
+
+    const { result } = renderHook(() => useWorkflowBuilder());
+    act(() => result.current.dispatch({ type: 'add-step', input: { kind: 'prompt', id: 'a' } }));
+    let res: unknown;
+    await act(async () => {
+      res = await result.current.save();
+    });
+    expect(res).toEqual(saved);
+    expect(result.current.state.dirty).toBe(false);
+    expect(invoke).toHaveBeenCalledWith('workflows.save', expect.objectContaining({ yaml: expect.any(String) }));
+  });
+
+  it('save refuses and surfaces an error when invalid', async () => {
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === 'workflows.validateDraft') return { ok: false, errors: ['name: bad'] };
+      throw new Error(`unexpected ${cmd}`);
+    });
+    __setApiOverride(fakeApi(invoke as unknown as MoxxyApi['invoke']));
+
+    const { result } = renderHook(() => useWorkflowBuilder());
+    act(() => result.current.dispatch({ type: 'add-step', input: { kind: 'prompt', id: 'a' } }));
+    let res: unknown = 'unset';
+    await act(async () => {
+      res = await result.current.save();
+    });
+    expect(res).toBeNull();
+    expect(result.current.error).toMatch(/highlighted errors/);
+    expect(invoke).not.toHaveBeenCalledWith('workflows.save', expect.anything());
+  });
+});

--- a/packages/client-core/src/useWorkflowBuilder.ts
+++ b/packages/client-core/src/useWorkflowBuilder.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import {
+  builderReducer,
+  emptyState,
+  hydrateYaml,
+  mapErrorsToNodes,
+  serialize,
+  type BuilderAction,
+  type BuilderState,
+  type SaveResult,
+} from '@moxxy/workflows-builder';
+import { api } from './transport.js';
+import { toErrorMessage } from './errors.js';
+
+/**
+ * The transport-neutral builder hook shared by the desktop canvas and the
+ * mobile editor. It owns the canvas reducer, loads a saved workflow's YAML via
+ * `workflows.getRun`, debounces a live `workflows.validateDraft` on every edit
+ * (mapping issues back onto nodes), and persists via `workflows.save`. It is
+ * DOM-free: it reaches the host only through the injected {@link api} transport,
+ * so the same hook drives the Electron preload bridge and the mobile WS bridge.
+ */
+
+export interface UseWorkflowBuilder {
+  readonly state: BuilderState;
+  readonly dispatch: (action: BuilderAction) => void;
+  /** Last validation outcome (null until the first run completes). */
+  readonly valid: boolean | null;
+  readonly validating: boolean;
+  readonly saving: boolean;
+  readonly error: string | null;
+  /** Load an existing workflow into the canvas (by name), or start empty. */
+  readonly load: (name: string | null) => Promise<void>;
+  /** Run validation now (also auto-runs, debounced, on edits). */
+  readonly validateNow: () => Promise<void>;
+  /** Validate + persist; returns the save result or null on failure. */
+  readonly save: () => Promise<SaveResult | null>;
+}
+
+const VALIDATE_DEBOUNCE_MS = 400;
+
+export function useWorkflowBuilder(): UseWorkflowBuilder {
+  const [state, dispatch] = useReducer(builderReducer, undefined, () => emptyState());
+  const [valid, setValid] = useState<boolean | null>(null);
+  const [validating, setValidating] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Keep a live ref to the latest state so the debounced validator reads fresh
+  // data without re-subscribing the timer on every keystroke.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  const runValidation = useCallback(async (): Promise<boolean> => {
+    const snapshot = stateRef.current;
+    setValidating(true);
+    try {
+      const { yaml } = serialize(snapshot);
+      const result = await api().invoke('workflows.validateDraft', { yaml });
+      dispatch({ type: 'apply-validation', errors: mapErrorsToNodes(result.errors, snapshot) });
+      setValid(result.ok);
+      setError(null);
+      return result.ok;
+    } catch (e) {
+      setError(toErrorMessage(e));
+      setValid(null);
+      return false;
+    } finally {
+      setValidating(false);
+    }
+  }, []);
+
+  // Debounced live validation: any content change re-validates after a pause.
+  // `nodes`/`edges`/`meta` identity changes on edits; viewport-only pans don't.
+  const validateNow = useCallback(async () => {
+    await runValidation();
+  }, [runValidation]);
+
+  useEffect(() => {
+    if (state.nodes.length === 0) {
+      setValid(null);
+      return;
+    }
+    const t = setTimeout(() => void runValidation(), VALIDATE_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [state.nodes, state.edges, state.meta, runValidation]);
+
+  const load = useCallback(async (name: string | null) => {
+    setError(null);
+    setValid(null);
+    if (!name) {
+      dispatch({ type: 'load', state: emptyState() });
+      return;
+    }
+    try {
+      const detail = await api().invoke('workflows.getRun', { name });
+      if (!detail) {
+        setError(`workflow "${name}" was not found`);
+        return;
+      }
+      dispatch({ type: 'load', state: hydrateYaml(detail.yaml) });
+    } catch (e) {
+      setError(toErrorMessage(e));
+    }
+  }, []);
+
+  const save = useCallback(async (): Promise<SaveResult | null> => {
+    setSaving(true);
+    setError(null);
+    try {
+      const ok = await runValidation();
+      if (!ok) {
+        setError('Fix the highlighted errors before saving.');
+        return null;
+      }
+      const { yaml } = serialize(stateRef.current);
+      const result = await api().invoke('workflows.save', { yaml });
+      dispatch({ type: 'mark-saved' });
+      return result;
+    } catch (e) {
+      setError(toErrorMessage(e));
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  }, [runValidation]);
+
+  return useMemo(
+    () => ({ state, dispatch, valid, validating, saving, error, load, validateNow, save }),
+    [state, valid, validating, saving, error, load, validateNow, save],
+  );
+}

--- a/packages/workflows-builder/package.json
+++ b/packages/workflows-builder/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@moxxy/workflows-builder",
+  "private": true,
+  "version": "0.0.0",
+  "description": "DOM-free, RN-safe shared model for the visual workflow builder: the canvas state + reducer, pure graph operations (add/remove step, connect needs, branch + loop-body/exit wiring, move/viewport), a Workflow<->YAML serializer pair (with auto-layout), and validate/save bridges over the workflows IPC. Consumed by the Electron desktop canvas and the Expo mobile editor.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@moxxy/sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/workflows-builder/src/index.ts
+++ b/packages/workflows-builder/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @moxxy/workflows-builder — the DOM-free, RN-safe shared model behind the
+ * visual workflow builder. It owns the canvas state + reducer, the pure graph
+ * operations, the Workflow<->YAML serializer pair (with auto-layout), and the
+ * validate/save bridges over the workflows IPC. The Electron desktop canvas and
+ * the Expo mobile editor both import from here and add only rendering +
+ * interaction on top.
+ */
+
+export * from './types.js';
+export * from './operations.js';
+export * from './serialize.js';
+export * from './reducer.js';
+export * from './validation.js';
+export { toYaml, fromYaml } from './yaml.js';

--- a/packages/workflows-builder/src/operations.test.ts
+++ b/packages/workflows-builder/src/operations.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addStep,
+  connectNeeds,
+  disconnectNeeds,
+  emptyState,
+  moveNode,
+  removeStep,
+  removeSwitchCase,
+  renameNode,
+  setBranchTargets,
+  setLoopBody,
+  setLoopConfig,
+  setLoopExit,
+  setSwitchCase,
+  uniqueId,
+  updateMeta,
+  updateNode,
+} from './operations.js';
+import { loopExitTarget } from './serialize.js';
+
+describe('addStep / removeStep', () => {
+  it('adds a node, selects it, flips dirty', () => {
+    const s = addStep(emptyState(), { kind: 'prompt', id: 'a' });
+    expect(s.nodes).toHaveLength(1);
+    expect(s.nodes[0]!.id).toBe('a');
+    expect(s.selected).toBe('a');
+    expect(s.dirty).toBe(true);
+  });
+
+  it('uniquifies a colliding id', () => {
+    let s = addStep(emptyState(), { kind: 'prompt', id: 'a' });
+    s = addStep(s, { kind: 'prompt', id: 'a' });
+    expect(s.nodes.map((n) => n.id)).toEqual(['a', 'a_2']);
+  });
+
+  it('wires `after` into a needs edge', () => {
+    let s = addStep(emptyState(), { kind: 'prompt', id: 'a' });
+    s = addStep(s, { kind: 'prompt', id: 'b', after: 'a' });
+    expect(s.nodes.find((n) => n.id === 'b')!.needs).toEqual(['a']);
+    expect(s.edges).toContainEqual(expect.objectContaining({ kind: 'needs', from: 'a', to: 'b' }));
+  });
+
+  it('removes a node and scrubs all references to it', () => {
+    let s = emptyState();
+    s = addStep(s, { kind: 'prompt', id: 'a' });
+    s = addStep(s, { kind: 'condition', id: 'c' });
+    s = addStep(s, { kind: 'prompt', id: 'b', after: 'a' });
+    s = setBranchTargets(s, 'c', 'then', ['b']);
+    s = removeStep(s, 'b');
+    expect(s.nodes.map((n) => n.id)).toEqual(['a', 'c']);
+    expect(s.nodes.find((n) => n.id === 'c')!.then).toEqual([]);
+    expect(s.edges.some((e) => e.to === 'b')).toBe(false);
+  });
+});
+
+describe('needs edges', () => {
+  it('connect/disconnect are idempotent and ignore self', () => {
+    let s = addStep(addStep(emptyState(), { kind: 'prompt', id: 'a' }), { kind: 'prompt', id: 'b' });
+    s = connectNeeds(s, 'a', 'b');
+    s = connectNeeds(s, 'a', 'b'); // dup ignored
+    s = connectNeeds(s, 'b', 'b'); // self ignored
+    expect(s.nodes.find((n) => n.id === 'b')!.needs).toEqual(['a']);
+    s = disconnectNeeds(s, 'a', 'b');
+    expect(s.nodes.find((n) => n.id === 'b')!.needs).toEqual([]);
+  });
+});
+
+describe('branch targets', () => {
+  it('sets condition then/else and derives labeled edges', () => {
+    let s = emptyState();
+    for (const id of ['c', 'x', 'y']) s = addStep(s, { kind: id === 'c' ? 'condition' : 'prompt', id });
+    s = setBranchTargets(s, 'c', 'then', ['x']);
+    s = setBranchTargets(s, 'c', 'else', ['y']);
+    expect(s.edges).toContainEqual(expect.objectContaining({ kind: 'then', from: 'c', to: 'x' }));
+    expect(s.edges).toContainEqual(expect.objectContaining({ kind: 'else', from: 'c', to: 'y' }));
+  });
+
+  it('switch cases + default produce case/default edges with caseId', () => {
+    let s = emptyState();
+    for (const id of ['sw', 'hi', 'lo', 'fb']) s = addStep(s, { kind: id === 'sw' ? 'switch' : 'prompt', id });
+    s = setSwitchCase(s, 'sw', 'high', ['hi']);
+    s = setSwitchCase(s, 'sw', 'low', ['lo']);
+    s = setBranchTargets(s, 'sw', 'default', ['fb']);
+    expect(s.edges).toContainEqual(expect.objectContaining({ kind: 'case', from: 'sw', to: 'hi', caseId: 'high' }));
+    expect(s.edges).toContainEqual(expect.objectContaining({ kind: 'default', from: 'sw', to: 'fb' }));
+    s = removeSwitchCase(s, 'sw', 'low');
+    expect(s.nodes.find((n) => n.id === 'sw')!.cases).toEqual({ high: ['hi'] });
+  });
+});
+
+describe('loop node body + exit model', () => {
+  function loopFixture() {
+    let s = emptyState();
+    s = addStep(s, { kind: 'prompt', id: 'seed' });
+    s = addStep(s, { kind: 'loop', id: 'loop', after: 'seed' });
+    s = addStep(s, { kind: 'bridge', id: 'improve' });
+    s = addStep(s, { kind: 'prompt', id: 'finish' });
+    return s;
+  }
+
+  it('setLoopBody scopes body steps to the loop via needs and derives loop-body edges', () => {
+    let s = loopFixture();
+    s = setLoopBody(s, 'loop', ['improve']);
+    expect(s.nodes.find((n) => n.id === 'loop')!.loop!.body).toEqual(['improve']);
+    expect(s.nodes.find((n) => n.id === 'improve')!.needs).toEqual(['loop']);
+    expect(s.edges).toContainEqual(expect.objectContaining({ kind: 'loop-body', from: 'loop', to: 'improve' }));
+    // body step's needs:[loop] is NOT rendered as a plain needs edge.
+    expect(s.edges.some((e) => e.kind === 'needs' && e.from === 'loop' && e.to === 'improve')).toBe(false);
+  });
+
+  it('dropping a step from the body removes its loop needs', () => {
+    let s = loopFixture();
+    s = setLoopBody(s, 'loop', ['improve']);
+    s = setLoopBody(s, 'loop', []);
+    expect(s.nodes.find((n) => n.id === 'improve')!.needs).toEqual([]);
+    expect(s.nodes.find((n) => n.id === 'loop')!.loop!.body).toEqual([]);
+  });
+
+  it('setLoopExit wires the single exit needs edge and re-points it', () => {
+    let s = loopFixture();
+    s = setLoopBody(s, 'loop', ['improve']);
+    s = setLoopExit(s, 'loop', 'finish');
+    expect(loopExitTarget(s.nodes.find((n) => n.id === 'loop')!, s.nodes)).toBe('finish');
+    expect(s.edges).toContainEqual(expect.objectContaining({ kind: 'loop-exit', from: 'loop', to: 'finish' }));
+    // exactly one loop-exit edge per loop
+    expect(s.edges.filter((e) => e.kind === 'loop-exit')).toHaveLength(1);
+    // detach
+    s = setLoopExit(s, 'loop', null);
+    expect(s.edges.some((e) => e.kind === 'loop-exit')).toBe(false);
+  });
+
+  it('refuses to make a body step the exit', () => {
+    let s = loopFixture();
+    s = setLoopBody(s, 'loop', ['improve']);
+    const before = s;
+    s = setLoopExit(s, 'loop', 'improve');
+    expect(s).toBe(before); // no-op
+  });
+
+  it('setLoopConfig clamps maxIterations to 1..50', () => {
+    let s = loopFixture();
+    s = setLoopConfig(s, 'loop', { maxIterations: 999, condition: 'good enough?' });
+    expect(s.nodes.find((n) => n.id === 'loop')!.loop!.maxIterations).toBe(50);
+    s = setLoopConfig(s, 'loop', { maxIterations: 0 });
+    expect(s.nodes.find((n) => n.id === 'loop')!.loop!.maxIterations).toBe(1);
+  });
+});
+
+describe('updateNode / updateMeta / move / rename', () => {
+  it('patches action text without touching topology', () => {
+    let s = addStep(emptyState(), { kind: 'prompt', id: 'a' });
+    const edgesRef = s.edges;
+    s = updateNode(s, 'a', { action: 'do the thing', label: 'Step A' });
+    expect(s.nodes[0]!.action).toBe('do the thing');
+    expect(s.nodes[0]!.label).toBe('Step A');
+    expect(s.edges).toBe(edgesRef);
+  });
+
+  it('clamps retries to 0..3', () => {
+    let s = addStep(emptyState(), { kind: 'prompt', id: 'a' });
+    s = updateNode(s, 'a', { retries: 9 });
+    expect(s.nodes[0]!.retries).toBe(3);
+  });
+
+  it('moveNode updates position, keeps edges', () => {
+    let s = addStep(emptyState(), { kind: 'prompt', id: 'a' });
+    const ref = s.edges;
+    s = moveNode(s, 'a', 123, 456);
+    expect(s.nodes[0]).toMatchObject({ x: 123, y: 456 });
+    expect(s.edges).toBe(ref);
+  });
+
+  it('updateMeta patches workflow fields', () => {
+    const s = updateMeta(emptyState(), { name: 'renamed', enabled: false });
+    expect(s.meta.name).toBe('renamed');
+    expect(s.meta.enabled).toBe(false);
+  });
+
+  it('renameNode rewrites every reference', () => {
+    let s = emptyState();
+    s = addStep(s, { kind: 'condition', id: 'c' });
+    s = addStep(s, { kind: 'prompt', id: 'old', after: 'c' });
+    s = setBranchTargets(s, 'c', 'then', ['old']);
+    s = renameNode(s, 'old', 'fresh');
+    expect(s.nodes.map((n) => n.id)).toContain('fresh');
+    expect(s.nodes.find((n) => n.id === 'c')!.then).toEqual(['fresh']);
+    expect(s.nodes.find((n) => n.id === 'fresh')!.needs).toEqual(['c']);
+  });
+});
+
+describe('uniqueId', () => {
+  it('slugifies and de-dupes', () => {
+    const s = addStep(emptyState(), { kind: 'prompt', id: 'my step' });
+    expect(s.nodes[0]!.id).toBe('my_step');
+    expect(uniqueId(s, 'my step')).toBe('my_step_2');
+  });
+});

--- a/packages/workflows-builder/src/operations.ts
+++ b/packages/workflows-builder/src/operations.ts
@@ -1,0 +1,362 @@
+/**
+ * Pure operations over {@link BuilderState}. Every function takes a state and
+ * returns a new one — no mutation, no side effects — so they compose cleanly
+ * under a reducer and are trivial to unit-test. Edges are re-derived after any
+ * structural change so the rendered graph always matches the node data.
+ *
+ * The loop node is modeled with TWO connection regions, exposed here as
+ * distinct operations: {@link setLoopBody} defines which steps run INSIDE the
+ * loop (the body region), and the EXIT connector is implicit — a loop continues
+ * to the first non-body step that `needs` it, so {@link setLoopExit} just wires
+ * that `needs` edge (and clears any prior exit) rather than storing a separate
+ * field. This keeps the on-disk schema unchanged while giving the canvas a
+ * single, unambiguous "on done / on error → next" edge per loop.
+ */
+
+import type { WorkflowStepErrorMode } from '@moxxy/sdk';
+import { deriveEdges, loopExitTarget } from './serialize.js';
+import {
+  type BuilderLoop,
+  type BuilderNode,
+  type BuilderState,
+  type StepKind,
+} from './types.js';
+
+const NEW_NODE_OFFSET = 40;
+
+/** Empty canvas for a brand-new workflow. */
+export function emptyState(name = 'new-workflow'): BuilderState {
+  return {
+    meta: {
+      name,
+      description: 'A new workflow.',
+      enabled: true,
+      version: 1,
+      concurrency: 4,
+      inputs: {},
+    },
+    nodes: [],
+    edges: [],
+    viewport: { x: 0, y: 0, zoom: 1 },
+    selected: null,
+    dirty: false,
+    errors: {},
+  };
+}
+
+function refresh(state: BuilderState, nodes: ReadonlyArray<BuilderNode>): BuilderState {
+  return { ...state, nodes, edges: deriveEdges(nodes), dirty: true };
+}
+
+function defaultNode(id: string, kind: StepKind, x: number, y: number): BuilderNode {
+  const base: BuilderNode = {
+    id,
+    kind,
+    x,
+    y,
+    action: '',
+    needs: [],
+    onError: 'fail',
+    retries: 0,
+  };
+  if (kind === 'condition') return { ...base, then: [], else: [] };
+  if (kind === 'switch') return { ...base, cases: {}, default: [] };
+  if (kind === 'loop') {
+    const loop: BuilderLoop = { body: [], condition: '', maxIterations: 10 };
+    return { ...base, loop };
+  }
+  return base;
+}
+
+/** Generate a unique slug-like id from a desired base. */
+export function uniqueId(state: BuilderState, base: string): string {
+  const slug = base
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 60) || 'step';
+  const taken = new Set(state.nodes.map((n) => n.id));
+  if (!taken.has(slug)) return slug;
+  let i = 2;
+  while (taken.has(`${slug}_${i}`)) i++;
+  return `${slug}_${i}`;
+}
+
+export interface AddStepInput {
+  readonly kind: StepKind;
+  readonly id?: string;
+  readonly label?: string;
+  /** Position; defaults to a cascade below the last node. */
+  readonly x?: number;
+  readonly y?: number;
+  /** When set, the new step `needs` this upstream step. */
+  readonly after?: string;
+}
+
+/** Add a node of the given kind. Selects it. */
+export function addStep(state: BuilderState, input: AddStepInput): BuilderState {
+  // Always slugify + de-dupe through uniqueId so a provided id can't smuggle
+  // in characters the schema's step-id rule forbids.
+  const id = uniqueId(state, input.id ?? input.kind);
+  const last = state.nodes[state.nodes.length - 1];
+  const x = input.x ?? (last ? last.x + NEW_NODE_OFFSET : NEW_NODE_OFFSET);
+  const y = input.y ?? (last ? last.y + NEW_NODE_OFFSET : NEW_NODE_OFFSET);
+  const node = defaultNode(id, input.kind, x, y);
+  if (input.label) node.label = input.label;
+  if (input.after && state.nodes.some((n) => n.id === input.after)) {
+    node.needs = [input.after];
+  }
+  const next = refresh(state, [...state.nodes, node]);
+  return { ...next, selected: id };
+}
+
+/** Remove a node and scrub every reference to it (needs, branches, loop bodies). */
+export function removeStep(state: BuilderState, id: string): BuilderState {
+  const nodes = state.nodes
+    .filter((n) => n.id !== id)
+    .map((n) => scrubReferences(n, id));
+  const next = refresh(state, nodes);
+  return { ...next, selected: state.selected === id ? null : state.selected };
+}
+
+function scrubReferences(node: BuilderNode, removed: string): BuilderNode {
+  const out: BuilderNode = {
+    ...node,
+    needs: node.needs.filter((d) => d !== removed),
+  };
+  if (out.then) out.then = out.then.filter((t) => t !== removed);
+  if (out.else) out.else = out.else.filter((t) => t !== removed);
+  if (out.default) out.default = out.default.filter((t) => t !== removed);
+  if (out.cases) {
+    out.cases = Object.fromEntries(
+      Object.entries(out.cases).map(([k, v]) => [k, v.filter((t) => t !== removed)]),
+    );
+  }
+  if (out.loop) out.loop = { ...out.loop, body: out.loop.body.filter((t) => t !== removed) };
+  return out;
+}
+
+/** Move a node to a new canvas position. Persists to `ui.layout` on save. */
+export function moveNode(state: BuilderState, id: string, x: number, y: number): BuilderState {
+  const nodes = state.nodes.map((n) => (n.id === id ? { ...n, x, y } : n));
+  // Position-only edits keep edges identical — skip re-derivation.
+  return { ...state, nodes, dirty: true };
+}
+
+/** Set the canvas pan/zoom. */
+export function setViewport(state: BuilderState, viewport: BuilderState['viewport']): BuilderState {
+  return { ...state, viewport, dirty: true };
+}
+
+/** Select a node (or clear selection with null). Not a content edit. */
+export function selectNode(state: BuilderState, id: string | null): BuilderState {
+  return { ...state, selected: id };
+}
+
+/** Add a `needs` dependency edge (idempotent; ignores self/unknown). */
+export function connectNeeds(state: BuilderState, from: string, to: string): BuilderState {
+  if (from === to) return state;
+  const exists = state.nodes.some((n) => n.id === from) && state.nodes.some((n) => n.id === to);
+  if (!exists) return state;
+  const nodes = state.nodes.map((n) =>
+    n.id === to && !n.needs.includes(from) ? { ...n, needs: [...n.needs, from] } : n,
+  );
+  return refresh(state, nodes);
+}
+
+/** Remove a `needs` dependency edge. */
+export function disconnectNeeds(state: BuilderState, from: string, to: string): BuilderState {
+  const nodes = state.nodes.map((n) =>
+    n.id === to ? { ...n, needs: n.needs.filter((d) => d !== from) } : n,
+  );
+  return refresh(state, nodes);
+}
+
+export type BranchSlot = 'then' | 'else' | 'default';
+
+/** Replace a condition step's `then`/`else` (or a switch's `default`) targets. */
+export function setBranchTargets(
+  state: BuilderState,
+  nodeId: string,
+  slot: BranchSlot,
+  targets: ReadonlyArray<string>,
+): BuilderState {
+  const nodes = state.nodes.map((n) =>
+    n.id === nodeId ? { ...n, [slot]: dedupe(targets) } : n,
+  );
+  return refresh(state, nodes);
+}
+
+/** Set the targets of one switch case (creates the case if new). */
+export function setSwitchCase(
+  state: BuilderState,
+  nodeId: string,
+  caseId: string,
+  targets: ReadonlyArray<string>,
+): BuilderState {
+  const nodes = state.nodes.map((n) =>
+    n.id === nodeId ? { ...n, cases: { ...(n.cases ?? {}), [caseId]: dedupe(targets) } } : n,
+  );
+  return refresh(state, nodes);
+}
+
+/** Remove a switch case entirely. */
+export function removeSwitchCase(state: BuilderState, nodeId: string, caseId: string): BuilderState {
+  const nodes = state.nodes.map((n) => {
+    if (n.id !== nodeId || !n.cases) return n;
+    const { [caseId]: _dropped, ...rest } = n.cases;
+    return { ...n, cases: rest };
+  });
+  return refresh(state, nodes);
+}
+
+/**
+ * Define the BODY membership of a loop node — the steps that run inside the
+ * loop, in order. Also keeps every body step's `needs: [loop]` so the executor
+ * scopes them to the loop, and drops `needs` for steps no longer in the body.
+ */
+export function setLoopBody(
+  state: BuilderState,
+  loopId: string,
+  body: ReadonlyArray<string>,
+): BuilderState {
+  const loopNode = state.nodes.find((n) => n.id === loopId);
+  if (!loopNode || loopNode.kind !== 'loop') return state;
+  const cleaned = dedupe(body).filter((id) => id !== loopId && state.nodes.some((n) => n.id === id));
+  const bodySet = new Set(cleaned);
+  const prevBody = new Set(loopNode.loop?.body ?? []);
+  const nodes = state.nodes.map((n) => {
+    if (n.id === loopId) {
+      const loop: BuilderLoop = { ...(n.loop ?? defaultLoop()), body: cleaned };
+      return { ...n, loop };
+    }
+    // Body members get `needs: [loop]`; steps dropped from the body lose it.
+    if (bodySet.has(n.id)) {
+      return n.needs.includes(loopId) ? n : { ...n, needs: [...n.needs, loopId] };
+    }
+    if (prevBody.has(n.id) && !bodySet.has(n.id)) {
+      return { ...n, needs: n.needs.filter((d) => d !== loopId) };
+    }
+    return n;
+  });
+  return refresh(state, nodes);
+}
+
+/**
+ * Wire a loop's EXIT target — the single step the loop continues to once its
+ * condition is met (or a body step errors). Implemented as a `needs: [loop]`
+ * edge on the target, with the previous exit's edge cleared, so there is always
+ * exactly one exit per loop. Pass null to detach the exit.
+ */
+export function setLoopExit(state: BuilderState, loopId: string, targetId: string | null): BuilderState {
+  const loopNode = state.nodes.find((n) => n.id === loopId);
+  if (!loopNode || loopNode.kind !== 'loop') return state;
+  if (targetId && (targetId === loopId || (loopNode.loop?.body ?? []).includes(targetId))) {
+    return state; // a body step can't also be the exit
+  }
+  const prev = loopExitTarget(loopNode, state.nodes);
+  const nodes = state.nodes.map((n) => {
+    if (prev && n.id === prev && n.id !== targetId) {
+      return { ...n, needs: n.needs.filter((d) => d !== loopId) };
+    }
+    if (targetId && n.id === targetId && !n.needs.includes(loopId)) {
+      return { ...n, needs: [...n.needs, loopId] };
+    }
+    return n;
+  });
+  return refresh(state, nodes);
+}
+
+/** Patch a loop node's condition / maxIterations. */
+export function setLoopConfig(
+  state: BuilderState,
+  loopId: string,
+  patch: Partial<Pick<BuilderLoop, 'condition' | 'maxIterations'>>,
+): BuilderState {
+  const nodes = state.nodes.map((n) => {
+    if (n.id !== loopId || n.kind !== 'loop') return n;
+    const loop: BuilderLoop = { ...(n.loop ?? defaultLoop()), ...patch };
+    loop.maxIterations = clampIterations(loop.maxIterations);
+    return { ...n, loop };
+  });
+  return refresh(state, nodes);
+}
+
+/** Editable per-node fields the inspector can patch directly. */
+export interface NodeFieldPatch {
+  label?: string;
+  action?: string;
+  input?: string;
+  args?: Record<string, unknown>;
+  when?: string;
+  onError?: WorkflowStepErrorMode;
+  retries?: number;
+  format?: BuilderNode['format'];
+  awaitInput?: boolean;
+}
+
+/** Patch scalar fields of a node (action text, label, onError, …). */
+export function updateNode(state: BuilderState, id: string, patch: NodeFieldPatch): BuilderState {
+  const nodes = state.nodes.map((n) => (n.id === id ? applyPatch(n, patch) : n));
+  // Field edits don't change topology — keep edges, just flip dirty.
+  return { ...state, nodes, dirty: true };
+}
+
+function applyPatch(node: BuilderNode, patch: NodeFieldPatch): BuilderNode {
+  const next: BuilderNode = { ...node };
+  if (patch.label !== undefined) next.label = patch.label || undefined;
+  if (patch.action !== undefined) next.action = patch.action;
+  if (patch.input !== undefined) next.input = patch.input || undefined;
+  if (patch.args !== undefined) next.args = patch.args;
+  if (patch.when !== undefined) next.when = patch.when || undefined;
+  if (patch.onError !== undefined) next.onError = patch.onError;
+  if (patch.retries !== undefined) next.retries = clampRetries(patch.retries);
+  if (patch.format !== undefined) next.format = patch.format;
+  if (patch.awaitInput !== undefined) next.awaitInput = patch.awaitInput || undefined;
+  return next;
+}
+
+/** Patch workflow-level metadata (name/description/enabled/…). */
+export function updateMeta(state: BuilderState, patch: Partial<BuilderState['meta']>): BuilderState {
+  return { ...state, meta: { ...state.meta, ...patch }, dirty: true };
+}
+
+/** Rename a node id, rewriting every reference (needs/branch/loop body). */
+export function renameNode(state: BuilderState, from: string, to: string): BuilderState {
+  if (from === to) return state;
+  if (!to || state.nodes.some((n) => n.id === to)) return state;
+  const nodes = state.nodes.map((n) => {
+    const renamed = n.id === from ? { ...n, id: to } : { ...n };
+    renamed.needs = renamed.needs.map((d) => (d === from ? to : d));
+    if (renamed.then) renamed.then = renamed.then.map((t) => (t === from ? to : t));
+    if (renamed.else) renamed.else = renamed.else.map((t) => (t === from ? to : t));
+    if (renamed.default) renamed.default = renamed.default.map((t) => (t === from ? to : t));
+    if (renamed.cases) {
+      renamed.cases = Object.fromEntries(
+        Object.entries(renamed.cases).map(([k, v]) => [k, v.map((t) => (t === from ? to : t))]),
+      );
+    }
+    if (renamed.loop) renamed.loop = { ...renamed.loop, body: renamed.loop.body.map((t) => (t === from ? to : t)) };
+    return renamed;
+  });
+  const next = refresh(state, nodes);
+  return { ...next, selected: state.selected === from ? to : state.selected };
+}
+
+function defaultLoop(): BuilderLoop {
+  return { body: [], condition: '', maxIterations: 10 };
+}
+
+function clampIterations(n: number): number {
+  if (!Number.isFinite(n)) return 10;
+  return Math.max(1, Math.min(50, Math.round(n)));
+}
+
+function clampRetries(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(3, Math.round(n)));
+}
+
+function dedupe(list: ReadonlyArray<string>): string[] {
+  return [...new Set(list.filter((x) => x.length > 0))];
+}

--- a/packages/workflows-builder/src/reducer.ts
+++ b/packages/workflows-builder/src/reducer.ts
@@ -1,0 +1,96 @@
+/**
+ * A typed reducer over {@link BuilderState} that dispatches to the pure
+ * operations. Both platforms drive the canvas through `useReducer(builderReducer)`
+ * (or an equivalent store), so all state transitions are centralized and
+ * replayable. Validation results arrive as their own action so the async
+ * bridge stays outside the reducer.
+ */
+
+import type { BuilderState } from './types.js';
+import {
+  addStep,
+  connectNeeds,
+  disconnectNeeds,
+  moveNode,
+  removeStep,
+  removeSwitchCase,
+  renameNode,
+  selectNode,
+  setBranchTargets,
+  setLoopBody,
+  setLoopConfig,
+  setLoopExit,
+  setSwitchCase,
+  setViewport,
+  updateMeta,
+  updateNode,
+  type AddStepInput,
+  type BranchSlot,
+  type NodeFieldPatch,
+} from './operations.js';
+
+export type BuilderAction =
+  | { type: 'load'; state: BuilderState }
+  | { type: 'add-step'; input: AddStepInput }
+  | { type: 'remove-step'; id: string }
+  | { type: 'move-node'; id: string; x: number; y: number }
+  | { type: 'set-viewport'; viewport: BuilderState['viewport'] }
+  | { type: 'select'; id: string | null }
+  | { type: 'connect-needs'; from: string; to: string }
+  | { type: 'disconnect-needs'; from: string; to: string }
+  | { type: 'set-branch'; nodeId: string; slot: BranchSlot; targets: ReadonlyArray<string> }
+  | { type: 'set-case'; nodeId: string; caseId: string; targets: ReadonlyArray<string> }
+  | { type: 'remove-case'; nodeId: string; caseId: string }
+  | { type: 'set-loop-body'; loopId: string; body: ReadonlyArray<string> }
+  | { type: 'set-loop-exit'; loopId: string; targetId: string | null }
+  | { type: 'set-loop-config'; loopId: string; patch: Parameters<typeof setLoopConfig>[2] }
+  | { type: 'update-node'; id: string; patch: NodeFieldPatch }
+  | { type: 'rename-node'; from: string; to: string }
+  | { type: 'update-meta'; patch: Partial<BuilderState['meta']> }
+  | { type: 'apply-validation'; errors: Record<string, ReadonlyArray<string>> }
+  | { type: 'mark-saved' };
+
+export function builderReducer(state: BuilderState, action: BuilderAction): BuilderState {
+  switch (action.type) {
+    case 'load':
+      return action.state;
+    case 'add-step':
+      return addStep(state, action.input);
+    case 'remove-step':
+      return removeStep(state, action.id);
+    case 'move-node':
+      return moveNode(state, action.id, action.x, action.y);
+    case 'set-viewport':
+      return setViewport(state, action.viewport);
+    case 'select':
+      return selectNode(state, action.id);
+    case 'connect-needs':
+      return connectNeeds(state, action.from, action.to);
+    case 'disconnect-needs':
+      return disconnectNeeds(state, action.from, action.to);
+    case 'set-branch':
+      return setBranchTargets(state, action.nodeId, action.slot, action.targets);
+    case 'set-case':
+      return setSwitchCase(state, action.nodeId, action.caseId, action.targets);
+    case 'remove-case':
+      return removeSwitchCase(state, action.nodeId, action.caseId);
+    case 'set-loop-body':
+      return setLoopBody(state, action.loopId, action.body);
+    case 'set-loop-exit':
+      return setLoopExit(state, action.loopId, action.targetId);
+    case 'set-loop-config':
+      return setLoopConfig(state, action.loopId, action.patch);
+    case 'update-node':
+      return updateNode(state, action.id, action.patch);
+    case 'rename-node':
+      return renameNode(state, action.from, action.to);
+    case 'update-meta':
+      return updateMeta(state, action.patch);
+    case 'apply-validation':
+      return { ...state, errors: action.errors };
+    case 'mark-saved':
+      return { ...state, dirty: false };
+    default:
+      return state;
+  }
+}

--- a/packages/workflows-builder/src/serialize.test.ts
+++ b/packages/workflows-builder/src/serialize.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addStep,
+  emptyState,
+  setBranchTargets,
+  setLoopBody,
+  setLoopConfig,
+  setLoopExit,
+  setSwitchCase,
+  updateMeta,
+  updateNode,
+} from './operations.js';
+import { autoLayout, hydrate, hydrateYaml, serialize } from './serialize.js';
+import { fromYaml, toYaml } from './yaml.js';
+
+function refineFixture() {
+  let s = emptyState('refine-draft');
+  s = updateMeta(s, { description: 'Draft then refine until good enough.' });
+  s = addStep(s, { kind: 'prompt', id: 'first_draft', label: 'First draft' });
+  s = updateNode(s, 'first_draft', { action: 'Write a first draft about {{ inputs.topic }}.\nKeep it short.' });
+  s = addStep(s, { kind: 'loop', id: 'refine', label: 'Refine loop', after: 'first_draft' });
+  s = addStep(s, { kind: 'bridge', id: 'improve', label: 'Improve' });
+  s = updateNode(s, 'improve', { action: 'Improve the draft. Return JSON vars.draft.' });
+  s = addStep(s, { kind: 'prompt', id: 'finish', label: 'Finish' });
+  s = updateNode(s, 'finish', { action: 'Emit the final draft.' });
+  s = setLoopBody(s, 'refine', ['improve']);
+  s = setLoopExit(s, 'refine', 'finish');
+  s = setLoopConfig(s, 'refine', { condition: 'Is the draft good enough?', maxIterations: 5 });
+  return s;
+}
+
+describe('serialize → Workflow', () => {
+  it('builds a Workflow object + ui.layout from the canvas', () => {
+    const s = refineFixture();
+    const { workflow, yaml } = serialize(s);
+    expect(workflow.name).toBe('refine-draft');
+    expect(workflow.steps).toHaveLength(4);
+    const loop = workflow.steps.find((st) => st.id === 'refine')!;
+    expect(loop.loop).toEqual({ body: ['improve'], condition: 'Is the draft good enough?', maxIterations: 5 });
+    // body + exit steps carry needs:[refine]
+    expect(workflow.steps.find((st) => st.id === 'improve')!.needs).toContain('refine');
+    expect(workflow.steps.find((st) => st.id === 'finish')!.needs).toContain('refine');
+    expect(workflow.ui?.layout?.nodes.first_draft).toBeDefined();
+    expect(workflow.ui?.layout?.viewport).toEqual({ x: 0, y: 0, zoom: 1 });
+    expect(yaml).toContain('name: refine-draft');
+    expect(yaml).toContain('loop:');
+  });
+
+  it('serializes multiline prompts as block scalars that round-trip', () => {
+    const s = refineFixture();
+    const { yaml } = serialize(s);
+    expect(yaml).toMatch(/prompt: \|/);
+    const parsed = fromYaml(yaml) as { steps: Array<{ id: string; prompt?: string }> };
+    const draft = parsed.steps.find((st) => st.id === 'first_draft')!;
+    expect(draft.prompt).toContain('Write a first draft');
+    expect(draft.prompt).toContain('Keep it short.');
+  });
+});
+
+describe('hydrate ← Workflow (round-trip)', () => {
+  it('round-trips loop body + exit + branches + layout', () => {
+    const original = refineFixture();
+    const { workflow } = serialize(original);
+    const re = hydrate(workflow);
+
+    expect(re.nodes.map((n) => n.id).sort()).toEqual(['finish', 'first_draft', 'improve', 'refine']);
+    const loop = re.nodes.find((n) => n.id === 'refine')!;
+    expect(loop.kind).toBe('loop');
+    expect(loop.loop).toEqual({ body: ['improve'], condition: 'Is the draft good enough?', maxIterations: 5 });
+    // loop-body + single loop-exit edges survive the round-trip
+    expect(re.edges).toContainEqual(expect.objectContaining({ kind: 'loop-body', from: 'refine', to: 'improve' }));
+    expect(re.edges.filter((e) => e.kind === 'loop-exit')).toHaveLength(1);
+    expect(re.edges).toContainEqual(expect.objectContaining({ kind: 'loop-exit', from: 'refine', to: 'finish' }));
+    // positions preserved from ui.layout
+    expect(re.nodes.find((n) => n.id === 'first_draft')!.x).toBe(workflow.ui!.layout!.nodes.first_draft!.x);
+  });
+
+  it('round-trips condition + switch branch edges', () => {
+    let s = emptyState('routing');
+    s = updateMeta(s, { description: 'Route on a predicate.' });
+    for (const id of ['gate', 'a', 'b', 'sw', 'hi', 'lo', 'fb']) {
+      const kind = id === 'gate' ? 'condition' : id === 'sw' ? 'switch' : 'prompt';
+      s = addStep(s, { kind, id });
+      if (kind === 'prompt') s = updateNode(s, id, { action: `do ${id}` });
+    }
+    s = updateNode(s, 'gate', { action: 'is it good?' });
+    s = updateNode(s, 'sw', { action: 'how big?' });
+    s = setBranchTargets(s, 'gate', 'then', ['a']);
+    s = setBranchTargets(s, 'gate', 'else', ['b']);
+    s = setSwitchCase(s, 'sw', 'high', ['hi']);
+    s = setSwitchCase(s, 'sw', 'low', ['lo']);
+    s = setBranchTargets(s, 'sw', 'default', ['fb']);
+
+    const { workflow } = serialize(s);
+    const re = hydrate(workflow);
+    expect(re.nodes.find((n) => n.id === 'gate')!.then).toEqual(['a']);
+    expect(re.nodes.find((n) => n.id === 'sw')!.cases).toEqual({ high: ['hi'], low: ['lo'] });
+    expect(re.nodes.find((n) => n.id === 'sw')!.default).toEqual(['fb']);
+    expect(re.edges).toContainEqual(expect.objectContaining({ kind: 'then', from: 'gate', to: 'a' }));
+    expect(re.edges).toContainEqual(expect.objectContaining({ kind: 'case', caseId: 'high', from: 'sw', to: 'hi' }));
+  });
+
+  it('hydrateYaml parses canonical YAML back into a canvas', () => {
+    const { yaml } = serialize(refineFixture());
+    const re = hydrateYaml(yaml);
+    expect(re.nodes.find((n) => n.id === 'refine')!.loop!.condition).toBe('Is the draft good enough?');
+    expect(re.dirty).toBe(false);
+  });
+});
+
+describe('auto-layout when ui.layout is absent', () => {
+  it('lays nodes left-to-right by longest-path depth', () => {
+    let s = emptyState('chain');
+    s = updateMeta(s, { description: 'linear chain' });
+    s = addStep(s, { kind: 'prompt', id: 'a' });
+    s = addStep(s, { kind: 'prompt', id: 'b', after: 'a' });
+    s = addStep(s, { kind: 'prompt', id: 'c', after: 'b' });
+    const { workflow } = serialize(s);
+    // strip ui so hydrate must auto-layout
+    const bare = { ...workflow, ui: undefined };
+    const re = hydrate(bare);
+    const x = (id: string) => re.nodes.find((n) => n.id === id)!.x;
+    expect(x('a')).toBeLessThan(x('b'));
+    expect(x('b')).toBeLessThan(x('c'));
+  });
+
+  it('autoLayout assigns increasing columns by depth', () => {
+    const positions = autoLayout([
+      { id: 'a', needs: [] } as never,
+      { id: 'b', needs: ['a'] } as never,
+      { id: 'c', needs: ['a'] } as never,
+    ]);
+    expect(positions[0]!.x).toBeLessThan(positions[1]!.x);
+    // b and c are siblings at the same depth → same column, stacked rows
+    expect(positions[1]!.x).toBe(positions[2]!.x);
+    expect(positions[1]!.y).not.toBe(positions[2]!.y);
+  });
+});
+
+describe('yaml codec edge cases', () => {
+  it('round-trips empty lists, numbers, booleans, and quoted strings', () => {
+    const value = {
+      name: 'x',
+      enabled: true,
+      version: 2,
+      inputs: {},
+      steps: [{ id: 'a', needs: [], tags: ['x', 'y'], note: 'has: colon' }],
+    };
+    const back = fromYaml(toYaml(value));
+    expect(back).toEqual(value);
+  });
+});

--- a/packages/workflows-builder/src/serialize.ts
+++ b/packages/workflows-builder/src/serialize.ts
@@ -1,0 +1,348 @@
+/**
+ * The graph <-> workflow bridge.
+ *
+ * `serialize` turns the canvas {@link BuilderState} into a plain `Workflow`
+ * object (assignable to the SDK type) plus its canonical YAML, folding node
+ * positions + viewport into `ui.layout`. `hydrate` does the inverse: it takes a
+ * saved `Workflow` (or its YAML) and rebuilds the canvas, deriving an
+ * auto-layout when `ui.layout` is absent so a hand-authored / freshly-imported
+ * workflow still opens as a sensible graph.
+ *
+ * Edges are DERIVED, never authored directly: `deriveEdges` projects each
+ * node's `needs`, branch lists, and loop body/exit into the typed
+ * {@link BuilderEdge} set the renderer draws.
+ */
+
+import type { Workflow, WorkflowStep, WorkflowUiLayout } from '@moxxy/sdk';
+import type {
+  BuilderEdge,
+  BuilderLoop,
+  BuilderMeta,
+  BuilderNode,
+  BuilderState,
+  BuilderViewport,
+  StepKind,
+} from './types.js';
+import { fromYaml, toYaml } from './yaml.js';
+
+type ActionField = 'skill' | 'prompt' | 'tool' | 'workflow' | 'bridge' | 'condition' | 'switch' | 'loop';
+
+const ACTION_KIND_FIELD: Record<StepKind, ActionField> = {
+  skill: 'skill',
+  prompt: 'prompt',
+  tool: 'tool',
+  workflow: 'workflow',
+  bridge: 'bridge',
+  condition: 'condition',
+  switch: 'switch',
+  loop: 'loop',
+};
+
+const DEFAULT_VIEWPORT: BuilderViewport = { x: 0, y: 0, zoom: 1 };
+
+export interface SerializeResult {
+  readonly workflow: Workflow;
+  readonly yaml: string;
+}
+
+/** Build a `Workflow` object (+ canonical YAML) from the canvas state. */
+export function serialize(state: BuilderState): SerializeResult {
+  const steps: WorkflowStep[] = state.nodes.map((node) => nodeToStep(node));
+  const layout: WorkflowUiLayout = {
+    nodes: Object.fromEntries(state.nodes.map((n) => [n.id, { x: round(n.x), y: round(n.y) }])),
+    viewport: {
+      x: round(state.viewport.x),
+      y: round(state.viewport.y),
+      zoom: state.viewport.zoom,
+    },
+  };
+  const workflow: Workflow = {
+    name: state.meta.name,
+    description: state.meta.description,
+    version: state.meta.version,
+    enabled: state.meta.enabled,
+    inputs: state.meta.inputs,
+    ...(state.meta.on ? { on: state.meta.on } : {}),
+    ...(state.meta.delivery ? { delivery: state.meta.delivery } : {}),
+    ui: { layout },
+    concurrency: state.meta.concurrency,
+    steps,
+  };
+  return { workflow, yaml: toYaml(stripUndefined(workflow)) };
+}
+
+function nodeToStep(node: BuilderNode): WorkflowStep {
+  const base: Record<string, unknown> = {
+    id: node.id,
+    needs: [...node.needs],
+    onError: node.onError,
+    retries: node.retries,
+  };
+  if (node.label) base.label = node.label;
+  if (node.when) base.when = node.when;
+  if (node.format) base.format = node.format;
+  if (node.awaitInput) base.awaitInput = node.awaitInput;
+
+  const field = ACTION_KIND_FIELD[node.kind];
+  if (node.kind === 'loop') {
+    base.loop = {
+      body: [...(node.loop?.body ?? [])],
+      condition: node.loop?.condition ?? '',
+      maxIterations: node.loop?.maxIterations ?? 10,
+    };
+  } else {
+    base[field] = node.action;
+  }
+
+  if (node.kind === 'skill' && node.input) base.input = node.input;
+  if ((node.kind === 'tool' || node.kind === 'workflow') && node.args) base.args = node.args;
+  if (node.kind === 'condition') {
+    base.then = [...(node.then ?? [])];
+    base.else = [...(node.else ?? [])];
+  }
+  if (node.kind === 'switch') {
+    base.cases = mapValues(node.cases ?? {}, (v) => [...v]);
+    if (node.default && node.default.length > 0) base.default = [...node.default];
+  }
+  return base as unknown as WorkflowStep;
+}
+
+/** Hydrate the canvas from a saved workflow object. */
+export function hydrate(workflow: Workflow): BuilderState {
+  const positions = workflow.ui?.layout?.nodes;
+  const autoPositions = positions ? undefined : autoLayout(workflow.steps);
+  const nodes: BuilderNode[] = workflow.steps.map((step, idx) => {
+    const pos = positions?.[step.id] ?? autoPositions?.[idx] ?? { x: 0, y: idx * NODE_GAP_Y };
+    return stepToNode(step, pos.x, pos.y);
+  });
+  const meta: BuilderMeta = {
+    name: workflow.name,
+    description: workflow.description,
+    enabled: workflow.enabled,
+    version: workflow.version,
+    concurrency: workflow.concurrency,
+    inputs: workflow.inputs ?? {},
+    ...(workflow.on ? { on: workflow.on } : {}),
+    ...(workflow.delivery ? { delivery: workflow.delivery } : {}),
+  };
+  const viewport = workflow.ui?.layout?.viewport ?? DEFAULT_VIEWPORT;
+  return {
+    meta,
+    nodes,
+    edges: deriveEdges(nodes),
+    viewport,
+    selected: null,
+    dirty: false,
+    errors: {},
+  };
+}
+
+/** Parse canonical YAML the host returned, then hydrate. */
+export function hydrateYaml(yaml: string): BuilderState {
+  const raw = fromYaml(yaml) as Partial<Workflow> | null;
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('workflow YAML did not parse to an object');
+  }
+  return hydrate(normalizeWorkflow(raw));
+}
+
+/** Fill in schema defaults the canvas relies on when reading loose YAML. */
+function normalizeWorkflow(raw: Partial<Workflow>): Workflow {
+  const steps = (raw.steps ?? []).map((s) => {
+    const step = s as Partial<WorkflowStep>;
+    return {
+      ...step,
+      needs: step.needs ?? [],
+      onError: step.onError ?? 'fail',
+      retries: step.retries ?? 0,
+    } as WorkflowStep;
+  });
+  return {
+    name: raw.name ?? 'untitled-workflow',
+    description: raw.description ?? '',
+    version: raw.version ?? 1,
+    enabled: raw.enabled ?? true,
+    inputs: raw.inputs ?? {},
+    ...(raw.on ? { on: raw.on } : {}),
+    ...(raw.delivery ? { delivery: raw.delivery } : {}),
+    ...(raw.ui ? { ui: raw.ui } : {}),
+    concurrency: raw.concurrency ?? 4,
+    steps,
+  };
+}
+
+function stepToNode(step: WorkflowStep, x: number, y: number): BuilderNode {
+  const kind = detectKind(step);
+  const loop: BuilderLoop | undefined = step.loop
+    ? {
+        body: [...step.loop.body],
+        condition: step.loop.condition,
+        maxIterations: step.loop.maxIterations,
+      }
+    : undefined;
+  return {
+    id: step.id,
+    kind,
+    x,
+    y,
+    action: kind === 'loop' ? '' : (step[ACTION_KIND_FIELD[kind]] as string) ?? '',
+    needs: [...step.needs],
+    onError: step.onError,
+    retries: step.retries,
+    ...(step.label ? { label: step.label } : {}),
+    ...(step.input ? { input: step.input } : {}),
+    ...(step.args ? { args: { ...step.args } } : {}),
+    ...(step.then ? { then: [...step.then] } : {}),
+    ...(step.else ? { else: [...step.else] } : {}),
+    ...(step.cases ? { cases: mapValues(step.cases, (v) => [...v]) } : {}),
+    ...(step.default ? { default: [...step.default] } : {}),
+    ...(loop ? { loop } : {}),
+    ...(step.when ? { when: step.when } : {}),
+    ...(step.format ? { format: step.format } : {}),
+    ...(step.awaitInput ? { awaitInput: step.awaitInput } : {}),
+  };
+}
+
+function detectKind(step: WorkflowStep): StepKind {
+  const kinds: StepKind[] = ['skill', 'prompt', 'tool', 'workflow', 'bridge', 'condition', 'switch', 'loop'];
+  for (const k of kinds) if (step[ACTION_KIND_FIELD[k]] != null) return k;
+  return 'prompt';
+}
+
+// ---------------------------------------------------------------------------
+// Edge derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Project the node graph into the renderable edge set. One `needs` edge per
+ * dependency (dependency → dependent), one branch edge per `then`/`else`/case/
+ * default target, one `loop-body` edge per body member, and exactly one
+ * `loop-exit` edge per loop node (loop → its first downstream non-body step, if
+ * any) so the single "on done / on error → next" connector is always present.
+ */
+export function deriveEdges(nodes: ReadonlyArray<BuilderNode>): BuilderEdge[] {
+  const ids = new Set(nodes.map((n) => n.id));
+  const edges: BuilderEdge[] = [];
+  const loopBodyOf = new Map<string, Set<string>>();
+  for (const n of nodes) {
+    if (n.kind === 'loop' && n.loop) loopBodyOf.set(n.id, new Set(n.loop.body));
+  }
+
+  for (const node of nodes) {
+    for (const dep of node.needs) {
+      if (!ids.has(dep)) continue;
+      // A body step's `needs: [loop]` edge is rendered as loop-body, not needs,
+      // so the canvas shows the containment region instead of a plain arrow.
+      const body = loopBodyOf.get(dep);
+      if (body?.has(node.id)) continue;
+      edges.push({ id: `needs:${dep}->${node.id}`, kind: 'needs', from: dep, to: node.id });
+    }
+    if (node.kind === 'condition') {
+      for (const t of node.then ?? []) {
+        if (ids.has(t)) edges.push({ id: `then:${node.id}->${t}`, kind: 'then', from: node.id, to: t });
+      }
+      for (const t of node.else ?? []) {
+        if (ids.has(t)) edges.push({ id: `else:${node.id}->${t}`, kind: 'else', from: node.id, to: t });
+      }
+    }
+    if (node.kind === 'switch') {
+      for (const [caseId, targets] of Object.entries(node.cases ?? {})) {
+        for (const t of targets) {
+          if (ids.has(t)) {
+            edges.push({ id: `case:${node.id}:${caseId}->${t}`, kind: 'case', from: node.id, to: t, caseId });
+          }
+        }
+      }
+      for (const t of node.default ?? []) {
+        if (ids.has(t)) edges.push({ id: `default:${node.id}->${t}`, kind: 'default', from: node.id, to: t });
+      }
+    }
+    if (node.kind === 'loop' && node.loop) {
+      for (const t of node.loop.body) {
+        if (ids.has(t)) edges.push({ id: `body:${node.id}->${t}`, kind: 'loop-body', from: node.id, to: t });
+      }
+      const exit = loopExitTarget(node, nodes);
+      if (exit) edges.push({ id: `exit:${node.id}->${exit}`, kind: 'loop-exit', from: node.id, to: exit });
+    }
+  }
+  return edges;
+}
+
+/**
+ * The single node a loop continues to once it stops: the first non-body step
+ * that `needs` the loop node. Returns null when nothing follows the loop (the
+ * loop is the tail of the graph) — the renderer then shows a dangling "→ end".
+ */
+export function loopExitTarget(loop: BuilderNode, nodes: ReadonlyArray<BuilderNode>): string | null {
+  if (loop.kind !== 'loop' || !loop.loop) return null;
+  const body = new Set(loop.loop.body);
+  for (const n of nodes) {
+    if (n.id === loop.id || body.has(n.id)) continue;
+    if (n.needs.includes(loop.id)) return n.id;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Auto-layout
+// ---------------------------------------------------------------------------
+
+const NODE_GAP_X = 280;
+const NODE_GAP_Y = 150;
+
+/**
+ * A simple longest-path layered layout over `needs` edges: x = depth column, y
+ * = stacking within the column. Good enough to open an un-laid-out workflow as
+ * a left-to-right graph; the user can then drag nodes and the positions persist.
+ */
+export function autoLayout(steps: ReadonlyArray<WorkflowStep>): Array<{ x: number; y: number }> {
+  const ids = steps.map((s) => s.id);
+  const byId = new Map(steps.map((s) => [s.id, s]));
+  const depth = new Map<string, number>();
+
+  const resolve = (id: string, seen: Set<string>): number => {
+    if (depth.has(id)) return depth.get(id)!;
+    if (seen.has(id)) return 0; // cycle guard — server validation will reject it
+    seen.add(id);
+    const step = byId.get(id);
+    const needs = step?.needs ?? [];
+    const d = needs.length === 0 ? 0 : Math.max(...needs.map((n) => resolve(n, seen) + 1));
+    depth.set(id, d);
+    seen.delete(id);
+    return d;
+  };
+  for (const id of ids) resolve(id, new Set());
+
+  const rowByCol = new Map<number, number>();
+  return steps.map((s) => {
+    const col = depth.get(s.id) ?? 0;
+    const row = rowByCol.get(col) ?? 0;
+    rowByCol.set(col, row + 1);
+    return { x: col * NODE_GAP_X + 40, y: row * NODE_GAP_Y + 40 };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function round(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function mapValues<T, U>(obj: Record<string, T>, fn: (v: T) => U): Record<string, U> {
+  return Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, fn(v)]));
+}
+
+/** Drop `undefined` values recursively so the YAML emitter never sees them. */
+function stripUndefined<T>(value: T): T {
+  if (Array.isArray(value)) return value.map((v) => stripUndefined(v)) as unknown as T;
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (v !== undefined) out[k] = stripUndefined(v);
+    }
+    return out as T;
+  }
+  return value;
+}

--- a/packages/workflows-builder/src/types.ts
+++ b/packages/workflows-builder/src/types.ts
@@ -1,0 +1,164 @@
+/**
+ * The builder's canvas data model — a normalized, framework-agnostic view of a
+ * {@link Workflow} laid out as nodes + edges. It is deliberately a SUPERSET of
+ * the on-disk {@link WorkflowStep} shape: every editable field of a step lives
+ * on its node, and the DAG/branch/loop relationships are projected into typed
+ * {@link BuilderEdge}s so a renderer can draw them without re-deriving topology.
+ *
+ * This module is pure data — no React, no DOM, no node built-ins — so it
+ * import-cleanly under both the Electron renderer and the Expo (Hermes) bundle.
+ */
+
+import type {
+  WorkflowDelivery,
+  WorkflowInputSpec,
+  WorkflowLogicStepFormat,
+  WorkflowStepErrorMode,
+  WorkflowTrigger,
+  WorkflowUiViewport,
+} from '@moxxy/sdk';
+
+/** The eight mutually-exclusive step actions, mirrored from the SDK. */
+export type StepKind =
+  | 'skill'
+  | 'prompt'
+  | 'tool'
+  | 'workflow'
+  | 'bridge'
+  | 'condition'
+  | 'switch'
+  | 'loop';
+
+/** Loop config carried on a `loop` node (mirrors `WorkflowLoopAction`). */
+export interface BuilderLoop {
+  /** Ordered step ids that run once per iteration. */
+  body: string[];
+  /** EXIT/GOAL predicate — met → stop the loop, continue to the next step. */
+  condition: string;
+  /** Hard iteration cap (1..50). */
+  maxIterations: number;
+}
+
+/**
+ * One node on the canvas — a workflow step plus its layout. The action field
+ * matching {@link kind} holds the step's instruction/target; the others are
+ * undefined. Branch targets (`then`/`else`/`cases`/`default`) and the loop body
+ * are kept on the node so the inspector edits them in place; they are ALSO
+ * projected into {@link BuilderEdge}s for rendering.
+ */
+export interface BuilderNode {
+  readonly id: string;
+  kind: StepKind;
+  label?: string;
+  /** Canvas position (persisted to `ui.layout.nodes[id]`). */
+  x: number;
+  y: number;
+
+  // --- action payloads (only the one matching `kind` is set) ---
+  /** skill name / prompt text / tool name / workflow name / logic instruction. */
+  action: string;
+  /** Templated instruction for skill steps. */
+  input?: string;
+  /** Templated args object for tool/workflow steps. */
+  args?: Record<string, unknown>;
+  /** Branch lists for condition steps. */
+  then?: string[];
+  else?: string[];
+  /** Branch map for switch steps. */
+  cases?: Record<string, string[]>;
+  default?: string[];
+  /** Loop config for loop steps. */
+  loop?: BuilderLoop;
+
+  // --- shared step fields ---
+  /** DAG dependencies (also projected as `needs` edges). */
+  needs: string[];
+  when?: string;
+  onError: WorkflowStepErrorMode;
+  retries: number;
+  format?: WorkflowLogicStepFormat;
+  awaitInput?: boolean;
+}
+
+/** How an edge relates two nodes — drives its label + visual treatment. */
+export type EdgeKind = 'needs' | 'then' | 'else' | 'case' | 'default' | 'loop-body' | 'loop-exit';
+
+/**
+ * A directed edge between two nodes, derived from the step graph. `needs` edges
+ * point from the dependency to the dependent (data-flow direction). Branch/loop
+ * edges point from the gate/loop node to a target. `caseId` is set only for
+ * `case` edges. `loop-exit` is the single edge a loop takes once its condition
+ * is met (or a body step errors) — there is exactly one per loop node.
+ */
+export interface BuilderEdge {
+  readonly id: string;
+  readonly kind: EdgeKind;
+  readonly from: string;
+  readonly to: string;
+  /** Label for `case` edges (the switch case id). */
+  readonly caseId?: string;
+}
+
+/** Workflow-level metadata edited in the builder's header, not on any node. */
+export interface BuilderMeta {
+  name: string;
+  description: string;
+  enabled: boolean;
+  version: number;
+  concurrency: number;
+  inputs: Record<string, WorkflowInputSpec>;
+  on?: WorkflowTrigger;
+  delivery?: WorkflowDelivery;
+}
+
+/** Pan/zoom of the canvas (persisted to `ui.layout.viewport`). */
+export type BuilderViewport = WorkflowUiViewport;
+
+/**
+ * The full builder state. Immutable from the reducer's point of view: every
+ * operation returns a fresh object (structural sharing where cheap). `dirty`
+ * flips true on any content edit and back to false after a successful save.
+ */
+export interface BuilderState {
+  readonly meta: BuilderMeta;
+  readonly nodes: ReadonlyArray<BuilderNode>;
+  readonly edges: ReadonlyArray<BuilderEdge>;
+  readonly viewport: BuilderViewport;
+  /** Currently-selected node id (drives the inspector), or null. */
+  readonly selected: string | null;
+  /** True when there are unsaved content changes. */
+  readonly dirty: boolean;
+  /**
+   * Per-node validation errors keyed by node id, plus a `__workflow__` bucket
+   * for graph-level / metadata issues that don't map to one node. Refreshed by
+   * {@link applyValidation} after a `validateDraft` round-trip.
+   */
+  readonly errors: Readonly<Record<string, ReadonlyArray<string>>>;
+}
+
+/** The catch-all error bucket key for issues that don't bind to a node. */
+export const WORKFLOW_ERROR_KEY = '__workflow__';
+
+/** Human label + accent token per step kind (consumed by both UIs). */
+export interface StepKindMeta {
+  readonly kind: StepKind;
+  readonly label: string;
+  /** A semantic color name; each platform maps it to its own token. */
+  readonly accent: 'blue' | 'green' | 'purple' | 'teal' | 'amber' | 'pink' | 'cyan' | 'orange';
+  readonly description: string;
+}
+
+export const STEP_KINDS: ReadonlyArray<StepKindMeta> = [
+  { kind: 'prompt', label: 'Prompt', accent: 'blue', description: 'Free-form instruction to a subagent.' },
+  { kind: 'skill', label: 'Skill', accent: 'green', description: 'Run a named skill with an input.' },
+  { kind: 'tool', label: 'Tool', accent: 'teal', description: 'Invoke a tool with templated args.' },
+  { kind: 'workflow', label: 'Sub-workflow', accent: 'cyan', description: 'Run another workflow by name.' },
+  { kind: 'bridge', label: 'Bridge', accent: 'amber', description: 'Extract/transform data into vars.' },
+  { kind: 'condition', label: 'Condition', accent: 'orange', description: 'If/else routing on a predicate.' },
+  { kind: 'switch', label: 'Switch', accent: 'pink', description: 'Multi-way routing on cases.' },
+  { kind: 'loop', label: 'Loop', accent: 'purple', description: 'Repeat a body until a goal is met.' },
+];
+
+export function stepKindMeta(kind: StepKind): StepKindMeta {
+  return STEP_KINDS.find((k) => k.kind === kind) ?? STEP_KINDS[0]!;
+}

--- a/packages/workflows-builder/src/validation.test.ts
+++ b/packages/workflows-builder/src/validation.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import { addStep, emptyState, setBranchTargets, updateMeta, updateNode } from './operations.js';
+import { mapErrorsToNodes, save, validate, ValidationError, type BuilderBridge } from './validation.js';
+import { WORKFLOW_ERROR_KEY } from './types.js';
+
+function fixture() {
+  let s = emptyState('demo');
+  s = updateMeta(s, { description: 'demo workflow' });
+  s = addStep(s, { kind: 'prompt', id: 'a' });
+  s = updateNode(s, 'a', { action: 'do a' });
+  s = addStep(s, { kind: 'condition', id: 'gate', after: 'a' });
+  s = updateNode(s, 'gate', { action: 'good?' });
+  s = setBranchTargets(s, 'gate', 'then', ['a']);
+  return s;
+}
+
+describe('mapErrorsToNodes', () => {
+  it('buckets step-mentioning issues under the named node', () => {
+    const s = fixture();
+    const mapped = mapErrorsToNodes(
+      [
+        'steps: step "gate" needs unknown step "ghost"',
+        'awaitInput: step "a": awaitInput is only allowed on prompt or skill steps',
+        'name: name must be slug-like',
+      ],
+      s,
+    );
+    expect(mapped.gate).toEqual(['steps: step "gate" needs unknown step "ghost"']);
+    expect(mapped.a).toEqual(['awaitInput: step "a": awaitInput is only allowed on prompt or skill steps']);
+    expect(mapped[WORKFLOW_ERROR_KEY]).toEqual(['name: name must be slug-like']);
+  });
+
+  it('maps duplicate-id issues to the node', () => {
+    const s = fixture();
+    const mapped = mapErrorsToNodes(['steps: duplicate step id "a"'], s);
+    expect(mapped.a).toEqual(['steps: duplicate step id "a"']);
+  });
+
+  it('falls back to the workflow bucket when no known step is named', () => {
+    const s = fixture();
+    const mapped = mapErrorsToNodes(['steps: step "unknown_one" needs unknown step "x"'], s);
+    expect(mapped[WORKFLOW_ERROR_KEY]).toHaveLength(1);
+  });
+});
+
+describe('validate bridge', () => {
+  it('serializes and returns mapped errors', async () => {
+    const bridge: BuilderBridge = {
+      validateDraft: vi.fn(async () => ({ ok: false, errors: ['steps: step "a" needs unknown step "z"'] })),
+      save: vi.fn(),
+    };
+    const { result, errors } = await validate(bridge, fixture());
+    expect(bridge.validateDraft).toHaveBeenCalledOnce();
+    expect(result.ok).toBe(false);
+    expect(errors.a).toBeDefined();
+  });
+});
+
+describe('save bridge', () => {
+  it('validates then saves on success', async () => {
+    const saved = { name: 'demo', scope: 'user', path: '/tmp/demo.yaml' };
+    const bridge: BuilderBridge = {
+      validateDraft: vi.fn(async () => ({ ok: true, errors: [] })),
+      save: vi.fn(async () => saved),
+    };
+    const { result, yaml } = await save(bridge, fixture());
+    expect(result).toEqual(saved);
+    expect(yaml).toContain('name: demo');
+    expect(bridge.save).toHaveBeenCalledOnce();
+  });
+
+  it('throws ValidationError without calling save when invalid', async () => {
+    const bridge: BuilderBridge = {
+      validateDraft: vi.fn(async () => ({ ok: false, errors: ['steps: step "a" needs unknown step "z"'] })),
+      save: vi.fn(),
+    };
+    await expect(save(bridge, fixture())).rejects.toBeInstanceOf(ValidationError);
+    expect(bridge.save).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workflows-builder/src/validation.ts
+++ b/packages/workflows-builder/src/validation.ts
@@ -1,0 +1,119 @@
+/**
+ * Validation + save bridges over the workflows IPC (`workflows.validateDraft` /
+ * `workflows.save`), plus the pure error-mapping that turns the host's flat
+ * `string[]` issues into a per-node bucket the inspector highlights.
+ *
+ * The transport is injected (not imported) so this module stays DOM-free and
+ * platform-neutral: the desktop passes `window.moxxy.invoke`, the mobile app
+ * passes its frame-bridge `invokeFrame`-wrapped invoker. Each issue line the
+ * host returns is scanned for a `step "<id>"` mention; matches bucket under
+ * that node id, everything else falls into {@link WORKFLOW_ERROR_KEY}.
+ */
+
+import type { BuilderState } from './types.js';
+import { WORKFLOW_ERROR_KEY } from './types.js';
+import { serialize } from './serialize.js';
+
+/** Minimal validate result shape (matches `WorkflowValidate` in the contract). */
+export interface ValidateResult {
+  readonly ok: boolean;
+  readonly errors: ReadonlyArray<string>;
+}
+
+/** Minimal save result shape (matches `WorkflowSave` in the contract). */
+export interface SaveResult {
+  readonly name: string;
+  readonly scope: string;
+  readonly path: string;
+}
+
+/** The host call surface the bridges need — implemented per platform. */
+export interface BuilderBridge {
+  validateDraft(yaml: string): Promise<ValidateResult>;
+  save(yaml: string): Promise<SaveResult>;
+}
+
+/**
+ * Validate the current canvas: serialize → call the host → map issues back
+ * onto nodes. Returns the raw result plus the per-node error buckets so a
+ * caller can both surface a banner and decorate nodes.
+ */
+export async function validate(
+  bridge: BuilderBridge,
+  state: BuilderState,
+): Promise<{ result: ValidateResult; errors: Record<string, string[]> }> {
+  const { yaml } = serialize(state);
+  const result = await bridge.validateDraft(yaml);
+  return { result, errors: mapErrorsToNodes(result.errors, state) };
+}
+
+/**
+ * Persist the canvas after a successful validation. Throws if validation fails
+ * (the host's `save` would reject anyway, but failing here yields the mapped
+ * per-node errors for the UI). On success the caller should mark the state
+ * clean and refresh the list.
+ */
+export async function save(
+  bridge: BuilderBridge,
+  state: BuilderState,
+): Promise<{ result: SaveResult; yaml: string }> {
+  const { yaml } = serialize(state);
+  const validation = await bridge.validateDraft(yaml);
+  if (!validation.ok) {
+    throw new ValidationError('workflow has validation errors', validation.errors, mapErrorsToNodes(validation.errors, state));
+  }
+  const result = await bridge.save(yaml);
+  return { result, yaml };
+}
+
+/** Thrown by {@link save} when the draft fails validation. */
+export class ValidationError extends Error {
+  constructor(
+    message: string,
+    readonly issues: ReadonlyArray<string>,
+    readonly byNode: Record<string, string[]>,
+  ) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}
+
+const STEP_MENTION_RE = /step "([^"]+)"/g;
+const DUP_RE = /duplicate step id "([^"]+)"/;
+
+/**
+ * Bucket each flat issue line under the node id(s) it names. A line that
+ * mentions `step "x"` is attached to node `x` (and to any other step it
+ * names, e.g. "step a needs unknown step b" — the author edits `a`). Lines
+ * with no recognizable step reference land in {@link WORKFLOW_ERROR_KEY}.
+ */
+export function mapErrorsToNodes(
+  issues: ReadonlyArray<string>,
+  state: BuilderState,
+): Record<string, string[]> {
+  const known = new Set(state.nodes.map((n) => n.id));
+  const out: Record<string, string[]> = {};
+  const push = (key: string, msg: string): void => {
+    (out[key] ??= []).push(msg);
+  };
+
+  for (const issue of issues) {
+    const mentioned = new Set<string>();
+    const dup = DUP_RE.exec(issue);
+    if (dup && known.has(dup[1]!)) mentioned.add(dup[1]!);
+    let m: RegExpExecArray | null;
+    STEP_MENTION_RE.lastIndex = 0;
+    while ((m = STEP_MENTION_RE.exec(issue))) {
+      if (known.has(m[1]!)) mentioned.add(m[1]!);
+    }
+    if (mentioned.size === 0) {
+      push(WORKFLOW_ERROR_KEY, issue);
+    } else {
+      // Attribute to the FIRST named step (the one whose definition is wrong);
+      // additional mentions are usually the unknown target the author must add.
+      const [first] = [...mentioned];
+      push(first!, issue);
+    }
+  }
+  return out;
+}

--- a/packages/workflows-builder/src/yaml.ts
+++ b/packages/workflows-builder/src/yaml.ts
@@ -1,0 +1,364 @@
+/**
+ * A tiny, dependency-free YAML codec scoped to the workflow artifact shape.
+ *
+ * Why hand-rolled instead of the `yaml` package: this model must bundle clean
+ * under React Native (Hermes), and `yaml` reaches for `node:process` in its log
+ * path, which Metro would have to shim. The workflow document is a bounded,
+ * well-known shape (a map with scalars, string lists, nested string-keyed maps,
+ * and `|`-style block scalars for prompts), so a focused emitter/parser is both
+ * safe and small. Authoritative validation still happens server-side via
+ * `workflows.validateDraft`; this codec only needs to round-trip the builder's
+ * own output and re-hydrate canonical YAML that the host returned.
+ */
+
+// ---------------------------------------------------------------------------
+// Emit
+// ---------------------------------------------------------------------------
+
+/** Serialize a plain JSON value to a workflow-flavoured YAML document. */
+export function toYaml(value: unknown): string {
+  const lines: string[] = [];
+  emitMap(value as Record<string, unknown>, 0, lines);
+  return lines.join('\n') + '\n';
+}
+
+function emitMap(obj: Record<string, unknown>, indent: number, out: string[]): void {
+  const pad = '  '.repeat(indent);
+  for (const [key, raw] of Object.entries(obj)) {
+    if (raw === undefined) continue;
+    const k = emitKey(key);
+    if (raw === null) {
+      out.push(`${pad}${k}: null`);
+    } else if (Array.isArray(raw)) {
+      if (raw.length === 0) {
+        out.push(`${pad}${k}: []`);
+      } else {
+        out.push(`${pad}${k}:`);
+        emitArray(raw, indent + 1, out);
+      }
+    } else if (isPlainObject(raw)) {
+      if (Object.keys(raw).length === 0) {
+        out.push(`${pad}${k}: {}`);
+      } else {
+        out.push(`${pad}${k}:`);
+        emitMap(raw as Record<string, unknown>, indent + 1, out);
+      }
+    } else {
+      emitScalarField(pad, k, raw, indent, out);
+    }
+  }
+}
+
+function emitArray(arr: ReadonlyArray<unknown>, indent: number, out: string[]): void {
+  const pad = '  '.repeat(indent);
+  for (const item of arr) {
+    if (item === null || item === undefined) {
+      out.push(`${pad}- null`);
+    } else if (Array.isArray(item)) {
+      out.push(`${pad}-`);
+      emitArray(item, indent + 1, out);
+    } else if (isPlainObject(item)) {
+      // Inline the first key on the `-` line, then continue the map indented.
+      const entries = Object.entries(item as Record<string, unknown>).filter(([, v]) => v !== undefined);
+      if (entries.length === 0) {
+        out.push(`${pad}- {}`);
+        continue;
+      }
+      const first = out.length;
+      emitMap(item as Record<string, unknown>, indent + 1, out);
+      // Splice the dash onto the first emitted child line.
+      out[first] = `${pad}- ${out[first]!.slice((indent + 1) * 2)}`;
+    } else {
+      out.push(`${pad}- ${emitScalar(item)}`);
+    }
+  }
+}
+
+function emitScalarField(
+  pad: string,
+  key: string,
+  raw: unknown,
+  indent: number,
+  out: string[],
+): void {
+  if (typeof raw === 'string' && raw.includes('\n')) {
+    // Block scalar (`|`) preserves newlines verbatim — used for prompts.
+    out.push(`${pad}${key}: |`);
+    const childPad = '  '.repeat(indent + 1);
+    for (const line of raw.replace(/\n$/, '').split('\n')) {
+      out.push(line.length > 0 ? `${childPad}${line}` : '');
+    }
+  } else {
+    out.push(`${pad}${key}: ${emitScalar(raw)}`);
+  }
+}
+
+function emitKey(key: string): string {
+  return /^[A-Za-z0-9_][A-Za-z0-9_-]*$/.test(key) ? key : emitScalar(key);
+}
+
+function emitScalar(value: unknown): string {
+  if (typeof value === 'boolean' || typeof value === 'number') return String(value);
+  if (value === null) return 'null';
+  const s = String(value);
+  if (s === '') return '""';
+  if (needsQuote(s)) return JSON.stringify(s);
+  return s;
+}
+
+function needsQuote(s: string): boolean {
+  if (/^\s|\s$/.test(s)) return true;
+  if (/[:#[\]{}&*!|>'"%@`,]/.test(s)) return true;
+  if (/^[-?]/.test(s)) return true;
+  // Reserved bare words / number-looking strings must be quoted to keep type.
+  if (/^(true|false|null|yes|no|on|off|~)$/i.test(s)) return true;
+  if (/^-?\d/.test(s) && /^-?\d+(\.\d+)?([eE][+-]?\d+)?$/.test(s)) return true;
+  return false;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+// ---------------------------------------------------------------------------
+// Parse
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a workflow-flavoured YAML document into a plain JSON value. Supports
+ * the subset this codec emits plus what the host's canonical emitter produces:
+ * nested maps, `- ` sequences (scalar, inline-map, and nested), `|` and `|-`
+ * block scalars, flow `[]`/`{}` empties, and quoted scalars. Throws on the
+ * obvious malformations; the server schema is the real arbiter.
+ */
+export function fromYaml(text: string): unknown {
+  const lines = stripComments(text)
+    .replace(/\r\n/g, '\n')
+    .split('\n');
+  const ctx = { lines, i: 0 };
+  return parseBlock(ctx, 0);
+}
+
+interface ParseCtx {
+  readonly lines: string[];
+  i: number;
+}
+
+function stripComments(text: string): string {
+  // Strip full-line `#` comments and trailing ` # ...` on lines without quotes
+  // or `#` inside a value. Conservative — only removes when `#` is preceded by
+  // whitespace and the line isn't a block-scalar body (handled by indent later).
+  return text
+    .split('\n')
+    .map((line) => {
+      const trimmed = line.trimStart();
+      if (trimmed.startsWith('#')) return '';
+      const hash = findBareHash(line);
+      return hash >= 0 ? line.slice(0, hash).replace(/\s+$/, '') : line;
+    })
+    .join('\n');
+}
+
+function findBareHash(line: string): number {
+  let inSingle = false;
+  let inDouble = false;
+  for (let j = 0; j < line.length; j++) {
+    const c = line[j];
+    if (c === '"' && !inSingle) inDouble = !inDouble;
+    else if (c === "'" && !inDouble) inSingle = !inSingle;
+    else if (c === '#' && !inSingle && !inDouble && j > 0 && /\s/.test(line[j - 1]!)) return j;
+  }
+  return -1;
+}
+
+function indentOf(line: string): number {
+  const m = /^( *)/.exec(line);
+  return m ? m[1]!.length : 0;
+}
+
+function isBlank(line: string): boolean {
+  return line.trim().length === 0;
+}
+
+function parseBlock(ctx: ParseCtx, minIndent: number): unknown {
+  // Skip blanks, then dispatch on whether the first content line is a sequence.
+  while (ctx.i < ctx.lines.length && isBlank(ctx.lines[ctx.i]!)) ctx.i++;
+  if (ctx.i >= ctx.lines.length) return null;
+  const line = ctx.lines[ctx.i]!;
+  const indent = indentOf(line);
+  if (indent < minIndent) return null;
+  return line.slice(indent).startsWith('- ') || line.slice(indent).trim() === '-'
+    ? parseSequence(ctx, indent)
+    : parseMap(ctx, indent);
+}
+
+function parseMap(ctx: ParseCtx, indent: number): Record<string, unknown> {
+  const obj: Record<string, unknown> = {};
+  while (ctx.i < ctx.lines.length) {
+    const line = ctx.lines[ctx.i]!;
+    if (isBlank(line)) {
+      ctx.i++;
+      continue;
+    }
+    const ind = indentOf(line);
+    if (ind < indent) break;
+    if (ind > indent) throw new Error(`yaml: unexpected indent at line ${ctx.i + 1}`);
+    const body = line.slice(indent);
+    if (body.startsWith('- ')) break; // a sequence at this level ends the map
+    const colon = splitKey(body);
+    if (!colon) throw new Error(`yaml: expected "key: value" at line ${ctx.i + 1}`);
+    const { key, rest } = colon;
+    ctx.i++;
+    if (rest === '' ) {
+      obj[key] = parseChild(ctx, indent);
+    } else if (rest === '|' || rest === '|-' || rest === '>' || rest === '>-') {
+      obj[key] = parseBlockScalar(ctx, indent, rest.startsWith('>'), rest.endsWith('-'));
+    } else {
+      obj[key] = parseScalar(rest);
+    }
+  }
+  return obj;
+}
+
+/** A value on its own line(s) below `parentIndent` — map, sequence, or null. */
+function parseChild(ctx: ParseCtx, parentIndent: number): unknown {
+  // Peek the next non-blank line; if it's deeper, recurse, else the value is null.
+  let j = ctx.i;
+  while (j < ctx.lines.length && isBlank(ctx.lines[j]!)) j++;
+  if (j >= ctx.lines.length) return null;
+  const ind = indentOf(ctx.lines[j]!);
+  if (ind <= parentIndent) return null;
+  ctx.i = j;
+  return parseBlock(ctx, ind);
+}
+
+function parseSequence(ctx: ParseCtx, indent: number): unknown[] {
+  const arr: unknown[] = [];
+  while (ctx.i < ctx.lines.length) {
+    const line = ctx.lines[ctx.i]!;
+    if (isBlank(line)) {
+      ctx.i++;
+      continue;
+    }
+    const ind = indentOf(line);
+    if (ind < indent) break;
+    const body = line.slice(indent);
+    if (!body.startsWith('-')) break;
+    const after = body.slice(1).replace(/^ /, '');
+    if (after === '') {
+      ctx.i++;
+      arr.push(parseChild(ctx, indent));
+    } else if (looksLikeKey(after)) {
+      // Inline map: `- key: value` — re-indent the rest as a map child.
+      const itemIndent = indent + 2;
+      ctx.lines[ctx.i] = ' '.repeat(itemIndent) + after;
+      arr.push(parseMap(ctx, itemIndent));
+    } else {
+      ctx.i++;
+      arr.push(parseScalar(after));
+    }
+  }
+  return arr;
+}
+
+function parseBlockScalar(ctx: ParseCtx, parentIndent: number, fold: boolean, strip: boolean): string {
+  const collected: string[] = [];
+  let blockIndent = -1;
+  while (ctx.i < ctx.lines.length) {
+    const line = ctx.lines[ctx.i]!;
+    if (isBlank(line)) {
+      collected.push('');
+      ctx.i++;
+      continue;
+    }
+    const ind = indentOf(line);
+    if (ind <= parentIndent) break;
+    if (blockIndent < 0) blockIndent = ind;
+    collected.push(line.slice(blockIndent));
+    ctx.i++;
+  }
+  // Trim trailing blank lines collected past the block.
+  while (collected.length > 0 && collected[collected.length - 1] === '') collected.pop();
+  const joined = fold ? collected.join(' ') : collected.join('\n');
+  return strip ? joined : joined + '\n';
+}
+
+function splitKey(body: string): { key: string; rest: string } | null {
+  // Find the first `: ` (or trailing `:`) outside quotes.
+  let inSingle = false;
+  let inDouble = false;
+  for (let j = 0; j < body.length; j++) {
+    const c = body[j];
+    if (c === '"' && !inSingle) inDouble = !inDouble;
+    else if (c === "'" && !inDouble) inSingle = !inSingle;
+    else if (c === ':' && !inSingle && !inDouble) {
+      const next = body[j + 1];
+      if (next === undefined || next === ' ') {
+        const key = unquote(body.slice(0, j).trim());
+        const rest = body.slice(j + 1).trim();
+        return { key, rest };
+      }
+    }
+  }
+  return null;
+}
+
+function looksLikeKey(s: string): boolean {
+  return splitKey(s) !== null;
+}
+
+function parseScalar(token: string): unknown {
+  const t = token.trim();
+  if (t === '[]') return [];
+  if (t === '{}') return {};
+  if (t === '~' || t === 'null') return null;
+  if (t === 'true') return true;
+  if (t === 'false') return false;
+  if (/^-?\d+$/.test(t)) return Number.parseInt(t, 10);
+  if (/^-?\d+\.\d+$/.test(t)) return Number.parseFloat(t);
+  // Flow sequence of scalars: ["a", "b"] / [a, b]
+  if (t.startsWith('[') && t.endsWith(']')) {
+    const inner = t.slice(1, -1).trim();
+    if (inner === '') return [];
+    return splitFlow(inner).map((x) => parseScalar(x));
+  }
+  return unquote(t);
+}
+
+function splitFlow(inner: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let inSingle = false;
+  let inDouble = false;
+  let cur = '';
+  for (const c of inner) {
+    if (c === '"' && !inSingle) inDouble = !inDouble;
+    else if (c === "'" && !inDouble) inSingle = !inSingle;
+    if (!inSingle && !inDouble) {
+      if (c === '[' || c === '{') depth++;
+      else if (c === ']' || c === '}') depth--;
+      else if (c === ',' && depth === 0) {
+        parts.push(cur.trim());
+        cur = '';
+        continue;
+      }
+    }
+    cur += c;
+  }
+  if (cur.trim() !== '') parts.push(cur.trim());
+  return parts;
+}
+
+function unquote(s: string): string {
+  if (s.length >= 2 && s[0] === '"' && s[s.length - 1] === '"') {
+    try {
+      return JSON.parse(s) as string;
+    } catch {
+      return s.slice(1, -1);
+    }
+  }
+  if (s.length >= 2 && s[0] === "'" && s[s.length - 1] === "'") {
+    return s.slice(1, -1).replace(/''/g, "'");
+  }
+  return s;
+}

--- a/packages/workflows-builder/tsconfig.json
+++ b/packages/workflows-builder/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023"],
+    "types": []
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+}

--- a/packages/workflows-builder/vitest.config.ts
+++ b/packages/workflows-builder/vitest.config.ts
@@ -1,0 +1,5 @@
+import preset from '@moxxy/vitest-preset';
+
+// Pure-logic suite: operations, serialize<->hydrate round-trips, validation
+// mapping, the loop node's body/exit model. No DOM, no RN — node env is fine.
+export default preset;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       '@moxxy/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
+      '@moxxy/workflows-builder':
+        specifier: workspace:*
+        version: link:../../packages/workflows-builder
       electron-updater:
         specifier: ^6.8.3
         version: 6.8.3
@@ -287,6 +290,9 @@ importers:
       '@moxxy/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
+      '@moxxy/workflows-builder':
+        specifier: workspace:*
+        version: link:../../packages/workflows-builder
       expo:
         specifier: ~54.0.0
         version: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
@@ -604,6 +610,9 @@ importers:
       '@moxxy/sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@moxxy/workflows-builder':
+        specifier: workspace:*
+        version: link:../workflows-builder
     devDependencies:
       '@moxxy/tsconfig':
         specifier: workspace:*
@@ -2112,6 +2121,25 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
+  packages/workflows-builder:
+    dependencies:
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+    devDependencies:
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@24.12.3)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
 
   tooling/eslint-config:
     dependencies:


### PR DESCRIPTION
Phase 2 of 2 of the workflows feature: the **visual builder GUI**, built on top of the phase-1 engine (this PR stacks on `feat/workflows-engine`). A drag canvas on desktop, an outline editor on mobile, both driven by one shared, DOM-free model.

## What shipped

### 1. Shared model — new `@moxxy/workflows-builder` (DOM-free, RN-safe)
A focused new package (rather than a module set in `client-core`) because both desktop *and* mobile import it and it must stay RN-safe — a clear ownership boundary. Zero React, zero DOM, zero node built-ins; the **Expo iOS export proves it bundles RN-clean**.

It holds:
- **State + reducer** — `BuilderState` (nodes, edges, selection, viewport, dirty, per-node errors) + a typed `builderReducer`.
- **Pure operations** — `addStep`/`removeStep`, `connectNeeds`/`disconnectNeeds`, `setBranchTargets`/`setSwitchCase`/`removeSwitchCase`, `setLoopBody`/`setLoopExit`/`setLoopConfig`, `moveNode`/`setViewport`/`selectNode`/`renameNode`/`updateNode`/`updateMeta`. Edges are always *derived* from the node graph (`deriveEdges`), never authored directly.
- **Serializer pair** — `serialize` (canvas → `Workflow` object + `ui.layout` + canonical YAML) and `hydrate`/`hydrateYaml` (saved workflow → canvas, with a longest-path **auto-layout** when `ui.layout` is absent).
- **A dependency-free YAML codec** scoped to the workflow shape. Chosen over the `yaml` package, which reaches for `node:process` (Metro would have to shim it); authoritative validation stays server-side via `validateDraft`, so the codec only round-trips the builder's own output + canonical host YAML.
- **Validation + save bridges** — map flat `workflows.validateDraft` issue strings back onto the offending node ids (`mapErrorsToNodes`), with a `__workflow__` catch-all bucket.

### 2. The loop node's two-region visual model
A `loop` node has **two connection regions**:
1. **BODY** — the steps that run inside the loop each iteration (toggled in the inspector, rendered as dashed `body` edges). `setLoopBody` keeps each body step's `needs: [loop]` so the executor scopes it correctly.
2. **EXIT** — a *single* edge to the next step, taken when the condition is met **or** a body step errors, labeled **"on done / error → next"**. Modeled as the body-excluded step that `needs` the loop, so there's always exactly one exit and the on-disk schema is unchanged.

The condition is the loop's EXIT/GOAL prompt (met → stop), matching the engine's semantics. Round-trips through serialize↔hydrate.

### 3. Desktop canvas (`apps/desktop/src/workflows/`)
`WorkflowsPanel` is now a **list↔builder switcher** (keeps enable/disable + run-now + last-run, adds per-row **Edit** + **New**). The builder is a **hand-rolled SVG drag-canvas** — no react-flow/@xyflow, because the graph is ≤40 nodes so a graph lib's bundle cost wasn't justified. It has: color-coded node cards per kind, derived `needs`/branch/loop edges with labels, draggable nodes that persist x/y to `ui.layout`, a node inspector (edits each kind's action fields incl. the loop's body/exit/condition/maxIterations), an add-node palette, live `validateDraft` decoration on the offending node, and Save (`validateDraft`→`save`).

### 4. Mobile editor (`apps/mobile/`)
New `app/workflow-edit.tsx` + `WorkflowEditor` + `useWorkflowEditor`, over the same shared model and the mobile frame bridge (new `buildWorkflowValidateFrame`/`buildWorkflowSaveFrame`/`buildWorkflowDetailFrame`, wired to the `MobileSessionHost` handlers the engine added). The list screen gains Edit/New navigation.

**v1 descope:** the mobile builder is an **outline editor** (a node list with the same operations, incl. the loop's body/exit/condition), *not* a touch-drag canvas — touch-dragging a node graph was disproportionate for v1. Revisit with `react-native-svg` + gesture-handler if a graphical mobile canvas is wanted.

### 5. Shared IPC glue (validate/save flow)
`client-core` gains `useWorkflowBuilder` (DOM-free): it owns the reducer, loads via `workflows.getRun`, debounces a live `workflows.validateDraft` on edits (mapping issues onto nodes), and persists via `workflows.save` — all over the injected transport (the Electron preload bridge on desktop, the WebSocket bridge on mobile). Confirmed end-to-end: validateDraft/save reach the CLI `WorkflowsView` / `MobileSessionHost` handlers the engine added.

## What's shared vs platform-specific
- **Shared (`@moxxy/workflows-builder` + `client-core` hook):** all state, all graph logic, serialize/hydrate, YAML, validation mapping, the loop body/exit model, the validate/save bridge.
- **Platform-specific:** rendering + interaction only — desktop's SVG canvas/inspector/palette, mobile's outline cards.

## Tests
- `@moxxy/workflows-builder`: **32** (operations, serialize↔hydrate round-trip incl. loop body+exit+branches+layout, validation-error mapping, loop body/exit modeling, YAML codec edge cases).
- `client-core` `useWorkflowBuilder`: **4** (load, validate-on-edit + node mapping, save-when-valid, refuse-when-invalid).
- desktop panel: **7** (list renders, New/Edit open builder, palette add, inspector field edit, loop body assignment, save calls IPC, validation error shown).
- mobile: clientFrames builder frames + a pure-logic editor test (nav href + loop-workflow YAML shape).

## Gate
`pnpm build` ✅ · `pnpm -w typecheck` ✅ · `pnpm -w test` ✅ · `pnpm -w lint` ✅ (0 errors) · `pnpm check:deps` ✅ · `pnpm --filter @moxxy/desktop typecheck` ✅ · `EXPO_OFFLINE=1 expo export --platform ios` ✅ (1570 modules, Hermes bytecode — shared model bundles RN-clean).

Changeset + TECH_DEBT (#11 phase-2 done + the mobile-outline v1 descope) updated.

> Note: stacked on `feat/workflows-engine`. Once that merges, this rebases onto main and the diff resolves to just the GUI work.