### PR TITLE
feat(desktop): workflow builder skill/tool pickers + fix macOS Dock ghost runner

### DIFF
--- a/.changeset/workflow-pickers-and-dock-ghost.md
+++ b/.changeset/workflow-pickers-and-dock-ghost.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/desktop': minor
+---
+
+Workflow builder: the skill and tool name fields are now dropdowns of what the session actually has registered (with an explicit "(not installed)" marker for saved names that no longer exist, an empty-state message when there are no skills/tools, and a free-text fallback while no session is attached). Also fixes the macOS Dock "exec" ghost: the runner and other run-as-node children are spawned via the app's LSUIElement Helper binary, so they no longer register a second Dock icon.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -723,6 +723,34 @@ graph) is intact; the two operate on different graphs and don't conflict.
   scheduled, that exclusion must be revisited. (b) awaitInput is barred inside a loop body
   (would need mid-iteration checkpointing) — orthogonal to the now-shipped resume path; lift
   only if a use-case appears.
+- **Builder UX pass (2026-06-10):** the inspector's skill/tool name fields are now pickers
+  fed by a live `session.info` registry snapshot (new client-core `useActionCatalog`,
+  refresh on `SESSION_INFO_REFRESH_EVENT`): dropdown of what's actually registered, explicit
+  "(not installed)" option preserving a saved-but-removed name, an explicit empty-state
+  message when the session has no skills/tools, and a free-text fallback when no session is
+  attached. The NodeCard shorthand/per-side border-color React warning is gone (per-side
+  colors via `edgeColor()`). **Remaining:** (a) the `workflow` step's name field is still
+  free text — populate it from `workflows.list` the same way; (b) the MOBILE outline editor
+  (`WorkflowEditor`) still has free-text name fields — `useActionCatalog` is client-core and
+  `session.info` is on `REMOTE_ALLOWED_COMMANDS`, so wiring it is mechanical.
+
+### 12. CLI `service install` units break under an Electron-as-node CLI — OPEN
+**Introduced/observed 2026-06-10** while root-causing the desktop Dock-ghost runner (fixed
+in desktop-host the same day — see ledger). `cli/src/commands/service/common.ts` `nodeBin()`
+returns `process.execPath` as the unit's `<node>`. When the CLI itself runs under the
+packaged desktop's Electron-as-node (the desktop spawns the bundled CLI that way — e.g. an
+agent running `moxxy service install` / `moxxy schedule daemon --background` from a desktop
+session), the launchd/systemd unit's ExecStart becomes the **Electron app binary** and the
+rendered unit env (`launchd.ts renderPlist` — PATH + spec.env only) has **no
+`ELECTRON_RUN_AS_NODE=1`**: the "daemon" boots a full GUI app instance at login
+(RunAtLoad+KeepAlive), i.e. a permanent Dock ghost that never runs the CLI. Fix shape:
+`nodeBin()` should detect run-as-node (env `ELECTRON_RUN_AS_NODE` present) and (a) export
+`ELECTRON_RUN_AS_NODE=1` into the unit env, and (b) on macOS prefer the bundle's
+`<App> Helper` binary (mirror desktop-host's `electronNodeBinary()` — the MAIN bundle
+executable registers a Foreground LaunchServices entry/Dock icon even WITH the env var on
+macOS 26) — or better, resolve a real `node` from PATH for the unit and only fall back to
+the Electron binary. Low blast radius today (services are normally installed from a real
+terminal CLI), but silently wrong when it happens.
 
 ---
 
@@ -731,6 +759,15 @@ graph) is intact; the two operate on different graphs and don't conflict.
 Collapsed from full write-ups; each was re-checked against `HEAD` and confirmed — no
 regressions. Restore the detail from git history (`TECH_DEBT.md` @ `b014c3a`) if needed.
 
