### PR TITLE
fix(desktop): mobile gateway — deny-by-default remote command allow-list + gateway hardening

### DIFF
--- a/.changeset/desktop-gateway-allowlist.md
+++ b/.changeset/desktop-gateway-allowlist.md
@@ -1,0 +1,23 @@
+---
+"@moxxy/desktop-ipc-contract": minor
+"@moxxy/ipc-server-ws": patch
+"@moxxy/desktop-host": patch
+"@moxxy/desktop": patch
+"@moxxy/plugin-channel-mobile": patch
+---
+
+Desktop mobile gateway: deny-by-default remote command allow-list + gateway hardening.
+
+**Security fix (critical/high).** The runtime mobile gateway (Settings → Mobile, PR #141) wired the desktop's COMPLETE IPC handler set onto the WebSocket bus and bound the LAN wildcard. The only per-command filter for remote clients was a blocklist that omitted host-mutating commands — so a paired phone (or anyone on the LAN with the bearer token) could invoke `session.setAutoApprove` (disable the desktop's approval prompts, then run any tool unattended), `desks.create`/`rename`/`remove`, `onboarding.saveProviderKey`/`openExternal`, `app.updateCli`/`checkUpdate`/`updateDashboard`, vault/settings/prefs writes, and more — a privilege-escalation / RCE-adjacent hole.
+
+The model is now **allow-by-default-deny**. `@moxxy/desktop-ipc-contract` exports `REMOTE_ALLOWED_COMMANDS` — the single source of truth for the remote/mobile trust surface (the exact commands a paired chat client needs: session info/runTurn/abort/setMode/newSession/runCommand, transcribe, ask RESPOND, connection discovery/retry, the per-workspace transcript log, and `workflows.list`/`run`/`getRun`). `@moxxy/ipc-server-ws`'s `WebSocketCommandBus` rejects any command not on the list with a coded error, regardless of what handlers the host registered. The Electron (renderer) bus keeps full access — only the WS/remote bus is restricted. `REMOTE_DISALLOWED_COMMANDS` is kept (deprecated) for renderer affordance-gating but no longer drives enforcement.
+
+**Finding 2 (medium).** Workflow AUTHORING is host-only: `workflows.save`, `workflows.validateDraft`, and `workflows.setEnabled` are NOT on the remote allow-list — a paired phone cannot rewrite or re-enable the host's workflows. Read + run (`list`/`getRun`/`run`) stay allowed.
+
+**Finding 3 (medium, stability).** `MobileGatewayManager` start/stop/setEnabled/rotate/resume now serialize through a lifecycle lock, so a rapid off→on toggle (or a boot resume racing a user toggle) can't double-bind the port or leak a LAN-bound listener.
+
+**Finding 4 (medium).** Token rotation is now coherent with a pinned `MOXXY_WS_TOKEN`: rotation is a no-op-with-warning when the env token pins the credential (it can't be rotated from here without diverging the advertised connectUrl from the live accepted token), and `status()`/`connectUrl` always reflect the live accepted token.
+
+**Finding 5 (medium, security UX).** The Mobile tab warning now states plainly that the connection is unencrypted plain `ws://`, so anyone on the network can passively intercept the pairing token and all traffic without the QR — use only on trusted networks.
+
+The standalone `moxxy mobile` host (`@moxxy/plugin-channel-mobile`) is its own trust surface (it registers a curated single-session subset) and opts out of the contract allow-list via `new WebSocketCommandBus({ allowedCommands: null })`. The wave-5 hardening (Origin default-deny, bearer subprotocol auth, connection caps, slow-reader eviction) is unchanged and still applies on the runtime-gateway path.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -37,6 +37,36 @@ pass also **retired the plugins-admin CLI install-hardening + dedup items** (for
 
 ---
 
+## 2026-06-10 round-2 audit intake — mobile gateway
+
+A targeted round-2 audit of the runtime mobile gateway shipped by PR #141 (the
+Settings → Mobile tab). Numbered B1+ so the A-series cross-refs stay stable.
+Severity in brackets.
+
+- **B1 [critical/high, security regression] Desktop mobile gateway exposed the FULL host
+  IPC to remote clients** — ✅ FIXED (this PR): `registerIpcHandlers([electronBus, wsBus], …)`
+  wired the COMPLETE handler set onto the LAN-bound WebSocket bus, and the only remote filter
+  was a BLOCKLIST (`REMOTE_DISALLOWED_COMMANDS`) that omitted host-mutating commands — so a
+  paired phone (or anyone on the LAN with the bearer token) could call `session.setAutoApprove`
+  (disable approval prompts → run any tool unattended), `desks.create`/`rename`/`remove`,
+  `onboarding.saveProviderKey`/`openExternal`, `app.updateCli`/`checkUpdate`/`updateDashboard`,
+  vault/settings/prefs writes, and `mobileGateway.*` — a privilege-escalation / RCE-adjacent
+  hole. **Inverted to ALLOW-by-default-deny:** the contract now exports `REMOTE_ALLOWED_COMMANDS`
+  (the single source of truth for the remote/mobile trust surface — session info/runTurn/abort/
+  setMode/newSession/runCommand, transcribe, ask RESPOND, connection discovery/retry, the
+  per-workspace transcript log, and `workflows.list`/`run`/`getRun`), and `WebSocketCommandBus`
+  rejects anything not on it with a coded error regardless of registered handlers. The Electron
+  (renderer) bus keeps full access. The standalone `moxxy mobile` host self-curates and opts out
+  via `new WebSocketCommandBus({ allowedCommands: null })`. Also fixed in the same area:
+  workflow AUTHORING (`save`/`validateDraft`/`setEnabled`) is host-only (read/run only over the
+  wire); `MobileGatewayManager` start/stop/rotate/resume now serialize through a lifecycle lock
+  (no double-bind / leaked listener on a rapid off→on); token rotation is coherent with a pinned
+  `MOXXY_WS_TOKEN` (no-op + warn, status always reflects the live accepted token); and the Mobile
+  tab warning now states plainly the connection is unencrypted `ws://` and passively interceptable.
+  Tests: deny/allow allow-list matrix in `ipc-server-ws`, plus serialization + pinned-rotate
+  coherence in the desktop `ws-bridge` suite. The wave-5 hardening (Origin default-deny, bearer
+  subprotocol, connection caps) verified still applied on the runtime-gateway path.
+
 ## 2026-06-09 audit intake — confirmed findings awaiting fixes
 
 Every item below survived an adversarial verification pass (an independent agent

--- a/apps/desktop/electron/main/ws-bridge.test.ts
+++ b/apps/desktop/electron/main/ws-bridge.test.ts
@@ -94,16 +94,41 @@ describe('rotateWsBridgeToken', () => {
       rotateAuthToken: (next: string) => calls.push(next),
       clientCount: () => 0,
     };
-    const rotated = rotateWsBridgeToken(userData, fakeServer);
-    expect(rotated).not.toBe(original);
-    expect(calls).toEqual([rotated]);
+    const result = rotateWsBridgeToken(userData, fakeServer);
+    expect(result.rotated).toBe(true);
+    expect(result.pinned).toBe(false);
+    expect(result.token).not.toBe(original);
+    expect(calls).toEqual([result.token]);
     // The next resolve picks up the rotated secret.
-    expect(resolveWsBridgeConfig(userData)?.authToken).toBe(rotated);
+    expect(resolveWsBridgeConfig(userData)?.authToken).toBe(result.token);
   });
 
   it('works without a live server (persists only)', () => {
-    const rotated = rotateWsBridgeToken(userData, null);
-    expect(resolveWsBridgeConfig(userData)?.authToken).toBe(rotated);
+    const result = rotateWsBridgeToken(userData, null);
+    expect(result.rotated).toBe(true);
+    expect(resolveWsBridgeConfig(userData)?.authToken).toBe(result.token);
+  });
+
+  it('is a coherent no-op when MOXXY_WS_TOKEN pins the token', () => {
+    // An env-pinned token wins at every resolve, so rotating the FILE token
+    // would diverge the live server from the advertised connectUrl. Refuse it.
+    process.env.MOXXY_WS_TOKEN = 'pinned-env-token';
+    const calls: string[] = [];
+    const fakeServer = {
+      address: 'ws://127.0.0.1:1',
+      onConnection: () => undefined,
+      close: () => Promise.resolve(),
+      rotateAuthToken: (next: string) => calls.push(next),
+      clientCount: () => 0,
+    };
+    const result = rotateWsBridgeToken(userData, fakeServer);
+    expect(result.rotated).toBe(false);
+    expect(result.pinned).toBe(true);
+    // The reported token is the live (env) one, and the server was NOT re-keyed.
+    expect(result.token).toBe('pinned-env-token');
+    expect(calls).toEqual([]);
+    // The advertised token still matches what the server accepts.
+    expect(resolveWsBridgeConfig(userData)?.authToken).toBe('pinned-env-token');
   });
 });
 
