### PR TITLE
fix(runner): tolerate additive protocol skew + stop the desktop hot-update reconnect loop

### DIFF
--- a/.changeset/runner-protocol-skew.md
+++ b/.changeset/runner-protocol-skew.md
@@ -1,0 +1,26 @@
+---
+'@moxxy/runner': minor
+'@moxxy/desktop-host': patch
+'@moxxy/desktop-ipc-contract': patch
+'@moxxy/desktop': patch
+---
+
+fix(runner): tolerate additive protocol skew + stop the desktop hot-update reconnect loop
+
+A desktop Tier-1 hot-update ships only the JS bundle, so it advances the bundled
+`@moxxy/runner` client past the separately-bundled CLI's runner. The strict
+`protocolVersion !==` handshake then rejected the (purely additive) skew and the
+supervisor respawned the SAME pinned CLI forever — an infinite "Reconnecting…".
+
+- **Tolerant negotiation (contract change):** new `MIN_COMPATIBLE_PROTOCOL_VERSION`
+  (bumped only on a BREAKING protocol change). The server accepts any client
+  `>= MIN_COMPATIBLE` and returns its own version; the client records the server
+  version and gates the v4-only `workflow.validateDraft/save/getRun` builder methods
+  on it, degrading with a clear "update the CLI" error instead of a raw
+  method-not-found. Additive skew now attaches cleanly.
+- **Desktop lockstep:** the signed app-bundle manifest carries a `runnerProtocol`
+  stamp; the bootstrap refuses to activate (reverts to floor) any JS bundle whose
+  stamp exceeds the spawnable CLI's protocol.
+- **No infinite loop:** a persistent mismatch surfaces a terminal
+  `protocol-incompatible` connection phase with an actionable message after one
+  failed recovery, rather than retrying into the same dead end.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -67,6 +67,34 @@ Severity in brackets.
   coherence in the desktop `ws-bridge` suite. The wave-5 hardening (Origin default-deny, bearer
   subprotocol, connection caps) verified still applied on the runtime-gateway path.
 
