### PR TITLE
feat(desktop): self-service full app update (Tier-2) + never mark desktop releases Latest

### DIFF
--- a/.changeset/desktop-shell-self-update.md
+++ b/.changeset/desktop-shell-self-update.md
@@ -1,0 +1,8 @@
+---
+'@moxxy/desktop': patch
+'@moxxy/desktop-host': patch
+'@moxxy/desktop-ipc-contract': patch
+'@moxxy/client-core': patch
+---
+
+"Requires full update" releases now install themselves. New `app.updateShell` IPC drives electron-updater against a generic feed pinned at the exact `desktop-v<version>` release assets (GitHub latest/atom discovery can't parse `desktop-v*` tags), streaming download progress over `app.update.progress` and quit-and-installing on completion; the banner/Settings CTA becomes "Update app" with the release page kept as a fallback once an automatic attempt fails. macOS builds add a `zip` target so Squirrel.Mac can apply them, and desktop releases are no longer marked "Latest" on GitHub (`make_latest: false`).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,6 +378,7 @@ jobs:
             apps/desktop/release/*.exe
             apps/desktop/release/*.deb
             apps/desktop/release/*.AppImage
+            apps/desktop/release/*.zip
             apps/desktop/release/*.yml
             apps/desktop/release/*.blockmap
           if-no-files-found: ignore
@@ -436,9 +437,10 @@ jobs:
           {
             echo "MoxxyAI Workspaces desktop **v${version}**."
             echo
-            echo "**In this release:** macOS \`.dmg\`, Windows \`.exe\`, Linux \`.deb\`/\`.AppImage\`,"
-            echo "plus the signed Tier-1 hot-update bundle (\`moxxy-app-manifest.json\` +"
-            echo "\`moxxy-app-bundle-*.json.gz\`) and the electron-updater feed (\`latest*.yml\`)."
+            echo "**In this release:** macOS \`.dmg\` (+ \`.zip\` for in-app updates), Windows \`.exe\`,"
+            echo "Linux \`.deb\`/\`.AppImage\`, plus the signed Tier-1 hot-update bundle"
+            echo "(\`moxxy-app-manifest.json\` + \`moxxy-app-bundle-*.json.gz\`) and the"
+            echo "electron-updater feed (\`latest*.yml\`)."
             echo "Existing installs self-update from these assets once the release is published."
             echo
             case "$status" in
@@ -478,13 +480,18 @@ jobs:
       # NOTE: self-update needs PUBLISHED assets. The release is created as a
       # DRAFT (human review); the moxxy-app-manifest.json / bundle (Tier-1) and
       # the electron-updater latest*.yml feed (Tier-2) only become downloadable
-      # via `releases/latest/download/...` once a human PUBLISHES this release.
-      # So: review → Publish → clients can update.
+      # once a human PUBLISHES this release. So: review → Publish → clients
+      # can update. `make_latest: false` — desktop releases must NEVER take the
+      # repo's "Latest" badge: nothing consumes `releases/latest` (the stager
+      # resolves desktop-v* tags via the API precisely because npm-package
+      # releases already break "latest" — see stager.ts), and the badge should
+      # stay on the npm/product releases. Publishing the draft keeps this flag.
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: desktop-v${{ needs.version-publish.outputs.desktop-version }}
           files: artifacts/*
           draft: true
+          make_latest: false
           generate_release_notes: true
           body_path: ${{ runner.temp }}/release-body.md

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -680,6 +680,20 @@ refused override impersonated the previous override and let the boot probe confi
 that wasn't running. Residual (low): any pre-be7d33a floor will show the macOS Dock ghost-runner
 whenever a refused update drops onto it — immutable floor code, only a full reinstall fixes it.
 
+**2026-06-12 Tier-2 is now self-service:** the "needs the full app installer" dead end
+(banner → release page → manual download/install) became one click: new `app.updateShell`
+IPC + `installFullAppUpdate` (shell-updater.ts) drive electron-updater against a **generic
+feed pinned at the exact `desktop-v<version>` release assets** — NOT GitHub latest/atom
+discovery, which can't parse `desktop-v*` tags (semver-invalid with the prefix) and is
+broken by npm-package releases anyway; this is also why the background
+`checkForUpdatesAndNotify` in `initShellUpdater` likely never found anything (left as-is,
+harmless). macOS gains a `zip` build target (Squirrel.Mac can't install from a dmg) and
+needs a signed build — on signature/asset failure the IPC returns the error and the UI
+falls back to the release page. Desktop releases stop taking the repo's "Latest" badge
+(`make_latest: false` in release.yml). Residual: installers/feeds are draft-gated, so
+`app.updateShell` 404s until the release is published (same as Tier-1); the zip only
+exists on releases built after this change.
+
 **2026-06-12 fourth failure mode found + fixed (the inverse of #3):** a STALE override
 outranked a freshly installed shell. The resolve gate had no floor-version check, so after
 "0.7.0 updates the bundled runner — install the full app update" → user installs 0.7.0,

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -65,7 +65,7 @@ import { resolveWsBridgeConfig, MobileGatewayManager } from './ws-bridge.js';
 import { BUNDLED_UPDATE_PUBLIC_KEY } from './update-key.js';
 import { FLOOR_RUNNER_PROTOCOL } from './floor-runner-protocol.js';
 import { readConfirmed, markConfirmed, markBad, appendBootLog } from '@moxxy/desktop-host/app-update';
-import { initShellUpdater } from './shell-updater.js';
+import { initShellUpdater, installFullAppUpdate } from './shell-updater.js';
 
 // In a packaged build there is no global `moxxy` (and a GUI launch has no
 // shell PATH / system `node`). Point the CLI resolver at a self-contained,
@@ -947,6 +947,10 @@ app.whenReady().then(async () => {
       // ≤ the floor's (the boot gate already admitted it) — i.e. at worst the
       // stage-time gate is conservative, never permissive.
       cliRunnerProtocol: FLOOR_RUNNER_PROTOCOL,
+      // Tier-2: lets `app.updateShell` download + install the full installer
+      // when a release can't ship as a hot-update (runner bump). Lives here —
+      // not in desktop-host — because this app owns the electron-updater dep.
+      installShellUpdate: installFullAppUpdate,
     },
     // Bridge-control commands (host-only; refused over the WS transport).
     ...(mobileGateway ? { mobileGateway } : {}),

--- a/apps/desktop/electron/main/shell-updater.ts
+++ b/apps/desktop/electron/main/shell-updater.ts
@@ -43,9 +43,74 @@ export function initShellUpdater(): void {
   })();
 }
 
+/**
+ * On-demand Tier-2: download the FULL installer from an exact desktop release
+ * and quit into it. Unlike {@link initShellUpdater}'s background check, this is
+ * user-triggered (the "requires full update" banner) and runs on EVERY
+ * platform — macOS included, now that CI signs + notarizes (Squirrel.Mac
+ * refuses unsigned apps; on an unsigned build this rejects and the UI falls
+ * back to the release page).
+ *
+ * `feedBaseUrl` is the `releases/download/desktop-v<version>/` asset base of
+ * the release to install, resolved by the caller (desktop-host's
+ * `app.updateShell`). A GENERIC feed pinned there — never GitHub's
+ * latest-release discovery, which can't parse `desktop-v*` tags and is broken
+ * by the repo's npm-package releases anyway. electron-builder attaches the
+ * `latest*.yml` feed files the generic provider reads to every release.
+ *
+ * Rejects on any failure; only a fully downloaded + verified installer
+ * reaches `quitAndInstall` (deferred a tick so the IPC reply can flush).
+ */
+export async function installFullAppUpdate(opts: {
+  feedBaseUrl: string;
+  onProgress: (p: {
+    phase: 'download' | 'install';
+    received?: number;
+    total?: number;
+    message?: string;
+  }) => void;
+}): Promise<void> {
+  if (!app.isPackaged) throw new Error('Full app updates run only in the packaged app.');
+  const mod = (await import('electron-updater')) as {
+    autoUpdater?: ElectronAutoUpdater;
+    default?: { autoUpdater?: ElectronAutoUpdater };
+  };
+  const autoUpdater = mod.autoUpdater ?? mod.default?.autoUpdater;
+  if (!autoUpdater) throw new Error('electron-updater is not available in this build.');
+
+  // Explicit, user-triggered flow: no background download, no install-on-quit
+  // side effects from the launch check.
+  autoUpdater.autoDownload = false;
+  autoUpdater.autoInstallOnAppQuit = false;
+  autoUpdater.setFeedURL({ provider: 'generic', url: opts.feedBaseUrl });
+
+  // The module-level autoUpdater is a singleton — drop listeners from any
+  // previous attempt before wiring this one.
+  autoUpdater.removeAllListeners('download-progress');
+  autoUpdater.on('download-progress', (p: { transferred?: number; total?: number }) => {
+    opts.onProgress({ phase: 'download', received: p.transferred, total: p.total });
+  });
+
+  opts.onProgress({ phase: 'download', message: 'Fetching installer…' });
+  const check = await autoUpdater.checkForUpdates();
+  if (!check?.updateInfo?.version) {
+    throw new Error('No installer found for this release.');
+  }
+  await autoUpdater.downloadUpdate();
+  opts.onProgress({ phase: 'install', message: 'Restarting to install…' });
+  // Defer past the IPC reply; before-quit teardown (runner reap) still runs.
+  setImmediate(() => autoUpdater.quitAndInstall());
+}
+
 /** The slice of electron-updater's autoUpdater we touch. */
 interface ElectronAutoUpdater {
   autoDownload: boolean;
   autoInstallOnAppQuit: boolean;
   checkForUpdatesAndNotify(): Promise<unknown>;
+  checkForUpdates(): Promise<{ updateInfo?: { version?: string } } | null>;
+  downloadUpdate(): Promise<unknown>;
+  quitAndInstall(): void;
+  setFeedURL(options: { provider: 'generic'; url: string }): void;
+  on(event: string, listener: (...args: never[]) => void): unknown;
+  removeAllListeners(event: string): unknown;
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -105,7 +105,10 @@
     ],
     "mac": {
       "category": "public.app-category.productivity",
-      "target": "dmg",
+      "target": [
+        "dmg",
+        "zip"
+      ],
       "icon": "public/logo.png",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,

--- a/apps/desktop/src/settings/DashboardUpdateSection.tsx
+++ b/apps/desktop/src/settings/DashboardUpdateSection.tsx
@@ -21,9 +21,9 @@ function statusLine(state: UpdateState, latest: string | null): string | null {
     case 'available':
       return `Version ${latest} is available.`;
     case 'incompatible':
-      return 'A newer version needs a full app update (reinstall).';
+      return 'A newer version needs a full app update.';
     case 'requires-full-update':
-      return `Version ${latest ?? '?'} updates the bundled runner — it needs the full app installer and can’t apply as a hot-update.`;
+      return `Version ${latest ?? '?'} updates the bundled runner — it can’t apply as a hot-update, but the app can install the full update itself.`;
     case 'unavailable':
       return null; // shown via the check.error / muted note instead
     case 'updating':
@@ -66,6 +66,7 @@ export function DashboardUpdateSection(): JSX.Element {
     diagnostics,
     runCheck,
     runUpdate,
+    runShellUpdate,
     loadDiagnostics,
     relaunch,
   } = useAppUpdate();
@@ -156,14 +157,28 @@ export function DashboardUpdateSection(): JSX.Element {
             >
               Update dashboard
             </button>
-          ) : (state === 'incompatible' || state === 'requires-full-update') && check?.releaseUrl ? (
-            <button
-              type="button"
-              style={primaryBtn(false)}
-              onClick={() => void api().invoke('onboarding.openExternal', { url: check.releaseUrl! })}
-            >
-              Get the update
-            </button>
+          ) : state === 'incompatible' || state === 'requires-full-update' ? (
+            <>
+              <button
+                type="button"
+                data-testid="update-shell"
+                style={primaryBtn(false)}
+                onClick={() => void runShellUpdate()}
+              >
+                Update app
+              </button>
+              {error && check?.releaseUrl && (
+                <button
+                  type="button"
+                  style={primaryBtn(false)}
+                  onClick={() =>
+                    void api().invoke('onboarding.openExternal', { url: check.releaseUrl! })
+                  }
+                >
+                  Get it manually
+                </button>
+              )}
+            </>
           ) : (
             <button
               type="button"

--- a/apps/desktop/src/shell/UpdateBanner.tsx
+++ b/apps/desktop/src/shell/UpdateBanner.tsx
@@ -11,9 +11,8 @@ import { api } from '@moxxy/client-core';
 import { useAppUpdate } from '@moxxy/client-core';
 
 export function UpdateBanner(): JSX.Element | null {
-  const { check, state, progress, error, stagedVersion, runUpdate, relaunch } = useAppUpdate({
-    autoCheck: true,
-  });
+  const { check, state, progress, error, stagedVersion, runUpdate, runShellUpdate, relaunch } =
+    useAppUpdate({ autoCheck: true });
   const [dismissed, setDismissed] = useState(false);
 
   const visible =
@@ -61,15 +60,20 @@ export function UpdateBanner(): JSX.Element | null {
       </>
     );
   } else {
-    // incompatible / requires-full-update → Tier-2 (full app update)
+    // incompatible / requires-full-update → Tier-2: the app downloads its own
+    // installer and restarts into it. The release page stays as a fallback
+    // link once an automatic attempt failed (e.g. unsigned build).
     body = (
       <>
         <span>
           {state === 'requires-full-update'
-            ? `Version ${check?.latestVersion ?? ''} updates the bundled runner — install the full app update.`
+            ? `Version ${check?.latestVersion ?? ''} updates the bundled runner — a full app update will be installed.`
             : 'A new version needs a full app update.'}
         </span>
-        {check?.releaseUrl && (
+        <button type="button" style={primaryBtn} onClick={() => void runShellUpdate()}>
+          Update app
+        </button>
+        {error && check?.releaseUrl && (
           <button
             type="button"
             style={primaryBtn}
@@ -77,7 +81,7 @@ export function UpdateBanner(): JSX.Element | null {
               void api().invoke('onboarding.openExternal', { url: check.releaseUrl! })
             }
           >
-            Get update
+            Get it manually
           </button>
         )}
       </>

--- a/packages/client-core/src/useAppUpdate.ts
+++ b/packages/client-core/src/useAppUpdate.ts
@@ -40,6 +40,11 @@ export interface UseAppUpdate {
   diagnostics: AppUpdateDiagnostics | null;
   runCheck: () => Promise<void>;
   runUpdate: () => Promise<void>;
+  /** Tier-2: download the FULL installer and quit into it (`app.updateShell`).
+   *  For `requires-full-update` / `incompatible` releases a hot-update can't
+   *  deliver. On success the app quits mid-call; on failure the state returns
+   *  to the CTA with `error` set so the UI can offer the release page. */
+  runShellUpdate: () => Promise<void>;
   loadDiagnostics: () => Promise<void>;
   relaunch: () => void;
 }
@@ -107,6 +112,27 @@ export function useAppUpdate(opts: { autoCheck?: boolean } = {}): UseAppUpdate {
     }
   }, []);
 
+  const runShellUpdate = useCallback(async (): Promise<void> => {
+    setState('updating');
+    setError(null);
+    setProgress(null);
+    try {
+      const r = await api().invoke('app.updateShell');
+      if (r.ok) {
+        // The app is quitting into the installer — leave the progress line up.
+        setProgress({ phase: 'install', message: 'Restarting to install…' });
+      } else {
+        // Back to the CTA (with the error shown) so the release-page fallback
+        // stays reachable.
+        setError(r.error ?? 'Full update failed.');
+        setState('requires-full-update');
+      }
+    } catch (e) {
+      setError(toErrorMessage(e));
+      setState('requires-full-update');
+    }
+  }, []);
+
   const loadDiagnostics = useCallback(async (): Promise<void> => {
     try {
       setDiagnostics(await api().invoke('app.updateDiagnostics'));
@@ -136,6 +162,7 @@ export function useAppUpdate(opts: { autoCheck?: boolean } = {}): UseAppUpdate {
     diagnostics,
     runCheck,
     runUpdate,
+    runShellUpdate,
     loadDiagnostics,
     relaunch,
   };

--- a/packages/desktop-host/src/ipc/update.ts
+++ b/packages/desktop-host/src/ipc/update.ts
@@ -45,6 +45,19 @@ export interface UpdateConfig {
    * skip the gate.
    */
   cliRunnerProtocol?: number;
+  /**
+   * Tier-2: download + install the FULL app installer from the given release
+   * download base (`https://github.com/<repo>/releases/download/desktop-v<v>/`)
+   * and quit into it. Injected by the app main (which owns the
+   * electron-updater dependency — this package stays free of it); omitted ⇒
+   * `app.updateShell` reports unavailable and the UI falls back to the
+   * release page. Must REJECT on any failure (unsigned macOS build, missing
+   * installer asset) rather than half-installing.
+   */
+  installShellUpdate?: (opts: {
+    feedBaseUrl: string;
+    onProgress: (p: { phase: 'download' | 'install'; received?: number; total?: number; message?: string }) => void;
+  }) => Promise<void>;
 }
 
 /** The GitHub repo whose `desktop-v*` releases the updater pulls from. */
@@ -161,6 +174,41 @@ export function registerUpdateHandlers(config: UpdateConfig): void {
       return { ok: true, version };
     } catch (e) {
       return { ok: false, version: null, error: messageOf(e) };
+    }
+  });
+
+  handle('app.updateShell', async () => {
+    // Tier-2: the hot-update path can't deliver this release (runner bump /
+    // shell incompatibility) — fetch the FULL installer and replace the app.
+    const currentVersion = runningVersion();
+    if (!enabled()) {
+      return { ok: false, error: 'Full app updates run only in the packaged app.' };
+    }
+    const installShellUpdate = config.installShellUpdate;
+    if (!installShellUpdate) {
+      return { ok: false, error: 'Full app updates are not available in this build.' };
+    }
+    const res = await check(currentVersion);
+    if (!res.available || !res.latestVersion) {
+      return { ok: false, error: res.error ?? 'No update available.' };
+    }
+    const target = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0] ?? null;
+    try {
+      await installShellUpdate({
+        // Pinned at the exact release the manifest named — NEVER a "latest"
+        // endpoint: desktop-v* tags don't hold the repo's Latest badge, and
+        // npm-package releases break latest-based discovery anyway.
+        feedBaseUrl: `https://github.com/${GH_REPO}/releases/download/desktop-v${res.latestVersion}/`,
+        onProgress: (p) => {
+          if (target) sendEvent(target, 'app.update.progress', p);
+          wsEventBus.broadcast('app.update.progress', p);
+        },
+      });
+      // The installer callback quits + reinstalls on success; this reply only
+      // races the shutdown.
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: messageOf(e) };
     }
   });
 

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -445,9 +445,10 @@ export interface AppUpdateCheck {
   error?: string;
 }
 
-/** Streamed progress while a dashboard update downloads + installs. */
+/** Streamed progress while a dashboard update downloads + installs.
+ *  `install` is the Tier-2 (`app.updateShell`) installer phase. */
 export interface AppUpdateProgress {
-  phase: 'download' | 'verify' | 'extract' | 'activate';
+  phase: 'download' | 'verify' | 'extract' | 'activate' | 'install';
   received?: number;
   total?: number;
   message?: string;
@@ -602,6 +603,16 @@ export interface IpcCommands {
     error?: string;
     requiresFullUpdate?: boolean;
   }>;
+  /** Download + install the FULL app installer (Tier-2, electron-updater) for
+   *  the newest desktop release, streaming `app.update.progress`. The path for
+   *  updates a hot-update can't deliver (`requiresFullUpdate` — runner bump —
+   *  or an Electron/ABI `incompatible`). The feed is resolved entirely
+   *  main-side (the renderer passes no URL), pinned at the exact
+   *  `desktop-v<version>` release assets. On success the app quits and
+   *  reinstalls itself, so callers may never observe the resolved promise;
+   *  failures (e.g. unsigned macOS build, missing installer asset) come back
+   *  in `error` so the UI can fall back to the release page. */
+  'app.updateShell': () => Promise<{ ok: boolean; error?: string }>;
   /** Relaunch the app so a freshly-installed dashboard bundle takes effect. */
   'app.relaunch': () => Promise<void>;
   /** Renderer → main heartbeat: the React tree mounted past the splash. Clears
@@ -1003,6 +1014,9 @@ export const REMOTE_DISALLOWED_COMMANDS: ReadonlySet<IpcCommandName> = new Set<I
   'focus.restoreMain',
   'focus.resize',
   'app.relaunch',
+  // Installs + relaunches the host app — host-only, like app.relaunch (and a
+  // remote client must never be able to make the host swap its own binary).
+  'app.updateShell',
   // Bridge control: a remote client driving over the WS bridge must never be
   // able to toggle the gateway off, read the pairing token, or rotate it (which
   // would let it lock out the host or hand itself a fresh credential). These are

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -79,6 +79,7 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
   'app.updateInfo': z.undefined(),
   'app.checkUpdate': z.undefined(),
   'app.updateDashboard': z.undefined(),
+  'app.updateShell': z.undefined(),
   'app.relaunch': z.undefined(),
   'app.appBooted': z.undefined(),
   'app.updateDiagnostics': z.undefined(),


### PR DESCRIPTION
## What

Follow-up to #189 (the stale-override fix): the **"Version X updates the bundled runner — install the full app update"** path no longer dead-ends on a manual download. The app downloads and installs the full update itself.

- **New `app.updateShell` IPC** (host-only — refused over the WS bridge, listed in `REMOTE_DISALLOWED_COMMANDS`): re-checks the manifest main-side (renderer passes nothing), then drives electron-updater against a **generic feed pinned at the exact `desktop-v<version>` release assets**. GitHub's latest/atom discovery is deliberately bypassed: it can't parse `desktop-v*` tags (semver-invalid with that prefix) and the repo's npm-package releases break "latest"-based resolution anyway — which is also why the existing background `checkForUpdatesAndNotify` likely never found anything.
- **`installFullAppUpdate`** (shell-updater.ts, injected into desktop-host via `UpdateConfig.installShellUpdate` so desktop-host stays free of the electron-updater dep): explicit download (no background side effects), progress streamed over the existing `app.update.progress` event (new `install` phase), then `quitAndInstall` deferred a tick so the IPC reply flushes. Rejects cleanly on unsigned builds / missing assets.
- **UI:** banner + Settings CTA become "Update app" (`runShellUpdate` in client-core's `useAppUpdate`); after a failed automatic attempt the release-page button reappears as "Get it manually".
- **macOS gets a `zip` build target** — Squirrel.Mac cannot install from a dmg — and the release workflow uploads it.
- **`make_latest: false`** on the release-create step: desktop releases never take the repo's "Latest" badge (nothing consumes `releases/latest`; the stager resolves by tag).

## Why

"Even if the runner needs to be replaced it should download and replace the whole app — the update process should anyway work properly." Previously the requires-full-update banner sent the user to the release page for a manual download + reinstall.

## Verification

- pnpm build / typecheck / lint (0 errors) / test / check:deps — all green
- Tier-2 round-trip needs real published releases: the mac `zip` (and feed entries referencing it) only exist on releases built AFTER this change, so the first self-install ride is the release after next on macOS; Windows/Linux can self-install on the next release.