### PR TITLE
fix(workflows): gate unshippable awaitInput resume, make builder IPC work on desktop, loop/validation correctness

### DIFF
--- a/.changeset/workflows-correctness.md
+++ b/.changeset/workflows-correctness.md
@@ -1,0 +1,19 @@
+---
+"@moxxy/plugin-workflows": patch
+"@moxxy/workflows-builder": patch
+"@moxxy/runner": patch
+"@moxxy/core": patch
+"@moxxy/sdk": patch
+"@moxxy/desktop-ipc-contract": patch
+"@moxxy/desktop-host": patch
+"@moxxy/client-core": patch
+"@moxxy/cli": patch
+---
+
+Workflows round-2 correctness: gate the unshippable `awaitInput` resume, make the visual builder work on the desktop, and fix loop/validation correctness.
+
+**`awaitInput` is gated (was a hang-forever dead-end).** The executor can pause + checkpoint an `awaitInput` step, but the resume trigger/channel that delivers the operator's reply never shipped to `main` — `resumeWorkflowRun` had zero production callers. So an agent-drafted "ask me, then act" workflow would pause forever, leak a retained child session for the process lifetime, and orphan a checkpoint file. `awaitInput` is now **rejected at validate/save time** with a clear "requires the resume channel, not available in this build" message, and `draft.ts` no longer teaches it (it steers the author to `inputs` fields instead). Defense-in-depth: the CLI runner treats a `paused` result as non-terminal (no inbox delivery), `Session.close()` clears retained child sessions so they can't leak, and a `WorkflowRunStore.sweepStale()` sweeper (7-day TTL, run on workflows boot) reaps orphaned `~/.moxxy/workflow-runs/active/` checkpoints. The executor pause/resume path is kept intact so re-enabling is a matter of landing a resume trigger and removing the schema gate.
+
+**Visual builder works on the desktop now.** The desktop drives a `RemoteSession`, whose workflows view only forwarded `list`/`setEnabled`/`run` — so the builder's `validateDraft`/`save`/`getRun` were `undefined` and threw "not supported on this session". Added a `workflow.validateDraft|save|getRun` runner-RPC family (**protocol bumped to v4**) with RemoteSession client methods + server handlers, so the desktop builder validates/saves/loads against the runner.
+
+**Loop + validation correctness.** A condition/switch step used as a loop body is rejected (its branch routing was silently ignored). A non-loop-body step that `needs` a loop-body step is rejected (it would stall — body steps are excluded from the main DAG). A loop-body step's own `when` guard and any `needs` other than its loop step / a sibling body step are rejected (body steps run unconditionally each iteration). Logic-step `vars` now drop `__proto__`/`constructor`/`prototype` keys (prototype-pollution guard). Paused-run checkpoints persist + restore `vars` set before the pause. Renaming a workflow via the builder removes the old file/entry instead of leaving an orphaned duplicate (`save(workflow, previousName)`, threaded through the view → IPC → runner RPC → builder hook).

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -636,13 +636,47 @@ graph) is intact; the two operate on different graphs and don't conflict.
   **v1 descope:** the mobile builder is an OUTLINE editor (a node list with the same
   operations), not a touch-drag canvas — touch dragging a node graph was disproportionate
   for v1; revisit with `react-native-svg` + gesture-handler if a graphical mobile canvas is
-  wanted. (b)
-  `awaitInput` is barred inside a `loop` body (would need mid-iteration checkpointing) — a
-  body prompt that sets it fails loudly; lift only if a use-case appears. (c) the
-  `RemoteSession` (TUI runner-RPC) leaves the three new builder methods undefined — wire
-  RunnerMethod RPCs if the TUI ever needs to validate/save drafts. (d) loop body steps are
-  excluded from the main DAG scheduler via a `loopBodyIds` set; if a future feature needs a
-  step to be both a loop body AND independently scheduled, that exclusion must be revisited.
+  wanted.
+- **Round-2 correctness pass (2026-06-10).** Eight audit findings fixed:
+  - **`awaitInput` is GATED, not shippable.** The executor pauses + checkpoints
+    (`run-store.ts` + `resumeWorkflowRun`), but the **resume trigger/channel that delivers
+    the operator's reply did NOT ship to main** — it lives only on the unmerged plugin-office
+    branch. `resumeWorkflowRun` has ZERO production callers. An earlier note here claimed the
+    operator "replies once in Virtual Office chat" — that was backed only by the unmerged
+    branch and was **wrong for main**. So `awaitInput` is now **rejected at validate/save
+    time** (`schema.ts`) with a clear "requires the resume channel, not available in this
+    build" message; `draft.ts` no longer teaches it (it steers to `inputs` instead). The
+    executor pause path is kept (in case a resume trigger lands) and tested via raw-workflow
+    builders that bypass the gate. Defense-in-depth: `runNow` (CLI) treats a `paused` result
+    as **non-terminal** (no inbox delivery); `Session.close()` now calls
+    `clearRetainedChildren()` so a paused run's retained child session can't leak for the
+    process lifetime; and `WorkflowRunStore.sweepStale()` (7-day TTL, run on workflows boot)
+    reaps orphaned `~/.moxxy/workflow-runs/active/<ulid>.json` checkpoints. **To re-enable
+    awaitInput:** land an in-tree resume trigger and remove the schema gate block.
+  - **Desktop builder IPC now works over the runner (was Finding 2 — real).** The desktop
+    drives a `RemoteSession`, whose workflows view only exposed `list/setEnabled/run` — so
+    `validateDraft`/`save`/`getRun` were `undefined` and the builder threw "not supported on
+    this session". Added a `workflow.validateDraft|save|getRun` RunnerMethod family
+    (**protocol bumped to v4**) + RemoteSession client methods + server handlers; the desktop
+    builder validates/saves/loads against the runner now. Tested in `runner/integration.test.ts`.
+  - **Loop-body validation (Findings 3/5/8):** a condition/switch step used as a loop body
+    is rejected (its branch routing was silently ignored); a NON-body step that `needs` a
+    loop-body step is rejected (it would stall — body steps are excluded from the main DAG);
+    a loop-body step's own `when` and any `needs` other than its loop step / a sibling body
+    step are rejected (body steps run unconditionally each iteration).
+  - **Checkpoint vars (Finding 4):** the checkpoint now persists+restores `vars` so a logic
+    step that ran before a pause isn't dropped on resume (moot under the gate, but correct if
+    resume lands).
+  - **Prototype-pollution guard (Finding 6):** model-provided logic-step `vars` skip
+    `__proto__`/`constructor`/`prototype` keys when merging.
+  - **Rename cleanup (Finding 7):** `WorkflowStore.save(workflow, previousName)` removes the
+    old file/entry on rename (threaded through `WorkflowsView.save` → desktop IPC → runner
+    RPC → builder hook), so renaming no longer leaves an orphaned duplicate.
+- **Remaining notes:** (a) loop body steps are excluded from the main DAG scheduler via a
+  `loopBodyIds` set; if a future feature needs a step to be both a loop body AND independently
+  scheduled, that exclusion must be revisited. (b) awaitInput is barred inside a loop body
+  (would need mid-iteration checkpointing) — orthogonal to the gate above; lift only if a
+  resume path AND a use-case appear.
 
 ---
 

--- a/packages/cli/src/setup/workflows.test.ts
+++ b/packages/cli/src/setup/workflows.test.ts
@@ -336,4 +336,54 @@ describe('buildWorkflowsIntegration afterWorkflow wiring', () => {
       stop();
     }
   });
+
+  it('does NOT deliver a paused (awaitInput) run to the inbox (Finding 1)', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-workflows-pause-'));
+    tempDirs.push(cwd);
+    process.env.HOME = cwd;
+    process.env.MOXXY_HOME = path.join(cwd, '.moxxy-home');
+
+    const projectDir = path.join(cwd, '.moxxy', 'workflows');
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.writeFile(
+      path.join(projectDir, 'paused-wf.yaml'),
+      ['name: paused-wf', 'description: test', 'steps:', '  - id: s1', '    prompt: hi', ''].join('\n'),
+    );
+
+    const session = new Session({ cwd, logger: silentLogger });
+    // A stub executor that returns a non-terminal `paused` result, mimicking a
+    // run parked on an awaitInput step awaiting resume.
+    session.workflowExecutors.register({
+      name: 'paused-stub',
+      run: async () => ({
+        ok: true,
+        status: 'paused',
+        steps: [],
+        output: 'question for the operator',
+        runId: 'RUN1',
+        pendingStepId: 's1',
+      }),
+    });
+    const integration = buildWorkflowsIntegration({ session, scheduleStore: new ScheduleStore({ file: path.join(cwd, 'sched.json') }) });
+    // onReady (which assigns session.workflows = view) fires on plugin onInit.
+    session.pluginHost.registerStatic(integration.plugin);
+    await session.dispatcher.dispatchInit(session.appContext());
+    try {
+      const result = await session.workflows!.run('paused-wf');
+      // The view maps the run result; a paused run must not look "ok+complete"
+      // with an inbox file behind it.
+      const inboxDir = path.join(process.env.MOXXY_HOME!, 'inbox');
+      let inboxFiles: string[] = [];
+      try {
+        inboxFiles = await fs.readdir(inboxDir);
+      } catch {
+        inboxFiles = [];
+      }
+      expect(inboxFiles).toEqual([]);
+      // The output still surfaces, but no inbox delivery happened.
+      expect(result.output).toContain('question for the operator');
+    } finally {
+      integration.stop();
+    }
+  });
 });

