### PR TITLE
fix(desktop): sign-up portal stranding (SPA nav) + stale override outranking a fresh install

### DIFF
--- a/.changeset/desktop-signup-strand-stale-override.md
+++ b/.changeset/desktop-signup-strand-stale-override.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/desktop': patch
+'@moxxy/desktop-host': patch
+---
+
+Two desktop fixes. (1) Fresh OAuth sign-up no longer strands the window on the Account Portal profile page: the portal-recovery net now also watches in-page (SPA) navigations — the portal's post-transfer router push to `/user` never fired `did-navigate` — and puts a 30s watchdog on the automatic `#/sso-callback` leg so a dead transfer page recovers into the app (where the boot sweep completes the sign-up) instead of requiring a restart. (2) Installing a full app update now actually runs it: the bootstrap's bundle gate gained a floor-version check (`older-than-floor` reject + active-pointer cleanup), so a hot-update override staged by a PREVIOUS install can no longer outrank the freshly installed shell — previously a stale 0.6 override kept booting over a newly installed 0.7.0, which then re-demanded the full installer forever.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -680,6 +680,17 @@ refused override impersonated the previous override and let the boot probe confi
 that wasn't running. Residual (low): any pre-be7d33a floor will show the macOS Dock ghost-runner
 whenever a refused update drops onto it — immutable floor code, only a full reinstall fixes it.
 
+**2026-06-12 fourth failure mode found + fixed (the inverse of #3):** a STALE override
+outranked a freshly installed shell. The resolve gate had no floor-version check, so after
+"0.7.0 updates the bundled runner — install the full app update" → user installs 0.7.0,
+the new shell still booted the staged 0.6.x override (signature/ABI/protocol gates all pass
+for an OLD bundle) — whose update UI then re-demanded the full installer forever. Observed
+live as "installed 0.7 but it still gets 0.6". `resolveActiveBundleDetailed` now takes
+`floorVersion` (bootstrap passes `app.getVersion()`; shell version == floor bundle version)
+and rejects `older-than-floor` (equal loses too — the baked copy is the trusted one); the
+bootstrap clears the active pointer on that reject (no poison — the bundle is obsolete, not
+broken) so later boots take the clean `no-active` path.
+
 **Multi-session testing caveat (2026-06-11):** desks now hold N sessions and the runner pool is
 keyed by session id, but every v1-migrated/first session has id === desk id — which masks
 pool-key regressions. Always test multi-session paths with a desk's *second* (UUID-keyed) session.
@@ -905,8 +916,15 @@ regressions. Restore the detail from git history (`TECH_DEBT.md` @ `b014c3a`) if
   recover), and the renderer's `OAuthTransferBridge` (apps/desktop/src/lib/oauthTransfer.tsx)
   sweeps any still-dangling transferable attempt on boot and completes it in-app.
   Instance config verified sane via the public FAPI `/v1/environment` (sign-up mode
-  `public` on dev + prod). **Remaining verify:** packaged round-trip with a
-  never-seen-before Google account.
+  `public` on dev + prod). **Third layer found live 2026-06-12:** the fresh-sign-up
+  round-trip still stranded the window — on the portal's *profile* page this time. The
+  portal is an SPA: its post-transfer hop from `/sign-in#/sso-callback` to `/user` is a
+  client-side router push, and the recovery net only listened to `did-navigate` (never
+  fired). Net now also watches `did-navigate-in-page`, plus a 30s watchdog on the
+  automatic `#/sso-callback` leg (interactive portal pages get NO timer) so a dead
+  transfer page recovers into the app, where the boot sweep finishes the sign-up — no
+  restart. **Remaining verify:** packaged round-trip with a never-seen-before Google
+  account.
 - **Desktop Dock-ghost runner process** (2026-06-10). The packaged desktop's runner
   (`moxxy serve`, spawned via the bundled CLI with `ELECTRON_RUN_AS_NODE=1`) showed up in
   the macOS Dock as a generic-executable ("exec") icon named after the app: on macOS 26

--- a/apps/desktop/electron/main/bootstrap.ts
+++ b/apps/desktop/electron/main/bootstrap.ts
@@ -29,6 +29,7 @@ import {
   recoverFromFailedBoot,
   writeBreadcrumb,
   markBad,
+  clearActiveVersion,
   appendBootLog,
   setupNativeResolution,
 } from '@moxxy/desktop-host/app-update';
