### PR TITLE
ci(release): pin Python 3.11 so desktop-build can compile node-pty

### DIFF
--- a/.changeset/pin-python-node-pty.md
+++ b/.changeset/pin-python-node-pty.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci(release): pin Python 3.11 on the desktop-build runners so node-gyp can compile `node-pty`. Python 3.12 (now the default on `macos-latest`, `ubuntu-24.04`, and `windows-latest`) dropped the `distutils` stdlib module that `node-gyp@9` imports, which broke both `pnpm install` and electron-builder's `@electron/rebuild`. CI-only change — releases no package.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,19 @@ jobs:
           node-version: '22.x'
           cache: pnpm
 
+      # node-pty (a real dep of @moxxy/cli, bundled into the desktop) compiles
+      # from source via node-gyp@9, which imports Python's `distutils`. That
+      # module was removed from the stdlib in Python 3.12 — now the default
+      # `python3` on macos-latest, ubuntu-24.04, and windows-latest — so the
+      # native build fails with "No module named 'distutils'" both at
+      # `pnpm install` (node-pty is in onlyBuiltDependencies) and again at
+      # electron-builder's @electron/rebuild. Pin 3.11, the last release that
+      # still ships distutils, on every leg so node-gyp resolves it.
+      - name: Setup Python (node-gyp needs distutils)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Problem

The agentic-surfaces work added `packages/plugin-terminal`, which pulls **`node-pty@1.1.0`** into the tree as a real dependency of `@moxxy/cli` (bundled into the desktop). `node-pty` has no Electron-ABI prebuilds, so it compiles from source via **`node-gyp@9.4.1`**, which still `import`s Python's **`distutils`**.

`distutils` was removed from the stdlib in **Python 3.12** — now the default `python3` on `macos-latest` (and `ubuntu-24.04` / `windows-latest`). So the `release` workflow's `desktop-build` job fails:

```
ModuleNotFoundError: No module named 'distutils'
⨯ node-gyp failed to rebuild '.../node-pty@1.1.0/node_modules/node-pty'
```

It bites at two points on every leg of the matrix: `pnpm install` (node-pty is in root `pnpm.onlyBuiltDependencies`) and, fatally, electron-builder's `@electron/rebuild`.

## Fix

Add one step to the `desktop-build` job — pin **Python 3.11** (the last release that still ships `distutils`) via `actions/setup-python@v5`, before `Install dependencies`. It applies to all three matrix legs and covers both compile points. The reported error is purely `distutils`, so satisfying it lets `node-gyp`'s configure proceed.

## Scope

- `ci.yml` is untouched — it's Linux-only and doesn't package the desktop; a failed `node-pty` build there is a non-fatal pnpm warning (plugin-terminal tests use the piped fallback).
- Considered bumping `node-gyp` to v10 or installing `setuptools` instead; the Python-3.11 pin is the canonical, lowest-risk fix without setuptools-version or electron-rebuild↔node-gyp compatibility risk.

Empty changeset — CI-only, releases no package.