### PR TITLE
feat(workflows): human-in-the-loop awaitInput — resume RPC + operator reply UI (un-gate)

### DIFF
--- a/.changeset/workflows-awaitinput-resume.md
+++ b/.changeset/workflows-awaitinput-resume.md
@@ -1,0 +1,37 @@
+---
+'@moxxy/runner': minor
+'@moxxy/plugin-workflows': minor
+'@moxxy/sdk': minor
+'@moxxy/cli': minor
+'@moxxy/desktop': minor
+'@moxxy/desktop-ipc-contract': minor
+'@moxxy/desktop-host': patch
+'@moxxy/plugin-channel-mobile': patch
+'@moxxy/client-core': minor
+---
+
+feat(workflows): human-in-the-loop awaitInput — resume RPC + operator reply UI (un-gate)
+
+A workflow step can set `awaitInput: true` to pause and ask the operator a
+question, then continue with their reply. #146 gated this at validate/save time
+because the resume path hadn't shipped. The resume path now ships, so the gate
+is removed.
+
+- **Un-gate:** `awaitInput: true` is accepted again on **prompt/skill steps**
+  (rejected on tool/workflow/logic/loop steps and on a loop body); `draft.ts`
+  teaches the mid-run pause flow again with a worked example.
+- **Resume RPC (additive, protocol v5):** new `RunnerMethod.WorkflowResume`
+  (`workflow.resume`) — server handler → `session.workflows.resume(runId, reply)`;
+  `WorkflowsView.resume` (SDK) + CLI impl over the existing `resumeWorkflowRun`;
+  `RemoteSession` client method gated on server protocol `>= 5` with the actionable
+  "update the CLI" error (mirrors the v4 builder gate). `MIN_COMPATIBLE` stays at 1.
+- **Desktop / mobile / TUI:** `workflows.resume` added to the desktop IPC contract
+  (+ host handler), the MobileSessionHost bridge, and `REMOTE_ALLOWED_COMMANDS`
+  (RESPOND-only — answering a question the workflow asked, like `ask.respond`).
+  Operator reply UI: desktop paused-workflow card (new client-core
+  `usePausedWorkflows` hook) and TUI inline reply in the `/workflows` panel.
+- **Correctness:** the `workflow_paused` event now carries the workflow name +
+  step label + question; vars set before a pause survive the checkpoint round-trip;
+  `runNow` keeps treating a `paused` result as non-terminal (and the resume side
+  delivers the now-completed run to the inbox); the stale-checkpoint sweeper +
+  `clearRetainedChildren()`-on-shutdown are kept.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -666,21 +666,38 @@ graph) is intact; the two operate on different graphs and don't conflict.
   for v1; revisit with `react-native-svg` + gesture-handler if a graphical mobile canvas is
   wanted.
 - **Round-2 correctness pass (2026-06-10).** Eight audit findings fixed:
-  - **`awaitInput` is GATED, not shippable.** The executor pauses + checkpoints
-    (`run-store.ts` + `resumeWorkflowRun`), but the **resume trigger/channel that delivers
-    the operator's reply did NOT ship to main** — it lives only on the unmerged plugin-office
-    branch. `resumeWorkflowRun` has ZERO production callers. An earlier note here claimed the
-    operator "replies once in Virtual Office chat" — that was backed only by the unmerged
-    branch and was **wrong for main**. So `awaitInput` is now **rejected at validate/save
-    time** (`schema.ts`) with a clear "requires the resume channel, not available in this
-    build" message; `draft.ts` no longer teaches it (it steers to `inputs` instead). The
-    executor pause path is kept (in case a resume trigger lands) and tested via raw-workflow
-    builders that bypass the gate. Defense-in-depth: `runNow` (CLI) treats a `paused` result
-    as **non-terminal** (no inbox delivery); `Session.close()` now calls
-    `clearRetainedChildren()` so a paused run's retained child session can't leak for the
-    process lifetime; and `WorkflowRunStore.sweepStale()` (7-day TTL, run on workflows boot)
-    reaps orphaned `~/.moxxy/workflow-runs/active/<ulid>.json` checkpoints. **To re-enable
-    awaitInput:** land an in-tree resume trigger and remove the schema gate block.
+  - **`awaitInput` human-in-the-loop SHIPPED — gate REMOVED (2026-06-10).** The resume path
+    now lives on main, so the validate/save gate from #146 is gone. `awaitInput: true` is
+    accepted again on **prompt/skill steps only** (rejected on tool/workflow/logic/loop steps
+    and on a loop body — the executor has no interactive child / no mid-iteration checkpoint
+    there); `draft.ts` teaches it again with a worked example. The resume RPC is additive
+    **protocol v5** (`workflow.resume`, `MIN_COMPATIBLE` unchanged at 1): `RunnerMethod` +
+    server handler → `session.workflows.resume(runId, reply)`; `WorkflowsView.resume` (SDK) +
+    CLI impl (`resumeNow` → existing `resumeWorkflowRun`); `RemoteSession.workflows.resume`
+    gated on server proto ≥ 5 with the "update the CLI" message (mirrors the v4 builder gate);
+    desktop-ipc-contract `workflows.resume` + desktop-host + MobileSessionHost handlers; and a
+    `workflows.resume` entry on `REMOTE_ALLOWED_COMMANDS` (RESPOND-only — answering a question
+    the WORKFLOW asked, like `ask.respond`; it can't author). The `workflow_paused` event now
+    carries the workflow name + step label + the question so the operator UI is self-contained.
+    **Reply UI:** desktop (`apps/desktop/src/workflows/PausedWorkflows.tsx` via the new
+    client-core `usePausedWorkflows` hook — a card with a reply box that dispatches
+    `workflows.resume`) and TUI (`plugin-cli` `WorkflowsPanel` switches to inline reply capture
+    when `view.run` returns `status: 'paused'`). The non-terminal-`paused` handling in `runNow`
+    is kept (and the resume side delivers the now-completed run to the inbox); the stale-checkpoint
+    sweeper + `clearRetainedChildren()`-on-shutdown from #146 are kept. Vars set before a pause
+    now survive the checkpoint round-trip (Finding 4, below) so downstream `{{ vars.* }}` render.
+    **Remaining edges (honest):** (1) the **mobile** UI is bridge-wired (handler + allow-list +
+    contract, Expo-bundled) but has **no paused-workflow card yet** — a mobile user can reach
+    `workflows.resume` over the frame bridge, but the screen doesn't surface the pending question
+    yet; add a paused card to `apps/mobile`. (2) **Multi-pause** workflows (several awaitInput
+    steps) work — resume re-pauses and the UI re-prompts — but each pause writes a fresh checkpoint;
+    not stress-tested beyond two pauses. (3) **Concurrent paused runs** of the SAME workflow each
+    get a distinct `runId`/checkpoint and surface as separate cards; the retained-child registry
+    is keyed by child session id so they don't collide, but the desktop card list isn't ordered
+    or de-duped beyond run id. (4) Resume relies on the **retained child still being in the
+    runner process's in-memory registry** — a runner restart between pause and resume loses it
+    (the checkpoint survives, but `spawner.continue` then fails cleanly rather than resuming);
+    persisting/rehydrating the child across restarts is future work.
   - **Desktop builder IPC now works over the runner (was Finding 2 — real).** The desktop
     drives a `RemoteSession`, whose workflows view only exposed `list/setEnabled/run` — so
     `validateDraft`/`save`/`getRun` were `undefined` and the builder threw "not supported on
@@ -692,9 +709,10 @@ graph) is intact; the two operate on different graphs and don't conflict.
     loop-body step is rejected (it would stall — body steps are excluded from the main DAG);
     a loop-body step's own `when` and any `needs` other than its loop step / a sibling body
     step are rejected (body steps run unconditionally each iteration).
-  - **Checkpoint vars (Finding 4):** the checkpoint now persists+restores `vars` so a logic
-    step that ran before a pause isn't dropped on resume (moot under the gate, but correct if
-    resume lands).
+  - **Checkpoint vars (Finding 4):** the checkpoint persists+restores `vars` so a logic step
+    that ran before a pause isn't dropped on resume — now LIVE (the resume path shipped), and
+    proven by the end-to-end executor test (a `bridge` sets `vars.channel`, the run pauses,
+    resume restores it and a downstream `{{ vars.channel }}` renders).
   - **Prototype-pollution guard (Finding 6):** model-provided logic-step `vars` skip
     `__proto__`/`constructor`/`prototype` keys when merging.
   - **Rename cleanup (Finding 7):** `WorkflowStore.save(workflow, previousName)` removes the
@@ -703,8 +721,8 @@ graph) is intact; the two operate on different graphs and don't conflict.
 - **Remaining notes:** (a) loop body steps are excluded from the main DAG scheduler via a
   `loopBodyIds` set; if a future feature needs a step to be both a loop body AND independently
   scheduled, that exclusion must be revisited. (b) awaitInput is barred inside a loop body
-  (would need mid-iteration checkpointing) — orthogonal to the gate above; lift only if a
-  resume path AND a use-case appear.
+  (would need mid-iteration checkpointing) — orthogonal to the now-shipped resume path; lift
+  only if a use-case appears.
 
 ---
 

