### PR TITLE
feat(desktop): multi-session workspaces, dark mode, infinite workflow canvas, honest self-update on protocol bumps

### DIFF
--- a/.changeset/desktop-fixes-wave-2-3.md
+++ b/.changeset/desktop-fixes-wave-2-3.md
@@ -1,0 +1,10 @@
+---
+'@moxxy/desktop-host': minor
+'@moxxy/desktop-ipc-contract': minor
+'@moxxy/client-core': minor
+'@moxxy/desktop': minor
+'@moxxy/design-tokens': minor
+'@moxxy/desktop-ui': patch
+---
+
+Desktop workspaces now hold multiple sessions: desks persist a session list (v1 docs migrate so the first session keeps the desk's id and resumes its existing logs), the runner pool is keyed by session id (one `moxxy serve` per session), new `sessions.list/create/setActive/remove/rename` IPC commands (list/create/setActive/rename remote-allowed for mobile; remove host-only), and the sidebar shows the active desk's sessions with new/rename/delete affordances — `session.newSession` keeps its reset-current semantics. The desktop also gains dark mode (light/dark/system in Settings → Appearance, persisted in prefs, nativeTheme-synced, Clerk modals themed; designed `darkTokens` palette with CI-enforced light/dark parity), the workflow builder becomes a true infinite canvas (pan both axes unbounded, cursor-anchored zoom 10–400%, zoom-to-fit, persisted viewport), and self-update is honest about runner-protocol bumps: such releases report "requires full update" with a release-page link instead of staging a bundle the bootstrap would refuse and claiming success, update diagnostics explain boot-time refusals, and floor boots after a relaunch no longer inherit the previous override's identity.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -604,6 +604,24 @@ on a real two-version update that 0.0.30+ now sticks (the fix lives in the *over
 a user on the broken 0.0.28 floor recovers simply by updating to a fixed release). Once verified,
 consider dropping the now-redundant renderer-heartbeat path. **Severity med** (needs a build to close).
 
