### PR TITLE
feat(workflows): drag-to-connect step wiring on the builder canvas (connections define flow order)

### DIFF
--- a/.changeset/workflows-canvas-connect.md
+++ b/.changeset/workflows-canvas-connect.md
@@ -1,0 +1,29 @@
+---
+'@moxxy/desktop': minor
+'@moxxy/workflows-builder': patch
+---
+
+Workflow builder canvas: drag-to-connect step wiring. You can now draw the
+dependency DAG directly on the canvas instead of only typing into the
+inspector's NEEDS field — and those connections ARE the workflow's execution
+order (an A→B edge means A runs before B).
+
+- Each node card gets connection handles: a left INPUT and a right OUTPUT
+  (plain `needs`). Condition nodes expose labeled `then`/`else` output handles;
+  loop nodes expose an `exit` output handle plus a distinct lower-half "body"
+  drop region (upper-half input = the loop's own `needs`).
+- A pointerdown on a HANDLE starts a connection drag (live temp line following
+  the cursor); a pointerdown on the card BODY still moves the node. Dropping on
+  another node's card dispatches the matching shared op (`connect-needs`,
+  `set-branch`, `set-loop-body`, `set-loop-exit`); dropping on empty canvas or
+  the source's own card cancels cleanly.
+- Existing edges are interactive: click the edge or its midpoint ✕ to remove the
+  dependency (routes through `disconnect-needs` / the relevant set-* op).
+- Self-connects and cycle-closing connections are refused (the latter with a
+  brief inline rejection), so the canvas can't author an invalid DAG.
+- Each node shows its 1-based topological execution order so the flow reads
+  source→target.
+
+workflows-builder: `connectNeeds` now also rejects edges that would create a
+cycle, and exports a pure `wouldCreateCycle(state, from, to)` guard for
+interaction layers to check a gesture before dispatching.

