### PR TITLE
feat(desktop): sidebar row polish — folder icon, hover-overlay actions, wider rail

### DIFF
--- a/.changeset/sidebar-row-polish.md
+++ b/.changeset/sidebar-row-polish.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/desktop': patch
+'@moxxy/desktop-ui': minor
+---
+
+Sidebar polish: workspace rows now carry a single color-tinted folder icon (replacing the grid glyph), row actions ([+] new session, ⋯ menu) are hover-only and overlay the right edge of the name with a gradient fade instead of reserving width — so workspace and session names use the full row when idle — and the sidebar widened 232px → 272px for readable first-prompt titles. desktop-ui gains a `folder` icon.

--- a/apps/desktop/src/shell/workspace-sidebar/WorkspaceTree.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/WorkspaceTree.tsx
@@ -21,6 +21,9 @@ import { SectionHeader } from './SectionHeader';
  *  - ⋯ menus carry Rename/Remove for both row kinds, with the same
  *    inline-rename gesture (Enter commits, Escape cancels) sessions
  *    always had;
+ *  - row actions ([+]/⋯) are hover-only and OVERLAY the right edge of the
+ *    name (gradient fade) instead of reserving width — names get the full
+ *    row when idle ({@link ActionsOverlay});
  *  - the active desk's active session is the single highlighted row.
  *
  * Purely presentational — the sidebar container owns the stores, the
@@ -277,7 +280,7 @@ function FolderRow({
           color: desk.color,
         }}
       >
-        <Icon name="workspace" size={14} />
+        <Icon name="folder" size={14} />
       </span>
       {editing !== null ? (
         <input
@@ -310,34 +313,35 @@ function FolderRow({
         </span>
       )}
       {unread && <UnreadDot label={`unread activity in ${desk.name}`} />}
-      <button
-        type="button"
-        data-testid={`session-new-${desk.id}`}
-        aria-label={`new session in ${desk.name}`}
-        title="New session"
-        disabled={busy}
-        onClick={(e) => {
-          e.stopPropagation();
-          onCreateSession();
-        }}
-        style={{
-          ...iconButtonStyle,
-          opacity: busy ? 0.5 : showActions || busy ? 0.9 : 0,
-          transition: 'opacity 120ms ease',
-        }}
-      >
-        <Icon name="plus" size={14} />
-      </button>
-      <RowMenu
-        kind="workspace"
-        name={desk.name}
-        visible={showActions}
-        open={menuOpen}
-        onOpenChange={setMenuOpen}
-        onRename={onStartRename}
-        onDelete={onRemove}
-        deleteLabel="Remove"
-      />
+      <ActionsOverlay show={showActions || busy} background={HOVER_ROW_BG}>
+        <button
+          type="button"
+          data-testid={`session-new-${desk.id}`}
+          aria-label={`new session in ${desk.name}`}
+          title="New session"
+          disabled={busy}
+          onClick={(e) => {
+            e.stopPropagation();
+            onCreateSession();
+          }}
+          style={{
+            ...iconButtonStyle,
+            opacity: busy ? 0.5 : 0.9,
+          }}
+        >
+          <Icon name="plus" size={14} />
+        </button>
+        <RowMenu
+          kind="workspace"
+          name={desk.name}
+          visible={showActions || busy}
+          open={menuOpen}
+          onOpenChange={setMenuOpen}
+          onRename={onStartRename}
+          onDelete={onRemove}
+          deleteLabel="Remove"
+        />
+      </ActionsOverlay>
     </div>
   );
 }
