### PR TITLE
fix(hooks): guard hook commands against a missing script (no-op instead of error)

### DIFF
--- a/.changeset/resilient-hooks.md
+++ b/.changeset/resilient-hooks.md
@@ -1,0 +1,4 @@
+---
+---
+
+Make the Claude Code Stop/PostToolUse hook commands existence-guarded so they no-op (exit 0) when the hook script isn't present in the current branch/worktree — instead of erroring with "No such file or directory". Docs/tooling only; no release.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/gate-on-stop.sh",
+            "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/gate-on-stop.sh\"; [ -x \"$f\" ] && exec \"$f\"; exit 0'",
             "timeout": 180
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/changeset-reminder.sh",
+            "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/changeset-reminder.sh\"; [ -x \"$f\" ] && exec \"$f\"; exit 0'",
             "timeout": 15
           }
         ]


### PR DESCRIPTION
**Reported:** `Stop hook error: ... /Users/maqsiak/personal/blocky/.claude/hooks/gate-on-stop.sh: No such file or directory`.

**Cause:** the committed `.claude/settings.json` Stop/PostToolUse hooks invoked `$CLAUDE_PROJECT_DIR/.claude/hooks/<script>.sh` directly. When the project dir is a checkout/worktree on a branch cut **before** the hooks landed (#138), the script isn't there and the hook errors on every Stop.

**Fix:** wrap each hook command so it runs the script only when present + executable, else exits 0 silently:
```sh
sh -c 'f="$CLAUDE_PROJECT_DIR/.claude/hooks/gate-on-stop.sh"; [ -x "$f" ] && exec "$f"; exit 0'
```
Hooks must tolerate not being present on every branch — a missing script is now a clean no-op, not an error. Verified: with the script absent the guarded command exits 0. (The script itself already no-ops in the main checkout by design; this guards the harder case of a branch lacking the file entirely.)

Empty changeset (tooling only).