### PR TITLE
feat(desktop): unified section headers + header view switcher + canvas zoom

### DIFF
--- a/.changeset/desktop-unified-headers-canvas-zoom.md
+++ b/.changeset/desktop-unified-headers-canvas-zoom.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/desktop': minor
+---
+
+Desktop shell: Chat, Workflows and Settings now share one unified 64px header with a Chat|Workflows switcher in the main pane (the sidebar MENU group is gone — only Settings remains there, and picking a workspace returns to chat). The settings tabs moved into the header (right-aligned; the redundant Refresh button is removed). The workflow builder canvas gains zoom (40–200%): a −/100%/+ control cluster plus pinch / ctrl+wheel zooming anchored at the cursor.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -733,6 +733,15 @@ graph) is intact; the two operate on different graphs and don't conflict.
   free text — populate it from `workflows.list` the same way; (b) the MOBILE outline editor
   (`WorkflowEditor`) still has free-text name fields — `useActionCatalog` is client-core and
   `session.info` is on `REMOTE_ALLOWED_COMMANDS`, so wiring it is mechanical.
+- **Shell/canvas UX pass 2 (2026-06-10):** the three desktop sections share one 64px header
+  (`apps/desktop/src/shell/ViewHeader.tsx` — `ViewHeader` + `Segmented` + a Chat|Workflows
+  `ViewSwitcher` leading every header); the sidebar's MENU group is gone (lone Settings entry;
+  picking a workspace returns to chat so Settings isn't a dead end); the settings tabs moved
+  into the fixed header (right-aligned, Refresh button dropped — `useSettings` fetches on
+  mount). The builder canvas zooms 40–200% (corner −/％/+ cluster + pinch/ctrl-wheel anchored
+  at the cursor; pointer math normalised into pre-zoom canvas coords). **Debt note:** the
+  settings error banner lost its only manual retry when the Refresh button went — if a
+  transient `settings.read` failure proves common, add a retry affordance to the error row.
 
 ### 12. CLI `service install` units break under an Electron-as-node CLI — OPEN
 **Introduced/observed 2026-06-10** while root-causing the desktop Dock-ghost runner (fixed

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -12,7 +12,8 @@ import {
 import { ConnectionScreen, type UpdateCliResult } from './connection/ConnectionScreen';
 import { Onboarding } from './onboarding/Onboarding';
 import { ChatSurface } from './chat/ChatSurface';
-import { WorkspaceSidebar, type View } from './shell/WorkspaceSidebar';
+import { WorkspaceSidebar } from './shell/WorkspaceSidebar';
+import type { View } from './shell/ViewHeader';
 import { ContextRail } from './shell/ContextRail';
 import { WorkflowsPanel } from './workflows/WorkflowsPanel';
 import { SettingsPanel } from './settings/SettingsPanel';
@@ -196,6 +197,7 @@ export function App(): JSX.Element {
             workspaceId={activeWorkspaceId}
             railOpen={railOpen}
             onShowRail={() => setRailOpen(true)}
+            onView={setView}
           />
           <ContextRail
             open={railOpen}
@@ -206,12 +208,12 @@ export function App(): JSX.Element {
       )}
       {view === 'workflows' && (
         <main className="col-main col-main--flat">
-          <WorkflowsPanel />
+          <WorkflowsPanel onView={setView} />
         </main>
       )}
       {view === 'settings' && (
         <main className="col-main col-main--flat">
-          <SettingsPanel />
+          <SettingsPanel onView={setView} />
         </main>
       )}
       {!connected && <ReconnectBanner label={describePhase(phase)} />}

--- a/apps/desktop/src/chat/ChatSurface.tsx
+++ b/apps/desktop/src/chat/ChatSurface.tsx
@@ -19,6 +19,7 @@ interface ChatSurfaceProps {
   readonly workspaceId: string;
   readonly railOpen: boolean;
   readonly onShowRail: () => void;
+  readonly onView: (v: import('../shell/ViewHeader').View) => void;
 }
 
 /** Stable empty reference for the searching code path (no extensions
@@ -39,6 +40,7 @@ export function ChatSurface({
   workspaceId,
   railOpen,
   onShowRail,
+  onView,
 }: ChatSurfaceProps): JSX.Element {
   const chat = useChat(workspaceId);
   const desks = useDesks();
@@ -75,6 +77,7 @@ export function ChatSurface({
         onSearchChange={setSearchQuery}
         canRename={activeDesk !== undefined}
         onRename={() => setRenameOpen(true)}
+        onView={onView}
       />
       {/* Keyed by workspace so the message area cross-fades on switch
        *  instead of snapping — masks the content swap flicker. */}

--- a/apps/desktop/src/chat/chat-surface/Header.tsx
+++ b/apps/desktop/src/chat/chat-surface/Header.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { ConnectionPhase } from '@moxxy/desktop-ipc-contract';
 import { Icon } from '@moxxy/desktop-ui';
+import { ViewHeader, ViewSwitcher, type View } from '../../shell/ViewHeader';
 
 export function Header({
   phase: _phase,
@@ -10,6 +11,7 @@ export function Header({
   onSearchChange,
   canRename,
   onRename,
+  onView,
 }: {
   readonly phase: ConnectionPhase;
   readonly railOpen: boolean;
@@ -18,25 +20,12 @@ export function Header({
   readonly onSearchChange: (q: string | null) => void;
   readonly canRename: boolean;
   readonly onRename: () => void;
+  readonly onView: (v: View) => void;
 }): JSX.Element {
   const [searchOpen, setSearchOpen] = useState(searchQuery !== null);
   return (
-    <header
-      style={{
-        height: 64,
-        minHeight: 64,
-        flexShrink: 0,
-        boxSizing: 'border-box',
-        padding: '0 24px',
-        borderBottom: '1px solid var(--color-card-border)',
-        display: 'flex',
-        alignItems: 'center',
-        gap: 12,
-      }}
-    >
-      <h1 style={{ margin: 0, fontSize: 18, fontWeight: 700, letterSpacing: '-0.01em' }}>
-        Chat
-      </h1>
+    <ViewHeader>
+      <ViewSwitcher view="chat" onView={onView} />
       {/* workspace path lives in the right-hand context rail now */}
       <span style={{ flex: 1 }} />
       {searchOpen ? (
@@ -91,7 +80,7 @@ export function Header({
           <Icon name="workspace" size={18} />
         </IconButton>
       )}
-    </header>
+    </ViewHeader>
   );
 }
 

--- a/apps/desktop/src/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/settings/SettingsPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useSettings } from '@moxxy/client-core';
-import { Button, Skeleton, Icon } from '@moxxy/desktop-ui';
+import { Skeleton, Icon } from '@moxxy/desktop-ui';
 import { SkillsView } from './SkillsView';
 import { ProvidersTab } from './ProvidersTab';
 import { McpTab } from './McpTab';
@@ -8,6 +8,7 @@ import { VaultTab } from './VaultTab';
 import { AboutTab } from './AboutTab';
 import { MobileTab } from './MobileTab';
 import { SearchBox } from './settings-primitives';
+import { ViewHeader, ViewSwitcher, Segmented, type View } from '../shell/ViewHeader';
 
 type Tab = 'providers' | 'mcp' | 'skills' | 'vault' | 'mobile' | 'about';
 
@@ -36,7 +37,13 @@ const STANDALONE_TABS: ReadonlySet<Tab> = new Set<Tab>(['about', 'mobile']);
  * This is the tab shell: it owns the segmented nav, the per-tab search filter,
  * and the loading / error chrome, then renders the active tab component.
  */
-export function SettingsPanel(): JSX.Element {
+export function SettingsPanel({
+  // Optional so the panel can render standalone (tests); the app shell
+  // always wires it so the header switcher navigates.
+  onView = () => undefined,
+}: {
+  readonly onView?: (v: View) => void;
+}): JSX.Element {
   const s = useSettings();
   const [tab, setTab] = useState<Tab>('providers');
   const [query, setQuery] = useState('');
@@ -47,63 +54,31 @@ export function SettingsPanel(): JSX.Element {
   const vault = q ? s.vault.filter((v) => v.name.toLowerCase().includes(q)) : s.vault;
 
   return (
-    <main
-      style={{
-        flex: 1,
-        overflowY: 'auto',
-        padding: '28px 32px 40px',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 20,
-      }}
-    >
-      <header style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
-        <h1 style={{ margin: 0, fontSize: 21, fontWeight: 700, letterSpacing: '-0.01em' }}>
-          Settings
-        </h1>
-        <nav
-          style={{
-            display: 'inline-flex',
-            gap: 2,
-            padding: 3,
-            background: '#f1f2f9',
-            borderRadius: 12,
-          }}
-        >
-          {TABS.map((t) => {
-            const active = tab === t.id;
-            return (
-              <button
-                key={t.id}
-                type="button"
-                data-testid={`settings-tab-${t.id}`}
-                data-active={active}
-                onClick={() => {
-                  setTab(t.id);
-                  setQuery('');
-                }}
-                style={{
-                  padding: '6px 15px',
-                  fontSize: 13,
-                  fontWeight: 600,
-                  borderRadius: 9,
-                  color: active ? 'var(--color-text)' : 'var(--color-text-muted)',
-                  background: active ? '#fff' : 'transparent',
-                  boxShadow: active ? '0 1px 3px rgba(15, 23, 42, 0.12)' : 'none',
-                  transition: 'background 140ms, color 140ms',
-                }}
-              >
-                {t.label}
-              </button>
-            );
-          })}
-        </nav>
+    <>
+      <ViewHeader>
+        <ViewSwitcher view="settings" onView={onView} />
         <span style={{ flex: 1 }} />
-        <Button variant="chip" onClick={() => void s.refresh()} style={{ borderRadius: 9 }}>
-          <Icon name="rotate" size={14} />
-          Refresh
-        </Button>
-      </header>
+        <Segmented
+          items={TABS}
+          value={tab}
+          onChange={(t) => {
+            setTab(t);
+            setQuery('');
+          }}
+          testIdPrefix="settings-tab-"
+        />
+      </ViewHeader>
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          padding: '20px 32px 40px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 20,
+        }}
+      >
 
       {/* About + Mobile are independent of the runner-backed settings slice —
           render them without the shared loading / error chrome below. */}
@@ -163,6 +138,7 @@ export function SettingsPanel(): JSX.Element {
           )}
         </>
       )}
-    </main>
+      </div>
+    </>
   );
 }

--- a/apps/desktop/src/shell/ViewHeader.tsx
+++ b/apps/desktop/src/shell/ViewHeader.tsx
@@ -1,0 +1,110 @@
+import type { ReactNode } from 'react';
+
+/** Top-level main-content views. Chat ↔ Workflows switch via the header's
+ *  `ViewSwitcher`; Settings is reached from the sidebar. */
+export type View = 'chat' | 'workflows' | 'settings';
+
+/**
+ * Shared section header — one 64px chrome bar so Chat / Workflows /
+ * Settings all top out with the same height, border and padding.
+ * Children lay out in a flex row; use `<span style={{ flex: 1 }} />`
+ * to push trailing controls to the right edge.
+ */
+export function ViewHeader({ children }: { readonly children: ReactNode }): JSX.Element {
+  return (
+    <header
+      style={{
+        height: 64,
+        minHeight: 64,
+        flexShrink: 0,
+        boxSizing: 'border-box',
+        padding: '0 24px',
+        borderBottom: '1px solid var(--color-card-border)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+      }}
+    >
+      {children}
+    </header>
+  );
+}
+
+/**
+ * Segmented pill nav — the settings-tabs look (grey track, white active
+ * pill), shared so the view switcher and the settings tabs read as one
+ * control family. `value: null` renders with no active segment (used by
+ * the switcher while Settings owns the pane).
+ */
+export function Segmented<T extends string>({
+  items,
+  value,
+  onChange,
+  testIdPrefix,
+}: {
+  readonly items: ReadonlyArray<{ readonly id: T; readonly label: string }>;
+  readonly value: T | null;
+  readonly onChange: (id: T) => void;
+  readonly testIdPrefix: string;
+}): JSX.Element {
+  return (
+    <nav
+      style={{
+        display: 'inline-flex',
+        gap: 2,
+        padding: 3,
+        background: '#f1f2f9',
+        borderRadius: 12,
+      }}
+    >
+      {items.map((t) => {
+        const active = value === t.id;
+        return (
+          <button
+            key={t.id}
+            type="button"
+            data-testid={`${testIdPrefix}${t.id}`}
+            data-active={active}
+            onClick={() => onChange(t.id)}
+            style={{
+              padding: '6px 15px',
+              fontSize: 13,
+              fontWeight: 600,
+              borderRadius: 9,
+              color: active ? 'var(--color-text)' : 'var(--color-text-muted)',
+              background: active ? '#fff' : 'transparent',
+              boxShadow: active ? '0 1px 3px rgba(15, 23, 42, 0.12)' : 'none',
+              transition: 'background 140ms, color 140ms',
+            }}
+          >
+            {t.label}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+const SWITCH_ITEMS: ReadonlyArray<{ readonly id: 'chat' | 'workflows'; readonly label: string }> = [
+  { id: 'chat', label: 'Chat' },
+  { id: 'workflows', label: 'Workflows' },
+];
+
+/** Chat ↔ Workflows segmented switcher — the leading element of every
+ *  unified header, standing in for a per-view title. */
+export function ViewSwitcher({
+  view,
+  onView,
+}: {
+  readonly view: View;
+  readonly onView: (v: View) => void;
+}): JSX.Element {
+  return (
+    <Segmented
+      items={SWITCH_ITEMS}
+      value={view === 'settings' ? null : view}
+      onChange={onView}
+      testIdPrefix="nav-"
+    />
+  );
+}

--- a/apps/desktop/src/shell/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/shell/WorkspaceSidebar.tsx
@@ -9,30 +9,17 @@ import { WorkspaceRow } from './workspace-sidebar/WorkspaceRow';
 import { NameWorkspaceModal } from './workspace-sidebar/NameWorkspaceModal';
 import { ProfilePill } from './workspace-sidebar/ProfilePill';
 import { listReset } from './workspace-sidebar/sidebar-styles';
-
-export type View = 'chat' | 'workflows' | 'settings';
+import type { View } from './ViewHeader';
 
 interface Props {
   readonly view: View;
   readonly onView: (v: View) => void;
 }
 
-// ---- menu config ----
-
-const MENU_ITEMS: ReadonlyArray<{
-  id: View;
-  label: string;
-  icon: Parameters<typeof Icon>[0]['name'];
-}> = [
-  { id: 'chat', label: 'Chat', icon: 'chat' },
-  { id: 'workflows', label: 'Workflows', icon: 'workflow' },
-  { id: 'settings', label: 'Settings', icon: 'settings' },
-];
-
 /**
- * Dark left rail. Top: WORKSPACES (each desk = workspace). Middle:
- * MENU (Chat / Workflows / Settings). Bottom: user-profile pill that
- * doubles as a presence indicator.
+ * Dark left rail. Top: WORKSPACES (each desk = workspace). Bottom:
+ * a lone Settings entry above the user-profile pill — Chat/Workflows
+ * navigation lives in the main-pane header (`ViewSwitcher`), not here.
  *
  * Density mirrors the reference shot — wide-enough rows (`44px`) to
  * read like nav, not a context menu.
@@ -82,7 +69,13 @@ export function WorkspaceSidebar({ view, onView }: Props): JSX.Element {
               desk={d}
               active={desks.activeId === d.id}
               unread={unread.has(d.id)}
-              onClick={() => void desks.setActive(d.id)}
+              onClick={() => {
+                // Picking a workspace always lands on its chat — also the
+                // way back out of Settings/Workflows now that the sidebar
+                // carries no Chat entry.
+                void desks.setActive(d.id);
+                onView('chat');
+              }}
               onRemove={() => setPendingRemove(d)}
             />
           ))}
@@ -119,52 +112,45 @@ export function WorkspaceSidebar({ view, onView }: Props): JSX.Element {
           {busy ? 'Picking folder…' : 'New workspace'}
         </button>
       </div>
-      {/* Menu is anchored to the bottom — Chat / Workflows / Settings sit
-       *  just above the profile's top border, not buried at the top of the
-       *  scrolling workspace list. */}
+      {/* Settings is the only sidebar destination — anchored just above
+       *  the profile's top border. Chat/Workflows switch in the main-pane
+       *  header instead. */}
       <nav style={{ padding: '6px 12px 10px' }}>
-        <SectionHeader title="Menu" />
-        <ul role="list" style={listReset}>
-          {MENU_ITEMS.map((m) => (
-            <li key={m.id}>
-              <button
-                type="button"
-                data-testid={`nav-${m.id}`}
-                data-active={view === m.id}
-                onClick={() => onView(m.id)}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 10,
-                  width: '100%',
-                  padding: '10px 12px',
-                  fontSize: 13.5,
-                  color:
-                    view === m.id
-                      ? 'var(--color-sidebar-text)'
-                      : 'var(--color-sidebar-text-dim)',
-                  background:
-                    view === m.id ? 'var(--color-sidebar-bg-active)' : 'transparent',
-                  borderRadius: 10,
-                  fontWeight: view === m.id ? 600 : 500,
-                }}
-              >
-                <span
-                  style={{
-                    width: 20,
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    opacity: 0.85,
-                  }}
-                >
-                  <Icon name={m.icon} size={17} />
-                </span>
-                <span>{m.label}</span>
-              </button>
-            </li>
-          ))}
-        </ul>
+        <button
+          type="button"
+          data-testid="nav-settings"
+          data-active={view === 'settings'}
+          onClick={() => onView('settings')}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            width: '100%',
+            padding: '10px 12px',
+            fontSize: 13.5,
+            color:
+              view === 'settings'
+                ? 'var(--color-sidebar-text)'
+                : 'var(--color-sidebar-text-dim)',
+            background:
+              view === 'settings' ? 'var(--color-sidebar-bg-active)' : 'transparent',
+            borderRadius: 10,
+            fontWeight: view === 'settings' ? 600 : 500,
+          }}
+        >
+          <span
+            style={{
+              width: 20,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              opacity: 0.85,
+            }}
+          >
+            <Icon name="settings" size={17} />
+          </span>
+          <span>Settings</span>
+        </button>
       </nav>
       <ProfilePill />
       {pendingFolder && (

--- a/apps/desktop/src/workflows/WorkflowCanvas.tsx
+++ b/apps/desktop/src/workflows/WorkflowCanvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   stepKindMeta,
   WORKFLOW_ERROR_KEY,
@@ -45,6 +45,15 @@ const NODE_H = 88;
 const ANCHOR_OFFSET = NODE_H / 2;
 const HANDLE_R = 7;
 
+const MIN_ZOOM = 0.4;
+const MAX_ZOOM = 2;
+/** Multiplicative step for the +/− buttons. */
+const ZOOM_STEP = 1.2;
+
+function clampZoom(z: number): number {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, z));
+}
+
 interface Props {
   readonly state: BuilderState;
   readonly dispatch: (action: BuilderAction) => void;
@@ -89,21 +98,76 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
   const [hoverTarget, setHoverTarget] = useState<string | null>(null);
   const [reject, setReject] = useState<string | null>(null);
   const rejectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [zoom, setZoom] = useState(1);
+  /** Scroll offsets to apply right after a zoom commit (keeps the anchor
+   *  point — cursor or viewport centre — visually fixed while scaling). */
+  const pendingScroll = useRef<{ left: number; top: number } | null>(null);
 
   const byId = useMemo(() => new Map(state.nodes.map((n) => [n.id, n])), [state.nodes]);
 
   /** Topological order index per node (1-based) so the canvas reads as a flow. */
   const order = useMemo(() => topoOrder(state.nodes), [state.nodes]);
 
-  const surfacePoint = useCallback((e: { clientX: number; clientY: number }) => {
-    const rect = surfaceRef.current?.getBoundingClientRect();
-    const left = surfaceRef.current?.scrollLeft ?? 0;
-    const top = surfaceRef.current?.scrollTop ?? 0;
-    return {
-      x: (rect ? e.clientX - rect.left : e.clientX) + left,
-      y: (rect ? e.clientY - rect.top : e.clientY) + top,
+  /** Pointer position in CONTENT coords (pre-zoom node space). */
+  const surfacePoint = useCallback(
+    (e: { clientX: number; clientY: number }) => {
+      const rect = surfaceRef.current?.getBoundingClientRect();
+      const left = surfaceRef.current?.scrollLeft ?? 0;
+      const top = surfaceRef.current?.scrollTop ?? 0;
+      return {
+        x: ((rect ? e.clientX - rect.left : e.clientX) + left) / zoom,
+        y: ((rect ? e.clientY - rect.top : e.clientY) + top) / zoom,
+      };
+    },
+    [zoom],
+  );
+
+  /** Zoom to `next`, keeping `anchor` (client coords; defaults to the
+   *  viewport centre) over the same content point. */
+  const applyZoom = useCallback(
+    (next: number, anchor?: { x: number; y: number }) => {
+      const z = clampZoom(next);
+      const el = surfaceRef.current;
+      if (el && z !== zoom) {
+        const rect = el.getBoundingClientRect();
+        const ax = anchor ? anchor.x - rect.left : rect.width / 2;
+        const ay = anchor ? anchor.y - rect.top : rect.height / 2;
+        pendingScroll.current = {
+          left: ((el.scrollLeft + ax) / zoom) * z - ax,
+          top: ((el.scrollTop + ay) / zoom) * z - ay,
+        };
+      }
+      setZoom(z);
+    },
+    [zoom],
+  );
+
+  // The scaled content commits in the same render as `zoom`, so the anchor
+  // correction must land before paint or the view visibly jumps.
+  useLayoutEffect(() => {
+    const el = surfaceRef.current;
+    const p = pendingScroll.current;
+    if (el && p) {
+      el.scrollLeft = p.left;
+      el.scrollTop = p.top;
+      pendingScroll.current = null;
+    }
+  }, [zoom]);
+
+  // Pinch / ctrl+wheel zoom. Native non-passive listener — React's root
+  // wheel listener is passive, so a synthetic onWheel can't preventDefault
+  // (and the page would scroll while pinching).
+  useEffect(() => {
+    const el = surfaceRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent): void => {
+      if (!e.ctrlKey && !e.metaKey) return; // macOS pinch arrives as ctrl+wheel
+      e.preventDefault();
+      applyZoom(zoom * Math.exp(-e.deltaY * 0.0018), { x: e.clientX, y: e.clientY });
     };
-  }, []);
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [applyZoom, zoom]);
 
   const flashReject = useCallback((msg: string) => {
     setReject(msg);
@@ -233,6 +297,7 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
   const height = Math.max(560, ...state.nodes.map((n) => n.y + NODE_H + 80));
 
   return (
+    <div style={{ position: 'relative', flex: 1, minHeight: 0, minWidth: 0, display: 'flex' }}>
     <div
       ref={surfaceRef}
       data-testid="workflow-canvas"
@@ -244,6 +309,7 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
         position: 'relative',
         flex: 1,
         minHeight: 0,
+        minWidth: 0,
         overflow: 'auto',
         background:
           'var(--color-bg) radial-gradient(circle, var(--color-card-border) 1px, transparent 1px)',
@@ -252,7 +318,18 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
         border: '1px solid var(--color-border)',
       }}
     >
-      <div style={{ position: 'relative', width, height }}>
+      {/* Scroll sizer: reserves the SCALED footprint so scrollbars track the
+       *  zoomed content (a transform alone doesn't change layout size). */}
+      <div style={{ width: width * zoom, height: height * zoom, overflow: 'hidden' }}>
+      <div
+        style={{
+          position: 'relative',
+          width,
+          height,
+          transform: `scale(${zoom})`,
+          transformOrigin: '0 0',
+        }}
+      >
         <svg width={width} height={height} style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
           <defs>
             {Object.entries(EDGE_STYLE).map(([kind, s]) => (
@@ -317,6 +394,7 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
           </div>
         )}
       </div>
+      </div>
 
       {reject && (
         <div
@@ -342,8 +420,92 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
         </div>
       )}
     </div>
+    <ZoomControls
+      zoom={zoom}
+      onZoomIn={() => applyZoom(zoom * ZOOM_STEP)}
+      onZoomOut={() => applyZoom(zoom / ZOOM_STEP)}
+      onReset={() => applyZoom(1)}
+    />
+    </div>
   );
 }
+
+/** Floating zoom cluster pinned to the canvas' bottom-right corner. The
+ *  percentage doubles as a reset-to-100% button. */
+function ZoomControls({
+  zoom,
+  onZoomIn,
+  onZoomOut,
+  onReset,
+}: {
+  readonly zoom: number;
+  readonly onZoomIn: () => void;
+  readonly onZoomOut: () => void;
+  readonly onReset: () => void;
+}): JSX.Element {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        right: 12,
+        bottom: 12,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 2,
+        padding: 3,
+        background: 'var(--color-bg-card)',
+        border: '1px solid var(--color-border)',
+        borderRadius: 'var(--radius-block)',
+        boxShadow: 'var(--color-card-shadow)',
+        zIndex: 10,
+      }}
+    >
+      <button
+        type="button"
+        data-testid="canvas-zoom-out"
+        title="Zoom out"
+        aria-label="Zoom out"
+        disabled={zoom <= MIN_ZOOM}
+        onClick={onZoomOut}
+        style={{ ...zoomBtn, opacity: zoom <= MIN_ZOOM ? 0.4 : 1 }}
+      >
+        −
+      </button>
+      <button
+        type="button"
+        data-testid="canvas-zoom-reset"
+        title="Reset zoom to 100%"
+        onClick={onReset}
+        style={{ ...zoomBtn, width: 'auto', minWidth: 40, padding: '0 6px', fontSize: '0.68rem' }}
+      >
+        {Math.round(zoom * 100)}%
+      </button>
+      <button
+        type="button"
+        data-testid="canvas-zoom-in"
+        title="Zoom in"
+        aria-label="Zoom in"
+        disabled={zoom >= MAX_ZOOM}
+        onClick={onZoomIn}
+        style={{ ...zoomBtn, opacity: zoom >= MAX_ZOOM ? 0.4 : 1 }}
+      >
+        +
+      </button>
+    </div>
+  );
+}
+
+const zoomBtn: React.CSSProperties = {
+  width: 26,
+  height: 26,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: '0.95rem',
+  fontWeight: 600,
+  color: 'var(--color-text-dim)',
+  borderRadius: 6,
+};
 
 function TempLine({
   from,

--- a/apps/desktop/src/workflows/WorkflowsPanel.tsx
+++ b/apps/desktop/src/workflows/WorkflowsPanel.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { useWorkflows } from '@moxxy/client-core';
-import { Skeleton } from '@moxxy/desktop-ui';
+import { Button, Icon, Skeleton } from '@moxxy/desktop-ui';
 import { WorkflowBuilder } from './WorkflowBuilder';
 import { PausedWorkflows } from './PausedWorkflows';
+import { ViewHeader, ViewSwitcher, type View } from '../shell/ViewHeader';
 
 /**
  * Workflows surface — two modes:
@@ -14,7 +15,13 @@ import { PausedWorkflows } from './PausedWorkflows';
  * model via `useWorkflowBuilder`; this panel only owns the mode toggle and
  * wires the list's `refresh` so a save re-lists.
  */
-export function WorkflowsPanel(): JSX.Element {
+export function WorkflowsPanel({
+  // Optional so the panel can render standalone (tests); the app shell
+  // always wires it so the header switcher navigates.
+  onView = () => undefined,
+}: {
+  readonly onView?: (v: View) => void;
+}): JSX.Element {
   const wf = useWorkflows();
   // `editing === undefined` → list; `null` → new workflow; string → edit by name.
   const [editing, setEditing] = useState<string | null | undefined>(undefined);
@@ -32,49 +39,34 @@ export function WorkflowsPanel(): JSX.Element {
   }
 
   return (
-    <main
-      style={{
-        flex: 1,
-        overflowY: 'auto',
-        padding: '1.5rem 2rem',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '1rem',
-      }}
-    >
-      <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <h1 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 700 }}>Workflows</h1>
-        <div style={{ display: 'flex', gap: '0.5rem' }}>
-          <button
-            type="button"
-            data-testid="new-workflow"
-            onClick={() => setEditing(null)}
-            style={{
-              fontSize: '0.75rem',
-              fontWeight: 600,
-              color: 'var(--color-bg)',
-              background: 'var(--color-primary)',
-              borderRadius: 'var(--radius-block)',
-              padding: '0.25rem 0.7rem',
-            }}
-          >
-            + New
-          </button>
-          <button
-            type="button"
-            onClick={() => void wf.refresh()}
-            style={{
-              fontSize: '0.75rem',
-              color: 'var(--color-text-dim)',
-              border: '1px solid var(--color-border)',
-              borderRadius: 'var(--radius-block)',
-              padding: '0.2rem 0.55rem',
-            }}
-          >
-            Refresh
-          </button>
-        </div>
-      </header>
+    <>
+      <ViewHeader>
+        <ViewSwitcher view="workflows" onView={onView} />
+        <span style={{ flex: 1 }} />
+        <Button variant="chip" onClick={() => void wf.refresh()} style={{ borderRadius: 9 }}>
+          <Icon name="rotate" size={14} />
+          Refresh
+        </Button>
+        <Button
+          variant="primary"
+          data-testid="new-workflow"
+          onClick={() => setEditing(null)}
+          style={{ borderRadius: 9, padding: '6px 14px', fontSize: 13 }}
+        >
+          + New
+        </Button>
+      </ViewHeader>
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          padding: '1.5rem 2rem',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1rem',
+        }}
+      >
       {wf.error && (
         <p
           role="alert"
@@ -200,7 +192,8 @@ export function WorkflowsPanel(): JSX.Element {
           </pre>
         </section>
       )}
-    </main>
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## What

**Unified section headers.** Chat, Workflows and Settings now share one 64px header bar (`apps/desktop/src/shell/ViewHeader.tsx`: `ViewHeader` shell + shared `Segmented` pill control), each led by a **Chat | Workflows switcher** in the main pane:

- **Chat** — switcher replaces the "Chat" title; search / rename / context-rail actions stay on the right.
- **Workflows** — the list header moves out of the scrolling area into the fixed bar; "Refresh" / "+ New" restyled to the shared Button chip/primary look.
- **Settings** — tabs selector moves into the fixed header, **right-aligned**; the Refresh button is removed (`useSettings` already fetches on mount, and every mutation refreshes).

**Sidebar.** The MENU group (Chat / Workflows / Settings) is gone — a lone **Settings** entry remains above the profile pill. Picking a workspace also returns to the chat view, so Settings/Workflows are never a dead end.

**Workflow canvas zoom (40–200%).** Bottom-right − / 100% / + cluster (the percentage resets to 100%) plus pinch / ctrl+wheel / cmd+wheel zooming anchored at the cursor. Implementation notes: native non-passive wheel listener (React's root wheel handler is passive, so a synthetic `onWheel` can't `preventDefault`); all pointer math (node drag, connection drag, drop targets) normalises into pre-zoom canvas coordinates; a scroll sizer reserves the scaled footprint so scrollbars track the zoomed content; the anchor correction lands in a layout effect so the view doesn't jump on scale.

## Why

The three sections had three different header heights/styles, and switching between chat and workflows required a trip to the sidebar. The builder canvas had no way to get an overview of (or zoom into) larger graphs.

## Verification

- `pnpm build` / `typecheck` / `lint` (0 errors, no warnings in touched files) / `test` (114 tasks; desktop 69/69 incl. 22 WorkflowsPanel canvas drag tests, which exercise the pointer math through the new zoom-aware `surfacePoint`) / `check:deps` — all green, after rebase onto latest main.
- Changeset: `@moxxy/desktop` minor.
- TECH_DEBT.md §11 updated (UX pass logged + a note that the settings error banner lost its manual-retry affordance with the Refresh button).