### PR TITLE
fix(desktop): create accounts on first OAuth sign-in — stop killing the Clerk sign-up transfer

### DIFF
--- a/.changeset/clerk-signup-transfer.md
+++ b/.changeset/clerk-signup-transfer.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/desktop': patch
+'@moxxy/desktop-host': patch
+---
+
+Fix desktop sign-in never creating accounts for new users ("External account not found"). The account-portal recovery net no longer kills the portal's `/sign-in` + `/sign-up` pages — the OAuth sso-callback leg that converts a new-user sign-in into a sign-up runs there — and the renderer now sweeps up any dangling transferable OAuth attempt on boot and completes the sign-up + sign-in itself (`OAuthTransferBridge`), with a `clerk-captcha` mount node so bot-protection challenges can render outside the prebuilt components.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -843,9 +843,22 @@ regressions. Restore the detail from git history (`TECH_DEBT.md` @ `b014c3a`) if
   OAUTH_HOST_PATTERNS + its own loopback serving origins for the return leg — the
   FAPI→app hop is not same-origin with the mid-flow page; focus window keeps the blanket
   deny) + `challenges.cloudflare.com` added to CSP connect-src for the sign-up Turnstile.
-  Postscript in `docs/desktop-clerk-loopback-subdomain.md`. **Remaining verify:** a real
-  packaged Google round-trip (the redirect reloads the app document mid-flow, which
-  clerk-js handles as a normal SPA return).
+  Postscript in `docs/desktop-clerk-loopback-subdomain.md`. The real round-trip verify
+  then surfaced the next layer (below).
+- **Packaged Clerk sign-in: NEW users were never created** (2026-06-11). The real
+  Google round-trip worked for existing users only — a new user got "External account
+  not found" and no account. Cause: the modal's OAuth callback returns to the hosted
+  Account Portal (`accounts.<domain>/sign-in#/sso-callback`), where client JS performs
+  the sign-in→sign-up "transfer" (`signUp.create({ transfer: true })`) for unknown
+  accounts — and `installAccountPortalRecovery` yanked the window off that page on
+  `did-navigate`, before the transfer could run (existing users survived because their
+  session is set server-side during the FAPI leg). Fixed twice over: the recovery net
+  now skips the portal's functional `/sign-in` + `/sign-up` paths (only `/user` etc.
+  recover), and the renderer's `OAuthTransferBridge` (apps/desktop/src/lib/oauthTransfer.tsx)
+  sweeps any still-dangling transferable attempt on boot and completes it in-app.
+  Instance config verified sane via the public FAPI `/v1/environment` (sign-up mode
+  `public` on dev + prod). **Remaining verify:** packaged round-trip with a
+  never-seen-before Google account.
 - **Desktop Dock-ghost runner process** (2026-06-10). The packaged desktop's runner
   (`moxxy serve`, spawned via the bundled CLI with `ELECTRON_RUN_AS_NODE=1`) showed up in
   the macOS Dock as a generic-executable ("exec") icon named after the app: on macOS 26