+- **Desktop Dock-ghost runner process** (2026-06-10). The packaged desktop's runner
+  (`moxxy serve`, spawned via the bundled CLI with `ELECTRON_RUN_AS_NODE=1`) showed up in
+  the macOS Dock as a generic-executable ("exec") icon named after the app: on macOS 26
+  ANY launch of the MAIN bundle executable registers a Foreground LaunchServices entry,
+  run-as-node or not (verified empirically with a probe). `nodeLauncher()`
+  (`desktop-host/src/cli-resolver.ts`) now routes run-as-node children through the
+  `<App> Helper.app` binary (`electronNodeBinary()` — `LSUIElement=true` → registers as
+  UIElement, no Dock presence; same framework, Node runs identically; falls back to
+  execPath when no helper). The CLI-side cousin is OPEN as P3 #12.
 - **Mode loop scaffolding hoisted to the SDK** (2026-06-08, PR #108, was P2 #6). The
   load-bearing stuck-loop orphan-result fix + the tool-batch abort path were copy-pasted
   across `mode-default` and `mode-goal` (a fix to one had to be hand-mirrored). Both now

--- a/apps/desktop/src/workflows/NodeInspector.tsx
+++ b/apps/desktop/src/workflows/NodeInspector.tsx
@@ -6,6 +6,7 @@ import {
   type BuilderState,
 } from '@moxxy/workflows-builder';
 import type { WorkflowStepErrorMode } from '@moxxy/sdk';
+import type { ActionCatalog } from '@moxxy/client-core';
 import { accentHex } from './accents';
 
 /**
@@ -26,11 +27,14 @@ interface Props {
   readonly state: BuilderState;
   readonly node: BuilderNode;
   readonly dispatch: (action: BuilderAction) => void;
+  /** Live skills/tools registry snapshot for the name pickers. Optional so the
+   *  inspector degrades to free-text fields when no session is attached yet. */
+  readonly catalog?: ActionCatalog;
 }
 
 const ERROR_MODES: WorkflowStepErrorMode[] = ['fail', 'continue', 'retry'];
 