--- a/packages/cli/src/setup/workflows.ts
+++ b/packages/cli/src/setup/workflows.ts
@@ -19,6 +19,7 @@ import {
   WorkflowStore,
   buildWorkflowsPlugin,
   defaultUserWorkflowsDir,
+  defaultWorkflowRunStore,
   parseWorkflowYaml,
   runWorkflow,
   serializeWorkflow,
@@ -144,6 +145,18 @@ export function buildWorkflowsIntegration(args: {
         },
         { executor: session.workflowExecutors.getActive() },
       );
+      // A `paused` result is NOT terminal: the run is parked on an awaitInput
+      // step waiting for an operator reply (resume). Delivering it to the inbox
+      // would falsely present a half-done run as complete. Don't deliver, and
+      // surface the paused status to the caller. (In practice awaitInput is
+      // gated at validate/save time, so this is a defense-in-depth guard.)
+      if (result.status === 'paused') {
+        logger?.warn?.('workflows: run paused awaiting operator input; not delivering to inbox', {
+          workflow: input.name,
+          runId: result.runId,
+        });
+        return result;
+      }
       await deliverToInbox(entry.workflow, result, logger);
       return result;
     } finally {
@@ -182,12 +195,12 @@ export function buildWorkflowsIntegration(args: {
       const r = parseWorkflowYaml(yaml);
       return { ok: r.ok, errors: r.errors };
     },
-    save: async (yaml) => {
+    save: async (yaml, previousName) => {
       const parsed = parseWorkflowYaml(yaml);
       if (!parsed.ok || !parsed.workflow) {
         throw new Error(`invalid workflow YAML — ${parsed.errors.join('; ')}`);
       }
-      const saved = await store.save(parsed.workflow);
+      const saved = await store.save(parsed.workflow, previousName);
       await syncSchedules();
       return { name: saved.workflow.name, scope: saved.scope, path: saved.path };
     },
@@ -325,6 +338,19 @@ export function buildWorkflowsIntegration(args: {
       session.workflows = view;
       await syncSchedules();
       await startFileWatchers();
+      // Sweep orphaned paused-run checkpoints on boot (a paused run whose
+      // resume never arrived — e.g. before awaitInput was gated, or after a
+      // crash — leaks a `<ulid>.json` under ~/.moxxy/workflow-runs/active/).
+      void defaultWorkflowRunStore
+        .sweepStale()
+        .then((n) => {
+          if (n > 0) logger?.info?.('workflows: swept stale paused-run checkpoints', { count: n });
+        })
+        .catch((err) =>
+          logger?.warn?.('workflows: checkpoint sweep failed', {
+            err: err instanceof Error ? err.message : String(err),
+          }),
+        );
     },
   });
 

--- a/packages/client-core/src/useWorkflowBuilder.test.tsx
+++ b/packages/client-core/src/useWorkflowBuilder.test.tsx
@@ -78,6 +78,50 @@ describe('useWorkflowBuilder', () => {
     expect(invoke).toHaveBeenCalledWith('workflows.save', expect.objectContaining({ yaml: expect.any(String) }));
   });
 
+  it('passes the loaded name as previousName on save so a rename cleans up (Finding 7)', async () => {
+    const yaml = sampleYaml();
+    const saved = { name: 'renamed', scope: 'user', path: '/renamed.yaml' };
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === 'workflows.getRun') return { name: 'demo', scope: 'user', path: '/demo.yaml', yaml };
+      if (cmd === 'workflows.validateDraft') return { ok: true, errors: [] };
+      if (cmd === 'workflows.save') return saved;
+      throw new Error(`unexpected ${cmd}`);
+    });
+    __setApiOverride(fakeApi(invoke as unknown as MoxxyApi['invoke']));
+
+    const { result } = renderHook(() => useWorkflowBuilder());
+    await act(async () => {
+      await result.current.load('demo');
+    });
+    // Rename on the canvas, then save.
+    act(() => result.current.dispatch({ type: 'update-meta', patch: { name: 'renamed' } }));
+    await act(async () => {
+      await result.current.save();
+    });
+    expect(invoke).toHaveBeenCalledWith(
+      'workflows.save',
+      expect.objectContaining({ previousName: 'demo' }),
+    );
+  });
+
+  it('omits previousName for a brand-new (unloaded) workflow', async () => {
+    const saved = { name: 'fresh', scope: 'user', path: '/fresh.yaml' };
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === 'workflows.validateDraft') return { ok: true, errors: [] };
+      if (cmd === 'workflows.save') return saved;
+      throw new Error(`unexpected ${cmd}`);
+    });
+    __setApiOverride(fakeApi(invoke as unknown as MoxxyApi['invoke']));
+
+    const { result } = renderHook(() => useWorkflowBuilder());
+    act(() => result.current.dispatch({ type: 'add-step', input: { kind: 'prompt', id: 'a' } }));
+    await act(async () => {
+      await result.current.save();
+    });
+    const call = invoke.mock.calls.find((c) => c[0] === 'workflows.save');
+    expect(call?.[1]).not.toHaveProperty('previousName');
+  });
+
   it('save refuses and surfaces an error when invalid', async () => {
     const invoke = vi.fn(async (cmd: string) => {
       if (cmd === 'workflows.validateDraft') return { ok: false, errors: ['name: bad'] };

--- a/packages/client-core/src/useWorkflowBuilder.ts
+++ b/packages/client-core/src/useWorkflowBuilder.ts
@@ -51,6 +51,11 @@ export function useWorkflowBuilder(): UseWorkflowBuilder {
   const stateRef = useRef(state);
   stateRef.current = state;
 
+  // The name the builder loaded (null for a fresh workflow). Carried to `save`
+  // as `previousName` so renaming a workflow removes the old file/entry instead
+  // of leaving an orphaned duplicate.
+  const loadedNameRef = useRef<string | null>(null);
+
   const runValidation = useCallback(async (): Promise<boolean> => {
     const snapshot = stateRef.current;
     setValidating(true);
@@ -88,6 +93,7 @@ export function useWorkflowBuilder(): UseWorkflowBuilder {
   const load = useCallback(async (name: string | null) => {
     setError(null);
     setValid(null);
+    loadedNameRef.current = null;
     if (!name) {
       dispatch({ type: 'load', state: emptyState() });
       return;
@@ -98,6 +104,7 @@ export function useWorkflowBuilder(): UseWorkflowBuilder {
         setError(`workflow "${name}" was not found`);
         return;
       }
+      loadedNameRef.current = detail.name;
       dispatch({ type: 'load', state: hydrateYaml(detail.yaml) });
     } catch (e) {
       setError(toErrorMessage(e));
@@ -114,7 +121,14 @@ export function useWorkflowBuilder(): UseWorkflowBuilder {
         return null;
       }
       const { yaml } = serialize(stateRef.current);
-      const result = await api().invoke('workflows.save', { yaml });
+      const previousName = loadedNameRef.current;
+      const result = await api().invoke('workflows.save', {
+        yaml,
+        ...(previousName ? { previousName } : {}),
+      });
+      // The saved name becomes the new baseline so a subsequent rename in the
+      // same session also cleans up correctly.
+      loadedNameRef.current = result.name;
       dispatch({ type: 'mark-saved' });
       return result;
     } catch (e) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 export { Session, type SessionOptions } from './session.js';
 export { runTurn, collectTurn, type RunTurnOptions } from './run-turn.js';
-export { createSubagentSpawner, type SubagentRuntime } from './subagents.js';
+export { createSubagentSpawner, clearRetainedChildren, type SubagentRuntime } from './subagents.js';
 export {
   loadPreferences,
   savePreferences,

--- a/packages/core/src/session.test.ts
+++ b/packages/core/src/session.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
-import { asToolCallId, defineMode, definePlugin } from '@moxxy/sdk';
+import { asSessionId, asToolCallId, defineMode, definePlugin } from '@moxxy/sdk';
 import { Session } from './session.js';
+import {
+  getRetainedChild,
+  registerRetainedChild,
+  releaseRetainedChild,
+  type RetainedChildSession,
+} from './subagents/registry.js';
 
 describe('Session', () => {
   it('boots with sensible defaults', () => {
@@ -75,6 +81,21 @@ describe('Session', () => {
     await s.close();
     await s.close();
     expect(onShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('close() clears retained child sessions so they do not leak (Finding 1)', async () => {
+    const childId = asSessionId('retained-leak-test');
+    // A workflow awaitInput pause would register a retained child here; a run
+    // that never resumes would pin it for the process lifetime without cleanup.
+    registerRetainedChild({ childSessionId: childId } as unknown as RetainedChildSession);
+    expect(getRetainedChild(childId)).toBeDefined();
+    try {
+      const s = new Session({ cwd: '/tmp', silent: true });
+      await s.close();
+      expect(getRetainedChild(childId)).toBeUndefined();
+    } finally {
+      releaseRetainedChild(childId);
+    }
   });
 
   it('getInfo returns a serializable snapshot of the registries', () => {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -49,6 +49,7 @@ import type {
   PermissionRule,
 } from '@moxxy/sdk';
 import { createLogger, silentLogger, type Logger } from './logger.js';
+import { clearRetainedChildren } from './subagents/registry.js';
 
 export interface SessionOptions {
   readonly cwd: string;
@@ -301,6 +302,11 @@ export class Session implements ClientSession, SessionRuntime {
     try {
       await this.dispatcher.dispatchShutdown(this.appContext());
     } finally {
+      // Drop any retained child sessions (the workflow `awaitInput` flow keeps
+      // them in a process-local registry until a `continue()`/`release()`). A
+      // paused run that never resumes would otherwise pin them for the whole
+      // process lifetime — release them on shutdown so they don't leak.
+      clearRetainedChildren();
       this.abort(reason);
     }
   }

--- a/packages/core/src/subagents.ts
+++ b/packages/core/src/subagents.ts
@@ -1,1 +1,2 @@
 export { createSubagentSpawner, type SubagentRuntime } from './subagents/spawn.js';
+export { clearRetainedChildren } from './subagents/registry.js';

--- a/packages/desktop-host/src/ipc/workflows.ts
+++ b/packages/desktop-host/src/ipc/workflows.ts
@@ -37,10 +37,10 @@ export function registerWorkflowsHandlers(pool: RunnerPool): void {
     if (!session.workflows?.validateDraft) throw new Error('workflows builder not supported on this session');
     return await session.workflows.validateDraft(yaml);
   });
-  handle('workflows.save', async ({ yaml }) => {
+  handle('workflows.save', async ({ yaml, previousName }) => {
     const session = mustSession(pool);
     if (!session.workflows?.save) throw new Error('workflows builder not supported on this session');
-    return await session.workflows.save(yaml);
+    return await session.workflows.save(yaml, previousName);
   });
   handle('workflows.getRun', async ({ name }) => {
     const session = mustSession(pool);

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -699,8 +699,12 @@ export interface IpcCommands {
   // plugin (or the builder-capable host) is absent — the renderer feature-checks.
   /** Parse + validate a draft YAML without saving. */
   'workflows.validateDraft': (args: { yaml: string }) => Promise<WorkflowValidate>;
-  /** Persist a workflow from full YAML (create or overwrite). */
-  'workflows.save': (args: { yaml: string }) => Promise<WorkflowSave>;
+  /**
+   * Persist a workflow from full YAML (create or overwrite). `previousName`
+   * (the name the builder loaded) supports rename: when it differs from the
+   * YAML's name, the old workflow file + entry are removed.
+   */
+  'workflows.save': (args: { yaml: string; previousName?: string }) => Promise<WorkflowSave>;
   /** Fetch one saved workflow as canonical YAML (null when unknown). */
   'workflows.getRun': (args: { name: string }) => Promise<WorkflowDetail | null>;
 

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -146,7 +146,10 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
   // hostile renderer can't OOM the host; save writes to disk so it's
   // filesystem-touching and gets a boundary check like the other writers.
   'workflows.validateDraft': z.object({ yaml: z.string().min(1).max(1_000_000) }),
-  'workflows.save': z.object({ yaml: z.string().min(1).max(1_000_000) }),
+  'workflows.save': z.object({
+    yaml: z.string().min(1).max(1_000_000),
+    previousName: workflowName.optional(),
+  }),
   'workflows.getRun': z.object({ name: workflowName }),
   // Security-sensitive: this bypasses the approval sheet, so validate it at
   // the boundary like the other dangerous commands.

--- a/packages/plugin-workflows/src/draft.test.ts
+++ b/packages/plugin-workflows/src/draft.test.ts
@@ -4,24 +4,20 @@ import { buildSystemPrompt, draftWorkflow } from './draft.js';
 
 const MULTI_STEP_DRAFT = `\`\`\`yaml
 name: image-report-email
-description: Collect image brief in chat, generate it, write a report, and email it.
+description: Generate an image from a brief, write a report, and email it.
 enabled: true
 inputs:
+  brief:
+    description: What image to generate.
   recipient:
     default: ""
     description: Email address for the final report.
 steps:
-  - id: collect_brief
-    label: Collect image brief
-    awaitInput: true
-    prompt: |
-      Ask the operator what image they want generated.
   - id: generate_image
-    needs: [collect_brief]
     label: Generate image
     prompt: |
       Generate the image from the brief:
-      {{ steps.collect_brief.output }}
+      {{ inputs.brief }}
   - id: write_report
     needs: [generate_image]
     label: Write report
@@ -49,8 +45,10 @@ describe('draftWorkflow', () => {
     expect(prompt).toContain('gmail_send');
     expect(prompt).toContain('at least 4 steps');
     expect(prompt).toContain('<< skill-name >>');
-    expect(prompt).toContain('awaitInput: true');
-    expect(prompt).toContain('collect_brief');
+    // awaitInput is gated (no resume channel) — the prompt must steer the model
+    // to `inputs` instead of teaching the unshippable pause flow.
+    expect(prompt).toContain('Never use `awaitInput`');
+    expect(prompt).not.toContain('awaitInput: true');
   });
 
   it('teaches the loop node with a worked example', () => {
@@ -77,9 +75,9 @@ describe('draftWorkflow', () => {
     expect(drafted.parse.ok).toBe(true);
     expect(drafted.parse.errors).toEqual([]);
     expect(drafted.parse.workflow?.name).toBe('image-report-email');
-    expect(drafted.parse.workflow?.steps).toHaveLength(4);
+    expect(drafted.parse.workflow?.steps).toHaveLength(3);
     expect(drafted.parse.workflow?.inputs?.recipient).toBeDefined();
-    expect(drafted.parse.workflow?.steps[3]?.tool).toBe('gmail_send');
+    expect(drafted.parse.workflow?.steps[2]?.tool).toBe('gmail_send');
     expect(provider.received[0]?.maxTokens).toBe(4096);
   });
 });

--- a/packages/plugin-workflows/src/draft.ts
+++ b/packages/plugin-workflows/src/draft.ts
@@ -48,28 +48,28 @@ A workflow is a DAG of steps. Schema:
     - args: templated args object for tool/workflow steps
     - needs: [ <upstream step ids> ]  (defines the DAG; omit only for true sources)
     - when (optional, legacy): simple guards only — '{{ steps.x.output }} is not empty'. Do NOT use when for semantic decisions (use condition/switch).
-    - awaitInput (optional, prompt/skill only): true — pause after the subagent's first message; the operator replies once in Virtual Office chat, then the step completes and the DAG continues
     - onError (optional): fail | continue | retry ; retries (optional, 0-3)
+
+IMPORTANT — no mid-run questions: this build has NO chat-resume channel, so a workflow CANNOT pause to ask the operator something mid-run (\`awaitInput\` is rejected at save time). For any value the operator must supply, declare it as an \`inputs\` field (the operator fills it in before Run); never try to "ask in chat".
 
 Templating: {{ steps.<id>.output }}, {{ inputs.<name> }}, {{ vars.<name> }}, {{ trigger }}, {{ now }}.
 
-Logic steps: default response is one JSON object (vars, branch, optional text). Describe semantics in the instruction; do not repeat JSON syntax unless needed. No awaitInput on bridge/condition/switch/loop.
+Logic steps: default response is one JSON object (vars, branch, optional text). Describe semantics in the instruction; do not repeat JSON syntax unless needed.
 
-Ordering: steps whose \`needs\` are all satisfied run in parallel — chain with \`needs\` for sequential pipelines. A loop's body steps run only inside the loop (each iteration), so give them \`needs: [<loop step id>]\` and never schedule them elsewhere.
+Ordering: steps whose \`needs\` are all satisfied run in parallel — chain with \`needs\` for sequential pipelines. A loop's body steps run only inside the loop (each iteration), so give them \`needs: [<loop step id>]\` and never schedule them elsewhere. A loop body step runs unconditionally each iteration: do NOT put \`when\` on it, do NOT make it a condition/switch step, and only \`needs\` its loop step or a sibling body step of the same loop. No NON-loop step may \`needs\` a loop body step — depend on the loop step instead.
 
 Authoring rules:
 1. Decompose the intent into concrete steps. Multi-phase requests (collect → act → summarize → deliver) need at least 4 steps with a linear or fan-in \`needs\` chain.
-2. Values the operator should provide **in chat** (search topic, recipient email, brief, clarifications): one \`awaitInput: true\` step **per distinct question** (e.g. \`collect_topic\`, then later \`collect_email\`). Never rely on a single awaitInput step to cover multiple unrelated inputs. One chat reply per awaitInput step; use \`{{ steps.<id>.output }}\` downstream.
-3. \`inputs\` are only for data known **before** Run (API keys, fixed defaults). Do NOT add \`inputs\` for topic/email when the user asked you to "ask" for them — use awaitInput steps instead. Never write descriptions like "workflow will ask before run" for fields you did not wire to an awaitInput step.
-4. Do NOT add a prompt/skill step that only says "ask the operator" without \`awaitInput: true\` — that finishes in one turn and stores the question as output.
-5. Research + report + email intents: typical chain — \`collect_topic\` (awaitInput) → \`web-research\` skill → \`write_report\` → \`collect_email\` (awaitInput) → \`send_email\` tool; reference \`{{ steps.collect_topic.output }}\` and \`{{ steps.collect_email.output }}\`, not empty \`inputs\`.
-6. Use ONLY skill/tool names from the catalogs below — never placeholders like "<< skill-name >>", "TBD", or empty skill/tool fields.
-7. Prefer a listed skill when its description fits; otherwise use a detailed \`prompt\` step.
-8. For email/notify: use a listed mail/MCP tool if available; else \`delivery: { channel: inbox }\`.
-9. For image generation: use a listed image/generation tool if available; else a \`prompt\` step that describes producing the image artifact in text.
-10. Later steps must read prior results via \`{{ steps.<id>.output }}\`, extracted fields via \`{{ vars.<name> }}\`, and operator data via \`{{ inputs.<name> }}\` — never invent example emails or briefs in prompts.
-11. Between incompatible steps insert \`bridge\` to extract fields into vars (e.g. email from chat). Use \`condition\` for if/else routing, \`switch\` for multi-way (e.g. value > 100 → pies, < 0 → kot, else nieokreslony).
-12. Use \`loop\` for "keep refining until good enough" / "retry up to N times" / "iterate while X holds" intents — set a sane maxIterations so it always terminates. Prefer bridge + vars over passing raw chat output to tools.
+2. Values the operator must supply (search topic, recipient email, brief): declare each as an \`inputs\` field with a clear \`description\` (and a \`default\` when sensible). The operator fills them in before Run; reference them downstream via \`{{ inputs.<name> }}\`. There is NO way to pause and ask mid-run.
+3. Never use \`awaitInput\` — it is rejected at save time in this build (no resume channel). Do NOT add a prompt/skill step that only says "ask the operator"; that finishes in one turn and just stores the question as output. Use \`inputs\` instead.
+4. Research + report + email intents: typical chain — \`web-research\` skill (over \`{{ inputs.topic }}\`) → \`write_report\` → \`send_email\` tool (to \`{{ inputs.recipient }}\`). Put \`topic\` and \`recipient\` in \`inputs\`.
+5. Use ONLY skill/tool names from the catalogs below — never placeholders like "<< skill-name >>", "TBD", or empty skill/tool fields.
+6. Prefer a listed skill when its description fits; otherwise use a detailed \`prompt\` step.
+7. For email/notify: use a listed mail/MCP tool if available; else \`delivery: { channel: inbox }\`.
+8. For image generation: use a listed image/generation tool if available; else a \`prompt\` step that describes producing the image artifact in text.
+9. Later steps must read prior results via \`{{ steps.<id>.output }}\`, extracted fields via \`{{ vars.<name> }}\`, and operator data via \`{{ inputs.<name> }}\` — never invent example emails or briefs in prompts.
+10. Between incompatible steps insert \`bridge\` to extract fields into vars (e.g. an email address from text). Use \`condition\` for if/else routing, \`switch\` for multi-way (e.g. value > 100 → pies, < 0 → kot, else nieokreslony).
+11. Use \`loop\` for "keep refining until good enough" / "retry up to N times" / "iterate while X holds" intents — set a sane maxIterations so it always terminates. Prefer bridge + vars over passing raw output to tools.
 
 Available skills (name — description):
 ${skills}
@@ -77,78 +77,63 @@ ${skills}
 Available tools (name — description):
 ${tools}
 
-Example shape for internet research → report → email (two awaitInput steps):
+Example shape for internet research → report → email (operator data via inputs):
 \`\`\`yaml
 name: internet-research-report-email
-description: Ask for search topic and recipient email in chat, research, report, and send.
+description: Research a topic, write a report, and email it to the recipient.
 enabled: true
+inputs:
+  topic:
+    description: Temat/zakres wyszukiwania w internecie.
+  recipient:
+    description: Adres e-mail odbiorcy raportu.
 steps:
-  - id: collect_topic
-    label: Zapytaj o temat
-    awaitInput: true
-    prompt: |
-      Zapytaj operatora po polsku, czego szukać w internecie (temat, zakres, język).
-      Po odpowiedzi zwróć krótki brief wyszukiwania.
   - id: search_web
-    needs: [collect_topic]
     label: Wyszukaj w internecie
     skill: web-research
     input: |
-      Przeprowadź research według briefu:
-      {{ steps.collect_topic.output }}
+      Przeprowadź research na temat:
+      {{ inputs.topic }}
   - id: write_report
     needs: [search_web]
     label: Przygotuj raport
     prompt: |
       Napisz raport po polsku z wyników researchu.
-      Brief: {{ steps.collect_topic.output }}
+      Temat: {{ inputs.topic }}
       Research: {{ steps.search_web.output }}
-  - id: collect_email
-    needs: [write_report]
-    label: Zapytaj o e-mail
-    awaitInput: true
-    prompt: |
-      Zapytaj operatora po polsku o adres e-mail odbiorcy raportu.
-      Po odpowiedzi zwróć sam adres e-mail (jedna linia).
-  - id: extract_email
-    needs: [collect_email]
-    label: Wyciągnij e-mail
-    bridge: Z wątku collect_email wyciągnij sam adres do vars.email.
   - id: send_email
-    needs: [write_report, extract_email]
+    needs: [write_report]
     label: Wyślij e-mail
     tool: gmail_send
     args:
-      to: ["{{ vars.email }}"]
+      to: ["{{ inputs.recipient }}"]
       subject: "Raport z researchu"
       body: "{{ steps.write_report.output }}"
 \`\`\`
 
-Example shape for awaitInput brief → generate → report → email:
+Example shape for image brief → generate → report → email (operator data via inputs):
 \`\`\`yaml
 name: image-report-email
-description: Collect image brief in chat, generate image, write a report, and email it.
+description: Generate an image from a brief, write a report, and email it.
 enabled: true
+inputs:
+  brief:
+    description: What image to generate (subject, style, format, mood, colors).
+  recipient:
+    description: Recipient email for the report.
 steps:
-  - id: collect_brief
-    label: Collect image brief
-    awaitInput: true
-    prompt: |
-      Ask the operator what image to generate (subject, style, format, mood, colors).
-      After they reply, return a concise structured brief only.
   - id: generate_image
-    needs: [collect_brief]
     label: Generate image
     prompt: |
       Generate the image from this brief:
-      {{ steps.collect_brief.output }}
+      {{ inputs.brief }}
       Return the artifact path or id and short generation notes.
   - id: write_report
     needs: [generate_image]
     label: Write report
     prompt: |
       Write a concise report in the operator's language.
-      Brief: {{ steps.collect_brief.output }}
+      Brief: {{ inputs.brief }}
       Generation: {{ steps.generate_image.output }}
   - id: send_report
     needs: [write_report]

--- a/packages/plugin-workflows/src/executor/dag.test.ts
+++ b/packages/plugin-workflows/src/executor/dag.test.ts
@@ -21,6 +21,31 @@ function wf(obj: Record<string, unknown>): Workflow {
   return r.workflow;
 }
 
+/**
+ * Build a Workflow shape WITHOUT schema validation. The executor still supports
+ * the awaitInput pause/resume path (kept in case a resume trigger lands), but
+ * the schema now GATES awaitInput (Finding 1) so `validateWorkflow` would reject
+ * it. These tests exercise the executor directly; they bypass the author-time
+ * gate the same way a hypothetical resume trigger would feed a stored checkpoint.
+ */
+function rawWf(steps: Array<Record<string, unknown>>, extra: Record<string, unknown> = {}): Workflow {
+  return {
+    name: 'raw',
+    description: 'x',
+    version: 1,
+    enabled: true,
+    inputs: {},
+    concurrency: 4,
+    steps: steps.map((s) => ({
+      needs: [],
+      onError: 'fail',
+      retries: 0,
+      ...s,
+    })),
+    ...extra,
+  } as unknown as Workflow;
+}
+
 interface Harness {
   readonly deps: WorkflowRunDeps;
   readonly specs: SubagentSpec[];
@@ -308,14 +333,10 @@ describe('dag executor', () => {
       runStore: store,
     } as Partial<WorkflowRunDeps>);
     const paused = await dagExecutor.run(
-      wf({
-        name: 'ask-then-go',
-        description: 'x',
-        steps: [
-          { id: 'ask', prompt: 'Ask for brief', awaitInput: true },
-          { id: 'go', needs: ['ask'], prompt: 'Use {{ steps.ask.output }}' },
-        ],
-      }),
+      rawWf([
+        { id: 'ask', prompt: 'Ask for brief', awaitInput: true },
+        { id: 'go', needs: ['ask'], prompt: 'Use {{ steps.ask.output }}' },
+      ]),
       h.deps,
     );
     expect(paused.status).toBe('paused');
@@ -330,6 +351,62 @@ describe('dag executor', () => {
     const go = h.specs.find((s) => s.label === 'go')!;
     expect(go.prompt).toContain('FINAL_ask');
     await rm(dir, { recursive: true, force: true });
+  });
+
+  it('restores vars set before the pause on resume (Finding 4)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'wf-pause-vars-'));
+    const store = new WorkflowRunStore(dir);
+    const h = makeHarness({
+      runStore: store,
+      logicResponses: { extract: '{"vars":{"email":"ops@example.com"}}' },
+    } as Partial<WorkflowRunDeps>);
+    // A bridge runs BEFORE the awaitInput pause, setting vars.email. After
+    // resume, a downstream tool reads {{ vars.email }}; without persisting vars
+    // in the checkpoint it would render empty.
+    const paused = await dagExecutor.run(
+      rawWf([
+        { id: 'extract', bridge: 'extract email into vars.email' },
+        { id: 'ask', needs: ['extract'], prompt: 'Ask for brief', awaitInput: true },
+        {
+          id: 'send',
+          needs: ['ask'],
+          tool: 'notify',
+          args: { to: '{{ vars.email }}' },
+        },
+      ]),
+      h.deps,
+    );
+    expect(paused.status).toBe('paused');
+
+    const resumed = await resumeWorkflowRun(paused.runId!, 'go ahead', h.deps, store);
+    expect(resumed.ok).toBe(true);
+    expect(h.toolCalls.find((c) => c.name === 'notify')?.input).toEqual({ to: 'ops@example.com' });
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('drops prototype-pollution keys from logic-step vars (Finding 6)', async () => {
+    const h = makeHarness({
+      logicResponses: {
+        evil: '{"vars":{"__proto__":{"polluted":true},"safe":"ok"}}',
+      },
+    } as Partial<WorkflowRunDeps>);
+    const result = await dagExecutor.run(
+      wf({
+        name: 'proto',
+        description: 'x',
+        steps: [
+          { id: 'evil', bridge: 'set vars' },
+          { id: 'use', needs: ['evil'], tool: 'notify', args: { v: '{{ vars.safe }}' } },
+        ],
+      }),
+      h.deps,
+    );
+    expect(result.ok).toBe(true);
+    // The safe key still merges…
+    expect(h.toolCalls[0]!.input).toEqual({ v: 'ok' });
+    // …but the prototype is not polluted.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(Object.prototype, 'polluted')).toBe(false);
   });
 
   it('bridge merges vars for downstream templates', async () => {
@@ -630,20 +707,17 @@ describe('dag executor — while-loop node', () => {
   });
 
   it('rejects awaitInput inside a loop body at runtime', async () => {
-    // Schema bars awaitInput on the loop step itself; a body prompt with
-    // awaitInput would pause mid-iteration — the loop fails loudly instead.
+    // Schema gates awaitInput everywhere now (Finding 1), but the executor
+    // still guards against a body step that pauses mid-iteration. Build the
+    // workflow raw (bypassing the author-time gate) to exercise that guard.
     const h = makeHarness({
       logicResponses: { 'spin (condition)': '{"branch":"then"}' },
     } as Partial<WorkflowRunDeps>);
     const result = await dagExecutor.run(
-      wf({
-        name: 'loop-await-body',
-        description: 'x',
-        steps: [
-          { id: 'spin', loop: { body: ['ask'], condition: 'go?', maxIterations: 3 } },
-          { id: 'ask', needs: ['spin'], prompt: 'ask something', awaitInput: true },
-        ],
-      }),
+      rawWf([
+        { id: 'spin', loop: { body: ['ask'], condition: 'go?', maxIterations: 3 } },
+        { id: 'ask', needs: ['spin'], prompt: 'ask something', awaitInput: true },
+      ]),
       h.deps,
     );
     expect(result.ok).toBe(false);

--- a/packages/plugin-workflows/src/executor/dag.ts
+++ b/packages/plugin-workflows/src/executor/dag.ts
@@ -107,9 +107,29 @@ function buildScope(ctx: ExecutorContext, nowIso: string): TemplateScope {
   };
 }
 
+/**
+ * Keys that would mutate the prototype chain rather than set an own property.
+ * Logic-step `vars` come from model output, so a hostile/garbled response could
+ * carry `__proto__`/`constructor`/`prototype` — drop them when merging.
+ */
+const UNSAFE_VAR_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 function mergeVars(ctx: ExecutorContext, vars: Record<string, unknown> | undefined): void {
   if (!vars) return;
-  Object.assign(ctx.vars, vars);
+  for (const [key, value] of Object.entries(vars)) {
+    if (UNSAFE_VAR_KEYS.has(key)) {
+      ctx.deps.logger?.warn?.('workflow vars: dropping prototype-pollution key', { key });
+      continue;
+    }
+    // Own-property assignment only (skips inherited keys that Object.entries
+    // wouldn't surface anyway, but keeps the intent explicit).
+    Object.defineProperty(ctx.vars, key, {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  }
 }
 
 async function applyBranchSkips(
@@ -293,6 +313,9 @@ async function runExecutorLoop(ctx: ExecutorContext): Promise<WorkflowRunResult>
           trigger: deps.trigger ?? 'manual',
           inputs: ctx.inputs,
           states: serializeStates(ctx.states),
+          // Persist vars set by logic steps that ran before this pause so a
+          // resume restores them (otherwise downstream `{{ vars.x }}` is lost).
+          vars: ctx.vars,
           pendingStepId: step.id,
           interactionAgentId: outcome.interactionAgentId!,
           startedAt: ctx.now(),
@@ -400,15 +423,19 @@ export async function resumeWorkflowRun(
     };
   }
 
+  // Restore vars captured at pause time (logic steps that ran before the
+  // awaitInput step). Older checkpoints predate `vars` — default to {}.
+  const restoredVars: Record<string, unknown> = {};
   const ctx: ExecutorContext = {
     workflow: checkpoint.workflow,
     deps: depsWithStore,
     inputs: checkpoint.inputs,
-    vars: {},
+    vars: restoredVars,
     states: restoreStates(checkpoint.states),
     now: nowFn(deps),
     loopBodyIds: collectLoopBodyIds(checkpoint.workflow),
   };
+  mergeVars(ctx, checkpoint.vars);
 
   const st = ctx.states.get(step.id)!;
   await deps.emit?.('workflow_resumed', { runId, stepId: step.id });

--- a/packages/plugin-workflows/src/index.ts
+++ b/packages/plugin-workflows/src/index.ts
@@ -41,7 +41,12 @@ export {
 
 export { dagExecutor, DAG_EXECUTOR_NAME, resumeWorkflowRun } from './executor/dag.js';
 export { runWorkflow, defaultRunRecordDir, type RunWorkflowOptions } from './engine.js';
-export { WorkflowRunStore, defaultWorkflowRunStore, type WorkflowRunCheckpoint } from './run-store.js';
+export {
+  WorkflowRunStore,
+  defaultWorkflowRunStore,
+  DEFAULT_CHECKPOINT_TTL_MS,
+  type WorkflowRunCheckpoint,
+} from './run-store.js';
 export {
   buildSystemPrompt,
   draftWorkflow,

--- a/packages/plugin-workflows/src/run-store.test.ts
+++ b/packages/plugin-workflows/src/run-store.test.ts
@@ -1,0 +1,68 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Workflow } from '@moxxy/sdk';
+import { WorkflowRunStore } from './run-store.js';
+
+let dir: string;
+let store: WorkflowRunStore;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-runstore-'));
+  store = new WorkflowRunStore(dir);
+});
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+const fakeWorkflow = { name: 'x', description: 'x', steps: [] } as unknown as Workflow;
+
+function checkpoint(vars: Record<string, unknown> = {}) {
+  return {
+    workflow: fakeWorkflow,
+    trigger: 'manual',
+    inputs: {},
+    states: {},
+    vars,
+    pendingStepId: 'ask',
+    interactionAgentId: 'child-1',
+    startedAt: 1,
+  };
+}
+
+describe('WorkflowRunStore', () => {
+  it('round-trips a checkpoint including vars (Finding 4)', async () => {
+    const runId = await store.save(checkpoint({ email: 'ops@example.com' }));
+    const loaded = await store.load(runId);
+    expect(loaded?.vars).toEqual({ email: 'ops@example.com' });
+    expect(loaded?.pendingStepId).toBe('ask');
+  });
+
+  it('removes a checkpoint', async () => {
+    const runId = await store.save(checkpoint());
+    await store.remove(runId);
+    expect(await store.load(runId)).toBeNull();
+  });
+
+  it('sweeps stale checkpoint files past the TTL (Finding 1)', async () => {
+    const stale = await store.save(checkpoint());
+    const fresh = await store.save(checkpoint());
+
+    // Backdate the stale file's mtime well past any TTL.
+    const stalePath = path.join(dir, `${stale}.json`);
+    const old = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+    await fs.utimes(stalePath, old, old);
+
+    const removed = await store.sweepStale(7 * 24 * 60 * 60 * 1000);
+    expect(removed).toBe(1);
+    expect(await store.load(stale)).toBeNull();
+    expect(await store.load(fresh)).not.toBeNull();
+  });
+
+  it('sweepStale on a missing dir returns 0', async () => {
+    const missing = new WorkflowRunStore(path.join(dir, 'does-not-exist'));
+    expect(await missing.sweepStale()).toBe(0);
+  });
+});

--- a/packages/plugin-workflows/src/run-store.ts
+++ b/packages/plugin-workflows/src/run-store.ts
@@ -24,6 +24,12 @@ export interface WorkflowRunCheckpoint {
   readonly trigger: string;
   readonly inputs: Record<string, unknown>;
   readonly states: Record<string, SerializedStepState>;
+  /**
+   * Variables set by logic steps BEFORE the pause. Restored on resume so a
+   * `bridge` that ran ahead of an `awaitInput` step isn't silently dropped
+   * (otherwise downstream `{{ vars.x }}` would render empty after resume).
+   */
+  readonly vars: Record<string, unknown>;
   readonly pendingStepId: string;
   readonly interactionAgentId: string;
   readonly startedAt: number;
@@ -63,7 +69,41 @@ export class WorkflowRunStore {
       // ignore
     }
   }
+
+  /**
+   * Delete checkpoint files older than `maxAgeMs` (by mtime). Paused runs that
+   * are never resumed (the common case while `awaitInput` is gated — see
+   * schema.ts — and in general after a crash) would otherwise accumulate
+   * `<ulid>.json` files under `active/` forever. Returns the count removed.
+   * Best-effort: a missing dir or an unreadable entry is skipped, not thrown.
+   */
+  async sweepStale(maxAgeMs = DEFAULT_CHECKPOINT_TTL_MS, now = Date.now()): Promise<number> {
+    let removed = 0;
+    let entries: string[];
+    try {
+      entries = await fs.readdir(this.dir);
+    } catch {
+      return 0;
+    }
+    for (const name of entries) {
+      if (!name.endsWith('.json')) continue;
+      const file = path.join(this.dir, name);
+      try {
+        const st = await fs.stat(file);
+        if (now - st.mtimeMs > maxAgeMs) {
+          await fs.unlink(file);
+          removed += 1;
+        }
+      } catch {
+        // racing unlink / unreadable entry — skip.
+      }
+    }
+    return removed;
+  }
 }
+
+/** Stale paused-run checkpoints are swept after 7 days by default. */
+export const DEFAULT_CHECKPOINT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 export const defaultWorkflowRunStore = new WorkflowRunStore();
 

--- a/packages/plugin-workflows/src/schema.test.ts
+++ b/packages/plugin-workflows/src/schema.test.ts
@@ -275,6 +275,119 @@ steps:
       ],
     });
     expect(r.ok).toBe(false);
-    expect(r.errors.join('\n')).toMatch(/awaitInput is only allowed on prompt or skill/);
+    expect(r.errors.join('\n')).toMatch(/awaitInput requires the resume channel/);
+  });
+
+  // --- awaitInput gate (Finding 1) -------------------------------------------
+  // The resume trigger that delivers the operator's reply did NOT ship to main,
+  // so a paused run would hang forever. awaitInput is rejected at author time
+  // on EVERY step kind until a resume path lands in-tree.
+
+  it('rejects awaitInput on a prompt step (resume channel not available)', () => {
+    const r = validateWorkflow({
+      name: 'await-prompt',
+      description: 'x',
+      steps: [{ id: 'ask', prompt: 'ask the operator', awaitInput: true }],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/awaitInput requires the resume channel/);
+  });
+
+  it('rejects awaitInput on a skill step', () => {
+    const r = validateWorkflow({
+      name: 'await-skill',
+      description: 'x',
+      steps: [{ id: 'ask', skill: 'web-research', input: 'ask', awaitInput: true }],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/awaitInput requires the resume channel/);
+  });
+
+  // --- loop-body integrity (Findings 3, 5, 8) -------------------------------
+
+  it('rejects a condition step used as a loop body (Finding 3)', () => {
+    const r = validateWorkflow({
+      name: 'loop-cond-body',
+      description: 'x',
+      steps: [
+        { id: 'spin', loop: { body: ['decide'], condition: 'done?', maxIterations: 3 } },
+        {
+          id: 'decide',
+          needs: ['spin'],
+          condition: 'is it good?',
+          then: ['spin'],
+          else: ['spin'],
+        },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/cannot be a condition\/switch step/);
+  });
+
+  it('rejects a switch step used as a loop body (Finding 3)', () => {
+    const r = validateWorkflow({
+      name: 'loop-switch-body',
+      description: 'x',
+      steps: [
+        { id: 'spin', loop: { body: ['route'], condition: 'done?', maxIterations: 3 } },
+        { id: 'route', needs: ['spin'], switch: 'which?', cases: { a: ['spin'] } },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/cannot be a condition\/switch step/);
+  });
+
+  it('rejects a non-loop step that needs a loop-body step (Finding 5)', () => {
+    const r = validateWorkflow({
+      name: 'needs-body',
+      description: 'x',
+      steps: [
+        { id: 'spin', loop: { body: ['work'], condition: 'done?', maxIterations: 3 } },
+        { id: 'work', needs: ['spin'], prompt: 'work' },
+        { id: 'after', needs: ['work'], prompt: 'after' },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/which is a loop body of "spin" — depend on the loop step/);
+  });
+
+  it('rejects a `when` guard on a loop-body step (Finding 8)', () => {
+    const r = validateWorkflow({
+      name: 'body-when',
+      description: 'x',
+      steps: [
+        { id: 'spin', loop: { body: ['work'], condition: 'done?', maxIterations: 3 } },
+        { id: 'work', needs: ['spin'], when: '{{ vars.x }} is not empty', prompt: 'work' },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/cannot have a `when` guard/);
+  });
+
+  it('rejects a loop-body step that needs a step outside its loop (Finding 8)', () => {
+    const r = validateWorkflow({
+      name: 'body-extra-needs',
+      description: 'x',
+      steps: [
+        { id: 'seed', prompt: 'seed' },
+        { id: 'spin', needs: ['seed'], loop: { body: ['work'], condition: 'done?', maxIterations: 3 } },
+        { id: 'work', needs: ['spin', 'seed'], prompt: 'work' },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/may only `needs` its loop step/);
+  });
+
+  it('accepts a loop body that needs a sibling body step of the same loop (Finding 8)', () => {
+    const r = validateWorkflow({
+      name: 'body-sibling-needs',
+      description: 'x',
+      steps: [
+        { id: 'spin', loop: { body: ['a', 'b'], condition: 'done?', maxIterations: 3 } },
+        { id: 'a', needs: ['spin'], prompt: 'a' },
+        { id: 'b', needs: ['a'], prompt: 'b' },
+      ],
+    });
+    expect(r.ok).toBe(true);
   });
 });

--- a/packages/plugin-workflows/src/schema.ts
+++ b/packages/plugin-workflows/src/schema.ts
@@ -20,7 +20,6 @@ const ACTION_KEYS = [
   'switch',
   'loop',
 ] as const;
-const LOGIC_ACTION_KEYS = ['bridge', 'condition', 'switch'] as const;
 
 export const SLUG_RE = /^[a-z0-9][a-z0-9-]*$/i;
 const STEP_ID_RE = /^[a-z0-9][a-z0-9_-]*$/i;
@@ -62,11 +61,20 @@ const stepSchema = z
     awaitInput: z.boolean().optional(),
   })
   .superRefine((step, ctx) => {
-    const isLogic = LOGIC_ACTION_KEYS.some((k) => step[k] != null);
-    if (step.awaitInput && (step.tool != null || step.workflow != null || step.loop != null || isLogic)) {
+    // awaitInput is GATED: the executor can pause + checkpoint, but the resume
+    // trigger/channel that delivers the operator's reply did NOT ship to main
+    // (it lives on an unmerged branch). Accepting `awaitInput: true` would
+    // create a run that pauses forever — leaking a retained child session and
+    // orphaning a checkpoint file. Reject it at author time until a resume path
+    // lands in-tree. (Re-enable by removing this block once a resume trigger
+    // exists; the executor side is already wired.)
+    if (step.awaitInput) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: `step "${step.id}": awaitInput is only allowed on prompt or skill steps`,
+        message:
+          `step "${step.id}": awaitInput requires the resume channel, which is not available ` +
+          `in this build — a paused run would hang forever. Remove awaitInput (gather the ` +
+          `input via an \`inputs\` field or a normal prompt step instead).`,
         path: ['awaitInput'],
       });
     }
@@ -290,6 +298,107 @@ export const workflowSchema = z
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: `step "${step.id}" loop references unknown body step "${ref}"`,
+            path: ['steps'],
+          });
+        }
+      }
+    }
+
+    // --- loop-body integrity -------------------------------------------------
+    // Map every body step id to its owning loop step id. The body steps are
+    // run by their loop each iteration and are excluded from the main DAG
+    // scheduler (`loopBodyIds`), so several edges around them are unsafe.
+    const stepById = new Map(wf.steps.map((s) => [s.id, s]));
+    const bodyOwner = new Map<string, string>();
+    for (const step of wf.steps) {
+      if (step.loop == null) continue;
+      for (const ref of step.loop.body) bodyOwner.set(ref, step.id);
+    }
+
+    for (const step of wf.steps) {
+      const owner = bodyOwner.get(step.id);
+      if (owner == null) continue;
+      const body = stepById.get(step.id)!;
+
+      // FINDING 3: a condition/switch used AS a loop body has its branch
+      // routing (then/else/cases) silently ignored — runLoopStep runs the body
+      // step but never applies its branch skips. Reject it so the author picks
+      // a supported body action.
+      if (body.condition != null || body.switch != null) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            `step "${step.id}" is a loop body of "${owner}" and cannot be a condition/switch ` +
+            `step — branch routing is not honored inside a loop body. Use a bridge step to set ` +
+            `vars and drive the loop's own exit condition instead.`,
+          path: ['steps'],
+        });
+      }
+
+      // FINDING 8: a loop body step runs unconditionally every iteration — its
+      // own `when` guard and any `needs` other than the owning loop step are
+      // ignored. Reject them so the semantics are explicit (body steps run
+      // unconditionally; the loop's exit `condition` is the only guard).
+      if (body.when != null) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            `step "${step.id}" is a loop body of "${owner}" and cannot have a \`when\` guard — ` +
+            `loop body steps run unconditionally each iteration. Gate the loop via its ` +
+            `\`condition\` (exit) instead.`,
+          path: ['steps'],
+        });
+      }
+      // A body step may declare `needs: [<loop step id>]` (the documented
+      // convention) or depend on a sibling body step of the SAME loop (intra-
+      // iteration ordering — the loop runs body steps in declared order).
+      // Anything else is a cross-DAG edge that won't be honored, so reject it.
+      for (const dep of body.needs) {
+        if (dep === owner) continue;
+        if (bodyOwner.get(dep) === owner) continue;
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            `step "${step.id}" is a loop body of "${owner}" and may only \`needs\` its loop ` +
+            `step ("${owner}") or a sibling body step of the same loop — "${dep}" is outside ` +
+            `the loop and would never settle for it.`,
+          path: ['steps'],
+        });
+      }
+    }
+
+    // FINDING 5: a NON-loop-body step that `needs` a loop-body step stalls the
+    // executor — the body step is owned by its loop and excluded from the main
+    // DAG, so its dependent never sees it settle. Depend on the loop step
+    // itself instead. (The body step's own loop step is allowed to "need" it
+    // implicitly via the loop, but no other step may.)
+    for (const step of wf.steps) {
+      if (bodyOwner.has(step.id)) continue; // body→body handled above
+      if (step.loop != null) {
+        // A loop step needing one of ITS OWN body ids is redundant but not a
+        // stall (it owns them); needing ANOTHER loop's body is still a stall.
+        const ownBody = new Set(step.loop.body);
+        for (const dep of step.needs) {
+          if (bodyOwner.has(dep) && !ownBody.has(dep)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message:
+                `step "${step.id}" needs "${dep}", which is a loop body of ` +
+                `"${bodyOwner.get(dep)}" — depend on the loop step "${bodyOwner.get(dep)}" instead.`,
+              path: ['steps'],
+            });
+          }
+        }
+        continue;
+      }
+      for (const dep of step.needs) {
+        if (bodyOwner.has(dep)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message:
+              `step "${step.id}" needs "${dep}", which is a loop body of ` +
+              `"${bodyOwner.get(dep)}" — depend on the loop step "${bodyOwner.get(dep)}" instead ` +
+              `(loop body steps are owned by their loop and never scheduled in the main DAG).`,
             path: ['steps'],
           });
         }

--- a/packages/plugin-workflows/src/store.test.ts
+++ b/packages/plugin-workflows/src/store.test.ts
@@ -59,4 +59,31 @@ describe('WorkflowStore CRUD', () => {
     expect(res.ok).toBe(true);
     expect(await store.get('delta')).toBeUndefined();
   });
+
+  it('renames a workflow without leaving an orphaned file/entry (Finding 7)', async () => {
+    const created = await store.create(sample('old-name'), 'user');
+    const oldPath = created.path;
+
+    // Save under a new name, declaring the previous name → old file/entry gone.
+    const renamed = await store.save(sample('new-name'), 'old-name');
+    expect(renamed.workflow.name).toBe('new-name');
+
+    expect(await store.get('old-name')).toBeUndefined();
+    expect((await store.get('new-name'))?.workflow.name).toBe('new-name');
+    await expect(fs.access(oldPath)).rejects.toThrow();
+
+    // A fresh store rediscovers only the new file (no orphan duplicate).
+    const fresh = new WorkflowStore({ cwd: dir, userDir: path.join(dir, 'user') });
+    await fresh.load();
+    const names = (await fresh.list()).map((w) => w.workflow.name);
+    expect(names).toContain('new-name');
+    expect(names).not.toContain('old-name');
+  });
+
+  it('save without a rename leaves the file in place', async () => {
+    await store.create(sample('keep'), 'user');
+    const before = (await store.get('keep'))!.path;
+    const after = await store.save(sample('keep'));
+    expect(after.path).toBe(before);
+  });
 });

--- a/packages/plugin-workflows/src/store.ts
+++ b/packages/plugin-workflows/src/store.ts
@@ -99,9 +99,25 @@ export class WorkflowStore {
   /**
    * Replace a workflow with a new definition. In-place rewrite for user/project
    * workflows; a user-scope override for builtin/plugin ones.
+   *
+   * `previousName` supports rename from the builder: when the workflow's name
+   * changed, the old user/project file and its registry entry are removed so a
+   * rename doesn't leave an orphaned duplicate file + stale entry behind.
    */
-  async save(workflow: Workflow): Promise<DiscoveredWorkflow> {
+  async save(workflow: Workflow, previousName?: string): Promise<DiscoveredWorkflow> {
     await this.ensureLoaded();
+
+    // Rename: the editor loaded `previousName`, the author changed the name,
+    // and we're saving under the new one. Drop the old editable file + entry
+    // before writing the new one. (A read-only builtin/plugin can't be renamed
+    // in place — leave it; the new name becomes a fresh user-scope workflow.)
+    const renamed =
+      previousName != null && previousName !== workflow.name ? this.byName.get(previousName) : undefined;
+    if (renamed && (renamed.scope === 'user' || renamed.scope === 'project')) {
+      await fs.rm(renamed.path, { force: true });
+      this.byName.delete(previousName!);
+    }
+
     const existing = this.byName.get(workflow.name);
     const editable = existing && (existing.scope === 'user' || existing.scope === 'project');
     if (existing && editable) {
@@ -111,11 +127,13 @@ export class WorkflowStore {
       return entry;
     }
     // New, or overriding a read-only builtin/plugin workflow → write to user dir.
-    const dir = this.userDir();
+    // Reuse the renamed file's scope when renaming a project workflow.
+    const scope: EditableScope = renamed?.scope === 'project' ? 'project' : 'user';
+    const dir = scope === 'project' ? this.projectDir() : this.userDir();
     await fs.mkdir(dir, { recursive: true });
     const file = await uniqueFilename(dir, workflow.name);
     await writeFileAtomic(file, serializeWorkflow(workflow));
-    const entry: DiscoveredWorkflow = { workflow, path: file, scope: 'user' };
+    const entry: DiscoveredWorkflow = { workflow, path: file, scope };
     this.byName.set(workflow.name, entry);
     return entry;
   }

--- a/packages/runner/src/integration.test.ts
+++ b/packages/runner/src/integration.test.ts
@@ -632,4 +632,66 @@ describe('runner end-to-end', () => {
     expect(session.approvalResolver?.name).toBe('runner-routing');
     expect(session.resolver.name).toBe('runner-routing');
   });
+
+  it('forwards the workflows builder methods (validateDraft/save/getRun) to the runner', async () => {
+    // Finding 2: the desktop drives a RemoteSession, whose workflows view used
+    // to omit the builder methods, so validateDraft/save/getRun were undefined
+    // and the builder was non-functional on desktop. They must reach the real
+    // handler over the runner socket (protocol v4).
+    const socketPath = tmpSocket();
+    const session = buildSession(new FakeProvider({ script: [textReply('hi')] }));
+    const calls: Array<{ method: string; arg: unknown; arg2?: unknown }> = [];
+    session.workflows = {
+      list: async () => [],
+      setEnabled: async () => undefined,
+      run: async () => ({ ok: true, output: '', steps: [] }),
+      validateDraft: async (yaml) => {
+        calls.push({ method: 'validateDraft', arg: yaml });
+        return { ok: false, errors: ['steps: step "a" needs unknown step "x"'] };
+      },
+      save: async (yaml, previousName) => {
+        calls.push({ method: 'save', arg: yaml, arg2: previousName });
+        return { name: 'renamed', scope: 'user', path: '/tmp/renamed.yaml' };
+      },
+      getRun: async (name) => {
+        calls.push({ method: 'getRun', arg: name });
+        return { name, scope: 'user', path: '/tmp/x.yaml', yaml: 'name: x' };
+      },
+    };
+    const server = await startRunnerServer(session, { socketPath });
+    servers.push(server);
+    const remote = await attach(socketPath);
+
+    const validated = await remote.workflows.validateDraft('name: bad');
+    expect(validated.ok).toBe(false);
+    expect(validated.errors[0]).toContain('needs unknown step');
+
+    const saved = await remote.workflows.save('name: renamed', 'old-name');
+    expect(saved.name).toBe('renamed');
+
+    const detail = await remote.workflows.getRun('x');
+    expect(detail?.yaml).toBe('name: x');
+
+    expect(calls).toEqual([
+      { method: 'validateDraft', arg: 'name: bad' },
+      { method: 'save', arg: 'name: renamed', arg2: 'old-name' },
+      { method: 'getRun', arg: 'x' },
+    ]);
+  });
+
+  it('rejects the workflows builder methods when the runner lacks the builder slice', async () => {
+    const socketPath = tmpSocket();
+    const session = buildSession(new FakeProvider({ script: [textReply('hi')] }));
+    // A workflows view WITHOUT the optional builder methods (older plugin).
+    session.workflows = {
+      list: async () => [],
+      setEnabled: async () => undefined,
+      run: async () => ({ ok: true, output: '', steps: [] }),
+    };
+    const server = await startRunnerServer(session, { socketPath });
+    servers.push(server);
+    const remote = await attach(socketPath);
+
+    await expect(remote.workflows.validateDraft('name: x')).rejects.toThrow(/builder not supported/);
+  });
 });

--- a/packages/runner/src/protocol.ts
+++ b/packages/runner/src/protocol.ts
@@ -27,8 +27,14 @@ import type {
  * mirror — and every attached mirror clears in lockstep. Without it, a
  * mirror-only clear desyncs seq-contiguous `ingest` and the mirror silently
  * rejects every subsequent event.
+ *
+ * v4: adds the workflow *builder* method family (`workflow.validateDraft`,
+ * `workflow.save`, `workflow.getRun`) so a thin client (TUI / desktop's
+ * RemoteSession) can drive the visual builder remotely. Like the other
+ * workflow.* methods they degrade cleanly: the server throws a clear "not
+ * supported" error when the workflows plugin (or its builder slice) is absent.
  */
-export const RUNNER_PROTOCOL_VERSION = 3;
+export const RUNNER_PROTOCOL_VERSION = 4;
 
 /** Request methods. Client->server unless noted. */
 export const RunnerMethod = {
@@ -74,6 +80,12 @@ export const RunnerMethod = {
   WorkflowSetEnabled: 'workflow.setEnabled',
   /** client->server: run a workflow now. */
   WorkflowRun: 'workflow.run',
+  /** client->server: validate a draft workflow YAML (builder). */
+  WorkflowValidateDraft: 'workflow.validateDraft',
+  /** client->server: persist a workflow from full YAML (builder). */
+  WorkflowSave: 'workflow.save',
+  /** client->server: fetch one saved workflow as canonical YAML (builder). */
+  WorkflowGetRun: 'workflow.getRun',
   /** server->client: ask this client to decide a tool-call permission. */
   PermissionCheck: 'permission.check',
   /** server->client: ask this client to confirm an approval checkpoint. */
@@ -181,6 +193,31 @@ export interface WorkflowSetEnabledParams {
 }
 export interface WorkflowRunParams {
   readonly name: string;
+}
+export interface WorkflowValidateDraftParams {
+  readonly yaml: string;
+}
+export interface WorkflowValidateDraftResult {
+  readonly ok: boolean;
+  readonly errors: ReadonlyArray<string>;
+}
+export interface WorkflowSaveParams {
+  readonly yaml: string;
+  readonly previousName?: string;
+}
+export interface WorkflowSaveResult {
+  readonly name: string;
+  readonly scope: string;
+  readonly path: string;
+}
+export interface WorkflowGetRunParams {
+  readonly name: string;
+}
+export interface WorkflowGetRunResult {
+  readonly name: string;
+  readonly scope: string;
+  readonly path: string;
+  readonly yaml: string;
 }
 
 export interface PermissionCheckParams {
@@ -295,3 +332,13 @@ export const workflowSetEnabledParamsSchema = z.object({
   enabled: z.boolean(),
 });
 export const workflowRunParamsSchema = z.object({ name: z.string() });
+// Builder params. YAML is bounded like the desktop IPC contract so a hostile
+// client can't OOM the runner; the YAML is parsed + schema-validated downstream.
+export const workflowValidateDraftParamsSchema = z.object({
+  yaml: z.string().min(1).max(1_000_000),
+});
+export const workflowSaveParamsSchema = z.object({
+  yaml: z.string().min(1).max(1_000_000),
+  previousName: z.string().min(1).max(120).optional(),
+});
+export const workflowGetRunParamsSchema = z.object({ name: z.string().min(1).max(120) });

--- a/packages/runner/src/remote-session.ts
+++ b/packages/runner/src/remote-session.ts
@@ -545,6 +545,17 @@ export class RemoteSession implements ClientSession {
       },
       run: (name) =>
         this.peer.request<WorkflowRunResult>(RunnerMethod.WorkflowRun, { name }),
+      // Builder methods (protocol v4): forward to the runner so the desktop's
+      // RemoteSession-backed visual builder can validate/save/load drafts.
+      validateDraft: (yaml) =>
+        this.peer.request<WorkflowValidateResult>(RunnerMethod.WorkflowValidateDraft, { yaml }),
+      save: (yaml, previousName) =>
+        this.peer.request<WorkflowSaveResult>(RunnerMethod.WorkflowSave, {
+          yaml,
+          ...(previousName ? { previousName } : {}),
+        }),
+      getRun: (name) =>
+        this.peer.request<WorkflowDetailResult | null>(RunnerMethod.WorkflowGetRun, { name }),
     };
   }
 }
@@ -574,10 +585,28 @@ interface WorkflowRunResult {
   readonly error?: string;
   readonly steps: ReadonlyArray<{ readonly id: string; readonly status: string; readonly error?: string }>;
 }
+interface WorkflowValidateResult {
+  readonly ok: boolean;
+  readonly errors: ReadonlyArray<string>;
+}
+interface WorkflowSaveResult {
+  readonly name: string;
+  readonly scope: string;
+  readonly path: string;
+}
+interface WorkflowDetailResult {
+  readonly name: string;
+  readonly scope: string;
+  readonly path: string;
+  readonly yaml: string;
+}
 interface WorkflowsClientView {
   list(): Promise<ReadonlyArray<WorkflowSummary>>;
   setEnabled(name: string, enabled: boolean): Promise<void>;
   run(name: string): Promise<WorkflowRunResult>;
+  validateDraft(yaml: string): Promise<WorkflowValidateResult>;
+  save(yaml: string, previousName?: string): Promise<WorkflowSaveResult>;
+  getRun(name: string): Promise<WorkflowDetailResult | null>;
 }
 
 // --- snapshot -> display-object reconstruction --------------------------------

--- a/packages/runner/src/server.ts
+++ b/packages/runner/src/server.ts
@@ -35,6 +35,9 @@ import {
   synthesizeParamsSchema,
   workflowRunParamsSchema,
   workflowSetEnabledParamsSchema,
+  workflowValidateDraftParamsSchema,
+  workflowSaveParamsSchema,
+  workflowGetRunParamsSchema,
   type AttachResult,
   type CommandRunResult,
   type RunTurnResult,
@@ -167,6 +170,11 @@ export class RunnerServer {
       this.handleWorkflowSetEnabled(raw),
     );
     peer.handle(RunnerMethod.WorkflowRun, (raw) => this.handleWorkflowRun(raw));
+    peer.handle(RunnerMethod.WorkflowValidateDraft, (raw) =>
+      this.handleWorkflowValidateDraft(raw),
+    );
+    peer.handle(RunnerMethod.WorkflowSave, (raw) => this.handleWorkflowSave(raw));
+    peer.handle(RunnerMethod.WorkflowGetRun, (raw) => this.handleWorkflowGetRun(raw));
 
     peer.onClose(() => this.onDisconnect(client));
   }
@@ -458,6 +466,31 @@ export class RunnerServer {
     const view = this.session.workflows;
     if (!view) throw new Error('workflows plugin not loaded');
     return view.run(params.name);
+  }
+
+  // --- Workflows builder (validate / save / getRun) ------------------------
+  // Optional on the view (older hosts / pre-builder plugins lack them), so
+  // feature-check and throw a clear error rather than calling undefined.
+
+  private async handleWorkflowValidateDraft(raw: unknown): Promise<unknown> {
+    const params = workflowValidateDraftParamsSchema.parse(raw);
+    const view = this.session.workflows;
+    if (!view?.validateDraft) throw new Error('workflows builder not supported on this runner');
+    return view.validateDraft(params.yaml);
+  }
+
+  private async handleWorkflowSave(raw: unknown): Promise<unknown> {
+    const params = workflowSaveParamsSchema.parse(raw);
+    const view = this.session.workflows;
+    if (!view?.save) throw new Error('workflows builder not supported on this runner');
+    return view.save(params.yaml, params.previousName);
+  }
+
+  private async handleWorkflowGetRun(raw: unknown): Promise<unknown> {
+    const params = workflowGetRunParamsSchema.parse(raw);
+    const view = this.session.workflows;
+    if (!view?.getRun) throw new Error('workflows builder not supported on this runner');
+    return (await view.getRun(params.name)) ?? null;
   }
 
   private broadcastInfo(): void {

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -195,8 +195,13 @@ export interface WorkflowsView {
   run(name: string): Promise<WorkflowRunView>;
   /** Parse + validate a draft YAML without saving it. */
   validateDraft?(yaml: string): Promise<WorkflowValidateView>;
-  /** Persist a workflow from full YAML (create or overwrite). */
-  save?(yaml: string): Promise<WorkflowSaveView>;
+  /**
+   * Persist a workflow from full YAML (create or overwrite). `previousName`
+   * (the name the builder loaded) supports rename: when it differs from the
+   * YAML's name, the old file + registry entry are removed so a rename doesn't
+   * leave an orphaned duplicate.
+   */
+  save?(yaml: string, previousName?: string): Promise<WorkflowSaveView>;
   /** Fetch one saved workflow's canonical YAML + on-disk metadata. */
   getRun?(name: string): Promise<{ readonly name: string; readonly scope: string; readonly path: string; readonly yaml: string } | null>;
 }

--- a/packages/workflows-builder/src/validation.test.ts
+++ b/packages/workflows-builder/src/validation.test.ts
@@ -20,13 +20,15 @@ describe('mapErrorsToNodes', () => {
     const mapped = mapErrorsToNodes(
       [
         'steps: step "gate" needs unknown step "ghost"',
-        'awaitInput: step "a": awaitInput is only allowed on prompt or skill steps',
+        'awaitInput: step "a": awaitInput requires the resume channel, which is not available in this build',
         'name: name must be slug-like',
       ],
       s,
     );
     expect(mapped.gate).toEqual(['steps: step "gate" needs unknown step "ghost"']);
-    expect(mapped.a).toEqual(['awaitInput: step "a": awaitInput is only allowed on prompt or skill steps']);
+    expect(mapped.a).toEqual([
+      'awaitInput: step "a": awaitInput requires the resume channel, which is not available in this build',
+    ]);
     expect(mapped[WORKFLOW_ERROR_KEY]).toEqual(['name: name must be slug-like']);
   });
 


### PR DESCRIPTION
Round-2 audit fixes for the workflows feature (engine #142 + builder GUI #143). Each finding was confirmed against the code before fixing; every fix has a test.

## Finding 1 (HIGH) — `awaitInput` pause/resume is a hang-forever dead-end → GATED
The executor pauses + checkpoints an `awaitInput` step, but the resume trigger/channel that delivers the operator's reply **never shipped to `main`** (it lives only on the unmerged plugin-office branch). `resumeWorkflowRun` had **zero production callers**. So an agent-drafted "ask me, then act" workflow (which `draft.ts` actively taught) would pause forever, leak a retained child session for the process lifetime, and orphan a `<ulid>.json` checkpoint.

**Decision: gate it.** No reasonable in-tree resume trigger exists on `main`, so `awaitInput` is now **rejected at validate/save time** (`schema.ts`) with a clear message, and `draft.ts` no longer teaches it (steers the author to `inputs`). The executor pause/resume path is kept intact (re-enable = land a resume trigger + remove the schema block). Defense-in-depth:
- `runNow` (CLI) treats a `paused` result as **non-terminal** — no inbox delivery, no false "complete".
- `Session.close()` calls `clearRetainedChildren()` (was dead code, never called) so retained sessions don't leak on shutdown.
- `WorkflowRunStore.sweepStale()` (7-day TTL, run on workflows boot) reaps orphaned `~/.moxxy/workflow-runs/active/` checkpoints.

## Finding 2 (HIGH) — builder IPC non-functional on the DESKTOP → REAL, fixed
Confirmed real. The desktop drives a `RemoteSession`, whose workflows view forwarded only `list`/`setEnabled`/`run` — `validateDraft`/`save`/`getRun` were `undefined`, so the desktop-host IPC threw "workflows builder not supported on this session". Fixed by adding a `workflow.validateDraft|save|getRun` runner-RPC family (**protocol bumped v3 → v4**): RemoteSession client methods + server handlers. Proven by a runner integration test that exercises the methods end-to-end over a real socket (and one asserting a clean "not supported" error when the runner lacks the builder slice).

## Finding 3 (MED) — condition/switch as a loop body
Rejected at validation (its `then`/`else`/`cases` routing was silently ignored by `runLoopStep`).

## Finding 4 (MED) — vars dropped on resume
Checkpoint now persists + restores `vars` set before the pause (moot under the gate, but correct if resume lands).

## Finding 5 (MED) — non-body step `needs` a loop-body step
Rejected at validation (the body step is owned by its loop, excluded from the main DAG, so the dependent would stall).

## Finding 6 (LOW) — prototype pollution in `mergeVars`
Model-provided logic-step `vars` now drop `__proto__`/`constructor`/`prototype` keys.

## Finding 7 (LOW) — rename leaves an orphaned file/entry
`WorkflowStore.save(workflow, previousName)` removes the old file + registry entry on rename, threaded through `WorkflowsView.save` → desktop IPC → runner RPC → the builder hook (which tracks the loaded name).

## Finding 8 (LOW) — loop body bypasses its own `needs`/`when`
Semantics made explicit: body steps run unconditionally each iteration, so a `when` guard or any `needs` other than the loop step / a sibling body step is rejected at validation.

## Tests
New/updated tests across `plugin-workflows` (schema, dag, store, run-store, draft), `runner` (integration), `core` (session close), `cli` (paused-not-delivered), `client-core` (rename `previousName`), `workflows-builder` (error-map fixture). Affected-package totals all green: plugin-workflows 81, runner 44, core 207, cli 117, client-core 47, workflows-builder 32, desktop-ipc-contract 22, desktop-host 207.

## Gate (all exit 0)
`pnpm build` ✅ · `pnpm -w typecheck` ✅ · `pnpm -w test` ✅ · `pnpm -w lint` ✅ (0 errors; 30 warnings, 1 fewer than baseline) · `pnpm check:deps` ✅

## Notes
- Did **not** touch `desktop-ipc-contract`'s `mobileGateway` sections or the `REMOTE_DISALLOWED_COMMANDS` allow-list (owned by the sibling gateway PR). The new builder RPCs ride the existing in-process IPC commands, which are not gateway-disallowed.
- Changeset: `.changeset/workflows-correctness.md`. TECH_DEBT #11 corrected (the "replies once in Virtual Office chat" claim was backed only by the unmerged branch; awaitInput is now documented as gated).