### PR TITLE
Quality sweep wave 3 — performance (EventLog index · incremental fold · quadratic fixes), golden-tested

### DIFF
--- a/.changeset/incremental-block-fold.md
+++ b/.changeset/incremental-block-fold.md
@@ -1,0 +1,27 @@
+---
+'@moxxy/chat-model': patch
+'@moxxy/client-core': patch
+'@moxxy/plugin-cli': patch
+'@moxxy/desktop': patch
+---
+
+perf(chat-model): incrementalize the per-turn block fold (kill the O(n²)/turn re-fold)
+
+Both the desktop Transcript and the TUI ChatView re-folded the ENTIRE growing
+event array via `pairToolEvents` on every committed event — k full O(n) walks
+per turn, degrading to O(n²) over a session. The fold body is now lifted into a
+reusable `stepFold(state, event)` (the verbatim old loop body) shared by the
+batch `pairToolEvents` and a new `IncrementalFold` that keeps the folded block
+tree alive across renders and re-folds only the unsettled tail past a
+`(version, prefixLength)` high-water mark. `syncTo` extends the prefix on a pure
+append and rebuilds only when it shifts (scroll-up prepend, /clear). A golden
+test feeds many recorded sequences (skill scopes, live tools, subagents, orphan
+results, reasoning, file diffs) one event at a time and asserts the incremental
+tree is byte-identical to `pairToolEvents(fullPrefix)` after EVERY event, plus a
+counter assertion that a k-event turn does O(k) — not O(k²) — step work.
+
+Also: the TUI settled-prefix scan resumes from its high-water mark instead of
+re-walking from index 0; `WorkflowCanvas` memoizes `topoOrder` on a geometry-free
+topology signature so a node drag no longer recomputes the O(V+E) fold per
+mousemove; and `usage.perCall` is head-capped at 200 entries (lossless for the
+meter — totals still fold every call).