--- a/apps/desktop/src/lib/oauthTransfer.test.ts
+++ b/apps/desktop/src/lib/oauthTransfer.test.ts
@@ -1,0 +1,131 @@
+/**
+ * completeDanglingOAuthTransfer:
+ *   1. New-user OAuth sign-in left `transferable` on the client → the sweep
+ *      creates the account (signUp.create transfer) and activates the session.
+ *   2. Mirror case: sign-up against an existing external account → signs in.
+ *   3. Clean clients / unrelated verification states are untouched.
+ *   4. Non-complete transfers and thrown API errors never activate a session
+ *      (and never throw — the sign-in modal stays the fallback UI).
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  completeDanglingOAuthTransfer,
+  type TransferClerkLike,
+} from './oauthTransfer';
+
+type Verification = { status: string | null; error?: { code?: string } | null };
+
+function fakeClerk(opts: {
+  signInVerification?: Verification;
+  signUpVerification?: Verification;
+  signUpCreate?: () => Promise<{ status: string | null; createdSessionId: string | null }>;
+  signInCreate?: () => Promise<{ status: string | null; createdSessionId: string | null }>;
+  client?: null;
+}) {
+  const signUpCreate = vi.fn(
+    opts.signUpCreate ?? (() => Promise.resolve({ status: 'complete', createdSessionId: 'sess_up' })),
+  );
+  const signInCreate = vi.fn(
+    opts.signInCreate ?? (() => Promise.resolve({ status: 'complete', createdSessionId: 'sess_in' })),
+  );
+  const setActive = vi.fn(() => Promise.resolve());
+  const clerk: TransferClerkLike = {
+    client:
+      opts.client === null
+        ? null
+        : {
+            signIn: {
+              firstFactorVerification: opts.signInVerification ?? { status: null },
+              create: signInCreate,
+            },
+            signUp: {
+              verifications: {
+                externalAccount: opts.signUpVerification ?? { status: null },
+              },
+              create: signUpCreate,
+            },
+          },
+    setActive,
+  };
+  return { clerk, signUpCreate, signInCreate, setActive };
+}
+
+const NOT_FOUND: Verification = {
+  status: 'transferable',
+  error: { code: 'external_account_not_found' },
+};
+const EXISTS: Verification = {
+  status: 'transferable',
+  error: { code: 'external_account_exists' },
+};
+
+describe('completeDanglingOAuthTransfer', () => {
+  it('creates the account + signs in when a new-user sign-in attempt dangles', async () => {
+    const { clerk, signUpCreate, signInCreate, setActive } = fakeClerk({
+      signInVerification: NOT_FOUND,
+    });
+    await expect(completeDanglingOAuthTransfer(clerk)).resolves.toBe('signed-in');
+    expect(signUpCreate).toHaveBeenCalledWith({ transfer: true });
+    expect(signInCreate).not.toHaveBeenCalled();
+    expect(setActive).toHaveBeenCalledWith({ session: 'sess_up' });
+  });
+
+  it('signs in when a sign-up attempt dangles against an existing account', async () => {
+    const { clerk, signUpCreate, signInCreate, setActive } = fakeClerk({
+      signUpVerification: EXISTS,
+    });
+    await expect(completeDanglingOAuthTransfer(clerk)).resolves.toBe('signed-in');
+    expect(signInCreate).toHaveBeenCalledWith({ transfer: true });
+    expect(signUpCreate).not.toHaveBeenCalled();
+    expect(setActive).toHaveBeenCalledWith({ session: 'sess_in' });
+  });
+
+  it('does nothing on a clean client', async () => {
+    const { clerk, signUpCreate, signInCreate, setActive } = fakeClerk({});
+    await expect(completeDanglingOAuthTransfer(clerk)).resolves.toBe('none');
+    expect(signUpCreate).not.toHaveBeenCalled();
+    expect(signInCreate).not.toHaveBeenCalled();
+    expect(setActive).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without a client, or on unrelated verification states', async () => {
+    const noClient = fakeClerk({ client: null });
+    await expect(completeDanglingOAuthTransfer(noClient.clerk)).resolves.toBe('none');
+
+    // transferable status but a different error code — not a transfer case
+    const wrongCode = fakeClerk({
+      signInVerification: { status: 'transferable', error: { code: 'user_locked' } },
+    });
+    await expect(completeDanglingOAuthTransfer(wrongCode.clerk)).resolves.toBe('none');
+
+    // right code but a settled (failed) verification — nothing to transfer
+    const settled = fakeClerk({
+      signInVerification: { status: 'failed', error: { code: 'external_account_not_found' } },
+    });
+    await expect(completeDanglingOAuthTransfer(settled.clerk)).resolves.toBe('none');
+    expect(settled.signUpCreate).not.toHaveBeenCalled();
+  });
+
+  it('reports incomplete transfers without activating a session', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { clerk, setActive } = fakeClerk({
+      signInVerification: NOT_FOUND,
+      signUpCreate: () => Promise.resolve({ status: 'missing_requirements', createdSessionId: null }),
+    });
+    await expect(completeDanglingOAuthTransfer(clerk)).resolves.toBe('incomplete');
+    expect(setActive).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('swallows API errors (the sign-in modal remains the fallback)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { clerk, setActive } = fakeClerk({
+      signInVerification: NOT_FOUND,
+      signUpCreate: () => Promise.reject(new Error('captcha_invalid')),
+    });
+    await expect(completeDanglingOAuthTransfer(clerk)).resolves.toBe('failed');
+    expect(setActive).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/apps/desktop/src/lib/oauthTransfer.tsx
+++ b/apps/desktop/src/lib/oauthTransfer.tsx
@@ -1,0 +1,129 @@
+/**
+ * Belt-and-braces completion of Clerk's OAuth "transfer" flow.
+ *
+ * Sign-in with an OAuth account that has no Clerk user behind it cannot
+ * complete server-side: Clerk parks the attempt on the client with
+ * `firstFactorVerification.status === 'transferable'` and expects client JS
+ * to convert it into a sign-up (`signUp.create({ transfer: true })`). In the
+ * desktop app that conversion normally happens on the hosted Account
+ * Portal's sso-callback page — a leg that has historically been fragile
+ * (full-window redirects, the portal-stranding recovery net). If it dies,
+ * the user lands back in the app signed OUT with the attempt dangling, and
+ * the next sign-in modal greets them with "External account not found".
+ *
+ * `OAuthTransferBridge` (mounted once inside ClerkProvider) sweeps up that
+ * state: on boot, signed out, with a dangling transferable attempt in either
+ * direction, it completes the transfer itself and activates the session —
+ * so "sign in with no account" always ends signed-up + signed-in.
+ *
+ * It also renders the `clerk-captcha` mount node: the instance has bot
+ * protection enabled, and Clerk's smart captcha needs a DOM element to
+ * render into when a sign-up created outside the prebuilt components
+ * requires an interactive challenge (without it, clerk-js falls back to an
+ * invisible challenge and sign-up can dead-end).
+ */
+
+import React from 'react';
+import { useAuth, useClerk } from '@clerk/clerk-react';
+
+// Structural slices of the Clerk client so the transfer logic is testable
+// without clerk-js. The real resources satisfy these (method params are
+// bivariant; status unions widen to string).
+
+interface VerificationLike {
+  readonly status: string | null;
+  readonly error?: { readonly code?: string } | null;
+}
+
+interface TransferAttemptResult {
+  readonly status: string | null;
+  readonly createdSessionId: string | null;
+}
+
+export interface TransferClerkLike {
+  readonly client:
+    | {
+        readonly signIn: {
+          readonly firstFactorVerification: VerificationLike;
+          create(params: { transfer: boolean }): Promise<TransferAttemptResult>;
+        };
+        readonly signUp: {
+          readonly verifications: { readonly externalAccount: VerificationLike };
+          create(params: { transfer: boolean }): Promise<TransferAttemptResult>;
+        };
+      }
+    | null
+    | undefined;
+  setActive(params: { session: string }): Promise<unknown>;
+}
+
+export type TransferOutcome = 'signed-in' | 'none' | 'incomplete' | 'failed';
+
+/**
+ * Complete a dangling OAuth transfer, in whichever direction it dangles:
+ *  - sign-in attempt against an unknown external account → create the user
+ *    (`signUp.create({ transfer: true })`) — the reported desktop bug;
+ *  - sign-up attempt against an already-linked external account → sign in
+ *    (`signIn.create({ transfer: true })`) — the mirror case, handled the
+ *    same way clerk-js's own sso-callback step does.
+ * Returns what happened so callers/tests can assert; never throws.
+ */
+export async function completeDanglingOAuthTransfer(
+  clerk: TransferClerkLike,
+): Promise<TransferOutcome> {
+  const client = clerk.client;
+  if (!client) return 'none';
+
+  const signInVerification = client.signIn.firstFactorVerification;
+  const needsSignUpTransfer =
+    signInVerification.status === 'transferable' &&
+    signInVerification.error?.code === 'external_account_not_found';
+
+  const signUpVerification = client.signUp.verifications.externalAccount;
+  const needsSignInTransfer =
+    signUpVerification.status === 'transferable' &&
+    signUpVerification.error?.code === 'external_account_exists';
+
+  if (!needsSignUpTransfer && !needsSignInTransfer) return 'none';
+
+  try {
+    const res = needsSignUpTransfer
+      ? await client.signUp.create({ transfer: true })
+      : await client.signIn.create({ transfer: true });
+    if (res.status === 'complete' && res.createdSessionId) {
+      await clerk.setActive({ session: res.createdSessionId });
+      return 'signed-in';
+    }
+    // e.g. missing_requirements / needs_second_factor — leave it to the
+    // sign-in modal, which resumes the attempt with its full UI.
+    console.warn(`[oauth-transfer] transfer did not complete (status: ${res.status})`);
+    return 'incomplete';
+  } catch (err) {
+    console.warn('[oauth-transfer] transfer failed', err);
+    return 'failed';
+  }
+}
+
+/** Mounted once inside ClerkProvider (see main.tsx). */
+export function OAuthTransferBridge(): React.ReactElement {
+  const clerk = useClerk();
+  const { isLoaded, isSignedIn } = useAuth();
+  // One sweep per app load: the dangling state we target only ever exists
+  // right after a (reload-inducing) OAuth round-trip.
+  const attempted = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!isLoaded || isSignedIn || attempted.current) return;
+    attempted.current = true;
+    void completeDanglingOAuthTransfer(clerk as unknown as TransferClerkLike);
+  }, [isLoaded, isSignedIn, clerk]);
+
+  // Captcha mount node — empty (and invisible) until clerk-js needs to show
+  // an interactive challenge; pinned above the modal overlay if it does.
+  return (
+    <div
+      id="clerk-captcha"
+      style={{ position: 'fixed', bottom: 16, right: 16, zIndex: 10_000 }}
+    />
+  );
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -5,6 +5,7 @@ import { dark } from '@clerk/themes';
 import { App } from './App';
 import { ErrorBoundary } from './ErrorBoundary';
 import { DeepLinkBridge } from './lib/useDeepLink';
