### PR TITLE
fix(desktop): allow Clerk's top-frame OAuth redirect through the navigation lockdown

### DIFF
--- a/.changeset/desktop-clerk-topframe-oauth.md
+++ b/.changeset/desktop-clerk-topframe-oauth.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/desktop': patch
+'@moxxy/desktop-host': patch
+---
+
+Fix packaged-app Google sign-in doing nothing (eternal button spinner): clerk-js's prebuilt sign-in buttons run the provider flow as a TOP-FRAME redirect, not a popup, and the navigation lockdown silently blocked it. `lockDownNavigation` gains an explicit `allowOriginPatterns` allow-list; the main window passes the OAuth hosts plus its own loopback serving origins so the frame can round-trip app → provider → Clerk FAPI → back, while everything else (and the focus window entirely) stays blanket-denied. Also adds `challenges.cloudflare.com` to CSP connect-src per Clerk's documented Turnstile requirements so the sign-up captcha can't dead-end.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -768,6 +768,17 @@ terminal CLI), but silently wrong when it happens.
 Collapsed from full write-ups; each was re-checked against `HEAD` and confirmed — no
 regressions. Restore the detail from git history (`TECH_DEBT.md` @ `b014c3a`) if needed.
 
+- **Packaged Clerk sign-in: OAuth is a top-frame redirect, not a popup** (2026-06-11).
+  First real packaged sign-in attempt: "Continue with Google" spun forever — clerk-js's
+  prebuilt modal navigates the TOP FRAME to the provider, and `lockDownNavigation`'s
+  blanket deny swallowed it silently (the popup-based `setWindowOpenHandler` path was
+  never exercised). `lockDownNavigation` now takes `allowOriginPatterns` (main window:
+  OAUTH_HOST_PATTERNS + its own loopback serving origins for the return leg — the
+  FAPI→app hop is not same-origin with the mid-flow page; focus window keeps the blanket
+  deny) + `challenges.cloudflare.com` added to CSP connect-src for the sign-up Turnstile.
+  Postscript in `docs/desktop-clerk-loopback-subdomain.md`. **Remaining verify:** a real
+  packaged Google round-trip (the redirect reloads the app document mid-flow, which
+  clerk-js handles as a normal SPA return).
 - **Desktop Dock-ghost runner process** (2026-06-10). The packaged desktop's runner
   (`moxxy serve`, spawned via the bundled CLI with `ELECTRON_RUN_AS_NODE=1`) showed up in
   the macOS Dock as a generic-executable ("exec") icon named after the app: on macOS 26

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -237,10 +237,21 @@ async function createWindow(): Promise<void> {
     },
   });
 
-  // Refuse top-frame navigation away from our own origin. The OAuth
-  // popups open via the `setWindowOpenHandler` below (kept intact), not
-  // by navigating this frame, so sign-in is unaffected.
-  lockDownNavigation(mainWindow, { keepWindowOpenHandler: true });
+  // Refuse top-frame navigation away from our own origin — EXCEPT to the
+  // OAuth hosts. clerk-js's prebuilt sign-in buttons run the provider flow
+  // as a top-frame redirect (not a popup), so the frame must be allowed to
+  // round-trip app → accounts.google.com → clerk FAPI → back here. The
+  // return leg lands on a loopback serving origin that differs from the
+  // page's CURRENT origin mid-flow, so those origins are allow-listed
+  // explicitly (dev: the Vite origin).
+  const appOriginPatterns = [
+    new RegExp(`^https://desktop\\.moxxy\\.ai:(?:${LOOPBACK_PORTS.join('|')})$`),
+    ...(isDev ? [/^http:\/\/(?:localhost|127\.0\.0\.1):\d+$/] : []),
+  ];
+  lockDownNavigation(mainWindow, {
+    keepWindowOpenHandler: true,
+    allowOriginPatterns: [...OAUTH_HOST_PATTERNS, ...appOriginPatterns],
+  });
 
   // OAuth popup handling — Clerk's clerk-js calls window.open() to
   // run the provider's OAuth flow. We allow popups whose origin is on

--- a/docs/desktop-clerk-loopback-subdomain.md
+++ b/docs/desktop-clerk-loopback-subdomain.md
@@ -137,3 +137,26 @@ own Frontend API host). Nothing further to wire — just set the env var in CI.
 | Wire-up: mint cert, start server, `certificate-error` scoped trust, CSP, ports | `apps/desktop/electron/main/index.ts` |
 | Renderer `allowedRedirectOrigins` | `apps/desktop/src/main.tsx` |
 | CSP (folds in the loopback origin + prod Clerk Frontend API host) | `packages/desktop-host/src/security.ts` |
