### PR TITLE
fix: desktop/mobile fixes wave — runner replay/turnId, agent-driven settings adds, subagent model inheritance, Clerk redirect, canvas + mobile UX

### DIFF
--- a/.changeset/desktop-mobile-fixes-wave.md
+++ b/.changeset/desktop-mobile-fixes-wave.md
@@ -1,0 +1,12 @@
+---
+'@moxxy/runner': minor
+'@moxxy/core': minor
+'@moxxy/desktop-host': patch
+'@moxxy/desktop': patch
+'@moxxy/mobile': patch
+'@moxxy/plugin-subagents': patch
+'@moxxy/plugin-workflows': patch
+'@moxxy/cli': patch
+---
+
+Wave of desktop/mobile fixes. Runner protocol v6 (additive): clients can supply the turn id (`runTurn.turnId`) so renderer per-turn filters actually match — fixing the silently-broken "generate skill with AI" flow and hidden-turn leaks — and `attach` gains a replay policy (`'full' | 'none' | { tail }`) with EventLog rebase so the desktop no longer replays full session history on app start/desk switch (history comes from the paginated NDJSON log). Desktop settings gain a shared "ask moxxy to do it" background-agent modal: the skill generator is refactored onto it and MCP servers and Providers get Add buttons driving `mcp_add_server`/`provider_add`, with permission asks surfaced in-modal (plus a global ask fallback outside the chat view). Subagents now inherit the parent's resolved model: hallucinated model ids warn and fall back, workflow-trigger spawns use the session's last resolved model, and hardcoded model-id fallbacks are gone. Clerk sign-in returns to the app instead of stranding on the hosted My-account page (explicit fallback redirect URLs + a main-process account-portal recovery handler). Workflow canvas: Delete/Backspace removes the selected node and dropping a connector on empty canvas opens an insert-node menu. Mobile: reconnects re-prime the connection store (fixes the deaf "Connected" state after a runner restart), gateway URL commits on blur, the redundant header actions toggle is gone, menu entries are chips, executed tools open a diagnostics panel on tap, and the QR scanner starts scanning immediately.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -428,10 +428,23 @@ change today.
 ### 2. Desktop persists every conversation twice — pick one source of truth — ⚠️ PARTIALLY DONE
 **Found 2026-06-08 (the "NDJSON-vs-replay redundancy" follow-up).** Every committed event
 is written to disk in **two** independent stores:
-- runner session log — `~/.moxxy/sessions/<id>.jsonl`, replayed in full on every attach
-  (`runner/src/server.ts:184` — always replays from seq 0);
+- runner session log — `~/.moxxy/sessions/<id>.jsonl`, replayed on attach
+  (`runner/src/server.ts` `handleAttach`);
 - desktop NDJSON chat-log — `~/.moxxy/chats/<workspaceId>.jsonl`
   (`desktop-host/src/chat-log.ts`), the renderer's windowed mirror.
+
+**Mechanism corrected + replay cost fixed (2026-06-11, runner protocol v6).** Empirically
+the attach replay never reached the renderer at all: the `SessionDriver` subscribes to the
+host-side mirror only AFTER attach completes, so the renderer transcript has always come
+solely from `chat.loadSegment` over the NDJSON store. The replay's only effect on desktop
+was COST — replaying the full event log (~95% `assistant_chunk`) into desktop-host's
+`RemoteSession` mirror on every app start / desk switch / cwd change / reconnect, with the
+composer-ready gate waiting on it. Fixed: `attach` now takes a `replay` param
+(`'full' | 'none' | { tail }`, default `'full'` preserves TUI/`moxxy attach`), the server
+announces the start seq via a `replay.start` notification, the client mirror rebases to it
+(`EventLog.rebase`), and the desktop supervisor attaches with `replay: 'none'`. So the two
+stores are no longer redundant on desktop: the runner JSONL feeds resume/context, the
+NDJSON feeds the renderer transcript.
 
 **Fixed (2026-06-08, PR #107):** the **unbounded NDJSON growth** defect. Because the runner
 replays the full history on every restart and the renderer re-appends each replayed event,
@@ -440,10 +453,12 @@ the NDJSON log used to grow by a complete copy of the conversation per restart �
 pagination. `appendEvents` is now **idempotent by event id** (lazy file-path-keyed id cache),
 so the log holds one copy and its cursors stay stable. +5 chat-log tests.
 
-**Remaining (the real decision):** the redundancy itself. The runner replay already
-delivers the complete history on every attach, so the desktop NDJSON store is arguably
-entirely redundant — dropping it (read history from the runner replay only) would also kill
-the redundant on-restart append IPC and the `/new` desync below. Counter-risk: legacy
+**Remaining (the real decision):** the dual on-disk history itself. The runner session
+JSONL still holds the complete history (replayable via `replay: 'full'` / `{ tail }`), so
+one of the two stores could in principle be retired — but with the desktop now attached via
+`replay: 'none'`, the NDJSON store is the renderer's ONLY history source, so any
+consolidation must move it to the runner log (paged reads), not just delete it.
+Counter-risk: legacy
 localStorage→NDJSON-migrated chats may live ONLY in NDJSON, not in any runner session log,
 so a naive drop loses early-adopter history. **Needs a product call + desktop-app
 verification — not a mechanical change.** Note (2026-06-09): the shared client layer (PR

--- a/apps/desktop/electron/main/floor-runner-protocol.ts
+++ b/apps/desktop/electron/main/floor-runner-protocol.ts
@@ -16,4 +16,4 @@
  * the release build asserts the two match (see scripts/build-app-bundle.mjs),
  * so a forgotten bump fails the build rather than shipping a wrong floor.
  */
-export const FLOOR_RUNNER_PROTOCOL = 5;
+export const FLOOR_RUNNER_PROTOCOL = 6;

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -36,6 +36,8 @@ import {
   lockDownNavigation,
   isSafeExternalUrl,
   clerkFrontendApiHost,
+  clerkAccountPortalHost,
+  installAccountPortalRecovery,
   preferredCliEntry,
   ensureDesktopVaultKey,
   activateManagedNode,
@@ -297,6 +299,23 @@ async function createWindow(): Promise<void> {
   mainWindow.webContents.on('did-start-loading', () => {
     rendererReady = false;
   });
+
+  // Recovery net for the OAuth return leg: when Clerk's FAPI loses the
+  // redirect_url mid-flow it falls back to the hosted Account Portal
+  // (accounts.<domain>) — a host the lockdown's parent-domain wildcard
+  // legitimately allows for the FAPI round-trip — stranding the window on
+  // "My account" instead of back in the app. Detect that landing and load
+  // the app root again (the session cookie is already set, so the user
+  // arrives signed in). Recovery only; the allow-list above is unchanged.
+  const appRootUrl = isDev
+    ? process.env['ELECTRON_RENDERER_URL']
+    : loopback?.url('index.html');
+  if (appRootUrl) {
+    installAccountPortalRecovery(mainWindow, {
+      portalHost: clerkAccountPortalHost(CLERK_PUBLISHABLE_KEY),
+      appUrl: appRootUrl,
+    });
+  }
 
   if (isDev) {
     await mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL']!);

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3,12 +3,15 @@ import { asset } from '@/lib/asset';
 import {
   ConnectionBridge,
   isConnected,
+  useActiveAsk,
   useActiveWorkspaceId,
   useConnection,
   ChatStoreBridge,
   chatStore,
   usePrefs,
 } from '@moxxy/client-core';
+import { AskSheet } from './chat/AskSheet';
+import { useAskSurfaceClaimed } from '@/lib/askSurface';
 import { ConnectionScreen, type UpdateCliResult } from './connection/ConnectionScreen';
 import { Onboarding } from './onboarding/Onboarding';
 import { ChatSurface } from './chat/ChatSurface';
@@ -217,6 +220,31 @@ export function App(): JSX.Element {
         </main>
       )}
       {!connected && <ReconnectBanner label={describePhase(phase)} />}
+      {/* The runner BLOCKS on permission/approval asks. ChatSurface renders
+          them in the chat view and AgentTaskModal claims the surface while a
+          background-agent modal is open — this fallback catches every other
+          view so an ask is never invisible (and never double-rendered). */}
+      {view !== 'chat' && <GlobalAskFallback workspaceId={activeWorkspaceId} />}
+    </div>
+  );
+}
+
+function GlobalAskFallback({ workspaceId }: { readonly workspaceId: string | null }): JSX.Element | null {
+  const ask = useActiveAsk(workspaceId);
+  const claimed = useAskSurfaceClaimed();
+  if (!ask || claimed) return null;
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        left: '50%',
+        bottom: 24,
+        transform: 'translateX(-50%)',
+        width: 'min(620px, calc(100vw - 48px))',
+        zIndex: 60,
+      }}
+    >
+      <AskSheet ask={ask} />
     </div>
   );
 }