@@ -263,6 +288,79 @@ describe('MobileGatewayManager', () => {
     await mgr.start();
     fake.setClients(2);
     expect(mgr.status().clientCount).toBe(2);
+  });
+
+  it('serializes concurrent start calls so the port binds exactly once', async () => {
+    // A slow start: the second concurrent call must wait for the first to settle
+    // rather than racing past the `if (this.server)` guard and binding twice.
+    let starts = 0;
+    let releaseFirst!: () => void;
+    const gate = new Promise<void>((r) => {
+      releaseFirst = r;
+    });
+    const fake = makeFakeServer();
+    const { rt, startCalls } = makeRuntime({
+      userData,
+      startSpy: () => fake.server,
+    });
+    // Wrap startWsBridge to delay the first resolve until we release the gate.
+    const original = rt.wsBridge!.startWsBridge as (b: unknown, o: unknown) => Promise<unknown>;
+    (rt.wsBridge as { startWsBridge: unknown }).startWsBridge = async (
+      bus: unknown,
+      o: unknown,
+    ) => {
+      starts += 1;
+      if (starts === 1) await gate;
+      return original(bus, o);
+    };
+    const mgr = new MobileGatewayManager(rt);
+
+    const first = mgr.start();
+    const second = mgr.start(); // queued behind the first
+    // Let the first proceed; the second resolves off the now-running server.
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    // Exactly one bind happened despite two concurrent starts.
+    expect(startCalls).toHaveLength(1);
+  });
+
+  it('serializes a rapid off→on toggle so it cannot leak a server', async () => {
+    const fake = makeFakeServer();
+    const { rt, startCalls, enabledRef } = makeRuntime({
+      userData,
+      startSpy: () => fake.server,
+      enabledRef: { value: true },
+    });
+    const mgr = new MobileGatewayManager(rt);
+    await mgr.setEnabled(true);
+
+    // Fire off→on back-to-back without awaiting between them.
+    const off = mgr.setEnabled(false);
+    const on = mgr.setEnabled(true);
+    await Promise.all([off, on]);
+
+    // The final state is ON, with one server tracked (no orphan), and the toggle
+    // ran to completion in order (start, stop, start).
+    expect(mgr.status().enabled).toBe(true);
+    expect(enabledRef.value).toBe(true);
+    expect(startCalls.length).toBe(2); // initial on + the re-on (off closes, no bind)
+  });
+
+  it('rotateToken is a coherent no-op when MOXXY_WS_TOKEN pins the token', async () => {
+    process.env.MOXXY_WS_TOKEN = 'pinned-token';
+    const fake = makeFakeServer();
+    const { rt } = makeRuntime({ userData, startSpy: () => fake.server });
+    const mgr = new MobileGatewayManager(rt);
+    const before = await mgr.start();
+    expect(before.token).toBe('pinned-token');
+
+    const after = await mgr.rotateToken();
+    // The live server is NOT re-keyed, and status keeps advertising the env token
+    // (so the connectUrl and the accepted token stay in lockstep).
+    expect(fake.rotations).toEqual([]);
+    expect(after.token).toBe('pinned-token');
+    expect(after.connectUrl).toBe(before.connectUrl);
   });
 });
 