@@ -363,7 +367,10 @@ function SessionRow({
 } & RenameHandlers): JSX.Element {
   const [hot, setHot] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
-  const showActions = hot || active || menuOpen;
+  // Hover/menu only — NOT `active`: actions overlay the name's right edge
+  // now, so pinning them open on the active row would permanently cover
+  // the end of its title.
+  const showActions = hot || menuOpen;
 
   return (
     <li>
@@ -420,18 +427,70 @@ function SessionRow({
           </span>
         )}
         {unread && <UnreadDot label="unread activity" />}
-        <RowMenu
-          kind="session"
-          name={s.name}
-          visible={showActions}
-          open={menuOpen}
-          onOpenChange={setMenuOpen}
-          onRename={onStartRename}
-          onDelete={onRemove}
-          deleteLabel="Delete"
-        />
+        <ActionsOverlay
+          show={showActions}
+          background={active ? 'var(--color-sidebar-bg-active)' : HOVER_ROW_BG}
+        >
+          <RowMenu
+            kind="session"
+            name={s.name}
+            visible={showActions}
+            open={menuOpen}
+            onOpenChange={setMenuOpen}
+            onRename={onStartRename}
+            onDelete={onRemove}
+            deleteLabel="Delete"
+          />
+        </ActionsOverlay>
       </div>
     </li>
+  );
+}
+
+/**
+ * The composite a hovered `.row-button` shows: the sidebar background with
+ * the hover inset tint (5% text) mixed in. Used as the overlay's masking
+ * color so the action cluster blends into the hovered row underneath it.
+ */
+const HOVER_ROW_BG = 'color-mix(in srgb, var(--color-text) 5%, var(--color-sidebar-bg))';
+
+/**
+ * Hover-only action cluster overlaying the row's right edge — the name keeps
+ * the FULL row width when idle, and on hover the buttons float above its
+ * tail end instead of permanently truncating it. The left gradient fades the
+ * covered text out instead of clipping it hard; `pointerEvents` gates clicks
+ * so the invisible cluster never swallows a row click.
+ */
+function ActionsOverlay({
+  show,
+  background,
+  children,
+}: {
+  readonly show: boolean;
+  /** Opaque color matching the row's CURRENT background (hover tint / active wash). */
+  readonly background: string;
+  readonly children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <span
+      style={{
+        position: 'absolute',
+        right: 3,
+        top: '50%',
+        transform: 'translateY(-50%)',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 2,
+        paddingLeft: 18,
+        opacity: show ? 1 : 0,
+        pointerEvents: show ? 'auto' : 'none',
+        transition: 'opacity 120ms ease',
+        background: `linear-gradient(to right, transparent, ${background} 16px)`,
+        borderRadius: 7,
+      }}
+    >
+      {children}
+    </span>
   );
 }
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -253,7 +253,9 @@ code, kbd, pre, .mono { font-family: var(--font-mono); }
 }
 
 .col-sidebar {
-  width: 232px;
+  /* Wide enough for ~30 chars of 13px row text before ellipsis — workspace
+   * and first-prompt session titles were unreadable at the old 232px. */
+  width: 272px;
   flex-shrink: 0;
   background: var(--color-sidebar-bg);
   color: var(--color-sidebar-text);

--- a/packages/desktop-ui/src/Icon.tsx
+++ b/packages/desktop-ui/src/Icon.tsx
@@ -37,7 +37,8 @@ export type IconName =
   | 'workflow'
   | 'settings'
   | 'agent'
-  | 'workspace';
+  | 'workspace'
+  | 'folder';
 
 export interface IconProps extends SVGProps<SVGSVGElement> {
   readonly name: IconName;
@@ -238,5 +239,8 @@ const paths: Record<IconName, JSX.Element> = {
       <rect x="14" y="12" width="7" height="9" rx="1.5" />
       <rect x="3" y="16" width="7" height="5" rx="1.5" />
     </>
+  ),
+  folder: (
+    <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
   ),
 };


### PR DESCRIPTION
Follow-up polish on the sidebar workspace tree (#183), from the screenshot feedback:

- **Single colored folder icon** per workspace row (tinted with the desk color) replaces the four-square grid glyph; `@moxxy/desktop-ui` gains a `folder` icon.
- **Names get the full row width.** The [+] new-session and ⋯ menu buttons no longer sit in the flex flow reserving ~50px even while invisible — they are hover-only and **overlay** the right edge of the row, with a gradient fade so the covered tail of the name dissolves instead of clipping hard. The invisible cluster is `pointer-events: none`, so row clicks pass through. The active session row no longer pins its ⋯ button open (it would permanently cover the end of the title).
- **Sidebar widened 232px → 272px**, fitting roughly 30 characters of 13px row text before ellipsis — workspace names and first-prompt session titles are actually readable now.

Gate green: build 59/59, typecheck 116/116, lint 0 errors, test 113/113 (incl. the 17 sidebar shell tests).