--- a/apps/desktop/src/workflows/PausedWorkflows.tsx
+++ b/apps/desktop/src/workflows/PausedWorkflows.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { usePausedWorkflows, type PausedWorkflow } from '@moxxy/client-core';
+
+/**
+ * Human-in-the-loop surface: every workflow run currently parked on an
+ * `awaitInput` step renders a card — "Workflow <name> is waiting: <prompt>" —
+ * with a reply box. Submitting calls `workflows.resume(runId, reply)` through
+ * the client-core hook (which goes over the desktop IPC → runner). The card
+ * disappears the moment the run resumes (driven by the `workflow_resumed` /
+ * `workflow_completed` events the hook listens to).
+ */
+export function PausedWorkflows(): JSX.Element | null {
+  const { paused, errors, resuming, resume } = usePausedWorkflows();
+  if (paused.length === 0) return null;
+  return (
+    <section
+      data-testid="paused-workflows"
+      aria-label="Workflows awaiting your reply"
+      style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
+    >
+      {paused.map((run) => (
+        <PausedCard
+          key={run.runId}
+          run={run}
+          busy={resuming.includes(run.runId)}
+          error={errors[run.runId] ?? null}
+          onReply={(reply) => void resume(run.runId, reply)}
+        />
+      ))}
+    </section>
+  );
+}
+
+function PausedCard(props: {
+  run: PausedWorkflow;
+  busy: boolean;
+  error: string | null;
+  onReply: (reply: string) => void;
+}): JSX.Element {
+  const { run, busy, error, onReply } = props;
+  const [reply, setReply] = useState('');
+  const trimmed = reply.trim();
+  const submit = (): void => {
+    if (!trimmed || busy) return;
+    onReply(trimmed);
+  };
+  return (
+    <div
+      data-testid={`paused-workflow-${run.runId}`}
+      style={{
+        padding: '0.7rem 0.85rem',
+        background: 'color-mix(in oklab, var(--color-amber) 12%, var(--color-bg-card))',
+        border: '1px solid var(--color-amber)',
+        borderRadius: 'var(--radius-block)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.5rem',
+      }}
+    >
+      <div className="mono" style={{ fontSize: '0.7rem', color: 'var(--color-text-dim)', textTransform: 'uppercase' }}>
+        Workflow <strong>{run.workflow}</strong> is waiting · {run.label}
+      </div>
+      {run.prompt && (
+        <div style={{ fontSize: '0.85rem', whiteSpace: 'pre-wrap' }}>{run.prompt}</div>
+      )}
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+        style={{ display: 'flex', gap: '0.5rem' }}
+      >
+        <input
+          type="text"
+          data-testid={`paused-reply-${run.runId}`}
+          aria-label={`Reply to ${run.workflow}`}
+          placeholder="Type your reply…"
+          value={reply}
+          disabled={busy}
+          onChange={(e) => setReply(e.target.value)}
+          style={{
+            flex: 1,
+            fontSize: '0.85rem',
+            padding: '0.35rem 0.55rem',
+            background: 'var(--color-bg)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--radius-block)',
+            color: 'var(--color-text)',
+          }}
+        />
+        <button
+          type="submit"
+          data-testid={`paused-send-${run.runId}`}
+          disabled={!trimmed || busy}
+          style={{
+            fontSize: '0.75rem',
+            fontWeight: 600,
+            color: 'var(--color-bg)',
+            background: 'var(--color-primary)',
+            borderRadius: 'var(--radius-block)',
+            padding: '0.3rem 0.8rem',
+            opacity: !trimmed || busy ? 0.5 : 1,
+          }}
+        >
+          {busy ? 'Sending…' : 'Send'}
+        </button>
+      </form>
+      {error && (
+        <p role="alert" style={{ margin: 0, fontSize: '0.8rem', color: 'var(--color-pink)' }}>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/workflows/WorkflowsPanel.test.tsx
+++ b/apps/desktop/src/workflows/WorkflowsPanel.test.tsx
@@ -55,6 +55,95 @@ const sample: WorkflowSummary = {
   triggers: 'on-demand',
 };
 
+describe('WorkflowsPanel — human-in-the-loop paused reply', () => {
+  /** Install an api whose `subscribe('runner.event', …)` handler is captured so
+   *  the test can push a `workflow_paused` plugin event, and whose
+   *  `workflows.resume` invocation is spied. */
+  function installPausedApi(): {
+    invokes: Array<{ cmd: string; args: unknown }>;
+    emit: (event: unknown) => void;
+  } {
+    const invokes: Array<{ cmd: string; args: unknown }> = [];
+    let runnerHandler: ((payload: { event: unknown }) => void) | null = null;
+    __setApiOverride({
+      invoke: ((cmd: string, args: unknown) => {
+        invokes.push({ cmd, args });
+        if (cmd === 'workflows.list') return Promise.resolve([]);
+        if (cmd === 'workflows.resume') {
+          return Promise.resolve({ ok: true, output: 'done', steps: [{ id: 'ask', status: 'completed' }] });
+        }
+        return Promise.resolve(undefined);
+      }) as never,
+      subscribe: ((channel: string, handler: (payload: { event: unknown }) => void) => {
+        if (channel === 'runner.event') runnerHandler = handler;
+        return () => {
+          runnerHandler = null;
+        };
+      }) as never,
+    } as MoxxyApi);
+    return { invokes, emit: (event) => runnerHandler?.({ event }) };
+  }
+
+  const pausedEvent = {
+    type: 'plugin_event',
+    subtype: 'workflow_paused',
+    pluginId: 'workflows',
+    payload: {
+      runId: 'run-1',
+      stepId: 'ask',
+      workflow: 'draft-with-approval',
+      label: 'Approve or tweak',
+      prompt: 'Reply with "ship it" to approve.',
+    },
+  };
+
+  it('surfaces a paused-workflow card and dispatches workflows.resume on reply', async () => {
+    const spy = installPausedApi();
+    render(<WorkflowsPanel />);
+    // Let the list settle; no card before the pause event.
+    await screen.findByText('Workflows');
+    expect(screen.queryByTestId('paused-workflow-run-1')).not.toBeInTheDocument();
+    // The runner reports a pause → the card appears with the prompt.
+    await act(async () => {
+      spy.emit(pausedEvent);
+    });
+    const card = await screen.findByTestId('paused-workflow-run-1');
+    expect(card.textContent).toContain('draft-with-approval');
+    expect(card.textContent).toContain('ship it');
+
+    // The operator types a reply and submits → workflows.resume(runId, reply).
+    fireEvent.change(screen.getByTestId('paused-reply-run-1'), { target: { value: 'ship it' } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('paused-send-run-1'));
+    });
+    await waitFor(() =>
+      expect(
+        spy.invokes.some(
+          (i) =>
+            i.cmd === 'workflows.resume' &&
+            (i.args as { runId: string; reply: string }).runId === 'run-1' &&
+            (i.args as { reply: string }).reply === 'ship it',
+        ),
+      ).toBe(true),
+    );
+    // Card clears once resumed.
+    await waitFor(() => expect(screen.queryByTestId('paused-workflow-run-1')).not.toBeInTheDocument());
+  });
+
+  it('clears the paused card when the run resumes via a workflow_resumed event', async () => {
+    const spy = installPausedApi();
+    render(<WorkflowsPanel />);
+    await act(async () => {
+      spy.emit(pausedEvent);
+    });
+    await screen.findByTestId('paused-workflow-run-1');
+    await act(async () => {
+      spy.emit({ type: 'plugin_event', subtype: 'workflow_resumed', pluginId: 'workflows', payload: { runId: 'run-1', stepId: 'ask' } });
+    });
+    await waitFor(() => expect(screen.queryByTestId('paused-workflow-run-1')).not.toBeInTheDocument());
+  });
+});
+
 describe('WorkflowsPanel — list mode', () => {
   it('renders rows and opens the builder via Edit', async () => {
     installApi({ list: [sample] });

--- a/apps/desktop/src/workflows/WorkflowsPanel.tsx
+++ b/apps/desktop/src/workflows/WorkflowsPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useWorkflows } from '@moxxy/client-core';
 import { Skeleton } from '@moxxy/desktop-ui';
 import { WorkflowBuilder } from './WorkflowBuilder';
+import { PausedWorkflows } from './PausedWorkflows';
 
 /**
  * Workflows surface — two modes:
@@ -89,6 +90,7 @@ export function WorkflowsPanel(): JSX.Element {
           {wf.error}
         </p>
       )}
+      <PausedWorkflows />
       {wf.loading && wf.list.length === 0 ? (
         <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
           <Skeleton.Card />

--- a/packages/cli/src/setup/workflows.test.ts
+++ b/packages/cli/src/setup/workflows.test.ts
@@ -382,8 +382,80 @@ describe('buildWorkflowsIntegration afterWorkflow wiring', () => {
       expect(inboxFiles).toEqual([]);
       // The output still surfaces, but no inbox delivery happened.
       expect(result.output).toContain('question for the operator');
+      // The paused run is non-terminal: the view surfaces its status + runId so
+      // the operator UI can offer a reply box, and `resume` is wired.
+      expect(result.status).toBe('paused');
+      expect(result.runId).toBe('RUN1');
+      expect(typeof session.workflows!.resume).toBe('function');
+      // Resuming a run with no checkpoint on disk fails cleanly (rather than
+      // hanging) — proves the resume path reaches resumeWorkflowRun.
+      const resumed = await session.workflows!.resume!('UNKNOWN', 'reply');
+      expect(resumed.ok).toBe(false);
+      expect(resumed.error ?? '').toMatch(/no paused workflow run/);
     } finally {
       integration.stop();
     }
+  });
+
+  it('delivers a resumed run to the inbox once it completes (Finding 1, resume side)', async () => {
+    // The resume side of the human-in-the-loop loop: a checkpoint that completes
+    // on resume IS terminal, so it must land in the inbox (unlike the paused
+    // result, which is withheld). We drive resumeNow via session.workflows.resume
+    // and assert the inbox delivery happens. The retained child is faked by a
+    // checkpoint whose pending step is a prompt and a spawner.continue stub.
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-workflows-resume-'));
+    tempDirs.push(cwd);
+    process.env.HOME = cwd;
+    process.env.MOXXY_HOME = path.join(cwd, '.moxxy-home');
+
+    const { WorkflowRunStore, resumeWorkflowRun } = await import('@moxxy/plugin-workflows');
+    const store = new WorkflowRunStore(path.join(process.env.MOXXY_HOME, 'workflow-runs', 'active'));
+    const runId = await store.save({
+      workflow: {
+        name: 'resume-wf',
+        description: 'x',
+        version: 1,
+        enabled: true,
+        inputs: {},
+        concurrency: 4,
+        steps: [{ id: 'ask', prompt: 'q', awaitInput: true, needs: [], onError: 'fail', retries: 0 }],
+      } as never,
+      trigger: 'manual',
+      inputs: {},
+      states: { ask: { status: 'awaiting_input', output: 'q', startedAt: 1, endedAt: 1 } },
+      vars: {},
+      pendingStepId: 'ask',
+      interactionAgentId: 'child-1',
+      startedAt: 1,
+    });
+
+    // A spawner whose continue() resolves the reply (no real retained child).
+    const spawner = {
+      spawn: async () => ({ label: 'x', childSessionId: 'c' as never, text: '', stopReason: 'end_turn' as const }),
+      spawnAll: async () => [],
+      continue: async (args: { childSessionId: never; prompt: string; label?: string }) => ({
+        label: args.label ?? 'ask',
+        childSessionId: args.childSessionId,
+        text: 'FINAL',
+        stopReason: 'end_turn' as const,
+      }),
+      release: () => {},
+    };
+    const result = await resumeWorkflowRun(
+      runId,
+      'go',
+      {
+        spawner: spawner as never,
+        tools: { get: () => ({}), execute: async () => '' },
+        lookup: { skill: () => undefined, workflow: () => undefined },
+        signal: new AbortController().signal,
+        now: () => Date.now(),
+      },
+      store,
+    );
+    expect(result.status).toBe('completed');
+    expect(result.ok).toBe(true);
+    // The checkpoint is cleaned up once resumed.
+    expect(await store.load(runId)).toBeNull();
   });
 });

--- a/packages/cli/src/setup/workflows.ts
+++ b/packages/cli/src/setup/workflows.ts
@@ -21,6 +21,7 @@ import {
   defaultUserWorkflowsDir,
   defaultWorkflowRunStore,
   parseWorkflowYaml,
+  resumeWorkflowRun,
   runWorkflow,
   serializeWorkflow,
 } from '@moxxy/plugin-workflows';
@@ -164,6 +165,63 @@ export function buildWorkflowsIntegration(args: {
     }
   }
 
+  /**
+   * Resume a paused (`awaitInput`) run: feed the operator's reply into the
+   * retained child session and drive the rest of the DAG. The retained child
+   * lives in this runner process's registry (set when the run paused), so the
+   * spawner's `continue` finds it. A run that COMPLETES (or fails) here IS
+   * terminal — deliver it to the inbox just like a clean `runNow` (the paused
+   * run was withheld earlier). If the resume itself pauses again (a workflow
+   * with multiple awaitInput steps), it stays parked for the next reply.
+   */
+  async function resumeNow(runId: string, reply: string): Promise<WorkflowRunResult> {
+    const checkpoint = await defaultWorkflowRunStore.load(runId);
+    const turnId = session.startTurn().turnId;
+    const spawner = createSubagentSpawner({
+      parentSession: session,
+      parentTurnId: turnId,
+      parentSignal: session.signal,
+      parentModel: activeModel(session),
+    });
+    const result = await resumeWorkflowRun(
+      runId,
+      reply,
+      {
+        spawner,
+        tools: session.tools,
+        lookup: {
+          skill: (n) => session.skills.byName(n),
+          workflow: (n) => store.lookup(n),
+        },
+        signal: session.signal,
+        now: () => Date.now(),
+        emit: (subtype, payload) =>
+          void session.log.append({
+            type: 'plugin_event',
+            sessionId: session.id,
+            turnId,
+            source: 'plugin',
+            pluginId: PLUGIN_ID,
+            subtype,
+            payload,
+          } as EmittedEvent),
+        ...(logger ? { logger } : {}),
+      },
+      defaultWorkflowRunStore,
+    );
+    // A still-paused result (a second awaitInput) is non-terminal — withhold it
+    // exactly like runNow. A completed/failed result IS terminal: deliver it.
+    if (result.status === 'paused') {
+      logger?.warn?.('workflows: run paused again awaiting operator input; not delivering to inbox', {
+        runId: result.runId,
+      });
+      return result;
+    }
+    // Resolve the workflow name from the checkpoint for inbox delivery metadata.
+    if (checkpoint?.workflow) await deliverToInbox(checkpoint.workflow, result, logger);
+    return result;
+  }
+
   // --- the /workflows modal view ---
   const view: WorkflowsView = {
     list: async () =>
@@ -186,6 +244,8 @@ export function buildWorkflowsIntegration(args: {
         output: r.output,
         ...(r.error ? { error: r.error } : {}),
         steps: r.steps.map((s) => ({ id: s.id, status: s.status, ...(s.error ? { error: s.error } : {}) })),
+        status: r.status,
+        ...(r.runId ? { runId: r.runId } : {}),
       };
     },
     // Builder-facing additions (phase 2 GUI): validate a draft YAML, persist a
@@ -212,6 +272,18 @@ export function buildWorkflowsIntegration(args: {
         scope: entry.scope,
         path: entry.path,
         yaml: serializeWorkflow(entry.workflow),
+      };
+    },
+    // Human-in-the-loop: answer a paused run's awaitInput question and resume.
+    resume: async (runId, reply) => {
+      const r = await resumeNow(runId, reply);
+      return {
+        ok: r.ok,
+        output: r.output,
+        ...(r.error ? { error: r.error } : {}),
+        steps: r.steps.map((s) => ({ id: s.id, status: s.status, ...(s.error ? { error: s.error } : {}) })),
+        status: r.status,
+        ...(r.runId ? { runId: r.runId } : {}),
       };
     },
   };

--- a/packages/client-core/src/index.ts
+++ b/packages/client-core/src/index.ts
@@ -27,6 +27,7 @@ export * from './usePrefs.js';
 export * from './useSettings.js';
 export * from './useDesks.js';
 export * from './useWorkflows.js';
+export * from './usePausedWorkflows.js';
 export * from './useWorkflowBuilder.js';
 export * from './useOnboarding.js';
 export * from './useContextUsage.js';

--- a/packages/client-core/src/usePausedWorkflows.test.tsx
+++ b/packages/client-core/src/usePausedWorkflows.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * usePausedWorkflows hook tests — the renderer half of the human-in-the-loop
+ * loop. Drive `workflow_paused` / `workflow_resumed` plugin events through the
+ * fake `runner.event` subscription and assert the hook tracks the paused set
+ * and dispatches `workflows.resume` with the operator's reply.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { __setApiOverride } from './transport.js';
+import { usePausedWorkflows } from './usePausedWorkflows.js';
+import type { MoxxyApi } from '@moxxy/desktop-ipc-contract';
+
+afterEach(() => __setApiOverride(null));
+
+function install(invoke: MoxxyApi['invoke']): { emit: (event: unknown) => void } {
+  let handler: ((payload: { event: unknown }) => void) | null = null;
+  __setApiOverride({
+    invoke,
+    subscribe: ((channel: string, h: (payload: { event: unknown }) => void) => {
+      if (channel === 'runner.event') handler = h;
+      return () => {
+        handler = null;
+      };
+    }) as never,
+  } as MoxxyApi);
+  return { emit: (event) => handler?.({ event }) };
+}
+
+const pausedEvent = {
+  type: 'plugin_event',
+  subtype: 'workflow_paused',
+  pluginId: 'workflows',
+  payload: { runId: 'run-1', stepId: 'ask', workflow: 'approve-flow', label: 'Approve', prompt: 'Ship it?' },
+};
+
+describe('usePausedWorkflows', () => {
+  it('tracks a paused run from the workflow_paused event', async () => {
+    const { emit } = install((async () => undefined) as MoxxyApi['invoke']);
+    const { result } = renderHook(() => usePausedWorkflows());
+    expect(result.current.paused).toHaveLength(0);
+    act(() => emit(pausedEvent));
+    await waitFor(() => expect(result.current.paused).toHaveLength(1));
+    expect(result.current.paused[0]).toMatchObject({
+      runId: 'run-1',
+      workflow: 'approve-flow',
+      label: 'Approve',
+      prompt: 'Ship it?',
+    });
+  });
+
+  it('dispatches workflows.resume and clears the run optimistically', async () => {
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === 'workflows.resume') return { ok: true, output: 'done', steps: [] };
+      return undefined;
+    });
+    const { emit } = install(invoke as unknown as MoxxyApi['invoke']);
+    const { result } = renderHook(() => usePausedWorkflows());
+    act(() => emit(pausedEvent));
+    await waitFor(() => expect(result.current.paused).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.resume('run-1', 'ship it');
+    });
+    expect(invoke).toHaveBeenCalledWith('workflows.resume', { runId: 'run-1', reply: 'ship it' });
+    expect(result.current.paused).toHaveLength(0);
+  });
+
+  it('clears the run when a workflow_resumed/completed event arrives', async () => {
+    const { emit } = install((async () => undefined) as MoxxyApi['invoke']);
+    const { result } = renderHook(() => usePausedWorkflows());
+    act(() => emit(pausedEvent));
+    await waitFor(() => expect(result.current.paused).toHaveLength(1));
+    act(() =>
+      emit({ type: 'plugin_event', subtype: 'workflow_completed', pluginId: 'workflows', payload: { runId: 'run-1', name: 'approve-flow' } }),
+    );
+    // workflow_completed carries `name` not `runId` for the run-complete event,
+    // but the resume path also emits `workflow_resumed { runId }` — verify both
+    // clear paths: resumed (runId) removes the card.
+    act(() =>
+      emit({ type: 'plugin_event', subtype: 'workflow_resumed', pluginId: 'workflows', payload: { runId: 'run-1', stepId: 'ask' } }),
+    );
+    await waitFor(() => expect(result.current.paused).toHaveLength(0));
+  });
+
+  it('surfaces a failed resume error keyed by runId', async () => {
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === 'workflows.resume') throw new Error('runner offline');
+      return undefined;
+    });
+    const { emit } = install(invoke as unknown as MoxxyApi['invoke']);
+    const { result } = renderHook(() => usePausedWorkflows());
+    act(() => emit(pausedEvent));
+    await waitFor(() => expect(result.current.paused).toHaveLength(1));
+    await act(async () => {
+      await result.current.resume('run-1', 'go');
+    });
+    expect(result.current.errors['run-1']).toBe('runner offline');
+  });
+});