+- **B2 [high, shipped regression] Desktop hot-update could strand its runner on a protocol skew**
+  — ✅ FIXED (this PR, branch `fix/runner-protocol-skew`). A Tier-1 JS hot-update ships only
+  `dist/` + `dist-electron/`, so it bumps the bundled `@moxxy/runner` CLIENT
+  (`RUNNER_PROTOCOL_VERSION`) but NOT the separately-bundled CLI the desktop spawns as its runner
+  (resolved by `preferredCliEntry` → `resourcesPath/moxxy-cli`). After a v3→v4 hot-update the
+  client was v4 and the runner v3; the server's STRICT `protocolVersion !== RUNNER_PROTOCOL_VERSION`
+  handshake threw, and the supervisor's "stale runner" recovery respawned from the SAME pinned CLI
+  → still v3 → infinite "Reconnecting…". (v3→v4 was purely additive — the rejection was needless.)
+  **Three-part fix:** (A) tolerant negotiation — `MIN_COMPATIBLE_PROTOCOL_VERSION` (=1, bump only
+  on a BREAKING change) gates the handshake; the server accepts any client `>= MIN_COMPATIBLE` and
+  reports its own version; the client records the server version and gates the v4-only
+  `workflow.validateDraft/save/getRun` builder methods on it, degrading with an actionable "update
+  the CLI" error instead of a raw method-not-found. (B) desktop lockstep (Option 1) — the signed
+  app-bundle manifest now carries a `runnerProtocol` stamp, and the bootstrap's
+  `resolveActiveBundleDetailed` refuses to activate (reverts to floor) any bundle whose stamp
+  EXCEEDS the spawnable CLI's protocol (`runner-protocol-skew` reject reason; floor protocol baked
+  as `FLOOR_RUNNER_PROTOCOL`, build asserts it == runner's). (C) UX — a persistent mismatch now
+  surfaces a TERMINAL `protocol-incompatible` connection phase (no Try-again, actionable hint,
+  vX/vY in Technical Details) after ONE failed recovery instead of an endless retry loop.
+  **Deferred follow-ups:** (1) `checkForUpdate` still OFFERS/downloads a skewed bundle — the
+  activation gate idempotently reverts it to floor every boot (no loop/crash), but a check-time
+  `cliRunnerProtocol` gate would avoid the wasted download + the surprised "update available then
+  nothing changes". (2) The deepest fix is to STOP a JS hot-update from outrunning the CLI at all
+  — i.e. ship the pnpm-deployed CLI INSIDE the Tier-1 bundle so client+runner update in lockstep
+  (Option 2). Larger (bundle bloat + cli-resolver/bootstrap prefer-the-bundle plumbing); left for a
+  dedicated PR now that Part A makes additive skew non-fatal and Part B/C make any future breaking
+  skew terminal-but-clear rather than a loop.
+
 ## 2026-06-09 audit intake — confirmed findings awaiting fixes
 
 Every item below survived an adversarial verification pass (an independent agent

--- a/apps/desktop/electron/main/bootstrap.ts
+++ b/apps/desktop/electron/main/bootstrap.ts
@@ -34,6 +34,7 @@ import {
 } from '@moxxy/desktop-host/app-update';
 
 import { BUNDLED_UPDATE_PUBLIC_KEY } from './update-key.js';
+import { FLOOR_RUNNER_PROTOCOL } from './floor-runner-protocol.js';
 
 // MUST run before any `app.getPath('userData')` below. `userData` resolves to
 // `…/Application Support/<app.getName()>`, and in a packaged build Electron
@@ -96,6 +97,10 @@ async function boot(): Promise<void> {
         userDataDir: userData,
         publicKeyPem: BUNDLED_UPDATE_PUBLIC_KEY,
         shell,
+        // Lockstep gate: refuse a JS bundle whose bundled client outruns the
+        // pinned CLI's runner (the hot-update protocol-skew loop). The floor's
+        // CLI is what we spawn, so its protocol is the ceiling for a hot-update.
+        cliRunnerProtocol: FLOOR_RUNNER_PROTOCOL,
       });
       if (resolved.bundle) {
         const picked = resolved.bundle;

--- a/apps/desktop/electron/main/floor-runner-protocol.ts
+++ b/apps/desktop/electron/main/floor-runner-protocol.ts
@@ -1,0 +1,19 @@
+/**
+ * The runner protocol version (`@moxxy/runner`'s `RUNNER_PROTOCOL_VERSION`) the
+ * FLOOR app's bundled CLI speaks — i.e. the protocol the desktop can ALWAYS
+ * serve, because the pinned `moxxy-cli` shipped in this app's resources runs at
+ * exactly this version.
+ *
+ * The bootstrap passes this to `resolveActiveBundleDetailed` as
+ * `cliRunnerProtocol`: a staged JS hot-update whose signed `runnerProtocol`
+ * exceeds this would strand the desktop with a client newer than any runner it
+ * can spawn (the protocol-skew reconnect loop), so the gate reverts it to the
+ * floor JS — which matches the CLI.
+ *
+ * Baked as a literal (not imported from `@moxxy/runner`) to keep the immutable
+ * bootstrap dependency-free + tiny, mirroring `update-key.ts`. MUST stay in
+ * lockstep with `@moxxy/runner`'s `RUNNER_PROTOCOL_VERSION` at release time —
+ * the release build asserts the two match (see scripts/build-app-bundle.mjs),
+ * so a forgotten bump fails the build rather than shipping a wrong floor.
+ */
+export const FLOOR_RUNNER_PROTOCOL = 4;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -217,6 +217,9 @@ function describePhase(
       return phase.reason ? `Reconnecting — ${phase.reason}` : 'Reconnecting…';
     case 'failed':
       return phase.error ? `Disconnected — ${phase.error}` : 'Disconnected';
+    case 'protocol-incompatible':
+      // Terminal — say so plainly rather than implying a reconnect is coming.
+      return phase.hint;
     default:
       return 'Reconnecting…';
   }

--- a/apps/desktop/src/connection/ConnectionScreen.test.tsx
+++ b/apps/desktop/src/connection/ConnectionScreen.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * The connection surface — focused on the TERMINAL protocol-incompatibility
+ * phase (Part C of the runner-protocol-skew fix): it must render an actionable
+ * "update the CLI" message and NOT offer a retry that would loop straight back
+ * into the same dead end. Contrast with `reconnecting`, which keeps the retry.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ConnectionSnapshot } from '@moxxy/desktop-ipc-contract';
+import { ConnectionScreen } from './ConnectionScreen';
+
+function snapshotWith(phase: ConnectionSnapshot['phase']): ConnectionSnapshot {
+  return { phase, cliPath: null, attempts: 1, log: [] };
+}
+
+describe('ConnectionScreen — protocol-incompatible (terminal)', () => {
+  it('renders the actionable hint and hides the retry button', () => {
+    const onRetry = vi.fn();
+    render(
+      <ConnectionScreen
+        snapshot={snapshotWith({
+          phase: 'protocol-incompatible',
+          serverVersion: 3,
+          clientVersion: 4,
+          detail: 'runner protocol mismatch: server v3, client v4',
+          hint: 'This app version needs a newer moxxy CLI. Update the CLI (or reinstall the app) to continue.',
+        })}
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(screen.getByText(/update needed to continue/i)).toBeTruthy();
+    // The actionable hint appears as the subtitle and again in the diagnostics.
+    expect(screen.getAllByText(/needs a newer moxxy CLI/i).length).toBeGreaterThan(0);
+    // No "Try again" — auto-retry into the same pinned CLI is a dead end.
+    expect(screen.queryByRole('button', { name: /try again/i })).toBeNull();
+  });
+});
+
+describe('ConnectionScreen — reconnecting (recoverable) keeps retrying', () => {
+  it('still offers the retry button', () => {
+    render(
+      <ConnectionScreen
+        snapshot={snapshotWith({ phase: 'reconnecting', reason: 'runner disconnected', attempt: 2 })}
+        onRetry={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/connection/ConnectionScreen.tsx
+++ b/apps/desktop/src/connection/ConnectionScreen.tsx
@@ -27,7 +27,12 @@ export function ConnectionScreen({
   const problem =
     phase.phase === 'failed' ||
     phase.phase === 'cli-missing' ||
-    phase.phase === 'reconnecting';
+    phase.phase === 'reconnecting' ||
+    phase.phase === 'protocol-incompatible';
+  // A protocol incompatibility is TERMINAL — respawning hits the same pinned
+  // CLI, so "Try again" would loop straight back into the dead end. Hide the
+  // retry and tell the user what action actually unblocks them.
+  const terminal = phase.phase === 'protocol-incompatible';
 
   // Happy path: a continuous branded loading screen.
   if (!problem) {
@@ -80,23 +85,25 @@ export function ConnectionScreen({
           </p>
         </div>
 
-        <button
-          type="button"
-          onClick={onRetry}
-          style={{
-            padding: '9px 20px',
-            background: 'var(--grad-cta)',
-            color: '#fff',
-            border: 'none',
-            borderRadius: 10,
-            fontWeight: 600,
-            fontSize: 13.5,
-            cursor: 'pointer',
-            boxShadow: '0 10px 20px -12px rgba(236, 72, 153, 0.55)',
-          }}
-        >
-          Try again
-        </button>
+        {!terminal && (
+          <button
+            type="button"
+            onClick={onRetry}
+            style={{
+              padding: '9px 20px',
+              background: 'var(--grad-cta)',
+              color: '#fff',
+              border: 'none',
+              borderRadius: 10,
+              fontWeight: 600,
+              fontSize: 13.5,
+              cursor: 'pointer',
+              boxShadow: '0 10px 20px -12px rgba(236, 72, 153, 0.55)',
+            }}
+          >
+            Try again
+          </button>
+        )}
 
         <TechnicalDetails snapshot={snapshot} phase={phase} />
       </div>
@@ -119,6 +126,8 @@ function friendlyTitle(phase: string): string {
       return 'Reconnecting…';
     case 'cli-missing':
       return "moxxy isn't installed yet";
+    case 'protocol-incompatible':
+      return 'Update needed to continue';
     case 'failed':
       return "Couldn't connect";
     default:
@@ -137,6 +146,8 @@ function friendlySub(phase: ConnectionPhase): string {
       return phase.reason
         ? `Lost the connection — ${phase.reason}`
         : 'Lost the connection to the runner. Reconnecting…';
+    case 'protocol-incompatible':
+      return phase.hint;
     default:
       return 'Hang tight while we get everything ready.';
   }
@@ -189,6 +200,20 @@ function TechnicalDetails({
           <>
             <DetailRow label="error" value={phase.error} />
             {phase.hint && <DetailRow label="hint" value={phase.hint} />}
+          </>
+        )}
+        {phase.phase === 'protocol-incompatible' && (
+          <>
+            <DetailRow
+              label="runner"
+              value={phase.serverVersion === null ? '(unknown)' : `v${phase.serverVersion}`}
+            />
+            <DetailRow
+              label="app"
+              value={phase.clientVersion === null ? '(unknown)' : `v${phase.clientVersion}`}
+            />
+            <DetailRow label="detail" value={phase.detail} />
+            <DetailRow label="hint" value={phase.hint} />
           </>
         )}
         {hasLog && snapshot && (

--- a/packages/desktop-host/src/app-update/build.ts
+++ b/packages/desktop-host/src/app-update/build.ts
@@ -25,6 +25,14 @@ export interface BuildInput {
   privateKeyPem: string;
   /** Bundle contents: dist-relative POSIX path → raw bytes. */
   files: Record<string, Buffer>;
+  /**
+   * The runner protocol version (`@moxxy/runner`'s `RUNNER_PROTOCOL_VERSION`)
+   * this bundle's bundled client speaks. Stamped into the signed manifest so
+   * the bootstrap can refuse to activate a JS bundle whose client would outrun
+   * the reachable CLI's runner (the protocol-skew lockstep gate). Omit on
+   * builds that predate the gate (treated as "no constraint").
+   */
+  runnerProtocol?: number;
   releaseUrl?: string;
   notes?: string;
 }
@@ -72,6 +80,11 @@ export function buildAppBundle(input: BuildInput): BuildOutput {
     sha256,
     bundleUrl: input.bundleUrl,
     files: fileHashes,
+    // Only stamped when supplied so a builder that hasn't wired the protocol
+    // through still produces a byte-identical legacy manifest.
+    ...(typeof input.runnerProtocol === 'number'
+      ? { runnerProtocol: input.runnerProtocol }
+      : {}),
   };
   const signature = cryptoSign(
     null,

--- a/packages/desktop-host/src/app-update/manifest.test.ts
+++ b/packages/desktop-host/src/app-update/manifest.test.ts
@@ -101,6 +101,25 @@ describe('verifyManifestSignature', () => {
     );
     expect(verifyManifestSignature(reordered!, publicKeyPem)).toBe(true);
   });
+
+  it('round-trips a manifest carrying a signed runnerProtocol stamp', () => {
+    const { manifest, publicKeyPem } = signed({ runnerProtocol: 4 });
+    expect(verifyManifestSignature(manifest, publicKeyPem)).toBe(true);
+    const parsed = parseManifest(JSON.stringify(manifest));
+    expect(parsed?.runnerProtocol).toBe(4);
+    expect(verifyManifestSignature(parsed!, publicKeyPem)).toBe(true);
+  });
+
+  it('rejects a downgrade that strips (or alters) the runnerProtocol stamp', () => {
+    const { manifest, publicKeyPem } = signed({ runnerProtocol: 4 });
+    const { runnerProtocol: _dropped, ...withoutStamp } = manifest;
+    expect(verifyManifestSignature(withoutStamp, publicKeyPem)).toBe(false);
+    expect(verifyManifestSignature({ ...manifest, runnerProtocol: 3 }, publicKeyPem)).toBe(false);
+
+    // …and a legacy manifest can't have a stamp injected.
+    const { manifest: legacy, publicKeyPem: legacyKey } = signed();
+    expect(verifyManifestSignature({ ...legacy, runnerProtocol: 4 }, legacyKey)).toBe(false);
+  });
 });
 
 describe('parseManifest', () => {
@@ -141,5 +160,13 @@ describe('parseManifest', () => {
     expect(parseManifest(JSON.stringify({ ...manifest, files: ['a'] }))).toBeNull();
     expect(parseManifest(JSON.stringify({ ...manifest, files: { '': 'a'.repeat(64) } }))).toBeNull();
     expect(parseManifest(JSON.stringify({ ...manifest, files: { 'a.js': 'short' } }))).toBeNull();
+  });
+
+  it('parses a valid runnerProtocol and rejects a malformed one', () => {
+    const { manifest } = signed({ runnerProtocol: 4 });
+    expect(parseManifest(JSON.stringify(manifest))?.runnerProtocol).toBe(4);
+    expect(parseManifest(JSON.stringify({ ...manifest, runnerProtocol: -1 }))).toBeNull();
+    expect(parseManifest(JSON.stringify({ ...manifest, runnerProtocol: 1.5 }))).toBeNull();
+    expect(parseManifest(JSON.stringify({ ...manifest, runnerProtocol: 'four' }))).toBeNull();
   });
 });

--- a/packages/desktop-host/src/app-update/manifest.ts
+++ b/packages/desktop-host/src/app-update/manifest.ts
@@ -30,6 +30,17 @@ export interface AppManifest {
    *  module skew. `''` is a wildcard ("any ABI"); the desktop's only native dep
    *  is optional + unpackaged, so Electron-version gating normally suffices. */
   nodeAbi: string;
+  /**
+   * The runner protocol version (`@moxxy/runner`'s `RUNNER_PROTOCOL_VERSION`)
+   * the bundle's bundled client speaks. Stamped at build time. The bootstrap
+   * REFUSES to activate a bundle whose `runnerProtocol` exceeds what the
+   * reachable (pinned, bundled) CLI's runner can serve — otherwise a JS
+   * hot-update would strand the desktop with a client newer than its runner
+   * (the protocol-skew reconnect loop). Absent on legacy manifests, which
+   * predate the field and are treated as "no constraint" (compatible by
+   * construction with the CLI they shipped beside).
+   */
+  runnerProtocol?: number;
   /** SHA-256 (hex) of the gzipped bundle payload. */
   sha256: string;
   /** Per-file integrity map: bundle-relative POSIX path → SHA-256 (hex) of the
@@ -71,13 +82,15 @@ type SignedField = (typeof SIGNED_FIELDS)[number];
 /**
  * Deterministic bytes the signature is computed/verified over.
  *
- * The `files` map is appended only when present, with sorted keys, so:
- *   - legacy manifests (no map) keep verifying byte-for-byte as before, and
- *   - stripping the map from (or adding one to) a signed manifest changes the
+ * The `files` map and `runnerProtocol` are appended only when present (files
+ * with sorted keys), so:
+ *   - legacy manifests (no map / no runnerProtocol) keep verifying byte-for-byte
+ *     as before, and
+ *   - stripping either from (or adding either to) a signed manifest changes the
  *     canonical bytes and breaks the signature — a downgrade can't be forged.
  */
 export function canonicalManifestBytes(
-  m: Pick<AppManifest, SignedField> & Pick<AppManifest, 'files'>,
+  m: Pick<AppManifest, SignedField> & Pick<AppManifest, 'files' | 'runnerProtocol'>,
 ): Buffer {
   const ordered: Record<string, unknown> = {};
   for (const k of SIGNED_FIELDS) ordered[k] = String(m[k] ?? '');
@@ -85,6 +98,11 @@ export function canonicalManifestBytes(
     const files: Record<string, string> = {};
     for (const rel of Object.keys(m.files).sort()) files[rel] = String(m.files[rel] ?? '');
     ordered.files = files;
+  }
+  // Appended after `files` (stable key order) so a manifest that carries the
+  // protocol stamp signs it too — a tampered/dropped stamp breaks the signature.
+  if (typeof m.runnerProtocol === 'number') {
+    ordered.runnerProtocol = String(m.runnerProtocol);
   }
   return Buffer.from(JSON.stringify(ordered), 'utf8');
 }
@@ -140,6 +158,13 @@ export function parseManifest(json: string): AppManifest | null {
       files[rel] = hash;
     }
     out.files = files;
+  }
+  // Optional runner-protocol stamp: a non-negative integer when present.
+  if (m.runnerProtocol !== undefined) {
+    if (typeof m.runnerProtocol !== 'number' || !Number.isInteger(m.runnerProtocol) || m.runnerProtocol < 0) {
+      return null;
+    }
+    out.runnerProtocol = m.runnerProtocol;
   }
   if (str(m.releaseUrl)) out.releaseUrl = m.releaseUrl;
   if (str(m.notes)) out.notes = m.notes;

--- a/packages/desktop-host/src/app-update/resolve.test.ts
+++ b/packages/desktop-host/src/app-update/resolve.test.ts
@@ -10,6 +10,7 @@ import {
   bundleRoot,
   appUpdateDir,
   resolveActiveBundle,
+  resolveActiveBundleDetailed,
   setActiveVersion,
   readActiveVersion,
   markBad,
@@ -115,6 +116,63 @@ describe('resolveActiveBundle', () => {
     writeFileSync(path.join(root, 'manifest.json'), JSON.stringify(manifestFor('0.0.6')));
     setActiveVersion(tmp, '0.0.6');
     expect(resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL })).toBeNull();
+  });
+});
+
+describe('runner-protocol lockstep gate', () => {
+  it('rejects a bundle whose runner-protocol exceeds the spawnable CLI', () => {
+    // A JS hot-update stamped at protocol v4, but the pinned CLI only serves v3
+    // → activating it would strand the desktop in a reconnect loop. Refuse it.
+    installBundle('0.0.6', { runnerProtocol: 4 });
+    const r = resolveActiveBundleDetailed({
+      userDataDir: tmp,
+      publicKeyPem: PUBKEY,
+      shell: SHELL,
+      cliRunnerProtocol: 3,
+    });
+    expect(r.bundle).toBeNull();
+    expect(r.reason).toBe('runner-protocol-skew');
+  });
+
+  it('accepts a bundle whose runner-protocol equals the CLI', () => {
+    installBundle('0.0.6', { runnerProtocol: 4 });
+    const r = resolveActiveBundle({
+      userDataDir: tmp,
+      publicKeyPem: PUBKEY,
+      shell: SHELL,
+      cliRunnerProtocol: 4,
+    });
+    expect(r?.version).toBe('0.0.6');
+  });
+
+  it('accepts a bundle whose runner-protocol is OLDER than the CLI (additive forward)', () => {
+    // A floor-ish bundle (v3) on a newer CLI (v4) is fine — the older client
+    // never calls the methods the newer runner added.
+    installBundle('0.0.6', { runnerProtocol: 3 });
+    const r = resolveActiveBundle({
+      userDataDir: tmp,
+      publicKeyPem: PUBKEY,
+      shell: SHELL,
+      cliRunnerProtocol: 4,
+    });
+    expect(r?.version).toBe('0.0.6');
+  });
+
+  it('does not gate a legacy manifest (no runnerProtocol stamp)', () => {
+    installBundle('0.0.6'); // no runnerProtocol
+    const r = resolveActiveBundle({
+      userDataDir: tmp,
+      publicKeyPem: PUBKEY,
+      shell: SHELL,
+      cliRunnerProtocol: 1, // even a very old CLI: an unstamped bundle is "no constraint"
+    });
+    expect(r?.version).toBe('0.0.6');
+  });
+
+  it('does not gate when the caller omits cliRunnerProtocol', () => {
+    installBundle('0.0.6', { runnerProtocol: 99 });
+    const r = resolveActiveBundle({ userDataDir: tmp, publicKeyPem: PUBKEY, shell: SHELL });
+    expect(r?.version).toBe('0.0.6');
   });
 });
 

--- a/packages/desktop-host/src/app-update/resolve.ts
+++ b/packages/desktop-host/src/app-update/resolve.ts
@@ -248,6 +248,17 @@ export interface ResolveOpts {
   /** Baked Ed25519 public key (SPKI PEM). Empty disables all overrides. */
   publicKeyPem: string;
   shell: ShellInfo;
+  /**
+   * The runner protocol version the REACHABLE CLI can serve — i.e. the
+   * `RUNNER_PROTOCOL_VERSION` of the CLI the desktop will actually spawn
+   * (the pinned, bundled `moxxy-cli` in resources, whose protocol equals the
+   * FLOOR app's). The bootstrap passes its own floor constant. A staged JS
+   * bundle whose signed `runnerProtocol` EXCEEDS this is rejected
+   * (`runner-protocol-skew`): its bundled client would speak a protocol the
+   * spawnable runner can't, stranding the desktop in a reconnect loop. Omit to
+   * skip the gate (e.g. legacy callers / tests that don't model the CLI).
+   */
+  cliRunnerProtocol?: number;
 }
 
 /** Why {@link resolveActiveBundleDetailed} declined to load an override bundle.
@@ -261,6 +272,7 @@ export type ResolveRejectReason =
   | 'version-mismatch' // manifest.version ≠ active version
   | 'bad-signature' // Ed25519 verification failed
   | 'incompatible' // Electron/ABI floor not met (needs a shell update)
+  | 'runner-protocol-skew' // bundle's client outruns the spawnable CLI's runner (needs a CLI/app update)
   | 'main-missing' // dist-electron/main/index.js absent on disk
   | 'file-tampered'; // a file in the signed `files` map is missing/modified on disk
 
@@ -280,7 +292,7 @@ export type ResolveResult =
  *   legacy manifests have no map and get no load-time file verification).
  */
 export function resolveActiveBundleDetailed(opts: ResolveOpts): ResolveResult {
-  const { userDataDir, publicKeyPem, shell } = opts;
+  const { userDataDir, publicKeyPem, shell, cliRunnerProtocol } = opts;
   if (!publicKeyPem) return { bundle: null, reason: 'disabled' };
 
   const version = readActiveVersion(userDataDir);
@@ -295,6 +307,20 @@ export function resolveActiveBundleDetailed(opts: ResolveOpts): ResolveResult {
   if (manifest.version !== version) return { bundle: null, reason: 'version-mismatch' };
   if (!verifyManifestSignature(manifest, publicKeyPem)) return { bundle: null, reason: 'bad-signature' };
   if (!isCompatible(manifest, shell)) return { bundle: null, reason: 'incompatible' };
+  // Lockstep gate: a JS hot-update ships only dist/ — its bundled @moxxy/runner
+  // CLIENT can advance past the pinned, bundled CLI's runner. Activating such a
+  // bundle would strand the desktop with a client newer than any runner it can
+  // spawn → the protocol-skew reconnect loop. Refuse it (the boot path reverts
+  // to the floor JS, which matches the CLI). Only enforced when both the
+  // bundle's stamp and the caller's CLI protocol are known (signed value, so
+  // trusted post-signature-check).
+  if (
+    typeof cliRunnerProtocol === 'number' &&
+    typeof manifest.runnerProtocol === 'number' &&
+    manifest.runnerProtocol > cliRunnerProtocol
+  ) {
+    return { bundle: null, reason: 'runner-protocol-skew' };
+  }
 
   const mainEntry = path.join(root, 'dist-electron', 'main', 'index.js');
   if (!existsSync(mainEntry)) return { bundle: null, reason: 'main-missing' };

--- a/packages/desktop-host/src/runner-supervisor.test.ts
+++ b/packages/desktop-host/src/runner-supervisor.test.ts
@@ -1,9 +1,25 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { EventEmitter } from 'node:events';
 import type { ChildProcess } from 'node:child_process';
+
+// Mock the runner client so we can drive a PERSISTENT protocol mismatch through
+// the supervisor's loop without a real `moxxy serve`. Everything else
+// (isProtocolMismatchError, RUNNER_PROTOCOL_VERSION, the socket helpers the
+// supervisor imports) keeps its real behavior.
+vi.mock('@moxxy/runner', async (importActual) => {
+  const actual = await importActual<typeof import('@moxxy/runner')>();
+  return {
+    ...actual,
+    connectRemoteSession: vi.fn(() => {
+      // The hard mismatch the runner throws for a genuinely-incompatible client
+      // — and the same version on every attempt (the pinned-CLI case).
+      return Promise.reject(new Error('runner protocol mismatch: server v99, client v4'));
+    }),
+  };
+});
 
 import { RunnerSupervisor } from './runner-supervisor';
 
@@ -131,6 +147,51 @@ describe('RunnerSupervisor', () => {
     expect(
       (sup as unknown as { child: ChildProcess | null }).child,
     ).toBeNull();
+  });
+
+  it('surfaces a TERMINAL protocol-incompatible phase instead of looping forever on a persistent mismatch', async () => {
+    // The desktop hot-update case: the (pinned) CLI's runner can never satisfy
+    // the JS bundle's newer client, so EVERY attach mismatches the SAME way.
+    // The supervisor must attempt recovery ONCE, see the same mismatch again,
+    // then STOP with a terminal phase — not reconnect endlessly.
+    const socketPath = path.join(tmp, 'serve.sock');
+
+    // A resolvable (no-op) CLI so we get past resolving-cli.
+    const cliEntry = path.join(tmp, 'fake-bin.js');
+    writeFileSync(cliEntry, '// fake moxxy cli\n');
+    process.env.MOXXY_CLI_ENTRY = cliEntry;
+
+    const sup = new RunnerSupervisor(socketPath);
+    // ADOPT path on every attempt (no real serve to spawn) + don't actually
+    // hunt/unlink processes. The mocked connectRemoteSession is what throws.
+    const priv = sup as unknown as {
+      probeSocket: () => Promise<boolean>;
+      killForeignRunner: () => Promise<void>;
+    };
+    priv.probeSocket = () => Promise.resolve(true);
+    priv.killForeignRunner = () => Promise.resolve();
+
+    const phases: string[] = [];
+    sup.on('change', (snap) => phases.push(snap.phase.phase));
+
+    const loop = sup.run();
+    await waitFor(() => sup.snapshot().phase.phase === 'protocol-incompatible', 8000);
+    // run() must have RETURNED (terminal phase breaks the loop) — not still spinning.
+    await loop;
+
+    const final = sup.snapshot().phase;
+    expect(final.phase).toBe('protocol-incompatible');
+    if (final.phase === 'protocol-incompatible') {
+      expect(final.serverVersion).toBe(99);
+      expect(final.clientVersion).toBe(4);
+      expect(final.hint).toMatch(/update the cli/i);
+    }
+    // Bounded: one "stale runner replaced" recovery reconnect at most, then
+    // terminal — never an unbounded reconnect storm.
+    const reconnects = phases.filter((p) => p === 'reconnecting').length;
+    expect(reconnects).toBeLessThanOrEqual(2);
+
+    await sup.stop();
   });
 });
 

--- a/packages/desktop-host/src/runner-supervisor.ts
+++ b/packages/desktop-host/src/runner-supervisor.ts
@@ -28,7 +28,9 @@ import { deleteSession } from '@moxxy/core';
 import {
   connectRemoteSession,
   isNamedPipe,
+  isProtocolMismatchError,
   platformSocket,
+  RUNNER_PROTOCOL_VERSION,
   type RemoteSession,
 } from '@moxxy/runner';
 
@@ -54,6 +56,15 @@ export class RunnerSupervisor extends EventEmitter {
   private child: ChildProcess | null = null;
   private retryNotify: () => void = () => {};
   private stopped = false;
+  /**
+   * How many times we've hard-killed a "stale" runner on a protocol mismatch
+   * and respawned. A respawn from our PINNED bundled CLI yields the SAME
+   * version, so a mismatch that survives one recovery is unrecoverable here —
+   * we then surface the terminal `protocol-incompatible` phase rather than
+   * loop "Reconnecting…" forever (the desktop hot-update skew bug). Reset on
+   * any successful connect.
+   */
+  private mismatchRecoveries = 0;
   /**
    * Currently active desk's cwd. The supervisor passes this as the
    * spawned moxxy serve's cwd so moxxy's config loader picks up the
@@ -227,9 +238,10 @@ export class RunnerSupervisor extends EventEmitter {
       try {
         await this.attempt();
       } catch (err) {
-        // attempt() sets the phase itself for known failures. This
-        // catch is the safety net for unexpected throws.
-        if (this.currentPhase.phase !== 'failed' && this.currentPhase.phase !== 'cli-missing') {
+        // attempt() sets the phase itself for known TERMINAL failures
+        // (cli-missing, protocol-incompatible) and the recoverable mismatch
+        // path. This catch is the safety net for unexpected throws.
+        if (!isTerminalPhase(this.currentPhase.phase)) {
           const msg = err instanceof Error ? err.message : String(err);
           this.attempts += 1;
           this.setPhase({
@@ -239,6 +251,9 @@ export class RunnerSupervisor extends EventEmitter {
           });
         }
       }
+      // A terminal phase means there is nothing a retry can fix — stop the loop
+      // instead of spinning forever (the desktop hot-update reconnect loop).
+      if (isTerminalPhase(this.currentPhase.phase)) break;
       await this.waitForRetry();
     }
   }
@@ -328,15 +343,26 @@ export class RunnerSupervisor extends EventEmitter {
         socketPath: this.socketPath,
       });
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      // A previously-installed older moxxy may have left a v1 daemon
-      // bound to ~/.moxxy/serve.sock. The desktop's client is v2 →
-      // mismatch. Kill the foreign daemon, sweep the socket, and let
-      // the run loop respin so we spawn our own bundled serve.
-      if (/protocol mismatch/i.test(msg)) {
+      // Only a GENUINELY-INCOMPATIBLE client (below the server's compatibility
+      // floor) throws a protocol mismatch now — additive skew is tolerated by
+      // the server and attaches cleanly. The classic recoverable case is an
+      // older `moxxy serve` daemon left bound to the socket: kill it, sweep the
+      // socket, respawn our own bundled serve. But our bundled CLI is PINNED,
+      // so if a SECOND attach still mismatches, respawning can't help — surface
+      // a terminal error instead of looping "Reconnecting…" forever (the
+      // hot-update skew bug: a JS bundle whose client outran the CLI's runner).
+      if (isProtocolMismatchError(err)) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (this.mismatchRecoveries >= 1) {
+          this.setPhase(protocolIncompatiblePhase(msg));
+          // Returning (not throwing) leaves the phase terminal; the run loop
+          // sees it and stops retrying.
+          return;
+        }
+        this.mismatchRecoveries += 1;
         this.pushLog(
           'stderr',
-          `protocol mismatch on attach (${msg}); killing stale runner and respawning`,
+          `protocol mismatch on attach (${msg}); killing stale runner and respawning (recovery ${this.mismatchRecoveries})`,
         );
         await this.killForeignRunner();
         throw new Error(`stale runner replaced (${msg})`);
@@ -344,6 +370,9 @@ export class RunnerSupervisor extends EventEmitter {
       throw err;
     }
     this.session = session;
+    // A clean attach clears the recovery counter so a later, unrelated stale
+    // daemon still gets its one recovery attempt.
+    this.mismatchRecoveries = 0;
 
     const info = session.getInfo();
     this.setPhase({
@@ -561,6 +590,36 @@ export class RunnerSupervisor extends EventEmitter {
 
 function displayPath(cli: CliInvocation): string {
   return cli.kind === 'direct' ? cli.bin : cli.entry;
+}
+
+/** Phases the run loop must NOT retry past — there is nothing a respin can
+ *  fix. `protocol-incompatible` joins the existing terminal phases so a
+ *  persistent runner-protocol mismatch stops the loop instead of looping. */
+function isTerminalPhase(phase: ConnectionPhase['phase']): boolean {
+  return phase === 'failed' || phase === 'cli-missing' || phase === 'protocol-incompatible';
+}
+
+/** Extract the two protocol versions from the runner's mismatch message
+ *  (`runner protocol mismatch: server vX, client vY`). Returns null per field
+ *  when unparseable so the renderer still shows the raw message. */
+function parseMismatchVersions(msg: string): { server: number | null; client: number | null } {
+  const m = /server v(\d+),\s*client v(\d+)/i.exec(msg);
+  if (!m) return { server: null, client: null };
+  return { server: Number.parseInt(m[1] ?? '', 10), client: Number.parseInt(m[2] ?? '', 10) };
+}
+
+/** Build the terminal `protocol-incompatible` phase from a mismatch error. The
+ *  CLIENT version is what this app's bundled @moxxy/runner speaks; the SERVER
+ *  version is what the reachable (pinned, bundled) CLI's runner speaks. */
+function protocolIncompatiblePhase(msg: string): ConnectionPhase {
+  const { server, client } = parseMismatchVersions(msg);
+  return {
+    phase: 'protocol-incompatible',
+    serverVersion: server,
+    clientVersion: client ?? RUNNER_PROTOCOL_VERSION,
+    detail: msg,
+    hint: 'This app version needs a newer moxxy CLI. Update the CLI (or reinstall the app) to continue.',
+  };
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -158,7 +158,22 @@ export type ConnectionPhase =
       reason: string;
       attempt: number;
     }
-  | { phase: 'failed'; error: string; hint?: string };
+  | { phase: 'failed'; error: string; hint?: string }
+  /**
+   * Terminal: the runner this app can reach speaks an incompatible protocol
+   * and respawning won't fix it (the bundled CLI is pinned), so we STOP
+   * retrying instead of looping "Reconnecting…" forever. `serverVersion` /
+   * `clientVersion` are the two protocol versions, for the diagnostics
+   * readout; `hint` is the actionable user-facing instruction. Surfaced after
+   * one failed recovery attempt — see RunnerSupervisor.
+   */
+  | {
+      phase: 'protocol-incompatible';
+      serverVersion: number | null;
+      clientVersion: number | null;
+      detail: string;
+      hint: string;
+    };
 
 export interface ConnectionSnapshot {
   phase: ConnectionPhase;

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -14,10 +14,12 @@ export { RunnerServer, startRunnerServer } from './server.js';
 export {
   RemoteSession,
   connectRemoteSession,
+  isProtocolMismatchError,
   type RemoteSessionOptions,
 } from './remote-session.js';
 export {
   RUNNER_PROTOCOL_VERSION,
+  MIN_COMPATIBLE_PROTOCOL_VERSION,
   RunnerMethod,
   RunnerNotification,
   attachParamsSchema,

--- a/packages/runner/src/protocol-negotiation.test.ts
+++ b/packages/runner/src/protocol-negotiation.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tolerant protocol negotiation (Part A of the runner-protocol-skew fix).
+ *
+ * The server accepts any client whose version is >= MIN_COMPATIBLE_PROTOCOL_VERSION
+ * (additive skew is non-fatal) and rejects only genuinely-incompatible clients
+ * below the floor. A newer client gates version-specific methods on the SERVER's
+ * reported version, degrading with an actionable error against an older runner
+ * rather than a raw JSON-RPC method-not-found.
+ */
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  Session,
+  autoAllowResolver,
+  silentLogger,
+} from '@moxxy/core';
+import { definePlugin, defineProvider } from '@moxxy/sdk';
+import { FakeProvider, textReply } from '@moxxy/testing';
+import { defaultModePlugin } from '@moxxy/mode-default';
+import { startRunnerServer, type RunnerServer } from './server.js';
+import { RemoteSession, connectRemoteSession, isProtocolMismatchError } from './remote-session.js';
+import { JsonRpcPeer } from './jsonrpc.js';
+import type { Transport } from './transport.js';
+import {
+  MIN_COMPATIBLE_PROTOCOL_VERSION,
+  RUNNER_PROTOCOL_VERSION,
+  RunnerMethod,
+  type AttachResult,
+} from './protocol.js';
+
+function buildSession(provider: FakeProvider): Session {
+  const session = new Session({
+    cwd: process.cwd(),
+    logger: silentLogger,
+    permissionResolver: autoAllowResolver,
+  });
+  session.pluginHost.registerStatic(
+    definePlugin({
+      name: 'neg-shim',
+      providers: [
+        defineProvider({
+          name: provider.name,
+          models: [...provider.models],
+          createClient: () => provider,
+        }),
+      ],
+    }),
+  );
+  session.providers.setActive(provider.name);
+  session.pluginHost.registerStatic(defaultModePlugin);
+  return session;
+}
+
+function tmpSocket(): string {
+  return path.join(os.tmpdir(), `moxxy-neg-${Math.random().toString(36).slice(2, 10)}.sock`);
+}
+
+const servers: RunnerServer[] = [];
+
+async function serve(): Promise<string> {
+  const socketPath = tmpSocket();
+  const server = await startRunnerServer(buildSession(new FakeProvider({ script: [textReply('hi')] })), {
+    socketPath,
+  });
+  servers.push(server);
+  return socketPath;
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((s) => s.close()));
+});
+
+/** A pair of in-memory transports wired to each other (mirrors jsonrpc.test). */
+function makePair(): [Transport, Transport] {
+  let aOnFrame: ((f: unknown) => void) | undefined;
+  let bOnFrame: ((f: unknown) => void) | undefined;
+  let aOnClose: ((e?: Error) => void) | undefined;
+  let bOnClose: ((e?: Error) => void) | undefined;
+  let closed = false;
+  const closeBoth = (): void => {
+    if (closed) return;
+    closed = true;
+    queueMicrotask(() => {
+      aOnClose?.();
+      bOnClose?.();
+    });
+  };
+  const a: Transport = {
+    send: (f) => {
+      if (!closed) queueMicrotask(() => bOnFrame?.(f));
+    },
+    onFrame: (h) => {
+      aOnFrame = h;
+    },
+    onClose: (h) => {
+      aOnClose = h;
+    },
+    close: closeBoth,
+  };
+  const b: Transport = {
+    send: (f) => {
+      if (!closed) queueMicrotask(() => aOnFrame?.(f));
+    },
+    onFrame: (h) => {
+      bOnFrame = h;
+    },
+    onClose: (h) => {
+      bOnClose = h;
+    },
+    close: closeBoth,
+  };
+  return [a, b];
+}
+
+describe('tolerant protocol negotiation — server handshake', () => {
+  it('the compatibility floor is at or below the current version', () => {
+    // Sanity: a current client must always be accepted by a current server.
+    expect(MIN_COMPATIBLE_PROTOCOL_VERSION).toBeLessThanOrEqual(RUNNER_PROTOCOL_VERSION);
+    // Every change through v4 has been additive — the floor is still 1.
+    expect(MIN_COMPATIBLE_PROTOCOL_VERSION).toBe(1);
+  });
+
+  it('accepts a client at the current protocol version', async () => {
+    const socketPath = await serve();
+    // connectRemoteSession sends RUNNER_PROTOCOL_VERSION; a clean attach proves
+    // the current-vs-current path works.
+    const remote = await connectRemoteSession({ socketPath, role: 'current' });
+    expect(remote.runnerProtocolVersion).toBe(RUNNER_PROTOCOL_VERSION);
+    await remote.close();
+  });
+
+  it('accepts a client at MIN_COMPATIBLE (additive-skew client on a newer server)', async () => {
+    const socketPath = await serve();
+    const transport = await import('./unix-socket.js').then((m) =>
+      m.connectUnixSocket(socketPath),
+    );
+    const peer = new JsonRpcPeer(transport);
+    // Attach by hand at exactly MIN_COMPATIBLE — an older but still-compatible
+    // client. The tolerant server must accept it and report ITS own version.
+    const result = await peer.request<AttachResult>(RunnerMethod.Attach, {
+      protocolVersion: MIN_COMPATIBLE_PROTOCOL_VERSION,
+      role: 'old-but-compatible',
+      sinceSeq: 0,
+    });
+    expect(result.protocolVersion).toBe(RUNNER_PROTOCOL_VERSION);
+    expect(result.sessionId).toBeTruthy();
+    peer.close();
+  });
+
+  it('rejects a client below MIN_COMPATIBLE with a hard mismatch', async () => {
+    const socketPath = await serve();
+    const transport = await import('./unix-socket.js').then((m) =>
+      m.connectUnixSocket(socketPath),
+    );
+    const peer = new JsonRpcPeer(transport);
+    const tooOld = MIN_COMPATIBLE_PROTOCOL_VERSION - 1;
+    await expect(
+      peer.request(RunnerMethod.Attach, {
+        protocolVersion: tooOld,
+        role: 'ancient',
+        sinceSeq: 0,
+      }),
+    ).rejects.toThrow(/protocol mismatch/i);
+    peer.close();
+  });
+});
+
+describe('tolerant protocol negotiation — client gating', () => {
+  /**
+   * A minimal fake server that reports an OLDER protocol version on attach and
+   * does NOT implement the v4 builder methods — exactly what a v4 client sees
+   * after a desktop JS hot-update outran the v3 CLI it spawns.
+   */
+  function fakeV3Server(reportedVersion: number): { client: RemoteSession; close: () => void } {
+    const [clientT, serverT] = makePair();
+    const serverPeer = new JsonRpcPeer(serverT);
+    serverPeer.handle(RunnerMethod.Attach, () => ({
+      sessionId: 'fake-v3',
+      protocolVersion: reportedVersion,
+      info: {
+        sessionId: 'fake-v3',
+        cwd: process.cwd(),
+        providers: [],
+        tools: [],
+        modes: [],
+        skills: [],
+        commands: [],
+        readyProviders: [],
+        activeProvider: null,
+        activeMode: null,
+      },
+    }));
+    // Deliberately register NO workflow.* handlers — a v3 server lacks them.
+    const client = new RemoteSession(clientT);
+    return { client, close: () => clientT.close() };
+  }
+
+  it('the additive-skew attach SUCCEEDS and records the server version', async () => {
+    const { client, close } = fakeV3Server(3);
+    await client.attach('desktop', 0);
+    expect(client.runnerProtocolVersion).toBe(3);
+    close();
+  });
+
+  it('gates the v4 builder methods with an actionable error against a v3 server', async () => {
+    const { client, close } = fakeV3Server(3);
+    await client.attach('desktop', 0);
+
+    await expect(client.workflows.validateDraft('name: x')).rejects.toThrow(
+      /not supported by this runner.*update the moxxy CLI/i,
+    );
+    await expect(client.workflows.save('name: x')).rejects.toThrow(/update the moxxy CLI/i);
+    await expect(client.workflows.getRun('x')).rejects.toThrow(/update the moxxy CLI/i);
+    close();
+  });
+
+  it('allows the v4 builder methods when the server is v4+', async () => {
+    let validateCalled = false;
+    const [clientT, serverT] = makePair();
+    const serverPeer = new JsonRpcPeer(serverT);
+    serverPeer.handle(RunnerMethod.Attach, () => ({
+      sessionId: 'fake-v4',
+      protocolVersion: 4,
+      info: {
+        sessionId: 'fake-v4',
+        cwd: process.cwd(),
+        providers: [],
+        tools: [],
+        modes: [],
+        skills: [],
+        commands: [],
+        readyProviders: [],
+        activeProvider: null,
+        activeMode: null,
+      },
+    }));
+    serverPeer.handle(RunnerMethod.WorkflowValidateDraft, () => {
+      validateCalled = true;
+      return { ok: true, errors: [] };
+    });
+    const client = new RemoteSession(clientT);
+    await client.attach('desktop', 0);
+    const res = await client.workflows.validateDraft('name: x');
+    expect(res.ok).toBe(true);
+    expect(validateCalled).toBe(true);
+    clientT.close();
+  });
+});
+
+describe('isProtocolMismatchError', () => {
+  it('recognizes the runner mismatch message', () => {
+    expect(
+      isProtocolMismatchError(new Error('runner protocol mismatch: server v5, client v1')),
+    ).toBe(true);
+  });
+  it('is false for an unrelated error', () => {
+    expect(isProtocolMismatchError(new Error('socket closed'))).toBe(false);
+  });
+});

--- a/packages/runner/src/protocol.ts
+++ b/packages/runner/src/protocol.ts
@@ -13,28 +13,61 @@ import type {
 } from '@moxxy/sdk';
 
 /**
- * Wire contract between the runner (server) and thin clients. Bumped when an
- * incompatible change lands; `attach` exchanges versions so a stale client
- * fails loudly instead of misbehaving.
+ * Wire contract between the runner (server) and thin clients. `attach`
+ * exchanges versions so an incompatible client fails loudly instead of
+ * misbehaving — but compatible skew is TOLERATED (see negotiation rule below).
+ *
+ * Versioning rule (two knobs):
+ *   - {@link RUNNER_PROTOCOL_VERSION} is bumped on ANY protocol change
+ *     (additive or breaking). It identifies "what this build speaks".
+ *   - {@link MIN_COMPATIBLE_PROTOCOL_VERSION} is bumped ONLY on a BREAKING
+ *     change — one that removes/renames a method or alters an existing
+ *     method's params/result shape so an older peer would misbehave. It is
+ *     the lowest CLIENT version whose CORE session protocol this server can
+ *     still serve correctly.
+ *
+ * The handshake then accepts any client `>= MIN_COMPATIBLE_PROTOCOL_VERSION`
+ * (Part A — tolerant negotiation): a NEWER client just won't call methods this
+ * (older) server lacks, and an OLDER-but-still-compatible client never used the
+ * methods this server added. Only a `< MIN_COMPATIBLE` client is genuinely
+ * incompatible — that's the sole hard "mismatch". The server returns its OWN
+ * version in {@link AttachResult.protocolVersion} so the client can gate
+ * version-specific methods (e.g. the v4 builder family) and degrade gracefully
+ * against an older runner instead of hitting a raw method-not-found.
  *
  * v2: adds mcp.* and workflow.* method families so a thin client can drive
  * the MCP-server admin + workflows panels remotely. Both families degrade
  * cleanly when the corresponding plugin isn't loaded on the runner — the
- * server returns an empty list / `null` rather than throwing.
+ * server returns an empty list / `null` rather than throwing. (Additive.)
  *
  * v3: adds `session.reset` (request) + `session.reset` (notification) so
  * `/new` clears the runner's authoritative log — not just a client's local
  * mirror — and every attached mirror clears in lockstep. Without it, a
  * mirror-only clear desyncs seq-contiguous `ingest` and the mirror silently
- * rejects every subsequent event.
+ * rejects every subsequent event. (Additive.)
  *
  * v4: adds the workflow *builder* method family (`workflow.validateDraft`,
  * `workflow.save`, `workflow.getRun`) so a thin client (TUI / desktop's
  * RemoteSession) can drive the visual builder remotely. Like the other
  * workflow.* methods they degrade cleanly: the server throws a clear "not
  * supported" error when the workflows plugin (or its builder slice) is absent.
+ * (Additive — a v3 server simply lacks these three methods; a v4 client gates
+ * them on the server's reported version, see {@link AttachResult}.)
+ *
+ * Every change v1→v4 has been ADDITIVE, so MIN_COMPATIBLE stays at 1: today's
+ * server can serve any client back to v1, and any client v1+ can attach. Bump
+ * MIN_COMPATIBLE to N only when landing a breaking change at version N.
  */
 export const RUNNER_PROTOCOL_VERSION = 4;
+
+/**
+ * Lowest client protocol version this build's CORE session protocol is
+ * compatible with. The handshake rejects only clients BELOW this. Since every
+ * change through v4 was purely additive, this is 1 — bump it (to the new
+ * version) the moment a genuinely BREAKING protocol change lands, and never
+ * before. See the versioning rule in the module doc above.
+ */
+export const MIN_COMPATIBLE_PROTOCOL_VERSION = 1;
 
 /** Request methods. Client->server unless noted. */
 export const RunnerMethod = {

--- a/packages/runner/src/remote-session.ts
+++ b/packages/runner/src/remote-session.ts
@@ -169,6 +169,14 @@ export class RemoteSession implements ClientSession {
   private permissionResolver: PermissionResolver | null = null;
   private approvalResolver: ApprovalResolver | null = null;
   private info: SessionInfo | null = null;
+  /**
+   * The protocol version the SERVER reported at attach. Defaults to our own
+   * version until the handshake resolves. Version-specific client methods (the
+   * v4 workflow *builder* family) gate on this so a newer client attached to an
+   * older runner degrades with a clear, actionable error instead of a raw
+   * JSON-RPC method-not-found. Null until attached.
+   */
+  private serverProtocolVersion: number | null = null;
 
   constructor(transport: Transport) {
     this.peer = new JsonRpcPeer(transport);
@@ -249,6 +257,39 @@ export class RemoteSession implements ClientSession {
       sinceSeq,
     });
     this.info = result.info;
+    // Record the server's protocol so version-gated methods can degrade
+    // cleanly against an older runner (tolerant negotiation, Part A). A server
+    // that predates this field reports nothing → assume it matches us.
+    this.serverProtocolVersion =
+      typeof result.protocolVersion === 'number'
+        ? result.protocolVersion
+        : RUNNER_PROTOCOL_VERSION;
+  }
+
+  /**
+   * The protocol version the attached runner speaks (its own, from the
+   * handshake). Lets a capability-detecting caller (e.g. the desktop's visual
+   * builder, see #146) decide whether a version-gated feature is available on
+   * THIS runner before invoking it. Null until attached.
+   */
+  get runnerProtocolVersion(): number | null {
+    return this.serverProtocolVersion;
+  }
+
+  /**
+   * Guard a method that only exists on a server at/after `minVersion`. Throws a
+   * clear, actionable error (not a raw JSON-RPC method-not-found) when the
+   * attached runner is older — the desktop case after a JS hot-update outran
+   * its bundled CLI.
+   */
+  private requireServerProtocol(minVersion: number, feature: string): void {
+    const server = this.serverProtocolVersion;
+    if (server !== null && server < minVersion) {
+      throw new Error(
+        `${feature} is not supported by this runner ` +
+          `(runner protocol v${server}, needs v${minVersion}) — update the moxxy CLI to continue.`,
+      );
+    }
   }
 
   get id(): SessionId {
@@ -547,15 +588,26 @@ export class RemoteSession implements ClientSession {
         this.peer.request<WorkflowRunResult>(RunnerMethod.WorkflowRun, { name }),
       // Builder methods (protocol v4): forward to the runner so the desktop's
       // RemoteSession-backed visual builder can validate/save/load drafts.
-      validateDraft: (yaml) =>
-        this.peer.request<WorkflowValidateResult>(RunnerMethod.WorkflowValidateDraft, { yaml }),
-      save: (yaml, previousName) =>
-        this.peer.request<WorkflowSaveResult>(RunnerMethod.WorkflowSave, {
+      // Gated on the SERVER's reported version so a v4 client on a v3 runner
+      // (a desktop whose JS hot-update outran its bundled CLI) gets a clear
+      // "update the CLI" error instead of a raw method-not-found.
+      validateDraft: async (yaml) => {
+        this.requireServerProtocol(4, 'The workflows builder');
+        return this.peer.request<WorkflowValidateResult>(RunnerMethod.WorkflowValidateDraft, {
+          yaml,
+        });
+      },
+      save: async (yaml, previousName) => {
+        this.requireServerProtocol(4, 'Saving a workflow from the builder');
+        return this.peer.request<WorkflowSaveResult>(RunnerMethod.WorkflowSave, {
           yaml,
           ...(previousName ? { previousName } : {}),
-        }),
-      getRun: (name) =>
-        this.peer.request<WorkflowDetailResult | null>(RunnerMethod.WorkflowGetRun, { name }),
+        });
+      },
+      getRun: async (name) => {
+        this.requireServerProtocol(4, 'Loading a workflow into the builder');
+        return this.peer.request<WorkflowDetailResult | null>(RunnerMethod.WorkflowGetRun, { name });
+      },
     };
   }
 }
@@ -673,13 +725,23 @@ function defaultApproval(request: ApprovalRequest): ApprovalDecision {
  * Connect to a running runner and return an attached {@link RemoteSession}.
  * Throws if no runner is listening (callers decide whether to self-host).
  *
- * Protocol-mismatch recovery: when the server is on a lower protocol
- * version than this client (i.e. the user upgraded moxxy but left an
- * older `moxxy serve` daemon running), the attach throws "protocol
- * mismatch: server vX, client vY". This is unambiguously fatal — the
- * older daemon can never speak our protocol — so we proactively kill
- * it and unlink the socket. The caller's next attempt (CLI's
- * self-host fallback, desktop supervisor's retry) finds a clean slate.
+ * Protocol-mismatch recovery: with tolerant negotiation (Part A) a server
+ * only ever throws "protocol mismatch" for a GENUINELY INCOMPATIBLE client
+ * (one below the server's MIN_COMPATIBLE floor) — additive skew (a newer
+ * client on an older server, e.g. v4-client/v3-runner) attaches cleanly and
+ * degrades per-method instead. A thrown mismatch is therefore a real stale
+ * daemon: an older `moxxy serve` left running after the user upgraded moxxy,
+ * which a fresh spawn fixes. We proactively kill it + unlink the socket so the
+ * caller's next attempt (CLI self-host fallback, desktop supervisor retry)
+ * finds a clean slate.
+ *
+ * IMPORTANT: a fresh spawn only fixes this when the new runner is genuinely
+ * newer. If respawning yields the SAME incompatible version (the desktop case:
+ * the bundled CLI is pinned), the caller MUST NOT retry forever — it has to
+ * surface a terminal, actionable error. {@link connectRemoteSession} re-throws
+ * the original mismatch so the caller (supervisor) can detect a persistent
+ * incompatibility across attempts and stop; recovery here is best-effort
+ * cleanup, not a guarantee the next attempt succeeds.
  *
  * Default ports also cleared: 4040 (web surface — locks out a fresh
  * `moxxy serve` even after the daemon is dead).
@@ -703,6 +765,18 @@ export async function connectRemoteSession(
   }
 }
 
+/**
+ * True iff `err` is the runner's hard protocol-mismatch error (a client below
+ * the server's compatibility floor — a real stale daemon). Exported so callers
+ * that supervise reconnects (the desktop supervisor) can distinguish a
+ * genuinely-incompatible runner — which a respawn from the SAME binary will NOT
+ * fix, so they must stop retrying — from a transient disconnect.
+ */
+export function isProtocolMismatchError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /protocol mismatch/i.test(msg);
+}
+
 /** Run recovery if (a) the error is a protocol mismatch, (b) the
  *  caller didn't inject a fake transport, and (c) the caller didn't
  *  opt out. Swallows recovery errors — the original attach error is
@@ -713,8 +787,7 @@ async function maybeRecoverFromMismatch(
   opts: RemoteSessionOptions,
 ): Promise<void> {
   if (opts.transport || opts.skipMismatchRecovery) return;
-  const msg = err instanceof Error ? err.message : String(err);
-  if (!/protocol mismatch/i.test(msg)) return;
+  if (!isProtocolMismatchError(err)) return;
   try {
     await killAndUnlinkRunner(socketPath, [...DEFAULT_RUNNER_PORTS, ...(opts.extraPortsToFree ?? [])]);
   } catch {

--- a/packages/runner/src/server.ts
+++ b/packages/runner/src/server.ts
@@ -18,6 +18,7 @@ import type { Transport, TransportServer } from './transport.js';
 import { createUnixSocketServer } from './unix-socket.js';
 import { runnerSocketPath } from './socket-path.js';
 import {
+  MIN_COMPATIBLE_PROTOCOL_VERSION,
   RUNNER_PROTOCOL_VERSION,
   RunnerMethod,
   RunnerNotification,
@@ -192,7 +193,15 @@ export class RunnerServer {
 
   private handleAttach(client: ConnectedClient, raw: unknown): AttachResult {
     const params = attachParamsSchema.parse(raw);
-    if (params.protocolVersion !== RUNNER_PROTOCOL_VERSION) {
+    // Tolerant negotiation: accept any client whose version is compatible with
+    // our core session protocol (>= MIN_COMPATIBLE). All skew through v4 is
+    // additive, so a newer client just won't call methods we lack, and an
+    // older-but-compatible client never used the methods we added. Only a
+    // client below the compatibility floor is genuinely broken — that is the
+    // sole hard "mismatch" (a real stale daemon the desktop should replace).
+    // The client gets our own version back in the result and gates
+    // version-specific methods on it.
+    if (params.protocolVersion < MIN_COMPATIBLE_PROTOCOL_VERSION) {
       throw new Error(
         `runner protocol mismatch: server v${RUNNER_PROTOCOL_VERSION}, client v${params.protocolVersion}`,
       );

--- a/scripts/build-app-bundle.mjs
+++ b/scripts/build-app-bundle.mjs
@@ -33,6 +33,10 @@ import { fileURLToPath } from 'node:url';
 // Built output of the shared, tested builder — same code the integration test
 // and (transitively) the client verifier use, so producer + consumer can't drift.
 import { buildAppBundle } from '../packages/desktop-host/dist/app-update/index.js';
+// The runner protocol the bundle's bundled client speaks — stamped into the
+// signed manifest so the bootstrap's lockstep gate can refuse a JS hot-update
+// whose client would outrun the pinned CLI's runner.
+import { RUNNER_PROTOCOL_VERSION } from '../packages/runner/dist/index.js';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const desktopDir = path.join(repoRoot, 'apps', 'desktop');
@@ -100,6 +104,25 @@ function main() {
     process.exit(1);
   }
 
+  // Lockstep guard: the immutable bootstrap bakes FLOOR_RUNNER_PROTOCOL and uses
+  // it as the ceiling for any hot-update. If a runner-protocol bump forgot to
+  // update that floor constant, the gate would mis-judge skew — fail the build
+  // here rather than ship a wrong floor.
+  const floorSrc = readFileSync(
+    path.join(desktopDir, 'electron', 'main', 'floor-runner-protocol.ts'),
+    'utf8',
+  );
+  const floorMatch = /FLOOR_RUNNER_PROTOCOL\s*=\s*(\d+)/.exec(floorSrc);
+  const floorProtocol = floorMatch ? Number.parseInt(floorMatch[1], 10) : NaN;
+  if (floorProtocol !== RUNNER_PROTOCOL_VERSION) {
+    console.error(
+      `build-app-bundle: FLOOR_RUNNER_PROTOCOL (${floorProtocol}) != ` +
+        `@moxxy/runner RUNNER_PROTOCOL_VERSION (${RUNNER_PROTOCOL_VERSION}) — ` +
+        'update apps/desktop/electron/main/floor-runner-protocol.ts to match.',
+    );
+    process.exit(1);
+  }
+
   const { manifest, manifestJson, bundleGz } = buildAppBundle({
     version,
     minElectron,
@@ -107,6 +130,7 @@ function main() {
     bundleUrl,
     privateKeyPem,
     files,
+    runnerProtocol: RUNNER_PROTOCOL_VERSION,
     releaseUrl,
     notes: process.env.MOXXY_BUNDLE_NOTES,
   });
@@ -119,7 +143,7 @@ function main() {
   console.log(
     `build-app-bundle: wrote ${Object.keys(files).length} files ` +
       `(${(bytes / 1024).toFixed(0)} KiB raw → ${(bundleGz.length / 1024).toFixed(0)} KiB gz)\n` +
-      `  version=${version} minElectron=${minElectron} nodeAbi=${nodeAbi || '(any)'}\n` +
+      `  version=${version} minElectron=${minElectron} nodeAbi=${nodeAbi || '(any)'} runnerProtocol=${RUNNER_PROTOCOL_VERSION}\n` +
       `  sha256=${manifest.sha256}\n` +
       `  bundleUrl=${bundleUrl}\n` +
       `  out=${outDir}`,


### PR DESCRIPTION
## The bug (shipped, user-reproduced)

After a desktop hot-update the user saw a looping `Reconnecting… — Lost the connection — stale runner replaced (runner protocol mismatch: server v3, client v4)`.

Root cause: a Tier-1 hot-update ships only `dist/` + `dist-electron/`, so it advances the bundled `@moxxy/runner` **client** (`RUNNER_PROTOCOL_VERSION` v3→v4) but **not** the separately-bundled CLI the desktop spawns as its runner (`preferredCliEntry` → `resourcesPath/moxxy-cli`, still v3). The server's strict `params.protocolVersion !== RUNNER_PROTOCOL_VERSION` handshake threw, and the supervisor's "stale runner" recovery respawned from the **same pinned CLI** → still v3 → infinite reconnect. v3→v4 was **purely additive** (only the three `workflow.validateDraft/save/getRun` builder methods, commit `4a8ec5d`), so the strict rejection was needless.

## The fix

### Part A — tolerant protocol negotiation (`@moxxy/runner`, the class-killer)
- New `MIN_COMPATIBLE_PROTOCOL_VERSION` (= **1**; every change v1→v4 was additive). Versioning rule documented: bump `RUNNER_PROTOCOL_VERSION` on *any* change, bump `MIN_COMPATIBLE` *only* on a breaking change.
- Server handshake accepts any client `>= MIN_COMPATIBLE`; only a `< MIN_COMPATIBLE` client is a hard mismatch. The server keeps returning its own version in `AttachResult`.
- `RemoteSession` records the server's version (`runnerProtocolVersion`) and gates the v4-only workflow builder methods on it — degrading with an actionable "update the moxxy CLI" error instead of a raw JSON-RPC method-not-found. Additive skew now attaches cleanly (no error at all).

### Part B — desktop lockstep (Option 1: stamp + activation gate)
- The signed app-bundle manifest now carries a `runnerProtocol` stamp (added to `BuildInput` + the signed canonical bytes, so a tampered/dropped stamp breaks the signature; legacy manifests grandfathered).
- The bootstrap's `resolveActiveBundleDetailed` refuses to activate (reverts to floor) any JS bundle whose `runnerProtocol` exceeds the spawnable CLI's protocol — new `runner-protocol-skew` reject reason. The floor CLI's protocol is baked as `FLOOR_RUNNER_PROTOCOL`; `build-app-bundle.mjs` asserts it equals the runner's `RUNNER_PROTOCOL_VERSION` so a forgotten bump fails the build.

**Why Option 1 over Option 2:** with Part A the v4-client/v3-runner case is already non-fatal (degraded builder), so Part B's real job is the *future breaking* bump. Option 1 fits the existing dependency-free bootstrap gate cleanly and adds no per-update bloat. Option 2 (ship the full CLI in every Tier-1 bundle) is bigger (bundle bloat + cli-resolver/bootstrap prefer-the-bundle plumbing) — journaled as a deferred deeper fix (TECH_DEBT B2).

### Part C — no infinite loop (UX)
- New terminal `protocol-incompatible` connection phase. The supervisor attempts recovery **once**; if the respawn yields the same incompatible version it surfaces the terminal phase (no more endless retry). The renderer shows an actionable "This app version needs a newer moxxy CLI…" message, hides "Try again", and keeps the vX/vY in Technical Details.

## Tests
- `@moxxy/runner` `protocol-negotiation.test.ts` (9): accept at MIN_COMPATIBLE + current, reject `< MIN_COMPATIBLE`, additive-skew attach succeeds + records server version, v4 builder methods gated with the actionable error against a v3 server (allowed against v4), `isProtocolMismatchError`.
- `@moxxy/desktop-host`: lockstep gate in `resolve.test.ts` (+5: refuse skewed bundle, accept equal/older/legacy/no-cli-protocol), `manifest.test.ts` (+2: runnerProtocol round-trip + downgrade rejection), `runner-supervisor.test.ts` (+1: terminal after one recovery, bounded reconnects).
- `@moxxy/desktop` `ConnectionScreen.test.tsx` (2): terminal phase renders the hint + no retry; reconnecting keeps retry.

## Gate (all exit 0)
`pnpm build`, `pnpm -w typecheck` (incl. `@moxxy/desktop`), `pnpm -w test`, `pnpm -w lint` (0 errors), `pnpm check:deps`.

Changeset: `@moxxy/runner` minor, `@moxxy/desktop-host` + `@moxxy/desktop-ipc-contract` + `@moxxy/desktop` patch. TECH_DEBT B2 added (incl. deferred follow-ups).