### PR TITLE
fix(provider-openai-codex): drop maxTokens — ChatGPT Codex backend rejects max_output_tokens

### DIFF
--- a/.changeset/codex-max-output-tokens.md
+++ b/.changeset/codex-max-output-tokens.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/plugin-provider-openai-codex': patch
+'@moxxy/plugin-workflows': patch
+---
+
+Fix workflow_create failing with a 400 on the openai-codex provider: the ChatGPT-plan Codex `/responses` backend rejects `max_output_tokens` ("Unsupported parameter"), so the provider now drops `req.maxTokens` (one-shot MOXXY_DEBUG note) instead of forwarding it — same policy as `temperature`. workflow_create's draft call also clamps its token budget to the model's catalog ceiling and reports an actionable "draft hit the output-token limit" error when the YAML is truncated at `max_tokens`, instead of a cryptic parse failure.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -352,6 +352,13 @@ Full report incl. the medium/low backlog and refuted findings:
   models 400 on sampling params) with a one-shot MOXXY_DEBUG note instead of a silent drop;
   `reasoningEffort` is a live `CodexProviderConfig` option and the CLI's codex credential
   resolver now merges `provider.config` through (it used to discard every configured option).
+  **Corrected 2026-06-11:** the `max_output_tokens` mapping was itself a regression — the
+  ChatGPT-plan `/responses` endpoint (unlike the platform Responses API) 400s with
+  `Unsupported parameter: max_output_tokens`, observed live when `workflow_create` passed its
+  draft budget (the only caller that sets `req.maxTokens`; normal turns leave it unset, which
+  is why chat never hit it). `req.maxTokens` is now dropped with a one-shot MOXXY_DEBUG note,
+  exactly like `temperature`; `draftWorkflow` additionally clamps its budget to the model's
+  catalog `maxOutputTokens` and surfaces a `max_tokens`-truncated draft as an actionable error.
 - **A37 [med, inconsistency] Runtime-registered openai-compat providers were second-class** —
   ✅ FIXED (this PR): the live client now reports the vendor's slug + model catalog
   (`OpenAIProviderConfig.name`/`models`, wired from `buildProviderDef`) so usage/errors

--- a/packages/plugin-provider-openai-codex/src/provider.test.ts
+++ b/packages/plugin-provider-openai-codex/src/provider.test.ts
@@ -119,7 +119,7 @@ describe('CodexProvider.stream', () => {
     expect(end?.usage).toEqual({ inputTokens: 100, outputTokens: 20, cacheReadTokens: 80 });
   });
 