+**2026-06-11 third failure mode found + fixed:** a release that bumps `RUNNER_PROTOCOL_VERSION`
+hot-staged fine but was refused at boot by the lockstep gate (`runner-protocol-skew`) — the stager
+never checked the gate, so the UI said "updated, relaunch" and every boot silently fell to the
+floor (observed live on 0.4.2→0.4.3). Stage-time now enforces the same gate via
+`exceedsCliRunnerProtocol` and reports **requires-full-update** (release-page CTA); Diagnostics
+renders boot-log reject reasons in plain language. Same pass: `bootstrap.ts boot()` now clears
+`MOXXY_APP_BUNDLE_ROOT/VERSION` up front — they survive `app.relaunch()`, so a floor boot after a
+refused override impersonated the previous override and let the boot probe confirm/poison a bundle
+that wasn't running. Residual (low): any pre-be7d33a floor will show the macOS Dock ghost-runner
+whenever a refused update drops onto it — immutable floor code, only a full reinstall fixes it.
+
+**Multi-session testing caveat (2026-06-11):** desks now hold N sessions and the runner pool is
+keyed by session id, but every v1-migrated/first session has id === desk id — which masks
+pool-key regressions. Always test multi-session paths with a desk's *second* (UUID-keyed) session.
+Related accepted behavior: `desks.remove` stops session runners but leaves their session JSONL +
+chat NDJSON on disk (pre-existing parity, now per-session); sessions spawn eagerly and background
+runners stay alive (consider lazy spawn + idle-stop).
+
 ### 10. Shared-client extraction + WebSocket bridge — follow-ups — ⚠️ PARTIALLY DONE
 **Introduced 2026-06-09** by the cross-platform client work (new `@moxxy/client-core`,
 `@moxxy/client-platform-web`, `@moxxy/client-transport-ws`, `@moxxy/ipc-server-ws`,

--- a/apps/desktop/electron/main/bootstrap.ts
+++ b/apps/desktop/electron/main/bootstrap.ts
@@ -63,6 +63,13 @@ async function load(entry: string): Promise<void> {
 const shell = { electron: process.versions.electron, nodeAbi: process.versions.modules ?? '' };
 
 async function boot(): Promise<void> {
+  // These survive app.relaunch(): a floor boot after a refused/rolled-back
+  // override would otherwise inherit the previous override's identity and let
+  // the boot probe confirm/poison a bundle that isn't running. Resolution
+  // re-sets them below when a bundle IS picked.
+  delete process.env.MOXXY_APP_BUNDLE_ROOT;
+  delete process.env.MOXXY_APP_BUNDLE_VERSION;
+
   // Let a userData bundle resolve the shell's optional native deps (keychain).
   setupNativeResolution(floorRoot);
 

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -63,6 +63,7 @@ import type { WebSocketCommandBus, WebSocketBridgeServer } from '@moxxy/ipc-serv
 import { resolveWsBridgeConfig, MobileGatewayManager } from './ws-bridge.js';
 
 import { BUNDLED_UPDATE_PUBLIC_KEY } from './update-key.js';
+import { FLOOR_RUNNER_PROTOCOL } from './floor-runner-protocol.js';
 import { readConfirmed, markConfirmed, markBad, appendBootLog } from '@moxxy/desktop-host/app-update';
 import { initShellUpdater } from './shell-updater.js';
 
@@ -77,7 +78,7 @@ if (app.isPackaged && !process.env.MOXXY_CLI_ENTRY) {
   const entry = preferredCliEntry(app.getPath('userData'), process.resourcesPath);
   if (entry) process.env.MOXXY_CLI_ENTRY = entry;
 }
-import { ipcMain, Tray, Menu, nativeImage, globalShortcut, session, shell, systemPreferences } from 'electron';
+import { ipcMain, Tray, Menu, nativeImage, nativeTheme, globalShortcut, session, shell, systemPreferences } from 'electron';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -226,7 +227,11 @@ async function createWindow(): Promise<void> {
     height: 760,
     minWidth: 720,
     minHeight: 480,
-    backgroundColor: '#f1f2f9',
+    // Match the themed app canvas (--color-app-bg light/dark) so the window
+    // doesn't flash white-then-dark while the renderer boots. themeSource was
+    // set from prefs before createWindow, so shouldUseDarkColors is correct
+    // for explicit choices as well as `system`.
+    backgroundColor: nativeTheme.shouldUseDarkColors ? '#0b0c13' : '#f1f2f9',
     autoHideMenuBar: true,
     icon: iconPath,
     webPreferences: {
@@ -729,6 +734,17 @@ app.whenReady().then(async () => {
   // app.quit() above; do nothing here so it exits cleanly.
   if (!gotSingleInstanceLock) return;
 
+  // Apply the persisted theme preference BEFORE any window exists so the
+  // very first paint (splash background, window chrome, the renderer's
+  // prefers-color-scheme media query) already reflects it. `system` is the
+  // default and means "follow the OS". The prefs.update IPC handler keeps
+  // themeSource in sync afterwards; readPrefs is sync, so no boot race.
+  // Guarded because prefs.json is user-editable and Electron throws on an
+  // unknown themeSource value — a hand-mangled pref must not brick boot.
+  const themePref = readPrefs().theme;
+  nativeTheme.themeSource =
+    themePref === 'light' || themePref === 'dark' ? themePref : 'system';
+
   // Present a plain desktop-Chrome user-agent (no Electron/app product
   // tokens) to every request. Google blocks OAuth from "embedded"
   // user-agents ("this browser may not be secure"); a clean UA lets the
@@ -924,6 +940,13 @@ app.whenReady().then(async () => {
       // Dev/test escape hatch: point the updater at a local manifest. Ignored in
       // packaged builds (the handler pins the source) so it can't be abused.
       manifestUrl: process.env.MOXXY_UPDATE_URL,
+      // The same runner-protocol ceiling the bootstrap's boot gate enforces, so
+      // the stager refuses (with a "needs the full installer" status) a bundle
+      // that every boot would silently reject as `runner-protocol-skew`. When
+      // this main IS a hot-updated override, its compiled constant can only be
+      // ≤ the floor's (the boot gate already admitted it) — i.e. at worst the
+      // stage-time gate is conservative, never permissive.
+      cliRunnerProtocol: FLOOR_RUNNER_PROTOCOL,
     },
     // Bridge-control commands (host-only; refused over the WS transport).
     ...(mobileGateway ? { mobileGateway } : {}),

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -871,8 +871,11 @@ app.whenReady().then(async () => {
   // surface from the first paint.
   const initialActive = await desks.getActive();
   if (initialActive) {
-    await pool.getOrCreate(initialActive.id, initialActive.cwd);
-    pool.setActive(initialActive.id);
+    // The pool is keyed by SESSION id — prime the desk's active session
+    // (for a pre-multi-session desk this is the desk id itself, so the
+    // sticky runner log it resumes is unchanged).
+    await pool.getOrCreate(initialActive.activeSessionId, initialActive.cwd);
+    pool.setActive(initialActive.activeSessionId);
   } else {
     await pool.getOrCreate(UNBOUND_ID, null);
     pool.setActive(UNBOUND_ID);

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -33,6 +33,14 @@
       #splash-fallback .label { font-size: 0.85rem; color: #475569;
         letter-spacing: 0.04em; font-family: 'JetBrains Mono', monospace; }
       @keyframes splash-spin { to { transform: rotate(360deg); } }
+      /* Dark splash — main sets nativeTheme.themeSource from the persisted
+         pref BEFORE the window is created, so this media query reflects the
+         user's choice (not just the OS) by the time this CSS evaluates. The
+         colors mirror styles.css's dark --color-main-bg / text tokens. */
+      @media (prefers-color-scheme: dark) {
+        html, body { background: #101117; color: #e8eaf6; }
+        #splash-fallback .label { color: #a4abc8; }
+      }
       @media (prefers-reduced-motion: reduce) {
         #splash-fallback .mark { animation-duration: 1.6s; }
       }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@clerk/clerk-react": "^5.0.0",
+    "@clerk/themes": "^2.4.57",
     "@moxxy/chat-model": "workspace:*",
     "@moxxy/cli": "workspace:*",
     "@moxxy/client-core": "workspace:*",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -12,6 +12,7 @@ import {
 } from '@moxxy/client-core';
 import { AskSheet } from './chat/AskSheet';
 import { useAskSurfaceClaimed } from '@/lib/askSurface';
+import { useTheme } from '@/lib/useTheme';
 import { ConnectionScreen, type UpdateCliResult } from './connection/ConnectionScreen';
 import { Onboarding } from './onboarding/Onboarding';
 import { ChatSurface } from './chat/ChatSurface';
@@ -35,6 +36,9 @@ import { api, toErrorMessage } from '@moxxy/client-core';
  *      WorkspaceSidebar | ContextRail | <active view>.
  */
 export function App(): JSX.Element {
+  // Theme controller — applies the persisted light/dark/system pref to
+  // <html data-theme> and tracks OS scheme changes. Mounted exactly once.
+  useTheme();
   const activeWorkspaceId = useActiveWorkspaceId();
   const { snapshot, hasEverConnected, retry } = useConnection(activeWorkspaceId);
   const { prefs, loading: prefsLoading } = usePrefs();

--- a/apps/desktop/src/ErrorBoundary.tsx
+++ b/apps/desktop/src/ErrorBoundary.tsx
@@ -46,13 +46,15 @@ export class ErrorBoundary extends Component<Props, State> {
           gap: 16,
           padding: '48px 40px',
           overflow: 'auto',
-          background: 'rgb(252, 252, 255)',
-          color: '#0f172a',
+          // Theme vars with literal fallbacks: the boundary must still
+          // render legibly if the app stylesheet itself failed to load.
+          background: 'var(--color-main-bg, rgb(252, 252, 255))',
+          color: 'var(--color-text, #0f172a)',
           fontFamily: "'Inter', -apple-system, system-ui, sans-serif",
         }}
       >
         <div style={{ fontSize: 18, fontWeight: 700 }}>MoxxyAI Workspaces hit an error</div>
-        <div style={{ fontSize: 14, color: '#475569' }}>
+        <div style={{ fontSize: 14, color: 'var(--color-text-muted, #475569)' }}>
           The app failed to render. You can reload, or report this with the details below.
         </div>
         <pre

--- a/apps/desktop/src/Splash.tsx
+++ b/apps/desktop/src/Splash.tsx
@@ -25,7 +25,7 @@ export function Splash({
         gap: '1.25rem',
         // Match the chat surface bg so the cold-start splash feels
         // continuous with the app's first useful screen.
-        background: 'rgb(252, 252, 255)',
+        background: 'var(--color-main-bg)',
         color: 'var(--color-text)',
       }}
     >

--- a/apps/desktop/src/chat/AskSheet.tsx
+++ b/apps/desktop/src/chat/AskSheet.tsx
@@ -84,7 +84,7 @@ function ApprovalSheet({
               fontSize: 13.5,
               lineHeight: 1.5,
               color: 'var(--color-text)',
-              background: '#fff',
+              background: 'var(--color-surface)',
               border: '1px solid var(--color-card-border)',
               borderRadius: 10,
               outline: 'none',
@@ -138,7 +138,7 @@ function Sheet({
       className="anim-fade-up"
       style={{
         margin: '0 24px 8px',
-        background: '#fff',
+        background: 'var(--color-surface)',
         border: `1px solid ${accent}`,
         borderRadius: 14,
         boxShadow: '0 18px 40px -22px rgba(15, 23, 42, 0.4)',
@@ -197,8 +197,8 @@ function SheetButton({
     tone === 'primary'
       ? { bg: 'var(--color-primary-strong)', color: '#fff', border: 'transparent' }
       : tone === 'danger'
-        ? { bg: '#fff', color: 'var(--color-red)', border: 'var(--color-card-border)' }
-        : { bg: '#fff', color: 'var(--color-text-muted)', border: 'var(--color-card-border)' };
+        ? { bg: 'var(--color-surface)', color: 'var(--color-red)', border: 'var(--color-card-border)' }
+        : { bg: 'var(--color-surface)', color: 'var(--color-text-muted)', border: 'var(--color-card-border)' };
   return (
     <button
       type="button"
@@ -231,7 +231,7 @@ const bodyTextStyle: React.CSSProperties = {
 const preStyle: React.CSSProperties = {
   margin: 0,
   padding: '10px 12px',
-  background: '#f7f8fc',
+  background: 'var(--color-input-soft)',
   border: '1px solid var(--color-card-border)',
   borderRadius: 8,
   fontSize: 11.5,

--- a/apps/desktop/src/chat/ChatSurface.tsx
+++ b/apps/desktop/src/chat/ChatSurface.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useChat } from '@moxxy/client-core';
-import { useDesks } from '@moxxy/client-core';
+import { deskForWorkspace, useDesks } from '@moxxy/client-core';
 import type { ConnectionPhase } from '@moxxy/desktop-ipc-contract';
 import { Transcript } from './Transcript';
 import { Composer } from './Composer';
@@ -48,7 +48,9 @@ export function ChatSurface({
   const ready = phase.phase === 'connected';
   const [searchQuery, setSearchQuery] = useState<string | null>(null);
   const [renameOpen, setRenameOpen] = useState(false);
-  const activeDesk = desks.desks.find((d) => d.id === workspaceId);
+  // workspaceId is a SESSION id (the runner-pool routing key) — resolve the
+  // desk that owns it (first sessions share their desk's id, so old ids work).
+  const activeDesk = deskForWorkspace(desks.desks, workspaceId);
 
   const filteredEvents = useMemo(() => {
     if (!searchQuery) return chat.events;

--- a/apps/desktop/src/chat/ContextMeter.tsx
+++ b/apps/desktop/src/chat/ContextMeter.tsx
@@ -38,7 +38,7 @@ export function ContextMeter({ workspaceId }: { readonly workspaceId: string }):
             width: 30,
             height: 5,
             borderRadius: 999,
-            background: 'rgba(148, 163, 184, 0.22)',
+            background: 'color-mix(in srgb, var(--color-text-dim) 22%, transparent)',
             overflow: 'hidden',
             flexShrink: 0,
           }}

--- a/apps/desktop/src/chat/ExtensionCard.tsx
+++ b/apps/desktop/src/chat/ExtensionCard.tsx
@@ -50,14 +50,19 @@ export function ExtensionCard({
       : ext.tone === 'notice'
         ? 'var(--color-amber)'
         : 'var(--color-primary-strong)';
-  const tint = ext.tone === 'error' ? '#fef2f2' : ext.tone === 'notice' ? '#fffbeb' : '#fdf2f8';
+  const tint =
+    ext.tone === 'error'
+      ? 'var(--color-red-wash)'
+      : ext.tone === 'notice'
+        ? 'var(--color-amber-wash)'
+        : 'var(--color-primary-soft)';
   return (
     <article
       data-testid="block-action"
       style={{
         alignSelf: 'stretch',
         maxWidth: '92%',
-        background: '#fff',
+        background: 'var(--color-card-bg)',
         border: '1px solid var(--color-card-border)',
         borderLeft: `3px solid ${accent}`,
         borderRadius: 12,

--- a/apps/desktop/src/chat/MarkdownBody.tsx
+++ b/apps/desktop/src/chat/MarkdownBody.tsx
@@ -44,7 +44,7 @@ const components: Components = {
           {...rest}
           className={className}
           style={{
-            background: '#f1f3fb',
+            background: 'var(--color-code-bg)',
             padding: '1px 6px',
             borderRadius: 4,
             fontSize: '0.92em',
@@ -67,7 +67,7 @@ const components: Components = {
       style={{
         margin: '0 0 0.55em',
         padding: '10px 12px',
-        background: '#f4f5fa',
+        background: 'var(--color-bg-card-hover)',
         border: '1px solid var(--color-card-border)',
         borderRadius: 8,
         fontSize: 12.5,

--- a/apps/desktop/src/chat/SkillGroupView.tsx
+++ b/apps/desktop/src/chat/SkillGroupView.tsx
@@ -137,7 +137,7 @@ export function ToolRow({ tool }: { readonly tool: ToolRowData }): JSX.Element {
   const status = statusOf(tool.outcome);
   const accent =
     status === 'error' ? 'var(--color-red)' : status === 'ok' ? 'var(--color-green)' : 'var(--color-primary)';
-  const tint = status === 'error' ? '#fee2e2' : status === 'ok' ? '#ecfdf5' : 'var(--color-primary-soft)';
+  const tint = status === 'error' ? 'var(--color-red-soft)' : status === 'ok' ? 'var(--color-green-soft)' : 'var(--color-primary-soft)';
   const summary = summarizeArgs(tool.input);
   const output = tool.outcome && tool.outcome.type === 'tool_result' ? tool.outcome.output : undefined;
   const error =
@@ -196,7 +196,7 @@ export function ToolRow({ tool }: { readonly tool: ToolRowData }): JSX.Element {
 const preStyle: React.CSSProperties = {
   margin: 0,
   padding: '8px 10px',
-  background: '#fff',
+  background: 'var(--color-surface)',
   border: '1px solid var(--color-card-border)',
   borderRadius: 6,
   fontSize: 11,

--- a/apps/desktop/src/chat/ToolGroupView.tsx
+++ b/apps/desktop/src/chat/ToolGroupView.tsx
@@ -39,7 +39,7 @@ export function ToolGroupView({
     : running
       ? 'var(--color-primary)'
       : 'var(--color-green)';
-  const tint = errored ? '#fee2e2' : running ? 'var(--color-primary-soft)' : '#ecfdf5';
+  const tint = errored ? 'var(--color-red-soft)' : running ? 'var(--color-primary-soft)' : 'var(--color-green-soft)';
 
   return (
     <div data-testid="block-tool-group" style={{ alignSelf: 'stretch', display: 'flex', gap: 12, maxWidth: '92%' }}>

--- a/apps/desktop/src/chat/UsageModal.tsx
+++ b/apps/desktop/src/chat/UsageModal.tsx
@@ -181,7 +181,7 @@ function Bar({ frac, color }: { readonly frac: number; readonly color: string })
       style={{
         height: 8,
         borderRadius: 999,
-        background: 'rgba(148, 163, 184, 0.18)',
+        background: 'color-mix(in srgb, var(--color-text-dim) 18%, transparent)',
         overflow: 'hidden',
       }}
     >

--- a/apps/desktop/src/chat/agent-picker/ChipButton.tsx
+++ b/apps/desktop/src/chat/agent-picker/ChipButton.tsx
@@ -27,7 +27,7 @@ export function ChipButton({
         color: 'var(--color-text-muted)',
         border: '1px solid var(--color-card-border)',
         borderRadius: 10,
-        background: '#fff',
+        background: 'var(--color-surface)',
         display: 'inline-flex',
         alignItems: 'center',
         gap: 6,

--- a/apps/desktop/src/chat/agent-picker/ChipSelect.tsx
+++ b/apps/desktop/src/chat/agent-picker/ChipSelect.tsx
@@ -4,8 +4,8 @@ import type { ModeBadge } from './types';
  *  chip and banner read as one signal: amber for attention, cyan for info. */
 function badgeAccent(tone: ModeBadge['tone']): { readonly accent: string; readonly soft: string } {
   return tone === 'info'
-    ? { accent: 'var(--color-accent-strong)', soft: 'rgba(34, 211, 238, 0.10)' }
-    : { accent: 'var(--color-amber)', soft: 'rgba(245, 158, 11, 0.10)' };
+    ? { accent: 'var(--color-accent-strong)', soft: 'color-mix(in srgb, var(--color-accent) 10%, transparent)' }
+    : { accent: 'var(--color-amber)', soft: 'color-mix(in srgb, var(--color-amber) 10%, transparent)' };
 }
 
 /**
@@ -44,7 +44,7 @@ export function ChipSelect({
         color: 'var(--color-text-muted)',
         border: `1px solid ${accent?.accent ?? 'var(--color-card-border)'}`,
         borderRadius: 10,
-        background: accent ? accent.soft : '#fff',
+        background: accent ? accent.soft : 'var(--color-surface)',
         display: 'inline-flex',
         alignItems: 'center',
         gap: 6,

--- a/apps/desktop/src/chat/agent-picker/ProviderModelPicker.tsx
+++ b/apps/desktop/src/chat/agent-picker/ProviderModelPicker.tsx
@@ -107,7 +107,7 @@ export function ProviderModelPicker({
             listStyle: 'none',
             margin: 0,
             padding: 6,
-            background: '#f7f8fc',
+            background: 'var(--color-input-soft)',
             borderRight: '1px solid var(--color-card-border)',
             overflowY: 'auto',
             maxHeight: 360,
@@ -141,7 +141,7 @@ export function ProviderModelPicker({
                     fontSize: 13,
                     borderRadius: 8,
                     color: isHovered ? 'var(--color-text)' : 'var(--color-text-muted)',
-                    background: isHovered ? '#fff' : 'transparent',
+                    background: isHovered ? 'var(--color-surface)' : 'transparent',
                     fontWeight: isHovered ? 600 : 500,
                     display: 'flex',
                     alignItems: 'center',
@@ -169,7 +169,7 @@ export function ProviderModelPicker({
           style={{
             display: 'flex',
             flexDirection: 'column',
-            background: '#fff',
+            background: 'var(--color-surface)',
             overflow: 'hidden',
           }}
         >
@@ -314,8 +314,8 @@ export function ProviderModelPicker({
                     margin: '6px 4px 0',
                     fontSize: 11.5,
                     color: 'var(--color-red)',
-                    background: '#fef2f2',
-                    border: '1px solid #fecaca',
+                    background: 'var(--color-red-wash)',
+                    border: '1px solid var(--color-red-border)',
                     borderRadius: 8,
                   }}
                 >

--- a/apps/desktop/src/chat/blocks/SubagentView.tsx
+++ b/apps/desktop/src/chat/blocks/SubagentView.tsx
@@ -17,8 +17,8 @@ export function SubagentView({
       : 'var(--color-green)';
   // Subagents get a distinct violet tile so they read as a different KIND of
   // actor than tool calls (which are status-tinted green/pink/red).
-  const tileBg = 'rgba(139, 92, 246, 0.14)';
-  const tileFg = '#7c3aed';
+  const tileBg = 'color-mix(in srgb, var(--color-purple) 14%, transparent)';
+  const tileFg = 'var(--color-purple-strong)';
   const statusText = running ? 'running' : block.error ? 'failed' : 'done';
   const elapsed =
     block.completedAtMs !== null ? Math.round((block.completedAtMs - block.startedAtMs) / 100) / 10 : null;
@@ -132,7 +132,7 @@ export function SubagentView({
                         gap: 7,
                         alignItems: 'baseline',
                         padding: '4px 8px',
-                        background: 'rgba(139, 92, 246, 0.07)',
+                        background: 'color-mix(in srgb, var(--color-purple) 7%, transparent)',
                         borderRadius: 7,
                         fontSize: 11,
                       }}

--- a/apps/desktop/src/chat/blocks/ToolBlock.tsx
+++ b/apps/desktop/src/chat/blocks/ToolBlock.tsx
@@ -42,7 +42,7 @@ export function ToolBlock({
   // stray indented line.
   const statusText = status === 'ok' ? 'ok' : status === 'error' ? 'failed' : 'running';
   const tint =
-    status === 'error' ? '#fee2e2' : status === 'ok' ? '#ecfdf5' : 'var(--color-primary-soft)';
+    status === 'error' ? 'var(--color-red-soft)' : status === 'ok' ? 'var(--color-green-soft)' : 'var(--color-primary-soft)';
   return (
     <div
       data-testid="block-tool"

--- a/apps/desktop/src/chat/blocks/UserBlock.tsx
+++ b/apps/desktop/src/chat/blocks/UserBlock.tsx
@@ -44,7 +44,7 @@ function FileChip({ att }: { readonly att: UserPromptAttachment }): JSX.Element 
         alignItems: 'center',
         gap: 6,
         padding: '4px 10px',
-        background: '#fff',
+        background: 'var(--color-surface)',
         border: '1px solid var(--color-primary)',
         borderRadius: 999,
         fontSize: 12,
@@ -120,7 +120,7 @@ export function UserBlock({
             whiteSpace: 'pre-wrap',
             lineHeight: 1.55,
             fontSize: 14.5,
-            boxShadow: '0 6px 18px -10px rgba(236, 72, 153, 0.55)',
+            boxShadow: '0 6px 18px -10px color-mix(in srgb, var(--color-primary) 55%, transparent)',
           }}
         >
           {text}

--- a/apps/desktop/src/chat/blocks/block-shared.ts
+++ b/apps/desktop/src/chat/blocks/block-shared.ts
@@ -7,7 +7,7 @@
 export const preStyle: React.CSSProperties = {
   margin: 0,
   padding: '8px 10px',
-  background: '#f6f7fc',
+  background: 'var(--color-input-soft)',
   border: '1px solid var(--color-card-border)',
   borderRadius: 6,
   fontSize: 11,

--- a/apps/desktop/src/chat/chat-surface/ErrorToast.tsx
+++ b/apps/desktop/src/chat/chat-surface/ErrorToast.tsx
@@ -12,7 +12,7 @@ export function ErrorToast({ text }: { readonly text: string }): JSX.Element {
         color: '#fff',
         borderRadius: 10,
         fontSize: 13,
-        boxShadow: '0 14px 28px -16px rgba(239, 68, 68, 0.6)',
+        boxShadow: '0 14px 28px -16px color-mix(in srgb, var(--color-red) 60%, transparent)',
       }}
     >
       {text}

--- a/apps/desktop/src/chat/chat-surface/Header.tsx
+++ b/apps/desktop/src/chat/chat-surface/Header.tsx
@@ -48,7 +48,7 @@ export function Header({
               color: 'var(--color-text)',
               border: '1px solid var(--color-card-border)',
               borderRadius: 8,
-              background: '#fff',
+              background: 'var(--color-surface)',
               outline: 'none',
               width: 220,
             }}

--- a/apps/desktop/src/chat/chat-surface/SuggestedActions.tsx
+++ b/apps/desktop/src/chat/chat-surface/SuggestedActions.tsx
@@ -36,7 +36,7 @@ export function SuggestedActions({
               padding: '6px 12px',
               fontSize: 12.5,
               color: 'var(--color-text-muted)',
-              background: '#fff',
+              background: 'var(--color-surface)',
               border: '1px solid var(--color-card-border)',
               borderRadius: 999,
             }}

--- a/apps/desktop/src/chat/command-palette/CommandPalette.tsx
+++ b/apps/desktop/src/chat/command-palette/CommandPalette.tsx
@@ -185,7 +185,7 @@ export function CommandPalette({ workspaceId, onClose }: Props): JSX.Element {
             padding: '9px 12px',
             fontSize: 13.5,
             color: 'var(--color-text)',
-            background: '#f7f8fc',
+            background: 'var(--color-input-soft)',
             border: '1px solid var(--color-card-border)',
             borderRadius: 10,
             outline: 'none',

--- a/apps/desktop/src/chat/composer/AttachmentChip.tsx
+++ b/apps/desktop/src/chat/composer/AttachmentChip.tsx
@@ -52,7 +52,7 @@ export function AttachmentChip({
           width: 18,
           height: 18,
           borderRadius: '50%',
-          background: 'rgba(236, 72, 153, 0.18)',
+          background: 'color-mix(in srgb, var(--color-primary) 18%, transparent)',
           color: 'var(--color-primary-strong)',
           display: 'inline-flex',
           alignItems: 'center',

--- a/apps/desktop/src/chat/composer/GoalModal.tsx
+++ b/apps/desktop/src/chat/composer/GoalModal.tsx
@@ -134,7 +134,7 @@ export function GoalModal({
             fontSize: 13.5,
             lineHeight: 1.5,
             color: 'var(--color-text)',
-            background: '#fff',
+            background: 'var(--color-surface)',
             border: '1px solid var(--color-card-border)',
             borderRadius: 10,
             outline: 'none',
@@ -151,7 +151,7 @@ export function GoalModal({
               fontSize: 13,
               fontWeight: 600,
               color: 'var(--color-text-muted)',
-              background: '#fff',
+              background: 'var(--color-surface)',
               border: '1px solid var(--color-card-border)',
               borderRadius: 10,
             }}

--- a/apps/desktop/src/chat/composer/ModeBanner.tsx
+++ b/apps/desktop/src/chat/composer/ModeBanner.tsx
@@ -18,9 +18,9 @@ function toneStyle(tone: ModeBadge['tone']): {
   readonly soft: string;
 } {
   if (tone === 'info') {
-    return { accent: 'var(--color-accent-strong)', soft: 'rgba(34, 211, 238, 0.12)' };
+    return { accent: 'var(--color-accent-strong)', soft: 'color-mix(in srgb, var(--color-accent) 12%, transparent)' };
   }
-  return { accent: 'var(--color-amber)', soft: 'rgba(245, 158, 11, 0.13)' };
+  return { accent: 'var(--color-amber)', soft: 'color-mix(in srgb, var(--color-amber) 13%, transparent)' };
 }
 
 export function ModeBanner({ badge }: { readonly badge: ModeBadge }): JSX.Element {

--- a/apps/desktop/src/chat/composer/OverflowMenu.tsx
+++ b/apps/desktop/src/chat/composer/OverflowMenu.tsx
@@ -67,7 +67,7 @@ export function OverflowMenu({
           lineHeight: 1,
           border: `1px solid ${armed ? 'var(--color-primary)' : 'var(--color-card-border)'}`,
           borderRadius: 10,
-          background: armed ? 'var(--color-primary-soft)' : '#fff',
+          background: armed ? 'var(--color-primary-soft)' : 'var(--color-surface)',
           color: armed ? 'var(--color-primary-strong)' : 'var(--color-text-muted)',
           cursor: disabled ? 'default' : 'pointer',
         }}

--- a/apps/desktop/src/chat/composer/QueuedChip.tsx
+++ b/apps/desktop/src/chat/composer/QueuedChip.tsx
@@ -57,7 +57,7 @@ export function QueuedChip({
           width: 18,
           height: 18,
           borderRadius: '50%',
-          background: 'rgba(236, 72, 153, 0.18)',
+          background: 'color-mix(in srgb, var(--color-primary) 18%, transparent)',
           color: 'var(--color-primary-strong)',
           display: 'inline-flex',
           alignItems: 'center',

--- a/apps/desktop/src/chat/composer/ToolChip.tsx
+++ b/apps/desktop/src/chat/composer/ToolChip.tsx
@@ -13,12 +13,12 @@ export function ToolChip({
    *  a subtle bg + border darken on hover. */
   const palette =
     tone === 'recording'
-      ? { bg: '#fee2e2', color: '#dc2626', border: '#fecaca' }
+      ? { bg: 'var(--color-red-soft)', color: 'var(--color-red-text)', border: 'var(--color-red-border)' }
       : tone === 'busy'
         ? { bg: 'var(--color-primary-soft)', color: 'var(--color-primary-strong)', border: 'var(--color-primary-soft)' }
         : tone === 'armed'
-          ? { bg: '#fef3c7', color: '#b45309', border: '#fde68a' }
-          : { bg: '#fff', color: 'var(--color-text-muted)', border: 'var(--color-card-border)' };
+          ? { bg: 'var(--color-amber-soft)', color: 'var(--color-amber-text)', border: 'var(--color-amber-border)' }
+          : { bg: 'var(--color-surface)', color: 'var(--color-text-muted)', border: 'var(--color-card-border)' };
   return (
     <button
       type="button"

--- a/apps/desktop/src/chat/composer/composer-styles.ts
+++ b/apps/desktop/src/chat/composer/composer-styles.ts
@@ -13,6 +13,6 @@ export function sendBtn(bg: string, enabled: boolean): React.CSSProperties {
     alignItems: 'center',
     justifyContent: 'center',
     opacity: enabled ? 1 : 0.45,
-    boxShadow: enabled ? '0 8px 20px -10px rgba(236, 72, 153, 0.55)' : 'none',
+    boxShadow: enabled ? '0 8px 20px -10px color-mix(in srgb, var(--color-primary) 55%, transparent)' : 'none',
   };
 }

--- a/apps/desktop/src/connection/ConnectionScreen.tsx
+++ b/apps/desktop/src/connection/ConnectionScreen.tsx
@@ -67,7 +67,7 @@ export function ConnectionScreen({
         display: 'grid',
         placeItems: 'center',
         padding: '2rem',
-        background: 'rgb(252, 252, 255)',
+        background: 'var(--color-main-bg)',
         color: 'var(--color-text)',
       }}
     >
@@ -296,7 +296,9 @@ function primaryButtonStyle(disabled: boolean): React.CSSProperties {
     fontWeight: 600,
     fontSize: 13.5,
     cursor: disabled ? 'default' : 'pointer',
-    boxShadow: disabled ? 'none' : '0 10px 20px -12px rgba(236, 72, 153, 0.55)',
+    boxShadow: disabled
+      ? 'none'
+      : '0 10px 20px -12px color-mix(in srgb, var(--color-primary) 55%, transparent)',
   };
 }
 

--- a/apps/desktop/src/lib/useTheme.test.tsx
+++ b/apps/desktop/src/lib/useTheme.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * useTheme controller tests:
+ *   1. A persisted `dark` pref sets <html data-theme="dark"> after mount.
+ *   2. A persisted `light` pref leaves/clears the attribute.
+ *   3. `system` follows the prefers-color-scheme media query, live.
+ *   4. setThemePreference flips the DOM synchronously and persists via
+ *      prefs.update.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act } from '@testing-library/react';
+import { __setApiOverride } from '@moxxy/client-core';
+import type { ThemePreference } from '@moxxy/desktop-ipc-contract';
+import {
+  useTheme,
+  setThemePreference,
+  isEffectiveDark,
+  __resetThemeForTests,
+} from './useTheme';
+
+interface FakeMedia {
+  matches: boolean;
+  fire: () => void;
+}
+
+/** Install a controllable matchMedia('(prefers-color-scheme: dark)'). */
+function installMatchMedia(initialMatches: boolean): FakeMedia {
+  const listeners = new Set<() => void>();
+  const state: FakeMedia = {
+    matches: initialMatches,
+    fire: () => {
+      for (const l of listeners) l();
+    },
+  };
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      media: query,
+      get matches() {
+        return state.matches;
+      },
+      addEventListener: (_: string, cb: () => void) => listeners.add(cb),
+      removeEventListener: (_: string, cb: () => void) => listeners.delete(cb),
+    }),
+  });
+  return state;
+}
+
+function installFakeApi(theme: ThemePreference): Array<{ channel: string; args: unknown }> {
+  const invokes: Array<{ channel: string; args: unknown }> = [];
+  __setApiOverride({
+    invoke: ((channel: string, args: unknown) => {
+      invokes.push({ channel, args });
+      if (channel === 'prefs.read') return Promise.resolve({ theme });
+      if (channel === 'prefs.update') return Promise.resolve({ theme: (args as { theme: ThemePreference }).theme });
+      return Promise.resolve(undefined);
+    }) as never,
+    subscribe: (() => () => undefined) as never,
+  } as never);
+  return invokes;
+}
+
+function Probe(): JSX.Element {
+  useTheme();
+  return <div />;
+}
+
+const themeAttr = (): string | undefined => document.documentElement.dataset.theme;
+
+beforeEach(() => {
+  __resetThemeForTests();
+});
+
+afterEach(() => {
+  __setApiOverride(null);
+  __resetThemeForTests();
+});
+
+describe('useTheme', () => {
+  it('applies a persisted dark pref to <html data-theme>', async () => {
+    installMatchMedia(false);
+    installFakeApi('dark');
+    render(<Probe />);
+    await waitFor(() => expect(themeAttr()).toBe('dark'));
+  });
+
+  it('keeps light mode attribute-free for a persisted light pref', async () => {
+    installMatchMedia(true); // OS dark, but the explicit pref wins
+    const invokes = installFakeApi('light');
+    render(<Probe />);
+    await waitFor(() => expect(invokes.some((i) => i.channel === 'prefs.read')).toBe(true));
+    expect(themeAttr()).toBeUndefined();
+  });
+
+  it('system follows prefers-color-scheme, live', async () => {
+    const media = installMatchMedia(false);
+    installFakeApi('system');
+    render(<Probe />);
+    await waitFor(() => expect(isEffectiveDark()).toBe(false));
+    expect(themeAttr()).toBeUndefined();
+
+    media.matches = true;
+    act(() => media.fire());
+    expect(themeAttr()).toBe('dark');
+
+    media.matches = false;
+    act(() => media.fire());
+    expect(themeAttr()).toBeUndefined();
+  });
+
+  it('setThemePreference flips the DOM synchronously and persists', async () => {
+    installMatchMedia(false);
+    const invokes = installFakeApi('light');
+    render(<Probe />);
+    await waitFor(() => expect(invokes.some((i) => i.channel === 'prefs.read')).toBe(true));
+
+    act(() => setThemePreference('dark'));
+    expect(themeAttr()).toBe('dark'); // synchronous, no round-trip needed
+    await waitFor(() =>
+      expect(invokes).toContainEqual({ channel: 'prefs.update', args: { theme: 'dark' } }),
+    );
+
+    act(() => setThemePreference('light'));
+    expect(themeAttr()).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/lib/useTheme.ts
+++ b/apps/desktop/src/lib/useTheme.ts
@@ -1,0 +1,109 @@
+/**
+ * Theme controller — maps the persisted `theme` desktop pref
+ * (`light` | `dark` | `system`) onto `data-theme="dark"` on `<html>`, which
+ * is what `styles.css`'s dark token block keys off. `system` follows the OS
+ * via `prefers-color-scheme` (live: we subscribe to the media query, and the
+ * main process mirrors the pref into `nativeTheme.themeSource`, so an
+ * explicit light/dark choice ALSO flips what the media query reports).
+ *
+ * One tiny module-level store (not a per-hook useState) so the single
+ * `useTheme()` mount in App and the Appearance settings tab share state —
+ * picking a theme in settings applies instantly without a prefs re-fetch.
+ *
+ * NOTE: the focus widget (src/focus/**) deliberately does NOT mount this —
+ * it's an always-on-top vibrancy window that stays light by design.
+ */
+
+import { useEffect, useSyncExternalStore } from 'react';
+import { api } from '@moxxy/client-core';
+import type { ThemePreference } from '@moxxy/desktop-ipc-contract';
+
+let pref: ThemePreference = 'system';
+let fetched = false;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+function systemQuery(): MediaQueryList | null {
+  return typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-color-scheme: dark)')
+    : null;
+}
+
+/** Effective darkness for a preference: explicit wins, `system` asks the OS. */
+export function isEffectiveDark(p: ThemePreference = pref): boolean {
+  return p === 'system' ? !!systemQuery()?.matches : p === 'dark';
+}
+
+/** Set / clear `data-theme="dark"` on the document element. */
+function applyDom(): void {
+  if (typeof document === 'undefined') return;
+  if (isEffectiveDark()) {
+    document.documentElement.dataset.theme = 'dark';
+  } else {
+    delete document.documentElement.dataset.theme;
+  }
+}
+
+/** The current theme preference (reactive). */
+export function useThemePreference(): ThemePreference {
+  return useSyncExternalStore(
+    (cb) => {
+      listeners.add(cb);
+      return () => listeners.delete(cb);
+    },
+    () => pref,
+  );
+}
+
+/** Apply + persist a new preference. DOM flips synchronously (snappy UI);
+ *  the prefs write — and main's nativeTheme mirror — follow asynchronously. */
+export function setThemePreference(next: ThemePreference): void {
+  pref = next;
+  fetched = true;
+  emit();
+  applyDom();
+  void api()
+    .invoke('prefs.update', { theme: next })
+    .catch(() => undefined);
+}
+
+/**
+ * Mount-once controller (App.tsx): loads the persisted preference, applies
+ * it to `<html data-theme>`, and re-applies on OS scheme changes while the
+ * preference is `system`.
+ */
+export function useTheme(): void {
+  useEffect(() => {
+    if (!fetched) {
+      fetched = true;
+      void api()
+        .invoke('prefs.read')
+        .then((p) => {
+          pref = p.theme ?? 'system';
+          emit();
+          applyDom();
+        })
+        .catch(() => undefined);
+    } else {
+      applyDom();
+    }
+
+    const mq = systemQuery();
+    const onChange = (): void => {
+      if (pref === 'system') applyDom();
+    };
+    mq?.addEventListener?.('change', onChange);
+    return () => mq?.removeEventListener?.('change', onChange);
+  }, []);
+}
+
+/** Test hook: reset the module store between cases. */
+export function __resetThemeForTests(): void {
+  pref = 'system';
+  fetched = false;
+  listeners.clear();
+  if (typeof document !== 'undefined') delete document.documentElement.dataset.theme;
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { ClerkProvider } from '@clerk/clerk-react';
+import { dark } from '@clerk/themes';
 import { App } from './App';
 import { ErrorBoundary } from './ErrorBoundary';
 import { DeepLinkBridge } from './lib/useDeepLink';
@@ -27,20 +28,58 @@ const CLERK_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 const REDIRECT_ORIGINS =
   /^(https:\/\/desktop\.moxxy\.ai|http:\/\/(127\.0\.0\.1|localhost)):(51789|51790|51791|51792)$/;
 
+// Reactive view of the app theme. `useTheme()` (mounted once in App, inside
+// the provider) owns the `data-theme` attribute on <html> — observing that
+// attribute is the single source of truth, and it also catches OS-driven
+// flips while the preference is `system` (which watching only the persisted
+// pref would miss). useSyncExternalStore + MutationObserver keeps this a
+// plain subscription with no extra state to reconcile.
+function subscribeToDataTheme(onChange: () => void): () => void {
+  const observer = new MutationObserver(onChange);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-theme'],
+  });
+  return () => observer.disconnect();
+}
+
+function isDocumentDark(): boolean {
+  return document.documentElement.dataset.theme === 'dark';
+}
+
 // signIn/signUpFallbackRedirectUrl pin the post-auth landing to the app's own
 // origin ('/' resolves against the serving origin above). Without an explicit
 // target, the OAuth code-exchange leg can lose the redirect_url and Clerk's
 // FAPI then falls back to the HOSTED Account Portal (accounts.<domain>) —
 // stranding the desktop window on "My account" instead of back in the app.
+// The `appearance` prop follows <html data-theme> so Clerk's modals (openSignIn
+// etc.) flip with the rest of the app — ClerkProvider applies appearance
+// updates reactively, so an open modal restyles live too.
+function ThemedClerkProvider({
+  publishableKey,
+  children,
+}: {
+  publishableKey: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  const isDark = React.useSyncExternalStore(subscribeToDataTheme, isDocumentDark);
+  return (
+    <ClerkProvider
+      publishableKey={publishableKey}
+      allowedRedirectOrigins={[REDIRECT_ORIGINS]}
+      signInFallbackRedirectUrl="/"
+      signUpFallbackRedirectUrl="/"
+      appearance={{ baseTheme: isDark ? dark : undefined }}
+    >
+      {children}
+    </ClerkProvider>
+  );
+}
+
 const Tree = CLERK_KEY ? (
-  <ClerkProvider
-    publishableKey={CLERK_KEY}
-    allowedRedirectOrigins={[REDIRECT_ORIGINS]}
-    signInFallbackRedirectUrl="/"
-    signUpFallbackRedirectUrl="/"
-  >
+  <ThemedClerkProvider publishableKey={CLERK_KEY}>
     <App />
-  </ClerkProvider>
+  </ThemedClerkProvider>
 ) : (
   <App />
 );

--- a/apps/desktop/src/onboarding/chrome/Shell.tsx
+++ b/apps/desktop/src/onboarding/chrome/Shell.tsx
@@ -4,15 +4,19 @@
  * whichever step is current. Stateless: it renders the passed step list,
  * highlights `currentIndex`, and slots `children` into the pane.
  *
- * The palette matches the splash / loading / chat surfaces (near-white
- * `rgb(252,252,255)`) so first-run feels continuous with the rest of the app.
+ * The palette matches the splash / loading / chat surfaces (the
+ * `--color-main-bg` column tone) so first-run feels continuous with the
+ * rest of the app — and follows the light/dark theme the same way.
  */
 
 import { Icon } from '@moxxy/desktop-ui';
 import { asset } from '@/lib/asset';
 
-const SURFACE = 'rgb(252, 252, 255)';
-const RAIL_BG = 'rgb(248, 248, 252)';
+const SURFACE = 'var(--color-main-bg)';
+// A whisper darker than the main pane so the step rail registers as its
+// own surface in both themes (light: ≈rgb(248,248,253); dark: a hair
+// below the main column, like the workspace sidebar).
+const RAIL_BG = 'color-mix(in srgb, var(--color-main-bg) 60%, var(--color-app-bg))';
 
 export function Shell({
   steps,

--- a/apps/desktop/src/onboarding/chrome/primitives.tsx
+++ b/apps/desktop/src/onboarding/chrome/primitives.tsx
@@ -123,11 +123,11 @@ export function SuccessRow({ text }: { readonly text: string }): JSX.Element {
         alignItems: 'center',
         gap: 10,
         padding: '10px 14px',
-        background: '#dcfce7',
-        border: '1px solid #bbf7d0',
+        background: 'var(--color-success-soft)',
+        border: '1px solid var(--color-success-soft-border)',
         borderRadius: 10,
         fontSize: 13,
-        color: '#166534',
+        color: 'var(--color-success-soft-text)',
         fontWeight: 600,
       }}
     >

--- a/apps/desktop/src/onboarding/chrome/styles.ts
+++ b/apps/desktop/src/onboarding/chrome/styles.ts
@@ -10,7 +10,7 @@ export const inputStyle: React.CSSProperties = {
   padding: '10px 12px',
   fontSize: 14,
   color: 'var(--color-text)',
-  background: '#fff',
+  background: 'var(--color-surface)',
   border: '1px solid var(--color-card-border)',
   borderRadius: 10,
   outline: 'none',
@@ -27,7 +27,7 @@ export const primaryBtnStyle: React.CSSProperties = {
   display: 'inline-flex',
   alignItems: 'center',
   gap: 6,
-  boxShadow: '0 10px 20px -12px rgba(236, 72, 153, 0.55)',
+  boxShadow: '0 10px 20px -12px color-mix(in srgb, var(--color-primary) 55%, transparent)',
 };
 
 export const secondaryBtnStyle: React.CSSProperties = {
@@ -47,7 +47,7 @@ export const pickerBtnStyle: React.CSSProperties = {
   padding: '10px 12px',
   fontSize: 13,
   color: 'var(--color-text)',
-  background: '#f7f8fc',
+  background: 'var(--color-input-soft)',
   border: '1px dashed var(--color-card-border-strong)',
   borderRadius: 10,
   textAlign: 'left',

--- a/apps/desktop/src/onboarding/steps/CliStep.tsx
+++ b/apps/desktop/src/onboarding/steps/CliStep.tsx
@@ -72,7 +72,7 @@ export function CliStep({
         <div
           style={{
             padding: '14px 16px',
-            background: '#fdf2f8',
+            background: 'var(--color-primary-soft)',
             border: '1px solid var(--color-card-border)',
             borderRadius: 12,
             display: 'flex',

--- a/apps/desktop/src/settings/AboutTab.tsx
+++ b/apps/desktop/src/settings/AboutTab.tsx
@@ -155,6 +155,7 @@ export function AboutTab(): JSX.Element {
             style={{
               margin: 0,
               padding: 10,
+              // Deliberate literals: terminal-style log is dark in both themes.
               background: '#0f172a',
               color: '#e2e8f0',
               borderRadius: 10,

--- a/apps/desktop/src/settings/AppearanceTab.tsx
+++ b/apps/desktop/src/settings/AppearanceTab.tsx
@@ -1,0 +1,52 @@
+/**
+ * Appearance tab — the light / dark / system theme picker.
+ *
+ * Standalone (like About / Mobile): it doesn't read the runner-backed
+ * settings slice. The segmented control writes through the shared theme
+ * store in `lib/useTheme`, which (1) flips `data-theme` on <html>
+ * synchronously so the change is instant, and (2) persists the pref via
+ * `prefs.update` — the main process mirrors it into
+ * `nativeTheme.themeSource` so window chrome and the boot splash agree.
+ */
+
+import { useThemePreference, setThemePreference } from '@/lib/useTheme';
+import type { ThemePreference } from '@moxxy/desktop-ipc-contract';
+import { Section } from './settings-primitives';
+import { Segmented } from '../shell/ViewHeader';
+
+const THEME_OPTIONS: ReadonlyArray<{ id: ThemePreference; label: string }> = [
+  { id: 'light', label: 'Light' },
+  { id: 'dark', label: 'Dark' },
+  { id: 'system', label: 'System' },
+];
+
+export function AppearanceTab(): JSX.Element {
+  const theme = useThemePreference();
+  return (
+    <Section
+      title="Appearance"
+      description="Choose how the app looks. System follows your OS setting."
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 14,
+          padding: '13px 16px',
+          background: 'var(--color-card-bg)',
+          border: '1px solid var(--color-card-border)',
+          borderRadius: 14,
+        }}
+      >
+        <div style={{ fontSize: 13.5, fontWeight: 600 }}>Theme</div>
+        <Segmented
+          items={THEME_OPTIONS}
+          value={theme}
+          onChange={setThemePreference}
+          testIdPrefix="appearance-theme-"
+        />
+      </div>
+    </Section>
+  );
+}

--- a/apps/desktop/src/settings/DashboardUpdateSection.tsx
+++ b/apps/desktop/src/settings/DashboardUpdateSection.tsx
@@ -22,6 +22,8 @@ function statusLine(state: UpdateState, latest: string | null): string | null {
       return `Version ${latest} is available.`;
     case 'incompatible':
       return 'A newer version needs a full app update (reinstall).';
+    case 'requires-full-update':
+      return `Version ${latest ?? '?'} updates the bundled runner — it needs the full app installer and can’t apply as a hot-update.`;
     case 'unavailable':
       return null; // shown via the check.error / muted note instead
     case 'updating':
@@ -33,6 +35,24 @@ function statusLine(state: UpdateState, latest: string | null): string | null {
     default:
       return null;
   }
+}
+
+/** Human-readable explanations for the boot-log's structured reject reasons, so
+ *  a refused override is legible right in the Diagnostics panel instead of
+ *  needing the resolve.ts source to decode. */
+const REASON_HINTS: Record<string, string> = {
+  'runner-protocol-skew':
+    'staged update needs a newer bundled runner than this install can spawn — install the full app update',
+  incompatible: 'staged update needs a newer app shell (Electron/ABI) — install the full app update',
+  poisoned: 'this version failed a previous boot and is blocked',
+  'bad-signature': 'staged bundle failed signature verification',
+  'file-tampered': 'a staged file does not match its signed hash',
+};
+
+function describeReason(reason: string | undefined): string {
+  if (!reason) return '';
+  const hint = REASON_HINTS[reason];
+  return `  reason=${reason}${hint ? ` (${hint})` : ''}`;
 }
 
 export function DashboardUpdateSection(): JSX.Element {
@@ -136,7 +156,7 @@ export function DashboardUpdateSection(): JSX.Element {
             >
               Update dashboard
             </button>
-          ) : state === 'incompatible' && check?.releaseUrl ? (
+          ) : (state === 'incompatible' || state === 'requires-full-update') && check?.releaseUrl ? (
             <button
               type="button"
               style={primaryBtn(false)}
@@ -176,6 +196,24 @@ export function DashboardUpdateSection(): JSX.Element {
           </summary>
           {diagnostics ? (
             <div style={{ marginTop: 8, display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {(() => {
+                // Surface the last boot-time rejection prominently: a staged
+                // update the bootstrap declined (e.g. runner-protocol-skew)
+                // used to be visible only by decoding the raw log below.
+                const lastBoot = [...diagnostics.log].reverse().find((e) => e.phase === 'boot');
+                const reason =
+                  lastBoot?.picked === 'floor' &&
+                  lastBoot.reason &&
+                  !['disabled', 'no-active'].includes(lastBoot.reason)
+                    ? lastBoot.reason
+                    : null;
+                return reason ? (
+                  <p role="alert" style={{ margin: 0, fontSize: 12, color: 'var(--color-red)', lineHeight: 1.5 }}>
+                    Last launch declined the staged update ({reason}
+                    {REASON_HINTS[reason] ? `: ${REASON_HINTS[reason]}` : ''}).
+                  </p>
+                ) : null;
+              })()}
               <div style={{ fontSize: 11.5, color: 'var(--color-text-dim)', lineHeight: 1.6 }}>
                 running <b className="mono">{diagnostics.running}</b> · active{' '}
                 <span className="mono">{diagnostics.active ?? '—'}</span> · confirmed{' '}
@@ -191,7 +229,7 @@ export function DashboardUpdateSection(): JSX.Element {
                       .map(
                         (e) =>
                           `${new Date(e.ts).toISOString()}  ${e.phase.padEnd(11)} ${e.picked ?? ''}` +
-                          (e.reason ? `  reason=${e.reason}` : '') +
+                          describeReason(e.reason) +
                           (e.recoveredTo ? `  → ${e.recoveredTo}` : '') +
                           (e.error ? `  error=${e.error}` : ''),
                       )
@@ -259,5 +297,5 @@ const badge = (updated: boolean): React.CSSProperties => ({
   padding: '2px 7px',
   borderRadius: 999,
   color: updated ? 'var(--color-green)' : 'var(--color-text-dim)',
-  background: updated ? 'rgba(34,197,94,0.12)' : 'var(--color-card-border)',
+  background: updated ? 'color-mix(in srgb, var(--color-green) 12%, transparent)' : 'var(--color-card-border)',
 });

--- a/apps/desktop/src/settings/MobileTab.tsx
+++ b/apps/desktop/src/settings/MobileTab.tsx
@@ -54,6 +54,8 @@ function QrCode({ value }: { readonly value: string }): JSX.Element {
       style={{
         width: 220,
         height: 220,
+        // Deliberate literal: QR codes need a white quiet zone for scanner
+        // contrast in BOTH themes — never theme this surface.
         background: '#fff',
         borderRadius: 14,
         padding: 10,
@@ -193,6 +195,8 @@ export function MobileTab(): JSX.Element {
                     minWidth: 0,
                     fontSize: 12,
                     padding: '8px 10px',
+                    // Deliberate literals: terminal-style chip is dark in both
+                    // themes (same as the AboutTab update log).
                     background: '#0f172a',
                     color: '#e2e8f0',
                     borderRadius: 8,

--- a/apps/desktop/src/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/settings/SettingsPanel.tsx
@@ -7,10 +7,11 @@ import { McpTab } from './McpTab';
 import { VaultTab } from './VaultTab';
 import { AboutTab } from './AboutTab';
 import { MobileTab } from './MobileTab';
+import { AppearanceTab } from './AppearanceTab';
 import { SearchBox } from './settings-primitives';
 import { ViewHeader, ViewSwitcher, Segmented, type View } from '../shell/ViewHeader';
 
-type Tab = 'providers' | 'mcp' | 'skills' | 'vault' | 'mobile' | 'about';
+type Tab = 'providers' | 'mcp' | 'skills' | 'vault' | 'mobile' | 'appearance' | 'about';
 
 const TABS: ReadonlyArray<{ id: Tab; label: string }> = [
   { id: 'providers', label: 'Providers' },
@@ -18,12 +19,13 @@ const TABS: ReadonlyArray<{ id: Tab; label: string }> = [
   { id: 'skills', label: 'Skills' },
   { id: 'vault', label: 'Vault' },
   { id: 'mobile', label: 'Mobile' },
+  { id: 'appearance', label: 'Appearance' },
   { id: 'about', label: 'About' },
 ];
 
 // Tabs that don't read the runner-backed settings slice — render them outside
 // the shared loading / error chrome (like About).
-const STANDALONE_TABS: ReadonlySet<Tab> = new Set<Tab>(['about', 'mobile']);
+const STANDALONE_TABS: ReadonlySet<Tab> = new Set<Tab>(['about', 'mobile', 'appearance']);
 
 /**
  * Tabbed settings panel — providers, MCP servers, skills, vault. Each tab
@@ -84,6 +86,7 @@ export function SettingsPanel({
           render them without the shared loading / error chrome below. */}
       {tab === 'about' && <AboutTab />}
       {tab === 'mobile' && <MobileTab />}
+      {tab === 'appearance' && <AppearanceTab />}
 
       {!STANDALONE_TABS.has(tab) && s.error && (
         <div

--- a/apps/desktop/src/settings/TabHeader.tsx
+++ b/apps/desktop/src/settings/TabHeader.tsx
@@ -65,7 +65,7 @@ export function TabHeader({
               fontSize: 11,
               fontWeight: 700,
               color: 'var(--color-text-muted)',
-              background: 'rgba(148, 163, 184, 0.16)',
+              background: 'color-mix(in srgb, var(--color-text-dim) 16%, transparent)',
             }}
           >
             {count}

--- a/apps/desktop/src/settings/VaultTab.tsx
+++ b/apps/desktop/src/settings/VaultTab.tsx
@@ -191,7 +191,7 @@ function VaultKeyCard({
       }}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
-        <Tile bg="rgba(148, 163, 184, 0.16)" fg="var(--color-text-muted)">
+        <Tile bg="color-mix(in srgb, var(--color-text-dim) 16%, transparent)" fg="var(--color-text-muted)">
           <Icon name="lock" size={15} />
         </Tile>
         <span

--- a/apps/desktop/src/settings/settings-primitives.tsx
+++ b/apps/desktop/src/settings/settings-primitives.tsx
@@ -26,7 +26,7 @@ export function SearchBox({
         alignItems: 'center',
         gap: 9,
         padding: '9px 12px',
-        background: '#fff',
+        background: 'var(--color-surface)',
         border: '1px solid var(--color-card-border)',
         borderRadius: 10,
       }}
@@ -202,7 +202,7 @@ export function StatusDot({
           height: 8,
           borderRadius: '50%',
           background: ok ? 'var(--color-green)' : 'var(--color-card-border-strong)',
-          boxShadow: ok ? '0 0 0 3px rgba(16, 185, 129, 0.16)' : 'none',
+          boxShadow: ok ? '0 0 0 3px color-mix(in srgb, var(--color-green) 16%, transparent)' : 'none',
         }}
       />
       {ok ? okLabel : offLabel}
@@ -245,6 +245,8 @@ export function Switch({
           width: 20,
           height: 20,
           borderRadius: '50%',
+          // Deliberate literal: the knob rides a colored/track fill in both
+          // themes (iOS-style) — it must stay white even in dark mode.
           background: '#fff',
           boxShadow: '0 1px 2px rgba(15, 23, 42, 0.35)',
           transform: on ? 'translateX(18px)' : 'translateX(0)',
@@ -269,7 +271,7 @@ export function Badge({ children }: { readonly children: React.ReactNode }): JSX
         letterSpacing: '0.04em',
         padding: '3px 9px',
         borderRadius: 999,
-        background: 'rgba(148, 163, 184, 0.16)',
+        background: 'color-mix(in srgb, var(--color-text-dim) 16%, transparent)',
         color: 'var(--color-text-muted)',
       }}
     >

--- a/apps/desktop/src/settings/shared/AgentTaskModal.tsx
+++ b/apps/desktop/src/settings/shared/AgentTaskModal.tsx
@@ -112,13 +112,13 @@ export function AgentTaskModal({
               border: '1px solid var(--color-card-border)',
               borderRadius: 12,
               overflow: 'hidden',
-              background: '#fff',
+              background: 'var(--color-surface)',
             }}
           >
             <header
               style={{
                 padding: '8px 12px',
-                background: '#f4f5fb',
+                background: 'var(--color-sidebar-bg-hover)',
                 borderBottom: '1px solid var(--color-card-border)',
                 fontSize: 11,
                 fontWeight: 700,

--- a/apps/desktop/src/settings/skills/CreateSkillModal.tsx
+++ b/apps/desktop/src/settings/skills/CreateSkillModal.tsx
@@ -91,7 +91,7 @@ Describe the inputs, the steps to take, and any constraints here.
               padding: '12px 14px',
               fontSize: 12.5,
               lineHeight: 1.55,
-              background: '#fbfcff',
+              background: 'var(--color-main-bg)',
             }}
           />
         </label>

--- a/apps/desktop/src/settings/skills/SkillEditor.tsx
+++ b/apps/desktop/src/settings/skills/SkillEditor.tsx
@@ -44,7 +44,7 @@ export function SkillEditor({
       style={{
         // Match the chat surface background so the skill body reads as
         // the same "writing surface" as a conversation.
-        background: 'rgb(252, 252, 255)',
+        background: 'var(--color-main-bg)',
         border: '1px solid var(--color-card-border)',
         borderRadius: 12,
         overflow: 'hidden',
@@ -100,7 +100,7 @@ export function SkillEditor({
           style={{
             padding: '6px 14px',
             borderRadius: 9,
-            background: dirty ? 'var(--grad-cta)' : '#e5e7eb',
+            background: dirty ? 'var(--grad-cta)' : 'var(--color-card-border)',
             color: dirty ? '#fff' : 'var(--color-text-dim)',
           }}
         >
@@ -152,7 +152,7 @@ function SegmentedToggle({
       role="tablist"
       style={{
         display: 'inline-flex',
-        background: '#f4f5fb',
+        background: 'var(--color-sidebar-bg-hover)',
         border: '1px solid var(--color-card-border)',
         borderRadius: 9,
         padding: 2,
@@ -171,7 +171,7 @@ function SegmentedToggle({
             fontWeight: 700,
             borderRadius: 7,
             color: value === m ? 'var(--color-text)' : 'var(--color-text-dim)',
-            background: value === m ? '#fff' : 'transparent',
+            background: value === m ? 'var(--color-surface)' : 'transparent',
             boxShadow: value === m ? '0 1px 2px rgba(15,23,42,0.06)' : 'none',
             textTransform: 'uppercase',
             letterSpacing: '0.04em',

--- a/apps/desktop/src/settings/skills/SkillGallery.tsx
+++ b/apps/desktop/src/settings/skills/SkillGallery.tsx
@@ -60,7 +60,7 @@ export function SkillGallery({
             alignItems: 'center',
             gap: 9,
             padding: '9px 12px',
-            background: '#fff',
+            background: 'var(--color-surface)',
             border: '1px solid var(--color-card-border)',
             borderRadius: 10,
           }}

--- a/apps/desktop/src/shell/ContextRail.tsx
+++ b/apps/desktop/src/shell/ContextRail.tsx
@@ -13,7 +13,7 @@
  */
 
 import { useState } from 'react';
-import { useDesks } from '@moxxy/client-core';
+import { deskForWorkspace, useDesks } from '@moxxy/client-core';
 import { Icon } from '@moxxy/desktop-ui';
 import { WorkspaceFiles } from './WorkspaceFiles';
 
@@ -34,7 +34,8 @@ interface Props {
 
 export function ContextRail({ onClose, open, workspaceId }: Props): JSX.Element {
   const desks = useDesks();
-  const active = desks.desks.find((d) => d.id === workspaceId);
+  // workspaceId is a SESSION id — resolve the desk that owns it.
+  const active = deskForWorkspace(desks.desks, workspaceId);
   // Bumping this re-reads the file tree (the button next to the FILES heading).
   const [filesReload, setFilesReload] = useState(0);
 

--- a/apps/desktop/src/shell/ContextRail.tsx
+++ b/apps/desktop/src/shell/ContextRail.tsx
@@ -230,7 +230,7 @@ function Path({ text }: { readonly text: string }): JSX.Element {
       style={{
         fontSize: 11.5,
         color: 'var(--color-text-muted)',
-        background: '#f7f8fc',
+        background: 'var(--color-input-soft)',
         padding: '8px 10px',
         borderRadius: 8,
         border: '1px solid var(--color-card-border)',
@@ -279,5 +279,5 @@ const iconBtnStyle: React.CSSProperties = {
   alignItems: 'center',
   justifyContent: 'center',
   border: '1px solid var(--color-card-border)',
-  background: '#fff',
+  background: 'var(--color-surface)',
 };

--- a/apps/desktop/src/shell/ProfileView.tsx
+++ b/apps/desktop/src/shell/ProfileView.tsx
@@ -221,10 +221,12 @@ function tierBadgeStyle(tier: string): React.CSSProperties {
     textTransform: 'uppercase',
     fontSize: 10.5,
     background: isFree
-      ? 'rgba(148, 163, 184, 0.18)'
+      ? 'color-mix(in srgb, var(--color-text-dim) 18%, transparent)'
       : 'linear-gradient(135deg, rgba(236, 72, 153, 0.95), rgba(217, 70, 239, 0.95))',
     color: isFree ? 'var(--color-text-muted)' : '#fff',
-    border: isFree ? '1px solid rgba(148, 163, 184, 0.32)' : 'none',
+    border: isFree
+      ? '1px solid color-mix(in srgb, var(--color-text-dim) 32%, transparent)'
+      : 'none',
     flexShrink: 0,
   };
 }

--- a/apps/desktop/src/shell/UpdateBanner.tsx
+++ b/apps/desktop/src/shell/UpdateBanner.tsx
@@ -17,7 +17,12 @@ export function UpdateBanner(): JSX.Element | null {
   const [dismissed, setDismissed] = useState(false);
 
   const visible =
-    !dismissed && (state === 'available' || state === 'updating' || state === 'staged' || state === 'incompatible');
+    !dismissed &&
+    (state === 'available' ||
+      state === 'updating' ||
+      state === 'staged' ||
+      state === 'incompatible' ||
+      state === 'requires-full-update');
   if (!visible) return null;
 
   const pct =
@@ -56,10 +61,14 @@ export function UpdateBanner(): JSX.Element | null {
       </>
     );
   } else {
-    // incompatible → Tier-2 (full app update)
+    // incompatible / requires-full-update → Tier-2 (full app update)
     body = (
       <>
-        <span>A new version needs a full app update.</span>
+        <span>
+          {state === 'requires-full-update'
+            ? `Version ${check?.latestVersion ?? ''} updates the bundled runner — install the full app update.`
+            : 'A new version needs a full app update.'}
+        </span>
         {check?.releaseUrl && (
           <button
             type="button"

--- a/apps/desktop/src/shell/ViewHeader.tsx
+++ b/apps/desktop/src/shell/ViewHeader.tsx
@@ -53,7 +53,7 @@ export function Segmented<T extends string>({
         display: 'inline-flex',
         gap: 2,
         padding: 3,
-        background: '#f1f2f9',
+        background: 'var(--color-app-bg)',
         borderRadius: 12,
       }}
     >
@@ -72,7 +72,7 @@ export function Segmented<T extends string>({
               fontWeight: 600,
               borderRadius: 9,
               color: active ? 'var(--color-text)' : 'var(--color-text-muted)',
-              background: active ? '#fff' : 'transparent',
+              background: active ? 'var(--color-surface)' : 'transparent',
               boxShadow: active ? '0 1px 3px rgba(15, 23, 42, 0.12)' : 'none',
               transition: 'background 140ms, color 140ms',
             }}

--- a/apps/desktop/src/shell/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/shell/WorkspaceSidebar.tsx
@@ -1,11 +1,12 @@
-import { useState } from 'react';
-import { useDesks } from '@moxxy/client-core';
+import { Fragment, useState } from 'react';
+import { useDesks, useSessions } from '@moxxy/client-core';
 import { Skeleton, Icon, ConfirmModal } from '@moxxy/desktop-ui';
 import { useUnreadWorkspaces } from '@moxxy/client-core';
-import type { Desk } from '@moxxy/desktop-ipc-contract';
+import type { Desk, DeskSession } from '@moxxy/desktop-ipc-contract';
 import { Logo } from './workspace-sidebar/Logo';
 import { SectionHeader } from './workspace-sidebar/SectionHeader';
 import { WorkspaceRow } from './workspace-sidebar/WorkspaceRow';
+import { SessionList } from './workspace-sidebar/SessionList';
 import { NameWorkspaceModal } from './workspace-sidebar/NameWorkspaceModal';
 import { ProfilePill } from './workspace-sidebar/ProfilePill';
 import { listReset } from './workspace-sidebar/sidebar-styles';
@@ -26,12 +27,16 @@ interface Props {
  */
 export function WorkspaceSidebar({ view, onView }: Props): JSX.Element {
   const desks = useDesks();
+  const sessions = useSessions(desks.activeId);
   const unread = new Set(useUnreadWorkspaces());
   const [busy, setBusy] = useState(false);
+  const [sessionBusy, setSessionBusy] = useState(false);
   /** Folder the user picked; null when no naming flow is in progress. */
   const [pendingFolder, setPendingFolder] = useState<string | null>(null);
   /** Workspace queued for removal; null when no confirm is open. */
   const [pendingRemove, setPendingRemove] = useState<Desk | null>(null);
+  /** Session queued for removal; null when no confirm is open. */
+  const [pendingSessionRemove, setPendingSessionRemove] = useState<DeskSession | null>(null);
 
   const onStartNewWorkspace = async (): Promise<void> => {
     setBusy(true);
@@ -51,6 +56,18 @@ export function WorkspaceSidebar({ view, onView }: Props): JSX.Element {
     if (desk) await desks.setActive(desk.id);
   };
 
+  const onNewSession = async (): Promise<void> => {
+    // ADD another conversation (unlike `/new`, which resets the current
+    // one in place) and foreground it right away.
+    setSessionBusy(true);
+    try {
+      const session = await sessions.create();
+      if (session) await sessions.setActive(session.id);
+    } finally {
+      setSessionBusy(false);
+    }
+  };
+
   return (
     <aside className="col-sidebar">
       <Logo />
@@ -63,22 +80,49 @@ export function WorkspaceSidebar({ view, onView }: Props): JSX.Element {
           </div>
         )}
         <ul role="list" style={listReset}>
-          {desks.desks.map((d) => (
-            <WorkspaceRow
-              key={d.id}
-              desk={d}
-              active={desks.activeId === d.id}
-              unread={unread.has(d.id)}
-              onClick={() => {
-                // Picking a workspace always lands on its chat — also the
-                // way back out of Settings/Workflows now that the sidebar
-                // carries no Chat entry.
-                void desks.setActive(d.id);
-                onView('chat');
-              }}
-              onRemove={() => setPendingRemove(d)}
-            />
-          ))}
+          {desks.desks.map((d) => {
+            const isActive = desks.activeId === d.id;
+            return (
+              <Fragment key={d.id}>
+                <WorkspaceRow
+                  desk={d}
+                  active={isActive}
+                  // Unread is tracked per routing id — a session id. Light
+                  // the desk's dot when ANY of its sessions has activity.
+                  unread={d.sessions.some((s) => unread.has(s.id)) || unread.has(d.id)}
+                  onClick={() => {
+                    // Picking a workspace always lands on its chat — also the
+                    // way back out of Settings/Workflows now that the sidebar
+                    // carries no Chat entry.
+                    void desks.setActive(d.id);
+                    onView('chat');
+                  }}
+                  onRemove={() => setPendingRemove(d)}
+                />
+                {/* Sessions of the ACTIVE desk, nested under its row. */}
+                {isActive && (
+                  <li>
+                    <SessionList
+                      sessions={sessions.sessions}
+                      activeSessionId={sessions.activeSessionId}
+                      unread={unread}
+                      busy={sessionBusy}
+                      onSelect={(id) => {
+                        void sessions.setActive(id);
+                        onView('chat');
+                      }}
+                      onCreate={() => {
+                        void onNewSession();
+                        onView('chat');
+                      }}
+                      onRename={(id, name) => void sessions.rename(id, name)}
+                      onRemove={(s) => setPendingSessionRemove(s)}
+                    />
+                  </li>
+                )}
+              </Fragment>
+            );
+          })}
         </ul>
         <button
           type="button"
@@ -171,6 +215,19 @@ export function WorkspaceSidebar({ view, onView }: Props): JSX.Element {
           onConfirm={() => {
             void desks.remove(pendingRemove.id);
             setPendingRemove(null);
+          }}
+        />
+      )}
+      {pendingSessionRemove && (
+        <ConfirmModal
+          title="Delete session?"
+          message={`The session "${pendingSessionRemove.name}" and its conversation history will be deleted. Workspace files are not touched.`}
+          confirmLabel="Delete"
+          destructive
+          onCancel={() => setPendingSessionRemove(null)}
+          onConfirm={() => {
+            void sessions.remove(pendingSessionRemove.id);
+            setPendingSessionRemove(null);
           }}
         />
       )}

--- a/apps/desktop/src/shell/workspace-sidebar/NameWorkspaceModal.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/NameWorkspaceModal.tsx
@@ -48,7 +48,7 @@ export function NameWorkspaceModal({
             color: 'var(--color-text-dim)',
             wordBreak: 'break-all',
             padding: '8px 10px',
-            background: '#f7f8fc',
+            background: 'var(--color-input-soft)',
             border: '1px solid var(--color-card-border)',
             borderRadius: 8,
           }}

--- a/apps/desktop/src/shell/workspace-sidebar/ProfilePill.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/ProfilePill.tsx
@@ -141,10 +141,12 @@ function tierBadgeStyle(tier: string): React.CSSProperties {
     textTransform: 'uppercase',
     fontSize: 9.5,
     background: isFree
-      ? 'rgba(148, 163, 184, 0.16)'
+      ? 'color-mix(in srgb, var(--color-text-dim) 16%, transparent)'
       : 'linear-gradient(135deg, rgba(236, 72, 153, 0.85), rgba(217, 70, 239, 0.85))',
     color: isFree ? 'var(--color-sidebar-text)' : '#fff',
-    border: isFree ? '1px solid rgba(148, 163, 184, 0.28)' : 'none',
+    border: isFree
+      ? '1px solid color-mix(in srgb, var(--color-text-dim) 28%, transparent)'
+      : 'none',
   };
 }
 

--- a/apps/desktop/src/shell/workspace-sidebar/SessionList.test.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/SessionList.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * SessionList renderer tests:
+ *   1. Renders one row per session; the active one carries the highlight
+ *      (data-active) and the unread dot shows for flagged sessions.
+ *   2. Clicking a row selects it; "New session" fires onCreate.
+ *   3. The pencil affordance opens an inline rename input; Enter commits
+ *      (trimmed) and Escape cancels.
+ *   4. The × affordance asks the container to remove (it confirms).
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { DeskSession } from '@moxxy/desktop-ipc-contract';
+import { SessionList } from './SessionList';
+
+const s1: DeskSession = { id: 's1', name: 'Session 1', createdAt: 1 };
+const s2: DeskSession = { id: 's2', name: 'Session 2', createdAt: 2 };
+
+function setup(
+  overrides: Partial<React.ComponentProps<typeof SessionList>> = {},
+): {
+  onSelect: ReturnType<typeof vi.fn>;
+  onCreate: ReturnType<typeof vi.fn>;
+  onRename: ReturnType<typeof vi.fn>;
+  onRemove: ReturnType<typeof vi.fn>;
+} {
+  const handlers = {
+    onSelect: vi.fn(),
+    onCreate: vi.fn(),
+    onRename: vi.fn(),
+    onRemove: vi.fn(),
+  };
+  render(
+    <SessionList
+      sessions={[s1, s2]}
+      activeSessionId="s1"
+      unread={new Set(['s2'])}
+      {...handlers}
+      {...overrides}
+    />,
+  );
+  return handlers;
+}
+
+describe('SessionList', () => {
+  it('renders a row per session with the active highlight + unread dot', () => {
+    setup();
+    expect(screen.getByText('Session 1')).toBeTruthy();
+    expect(screen.getByText('Session 2')).toBeTruthy();
+    expect(screen.getByTestId('session-row-s1').getAttribute('data-active')).toBe('true');
+    expect(screen.getByTestId('session-row-s2').getAttribute('data-active')).toBe('false');
+    // Only the unread session shows the activity dot.
+    expect(screen.getAllByLabelText('unread activity')).toHaveLength(1);
+  });
+
+  it('clicking a row selects it', () => {
+    const { onSelect } = setup();
+    fireEvent.click(screen.getByTestId('session-row-s2'));
+    expect(onSelect).toHaveBeenCalledWith('s2');
+  });
+
+  it('"New session" fires onCreate (and is disabled while busy)', () => {
+    const { onCreate } = setup();
+    fireEvent.click(screen.getByTestId('session-new'));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('renames inline: pencil → input, Enter commits trimmed', () => {
+    const { onRename, onSelect } = setup();
+    fireEvent.click(screen.getByLabelText('rename session Session 2'));
+    const input = screen.getByDisplayValue('Session 2');
+    fireEvent.change(input, { target: { value: '  Deep dive  ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onRename).toHaveBeenCalledWith('s2', 'Deep dive');
+    // Opening the editor must not have selected the row.
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('Escape cancels a rename without committing', () => {
+    const { onRename } = setup();
+    fireEvent.click(screen.getByLabelText('rename session Session 2'));
+    const input = screen.getByDisplayValue('Session 2');
+    fireEvent.change(input, { target: { value: 'Nope' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.getByText('Session 2')).toBeTruthy();
+  });
+
+  it('an unchanged name does not commit a rename', () => {
+    const { onRename } = setup();
+    fireEvent.click(screen.getByLabelText('rename session Session 2'));
+    const input = screen.getByDisplayValue('Session 2');
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it('the × affordance asks the container to remove (without selecting)', () => {
+    const { onRemove, onSelect } = setup();
+    fireEvent.click(screen.getByLabelText('remove session Session 2'));
+    expect(onRemove).toHaveBeenCalledWith(s2);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/shell/workspace-sidebar/SessionList.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/SessionList.tsx
@@ -1,0 +1,214 @@
+import { useState } from 'react';
+import { Icon } from '@moxxy/desktop-ui';
+import type { DeskSession } from '@moxxy/desktop-ipc-contract';
+
+/**
+ * The ACTIVE desk's sessions, nested under its workspace row in the
+ * rail. Mirrors the workspace rows' visual language at a smaller scale:
+ * indented rows (a dot stands in for the monogram tile), active
+ * highlight, unread dot, hover-only rename (✎) / remove (×)
+ * affordances, and a dim "New session" row at the bottom.
+ *
+ * Purely presentational — the sidebar container owns the store calls
+ * and the remove confirmation.
+ */
+export function SessionList({
+  sessions,
+  activeSessionId,
+  unread,
+  busy,
+  onSelect,
+  onCreate,
+  onRename,
+  onRemove,
+}: {
+  readonly sessions: ReadonlyArray<DeskSession>;
+  readonly activeSessionId: string | null;
+  readonly unread: ReadonlySet<string>;
+  readonly busy?: boolean;
+  readonly onSelect: (id: string) => void;
+  readonly onCreate: () => void;
+  readonly onRename: (id: string, name: string) => void;
+  readonly onRemove: (session: DeskSession) => void;
+}): JSX.Element {
+  /** Session whose name is being edited inline; null = none. */
+  const [editing, setEditing] = useState<{ id: string; draft: string } | null>(null);
+
+  const commitRename = (): void => {
+    if (!editing) return;
+    const name = editing.draft.trim();
+    const prev = sessions.find((s) => s.id === editing.id)?.name;
+    setEditing(null);
+    if (name && name !== prev) onRename(editing.id, name);
+  };
+
+  return (
+    <ul
+      role="list"
+      aria-label="Sessions"
+      style={{
+        listStyle: 'none',
+        margin: '2px 0 4px',
+        padding: '0 0 0 24px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1,
+      }}
+    >
+      {sessions.map((s) => {
+        const active = s.id === activeSessionId;
+        return (
+          <li key={s.id}>
+            <div
+              data-testid={`session-row-${s.id}`}
+              data-active={active}
+              onClick={() => onSelect(s.id)}
+              className={active ? undefined : 'row-button'}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                padding: '5px 8px',
+                borderRadius: 8,
+                cursor: 'pointer',
+                background: active ? 'var(--color-sidebar-bg-active)' : 'transparent',
+                color: active
+                  ? 'var(--color-sidebar-text)'
+                  : 'var(--color-sidebar-text-dim)',
+                fontWeight: active ? 600 : 400,
+              }}
+            >
+              <span
+                aria-hidden
+                style={{
+                  width: 5,
+                  height: 5,
+                  borderRadius: '50%',
+                  background: 'currentColor',
+                  opacity: active ? 0.9 : 0.45,
+                  flexShrink: 0,
+                }}
+              />
+              {editing?.id === s.id ? (
+                <input
+                  autoFocus
+                  value={editing.draft}
+                  aria-label={`rename session ${s.name}`}
+                  onClick={(e) => e.stopPropagation()}
+                  onChange={(e) => setEditing({ id: s.id, draft: e.target.value })}
+                  onBlur={commitRename}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') commitRename();
+                    if (e.key === 'Escape') setEditing(null);
+                  }}
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    fontSize: 12.5,
+                    padding: '1px 4px',
+                    borderRadius: 6,
+                    border: '1px solid var(--color-sidebar-text-dim)',
+                    background: 'transparent',
+                    color: 'var(--color-sidebar-text)',
+                    outline: 'none',
+                  }}
+                />
+              ) : (
+                <span
+                  style={{
+                    flex: 1,
+                    fontSize: 12.5,
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}
+                >
+                  {s.name}
+                </span>
+              )}
+              {unread.has(s.id) && (
+                <span
+                  aria-label="unread activity"
+                  title="New activity in this session"
+                  style={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: '50%',
+                    background: 'var(--color-primary)',
+                    flexShrink: 0,
+                    boxShadow: '0 0 8px rgba(236, 72, 153, 0.6)',
+                  }}
+                />
+              )}
+              <button
+                type="button"
+                aria-label={`rename session ${s.name}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setEditing({ id: s.id, draft: s.name });
+                }}
+                style={{
+                  color: 'var(--color-sidebar-text-dim)',
+                  opacity: active ? 0.9 : 0.55,
+                  padding: '0 2px',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                }}
+              >
+                <Icon name="pencil" size={11} />
+              </button>
+              <button
+                type="button"
+                aria-label={`remove session ${s.name}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRemove(s);
+                }}
+                style={{
+                  color: 'var(--color-sidebar-text-dim)',
+                  opacity: active ? 1 : 0.55,
+                  padding: '0 2px',
+                  fontSize: 13,
+                }}
+              >
+                ×
+              </button>
+            </div>
+          </li>
+        );
+      })}
+      <li>
+        <button
+          type="button"
+          data-testid="session-new"
+          onClick={onCreate}
+          disabled={busy}
+          style={{
+            width: '100%',
+            textAlign: 'left',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '5px 8px',
+            fontSize: 12.5,
+            color: 'var(--color-sidebar-text-dim)',
+            borderRadius: 8,
+            opacity: busy ? 0.6 : 1,
+          }}
+        >
+          <span
+            style={{
+              width: 5,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Icon name="plus" size={12} />
+          </span>
+          New session
+        </button>
+      </li>
+    </ul>
+  );
+}

--- a/apps/desktop/src/shell/workspace-sidebar/SessionList.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/SessionList.tsx
@@ -136,7 +136,7 @@ export function SessionList({
                     borderRadius: '50%',
                     background: 'var(--color-primary)',
                     flexShrink: 0,
-                    boxShadow: '0 0 8px rgba(236, 72, 153, 0.6)',
+                    boxShadow: '0 0 8px color-mix(in srgb, var(--color-primary) 60%, transparent)',
                   }}
                 />
               )}

--- a/apps/desktop/src/shell/workspace-sidebar/WorkspaceRow.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/WorkspaceRow.tsx
@@ -75,7 +75,7 @@ export function WorkspaceRow({
               borderRadius: '50%',
               background: 'var(--color-primary)',
               flexShrink: 0,
-              boxShadow: '0 0 8px rgba(236, 72, 153, 0.6)',
+              boxShadow: '0 0 8px color-mix(in srgb, var(--color-primary) 60%, transparent)',
             }}
           />
         )}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -8,6 +8,16 @@
 :root {
   /* App canvas — cool lavender to match the landing site's hero. */
   --color-app-bg:        #f1f2f9;
+  /* Main chat column — near-white with a faint cool tint, a hair off
+   * pure white so the column reads as separate from any adjacent white
+   * surface without being grey. */
+  --color-main-bg:       rgb(252, 252, 255);
+  /* Resting surface for buttons / chips / inputs that sit ON a card or
+   * column (the things that used to be hard-coded `#fff`). */
+  --color-surface:       #ffffff;
+  /* Recessed "soft" input fill — a cool near-white a step below the
+   * surface, used by TextInput/TextArea tone='soft' and modal fields. */
+  --color-input-soft:    #f7f8fc;
   --color-card-bg:       #ffffff;
   --color-card-border:   #e3e5f0;
   --color-card-border-strong: #cdd1e3;
@@ -40,6 +50,27 @@
   --color-amber:          #f59e0b;
   --color-pink:           #ec4899;
   --color-red:            #ef4444;
+  --color-purple-strong:  #7c3aed;   /* readable violet for text on the purple tints */
+
+  /* Status tints — the tailwind-derived washes the transcript blocks and
+   * composer chips use for error/ok/attention states. Solid (not alpha)
+   * fills so they read identically over any surface; each gets a DESIGNED
+   * dark counterpart in the [data-theme="dark"] block below. */
+  --color-red-soft:     #fee2e2;   /* error chip/tile fill (red-100) */
+  --color-red-wash:     #fef2f2;   /* subtler error card wash (red-50) */
+  --color-red-border:   #fecaca;
+  --color-red-text:     #dc2626;
+  --color-green-soft:   #ecfdf5;   /* success tile fill (emerald-50) */
+  /* Onboarding SuccessRow chip — a stronger green-100/200/800 set. */
+  --color-success-soft:        #dcfce7;
+  --color-success-soft-border: #bbf7d0;
+  --color-success-soft-text:   #166534;
+  --color-amber-soft:   #fef3c7;   /* attention chip fill (amber-100) */
+  --color-amber-wash:   #fffbeb;   /* subtler notice card wash (amber-50) */
+  --color-amber-border: #fde68a;
+  --color-amber-text:   #b45309;
+  /* Inline-code background in rendered Markdown. */
+  --color-code-bg:      #f1f3fb;
 
   /* Brand gradients */
   --grad-user:    linear-gradient(135deg, #ec4899 0%, #f472b6 100%);
@@ -58,6 +89,9 @@
 
 /* Legacy aliases — older components still read these names. Map them
  * to the new tokens so we don't have to touch every file in one go.
+ * NOTE: any alias holding a LITERAL color (not a var() reference) MUST
+ * be re-declared in the [data-theme="dark"] block below, or it silently
+ * stays light in dark mode — the design-tokens parity test enforces it.
  */
 :root {
   --color-bg:              var(--color-app-bg);
@@ -65,6 +99,85 @@
   --color-bg-card-hover:   #f4f5fa;
   --color-border:          var(--color-card-border);
   --color-border-light:    #d8dbeb;
+}
+
+/* --- Dark theme -------------------------------------------------
+ * Activated by `data-theme="dark"` on <html> (set by the renderer's
+ * useTheme() controller from the `theme` desktop pref; `system`
+ * follows the OS via prefers-color-scheme). Values mirror
+ * `darkTokens` in @moxxy/design-tokens — the parity test in that
+ * package keeps the two in lockstep, and additionally requires every
+ * literal-color custom property declared in :root to be overridden
+ * here. The palette is DESIGNED, not inverted: rail < canvas < main
+ * column < cards < surfaces in lightness, brand accents unchanged.
+ */
+[data-theme="dark"] {
+  --color-app-bg:        #0b0c13;
+  --color-main-bg:       #101117;
+  --color-surface:       #1b1e2b;
+  /* Soft inputs recess BELOW the card they sit on (mirror of light's
+   * near-white-on-white): between main column and card lightness. */
+  --color-input-soft:    #121420;
+  --color-card-bg:       #161823;
+  --color-card-border:   #262a3c;
+  --color-card-border-strong: #363c54;
+  --color-card-shadow:   0 1px 2px rgba(0, 0, 0, 0.5), 0 10px 24px -18px rgba(0, 0, 0, 0.7);
+
+  --color-text:          #e8eaf6;
+  --color-text-muted:    #a4abc8;
+  --color-text-dim:      #697091;
+
+  /* Left rail deepens slightly below the canvas so the columns still
+   * register as separate surfaces in the dark. */
+  --color-sidebar-bg:        #0d0e16;
+  --color-sidebar-bg-hover:  #171927;
+  --color-sidebar-bg-active: #2b1622;   /* dark plum — the brand-pink wash on dark */
+  --color-sidebar-text:      #e8eaf6;
+  --color-sidebar-text-dim:  #8b91b0;
+  --color-sidebar-border:    #1f2233;
+
+  /* Brand accents survive dark unchanged (re-declared so the parity
+   * test can assert full coverage), EXCEPT the near-white pink-50
+   * "soft" wash which flips to the dark plum. */
+  --color-primary:        #ec4899;
+  --color-primary-strong: #db2777;
+  --color-primary-soft:   #2b1622;
+  --color-send:           #ec4899;
+  --color-accent:         #22d3ee;
+  --color-accent-strong:  #06b6d4;
+  --color-purple:         #8b5cf6;
+  --color-green:          #10b981;
+  --color-amber:          #f59e0b;
+  --color-pink:           #ec4899;
+  --color-red:            #ef4444;
+  --color-purple-strong:  #a78bfa;   /* violet text lightens for contrast on dark tints */
+
+  /* Status tints — deep desaturated washes in the same lightness band as
+   * the dark --color-primary-soft plum; text accents lighten instead. */
+  --color-red-soft:     #3d1b22;
+  --color-red-wash:     #2c161c;
+  --color-red-border:   #5c2b33;
+  --color-red-text:     #f87171;
+  --color-green-soft:   #11261e;
+  --color-success-soft:        #0e2a1c;
+  --color-success-soft-border: #1c4532;
+  --color-success-soft-text:   #7ce0a8;
+  --color-amber-soft:   #33250b;
+  --color-amber-wash:   #271e0c;
+  --color-amber-border: #5b430f;
+  --color-amber-text:   #fbbf24;
+  /* Inline code pops a step LIGHTER than the card it sits on. */
+  --color-code-bg:      #262b40;
+
+  --grad-user:    linear-gradient(135deg, #ec4899 0%, #f472b6 100%);
+  --grad-cta:     linear-gradient(135deg, #ec4899 0%, #db2777 100%);
+  --grad-accent:  linear-gradient(135deg, #38bdf8 0%, #22d3ee 100%);
+
+  /* Legacy literal aliases — see the note above the alias block. */
+  --color-bg-card-hover:   #1d2030;
+  --color-border-light:    #2c3147;
+
+  color-scheme: dark;
 }
 
 * { box-sizing: border-box; }
@@ -193,10 +306,7 @@ code, kbd, pre, .mono { font-family: var(--font-mono); }
   flex-direction: column;
   padding: 16px 18px 16px 4px;
   min-width: 0;
-  /* Near-white with a faint cool tint — sits a hair off pure white
-   * so the column reads as separate from any adjacent white surface
-   * without being grey. */
-  background: rgb(252, 252, 255);
+  background: var(--color-main-bg);
 }
 
 /* `col-main--flat` removes the inset gutters so the chat content
@@ -290,32 +400,32 @@ code, kbd, pre, .mono { font-family: var(--font-mono); }
  */
 
 .btn-icon:hover:not(:disabled) {
-  box-shadow: inset 0 0 0 999px rgba(15, 23, 42, 0.07);
+  box-shadow: inset 0 0 0 999px color-mix(in srgb, var(--color-text) 7%, transparent);
   color: var(--color-text);
 }
 
 .btn-chip:hover:not(:disabled) {
-  box-shadow: inset 0 0 0 999px rgba(15, 23, 42, 0.05);
+  box-shadow: inset 0 0 0 999px color-mix(in srgb, var(--color-text) 5%, transparent);
   border-color: var(--color-card-border-strong);
   color: var(--color-text);
 }
 
 .btn-cta:hover:not(:disabled) {
   filter: brightness(1.06);
-  box-shadow: 0 12px 24px -12px rgba(236, 72, 153, 0.6);
+  box-shadow: 0 12px 24px -12px color-mix(in srgb, var(--color-primary) 60%, transparent);
 }
 .btn-cta:active:not(:disabled) {
   filter: brightness(0.97);
 }
 
 .btn-outline:hover:not(:disabled) {
-  box-shadow: inset 0 0 0 999px rgba(15, 23, 42, 0.05);
+  box-shadow: inset 0 0 0 999px color-mix(in srgb, var(--color-text) 5%, transparent);
   border-color: var(--color-card-border-strong);
   color: var(--color-text);
 }
 
 .btn-ghost:hover:not(:disabled) {
-  box-shadow: inset 0 0 0 999px rgba(15, 23, 42, 0.05);
+  box-shadow: inset 0 0 0 999px color-mix(in srgb, var(--color-text) 5%, transparent);
   color: var(--color-text);
 }
 
@@ -323,7 +433,7 @@ code, kbd, pre, .mono { font-family: var(--font-mono); }
   transition: background-color 140ms ease, color 140ms ease, box-shadow 140ms ease;
 }
 .row-button:hover:not(:disabled) {
-  box-shadow: inset 0 0 0 999px rgba(15, 23, 42, 0.05);
+  box-shadow: inset 0 0 0 999px color-mix(in srgb, var(--color-text) 5%, transparent);
 }
 
 /* Skill gallery card — barely-there hover (border firms up, faint tint),
@@ -334,7 +444,7 @@ code, kbd, pre, .mono { font-family: var(--font-mono); }
 .skill-card:hover:not(:disabled) {
   filter: none;
   border-color: var(--color-card-border-strong);
-  background: #fcfcff;
+  background: color-mix(in srgb, var(--color-card-bg) 97%, var(--color-text));
 }
 
 .btn-suggestion {
@@ -344,7 +454,7 @@ code, kbd, pre, .mono { font-family: var(--font-mono); }
   /* Very subtle brand tint on hover — `filter: none` overrides the global
    * button brightness() so the white pill doesn't read as a gray fill. */
   filter: none;
-  background: rgba(236, 72, 153, 0.06);
+  background: color-mix(in srgb, var(--color-primary) 6%, transparent);
   border-color: var(--color-primary);
 }
 

--- a/apps/desktop/src/workflows/WorkflowCanvas.tsx
+++ b/apps/desktop/src/workflows/WorkflowCanvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   STEP_KINDS,
   stepKindMeta,
@@ -18,6 +18,22 @@ import { accentHex } from './accents';
  * cards over an SVG edge layer. Hand-rolled (no react-flow) to avoid pulling a
  * heavy graph lib into the Electron bundle — the graph here is small (≤40
  * steps) and the interactions are limited to drag + select + wire.
+ *
+ * The canvas is an INFINITE world viewed through a pan/zoom transform (Figma
+ * model): the viewport div clips (`overflow: hidden`) and a zero-size content
+ * layer carries `translate(view.x, view.y) scale(view.zoom)`. There are no
+ * scrollbars and no world bounds — nodes can live at negative coordinates.
+ * The transform is the builder state's persisted `viewport` (set-viewport),
+ * so a saved workflow reopens at the same view.
+ *
+ *   world = (client − viewportRect.origin − view.pan) / view.zoom
+ *
+ * Navigation: drag empty canvas to pan; wheel / two-finger trackpad scroll
+ * pans both axes; ctrl/cmd+wheel (and macOS pinch, which arrives as
+ * ctrl+wheel) zooms anchored at the cursor; double-click empty canvas resets
+ * to 100% (anchored at the cursor); the bottom-right cluster has −/%/+ plus
+ * zoom-to-fit. The dotted background grid lives on the viewport and follows
+ * the transform via background-position/size, so it repeats forever.
  *
  * Two pointer gestures share the cards, disambiguated by WHERE the pointerdown
  * lands:
@@ -54,10 +70,14 @@ const NODE_H = 88;
 const ANCHOR_OFFSET = NODE_H / 2;
 const HANDLE_R = 7;
 
-const MIN_ZOOM = 0.4;
-const MAX_ZOOM = 2;
+const MIN_ZOOM = 0.1;
+const MAX_ZOOM = 4;
 /** Multiplicative step for the +/− buttons. */
 const ZOOM_STEP = 1.2;
+/** Base spacing of the dotted background grid at 100% zoom. */
+const GRID_SIZE = 24;
+/** Viewport padding around the graph for zoom-to-fit. */
+const FIT_PAD = 60;
 
 function clampZoom(z: number): number {
   return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, z));
@@ -92,23 +112,28 @@ interface InsertMenuState {
   readonly oy: number;
 }
 
+/** Loop-exit edges use violet-600 — a deliberate step darker than
+ *  `--color-purple` so exit reads apart from body; theme-invariant accent
+ *  with no design token, so it stays literal. */
+const LOOP_EXIT_COLOR = '#7c3aed';
+
 const EDGE_STYLE: Record<BuilderEdge['kind'], { color: string; dash?: string; label?: string }> = {
-  needs: { color: '#94a3b8' },
-  then: { color: '#10b981', label: 'then' },
-  else: { color: '#ef4444', label: 'else' },
-  case: { color: '#8b5cf6' },
-  default: { color: '#94a3b8', label: 'default' },
-  'loop-body': { color: '#8b5cf6', dash: '6 5', label: 'body' },
-  'loop-exit': { color: '#7c3aed', label: 'on done / error → next' },
+  needs: { color: 'var(--color-text-dim)' },
+  then: { color: 'var(--color-green)', label: 'then' },
+  else: { color: 'var(--color-red)', label: 'else' },
+  case: { color: 'var(--color-purple)' },
+  default: { color: 'var(--color-text-dim)', label: 'default' },
+  'loop-body': { color: 'var(--color-purple)', dash: '6 5', label: 'body' },
+  'loop-exit': { color: LOOP_EXIT_COLOR, label: 'on done / error → next' },
 };
 
 const PORT_COLOR: Record<PortKind, string> = {
-  needs: '#94a3b8',
-  then: '#10b981',
-  else: '#ef4444',
-  'loop-exit': '#7c3aed',
+  needs: 'var(--color-text-dim)',
+  then: 'var(--color-green)',
+  else: 'var(--color-red)',
+  'loop-exit': LOOP_EXIT_COLOR,
 };
-const LOOP_BODY_COLOR = '#8b5cf6';
+const LOOP_BODY_COLOR = 'var(--color-purple)';
 
 export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
   const surfaceRef = useRef<HTMLDivElement>(null);
@@ -120,85 +145,100 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
   const [hoverTarget, setHoverTarget] = useState<string | null>(null);
   const [reject, setReject] = useState<string | null>(null);
   const rejectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [zoom, setZoom] = useState(1);
-  /** Scroll offsets to apply right after a zoom commit (keeps the anchor
-   *  point — cursor or viewport centre — visually fixed while scaling). */
-  const pendingScroll = useRef<{ left: number; top: number } | null>(null);
-  /** Background drag-to-pan: pointer + scroll origin, and whether it actually
-   *  moved (a still pan is a click and must keep deselecting). */
-  const pan = useRef<{ x: number; y: number; left: number; top: number; moved: boolean } | null>(
-    null,
-  );
+  /** Background drag-to-pan: last pointer position (deltas apply incrementally
+   *  to the viewport), cumulative travel, and whether it actually moved (a
+   *  still pan is a click and must keep deselecting). */
+  const pan = useRef<{ lx: number; ly: number; dist: number; moved: boolean } | null>(null);
   const [panning, setPanning] = useState(false);
   /** Set on pan end so the synthetic click that follows doesn't deselect. */
   const suppressClick = useRef(false);
   const [insertMenu, setInsertMenu] = useState<InsertMenuState | null>(null);
+
+  /** The pan/zoom transform — the builder state's persisted viewport. */
+  const view = state.viewport;
+  const setView = useCallback(
+    (viewport: BuilderState['viewport']) => dispatch({ type: 'set-viewport', viewport }),
+    [dispatch],
+  );
 
   const byId = useMemo(() => new Map(state.nodes.map((n) => [n.id, n])), [state.nodes]);
 
   /** Topological order index per node (1-based) so the canvas reads as a flow. */
   const order = useMemo(() => topoOrder(state.nodes), [state.nodes]);
 
-  /** Pointer position in CONTENT coords (pre-zoom node space). */
+  /** Pointer position in WORLD coords (node space, pre-transform). */
   const surfacePoint = useCallback(
     (e: { clientX: number; clientY: number }) => {
       const rect = surfaceRef.current?.getBoundingClientRect();
-      const left = surfaceRef.current?.scrollLeft ?? 0;
-      const top = surfaceRef.current?.scrollTop ?? 0;
-      return {
-        x: ((rect ? e.clientX - rect.left : e.clientX) + left) / zoom,
-        y: ((rect ? e.clientY - rect.top : e.clientY) + top) / zoom,
-      };
+      const cx = rect ? e.clientX - rect.left : e.clientX;
+      const cy = rect ? e.clientY - rect.top : e.clientY;
+      return { x: (cx - view.x) / view.zoom, y: (cy - view.y) / view.zoom };
     },
-    [zoom],
+    [view],
   );
 
   /** Zoom to `next`, keeping `anchor` (client coords; defaults to the
-   *  viewport centre) over the same content point. */
+   *  viewport centre) over the same world point: solve the pan from
+   *  anchor = world·z + pan. */
   const applyZoom = useCallback(
     (next: number, anchor?: { x: number; y: number }) => {
       const z = clampZoom(next);
-      const el = surfaceRef.current;
-      if (el && z !== zoom) {
-        const rect = el.getBoundingClientRect();
-        const ax = anchor ? anchor.x - rect.left : rect.width / 2;
-        const ay = anchor ? anchor.y - rect.top : rect.height / 2;
-        pendingScroll.current = {
-          left: ((el.scrollLeft + ax) / zoom) * z - ax,
-          top: ((el.scrollTop + ay) / zoom) * z - ay,
-        };
-      }
-      setZoom(z);
+      if (z === view.zoom) return;
+      const rect = surfaceRef.current?.getBoundingClientRect();
+      const ax = anchor ? anchor.x - (rect?.left ?? 0) : (rect?.width ?? 0) / 2;
+      const ay = anchor ? anchor.y - (rect?.top ?? 0) : (rect?.height ?? 0) / 2;
+      setView({
+        x: ax - ((ax - view.x) / view.zoom) * z,
+        y: ay - ((ay - view.y) / view.zoom) * z,
+        zoom: z,
+      });
     },
-    [zoom],
+    [setView, view],
   );
 
-  // The scaled content commits in the same render as `zoom`, so the anchor
-  // correction must land before paint or the view visibly jumps.
-  useLayoutEffect(() => {
-    const el = surfaceRef.current;
-    const p = pendingScroll.current;
-    if (el && p) {
-      el.scrollLeft = p.left;
-      el.scrollTop = p.top;
-      pendingScroll.current = null;
+  /** Frame all nodes in the viewport (centered, padded, capped at 100%). */
+  const zoomToFit = useCallback(() => {
+    const rect = surfaceRef.current?.getBoundingClientRect();
+    if (!rect || rect.width <= 0 || rect.height <= 0 || state.nodes.length === 0) {
+      setView({ x: 0, y: 0, zoom: 1 });
+      return;
     }
-  }, [zoom]);
+    const minX = Math.min(...state.nodes.map((n) => n.x));
+    const minY = Math.min(...state.nodes.map((n) => n.y));
+    const maxX = Math.max(...state.nodes.map((n) => n.x + NODE_W));
+    const maxY = Math.max(...state.nodes.map((n) => n.y + NODE_H));
+    const z = clampZoom(
+      Math.min(
+        (rect.width - FIT_PAD * 2) / Math.max(1, maxX - minX),
+        (rect.height - FIT_PAD * 2) / Math.max(1, maxY - minY),
+        1, // frame, don't magnify — a lone node shouldn't fill the screen
+      ),
+    );
+    setView({
+      x: (rect.width - (maxX - minX) * z) / 2 - minX * z,
+      y: (rect.height - (maxY - minY) * z) / 2 - minY * z,
+      zoom: z,
+    });
+  }, [setView, state.nodes]);
 
-  // Pinch / ctrl+wheel zoom. Native non-passive listener — React's root
-  // wheel listener is passive, so a synthetic onWheel can't preventDefault
-  // (and the page would scroll while pinching).
+  // Wheel: plain wheel / two-finger trackpad scroll PANS both axes;
+  // ctrl/cmd+wheel (macOS pinch arrives as ctrl+wheel) ZOOMS at the cursor.
+  // Native non-passive listener — React's root wheel listener is passive, so
+  // a synthetic onWheel can't preventDefault (and the page would scroll).
   useEffect(() => {
     const el = surfaceRef.current;
     if (!el) return;
     const onWheel = (e: WheelEvent): void => {
-      if (!e.ctrlKey && !e.metaKey) return; // macOS pinch arrives as ctrl+wheel
       e.preventDefault();
-      applyZoom(zoom * Math.exp(-e.deltaY * 0.0018), { x: e.clientX, y: e.clientY });
+      if (e.ctrlKey || e.metaKey) {
+        applyZoom(view.zoom * Math.exp(-e.deltaY * 0.0018), { x: e.clientX, y: e.clientY });
+      } else {
+        setView({ x: view.x - e.deltaX, y: view.y - e.deltaY, zoom: view.zoom });
+      }
     };
     el.addEventListener('wheel', onWheel, { passive: false });
     return () => el.removeEventListener('wheel', onWheel);
-  }, [applyZoom, zoom]);
+  }, [applyZoom, setView, view]);
 
   // Keyboard: Delete/Backspace removes the selected node + its edges (same op
   // as the inspector's Delete button); Escape dismisses the insert menu,
@@ -271,16 +311,8 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
         setInsertMenu(null);
         return;
       }
-      const el = surfaceRef.current;
-      if (!el) return;
       (e.target as Element).setPointerCapture?.(e.pointerId);
-      pan.current = {
-        x: e.clientX,
-        y: e.clientY,
-        left: el.scrollLeft,
-        top: el.scrollTop,
-        moved: false,
-      };
+      pan.current = { lx: e.clientX, ly: e.clientY, dist: 0, moved: false };
       setPanning(true);
     },
     [insertMenu],
@@ -290,9 +322,8 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
     (e: React.PointerEvent) => {
       const p = surfacePoint(e);
       if (drag.current) {
-        const x = Math.max(0, p.x - drag.current.dx);
-        const y = Math.max(0, p.y - drag.current.dy);
-        dispatch({ type: 'move-node', id: drag.current.id, x, y });
+        // Unbounded world — negative coordinates are fine.
+        dispatch({ type: 'move-node', id: drag.current.id, x: p.x - drag.current.dx, y: p.y - drag.current.dy });
         return;
       }
       if (connect.current) {
@@ -301,16 +332,16 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
         return;
       }
       if (pan.current) {
-        const el = surfaceRef.current;
-        if (!el) return;
-        const dx = e.clientX - pan.current.x;
-        const dy = e.clientY - pan.current.y;
-        if (Math.abs(dx) + Math.abs(dy) > 3) pan.current.moved = true;
-        el.scrollLeft = pan.current.left - dx;
-        el.scrollTop = pan.current.top - dy;
+        const dx = e.clientX - pan.current.lx;
+        const dy = e.clientY - pan.current.ly;
+        pan.current.lx = e.clientX;
+        pan.current.ly = e.clientY;
+        pan.current.dist += Math.abs(dx) + Math.abs(dy);
+        if (pan.current.dist > 3) pan.current.moved = true;
+        setView({ x: view.x + dx, y: view.y + dy, zoom: view.zoom });
       }
     },
-    [dispatch, state.nodes, surfacePoint],
+    [dispatch, setView, state.nodes, surfacePoint, view],
   );
 
   const finishConnection = useCallback(
@@ -381,9 +412,9 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
       const source = byId.get(menu.nodeId);
       if (!source) return;
       const id = uniqueId(state, kind);
-      const x = Math.max(0, menu.x);
+      const x = menu.x;
       // Offset so the new node's left input anchor lands at the drop point.
-      const y = Math.max(0, menu.y - ANCHOR_OFFSET);
+      const y = menu.y - ANCHOR_OFFSET;
       switch (menu.port) {
         case 'needs':
           dispatch({ type: 'add-step', input: { kind, id, x, y, after: source.id } });
@@ -440,9 +471,6 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
     }
   }, []);
 
-  const width = Math.max(900, ...state.nodes.map((n) => n.x + NODE_W + 80));
-  const height = Math.max(560, ...state.nodes.map((n) => n.y + NODE_H + 80));
-
   return (
     <div style={{ position: 'relative', flex: 1, minHeight: 0, minWidth: 0, display: 'flex' }}>
     <div
@@ -452,6 +480,7 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
       onPointerLeave={onPointerLeave}
+      onDoubleClick={(e) => applyZoom(1, { x: e.clientX, y: e.clientY })}
       onClick={() => {
         if (suppressClick.current) {
           suppressClick.current = false;
@@ -464,28 +493,38 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
         flex: 1,
         minHeight: 0,
         minWidth: 0,
-        overflow: 'auto',
+        overflow: 'hidden',
+        touchAction: 'none',
         cursor: panning ? 'grabbing' : 'grab',
         background:
           'var(--color-bg) radial-gradient(circle, var(--color-card-border) 1px, transparent 1px)',
-        backgroundSize: '24px 24px',
+        // The grid lives on the viewport but tracks the world transform, so it
+        // reads as an infinite sheet: spacing scales with zoom, offset follows pan.
+        backgroundSize: `${GRID_SIZE * view.zoom}px ${GRID_SIZE * view.zoom}px`,
+        backgroundPosition: `${view.x}px ${view.y}px`,
         borderRadius: 'var(--radius-block)',
         border: '1px solid var(--color-border)',
       }}
     >
-      {/* Scroll sizer: reserves the SCALED footprint so scrollbars track the
-       *  zoomed content (a transform alone doesn't change layout size). */}
-      <div style={{ width: width * zoom, height: height * zoom, overflow: 'hidden' }}>
+      {/* The world: a zero-size layer carrying the pan/zoom transform; children
+       *  (absolutely positioned, overflow visible) extend in every direction. */}
       <div
+        data-testid="canvas-content"
         style={{
-          position: 'relative',
-          width,
-          height,
-          transform: `scale(${zoom})`,
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 0,
+          height: 0,
+          transform: `translate(${view.x}px, ${view.y}px) scale(${view.zoom})`,
           transformOrigin: '0 0',
         }}
       >
-        <svg width={width} height={height} style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+        <svg
+          width="2"
+          height="2"
+          style={{ position: 'absolute', left: 0, top: 0, overflow: 'visible', pointerEvents: 'none' }}
+        >
           <defs>
             {Object.entries(EDGE_STYLE).map(([kind, s]) => (
               <marker
@@ -542,34 +581,37 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
         ))}
 
         {insertMenu && byId.has(insertMenu.nodeId) && (
-          <InsertNodeMenu menu={insertMenu} zoom={zoom} onPick={insertFromMenu} />
+          <InsertNodeMenu menu={insertMenu} zoom={view.zoom} onPick={insertFromMenu} />
         )}
+      </div>
 
-        {state.nodes.length === 0 && (
-          <div
-            style={{
-              position: 'absolute',
-              inset: 0,
-              display: 'grid',
-              placeItems: 'center',
-              color: 'var(--color-text-dim)',
-              fontSize: '0.9rem',
-            }}
-          >
-            Add a step from the palette to start building.
-          </div>
-        )}
-      </div>
-      </div>
+      {/* Empty-state hint lives on the viewport (not the world) so it stays
+       *  centered and readable regardless of pan/zoom. */}
+      {state.nodes.length === 0 && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'grid',
+            placeItems: 'center',
+            color: 'var(--color-text-dim)',
+            fontSize: '0.9rem',
+            pointerEvents: 'none',
+          }}
+        >
+          Add a step from the palette to start building.
+        </div>
+      )}
 
       {reject && (
         <div
           role="alert"
           data-testid="connect-reject"
           style={{
-            position: 'sticky',
+            position: 'absolute',
             bottom: 12,
-            margin: '0 auto',
+            left: '50%',
+            transform: 'translateX(-50%)',
             width: 'fit-content',
             maxWidth: '80%',
             padding: '0.4rem 0.7rem',
@@ -587,27 +629,30 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
       )}
     </div>
     <ZoomControls
-      zoom={zoom}
-      onZoomIn={() => applyZoom(zoom * ZOOM_STEP)}
-      onZoomOut={() => applyZoom(zoom / ZOOM_STEP)}
+      zoom={view.zoom}
+      onZoomIn={() => applyZoom(view.zoom * ZOOM_STEP)}
+      onZoomOut={() => applyZoom(view.zoom / ZOOM_STEP)}
       onReset={() => applyZoom(1)}
+      onFit={zoomToFit}
     />
     </div>
   );
 }
 
 /** Floating zoom cluster pinned to the canvas' bottom-right corner. The
- *  percentage doubles as a reset-to-100% button. */
+ *  percentage doubles as a reset-to-100% button; ⛶ frames all nodes. */
 function ZoomControls({
   zoom,
   onZoomIn,
   onZoomOut,
   onReset,
+  onFit,
 }: {
   readonly zoom: number;
   readonly onZoomIn: () => void;
   readonly onZoomOut: () => void;
   readonly onReset: () => void;
+  readonly onFit: () => void;
 }): JSX.Element {
   return (
     <div
@@ -657,6 +702,16 @@ function ZoomControls({
       >
         +
       </button>
+      <button
+        type="button"
+        data-testid="canvas-zoom-fit"
+        title="Zoom to fit all steps"
+        aria-label="Zoom to fit"
+        onClick={onFit}
+        style={{ ...zoomBtn, fontSize: '0.8rem' }}
+      >
+        ⛶
+      </button>
     </div>
   );
 }
@@ -683,6 +738,7 @@ function InsertNodeMenu({
       // canvas, dismiss the menu, or deselect.
       onPointerDown={(e) => e.stopPropagation()}
       onClick={(e) => e.stopPropagation()}
+      onDoubleClick={(e) => e.stopPropagation()}
       style={{
         position: 'absolute',
         left: menu.x,
@@ -900,6 +956,8 @@ function NodeCard({
       data-testid={`wf-node-${node.id}`}
       onPointerDown={onBodyPointerDown}
       onClick={(e) => e.stopPropagation()}
+      // Double-click on a CARD must not trigger the canvas' zoom reset.
+      onDoubleClick={(e) => e.stopPropagation()}
       style={{
         position: 'absolute',
         left: node.x,

--- a/apps/desktop/src/workflows/WorkflowsPanel.test.tsx
+++ b/apps/desktop/src/workflows/WorkflowsPanel.test.tsx
@@ -534,3 +534,162 @@ describe('WorkflowsPanel — canvas drag-to-connect', () => {
     expect(screen.getByTestId('wf-node-prompt')).toBeInTheDocument();
   });
 });
+
+/**
+ * Infinite-canvas pan/zoom. The world is rendered through a single
+ * `translate(x, y) scale(zoom)` on the content layer (testid canvas-content);
+ * these tests parse that transform to assert the view maths. jsdom's
+ * getBoundingClientRect is all-zeros, so client coords == viewport coords and
+ * `world = (client − view.pan) / view.zoom` exactly.
+ */
+describe('WorkflowsPanel — infinite canvas pan/zoom', () => {
+  async function openWith(): Promise<void> {
+    installApi({ list: [] });
+    render(<WorkflowsPanel />);
+    fireEvent.click(await screen.findByTestId('new-workflow'));
+    await screen.findByTestId('workflow-canvas');
+  }
+
+  /** Parse the content layer's `translate(xpx, ypx) scale(z)` transform. */
+  function getView(): { x: number; y: number; zoom: number } {
+    const t = (screen.getByTestId('canvas-content') as HTMLElement).style.transform;
+    const m = /translate\((-?[\d.]+)px, (-?[\d.]+)px\) scale\((-?[\d.]+)\)/.exec(t);
+    if (!m) throw new Error(`unexpected canvas transform: ${t}`);
+    return { x: Number(m[1]), y: Number(m[2]), zoom: Number(m[3]) };
+  }
+
+  it('plain wheel pans BOTH axes (no horizontal-strip scrolling)', async () => {
+    await openWith();
+    fireEvent.click(screen.getByTestId('palette-add-prompt')); // node @ (40,40)
+    await screen.findByTestId('wf-node-prompt');
+    const canvas = screen.getByTestId('workflow-canvas');
+    fireEvent.wheel(canvas, { deltaX: -120, deltaY: -60 });
+    expect(getView()).toEqual({ x: 120, y: 60, zoom: 1 });
+    // Panning moves the VIEW, not the world: the node keeps its coordinates.
+    const node = screen.getByTestId('wf-node-prompt') as HTMLElement;
+    expect(node.style.left).toBe('40px');
+    expect(node.style.top).toBe('40px');
+    // And it pans back past the origin without any scroll clamp.
+    fireEvent.wheel(canvas, { deltaX: 300, deltaY: 200 });
+    expect(getView()).toEqual({ x: -180, y: -140, zoom: 1 });
+  });
+
+  it('ctrl+wheel zooms anchored at the cursor (the world point under it stays fixed)', async () => {
+    await openWith();
+    const canvas = screen.getByTestId('workflow-canvas');
+    // World point under the cursor before zooming: (100 − 0) / 1 = 100.
+    fireEvent.wheel(canvas, { ctrlKey: true, deltaY: -200, clientX: 100, clientY: 100 });
+    const zoomed = getView();
+    expect(zoomed.zoom).toBeGreaterThan(1);
+    // anchor = world·zoom + pan ⇒ the same world point must sit under (100,100).
+    expect((100 - zoomed.x) / zoomed.zoom).toBeCloseTo(100, 6);
+    expect((100 - zoomed.y) / zoomed.zoom).toBeCloseTo(100, 6);
+    // Zoom again at a DIFFERENT cursor point — that point must now hold still.
+    const worldX = (300 - zoomed.x) / zoomed.zoom;
+    const worldY = (40 - zoomed.y) / zoomed.zoom;
+    fireEvent.wheel(canvas, { ctrlKey: true, deltaY: -150, clientX: 300, clientY: 40 });
+    const again = getView();
+    expect(again.zoom).toBeGreaterThan(zoomed.zoom);
+    expect((300 - again.x) / again.zoom).toBeCloseTo(worldX, 6);
+    expect((40 - again.y) / again.zoom).toBeCloseTo(worldY, 6);
+    // Double-click on empty canvas resets to 100%.
+    fireEvent.doubleClick(canvas, { clientX: 50, clientY: 50 });
+    expect(getView().zoom).toBe(1);
+  });
+
+  it('ctrl+wheel zoom is clamped to the 10%–400% range', async () => {
+    await openWith();
+    const canvas = screen.getByTestId('workflow-canvas');
+    fireEvent.wheel(canvas, { ctrlKey: true, deltaY: -100000, clientX: 0, clientY: 0 });
+    expect(getView().zoom).toBe(4);
+    fireEvent.wheel(canvas, { ctrlKey: true, deltaY: 100000, clientX: 0, clientY: 0 });
+    expect(getView().zoom).toBe(0.1);
+  });
+
+  it('nodes live happily at NEGATIVE coordinates: render, select, and receive connections', async () => {
+    await openWith();
+    fireEvent.click(screen.getByTestId('palette-add-prompt')); // A @ (40,40)
+    await screen.findByTestId('wf-node-prompt');
+    fireEvent.click(screen.getByTestId('palette-add-prompt')); // B @ (80,80)
+    await screen.findByTestId('wf-node-prompt_2');
+    const canvas = screen.getByTestId('workflow-canvas');
+    // Drag B deep into negative space (grab its origin so dx=dy=0).
+    firePointer(screen.getByTestId('wf-node-prompt_2'), 'pointerDown', 80, 80);
+    firePointer(canvas, 'pointerMove', -400, -300);
+    firePointer(canvas, 'pointerUp', -400, -300);
+    const b = screen.getByTestId('wf-node-prompt_2') as HTMLElement;
+    expect(b.style.left).toBe('-400px');
+    expect(b.style.top).toBe('-300px');
+    // Connector hit-testing works at negative world coords: A.output → B.
+    firePointer(screen.getByTestId('wf-handle-prompt-needs-right'), 'pointerDown', 240, 84, 2);
+    firePointer(canvas, 'pointerMove', -350, -260, 2);
+    firePointer(canvas, 'pointerUp', -350, -260, 2);
+    expect(await screen.findByTestId('wf-edge-needs:prompt->prompt_2')).toBeInTheDocument();
+    // And the node is still clickable: deselect, then select it again.
+    fireEvent.click(canvas);
+    expect(screen.queryByTestId('field-action')).not.toBeInTheDocument();
+    firePointer(b, 'pointerDown', -380, -280);
+    firePointer(canvas, 'pointerUp', -380, -280);
+    expect(await screen.findByTestId('field-action')).toBeInTheDocument();
+  });
+
+  it('the insert menu opens at the correct WORLD position while panned + zoomed', async () => {
+    await openWith();
+    fireEvent.click(screen.getByTestId('palette-add-prompt')); // source @ (40,40)
+    await screen.findByTestId('wf-node-prompt');
+    const canvas = screen.getByTestId('workflow-canvas');
+    // Pan to (120, 60), then zoom in once via the button: the button anchors at
+    // the viewport centre (0,0 in jsdom) → view = (144, 72) @ 1.2×.
+    fireEvent.wheel(canvas, { deltaX: -120, deltaY: -60 });
+    fireEvent.click(screen.getByTestId('canvas-zoom-in'));
+    expect(getView()).toEqual({ x: 144, y: 72, zoom: 1.2 });
+    // Drop a connection on empty canvas at client (444, 312) — world
+    // ((444−144)/1.2, (312−72)/1.2) = (250, 200).
+    firePointer(screen.getByTestId('wf-handle-prompt-needs-right'), 'pointerDown', 0, 0, 2);
+    firePointer(canvas, 'pointerMove', 444, 312, 2);
+    firePointer(canvas, 'pointerUp', 444, 312, 2);
+    const menu = (await screen.findByTestId('insert-node-menu')) as HTMLElement;
+    expect(parseFloat(menu.style.left)).toBeCloseTo(250, 6);
+    expect(parseFloat(menu.style.top)).toBeCloseTo(200, 6);
+    // Inserting places the node at the drop point (input anchor on the drop):
+    // y is offset by half the node height (88/2 = 44).
+    fireEvent.click(within(menu).getByTestId('insert-add-skill'));
+    const node = (await screen.findByTestId('wf-node-skill')) as HTMLElement;
+    expect(parseFloat(node.style.left)).toBeCloseTo(250, 6);
+    expect(parseFloat(node.style.top)).toBeCloseTo(156, 6);
+    expect(await screen.findByTestId('wf-edge-needs:prompt->skill')).toBeInTheDocument();
+  });
+
+  it('drag-to-pan on empty canvas moves the view and keeps a still click deselecting', async () => {
+    await openWith();
+    fireEvent.click(screen.getByTestId('palette-add-prompt'));
+    await screen.findByTestId('wf-node-prompt');
+    const canvas = screen.getByTestId('workflow-canvas');
+    firePointer(canvas, 'pointerDown', 500, 400);
+    firePointer(canvas, 'pointerMove', 560, 340); // +60, −60
+    firePointer(canvas, 'pointerUp', 560, 340);
+    expect(getView()).toEqual({ x: 60, y: -60, zoom: 1 });
+    // The selection survives a moved pan (the trailing click is swallowed)…
+    fireEvent.click(canvas);
+    expect(screen.getByTestId('field-action')).toBeInTheDocument();
+    // …but a still click on the background still deselects.
+    firePointer(canvas, 'pointerDown', 500, 400);
+    firePointer(canvas, 'pointerUp', 500, 400);
+    fireEvent.click(canvas);
+    expect(screen.queryByTestId('field-action')).not.toBeInTheDocument();
+  });
+
+  it('zoom-to-fit recovers a lost view (jsdom zero-size rect → reset path)', async () => {
+    await openWith();
+    fireEvent.click(screen.getByTestId('palette-add-prompt'));
+    await screen.findByTestId('wf-node-prompt');
+    // Wander far off, then fit. jsdom's viewport rect is zero-size, which
+    // exercises the degenerate-rect fallback: reset to origin @ 100%. (The
+    // real bbox-centring math needs a layout engine; asserted by formula in
+    // the component.)
+    const canvas = screen.getByTestId('workflow-canvas');
+    fireEvent.wheel(canvas, { deltaX: -999, deltaY: -999 });
+    fireEvent.click(screen.getByTestId('canvas-zoom-fit'));
+    expect(getView()).toEqual({ x: 0, y: 0, zoom: 1 });
+  });
+});

--- a/apps/desktop/src/workflows/accents.ts
+++ b/apps/desktop/src/workflows/accents.ts
@@ -22,5 +22,5 @@ export function accentHex(accent: StepKindMeta['accent']): string {
 
 /** A translucent wash of the accent, for node card backgrounds. */
 export function accentWash(accent: StepKindMeta['accent']): string {
-  return `color-mix(in oklab, ${accentHex(accent)} 8%, white)`;
+  return `color-mix(in oklab, ${accentHex(accent)} 8%, var(--color-card-bg))`;
 }

--- a/packages/client-core/src/index.ts
+++ b/packages/client-core/src/index.ts
@@ -26,6 +26,7 @@ export * from './useConnection.js';
 export * from './usePrefs.js';
 export * from './useSettings.js';
 export * from './useDesks.js';
+export * from './useSessions.js';
 export * from './useWorkflows.js';
 export * from './usePausedWorkflows.js';
 export * from './useWorkflowBuilder.js';

--- a/packages/client-core/src/useAppUpdate.ts
+++ b/packages/client-core/src/useAppUpdate.ts
@@ -24,6 +24,7 @@ export type UpdateState =
   | 'uptodate'
   | 'available' // newer + compatible → can hot-update
   | 'incompatible' // newer but needs a full app/shell update
+  | 'requires-full-update' // newer but its runner protocol outruns the bundled CLI → full installer only
   | 'unavailable' // not configured / dev / offline
   | 'updating'
   | 'staged' // installed; relaunch to apply
@@ -73,6 +74,7 @@ export function useAppUpdate(opts: { autoCheck?: boolean } = {}): UseAppUpdate {
       setCheck(c);
       if (c.error) setState('unavailable');
       else if (!c.available) setState('uptodate');
+      else if (c.requiresFullUpdate) setState('requires-full-update');
       else if (!c.compatible) setState('incompatible');
       else setState('available');
     } catch (e) {
@@ -90,6 +92,11 @@ export function useAppUpdate(opts: { autoCheck?: boolean } = {}): UseAppUpdate {
       if (r.ok && r.version) {
         setStagedVersion(r.version);
         setState('staged');
+      } else if (r.requiresFullUpdate) {
+        // The bundle was deliberately not staged — it needs the full installer.
+        // Distinct from a failure so the UI shows the Tier-2 call-to-action.
+        setError(r.error ?? null);
+        setState('requires-full-update');
       } else {
         setError(r.error ?? 'Update failed.');
         setState('error');

--- a/packages/client-core/src/useDesks.ts
+++ b/packages/client-core/src/useDesks.ts
@@ -109,16 +109,24 @@ class DesksStore {
     // + active workspace follow the click without waiting for the IPC +
     // the supervisor's full re-resolve. Also pre-bind the connection
     // store's active id so the chat surface, context rail, and chat store
-    // all swap to the new workspace in the same render.
+    // all swap to the new workspace in the same render. The connection /
+    // chat routing key is the desk's ACTIVE SESSION id (the runner-pool
+    // key), not the desk id itself.
     const prev = this.state.activeId;
+    const prevConn = connectionStore.active$();
+    const desk = this.state.desks.find((d) => d.id === id);
     this.set({ activeId: id });
-    connectionStore.setActive(id);
+    connectionStore.setActive(desk?.activeSessionId ?? id);
     try {
       await api().invoke('desks.setActive', { id });
       await this.refresh();
+      // Re-sync in case the host resolved a different active session than
+      // the (possibly stale) one we predicted.
+      const fresh = this.state.desks.find((d) => d.id === id);
+      if (fresh?.activeSessionId) connectionStore.setActive(fresh.activeSessionId);
     } catch (e) {
       this.set({ activeId: prev, error: toErrorMessage(e) });
-      if (prev) connectionStore.setActive(prev);
+      if (prevConn) connectionStore.setActive(prevConn);
     }
   };
 
@@ -132,7 +140,26 @@ class DesksStore {
   };
 }
 
-const desksStore = new DesksStore();
+/** Shared singleton. Exported so sibling stores (the sessions store) can
+ *  refresh the desk list after a mutation that changes a desk's embedded
+ *  `sessions` array — not for component use (components go through
+ *  {@link useDesks}). */
+export const desksStore = new DesksStore();
+
+/**
+ * The desk that owns `workspaceId`. Routing ids are SESSION ids (the
+ * runner-pool key), so match a desk by owning the session — or by the desk
+ * id itself, which equals its default first session's id.
+ */
+export function deskForWorkspace(
+  desks: ReadonlyArray<Desk>,
+  workspaceId: string | null,
+): Desk | undefined {
+  if (!workspaceId) return undefined;
+  return desks.find(
+    (d) => d.id === workspaceId || d.sessions.some((s) => s.id === workspaceId),
+  );
+}
 
 export function useDesks(): UseDesks {
   const state = useSyncExternalStore(

--- a/packages/client-core/src/useSessions.test.tsx
+++ b/packages/client-core/src/useSessions.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * useSessions store tests — drive the IPC surface through the fake api
+ * shim and assert the session list, the optimistic local-first switch
+ * (connectionStore.setActive BEFORE the IPC lands + rollback on
+ * failure), and the post-remove re-point onto the host's promoted
+ * session.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { __setApiOverride } from './transport.js';
+import { connectionStore } from './useConnection.js';
+import { sessionsStore, useSessions } from './useSessions.js';
+import type { DeskSession, MoxxyApi, SessionsOverview } from '@moxxy/desktop-ipc-contract';
+
+function fakeApi(invoke: MoxxyApi['invoke']): MoxxyApi {
+  return { invoke, subscribe: () => () => {} };
+}
+
+const s1: DeskSession = { id: 's1', name: 'Session 1', createdAt: 1 };
+const s2: DeskSession = { id: 's2', name: 'Session 2', createdAt: 2 };
+
+/** A fake host: one desk ('d1') whose sessions live in `state`. Also
+ *  answers the desks.list refresh the store fires after mutations. */
+function installHost(initial: SessionsOverview): {
+  invokes: Array<{ cmd: string; args: unknown }>;
+  state: { overview: SessionsOverview };
+} {
+  const invokes: Array<{ cmd: string; args: unknown }> = [];
+  const state = { overview: initial };
+  const invoke = vi.fn(async (cmd: string, args?: unknown) => {
+    invokes.push({ cmd, args });
+    switch (cmd) {
+      case 'sessions.list':
+        return state.overview;
+      case 'sessions.create': {
+        const created: DeskSession = { id: 'new', name: 'Session N', createdAt: 9 };
+        state.overview = {
+          ...state.overview,
+          sessions: [...state.overview.sessions, created],
+        };
+        return created;
+      }
+      case 'sessions.setActive':
+        state.overview = {
+          ...state.overview,
+          activeSessionId: (args as { id: string }).id,
+        };
+        return undefined;
+      case 'sessions.remove': {
+        const id = (args as { id: string }).id;
+        const left = state.overview.sessions.filter((s) => s.id !== id);
+        state.overview = {
+          sessions: left,
+          activeSessionId:
+            state.overview.activeSessionId === id
+              ? (left[0]?.id ?? null)
+              : state.overview.activeSessionId,
+        };
+        return undefined;
+      }
+      case 'sessions.rename':
+        return undefined;
+      case 'desks.list':
+        return { desks: [], activeId: null };
+      default:
+        throw new Error(`unexpected ${cmd}`);
+    }
+  });
+  __setApiOverride(fakeApi(invoke as unknown as MoxxyApi['invoke']));
+  return { invokes, state };
+}
+
+afterEach(() => {
+  // Reset the module-level singletons between tests.
+  act(() => {
+    sessionsStore.setDesk(null);
+    connectionStore.setActive(null);
+  });
+  __setApiOverride(null);
+});
+
+describe('useSessions', () => {
+  it('loads the desk\'s sessions on mount and reloads on desk switch', async () => {
+    const { invokes } = installHost({ sessions: [s1, s2], activeSessionId: 's1' });
+    const { result, rerender } = renderHook(({ deskId }) => useSessions(deskId), {
+      initialProps: { deskId: 'd1' as string | null },
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.sessions).toEqual([s1, s2]);
+    expect(result.current.activeSessionId).toBe('s1');
+    expect(invokes).toContainEqual({ cmd: 'sessions.list', args: { deskId: 'd1' } });
+
+    rerender({ deskId: 'd2' });
+    await waitFor(() =>
+      expect(invokes).toContainEqual({ cmd: 'sessions.list', args: { deskId: 'd2' } }),
+    );
+  });
+
+  it('clears to the empty state when the desk goes null', async () => {
+    installHost({ sessions: [s1], activeSessionId: 's1' });
+    const { result, rerender } = renderHook(({ deskId }) => useSessions(deskId), {
+      initialProps: { deskId: 'd1' as string | null },
+    });
+    await waitFor(() => expect(result.current.sessions).toEqual([s1]));
+    rerender({ deskId: null });
+    await waitFor(() => expect(result.current.sessions).toEqual([]));
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('setActive flips connectionStore BEFORE the IPC lands (optimistic, local-first)', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const overview: SessionsOverview = { sessions: [s1, s2], activeSessionId: 's1' };
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === 'sessions.list') return overview;
+      if (cmd === 'sessions.setActive') {
+        await gate; // hold the IPC open so we can observe the optimistic flip
+        return undefined;
+      }
+      if (cmd === 'desks.list') return { desks: [], activeId: null };
+      throw new Error(`unexpected ${cmd}`);
+    });
+    __setApiOverride(fakeApi(invoke as unknown as MoxxyApi['invoke']));
+
+    const { result } = renderHook(() => useSessions('d1'));
+    await waitFor(() => expect(result.current.sessions).toEqual([s1, s2]));
+
+    let done: Promise<void>;
+    act(() => {
+      done = result.current.setActive('s2');
+    });
+    // The switch is already visible while the host call is still in flight.
+    expect(connectionStore.active$()).toBe('s2');
+    expect(result.current.activeSessionId).toBe('s2');
+    release();
+    await act(async () => done);
+  });
+
+  it('setActive rolls back the optimistic flip when the IPC fails', async () => {
+    const overview: SessionsOverview = { sessions: [s1, s2], activeSessionId: 's1' };
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === 'sessions.list') return overview;
+      if (cmd === 'sessions.setActive') throw new Error('boom');
+      if (cmd === 'desks.list') return { desks: [], activeId: null };
+      throw new Error(`unexpected ${cmd}`);
+    });
+    __setApiOverride(fakeApi(invoke as unknown as MoxxyApi['invoke']));
+    connectionStore.setActive('s1');
+
+    const { result } = renderHook(() => useSessions('d1'));
+    await waitFor(() => expect(result.current.sessions).toEqual([s1, s2]));
+    await act(async () => result.current.setActive('s2'));
+    expect(result.current.activeSessionId).toBe('s1');
+    expect(connectionStore.active$()).toBe('s1');
+    expect(result.current.error).toBe('boom');
+  });
+
+  it('create invokes sessions.create for the tracked desk and refreshes', async () => {
+    const { invokes } = installHost({ sessions: [s1], activeSessionId: 's1' });
+    const { result } = renderHook(() => useSessions('d1'));
+    await waitFor(() => expect(result.current.sessions).toEqual([s1]));
+    let created: DeskSession | null = null;
+    await act(async () => {
+      created = await result.current.create();
+    });
+    expect(created).toMatchObject({ id: 'new' });
+    expect(invokes).toContainEqual({ cmd: 'sessions.create', args: { deskId: 'd1' } });
+    await waitFor(() => expect(result.current.sessions.map((s) => s.id)).toContain('new'));
+  });
+
+  it('remove re-points the connection store at the host\'s promoted session', async () => {
+    installHost({ sessions: [s1, s2], activeSessionId: 's2' });
+    connectionStore.setActive('s2');
+    const { result } = renderHook(() => useSessions('d1'));
+    await waitFor(() => expect(result.current.sessions).toEqual([s1, s2]));
+    await act(async () => result.current.remove('s2'));
+    expect(result.current.sessions).toEqual([s1]);
+    expect(result.current.activeSessionId).toBe('s1');
+    expect(connectionStore.active$()).toBe('s1');
+  });
+
+  it('rename invokes sessions.rename and surfaces errors via state', async () => {
+    const { invokes } = installHost({ sessions: [s1], activeSessionId: 's1' });
+    const { result } = renderHook(() => useSessions('d1'));
+    await waitFor(() => expect(result.current.sessions).toEqual([s1]));
+    await act(async () => result.current.rename('s1', 'Deep dive'));
+    expect(invokes).toContainEqual({
+      cmd: 'sessions.rename',
+      args: { id: 's1', name: 'Deep dive' },
+    });
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/packages/client-core/src/useSessions.ts
+++ b/packages/client-core/src/useSessions.ts
@@ -1,0 +1,192 @@
+/**
+ * Per-desk session list — multiple conversations per workspace.
+ *
+ * Module-level store cloned from the {@link DesksStore} pattern: one
+ * shared snapshot for every consumer, optimistic active-id flips, and
+ * the same "connectionStore.setActive first, IPC second" switch gesture
+ * the desks store (and the mobile app's selectWorkspace) uses. The
+ * store tracks ONE desk at a time (the sidebar shows the active desk's
+ * sessions); switching desks re-points it via {@link useSessions}'s
+ * effect.
+ *
+ * Switching sessions is local-first: `connectionStore.setActive(id)`
+ * swaps the chat surface instantly (chatStore follows via App.tsx's
+ * activeWorkspaceId mirror), then `sessions.setActive` makes the host
+ * persist + foreground that session's runner.
+ */
+
+import { useEffect, useSyncExternalStore } from 'react';
+import { api } from './transport.js';
+import { toErrorMessage } from './errors.js';
+import { connectionStore } from './useConnection.js';
+import { desksStore } from './useDesks.js';
+import type { DeskSession, SessionsOverview } from '@moxxy/desktop-ipc-contract';
+
+export interface UseSessions {
+  readonly sessions: ReadonlyArray<DeskSession>;
+  readonly activeSessionId: string | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+  readonly refresh: () => Promise<void>;
+  /** Create a session under the tracked desk (auto-named "Session N"
+   *  unless `name` is given). Does not foreground it. */
+  readonly create: (name?: string) => Promise<DeskSession | null>;
+  readonly setActive: (id: string) => Promise<void>;
+  readonly remove: (id: string) => Promise<void>;
+  readonly rename: (id: string, name: string) => Promise<void>;
+}
+
+interface SessionsState {
+  /** The desk whose sessions are loaded. */
+  readonly deskId: string | null;
+  readonly sessions: ReadonlyArray<DeskSession>;
+  readonly activeSessionId: string | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+const INITIAL: SessionsState = {
+  deskId: null,
+  sessions: [],
+  activeSessionId: null,
+  loading: false,
+  error: null,
+};
+
+class SessionsStore {
+  private state: SessionsState = INITIAL;
+  private listeners = new Set<() => void>();
+
+  subscribe = (fn: () => void): (() => void) => {
+    this.listeners.add(fn);
+    return () => {
+      this.listeners.delete(fn);
+    };
+  };
+
+  /** Cached snapshot — referentially stable until {@link set} swaps it. */
+  getSnapshot = (): SessionsState => this.state;
+
+  private set(patch: Partial<SessionsState>): void {
+    this.state = { ...this.state, ...patch };
+    for (const l of this.listeners) l();
+  }
+
+  /** Point the store at a desk (null clears it). Triggers a load. */
+  setDesk(deskId: string | null): void {
+    if (this.state.deskId === deskId) return;
+    this.state = { ...INITIAL, deskId, loading: deskId !== null };
+    for (const l of this.listeners) l();
+    if (deskId) void this.refresh();
+  }
+
+  refresh = async (): Promise<void> => {
+    const deskId = this.state.deskId;
+    if (!deskId) return;
+    try {
+      const next: SessionsOverview = await api().invoke('sessions.list', { deskId });
+      // A desk switch can race the round-trip — drop a stale response.
+      if (this.state.deskId !== deskId) return;
+      this.set({
+        sessions: next.sessions,
+        activeSessionId: next.activeSessionId,
+        loading: false,
+        error: null,
+      });
+    } catch (e) {
+      if (this.state.deskId !== deskId) return;
+      this.set({ error: toErrorMessage(e), loading: false });
+    }
+  };
+
+  create = async (name?: string): Promise<DeskSession | null> => {
+    const deskId = this.state.deskId;
+    try {
+      const session = await api().invoke('sessions.create', {
+        ...(deskId ? { deskId } : {}),
+        ...(name ? { name } : {}),
+      });
+      await this.refresh();
+      // Desks embed their sessions array — keep the desk list in step so
+      // session-aware desk lookups (chat header, context rail) stay fresh.
+      void desksStore.refresh();
+      return session;
+    } catch (e) {
+      this.set({ error: toErrorMessage(e) });
+      return null;
+    }
+  };
+
+  setActive = async (id: string): Promise<void> => {
+    // Optimistic: re-point the connection store (and with it the chat
+    // surface + chat store via the activeWorkspaceId mirror) immediately —
+    // exactly the desks-store switch gesture / mobile's selectWorkspace.
+    const prevActive = this.state.activeSessionId;
+    const prevConn = connectionStore.active$();
+    this.set({ activeSessionId: id });
+    connectionStore.setActive(id);
+    try {
+      await api().invoke('sessions.setActive', { id });
+      await this.refresh();
+    } catch (e) {
+      this.set({ activeSessionId: prevActive, error: toErrorMessage(e) });
+      if (prevConn) connectionStore.setActive(prevConn);
+    }
+  };
+
+  remove = async (id: string): Promise<void> => {
+    try {
+      await api().invoke('sessions.remove', { id });
+      await this.refresh();
+      void desksStore.refresh();
+      // Removing the foregrounded session leaves the connection store on a
+      // dead id — follow the host's promoted (or freshly-seeded) session.
+      const nextActive = this.state.activeSessionId;
+      if (connectionStore.active$() === id && nextActive) {
+        connectionStore.setActive(nextActive);
+      }
+    } catch (e) {
+      this.set({ error: toErrorMessage(e) });
+    }
+  };
+
+  rename = async (id: string, name: string): Promise<void> => {
+    try {
+      await api().invoke('sessions.rename', { id, name });
+      await this.refresh();
+      void desksStore.refresh();
+    } catch (e) {
+      this.set({ error: toErrorMessage(e) });
+    }
+  };
+}
+
+/** Shared singleton (exported for tests — components use {@link useSessions}). */
+export const sessionsStore = new SessionsStore();
+
+/**
+ * Sessions of one desk (pass the ACTIVE desk id; the sidebar's session
+ * list is scoped to it). Re-points the shared store when the desk
+ * changes.
+ */
+export function useSessions(deskId: string | null): UseSessions {
+  const state = useSyncExternalStore(
+    sessionsStore.subscribe,
+    sessionsStore.getSnapshot,
+    sessionsStore.getSnapshot,
+  );
+  useEffect(() => {
+    sessionsStore.setDesk(deskId);
+  }, [deskId]);
+  return {
+    sessions: state.sessions,
+    activeSessionId: state.activeSessionId,
+    loading: state.loading,
+    error: state.error,
+    refresh: sessionsStore.refresh,
+    create: sessionsStore.create,
+    setActive: sessionsStore.setActive,
+    remove: sessionsStore.remove,
+    rename: sessionsStore.rename,
+  };
+}

--- a/packages/design-tokens/src/css-vars.test.ts
+++ b/packages/design-tokens/src/css-vars.test.ts
@@ -1,6 +1,8 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
-import { tokens } from './index.js';
-import { CSS_VAR_MAP, generateRootCss } from './css-vars.js';
+import { tokens, darkTokens } from './index.js';
+import { CSS_VAR_MAP, DARK_CSS_VAR_MAP, generateRootCss, generateThemeCss } from './css-vars.js';
 
 describe('generateRootCss', () => {
   it('emits a :root block', () => {
@@ -21,6 +23,8 @@ describe('generateRootCss', () => {
     // Spot-check the load-bearing brand declarations against the desktop CSS.
     expect(css).toContain('--color-primary: #ec4899;');
     expect(css).toContain('--color-app-bg: #f1f2f9;');
+    expect(css).toContain('--color-main-bg: rgb(252, 252, 255);');
+    expect(css).toContain('--color-surface: #ffffff;');
     expect(css).toContain(
       '--color-card-shadow: 0 1px 2px rgba(15, 23, 42, 0.04), 0 10px 24px -18px rgba(15, 23, 42, 0.10);',
     );
@@ -31,5 +35,96 @@ describe('generateRootCss', () => {
   it('renders radii as numbers with a px unit (RN keeps the bare number)', () => {
     expect(tokens.radius.card).toBe(14);
     expect(generateRootCss()).toContain('--radius-card: 14px;');
+  });
+});
+
+describe('generateThemeCss', () => {
+  it('emits :root followed by a [data-theme="dark"] override block', () => {
+    const css = generateThemeCss();
+    expect(css.startsWith(':root {\n')).toBe(true);
+    expect(css).toContain('[data-theme="dark"] {');
+    expect(css).toContain('color-scheme: dark;');
+  });
+
+  it('declares every dark-mapped variable with its darkTokens value', () => {
+    const dark = generateThemeCss().split('[data-theme="dark"]')[1]!;
+    for (const [name, value] of DARK_CSS_VAR_MAP) {
+      expect(dark).toContain(`  ${name}: ${value};`);
+    }
+  });
+
+  it('gives every light color/gradient var a dark counterpart (fonts/radii are theme-invariant)', () => {
+    const lightNames = CSS_VAR_MAP.map(([n]) => n).filter(
+      (n) => !n.startsWith('--font-') && !n.startsWith('--radius-'),
+    );
+    const darkNames = new Set(DARK_CSS_VAR_MAP.map(([n]) => n));
+    for (const name of lightNames) {
+      expect(darkNames.has(name), `${name} has no dark counterpart`).toBe(true);
+    }
+  });
+
+  it('darkTokens has exactly the same flat color keys as tokens (shape frozen)', () => {
+    expect(Object.keys(darkTokens.color).sort()).toEqual(Object.keys(tokens.color).sort());
+    expect(Object.keys(darkTokens)).toEqual(Object.keys(tokens));
+  });
+});
+
+/**
+ * styles.css ↔ tokens parity. styles.css stays authoritative for the desktop;
+ * these tests pin the two declarations of the palette together so an edit to
+ * either side without the other fails loudly. Crucially they also enforce the
+ * dark theme's completeness: ANY literal-color custom property declared in a
+ * :root block (including the legacy aliases) that lacks a re-declaration in
+ * the [data-theme="dark"] block would silently stay light in dark mode.
+ */
+describe('apps/desktop styles.css parity', () => {
+  const stylesPath = fileURLToPath(
+    new URL('../../../apps/desktop/src/styles.css', import.meta.url),
+  );
+  // Strip comments so colors mentioned in prose don't trip the literal scan.
+  const css = readFileSync(stylesPath, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '');
+
+  function declsOf(block: string): Map<string, string> {
+    const map = new Map<string, string>();
+    for (const m of block.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+      map.set(m[1]!, m[2]!.trim().replace(/\s+/g, ' '));
+    }
+    return map;
+  }
+
+  const rootDecls = new Map<string, string>();
+  for (const m of css.matchAll(/(?:^|\n)\s*:root\s*\{([^}]*)\}/g)) {
+    for (const [k, v] of declsOf(m[1]!)) rootDecls.set(k, v);
+  }
+  const darkMatch = css.match(/\[data-theme="dark"\]\s*\{([^}]*)\}/);
+  const darkDecls = darkMatch ? declsOf(darkMatch[1]!) : new Map<string, string>();
+
+  it('found both the :root and the [data-theme="dark"] blocks', () => {
+    expect(rootDecls.size).toBeGreaterThan(0);
+    expect(darkDecls.size).toBeGreaterThan(0);
+    expect(darkMatch?.[1]).toContain('color-scheme: dark');
+  });
+
+  it(':root matches the light tokens (CSS_VAR_MAP)', () => {
+    for (const [name, value] of CSS_VAR_MAP) {
+      expect(rootDecls.get(name), `:root ${name}`).toBe(value.replace(/\s+/g, ' '));
+    }
+  });
+
+  it('[data-theme="dark"] matches the dark tokens (DARK_CSS_VAR_MAP)', () => {
+    for (const [name, value] of DARK_CSS_VAR_MAP) {
+      expect(darkDecls.get(name), `dark ${name}`).toBe(value.replace(/\s+/g, ' '));
+    }
+  });
+
+  it('every literal-color :root var (incl. legacy aliases) is overridden in the dark block', () => {
+    const hasLiteralColor = (v: string): boolean => /#[0-9a-f]{3,8}\b|rgba?\(/i.test(v);
+    for (const [name, value] of rootDecls) {
+      if (!/^--(?:color|grad)-/.test(name)) continue;
+      if (!hasLiteralColor(value)) continue; // pure var() aliases follow their target
+      expect(darkDecls.has(name), `${name} (${value}) is missing from [data-theme="dark"]`).toBe(
+        true,
+      );
+    }
   });
 });

--- a/packages/design-tokens/src/css-vars.ts
+++ b/packages/design-tokens/src/css-vars.ts
@@ -4,50 +4,82 @@
  * declares, so this generator can become the single source of that block. It's
  * shipped now but not yet consumed by the desktop (styles.css stays the source
  * of truth) — the parity test guards the mapping so a later switch is safe.
+ *
+ * Theming: {@link generateThemeCss} additionally emits a
+ * `[data-theme="dark"]` block from {@link darkTokens}. The desktop's
+ * `useTheme()` controller toggles `data-theme="dark"` on `<html>`; anything
+ * reading the variables below re-themes for free.
  */
 
-import { tokens } from './index.js';
+import { tokens, darkTokens, type ThemeTokens } from './index.js';
 
-/** `[cssVarName, value]` pairs, in the desktop's declaration order. Numbers
- *  (radii) are emitted with a `px` unit; everything else is verbatim. */
-export const CSS_VAR_MAP: ReadonlyArray<readonly [string, string]> = [
-  ['--color-app-bg', tokens.color.appBg],
-  ['--color-card-bg', tokens.color.cardBg],
-  ['--color-card-border', tokens.color.cardBorder],
-  ['--color-card-border-strong', tokens.color.cardBorderStrong],
-  ['--color-card-shadow', tokens.shadow.card],
-  ['--color-text', tokens.color.text],
-  ['--color-text-muted', tokens.color.textMuted],
-  ['--color-text-dim', tokens.color.textDim],
-  ['--color-sidebar-bg', tokens.color.sidebarBg],
-  ['--color-sidebar-bg-hover', tokens.color.sidebarBgHover],
-  ['--color-sidebar-bg-active', tokens.color.sidebarBgActive],
-  ['--color-sidebar-text', tokens.color.sidebarText],
-  ['--color-sidebar-text-dim', tokens.color.sidebarTextDim],
-  ['--color-sidebar-border', tokens.color.sidebarBorder],
-  ['--color-primary', tokens.color.primary],
-  ['--color-primary-strong', tokens.color.primaryStrong],
-  ['--color-primary-soft', tokens.color.primarySoft],
-  ['--color-send', tokens.color.send],
-  ['--color-accent', tokens.color.accent],
-  ['--color-accent-strong', tokens.color.accentStrong],
-  ['--color-purple', tokens.color.purple],
-  ['--color-green', tokens.color.green],
-  ['--color-amber', tokens.color.amber],
-  ['--color-pink', tokens.color.pink],
-  ['--color-red', tokens.color.red],
-  ['--grad-user', tokens.gradient.user],
-  ['--grad-cta', tokens.gradient.cta],
-  ['--grad-accent', tokens.gradient.accent],
-  ['--font-sans', tokens.font.sans],
-  ['--font-mono', tokens.font.mono],
-  ['--radius-block', `${tokens.radius.block}px`],
-  ['--radius-card', `${tokens.radius.card}px`],
-  ['--radius-pill', `${tokens.radius.pill}px`],
-];
+/** Build `[cssVarName, value]` pairs for one palette, in the desktop's
+ *  declaration order. Numbers (radii) are emitted with a `px` unit;
+ *  everything else is verbatim. */
+function varPairs(t: ThemeTokens): ReadonlyArray<readonly [string, string]> {
+  return [
+    ['--color-app-bg', t.color.appBg],
+    ['--color-main-bg', t.color.mainBg],
+    ['--color-surface', t.color.surface],
+    ['--color-input-soft', t.color.inputSoft],
+    ['--color-card-bg', t.color.cardBg],
+    ['--color-card-border', t.color.cardBorder],
+    ['--color-card-border-strong', t.color.cardBorderStrong],
+    ['--color-card-shadow', t.shadow.card],
+    ['--color-text', t.color.text],
+    ['--color-text-muted', t.color.textMuted],
+    ['--color-text-dim', t.color.textDim],
+    ['--color-sidebar-bg', t.color.sidebarBg],
+    ['--color-sidebar-bg-hover', t.color.sidebarBgHover],
+    ['--color-sidebar-bg-active', t.color.sidebarBgActive],
+    ['--color-sidebar-text', t.color.sidebarText],
+    ['--color-sidebar-text-dim', t.color.sidebarTextDim],
+    ['--color-sidebar-border', t.color.sidebarBorder],
+    ['--color-primary', t.color.primary],
+    ['--color-primary-strong', t.color.primaryStrong],
+    ['--color-primary-soft', t.color.primarySoft],
+    ['--color-send', t.color.send],
+    ['--color-accent', t.color.accent],
+    ['--color-accent-strong', t.color.accentStrong],
+    ['--color-purple', t.color.purple],
+    ['--color-green', t.color.green],
+    ['--color-amber', t.color.amber],
+    ['--color-pink', t.color.pink],
+    ['--color-red', t.color.red],
+    ['--grad-user', t.gradient.user],
+    ['--grad-cta', t.gradient.cta],
+    ['--grad-accent', t.gradient.accent],
+    ['--font-sans', t.font.sans],
+    ['--font-mono', t.font.mono],
+    ['--radius-block', `${t.radius.block}px`],
+    ['--radius-card', `${t.radius.card}px`],
+    ['--radius-pill', `${t.radius.pill}px`],
+  ];
+}
 
-/** Render the tokens as a `:root { … }` CSS block. */
+/** `[cssVarName, value]` pairs for the LIGHT (default) palette. */
+export const CSS_VAR_MAP: ReadonlyArray<readonly [string, string]> = varPairs(tokens);
+
+/** `[cssVarName, value]` pairs for the DARK palette ({@link darkTokens}).
+ *  Fonts and radii are theme-invariant, so the dark override block only
+ *  carries the color-bearing variables. */
+export const DARK_CSS_VAR_MAP: ReadonlyArray<readonly [string, string]> = varPairs(
+  darkTokens,
+).filter(([name]) => !name.startsWith('--font-') && !name.startsWith('--radius-'));
+
+/** Render the light tokens as a `:root { … }` CSS block. */
 export function generateRootCss(): string {
   const lines = CSS_VAR_MAP.map(([name, value]) => `  ${name}: ${value};`);
   return `:root {\n${lines.join('\n')}\n}`;
+}
+
+/** Render both palettes: `:root { … }` (light, plus `color-scheme: light`)
+ *  followed by a `[data-theme="dark"] { … }` override block. */
+export function generateThemeCss(): string {
+  const dark = DARK_CSS_VAR_MAP.map(([name, value]) => `  ${name}: ${value};`);
+  return [
+    generateRootCss(),
+    '',
+    `[data-theme="dark"] {\n${dark.join('\n')}\n  color-scheme: dark;\n}`,
+  ].join('\n');
 }

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -14,6 +14,15 @@
 export const tokens = {
   color: {
     appBg: '#f1f2f9',
+    /* Main chat column — a hair off pure white so it reads as separate
+     * from adjacent white surfaces without being grey. */
+    mainBg: 'rgb(252, 252, 255)',
+    /* Resting surface for buttons / chips / inputs that sit ON a card
+     * or column (the things that were hard-coded `#fff`). */
+    surface: '#ffffff',
+    /* Recessed "soft" input fill — a cool near-white a step below the
+     * surface (TextInput/TextArea tone='soft', modal fields). */
+    inputSoft: '#f7f8fc',
     cardBg: '#ffffff',
     cardBorder: '#e3e5f0',
     cardBorderStrong: '#cdd1e3',
@@ -58,3 +67,61 @@ export const tokens = {
 } as const;
 
 export type Tokens = typeof tokens;
+
+/** Structural widening of {@link Tokens} — same keys, plain `string` /
+ *  `number` leaves — so alternate palettes (dark) can hold different values
+ *  while staying shape-compatible with everything that reads `tokens`. */
+type Widen<T> = {
+  [K in keyof T]: T[K] extends string ? string : T[K] extends number ? number : Widen<T[K]>;
+};
+export type ThemeTokens = Widen<Tokens>;
+
+/**
+ * The DESIGNED dark palette — not a naive inversion. Lightness ordering
+ * (darkest → lightest): sidebar rail < app canvas < main column < cards <
+ * resting surfaces, mirroring the light theme's "columns register against
+ * each other" intent. The brand accents (pink / cyan / purple / status
+ * colors) and gradients survive dark unchanged; text flips to light
+ * grays in the same cool-indigo family; shadows go near-black at higher
+ * alpha because rgba(15,23,42,…) ink reads as nothing on a dark canvas.
+ *
+ * Shape-frozen against {@link tokens} (same flat color keys) — mobile's
+ * tailwind config and the CSS-var generator consume both interchangeably.
+ */
+export const darkTokens: ThemeTokens = {
+  color: {
+    appBg: '#0b0c13',
+    mainBg: '#101117',
+    surface: '#1b1e2b',
+    inputSoft: '#121420' /* soft inputs recess below the card they sit on */,
+    cardBg: '#161823',
+    cardBorder: '#262a3c',
+    cardBorderStrong: '#363c54',
+    text: '#e8eaf6',
+    textMuted: '#a4abc8',
+    textDim: '#697091',
+    sidebarBg: '#0d0e16',
+    sidebarBgHover: '#171927',
+    sidebarBgActive: '#2b1622' /* dark plum — the brand-pink wash on dark */,
+    sidebarText: '#e8eaf6',
+    sidebarTextDim: '#8b91b0',
+    sidebarBorder: '#1f2233',
+    primary: tokens.color.primary,
+    primaryStrong: tokens.color.primaryStrong,
+    primarySoft: '#2b1622' /* the near-white pink-50 flips to the dark plum wash */,
+    send: tokens.color.send,
+    accent: tokens.color.accent,
+    accentStrong: tokens.color.accentStrong,
+    purple: tokens.color.purple,
+    green: tokens.color.green,
+    amber: tokens.color.amber,
+    pink: tokens.color.pink,
+    red: tokens.color.red,
+  },
+  shadow: {
+    card: '0 1px 2px rgba(0, 0, 0, 0.5), 0 10px 24px -18px rgba(0, 0, 0, 0.7)',
+  },
+  gradient: { ...tokens.gradient },
+  font: { ...tokens.font },
+  radius: { ...tokens.radius },
+};

--- a/packages/desktop-host/src/app-update/index.ts
+++ b/packages/desktop-host/src/app-update/index.ts
@@ -40,6 +40,7 @@ export {
   readConfirmed,
   compareSemver,
   isCompatible,
+  exceedsCliRunnerProtocol,
   resolveActiveBundle,
   resolveActiveBundleDetailed,
   type ResolveResult,

--- a/packages/desktop-host/src/app-update/resolve.ts
+++ b/packages/desktop-host/src/app-update/resolve.ts
@@ -243,6 +243,31 @@ export function isCompatible(m: AppManifest, shell: ShellInfo): boolean {
   return m.nodeAbi === '' || shell.nodeAbi === m.nodeAbi;
 }
 
+/**
+ * True iff the bundle's signed `runnerProtocol` stamp EXCEEDS the runner
+ * protocol the reachable CLI can serve — i.e. activating this JS bundle would
+ * strand the desktop with a client newer than any runner it can spawn (the
+ * protocol-skew reconnect loop). Such an update needs the FULL app installer
+ * (Tier-2), not a hot-update. Either side unknown (legacy manifest / caller
+ * that doesn't model the CLI) ⇒ no constraint.
+ *
+ * Single-sourced here so the boot gate ({@link resolveActiveBundleDetailed})
+ * and the stager's stage-time gate can never disagree: previously the stager
+ * happily staged + activated such a bundle, the UI said "updated — relaunch",
+ * and every boot silently rejected it (`runner-protocol-skew`) back to the
+ * floor.
+ */
+export function exceedsCliRunnerProtocol(
+  m: Pick<AppManifest, 'runnerProtocol'>,
+  cliRunnerProtocol?: number,
+): boolean {
+  return (
+    typeof cliRunnerProtocol === 'number' &&
+    typeof m.runnerProtocol === 'number' &&
+    m.runnerProtocol > cliRunnerProtocol
+  );
+}
+
 export interface ResolveOpts {
   userDataDir: string;
   /** Baked Ed25519 public key (SPKI PEM). Empty disables all overrides. */
@@ -314,11 +339,7 @@ export function resolveActiveBundleDetailed(opts: ResolveOpts): ResolveResult {
   // to the floor JS, which matches the CLI). Only enforced when both the
   // bundle's stamp and the caller's CLI protocol are known (signed value, so
   // trusted post-signature-check).
-  if (
-    typeof cliRunnerProtocol === 'number' &&
-    typeof manifest.runnerProtocol === 'number' &&
-    manifest.runnerProtocol > cliRunnerProtocol
-  ) {
+  if (exceedsCliRunnerProtocol(manifest, cliRunnerProtocol)) {
     return { bundle: null, reason: 'runner-protocol-skew' };
   }
 

--- a/packages/desktop-host/src/app-update/stager.test.ts
+++ b/packages/desktop-host/src/app-update/stager.test.ts
@@ -117,6 +117,64 @@ describe('checkForUpdate', () => {
   });
 });
 
+describe('checkForUpdate runner-protocol gate', () => {
+  const MANIFEST_URL = 'https://github.com/moxxy-ai/moxxy/releases/download/desktop-v0.0.9/moxxy-app-manifest.json';
+
+  function checkWithProtocol(
+    bundleProtocol: number | undefined,
+    cliRunnerProtocol: number | undefined,
+  ): ReturnType<typeof checkForUpdate> {
+    const { manifestJson } = buildAppBundle({
+      version: '0.0.9',
+      minElectron: '33.0.0',
+      nodeAbi: '',
+      bundleUrl: 'https://github.com/moxxy-ai/moxxy/releases/download/desktop-v0.0.9/b.json.gz',
+      privateKeyPem: PRIVKEY,
+      files: { 'dist/index.html': Buffer.from('x') },
+      ...(typeof bundleProtocol === 'number' ? { runnerProtocol: bundleProtocol } : {}),
+    });
+    const fetchImpl = (async () => new Response(manifestJson)) as unknown as typeof fetch;
+    return checkForUpdate(
+      {
+        repo: 'moxxy-ai/moxxy',
+        currentVersion: '0.0.5',
+        publicKeyPem: PUBKEY,
+        shell: SHELL,
+        ...(typeof cliRunnerProtocol === 'number' ? { cliRunnerProtocol } : {}),
+        manifestUrlOverride: MANIFEST_URL,
+      },
+      { fetchImpl },
+    );
+  }
+
+  it('flags a bundle whose runner protocol outruns the spawnable CLI as requiring a full update', async () => {
+    const res = await checkWithProtocol(7, 6);
+    expect(res.available).toBe(true);
+    expect(res.requiresFullUpdate).toBe(true);
+    expect(res.compatible).toBe(false); // can't be applied as a hot-update
+  });
+
+  it('does not flag an equal or lower runner protocol', async () => {
+    const equal = await checkWithProtocol(6, 6);
+    expect(equal.requiresFullUpdate).toBeUndefined();
+    expect(equal.compatible).toBe(true);
+
+    const lower = await checkWithProtocol(5, 6);
+    expect(lower.requiresFullUpdate).toBeUndefined();
+    expect(lower.compatible).toBe(true);
+  });
+
+  it('does not flag when either side of the gate is unknown', async () => {
+    const noStamp = await checkWithProtocol(undefined, 6); // legacy manifest
+    expect(noStamp.requiresFullUpdate).toBeUndefined();
+    expect(noStamp.compatible).toBe(true);
+
+    const noCli = await checkWithProtocol(7, undefined); // caller doesn't model the CLI
+    expect(noCli.requiresFullUpdate).toBeUndefined();
+    expect(noCli.compatible).toBe(true);
+  });
+});
+
 describe('downloadAndStage hardening', () => {
   const GH = 'https://github.com/moxxy-ai/moxxy/releases/latest/download/b.json.gz';
 
@@ -227,6 +285,57 @@ describe('downloadAndStage hardening', () => {
       readFileSync(path.join(bundleRoot(tmp, '0.0.7'), 'package.json'), 'utf8'),
     );
     expect(pkg.type).toBe('module'); // the staged tree now loads as ESM
+  });
+
+  it('refuses to stage a bundle whose runner protocol outruns the spawnable CLI', async () => {
+    // Reproduces the "says updated and restart but it does not update" loop:
+    // the stager used to download/verify/activate such a bundle, the UI said
+    // "relaunch to apply", and the boot gate rejected it (`runner-protocol-skew`)
+    // on every launch. The stage-time gate must refuse BEFORE anything lands.
+    const { manifest, bundleGz } = buildAppBundle({
+      version: '0.0.6',
+      minElectron: '33.0.0',
+      nodeAbi: '',
+      bundleUrl: GH,
+      privateKeyPem: PRIVKEY,
+      runnerProtocol: 7,
+      files: {
+        'dist/index.html': Buffer.from('x'),
+        'dist-electron/main/index.js': Buffer.from('// main'),
+      },
+    });
+    const fetchImpl = (async () => new Response(new Uint8Array(bundleGz))) as unknown as typeof fetch;
+    await expect(
+      downloadAndStage(
+        { userDataDir: tmp, manifest, publicKeyPem: PUBKEY, cliRunnerProtocol: 6 },
+        { fetchImpl },
+      ),
+    ).rejects.toThrow(/full app installer/i);
+    // nothing staged, nothing activated — no false "updated, relaunch" state
+    expect(existsSync(bundleRoot(tmp, '0.0.6'))).toBe(false);
+    expect(readActiveVersion(tmp)).toBeNull();
+  });
+
+  it('stages a bundle whose runner protocol matches the spawnable CLI', async () => {
+    const { manifest, bundleGz } = buildAppBundle({
+      version: '0.0.6',
+      minElectron: '33.0.0',
+      nodeAbi: '',
+      bundleUrl: GH,
+      privateKeyPem: PRIVKEY,
+      runnerProtocol: 6,
+      files: {
+        'dist/index.html': Buffer.from('x'),
+        'dist-electron/main/index.js': Buffer.from('// main'),
+      },
+    });
+    const fetchImpl = (async () => new Response(new Uint8Array(bundleGz))) as unknown as typeof fetch;
+    const { version } = await downloadAndStage(
+      { userDataDir: tmp, manifest, publicKeyPem: PUBKEY, cliRunnerProtocol: 6 },
+      { fetchImpl },
+    );
+    expect(version).toBe('0.0.6');
+    expect(readActiveVersion(tmp)).toBe('0.0.6');
   });
 
   it('clears a prior poison mark on the version it installs (un-wedges a reinstall)', async () => {

--- a/packages/desktop-host/src/app-update/stager.ts
+++ b/packages/desktop-host/src/app-update/stager.ts
@@ -31,6 +31,7 @@ import {
   appUpdateDir,
   bundleRoot,
   compareSemver,
+  exceedsCliRunnerProtocol,
   isCompatible,
   isSafeVersion,
   safeRelPath,
@@ -64,6 +65,11 @@ export interface CheckResult {
   latestVersion: string | null;
   /** The running shell satisfies the bundle (false ⇒ a shell/Tier-2 update is needed). */
   compatible: boolean;
+  /** True ⇒ the bundle's signed `runnerProtocol` outruns the CLI the desktop
+   *  can spawn: a hot-update would be staged but REFUSED at every boot
+   *  (`runner-protocol-skew`), so this update needs the full app installer
+   *  (Tier-2). Only computed when the caller supplies `cliRunnerProtocol`. */
+  requiresFullUpdate?: boolean;
   manifest: AppManifest | null;
   /** Where to download the bundle — the discovered release asset URL (preferred
    *  over the manifest's signed `bundleUrl`, which integrity-binds via sha256). */
@@ -161,6 +167,11 @@ export async function checkForUpdate(
     currentVersion: string;
     publicKeyPem: string;
     shell: ShellInfo;
+    /** Runner protocol the spawnable (floor) CLI speaks — same ceiling the boot
+     *  gate enforces. Supplying it lets the check flag a bundle the bootstrap
+     *  would refuse (`requiresFullUpdate`) BEFORE anything is staged. Omit to
+     *  skip the gate (legacy callers / tests that don't model the CLI). */
+    cliRunnerProtocol?: number;
     manifestUrlOverride?: string;
   },
   deps: StagerDeps = {},
@@ -204,10 +215,16 @@ export async function checkForUpdate(
   }
 
   const newer = compareSemver(manifest.version, currentVersion) > 0;
+  // Mirror the boot gate at CHECK time: a bundle whose runner protocol outruns
+  // the spawnable CLI would stage fine but be rejected on every launch
+  // (`runner-protocol-skew`) — report it as needing the full installer instead
+  // of letting the flow claim a success that can never take effect.
+  const requiresFullUpdate = exceedsCliRunnerProtocol(manifest, opts.cliRunnerProtocol);
   const result: CheckResult = {
     available: newer,
     latestVersion: manifest.version,
-    compatible: isCompatible(manifest, shell),
+    compatible: isCompatible(manifest, shell) && !requiresFullUpdate,
+    ...(requiresFullUpdate ? { requiresFullUpdate } : {}),
     manifest: newer ? manifest : null,
     // Prefer the discovered release asset URL; fall back to the (signed) one.
     bundleUrl: bundleUrl ?? manifest.bundleUrl,
@@ -244,6 +261,11 @@ export async function downloadAndStage(
      *  the manifest's signed `bundleUrl`. Integrity is bound by `sha256` either
      *  way, so a stale/wrong signed `bundleUrl` doesn't compromise safety. */
     bundleUrl?: string;
+    /** Runner protocol the spawnable (floor) CLI speaks. When supplied, a
+     *  bundle whose signed `runnerProtocol` exceeds it is refused HERE —
+     *  staging it would only produce a "updated, relaunch" that the boot gate
+     *  silently rejects (`runner-protocol-skew`) on every launch. */
+    cliRunnerProtocol?: number;
     onProgress?: (p: Progress) => void;
   },
   deps: StagerDeps = {},
@@ -257,6 +279,14 @@ export async function downloadAndStage(
   }
   if (!isSafeVersion(manifest.version)) {
     throw new Error(`unsafe bundle version: ${manifest.version}`);
+  }
+  // Stage-time mirror of the bootstrap's runner-protocol lockstep gate (checked
+  // AFTER the signature so the stamp is trusted): refuse before any download
+  // rather than activate a bundle every subsequent boot will refuse.
+  if (exceedsCliRunnerProtocol(manifest, opts.cliRunnerProtocol)) {
+    throw new Error(
+      'this update changes the runner protocol and needs the full app installer — a hot-update would be refused at startup',
+    );
   }
   if (!isAllowedUpdateHost(downloadUrl)) {
     throw new Error('update bundle is not hosted on an allowed origin');

--- a/packages/desktop-host/src/desks.test.ts
+++ b/packages/desktop-host/src/desks.test.ts
@@ -98,3 +98,179 @@ describe('DeskStore', () => {
     expect(body).toContain('"name": "X"');
   });
 });
+
+describe('DeskStore v1→v2 migration (sessions)', () => {
+  /** A pre-multi-session desks.json — no sessions, no activeSessionId. */
+  function writeV1(desks: Array<{ id: string; name: string }>, activeId: string | null): void {
+    writeFileSync(
+      storePath,
+      JSON.stringify({
+        version: 1,
+        activeId,
+        desks: desks.map((d) => ({
+          ...d,
+          cwd: `/cwd/${d.id}`,
+          color: '#3b82f6',
+          createdAt: 111,
+        })),
+      }),
+    );
+  }
+
+  it('seeds each v1 desk with one session whose id === the desk id', async () => {
+    writeV1([{ id: 'desk-a', name: 'A' }, { id: 'desk-b', name: 'B' }], 'desk-b');
+    const s = new DeskStore(storePath);
+    const desks = await s.list();
+    expect(desks).toHaveLength(2);
+    for (const desk of desks) {
+      expect(desk.sessions).toHaveLength(1);
+      // THE migration invariant: the seeded session id equals the desk id, so
+      // the runner's sticky ~/.moxxy/sessions/<deskId>.jsonl and the chat
+      // mirror ~/.moxxy/chats/<deskId>.jsonl resume untouched.
+      expect(desk.sessions[0]!.id).toBe(desk.id);
+      expect(desk.sessions[0]!.createdAt).toBe(desk.createdAt);
+      expect(desk.activeSessionId).toBe(desk.id);
+    }
+    expect((await s.getActive())?.id).toBe('desk-b');
+  });
+
+  it('create() seeds the first session with id === desk id', async () => {
+    const s = new DeskStore(storePath);
+    const desk = await s.create({ name: 'Fresh', cwd: '/f' });
+    expect(desk.sessions).toHaveLength(1);
+    expect(desk.sessions[0]!.id).toBe(desk.id);
+    expect(desk.activeSessionId).toBe(desk.id);
+  });
+
+  it('repairs a desk whose activeSessionId points at a deleted session', async () => {
+    writeV1([{ id: 'desk-a', name: 'A' }], 'desk-a');
+    // Hand-corrupt: sessions present but activeSessionId dangling.
+    const doc = JSON.parse(readFileSync(storePath, 'utf8'));
+    doc.desks[0].sessions = [{ id: 's1', name: 'Session 1', createdAt: 1 }];
+    doc.desks[0].activeSessionId = 'gone';
+    writeFileSync(storePath, JSON.stringify(doc));
+    const s = new DeskStore(storePath);
+    const [desk] = await s.list();
+    expect(desk!.activeSessionId).toBe('s1');
+  });
+
+  it('a v2 doc round-trips: mutation persists sessions + version 2', async () => {
+    writeV1([{ id: 'desk-a', name: 'A' }], 'desk-a');
+    const s = new DeskStore(storePath);
+    await s.rename('desk-a', 'Renamed');
+    const body = JSON.parse(readFileSync(storePath, 'utf8'));
+    expect(body.version).toBe(2);
+    expect(body.desks[0].sessions).toHaveLength(1);
+    expect(body.desks[0].activeSessionId).toBe('desk-a');
+  });
+});
+
+describe('DeskStore sessions', () => {
+  async function seeded() {
+    const s = new DeskStore(storePath);
+    const desk = await s.create({ name: 'A', cwd: '/a' });
+    return { s, desk };
+  }
+
+  it('createSession appends an auto-named session without changing the active one', async () => {
+    const { s, desk } = await seeded();
+    const { session } = await s.createSession(desk.id);
+    expect(session.name).toBe('Session 2');
+    const overview = await s.listSessions(desk.id);
+    expect(overview.sessions.map((x) => x.id)).toEqual([desk.id, session.id]);
+    expect(overview.activeSessionId).toBe(desk.id);
+  });
+
+  it('createSession defaults to the active desk and honors an explicit name', async () => {
+    const { s, desk } = await seeded();
+    const { desk: owner, session } = await s.createSession(undefined, '  Research  ');
+    expect(owner.id).toBe(desk.id);
+    expect(session.name).toBe('Research');
+  });
+
+  it('createSession never mints a duplicate auto-name after deletions', async () => {
+    const { s, desk } = await seeded();
+    const { session: s2 } = await s.createSession(desk.id);
+    const { session: s3 } = await s.createSession(desk.id);
+    expect(s3.name).toBe('Session 3');
+    await s.removeSession(s2.id);
+    const { session: s4 } = await s.createSession(desk.id);
+    // 2 sessions left → count+1 = 3 is taken, so bump past it.
+    expect(s4.name).not.toBe(s3.name);
+  });
+
+  it('createSession rejects an unknown desk', async () => {
+    const { s } = await seeded();
+    await expect(s.createSession('nope')).rejects.toThrow(/unknown desk/);
+  });
+
+  it('setActiveSession activates the session AND its desk', async () => {
+    const { s, desk } = await seeded();
+    const other = await s.create({ name: 'B', cwd: '/b' });
+    const { session } = await s.createSession(other.id);
+    const owner = await s.setActiveSession(session.id);
+    expect(owner.id).toBe(other.id);
+    expect(owner.activeSessionId).toBe(session.id);
+    expect((await s.getActive())?.id).toBe(other.id);
+    // The first desk's own active session is untouched.
+    expect((await s.listSessions(desk.id)).activeSessionId).toBe(desk.id);
+  });
+
+  it('setActiveSession rejects unknown ids', async () => {
+    const { s } = await seeded();
+    await expect(s.setActiveSession('nope')).rejects.toThrow(/unknown session/);
+  });
+
+  it('removeSession promotes another session when the active one is removed', async () => {
+    const { s, desk } = await seeded();
+    const { session } = await s.createSession(desk.id);
+    await s.setActiveSession(session.id);
+    const updated = await s.removeSession(session.id);
+    expect(updated!.sessions.map((x) => x.id)).toEqual([desk.id]);
+    expect(updated!.activeSessionId).toBe(desk.id);
+  });
+
+  it('removeSession of the LAST session seeds a fresh replacement (desk keeps >= 1)', async () => {
+    const { s, desk } = await seeded();
+    const updated = await s.removeSession(desk.id);
+    expect(updated!.sessions).toHaveLength(1);
+    const fresh = updated!.sessions[0]!;
+    expect(fresh.id).not.toBe(desk.id);
+    expect(updated!.activeSessionId).toBe(fresh.id);
+  });
+
+  it('removeSession returns null for unknown ids', async () => {
+    const { s } = await seeded();
+    expect(await s.removeSession('nope')).toBeNull();
+  });
+
+  it('renameSession persists; empty names rejected', async () => {
+    const { s, desk } = await seeded();
+    const renamed = await s.renameSession(desk.id, '  Deep dive ');
+    expect(renamed.name).toBe('Deep dive');
+    expect((await s.listSessions(desk.id)).sessions[0]!.name).toBe('Deep dive');
+    await expect(s.renameSession(desk.id, '   ')).rejects.toThrow(/empty/);
+    await expect(s.renameSession('nope', 'x')).rejects.toThrow(/unknown session/);
+  });
+
+  it('deskForSession finds the owning desk', async () => {
+    const { s, desk } = await seeded();
+    const { session } = await s.createSession(desk.id);
+    expect((await s.deskForSession(session.id))?.id).toBe(desk.id);
+    expect(await s.deskForSession('nope')).toBeNull();
+  });
+
+  it('remove() returns the removed desk with its sessions', async () => {
+    const { s, desk } = await seeded();
+    const { session } = await s.createSession(desk.id);
+    const removed = await s.remove(desk.id);
+    expect(removed?.id).toBe(desk.id);
+    expect(removed?.sessions.map((x) => x.id)).toEqual([desk.id, session.id]);
+    expect(await s.remove('nope')).toBeNull();
+  });
+
+  it('listSessions of an unknown desk returns an empty overview', async () => {
+    const { s } = await seeded();
+    expect(await s.listSessions('nope')).toEqual({ sessions: [], activeSessionId: null });
+  });
+});

--- a/packages/desktop-host/src/desks.ts
+++ b/packages/desktop-host/src/desks.ts
@@ -15,10 +15,20 @@ import { homedir } from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { createMutex, writeFileAtomic, type Mutex } from '@moxxy/sdk';
-import type { Desk } from '@moxxy/desktop-ipc-contract';
+import type { Desk, DeskSession, SessionsOverview } from '@moxxy/desktop-ipc-contract';
 
+/**
+ * v2: each desk carries `sessions` (>= 1 of them) + `activeSessionId`.
+ * A v1 doc (or any desk missing/holding a malformed sessions array) is
+ * migrated in memory on load: the desk gets exactly ONE session whose id
+ * equals the desk id — which is precisely the sticky session id the
+ * runner pool used to derive FROM the desk id, so the runner's persisted
+ * log `~/.moxxy/sessions/<deskId>.jsonl` and the chat NDJSON mirror
+ * `~/.moxxy/chats/<deskId>.jsonl` resume untouched. The migrated shape
+ * is persisted on the next mutation (every save writes version 2).
+ */
 interface DeskDoc {
-  version: 1;
+  version: 2;
   activeId: string | null;
   desks: Desk[];
 }
@@ -48,14 +58,17 @@ export class DeskStore {
   async load(): Promise<DeskDoc> {
     try {
       const raw = await readFile(this.path, 'utf8');
-      const parsed = JSON.parse(raw) as DeskDoc;
+      const parsed = JSON.parse(raw) as { activeId?: string | null; desks?: unknown[] };
       // Light-touch validation: bad shape → start fresh rather than
       // throw and stall onboarding.
       if (!Array.isArray(parsed.desks)) return emptyDoc();
       return {
-        version: 1,
+        version: 2,
         activeId: parsed.activeId ?? null,
-        desks: parsed.desks.filter(isValidDesk),
+        // normalizeSessions is the v1→v2 migration (and the repair path
+        // for a hand-edited file): every desk comes out with >= 1 valid
+        // session and an activeSessionId that points at one of them.
+        desks: parsed.desks.filter(isValidDesk).map(normalizeSessions),
       };
     } catch {
       return emptyDoc();
@@ -80,14 +93,21 @@ export class DeskStore {
   async create(input: { name: string; cwd: string; color?: string }): Promise<Desk> {
     return this.mutex.run(async () => {
       const doc = await this.load();
+      const id = randomUUID();
+      const createdAt = Date.now();
       const desk: Desk = {
-        id: randomUUID(),
+        id,
         name: input.name.trim() || 'Unnamed desk',
         cwd: input.cwd,
         color:
           input.color ??
           DEFAULT_COLORS[doc.desks.length % DEFAULT_COLORS.length]!,
-        createdAt: Date.now(),
+        createdAt,
+        // First session id === desk id, matching the migration invariant:
+        // the pool key (and so the runner log + chat mirror filename) for a
+        // fresh desk's default session is the same string it always was.
+        sessions: [{ id, name: DEFAULT_SESSION_NAME, createdAt }],
+        activeSessionId: id,
       };
       doc.desks.push(desk);
       // First desk auto-becomes active.
@@ -97,12 +117,16 @@ export class DeskStore {
     });
   }
 
-  async remove(id: string): Promise<void> {
+  /** Remove a desk. Returns the removed desk (so the caller can tear down
+   *  every one of its session runners) or null when the id was unknown. */
+  async remove(id: string): Promise<Desk | null> {
     return this.mutex.run(async () => {
       const doc = await this.load();
+      const removed = doc.desks.find((d) => d.id === id) ?? null;
       doc.desks = doc.desks.filter((d) => d.id !== id);
       if (doc.activeId === id) doc.activeId = doc.desks[0]?.id ?? null;
       await this.save(doc);
+      return removed;
     });
   }
 
@@ -129,10 +153,124 @@ export class DeskStore {
       return desk;
     });
   }
+
+  // ---- Sessions (multiple conversations per desk) -------------------------
+
+  /** Sessions of one desk (default: the active desk). Unknown/absent desk →
+   *  an empty overview rather than a throw, so the renderer can render a
+   *  bare list while desks are still loading. */
+  async listSessions(deskId?: string): Promise<SessionsOverview> {
+    const doc = await this.load();
+    const desk = this.resolveDesk(doc, deskId);
+    if (!desk) return { sessions: [], activeSessionId: null };
+    return { sessions: desk.sessions, activeSessionId: desk.activeSessionId };
+  }
+
+  /** The desk that owns `sessionId`, or null. */
+  async deskForSession(sessionId: string): Promise<Desk | null> {
+    const doc = await this.load();
+    return doc.desks.find((d) => d.sessions.some((s) => s.id === sessionId)) ?? null;
+  }
+
+  /** Add a session to a desk (default: the active desk). Does NOT change
+   *  the desk's active session — that's `setActiveSession`'s job, mirroring
+   *  how desks.create doesn't auto-activate (beyond the first). */
+  async createSession(
+    deskId?: string,
+    name?: string,
+  ): Promise<{ desk: Desk; session: DeskSession }> {
+    return this.mutex.run(async () => {
+      const doc = await this.load();
+      const desk = this.resolveDesk(doc, deskId);
+      if (!desk) throw new Error(deskId ? `unknown desk: ${deskId}` : 'no active desk');
+      const session: DeskSession = {
+        id: randomUUID(),
+        name: name?.trim() || nextSessionName(desk.sessions),
+        createdAt: Date.now(),
+      };
+      desk.sessions.push(session);
+      await this.save(doc);
+      return { desk, session };
+    });
+  }
+
+  /** Foreground a session: its desk becomes the active desk and the session
+   *  becomes that desk's active session. Returns the owning desk (the caller
+   *  needs its cwd to spawn/foreground the runner). */
+  async setActiveSession(sessionId: string): Promise<Desk> {
+    return this.mutex.run(async () => {
+      const doc = await this.load();
+      const desk = doc.desks.find((d) => d.sessions.some((s) => s.id === sessionId));
+      if (!desk) throw new Error(`unknown session: ${sessionId}`);
+      desk.activeSessionId = sessionId;
+      doc.activeId = desk.id;
+      await this.save(doc);
+      return desk;
+    });
+  }
+
+  /**
+   * Remove a session from its desk. A desk always keeps >= 1 session, so
+   * removing the last one seeds a fresh empty replacement; removing the
+   * ACTIVE session promotes another. Returns the updated owning desk (its
+   * `activeSessionId` is what the caller should spawn/foreground next) or
+   * null when the session id was unknown.
+   */
+  async removeSession(sessionId: string): Promise<Desk | null> {
+    return this.mutex.run(async () => {
+      const doc = await this.load();
+      const desk = doc.desks.find((d) => d.sessions.some((s) => s.id === sessionId));
+      if (!desk) return null;
+      desk.sessions = desk.sessions.filter((s) => s.id !== sessionId);
+      if (desk.sessions.length === 0) {
+        desk.sessions = [
+          { id: randomUUID(), name: DEFAULT_SESSION_NAME, createdAt: Date.now() },
+        ];
+      }
+      if (desk.activeSessionId === sessionId) {
+        desk.activeSessionId = desk.sessions[0]!.id;
+      }
+      await this.save(doc);
+      return desk;
+    });
+  }
+
+  async renameSession(sessionId: string, name: string): Promise<DeskSession> {
+    const trimmed = name.trim();
+    if (!trimmed) throw new Error('name must not be empty');
+    return this.mutex.run(async () => {
+      const doc = await this.load();
+      const session = doc.desks
+        .flatMap((d) => d.sessions)
+        .find((s) => s.id === sessionId);
+      if (!session) throw new Error(`unknown session: ${sessionId}`);
+      session.name = trimmed;
+      await this.save(doc);
+      return session;
+    });
+  }
+
+  /** Desk by id, or the active desk when no id was given. */
+  private resolveDesk(doc: DeskDoc, deskId?: string): Desk | null {
+    const id = deskId ?? doc.activeId;
+    if (!id) return null;
+    return doc.desks.find((d) => d.id === id) ?? null;
+  }
+}
+
+const DEFAULT_SESSION_NAME = 'Session 1';
+
+/** "Session N" with N picked past every existing auto-generated name, so
+ *  create → delete → create never mints a duplicate label. */
+function nextSessionName(sessions: ReadonlyArray<DeskSession>): string {
+  let n = sessions.length + 1;
+  const taken = new Set(sessions.map((s) => s.name));
+  while (taken.has(`Session ${n}`)) n += 1;
+  return `Session ${n}`;
 }
 
 function emptyDoc(): DeskDoc {
-  return { version: 1, activeId: null, desks: [] };
+  return { version: 2, activeId: null, desks: [] };
 }
 
 function isValidDesk(value: unknown): value is Desk {
@@ -145,4 +283,31 @@ function isValidDesk(value: unknown): value is Desk {
     typeof v.color === 'string' &&
     typeof v.createdAt === 'number'
   );
+}
+
+function isValidSession(value: unknown): value is DeskSession {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === 'string' && typeof v.name === 'string' && typeof v.createdAt === 'number'
+  );
+}
+
+/**
+ * The v1→v2 migration + self-repair: guarantee `sessions` holds >= 1 valid
+ * session and `activeSessionId` points at one of them. A v1 desk (no
+ * sessions at all) is seeded with one session whose id === the desk id —
+ * exactly the sticky session id the pool used to derive from the desk id,
+ * so existing runner logs and chat mirrors keep resuming.
+ */
+function normalizeSessions(desk: Desk): Desk {
+  const raw = Array.isArray(desk.sessions) ? desk.sessions : [];
+  let sessions = raw.filter(isValidSession);
+  if (sessions.length === 0) {
+    sessions = [{ id: desk.id, name: DEFAULT_SESSION_NAME, createdAt: desk.createdAt }];
+  }
+  const activeSessionId = sessions.some((s) => s.id === desk.activeSessionId)
+    ? desk.activeSessionId
+    : sessions[0]!.id;
+  return { ...desk, sessions, activeSessionId };
 }

--- a/packages/desktop-host/src/ipc.ts
+++ b/packages/desktop-host/src/ipc.ts
@@ -39,6 +39,7 @@ import { registerAskHandlers } from './ipc/ask';
 import { registerConnectionHandlers } from './ipc/connection';
 import { registerOnboardingHandlers } from './ipc/onboarding';
 import { registerSessionHandlers } from './ipc/session';
+import { registerSessionsHandlers } from './ipc/sessions';
 import { registerWorkspaceFsHandlers } from './ipc/workspace-fs';
 import { registerDesksHandlers } from './ipc/desks';
 import { registerWorkflowsHandlers } from './ipc/workflows';
@@ -74,6 +75,7 @@ export function registerIpcHandlers(
     registerConnectionHandlers(pool);
     registerOnboardingHandlers(pool);
     registerSessionHandlers(pool);
+    registerSessionsHandlers(pool, desks);
     registerWorkspaceFsHandlers(desks);
     registerDesksHandlers(pool, desks);
     registerWorkflowsHandlers(pool);

--- a/packages/desktop-host/src/ipc/desks.ts
+++ b/packages/desktop-host/src/ipc/desks.ts
@@ -24,17 +24,25 @@ export function registerDesksHandlers(pool: RunnerPool, desks: DeskStore): void 
   });
   handle('desks.create', async ({ name, cwd }) => desks.create({ name, cwd }));
   handle('desks.remove', async ({ id }) => {
-    await desks.remove(id);
+    // The pool is keyed by SESSION id (a desk can hold several), so tear down
+    // every one of the removed desk's session runners — not just one entry.
+    const removed = await desks.remove(id);
+    for (const session of removed?.sessions ?? []) {
+      await pool.remove(session.id);
+    }
+    // Defensive: also drop a pool entry keyed by the bare desk id (the
+    // pre-multi-session key; normally identical to the first session's id).
     await pool.remove(id);
     const active = await desks.getActive();
-    if (active) await pool.getOrCreate(active.id, active.cwd);
+    if (active) await pool.getOrCreate(active.activeSessionId, active.cwd);
   });
   handle('desks.setActive', async ({ id }) => {
     await desks.setActive(id);
     const active = await desks.getActive();
     if (active) {
-      await pool.getOrCreate(active.id, active.cwd);
-      pool.setActive(active.id);
+      // Foreground the desk's ACTIVE SESSION — the pool key is a session id.
+      await pool.getOrCreate(active.activeSessionId, active.cwd);
+      pool.setActive(active.activeSessionId);
     }
   });
   handle('desks.rename', async ({ id, name }) => desks.rename(id, name));

--- a/packages/desktop-host/src/ipc/prefs.test.ts
+++ b/packages/desktop-host/src/ipc/prefs.test.ts
@@ -1,0 +1,90 @@
+/**
+ * prefs IPC handler tests:
+ *   1. prefs.update merges through the store and returns the result.
+ *   2. A `theme` patch runs the nativeTheme sync WITHOUT throwing in a
+ *      non-electron (plain node vitest) environment — the guard that keeps
+ *      these handlers testable and WS-bridge-safe.
+ *   3. prefs.read delegates to the store.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DesktopPrefs } from '@moxxy/desktop-ipc-contract';
+import { setActiveBus } from './shared';
+import { registerPrefsHandlers } from './prefs';
+
+const BASE: DesktopPrefs = {
+  onboardingComplete: true,
+  clerkUserId: null,
+  clerkDisplayName: null,
+  signedInAt: null,
+  mobileGatewayEnabled: false,
+  theme: 'system',
+  version: 1,
+};
+
+vi.mock('../prefs', () => {
+  let current: DesktopPrefs = {
+    onboardingComplete: true,
+    clerkUserId: null,
+    clerkDisplayName: null,
+    signedInAt: null,
+    mobileGatewayEnabled: false,
+    theme: 'system',
+    version: 1,
+  };
+  return {
+    readPrefs: vi.fn(() => current),
+    updatePrefs: vi.fn((patch: Partial<DesktopPrefs>) => {
+      current = { ...current, ...patch, version: 1 as const };
+      return Promise.resolve(current);
+    }),
+  };
+});
+
+type Handler = (...args: unknown[]) => Promise<unknown>;
+
+function captureHandlers(): Map<string, Handler> {
+  const handlers = new Map<string, Handler>();
+  setActiveBus({
+    handle: (channel: string, fn: Handler) => {
+      handlers.set(channel, fn);
+    },
+  } as never);
+  registerPrefsHandlers();
+  return handlers;
+}
+
+describe('prefs IPC handlers', () => {
+  let handlers: Map<string, Handler>;
+
+  beforeEach(() => {
+    handlers = captureHandlers();
+  });
+
+  it('registers both prefs commands', () => {
+    expect(handlers.has('prefs.read')).toBe(true);
+    expect(handlers.has('prefs.update')).toBe(true);
+  });
+
+  it('prefs.read returns the stored prefs (theme defaults to system)', async () => {
+    const prefs = (await handlers.get('prefs.read')!()) as DesktopPrefs;
+    expect(prefs).toEqual(BASE);
+  });
+
+  it('prefs.update merges and returns the patched prefs', async () => {
+    const next = (await handlers.get('prefs.update')!({
+      mobileGatewayEnabled: true,
+    })) as DesktopPrefs;
+    expect(next.mobileGatewayEnabled).toBe(true);
+    expect(next.theme).toBe('system');
+  });
+
+  it('a theme patch persists and survives the nativeTheme sync outside electron', async () => {
+    // In plain-node vitest the `electron` module is either missing or exports
+    // a binary-path string with no `nativeTheme` — the handler must not throw.
+    const next = (await handlers.get('prefs.update')!({ theme: 'dark' })) as DesktopPrefs;
+    expect(next.theme).toBe('dark');
+    const read = (await handlers.get('prefs.read')!()) as DesktopPrefs;
+    expect(read.theme).toBe('dark');
+  });
+});

--- a/packages/desktop-host/src/ipc/prefs.ts
+++ b/packages/desktop-host/src/ipc/prefs.ts
@@ -7,7 +7,25 @@
  * file isn't touched until the renderer asks.
  */
 
+import type { ThemePreference } from '@moxxy/desktop-ipc-contract';
 import { handle } from './shared';
+
+const THEME_VALUES: ReadonlyArray<ThemePreference> = ['light', 'dark', 'system'];
+
+/** Mirror the persisted theme pref into Electron's `nativeTheme.themeSource`
+ *  so window chrome AND the renderer's `prefers-color-scheme` track the
+ *  user's choice (`system` = follow the OS). No-op outside Electron — the
+ *  handlers also run under plain-node vitest, where the `electron` package
+ *  resolves to a binary-path string with no `nativeTheme` export. */
+async function syncNativeTheme(theme: ThemePreference): Promise<void> {
+  if (!THEME_VALUES.includes(theme)) return;
+  try {
+    const electron = (await import('electron')) as Partial<typeof import('electron')>;
+    if (electron.nativeTheme) electron.nativeTheme.themeSource = theme;
+  } catch {
+    /* non-electron host (tests) */
+  }
+}
 
 export function registerPrefsHandlers(): void {
   // Desktop preferences -----------------------------------------------------
@@ -17,6 +35,10 @@ export function registerPrefsHandlers(): void {
   });
   handle('prefs.update', async (patch) => {
     const { updatePrefs } = await import('../prefs');
-    return updatePrefs(patch);
+    const next = await updatePrefs(patch);
+    if (patch && typeof patch === 'object' && 'theme' in patch) {
+      await syncNativeTheme(next.theme);
+    }
+    return next;
   });
 }

--- a/packages/desktop-host/src/ipc/sessions.test.ts
+++ b/packages/desktop-host/src/ipc/sessions.test.ts
@@ -1,0 +1,188 @@
+/**
+ * sessions.* handler tests — the registrar is wired onto a fake
+ * CommandBus (via setActiveBus, same seam every transport uses) with a
+ * recording RunnerPool stand-in and a REAL DeskStore on a tmp file, so
+ * the tests exercise the actual persistence + pool-keying contract:
+ * the pool is driven with SESSION ids, removal erases the session's
+ * on-disk runner log + chat mirror, and a desk never drops below one
+ * session.
+ */
+
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// shared.ts (the `handle` choke point) transitively touches electron;
+// importing it must not require the GUI binary. Same stub as shared.test.ts.
+vi.mock('electron', () => ({ ipcMain: { handle: () => undefined } }));
+
+// The handlers delete the runner's persisted session log via @moxxy/core —
+// record the calls instead of touching ~/.moxxy.
+const deleteSessionMock = vi.fn(async (_id: string) => {});
+vi.mock('@moxxy/core', () => ({
+  deleteSession: (id: string) => deleteSessionMock(id),
+}));
+
+// Chat NDJSON mirror removal — record instead of touching the disk.
+const clearLogMock = vi.fn(async (_id: string) => {});
+vi.mock('../chat-log', () => ({
+  clearLog: (id: string) => clearLogMock(id),
+}));
+
+import type { CommandBus } from '@moxxy/desktop-ipc-contract/bus';
+import type { IpcCommandName } from '@moxxy/desktop-ipc-contract';
+import { DeskStore } from '../desks';
+import type { RunnerPool } from '../runner-pool';
+import { setActiveBus } from './shared';
+import { registerSessionsHandlers } from './sessions';
+
+type Handler = (...args: unknown[]) => Promise<unknown>;
+
+function fakeBus(): { bus: CommandBus; handlers: Map<string, Handler> } {
+  const handlers = new Map<string, Handler>();
+  const bus = {
+    handle: (channel: IpcCommandName, fn: Handler) => {
+      handlers.set(channel, fn);
+    },
+  } as unknown as CommandBus;
+  return { bus, handlers };
+}
+
+interface PoolCall {
+  readonly op: 'getOrCreate' | 'setActive' | 'remove';
+  readonly id: string;
+  readonly cwd?: string | null;
+}
+
+function fakePool(): { pool: RunnerPool; calls: PoolCall[] } {
+  const calls: PoolCall[] = [];
+  const known = new Set<string>();
+  const pool = {
+    getOrCreate: async (id: string, cwd: string | null) => {
+      calls.push({ op: 'getOrCreate', id, cwd });
+      known.add(id);
+      return {} as never;
+    },
+    setActive: (id: string) => {
+      calls.push({ op: 'setActive', id });
+      if (!known.has(id)) throw new Error(`RunnerPool.setActive: unknown workspace ${id}`);
+    },
+    remove: async (id: string) => {
+      calls.push({ op: 'remove', id });
+      known.delete(id);
+    },
+    activeWorkspaceId: () => null,
+  } as unknown as RunnerPool;
+  return { pool, calls };
+}
+
+let desks: DeskStore;
+let handlers: Map<string, Handler>;
+let calls: PoolCall[];
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  const tmp = mkdtempSync(path.join(os.tmpdir(), 'sessions-ipc-'));
+  desks = new DeskStore(path.join(tmp, 'desks.json'));
+  const { bus, handlers: h } = fakeBus();
+  const { pool, calls: c } = fakePool();
+  handlers = h;
+  calls = c;
+  setActiveBus(bus);
+  registerSessionsHandlers(pool, desks);
+});
+
+const invoke = (channel: string, args?: unknown): Promise<unknown> =>
+  handlers.get(channel)!(args);
+
+describe('sessions.* handlers', () => {
+  it('registers the full command set', () => {
+    expect([...handlers.keys()].sort()).toEqual([
+      'sessions.create',
+      'sessions.list',
+      'sessions.remove',
+      'sessions.rename',
+      'sessions.setActive',
+    ]);
+  });
+
+  it('list defaults to the active desk', async () => {
+    const desk = await desks.create({ name: 'A', cwd: '/a' });
+    const overview = (await invoke('sessions.list')) as {
+      sessions: Array<{ id: string }>;
+      activeSessionId: string | null;
+    };
+    expect(overview.sessions.map((s) => s.id)).toEqual([desk.id]);
+    expect(overview.activeSessionId).toBe(desk.id);
+  });
+
+  it('create persists under the desk and spawns the session runner with the desk cwd', async () => {
+    const desk = await desks.create({ name: 'A', cwd: '/a' });
+    const session = (await invoke('sessions.create', { deskId: desk.id })) as { id: string };
+    expect(calls).toContainEqual({ op: 'getOrCreate', id: session.id, cwd: '/a' });
+    const overview = await desks.listSessions(desk.id);
+    expect(overview.sessions.map((s) => s.id)).toContain(session.id);
+    // Not auto-foregrounded.
+    expect(calls.find((c) => c.op === 'setActive')).toBeUndefined();
+  });
+
+  it('setActive persists, ensures a runner, and foregrounds the SESSION id', async () => {
+    const desk = await desks.create({ name: 'A', cwd: '/a' });
+    const session = (await invoke('sessions.create', { deskId: desk.id })) as { id: string };
+    await invoke('sessions.setActive', { id: session.id });
+    expect((await desks.listSessions(desk.id)).activeSessionId).toBe(session.id);
+    expect(calls).toContainEqual({ op: 'getOrCreate', id: session.id, cwd: '/a' });
+    expect(calls).toContainEqual({ op: 'setActive', id: session.id });
+  });
+
+  it('remove tears down the runner and erases BOTH on-disk logs', async () => {
+    const desk = await desks.create({ name: 'A', cwd: '/a' });
+    const session = (await invoke('sessions.create', { deskId: desk.id })) as { id: string };
+    await invoke('sessions.remove', { id: session.id });
+    expect(calls).toContainEqual({ op: 'remove', id: session.id });
+    expect(deleteSessionMock).toHaveBeenCalledWith(session.id);
+    expect(clearLogMock).toHaveBeenCalledWith(session.id);
+    expect((await desks.listSessions(desk.id)).sessions.map((s) => s.id)).toEqual([desk.id]);
+  });
+
+  it('removing the active desk\'s foregrounded session promotes its replacement', async () => {
+    const desk = await desks.create({ name: 'A', cwd: '/a' });
+    // Remove the desk's only session: a fresh one is seeded + foregrounded.
+    await invoke('sessions.remove', { id: desk.id });
+    const overview = await desks.listSessions(desk.id);
+    expect(overview.sessions).toHaveLength(1);
+    const fresh = overview.sessions[0]!;
+    expect(fresh.id).not.toBe(desk.id);
+    expect(calls).toContainEqual({ op: 'getOrCreate', id: fresh.id, cwd: '/a' });
+    expect(calls).toContainEqual({ op: 'setActive', id: fresh.id });
+  });
+
+  it('removing a BACKGROUND desk\'s session never re-foregrounds that desk', async () => {
+    const a = await desks.create({ name: 'A', cwd: '/a' });
+    const b = await desks.create({ name: 'B', cwd: '/b' });
+    const session = (await invoke('sessions.create', { deskId: b.id })) as { id: string };
+    await desks.setActive(a.id);
+    calls.length = 0;
+    await invoke('sessions.remove', { id: session.id });
+    expect(calls.find((c) => c.op === 'setActive')).toBeUndefined();
+    expect(calls.find((c) => c.op === 'getOrCreate')).toBeUndefined();
+  });
+
+  it('remove of an unknown session still best-effort clears its logs', async () => {
+    await desks.create({ name: 'A', cwd: '/a' });
+    await invoke('sessions.remove', { id: 'ghost' });
+    expect(deleteSessionMock).toHaveBeenCalledWith('ghost');
+    expect(clearLogMock).toHaveBeenCalledWith('ghost');
+    expect(calls.find((c) => c.op === 'setActive')).toBeUndefined();
+  });
+
+  it('rename round-trips through the store', async () => {
+    const desk = await desks.create({ name: 'A', cwd: '/a' });
+    const renamed = (await invoke('sessions.rename', { id: desk.id, name: 'Deep dive' })) as {
+      name: string;
+    };
+    expect(renamed.name).toBe('Deep dive');
+    expect((await desks.listSessions(desk.id)).sessions[0]!.name).toBe('Deep dive');
+  });
+});

--- a/packages/desktop-host/src/ipc/sessions.ts
+++ b/packages/desktop-host/src/ipc/sessions.ts
@@ -1,0 +1,72 @@
+/**
+ * Multi-session commands — multiple conversations per desk.
+ *
+ * The {@link DeskStore} owns the persisted session registry (which
+ * sessions exist under which desk + which is active); these handlers
+ * keep the {@link RunnerPool} in step. The pool is keyed by SESSION id:
+ * every session runs its own supervised `moxxy serve` whose sticky
+ * MOXXY_SESSION_ID is the session id, so each conversation persists to
+ * its own `~/.moxxy/sessions/<sessionId>.jsonl` and streams events
+ * tagged with its own workspace-routing key. Switching sessions never
+ * tears the others down — same model as switching desks.
+ *
+ * `session.newSession` (the `/new` reset of the CURRENT session) is
+ * unchanged and lives in ./session.ts; `sessions.create` ADDS a
+ * conversation instead.
+ */
+
+import { deleteSession } from '@moxxy/core';
+
+import type { RunnerPool } from '../runner-pool';
+import type { DeskStore } from '../desks';
+import { clearLog } from '../chat-log';
+import { handle } from './shared';
+
+export function registerSessionsHandlers(pool: RunnerPool, desks: DeskStore): void {
+  // ---- Sessions (per-desk conversations) -----------------------------------
+
+  handle('sessions.list', async (args) => desks.listSessions(args?.deskId));
+
+  handle('sessions.create', async (args) => {
+    const { desk, session } = await desks.createSession(args?.deskId, args?.name);
+    // Spawn the session's runner eagerly so a follow-up setActive (the usual
+    // next call from the UI) foregrounds an already-connecting supervisor.
+    await pool.getOrCreate(session.id, desk.cwd);
+    return session;
+  });
+
+  handle('sessions.setActive', async ({ id }) => {
+    // Persist first (also makes the owning desk the active desk), then make
+    // sure a runner exists before pointing the pool at it — pool.setActive
+    // throws on unknown ids.
+    const desk = await desks.setActiveSession(id);
+    await pool.getOrCreate(id, desk.cwd);
+    pool.setActive(id);
+  });
+
+  handle('sessions.remove', async ({ id }) => {
+    // Drop it from the registry first (this also seeds a fresh replacement
+    // when it was the desk's last session), then tear down + erase its
+    // on-disk state: the runner's sticky session log (else the conversation
+    // would resurrect if the id were ever reused) and the chat NDJSON mirror.
+    const desk = await desks.removeSession(id);
+    await pool.remove(id);
+    try {
+      await deleteSession(id);
+    } catch {
+      // Best-effort: a missing file just means there was nothing to clear.
+    }
+    await clearLog(id);
+    if (!desk) return;
+    // If the removed session belonged to the ACTIVE desk, foreground the
+    // desk's (possibly freshly-seeded) active session so the user never
+    // lands on a dead pool id — pool.remove promotes an arbitrary entry.
+    const active = await desks.getActive();
+    if (active && active.id === desk.id) {
+      await pool.getOrCreate(desk.activeSessionId, desk.cwd);
+      pool.setActive(desk.activeSessionId);
+    }
+  });
+
+  handle('sessions.rename', async ({ id, name }) => desks.renameSession(id, name));
+}

--- a/packages/desktop-host/src/ipc/update.ts
+++ b/packages/desktop-host/src/ipc/update.ts
@@ -35,6 +35,16 @@ export interface UpdateConfig {
   publicKeyPem: string;
   /** Manifest URL override (dev/test only). Defaults to the GitHub latest release. */
   manifestUrl?: string;
+  /**
+   * Runner protocol version the floor's pinned CLI speaks — the same ceiling
+   * the bootstrap's boot gate enforces (`FLOOR_RUNNER_PROTOCOL`, see
+   * `apps/desktop/electron/main/bootstrap.ts`). Threading it here lets the
+   * check/stage flow refuse a bundle the boot gate would silently reject
+   * (`runner-protocol-skew`) and tell the user a full app update is needed,
+   * instead of claiming "updated — relaunch" that never takes effect. Omit to
+   * skip the gate.
+   */
+  cliRunnerProtocol?: number;
 }
 
 /** The GitHub repo whose `desktop-v*` releases the updater pulls from. */
@@ -53,14 +63,21 @@ function messageOf(e: unknown): string {
 }
 
 export function registerUpdateHandlers(config: UpdateConfig): void {
-  const { publicKeyPem } = config;
+  const { publicKeyPem, cliRunnerProtocol } = config;
   // A manifest-URL override is honored ONLY in dev/test (never in a packaged
   // build) so a shipped app can't be pointed at an attacker origin; in prod the
   // updater discovers the latest desktop release from GH_REPO's API.
   const manifestUrlOverride = app.isPackaged ? undefined : config.manifestUrl;
   const enabled = (): boolean => !!publicKeyPem && app.isPackaged;
   const check = (currentVersion: string): ReturnType<typeof checkForUpdate> =>
-    checkForUpdate({ repo: GH_REPO, currentVersion, publicKeyPem, shell: shellInfo(), manifestUrlOverride });
+    checkForUpdate({
+      repo: GH_REPO,
+      currentVersion,
+      publicKeyPem,
+      shell: shellInfo(),
+      cliRunnerProtocol,
+      manifestUrlOverride,
+    });
 
   handle('app.updateInfo', async () => ({
     version: runningVersion(),
@@ -87,6 +104,7 @@ export function registerUpdateHandlers(config: UpdateConfig): void {
       currentVersion,
       latestVersion: res.latestVersion,
       compatible: res.compatible,
+      ...(res.requiresFullUpdate ? { requiresFullUpdate: true } : {}),
       ...(res.notes ? { notes: res.notes } : {}),
       ...(res.releaseUrl ? { releaseUrl: res.releaseUrl } : {}),
       ...(res.error ? { error: res.error } : {}),
@@ -104,6 +122,18 @@ export function registerUpdateHandlers(config: UpdateConfig): void {
     if (!res.available || !res.manifest) {
       return { ok: false, version: null, error: res.error ?? 'No update available.' };
     }
+    if (res.requiresFullUpdate) {
+      // The bundle's runner protocol outruns the CLI this install can spawn:
+      // staging it would only produce an "updated — relaunch" that the boot
+      // gate rejects (`runner-protocol-skew`) on every launch. Distinct status
+      // so the UI sends the user to the full installer (Tier-2) instead.
+      return {
+        ok: false,
+        version: res.latestVersion,
+        requiresFullUpdate: true,
+        error: 'This update changes the bundled runner and needs the full app installer — it cannot be applied as a hot-update.',
+      };
+    }
     if (!res.compatible) {
       return {
         ok: false,
@@ -117,6 +147,8 @@ export function registerUpdateHandlers(config: UpdateConfig): void {
         userDataDir: app.getPath('userData'),
         manifest: res.manifest,
         publicKeyPem,
+        // Belt-and-braces: the stager re-checks the runner-protocol gate itself.
+        ...(typeof cliRunnerProtocol === 'number' ? { cliRunnerProtocol } : {}),
         ...(res.bundleUrl ? { bundleUrl: res.bundleUrl } : {}),
         onProgress: (p) => {
           if (target) sendEvent(target, 'app.update.progress', p);

--- a/packages/desktop-host/src/ipc/workspace-fs.ts
+++ b/packages/desktop-host/src/ipc/workspace-fs.ts
@@ -17,9 +17,14 @@ export function registerWorkspaceFsHandlers(desks: DeskStore): void {
   handle('workspace.listDir', async ({ workspaceId, path: relPath }) => {
     const { listDir } = await import('../workspace-fs');
     // Look up the cwd by the workspace id so background workspaces
-    // can be browsed too; fall back to the active desk.
+    // can be browsed too; fall back to the active desk. The routing id is
+    // a SESSION id (the pool key), so match a desk by id OR by owning the
+    // session — first sessions share their desk's id, so both arms hit.
     const all = await desks.list();
-    const desk = all.find((d) => d.id === workspaceId) ?? (await desks.getActive());
+    const desk =
+      all.find(
+        (d) => d.id === workspaceId || d.sessions.some((s) => s.id === workspaceId),
+      ) ?? (await desks.getActive());
     if (!desk) {
       return { cwd: process.cwd(), path: '.', entries: [] };
     }

--- a/packages/desktop-host/src/prefs.ts
+++ b/packages/desktop-host/src/prefs.ts
@@ -21,6 +21,7 @@ const DEFAULTS: DesktopPrefs = {
   clerkDisplayName: null,
   signedInAt: null,
   mobileGatewayEnabled: false,
+  theme: 'system',
   version: 1,
 };
 

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -326,17 +326,40 @@ export interface SkillFile {
 
 // ---------- Desks ---------------------------------------------------------
 
+/** One conversation under a desk. Each session is backed by its own
+ *  runner process (the pool keys supervisors by session id) with its
+ *  own sticky runner log (`~/.moxxy/sessions/<id>.jsonl`) and chat
+ *  NDJSON mirror — switching sessions never tears the others down. */
+export interface DeskSession {
+  id: string;
+  name: string;
+  createdAt: number;
+}
+
 export interface Desk {
   id: string;
   name: string;
   cwd: string;
   color: string;
   createdAt: number;
+  /** Every conversation under this desk. A desk always has >= 1 session;
+   *  the default first session's id equals the desk id (the v1 migration
+   *  invariant that keeps pre-multi-session runner logs + chat mirrors
+   *  resuming untouched). */
+  sessions: DeskSession[];
+  /** The session the desk foregrounds when it becomes active. */
+  activeSessionId: string;
 }
 
 export interface DesksOverview {
   desks: Desk[];
   activeId: string | null;
+}
+
+/** `sessions.list` result — one desk's sessions + which one is active. */
+export interface SessionsOverview {
+  sessions: DeskSession[];
+  activeSessionId: string | null;
 }
 
 // ---------- Chat -----------------------------------------------------------
@@ -585,6 +608,25 @@ export interface IpcCommands {
   /** Open a native folder picker; resolves to the absolute path or null
    *  if the user cancelled. */
   'desks.pickFolder': () => Promise<string | null>;
+
+  // ---- Sessions (multiple conversations per desk) ------------------------
+  /** List a desk's sessions (defaults to the active desk). */
+  'sessions.list': (args?: { deskId?: string }) => Promise<SessionsOverview>;
+  /** Create a NEW session under a desk (defaults to the active desk) and
+   *  spawn its runner. Unlike `session.newSession` (which destructively
+   *  resets the CURRENT session in place), this adds another concurrent
+   *  conversation. Name defaults to "Session N". Does not change the
+   *  active session — call `sessions.setActive` to foreground it. */
+  'sessions.create': (args?: { deskId?: string; name?: string }) => Promise<DeskSession>;
+  /** Foreground a session: persists it as its desk's active session (and
+   *  that desk as the active desk), spawns its runner if needed, and
+   *  points the pool at it. */
+  'sessions.setActive': (args: { id: string }) => Promise<void>;
+  /** Delete a session: stop its runner, delete its persisted runner log
+   *  and chat transcript. A desk always keeps >= 1 session — removing the
+   *  last one seeds a fresh empty session in its place. */
+  'sessions.remove': (args: { id: string }) => Promise<void>;
+  'sessions.rename': (args: { id: string; name: string }) => Promise<DeskSession>;
 
   /** Returns the runner's SessionInfo snapshot for the workspace.
    *  Defaults to the active workspace. */
@@ -851,6 +893,17 @@ export const REMOTE_ALLOWED_COMMANDS: ReadonlySet<IpcCommandName> = new Set<IpcC
   'session.setMode',
   'session.newSession',
   'session.runCommand',
+  // Multi-session conversations: list/create/switch/rename are conversation-
+  // scoped — the same trust class as `session.newSession` (already allowed),
+  // and what a paired phone needs to mirror the desktop's session list.
+  // `sessions.remove` is deliberately NOT here: it deletes on-disk state
+  // (the runner's session JSONL + the chat NDJSON transcript), a destructive
+  // host mutation in the same class as `desks.remove`, which is also
+  // host-only.
+  'sessions.list',
+  'sessions.create',
+  'sessions.setActive',
+  'sessions.rename',
   // Voice input (capability-probed; transcribe fails coded without a transcriber).
   'session.hasTranscriber',
   'session.transcribe',

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -208,6 +208,9 @@ export interface NodeProbe {
 
 // ---------- Desktop preferences (first-run + auth state) -------------------
 
+/** The user's color-scheme choice. `system` follows the OS (the default). */
+export type ThemePreference = 'light' | 'dark' | 'system';
+
 export interface DesktopPrefs {
   onboardingComplete: boolean;
   clerkUserId: string | null;
@@ -218,6 +221,11 @@ export interface DesktopPrefs {
    *  survives a restart. Defaults to false (OFF) — exposing the host on the LAN
    *  is always an explicit opt-in. */
   mobileGatewayEnabled: boolean;
+  /** Color scheme. The renderer's useTheme() controller maps it to
+   *  `data-theme="dark"` on <html>; the main process mirrors it into
+   *  `nativeTheme.themeSource` so window chrome / prefers-color-scheme agree.
+   *  Defaults to `system`. */
+  theme: ThemePreference;
   version: 1;
 }
 
@@ -410,6 +418,10 @@ export interface AppUpdateCheck {
   latestVersion: string | null;
   /** False ⇒ the update needs a newer shell (a Tier-2 / installer update). */
   compatible: boolean;
+  /** True ⇒ the published bundle's runner protocol outruns the CLI this
+   *  install can spawn: a hot-update would be staged but refused at every boot
+   *  (`runner-protocol-skew`), so the update needs the full app installer. */
+  requiresFullUpdate?: boolean;
   notes?: string;
   releaseUrl?: string;
   /** Set when the check itself failed (offline, not configured, …). */
@@ -558,8 +570,15 @@ export interface IpcCommands {
    *  the writable userData copy, streaming `app.update.progress`. On success
    *  the new bundle activates on the next launch (the UI offers a relaunch).
    *  The update SOURCE is resolved entirely main-side — the renderer passes no
-   *  URL. */
-  'app.updateDashboard': () => Promise<{ ok: boolean; version: string | null; error?: string }>;
+   *  URL. `requiresFullUpdate` ⇒ the bundle was deliberately NOT staged: its
+   *  runner protocol outruns the spawnable CLI, so only the full app installer
+   *  (Tier-2) can deliver it. */
+  'app.updateDashboard': () => Promise<{
+    ok: boolean;
+    version: string | null;
+    error?: string;
+    requiresFullUpdate?: boolean;
+  }>;
   /** Relaunch the app so a freshly-installed dashboard bundle takes effect. */
   'app.relaunch': () => Promise<void>;
   /** Renderer → main heartbeat: the React tree mounted past the splash. Clears

--- a/packages/desktop-ipc-contract/src/validation.test.ts
+++ b/packages/desktop-ipc-contract/src/validation.test.ts
@@ -77,6 +77,31 @@ describe('IPC payload validation', () => {
     ).toThrow();
   });
 
+  it('bounds sessions.create / rename names like desks.create / rename', () => {
+    expect(() => validateIpcInput('sessions.create', undefined)).not.toThrow();
+    expect(() => validateIpcInput('sessions.create', {})).not.toThrow();
+    expect(() =>
+      validateIpcInput('sessions.create', { deskId: 'd1', name: 'Research' }),
+    ).not.toThrow();
+    expect(() => validateIpcInput('sessions.create', { name: '' })).toThrow();
+    expect(() => validateIpcInput('sessions.create', { name: 'x'.repeat(201) })).toThrow();
+    expect(() =>
+      validateIpcInput('sessions.rename', { id: 's1', name: 'New name' }),
+    ).not.toThrow();
+    expect(() => validateIpcInput('sessions.rename', { id: 's1', name: '' })).toThrow();
+    expect(() =>
+      validateIpcInput('sessions.rename', { id: 's1', name: 'x'.repeat(201) }),
+    ).toThrow();
+  });
+
+  it('requires bounded ids for sessions.setActive / remove', () => {
+    expect(() => validateIpcInput('sessions.setActive', { id: 's1' })).not.toThrow();
+    expect(() => validateIpcInput('sessions.setActive', { id: '' })).toThrow();
+    expect(() => validateIpcInput('sessions.setActive', {})).toThrow();
+    expect(() => validateIpcInput('sessions.remove', { id: 's1' })).not.toThrow();
+    expect(() => validateIpcInput('sessions.remove', { id: 'x'.repeat(257) })).toThrow();
+  });
+
   it('requires a boolean for setAutoApprove', () => {
     expect(() =>
       validateIpcInput('session.setAutoApprove', { workspaceId: 'ws', enabled: true }),

--- a/packages/desktop-ipc-contract/src/validation.test.ts
+++ b/packages/desktop-ipc-contract/src/validation.test.ts
@@ -132,6 +132,14 @@ describe('IPC payload validation', () => {
     expect(() => validateIpcInput('prefs.update', { mobileGatewayEnabled: 'x' })).toThrow();
   });
 
+  it('whitelists theme in prefs.update to the three known values', () => {
+    expect(() => validateIpcInput('prefs.update', { theme: 'light' })).not.toThrow();
+    expect(() => validateIpcInput('prefs.update', { theme: 'dark' })).not.toThrow();
+    expect(() => validateIpcInput('prefs.update', { theme: 'system' })).not.toThrow();
+    expect(() => validateIpcInput('prefs.update', { theme: 'hotdog' })).toThrow();
+    expect(() => validateIpcInput('prefs.update', { theme: true })).toThrow();
+  });
+
   it('is a no-op for commands without a schema', () => {
     expect(() => validateIpcInput('desks.list', undefined)).not.toThrow();
     expect(() => validateIpcInput('connection.snapshotAll', undefined)).not.toThrow();

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -175,6 +175,22 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
     id: z.string().min(1).max(256),
     name: z.string().min(1).max(200),
   }),
+  // Sessions: create/rename persist the name into the desks JSON (bound it
+  // like desks.create/rename); setActive spawns a runner and remove deletes
+  // the session's on-disk logs, so their ids are bounded too. These commands
+  // are also served to remote (WS) clients, so the bounds are load-bearing.
+  'sessions.create': z
+    .object({
+      deskId: z.string().min(1).max(256).optional(),
+      name: z.string().min(1).max(200).optional(),
+    })
+    .optional(),
+  'sessions.setActive': z.object({ id: z.string().min(1).max(256) }),
+  'sessions.remove': z.object({ id: z.string().min(1).max(256) }),
+  'sessions.rename': z.object({
+    id: z.string().min(1).max(256),
+    name: z.string().min(1).max(200),
+  }),
   // Whitelist the fields a renderer may write — `version` is managed by
   // the main process; unknown keys are rejected (.strict()).
   'prefs.update': z

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -200,6 +200,7 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
       clerkDisplayName: z.string().max(256).nullable().optional(),
       signedInAt: z.number().nullable().optional(),
       mobileGatewayEnabled: z.boolean().optional(),
+      theme: z.enum(['light', 'dark', 'system']).optional(),
     })
     .strict(),
   // Mobile-gateway control. Both no-arg variants pin the payload to "nothing"

--- a/packages/desktop-ui/src/Button.tsx
+++ b/packages/desktop-ui/src/Button.tsx
@@ -37,7 +37,7 @@ const VARIANT: Record<ButtonVariant, { className?: string; style: CSSProperties 
   secondary: {
     className: 'btn-outline',
     style: {
-      background: '#fff',
+      background: 'var(--color-surface)',
       color: 'var(--color-text-muted)',
       border: '1px solid var(--color-card-border)',
     },
@@ -45,7 +45,7 @@ const VARIANT: Record<ButtonVariant, { className?: string; style: CSSProperties 
   chip: {
     className: 'btn-chip',
     style: {
-      background: '#fff',
+      background: 'var(--color-surface)',
       color: 'var(--color-text-muted)',
       border: '1px solid var(--color-card-border)',
       fontSize: 12.5,
@@ -94,7 +94,7 @@ export interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>
   readonly size?: number;
   /** Corner radius in px. Default 8. */
   readonly radius?: number;
-  /** Draw a card border + white fill (the rail's collapse affordance). */
+  /** Draw a card border + surface fill (the rail's collapse affordance). */
   readonly bordered?: boolean;
 }
 
@@ -115,7 +115,9 @@ export function IconButton({
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
-    ...(bordered ? { border: '1px solid var(--color-card-border)', background: '#fff' } : {}),
+    ...(bordered
+      ? { border: '1px solid var(--color-card-border)', background: 'var(--color-surface)' }
+      : {}),
     ...style,
   };
   const cls = ['btn-icon', className].filter(Boolean).join(' ');

--- a/packages/desktop-ui/src/TextInput.tsx
+++ b/packages/desktop-ui/src/TextInput.tsx
@@ -1,6 +1,7 @@
 /**
  * Text field primitives — the one card-input shape the desktop uses, plus a
- * matching multi-line `TextArea`. `tone='soft'` is the `#f7f8fc` fill some
+ * matching multi-line `TextArea`. `tone='soft'` is the recessed
+ * `var(--color-input-soft)` fill some
  * modals use; `mono` switches to the monospace token (skill filenames, command
  * args). `style`/`className` merge last for per-site tweaks (width, min-height).
  */
@@ -12,7 +13,7 @@ const fieldStyle = (tone: FieldTone, mono: boolean): CSSProperties => ({
   padding: '9px 12px',
   fontSize: 14,
   color: 'var(--color-text)',
-  background: tone === 'soft' ? '#f7f8fc' : '#fff',
+  background: tone === 'soft' ? 'var(--color-input-soft)' : 'var(--color-surface)',
   border: '1px solid var(--color-card-border)',
   borderRadius: 10,
   outline: 'none',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@clerk/clerk-react':
         specifier: ^5.0.0
         version: 5.61.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@clerk/themes':
+        specifier: ^2.4.57
+        version: 2.4.57(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@moxxy/chat-model':
         specifier: workspace:*
         version: link:../../packages/chat-model
@@ -2793,6 +2796,10 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  '@clerk/themes@2.4.57':
+    resolution: {integrity: sha512-Nb3bO79rMTU/MPVTC/dde6LG27/IgOMKIYi5KSvAmO4ZUHlj0OWufu6CMvz5OYVZ0YdyMnTBU2aPGRUiRzO+2w==}
+    engines: {node: '>=18.17.0'}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -11572,6 +11579,14 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@clerk/themes@2.4.57(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@clerk/shared': 3.47.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@csstools/color-helpers@5.1.0': {}
 


### PR DESCRIPTION
Waves 2–3 of the fixes effort — PR #167 was merged before these landed on its branch, so they're re-cut here on top of main (content identical to what was verified there, plus a fresh changeset since #168 consumed the original).

## Multiple sessions per workspace
Desks own a session list (DeskDoc v2; v1 migrates by seeding one session whose id equals the desk id, so existing runner logs and chat mirrors resume untouched). The runner pool is keyed by session id — one `moxxy serve` per session — and everything downstream (event tagging, connection routing, NDJSON chat mirrors, attachment authz) was already id-agnostic. New `sessions.list/create/setActive/remove/rename` IPC commands (remove is host-only; the rest are remote-allowed so mobile can adopt real session lists later). The sidebar lists the active desk's sessions with active highlight, unread dots, inline rename, confirmed delete, and a New-session affordance; a desk always keeps at least one session. `session.newSession` retains its reset-current semantics.

## Dark mode
- Designed dark palette as `darkTokens` in `@moxxy/design-tokens` (additive — the mobile-consumed token shape is frozen) with a `[data-theme="dark"]` block in styles.css whose parity with `:root` is CI-enforced (a missed alias now fails tests).
- Theme preference light/dark/system persisted in desktop prefs and mirrored into `nativeTheme` **before** window creation (dark-aware window background + splash media queries — no white flash). New Settings → Appearance tab.
- ~224 hardcoded colors migrated across chat, settings, shell, onboarding, workflows, and `@moxxy/desktop-ui` (white-on-brand text, scrims, shadows, and terminal blocks deliberately kept literal). Clerk modals follow the theme via `@clerk/themes`. The focus widget window is excluded by design.

## Infinite workflow canvas
True Figma-style canvas: zero-size content layer with translate+scale instead of a scroll container; wheel/trackpad pans both axes unbounded (negative coords fine); ctrl/cmd+wheel and pinch zoom anchored at the cursor (10–400%); drag-to-pan kept; double-click resets to 100%; new zoom-to-fit; the grid tracks the transform; viewport persists with the workflow.

## Self-update: honest about runner-protocol bumps
Staging now enforces the same runner-protocol lockstep gate as boot. A release that bumps the runner protocol reports **requires full update** with a release-page CTA instead of staging a bundle the bootstrap is guaranteed to refuse and then claiming "updated — relaunch" (the exact failure observed live on the 0.4.2→0.4.3 update). Update diagnostics render boot-log reject reasons in plain language with a red callout when the last boot declined a staged update. Also: `bootstrap.ts boot()` now clears `MOXXY_APP_BUNDLE_ROOT/VERSION` up front — they survive `app.relaunch()`, so a floor boot after a refused override could impersonate the previous override and corrupt the self-update health signal.

## Tests
Full gate green: build, typecheck, lint, tests (desktop-host 281, apps/desktop 101, client-core 58, ipc-contract 25, design-tokens 12, plus all unaffected suites). New coverage: desks v1→v2 migration + sessions handler/store/UI tests, dark-parity tests, useTheme tests, stage-time protocol-gate tests, infinite-canvas pan/zoom tests.

Manual follow-ups: visual dark-mode QA pass (chat/settings/onboarding/canvas), packaged Google sign-in round-trip.