### PR TITLE
fix(desktop): chat sticks to bottom while streaming + jump-to-latest arrow

### DIFF
--- a/.changeset/chat-autoscroll.md
+++ b/.changeset/chat-autoscroll.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/desktop': patch
+---
+
+The chat transcript sticks to the bottom while the agent streams a reply. If you scroll up, autoscroll pauses and a floating ↓ button appears (with a dot when new content arrives below); clicking it — or scrolling back down yourself — jumps to the latest message and re-enables autoscroll.

--- a/apps/desktop/src/chat/JumpToLatest.test.tsx
+++ b/apps/desktop/src/chat/JumpToLatest.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * JumpToLatest button + useNewContentBelow hook:
+ *   1. The button only mounts while `visible` (i.e. user scrolled up),
+ *      exposes the aria-label/testid contract, and fires onJump on click.
+ *   2. The unread dot rides on `unread`.
+ *   3. useNewContentBelow flags appended content only while scrolled up,
+ *      ignores key changes at the bottom, and resets when the user
+ *      returns to the bottom. A stable key (upward-pagination prepend)
+ *      never flags.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { JumpToLatest, useNewContentBelow } from './JumpToLatest';
+
+describe('JumpToLatest', () => {
+  it('renders nothing while at the bottom (visible=false)', () => {
+    render(<JumpToLatest visible={false} unread={false} onJump={() => {}} />);
+    expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument();
+  });
+
+  it('shows the button when scrolled up and fires onJump on click', () => {
+    const onJump = vi.fn();
+    render(<JumpToLatest visible unread={false} onJump={onJump} />);
+    const btn = screen.getByTestId('scroll-to-bottom');
+    expect(btn).toHaveAccessibleName('Scroll to latest');
+    fireEvent.click(btn);
+    expect(onJump).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the unread dot only when unread', () => {
+    const { rerender } = render(<JumpToLatest visible unread={false} onJump={() => {}} />);
+    expect(screen.queryByTestId('scroll-to-bottom-unread')).not.toBeInTheDocument();
+    rerender(<JumpToLatest visible unread onJump={() => {}} />);
+    expect(screen.getByTestId('scroll-to-bottom-unread')).toBeInTheDocument();
+  });
+});
+
+/** Tiny harness exposing the hook's output as a testable DOM flag. */
+function Probe({ atBottom, contentKey }: { atBottom: boolean; contentKey: string }): JSX.Element {
+  const unread = useNewContentBelow(atBottom, contentKey);
+  return <output data-testid="unread">{String(unread)}</output>;
+}
+
+describe('useNewContentBelow', () => {
+  it('stays false while at the bottom even as content appends', () => {
+    const { rerender } = render(<Probe atBottom contentKey="a:0" />);
+    rerender(<Probe atBottom contentKey="b:0" />);
+    rerender(<Probe atBottom contentKey="b:42" />);
+    expect(screen.getByTestId('unread')).toHaveTextContent('false');
+  });
+
+  it('flips true when content appends while scrolled up, and resets at bottom', () => {
+    const { rerender } = render(<Probe atBottom contentKey="a:0" />);
+    rerender(<Probe atBottom={false} contentKey="a:0" />);
+    // No new content yet — just scrolling up must not flag.
+    expect(screen.getByTestId('unread')).toHaveTextContent('false');
+    // A streaming chunk arrives below.
+    rerender(<Probe atBottom={false} contentKey="a:17" />);
+    expect(screen.getByTestId('unread')).toHaveTextContent('true');
+    // Returning to the bottom clears the hint.
+    rerender(<Probe atBottom contentKey="a:17" />);
+    expect(screen.getByTestId('unread')).toHaveTextContent('false');
+  });
+
+  it('ignores a stable key while scrolled up (upward-pagination prepend)', () => {
+    const { rerender } = render(<Probe atBottom contentKey="tail:0" />);
+    rerender(<Probe atBottom={false} contentKey="tail:0" />);
+    // Prepending history does not change the tail key — no unread hint.
+    rerender(<Probe atBottom={false} contentKey="tail:0" />);
+    expect(screen.getByTestId('unread')).toHaveTextContent('false');
+  });
+});