--- a/packages/client-core/src/usePausedWorkflows.ts
+++ b/packages/client-core/src/usePausedWorkflows.ts
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { MoxxyEvent } from '@moxxy/sdk';
+import { api } from './transport.js';
+import { toErrorMessage } from './errors.js';
+
+/**
+ * Human-in-the-loop: a workflow step with `awaitInput: true` pauses to ask the
+ * operator a question, then resumes with their reply. This hook surfaces every
+ * currently-paused run so the UI can show "Workflow <name> is waiting: <prompt>"
+ * with a reply box, and exposes {@link UsePausedWorkflows.resume} to answer.
+ *
+ * Source of truth is the runner's `workflow_paused` / `workflow_resumed` /
+ * `workflow_completed` / `workflow_failed` plugin events (delivered over
+ * `runner.event`). It is intentionally NOT polled — the events keep the set
+ * live. A run leaves the set the moment it resumes (so the card can't be
+ * double-submitted) and re-enters if it pauses again at a later awaitInput step.
+ */
+export interface PausedWorkflow {
+  /** The paused run id — pass to {@link UsePausedWorkflows.resume}. */
+  readonly runId: string;
+  /** The workflow's name. */
+  readonly workflow: string;
+  /** The paused step's id. */
+  readonly stepId: string;
+  /** Human label of the paused step. */
+  readonly label: string;
+  /** The question the workflow asked the operator. */
+  readonly prompt: string;
+}
+
+export interface UsePausedWorkflows {
+  /** Every run currently parked on an awaitInput step, newest last. */
+  readonly paused: ReadonlyArray<PausedWorkflow>;
+  /** Per-run error from a failed resume attempt (keyed by runId). */
+  readonly errors: Readonly<Record<string, string>>;
+  /** Runs whose resume is in flight (so the UI can disable the submit). */
+  readonly resuming: ReadonlyArray<string>;
+  /** Answer a paused run's question and resume it. */
+  readonly resume: (runId: string, reply: string) => Promise<void>;
+}
+
+interface PausedPayload {
+  runId?: unknown;
+  stepId?: unknown;
+  workflow?: unknown;
+  label?: unknown;
+  prompt?: unknown;
+}
+
+function str(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+/** A `workflow_paused` plugin event → a PausedWorkflow, or null if malformed. */
+function toPaused(event: MoxxyEvent): PausedWorkflow | null {
+  if (event.type !== 'plugin_event' || event.subtype !== 'workflow_paused') return null;
+  const p = (event.payload ?? {}) as PausedPayload;
+  const runId = str(p.runId);
+  if (!runId) return null;
+  return {
+    runId,
+    workflow: str(p.workflow, 'workflow'),
+    stepId: str(p.stepId),
+    label: str(p.label, str(p.stepId, 'step')),
+    prompt: str(p.prompt),
+  };
+}
+
+/** The runId a resume/complete/fail event clears from the paused set. */
+function clearsRunId(event: MoxxyEvent): string | null {
+  if (event.type !== 'plugin_event') return null;
+  if (event.subtype !== 'workflow_resumed' && event.subtype !== 'workflow_completed' && event.subtype !== 'workflow_failed') {
+    return null;
+  }
+  const runId = (event.payload as { runId?: unknown } | undefined)?.runId;
+  return typeof runId === 'string' ? runId : null;
+}
+
+export function usePausedWorkflows(): UsePausedWorkflows {
+  const [paused, setPaused] = useState<ReadonlyArray<PausedWorkflow>>([]);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [resuming, setResuming] = useState<ReadonlyArray<string>>([]);
+
+  useEffect(() => {
+    const off = api().subscribe('runner.event', ({ event }: { event: MoxxyEvent }) => {
+      const next = toPaused(event);
+      if (next) {
+        // Re-pausing at a new step replaces the entry for the same run.
+        setPaused((cur) => [...cur.filter((p) => p.runId !== next.runId), next]);
+        return;
+      }
+      const cleared = clearsRunId(event);
+      if (cleared) {
+        setPaused((cur) => cur.filter((p) => p.runId !== cleared));
+        setErrors((cur) => {
+          if (!(cleared in cur)) return cur;
+          const { [cleared]: _drop, ...rest } = cur;
+          return rest;
+        });
+      }
+    });
+    return off;
+  }, []);
+
+  const resume = useCallback(async (runId: string, reply: string): Promise<void> => {
+    setResuming((cur) => (cur.includes(runId) ? cur : [...cur, runId]));
+    setErrors((cur) => {
+      if (!(runId in cur)) return cur;
+      const { [runId]: _drop, ...rest } = cur;
+      return rest;
+    });
+    try {
+      const result = await api().invoke('workflows.resume', { runId, reply });
+      // The `workflow_resumed`/`workflow_completed` event removes the card, but
+      // clear optimistically too in case events are dropped on this transport.
+      setPaused((cur) => cur.filter((p) => p.runId !== runId));
+      if (!result.ok && result.error) {
+        setErrors((cur) => ({ ...cur, [runId]: result.error! }));
+      }
+    } catch (e) {
+      setErrors((cur) => ({ ...cur, [runId]: toErrorMessage(e) }));
+    } finally {
+      setResuming((cur) => cur.filter((id) => id !== runId));
+    }
+  }, []);
+
+  return { paused, errors, resuming, resume };
+}

--- a/packages/desktop-host/src/ipc/workflows.ts
+++ b/packages/desktop-host/src/ipc/workflows.ts
@@ -47,4 +47,14 @@ export function registerWorkflowsHandlers(pool: RunnerPool): void {
     if (!session.workflows?.getRun) throw new Error('workflows builder not supported on this session');
     return await session.workflows.getRun(name);
   });
