### PR TITLE
fix(desktop): align Skills settings tab with MCP/Vault (drop logo hero)

### DIFF
--- a/.changeset/skills-tab-empty-state.md
+++ b/.changeset/skills-tab-empty-state.md
@@ -1,0 +1,5 @@
+---
+"@moxxy/desktop": patch
+---
+
+desktop: the Skills settings tab now matches the MCP and Vault tabs. Its empty state uses the shared compact icon + text `EmptyState` instead of a bespoke hero with an oversized animated logo and duplicate create buttons; the create/generate actions already live in the shared tab header.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -37,6 +37,19 @@ pass also **retired the plugins-admin CLI install-hardening + dedup items** (for
 
 ---
 
+## 2026-06-17 — Skills gallery reimplements the shared settings `SearchBox`
+
+- **`SkillGallery` hand-rolls its own search input** (the `display:flex` row with
+  the magnifier `Icon` + `<input type="search">` in `apps/desktop/src/settings/skills/SkillGallery.tsx`)
+  instead of using the `SearchBox` primitive already exported from
+  `apps/desktop/src/settings/settings-primitives.tsx` for the MCP/Vault/Providers
+  tabs. The markup is a near-verbatim copy, so styling drift between the Skills
+  search and the other tabs' search is a when-not-if. Noticed while aligning the
+  Skills empty state to the shared `EmptyState` (this change retired the bespoke
+  `EmptyHero` logo). **Fix:** swap the inline block for `<SearchBox value={query}
+  onChange={setQuery} placeholder="Search skills…" />` and delete the duplicate.
+  Left out of this PR to keep it a pure empty-state alignment.
+
 ## 2026-06-17 — desktop native build (node-gyp) is brittle against runner-image churn
 
 - **`node-gyp@9.4.1` is too old for the current GitHub runner images, and the desktop

--- a/apps/desktop/src/settings/skills/SkillGallery.tsx
+++ b/apps/desktop/src/settings/skills/SkillGallery.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react';
 import { Button, Icon } from '@moxxy/desktop-ui';
 import type { useSettings } from '@moxxy/client-core';
 import { TabHeader } from '../TabHeader';
-import { EmptyHero } from './heroes';
+import { EmptyState } from '../settings-primitives';
 
 export function SkillGallery({
   skills,
@@ -85,7 +85,7 @@ export function SkillGallery({
       )}
 
       {skills.length === 0 ? (
-        <EmptyHero onCreate={onCreate} onGenerate={onGenerate} />
+        <EmptyState icon="spark" text="No skills yet." />
       ) : shown.length === 0 ? (
         <p style={{ margin: 0, padding: '24px 4px', fontSize: 13, color: 'var(--color-text-dim)' }}>
           No skills match “{query}”.

--- a/apps/desktop/src/settings/skills/heroes.tsx
+++ b/apps/desktop/src/settings/skills/heroes.tsx
@@ -1,54 +1,9 @@
 /**
- * Empty / loading states for the Skills tab. EmptyHero greets a user with no
- * skills yet (avatar + the two create paths); LoadingHero is the spinner shown
- * inside the editor while a skill's body streams in from disk.
+ * Loading state for the Skills editor — the spinner shown inside the editor
+ * while a skill's body streams in from disk.
  */
 
-import { Button, Icon } from '@moxxy/desktop-ui';
 import { asset } from '@/lib/asset';
-
-export function EmptyHero({
-  onCreate,
-  onGenerate,
-}: {
-  readonly onCreate: () => void;
-  readonly onGenerate: () => void;
-}): JSX.Element {
-  return (
-    <div
-      style={{
-        height: '100%',
-        display: 'grid',
-        placeItems: 'center',
-        padding: 24,
-        textAlign: 'center',
-      }}
-    >
-      <div>
-        <img
-          src={asset('new-animation.gif')}
-          alt=""
-          aria-hidden
-          style={{ width: 140, height: 'auto', imageRendering: 'pixelated', marginBottom: 14 }}
-        />
-        <h3 style={{ margin: 0, fontSize: 17, fontWeight: 700 }}>Compose a new skill</h3>
-        <p style={{ margin: '6px 0 16px', color: 'var(--color-text-dim)', fontSize: 13 }}>
-          Skills are Markdown files I'll read on demand to learn how to do something specific.
-        </p>
-        <div style={{ display: 'flex', gap: 8, justifyContent: 'center' }}>
-          <Button variant="cta" onClick={onCreate} style={{ padding: '10px 16px' }}>
-            <Icon name="plus" size={14} />
-            Blank skill
-          </Button>
-          <Button variant="secondary" onClick={onGenerate} style={{ padding: '10px 16px' }}>
-            <Icon name="spark" size={14} />
-            Generate with AI
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 export function LoadingHero(): JSX.Element {
   return (


### PR DESCRIPTION
## What

The Skills settings tab now matches the MCP / Vault / Providers tabs.

Its empty state used a bespoke `EmptyHero` — an oversized pixelated animated logo (`new-animation.gif`), a heading, a paragraph, and a duplicate pair of create buttons. Every other settings tab uses the shared compact `EmptyState` (a dashed-border box with an icon + one line of text). Skills now uses that same `EmptyState` (`spark` icon + "No skills yet.").

The now-unused `EmptyHero` is removed from `skills/heroes.tsx`. `LoadingHero` (the transient spinner shown inside the skill editor while a body streams in from disk) is untouched — the other tabs have no editor to compare it against.

## Why

The big animated logo made the Skills tab look inconsistent with the rest of Settings. The shared header (`TabHeader`) was already common to all tabs; only the empty state diverged. The "Generate with AI" / "New skill" actions already live in that header (mirroring "Add server" / "Add key"), so dropping the hero's inline buttons loses no functionality.

The app-wide `new-animation.gif` (onboarding, chat, connection screen) is untouched.

## Verification

- `pnpm build` — 64/64 ✓
- `pnpm typecheck` — 126/126 ✓
- `pnpm lint` — 0 errors (pre-existing warnings only) ✓
- `pnpm test` — 123/123 turbo + 8/8 scripts ✓
- `pnpm check:deps` — no violations (656 modules) ✓
- Changeset added (`@moxxy/desktop` patch).
- TECH_DEBT: logged that `SkillGallery` reimplements the shared `SearchBox` primitive inline (left out of this PR to keep it a pure empty-state alignment).