### PR TITLE
feat(desktop): self-heal the protocol-incompatible screen with an in-app 'Update CLI & reconnect'

### DIFF
--- a/.changeset/protocol-screen-update-cli.md
+++ b/.changeset/protocol-screen-update-cli.md
@@ -1,0 +1,5 @@
+---
+"@moxxy/desktop": patch
+---
+
+Self-heal the terminal "Update needed to continue" (protocol-incompatible) connection screen: when the spawned runner CLI is older than the app, the screen now offers a primary "Update CLI & reconnect" button that updates the bundled CLI in place (via `app.updateCli`) and re-runs the supervisor connect so the now-newer runner attaches cleanly — no hand-running npm. It shows an in-progress state while updating, surfaces failures with the exact manual `npm install --prefix "<userData>/cli" @moxxy/cli@latest` fallback, and when the app is the older side (a CLI update can't help) shows reinstall-the-app guidance instead of an update button.

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -9,7 +9,7 @@ import {
   chatStore,
   usePrefs,
 } from '@moxxy/client-core';
-import { ConnectionScreen } from './connection/ConnectionScreen';
+import { ConnectionScreen, type UpdateCliResult } from './connection/ConnectionScreen';
 import { Onboarding } from './onboarding/Onboarding';
 import { ChatSurface } from './chat/ChatSurface';
 import { WorkspaceSidebar, type View } from './shell/WorkspaceSidebar';
@@ -18,7 +18,7 @@ import { WorkflowsPanel } from './workflows/WorkflowsPanel';
 import { SettingsPanel } from './settings/SettingsPanel';
 import { UpdateBanner } from './shell/UpdateBanner';
 import { Splash } from './Splash';
-import { api } from '@moxxy/client-core';
+import { api, toErrorMessage } from '@moxxy/client-core';
 
 /**
  * Top-level shell. Three layers of gating, in order:
@@ -147,11 +147,32 @@ export function App(): JSX.Element {
   }
 
   if (!isConnected(phase) && !hasEverConnected) {
+    // Terminal protocol-incompatible self-heal: update the bundled CLI in
+    // place (host `app.updateCli`), then re-run the supervisor connect — which
+    // respawns the runner from the now-newer CLI, so the client attaches
+    // cleanly. App.tsx owns the IPC call + the retry; ConnectionScreen stays
+    // presentational. Failures surface in the screen's error + manual hint.
+    const onUpdateCli = async (): Promise<UpdateCliResult> => {
+      try {
+        const { code } = await api().invoke('app.updateCli');
+        if (code !== 0) {
+          return { ok: false, error: `Updating the moxxy CLI failed (npm exited with code ${code}).` };
+        }
+        void retry();
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: toErrorMessage(e) };
+      }
+    };
     return (
       <>
         <ConnectionBridge />
         <ChatStoreBridge />
-        <ConnectionScreen snapshot={snapshot} onRetry={() => void retry()} />
+        <ConnectionScreen
+          snapshot={snapshot}
+          onRetry={() => void retry()}
+          onUpdateCli={onUpdateCli}
+        />
       </>
     );
   }

--- a/apps/desktop/src/connection/ConnectionScreen.test.tsx
+++ b/apps/desktop/src/connection/ConnectionScreen.test.tsx
@@ -1,20 +1,33 @@
 /**
  * The connection surface — focused on the TERMINAL protocol-incompatibility
  * phase (Part C of the runner-protocol-skew fix): it must render an actionable
- * "update the CLI" message and NOT offer a retry that would loop straight back
- * into the same dead end. Contrast with `reconnecting`, which keeps the retry.
+ * way to update the CLI and reconnect (the in-app self-heal) and NOT offer a
+ * bare retry that would loop straight back into the same dead end. Contrast
+ * with `reconnecting`, which keeps the retry.
  */
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { ConnectionSnapshot } from '@moxxy/desktop-ipc-contract';
-import { ConnectionScreen } from './ConnectionScreen';
+import { ConnectionScreen, manualUpdateCommand } from './ConnectionScreen';
 
-function snapshotWith(phase: ConnectionSnapshot['phase']): ConnectionSnapshot {
-  return { phase, cliPath: null, attempts: 1, log: [] };
+function snapshotWith(
+  phase: ConnectionSnapshot['phase'],
+  cliPath: string | null = null,
+): ConnectionSnapshot {
+  return { phase, cliPath, attempts: 1, log: [] };
 }
 
+const SERVER_OLDER = {
+  phase: 'protocol-incompatible' as const,
+  serverVersion: 4,
+  clientVersion: 5,
+  detail: 'runner protocol mismatch: server v4, client v5',
+  hint: 'This app version needs a newer moxxy CLI. Update the CLI (or reinstall the app) to continue.',
+};
+
 describe('ConnectionScreen — protocol-incompatible (terminal)', () => {
-  it('renders the actionable hint and hides the retry button', () => {
+  it('renders the actionable hint and hides the bare retry button', () => {
     const onRetry = vi.fn();
     render(
       <ConnectionScreen
@@ -35,6 +48,119 @@ describe('ConnectionScreen — protocol-incompatible (terminal)', () => {
     // No "Try again" — auto-retry into the same pinned CLI is a dead end.
     expect(screen.queryByRole('button', { name: /try again/i })).toBeNull();
   });
+
+  it('offers "Update CLI & reconnect" when the runner is OLDER than the app', () => {
+    render(
+      <ConnectionScreen
+        snapshot={snapshotWith(SERVER_OLDER)}
+        onRetry={vi.fn()}
+        onUpdateCli={vi.fn().mockResolvedValue({ ok: true })}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: /update cli & reconnect/i }),
+    ).toBeTruthy();
+  });
+
+  it('on click calls onUpdateCli and, on resolve, calls onRetry (via the handler)', async () => {
+    const onRetry = vi.fn();
+    // Mirror App.tsx: onUpdateCli triggers retry() before resolving { ok }.
+    const onUpdateCli = vi.fn().mockImplementation(async () => {
+      onRetry();
+      return { ok: true };
+    });
+    const user = userEvent.setup();
+    render(
+      <ConnectionScreen
+        snapshot={snapshotWith(SERVER_OLDER)}
+        onRetry={onRetry}
+        onUpdateCli={onUpdateCli}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /update cli & reconnect/i }));
+
+    expect(onUpdateCli).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onRetry).toHaveBeenCalledTimes(1));
+  });
+
+  it('shows an in-progress state while the update runs', async () => {
+    let resolve!: (r: { ok: boolean }) => void;
+    const onUpdateCli = vi.fn().mockReturnValue(
+      new Promise<{ ok: boolean }>((r) => {
+        resolve = r;
+      }),
+    );
+    const user = userEvent.setup();
+    render(
+      <ConnectionScreen
+        snapshot={snapshotWith(SERVER_OLDER)}
+        onRetry={vi.fn()}
+        onUpdateCli={onUpdateCli}
+      />,
+    );
+
+    const btn = screen.getByRole('button', { name: /update cli & reconnect/i });
+    await user.click(btn);
+
+    // In-progress: button shows the updating label, is disabled + aria-busy.
+    const busy = await screen.findByRole('button', { name: /updating the moxxy cli/i });
+    expect(busy).toBeDisabled();
+    expect(busy.getAttribute('aria-busy')).toBe('true');
+
+    resolve({ ok: true });
+  });
+
+  it('shows the error + the manual command when the update fails', async () => {
+    const onUpdateCli = vi
+      .fn()
+      .mockResolvedValue({ ok: false, error: 'npm not found on PATH' });
+    const user = userEvent.setup();
+    render(
+      <ConnectionScreen
+        snapshot={snapshotWith(
+          SERVER_OLDER,
+          '/Users/x/Library/Application Support/MoxxyAI Workspaces/cli/node_modules/@moxxy/cli/dist/bin.js',
+        )}
+        onRetry={vi.fn()}
+        onUpdateCli={onUpdateCli}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /update cli & reconnect/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/npm not found on PATH/i);
+    // Manual escape hatch: the exact prefix-scoped install command.
+    expect(
+      screen.getAllByText(
+        /npm install --prefix .*MoxxyAI Workspaces\/cli.* @moxxy\/cli@latest/i,
+      ).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('shows reinstall guidance and NO update button when the APP is older than the runner', () => {
+    render(
+      <ConnectionScreen
+        snapshot={snapshotWith({
+          phase: 'protocol-incompatible',
+          serverVersion: 6, // runner is NEWER
+          clientVersion: 5, // app is OLDER
+          detail: 'runner protocol mismatch: server v6, client v5',
+          hint: 'This app is out of date. Reinstall the latest moxxy desktop app to continue.',
+        })}
+        onRetry={vi.fn()}
+        onUpdateCli={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole('button', { name: /update cli & reconnect/i }),
+    ).toBeNull();
+    // The note tells the user to reinstall the app (the hint also says so).
+    expect(screen.getAllByText(/reinstall the latest moxxy desktop app/i).length).toBeGreaterThan(0);
+    // And it must NOT claim updating the CLI would help.
+    expect(screen.getByText(/updating the cli/i)).toBeTruthy();
+  });
 });
 
 describe('ConnectionScreen — reconnecting (recoverable) keeps retrying', () => {
@@ -46,5 +172,31 @@ describe('ConnectionScreen — reconnecting (recoverable) keeps retrying', () =>
       />,
     );
     expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy();
+  });
+});
+
+describe('manualUpdateCommand', () => {
+  it('derives the <userData>/cli prefix from the resolved CLI path', () => {
+    const cmd = manualUpdateCommand(
+      '/Users/x/Library/Application Support/MoxxyAI Workspaces/cli/node_modules/@moxxy/cli/dist/bin.js',
+    );
+    expect(cmd).toBe(
+      'npm install --prefix "/Users/x/Library/Application Support/MoxxyAI Workspaces/cli" @moxxy/cli@latest',
+    );
+  });
+
+  it('falls back to a placeholder prefix when the path is unknown', () => {
+    expect(manualUpdateCommand(null)).toBe(
+      'npm install --prefix "<userData>/cli" @moxxy/cli@latest',
+    );
+  });
+
+  it('handles Windows-style separators', () => {
+    const cmd = manualUpdateCommand(
+      'C:\\Users\\x\\AppData\\Roaming\\MoxxyAI Workspaces\\cli\\node_modules\\@moxxy\\cli\\dist\\bin.js',
+    );
+    expect(cmd).toBe(
+      'npm install --prefix "C:\\Users\\x\\AppData\\Roaming\\MoxxyAI Workspaces\\cli" @moxxy/cli@latest',
+    );
   });
 });

--- a/apps/desktop/src/connection/ConnectionScreen.tsx
+++ b/apps/desktop/src/connection/ConnectionScreen.tsx
@@ -1,10 +1,27 @@
+import { useState } from 'react';
 import type { ConnectionPhase, ConnectionSnapshot } from '@moxxy/desktop-ipc-contract';
 import { asset } from '@/lib/asset';
 import { Splash } from '@/Splash';
 
+/** Result of an in-app CLI update attempt. On success the caller (App.tsx)
+ *  has already kicked the supervisor retry; on failure we surface `error`
+ *  and fall back to the manual escape hatch. */
+export interface UpdateCliResult {
+  readonly ok: boolean;
+  readonly error?: string;
+}
+
 interface ConnectionScreenProps {
   readonly snapshot: ConnectionSnapshot | null;
   readonly onRetry: () => void;
+  /**
+   * Updates the bundled CLI in place (host `app.updateCli`) and, on success,
+   * triggers the same supervisor retry `onRetry` does. Only invoked from the
+   * terminal `protocol-incompatible` screen when the runner is OLDER than the
+   * app — the one direction a CLI update can fix. Optional so existing call
+   * sites (and the non-terminal phases) keep working unchanged.
+   */
+  readonly onUpdateCli?: () => Promise<UpdateCliResult>;
 }
 
 /**
@@ -22,6 +39,7 @@ interface ConnectionScreenProps {
 export function ConnectionScreen({
   snapshot,
   onRetry,
+  onUpdateCli,
 }: ConnectionScreenProps): JSX.Element {
   const phase: ConnectionPhase = snapshot?.phase ?? { phase: 'idle' };
   const problem =
@@ -29,9 +47,10 @@ export function ConnectionScreen({
     phase.phase === 'cli-missing' ||
     phase.phase === 'reconnecting' ||
     phase.phase === 'protocol-incompatible';
-  // A protocol incompatibility is TERMINAL — respawning hits the same pinned
-  // CLI, so "Try again" would loop straight back into the dead end. Hide the
-  // retry and tell the user what action actually unblocks them.
+  // A protocol incompatibility is TERMINAL — a bare respawn hits the same
+  // pinned CLI, so a plain "Try again" would loop straight back into the dead
+  // end. Instead of a retry, the terminal screen offers an in-app self-heal
+  // (update the CLI, then retry) when the runner is the OLDER side.
   const terminal = phase.phase === 'protocol-incompatible';
 
   // Happy path: a continuous branded loading screen.
@@ -85,30 +104,200 @@ export function ConnectionScreen({
           </p>
         </div>
 
-        {!terminal && (
-          <button
-            type="button"
-            onClick={onRetry}
-            style={{
-              padding: '9px 20px',
-              background: 'var(--grad-cta)',
-              color: '#fff',
-              border: 'none',
-              borderRadius: 10,
-              fontWeight: 600,
-              fontSize: 13.5,
-              cursor: 'pointer',
-              boxShadow: '0 10px 20px -12px rgba(236, 72, 153, 0.55)',
-            }}
-          >
-            Try again
-          </button>
+        {phase.phase === 'protocol-incompatible' ? (
+          <ProtocolIncompatibleActions
+            phase={phase}
+            snapshot={snapshot}
+            onUpdateCli={onUpdateCli}
+          />
+        ) : (
+          !terminal && (
+            <button
+              type="button"
+              onClick={onRetry}
+              style={primaryButtonStyle(false)}
+            >
+              Try again
+            </button>
+          )
         )}
 
         <TechnicalDetails snapshot={snapshot} phase={phase} />
       </div>
     </main>
   );
+}
+
+/**
+ * Action area for the terminal protocol-incompatible screen.
+ *
+ * The runner SERVER speaks `serverVersion`; this app's CLIENT speaks
+ * `clientVersion`. Two directions:
+ *
+ *   - server < client (the common case after a desktop hot-update): the
+ *     installed CLI is too OLD. Updating the CLI in place fixes it, so we
+ *     offer the primary "Update CLI & reconnect" button. On click we run
+ *     `onUpdateCli` (host `app.updateCli`), show progress, and on success
+ *     the supervisor respawns the now-newer runner.
+ *   - client < server (the app is the older side): updating the CLI can't
+ *     help — the user needs a newer APP. Show reinstall guidance, no button.
+ *
+ * When versions are unknown (null) we can't prove the updatable direction,
+ * so we still offer the update button (it's the most likely fix) but lean on
+ * the manual escape hatch in the details.
+ */
+function ProtocolIncompatibleActions({
+  phase,
+  snapshot,
+  onUpdateCli,
+}: {
+  readonly phase: Extract<ConnectionPhase, { phase: 'protocol-incompatible' }>;
+  readonly snapshot: ConnectionSnapshot | null;
+  readonly onUpdateCli?: () => Promise<UpdateCliResult>;
+}): JSX.Element {
+  const [status, setStatus] = useState<'idle' | 'updating' | 'error'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const { serverVersion, clientVersion } = phase;
+  // The app is strictly newer than the runner → the CLI is the stale side and
+  // an in-place update is the fix. When either version is unknown we treat the
+  // update as offerable (it's the common, fixable direction).
+  const appNewerThanRunner =
+    serverVersion === null || clientVersion === null
+      ? true
+      : serverVersion < clientVersion;
+  const canUpdate = appNewerThanRunner && !!onUpdateCli;
+
+  const runUpdate = async (): Promise<void> => {
+    if (!onUpdateCli) return;
+    setStatus('updating');
+    setError(null);
+    const result = await onUpdateCli();
+    if (result.ok) {
+      // App.tsx has already kicked the supervisor retry; this screen will be
+      // torn down as the connection phase advances. Keep the spinner up.
+      return;
+    }
+    setError(result.error ?? 'The update failed. Try the manual command below.');
+    setStatus('error');
+  };
+
+  const manualCommand = manualUpdateCommand(snapshot?.cliPath ?? null);
+
+  if (!canUpdate) {
+    // client < server (or no updater wired): updating the CLI won't help.
+    return (
+      <div
+        role="note"
+        style={{
+          fontSize: 12.5,
+          color: 'var(--color-text-muted)',
+          lineHeight: 1.6,
+          maxWidth: 420,
+        }}
+      >
+        This app is older than the moxxy runner it found, so updating the CLI
+        won&rsquo;t help. Reinstall the latest moxxy desktop app to continue.
+      </div>
+    );
+  }
+
+  const updating = status === 'updating';
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 10,
+        width: '100%',
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => void runUpdate()}
+        disabled={updating}
+        aria-busy={updating}
+        style={primaryButtonStyle(updating)}
+      >
+        {updating ? 'Updating the moxxy CLI…' : 'Update CLI & reconnect'}
+      </button>
+
+      {status === 'error' && error && (
+        <div
+          role="alert"
+          style={{
+            fontSize: 12.5,
+            color: 'var(--color-red)',
+            lineHeight: 1.6,
+            maxWidth: 420,
+            textAlign: 'center',
+          }}
+        >
+          <p style={{ margin: 0 }}>{error}</p>
+          <p style={{ margin: '6px 0 0', color: 'var(--color-text-muted)' }}>
+            You can update it by hand instead, or reinstall the app:
+          </p>
+          <code
+            className="mono"
+            style={{
+              display: 'block',
+              margin: '6px 0 0',
+              padding: '6px 8px',
+              background: 'var(--color-card-bg)',
+              border: '1px solid var(--color-card-border)',
+              borderRadius: 8,
+              fontSize: 11.5,
+              color: 'var(--color-text)',
+              wordBreak: 'break-all',
+              textAlign: 'left',
+            }}
+          >
+            {manualCommand}
+          </code>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The exact shell command a user can run to update the CLI by hand if the
+ * in-app button fails. Mirrors {@link updateCli}'s real invocation:
+ *   npm install --prefix "<userData>/cli" @moxxy/cli@latest
+ *
+ * `<userData>/cli` is derived from the resolved CLI path the snapshot carries
+ * (`<userData>/cli/node_modules/@moxxy/cli/dist/bin.js`) by stripping the
+ * trailing `node_modules/@moxxy/cli/dist/bin.js`. Falls back to a generic
+ * placeholder when the path is unknown or doesn't match the expected layout.
+ */
+export function manualUpdateCommand(cliPath: string | null): string {
+  const prefix = cliPrefixFromPath(cliPath) ?? '<userData>/cli';
+  return `npm install --prefix "${prefix}" @moxxy/cli@latest`;
+}
+
+function cliPrefixFromPath(cliPath: string | null): string | null {
+  if (!cliPath) return null;
+  // Handle both POSIX and Windows separators; the prefix is the dir that
+  // CONTAINS node_modules/@moxxy/cli/….
+  const marker = /[/\\]node_modules[/\\]@moxxy[/\\]cli[/\\]/;
+  const m = marker.exec(cliPath);
+  if (!m) return null;
+  return cliPath.slice(0, m.index);
+}
+
+function primaryButtonStyle(disabled: boolean): React.CSSProperties {
+  return {
+    padding: '9px 20px',
+    background: disabled ? 'var(--color-card-border-strong)' : 'var(--grad-cta)',
+    color: '#fff',
+    border: 'none',
+    borderRadius: 10,
+    fontWeight: 600,
+    fontSize: 13.5,
+    cursor: disabled ? 'default' : 'pointer',
+    boxShadow: disabled ? 'none' : '0 10px 20px -12px rgba(236, 72, 153, 0.55)',
+  };
 }
 
 /** Friendly, non-technical headline per phase. */
@@ -214,6 +403,9 @@ function TechnicalDetails({
             />
             <DetailRow label="detail" value={phase.detail} />
             <DetailRow label="hint" value={phase.hint} />
+            {/* The manual escape hatch — exact command to update the CLI by
+                hand if the in-app button fails (or "reinstall the app"). */}
+            <DetailRow label="manual" value={manualUpdateCommand(snapshot?.cliPath ?? null)} />
           </>
         )}
         {hasLog && snapshot && (


### PR DESCRIPTION
## Problem

A real user got stuck: after a desktop hot-update, the app's runner CLIENT became newer (v5) than the spawned runner SERVER (their installed CLI, v4). #148 added a terminal `protocol-incompatible` ConnectionScreen that correctly STOPS the infinite reconnect loop and shows "Update needed to continue". But that screen offered no in-app way to actually update the CLI — the user had to run npm by hand.

## Fix

The terminal `protocol-incompatible` screen now self-heals.

- **`ConnectionScreen.tsx`** (kept presentational): for `protocol-incompatible` it renders a primary **"Update CLI & reconnect"** button (plus the existing technical-details disclosure + diagnostic rows). On click it runs the new `onUpdateCli` prop, shows an in-progress state ("Updating the moxxy CLI…", button disabled + `aria-busy`), and on failure surfaces the error + the exact manual command + reinstall fallback.
- **`App.tsx`** owns the IPC + retry: the `onUpdateCli` handler calls `api().invoke('app.updateCli')` (the existing host-side updater that installs `@moxxy/cli@latest` into the writable `<userData>/cli`, re-points `MOXXY_CLI_ENTRY`, and restarts every runner). On success (`code === 0`) it kicks the same `retry()` the screen already wires, so the supervisor respawns the now-newer runner and the v5 client attaches cleanly. `onRetry` is unchanged for the non-terminal problem phases.

### server < client vs client < server

- **server < client** (the runner is OLDER — the common case after a hot-update): show the "Update CLI & reconnect" button (the fixable direction). When either version is `null` we still offer the button (the most likely fix), leaning on the manual escape hatch.
- **client < server** (the app is OLDER): a CLI update can't help — show reinstall-the-app guidance, no update button.

### Manual escape hatch

Mirrors the real `updateCli` invocation, derived from the resolved `cliPath` (`<userData>/cli/node_modules/@moxxy/cli/dist/bin.js` → strip the trailing `node_modules/@moxxy/cli/...`):

```
npm install --prefix "<userData>/cli" @moxxy/cli@latest
```

Shown in the technical-details `manual` row always, and again in the error block when the in-app update fails. Falls back to a `<userData>/cli` placeholder when the path is unknown; handles Windows separators.

## Tests

`apps/desktop` testing-library, #148 style — ConnectionScreen now 10 tests (was 2; both originals kept green):
- server<client renders "Update CLI & reconnect"; clicking calls `onUpdateCli` and (via the handler) `onRetry`
- in-progress state (disabled + `aria-busy`)
- failure shows error + the exact `--prefix` manual command
- client<server shows reinstall guidance, no update button
- `manualUpdateCommand` derivation: POSIX, null fallback, Windows separators

## Gate

`pnpm build`, `pnpm -w typecheck`, `pnpm -w test`, `pnpm -w lint` (0 errors), `pnpm check:deps`, and `pnpm --filter @moxxy/desktop typecheck` all exit 0. Changeset added (`@moxxy/desktop` patch). The IPC wiring typechecks against the real `app.updateCli` contract; full CLI-update e2e isn't runnable headlessly.