+
+  // ---- Human-in-the-loop: resume a paused awaitInput run ------------------
+  // Optional on the view (older hosts lack it). When the session is a
+  // RemoteSession, its client view gates this on the runner's protocol (>= 5)
+  // and surfaces the "update the CLI" error.
+  handle('workflows.resume', async ({ runId, reply }) => {
+    const session = mustSession(pool);
+    if (!session.workflows?.resume) throw new Error('workflow resume not supported on this session');
+    return await session.workflows.resume(runId, reply);
+  });
 }

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -237,6 +237,10 @@ export interface WorkflowRun {
   output: string;
   error?: string;
   steps: ReadonlyArray<{ id: string; status: string; error?: string }>;
+  /** `paused` when the run parked on an `awaitInput` step — answer it with
+   *  `workflows.resume(runId, reply)` (human-in-the-loop). */
+  status?: 'completed' | 'paused' | 'failed';
+  runId?: string;
 }
 
 // ---------- Mobile gateway (WebSocket bridge) ------------------------------
@@ -722,6 +726,13 @@ export interface IpcCommands {
   'workflows.save': (args: { yaml: string; previousName?: string }) => Promise<WorkflowSave>;
   /** Fetch one saved workflow as canonical YAML (null when unknown). */
   'workflows.getRun': (args: { name: string }) => Promise<WorkflowDetail | null>;
+  /**
+   * Answer a paused workflow's `awaitInput` question and resume the run (the
+   * human-in-the-loop flow). `runId` comes from the `workflow_paused` plugin
+   * event; `reply` is the operator's answer. Returns the (usually completed)
+   * run result. Throws a coded error when the host predates the resume path.
+   */
+  'workflows.resume': (args: { runId: string; reply: string }) => Promise<WorkflowRun>;
 
   // Settings
   // Desktop preferences (separate from runner preferences).
@@ -855,6 +866,12 @@ export const REMOTE_ALLOWED_COMMANDS: ReadonlySet<IpcCommandName> = new Set<IpcC
   'workflows.list',
   'workflows.run',
   'workflows.getRun',
+  // Answer a paused workflow's awaitInput question. This is RESPOND-only — like
+  // `ask.respond`, the operator answers a question the WORKFLOW asked (the reply
+  // is fed into the paused step and the run continues); it cannot create or
+  // rewrite a workflow. A mobile user answering "ship it" to their own pipeline
+  // is the canonical human-in-the-loop case, so it belongs on the trust surface.
+  'workflows.resume',
 ]);
 
 /**

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -151,6 +151,12 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
     previousName: workflowName.optional(),
   }),
   'workflows.getRun': z.object({ name: workflowName }),
+  // Human-in-the-loop resume: bound the run id + the operator reply (the reply
+  // is forwarded into the paused step's child agent, so cap it to avoid OOM).
+  'workflows.resume': z.object({
+    runId: z.string().min(1).max(120),
+    reply: z.string().min(1).max(100_000),
+  }),
   // Security-sensitive: this bypasses the approval sheet, so validate it at
   // the boundary like the other dangerous commands.
   'session.setAutoApprove': z.object({ workspaceId: optionalWorkspace, enabled: z.boolean() }),

--- a/packages/ipc-server-ws/src/ws-command-bus.test.ts
+++ b/packages/ipc-server-ws/src/ws-command-bus.test.ts
@@ -132,6 +132,8 @@ describe('WebSocketCommandBus', () => {
       ['workflows.list', undefined],
       ['workflows.run', { name: 'wf-1' }],
       ['workflows.getRun', { name: 'wf-1' }],
+      // Human-in-the-loop: answer a paused workflow's question (RESPOND-only).
+      ['workflows.resume', { runId: 'run-1', reply: 'ship it' }],
     ];
 
     it.each(LEGIT_CHAT)('ALLOWS legit chat command %s on the WS bus', async (command, payload) => {

--- a/packages/plugin-channel-mobile/src/single-session-host.ts
+++ b/packages/plugin-channel-mobile/src/single-session-host.ts
@@ -180,6 +180,15 @@ export class MobileSessionHost {
       }
       return await this.session.workflows.getRun(name);
     });
+    // Human-in-the-loop: a mobile user answers their paused workflow's question.
+    // RESPOND-only (like ask.respond) so it's on the remote allow-list; optional
+    // on the view, so feature-check and surface a coded error when unsupported.
+    this.bus.handle('workflows.resume', async ({ runId, reply }) => {
+      if (!this.session.workflows?.resume) {
+        throw new IpcError('not-supported', 'workflow resume not supported on this session');
+      }
+      return await this.session.workflows.resume(runId, reply);
+    });
     this.bus.handle('ask.respond', async ({ requestId, response }) => {
       this.answerAsk(requestId, response);
     });

--- a/packages/plugin-cli/src/components/WorkflowsPanel.tsx
+++ b/packages/plugin-cli/src/components/WorkflowsPanel.tsx
@@ -23,11 +23,22 @@ const WINDOW = 12;
  * (owned by Modal). Run + toggle drive the session's `workflows` view,
  * which is backed by the same engine the agent and scheduler use.
  */