+
+---
+
+## Postscript (2026-06-11): the flow is a TOP-FRAME redirect, not a popup
+
+First real packaged-build sign-in attempt surfaced one more blocker: clicking
+"Continue with Google" did nothing (eternal button spinner, no window). The
+serving stack was healthy — DNS, loopback https, `allowed_origins` all verified
+— and the FAPI `POST /v1/client/sign_ins` returned the Google
+`external_verification_redirect_url` fine.
+
+The wrong assumption was that clerk-js opens the provider in a **popup**
+(`window.open` → `setWindowOpenHandler`). The prebuilt `openSignIn` modal
+actually runs OAuth as a **top-frame redirect** (`window.location = accounts.google.com…`),
+which `lockDownNavigation`'s blanket `will-navigate`/`will-redirect` deny
+silently swallowed. Fix: `lockDownNavigation` takes `allowOriginPatterns`; the
+main window passes `OAUTH_HOST_PATTERNS` **plus its own loopback serving
+origins** — the return leg (`clerk.moxxy.ai → desktop.moxxy.ai:<port>`) is not
+same-origin with the page's mid-flow URL, so the app origins must be explicit.
+The focus window passes nothing and keeps the blanket deny.
+
+Also folded `challenges.cloudflare.com` into CSP `connect-src` (Clerk's
+documented Turnstile set) so the sign-up captcha can't dead-end.

--- a/packages/desktop-host/src/security.test.ts
+++ b/packages/desktop-host/src/security.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { Session } from 'electron';
+import type { BrowserWindow, Session } from 'electron';
 import {
   isSafeProviderName,
   assertSafeProviderName,
@@ -9,6 +9,7 @@ import {
   clerkFrontendApiHost,
   clerkCspHostSources,
   installContentSecurityPolicy,
+  lockDownNavigation,
 } from './security';
 
 describe('provider-name validation', () => {
@@ -35,6 +36,65 @@ describe('provider-name validation', () => {
       expect(isSafeProviderName(bad)).toBe(false);
       expect(() => assertSafeProviderName(bad)).toThrow();
     }
+  });
+});
+
+describe('navigation lockdown', () => {
+  /** Minimal BrowserWindow stand-in: captures the will-navigate/redirect
+   *  guards so a test can replay navigations against them. */
+  function fakeWindow(currentUrl: string): {
+    win: BrowserWindow;
+    setUrl: (u: string) => void;
+    allows: (url: string) => boolean;
+  } {
+    let url = currentUrl;
+    const handlers = new Map<string, (e: { preventDefault: () => void }, u: string) => void>();
+    const wc = {
+      getURL: () => url,
+      on: (ev: string, fn: (e: { preventDefault: () => void }, u: string) => void) => {
+        handlers.set(ev, fn);
+      },
+      setWindowOpenHandler: () => undefined,
+    };
+    return {
+      win: { webContents: wc } as unknown as BrowserWindow,
+      setUrl: (u) => {
+        url = u;
+      },
+      allows: (target) => {
+        let prevented = false;
+        handlers.get('will-navigate')!({ preventDefault: () => (prevented = true) }, target);
+        return !prevented;
+      },
+    };
+  }
+
+  it('blocks every off-origin navigation by default, keeps same-origin', () => {
+    const { win, allows } = fakeWindow('https://desktop.moxxy.ai:51789/');
+    lockDownNavigation(win);
+    expect(allows('https://desktop.moxxy.ai:51789/#focus')).toBe(true);
+    expect(allows('https://accounts.google.com/o/oauth2/auth')).toBe(false);
+    expect(allows('https://evil.example.com/')).toBe(false);
+  });
+
+  it('allows the OAuth round-trip when the hosts are allow-listed', () => {
+    const oauth = [/^https:\/\/accounts\.google\.com$/, /^https:\/\/clerk\.moxxy\.ai$/];
+    const appOrigins = [/^https:\/\/desktop\.moxxy\.ai:(?:51789|51790|51791|51792)$/];
+    const { win, setUrl, allows } = fakeWindow('https://desktop.moxxy.ai:51789/');
+    lockDownNavigation(win, { allowOriginPatterns: [...oauth, ...appOrigins] });
+
+    // app → provider
+    expect(allows('https://accounts.google.com/o/oauth2/auth?x=1')).toBe(true);
+    // provider → FAPI callback (current origin is now Google's)
+    setUrl('https://accounts.google.com/o/oauth2/auth?x=1');
+    expect(allows('https://clerk.moxxy.ai/v1/oauth_callback?code=…')).toBe(true);
+    // FAPI → back to the app: NOT same-origin with the current page, so the
+    // serving origin must be allow-listed explicitly for the return leg.
+    setUrl('https://clerk.moxxy.ai/v1/oauth_callback');
+    expect(allows('https://desktop.moxxy.ai:51789/?__clerk_status=…')).toBe(true);
+    // …and anything else stays blocked even with the allow-list installed.
+    expect(allows('https://evil.example.com/')).toBe(false);
+    expect(allows('not a url')).toBe(false);
   });
 });
 