--- a/apps/desktop/src/chat/JumpToLatest.tsx
+++ b/apps/desktop/src/chat/JumpToLatest.tsx
@@ -1,0 +1,83 @@
+/**
+ * Floating "jump to latest" affordance for the transcript.
+ *
+ * Shown while the user has scrolled away from the bottom; clicking it asks
+ * the transcript to scroll back down, which flips Virtuoso's `atBottom`
+ * back on and resumes stick-to-bottom (`followOutput`). A primary-coloured
+ * dot marks that NEW content (a committed row or streaming chunks) arrived
+ * below the viewport since the user scrolled up.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { Icon, IconButton } from '@moxxy/desktop-ui';
+
+/**
+ * Tracks whether content was appended below the viewport while the user is
+ * scrolled up. `contentKey` must change whenever content is APPENDED (last
+ * row key / streaming length) but stay stable across upward-pagination
+ * prepends, so paging older history in never fakes an unread hint.
+ */
+export function useNewContentBelow(atBottom: boolean, contentKey: string): boolean {
+  const [unread, setUnread] = useState(false);
+  const prev = useRef(contentKey);
+  useEffect(() => {
+    if (atBottom) {
+      prev.current = contentKey;
+      setUnread(false);
+      return;
+    }
+    if (contentKey !== prev.current) {
+      prev.current = contentKey;
+      setUnread(true);
+    }
+  }, [atBottom, contentKey]);
+  return unread;
+}
+
+interface JumpToLatestProps {
+  /** True when the user is scrolled away from the bottom. */
+  readonly visible: boolean;
+  /** True when new content arrived below while scrolled up. */
+  readonly unread: boolean;
+  readonly onJump: () => void;
+}
+
+export function JumpToLatest({ visible, unread, onJump }: JumpToLatestProps): JSX.Element | null {
+  if (!visible) return null;
+  return (
+    <IconButton
+      bordered
+      size={36}
+      radius={999}
+      aria-label="Scroll to latest"
+      data-testid="scroll-to-bottom"
+      onClick={onJump}
+      style={{
+        position: 'absolute',
+        left: '50%',
+        bottom: 16,
+        transform: 'translateX(-50%)',
+        zIndex: 5,
+        boxShadow: 'var(--color-card-shadow)',
+        color: 'var(--color-text)',
+      }}
+    >
+      {/* The icon set has no chevron-down/arrow-down glyph — reuse the
+       *  existing chevron rotated a quarter turn. */}
+      <Icon name="chevron-right" size={18} style={{ transform: 'rotate(90deg)' }} />
+      {unread && (
+        <span
+          data-testid="scroll-to-bottom-unread"
+          style={{
+            position: 'absolute',
+            top: 1,
+            right: 1,
+            width: 8,
+            height: 8,
+            borderRadius: 999,
+            background: 'var(--color-primary)',
+          }}
+        />
+      )}
+    </IconButton>
+  );
+}

