### PR TITLE
fix(release): pin desktop Windows build to windows-2022 (node-gyp vs VS2026)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,15 @@ jobs:
         include:
           - os: macos-latest
             artifact: dmg
-          - os: windows-latest
+          # Pinned to windows-2022, NOT windows-latest. `windows-latest` now
+          # resolves to the windows-2025-vs2026 image, which ships Visual
+          # Studio 2026 — and node-gyp@9.4.1 (what @electron/rebuild drives to
+          # compile node-pty against Electron's ABI) only recognises VS up to
+          # 2022, so it fails with "Could not find any Visual Studio
+          # installation to use". windows-2022 carries VS2022, which node-gyp
+          # detects. Revisit when node-gyp is upgraded to a VS2026-aware
+          # release (see TECH_DEBT) and this can return to windows-latest.
+          - os: windows-2022
             artifact: exe
           - os: ubuntu-latest
             artifact: deb-appimage
@@ -209,7 +217,7 @@ jobs:
       # node-pty (a real dep of @moxxy/cli, bundled into the desktop) compiles
       # from source via node-gyp@9, which imports Python's `distutils`. That
       # module was removed from the stdlib in Python 3.12 — now the default
-      # `python3` on macos-latest, ubuntu-24.04, and windows-latest — so the
+      # `python3` on the current macOS / Ubuntu / Windows runner images — so the
       # native build fails with "No module named 'distutils'" both at
       # `pnpm install` (node-pty is in onlyBuiltDependencies) and again at
       # electron-builder's @electron/rebuild. Pin 3.11, the last release that

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -37,6 +37,21 @@ pass also **retired the plugins-admin CLI install-hardening + dedup items** (for
 
 ---
 
+## 2026-06-17 — desktop native build (node-gyp) is brittle against runner-image churn
+
+- **`node-gyp@9.4.1` is too old for the current GitHub runner images, and the desktop
+  release build (electron-builder → `@electron/rebuild` → node-gyp, rebuilding `node-pty`
+  against Electron's ABI) papers over it with two CI pins rather than fixing the root.**
+  Two breakages, same cause: (1) macOS/Linux runners default to Python 3.12, which dropped
+  `distutils` that node-gyp@9 imports → pinned Python 3.11 in `release.yml` (#200); (2)
+  `windows-latest` moved to the `windows-2025-vs2026` image (Visual Studio 2026), which
+  node-gyp@9's VS finder doesn't recognise → pinned the Windows leg to `windows-2022`
+  (this change). **Real fix:** bump `node-gyp` to a VS2026-aware / Python-3.12-native
+  release (≥10, likely 11) via a `pnpm.overrides` entry + lockfile regen, verify
+  `@electron/rebuild@3.6.1` drives it cleanly on all three legs, then drop the Python pin
+  and return the Windows leg to `windows-latest`. Until then both pins will silently rot
+  as the pinned images age out.
+
 ## 2026-06-17 — desktop OAuth provider sign-in (claude-code) + de-hardcoded auth kind
 
 - **Retired: Settings → Providers showed a dead "run `moxxy login <provider>` in a


### PR DESCRIPTION
## Problem

The desktop release build's Windows leg fails at electron-builder's `@electron/rebuild` step:

```
• executing @electron/rebuild  electronVersion=33.4.11 arch=x64
• preparing  moduleName=node-pty arch=x64
Error: Could not find any Visual Studio installation to use
    at VisualStudioFinder.fail (node-gyp@9.4.1/.../find-visualstudio.js:122:47)
⨯ node-gyp failed to rebuild '...node-pty'
ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "electron-builder" not found
```

**Root cause:** `windows-latest` now resolves to the **`windows-2025-vs2026`** runner image, which ships **Visual Studio 2026**. `node-gyp@9.4.1` (driven by `@electron/rebuild` to compile `node-pty` against Electron's ABI) only recognises VS up to 2022, so its finder reports no usable install.

This is Windows-specific: with the Python 3.11 pin from #200, **macOS and Linux already build cleanly** (verified on the last release run — both green; only Windows failed).

## Fix

Pin the desktop Windows matrix leg to **`windows-2022`** (VS2022, which node-gyp 9.4.1 detects). macOS/Linux stay on `*-latest`. No lockfile change, no impact on the working legs.

## Follow-up (logged in TECH_DEBT.md)

The durable fix is to upgrade `node-gyp` (≥10/11, VS2026- and Python-3.12-aware) via a `pnpm.overrides` entry + lockfile regen, then drop both CI pins (Python 3.11 and `windows-2022`). Done here as a runner pin to unblock the release without lockfile churn.

## Note

The "Changeset present" check will be red (this PR adds no changeset, to avoid re-stranding the desktop `cut` step — see #201). It is **not a required status check** on `main`. Merging this triggers a publish-mode run that re-cuts the still-untagged `desktop-v0.8.0` with all three legs green.