### PR TITLE
feat(reasoning): visible per-provider reasoning + grouped sub-agents view

### DIFF
--- a/.changeset/visible-reasoning-and-subagent-groups.md
+++ b/.changeset/visible-reasoning-and-subagent-groups.md
@@ -1,0 +1,40 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/chat-model': minor
+'@moxxy/client-core': minor
+'@moxxy/config': minor
+'@moxxy/cli': minor
+'@moxxy/desktop': minor
+'@moxxy/core': patch
+'@moxxy/plugin-subagents': patch
+'@moxxy/plugin-provider-anthropic': patch
+'@moxxy/plugin-provider-openai': patch
+'@moxxy/plugin-provider-openai-codex': patch
+---
+
+Make the model's reasoning visible, and redesign sub-agents as a collapsible group.
+
+**Reasoning preview (per-provider, Codex-style between calls).** When enabled, the model's
+thinking now streams live (replacing the silent "thinking…" dots) and is kept as a dim,
+collapsible "Thinking" block interleaved with the tool calls it precedes — so you can see what
+the model is doing instead of waiting out a multi-second pause. Because reasoning is finalized
+once per provider round, summaries land naturally between tool batches.
+
+It's gated per provider/model via a new `ModelDescriptor.supportsReasoning` capability and turned
+on with `config.context.reasoning` (`true`, or `{ effort: 'low' | 'medium' | 'high' }`):
+
+- **Anthropic / Claude Code** — adaptive thinking with summarized display; the signed thinking
+  block round-trips so interleaved-thinking tool-use continuations stay valid.
+- **OpenAI Codex** — surfaces the reasoning summary it already requests (previously discarded).
+- **OpenAI** — `reasoning_effort` for the gpt-5 family plus the `reasoning_content` summary that
+  OpenAI-compatible reasoning backends stream.
+
+New SDK surface: a `reasoning` `ContentBlock`, `reasoning_delta`/`reasoning_signature`
+`ProviderEvent`s, `reasoning_chunk`/`reasoning_message` events, a `ProviderRequest.reasoning`
+knob, and `ModelDescriptor.supportsReasoning`. No runner protocol bump — reasoning events ride
+the existing event channel.
+
+**Grouped sub-agents view.** A `dispatch_agent` fan-out now renders as one collapsible group —
+a header (`N Explore agents finished`) over a tree of per-agent rows showing each agent's tool-use
+count, **token usage**, and status — instead of one block per child. Per-agent token totals and the
+agent kind are forwarded on the `subagent_*` events; both the desktop and TUI render the new tree.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -1028,6 +1028,37 @@ regressions. Restore the detail from git history (`TECH_DEBT.md` @ `b014c3a`) if
 
 ---
 