--- a/apps/desktop/src/chat/Transcript.test.tsx
+++ b/apps/desktop/src/chat/Transcript.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Transcript ↔ Virtuoso wiring (Virtuoso itself is mocked — jsdom can't
+ * measure a virtualised scroller, so we capture the props Transcript hands
+ * it and drive the callbacks directly):
+ *   1. Stick-to-bottom: `followOutput` returns false when scrolled up,
+ *      'auto' while streaming (rapid chunks must pin instantly), and
+ *      'smooth' for a committed line; `atBottomThreshold` carries slack.
+ *   2. The jump button is hidden at the bottom, appears after
+ *      `atBottomStateChange(false)`, and clicking it calls
+ *      scrollToIndex({ index: 'LAST', … }) on the handle.
+ *   3. An upward-pagination prepend shifts `firstItemIndex` down by the
+ *      prepended row count and never flags the unread dot.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import type { MoxxyEvent } from '@moxxy/sdk';
+import { Transcript } from './Transcript';
+
+interface CapturedProps {
+  followOutput: (isAtBottom: boolean) => false | 'smooth' | 'auto';
+  atBottomStateChange: (atBottom: boolean) => void;
+  atBottomThreshold: number;
+  firstItemIndex: number;
+  initialTopMostItemIndex: number;
+}
+
+const captured = vi.hoisted(() => ({
+  props: null as CapturedProps | null,
+  scrollToIndex: vi.fn(),
+}));
+
+vi.mock('react-virtuoso', async () => {
+  const React = await import('react');
+  return {
+    Virtuoso: React.forwardRef(function MockVirtuoso(
+      props: Record<string, unknown>,
+      ref: React.Ref<unknown>,
+    ) {
+      captured.props = props as unknown as CapturedProps;
+      React.useImperativeHandle(ref, () => ({ scrollToIndex: captured.scrollToIndex }));
+      return React.createElement('div', { 'data-testid': 'virtuoso-mock' });
+    }),
+  };
+});
+
+function userPrompt(id: string, text: string): MoxxyEvent {
+  return {
+    type: 'user_prompt',
+    text,
+    id,
+    seq: 1,
+    ts: 1,
+    sessionId: 's1',
+    turnId: 't1',
+    source: 'user',
+  } as unknown as MoxxyEvent;
+}
+
+function renderTranscript(
+  overrides: Partial<React.ComponentProps<typeof Transcript>> = {},
+): ReturnType<typeof render> {
+  return render(
+    <Transcript events={[userPrompt('e1', 'hi')]} extensions={[]} streamingText="" {...overrides} />,
+  );
+}
+
+beforeEach(() => {
+  captured.props = null;
+  captured.scrollToIndex.mockClear();
+});
+
+describe('Transcript stick-to-bottom wiring', () => {
+  it('followOutput pins instantly while streaming, smoothly otherwise, never when scrolled up', () => {
+    const { rerender } = renderTranscript();
+    expect(captured.props?.followOutput(true)).toBe('smooth');
+    expect(captured.props?.followOutput(false)).toBe(false);
+    rerender(
+      <Transcript events={[userPrompt('e1', 'hi')]} extensions={[]} streamingText="chunk" />,
+    );
+    expect(captured.props?.followOutput(true)).toBe('auto');
+    expect(captured.props?.followOutput(false)).toBe(false);
+    // Slack so trackpad jitter near the bottom doesn't break the follow.
+    expect(captured.props?.atBottomThreshold).toBe(80);
+  });
+
+  it('mounts at the bottom (initialTopMostItemIndex = last row) with no button', () => {
+    renderTranscript();
+    expect(captured.props?.initialTopMostItemIndex).toBe(0);
+    expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument();
+  });
+
+  it('shows the jump button when scrolled up; clicking scrolls to LAST and it hides at bottom', () => {
+    renderTranscript();
+    act(() => captured.props?.atBottomStateChange(false));
+    const btn = screen.getByTestId('scroll-to-bottom');
+    fireEvent.click(btn);
+    expect(captured.scrollToIndex).toHaveBeenCalledWith({
+      index: 'LAST',
+      align: 'end',
+      behavior: 'smooth',
+    });
+    // Landing at the bottom re-enables stick-to-bottom and hides the button.
+    act(() => captured.props?.atBottomStateChange(true));
+    expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument();
+  });
+
+  it('flags unread when chunks stream in while scrolled up', () => {
+    const { rerender } = renderTranscript();
+    act(() => captured.props?.atBottomStateChange(false));
+    expect(screen.queryByTestId('scroll-to-bottom-unread')).not.toBeInTheDocument();
+    rerender(
+      <Transcript events={[userPrompt('e1', 'hi')]} extensions={[]} streamingText="more text" />,
+    );
+    expect(screen.getByTestId('scroll-to-bottom-unread')).toBeInTheDocument();
+  });
+
+  it('prepending older history shifts firstItemIndex and does not flag unread', () => {
+    const e2 = userPrompt('e2', 'newest');
+    const { rerender } = render(<Transcript events={[e2]} extensions={[]} streamingText="" />);
+    const before = captured.props?.firstItemIndex ?? 0;
+    act(() => captured.props?.atBottomStateChange(false));
+    // Older page lands at the head; the tail row is unchanged.
+    rerender(
+      <Transcript events={[userPrompt('e1', 'older'), e2]} extensions={[]} streamingText="" />,
+    );
+    expect(captured.props?.firstItemIndex).toBe(before - 1);
+    expect(screen.queryByTestId('scroll-to-bottom-unread')).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/chat/Transcript.tsx
+++ b/apps/desktop/src/chat/Transcript.tsx
@@ -1,5 +1,5 @@
-import { memo, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { Virtuoso } from 'react-virtuoso';
+import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import type { MoxxyEvent } from '@moxxy/sdk';
 import { blocksEquivalent, type Block as FoldedBlock } from '@moxxy/chat-model';
 import { buildRenderNodes, groupToolNodes, type Extension, type RenderNode } from '@moxxy/client-core';
@@ -7,6 +7,7 @@ import { BlockView, StreamingAssistant } from './BlockView';
 import { ToolGroupView } from './ToolGroupView';
 import { ExtensionCard } from './ExtensionCard';
 import { ThinkingIndicator } from './ThinkingIndicator';
+import { JumpToLatest, useNewContentBelow } from './JumpToLatest';
 
 interface TranscriptProps {
   readonly events: ReadonlyArray<MoxxyEvent>;
@@ -85,6 +86,26 @@ export function Transcript({
     [events, extensions],
   );
 
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
+
+  // Mirrors Virtuoso's at-bottom flag. Starts true: `initialTopMostItemIndex`
+  // mounts the list at the bottom, so the jump affordance must not flash
+  // before the first `atBottomStateChange` callback lands.
+  const [atBottom, setAtBottom] = useState(true);
+
+  // Changes on APPENDS only (new last row or streaming chunk) — stable
+  // across upward-pagination prepends, so paging in history never fakes an
+  // unread hint or flickers the jump button.
+  const lastKey = nodes.length > 0 ? keyOf(nodes[nodes.length - 1]!) : '';
+  const newBelow = useNewContentBelow(atBottom, `${lastKey}:${streamingText.length}`);
+
+  const jumpToLatest = useCallback(() => {
+    // `align: 'end'` on the LAST index also accounts for the Footer (the
+    // in-flight streaming bubble), landing fully at the bottom — which
+    // flips `atBottom` back on and resumes `followOutput`.
+    virtuosoRef.current?.scrollToIndex({ index: 'LAST', align: 'end', behavior: 'smooth' });
+  }, []);
+
   // Track how many rows have been prepended so far and shift
   // firstItemIndex by that amount. Detect a prepend by finding where the
   // previous head row landed in the new list.
@@ -100,28 +121,38 @@ export function Transcript({
   }, [nodes]);
 
   return (
-    <Virtuoso<RenderNode>
-      data={nodes as RenderNode[]}
-      data-testid="transcript"
-      style={{ flex: 1 }}
-      // Only follow when the user is already at the bottom (scrolling up to
-      // read is never interrupted). A newly-committed line scrolls SMOOTHLY;
-      // during active streaming we pin instantly so rapid chunks don't stack
-      // overlapping smooth-scroll animations into jank.
-      followOutput={(atBottom) => (atBottom ? (streamingText ? 'auto' : 'smooth') : false)}
-      firstItemIndex={firstItemIndex}
-      initialTopMostItemIndex={Math.max(0, nodes.length - 1)}
-      {...(hasOlder && onReachedTop ? { startReached: onReachedTop } : {})}
-      computeItemKey={(_i, node) => keyOf(node)}
-      itemContent={(_i, node) => <Row node={node} workspaceId={workspaceId} />}
-      components={{
-        Footer: () => (
-          <div style={{ padding: '0 24px 12px' }}>
-            {streamingText && <StreamingAssistant text={streamingText} />}
-            {sending && streamingText === '' && <ThinkingIndicator />}
-          </div>
-        ),
-      }}
-    />
+    // Relative wrapper so the jump-to-latest button can float over the
+    // scroller without joining the virtualised content.
+    <div style={{ position: 'relative', flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+      <Virtuoso<RenderNode>
+        ref={virtuosoRef}
+        data={nodes as RenderNode[]}
+        data-testid="transcript"
+        style={{ flex: 1 }}
+        // Only follow when the user is already at the bottom (scrolling up to
+        // read is never interrupted). A newly-committed line scrolls SMOOTHLY;
+        // during active streaming we pin instantly ('auto') so rapid chunks
+        // don't stack overlapping smooth-scroll animations into lag/jank.
+        followOutput={(isAtBottom) => (isAtBottom ? (streamingText ? 'auto' : 'smooth') : false)}
+        // ~80px of slack so trackpad jitter / a sub-row nudge near the bottom
+        // doesn't flip stick-to-bottom off (default is a razor-thin 4px).
+        atBottomThreshold={80}
+        atBottomStateChange={setAtBottom}
+        firstItemIndex={firstItemIndex}
+        initialTopMostItemIndex={Math.max(0, nodes.length - 1)}
+        {...(hasOlder && onReachedTop ? { startReached: onReachedTop } : {})}
+        computeItemKey={(_i, node) => keyOf(node)}
+        itemContent={(_i, node) => <Row node={node} workspaceId={workspaceId} />}
+        components={{
+          Footer: () => (
+            <div style={{ padding: '0 24px 12px' }}>
+              {streamingText && <StreamingAssistant text={streamingText} />}
+              {sending && streamingText === '' && <ThinkingIndicator />}
+            </div>
+          ),
+        }}
+      />
+      <JumpToLatest visible={!atBottom} unread={newBelow} onJump={jumpToLatest} />
+    </div>
   );
 }


### PR DESCRIPTION
While the agent streams a reply, the transcript now stays pinned to the bottom. If the user scrolls up, autoscroll pauses and a floating ↓ button appears over the transcript (with a primary dot when new content arrives below); clicking it — or scrolling back to the bottom manually — jumps to the latest message and re-enables following.

Implementation: react-virtuoso `followOutput` (`'auto'` during token streams — smooth animations stack into lag on rapid chunks), `atBottomThreshold={80}` so trackpad jitter near the bottom doesn't flip it, `atBottomStateChange` drives the button, click does `scrollToIndex({ index: 'LAST', align: 'end', behavior: 'smooth' })`. The unread hint is keyed on appends/chunk growth only, so upward history pagination (`firstItemIndex` prepends) never fakes an unread or flickers the button — covered by a regression test.

Tests: apps/desktop suite 131/131 (new Transcript tests with a virtuoso mock + pure JumpToLatest/useNewContentBelow tests), typecheck + eslint clean.