### PR TITLE
feat(desktop): Files explorer in the context rail

### DIFF
--- a/.changeset/desktop-files-explorer.md
+++ b/.changeset/desktop-files-explorer.md
@@ -1,0 +1,15 @@
+---
+"@moxxy/desktop": patch
+---
+
+feat(desktop): Files explorer in the context rail
+
+Adds a **Files** option to the context-rail dropdown — a workspace file explorer
+that browses the full directory tree and previews any file's contents (via
+`workspace.readFile`). Unlike the existing **Files changed** option, it is always
+available (no git repo required) so you can read/preview workspace files in any
+project. Clicking a file opens the shared menu to Add it to the agent or Open it
+in the viewer.
+
+The click menu + list chrome shared by the two file panes are factored out into
+`FilePaneShared.tsx` so "Files changed" and "Files" can't drift apart.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -265,7 +265,16 @@ item — the debt it *creates* is logged here on sight:
 - **"Add to agent" on a git-changed file assumes cwd === repo root.** `git status`
   paths are repo-root-relative; the absolute path is built from the workspace cwd.
   Correct for the common case; wrong when the workspace cwd is a repo subdir.
-  File: `apps/desktop/src/shell/surfaces/FilesPane.tsx`.
+  File: `apps/desktop/src/shell/surfaces/FilesPane.tsx`. (The newer **Files**
+  explorer pane is unaffected — it builds paths from the cwd `workspace.listDir`
+  reports, which is the workspace root.)
+- **A second file pane now exists: `FilesExplorerPane.tsx`** ("Files" dropdown
+  option) — browse + preview the whole workspace tree, always available (no git
+  repo). The click menu + list chrome shared with `FilesPane` were factored into
+  `FilePaneShared.tsx` so the two can't drift; the git "Changed" group stays
+  `FilesPane`-only. Both panes still poll IPC (`git.*` / `workspace.listDir` +
+  `readFile`) rather than streaming via the Surface protocol — fine for files,
+  but if a third pane wants live updates, promote them to a real `Surface`.
 - **The `terminal` tool's sentinel-based completion is best-effort** in a shared,
   input-echoing shell (it strips the echoed command + sentinel lines heuristically).
   Good enough for run-and-read; a structured exec channel would be cleaner.

