### PR TITLE
feat(desktop): real OAuth provider sign-in (claude-code out-of-band token paste)

### DIFF
--- a/.changeset/desktop-oauth-provider-signin.md
+++ b/.changeset/desktop-oauth-provider-signin.md
@@ -1,0 +1,13 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/cli': minor
+'@moxxy/desktop-ipc-contract': minor
+'@moxxy/desktop-host': minor
+'@moxxy/desktop': minor
+---
+
+Desktop OAuth providers now sign in for real instead of showing a "run `moxxy login` in a terminal" hint.
+
+Settings → Providers (and the onboarding wizard) drive a shared `OAuthSignIn` flow that spawns `moxxy login <provider>`, opens the browser, and — for out-of-band providers like `claude-code` — collects the pasted `claude setup-token` or `code#state` in the UI (browser-authorize primary, token paste as a fallback). Loopback providers (openai-codex) keep their automatic browser+callback flow.
+
+Mechanics: `moxxy login --stdin-prompts` relays each interactive prompt to the host as a NUL-bracketed marker on stdout (new `encodeLoginPrompt` / `createLoginStreamScanner` in `@moxxy/sdk`) and reads answers as stdin lines, so a GUI host can drive the paste flow without a TTY. The desktop exposes this via new `provider.login.start` / `answer` / `cancel` IPC commands and `provider.login.prompt` / `output` / `done` events; the dead `onboarding.runProviderLogin` command was removed. `onboarding.providerAuthKind` now derives a provider's auth kind from the runner's registry (fixing `claude-code` being mis-detected as an API-key provider) instead of a hardcoded list.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -37,6 +37,30 @@ pass also **retired the plugins-admin CLI install-hardening + dedup items** (for
 
 ---
 
+## 2026-06-17 — desktop OAuth provider sign-in (claude-code) + de-hardcoded auth kind
+
+- **Retired: Settings → Providers showed a dead "run `moxxy login <provider>` in a
+  terminal" comment for OAuth providers.** It now drives a real sign-in: a shared
+  `OAuthSignIn` component spawns `moxxy login <provider>` in the host and relays the
+  flow, opening the browser and collecting any pasted value. Onboarding's `ProviderStep`
+  was migrated onto the same component, so both surfaces behave identically.
+- **Retired the `onboarding.providerAuthKind` hardcode** (`OAUTH_PROVIDERS = new
+  Set(['openai-codex'])`, which mis-classified `claude-code` as api-key and showed it a
+  key field). It now reads the runner's own registry metadata
+  (`getInfo().providers[].authKind`) — the source of truth that already feeds Settings —
+  and only falls back to a static set (now both OAuth providers) when the runner isn't
+  reachable yet. One fewer place a new OAuth provider must be registered by hand.
+- **Removed dead code:** `installer.ts#runProviderLogin` and the
+  `onboarding.runProviderLogin` IPC command (+ its validation schema), superseded by the
+  generic `provider.login.start/answer/cancel` commands.
+- **New seam (not debt, noted for the next reader):** out-of-band providers like
+  `claude-code` ask the user to paste a token / `code#state`, which a GUI host can't do
+  over a clack TTY. The CLI's `moxxy login --stdin-prompts` now relays each `ctx.prompt`
+  as a NUL-bracketed marker on stdout (parsed by `@moxxy/sdk`'s
+  `createLoginStreamScanner`) and reads answers as stdin lines — so the desktop drives the
+  paste flow without re-implementing the OAuth dance. Loopback providers (openai-codex)
+  emit no markers and are unaffected.
+
 ## 2026-06-15 — built-in providers: z.ai / xAI / Google Gemini / local
 
 - **New (`@moxxy/plugin-provider-{zai,xai,google,local}`):** four first-class

--- a/apps/desktop/src/onboarding/steps/ProviderStep.tsx
+++ b/apps/desktop/src/onboarding/steps/ProviderStep.tsx
@@ -1,9 +1,10 @@
 /**
  * The provider-connect step — pick a provider from the catalog, then
- * either paste an API key (api-key providers) or run the browser OAuth
- * login (oauth providers), streaming the login subprocess's stdout to a
- * log box. The auth kind re-resolves whenever the provider changes.
- * Applies on first run and whenever the recovery gate finds no provider.
+ * either paste an API key (api-key providers) or run the real OAuth login
+ * (oauth providers) via the shared {@link OAuthSignIn} flow, which opens the
+ * browser and collects any pasted token / code. The auth kind re-resolves
+ * whenever the provider changes. Applies on first run and whenever the
+ * recovery gate finds no provider.
  */
 
 import { useEffect, useState } from 'react';
@@ -11,6 +12,7 @@ import { decodeError, toErrorMessage } from '@moxxy/client-core';
 import { api } from '@moxxy/client-core';
 import { retryWhileReconnecting } from '@moxxy/client-core';
 import { StepCard, Nav, PrimaryButton, SuccessRow, inputStyle } from '../chrome';
+import { OAuthSignIn } from '../../settings/shared/OAuthSignIn';
 
 export function ProviderStep({
   onNext,
@@ -23,6 +25,7 @@ export function ProviderStep({
     'anthropic',
     'openai',
     'openai-codex',
+    'claude-code',
   ]);
   const [provider, setProvider] = useState('anthropic');
   const [authKind, setAuthKind] = useState<'oauth' | 'api-key'>('api-key');
@@ -30,7 +33,6 @@ export function ProviderStep({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState(false);
-  const [loginLog, setLoginLog] = useState<string[]>([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -67,16 +69,6 @@ export function ProviderStep({
       cancelled = true;
     };
   }, [provider]);
-
-  // Reuse the install-progress channel so the OAuth subprocess's
-  // stdout (the URL prompt, success row, etc.) streams to the
-  // log box.
-  useEffect(() => {
-    const off = api().subscribe('onboarding.install.progress', (line: string) => {
-      setLoginLog((cur) => [...cur.slice(-80), line]);
-    });
-    return off;
-  }, []);
 
   // After a credential lands in the vault, tell the RUNNING runner to activate
   // this provider. The runner booted with no active provider (no creds existed
@@ -116,23 +108,17 @@ export function ProviderStep({
     }
   };
 
-  const runOauthLogin = async (): Promise<void> => {
-    setSaving(true);
-    setError(null);
-    setLoginLog([]);
-    try {
-      const code = await api().invoke('onboarding.runProviderLogin', { provider });
-      if (code !== 0) {
-        setError(`moxxy login exit ${code}`);
-        return;
+  // OAuth providers sign in through the shared flow; once it reports success
+  // we activate the provider (same vault→runner handoff as the key path).
+  const onOauthSignedIn = (): void => {
+    void (async () => {
+      try {
+        await activateProvider();
+        setDone(true);
+      } catch (e) {
+        setError(toErrorMessage(e));
       }
-      await activateProvider();
-      setDone(true);
-    } catch (e) {
-      setError(toErrorMessage(e));
-    } finally {
-      setSaving(false);
-    }
+    })();
   };
 
   return (
@@ -167,7 +153,7 @@ export function ProviderStep({
             {catalog.map((name) => (
               <option key={name} value={name}>
                 {name}
-                {name === 'openai-codex' ? ' · OAuth' : ''}
+                {name === 'openai-codex' || name === 'claude-code' ? ' · OAuth' : ''}
               </option>
             ))}
           </select>
@@ -193,41 +179,13 @@ export function ProviderStep({
             {error}
           </p>
         )}
-        {done && (
-          <SuccessRow
-            text={
-              authKind === 'oauth'
-                ? `Signed in to ${provider}.`
-                : 'Key saved to the vault.'
-            }
-          />
-        )}
+        {done && authKind === 'api-key' && <SuccessRow text="Key saved to the vault." />}
         {authKind === 'oauth' ? (
-          <PrimaryButton onClick={() => void runOauthLogin()} disabled={saving}>
-            {saving ? 'Waiting for browser…' : done ? `Re-link ${provider}` : `Sign in with ${provider}`}
-          </PrimaryButton>
+          <OAuthSignIn provider={provider} onSignedIn={onOauthSignedIn} />
         ) : (
           <PrimaryButton onClick={() => void saveKey()} disabled={saving || !secret.trim()}>
             {saving ? 'Saving…' : done ? 'Update key' : 'Save key'}
           </PrimaryButton>
-        )}
-        {authKind === 'oauth' && loginLog.length > 0 && (
-          <pre
-            className="mono"
-            style={{
-              margin: 0,
-              padding: 10,
-              background: '#0f172a',
-              color: '#e2e8f0',
-              borderRadius: 10,
-              fontSize: 11,
-              maxHeight: 140,
-              overflow: 'auto',
-              whiteSpace: 'pre-wrap',
-            }}
-          >
-            {loginLog.slice(-20).join('\n')}
-          </pre>
         )}
       </div>
       <Nav onBack={onBack} onNext={onNext} nextLabel={done ? 'Continue' : 'Skip for now'} />

--- a/apps/desktop/src/settings/ProvidersTab.test.tsx
+++ b/apps/desktop/src/settings/ProvidersTab.test.tsx
@@ -106,10 +106,15 @@ describe('ProvidersTab', () => {
     );
   });
 
-  it('shows a login hint instead of a key form for OAuth providers', () => {
+  it('offers a real sign-in (not a key form) for OAuth providers', () => {
+    // The OAuthSignIn flow subscribes to provider.login.* on mount, so the
+    // configure sheet needs a transport even though the buttons aren't clicked.
+    __setApiOverride({ invoke: vi.fn(() => Promise.resolve()), subscribe: vi.fn(() => () => {}) } as never);
     renderTab();
     fireEvent.click(screen.getByRole('button', { name: /configure openai-codex/i }));
     expect(screen.getByText(/signs in with OAuth/i)).toBeTruthy();
     expect(screen.queryByTestId('provider-key-input')).toBeNull();
+    // The dead "run moxxy login in a terminal" hint is gone — there's a button.
+    expect(screen.getByRole('button', { name: /sign in with openai-codex/i })).toBeTruthy();
   });
 });

--- a/apps/desktop/src/settings/ProvidersTab.tsx
+++ b/apps/desktop/src/settings/ProvidersTab.tsx
@@ -13,6 +13,7 @@ import type { useSettings } from '@moxxy/client-core';
 import { Button, Icon, IconButton, Modal, TextInput } from '@moxxy/desktop-ui';
 import { Section, CardList, Row, Tile, StatusDot, Switch, Badge, EmptyState } from './settings-primitives';
 import { AgentTaskModal } from './shared/AgentTaskModal';
+import { OAuthSignIn } from './shared/OAuthSignIn';
 import { PROVIDER_PROMPT_TEMPLATE } from './provider-prompt';
 
 type ProviderRow = ReturnType<typeof useSettings>['providers'][number];
@@ -110,6 +111,7 @@ export function ProvidersTab({
           provider={configuring}
           onConfigure={onConfigure}
           onSetKey={onSetKey}
+          onRefresh={onRefresh}
           onClose={() => setConfiguring(null)}
         />
       )}
@@ -121,7 +123,7 @@ function subtitleFor(p: ProviderRow): string {
   if (!p.enabled) return 'Disabled · excluded from activation';
   if (p.ready) return 'Active · credentials resolved';
   return p.authKind === 'oauth'
-    ? 'Inactive · sign in with `moxxy login` to use'
+    ? 'Inactive · sign in to connect'
     : 'Inactive · add a key to use';
 }
 
@@ -137,6 +139,7 @@ function ConfigureProviderModal({
   provider,
   onConfigure,
   onSetKey,
+  onRefresh,
   onClose,
 }: {
   readonly provider: ProviderRow;
@@ -145,6 +148,7 @@ function ConfigureProviderModal({
     patch: { baseURL?: string; defaultModel?: string },
   ) => Promise<void>;
   readonly onSetKey: (keyName: string, value: string) => Promise<void>;
+  readonly onRefresh: () => Promise<void>;
   readonly onClose: () => void;
 }): JSX.Element {
   const [key, setKey] = useState('');
@@ -178,11 +182,18 @@ function ConfigureProviderModal({
     <Modal title={`Configure ${provider.name}`} onClose={onClose} width={420}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
         {provider.authKind === 'oauth' ? (
-          <p style={{ margin: 0, fontSize: 13, color: 'var(--color-text-muted)', lineHeight: 1.55 }}>
-            This provider signs in with OAuth — run{' '}
-            <code style={{ fontSize: 12.5 }}>moxxy login {provider.name}</code> in a terminal to
-            connect it. There is no API key to store.
-          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <p style={{ margin: 0, fontSize: 13, color: 'var(--color-text-muted)', lineHeight: 1.55 }}>
+              This provider signs in with OAuth — no API key to store. We'll open your browser to
+              finish; any pasted token stays in the encrypted vault.
+            </p>
+            <OAuthSignIn
+              provider={provider.name}
+              onSignedIn={() => {
+                void onRefresh();
+              }}
+            />
+          </div>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
             <label style={fieldLabelStyle}>

--- a/apps/desktop/src/settings/shared/OAuthSignIn.tsx
+++ b/apps/desktop/src/settings/shared/OAuthSignIn.tsx
@@ -1,0 +1,205 @@
+/**
+ * Interactive OAuth sign-in for a provider, driven entirely from the UI.
+ *
+ * Spawns `moxxy login <provider>` in the host via `provider.login.start` and
+ * relays the flow: streamed progress goes to a log box; when the provider asks
+ * for a pasted value (the out-of-band token / `code#state` claude-code needs)
+ * a `provider.login.prompt` event surfaces an input we answer with
+ * `provider.login.answer`. Loopback providers (openai-codex) never prompt —
+ * the browser opens, the callback lands, and `provider.login.done` arrives.
+ *
+ * Shared by Settings → Providers and the onboarding wizard so both get the
+ * identical real login (not a "run it in a terminal" hint).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { api, toErrorMessage } from '@moxxy/client-core';
+import { Button, TextInput } from '@moxxy/desktop-ui';
+
+type Phase = 'idle' | 'running' | 'done' | 'error';
+
+export function OAuthSignIn({
+  provider,
+  onSignedIn,
+  startLabel,
+}: {
+  readonly provider: string;
+  /** Called once the login exits 0 — the caller activates the provider. */
+  readonly onSignedIn?: () => void;
+  /** Override the initial button text (defaults to `Sign in with <provider>`). */
+  readonly startLabel?: string;
+}): JSX.Element {
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [log, setLog] = useState<string[]>([]);
+  const [prompt, setPrompt] = useState<{ question: string; mask: boolean } | null>(null);
+  const [answer, setAnswer] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const loginIdRef = useRef<string | null>(null);
+
+  const append = (text: string): void =>
+    setLog((cur) => {
+      // Split on newlines so the log renders line-by-line; drop empties.
+      const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
+      return [...cur, ...lines].slice(-200);
+    });
+
+  // One set of subscriptions for the component's lifetime, filtered by the
+  // active loginId so a stale run's late events can't bleed into a new one.
+  useEffect(() => {
+    const offs = [
+      api().subscribe('provider.login.output', (p) => {
+        if (p.loginId === loginIdRef.current) append(p.text);
+      }),
+      api().subscribe('provider.login.prompt', (p) => {
+        if (p.loginId !== loginIdRef.current) return;
+        setPrompt({ question: p.question, mask: p.mask });
+        setAnswer('');
+      }),
+      api().subscribe('provider.login.done', (p) => {
+        if (p.loginId !== loginIdRef.current) return;
+        loginIdRef.current = null;
+        setPrompt(null);
+        if (p.code === 0) {
+          setPhase('done');
+          onSignedIn?.();
+        } else {
+          setPhase('error');
+          setError(`Sign-in did not complete (exit ${p.code}).`);
+        }
+      }),
+    ];
+    return () => offs.forEach((off) => off());
+    // onSignedIn is captured per-mount; callers pass a stable handler.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Abort a still-running login if the component unmounts (modal closed).
+  useEffect(
+    () => () => {
+      const id = loginIdRef.current;
+      if (id) void api().invoke('provider.login.cancel', { loginId: id });
+    },
+    [],
+  );
+
+  const start = async (): Promise<void> => {
+    const id = crypto.randomUUID();
+    loginIdRef.current = id;
+    setPhase('running');
+    setError(null);
+    setLog([]);
+    setPrompt(null);
+    try {
+      await api().invoke('provider.login.start', { loginId: id, provider });
+    } catch (e) {
+      loginIdRef.current = null;
+      setError(toErrorMessage(e));
+      setPhase('error');
+    }
+  };
+
+  const submit = async (value: string): Promise<void> => {
+    const id = loginIdRef.current;
+    if (!id) return;
+    setPrompt(null); // back to "waiting" until the next prompt / completion
+    try {
+      await api().invoke('provider.login.answer', { loginId: id, value });
+    } catch (e) {
+      setError(toErrorMessage(e));
+    }
+  };
+
+  // claude-code's first prompt offers "paste a token OR press Enter for the
+  // browser"; surface both, browser primary. The flag keys off the question
+  // text the CLI sends, so it stays true to the actual flow.
+  const offersBrowser = prompt !== null && /browser/i.test(prompt.question);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {phase === 'idle' && (
+        <Button variant="primary" onClick={() => void start()}>
+          {startLabel ?? `Sign in with ${provider}`}
+        </Button>
+      )}
+
+      {phase === 'done' && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--color-green, #16a34a)' }}>
+            Signed in to {provider}.
+          </p>
+          <Button onClick={() => void start()}>Re-link {provider}</Button>
+        </div>
+      )}
+
+      {(phase === 'running' || phase === 'error') && prompt && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <label style={{ fontSize: 12.5, color: 'var(--color-text-muted)', lineHeight: 1.5 }}>
+            {prompt.question}
+          </label>
+          {offersBrowser && (
+            <Button variant="primary" onClick={() => void submit('')}>
+              Sign in with your browser
+            </Button>
+          )}
+          <div style={{ display: 'flex', gap: 8 }}>
+            <TextInput
+              type={prompt.mask ? 'password' : 'text'}
+              value={answer}
+              onChange={(e) => setAnswer(e.target.value)}
+              placeholder={offersBrowser ? '…or paste a token' : 'Paste here'}
+              autoComplete="off"
+              spellCheck={false}
+              style={{ flex: 1 }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && answer.trim()) void submit(answer.trim());
+              }}
+            />
+            <Button
+              variant={offersBrowser ? 'secondary' : 'primary'}
+              disabled={!answer.trim()}
+              onClick={() => void submit(answer.trim())}
+            >
+              {offersBrowser ? 'Use token' : 'Continue'}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {phase === 'running' && !prompt && (
+        <p style={{ margin: 0, fontSize: 13, color: 'var(--color-text-muted)' }}>
+          Opening your browser — complete the sign-in there…
+        </p>
+      )}
+
+      {error && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <p role="alert" style={{ margin: 0, fontSize: 12.5, color: 'var(--color-red)' }}>
+            {error}
+          </p>
+          {phase === 'error' && (
+            <Button onClick={() => void start()}>Try again</Button>
+          )}
+        </div>
+      )}
+
+      {log.length > 0 && (phase === 'running' || phase === 'error') && (
+        <pre
+          className="mono"
+          style={{
+            margin: 0,
+            padding: 10,
+            background: '#0f172a',
+            color: '#e2e8f0',
+            borderRadius: 10,
+            fontSize: 11,
+            maxHeight: 140,
+            overflow: 'auto',
+            whiteSpace: 'pre-wrap',
+          }}
+        >
+          {log.slice(-30).join('\n')}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -44,6 +44,7 @@ function buildHelp(session: Session | null): string {
         rows: [
           ['--browser', 'force the loopback/browser flow even without a TTY (opens the browser automatically)'],
           ['--no-browser', 'force the headless device-code flow (auto when no TTY)'],
+          ['--stdin-prompts', 'GUI-host mode: relay paste prompts over stdout markers + stdin lines (desktop app)'],
         ],
       },
     ],
@@ -111,18 +112,29 @@ async function loginProvider(argv: ParsedArgv, providerName: string): Promise<nu
   // flow that's about to start.
   await vault.open();
 
+  // `--stdin-prompts` is the desktop GUI's mode: the provider's prompts are
+  // relayed to the host over the pipe (markers on stdout, answers as stdin
+  // lines) so the out-of-band paste flow (claude-code) works without a TTY.
+  // It implies an interactive (non-headless) flow — the host IS the terminal.
+  const stdinPrompts = hasBoolFlag(argv, 'stdin-prompts');
+
   // Headless (device-code) mode triggers when:
   //   - the user passes `--no-browser` (e.g. running on a remote box and
   //     wanting to complete the flow from their laptop's browser), OR
   //   - stdin isn't a TTY (CI, ssh -T, docker exec without -t) AND the
-  //     caller didn't force the browser flow with `--browser`.
+  //     caller didn't force the browser flow with `--browser` / drive it over
+  //     `--stdin-prompts`.
   // `--browser` lets a GUI host (the desktop app) spawn `moxxy login` with
   // piped stdio yet still get the loopback flow that opens the browser
   // automatically — no manual code copying.
   const headless =
-    hasBoolFlag(argv, 'no-browser') ||
-    (!hasBoolFlag(argv, 'browser') && process.stdin.isTTY !== true);
-  const ctx = buildProviderAuthContext(vault, { headless });
+    !stdinPrompts &&
+    (hasBoolFlag(argv, 'no-browser') ||
+      (!hasBoolFlag(argv, 'browser') && process.stdin.isTTY !== true));
+  const ctx = buildProviderAuthContext(vault, {
+    headless,
+    ...(stdinPrompts ? { promptMode: 'stdin' as const } : {}),
+  });
 
   try {
     const result = await def.auth.login(ctx);

--- a/packages/cli/src/wizard/auth-context.ts
+++ b/packages/cli/src/wizard/auth-context.ts
@@ -5,7 +5,8 @@
  * dance is identical regardless of which provider plugin owns it.
  */
 
-import { MoxxyError, type ProviderAuthContext, type ProviderDef } from '@moxxy/sdk';
+import { createInterface, type Interface } from 'node:readline';
+import { MoxxyError, encodeLoginPrompt, type ProviderAuthContext, type ProviderDef } from '@moxxy/sdk';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { isCancel, password, text } from '@clack/prompts';
 
@@ -13,25 +14,81 @@ export interface BuildAuthContextOptions {
   readonly headless: boolean;
   /** Defaults to writing through `process.stdout`. Wizard hosts pass a clack-aware writer. */
   readonly write?: (chunk: string) => void;
+  /**
+   * How `ctx.prompt` is satisfied. `'clack'` (default) renders interactive TTY
+   * prompts. `'stdin'` relays each prompt to the host as a NUL-bracketed marker
+   * on stdout and reads the answer back as one stdin line — for a GUI host (the
+   * desktop app) that drives `moxxy login` as a subprocess with no TTY and so
+   * can't render a clack prompt. The out-of-band paste flows (claude-code)
+   * work identically; only the input transport differs.
+   */
+  readonly promptMode?: 'clack' | 'stdin';
 }
 
 export function buildProviderAuthContext(
   vault: VaultStore,
   opts: BuildAuthContextOptions,
 ): ProviderAuthContext {
+  // 'stdin' mode always exposes a prompt (the host drives it over the pipe);
+  // 'clack' only when there's a TTY. Headless with no prompt makes paste flows
+  // fail fast with a "set the env var instead" message rather than hang.
+  const prompt =
+    opts.promptMode === 'stdin' ? stdinLinePrompt : opts.headless ? undefined : clackPrompt;
   return {
     headless: opts.headless,
     write: opts.write ?? ((s) => process.stdout.write(s)),
-    // A TTY-only single-line input used by out-of-band / paste flows (e.g.
-    // claude-code). Omitted in headless mode so those flows fail fast with a
-    // "set the env var instead" message rather than hanging on a dead stdin.
-    ...(opts.headless ? {} : { prompt: clackPrompt }),
+    ...(prompt ? { prompt } : {}),
     vault: {
       get: (key) => vault.get(key),
       set: (key, value, tags) => vault.set(key, value, tags ? [...tags] : undefined),
       delete: (key) => vault.delete(key),
     },
   };
+}
+
+// --- stdin-driven prompt (GUI host over a subprocess) ----------------------
+//
+// One readline over the process's stdin, shared across the (sequential) prompt
+// calls a single login makes. The host writes one line per prompt; we hand
+// each line to the next waiting prompt, or queue it if it arrives early.
+
+let lineReader: Interface | null = null;
+let stdinEnded = false;
+const lineQueue: string[] = [];
+const lineWaiters: Array<(line: string) => void> = [];
+
+function ensureLineReader(): void {
+  if (lineReader) return;
+  lineReader = createInterface({ input: process.stdin });
+  lineReader.on('line', (line) => {
+    const waiter = lineWaiters.shift();
+    if (waiter) waiter(line);
+    else lineQueue.push(line);
+  });
+  // If the host closes stdin, don't leave a prompt hanging forever — resolve
+  // pending + future reads as empty (treated as a cancellation by callers).
+  lineReader.on('close', () => {
+    stdinEnded = true;
+    for (const w of lineWaiters.splice(0)) w('');
+  });
+}
+
+function readStdinLine(): Promise<string> {
+  ensureLineReader();
+  const queued = lineQueue.shift();
+  if (queued !== undefined) return Promise.resolve(queued);
+  if (stdinEnded) return Promise.resolve('');
+  return new Promise<string>((resolve) => lineWaiters.push(resolve));
+}
+
+async function stdinLinePrompt(
+  question: string,
+  opts?: { readonly mask?: boolean },
+): Promise<string> {
+  // Emit a structured marker the host parses to render its own input field,
+  // then await the answer as one stdin line. `mask` only hints the host's UI.
+  process.stdout.write(encodeLoginPrompt({ question, mask: opts?.mask === true }));
+  return await readStdinLine();
 }
 
 async function clackPrompt(question: string, opts?: { readonly mask?: boolean }): Promise<string> {

--- a/packages/desktop-host/src/installer.ts
+++ b/packages/desktop-host/src/installer.ts
@@ -15,7 +15,6 @@ import path, { dirname } from 'node:path';
 import { type BrowserWindow } from 'electron';
 import type { NodeProbe } from '@moxxy/desktop-ipc-contract';
 import { augmentedPaths, findExecutable, resolveMoxxyCli, spawnCli, spawnPath } from './cli-resolver';
-import { assertSafeProviderName } from './security';
 import { sendEvent } from './send-event';
 import { wsEventBus } from './event-bus';
 
@@ -162,39 +161,6 @@ export async function updateCli(userDataDir: string, window: BrowserWindow): Pro
       // shebang needs node, which lives in npm's own dir.
       env: { ...process.env, PATH: spawnPath([dirname(npm)]) },
     });
-    proc.stdout?.on('data', (b: Buffer) => stream(window, b.toString()));
-    proc.stderr?.on('data', (b: Buffer) => stream(window, b.toString()));
-    proc.on('error', reject);
-    proc.on('exit', (code) => resolve(code ?? -1));
-  });
-}
-
-/**
- * Spawn `moxxy login <provider>`. The CLI runs the provider's OAuth
- * flow — opens the system browser to the provider's auth page and
- * listens for the loopback callback — then stores the resulting
- * tokens in the vault.
- *
- * stdout + stderr stream back to the renderer via the same channel
- * the npm install uses (`onboarding.install.progress`). Resolves
- * with the exit code; the wizard treats 0 as "logged in".
- */
-export async function runProviderLogin(
-  provider: string,
-  window: BrowserWindow,
-): Promise<number> {
-  assertSafeProviderName(provider);
-  const cli = resolveMoxxyCli({ extraPaths: augmentedPaths() });
-  if (!cli) throw new Error('moxxy CLI not found — run the install step first');
-
-  emit(window, `$ moxxy login ${provider} --browser`);
-
-  // `--browser` forces the loopback flow (which opens the system browser
-  // automatically + catches the localhost callback) instead of the headless
-  // device-code flow `moxxy login` would otherwise pick because we spawn it
-  // with piped stdio (no TTY). The desktop is a GUI — no code copying.
-  const proc = spawnCli(cli, ['login', provider, '--browser']);
-  return new Promise<number>((resolve, reject) => {
     proc.stdout?.on('data', (b: Buffer) => stream(window, b.toString()));
     proc.stderr?.on('data', (b: Buffer) => stream(window, b.toString()));
     proc.on('error', reject);

--- a/packages/desktop-host/src/ipc.ts
+++ b/packages/desktop-host/src/ipc.ts
@@ -38,6 +38,7 @@ import { registerUpdateHandlers, type UpdateConfig } from './ipc/update';
 import { registerAskHandlers } from './ipc/ask';
 import { registerConnectionHandlers } from './ipc/connection';
 import { registerOnboardingHandlers } from './ipc/onboarding';
+import { registerProviderLoginHandlers } from './ipc/provider-login';
 import { registerSessionHandlers } from './ipc/session';
 import { registerSessionsHandlers } from './ipc/sessions';
 import { registerWorkspaceFsHandlers } from './ipc/workspace-fs';
@@ -74,6 +75,7 @@ export function registerIpcHandlers(
     registerUpdateHandlers(opts.update ?? { publicKeyPem: '' });
     registerConnectionHandlers(pool);
     registerOnboardingHandlers(pool);
+    registerProviderLoginHandlers(pool);
     registerSessionHandlers(pool);
     registerSessionsHandlers(pool, desks);
     registerWorkspaceFsHandlers(desks);

--- a/packages/desktop-host/src/ipc/onboarding.ts
+++ b/packages/desktop-host/src/ipc/onboarding.ts
@@ -48,19 +48,14 @@ export function registerOnboardingHandlers(pool: RunnerPool): void {
     if (session) session.providers.setActive(provider);
   });
   handle('onboarding.providerAuthKind', async ({ provider }) => {
-    // The only built-in OAuth provider today is openai-codex; admin-
-    // registered providers in providers.json are all api-key. Keep
-    // this list as the source of truth until the runner exposes
-    // provider auth metadata over RPC.
-    const OAUTH_PROVIDERS = new Set(['openai-codex']);
-    return OAUTH_PROVIDERS.has(provider) ? 'oauth' : 'api-key';
-  });
-  handle('onboarding.runProviderLogin', async ({ provider }) => {
-    const { runProviderLogin } = await import('../installer');
-    const target = BrowserWindowApi.getFocusedWindow() ?? BrowserWindowApi.getAllWindows()[0];
-    if (!target) throw new Error('no window to stream login progress to');
-    const code = await runProviderLogin(provider, target);
-    if (code === 0) pool.active()?.forceRetry();
-    return code;
+    // Prefer the runner's own registry metadata — it knows every provider's
+    // declared auth kind (including OAuth ones like claude-code), so no list
+    // here can drift. Fall back to the known built-in OAuth providers only
+    // when the runner isn't reachable yet (early in onboarding).
+    const info = pool.active()?.remote()?.getInfo();
+    const known = info?.providers.find((p) => p.name === provider);
+    if (known) return known.authKind;
+    const OAUTH_FALLBACK = new Set(['openai-codex', 'claude-code']);
+    return OAUTH_FALLBACK.has(provider) ? 'oauth' : 'api-key';
   });
 }

--- a/packages/desktop-host/src/ipc/provider-login.ts
+++ b/packages/desktop-host/src/ipc/provider-login.ts
@@ -1,0 +1,37 @@
+/**
+ * Interactive provider sign-in handlers (OAuth) shared by the onboarding
+ * wizard and Settings → Providers. They spawn + drive `moxxy login <provider>`
+ * via {@link startProviderLogin}; the renderer relays the user's pasted
+ * answers. On a successful exit we nudge the active supervisor's
+ * {@link RunnerSupervisor.forceRetry} so the next turn picks up the new
+ * credential without a relaunch (the renderer separately activates the
+ * provider via `session.setProvider`).
+ */
+
+import { BrowserWindow as BrowserWindowApi } from 'electron';
+
+import type { RunnerPool } from '../runner-pool';
+import {
+  answerProviderLogin,
+  cancelProviderLogin,
+  startProviderLogin,
+} from '../provider-login';
+import { handle } from './shared';
+
+export function registerProviderLoginHandlers(pool: RunnerPool): void {
+  handle('provider.login.start', async ({ loginId, provider }) => {
+    const target = BrowserWindowApi.getFocusedWindow() ?? BrowserWindowApi.getAllWindows()[0];
+    if (!target) throw new Error('no window to drive the provider login');
+    startProviderLogin(loginId, provider, target, {
+      onExit: (code) => {
+        if (code === 0) pool.active()?.forceRetry();
+      },
+    });
+  });
+  handle('provider.login.answer', async ({ loginId, value }) => {
+    answerProviderLogin(loginId, value);
+  });
+  handle('provider.login.cancel', async ({ loginId }) => {
+    cancelProviderLogin(loginId);
+  });
+}

--- a/packages/desktop-host/src/provider-login.test.ts
+++ b/packages/desktop-host/src/provider-login.test.ts
@@ -15,6 +15,11 @@ const h = vi.hoisted(() => ({
   sent: [] as Array<{ channel: string; payload: Record<string, unknown> }>,
 }));
 
+// `electron` is a type-only import in provider-login.ts, but the CI test
+// environment may not have electron's native binary installed (esp. Node 24),
+// so stub it — matching the sibling desktop-host tests — to keep collection
+// from touching the real package.
+vi.mock('electron', () => ({}));
 vi.mock('./cli-resolver', () => ({
   augmentedPaths: () => [],
   resolveMoxxyCli: () => ({ kind: 'direct', bin: '/fake/moxxy' }),

--- a/packages/desktop-host/src/provider-login.test.ts
+++ b/packages/desktop-host/src/provider-login.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The provider-login relay: spawn `moxxy login --stdin-prompts`, turn its
+ * stdout into output/prompt events, feed answers to its stdin, and finish on
+ * exit. The CLI + stream format are exercised for real elsewhere (the SDK
+ * scanner test + a live `--stdin-prompts` run); here we mock the subprocess to
+ * pin the glue: arg shape, event fan-out, stdin writes, and cancel semantics.
+ */
+
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { encodeLoginPrompt } from '@moxxy/sdk';
+
+const h = vi.hoisted(() => ({
+  spawn: undefined as undefined | ((...args: unknown[]) => unknown),
+  sent: [] as Array<{ channel: string; payload: Record<string, unknown> }>,
+}));
+
+vi.mock('./cli-resolver', () => ({
+  augmentedPaths: () => [],
+  resolveMoxxyCli: () => ({ kind: 'direct', bin: '/fake/moxxy' }),
+  spawnCli: (...args: unknown[]) => h.spawn!(...args),
+}));
+vi.mock('./send-event', () => ({
+  sendEvent: (_w: unknown, channel: string, payload: Record<string, unknown>) =>
+    h.sent.push({ channel, payload }),
+}));
+vi.mock('./security', () => ({ assertSafeProviderName: () => undefined }));
+
+import {
+  answerProviderLogin,
+  cancelProviderLogin,
+  startProviderLogin,
+} from './provider-login';
+
+function makeChild(): {
+  child: EventEmitter & { stdout: EventEmitter; stderr: EventEmitter; stdin: { write: ReturnType<typeof vi.fn> }; kill: ReturnType<typeof vi.fn> };
+} {
+  const child = new EventEmitter() as never as ReturnType<typeof makeChild>['child'];
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = { write: vi.fn() };
+  child.kill = vi.fn();
+  return { child };
+}
+
+const fakeWindow = { once: vi.fn() } as never;
+let spawnArgs: unknown[] = [];
+let current: ReturnType<typeof makeChild>['child'];
+
+beforeEach(() => {
+  h.sent.length = 0;
+  spawnArgs = [];
+  const { child } = makeChild();
+  current = child;
+  h.spawn = (...args: unknown[]) => {
+    spawnArgs = args;
+    return child;
+  };
+});
+
+const events = (channel: string): Array<Record<string, unknown>> =>
+  h.sent.filter((s) => s.channel === channel).map((s) => s.payload);
+
+describe('provider-login relay', () => {
+  it('spawns `moxxy login <provider> --stdin-prompts` with piped stdio', () => {
+    startProviderLogin('id1', 'claude-code', fakeWindow);
+    expect(spawnArgs[1]).toEqual(['login', 'claude-code', '--stdin-prompts']);
+    expect((spawnArgs[2] as { stdio: unknown }).stdio).toEqual(['pipe', 'pipe', 'pipe']);
+  });
+
+  it('relays plain stdout as output and markers as prompts', () => {
+    startProviderLogin('idR', 'claude-code', fakeWindow);
+    current.stdout.emit(
+      'data',
+      Buffer.from('opening…\n' + encodeLoginPrompt({ question: 'Paste:', mask: true })),
+    );
+    expect(events('provider.login.output').map((p) => p.text)).toContain('opening…\n');
+    expect(events('provider.login.prompt')[0]).toEqual({
+      loginId: 'idR',
+      question: 'Paste:',
+      mask: true,
+    });
+  });
+
+  it('writes one stdin line per answer (stripping embedded newlines)', () => {
+    startProviderLogin('id2', 'claude-code', fakeWindow);
+    answerProviderLogin('id2', 'tok\nen');
+    expect(current.stdin.write).toHaveBeenCalledWith('token\n');
+  });
+
+  it('emits done + onExit on a normal exit', () => {
+    const onExit = vi.fn();
+    startProviderLogin('id3', 'claude-code', fakeWindow, { onExit });
+    current.emit('exit', 0);
+    expect(events('provider.login.done')[0]).toEqual({ loginId: 'id3', code: 0 });
+    expect(onExit).toHaveBeenCalledWith(0);
+  });
+
+  it('cancel kills the child and suppresses the done event', () => {
+    const onExit = vi.fn();
+    startProviderLogin('id4', 'claude-code', fakeWindow, { onExit });
+    cancelProviderLogin('id4');
+    expect(current.kill).toHaveBeenCalled();
+    current.emit('exit', 0); // late exit after cancel
+    expect(events('provider.login.done')).toHaveLength(0);
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('rejects a second login reusing a live id', () => {
+    startProviderLogin('dup', 'claude-code', fakeWindow);
+    expect(() => startProviderLogin('dup', 'claude-code', fakeWindow)).toThrow(/already running/);
+  });
+});

--- a/packages/desktop-host/src/provider-login.ts
+++ b/packages/desktop-host/src/provider-login.ts
@@ -1,0 +1,105 @@
+/**
+ * Interactive provider sign-in, driven from the desktop UI.
+ *
+ * The desktop has no TTY, so it spawns `moxxy login <provider> --stdin-prompts`
+ * and relays the flow: the CLI streams the provider's progress text on stdout
+ * and emits each interactive prompt (the out-of-band token / authorization-code
+ * paste that `claude-code` needs) as a NUL-bracketed marker, which the shared
+ * {@link createLoginStreamScanner} pulls out. We forward output + prompts to the
+ * renderer as `provider.login.*` events and write the user's typed answers back
+ * as stdin lines. Loopback providers (openai-codex) emit no prompts — the CLI
+ * opens the browser, catches the callback, and exits; the renderer just shows
+ * the streamed log.
+ *
+ * Encryption + the OAuth dance stay entirely in the CLI (mirroring
+ * `saveProviderKey` → `moxxy vault set`); this module is only a relay.
+ */
+
+import { type BrowserWindow } from 'electron';
+import { createLoginStreamScanner } from '@moxxy/sdk';
+import type { ChildProcess } from 'node:child_process';
+import { augmentedPaths, resolveMoxxyCli, spawnCli } from './cli-resolver';
+import { assertSafeProviderName } from './security';
+import { sendEvent } from './send-event';
+
+interface LoginRun {
+  readonly child: ChildProcess;
+  readonly window: BrowserWindow;
+}
+
+/** In-flight logins, keyed by the renderer-supplied correlation id. One per
+ *  sign-in modal; the map lets a second window run its own without crosstalk. */
+const runs = new Map<string, LoginRun>();
+
+/**
+ * Spawn an interactive login for `provider`, streaming `provider.login.output`
+ * + `provider.login.prompt` events tagged with `loginId`, and a final
+ * `provider.login.done` with the exit code. The renderer answers prompts via
+ * {@link answerProviderLogin}. Throws if the CLI can't be resolved or a login
+ * with this id is already running.
+ */
+export function startProviderLogin(
+  loginId: string,
+  provider: string,
+  window: BrowserWindow,
+  opts: { readonly onExit?: (code: number) => void } = {},
+): void {
+  assertSafeProviderName(provider);
+  if (runs.has(loginId)) throw new Error('a login with this id is already running');
+  const cli = resolveMoxxyCli({ extraPaths: augmentedPaths() });
+  if (!cli) throw new Error('moxxy CLI not found — run the install step first');
+
+  const child = spawnCli(cli, ['login', provider, '--stdin-prompts'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  runs.set(loginId, { child, window });
+
+  const scanner = createLoginStreamScanner();
+  child.stdout?.on('data', (b: Buffer) => {
+    for (const item of scanner.push(b.toString())) {
+      if (item.type === 'prompt') {
+        sendEvent(window, 'provider.login.prompt', {
+          loginId,
+          question: item.prompt.question,
+          mask: item.prompt.mask,
+        });
+      } else if (item.text) {
+        sendEvent(window, 'provider.login.output', { loginId, text: item.text });
+      }
+    }
+  });
+  // stderr is plain progress/diagnostics — never carries a prompt marker.
+  child.stderr?.on('data', (b: Buffer) => {
+    sendEvent(window, 'provider.login.output', { loginId, text: b.toString() });
+  });
+
+  const finish = (code: number): void => {
+    if (!runs.has(loginId)) return; // already finished/cancelled
+    runs.delete(loginId);
+    sendEvent(window, 'provider.login.done', { loginId, code });
+    opts.onExit?.(code);
+  };
+  child.on('error', (err) => {
+    sendEvent(window, 'provider.login.output', { loginId, text: String(err) });
+    finish(-1);
+  });
+  child.on('exit', (code) => finish(code ?? -1));
+  // If the window goes away mid-flow, don't leave the CLI blocked on stdin.
+  window.once('closed', () => cancelProviderLogin(loginId));
+}
+
+/** Feed one answer line (a pasted token or `code#state`) to a running login. */
+export function answerProviderLogin(loginId: string, value: string): void {
+  const run = runs.get(loginId);
+  if (!run) throw new Error('no login is running for this id');
+  // One line per prompt; the CLI's stdin reader splits on the newline.
+  run.child.stdin?.write(value.replace(/\r?\n/g, '') + '\n');
+}
+
+/** Abort a running login (modal closed / cancelled). Safe if already done. */
+export function cancelProviderLogin(loginId: string): void {
+  const run = runs.get(loginId);
+  if (!run) return;
+  runs.delete(loginId);
+  run.child.kill();
+}

--- a/packages/desktop-host/src/provider-login.ts
+++ b/packages/desktop-host/src/provider-login.ts
@@ -15,7 +15,7 @@
  * `saveProviderKey` → `moxxy vault set`); this module is only a relay.
  */
 
-import { type BrowserWindow } from 'electron';
+import type { BrowserWindow } from 'electron';
 import { createLoginStreamScanner } from '@moxxy/sdk';
 import type { ChildProcess } from 'node:child_process';
 import { augmentedPaths, resolveMoxxyCli, spawnCli } from './cli-resolver';

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -542,6 +542,16 @@ export interface IpcEvents {
    *  on its EventBus so every info-derived view (Settings tabs, mode badge,
    *  action catalog) refreshes without polling or an app restart. */
   'session.info.changed': { workspaceId: string };
+  /** A running interactive provider login (`provider.login.start`) needs a
+   *  pasted answer — the out-of-band token or `code#state` claude-code's flow
+   *  asks for. The renderer renders an input (masked when `mask`) and replies
+   *  via `provider.login.answer`. Loopback providers never emit this. */
+  'provider.login.prompt': { loginId: string; question: string; mask: boolean };
+  /** Streamed stdout/stderr text from a running provider login (progress, the
+   *  authorize URL, the final summary). One event per chunk. */
+  'provider.login.output': { loginId: string; text: string };
+  /** A provider login finished. `code === 0` ⇒ signed in. */
+  'provider.login.done': { loginId: string; code: number };
 }
 
 // ---------- Invokable commands (renderer → main) --------------------------
@@ -648,10 +658,22 @@ export interface IpcCommands {
   /** Returns how a provider authenticates so the wizard can pick the
    *  right UI affordance: a key field vs an OAuth button. */
   'onboarding.providerAuthKind': (args: { provider: string }) => Promise<'oauth' | 'api-key'>;
-  /** Spawn `moxxy login <provider>`. The CLI opens the browser and
-   *  runs the OAuth flow. stdout/stderr are streamed via
-   *  `onboarding.install.progress`. Resolves with the exit code. */
-  'onboarding.runProviderLogin': (args: { provider: string }) => Promise<number>;
+
+  // ---- Interactive provider sign-in (OAuth) ------------------------------
+  /** Begin an interactive sign-in for `provider`, correlated by the
+   *  renderer-supplied `loginId`. Spawns `moxxy login <provider>`, which opens
+   *  the browser; the CLI streams progress via `provider.login.output` and —
+   *  for out-of-band providers (claude-code) — asks for a pasted token /
+   *  `code#state` via `provider.login.prompt`. Resolves once the subprocess is
+   *  spawned; completion arrives as `provider.login.done`. Used by both the
+   *  onboarding wizard and Settings → Providers. */
+  'provider.login.start': (args: { loginId: string; provider: string }) => Promise<void>;
+  /** Answer the current `provider.login.prompt` with one line (a pasted token,
+   *  a `code#state`, or empty to take the browser branch). */
+  'provider.login.answer': (args: { loginId: string; value: string }) => Promise<void>;
+  /** Abort a running login (the sign-in modal was closed). No-op if it already
+   *  finished. */
+  'provider.login.cancel': (args: { loginId: string }) => Promise<void>;
 
   'desks.list': () => Promise<DesksOverview>;
   'desks.create': (args: { name: string; cwd: string }) => Promise<Desk>;

--- a/packages/desktop-ipc-contract/src/validation.test.ts
+++ b/packages/desktop-ipc-contract/src/validation.test.ts
@@ -9,9 +9,23 @@ describe('IPC payload validation', () => {
   });
 
   it('confines provider names to a slug', () => {
-    expect(() => validateIpcInput('onboarding.runProviderLogin', { provider: 'openai-codex' })).not.toThrow();
-    expect(() => validateIpcInput('onboarding.runProviderLogin', { provider: '--flag' })).toThrow();
+    expect(() => validateIpcInput('provider.login.start', { loginId: 'abc', provider: 'openai-codex' })).not.toThrow();
+    expect(() => validateIpcInput('provider.login.start', { loginId: 'abc', provider: '--flag' })).toThrow();
     expect(() => validateIpcInput('onboarding.saveProviderKey', { provider: '../x', secret: 'k' })).toThrow();
+  });
+
+  it('guards interactive-login ids + bounds the pasted answer', () => {
+    expect(() =>
+      validateIpcInput('provider.login.start', { loginId: 'A1-b2', provider: 'claude-code' }),
+    ).not.toThrow();
+    // loginId must be a plain token — no path/shell text.
+    expect(() => validateIpcInput('provider.login.cancel', { loginId: '../x' })).toThrow();
+    expect(() => validateIpcInput('provider.login.cancel', { loginId: '' })).toThrow();
+    // Empty answer is valid (the "take the browser branch" choice).
+    expect(() => validateIpcInput('provider.login.answer', { loginId: 'x', value: '' })).not.toThrow();
+    expect(() =>
+      validateIpcInput('provider.login.answer', { loginId: 'x', value: 'y'.repeat(8193) }),
+    ).toThrow();
   });
 
   it('blocks skill-name path traversal', () => {

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -16,6 +16,10 @@ import type { IpcCommandName } from './index.js';
  *  provider name can't inject a CLI flag or traverse the vault keyspace. */
 const providerName = z.string().regex(/^[a-z][a-z0-9-]{0,63}$/, 'invalid provider name');
 
+/** Renderer-supplied correlation id for an interactive login (a UUID). A plain
+ *  token so it can't smuggle a path or shell text into the host's run map. */
+const loginId = z.string().min(1).max(64).regex(/^[A-Za-z0-9-]+$/, 'invalid login id');
+
 const httpUrl = z
   .string()
   .refine((s) => {
@@ -92,7 +96,13 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
     secret: z.string().min(1).max(8192),
   }),
   'onboarding.providerAuthKind': z.object({ provider: providerName }),
-  'onboarding.runProviderLogin': z.object({ provider: providerName }),
+  // Interactive provider sign-in spawns `moxxy login <provider>` and feeds it
+  // the user's pasted answers over stdin — guard the provider slug and the
+  // correlation id, and bound the answer (a token / `code#state`) so a hostile
+  // renderer can't OOM the host or smuggle a flag.
+  'provider.login.start': z.object({ loginId, provider: providerName }),
+  'provider.login.answer': z.object({ loginId, value: z.string().max(8192) }),
+  'provider.login.cancel': z.object({ loginId }),
   'session.transcribe': z.object({
     audioBase64: z.string().max(MAX_AUDIO_BASE64),
     mimeType: z.string().max(128).optional(),

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -136,6 +136,12 @@ export type {
   ProviderOAuthStatus,
   ProviderAuthDescriptor,
 } from './provider.js';
+export {
+  encodeLoginPrompt,
+  decodeLoginPrompt,
+  createLoginStreamScanner,
+} from './provider-login-bridge.js';
+export type { LoginPromptRequest, LoginStreamItem } from './provider-login-bridge.js';
 export type { CacheStrategyDef, CacheStrategyContext } from './cache-strategy.js';
 export type {
   ViewNode,

--- a/packages/sdk/src/provider-login-bridge.test.ts
+++ b/packages/sdk/src/provider-login-bridge.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createLoginStreamScanner,
+  decodeLoginPrompt,
+  encodeLoginPrompt,
+  type LoginStreamItem,
+} from './provider-login-bridge.js';
+
+describe('encode/decode login prompt', () => {
+  it('round-trips a request', () => {
+    const marker = encodeLoginPrompt({ question: 'Paste token:', mask: true });
+    // NUL-bracketed.
+    expect(marker.startsWith('\u0000')).toBe(true);
+    expect(marker.endsWith('\u0000')).toBe(true);
+    const inner = marker.slice(1, -1);
+    expect(decodeLoginPrompt(inner)).toEqual({ question: 'Paste token:', mask: true });
+  });
+
+  it('rejects non-marker segments', () => {
+    expect(decodeLoginPrompt('just text')).toBeNull();
+    expect(decodeLoginPrompt('{"tag":"other","question":"x"}')).toBeNull();
+    expect(decodeLoginPrompt('{not json')).toBeNull();
+  });
+});
+
+/** Drain a scanner across the given chunks into a flat item list. */
+function scanAll(chunks: string[]): LoginStreamItem[] {
+  const scanner = createLoginStreamScanner();
+  return chunks.flatMap((c) => [...scanner.push(c)]);
+}
+
+describe('createLoginStreamScanner', () => {
+  it('passes plain output straight through', () => {
+    expect(scanAll(['hello world'])).toEqual([{ type: 'output', text: 'hello world' }]);
+  });
+
+  it('extracts a marker with surrounding output', () => {
+    const stream = 'opening browser\n' + encodeLoginPrompt({ question: 'Paste code:', mask: false }) + 'done\n';
+    expect(scanAll([stream])).toEqual([
+      { type: 'output', text: 'opening browser\n' },
+      { type: 'prompt', prompt: { question: 'Paste code:', mask: false } },
+      { type: 'output', text: 'done\n' },
+    ]);
+  });
+
+  it('reassembles a marker split across chunks', () => {
+    const marker = encodeLoginPrompt({ question: 'Paste token:', mask: true });
+    const mid = Math.floor(marker.length / 2);
+    const items = scanAll(['prefix', marker.slice(0, mid), marker.slice(mid), 'suffix']);
+    expect(items).toEqual([
+      { type: 'output', text: 'prefix' },
+      { type: 'prompt', prompt: { question: 'Paste token:', mask: true } },
+      { type: 'output', text: 'suffix' },
+    ]);
+  });
+
+  it('handles two prompts in sequence', () => {
+    const a = encodeLoginPrompt({ question: 'first', mask: false });
+    const b = encodeLoginPrompt({ question: 'second', mask: true });
+    expect(scanAll([a + b])).toEqual([
+      { type: 'prompt', prompt: { question: 'first', mask: false } },
+      { type: 'prompt', prompt: { question: 'second', mask: true } },
+    ]);
+  });
+
+  it('holds back a lone opening NUL until its partner arrives', () => {
+    const scanner = createLoginStreamScanner();
+    const marker = encodeLoginPrompt({ question: 'q', mask: false });
+    // Feed everything except the closing NUL: nothing should surface yet.
+    expect([...scanner.push('text' + marker.slice(0, -1))]).toEqual([
+      { type: 'output', text: 'text' },
+    ]);
+    // Closing NUL completes the marker.
+    expect([...scanner.push('\u0000')]).toEqual([
+      { type: 'prompt', prompt: { question: 'q', mask: false } },
+    ]);
+  });
+});

--- a/packages/sdk/src/provider-login-bridge.ts
+++ b/packages/sdk/src/provider-login-bridge.ts
@@ -1,0 +1,105 @@
+/**
+ * Cross-process bridge for relaying a provider login's interactive prompts —
+ * the out-of-band token / authorization-code paste that `claude-code` needs —
+ * from a spawned `moxxy login --stdin-prompts` subprocess to a GUI host that
+ * has no TTY (the desktop app).
+ *
+ * The subprocess emits each `ctx.prompt(question)` call as a NUL-bracketed
+ * JSON marker on stdout. NUL never appears in normal terminal output, so the
+ * host can scan the byte stream for these markers, render the prompt, and
+ * write the user's answer back as one stdin line. Loopback flows that never
+ * call `ctx.prompt` (e.g. openai-codex, which captures the code via a local
+ * callback server) emit no markers — the host just streams their output and
+ * waits for the process to exit.
+ *
+ * Living here (not in the CLI or the desktop contract) keeps the one wire
+ * format in a package both the CLI producer and the desktop consumer already
+ * depend on, so the two ends can never drift.
+ */
+
+/** The byte that brackets a prompt marker. Absent from normal CLI output. */
+const NUL = '\u0000';
+
+/** Tag distinguishing a login-prompt marker from any other NUL-bracketed run. */
+const PROMPT_TAG = 'moxxy.login.prompt';
+
+export interface LoginPromptRequest {
+  /** The question to show the user, verbatim from `ctx.prompt`. */
+  readonly question: string;
+  /** True for secrets — the host should mask the input field. */
+  readonly mask: boolean;
+}
+
+/** One decoded item from a login subprocess's stdout stream. */
+export type LoginStreamItem =
+  | { readonly type: 'output'; readonly text: string }
+  | { readonly type: 'prompt'; readonly prompt: LoginPromptRequest };
+
+/**
+ * Serialize a prompt request as a NUL-bracketed marker for stdout. The
+ * leading NUL also delimits it from any partial preceding `ctx.write` output
+ * the host scanner has buffered.
+ */
+export function encodeLoginPrompt(req: LoginPromptRequest): string {
+  return NUL + JSON.stringify({ tag: PROMPT_TAG, question: req.question, mask: req.mask }) + NUL;
+}
+
+/**
+ * Try to parse a single inter-NUL segment as a prompt marker. Returns null
+ * when it isn't one, so the host can pass the segment through as output.
+ */
+export function decodeLoginPrompt(segment: string): LoginPromptRequest | null {
+  if (!segment.startsWith('{')) return null;
+  try {
+    const o = JSON.parse(segment) as Record<string, unknown>;
+    if (o.tag !== PROMPT_TAG || typeof o.question !== 'string') return null;
+    return { question: o.question, mask: o.mask === true };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Streaming scanner for a login subprocess's stdout. Feed it chunks; it
+ * returns the ordered output / prompt items decoded so far, holding back any
+ * incomplete trailing marker (an opening NUL with no closing NUL yet) until
+ * the rest of it arrives in a later chunk.
+ */
+export function createLoginStreamScanner(): {
+  push(chunk: string): ReadonlyArray<LoginStreamItem>;
+} {
+  let buf = '';
+  return {
+    push(chunk: string): ReadonlyArray<LoginStreamItem> {
+      buf += chunk;
+      const out: LoginStreamItem[] = [];
+      // Consume every COMPLETE marker (NUL <json> NUL), emitting the plain
+      // text before each as output. Stop at the first NUL with no closing
+      // partner — that's a marker still mid-flight, kept for the next chunk.
+      for (;;) {
+        const open = buf.indexOf(NUL);
+        if (open === -1) break;
+        const close = buf.indexOf(NUL, open + 1);
+        if (close === -1) break;
+        if (open > 0) out.push({ type: 'output', text: buf.slice(0, open) });
+        const segment = buf.slice(open + 1, close);
+        const prompt = decodeLoginPrompt(segment);
+        // A NUL-bracketed run that isn't a valid marker is anomalous; surface
+        // its inner text as output rather than swallowing it.
+        out.push(prompt ? { type: 'prompt', prompt } : { type: 'output', text: segment });
+        buf = buf.slice(close + 1);
+      }
+      // Flush any plain text that precedes a still-incomplete marker (or all
+      // of it when no NUL is pending), keeping only the partial marker.
+      const pending = buf.indexOf(NUL);
+      if (pending === -1) {
+        if (buf) out.push({ type: 'output', text: buf });
+        buf = '';
+      } else if (pending > 0) {
+        out.push({ type: 'output', text: buf.slice(0, pending) });
+        buf = buf.slice(pending);
+      }
+      return out;
+    },
+  };
+}


### PR DESCRIPTION
## What

OAuth providers in the desktop app now drive a **real sign-in** instead of showing a dead "run `moxxy login <provider>` in a terminal" comment. This makes the `claude-code` (Claude Pro/Max subscription) provider — and `openai-codex` — connectable entirely from the GUI.

- **Settings → Providers**: the Configure sheet for an OAuth provider now renders a live sign-in flow (was static text at `ProvidersTab.tsx:180`).
- **Onboarding wizard**: `ProviderStep` was migrated onto the same shared `OAuthSignIn` component, so both surfaces behave identically (and `claude-code` works in onboarding, which it previously didn't).
- `claude-code` is **out-of-band**: unlike openai-codex it can't silently catch a loopback callback, so the UI collects one pasted value — **browser-authorize primary** (open consent → paste the shown `code#state`), with **paste a `claude setup-token`** as a fallback. This mirrors the terminal `moxxy login claude-code` exactly.

## How

`moxxy login --stdin-prompts` (new) relays each interactive `ctx.prompt` to the host as a **NUL-bracketed JSON marker** on stdout (NUL never appears in normal CLI output) and reads answers as stdin lines — so a GUI host with no TTY can drive the paste flow without re-implementing the OAuth/PKCE dance (it stays entirely in the CLI, like `saveProviderKey` → `moxxy vault set`).

- `@moxxy/sdk`: `encodeLoginPrompt` / `decodeLoginPrompt` / `createLoginStreamScanner` (the shared wire format + a streaming scanner that survives markers split across chunks).
- desktop-host: a stateful login relay (`provider-login.ts`) + IPC handlers; new `provider.login.start` / `answer` / `cancel` commands and `provider.login.prompt` / `output` / `done` events.
- Renderer: shared `OAuthSignIn` component used by Settings + onboarding.

### De-hardcoding / dead-code removal
- `onboarding.providerAuthKind` now derives a provider's auth kind from the **runner registry** (`getInfo().providers[].authKind`) instead of a hardcoded `Set(['openai-codex'])` — which had mis-classified `claude-code` as an API-key provider.
- Removed the now-dead `installer.runProviderLogin` + `onboarding.runProviderLogin` IPC command (superseded by `provider.login.*`).

## Validation
- New SDK scanner unit tests (incl. markers split across chunks); desktop-host relay unit tests (arg shape, event fan-out, stdin writes, cancel); updated contract validation tests.
- **End-to-end mechanics confirmed live**: piping a token to `moxxy login claude-code --stdin-prompts` emits the prompt marker, consumes the stdin answer, and stores it under `oauth/claude-code/*` (exit 0).
- **Remaining (manual, needs a real subscription token):** confirm the Anthropic Messages API actually accepts a `claude setup-token` bearer with the current `anthropic-beta` flags + identity preamble — the one knob never verified against a live subscription. Tracked separately; if it 401s, the fix is in the provider's beta-flag list, not this PR.

## Gate
`build` 63/63 · `typecheck` 124/124 · `test` green · `lint` 0 errors · `check:deps` clean. Changeset included (sdk/cli minor + desktop packages).
