### PR TITLE
fix(workflows): canvas drag-to-pan, aligned builder header, human-readable validation errors

### DIFF
--- a/.changeset/workflow-canvas-pan-friendly-errors.md
+++ b/.changeset/workflow-canvas-pan-friendly-errors.md
@@ -1,0 +1,7 @@
+---
+'@moxxy/plugin-workflows': patch
+'@moxxy/cli': patch
+'@moxxy/desktop': patch
+---
+
+Workflow builder UX: the canvas pans by dragging the background (grab cursor; node drag / connection drag / click-to-deselect unaffected), the header controls (Back / validity badge / Save) align to the name/description input row instead of floating centred, and schema validation errors read as plain English anchored to the step — `step "greet": prompt must not be empty` instead of `steps.0.prompt: String must contain at least 1 character(s)` — so the builder can pin them to the offending node card.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -742,6 +742,15 @@ graph) is intact; the two operate on different graphs and don't conflict.
   at the cursor; pointer math normalised into pre-zoom canvas coords). **Debt note:** the
   settings error banner lost its only manual retry when the Refresh button went — if a
   transient `settings.read` failure proves common, add a retry affordance to the error row.
+- **Builder UX pass 3 (2026-06-10):** canvas drag-to-pan (background drag scrolls the
+  surface; a pan that moved suppresses the follow-up deselect click — node drag / connection
+  drag / edge-✕ are untouched since they stopPropagation), builder-header controls (Back /
+  validity badge / Save) aligned to the input row via flex-end + a shared `CONTROL_H`
+  matching TextInput, and plugin-workflows `formatIssues` now emits step-anchored plain
+  English (`step "greet": prompt must not be empty`) instead of zod-speak — which also makes
+  raw schema errors bucket onto the offending node via `mapErrorsToNodes` (they previously
+  only hit the generic banner, e.g. `steps.0.prompt: String must contain at least 1
+  character(s)`).
 
 ### 12. CLI `service install` units break under an Electron-as-node CLI — OPEN
 **Introduced/observed 2026-06-10** while root-causing the desktop Dock-ghost runner (fixed

--- a/apps/desktop/src/workflows/WorkflowBuilder.tsx
+++ b/apps/desktop/src/workflows/WorkflowBuilder.tsx
@@ -46,7 +46,10 @@ export function WorkflowBuilder({ name, onClose, onSaved }: Props): JSX.Element 
       <header
         style={{
           display: 'flex',
-          alignItems: 'center',
+          // Bottom-align: the two labelled fields are taller than the buttons
+          // (label row on top), so centring left Back/valid/Save floating
+          // above the input line — anchor everything to the input row instead.
+          alignItems: 'flex-end',
           gap: '0.75rem',
           padding: '0.75rem 1rem',
           borderBottom: '1px solid var(--color-border)',
@@ -130,7 +133,11 @@ function ValidityBadge({ valid, validating }: { valid: boolean | null; validatin
         color,
         border: `1px solid ${color}`,
         borderRadius: 'var(--radius-block)',
-        padding: '0.2rem 0.5rem',
+        padding: '0 0.5rem',
+        height: CONTROL_H,
+        display: 'inline-flex',
+        alignItems: 'center',
+        boxSizing: 'border-box',
       }}
     >
       {label}
@@ -143,12 +150,21 @@ const metaLabel: React.CSSProperties = {
   fontWeight: 700,
   textTransform: 'uppercase',
   color: 'var(--color-text-dim)',
+  marginBottom: 2,
 };
+
+/** TextInput renders ~37px tall (9px padding + 14px text + border); every
+ *  header control matches it so the flex-end row reads as one line. */
+const CONTROL_H = 37;
 
 const primaryBtn: React.CSSProperties = {
   fontSize: '0.8rem',
   fontWeight: 600,
-  padding: '0.4rem 1rem',
+  padding: '0 1rem',
+  height: CONTROL_H,
+  display: 'inline-flex',
+  alignItems: 'center',
+  boxSizing: 'border-box',
   color: 'var(--color-bg)',
   background: 'var(--color-primary)',
   borderRadius: 'var(--radius-block)',
@@ -159,7 +175,11 @@ const ghostBtn: React.CSSProperties = {
   color: 'var(--color-text-muted)',
   border: '1px solid var(--color-border)',
   borderRadius: 'var(--radius-block)',
-  padding: '0.3rem 0.7rem',
+  padding: '0 0.7rem',
+  height: CONTROL_H,
+  display: 'inline-flex',
+  alignItems: 'center',
+  boxSizing: 'border-box',
 };
 
 const alertBox: React.CSSProperties = {

--- a/apps/desktop/src/workflows/WorkflowCanvas.tsx
+++ b/apps/desktop/src/workflows/WorkflowCanvas.tsx
@@ -102,6 +102,14 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
   /** Scroll offsets to apply right after a zoom commit (keeps the anchor
    *  point — cursor or viewport centre — visually fixed while scaling). */
   const pendingScroll = useRef<{ left: number; top: number } | null>(null);
+  /** Background drag-to-pan: pointer + scroll origin, and whether it actually
+   *  moved (a still pan is a click and must keep deselecting). */
+  const pan = useRef<{ x: number; y: number; left: number; top: number; moved: boolean } | null>(
+    null,
+  );
+  const [panning, setPanning] = useState(false);
+  /** Set on pan end so the synthetic click that follows doesn't deselect. */
+  const suppressClick = useRef(false);
 
   const byId = useMemo(() => new Map(state.nodes.map((n) => [n.id, n])), [state.nodes]);
 
@@ -203,6 +211,24 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
     [surfacePoint],
   );
 
+  // --- background pan (canvas drag) ---
+  // Node bodies and handles stopPropagation on pointerdown, so anything that
+  // reaches the surface here is empty canvas (or an edge) → start panning.
+  const onSurfacePointerDown = useCallback((e: React.PointerEvent) => {
+    if (e.button !== 0) return;
+    const el = surfaceRef.current;
+    if (!el) return;
+    (e.target as Element).setPointerCapture?.(e.pointerId);
+    pan.current = {
+      x: e.clientX,
+      y: e.clientY,
+      left: el.scrollLeft,
+      top: el.scrollTop,
+      moved: false,
+    };
+    setPanning(true);
+  }, []);
+
   const onPointerMove = useCallback(
     (e: React.PointerEvent) => {
       const p = surfacePoint(e);
@@ -215,6 +241,16 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
       if (connect.current) {
         setCursor(p);
         setHoverTarget(nodeAt(state.nodes, p, connect.current.nodeId));
+        return;
+      }
+      if (pan.current) {
+        const el = surfaceRef.current;
+        if (!el) return;
+        const dx = e.clientX - pan.current.x;
+        const dy = e.clientY - pan.current.y;
+        if (Math.abs(dx) + Math.abs(dy) > 3) pan.current.moved = true;
+        el.scrollLeft = pan.current.left - dx;
+        el.scrollTop = pan.current.top - dy;
       }
     },
     [dispatch, state.nodes, surfacePoint],
@@ -278,7 +314,17 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
         setDragging(null);
         return;
       }
-      if (connect.current) finishConnection(surfacePoint(e));
+      if (connect.current) {
+        finishConnection(surfacePoint(e));
+        return;
+      }
+      if (pan.current) {
+        // A pan that moved must not read as a background click (deselect) —
+        // swallow the click that follows this pointerup.
+        suppressClick.current = pan.current.moved;
+        pan.current = null;
+        setPanning(false);
+      }
     },
     [finishConnection, surfacePoint],
   );
@@ -291,6 +337,10 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
       setCursor(null);
       setHoverTarget(null);
     }
+    if (pan.current) {
+      pan.current = null;
+      setPanning(false);
+    }
   }, []);
 
   const width = Math.max(900, ...state.nodes.map((n) => n.x + NODE_W + 80));