--- a/apps/desktop/src/chat/chat-surface/RailMenu.tsx
+++ b/apps/desktop/src/chat/chat-surface/RailMenu.tsx
@@ -6,7 +6,8 @@ import type { RailPane } from '../../shell/ContextRail';
 /**
  * The repurposed context button: instead of toggling the rail, it opens a
  * dropdown to pick what the rail shows — Open a terminal, Files changed (only
- * in a git repo), or Browser. Picking a pane opens the rail to it.
+ * in a git repo), Files (browse + preview the whole workspace), or Browser.
+ * Picking a pane opens the rail to it.
  */
 export function RailMenu({
   workspaceId,
@@ -56,6 +57,7 @@ export function RailMenu({
   const items: ReadonlyArray<{ pane: RailPane; icon: IconName; label: string; show: boolean }> = [
     { pane: 'terminal', icon: 'terminal', label: 'Open a terminal', show: true },
     { pane: 'files', icon: 'diff', label: 'Files changed', show: isRepo },
+    { pane: 'explorer', icon: 'folder', label: 'Files', show: true },
     { pane: 'browser', icon: 'globe', label: 'Browser', show: true },
   ];
 

--- a/apps/desktop/src/shell/ContextRail.tsx
+++ b/apps/desktop/src/shell/ContextRail.tsx
@@ -5,6 +5,7 @@
  * dropdown (see {@link RailMenu}) to pick what the rail shows:
  *   - Terminal — a shared shell the user and the agent drive together.
  *   - Files changed — git-changed files with a diff (only in a git repo).
+ *   - Files — browse + preview every file in the workspace (any folder).
  *   - Browser — a live, in-window view of the agent's browser.
  *
  * The rail is drag-resizable (left edge) and its width persists across
@@ -17,13 +18,15 @@ import { Icon } from '@moxxy/desktop-ui';
 import { RAIL_MAX_WIDTH, RAIL_MIN_WIDTH, setRailWidth, useRailWidth } from '../lib/useRailWidth';
 import { TerminalPane } from './surfaces/TerminalPane';
 import { FilesPane } from './surfaces/FilesPane';
+import { FilesExplorerPane } from './surfaces/FilesExplorerPane';
 import { BrowserPane } from './surfaces/BrowserPane';
 
-export type RailPane = 'terminal' | 'files' | 'browser';
+export type RailPane = 'terminal' | 'files' | 'explorer' | 'browser';
 
 const PANE_TITLE: Record<RailPane, string> = {
   terminal: 'Terminal',
   files: 'Files changed',
+  explorer: 'Files',
   browser: 'Browser',
 };
 
@@ -98,6 +101,7 @@ export function ContextRail({ pane, onClose, workspaceId }: Props): JSX.Element 
       <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
         {pane === 'terminal' && <TerminalPane workspaceId={workspaceId} />}
         {pane === 'files' && <FilesPane workspaceId={workspaceId} cwd={active?.cwd ?? null} />}
+        {pane === 'explorer' && <FilesExplorerPane workspaceId={workspaceId} />}
         {pane === 'browser' && <BrowserPane workspaceId={workspaceId} />}
       </div>
     </section>

--- a/apps/desktop/src/shell/surfaces/FilePaneShared.tsx
+++ b/apps/desktop/src/shell/surfaces/FilePaneShared.tsx
@@ -1,0 +1,151 @@
+/**
+ * UI shared by the two file panes in the context rail — "Files changed"
+ * ({@link FilesPane}) and "Files" ({@link FilesExplorerPane}). Both render the
+ * workspace tree on the left and a file viewer on the right, and both open the
+ * same click menu (Add to agent / Open). Keeping the menu + list chrome here
+ * means the two panes can't drift apart.
+ */
+
+import { Icon } from '@moxxy/desktop-ui';
+import type { FileInsertDetail } from '../WorkspaceFiles';
+
+/** A pending file click-menu, anchored at the click point. */
+export interface MenuState {
+  readonly detail: FileInsertDetail;
+  /** True when the file is git-changed (Open shows a diff, not content). */
+  readonly changed: boolean;
+  readonly x: number;
+  readonly y: number;
+}
+
+/**
+ * The click menu shared by both file panes: Add the file to the agent (the
+ * existing attachment flow) or Open it in the viewer — a diff for a git-changed
+ * file, full content otherwise.
+ */
+export function FileMenu({
+  menu,
+  onAdd,
+  onOpen,
+}: {
+  readonly menu: MenuState;
+  readonly onAdd: () => void;
+  readonly onOpen: () => void;
+}): JSX.Element {
+  // Anchor at the click; clamp to viewport so it never overflows off-screen.
+  const left = Math.min(menu.x, window.innerWidth - 200);
+  const top = Math.min(menu.y, window.innerHeight - 96);
+  return (
+    <div
+      role="menu"
+      // Stop the window mousedown-to-close from firing for clicks inside.
+      onMouseDown={(e) => e.stopPropagation()}
+      style={{
+        position: 'fixed',
+        left,
+        top,
+        zIndex: 50,
+        minWidth: 184,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        padding: 4,
+        background: 'var(--color-card-bg)',
+        border: '1px solid var(--color-card-border)',
+        borderRadius: 12,
+        boxShadow: '0 18px 40px -22px rgba(15, 23, 42, 0.45)',
+      }}
+    >
+      <MenuItem icon="attach" label="Add to agent" onClick={onAdd} />
+      <MenuItem icon={menu.changed ? 'diff' : 'file'} label={menu.changed ? 'Open diff' : 'Open'} onClick={onOpen} />
+    </div>
+  );
+}
+
+function MenuItem({
+  icon,
+  label,
+  onClick,
+}: {
+  readonly icon: 'attach' | 'file' | 'diff';
+  readonly label: string;
+  readonly onClick: () => void;
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onClick}
+      className="row-button"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        width: '100%',
+        padding: '7px 9px',
+        borderRadius: 8,
+        fontSize: 12.5,
+        color: 'var(--color-text)',
+        textAlign: 'left',
+      }}
+    >
+      <Icon name={icon} size={14} />
+      {label}
+    </button>
+  );
+}
+
+/** A titled list section with an optional right-aligned action. */
+export function Group({
+  title,
+  action,
+  children,
+}: {
+  readonly title: string;
+  readonly action?: React.ReactNode;
+  readonly children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <section style={{ marginBottom: 12 }}>
+      <header
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          fontSize: 10,
+          fontWeight: 700,
+          color: 'var(--color-text-dim)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.08em',
+          marginBottom: 6,
+          padding: '0 4px',
+        }}
+      >
+        <span>{title}</span>
+        {action && (
+          <>
+            <span style={{ flex: 1 }} />
+            {action}
+          </>
+        )}
+      </header>
+      {children}
+    </section>
+  );
+}
+
+/** Dim hint / empty-state text. */
+export function Hint({ children }: { readonly children: React.ReactNode }): JSX.Element {
+  return <div style={{ fontSize: 11, color: 'var(--color-text-dim)', padding: '2px 4px' }}>{children}</div>;
+}
+
+/** Square icon-button style for in-list actions (e.g. a reload button). */
+export const iconBtn: React.CSSProperties = {
+  width: 20,
+  height: 20,
+  borderRadius: 6,
+  color: 'var(--color-text-dim)',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+};