--- a/packages/desktop-host/src/security.ts
+++ b/packages/desktop-host/src/security.ts
@@ -97,18 +97,40 @@ function sameOrigin(a: string, b: string): boolean {
  * Refuse to navigate the top frame away from the app's own origin and
  * (unless the window installs its own handler) deny `window.open`. An
  * XSS that tries to point the window at a remote page or spawn a
- * privileged popup is stopped here. Hash routing (`#focus`) and the
- * Clerk OAuth popups (which open via the main window's own
- * `setWindowOpenHandler`) are unaffected — those are in-page or handled
- * explicitly.
+ * privileged popup is stopped here. Hash routing (`#focus`) is in-page
+ * and unaffected.
+ *
+ * `allowOriginPatterns` punches a deliberate, narrow hole for the Clerk
+ * OAuth flow: clerk-js's prebuilt sign-in buttons run the provider flow as
+ * a TOP-FRAME redirect (`window.location = accounts.google.com…`), not a
+ * popup — with a blanket deny the click silently no-ops (eternal button
+ * spinner; the original packaged-app sign-in bug). The main window passes
+ * its OAuth host patterns + its own serving origins, so the frame may
+ * round-trip app → provider → Clerk FAPI → back to the app, and nothing
+ * else. Windows that never sign in (focus widget) pass none and keep the
+ * blanket deny.
  */
 export function lockDownNavigation(
   win: BrowserWindow,
-  opts: { readonly keepWindowOpenHandler?: boolean } = {},
+  opts: {
+    readonly keepWindowOpenHandler?: boolean;
+    /** Origins (matched as `URL.origin`) the top frame MAY navigate to. */
+    readonly allowOriginPatterns?: ReadonlyArray<RegExp>;
+  } = {},
 ): void {
   const wc = win.webContents;
+  const allowed = opts.allowOriginPatterns ?? [];
   const guard = (event: { preventDefault: () => void }, url: string): void => {
-    if (!sameOrigin(url, wc.getURL())) event.preventDefault();
+    if (sameOrigin(url, wc.getURL())) return;
+    let origin: string;
+    try {
+      origin = new URL(url).origin;
+    } catch {
+      event.preventDefault();
+      return;
+    }
+    if (allowed.some((re) => re.test(origin))) return;
+    event.preventDefault();
   };
   wc.on('will-navigate', guard);
   wc.on('will-redirect', guard);
@@ -191,7 +213,10 @@ function buildCspDirectives(extraClerkHosts: readonly string[]): string {
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     `img-src 'self' data: blob: https://img.clerk.com https://*.clerk.com${extra}`,
     "font-src 'self' data: https://fonts.gstatic.com",
-    `connect-src 'self' https://*.clerk.accounts.dev https://*.clerk.com${extra}`,
+    // challenges.cloudflare.com: Clerk's bot-protection (Turnstile) runs on
+    // sign-up — Clerk's documented CSP needs it in connect-src too, not just
+    // script/frame-src, or the captcha can fail and sign-up dead-ends.
+    `connect-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com${extra}`,
     "worker-src 'self' blob:",
     `frame-src https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com${extra}`,
     "object-src 'none'",


### PR DESCRIPTION
## What

Fixes the packaged-app sign-in being completely dead ("Continue with Google" spins forever, no window opens; email flows stuck too if the captcha can't load).

- `lockDownNavigation` (desktop-host) gains an explicit `allowOriginPatterns` allow-list. The main window passes `OAUTH_HOST_PATTERNS` **plus its own loopback serving origins** (`https://desktop.moxxy.ai:51789..92`; dev adds the Vite origin) so the top frame can round-trip app → provider → Clerk FAPI → back to the app. Everything else stays blanket-denied; the focus window passes no patterns and keeps the full lockdown.
- CSP `connect-src` adds `challenges.cloudflare.com` (Clerk's documented Turnstile set) so the sign-up bot-protection captcha can't dead-end.
- Two new navigation-lockdown tests: default blanket deny, and the full OAuth round-trip including the return leg (which is *not* same-origin with the page's mid-flow URL — that's why the app origins must be allow-listed explicitly).
- Postscript appended to `docs/desktop-clerk-loopback-subdomain.md`; resolved-ledger entry in TECH_DEBT.md.

## Why

Live diagnosis on a packaged build (hot-update bundle 0.4.0, which already contains the full https-subdomain serving stack): DNS, loopback server, cert and Clerk `allowed_origins` all verified healthy, and `POST /v1/client/sign_ins` returns the Google `external_verification_redirect_url` correctly. The failure was client-side: clerk-js's prebuilt sign-in modal runs OAuth as a **top-frame redirect**, not a popup — so the popup-oriented `setWindowOpenHandler` allow-list was never exercised and the navigation guard silently `preventDefault`ed the redirect. Classic eternal-spinner.

## Verification

- Full gate green after rebase onto main: `pnpm build` / `typecheck` / `lint` (0 errors) / `test` (114 tasks; desktop-host 240/240 incl. the 2 new lockdown tests) / `check:deps`.
- Server-side flow probed live against the production Clerk instance (origin accepted, Google redirect URL issued).
- Remaining manual verify: a real packaged Google round-trip — the redirect reloads the app document mid-flow, which clerk-js handles as a standard SPA return.