--- a/apps/desktop/src/lib/askSurface.ts
+++ b/apps/desktop/src/lib/askSurface.ts
@@ -1,0 +1,40 @@
+/**
+ * Ask-surface ownership. The runner BLOCKS on every `ask.request` until it's
+ * answered, so an ask must never be invisible — but it also must not render
+ * twice. ChatSurface owns asks in the chat view; modals that run hidden agent
+ * turns (AgentTaskModal) claim the surface while mounted; App.tsx renders a
+ * global fallback only when nobody else has claimed it.
+ */
+
+import { useEffect, useSyncExternalStore } from 'react';
+
+let owners = 0;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+/** Claim the ask surface for the lifetime of the calling component. */
+export function useClaimAskSurface(): void {
+  useEffect(() => {
+    owners += 1;
+    emit();
+    return () => {
+      owners -= 1;
+      emit();
+    };
+  }, []);
+}
+
+/** True while any mounted component has claimed the ask surface. */
+export function useAskSurfaceClaimed(): boolean {
+  return useSyncExternalStore(subscribe, () => owners > 0);
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -27,8 +27,18 @@ const CLERK_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 const REDIRECT_ORIGINS =
   /^(https:\/\/desktop\.moxxy\.ai|http:\/\/(127\.0\.0\.1|localhost)):(51789|51790|51791|51792)$/;
 
+// signIn/signUpFallbackRedirectUrl pin the post-auth landing to the app's own
+// origin ('/' resolves against the serving origin above). Without an explicit
+// target, the OAuth code-exchange leg can lose the redirect_url and Clerk's
+// FAPI then falls back to the HOSTED Account Portal (accounts.<domain>) —
+// stranding the desktop window on "My account" instead of back in the app.
 const Tree = CLERK_KEY ? (
-  <ClerkProvider publishableKey={CLERK_KEY} allowedRedirectOrigins={[REDIRECT_ORIGINS]}>
+  <ClerkProvider
+    publishableKey={CLERK_KEY}
+    allowedRedirectOrigins={[REDIRECT_ORIGINS]}
+    signInFallbackRedirectUrl="/"
+    signUpFallbackRedirectUrl="/"
+  >
     <App />
   </ClerkProvider>
 ) : (

--- a/apps/desktop/src/settings/AddWithAgent.test.tsx
+++ b/apps/desktop/src/settings/AddWithAgent.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * "Ask moxxy to do it" Add buttons on the MCP / Providers tabs:
+ *   1. Each tab renders its CTA in the Section actions slot.
+ *   2. Clicking it opens the shared AgentTaskModal with the right title.
+ *   3. Without an active workspace the modal says so and the CTA is disabled
+ *      (the same guard the skill generate flow has).
+ */
+
+import { describe, expect, it, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { __setApiOverride } from '@moxxy/client-core';
+import { McpTab } from './McpTab';
+import { ProvidersTab } from './ProvidersTab';
+
+function installFakeApi(): void {
+  __setApiOverride({
+    invoke: (() => Promise.resolve(undefined)) as never,
+    subscribe: (() => () => undefined) as never,
+  } as never);
+}
+
+afterEach(() => {
+  __setApiOverride(null);
+});
+
+describe('settings Add buttons (agent-task flows)', () => {
+  it('McpTab: "Add server" opens the agent-task modal', () => {
+    installFakeApi();
+    render(<McpTab servers={[]} onToggle={() => Promise.resolve()} onRefresh={() => Promise.resolve()} />);
+    fireEvent.click(screen.getByRole('button', { name: /add server/i }));
+    expect(screen.getByText('Add MCP server')).toBeTruthy();
+    expect(screen.getByText(/describe the server/i)).toBeTruthy();
+    // No active workspace in this harness — the guard must surface.
+    expect(screen.getByText(/no active workspace/i)).toBeTruthy();
+  });
+
+  it('ProvidersTab: "Add provider" opens the agent-task modal', () => {
+    installFakeApi();
+    render(<ProvidersTab providers={[]} onRefresh={() => Promise.resolve()} />);
+    fireEvent.click(screen.getByRole('button', { name: /add provider/i }));
+    expect(screen.getByText('Add provider', { selector: 'h2, h3, header *' })).toBeTruthy();
+    expect(screen.getByText(/describe the provider/i)).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/settings/McpTab.tsx
+++ b/apps/desktop/src/settings/McpTab.tsx
@@ -2,26 +2,40 @@
  * MCP servers tab — Model Context Protocol servers the runner knows about.
  * Each Row's Switch reflects the LIVE attach state (`connected`), not the
  * persisted `enabled` flag, so toggling on enables+attaches and off detaches.
+ * "Add server" opens the shared agent-task modal: the user describes the
+ * server, moxxy tests + registers it in a hidden background turn.
  */
 
-import { Icon } from '@moxxy/desktop-ui';
+import { useState } from 'react';
+import { Button, Icon } from '@moxxy/desktop-ui';
 import { Section, CardList, Row, Tile, Switch, EmptyState } from './settings-primitives';
+import { AgentTaskModal } from './shared/AgentTaskModal';
+import { MCP_PROMPT_TEMPLATE } from './mcp-prompt';
 
 export function McpTab({
   servers,
   onToggle,
+  onRefresh,
   search,
 }: {
   readonly servers: ReadonlyArray<{ name: string; enabled: boolean; connected: boolean }>;
   readonly onToggle: (name: string, enabled: boolean) => Promise<void>;
+  readonly onRefresh: () => Promise<void>;
   readonly search?: React.ReactNode;
 }): JSX.Element {
+  const [adding, setAdding] = useState(false);
   return (
     <Section
       title="MCP servers"
       count={servers.length}
       description="Model Context Protocol servers. Toggle one on to attach its tools to the agent."
       search={search}
+      actions={
+        <Button variant="cta" onClick={() => setAdding(true)} style={{ gap: 7 }}>
+          <Icon name="plus" size={14} />
+          Add server
+        </Button>
+      }
     >
       {servers.length === 0 ? (
         <EmptyState icon="plug" text="No MCP servers configured." />
@@ -58,6 +72,18 @@ export function McpTab({
             />
           ))}
         </CardList>
+      )}
+      {adding && (
+        <AgentTaskModal
+          title="Add MCP server"
+          label="Describe the server"
+          placeholder="e.g. The official GitHub MCP server from npm, using my GITHUB_TOKEN for auth."
+          hint="Moxxy sets it up in the background — it tests connectivity, keeps any secret in the vault, then registers the server."
+          buildPrompt={MCP_PROMPT_TEMPLATE}
+          onComplete={onRefresh}
+          doneLabel="Done"
+          onClose={() => setAdding(false)}
+        />
       )}
     </Section>
   );

--- a/apps/desktop/src/settings/ProvidersTab.tsx
+++ b/apps/desktop/src/settings/ProvidersTab.tsx
@@ -2,24 +2,39 @@
  * Providers tab — the model providers the connected runner can route to. Each
  * provider is a Row with a deterministic colour-tinted initial Tile and a
  * ready/inactive StatusDot; add a provider's key in the vault to activate it.
+ * "Add provider" opens the shared agent-task modal: the user names the
+ * vendor, moxxy registers it in a hidden background turn.
  */
 
+import { useState } from 'react';
 import type { useSettings } from '@moxxy/client-core';
+import { Button, Icon } from '@moxxy/desktop-ui';
 import { Section, CardList, Row, Tile, StatusDot, EmptyState } from './settings-primitives';
+import { AgentTaskModal } from './shared/AgentTaskModal';
+import { PROVIDER_PROMPT_TEMPLATE } from './provider-prompt';
 
 export function ProvidersTab({
   providers,
+  onRefresh,
   search,
 }: {
   readonly providers: ReturnType<typeof useSettings>['providers'];
+  readonly onRefresh: () => Promise<void>;
   readonly search?: React.ReactNode;
 }): JSX.Element {
+  const [adding, setAdding] = useState(false);
   return (
     <Section
       title="Providers"
       count={providers.length}
       description="Model providers the runner can route to. Add a provider's key in the vault to activate it."
       search={search}
+      actions={
+        <Button variant="cta" onClick={() => setAdding(true)} style={{ gap: 7 }}>
+          <Icon name="plus" size={14} />
+          Add provider
+        </Button>
+      }
     >
       {providers.length === 0 ? (
         <EmptyState icon="spark" text="No providers known to the connected runner." />
@@ -42,6 +57,18 @@ export function ProvidersTab({
             );
           })}
         </CardList>
+      )}
+      {adding && (
+        <AgentTaskModal
+          title="Add provider"
+          label="Describe the provider"
+          placeholder="e.g. DeepSeek — I'll add the API key to the vault afterwards."
+          hint="Moxxy registers the provider in the background with the vendor's well-known defaults. Your API key stays in the vault."
+          buildPrompt={PROVIDER_PROMPT_TEMPLATE}
+          onComplete={onRefresh}
+          doneLabel="Done"
+          onClose={() => setAdding(false)}
+        />
       )}
     </Section>
   );

--- a/apps/desktop/src/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/settings/SettingsPanel.tsx
@@ -117,6 +117,7 @@ export function SettingsPanel({
           {tab === 'providers' && (
             <ProvidersTab
               providers={providers}
+              onRefresh={s.refresh}
               search={<SearchBox value={query} onChange={setQuery} placeholder="Search providers…" />}
             />
           )}
@@ -124,6 +125,7 @@ export function SettingsPanel({
             <McpTab
               servers={mcp}
               onToggle={s.toggleMcp}
+              onRefresh={s.refresh}
               search={<SearchBox value={query} onChange={setQuery} placeholder="Search MCP servers…" />}
             />
           )}

--- a/apps/desktop/src/settings/mcp-prompt.ts
+++ b/apps/desktop/src/settings/mcp-prompt.ts
@@ -1,0 +1,26 @@
+/**
+ * Prompt template for the "Add MCP server" agent flow — wraps the user's
+ * free-text description in an instruction that drives the runner's MCP admin
+ * tools (mcp_test_server → mcp_add_server) with the vault rules baked in.
+ */
+export const MCP_PROMPT_TEMPLATE = (description: string): string => `You are
+setting up a new MCP (Model Context Protocol) server for the user, using the
+MCP admin tools.
+
+1. Derive the server config from the description below. Use kind "stdio"
+   for local packages — command "npx" with args ["-y", "<package>"] for npm
+   packages, or "uvx" for Python ones — and kind "http" or "sse" for remote
+   URLs. Pick a short slug-like name.
+2. NEVER put API keys or tokens in plaintext env/header values. If the user
+   supplied a secret, store it first with vault_set, then reference it as
+   "\${vault:NAME}". If a required secret is missing, stop and ask for it
+   instead of guessing.
+3. Verify connectivity with mcp_test_server first, then persist with
+   mcp_add_server.
+
+Finish with a single short line confirming what was added (server name +
+transport), or a single clear question if you are blocked. No code fences,
+no long explanations.
+
+USER DESCRIPTION:
+${description}`.trim();

--- a/apps/desktop/src/settings/provider-prompt.ts
+++ b/apps/desktop/src/settings/provider-prompt.ts
@@ -1,0 +1,24 @@
+/**
+ * Prompt template for the "Add provider" agent flow — wraps the user's
+ * free-text description in an instruction that drives the runner's provider
+ * admin tools (provider_add / provider_test) with the vault rules baked in.
+ */
+export const PROVIDER_PROMPT_TEMPLATE = (description: string): string => `You are
+registering a new LLM provider for the user, using the provider admin tools.
+
+1. Call provider_add with kind "openai-compat", a short slug name, the
+   vendor's baseURL, a defaultModel, and a models list (id + contextWindow
+   at minimum). For vendors you recognise (deepseek, groq, openrouter,
+   together, fireworks, mistral, z.ai, …) use their well-known baseURL and
+   current flagship models instead of asking.
+2. NEVER ask for or echo a plaintext API key. The user stores it themselves
+   as the vault entry <NAME>_API_KEY (Settings → Vault, or /vault set). If
+   they say the key is already stored, verify it with provider_test
+   (baseURL + keyName).
+
+Finish with a single short line confirming the provider was registered and
+which vault key activates it, or a single clear question if you are blocked.
+No code fences, no long explanations.
+
+USER DESCRIPTION:
+${description}`.trim();

--- a/apps/desktop/src/settings/shared/AgentTaskModal.tsx
+++ b/apps/desktop/src/settings/shared/AgentTaskModal.tsx
@@ -1,0 +1,188 @@
+/**
+ * Shared "ask moxxy to do it" modal — takes a free-text description, wraps it
+ * with the caller's prompt template, and runs it as a hidden background agent
+ * turn (useAgentTask), streaming the assistant's reply into a preview.
+ *
+ * The agent's tools may gate on permission asks while the user is here (away
+ * from the chat's AskSheet), so the modal embeds its own AskSheet and claims
+ * the global ask surface while mounted — otherwise the runner would block on
+ * an invisible prompt forever.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { useActiveAsk, useActiveWorkspaceId } from '@moxxy/client-core';
+import { Button, Icon, Modal, TextArea } from '@moxxy/desktop-ui';
+import { MarkdownBody } from '@/chat/MarkdownBody';
+import { AskSheet } from '@/chat/AskSheet';
+import { useClaimAskSurface } from '@/lib/askSurface';
+import { useAgentTask, type AgentTaskPhase } from './useAgentTask';
+
+export function AgentTaskModal({
+  title,
+  label,
+  placeholder,
+  hint,
+  buildPrompt,
+  onComplete,
+  doneLabel,
+  onClose,
+  onUseOutput,
+}: {
+  readonly title: string;
+  readonly label: string;
+  readonly placeholder: string;
+  readonly hint: string;
+  readonly buildPrompt: (description: string) => string;
+  /** Awaited (e.g. section refresh) before the CTA flips to `doneLabel`. */
+  readonly onComplete?: () => Promise<void>;
+  readonly doneLabel: string;
+  readonly onClose: () => void;
+  /** When set, the done CTA hands the output off instead of closing. */
+  readonly onUseOutput?: (output: string) => void;
+}): JSX.Element {
+  const workspaceId = useActiveWorkspaceId();
+  const [description, setDescription] = useState('');
+  const task = useAgentTask(workspaceId);
+
+  // Permission asks raised by the agent's tools must surface HERE — the
+  // chat's AskSheet isn't visible from settings. Claiming the surface also
+  // suppresses the App-level fallback so the ask never double-renders.
+  useClaimAskSurface();
+  const ask = useActiveAsk(workspaceId);
+
+  // Hold the "done" CTA until onComplete (the section refresh) has settled,
+  // so the list behind the modal already shows the agent's work. A refresh
+  // failure isn't a generation failure — the section owns its own error
+  // chrome — so we finalize either way.
+  const [finalized, setFinalized] = useState(false);
+  const completeRan = useRef(false);
+  useEffect(() => {
+    if (task.phase !== 'done' || completeRan.current) return;
+    completeRan.current = true;
+    let cancelled = false;
+    void (onComplete?.() ?? Promise.resolve())
+      .catch(() => undefined)
+      .then(() => {
+        if (!cancelled) setFinalized(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [task.phase, onComplete]);
+
+  // A turn that "succeeds" without producing any output is a failure from the
+  // user's point of view — never present it as silent success.
+  const emptyDone = task.phase === 'done' && finalized && task.output.trim().length === 0;
+  const phase: AgentTaskPhase = emptyDone
+    ? 'error'
+    : task.phase === 'done' && !finalized
+      ? 'streaming'
+      : task.phase;
+  const error = emptyDone ? 'Generation produced no output.' : task.error;
+
+  const onStart = async (): Promise<void> => {
+    if (!workspaceId || !description.trim()) return;
+    completeRan.current = false;
+    setFinalized(false);
+    await task.start(buildPrompt(description.trim()));
+  };
+
+  return (
+    <Modal title={title} onClose={onClose} width={760}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <span style={{ fontSize: 12.5, fontWeight: 600, color: 'var(--color-text-muted)' }}>
+            {label}
+          </span>
+          <TextArea
+            tone="soft"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder={placeholder}
+            disabled={phase === 'streaming'}
+            style={{ minHeight: 110, padding: '12px 14px', fontSize: 13, lineHeight: 1.6 }}
+          />
+        </label>
+        <span style={{ fontSize: 11.5, color: 'var(--color-text-dim)' }}>
+          {workspaceId ? hint : 'No active workspace — open one before generating.'}
+        </span>
+        {(phase === 'streaming' || phase === 'done' || phase === 'error') && (
+          <section
+            style={{
+              border: '1px solid var(--color-card-border)',
+              borderRadius: 12,
+              overflow: 'hidden',
+              background: '#fff',
+            }}
+          >
+            <header
+              style={{
+                padding: '8px 12px',
+                background: '#f4f5fb',
+                borderBottom: '1px solid var(--color-card-border)',
+                fontSize: 11,
+                fontWeight: 700,
+                color: 'var(--color-text-dim)',
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+              }}
+            >
+              Preview {phase === 'streaming' && '· streaming'}
+            </header>
+            <div
+              style={{
+                maxHeight: 360,
+                overflowY: 'auto',
+                padding: 16,
+              }}
+            >
+              {task.output ? (
+                <MarkdownBody text={task.output} streaming={phase === 'streaming'} />
+              ) : (
+                <p style={{ margin: 0, fontSize: 12, color: 'var(--color-text-dim)' }}>
+                  Waiting for the first chunk…
+                </p>
+              )}
+            </div>
+          </section>
+        )}
+        {ask && <AskSheet ask={ask} />}
+        {error && (
+          <p role="alert" style={{ margin: 0, fontSize: 12, color: 'var(--color-red)' }}>
+            {error}
+          </p>
+        )}
+        <footer style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          {(() => {
+            // One primary action that morphs by phase: Generate → Generating…
+            // → doneLabel (shown in the same spot once output exists).
+            const ready = phase === 'done' && task.output.trim().length > 0;
+            const canGenerate = !!workspaceId && description.trim().length > 0;
+            const disabled = phase === 'streaming' || (!ready && !canGenerate);
+            return (
+              <Button
+                variant="cta"
+                onClick={
+                  ready
+                    ? () => (onUseOutput ? onUseOutput(task.output) : onClose())
+                    : () => void onStart()
+                }
+                disabled={disabled}
+                style={{ padding: '8px 16px', opacity: disabled ? 0.5 : 1 }}
+              >
+                <Icon name={ready ? 'check' : 'spark'} size={14} />
+                {phase === 'streaming' ? 'Generating…' : ready ? doneLabel : 'Generate'}
+              </Button>
+            );
+          })()}
+        </footer>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/desktop/src/settings/shared/useAgentTask.test.tsx
+++ b/apps/desktop/src/settings/shared/useAgentTask.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * useAgentTask — the shared "ask moxxy to do it" background-turn hook.
+ * Locks down:
+ *   1. start() invokes session.runTurn and hides the turn from the transcript.
+ *   2. runner.event chunks are mirrored only for the matching turnId
+ *      (assistant_message replaces the accumulated text).
+ *   3. runner.turn.complete flips to done/error and unhides the turn;
+ *      completes for other turns are ignored.
+ *   4. Unmount unhides the turn even mid-stream (cleanup).
+ *   5. Without a workspace, start() is a no-op.
+ */
+
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { __setApiOverride, chatStore } from '@moxxy/client-core';
+import { useAgentTask } from './useAgentTask';
+
+interface IpcSpy {
+  invokes: Array<{ channel: string; args: unknown }>;
+  emit: (channel: string, payload: unknown) => void;
+}
+
+function installFakeApi(): IpcSpy {
+  const invokes: Array<{ channel: string; args: unknown }> = [];
+  const subs = new Map<string, Set<(payload: unknown) => void>>();
+
+  __setApiOverride({
+    invoke: ((channel: string, args: unknown) => {
+      invokes.push({ channel, args });
+      if (channel === 'session.runTurn') return Promise.resolve({ turnId: 't-1' });
+      return Promise.resolve(undefined);
+    }) as never,
+    subscribe: ((channel: string, cb: (payload: unknown) => void) => {
+      let set = subs.get(channel);
+      if (!set) {
+        set = new Set();
+        subs.set(channel, set);
+      }
+      set.add(cb);
+      return () => {
+        set?.delete(cb);
+      };
+    }) as never,
+  } as never);
+
+  return {
+    invokes,
+    emit: (channel, payload) => {
+      const set = subs.get(channel);
+      if (set) for (const cb of set) cb(payload);
+    },
+  };
+}
+
+const chunk = (turnId: string, delta: string): unknown => ({
+  workspaceId: 'ws-test',
+  event: { type: 'assistant_chunk', turnId, delta },
+});
+
+const message = (turnId: string, content: string): unknown => ({
+  workspaceId: 'ws-test',
+  event: { type: 'assistant_message', turnId, content, stopReason: 'end_turn' },
+});
+
+const complete = (turnId: string, error: string | null): unknown => ({
+  workspaceId: 'ws-test',
+  turnId,
+  error,
+});
+
+afterEach(() => {
+  __setApiOverride(null);
+  vi.restoreAllMocks();
+});
+
+describe('useAgentTask', () => {
+  it('start() runs a hidden turn and mirrors only matching chunks', async () => {
+    const spy = installFakeApi();
+    const hide = vi.spyOn(chatStore, 'hideTurn');
+    const { result } = renderHook(() => useAgentTask('ws-test'));
+
+    expect(result.current.phase).toBe('idle');
+    await act(async () => {
+      await result.current.start('PROMPT');
+    });
+
+    const run = spy.invokes.find((i) => i.channel === 'session.runTurn');
+    expect(run).toBeTruthy();
+    expect(run!.args).toEqual({ workspaceId: 'ws-test', prompt: 'PROMPT' });
+    expect(hide).toHaveBeenCalledWith('t-1');
+    expect(result.current.phase).toBe('streaming');
+
+    act(() => {
+      spy.emit('runner.event', chunk('t-1', 'Hello '));
+      spy.emit('runner.event', chunk('t-OTHER', 'NOPE'));
+      spy.emit('runner.event', chunk('t-1', 'world'));
+    });
+    expect(result.current.output).toBe('Hello world');
+
+    // assistant_message replaces the accumulated stream.
+    act(() => {
+      spy.emit('runner.event', message('t-1', 'final text'));
+    });
+    expect(result.current.output).toBe('final text');
+  });
+
+  it('turn completion flips to done and unhides; foreign completes are ignored', async () => {
+    const spy = installFakeApi();
+    const unhide = vi.spyOn(chatStore, 'unhideTurn');
+    const { result } = renderHook(() => useAgentTask('ws-test'));
+
+    await act(async () => {
+      await result.current.start('PROMPT');
+    });
+    act(() => {
+      spy.emit('runner.turn.complete', complete('t-OTHER', null));
+    });
+    expect(result.current.phase).toBe('streaming');
+
+    act(() => {
+      spy.emit('runner.turn.complete', complete('t-1', null));
+    });
+    expect(result.current.phase).toBe('done');
+    expect(result.current.error).toBeNull();
+    expect(unhide).toHaveBeenCalledWith('t-1');
+  });
+
+  it('turn completion with an error flips to error', async () => {
+    const spy = installFakeApi();
+    const { result } = renderHook(() => useAgentTask('ws-test'));
+
+    await act(async () => {
+      await result.current.start('PROMPT');
+    });
+    act(() => {
+      spy.emit('runner.turn.complete', complete('t-1', 'provider exploded'));
+    });
+    expect(result.current.phase).toBe('error');
+    expect(result.current.error).toBe('provider exploded');
+  });
+
+  it('unmount unhides the in-flight turn (cleanup)', async () => {
+    installFakeApi();
+    const unhide = vi.spyOn(chatStore, 'unhideTurn');
+    const { result, unmount } = renderHook(() => useAgentTask('ws-test'));
+
+    await act(async () => {
+      await result.current.start('PROMPT');
+    });
+    expect(unhide).not.toHaveBeenCalled();
+    unmount();
+    expect(unhide).toHaveBeenCalledWith('t-1');
+  });
+
+  it('is a no-op without an active workspace', async () => {
+    const spy = installFakeApi();
+    const { result } = renderHook(() => useAgentTask(null));
+
+    await act(async () => {
+      await result.current.start('PROMPT');
+    });
+    expect(spy.invokes.find((i) => i.channel === 'session.runTurn')).toBeUndefined();
+    expect(result.current.phase).toBe('idle');
+  });
+
+  it('surfaces a runTurn rejection as an error phase', async () => {
+    installFakeApi();
+    __setApiOverride({
+      invoke: (() => Promise.reject(new Error('runner offline'))) as never,
+      subscribe: (() => () => undefined) as never,
+    } as never);
+    const { result } = renderHook(() => useAgentTask('ws-test'));
+
+    await act(async () => {
+      await result.current.start('PROMPT');
+    });
+    expect(result.current.phase).toBe('error');
+    expect(result.current.error).toMatch(/runner offline/);
+  });
+});

--- a/apps/desktop/src/settings/shared/useAgentTask.ts
+++ b/apps/desktop/src/settings/shared/useAgentTask.ts
@@ -1,0 +1,84 @@
+/**
+ * "Ask moxxy to do it" — runs a one-off background agent task as a real
+ * runner turn against the active workspace's session (the only path to the
+ * model from this thin client), but HIDES the turn from the transcript via
+ * `chatStore.hideTurn` so it never pollutes the chat. Assistant chunks are
+ * mirrored into local state for an in-modal preview.
+ *
+ * Lifted from the GenerateSkillModal flow so the skill / MCP / provider
+ * settings flows all share one mechanism.
+ */
+
+import { useEffect, useState } from 'react';
+import { api, chatStore, toErrorMessage } from '@moxxy/client-core';
+import type { MoxxyEvent } from '@moxxy/sdk';
+
+export type AgentTaskPhase = 'idle' | 'streaming' | 'done' | 'error';
+
+export interface AgentTask {
+  readonly phase: AgentTaskPhase;
+  readonly output: string;
+  readonly error: string | null;
+  readonly start: (prompt: string) => Promise<void>;
+}
+
+export function useAgentTask(workspaceId: string | null): AgentTask {
+  const [phase, setPhase] = useState<AgentTaskPhase>('idle');
+  const [output, setOutput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [turnId, setTurnId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!turnId) return;
+    const offEvent = api().subscribe(
+      'runner.event',
+      ({ event: ev }: { workspaceId: string; event: MoxxyEvent }) => {
+        if (ev.turnId !== turnId) return;
+        if (ev.type === 'assistant_chunk') {
+          setOutput((cur) => cur + ev.delta);
+        } else if (ev.type === 'assistant_message') {
+          setOutput(ev.content);
+        }
+      },
+    );
+    const offDone = api().subscribe(
+      'runner.turn.complete',
+      ({ turnId: id, error: err }: { workspaceId: string; turnId: string; error: string | null }) => {
+        if (id !== turnId) return;
+        chatStore.unhideTurn(id);
+        if (err) {
+          setPhase('error');
+          setError(err);
+        } else {
+          setPhase('done');
+        }
+      },
+    );
+    return () => {
+      offEvent();
+      offDone();
+      chatStore.unhideTurn(turnId);
+    };
+  }, [turnId]);
+
+  const start = async (prompt: string): Promise<void> => {
+    if (!workspaceId || phase === 'streaming') return;
+    setPhase('streaming');
+    setOutput('');
+    setError(null);
+    try {
+      const { turnId: id } = await api().invoke('session.runTurn', { workspaceId, prompt });
+      // Hide BEFORE we start reading: the runner echoes a user_prompt + the
+      // assistant output for this turn, and none of it should reach the
+      // transcript. We deliberately do NOT dispatch send_started either, so
+      // the chat never shows a phantom "sending" turn.
+      chatStore.hideTurn(id);
+      setTurnId(id);
+    } catch (e) {
+      setPhase('error');
+      setError(toErrorMessage(e));
+    }
+  };
+
+  return { phase, output, error, start };
+}

--- a/apps/desktop/src/settings/skills/GenerateSkillModal.tsx
+++ b/apps/desktop/src/settings/skills/GenerateSkillModal.tsx
@@ -1,20 +1,11 @@
 /**
- * "Generate skill with AI" modal. Takes a free-text description and runs it as
- * a real runner turn against the active workspace's session — the only path to
- * the model from this thin client — but HIDES the turn from the transcript via
- * `chatStore.hideTurn`, mirroring the assistant chunks into a local preview.
- * On confirm the draft is handed to the Create modal so the user can tweak the
- * filename and body before persisting.
+ * "Generate skill with AI" modal — a thin wrapper over the shared
+ * AgentTaskModal (hidden background runner turn + streamed preview). On
+ * confirm the draft is handed to the Create modal via `onUseGenerated` so the
+ * user can tweak the filename and body before persisting.
  */
 
-import { useEffect, useState } from 'react';
-import { toErrorMessage } from '@moxxy/client-core';
-import { useActiveWorkspaceId } from '@moxxy/client-core';
-import { chatStore } from '@moxxy/client-core';
-import { api } from '@moxxy/client-core';
-import { Button, Icon, Modal, TextArea } from '@moxxy/desktop-ui';
-import { MarkdownBody } from '@/chat/MarkdownBody';
-import type { MoxxyEvent } from '@moxxy/sdk';
+import { AgentTaskModal } from '../shared/AgentTaskModal';
 import { SKILL_PROMPT_TEMPLATE } from './skill-prompt';
 
 export function GenerateSkillModal({
@@ -24,169 +15,16 @@ export function GenerateSkillModal({
   readonly onCancel: () => void;
   readonly onUseGenerated: (content: string) => void;
 }): JSX.Element {
-  const workspaceId = useActiveWorkspaceId();
-  const [description, setDescription] = useState('');
-  const [phase, setPhase] = useState<'idle' | 'streaming' | 'done' | 'error'>('idle');
-  const [generated, setGenerated] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [turnId, setTurnId] = useState<string | null>(null);
-
-  // The generation runs as a real runner turn (the only path to the model
-  // from this thin client), but the turn is HIDDEN from the transcript via
-  // chatStore.hideTurn — so it never pollutes the chat. We mirror the
-  // assistant chunks into local state for the in-modal preview.
-  useEffect(() => {
-    if (!turnId) return;
-    const offEvent = api().subscribe(
-      'runner.event',
-      ({ event: ev }: { workspaceId: string; event: MoxxyEvent }) => {
-        if (ev.turnId !== turnId) return;
-        if (ev.type === 'assistant_chunk') {
-          setGenerated((cur) => cur + ev.delta);
-        } else if (ev.type === 'assistant_message') {
-          setGenerated(ev.content);
-        }
-      },
-    );
-    const offDone = api().subscribe(
-      'runner.turn.complete',
-      ({ turnId: id, error: err }: { workspaceId: string; turnId: string; error: string | null }) => {
-        if (id !== turnId) return;
-        chatStore.unhideTurn(id);
-        if (err) {
-          setPhase('error');
-          setError(err);
-        } else {
-          setPhase('done');
-        }
-      },
-    );
-    return () => {
-      offEvent();
-      offDone();
-      chatStore.unhideTurn(turnId);
-    };
-  }, [turnId]);
-
-  const onGenerate = async (): Promise<void> => {
-    if (!workspaceId || !description.trim()) return;
-    setPhase('streaming');
-    setGenerated('');
-    setError(null);
-    try {
-      const { turnId: id } = await api().invoke('session.runTurn', {
-        workspaceId,
-        prompt: SKILL_PROMPT_TEMPLATE(description.trim()),
-      });
-      // Hide BEFORE we start reading: the runner echoes a user_prompt + the
-      // assistant output for this turn, and none of it should reach the
-      // transcript. We deliberately do NOT dispatch send_started either, so
-      // the chat never shows a phantom "sending" turn.
-      chatStore.hideTurn(id);
-      setTurnId(id);
-    } catch (e) {
-      setPhase('error');
-      setError(toErrorMessage(e));
-    }
-  };
-
   return (
-    <Modal title="Generate skill with AI" onClose={onCancel} width={760}>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-        <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-          <span style={{ fontSize: 12.5, fontWeight: 600, color: 'var(--color-text-muted)' }}>
-            Describe the skill
-          </span>
-          <TextArea
-            tone="soft"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="e.g. A skill that summarises long URLs by fetching them, extracting the headline and key bullets, and citing each source link."
-            disabled={phase === 'streaming'}
-            style={{ minHeight: 110, padding: '12px 14px', fontSize: 13, lineHeight: 1.6 }}
-          />
-        </label>
-        <span style={{ fontSize: 11.5, color: 'var(--color-text-dim)' }}>
-          {workspaceId
-            ? 'Generated privately — it stays here in the editor and never shows in the chat.'
-            : 'No active workspace — open one before generating.'}
-        </span>
-        {(phase === 'streaming' || phase === 'done' || phase === 'error') && (
-          <section
-            style={{
-              border: '1px solid var(--color-card-border)',
-              borderRadius: 12,
-              overflow: 'hidden',
-              background: '#fff',
-            }}
-          >
-            <header
-              style={{
-                padding: '8px 12px',
-                background: '#f4f5fb',
-                borderBottom: '1px solid var(--color-card-border)',
-                fontSize: 11,
-                fontWeight: 700,
-                color: 'var(--color-text-dim)',
-                textTransform: 'uppercase',
-                letterSpacing: '0.06em',
-                display: 'flex',
-                alignItems: 'center',
-                gap: 6,
-              }}
-            >
-              Preview {phase === 'streaming' && '· streaming'}
-            </header>
-            <div
-              style={{
-                maxHeight: 360,
-                overflowY: 'auto',
-                padding: 16,
-              }}
-            >
-              {generated ? (
-                <MarkdownBody text={generated} streaming={phase === 'streaming'} />
-              ) : (
-                <p style={{ margin: 0, fontSize: 12, color: 'var(--color-text-dim)' }}>
-                  Waiting for the first chunk…
-                </p>
-              )}
-            </div>
-          </section>
-        )}
-        {error && (
-          <p role="alert" style={{ margin: 0, fontSize: 12, color: 'var(--color-red)' }}>
-            {error}
-          </p>
-        )}
-        <footer style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
-          <Button variant="secondary" onClick={onCancel}>
-            Cancel
-          </Button>
-          {(() => {
-            // One primary action that morphs by phase: Generate → Generating…
-            // → Use this skill (shown in the same spot once a draft exists).
-            const ready = phase === 'done' && generated.trim().length > 0;
-            const canGenerate = !!workspaceId && description.trim().length > 0;
-            const disabled = phase === 'streaming' || (!ready && !canGenerate);
-            return (
-              <Button
-                variant="cta"
-                onClick={ready ? () => onUseGenerated(generated) : () => void onGenerate()}
-                disabled={disabled}
-                style={{ padding: '8px 16px', opacity: disabled ? 0.5 : 1 }}
-              >
-                <Icon name={ready ? 'check' : 'spark'} size={14} />
-                {phase === 'streaming'
-                  ? 'Generating…'
-                  : ready
-                    ? 'Use this skill'
-                    : 'Generate'}
-              </Button>
-            );
-          })()}
-        </footer>
-      </div>
-    </Modal>
+    <AgentTaskModal
+      title="Generate skill with AI"
+      label="Describe the skill"
+      placeholder="e.g. A skill that summarises long URLs by fetching them, extracting the headline and key bullets, and citing each source link."
+      hint="Generated privately — it stays here in the editor and never shows in the chat."
+      buildPrompt={SKILL_PROMPT_TEMPLATE}
+      doneLabel="Use this skill"
+      onClose={onCancel}
+      onUseOutput={onUseGenerated}
+    />
   );
 }

--- a/apps/desktop/src/shell/workspace-sidebar/ProfilePill.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/ProfilePill.tsx
@@ -72,7 +72,12 @@ export function ProfilePill(): JSX.Element {
       <button
         type="button"
         className="row-button"
-        onClick={() => void clerk.openSignIn()}
+        // Explicit redirect targets, mirroring the ClerkProvider fallback
+        // props: keep the post-OAuth landing on the app's own origin so the
+        // FAPI never falls back to the hosted Account Portal.
+        onClick={() =>
+          void clerk.openSignIn({ fallbackRedirectUrl: '/', signUpFallbackRedirectUrl: '/' })
+        }
         style={profileRowStyle('var(--color-primary-strong)')}
       >
         <Icon name="agent" size={14} style={{ flexShrink: 0 }} />

--- a/apps/desktop/src/workflows/WorkflowCanvas.tsx
+++ b/apps/desktop/src/workflows/WorkflowCanvas.tsx
@@ -1,12 +1,15 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
+  STEP_KINDS,
   stepKindMeta,
+  uniqueId,
   WORKFLOW_ERROR_KEY,
   wouldCreateCycle,
   type BuilderAction,
   type BuilderEdge,
   type BuilderNode,
   type BuilderState,
+  type StepKind,
 } from '@moxxy/workflows-builder';
 import { accentHex } from './accents';
 
@@ -22,7 +25,13 @@ import { accentHex } from './accents';
  *   - on a connection HANDLE (the small circles on a card's edges) → draw a
  *     CONNECTION (connect.current); on pointerup over a target node it
  *     dispatches the matching graph op. These connections ARE the execution
- *     order: a `needs` edge from A→B means A runs before B.
+ *     order: a `needs` edge from A→B means A runs before B. Releasing over
+ *     EMPTY canvas instead opens the insert menu: pick a step kind to create
+ *     it at the drop point already wired to the pending edge (Escape or
+ *     click-away cancels).
+ *
+ * Keyboard: Delete/Backspace removes the selected node (suppressed while a
+ * text field has focus); Escape dismisses the insert menu.
  *
  * Handles per kind (outputs initiate a drag, inputs/targets receive it):
  *   - every node: a right-edge OUTPUT (plain `needs`) + a left-edge INPUT.
@@ -70,6 +79,19 @@ interface PendingConnection {
   readonly oy: number;
 }
 
+/** A connection dropped on empty canvas, parked while the insert menu is open. */
+interface InsertMenuState {
+  /** Source node + port of the pending edge. */
+  readonly nodeId: string;
+  readonly port: PortKind;
+  /** Drop point in content coords (the new node's input anchor lands here). */
+  readonly x: number;
+  readonly y: number;
+  /** Pending-edge origin, kept so the preview line stays drawn. */
+  readonly ox: number;
+  readonly oy: number;
+}
+
 const EDGE_STYLE: Record<BuilderEdge['kind'], { color: string; dash?: string; label?: string }> = {
   needs: { color: '#94a3b8' },
   then: { color: '#10b981', label: 'then' },
@@ -110,6 +132,7 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
   const [panning, setPanning] = useState(false);
   /** Set on pan end so the synthetic click that follows doesn't deselect. */
   const suppressClick = useRef(false);
+  const [insertMenu, setInsertMenu] = useState<InsertMenuState | null>(null);
 
   const byId = useMemo(() => new Map(state.nodes.map((n) => [n.id, n])), [state.nodes]);
 
@@ -177,6 +200,27 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
     return () => el.removeEventListener('wheel', onWheel);
   }, [applyZoom, zoom]);
 
+  // Keyboard: Delete/Backspace removes the selected node + its edges (same op
+  // as the inspector's Delete button); Escape dismisses the insert menu,
+  // cancelling its pending edge. Skipped while typing in a field so editing
+  // text never nukes a node. (Edges aren't selectable — they delete via the
+  // midpoint ✕ — so there's no edge case here.)
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        setInsertMenu(null);
+        return;
+      }
+      if (e.key !== 'Delete' && e.key !== 'Backspace') return;
+      if (state.selected == null || isEditableTarget(e.target)) return;
+      e.preventDefault();
+      setInsertMenu(null);
+      dispatch({ type: 'remove-step', id: state.selected });
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [dispatch, state.selected]);
+
   const flashReject = useCallback((msg: string) => {
     setReject(msg);
     if (rejectTimer.current) clearTimeout(rejectTimer.current);
@@ -188,6 +232,7 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
     (e: React.PointerEvent, node: BuilderNode) => {
       e.stopPropagation();
       (e.target as Element).setPointerCapture?.(e.pointerId);
+      setInsertMenu(null);
       const p = surfacePoint(e);
       drag.current = { id: node.id, dx: p.x - node.x, dy: p.y - node.y };
       setDragging(node.id);
@@ -201,6 +246,7 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
     (e: React.PointerEvent, node: BuilderNode, port: PortKind) => {
       e.stopPropagation();
       (e.target as Element).setPointerCapture?.(e.pointerId);
+      setInsertMenu(null);
       const origin = portOrigin(node, port);
       const start: PendingConnection = { nodeId: node.id, port, ox: origin.x, oy: origin.y };
       connect.current = start;
@@ -214,20 +260,31 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
   // --- background pan (canvas drag) ---
   // Node bodies and handles stopPropagation on pointerdown, so anything that
   // reaches the surface here is empty canvas (or an edge) → start panning.
-  const onSurfacePointerDown = useCallback((e: React.PointerEvent) => {
-    if (e.button !== 0) return;
-    const el = surfaceRef.current;
-    if (!el) return;
-    (e.target as Element).setPointerCapture?.(e.pointerId);
-    pan.current = {
-      x: e.clientX,
-      y: e.clientY,
-      left: el.scrollLeft,
-      top: el.scrollTop,
-      moved: false,
-    };
-    setPanning(true);
-  }, []);
+  const onSurfacePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      // Truthy = non-primary button. (Not `!== 0`: jsdom test events have no
+      // PointerEvent, so `button` arrives undefined there.)
+      if (e.button) return;
+      if (insertMenu) {
+        // Click-away dismisses the insert menu (cancels the pending edge);
+        // swallow the gesture so it doesn't also start a pan.
+        setInsertMenu(null);
+        return;
+      }
+      const el = surfaceRef.current;
+      if (!el) return;
+      (e.target as Element).setPointerCapture?.(e.pointerId);
+      pan.current = {
+        x: e.clientX,
+        y: e.clientY,
+        left: el.scrollLeft,
+        top: el.scrollTop,
+        moved: false,
+      };
+      setPanning(true);
+    },
+    [insertMenu],
+  );
 
   const onPointerMove = useCallback(
     (e: React.PointerEvent) => {
@@ -265,7 +322,12 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
       setHoverTarget(null);
       if (!c) return;
       const targetId = nodeAt(state.nodes, p, c.nodeId);
-      if (!targetId) return; // dropped on empty canvas → cancel, no-op
+      if (!targetId) {
+        // Dropped on empty canvas → offer to insert a node right there, wired
+        // to the pending connection (Escape / click-away cancels).
+        setInsertMenu({ nodeId: c.nodeId, port: c.port, x: p.x, y: p.y, ox: c.ox, oy: c.oy });
+        return;
+      }
       const target = byId.get(targetId);
       const source = byId.get(c.nodeId);
       if (!target || !source || target.id === source.id) return;
@@ -305,6 +367,41 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
       }
     },
     [byId, dispatch, flashReject, state],
+  );
+
+  // Insert a node of `kind` at the menu's drop point and wire the pending edge
+  // to it, through the same ops the drop-on-node path dispatches. The id is
+  // precomputed (uniqueId) because dispatch can't return the id add-step picks;
+  // sequential dispatches reduce in order, so the wire op sees the new node.
+  const insertFromMenu = useCallback(
+    (kind: StepKind) => {
+      const menu = insertMenu;
+      setInsertMenu(null);
+      if (!menu) return;
+      const source = byId.get(menu.nodeId);
+      if (!source) return;
+      const id = uniqueId(state, kind);
+      const x = Math.max(0, menu.x);
+      // Offset so the new node's left input anchor lands at the drop point.
+      const y = Math.max(0, menu.y - ANCHOR_OFFSET);
+      switch (menu.port) {
+        case 'needs':
+          dispatch({ type: 'add-step', input: { kind, id, x, y, after: source.id } });
+          return;
+        case 'then':
+        case 'else': {
+          dispatch({ type: 'add-step', input: { kind, id, x, y } });
+          const current = (menu.port === 'then' ? source.then : source.else) ?? [];
+          dispatch({ type: 'set-branch', nodeId: source.id, slot: menu.port, targets: [...current, id] });
+          return;
+        }
+        case 'loop-exit':
+          dispatch({ type: 'add-step', input: { kind, id, x, y } });
+          dispatch({ type: 'set-loop-exit', loopId: source.id, targetId: id });
+          return;
+      }
+    },
+    [byId, dispatch, insertMenu, state],
   );
 
   const onPointerUp = useCallback(
@@ -420,6 +517,13 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
             );
           })}
           {pending && cursor && <TempLine from={{ x: pending.ox, y: pending.oy }} to={cursor} port={pending.port} />}
+          {insertMenu && byId.has(insertMenu.nodeId) && (
+            <TempLine
+              from={{ x: insertMenu.ox, y: insertMenu.oy }}
+              to={{ x: insertMenu.x, y: insertMenu.y }}
+              port={insertMenu.port}
+            />
+          )}
         </svg>
 
         {state.nodes.map((node) => (
@@ -436,6 +540,10 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
             onHandlePointerDown={(e, port) => onHandlePointerDown(e, node, port)}
           />
         ))}
+
+        {insertMenu && byId.has(insertMenu.nodeId) && (
+          <InsertNodeMenu menu={insertMenu} zoom={zoom} onPick={insertFromMenu} />
+        )}
 
         {state.nodes.length === 0 && (
           <div
@@ -549,6 +657,93 @@ function ZoomControls({
       >
         +
       </button>
+    </div>
+  );
+}
+
+/**
+ * The drop-on-empty-canvas insert menu: pick a step kind to create it at the
+ * drop point, pre-wired to the pending connection. Lives inside the scaled
+ * content layer (so it tracks the drop point through pan/zoom) but counter-
+ * scales itself to stay readable at any zoom level.
+ */
+function InsertNodeMenu({
+  menu,
+  zoom,
+  onPick,
+}: {
+  readonly menu: InsertMenuState;
+  readonly zoom: number;
+  readonly onPick: (kind: StepKind) => void;
+}): JSX.Element {
+  return (
+    <div
+      data-testid="insert-node-menu"
+      // Own the gesture: a pointerdown/click inside the menu must not pan the
+      // canvas, dismiss the menu, or deselect.
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+      style={{
+        position: 'absolute',
+        left: menu.x,
+        top: menu.y,
+        transform: `scale(${1 / zoom})`,
+        transformOrigin: '0 0',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        padding: 4,
+        minWidth: 160,
+        background: 'var(--color-bg-card)',
+        border: '1px solid var(--color-border)',
+        borderRadius: 'var(--radius-block)',
+        boxShadow: 'var(--color-card-shadow)',
+        zIndex: 6,
+      }}
+    >
+      <span
+        style={{
+          fontSize: '0.6rem',
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          letterSpacing: '0.04em',
+          color: 'var(--color-text-dim)',
+          padding: '2px 6px',
+        }}
+      >
+        Insert step
+      </span>
+      {STEP_KINDS.map((k) => (
+        <button
+          key={k.kind}
+          type="button"
+          data-testid={`insert-add-${k.kind}`}
+          title={k.description}
+          onClick={() => onPick(k.kind)}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            fontSize: '0.74rem',
+            fontWeight: 600,
+            padding: '0.28rem 0.5rem',
+            textAlign: 'left',
+            color: 'var(--color-text)',
+            borderRadius: 6,
+          }}
+        >
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              background: accentHex(k.accent),
+              flexShrink: 0,
+            }}
+          />
+          {k.label}
+        </button>
+      ))}
     </div>
   );
 }
@@ -1010,6 +1205,14 @@ function disconnectEdge(dispatch: (a: BuilderAction) => void, edge: BuilderEdge,
       dispatch({ type: 'set-loop-exit', loopId: edge.from, targetId: null });
       return;
   }
+}
+
+/** True when a key event originated in a text-editing element (don't delete). */
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  const tag = target.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
 }
 
 /** The node whose card contains the point (excluding `exclude`), or null. */

--- a/apps/desktop/src/workflows/WorkflowsPanel.test.tsx
+++ b/apps/desktop/src/workflows/WorkflowsPanel.test.tsx
@@ -393,15 +393,59 @@ describe('WorkflowsPanel — canvas drag-to-connect', () => {
     expect(await screen.findByTestId('wf-edge-needs:prompt->prompt_2')).toBeInTheDocument();
   });
 
-  it('pointerup on empty canvas cancels — no edge, no stuck temp line', async () => {
+  it('pointerup on empty canvas opens the insert menu; Escape cancels the pending edge', async () => {
     await twoNodes();
     const canvas = screen.getByTestId('workflow-canvas');
     firePointer(screen.getByTestId('wf-handle-prompt-needs-right'), 'pointerDown', 240, 84, 2);
     firePointer(canvas, 'pointerMove', 700, 500, 2);
     expect(screen.getByTestId('temp-connection')).toBeInTheDocument(); // line is live mid-drag
     firePointer(canvas, 'pointerUp', 700, 500, 2);
+    // Released on empty canvas → the insert menu offers to create a node there
+    // (the pending line stays as a preview).
+    expect(await screen.findByTestId('insert-node-menu')).toBeInTheDocument();
+    expect(screen.getByTestId('temp-connection')).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByTestId('insert-node-menu')).not.toBeInTheDocument();
     expect(screen.queryByTestId('temp-connection')).not.toBeInTheDocument(); // cleared
     expect(screen.queryByTestId('wf-edge-needs:prompt->prompt_2')).not.toBeInTheDocument();
+  });
+
+  it('picking a kind from the insert menu creates the node at the drop point, wired to the edge', async () => {
+    await openWith();
+    fireEvent.click(screen.getByTestId('palette-add-prompt')); // id "prompt" @ (40,40)
+    await screen.findByTestId('wf-node-prompt');
+    dragConnect('wf-handle-prompt-needs-right', 240, 84, 500, 300); // empty spot
+    const menu = await screen.findByTestId('insert-node-menu');
+    fireEvent.click(within(menu).getByTestId('insert-add-skill'));
+    // The new node exists, the pending `needs` edge landed on it, menu closed.
+    expect(await screen.findByTestId('wf-node-skill')).toBeInTheDocument();
+    expect(await screen.findByTestId('wf-edge-needs:prompt->skill')).toBeInTheDocument();
+    expect(screen.queryByTestId('insert-node-menu')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('temp-connection')).not.toBeInTheDocument();
+  });
+
+  it("inserting from a condition's 'then' handle wires the branch to the new node", async () => {
+    await openWith();
+    fireEvent.click(screen.getByTestId('palette-add-condition')); // id "condition" @ (40,40)
+    await screen.findByTestId('wf-node-condition');
+    dragConnect('wf-handle-condition-then-right', 240, 70, 500, 300);
+    const menu = await screen.findByTestId('insert-node-menu');
+    fireEvent.click(within(menu).getByTestId('insert-add-prompt'));
+    expect(await screen.findByTestId('wf-node-prompt')).toBeInTheDocument();
+    expect(await screen.findByTestId('wf-edge-then:condition->prompt')).toBeInTheDocument();
+  });
+
+  it('clicking away on the canvas dismisses the insert menu without inserting', async () => {
+    await openWith();
+    fireEvent.click(screen.getByTestId('palette-add-prompt'));
+    await screen.findByTestId('wf-node-prompt');
+    dragConnect('wf-handle-prompt-needs-right', 240, 84, 500, 300);
+    await screen.findByTestId('insert-node-menu');
+    firePointer(screen.getByTestId('workflow-canvas'), 'pointerDown', 700, 500, 3);
+    expect(screen.queryByTestId('insert-node-menu')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('temp-connection')).not.toBeInTheDocument();
+    // Only the original node remains.
+    expect(screen.queryByTestId('wf-node-prompt_2')).not.toBeInTheDocument();
   });
 
   it('clicking an edge ✕ dispatches disconnect (the edge disappears)', async () => {
@@ -455,5 +499,38 @@ describe('WorkflowsPanel — canvas drag-to-connect', () => {
     dragConnect('wf-handle-condition-then-right', 240, 70, 460, 320);
     // setBranchTargets(condition, 'then', ['prompt']) derives a then edge.
     expect(await screen.findByTestId('wf-edge-then:condition->prompt')).toBeInTheDocument();
+  });
+
+  it('Delete removes the selected node and its edges (same op as the inspector button)', async () => {
+    await twoNodes();
+    dragConnect('wf-handle-prompt-needs-right', 240, 84, 460, 320); // wire A→B
+    await screen.findByTestId('wf-edge-needs:prompt->prompt_2');
+    // Select A by pressing down on its card body.
+    firePointer(screen.getByTestId('wf-node-prompt'), 'pointerDown', 120, 80);
+    firePointer(screen.getByTestId('workflow-canvas'), 'pointerUp', 120, 80);
+    fireEvent.keyDown(window, { key: 'Delete' });
+    await waitFor(() => expect(screen.queryByTestId('wf-node-prompt')).not.toBeInTheDocument());
+    expect(screen.queryByTestId('wf-edge-needs:prompt->prompt_2')).not.toBeInTheDocument();
+    expect(screen.getByTestId('wf-node-prompt_2')).toBeInTheDocument(); // the other node survives
+  });
+
+  it('Backspace removes the selected node', async () => {
+    await openWith();
+    fireEvent.click(screen.getByTestId('palette-add-prompt')); // add-step auto-selects
+    await screen.findByTestId('wf-node-prompt');
+    fireEvent.keyDown(window, { key: 'Backspace' });
+    await waitFor(() => expect(screen.queryByTestId('wf-node-prompt')).not.toBeInTheDocument());
+  });
+
+  it('Delete/Backspace does NOT delete while typing in an inspector field', async () => {
+    await openWith();
+    fireEvent.click(screen.getByTestId('palette-add-prompt'));
+    await screen.findByTestId('wf-node-prompt');
+    // The node auto-selects → the inspector shows; key events from its fields
+    // are text editing, not graph commands.
+    const action = await screen.findByTestId('field-action');
+    fireEvent.keyDown(action, { key: 'Backspace' });
+    fireEvent.keyDown(action, { key: 'Delete' });
+    expect(screen.getByTestId('wf-node-prompt')).toBeInTheDocument();
   });
 });

--- a/apps/mobile/app/chat.tsx
+++ b/apps/mobile/app/chat.tsx
@@ -105,7 +105,6 @@ export default function ChatScreen() {
             pendingActions={pendingActions}
             onToggleMenu={chrome.toggleMenu}
             onNewSession={sessions.newSession}
-            onToggleActions={() => composer.setActionsOpen(!composer.actionsOpen)}
           />
 
           <ComposerCard

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -54,7 +54,6 @@ export default function SettingsScreen() {
         permission={qrScanner.permission}
         ui={pairingUi}
         onRequestPermission={() => void qrScanner.requestPermission()}
-        onArmScanner={qrScanner.armScanner}
         onScanned={(raw) => void qrScanner.handlePayload(raw)}
         onCancel={qrScanner.closeScanner}
       />

--- a/apps/mobile/src/__tests__/mobile-chat-transcript.test.ts
+++ b/apps/mobile/src/__tests__/mobile-chat-transcript.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { buildChatTranscript } from '../chatTranscript';
 
+const pretty = (value: unknown) => JSON.stringify(value, null, 2);
+
 describe('mobile chat transcript model', () => {
   it('folds streamed assistant chunks into one assistant message instead of event cards', () => {
     const transcript = buildChatTranscript([
@@ -85,8 +87,8 @@ describe('mobile chat transcript model', () => {
         collapsed: true,
         summary: '1 ok · 1 running',
         tools: [
-          { id: 'call-1', name: 'Read', status: 'ok', summary: 'path: a.ts' },
-          { id: 'call-2', name: 'Bash', status: 'running', summary: 'command: pwd' },
+          { id: 'call-1', name: 'Read', status: 'ok', summary: 'path: a.ts', input: pretty({ path: 'a.ts' }), output: 'ok' },
+          { id: 'call-2', name: 'Bash', status: 'running', summary: 'command: pwd', input: pretty({ command: 'pwd' }) },
         ],
       },
     ]);
@@ -111,9 +113,9 @@ describe('mobile chat transcript model', () => {
         collapsed: true,
         summary: '2 failed · 1 running',
         tools: [
-          { id: 'call-running', name: 'Read', status: 'running', summary: 'path: a.ts' },
-          { id: 'call-error', name: 'Bash', status: 'error', summary: 'command: bad' },
-          { id: 'call-is-error', name: 'Fetch', status: 'error', summary: 'url: https://example.com' },
+          { id: 'call-running', name: 'Read', status: 'running', summary: 'path: a.ts', input: pretty({ path: 'a.ts' }) },
+          { id: 'call-error', name: 'Bash', status: 'error', summary: 'command: bad', input: pretty({ command: 'bad' }), errorText: 'boom' },
+          { id: 'call-is-error', name: 'Fetch', status: 'error', summary: 'url: https://example.com', input: pretty({ url: 'https://example.com' }), output: 'failed' },
         ],
       },
     ]);
@@ -135,10 +137,41 @@ describe('mobile chat transcript model', () => {
         collapsed: true,
         summary: '1 ok',
         tools: [
-          { id: 'bridge-call', name: 'Read', status: 'ok', summary: 'path: a.ts' },
+          { id: 'bridge-call', name: 'Read', status: 'ok', summary: 'path: a.ts', input: pretty({ path: 'a.ts' }), output: 'ok' },
         ],
       },
     ]);
+  });
+
+  it('retains pretty-printed tool diagnostics and caps huge tool_result outputs', () => {
+    const hugeOutput = 'x'.repeat(64 * 1024);
+    const transcript = buildChatTranscript([
+      { id: 't1', type: 'tool_call_requested', callId: 'call-1', name: 'Read', input: { path: 'a.ts', limit: 5 } },
+      { id: 't2', type: 'tool_result', callId: 'call-1', ok: true, output: hugeOutput },
+    ]);
+
+    const group = transcript.find((item) => item.kind === 'tool-group');
+    const tool = group?.kind === 'tool-group' ? group.tools[0] : undefined;
+
+    expect(tool?.input).toBe(pretty({ path: 'a.ts', limit: 5 }));
+    expect(tool?.output?.startsWith('x'.repeat(100))).toBe(true);
+    expect(tool?.output?.length).toBeLessThan(17 * 1024);
+    expect(tool?.output).toContain('truncated');
+  });
+
+  it('pretty-prints structured tool_result outputs and surfaces denial reasons', () => {
+    const transcript = buildChatTranscript([
+      { id: 't1', type: 'tool_call_requested', callId: 'call-1', name: 'Fetch', input: { url: 'https://a' } },
+      { id: 't2', type: 'tool_result', callId: 'call-1', ok: true, output: { status: 200 } },
+      { id: 't3', type: 'tool_call_requested', callId: 'call-2', name: 'Bash', input: { command: 'rm' } },
+      { id: 't4', type: 'tool_call_denied', callId: 'call-2', reason: 'user said no' },
+    ]);
+
+    const group = transcript.find((item) => item.kind === 'tool-group');
+    const tools = group?.kind === 'tool-group' ? group.tools : [];
+
+    expect(tools[0]).toMatchObject({ status: 'ok', output: pretty({ status: 200 }) });
+    expect(tools[1]).toMatchObject({ status: 'error', errorText: 'user said no' });
   });
 
   it('keeps one tool group when a skill event arrives between request and result', () => {
@@ -161,7 +194,7 @@ describe('mobile chat transcript model', () => {
         collapsed: true,
         summary: '1 ok',
         tools: [
-          { id: 'call-1', name: 'Bash', status: 'ok', summary: 'command: pwd' },
+          { id: 'call-1', name: 'Bash', status: 'ok', summary: 'command: pwd', input: pretty({ command: 'pwd' }), output: 'ok' },
         ],
       },
     ]);

--- a/apps/mobile/src/__tests__/mobile-qr-scan-gate.test.ts
+++ b/apps/mobile/src/__tests__/mobile-qr-scan-gate.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { createQrScanGate } from '../qrScanGate';
 
 describe('mobile QR scan gate', () => {
-  it('stays idle until the user arms scanning and then accepts only one QR payload', () => {
+  it('stays idle until armed and then accepts only one QR payload', () => {
     const gate = createQrScanGate();
 
     expect(gate.tryAcquire()).toBe(false);
@@ -17,7 +17,7 @@ describe('mobile QR scan gate', () => {
     expect(gate.tryAcquire()).toBe(false);
   });
 
-  it('does not scan automatically before the explicit scan action', async () => {
+  it('ignores camera callbacks while the gate is disarmed', async () => {
     const gate = createQrScanGate();
     const scanned: string[] = [];
 
@@ -32,5 +32,24 @@ describe('mobile QR scan gate', () => {
     await handleScan('payload-1');
 
     expect(scanned).toEqual(['payload-1']);
+  });
+
+  // openScanner now auto-arms (reset + arm); the one-shot acquire still
+  // dedupes the burst of onBarcodeScanned callbacks, and closeScanner's
+  // reset means a re-open re-arms from scratch.
+  it('auto-armed open flow accepts the first payload, dedupes the rest, and re-arms after close', () => {
+    const gate = createQrScanGate();
+
+    gate.reset();
+    gate.arm();
+    expect(gate.tryAcquire()).toBe(true);
+    expect(gate.tryAcquire()).toBe(false);
+
+    gate.reset();
+    expect(gate.tryAcquire()).toBe(false);
+
+    gate.reset();
+    gate.arm();
+    expect(gate.tryAcquire()).toBe(true);
   });
 });

--- a/apps/mobile/src/__tests__/mobile-socket-lifecycle.test.ts
+++ b/apps/mobile/src/__tests__/mobile-socket-lifecycle.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import type { ConnectionSnapshot, MoxxyApi } from '@moxxy/desktop-ipc-contract';
+import { refreshConnectionStore, type ConnectionStoreLike } from '../connectionRefresh';
 import { buildConnectionUi, shouldOfferRepair } from '../socketLifecycle';
 
 // The transport (`WsRpcClient`) owns reconnect/backoff, so the lifecycle
@@ -48,5 +50,74 @@ describe('mobile socket lifecycle ui', () => {
       canSend: false,
       shouldOfferRepair: false,
     });
+  });
+});
+
+// `ConnectionBridge` primes the store once per client mount and never
+// retries; the gateway provider re-primes via refreshConnectionStore on
+// every refreshTick so a failed first dial / runner restart can't leave the
+// app deaf on a stale workspace.
+describe('mobile connection store refresh', () => {
+  const snapshot: ConnectionSnapshot = {
+    phase: { phase: 'connected' } as ConnectionSnapshot['phase'],
+    cliPath: null,
+    attempts: 0,
+    log: [],
+  };
+
+  function makeStore() {
+    const snapshots: Array<{ workspaceId: string; snapshot: ConnectionSnapshot }> = [];
+    const actives: Array<string | null> = [];
+    const store: ConnectionStoreLike = {
+      setSnapshot: (workspaceId, next) => snapshots.push({ workspaceId, snapshot: next }),
+      setActive: (workspaceId) => actives.push(workspaceId),
+    };
+    return { store, snapshots, actives };
+  }
+
+  function makeTransport(handlers: Record<string, () => Promise<unknown>>): Pick<MoxxyApi, 'invoke'> {
+    return {
+      invoke: ((command: string) => handlers[command]!()) as MoxxyApi['invoke'],
+    };
+  }
+
+  it('re-primes every workspace snapshot and the active workspace', async () => {
+    const { store, snapshots, actives } = makeStore();
+    await refreshConnectionStore(
+      makeTransport({
+        'connection.snapshotAll': async () => [{ workspaceId: 'ws-2', ...snapshot }],
+        'connection.activeWorkspace': async () => 'ws-2',
+      }),
+      store,
+    );
+
+    expect(snapshots).toEqual([{ workspaceId: 'ws-2', snapshot }]);
+    expect(actives).toEqual(['ws-2']);
+  });
+
+  it('still applies the active workspace when snapshotAll fails (and vice versa)', async () => {
+    const failing = async () => Promise.reject(new Error('not connected'));
+
+    const first = makeStore();
+    await refreshConnectionStore(
+      makeTransport({
+        'connection.snapshotAll': failing,
+        'connection.activeWorkspace': async () => 'ws-1',
+      }),
+      first.store,
+    );
+    expect(first.snapshots).toEqual([]);
+    expect(first.actives).toEqual(['ws-1']);
+
+    const second = makeStore();
+    await refreshConnectionStore(
+      makeTransport({
+        'connection.snapshotAll': async () => [{ workspaceId: 'ws-1', ...snapshot }],
+        'connection.activeWorkspace': failing,
+      }),
+      second.store,
+    );
+    expect(second.snapshots).toEqual([{ workspaceId: 'ws-1', snapshot }]);
+    expect(second.actives).toEqual([]);
   });
 });

--- a/apps/mobile/src/__tests__/mobile-tool-group-ui.test.ts
+++ b/apps/mobile/src/__tests__/mobile-tool-group-ui.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildToolGroupUi } from '../toolGroupUi';
+import { buildToolDiagnostics, buildToolGroupUi } from '../toolGroupUi';
 
 describe('mobile tool group ui', () => {
   it('surfaces running as the primary collapsed status', () => {
@@ -22,5 +22,27 @@ describe('mobile tool group ui', () => {
       summary: '1 failed · 1 running',
       pulse: false,
     });
+  });
+});
+
+describe('mobile tool diagnostics', () => {
+  it('expands a tapped tool into input, output, then error sections', () => {
+    expect(buildToolDiagnostics({
+      id: 't1',
+      name: 'Bash',
+      status: 'error',
+      summary: 'command: rm',
+      input: '{\n  "command": "rm"\n}',
+      output: 'partial output',
+      errorText: 'denied',
+    })).toEqual([
+      { kind: 'input', text: '{\n  "command": "rm"\n}' },
+      { kind: 'output', text: 'partial output' },
+      { kind: 'error', text: 'denied' },
+    ]);
+  });
+
+  it('yields no sections (row not expandable) when the events carried no detail', () => {
+    expect(buildToolDiagnostics({ id: 't1', name: 'Read', status: 'running', summary: '' })).toEqual([]);
   });
 });

--- a/apps/mobile/src/chatTranscript.ts
+++ b/apps/mobile/src/chatTranscript.ts
@@ -58,6 +58,12 @@ export interface ToolTranscriptItem {
   readonly name: string;
   readonly status: 'running' | 'ok' | 'error';
   readonly summary: string;
+  /** Pretty-printed tool input, capped — for the tap-to-expand diagnostics. */
+  readonly input?: string;
+  /** Pretty-printed tool output, capped (tool_result frames can be huge). */
+  readonly output?: string;
+  /** Error/denial message when the call failed. */
+  readonly errorText?: string;
 }
 
 export interface ErrorTranscriptItem {
@@ -260,23 +266,52 @@ function upsertTool(
   const id = toolCallId(event) || `tool-${index}`;
   const existing = tools.find((tool) => tool.id === id);
   const status = toolStatus(type, event);
+  const input = toolDetail(event.input) || existing?.input || '';
+  const output =
+    (type === 'tool_result' || type === 'tool_call_completed' ? toolDetail(event.output) : '') ||
+    existing?.output ||
+    '';
+  const errorText = toolErrorText(type, event) || existing?.errorText || '';
   const next: ToolTranscriptItem = {
     id,
     name: firstText(event.name, event.toolName, event.command, event.title) || existing?.name || 'Tool',
     status,
     summary: summarizeToolInput(event.input) || existing?.summary || firstText(event.command, event.path, event.title),
+    ...(input ? { input } : {}),
+    ...(output ? { output } : {}),
+    ...(errorText ? { errorText } : {}),
   };
   if (!existing) return [...tools, next];
-  return tools.map((tool) =>
-    tool.id === id
-      ? {
-          ...tool,
-          name: next.name || tool.name,
-          status,
-          summary: next.summary || tool.summary,
-        }
-      : tool,
-  );
+  return tools.map((tool) => (tool.id === id ? next : tool));
+}
+
+// tool_result frames can carry entire file reads — cap what the transcript
+// retains so the chat list never holds megabytes per tool row.
+const TOOL_DETAIL_MAX_CHARS = 16_384;
+
+function toolDetail(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  const text = typeof value === 'string' ? value : safeJson(value);
+  if (text.length <= TOOL_DETAIL_MAX_CHARS) return text;
+  return `${text.slice(0, TOOL_DETAIL_MAX_CHARS)}\n… truncated (${text.length} chars)`;
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function toolErrorText(type: string, event: Record<string, unknown>): string {
+  if (type === 'tool_call_denied') return firstText(event.reason, event.message) || 'Tool call denied';
+  if (type !== 'tool_result' && type !== 'tool_call_completed') return '';
+  const error = event.error;
+  if (typeof error === 'string') return error;
+  if (!error || typeof error !== 'object') return '';
+  const payload = error as Record<string, unknown>;
+  return firstText(payload.message, payload.reason, payload.kind);
 }
 
 function toolStatus(type: string, event: Record<string, unknown>): ToolTranscriptItem['status'] {

--- a/apps/mobile/src/components/ChatList.tsx
+++ b/apps/mobile/src/components/ChatList.tsx
@@ -1,4 +1,4 @@
-import { Pressable, ScrollView, Text, View } from 'react-native';
+import { Platform, Pressable, ScrollView, Text, View } from 'react-native';
 import { useState } from 'react';
 import { summarizeAttachment } from '@/attachments';
 import type { AssistantTranscriptItem, SystemGroupTranscriptItem, ToolGroupTranscriptItem, TranscriptItem } from '@/chatTranscript';
@@ -6,7 +6,7 @@ import type { PromptAttachment } from '@/clientFrames';
 import { shouldShowThinkingIndicator } from '@/chatListState';
 import { useChatListAutoScroll } from '@/hooks/useChatListAutoScroll';
 import { buildMessageActions } from '@/messageActions';
-import { buildToolGroupUi } from '@/toolGroupUi';
+import { buildToolDiagnostics, buildToolGroupUi, type ToolDiagnosticsSection } from '@/toolGroupUi';
 import { MobileIcon } from './MobileIcon';
 import { ThinkingIndicator } from './ThinkingIndicator';
 
@@ -244,6 +244,9 @@ function AssistantMessage({
 
 function ToolGroupMessage({ group }: { readonly group: ToolGroupTranscriptItem }) {
   const [open, setOpen] = useState(false);
+  const [openToolIds, setOpenToolIds] = useState<ReadonlyArray<string>>([]);
+  const toggleTool = (id: string) =>
+    setOpenToolIds((ids) => (ids.includes(id) ? ids.filter((value) => value !== id) : [...ids, id]));
   const ui = buildToolGroupUi(group.tools);
 
   return (
@@ -299,35 +302,54 @@ function ToolGroupMessage({ group }: { readonly group: ToolGroupTranscriptItem }
         </Pressable>
         {open ? (
           <View className="mt-2 overflow-hidden rounded-block border border-cardBorder bg-cardBg">
-            {group.tools.map((tool, index) => (
-              <View
-                key={tool.id}
-                style={{
-                  borderTopColor: '#e3e5f0',
-                  borderTopWidth: index === 0 ? 0 : 1,
-                  paddingHorizontal: 10,
-                  paddingVertical: 8,
-                }}
-              >
-                <View style={{ alignItems: 'center', flexDirection: 'row', gap: 8 }}>
-                  <View
-                    style={{
-                      backgroundColor: statusColor(tool.status),
-                      borderRadius: 999,
-                      height: 7,
-                      width: 7,
-                    }}
-                  />
-                  <Text className="text-[12px] font-bold text-text">{tool.name}</Text>
-                  <Text className="text-[11px] font-bold text-dim">{statusLabel(tool.status)}</Text>
-                </View>
-                {tool.summary ? (
-                  <Text className="mt-1 text-[11px] leading-4 text-muted" numberOfLines={2}>
-                    {tool.summary}
-                  </Text>
-                ) : null}
-              </View>
-            ))}
+            {group.tools.map((tool, index) => {
+              const diagnostics = buildToolDiagnostics(tool);
+              const toolOpen = openToolIds.includes(tool.id);
+              return (
+                <Pressable
+                  key={tool.id}
+                  accessibilityRole="button"
+                  accessibilityState={{ expanded: toolOpen }}
+                  disabled={diagnostics.length === 0}
+                  onPress={() => toggleTool(tool.id)}
+                  style={{
+                    borderTopColor: '#e3e5f0',
+                    borderTopWidth: index === 0 ? 0 : 1,
+                    paddingHorizontal: 10,
+                    paddingVertical: 8,
+                  }}
+                >
+                  <View style={{ alignItems: 'center', flexDirection: 'row', gap: 8 }}>
+                    <View
+                      style={{
+                        backgroundColor: statusColor(tool.status),
+                        borderRadius: 999,
+                        height: 7,
+                        width: 7,
+                      }}
+                    />
+                    <Text className="text-[12px] font-bold text-text">{tool.name}</Text>
+                    <Text className="text-[11px] font-bold text-dim">{statusLabel(tool.status)}</Text>
+                    <View style={{ flex: 1 }} />
+                    {diagnostics.length > 0 ? (
+                      <Text className="text-[14px] font-bold text-dim">{toolOpen ? '-' : '+'}</Text>
+                    ) : null}
+                  </View>
+                  {tool.summary ? (
+                    <Text className="mt-1 text-[11px] leading-4 text-muted" numberOfLines={2}>
+                      {tool.summary}
+                    </Text>
+                  ) : null}
+                  {toolOpen ? (
+                    <View style={{ gap: 6, marginTop: 8 }}>
+                      {diagnostics.map((section) => (
+                        <ToolDiagnosticsBlock key={section.kind} section={section} />
+                      ))}
+                    </View>
+                  ) : null}
+                </Pressable>
+              );
+            })}
           </View>
         ) : null}
       </View>
@@ -367,6 +389,29 @@ function SystemGroupMessage({ group }: { readonly group: SystemGroupTranscriptIt
           </View>
         ) : null}
       </View>
+    </View>
+  );
+}
+
+const MONO_FONT = Platform.select({ android: 'monospace', ios: 'Menlo', default: 'monospace' });
+
+function ToolDiagnosticsBlock({ section }: { readonly section: ToolDiagnosticsSection }) {
+  return (
+    <View className="overflow-hidden rounded-block border border-cardBorder bg-white" style={{ maxHeight: 240 }}>
+      <ScrollView nestedScrollEnabled style={{ maxHeight: 240 }}>
+        <Text
+          style={{
+            color: section.kind === 'error' ? '#ef4444' : '#334155',
+            fontFamily: MONO_FONT,
+            fontSize: 11,
+            lineHeight: 16,
+            paddingHorizontal: 10,
+            paddingVertical: 8,
+          }}
+        >
+          {section.text}
+        </Text>
+      </ScrollView>
     </View>
   );
 }

--- a/apps/mobile/src/components/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/ConnectionSettings.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { Pressable, Switch, Text, TextInput, View } from 'react-native';
 import type { CameraPermissionState } from '../pairingUi';
 import { buildPairingUiState } from '../pairingUi';
@@ -26,6 +27,15 @@ interface ConnectionSettingsProps {
 }
 
 export function ConnectionSettings(props: ConnectionSettingsProps) {
+  // Draft URL stays local while typing — committing per keystroke would churn
+  // the WS client (the socket effect re-dials on every gatewayUrl change).
+  const [draftUrl, setDraftUrl] = useState(props.gatewayUrl);
+  useEffect(() => {
+    setDraftUrl(props.gatewayUrl);
+  }, [props.gatewayUrl]);
+  const commitDraftUrl = () => {
+    if (draftUrl !== props.gatewayUrl) props.onGatewayUrlChange(draftUrl);
+  };
   const canPair = props.code.length > 0 && !props.loading;
   const pairingUi = buildPairingUiState({
     token: props.token,
@@ -63,8 +73,10 @@ export function ConnectionSettings(props: ConnectionSettingsProps) {
         {props.manualPairingOpen || pairingUi.manualPairingVisible ? (
           <View className="gap-3">
             <TextInput
-              value={props.gatewayUrl}
-              onChangeText={props.onGatewayUrlChange}
+              value={draftUrl}
+              onChangeText={setDraftUrl}
+              onBlur={commitDraftUrl}
+              onSubmitEditing={commitDraftUrl}
               autoCapitalize="none"
               autoCorrect={false}
               inputMode="url"

--- a/apps/mobile/src/components/FloatingChatHeader.tsx
+++ b/apps/mobile/src/components/FloatingChatHeader.tsx
@@ -7,7 +7,6 @@ interface FloatingChatHeaderProps {
   readonly pendingActions: number;
   readonly onToggleMenu: () => void;
   readonly onNewSession: () => void;
-  readonly onToggleActions: () => void;
 }
 
 export function FloatingChatHeader({
@@ -16,7 +15,6 @@ export function FloatingChatHeader({
   pendingActions,
   onToggleMenu,
   onNewSession,
-  onToggleActions,
 }: FloatingChatHeaderProps) {
   return (
     <View
@@ -83,14 +81,6 @@ export function FloatingChatHeader({
             onPress={onNewSession}
           >
             <MobileIcon name="edit" size={19} strokeWidth={2.3} color="#475569" />
-          </Pressable>
-          <Pressable
-            accessibilityLabel="More actions"
-            className="items-center justify-center rounded-block"
-            style={{ borderRadius: 9, height: 36, width: 36 }}
-            onPress={onToggleActions}
-          >
-            <MobileIcon name="more" size={20} strokeWidth={2.7} color="#475569" />
           </Pressable>
         </View>
     </View>

--- a/apps/mobile/src/components/MobileMenuSheet.tsx
+++ b/apps/mobile/src/components/MobileMenuSheet.tsx
@@ -117,7 +117,7 @@ export function MobileMenuSheet({
           </View>
         ) : null}
 
-        <View className="mt-8 gap-1">
+        <View className="mt-8 flex-row flex-wrap gap-2">
           {items.map((item) => (
             <MenuActionRow
               key={`${item.kind}-${item.label}`}
@@ -302,11 +302,12 @@ function MenuActionRow({
   readonly onCommand: (name: string, args?: string) => void;
 }) {
   const content = (
-    <View className="min-h-12 flex-row items-center gap-4 rounded-block" style={{ paddingVertical: 6 }}>
-      <View className="h-9 w-9 items-center justify-center">
-        <MobileIcon name={item.icon} size={22} strokeWidth={2.25} color="#0f172a" />
-      </View>
-      <Text className="flex-1 text-[18px] font-bold text-text">{item.label}</Text>
+    <View
+      className="flex-row items-center gap-2 rounded-pill border border-cardBorder bg-cardBg px-4 py-2 shadow-card"
+      style={{ shadowOpacity: 0.1 }}
+    >
+      <MobileIcon name={item.icon} size={18} strokeWidth={2.25} color="#0f172a" />
+      <Text className="text-[14px] font-bold text-text">{item.label}</Text>
     </View>
   );
 

--- a/apps/mobile/src/components/QrScannerSheet.tsx
+++ b/apps/mobile/src/components/QrScannerSheet.tsx
@@ -10,7 +10,6 @@ interface QrScannerSheetProps {
   readonly permission: CameraPermissionState;
   readonly ui: PairingUiState;
   readonly onRequestPermission: () => void;
-  readonly onArmScanner: () => void;
   readonly onScanned: (raw: string) => void;
   readonly onCancel: () => void;
 }
@@ -22,7 +21,6 @@ export function QrScannerSheet({
   permission,
   ui,
   onRequestPermission,
-  onArmScanner,
   onScanned,
   onCancel,
 }: QrScannerSheetProps) {
@@ -53,16 +51,12 @@ export function QrScannerSheet({
                 <View className={`h-56 w-56 rounded-card border-2 ${armed ? 'border-primary' : 'border-white/80'}`} />
               </View>
               <View className="absolute bottom-4 left-4 right-4">
-                <Pressable
-                  className={`min-h-12 flex-row items-center justify-center gap-2 rounded-block ${armed || processing ? 'bg-primarySoft' : 'bg-primary'}`}
-                  disabled={armed || processing}
-                  onPress={onArmScanner}
-                >
-                  <MobileIcon name="camera" color={armed || processing ? '#db2777' : '#ffffff'} size={20} />
-                  <Text className={`text-[14px] font-black ${armed || processing ? 'text-primaryStrong' : 'text-white'}`}>
-                    {processing ? 'Pairing...' : armed ? 'Looking for QR...' : 'Scan QR code'}
+                <View className="min-h-12 flex-row items-center justify-center gap-2 rounded-block bg-primarySoft">
+                  <MobileIcon name="camera" color="#db2777" size={20} />
+                  <Text className="text-[14px] font-black text-primaryStrong">
+                    {processing ? 'Pairing...' : 'Looking for QR...'}
                   </Text>
-                </Pressable>
+                </View>
               </View>
             </View>
           ) : (

--- a/apps/mobile/src/connectionRefresh.ts
+++ b/apps/mobile/src/connectionRefresh.ts
@@ -1,0 +1,37 @@
+/**
+ * Re-primes the client-core connection store from the gateway.
+ *
+ * `ConnectionBridge` fetches `connection.snapshotAll` / `connection.activeWorkspace`
+ * exactly once per client mount with swallowed catches — if that first attempt
+ * races a failed dial (the WS client clears its outbox on connect failure) the
+ * store keeps a null workspace forever while the socket header says Connected.
+ * The moxxy-mobile host also mints a NEW workspace id per runner restart, so a
+ * reconnect must re-resolve the active workspace, not just resubscribe. The
+ * gateway provider calls this on every successful (re)connect (`refreshTick`).
+ */
+
+import { connectionStore } from '@moxxy/client-core';
+import type { ConnectionSnapshot, MoxxyApi } from '@moxxy/desktop-ipc-contract';
+
+export interface ConnectionStoreLike {
+  setSnapshot(workspaceId: string, snapshot: ConnectionSnapshot): void;
+  setActive(workspaceId: string | null): void;
+}
+
+export async function refreshConnectionStore(
+  transport: Pick<MoxxyApi, 'invoke'>,
+  store: ConnectionStoreLike = connectionStore,
+): Promise<void> {
+  // Independent settle: a failure of one call must not drop the other's result
+  // (mirrors ConnectionBridge's per-call catches).
+  const [snapshots, active] = await Promise.allSettled([
+    transport.invoke('connection.snapshotAll'),
+    transport.invoke('connection.activeWorkspace'),
+  ]);
+  if (snapshots.status === 'fulfilled') {
+    for (const { workspaceId, ...snapshot } of snapshots.value) {
+      store.setSnapshot(workspaceId, snapshot);
+    }
+  }
+  if (active.status === 'fulfilled') store.setActive(active.value);
+}

--- a/apps/mobile/src/hooks/useGatewayStore.tsx
+++ b/apps/mobile/src/hooks/useGatewayStore.tsx
@@ -43,6 +43,7 @@ import {
   emptyLocalUiState,
   type MobileState,
 } from '../protocol';
+import { refreshConnectionStore } from '../connectionRefresh';
 import { normalizeGatewayUrl } from '../pairingUrl';
 import { usePairing, type PairingState } from './usePairing';
 import { useAutoApprove } from './useAutoApprove';
@@ -84,7 +85,20 @@ function useSessionInfo(socket: GatewaySocketState, workspaceId: string | null, 
   return { info, refresh };
 }
 
+/** `ConnectionBridge` primes the connection store only once per client mount
+ *  (and only remounts per `generation`, not per reconnect) — re-prime on every
+ *  successful (re)connect so a failed first dial or a runner restart (new
+ *  workspace id) can't leave the app deaf on a stale/null workspace. */
+function useConnectionRefresh(socket: GatewaySocketState) {
+  const { ready } = socket;
+  useEffect(() => {
+    if (!ready) return;
+    void refreshConnectionStore(api());
+  }, [ready, socket.refreshTick]);
+}
+
 function useGatewayStoreValue(pairing: PairingState, socket: GatewaySocketState) {
+  useConnectionRefresh(socket);
   const workspaceId = useActiveWorkspaceId();
   const chatHandle = useChat(workspaceId);
   const { info, refresh: refreshInfo } = useSessionInfo(socket, workspaceId, chatHandle.sending);

--- a/apps/mobile/src/hooks/useQrScanner.ts
+++ b/apps/mobile/src/hooks/useQrScanner.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useCameraPermissions } from 'expo-camera';
 import type { CameraPermissionState } from '../pairingUi';
 import { createQrScanGate } from '../qrScanGate';
@@ -9,7 +9,6 @@ export interface QrScannerState {
   readonly armed: boolean;
   readonly permission: CameraPermissionState;
   readonly openScanner: () => Promise<void>;
-  readonly armScanner: () => void;
   readonly closeScanner: () => void;
   readonly requestPermission: () => Promise<void>;
   readonly handlePayload: (raw: string) => Promise<void>;
@@ -29,19 +28,26 @@ export function useQrScanner(onPayload: (raw: string) => Promise<void>): QrScann
   }, [requestCameraPermission]);
 
   const openScanner = useCallback(async () => {
+    // Auto-arm: the camera hunts for a QR the moment the sheet opens — the
+    // gate's one-shot tryAcquire still dedupes the onBarcodeScanned burst.
     scanGateRef.current.reset();
+    scanGateRef.current.arm();
     setOpen(true);
     setProcessing(false);
-    setArmed(false);
+    setArmed(true);
     if (!permission?.granted && permission?.canAskAgain !== false) {
       await requestCameraPermission();
     }
   }, [permission?.canAskAgain, permission?.granted, requestCameraPermission]);
 
-  const armScanner = useCallback(() => {
+  // Permission can flip to granted only after the sheet opened (first-run
+  // prompt) — arm as soon as the camera becomes usable.
+  useEffect(() => {
+    if (!open || processing || armed) return;
+    if (permissionState !== 'granted') return;
     scanGateRef.current.arm();
     setArmed(true);
-  }, []);
+  }, [armed, open, permissionState, processing]);
 
   const closeScanner = useCallback(() => {
     scanGateRef.current.reset();
@@ -68,7 +74,6 @@ export function useQrScanner(onPayload: (raw: string) => Promise<void>): QrScann
     armed,
     permission: permissionState,
     openScanner,
-    armScanner,
     closeScanner,
     requestPermission,
     handlePayload,

--- a/apps/mobile/src/pairingUi.ts
+++ b/apps/mobile/src/pairingUi.ts
@@ -28,6 +28,6 @@ export function buildPairingUiState(input: PairingUiInput): PairingUiState {
     scannerTitle: 'Scan Moxxy QR',
     scannerHint: permissionDenied
       ? 'Camera permission is required to scan the Moxxy pairing QR code.'
-      : 'Point your camera at the gateway QR, then tap Scan QR code.',
+      : 'Point your camera at the gateway QR — pairing starts automatically.',
   };
 }

--- a/apps/mobile/src/toolGroupUi.ts
+++ b/apps/mobile/src/toolGroupUi.ts
@@ -30,3 +30,19 @@ export function buildToolGroupUi(tools: ReadonlyArray<ToolTranscriptItem>): Tool
     pulse: hasRunning && !hasError,
   };
 }
+
+export interface ToolDiagnosticsSection {
+  readonly kind: 'input' | 'output' | 'error';
+  readonly text: string;
+}
+
+/** The sections a tapped tool row expands into (mirrors desktop's ToolRow:
+ *  input, then output, then the error message). Empty when the events carried
+ *  no detail — the row is then not expandable. */
+export function buildToolDiagnostics(tool: ToolTranscriptItem): ToolDiagnosticsSection[] {
+  const sections: ToolDiagnosticsSection[] = [];
+  if (tool.input) sections.push({ kind: 'input', text: tool.input });
+  if (tool.output) sections.push({ kind: 'output', text: tool.output });
+  if (tool.errorText) sections.push({ kind: 'error', text: tool.errorText });
+  return sections;
+}

--- a/packages/cli/src/setup/webhook-runner.ts
+++ b/packages/cli/src/setup/webhook-runner.ts
@@ -149,6 +149,15 @@ function scopedSessionView(
     get pluginHost() {
       return session.pluginHost;
     },
+    // Read-through AND write-through: runTurn records the resolved model on
+    // the session it was handed, and that must land on the real session, not
+    // this per-fire view.
+    get lastResolvedModel() {
+      return session.lastResolvedModel;
+    },
+    set lastResolvedModel(model: string | null) {
+      session.lastResolvedModel = model;
+    },
     startTurn: () => session.startTurn(),
     appContext: () => session.appContext(),
   };

--- a/packages/cli/src/setup/workflows.test.ts
+++ b/packages/cli/src/setup/workflows.test.ts
@@ -3,10 +3,11 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterAll, describe, expect, it, vi } from 'vitest';
 import { Session, silentLogger } from '@moxxy/core';
-import { asPluginId, type EmittedEvent } from '@moxxy/sdk';
+import { asPluginId, definePlugin, defineProvider, type EmittedEvent } from '@moxxy/sdk';
 import { ScheduleStore } from '@moxxy/plugin-scheduler';
 import { WORKFLOWS_PLUGIN_NAME } from '@moxxy/plugin-workflows';
 import {
+  activeModel,
   buildWorkflowsIntegration,
   applyAfterWorkflowCycleGuard,
   detectAfterWorkflowCycles,
@@ -457,5 +458,52 @@ describe('buildWorkflowsIntegration afterWorkflow wiring', () => {
     expect(result.ok).toBe(true);
     // The checkpoint is cleaned up once resumed.
     expect(await store.load(runId)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// activeModel — model resolution for trigger-spawned workflow children
+
+describe('activeModel', () => {
+  function sessionWithProvider(modelIds: ReadonlyArray<string>): Session {
+    const session = new Session({ cwd: '/tmp', logger: silentLogger });
+    const models = modelIds.map((id) => ({ id }));
+    session.pluginHost.registerStatic(
+      definePlugin({
+        name: 'test-workflow-provider',
+        providers: [
+          defineProvider({
+            name: 'wf-test',
+            models,
+            createClient: () => ({
+              name: 'wf-test',
+              models,
+              stream: async function* () {
+                // unused
+              },
+              countTokens: async () => 0,
+            }),
+          }),
+        ],
+      }),
+    );
+    session.providers.setActive('wf-test');
+    return session;
+  }
+
+  it('prefers the model the last turn actually resolved (lastResolvedModel)', () => {
+    const session = sessionWithProvider(['descriptor-first', 'other']);
+    session.lastResolvedModel = 'user-picked-model';
+    expect(activeModel(session)).toBe('user-picked-model');
+  });
+
+  it('falls back to the active provider first descriptor before any turn ran', () => {
+    const session = sessionWithProvider(['descriptor-first', 'other']);
+    expect(activeModel(session)).toBe('descriptor-first');
+  });
+
+  it("returns 'default' (runTurn's own terminal fallback) with no provider and no turn", () => {
+    const session = new Session({ cwd: '/tmp', logger: silentLogger });
+    expect(activeModel(session)).toBe('default');
   });
 });

--- a/packages/cli/src/setup/workflows.ts
+++ b/packages/cli/src/setup/workflows.ts
@@ -577,8 +577,15 @@ export async function fireAfterWorkflowDependents(args: {
   }
 }
 
-function activeModel(session: Session): string {
-  return safeActiveProvider(session)?.models[0]?.id ?? 'claude-sonnet-4-6';
+/**
+ * Model for trigger-spawned workflow children. Prefers the model the user's
+ * conversation last actually ran on (`session.lastResolvedModel`, recorded by
+ * runTurn) over the provider's first descriptor — the descriptor list often
+ * leads with a model the user isn't using. Exported for tests. The 'default'
+ * terminal fallback matches runTurn's own resolution.
+ */
+export function activeModel(session: Session): string {
+  return session.lastResolvedModel ?? safeActiveProvider(session)?.models[0]?.id ?? 'default';
 }
 
 function safeActiveProvider(session: Session): ReturnType<Session['providers']['getActive']> | null {

--- a/packages/core/src/events/log.test.ts
+++ b/packages/core/src/events/log.test.ts
@@ -208,6 +208,65 @@ describe('EventLog', () => {
     await new Promise((resolve) => setImmediate(resolve));
   });
 
+  it('rebase lets an empty mirror ingest a partial (tail) replay contiguously', async () => {
+    // Author a few events so we have authoritative seqs to mirror.
+    const source = new EventLog();
+    const events = [];
+    for (const text of ['a', 'b', 'c', 'd']) {
+      events.push(await source.append({ type: 'user_prompt', sessionId: sid, turnId: tid, source: 'user', text }));
+    }
+
+    // A mirror primed by `replay: { tail: 2 }` — the runner announces fromSeq 2.
+    const mirror = new EventLog();
+    mirror.rebase(2);
+    expect(mirror.baseSeq).toBe(2);
+
+    // Below-base events (already-seen history) are dropped, not mis-indexed.
+    mirror.ingest(events[0]!);
+    expect(mirror.length).toBe(0);
+    // A gap (seq 3 before seq 2) is refused.
+    mirror.ingest(events[3]!);
+    expect(mirror.length).toBe(0);
+    // The contiguous tail lands, seq-addressed reads line up with the source.
+    mirror.ingest(events[2]!);
+    mirror.ingest(events[3]!);
+    expect(mirror.length).toBe(2);
+    expect(mirror.at(2)?.id).toBe(events[2]!.id);
+    expect(mirror.at(3)?.id).toBe(events[3]!.id);
+    expect(mirror.at(0)).toBeUndefined();
+    expect(mirror.slice().map((e) => e.seq)).toEqual([2, 3]);
+    expect(mirror.slice(3)).toHaveLength(1);
+    // New appends continue at base + length (seq stays authoritative).
+    const next = await mirror.append({ type: 'user_prompt', sessionId: sid, turnId: tid, source: 'user', text: 'e' });
+    expect(next.seq).toBe(4);
+  });
+
+  it('rebase throws on a non-empty log and on an invalid seq', async () => {
+    const log = new EventLog();
+    await log.append({ type: 'user_prompt', sessionId: sid, turnId: tid, source: 'user', text: 'x' });
+    expect(() => log.rebase(5)).toThrow(/already holds/);
+    const empty = new EventLog();
+    expect(() => empty.rebase(-1)).toThrow(/non-negative/);
+    expect(() => empty.rebase(1.5)).toThrow(/non-negative integer/);
+  });
+
+  it('clear resets the rebase so post-reset events restart at seq 0', async () => {
+    const source = new EventLog();
+    await source.append({ type: 'user_prompt', sessionId: sid, turnId: tid, source: 'user', text: 'old' });
+
+    const mirror = new EventLog();
+    mirror.rebase(1); // attached with replay 'none' after one event
+    mirror.clear(); // session.reset
+    expect(mirror.baseSeq).toBe(0);
+
+    source.clear();
+    const fresh = await source.append({ type: 'user_prompt', sessionId: sid, turnId: tid, source: 'user', text: 'new' });
+    expect(fresh.seq).toBe(0);
+    mirror.ingest(fresh);
+    expect(mirror.length).toBe(1);
+    expect(mirror.at(0)?.id).toBe(fresh.id);
+  });
+
   it('clear survives a throwing onClear listener', () => {
     const log = new EventLog();
     log.onClear(() => {

--- a/packages/core/src/events/log.ts
+++ b/packages/core/src/events/log.ts
@@ -15,6 +15,14 @@ export class EventLog implements EventLogReader {
   private readonly listeners = new Set<EventListener>();
   private readonly clearListeners = new Set<() => void>();
   private readonly now: () => number;
+  /**
+   * Seq of the FIRST event this log holds. 0 for an authoring log; a mirror
+   * primed by a partial attach replay (runner protocol v6 `replay.start`)
+   * rebases to the first replayed seq so `ingest`'s contiguity gate lines up
+   * with the runner's stream instead of expecting history we never received.
+   * `seq === base + index` for every held event.
+   */
+  private base = 0;
 
   constructor(seed: ReadonlyArray<MoxxyEvent> = [], opts: { now?: () => number } = {}) {
     this.now = opts.now ?? Date.now;
@@ -25,13 +33,21 @@ export class EventLog implements EventLogReader {
     return this.events.length;
   }
 
-  at(seq: number): MoxxyEvent | undefined {
-    if (seq < 0 || seq >= this.events.length) return undefined;
-    return this.events[seq];
+  /** Seq of the first held event (see {@link rebase}). */
+  get baseSeq(): number {
+    return this.base;
   }
 
-  slice(from = 0, to: number = this.events.length): ReadonlyArray<MoxxyEvent> {
-    return this.events.slice(from, to);
+  at(seq: number): MoxxyEvent | undefined {
+    const index = seq - this.base;
+    if (index < 0 || index >= this.events.length) return undefined;
+    return this.events[index];
+  }
+
+  slice(from = 0, to: number = this.base + this.events.length): ReadonlyArray<MoxxyEvent> {
+    // Seq-addressed, like `at`. Events below the base were never held, so a
+    // `from` before it just clamps to everything we have.
+    return this.events.slice(Math.max(0, from - this.base), Math.max(0, to - this.base));
   }
 
   ofType<T extends MoxxyEventType>(type: T): ReadonlyArray<MoxxyEventOfType<T>> {
@@ -47,7 +63,7 @@ export class EventLog implements EventLogReader {
   }
 
   async append(partial: EmittedEvent): Promise<MoxxyEvent> {
-    const event = materializeEvent(partial, this.events.length, this.now);
+    const event = materializeEvent(partial, this.base + this.events.length, this.now);
     this.events.push(event);
     // Snapshot listeners so a subscribe/unsubscribe during dispatch (e.g.,
     // a runTurn finishing and unsubscribing while we're still mid-fanout)
@@ -79,13 +95,14 @@ export class EventLog implements EventLogReader {
    * Not for normal authoring; use {@link append} for that.
    */
   ingest(event: MoxxyEvent): void {
-    // Contiguous, ordered delivery over a single socket means seq === index.
-    // Accept ONLY the next-expected seq: this drops duplicates (overlap
-    // between attach-replay and the live stream, seq < length) AND refuses a
-    // gap (seq > length) rather than pushing it at the wrong index, which
-    // would permanently desync `seq` from the array index. A gap can't happen
-    // over the reliable in-order transport, so refusing one is fail-safe.
-    if (event.seq !== this.events.length) return;
+    // Contiguous, ordered delivery over a single socket means
+    // seq === base + index. Accept ONLY the next-expected seq: this drops
+    // duplicates (overlap between attach-replay and the live stream,
+    // seq < base + length) AND refuses a gap (seq > base + length) rather than
+    // pushing it at the wrong index, which would permanently desync `seq` from
+    // the array index. A gap can't happen over the reliable in-order
+    // transport, so refusing one is fail-safe.
+    if (event.seq !== this.base + this.events.length) return;
     this.events.push(event);
     const snapshot = [...this.listeners];
     for (const fn of snapshot) {
@@ -117,8 +134,28 @@ export class EventLog implements EventLogReader {
    * Safe to call only when no turn is in flight — callers should abort
    * their AbortController and await any pending runTurn() first.
    */
+  /**
+   * Start this (empty) log at `seq` instead of 0. A mirror primed by a
+   * PARTIAL attach replay (`replay: 'none'` / `{ tail }`) calls this with the
+   * runner's announced first seq so {@link ingest}'s contiguity gate accepts
+   * the stream. Only valid while empty — rebasing held events would detach
+   * their seqs from their indices.
+   */
+  rebase(seq: number): void {
+    if (this.events.length > 0) {
+      throw new Error(`EventLog.rebase(${seq}): log already holds ${this.events.length} events`);
+    }
+    if (!Number.isInteger(seq) || seq < 0) {
+      throw new Error(`EventLog.rebase(${seq}): seq must be a non-negative integer`);
+    }
+    this.base = seq;
+  }
+
   clear(): void {
     this.events.length = 0;
+    // A session reset restarts the authoritative stream at seq 0 — a rebased
+    // mirror must follow, or it would wait forever for seqs that never come.
+    this.base = 0;
     const snapshot = [...this.clearListeners];
     for (const fn of snapshot) {
       try {

--- a/packages/core/src/run-turn.ts
+++ b/packages/core/src/run-turn.ts
@@ -22,6 +22,10 @@ export async function* runTurn(
   const turnId = opts.turnId ?? session.startTurn().turnId;
   const provider = session.providers.getActive();
   const model = opts.model ?? provider.models[0]?.id ?? 'default';
+  // Record the resolution so out-of-band spawns (workflow triggers) can
+  // inherit the conversation's current model. Last-writer-wins when turns
+  // run concurrently — see the field's doc in SessionRuntime.
+  session.lastResolvedModel = model;
 
   const queue: MoxxyEvent[] = [];
   const waiters: Array<() => void> = [];

--- a/packages/core/src/session-runtime.ts
+++ b/packages/core/src/session-runtime.ts
@@ -59,6 +59,15 @@ export interface SessionRuntime {
   readonly lazyTools: boolean;
   readonly dispatcher: HookDispatcher;
   readonly pluginHost: PluginHostHandle;
+  /**
+   * Model id resolved by the most recent `runTurn()` on this session.
+   * Out-of-band spawns (workflow triggers, schedulers) read this so their
+   * children inherit whatever the user is currently talking to instead of a
+   * stale hardcoded default. Last-writer-wins under concurrent turns — it is
+   * a "current conversation model" hint, not a per-turn record. Null until
+   * the first turn resolves a model.
+   */
+  lastResolvedModel: string | null;
   startTurn(): { turnId: TurnId };
   appContext(): AppContext;
 }

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -140,6 +140,11 @@ export class Session implements ClientSession, SessionRuntime {
   /** Lazy tool loading toggle, from `config.context.lazyTools`. Default off. */
   lazyTools = false;
   /**
+   * Model id resolved by the most recent `runTurn()` (see SessionRuntime).
+   * Last-writer-wins for concurrent turns; null until the first turn runs.
+   */
+  lastResolvedModel: string | null = null;
+  /**
    * Live runtime capabilities the host installs on a local Session (see
    * SessionLike). A RemoteSession leaves them undefined. Declared here — rather
    * than monkey-patched on via `as unknown as` — so the host and channels get

--- a/packages/core/src/skills/synthesize.ts
+++ b/packages/core/src/skills/synthesize.ts
@@ -43,7 +43,11 @@ export async function synthesizeSkill(
   opts: SynthesizeOptions = {},
 ): Promise<SynthesizedSkill> {
   const provider = session.providers.getActive();
-  const model = opts.model ?? provider.models[0]?.id ?? 'claude-sonnet-4-6';
+  // Prefer the model the conversation last ran on over the provider's first
+  // descriptor; 'default' matches run-turn's terminal fallback (never a
+  // hardcoded vendor id that goes stale).
+  const model =
+    opts.model ?? session.lastResolvedModel ?? provider.models[0]?.id ?? 'default';
   const draft = await draftSkill(provider, model, intent, session.signal);
 
   const baseDir =

--- a/packages/core/src/subagents/run-child.test.ts
+++ b/packages/core/src/subagents/run-child.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import type { ModeContext, ModeDef, MoxxyEvent, ProviderDef } from '@moxxy/sdk';
+import { defineMode, defineProvider, definePlugin } from '@moxxy/sdk';
+import { Session } from '../session.js';
+import { runChildTurn, type SubagentRuntime } from './run-child.js';
+
+// A mode that reports the model it was handed — lets tests observe the
+// child's EFFECTIVE model through the returned result text.
+function makeEchoModelMode(): ModeDef {
+  return defineMode({
+    name: 'echo-model',
+    run: async function* (ctx: ModeContext): AsyncIterable<MoxxyEvent> {
+      await ctx.emit({
+        type: 'assistant_message',
+        sessionId: ctx.sessionId,
+        turnId: ctx.turnId,
+        source: 'assistant',
+        content: ctx.model,
+        stopReason: 'end_turn',
+      });
+    },
+  });
+}
+
+// A mode that spawns a grandchild (no model override) and reports what model
+// the grandchild ran on — exercises nested-spawner model inheritance.
+function makeNestedSpawnMode(): ModeDef {
+  return defineMode({
+    name: 'nested-spawn',
+    run: async function* (ctx: ModeContext): AsyncIterable<MoxxyEvent> {
+      const result = await ctx.subagents!.spawn({ prompt: 'echo', mode: 'echo-model' });
+      await ctx.emit({
+        type: 'assistant_message',
+        sessionId: ctx.sessionId,
+        turnId: ctx.turnId,
+        source: 'assistant',
+        content: result.text,
+        stopReason: 'end_turn',
+      });
+    },
+  });
+}
+
+function makeProvider(modelIds: ReadonlyArray<string>): ProviderDef {
+  const models = modelIds.map((id) => ({ id }));
+  return defineProvider({
+    name: 'listed',
+    models,
+    createClient: () => ({
+      name: 'listed',
+      models,
+      stream: async function* () {
+        // unused — the test modes don't call into the provider.
+      },
+      countTokens: async () => 0,
+    }),
+  });
+}
+
+function buildSession(modelIds: ReadonlyArray<string>): Session {
+  const session = new Session({ cwd: '/tmp', silent: true });
+  session.pluginHost.registerStatic(
+    definePlugin({
+      name: 'test-subagent-models',
+      version: '0.0.0',
+      providers: [makeProvider(modelIds)],
+      modes: [makeEchoModelMode(), makeNestedSpawnMode()],
+    }),
+  );
+  session.providers.setActive('listed');
+  session.modes.setActive('echo-model');
+  return session;
+}
+
+function buildRuntime(session: Session, parentModel: string): SubagentRuntime {
+  return {
+    parentSession: session,
+    parentTurnId: session.startTurn().turnId,
+    parentSignal: new AbortController().signal,
+    parentModel,
+  };
+}
+
+function collectParentEvents(session: Session): MoxxyEvent[] {
+  const events: MoxxyEvent[] = [];
+  session.log.subscribe((e) => void events.push(e));
+  return events;
+}
+
+function findWarning(events: ReadonlyArray<MoxxyEvent>): string | undefined {
+  const evt = events.find((e) => e.type === 'plugin_event' && e.subtype === 'subagent_warning');
+  return evt?.type === 'plugin_event' ? (evt.payload as { message: string }).message : undefined;
+}
+
+describe('runChildTurn model resolution', () => {
+  it('falls back to the parent model (with a warning) on an unknown model id', async () => {
+    const session = buildSession(['parent-model', 'cheap-model']);
+    const events = collectParentEvents(session);
+    const rt = buildRuntime(session, 'parent-model');
+
+    const result = await runChildTurn({
+      rt,
+      spec: { prompt: 'echo', mode: 'echo-model', model: 'claude-3-5-sonnet' },
+      retainSession: false,
+    });
+
+    expect(result.text).toBe('parent-model');
+    expect(findWarning(events)).toBe(
+      'unknown model "claude-3-5-sonnet" — falling back to parent model "parent-model"',
+    );
+  });
+
+  it('honors a model id the active provider lists, without warning', async () => {
+    const session = buildSession(['parent-model', 'cheap-model']);
+    const events = collectParentEvents(session);
+    const rt = buildRuntime(session, 'parent-model');
+
+    const result = await runChildTurn({
+      rt,
+      spec: { prompt: 'echo', mode: 'echo-model', model: 'cheap-model' },
+      retainSession: false,
+    });
+
+    expect(result.text).toBe('cheap-model');
+    expect(findWarning(events)).toBeUndefined();
+  });
+
+  it('inherits the parent model when no override is given', async () => {
+    const session = buildSession(['parent-model']);
+    const rt = buildRuntime(session, 'parent-model');
+
+    const result = await runChildTurn({
+      rt,
+      spec: { prompt: 'echo', mode: 'echo-model' },
+      retainSession: false,
+    });
+
+    expect(result.text).toBe('parent-model');
+  });
+
+  it('skips validation when the provider publishes no models (sparse providers)', async () => {
+    const session = buildSession([]);
+    const events = collectParentEvents(session);
+    const rt = buildRuntime(session, 'parent-model');
+
+    const result = await runChildTurn({
+      rt,
+      spec: { prompt: 'echo', mode: 'echo-model', model: 'unlisted-but-real' },
+      retainSession: false,
+    });
+
+    expect(result.text).toBe('unlisted-but-real');
+    expect(findWarning(events)).toBeUndefined();
+  });
+
+  it('does not warn when the override IS the parent model, even if unlisted', async () => {
+    const session = buildSession(['some-other-model']);
+    const events = collectParentEvents(session);
+    const rt = buildRuntime(session, 'unlisted-parent');
+
+    const result = await runChildTurn({
+      rt,
+      spec: { prompt: 'echo', mode: 'echo-model', model: 'unlisted-parent' },
+      retainSession: false,
+    });
+
+    expect(result.text).toBe('unlisted-parent');
+    expect(findWarning(events)).toBeUndefined();
+  });
+
+  it('grandchildren inherit the child effective model, not the grandparent model', async () => {
+    const session = buildSession(['parent-model', 'cheap-model']);
+    const rt = buildRuntime(session, 'parent-model');
+
+    const result = await runChildTurn({
+      rt,
+      spec: { prompt: 'spawn nested', mode: 'nested-spawn', model: 'cheap-model' },
+      retainSession: false,
+    });
+
+    // The grandchild echoes its own ctx.model — it must see the child's
+    // resolved model ('cheap-model'), not the original parent's.
+    expect(result.text).toBe('cheap-model');
+  });
+});

--- a/packages/core/src/subagents/run-child.ts
+++ b/packages/core/src/subagents/run-child.ts
@@ -92,11 +92,17 @@ export async function runChildTurn(args: {
       ? buildFilteredToolRegistry(parentSession.tools, new Set(spec.allowedTools))
       : (parentSession.tools as unknown as ToolRegistry);
 
+  const childModel = await resolveChildModel(rt, spec, label, childSessionId);
+
   const childLog = new EventLog();
-  const spawner = createSubagentSpawner(rt);
+  // The nested spawner's parentModel must be the CHILD's effective model —
+  // building it from the original rt would make grandchildren silently
+  // revert to the grandparent's model.
+  const spawner = createSubagentSpawner({ ...rt, parentModel: childModel });
   const childCtx = buildChildContext(
     rt,
     spec,
+    childModel,
     childSessionId,
     childTurnId,
     toolRegistry,
@@ -311,20 +317,56 @@ async function resolveStrategy(
   };
 }
 
+/**
+ * Resolve the child's effective model. A `spec.model` usually comes from the
+ * calling LLM (dispatch_agent's free-form string field), which sometimes
+ * hallucinates training-era ids ("claude-3-5-sonnet", "gpt-4o") — running the
+ * child on those would 404 or silently land on a different vendor model. When
+ * the active provider publishes a models list and the requested id isn't in
+ * it, fall back to the parent's model with a warning (mirroring the
+ * unknown-mode fallback above) instead of hard-erroring. Providers with an
+ * EMPTY models list (sparse admin-registered vendors — see the
+ * resolveModelContext caveat in @moxxy/sdk) skip validation entirely: we
+ * can't tell a typo from a legitimate unlisted id there.
+ */
+async function resolveChildModel(
+  rt: SubagentRuntime,
+  spec: SubagentSpec,
+  label: string,
+  childSessionId: ReturnType<typeof newSessionId>,
+): Promise<string> {
+  const { parentSession, parentTurnId, parentModel } = rt;
+  const requested = spec.model;
+  if (requested === undefined || requested === parentModel) return parentModel;
+  const models = parentSession.providers.getActive().models;
+  if (models.length > 0 && !models.some((m) => m.id === requested)) {
+    await emitSubagentWarning(
+      parentSession,
+      parentTurnId,
+      label,
+      childSessionId,
+      `unknown model "${requested}" — falling back to parent model "${parentModel}"`,
+    );
+    return parentModel;
+  }
+  return requested;
+}
+
 function buildChildContext(
   rt: SubagentRuntime,
   spec: SubagentSpec,
+  model: string,
   childSessionId: ReturnType<typeof newSessionId>,
   childTurnId: TurnId,
   toolRegistry: ToolRegistry,
   childLog: EventLog,
   spawner: SubagentSpawner,
 ): ModeContext {
-  const { parentSession, parentSignal, parentModel } = rt;
+  const { parentSession, parentSignal } = rt;
   return {
     sessionId: childSessionId,
     turnId: childTurnId,
-    model: spec.model ?? parentModel,
+    model,
     ...(spec.systemPrompt !== undefined ? { systemPrompt: spec.systemPrompt } : {}),
     provider: parentSession.providers.getActive(),
     tools: toolRegistry,

--- a/packages/desktop-host/src/chat-log.ts
+++ b/packages/desktop-host/src/chat-log.ts
@@ -38,14 +38,16 @@ function fileFor(workspaceId: string): string {
  * resolved FILE PATH (not the workspace id) so tests pointing `MOXXY_CHATS_DIR`
  * at different tmp dirs never share a cache entry.
  *
- * Why idempotent: on every desktop restart the runner replays its FULL event
- * history to each attaching client (runner attach replays from seq 0), and the
- * renderer re-appends every replayed event here. Without dedup the NDJSON log
- * grew by a complete copy of the conversation on each restart — and because
- * {@link loadSegment}'s cursor is a line index, a doubled file also corrupted
- * scroll-up pagination. Deduping by id keeps the log one copy and its cursors
- * stable. (The runner session log remains the source of truth on replay; this
- * file is the renderer's windowed mirror.)
+ * Why idempotent: the renderer (and the WS bridge) may dispatch the same
+ * committed event more than once across reconnects, and dedup-by-id keeps the
+ * NDJSON log at one copy with stable {@link loadSegment} line-index cursors.
+ * Mechanism note (corrected 2026-06-11): the runner's attach-time replay was
+ * NEVER the duplicate source the original comment claimed — the SessionDriver
+ * subscribes to the mirror only AFTER attach completes, so replayed events
+ * never reached the renderer; the transcript is loaded solely via
+ * `chat.loadSegment` from this file. The desktop now attaches with
+ * `replay: 'none'` (runner protocol v6), so the replay doesn't even populate
+ * the host-side mirror anymore.
  */
 const writtenIds = new Map<string, Set<string>>();
 

--- a/packages/desktop-host/src/index.ts
+++ b/packages/desktop-host/src/index.ts
@@ -33,6 +33,8 @@ export {
   isSafeExternalUrl,
   clerkFrontendApiHost,
   clerkCspHostSources,
+  clerkAccountPortalHost,
+  installAccountPortalRecovery,
 } from './security.js';
 export {
   startLoopbackServer,

--- a/packages/desktop-host/src/runner-supervisor.ts
+++ b/packages/desktop-host/src/runner-supervisor.ts
@@ -341,6 +341,14 @@ export class RunnerSupervisor extends EventEmitter {
       session = await connectRemoteSession({
         role: 'desktop',
         socketPath: this.socketPath,
+        // Skip the full-history replay (protocol v6): the renderer's
+        // transcript comes from the NDJSON chat log (chat.loadSegment), never
+        // from this mirror, so replaying thousands of events (mostly
+        // assistant_chunk) on every app start / desk switch / reconnect only
+        // delayed the composer-ready gate. Live events still stream in. An
+        // older bundled CLI ignores the option and replays in full — correct,
+        // just slower.
+        replay: 'none',
       });
     } catch (err) {
       // Only a GENUINELY-INCOMPATIBLE client (below the server's compatibility

--- a/packages/desktop-host/src/security.test.ts
+++ b/packages/desktop-host/src/security.test.ts
@@ -8,6 +8,8 @@ import {
   redactSecrets,
   clerkFrontendApiHost,
   clerkCspHostSources,
+  clerkAccountPortalHost,
+  installAccountPortalRecovery,
   installContentSecurityPolicy,
   lockDownNavigation,
 } from './security';
@@ -150,6 +152,76 @@ describe('clerk frontend-api host', () => {
     for (const bad of [undefined, null, '', 'not-a-key', 'pk_live_', 'sk_live_abc', 'pk_live_!!!']) {
       expect(clerkFrontendApiHost(bad)).toBeNull();
     }
+  });
+});
+
+describe('clerk account-portal host', () => {
+  it('derives accounts.<domain> for a live key', () => {
+    expect(clerkAccountPortalHost(LIVE)).toBe('accounts.acme.com');
+  });
+
+  it('returns null for test keys (portal host is never allow-listed)', () => {
+    expect(clerkAccountPortalHost(TEST)).toBeNull();
+  });
+
+  it('returns null for missing / malformed keys', () => {
+    for (const bad of [undefined, null, '', 'not-a-key', 'pk_live_!!!']) {
+      expect(clerkAccountPortalHost(bad)).toBeNull();
+    }
+  });
+});
+
+describe('account-portal recovery net', () => {
+  /** Minimal BrowserWindow stand-in: captures the did-navigate handler and
+   *  records loadURL calls so a test can replay post-OAuth landings. */
+  function fakeWindow(): {
+    win: BrowserWindow;
+    navigate: (url: string) => void;
+    hasHandler: () => boolean;
+    loads: string[];
+  } {
+    const loads: string[] = [];
+    let handler: ((e: unknown, url: string) => void) | undefined;
+    const wc = {
+      on: (ev: string, fn: (e: unknown, url: string) => void) => {
+        if (ev === 'did-navigate') handler = fn;
+      },
+      loadURL: (url: string) => {
+        loads.push(url);
+        return Promise.resolve();
+      },
+    };
+    return {
+      win: { webContents: wc } as unknown as BrowserWindow,
+      navigate: (url) => handler?.({}, url),
+      hasHandler: () => !!handler,
+      loads,
+    };
+  }
+
+  const APP = 'https://desktop.moxxy.ai:51789/index.html';
+
+  it('loads the app root back when the top frame lands on the portal', () => {
+    const { win, navigate, loads } = fakeWindow();
+    installAccountPortalRecovery(win, { portalHost: 'accounts.acme.com', appUrl: APP });
+    navigate('https://accounts.acme.com/account');
+    expect(loads).toEqual([APP]);
+  });
+
+  it('ignores every other host (no loop on the recovery load itself)', () => {
+    const { win, navigate, loads } = fakeWindow();
+    installAccountPortalRecovery(win, { portalHost: 'accounts.acme.com', appUrl: APP });
+    navigate(APP); // the recovery load landing
+    navigate('https://clerk.acme.com/v1/oauth_callback');
+    navigate('https://accounts.google.com/o/oauth2/auth');
+    navigate('not a url');
+    expect(loads).toEqual([]);
+  });
+
+  it('is a no-op without a portal host (test key / no key)', () => {
+    const { win, hasHandler } = fakeWindow();
+    installAccountPortalRecovery(win, { portalHost: null, appUrl: APP });
+    expect(hasHandler()).toBe(false);
   });
 });
 

--- a/packages/desktop-host/src/security.ts
+++ b/packages/desktop-host/src/security.ts
@@ -176,6 +176,65 @@ export function clerkFrontendApiHost(publishableKey?: string | null): string | n
 }
 
 /**
+ * The hosted Account Portal host of a `pk_live_` Clerk instance —
+ * `accounts.<domain>` next to its `clerk.<domain>` Frontend API host. After
+ * an OAuth code exchange, Clerk's FAPI falls back to redirecting THERE when
+ * the flow carries no usable `redirect_url` — which strands the desktop
+ * window on a page that isn't the app. The main process watches for a
+ * top-frame landing on this host and recovers back to the app root (see
+ * {@link installAccountPortalRecovery}).
+ *
+ * null for missing/malformed keys and for test keys: a dev instance's
+ * portal lives on `<slug>.accounts.dev`, which the navigation lockdown
+ * never allows in the first place (only live keys get the parent-domain
+ * wildcard), so there is nothing to recover from.
+ */
+export function clerkAccountPortalHost(publishableKey?: string | null): string | null {
+  const host = clerkFrontendApiHost(publishableKey);
+  if (!host) return null;
+  if (host.endsWith('.clerk.accounts.dev') || host.endsWith('.clerk.com')) return null;
+  const parent = host.split('.').slice(1).join('.');
+  // Same registrable-parent guard as the CSP sources — never a bare TLD.
+  if (parent.split('.').length < 2) return null;
+  return `accounts.${parent}`;
+}
+
+/**
+ * Recovery net for the OAuth return leg: if the top frame lands on the Clerk
+ * hosted Account Portal instead of back in the app, immediately load the app
+ * root. The lockdown's parent-domain wildcard legitimately allows that host
+ * (it's on the FAPI round-trip path), so this does NOT widen the navigation
+ * allow-list — it only adds a way back when Clerk's fallback redirect picks
+ * the portal over the app. Loop-safe: it only fires for the portal host, and
+ * `appUrl` is on a different host, so the recovery load can't re-trigger it.
+ */
+export function installAccountPortalRecovery(
+  win: BrowserWindow,
+  opts: {
+    /** From {@link clerkAccountPortalHost}; null/undefined disables the net. */
+    readonly portalHost: string | null | undefined;
+    /** The app root the window was originally loaded from. */
+    readonly appUrl: string;
+  },
+): void {
+  const { portalHost, appUrl } = opts;
+  if (!portalHost) return;
+  const wc = win.webContents;
+  wc.on('did-navigate', (_event, url) => {
+    let hostname: string;
+    try {
+      hostname = new URL(url).hostname;
+    } catch {
+      return;
+    }
+    if (hostname !== portalHost || url === appUrl) return;
+    void Promise.resolve(wc.loadURL(appUrl)).catch(() => {
+      /* window may be tearing down — nothing to recover */
+    });
+  });
+}
+
+/**
  * CSP host-source tokens a Clerk instance needs beyond the static
  * `*.clerk.accounts.dev` / `*.clerk.com` entries: the exact prod Frontend
  * API host plus a wildcard on its parent domain (so the instance's own

--- a/packages/desktop-host/src/session-driver.test.ts
+++ b/packages/desktop-host/src/session-driver.test.ts
@@ -210,6 +210,14 @@ describe('SessionDriver approval-gate survival', () => {
     );
     const errs = remote.log.ofType('error');
     expect(errs).toHaveLength(0);
+    // The driver's pre-minted id must reach the runner (protocol v6): every
+    // event of the turn carries THE id runTurn returned to the renderer —
+    // that's what renderer-side per-turn filters (skill-generation preview,
+    // turn hiding) key on. Previously the runner minted its own id and the
+    // returned one matched nothing.
+    const turnEvents = remote.log.slice();
+    expect(turnEvents.length).toBeGreaterThan(0);
+    expect(turnEvents.every((e) => e.turnId === turnId)).toBe(true);
     stop();
     driver.dispose();
   });

--- a/packages/desktop-host/src/session-driver.ts
+++ b/packages/desktop-host/src/session-driver.ts
@@ -175,10 +175,16 @@ export class SessionDriver {
       try {
         const opts: {
           signal: AbortSignal;
+          turnId: string;
           model?: string;
           attachments?: ReadonlyArray<UserPromptAttachment>;
         } = {
           signal: controller.signal,
+          // Run the turn under the id we just returned to the renderer
+          // (protocol v6): its per-turn event filters (skill-generation
+          // preview, turn hiding) only match when the runner's events carry
+          // THIS id, not a server-minted one.
+          turnId: id,
         };
         if (model) opts.model = model;
         if (attachments && attachments.length > 0) {

--- a/packages/plugin-subagents/src/dispatch-agent.test.ts
+++ b/packages/plugin-subagents/src/dispatch-agent.test.ts
@@ -161,3 +161,69 @@ describe('subagents — basic spawning', () => {
     expect(labels).toEqual(['one', 'three', 'two']);
   });
 });
+
+describe('subagents — model override validation', () => {
+  it('falls back to the parent model (with a warning) on a hallucinated model id', async () => {
+    const provider = new FakeProvider({
+      script: [
+        toolUseReply(
+          'dispatch_agent',
+          // Training-era id the calling LLM tends to invent.
+          { agents: [{ prompt: 'task', label: 'kid', model: 'claude-3-5-sonnet' }] },
+          'p1',
+        ),
+        textReply('child done'),
+        textReply('parent done'),
+      ],
+    });
+    const session = createFakeSession({ provider });
+    session.pluginHost.registerStatic(defaultModePlugin);
+    session.modes.setActive('default');
+    session.tools.register(dispatchAgentTool);
+
+    const events = await collectTurn(session, 'spawn with a bogus model');
+
+    const warning = events.find(
+      (e) => e.type === 'plugin_event' && e.subtype === 'subagent_warning',
+    );
+    expect(warning).toBeDefined();
+    if (warning?.type === 'plugin_event') {
+      expect((warning.payload as { message: string }).message).toBe(
+        'unknown model "claude-3-5-sonnet" — falling back to parent model "fake-model"',
+      );
+    }
+    // Request order: parent iteration 1, child, parent wrap-up. The child's
+    // provider request must carry the parent's model, not the invented one.
+    expect(provider.received[1]?.model).toBe('fake-model');
+  });
+
+  it('honors a model override the provider actually lists', async () => {
+    const models = [
+      { id: 'fake-model', contextWindow: 200_000 },
+      { id: 'cheap-model', contextWindow: 200_000 },
+    ];
+    const provider = new FakeProvider({
+      models,
+      script: [
+        toolUseReply(
+          'dispatch_agent',
+          { agents: [{ prompt: 'task', label: 'kid', model: 'cheap-model' }] },
+          'p1',
+        ),
+        textReply('child done'),
+        textReply('parent done'),
+      ],
+    });
+    const session = createFakeSession({ provider });
+    session.pluginHost.registerStatic(defaultModePlugin);
+    session.modes.setActive('default');
+    session.tools.register(dispatchAgentTool);
+
+    const events = await collectTurn(session, 'spawn cheap');
+
+    expect(
+      events.find((e) => e.type === 'plugin_event' && e.subtype === 'subagent_warning'),
+    ).toBeUndefined();
+    expect(provider.received[1]?.model).toBe('cheap-model');
+  });
+});

--- a/packages/plugin-subagents/src/dispatch-agent.ts
+++ b/packages/plugin-subagents/src/dispatch-agent.ts
@@ -30,7 +30,11 @@ const agentSpecSchema = z.object({
   model: z
     .string()
     .optional()
-    .describe('Model id override; defaults to the kind\'s model, then the parent\'s.'),
+    .describe(
+      'Model id override; defaults to the kind\'s model, then the parent\'s. ' +
+        'Omit unless the user explicitly requested a specific model — do NOT ' +
+        'invent model ids. Unknown ids fall back to the parent\'s model with a warning.',
+    ),
   mode: z
     .string()
     .optional()

--- a/packages/plugin-workflows/src/tools.ts
+++ b/packages/plugin-workflows/src/tools.ts
@@ -138,7 +138,9 @@ function createTool(deps: WorkflowToolDeps): ToolDef {
       if (!provider) {
         throw new MoxxyError({ code: 'PROVIDER_NOT_CONFIGURED', message: 'workflow_create: no active provider to draft with.' });
       }
-      const model = deps.draftModel ?? provider.models[0]?.id ?? 'claude-sonnet-4-6';
+      // 'default' matches run-turn's terminal fallback — never a hardcoded
+      // vendor model id that goes stale.
+      const model = deps.draftModel ?? provider.models[0]?.id ?? 'default';
       const drafted = await draftWorkflow(provider, model, intent, ctx.signal, {
         ...(deps.listSkills ? { availableSkills: deps.listSkills() } : {}),
         ...(deps.listTools ? { availableTools: deps.listTools() } : {}),

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -27,6 +27,7 @@ export {
   abortParamsSchema,
   setResolverParamsSchema,
   type AttachParams,
+  type AttachReplay,
   type AttachResult,
   type RunTurnParams,
   type RunTurnResult,
@@ -39,4 +40,5 @@ export {
   type EventNotification,
   type TurnCompleteNotification,
   type InfoChangedNotification,
+  type ReplayStartNotification,
 } from './protocol.js';

--- a/packages/runner/src/integration.test.ts
+++ b/packages/runner/src/integration.test.ts
@@ -17,6 +17,7 @@ import {
   type Logger,
 } from '@moxxy/core';
 import {
+  asTurnId,
   defineMode,
   definePlugin,
   defineProvider,
@@ -180,6 +181,132 @@ describe('runner end-to-end', () => {
     expect(late.log.length).toBeGreaterThan(skipTo);
     const followups = late.log.ofType('assistant_message');
     expect(followups[followups.length - 1]?.content).toContain('second answer');
+  });
+
+  it('runs the turn under a client-supplied turnId so per-turn filters match (v6)', async () => {
+    // Regression: the desktop pre-mints a turn id per renderer request, but the
+    // server used to mint its OWN id — so renderer filters on the returned id
+    // (skill-generation preview, turn hiding) never matched any event.
+    const { socketPath } = await serve(new FakeProvider({ script: [textReply('tagged')] }));
+    const remote = await attach(socketPath);
+    const minted = asTurnId('client-minted-turn');
+    const turnIds = new Set<string>();
+    for await (const event of remote.runTurn('say hi', { turnId: minted })) {
+      turnIds.add(event.turnId);
+    }
+    expect([...turnIds]).toEqual([minted]);
+    // The authoritative log carries the client's id too, not a server-minted one.
+    expect(remote.log.byTurn(minted).length).toBeGreaterThan(0);
+  });
+
+  it('rejects a client-supplied turnId that is already in flight (collision)', async () => {
+    const socketPath = tmpSocket();
+    const session = buildSession(new FakeProvider({ script: [textReply('unused')] }));
+    // A mode that blocks until aborted, so the first turn is still in flight
+    // when the colliding request lands.
+    session.pluginHost.registerStatic(
+      definePlugin({
+        name: 'runner-test-collision',
+        modes: [
+          defineMode({
+            name: 'wait-mode',
+
+            run: async function* (modeCtx) {
+              await new Promise<void>((resolve) => {
+                if (modeCtx.signal.aborted) return resolve();
+                modeCtx.signal.addEventListener('abort', () => resolve(), { once: true });
+              });
+            },
+          }),
+        ],
+      }),
+    );
+    session.modes.setActive('wait-mode');
+    const server = await startRunnerServer(session, { socketPath });
+    servers.push(server);
+    const remote = await attach(socketPath);
+
+    const minted = asTurnId('duplicate-turn');
+    const controller = new AbortController();
+    const first = (async () => {
+      for await (const _event of remote.runTurn('block', { turnId: minted, signal: controller.signal })) {
+        void _event;
+      }
+    })();
+    await waitFor(() => session.log.length > 0);
+
+    const second = (async () => {
+      for await (const _event of remote.runTurn('hijack', { turnId: minted })) void _event;
+    })();
+    await expect(second).rejects.toThrow(/already in flight/);
+
+    controller.abort();
+    await expect(first).resolves.toBeUndefined();
+  });
+
+  it('skips the history replay when a client attaches with replay "none" (v6)', async () => {
+    const { session, socketPath } = await serve(
+      new FakeProvider({ script: [textReply('first answer'), textReply('live answer')] }),
+    );
+    const a = await attach(socketPath, 'first');
+    for await (const _event of a.runTurn('say hi')) void _event;
+    const historyLen = session.log.length;
+    expect(historyLen).toBeGreaterThan(0);
+
+    const late = await connectRemoteSession({ socketPath, role: 'late', replay: 'none' });
+    remotes.push(late);
+    // No history was replayed into the mirror...
+    expect(late.log.length).toBe(0);
+
+    // ...but live events still stream in contiguously: ReplayStart rebased the
+    // mirror to the runner's current seq, so the next event is accepted.
+    for await (const _event of late.runTurn('again')) void _event;
+    expect(late.log.length).toBeGreaterThan(0);
+    // Original (authoritative) seqs are preserved on the rebased mirror.
+    expect(late.log.at(historyLen)?.seq).toBe(historyLen);
+    const fresh = late.log.ofType('assistant_message')[0] as AssistantMessageEvent | undefined;
+    expect(fresh?.content).toContain('live answer');
+    expect(JSON.stringify(late.log.toJSON())).not.toContain('first answer');
+  });
+
+  it('replays only the last N events when a client attaches with replay { tail } (v6)', async () => {
+    const { session, socketPath } = await serve(
+      new FakeProvider({ script: [textReply('first answer')] }),
+    );
+    const a = await attach(socketPath, 'first');
+    for await (const _event of a.runTurn('say hi')) void _event;
+    const historyLen = session.log.length;
+    // At minimum a user_prompt and an assistant_message.
+    expect(historyLen).toBeGreaterThan(1);
+
+    const late = await connectRemoteSession({ socketPath, role: 'late', replay: { tail: 1 } });
+    remotes.push(late);
+    expect(late.log.length).toBe(1);
+    // The tail keeps its authoritative seq (rebased mirror, not re-numbered).
+    expect(late.log.at(historyLen - 1)?.seq).toBe(historyLen - 1);
+    expect(late.log.at(historyLen - 2)).toBeUndefined();
+  });
+
+  it('session.reset re-arms a replay-"none" (rebased) mirror at seq 0', async () => {
+    const { session, socketPath } = await serve(
+      new FakeProvider({ script: [textReply('first answer'), textReply('post-reset answer')] }),
+    );
+    const a = await attach(socketPath, 'first');
+    for await (const _event of a.runTurn('say hi')) void _event;
+    expect(session.log.length).toBeGreaterThan(0);
+
+    const late = await connectRemoteSession({ socketPath, role: 'late', replay: 'none' });
+    remotes.push(late);
+
+    await late.reset();
+    expect(session.log.length).toBe(0);
+
+    // Post-reset events restart at seq 0; the cleared mirror must accept them
+    // (clear() reset the rebased base back to 0).
+    for await (const _event of late.runTurn('again')) void _event;
+    expect(late.log.at(0)?.seq).toBe(0);
+    const fresh = late.log.ofType('assistant_message')[0] as AssistantMessageEvent | undefined;
+    expect(fresh?.content).toContain('post-reset answer');
   });
 
   it('routes a tool-call permission prompt to the turn-owning client', async () => {
@@ -713,7 +840,7 @@ describe('runner end-to-end', () => {
     const server = await startRunnerServer(session, { socketPath });
     servers.push(server);
     const remote = await attach(socketPath);
-    expect(remote.runnerProtocolVersion).toBe(5);
+    expect(remote.runnerProtocolVersion).toBe(RUNNER_PROTOCOL_VERSION);
 
     const result = await remote.workflows.resume('run-7', 'ship it');
     expect(result.ok).toBe(true);

--- a/packages/runner/src/protocol-negotiation.test.ts
+++ b/packages/runner/src/protocol-negotiation.test.ts
@@ -117,7 +117,7 @@ describe('tolerant protocol negotiation — server handshake', () => {
   it('the compatibility floor is at or below the current version', () => {
     // Sanity: a current client must always be accepted by a current server.
     expect(MIN_COMPATIBLE_PROTOCOL_VERSION).toBeLessThanOrEqual(RUNNER_PROTOCOL_VERSION);
-    // Every change through v5 has been additive — the floor is still 1.
+    // Every change through v6 has been additive — the floor is still 1.
     expect(MIN_COMPATIBLE_PROTOCOL_VERSION).toBe(1);
   });
 

--- a/packages/runner/src/protocol.ts
+++ b/packages/runner/src/protocol.ts
@@ -63,16 +63,32 @@ import type {
  * an actionable "update the CLI" message instead of a raw method-not-found.
  * (Additive — a v4 server simply lacks this one method.)
  *
- * Every change v1→v5 has been ADDITIVE, so MIN_COMPATIBLE stays at 1: today's
+ * v6: two additive changes.
+ *   - `runTurn` accepts an optional client-supplied `turnId`, echoed onto every
+ *     event of the turn. The desktop pre-mints a turn id per renderer request,
+ *     and its per-turn event filters (skill-generation preview, turn hiding)
+ *     only work when the runner's events actually carry that id. An older
+ *     server ignores the field (zod strips unknown keys) and mints its own id —
+ *     the reply still returns the AUTHORITATIVE id, so a v6 client on a v5
+ *     server degrades to the old behavior instead of breaking.
+ *   - `attach` accepts an optional `replay` param ('full' | 'none' |
+ *     { tail: N }, default 'full') and the server sends a `replay.start`
+ *     notification ({ fromSeq }) before the replay loop so the client can
+ *     rebase its mirror to the first replayed seq. Lets the desktop skip the
+ *     full-history replay (its renderer history comes from the NDJSON chat
+ *     log, not the mirror). An older server ignores the param and replays in
+ *     full from seq 0 without `replay.start` — still correct, just slower.
+ *
+ * Every change v1→v6 has been ADDITIVE, so MIN_COMPATIBLE stays at 1: today's
  * server can serve any client back to v1, and any client v1+ can attach. Bump
  * MIN_COMPATIBLE to N only when landing a breaking change at version N.
  */
-export const RUNNER_PROTOCOL_VERSION = 5;
+export const RUNNER_PROTOCOL_VERSION = 6;
 
 /**
  * Lowest client protocol version this build's CORE session protocol is
  * compatible with. The handshake rejects only clients BELOW this. Since every
- * change through v4 was purely additive, this is 1 — bump it (to the new
+ * change through v6 was purely additive, this is 1 — bump it (to the new
  * version) the moment a genuinely BREAKING protocol change lands, and never
  * before. See the versioning rule in the module doc above.
  */
@@ -156,6 +172,13 @@ export const RunnerNotification = {
    * mirror only accepts from an empty log.
    */
   SessionReset: 'session.reset',
+  /**
+   * Sent once, immediately before the attach-time replay loop (v6): the
+   * first seq this connection will replay/stream. The client rebases its
+   * (empty) mirror to `fromSeq` so a partial replay (`replay: 'none'` /
+   * `{ tail }`) ingests contiguously instead of dropping every event.
+   */
+  ReplayStart: 'replay.start',
 } as const;
 export type RunnerNotification = (typeof RunnerNotification)[keyof typeof RunnerNotification];
 
@@ -163,12 +186,26 @@ export type RunnerNotification = (typeof RunnerNotification)[keyof typeof Runner
 // Request params / results
 // ---------------------------------------------------------------------------
 
+/**
+ * How much history `attach` replays into the client's mirror (v6).
+ *   - 'full' (default): everything from seq 0 — the TUI / `moxxy attach` path.
+ *   - 'none': nothing — the desktop path, whose renderer history comes from
+ *     its own NDJSON chat log; only live events stream after attach.
+ *   - { tail: N }: the last N events — enough recent context for a mirror
+ *     without paying for the whole conversation.
+ * The server announces the chosen start seq via the `replay.start`
+ * notification so the client can rebase its mirror before ingesting.
+ */
+export type AttachReplay = 'full' | 'none' | { readonly tail: number };
+
 export interface AttachParams {
   readonly protocolVersion: number;
   /** Channel role attaching (e.g. 'tui', 'telegram') - informational/logging. */
   readonly role: string;
   /** Replay events from this seq on attach so a late client sees history. */
   readonly sinceSeq?: number;
+  /** Replay policy (v6). Older servers strip the key and replay in full. */
+  readonly replay?: AttachReplay;
 }
 export interface AttachResult {
   readonly sessionId: string;
@@ -182,6 +219,12 @@ export interface RunTurnParams {
   readonly systemPrompt?: string;
   readonly maxIterations?: number;
   readonly attachments?: ReadonlyArray<UserPromptAttachment>;
+  /**
+   * Client-supplied turn id (v6). When present the server runs the turn under
+   * THIS id (so the client's per-turn event filters match) instead of minting
+   * one; it must be unique — the server rejects an id already in flight.
+   */
+  readonly turnId?: string;
 }
 export interface RunTurnResult {
   readonly turnId: string;
@@ -310,6 +353,10 @@ export interface TurnCompleteNotification {
 export interface InfoChangedNotification {
   readonly info: SessionInfo;
 }
+export interface ReplayStartNotification {
+  /** First seq this connection replays/streams; the mirror rebases to it. */
+  readonly fromSeq: number;
+}
 
 // ---------------------------------------------------------------------------
 // Inbound validation (control plane). The runner validates client->server
@@ -331,6 +378,13 @@ export const attachParamsSchema = z.object({
   protocolVersion: z.number(),
   role: z.string(),
   sinceSeq: z.number().int().nonnegative().optional(),
+  replay: z
+    .union([
+      z.literal('full'),
+      z.literal('none'),
+      z.object({ tail: z.number().int().positive() }),
+    ])
+    .optional(),
 });
 
 export const runTurnParamsSchema = z.object({
@@ -339,6 +393,9 @@ export const runTurnParamsSchema = z.object({
   systemPrompt: z.string().optional(),
   maxIterations: z.number().int().positive().optional(),
   attachments: z.array(attachmentSchema).optional(),
+  // Bounded like the other id-bearing params so a hostile client can't stuff
+  // an arbitrary blob into every event of the turn.
+  turnId: z.string().min(1).max(120).optional(),
 });
 
 export const abortParamsSchema = z.object({ turnId: z.string() });

--- a/packages/runner/src/remote-session.ts
+++ b/packages/runner/src/remote-session.ts
@@ -49,10 +49,12 @@ import {
   RunnerMethod,
   RunnerNotification,
   type ApprovalConfirmParams,
+  type AttachReplay,
   type AttachResult,
   type EventNotification,
   type InfoChangedNotification,
   type PermissionCheckParams,
+  type ReplayStartNotification,
   type RunTurnResult,
   type SynthesizeResult,
   type TurnCompleteNotification,
@@ -104,6 +106,13 @@ export interface RemoteSessionOptions {
   readonly role?: string;
   /** Replay history from this seq (default 0 = full conversation). */
   readonly sinceSeq?: number;
+  /**
+   * Attach-time replay policy (protocol v6, default 'full'). 'none' / { tail }
+   * skip (most of) the history replay — for clients whose UI history comes
+   * from somewhere else (the desktop's NDJSON chat log). An older server
+   * ignores the option and replays in full, which is still correct.
+   */
+  readonly replay?: AttachReplay;
   /** Inject a transport (tests). Defaults to a unix-socket connection. */
   readonly transport?: Transport;
   /**
@@ -197,6 +206,13 @@ export class RemoteSession implements ClientSession {
     this.peer.on(RunnerNotification.InfoChanged, (params) => {
       this.info = (params as InfoChangedNotification).info;
     });
+    this.peer.on(RunnerNotification.ReplayStart, (params) => {
+      // The server announces the first seq it will replay/stream on this
+      // connection (v6) before any event arrives. Rebase the (still empty)
+      // mirror so a partial replay ('none' / { tail }) ingests contiguously.
+      const { fromSeq } = params as ReplayStartNotification;
+      this.mirror.rebase(fromSeq);
+    });
     this.peer.on(RunnerNotification.SessionReset, () => {
       // The runner wiped its authoritative log (a /new from this client or
       // any other). Clear the mirror in lockstep: `ingest` accepts only
@@ -250,11 +266,12 @@ export class RemoteSession implements ClientSession {
   }
 
   /** Handshake. Resolves once history has been replayed into the mirror. */
-  async attach(role: string, sinceSeq: number): Promise<void> {
+  async attach(role: string, sinceSeq: number, replay?: AttachReplay): Promise<void> {
     const result = await this.peer.request<AttachResult>(RunnerMethod.Attach, {
       protocolVersion: RUNNER_PROTOCOL_VERSION,
       role,
       sinceSeq,
+      ...(replay ? { replay } : {}),
     });
     this.info = result.info;
     // Record the server's protocol so version-gated methods can degrade
@@ -331,6 +348,10 @@ export class RemoteSession implements ClientSession {
       ...(opts.systemPrompt ? { systemPrompt: opts.systemPrompt } : {}),
       ...(opts.maxIterations ? { maxIterations: opts.maxIterations } : {}),
       ...(opts.attachments && opts.attachments.length > 0 ? { attachments: opts.attachments } : {}),
+      // Pre-minted client turn id (v6) so per-turn event filters match. The
+      // reply's turnId stays authoritative: an older server ignores ours and
+      // mints its own.
+      ...(opts.turnId ? { turnId: opts.turnId } : {}),
     });
     const turnId = result.turnId as TurnId;
 
@@ -772,7 +793,7 @@ export async function connectRemoteSession(
     (await connectWithRetry(socketPath, opts.connectRetries ?? 5));
   const session = new RemoteSession(transport);
   try {
-    await session.attach(opts.role ?? 'client', opts.sinceSeq ?? 0);
+    await session.attach(opts.role ?? 'client', opts.sinceSeq ?? 0, opts.replay);
     return session;
   } catch (err) {
     await maybeRecoverFromMismatch(err, socketPath, opts);

--- a/packages/runner/src/server.ts
+++ b/packages/runner/src/server.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Session } from '@moxxy/core';
 import { newTurnId, savePreferences } from '@moxxy/core';
+import { asTurnId } from '@moxxy/sdk';
 import type {
   ApprovalDecision,
   ApprovalRequest,
@@ -210,14 +211,21 @@ export class RunnerServer {
     }
     client.role = params.role;
     client.attached = true;
-    // Always replay the full history from seq 0, regardless of params.sinceSeq.
-    // The client's mirror is a fresh EventLog whose `ingest` accepts only the
-    // next-expected seq (contiguous from 0), so a partial replay starting at
-    // sinceSeq>0 would drop every event and permanently desync the mirror.
-    // `sinceSeq` stays on the wire for compatibility but is intentionally
-    // ignored. This loop is fully synchronous, so no live event can interleave
-    // before it finishes - every later event arrives exactly once via broadcast.
-    for (const event of this.session.log.slice(0)) {
+    // Replay per the client's `replay` policy (v6; default 'full'). The start
+    // seq is announced via `replay.start` BEFORE the loop so the client can
+    // rebase its (empty) mirror — its `ingest` accepts only the next-expected
+    // seq, so a partial replay without the rebase would drop every event and
+    // permanently desync the mirror. `sinceSeq` predates `replay` and stays on
+    // the wire for compatibility but is intentionally ignored (pre-v6 clients
+    // can't rebase, so they always need the full replay). This loop is fully
+    // synchronous, so no live event can interleave before it finishes - every
+    // later event arrives exactly once via broadcast.
+    const replay = params.replay ?? 'full';
+    const total = this.session.log.length;
+    const start =
+      replay === 'full' ? 0 : replay === 'none' ? total : Math.max(0, total - replay.tail);
+    client.peer.notify(RunnerNotification.ReplayStart, { fromSeq: start });
+    for (const event of this.session.log.slice(start)) {
       client.peer.notify(RunnerNotification.Event, { event });
     }
     return {
@@ -229,7 +237,16 @@ export class RunnerServer {
 
   private handleRunTurn(client: ConnectedClient, raw: unknown): RunTurnResult {
     const params = runTurnParamsSchema.parse(raw);
-    const turnId = newTurnId();
+    // Honour a client-supplied id (v6) so the client's per-turn event filters
+    // match the events the runner emits. A collision with an in-flight turn is
+    // a client bug (or a cross-client hijack attempt) — reject it loudly
+    // rather than letting two turns share one controller/owner entry.
+    const turnId = params.turnId ? asTurnId(params.turnId) : newTurnId();
+    if (this.turnControllers.has(turnId)) {
+      throw new Error(
+        `turn id ${turnId} is already in flight — client-supplied turn ids must be unique`,
+      );
+    }
     const controller = new AbortController();
     this.turnControllers.set(turnId, { controller, owner: client });
     client.turns.add(turnId);


### PR DESCRIPTION
Fixes 17 reported issues across the desktop app, mobile app, and core.

## Runner protocol v6 (additive, floor bumped in lockstep)
- **Client-supplied turn ids**: `runTurn` accepts a pre-minted `turnId`, so the renderer-visible id matches `event.turnId`. Fixes the completely broken **"Generate skill with AI"** flow (preview never streamed; generation leaked into the chat transcript) at the root.
- **Attach replay policy** `'full' | 'none' | { tail: n }` + EventLog rebase: the desktop attaches with `replay: 'none'`, so app start / desk switch / reconnect no longer replays the full session JSONL (~95% per-token chunks) over the socket. History was already paginated via `chat.loadSegment`; the composer-ready gate now stops waiting on a full replay.

## Desktop
- **Multiple sessions per workspace**: desks own a session list (DeskDoc v2; v1 migrates so the first session keeps the desk id and resumes existing logs), the runner pool is keyed by session id (one `moxxy serve` per session), new `sessions.list/create/setActive/remove/rename` IPC (remove host-only, rest remote-allowed), and the sidebar lists the active desk's sessions with new/rename/delete. `session.newSession` keeps its reset-current semantics.
- **Dark mode**: light/dark/system in Settings → Appearance, persisted in prefs and mirrored into `nativeTheme` before window creation (dark splash + window background, no white flash); designed `darkTokens` palette in `@moxxy/design-tokens` with a CI-enforced `[data-theme="dark"]` parity test; ~224 hardcoded colors migrated across chat/settings/shell/onboarding/workflows/desktop-ui; Clerk modals follow the theme via `@clerk/themes`.
- **MCP & Provider Add buttons** with a shared "ask moxxy to do it" prompt-box (`useAgentTask` + `AgentTaskModal`): moxxy runs a hidden background turn using `mcp_test_server`/`mcp_add_server`, `provider_add`/`provider_test` (secrets via vault); the skill generator is refactored onto the same mechanism; permission asks render in-modal plus a global fallback.
- **Subagents inherit the parent's resolved model**: hallucinated ids warn + fall back to the parent model, workflow-trigger spawns use the session's last resolved model, nested spawns inherit the child's effective model, hardcoded model-id fallbacks deleted.
- **Clerk sign-in redirect**: Google OAuth no longer strands the window on Clerk's blank hosted "My account" page — explicit fallback redirect URLs + a main-process account-portal recovery handler (no allow-list widening).
- **Self-update is honest about protocol bumps**: staging enforces the same runner-protocol lockstep gate as boot, so a protocol-bumping release reports **requires full update** with a release-page CTA instead of staging a bundle the bootstrap refuses and claiming success (the reported "says updated and restart but nothing changes"). Update diagnostics surface boot-log reject reasons in plain language, and floor boots after `app.relaunch()` no longer inherit the previous override's identity (health-signal corruption). The Dock ghost-terminal sighting was diagnosed as the pre-fix floor binary running during the refused-update window — already resolved by the 0.4.3 full install; current spawn paths verified clean live.
- **Workflow canvas**: now a true infinite canvas (Figma-like) — wheel/trackpad pans both axes unbounded, ctrl/cmd+wheel & pinch zoom anchored at the cursor (10–400%), drag-to-pan, double-click resets, zoom-to-fit, viewport persisted with the workflow; Delete/Backspace removes the selected node; dropping a connector on empty canvas opens an insert-node popup that creates and wires the node at the drop point.

## Mobile
- **Connection fix (verified live)**: the connection store re-primes on every reconnect, fixing the "shows Connected but deaf" state — reproduced headlessly against a local `moxxy mobile` gateway incl. runner-restart workspace-id rotation; gateway URL edits commit on blur instead of rebuilding the socket per keystroke.
- Removed the redundant top-right actions toggle; menu entries are chips; tapping an executed tool opens a diagnostics panel (input/output/error, 16KB cap); the QR scanner starts scanning immediately.

## Tests
Full gate green at every wave: build, typecheck, lint, tests (desktop-host 281, core 216+, runner 62, apps/desktop 101, mobile 96, client-core 58, plus cli/plugin suites). New coverage: runner turnId/replay integration tests, EventLog rebase units, desks v1→v2 migration + sessions handler/store/UI tests, subagent model-fallback tests, stage-time protocol-gate tests, dark-mode parity tests, infinite-canvas pan/zoom tests, mobile transcript/diagnostics/QR tests.

Manual follow-ups: packaged-app Google sign-in round-trip; visual dark-mode QA pass (chat/settings/onboarding); physical-device pairing pass.