### PR TITLE
feat(desktop): live registry refresh + interactive provider management

### DIFF
--- a/.changeset/desktop-live-provider-management.md
+++ b/.changeset/desktop-live-provider-management.md
@@ -1,0 +1,16 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/core': minor
+'@moxxy/cli': minor
+'@moxxy/plugin-provider-admin': minor
+'@moxxy/desktop-ipc-contract': minor
+'@moxxy/desktop-host': minor
+'@moxxy/client-core': minor
+'@moxxy/desktop': minor
+---
+
+Desktop: live registry refresh + interactive provider management.
+
+The runner now broadcasts `info.changed` after every completed turn, so registry changes made by tools inside a conversation (provider_add, mcp_add, workflow_create, skill writes, …) reach attached clients; the desktop forwards the push to the renderer (`session.info.changed` → `SESSION_INFO_REFRESH_EVENT`) and the Settings panel re-fetches live — no more app restart to see an agent-added provider.
+
+Settings → Providers is now interactive: enable/disable any provider (runner protocol v7 `provider.setEnabled`, persisted to `preferences.json#disabledProviders` and honored by boot's activation walk; disabling the ACTIVE provider is refused), and a Configure sheet sets the API key (vault + live readiness re-probe via `provider.refreshReady`) and, for runtime-registered providers, the stored baseURL/default model (`provider.configure` through the new `SessionLike.providerAdmin` view). OAuth providers get a `moxxy login` hint instead of a key form.

--- a/.claude/skills/change-runner-protocol/SKILL.md
+++ b/.claude/skills/change-runner-protocol/SKILL.md
@@ -6,26 +6,35 @@ description: Change the runner↔thin-client wire protocol (RunnerMethod, notifi
 # Change the runner protocol
 
 The contract lives in `packages/runner/src/protocol.ts`
-(`RUNNER_PROTOCOL_VERSION`, currently 3; `RunnerMethod`; zod param schemas).
+(`RUNNER_PROTOCOL_VERSION`, currently 7; `MIN_COMPATIBLE_PROTOCOL_VERSION`,
+currently 1; `RunnerMethod`; zod param schemas).
 Clients: TUI, desktop supervisor, anything using `connectRemoteSession`.
 
-Rules:
-- **Additive + tolerated by old peers** (new optional field, new method the
-  server can 404 cleanly) → NO bump needed.
-- **Incompatible** (changed semantics, required new method for correctness —
-  e.g. v3's `session.reset`, PR #129) → bump `RUNNER_PROTOCOL_VERSION` AND
-  document the change in the version-history docstring right above it
-  (`v2: ...`, `v3: ...` — keep the convention).
-- `attach` exchanges versions; mismatch fails LOUDLY server-side
-  (`server.ts:187`) — never let a stale peer limp along.
+Rules (tolerant negotiation since B2, branch fix/runner-protocol-skew):
+- **Any protocol change** (even additive) → bump `RUNNER_PROTOCOL_VERSION`
+  AND document it in the version-history docstring right above it
+  (`v2: ...`, `v7: ...` — keep the convention).
+- **Breaking change only** → ALSO bump `MIN_COMPATIBLE_PROTOCOL_VERSION` to
+  the new version. The handshake accepts any client `>= MIN_COMPATIBLE`; the
+  server reports its own version in `AttachResult.protocolVersion`.
+- New client-called methods must be GATED on the server's reported version via
+  `RemoteSession.requireServerProtocol(N, 'Feature name')` so a newer client
+  on an older runner gets an actionable "update the CLI" error, not a raw
+  method-not-found (see the v4 workflow-builder family or the v7
+  providerAdmin view for the pattern).
+- Desktop floor lockstep: `apps/desktop/electron/main/floor-runner-protocol.ts`
+  bakes `FLOOR_RUNNER_PROTOCOL` as a literal — bump it with the version; the
+  release build asserts it matches `@moxxy/runner` (scripts/build-app-bundle.mjs),
+  and the signed app-bundle manifest carries the stamp the bootstrap's
+  skew gate checks.
 
-Mismatch recovery expectations (`remote-session.ts:643+`): on "protocol
-mismatch" the CLIENT proactively kills the stale daemon and unlinks the
-socket — but only after verifying the holder's `ps` line carries a moxxy
-marker (never kill-by-port blind, A7); it also frees default port 4040 (web
-surface). Callers retry/self-host on a clean slate. Opt-outs:
-`skipMismatchRecovery`, injected transports skip it automatically. If you
-change attach/recovery, keep `MOXXY_RUNNER_STRICT_ABORT` and the
+Mismatch recovery expectations (`remote-session.ts`): on a genuine "protocol
+mismatch" (client `< MIN_COMPATIBLE`) the CLIENT proactively kills the stale
+daemon and unlinks the socket — but only after verifying the holder's `ps`
+line carries a moxxy marker (never kill-by-port blind, A7); it also frees
+default port 4040 (web surface). Callers retry/self-host on a clean slate.
+Opt-outs: `skipMismatchRecovery`, injected transports skip it automatically.
+If you change attach/recovery, keep `MOXXY_RUNNER_STRICT_ABORT` and the
 socket-dir-0700-before-listen hardening intact (A31).
 
 Also update:
@@ -36,7 +45,7 @@ Also update:
   protocol — check `runner-supervisor.ts`.
 - Tests: `packages/runner/src/integration.test.ts` pins the handshake +
   per-method behavior; add a case for your change and a mismatch test if you
-  bumped.
+  bumped MIN_COMPATIBLE.
 
 Changeset: `@moxxy/cli` (runner is bundled) + `@moxxy/desktop` if the desktop
 must pick it up.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -37,6 +37,39 @@ pass also **retired the plugins-admin CLI install-hardening + dedup items** (for
 
 ---
 
+## 2026-06-12 — desktop live registry refresh + interactive provider management
+
+- **Retired (found + fixed same PR): desktop UI went stale after runtime registry
+  changes** — `provider_add` (and mcp/skill/workflow mutations made by TOOLS inside a
+  turn) updated the runner's live registries but nothing pushed the change to the
+  renderer: the runner only broadcast `info.changed` on mode switch / provider
+  setActive / command.run / transcribe, `SessionDriver` never forwarded it, and
+  `useSettings` fetched once on mount — so a provider added via prompt needed an app
+  RESTART to appear. Fix, end to end: the runner broadcasts `info.changed` after every
+  completed turn (`server.ts` runTurn finally); `RemoteSession.onInfoChanged` exposes
+  the push; `SessionDriver` forwards it as the new `session.info.changed` IPC event;
+  `useSessionInfoBridge` (mounted in App) re-emits it as `SESSION_INFO_REFRESH_EVENT`;
+  and `useSettings` re-fetches on that signal (mode badge / action catalog / agent
+  picker already listened).
+- **Protocol v7** (additive; MIN_COMPATIBLE stays 1; desktop `FLOOR_RUNNER_PROTOCOL`
+  bumped in lockstep): `provider.setEnabled` (live toggle + persisted
+  `preferences.json#disabledProviders`, seeded into the registry before boot's
+  activation walk; disabling the ACTIVE provider is refused), `provider.refreshReady`
+  (re-probe credentials via `session.credentialResolver` so a vault key flips
+  readiness live), `provider.configure` (patch a stored provider through the new
+  `SessionLike.providerAdmin` view — wired from `buildProviderAdminPluginWithApi`,
+  mirrors mcpAdmin). Settings → Providers now has the enable/disable Switch + a
+  Configure sheet (vault key for api-key providers, login hint for OAuth, stored
+  baseURL/defaultModel for admin providers). The change-runner-protocol skill was
+  refreshed (it still said "currently 3" + pre-tolerant-negotiation semantics).
+- **New (low, ux):** the Configure sheet edits a stored provider's `baseURL` /
+  `defaultModel` but not its `models` ARRAY — model-list edits still need
+  `provider_add` (replace) or `settings.fetchProviderModels` + a future picker.
+- **New (low, consistency):** `provider.setEnabled` persists the disabled list via a
+  fire-and-forget read-merge-write of preferences.json; two rapid toggles of
+  DIFFERENT providers from two clients could lose one update (same best-effort
+  semantics as every `savePreferences` caller — acceptable, noted for completeness).
+
 ## 2026-06-11 — mobile-poc app intake
 
 `apps/mobile-poc` (Expo SDK 54, single screen) replaces the removed `apps/mobile` as the

--- a/apps/desktop/electron/main/floor-runner-protocol.ts
+++ b/apps/desktop/electron/main/floor-runner-protocol.ts
@@ -16,4 +16,4 @@
  * the release build asserts the two match (see scripts/build-app-bundle.mjs),
  * so a forgotten bump fails the build rather than shipping a wrong floor.
  */
-export const FLOOR_RUNNER_PROTOCOL = 6;
+export const FLOOR_RUNNER_PROTOCOL = 7;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -9,6 +9,7 @@ import {
   ChatStoreBridge,
   chatStore,
   usePrefs,
+  useSessionInfoBridge,
 } from '@moxxy/client-core';
 import { AskSheet } from './chat/AskSheet';
 import { useAskSurfaceClaimed } from '@/lib/askSurface';
@@ -40,6 +41,11 @@ export function App(): JSX.Element {
   // Theme controller — applies the persisted light/dark/system pref to
   // <html data-theme> and tracks OS scheme changes. Mounted exactly once.
   useTheme();
+  // Re-emit the runner's registry-change push (`session.info.changed`) as the
+  // SESSION_INFO_REFRESH_EVENT every info-derived view listens for — Settings
+  // tabs, mode badge, agent picker — so agent-made changes (provider_add, …)
+  // show up live instead of after an app restart. Mounted exactly once.
+  useSessionInfoBridge();
   const activeWorkspaceId = useActiveWorkspaceId();
   const { snapshot, hasEverConnected, retry } = useConnection(activeWorkspaceId);
   const { prefs, loading: prefsLoading } = usePrefs();

--- a/apps/desktop/src/settings/AddWithAgent.test.tsx
+++ b/apps/desktop/src/settings/AddWithAgent.test.tsx
@@ -36,7 +36,15 @@ describe('settings Add buttons (agent-task flows)', () => {
 
   it('ProvidersTab: "Add provider" opens the agent-task modal', () => {
     installFakeApi();
-    render(<ProvidersTab providers={[]} onRefresh={() => Promise.resolve()} />);
+    render(
+      <ProvidersTab
+        providers={[]}
+        onToggle={() => Promise.resolve()}
+        onConfigure={() => Promise.resolve()}
+        onSetKey={() => Promise.resolve()}
+        onRefresh={() => Promise.resolve()}
+      />,
+    );
     fireEvent.click(screen.getByRole('button', { name: /add provider/i }));
     expect(screen.getByText('Add provider', { selector: 'h2, h3, header *' })).toBeTruthy();
     expect(screen.getByText(/describe the provider/i)).toBeTruthy();

--- a/apps/desktop/src/settings/ProvidersTab.test.tsx
+++ b/apps/desktop/src/settings/ProvidersTab.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * ProvidersTab interactions:
+ *   1. The enable/disable Switch calls onToggle with the inverted state,
+ *      and is disabled (control-level) for the ACTIVE provider — mirroring
+ *      the runner's refusal to disable it.
+ *   2. Configure opens the sheet; "Save key" routes through onSetKey with
+ *      the row's canonical vault key name.
+ *   3. Admin rows expose endpoint fields; "Save configuration" sends only
+ *      the changed fields. OAuth rows get a login hint instead of a key form.
+ */
+
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { __setApiOverride } from '@moxxy/client-core';
+import type { ProviderEntry } from '@moxxy/desktop-ipc-contract';
+import { ProvidersTab } from './ProvidersTab';
+
+afterEach(() => {
+  __setApiOverride(null);
+});
+
+const anthropic: ProviderEntry = {
+  name: 'anthropic',
+  ready: true,
+  enabled: true,
+  active: true,
+  authKind: 'api-key',
+  kind: 'builtin',
+  keyName: 'ANTHROPIC_API_KEY',
+};
+
+const codex: ProviderEntry = {
+  name: 'openai-codex',
+  ready: false,
+  enabled: true,
+  active: false,
+  authKind: 'oauth',
+  kind: 'builtin',
+  keyName: 'OPENAI_CODEX_API_KEY',
+};
+
+const zai: ProviderEntry = {
+  name: 'zai',
+  ready: false,
+  enabled: false,
+  active: false,
+  authKind: 'api-key',
+  kind: 'admin',
+  keyName: 'ZAI_API_KEY',
+  baseURL: 'https://api.z.ai/v4',
+  defaultModel: 'glm-4',
+  modelIds: ['glm-4', 'glm-4-air'],
+};
+
+function renderTab(overrides?: Partial<Parameters<typeof ProvidersTab>[0]>): {
+  onToggle: ReturnType<typeof vi.fn>;
+  onConfigure: ReturnType<typeof vi.fn>;
+  onSetKey: ReturnType<typeof vi.fn>;
+} {
+  const onToggle = vi.fn(() => Promise.resolve());
+  const onConfigure = vi.fn(() => Promise.resolve());
+  const onSetKey = vi.fn(() => Promise.resolve());
+  render(
+    <ProvidersTab
+      providers={[anthropic, codex, zai]}
+      onToggle={onToggle}
+      onConfigure={onConfigure}
+      onSetKey={onSetKey}
+      onRefresh={() => Promise.resolve()}
+      {...overrides}
+    />,
+  );
+  return { onToggle, onConfigure, onSetKey };
+}
+
+describe('ProvidersTab', () => {
+  it('toggles a provider via the switch; the ACTIVE provider switch is disabled', () => {
+    const { onToggle } = renderTab();
+
+    // zai is disabled → switch turns it ON.
+    fireEvent.click(screen.getByRole('switch', { name: /enable zai/i }));
+    expect(onToggle).toHaveBeenCalledWith('zai', true);
+
+    // anthropic is the active provider — its disable switch is inert.
+    const activeSwitch = screen.getByRole('switch', { name: /disable anthropic/i });
+    expect((activeSwitch as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('saves an API key through the configure sheet under the row keyName', async () => {
+    const { onSetKey } = renderTab();
+    fireEvent.click(screen.getByRole('button', { name: /configure anthropic/i }));
+    fireEvent.change(screen.getByTestId('provider-key-input'), { target: { value: 'sk-abc' } });
+    fireEvent.click(screen.getByRole('button', { name: /save key/i }));
+    await waitFor(() => expect(onSetKey).toHaveBeenCalledWith('ANTHROPIC_API_KEY', 'sk-abc'));
+  });
+
+  it('sends only the changed endpoint fields for an admin provider', async () => {
+    const { onConfigure } = renderTab();
+    fireEvent.click(screen.getByRole('button', { name: /configure zai/i }));
+    fireEvent.change(screen.getByTestId('provider-baseurl-input'), {
+      target: { value: 'https://api.z.ai/v5' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save configuration/i }));
+    await waitFor(() =>
+      expect(onConfigure).toHaveBeenCalledWith('zai', { baseURL: 'https://api.z.ai/v5' }),
+    );
+  });
+
+  it('shows a login hint instead of a key form for OAuth providers', () => {
+    renderTab();
+    fireEvent.click(screen.getByRole('button', { name: /configure openai-codex/i }));
+    expect(screen.getByText(/signs in with OAuth/i)).toBeTruthy();
+    expect(screen.queryByTestId('provider-key-input')).toBeNull();
+  });
+});

--- a/apps/desktop/src/settings/ProvidersTab.tsx
+++ b/apps/desktop/src/settings/ProvidersTab.tsx
@@ -1,33 +1,47 @@
 /**
  * Providers tab — the model providers the connected runner can route to. Each
- * provider is a Row with a deterministic colour-tinted initial Tile and a
- * ready/inactive StatusDot; add a provider's key in the vault to activate it.
- * "Add provider" opens the shared agent-task modal: the user names the
- * vendor, moxxy registers it in a hidden background turn.
+ * provider is a Row with a deterministic colour-tinted initial Tile, a
+ * ready/inactive StatusDot, an enable/disable Switch (persisted on the
+ * runner; the ACTIVE provider can't be disabled), and a Configure sheet for
+ * the API key (vault) plus — for admin-registered providers — the stored
+ * baseURL / default model. "Add provider" opens the shared agent-task modal:
+ * the user names the vendor, moxxy registers it in a hidden background turn.
  */
 
 import { useState } from 'react';
 import type { useSettings } from '@moxxy/client-core';
-import { Button, Icon } from '@moxxy/desktop-ui';
-import { Section, CardList, Row, Tile, StatusDot, EmptyState } from './settings-primitives';
+import { Button, Icon, IconButton, Modal, TextInput } from '@moxxy/desktop-ui';
+import { Section, CardList, Row, Tile, StatusDot, Switch, Badge, EmptyState } from './settings-primitives';
 import { AgentTaskModal } from './shared/AgentTaskModal';
 import { PROVIDER_PROMPT_TEMPLATE } from './provider-prompt';
 
+type ProviderRow = ReturnType<typeof useSettings>['providers'][number];
+
 export function ProvidersTab({
   providers,
+  onToggle,
+  onConfigure,
+  onSetKey,
   onRefresh,
   search,
 }: {
   readonly providers: ReturnType<typeof useSettings>['providers'];
+  readonly onToggle: (name: string, enabled: boolean) => Promise<void>;
+  readonly onConfigure: (
+    name: string,
+    patch: { baseURL?: string; defaultModel?: string },
+  ) => Promise<void>;
+  readonly onSetKey: (keyName: string, value: string) => Promise<void>;
   readonly onRefresh: () => Promise<void>;
   readonly search?: React.ReactNode;
 }): JSX.Element {
   const [adding, setAdding] = useState(false);
+  const [configuring, setConfiguring] = useState<ProviderRow | null>(null);
   return (
     <Section
       title="Providers"
       count={providers.length}
-      description="Model providers the runner can route to. Add a provider's key in the vault to activate it."
+      description="Model providers the runner can route to. Toggle one off to exclude it; configure adds the API key (and endpoint for custom vendors)."
       search={search}
       actions={
         <Button variant="cta" onClick={() => setAdding(true)} style={{ gap: 7 }}>
@@ -45,14 +59,35 @@ export function ProvidersTab({
             return (
               <Row
                 key={p.name}
+                testId={`provider-row-${p.name}`}
                 tile={
                   <Tile bg={bg} fg={fg}>
                     {p.name.slice(0, 1).toUpperCase()}
                   </Tile>
                 }
                 title={p.name}
-                subtitle={p.ready ? 'Active · credentials resolved' : 'Inactive · add a key to use'}
-                trailing={<StatusDot ok={p.ready} okLabel="Ready" offLabel="Inactive" />}
+                subtitle={subtitleFor(p)}
+                trailing={
+                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 10 }}>
+                    {p.active && <Badge>Active</Badge>}
+                    <StatusDot ok={p.ready} okLabel="Ready" offLabel="Inactive" />
+                    <IconButton
+                      aria-label={`Configure ${p.name}`}
+                      onClick={() => setConfiguring(p)}
+                      size={28}
+                    >
+                      <Icon name="sliders" size={14} />
+                    </IconButton>
+                    <Switch
+                      on={p.enabled}
+                      label={`${p.enabled ? 'Disable' : 'Enable'} ${p.name}`}
+                      // The runner refuses to disable the ACTIVE provider —
+                      // disable the control too so the row matches reality.
+                      disabled={p.active && p.enabled}
+                      onClick={() => void onToggle(p.name, !p.enabled)}
+                    />
+                  </span>
+                }
               />
             );
           })}
@@ -70,9 +105,201 @@ export function ProvidersTab({
           onClose={() => setAdding(false)}
         />
       )}
+      {configuring && (
+        <ConfigureProviderModal
+          provider={configuring}
+          onConfigure={onConfigure}
+          onSetKey={onSetKey}
+          onClose={() => setConfiguring(null)}
+        />
+      )}
     </Section>
   );
 }
+
+function subtitleFor(p: ProviderRow): string {
+  if (!p.enabled) return 'Disabled · excluded from activation';
+  if (p.ready) return 'Active · credentials resolved';
+  return p.authKind === 'oauth'
+    ? 'Inactive · sign in with `moxxy login` to use'
+    : 'Inactive · add a key to use';
+}
+
+/**
+ * Configure sheet — two independent forms:
+ *   - API key → vault under the provider's canonical key name, then the
+ *     runner re-probes credentials so the readiness dot flips live. OAuth
+ *     providers get a hint instead (their credential is a login, not a key).
+ *   - Endpoint (admin-registered providers only): stored baseURL + default
+ *     model, applied to the live registry and persisted to providers.json.
+ */
+function ConfigureProviderModal({
+  provider,
+  onConfigure,
+  onSetKey,
+  onClose,
+}: {
+  readonly provider: ProviderRow;
+  readonly onConfigure: (
+    name: string,
+    patch: { baseURL?: string; defaultModel?: string },
+  ) => Promise<void>;
+  readonly onSetKey: (keyName: string, value: string) => Promise<void>;
+  readonly onClose: () => void;
+}): JSX.Element {
+  const [key, setKey] = useState('');
+  const [baseURL, setBaseURL] = useState(provider.baseURL ?? '');
+  const [defaultModel, setDefaultModel] = useState(provider.defaultModel ?? '');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState<string | null>(null);
+
+  const run = async (fn: () => Promise<void>, doneNote: string): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    setSaved(null);
+    try {
+      await fn();
+      setSaved(doneNote);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const isAdmin = provider.kind === 'admin';
+  const configDirty =
+    isAdmin &&
+    ((baseURL.trim() !== (provider.baseURL ?? '') && baseURL.trim().length > 0) ||
+      (defaultModel.trim() !== (provider.defaultModel ?? '') && defaultModel.trim().length > 0));
+
+  return (
+    <Modal title={`Configure ${provider.name}`} onClose={onClose} width={420}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        {provider.authKind === 'oauth' ? (
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--color-text-muted)', lineHeight: 1.55 }}>
+            This provider signs in with OAuth — run{' '}
+            <code style={{ fontSize: 12.5 }}>moxxy login {provider.name}</code> in a terminal to
+            connect it. There is no API key to store.
+          </p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <label style={fieldLabelStyle}>
+              API key · stored in the vault as <code style={{ fontSize: 11.5 }}>{provider.keyName}</code>
+            </label>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <TextInput
+                type="password"
+                value={key}
+                onChange={(e) => setKey(e.target.value)}
+                placeholder="sk-…"
+                style={{ flex: 1 }}
+                data-testid="provider-key-input"
+              />
+              <Button
+                variant="primary"
+                disabled={key.length === 0 || busy}
+                onClick={() =>
+                  void run(async () => {
+                    await onSetKey(provider.keyName, key);
+                    setKey('');
+                  }, 'Key saved — readiness re-checked.')
+                }
+              >
+                Save key
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {isAdmin && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <label style={fieldLabelStyle}>Endpoint</label>
+            <TextInput
+              value={baseURL}
+              onChange={(e) => setBaseURL(e.target.value)}
+              placeholder="https://api.vendor.com/v1"
+              className="mono"
+              data-testid="provider-baseurl-input"
+            />
+            <label style={fieldLabelStyle}>Default model</label>
+            {provider.modelIds && provider.modelIds.length > 0 ? (
+              <select
+                value={defaultModel}
+                onChange={(e) => setDefaultModel(e.target.value)}
+                style={selectStyle}
+                data-testid="provider-defaultmodel-select"
+              >
+                {provider.modelIds.map((id) => (
+                  <option key={id} value={id}>
+                    {id}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <TextInput
+                value={defaultModel}
+                onChange={(e) => setDefaultModel(e.target.value)}
+                placeholder="model-id"
+                className="mono"
+              />
+            )}
+            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <Button
+                variant="primary"
+                disabled={!configDirty || busy}
+                onClick={() =>
+                  void run(async () => {
+                    const patch: { baseURL?: string; defaultModel?: string } = {};
+                    if (baseURL.trim() && baseURL.trim() !== provider.baseURL) patch.baseURL = baseURL.trim();
+                    if (defaultModel.trim() && defaultModel.trim() !== provider.defaultModel) {
+                      patch.defaultModel = defaultModel.trim();
+                    }
+                    await onConfigure(provider.name, patch);
+                  }, 'Configuration saved.')
+                }
+              >
+                Save configuration
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {!isAdmin && provider.authKind !== 'oauth' && (
+          <p style={{ margin: 0, fontSize: 12.5, color: 'var(--color-text-muted)', lineHeight: 1.5 }}>
+            Built-in provider — endpoint and model list ship with moxxy; only the key is configurable.
+          </p>
+        )}
+
+        {error && (
+          <p role="alert" style={{ margin: 0, fontSize: 12.5, color: 'var(--color-red)' }}>
+            {error}
+          </p>
+        )}
+        {saved && !error && (
+          <p style={{ margin: 0, fontSize: 12.5, color: 'var(--color-green, #16a34a)' }}>{saved}</p>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+const fieldLabelStyle: React.CSSProperties = {
+  fontSize: 12,
+  fontWeight: 600,
+  color: 'var(--color-text-muted)',
+};
+
+const selectStyle: React.CSSProperties = {
+  padding: '8px 10px',
+  borderRadius: 10,
+  border: '1px solid var(--color-card-border)',
+  background: 'var(--color-card-bg)',
+  fontSize: 13,
+  fontFamily: 'inherit',
+  color: 'inherit',
+};
 
 /** Deterministic soft tint per provider name, so each tile is distinct
  *  but on-brand (pastel bg, saturated fg from the same hue). */

--- a/apps/desktop/src/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/settings/SettingsPanel.tsx
@@ -120,6 +120,9 @@ export function SettingsPanel({
           {tab === 'providers' && (
             <ProvidersTab
               providers={providers}
+              onToggle={s.setProviderEnabled}
+              onConfigure={s.configureProvider}
+              onSetKey={s.setProviderKey}
               onRefresh={s.refresh}
               search={<SearchBox value={query} onChange={setQuery} placeholder="Search providers…" />}
             />

--- a/apps/desktop/src/settings/settings-primitives.tsx
+++ b/apps/desktop/src/settings/settings-primitives.tsx
@@ -215,10 +215,12 @@ export function Switch({
   on,
   onClick,
   label,
+  disabled = false,
 }: {
   readonly on: boolean;
   readonly onClick: () => void;
   readonly label: string;
+  readonly disabled?: boolean;
 }): JSX.Element {
   return (
     <button
@@ -226,6 +228,7 @@ export function Switch({
       role="switch"
       aria-checked={on}
       aria-label={label}
+      disabled={disabled}
       onClick={onClick}
       style={{
         flexShrink: 0,
@@ -237,6 +240,8 @@ export function Switch({
         display: 'inline-flex',
         alignItems: 'center',
         transition: 'background 160ms ease',
+        opacity: disabled ? 0.5 : 1,
+        cursor: disabled ? 'not-allowed' : undefined,
       }}
     >
       <span

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -7,6 +7,7 @@ import {
   defaultUserSkillsDir,
   denyByDefaultResolver,
   discoverSkills,
+  loadPreferences,
   silentLogger,
 } from '@moxxy/core';
 import type { Plugin } from '@moxxy/sdk';
@@ -144,6 +145,19 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
   // selects one by name via `security.isolator`, so a discovered isolator can't
   // silently become the sandbox boundary.
   for (const iso of session.isolators.list()) security.registry.register(iso);
+
+  // Seed user-disabled providers (desktop Settings → Providers toggle) BEFORE
+  // the activation walk so a disabled provider is never auto-activated. The
+  // registry's disabled set is name-based, so seeding works regardless of
+  // plugin registration order. Best-effort, like every preferences read.
+  try {
+    const bootPrefs = await loadPreferences();
+    for (const name of bootPrefs.disabledProviders ?? []) {
+      session.providers.setEnabled(name, false);
+    }
+  } catch {
+    // preferences are optional — never block boot
+  }
 
   const { credentialResolver } = await activateProvider({
     session,

--- a/packages/cli/src/setup/activate-provider.ts
+++ b/packages/cli/src/setup/activate-provider.ts
@@ -55,6 +55,13 @@ export async function activateProvider(args: ActivateProviderArgs): Promise<Acti
   } else {
     for (let i = 0; i < candidates.length; i++) {
       const candidate = candidates[i]!;
+      // A user-disabled provider (preferences.json `disabledProviders`,
+      // seeded into the registry before this walk) is never auto-activated —
+      // fall through to the next candidate instead of failing on setActive.
+      if (!session.providers.isEnabled(candidate)) {
+        logger.warn('skipping disabled provider', { provider: candidate });
+        continue;
+      }
       // Only the FIRST candidate gets the interactive prompt — chaining
       // through fallbacks via prompts would be confusing.
       const interactive = i === 0 && !skipKeyPrompt && process.stdin.isTTY === true;

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -33,7 +33,7 @@ import {
   INSTALLABLE_PLUGIN_CATALOG,
 } from '@moxxy/plugin-plugins-admin';
 import { buildSelfUpdatePlugin } from '@moxxy/plugin-self-update';
-import { buildProviderAdminPlugin } from '@moxxy/plugin-provider-admin';
+import { buildProviderAdminPluginWithApi } from '@moxxy/plugin-provider-admin';
 import { buildUsageStatsPlugin } from '@moxxy/plugin-usage-stats';
 import { commandsPlugin } from '@moxxy/plugin-commands';
 import { buildViewPlugin } from '@moxxy/plugin-view';
@@ -430,10 +430,14 @@ export function buildBuiltinsCore(args: BuildBuiltinsArgs): BuiltBuiltinsCore {
     // ~/.moxxy/providers.json; the plugin's onInit re-registers them on
     // every boot. Pairs with the `add-provider` skill which walks the
     // model through gathering baseURL + models + key.
-    {
-      name: '@moxxy/plugin-provider-admin',
-      plugin: buildProviderAdminPlugin({ providerRegistry: session.providers }),
-    },
+    (() => {
+      const { plugin, api } = buildProviderAdminPluginWithApi({ providerRegistry: session.providers });
+      // Stash the api on the session so the desktop (via the runner's
+      // `provider.configure`) can edit a stored provider without going
+      // through the model. Mirrors the mcpAdmin stash below.
+      session.providerAdmin = api;
+      return { name: '@moxxy/plugin-provider-admin', plugin };
+    })(),
     // Admin tools (mcp_add_server, mcp_list_servers, mcp_remove_server,
     // mcp_test_server) plus the boot-time lazy attach. Passing the
     // session's live tool registry enables both hot-attach for runtime

--- a/packages/client-core/src/index.ts
+++ b/packages/client-core/src/index.ts
@@ -37,3 +37,4 @@ export * from './useAppUpdate.js';
 export * from './useMobileGateway.js';
 export * from './useVoiceRecorder.js';
 export * from './useActiveModeBadge.js';
+export * from './useSessionInfoBridge.js';

--- a/packages/client-core/src/useSessionInfoBridge.ts
+++ b/packages/client-core/src/useSessionInfoBridge.ts
@@ -1,0 +1,24 @@
+/**
+ * Bridges the runner's registry-change push to the renderer's EventBus.
+ *
+ * The host forwards the runner's `info.changed` notification as the
+ * `session.info.changed` IPC event (any provider/mode/MCP/workflow mutation —
+ * including ones made by TOOLS inside a turn, e.g. `provider_add`). This hook
+ * re-emits it as {@link SESSION_INFO_REFRESH_EVENT} on the platform EventBus,
+ * the signal every info-derived view already listens for (`useSettings`,
+ * `useActiveModeBadge`, `useActionCatalog`, the agent picker's raw window
+ * listener). Mount it ONCE near the app root.
+ */
+
+import { useEffect } from 'react';
+import { SESSION_INFO_REFRESH_EVENT } from '@moxxy/desktop-ipc-contract';
+import { api } from './transport.js';
+import { getPlatform } from './platform.js';
+
+export function useSessionInfoBridge(): void {
+  useEffect(() => {
+    return api().subscribe('session.info.changed', () => {
+      getPlatform().eventBus?.emit(SESSION_INFO_REFRESH_EVENT);
+    });
+  }, []);
+}

--- a/packages/client-core/src/useSettings.test.tsx
+++ b/packages/client-core/src/useSettings.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * useSettings + useSessionInfoBridge tests — drive the IPC surface through
+ * the fake api shim and assert (1) the settings slice re-fetches when the
+ * session-info refresh signal fires on the platform EventBus, (2) the
+ * provider actions hit the right IPC commands in the right order, and
+ * (3) the bridge re-emits the runner's `session.info.changed` push as
+ * SESSION_INFO_REFRESH_EVENT.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { SESSION_INFO_REFRESH_EVENT } from '@moxxy/desktop-ipc-contract';
+import type { MoxxyApi } from '@moxxy/desktop-ipc-contract';
+import { __setApiOverride } from './transport.js';
+import { configurePlatform, type EventBus } from './platform.js';
+import { useSettings } from './useSettings.js';
+import { useSessionInfoBridge } from './useSessionInfoBridge.js';
+
+/** In-memory EventBus (the real desktop one wraps window events). */
+function fakeEventBus(): EventBus & { fire: (event: string) => void } {
+  const listeners = new Map<string, Set<() => void>>();
+  return {
+    on(event, handler) {
+      const set = listeners.get(event) ?? new Set();
+      set.add(handler);
+      listeners.set(event, set);
+      return () => set.delete(handler);
+    },
+    emit(event) {
+      for (const fn of listeners.get(event) ?? []) fn();
+    },
+    fire(event) {
+      for (const fn of listeners.get(event) ?? []) fn();
+    },
+  };
+}
+
+afterEach(() => {
+  __setApiOverride(null);
+  configurePlatform({});
+});
+
+describe('useSettings', () => {
+  it('re-fetches when SESSION_INFO_REFRESH_EVENT fires on the EventBus', async () => {
+    const bus = fakeEventBus();
+    configurePlatform({ eventBus: bus });
+    const counts = { providers: 0 };
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === 'settings.providers') {
+        counts.providers += 1;
+        return [];
+      }
+      return [];
+    });
+    __setApiOverride({ invoke, subscribe: () => () => {} } as unknown as MoxxyApi);
+
+    renderHook(() => useSettings());
+    await waitFor(() => expect(counts.providers).toBe(1));
+
+    act(() => bus.fire(SESSION_INFO_REFRESH_EVENT));
+    await waitFor(() => expect(counts.providers).toBe(2));
+  });
+
+  it('setProviderEnabled hits settings.providerSetEnabled then refreshes', async () => {
+    const invokes: string[] = [];
+    const invoke = vi.fn(async (cmd: string) => {
+      invokes.push(cmd);
+      return [];
+    });
+    __setApiOverride({ invoke, subscribe: () => () => {} } as unknown as MoxxyApi);
+
+    const { result } = renderHook(() => useSettings());
+    await waitFor(() => expect(invokes).toContain('settings.providers'));
+    invokes.length = 0;
+
+    await act(() => result.current.setProviderEnabled('zai', false));
+    expect(invokes[0]).toBe('settings.providerSetEnabled');
+    expect(invokes).toContain('settings.providers'); // refreshed after
+  });
+
+  it('setProviderKey saves to the vault, re-probes readiness, then refreshes', async () => {
+    const invokes: Array<{ cmd: string; args: unknown }> = [];
+    const invoke = vi.fn(async (cmd: string, args?: unknown) => {
+      invokes.push({ cmd, args });
+      return [];
+    });
+    __setApiOverride({ invoke, subscribe: () => () => {} } as unknown as MoxxyApi);
+
+    const { result } = renderHook(() => useSettings());
+    await waitFor(() => expect(invokes.some((i) => i.cmd === 'settings.providers')).toBe(true));
+    invokes.length = 0;
+
+    await act(() => result.current.setProviderKey('ZAI_API_KEY', 'sk-test'));
+    expect(invokes[0]).toEqual({
+      cmd: 'settings.vaultSet',
+      args: { name: 'ZAI_API_KEY', value: 'sk-test' },
+    });
+    expect(invokes[1]?.cmd).toBe('settings.providerRefreshReady');
+  });
+
+  it('surfaces the runner error when a toggle is refused (active provider)', async () => {
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === 'settings.providerSetEnabled') {
+        throw new Error('Cannot disable the active provider "fake"');
+      }
+      return [];
+    });
+    __setApiOverride({ invoke, subscribe: () => () => {} } as unknown as MoxxyApi);
+
+    const { result } = renderHook(() => useSettings());
+    // Let the mount fetch settle first — its success path clears `error`.
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(() => result.current.setProviderEnabled('fake', false));
+    await waitFor(() => expect(result.current.error).toMatch(/active provider/i));
+  });
+});
+
+describe('useSessionInfoBridge', () => {
+  it("re-emits the host's session.info.changed push as SESSION_INFO_REFRESH_EVENT", async () => {
+    const bus = fakeEventBus();
+    configurePlatform({ eventBus: bus });
+    let push: (() => void) | null = null;
+    const api = {
+      invoke: vi.fn(async () => []),
+      subscribe: (channel: string, handler: () => void) => {
+        if (channel === 'session.info.changed') push = handler;
+        return () => {
+          push = null;
+        };
+      },
+    };
+    __setApiOverride(api as unknown as MoxxyApi);
+
+    const heard = vi.fn();
+    bus.on(SESSION_INFO_REFRESH_EVENT, heard);
+
+    const { unmount } = renderHook(() => useSessionInfoBridge());
+    await waitFor(() => expect(push).not.toBeNull());
+
+    act(() => push!());
+    expect(heard).toHaveBeenCalledTimes(1);
+
+    // Unmount unsubscribes from the IPC channel.
+    unmount();
+    expect(push).toBeNull();
+  });
+});

--- a/packages/client-core/src/useSettings.ts
+++ b/packages/client-core/src/useSettings.ts
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 import { api } from './transport.js';
+import { getPlatform } from './platform.js';
 import { toErrorMessage } from './errors.js';
-import type {
-  McpServerEntry,
-  ProviderEntry,
-  SkillFile,
-  VaultEntryName,
+import {
+  SESSION_INFO_REFRESH_EVENT,
+  type McpServerEntry,
+  type ProviderEntry,
+  type SkillFile,
+  type VaultEntryName,
 } from '@moxxy/desktop-ipc-contract';
 
 export interface UseSettings {
@@ -17,6 +19,19 @@ export interface UseSettings {
   readonly error: string | null;
   readonly refresh: () => Promise<void>;
   readonly toggleMcp: (name: string, enabled: boolean) => Promise<void>;
+  /** Enable/disable a provider on the runner. Surfaces the runner's error
+   *  (e.g. refusing to disable the ACTIVE provider) via `error`. */
+  readonly setProviderEnabled: (name: string, enabled: boolean) => Promise<void>;
+  /** Patch a stored (admin) provider's config. Throws so the configure
+   *  sheet can render the error inline. */
+  readonly configureProvider: (
+    name: string,
+    patch: { baseURL?: string; defaultModel?: string; envVar?: string },
+  ) => Promise<void>;
+  /** Save an API key to the vault under `keyName`, then have the runner
+   *  re-probe credentials so the readiness dot flips live. Throws for
+   *  inline error rendering. */
+  readonly setProviderKey: (keyName: string, value: string) => Promise<void>;
   readonly readSkill: (name: string) => Promise<string>;
   readonly writeSkill: (name: string, body: string) => Promise<void>;
   readonly deleteSkill: (name: string) => Promise<void>;
@@ -57,6 +72,17 @@ export function useSettings(): UseSettings {
     void refresh();
   }, [refresh]);
 
+  // Re-fetch whenever the session-info refresh signal fires — emitted by the
+  // renderer's own pickers AND (via useSessionInfoBridge) by the runner's
+  // `info.changed` push, so a provider/MCP/skill/workflow added by the agent
+  // mid-conversation shows up here without reopening Settings.
+  useEffect(() => {
+    const off = getPlatform().eventBus?.on(SESSION_INFO_REFRESH_EVENT, () => {
+      void refresh();
+    });
+    return off;
+  }, [refresh]);
+
   const toggleMcp = useCallback(
     async (name: string, enabled: boolean): Promise<void> => {
       try {
@@ -65,6 +91,47 @@ export function useSettings(): UseSettings {
       } catch (e) {
         setError(toErrorMessage(e));
       }
+    },
+    [refresh],
+  );
+
+  const setProviderEnabled = useCallback(
+    async (name: string, enabled: boolean): Promise<void> => {
+      try {
+        await api().invoke('settings.providerSetEnabled', { name, enabled });
+        await refresh();
+      } catch (e) {
+        setError(toErrorMessage(e));
+      }
+    },
+    [refresh],
+  );
+
+  const configureProvider = useCallback(
+    async (
+      name: string,
+      patch: { baseURL?: string; defaultModel?: string; envVar?: string },
+    ): Promise<void> => {
+      // Let the configure sheet surface the error inline; still refresh on
+      // success so the row reflects the new config.
+      await api().invoke('settings.providerConfigure', { name, patch });
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const setProviderKey = useCallback(
+    async (keyName: string, value: string): Promise<void> => {
+      await api().invoke('settings.vaultSet', { name: keyName, value });
+      // The key is on disk; have the runner re-probe credentials so the
+      // readiness dot flips without a restart. Best-effort — an old runner
+      // without v7 still saved the key, it just needs a restart to see it.
+      try {
+        await api().invoke('settings.providerRefreshReady');
+      } catch {
+        /* pre-v7 runner — key saved, readiness updates on next boot */
+      }
+      await refresh();
     },
     [refresh],
   );
@@ -129,6 +196,9 @@ export function useSettings(): UseSettings {
     error,
     refresh,
     toggleMcp,
+    setProviderEnabled,
+    configureProvider,
+    setProviderKey,
     readSkill,
     writeSkill,
     deleteSkill,

--- a/packages/core/src/preferences.ts
+++ b/packages/core/src/preferences.ts
@@ -18,6 +18,12 @@ export interface MoxxyPreferences {
   readonly model?: string;
   /** Active loop strategy name (e.g. "default", "research", "goal"). */
   readonly mode?: string;
+  /**
+   * Providers the user disabled (desktop Settings → Providers toggle).
+   * Seeded into the ProviderRegistry at boot; a listed provider stays
+   * registered but can't be activated until re-enabled.
+   */
+  readonly disabledProviders?: ReadonlyArray<string>;
 }
 
 export function preferencesPath(): string {

--- a/packages/core/src/registries/providers.test.ts
+++ b/packages/core/src/registries/providers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { LLMProvider, ProviderDef } from '@moxxy/sdk';
+import { ProviderRegistry } from './providers.js';
+
+function def(name: string): ProviderDef {
+  return {
+    name,
+    models: [{ id: `${name}-model`, contextWindow: 1000 }],
+    createClient: () => ({ name, models: [] }) as unknown as LLMProvider,
+  } as ProviderDef;
+}
+
+describe('ProviderRegistry enable/disable', () => {
+  it('providers are enabled by default; disabling blocks setActive', () => {
+    const reg = new ProviderRegistry();
+    reg.register(def('a'));
+    expect(reg.isEnabled('a')).toBe(true);
+
+    reg.setEnabled('a', false);
+    expect(reg.isEnabled('a')).toBe(false);
+    expect(() => reg.setActive('a')).toThrow(/disabled/);
+
+    reg.setEnabled('a', true);
+    expect(() => reg.setActive('a')).not.toThrow();
+  });
+
+  it('refuses to disable the ACTIVE provider', () => {
+    const reg = new ProviderRegistry();
+    reg.register(def('a'));
+    reg.setActive('a');
+    expect(() => reg.setEnabled('a', false)).toThrow(/active provider/i);
+    // Still enabled after the refused toggle.
+    expect(reg.isEnabled('a')).toBe(true);
+  });
+
+  it('accepts seeding unknown names before their defs register (boot order)', () => {
+    const reg = new ProviderRegistry();
+    reg.setEnabled('later', false);
+    reg.register(def('later'));
+    expect(reg.isEnabled('later')).toBe(false);
+    expect(() => reg.setActive('later')).toThrow(/disabled/);
+  });
+
+  it('keeps disabled providers listed (visible but inactive)', () => {
+    const reg = new ProviderRegistry();
+    reg.register(def('a'));
+    reg.setEnabled('a', false);
+    expect(reg.list().map((d) => d.name)).toContain('a');
+  });
+});

--- a/packages/core/src/registries/providers.ts
+++ b/packages/core/src/registries/providers.ts
@@ -4,6 +4,13 @@ export class ProviderRegistry {
   private readonly defs = new Map<string, ProviderDef>();
   private readonly instances = new Map<string, LLMProvider>();
   private active: string | null = null;
+  /**
+   * Names the user disabled. Kept name-based (not def-based) so it can be
+   * seeded from preferences BEFORE the plugins register their defs — boot
+   * order doesn't matter. A disabled provider stays registered/listable but
+   * can't be activated.
+   */
+  private readonly disabled = new Set<string>();
 
   /**
    * Register a provider def. Throws on duplicate — use `replace()` for
@@ -34,9 +41,31 @@ export class ProviderRegistry {
     return [...this.defs.values()];
   }
 
+  /**
+   * Enable/disable a provider by name. Disabling the ACTIVE provider is
+   * refused — switch first, then disable — so a session never ends up with an
+   * active-but-disabled provider. Unknown names are accepted (the set seeds
+   * from preferences before plugins register), except when disabling via a
+   * live toggle is meaningless because the provider is active.
+   */
+  setEnabled(name: string, enabled: boolean): void {
+    if (!enabled && this.active === name) {
+      throw new Error(`Cannot disable the active provider "${name}" — switch providers first.`);
+    }
+    if (enabled) this.disabled.delete(name);
+    else this.disabled.add(name);
+  }
+
+  isEnabled(name: string): boolean {
+    return !this.disabled.has(name);
+  }
+
   setActive(name: string, config?: Record<string, unknown>): LLMProvider {
     const def = this.defs.get(name);
     if (!def) throw new Error(`Provider not registered: ${name}`);
+    if (this.disabled.has(name)) {
+      throw new Error(`Provider "${name}" is disabled — enable it first.`);
+    }
     let instance = this.instances.get(name);
     if (!instance) {
       instance = def.createClient(config ?? {});

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -40,6 +40,7 @@ import type {
   CredentialResolver,
   ElisionSettings,
   McpAdminView,
+  ProviderAdminView,
   WorkflowsView,
   PluginsAdminView,
   PendingToolCall,
@@ -153,6 +154,7 @@ export class Session implements ClientSession, SessionRuntime {
   readyProviders?: Set<string>;
   credentialResolver?: CredentialResolver;
   mcpAdmin?: McpAdminView;
+  providerAdmin?: ProviderAdminView;
   workflows?: WorkflowsView;
   pluginsAdmin?: PluginsAdminView;
   readonly dispatcher: HookDispatcherImpl;
@@ -379,6 +381,7 @@ export class Session implements ClientSession, SessionRuntime {
         // setting `supportsLiveModelDiscovery: true` on their def.
         supportsLiveModelDiscovery:
           (p as { supportsLiveModelDiscovery?: boolean }).supportsLiveModelDiscovery === true,
+        enabled: this.providers.isEnabled(p.name),
       })),
       activeMode,
       activeModeBadge,

--- a/packages/desktop-host/src/ipc/settings.ts
+++ b/packages/desktop-host/src/ipc/settings.ts
@@ -10,7 +10,7 @@
  */
 
 import type { RunnerPool } from '../runner-pool';
-import { handle, mustSession, resolveSupervisor } from './shared';
+import { handle, mustRemote, mustSession, resolveSupervisor } from './shared';
 
 export function registerSettingsHandlers(pool: RunnerPool): void {
   // ---- Settings -----------------------------------------------------------
@@ -43,10 +43,39 @@ export function registerSettingsHandlers(pool: RunnerPool): void {
     if (!session) return [];
     const info = session.getInfo();
     const readySet = new Set(info.readyProviders ?? []);
-    return info.providers.map((p) => ({
-      name: p.name,
-      ready: readySet.has(p.name),
-    }));
+    // Stored (runtime-registered) entries carry the configure-relevant
+    // detail; providers absent from providers.json are built-ins.
+    const { readAdminProviderDetails, builtinProviderKeyName } = await import('../provider-discovery');
+    const admin = await readAdminProviderDetails();
+    return info.providers.map((p) => {
+      const detail = admin.get(p.name);
+      return {
+        name: p.name,
+        ready: readySet.has(p.name),
+        // Older runners (pre-v7) omit `enabled` — treat absent as enabled.
+        enabled: p.enabled !== false,
+        active: info.activeProvider === p.name,
+        authKind: p.authKind,
+        kind: detail ? ('admin' as const) : ('builtin' as const),
+        keyName: detail?.keyName ?? builtinProviderKeyName(p.name),
+        ...(detail
+          ? {
+              baseURL: detail.baseURL,
+              defaultModel: detail.defaultModel,
+              modelIds: detail.modelIds,
+            }
+          : {}),
+      };
+    });
+  });
+  handle('settings.providerSetEnabled', async ({ workspaceId, name, enabled }) => {
+    await mustRemote(pool, workspaceId).providerAdmin.setEnabled(name, enabled);
+  });
+  handle('settings.providerConfigure', async ({ workspaceId, name, patch }) => {
+    await mustRemote(pool, workspaceId).providerAdmin.configure(name, patch);
+  });
+  handle('settings.providerRefreshReady', async (args) => {
+    await mustRemote(pool, args?.workspaceId).providerAdmin.refreshReady();
   });
   handle('settings.mcpServers', async (args) => {
     const session = mustSession(pool, args?.workspaceId);

--- a/packages/desktop-host/src/provider-discovery.ts
+++ b/packages/desktop-host/src/provider-discovery.ts
@@ -56,6 +56,45 @@ export async function readAdminProviderNames(): Promise<string[]> {
   return providers.map((p) => p.name).filter((n): n is string => typeof n === 'string');
 }
 
+/** Display detail of one stored admin provider for the Settings tab. */
+export interface AdminProviderDetail {
+  readonly name: string;
+  readonly baseURL: string;
+  readonly defaultModel: string;
+  readonly modelIds: ReadonlyArray<string>;
+  /** Vault entry name holding the API key (`envVar` override or `<NAME>_API_KEY`). */
+  readonly keyName: string;
+}
+
+/**
+ * Stored admin-provider entries keyed by name, for merging configure-relevant
+ * detail (baseURL/defaultModel/models/keyName) into `settings.providers`.
+ */
+export async function readAdminProviderDetails(): Promise<Map<string, AdminProviderDetail>> {
+  const { providers } = await readStoredProviders();
+  const out = new Map<string, AdminProviderDetail>();
+  for (const p of providers) {
+    if (typeof p.name !== 'string') continue;
+    out.set(p.name, {
+      name: p.name,
+      baseURL: p.baseURL,
+      defaultModel: p.defaultModel,
+      modelIds: (p.models ?? []).map((m) => m.id).filter((id): id is string => typeof id === 'string'),
+      keyName: envVarFor(p),
+    });
+  }
+  return out;
+}
+
+/**
+ * Vault entry name for a BUILT-IN provider's API key — the same
+ * `<NAME>_API_KEY` derivation `saveProviderKey` (onboarding) and the CLI's
+ * credential resolver use.
+ */
+export function builtinProviderKeyName(providerName: string): string {
+  return `${providerName.toUpperCase().replace(/-/g, '_')}_API_KEY`;
+}
+
 /**
  * Spawn `moxxy vault get <key>` and resolve to stdout (trimmed). The
  * CLI prints the decrypted value to stdout and any UX scaffolding to

--- a/packages/desktop-host/src/session-driver.test.ts
+++ b/packages/desktop-host/src/session-driver.test.ts
@@ -310,8 +310,13 @@ interface PermissionCheck {
     ctx: { toolDescription?: string },
   ) => Promise<{ mode: string }>;
 }
-function fakeRemote(): { remote: RemoteSession; captured: { permission?: PermissionCheck } } {
+function fakeRemote(): {
+  remote: RemoteSession;
+  captured: { permission?: PermissionCheck };
+  fireInfoChanged: () => void;
+} {
   const captured: { permission?: PermissionCheck } = {};
+  const infoListeners = new Set<() => void>();
   const remote = {
     log: { subscribe: () => () => undefined },
     setPermissionResolver: (r: PermissionCheck) => {
@@ -319,8 +324,18 @@ function fakeRemote(): { remote: RemoteSession; captured: { permission?: Permiss
     },
     setApprovalResolver: () => undefined,
     onClose: () => undefined,
+    onInfoChanged: (fn: () => void) => {
+      infoListeners.add(fn);
+      return () => infoListeners.delete(fn);
+    },
   };
-  return { remote: remote as unknown as RemoteSession, captured };
+  return {
+    remote: remote as unknown as RemoteSession,
+    captured,
+    fireInfoChanged: () => {
+      for (const fn of infoListeners) fn();
+    },
+  };
 }
 
 describe('SessionDriver auto-approve', () => {
@@ -351,5 +366,23 @@ describe('SessionDriver auto-approve', () => {
     driver.dispose();
     const res = await p;
     expect(res.mode).toBe('deny');
+  });
+});
+
+describe('SessionDriver info-changed forwarding', () => {
+  it("mirrors the runner's info.changed push as a session.info.changed IPC event", () => {
+    const { remote, fireInfoChanged } = fakeRemote();
+    const { win, sent } = fakeWindow();
+    const driver = new SessionDriver(remote, win, 'ws-1');
+
+    fireInfoChanged();
+    const frames = sent.filter((f) => f.channel === 'session.info.changed');
+    expect(frames).toHaveLength(1);
+    expect(frames[0]!.payload).toEqual({ workspaceId: 'ws-1' });
+
+    // After dispose the subscription is dropped — no more forwards.
+    driver.dispose();
+    fireInfoChanged();
+    expect(sent.filter((f) => f.channel === 'session.info.changed')).toHaveLength(1);
   });
 });

--- a/packages/desktop-host/src/session-driver.ts
+++ b/packages/desktop-host/src/session-driver.ts
@@ -64,6 +64,16 @@ export class SessionDriver {
     });
     this.disposes.push(logUnsub);
 
+    // Forward registry-snapshot pushes (`info.changed`) so the renderer's
+    // info-derived views (Settings tabs, mode badge, action catalog) refresh
+    // when a provider/MCP/workflow/mode changes on the runner — including
+    // changes made by TOOLS inside a turn (provider_add etc.), which used to
+    // require an app restart to show up.
+    const infoUnsub = this.session.onInfoChanged(() => {
+      this.send('session.info.changed', { workspaceId });
+    });
+    this.disposes.push(infoUnsub);
+
     // Forward the runner's permission + approval decisions to the renderer's
     // bottom sheet. Declaring these resolvers tells the runner this client
     // handles permissions/approvals, so loop strategies (research)

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -312,6 +312,23 @@ export interface ProviderEntry {
   /** True when the runner has activated this provider (credentials
    *  resolved). False = entry exists but key is missing or invalid. */
   ready: boolean;
+  /** False when the user disabled this provider (Settings toggle). */
+  enabled: boolean;
+  /** True when this is the runner's active provider (disable is refused). */
+  active: boolean;
+  /** 'oauth' providers authenticate via `moxxy login`, not a vault key. */
+  authKind: 'oauth' | 'api-key';
+  /** 'admin' = runtime-registered via providers.json (configurable);
+   *  'builtin' = ships with moxxy (key/enable management only). */
+  kind: 'builtin' | 'admin';
+  /** Vault entry name holding this provider's API key (`<NAME>_API_KEY` or
+   *  the stored envVar override). The Configure sheet writes it via
+   *  `settings.vaultSet` then calls `settings.providerRefreshReady`. */
+  keyName: string;
+  /** Stored entry detail — admin providers only. */
+  baseURL?: string;
+  defaultModel?: string;
+  modelIds?: ReadonlyArray<string>;
 }
 
 export interface McpServerEntry {
@@ -518,6 +535,12 @@ export interface IpcEvents {
    *  client connected/left) — the Settings → Mobile tab re-renders the QR +
    *  client count from this without polling. */
   'mobileGateway.changed': MobileGatewayStatus;
+  /** The runner's registry snapshot changed (provider/mode/MCP/workflow
+   *  mutations — including ones made by TOOLS inside a turn, e.g.
+   *  provider_add). The renderer re-emits {@link SESSION_INFO_REFRESH_EVENT}
+   *  on its EventBus so every info-derived view (Settings tabs, mode badge,
+   *  action catalog) refreshes without polling or an app restart. */
+  'session.info.changed': { workspaceId: string };
 }
 
 // ---------- Invokable commands (renderer → main) --------------------------
@@ -815,6 +838,23 @@ export interface IpcCommands {
 
   /** Provider list for the given workspace (defaults to active). */
   'settings.providers': (args?: { workspaceId?: string }) => Promise<ReadonlyArray<ProviderEntry>>;
+  /** Enable/disable a provider on the runner (persists across restarts).
+   *  Disabling the ACTIVE provider is refused with a clear error. */
+  'settings.providerSetEnabled': (args: {
+    workspaceId?: string;
+    name: string;
+    enabled: boolean;
+  }) => Promise<void>;
+  /** Patch a stored (runtime-registered) provider's config — live registry
+   *  re-register + providers.json persist. Built-ins are not configurable. */
+  'settings.providerConfigure': (args: {
+    workspaceId?: string;
+    name: string;
+    patch: { baseURL?: string; defaultModel?: string; envVar?: string };
+  }) => Promise<void>;
+  /** Re-probe every provider's credentials on the runner so a key just saved
+   *  via `settings.vaultSet` flips readiness without a restart. */
+  'settings.providerRefreshReady': (args?: { workspaceId?: string }) => Promise<void>;
   /** Hit the provider's /v1/models endpoint and return the model ids
    *  it advertises. Useful for admin-registered providers whose
    *  providers.json entry didn't enumerate models upfront. */

--- a/packages/plugin-provider-admin/src/index.ts
+++ b/packages/plugin-provider-admin/src/index.ts
@@ -1,4 +1,13 @@
-import { defineTool, definePlugin, MoxxyError, type Plugin, type ProviderDef, z } from '@moxxy/sdk';
+import {
+  defineTool,
+  definePlugin,
+  MoxxyError,
+  z,
+  type Plugin,
+  type ProviderAdminView,
+  type ProviderConfigurePatch,
+  type ProviderDef,
+} from '@moxxy/sdk';
 import { buildProviderDef, validateOpenAICompatKey } from './factory.js';
 import { providerApiKeyName } from './key-name.js';
 import {
@@ -98,6 +107,64 @@ const testProviderInput = z.object({
         'and never pass one as a tool argument. Have them store it first: /vault set <NAME> <key>.',
     ),
 });
+
+/**
+ * Like {@link buildProviderAdminPlugin} but also returns a
+ * {@link ProviderAdminView} api the host can stash on the session
+ * (`session.providerAdmin`) so channels — and the runner's
+ * `provider.configure` method — can edit a stored provider without going
+ * through the model. Mirrors `buildMcpAdminPluginWithApi`.
+ */
+export function buildProviderAdminPluginWithApi(opts: BuildProviderAdminPluginOptions): {
+  readonly plugin: Plugin;
+  readonly api: ProviderAdminView;
+} {
+  const { providerRegistry, configPath } = opts;
+  const api: ProviderAdminView = {
+    configure: async (name: string, patch: ProviderConfigurePatch): Promise<void> => {
+      const cfg = await readProvidersConfig(configPath);
+      const entry = cfg.providers.find((p) => p.name === name);
+      if (!entry) {
+        throw new MoxxyError({
+          code: 'CONFIG_INVALID',
+          message:
+            `provider-admin: no stored provider named "${name}" — only runtime-registered ` +
+            `(providers.json) providers are configurable; built-ins are code.`,
+        });
+      }
+      const next: StoredProvider = {
+        ...entry,
+        ...(patch.baseURL ? { baseURL: patch.baseURL } : {}),
+        ...(patch.defaultModel ? { defaultModel: patch.defaultModel } : {}),
+        ...(patch.envVar ? { envVar: patch.envVar } : {}),
+        ...(patch.models && patch.models.length > 0 ? { models: patch.models } : {}),
+      };
+      if (!next.models.some((m) => m.id === next.defaultModel)) {
+        throw new MoxxyError({
+          code: 'CONFIG_INVALID',
+          message:
+            `provider-admin: defaultModel "${next.defaultModel}" is not in the models list ` +
+            `(${next.models.map((m) => m.id).join(', ')}).`,
+        });
+      }
+      // Same order as provider_add: live registry first, then disk, so a
+      // failed write can roll back to the previous def.
+      const def = buildProviderDef(next);
+      const hadDef = providerRegistry.list().some((p) => p.name === name);
+      if (hadDef) providerRegistry.replace(def);
+      else providerRegistry.register(def);
+      try {
+        await upsertStoredProvider(next, configPath);
+      } catch (err) {
+        const prev = buildProviderDef(entry);
+        if (hadDef) providerRegistry.replace(prev);
+        else providerRegistry.unregister(name);
+        throw err;
+      }
+    },
+  };
+  return { plugin: buildProviderAdminPlugin(opts), api };
+}
 
 export function buildProviderAdminPlugin(opts: BuildProviderAdminPluginOptions): Plugin {
   const { providerRegistry, configPath } = opts;

--- a/packages/runner/src/integration.test.ts
+++ b/packages/runner/src/integration.test.ts
@@ -863,3 +863,147 @@ describe('runner end-to-end', () => {
     await expect(remote.workflows.resume('run-7', 'hi')).rejects.toThrow(/resume not supported/);
   });
 });
+
+describe('provider management (protocol v7)', () => {
+  /** Run `fn` with HOME redirected to a temp dir so preference writes land
+   *  in the test sandbox (same pattern as the persists-provider test). */
+  async function withTempHome(fn: (home: string) => Promise<void>): Promise<void> {
+    const home = await mkdtemp(path.join(os.tmpdir(), 'moxxy-prov-'));
+    const prevHome = process.env.HOME;
+    const prevUserProfile = process.env.USERPROFILE;
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    try {
+      await fn(home);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevUserProfile;
+      await rm(home, { recursive: true, force: true });
+    }
+  }
+
+  function withSecondProvider(session: Session, provider: FakeProvider): void {
+    session.pluginHost.registerStatic(
+      definePlugin({
+        name: 'runner-test-second-provider',
+        providers: [
+          defineProvider({
+            name: 'fake2',
+            models: [...provider.models],
+            createClient: () => provider,
+          }),
+        ],
+      }),
+    );
+  }
+
+  it('provider.setEnabled disables in the live registry, persists, and pushes info', async () => {
+    await withTempHome(async (home) => {
+      const socketPath = tmpSocket();
+      const provider = new FakeProvider({ script: [textReply('hi')] });
+      const session = buildSession(provider);
+      withSecondProvider(session, provider);
+      const server = await startRunnerServer(session, { socketPath });
+      servers.push(server);
+      const remote = await attach(socketPath);
+
+      await remote.providerAdmin.setEnabled('fake2', false);
+      expect(session.providers.isEnabled('fake2')).toBe(false);
+      // The push refreshes the client snapshot.
+      await waitFor(
+        () => remote.getInfo().providers.find((p) => p.name === 'fake2')?.enabled === false,
+      );
+      // Persisted (fire-and-forget) so the next boot's walk skips it.
+      const prefsPath = path.join(home, '.moxxy', 'preferences.json');
+      await waitForAsync(async () => {
+        const prefs = JSON.parse(await readFile(prefsPath, 'utf8')) as {
+          disabledProviders?: string[];
+        };
+        return prefs.disabledProviders?.includes('fake2') === true;
+      });
+
+      // Re-enable: registry + persisted list both flip back.
+      await remote.providerAdmin.setEnabled('fake2', true);
+      expect(session.providers.isEnabled('fake2')).toBe(true);
+      await waitForAsync(async () => {
+        const prefs = JSON.parse(await readFile(prefsPath, 'utf8')) as {
+          disabledProviders?: string[];
+        };
+        return prefs.disabledProviders?.includes('fake2') === false;
+      });
+    });
+  });
+
+  it('provider.setEnabled refuses to disable the ACTIVE provider', async () => {
+    await withTempHome(async () => {
+      const provider = new FakeProvider({ script: [textReply('hi')] });
+      const { socketPath } = await serve(provider);
+      const remote = await attach(socketPath);
+      await expect(remote.providerAdmin.setEnabled(provider.name, false)).rejects.toThrow(
+        /active provider/i,
+      );
+    });
+  });
+
+  it('provider.refreshReady re-probes credentials via the session resolver', async () => {
+    const socketPath = tmpSocket();
+    const provider = new FakeProvider({ script: [textReply('hi')] });
+    const session = buildSession(provider);
+    withSecondProvider(session, provider);
+    // Only fake2 resolves; the probe must add it to readyProviders.
+    session.credentialResolver = async (name) => {
+      if (name === 'fake2') return {};
+      throw new Error('no credentials');
+    };
+    session.readyProviders = new Set();
+    const server = await startRunnerServer(session, { socketPath });
+    servers.push(server);
+    const remote = await attach(socketPath);
+
+    await remote.providerAdmin.refreshReady();
+    // The active provider is always included; fake2 resolved.
+    expect([...(session.readyProviders ?? [])].sort()).toEqual([provider.name, 'fake2'].sort());
+    await waitFor(() => remote.getInfo().readyProviders.includes('fake2'));
+  });
+
+  it('provider.configure forwards to the session providerAdmin view and pushes info', async () => {
+    const socketPath = tmpSocket();
+    const provider = new FakeProvider({ script: [textReply('hi')] });
+    const session = buildSession(provider);
+    const configured: Array<{ name: string; patch: unknown }> = [];
+    session.providerAdmin = {
+      configure: async (name, patch) => {
+        configured.push({ name, patch });
+      },
+    };
+    const server = await startRunnerServer(session, { socketPath });
+    servers.push(server);
+    const remote = await attach(socketPath);
+
+    await remote.providerAdmin.configure('zai', { baseURL: 'https://api.z.ai/v1' });
+    expect(configured).toEqual([{ name: 'zai', patch: { baseURL: 'https://api.z.ai/v1' } }]);
+  });
+
+  it('provider.configure rejects cleanly when the runner lacks the providerAdmin view', async () => {
+    const provider = new FakeProvider({ script: [textReply('hi')] });
+    const { socketPath } = await serve(provider);
+    const remote = await attach(socketPath);
+    await expect(remote.providerAdmin.configure('zai', {})).rejects.toThrow(/not supported/);
+  });
+
+  it('broadcasts info.changed after a turn completes (registry-mutating tools)', async () => {
+    const provider = new FakeProvider({ script: [textReply('done')] });
+    const { socketPath } = await serve(provider);
+    const remote = await attach(socketPath);
+
+    let pushes = 0;
+    remote.onInfoChanged(() => {
+      pushes += 1;
+    });
+    for await (const event of remote.runTurn('hello')) void event;
+    await waitFor(() => pushes >= 1);
+    expect(pushes).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/runner/src/protocol.ts
+++ b/packages/runner/src/protocol.ts
@@ -79,11 +79,30 @@ import type {
  *     log, not the mirror). An older server ignores the param and replays in
  *     full from seq 0 without `replay.start` — still correct, just slower.
  *
- * Every change v1→v6 has been ADDITIVE, so MIN_COMPATIBLE stays at 1: today's
+ * v7: three additive provider-management methods backing the desktop's
+ * interactive Settings → Providers tab.
+ *   - `provider.setEnabled` toggles a provider on/off in the live registry
+ *     (disable refuses the ACTIVE provider) and persists the disabled set to
+ *     ~/.moxxy/preferences.json so the next boot's activation walk skips it.
+ *   - `provider.refreshReady` re-probes every registered provider's
+ *     credentials via the session's credential resolver and replaces
+ *     `readyProviders` — so a key saved to the vault flips the readiness dot
+ *     without a runner restart.
+ *   - `provider.configure` patches a STORED (runtime-registered) provider's
+ *     entry through the session's optional `providerAdmin` view (live
+ *     re-register + providers.json persist); it throws a clear "not
+ *     supported" error when the provider-admin plugin isn't wired.
+ *   The server also broadcasts `info.changed` after every completed turn —
+ *   a turn may have run registry-mutating tools (provider_add, mcp_add,
+ *   workflow_create, …), and attached clients (the desktop Settings panel)
+ *   re-render from that push instead of requiring an app restart. A v7
+ *   client gates the new methods on the server's reported version.
+ *
+ * Every change v1→v7 has been ADDITIVE, so MIN_COMPATIBLE stays at 1: today's
  * server can serve any client back to v1, and any client v1+ can attach. Bump
  * MIN_COMPATIBLE to N only when landing a breaking change at version N.
  */
-export const RUNNER_PROTOCOL_VERSION = 6;
+export const RUNNER_PROTOCOL_VERSION = 7;
 
 /**
  * Lowest client protocol version this build's CORE session protocol is
@@ -118,6 +137,12 @@ export const RunnerMethod = {
   ModeSetActive: 'mode.setActive',
   /** client->server: switch the active provider (server resolves credentials). */
   ProviderSetActive: 'provider.setActive',
+  /** client->server: enable/disable a provider (v7; persists to preferences). */
+  ProviderSetEnabled: 'provider.setEnabled',
+  /** client->server: re-probe every provider's credentials → readyProviders (v7). */
+  ProviderRefreshReady: 'provider.refreshReady',
+  /** client->server: patch a stored (runtime-registered) provider's config (v7). */
+  ProviderConfigure: 'provider.configure',
   /** client->server: persist an allow-always permission rule. */
   PermissionAddAllow: 'permission.addAllow',
   /** client->server: run a registered slash command on the runner. */
@@ -410,6 +435,33 @@ export const modeSetActiveParamsSchema = z.object({ name: z.string() });
 export const providerSetActiveParamsSchema = z.object({
   name: z.string(),
   config: z.record(z.unknown()).optional(),
+});
+
+export const providerSetEnabledParamsSchema = z.object({
+  name: z.string().min(1),
+  enabled: z.boolean(),
+});
+
+/**
+ * Patch for `provider.configure` (v7). Models are validated structurally
+ * (id + contextWindow, passthrough for richer descriptor fields) — the same
+ * looseness as the provider-admin store schema, so newer descriptor fields
+ * round-trip through an older runner without being stripped.
+ */
+export const providerConfigureParamsSchema = z.object({
+  name: z.string().min(1),
+  patch: z.object({
+    baseURL: z.string().url().optional(),
+    defaultModel: z.string().min(1).optional(),
+    envVar: z
+      .string()
+      .regex(/^[A-Z][A-Z0-9_]*$/)
+      .optional(),
+    models: z
+      .array(z.object({ id: z.string().min(1), contextWindow: z.number() }).passthrough())
+      .min(1)
+      .optional(),
+  }),
 });
 
 export const permissionAddAllowParamsSchema = z.object({

--- a/packages/runner/src/remote-session.ts
+++ b/packages/runner/src/remote-session.ts
@@ -19,6 +19,7 @@ import type {
   PendingToolCall,
   PermissionResolver,
   PermissionsClientView,
+  ProviderAdminView,
   ProviderDef,
   ProviderInfo,
   ProvidersClientView,
@@ -165,6 +166,7 @@ export class RemoteSession implements ClientSession {
   readonly requirements: RequirementsClientView;
   readonly permissions: PermissionsClientView;
   readonly mcpAdmin: McpAdminClientView;
+  readonly providerAdmin: ProviderAdminClientView;
   readonly workflows: WorkflowsClientView;
   /**
    * Turns that completed before their `runTurn` stream was registered. A fast
@@ -178,6 +180,8 @@ export class RemoteSession implements ClientSession {
   private permissionResolver: PermissionResolver | null = null;
   private approvalResolver: ApprovalResolver | null = null;
   private info: SessionInfo | null = null;
+  /** Subscribers to `info.changed` pushes (see {@link onInfoChanged}). */
+  private readonly infoListeners = new Set<(info: SessionInfo) => void>();
   /**
    * The protocol version the SERVER reported at attach. Defaults to our own
    * version until the handshake resolves. Version-specific client methods (the
@@ -205,6 +209,16 @@ export class RemoteSession implements ClientSession {
     });
     this.peer.on(RunnerNotification.InfoChanged, (params) => {
       this.info = (params as InfoChangedNotification).info;
+      // Fan out to subscribers (the desktop's SessionDriver forwards this to
+      // the renderer so Settings panels refresh without polling). Listener
+      // errors are swallowed — a bad subscriber must not break the mirror.
+      for (const fn of this.infoListeners) {
+        try {
+          fn(this.info);
+        } catch {
+          /* ignore */
+        }
+      }
     });
     this.peer.on(RunnerNotification.ReplayStart, (params) => {
       // The server announces the first seq it will replay/stream on this
@@ -253,6 +267,7 @@ export class RemoteSession implements ClientSession {
     this.requirements = { check: () => ({ ready: false, issues: [] }) };
     this.permissions = this.makePermissionsView();
     this.mcpAdmin = this.makeMcpAdminView();
+    this.providerAdmin = this.makeProviderAdminView();
     this.workflows = this.makeWorkflowsView();
   }
 
@@ -339,6 +354,17 @@ export class RemoteSession implements ClientSession {
 
   getInfo(): SessionInfo {
     return this.requireInfo();
+  }
+
+  /**
+   * Subscribe to runner `info.changed` pushes (registry snapshot changes —
+   * provider/mode/MCP/workflow mutations, including ones made by tools inside
+   * a turn). Fires after the local `getInfo()` mirror has been updated, so a
+   * listener can re-read it synchronously. Returns an unsubscribe fn.
+   */
+  onInfoChanged(fn: (info: SessionInfo) => void): () => void {
+    this.infoListeners.add(fn);
+    return () => this.infoListeners.delete(fn);
   }
 
   async *runTurn(prompt: string, opts: RunTurnOptions = {}): AsyncIterable<MoxxyEvent> {
@@ -593,6 +619,28 @@ export class RemoteSession implements ClientSession {
     };
   }
 
+  // Provider management (protocol v7): backs the desktop's interactive
+  // Settings → Providers tab. Gated on the SERVER's reported version so a v7
+  // client attached to an older runner (a desktop whose JS hot-update outran
+  // its bundled CLI) gets a clear "update the CLI" error instead of a raw
+  // method-not-found.
+  private makeProviderAdminView(): ProviderAdminClientView {
+    return {
+      setEnabled: async (name, enabled) => {
+        this.requireServerProtocol(7, 'Enabling/disabling a provider');
+        await this.peer.request(RunnerMethod.ProviderSetEnabled, { name, enabled });
+      },
+      refreshReady: async () => {
+        this.requireServerProtocol(7, 'Re-probing provider credentials');
+        await this.peer.request(RunnerMethod.ProviderRefreshReady, {});
+      },
+      configure: async (name, patch) => {
+        this.requireServerProtocol(7, 'Configuring a provider');
+        await this.peer.request(RunnerMethod.ProviderConfigure, { name, patch });
+      },
+    };
+  }
+
   private makeWorkflowsView(): WorkflowsClientView {
     return {
       list: () =>
@@ -653,6 +701,13 @@ interface McpAdminClientView {
   listServers(): Promise<ReadonlyArray<McpServerStatus>>;
   enableAndAttach(name: string): Promise<{ toolNames: ReadonlyArray<string> } | null>;
   detach(name: string): Promise<boolean>;
+}
+
+interface ProviderAdminClientView extends ProviderAdminView {
+  /** Enable/disable a provider on the runner (persists to preferences). */
+  setEnabled(name: string, enabled: boolean): Promise<void>;
+  /** Re-probe every provider's credentials → fresh readyProviders. */
+  refreshReady(): Promise<void>;
 }
 
 interface WorkflowSummary {

--- a/packages/runner/src/server.ts
+++ b/packages/runner/src/server.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Session } from '@moxxy/core';
-import { newTurnId, savePreferences } from '@moxxy/core';
+import { loadPreferences, newTurnId, savePreferences } from '@moxxy/core';
 import { asTurnId } from '@moxxy/sdk';
 import type {
   ApprovalDecision,
@@ -30,7 +30,9 @@ import {
   mcpEnableAndAttachParamsSchema,
   modeSetActiveParamsSchema,
   permissionAddAllowParamsSchema,
+  providerConfigureParamsSchema,
   providerSetActiveParamsSchema,
+  providerSetEnabledParamsSchema,
   runTurnParamsSchema,
   setResolverParamsSchema,
   transcribeParamsSchema,
@@ -159,6 +161,9 @@ export class RunnerServer {
     peer.handle(RunnerMethod.SetResolver, (raw) => this.handleSetResolver(client, raw));
     peer.handle(RunnerMethod.ModeSetActive, (raw) => this.handleModeSetActive(raw));
     peer.handle(RunnerMethod.ProviderSetActive, (raw) => this.handleProviderSetActive(raw));
+    peer.handle(RunnerMethod.ProviderSetEnabled, (raw) => this.handleProviderSetEnabled(raw));
+    peer.handle(RunnerMethod.ProviderRefreshReady, () => this.handleProviderRefreshReady());
+    peer.handle(RunnerMethod.ProviderConfigure, (raw) => this.handleProviderConfigure(raw));
     peer.handle(RunnerMethod.PermissionAddAllow, (raw) => this.handlePermissionAddAllow(raw));
     peer.handle(RunnerMethod.CommandRun, (raw) => this.handleCommandRun(raw));
     peer.handle(RunnerMethod.Transcribe, (raw) => this.handleTranscribe(raw));
@@ -280,6 +285,11 @@ export class RunnerServer {
           turnId,
           ...(error ? { error } : {}),
         });
+        // A turn may have run registry-mutating tools (provider_add, mcp_add,
+        // workflow_create, skill writes, …). Push the fresh snapshot so
+        // attached clients (the desktop Settings panel) re-render without an
+        // app restart. Once per turn — cheap relative to the turn itself.
+        this.broadcastInfo();
       }
     });
 
@@ -366,6 +376,61 @@ export class RunnerServer {
     // Best-effort: savePreferences swallows its own write errors and never
     // throws, so a read-only home can't fail the setActive RPC.
     void savePreferences({ providerName: name });
+    this.broadcastInfo();
+    return {};
+  }
+
+  private async handleProviderSetEnabled(raw: unknown): Promise<Record<string, never>> {
+    const { name, enabled } = providerSetEnabledParamsSchema.parse(raw);
+    if (!this.session.providers.list().some((p) => p.name === name)) {
+      throw new Error(`Provider not registered: ${name}`);
+    }
+    // Throws when disabling the ACTIVE provider — surface that verbatim.
+    this.session.providers.setEnabled(name, enabled);
+    // Persist so the next boot's activation walk skips it (setup.ts seeds the
+    // registry from this list). Read-merge so concurrent writers of other
+    // preference fields aren't clobbered; best-effort like every prefs write.
+    void (async () => {
+      const prefs = await loadPreferences();
+      const current = new Set(prefs.disabledProviders ?? []);
+      if (enabled) current.delete(name);
+      else current.add(name);
+      await savePreferences({ disabledProviders: [...current] });
+    })();
+    this.broadcastInfo();
+    return {};
+  }
+
+  private async handleProviderRefreshReady(): Promise<Record<string, never>> {
+    // Re-probe every registered provider's credentials (vault keys / env /
+    // OAuth tokens) so a key the user just saved flips readiness without a
+    // runner restart. The resolver is the same non-interactive probe boot
+    // uses; absent resolver (bare test sessions) → leave the set untouched.
+    const resolver = this.session.credentialResolver;
+    if (resolver) {
+      const ready = new Set<string>();
+      const active = this.session.providers.getActiveName();
+      if (active) ready.add(active);
+      for (const p of this.session.providers.list()) {
+        if (ready.has(p.name)) continue;
+        try {
+          await resolver(p.name);
+          ready.add(p.name);
+        } catch {
+          // not ready — leave out
+        }
+      }
+      this.session.readyProviders = ready;
+    }
+    this.broadcastInfo();
+    return {};
+  }
+
+  private async handleProviderConfigure(raw: unknown): Promise<Record<string, never>> {
+    const { name, patch } = providerConfigureParamsSchema.parse(raw);
+    const admin = this.session.providerAdmin;
+    if (!admin) throw new Error('provider admin not supported on this runner');
+    await admin.configure(name, patch as Parameters<typeof admin.configure>[1]);
     this.broadcastInfo();
     return {};
   }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -50,6 +50,8 @@ export type {
   CredentialResolver,
   McpAdminView,
   McpServerStatusView,
+  ProviderAdminView,
+  ProviderConfigurePatch,
   WorkflowsView,
   WorkflowSummaryView,
   WorkflowRunView,

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -57,6 +57,12 @@ export interface ProviderInfo {
    *  via /v1/models). Lets the desktop's model picker show a
    *  "Fetch live" affordance only where it makes sense. */
   readonly supportsLiveModelDiscovery: boolean;
+  /**
+   * False when the user disabled this provider (it stays registered but can't
+   * be activated and is excluded from boot's candidate walk). Optional for
+   * wire back-compat — an older runner omits it; treat absent as enabled.
+   */
+  readonly enabled?: boolean;
 }
 
 /** Serializable tool metadata for status lines / slash menus / compact rendering. */
@@ -144,6 +150,36 @@ export interface McpAdminView {
   enableAndAttach(name: string): Promise<{ toolNames: ReadonlyArray<string> } | null>;
   detach(name: string): Promise<boolean>;
   listServers(): Promise<ReadonlyArray<McpServerStatusView>>;
+}
+
+/**
+ * Editable fields of a stored (runtime-registered) provider entry. Mirrors
+ * the persisted `providers.json` shape owned by `@moxxy/plugin-provider-admin`
+ * minus the immutable identity (`name`, `kind`).
+ */
+export interface ProviderConfigurePatch {
+  readonly baseURL?: string;
+  readonly defaultModel?: string;
+  /** Override the API-key env-var/vault name (`<NAME>_API_KEY` by default). */
+  readonly envVar?: string;
+  readonly models?: ReadonlyArray<ModelDescriptor>;
+}
+
+/**
+ * The slice of the provider admin API a channel needs to edit a stored
+ * (runtime-registered) provider in place. Present on a local Session when
+ * `@moxxy/plugin-provider-admin` is wired (mirrors {@link McpAdminView});
+ * a `RemoteSession` proxies it over the runner protocol (v7+). Built-in
+ * providers are not configurable through this view — their config is code.
+ */
+export interface ProviderAdminView {
+  /**
+   * Patch a stored provider's entry: re-registers the live provider def and
+   * persists the merged entry to providers.json. Throws a MoxxyError when no
+   * stored provider has that name or the patch is inconsistent (e.g. a
+   * defaultModel missing from the models list).
+   */
+  configure(name: string, patch: ProviderConfigurePatch): Promise<void>;
 }
 
 /** One workflow's summary for the `/workflows` modal. */
@@ -308,6 +344,8 @@ export interface SessionLike {
   credentialResolver?: CredentialResolver;
   /** MCP admin slice backing the MCP picker / status line. */
   mcpAdmin?: McpAdminView;
+  /** Provider admin slice — edit stored (runtime-registered) providers. */
+  providerAdmin?: ProviderAdminView;
   /** Workflows slice backing the `/workflows` modal. */
   workflows?: WorkflowsView;
   /** Plugin-management slice backing the `/plugins` picker. */


### PR DESCRIPTION
## Problems

1. **Stale desktop UI after runtime changes** (reported): adding a provider via prompt worked, but the Settings → Providers list didn't update until the app was killed. Same staleness applied to MCP servers, skills, workflows, modes — any registry change made by a TOOL inside a turn. Root cause: the runner only broadcast `info.changed` on mode/provider switches, command runs, and transcribe; `SessionDriver` never forwarded it to the renderer; and `useSettings` fetched once on mount.
2. **No interactive provider management** (requested): the Providers tab was display-only — no enable/disable, no key entry, no endpoint editing.

## Live refresh

- Runner broadcasts `info.changed` after **every completed turn** (a turn may have run registry-mutating tools).
- `RemoteSession.onInfoChanged()` exposes the push; `SessionDriver` forwards it as the new `session.info.changed` IPC event (also mirrored to WS-bridge clients).
- New `useSessionInfoBridge` (mounted once in App) re-emits it as the existing `SESSION_INFO_REFRESH_EVENT`; `useSettings` re-fetches on that signal. Mode badge, action catalog, and agent picker already listened to it, so agent-driven mode/provider changes now refresh those too.

## Interactive providers (runner protocol v7 — additive, MIN_COMPATIBLE stays 1)

- **`provider.setEnabled`** — live registry toggle, persisted to `preferences.json#disabledProviders`, seeded into the registry before boot's activation walk (a disabled provider is never auto-activated; disabling the ACTIVE provider is refused with a clear error).
- **`provider.refreshReady`** — re-probes every provider's credentials via the session resolver, so a key saved to the vault flips the readiness dot without a restart.
- **`provider.configure`** — patches a stored (runtime-registered) provider's baseURL/defaultModel through the new `SessionLike.providerAdmin` view (`buildProviderAdminPluginWithApi`, mirrors mcpAdmin; live re-register + providers.json persist with rollback).
- Settings → Providers UI: enable/disable Switch per row (inert for the active provider), Active badge, and a Configure sheet — vault key for api-key providers (live readiness re-probe), `moxxy login` hint for OAuth providers, endpoint + default-model editing for admin providers.
- Desktop `FLOOR_RUNNER_PROTOCOL` bumped to 7 in lockstep; new client methods gate on the server's reported version (actionable "update the CLI" error on older runners). New `settings.provider*` IPC commands are host-only (NOT on `REMOTE_ALLOWED_COMMANDS`).

## Tests

- Runner integration: setEnabled (live + persisted + push), active-provider refusal, refreshReady probe, configure forwarding + clean degrade without the view, turn-end info broadcast.
- Core: ProviderRegistry enable/disable semantics (incl. boot-order seeding).
- desktop-host: SessionDriver info-changed forwarding + unsubscribe on dispose.
- client-core: useSettings refresh-on-event + provider actions + error surfacing; useSessionInfoBridge re-emit.
- desktop: ProvidersTab toggle/configure/OAuth-hint interactions.

The stale `change-runner-protocol` skill was refreshed in the same PR (P3 #0); TECH_DEBT.md carries the intake entry.

## Verification

Full gate green: build 59/59, typecheck 116/116, lint 0 errors, test 113/113 tasks, check:deps clean.