@@ -108,6 +109,10 @@ async function boot(): Promise<void> {
         // pinned CLI's runner (the hot-update protocol-skew loop). The floor's
         // CLI is what we spawn, so its protocol is the ceiling for a hot-update.
         cliRunnerProtocol: FLOOR_RUNNER_PROTOCOL,
+        // Floor gate: a staged override from a PREVIOUS install must lose to a
+        // freshly installed shell, or "install the full app update" keeps
+        // booting the old JS (the shell version IS the floor bundle version).
+        floorVersion: app.getVersion(),
       });
       if (resolved.bundle) {
         const picked = resolved.bundle;
@@ -126,6 +131,12 @@ async function boot(): Promise<void> {
         // `disabled`/`no-active` are the normal "nothing staged" cases; anything
         // else is a staged bundle we declined — exactly what we want visible.
         appendBootLog(userData, { phase: 'boot', picked: 'floor', reason: resolved.reason, ...shell });
+        if (resolved.reason === 'older-than-floor') {
+          // The override isn't broken, just superseded by this install — drop
+          // the pointer (no poison) so state stops naming a bundle that can
+          // never load again and later boots take the clean `no-active` path.
+          clearActiveVersion(userData);
+        }
       }
     } catch (err) {
       // Any resolution failure → run the floor.

--- a/packages/desktop-host/src/app-update/index.ts
+++ b/packages/desktop-host/src/app-update/index.ts
@@ -31,6 +31,7 @@ export {
   bundleRoot,
   readActiveVersion,
   setActiveVersion,
+  clearActiveVersion,
   readBadVersions,
   markBad,
   unmarkBad,

--- a/packages/desktop-host/src/app-update/resolve-detailed.test.ts
+++ b/packages/desktop-host/src/app-update/resolve-detailed.test.ts
@@ -75,6 +75,43 @@ describe('resolveActiveBundleDetailed', () => {
     ).toBe('poisoned');
   });
 
+  it('names "older-than-floor" when a fresh shell install supersedes the override', () => {
+    // The live bug: user on 0.6 had a staged 0.6.2 override, installed the
+    // full 0.7.0 app — and the new shell kept booting the stale 0.6.2 JS.
+    installBundle('0.6.2');
+    expect(
+      resolveActiveBundleDetailed({
+        userDataDir: tmp,
+        publicKeyPem: PUBKEY,
+        shell: SHELL,
+        floorVersion: '0.7.0',
+      }).reason,
+    ).toBe('older-than-floor');
+  });
+
+  it('floor gate: an override EQUAL to the floor loses too (baked copy is the trusted one)', () => {
+    installBundle('0.7.0');
+    expect(
+      resolveActiveBundleDetailed({
+        userDataDir: tmp,
+        publicKeyPem: PUBKEY,
+        shell: SHELL,
+        floorVersion: '0.7.0',
+      }).reason,
+    ).toBe('older-than-floor');
+  });
+
+  it('floor gate: a NEWER override still wins (the normal hot-update case)', () => {
+    installBundle('0.7.1');
+    const r = resolveActiveBundleDetailed({
+      userDataDir: tmp,
+      publicKeyPem: PUBKEY,
+      shell: SHELL,
+      floorVersion: '0.7.0',
+    });
+    expect(r.bundle?.version).toBe('0.7.1');
+  });
+
   it('names "manifest-missing" when the manifest is absent', () => {
     const root = bundleRoot(tmp, '0.0.6');
     mkdirSync(path.join(root, 'dist-electron', 'main'), { recursive: true });

--- a/packages/desktop-host/src/app-update/resolve.ts
+++ b/packages/desktop-host/src/app-update/resolve.ts
@@ -148,6 +148,18 @@ export function setActiveVersion(userDataDir: string, version: string): void {
   writeJsonAtomic(activePath(userDataDir), { version });
 }
 
+/** Drop the active pointer WITHOUT poisoning the version (unlike {@link markBad}
+ *  — the bundle isn't broken, just obsolete). Used by the bootstrap when a
+ *  fresh shell install supersedes the staged override (`older-than-floor`), so
+ *  state files stop pointing at a bundle that will never be loaded again. */
+export function clearActiveVersion(userDataDir: string): void {
+  try {
+    rmSync(activePath(userDataDir), { force: true });
+  } catch {
+    /* best effort */
+  }
+}
+
 export function readBadVersions(userDataDir: string): Set<string> {
   const raw = tryRead(badPath(userDataDir));
   if (!raw) return new Set();
@@ -274,6 +286,18 @@ export interface ResolveOpts {
   publicKeyPem: string;
   shell: ShellInfo;
   /**
+   * The version of the BAKED floor bundle (= the installed shell's app
+   * version — they ship together and share the release version stream). An
+   * override is only an *update* while it is NEWER than the floor: after the
+   * user installs a fresh full app, any staged bundle from the previous
+   * install is older-or-equal and must lose to the floor. Without this gate a
+   * stale `active.json` keeps winning — observed live as "installed 0.7.0 but
+   * the app still runs 0.6": the new shell booted the old 0.6 override JS,
+   * whose update UI then re-demanded the full installer forever. Omit to skip
+   * the gate (legacy callers / tests that don't model the floor).
+   */
+  floorVersion?: string;
+  /**
    * The runner protocol version the REACHABLE CLI can serve — i.e. the
    * `RUNNER_PROTOCOL_VERSION` of the CLI the desktop will actually spawn
    * (the pinned, bundled `moxxy-cli` in resources, whose protocol equals the
@@ -292,6 +316,8 @@ export type ResolveRejectReason =
   | 'disabled' // no signing key baked → self-update off
   | 'no-active' // nothing staged
   | 'poisoned' // active version is on the bad list
+  | 'older-than-floor' // a fresh shell install superseded the staged override
+
   | 'manifest-missing' // no manifest.json under the bundle dir
   | 'manifest-malformed' // manifest failed shape checks
   | 'version-mismatch' // manifest.version ≠ active version
@@ -317,12 +343,17 @@ export type ResolveResult =
  *   legacy manifests have no map and get no load-time file verification).
  */
 export function resolveActiveBundleDetailed(opts: ResolveOpts): ResolveResult {
-  const { userDataDir, publicKeyPem, shell, cliRunnerProtocol } = opts;
+  const { userDataDir, publicKeyPem, shell, cliRunnerProtocol, floorVersion } = opts;
   if (!publicKeyPem) return { bundle: null, reason: 'disabled' };
 
   const version = readActiveVersion(userDataDir);
   if (!version) return { bundle: null, reason: 'no-active' };
   if (readBadVersions(userDataDir).has(version)) return { bundle: null, reason: 'poisoned' };
+  // An override only ever exists to run something NEWER than the baked floor.
+  // Equal loses too: same release, and the baked copy is the trusted one.
+  if (floorVersion && compareSemver(version, floorVersion) <= 0) {
+    return { bundle: null, reason: 'older-than-floor' };
+  }
 
   const root = bundleRoot(userDataDir, version);
   const manifestRaw = tryRead(path.join(root, 'manifest.json'));

--- a/packages/desktop-host/src/security.test.ts
+++ b/packages/desktop-host/src/security.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { BrowserWindow, Session } from 'electron';
 import {
   isSafeProviderName,
@@ -172,19 +172,20 @@ describe('clerk account-portal host', () => {
 });
 
 describe('account-portal recovery net', () => {
-  /** Minimal BrowserWindow stand-in: captures the did-navigate handler and
+  /** Minimal BrowserWindow stand-in: captures the navigation handlers and
    *  records loadURL calls so a test can replay post-OAuth landings. */
   function fakeWindow(): {
     win: BrowserWindow;
     navigate: (url: string) => void;
+    navigateInPage: (url: string) => void;
     hasHandler: () => boolean;
     loads: string[];
   } {
     const loads: string[] = [];
-    let handler: ((e: unknown, url: string) => void) | undefined;
+    const handlers = new Map<string, (e: unknown, url: string) => void>();
     const wc = {
       on: (ev: string, fn: (e: unknown, url: string) => void) => {
-        if (ev === 'did-navigate') handler = fn;
+        handlers.set(ev, fn);
       },
       loadURL: (url: string) => {
         loads.push(url);
@@ -193,8 +194,9 @@ describe('account-portal recovery net', () => {
     };
     return {
       win: { webContents: wc } as unknown as BrowserWindow,
-      navigate: (url) => handler?.({}, url),
-      hasHandler: () => !!handler,
+      navigate: (url) => handlers.get('did-navigate')?.({}, url),
+      navigateInPage: (url) => handlers.get('did-navigate-in-page')?.({}, url),
+      hasHandler: () => handlers.has('did-navigate'),
       loads,
     };
   }
@@ -239,6 +241,72 @@ describe('account-portal recovery net', () => {
     const { win, hasHandler } = fakeWindow();
     installAccountPortalRecovery(win, { portalHost: null, appUrl: APP });
     expect(hasHandler()).toBe(false);
+  });
+
+  it('recovers from an SPA (in-page) hop onto the portal profile page — the post-transfer stranding', () => {
+    const { win, navigate, navigateInPage, loads } = fakeWindow();
+    installAccountPortalRecovery(win, { portalHost: 'accounts.acme.com', appUrl: APP });
+    // Full-page landing on the functional sso-callback leg: left to run.
+    navigate('https://accounts.acme.com/sign-in#/sso-callback?after_sign_in_url=x');
+    expect(loads).toEqual([]);
+    // The portal SPA's router then PUSHES to /user — no did-navigate fires.
+    navigateInPage('https://accounts.acme.com/user');
+    expect(loads).toEqual([APP]);
+  });
+
+  it('recovers when the automatic sso-callback page dies (watchdog)', () => {
+    vi.useFakeTimers();
+    try {
+      const { win, navigate, loads } = fakeWindow();
+      installAccountPortalRecovery(win, {
+        portalHost: 'accounts.acme.com',
+        appUrl: APP,
+        ssoCallbackTimeoutMs: 1000,
+      });
+      navigate('https://accounts.acme.com/sign-in#/sso-callback?after_sign_in_url=x');
+      vi.advanceTimersByTime(999);
+      expect(loads).toEqual([]);
+      vi.advanceTimersByTime(1);
+      expect(loads).toEqual([APP]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('disarms the sso-callback watchdog once the flow moves on', () => {
+    vi.useFakeTimers();
+    try {
+      const { win, navigate, loads } = fakeWindow();
+      installAccountPortalRecovery(win, {
+        portalHost: 'accounts.acme.com',
+        appUrl: APP,
+        ssoCallbackTimeoutMs: 1000,
+      });
+      navigate('https://accounts.acme.com/sign-in#/sso-callback?after_sign_in_url=x');
+      navigate(APP); // the flow returned to the app on its own
+      vi.advanceTimersByTime(60_000);
+      expect(loads).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('puts no timer on interactive portal pages (sign-in form, verify-email)', () => {
+    vi.useFakeTimers();
+    try {
+      const { win, navigate, navigateInPage, loads } = fakeWindow();
+      installAccountPortalRecovery(win, {
+        portalHost: 'accounts.acme.com',
+        appUrl: APP,
+        ssoCallbackTimeoutMs: 1000,
+      });
+      navigate('https://accounts.acme.com/sign-in');
+      navigateInPage('https://accounts.acme.com/sign-up#/verify-email-address');
+      vi.advanceTimersByTime(60_000);
+      expect(loads).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/desktop-host/src/security.ts
+++ b/packages/desktop-host/src/security.ts
@@ -226,6 +226,18 @@ export function isStrandedPortalUrl(url: string, portalHost: string): boolean {
 }
 
 /**
+ * How long the portal's automatic `#/sso-callback` page may hold the top
+ * frame before the net declares it dead and recovers to the app. That page is
+ * a spinner running clerk-js's transfer (`signUp.create({transfer: true})`) —
+ * normally seconds; the budget is generous enough for a slow network plus an
+ * interactive Turnstile challenge, because recovering early would abort a
+ * transfer that was still going to finish. After recovery the app's boot
+ * sweep (`OAuthTransferBridge`) completes the dangling transfer in-app, so a
+ * dead callback page no longer needs an app restart to get signed in.
+ */
+const SSO_CALLBACK_TIMEOUT_MS = 30_000;
+
+/**
  * Recovery net for the OAuth return leg: if the top frame lands STRANDED on
  * the Clerk hosted Account Portal instead of back in the app (see
  * {@link isStrandedPortalUrl} — the functional `/sign-in` + `/sign-up` legs
@@ -235,6 +247,18 @@ export function isStrandedPortalUrl(url: string, portalHost: string): boolean {
  * only adds a way back when Clerk's fallback redirect picks the portal over
  * the app. Loop-safe: it only fires for the portal host, and `appUrl` is on
  * a different host, so the recovery load can't re-trigger it.
+ *
+ * Listens to BOTH full loads (`did-navigate`) and in-page navigations
+ * (`did-navigate-in-page`): the portal is an SPA, and the stranding users
+ * actually hit is its post-transfer client-side router push from
+ * `/sign-in#/sso-callback` to the `/user` profile page — a pushState hop
+ * `did-navigate` never reports.
+ *
+ * The functional legs additionally get a watchdog on the automatic
+ * `#/sso-callback` step (see {@link SSO_CALLBACK_TIMEOUT_MS}): if its JS
+ * dies, the window would otherwise sit on a blank portal page forever.
+ * Interactive portal pages (sign-in form, verify-email-address) are never
+ * put on a timer — a user mid-typing must not be yanked.
  */
 export function installAccountPortalRecovery(
   win: BrowserWindow,
@@ -243,17 +267,54 @@ export function installAccountPortalRecovery(
     readonly portalHost: string | null | undefined;
     /** The app root the window was originally loaded from. */
     readonly appUrl: string;
+    /** Test seam for the sso-callback watchdog. */
+    readonly ssoCallbackTimeoutMs?: number;
   },
 ): void {
   const { portalHost, appUrl } = opts;
   if (!portalHost) return;
+  const timeoutMs = opts.ssoCallbackTimeoutMs ?? SSO_CALLBACK_TIMEOUT_MS;
   const wc = win.webContents;
-  wc.on('did-navigate', (_event, url) => {
-    if (url === appUrl || !isStrandedPortalUrl(url, portalHost)) return;
-    void Promise.resolve(wc.loadURL(appUrl)).catch(() => {
-      /* window may be tearing down — nothing to recover */
-    });
-  });
+  let watchdog: ReturnType<typeof setTimeout> | null = null;
+  const disarm = (): void => {
+    if (watchdog) {
+      clearTimeout(watchdog);
+      watchdog = null;
+    }
+  };
+  const recover = (): void => {
+    try {
+      void Promise.resolve(wc.loadURL(appUrl)).catch(() => {
+        /* window may be tearing down — nothing to recover */
+      });
+    } catch {
+      /* webContents destroyed — nothing to recover */
+    }
+  };
+  const onLanding = (url: string): void => {
+    disarm(); // any navigation supersedes a pending sso-callback deadline
+    if (url === appUrl) return;
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return;
+    }
+    if (parsed.hostname !== portalHost) return;
+    if (isStrandedPortalUrl(url, portalHost)) {
+      recover();
+      return;
+    }
+    if (parsed.hash.startsWith('#/sso-callback')) {
+      watchdog = setTimeout(() => {
+        watchdog = null;
+        recover();
+      }, timeoutMs);
+    }
+  };
+  wc.on('did-navigate', (_event, url) => onLanding(url));
+  wc.on('did-navigate-in-page', (_event, url) => onLanding(url));
+  wc.on('destroyed', disarm);
 }
 
 /**


### PR DESCRIPTION
## What

Two field-reported desktop bugs, both in `@moxxy/desktop-host`:

**1. Fresh OAuth sign-up strands on the Account Portal's empty profile page (restart required).**
The portal-recovery net (`installAccountPortalRecovery`) only listened to `did-navigate`. But the hosted Account Portal is an SPA: after the sign-up transfer runs on `accounts.<domain>/sign-in#/sso-callback`, its router *pushes* to the `/user` profile page — a client-side hop that only fires `did-navigate-in-page`, so the net never saw it and the window stranded there. The net now:
- also watches `did-navigate-in-page` (recovers the observed stranding immediately), and
- arms a **30s watchdog on the automatic `#/sso-callback` leg** so a transfer page whose JS dies recovers into the app, where the boot sweep (`OAuthTransferBridge`, PR #182) completes the dangling sign-up. Interactive portal pages (sign-in form, verify-email) get **no** timer — a user mid-typing is never yanked.

**2. "Installed 0.7.0 but the app still runs 0.6."**
The bootstrap's bundle gate (`resolveActiveBundleDetailed`) had no floor-version check: a hot-update override staged by the *previous* install passes every existing gate (signature, ABI, runner-protocol — which only rejects bundles *newer* than the CLI), so a freshly installed 0.7.0 shell kept booting the stale 0.6.x override JS — whose update UI then re-demanded the full installer forever. The gate now takes `floorVersion` (bootstrap passes `app.getVersion()`; shell version == floor bundle version) and rejects `older-than-floor` (equal loses too — the baked copy is the trusted one). On that reject the bootstrap clears the active pointer via the new `clearActiveVersion` (no poison — the bundle is obsolete, not broken), so later boots take the clean `no-active` path.

## Why

Both block the two most basic flows for a fresh user: creating an account, and installing an update the app itself asked for.

## Verification

- pnpm build (59/59) / typecheck (116/116) / lint (0 errors) / test / check:deps — all green
- New unit tests: SPA in-page stranding recovers; sso-callback watchdog fires/disarms; interactive portal pages get no timer; `older-than-floor` rejects older AND equal overrides; newer override still wins (29 security tests, 89 app-update tests passing)
- Manual packaged round-trip (brand-new Google account + 0.6→0.7 reinstall) still pending — needs a real build