@@ -301,16 +351,24 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
     <div
       ref={surfaceRef}
       data-testid="workflow-canvas"
+      onPointerDown={onSurfacePointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
       onPointerLeave={onPointerLeave}
-      onClick={() => dispatch({ type: 'select', id: null })}
+      onClick={() => {
+        if (suppressClick.current) {
+          suppressClick.current = false;
+          return;
+        }
+        dispatch({ type: 'select', id: null });
+      }}
       style={{
         position: 'relative',
         flex: 1,
         minHeight: 0,
         minWidth: 0,
         overflow: 'auto',
+        cursor: panning ? 'grabbing' : 'grab',
         background:
           'var(--color-bg) radial-gradient(circle, var(--color-card-border) 1px, transparent 1px)',
         backgroundSize: '24px 24px',

--- a/packages/plugin-workflows/src/schema.test.ts
+++ b/packages/plugin-workflows/src/schema.test.ts
@@ -94,6 +94,29 @@ steps:
     expect(r.errors.join('\n')).toMatch(/cycle/);
   });
 
+  it('formats schema issues as friendly, step-anchored lines (no zod-speak)', () => {
+    const r = validateWorkflow({
+      name: 'fmt',
+      description: 'x',
+      steps: [{ id: 'greet', prompt: '' }],
+    });
+    expect(r.ok).toBe(false);
+    // `step "<id>"` anchors the line to the canvas node; the message reads
+    // as English, not 'String must contain at least 1 character(s)'.
+    expect(r.errors.join('\n')).toMatch(/step "greet": prompt must not be empty/);
+    expect(r.errors.join('\n')).not.toMatch(/String must contain/);
+  });
+
+  it('falls back to the step number when the failing step has no id', () => {
+    const r = validateWorkflow({
+      name: 'fmt2',
+      description: 'x',
+      steps: [{ prompt: 'hello' }],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toMatch(/step 1: id is required/);
+  });
+
   it('rejects duplicate step ids', () => {
     const r = validateWorkflow({
       name: 'dup',

--- a/packages/plugin-workflows/src/schema.ts
+++ b/packages/plugin-workflows/src/schema.ts
@@ -454,21 +454,71 @@ function findCycle(steps: ReadonlyArray<{ id: string; needs: ReadonlyArray<strin
 export interface WorkflowParseResult {
   readonly ok: boolean;
   readonly workflow?: Workflow;
-  /** One readable line per issue, e.g. `steps: step "a" needs unknown step "x"`. */
+  /** One readable line per issue, e.g. `step "a": prompt must not be empty`. */
   readonly errors: ReadonlyArray<string>;
 }
 
-function formatIssues(error: z.ZodError): string[] {
+/**
+ * Render one zod issue as a human sentence instead of zod's library-speak
+ * ("String must contain at least 1 character(s)"). These lines are read by
+ * workflow authors in the builder banner/inspector and by agents fixing a
+ * draft, so plain English wins over schema jargon.
+ */
+function humanizeIssue(iss: z.ZodIssue): string {
+  switch (iss.code) {
+    case 'too_small': {
+      const min = Number(iss.minimum);
+      if (iss.type === 'string') return min === 1 ? 'must not be empty' : `must be at least ${min} characters`;
+      if (iss.type === 'array') return min === 1 ? 'needs at least one entry' : `needs at least ${min} entries`;
+      return `must be at least ${min}`;
+    }
+    case 'too_big': {
+      const max = Number(iss.maximum);
+      if (iss.type === 'string') return `must be at most ${max} characters`;
+      if (iss.type === 'array') return `can have at most ${max} entries`;
+      return `must be at most ${max}`;
+    }
+    case 'invalid_type':
+      return iss.received === 'undefined' ? 'is required' : `should be a ${iss.expected} (got ${iss.received})`;
+    case 'invalid_enum_value':
+      return `must be one of: ${iss.options.map((o) => `"${String(o)}"`).join(', ')}`;
+    default:
+      return iss.message;
+  }
+}
+
+function formatIssues(error: z.ZodError, raw: unknown): string[] {
+  const steps: unknown[] =
+    raw !== null && typeof raw === 'object' && Array.isArray((raw as { steps?: unknown }).steps)
+      ? ((raw as { steps: unknown[] }).steps)
+      : [];
   return error.issues.map((iss) => {
-    const path = iss.path.join('.') || '(root)';
-    return `${path}: ${iss.message}`;
+    // Refinement messages (superRefine/regex `message:`) already speak human
+    // and name their step — pass them through untouched.
+    if (iss.code === 'custom') return iss.message;
+    const msg = humanizeIssue(iss);
+    const [head, idx, ...rest] = iss.path;
+    if (head === 'steps' && typeof idx === 'number') {
+      // Anchor the line to the step's id (the `step "<id>"` shape is what the
+      // builder uses to attach the error to the right node on the canvas).
+      const step = steps[idx];
+      const id =
+        step !== null && typeof step === 'object' && typeof (step as { id?: unknown }).id === 'string'
+          ? ((step as { id: string }).id)
+          : '';
+      const where = id ? `step "${id}"` : `step ${idx + 1}`;
+      const field = rest.join('.');
+      return field ? `${where}: ${field} ${msg}` : `${where} ${msg}`;
+    }
+    const path = iss.path.join('.');
+    return path ? `${path} ${msg}` : `workflow ${msg}`;
   });
 }
 
 /** Validate an already-parsed object against the workflow schema. */
 export function validateWorkflow(raw: unknown): WorkflowParseResult {
   const parsed = workflowSchema.safeParse(raw);
-  if (!parsed.success) return { ok: false, errors: formatIssues(parsed.error) };
+  if (!parsed.success) return { ok: false, errors: formatIssues(parsed.error, raw) };
   return { ok: true, workflow: parsed.data as Workflow, errors: [] };
 }
 


### PR DESCRIPTION
## What

- **Canvas drag-to-pan** — dragging the empty canvas background pans the view (grab/grabbing cursor), so larger graphs can be navigated without the scrollbars. Node drag, connection drag and the edge ✕ are unaffected (they stopPropagation on pointerdown); a pan that actually moved suppresses the follow-up click so it doesn't deselect the current node.
- **Builder header alignment** — Back / validity badge / Save now bottom-align with the name + description inputs (header `alignItems: flex-end` + a shared `CONTROL_H` that matches TextInput's rendered height) instead of floating centred against the taller labelled fields.
- **Human-readable validation errors** — `formatIssues` in plugin-workflows turns raw zod issues into step-anchored plain English: `step "greet": prompt must not be empty` instead of `steps.0.prompt: String must contain at least 1 character(s)`. Because the `step "<id>"` shape is what the builder's `mapErrorsToNodes` keys on, schema-level errors now also decorate the offending node card (⚠ badge + inspector) rather than only the generic banner. Custom refinement messages (already human, already step-named) pass through untouched.

## Why

Builder feedback from real use: no way to pan the canvas while building bigger workflows, header buttons visibly misaligned, and zod's library-speak leaking straight into the error banner.

## Verification

- Full gate green: `pnpm build` / `typecheck` / `lint` (0 errors) / `test` (114 tasks; plugin-workflows 87/87 incl. 2 new format-pinning tests, desktop 69/69 — the canvas suites exercise pointer handling around the new pan path) / `check:deps`.
- Changeset: `@moxxy/plugin-workflows` + `@moxxy/cli` + `@moxxy/desktop` patch.
- TECH_DEBT.md §11 updated (builder UX pass 3).