+import { OAuthTransferBridge } from './lib/oauthTransfer';
 import { bootClient } from './lib/boot';
 import './styles.css';
 
@@ -71,6 +72,11 @@ function ThemedClerkProvider({
       signUpFallbackRedirectUrl="/"
       appearance={{ baseTheme: isDark ? dark : undefined }}
     >
+      {/* Completes a dangling OAuth sign-up "transfer" (new-user sign-in)
+          that the full-window redirect flow failed to finish — see
+          lib/oauthTransfer.tsx. Needs Clerk context, hence inside the
+          provider; mounted before children so it sweeps on boot. */}
+      <OAuthTransferBridge />
       {children}
     </ClerkProvider>
   );

--- a/packages/desktop-host/src/security.test.ts
+++ b/packages/desktop-host/src/security.test.ts
@@ -218,6 +218,23 @@ describe('account-portal recovery net', () => {
     expect(loads).toEqual([]);
   });
 
+  it('leaves the portal /sign-in + /sign-up legs alone (they host the OAuth sso-callback that CREATES the account for a new user)', () => {
+    const { win, navigate, loads } = fakeWindow();
+    installAccountPortalRecovery(win, { portalHost: 'accounts.acme.com', appUrl: APP });
+    navigate('https://accounts.acme.com/sign-in#/sso-callback?after_sign_in_url=https%3A%2F%2Fdesktop.moxxy.ai%3A51789%2F');
+    navigate('https://accounts.acme.com/sign-in');
+    navigate('https://accounts.acme.com/sign-up#/verify-email-address');
+    expect(loads).toEqual([]);
+  });
+
+  it('still recovers from genuinely stranded portal pages', () => {
+    const { win, navigate, loads } = fakeWindow();
+    installAccountPortalRecovery(win, { portalHost: 'accounts.acme.com', appUrl: APP });
+    navigate('https://accounts.acme.com/user'); // "My account"
+    navigate('https://accounts.acme.com/');
+    expect(loads).toEqual([APP, APP]);
+  });
+
   it('is a no-op without a portal host (test key / no key)', () => {
     const { win, hasHandler } = fakeWindow();
     installAccountPortalRecovery(win, { portalHost: null, appUrl: APP });

--- a/packages/desktop-host/src/security.ts
+++ b/packages/desktop-host/src/security.ts
@@ -200,13 +200,41 @@ export function clerkAccountPortalHost(publishableKey?: string | null): string |
 }
 
 /**
- * Recovery net for the OAuth return leg: if the top frame lands on the Clerk
- * hosted Account Portal instead of back in the app, immediately load the app
- * root. The lockdown's parent-domain wildcard legitimately allows that host
- * (it's on the FAPI round-trip path), so this does NOT widen the navigation
- * allow-list — it only adds a way back when Clerk's fallback redirect picks
- * the portal over the app. Loop-safe: it only fires for the portal host, and
- * `appUrl` is on a different host, so the recovery load can't re-trigger it.
+ * Is a top-frame landing on the Account Portal a STRANDING (recover to the
+ * app) or a FUNCTIONAL leg of an auth flow (leave it alone)?
+ *
+ * The portal's `/sign-in` + `/sign-up` pages are load-bearing: clerk-js's
+ * modal (virtual-routing) OAuth flow builds its callback URL on the portal's
+ * sign-in page (`accounts.<domain>/sign-in#/sso-callback?...`), and for a
+ * NEW user it is that page's JS which converts the failed sign-in into a
+ * sign-up (`signUp.create({ transfer: true })`) and only then redirects back
+ * to the app. Yanking the window off those paths kills account creation —
+ * the sign-in attempt dangles and the next modal open shows "External
+ * account not found". Every other portal page (`/user` "My account", portal
+ * home, …) is a dead end for the desktop and gets recovered.
+ */
+export function isStrandedPortalUrl(url: string, portalHost: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.hostname !== portalHost) return false;
+  const path = parsed.pathname;
+  return !(path.startsWith('/sign-in') || path.startsWith('/sign-up'));
+}
+
+/**
+ * Recovery net for the OAuth return leg: if the top frame lands STRANDED on
+ * the Clerk hosted Account Portal instead of back in the app (see
+ * {@link isStrandedPortalUrl} — the functional `/sign-in` + `/sign-up` legs
+ * are deliberately left to run), load the app root. The lockdown's
+ * parent-domain wildcard legitimately allows that host (it's on the FAPI
+ * round-trip path), so this does NOT widen the navigation allow-list — it
+ * only adds a way back when Clerk's fallback redirect picks the portal over
+ * the app. Loop-safe: it only fires for the portal host, and `appUrl` is on
+ * a different host, so the recovery load can't re-trigger it.
  */
 export function installAccountPortalRecovery(
   win: BrowserWindow,
@@ -221,13 +249,7 @@ export function installAccountPortalRecovery(
   if (!portalHost) return;
   const wc = win.webContents;
   wc.on('did-navigate', (_event, url) => {
-    let hostname: string;
-    try {
-      hostname = new URL(url).hostname;
-    } catch {
-      return;
-    }
-    if (hostname !== portalHost || url === appUrl) return;
+    if (url === appUrl || !isStrandedPortalUrl(url, portalHost)) return;
     void Promise.resolve(wc.loadURL(appUrl)).catch(() => {
       /* window may be tearing down — nothing to recover */
     });


### PR DESCRIPTION
## What

New-user OAuth sign-in in the packaged desktop app errored **"External account not found"** and never created an account. Two-layer fix:

- `installAccountPortalRecovery` (desktop-host) now leaves the Account Portal's functional `/sign-in` + `/sign-up` pages alone (`isStrandedPortalUrl`) and only recovers from genuinely stranded pages (`/user` "My account", portal home).
- New `OAuthTransferBridge` (desktop renderer, mounted inside `ClerkProvider`): on boot, signed out, it finds a dangling `transferable` OAuth attempt on the Clerk client and completes it in-app — `signUp.create({ transfer: true })` for the new-user case (and the mirror `signIn.create({ transfer: true })`), then `setActive`. Also renders the `clerk-captcha` mount node so bot-protection challenges can render for sign-ups created outside the prebuilt components.

## Why

clerk-js's `openSignIn` modal (virtual routing) builds its OAuth callback URL on the **hosted Account Portal** (`accounts.<domain>/sign-in#/sso-callback`). For an existing user the session is set server-side during the FAPI redirect, so landing anywhere works — but for a **new** user, account creation is performed by that portal page's JS (the sign-in→sign-up "transfer"). The desktop's portal-stranding recovery net fired on *any* `did-navigate` to the portal host and yanked the window back to the app root before the transfer could run: no account created, dangling sign-in attempt, and the next modal open surfaces its error. Instance config is not the culprit — sign-up mode is `public` on dev + prod (verified via the public FAPI `/v1/environment`).

The renderer sweep makes the outcome correct even if the portal leg is interrupted again for any other reason: sign-in with no account always ends signed-up + signed-in.

## Verification

- `pnpm build` / `turbo typecheck test` (desktop + desktop-host) / `pnpm lint` (0 errors) / `check:deps` — all green
- New unit suites: `isStrandedPortalUrl` scoping in `security.test.ts` (sso-callback + sign-up legs untouched, `/user` + portal home recovered, no-loop invariants kept); `completeDanglingOAuthTransfer` (both transfer directions, clean-client no-op, unrelated verification states, incomplete transfer, thrown API error)
- Clerk instance settings checked via public `https://clerk.moxxy.ai/v1/environment`: sign-up mode `public`, Google OAuth enabled, captcha `smart` (hence the captcha mount node)
- **Needs a manual packaged-build check:** Google sign-in round-trip with a never-seen-before account (cannot drive a real Google login from CI)