--- a/apps/desktop/electron/main/ws-bridge.ts
+++ b/apps/desktop/electron/main/ws-bridge.ts
@@ -38,6 +38,15 @@ import type { MobileGatewayStatus } from '@moxxy/desktop-ipc-contract';
 const DEFAULT_PORT = 8765;
 const TOKEN_FILE = 'ws-token';
 
+/** True when `MOXXY_WS_TOKEN` pins the gateway token at its source. A pinned
+ *  token wins at every `resolveChannelToken` call, so it cannot be rotated from
+ *  here — the file-persisted token rotate path would re-key the live server to a
+ *  fresh secret while the advertised connectUrl still showed the env token,
+ *  bricking pairing (or vice versa). Rotation is a coherent no-op while pinned. */
+function envTokenPinned(): boolean {
+  return Boolean(process.env.MOXXY_WS_TOKEN?.trim());
+}
+
 /**
  * Returns the bridge options when the ENV bridge is enabled, or `null` when off.
  * Resolving this does NOT start a server — the caller registers handlers onto a
@@ -68,18 +77,37 @@ export function resolveWsBridgeConfig(userDataDir: string): WebSocketBridgeOptio
  * Rotate the bridge's pairing token: persist a fresh secret to the userData
  * token file and (when the bridge is running) re-key the live server, which
  * terminates every existing connection — a leaked token/QR stops working
- * immediately. Returns the new token so the host can re-display pairing info.
+ * immediately. Returns the rotation outcome so the host can re-display pairing
+ * info or surface why nothing changed.
  *
- * Note: if `MOXXY_WS_TOKEN` is set it takes precedence at next resolve — env
- * tokens must be rotated at their source.
+ * COHERENCE: if `MOXXY_WS_TOKEN` pins the token, the env source wins at every
+ * resolve, so rotating the FILE token here would diverge the live server's
+ * accepted token from the advertised one. We therefore refuse to rotate while
+ * pinned (a no-op with `pinned: true`) — the operator must rotate the env var at
+ * its source and restart. When NOT pinned, the file token is rotated and the
+ * live server is re-keyed in lockstep so the next `status()` advertises exactly
+ * the token the server now accepts.
  */
 export function rotateWsBridgeToken(
   userDataDir: string,
   server: WebSocketBridgeServer | null,
-): string {
+): { rotated: boolean; pinned: boolean; token: string } {
+  if (envTokenPinned()) {
+    // Can't rotate a pinned token — report the live (env) token unchanged.
+    const token = resolveChannelToken({
+      envVar: 'MOXXY_WS_TOKEN',
+      fileName: TOKEN_FILE,
+      dir: userDataDir,
+    });
+    console.warn(
+      '[moxxy] mobile gateway: cannot rotate the pairing token while MOXXY_WS_TOKEN is set — ' +
+        'rotate it at the env source and restart.',
+    );
+    return { rotated: false, pinned: true, token };
+  }
   const token = rotateChannelToken({ fileName: TOKEN_FILE, dir: userDataDir });
   server?.rotateAuthToken(token);
-  return token;
+  return { rotated: true, pinned: false, token };
 }
 
 /** Absolute path of the persisted bridge token file (for diagnostics). */
