### PR TITLE
fix(mobile): LAN pairing to the desktop gateway — advertised-IP ranking + iOS/Android network permissions

### DIFF
--- a/.changeset/mobile-gateway-connect.md
+++ b/.changeset/mobile-gateway-connect.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/plugin-channel-mobile': patch
+'@moxxy/mobile': patch
+---
+
+Fix the phone never connecting to the desktop-started mobile gateway on the same network. Two defects: (1) the advertised QR host picked the first non-internal IPv4, so a VPN/Docker/link-local interface could be advertised instead of the reachable LAN IP — `lanHost` now ranks candidates (RFC1918 on physical NICs first, skipping utun/vmnet/bridge/awdl-style interfaces unless nothing else exists); (2) the built mobile app was missing iOS's `NSLocalNetworkUsageDescription` (iOS 14+ silently denies LAN dials without it) and Android's cleartext-`ws://` allowance — both added to app.json (requires a new native build; OTA updates do not deliver Info.plist/manifest changes). Expo Go masked both, which is why dev pairing worked.

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -10,7 +10,8 @@
     "ios": {
       "supportsTablet": true,
       "infoPlist": {
-        "NSCameraUsageDescription": "Scan the connection QR shown by `moxxy mobile` to connect to your agent."
+        "NSCameraUsageDescription": "Scan the connection QR shown by `moxxy mobile` to connect to your agent.",
+        "NSLocalNetworkUsageDescription": "Connect to the Moxxy gateway running on your computer over your local Wi-Fi network."
       }
     },
     "android": {
@@ -25,6 +26,14 @@
     "plugins": [
       "expo-router",
       "expo-secure-store",
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "usesCleartextTraffic": true
+          }
+        }
+      ],
       [
         "expo-audio",
         {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -21,6 +21,7 @@
     "@moxxy/workflows-builder": "workspace:*",
     "expo": "~54.0.0",
     "expo-audio": "~1.1.1",
+    "expo-build-properties": "~1.0.10",
     "expo-camera": "~17.0.10",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",

--- a/apps/mobile/src/__tests__/mobile-pairing-url.test.ts
+++ b/apps/mobile/src/__tests__/mobile-pairing-url.test.ts
@@ -35,6 +35,14 @@ describe('mobile pairing bridge url', () => {
     expect(chooseGatewayUrlForPairing('ws://localhost:8765', '192.168.1.44:8081')).toBe('ws://192.168.1.44:8765');
     expect(chooseGatewayUrlForPairing('ws://10.0.0.2:8765', '192.168.1.44:8081')).toBe('ws://10.0.0.2:8765');
   });
+
+  it('never rewrites a scanned desktop-gateway LAN URL (built app, no Expo dev host)', () => {
+    // The desktop QR advertises the machine's LAN IP; the app must dial it
+    // verbatim — in a built app there is no Expo host to "improve" it with,
+    // and even in dev the non-loopback host wins (previous case).
+    expect(chooseGatewayUrlForPairing('ws://172.20.10.2:8765', null)).toBe('ws://172.20.10.2:8765');
+    expect(chooseGatewayUrlForPairing('ws://192.168.1.7:8765', undefined)).toBe('ws://192.168.1.7:8765');
+  });
 });
 
 describe('mobile pairing QR payload', () => {

--- a/packages/plugin-channel-mobile/src/pairing.ts
+++ b/packages/plugin-channel-mobile/src/pairing.ts
@@ -33,15 +33,61 @@ export function isWildcardHost(host: string): boolean {
   return h === '0.0.0.0' || h === '::' || h === '[::]';
 }
 
-/** First non-internal IPv4 address, so a phone on the same Wi-Fi can reach the
- *  bridge without a tunnel. Falls back to the bind host. */
+/** Interface names that are overlay/virtual links a phone on the Wi-Fi cannot
+ *  reach: VPN tunnels (utun/wg/tailscale…), VM/container bridges (vmnet/
+ *  bridge/docker…), and Apple's special-purpose links (awdl/llw/ap). A private
+ *  address on one of these is only routable inside that overlay. */
+const VIRTUAL_IFACE = /^(?:utun|tun|tap|ppp|ipsec|wg|zt|ts|tailscale|vmnet|vnic|bridge|docker|veth|awdl|llw|ap|anpi)\d*$/i;
+
+/** 169.254/16 — self-assigned, never routed; a phone can't dial it. (Intel
+ *  Macs expose the T2 iBridge as `en5` with a link-local IPv4, and it often
+ *  enumerates BEFORE en0 — the classic "first IPv4" trap.) */
+function isLinkLocalV4(ip: string): boolean {
+  return ip.startsWith('169.254.');
+}
+
+/** RFC1918 private space — what a home/office Wi-Fi actually hands out. */
+function isRfc1918(ip: string): boolean {
+  if (ip.startsWith('10.') || ip.startsWith('192.168.')) return true;
+  const m = /^172\.(\d{1,3})\./.exec(ip);
+  return m !== null && Number(m[1]) >= 16 && Number(m[1]) <= 31;
+}
+
+/** 100.64/10 (CGNAT) — Tailscale-style overlay addresses; reachable only by
+ *  peers of the same overlay, not by a phone on the local Wi-Fi. */
+function isCgnat(ip: string): boolean {
+  const m = /^100\.(\d{1,3})\./.exec(ip);
+  return m !== null && Number(m[1]) >= 64 && Number(m[1]) <= 127;
+}
+
+/**
+ * The IPv4 address a phone on the same Wi-Fi should dial, so the bridge is
+ * reachable without a tunnel. NOT simply the first non-internal IPv4: macOS
+ * enumerates iBridge link-locals, VPN utuns, and VM bridges alongside the real
+ * NIC, and advertising one of those in the QR makes pairing dial a dead
+ * address. Candidates are ranked:
+ *   1. RFC1918 on a physical-looking interface (en0/eth0/wlan0…),
+ *   2. any other routable address on a physical interface,
+ *   3. RFC1918 on a virtual interface (a VPN's 10.x — last-resort connectable),
+ *   4. CGNAT overlay (Tailscale) / other virtual,
+ *   5. link-local 169.254.x (kept only so SOMETHING shows when it's all we have),
+ * with enumeration order breaking ties. Falls back to the bind host.
+ */
 export function lanHost(fallback: string): string {
-  for (const list of Object.values(os.networkInterfaces())) {
+  let best: { address: string; rank: number } | null = null;
+  for (const [name, list] of Object.entries(os.networkInterfaces())) {
     for (const ni of list ?? []) {
-      if (ni.family === 'IPv4' && !ni.internal) return ni.address;
+      if (ni.family !== 'IPv4' || ni.internal) continue;
+      const virtual = VIRTUAL_IFACE.test(name);
+      let rank: number;
+      if (isLinkLocalV4(ni.address)) rank = 5;
+      else if (isRfc1918(ni.address)) rank = virtual ? 3 : 1;
+      else if (isCgnat(ni.address)) rank = 4;
+      else rank = virtual ? 4 : 2;
+      if (!best || rank < best.rank) best = { address: ni.address, rank };
     }
   }
-  return fallback;
+  return best?.address ?? fallback;
 }
 
 /**

--- a/packages/plugin-channel-mobile/src/tunnel.test.ts
+++ b/packages/plugin-channel-mobile/src/tunnel.test.ts
@@ -122,3 +122,53 @@ describe('buildConnectUrl', () => {
     expect(lanHost('127.0.0.1')).toBe('127.0.0.1');
   });
 });
+
+describe('lanHost interface ranking (the QR must advertise a phone-reachable IP)', () => {
+  it('skips a link-local iBridge IPv4 that enumerates before en0 (Intel Mac T2)', () => {
+    ifaces.mockReturnValueOnce({
+      lo0: [{ family: 'IPv4', internal: true, address: '127.0.0.1' }],
+      en5: [{ family: 'IPv4', internal: false, address: '169.254.123.4' }],
+      en0: [{ family: 'IPv4', internal: false, address: '192.168.1.42' }],
+    } as never);
+    expect(lanHost('127.0.0.1')).toBe('192.168.1.42');
+  });
+
+  it('prefers the physical NIC over a VPN utun with an RFC1918 address', () => {
+    ifaces.mockReturnValueOnce({
+      utun4: [{ family: 'IPv4', internal: false, address: '10.8.0.2' }],
+      en0: [{ family: 'IPv4', internal: false, address: '192.168.1.42' }],
+    } as never);
+    expect(lanHost('127.0.0.1')).toBe('192.168.1.42');
+  });
+
+  it('prefers the physical NIC over a Tailscale CGNAT overlay address', () => {
+    ifaces.mockReturnValueOnce({
+      utun3: [{ family: 'IPv4', internal: false, address: '100.101.102.103' }],
+      en0: [{ family: 'IPv4', internal: false, address: '172.20.10.2' }],
+    } as never);
+    expect(lanHost('127.0.0.1')).toBe('172.20.10.2');
+  });
+
+  it('prefers the physical NIC over a VM bridge (Docker/Parallels style)', () => {
+    ifaces.mockReturnValueOnce({
+      bridge100: [{ family: 'IPv4', internal: false, address: '192.168.64.1' }],
+      en0: [{ family: 'IPv4', internal: false, address: '10.0.1.5' }],
+    } as never);
+    expect(lanHost('127.0.0.1')).toBe('10.0.1.5');
+  });
+
+  it('still returns a VPN address when it is the only routable candidate', () => {
+    ifaces.mockReturnValueOnce({
+      utun4: [{ family: 'IPv4', internal: false, address: '10.8.0.2' }],
+    } as never);
+    expect(lanHost('127.0.0.1')).toBe('10.8.0.2');
+  });
+
+  it('keeps first-enumerated order between equally-ranked candidates', () => {
+    ifaces.mockReturnValueOnce({
+      en0: [{ family: 'IPv4', internal: false, address: '192.168.1.42' }],
+      en1: [{ family: 'IPv4', internal: false, address: '192.168.1.43' }],
+    } as never);
+    expect(lanHost('127.0.0.1')).toBe('192.168.1.42');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       expo-audio:
         specifier: ~1.1.1
         version: 1.1.1(expo-asset@12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-build-properties:
+        specifier: ~1.0.10
+        version: 1.0.10(expo@54.0.35)
       expo-camera:
         specifier: ~17.0.10
         version: 17.0.10(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -6464,6 +6467,11 @@ packages:
       expo-asset: '*'
       react: '*'
       react-native: '*'
+
+  expo-build-properties@1.0.10:
+    resolution: {integrity: sha512-mFCZbrbrv0AP5RB151tAoRzwRJelqM7bCJzCkxpu+owOyH+p/rFC/q7H5q8B9EpVWj8etaIuszR+gKwohpmu1Q==}
+    peerDependencies:
+      expo: '*'
 
   expo-camera@17.0.10:
     resolution: {integrity: sha512-w1RBw83mAGVk4BPPwNrCZyFop0VLiVSRE3c2V9onWbdFwonpRhzmB4drygG8YOUTl1H3wQvALJHyMPTbgsK1Jg==}
@@ -15853,6 +15861,12 @@ snapshots:
       expo-asset: 12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+
+  expo-build-properties@1.0.10(expo@54.0.35):
+    dependencies:
+      ajv: 8.20.0
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      semver: 7.8.0
 
   expo-camera@17.0.10(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:


### PR DESCRIPTION
Fixes "phone on the same network still can't connect to the desktop-started mobile gateway".

## Diagnosis (reproduced live against the real bridge)
The bridge itself is fine: it binds `0.0.0.0:8765`, and probes with the app's exact bearer-subprotocol handshake succeed from both loopback and the machine's LAN IP (and 401 on a bad token). Two real defects sat around it:

1. **Fragile advertised IP (desktop QR).** `lanHost()` returned the *first* non-internal IPv4 from `os.networkInterfaces()` — with a VPN (`utun*`), Docker/Parallels bridge, or an iBridge link-local interface enumerating before `en0`, the QR advertises an address the phone can never reach. Now ranks candidates: RFC1918 on physical NICs → other routable physical → virtual as last resort, skipping `utun/wg/tailscale/vmnet/bridge/docker/awdl`-style names unless nothing else exists. Benefits both the desktop gateway and `moxxy mobile`.

2. **Built-app network policy (most likely the reported case).** The EAS-built app had no `NSLocalNetworkUsageDescription` — iOS 14+ silently denies connections to LAN IPs without it — and no Android cleartext allowance, so Android 9+ release builds block plain `ws://` outright. Expo Go has these entitlements, which is why dev pairing worked and built-app pairing churned forever. Added via app.json + `expo-build-properties`.

> ⚠️ The app.json fixes are native config — they need a **new EAS build / dev-client rebuild**; OTA updates won't deliver them. After rebuilding, iOS will prompt for Local Network permission on first connect.

## wss assessment (asked alongside)
RN/Hermes WebSocket has no certificate-trust hook, so self-signed/local-CA wss is not viable, and public CAs won't issue for private-IP SANs. Tunnel mode already gives wss end-to-end (cloudflared/ngrok) — recommended for untrusted networks today. The right long-term LAN fix is app-layer encryption over ws (Noise/libsodium keyed from the QR secret); noted as follow-up, not in this PR.

## Tests
6 new `lanHost` ranking tests, a built-app no-URL-rewrite regression test; plugin-channel-mobile 29/29, mobile 97/97, ipc-server-ws 62/62, desktop-host gateway 6/6, build + typecheck green.