--- a/apps/desktop/src/shell/surfaces/FilesExplorerPane.tsx
+++ b/apps/desktop/src/shell/surfaces/FilesExplorerPane.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react';
+import { Icon } from '@moxxy/desktop-ui';
+import { WorkspaceFiles, emitInsertPath } from '../WorkspaceFiles';
+import { FileViewer } from './FileViewer';
+import { FileMenu, Group, Hint, iconBtn, type MenuState } from './FilePaneShared';
+
+interface Selected {
+  readonly path: string;
+  readonly label: string;
+}
+
+/**
+ * The "Files" explorer pane: browse the entire workspace tree and preview any
+ * file's contents. Unlike the git-centric "Files changed" pane this is always
+ * available (no repo required) and every file opens its full content via
+ * `workspace.readFile`. Clicking a file opens the shared menu to Add it to the
+ * agent (attachment flow) or Open it in the viewer.
+ */
+export function FilesExplorerPane({
+  workspaceId,
+}: {
+  readonly workspaceId: string | null;
+}): JSX.Element {
+  const [menu, setMenu] = useState<MenuState | null>(null);
+  const [selected, setSelected] = useState<Selected | null>(null);
+  const [reload, setReload] = useState(0);
+
+  // Close the dropdown on any outside click / Escape (mirrors FilesPane).
+  useEffect(() => {
+    if (!menu) return;
+    const close = (): void => setMenu(null);
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setMenu(null);
+    };
+    window.addEventListener('mousedown', close);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('mousedown', close);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [menu]);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        height: '100%',
+        minHeight: 0,
+        // Side-by-side: file tree + content. Horizontal scroll kicks in only
+        // when the rail is too narrow to fit both.
+        overflow: 'hidden',
+      }}
+    >
+      {/* Left: full workspace tree */}
+      <div
+        style={{
+          width: 200,
+          minWidth: 160,
+          flexShrink: 0,
+          overflowY: 'auto',
+          borderRight: '1px solid var(--color-card-border)',
+          padding: '8px 6px',
+        }}
+      >
+        <Group
+          title="Files"
+          action={
+            workspaceId ? (
+              <button
+                type="button"
+                className="btn-icon"
+                aria-label="Reload files"
+                title="Reload files"
+                onClick={() => setReload((k) => k + 1)}
+                style={iconBtn}
+              >
+                <Icon name="rotate" size={12} />
+              </button>
+            ) : undefined
+          }
+        >
+          {workspaceId ? (
+            <WorkspaceFiles
+              workspaceId={workspaceId}
+              reloadSignal={reload}
+              onPickFile={(detail, anchor) =>
+                setMenu({ detail, changed: false, x: anchor.x, y: anchor.y })
+              }
+            />
+          ) : (
+            <Hint>Pick a workspace to browse its files.</Hint>
+          )}
+        </Group>
+      </div>
+
+      {/* Right: content viewer */}
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+        {selected && (
+          <div
+            className="mono"
+            title={selected.label}
+            style={{
+              padding: '6px 10px',
+              fontSize: 11,
+              color: 'var(--color-text-muted)',
+              borderBottom: '1px solid var(--color-card-border)',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              flexShrink: 0,
+            }}
+          >
+            {selected.label}
+          </div>
+        )}
+        <div style={{ flex: 1, minHeight: 0, padding: 6 }}>
+          <FileViewer workspaceId={workspaceId} path={selected?.path ?? null} mode="content" />
+        </div>
+      </div>
+
+      {menu && (
+        <FileMenu
+          menu={menu}
+          onAdd={() => {
+            emitInsertPath(menu.detail);
+            setMenu(null);
+          }}
+          onOpen={() => {
+            setSelected({ path: menu.detail.relPath, label: menu.detail.relPath });
+            setMenu(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/shell/surfaces/FilesPane.tsx
+++ b/apps/desktop/src/shell/surfaces/FilesPane.tsx
@@ -3,18 +3,11 @@ import { api } from '@moxxy/client-core';
 import { Icon } from '@moxxy/desktop-ui';
 import { WorkspaceFiles, emitInsertPath, type FileInsertDetail } from '../WorkspaceFiles';
 import { FileViewer, type FileViewMode } from './FileViewer';
+import { FileMenu, Group, Hint, iconBtn, type MenuState } from './FilePaneShared';
 
 interface ChangedFile {
   readonly path: string;
   readonly status: string;
-}
-
-interface MenuState {
-  readonly detail: FileInsertDetail;
-  /** True when the file is git-changed (Open shows a diff, not content). */
-  readonly changed: boolean;
-  readonly x: number;
-  readonly y: number;
 }
 
 interface Selected {
@@ -207,78 +200,6 @@ export function FilesPane({
   );
 }
 
-function FileMenu({
-  menu,
-  onAdd,
-  onOpen,
-}: {
-  readonly menu: MenuState;
-  readonly onAdd: () => void;
-  readonly onOpen: () => void;
-}): JSX.Element {
-  // Anchor at the click; clamp to viewport so it never overflows off-screen.
-  const left = Math.min(menu.x, window.innerWidth - 200);
-  const top = Math.min(menu.y, window.innerHeight - 96);
-  return (
-    <div
-      role="menu"
-      // Stop the window mousedown-to-close from firing for clicks inside.
-      onMouseDown={(e) => e.stopPropagation()}
-      style={{
-        position: 'fixed',
-        left,
-        top,
-        zIndex: 50,
-        minWidth: 184,
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 2,
-        padding: 4,
-        background: 'var(--color-card-bg)',
-        border: '1px solid var(--color-card-border)',
-        borderRadius: 12,
-        boxShadow: '0 18px 40px -22px rgba(15, 23, 42, 0.45)',
-      }}
-    >
-      <MenuItem icon="attach" label="Add to agent" onClick={onAdd} />
-      <MenuItem icon={menu.changed ? 'diff' : 'file'} label={menu.changed ? 'Open diff' : 'Open'} onClick={onOpen} />
-    </div>
-  );
-}
-
-function MenuItem({
-  icon,
-  label,
-  onClick,
-}: {
-  readonly icon: 'attach' | 'file' | 'diff';
-  readonly label: string;
-  readonly onClick: () => void;
-}): JSX.Element {
-  return (
-    <button
-      type="button"
-      role="menuitem"
-      onClick={onClick}
-      className="row-button"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 8,
-        width: '100%',
-        padding: '7px 9px',
-        borderRadius: 8,
-        fontSize: 12.5,
-        color: 'var(--color-text)',
-        textAlign: 'left',
-      }}
-    >
-      <Icon name={icon} size={14} />
-      {label}
-    </button>
-  );
-}
-
 function ChangedRow({
   file,
   active,
@@ -331,54 +252,3 @@ function statusColor(status: string): string {
   return '#7aa2f7';
 }
 
-function Group({
-  title,
-  action,
-  children,
-}: {
-  readonly title: string;
-  readonly action?: React.ReactNode;
-  readonly children: React.ReactNode;
-}): JSX.Element {
-  return (
-    <section style={{ marginBottom: 12 }}>
-      <header
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 6,
-          fontSize: 10,
-          fontWeight: 700,
-          color: 'var(--color-text-dim)',
-          textTransform: 'uppercase',
-          letterSpacing: '0.08em',
-          marginBottom: 6,
-          padding: '0 4px',
-        }}
-      >
-        <span>{title}</span>
-        {action && (
-          <>
-            <span style={{ flex: 1 }} />
-            {action}
-          </>
-        )}
-      </header>
-      {children}
-    </section>
-  );
-}
-
-function Hint({ children }: { readonly children: React.ReactNode }): JSX.Element {
-  return <div style={{ fontSize: 11, color: 'var(--color-text-dim)', padding: '2px 4px' }}>{children}</div>;
-}
-
-const iconBtn: React.CSSProperties = {
-  width: 20,
-  height: 20,
-  borderRadius: 6,
-  color: 'var(--color-text-dim)',
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-};


### PR DESCRIPTION
## What

Adds a **Files** option to the desktop context-rail dropdown (folder icon, after "Files changed") — a workspace file explorer that browses the full directory tree and previews any file's contents.

- **`FilesExplorerPane.tsx`** (new): full workspace tree on the left (`WorkspaceFiles` → `workspace.listDir`), content preview on the right (`FileViewer` content mode → `workspace.readFile`, which already handles binary/truncation). Click a file → shared menu to **Add to agent** or **Open**. Reload button picks up files the agent wrote.
- **`FilePaneShared.tsx`** (new): the click menu + list chrome that both file panes use, extracted so "Files changed" and "Files" can't drift apart. `FilesPane.tsx` shrank ~132 lines; its git-specific "Changed" group stays put.
- **`ContextRail.tsx` / `RailMenu.tsx`**: new `'explorer'` pane wired into the `RailPane` union, title map, render branch, and dropdown.

## Why

The rail dropdown only offered Terminal / Files changed / Browser. "Files changed" is git-diff-only and gated behind `show: isRepo`, so in a non-git workspace there was no way to browse or preview workspace files at all, and even in a repo the general file tree was buried under a git-centric label. This restores always-available file browsing + preview as its own option. It's almost entirely renderer-side — every backend piece (`listDir`, `readFile`, the tree, the viewer) already existed.

## Verification

- `pnpm build` 64/64 ✓ · `pnpm typecheck` 126/126 ✓ · `pnpm lint` 0 errors (28 pre-existing warnings, none in changed files) ✓ · `pnpm test` full suite exit 0 (desktop 178/178) ✓
- Changeset present (`@moxxy/desktop` patch); TECH_DEBT.md updated (logged the new pane + shared extraction).
- Not yet visually verified in a running Electron build (needs a display) — build + types + tests give high confidence for a renderer-only change.