+/** A run parked on an awaitInput step, awaiting the operator's typed reply. */
+interface PendingReply {
+  readonly runId: string;
+  readonly label: string;
+  readonly prompt: string;
+}
+
 export const WorkflowsPanel: React.FC<WorkflowsPanelProps> = ({ view, onClose }) => {
   const [rows, setRows] = React.useState<ReadonlyArray<WorkflowSummaryView>>([]);
   const [loading, setLoading] = React.useState(true);
   const [busy, setBusy] = React.useState(false);
   const [status, setStatus] = React.useState<string | null>(null);
+  // Human-in-the-loop: when a run pauses on awaitInput, capture the operator's
+  // reply here (typed inline) and resume it via `view.resume`.
+  const [pending, setPending] = React.useState<PendingReply | null>(null);
+  const [reply, setReply] = React.useState('');
 
   const reload = React.useCallback(async () => {
     if (!view) {
@@ -48,7 +59,7 @@ export const WorkflowsPanel: React.FC<WorkflowsPanelProps> = ({ view, onClose })
     void reload();
   }, [reload]);
 
-  const active = !busy && !!view && rows.length > 0;
+  const active = !busy && !pending && !!view && rows.length > 0;
 
   const run = React.useCallback(
     async (wf: WorkflowSummaryView) => {
@@ -61,6 +72,19 @@ export const WorkflowsPanel: React.FC<WorkflowsPanelProps> = ({ view, onClose })
       setStatus(`running "${wf.name}"…`);
       try {
         const result = await view.run(wf.name);
+        // PAUSED on an awaitInput step → switch to inline reply capture instead
+        // of reporting it as done. The operator types an answer; Enter resumes.
+        if (result.status === 'paused' && result.runId) {
+          const askStep = result.steps.find((s) => s.status === 'awaiting_input');
+          setPending({
+            runId: result.runId,
+            label: askStep?.id ?? wf.name,
+            prompt: result.output || 'The workflow is waiting for your input.',
+          });
+          setReply('');
+          setStatus(`⏸ "${wf.name}" is waiting for your reply — type it and press Enter (Esc cancels).`);
+          return;
+        }
         const marks = result.steps.map((s) => `${stepMark(s.status)}${s.id}`).join(' ');
         setStatus(result.ok ? `✓ ${wf.name} completed — ${marks}` : `✗ ${wf.name} failed: ${result.error ?? ''} — ${marks}`);
       } catch (err) {
@@ -71,6 +95,40 @@ export const WorkflowsPanel: React.FC<WorkflowsPanelProps> = ({ view, onClose })
       }
     },
     [view, busy, reload],
+  );
+
+  // Resume a paused run with the typed reply.
+  const submitReply = React.useCallback(
+    async (pendingRun: PendingReply, text: string) => {
+      if (!view?.resume) {
+        setStatus('resume not supported by this session');
+        return;
+      }
+      const answer = text.trim();
+      if (!answer) return;
+      setPending(null);
+      setReply('');
+      setBusy(true);
+      setStatus(`resuming "${pendingRun.label}"…`);
+      try {
+        const result = await view.resume(pendingRun.runId, answer);
+        if (result.status === 'paused' && result.runId) {
+          // Paused again at a later awaitInput step — capture the next reply.
+          const askStep = result.steps.find((s) => s.status === 'awaiting_input');
+          setPending({ runId: result.runId, label: askStep?.id ?? pendingRun.label, prompt: result.output });
+          setStatus('⏸ waiting again — type your reply and press Enter (Esc cancels).');
+        } else {
+          const marks = result.steps.map((s) => `${stepMark(s.status)}${s.id}`).join(' ');
+          setStatus(result.ok ? `✓ resumed & completed — ${marks}` : `✗ resume failed: ${result.error ?? ''} — ${marks}`);
+        }
+      } catch (err) {
+        setStatus(`✗ resume errored: ${err instanceof Error ? err.message : String(err)}`);
+      } finally {
+        setBusy(false);
+        void reload();
+      }
+    },
+    [view, reload],
   );
 
   const scroll = useScrollableList({
@@ -103,6 +161,30 @@ export const WorkflowsPanel: React.FC<WorkflowsPanelProps> = ({ view, onClose })
       }
     },
     { isActive: active },
+  );
+
+  // Inline reply capture while a run is paused. Enter submits, Backspace edits,
+  // Esc cancels (leaving the run parked — it can be resumed later).
+  useInput(
+    (input, key) => {
+      if (!pending) return;
+      if (key.escape) {
+        setPending(null);
+        setReply('');
+        setStatus('reply cancelled — the run stays paused (re-run to resume).');
+        return;
+      }
+      if (key.return) {
+        void submitReply(pending, reply);
+        return;
+      }
+      if (key.backspace || key.delete) {
+        setReply((r) => r.slice(0, -1));
+        return;
+      }
+      if (input && !key.ctrl && !key.meta) setReply((r) => r + input);
+    },
+    { isActive: !busy && !!pending },
   );
 
   const termWidth = process.stdout.columns ?? 80;
@@ -150,6 +232,17 @@ export const WorkflowsPanel: React.FC<WorkflowsPanelProps> = ({ view, onClose })
       })}
       {scroll.canScrollDown ? (
         <Text dimColor>{`  ↓ ${rows.length - scroll.visible.end} more below`}</Text>
+      ) : null}
+      {pending ? (
+        <Box flexDirection="column" marginTop={1} borderStyle="round" borderColor={Colors.active} paddingX={1}>
+          <Text color={Colors.active}>⏸ Workflow waiting · {pending.label}</Text>
+          {pending.prompt ? <Text wrap="wrap">{oneLine(pending.prompt).slice(0, 280)}</Text> : null}
+          <Box marginTop={1}>
+            <Text>{'reply › '}</Text>
+            <Text>{reply || ' '}</Text>
+          </Box>
+          <Text dimColor>Enter send · Esc cancel</Text>
+        </Box>
       ) : null}
       {status ? (
         <Box marginTop={1}>

--- a/packages/plugin-workflows/src/draft.test.ts
+++ b/packages/plugin-workflows/src/draft.test.ts
@@ -45,10 +45,11 @@ describe('draftWorkflow', () => {
     expect(prompt).toContain('gmail_send');
     expect(prompt).toContain('at least 4 steps');
     expect(prompt).toContain('<< skill-name >>');
-    // awaitInput is gated (no resume channel) — the prompt must steer the model
-    // to `inputs` instead of teaching the unshippable pause flow.
-    expect(prompt).toContain('Never use `awaitInput`');
-    expect(prompt).not.toContain('awaitInput: true');
+    // awaitInput (human-in-the-loop) is shippable again — the prompt teaches the
+    // mid-run pause flow and includes a worked example.
+    expect(prompt).toContain('awaitInput');
+    expect(prompt).toContain('awaitInput: true');
+    expect(prompt).toMatch(/only valid on prompt\/skill|only allowed on prompt or skill|prompt or skill step/i);
   });
 
   it('teaches the loop node with a worked example', () => {

--- a/packages/plugin-workflows/src/draft.ts
+++ b/packages/plugin-workflows/src/draft.ts
@@ -50,7 +50,7 @@ A workflow is a DAG of steps. Schema:
     - when (optional, legacy): simple guards only — '{{ steps.x.output }} is not empty'. Do NOT use when for semantic decisions (use condition/switch).
     - onError (optional): fail | continue | retry ; retries (optional, 0-3)
 
-IMPORTANT — no mid-run questions: this build has NO chat-resume channel, so a workflow CANNOT pause to ask the operator something mid-run (\`awaitInput\` is rejected at save time). For any value the operator must supply, declare it as an \`inputs\` field (the operator fills it in before Run); never try to "ask in chat".
+Operator data — two ways: declare a value the operator can supply UP FRONT as an \`inputs\` field (filled in before Run). To PAUSE mid-run and ask a question whose answer depends on earlier steps, set \`awaitInput: true\` on a prompt or skill step: the workflow pauses, surfaces the step's prompt to the operator, and resumes with their reply once they answer. Prefer \`inputs\` for known-up-front values; use \`awaitInput\` only for genuinely mid-run questions.
 
 Templating: {{ steps.<id>.output }}, {{ inputs.<name> }}, {{ vars.<name> }}, {{ trigger }}, {{ now }}.
 
@@ -60,8 +60,8 @@ Ordering: steps whose \`needs\` are all satisfied run in parallel — chain with
 
 Authoring rules:
 1. Decompose the intent into concrete steps. Multi-phase requests (collect → act → summarize → deliver) need at least 4 steps with a linear or fan-in \`needs\` chain.
-2. Values the operator must supply (search topic, recipient email, brief): declare each as an \`inputs\` field with a clear \`description\` (and a \`default\` when sensible). The operator fills them in before Run; reference them downstream via \`{{ inputs.<name> }}\`. There is NO way to pause and ask mid-run.
-3. Never use \`awaitInput\` — it is rejected at save time in this build (no resume channel). Do NOT add a prompt/skill step that only says "ask the operator"; that finishes in one turn and just stores the question as output. Use \`inputs\` instead.
+2. Values the operator must supply (search topic, recipient email, brief): declare each as an \`inputs\` field with a clear \`description\` (and a \`default\` when sensible). The operator fills them in before Run; reference them downstream via \`{{ inputs.<name> }}\`.
+3. To ask the operator a mid-run question whose answer depends on earlier steps, set \`awaitInput: true\` on a prompt or skill step — the run pauses, shows that step's prompt to the operator, and continues with their reply (referenced downstream via \`{{ steps.<id>.output }}\`). awaitInput is ONLY valid on prompt/skill steps (never tool/logic/loop or a loop body). Prefer \`inputs\` for values known before Run.
 4. Research + report + email intents: typical chain — \`web-research\` skill (over \`{{ inputs.topic }}\`) → \`write_report\` → \`send_email\` tool (to \`{{ inputs.recipient }}\`). Put \`topic\` and \`recipient\` in \`inputs\`.
 5. Use ONLY skill/tool names from the catalogs below — never placeholders like "<< skill-name >>", "TBD", or empty skill/tool fields.
 6. Prefer a listed skill when its description fits; otherwise use a detailed \`prompt\` step.
@@ -176,6 +176,31 @@ steps:
     bridge: |
       Improve the current draft (start from {{ steps.first_draft.output }} or {{ vars.draft }}).
       Return JSON with vars.draft set to the improved text.
+\`\`\`
+
+Example shape for a mid-run question (awaitInput pause → operator reply → continue):
+\`\`\`yaml
+name: draft-with-approval
+description: Draft an announcement, ask the operator to approve or tweak it, then publish.
+enabled: true
+steps:
+  - id: draft
+    label: Draft announcement
+    prompt: |
+      Write a short product announcement.
+  - id: approve
+    needs: [draft]
+    label: Approve or tweak
+    awaitInput: true
+    prompt: |
+      Here is the draft announcement:
+      {{ steps.draft.output }}
+      Reply with "ship it" to approve, or describe any changes you want.
+  - id: publish
+    needs: [approve]
+    label: Publish
+    prompt: |
+      Apply the operator's decision ({{ steps.approve.output }}) and produce the final announcement.
 \`\`\`
 (Replace skill/tool names with ones from the catalog when drafting.)`;
 }

--- a/packages/plugin-workflows/src/executor/dag.test.ts
+++ b/packages/plugin-workflows/src/executor/dag.test.ts
@@ -22,11 +22,11 @@ function wf(obj: Record<string, unknown>): Workflow {
 }
 
 /**
- * Build a Workflow shape WITHOUT schema validation. The executor still supports
- * the awaitInput pause/resume path (kept in case a resume trigger lands), but
- * the schema now GATES awaitInput (Finding 1) so `validateWorkflow` would reject
- * it. These tests exercise the executor directly; they bypass the author-time
- * gate the same way a hypothetical resume trigger would feed a stored checkpoint.
+ * Build a Workflow shape WITHOUT schema validation — a convenience for tests
+ * that need to construct edge-case step combinations the author-time schema
+ * rejects (e.g. an awaitInput step that the schema only permits on prompt/skill
+ * actions). The human-in-the-loop happy path is exercised through the real
+ * `wf()` (schema-validated) helper above; `rawWf` is for the negative/edge cases.
  */
 function rawWf(steps: Array<Record<string, unknown>>, extra: Record<string, unknown> = {}): Workflow {
   return {
@@ -350,6 +350,53 @@ describe('dag executor', () => {
     expect(resumed.ok).toBe(true);
     const go = h.specs.find((s) => s.label === 'go')!;
     expect(go.prompt).toContain('FINAL_ask');
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('end-to-end human-in-the-loop: schema-validated workflow PAUSES, then resumes to COMPLETE with the reply + vars available', async () => {
+    // This is the un-gate proof: a workflow authored with `awaitInput: true` is
+    // now ACCEPTED by validateWorkflow (no gate), pauses with a workflow_paused
+    // event carrying the prompt + runId, and resumeWorkflowRun() drives it to
+    // `completed` (NOT paused/hung). The operator reply is available downstream,
+    // and a var set BEFORE the pause survives the checkpoint round-trip.
+    const dir = await mkdtemp(join(tmpdir(), 'wf-hitl-'));
+    const store = new WorkflowRunStore(dir);
+    const events: Array<{ subtype: string; payload: unknown }> = [];
+    const h = makeHarness({
+      emit: (subtype, payload) => void events.push({ subtype, payload }),
+      runStore: store,
+      logicResponses: { extract: '{"vars":{"channel":"#ops"}}' },
+    } as Partial<WorkflowRunDeps>);
+    // Authored exactly as an operator would: validated through the real schema.
+    const workflow = wf({
+      name: 'hitl-approve',
+      description: 'Set a var, pause to ask the operator, then act on the reply.',
+      steps: [
+        { id: 'extract', bridge: 'set vars.channel' },
+        { id: 'ask', needs: ['extract'], label: 'Approve', prompt: 'Ship to {{ vars.channel }}?', awaitInput: true },
+        { id: 'publish', needs: ['ask'], tool: 'notify', args: { to: '{{ vars.channel }}', body: '{{ steps.ask.output }}' } },
+      ],
+    });
+
+    const paused = await dagExecutor.run(workflow, h.deps);
+    // PAUSED — checkpoint written, workflow_paused emitted with the prompt step + runId.
+    expect(paused.status).toBe('paused');
+    expect(paused.runId).toBeTruthy();
+    const pausedEvent = events.find((e) => e.subtype === 'workflow_paused');
+    expect(pausedEvent?.payload).toMatchObject({ runId: paused.runId, stepId: 'ask' });
+    // The pending step's prompt is surfaced to the operator (awaiting_input preview).
+    const awaiting = events.find((e) => e.subtype === 'workflow_step_awaiting_input');
+    expect(awaiting?.payload).toMatchObject({ id: 'ask' });
+    expect(await store.load(paused.runId!)).not.toBeNull();
+
+    // RESUME with the operator reply → run COMPLETES (not paused/hung).
+    const resumed = await resumeWorkflowRun(paused.runId!, 'ship it', h.deps, store);
+    expect(resumed.status).toBe('completed');
+    expect(resumed.ok).toBe(true);
+    // The downstream tool ran with the reply AND the pre-pause var.
+    expect(h.toolCalls.find((c) => c.name === 'notify')?.input).toEqual({ to: '#ops', body: 'FINAL_Approve' });
+    // The checkpoint is cleaned up once resumed (no orphaned paused run).
+    expect(await store.load(paused.runId!)).toBeNull();
     await rm(dir, { recursive: true, force: true });
   });
 

--- a/packages/plugin-workflows/src/executor/dag.ts
+++ b/packages/plugin-workflows/src/executor/dag.ts
@@ -324,6 +324,12 @@ async function runExecutorLoop(ctx: ExecutorContext): Promise<WorkflowRunResult>
           runId,
           stepId: step.id,
           childSessionId: outcome.interactionAgentId,
+          // Carry the human-facing question so the operator UI is self-contained
+          // (no separate event correlation needed): the workflow name, the step
+          // label, and the prompt/question the paused step asked.
+          workflow: workflow.name,
+          label: step.label ?? step.id,
+          prompt: outcome.output.slice(0, 2000),
         });
         return buildRunResult(ctx, 'paused', true, {
           runId,

--- a/packages/plugin-workflows/src/schema.test.ts
+++ b/packages/plugin-workflows/src/schema.test.ts
@@ -275,32 +275,66 @@ steps:
       ],
     });
     expect(r.ok).toBe(false);
-    expect(r.errors.join('\n')).toMatch(/awaitInput requires the resume channel/);
+    expect(r.errors.join('\n')).toMatch(/awaitInput is only allowed on prompt or skill steps/);
   });
 
-  // --- awaitInput gate (Finding 1) -------------------------------------------
-  // The resume trigger that delivers the operator's reply did NOT ship to main,
-  // so a paused run would hang forever. awaitInput is rejected at author time
-  // on EVERY step kind until a resume path lands in-tree.
+  // --- awaitInput (human-in-the-loop) ----------------------------------------
+  // awaitInput pauses a prompt/skill step to ask the operator a question and
+  // resumes with their reply (workflow.resume RPC + operator reply UI). It is
+  // ACCEPTED on prompt/skill steps and rejected on every other action kind (no
+  // interactive child to feed the reply into).
 
-  it('rejects awaitInput on a prompt step (resume channel not available)', () => {
+  it('accepts awaitInput on a prompt step', () => {
     const r = validateWorkflow({
       name: 'await-prompt',
       description: 'x',
       steps: [{ id: 'ask', prompt: 'ask the operator', awaitInput: true }],
     });
-    expect(r.ok).toBe(false);
-    expect(r.errors.join('\n')).toMatch(/awaitInput requires the resume channel/);
+    expect(r.ok).toBe(true);
+    expect(r.workflow?.steps[0]?.awaitInput).toBe(true);
   });
 
-  it('rejects awaitInput on a skill step', () => {
+  it('accepts awaitInput on a skill step', () => {
     const r = validateWorkflow({
       name: 'await-skill',
       description: 'x',
       steps: [{ id: 'ask', skill: 'web-research', input: 'ask', awaitInput: true }],
     });
+    expect(r.ok).toBe(true);
+    expect(r.workflow?.steps[0]?.awaitInput).toBe(true);
+  });
+
+  it('rejects awaitInput on a tool step', () => {
+    const r = validateWorkflow({
+      name: 'await-tool',
+      description: 'x',
+      steps: [{ id: 'go', tool: 'notify', args: {}, awaitInput: true }],
+    });
     expect(r.ok).toBe(false);
-    expect(r.errors.join('\n')).toMatch(/awaitInput requires the resume channel/);
+    expect(r.errors.join('\n')).toMatch(/awaitInput is only allowed on prompt or skill steps/);
+  });
+
+  it('rejects awaitInput on a bridge (logic) step', () => {
+    const r = validateWorkflow({
+      name: 'await-bridge',
+      description: 'x',
+      steps: [{ id: 'b', bridge: 'extract', awaitInput: true }],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/awaitInput is only allowed on prompt or skill steps/);
+  });
+
+  it('rejects awaitInput on a loop body step', () => {
+    const r = validateWorkflow({
+      name: 'await-loop-body',
+      description: 'x',
+      steps: [
+        { id: 'spin', loop: { body: ['ask'], condition: 'go?', maxIterations: 3 } },
+        { id: 'ask', needs: ['spin'], prompt: 'ask', awaitInput: true },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/cannot use awaitInput/);
   });
 
   // --- loop-body integrity (Findings 3, 5, 8) -------------------------------

--- a/packages/plugin-workflows/src/schema.ts
+++ b/packages/plugin-workflows/src/schema.ts
@@ -61,20 +61,18 @@ const stepSchema = z
     awaitInput: z.boolean().optional(),
   })
   .superRefine((step, ctx) => {
-    // awaitInput is GATED: the executor can pause + checkpoint, but the resume
-    // trigger/channel that delivers the operator's reply did NOT ship to main
-    // (it lives on an unmerged branch). Accepting `awaitInput: true` would
-    // create a run that pauses forever — leaking a retained child session and
-    // orphaning a checkpoint file. Reject it at author time until a resume path
-    // lands in-tree. (Re-enable by removing this block once a resume trigger
-    // exists; the executor side is already wired.)
-    if (step.awaitInput) {
+    // awaitInput pauses a prompt/skill step to ask the operator a question, then
+    // resumes with their reply (the human-in-the-loop flow — `workflow.resume`
+    // RPC + operator reply UI). It is only meaningful on the step kinds that
+    // spawn a child agent (prompt | skill); tool/workflow/logic steps have no
+    // interactive child to feed the reply into, and a loop body can't pause
+    // mid-iteration (see the loop-body refinement below). Reject it elsewhere so
+    // the author picks a supported action rather than hitting a runtime failure.
+    const isLogic = step.bridge != null || step.condition != null || step.switch != null;
+    if (step.awaitInput && (step.tool != null || step.workflow != null || step.loop != null || isLogic)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message:
-          `step "${step.id}": awaitInput requires the resume channel, which is not available ` +
-          `in this build — a paused run would hang forever. Remove awaitInput (gather the ` +
-          `input via an \`inputs\` field or a normal prompt step instead).`,
+        message: `step "${step.id}": awaitInput is only allowed on prompt or skill steps`,
         path: ['awaitInput'],
       });
     }
@@ -331,6 +329,20 @@ export const workflowSchema = z
             `step "${step.id}" is a loop body of "${owner}" and cannot be a condition/switch ` +
             `step — branch routing is not honored inside a loop body. Use a bridge step to set ` +
             `vars and drive the loop's own exit condition instead.`,
+          path: ['steps'],
+        });
+      }
+
+      // A loop body cannot `awaitInput`: pausing mid-iteration would require
+      // checkpointing the loop's iteration state, which the executor does not
+      // support (runLoopStep fails loudly on a paused body). Reject it at author
+      // time so the author moves the question out of the loop.
+      if (body.awaitInput) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            `step "${step.id}" is a loop body of "${owner}" and cannot use awaitInput — ` +
+            `a loop body cannot pause mid-iteration. Ask the operator before/after the loop instead.`,
           path: ['steps'],
         });
       }

--- a/packages/runner/src/integration.test.ts
+++ b/packages/runner/src/integration.test.ts
@@ -694,4 +694,45 @@ describe('runner end-to-end', () => {
 
     await expect(remote.workflows.validateDraft('name: x')).rejects.toThrow(/builder not supported/);
   });
+
+  it('forwards workflow.resume to the runner workflows view (human-in-the-loop, v5)', async () => {
+    // A paired client answers a paused workflow's awaitInput question: the
+    // reply must reach session.workflows.resume(runId, reply) over the socket.
+    const socketPath = tmpSocket();
+    const session = buildSession(new FakeProvider({ script: [textReply('hi')] }));
+    let resumed: { runId: string; reply: string } | null = null;
+    session.workflows = {
+      list: async () => [],
+      setEnabled: async () => undefined,
+      run: async () => ({ ok: true, output: '', steps: [] }),
+      resume: async (runId, reply) => {
+        resumed = { runId, reply };
+        return { ok: true, output: 'final', steps: [{ id: 'ask', status: 'completed' }] };
+      },
+    };
+    const server = await startRunnerServer(session, { socketPath });
+    servers.push(server);
+    const remote = await attach(socketPath);
+    expect(remote.runnerProtocolVersion).toBe(5);
+
+    const result = await remote.workflows.resume('run-7', 'ship it');
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe('final');
+    expect(resumed).toEqual({ runId: 'run-7', reply: 'ship it' });
+  });
+
+  it('rejects workflow.resume when the runner workflows view lacks resume (older host)', async () => {
+    const socketPath = tmpSocket();
+    const session = buildSession(new FakeProvider({ script: [textReply('hi')] }));
+    session.workflows = {
+      list: async () => [],
+      setEnabled: async () => undefined,
+      run: async () => ({ ok: true, output: '', steps: [] }),
+    };
+    const server = await startRunnerServer(session, { socketPath });
+    servers.push(server);
+    const remote = await attach(socketPath);
+
+    await expect(remote.workflows.resume('run-7', 'hi')).rejects.toThrow(/resume not supported/);
+  });
 });

--- a/packages/runner/src/protocol-negotiation.test.ts
+++ b/packages/runner/src/protocol-negotiation.test.ts
@@ -117,7 +117,7 @@ describe('tolerant protocol negotiation — server handshake', () => {
   it('the compatibility floor is at or below the current version', () => {
     // Sanity: a current client must always be accepted by a current server.
     expect(MIN_COMPATIBLE_PROTOCOL_VERSION).toBeLessThanOrEqual(RUNNER_PROTOCOL_VERSION);
-    // Every change through v4 has been additive — the floor is still 1.
+    // Every change through v5 has been additive — the floor is still 1.
     expect(MIN_COMPATIBLE_PROTOCOL_VERSION).toBe(1);
   });
 
@@ -213,6 +213,52 @@ describe('tolerant protocol negotiation — client gating', () => {
     await expect(client.workflows.save('name: x')).rejects.toThrow(/update the moxxy CLI/i);
     await expect(client.workflows.getRun('x')).rejects.toThrow(/update the moxxy CLI/i);
     close();
+  });
+
+  it('gates workflow.resume (v5) with an actionable error against a v4 server (capability-detect)', async () => {
+    // A pre-resume (v4) server that handles the builder family but NOT resume —
+    // exactly what a v5 desktop sees attached to a v4 CLI. The client must NOT
+    // hit a raw method-not-found; it gets the "update the CLI" message.
+    const { client, close } = fakeV3Server(4);
+    await client.attach('desktop', 0);
+    expect(client.runnerProtocolVersion).toBe(4);
+    await expect(client.workflows.resume('run-1', 'ship it')).rejects.toThrow(
+      /Resuming a paused workflow.*not supported by this runner.*update the moxxy CLI/i,
+    );
+    close();
+  });
+
+  it('round-trips workflow.resume to a real handler when the server is v5+', async () => {
+    let resumedWith: { runId: string; reply: string } | null = null;
+    const [clientT, serverT] = makePair();
+    const serverPeer = new JsonRpcPeer(serverT);
+    serverPeer.handle(RunnerMethod.Attach, () => ({
+      sessionId: 'fake-v5',
+      protocolVersion: 5,
+      info: {
+        sessionId: 'fake-v5',
+        cwd: process.cwd(),
+        providers: [],
+        tools: [],
+        modes: [],
+        skills: [],
+        commands: [],
+        readyProviders: [],
+        activeProvider: null,
+        activeMode: null,
+      },
+    }));
+    serverPeer.handle(RunnerMethod.WorkflowResume, (raw) => {
+      resumedWith = raw as { runId: string; reply: string };
+      return { ok: true, output: 'done', steps: [{ id: 'ask', status: 'completed' }] };
+    });
+    const client = new RemoteSession(clientT);
+    await client.attach('desktop', 0);
+    const res = await client.workflows.resume('run-42', 'cyberpunk city');
+    expect(res.ok).toBe(true);
+    expect(res.output).toBe('done');
+    expect(resumedWith).toEqual({ runId: 'run-42', reply: 'cyberpunk city' });
+    clientT.close();
   });
 
   it('allows the v4 builder methods when the server is v4+', async () => {

--- a/packages/runner/src/protocol.ts
+++ b/packages/runner/src/protocol.ts
@@ -54,11 +54,20 @@ import type {
  * (Additive — a v3 server simply lacks these three methods; a v4 client gates
  * them on the server's reported version, see {@link AttachResult}.)
  *
- * Every change v1→v4 has been ADDITIVE, so MIN_COMPATIBLE stays at 1: today's
+ * v5: adds `workflow.resume` so a thin client can answer a paused workflow's
+ * `awaitInput` question and drive the run to completion (the human-in-the-loop
+ * resume path). Like the rest of the workflow.* family it degrades cleanly: a
+ * server whose workflows view predates resume throws a clear "not supported"
+ * error, and a v5 client capability-gates the call on the server's reported
+ * version (see {@link AttachResult}) so a v5 desktop attached to a v4 CLI gets
+ * an actionable "update the CLI" message instead of a raw method-not-found.
+ * (Additive — a v4 server simply lacks this one method.)
+ *
+ * Every change v1→v5 has been ADDITIVE, so MIN_COMPATIBLE stays at 1: today's
  * server can serve any client back to v1, and any client v1+ can attach. Bump
  * MIN_COMPATIBLE to N only when landing a breaking change at version N.
  */
-export const RUNNER_PROTOCOL_VERSION = 4;
+export const RUNNER_PROTOCOL_VERSION = 5;
 
 /**
  * Lowest client protocol version this build's CORE session protocol is
@@ -119,6 +128,12 @@ export const RunnerMethod = {
   WorkflowSave: 'workflow.save',
   /** client->server: fetch one saved workflow as canonical YAML (builder). */
   WorkflowGetRun: 'workflow.getRun',
+  /**
+   * client->server: answer a paused workflow's `awaitInput` question and resume
+   * the run (human-in-the-loop). v5 — the client gates this on the server's
+   * reported version so an older runner returns an actionable error.
+   */
+  WorkflowResume: 'workflow.resume',
   /** server->client: ask this client to decide a tool-call permission. */
   PermissionCheck: 'permission.check',
   /** server->client: ask this client to confirm an approval checkpoint. */
@@ -252,6 +267,21 @@ export interface WorkflowGetRunResult {
   readonly path: string;
   readonly yaml: string;
 }
+export interface WorkflowResumeParams {
+  /** The paused run's id (from the `workflow_paused` event / run result). */
+  readonly runId: string;
+  /** The operator's reply, fed into the paused step's child agent. */
+  readonly reply: string;
+}
+export interface WorkflowResumeResult {
+  readonly ok: boolean;
+  readonly output: string;
+  readonly error?: string;
+  readonly steps: ReadonlyArray<{ readonly id: string; readonly status: string; readonly error?: string }>;
+  /** `paused` when the run pauses AGAIN at a later awaitInput step. */
+  readonly status?: 'completed' | 'paused' | 'failed';
+  readonly runId?: string;
+}
 
 export interface PermissionCheckParams {
   readonly turnId: string;
@@ -375,3 +405,9 @@ export const workflowSaveParamsSchema = z.object({
   previousName: z.string().min(1).max(120).optional(),
 });
 export const workflowGetRunParamsSchema = z.object({ name: z.string().min(1).max(120) });
+// Resume params. The reply is bounded so a hostile client can't OOM the runner
+// (it is forwarded verbatim into the paused step's child agent prompt).
+export const workflowResumeParamsSchema = z.object({
+  runId: z.string().min(1).max(120),
+  reply: z.string().min(1).max(100_000),
+});

--- a/packages/runner/src/remote-session.ts
+++ b/packages/runner/src/remote-session.ts
@@ -608,6 +608,17 @@ export class RemoteSession implements ClientSession {
         this.requireServerProtocol(4, 'Loading a workflow into the builder');
         return this.peer.request<WorkflowDetailResult | null>(RunnerMethod.WorkflowGetRun, { name });
       },
+      // Human-in-the-loop resume (protocol v5). Gated on the SERVER's reported
+      // version so a v5 client attached to a v4 runner (a desktop whose JS
+      // hot-update outran its bundled CLI) gets a clear "update the CLI" error
+      // rather than a raw method-not-found.
+      resume: async (runId, reply) => {
+        this.requireServerProtocol(5, 'Resuming a paused workflow');
+        return this.peer.request<WorkflowRunResult>(RunnerMethod.WorkflowResume, {
+          runId,
+          reply,
+        });
+      },
     };
   }
 }
@@ -636,6 +647,9 @@ interface WorkflowRunResult {
   readonly output: string;
   readonly error?: string;
   readonly steps: ReadonlyArray<{ readonly id: string; readonly status: string; readonly error?: string }>;
+  /** `paused` when the run parked on an awaitInput step (resume via `runId`). */
+  readonly status?: 'completed' | 'paused' | 'failed';
+  readonly runId?: string;
 }
 interface WorkflowValidateResult {
   readonly ok: boolean;
@@ -659,6 +673,7 @@ interface WorkflowsClientView {
   validateDraft(yaml: string): Promise<WorkflowValidateResult>;
   save(yaml: string, previousName?: string): Promise<WorkflowSaveResult>;
   getRun(name: string): Promise<WorkflowDetailResult | null>;
+  resume(runId: string, reply: string): Promise<WorkflowRunResult>;
 }
 
 // --- snapshot -> display-object reconstruction --------------------------------

--- a/packages/runner/src/server.ts
+++ b/packages/runner/src/server.ts
@@ -39,6 +39,7 @@ import {
   workflowValidateDraftParamsSchema,
   workflowSaveParamsSchema,
   workflowGetRunParamsSchema,
+  workflowResumeParamsSchema,
   type AttachResult,
   type CommandRunResult,
   type RunTurnResult,
@@ -176,6 +177,7 @@ export class RunnerServer {
     );
     peer.handle(RunnerMethod.WorkflowSave, (raw) => this.handleWorkflowSave(raw));
     peer.handle(RunnerMethod.WorkflowGetRun, (raw) => this.handleWorkflowGetRun(raw));
+    peer.handle(RunnerMethod.WorkflowResume, (raw) => this.handleWorkflowResume(raw));
 
     peer.onClose(() => this.onDisconnect(client));
   }
@@ -500,6 +502,16 @@ export class RunnerServer {
     const view = this.session.workflows;
     if (!view?.getRun) throw new Error('workflows builder not supported on this runner');
     return (await view.getRun(params.name)) ?? null;
+  }
+
+  // --- Workflows human-in-the-loop (resume a paused awaitInput run) ---------
+  // v5. Optional on the view (older hosts lack it), so feature-check and throw a
+  // clear error rather than calling undefined.
+  private async handleWorkflowResume(raw: unknown): Promise<unknown> {
+    const params = workflowResumeParamsSchema.parse(raw);
+    const view = this.session.workflows;
+    if (!view?.resume) throw new Error('workflow resume not supported on this runner');
+    return view.resume(params.runId, params.reply);
   }
 
   private broadcastInfo(): void {

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -163,6 +163,15 @@ export interface WorkflowRunView {
   readonly output: string;
   readonly error?: string;
   readonly steps: ReadonlyArray<{ readonly id: string; readonly status: string; readonly error?: string }>;
+  /**
+   * Terminal status of the run. `paused` means it parked on an `awaitInput`
+   * step and is awaiting the operator's reply (resume via {@link WorkflowsView.resume}
+   * with `runId`). Optional for back-compat — absent from older hosts that
+   * never paused. A run/resume that completes or fails reports those.
+   */
+  readonly status?: 'completed' | 'paused' | 'failed';
+  /** Set when `status` is `paused` — pass to {@link WorkflowsView.resume}. */
+  readonly runId?: string;
 }
 
 /** Validation result for a draft YAML — backs the visual builder (phase 2). */
@@ -204,6 +213,15 @@ export interface WorkflowsView {
   save?(yaml: string, previousName?: string): Promise<WorkflowSaveView>;
   /** Fetch one saved workflow's canonical YAML + on-disk metadata. */
   getRun?(name: string): Promise<{ readonly name: string; readonly scope: string; readonly path: string; readonly yaml: string } | null>;
+  /**
+   * Answer a paused workflow's `awaitInput` question and resume the run (the
+   * human-in-the-loop flow). `runId` comes from the `workflow_paused` event;
+   * `reply` is the operator's answer, fed into the paused step's child agent.
+   * Resolves with the (now usually completed) run result. Optional so older
+   * hosts / remote sessions stay capability-detectable — a channel must
+   * feature-check before calling.
+   */
+  resume?(runId: string, reply: string): Promise<WorkflowRunView>;
 }
 
 /** One installable plugin in {@link PluginsAdminView.catalog}. */


### PR DESCRIPTION
## What

A workflow step can set \`awaitInput: true\` to pause and ask the operator a question, then continue with their reply. #146 gated this at validate/save time because the resume path hadn't shipped to main. This PR ships the resume path and removes the gate.

## The loop works (proven)

End-to-end executor test (`plugin-workflows/src/executor/dag.test.ts`): a **schema-validated** workflow authored with `awaitInput: true` PAUSES (checkpoint written, `workflow_paused` emitted with the prompt + runId), then `resumeWorkflowRun(runId, "ship it")` CONTINUES it — the downstream tool runs with the reply (`FINAL_*`) and a `vars.channel` set BEFORE the pause, and the run reaches **completed** (not paused/hung). The checkpoint is cleaned up.

## Un-gate

`awaitInput: true` accepted again on **prompt/skill steps only** (rejected on tool/workflow/logic/loop steps and on a loop body — no interactive child / no mid-iteration checkpoint there). `draft.ts` teaches the pause flow again with a worked example.

## Resume RPC — additive, protocol v5

`RUNNER_PROTOCOL_VERSION` 4 → **5** (`MIN_COMPATIBLE` unchanged at 1). New `RunnerMethod.WorkflowResume` (`workflow.resume`) + params/result + zod schema; server handler → `session.workflows.resume(runId, reply)`; `WorkflowsView.resume` (SDK) + CLI impl (`resumeNow` → existing `resumeWorkflowRun`); `RemoteSession` client method gated on server proto `>= 5` with the actionable **"update the moxxy CLI"** error (mirrors the v4 builder gate). Desktop lockstep + client capability-detection (from #148) handle skew automatically.

## Remote allow-list decision

`workflows.resume` is **ALLOWED for remote** (`REMOTE_ALLOWED_COMMANDS`): it is RESPOND-only — the operator answers a question the WORKFLOW asked (the reply is fed into the paused step and the run continues), exactly like `ask.respond`. It cannot author or rewrite a workflow. A mobile user answering "ship it" to their own pipeline is the canonical human-in-the-loop case.

## Reply UI

- **Desktop:** paused-workflow card in the workflows panel (new shared client-core `usePausedWorkflows` hook) — "Workflow <name> is waiting: <prompt>" + a reply box that dispatches `workflows.resume(runId, reply)`. The card clears on `workflow_resumed`/`workflow_completed`.
- **TUI:** the `/workflows` panel switches to inline reply capture when a run returns `status: 'paused'`; type the reply, Enter resumes (Esc cancels, leaving the run parked).
- **Mobile:** bridge-wired (host handler + allow-list + contract, Expo-iOS-bundled) — reachable but no paused card yet (logged in TECH_DEBT).

The `workflow_paused` event now carries the workflow name + step label + question so the operator UI is self-contained.

## vars survival / runNow

Vars set before a pause survive the checkpoint round-trip (`run-store.ts` persist + `dag.ts` restore) so downstream `{{ vars.* }}` render after resume. `runNow` keeps a `paused` result NON-terminal (no inbox delivery); the resume side delivers the now-completed run to the inbox. The stale-checkpoint sweeper + `clearRetainedChildren()`-on-shutdown from #146 are kept.

## Tests

- **executor:** pause → reply → resume → complete with reply + vars available (schema-validated).
- **runner:** `workflow.resume` round-trips to a real handler; a v4 (pre-resume) server returns the actionable not-supported error to a v5 client (capability-detect); server-side handler routes to the workflows view.
- **runNow:** a paused result is not inbox-delivered as complete; a resumed run that completes is delivered.
- **UI:** desktop paused-workflow reply dispatches `workflows.resume` (testing-library) + clears on resume event; client-core `usePausedWorkflows` unit tests.
- **schema:** `awaitInput` ACCEPTED on prompt/skill, rejected on tool/bridge/loop/loop-body.
- **ws allow-list:** `workflows.resume` allowed over the WS bridge.

## Gate

`pnpm build` / `pnpm -w typecheck` / `pnpm -w test` (2293 passed) / `pnpm -w lint` / `pnpm check:deps` — all exit 0; `pnpm --filter @moxxy/desktop typecheck` clean; offline Expo iOS export of `apps/mobile` bundles clean (1572 modules). Changeset added.