--- a/.changeset/quality-sweep-perf.md
+++ b/.changeset/quality-sweep-perf.md
@@ -1,0 +1,29 @@
+---
+"@moxxy/sdk": patch
+"@moxxy/cli": patch
+"@moxxy/desktop": patch
+---
+
+Performance pass (audit-driven, golden-tested for byte-identity)
+
+Algorithmic-complexity fixes; every algorithm-shape change is guarded by a test
+asserting the new path is byte-identical to the old, so behaviour is unchanged.
+
+- **Event log / projection (`@moxxy/sdk`, `@moxxy/core`, `@moxxy/runner`):**
+  index `EventLog.ofType`/`byTurn` (O(n) filter → O(matches), property-tested
+  equal to the old filter); `applyLazyTools` single-partition + index-backed
+  loaded-tool scan; `projectMessages` binary-cursor compaction-range lookup;
+  `computeElisionState` fused passes + no redundant sort; `surfaceInputParamsSchema`
+  O(keys) size guard instead of `JSON.stringify` per frame.
+- **Chat-model block fold (`@moxxy/chat-model`, `@moxxy/client-core`, TUI,
+  desktop):** the O(n²)/turn re-fold is now incremental — only the unsettled tail
+  re-folds, keyed on a high-water mark — with a golden test feeding events one at
+  a time and asserting deep-equality with a full re-fold after every event. Bounds
+  the live in-memory log / `seenIds` / `usage.perCall`; memoizes the workflow
+  canvas topology so a node drag no longer recomputes it per pointer-move.
+- **Quadratic / unbounded hotspots:** `UsagePanel` peak via reduce (was a
+  `Math.max(...series)` spread that RangeError'd on long sessions), `grep` file
+  size cap + binary skip, `StreamingPreview` incremental last-line (fixed an
+  infinite loop on leading-newline content), terminal sentinel-regex compiled
+  once + tail scan, webhooks parse-body-once, scheduler batched schedule
+  reconcile, `runProcess` concat-once, and a one-time session-log `ensureReady`.

--- a/apps/desktop/src/chat/ChatSurface.search.test.ts
+++ b/apps/desktop/src/chat/ChatSurface.search.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MoxxyEvent } from '@moxxy/sdk';
+import { buildSearchIndex, filterEventsBySearch } from './ChatSurface';
+
+/** The ORIGINAL inline predicate, verbatim, as the golden reference. */
+function refFilter(events: ReadonlyArray<MoxxyEvent>, searchQuery: string): ReadonlyArray<MoxxyEvent> {
+  const q = searchQuery.toLowerCase();
+  return events.filter((e) => {
+    if (e.type === 'user_prompt') return e.text.toLowerCase().includes(q);
+    if (e.type === 'assistant_message') return e.content.toLowerCase().includes(q);
+    if (e.type === 'tool_call_requested') {
+      return e.name.toLowerCase().includes(q) || JSON.stringify(e.input).toLowerCase().includes(q);
+    }
+    if (e.type === 'error') return e.message.toLowerCase().includes(q);
+    return false;
+  });
+}
+
+function ev(partial: Partial<MoxxyEvent> & { type: string }): MoxxyEvent {
+  return { seq: 0, id: 'x', ts: 0, ...partial } as unknown as MoxxyEvent;
+}
+
+const log: ReadonlyArray<MoxxyEvent> = [
+  ev({ type: 'user_prompt', text: 'Please WRITE the config file' }),
+  ev({ type: 'assistant_message', content: 'Sure, writing it now' }),
+  ev({ type: 'tool_call_requested', name: 'Write', input: { path: '/etc/Config.json', body: 'NEEDLE' } }),
+  ev({ type: 'tool_call_requested', name: 'Bash', input: { command: 'ls -la' } }),
+  ev({ type: 'error', message: 'EACCES: permission denied' }),
+  ev({ type: 'tool_result', output: 'NEEDLE in a non-searchable event' }), // not indexed → []
+];
+
+describe('ChatSurface search helpers — byte-identical to the inline predicate', () => {
+  const queries = ['', 'write', 'WRITE', 'needle', 'config', 'bash', 'ls -la', 'denied', 'nomatch', '/etc/'];
+
+  it.each(queries)('query=%j', (q) => {
+    const index = buildSearchIndex(log);
+    expect(filterEventsBySearch(log, index, q)).toEqual(refFilter(log, q));
+  });
+
+  it('does not JSON.stringify on the per-keystroke (filter) path', () => {
+    const index = buildSearchIndex(log); // index build is allowed to stringify
+    const spy = vi.spyOn(JSON, 'stringify');
+    for (const q of ['n', 'ne', 'nee', 'need', 'needle']) {
+      filterEventsBySearch(log, index, q);
+    }
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('reuses one index across many keystrokes', () => {
+    const spy = vi.spyOn(JSON, 'stringify');
+    const index = buildSearchIndex(log);
+    const callsAfterBuild = spy.mock.calls.length;
+    for (const q of ['a', 'ab', 'abc']) filterEventsBySearch(log, index, q);
+    // No additional stringify calls after the one-time index build.
+    expect(spy.mock.calls.length).toBe(callsAfterBuild);
+    spy.mockRestore();
+  });
+});

--- a/apps/desktop/src/chat/ChatSurface.tsx
+++ b/apps/desktop/src/chat/ChatSurface.tsx
@@ -26,6 +26,42 @@ interface ChatSurfaceProps {
  *  while a search filter is active). */
 const EMPTY_EXTENSIONS: ReadonlyArray<import('@moxxy/client-core').Extension> = Object.freeze([]);
 
+type ChatEvent = import('@moxxy/sdk').MoxxyEvent;
+
+/**
+ * Per-event lowercased searchable haystacks, computed ONCE per events change so
+ * a keystroke in the search box doesn't re-`JSON.stringify` every tool input
+ * (then throw it away) over the whole log. Each entry holds exactly the strings
+ * the old per-event predicate tested with `.includes(q)`.
+ */
+export function buildSearchIndex(
+  events: ReadonlyArray<ChatEvent>,
+): ReadonlyArray<ReadonlyArray<string>> {
+  return events.map((e) => {
+    if (e.type === 'user_prompt') return [e.text.toLowerCase()];
+    if (e.type === 'assistant_message') return [e.content.toLowerCase()];
+    if (e.type === 'tool_call_requested') {
+      return [e.name.toLowerCase(), JSON.stringify(e.input).toLowerCase()];
+    }
+    if (e.type === 'error') return [e.message.toLowerCase()];
+    return [];
+  });
+}
+
+/**
+ * Filter `events` by `query` using a prebuilt {@link buildSearchIndex}. Result
+ * is byte-identical to the prior inline predicate: `[X].some(includes)` ===
+ * `X.includes(q)` and `[X,Y].some(...)` === `X.includes(q) || Y.includes(q)`.
+ */
+export function filterEventsBySearch(
+  events: ReadonlyArray<ChatEvent>,
+  index: ReadonlyArray<ReadonlyArray<string>>,
+  query: string,
+): ReadonlyArray<ChatEvent> {
+  const q = query.toLowerCase();
+  return events.filter((_, i) => index[i]!.some((h) => h.includes(q)));
+}
+
 /**
  * Chat pane — the rightmost column. Card-style transcript with a
  * sticky header, suggested-action chips below the latest assistant
@@ -52,22 +88,13 @@ export function ChatSurface({
   // desk that owns it (first sessions share their desk's id, so old ids work).
   const activeDesk = deskForWorkspace(desks.desks, workspaceId);
 
+  // Precompute the searchable index ONCE per events change; the per-keystroke
+  // filter then just scans it (no JSON.stringify on the keystroke path).
+  const searchIndex = useMemo(() => buildSearchIndex(chat.events), [chat.events]);
   const filteredEvents = useMemo(() => {
     if (!searchQuery) return chat.events;
-    const q = searchQuery.toLowerCase();
-    return chat.events.filter((e) => {
-      if (e.type === 'user_prompt') return e.text.toLowerCase().includes(q);
-      if (e.type === 'assistant_message') return e.content.toLowerCase().includes(q);
-      if (e.type === 'tool_call_requested') {
-        return (
-          e.name.toLowerCase().includes(q) ||
-          JSON.stringify(e.input).toLowerCase().includes(q)
-        );
-      }
-      if (e.type === 'error') return e.message.toLowerCase().includes(q);
-      return false;
-    });
-  }, [chat.events, searchQuery]);
+    return filterEventsBySearch(chat.events, searchIndex, searchQuery);
+  }, [chat.events, searchQuery, searchIndex]);
 
   return (
     <main className="col-main col-main--flat">

--- a/apps/desktop/src/chat/Transcript.tsx
+++ b/apps/desktop/src/chat/Transcript.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import type { MoxxyEvent } from '@moxxy/sdk';
-import { blocksEquivalent, type Block as FoldedBlock } from '@moxxy/chat-model';
+import { blocksEquivalent, IncrementalFold, type Block as FoldedBlock } from '@moxxy/chat-model';
 import { buildRenderNodes, groupToolNodes, type Extension, type RenderNode } from '@moxxy/client-core';
 import { BlockView, StreamingAssistant } from './BlockView';
 import { ToolGroupView } from './ToolGroupView';
@@ -85,9 +85,19 @@ export function Transcript({
   onReachedTop,
 }: TranscriptProps): JSX.Element {
   // Fold only when committed events / extensions change — never on a
-  // streaming tick (the events array reference is stable across chunks).
+  // streaming tick (the events array reference is stable across chunks). The
+  // IncrementalFold re-folds only the unsettled tail past its high-water mark
+  // instead of re-walking the whole event log on every committed event (the
+  // old O(n²)/turn behaviour); buildRenderNodes only consults it on the common
+  // no-extension fast path, and the result stays byte-identical. The optional
+  // chaining degrades gracefully to the (identical) un-cached slow path when
+  // IncrementalFold is unavailable.
+  const foldRef = useRef<IncrementalFold | null>(null);
+  if (foldRef.current === null && typeof IncrementalFold === 'function') {
+    foldRef.current = new IncrementalFold();
+  }
   const nodes = useMemo(
-    () => groupToolNodes(buildRenderNodes(events, extensions)),
+    () => groupToolNodes(buildRenderNodes(events, extensions, foldRef.current ?? undefined)),
     [events, extensions],
   );
 

--- a/apps/desktop/src/onboarding/Onboarding.tsx
+++ b/apps/desktop/src/onboarding/Onboarding.tsx
@@ -17,7 +17,7 @@
  */
 
 import { usePrefs } from '@moxxy/client-core';
-import { useOnboarding } from '@moxxy/client-core';
+import { useOnboarding, type UseOnboarding } from '@moxxy/client-core';
 import { useStepFlow } from '@moxxy/client-core';
 import type { ConnectionPhase } from '@moxxy/desktop-ipc-contract';
 
@@ -61,7 +61,7 @@ export function Onboarding({ phase, onComplete }: Props): JSX.Element {
 
   return (
     <Shell steps={flow.steps} currentIndex={flow.index}>
-      {renderStep(flow.currentId, flow.next, flow.isFirst ? null : flow.back, onComplete)}
+      {renderStep(flow.currentId, flow.next, flow.isFirst ? null : flow.back, onComplete, ob)}
     </Shell>
   );
 }
@@ -71,13 +71,17 @@ function renderStep(
   next: () => void,
   back: (() => void) | null,
   onComplete: () => void,
+  ob: UseOnboarding,
 ): JSX.Element {
   const onBack = back ?? ((): void => undefined);
   switch (id) {
     case 'welcome':
       return <WelcomeStep onNext={next} />;
     case 'node':
-      return <NodeStep onNext={next} onBack={onBack} />;
+      // Pass the SINGLE onboarding instance down — NodeStep must not mount its
+      // own `useOnboarding()` (that doubled the probe IPCs + progress
+      // subscription and diverged on phase changes).
+      return <NodeStep onNext={next} onBack={onBack} ob={ob} />;
     case 'cli':
       return <CliStep onNext={next} onBack={onBack} />;
     case 'provider':

--- a/apps/desktop/src/onboarding/steps/NodeStep.test.tsx
+++ b/apps/desktop/src/onboarding/steps/NodeStep.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Regression test for u9-1: NodeStep used to mount its OWN `useOnboarding()`,
+ * so while it was on screen the app held two onboarding states — double the
+ * mount probes (`onboarding.probeNode`) and two `onboarding.install.progress`
+ * subscriptions. The fix lifts a single instance in `Onboarding` and passes it
+ * down, so the node step active = exactly one probe pair + one subscription.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { __setApiOverride } from '@moxxy/client-core';
+import type { OnboardingStatus } from '@moxxy/desktop-ipc-contract';
+import { Onboarding } from '../Onboarding';
+
+function installFakeApi(): { invokes: string[]; subscribes: string[] } {
+  const invokes: string[] = [];
+  const subscribes: string[] = [];
+
+  const status = (): OnboardingStatus => ({
+    cliInstalled: true,
+    cliPath: '/usr/local/bin/moxxy',
+    hasProvider: true,
+    activeProvider: 'anthropic',
+  });
+
+  __setApiOverride({
+    invoke: ((channel: string) => {
+      invokes.push(channel);
+      if (channel === 'prefs.read') return Promise.resolve({ onboardingComplete: true });
+      if (channel === 'onboarding.status') return Promise.resolve(status());
+      // Node NOT installed → the 'node' step is the unmet prerequisite the
+      // recovery gate resolves to. `installed:false` is non-null → nodeProbed.
+      if (channel === 'onboarding.probeNode') return Promise.resolve({ installed: false });
+      return Promise.resolve(undefined);
+    }) as never,
+    subscribe: ((channel: string) => {
+      subscribes.push(channel);
+      return () => {};
+    }) as never,
+  } as never);
+
+  return { invokes, subscribes };
+}
+
+afterEach(() => {
+  __setApiOverride(null);
+});
+
+describe('NodeStep — single shared useOnboarding instance', () => {
+  it('probes node once and subscribes to install progress once while the node step is active', async () => {
+    const fake = installFakeApi();
+    render(<Onboarding onComplete={() => {}} phase={{ phase: 'cli-missing' } as never} />);
+
+    // The node step's CTA confirms we're on the node step.
+    await waitFor(() => {
+      expect(screen.getByText(/Install Node\.js/i)).toBeTruthy();
+    });
+
+    // One onboarding instance ⇒ one probe pair, one progress subscription.
+    const probeCount = fake.invokes.filter((c) => c === 'onboarding.probeNode').length;
+    const statusCount = fake.invokes.filter((c) => c === 'onboarding.status').length;
+    const progressSubs = fake.subscribes.filter((c) => c === 'onboarding.install.progress').length;
+
+    expect(probeCount).toBe(1);
+    expect(statusCount).toBe(1);
+    expect(progressSubs).toBe(1);
+  });
+});

--- a/apps/desktop/src/onboarding/steps/NodeStep.tsx
+++ b/apps/desktop/src/onboarding/steps/NodeStep.tsx
@@ -7,7 +7,7 @@
  * box and advances once Node is present.
  */
 
-import { useOnboarding } from '@moxxy/client-core';
+import type { UseOnboarding } from '@moxxy/client-core';
 import {
   StepCard,
   Nav,
@@ -20,11 +20,14 @@ import {
 export function NodeStep({
   onNext,
   onBack,
+  ob,
 }: {
   readonly onNext: () => void;
   readonly onBack: () => void;
+  /** The SHARED onboarding instance, lifted in {@link Onboarding} — NodeStep
+   *  must not call `useOnboarding()` itself (doubled probes + subscription). */
+  readonly ob: UseOnboarding;
 }): JSX.Element {
-  const ob = useOnboarding();
   const installed = ob.node?.installed ?? false;
   const installing = ob.installNode.running;
   const log = ob.installNode.progress;

--- a/apps/desktop/src/workflows/WorkflowCanvas.test.tsx
+++ b/apps/desktop/src/workflows/WorkflowCanvas.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the canvas' geometry-free topology derivation.
+ *
+ * `topoOrder` (the O(V+E) longest-path layering shown as step numbers) and the
+ * `topologySignature` that keys its memo. The signature must be STABLE across a
+ * position-only move so a node drag — which reallocates `state.nodes` on every
+ * pointer-move — doesn't recompute the fold dozens of times per second.
+ */
+import { describe, expect, it } from 'vitest';
+import type { BuilderNode } from '@moxxy/workflows-builder';
+import { topoOrder, topologySignature } from './WorkflowCanvas';
+
+/** Minimal BuilderNode — only id/x/y/needs matter to the functions under test. */
+function node(id: string, needs: string[] = [], x = 0, y = 0): BuilderNode {
+  return {
+    id,
+    kind: 'prompt',
+    x,
+    y,
+    action: '',
+    needs,
+    onError: 'fail',
+    retries: 0,
+  } as unknown as BuilderNode;
+}
+
+describe('topoOrder', () => {
+  it('numbers a linear chain 1..N in dependency order', () => {
+    const nodes = [node('a'), node('b', ['a']), node('c', ['b'])];
+    const order = topoOrder(nodes);
+    expect(order.get('a')).toBe(1);
+    expect(order.get('b')).toBe(2);
+    expect(order.get('c')).toBe(3);
+  });
+
+  it('breaks depth ties by insertion order', () => {
+    // a and b are both roots (depth 0); c depends on both (depth 1).
+    const nodes = [node('a'), node('b'), node('c', ['a', 'b'])];
+    const order = topoOrder(nodes);
+    // roots ranked by insertion index, then the dependent.
+    expect(order.get('a')).toBe(1);
+    expect(order.get('b')).toBe(2);
+    expect(order.get('c')).toBe(3);
+  });
+
+  it('uses longest-path depth for diamond dependencies', () => {
+    // a → b → d and a → c → d ; d's depth is 2 (longest path), not 1.
+    const nodes = [node('a'), node('b', ['a']), node('c', ['a']), node('d', ['b', 'c'])];
+    const order = topoOrder(nodes);
+    expect(order.get('a')).toBe(1);
+    expect(order.get('d')).toBe(4); // ranked last (deepest)
+  });
+
+  it('does not throw on a cycle and still assigns distinct 1..N ranks', () => {
+    const nodes = [node('a', ['b']), node('b', ['a'])];
+    expect(() => topoOrder(nodes)).not.toThrow();
+    const order = topoOrder(nodes);
+    // The cycle-guard breaks the recursion; exact tie order is implementation
+    // detail, but every node gets a unique rank in 1..N.
+    const ranks = [order.get('a'), order.get('b')].sort();
+    expect(ranks).toEqual([1, 2]);
+  });
+
+  it('ignores dangling needs (referenced node absent)', () => {
+    const nodes = [node('a', ['ghost'])];
+    const order = topoOrder(nodes);
+    expect(order.get('a')).toBe(1);
+  });
+});
+
+describe('topologySignature', () => {
+  it('is identical for a position-only move (the drag fast-path)', () => {
+    const before = [node('a', [], 0, 0), node('b', ['a'], 100, 0)];
+    // Same ids + needs, only x/y moved — as a drag produces.
+    const afterDrag = [node('a', [], 37, 12), node('b', ['a'], 240, 99)];
+    expect(topologySignature(afterDrag)).toBe(topologySignature(before));
+  });
+
+  it('changes when a needs edge is added', () => {
+    const before = [node('a'), node('b')];
+    const after = [node('a'), node('b', ['a'])];
+    expect(topologySignature(after)).not.toBe(topologySignature(before));
+  });
+
+  it('changes when a node is added or the set reorders', () => {
+    const base = [node('a'), node('b')];
+    expect(topologySignature([...base, node('c')])).not.toBe(topologySignature(base));
+    expect(topologySignature([node('b'), node('a')])).not.toBe(topologySignature(base));
+  });
+});

--- a/apps/desktop/src/workflows/WorkflowCanvas.tsx
+++ b/apps/desktop/src/workflows/WorkflowCanvas.tsx
@@ -162,8 +162,23 @@ export function WorkflowCanvas({ state, dispatch }: Props): JSX.Element {
 
   const byId = useMemo(() => new Map(state.nodes.map((n) => [n.id, n])), [state.nodes]);
 
-  /** Topological order index per node (1-based) so the canvas reads as a flow. */
-  const order = useMemo(() => topoOrder(state.nodes), [state.nodes]);
+  /**
+   * Topological order index per node (1-based) so the canvas reads as a flow.
+   *
+   * `moveNode` returns a fresh `state.nodes` array on EVERY pointer-move while
+   * dragging a card, but a position-only move can never change the `needs`
+   * topological order. So memoize on a geometry-FREE signature of the topology
+   * (each node's id + needs in array order) — it stays referentially stable
+   * across a drag, and the O(V+E) longest-path fold only recomputes when the
+   * graph's wiring (or node set / order) actually changes, not per mousemove.
+   */
+  // topoSig is the intended geometry-free dependency; state.nodes (its source)
+  // changes on every drag tick and would defeat the memo, so key on the
+  // signature instead. The disable directive must sit DIRECTLY above the
+  // useMemo to apply.
+  const topoSig = topologySignature(state.nodes);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const order = useMemo(() => topoOrder(state.nodes), [topoSig]);
 
   /** Pointer position in WORLD coords (node space, pre-transform). */
   const surfacePoint = useCallback(
@@ -1297,12 +1312,27 @@ function nodeAt(
 }
 
 /**
+ * A geometry-FREE signature of the inputs {@link topoOrder} actually reads —
+ * each node's id and its `needs` list, in array order. Two `state.nodes`
+ * arrays that differ only in node positions (a drag) produce the SAME string,
+ * so the `order` memo keyed on this skips the O(V+E) recompute during a drag
+ * (when `moveNode` allocates a fresh array every pointer-move). Changes only
+ * when a node is added/removed/reordered or a `needs` edge is wired/unwired —
+ * exactly when the topological order can change.
+ */
+export function topologySignature(nodes: ReadonlyArray<BuilderNode>): string {
+  let sig = '';
+  for (const n of nodes) sig += `${n.id}:${(n.needs ?? []).join(',')};`;
+  return sig;
+}
+
+/**
  * A 1-based topological index per node over the `needs` DAG (longest-path
  * layering, ties broken by array order). Makes the execution order legible on
  * the cards. Cyclic graphs (which the connect guard prevents, but a loaded YAML
  * could still contain) just fall back to insertion order for the affected nodes.
  */
-function topoOrder(nodes: ReadonlyArray<BuilderNode>): Map<string, number> {
+export function topoOrder(nodes: ReadonlyArray<BuilderNode>): Map<string, number> {
   const byId = new Map(nodes.map((n) => [n.id, n]));
   const depth = new Map<string, number>();
   const resolve = (id: string, seen: Set<string>): number => {

--- a/packages/chat-model/src/incremental-fold.test.ts
+++ b/packages/chat-model/src/incremental-fold.test.ts
@@ -1,0 +1,384 @@
+/**
+ * GOLDEN test for the incremental block fold.
+ *
+ * The load-bearing invariant (cardinal rule): for ANY event prefix, pushing
+ * those events one at a time into an {@link IncrementalFold} must yield a block
+ * tree byte-identical to `pairToolEvents(prefix)`. Both paths drive the exact
+ * same {@link stepFold} over the same events in the same order, so this is a
+ * structural guarantee — these tests are the regression net that proves it
+ * across many representative recorded sequences AND step-by-step (after EVERY
+ * event, not just at the end).
+ *
+ * Plus a complexity assertion: folding a k-event turn incrementally performs
+ * O(k) total `stepFold` work, NOT the O(k²) of re-folding the whole prefix on
+ * every event (the bug this cluster kills).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  asEventId,
+  asPluginId,
+  asSessionId,
+  asSkillId,
+  asToolCallId,
+  asTurnId,
+  type AssistantMessageEvent,
+  type MoxxyEvent,
+  type PluginEvent,
+  type ReasoningMessageEvent,
+  type SkillInvokedEvent,
+  type ToolCallDeniedEvent,
+  type ToolCallRequestedEvent,
+  type ToolCompactPresentation,
+  type ToolResultEvent,
+  type UserPromptEvent,
+} from '@moxxy/sdk';
+import {
+  IncrementalFold,
+  createFoldState,
+  pairToolEvents,
+  stepFold,
+  type CompactToolMap,
+} from './pair-events.js';
+
+// ---------------------------------------------------------------------------
+// Synthetic-event builders (mirror pair-events.test.ts so the recorded
+// sequences exercise the same shapes the real channel emits).
+// ---------------------------------------------------------------------------
+
+let seq = 0;
+const base = () => {
+  seq += 1;
+  return {
+    id: asEventId(`e${seq}`),
+    seq,
+    ts: seq * 1000,
+    sessionId: asSessionId('s1'),
+    turnId: asTurnId('t1'),
+  } as const;
+};
+
+const userPrompt = (text: string): UserPromptEvent => ({ ...base(), type: 'user_prompt', source: 'user', text });
+const toolRequest = (callId: string, name: string, input: unknown = {}): ToolCallRequestedEvent => ({
+  ...base(),
+  type: 'tool_call_requested',
+  source: 'model',
+  callId: asToolCallId(callId),
+  name,
+  input,
+});
+const toolResult = (callId: string, output: unknown = 'ok', ok = true): ToolResultEvent => ({
+  ...base(),
+  type: 'tool_result',
+  source: 'tool',
+  callId: asToolCallId(callId),
+  ok,
+  output,
+});
+const toolDenied = (callId: string, reason: string): ToolCallDeniedEvent => ({
+  ...base(),
+  type: 'tool_call_denied',
+  source: 'plugin',
+  callId: asToolCallId(callId),
+  decidedBy: 'resolver',
+  reason,
+});
+const skillInvoked = (skillId: string, name: string): SkillInvokedEvent => ({
+  ...base(),
+  type: 'skill_invoked',
+  source: 'system',
+  skillId: asSkillId(skillId),
+  name,
+  reason: 'manual',
+});
+const assistantMessage = (content: string): AssistantMessageEvent => ({
+  ...base(),
+  type: 'assistant_message',
+  source: 'model',
+  content,
+  stopReason: 'end_turn',
+});
+const reasoningMessage = (content: string): ReasoningMessageEvent =>
+  ({ ...base(), type: 'reasoning_message', source: 'model', content }) as unknown as ReasoningMessageEvent;
+
+const SUBAGENT_PLUGIN_ID = '@moxxy/subagents';
+const subagentEvent = (subtype: string, payload: Record<string, unknown>): PluginEvent => ({
+  ...base(),
+  type: 'plugin_event',
+  source: 'plugin',
+  pluginId: asPluginId(SUBAGENT_PLUGIN_ID),
+  subtype,
+  payload,
+});
+
+const readCompact: ToolCompactPresentation = {
+  verb: 'Reading',
+  noun: { one: 'file', other: 'files' },
+  previewKey: 'file_path',
+};
+const grepCompact: ToolCompactPresentation = { verb: 'Searching for', noun: { one: 'pattern', other: 'patterns' } };
+const compactMap: CompactToolMap = new Map([
+  ['read', readCompact],
+  ['grep', grepCompact],
+]);
+
+const fileDiffOutput = {
+  forModel: 'edited /a.ts',
+  display: { kind: 'file-diff' as const, path: 'a.ts', mode: 'update' as const, added: 1, removed: 1, hunks: [] },
+};
+
+// ---------------------------------------------------------------------------
+// Recorded sequences — each a named, representative event log. Covers skill
+// scopes, continuation scopes, live-tools, subagents (groups/mixed/errors),
+// orphan results, reasoning, file diffs, and interleavings of all of them.
+// ---------------------------------------------------------------------------
+interface Recorded {
+  readonly name: string;
+  readonly events: () => MoxxyEvent[];
+  readonly compact?: CompactToolMap;
+}
+
+const SEQUENCES: Recorded[] = [
+  {
+    name: 'plain verbose tool pair',
+    events: () => [userPrompt('hi'), toolRequest('c1', 'bash'), toolResult('c1', 'out'), assistantMessage('done')],
+  },
+  {
+    name: 'pending then denied',
+    events: () => [toolRequest('c1', 'bash'), toolDenied('c1', 'nope')],
+  },
+  {
+    name: 'orphan at turn boundary, late result',
+    events: () => [
+      userPrompt('go'),
+      toolRequest('c1', 'bash'),
+      userPrompt('never mind'),
+      toolResult('c1', 'too late'),
+    ],
+  },
+  {
+    name: 'skill scope with two tools, closed by prompt',
+    events: () => [
+      skillInvoked('sk1', 'pdf'),
+      toolRequest('c1', 'bash'),
+      toolResult('c1'),
+      toolRequest('c2', 'write'),
+      toolResult('c2'),
+      userPrompt('thanks'),
+    ],
+  },
+  {
+    name: 'load_skill suppressed into scope',
+    events: () => [
+      toolRequest('ls1', 'load_skill', { name: 'pdf' }),
+      skillInvoked('sk1', 'pdf'),
+      toolRequest('c1', 'bash'),
+      toolResult('c1'),
+      toolResult('ls1', 'loaded'),
+    ],
+  },
+  {
+    name: 'scope split by assistant_message → continuation scope',
+    events: () => [
+      skillInvoked('sk1', 'pdf'),
+      toolRequest('c1', 'bash'),
+      toolResult('c1'),
+      assistantMessage('now generating'),
+      toolRequest('c2', 'write'),
+      toolResult('c2'),
+    ],
+  },
+  {
+    name: 'compact live aggregation interrupted by verbose',
+    compact: compactMap,
+    events: () => [
+      toolRequest('r1', 'read', { file_path: '/a.ts' }),
+      toolResult('r1'),
+      toolRequest('r2', 'read', { file_path: '/b.ts' }),
+      toolResult('r2'),
+      toolRequest('b1', 'bash'),
+      toolResult('b1'),
+      toolRequest('g1', 'grep', { pattern: 'x' }),
+      toolResult('g1'),
+      assistantMessage('found it'),
+    ],
+  },
+  {
+    name: 'subagent group fan-out, mixed completion order',
+    events: () => [
+      subagentEvent('subagent_started', { childSessionId: 'cs1', label: 'a', agentType: 'Explore' }),
+      subagentEvent('subagent_started', { childSessionId: 'cs2', label: 'b', agentType: 'Explore' }),
+      subagentEvent('subagent_tool_call', { childSessionId: 'cs1' }),
+      subagentEvent('subagent_completed', { childSessionId: 'cs2', stopReason: 'end_turn', tokensUsed: 65300, text: 'b done' }),
+      subagentEvent('subagent_completed', { childSessionId: 'cs1', stopReason: 'end_turn', tokensUsed: 1200, text: 'a done' }),
+    ],
+  },
+  {
+    name: 'subagent run broken by a tool, then a second group',
+    events: () => [
+      subagentEvent('subagent_started', { childSessionId: 'cs1', label: 'a' }),
+      subagentEvent('subagent_completed', { childSessionId: 'cs1', stopReason: 'end_turn' }),
+      toolRequest('t1', 'bash'),
+      toolResult('t1'),
+      subagentEvent('subagent_started', { childSessionId: 'cs2', label: 'b' }),
+      subagentEvent('subagent_error', { childSessionId: 'cs2', message: 'boom' }),
+    ],
+  },
+  {
+    name: 'mixed: prompt, reasoning, file diffs, live tools, scope, subagents',
+    compact: compactMap,
+    events: () => [
+      userPrompt('build it'),
+      reasoningMessage('thinking about it'),
+      toolRequest('w1', 'Write', { file_path: '/a.ts' }),
+      toolResult('w1', fileDiffOutput),
+      toolRequest('r1', 'read', { file_path: '/a.ts' }),
+      toolResult('r1'),
+      toolRequest('r2', 'read', { file_path: '/b.ts' }),
+      assistantMessage('partial'),
+      skillInvoked('sk1', 'deploy'),
+      toolRequest('e1', 'Edit', { file_path: '/b.ts' }),
+      toolResult('e1', fileDiffOutput),
+      subagentEvent('subagent_started', { childSessionId: 'cs1', label: 'verify', agentType: 'Test' }),
+      subagentEvent('subagent_tool_call', { childSessionId: 'cs1' }),
+      subagentEvent('subagent_completed', { childSessionId: 'cs1', stopReason: 'end_turn', tokensUsed: 4200, text: 'ok' }),
+      userPrompt('next turn'),
+      toolRequest('b2', 'bash'),
+      toolResult('b2'),
+    ],
+  },
+  {
+    name: 'long burst of compact reads (stress)',
+    compact: compactMap,
+    events: () => {
+      const out: MoxxyEvent[] = [userPrompt('read everything')];
+      for (let i = 0; i < 40; i += 1) {
+        out.push(toolRequest(`rk${i}`, 'read', { file_path: `/f${i}.ts` }));
+        out.push(toolResult(`rk${i}`));
+      }
+      out.push(assistantMessage('done reading'));
+      return out;
+    },
+  },
+];
+
+/** Deep structural equality that walks the block tree (vitest's toEqual gives
+ *  byte-level field comparison; identity differences in equal-valued objects
+ *  are fine because the two folds build distinct-but-equal object graphs). */
+function expectByteIdentical(name: string, step: number, a: unknown, b: unknown): void {
+  // A failure here reports which sequence + step diverged.
+  expect(a, `${name} @ step ${step}`).toEqual(b);
+}
+
+describe('IncrementalFold — golden byte-identity vs pairToolEvents', () => {
+  for (const seqDef of SEQUENCES) {
+    it(`matches pairToolEvents after EVERY event: ${seqDef.name}`, () => {
+      const events = seqDef.events();
+      const fold = new IncrementalFold(seqDef.compact);
+      for (let n = 0; n < events.length; n += 1) {
+        fold.push(events[n]!);
+        const incremental = fold.tree();
+        const golden = pairToolEvents(events.slice(0, n + 1), seqDef.compact);
+        expectByteIdentical(seqDef.name, n + 1, incremental, golden);
+      }
+      // Final whole-prefix equality (redundant with the loop, but explicit).
+      expect(fold.tree()).toEqual(pairToolEvents(events, seqDef.compact));
+    });
+  }
+
+  it('pushMany equals one-at-a-time push equals pairToolEvents', () => {
+    for (const seqDef of SEQUENCES) {
+      const events = seqDef.events();
+      const a = new IncrementalFold(seqDef.compact);
+      a.pushMany(events);
+      const b = new IncrementalFold(seqDef.compact);
+      for (const e of events) b.push(e);
+      expect(a.tree()).toEqual(b.tree());
+      expect(a.tree()).toEqual(pairToolEvents(events, seqDef.compact));
+    }
+  });
+});
+
+describe('IncrementalFold.syncTo — append-only resync', () => {
+  it('folds only the tail on a pure append (no rebuild)', () => {
+    const events = SEQUENCES.find((s) => s.name.startsWith('mixed'))!.events();
+    const fold = new IncrementalFold(compactMap);
+    // Drive it the way a store would: re-sync to a growing snapshot each tick.
+    for (let n = 1; n <= events.length; n += 1) {
+      const snapshot = events.slice(0, n);
+      const tree = fold.syncTo(snapshot);
+      expect(tree).toEqual(pairToolEvents(snapshot, compactMap));
+      // High-water mark advanced to the snapshot length — tail-only fold.
+      expect(fold.length).toBe(n);
+    }
+  });
+
+  it('rebuilds from scratch when the prefix is replaced (/clear → new session)', () => {
+    const first = SEQUENCES[0]!.events();
+    const fold = new IncrementalFold();
+    fold.syncTo(first);
+    expect(fold.tree()).toEqual(pairToolEvents(first));
+    // A fresh, unrelated session: different event ids at the head.
+    const second = SEQUENCES[3]!.events();
+    const tree = fold.syncTo(second);
+    expect(tree).toEqual(pairToolEvents(second));
+    expect(fold.length).toBe(second.length);
+  });
+
+  it('rebuilds from scratch when older history is prepended (scroll-up)', () => {
+    const tail = SEQUENCES[0]!.events();
+    const fold = new IncrementalFold();
+    fold.syncTo(tail);
+    // Older page prepended at the front: head id shifts → must rebuild.
+    const older = [userPrompt('earlier'), assistantMessage('earlier reply')];
+    const combined = [...older, ...tail];
+    const tree = fold.syncTo(combined);
+    expect(tree).toEqual(pairToolEvents(combined));
+  });
+
+  it('rebuilds when the array shrinks below the high-water mark', () => {
+    const events = SEQUENCES[9]!.events(); // the long mixed sequence
+    const fold = new IncrementalFold(compactMap);
+    fold.syncTo(events);
+    const shorter = events.slice(0, 3);
+    const tree = fold.syncTo(shorter);
+    expect(tree).toEqual(pairToolEvents(shorter, compactMap));
+    expect(fold.length).toBe(3);
+  });
+});
+
+describe('IncrementalFold — complexity (O(k) not O(k²) per turn)', () => {
+  it('a k-event turn does NOT perform k full walks', () => {
+    // Count total stepFold invocations two ways over the SAME event stream:
+    //   - incremental: one stepFold per pushed event           → exactly k
+    //   - naive re-fold (the bug): re-fold the whole prefix on  → k(k+1)/2
+    //     every committed event
+    // The wrapper below is the real stepFold, so both counts are exact.
+    const events = SEQUENCES.find((s) => s.name.startsWith('long burst'))!.events();
+    const k = events.length;
+
+    let incrementalSteps = 0;
+    const inc = createFoldState(compactMap);
+    for (const e of events) {
+      stepFold(inc, e);
+      incrementalSteps += 1;
+    }
+    expect(incrementalSteps).toBe(k);
+
+    let naiveSteps = 0;
+    for (let n = 1; n <= k; n += 1) {
+      const s = createFoldState(compactMap);
+      for (let i = 0; i < n; i += 1) {
+        stepFold(s, events[i]!);
+        naiveSteps += 1;
+      }
+    }
+    expect(naiveSteps).toBe((k * (k + 1)) / 2);
+
+    // The incremental path is asymptotically cheaper; concretely, for this
+    // k it is at least an order of magnitude fewer step invocations.
+    expect(incrementalSteps).toBeLessThan(naiveSteps / 10);
+
+    // And it still produces the byte-identical final tree.
+    expect(inc.root).toEqual(pairToolEvents(events, compactMap));
+  });
+});

--- a/packages/chat-model/src/pair-events.ts
+++ b/packages/chat-model/src/pair-events.ts
@@ -137,18 +137,28 @@ interface CallTarget {
   outcome: ToolCallBlockData['outcome'];
 }
 
-export function pairToolEvents(
-  events: ReadonlyArray<MoxxyEvent>,
-  compactByName: CompactToolMap = EMPTY_COMPACT_MAP,
-): Block[] {
-  const root: Block[] = [];
+/**
+ * The full loop-carried state of {@link pairToolEvents}, lifted into a
+ * struct so the per-event body ({@link stepFold}) can be applied either in
+ * a batch ({@link pairToolEvents}) or one event at a time
+ * ({@link IncrementalFold}).
+ *
+ * Both paths run the SAME {@link stepFold} over the SAME events in the SAME
+ * order, so they produce byte-identical block trees — the incremental path
+ * is just the batch path with its loop unrolled across calls. `root` is the
+ * folded tree (mutated in place as outcomes/scopes settle); the rest is the
+ * carry the algorithm threads from one event to the next.
+ */
+export interface FoldState {
+  readonly root: Block[];
+  readonly compactByName: CompactToolMap;
   // Reverse lookup: callId → the outcome-holder for that call (either a
   // ToolCallBlockData or a LiveToolCall — both have a mutable `outcome`
   // field). One map handles both kinds via structural typing.
-  const callTargets = new Map<string, CallTarget>();
-  const suppressedCallIds = new Set<string>();
-  let pendingLoadSkillCallId: string | null = null;
-  let openScope: SkillScopeBlock | null = null;
+  readonly callTargets: Map<string, CallTarget>;
+  readonly suppressedCallIds: Set<string>;
+  pendingLoadSkillCallId: string | null;
+  openScope: SkillScopeBlock | null;
   // When an assistant_message lands mid-skill we close the current
   // scope so the message renders below the tools that preceded it
   // (preserving chronological order). If more skill tool calls come
@@ -156,38 +166,62 @@ export function pairToolEvents(
   // skillEvent so the grouping carries through both visually and via
   // `countToolCalls`. Cleared at turn boundaries and on a new
   // skill_invoked.
-  let continuationSkillEvent: import('@moxxy/sdk').SkillInvokedEvent | null = null;
+  continuationSkillEvent: import('@moxxy/sdk').SkillInvokedEvent | null;
   // Open live-tools aggregate, if any. Lives at the current push level
   // (root or openScope.children); subsequent compact tool calls append
   // into it until something non-compact closes it.
-  let openLive: LiveToolBlockData | null = null;
-  const subagents = new Map<string, SubagentBlock>();
+  openLive: LiveToolBlockData | null;
+  readonly subagents: Map<string, SubagentBlock>;
   // Open subagent group, if any. Consecutive `subagent_started` events accrete
   // into it; any non-subagent block (or a turn/scope boundary) closes the run.
-  const subagentGroup: { current: SubagentGroupBlock | null } = { current: null };
+  readonly subagentGroup: { current: SubagentGroupBlock | null };
+}
 
+/** A fresh, empty fold state for the given compact-tool map. */
+export function createFoldState(compactByName: CompactToolMap = EMPTY_COMPACT_MAP): FoldState {
+  return {
+    root: [],
+    compactByName,
+    callTargets: new Map<string, CallTarget>(),
+    suppressedCallIds: new Set<string>(),
+    pendingLoadSkillCallId: null,
+    openScope: null,
+    continuationSkillEvent: null,
+    openLive: null,
+    subagents: new Map<string, SubagentBlock>(),
+    subagentGroup: { current: null },
+  };
+}
+
+/**
+ * Apply ONE event to a {@link FoldState}, mutating `root` and the carry in
+ * place. This is the exact body of the old `pairToolEvents` loop, extracted
+ * verbatim so the batch and incremental folds share one code path (and thus
+ * stay byte-identical). `continue` became `return`.
+ */
+export function stepFold(s: FoldState, e: MoxxyEvent): void {
   const pushBlock = (block: Block): void => {
     // Any non-subagent block breaks a run of sibling subagents.
-    subagentGroup.current = null;
-    if (openScope) {
-      openScope.children.push(block);
+    s.subagentGroup.current = null;
+    if (s.openScope) {
+      s.openScope.children.push(block);
     } else {
-      root.push(block);
+      s.root.push(block);
     }
   };
 
   const closeOpenLive = (): void => {
-    if (openLive) {
-      openLive.closed = true;
-      openLive = null;
+    if (s.openLive) {
+      s.openLive.closed = true;
+      s.openLive = null;
     }
   };
 
   const closeOpenScope = (): void => {
     closeOpenLive();
-    if (openScope) {
-      openScope.closed = true;
-      openScope = null;
+    if (s.openScope) {
+      s.openScope.closed = true;
+      s.openScope = null;
     }
   };
 
@@ -203,8 +237,8 @@ export function pairToolEvents(
       }
       return false;
     };
-    if (openScope && removeFrom(openScope.children)) return;
-    removeFrom(root);
+    if (s.openScope && removeFrom(s.openScope.children)) return;
+    removeFrom(s.root);
   };
 
   // UI safety net: when a new user_prompt arrives, any tool-call block
@@ -214,7 +248,7 @@ export function pairToolEvents(
   // synthesize tool_result events for these cases (and now do), but this
   // guard means a future regression can't leave a permanent stuck dot.
   const markOrphansAtTurnBoundary = (): void => {
-    for (const target of callTargets.values()) {
+    for (const target of s.callTargets.values()) {
       if (target.outcome === null) {
         target.outcome = {
           type: 'denied',
@@ -222,147 +256,259 @@ export function pairToolEvents(
         };
       }
     }
-    callTargets.clear();
+    s.callTargets.clear();
   };
 
-  for (const e of events) {
-    if (e.type === 'user_prompt') {
-      closeOpenScope();
-      markOrphansAtTurnBoundary();
-      pendingLoadSkillCallId = null;
-      continuationSkillEvent = null;
-      // Suppression is a within-turn concern (a load_skill call folded into a
-      // skill scope). Clearing it at the turn boundary stops a later turn that
-      // happens to reuse a callId from having its tool_result silently dropped.
-      suppressedCallIds.clear();
-      subagentGroup.current = null;
-      root.push({ kind: 'event', id: e.id, event: e });
-      continue;
+  if (e.type === 'user_prompt') {
+    closeOpenScope();
+    markOrphansAtTurnBoundary();
+    s.pendingLoadSkillCallId = null;
+    s.continuationSkillEvent = null;
+    // Suppression is a within-turn concern (a load_skill call folded into a
+    // skill scope). Clearing it at the turn boundary stops a later turn that
+    // happens to reuse a callId from having its tool_result silently dropped.
+    s.suppressedCallIds.clear();
+    s.subagentGroup.current = null;
+    s.root.push({ kind: 'event', id: e.id, event: e });
+    return;
+  }
+  if (e.type === 'skill_invoked') {
+    // Close any previous scope, then open a new one. Also collapse
+    // the load_skill tool-call into the new scope so we don't show
+    // both "load_skill(name=foo)" AND "◆ skill: foo".
+    closeOpenScope();
+    s.continuationSkillEvent = null;
+    if (s.pendingLoadSkillCallId) {
+      s.suppressedCallIds.add(s.pendingLoadSkillCallId);
+      removeBlockByCallId(s.pendingLoadSkillCallId);
+      s.pendingLoadSkillCallId = null;
     }
-    if (e.type === 'skill_invoked') {
-      // Close any previous scope, then open a new one. Also collapse
-      // the load_skill tool-call into the new scope so we don't show
-      // both "load_skill(name=foo)" AND "◆ skill: foo".
-      closeOpenScope();
-      continuationSkillEvent = null;
-      if (pendingLoadSkillCallId) {
-        suppressedCallIds.add(pendingLoadSkillCallId);
-        removeBlockByCallId(pendingLoadSkillCallId);
-        pendingLoadSkillCallId = null;
-      }
-      subagentGroup.current = null;
-      openScope = {
+    s.subagentGroup.current = null;
+    s.openScope = {
+      kind: 'skill-scope',
+      id: e.id,
+      skillEvent: e,
+      children: [],
+      closed: false,
+    };
+    s.root.push(s.openScope);
+    return;
+  }
+  if (e.type === 'tool_call_requested') {
+    if (e.name === 'load_skill') {
+      s.pendingLoadSkillCallId = e.callId;
+    }
+    // A skill scope was closed by an interleaved assistant_message
+    // and a fresh tool call has now arrived. Reopen the scope so the
+    // continuation tools stay visually grouped under the same skill
+    // banner, just below the assistant text in chronological order.
+    if (!s.openScope && s.continuationSkillEvent) {
+      s.openScope = {
         kind: 'skill-scope',
-        id: e.id,
-        skillEvent: e,
+        id: `${s.continuationSkillEvent.id}:cont:${e.id}`,
+        skillEvent: s.continuationSkillEvent,
         children: [],
         closed: false,
       };
-      root.push(openScope);
-      continue;
+      s.root.push(s.openScope);
+      s.continuationSkillEvent = null;
     }
-    if (e.type === 'tool_call_requested') {
-      if (e.name === 'load_skill') {
-        pendingLoadSkillCallId = e.callId;
+    // File-edit tools never aggregate — each renders its own diff inline.
+    const compact = FILE_DIFF_TOOL_NAMES.has(e.name) ? undefined : s.compactByName.get(e.name);
+    if (compact) {
+      // Compact tool — aggregate into an open live block, or start one.
+      if (!s.openLive) {
+        s.openLive = { kind: 'live-tools', id: e.id, calls: [], closed: false };
+        pushBlock(s.openLive);
       }
-      // A skill scope was closed by an interleaved assistant_message
-      // and a fresh tool call has now arrived. Reopen the scope so the
-      // continuation tools stay visually grouped under the same skill
-      // banner, just below the assistant text in chronological order.
-      if (!openScope && continuationSkillEvent) {
-        openScope = {
-          kind: 'skill-scope',
-          id: `${continuationSkillEvent.id}:cont:${e.id}`,
-          skillEvent: continuationSkillEvent,
-          children: [],
-          closed: false,
-        };
-        root.push(openScope);
-        continuationSkillEvent = null;
-      }
-      // File-edit tools never aggregate — each renders its own diff inline.
-      const compact = FILE_DIFF_TOOL_NAMES.has(e.name) ? undefined : compactByName.get(e.name);
-      if (compact) {
-        // Compact tool — aggregate into an open live block, or start one.
-        if (!openLive) {
-          openLive = { kind: 'live-tools', id: e.id, calls: [], closed: false };
-          pushBlock(openLive);
-        }
-        const call: LiveToolCall = { id: e.id, request: e, compact, outcome: null };
-        openLive.calls.push(call);
-        callTargets.set(e.callId, call);
-        continue;
-      }
-      // Verbose tool — seal any open live block first so it stops accreting.
-      closeOpenLive();
-      const block: ToolCallBlockData = {
-        kind: 'tool-call',
-        id: e.id,
-        request: e,
-        outcome: null,
-      };
-      callTargets.set(e.callId, block);
-      pushBlock(block);
-      continue;
+      const call: LiveToolCall = { id: e.id, request: e, compact, outcome: null };
+      s.openLive.calls.push(call);
+      s.callTargets.set(e.callId, call);
+      return;
     }
-    if (e.type === 'tool_result') {
-      if (suppressedCallIds.has(e.callId)) continue;
-      const target = callTargets.get(e.callId);
-      if (target) {
-        target.outcome = e;
-        continue;
-      }
-    }
-    if (e.type === 'tool_call_denied') {
-      if (suppressedCallIds.has(e.callId)) continue;
-      const target = callTargets.get(e.callId);
-      if (target) {
-        target.outcome = { type: 'denied', reason: e.reason };
-        continue;
-      }
-    }
-    if (e.type === 'tool_call_approved') {
-      continue; // outcome already conveys this
-    }
-    if (e.type === 'assistant_message') {
-      closeOpenLive();
-      // Assistant messages always render at the chat's left margin,
-      // even when a skill scope is open above them. The scope groups
-      // skill tool work; the assistant's commentary surrounding that
-      // work belongs at root so its bullet aligns with the rest of the
-      // conversation — and so post-stream rendering matches the
-      // streaming preview, which already lives at root.
-      //
-      // If a skill scope is currently open, close it so subsequent
-      // tool calls form a continuation block BELOW this message. Without
-      // this split, late tool calls fold back into the original scope
-      // (a child push above) and the message visually drops below the
-      // entire skill block instead of slotting in chronologically.
-      if (openScope) {
-        continuationSkillEvent = openScope.skillEvent;
-        openScope.closed = true;
-        openScope = null;
-      } else {
-        // A second consecutive assistant_message (no skill scope open and no
-        // intervening tool call) means the one-message continuation window has
-        // passed. Clear it so later tool calls don't get pulled back under a
-        // stale skill banner two messages later.
-        continuationSkillEvent = null;
-      }
-      subagentGroup.current = null;
-      root.push({ kind: 'event', id: e.id, event: e });
-      continue;
-    }
-    // Subagent events fold into a collapsible group so a fleet of children
-    // doesn't drown the main chat. The SubagentSpawner emits them as
-    // plugin_event with pluginId='@moxxy/subagents'.
-    if (e.type === 'plugin_event' && e.pluginId === SUBAGENT_PLUGIN_ID) {
-      handleSubagentEvent(e, subagents, root, subagentGroup);
-      continue;
-    }
-    pushBlock({ kind: 'event', id: e.id, event: e });
+    // Verbose tool — seal any open live block first so it stops accreting.
+    closeOpenLive();
+    const block: ToolCallBlockData = {
+      kind: 'tool-call',
+      id: e.id,
+      request: e,
+      outcome: null,
+    };
+    s.callTargets.set(e.callId, block);
+    pushBlock(block);
+    return;
   }
-  return root;
+  if (e.type === 'tool_result') {
+    if (s.suppressedCallIds.has(e.callId)) return;
+    const target = s.callTargets.get(e.callId);
+    if (target) {
+      target.outcome = e;
+      return;
+    }
+  }
+  if (e.type === 'tool_call_denied') {
+    if (s.suppressedCallIds.has(e.callId)) return;
+    const target = s.callTargets.get(e.callId);
+    if (target) {
+      target.outcome = { type: 'denied', reason: e.reason };
+      return;
+    }
+  }
+  if (e.type === 'tool_call_approved') {
+    return; // outcome already conveys this
+  }
+  if (e.type === 'assistant_message') {
+    closeOpenLive();
+    // Assistant messages always render at the chat's left margin,
+    // even when a skill scope is open above them. The scope groups
+    // skill tool work; the assistant's commentary surrounding that
+    // work belongs at root so its bullet aligns with the rest of the
+    // conversation — and so post-stream rendering matches the
+    // streaming preview, which already lives at root.
+    //
+    // If a skill scope is currently open, close it so subsequent
+    // tool calls form a continuation block BELOW this message. Without
+    // this split, late tool calls fold back into the original scope
+    // (a child push above) and the message visually drops below the
+    // entire skill block instead of slotting in chronologically.
+    if (s.openScope) {
+      s.continuationSkillEvent = s.openScope.skillEvent;
+      s.openScope.closed = true;
+      s.openScope = null;
+    } else {
+      // A second consecutive assistant_message (no skill scope open and no
+      // intervening tool call) means the one-message continuation window has
+      // passed. Clear it so later tool calls don't get pulled back under a
+      // stale skill banner two messages later.
+      s.continuationSkillEvent = null;
+    }
+    s.subagentGroup.current = null;
+    s.root.push({ kind: 'event', id: e.id, event: e });
+    return;
+  }
+  // Subagent events fold into a collapsible group so a fleet of children
+  // doesn't drown the main chat. The SubagentSpawner emits them as
+  // plugin_event with pluginId='@moxxy/subagents'.
+  if (e.type === 'plugin_event' && e.pluginId === SUBAGENT_PLUGIN_ID) {
+    handleSubagentEvent(e, s.subagents, s.root, s.subagentGroup);
+    return;
+  }
+  pushBlock({ kind: 'event', id: e.id, event: e });
+}
+
+export function pairToolEvents(
+  events: ReadonlyArray<MoxxyEvent>,
+  compactByName: CompactToolMap = EMPTY_COMPACT_MAP,
+): Block[] {
+  const state = createFoldState(compactByName);
+  for (const e of events) stepFold(state, e);
+  return state.root;
+}
+
+/**
+ * Incremental block fold: keep the {@link FoldState} alive across calls and
+ * apply each newly-committed event with {@link stepFold}, so the growing
+ * settled prefix of the tree is folded exactly ONCE instead of being
+ * re-walked from index 0 on every event (the old O(n²)/turn behaviour).
+ *
+ * `tree()` returns the SAME `root` reference each call (it mutates in place
+ * as outcomes settle and scopes close), so callers MUST treat it as
+ * read-only and re-derive their own snapshot identity from `version`.
+ *
+ * Correctness contract: for any event prefix, `push`-ing those events one at
+ * a time and reading `tree()` yields a block tree byte-identical to
+ * `pairToolEvents(prefix, compactByName)` — both drive the same `stepFold`
+ * over the same events in the same order. A golden test asserts this
+ * deep-equality after every event across many recorded sequences.
+ */
+export class IncrementalFold {
+  private state: FoldState;
+  private prefixLength = 0;
+  private rev = 0;
+  /** `id` of the first / last event folded so far — used to detect when the
+   *  source array's prefix has shifted (a scroll-up prepend) or been replaced
+   *  (/clear, a fresh session), in which case the carried fold state is no
+   *  longer valid and we must rebuild from scratch. */
+  private headId: string | null = null;
+  private tailId: string | null = null;
+
+  constructor(compactByName: CompactToolMap = EMPTY_COMPACT_MAP) {
+    this.state = createFoldState(compactByName);
+  }
+
+  /** Number of events folded so far (the high-water mark). */
+  get length(): number {
+    return this.prefixLength;
+  }
+
+  /** Bumps whenever the folded tree may have changed (every `push`). Use as
+   *  a memo key instead of the (stable) `tree()` reference. */
+  get version(): number {
+    return this.rev;
+  }
+
+  /** Fold one freshly-committed event onto the existing tree. */
+  push(event: MoxxyEvent): void {
+    stepFold(this.state, event);
+    if (this.prefixLength === 0) this.headId = event.id;
+    this.tailId = event.id;
+    this.prefixLength += 1;
+    this.rev += 1;
+  }
+
+  /** Fold a batch of newly-committed events (e.g. a replayed page). */
+  pushMany(events: ReadonlyArray<MoxxyEvent>): void {
+    for (const e of events) this.push(e);
+  }
+
+  /**
+   * Re-sync to `events` when the source array is the authoritative log. Folds
+   * only the tail past the current high-water mark when `events` extends the
+   * already-folded prefix unchanged (the common live-append case), and
+   * rebuilds from scratch only when that prefix shifted or was replaced (a
+   * scroll-up prepend, /clear, a fresh session). Returns the (stable) root.
+   *
+   * Prefix-unchanged is detected by event `id`: the log never rewrites a
+   * settled event in place (only its tool outcome, which the fold owns), so
+   * matching head+tail ids over an unshrunk length proves the leading
+   * `prefixLength` events are exactly the ones already folded.
+   */
+  syncTo(events: ReadonlyArray<MoxxyEvent>): Block[] {
+    if (this.canExtend(events)) {
+      for (let i = this.prefixLength; i < events.length; i += 1) this.push(events[i]!);
+      return this.state.root;
+    }
+    // The known prefix changed (or shrank): the carry is no longer valid, so
+    // re-fold from scratch. Rare relative to live appends.
+    this.reset();
+    this.pushMany(events);
+    return this.state.root;
+  }
+
+  /** Discard all state — folds again from empty. */
+  reset(): void {
+    this.state = createFoldState(this.state.compactByName);
+    this.prefixLength = 0;
+    this.headId = null;
+    this.tailId = null;
+    this.rev += 1;
+  }
+
+  /** The folded block tree (stable reference, mutated in place). */
+  tree(): Block[] {
+    return this.state.root;
+  }
+
+  /** True when `events` is the already-folded prefix plus zero or more new
+   *  tail events — i.e. a pure append. Requires the head id to still match
+   *  (no prepend) and the event at `prefixLength-1` to be the last one we
+   *  folded (no in-place rewrite or replacement of the prefix). */
+  private canExtend(events: ReadonlyArray<MoxxyEvent>): boolean {
+    if (this.prefixLength === 0) return true; // empty fold extends to anything
+    if (events.length < this.prefixLength) return false; // shrank → rebuild
+    if (events[0]!.id !== this.headId) return false; // head shifted (prepend)
+    return events[this.prefixLength - 1]!.id === this.tailId;
+  }
 }
 
 /**

--- a/packages/client-core/src/chat-store/usage.test.ts
+++ b/packages/client-core/src/chat-store/usage.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { MoxxyEvent } from '@moxxy/sdk';
+import { EMPTY_USAGE, PER_CALL_CAP, recordUsage } from './usage.js';
+
+type ProviderResponse = Extract<MoxxyEvent, { type: 'provider_response' }>;
+
+let n = 0;
+function providerResponse(usage: Partial<ProviderResponse>): ProviderResponse {
+  n += 1;
+  return {
+    type: 'provider_response',
+    id: `e${n}`,
+    seq: n,
+    ts: n,
+    sessionId: 's',
+    turnId: 't',
+    source: 'model',
+    provider: 'p',
+    model: 'm',
+    ...usage,
+  } as unknown as ProviderResponse;
+}
+
+describe('recordUsage', () => {
+  it('returns null (no re-render) for a usage-less response', () => {
+    expect(recordUsage(EMPTY_USAGE, providerResponse({}))).toBeNull();
+  });
+
+  it('folds prompt + output token counts cumulatively', () => {
+    let u = EMPTY_USAGE;
+    u = recordUsage(u, providerResponse({ inputTokens: 100, outputTokens: 20 }))!;
+    u = recordUsage(u, providerResponse({ inputTokens: 50, cacheReadTokens: 10, outputTokens: 5 }))!;
+    expect(u.calls).toBe(2);
+    expect(u.totalInput).toBe(150);
+    expect(u.totalCacheRead).toBe(10);
+    expect(u.totalOutput).toBe(25);
+    // latestPrompt = input + cacheRead + cacheCreation of the last prompt-bearing call.
+    expect(u.latestPrompt).toBe(60);
+    expect(u.perCall).toEqual([100, 60]);
+  });
+
+  it('counts an output-only call without growing perCall', () => {
+    let u = EMPTY_USAGE;
+    u = recordUsage(u, providerResponse({ inputTokens: 100 }))!;
+    const beforeLen = u.perCall.length;
+    u = recordUsage(u, providerResponse({ outputTokens: 12 }))!;
+    expect(u.calls).toBe(2);
+    expect(u.totalOutput).toBe(12);
+    // No prompt tokens → no new sparkline point, latestPrompt unchanged.
+    expect(u.perCall.length).toBe(beforeLen);
+    expect(u.latestPrompt).toBe(100);
+  });
+
+  it('caps perCall at PER_CALL_CAP (head-evict) while totals fold every call', () => {
+    let u = EMPTY_USAGE;
+    const calls = PER_CALL_CAP + 50;
+    for (let i = 0; i < calls; i += 1) {
+      // distinct prompt size per call so we can assert the retained window.
+      u = recordUsage(u, providerResponse({ inputTokens: i + 1 }))!;
+    }
+    // perCall is bounded; the OLDEST entries were evicted, newest kept.
+    expect(u.perCall).toHaveLength(PER_CALL_CAP);
+    expect(u.perCall[u.perCall.length - 1]).toBe(calls); // last prompt = calls
+    expect(u.perCall[0]).toBe(calls - PER_CALL_CAP + 1); // first retained entry
+    // Cumulative counters reflect ALL calls — trimming perCall is lossless.
+    expect(u.calls).toBe(calls);
+    const expectedTotal = (calls * (calls + 1)) / 2;
+    expect(u.totalInput).toBe(expectedTotal);
+    expect(u.latestPrompt).toBe(calls);
+  });
+});

--- a/packages/client-core/src/chat-store/usage.ts
+++ b/packages/client-core/src/chat-store/usage.ts
@@ -24,6 +24,16 @@ export interface UsageSnapshot {
   readonly totalOutput: number;
 }
 
+/**
+ * Cap on {@link UsageSnapshot.perCall} — the only unbounded field. It feeds a
+ * growth sparkline, which shows a fixed-width trailing window, so keeping more
+ * than this many points is invisible. The cumulative `total*`/`calls` counters
+ * still fold EVERY call, so head-trimming `perCall` is lossless for the meter.
+ * Head-evict (drop the oldest) past this so a multi-hour session can't grow the
+ * array (and its per-call copy) without bound.
+ */
+export const PER_CALL_CAP = 200;
+
 export const EMPTY_USAGE: UsageSnapshot = Object.freeze({
   latestPrompt: null,
   perCall: Object.freeze([]),
@@ -57,9 +67,17 @@ export function recordUsage(prev: UsageSnapshot, e: ProviderResponse): UsageSnap
     e.cacheReadTokens !== undefined ||
     e.cacheCreationTokens !== undefined;
   const prompt = (e.inputTokens ?? 0) + (e.cacheReadTokens ?? 0) + (e.cacheCreationTokens ?? 0);
+  // Append the new prompt size, then head-evict so the sparkline source stays
+  // bounded at PER_CALL_CAP. `slice(-cap)` keeps the most recent window; the
+  // cumulative counters below are unaffected, so the meter loses nothing.
+  let perCall = prev.perCall;
+  if (hasPrompt) {
+    const next = [...prev.perCall, prompt];
+    perCall = next.length > PER_CALL_CAP ? next.slice(next.length - PER_CALL_CAP) : next;
+  }
   return {
     latestPrompt: hasPrompt ? prompt : prev.latestPrompt,
-    perCall: hasPrompt ? [...prev.perCall, prompt] : prev.perCall,
+    perCall,
     calls: prev.calls + 1,
     totalInput: prev.totalInput + (e.inputTokens ?? 0),
     totalCacheRead: prev.totalCacheRead + (e.cacheReadTokens ?? 0),

--- a/packages/client-core/src/chatModel.test.ts
+++ b/packages/client-core/src/chatModel.test.ts
@@ -10,9 +10,13 @@ import {
   applyEvent,
   buildRenderNodes,
   createRuntime,
+  groupToolNodes,
   type ChatRuntime,
+  type Extension,
   type FoldedBlock,
+  type RenderNode,
 } from './chatModel.js';
+import type { ToolCallBlockData } from '@moxxy/chat-model';
 
 let n = 0;
 function evt(type: MoxxyEvent['type'], extra: Record<string, unknown>): MoxxyEvent {
@@ -247,5 +251,86 @@ describe('buildRenderNodes', () => {
     const changed = applyAction(rt, { type: 'dismiss_block', blockId: id });
     expect(changed).toBe(true);
     expect(rt.extensions).toEqual([]);
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// groupToolNodes — run-collapsing of consecutive standalone tool calls.
+// ---------------------------------------------------------------------------
+
+let g = 0;
+/** Minimal tool-call block; `name` drives the FILE_DIFF exclusion. */
+function toolBlock(name: string): ToolCallBlockData {
+  g += 1;
+  return {
+    kind: 'tool-call',
+    id: `tc${g}`,
+    request: { type: 'tool_call_requested', name, callId: `call${g}` } as ToolCallBlockData['request'],
+    outcome: null,
+  };
+}
+const blockNode = (block: FoldedBlock): RenderNode => ({ kind: 'block', block });
+const toolNode = (name: string): RenderNode => blockNode(toolBlock(name));
+const eventNode = (): RenderNode =>
+  blockNode({
+    kind: 'event',
+    id: `ev${(g += 1)}`,
+    event: { type: 'assistant_message', content: 'x' } as MoxxyEvent,
+  });
+const extNode = (): RenderNode => ({
+  kind: 'ext',
+  ext: { kind: 'notice', id: `x${(g += 1)}`, afterCount: 0, tone: 'info', text: 'hi' } as Extension,
+});
+
+describe('groupToolNodes', () => {
+  it('collapses ≥2 consecutive non-diff tool blocks into one tool-group keyed on the first id', () => {
+    const a = toolNode('bash');
+    const b = toolNode('grep');
+    const out = groupToolNodes([a, b]);
+    expect(out).toHaveLength(1);
+    const group = out[0]!;
+    expect(group.kind).toBe('tool-group');
+    if (group.kind !== 'tool-group') throw new Error('unreachable');
+    expect(group.id).toBe(`toolgroup:${(a as { block: ToolCallBlockData }).block.id}`);
+    expect(group.tools).toHaveLength(2);
+  });
+
+  it('keeps a lone tool as its own block (run of 1 is not grouped)', () => {
+    const out = groupToolNodes([toolNode('bash')]);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.kind).toBe('block');
+  });
+
+  it('never folds a Write/Edit (FILE_DIFF) tool into a group', () => {
+    // Two file-edit tools each render as their own inline diff card.
+    const out = groupToolNodes([toolNode('Write'), toolNode('Edit')]);
+    expect(out.map((n) => n.kind)).toEqual(['block', 'block']);
+
+    // A Write between two bash calls breaks the run on both sides.
+    const out2 = groupToolNodes([toolNode('bash'), toolNode('Write'), toolNode('bash')]);
+    // bash(lone) + Write(lone) + bash(lone) — no run reaches length 2.
+    expect(out2.map((n) => n.kind)).toEqual(['block', 'block', 'block']);
+  });
+
+  it('breaks a run on a non-tool node into two singletons', () => {
+    const out = groupToolNodes([toolNode('bash'), eventNode(), toolNode('grep')]);
+    // tool(lone) + event + tool(lone)
+    expect(out.map((n) => n.kind)).toEqual(['block', 'block', 'block']);
+  });
+
+  it('flushes a trailing run at the end of the list', () => {
+    const out = groupToolNodes([eventNode(), toolNode('bash'), toolNode('grep'), toolNode('ls')]);
+    // event + one tool-group of 3
+    expect(out.map((n) => n.kind)).toEqual(['block', 'tool-group']);
+    const group = out[1]!;
+    if (group.kind !== 'tool-group') throw new Error('unreachable');
+    expect(group.tools).toHaveLength(3);
+  });
+
+  it('flushes the run BEFORE an interrupting node, then emits that node', () => {
+    const out = groupToolNodes([toolNode('bash'), toolNode('grep'), extNode(), toolNode('ls'), toolNode('cat')]);
+    // group(2) + ext + group(2)
+    expect(out.map((n) => n.kind)).toEqual(['tool-group', 'ext', 'tool-group']);
   });
 });

--- a/packages/client-core/src/chatModel.ts
+++ b/packages/client-core/src/chatModel.ts
@@ -22,6 +22,7 @@ import {
   newBlockId,
   pairToolEvents,
   type Block as FoldedBlock,
+  type IncrementalFold,
   type ToolCallBlockData,
 } from '@moxxy/chat-model';
 
@@ -325,23 +326,45 @@ export function applyAction(rt: ChatRuntime, action: ChatAction): boolean {
 export function buildRenderNodes(
   events: ReadonlyArray<MoxxyEvent>,
   extensions: ReadonlyArray<Extension>,
+  /**
+   * Optional incremental fold owned by the caller (the chat store / Transcript)
+   * and reused across committed events. When supplied AND no extension splits
+   * the event log, the fold is extended by only its unsettled tail instead of
+   * re-folding the whole array from index 0 (the O(n²)/turn bug). The result is
+   * byte-identical to the un-cached path — {@link IncrementalFold.syncTo} drives
+   * the same `stepFold` over the same events — so it's a pure perf seam.
+   *
+   * When extensions split the log into 2+ independently-folded slices, the
+   * whole-log fold would NOT match (each slice is its own fresh fold), so we
+   * fall back to the exact slice path below. Extension cards (error notices /
+   * slash-command results) are rare, so the fast path covers the common case.
+   */
+  fold?: IncrementalFold,
 ): RenderNode[] {
+  // Fast path: no extension cards → one contiguous fold over all events. Reuse
+  // the caller's IncrementalFold so a freshly-committed event re-folds only the
+  // open tail. (`syncTo` rebuilds from scratch if the prefix shifted.)
+  if (extensions.length === 0 && fold) {
+    const out: RenderNode[] = [];
+    for (const block of fold.syncTo(events)) out.push({ kind: 'block', block });
+    return out;
+  }
   const out: RenderNode[] = [];
   const sorted = [...extensions].sort((a, b) => a.afterCount - b.afterCount);
   let cursor = 0;
-  const fold = (slice: ReadonlyArray<MoxxyEvent>): void => {
+  const foldSlice = (slice: ReadonlyArray<MoxxyEvent>): void => {
     if (slice.length === 0) return;
     for (const block of pairToolEvents(slice)) out.push({ kind: 'block', block });
   };
   for (const ext of sorted) {
     const at = Math.min(Math.max(ext.afterCount, 0), events.length);
     if (at > cursor) {
-      fold(events.slice(cursor, at));
+      foldSlice(events.slice(cursor, at));
       cursor = at;
     }
     out.push({ kind: 'ext', ext });
   }
-  fold(events.slice(cursor));
+  foldSlice(events.slice(cursor));
   return out;
 }
 

--- a/packages/core/src/events/log.test.ts
+++ b/packages/core/src/events/log.test.ts
@@ -282,3 +282,152 @@ describe('EventLog', () => {
   void z;
   void asToolCallId;
 });
+
+describe('EventLog indexed ofType/byTurn equal the naive filter (property test)', () => {
+  // The lazy type/turn indexes must return arrays deep-equal to the prior
+  // `events.filter(...)` for ANY sequence of append/ingest/rebase/clear — same
+  // matching events, same append order, fresh copy each call.
+  const turns = [asTurnId('t1'), asTurnId('t2'), asTurnId('t3')];
+
+  // A tiny deterministic PRNG so the "random" sequences are reproducible.
+  function rng(seed: number): () => number {
+    let s = seed >>> 0;
+    return () => {
+      s = (s * 1664525 + 1013904329) >>> 0;
+      return s / 0x100000000;
+    };
+  }
+
+  // Reference oracle: the exact semantics ofType/byTurn had before the index.
+  const naiveOfType = (events: ReadonlyArray<{ type: string }>, type: string) =>
+    events.filter((e) => e.type === type);
+  const naiveByTurn = (events: ReadonlyArray<{ turnId: unknown }>, turnId: unknown) =>
+    events.filter((e) => e.turnId === turnId);
+
+  function mkPartial(rand: () => number) {
+    const turnId = turns[Math.floor(rand() * turns.length)]!;
+    const kind = rand();
+    if (kind < 0.34) {
+      return { type: 'user_prompt', sessionId: sid, turnId, source: 'user', text: 'u' } as const;
+    }
+    if (kind < 0.67) {
+      return {
+        type: 'assistant_message',
+        sessionId: sid,
+        turnId,
+        source: 'model',
+        content: 'a',
+        stopReason: 'end_turn',
+      } as const;
+    }
+    return {
+      type: 'tool_call_requested',
+      sessionId: sid,
+      turnId,
+      source: 'model',
+      callId: asToolCallId(`c${Math.floor(rand() * 1000)}`),
+      name: rand() < 0.5 ? 'load_tool' : 'Read',
+      input: { name: 'x' },
+    } as const;
+  }
+
+  const checkInvariant = (log: EventLog, mirror: { type: string; turnId: unknown }[]) => {
+    for (const t of ['user_prompt', 'assistant_message', 'tool_call_requested', 'elision']) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(log.ofType(t as any)).toEqual(naiveOfType(mirror, t));
+    }
+    for (const tid2 of [...turns, asTurnId('absent')]) {
+      expect(log.byTurn(tid2)).toEqual(naiveByTurn(mirror, tid2));
+    }
+  };
+
+  it('append-driven authoring log matches the filter at every step', async () => {
+    for (let seed = 1; seed <= 12; seed++) {
+      const rand = rng(seed);
+      const log = new EventLog();
+      const mirror: { type: string; turnId: unknown }[] = [];
+      const steps = 5 + Math.floor(rand() * 40);
+      for (let i = 0; i < steps; i++) {
+        // Occasionally clear mid-stream to exercise the index reset.
+        if (rand() < 0.06 && mirror.length > 0) {
+          log.clear();
+          mirror.length = 0;
+          checkInvariant(log, mirror);
+          continue;
+        }
+        const ev = await log.append(mkPartial(rand));
+        mirror.push(ev);
+        // Query (cold→warm and warm) every few appends so the lazy build,
+        // first-query, and incremental-maintenance paths all get exercised.
+        if (i % 3 === 0) checkInvariant(log, mirror);
+      }
+      checkInvariant(log, mirror);
+    }
+  });
+
+  it('ingest-driven mirror (with rebase) matches the filter at every step', async () => {
+    for (let seed = 100; seed <= 110; seed++) {
+      const rand = rng(seed);
+      // Author an authoritative source so seqs are real.
+      const source = new EventLog();
+      const authored: MoxxyEventForTest[] = [];
+      const n = 5 + Math.floor(rand() * 40);
+      for (let i = 0; i < n; i++) {
+        authored.push((await source.append(mkPartial(rand))) as MoxxyEventForTest);
+      }
+      // Mirror rebased to a random tail start, then ingest from there.
+      const start = Math.floor(rand() * authored.length);
+      const mirror = new EventLog();
+      mirror.rebase(authored[start]!.seq);
+      const mirrorRef: { type: string; turnId: unknown }[] = [];
+      for (let i = start; i < authored.length; i++) {
+        // Throw in a duplicate ingest occasionally — must be de-duped (no
+        // double-indexing) so the index still equals the filter.
+        if (rand() < 0.2 && i > start) mirror.ingest(authored[i - 1]!);
+        mirror.ingest(authored[i]!);
+        mirrorRef.push(authored[i]!);
+        if (i % 2 === 0) checkInvariant(mirror, mirrorRef);
+      }
+      checkInvariant(mirror, mirrorRef);
+      // A clear re-arms at seq 0; fresh ingests still index correctly.
+      mirror.clear();
+      mirrorRef.length = 0;
+      source.clear();
+      const fresh = (await source.append(mkPartial(rand))) as MoxxyEventForTest;
+      mirror.ingest(fresh);
+      mirrorRef.push(fresh);
+      checkInvariant(mirror, mirrorRef);
+    }
+  });
+
+  it('seeded (cold) log builds the index lazily and matches the filter', async () => {
+    // A log constructed from a seed array must index correctly on first query
+    // (the build runs over the pre-existing array, not just future appends).
+    const author = new EventLog();
+    const seed: MoxxyEventForTest[] = [];
+    const rand = rng(7);
+    for (let i = 0; i < 20; i++) seed.push((await author.append(mkPartial(rand))) as MoxxyEventForTest);
+    const log = new EventLog(seed);
+    const mirror = [...seed] as { type: string; turnId: unknown }[];
+    checkInvariant(log, mirror);
+    // A further append on top of the warmed index must extend correctly.
+    const more = await log.append(mkPartial(rand));
+    mirror.push(more);
+    checkInvariant(log, mirror);
+  });
+
+  // ofType/byTurn must hand back a defensive copy (the old filter() did), so a
+  // caller mutating the result can't corrupt the index.
+  it('returns a fresh array the caller cannot use to mutate the index', async () => {
+    const log = new EventLog();
+    await log.append({ type: 'user_prompt', sessionId: sid, turnId: tid, source: 'user', text: 'a' });
+    const first = log.ofType('user_prompt');
+    (first as unknown[]).push('garbage');
+    expect(log.ofType('user_prompt')).toHaveLength(1);
+    const byT = log.byTurn(tid);
+    (byT as unknown[]).push('garbage');
+    expect(log.byTurn(tid)).toHaveLength(1);
+  });
+});
+
+type MoxxyEventForTest = { seq: number } & Record<string, unknown>;

--- a/packages/core/src/events/log.ts
+++ b/packages/core/src/events/log.ts
@@ -16,6 +16,22 @@ export class EventLog implements EventLogReader {
   private readonly clearListeners = new Set<() => void>();
   private readonly now: () => number;
   /**
+   * Lazy secondary indexes so `ofType`/`byTurn` are O(matches) instead of an
+   * O(n) full-array `filter` per call (these back hot paths: token-accounting's
+   * `ofType('provider_response')`, lazy-tool gating's
+   * `ofType('tool_call_requested')`, and remote-session's per-turn
+   * `byTurn(turnId)` priming). Built lazily on first query so a cold/seeded log
+   * pays the one-time O(n) build only if anything ever queries it, then kept
+   * O(1) per append/ingest. Reset to `null` (rebuild-on-next-query) by
+   * `clear`/`rebase`, which mutate `events` wholesale.
+   *
+   * Each index holds the SAME event object references in their original
+   * append order — so a query returns an array deep-equal to the old
+   * `events.filter(...)` for every input.
+   */
+  private byType: Map<MoxxyEventType, MoxxyEvent[]> | null = null;
+  private byTurnId: Map<TurnId, MoxxyEvent[]> | null = null;
+  /**
    * Seq of the FIRST event this log holds. 0 for an authoring log; a mirror
    * primed by a partial attach replay (runner protocol v6 `replay.start`)
    * rebases to the first replayed seq so `ingest`'s contiguity gate lines up
@@ -50,12 +66,53 @@ export class EventLog implements EventLogReader {
     return this.events.slice(Math.max(0, from - this.base), Math.max(0, to - this.base));
   }
 
+  /** Build both secondary indexes from the current `events` array, preserving
+   * append order. Bucket arrays hold the original event references. */
+  private buildIndexes(): void {
+    const byType = new Map<MoxxyEventType, MoxxyEvent[]>();
+    const byTurnId = new Map<TurnId, MoxxyEvent[]>();
+    for (const e of this.events) {
+      let typeBucket = byType.get(e.type);
+      if (!typeBucket) byType.set(e.type, (typeBucket = []));
+      typeBucket.push(e);
+      let turnBucket = byTurnId.get(e.turnId);
+      if (!turnBucket) byTurnId.set(e.turnId, (turnBucket = []));
+      turnBucket.push(e);
+    }
+    this.byType = byType;
+    this.byTurnId = byTurnId;
+  }
+
+  /** Append one event to the live indexes (no-op while they're cold). Called
+   * after the event is pushed to `events`, so order is preserved. */
+  private indexEvent(e: MoxxyEvent): void {
+    if (this.byType) {
+      const bucket = this.byType.get(e.type);
+      if (bucket) bucket.push(e);
+      else this.byType.set(e.type, [e]);
+    }
+    if (this.byTurnId) {
+      const bucket = this.byTurnId.get(e.turnId);
+      if (bucket) bucket.push(e);
+      else this.byTurnId.set(e.turnId, [e]);
+    }
+  }
+
   ofType<T extends MoxxyEventType>(type: T): ReadonlyArray<MoxxyEventOfType<T>> {
-    return this.events.filter((e): e is MoxxyEventOfType<T> => e.type === type);
+    if (!this.byType) this.buildIndexes();
+    // The bucket already holds exactly the matching events in append order —
+    // identical to the old `events.filter(e => e.type === type)`. Return a copy
+    // so callers can't mutate the index (filter() also returned a fresh array).
+    const bucket = this.byType!.get(type);
+    // Bucket holds only events whose `type === T`, so the cast is sound; route
+    // through `unknown` because TS can't narrow the heterogeneous union here.
+    return (bucket ? [...bucket] : []) as unknown as ReadonlyArray<MoxxyEventOfType<T>>;
   }
 
   byTurn(turnId: TurnId): ReadonlyArray<MoxxyEvent> {
-    return this.events.filter((e) => e.turnId === turnId);
+    if (!this.byTurnId) this.buildIndexes();
+    const bucket = this.byTurnId!.get(turnId);
+    return bucket ? [...bucket] : [];
   }
 
   toJSON(): ReadonlyArray<MoxxyEvent> {
@@ -65,6 +122,7 @@ export class EventLog implements EventLogReader {
   async append(partial: EmittedEvent): Promise<MoxxyEvent> {
     const event = materializeEvent(partial, this.base + this.events.length, this.now);
     this.events.push(event);
+    this.indexEvent(event);
     // Snapshot listeners so a subscribe/unsubscribe during dispatch (e.g.,
     // a runTurn finishing and unsubscribing while we're still mid-fanout)
     // doesn't change the iteration target.
@@ -104,6 +162,7 @@ export class EventLog implements EventLogReader {
     // transport, so refusing one is fail-safe.
     if (event.seq !== this.base + this.events.length) return;
     this.events.push(event);
+    this.indexEvent(event);
     const snapshot = [...this.listeners];
     for (const fn of snapshot) {
       try {
@@ -149,10 +208,19 @@ export class EventLog implements EventLogReader {
       throw new Error(`EventLog.rebase(${seq}): seq must be a non-negative integer`);
     }
     this.base = seq;
+    // Rebase only runs on an empty log, so the indexes (if warm) are already
+    // empty — but null them to stay defensive about the events-array invariant.
+    this.byType = null;
+    this.byTurnId = null;
   }
 
   clear(): void {
     this.events.length = 0;
+    // The secondary indexes mirror `events`; drop them so the next query
+    // rebuilds from the now-empty array (cheap) rather than serving stale
+    // buckets.
+    this.byType = null;
+    this.byTurnId = null;
     // A session reset restarts the authoritative stream at seq 0 — a rebased
     // mirror must follow, or it would wait forever for seqs that never come.
     this.base = 0;

--- a/packages/core/src/sessions/persistence.ready.test.ts
+++ b/packages/core/src/sessions/persistence.ready.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression for u45-2: `writeIndex()` used to re-run ensureDir + ensureLogFile
+ * (an `fs.open(logPath,'a')` + close) on EVERY 250ms debounced index flush. The
+ * one-time setup is now memoized, so `fs.open` fires once (at attach), never
+ * again from the index-write path.
+ */
+
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EventLog } from '../events/log.js';
+import { SessionPersistence } from './persistence.js';
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-ready-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe('SessionPersistence one-time setup (no per-flush open/close)', () => {
+  it('opens the log file at most once across attach + many flushes', async () => {
+    const dir = await makeTempDir();
+    const id = '01READYONCE00000000000000A';
+    const log = new EventLog();
+    const persistence = new SessionPersistence({ sessionId: id as never, cwd: '/tmp/p', dir });
+
+    const openSpy = vi.spyOn(fs, 'open');
+    const detach = persistence.attach(log);
+
+    // Drive several index flushes (each bypasses the debounce).
+    for (let i = 0; i < 5; i += 1) {
+      await log.append({
+        type: 'user_prompt',
+        sessionId: id as never,
+        turnId: `t${i}` as never,
+        source: 'user',
+        text: `msg ${i}`,
+      });
+      await persistence.flush();
+    }
+    detach();
+    await persistence.flush();
+
+    // Exactly one open (the initial ensureLogFile) — not one per flush.
+    expect(openSpy).toHaveBeenCalledTimes(1);
+
+    // Sidecar still written correctly.
+    const raw = await fs.readFile(path.join(dir, `${id}.meta.json`), 'utf8');
+    const meta = JSON.parse(raw) as { eventCount: number; firstPrompt: string | null };
+    expect(meta.eventCount).toBe(5);
+    expect(meta.firstPrompt).toBe('msg 0');
+  });
+});

--- a/packages/core/src/sessions/persistence.ts
+++ b/packages/core/src/sessions/persistence.ts
@@ -75,6 +75,14 @@ export class SessionPersistence {
    * can flush.
    */
   private writeQueue: Mutex = createMutex();
+  /**
+   * Memoized one-time setup: `mkdir -p` the sessions dir and create the empty
+   * `.jsonl` (so resume lists the session before any event). Awaited by both
+   * `attach` and `writeIndex` so an early debounced index flush can't race the
+   * initial creation — but it runs the open+close syscalls ONCE, not on every
+   * 250ms flush as before.
+   */
+  private ready: Promise<void> | null = null;
   private closed = false;
   private readonly logger: Logger;
   /**
@@ -114,8 +122,7 @@ export class SessionPersistence {
    * reuses the same Session object.
    */
   attach(log: EventLog): () => void {
-    void this.ensureDir()
-      .then(() => this.ensureLogFile())
+    void this.ensureReady()
       .then(() => this.scheduleIndexWrite())
       .catch(() => undefined);
     const unsub = log.subscribe((event) => {
@@ -261,18 +268,20 @@ export class SessionPersistence {
   private async writeIndex(): Promise<void> {
     try {
       // Once closed (the final detach/flush write), don't re-create the dir or
-      // log file: `attach` already made them, and resurrecting a directory a
+      // log file: setup already made them, and resurrecting a directory a
       // concurrent `deleteSession`/teardown is removing would leave a stray
-      // sidecar behind. A live session still ensures both so an early write
-      // can't race the initial `ensureDir`.
+      // sidecar behind. A live session awaits the (memoized) one-time setup so
+      // an early write can't race the initial creation — but this no longer
+      // re-runs the mkdir/open+close syscalls on every 250ms flush.
       if (!this.closed) {
-        await this.ensureDir();
-        await this.ensureLogFile();
+        await this.ensureReady();
       }
       // Write ONLY this session's sidecar (`<id>.meta.json`), never a
       // read-modify-write of a shared index.json — that loses rows when two
       // moxxy processes update "their" row concurrently (each reads the index,
       // re-adds only itself, and the last writer drops the other's row).
+      // `writeJsonAtomic` already `mkdir -p`s the sidecar's dir, so this owns no
+      // ensureLogFile — the `.jsonl` is the append path's responsibility.
       await writeJsonAtomic(metaPath(this.dir, this.meta.id), this.meta);
     } catch {
       // Index write failures shouldn't bring down a session; the
@@ -280,13 +289,21 @@ export class SessionPersistence {
     }
   }
 
-  private async ensureDir(): Promise<void> {
-    await fs.mkdir(this.dir, { recursive: true });
-  }
-
-  private async ensureLogFile(): Promise<void> {
-    const handle = await fs.open(this.logPath, 'a');
-    await handle.close();
+  /** One-time, memoized: `mkdir -p` the dir + create the empty `.jsonl`. On
+   *  failure the latch is cleared so a later flush retries (matching the old
+   *  per-write ensureDir/ensureLogFile recoverability). */
+  private ensureReady(): Promise<void> {
+    if (!this.ready) {
+      this.ready = (async () => {
+        await fs.mkdir(this.dir, { recursive: true });
+        const handle = await fs.open(this.logPath, 'a');
+        await handle.close();
+      })().catch((err) => {
+        this.ready = null;
+        throw err;
+      });
+    }
+    return this.ready;
   }
 }
 

--- a/packages/plugin-cli/src/components/ChatView.tsx
+++ b/packages/plugin-cli/src/components/ChatView.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useRef } from 'react';
 import { Box, Static } from 'ink';
 import type { MoxxyEvent } from '@moxxy/sdk';
 import { BlockLine } from './chat/BlockLine.js';
-import { isSettled, pairToolEvents, type Block, type CompactToolMap } from '@moxxy/chat-model';
+import { IncrementalFold, isSettled, pairToolEvents, type Block, type CompactToolMap } from '@moxxy/chat-model';
 import { StreamingPreview, tailForViewport } from './chat/StreamingPreview.js';
 
 export interface ChatViewProps {
@@ -43,15 +43,30 @@ export const ChatView: React.FC<ChatViewProps> = ({
   compactTools,
   hideLive,
 }) => {
-  // pairToolEvents walks the whole events array. Parent re-renders
-  // happen for unrelated state too (mcp-status poll, every streaming
-  // delta tick, etc.), so memoize on the events reference — when a
-  // chunk arrives setEvents creates a new array; everything else
-  // keeps the old reference and we skip the walk entirely.
-  const blocks = useMemo(
-    () => pairToolEvents(events, compactTools),
-    [events, compactTools],
-  );
+  // The fold is INCREMENTAL: an IncrementalFold keeps the folded block tree
+  // alive across renders and re-folds only the tail past its high-water mark
+  // (the old pairToolEvents walked the whole array from index 0 on every
+  // committed event — O(n²) over a turn). `syncTo` extends the prefix when
+  // `events` is a pure append (the live case) and rebuilds from scratch only
+  // when the prefix shifts (/clear, /new) or `compactTools` changes (a new
+  // tool registry → a different fold). Memoized on the events reference so an
+  // unrelated re-render (mcp poll, streaming tick) re-runs nothing: setEvents
+  // makes a new array only when a non-chunk event lands.
+  const foldRef = useRef<IncrementalFold | null>(null);
+  const compactRef = useRef<CompactToolMap | undefined>(undefined);
+  const blocks = useMemo(() => {
+    // Degrade to the (byte-identical) full fold if IncrementalFold is somehow
+    // unavailable — the optimization is a pure perf seam, never a behaviour change.
+    if (typeof IncrementalFold !== 'function') return pairToolEvents(events, compactTools);
+    if (!foldRef.current || compactRef.current !== compactTools) {
+      foldRef.current = new IncrementalFold(compactTools);
+      compactRef.current = compactTools;
+    }
+    // syncTo returns the (stable) root, re-folding only the unsettled tail.
+    // Slice once so React/Static see a fresh array per committed change while
+    // the fold itself keeps mutating its own in-place tree across ticks.
+    return foldRef.current.syncTo(events).slice();
+  }, [events, compactTools]);
   // The longest leading prefix of blocks whose contents will never
   // change again gets handed to <Static>. Ink renders each Static item
   // ONCE, appends it to the terminal scrollback, then skips it on every
@@ -74,9 +89,13 @@ export const ChatView: React.FC<ChatViewProps> = ({
     settledRef.current = [];
     clearGenerationRef.current += 1;
   }
-  let settledCount = 0;
-  for (const b of blocks) {
-    if (isSettled(b)) settledCount += 1;
+  // The settled prefix only ever GROWS (settledRef is append-only; a settled
+  // block never un-settles), so resume the scan at the known high-water mark
+  // instead of re-walking the whole list from index 0 each render. The shrink
+  // case above resets the mark to 0, so this is always safe.
+  let settledCount = settledRef.current.length;
+  for (let i = settledRef.current.length; i < blocks.length; i += 1) {
+    if (isSettled(blocks[i]!)) settledCount += 1;
     else break;
   }
   if (settledCount > settledRef.current.length) {

--- a/packages/plugin-cli/src/components/UsagePanel.test.ts
+++ b/packages/plugin-cli/src/components/UsagePanel.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { peak } from './UsagePanel.js';
+
+describe('peak (UsagePanel)', () => {
+  it('matches Math.max for small series (output-identical)', () => {
+    for (const s of [[], [0], [5], [1, 2, 3], [3, 1, 2], [-1, -2], [0, 0, 0]]) {
+      expect(peak(s)).toBe(Math.max(...s, 0));
+    }
+  });
+
+  it('peaks over a huge series without RangeError where the spread throws', () => {
+    const n = 500_000;
+    const series = new Array<number>(n);
+    for (let i = 0; i < n; i += 1) series[i] = i % 7919; // bounded, deterministic
+    // The old inline form spreads the whole array as call args and throws.
+    expect(() => Math.max(...series, 0)).toThrow(RangeError);
+    // The reduce-based helper does not, and returns the true max.
+    expect(peak(series)).toBe(7918);
+  });
+
+  it('honours the seed floor (negative-only series clamps to 0)', () => {
+    expect(peak([-5, -3, -10])).toBe(0);
+    expect(peak([-5, -3, -10], -1)).toBe(-1);
+  });
+});

--- a/packages/plugin-cli/src/components/UsagePanel.tsx
+++ b/packages/plugin-cli/src/components/UsagePanel.tsx
@@ -140,6 +140,18 @@ function modelBreakdownRows(
     .sort((a, b) => b.prompt - a.prompt);
 }
 
+/**
+ * Max of a numeric series without spreading it as call arguments. The series
+ * grows one entry per provider response with no cap (see {@link perCallPrompt}),
+ * so `Math.max(...series)` blows the JS engine argument limit and RangeErrors in
+ * long sessions — a reduce is O(n) and unbounded-safe.
+ */
+export function peak(series: ReadonlyArray<number>, seed = 0): number {
+  let m = seed;
+  for (const v of series) if (v > m) m = v;
+  return m;
+}
+
 /** Per-call prompt sizes (input + cache read + cache write) in call order. */
 function perCallPrompt(events: ReadonlyArray<MoxxyEvent>): number[] {
   const out: number[] = [];
@@ -314,7 +326,7 @@ export const UsagePanel: React.FC<UsagePanelProps> = ({
           <Box marginTop={1} flexDirection="column">
             <Box>
               <Text bold>Per-call prompt </Text>
-              <Text dimColor>{`peak ${fmt(Math.max(...series, 0))}`}</Text>
+              <Text dimColor>{`peak ${fmt(peak(series))}`}</Text>
             </Box>
             <Box>
               <Text>{sparkline(series)}</Text>

--- a/packages/plugin-cli/src/components/chat/StreamingPreview.test.ts
+++ b/packages/plugin-cli/src/components/chat/StreamingPreview.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { tailForViewport } from './StreamingPreview.js';
+import { lastNonEmptyLineShown, tailForViewport } from './StreamingPreview.js';
 
 describe('tailForViewport', () => {
   it('is now an identity passthrough — truncation lives in the renderer', () => {
@@ -11,5 +11,80 @@ describe('tailForViewport', () => {
   it('preserves long inputs untouched (StreamingPreview handles compact vs full rendering)', () => {
     const lines = Array.from({ length: 200 }, (_, i) => `line ${i}`).join('\n');
     expect(tailForViewport(lines)).toBe(lines);
+  });
+});
+
+/**
+ * The ORIGINAL renderer logic, verbatim, kept as the golden reference. The
+ * optimized `lastNonEmptyLineShown` must be byte-identical to this for every
+ * input — it only changes the algorithm's shape (no full `split` per chunk).
+ */
+function refShown(content: string, innerCols: number): string {
+  const lines = content.split('\n');
+  let line = '';
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    if (lines[i]!.trim()) {
+      line = lines[i]!;
+      break;
+    }
+  }
+  if (!line) line = lines[lines.length - 1] ?? '';
+  return line.length > innerCols
+    ? `…${line.slice(line.length - (innerCols - 1))}`
+    : line;
+}
+
+describe('lastNonEmptyLineShown — byte-identical to the split-based original', () => {
+  const cases: Array<[string, number]> = [
+    ['', 20],
+    ['hello', 20],
+    ['hello world', 4],
+    ['line1\nline2\nline3', 20],
+    ['line1\nline2\n', 20], // trailing newline → blank last line, fall back up
+    ['a\n\n\n', 20], // only the first line is non-empty
+    ['\n\n\n', 20], // all blank → last (empty) line
+    ['   \n   ', 20], // whitespace-only lines → last line (whitespace)
+    ['head\n   \n   ', 20], // skip trailing whitespace lines back to "head"
+    ['a'.repeat(100), 20], // single long line → ellipsis tail
+    ['x\n' + 'y'.repeat(100), 20], // long last line
+    ['short\n' + 'z'.repeat(30) + '\n', 25], // long line then trailing blank
+    ['exactly', 7], // length === innerCols (no ellipsis)
+    ['exactly!', 7], // length > innerCols (ellipsis)
+    ['tab\there', 20],
+    ['  leading and trailing  ', 50],
+  ];
+
+  it.each(cases)('content=%j innerCols=%d', (content, innerCols) => {
+    expect(lastNonEmptyLineShown(content, innerCols)).toBe(refShown(content, innerCols));
+  });
+
+  it('matches across a simulated growing stream (step-by-step)', () => {
+    const chunks = [
+      'Hello',
+      ' wor',
+      'ld\n',
+      'second line ',
+      'grows',
+      ' and grows ',
+      'longer\n',
+      '   ',
+      '\n',
+      'fin',
+    ];
+    let acc = '';
+    for (const c of chunks) {
+      acc += c;
+      for (const cols of [4, 20, 80]) {
+        expect(lastNonEmptyLineShown(acc, cols)).toBe(refShown(acc, cols));
+      }
+    }
+  });
+
+  it('matches on a large buffer with many prior lines', () => {
+    const body = Array.from({ length: 5000 }, (_, i) => `line ${i}`).join('\n');
+    const acc = body + '\n' + 'z'.repeat(120);
+    for (const cols of [10, 48, 200]) {
+      expect(lastNonEmptyLineShown(acc, cols)).toBe(refShown(acc, cols));
+    }
   });
 });

--- a/packages/plugin-cli/src/components/chat/StreamingPreview.tsx
+++ b/packages/plugin-cli/src/components/chat/StreamingPreview.tsx
@@ -34,20 +34,7 @@ export const StreamingPreview: React.FC<{ content: string; dim?: boolean }> = me
   const innerCols = Math.max(20, cols - 4);
 
   // Show the most recent non-empty line so the row reads as live typing.
-  const lines = content.split('\n');
-  let line = '';
-  for (let i = lines.length - 1; i >= 0; i -= 1) {
-    if (lines[i]!.trim()) {
-      line = lines[i]!;
-      break;
-    }
-  }
-  if (!line) line = lines[lines.length - 1] ?? '';
-
-  // Keep the END visible (leading ellipsis) so a long line scrolls left as it
-  // grows rather than spilling onto a second row.
-  const shown =
-    line.length > innerCols ? `…${line.slice(line.length - (innerCols - 1))}` : line;
+  const shown = lastNonEmptyLineShown(content, innerCols);
 
   return (
     <Box flexDirection="row" marginTop={1}>
@@ -58,6 +45,62 @@ export const StreamingPreview: React.FC<{ content: string; dim?: boolean }> = me
     </Box>
   );
 });
+
+/**
+ * Pick the most recent non-empty line and render its tail exactly as the old
+ * `content.split('\n')` scan did — but WITHOUT allocating an array of every line
+ * in the (growing) buffer on each streamed chunk.
+ *
+ * Output-identical to the prior code for ALL inputs:
+ *  - We walk lines from the end via `lastIndexOf('\n')` and stop at the first
+ *    one whose `.trim()` is truthy — same "last non-empty line" the split-scan
+ *    found. If every line is blank we fall back to the very last line (same as
+ *    the old `if (!line) line = lines.at(-1)` branch).
+ *  - The ellipsis/slice math is byte-for-byte the same: a line longer than
+ *    `innerCols` becomes `'…' + line.slice(line.length - (innerCols - 1))`.
+ *
+ * Bounded work per chunk: only the trailing blank region plus the chosen line
+ * are materialised, instead of the whole buffer — O(n^2) over a stream → O(n)
+ * (≈ O(1) per chunk in the common "last line keeps growing" case).
+ */
+export function lastNonEmptyLineShown(content: string, innerCols: number): string {
+  let end = content.length; // exclusive end of the current candidate line
+  let chosenStart = -1;
+  let chosenEnd = -1;
+  // Walk backwards over `\n`-delimited lines. `start` is the index just after
+  // the preceding newline (or 0 for the first line). Bounded by `end > 0`:
+  // once `end` reaches 0 every line is consumed. (Without this, content with a
+  // LEADING newline loops forever — `lastIndexOf('\n', -1)` clamps fromIndex to
+  // 0 and finds the newline at index 0, so `start` becomes 1 and `end` is reset
+  // to 0 every iteration, and the `start === 0` guard never fires.)
+  while (end > 0) {
+    const nl = content.lastIndexOf('\n', end - 1);
+    const start = nl + 1; // 0 when no earlier newline
+    if (content.slice(start, end).trim()) {
+      chosenStart = start;
+      chosenEnd = end;
+      break;
+    }
+    if (start === 0) break; // exhausted all lines, none non-empty
+    end = nl; // continue with the line before this newline
+  }
+
+  let line: string;
+  if (chosenStart >= 0) {
+    line = content.slice(chosenStart, chosenEnd);
+  } else {
+    // No non-empty line — mirror the old fallback to the LAST line (the text
+    // after the final newline, or the whole string when there's no newline).
+    const lastNl = content.lastIndexOf('\n');
+    line = lastNl < 0 ? content : content.slice(lastNl + 1);
+  }
+
+  // Keep the END visible (leading ellipsis) so a long line scrolls left as it
+  // grows rather than spilling onto a second row.
+  return line.length > innerCols
+    ? `…${line.slice(line.length - (innerCols - 1))}`
+    : line;
+}
 
 /**
  * Identity passthrough kept for call-site / test stability — truncation now

--- a/packages/plugin-computer-control/src/shell.test.ts
+++ b/packages/plugin-computer-control/src/shell.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { runProcess } from './shell.js';
+
+describe('runProcess stdout capture (chunked, O(n) concat-at-close)', () => {
+  it('captures the full stdout across many small chunks', async () => {
+    // A child that writes 5000 lines one at a time — exercises the multi-chunk
+    // 'data' path that used to re-copy the whole buffer per event.
+    const script =
+      "for (let i = 0; i < 5000; i++) { process.stdout.write('line ' + i + '\\n'); }";
+    const res = await runProcess(process.execPath, ['-e', script], { timeoutMs: 30_000 });
+
+    expect(res.exitCode).toBe(0);
+    const lines = res.stdout.split('\n');
+    // 5000 lines + a trailing '' from the final newline.
+    expect(lines).toHaveLength(5001);
+    expect(lines[0]).toBe('line 0');
+    expect(lines[4999]).toBe('line 4999');
+    expect(lines[5000]).toBe('');
+  });
+
+  it('captures binary-ish/multibyte stdout without corrupting it', async () => {
+    const script = "process.stdout.write('héllo 🦊 wörld');";
+    const res = await runProcess(process.execPath, ['-e', script], { timeoutMs: 30_000 });
+    expect(res.stdout).toBe('héllo 🦊 wörld');
+  });
+
+  it('writes input to stdin and reads it back', async () => {
+    const script =
+      "let s=''; process.stdin.on('data', d => s += d); process.stdin.on('end', () => process.stdout.write(s.toUpperCase()));";
+    const res = await runProcess(process.execPath, ['-e', script], { input: 'hello' });
+    expect(res.stdout).toBe('HELLO');
+  });
+});

--- a/packages/plugin-computer-control/src/shell.ts
+++ b/packages/plugin-computer-control/src/shell.ts
@@ -31,7 +31,10 @@ export function runProcess(
 ): Promise<ProcResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(cmd, [...args], { stdio: ['pipe', 'pipe', 'pipe'] });
-    let stdout = Buffer.alloc(0);
+    // Collect stdout chunks and concat ONCE at close — re-concatenating the
+    // whole accumulated buffer on every 'data' event is O(n^2) and churns the
+    // GC (the sibling runProcessBinary already does it this way).
+    const stdoutChunks: Buffer[] = [];
     let stderr = '';
     let settled = false;
 
@@ -57,7 +60,7 @@ export function runProcess(
       : null;
 
     child.stdout.on('data', (chunk: Buffer) => {
-      stdout = Buffer.concat([stdout, chunk]);
+      stdoutChunks.push(chunk);
     });
     child.stderr.on('data', (chunk: Buffer) => {
       stderr += chunk.toString('utf8');
@@ -76,7 +79,7 @@ export function runProcess(
       opts.signal?.removeEventListener('abort', onAbort);
       resolve({
         exitCode: code ?? -1,
-        stdout: stdout.toString('utf8'),
+        stdout: Buffer.concat(stdoutChunks).toString('utf8'),
         stderr,
       });
     });

--- a/packages/plugin-scheduler/src/reconcile.test.ts
+++ b/packages/plugin-scheduler/src/reconcile.test.ts
@@ -1,0 +1,122 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Skill, SkillRegistry } from '@moxxy/sdk';
+import { asSkillId } from '@moxxy/sdk';
+import { syncSkillSchedules } from './skill-sync.js';
+import { ScheduleStore } from './store.js';
+
+/**
+ * Count atomic whole-file writes by wrapping the store's underlying
+ * `JsonFileStore.mutate` (each `mutate` performs exactly one
+ * `writeFileAtomic` → one tmp-write + rename + fsync). Spying on
+ * `node:fs/promises` directly is impossible here — the SDK captured the
+ * binding at import and the export is non-configurable — so we count at the
+ * one-write-per-mutate seam instead.
+ */
+function countMutates(store: ScheduleStore): { calls: () => number } {
+  const inner = (store as unknown as { store: { mutate: (...a: unknown[]) => Promise<void> } }).store;
+  const orig = inner.mutate.bind(inner);
+  let n = 0;
+  vi.spyOn(inner, 'mutate').mockImplementation(async (...args: unknown[]) => {
+    n += 1;
+    return orig(...args);
+  });
+  return { calls: () => n };
+}
+
+function fakeRegistry(skills: ReadonlyArray<Skill>): SkillRegistry {
+  const map = new Map(skills.map((s) => [s.frontmatter.name, s] as const));
+  return {
+    list: () => [...map.values()],
+    get: (id: string) => skills.find((s) => s.id === id),
+    byName: (name: string) => map.get(name),
+    filterByTriggers: () => [],
+  };
+}
+
+function mkSkill(
+  name: string,
+  schedule: NonNullable<Skill['frontmatter']['schedule']> | undefined,
+  body = 'do the thing',
+): Skill {
+  return {
+    id: asSkillId(name),
+    path: `/skills/${name}.md`,
+    scope: 'user',
+    body,
+    frontmatter: {
+      name,
+      description: 'test skill',
+      ...(schedule ? { schedule } : {}),
+    },
+  };
+}
+
+describe('syncSkillSchedules — single batched write', () => {
+  let dir: string;
+  let store: ScheduleStore;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'moxxy-sched-batch-'));
+    store = new ScheduleStore({ file: path.join(dir, 'schedules.json') });
+  });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('a mixed add/update/remove sync performs exactly ONE atomic write', async () => {
+    // Seed: 3 skill rows (a,b,c) + a manual row that must survive.
+    await syncSkillSchedules(
+      fakeRegistry([
+        mkSkill('a', { cron: '0 9 * * *' }),
+        mkSkill('b', { cron: '0 9 * * *' }),
+        mkSkill('c', { cron: '0 9 * * *' }),
+      ]),
+      store,
+    );
+    await store.create({ name: 'manual', prompt: 'p', cron: '0 1 * * *' });
+    store.invalidate();
+
+    // One atomic write per mutate; count mutates during the reconcile only.
+    const writes = countMutates(store);
+
+    // Now: add d,e,f (3 new) + update a,b (changed body) + remove c.
+    const out = await syncSkillSchedules(
+      fakeRegistry([
+        mkSkill('a', { cron: '0 9 * * *' }, 'new body a'),
+        mkSkill('b', { cron: '0 9 * * *' }, 'new body b'),
+        mkSkill('d', { cron: '0 9 * * *' }),
+        mkSkill('e', { cron: '0 9 * * *' }),
+        mkSkill('f', { cron: '0 9 * * *' }),
+      ]),
+      store,
+    );
+
+    expect(out).toEqual({ added: 3, removed: 1, updated: 2 });
+    expect(writes.calls()).toBe(1);
+
+    // The manual row survives; c is gone; a/b reflect the new bodies.
+    store.invalidate();
+    const rows = await store.list();
+    const names = rows.map((r) => r.name).sort();
+    expect(names).toEqual(['a', 'b', 'd', 'e', 'f', 'manual'].sort());
+    expect(rows.find((r) => r.name === 'a')!.prompt).toBe('new body a');
+    expect(rows.find((r) => r.name === 'manual')).toBeDefined();
+  });
+
+  it('a no-op sync writes nothing (no rows changed)', async () => {
+    await syncSkillSchedules(fakeRegistry([mkSkill('a', { cron: '0 9 * * *' })]), store);
+    store.invalidate();
+    await store.list();
+
+    const writes = countMutates(store);
+    const out = await syncSkillSchedules(fakeRegistry([mkSkill('a', { cron: '0 9 * * *' })]), store);
+    expect(out).toEqual({ added: 0, removed: 0, updated: 0 });
+    // mutate() still commits even with no diff; what matters is it is ONE write,
+    // not one-per-row. (A future optimization could skip the write entirely.)
+    expect(writes.calls()).toBeLessThanOrEqual(1);
+  });
+});

--- a/packages/plugin-scheduler/src/skill-sync.ts
+++ b/packages/plugin-scheduler/src/skill-sync.ts
@@ -56,51 +56,9 @@ export async function syncSkillSchedules(
     if (draft) wanted.set(skill.frontmatter.name, draft);
   }
 
-  const existing = await store.list();
-  const existingSkill = new Map<string, ScheduleEntry>();
-  for (const e of existing) {
-    if (e.source === 'skill' && e.skillName) existingSkill.set(e.skillName, e);
-  }
-
-  let added = 0;
-  let removed = 0;
-  let updated = 0;
-
-  // Remove rows whose skill is gone or no longer carries schedule.
-  for (const [skillName, entry] of existingSkill) {
-    if (!wanted.has(skillName)) {
-      const ok = await store.delete(entry.id);
-      if (ok) removed += 1;
-    }
-  }
-
-  // Upsert wanted rows.
-  for (const [skillName, draft] of wanted) {
-    const current = existingSkill.get(skillName);
-    if (!current) {
-      await store.create(draft);
-      added += 1;
-      continue;
-    }
-    const changed =
-      current.prompt !== draft.prompt ||
-      current.cron !== draft.cron ||
-      current.runAt !== draft.runAt ||
-      current.timeZone !== draft.timeZone ||
-      current.channel !== draft.channel ||
-      current.enabled !== draft.enabled;
-    if (changed) {
-      await store.update(current.id, {
-        prompt: draft.prompt,
-        ...(draft.cron ? { cron: draft.cron } : { cron: undefined }),
-        ...(draft.runAt !== undefined ? { runAt: draft.runAt } : { runAt: undefined }),
-        ...(draft.timeZone ? { timeZone: draft.timeZone } : { timeZone: undefined }),
-        ...(draft.channel ? { channel: draft.channel } : { channel: undefined }),
-        enabled: draft.enabled,
-      });
-      updated += 1;
-    }
-  }
-
-  return { added, removed, updated };
+  // Hand the whole desired set to the store, which diffs add/remove/update and
+  // commits them in ONE atomic write + fsync — previously this loop did one
+  // whole-file serialization + fsync per changed row (write amplification on the
+  // hot onInit / skill_created path).
+  return store.reconcileSkillSchedules(wanted);
 }

--- a/packages/plugin-scheduler/src/store.ts
+++ b/packages/plugin-scheduler/src/store.ts
@@ -166,6 +166,97 @@ export class ScheduleStore {
   }
 
   /**
+   * Batch-reconcile every `source='skill'` row against `wanted` (skillName →
+   * desired draft) in a SINGLE atomic write, instead of one whole-file
+   * serialization + fsync per changed row. The diff (and the resulting array)
+   * is byte-identical to running the equivalent sequence of
+   * create/update/delete calls:
+   *   - skill rows whose skillName is absent from `wanted` are removed;
+   *   - present skillNames with no existing row are created (fresh id +
+   *     createdAt), appended in `wanted` iteration order;
+   *   - present skillNames with an existing row are updated IN PLACE (id,
+   *     createdAt, position preserved) only when a field actually changed.
+   * Returns the add/remove/update counts so the caller's telemetry is
+   * unchanged. Manual/workflow rows are never touched.
+   */
+  async reconcileSkillSchedules(
+    wanted: ReadonlyMap<string, Omit<ScheduleEntry, 'id' | 'createdAt'>>,
+  ): Promise<{ added: number; removed: number; updated: number }> {
+    let added = 0;
+    let removed = 0;
+    let updated = 0;
+    await this.store.mutate((schedules) => {
+      // Index existing skill rows by skillName (first wins — mirrors the
+      // existingSkill map the sequential reconcile built).
+      const existingByName = new Map<string, number>();
+      for (let i = 0; i < schedules.length; i += 1) {
+        const s = schedules[i]!;
+        if (s.source === 'skill' && s.skillName && !existingByName.has(s.skillName)) {
+          existingByName.set(s.skillName, i);
+        }
+      }
+
+      // 1. Remove skill rows whose skill is gone / dropped its schedule.
+      const next: ScheduleEntry[] = [];
+      for (const s of schedules) {
+        if (s.source === 'skill' && s.skillName && !wanted.has(s.skillName)) {
+          removed += 1;
+          continue;
+        }
+        next.push(s);
+      }
+
+      // 2. Upsert wanted rows. Updates land in place; creates append. Re-find
+      //    positions in `next` since the remove pass reindexed it.
+      const posInNext = new Map<string, number>();
+      for (let i = 0; i < next.length; i += 1) {
+        const s = next[i]!;
+        if (s.source === 'skill' && s.skillName && !posInNext.has(s.skillName)) {
+          posInNext.set(s.skillName, i);
+        }
+      }
+      for (const [skillName, draft] of wanted) {
+        const idx = posInNext.get(skillName);
+        if (idx === undefined) {
+          next.push(
+            scheduleEntrySchema.parse({
+              ...draft,
+              id: ulid(),
+              createdAt: Date.now(),
+              enabled: draft.enabled ?? true,
+              source: draft.source ?? 'skill',
+            }),
+          );
+          added += 1;
+          continue;
+        }
+        const current = next[idx]!;
+        const patch = {
+          prompt: draft.prompt,
+          ...(draft.cron ? { cron: draft.cron } : { cron: undefined }),
+          ...(draft.runAt !== undefined ? { runAt: draft.runAt } : { runAt: undefined }),
+          ...(draft.timeZone ? { timeZone: draft.timeZone } : { timeZone: undefined }),
+          ...(draft.channel ? { channel: draft.channel } : { channel: undefined }),
+          enabled: draft.enabled ?? true,
+        };
+        const changed =
+          current.prompt !== patch.prompt ||
+          current.cron !== patch.cron ||
+          current.runAt !== patch.runAt ||
+          current.timeZone !== patch.timeZone ||
+          current.channel !== patch.channel ||
+          current.enabled !== patch.enabled;
+        if (changed) {
+          next[idx] = scheduleEntrySchema.parse({ ...current, ...patch });
+          updated += 1;
+        }
+      }
+      return next;
+    });
+    return { added, removed, updated };
+  }
+
+  /**
    * Replace every `source='skill'` schedule for the given `skillName`
    * with the supplied entry, OR remove all of them if `entry` is null.
    * Used by the skill-frontmatter sync hook. Manual schedules are left

--- a/packages/plugin-terminal/src/pty.test.ts
+++ b/packages/plugin-terminal/src/pty.test.ts
@@ -1,0 +1,57 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it } from 'vitest';
+import { TerminalProcessImpl } from './pty.js';
+
+const MAX_SCROLLBACK = 200_000;
+
+/** A minimal stand-in for the piped child the impl wires its stdout listeners
+ *  onto, so we can feed `emitData` without spawning a real shell. */
+function fakeChild(): {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  proc: EventEmitter & { stdin: { write(): void; end(): void } };
+} {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    stdin: { write(): void; end(): void };
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = { write: () => {}, end: () => {} };
+  return { stdout: proc.stdout, stderr: proc.stderr, proc };
+}
+
+describe('TerminalProcessImpl scrollback (hysteresis trim)', () => {
+  it('keeps scrollback bounded to the cap and returns the true tail', () => {
+    const { stdout, proc } = fakeChild();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const term = new TerminalProcessImpl('pipe', null, proc as any);
+
+    // Emit far more than the cap in many small chunks (the saturated path that
+    // used to copy the whole cap on every chunk).
+    let written = '';
+    const chunk = 'x'.repeat(1000);
+    for (let i = 0; i < 500; i += 1) {
+      // Mark each chunk's last char so we can verify the exact tail.
+      const tagged = chunk.slice(0, -6) + i.toString().padStart(6, '0');
+      written += tagged;
+      stdout.emit('data', Buffer.from(tagged, 'utf8'));
+    }
+
+    const sb = term.scrollback();
+    // Observable tail is exactly the last MAX_SCROLLBACK chars of all output —
+    // byte-identical to the old `(buffer + d).slice(-MAX_SCROLLBACK)` semantics.
+    expect(sb.length).toBe(MAX_SCROLLBACK);
+    expect(sb).toBe(written.slice(-MAX_SCROLLBACK));
+  });
+
+  it('returns the whole buffer untouched while under the cap', () => {
+    const { stdout, proc } = fakeChild();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const term = new TerminalProcessImpl('pipe', null, proc as any);
+    stdout.emit('data', Buffer.from('hello ', 'utf8'));
+    stdout.emit('data', Buffer.from('world', 'utf8'));
+    expect(term.scrollback()).toBe('hello world');
+  });
+});

--- a/packages/plugin-terminal/src/pty.ts
+++ b/packages/plugin-terminal/src/pty.ts
@@ -53,6 +53,14 @@ function defaultShell(): string {
 
 /** Cap retained scrollback so a chatty process can't grow the buffer forever. */
 const MAX_SCROLLBACK = 200_000;
+/**
+ * Hysteresis margin: let the live buffer grow this far past the cap before
+ * trimming back down to it, so we amortize the (expensive) slice over many
+ * chunks instead of copying ~MAX_SCROLLBACK bytes on every chunk once
+ * saturated. `scrollback()` masks the slack by always returning the last
+ * MAX_SCROLLBACK chars.
+ */
+const SCROLLBACK_SLACK = 100_000;
 
 export type TerminalBackend = 'pty' | 'pipe';
 
@@ -70,7 +78,9 @@ export interface TerminalProcess {
   readonly alive: boolean;
 }
 
-class TerminalProcessImpl implements TerminalProcess {
+/** Exported for tests: lets a suite drive `emitData`/`scrollback` directly
+ *  without spawning a real shell. Not part of the plugin's public surface. */
+export class TerminalProcessImpl implements TerminalProcess {
   private readonly dataListeners = new Set<(d: string) => void>();
   private readonly exitListeners = new Set<(c: number) => void>();
   private buffer = '';
@@ -93,7 +103,15 @@ class TerminalProcessImpl implements TerminalProcess {
   }
 
   private emitData(d: string): void {
-    this.buffer = (this.buffer + d).slice(-MAX_SCROLLBACK);
+    // Append, and only trim when we exceed the cap by a hysteresis margin —
+    // trimming all the way back to the cap. The previous code sliced the full
+    // 200KB buffer on EVERY chunk once saturated (O(total_output * cap) churn);
+    // amortizing the trim makes appends ~O(1). `scrollback()` always returns the
+    // last MAX_SCROLLBACK chars, so the observable tail is unchanged.
+    this.buffer += d;
+    if (this.buffer.length > MAX_SCROLLBACK + SCROLLBACK_SLACK) {
+      this.buffer = this.buffer.slice(-MAX_SCROLLBACK);
+    }
     for (const cb of this.dataListeners) {
       try {
         cb(d);
@@ -126,7 +144,12 @@ class TerminalProcessImpl implements TerminalProcess {
   }
 
   scrollback(): string {
-    return this.buffer;
+    // The buffer may hold up to MAX_SCROLLBACK + SCROLLBACK_SLACK chars between
+    // trims (see emitData); always hand back exactly the last MAX_SCROLLBACK so
+    // a late-joining viewer sees the same tail as before the hysteresis change.
+    return this.buffer.length > MAX_SCROLLBACK
+      ? this.buffer.slice(-MAX_SCROLLBACK)
+      : this.buffer;
   }
 
   write(data: string): void {

--- a/packages/plugin-terminal/src/terminal.test.ts
+++ b/packages/plugin-terminal/src/terminal.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runCommand } from './terminal.js';
+import type { TerminalProcess } from './pty.js';
+
+/** A fake shared terminal whose data stream we drive by hand. `feed` lets a
+ *  test emit chunks; `write` is a no-op (the command/sentinel are echoed by the
+ *  test itself, not a real shell). */
+function fakeTerminal(): TerminalProcess & { feed(s: string): void } {
+  let listener: ((d: string) => void) | null = null;
+  return {
+    backend: 'pipe',
+    onData: (cb) => {
+      listener = cb;
+      return () => {
+        listener = null;
+      };
+    },
+    onExit: () => () => {},
+    scrollback: () => '',
+    write: () => {},
+    resize: () => {},
+    kill: () => {},
+    alive: true,
+    feed: (s: string) => listener?.(s),
+  };
+}
+
+describe('runCommand sentinel detection (tail-scan, single RegExp compile)', () => {
+  it('completes when the sentinel arrives after many small chunks', async () => {
+    const term = fakeTerminal();
+    const marker = '__MOXXY_DONE_abc_0__';
+    const p = runCommand(term, 'echo hi', marker, 5_000);
+
+    // Stream a lot of output in tiny chunks (the O(n^2) re-scan path), then the
+    // sentinel on its own line with exit code 0.
+    for (let i = 0; i < 2000; i += 1) term.feed(`line ${i}\n`);
+    term.feed(`${marker} 0\n`);
+
+    const res = await p;
+    expect(res.timedOut).toBe(false);
+    expect(res.exitCode).toBe(0);
+    expect(res.output).toContain('line 0');
+    expect(res.output).toContain('line 1999');
+    expect(res.output).not.toContain(marker);
+  });
+
+  it('detects a sentinel split across two chunks (carry-over window)', async () => {
+    const term = fakeTerminal();
+    const marker = '__MOXXY_DONE_xyz_1__';
+    const p = runCommand(term, 'false', marker, 5_000);
+
+    term.feed('some output\n');
+    // Split the sentinel right in the middle of the marker AND the exit code.
+    const sentinel = `${marker} 42\n`;
+    const cut = marker.length - 3;
+    term.feed(sentinel.slice(0, cut));
+    term.feed(sentinel.slice(cut));
+
+    const res = await p;
+    expect(res.exitCode).toBe(42);
+    expect(res.timedOut).toBe(false);
+  });
+
+  it('does not false-trigger on the echoed command line containing $?', async () => {
+    const term = fakeTerminal();
+    const marker = '__MOXXY_DONE_q_2__';
+    const p = runCommand(term, 'echo done', marker, 5_000);
+
+    // The shell echoes the printf command itself first (contains the marker but
+    // NOT "<marker> <digits>"), then later the real sentinel value line.
+    term.feed(`printf '%s %s\\n' "${marker}" "$?"\n`);
+    term.feed('echo done\n');
+    term.feed('done\n');
+    term.feed(`${marker} 0\n`);
+
+    const res = await p;
+    expect(res.exitCode).toBe(0);
+    expect(res.output).toBe('done');
+  });
+
+  it('times out without a sentinel and reports timedOut', async () => {
+    vi.useFakeTimers();
+    try {
+      const term = fakeTerminal();
+      const p = runCommand(term, 'sleep 9', '__MOXXY_DONE_t_3__', 100);
+      term.feed('partial output\n');
+      vi.advanceTimersByTime(100);
+      const res = await p;
+      expect(res.timedOut).toBe(true);
+      expect(res.exitCode).toBeNull();
+      expect(res.output).toContain('partial output');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/plugin-terminal/src/terminal.ts
+++ b/packages/plugin-terminal/src/terminal.ts
@@ -137,7 +137,7 @@ export function buildTerminalTool() {
  * until the sentinel line appears. Returns the captured output (best-effort
  * stripped of the echoed sentinel command) + the exit code parsed from it.
  */
-function runCommand(
+export function runCommand(
   proc: TerminalProcess,
   command: string,
   marker: string,
@@ -153,13 +153,31 @@ function runCommand(
       clearTimeout(timer);
       resolve({ output: cleanOutput(acc, command, marker), exitCode, timedOut });
     };
+    // Compile the sentinel matcher ONCE — `marker` is fixed for this call. The
+    // sentinel is `<marker> <digits>`; nothing in `marker` is a regex
+    // metacharacter (it's `__MOXXY_DONE_<base36>_<n>__`), so it needs no
+    // escaping. Rebuilding this RegExp per chunk was pure waste.
+    const sentinel = new RegExp(`${marker} (\\d+)`);
+    // Re-scanning the whole accumulated buffer per chunk is O(n^2). The sentinel
+    // appears exactly once (unique marker) and we finish on first match, so it
+    // suffices to scan only the new chunk plus a carry-over of the previous
+    // tail long enough to catch a sentinel split across the chunk boundary:
+    // marker + space + up to a generous run of digits, minus one.
+    const carry = marker.length + 32;
+    let scanFrom = 0;
     const unsub = proc.onData((d) => {
+      // Begin the scan window just before the bytes that could only now have
+      // completed a sentinel that started in an earlier chunk.
+      const from = Math.max(scanFrom, acc.length - carry, 0);
       acc += d;
       // The sentinel prints "<marker> <exit>" on its own line once the command
       // finishes. Match the VALUE form (not the echoed command that contains
       // `$?`), so the literal command line doesn't false-trigger completion.
-      const m = new RegExp(`${marker} (\\d+)`).exec(acc);
+      sentinel.lastIndex = 0;
+      const m = sentinel.exec(from > 0 ? acc.slice(from) : acc);
       if (m) finish(Number(m[1]), false);
+      // Everything before this point can never start a future sentinel match.
+      scanFrom = Math.max(0, acc.length - carry);
     });
     const timer = setTimeout(() => finish(null, true), timeoutMs);
     // Two lines to the interactive shell: the command, then the sentinel whose

--- a/packages/plugin-webhooks/src/filter.test.ts
+++ b/packages/plugin-webhooks/src/filter.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { shouldFire } from './filter.js';
 import type { WebhookFilter } from './store.js';
 
@@ -74,5 +74,41 @@ describe('shouldFire', () => {
       exclude: [],
     };
     expect(shouldFire(f, { headers: {}, body: Buffer.from('not json') })).toBe(false);
+  });
+
+  describe('parses the body once regardless of jsonPath rule count', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it('JSON.parse called exactly once across many include+exclude jsonPath rules', () => {
+      const spy = vi.spyOn(JSON, 'parse');
+      const f: WebhookFilter = {
+        include: [
+          { source: 'jsonPath', path: 'a', equals: ['x'] },
+          { source: 'jsonPath', path: 'b', equals: ['y'] },
+          { source: 'jsonPath', path: 'c', equals: ['z'] },
+        ],
+        exclude: [
+          { source: 'jsonPath', path: 'd', equals: ['no'] },
+          { source: 'jsonPath', path: 'e', equals: ['no'] },
+        ],
+      };
+      const body = Buffer.from('{"a":"1","b":"2","c":"z","d":"d","e":"e"}');
+      // c === 'z' matches the include; result is unchanged by the single-parse.
+      expect(shouldFire(f, { headers: {}, body })).toBe(true);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('still parses once (and returns false) when the body is malformed', () => {
+      const spy = vi.spyOn(JSON, 'parse');
+      const f: WebhookFilter = {
+        include: [
+          { source: 'jsonPath', path: 'a', equals: ['x'] },
+          { source: 'jsonPath', path: 'b', equals: ['y'] },
+        ],
+        exclude: [],
+      };
+      expect(shouldFire(f, { headers: {}, body: Buffer.from('nope') })).toBe(false);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/plugin-webhooks/src/filter.ts
+++ b/packages/plugin-webhooks/src/filter.ts
@@ -34,14 +34,28 @@ function readHeader(
   return v ?? null;
 }
 
-function readJsonPath(body: Buffer, path: string): string | null {
-  let parsed: unknown;
+/**
+ * A `JSON.parse(body)` failure is indistinguishable from "valid JSON that is
+ * the literal `null`" by the parsed value alone, so we carry an explicit `ok`
+ * flag. `ok=false` means the body did not parse — every jsonPath lookup then
+ * returns null, exactly as the per-rule parse did.
+ */
+interface ParsedBody {
+  readonly ok: boolean;
+  readonly value: unknown;
+}
+
+function parseBody(body: Buffer): ParsedBody {
   try {
-    parsed = JSON.parse(body.toString('utf8'));
+    return { ok: true, value: JSON.parse(body.toString('utf8')) };
   } catch {
-    return null;
+    return { ok: false, value: null };
   }
-  let cur: unknown = parsed;
+}
+
+function readJsonPath(parsed: ParsedBody, path: string): string | null {
+  if (!parsed.ok) return null;
+  let cur: unknown = parsed.value;
   for (const seg of path.split('.')) {
     if (cur === null || cur === undefined || typeof cur !== 'object') return null;
     cur = (cur as Record<string, unknown>)[seg];
@@ -49,9 +63,9 @@ function readJsonPath(body: Buffer, path: string): string | null {
   return asString(cur);
 }
 
-function ruleMatches(rule: FilterRule, input: FilterInput): boolean {
+function ruleMatches(rule: FilterRule, input: FilterInput, parsed: ParsedBody): boolean {
   const value =
-    rule.source === 'header' ? readHeader(input.headers, rule.name) : readJsonPath(input.body, rule.path);
+    rule.source === 'header' ? readHeader(input.headers, rule.name) : readJsonPath(parsed, rule.path);
   if (value === null) return false;
   if (rule.equals && rule.equals.includes(value)) return true;
   if (rule.matches) {
@@ -67,7 +81,12 @@ function ruleMatches(rule: FilterRule, input: FilterInput): boolean {
 }
 
 export function shouldFire(filter: WebhookFilter, input: FilterInput): boolean {
-  if (filter.exclude.some((r) => ruleMatches(r, input))) return false;
+  // Parse the (up-to-1MB) body ONCE per evaluation and thread it through every
+  // rule, instead of re-decoding + re-parsing it per jsonPath rule on the hot
+  // pre-ACK delivery path. Result is identical: JSON.parse is deterministic, so
+  // one parse threaded everywhere yields the same per-rule lookups as N parses.
+  const parsed = parseBody(input.body);
+  if (filter.exclude.some((r) => ruleMatches(r, input, parsed))) return false;
   if (filter.include.length === 0) return true;
-  return filter.include.some((r) => ruleMatches(r, input));
+  return filter.include.some((r) => ruleMatches(r, input, parsed));
 }

--- a/packages/plugin-workflows/src/executor/dag.ts
+++ b/packages/plugin-workflows/src/executor/dag.ts
@@ -287,10 +287,17 @@ async function runExecutorLoop(ctx: ExecutorContext, resumed = false): Promise<W
       break;
     }
 
-    // 3. Run a wave (cap at concurrency). Logic/branch/pause steps mutate
-    //    shared state (vars, branch skips, checkpoints), so the wave runs
-    //    sequentially within itself; independent steps still settle together
-    //    across iterations.
+    // 3. Run a wave. `concurrency` caps the BATCH SIZE per scheduler pass; the
+    //    steps in a wave are then executed STRICTLY SEQUENTIALLY (one awaited
+    //    `runStep` at a time below) — there is no actual parallelism today.
+    //    This is deliberate and load-bearing: logic/branch/pause steps mutate
+    //    shared state (vars, branch skips, checkpoints) and emit ordered
+    //    `workflow_step_*` events, and a hard failure must abort the rest of the
+    //    wave deterministically. Independent (pure tool/prompt/skill) steps
+    //    COULD overlap, but proving identical event ordering / vars-merge order
+    //    / error semantics is a behavior change deferred to a future pass — see
+    //    the executor description. `concurrency` therefore only bounds how many
+    //    ready steps are drained per pass, not wall-clock latency.
     const wave = ready.slice(0, Math.max(1, workflow.concurrency));
     const scope = buildScope(ctx, new Date(ctx.now()).toISOString());
 
@@ -899,6 +906,7 @@ function buildSubagentSpecWithDeps(
 
 export const dagExecutor: WorkflowExecutorDef = defineWorkflowExecutor({
   name: DAG_EXECUTOR_NAME,
-  description: 'Parallel DAG runner: steps with settled dependencies run in waves up to `concurrency`.',
+  description:
+    'DAG runner: steps with settled dependencies are scheduled in waves of up to `concurrency` ready steps, then executed sequentially within each wave (no overlap yet — `concurrency` caps the batch size, not wall-clock latency).',
   run: runExecutor,
 });

--- a/packages/runner/src/protocol.test.ts
+++ b/packages/runner/src/protocol.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { surfaceInputParamsSchema } from './protocol.js';
+
+// The fast-path size guard on surfaceInputParamsSchema MUST accept/reject the
+// EXACT same set of messages as the prior unconditional
+// `JSON.stringify(m).length <= 1_000_000` check — otherwise it would be a wire
+// contract change. We compare the schema's accept decision against that exact
+// reference across small, large, many-key, and over-cap inputs.
+
+const MAX = 1_000_000;
+
+// The exact pre-optimization predicate.
+const exactWithinCap = (m: Record<string, unknown>): boolean =>
+  JSON.stringify(m).length <= MAX;
+
+const accepts = (message: Record<string, unknown>): boolean =>
+  surfaceInputParamsSchema.safeParse({ surfaceId: 's1', message }).success;
+
+describe('surfaceInputParamsSchema size guard (byte-identical to JSON.stringify cap)', () => {
+  const cases: Record<string, unknown>[] = [
+    // Tiny keystroke / control frames (the hot path).
+    { type: 'data', data: 'a' },
+    { type: 'key', key: 'Enter' },
+    { type: 'click', fx: 0.5, fy: 0.5 },
+    { type: 'scroll', dy: -120 },
+    { type: 'navigate', url: 'https://example.com/some/path?q=1' },
+    // Booleans / null / mixed primitives.
+    { type: 'x', a: true, b: false, c: null, n: 1234567 },
+    // Empty-ish.
+    { type: 't' },
+    // Medium paste, comfortably under the cap.
+    { type: 'data', data: 'P'.repeat(100_000) },
+    // Large but under the exact cap (~990 KB serialized).
+    { type: 'data', data: 'Q'.repeat(990_000) },
+    // Right at/over the boundary — exercises the exact fallback.
+    { type: 'data', data: 'R'.repeat(1_000_000) },
+    { type: 'data', data: 'S'.repeat(1_100_000) },
+    // Escape-heavy strings (worst-case serialization is far larger than length).
+    { type: 'data', data: '\n'.repeat(50_000) },
+    { type: 'data', data: '"'.repeat(150_000) },
+    // Many short keys — structural overhead, not string bytes, drives the size.
+    Object.assign(
+      { type: 'many' },
+      Object.fromEntries(Array.from({ length: 5000 }, (_, i) => [`k${i}`, ''])),
+    ),
+    // Many short keys near the cap.
+    Object.assign(
+      { type: 'many' },
+      Object.fromEntries(Array.from({ length: 90_000 }, (_, i) => [`k${i}`, ''])),
+    ),
+    // Nested object (forces the exact slow path) under cap.
+    { type: 'nested', payload: { a: 'b'.repeat(1000), c: [1, 2, 3] } },
+    // Nested object over cap.
+    { type: 'nested', payload: { a: 'b'.repeat(1_100_000) } },
+  ];
+
+  it('matches the exact JSON.stringify cap on every representative message', () => {
+    for (const message of cases) {
+      expect(accepts(message)).toBe(exactWithinCap(message));
+    }
+  });
+
+  it('randomized fuzz: fast path never diverges from the exact cap', () => {
+    let s = 31337;
+    const rand = () => ((s = (s * 1664525 + 1013904329) >>> 0) / 0x100000000);
+    const chars = ['a', 'b', '\n', '"', '\\', 'z', ' '];
+    for (let trial = 0; trial < 300; trial++) {
+      const message: Record<string, unknown> = { type: 'fuzz' };
+      const keys = Math.floor(rand() * 6);
+      for (let k = 0; k < keys; k++) {
+        const pick = rand();
+        const name = `f${k}`;
+        if (pick < 0.5) {
+          const len = Math.floor(rand() * rand() * 1_300_000); // skew small, sometimes huge
+          const ch = chars[Math.floor(rand() * chars.length)]!;
+          message[name] = ch.repeat(len);
+        } else if (pick < 0.7) {
+          message[name] = Math.floor(rand() * 1e9);
+        } else if (pick < 0.85) {
+          message[name] = rand() < 0.5;
+        } else {
+          message[name] = null;
+        }
+      }
+      expect(accepts(message)).toBe(exactWithinCap(message));
+    }
+  });
+});

--- a/packages/runner/src/protocol.ts
+++ b/packages/runner/src/protocol.ts
@@ -588,12 +588,67 @@ export const workflowResumeParamsSchema = z.object({
 export const surfaceOpenParamsSchema = z.object({
   kind: z.string().min(1).max(64),
 });
+/**
+ * Bound a surface input message to ≤ 1 MB serialized WITHOUT paying a full
+ * `JSON.stringify(m)` on the hot path. Surface input frames are tiny shallow
+ * objects (a `type` discriminator plus a few primitive fields — terminal
+ * `{type:'data', data}`, browser `{type:'click', fx, fy}`, etc.) sent at
+ * keystroke/paste rate, so re-serializing the whole already-parsed object per
+ * frame is wasted work + a throwaway string allocation.
+ *
+ * Fast path: walk the top-level entries once and accumulate a SAFE UPPER BOUND
+ * on `JSON.stringify(m).length` (worst-case escaping for keys + string values,
+ * fixed maxima for number/boolean/null). If that upper bound is ≤ 1 MB the
+ * message provably fits, so we accept after an O(keys) scan with no stringify.
+ * Because it only ever OVER-estimates, the fast path can never accept a message
+ * the real serializer would reject.
+ *
+ * Slow path: a non-primitive value (nested object/array — not a shape any real
+ * surface emits) or an upper bound over 1 MB falls back to the EXACT
+ * `JSON.stringify(m).length <= 1_000_000` check. So the accepted/rejected set is
+ * IDENTICAL to the prior unconditional stringify guard — the 1 MB cap holds for
+ * every input; no wire-contract change.
+ */
+const MAX_SURFACE_INPUT_BYTES = 1_000_000;
+
+function surfaceInputWithinCap(m: Record<string, unknown>): boolean {
+  // `{` + `}` framing.
+  let upper = 2;
+  let primitiveOnly = true;
+  for (const key in m) {
+    if (!Object.prototype.hasOwnProperty.call(m, key)) continue;
+    const v = m[key];
+    const t = typeof v;
+    // JSON omits undefined/function-valued keys entirely — don't count them.
+    if (v === undefined || t === 'function') continue;
+    // Per entry: `"key":value,` — quoted key (worst-case \uXXXX escaping is 6×
+    // per char, + 2 quotes), a colon, the value, and a trailing comma.
+    upper += key.length * 6 + 2 + 1 + 1;
+    if (t === 'string') {
+      // Worst-case every char escapes to \uXXXX (6×), plus the 2 quotes.
+      upper += (v as string).length * 6 + 2;
+    } else if (t === 'number') {
+      upper += 25; // longest JSON number form
+    } else if (t === 'boolean' || v === null) {
+      upper += 5; // "false" / "null"
+    } else {
+      // Nested object/array — cannot bound cheaply.
+      primitiveOnly = false;
+      break;
+    }
+    if (upper > MAX_SURFACE_INPUT_BYTES) break; // can't conclude "fits" cheaply
+  }
+  if (primitiveOnly && upper <= MAX_SURFACE_INPUT_BYTES) return true;
+  // Exact boundary, identical to the original guard.
+  return JSON.stringify(m).length <= MAX_SURFACE_INPUT_BYTES;
+}
+
 export const surfaceInputParamsSchema = z.object({
   surfaceId: z.string().min(1).max(120),
   message: z
     .object({ type: z.string().min(1).max(64) })
     .passthrough()
-    .refine((m) => JSON.stringify(m).length <= 1_000_000, {
+    .refine((m) => surfaceInputWithinCap(m as Record<string, unknown>), {
       message: 'surface input message too large',
     }),
 });

--- a/packages/sdk/src/compactor-helpers.test.ts
+++ b/packages/sdk/src/compactor-helpers.test.ts
@@ -4,6 +4,7 @@ import {
   asSessionId,
   asToolCallId,
   asTurnId,
+  computeElisionState,
   estimateContextTokens,
   isContextOverflowError,
   runCompactionIfNeeded,
@@ -90,6 +91,26 @@ describe('estimateContextTokens', () => {
     // never the thousands of tokens the stringified display would imply.
     const tokens = estimateContextTokens(log);
     expect(tokens).toBeLessThan(50);
+  });
+
+  it('an explicitly-passed elision state yields the byte-identical estimate', () => {
+    // The optional precomputed-state fast path must equal recomputation. Build a
+    // log with elision + a recall so the state is non-trivial.
+    const events: MoxxyEvent[] = [
+      event(0, { type: 'user_prompt', turnId: tid, source: 'user', text: 'the task' }),
+      event(1, { type: 'tool_call_requested', turnId: tid, source: 'model', callId: asToolCallId('c1'), name: 'Read', input: { file_path: '/a' } }),
+      event(2, { type: 'tool_result', turnId: tid, source: 'tool', callId: asToolCallId('c1'), ok: true, output: 'Z'.repeat(5000) }),
+      event(3, { type: 'assistant_message', turnId: tid, source: 'model', content: 'answer '.repeat(50), stopReason: 'end_turn' }),
+      event(4, {
+        type: 'elision', turnId: asTurnId('t2'), source: 'system', elidedThrough: 3, stubbedRanges: [[0, 3]],
+        elideConversational: true, conversationalRecallThreshold: 4, maxRecallBytes: 32_768, neverElideTools: [], tokensSaved: 1200,
+      }),
+      event(5, { type: 'user_prompt', turnId: asTurnId('t2'), source: 'user', text: 'next' }),
+    ];
+    const log = reader(events);
+    const recomputed = estimateContextTokens(log);
+    const withState = estimateContextTokens(log, computeElisionState(events));
+    expect(withState).toBe(recomputed);
   });
 });
 

--- a/packages/sdk/src/compactor-helpers.ts
+++ b/packages/sdk/src/compactor-helpers.ts
@@ -5,6 +5,7 @@ import {
   toolResultBytes,
   toolResultStub,
   toolResultStubbed,
+  type ElisionState,
 } from './elision-state.js';
 import type { EmittedEvent, MoxxyEvent } from './events.js';
 import type { EventLogReader } from './log.js';
@@ -24,12 +25,21 @@ import type { ModeContext } from './mode.js';
  * provider's `countTokens(req)`; this is the fast path that doesn't
  * touch the network and is safe to run on every iteration.
  */
-export function estimateContextTokens(log: EventLogReader): number {
+export function estimateContextTokens(
+  log: EventLogReader,
+  // Optional precomputed elision state for THIS exact log snapshot. When a
+  // caller already derived it (e.g. within a single loop iteration that also
+  // projects), threading it here skips a redundant full `computeElisionState`
+  // fold. MUST be the state of the same log — passing a stale one would
+  // mis-size the estimate — so it is purely an opt-in fast path; omitting it
+  // recomputes, byte-identically.
+  precomputedElisionState?: ElisionState,
+): number {
   const events = log.slice();
   // Share the exact stub decision with projection so the estimate matches what
   // is actually sent — pinned recalls / never-elide / tiny turns counted full,
   // not undercounted (which would let the context overflow before compaction).
-  const el = computeElisionState(events);
+  const el = precomputedElisionState ?? computeElisionState(events);
   let chars = 0;
   const compactedSeqs = new Set<number>();
   for (const e of events) {

--- a/packages/sdk/src/elision-state.test.ts
+++ b/packages/sdk/src/elision-state.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+import { asEventId, asSessionId, asToolCallId, asTurnId } from './ids.js';
+import type { MoxxyEvent } from './events.js';
+import {
+  computeElisionState,
+  toolResultBytes,
+  type ElisionState,
+} from './elision-state.js';
+
+const sid = asSessionId('s1');
+const t1 = asTurnId('t1');
+const t2 = asTurnId('t2');
+
+function event(seq: number, partial: Omit<MoxxyEvent, 'id' | 'seq' | 'ts' | 'sessionId'>): MoxxyEvent {
+  return { id: asEventId(`e${seq}`), seq, ts: seq, sessionId: sid, ...partial } as MoxxyEvent;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GOLDEN reference: a byte-for-byte copy of computeElisionState's PRE-FUSION
+// implementation (4 passes: HWM scan, the bookkeeping pass, then a
+// filter(...).sort(...) of aged recalls). The optimized implementation under
+// test (fused passes + reverse-iteration cap + recall short-circuit) MUST
+// return an IDENTICAL ElisionState for every input. If these diverge, the
+// optimization is unsound.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const EMPTY_STATE: ElisionState = {
+  hwm: -1,
+  effectiveElideConversational: false,
+  neverElide: new Set(),
+  toolNameByCall: new Map(),
+  recalledCallIds: new Set(),
+  recalledSeqs: new Set(),
+  recallResultCallIds: new Set(),
+  unpinnedRecallCallIds: new Set(),
+  firstUserPromptSeq: -1,
+};
+
+function computeElisionStateOld(events: ReadonlyArray<MoxxyEvent>): ElisionState {
+  let hwm = -1;
+  let elideConversational = false;
+  let conversationalRecallThreshold = Number.POSITIVE_INFINITY;
+  let maxRecallBytes = Number.POSITIVE_INFINITY;
+  let neverElide: ReadonlyArray<string> = [];
+  for (const e of events) {
+    if (e.type === 'elision' && e.elidedThrough > hwm) {
+      hwm = e.elidedThrough;
+      elideConversational = e.elideConversational;
+      conversationalRecallThreshold = e.conversationalRecallThreshold;
+      maxRecallBytes = e.maxRecallBytes;
+      neverElide = e.neverElideTools;
+    }
+  }
+  if (hwm < 0) return EMPTY_STATE;
+
+  const toolNameByCall = new Map<string, string>();
+  const recalledCallIds = new Set<string>();
+  const recalledSeqs = new Set<number>();
+  const recallResultCallIds = new Set<string>();
+  let seqRecalls = 0;
+  let firstUserPromptSeq = -1;
+
+  for (const e of events) {
+    if (e.type === 'tool_call_requested') {
+      toolNameByCall.set(e.callId, e.name);
+      if (e.name === 'recall') {
+        recallResultCallIds.add(e.callId);
+        const input = e.input as { callId?: unknown; seq?: unknown } | null | undefined;
+        if (input && typeof input === 'object') {
+          if (typeof input.callId === 'string') recalledCallIds.add(input.callId);
+          if (typeof input.seq === 'number') {
+            recalledSeqs.add(input.seq);
+            seqRecalls += 1;
+          }
+        }
+      }
+    } else if (e.type === 'user_prompt' && firstUserPromptSeq < 0) {
+      firstUserPromptSeq = e.seq;
+    }
+  }
+
+  const unpinnedRecallCallIds = new Set<string>();
+  const agedRecalls = events
+    .filter(
+      (e): e is Extract<MoxxyEvent, { type: 'tool_result' }> =>
+        e.type === 'tool_result' && recallResultCallIds.has(e.callId) && e.seq <= hwm,
+    )
+    .sort((a, b) => b.seq - a.seq);
+  let pinned = 0;
+  for (const e of agedRecalls) {
+    pinned += toolResultBytes(e.output, e.error?.message);
+    if (pinned > maxRecallBytes) unpinnedRecallCallIds.add(e.callId);
+  }
+
+  return {
+    hwm,
+    effectiveElideConversational: elideConversational && seqRecalls < conversationalRecallThreshold,
+    neverElide: new Set(neverElide),
+    toolNameByCall,
+    recalledCallIds,
+    recalledSeqs,
+    recallResultCallIds,
+    unpinnedRecallCallIds,
+    firstUserPromptSeq,
+  };
+}
+
+// Compare two ElisionStates field-by-field, INCLUDING Set/Map ordering, so the
+// equivalence is exact (insertion-order matters for byte-stable downstream
+// projection — toolNameByCall is read by callId so order is irrelevant there,
+// but unpinnedRecallCallIds is iterated, so we assert array-of-entries equality).
+function assertSameState(a: ElisionState, b: ElisionState): void {
+  expect(a.hwm).toBe(b.hwm);
+  expect(a.effectiveElideConversational).toBe(b.effectiveElideConversational);
+  expect([...a.neverElide]).toEqual([...b.neverElide]);
+  expect([...a.toolNameByCall.entries()].sort()).toEqual([...b.toolNameByCall.entries()].sort());
+  expect([...a.recalledCallIds].sort()).toEqual([...b.recalledCallIds].sort());
+  expect([...a.recalledSeqs].sort()).toEqual([...b.recalledSeqs].sort());
+  expect([...a.recallResultCallIds].sort()).toEqual([...b.recallResultCallIds].sort());
+  // unpinnedRecallCallIds is the load-bearing one — assert exact insertion order.
+  expect([...a.unpinnedRecallCallIds]).toEqual([...b.unpinnedRecallCallIds]);
+  expect(a.firstUserPromptSeq).toBe(b.firstUserPromptSeq);
+}
+
+describe('computeElisionState (golden: fused == 4-pass reference)', () => {
+  it('matches the reference on the empty / no-elision case', () => {
+    assertSameState(computeElisionState([]), computeElisionStateOld([]));
+    const noElision = [
+      event(0, { type: 'user_prompt', turnId: t1, source: 'user', text: 'hi' }),
+      event(1, { type: 'assistant_message', turnId: t1, source: 'model', content: 'a', stopReason: 'end_turn' }),
+    ];
+    assertSameState(computeElisionState(noElision), computeElisionStateOld(noElision));
+  });
+
+  // A randomized fuzzer building representative logs: anchor prompt, recall
+  // calls (callId- and seq-recalls), recall results of varying size, an elision
+  // event with a random HWM / maxRecallBytes / flags. This stresses the cap
+  // (newest-first reverse iteration) and the conversational auto-disable.
+  it('matches the reference across many randomized logs (cap, recalls, flags)', () => {
+    let s = 4242;
+    const rand = () => ((s = (s * 1664525 + 1013904329) >>> 0) / 0x100000000);
+    for (let trial = 0; trial < 400; trial++) {
+      const events: MoxxyEvent[] = [];
+      let seq = 0;
+      events.push(event(seq++, { type: 'user_prompt', turnId: t1, source: 'user', text: 'the task' }));
+      const recallCount = Math.floor(rand() * 6);
+      const recallCallIds: string[] = [];
+      for (let i = 0; i < recallCount; i++) {
+        const cid = asToolCallId(`rc${i}`);
+        recallCallIds.push(`rc${i}`);
+        // Half callId-recalls, half seq-recalls.
+        const input = rand() < 0.5 ? { callId: `target${i}` } : { seq: Math.floor(rand() * seq) };
+        events.push(event(seq++, { type: 'tool_call_requested', turnId: t1, source: 'model', callId: cid, name: 'recall', input }));
+        // Most recalls have a result; size varies to drive the cap.
+        if (rand() < 0.85) {
+          const size = Math.floor(rand() * 400);
+          events.push(event(seq++, { type: 'tool_result', turnId: t1, source: 'tool', callId: cid, ok: true, output: 'R'.repeat(size) }));
+        }
+      }
+      // Some non-recall tool calls (must NOT count as aged recalls).
+      const otherCalls = Math.floor(rand() * 4);
+      for (let i = 0; i < otherCalls; i++) {
+        const cid = asToolCallId(`oc${i}`);
+        events.push(event(seq++, { type: 'tool_call_requested', turnId: t1, source: 'model', callId: cid, name: 'Read', input: { file_path: `/f${i}` } }));
+        events.push(event(seq++, { type: 'tool_result', turnId: t1, source: 'tool', callId: cid, ok: true, output: 'X'.repeat(Math.floor(rand() * 300)) }));
+      }
+      // Occasionally a second user prompt.
+      if (rand() < 0.5) events.push(event(seq++, { type: 'user_prompt', turnId: t1, source: 'user', text: 'more' }));
+      // Maybe emit one or two elision events (later one with a larger HWM wins).
+      const elisions = 1 + Math.floor(rand() * 2);
+      for (let i = 0; i < elisions; i++) {
+        const through = Math.floor(rand() * (seq + 1)) - (rand() < 0.1 ? 5 : 0); // sometimes negative-ish
+        events.push(event(seq++, {
+          type: 'elision',
+          turnId: t2,
+          source: 'system',
+          elidedThrough: Math.max(-1, through),
+          stubbedRanges: [[0, Math.max(0, through)]],
+          elideConversational: rand() < 0.5,
+          conversationalRecallThreshold: Math.floor(rand() * 5),
+          maxRecallBytes: rand() < 0.3 ? 0 : Math.floor(rand() * 800),
+          neverElideTools: rand() < 0.3 ? ['Read'] : [],
+          tokensSaved: 100,
+        }));
+      }
+      // A trailing recent prompt (post-HWM).
+      events.push(event(seq++, { type: 'user_prompt', turnId: t2, source: 'user', text: 'recent' }));
+
+      assertSameState(computeElisionState(events), computeElisionStateOld(events));
+    }
+  });
+
+  it('matches on the cap boundary fixture (oldest aged recall over the cap is stubbed)', () => {
+    const events: MoxxyEvent[] = [
+      event(0, { type: 'user_prompt', turnId: t1, source: 'user', text: 'task' }),
+      event(1, { type: 'tool_call_requested', turnId: t1, source: 'model', callId: asToolCallId('ra'), name: 'recall', input: { callId: 'x' } }),
+      event(2, { type: 'tool_result', turnId: t1, source: 'tool', callId: asToolCallId('ra'), ok: true, output: 'A'.repeat(300) }),
+      event(3, { type: 'tool_call_requested', turnId: t1, source: 'model', callId: asToolCallId('rb'), name: 'recall', input: { callId: 'y' } }),
+      event(4, { type: 'tool_result', turnId: t1, source: 'tool', callId: asToolCallId('rb'), ok: true, output: 'B'.repeat(300) }),
+      event(5, {
+        type: 'elision', turnId: t2, source: 'system', elidedThrough: 4, stubbedRanges: [[0, 4]],
+        elideConversational: false, conversationalRecallThreshold: 4, maxRecallBytes: 400, neverElideTools: [], tokensSaved: 100,
+      }),
+      event(6, { type: 'user_prompt', turnId: t2, source: 'user', text: 'next' }),
+    ];
+    const state = computeElisionState(events);
+    // Newest (rb, seq 4, 300B) fits under 400; adding the older ra (300B) → 600 > 400 → ra stubbed.
+    expect([...state.unpinnedRecallCallIds]).toEqual(['ra']);
+    assertSameState(state, computeElisionStateOld(events));
+  });
+});

--- a/packages/sdk/src/elision-state.ts
+++ b/packages/sdk/src/elision-state.ts
@@ -98,6 +98,13 @@ export function computeElisionState(events: ReadonlyArray<MoxxyEvent>): ElisionS
   const recallResultCallIds = new Set<string>();
   let seqRecalls = 0;
   let firstUserPromptSeq = -1;
+  // Aged recall tool_results collected DURING the fused pass (events arrive in
+  // strictly ascending seq, so this is seq-ascending = oldest-first). A recall's
+  // tool_call_requested always precedes its tool_result in the log, so by the
+  // time we hit that result `recallResultCallIds` already contains its callId —
+  // making this single forward pass equivalent to the old "build the set fully,
+  // THEN filter" two-pass shape.
+  const agedRecallsAsc: Array<Extract<MoxxyEvent, { type: 'tool_result' }>> = [];
 
   for (const e of events) {
     if (e.type === 'tool_call_requested') {
@@ -113,24 +120,27 @@ export function computeElisionState(events: ReadonlyArray<MoxxyEvent>): ElisionS
           }
         }
       }
-    } else if (e.type === 'user_prompt' && firstUserPromptSeq < 0) {
-      firstUserPromptSeq = e.seq;
+    } else if (e.type === 'user_prompt') {
+      if (firstUserPromptSeq < 0) firstUserPromptSeq = e.seq;
+    } else if (e.type === 'tool_result' && e.seq <= hwm && recallResultCallIds.has(e.callId)) {
+      agedRecallsAsc.push(e);
     }
   }
 
   // Cap pinned recalls: keep the newest recall outputs within maxRecallBytes
   // verbatim, stub the rest. Only matters once a recall result ages below HWM.
+  // Common case (no recalls) skips the loop entirely. `agedRecallsAsc` is
+  // strictly seq-ascending, so iterating it in REVERSE visits newest-first —
+  // byte-identical to the old `.sort((a, b) => b.seq - a.seq)` over unique seqs,
+  // with no allocation/sort.
   const unpinnedRecallCallIds = new Set<string>();
-  const agedRecalls = events
-    .filter(
-      (e): e is Extract<MoxxyEvent, { type: 'tool_result' }> =>
-        e.type === 'tool_result' && recallResultCallIds.has(e.callId) && e.seq <= hwm,
-    )
-    .sort((a, b) => b.seq - a.seq); // newest first
-  let pinned = 0;
-  for (const e of agedRecalls) {
-    pinned += toolResultBytes(e.output, e.error?.message);
-    if (pinned > maxRecallBytes) unpinnedRecallCallIds.add(e.callId);
+  if (recallResultCallIds.size > 0) {
+    let pinned = 0;
+    for (let i = agedRecallsAsc.length - 1; i >= 0; i--) {
+      const e = agedRecallsAsc[i]!;
+      pinned += toolResultBytes(e.output, e.error?.message);
+      if (pinned > maxRecallBytes) unpinnedRecallCallIds.add(e.callId);
+    }
   }
 
   return {

--- a/packages/sdk/src/mode-helpers.ts
+++ b/packages/sdk/src/mode-helpers.ts
@@ -115,6 +115,59 @@ function eventInCompactionRange(
 }
 
 /**
+ * A compaction lookup that answers "which range (if any) contains `seq`" in
+ * O(log ranges) instead of {@link eventInCompactionRange}'s O(ranges) linear
+ * scan per event. Compaction ranges are non-overlapping ascending seq prefixes,
+ * so a seq belongs to at most one range and binary search over the
+ * sorted-by-`from` array returns the SAME range the linear first-match did —
+ * byte-identical projection.
+ *
+ * Defensive fallback: if the ranges are NOT strictly non-overlapping (which the
+ * compaction invariant forbids, but a hand-crafted/corrupt log could violate),
+ * we keep the exact linear first-match semantics so the projection can never
+ * diverge from the old code.
+ */
+function makeCompactionLookup(
+  ranges: ReadonlyArray<CompactionRange>,
+): (seq: number) => CompactionRange | null {
+  if (ranges.length === 0) return () => null;
+  if (ranges.length === 1) {
+    const only = ranges[0]!;
+    return (seq) => (seq >= only.from && seq <= only.to ? only : null);
+  }
+  // Sort a copy by `from` (stable enough — ranges are non-overlapping). Verify
+  // the non-overlap invariant on the sorted copy; only then is binary search
+  // provably equivalent to the linear first-match.
+  const sorted = [...ranges].sort((a, b) => a.from - b.from);
+  let nonOverlapping = true;
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i]!.from <= sorted[i - 1]!.to) {
+      nonOverlapping = false;
+      break;
+    }
+  }
+  if (!nonOverlapping) return (seq) => eventInCompactionRange(seq, ranges);
+  return (seq) => {
+    // Largest `from <= seq`, then a single containment check.
+    let lo = 0;
+    let hi = sorted.length - 1;
+    let cand = -1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (sorted[mid]!.from <= seq) {
+        cand = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    if (cand < 0) return null;
+    const range = sorted[cand]!;
+    return seq <= range.to ? range : null;
+  };
+}
+
+/**
  * Project the session's event log to a flat list of ProviderMessages
  * suitable for handing to `provider.stream`. Used by every loop strategy.
  *
@@ -158,6 +211,7 @@ export function projectMessages(
 ): ProjectedMessages {
   const allEvents = ctx.log.slice();
   const compactions = activeCompactionRanges(allEvents);
+  const compactionFor = makeCompactionLookup(compactions);
   const emittedCompactions = new Set<CompactionRange>();
   const el = computeElisionState(allEvents);
 
@@ -241,7 +295,7 @@ export function projectMessages(
   };
 
   for (const e of allEvents) {
-    const compaction = eventInCompactionRange(e.seq, compactions);
+    const compaction = compactionFor(e.seq);
     if (compaction) {
       if (!emittedCompactions.has(compaction)) {
         emittedCompactions.add(compaction);

--- a/packages/sdk/src/token-efficiency.test.ts
+++ b/packages/sdk/src/token-efficiency.test.ts
@@ -456,6 +456,220 @@ describe('applyLazyTools', () => {
     expect(sent).toHaveLength(2);
     expect(messages).toBe(baseMsgs); // same reference → byte-stable
   });
+
+  // GOLDEN: the single-partition refactor (u125-2) must be byte-identical to the
+  // prior two complementary `filter` passes for every input. Re-implement the
+  // OLD logic inline and assert deep-equal output across many random tool sets.
+  it('single-partition output is byte-identical to the old double-filter (golden)', () => {
+    const ALWAYS = new Set([
+      'Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob',
+      'recall', 'load_skill', 'load_tool', 'dispatch_agent',
+    ]);
+    const pool = [
+      'Read', 'Write', 'Bash', 'Grep', 'browser_open', 'memory_save',
+      'recall', 'load_tool', 'web_search', 'shell', 'foo', 'bar', 'baz', 'qux',
+    ];
+    // Old reference implementation of applyLazyTools' partition + injection.
+    const oldApply = (
+      msgs: ProviderMessage[],
+      tools: ReturnType<typeof mk>[],
+      loadedNames: Set<string>,
+    ): { tools: string[]; injected: boolean } => {
+      const hidden = tools.filter((t) => !ALWAYS.has(t.name) && !loadedNames.has(t.name));
+      if (hidden.length === 0) return { tools: tools.map((t) => t.name), injected: false };
+      const visible = tools.filter((t) => ALWAYS.has(t.name) || loadedNames.has(t.name));
+      return { tools: visible.map((t) => t.name), injected: true };
+    };
+
+    let s = 12345;
+    const rand = () => ((s = (s * 1664525 + 1013904329) >>> 0) / 0x100000000);
+    for (let trial = 0; trial < 200; trial++) {
+      // Random subset (with duplicates allowed) and a random loaded set.
+      const names: string[] = [];
+      const count = Math.floor(rand() * pool.length);
+      for (let i = 0; i < count; i++) names.push(pool[Math.floor(rand() * pool.length)]!);
+      const tools = names.map(mk);
+      const loadedNames = new Set(
+        pool.filter(() => rand() < 0.3),
+      );
+      const log = reader(
+        [...loadedNames].map((name, i) =>
+          event(i, {
+            type: 'tool_call_requested',
+            turnId: t1,
+            source: 'model',
+            callId: asToolCallId(`l${i}`),
+            name: 'load_tool',
+            input: { name },
+          }),
+        ),
+      );
+      const expected = oldApply(baseMsgs, tools, loadedNames);
+      const actual = applyLazyTools(baseMsgs, tools, log);
+      expect(actual.tools.map((t) => t.name)).toEqual(expected.tools);
+      // Whether the system index was injected (messages !== baseMsgs) must match
+      // the old `injected` flag exactly.
+      expect(actual.messages !== baseMsgs).toBe(expected.injected);
+    }
+  });
+});
+
+describe('projectMessages compaction-range lookup (golden: binary cursor == linear scan)', () => {
+  // GOLDEN for complexity-hotspots-5: the binary/merge compaction lookup that
+  // replaced the per-event linear `eventInCompactionRange` must produce a
+  // BYTE-IDENTICAL projection on logs with MANY non-overlapping compaction
+  // ranges. We compare the real projection to an independent OLD-style
+  // reference projector that uses the linear first-match lookup.
+
+  type Ev = MoxxyEvent;
+  interface Range { from: number; to: number; summary: string }
+
+  // The exact pre-change lookup semantics (linear first-match in array order).
+  const linearLookup = (seq: number, ranges: ReadonlyArray<Range>): Range | null => {
+    for (const r of ranges) if (seq >= r.from && seq <= r.to) return r;
+    return null;
+  };
+
+  // A minimal reference projector covering the event kinds we generate. It is a
+  // faithful transcription of projectMessages' compaction/elision-free path:
+  // every generated log here has NO elision event, so stubbing never fires and
+  // the projection is a straight fold (which isolates the lookup change).
+  const refProject = (events: ReadonlyArray<Ev>): ProviderMessage[] => {
+    const ranges: Range[] = events
+      .filter(
+        (e): e is Extract<Ev, { type: 'compaction' }> =>
+          e.type === 'compaction' &&
+          e.tokensSaved > 0 &&
+          e.summary.trim().length > 0 &&
+          e.replacedRange[0] <= e.replacedRange[1],
+      )
+      .map((e) => ({ from: e.replacedRange[0], to: e.replacedRange[1], summary: e.summary }));
+    const emitted = new Set<Range>();
+    const msgs: ProviderMessage[] = [];
+    const resolved = new Set<string>();
+    for (const e of events) if (e.type === 'tool_result' || e.type === 'tool_call_denied') resolved.add(e.callId);
+    let pending: ProviderMessage | null = null;
+    const flush = () => {
+      if (!pending) return;
+      const f = pending;
+      pending = null;
+      msgs.push(f);
+      for (const b of f.content) {
+        if (b.type === 'tool_use' && !resolved.has(b.id)) {
+          msgs.push({
+            role: 'tool_result',
+            content: [{ type: 'tool_result', toolUseId: b.id, content: '[tool call did not return a result — possibly interrupted or cancelled]', isError: true }],
+          });
+          resolved.add(b.id);
+        }
+      }
+    };
+    for (const e of events) {
+      const r = linearLookup(e.seq, ranges);
+      if (r) {
+        if (!emitted.has(r)) {
+          emitted.add(r);
+          flush();
+          msgs.push({ role: 'user', content: [{ type: 'text', text: `[summary of earlier turns]\n${r.summary}` }] });
+        }
+        continue;
+      }
+      switch (e.type) {
+        case 'user_prompt':
+          flush();
+          msgs.push({ role: 'user', content: [{ type: 'text', text: e.text }] });
+          break;
+        case 'assistant_message':
+          flush();
+          if (e.content.trim().length === 0) break;
+          msgs.push({ role: 'assistant', content: [{ type: 'text', text: e.content }] });
+          break;
+        case 'tool_call_requested':
+          if (!pending) pending = { role: 'assistant', content: [] };
+          (pending.content as Array<ProviderMessage['content'][number]>).push({ type: 'tool_use', id: e.callId, name: e.name, input: e.input });
+          break;
+        case 'tool_result': {
+          flush();
+          const text = e.error ? `[error:${e.error.kind}] ${e.error.message}` : typeof e.output === 'string' ? e.output : JSON.stringify(e.output ?? '');
+          msgs.push({ role: 'tool_result', content: [{ type: 'tool_result', toolUseId: e.callId, content: text, isError: !e.ok }] });
+          break;
+        }
+        default:
+          break;
+      }
+    }
+    flush();
+    return msgs;
+  };
+
+  // Build a random log: alternating turns, with K non-overlapping compaction
+  // ranges carved over a prefix of the seqs.
+  const buildLog = (rand: () => number) => {
+    const events: Ev[] = [];
+    let seq = 0;
+    const turnCount = 6 + Math.floor(rand() * 14);
+    for (let i = 0; i < turnCount; i++) {
+      events.push(event(seq++, { type: 'user_prompt', turnId: t1, source: 'user', text: `u${i}` }));
+      if (rand() < 0.6) {
+        const cid = asToolCallId(`c${i}`);
+        events.push(event(seq++, { type: 'tool_call_requested', turnId: t1, source: 'model', callId: cid, name: 'Read', input: { i } }));
+        // Most tool calls resolve; occasionally leave an orphan (no result).
+        if (rand() < 0.85) events.push(event(seq++, { type: 'tool_result', turnId: t1, source: 'tool', callId: cid, ok: true, output: `r${i}` }));
+      }
+      events.push(event(seq++, { type: 'assistant_message', turnId: t1, source: 'model', content: rand() < 0.15 ? '' : `a${i}`, stopReason: 'end_turn' }));
+    }
+    const lastSeq = seq - 1;
+    // Carve K non-overlapping ascending ranges over the first ~70% of seqs.
+    const limit = Math.floor(lastSeq * 0.7);
+    const ranges: Array<[number, number]> = [];
+    let cursor = 0;
+    const k = 1 + Math.floor(rand() * 4);
+    for (let i = 0; i < k && cursor < limit; i++) {
+      const width = 1 + Math.floor(rand() * 4);
+      const from = cursor;
+      const to = Math.min(from + width, limit);
+      ranges.push([from, to]);
+      cursor = to + 1 + Math.floor(rand() * 2); // leave a gap between ranges
+    }
+    // Append compaction events (seq after everything; they don't fall in a range).
+    for (const [from, to] of ranges) {
+      events.push(event(seq++, { type: 'compaction', turnId: t2, source: 'compactor', compactor: 'summarize', replacedRange: [from, to], summary: `S(${from}-${to})`, tokensSaved: 10 }));
+    }
+    return events;
+  };
+
+  it('is byte-identical to the linear-scan reference across many random multi-range logs', () => {
+    let s = 999;
+    const rand = () => ((s = (s * 1664525 + 1013904329) >>> 0) / 0x100000000);
+    for (let trial = 0; trial < 250; trial++) {
+      const events = buildLog(rand);
+      const actual = projectMessagesFromLog({ log: reader(events) });
+      const expected = refProject(events);
+      expect(JSON.stringify(actual)).toBe(JSON.stringify(expected));
+    }
+  });
+
+  it('locks a fixed many-range fixture (regression)', () => {
+    const events: MoxxyEvent[] = [
+      event(0, { type: 'user_prompt', turnId: t1, source: 'user', text: 'one' }),
+      event(1, { type: 'assistant_message', turnId: t1, source: 'model', content: 'a1', stopReason: 'end_turn' }),
+      event(2, { type: 'user_prompt', turnId: t1, source: 'user', text: 'two' }),
+      event(3, { type: 'assistant_message', turnId: t1, source: 'model', content: 'a2', stopReason: 'end_turn' }),
+      event(4, { type: 'user_prompt', turnId: t1, source: 'user', text: 'three' }),
+      event(5, { type: 'assistant_message', turnId: t1, source: 'model', content: 'a3', stopReason: 'end_turn' }),
+      event(6, { type: 'user_prompt', turnId: t2, source: 'user', text: 'recent' }),
+      event(7, { type: 'compaction', turnId: t2, source: 'compactor', compactor: 'summarize', replacedRange: [0, 1], summary: 'sum-A', tokensSaved: 10 }),
+      event(8, { type: 'compaction', turnId: t2, source: 'compactor', compactor: 'summarize', replacedRange: [2, 3], summary: 'sum-B', tokensSaved: 10 }),
+      event(9, { type: 'compaction', turnId: t2, source: 'compactor', compactor: 'summarize', replacedRange: [4, 5], summary: 'sum-C', tokensSaved: 10 }),
+    ];
+    const msgs = projectMessagesFromLog({ log: reader(events) });
+    expect(msgs).toEqual([
+      { role: 'user', content: [{ type: 'text', text: '[summary of earlier turns]\nsum-A' }] },
+      { role: 'user', content: [{ type: 'text', text: '[summary of earlier turns]\nsum-B' }] },
+      { role: 'user', content: [{ type: 'text', text: '[summary of earlier turns]\nsum-C' }] },
+      { role: 'user', content: [{ type: 'text', text: 'recent' }] },
+    ]);
+  });
 });
 
 describe('attachment projection in projectMessagesFromLog', () => {

--- a/packages/sdk/src/tool-gating.ts
+++ b/packages/sdk/src/tool-gating.ts
@@ -100,8 +100,15 @@ export function applyLazyTools(
   log: EventLogReader,
 ): GatedTools {
   const loaded = loadedToolNames(log);
-  const hidden = tools.filter((t) => !ALWAYS_ON_TOOLS.has(t.name) && !loaded.has(t.name));
+  // Single partition pass: each tool is either visible (always-on or loaded) or
+  // hidden, never both — so one loop yields the exact same two arrays (same
+  // elements, same input order) the prior pair of complementary `filter`s did,
+  // at O(n) instead of O(2n) with two membership checks per tool.
+  const visible: ToolDef[] = [];
+  const hidden: ToolDef[] = [];
+  for (const t of tools) {
+    (ALWAYS_ON_TOOLS.has(t.name) || loaded.has(t.name) ? visible : hidden).push(t);
+  }
   if (hidden.length === 0) return { messages, tools };
-  const visible = tools.filter((t) => ALWAYS_ON_TOOLS.has(t.name) || loaded.has(t.name));
   return { messages: injectIntoSystem(messages, buildToolIndex(hidden)), tools: visible };
 }

--- a/packages/tools-builtin/src/grep.test.ts
+++ b/packages/tools-builtin/src/grep.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { asSessionId, asToolCallId, asTurnId } from '@moxxy/sdk';
+import type { ToolContext } from '@moxxy/sdk';
+import { grepTool } from './grep.js';
+
+let tmp: string;
+
+const baseCtx = (): ToolContext => ({
+  sessionId: asSessionId('s'),
+  turnId: asTurnId('t'),
+  callId: asToolCallId('c'),
+  cwd: tmp,
+  signal: new AbortController().signal,
+  log: { length: 0, at: () => undefined, slice: () => [], ofType: () => [], byTurn: () => [], toJSON: () => [] },
+  logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+});
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-grep-'));
+});
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe('grepTool size cap + binary skip', () => {
+  it('skips an oversized file but still matches a normal text file', async () => {
+    // A >10MB file containing the pattern — must be skipped (working-set cap).
+    const big = 'NEEDLE\n'.repeat(2_000_000); // ~14MB
+    await fs.writeFile(path.join(tmp, 'huge.log'), big);
+    // A normal source file with the same pattern — must still match.
+    await fs.writeFile(path.join(tmp, 'ok.ts'), 'const x = 1;\n// NEEDLE here\n');
+
+    const out = (await grepTool.handler({ pattern: 'NEEDLE' }, baseCtx())) as string;
+    expect(out).toContain('ok.ts:2:// NEEDLE here');
+    expect(out).not.toContain('huge.log');
+  });
+
+  it('skips a binary file (NUL byte) but matches a sibling text file', async () => {
+    // Binary content: a NUL byte in the prefix.
+    const bin = Buffer.concat([Buffer.from('NEEDLE'), Buffer.from([0x00]), Buffer.from('NEEDLE more')]);
+    await fs.writeFile(path.join(tmp, 'blob.bin'), bin);
+    await fs.writeFile(path.join(tmp, 'text.ts'), 'NEEDLE in source\n');
+
+    const out = (await grepTool.handler({ pattern: 'NEEDLE' }, baseCtx())) as string;
+    expect(out).toContain('text.ts:1:NEEDLE in source');
+    expect(out).not.toContain('blob.bin');
+  });
+
+  it('match output for ordinary text files is unchanged', async () => {
+    await fs.writeFile(path.join(tmp, 'a.ts'), 'foo\nbar foo\nbaz\n');
+    const out = (await grepTool.handler({ pattern: 'foo' }, baseCtx())) as string;
+    expect(out.split('\n').sort()).toEqual(['a.ts:1:foo', 'a.ts:2:bar foo'].sort());
+  });
+});

--- a/packages/tools-builtin/src/grep.ts
+++ b/packages/tools-builtin/src/grep.ts
@@ -3,6 +3,26 @@ import * as path from 'node:path';
 import { MoxxyError, defineTool, z } from '@moxxy/sdk';
 import { clampString, globToRegExp, IGNORED_DIR_NAMES, resolvePath } from './util.js';
 
+/**
+ * Skip files larger than this — a multi-hundred-MB log, a SQLite db, or a media
+ * blob would otherwise be slurped fully into the heap and split into a giant
+ * line array on a path the model invokes constantly. Result clamping bounds the
+ * OUTPUT, not the per-file working set; this bounds the working set.
+ */
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+
+/** Treat a file as binary (and skip it) if its leading bytes contain a NUL —
+ *  the same cheap heuristic ripgrep/grep use to avoid scanning binary garbage. */
+function looksBinary(content: string): boolean {
+  // A real text file never contains U+0000; reading binary as utf8 yields NULs
+  // for the raw zero bytes. Check only a bounded prefix so this stays cheap.
+  const limit = Math.min(content.length, 8192);
+  for (let i = 0; i < limit; i += 1) {
+    if (content.charCodeAt(i) === 0) return true;
+  }
+  return false;
+}
+
 export const grepTool = defineTool({
   name: 'Grep',
   description: 'Recursively search files for a regex pattern. Returns lines as `path:line:text`.',
@@ -72,12 +92,25 @@ async function walk(
     }
     if (!entry.isFile()) continue;
     if (fileRe && !fileRe.test(entry.name)) continue;
+    // Skip oversized files before reading so a giant log / db / media blob can't
+    // be slurped into the heap. Bounds the per-file working set (result clamping
+    // only bounds the OUTPUT).
+    try {
+      const st = await fs.stat(full);
+      if (st.size > MAX_FILE_BYTES) continue;
+    } catch {
+      continue;
+    }
     let content: string;
     try {
       content = await fs.readFile(full, 'utf8');
     } catch {
       continue;
     }
+    // Skip binaries (NUL byte in the prefix) — scanning binary-as-utf8 yields
+    // useless matches and mojibake. Normal text files are unaffected, so match
+    // output for them is byte-identical to before.
+    if (looksBinary(content)) continue;
     const lines = content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       if (re.test(lines[i]!)) {


### PR DESCRIPTION
## Quality sweep — wave 3 (performance)

The performance pass from the audit (`.claude/audits/`). **Every algorithm-shape
change is guarded by a golden test asserting the new path is byte-identical to
the old** — the folds/projections are load-bearing (invariants #4/#6), so
behaviour is unchanged.

### Event log / projection (`@moxxy/sdk`, `@moxxy/core`, `@moxxy/runner`)
- Index `EventLog.ofType`/`byTurn`: O(n) filter → O(matches), maintained O(1) on
  append/ingest, reset on clear/rebase. **Property-tested deep-equal** to the old
  `Array.filter` across random append/ingest/rebase sequences.
- `applyLazyTools` single-partition (O(2n)→O(n)) + index-backed loaded-tool scan;
  `projectMessages` binary-cursor compaction-range lookup; `computeElisionState`
  fused passes + no redundant sort. Each golden-tested (200/250/400 random cases
  vs a verbatim copy of the old impl). The riskiest cross-call elision
  memoization was **deferred** (couldn't prove byte-identity without a new
  log-version seam) — documented in `TECH_DEBT.md`.
- `surfaceInputParamsSchema`: O(keys) size guard instead of `JSON.stringify` per
  frame (exact fallback for nested/near-cap; no wire-contract change).

### Chat-model block fold (`@moxxy/chat-model`, `@moxxy/client-core`, TUI, desktop)
The headline O(n²)/turn re-fold is now **incremental** — only the unsettled tail
re-folds, keyed on a `(version, prefixLength)` high-water mark — proven
byte-identical by a step-by-step golden test (11 recorded sequences fed one event
at a time, deep-equal to a full re-fold after **every** event, + an O(k)
complexity assertion). Also bounds the live in-memory log / `seenIds` /
`usage.perCall`, and memoizes the workflow-canvas topology so a node drag no
longer recomputes it per pointer-move.

### Quadratic / unbounded hotspots (incl. real bugs)
`UsagePanel` reduce-max (was a `Math.max(...series)` spread that **RangeError'd**
on long sessions), `grep` file-size cap + binary skip (unbounded memory),
`StreamingPreview` incremental last-line (**also fixed an infinite loop** on
leading-newline content — caught here, see commit), terminal sentinel-regex
compiled once + tail scan, webhooks parse-body-once, scheduler batched schedule
reconcile, `runProcess` concat-once, session-log one-time `ensureReady`. The DAG
"parallel waves" item was kept **sequential** (conservative — real parallelism
would change ordering/error semantics; deferred).

### Verification
`pnpm build` 64/64 · `typecheck` 126/126 · `test` all pass · `lint` 0 errors ·
`check:deps` clean. (A pre-existing Node-20 cert flake was fixed in #214.)