@@ -118,8 +146,31 @@ export class MobileGatewayManager {
   /** The host the bridge was bound to (wildcard for LAN exposure). */
   private boundHost: string | null = null;
   private boundPort: number | null = null;
+  /**
+   * Serializes every lifecycle mutation (start/stop/setEnabled/rotate/resume).
+   * Concurrent toggles from the Settings tab — a rapid off→on, or a resume
+   * racing a user toggle — would otherwise interleave their awaits: two `start`s
+   * could both pass the `if (this.server)` guard and double-bind the port, or a
+   * `stop` could null `this.server` out from under an in-flight `start`, leaking
+   * a LAN-bound listener nobody tracks. Chaining each op onto the previous one's
+   * settle makes the start/stop/rotate sequence atomic.
+   */
+  private lifecycle: Promise<unknown> = Promise.resolve();
 
   constructor(private readonly rt: BridgeRuntime) {}
+
+  /** Run `op` after every previously-queued lifecycle op settles, so the
+   *  start/stop/rotate sequence can't interleave. A throw rejects this call but
+   *  does not poison the chain (the next op still runs). */
+  private runExclusive<T>(op: () => Promise<T>): Promise<T> {
+    const run = this.lifecycle.then(op, op);
+    // Keep the chain alive regardless of this op's outcome.
+    this.lifecycle = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
 
   /** The current live server (if running) — exposed so the env-boot path can
    *  hand its already-started server in and so shutdown can close it. */
@@ -137,21 +188,24 @@ export class MobileGatewayManager {
   /**
    * Re-start the gateway on boot iff the persisted preference says it was on.
    * Best-effort: a start failure is swallowed (logged) so a transient port
-   * clash can't brick boot — the user can re-toggle from Settings.
+   * clash can't brick boot — the user can re-toggle from Settings. Serialized
+   * with start/stop/rotate so a user toggle that races boot can't double-bind.
    */
   async resume(): Promise<void> {
-    let enabled = false;
-    try {
-      enabled = await this.rt.readEnabledPref();
-    } catch {
-      enabled = false;
-    }
-    if (!enabled || this.server) return;
-    try {
-      await this.start();
-    } catch (e) {
-      console.error('[moxxy] mobile gateway: failed to resume on boot:', e);
-    }
+    await this.runExclusive(async () => {
+      let enabled = false;
+      try {
+        enabled = await this.rt.readEnabledPref();
+      } catch {
+        enabled = false;
+      }
+      if (!enabled || this.server) return;
+      try {
+        await this.startLocked();
+      } catch (e) {
+        console.error('[moxxy] mobile gateway: failed to resume on boot:', e);
+      }
+    });
   }
 
   /** Build the status snapshot. Reads the persisted token (the same secret a
@@ -183,8 +237,14 @@ export class MobileGatewayManager {
     return typeof count === 'number' ? { ...status, clientCount: count } : status;
   }
 
-  /** Start the bridge (idempotent — returns the current status if already up). */
+  /** Start the bridge (idempotent — returns the current status if already up).
+   *  Serialized so concurrent toggles can't double-bind the port. */
   async start(): Promise<MobileGatewayStatus> {
+    return this.runExclusive(() => this.startLocked());
+  }
+
+  /** Start implementation — runs only while the lifecycle lock is held. */
+  private async startLocked(): Promise<MobileGatewayStatus> {
     if (this.server) return this.status();
     if (!this.rt.wsBridge || !this.rt.wsBus) {
       throw new Error('the WebSocket bridge module is unavailable in this build');
@@ -216,8 +276,15 @@ export class MobileGatewayManager {
     return this.status();
   }
 
-  /** Stop the bridge: close the listener + terminate every connected client. */
+  /** Stop the bridge: close the listener + terminate every connected client.
+   *  Serialized so a stop can't null the server out from under an in-flight
+   *  start (and vice versa). */
   async stop(): Promise<MobileGatewayStatus> {
+    return this.runExclusive(() => this.stopLocked());
+  }
+
+  /** Stop implementation — runs only while the lifecycle lock is held. */
+  private async stopLocked(): Promise<MobileGatewayStatus> {
     const server = this.server;
     this.server = null;
     this.boundHost = null;
@@ -232,25 +299,34 @@ export class MobileGatewayManager {
     return this.status();
   }
 
-  /** Toggle on/off, persist the preference, and notify the renderer. */
+  /** Toggle on/off, persist the preference, and notify the renderer. The whole
+   *  toggle (start/stop + persist) runs under one lifecycle turn, so a rapid
+   *  off→on can't race the bind. */
   async setEnabled(enabled: boolean): Promise<MobileGatewayStatus> {
-    const status = enabled ? await this.start() : await this.stop();
-    try {
-      await this.rt.writeEnabledPref(enabled);
-    } catch (e) {
-      console.error('[moxxy] mobile gateway: failed to persist preference:', e);
-    }
-    this.rt.onChange(status);
-    return status;
+    return this.runExclusive(async () => {
+      const status = enabled ? await this.startLocked() : await this.stopLocked();
+      try {
+        await this.rt.writeEnabledPref(enabled);
+      } catch (e) {
+        console.error('[moxxy] mobile gateway: failed to persist preference:', e);
+      }
+      this.rt.onChange(status);
+      return status;
+    });
   }
 
-  /** Rotate the pairing token (no-op when off), persist + re-key the live
-   *  server (terminating existing clients), and notify the renderer. */
+  /** Rotate the pairing token (no-op when off or when MOXXY_WS_TOKEN pins it),
+   *  re-key the live server (terminating existing clients), and notify the
+   *  renderer. Serialized so a rotate can't race a concurrent stop/start. */
   async rotateToken(): Promise<MobileGatewayStatus> {
-    if (!this.server) return this.status();
-    rotateWsBridgeToken(this.rt.userDataDir, this.server);
-    const status = this.status();
-    this.rt.onChange(status);
-    return status;
+    return this.runExclusive(async () => {
+      if (!this.server) return this.status();
+      // Rotation is coherent with an env-pinned token (no-op + warn) — see
+      // rotateWsBridgeToken. status() reads the LIVE accepted token either way.
+      rotateWsBridgeToken(this.rt.userDataDir, this.server);
+      const status = this.status();
+      this.rt.onChange(status);
+      return status;
+    });
   }
 }

--- a/apps/desktop/src/settings/MobileTab.test.tsx
+++ b/apps/desktop/src/settings/MobileTab.test.tsx
@@ -102,9 +102,12 @@ describe('MobileTab', () => {
     expect(screen.getByTestId('mobile-connect-url').textContent).toBe(
       'ws://192.168.1.7:8765/?t=s3cret',
     );
-    // The honest, prominent security warning must be present.
+    // The honest, prominent security warning must be present — and it must be
+    // explicit that the connection is unencrypted and passively interceptable.
     const warning = screen.getByTestId('mobile-lan-warning');
     expect(warning.textContent).toMatch(/exposes your desktop on the local network/i);
+    expect(warning.textContent).toMatch(/unencrypted/i);
+    expect(warning.textContent).toMatch(/intercept/i);
     // Connected-client count surfaces.
     expect(screen.getByText(/1 device connected/i)).toBeTruthy();
   });

--- a/apps/desktop/src/settings/MobileTab.tsx
+++ b/apps/desktop/src/settings/MobileTab.tsx
@@ -165,10 +165,13 @@ export function MobileTab(): JSX.Element {
           >
             <Icon name="lock" size={15} style={{ marginTop: 1, flexShrink: 0 }} />
             <span>
-              <strong>This exposes your desktop on the local network.</strong> Anyone on your Wi-Fi
-              who has this QR code or token can drive moxxy on this machine — send prompts, run
-              tools, read your workspaces. Only pair devices you trust, and turn the gateway off
-              when you are done. Use <em>Regenerate code</em> if a token may have leaked.
+              <strong>This exposes your desktop on the local network over an unencrypted
+              connection.</strong> Traffic uses plain <code>ws://</code> (no TLS), so anyone on the
+              same network can passively intercept the pairing token and everything you send and
+              receive — they do not even need the QR code to do it. Once they have the token they
+              can drive moxxy on this machine: send prompts, run tools, read your workspaces. Only
+              enable this on networks you trust, turn the gateway off when you are done, and use{' '}
+              <em>Regenerate code</em> if a token may have leaked.
             </span>
           </div>
         )}

--- a/packages/desktop-host/src/ipc/mobile-gateway.ts
+++ b/packages/desktop-host/src/ipc/mobile-gateway.ts
@@ -8,10 +8,11 @@
  * Electron `app` + userData paths. The main injects a {@link MobileGatewayController}
  * into `registerIpcHandlers`; these handlers just forward to it.
  *
- * Security: these COMMANDS control the gateway, so they are host-only — listed
- * in `REMOTE_DISALLOWED_COMMANDS`, the WS bus refuses them. A remote client can
- * never toggle the gateway, read the pairing token, or rotate it over the very
- * transport that token guards.
+ * Security: these COMMANDS control the gateway, so they are host-only. The WS
+ * bus is deny-by-default — it accepts ONLY the commands in the contract's
+ * `REMOTE_ALLOWED_COMMANDS` (the mobile trust surface), and `mobileGateway.*` is
+ * deliberately not among them, so a remote client can never toggle the gateway,
+ * read the pairing token, or rotate it over the very transport that token guards.
  */
 
 import type { MobileGatewayStatus } from '@moxxy/desktop-ipc-contract';

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -754,10 +754,10 @@ export interface IpcCommands {
   'settings.deleteSkill': (args: { name: string }) => Promise<void>;
 
   // ---- Mobile gateway (WebSocket bridge) --------------------------------
-  // These CONTROL the bridge, so they are host-only — see
-  // REMOTE_DISALLOWED_COMMANDS — a remote (WS) client must never be able to
-  // toggle the gateway or read/rotate the pairing token over the very transport
-  // the token guards.
+  // These CONTROL the bridge, so they are host-only. The WS bus is
+  // deny-by-default (see REMOTE_ALLOWED_COMMANDS) and these are NOT on the
+  // allow-list — a remote (WS) client must never be able to toggle the gateway
+  // or read/rotate the pairing token over the very transport the token guards.
   /** Current gateway status (enabled, advertised host+port, connectUrl/QR
    *  payload, token, connected-client count). */
   'mobileGateway.status': () => Promise<MobileGatewayStatus>;
@@ -775,12 +775,78 @@ export interface IpcCommands {
 export type IpcCommandName = keyof IpcCommands;
 
 /**
- * Commands that only make sense on the machine running the host and must be
- * refused over a remote (WebSocket) transport: native OS dialogs that would pop
- * on the host rather than the remote client, focus-widget window control, and
- * the app relaunch. The WebSocket bus rejects these with a coded error; a remote
- * client can read this set to gray out the corresponding affordances. (Remote
- * clients attach files via `session.saveImageAttachment` instead of a picker.)
+ * THE REMOTE / MOBILE TRUST SURFACE — the single source of truth for what a
+ * paired phone (or anything else on the LAN holding the bearer token) may invoke
+ * over the WebSocket bridge. This is an ALLOW-list, enforced deny-by-default: the
+ * WS bus REJECTS any command not listed here with a coded error, regardless of
+ * which handlers the host happened to register on the bus.
+ *
+ * Why an allow-list and not a blocklist: the desktop wires its COMPLETE IPC
+ * handler set onto the WS bus (`registerIpcHandlers([electronBus, wsBus], …)`),
+ * and the runtime "mobile gateway" binds the LAN wildcard. A blocklist that
+ * merely omitted a host-mutating command (toggling auto-approve, creating desks,
+ * writing the vault, updating the CLI, …) silently exposed it to a remote client
+ * — a privilege-escalation / RCE-adjacent hole. Inverting to allow-by-default-
+ * deny means a NEW command is locked out by default; you opt it in here only
+ * after deciding a paired phone should be able to drive it.
+ *
+ * The list is exactly the commands a chat client legitimately needs to hold a
+ * conversation: read the session snapshot, send/abort a turn, switch mode, run a
+ * slash command, reset the conversation, transcribe voice, ANSWER (not bypass)
+ * permission prompts, persist the per-workspace transcript, and list/run/read an
+ * EXISTING workflow. Everything else — auto-approve toggling, desk/onboarding/
+ * settings/vault/app/prefs writes, workflow AUTHORING (save/validateDraft/
+ * setEnabled), native pickers, focus-window control, and the gateway-control
+ * commands themselves (`mobileGateway.*`) — stays Electron-bus-only (the trusted
+ * local UI) and is refused over the wire.
+ *
+ * RULE: add a command here ONLY if a paired phone should be able to invoke it.
+ * If it mutates host state beyond the conversation, it almost certainly does not
+ * belong.
+ */
+export const REMOTE_ALLOWED_COMMANDS: ReadonlySet<IpcCommandName> = new Set<IpcCommandName>([
+  // Answer a permission/approval prompt — RESPOND only. Note that
+  // `session.setAutoApprove` (turn the prompt OFF entirely) is deliberately NOT
+  // here: a remote client may answer the desktop user's prompts, never disable
+  // them and run tools unattended.
+  'ask.respond',
+  // Workspace discovery + reconnect (read-only / non-mutating).
+  'connection.snapshotAll',
+  'connection.activeWorkspace',
+  'connection.retry',
+  // The conversation itself.
+  'session.info',
+  'session.runTurn',
+  'session.abortTurn',
+  'session.setMode',
+  'session.newSession',
+  'session.runCommand',
+  // Voice input (capability-probed; transcribe fails coded without a transcriber).
+  'session.hasTranscriber',
+  'session.transcribe',
+  // Per-workspace transcript log (the mobile ChatStoreBridge persists through
+  // these; they're scoped to a workspace's NDJSON log, not host config).
+  'chat.append',
+  'chat.loadSegment',
+  'chat.clearLog',
+  'chat.migrate',
+  // Workflows: READ + run an existing one only. Authoring (`workflows.save`,
+  // `workflows.validateDraft`, `workflows.setEnabled`) is host-only — a paired
+  // phone must not rewrite or re-enable the host's workflows.
+  'workflows.list',
+  'workflows.run',
+  'workflows.getRun',
+]);
+
+/**
+ * @deprecated Use {@link REMOTE_ALLOWED_COMMANDS} — enforcement is now
+ * allow-by-default-deny, not blocklist-based. Retained for UI affordance-gating:
+ * a renderer can still read this to gray out the host-only controls it shows. It
+ * is the set of commands the desktop renderer surfaces that are NOT in the remote
+ * allow-list (the native pickers, focus-window control, app relaunch, and the
+ * gateway-control commands), so its prior consumers keep working. The WS bus no
+ * longer consults it — anything outside {@link REMOTE_ALLOWED_COMMANDS} is
+ * refused, this set or not.
  */
 export const REMOTE_DISALLOWED_COMMANDS: ReadonlySet<IpcCommandName> = new Set<IpcCommandName>([
   'desks.pickFolder',

--- a/packages/ipc-server-ws/src/ws-command-bus.test.ts
+++ b/packages/ipc-server-ws/src/ws-command-bus.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { JsonRpcPeer, RpcError, type Transport } from '@moxxy/runner';
+import type { IpcCommandName } from '@moxxy/desktop-ipc-contract';
 import { IpcError } from '@moxxy/desktop-ipc-contract/dispatch';
 import { WebSocketCommandBus } from './ws-command-bus.js';
 
@@ -64,6 +65,93 @@ describe('WebSocketCommandBus', () => {
     expect(ran).toBe(false);
     expect(err).toBeInstanceOf(RpcError);
     expect((err as RpcError).data).toMatchObject({ code: 'runner-error' });
+  });
+
+  describe('deny-by-default remote allow-list', () => {
+    /** The host-mutating commands a paired phone (or a LAN attacker with the
+     *  token) must NEVER reach over the WS bridge — even though the desktop wires
+     *  ALL of them onto the same bus as the chat commands. */
+    const HOST_MUTATING: ReadonlyArray<IpcCommandName> = [
+      'session.setAutoApprove',
+      'desks.create',
+      'desks.rename',
+      'desks.remove',
+      'onboarding.saveProviderKey',
+      'onboarding.openExternal',
+      'app.updateCli',
+      'app.checkUpdate',
+      'app.updateDashboard',
+      'settings.vaultSet',
+      'settings.vaultDelete',
+      'prefs.update',
+      // Workflow AUTHORING (write) + re-enable — read/run stays allowed.
+      'workflows.save',
+      'workflows.validateDraft',
+      'workflows.setEnabled',
+      // The gateway-control commands themselves.
+      'mobileGateway.status',
+      'mobileGateway.setEnabled',
+      'mobileGateway.rotateToken',
+    ];
+
+    it.each(HOST_MUTATING)('REJECTS host-mutating command %s on the WS bus', async (command) => {
+      const bus = new WebSocketCommandBus();
+      let ran = false;
+      // Register the handler exactly as the desktop's registerIpcHandlers would.
+      bus.handle(command, (async () => {
+        ran = true;
+      }) as never);
+      const [server, client] = makeTransportPair();
+      bus.attach(server);
+      const peer = new JsonRpcPeer(client);
+      const err = await peer.request(command, {}).then(
+        () => null,
+        (e: unknown) => e,
+      );
+      expect(ran).toBe(false);
+      expect(err).toBeInstanceOf(RpcError);
+      expect((err as RpcError).data).toMatchObject({ code: 'runner-error' });
+      expect((err as RpcError).message).toMatch(/not available over a remote transport/);
+    });
+
+    /** The legitimate chat-driving commands a paired phone DOES need, paired
+     *  with a VALID payload so the shared dispatch-core schema validation passes
+     *  and we exercise the allow gate, not the validator. */
+    const LEGIT_CHAT: ReadonlyArray<[IpcCommandName, unknown]> = [
+      ['ask.respond', { requestId: 'r1', response: { mode: 'allow' } }],
+      ['session.info', { workspaceId: 'ws-1' }],
+      ['session.runTurn', { workspaceId: 'ws-1', prompt: 'hi' }],
+      ['session.abortTurn', { workspaceId: 'ws-1', turnId: 't1' }],
+      ['session.setMode', { workspaceId: 'ws-1', mode: 'default' }],
+      ['session.newSession', { workspaceId: 'ws-1' }],
+      ['session.runCommand', { workspaceId: 'ws-1', name: 'compact', args: '' }],
+      ['session.transcribe', { audioBase64: 'AA==' }],
+      ['connection.snapshotAll', undefined],
+      ['chat.append', { workspaceId: 'ws-1', events: [] }],
+      ['chat.loadSegment', { workspaceId: 'ws-1', before: null, limit: 50 }],
+      ['workflows.list', undefined],
+      ['workflows.run', { name: 'wf-1' }],
+      ['workflows.getRun', { name: 'wf-1' }],
+    ];
+
+    it.each(LEGIT_CHAT)('ALLOWS legit chat command %s on the WS bus', async (command, payload) => {
+      const bus = new WebSocketCommandBus();
+      bus.handle(command, (async () => 'ok') as never);
+      const [server, client] = makeTransportPair();
+      bus.attach(server);
+      const peer = new JsonRpcPeer(client);
+      await expect(peer.request(command, payload)).resolves.toBe('ok');
+    });
+
+    it('a self-curating host (allowedCommands: null) skips the allow-list', async () => {
+      // The standalone `moxxy mobile` MobileSessionHost is its own trust surface.
+      const bus = new WebSocketCommandBus({ allowedCommands: null });
+      bus.handle('session.setAutoApprove', (async () => undefined) as never);
+      const [server, client] = makeTransportPair();
+      bus.attach(server);
+      const peer = new JsonRpcPeer(client);
+      await expect(peer.request('session.setAutoApprove', { enabled: true })).resolves.toBeNull();
+    });
   });
 
   it('broadcasts events as notifications to every open peer', async () => {

--- a/packages/ipc-server-ws/src/ws-command-bus.ts
+++ b/packages/ipc-server-ws/src/ws-command-bus.ts
@@ -22,15 +22,41 @@ import type {
   IpcCommands,
   IpcEvents,
 } from '@moxxy/desktop-ipc-contract';
-import { REMOTE_DISALLOWED_COMMANDS } from '@moxxy/desktop-ipc-contract';
+import { REMOTE_ALLOWED_COMMANDS } from '@moxxy/desktop-ipc-contract';
 import type { CommandBus, EventSink } from '@moxxy/desktop-ipc-contract/bus';
 import { dispatch } from '@moxxy/desktop-ipc-contract/dispatch';
 
 type RegisteredHandler = (...args: never[]) => Promise<unknown>;
 
+/** Options for {@link WebSocketCommandBus}. */
+export interface WebSocketCommandBusOptions {
+  /**
+   * The allow-list of commands accepted over this remote transport. Defaults to
+   * the contract's {@link REMOTE_ALLOWED_COMMANDS} — the desktop gateway wires
+   * its COMPLETE IPC handler set onto the WS bus, so the allow-list is the only
+   * thing standing between a paired phone and the host-mutating commands; it
+   * must stay deny-by-default.
+   *
+   * Pass an explicit set ONLY for a host that already exposes a deliberately
+   * curated subset on this bus (e.g. the standalone `moxxy mobile`
+   * `MobileSessionHost`, which registers exactly one single-session command set
+   * and so is its own trust surface). `null` disables the allow-list entirely —
+   * reserved for the same self-curating-host case; never use it for a bus the
+   * full desktop IPC handler set is registered on.
+   */
+  readonly allowedCommands?: ReadonlySet<IpcCommandName> | null;
+}
+
 export class WebSocketCommandBus implements CommandBus, EventSink {
   private readonly methods = new Map<IpcCommandName, RegisteredHandler>();
   private readonly peers = new Set<JsonRpcPeer>();
+  /** Deny-by-default allow-list (null ⇒ no filter; see the constructor). */
+  private readonly allowedCommands: ReadonlySet<IpcCommandName> | null;
+
+  constructor(opts: WebSocketCommandBusOptions = {}) {
+    this.allowedCommands =
+      opts.allowedCommands === undefined ? REMOTE_ALLOWED_COMMANDS : opts.allowedCommands;
+  }
 
   handle<K extends IpcCommandName>(
     channel: K,
@@ -50,7 +76,12 @@ export class WebSocketCommandBus implements CommandBus, EventSink {
     const peer = new JsonRpcPeer(transport);
     for (const [channel, fn] of this.methods) {
       peer.handle(channel, async (params) => {
-        if (REMOTE_DISALLOWED_COMMANDS.has(channel)) {
+        // Deny-by-default: a command the host registered on this bus is still
+        // refused unless it is on the remote allow-list (the mobile trust
+        // surface). This is the gate that stops a paired phone — or anyone on
+        // the LAN with the bearer token — from reaching a host-mutating command
+        // the desktop happened to wire onto the same bus as the chat commands.
+        if (this.allowedCommands && !this.allowedCommands.has(channel)) {
           const message = `command "${channel}" is not available over a remote transport`;
           throw new RpcError(message, { code: 'runner-error', message });
         }

--- a/packages/plugin-channel-mobile/src/channel.ts
+++ b/packages/plugin-channel-mobile/src/channel.ts
@@ -97,7 +97,13 @@ export class MobileChannel implements Channel<MobileStartOpts> {
   }
 
   async start(startOpts: MobileStartOpts): Promise<ChannelHandle> {
-    const bus = new WebSocketCommandBus();
+    // The standalone `moxxy mobile` host is its OWN trust surface: it registers
+    // exactly the curated single-session subset a mobile client drives (see
+    // `MobileSessionHost.register`) and nothing else, so the bus's deny-by-
+    // default remote allow-list (which targets the DESKTOP gateway, where the
+    // full host IPC handler set is on the bus) would only over-restrict it.
+    // `allowedCommands: null` keeps that curated subset authoritative here.
+    const bus = new WebSocketCommandBus({ allowedCommands: null });
     const host = new MobileSessionHost(bus, startOpts.session);
     this.host = host;
     host.register(); // populate the method map BEFORE accepting connections


### PR DESCRIPTION
## The hole (critical/high — privilege escalation, RCE-adjacent)

The runtime mobile gateway shipped by **#141** (Settings → Mobile) wired the desktop's **complete** IPC handler set onto the WebSocket bus:

```ts
registerIpcHandlers(wsBus ? [electronBus, wsBus] : [electronBus], pool, desks, …)
```

…and the gateway binds the LAN wildcard (`MOXXY_WS_HOST?.trim() || '0.0.0.0'`). The **only** per-command filter for remote/WS clients was `REMOTE_DISALLOWED_COMMANDS` — a **blocklist** that omitted every host-mutating command. So a paired phone, or **anyone on the LAN with the bearer token**, could invoke:

- `session.setAutoApprove` → turn off the desktop user's approval prompts, then run **any tool unprompted**
- `desks.create` / `desks.rename` / `desks.remove`
- `onboarding.saveProviderKey`, `onboarding.openExternal`
- `app.updateCli` / `app.checkUpdate` / `app.updateDashboard`
- `settings.vaultSet` / `settings.vaultDelete` / `prefs.update`, …

A network-reachable privilege-escalation / RCE-adjacent surface.

## The fix — invert to allow-by-default-deny

`@moxxy/desktop-ipc-contract` now exports **`REMOTE_ALLOWED_COMMANDS`**, the single source of truth for the remote/mobile trust surface. `@moxxy/ipc-server-ws`'s `WebSocketCommandBus` **rejects any command not on the list** with a coded error, regardless of which handlers the host registered. The Electron (renderer) bus keeps full access — only the WS/remote bus is restricted.

**Allowed remotely** (exactly what a paired chat client needs to drive a conversation — derived from `MobileSessionHost.register()` + the mobile app / client-core call sites):

`ask.respond` · `connection.snapshotAll` · `connection.activeWorkspace` · `connection.retry` · `session.info` · `session.runTurn` · `session.abortTurn` · `session.setMode` · `session.newSession` · `session.runCommand` · `session.hasTranscriber` · `session.transcribe` · `chat.append` · `chat.loadSegment` · `chat.clearLog` · `chat.migrate` · `workflows.list` · `workflows.run` · `workflows.getRun`

**Now rejected over the wire** (host-only — stays Electron-bus-only): `session.setAutoApprove` (a remote client may *answer* prompts, never disable them), all `desks.*`, `onboarding.*`, `app.*`, `settings.*`/vault, `prefs.*`, `focus.*`, `workspace.listDir`, the native pickers, and `mobileGateway.*` (the gateway-control commands themselves).

`REMOTE_DISALLOWED_COMMANDS` is kept (deprecated) for renderer affordance-gating but no longer drives enforcement. The standalone `moxxy mobile` host (`@moxxy/plugin-channel-mobile`) is its own trust surface — it registers a curated single-session subset and opts out via `new WebSocketCommandBus({ allowedCommands: null })`, so it isn't regressed.

## Findings 2–5

- **2 (medium).** Workflow **authoring** is host-only: `workflows.save`, `workflows.validateDraft`, and `workflows.setEnabled` are NOT on the allow-list — a paired phone can't rewrite or re-enable the host's workflows. Read + run only.
- **3 (medium, stability).** `MobileGatewayManager` start/stop/setEnabled/rotate/resume serialize through a lifecycle lock — a rapid off→on (or a boot resume racing a user toggle) can't double-bind the port or leak a LAN-bound listener.
- **4 (medium).** Token rotation is coherent with a pinned `MOXXY_WS_TOKEN`: a no-op-with-warning when the env token pins the credential, and `status()`/`connectUrl` always reflect the **live accepted** token (previously rotation re-keyed the server while the advertised QR still showed the env token — bricked pairing).
- **5 (medium, security UX).** The Mobile tab warning now states plainly that the connection is **unencrypted plain `ws://`**, so anyone on the network can passively intercept the token + all traffic **without** the QR — trusted networks only.

## Verification

Wave-5 hardening (Origin default-deny, bearer subprotocol, connection caps, slow-reader eviction) is unchanged and verified still applied on the runtime-gateway path.

Tests added:
- `ipc-server-ws/src/ws-command-bus.test.ts` — deny/allow matrix: 18 host-mutating commands (incl. `setAutoApprove`, `desks.create`, `onboarding.saveProviderKey`, `app.updateCli`, `workflows.save/validateDraft/setEnabled`, `mobileGateway.*`) REJECTED; 14 legit chat commands ALLOWED (with valid payloads); plus the `allowedCommands: null` self-curating-host path.
- `apps/desktop/electron/main/ws-bridge.test.ts` — start serialization, rapid off→on toggle, and pinned-`MOXXY_WS_TOKEN` rotate coherence (manager + helper level).
- `apps/desktop/src/settings/MobileTab.test.tsx` — asserts the warning is explicit about *unencrypted* + *intercept*.

Gate (all exit 0): `pnpm build` · `pnpm -w typecheck` · `pnpm -w test` · `pnpm -w lint` (0 errors) · `pnpm check:deps` · `pnpm --filter @moxxy/desktop typecheck`.

Changeset: `@moxxy/desktop-ipc-contract` minor (allow-list is a contract change) + `ipc-server-ws`/`desktop-host`/`@moxxy/desktop`/`plugin-channel-mobile` patches. TECH_DEBT **B1** logged FIXED (round-2 audit intake).