+## Reasoning + sub-agent-groups intake (2026-06-17)
+
+Logged while shipping visible per-provider reasoning + the grouped sub-agents view. Reviewed the
+provider stream parsers, `chat-model` projection, and the subagent event bridge in passing.
+
+- **R1 — built-in reasoning config isn't wired live to the runner from the desktop.** The functional
+  path is `config.context.reasoning` (CLI + the desktop's runner read it). The desktop Settings →
+  Providers reasoning-effort control persists to local state only with a `TODO`; making it live needs
+  a typed `DesktopPrefs.reasoning` + `ProviderEntry.supportsReasoning` in `@moxxy/desktop-ipc-contract`
+  and a runner config-apply step. Until then the desktop control stays hidden (no row reports
+  `supportsReasoning`). `apps/desktop/src/settings/ProvidersTab.tsx`.
+- **R2 — reasoning config is session-level, not per-provider-granular.** `session.reasoning` is one
+  value applied to whichever provider is active (gated by `supportsReasoning`), not a per-provider
+  map. Good enough for one PR ("only supporting providers honor it"); a true `{ [provider]: effort }`
+  map is the follow-up. `packages/core/src/session.ts`, `cli/src/config-applier.ts`.
+- **R3 — Codex/OpenAI reasoning isn't round-tripped.** Codex captures `encrypted_content` into the
+  `reasoning_message` event (and the log), but `toResponsesInput` drops the `reasoning` block rather
+  than replaying it as a `reasoning` input item; OpenAI Chat Completions can't accept reasoning back at
+  all. Display works; reasoning continuity across turns is deferred. Only Anthropic round-trips today.
+- **R4 — Anthropic multi-block thinking collapses to one round-trip block.** A single provider call
+  with multiple interleaved `thinking` blocks is captured as one accumulated block carrying the last
+  signature. Correct for the common single-block case; multi-block could mis-validate on replay.
+  `packages/plugin-provider-anthropic/src/provider.ts` (`streamOnce`).
+- **R5 — sub-agent grouping lives in the shared `pair-events` fold; tool grouping lives in client-core
+  (`groupToolNodes`).** Intentional (the TUI has no render-node layer), but the two grouping homes are
+  a candidate to unify. Nested grandchild agents render as additional groups, not a recursive tree (out
+  of scope). The standalone `SubagentView`/`SubagentScopeView` now duplicate the group's per-agent row —
+  collapse standalone into a group-of-one later.
+
+---
+
 ## Blocked items (fix agents declined to do mechanically — sound calls)
 
 - **B6.** mcp `wrap.ts` `throw new Error('aborted')` ×3 — internal abort control-flow, not

--- a/apps/desktop/src/chat/ChatSurface.tsx
+++ b/apps/desktop/src/chat/ChatSurface.tsx
@@ -97,6 +97,7 @@ export function ChatSurface({
             events={filteredEvents}
             extensions={searchQuery ? EMPTY_EXTENSIONS : chat.extensions}
             streamingText={searchQuery ? '' : chat.streamingText}
+            streamingReasoning={searchQuery ? '' : chat.streamingReasoning}
             sending={chat.sending}
             workspaceId={workspaceId}
             hasOlder={!searchQuery && chat.hasOlder}

--- a/apps/desktop/src/chat/Transcript.tsx
+++ b/apps/desktop/src/chat/Transcript.tsx
@@ -7,12 +7,16 @@ import { BlockView, StreamingAssistant } from './BlockView';
 import { ToolGroupView } from './ToolGroupView';
 import { ExtensionCard } from './ExtensionCard';
 import { ThinkingIndicator } from './ThinkingIndicator';
+import { StreamingReasoning } from './blocks/StreamingReasoning';
 import { JumpToLatest, useNewContentBelow } from './JumpToLatest';
 
 interface TranscriptProps {
   readonly events: ReadonlyArray<MoxxyEvent>;
   readonly extensions: ReadonlyArray<Extension>;
   readonly streamingText: string;
+  /** Live thinking text for the active turn (reasoning models); shown as a
+   *  dim preview before the answer text starts arriving. */
+  readonly streamingReasoning?: string;
   readonly sending?: boolean;
   /** Forwarded into ExtensionCard for the dismiss control. */
   readonly workspaceId?: string;
@@ -74,6 +78,7 @@ export function Transcript({
   events,
   extensions,
   streamingText,
+  streamingReasoning = '',
   sending,
   workspaceId,
   hasOlder,
@@ -146,8 +151,13 @@ export function Transcript({
         components={{
           Footer: () => (
             <div style={{ padding: '0 24px 12px' }}>
-              {streamingText && <StreamingAssistant text={streamingText} />}
-              {sending && streamingText === '' && <ThinkingIndicator />}
+              {streamingText ? (
+                <StreamingAssistant text={streamingText} />
+              ) : streamingReasoning ? (
+                <StreamingReasoning text={streamingReasoning} />
+              ) : sending ? (
+                <ThinkingIndicator />
+              ) : null}
             </div>
           ),
         }}

--- a/apps/desktop/src/chat/blocks/BlockView.tsx
+++ b/apps/desktop/src/chat/blocks/BlockView.tsx
@@ -3,6 +3,7 @@ import { SkillGroupView } from '../SkillGroupView';
 import { EventBlockView } from './EventBlockView';
 import { ToolBlock } from './ToolBlock';
 import { SubagentView } from './SubagentView';
+import { SubagentGroupView } from './SubagentGroupView';
 
 /**
  * One transcript block, rendered from the shared @moxxy/chat-model fold.
@@ -13,6 +14,7 @@ import { SubagentView } from './SubagentView';
  *   - tool-call               → mono summary with status-coloured bar.
  *   - skill-scope             → SkillGroupView (banner + nested children).
  *   - subagent                → one-line agent row.
+ *   - subagent-group          → collapsible tree of folded sibling agents.
  *   - live-tools              → each call rendered as a tool row.
  *
  * The in-flight streaming assistant text is NOT a block — Transcript
@@ -34,6 +36,8 @@ export function BlockView({ block }: { readonly block: FoldedBlock }): JSX.Eleme
       return <SkillGroupView scope={block} />;
     case 'subagent':
       return <SubagentView block={block} />;
+    case 'subagent-group':
+      return <SubagentGroupView block={block} />;
     case 'live-tools':
       return <LiveToolsBlock block={block} />;
   }

--- a/apps/desktop/src/chat/blocks/EventBlockView.tsx
+++ b/apps/desktop/src/chat/blocks/EventBlockView.tsx
@@ -1,6 +1,7 @@
 import type { MoxxyEvent } from '@moxxy/sdk';
 import { UserBlock } from './UserBlock';
 import { AssistantBlock } from './AssistantBlock';
+import { ReasoningBlock } from './ReasoningBlock';
 
 export function EventBlockView({ event }: { readonly event: MoxxyEvent }): JSX.Element | null {
   switch (event.type) {
@@ -8,6 +9,8 @@ export function EventBlockView({ event }: { readonly event: MoxxyEvent }): JSX.E
       return <UserBlock text={event.text} attachments={event.attachments} />;
     case 'assistant_message':
       return <AssistantBlock text={event.content} streaming={false} stopReason={event.stopReason} />;
+    case 'reasoning_message':
+      return <ReasoningBlock event={event} />;
     case 'error':
       return <SystemBlock text={event.message} tone="error" />;
     case 'abort':

--- a/apps/desktop/src/chat/blocks/ReasoningBlock.tsx
+++ b/apps/desktop/src/chat/blocks/ReasoningBlock.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import type { ReasoningMessageEvent } from '@moxxy/sdk';
+import { Icon } from '@moxxy/desktop-ui';
+import { MarkdownBody } from '../MarkdownBody';
+
+/**
+ * A finalized reasoning summary persisted in the log — the model's thinking
+ * that preceded the following tool calls / answer text. Rendered DIM and
+ * COLLAPSED by default (a "Thinking" header + chevron); expanding reveals the
+ * markdown summary. Redacted reasoning is never expandable — a static
+ * "[reasoning withheld]" line stands in for the opaque blob.
+ */
+export function ReasoningBlock({ event }: { readonly event: ReasoningMessageEvent }): JSX.Element {
+  const [open, setOpen] = useState(false);
+
+  if (event.redacted) {
+    return (
+      <div
+        data-testid="block-reasoning"
+        className="mono"
+        style={{
+          alignSelf: 'stretch',
+          maxWidth: '92%',
+          fontSize: 11,
+          color: 'var(--color-text-dim)',
+          fontStyle: 'italic',
+          padding: '2px 0',
+        }}
+      >
+        [reasoning withheld]
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="block-reasoning"
+      style={{ alignSelf: 'stretch', maxWidth: '92%', opacity: 0.8 }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '2px 0',
+          width: '100%',
+          textAlign: 'left',
+        }}
+      >
+        <span
+          aria-hidden
+          style={{
+            color: 'var(--color-text-dim)',
+            transform: open ? 'rotate(90deg)' : 'none',
+            transition: 'transform 120ms ease',
+            display: 'inline-flex',
+          }}
+        >
+          <Icon name="chevron-right" size={14} />
+        </span>
+        <span style={{ fontWeight: 600, fontSize: 12.5, color: 'var(--color-text-muted)' }}>
+          Thinking
+        </span>
+      </button>
+      {open && (
+        <div style={{ marginTop: 4, paddingLeft: 22, color: 'var(--color-text-muted)' }}>
+          <MarkdownBody text={event.content} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/chat/blocks/StreamingReasoning.tsx
+++ b/apps/desktop/src/chat/blocks/StreamingReasoning.tsx
@@ -1,0 +1,65 @@
+import { Icon } from '@moxxy/desktop-ui';
+import { MarkdownBody } from '../MarkdownBody';
+
+/** Live reasoning preview while the model is still thinking — shown in
+ *  place of the dead "thinking…" dots for a reasoning model. Visually
+ *  subdued (dim avatar + muted body) so it reads as the model's scratch
+ *  thinking, not its final answer; replaced by StreamingAssistant the
+ *  moment the answer text starts to arrive. */
+export function StreamingReasoning({ text }: { readonly text: string }): JSX.Element {
+  return (
+    <div
+      data-testid="block-streaming-reasoning"
+      style={{ alignSelf: 'stretch', display: 'flex', gap: 12, maxWidth: '92%', opacity: 0.7 }}
+    >
+      <span
+        aria-hidden
+        style={{
+          width: 34,
+          height: 34,
+          borderRadius: 10,
+          background: 'var(--color-input-soft)',
+          color: 'var(--color-text-dim)',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        }}
+      >
+        <Icon name="agent" size={18} />
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontWeight: 600, fontSize: 13.5, color: 'var(--color-text-muted)' }}>
+            Thinking
+          </span>
+          <span
+            className="mono"
+            style={{
+              fontSize: 11,
+              color: 'var(--color-text-dim)',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+            }}
+          >
+            <span
+              aria-hidden
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: '50%',
+                background: 'var(--color-text-dim)',
+                animation: 'moxxy-thinking 1.1s ease-in-out infinite',
+              }}
+            />
+            thinking…
+          </span>
+        </div>
+        <div style={{ marginTop: 6, color: 'var(--color-text-muted)' }}>
+          <MarkdownBody text={text} streaming />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/chat/blocks/SubagentGroupView.tsx
+++ b/apps/desktop/src/chat/blocks/SubagentGroupView.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react';
+import { formatTokensK, type SubagentBlock, type SubagentGroupBlock } from '@moxxy/chat-model';
+import { Icon } from '@moxxy/desktop-ui';
+import { SubagentDetail, SUBAGENT_TILE_FG } from './SubagentView';
+
+/**
+ * A fan-out of sibling subagents folded into one compact collapsible tree:
+ *
+ *   ● 4 Explore agents finished
+ *     ├ Find file-writing tools · 45 tool uses · 65.3k tokens
+ *     │  └ Done
+ *     ├ Understand TUI rendering · 43 tool uses · 66.3k tokens
+ *     │  └ Done
+ *
+ * Collapsed by default — one header row summarising the batch. Expanding
+ * lists each agent as a tree row; each row is itself secondarily expandable
+ * to reveal that agent's tool calls + final output (shared SubagentDetail).
+ */
+export function SubagentGroupView({
+  block,
+}: {
+  readonly block: SubagentGroupBlock;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+
+  const running = block.agents.filter(isRunning).length;
+  const failed = block.agents.filter((a) => a.error !== null).length;
+  const accent = failed > 0 ? 'var(--color-red)' : running > 0 ? 'var(--color-primary)' : 'var(--color-green)';
+
+  return (
+    <div
+      data-testid="block-subagent-group"
+      style={{ alignSelf: 'stretch', display: 'flex', gap: 12, maxWidth: '92%' }}
+    >
+      <span
+        aria-hidden
+        style={{
+          width: 34,
+          height: 34,
+          flexShrink: 0,
+          borderRadius: 10,
+          background: 'color-mix(in srgb, var(--color-purple) 14%, transparent)',
+          color: SUBAGENT_TILE_FG,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Icon name="agent" size={18} />
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '2px 0',
+            width: '100%',
+            textAlign: 'left',
+          }}
+        >
+          <span
+            aria-hidden
+            style={{
+              width: 7,
+              height: 7,
+              flexShrink: 0,
+              borderRadius: '50%',
+              background: accent,
+              ...(running > 0 ? { animation: 'moxxy-thinking 1.1s ease-in-out infinite' } : {}),
+            }}
+          />
+          <span style={{ fontWeight: 600, fontSize: 13.5 }}>{headerLabel(block, running, failed)}</span>
+          <span style={{ flex: 1 }} />
+          <span
+            aria-hidden
+            style={{
+              color: 'var(--color-text-dim)',
+              transform: open ? 'rotate(90deg)' : 'none',
+              transition: 'transform 120ms ease',
+              display: 'inline-flex',
+            }}
+          >
+            <Icon name="chevron-right" size={14} />
+          </span>
+        </button>
+        {open && (
+          <div style={{ marginTop: 6, display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {block.agents.map((agent) => (
+              <AgentTreeRow key={agent.id} agent={agent} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** One agent as a tree row + status sub-line, secondarily expandable to its
+ *  tool-call / final-output detail. */
+function AgentTreeRow({ agent }: { readonly agent: SubagentBlock }): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const running = isRunning(agent);
+  const tokens = formatTokensK(agent.tokensUsed);
+  const statusText = running ? 'running' : agent.error ? 'failed' : 'Done';
+  const statusColor = agent.error
+    ? 'var(--color-red)'
+    : running
+      ? 'var(--color-primary)'
+      : 'var(--color-text-muted)';
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="mono"
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 6,
+          padding: '1px 0',
+          width: '100%',
+          textAlign: 'left',
+          fontSize: 11.5,
+        }}
+      >
+        <span aria-hidden style={{ color: 'var(--color-text-dim)', flexShrink: 0 }}>
+          ├
+        </span>
+        <span style={{ color: 'var(--color-text)', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {agent.label}
+        </span>
+        <span style={{ color: 'var(--color-text-dim)', flexShrink: 0 }}>
+          · {agent.toolCallCount} tool {agent.toolCallCount === 1 ? 'use' : 'uses'}
+          {tokens ? ` · ${tokens} tokens` : ''}
+        </span>
+      </button>
+      <div
+        className="mono"
+        style={{ display: 'flex', alignItems: 'baseline', gap: 6, fontSize: 11.5, paddingLeft: 0 }}
+      >
+        <span aria-hidden style={{ color: 'var(--color-text-dim)', flexShrink: 0 }}>
+          {'  │  └'}
+        </span>
+        <span style={{ color: statusColor }}>
+          {statusText}
+          {agent.error ? ` — ${agent.error}` : ''}
+        </span>
+      </div>
+      {open && (
+        <div style={{ paddingLeft: 16 }}>
+          <SubagentDetail block={agent} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function isRunning(a: SubagentBlock): boolean {
+  return a.completedAtMs === null && a.error === null;
+}
+
+/** "4 Explore agents finished" / "1 Explore agent finished" / "3 agents
+ *  finished" (mixed) — plus a "running" / "(M failed)" suffix when in flight
+ *  or any member errored. */
+function headerLabel(block: SubagentGroupBlock, running: number, failed: number): string {
+  const n = block.agents.length;
+  const typeWord = block.agentType === 'mixed' ? '' : `${block.agentType} `;
+  const noun = n === 1 ? 'agent' : 'agents';
+  const verb = running > 0 ? 'running' : 'finished';
+  const failSuffix = failed > 0 ? ` (${failed} failed)` : '';
+  return `${n} ${typeWord}${noun} ${verb}${failSuffix}`;
+}

--- a/apps/desktop/src/chat/blocks/SubagentView.tsx
+++ b/apps/desktop/src/chat/blocks/SubagentView.tsx
@@ -1,12 +1,16 @@
 import { useState } from 'react';
-import { oneLine, summarizeArgs, type Block as FoldedBlock } from '@moxxy/chat-model';
+import { oneLine, summarizeArgs, type SubagentBlock } from '@moxxy/chat-model';
 import { Icon } from '@moxxy/desktop-ui';
 import { preStyle } from './block-shared';
+
+/** Violet accents mark subagents as a different KIND of actor than tool
+ *  calls — shared with SubagentGroupView so the group reads the same. */
+export const SUBAGENT_TILE_FG = 'var(--color-purple-strong)';
 
 export function SubagentView({
   block,
 }: {
-  readonly block: Extract<FoldedBlock, { kind: 'subagent' }>;
+  readonly block: SubagentBlock;
 }): JSX.Element {
   const [open, setOpen] = useState(false);
   const running = block.completedAtMs === null && block.error === null;
@@ -18,10 +22,8 @@ export function SubagentView({
   // Subagents get a distinct violet tile so they read as a different KIND of
   // actor than tool calls (which are status-tinted green/pink/red).
   const tileBg = 'color-mix(in srgb, var(--color-purple) 14%, transparent)';
-  const tileFg = 'var(--color-purple-strong)';
+  const tileFg = SUBAGENT_TILE_FG;
   const statusText = running ? 'running' : block.error ? 'failed' : 'done';
-  const elapsed =
-    block.completedAtMs !== null ? Math.round((block.completedAtMs - block.startedAtMs) / 100) / 10 : null;
   return (
     <div
       data-testid="block-subagent"
@@ -94,79 +96,94 @@ export function SubagentView({
             <Icon name="chevron-right" size={14} />
           </span>
         </button>
-        {open && (
-          <div
-            style={{
-              marginTop: 6,
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 6,
-              fontSize: 12,
-              color: 'var(--color-text-muted)',
-            }}
-          >
-            <div className="mono" style={{ fontSize: 11, color: 'var(--color-text-dim)' }}>
-              {block.toolCallCount} tool {block.toolCallCount === 1 ? 'call' : 'calls'}
-              {block.stopReason ? ` · ${block.stopReason}` : ''}
-              {elapsed !== null ? ` · ${elapsed}s` : ''}
-            </div>
-            {block.toolCalls.length > 0 && (
-              <ul
-                className="mono"
+        {open && <SubagentDetail block={block} />}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The expanded detail body for one subagent — its tool-call list + final
+ * preview (or error). Shared so SubagentGroupView's per-agent rows show the
+ * exact same "expand to see tool calls + final output" view as a standalone
+ * SubagentView.
+ */
+export function SubagentDetail({ block }: { readonly block: SubagentBlock }): JSX.Element {
+  const running = block.completedAtMs === null && block.error === null;
+  const elapsed =
+    block.completedAtMs !== null ? Math.round((block.completedAtMs - block.startedAtMs) / 100) / 10 : null;
+  return (
+    <div
+      style={{
+        marginTop: 6,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+        fontSize: 12,
+        color: 'var(--color-text-muted)',
+      }}
+    >
+      <div className="mono" style={{ fontSize: 11, color: 'var(--color-text-dim)' }}>
+        {block.toolCallCount} tool {block.toolCallCount === 1 ? 'call' : 'calls'}
+        {block.stopReason ? ` · ${block.stopReason}` : ''}
+        {elapsed !== null ? ` · ${elapsed}s` : ''}
+      </div>
+      {block.toolCalls.length > 0 && (
+        <ul
+          className="mono"
+          style={{
+            listStyle: 'none',
+            margin: 0,
+            padding: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 3,
+          }}
+        >
+          {block.toolCalls.map((tc, i) => {
+            const sum = oneLine(summarizeArgs(tc.input));
+            return (
+              <li
+                key={i}
                 style={{
-                  listStyle: 'none',
-                  margin: 0,
-                  padding: 0,
                   display: 'flex',
-                  flexDirection: 'column',
-                  gap: 3,
+                  gap: 7,
+                  alignItems: 'baseline',
+                  padding: '4px 8px',
+                  background: 'color-mix(in srgb, var(--color-purple) 7%, transparent)',
+                  borderRadius: 7,
+                  fontSize: 11,
                 }}
               >
-                {block.toolCalls.map((tc, i) => {
-                  const sum = oneLine(summarizeArgs(tc.input));
-                  return (
-                    <li
-                      key={i}
-                      style={{
-                        display: 'flex',
-                        gap: 7,
-                        alignItems: 'baseline',
-                        padding: '4px 8px',
-                        background: 'color-mix(in srgb, var(--color-purple) 7%, transparent)',
-                        borderRadius: 7,
-                        fontSize: 11,
-                      }}
-                    >
-                      <span style={{ color: tileFg, fontWeight: 600, flexShrink: 0 }}>{tc.name}</span>
-                      {sum && (
-                        <span
-                          style={{
-                            color: 'var(--color-text-dim)',
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                          }}
-                        >
-                          {sum}
-                        </span>
-                      )}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-            {block.error ? (
-              <pre style={{ ...preStyle, color: 'var(--color-red)' }}>{block.error}</pre>
-            ) : block.finalPreview ? (
-              <pre style={preStyle}>{block.finalPreview}</pre>
-            ) : (
-              <div style={{ fontStyle: 'italic', color: 'var(--color-text-dim)' }}>
-                {running ? 'Working…' : 'No output captured.'}
-              </div>
-            )}
-          </div>
-        )}
-      </div>
+                <span style={{ color: SUBAGENT_TILE_FG, fontWeight: 600, flexShrink: 0 }}>
+                  {tc.name}
+                </span>
+                {sum && (
+                  <span
+                    style={{
+                      color: 'var(--color-text-dim)',
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}
+                  >
+                    {sum}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      {block.error ? (
+        <pre style={{ ...preStyle, color: 'var(--color-red)' }}>{block.error}</pre>
+      ) : block.finalPreview ? (
+        <pre style={preStyle}>{block.finalPreview}</pre>
+      ) : (
+        <div style={{ fontStyle: 'italic', color: 'var(--color-text-dim)' }}>
+          {running ? 'Working…' : 'No output captured.'}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/settings/ProvidersTab.tsx
+++ b/apps/desktop/src/settings/ProvidersTab.tsx
@@ -18,6 +18,49 @@ import { PROVIDER_PROMPT_TEMPLATE } from './provider-prompt';
 
 type ProviderRow = ReturnType<typeof useSettings>['providers'][number];
 
+/** Reasoning-effort levels offered for providers whose models support it.
+ *  Mirrors the CLI's proven `config.context.reasoning` path. */
+const REASONING_LEVELS = ['off', 'low', 'medium', 'high'] as const;
+type ReasoningLevel = (typeof REASONING_LEVELS)[number];
+
+// TODO(reasoning): this control persists the per-provider effort to
+// localStorage only — the runner doesn't yet pick it up live. The proven
+// functional path is the CLI's `config.context.reasoning`; wiring the desktop
+// session to it needs a typed `DesktopPrefs.reasoning` field (+ a
+// `ProviderEntry.supportsReasoning` flag) in @moxxy/desktop-ipc-contract and a
+// runner config-apply step — both outside this app/src change. Until then this
+// is a UI placeholder that round-trips the user's choice.
+const REASONING_PREF_KEY = 'moxxy.reasoning.effort';
+
+function reasoningEffortFor(providerName: string): ReasoningLevel {
+  try {
+    const raw = localStorage.getItem(REASONING_PREF_KEY);
+    const map = raw ? (JSON.parse(raw) as Record<string, string>) : {};
+    const v = map[providerName];
+    return REASONING_LEVELS.includes(v as ReasoningLevel) ? (v as ReasoningLevel) : 'off';
+  } catch {
+    return 'off';
+  }
+}
+
+function setReasoningEffortFor(providerName: string, level: ReasoningLevel): void {
+  try {
+    const raw = localStorage.getItem(REASONING_PREF_KEY);
+    const map = raw ? (JSON.parse(raw) as Record<string, string>) : {};
+    map[providerName] = level;
+    localStorage.setItem(REASONING_PREF_KEY, JSON.stringify(map));
+  } catch {
+    // best-effort; a missing localStorage just means the choice doesn't persist
+  }
+}
+
+/** The runner's model descriptors carry `supportsReasoning?: boolean`; it is
+ *  not yet surfaced on `ProviderEntry`, so read it defensively from whatever
+ *  the row exposes (forward-compatible once the contract plumbs it through). */
+function providerSupportsReasoning(p: ProviderRow): boolean {
+  return (p as { supportsReasoning?: boolean }).supportsReasoning === true;
+}
+
 export function ProvidersTab({
   providers,
   onToggle,
@@ -154,6 +197,7 @@ function ConfigureProviderModal({
   const [key, setKey] = useState('');
   const [baseURL, setBaseURL] = useState(provider.baseURL ?? '');
   const [defaultModel, setDefaultModel] = useState(provider.defaultModel ?? '');
+  const [reasoning, setReasoning] = useState<ReasoningLevel>(() => reasoningEffortFor(provider.name));
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState<string | null>(null);
@@ -281,6 +325,31 @@ function ConfigureProviderModal({
           <p style={{ margin: 0, fontSize: 12.5, color: 'var(--color-text-muted)', lineHeight: 1.5 }}>
             Built-in provider — endpoint and model list ship with moxxy; only the key is configurable.
           </p>
+        )}
+
+        {providerSupportsReasoning(provider) && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <label style={fieldLabelStyle}>Reasoning effort</label>
+            <select
+              value={reasoning}
+              onChange={(e) => {
+                const next = e.target.value as ReasoningLevel;
+                setReasoning(next);
+                setReasoningEffortFor(provider.name, next);
+              }}
+              style={selectStyle}
+              data-testid="provider-reasoning-select"
+            >
+              {REASONING_LEVELS.map((level) => (
+                <option key={level} value={level}>
+                  {level === 'off' ? 'Off' : level[0]!.toUpperCase() + level.slice(1)}
+                </option>
+              ))}
+            </select>
+            <p style={{ margin: 0, fontSize: 11.5, color: 'var(--color-text-dim)', lineHeight: 1.5 }}>
+              How much the model thinks before answering. Higher effort is slower but deeper.
+            </p>
+          </div>
         )}
 
         {error && (

--- a/packages/chat-model/src/format.ts
+++ b/packages/chat-model/src/format.ts
@@ -30,6 +30,17 @@ export function formatElapsed(ms: number): string {
   return `${hr}h ${remMin.toString().padStart(2, '0')}m`;
 }
 
+/**
+ * Compact token count for tree rows: `65.3k` for ≥ 1000, the raw count below
+ * that. Returns `null` for null/negative input so callers can omit the segment
+ * (e.g. a still-running agent with no total yet).
+ */
+export function formatTokensK(n: number | null | undefined): string | null {
+  if (n == null || n < 0) return null;
+  if (n < 1000) return String(n);
+  return `${(n / 1000).toFixed(1)}k`;
+}
+
 // Hard cap on the full argument-summary string. Joining lots of fields
 // (especially MCP tools with `query`, `user_intent`, `design_type`, …)
 // produces a multi-line wrap that dwarfs the rest of the chat. Cap at

--- a/packages/chat-model/src/pair-events.test.ts
+++ b/packages/chat-model/src/pair-events.test.ts
@@ -23,7 +23,13 @@ import {
   pairToolEvents,
   type CompactToolMap,
 } from './pair-events.js';
-import type { LiveToolBlockData, SkillScopeBlock, SubagentBlock, ToolCallBlockData } from './types.js';
+import type {
+  LiveToolBlockData,
+  SkillScopeBlock,
+  SubagentBlock,
+  SubagentGroupBlock,
+  ToolCallBlockData,
+} from './types.js';
 
 // ---------------------------------------------------------------------------
 // Synthetic-event builders. Each returns a fully-typed MoxxyEvent so we drive
@@ -136,11 +142,15 @@ const asLive = (b: unknown): LiveToolBlockData => {
   expect(block.kind).toBe('live-tools');
   return block;
 };
-const asSubagent = (b: unknown): SubagentBlock => {
-  const block = b as SubagentBlock;
-  expect(block.kind).toBe('subagent');
+const asSubagentGroup = (b: unknown): SubagentGroupBlock => {
+  const block = b as SubagentGroupBlock;
+  expect(block.kind).toBe('subagent-group');
   return block;
 };
+
+// Every projection folds even a lone agent into a group; unwrap to its first
+// member so the per-agent assertions below read naturally.
+const asSubagent = (b: unknown): SubagentBlock => asSubagentGroup(b).agents[0]!;
 
 describe('pairToolEvents — verbose tool pairing', () => {
   it('pairs a tool_call_requested with its tool_result into one settled block', () => {
@@ -431,6 +441,58 @@ describe('pairToolEvents — subagent lifecycle accretion', () => {
   it('ignores subagent events with no matching started block', () => {
     const blocks = pairToolEvents([subagentEvent('subagent_tool_call', { childSessionId: 'ghost' })]);
     expect(blocks).toHaveLength(0);
+  });
+
+  it('folds two consecutive sibling agents into ONE group', () => {
+    const blocks = pairToolEvents([
+      subagentEvent('subagent_started', { childSessionId: 'cs1', label: 'a', agentType: 'Explore' }),
+      subagentEvent('subagent_started', { childSessionId: 'cs2', label: 'b', agentType: 'Explore' }),
+      subagentEvent('subagent_tool_call', { childSessionId: 'cs1' }),
+      subagentEvent('subagent_completed', { childSessionId: 'cs2', stopReason: 'end_turn', tokensUsed: 65300 }),
+      subagentEvent('subagent_completed', { childSessionId: 'cs1', stopReason: 'end_turn', tokensUsed: 1200 }),
+    ]);
+    expect(blocks).toHaveLength(1);
+    const group = asSubagentGroup(blocks[0]);
+    expect(group.agentType).toBe('Explore');
+    expect(group.agents).toHaveLength(2);
+    // Each child accretes independently by childSessionId.
+    expect(group.agents[0]!.toolCallCount).toBe(1);
+    expect(group.agents[0]!.tokensUsed).toBe(1200);
+    expect(group.agents[1]!.tokensUsed).toBe(65300);
+    expect(isSettled(group)).toBe(true);
+  });
+
+  it('breaks the group when a non-subagent block interrupts the run', () => {
+    const blocks = pairToolEvents([
+      subagentEvent('subagent_started', { childSessionId: 'cs1', label: 'a' }),
+      subagentEvent('subagent_completed', { childSessionId: 'cs1', stopReason: 'end_turn' }),
+      toolRequest('t1', 'bash', { command: 'ls' }),
+      subagentEvent('subagent_started', { childSessionId: 'cs2', label: 'b' }),
+      subagentEvent('subagent_completed', { childSessionId: 'cs2', stopReason: 'end_turn' }),
+    ]);
+    const groups = blocks.filter((b) => b.kind === 'subagent-group');
+    expect(groups).toHaveLength(2);
+  });
+
+  it('marks a group as mixed when member agent types differ', () => {
+    const group = asSubagentGroup(
+      pairToolEvents([
+        subagentEvent('subagent_started', { childSessionId: 'cs1', label: 'a', agentType: 'Explore' }),
+        subagentEvent('subagent_started', { childSessionId: 'cs2', label: 'b', agentType: 'Plan' }),
+      ])[0],
+    );
+    expect(group.agentType).toBe('mixed');
+  });
+
+  it('keeps a group unsettled while any member is still running', () => {
+    const group = asSubagentGroup(
+      pairToolEvents([
+        subagentEvent('subagent_started', { childSessionId: 'cs1', label: 'a' }),
+        subagentEvent('subagent_completed', { childSessionId: 'cs1', stopReason: 'end_turn' }),
+        subagentEvent('subagent_started', { childSessionId: 'cs2', label: 'b' }),
+      ])[0],
+    );
+    expect(isSettled(group)).toBe(false);
   });
 });
 

--- a/packages/chat-model/src/pair-events.ts
+++ b/packages/chat-model/src/pair-events.ts
@@ -5,6 +5,7 @@ import type {
   LiveToolCall,
   SkillScopeBlock,
   SubagentBlock,
+  SubagentGroupBlock,
   ToolCallBlockData,
 } from './types.js';
 import { oneLine } from './format.js';
@@ -22,26 +23,46 @@ function handleSubagentEvent(
   e: PluginEvent,
   subagents: Map<string, SubagentBlock>,
   root: Block[],
+  groupRef: { current: SubagentGroupBlock | null },
 ): void {
   const payload = (e.payload ?? {}) as Record<string, unknown>;
   const childSessionId = String(payload.childSessionId ?? '');
   if (!childSessionId) return;
   if (e.subtype === 'subagent_started') {
+    const agentType = String(payload.agentType ?? 'default');
     const block: SubagentBlock = {
       kind: 'subagent',
       id: e.id,
       childSessionId,
       label: String(payload.label ?? 'agent'),
+      agentType,
       startedAtMs: new Date(e.ts).getTime(),
       completedAtMs: null,
       toolCallCount: 0,
+      tokensUsed: null,
       toolCalls: [],
       stopReason: null,
       finalPreview: null,
       error: null,
     };
     subagents.set(childSessionId, block);
-    root.push(block);
+    // Fold consecutive sibling agents (a dispatch_agent fan-out) into one
+    // group. The run is broken by any non-subagent block (see pushBlock /
+    // boundary resets), so a fresh `subagent_started` after that opens a new
+    // group. A lone agent renders as a group of one.
+    if (groupRef.current) {
+      groupRef.current.agents.push(block);
+      if (groupRef.current.agentType !== agentType) groupRef.current.agentType = 'mixed';
+    } else {
+      const group: SubagentGroupBlock = {
+        kind: 'subagent-group',
+        id: `subagentgroup:${e.id}`,
+        agentType,
+        agents: [block],
+      };
+      groupRef.current = group;
+      root.push(group);
+    }
     return;
   }
   const block = subagents.get(childSessionId);
@@ -54,6 +75,7 @@ function handleSubagentEvent(
   if (e.subtype === 'subagent_completed') {
     block.completedAtMs = new Date(e.ts).getTime();
     block.stopReason = String(payload.stopReason ?? '');
+    block.tokensUsed = typeof payload.tokensUsed === 'number' ? payload.tokensUsed : 0;
     const text = typeof payload.text === 'string' ? payload.text : '';
     if (text) block.finalPreview = oneLine(text);
     if (typeof payload.error === 'string') block.error = payload.error;
@@ -114,8 +136,13 @@ export function pairToolEvents(
   // into it until something non-compact closes it.
   let openLive: LiveToolBlockData | null = null;
   const subagents = new Map<string, SubagentBlock>();
+  // Open subagent group, if any. Consecutive `subagent_started` events accrete
+  // into it; any non-subagent block (or a turn/scope boundary) closes the run.
+  const subagentGroup: { current: SubagentGroupBlock | null } = { current: null };
 
   const pushBlock = (block: Block): void => {
+    // Any non-subagent block breaks a run of sibling subagents.
+    subagentGroup.current = null;
     if (openScope) {
       openScope.children.push(block);
     } else {
@@ -182,6 +209,7 @@ export function pairToolEvents(
       // skill scope). Clearing it at the turn boundary stops a later turn that
       // happens to reuse a callId from having its tool_result silently dropped.
       suppressedCallIds.clear();
+      subagentGroup.current = null;
       root.push({ kind: 'event', id: e.id, event: e });
       continue;
     }
@@ -196,6 +224,7 @@ export function pairToolEvents(
         removeBlockByCallId(pendingLoadSkillCallId);
         pendingLoadSkillCallId = null;
       }
+      subagentGroup.current = null;
       openScope = {
         kind: 'skill-scope',
         id: e.id,
@@ -293,14 +322,15 @@ export function pairToolEvents(
         // stale skill banner two messages later.
         continuationSkillEvent = null;
       }
+      subagentGroup.current = null;
       root.push({ kind: 'event', id: e.id, event: e });
       continue;
     }
-    // Subagent events fold into one-line scope blocks so a fleet of
-    // children doesn't drown the main chat. The SubagentSpawner emits
-    // them as plugin_event with pluginId='@moxxy/subagents'.
+    // Subagent events fold into a collapsible group so a fleet of children
+    // doesn't drown the main chat. The SubagentSpawner emits them as
+    // plugin_event with pluginId='@moxxy/subagents'.
     if (e.type === 'plugin_event' && e.pluginId === SUBAGENT_PLUGIN_ID) {
-      handleSubagentEvent(e, subagents, root);
+      handleSubagentEvent(e, subagents, root, subagentGroup);
       continue;
     }
     pushBlock({ kind: 'event', id: e.id, event: e });
@@ -319,6 +349,7 @@ export function isSettled(block: Block): boolean {
   if (block.kind === 'event') return true;
   if (block.kind === 'tool-call') return block.outcome !== null;
   if (block.kind === 'subagent') return block.completedAtMs !== null || block.error !== null;
+  if (block.kind === 'subagent-group') return block.agents.every(isSettled);
   if (block.kind === 'skill-scope') {
     return block.closed && block.children.every(isSettled);
   }
@@ -344,13 +375,22 @@ export function blocksEquivalent(a: Block, b: Block): boolean {
     return a.request === b.request && a.outcome === b.outcome;
   }
   if (a.kind === 'subagent' && b.kind === 'subagent') {
-    // Subagent updates: tool count, completion timestamp, preview, error.
+    // Subagent updates: tool count, tokens, completion timestamp, preview, error.
     return (
       a.completedAtMs === b.completedAtMs &&
       a.toolCallCount === b.toolCallCount &&
+      a.tokensUsed === b.tokensUsed &&
       a.finalPreview === b.finalPreview &&
       a.error === b.error
     );
+  }
+  if (a.kind === 'subagent-group' && b.kind === 'subagent-group') {
+    if (a.agentType !== b.agentType) return false;
+    if (a.agents.length !== b.agents.length) return false;
+    for (let i = 0; i < a.agents.length; i += 1) {
+      if (!blocksEquivalent(a.agents[i]!, b.agents[i]!)) return false;
+    }
+    return true;
   }
   if (a.kind === 'skill-scope' && b.kind === 'skill-scope') {
     if (a.closed !== b.closed) return false;
@@ -378,6 +418,9 @@ export function countToolCalls(blocks: ReadonlyArray<Block>): number {
     if (b.kind === 'tool-call') n += 1;
     else if (b.kind === 'skill-scope') n += countToolCalls(b.children);
     else if (b.kind === 'live-tools') n += b.calls.length;
+    else if (b.kind === 'subagent-group') {
+      for (const a of b.agents) n += a.toolCallCount;
+    }
   }
   return n;
 }

--- a/packages/chat-model/src/types.ts
+++ b/packages/chat-model/src/types.ts
@@ -11,6 +11,7 @@ export type Block =
   | ToolCallBlockData
   | SkillScopeBlock
   | SubagentBlock
+  | SubagentGroupBlock
   | LiveToolBlockData;
 
 /**
@@ -26,10 +27,14 @@ export interface SubagentBlock {
   readonly id: string;
   readonly childSessionId: string;
   readonly label: string;
+  /** The kind this child was spawned as (e.g. `Explore`); `default` when unset. */
+  agentType: string;
   readonly startedAtMs: number;
   /** ms timestamp of completion, or null while running. */
   completedAtMs: number | null;
   toolCallCount: number;
+  /** Total tokens the child consumed (input + output), null until completion. */
+  tokensUsed: number | null;
   /** The agent's tool calls in order (name + input), accumulated live from
    *  `subagent_tool_call` events — lets a surface show what it's doing. */
   readonly toolCalls: Array<{ readonly name: string; readonly input: unknown }>;
@@ -39,6 +44,21 @@ export interface SubagentBlock {
   finalPreview: string | null;
   /** Error message if the agent failed (subagent_error/abort or non-OK stopReason). */
   error: string | null;
+}
+
+/**
+ * A run of consecutive sibling subagents (a `dispatch_agent` fan-out) folded
+ * into one collapsible group. Rendered as a header (`N Explore agents
+ * finished`) over a tree of per-agent rows (`label · N tool uses · NN.Nk
+ * tokens` + a status sub-line). A lone agent still folds into a group of one.
+ */
+export interface SubagentGroupBlock {
+  kind: 'subagent-group';
+  readonly id: string;
+  /** Shared kind across the group, or `'mixed'` when members differ. */
+  agentType: string;
+  /** Member agents, mutated in place as their events accrete. */
+  agents: SubagentBlock[];
 }
 
 export interface EventBlock {

--- a/packages/cli/src/config-applier.ts
+++ b/packages/cli/src/config-applier.ts
@@ -94,6 +94,11 @@ export function buildSessionConfigApplier(
       applied.push('lazyTools');
     }
 
+    if (next.context?.reasoning !== last.context?.reasoning) {
+      session.reasoning = next.context?.reasoning;
+      applied.push('reasoning');
+    }
+
     if (next.hookTimeoutMs !== last.hookTimeoutMs) {
       // The dispatcher reads its timeout at construction. v0: pending.
       pending.push('hookTimeoutMs (restart required)');

--- a/packages/client-core/src/chat-store/state.ts
+++ b/packages/client-core/src/chat-store/state.ts
@@ -34,6 +34,8 @@ export interface ChatSnapshot {
   readonly events: ReadonlyArray<MoxxyEvent>;
   readonly extensions: ReadonlyArray<Extension>;
   readonly streamingText: string;
+  /** Live reasoning/thinking preview for the active turn (empty when none). */
+  readonly streamingReasoning: string;
   readonly sending: boolean;
   readonly activeTurnId: string | null;
   readonly error: string | null;
@@ -82,6 +84,7 @@ export const EMPTY_SNAPSHOT: ChatSnapshot = Object.freeze({
   events: EMPTY_EVENTS,
   extensions: EMPTY_EXTENSIONS,
   streamingText: '',
+  streamingReasoning: '',
   sending: false,
   activeTurnId: null,
   error: null,
@@ -129,6 +132,7 @@ export function buildSnapshot(slot: Slot): ChatSnapshot {
     events,
     extensions: rt.extensions,
     streamingText: rt.streamingText,
+    streamingReasoning: rt.streamingReasoning,
     sending: rt.sending,
     activeTurnId: rt.activeTurnId,
     error: rt.error,

--- a/packages/client-core/src/chatModel.test.ts
+++ b/packages/client-core/src/chatModel.test.ts
@@ -75,6 +75,34 @@ describe('chat model runtime', () => {
     expect(blocksOf(rt)).toEqual([]);
   });
 
+  it('accumulates reasoning chunks into streamingReasoning — never into the log', () => {
+    const rt = createRuntime();
+    applyEvent(rt, evt('reasoning_chunk', { delta: 'think' }));
+    applyEvent(rt, evt('reasoning_chunk', { delta: 'ing…' }));
+    expect(rt.streamingReasoning).toBe('thinking…');
+    expect(rt.log.length).toBe(0);
+  });
+
+  it('commits reasoning_message + clears the live reasoning preview', () => {
+    const rt = createRuntime();
+    applyEvent(rt, evt('reasoning_chunk', { delta: 'pondering' }));
+    applyEvent(rt, evt('reasoning_message', { content: 'pondering' }));
+    expect(rt.streamingReasoning).toBe('');
+    const blocks = blocksOf(rt);
+    expect(blocks).toHaveLength(1);
+    expect((blocks[0] as Extract<FoldedBlock, { kind: 'event' }>).event).toMatchObject({
+      type: 'reasoning_message',
+      content: 'pondering',
+    });
+  });
+
+  it('assistant_message clears any live reasoning preview too', () => {
+    const rt = createRuntime();
+    applyEvent(rt, evt('reasoning_chunk', { delta: 'hmm' }));
+    applyEvent(rt, assistant('done.', 'end_turn'));
+    expect(rt.streamingReasoning).toBe('');
+  });
+
   it('commits the streamed text on assistant_message and clears the stream', () => {
     const rt = createRuntime();
     applyEvent(rt, chunk('hi'));

--- a/packages/client-core/src/chatModel.ts
+++ b/packages/client-core/src/chatModel.ts
@@ -117,6 +117,9 @@ const RENDERED_EVENT_TYPES: ReadonlySet<MoxxyEvent['type']> = new Set([
   'skill_invoked',
   'error',
   'abort',
+  // Finalized per-call reasoning summary — committed + rendered as a collapsible
+  // "Thinking" block. `reasoning_chunk` (the live delta) is handled separately.
+  'reasoning_message',
 ]);
 
 const SUBAGENT_PLUGIN_ID = '@moxxy/subagents';
@@ -138,6 +141,10 @@ export interface ChatRuntime {
   readonly seenIds: Set<string>;
   extensions: Extension[];
   streamingText: string;
+  /** Live reasoning/thinking preview for the active turn (parallels
+   *  `streamingText`); cleared on the matching reasoning_message / the turn's
+   *  assistant_message / turn completion. Never committed to the log. */
+  streamingReasoning: string;
   activeTurnId: string | null;
   sending: boolean;
   error: string | null;
@@ -150,6 +157,7 @@ export function createRuntime(initialEvents: ReadonlyArray<MoxxyEvent> = []): Ch
     seenIds: new Set(initialEvents.map((e) => e.id)),
     extensions: [],
     streamingText: '',
+    streamingReasoning: '',
     activeTurnId: null,
     sending: false,
     error: null,
@@ -172,18 +180,41 @@ export function applyEvent(rt: ChatRuntime, event: MoxxyEvent): boolean {
     rt.rev += 1;
     return true;
   }
+  if (event.type === 'reasoning_chunk') {
+    // Live thinking preview — accumulate ephemerally like assistant_chunk.
+    rt.streamingReasoning += event.delta;
+    rt.rev += 1;
+    return true;
+  }
+  if (event.type === 'reasoning_message') {
+    // Finalized reasoning summary: clear the live preview and commit it as a
+    // rendered block. Drop a replayed/duplicate, still clearing any live preview.
+    if (rt.seenIds.has(event.id)) {
+      if (rt.streamingReasoning === '') return false;
+      rt.streamingReasoning = '';
+      rt.rev += 1;
+      return true;
+    }
+    rt.log.append(event);
+    rt.seenIds.add(event.id);
+    rt.streamingReasoning = '';
+    rt.rev += 1;
+    return true;
+  }
   if (event.type === 'assistant_message') {
     // Drop a replayed/duplicate message, but still clear any live streaming
     // preview it corresponds to so a re-attach mid-reply doesn't strand it.
     if (rt.seenIds.has(event.id)) {
-      if (rt.streamingText === '') return false;
+      if (rt.streamingText === '' && rt.streamingReasoning === '') return false;
       rt.streamingText = '';
+      rt.streamingReasoning = '';
       rt.rev += 1;
       return true;
     }
     rt.log.append(event);
     rt.seenIds.add(event.id);
     rt.streamingText = '';
+    rt.streamingReasoning = '';
     rt.rev += 1;
     return true;
   }
@@ -220,6 +251,7 @@ export function applyAction(rt: ChatRuntime, action: ChatAction): boolean {
         rt.seenIds.add(synth.id);
       }
       rt.streamingText = '';
+      rt.streamingReasoning = '';
       rt.sending = false;
       rt.activeTurnId = null;
       if (action.error) {
@@ -264,6 +296,7 @@ export function applyAction(rt: ChatRuntime, action: ChatAction): boolean {
       rt.seenIds.clear();
       rt.extensions = [];
       rt.streamingText = '';
+      rt.streamingReasoning = '';
       rt.activeTurnId = null;
       rt.sending = false;
       rt.error = null;

--- a/packages/client-core/src/useChat.ts
+++ b/packages/client-core/src/useChat.ts
@@ -18,6 +18,8 @@ export interface UseChat {
   readonly extensions: ReadonlyArray<Extension>;
   /** In-flight assistant text, rendered as a live preview at the tail. */
   readonly streamingText: string;
+  /** In-flight reasoning/thinking text, rendered as a dim live preview. */
+  readonly streamingReasoning: string;
   readonly sending: boolean;
   readonly activeTurnId: string | null;
   readonly error: string | null;
@@ -205,6 +207,7 @@ export function useChat(workspaceId: string | null): UseChat {
     events: snap.events,
     extensions: snap.extensions,
     streamingText: snap.streamingText,
+    streamingReasoning: snap.streamingReasoning,
     sending: snap.sending,
     activeTurnId: snap.activeTurnId,
     error: snap.error,

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -115,6 +115,14 @@ export const contextConfigSchema = z.object({
   elision: elisionConfigSchema.optional(),
   /** Lazy tool loading: send only core + loaded tool schemas, index the rest. Default false. */
   lazyTools: z.boolean().optional(),
+  /**
+   * Reasoning/thinking preview. `true` enables it at the model's default depth;
+   * `{ effort }` sets the depth. Honored only by providers/models that support
+   * reasoning (Anthropic adaptive thinking, OpenAI/Codex reasoning). Default off.
+   */
+  reasoning: z
+    .union([z.boolean(), z.object({ effort: z.enum(['low', 'medium', 'high']).optional() })])
+    .optional(),
 });
 
 export const moxxyConfigSchema = z.object({

--- a/packages/core/src/run-turn.ts
+++ b/packages/core/src/run-turn.ts
@@ -75,6 +75,9 @@ export async function* runTurn(
       cacheStrategy: session.cacheStrategies.getActive(),
       ...(session.elisionSettings ? { elision: session.elisionSettings } : {}),
       ...(session.lazyTools ? { lazyTools: true } : {}),
+      // Reasoning preference (effort) — honored only by providers/models that
+      // advertise `supportsReasoning` (gated in collectProviderStream).
+      ...(session.reasoning ? { reasoning: session.reasoning } : {}),
       permissions: session.resolver,
       ...(session.approvalResolver ? { approval: session.approvalResolver } : {}),
       hooks: session.dispatcher,

--- a/packages/core/src/session-runtime.ts
+++ b/packages/core/src/session-runtime.ts
@@ -57,6 +57,8 @@ export interface SessionRuntime {
   readonly approvalResolver: ApprovalResolver | null;
   readonly elisionSettings: ElisionSettings | null;
   readonly lazyTools: boolean;
+  /** Reasoning/thinking preference (effort), forwarded to each turn's ModeContext. */
+  readonly reasoning?: { readonly effort?: 'low' | 'medium' | 'high' } | boolean | undefined;
   readonly dispatcher: HookDispatcher;
   readonly pluginHost: PluginHostHandle;
   /**

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -141,6 +141,12 @@ export class Session implements ClientSession, SessionRuntime {
   /** Lazy tool loading toggle, from `config.context.lazyTools`. Default off. */
   lazyTools = false;
   /**
+   * Reasoning/thinking preference, from `config.context.reasoning`. Forwarded
+   * to each turn's ModeContext and on to the provider, which honors it only
+   * when the active model advertises `supportsReasoning`. Undefined → off.
+   */
+  reasoning: { readonly effort?: 'low' | 'medium' | 'high' } | boolean | undefined = undefined;
+  /**
    * Model id resolved by the most recent `runTurn()` (see SessionRuntime).
    * Last-writer-wins for concurrent turns; null until the first turn runs.
    */

--- a/packages/core/src/subagents/events.ts
+++ b/packages/core/src/subagents/events.ts
@@ -36,6 +36,7 @@ export async function emitSubagentStart(
       childSessionId: String(childSessionId),
       prompt: spec.prompt,
       mode,
+      agentType: spec.agentType ?? 'default',
       ...(spec.model ? { model: spec.model } : {}),
     },
   });
@@ -49,6 +50,8 @@ export async function emitSubagentCompleted(
   text: string,
   stopReason: StopReason,
   errorMessage: string | null,
+  agentType: string,
+  tokensUsed: number,
 ): Promise<void> {
   await parentSession.log.append({
     type: 'plugin_event',
@@ -62,6 +65,8 @@ export async function emitSubagentCompleted(
       childSessionId: String(childSessionId),
       text,
       stopReason,
+      agentType,
+      tokensUsed,
       ...(errorMessage ? { error: errorMessage } : {}),
     },
   });

--- a/packages/core/src/subagents/run-child.ts
+++ b/packages/core/src/subagents/run-child.ts
@@ -211,12 +211,21 @@ async function executeChildLoop(args: {
   } = args;
   const { parentSession, parentTurnId } = rt;
 
-  const capture = { text: '', stopReason: 'end_turn' as StopReason, error: null as string | null };
+  const capture = {
+    text: '',
+    stopReason: 'end_turn' as StopReason,
+    error: null as string | null,
+    tokensUsed: 0,
+  };
 
   const unsubCapture = childLog.subscribe((e) => {
     if (e.type === 'assistant_message') {
       if (e.content) capture.text = e.content;
       if (e.stopReason) capture.stopReason = e.stopReason;
+    } else if (e.type === 'provider_response') {
+      // Sum every provider call's tokens so the parent can show how much this
+      // child consumed (input + output, matching a context-meter reading).
+      capture.tokensUsed += (e.inputTokens ?? 0) + (e.outputTokens ?? 0);
     } else if (e.type === 'error' && e.kind === 'fatal') {
       capture.error = e.message;
     }
@@ -267,6 +276,8 @@ async function executeChildLoop(args: {
       capture.text,
       result.stopReason,
       capture.error,
+      spec.agentType ?? 'default',
+      capture.tokensUsed,
     );
   }
 
@@ -305,7 +316,7 @@ async function resolveStrategy(
   // No default mode either — that's a config error, not a model mistake.
   await emitSubagentStart(parentSession, parentTurnId, label, childSessionId, spec, requestedStrategy);
   const errorMsg = `Subagent failed: unknown mode "${requestedStrategy}" and no fallback available`;
-  await emitSubagentCompleted(parentSession, parentTurnId, label, childSessionId, '', 'error', errorMsg);
+  await emitSubagentCompleted(parentSession, parentTurnId, label, childSessionId, '', 'error', errorMsg, spec.agentType ?? 'default', 0);
   return {
     failure: {
       label,

--- a/packages/mode-default/src/turn-iterator.ts
+++ b/packages/mode-default/src/turn-iterator.ts
@@ -72,10 +72,14 @@ export async function* runDefaultMode(ctx: ModeContext): AsyncIterable<MoxxyEven
       model: ctx.model,
     });
 
-    const { text, toolUses, stopReason, error, usage } = await collectProviderStream(ctx, messages, {
-      iteration,
-      stablePrefixIndex,
-    });
+    const { text, toolUses, stopReason, error, usage, reasoning } = await collectProviderStream(
+      ctx,
+      messages,
+      {
+        iteration,
+        stablePrefixIndex,
+      },
+    );
 
     yield await ctx.emit({
       type: 'provider_response',
@@ -123,6 +127,23 @@ export async function* runDefaultMode(ctx: ModeContext): AsyncIterable<MoxxyEven
     }
     // Clean provider call — reset the overflow-recovery budget.
     reactiveCompactions = 0;
+
+    // Finalize the reasoning summary for THIS call BEFORE the tool/assistant
+    // emits, so the log order is reasoning → tool_use → text (projection
+    // attaches the signed thinking block as content[0] of the same assistant
+    // turn). collectProviderStream already guards on non-empty text / encrypted.
+    if (reasoning) {
+      yield await ctx.emit({
+        type: 'reasoning_message',
+        sessionId: ctx.sessionId,
+        turnId: ctx.turnId,
+        source: 'model',
+        content: reasoning.text,
+        ...(reasoning.signature ? { signature: reasoning.signature } : {}),
+        ...(reasoning.redacted ? { redacted: true } : {}),
+        ...(reasoning.encrypted ? { encrypted: reasoning.encrypted } : {}),
+      });
+    }
 
     const stuck = yield* emitRequestsAndDetectStuck(ctx, toolUses, detector, {
       abortedResultMessage: 'default mode loop aborted (stuck pattern) before this call ran',

--- a/packages/mode-goal/src/goal-loop.ts
+++ b/packages/mode-goal/src/goal-loop.ts
@@ -146,7 +146,7 @@ export async function* runGoalMode(ctx: ModeContext): AsyncIterable<MoxxyEvent> 
       model: goalCtx.model,
     });
 
-    const { text, toolUses, stopReason, error, usage } = await collectProviderStream(
+    const { text, toolUses, stopReason, error, usage, reasoning } = await collectProviderStream(
       goalCtx,
       messages,
       {
@@ -225,6 +225,22 @@ export async function* runGoalMode(ctx: ModeContext): AsyncIterable<MoxxyEvent> 
         stopReason: 'end_turn',
       });
       return;
+    }
+
+    // Finalize the reasoning summary for THIS call before the tool/assistant
+    // emits so the log order is reasoning → tool_use → text (projection
+    // attaches the signed thinking block as content[0] of the same turn).
+    if (reasoning) {
+      yield await ctx.emit({
+        type: 'reasoning_message',
+        sessionId: ctx.sessionId,
+        turnId: ctx.turnId,
+        source: 'model',
+        content: reasoning.text,
+        ...(reasoning.signature ? { signature: reasoning.signature } : {}),
+        ...(reasoning.redacted ? { redacted: true } : {}),
+        ...(reasoning.encrypted ? { encrypted: reasoning.encrypted } : {}),
+      });
     }
 
     const stuck = yield* emitRequestsAndDetectStuck(ctx, toolUses, detector, {

--- a/packages/plugin-cli/src/components/ChatView.tsx
+++ b/packages/plugin-cli/src/components/ChatView.tsx
@@ -8,6 +8,8 @@ import { StreamingPreview, tailForViewport } from './chat/StreamingPreview.js';
 export interface ChatViewProps {
   readonly events: ReadonlyArray<MoxxyEvent>;
   readonly streamingDelta?: string;
+  /** Live (un-persisted) thinking stream; shown dim when no assistant text yet. */
+  readonly reasoningDelta?: string;
   /** Global Ctrl+O toggle — expand every live-tools block at once. */
   readonly expandToolOutputs?: boolean;
   /** Per-tool compact-presentation metadata from the active tool registry. */
@@ -36,6 +38,7 @@ export interface ChatViewProps {
 export const ChatView: React.FC<ChatViewProps> = ({
   events,
   streamingDelta,
+  reasoningDelta,
   expandToolOutputs,
   compactTools,
   hideLive,
@@ -106,6 +109,11 @@ export const ChatView: React.FC<ChatViewProps> = ({
           ))}
           {streamingDelta && streamingDelta.trim() ? (
             <StreamingPreview content={tailForViewport(streamingDelta)} />
+          ) : reasoningDelta && reasoningDelta.trim() ? (
+            // Dim live-thinking preview, only while there's no assistant text
+            // yet. Prefix lands on the same single visual row as the content
+            // tail, preserving StreamingPreview's no-stacking invariant.
+            <StreamingPreview content={`thinking · ${tailForViewport(reasoningDelta)}`} dim />
           ) : null}
         </Box>
       )}

--- a/packages/plugin-cli/src/components/chat/BlockLine.tsx
+++ b/packages/plugin-cli/src/components/chat/BlockLine.tsx
@@ -5,6 +5,7 @@ import { EventLine } from './EventLine.js';
 import { LiveToolBlock } from './LiveToolBlock.js';
 import { ToolCallBlock } from './ToolCallBlock.js';
 import { SubagentScopeView } from './SubagentScopeView.js';
+import { SubagentGroupView } from './SubagentGroupView.js';
 import {
   blocksEquivalent,
   countToolCalls,
@@ -24,9 +25,13 @@ export interface BlockLineProps {
 
 export const BlockLine: React.FC<BlockLineProps> = memo(
   function BlockLine({ block, expandToolOutputs }) {
-    if (block.kind === 'event') return <EventLine event={block.event} />;
+    if (block.kind === 'event')
+      return <EventLine event={block.event} expandToolOutputs={expandToolOutputs} />;
     if (block.kind === 'tool-call') {
       return <ToolCallBlock request={block.request} outcome={block.outcome} />;
+    }
+    if (block.kind === 'subagent-group') {
+      return <SubagentGroupView group={block} expandToolOutputs={expandToolOutputs} />;
     }
     if (block.kind === 'subagent') {
       return <SubagentScopeView scope={block} />;

--- a/packages/plugin-cli/src/components/chat/EventLine.tsx
+++ b/packages/plugin-cli/src/components/chat/EventLine.tsx
@@ -2,9 +2,13 @@ import React from 'react';
 import { Box, Text } from 'ink';
 import type { MoxxyEvent } from '@moxxy/sdk';
 import { Colors, Glyphs } from '../../theme.js';
+import { truncate } from '@moxxy/chat-model';
 import { AssistantBlock } from './AssistantBlock.js';
 
-export const EventLine: React.FC<{ event: MoxxyEvent }> = ({ event }) => {
+export const EventLine: React.FC<{ event: MoxxyEvent; expandToolOutputs?: boolean }> = ({
+  event,
+  expandToolOutputs,
+}) => {
   switch (event.type) {
     case 'user_prompt':
       // System-injected context notes (e.g. the /vault reference) aren't user
@@ -48,6 +52,37 @@ export const EventLine: React.FC<{ event: MoxxyEvent }> = ({ event }) => {
       );
     case 'assistant_message':
       return <AssistantBlock content={event.content} />;
+    case 'reasoning_message': {
+      // Redacted/encrypted thinking is display-suppressed and can never be
+      // expanded — show a static withheld marker.
+      if (event.redacted) {
+        return (
+          <Box marginTop={1}>
+            <Text dimColor>{`${Glyphs.pending} reasoning withheld`}</Text>
+          </Box>
+        );
+      }
+      const content = event.content ?? '';
+      // Collapsed (default): one dim line — the diamond + first content line.
+      // Ctrl+O (the global expandToolOutputs toggle) reveals the full text,
+      // since Ink has no native collapse affordance.
+      if (expandToolOutputs) {
+        return (
+          <Box flexDirection="column" marginTop={1}>
+            <Text dimColor>{`${Glyphs.pending} thinking`}</Text>
+            <Box marginLeft={2}>
+              <Text dimColor>{content}</Text>
+            </Box>
+          </Box>
+        );
+      }
+      const firstLine = content.split('\n').find((l) => l.trim()) ?? '';
+      return (
+        <Box marginTop={1}>
+          <Text dimColor>{`${Glyphs.pending} thinking · ${truncate(firstLine, 100)}`}</Text>
+        </Box>
+      );
+    }
     case 'skill_invoked':
       // SkillScopeView owns this render; if we reach here it means the
       // event escaped grouping (defensive fallback only).

--- a/packages/plugin-cli/src/components/chat/StreamingPreview.tsx
+++ b/packages/plugin-cli/src/components/chat/StreamingPreview.tsx
@@ -27,9 +27,8 @@ import { Glyphs } from '../../theme.js';
  * full Markdown pipeline only kicks in once the `assistant_message` event lands
  * and the message becomes a settled `<Static>` block.
  */
-export const StreamingPreview: React.FC<{ content: string }> = memo(function StreamingPreview({
-  content,
-}) {
+export const StreamingPreview: React.FC<{ content: string; dim?: boolean }> = memo(
+  function StreamingPreview({ content, dim }) {
   const cols = process.stdout.columns ?? 80;
   // Room for the marker column (glyph + 1-col margin) plus a little slack.
   const innerCols = Math.max(20, cols - 4);
@@ -55,7 +54,7 @@ export const StreamingPreview: React.FC<{ content: string }> = memo(function Str
       <Box marginRight={1}>
         <Text dimColor>{Glyphs.filled}</Text>
       </Box>
-      <Text>{shown || ' '}</Text>
+      <Text dimColor={dim}>{shown || ' '}</Text>
     </Box>
   );
 });

--- a/packages/plugin-cli/src/components/chat/SubagentGroupView.tsx
+++ b/packages/plugin-cli/src/components/chat/SubagentGroupView.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { Colors, Glyphs } from '../../theme.js';
+import {
+  DotColors,
+  formatTokensK,
+  truncate,
+  type SubagentBlock,
+  type SubagentGroupBlock,
+} from '@moxxy/chat-model';
+
+const LABEL_MAX = 60;
+const ERROR_MAX = 80;
+
+/**
+ * Renders a folded run of sibling subagents (one `dispatch_agent` fan-out).
+ *
+ * Collapsed (default) — a single header row:
+ *
+ *   ● 4 Explore agents finished (ctrl+o to expand)
+ *
+ * Expanded (Ctrl+O / `expandToolOutputs`) — a compact tree, one branch per
+ * agent with a status sub-line:
+ *
+ *   ├ Find file-writing tools · 45 tool uses · 65.3k tokens
+ *   │  └ Done
+ *
+ * Like the rest of the chat blocks this feeds Ink's `<Static>` region once the
+ * group is settled (`isSettled` is true for a fully-completed group), so it
+ * holds no live timers — the header verb flips to past tense on completion.
+ */
+export const SubagentGroupView: React.FC<{
+  group: SubagentGroupBlock;
+  expandToolOutputs: boolean;
+}> = ({ group, expandToolOutputs }) => {
+  const agents = group.agents;
+  const total = agents.length;
+  const running = agents.filter((a) => a.completedAtMs == null && a.error == null).length;
+  const failed = agents.filter((a) => a.error != null).length;
+  const anyRunning = running > 0;
+  const dotColor = failed > 0 ? Colors.danger : anyRunning ? Colors.busy : DotColors.subagent;
+
+  // "N {type} agents {verb}" — drop the type word for a mixed fan-out, use the
+  // singular noun for a lone agent, and append a failure tail when any failed.
+  const typeWord = group.agentType === 'mixed' ? '' : `${group.agentType} `;
+  const noun = total === 1 ? 'agent' : 'agents';
+  const verb = anyRunning ? 'running' : 'finished';
+  const failTail = failed > 0 ? ` (${failed} failed)` : '';
+  const header = `${total} ${typeWord}${noun} ${verb}${failTail}`;
+
+  if (!expandToolOutputs) {
+    return (
+      <Box marginTop={1}>
+        <Text color={dotColor}>{Glyphs.filled} </Text>
+        <Text>{header}</Text>
+        <Text dimColor>{' (ctrl+o to expand)'}</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Box>
+        <Text color={dotColor}>{Glyphs.filled} </Text>
+        <Text>{header}</Text>
+      </Box>
+      <Box flexDirection="column" marginLeft={2}>
+        {agents.map((a) => (
+          <SubagentRow key={a.id} agent={a} />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+const SubagentRow: React.FC<{ agent: SubagentBlock }> = ({ agent }) => {
+  const running = agent.completedAtMs == null && agent.error == null;
+  const tokens = formatTokensK(agent.tokensUsed);
+  const toolPart = `${agent.toolCallCount} tool use${agent.toolCallCount === 1 ? '' : 's'}`;
+  const statusColor = agent.error ? Colors.danger : running ? Colors.busy : DotColors.subagent;
+  const statusText = agent.error
+    ? truncate(agent.error, ERROR_MAX)
+    : running
+      ? 'running'
+      : 'Done';
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text dimColor>{'├ '}</Text>
+        <Text>{truncate(agent.label, LABEL_MAX)}</Text>
+        <Text dimColor>{` · ${toolPart}`}</Text>
+        {tokens ? <Text dimColor>{` · ${tokens} tokens`}</Text> : null}
+      </Box>
+      <Box>
+        <Text dimColor>{'│  └ '}</Text>
+        <Text color={statusColor}>{statusText}</Text>
+      </Box>
+    </Box>
+  );
+};

--- a/packages/plugin-cli/src/session/SessionView.tsx
+++ b/packages/plugin-cli/src/session/SessionView.tsx
@@ -205,6 +205,8 @@ export const SessionView: React.FC<SessionViewProps> = ({
     stream.cancelStreamFlush();
     stream.setStreamingDelta('');
     stream.streamingBufferRef.current = '';
+    stream.setReasoningDelta('');
+    stream.reasoningBufferRef.current = '';
     if (action === 'clear') {
       if (notice) setSystemNotice(notice);
       return;
@@ -331,6 +333,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
       <ChatView
         events={stream.events}
         streamingDelta={stream.streamingDelta}
+        reasoningDelta={stream.reasoningDelta}
         expandToolOutputs={expandToolOutputs}
         compactTools={compactTools}
         hideLive={

--- a/packages/plugin-cli/src/session/use-event-stream.ts
+++ b/packages/plugin-cli/src/session/use-event-stream.ts
@@ -7,6 +7,10 @@ export interface EventStreamHandle {
   streamingDelta: string;
   setStreamingDelta: React.Dispatch<React.SetStateAction<string>>;
   streamingBufferRef: React.MutableRefObject<string>;
+  /** Live (un-persisted) thinking stream, throttled like `streamingDelta`. */
+  reasoningDelta: string;
+  setReasoningDelta: React.Dispatch<React.SetStateAction<string>>;
+  reasoningBufferRef: React.MutableRefObject<string>;
   /** Cancel any pending flush (used on /clear, /new, manual resets). */
   cancelStreamFlush: () => void;
 }
@@ -23,6 +27,9 @@ export function useEventStream(session: Session): EventStreamHandle {
   const [streamingDelta, setStreamingDelta] = useState('');
   const streamingBufferRef = useRef('');
   const streamFlushRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [reasoningDelta, setReasoningDelta] = useState('');
+  const reasoningBufferRef = useRef('');
+  const reasoningFlushRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const scheduleStreamFlush = React.useCallback(() => {
     if (streamFlushRef.current) return;
@@ -32,10 +39,22 @@ export function useEventStream(session: Session): EventStreamHandle {
     }, 33);
   }, []);
 
+  const scheduleReasoningFlush = React.useCallback(() => {
+    if (reasoningFlushRef.current) return;
+    reasoningFlushRef.current = setTimeout(() => {
+      reasoningFlushRef.current = null;
+      setReasoningDelta(reasoningBufferRef.current);
+    }, 33);
+  }, []);
+
   const cancelStreamFlush = React.useCallback(() => {
     if (streamFlushRef.current) {
       clearTimeout(streamFlushRef.current);
       streamFlushRef.current = null;
+    }
+    if (reasoningFlushRef.current) {
+      clearTimeout(reasoningFlushRef.current);
+      reasoningFlushRef.current = null;
     }
   }, []);
 
@@ -59,17 +78,32 @@ export function useEventStream(session: Session): EventStreamHandle {
         scheduleStreamFlush();
         return;
       }
+      // reasoning_chunk mirrors assistant_chunk: a high-frequency live
+      // thinking stream that never enters `events` (it isn't persisted).
+      // Buffer + throttle it onto its own delta.
+      if (event.type === 'reasoning_chunk') {
+        reasoningBufferRef.current += event.delta;
+        scheduleReasoningFlush();
+        return;
+      }
       setEvents((prev) => [...prev, event]);
-      if (event.type === 'assistant_message') {
+      if (event.type === 'assistant_message' || event.type === 'reasoning_message') {
         // Cancel any pending flush — the message is in `events` now,
         // so leaving the streaming delta visible would double-render.
+        // The finalized reasoning_message (persisted) supersedes the
+        // live thinking stream, so clear that too here; assistant_message
+        // ends the turn and clears both.
         cancelStreamFlush();
+        reasoningBufferRef.current = '';
+        setReasoningDelta('');
+      }
+      if (event.type === 'assistant_message') {
         streamingBufferRef.current = '';
         setStreamingDelta('');
       }
     });
     return unsub;
-  }, [session, scheduleStreamFlush, cancelStreamFlush]);
+  }, [session, scheduleStreamFlush, scheduleReasoningFlush, cancelStreamFlush]);
 
   return {
     events,
@@ -77,6 +111,9 @@ export function useEventStream(session: Session): EventStreamHandle {
     streamingDelta,
     setStreamingDelta,
     streamingBufferRef,
+    reasoningDelta,
+    setReasoningDelta,
+    reasoningBufferRef,
     cancelStreamFlush,
   };
 }

--- a/packages/plugin-provider-anthropic/src/provider.ts
+++ b/packages/plugin-provider-anthropic/src/provider.ts
@@ -68,12 +68,15 @@ export interface AnthropicProviderConfig {
 // ceiling; sonnet-4-6 is 1M/64k; haiku-4-5 is 200k/64k. fable-5 is Anthropic's most
 // capable model (always-on reasoning); the loop never sets `temperature`, which
 // fable-5/opus-4-8/4.7 reject — so they stream cleanly here, same as opus-4-7 already did.
+// `supportsReasoning` marks models that accept adaptive thinking (`thinking:
+// {type:'adaptive', display:'summarized'}`) — fable-5/opus-4-8/4-7/4-6 and sonnet-4-6
+// do; haiku-4-5 does not (effort/adaptive-thinking error there), so it stays off.
 export const anthropicModels: ReadonlyArray<ModelDescriptor> = [
-  { id: 'claude-fable-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
-  { id: 'claude-opus-4-8', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
-  { id: 'claude-opus-4-7', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
-  { id: 'claude-opus-4-6', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
-  { id: 'claude-sonnet-4-6', contextWindow: 1_000_000, maxOutputTokens: 64_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'claude-fable-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'claude-opus-4-8', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'claude-opus-4-7', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'claude-opus-4-6', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'claude-sonnet-4-6', contextWindow: 1_000_000, maxOutputTokens: 64_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
   { id: 'claude-haiku-4-5-20251001', contextWindow: 200_000, maxOutputTokens: 64_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
 ];
 
@@ -240,6 +243,22 @@ export class AnthropicProvider implements LLMProvider {
       ...(req.temperature !== undefined ? { temperature: req.temperature } : {}),
     };
 
+    // Reasoning: on supported models (gated upstream by `supportsReasoning`),
+    // enable adaptive thinking with summarized display so the model streams a
+    // readable reasoning summary (`display: 'omitted'` — the default — would
+    // stream empty thinking blocks). Adaptive thinking auto-enables interleaved
+    // thinking on the 4.6+ catalog, so no beta header is needed. `effort` maps
+    // to `output_config.effort`. Fields are attached via a cast because the
+    // pinned SDK's `MessageStreamParams` predates these params (same hand-rolled
+    // approach used for system/messages/tools above).
+    const reasoningOn = req.reasoning !== undefined && req.reasoning !== false;
+    if (reasoningOn) {
+      const effort = typeof req.reasoning === 'object' ? req.reasoning.effort : undefined;
+      const body = requestBody as unknown as Record<string, unknown>;
+      body.thinking = { type: 'adaptive', display: 'summarized' };
+      if (effort) body.output_config = { effort };
+    }
+
     // A 401 always arrives before any SSE body, so in OAuth mode we can force
     // a single refresh and replay the request with no risk of duplicate output.
     try {
@@ -284,6 +303,10 @@ export class AnthropicProvider implements LLMProvider {
     // we used to return the first key in `pendingToolUses` for every event,
     // causing two parallel blocks to overwrite each other's partial JSON.
     const blockIndexToId = new Map<number, string>();
+    // Track which block indices are `thinking` blocks so their signature_delta
+    // accumulates and flushes as a reasoning_signature at content_block_stop.
+    const thinkingBlockIndices = new Set<number>();
+    let pendingThinkingSig = '';
     let stopReason: StopReason = 'end_turn';
     let usage: { inputTokens: number; outputTokens: number } | undefined;
 
@@ -322,6 +345,12 @@ export class AnthropicProvider implements LLMProvider {
               const idx = typeof event.index === 'number' ? event.index : blockIndexToId.size;
               blockIndexToId.set(idx, block.id);
               yield { type: 'tool_use_start', id: block.id, name: block.name };
+            } else if (block && block.type === 'thinking') {
+              if (typeof event.index === 'number') thinkingBlockIndices.add(event.index);
+              pendingThinkingSig = '';
+            } else if (block && block.type === 'redacted_thinking') {
+              // No readable text — replay the opaque blob verbatim on round-trip.
+              yield { type: 'reasoning_signature', redacted: true, ...(block.data ? { encrypted: block.data } : {}) };
             }
             break;
           }
@@ -330,6 +359,10 @@ export class AnthropicProvider implements LLMProvider {
             if (!delta) break;
             if (delta.type === 'text_delta' && typeof delta.text === 'string') {
               yield { type: 'text_delta', delta: delta.text };
+            } else if (delta.type === 'thinking_delta' && typeof delta.thinking === 'string') {
+              yield { type: 'reasoning_delta', delta: delta.thinking };
+            } else if (delta.type === 'signature_delta' && typeof delta.signature === 'string') {
+              pendingThinkingSig += delta.signature;
             } else if (delta.type === 'input_json_delta' && typeof delta.partial_json === 'string') {
               const id = idOfBlock(event, blockIndexToId);
               if (id) {
@@ -343,6 +376,12 @@ export class AnthropicProvider implements LLMProvider {
             break;
           }
           case 'content_block_stop': {
+            if (typeof event.index === 'number' && thinkingBlockIndices.has(event.index)) {
+              thinkingBlockIndices.delete(event.index);
+              if (pendingThinkingSig) yield { type: 'reasoning_signature', signature: pendingThinkingSig };
+              pendingThinkingSig = '';
+              break;
+            }
             const id = idOfBlock(event, blockIndexToId);
             if (id) {
               const t = pendingToolUses.get(id);
@@ -441,12 +480,22 @@ interface AnthropicStreamEvent {
       cache_creation_input_tokens?: number;
     };
   };
-  content_block?: { type: 'text' | 'tool_use'; id: string; name: string };
+  content_block?: {
+    type: 'text' | 'tool_use' | 'thinking' | 'redacted_thinking';
+    id: string;
+    name: string;
+    /** redacted_thinking carries an opaque encrypted blob (no readable text). */
+    data?: string;
+  };
   index?: number;
   delta?: {
-    type?: 'text_delta' | 'input_json_delta';
+    type?: 'text_delta' | 'input_json_delta' | 'thinking_delta' | 'signature_delta';
     text?: string;
     partial_json?: string;
+    /** thinking_delta payload (the summarized reasoning text). */
+    thinking?: string;
+    /** signature_delta payload (the thinking-block signature for round-trip). */
+    signature?: string;
     stop_reason?: string;
   };
   usage?: { output_tokens?: number };

--- a/packages/plugin-provider-anthropic/src/translate.ts
+++ b/packages/plugin-provider-anthropic/src/translate.ts
@@ -28,7 +28,12 @@ export type AnthropicContentBlock =
       source: { type: 'base64'; media_type: string; data: string };
       title?: string;
       cache_control?: CacheControl;
-    };
+    }
+  // Reasoning round-trip: a signed `thinking` block (replayed verbatim on the
+  // same model so Anthropic accepts an interleaved-thinking tool-use turn) or a
+  // `redacted_thinking` block carrying only the opaque encrypted blob.
+  | { type: 'thinking'; thinking: string; signature: string; cache_control?: CacheControl }
+  | { type: 'redacted_thinking'; data: string; cache_control?: CacheControl };
 
 export interface AnthropicToolDef {
   name: string;
@@ -153,6 +158,18 @@ function toAnthropicBlock(block: ContentBlock): AnthropicContentBlock {
         type: 'text',
         text: `[audio attachment dropped: ${block.mediaType} not supported by this model]`,
       };
+    case 'reasoning':
+      // Replayed verbatim so Anthropic accepts an interleaved-thinking tool-use
+      // continuation. `redacted` → the opaque encrypted blob; otherwise the
+      // signed thinking block (projection only forwards reasoning that carries a
+      // signature or encrypted blob, so the text fallback below is unreachable).
+      if (block.redacted && block.encrypted) {
+        return { type: 'redacted_thinking', data: block.encrypted };
+      }
+      if (block.signature) {
+        return { type: 'thinking', thinking: block.text, signature: block.signature };
+      }
+      return { type: 'text', text: block.text };
   }
 }
 

--- a/packages/plugin-provider-openai-codex/src/codex/sse-event-handler.test.ts
+++ b/packages/plugin-provider-openai-codex/src/codex/sse-event-handler.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { handleSseEvent } from './sse-event-handler.js';
+import type { PendingFunctionCall, ResponsesSseEvent } from './stream-types.js';
+
+const run = (ev: ResponsesSseEvent, emitReasoning: boolean) =>
+  handleSseEvent(ev, new Map<string, PendingFunctionCall>(), emitReasoning);
+
+describe('handleSseEvent — reasoning summary', () => {
+  it('maps reasoning_summary_text.delta to a reasoning_delta when enabled', () => {
+    const out = run({ type: 'response.reasoning_summary_text.delta', delta: 'planning…' }, true);
+    expect(out.events).toEqual([{ type: 'reasoning_delta', delta: 'planning…' }]);
+  });
+
+  it('drops the reasoning summary entirely when the toggle is off', () => {
+    const out = run({ type: 'response.reasoning_summary_text.delta', delta: 'planning…' }, false);
+    expect(out.events ?? []).toEqual([]);
+  });
+
+  it('captures a reasoning item encrypted_content as a reasoning_signature', () => {
+    const out = run(
+      { type: 'response.output_item.added', item: { type: 'reasoning', encrypted_content: 'blob' } },
+      true,
+    );
+    expect(out.events).toEqual([{ type: 'reasoning_signature', encrypted: 'blob' }]);
+  });
+
+  it('still maps text + function-call events regardless of the reasoning toggle', () => {
+    expect(run({ type: 'response.output_text.delta', delta: 'hi' }, false).events).toEqual([
+      { type: 'text_delta', delta: 'hi' },
+    ]);
+  });
+});

--- a/packages/plugin-provider-openai-codex/src/codex/sse-event-handler.ts
+++ b/packages/plugin-provider-openai-codex/src/codex/sse-event-handler.ts
@@ -17,11 +17,27 @@ import type { PendingFunctionCall, ResponsesSseEvent, SseStepResult } from './st
 export function handleSseEvent(
   ev: ResponsesSseEvent,
   pending: Map<string, PendingFunctionCall>,
+  emitReasoning = false,
 ): SseStepResult {
   const type = ev.type ?? '';
 
   if (type === 'response.output_text.delta' && typeof ev.delta === 'string' && ev.delta) {
     return { events: [{ type: 'text_delta', delta: ev.delta }] };
+  }
+
+  // Reasoning summary text (Codex requests `summary: 'auto'`) → reasoning_delta.
+  // The streamed summary is the visible "thinking" between tool calls. Gated on
+  // the per-provider reasoning toggle; off → discard as before.
+  if (emitReasoning && type === 'response.reasoning_summary_text.delta' && typeof ev.delta === 'string' && ev.delta) {
+    return { events: [{ type: 'reasoning_delta', delta: ev.delta }] };
+  }
+
+  // A `reasoning` output item carries the encrypted_content we must replay
+  // verbatim on the next request (Codex requests `include: ['reasoning.encrypted_content']`).
+  if (emitReasoning && type === 'response.output_item.added' && ev.item?.type === 'reasoning') {
+    return ev.item.encrypted_content
+      ? { events: [{ type: 'reasoning_signature', encrypted: ev.item.encrypted_content }] }
+      : {};
   }
 
   if (type === 'response.output_item.added' && ev.item?.type === 'function_call') {

--- a/packages/plugin-provider-openai-codex/src/codex/stream-consumer.ts
+++ b/packages/plugin-provider-openai-codex/src/codex/stream-consumer.ts
@@ -13,6 +13,7 @@ export function toErrorEvent(err: unknown): ProviderEvent {
 export async function* consumeResponsesSse(
   body: ReadableStream<Uint8Array>,
   signal: AbortSignal | undefined,
+  emitReasoning = false,
 ): AsyncIterable<ProviderEvent> {
   const reader = body.getReader();
   const decoder = new TextDecoder('utf-8');
@@ -62,7 +63,7 @@ export async function* consumeResponsesSse(
             } catch {
               continue;
             }
-            const result = handleSseEvent(json, pending);
+            const result = handleSseEvent(json, pending, emitReasoning);
             if (result.events) {
               for (const ev of result.events) {
                 if (ev.type === 'tool_use_end') sawToolCall = true;

--- a/packages/plugin-provider-openai-codex/src/codex/stream-types.ts
+++ b/packages/plugin-provider-openai-codex/src/codex/stream-types.ts
@@ -17,6 +17,8 @@ export interface ResponsesSseEvent {
     call_id?: string;
     name?: string;
     arguments?: string;
+    /** On a `reasoning` output item: the opaque blob to replay (round-trip). */
+    encrypted_content?: string;
   };
   item_id?: string;
   call_id?: string;

--- a/packages/plugin-provider-openai-codex/src/models.ts
+++ b/packages/plugin-provider-openai-codex/src/models.ts
@@ -6,13 +6,16 @@ import type { ModelDescriptor } from '@moxxy/sdk';
  * still exposes the full catalog; this list is the subset the Codex backend
  * routes to ChatGPT-Pro/Plus subscribers without per-token billing.
  */
+// Every Codex-served model is a gpt-5-family reasoning model, so all advertise
+// `supportsReasoning` — the request already sends `reasoning.summary: 'auto'`;
+// the per-provider toggle decides whether the summary is surfaced.
 export const codexModels: ReadonlyArray<ModelDescriptor> = [
-  { id: 'gpt-5.5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
-  { id: 'gpt-5.4', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
-  { id: 'gpt-5.4-mini', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
-  { id: 'gpt-5.3-codex', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
-  { id: 'gpt-5.3-codex-spark', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
-  { id: 'gpt-5.2', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-5.5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5.4', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5.4-mini', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5.3-codex', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5.3-codex-spark', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5.2', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
 ];
 
 export const DEFAULT_CODEX_MODEL = 'gpt-5.3-codex';

--- a/packages/plugin-provider-openai-codex/src/provider.ts
+++ b/packages/plugin-provider-openai-codex/src/provider.ts
@@ -96,6 +96,12 @@ export class CodexProvider implements LLMProvider {
     }
 
     const sessionId = this.sessionIdProvider();
+    // Reasoning preview is gated by the per-provider toggle (`req.reasoning`):
+    // when off we behave exactly as before (discard reasoning). The per-call
+    // effort, when set, overrides the instance default from provider config.
+    const emitReasoning = req.reasoning != null && req.reasoning !== false;
+    const reqEffort = typeof req.reasoning === 'object' ? req.reasoning.effort : undefined;
+    const reasoningEffort = reqEffort ?? this.reasoningEffort;
     // Pass the session id as the Responses prefix-cache key so repeated turns
     // in a session reuse the cached prefix (cheaper + faster). Codex DOES
     // support this even though the Chat-Completions providers ignore cacheHints.
@@ -103,7 +109,7 @@ export class CodexProvider implements LLMProvider {
       { ...req, model },
       {
         sessionHint: sessionId,
-        ...(this.reasoningEffort ? { reasoningEffort: this.reasoningEffort } : {}),
+        ...(reasoningEffort ? { reasoningEffort } : {}),
       },
     );
 
@@ -143,7 +149,7 @@ export class CodexProvider implements LLMProvider {
       return;
     }
 
-    yield* consumeResponsesSse(response.body, req.signal);
+    yield* consumeResponsesSse(response.body, req.signal, emitReasoning);
   }
 
   async countTokens(

--- a/packages/plugin-provider-openai/src/provider.ts
+++ b/packages/plugin-provider-openai/src/provider.ts
@@ -41,24 +41,29 @@ export interface OpenAIProviderConfig {
  * 2026; verify against https://developers.openai.com/api/docs/models when
  * picking a model for a long-context workload.
  */
+// The gpt-5.x family are reasoning models (`supportsReasoning`): they accept
+// `reasoning_effort` and, on backends that stream a summary, surface reasoning
+// deltas. Official OpenAI Chat Completions doesn't stream a reasoning summary
+// (Responses-API only), so the flag mainly gates the config UI + effort there;
+// OpenAI-compatible reasoning backends (DeepSeek/z.ai/local) do stream it.
 export const openAIModels: ReadonlyArray<ModelDescriptor> = [
   // GPT-5.5 family (released April 23, 2026): newest frontier class.
-  { id: 'gpt-5.5', contextWindow: 1_050_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
-  { id: 'gpt-5.5-pro', contextWindow: 1_050_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-5.5', contextWindow: 1_050_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5.5-pro', contextWindow: 1_050_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
 
   // GPT-5.4 family: cheaper general-purpose tier; -mini and -nano are the
   // new sweet-spot defaults for high-volume agentic workloads.
-  { id: 'gpt-5.4', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
-  { id: 'gpt-5.4-pro', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
-  { id: 'gpt-5.4-mini', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
-  { id: 'gpt-5.4-nano', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-5.4', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5.4-pro', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5.4-mini', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5.4-nano', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
 
   // GPT-5.3-Codex: agentic coding specialist. Vision-capable.
-  { id: 'gpt-5.3-codex', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-5.3-codex', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
 
   // GPT-5.2 and GPT-5: prior reasoning models, configurable effort.
-  { id: 'gpt-5.2', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
-  { id: 'gpt-5', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'gpt-5.2', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
 
   // GPT-4 family: kept for explicit-pin use cases.
   // 4.1 is text-only; 4o/4o-mini are vision + document capable; 4-turbo predates file inputs.
@@ -118,6 +123,13 @@ export class OpenAIProvider implements LLMProvider {
     const usesCompletionTokens = /^(?:gpt-5|o1|o3)/.test(model);
     const tokenLimitKey = usesCompletionTokens ? 'max_completion_tokens' : 'max_tokens';
 
+    // Reasoning preview is gated by the per-provider toggle (`req.reasoning`).
+    // When on, request `reasoning_effort` for OpenAI reasoning models (improves
+    // depth + makes a summary available where the backend streams one) and
+    // surface the streamed reasoning/reasoning_content deltas.
+    const emitReasoning = req.reasoning != null && req.reasoning !== false;
+    const reasoningEffort = typeof req.reasoning === 'object' ? req.reasoning.effort : undefined;
+
     let stream: AsyncIterable<unknown>;
     try {
       stream = (await this.client.chat.completions.create(
@@ -127,6 +139,9 @@ export class OpenAIProvider implements LLMProvider {
           ...(tools ? { tools: tools as never } : {}),
           ...(req.temperature !== undefined ? { temperature: req.temperature } : {}),
           ...(req.maxTokens ? { [tokenLimitKey]: req.maxTokens } : {}),
+          ...(emitReasoning && usesCompletionTokens && reasoningEffort
+            ? { reasoning_effort: reasoningEffort }
+            : {}),
           stream: true,
           // OpenAI only emits the final `usage` chunk when this is set;
           // without it `raw.usage` is null on every chunk and token usage
@@ -174,6 +189,13 @@ export class OpenAIProvider implements LLMProvider {
 
         if (typeof delta.content === 'string' && delta.content) {
           yield { type: 'text_delta', delta: delta.content };
+        }
+
+        if (emitReasoning) {
+          const reasoning = delta.reasoning_content ?? delta.reasoning;
+          if (typeof reasoning === 'string' && reasoning) {
+            yield { type: 'reasoning_delta', delta: reasoning };
+          }
         }
 
         if (delta.tool_calls) {
@@ -256,6 +278,12 @@ interface OpenAIStreamChunk {
     index?: number;
     delta?: {
       content?: string | null;
+      // Reasoning summary streamed by OpenAI-compatible reasoning backends
+      // (DeepSeek-R1, z.ai/GLM, vLLM, Ollama, …). The field name varies by
+      // vendor — handle both. Official OpenAI Chat Completions doesn't stream
+      // it (Responses-API only), so it's simply absent there.
+      reasoning_content?: string | null;
+      reasoning?: string | null;
       tool_calls?: Array<{
         index?: number;
         id?: string;

--- a/packages/plugin-subagents/src/dispatch-agent.ts
+++ b/packages/plugin-subagents/src/dispatch-agent.ts
@@ -127,6 +127,8 @@ function resolveSpec(input: AgentSpecInput, deps: DispatchAgentDeps): SubagentSp
   const merged: SubagentSpec = {
     prompt: input.prompt,
     label: input.label ?? def.name,
+    // The requested kind, surfaced in subagent_* payloads for group rendering.
+    agentType: requested,
   };
   const systemPrompt = input.systemPrompt ?? def.systemPrompt;
   if (systemPrompt !== undefined) (merged as { systemPrompt?: string }).systemPrompt = systemPrompt;

--- a/packages/sdk/src/events.ts
+++ b/packages/sdk/src/events.ts
@@ -49,6 +49,40 @@ export interface AssistantMessageEvent extends EventBase {
   readonly stopReason: 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' | 'error';
 }
 
+/**
+ * A live reasoning/thinking delta. Parallels {@link AssistantChunkEvent}: it is
+ * streamed for the UI's live "thinking…" preview and is NOT retained in the
+ * display log (renderers accumulate it ephemerally, clearing on the matching
+ * {@link ReasoningMessageEvent} or the turn's `assistant_message`). Only
+ * emitted when the active provider+model supports reasoning AND it is enabled
+ * in that provider's config.
+ */
+export interface ReasoningChunkEvent extends EventBase {
+  readonly type: 'reasoning_chunk';
+  readonly delta: string;
+}
+
+/**
+ * A finalized reasoning summary for ONE provider call. Parallels
+ * {@link AssistantMessageEvent}: it is persisted + replayed, and because
+ * `collectProviderStream` runs once per loop round these land between tool
+ * batches (the "summary of the work done between calls" behavior). The
+ * `signature`/`redacted`/`encrypted` fields exist purely for history
+ * round-trip — Anthropic requires the signed `thinking` block be replayed
+ * first on a tool-use continuation; Codex/Anthropic redacted thinking carries
+ * an opaque blob replayed verbatim and never shown.
+ */
+export interface ReasoningMessageEvent extends EventBase {
+  readonly type: 'reasoning_message';
+  readonly content: string;
+  /** Anthropic thinking-block signature; absent for providers that don't sign. */
+  readonly signature?: string;
+  /** True when the reasoning is redacted/encrypted and must not be displayed. */
+  readonly redacted?: boolean;
+  /** Opaque provider blob (Anthropic redacted_thinking data / Codex encrypted_content) replayed as-is. */
+  readonly encrypted?: string;
+}
+
 export interface ToolCallRequestedEvent extends EventBase {
   readonly type: 'tool_call_requested';
   readonly callId: ToolCallId;
@@ -226,6 +260,8 @@ export type MoxxyEvent =
   | UserPromptEvent
   | AssistantChunkEvent
   | AssistantMessageEvent
+  | ReasoningChunkEvent
+  | ReasoningMessageEvent
   | ToolCallRequestedEvent
   | ToolCallApprovedEvent
   | ToolCallDeniedEvent

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -19,6 +19,8 @@ export type {
   UserPromptAttachment,
   AssistantChunkEvent,
   AssistantMessageEvent,
+  ReasoningChunkEvent,
+  ReasoningMessageEvent,
   ToolCallRequestedEvent,
   ToolCallApprovedEvent,
   ToolCallDeniedEvent,

--- a/packages/sdk/src/mode-helpers.ts
+++ b/packages/sdk/src/mode-helpers.ts
@@ -196,6 +196,14 @@ export function projectMessages(
 
   let pendingAssistant: ProviderMessage | null = null;
   let pendingAssistantMaxSeq = -1;
+  // Reasoning block awaiting attachment to the current assistant turn. Only set
+  // for REPLAYABLE reasoning (Anthropic signature / redacted-or-Codex encrypted
+  // blob) — render-only reasoning is never sent back. Attached as content[0] of
+  // the turn's assistant message (Anthropic requires the signed thinking block
+  // first on an interleaved-thinking tool-use continuation; a missing/unsigned
+  // one is a hard 400). Dropped at any turn/compaction boundary it doesn't reach.
+  let pendingReasoning: Extract<ContentBlock, { type: 'reasoning' }> | null = null;
+  let pendingReasoningSeq = -1;
   const flush = (): void => {
     if (!pendingAssistant) return;
     const flushed = pendingAssistant;
@@ -237,6 +245,7 @@ export function projectMessages(
       if (!emittedCompactions.has(compaction)) {
         emittedCompactions.add(compaction);
         flush();
+        pendingReasoning = null;
         messages.push({
           role: 'user',
           content: [{ type: 'text', text: `[summary of earlier turns]\n${compaction.summary}` }],
@@ -249,6 +258,7 @@ export function projectMessages(
     switch (e.type) {
       case 'user_prompt': {
         flush();
+        pendingReasoning = null;
         // Elided + conversational: collapse to a stub (anchor/tiny kept full).
         if (conversationalStubbed(e, el)) {
           messages.push({
@@ -286,9 +296,26 @@ export function projectMessages(
         recordStable(e.seq);
         break;
       }
+      case 'reasoning_message': {
+        // Render-only reasoning (no signature/encrypted) is never replayed —
+        // it exists only for the live/scrollback "Thinking" view. Replayable
+        // reasoning is stashed for content[0] of this turn's assistant message.
+        if (e.signature || e.encrypted) {
+          pendingReasoning = {
+            type: 'reasoning',
+            text: e.content,
+            ...(e.signature ? { signature: e.signature } : {}),
+            ...(e.redacted ? { redacted: true } : {}),
+            ...(e.encrypted ? { encrypted: e.encrypted } : {}),
+          };
+          pendingReasoningSeq = e.seq;
+        }
+        break;
+      }
       case 'assistant_message':
         flush();
         if (conversationalStubbed(e, el)) {
+          pendingReasoning = null;
           messages.push({
             role: 'assistant',
             content: [{ type: 'text', text: conversationalStub('assistant', e.seq) }],
@@ -303,14 +330,31 @@ export function projectMessages(
         // tool_use blocks are projected from tool_call_requested events —
         // which also un-wedges historical logs that already contain one.
         if (e.content.trim().length === 0) {
+          pendingReasoning = null;
           recordStable(e.seq);
           break;
         }
-        messages.push({ role: 'assistant', content: [{ type: 'text', text: e.content }] });
+        {
+          const content: Array<ProviderMessage['content'][number]> = [];
+          if (pendingReasoning) {
+            content.push(pendingReasoning);
+            pendingReasoning = null;
+          }
+          content.push({ type: 'text', text: e.content });
+          messages.push({ role: 'assistant', content });
+        }
         recordStable(e.seq);
         break;
       case 'tool_call_requested': {
-        pendingAssistant ??= { role: 'assistant', content: [] };
+        if (!pendingAssistant) {
+          // Seed the assistant turn so the signed reasoning block is content[0],
+          // ahead of every tool_use (Anthropic's interleaved-thinking ordering).
+          pendingAssistant = { role: 'assistant', content: pendingReasoning ? [pendingReasoning] : [] };
+          if (pendingReasoning) {
+            pendingAssistantMaxSeq = Math.max(pendingAssistantMaxSeq, pendingReasoningSeq);
+            pendingReasoning = null;
+          }
+        }
         pendingAssistantMaxSeq = Math.max(pendingAssistantMaxSeq, e.seq);
         (pendingAssistant.content as Array<ProviderMessage['content'][number]>).push({
           type: 'tool_use',
@@ -361,6 +405,18 @@ export interface StreamResult {
   readonly error: { readonly message: string; readonly retryable: boolean } | null;
   /** Token usage reported by the provider on `message_end`, including cache hits/writes. */
   readonly usage?: TokenUsage;
+  /**
+   * Reasoning/thinking summary for this provider call, when the model emitted
+   * any. The mode emits it as a `reasoning_message` event (so it persists and
+   * round-trips). `signature`/`encrypted` carry Anthropic's signed thinking
+   * block / redacted blob; `redacted` marks display-suppressed reasoning.
+   */
+  readonly reasoning?: {
+    readonly text: string;
+    readonly signature?: string;
+    readonly redacted?: boolean;
+    readonly encrypted?: string;
+  };
 }
 
 /**
@@ -431,12 +487,17 @@ export async function collectProviderStream(
   // message-derived system text. Prefilling it would duplicate the prompt.
   // It stays as the side channel `onBeforeProviderCall` hooks use to inject
   // per-request system text (e.g. the memory consolidation nudge).
+  // Forward the per-provider reasoning preference, but only when THIS model
+  // advertises `supportsReasoning` — providers ignore the knob otherwise, but
+  // gating here keeps requests clean and avoids unsupported-param errors.
+  const reqReasoning = descriptor?.supportsReasoning ? ctx.reasoning : undefined;
   const req = {
     model: ctx.model,
     messages: effectiveMessages,
     ...(toolList ? { tools: toolList } : {}),
     ...(cacheHints && cacheHints.length > 0 ? { cacheHints } : {}),
     ...(opts.maxTokens !== undefined ? { maxTokens: opts.maxTokens } : {}),
+    ...(reqReasoning ? { reasoning: reqReasoning } : {}),
     signal: ctx.signal,
   };
   const transformed = await ctx.hooks.dispatchBeforeProviderCall(req, {
@@ -453,6 +514,14 @@ export async function collectProviderStream(
   let stopReason: StopReason = 'end_turn';
   let error: StreamResult['error'] = null;
   let usage: TokenUsage | undefined;
+  // Reasoning/thinking accumulation for this single provider call. Emitted as a
+  // finalized `reasoning_message` by the mode (turn-iterator / goal-loop) so it
+  // persists and round-trips; `signature`/`encrypted` carry Anthropic's signed
+  // thinking block / redacted blob for replay.
+  let reasoningText = '';
+  let reasoningSignature: string | undefined;
+  let reasoningRedacted = false;
+  let reasoningEncrypted: string | undefined;
 
   let stream: AsyncIterable<ProviderEvent>;
   try {
@@ -498,6 +567,25 @@ export async function collectProviderStream(
           error = { message: event.message, retryable: event.retryable };
           break;
         }
+        case 'reasoning_delta': {
+          reasoningText += event.delta;
+          // Live preview only — parallels `assistant_chunk`; renderers
+          // accumulate ephemerally and clear on the finalized reasoning_message.
+          await ctx.emit({
+            type: 'reasoning_chunk',
+            sessionId: ctx.sessionId,
+            turnId: ctx.turnId,
+            source: 'model',
+            delta: event.delta,
+          });
+          break;
+        }
+        case 'reasoning_signature': {
+          if (event.signature) reasoningSignature = event.signature;
+          if (event.encrypted) reasoningEncrypted = event.encrypted;
+          if (event.redacted) reasoningRedacted = true;
+          break;
+        }
         case 'message_start':
         case 'tool_use_delta':
         default:
@@ -516,7 +604,25 @@ export async function collectProviderStream(
     if (!partial.name) continue;
     finalToolUses.push({ id, name: partial.name, input: partial.input ?? {} });
   }
-  return { text, toolUses: finalToolUses, stopReason, error, ...(usage ? { usage } : {}) };
+  // Surface reasoning when there's visible text OR an opaque blob to replay
+  // (a redacted_thinking block has no text but must still round-trip).
+  const reasoning =
+    reasoningText.trim().length > 0 || reasoningEncrypted
+      ? {
+          text: reasoningText,
+          ...(reasoningSignature ? { signature: reasoningSignature } : {}),
+          ...(reasoningRedacted ? { redacted: true } : {}),
+          ...(reasoningEncrypted ? { encrypted: reasoningEncrypted } : {}),
+        }
+      : undefined;
+  return {
+    text,
+    toolUses: finalToolUses,
+    stopReason,
+    error,
+    ...(usage ? { usage } : {}),
+    ...(reasoning ? { reasoning } : {}),
+  };
 }
 
 /**

--- a/packages/sdk/src/mode.ts
+++ b/packages/sdk/src/mode.ts
@@ -77,6 +77,13 @@ export interface ModeContext {
   readonly elision?: ElisionSettings;
   /** When true, send only always-on + loaded tool schemas; index the rest. */
   readonly lazyTools?: boolean;
+  /**
+   * Per-provider reasoning/thinking preference, resolved from the active
+   * provider's config at session build. Forwarded to the provider as
+   * `ProviderRequest.reasoning` by {@link collectProviderStream}, gated on the
+   * active model's `supportsReasoning`. Absent/false → reasoning off.
+   */
+  readonly reasoning?: { readonly effort?: 'low' | 'medium' | 'high' } | boolean;
   readonly permissions: PermissionResolver;
   /**
    * Optional generic "ask the user a question" gate. Any loop strategy can

--- a/packages/sdk/src/provider.ts
+++ b/packages/sdk/src/provider.ts
@@ -19,7 +19,24 @@ export type ContentBlock =
    * to a text placeholder. Text/Office files are inlined as `text` instead — only
    * formats a model ingests as bytes become `document` blocks.
    */
-  | { readonly type: 'document'; readonly mediaType: string; readonly data: string; readonly name?: string };
+  | { readonly type: 'document'; readonly mediaType: string; readonly data: string; readonly name?: string }
+  /**
+   * A model reasoning/thinking block, preserved in conversation history so it
+   * can be replayed on the next request. Anthropic REQUIRES the signed
+   * `thinking` block be sent back (as the first block of an assistant turn that
+   * also carries tool_use) on an interleaved-thinking continuation — a missing
+   * or unsigned block is a hard 400, so the loop drops unsigned reasoning from
+   * what it replays. `redacted` blocks carry only `encrypted` (the opaque blob)
+   * and `text: ''`; they are replayed verbatim, never shown. Providers without
+   * reasoning ignore this block.
+   */
+  | {
+      readonly type: 'reasoning';
+      readonly text: string;
+      readonly signature?: string;
+      readonly redacted?: boolean;
+      readonly encrypted?: string;
+    };
 
 /**
  * Provider-neutral instruction for where a prompt-cache breakpoint should be
@@ -56,6 +73,15 @@ export interface ProviderRequest {
   readonly signal?: AbortSignal;
   /** Where to place prompt-cache breakpoints. Set by the active CacheStrategy. */
   readonly cacheHints?: ReadonlyArray<CacheHint>;
+  /**
+   * Request reasoning/thinking from the model. `false`/absent = off. Providers
+   * gate on this AND the model descriptor's `supportsReasoning`; unsupported
+   * providers/models ignore it. The loop sets it from the active provider's
+   * reasoning config (see the per-provider reasoning setting). `effort` maps to
+   * each provider's native knob (Anthropic thinking budget, OpenAI/Codex
+   * `reasoning.effort`).
+   */
+  readonly reasoning?: { readonly effort?: 'low' | 'medium' | 'high' } | boolean;
 }
 
 export type ProviderEvent =
@@ -65,7 +91,17 @@ export type ProviderEvent =
   | { readonly type: 'tool_use_delta'; readonly id: string; readonly partialInput: string }
   | { readonly type: 'tool_use_end'; readonly id: string; readonly input: unknown }
   | { readonly type: 'message_end'; readonly stopReason: 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' | 'error'; readonly usage?: TokenUsage }
-  | { readonly type: 'error'; readonly message: string; readonly retryable: boolean };
+  | { readonly type: 'error'; readonly message: string; readonly retryable: boolean }
+  /** A streamed reasoning/thinking text delta (visible summary). */
+  | { readonly type: 'reasoning_delta'; readonly delta: string }
+  /**
+   * End-of-reasoning-block metadata for history round-trip, emitted once per
+   * reasoning block. `signature` is Anthropic's thinking-block signature;
+   * `encrypted` carries an opaque blob (Anthropic redacted_thinking data /
+   * Codex reasoning encrypted_content) that must be replayed verbatim;
+   * `redacted` marks reasoning that must never be displayed.
+   */
+  | { readonly type: 'reasoning_signature'; readonly signature?: string; readonly redacted?: boolean; readonly encrypted?: string };
 
 export interface TokenUsage {
   readonly inputTokens: number;
@@ -101,6 +137,13 @@ export interface ModelDescriptor {
    * the transcript as text instead.
    */
   readonly supportsAudio?: boolean;
+  /**
+   * Whether this model can emit reasoning/thinking summaries (Anthropic
+   * extended thinking, OpenAI o-series / Codex reasoning). Gates the
+   * per-provider reasoning config UI and whether the loop requests reasoning
+   * for this model. When false, `ProviderRequest.reasoning` is ignored.
+   */
+  readonly supportsReasoning?: boolean;
 }
 
 export interface LLMProvider {

--- a/packages/sdk/src/subagent.ts
+++ b/packages/sdk/src/subagent.ts
@@ -27,6 +27,12 @@ export interface SubagentSpec {
   /** Human-readable label surfaced in `subagent_*` event payloads. */
   readonly label?: string;
   /**
+   * Named kind this child was spawned as (e.g. `'Explore'`, `'code-reviewer'`).
+   * Surfaced in `subagent_*` payloads so sibling agents of the same kind group
+   * under one collapsible header. Defaults to `'default'`.
+   */
+  readonly agentType?: string;
+  /**
    * When true, the child session stays alive after the first turn for
    * {@link SubagentSpawner.continue}. `subagent_completed` is deferred until
    * continue or release. Used by the workflow `awaitInput` pause/resume flow.


### PR DESCRIPTION
## What

Two transparency features the user asked for:

### 1. Visible reasoning (per-provider, Codex-style between calls)
Instead of staring at a silent "thinking…" indicator, the model's reasoning now **streams live** and is kept as a **dim, collapsible "Thinking" block** interleaved with the tool calls it precedes. Because reasoning is finalized once per provider round, summaries land naturally between tool batches.

- Gated per model via a new `ModelDescriptor.supportsReasoning`; enabled with `config.context.reasoning` (`true` or `{ effort: 'low' | 'medium' | 'high' }`).
- **Anthropic / Claude Code** — adaptive thinking with summarized display; the signed thinking block round-trips so interleaved-thinking tool-use continuations stay valid.
- **OpenAI Codex** — surfaces the reasoning summary it already requested (previously discarded), gated on the toggle.
- **OpenAI** — `reasoning_effort` for the gpt-5 family + the `reasoning_content` summary that OpenAI-compatible reasoning backends stream.

New SDK surface: a `reasoning` `ContentBlock`, `reasoning_delta`/`reasoning_signature` `ProviderEvent`s, `reasoning_chunk`/`reasoning_message` events, `ProviderRequest.reasoning`, and `ModelDescriptor.supportsReasoning`. **No runner protocol bump** — reasoning events ride the existing event channel.

### 2. Grouped sub-agents view
A `dispatch_agent` fan-out now renders as **one collapsible group** — a header (`N Explore agents finished`) over a tree of per-agent rows showing each agent's tool-use count, **token usage**, and status — instead of one block per child. Per-agent token totals and the agent kind are forwarded on the `subagent_*` events; both desktop and TUI render the new tree.

## How it's wired
Provider stream parsers → SDK `reasoning_*` events → `collectProviderStream` (runs once per round, so reasoning interleaves between tool batches) → `projectMessages` prepends the signed reasoning block as `content[0]` for Anthropic round-trip → `chat-model` projection (`reasoning_message` block + `SubagentGroupBlock` fold) → `client-core` `streamingReasoning` → desktop + TUI rendering.

## Verification
- Build 59/59, typecheck 116/116, lint 0 errors, `check:deps` clean, tests 113/113 + scripts 8/8.
- New tests: reasoning accumulation/clear (`client-core`), Codex reasoning-summary gating, sub-agent group folding (consecutive fold, group-break, tokens/agentType/mixed/running-not-settled).

## Follow-ups (logged in TECH_DEBT.md → "Reasoning + sub-agent-groups intake")
Desktop Settings reasoning control isn't live-wired to the runner yet (CLI `config.context.reasoning` is the functional path); session-level (not per-provider-granular) config; Codex/OpenAI reasoning not round-tripped; Anthropic multi-block thinking collapses to one round-trip block.