### PR TITLE
feat(mobile): mobile-poc Expo app — QR pairing + chat over the mobile channel

### DIFF
--- a/.changeset/mobile-poc-app.md
+++ b/.changeset/mobile-poc-app.md
@@ -1,0 +1,8 @@
+---
+'@moxxy/client-transport-ws': patch
+'@moxxy/mobile-poc': patch
+---
+
+New `apps/mobile-poc`: a minimal Expo SDK 54 proof-of-concept app that pairs with `moxxy mobile` by scanning its QR code and chats with the agent through the shared `@moxxy/client-core` hooks over the WebSocket bridge (including the permission ask round-trip). Single screen, no router/styling stack — replaces the removed full mobile app with the smallest thing that proves the channel works end to end.
+
+`@moxxy/client-transport-ws` grows the client half of the pairing contract: `splitConnectUrl` strips the `?t=` pairing token off a scanned QR URL so it can be presented via the `Sec-WebSocket-Protocol` bearer entry instead of riding the live WS URL. The app consumes it at boot, and the desktop's QR ↔ app round-trip test now asserts against this shared function (it previously imported the removed `apps/mobile`'s parser, which broke `pnpm typecheck` on main).

--- a/.changeset/ws-bridge-ios-origin.md
+++ b/.changeset/ws-bridge-ios-origin.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/cli': patch
+---
+
+Fix the WS bridge rejecting real iOS devices at the upgrade handshake. iOS React Native (SocketRocket) sends an `Origin` header derived from the WS URL it dials (ws→http, wss→https) — it is not a browser-only signal — so the Origin default-deny dropped every iPhone pairing with `moxxy mobile` or the desktop gateway. The bridge server now supports `setAllowedOrigins` on the live listener (a tunnel URL is only assigned after start), and both the mobile channel and the desktop mobile gateway allow-list exactly the origins of the URLs they advertise: the tunnel origin, the LAN/loopback connect-URL origin, and the loopback spellings for simulators. Default-deny for everything else is unchanged.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -57,6 +57,15 @@ smallest app proving the mobile channel end to end (QR pairing → chat → ask 
   (non-Expo-Go) pinning story; until then, treat LAN binds as trusted-network-only.
 - **M2 [low, dx]** the PoC consumes workspace packages as built `dist` — editing any
   `@moxxy/*` package needs a root `pnpm build` before Metro sees it (documented in the README).
+- **Retired (2026-06-11): real iPhones were rejected by the Origin default-deny.** The A27
+  hardening assumed "native clients send no `Origin` header" — false on iOS: React Native's
+  WebSocket (SocketRocket) sends an Origin derived from the dialed URL (ws→http, wss→https,
+  default ports elided), so every real-device pairing (tunnel or LAN) failed at the upgrade
+  with `rejected browser-origin upgrade`. Android (OkHttp) and Node send none, which is why
+  tests/simulator-on-node never caught it. Fix: `WebSocketBridgeServer.setAllowedOrigins`
+  (live update — the tunnel URL only exists after start) + the mobile channel and desktop
+  gateway allow-list exactly the origins of the URLs they advertise (`advertisedOrigins` /
+  `connectUrlOrigin` in `plugin-channel-mobile/pairing.ts`). Default-deny otherwise unchanged.
 
 ## 2026-06-10 round-2 audit intake — mobile gateway
 

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -37,6 +37,27 @@ pass also **retired the plugins-admin CLI install-hardening + dedup items** (for
 
 ---
 
+## 2026-06-11 — mobile-poc app intake
+
+`apps/mobile-poc` (Expo SDK 54, single screen) replaces the removed `apps/mobile` as the
+smallest app proving the mobile channel end to end (QR pairing → chat → ask round-trip).
+
+- **Retired:** the "remove broken apps" commit (508f5d8) left `apps/desktop`'s
+  `ws-bridge.test.ts` importing the deleted `apps/mobile/src/pairingQr` — `pnpm typecheck`
+  on main was red. The client half of the pairing contract (`splitConnectUrl`) now lives in
+  `@moxxy/client-transport-ws`, and both the PoC app and the desktop round-trip test consume
+  it from there (no app→app imports).
+- **M1 [med, security/feature gap] LAN pairing is cleartext `ws://`** — the bridge
+  (`createWebSocketTransportServer`) constructs a plain `WebSocketServer` with no TLS
+  option, so a `MOXXY_MOBILE_HOST=0.0.0.0` bind sends the bearer handshake unencrypted on
+  the LAN. Even with a TLS option, RN/Expo Go cannot trust a self-signed cert for a private
+  IP (no pinning escape hatch), so the secure phone path is the tunnel (`wss://`, publicly
+  trusted cert) — the PoC README now leads with it. **Action** if direct-LAN encryption ever
+  matters: add an optional `https.Server` (cert/key) to `WebSocketBridgeOptions` + a dev-build
+  (non-Expo-Go) pinning story; until then, treat LAN binds as trusted-network-only.
+- **M2 [low, dx]** the PoC consumes workspace packages as built `dist` — editing any
+  `@moxxy/*` package needs a root `pnpm build` before Metro sees it (documented in the README).
+
 ## 2026-06-10 round-2 audit intake — mobile gateway
 
 A targeted round-2 audit of the runtime mobile gateway shipped by PR #141 (the

--- a/apps/desktop/electron/main/ws-bridge.test.ts
+++ b/apps/desktop/electron/main/ws-bridge.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { parsePairingQrPayload } from '../../../mobile/src/pairingQr';
+import { splitConnectUrl } from '@moxxy/client-transport-ws';
 import type { MobileGatewayStatus } from '@moxxy/desktop-ipc-contract';
 import type { WebSocketBridgeServer, WebSocketCommandBus } from '@moxxy/ipc-server-ws';
 import {
@@ -368,19 +368,19 @@ describe('MobileGatewayManager', () => {
 // what the shipped mobile app accepts. We import the app's own parser and feed
 // it the connectUrl the gateway built. -------------------------------------
 describe('QR ↔ mobile app round-trip', () => {
-  it('the gateway connectUrl parses cleanly via the app parsePairingQrPayload', async () => {
+  it('the gateway connectUrl parses cleanly via the app splitConnectUrl', async () => {
     const { rt } = makeRuntime({ userData });
     const mgr = new MobileGatewayManager(rt);
     const status = await mgr.start();
     expect(status.connectUrl).toBeTruthy();
 
     // The mobile app scans this exact string off the QR.
-    const parsed = parsePairingQrPayload(status.connectUrl!);
+    const parsed = splitConnectUrl(status.connectUrl!);
     // The token round-trips intact…
     expect(parsed.token).toBe(status.token);
     // …and the bare gateway URL is a ws:// address with the bound port and the
     // ?t= credential stripped (the app presents the token via the subprotocol).
-    expect(parsed.gatewayUrl).toMatch(/^ws:\/\/[^/]+:8765$/);
-    expect(parsed.gatewayUrl).not.toContain('?t=');
+    expect(parsed.url).toMatch(/^ws:\/\/[^/]+:8765\/?$/);
+    expect(parsed.url).not.toContain('?');
   });
 });

--- a/apps/desktop/electron/main/ws-bridge.test.ts
+++ b/apps/desktop/electron/main/ws-bridge.test.ts
@@ -92,6 +92,7 @@ describe('rotateWsBridgeToken', () => {
       onConnection: () => undefined,
       close: () => Promise.resolve(),
       rotateAuthToken: (next: string) => calls.push(next),
+      setAllowedOrigins: () => undefined,
       clientCount: () => 0,
     };
     const result = rotateWsBridgeToken(userData, fakeServer);
@@ -119,6 +120,7 @@ describe('rotateWsBridgeToken', () => {
       onConnection: () => undefined,
       close: () => Promise.resolve(),
       rotateAuthToken: (next: string) => calls.push(next),
+      setAllowedOrigins: () => undefined,
       clientCount: () => 0,
     };
     const result = rotateWsBridgeToken(userData, fakeServer);
@@ -139,11 +141,13 @@ function makeFakeServer(): {
   server: WebSocketBridgeServer;
   closed: () => boolean;
   rotations: string[];
+  originSets: string[][];
   setClients: (n: number) => void;
 } {
   let isClosed = false;
   let clients = 0;
   const rotations: string[] = [];
+  const originSets: string[][] = [];
   const server: WebSocketBridgeServer = {
     address: 'ws://0.0.0.0:8765',
     onConnection: () => undefined,
@@ -154,12 +158,16 @@ function makeFakeServer(): {
     rotateAuthToken: (next: string) => {
       rotations.push(next);
     },
+    setAllowedOrigins: (origins: readonly string[]) => {
+      originSets.push([...origins]);
+    },
     clientCount: () => clients,
   };
   return {
     server,
     closed: () => isClosed,
     rotations,
+    originSets,
     setClients: (n: number) => {
       clients = n;
     },
@@ -213,7 +221,8 @@ describe('MobileGatewayManager', () => {
   });
 
   it('start binds the LAN-advertised interface (0.0.0.0) and produces a connectUrl', async () => {
-    const { rt, startCalls } = makeRuntime({ userData });
+    const fake = makeFakeServer();
+    const { rt, startCalls } = makeRuntime({ userData, startSpy: () => fake.server });
     const mgr = new MobileGatewayManager(rt);
     const status = await mgr.start();
     expect(status.enabled).toBe(true);
@@ -224,6 +233,12 @@ describe('MobileGatewayManager', () => {
     // The connectUrl carries the token as ?t= and never advertises 0.0.0.0.
     expect(status.connectUrl).toMatch(/^ws:\/\/[^/]+:8765\/\?t=[0-9a-f]{64}$/);
     expect(status.connectUrl).not.toContain('0.0.0.0');
+    // The advertised URL's origin is allow-listed post-bind — iOS RN presents
+    // it at the upgrade (Origin default-deny would reject iPhones otherwise).
+    expect(fake.originSets).toHaveLength(1);
+    const origins = fake.originSets[0] ?? [];
+    expect(origins).toContain('http://127.0.0.1:8765');
+    expect(origins.every((o) => !o.includes('0.0.0.0'))).toBe(true);
   });
 
   it('setEnabled(true/false) starts, persists, stops, and notifies', async () => {

--- a/apps/desktop/electron/main/ws-bridge.ts
+++ b/apps/desktop/electron/main/ws-bridge.ts
@@ -31,7 +31,11 @@
 import path from 'node:path';
 
 import { resolveChannelToken, rotateChannelToken } from '@moxxy/sdk';
-import { advertisedHost, buildConnectUrl } from '@moxxy/plugin-channel-mobile/pairing';
+import {
+  advertisedHost,
+  advertisedOrigins,
+  buildConnectUrl,
+} from '@moxxy/plugin-channel-mobile/pairing';
 import type { WebSocketBridgeOptions, WebSocketBridgeServer } from '@moxxy/ipc-server-ws';
 import type { MobileGatewayStatus } from '@moxxy/desktop-ipc-contract';
 
@@ -183,6 +187,10 @@ export class MobileGatewayManager {
     this.server = server;
     this.boundHost = host;
     this.boundPort = port;
+    // iOS React Native presents the dialed URL's origin at the upgrade —
+    // allow-list the URLs we advertise (QR / Settings tab) or iPhones are
+    // rejected by the Origin default-deny.
+    server.setAllowedOrigins(advertisedOrigins(host, port));
   }
 
   /**
@@ -272,6 +280,11 @@ export class MobileGatewayManager {
     // been an ephemeral 0).
     const m = /:(\d+)$/.exec(this.server.address);
     this.boundPort = m ? Number(m[1]) : port;
+    // iOS React Native presents the dialed URL's origin at the upgrade —
+    // allow-list the URLs we advertise (QR / Settings tab) or iPhones are
+    // rejected by the Origin default-deny. Set post-bind so an ephemeral
+    // port (0) resolves to the real one.
+    this.server.setAllowedOrigins(advertisedOrigins(host, this.boundPort));
     console.log(`[moxxy] mobile gateway listening on ${this.server.address}`);
     return this.status();
   }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -52,6 +52,7 @@
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
+    "@moxxy/client-transport-ws": "workspace:*",
     "@moxxy/tsconfig": "workspace:*",
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/react": "^16.1.0",

--- a/apps/mobile-poc/.gitignore
+++ b/apps/mobile-poc/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.expo/
+dist/
+web-build/
+*.tsbuildinfo

--- a/apps/mobile-poc/README.md
+++ b/apps/mobile-poc/README.md
@@ -1,0 +1,67 @@
+# @moxxy/mobile-poc
+
+The smallest Expo app (SDK 54) that proves the mobile channel end to end: scan
+the QR `moxxy mobile` prints, connect to the runner's WebSocket bridge, and
+chat with the agent — including the permission/approval ask round-trip.
+
+It is a single screen on purpose. No router, no styling stack, no
+voice/attachments: the connection + chat path runs entirely through the shared
+`@moxxy/client-core` hooks over `@moxxy/client-transport-ws` — the same
+headless client layer the desktop renderer uses.
+
+## Run it
+
+1. Start the channel on this machine (from the repo root, after `pnpm build`):
+
+   ```sh
+   moxxy mobile
+   ```
+
+   For a real phone the bridge must be reachable beyond loopback. Prefer a
+   tunnel — the QR then carries a `wss://` URL, so the whole connection
+   (token handshake included) is TLS-encrypted with a publicly trusted cert:
+
+   ```sh
+   MOXXY_MOBILE_TUNNEL=cloudflared moxxy mobile
+   ```
+
+   Alternatively bind on the LAN (`MOXXY_MOBILE_HOST=0.0.0.0 moxxy mobile`) —
+   but that path is plain `ws://`: a phone can't trust a self-signed cert for
+   a private IP (no CA issues one, and RN/Expo Go has no cert-pinning escape
+   hatch), so LAN traffic — the bearer handshake included — rides cleartext.
+   Fine on a trusted home network, not elsewhere. Either way the terminal
+   prints a QR with the connect URL + pairing token.
+
+2. Start the app and open it in Expo Go (or a dev build):
+
+   ```sh
+   pnpm --filter @moxxy/mobile-poc start
+   ```
+
+3. Scan the QR from step 1 inside the app. You're chatting with the runner's
+   session; tool permission prompts surface as Allow/Deny cards.
+
+### Simulator shortcut (no camera)
+
+Bake the connect URL in via env and the app skips the scanner — loopback works
+because the simulator shares the host's network:
+
+```sh
+EXPO_PUBLIC_MOXXY_WS_URL='ws://127.0.0.1:8765/?t=<token>' pnpm --filter @moxxy/mobile-poc start
+```
+
+(`?t=` is split off and presented as the WebSocket bearer subprotocol, exactly
+like a scanned QR; `EXPO_PUBLIC_MOXXY_WS_TOKEN` works too if you prefer the
+token separate.)
+
+## Notes
+
+- The token never rides the live WS URL: `src/boot.ts` strips `?t=` from the
+  scanned pairing URL and authenticates via the `Sec-WebSocket-Protocol`
+  bearer entry (`moxxy.bearer.<token>`).
+- `metro.config.js` is monorepo-aware: it watches the repo root, resolves the
+  hoisted pnpm `node_modules`, and pins react/react-native to the app's copy so
+  workspace packages' own React (kept for their vitest suites) never bundles.
+- The shared packages are consumed as their built `dist`, so run `pnpm build`
+  at the repo root before `expo start` (and after editing any `@moxxy/*`
+  package).

--- a/apps/mobile-poc/app.json
+++ b/apps/mobile-poc/app.json
@@ -1,0 +1,35 @@
+{
+  "expo": {
+    "name": "moxxy POC",
+    "slug": "moxxy-mobile-poc",
+    "version": "0.0.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "dark",
+    "newArchEnabled": true,
+    "ios": {
+      "infoPlist": {
+        "NSCameraUsageDescription": "Scan the connection QR shown by `moxxy mobile` to connect to your agent.",
+        "NSLocalNetworkUsageDescription": "Connect to the moxxy runner on your computer over your local Wi-Fi network."
+      }
+    },
+    "android": {
+      "permissions": ["android.permission.CAMERA"]
+    },
+    "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "usesCleartextTraffic": true
+          }
+        }
+      ],
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "Scan the connection QR shown by `moxxy mobile` to connect to your agent."
+        }
+      ]
+    ]
+  }
+}

--- a/apps/mobile-poc/babel.config.js
+++ b/apps/mobile-poc/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/apps/mobile-poc/index.js
+++ b/apps/mobile-poc/index.js
@@ -1,0 +1,5 @@
+import { registerRootComponent } from 'expo';
+
+import App from './src/App';
+
+registerRootComponent(App);

--- a/apps/mobile-poc/metro.config.js
+++ b/apps/mobile-poc/metro.config.js
@@ -1,0 +1,42 @@
+// Metro, made monorepo-aware so it resolves the shared `@moxxy/*` packages out
+// of the pnpm workspace. SDK 54's `expo/metro-config` already follows symlinks
+// and detects monorepos, so we only *extend* its defaults: watch the repo root,
+// also search the hoisted node_modules, and force a single copy of React. The
+// shared packages are consumed as their built `dist` (their `exports` map
+// points there), so their `.js`-authored relative specifiers resolve under
+// Metro exactly as under Node ESM.
+const { getDefaultConfig } = require('expo/metro-config');
+const path = require('node:path');
+
+const projectRoot = __dirname;
+const workspaceRoot = path.resolve(projectRoot, '../..');
+
+const config = getDefaultConfig(projectRoot);
+
+config.watchFolders = [...new Set([...config.watchFolders, workspaceRoot])];
+config.resolver.nodeModulesPaths = [
+  ...new Set([
+    ...(config.resolver.nodeModulesPaths ?? []),
+    path.resolve(projectRoot, 'node_modules'),
+    path.resolve(workspaceRoot, 'node_modules'),
+  ]),
+];
+
+// The workspace packages keep their own (older) React in node_modules for
+// their vitest suites; under pnpm Metro would resolve `react` from there and
+// bundle two Reacts, breaking hooks. Pin react/react-dom to the app's copy.
+const singletons = ['react', 'react-dom'];
+const defaultResolveRequest = config.resolver.resolveRequest;
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  const resolve = defaultResolveRequest ?? context.resolveRequest;
+  if (singletons.some((s) => moduleName === s || moduleName.startsWith(`${s}/`))) {
+    return resolve(
+      { ...context, originModulePath: path.join(projectRoot, 'index.js') },
+      moduleName,
+      platform,
+    );
+  }
+  return resolve(context, moduleName, platform);
+};
+
+module.exports = config;

--- a/apps/mobile-poc/package.json
+++ b/apps/mobile-poc/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@moxxy/mobile-poc",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Minimal Expo (SDK 54) proof-of-concept: scan the QR `moxxy mobile` prints, connect to the runner's WebSocket bridge through the shared @moxxy/client-core hooks, and chat with the agent. Deliberately a single screen with no router/styling stack — the smallest app that proves the pairing + chat loop end to end.",
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@expo/metro-runtime": "~6.1.2",
+    "@moxxy/client-core": "workspace:*",
+    "@moxxy/client-transport-ws": "workspace:*",
+    "@moxxy/sdk": "workspace:*",
+    "expo": "~54.0.0",
+    "expo-build-properties": "~1.0.10",
+    "expo-camera": "~17.0.10",
+    "expo-status-bar": "~3.0.9",
+    "react": "19.1.0",
+    "react-native": "0.81.5"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.0",
+    "@types/react": "~19.1.0",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/mobile-poc/src/App.tsx
+++ b/apps/mobile-poc/src/App.tsx
@@ -1,0 +1,348 @@
+/**
+ * The PoC chat screen. Everything here that ISN'T a React Native primitive
+ * comes from the SAME shared packages the desktop renderer uses —
+ * `ConnectionBridge`, `ChatStoreBridge`, `useConnection`, `useChat`,
+ * `useActiveWorkspaceId`, `askStore` — over the WebSocket transport. The render
+ * layer is bare on purpose: the point is proving QR pairing + the shared
+ * store/model/hook code path drive a live chat loop on RN, nothing more.
+ */
+
+import React, { useState } from 'react';
+import {
+  FlatList,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import { CameraView, useCameraPermissions } from 'expo-camera';
+import type { MoxxyEvent } from '@moxxy/sdk';
+import {
+  askStore,
+  ChatStoreBridge,
+  ConnectionBridge,
+  useActiveAsk,
+  useActiveWorkspaceId,
+  useChat,
+  useConnection,
+} from '@moxxy/client-core';
+import { bootMobile } from './boot';
+
+// If a URL is baked in via env, connect straight away; otherwise show the QR
+// scanner so the user pairs by scanning the code `moxxy mobile` prints.
+// (The env path is for simulators on this machine — no camera needed.)
+const ENV_URL = process.env.EXPO_PUBLIC_MOXXY_WS_URL;
+const ENV_TOKEN = process.env.EXPO_PUBLIC_MOXXY_WS_TOKEN;
+
+export default function App(): React.JSX.Element {
+  const [connected, setConnected] = useState<boolean>(() => {
+    if (ENV_URL) {
+      bootMobile(ENV_URL, ENV_TOKEN);
+      return true;
+    }
+    return false;
+  });
+
+  if (!connected) {
+    return (
+      <ConnectScreen
+        onConnect={(url) => {
+          // The scanned QR embeds the token as ?t=…; bootMobile strips it from
+          // the WS URL and presents it via the subprotocol bearer entry.
+          bootMobile(url);
+          setConnected(true);
+        }}
+      />
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.root}>
+      <StatusBar style="light" />
+      <ConnectionBridge />
+      <ChatStoreBridge />
+      <Chat />
+    </SafeAreaView>
+  );
+}
+
+/** Pair by scanning the QR `moxxy mobile` prints. */
+function ConnectScreen({ onConnect }: { onConnect: (url: string) => void }): React.JSX.Element {
+  const [permission, requestPermission] = useCameraPermissions();
+  const [scanned, setScanned] = useState(false);
+
+  if (!permission) {
+    return (
+      <SafeAreaView style={styles.center}>
+        <Text style={styles.centerText}>Preparing camera…</Text>
+      </SafeAreaView>
+    );
+  }
+  if (!permission.granted) {
+    return (
+      <SafeAreaView style={styles.center}>
+        <Text style={styles.centerText}>
+          Camera access is needed to scan the connection QR from `moxxy mobile`.
+        </Text>
+        <Pressable style={styles.send} onPress={() => void requestPermission()}>
+          <Text style={styles.sendLabel}>Grant camera access</Text>
+        </Pressable>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <View style={styles.flex}>
+      <CameraView
+        style={styles.flex}
+        barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+        onBarcodeScanned={
+          scanned
+            ? undefined
+            : ({ data }) => {
+                if (/^wss?:\/\//i.test(data)) {
+                  setScanned(true);
+                  onConnect(data);
+                }
+              }
+        }
+      />
+      <SafeAreaView style={styles.scanHint}>
+        <Text style={styles.scanHintText}>Scan the QR printed by `moxxy mobile`</Text>
+      </SafeAreaView>
+    </View>
+  );
+}
+
+function Chat(): React.JSX.Element {
+  const workspaceId = useActiveWorkspaceId();
+  const { snapshot } = useConnection(workspaceId);
+  const { events, streamingText, sending, send } = useChat(workspaceId);
+  const [draft, setDraft] = useState('');
+
+  const phase = snapshot?.phase.phase ?? 'connecting…';
+  const ready = !!workspaceId;
+  const lines = events
+    .map((event) => ({ event, line: renderLine(event) }))
+    .filter((e): e is { event: MoxxyEvent; line: Line } => e.line !== null);
+
+  const onSend = (): void => {
+    const text = draft.trim();
+    if (!text || !ready) return;
+    setDraft('');
+    void send(text);
+  };
+
+  return (
+    <View style={styles.flex}>
+      <Text style={styles.status}>
+        moxxy · {phase}
+        {ready ? '' : ' · waiting for a workspace'}
+      </Text>
+
+      <FlatList
+        style={styles.flex}
+        contentContainerStyle={styles.listContent}
+        data={lines}
+        keyExtractor={({ event }) => event.id}
+        renderItem={({ item }) => (
+          <View style={[styles.event, item.line.who === 'you' && styles.eventUser]}>
+            <Text style={styles.eventWho}>{item.line.who}</Text>
+            <Text style={styles.eventText}>{item.line.text}</Text>
+          </View>
+        )}
+        ListFooterComponent={
+          streamingText ? <Text style={styles.streaming}>{streamingText}</Text> : null
+        }
+        ListEmptyComponent={<Text style={styles.empty}>No messages yet — say hello.</Text>}
+      />
+
+      <AskPrompt workspaceId={workspaceId} />
+
+      <View style={styles.composer}>
+        <TextInput
+          style={styles.input}
+          value={draft}
+          onChangeText={setDraft}
+          placeholder="Message moxxy…"
+          placeholderTextColor={palette.textDim}
+          editable={ready}
+          onSubmitEditing={onSend}
+          returnKeyType="send"
+        />
+        <Pressable
+          style={[styles.send, (!ready || sending) && styles.sendDisabled]}
+          disabled={!ready || sending}
+          onPress={onSend}
+        >
+          <Text style={styles.sendLabel}>{sending ? '…' : 'Send'}</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+/** Permission/approval prompt — proves the ask path works over the bridge too.
+ *  The interactive resolver in the host parks the runner until we respond. */
+function AskPrompt({ workspaceId }: { workspaceId: string | null }): React.JSX.Element | null {
+  const ask = useActiveAsk(workspaceId);
+  if (!ask) return null;
+
+  const allow = (): void => {
+    if (ask.kind === 'permission') askStore.respond(ask.requestId, { mode: 'allow' });
+    else askStore.respond(ask.requestId, { optionId: ask.approval?.options[0]?.id ?? '' });
+  };
+  const deny = (): void => {
+    if (ask.kind === 'permission') askStore.respond(ask.requestId, { mode: 'deny' });
+    else
+      askStore.respond(ask.requestId, {
+        optionId:
+          ask.approval?.options.find((o) => o.danger)?.id ?? ask.approval?.defaultOptionId ?? '',
+      });
+  };
+
+  const label =
+    ask.kind === 'permission' ? `Allow tool "${ask.tool?.name}"?` : 'Approval requested';
+
+  return (
+    <View style={styles.ask}>
+      <Text style={styles.askLabel}>{label}</Text>
+      <View style={styles.askButtons}>
+        <Pressable style={styles.askBtn} onPress={allow}>
+          <Text style={styles.askBtnLabel}>Allow</Text>
+        </Pressable>
+        <Pressable style={[styles.askBtn, styles.askDeny]} onPress={deny}>
+          <Text style={styles.askBtnLabel}>Deny</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+interface Line {
+  readonly who: 'you' | 'moxxy' | 'tool' | 'error';
+  readonly text: string;
+}
+
+/** Human-readable line for the transcript-bearing events; null skips the rest
+ *  (chunks ride `streamingText`, provider/plugin noise stays off a PoC screen). */
+function renderLine(event: MoxxyEvent): Line | null {
+  switch (event.type) {
+    case 'user_prompt':
+      return { who: 'you', text: event.text };
+    case 'assistant_message':
+      return event.content.trim() ? { who: 'moxxy', text: event.content } : null;
+    case 'tool_call_requested':
+      return { who: 'tool', text: `→ ${event.name}` };
+    case 'tool_result':
+      return { who: 'tool', text: event.ok ? '✓ done' : `✗ ${event.error?.message ?? 'failed'}` };
+    case 'error':
+      return { who: 'error', text: event.message };
+    default:
+      return null;
+  }
+}
+
+const palette = {
+  appBg: '#101014',
+  cardBg: '#1a1a21',
+  border: '#2a2a33',
+  text: '#f2f2f5',
+  textMuted: '#b7b7c2',
+  textDim: '#6f6f7c',
+  primary: '#6c5ce7',
+  primarySoft: '#27243d',
+  red: '#d63a4f',
+};
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: palette.appBg },
+  flex: { flex: 1 },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    gap: 16,
+    backgroundColor: palette.appBg,
+  },
+  centerText: { color: palette.text, textAlign: 'center', fontSize: 16 },
+  scanHint: { position: 'absolute', bottom: 0, left: 0, right: 0, alignItems: 'center', padding: 16 },
+  scanHintText: {
+    color: '#ffffff',
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 999,
+    overflow: 'hidden',
+  },
+  status: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    color: palette.text,
+    fontWeight: '600',
+    backgroundColor: palette.cardBg,
+    borderBottomWidth: 1,
+    borderBottomColor: palette.border,
+  },
+  listContent: { padding: 12, gap: 8 },
+  event: {
+    backgroundColor: palette.cardBg,
+    borderRadius: 10,
+    padding: 10,
+    gap: 2,
+  },
+  eventUser: { backgroundColor: palette.primarySoft },
+  eventWho: { color: palette.textDim, fontSize: 11, textTransform: 'uppercase' },
+  eventText: { color: palette.text, fontSize: 14 },
+  streaming: { color: palette.textMuted, fontStyle: 'italic', padding: 10 },
+  empty: { color: palette.textDim, textAlign: 'center', marginTop: 40 },
+  composer: {
+    flexDirection: 'row',
+    padding: 12,
+    gap: 8,
+    borderTopWidth: 1,
+    borderTopColor: palette.border,
+    backgroundColor: palette.cardBg,
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: palette.border,
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    color: palette.text,
+  },
+  send: {
+    backgroundColor: palette.primary,
+    borderRadius: 12,
+    paddingHorizontal: 18,
+    justifyContent: 'center',
+  },
+  sendDisabled: { opacity: 0.5 },
+  sendLabel: { color: '#ffffff', fontWeight: '700' },
+  ask: {
+    margin: 12,
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: palette.primarySoft,
+    borderWidth: 1,
+    borderColor: palette.primary,
+    gap: 8,
+  },
+  askLabel: { color: palette.text, fontWeight: '600' },
+  askButtons: { flexDirection: 'row', gap: 8 },
+  askBtn: {
+    flex: 1,
+    backgroundColor: palette.primary,
+    borderRadius: 10,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  askDeny: { backgroundColor: palette.red },
+  askBtnLabel: { color: '#ffffff', fontWeight: '700' },
+});

--- a/apps/mobile-poc/src/boot.ts
+++ b/apps/mobile-poc/src/boot.ts
@@ -1,0 +1,27 @@
+/**
+ * Wire the shared client layer to React Native: a WebSocket transport pointed
+ * at the bridge `moxxy mobile` (or the desktop gateway) listens on.
+ *
+ * The QR `moxxy mobile` prints embeds the pairing token as `?t=` (one scan
+ * carries everything), but the token must NOT ride the live WS URL — query
+ * strings leak through tunnel/proxy logs. So the scanned URL is split here:
+ * `?t=` is stripped and handed to the transport, which presents it via the
+ * `Sec-WebSocket-Protocol` bearer entry instead.
+ *
+ * Platform capabilities stay EMPTY (`configurePlatform({})`): this PoC has no
+ * voice/attachments/TTS surface, and client-core's optional-capability design
+ * makes the shared hooks degrade to their "unsupported" branch.
+ */
+
+import { configureTransport } from '@moxxy/client-core/transport';
+import { configurePlatform } from '@moxxy/client-core/platform';
+import { makeWsApi, splitConnectUrl } from '@moxxy/client-transport-ws';
+
+export function bootMobile(rawUrl: string, token?: string): void {
+  const split = splitConnectUrl(rawUrl);
+  const effectiveToken = token ?? split.token;
+  configureTransport(
+    makeWsApi({ url: split.url, ...(effectiveToken ? { token: effectiveToken } : {}) }),
+  );
+  configurePlatform({});
+}

--- a/apps/mobile-poc/tsconfig.json
+++ b/apps/mobile-poc/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "react-jsx",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true
+  },
+  "include": ["index.js", "src/**/*", "*.config.js"]
+}

--- a/packages/client-transport-ws/src/index.ts
+++ b/packages/client-transport-ws/src/index.ts
@@ -32,6 +32,7 @@ export {
   type WsClientStatus,
   type WsRpcClientOptions,
 } from './json-rpc-client.js';
+export { splitConnectUrl } from './pairing.js';
 
 /** Mirrors `MOXXY_WS_SUBPROTOCOL` in `@moxxy/sdk`. */
 const WS_SUBPROTOCOL = 'moxxy.v1';

--- a/packages/client-transport-ws/src/pairing.test.ts
+++ b/packages/client-transport-ws/src/pairing.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { splitConnectUrl } from './pairing.js';
+
+describe('splitConnectUrl', () => {
+  it('strips the ?t= token from a local pairing URL', () => {
+    expect(splitConnectUrl('ws://192.168.1.7:8765/?t=abc123')).toEqual({
+      url: 'ws://192.168.1.7:8765/',
+      token: 'abc123',
+    });
+  });
+
+  it('decodes a percent-encoded token (tunnel URL)', () => {
+    expect(splitConnectUrl('wss://foo.trycloudflare.com/?t=a%2Bb%3D')).toEqual({
+      url: 'wss://foo.trycloudflare.com/',
+      token: 'a+b=',
+    });
+  });
+
+  it('keeps other query params when removing the token', () => {
+    expect(splitConnectUrl('ws://host:8765/?t=tok&x=1')).toEqual({
+      url: 'ws://host:8765/?x=1',
+      token: 'tok',
+    });
+  });
+
+  it('passes a URL without a token through unchanged', () => {
+    expect(splitConnectUrl('ws://127.0.0.1:8765')).toEqual({ url: 'ws://127.0.0.1:8765' });
+  });
+
+  it('connects as-is when the token escape is malformed', () => {
+    expect(splitConnectUrl('ws://host:8765/?t=%zz')).toEqual({ url: 'ws://host:8765/?t=%zz' });
+  });
+});

--- a/packages/client-transport-ws/src/pairing.ts
+++ b/packages/client-transport-ws/src/pairing.ts
@@ -1,0 +1,30 @@
+/**
+ * Client-side parsing of the pairing URL a moxxy QR carries (`moxxy mobile`,
+ * the desktop gateway). The payload is the connect URL itself with the pairing
+ * token embedded as `?t=` — one scan carries everything:
+ *
+ *   ws://192.168.1.7:8765/?t=<token>        (LAN)
+ *   wss://xyz.trycloudflare.com/?t=<token>  (tunnel)
+ *
+ * The split yields the bare WS URL + the token: the token must never ride the
+ * live WS URL (query strings leak through tunnel/proxy logs), so callers hand
+ * it to {@link makeWsApi}, which presents it via the `Sec-WebSocket-Protocol`
+ * bearer entry instead. Regex, not `new URL` — Hermes' URL support is
+ * unreliable, and this module must stay RN-bundlable.
+ *
+ * This is the OTHER half of the contract `buildConnectUrl` (in
+ * `@moxxy/plugin-channel-mobile`) emits; the desktop's ws-bridge round-trip
+ * test feeds its gateway URL through this exact function.
+ */
+export function splitConnectUrl(scanned: string): { url: string; token?: string } {
+  const match = /[?&]t=([^&#]+)/.exec(scanned);
+  if (!match) return { url: scanned };
+  let token: string;
+  try {
+    token = decodeURIComponent(match[1]!);
+  } catch {
+    return { url: scanned }; // malformed escape — connect as-is
+  }
+  const url = scanned.replace(/([?&])t=[^&#]*&?/, '$1').replace(/[?&]$/, '');
+  return { url, token };
+}

--- a/packages/ipc-server-ws/src/auth.ts
+++ b/packages/ipc-server-ws/src/auth.ts
@@ -13,10 +13,13 @@
  *      URLs. Enable via `allowQueryToken` only where an already-paired legacy
  *      client must keep working.
  *
- * Origin: native clients send no `Origin` header and always pass that check; a
- * browser-initiated connection (which always carries one) is rejected unless
- * the origin is explicitly allow-listed — this stops a malicious webpage on the
- * victim's machine from even attempting the token handshake.
+ * Origin: a request WITHOUT an `Origin` header (Node `ws`, Android/OkHttp)
+ * always passes that check; one that carries an Origin is rejected unless it
+ * is explicitly allow-listed — this stops a malicious webpage on the victim's
+ * machine from even attempting the token handshake. NOTE the header is NOT a
+ * browser-only signal: iOS React Native (SocketRocket) sends an Origin derived
+ * from the WS URL itself (ws→http, wss→https), so a server real devices pair
+ * with must allow-list the origins of every URL it advertises.
  */
 
 import type { IncomingMessage } from 'node:http';
@@ -55,11 +58,12 @@ export function checkWsAuth(
 }
 
 /**
- * Reject browser-initiated upgrades: a request with an `Origin` header only
+ * Reject unknown-origin upgrades: a request with an `Origin` header only
  * passes when that origin is in `allowedOrigins` (case-insensitive). Requests
- * WITHOUT an Origin header (native clients — the mobile app, Node `ws`) always
- * pass; browsers cannot omit the header, so this cleanly fences off web pages
- * probing `ws://127.0.0.1`.
+ * WITHOUT an Origin header (Node `ws`, Android/OkHttp) always pass; browsers
+ * cannot omit the header, so this cleanly fences off web pages probing
+ * `ws://127.0.0.1`. iOS React Native DOES send one (derived from the WS URL),
+ * so the caller must allow-list every advertised URL's origin.
  */
 export function checkWsOrigin(
   req: IncomingMessage,

--- a/packages/ipc-server-ws/src/ws-transport.test.ts
+++ b/packages/ipc-server-ws/src/ws-transport.test.ts
@@ -91,6 +91,24 @@ describe('createWebSocketTransportServer', () => {
     ).resolves.toBeDefined();
   });
 
+  it('setAllowedOrigins admits an origin learned after start (a tunnel URL) without dropping clients', async () => {
+    const server = await startServer();
+    const existing = await connect(server.address, { headers: bearerHeaders });
+
+    // Unknown origin (the tunnel URL isn't assigned until the tunnel opens).
+    const tunnelOrigin = 'https://abcd.trycloudflare.example';
+    await expect(
+      connect(server.address, { headers: bearerHeaders, origin: tunnelOrigin }),
+    ).rejects.toThrow();
+
+    server.setAllowedOrigins([tunnelOrigin]);
+    await expect(
+      connect(server.address, { headers: bearerHeaders, origin: tunnelOrigin }),
+    ).resolves.toBeDefined();
+    // Nothing was revoked — the pre-existing connection survives the update.
+    expect(existing.readyState).toBe(existing.OPEN);
+  });
+
   it('caps concurrent connections', async () => {
     const server = await startServer({ maxConnections: 1 });
     await connect(server.address, { headers: bearerHeaders });

--- a/packages/ipc-server-ws/src/ws-transport.ts
+++ b/packages/ipc-server-ws/src/ws-transport.ts
@@ -121,9 +121,12 @@ export interface WebSocketBridgeOptions {
    *  belongs in the `Authorization` header or the `Sec-WebSocket-Protocol`
    *  bearer entry, never the URL. */
   readonly allowQueryToken?: boolean;
-  /** Browser origins allowed to connect. Default `[]`: every upgrade carrying
-   *  an `Origin` header (i.e. browser-initiated) is rejected; native clients
-   *  send no Origin and are unaffected. */
+  /** Origins allowed to connect. Default `[]`: every upgrade carrying an
+   *  `Origin` header is rejected. Browsers always send one — but so does iOS
+   *  React Native (SocketRocket derives it from the WS URL: ws→http,
+   *  wss→https), so a bridge that real devices pair with must allow-list the
+   *  origins of every URL it advertises. Origins learned only after start
+   *  (a tunnel URL) go in via {@link WebSocketBridgeServer.setAllowedOrigins}. */
   readonly allowedOrigins?: readonly string[];
   /** Max concurrent connections (default 8); excess upgrades are rejected. */
   readonly maxConnections?: number;
@@ -145,6 +148,15 @@ export interface WebSocketBridgeServer extends TransportServer {
    * persist `next` first (e.g. `rotateChannelToken` in `@moxxy/sdk`).
    */
   rotateAuthToken(next: string): void;
+  /**
+   * Replace the Origin allow-list on the LIVE server. Needed because some
+   * allowed origins are only known after the listener is up — a tunnel
+   * (cloudflared/ngrok) URL is assigned once the tunnel opens, and iOS React
+   * Native clients present that URL's https origin at the upgrade. Affects
+   * future handshakes only; established connections stay up (unlike
+   * `rotateAuthToken`, nothing is being revoked on the additive path).
+   */
+  setAllowedOrigins(origins: readonly string[]): void;
   /** Number of clients currently connected — surfaced so a pairing UI (the
    *  desktop's Settings → Mobile tab) can show "1 device connected". */
   clientCount(): number;
@@ -161,6 +173,7 @@ export async function createWebSocketTransportServer(
   const host = opts.host ?? '127.0.0.1';
   const maxConnections = opts.maxConnections ?? DEFAULT_MAX_CONNECTIONS;
   let currentToken = opts.authToken;
+  let currentAllowedOrigins: readonly string[] = opts.allowedOrigins ?? [];
   let connections = 0;
 
   const wss = new WebSocketServer({
@@ -168,7 +181,7 @@ export async function createWebSocketTransportServer(
     port: opts.port,
     maxPayload: opts.maxPayloadBytes ?? 64 * 1024 * 1024,
     verifyClient: (info: { req: IncomingMessage }) => {
-      if (!checkWsOrigin(info.req, opts.allowedOrigins)) {
+      if (!checkWsOrigin(info.req, currentAllowedOrigins)) {
         console.warn(
           `[moxxy] ws bridge: rejected browser-origin upgrade (Origin: ${String(info.req.headers.origin)})`,
         );
@@ -216,6 +229,9 @@ export async function createWebSocketTransportServer(
     rotateAuthToken(next: string): void {
       currentToken = next;
       for (const client of wss.clients) client.terminate();
+    },
+    setAllowedOrigins(origins: readonly string[]): void {
+      currentAllowedOrigins = [...origins];
     },
     clientCount(): number {
       return connections;

--- a/packages/plugin-channel-mobile/src/channel.ts
+++ b/packages/plugin-channel-mobile/src/channel.ts
@@ -20,7 +20,9 @@ import { MobileSessionHost } from './single-session-host.js';
 import { resolveMobileToken, rotateMobileToken } from './token.js';
 import {
   advertisedHost,
+  advertisedOrigins,
   buildConnectUrl,
+  connectUrlOrigin,
   isLoopbackHost,
   normalizeTunnelChoice,
   resolveBindHost,
@@ -109,10 +111,17 @@ export class MobileChannel implements Channel<MobileStartOpts> {
     host.register(); // populate the method map BEFORE accepting connections
     host.wire(); // stream events + install the ask resolvers
 
+    // iOS React Native sends an `Origin` header derived from the WS URL it
+    // dials (Android/Node send none), so every URL this channel advertises
+    // must have its origin allow-listed or real iPhones are rejected at the
+    // upgrade. Local origins are known now; the tunnel origin is added below
+    // once the tunnel URL is assigned.
+    const localOrigins = advertisedOrigins(this.bindHost, this.port);
     const server = await startWsBridge(bus, {
       port: this.port,
       host: this.bindHost,
       authToken: this.token,
+      allowedOrigins: localOrigins,
       // Back-compat ONLY: the QR this channel prints embeds the token as `?t=`
       // (pairing payload); current apps strip it and authenticate via the
       // Sec-WebSocket-Protocol bearer entry, but older installed builds still
@@ -129,6 +138,7 @@ export class MobileChannel implements Channel<MobileStartOpts> {
       try {
         this.tunnel = await provider.open({ port: this.port, host: this.bindHost });
         tunnelUrl = this.tunnel.url;
+        server.setAllowedOrigins([...localOrigins, connectUrlOrigin(tunnelUrl)]);
         this.logger?.info?.('mobile tunnel open', { provider: provider.name, url: tunnelUrl });
       } catch (err) {
         this.logger?.warn?.('mobile tunnel failed; using the local URL', {

--- a/packages/plugin-channel-mobile/src/pairing.ts
+++ b/packages/plugin-channel-mobile/src/pairing.ts
@@ -127,3 +127,36 @@ export function buildConnectUrl(opts: {
   }
   return `ws://${opts.localHost}:${opts.port}/?t=${t}`;
 }
+
+/**
+ * The `Origin` header a client dialing `url` will present, when its WebSocket
+ * implementation sends one. Browsers send the page origin, but iOS React
+ * Native (SocketRocket) derives an Origin from the WS URL itself — ws→http,
+ * wss→https, default ports elided — so the bridge must allow-list the origin
+ * of every URL it advertises or real iOS devices are rejected at the upgrade
+ * handshake. Accepts ws/wss connect URLs and http/https tunnel URLs alike.
+ */
+export function connectUrlOrigin(url: string): string {
+  const u = new URL(url);
+  const secure = u.protocol === 'wss:' || u.protocol === 'https:';
+  // WHATWG URL elides the scheme-default port from `host` (ws:80 / wss:443),
+  // matching SocketRocket's own default-port elision after scheme mapping.
+  return `${secure ? 'https' : 'http'}://${u.host}`;
+}
+
+/**
+ * Every Origin a correctly-paired client may present to a bridge bound to
+ * `bindHost`:`port` WITHOUT a tunnel: the advertised URL's origin, plus both
+ * loopback spellings (simulators on this machine dial 127.0.0.1 or localhost
+ * regardless of what the QR advertises). A tunnel origin is appended by the
+ * caller once the tunnel URL is known — see `setAllowedOrigins`.
+ */
+export function advertisedOrigins(bindHost: string, port: number): string[] {
+  return [
+    ...new Set([
+      connectUrlOrigin(`ws://${advertisedHost(bindHost)}:${port}`),
+      `http://127.0.0.1:${port}`,
+      `http://localhost:${port}`,
+    ]),
+  ];
+}

--- a/packages/plugin-channel-mobile/src/tunnel.test.ts
+++ b/packages/plugin-channel-mobile/src/tunnel.test.ts
@@ -16,7 +16,9 @@ vi.mock('node:os', () => ({
 import os from 'node:os';
 import {
   advertisedHost,
+  advertisedOrigins,
   buildConnectUrl,
+  connectUrlOrigin,
   isLoopbackHost,
   isWildcardHost,
   lanHost,
@@ -120,6 +122,42 @@ describe('buildConnectUrl', () => {
   it('lanHost falls back to the given host when no external interface exists', () => {
     ifaces.mockReturnValueOnce({} as never);
     expect(lanHost('127.0.0.1')).toBe('127.0.0.1');
+  });
+});
+
+describe('connectUrlOrigin (the Origin iOS RN presents for a dialed URL)', () => {
+  it('maps a ws connect URL to its http origin, keeping a non-default port', () => {
+    expect(connectUrlOrigin('ws://192.168.1.7:8765/?t=tok')).toBe('http://192.168.1.7:8765');
+  });
+
+  it('maps a wss tunnel connect URL to its https origin (default port elided)', () => {
+    // Exactly the Origin a real iPhone sent through an ngrok tunnel.
+    expect(connectUrlOrigin('wss://abcd.ngrok-free.example/?t=tok')).toBe(
+      'https://abcd.ngrok-free.example',
+    );
+  });
+
+  it('accepts a raw https tunnel URL (pre-wss rewrite) too', () => {
+    expect(connectUrlOrigin('https://example.trycloudflare.com')).toBe(
+      'https://example.trycloudflare.com',
+    );
+  });
+});
+
+describe('advertisedOrigins (what the bridge must allow-list for real devices)', () => {
+  it('wildcard bind: the LAN advertised origin plus both loopback spellings', () => {
+    expect(advertisedOrigins('0.0.0.0', 8765)).toEqual([
+      'http://192.168.1.42:8765',
+      'http://127.0.0.1:8765',
+      'http://localhost:8765',
+    ]);
+  });
+
+  it('loopback bind: dedupes to just the loopback spellings', () => {
+    expect(advertisedOrigins('127.0.0.1', 8765)).toEqual([
+      'http://127.0.0.1:8765',
+      'http://localhost:8765',
+    ]);
   });
 });
 

--- a/packages/plugin-channel-mobile/src/tunnel.ts
+++ b/packages/plugin-channel-mobile/src/tunnel.ts
@@ -19,6 +19,8 @@ export {
   lanHost,
   advertisedHost,
   buildConnectUrl,
+  connectUrlOrigin,
+  advertisedOrigins,
 } from './pairing.js';
 
 export type TunnelChoice = 'localhost' | 'cloudflared' | 'ngrok';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
         specifier: ^4.0.0
         version: 4.0.1
     devDependencies:
+      '@moxxy/client-transport-ws':
+        specifier: workspace:*
+        version: link:../../packages/client-transport-ws
       '@moxxy/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig
@@ -272,6 +275,49 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
+  apps/mobile-poc:
+    dependencies:
+      '@expo/metro-runtime':
+        specifier: ~6.1.2
+        version: 6.1.2(expo@54.0.35)(react-dom@18.3.1(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@moxxy/client-core':
+        specifier: workspace:*
+        version: link:../../packages/client-core
+      '@moxxy/client-transport-ws':
+        specifier: workspace:*
+        version: link:../../packages/client-transport-ws
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      expo:
+        specifier: ~54.0.0
+        version: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-build-properties:
+        specifier: ~1.0.10
+        version: 1.0.10(expo@54.0.35)
+      expo-camera:
+        specifier: ~17.0.10
+        version: 17.0.10(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-status-bar:
+        specifier: ~3.0.9
+        version: 3.0.9(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-native:
+        specifier: 0.81.5
+        version: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+    devDependencies:
+      '@babel/core':
+        specifier: ^7.24.0
+        version: 7.29.7
+      '@types/react':
+        specifier: ~19.1.0
+        version: 19.1.17
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   packages/cache-strategy-stable-prefix:
     dependencies:
@@ -1086,64 +1132,6 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
-
-  packages/plugin-channel-virtual-office:
-    dependencies:
-      '@moxxy/core':
-        specifier: workspace:*
-        version: link:../core
-      '@moxxy/desktop-ipc-contract':
-        specifier: workspace:*
-        version: link:../desktop-ipc-contract
-      '@moxxy/ipc-server-ws':
-        specifier: workspace:*
-        version: link:../ipc-server-ws
-      '@moxxy/sdk':
-        specifier: workspace:*
-        version: link:../sdk
-    devDependencies:
-      '@moxxy/client-core':
-        specifier: workspace:*
-        version: link:../client-core
-      '@moxxy/client-transport-ws':
-        specifier: workspace:*
-        version: link:../client-transport-ws
-      '@moxxy/tsconfig':
-        specifier: workspace:*
-        version: link:../../tooling/tsconfig
-      '@moxxy/vitest-preset':
-        specifier: workspace:*
-        version: link:../../tooling/vitest-preset
-      '@types/node':
-        specifier: 'catalog:'
-        version: 22.19.18
-      '@types/react':
-        specifier: 'catalog:'
-        version: 18.3.28
-      '@types/react-dom':
-        specifier: 'catalog:'
-        version: 18.3.7(@types/react@18.3.28)
-      esbuild:
-        specifier: 'catalog:'
-        version: 0.25.12
-      phaser:
-        specifier: ^3.87.0
-        version: 3.90.0
-      react:
-        specifier: 'catalog:'
-        version: 18.3.1
-      react-dom:
-        specifier: 'catalog:'
-        version: 18.3.1(react@18.3.1)
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
-      vitest:
-        specifier: 'catalog:'
-        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
 
   packages/plugin-channel-web:
     dependencies:
@@ -2135,10 +2123,6 @@ packages:
   '@alcalzone/ansi-tokenize@0.1.3':
     resolution: {integrity: sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==}
     engines: {node: '>=14.13.1'}
-
-  '@alloc/quick-lru@5.2.0':
-    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
-    engines: {node: '>=10'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -5221,9 +5205,6 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
-  array-timsort@1.0.3:
-    resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
-
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
@@ -5384,10 +5365,6 @@ packages:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
 
-  binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
-
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -5518,10 +5495,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  camelcase-css@2.0.1:
-    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
-    engines: {node: '>= 6'}
-
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
@@ -5571,10 +5544,6 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
-
-  chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -5742,10 +5711,6 @@ packages:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
 
-  comment-json@4.6.2:
-    resolution: {integrity: sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w==}
-    engines: {node: '>= 6'}
-
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
 
@@ -5860,10 +5825,6 @@ packages:
 
   css-selector-parser@3.3.0:
     resolution: {integrity: sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==}
-
-  css-tree@1.1.3:
-    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
-    engines: {node: '>=8.0.0'}
 
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
@@ -6013,11 +5974,6 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  detect-libc@1.0.3:
-    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
-    engines: {node: '>=0.10'}
-    hasBin: true
-
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -6037,9 +5993,6 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
-
-  didyoumean@1.2.2:
-    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -6409,14 +6362,6 @@ packages:
       react: '*'
       react-native: '*'
 
-  expo-audio@1.1.1:
-    resolution: {integrity: sha512-CPCpJ+0AEHdzWROc0f00Zh6e+irLSl2ALos/LPvxEeIcJw1APfBa4DuHPkL4CQCWsVe7EnUjFpdwpqsEUWcP0g==}
-    peerDependencies:
-      expo: '*'
-      expo-asset: '*'
-      react: '*'
-      react-native: '*'
-
   expo-build-properties@1.0.10:
     resolution: {integrity: sha512-mFCZbrbrv0AP5RB151tAoRzwRJelqM7bCJzCkxpu+owOyH+p/rFC/q7H5q8B9EpVWj8etaIuszR+gKwohpmu1Q==}
     peerDependencies:
@@ -6433,23 +6378,11 @@ packages:
       react-native-web:
         optional: true
 
-  expo-clipboard@8.0.8:
-    resolution: {integrity: sha512-VKoBkHIpZZDJTB0jRO4/PZskHdMNOEz3P/41tmM6fDuODMpqhvyWK053X0ebspkxiawJX9lX33JXHBCvVsTTOA==}
-    peerDependencies:
-      expo: '*'
-      react: '*'
-      react-native: '*'
-
   expo-constants@18.0.13:
     resolution: {integrity: sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==}
     peerDependencies:
       expo: '*'
       react-native: '*'
-
-  expo-document-picker@14.0.8:
-    resolution: {integrity: sha512-3tyQKpPqWWFlI8p9RiMX1+T1Zge5mEKeBuXWp1h8PEItFMUDSiOJbQ112sfdC6Hxt8wSxreV9bCRl/NgBdt+fA==}
-    peerDependencies:
-      expo: '*'
 
   expo-file-system@19.0.23:
     resolution: {integrity: sha512-MeGkid9OeNILfT/qonaXHp4f2c15xaB28U/bcN7pqZej0Kx0+6+V7e9ZIXpPHm07zVatxA+QkMTPQEGfmvVOxA==}
@@ -6463,16 +6396,6 @@ packages:
       expo: '*'
       react: '*'
       react-native: '*'
-
-  expo-image-loader@6.0.0:
-    resolution: {integrity: sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==}
-    peerDependencies:
-      expo: '*'
-
-  expo-image-picker@17.0.11:
-    resolution: {integrity: sha512-/apkoyukDvsCHHb9fzP+F34A1uQqSzUtYH/2P/xJACNEwq+mwEXjXvVU8bzlJq6ih0Qo1+tpVivIa7B9kYSwOQ==}
-    peerDependencies:
-      expo: '*'
 
   expo-keep-awake@15.0.8:
     resolution: {integrity: sha512-YK9M1VrnoH1vLJiQzChZgzDvVimVoriibiDIFLbQMpjYBnvyfUeHJcin/Gx1a+XgupNXy92EQJLgI/9ZuXajYQ==}
@@ -6529,11 +6452,6 @@ packages:
         optional: true
       react-server-dom-webpack:
         optional: true
-
-  expo-secure-store@15.0.8:
-    resolution: {integrity: sha512-lHnzvRajBu4u+P99+0GEMijQMFCOYpWRO4dWsXSuMt77+THPIGjzNvVKrGSl6mMrLsfVaKL8BpwYZLGlgA+zAw==}
-    peerDependencies:
-      expo: '*'
 
   expo-server@1.0.7:
     resolution: {integrity: sha512-mcmyML3oXcqFUXUxtdtCL1O00ztNI2v76d+MdniXRUgHNxIcHZ05zo+DqBaOOT6LQnPk4vA4YHqQl7iGUfRb3g==}
@@ -7199,10 +7117,6 @@ packages:
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
-  is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
-
   is-ci@3.0.1:
     resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
     hasBin: true
@@ -7395,10 +7309,6 @@ packages:
   jimp-compact@0.16.1:
     resolution: {integrity: sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww==}
 
-  jiti@1.21.7:
-    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
-    hasBin: true
-
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -7522,22 +7432,10 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  lightningcss-darwin-arm64@1.27.0:
-    resolution: {integrity: sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
-    os: [darwin]
-
-  lightningcss-darwin-x64@1.27.0:
-    resolution: {integrity: sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.32.0:
@@ -7546,36 +7444,17 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.27.0:
-    resolution: {integrity: sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
   lightningcss-freebsd-x64@1.32.0:
     resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-linux-arm-gnueabihf@1.27.0:
-    resolution: {integrity: sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm]
-    os: [linux]
-
   lightningcss-linux-arm-gnueabihf@1.32.0:
     resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
-
-  lightningcss-linux-arm64-gnu@1.27.0:
-    resolution: {integrity: sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
@@ -7584,26 +7463,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-arm64-musl@1.27.0:
-    resolution: {integrity: sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
-
-  lightningcss-linux-x64-gnu@1.27.0:
-    resolution: {integrity: sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
@@ -7612,13 +7477,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-x64-musl@1.27.0:
-    resolution: {integrity: sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
@@ -7626,22 +7484,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  lightningcss-win32-arm64-msvc@1.27.0:
-    resolution: {integrity: sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [win32]
-
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
-    os: [win32]
-
-  lightningcss-win32-x64-msvc@1.27.0:
-    resolution: {integrity: sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.32.0:
@@ -7649,10 +7495,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
-
-  lightningcss@1.27.0:
-    resolution: {integrity: sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==}
-    engines: {node: '>= 12.0.0'}
 
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
@@ -7853,9 +7695,6 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
-
-  mdn-data@2.0.14:
-    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
 
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
@@ -8308,12 +8147,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nativewind@4.2.5:
-    resolution: {integrity: sha512-kKy2BG2xCca7tn3GZ65+sQ2aZH5T2hJ/sN/vlA1WSDu2YPn1rkdjsBOHy2TMv0I/au/HAuvgKIbX+LsSXvcf1Q==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      tailwindcss: '>3.3.0'
-
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -8446,10 +8279,6 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  object-hash@3.0.0:
-    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
-    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -8679,9 +8508,6 @@ packages:
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
-  phaser@3.90.0:
-    resolution: {integrity: sha512-/cziz/5ZIn02uDkC9RzN8VF9x3Gs3XdFFf9nkiMEQT3p7hQlWuyjy4QWosU802qqno2YSLn2BfqwOKLv/sSVfQ==}
-
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
@@ -8695,10 +8521,6 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
-
-  pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
 
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
@@ -8736,18 +8558,6 @@ packages:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
 
-  postcss-import@15.1.0:
-    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      postcss: ^8.0.0
-
-  postcss-js@4.1.0:
-    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
-    engines: {node: ^12 || ^14 || >= 16}
-    peerDependencies:
-      postcss: ^8.4.21
-
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -8775,9 +8585,6 @@ packages:
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
-
-  postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.4.49:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
@@ -8945,22 +8752,6 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
-  react-native-css-interop@0.2.5:
-    resolution: {integrity: sha512-V8/d9lBqn4w8m4d7dmwQPOFJB49bqga/9dmamfRHSGTQjGzrY/jAvDFOzSe+Ew2XuGz1ShVBD2cFIClFYasGyw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      react: '>=18'
-      react-native: '*'
-      react-native-reanimated: '>=3.6.2'
-      react-native-safe-area-context: '*'
-      react-native-svg: '*'
-      tailwindcss: ~3
-    peerDependenciesMeta:
-      react-native-safe-area-context:
-        optional: true
-      react-native-svg:
-        optional: true
-
   react-native-gesture-handler@2.28.0:
     resolution: {integrity: sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==}
     peerDependencies:
@@ -8988,12 +8779,6 @@ packages:
 
   react-native-screens@4.16.0:
     resolution: {integrity: sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==}
-    peerDependencies:
-      react: '*'
-      react-native: '*'
-
-  react-native-svg@15.12.1:
-    resolution: {integrity: sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -9079,9 +8864,6 @@ packages:
     resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
     hasBin: true
 
-  read-cache@1.0.0:
-    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
-
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
@@ -9099,10 +8881,6 @@ packages:
 
   readdir-glob@1.1.3:
     resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
-
-  readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -9731,11 +9509,6 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-
-  tailwindcss@3.4.19:
-    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -10716,8 +10489,6 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 4.0.0
 
-  '@alloc/quick-lru@5.2.0': {}
-
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -11432,6 +11203,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -11578,6 +11350,7 @@ snapshots:
   '@egjs/hammerjs@2.0.17':
     dependencies:
       '@types/hammerjs': 2.0.46
+    optional: true
 
   '@electron/asar@3.4.1':
     dependencies:
@@ -12733,13 +12506,16 @@ snapshots:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
+    optional: true
 
-  '@nodelib/fs.stat@2.0.5': {}
+  '@nodelib/fs.stat@2.0.5':
+    optional: true
 
   '@nodelib/fs.walk@1.2.8':
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+    optional: true
 
   '@npmcli/fs@2.1.2':
     dependencies:
@@ -12802,7 +12578,8 @@ snapshots:
 
   '@protobufjs/utf8@1.1.1': {}
 
-  '@radix-ui/primitive@1.1.4': {}
+  '@radix-ui/primitive@1.1.4':
+    optional: true
 
   '@radix-ui/react-collection@1.1.9(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -12815,24 +12592,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
       '@types/react-dom': 18.3.7(@types/react@19.1.17)
+    optional: true
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   '@radix-ui/react-compose-refs@1.1.3(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   '@radix-ui/react-context@1.1.4(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   '@radix-ui/react-dialog@1.1.16(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -12855,12 +12636,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
       '@types/react-dom': 18.3.7(@types/react@19.1.17)
+    optional: true
 
   '@radix-ui/react-direction@1.1.2(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   '@radix-ui/react-dismissable-layer@1.1.12(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -12874,12 +12657,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
       '@types/react-dom': 18.3.7(@types/react@19.1.17)
+    optional: true
 
   '@radix-ui/react-focus-guards@1.1.4(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   '@radix-ui/react-focus-scope@1.1.9(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -12891,6 +12676,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
       '@types/react-dom': 18.3.7(@types/react@19.1.17)
+    optional: true
 
   '@radix-ui/react-id@1.1.2(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
@@ -12898,6 +12684,7 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   '@radix-ui/react-portal@1.1.11(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -12908,6 +12695,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
       '@types/react-dom': 18.3.7(@types/react@19.1.17)
+    optional: true
 
   '@radix-ui/react-presence@1.1.6(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -12917,6 +12705,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
       '@types/react-dom': 18.3.7(@types/react@19.1.17)
+    optional: true
 
   '@radix-ui/react-primitive@2.1.5(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -12926,6 +12715,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
       '@types/react-dom': 18.3.7(@types/react@19.1.17)
+    optional: true
 
   '@radix-ui/react-roving-focus@1.1.12(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -12943,6 +12733,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
       '@types/react-dom': 18.3.7(@types/react@19.1.17)
+    optional: true
 
   '@radix-ui/react-slot@1.2.0(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
@@ -12950,6 +12741,7 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   '@radix-ui/react-slot@1.2.5(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
@@ -12957,6 +12749,7 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   '@radix-ui/react-tabs@1.1.14(@types/react-dom@18.3.7(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@18.3.1(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -12973,12 +12766,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
       '@types/react-dom': 18.3.7(@types/react@19.1.17)
+    optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
@@ -12987,6 +12782,7 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
@@ -12994,6 +12790,7 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   '@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
@@ -13001,12 +12798,14 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   '@react-native-community/cli-clean@13.6.9(encoding@0.1.13)':
     dependencies:
@@ -13184,6 +12983,7 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+    optional: true
 
   '@react-native/babel-preset@0.81.5(@babel/core@7.29.7)':
     dependencies:
@@ -13272,6 +13072,7 @@ snapshots:
       react-refresh: 0.14.2
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@react-native/codegen@0.81.5(@babel/core@7.29.7)':
     dependencies:
@@ -13292,6 +13093,7 @@ snapshots:
       nullthrows: 1.1.1
       tinyglobby: 0.2.16
       yargs: 17.7.2
+    optional: true
 
   '@react-native/community-cli-plugin@0.81.5(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))':
     dependencies:
@@ -13334,7 +13136,8 @@ snapshots:
 
   '@react-native/js-polyfills@0.81.5': {}
 
-  '@react-native/js-polyfills@0.86.0': {}
+  '@react-native/js-polyfills@0.86.0':
+    optional: true
 
   '@react-native/metro-babel-transformer@0.86.0(@babel/core@7.29.7)':
     dependencies:
@@ -13344,6 +13147,7 @@ snapshots:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@react-native/metro-config@0.86.0(@babel/core@7.29.7)':
     dependencies:
@@ -13356,6 +13160,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   '@react-native/normalize-colors@0.81.5': {}
 
@@ -13380,6 +13185,7 @@ snapshots:
       sf-symbols-typescript: 2.2.0
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
+    optional: true
 
   '@react-navigation/core@7.19.0(react@19.1.0)':
     dependencies:
@@ -13392,6 +13198,7 @@ snapshots:
       react-is: 19.2.7
       use-latest-callback: 0.2.6(react@19.1.0)
       use-sync-external-store: 1.6.0(react@19.1.0)
+    optional: true
 
   '@react-navigation/elements@2.9.22(@react-navigation/native@7.3.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -13402,6 +13209,7 @@ snapshots:
       react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       use-latest-callback: 0.2.6(react@19.1.0)
       use-sync-external-store: 1.6.0(react@19.1.0)
+    optional: true
 
   '@react-navigation/native-stack@7.17.2(@react-navigation/native@7.3.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -13416,6 +13224,7 @@ snapshots:
       warn-once: 0.1.1
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
+    optional: true
 
   '@react-navigation/native@7.3.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -13427,10 +13236,12 @@ snapshots:
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
       standard-navigation: 0.0.7
       use-latest-callback: 0.2.6(react@19.1.0)
+    optional: true
 
   '@react-navigation/routers@7.5.6':
     dependencies:
       nanoid: 3.3.12
+    optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -13716,7 +13527,8 @@ snapshots:
     dependencies:
       '@types/node': 24.12.3
 
-  '@types/hammerjs@2.0.46': {}
+  '@types/hammerjs@2.0.46':
+    optional: true
 
   '@types/hast@3.0.4':
     dependencies:
@@ -14299,6 +14111,7 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   aria-query@5.3.0:
     dependencies:
@@ -14307,8 +14120,6 @@ snapshots:
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
-
-  array-timsort@1.0.3: {}
 
   asap@2.0.6: {}
 
@@ -14513,6 +14324,7 @@ snapshots:
   babel-plugin-syntax-hermes-parser@0.36.0:
     dependencies:
       hermes-parser: 0.36.0
+    optional: true
 
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.29.7):
     dependencies:
@@ -14602,8 +14414,6 @@ snapshots:
       open: 8.4.2
 
   big-integer@1.6.52: {}
-
-  binary-extensions@2.3.0: {}
 
   bl@4.1.0:
     dependencies:
@@ -14805,8 +14615,6 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camelcase-css@2.0.1: {}
-
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
@@ -14847,18 +14655,6 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   check-error@2.1.3: {}
-
-  chokidar@3.6.0:
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
 
   chokidar@4.0.3:
     dependencies:
@@ -14929,7 +14725,8 @@ snapshots:
       slice-ansi: 5.0.0
       string-width: 7.2.0
 
-  client-only@0.0.1: {}
+  client-only@0.0.1:
+    optional: true
 
   cliui@6.0.0:
     dependencies:
@@ -15009,11 +14806,6 @@ snapshots:
 
   commander@9.5.0:
     optional: true
-
-  comment-json@4.6.2:
-    dependencies:
-      array-timsort: 1.0.3
-      esprima: 4.0.1
 
   common-ancestor-path@1.0.1: {}
 
@@ -15141,11 +14933,6 @@ snapshots:
 
   css-selector-parser@3.3.0: {}
 
-  css-tree@1.1.3:
-    dependencies:
-      mdn-data: 2.0.14
-      source-map: 0.6.1
-
   css-tree@2.2.1:
     dependencies:
       mdn-data: 2.0.28
@@ -15203,7 +14990,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  decode-uri-component@0.2.2: {}
+  decode-uri-component@0.2.2:
+    optional: true
 
   decompress-response@6.0.0:
     dependencies:
@@ -15276,11 +15064,10 @@ snapshots:
 
   destroy@1.2.0: {}
 
-  detect-libc@1.0.3: {}
-
   detect-libc@2.1.2: {}
 
-  detect-node-es@1.1.0: {}
+  detect-node-es@1.1.0:
+    optional: true
 
   detect-node@2.1.0: {}
 
@@ -15293,8 +15080,6 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
-
-  didyoumean@1.2.2: {}
 
   diff@8.0.4: {}
 
@@ -15807,13 +15592,6 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-audio@1.1.1(expo-asset@12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
-    dependencies:
-      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-asset: 12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
-
   expo-build-properties@1.0.10(expo@54.0.35):
     dependencies:
       ajv: 8.20.0
@@ -15827,12 +15605,6 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
 
-  expo-clipboard@8.0.8(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
-    dependencies:
-      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
-
   expo-constants@18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
       '@expo/config': 12.0.13
@@ -15841,10 +15613,6 @@ snapshots:
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
-
-  expo-document-picker@14.0.8(expo@54.0.35):
-    dependencies:
-      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-file-system@19.0.23(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
@@ -15857,15 +15625,6 @@ snapshots:
       fontfaceobserver: 2.3.0
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
-
-  expo-image-loader@6.0.0(expo@54.0.35):
-    dependencies:
-      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-
-  expo-image-picker@17.0.11(expo@54.0.35):
-    dependencies:
-      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-image-loader: 6.0.0(expo@54.0.35)
 
   expo-keep-awake@15.0.8(expo@54.0.35)(react@19.1.0):
     dependencies:
@@ -15881,6 +15640,7 @@ snapshots:
     transitivePeerDependencies:
       - expo
       - supports-color
+    optional: true
 
   expo-modules-autolinking@3.0.26:
     dependencies:
@@ -15937,10 +15697,7 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
       - supports-color
-
-  expo-secure-store@15.0.8(expo@54.0.35):
-    dependencies:
-      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+    optional: true
 
   expo-server@1.0.7: {}
 
@@ -16057,6 +15814,7 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+    optional: true
 
   fast-json-stable-stringify@2.1.0: {}
 
@@ -16082,6 +15840,7 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+    optional: true
 
   fb-watchman@2.0.2:
     dependencies:
@@ -16113,7 +15872,8 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  filter-obj@1.1.0: {}
+  filter-obj@1.1.0:
+    optional: true
 
   finalhandler@1.1.2:
     dependencies:
@@ -16276,7 +16036,8 @@ snapshots:
       hasown: 2.0.3
       math-intrinsics: 1.1.0
 
-  get-nonce@1.0.1: {}
+  get-nonce@1.0.1:
+    optional: true
 
   get-package-type@0.1.0: {}
 
@@ -16303,6 +16064,7 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+    optional: true
 
   glob-parent@6.0.2:
     dependencies:
@@ -16624,7 +16386,8 @@ snapshots:
 
   hermes-estree@0.35.0: {}
 
-  hermes-estree@0.36.0: {}
+  hermes-estree@0.36.0:
+    optional: true
 
   hermes-parser@0.25.1:
     dependencies:
@@ -16645,6 +16408,7 @@ snapshots:
   hermes-parser@0.36.0:
     dependencies:
       hermes-estree: 0.36.0
+    optional: true
 
   hermes-profile-transformer@0.0.6:
     dependencies:
@@ -16654,6 +16418,7 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
+    optional: true
 
   hono@4.12.18: {}
 
@@ -16848,10 +16613,6 @@ snapshots:
     optional: true
 
   is-arrayish@0.3.4: {}
-
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
 
   is-ci@3.0.1:
     dependencies:
@@ -17055,8 +16816,6 @@ snapshots:
 
   jimp-compact@0.16.1: {}
 
-  jiti@1.21.7: {}
-
   jiti@2.7.0: {}
 
   joi@17.13.3:
@@ -17181,80 +16940,35 @@ snapshots:
   lightningcss-android-arm64@1.32.0:
     optional: true
 
-  lightningcss-darwin-arm64@1.27.0:
-    optional: true
-
   lightningcss-darwin-arm64@1.32.0:
-    optional: true
-
-  lightningcss-darwin-x64@1.27.0:
     optional: true
 
   lightningcss-darwin-x64@1.32.0:
     optional: true
 
-  lightningcss-freebsd-x64@1.27.0:
-    optional: true
-
   lightningcss-freebsd-x64@1.32.0:
-    optional: true
-
-  lightningcss-linux-arm-gnueabihf@1.27.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
-  lightningcss-linux-arm64-gnu@1.27.0:
-    optional: true
-
   lightningcss-linux-arm64-gnu@1.32.0:
-    optional: true
-
-  lightningcss-linux-arm64-musl@1.27.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
-  lightningcss-linux-x64-gnu@1.27.0:
-    optional: true
-
   lightningcss-linux-x64-gnu@1.32.0:
-    optional: true
-
-  lightningcss-linux-x64-musl@1.27.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.32.0:
     optional: true
 
-  lightningcss-win32-arm64-msvc@1.27.0:
-    optional: true
-
   lightningcss-win32-arm64-msvc@1.32.0:
-    optional: true
-
-  lightningcss-win32-x64-msvc@1.27.0:
     optional: true
 
   lightningcss-win32-x64-msvc@1.32.0:
     optional: true
-
-  lightningcss@1.27.0:
-    dependencies:
-      detect-libc: 1.0.3
-    optionalDependencies:
-      lightningcss-darwin-arm64: 1.27.0
-      lightningcss-darwin-x64: 1.27.0
-      lightningcss-freebsd-x64: 1.27.0
-      lightningcss-linux-arm-gnueabihf: 1.27.0
-      lightningcss-linux-arm64-gnu: 1.27.0
-      lightningcss-linux-arm64-musl: 1.27.0
-      lightningcss-linux-x64-gnu: 1.27.0
-      lightningcss-linux-x64-musl: 1.27.0
-      lightningcss-win32-arm64-msvc: 1.27.0
-      lightningcss-win32-x64-msvc: 1.27.0
 
   lightningcss@1.32.0:
     dependencies:
@@ -17593,8 +17307,6 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
-  mdn-data@2.0.14: {}
-
   mdn-data@2.0.28: {}
 
   mdn-data@2.27.1: {}
@@ -17611,7 +17323,8 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
-  merge2@1.4.1: {}
+  merge2@1.4.1:
+    optional: true
 
   metro-babel-transformer@0.83.3:
     dependencies:
@@ -17641,6 +17354,7 @@ snapshots:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   metro-cache-key@0.83.3:
     dependencies:
@@ -17653,6 +17367,7 @@ snapshots:
   metro-cache-key@0.84.4:
     dependencies:
       flow-enums-runtime: 0.0.6
+    optional: true
 
   metro-cache@0.83.3:
     dependencies:
@@ -17680,6 +17395,7 @@ snapshots:
       metro-core: 0.84.4
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   metro-config@0.83.3:
     dependencies:
@@ -17725,6 +17441,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   metro-core@0.83.3:
     dependencies:
@@ -17743,6 +17460,7 @@ snapshots:
       flow-enums-runtime: 0.0.6
       lodash.throttle: 4.1.1
       metro-resolver: 0.84.4
+    optional: true
 
   metro-file-map@0.83.3:
     dependencies:
@@ -17785,6 +17503,7 @@ snapshots:
       walker: 1.0.8
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   metro-minify-terser@0.83.3:
     dependencies:
@@ -17800,6 +17519,7 @@ snapshots:
     dependencies:
       flow-enums-runtime: 0.0.6
       terser: 5.48.0
+    optional: true
 
   metro-resolver@0.83.3:
     dependencies:
@@ -17812,6 +17532,7 @@ snapshots:
   metro-resolver@0.84.4:
     dependencies:
       flow-enums-runtime: 0.0.6
+    optional: true
 
   metro-runtime@0.83.3:
     dependencies:
@@ -17827,6 +17548,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
       flow-enums-runtime: 0.0.6
+    optional: true
 
   metro-source-map@0.83.3:
     dependencies:
@@ -17870,6 +17592,7 @@ snapshots:
       vlq: 1.0.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   metro-symbolicate@0.83.3:
     dependencies:
@@ -17903,6 +17626,7 @@ snapshots:
       vlq: 1.0.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   metro-transform-plugins@0.83.3:
     dependencies:
@@ -17936,6 +17660,7 @@ snapshots:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   metro-transform-worker@0.83.3:
     dependencies:
@@ -17996,6 +17721,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   metro@0.83.3:
     dependencies:
@@ -18135,6 +17861,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -18527,20 +18254,6 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  nativewind@4.2.5(beef0d520c79bfe26b55be4fd582eecc):
-    dependencies:
-      comment-json: 4.6.2
-      debug: 4.4.3
-      react-native-css-interop: 0.2.5(beef0d520c79bfe26b55be4fd582eecc)
-      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - react
-      - react-native
-      - react-native-reanimated
-      - react-native-safe-area-context
-      - react-native-svg
-      - supports-color
-
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
@@ -18657,10 +18370,9 @@ snapshots:
   ob1@0.84.4:
     dependencies:
       flow-enums-runtime: 0.0.6
+    optional: true
 
   object-assign@4.1.1: {}
-
-  object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
 
@@ -18922,10 +18634,6 @@ snapshots:
 
   pend@1.2.0: {}
 
-  phaser@3.90.0:
-    dependencies:
-      eventemitter3: 5.0.4
-
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
@@ -18933,8 +18641,6 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
-
-  pify@2.3.0: {}
 
   pirates@4.0.7: {}
 
@@ -18966,27 +18672,6 @@ snapshots:
 
   pngjs@5.0.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.14):
-    dependencies:
-      postcss: 8.5.14
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.12
-
-  postcss-js@4.1.0(postcss@8.5.14):
-    dependencies:
-      camelcase-css: 2.0.1
-      postcss: 8.5.14
-
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.9.0):
-    dependencies:
-      lilconfig: 3.1.3
-    optionalDependencies:
-      jiti: 1.21.7
-      postcss: 8.5.14
-      tsx: 4.21.0
-      yaml: 2.9.0
-
   postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
@@ -19005,8 +18690,6 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-
-  postcss-value-parser@4.2.0: {}
 
   postcss@8.4.49:
     dependencies:
@@ -19119,8 +18802,10 @@ snapshots:
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
+    optional: true
 
-  queue-microtask@1.2.3: {}
+  queue-microtask@1.2.3:
+    optional: true
 
   queue@6.0.2:
     dependencies:
@@ -19165,20 +18850,25 @@ snapshots:
       loose-envify: 1.4.0
       react: 19.1.0
       scheduler: 0.23.2
+    optional: true
 
-  react-fast-compare@3.2.2: {}
+  react-fast-compare@3.2.2:
+    optional: true
 
   react-freeze@1.0.4(react@19.1.0):
     dependencies:
       react: 19.1.0
+    optional: true
 
-  react-is@16.13.1: {}
+  react-is@16.13.1:
+    optional: true
 
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
-  react-is@19.2.7: {}
+  react-is@19.2.7:
+    optional: true
 
   react-markdown@9.1.0(@types/react@18.3.28)(react@18.3.1):
     dependencies:
@@ -19198,24 +18888,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-native-css-interop@0.2.5(beef0d520c79bfe26b55be4fd582eecc):
-    dependencies:
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
-      debug: 4.4.3
-      lightningcss: 1.27.0
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
-      react-native-reanimated: 4.1.7(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      semver: 7.8.0
-      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
-    optionalDependencies:
-      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      react-native-svg: 15.12.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-    transitivePeerDependencies:
-      - supports-color
-
   react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@egjs/hammerjs': 2.0.17
@@ -19223,6 +18895,7 @@ snapshots:
       invariant: 2.2.4
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+    optional: true
 
   react-native-is-edge-to-edge@1.3.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -19236,11 +18909,13 @@ snapshots:
       react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       semver: 7.8.0
+    optional: true
 
   react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+    optional: true
 
   react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -19249,14 +18924,7 @@ snapshots:
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
       react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       warn-once: 0.1.1
-
-  react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
-    dependencies:
-      css-select: 5.2.2
-      css-tree: 1.1.3
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
-      warn-once: 0.1.1
+    optional: true
 
   react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -19277,6 +18945,7 @@ snapshots:
       semver: 7.8.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0):
     dependencies:
@@ -19342,6 +19011,7 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   react-remove-scroll@2.7.2(@types/react@19.1.17)(react@19.1.0):
     dependencies:
@@ -19353,6 +19023,7 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@19.1.17)(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   react-style-singleton@2.2.3(@types/react@19.1.17)(react@19.1.0):
     dependencies:
@@ -19361,6 +19032,7 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   react-virtuoso@4.18.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -19378,10 +19050,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  read-cache@1.0.0:
-    dependencies:
-      pify: 2.3.0
 
   readable-stream@2.3.8:
     dependencies:
@@ -19414,10 +19082,6 @@ snapshots:
   readdir-glob@1.1.3:
     dependencies:
       minimatch: 5.1.9
-
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.2
 
   readdirp@4.1.2: {}
 
@@ -19696,7 +19360,8 @@ snapshots:
 
   retry@0.12.0: {}
 
-  reusify@1.1.0: {}
+  reusify@1.1.0:
+    optional: true
 
   rimraf@3.0.2:
     dependencies:
@@ -19759,6 +19424,7 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+    optional: true
 
   safe-buffer@5.1.2: {}
 
@@ -19790,7 +19456,8 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.6.3: {}
+  semver@7.6.3:
+    optional: true
 
   semver@7.7.4: {}
 
@@ -19854,15 +19521,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  server-only@0.0.1: {}
+  server-only@0.0.1:
+    optional: true
 
   set-blocking@2.0.0: {}
 
   setprototypeof@1.2.0: {}
 
-  sf-symbols-typescript@2.2.0: {}
+  sf-symbols-typescript@2.2.0:
+    optional: true
 
-  shallowequal@1.1.0: {}
+  shallowequal@1.1.0:
+    optional: true
 
   sharp@0.33.5:
     dependencies:
@@ -20068,7 +19738,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  split-on-first@1.1.0: {}
+  split-on-first@1.1.0:
+    optional: true
 
   sprintf-js@1.0.3: {}
 
@@ -20090,7 +19761,8 @@ snapshots:
     dependencies:
       type-fest: 0.7.1
 
-  standard-navigation@0.0.7: {}
+  standard-navigation@0.0.7:
+    optional: true
 
   stat-mode@1.0.0: {}
 
@@ -20104,7 +19776,8 @@ snapshots:
 
   stream-replace-string@2.0.0: {}
 
-  strict-uri-encode@2.0.0: {}
+  strict-uri-encode@2.0.0:
+    optional: true
 
   string-width@4.2.3:
     dependencies:
@@ -20235,34 +19908,6 @@ snapshots:
       use-sync-external-store: 1.6.0(react@18.3.1)
 
   symbol-tree@3.2.4: {}
-
-  tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0):
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.7
-      lilconfig: 3.1.3
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.5.14
-      postcss-import: 15.1.0(postcss@8.5.14)
-      postcss-js: 4.1.0(postcss@8.5.14)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.9.0)
-      postcss-nested: 6.2.0(postcss@8.5.14)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.12
-      sucrase: 3.35.1
-    transitivePeerDependencies:
-      - tsx
-      - yaml
 
   tapable@2.3.3: {}
 
@@ -20638,10 +20283,12 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   use-latest-callback@0.2.6(react@19.1.0):
     dependencies:
       react: 19.1.0
+    optional: true
 
   use-sidecar@1.1.3(@types/react@19.1.17)(react@19.1.0):
     dependencies:
@@ -20650,6 +20297,7 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.17
+    optional: true
 
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:
@@ -20658,6 +20306,7 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.1.0):
     dependencies:
       react: 19.1.0
+    optional: true
 
   utf8-byte-length@1.0.5: {}
 
@@ -20679,6 +20328,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+    optional: true
 
   verror@1.10.1:
     dependencies:
@@ -20960,7 +20610,8 @@ snapshots:
     dependencies:
       makeerror: 1.0.12
 
-  warn-once@0.1.1: {}
+  warn-once@0.1.1:
+    optional: true
 
   watskeburt@4.2.3: {}
 


### PR DESCRIPTION
## What

- **`apps/mobile-poc`** — a minimal Expo **SDK 54** app (one screen, no router, no styling stack) that proves the mobile channel end to end: scan the QR `moxxy mobile` prints → connect to the runner's WS bridge → chat with the agent → answer permission/approval asks. Everything non-RN comes from the shared client layer (`ConnectionBridge`, `ChatStoreBridge`, `useConnection`, `useChat`, `askStore`) over `@moxxy/client-transport-ws`. A `EXPO_PUBLIC_MOXXY_WS_URL` env shortcut skips the scanner for simulators.
- **`@moxxy/client-transport-ws` grows `splitConnectUrl`** — the client half of the pairing contract (strip `?t=` off the scanned URL; the token is presented via the `Sec-WebSocket-Protocol` bearer entry, never the live WS URL). The app consumes it at boot; no app-local copy.
- **Fixes red typecheck on main:** the "remove broken apps" commit left `apps/desktop`'s `ws-bridge.test.ts` importing the deleted `apps/mobile/src/pairingQr`. The QR ↔ app round-trip test now asserts against the shared `splitConnectUrl` (desktop gets `@moxxy/client-transport-ws` as a devDependency) — no cross-app relative imports.
- README leads with the tunnel path (`MOXXY_MOBILE_TUNNEL=cloudflared` → `wss://`, TLS end to end) for real phones and spells out why direct LAN `wss://` isn't a thing for RN clients (no CA for private IPs, no pinning in Expo Go); LAN `ws://` binds are flagged trusted-network-only. TECH_DEBT.md logs that as M1 with the action if direct-LAN encryption ever matters.

## Why

The previous full-featured `apps/mobile` was removed as broken. This restores the smallest possible verification surface for the channel — pairing + chat only — so the channel keeps a living consumer without the app-level complexity that rotted last time.

## Verification

- `pnpm build` / `typecheck` (116/116 — red on main before this) / `lint` (0 errors) / `test` (turbo 113/113 + script tests 8/8) / `check:deps` all green; CLI smoke OK.
- `expo export --platform ios` bundles cleanly under Metro (631 modules → 1.92 MB Hermes bundle) — the pnpm-monorepo resolution path that historically breaks is exercised.
- `packages/client-transport-ws` pairing tests (5) + desktop `ws-bridge.test.ts` (131 desktop tests) pass, including the gateway-URL → `splitConnectUrl` round-trip.
- Not verified here: a live phone scan against a running `moxxy mobile` (needs a device; README documents the exact flow).