--- a/apps/desktop/src/workflows/WorkflowCanvas.tsx
+++ b/apps/desktop/src/workflows/WorkflowCanvas.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import {
   stepKindMeta,
   WORKFLOW_ERROR_KEY,
+  wouldCreateCycle,
   type BuilderAction,
   type BuilderEdge,
   type BuilderNode,
@@ -13,7 +14,22 @@ import { accentHex } from './accents';
  * The builder canvas: an absolute-positioned layer of draggable step-node
  * cards over an SVG edge layer. Hand-rolled (no react-flow) to avoid pulling a
  * heavy graph lib into the Electron bundle — the graph here is small (≤40
- * steps) and the interactions are limited to drag + select.
+ * steps) and the interactions are limited to drag + select + wire.
+ *
+ * Two pointer gestures share the cards, disambiguated by WHERE the pointerdown
+ * lands:
+ *   - on the card BODY  → MOVE the node (drag.current / move-node).
+ *   - on a connection HANDLE (the small circles on a card's edges) → draw a
+ *     CONNECTION (connect.current); on pointerup over a target node it
+ *     dispatches the matching graph op. These connections ARE the execution
+ *     order: a `needs` edge from A→B means A runs before B.
+ *
+ * Handles per kind (outputs initiate a drag, inputs/targets receive it):
+ *   - every node: a right-edge OUTPUT (plain `needs`) + a left-edge INPUT.
+ *   - condition : `then` (green) + `else` (red) OUTPUT handles → setBranchTargets.
+ *   - loop      : a `body` INPUT region (drop a step → setLoopBody) + an `exit`
+ *                 OUTPUT handle (drag to a step → setLoopExit). No plain input
+ *                 (a loop's predecessors are wired as their own `needs`).
  *
  * Edge legend:
  *   - needs  : solid grey arrow (DAG dependency)
@@ -27,10 +43,22 @@ import { accentHex } from './accents';
 const NODE_W = 200;
 const NODE_H = 88;
 const ANCHOR_OFFSET = NODE_H / 2;
+const HANDLE_R = 7;
 
 interface Props {
   readonly state: BuilderState;
   readonly dispatch: (action: BuilderAction) => void;
+}
+
+/** What a handle emits when its drag is dropped on a target node. */
+type PortKind = 'needs' | 'then' | 'else' | 'loop-exit';
+
+interface PendingConnection {
+  readonly nodeId: string;
+  readonly port: PortKind;
+  /** Handle origin in surface coords (where the temp line starts). */
+  readonly ox: number;
+  readonly oy: number;
 }
 
 const EDGE_STYLE: Record<BuilderEdge['kind'], { color: string; dash?: string; label?: string }> = {
@@ -43,43 +71,162 @@ const EDGE_STYLE: Record<BuilderEdge['kind'], { color: string; dash?: string; la
   'loop-exit': { color: '#7c3aed', label: 'on done / error → next' },
 };
 
+const PORT_COLOR: Record<PortKind, string> = {
+  needs: '#94a3b8',
+  then: '#10b981',
+  else: '#ef4444',
+  'loop-exit': '#7c3aed',
+};
+const LOOP_BODY_COLOR = '#8b5cf6';
+
 export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
   const surfaceRef = useRef<HTMLDivElement>(null);
   const drag = useRef<{ id: string; dx: number; dy: number } | null>(null);
+  const connect = useRef<PendingConnection | null>(null);
   const [dragging, setDragging] = useState<string | null>(null);
+  const [pending, setPending] = useState<PendingConnection | null>(null);
+  const [cursor, setCursor] = useState<{ x: number; y: number } | null>(null);
+  const [hoverTarget, setHoverTarget] = useState<string | null>(null);
+  const [reject, setReject] = useState<string | null>(null);
+  const rejectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const byId = new Map(state.nodes.map((n) => [n.id, n]));
+  const byId = useMemo(() => new Map(state.nodes.map((n) => [n.id, n])), [state.nodes]);
 
-  const onPointerDown = useCallback(
+  /** Topological order index per node (1-based) so the canvas reads as a flow. */
+  const order = useMemo(() => topoOrder(state.nodes), [state.nodes]);
+
+  const surfacePoint = useCallback((e: { clientX: number; clientY: number }) => {
+    const rect = surfaceRef.current?.getBoundingClientRect();
+    const left = surfaceRef.current?.scrollLeft ?? 0;
+    const top = surfaceRef.current?.scrollTop ?? 0;
+    return {
+      x: (rect ? e.clientX - rect.left : e.clientX) + left,
+      y: (rect ? e.clientY - rect.top : e.clientY) + top,
+    };
+  }, []);
+
+  const flashReject = useCallback((msg: string) => {
+    setReject(msg);
+    if (rejectTimer.current) clearTimeout(rejectTimer.current);
+    rejectTimer.current = setTimeout(() => setReject(null), 2600);
+  }, []);
+
+  // --- node move (body drag) ---
+  const onBodyPointerDown = useCallback(
     (e: React.PointerEvent, node: BuilderNode) => {
       e.stopPropagation();
       (e.target as Element).setPointerCapture?.(e.pointerId);
-      const rect = surfaceRef.current?.getBoundingClientRect();
-      const ox = rect ? e.clientX - rect.left : e.clientX;
-      const oy = rect ? e.clientY - rect.top : e.clientY;
-      drag.current = { id: node.id, dx: ox - node.x, dy: oy - node.y };
+      const p = surfacePoint(e);
+      drag.current = { id: node.id, dx: p.x - node.x, dy: p.y - node.y };
       setDragging(node.id);
       dispatch({ type: 'select', id: node.id });
     },
-    [dispatch],
+    [dispatch, surfacePoint],
+  );
+
+  // --- connection drag (handle pointerdown) ---
+  const onHandlePointerDown = useCallback(
+    (e: React.PointerEvent, node: BuilderNode, port: PortKind) => {
+      e.stopPropagation();
+      (e.target as Element).setPointerCapture?.(e.pointerId);
+      const origin = portOrigin(node, port);
+      const start: PendingConnection = { nodeId: node.id, port, ox: origin.x, oy: origin.y };
+      connect.current = start;
+      setPending(start);
+      const p = surfacePoint(e);
+      setCursor(p);
+    },
+    [surfacePoint],
   );
 
   const onPointerMove = useCallback(
     (e: React.PointerEvent) => {
-      if (!drag.current) return;
-      const rect = surfaceRef.current?.getBoundingClientRect();
-      const ox = rect ? e.clientX - rect.left : e.clientX;
-      const oy = rect ? e.clientY - rect.top : e.clientY;
-      const x = Math.max(0, ox - drag.current.dx);
-      const y = Math.max(0, oy - drag.current.dy);
-      dispatch({ type: 'move-node', id: drag.current.id, x, y });
+      const p = surfacePoint(e);
+      if (drag.current) {
+        const x = Math.max(0, p.x - drag.current.dx);
+        const y = Math.max(0, p.y - drag.current.dy);
+        dispatch({ type: 'move-node', id: drag.current.id, x, y });
+        return;
+      }
+      if (connect.current) {
+        setCursor(p);
+        setHoverTarget(nodeAt(state.nodes, p, connect.current.nodeId));
+      }
     },
-    [dispatch],
+    [dispatch, state.nodes, surfacePoint],
   );
 
-  const onPointerUp = useCallback(() => {
-    drag.current = null;
-    setDragging(null);
+  const finishConnection = useCallback(
+    (p: { x: number; y: number }) => {
+      const c = connect.current;
+      connect.current = null;
+      setPending(null);
+      setCursor(null);
+      setHoverTarget(null);
+      if (!c) return;
+      const targetId = nodeAt(state.nodes, p, c.nodeId);
+      if (!targetId) return; // dropped on empty canvas → cancel, no-op
+      const target = byId.get(targetId);
+      const source = byId.get(c.nodeId);
+      if (!target || !source || target.id === source.id) return;
+
+      switch (c.port) {
+        case 'needs': {
+          // Dropping a plain output onto a LOOP is ambiguous, so we read the
+          // drop sub-region: the lower "body" half adds the source to the loop
+          // body (it runs INSIDE the loop); the upper half wires a plain `needs`
+          // (the source runs BEFORE the loop).
+          if (target.kind === 'loop' && target.loop) {
+            if (inBodyRegion(target, p)) {
+              if (target.loop.body.includes(source.id)) return;
+              dispatch({ type: 'set-loop-body', loopId: target.id, body: [...target.loop.body, source.id] });
+              return;
+            }
+          }
+          if (wouldCreateCycle(state, source.id, target.id)) {
+            flashReject(`Can't connect ${labelOf(source)} → ${labelOf(target)}: it would create a cycle.`);
+            return;
+          }
+          dispatch({ type: 'connect-needs', from: source.id, to: target.id });
+          return;
+        }
+        case 'then':
+        case 'else': {
+          const current = (c.port === 'then' ? source.then : source.else) ?? [];
+          if (current.includes(target.id)) return;
+          dispatch({ type: 'set-branch', nodeId: source.id, slot: c.port, targets: [...current, target.id] });
+          return;
+        }
+        case 'loop-exit': {
+          // Source is the loop; target becomes its single exit (on done/error → next).
+          dispatch({ type: 'set-loop-exit', loopId: source.id, targetId: target.id });
+          return;
+        }
+      }
+    },
+    [byId, dispatch, flashReject, state],
+  );
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      if (drag.current) {
+        drag.current = null;
+        setDragging(null);
+        return;
+      }
+      if (connect.current) finishConnection(surfacePoint(e));
+    },
+    [finishConnection, surfacePoint],
+  );
+
+  // Pointer leaving the surface mid-connection cancels cleanly (no stuck line).
+  const onPointerLeave = useCallback(() => {
+    if (connect.current) {
+      connect.current = null;
+      setPending(null);
+      setCursor(null);
+      setHoverTarget(null);
+    }
   }, []);
 
   const width = Math.max(900, ...state.nodes.map((n) => n.x + NODE_W + 80));
@@ -91,6 +238,7 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
       data-testid="workflow-canvas"
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
+      onPointerLeave={onPointerLeave}
       onClick={() => dispatch({ type: 'select', id: null })}
       style={{
         position: 'relative',
@@ -126,8 +274,17 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
             const from = byId.get(edge.from);
             const to = byId.get(edge.to);
             if (!from || !to) return null;
-            return <Edge key={edge.id} edge={edge} from={from} to={to} />;
+            return (
+              <Edge
+                key={edge.id}
+                edge={edge}
+                from={from}
+                to={to}
+                onDisconnect={() => disconnectEdge(dispatch, edge, from)}
+              />
+            );
           })}
+          {pending && cursor && <TempLine from={{ x: pending.ox, y: pending.oy }} to={cursor} port={pending.port} />}
         </svg>
 
         {state.nodes.map((node) => (
@@ -137,7 +294,11 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
             selected={state.selected === node.id}
             dragging={dragging === node.id}
             errors={state.errors[node.id]?.length ?? 0}
-            onPointerDown={(e) => onPointerDown(e, node)}
+            order={order.get(node.id)}
+            connecting={pending != null}
+            isHoverTarget={hoverTarget === node.id}
+            onBodyPointerDown={(e) => onBodyPointerDown(e, node)}
+            onHandlePointerDown={(e, port) => onHandlePointerDown(e, node, port)}
           />
         ))}
 
@@ -156,21 +317,95 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
           </div>
         )}
       </div>
+
+      {reject && (
+        <div
+          role="alert"
+          data-testid="connect-reject"
+          style={{
+            position: 'sticky',
+            bottom: 12,
+            margin: '0 auto',
+            width: 'fit-content',
+            maxWidth: '80%',
+            padding: '0.4rem 0.7rem',
+            background: 'var(--color-red)',
+            color: 'var(--color-bg)',
+            fontSize: '0.76rem',
+            fontWeight: 600,
+            borderRadius: 'var(--radius-block)',
+            boxShadow: 'var(--color-card-shadow)',
+            zIndex: 10,
+          }}
+        >
+          {reject}
+        </div>
+      )}
     </div>
   );
 }
 
