### PR TITLE
feat(office): wheel/pinch zoom + drag pan with map-clamped camera

### DIFF
--- a/.changeset/office-zoom-pan.md
+++ b/.changeset/office-zoom-pan.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/cli': patch
+---
+
+Virtual office: mouse-wheel / trackpad-pinch zoom (anchored at the cursor) and drag-to-pan, clamped to the office map; sprite clicks now fire on pointer-up with a drag threshold so panning never opens the chat panel.

--- a/packages/plugin-channel-virtual-office/src/frontend/game/OfficeScene.ts
+++ b/packages/plugin-channel-virtual-office/src/frontend/game/OfficeScene.ts
@@ -27,6 +27,10 @@ export class OfficeScene extends Phaser.Scene {
   private monitorFlip = false;
   private monitorTimer = 0;
   private selectedId: string | null = null;
+  /** Zoom at which the whole office exactly fits the window — the floor of
+   *  the user's zoom range and the default view. */
+  private fitZoom = 1;
+  private drag: { x: number; y: number; scrollX: number; scrollY: number } | null = null;
 
   constructor(
     private readonly director: OfficeDirector,
@@ -59,25 +63,104 @@ export class OfficeScene extends Phaser.Scene {
       }
     }
 
-    this.input.on('pointerdown', (_p: Phaser.Input.Pointer, over: unknown[]) => {
-      if (over.length === 0) this.callbacks.onBackgroundClick?.();
+    // A click on empty floor (not a drag — pointer barely moved) deselects.
+    this.input.on('pointerup', (p: Phaser.Input.Pointer, over: unknown[]) => {
+      if (over.length === 0 && p.getDistance() < 6) this.callbacks.onBackgroundClick?.();
     });
 
+    this.wireCameraControls();
+
     this.cameras.main.setRoundPixels(true);
-    this.fitCamera();
-    this.scale.on(Phaser.Scale.Events.RESIZE, () => this.fitCamera());
+    this.fitCamera(true);
+    this.scale.on(Phaser.Scale.Events.RESIZE, () => this.fitCamera(false));
   }
 
-  /** Zoom the camera so the WHOLE office fills as much of the window as
-   *  possible (letterboxed on the short axis), recomputed on every resize. */
-  private fitCamera(): void {
+  /**
+   * Recompute the fit-the-whole-office zoom. `reset` (boot) snaps to it; on
+   * window resizes we keep the user's zoom (re-clamped) unless they were AT
+   * the fit view, which then follows the new window size.
+   */
+  private fitCamera(reset: boolean): void {
+    const cam = this.cameras.main;
+    const wasAtFit = Math.abs(cam.zoom - this.fitZoom) < 0.001;
+    const worldW = MAP_W * TILE;
+    const worldH = MAP_H * TILE;
+    // Never below 1 (unreadably small) — tiny windows scroll-crop instead.
+    this.fitZoom = Math.max(
+      1,
+      Math.min(this.scale.width / worldW, this.scale.height / worldH),
+    );
+    if (reset || wasAtFit) {
+      cam.setZoom(this.fitZoom);
+      cam.centerOn(worldW / 2, worldH / 2);
+    }
+    this.clampCamera();
+  }
+
+  /** Wheel (and macOS trackpad pinch, which arrives as ctrl+wheel) zooms
+   *  anchored at the cursor; dragging pans. Sprite clicks stay intact —
+   *  actors react on pointerUP with a small movement threshold. */
+  private wireCameraControls(): void {
+    const cam = this.cameras.main;
+
+    this.input.on(
+      'wheel',
+      (pointer: Phaser.Input.Pointer, _over: unknown[], _dx: number, dy: number) => {
+        const z1 = cam.zoom;
+        const z2 = Phaser.Math.Clamp(z1 * Math.exp(-dy * 0.0015), this.fitZoom, 8);
+        if (z2 === z1) return;
+        // Keep the world point under the cursor fixed. Phaser's visible rect
+        // is centered on (scroll + half-viewport) and sized viewport/zoom, so
+        // the world point under screen (px, py) is
+        //   w = scroll + half - half/zoom + p/zoom
+        // — solve for the new scroll that keeps w in place at the new zoom.
+        const halfW = cam.width / 2;
+        const halfH = cam.height / 2;
+        const wx = cam.scrollX + halfW - halfW / z1 + pointer.x / z1;
+        const wy = cam.scrollY + halfH - halfH / z1 + pointer.y / z1;
+        cam.setZoom(z2);
+        cam.scrollX = wx - halfW + halfW / z2 - pointer.x / z2;
+        cam.scrollY = wy - halfH + halfH / z2 - pointer.y / z2;
+        this.clampCamera();
+      },
+    );
+
+    this.input.on('pointerdown', (p: Phaser.Input.Pointer) => {
+      this.drag = { x: p.x, y: p.y, scrollX: cam.scrollX, scrollY: cam.scrollY };
+    });
+    this.input.on('pointermove', (p: Phaser.Input.Pointer) => {
+      if (!this.drag || !p.isDown) return;
+      cam.scrollX = this.drag.scrollX - (p.x - this.drag.x) / cam.zoom;
+      cam.scrollY = this.drag.scrollY - (p.y - this.drag.y) / cam.zoom;
+      this.clampCamera();
+    });
+    const endDrag = () => {
+      this.drag = null;
+    };
+    this.input.on('pointerup', endDrag);
+    this.input.on('pointerupoutside', endDrag);
+  }
+
+  /** Keep the office on screen. Phaser's visible world rect is CENTERED on
+   *  (scroll + half-viewport) and sized viewport/zoom — clamp that midpoint so
+   *  the view stays on the map, or pin it to the map center on any axis where
+   *  the view is larger than the map (letterbox). */
+  private clampCamera(): void {
     const cam = this.cameras.main;
     const worldW = MAP_W * TILE;
     const worldH = MAP_H * TILE;
-    const zoom = Math.min(this.scale.width / worldW, this.scale.height / worldH);
-    // Never below 1 (unreadably small) — tiny windows scroll-crop instead.
-    cam.setZoom(Math.max(1, zoom));
-    cam.centerOn(worldW / 2, worldH / 2);
+    const viewW = cam.width / cam.zoom;
+    const viewH = cam.height / cam.zoom;
+    const midX =
+      viewW >= worldW
+        ? worldW / 2
+        : Phaser.Math.Clamp(cam.scrollX + cam.width / 2, viewW / 2, worldW - viewW / 2);
+    const midY =
+      viewH >= worldH
+        ? worldH / 2
+        : Phaser.Math.Clamp(cam.scrollY + cam.height / 2, viewH / 2, worldH - viewH / 2);
+    cam.scrollX = midX - cam.width / 2;
+    cam.scrollY = midY - cam.height / 2;
   }
 
   private indexMonitor(x: number, y: number, img: Phaser.GameObjects.Image): void {

--- a/packages/plugin-channel-virtual-office/src/frontend/game/SpriteActor.ts
+++ b/packages/plugin-channel-virtual-office/src/frontend/game/SpriteActor.ts
@@ -58,8 +58,12 @@ export class SpriteActor extends Phaser.GameObjects.Container {
 
     // Click → open this worker's chat. Subagents are informational only, but
     // selecting them is harmless (the panel just has nothing to drive).
+    // Fires on pointerUP with a movement threshold so camera drags that start
+    // on a sprite pan the view instead of opening the panel.
     this.sprite.setInteractive({ useHandCursor: true });
-    this.sprite.on('pointerdown', () => onClick(snapshot.id));
+    this.sprite.on('pointerup', (pointer: Phaser.Input.Pointer) => {
+      if (pointer.getDistance() < 6) onClick(snapshot.id);
+    });
   }
 
   /** Reflect this frame's snapshot. `timeMs` drives idle micro-animation. */

--- a/packages/plugin-channel-virtual-office/src/frontend/game/createGame.ts
+++ b/packages/plugin-channel-virtual-office/src/frontend/game/createGame.ts
@@ -37,5 +37,7 @@ export function createGame(
     },
     scene,
   });
+  // Debug handle for headless smoke probes (harmless in production).
+  (window as unknown as Record<string, unknown>).__officeGame = game;
   return { game, scene };
 }


### PR DESCRIPTION
## What

Follow-up to #177 (the office merged while this was being finished): camera controls for the virtual office.

- **Wheel zoom** (and macOS trackpad pinch, which browsers deliver as ctrl+wheel), anchored at the cursor — the world point under the pointer stays fixed while zooming. Range: the fit-the-whole-office view (floor) up to 8×.
- **Drag to pan**, clamped so the office never leaves the screen; any axis where the view is larger than the map stays centered (letterbox).
- Sprite and background clicks moved from pointer-down to pointer-up with a 6px movement threshold, so drags that start on a sprite pan the camera instead of opening/closing the chat panel.

## Notes

The clamp math uses Phaser's actual camera model — the visible world rect is **centered on `scroll + half-viewport`** and sized `viewport/zoom`. A first cut assumed a top-left scroll convention, which shoved the view off the map (verified and fixed against a live probe of camera state in headless Chrome).

## Test plan

- Package suite green (100 tests); frontend strict typecheck clean.
- Headless-Chrome visual run against a live `moxxy office`: zoom-in fills the window anchored at the cursor, drag pans across the map with no dead space, zoom-out clamps at the centered fit view, and sprite clicks still open the panel after pans.