### PR TITLE
chore: drop stray empty changeset to unblock the desktop release

### DIFF
--- a/.changeset/pin-python-node-pty.md
+++ b/.changeset/pin-python-node-pty.md
@@ -1,4 +1,0 @@
----
----
-
-ci(release): pin Python 3.11 on the desktop-build runners so node-gyp can compile `node-pty`. Python 3.12 (now the default on `macos-latest`, `ubuntu-24.04`, and `windows-latest`) dropped the `distutils` stdlib module that `node-gyp@9` imports, which broke both `pnpm install` and electron-builder's `@electron/rebuild`. CI-only change — releases no package.


### PR DESCRIPTION
## What

Removes `.changeset/pin-python-node-pty.md` — the empty changeset added in #200.

## Why — this forces the stranded desktop release

Two things are currently blocking a desktop release:

1. **Desktop `0.8.0` was never cut.** The #198 Version-PR merge (which bumped `apps/desktop/package.json` to `0.8.0`) **did not trigger a Release run**, so the `cut` step never ran — there is no `desktop-v0.8.0` tag (latest is `desktop-v0.7.2`).
2. **The empty changeset blocks `cut`.** The release workflow only cuts a desktop release when `steps.changesets.outputs.hasChangesets == 'false'`. A present changeset file — even an empty one — makes `changesets/action` report `hasChangesets == 'true'` (it logs *"All changesets are empty; not creating PR"* and won't open a Version PR to consume it). So `cut` is skipped on every push, which is why merging #200 built nothing.

## Effect of merging this

The push to `main` runs the release workflow in **publish mode** (no changesets → `hasChangesets == 'false'`):

- `cut` reads `apps/desktop/package.json` → `0.8.0`, finds no `desktop-v0.8.0` tag → `release=true`.
- The `desktop-build` matrix runs **with the node-pty / Python 3.11 fix from #200**, builds the installers, and `desktop-release` pushes `desktop-v0.8.0` + creates the GitHub Release.

This is exactly the pipeline's intended recovery path ("a failed/missing build leaves no tag; the next publish run re-cuts it").

## Note

The "Changeset present" check will go red here (this PR intentionally adds no changeset). It is **not a required status check** on `main`, so it does not block merge. This is a release-plumbing change that ships no package on its own — the desktop ships because `0.8.0` is already bumped on `main`.