### PR TITLE
fix(desktop): FLOOR_RUNNER_PROTOCOL=5 lockstep (unblock desktop release) + CI guard

### DIFF
--- a/.changeset/floor-runner-protocol-5.md
+++ b/.changeset/floor-runner-protocol-5.md
@@ -1,0 +1,5 @@
+---
+"@moxxy/desktop": patch
+---
+
+Fix the desktop release build: bump `FLOOR_RUNNER_PROTOCOL` to 5 to match `RUNNER_PROTOCOL_VERSION` (the workflow.resume bump in #151 raised the runner protocol to 5 but left the desktop floor at 4, so the release-time lockstep assertion in `build-app-bundle.mjs` failed and the desktop release was skipped). Adds a unit test asserting `FLOOR_RUNNER_PROTOCOL === RUNNER_PROTOCOL_VERSION` so a forgotten floor bump fails normal CI instead of only the release.

--- a/apps/desktop/electron/main/floor-runner-protocol.test.ts
+++ b/apps/desktop/electron/main/floor-runner-protocol.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { RUNNER_PROTOCOL_VERSION } from '@moxxy/runner';
+import { FLOOR_RUNNER_PROTOCOL } from './floor-runner-protocol';
+
+// Lockstep guard (catches in normal CI what build-app-bundle.mjs's assertion
+// otherwise only catches at release time): the desktop's baked floor protocol
+// MUST equal the runner's current protocol. When you bump
+// RUNNER_PROTOCOL_VERSION, bump FLOOR_RUNNER_PROTOCOL in the same change — this
+// test fails otherwise (as the desktop release build did when v5 shipped with
+// the floor left at 4).
+describe('FLOOR_RUNNER_PROTOCOL', () => {
+  it('equals @moxxy/runner RUNNER_PROTOCOL_VERSION', () => {
+    expect(FLOOR_RUNNER_PROTOCOL).toBe(RUNNER_PROTOCOL_VERSION);
+  });
+});

--- a/apps/desktop/electron/main/floor-runner-protocol.ts
+++ b/apps/desktop/electron/main/floor-runner-protocol.ts
@@ -16,4 +16,4 @@
  * the release build asserts the two match (see scripts/build-app-bundle.mjs),
  * so a forgotten bump fails the build rather than shipping a wrong floor.
  */
-export const FLOOR_RUNNER_PROTOCOL = 4;
+export const FLOOR_RUNNER_PROTOCOL = 5;


### PR DESCRIPTION
## Why
The publish-mode release run published npm (`@moxxy/sdk 0.10.0`, `@moxxy/cli 0.8.0` — live) but the **Linux desktop-build failed** at the 'Build + sign app update bundle' step, so the desktop release was **skipped** (the A22 tag-after-build guard working as intended — no partial/​burned tag).

Root cause: #151 bumped `RUNNER_PROTOCOL_VERSION` 4→5 (for `workflow.resume`) but left `FLOOR_RUNNER_PROTOCOL` at 4. `scripts/build-app-bundle.mjs` (from #148) asserts the desktop floor protocol equals the runner protocol and threw — that assertion only runs in the release-only bundle step, so normal CI didn't catch it.

## Fix
- `apps/desktop/electron/main/floor-runner-protocol.ts`: `FLOOR_RUNNER_PROTOCOL = 5`.
- New `electron/main/floor-runner-protocol.test.ts`: asserts `FLOOR_RUNNER_PROTOCOL === RUNNER_PROTOCOL_VERSION` — so a forgotten floor bump fails **normal CI on every PR**, not just the release job.

## Verify
Desktop tests 55/55 (incl. the new guard); full build green; the bundle-build assertion no longer trips. Patch changeset for `@moxxy/desktop` → re-cuts the desktop release (0.2.1) on the next publish run.