-  it('wires req.maxTokens to max_output_tokens and never forwards temperature', async () => {
+  it('never forwards req.maxTokens or req.temperature', async () => {
     let body: Record<string, unknown> | undefined;
     const fakeFetch = vi.fn(async (_u: RequestInfo | URL, init?: RequestInit) => {
       body = JSON.parse(String(init?.body));
@@ -131,9 +131,10 @@ describe('CodexProvider.stream', () => {
     });
     await collect(provider.stream(baseRequest({ maxTokens: 1234, temperature: 0.2 })));
 
-    expect(body?.max_output_tokens).toBe(1234);
-    // gpt-5 reasoning models reject sampling params with a 400, so the
-    // provider must drop temperature instead of forwarding it.
+    // The ChatGPT Codex backend 400s on max_output_tokens ("Unsupported
+    // parameter") and gpt-5 reasoning models reject sampling params, so the
+    // provider must drop both instead of forwarding them.
+    expect(body).not.toHaveProperty('max_output_tokens');
     expect(body).not.toHaveProperty('temperature');
   });
 

--- a/packages/plugin-provider-openai-codex/src/translate.test.ts
+++ b/packages/plugin-provider-openai-codex/src/translate.test.ts
@@ -70,9 +70,9 @@ describe('toResponsesBody', () => {
     expect(body.instructions).toBe('BASE\n\nNUDGE');
   });
 
-  it('maps maxTokens to max_output_tokens and drops temperature', () => {
+  it('drops both maxTokens and temperature (ChatGPT Codex backend rejects them)', () => {
     const body = toResponsesBody({ ...req, maxTokens: 999, temperature: 0.5 });
-    expect(body.max_output_tokens).toBe(999);
+    expect(body).not.toHaveProperty('max_output_tokens');
     expect(body).not.toHaveProperty('temperature');
   });
 });

--- a/packages/plugin-provider-openai-codex/src/translate.ts
+++ b/packages/plugin-provider-openai-codex/src/translate.ts
@@ -36,12 +36,11 @@ export interface ResponsesBody {
   stream: true;
   prompt_cache_key?: string;
   include?: string[];
-  /** Responses-API output cap; carries `ProviderRequest.maxTokens`. */
-  max_output_tokens?: number;
-  // NOTE: no `temperature` — every model the Codex backend serves is a
-  // gpt-5-family reasoning model, and the Responses API rejects sampling
-  // params (`temperature`/`top_p`) for reasoning models with a 400. See
-  // `noteTemperatureUnsupported` below.
+  // NOTE: no `temperature` and no `max_output_tokens` — every model the Codex
+  // backend serves is a gpt-5-family reasoning model, and the ChatGPT-plan
+  // `/responses` endpoint rejects sampling params (`temperature`/`top_p`) AND
+  // `max_output_tokens` with a 400 ("Unsupported parameter"). See
+  // `noteTemperatureUnsupported`/`noteMaxTokensUnsupported` below.
 }
 
 function contentBlocksToInputText(
@@ -179,6 +178,25 @@ function noteTemperatureUnsupported(): void {
   }
 }
 
+/**
+ * One-shot debug note for the unsupported `maxTokens` param. Unlike the
+ * platform Responses API, the ChatGPT-plan Codex backend rejects
+ * `max_output_tokens` with `400: {"detail":"Unsupported parameter:
+ * max_output_tokens"}` — observed live when `workflow_create` passed a draft
+ * budget. Same policy as temperature: drop it instead of breaking the request.
+ */
+let maxTokensNoteShown = false;
+function noteMaxTokensUnsupported(): void {
+  if (maxTokensNoteShown) return;
+  maxTokensNoteShown = true;
+  if (process.env.MOXXY_DEBUG) {
+    console.debug(
+      '[openai-codex] ProviderRequest.maxTokens is not supported by the Codex ' +
+        'Responses backend (400 Unsupported parameter: max_output_tokens); ignoring it.',
+    );
+  }
+}
+
 export function toResponsesBody(req: ProviderRequest, opts: BuildBodyOptions = {}): ResponsesBody {
   const instructions = extractSystemText(req.messages, req.system) || DEFAULT_INSTRUCTIONS;
   const body: ResponsesBody = {
@@ -193,7 +211,7 @@ export function toResponsesBody(req: ProviderRequest, opts: BuildBodyOptions = {
   };
   if (req.tools && req.tools.length > 0) body.tools = toResponsesTools(req.tools);
   if (opts.sessionHint) body.prompt_cache_key = opts.sessionHint;
-  if (req.maxTokens !== undefined) body.max_output_tokens = req.maxTokens;
+  if (req.maxTokens !== undefined) noteMaxTokensUnsupported();
   if (req.temperature !== undefined) noteTemperatureUnsupported();
   return body;
 }

--- a/packages/plugin-workflows/src/draft.test.ts
+++ b/packages/plugin-workflows/src/draft.test.ts
@@ -80,5 +80,30 @@ describe('draftWorkflow', () => {
     expect(drafted.parse.workflow?.inputs?.recipient).toBeDefined();
     expect(drafted.parse.workflow?.steps[2]?.tool).toBe('gmail_send');
     expect(provider.received[0]?.maxTokens).toBe(4096);
+    expect(drafted.truncated).toBe(false);
+  });
+
+  it('clamps the draft budget to the model maxOutputTokens ceiling', async () => {
+    const provider = new FakeProvider({
+      models: [{ id: 'tiny-model', contextWindow: 8000, maxOutputTokens: 2000, supportsTools: true, supportsStreaming: true }],
+      script: [textReply(MULTI_STEP_DRAFT)],
+    });
+    await draftWorkflow(provider, 'tiny-model', 'anything', AbortSignal.timeout(5000));
+    expect(provider.received[0]?.maxTokens).toBe(2000);
+  });
+
+  it('flags a max_tokens stop as truncated', async () => {
+    const provider = new FakeProvider({
+      script: [
+        [
+          { type: 'message_start', model: 'fake' },
+          { type: 'text_delta', delta: 'name: cut-off\ndescription: partial draft\nsteps:\n  - id: one\n    lab' },
+          { type: 'message_end', stopReason: 'max_tokens' },
+        ],
+      ],
+    });
+    const drafted = await draftWorkflow(provider, 'fake-model', 'anything', AbortSignal.timeout(5000));
+    expect(drafted.truncated).toBe(true);
+    expect(drafted.parse.ok).toBe(false);
   });
 });

--- a/packages/plugin-workflows/src/draft.ts
+++ b/packages/plugin-workflows/src/draft.ts
@@ -218,6 +218,8 @@ function formatCatalog(
 export interface DraftedWorkflow {
   readonly raw: string;
   readonly parse: WorkflowParseResult;
+  /** True when the stream stopped at the output-token cap — the YAML is likely cut off. */
+  readonly truncated: boolean;
 }
 
 export async function draftWorkflow(
@@ -228,18 +230,25 @@ export async function draftWorkflow(
   opts: DraftWorkflowOptions = {},
 ): Promise<DraftedWorkflow> {
   let accumulated = '';
+  let truncated = false;
+  // Clamp the draft budget to the model's own output ceiling — passing more
+  // than the model allows is a provider-side 400 (e.g. anthropic rejects
+  // max_tokens above the catalog cap).
+  const ceiling = provider.models.find((m) => m.id === model)?.maxOutputTokens;
+  const budget = Math.min(opts.maxTokens ?? DEFAULT_MAX_TOKENS, ceiling ?? Number.POSITIVE_INFINITY);
   for await (const event of provider.stream({
     model,
     system: buildSystemPrompt(opts),
     messages: [{ role: 'user', content: [{ type: 'text', text: `Build a workflow for: ${intent}` }] }],
-    maxTokens: opts.maxTokens ?? DEFAULT_MAX_TOKENS,
+    maxTokens: budget,
     signal,
   })) {
     if (event.type === 'text_delta') accumulated += event.delta;
+    if (event.type === 'message_end') truncated = event.stopReason === 'max_tokens';
     if (event.type === 'error') throw new Error(`workflow_create: provider error: ${event.message}`);
   }
   const raw = extractYamlBlock(accumulated);
-  return { raw, parse: parseWorkflowYaml(raw) };
+  return { raw, parse: parseWorkflowYaml(raw), truncated };
 }
 
 function extractYamlBlock(s: string): string {

--- a/packages/plugin-workflows/src/tools.ts
+++ b/packages/plugin-workflows/src/tools.ts
@@ -149,9 +149,11 @@ function createTool(deps: WorkflowToolDeps): ToolDef {
       if (!drafted.parse.ok || !drafted.parse.workflow) {
         throw new MoxxyError({
           code: 'TOOL_ERROR',
-          message:
-            `workflow_create: the model did not produce a valid workflow ` +
-            `(${drafted.parse.errors.join('; ')}). Try a more specific intent.`,
+          message: drafted.truncated
+            ? 'workflow_create: the draft hit the output-token limit before the YAML was ' +
+              'complete. Try a simpler intent, or split the workflow into smaller ones.'
+            : `workflow_create: the model did not produce a valid workflow ` +
+              `(${drafted.parse.errors.join('; ')}). Try a more specific intent.`,
         });
       }
       const created = await deps.store.create(drafted.parse.workflow, scope as EditableScope);


### PR DESCRIPTION
## Problem

Adding a workflow via prompt in the desktop app fails on the openai-codex provider with:

```
workflow_create: provider error: Codex /responses returned 400: {"detail":"Unsupported parameter: max_output_tokens"}
```

The ChatGPT-plan Codex `/responses` endpoint — unlike the platform Responses API — rejects `max_output_tokens` outright. `workflow_create` is the only caller that sets `req.maxTokens` (its 4096 draft budget), so every workflow-add via prompt failed while normal chat (which leaves `maxTokens` unset) worked. The mapping was introduced by the A36 audit fix; the live backend disagrees with it.

## Fix

- **plugin-provider-openai-codex**: drop `req.maxTokens` with a one-shot `MOXXY_DEBUG` note instead of forwarding it — exactly the existing `temperature` policy. Doc comments + `ResponsesBody` type updated; tests assert neither param is ever sent.
- **plugin-workflows**: `draftWorkflow` now clamps its budget to the model's catalog `maxOutputTokens` ceiling (passing more than the model allows is a provider-side 400 on anthropic), tracks the `max_tokens` stop reason, and `workflow_create` reports an actionable "draft hit the output-token limit" error for truncated YAML instead of a cryptic parse failure.
- TECH_DEBT A36 entry corrected with the regression note.

## Verification

Full gate green: build 59/59, typecheck, lint 0 errors, test 113/113 tasks, check:deps clean. New tests: codex translate/provider param-drop assertions, draft budget clamp, truncation flag.