-export function NodeInspector({ state, node, dispatch }: Props): JSX.Element {
+export function NodeInspector({ state, node, dispatch, catalog }: Props): JSX.Element {
   const meta = stepKindMeta(node.kind);
   const accent = accentHex(meta.accent);
   const otherNodes = state.nodes.filter((n) => n.id !== node.id);
@@ -83,7 +87,7 @@ export function NodeInspector({ state, node, dispatch }: Props): JSX.Element {
         />
       </Field>
 
-      {renderAction(node, dispatch, patch)}
+      {renderAction(node, dispatch, patch, catalog)}
 
       {node.kind === 'condition' && (
         <>
@@ -164,6 +168,7 @@ function renderAction(
   node: BuilderNode,
   _dispatch: (a: BuilderAction) => void,
   patch: (p: Parameters<typeof dispatchUpdate>[2]) => void,
+  catalog?: ActionCatalog,
 ): JSX.Element | null {
   switch (node.kind) {
     case 'prompt':
@@ -183,9 +188,12 @@ function renderAction(
     case 'skill':
       return (
         <>
-          <Field label="Skill name">
-            <TextInput value={node.action} onChange={(e) => patch({ action: e.target.value })} data-testid="field-action" />
-          </Field>
+          <ActionNamePicker
+            kind="skill"
+            value={node.action}
+            onChange={(action) => patch({ action })}
+            catalog={catalog}
+          />
           <Field label="Input">
             <TextArea rows={3} value={node.input ?? ''} onChange={(e) => patch({ input: e.target.value })} data-testid="field-input" />
           </Field>
@@ -195,9 +203,18 @@ function renderAction(
     case 'workflow':
       return (
         <>
-          <Field label={node.kind === 'tool' ? 'Tool name' : 'Workflow name'}>
-            <TextInput value={node.action} onChange={(e) => patch({ action: e.target.value })} data-testid="field-action" />
-          </Field>
+          {node.kind === 'tool' ? (
+            <ActionNamePicker
+              kind="tool"
+              value={node.action}
+              onChange={(action) => patch({ action })}
+              catalog={catalog}
+            />
+          ) : (
+            <Field label="Workflow name">
+              <TextInput value={node.action} onChange={(e) => patch({ action: e.target.value })} data-testid="field-action" />
+            </Field>
+          )}
           <Field label="Args (JSON)">
             <TextArea
               rows={3}
@@ -217,6 +234,74 @@ function renderAction(
     case 'loop':
       return null; // handled by LoopEditor
   }
+}
+
+/**
+ * The skill/tool name field. With a loaded catalog it's a dropdown of what the
+ * session actually has registered (a saved name that no longer exists stays
+ * selectable, marked "(not installed)", so loading an old workflow never
+ * silently rewrites it); an empty catalog states that plainly and leaves a
+ * free-text field for forward-authoring; no catalog (no session attached yet)
+ * keeps the plain text field.
+ */
+function ActionNamePicker({
+  kind,
+  value,
+  onChange,
+  catalog,
+}: {
+  kind: 'skill' | 'tool';
+  value: string;
+  onChange: (value: string) => void;
+  catalog?: ActionCatalog;
+}): JSX.Element {
+  const label = kind === 'skill' ? 'Skill name' : 'Tool name';
+  if (!catalog?.loaded) {
+    return (
+      <Field label={label}>
+        <TextInput value={value} onChange={(e) => onChange(e.target.value)} data-testid="field-action" />
+      </Field>
+    );
+  }
+  const items: ReadonlyArray<{ name: string; description?: string }> =
+    kind === 'skill' ? catalog.skills : catalog.tools;
+  if (items.length === 0) {
+    return (
+      <Field label={label}>
+        <span data-testid="catalog-empty" style={emptyHint}>
+          {kind === 'skill'
+            ? 'No skills are currently available. Add one (e.g. via /skills or ~/.moxxy/skills), then pick it here.'
+            : 'No tools are currently available. Enable a plugin that provides tools, then pick one here.'}
+        </span>
+        <TextInput value={value} onChange={(e) => onChange(e.target.value)} data-testid="field-action" />
+      </Field>
+    );
+  }
+  const known = items.some((i) => i.name === value);
+  const description = items.find((i) => i.name === value)?.description;
+  return (
+    <Field label={label}>
+      <select
+        value={value}
+        data-testid="field-action"
+        onChange={(e) => onChange(e.target.value)}
+        style={selectStyle}
+      >
+        {value === '' && <option value="">Select a {kind}…</option>}
+        {!known && value !== '' && <option value={value}>{value} (not installed)</option>}
+        {items.map((i) => (
+          <option key={i.name} value={i.name} title={i.description}>
+            {i.name}
+          </option>
+        ))}
+      </select>
+      {description && (
+        <span data-testid="action-description" style={emptyHint}>
+          {description}
+        </span>
+      )}
+    </Field>
+  );
 }
 
 function LoopEditor({

--- a/apps/desktop/src/workflows/WorkflowBuilder.tsx
+++ b/apps/desktop/src/workflows/WorkflowBuilder.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useWorkflowBuilder } from '@moxxy/client-core';
+import { useActionCatalog, useWorkflowBuilder } from '@moxxy/client-core';
 import { TextInput } from '@moxxy/desktop-ui';
 import { WORKFLOW_ERROR_KEY } from '@moxxy/workflows-builder';
 import { WorkflowCanvas } from './WorkflowCanvas';
@@ -24,6 +24,7 @@ interface Props {
 
 export function WorkflowBuilder({ name, onClose, onSaved }: Props): JSX.Element {
   const builder = useWorkflowBuilder();
+  const catalog = useActionCatalog();
   const { state, dispatch } = builder;
 
   useEffect(() => {
@@ -104,7 +105,9 @@ export function WorkflowBuilder({ name, onClose, onSaved }: Props): JSX.Element 
 
       <div style={{ display: 'flex', flex: 1, minHeight: 0, gap: 0, padding: '0 1rem 1rem' }}>
         <WorkflowCanvas state={state} dispatch={dispatch} />
-        {selectedNode && <NodeInspector state={state} node={selectedNode} dispatch={dispatch} />}
+        {selectedNode && (
+          <NodeInspector state={state} node={selectedNode} dispatch={dispatch} catalog={catalog} />
+        )}
       </div>
     </div>
   );

--- a/apps/desktop/src/workflows/WorkflowCanvas.tsx
+++ b/apps/desktop/src/workflows/WorkflowCanvas.tsx
@@ -448,6 +448,12 @@ function Edge({
   );
 }
 
+function edgeColor(isHoverTarget: boolean, selected: boolean, accent: string, errors: number): string {
+  if (isHoverTarget) return 'var(--color-primary)';
+  if (selected) return accent;
+  return errors > 0 ? 'var(--color-red)' : 'var(--color-border)';
+}
+
 function NodeCard({
   node,
   selected,
@@ -490,9 +496,11 @@ function NodeCard({
         background: 'var(--color-bg-card)',
         borderStyle: 'solid',
         borderWidth: '2px 2px 2px 5px',
-        borderColor: `${
-          isHoverTarget ? 'var(--color-primary)' : selected ? accent : errors > 0 ? 'var(--color-red)' : 'var(--color-border)'
-        }`,
+        // Per-side colors only — mixing the borderColor shorthand with
+        // borderLeftColor makes React warn on rerender.
+        borderTopColor: edgeColor(isHoverTarget, selected, accent, errors),
+        borderRightColor: edgeColor(isHoverTarget, selected, accent, errors),
+        borderBottomColor: edgeColor(isHoverTarget, selected, accent, errors),
         borderLeftColor: accent,
         borderRadius: 'var(--radius-block)',
         boxShadow: isHoverTarget

--- a/apps/desktop/src/workflows/WorkflowsPanel.test.tsx
+++ b/apps/desktop/src/workflows/WorkflowsPanel.test.tsx
@@ -24,6 +24,9 @@ interface Spy {
 function installApi(opts: {
   list?: WorkflowSummary[];
   validate?: (yaml: string) => { ok: boolean; errors: string[] };
+  /** Partial `session.info` payload (skills/tools) for the action pickers;
+   *  omitted → session.info resolves null (no session) like the real handler. */
+  sessionInfo?: { skills?: Array<{ id: string; name: string }>; tools?: Array<{ name: string; description: string }> };
 } = {}): Spy {
   const invokes: Array<{ cmd: string; args: unknown }> = [];
   const list = opts.list ?? [];
@@ -37,6 +40,13 @@ function installApi(opts: {
       }
       if (cmd === 'workflows.save') return Promise.resolve({ name: 'demo', scope: 'user', path: '/x.yaml' });
       if (cmd === 'workflows.getRun') return Promise.resolve(null);
+      if (cmd === 'session.info') {
+        return Promise.resolve(
+          opts.sessionInfo
+            ? { skills: opts.sessionInfo.skills ?? [], tools: opts.sessionInfo.tools ?? [] }
+            : null,
+        );
+      }
       return Promise.resolve(undefined);
     }) as never,
     subscribe: (() => () => {}) as never,
@@ -210,6 +220,106 @@ describe('WorkflowsPanel — builder', () => {
     });
     await waitFor(() => expect(spy.invokes.some((i) => i.cmd === 'workflows.save')).toBe(true));
     expect(spy.invokes.some((i) => i.cmd === 'workflows.validateDraft')).toBe(true);
+  });
+
+  it('offers a dropdown of the session\'s skills on a skill node', async () => {
+    await openBuilder({
+      sessionInfo: {
+        skills: [
+          { id: 'sum', name: 'summarize-inbox' },
+          { id: 'rep', name: 'weekly-report' },
+        ],
+      },
+    });
+    fireEvent.click(screen.getByTestId('palette-add-skill'));
+    await screen.findByTestId('wf-node-skill');
+    const picker = await screen.findByTestId('field-action');
+    await waitFor(() => expect(picker.tagName).toBe('SELECT'));
+    const options = within(picker).getAllByRole('option').map((o) => (o as HTMLOptionElement).value);
+    expect(options).toContain('summarize-inbox');
+    expect(options).toContain('weekly-report');
+    fireEvent.change(picker, { target: { value: 'weekly-report' } });
+    expect((picker as HTMLSelectElement).value).toBe('weekly-report');
+  });
+
+  it('offers a dropdown of the session\'s tools on a tool node, with the description shown', async () => {
+    await openBuilder({
+      sessionInfo: { tools: [{ name: 'web_fetch', description: 'Fetch a URL over HTTP.' }] },
+    });
+    fireEvent.click(screen.getByTestId('palette-add-tool'));
+    await screen.findByTestId('wf-node-tool');
+    const picker = await screen.findByTestId('field-action');
+    await waitFor(() => expect(picker.tagName).toBe('SELECT'));
+    fireEvent.change(picker, { target: { value: 'web_fetch' } });
+    expect((await screen.findByTestId('action-description')).textContent).toContain('Fetch a URL');
+  });
+
+  it('renders a placeholder option until a skill is picked', async () => {
+    await openBuilder({ sessionInfo: { skills: [{ id: 'a', name: 'present-skill' }] } });
+    fireEvent.click(screen.getByTestId('palette-add-skill'));
+    await screen.findByTestId('wf-node-skill');
+    const picker = await screen.findByTestId('field-action');
+    await waitFor(() => expect(picker.tagName).toBe('SELECT'));
+    expect(within(picker).getAllByRole('option')[0]!.textContent).toContain('Select a skill');
+  });
+
+  it('keeps a saved-but-uninstalled skill selectable instead of rewriting it', async () => {
+    // A saved workflow references a skill that's no longer installed: the
+    // picker must surface it as "(not installed)" rather than silently
+    // swapping the value to something else.
+    const yaml = [
+      'name: uses-ghost',
+      'description: refs a removed skill',
+      'steps:',
+      '  - id: run_skill',
+      '    skill: ghost-skill',
+    ].join('\n');
+    __setApiOverride({
+      invoke: ((cmd: string) => {
+        if (cmd === 'workflows.list') return Promise.resolve([{ ...sample, name: 'uses-ghost' }]);
+        if (cmd === 'workflows.getRun') return Promise.resolve({ name: 'uses-ghost', yaml });
+        if (cmd === 'workflows.validateDraft') return Promise.resolve({ ok: true, errors: [] });
+        if (cmd === 'session.info') {
+          return Promise.resolve({ skills: [{ id: 'a', name: 'present-skill' }], tools: [] });
+        }
+        return Promise.resolve(undefined);
+      }) as never,
+      subscribe: (() => () => {}) as never,
+    } as MoxxyApi);
+    render(<WorkflowsPanel />);
+    await screen.findByTestId('workflow-row-uses-ghost');
+    fireEvent.click(screen.getByTestId('edit-workflow-uses-ghost'));
+    await screen.findByTestId('workflow-canvas');
+    fireEvent.pointerDown(await screen.findByTestId('wf-node-run_skill'));
+    const picker = await screen.findByTestId('field-action');
+    await waitFor(() => expect(picker.tagName).toBe('SELECT'));
+    expect((picker as HTMLSelectElement).value).toBe('ghost-skill');
+    const labels = within(picker).getAllByRole('option').map((o) => o.textContent);
+    expect(labels.some((l) => l?.includes('ghost-skill') && l.includes('not installed'))).toBe(true);
+    expect(labels).toContain('present-skill');
+  });
+
+  it('says so when there are no skills (and no tools) instead of a bare field', async () => {
+    await openBuilder({ sessionInfo: { skills: [], tools: [] } });
+    fireEvent.click(screen.getByTestId('palette-add-skill'));
+    await screen.findByTestId('wf-node-skill');
+    const hint = await screen.findByTestId('catalog-empty');
+    expect(hint.textContent).toMatch(/no skills/i);
+    // Tool node shows its own empty-state message.
+    fireEvent.click(screen.getByTestId('palette-add-tool'));
+    await screen.findByTestId('wf-node-tool');
+    const toolHint = await screen.findByTestId('catalog-empty');
+    expect(toolHint.textContent).toMatch(/no tools/i);
+  });
+
+  it('falls back to a free-text field when no session is attached', async () => {
+    await openBuilder(); // session.info → null
+    fireEvent.click(screen.getByTestId('palette-add-skill'));
+    await screen.findByTestId('wf-node-skill');
+    const field = await screen.findByTestId('field-action');
+    expect(field.tagName).toBe('INPUT');
+    fireEvent.change(field, { target: { value: 'hand-typed-skill' } });
+    expect((field as HTMLInputElement).value).toBe('hand-typed-skill');
   });
 
   it('shows a validation error on the offending node', async () => {

--- a/packages/client-core/src/index.ts
+++ b/packages/client-core/src/index.ts
@@ -29,6 +29,7 @@ export * from './useDesks.js';
 export * from './useWorkflows.js';
 export * from './usePausedWorkflows.js';
 export * from './useWorkflowBuilder.js';
+export * from './useActionCatalog.js';
 export * from './useOnboarding.js';
 export * from './useContextUsage.js';
 export * from './useAppUpdate.js';

--- a/packages/client-core/src/useActionCatalog.ts
+++ b/packages/client-core/src/useActionCatalog.ts
@@ -1,0 +1,52 @@
+/**
+ * Loads the action catalog — the skills and tools the live session actually
+ * has registered — so the workflow builder can offer pickers instead of
+ * free-text name fields. Fetch-on-mount from `session.info` (the runner's
+ * wire-friendly registry snapshot, also available to remote clients) +
+ * refresh on {@link SESSION_INFO_REFRESH_EVENT} through the platform
+ * {@link EventBus} capability, mirroring `useActiveModeBadge`.
+ *
+ * `loaded` stays false until `session.info` answers with a session — callers
+ * should fall back to a plain text field in that state rather than claiming
+ * "there are no skills".
+ */
+
+import { useEffect, useState } from 'react';
+import type { SkillInfo, ToolInfo } from '@moxxy/sdk';
+import { SESSION_INFO_REFRESH_EVENT } from '@moxxy/desktop-ipc-contract';
+import { api } from './transport.js';
+import { getPlatform } from './platform.js';
+
+export interface ActionCatalog {
+  /** True once `session.info` answered with a live session (even with empty lists). */
+  readonly loaded: boolean;
+  readonly skills: ReadonlyArray<SkillInfo>;
+  readonly tools: ReadonlyArray<ToolInfo>;
+}
+
+const EMPTY: ActionCatalog = { loaded: false, skills: [], tools: [] };
+
+export function useActionCatalog(workspaceId?: string): ActionCatalog {
+  const [catalog, setCatalog] = useState<ActionCatalog>(EMPTY);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchCatalog = (): void => {
+      void api()
+        .invoke('session.info', workspaceId ? { workspaceId } : undefined)
+        .then((info) => {
+          if (cancelled || !info) return;
+          setCatalog({ loaded: true, skills: info.skills, tools: info.tools });
+        })
+        .catch(() => {});
+    };
+    fetchCatalog();
+    const off = getPlatform().eventBus?.on(SESSION_INFO_REFRESH_EVENT, fetchCatalog);
+    return () => {
+      cancelled = true;
+      off?.();
+    };
+  }, [workspaceId]);
+
+  return catalog;
+}

--- a/packages/desktop-host/src/cli-resolver.test.ts
+++ b/packages/desktop-host/src/cli-resolver.test.ts
@@ -7,6 +7,7 @@ import {
   resolveMoxxyCli,
   executableCandidates,
   augmentedPaths,
+  electronNodeBinary,
   findExecutable,
 } from './cli-resolver';
 
@@ -173,5 +174,38 @@ describe('findExecutable', () => {
 
   it('returns null when the binary is absent', () => {
     expect(findExecutable('definitely-not-here', [tmp])).toBeNull();
+  });
+});
+
+describe('electronNodeBinary (macOS Helper substitution for run-as-node children)', () => {
+  const bundleExec = path.join('/Applications', 'My App.app', 'Contents', 'MacOS', 'My App');
+  const helperExec = path.join(
+    '/Applications',
+    'My App.app',
+    'Contents',
+    'Frameworks',
+    'My App Helper.app',
+    'Contents',
+    'MacOS',
+    'My App Helper',
+  );
+
+  it('prefers the LSUIElement Helper binary when execPath is inside a bundle and the helper exists', () => {
+    expect(electronNodeBinary(bundleExec, 'darwin', (p) => p === helperExec)).toBe(helperExec);
+  });
+
+  it('falls back to execPath when the helper binary is missing', () => {
+    expect(electronNodeBinary(bundleExec, 'darwin', () => false)).toBe(bundleExec);
+  });
+
+  it('leaves non-bundle paths alone on darwin', () => {
+    const bare = path.join('/usr', 'local', 'bin', 'electron');
+    expect(electronNodeBinary(bare, 'darwin', () => true)).toBe(bare);
+  });
+
+  it('never substitutes on linux or windows', () => {
+    expect(electronNodeBinary(bundleExec, 'linux', () => true)).toBe(bundleExec);
+    const winExec = path.join('C:', 'Apps', 'My App.app', 'Contents', 'MacOS', 'My App');
+    expect(electronNodeBinary(winExec, 'win32', () => true)).toBe(winExec);
   });
 });

--- a/packages/desktop-host/src/cli-resolver.ts
+++ b/packages/desktop-host/src/cli-resolver.ts
@@ -138,9 +138,43 @@ export function spawnPath(extraDirs: ReadonlyArray<string> = []): string {
  */
 export function nodeLauncher(): { command: string; env: NodeJS.ProcessEnv } {
   if (process.versions.electron) {
-    return { command: process.execPath, env: { ELECTRON_RUN_AS_NODE: '1' } };
+    return { command: electronNodeBinary(process.execPath), env: { ELECTRON_RUN_AS_NODE: '1' } };
   }
   return { command: 'node', env: {} };
+}
+
+/**
+ * The Electron binary to use for ELECTRON_RUN_AS_NODE children.
+ *
+ * On macOS, launching the MAIN bundle executable registers a Foreground
+ * LaunchServices entry even under ELECTRON_RUN_AS_NODE — the runner showed up
+ * in the Dock as a ghost generic-executable ("exec") icon named after the app.
+ * The `<App> Helper.app` bundle ships `LSUIElement=true`, so the same
+ * framework binary launched from there checks in as a UIElement (no Dock
+ * presence) and still runs Node identically. Prefer it whenever `execPath`
+ * sits inside an `.app` bundle and the helper exists; everywhere else (Linux,
+ * Windows, bare binaries, tests) the execPath is returned unchanged.
+ */
+export function electronNodeBinary(
+  execPath: string,
+  platform: NodeJS.Platform = process.platform,
+  exists: (p: string) => boolean = existsSync,
+): string {
+  if (platform !== 'darwin') return execPath;
+  const macosDir = path.dirname(execPath);
+  const contentsDir = path.dirname(macosDir);
+  const inBundle = path.basename(macosDir) === 'MacOS' && path.basename(contentsDir) === 'Contents';
+  if (!inBundle) return execPath;
+  const name = path.basename(execPath);
+  const helper = path.join(
+    contentsDir,
+    'Frameworks',
+    `${name} Helper.app`,
+    'Contents',
+    'MacOS',
+    `${name} Helper`,
+  );
+  return exists(helper) ? helper : execPath;
 }
 
 /**


### PR DESCRIPTION
## What

**Workflow builder pickers.** The node inspector's *Skill name* and *Tool name* fields are now dropdowns of what the session actually has registered, instead of free-text fields that made the user remember exact names:

- New `@moxxy/client-core` hook `useActionCatalog` — fetches `session.info` (skills + tools registry snapshot), refreshes on `SESSION_INFO_REFRESH_EVENT`; `session.info` is already on `REMOTE_ALLOWED_COMMANDS`, so the mobile editor can adopt it later.
- A saved workflow referencing a skill/tool that's no longer installed keeps its value, surfaced as `<name> (not installed)` — loading an old workflow never silently rewrites it.
- Empty catalog → an explicit "No skills/tools are currently available …" message (plus a free-text field for forward-authoring).
- No session attached yet → free-text fallback (unchanged behavior).
- Tool picker shows the selected tool's description under the field.
- Drive-by: retired the React "borderColor vs borderLeftColor" rerender warning in `NodeCard` (per-side colors).

**macOS Dock "exec" ghost.** Running the desktop showed a second Dock icon (generic Unix-executable icon, process `moxxy serve`, named "MoxxyAI Workspaces"). Root cause, verified empirically with probes: on macOS 26, **any** launch of the MAIN bundle executable registers a Foreground LaunchServices entry — even with `ELECTRON_RUN_AS_NODE=1` (`lsappinfo` shows `type="Foreground"`, `!cgsConnection`). The runner is spawned exactly that way. Fix: `nodeLauncher()` now routes run-as-node children through the `<App> Helper.app` binary via the new pure `electronNodeBinary()` — the helper ships `LSUIElement=true`, so it registers as `type="UIElement"` (no Dock presence) and runs Node identically (probe-verified). Falls back to `execPath` when no helper exists (dev/Linux/Windows/bare binaries).

## Why

Builder UX: users had to remember exact skill/tool names; an empty registry looked identical to a working free-text field. Dock ghost: a phantom terminal-looking app in the Dock for every desktop session looks broken and invites force-quitting the runner.

## Verification

- `pnpm build` / `typecheck` / `lint` (0 errors) / `test` / `check:deps` all green at HEAD.
- `desktop-host` cli-resolver: 22/22 (4 new for `electronNodeBinary`: helper preferred, missing-helper fallback, non-bundle untouched, non-darwin untouched).
- `apps/desktop` WorkflowsPanel: 22/22 (6 new: skill dropdown options + selection, tool dropdown + description, placeholder option, "(not installed)" preservation when loading a saved workflow with a ghost skill, empty-state messages for both kinds, free-text fallback without a session).
- Dock behavior probed on a packaged install (macOS 26): main-bundle binary with `ELECTRON_RUN_AS_NODE=1` → Foreground LS entry (the bug); `MoxxyAI Workspaces Helper` with the same env → `type="UIElement"`, Node v20.18.3 runs fine, no Dock icon.

TECH_DEBT.md: section 11 refreshed (builder UX pass + remaining mobile/workflow-name follow-ups), Dock-ghost recorded in the resolved ledger, new P3 #12 logged (CLI `service install` units have the same Electron-as-node defect — unit ExecStart becomes the GUI binary with no `ELECTRON_RUN_AS_NODE`).