-function Edge({ edge, from, to }: { edge: BuilderEdge; from: BuilderNode; to: BuilderNode }): JSX.Element {
+function TempLine({
+  from,
+  to,
+  port,
+}: {
+  from: { x: number; y: number };
+  to: { x: number; y: number };
+  port: PortKind;
+}): JSX.Element {
+  const midX = (from.x + to.x) / 2;
+  const path = `M ${from.x} ${from.y} C ${midX} ${from.y}, ${midX} ${to.y}, ${to.x} ${to.y}`;
+  return (
+    <path
+      data-testid="temp-connection"
+      d={path}
+      fill="none"
+      stroke={PORT_COLOR[port]}
+      strokeWidth={2}
+      strokeDasharray="5 4"
+      opacity={0.85}
+    />
+  );
+}
+
+function Edge({
+  edge,
+  from,
+  to,
+  onDisconnect,
+}: {
+  edge: BuilderEdge;
+  from: BuilderNode;
+  to: BuilderNode;
+  onDisconnect: () => void;
+}): JSX.Element {
   const style = EDGE_STYLE[edge.kind];
   const x1 = from.x + NODE_W;
   const y1 = from.y + ANCHOR_OFFSET;
   const x2 = to.x;
   const y2 = to.y + ANCHOR_OFFSET;
   const midX = (x1 + x2) / 2;
+  const midY = (y1 + y2) / 2;
   const path = `M ${x1} ${y1} C ${midX} ${y1}, ${midX} ${y2}, ${x2} ${y2}`;
   const label = edge.caseId ?? style.label;
+  const onRemove = (e: { stopPropagation: () => void }): void => {
+    e.stopPropagation();
+    onDisconnect();
+  };
   return (
-    <g>
+    <g data-testid={`wf-edge-${edge.id}`}>
+      {/* fat invisible hit area so the thin edge is easy to click to delete */}
+      <path
+        d={path}
+        fill="none"
+        stroke="transparent"
+        strokeWidth={14}
+        style={{ pointerEvents: 'stroke', cursor: 'pointer' }}
+        onClick={onRemove}
+      >
+        <title>Click to remove this connection</title>
+      </path>
       <path
         d={path}
         fill="none"
@@ -178,19 +413,37 @@ function Edge({ edge, from, to }: { edge: BuilderEdge; from: BuilderNode; to: Bu
         strokeWidth={2}
         strokeDasharray={style.dash}
         markerEnd={`url(#arrow-${edge.kind})`}
+        style={{ pointerEvents: 'none' }}
       />
       {label && (
         <text
           x={midX}
-          y={(y1 + y2) / 2 - 6}
+          y={midY - 6}
           textAnchor="middle"
           fontSize="10"
           fill={style.color}
-          style={{ fontWeight: 600, paintOrder: 'stroke', stroke: 'var(--color-bg)', strokeWidth: 3 }}
+          style={{
+            fontWeight: 600,
+            paintOrder: 'stroke',
+            stroke: 'var(--color-bg)',
+            strokeWidth: 3,
+            pointerEvents: 'none',
+          }}
         >
           {label}
         </text>
       )}
+      {/* a small ✕ at the midpoint to delete the connection */}
+      <g
+        data-testid={`wf-edge-remove-${edge.id}`}
+        transform={`translate(${midX}, ${midY + 8})`}
+        style={{ pointerEvents: 'all', cursor: 'pointer' }}
+        onClick={onRemove}
+      >
+        <circle r={7} fill="var(--color-bg-card)" stroke={style.color} strokeWidth={1} />
+        <path d="M -3 -3 L 3 3 M 3 -3 L -3 3" stroke={style.color} strokeWidth={1.4} />
+        <title>Remove this connection</title>
+      </g>
     </g>
   );
 }
@@ -200,21 +453,31 @@ function NodeCard({
   selected,
   dragging,
   errors,
-  onPointerDown,
+  order,
+  connecting,
+  isHoverTarget,
+  onBodyPointerDown,
+  onHandlePointerDown,
 }: {
   node: BuilderNode;
   selected: boolean;
   dragging: boolean;
   errors: number;
-  onPointerDown: (e: React.PointerEvent) => void;
+  order: number | undefined;
+  connecting: boolean;
+  isHoverTarget: boolean;
+  onBodyPointerDown: (e: React.PointerEvent) => void;
+  onHandlePointerDown: (e: React.PointerEvent, port: PortKind) => void;
 }): JSX.Element {
   const meta = stepKindMeta(node.kind);
   const accent = accentHex(meta.accent);
   const isLoop = node.kind === 'loop';
+  const isCondition = node.kind === 'condition';
+  const isSwitch = node.kind === 'switch';
   return (
     <div
       data-testid={`wf-node-${node.id}`}
-      onPointerDown={onPointerDown}
+      onPointerDown={onBodyPointerDown}
       onClick={(e) => e.stopPropagation()}
       style={{
         position: 'absolute',
@@ -227,34 +490,56 @@ function NodeCard({
         background: 'var(--color-bg-card)',
         borderStyle: 'solid',
         borderWidth: '2px 2px 2px 5px',
-        borderColor: `${selected ? accent : errors > 0 ? 'var(--color-red)' : 'var(--color-border)'}`,
+        borderColor: `${
+          isHoverTarget ? 'var(--color-primary)' : selected ? accent : errors > 0 ? 'var(--color-red)' : 'var(--color-border)'
+        }`,
         borderLeftColor: accent,
         borderRadius: 'var(--radius-block)',
-        boxShadow: selected ? `0 4px 16px -6px ${accent}` : 'var(--color-card-shadow)',
+        boxShadow: isHoverTarget
+          ? '0 0 0 2px var(--color-primary)'
+          : selected
+            ? `0 4px 16px -6px ${accent}`
+            : 'var(--color-card-shadow)',
         padding: '0.5rem 0.65rem',
         zIndex: selected ? 3 : 2,
       }}
     >
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 6 }}>
-        <span
-          style={{
-            fontSize: '0.6rem',
-            fontWeight: 700,
-            textTransform: 'uppercase',
-            letterSpacing: '0.04em',
-            color: accent,
-          }}
-        >
-          {meta.label}
+        <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          {order != null && (
+            <span
+              title={`step ${order} in execution order`}
+              style={{
+                fontSize: '0.58rem',
+                fontWeight: 800,
+                minWidth: 16,
+                height: 16,
+                lineHeight: '16px',
+                textAlign: 'center',
+                borderRadius: '50%',
+                color: 'var(--color-bg)',
+                background: accent,
+              }}
+            >
+              {order}
+            </span>
+          )}
+          <span
+            style={{
+              fontSize: '0.6rem',
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.04em',
+              color: accent,
+            }}
+          >
+            {meta.label}
+          </span>
         </span>
         {errors > 0 && (
           <span
             title={`${errors} validation issue(s)`}
-            style={{
-              fontSize: '0.6rem',
-              fontWeight: 700,
-              color: 'var(--color-red)',
-            }}
+            style={{ fontSize: '0.6rem', fontWeight: 700, color: 'var(--color-red)' }}
           >
             ⚠ {errors}
           </span>
@@ -278,13 +563,279 @@ function NodeCard({
           ? `loop · ${node.loop?.body.length ?? 0} in body · max ${node.loop?.maxIterations ?? 10}`
           : preview(node.action)}
       </div>
+
+      {/* --- INPUT handle(s) (left edge): drop targets / receivers --- */}
+      {isLoop ? (
+        <>
+          <Handle
+            node={node}
+            port="needs"
+            side="left"
+            y={ANCHOR_OFFSET - 16}
+            input
+            title="Input — drop a step's output on the UPPER half so it runs BEFORE the loop"
+            connecting={connecting}
+          />
+          <BodyDropHandle node={node} y={ANCHOR_OFFSET + 16} connecting={connecting} />
+        </>
+      ) : (
+        <Handle
+          node={node}
+          port="needs"
+          side="left"
+          y={ANCHOR_OFFSET}
+          input
+          title="Input — drag a connection here to make this step depend on another"
+          connecting={connecting}
+        />
+      )}
+
+      {/* --- OUTPUT handle(s) (right edge): initiate a connection drag --- */}
+      {isCondition ? (
+        <>
+          <Handle
+            node={node}
+            port="then"
+            side="right"
+            y={ANCHOR_OFFSET - 14}
+            title="then → drag to the step that runs when the condition is met"
+            onPointerDown={(e) => onHandlePointerDown(e, 'then')}
+          />
+          <Handle
+            node={node}
+            port="else"
+            side="right"
+            y={ANCHOR_OFFSET + 14}
+            title="else → drag to the step that runs when the condition is NOT met"
+            onPointerDown={(e) => onHandlePointerDown(e, 'else')}
+          />
+        </>
+      ) : isLoop ? (
+        <Handle
+          node={node}
+          port="loop-exit"
+          side="right"
+          y={ANCHOR_OFFSET}
+          title="exit → drag to the step the loop continues to (on done / on error)"
+          onPointerDown={(e) => onHandlePointerDown(e, 'loop-exit')}
+        />
+      ) : (
+        <Handle
+          node={node}
+          port="needs"
+          side="right"
+          y={ANCHOR_OFFSET}
+          title={
+            isSwitch
+              ? 'Output — drag to a step that should run after this (set cases in the inspector)'
+              : 'Output — drag to a step that should run after this one'
+          }
+          onPointerDown={(e) => onHandlePointerDown(e, 'needs')}
+        />
+      )}
     </div>
   );
+}
+
+function Handle({
+  node,
+  port,
+  side,
+  y,
+  title,
+  input,
+  connecting,
+  onPointerDown,
+}: {
+  node: BuilderNode;
+  port: PortKind;
+  side: 'left' | 'right';
+  y: number;
+  title: string;
+  /** A pure receiving input (no drag); highlight while a connection is active. */
+  input?: boolean;
+  connecting?: boolean;
+  onPointerDown?: (e: React.PointerEvent) => void;
+}): JSX.Element {
+  const color = PORT_COLOR[port];
+  return (
+    <div
+      data-testid={`wf-handle-${node.id}-${port}-${side}`}
+      title={title}
+      onPointerDown={
+        onPointerDown
+          ? (e) => {
+              // A handle pointerdown must NOT start a node move — own the event.
+              e.stopPropagation();
+              onPointerDown(e);
+            }
+          : undefined
+      }
+      onClick={(e) => e.stopPropagation()}
+      style={{
+        position: 'absolute',
+        top: y - HANDLE_R,
+        [side]: -HANDLE_R,
+        width: HANDLE_R * 2,
+        height: HANDLE_R * 2,
+        borderRadius: '50%',
+        background: input && connecting ? color : 'var(--color-bg-card)',
+        border: `2px solid ${color}`,
+        cursor: input ? 'default' : 'crosshair',
+        boxShadow: input && connecting ? `0 0 0 3px color-mix(in oklab, ${color} 40%, transparent)` : 'none',
+        zIndex: 4,
+      } as React.CSSProperties}
+    />
+  );
+}
+
+/**
+ * The loop's "body" drop region — a distinct purple input handle on the lower
+ * half of the loop card. Dropping a step's output here (i.e. anywhere over the
+ * loop's lower half) adds it to the loop body via setLoopBody. It's a passive
+ * receiver, so it only highlights; the drop is resolved by {@link inBodyRegion}.
+ */
+function BodyDropHandle({
+  node,
+  y,
+  connecting,
+}: {
+  node: BuilderNode;
+  y: number;
+  connecting: boolean;
+}): JSX.Element {
+  return (
+    <div
+      data-testid={`wf-handle-${node.id}-loop-body-left`}
+      title="Body — drop a step's output on the LOWER half so it runs INSIDE the loop"
+      onClick={(e) => e.stopPropagation()}
+      style={{
+        position: 'absolute',
+        top: y - HANDLE_R,
+        left: -HANDLE_R,
+        width: HANDLE_R * 2,
+        height: HANDLE_R * 2,
+        borderRadius: '50%',
+        background: connecting ? LOOP_BODY_COLOR : 'var(--color-bg-card)',
+        border: `2px dashed ${LOOP_BODY_COLOR}`,
+        boxShadow: connecting ? `0 0 0 3px color-mix(in oklab, ${LOOP_BODY_COLOR} 40%, transparent)` : 'none',
+        zIndex: 4,
+      }}
+    />
+  );
+}
+
+/** Compute the surface-space origin of a node's output handle for the temp line. */
+function portOrigin(node: BuilderNode, port: PortKind): { x: number; y: number } {
+  switch (port) {
+    case 'then':
+      return { x: node.x + NODE_W, y: node.y + ANCHOR_OFFSET - 14 };
+    case 'else':
+      return { x: node.x + NODE_W, y: node.y + ANCHOR_OFFSET + 14 };
+    case 'loop-exit':
+    case 'needs':
+    default:
+      return { x: node.x + NODE_W, y: node.y + ANCHOR_OFFSET };
+  }
+}
+
+/** The lower half of a loop card is its "body" drop region (vs the upper input). */
+function inBodyRegion(loop: BuilderNode, p: { x: number; y: number }): boolean {
+  return p.y >= loop.y + ANCHOR_OFFSET;
+}
+
+/**
+ * Dispatch the correct disconnect for an edge's kind, reversing whatever wiring
+ * op produced it. Each case routes through an EXISTING shared op (no new graph
+ * logic in the desktop layer): branch/loop edges re-set their target list with
+ * the one target filtered out; `needs`/`loop-exit` have direct inverse ops.
+ * `from` is the edge's source node, needed to read its current target lists.
+ */
+function disconnectEdge(dispatch: (a: BuilderAction) => void, edge: BuilderEdge, from: BuilderNode): void {
+  switch (edge.kind) {
+    case 'needs':
+      dispatch({ type: 'disconnect-needs', from: edge.from, to: edge.to });
+      return;
+    case 'then':
+    case 'else': {
+      const current = (edge.kind === 'then' ? from.then : from.else) ?? [];
+      dispatch({ type: 'set-branch', nodeId: edge.from, slot: edge.kind, targets: current.filter((t) => t !== edge.to) });
+      return;
+    }
+    case 'default': {
+      const current = from.default ?? [];
+      dispatch({ type: 'set-branch', nodeId: edge.from, slot: 'default', targets: current.filter((t) => t !== edge.to) });
+      return;
+    }
+    case 'case': {
+      const caseId = edge.caseId ?? '';
+      const current = from.cases?.[caseId] ?? [];
+      dispatch({ type: 'set-case', nodeId: edge.from, caseId, targets: current.filter((t) => t !== edge.to) });
+      return;
+    }
+    case 'loop-body': {
+      const body = from.loop?.body ?? [];
+      dispatch({ type: 'set-loop-body', loopId: edge.from, body: body.filter((b) => b !== edge.to) });
+      return;
+    }
+    case 'loop-exit':
+      dispatch({ type: 'set-loop-exit', loopId: edge.from, targetId: null });
+      return;
+  }
+}
+
+/** The node whose card contains the point (excluding `exclude`), or null. */
+function nodeAt(
+  nodes: ReadonlyArray<BuilderNode>,
+  p: { x: number; y: number },
+  exclude: string,
+): string | null {
+  // Iterate in reverse so a node drawn on top wins when cards overlap.
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    const n = nodes[i]!;
+    if (n.id === exclude) continue;
+    if (p.x >= n.x && p.x <= n.x + NODE_W && p.y >= n.y && p.y <= n.y + NODE_H) return n.id;
+  }
+  return null;
+}
+
+/**
+ * A 1-based topological index per node over the `needs` DAG (longest-path
+ * layering, ties broken by array order). Makes the execution order legible on
+ * the cards. Cyclic graphs (which the connect guard prevents, but a loaded YAML
+ * could still contain) just fall back to insertion order for the affected nodes.
+ */
+function topoOrder(nodes: ReadonlyArray<BuilderNode>): Map<string, number> {
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const depth = new Map<string, number>();
+  const resolve = (id: string, seen: Set<string>): number => {
+    const cached = depth.get(id);
+    if (cached != null) return cached;
+    if (seen.has(id)) return 0; // cycle guard
+    seen.add(id);
+    const needs = byId.get(id)?.needs ?? [];
+    const d = needs.length === 0 ? 0 : Math.max(...needs.map((n) => (byId.has(n) ? resolve(n, seen) + 1 : 0)));
+    seen.delete(id);
+    depth.set(id, d);
+    return d;
+  };
+  for (const n of nodes) resolve(n.id, new Set());
+  // Rank by (depth, insertion index) then assign 1..N.
+  const ranked = [...nodes]
+    .map((n, idx) => ({ id: n.id, depth: depth.get(n.id) ?? 0, idx }))
+    .sort((a, b) => a.depth - b.depth || a.idx - b.idx);
+  const order = new Map<string, number>();
+  ranked.forEach((r, i) => order.set(r.id, i + 1));
+  return order;
 }
 
 function preview(text: string): string {
   const t = (text ?? '').trim().replace(/\s+/g, ' ');
   return t.length > 0 ? t : '(empty)';
+}
+
+function labelOf(node: BuilderNode): string {
+  return node.label || node.id;
 }
 
 export { WORKFLOW_ERROR_KEY };

--- a/apps/desktop/src/workflows/WorkflowsPanel.test.tsx
+++ b/apps/desktop/src/workflows/WorkflowsPanel.test.tsx
@@ -11,8 +11,8 @@
  * the wiring (render ↔ reducer ↔ IPC) the panel is responsible for.
  */
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { render, screen, fireEvent, waitFor, within, act, createEvent } from '@testing-library/react';
 import { __setApiOverride } from '@moxxy/client-core';
 import type { MoxxyApi, WorkflowSummary } from '@moxxy/desktop-ipc-contract';
 import { WorkflowsPanel } from './WorkflowsPanel';
@@ -132,5 +132,129 @@ describe('WorkflowsPanel — builder', () => {
     // The debounced live validation maps the error onto the node + inspector.
     const errors = await screen.findByTestId('node-errors', undefined, { timeout: 2000 });
     expect(errors.textContent).toContain('ghost');
+  });
+});
+
+/**
+ * Drag-to-connect on the canvas. Two jsdom quirks shape these tests:
+ *   1. getBoundingClientRect is all-zeros + scroll is 0, so surface coords ==
+ *      clientX/clientY and node hit-testing is purely positional — we lay nodes
+ *      out by dragging them to known spots, then assert the derived edges.
+ *   2. jsdom's PointerEvent drops clientX/clientY, so `firePointer` builds the
+ *      event and forces the coordinates on before dispatch.
+ */
+type PointerType = 'pointerDown' | 'pointerMove' | 'pointerUp';
+function firePointer(el: Element, type: PointerType, x: number, y: number, pointerId = 1): void {
+  const ev = createEvent[type](el, { clientX: x, clientY: y, pointerId });
+  Object.defineProperty(ev, 'clientX', { value: x });
+  Object.defineProperty(ev, 'clientY', { value: y });
+  fireEvent(el, ev);
+}
+
+describe('WorkflowsPanel — canvas drag-to-connect', () => {
+  async function openWith(spyOpts?: Parameters<typeof installApi>[0]): Promise<Spy> {
+    const spy = installApi({ list: [], ...spyOpts });
+    render(<WorkflowsPanel />);
+    fireEvent.click(await screen.findByTestId('new-workflow'));
+    await screen.findByTestId('workflow-canvas');
+    return spy;
+  }
+
+  /** Body-drag a node from its current origin to (x, y). */
+  function moveNodeTo(id: string, fromX: number, fromY: number, x: number, y: number): void {
+    const canvas = screen.getByTestId('workflow-canvas');
+    firePointer(screen.getByTestId(`wf-node-${id}`), 'pointerDown', fromX, fromY);
+    firePointer(canvas, 'pointerMove', x, y);
+    firePointer(canvas, 'pointerUp', x, y);
+  }
+
+  /** Drag from a source handle to a drop point on the canvas. */
+  function dragConnect(handleTestId: string, fromX: number, fromY: number, toX: number, toY: number): void {
+    const canvas = screen.getByTestId('workflow-canvas');
+    firePointer(screen.getByTestId(handleTestId), 'pointerDown', fromX, fromY, 2);
+    firePointer(canvas, 'pointerMove', toX, toY, 2);
+    firePointer(canvas, 'pointerUp', toX, toY, 2);
+  }
+
+  // First two prompt steps land at (40,40) and (80,80). Spread B clear of A.
+  async function twoNodes(): Promise<Spy> {
+    const spy = await openWith();
+    fireEvent.click(screen.getByTestId('palette-add-prompt')); // -> id "prompt" @ (40,40)
+    await screen.findByTestId('wf-node-prompt');
+    fireEvent.click(screen.getByTestId('palette-add-prompt')); // -> id "prompt_2" @ (80,80)
+    await screen.findByTestId('wf-node-prompt_2');
+    moveNodeTo('prompt_2', 80, 80, 400, 300); // B card now spans x∈[400,600], y∈[300,388]
+    return spy;
+  }
+
+  it('dragging A.output → over B dispatches connect ⇒ B.needs=[A] (a needs edge appears)', async () => {
+    await twoNodes();
+    dragConnect('wf-handle-prompt-needs-right', 240, 84, 460, 320);
+    // connect-needs(from=prompt, to=prompt_2) derives this edge.
+    expect(await screen.findByTestId('wf-edge-needs:prompt->prompt_2')).toBeInTheDocument();
+  });
+
+  it('pointerup on empty canvas cancels — no edge, no stuck temp line', async () => {
+    await twoNodes();
+    const canvas = screen.getByTestId('workflow-canvas');
+    firePointer(screen.getByTestId('wf-handle-prompt-needs-right'), 'pointerDown', 240, 84, 2);
+    firePointer(canvas, 'pointerMove', 700, 500, 2);
+    expect(screen.getByTestId('temp-connection')).toBeInTheDocument(); // line is live mid-drag
+    firePointer(canvas, 'pointerUp', 700, 500, 2);
+    expect(screen.queryByTestId('temp-connection')).not.toBeInTheDocument(); // cleared
+    expect(screen.queryByTestId('wf-edge-needs:prompt->prompt_2')).not.toBeInTheDocument();
+  });
+
+  it('clicking an edge ✕ dispatches disconnect (the edge disappears)', async () => {
+    await twoNodes();
+    dragConnect('wf-handle-prompt-needs-right', 240, 84, 460, 320); // wire A→B
+    await screen.findByTestId('wf-edge-needs:prompt->prompt_2');
+    // Then remove it via the midpoint ✕.
+    fireEvent.click(screen.getByTestId('wf-edge-remove-needs:prompt->prompt_2'));
+    await waitFor(() =>
+      expect(screen.queryByTestId('wf-edge-needs:prompt->prompt_2')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('a self-connect (drop the output back on its own card) is a no-op', async () => {
+    await twoNodes();
+    // Drop back inside A's own card (A spans x∈[40,240], y∈[40,128]).
+    dragConnect('wf-handle-prompt-needs-right', 240, 84, 120, 80);
+    expect(screen.queryByTestId('wf-edge-needs:prompt->prompt')).not.toBeInTheDocument();
+  });
+
+  it('refuses a drag that would create a cycle (surfaces a rejection)', async () => {
+    await twoNodes();
+    dragConnect('wf-handle-prompt-needs-right', 240, 84, 460, 320); // A→B
+    await screen.findByTestId('wf-edge-needs:prompt->prompt_2');
+    // Now drag B's output back onto A — that B→A would close A→B→A.
+    dragConnect('wf-handle-prompt_2-needs-right', 600, 344, 120, 80);
+    expect(await screen.findByTestId('connect-reject')).toBeInTheDocument();
+    expect(screen.queryByTestId('wf-edge-needs:prompt_2->prompt')).not.toBeInTheDocument();
+  });
+
+  it('dropping a step onto a loop card BODY region wires it into the loop body', async () => {
+    await openWith();
+    fireEvent.click(screen.getByTestId('palette-add-loop')); // id "loop" @ (40,40)
+    await screen.findByTestId('wf-node-loop');
+    fireEvent.click(screen.getByTestId('palette-add-bridge')); // id "bridge" @ (80,80)
+    await screen.findByTestId('wf-node-bridge');
+    moveNodeTo('loop', 40, 40, 400, 300); // loop spans x∈[400,600], y∈[300,388]; body region y≥344
+    // Drop the bridge output on the loop's LOWER (body) half (y > 344).
+    dragConnect('wf-handle-bridge-needs-right', 280, 124, 460, 370);
+    // setLoopBody derives a loop-body edge loop -> bridge.
+    expect(await screen.findByTestId('wf-edge-body:loop->bridge')).toBeInTheDocument();
+  });
+
+  it("dragging a condition's 'then' handle to a target sets the branch", async () => {
+    await openWith();
+    fireEvent.click(screen.getByTestId('palette-add-condition')); // id "condition" @ (40,40)
+    await screen.findByTestId('wf-node-condition');
+    fireEvent.click(screen.getByTestId('palette-add-prompt')); // id "prompt" @ (80,80)
+    await screen.findByTestId('wf-node-prompt');
+    moveNodeTo('prompt', 80, 80, 400, 300); // target spans x∈[400,600], y∈[300,388]
+    dragConnect('wf-handle-condition-then-right', 240, 70, 460, 320);
+    // setBranchTargets(condition, 'then', ['prompt']) derives a then edge.
+    expect(await screen.findByTestId('wf-edge-then:condition->prompt')).toBeInTheDocument();
   });
 });

--- a/packages/workflows-builder/src/operations.test.ts
+++ b/packages/workflows-builder/src/operations.test.ts
@@ -16,6 +16,7 @@ import {
   uniqueId,
   updateMeta,
   updateNode,
+  wouldCreateCycle,
 } from './operations.js';
 import { loopExitTarget } from './serialize.js';
 
@@ -63,6 +64,20 @@ describe('needs edges', () => {
     expect(s.nodes.find((n) => n.id === 'b')!.needs).toEqual(['a']);
     s = disconnectNeeds(s, 'a', 'b');
     expect(s.nodes.find((n) => n.id === 'b')!.needs).toEqual([]);
+  });
+
+  it('refuses a connection that would create a cycle', () => {
+    let s = emptyState();
+    for (const id of ['a', 'b', 'c']) s = addStep(s, { kind: 'prompt', id });
+    s = connectNeeds(s, 'a', 'b'); // a → b
+    s = connectNeeds(s, 'b', 'c'); // b → c
+    expect(wouldCreateCycle(s, 'c', 'a')).toBe(true); // c → a closes a→b→c→a
+    const before = s;
+    s = connectNeeds(s, 'c', 'a');
+    expect(s).toBe(before); // no-op, no cycle authored
+    expect(s.nodes.find((n) => n.id === 'a')!.needs).toEqual([]);
+    // the reverse direction (already implied) is fine and idempotent
+    expect(wouldCreateCycle(s, 'a', 'c')).toBe(false);
   });
 });
 

--- a/packages/workflows-builder/src/operations.ts
+++ b/packages/workflows-builder/src/operations.ts
@@ -153,15 +153,43 @@ export function selectNode(state: BuilderState, id: string | null): BuilderState
   return { ...state, selected: id };
 }
 
-/** Add a `needs` dependency edge (idempotent; ignores self/unknown). */
+/** Add a `needs` dependency edge (idempotent; ignores self/unknown/cyclic). */
 export function connectNeeds(state: BuilderState, from: string, to: string): BuilderState {
   if (from === to) return state;
   const exists = state.nodes.some((n) => n.id === from) && state.nodes.some((n) => n.id === to);
   if (!exists) return state;
+  // `to` would `needs: [from]`, i.e. `from` must run before `to`. If `from`
+  // already (transitively) depends on `to`, that edge closes a cycle the engine
+  // can never schedule — refuse it here so the canvas can't author an invalid
+  // DAG the way the inspector's free-text field could.
+  if (wouldCreateCycle(state, from, to)) return state;
   const nodes = state.nodes.map((n) =>
     n.id === to && !n.needs.includes(from) ? { ...n, needs: [...n.needs, from] } : n,
   );
   return refresh(state, nodes);
+}
+
+/**
+ * Would adding `to.needs += from` (⇒ `from` runs before `to`) close a cycle in
+ * the `needs` DAG? True iff `from` already depends — directly or transitively —
+ * on `to`. Pure + synchronous so interaction layers can guard a gesture before
+ * dispatching (server validation also rejects cycles, but only after a save).
+ */
+export function wouldCreateCycle(state: BuilderState, from: string, to: string): boolean {
+  if (from === to) return true;
+  const byId = new Map(state.nodes.map((n) => [n.id, n]));
+  // Walk `from`'s upstream dependencies; if we reach `to`, the new edge cycles.
+  const stack = [from];
+  const seen = new Set<string>();
+  while (stack.length > 0) {
+    const id = stack.pop()!;
+    if (id === to) return true;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const node = byId.get(id);
+    if (node) stack.push(...node.needs);
+  }
+  return false;
 }
 
 /** Remove a `needs` dependency edge. */


### PR DESCRIPTION
## What

The desktop workflow builder canvas rendered step-node cards and drew edge lines from each step's `needs`, but there was **no way to draw a connection** — the only way to set a dependency was typing into the inspector's NEEDS field. This adds point-to-point drag-to-connect wiring, like a real node editor.

These connections **are the workflow's execution order**: a `needs` edge A→B means A runs before B. All graph mutations go through the shared `@moxxy/workflows-builder` operations via dispatch — no graph logic is duplicated in the desktop layer.

## The handle / drag UX

- **Ports on each card** (small circles): a left **INPUT** and a right **OUTPUT** (plain `needs`).
  - **Condition** nodes: labeled `then` (green) + `else` (red) output handles.
  - **Loop** nodes: an `exit` output handle (right) + a distinct lower-half **"body" drop region** (purple dashed) vs the upper-half `needs` input.
- **Move vs connect disambiguation:** a pointerdown on the card **BODY** moves the node (existing behavior, unchanged); a pointerdown on a **HANDLE** starts a connection (handles `stopPropagation` so they never trigger a move).
- **Drag:** a live dashed temp line follows the cursor from the handle. On pointerup:
  - over another node → dispatch the matching op (`connect-needs` / `set-branch` / `set-loop-body` / `set-loop-exit`).
  - over empty canvas, the source's own card, or on pointer-leave → cancel cleanly (no stuck temp line).
- Output→input semantics: `connectNeeds(from=source, to=target)` ⇒ `target.needs += source` ⇒ **source runs before target**.

## Loop / branch wiring (all wired, none deferred)

- **Loop body:** drop a step's output on the loop card's **lower half** → `setLoopBody(loop, [...body, step])`. Drop on the **upper half** → plain `needs` (the step runs before the loop).
- **Loop exit:** drag the loop's `exit` output handle to a target → `setLoopExit(loop, target)` (the single on-done/on-error→next edge).
- **Condition then/else:** drag the labeled output handle to a target → `setBranchTargets(node, slot, …)`.
- Switch `case`/`default` outputs use the generic output handle for plain ordering; per-case handles are left to the inspector (cases are created there). Switch case/default **edges remain clickable to remove**.

## Edge deletion / re-wiring

Every existing edge is interactive: click the edge line or its midpoint ✕ to remove the dependency. Each kind routes through its existing inverse op (`disconnect-needs`, or `set-branch`/`set-case`/`set-loop-body` re-set with the target filtered, `set-loop-exit(null)`).

## Guards

- **Self-connect:** dropping the output back on the source card resolves to no target → no-op.
- **Cycle:** `connectNeeds` now refuses any edge that would close a cycle, and a new pure `wouldCreateCycle(state, from, to)` lets the canvas check the gesture up-front and surface a brief inline rejection instead of silently authoring an invalid DAG (server validation is async via `validateDraft`, so the canvas needs a synchronous guard).

## Legibility

Each node shows a **1-based topological execution-order badge** (longest-path layering over the `needs` DAG), and arrows read source→target with arrowheads, so the flow order is visible at a glance.

## In sync with the inspector

Canvas wiring and the inspector's NEEDS / branch / loop editors both dispatch the same shared ops, so editing one reflects in the other. The inspector's keyboard-accessible fields stay. The shared model and the Expo mobile editor are unchanged (mobile already sets `needs` via its field).

## Tests

- `@moxxy/desktop` `WorkflowsPanel.test.tsx`: 7 new canvas tests (drag A.output→B ⇒ B.needs=[A]; pointerup on empty canvas cancels with no dispatch + no stuck temp line; edge ✕ disconnects; self-connect no-op; cycle drag refused + inline rejection; loop-body drop ⇒ `set-loop-body`; condition `then` handle drag ⇒ `set-branch`). The original 7 stay green → 14 total. (jsdom drops `clientX` on PointerEvent, so the suite forces coordinates onto the event before dispatch.)
- `@moxxy/workflows-builder` `operations.test.ts`: cycle-guard test for `connectNeeds` + `wouldCreateCycle`.

## Gate

`pnpm build` 0 · `pnpm -w typecheck` 0 · `pnpm -w test` 0 · `pnpm -w lint` 0 (0 errors) · `pnpm check:deps` 0 · `pnpm --filter @moxxy/desktop typecheck` 0.

Changeset: `@moxxy/desktop` minor, `@moxxy/workflows-builder` patch.