### PR TITLE
fix(surfaces): real PTY for the terminal + ask-first browser-engine install

### DIFF
--- a/.changeset/terminal-pty-fix-browser-install.md
+++ b/.changeset/terminal-pty-fix-browser-install.md
@@ -1,0 +1,28 @@
+---
+"@moxxy/plugin-terminal": patch
+"@moxxy/plugin-browser": patch
+"@moxxy/desktop-host": patch
+"@moxxy/desktop": patch
+---
+
+fix(surfaces): make the terminal a real PTY + offer to install the browser engine
+
+**Terminal — the root cause it never accepted input.** node-pty ships its macOS
+`spawn-helper` binary without the executable bit, and several install/repack
+paths (npm into the desktop's CLI prefix, pnpm's content store) keep it that way.
+node-pty then loads fine but `pty.spawn` throws `posix_spawnp failed`, which was
+silently swallowed into the piped fallback — a shell with no TTY line discipline,
+so a viewer's Enter (`\r`) never reaches it and nothing echoes. The pane looked
+alive (it showed a prompt) but ignored every keystroke. This affected dev and
+packaged builds alike, which is why earlier UI/sizing/ref-count fixes didn't
+help. Fix: `pty.ts` now repairs the `spawn-helper` exec bit before spawning and
+retries once; the installer chmods it after `npm install` too. When a real PTY
+genuinely can't start, the pane shows an honest "Terminal unavailable" status
+instead of a silently-dead box.
+
+**Browser — offer to install Playwright instead of erroring.** When the
+`playwright` npm package is missing, the browser surface now reports a distinct
+`needs-install` state and shows an **Install browser engine (~200MB)** button.
+On click it installs the npm package + the Chromium engine with live progress in
+the pane, restarts the sidecar, and resumes — no manual `npm i playwright` in the
+install dir.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -257,8 +257,29 @@ item — the debt it *creates* is logged here on sight:
   a real PTY when the binary builds (it's N-API, ABI-stable like
   `@napi-rs/keyring`, so the desktop's `pnpm deploy --prod` bundle works without
   electron-rebuild). Falls back to the dependency-free piped shell when absent.
-  **Remaining:** verify the real PTY in a *packaged* desktop launch (Electron-as-
-  node ABI) — can't be checked in the normal gate.
+  **RESOLVED 2026-06-18 — the "verify real PTY in a packaged launch" was hiding a
+  bug the gate can't see: node-pty loaded but `pty.spawn` threw `posix_spawnp
+  failed` because its macOS `prebuilds/<plat>/spawn-helper` ships WITHOUT the
+  exec bit — true in BOTH pnpm (dev) and npm-into-the-CLI-prefix (packaged).**
+  The throw was swallowed into the piped fallback, which is not an interactive
+  terminal (no TTY line discipline: a viewer's `\r` is never turned into `\n`,
+  nothing echoes), so every install showed a live-looking prompt that ignored all
+  input. **Fix:** `pty.ts` `ensureSpawnHelperExecutable()` chmods the helper
+  before spawn + retries once; `desktop-host/installer.ts` chmods it after
+  `npm install`; the surface now reports an honest "Terminal unavailable" status
+  (`backend === 'pipe'` → `ptyError`) instead of a silently-dead box. **Dormant
+  debt:** the piped fallback is deliberately NOT made interactive (node-pty now
+  works for everyone) — if a no-prebuild platform ever needs it, it must gain
+  CR→LF translation + local echo.
+- **Browser surface offers a one-click Playwright install (ask-first).** When the
+  `playwright` npm package is absent, `sidecar/install.ts` `importPlaywright`
+  tags the failure `needs-install` (vs `init`); the kind rides the JSON-RPC reply
+  (`browser-session.ts`), the surface pauses polling + emits a `needsInstall`
+  status, and an `install` input runs `installPlaywrightPackage` (npm + the
+  Chromium engine, ~200MB) into `resolveBrowserInstallRoot()` with streamed
+  progress, then restarts the sidecar. **Constraint:** the install runs in the
+  runner via PATH-resolved `npm`/`npx` (same assumption as the existing browser-
+  binary auto-install) — a GUI launch must keep node/npm on the runner's PATH.
 - **Surfaces are desktop-only — deliberately off the mobile WS allow-list**
   (`REMOTE_ALLOWED_COMMANDS`). A sandboxed shell/browser over a tunnel is a real
   feature with its own threat model; revisit when mobile needs it.

--- a/apps/desktop/src/shell/surfaces/BrowserPane.tsx
+++ b/apps/desktop/src/shell/surfaces/BrowserPane.tsx
@@ -9,6 +9,9 @@ interface BrowserFrame {
   readonly url?: string;
   /** Carried by `{ type: 'status' }` payloads — launch progress or a hard error. */
   readonly text?: string;
+  /** Set on a status when the Playwright engine isn't installed — the pane shows
+   *  an "Install" button (the download is ~200MB, so we ask first). */
+  readonly needsInstall?: boolean;
 }
 
 /**
@@ -22,6 +25,8 @@ interface BrowserFrame {
 export function BrowserPane({ workspaceId }: { readonly workspaceId: string | null }): JSX.Element {
   const [frame, setFrame] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
+  const [needsInstall, setNeedsInstall] = useState(false);
+  const [installing, setInstalling] = useState(false);
   const [url, setUrl] = useState('');
   const [editingUrl, setEditingUrl] = useState('');
   const imgRef = useRef<HTMLDivElement | null>(null);
@@ -31,8 +36,16 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
     if (p?.type === 'frame' && typeof p.base64 === 'string') {
       setFrame(`data:${p.mime ?? 'image/jpeg'};base64,${p.base64}`);
       setStatus(null);
+      setNeedsInstall(false);
+      setInstalling(false);
     } else if (p?.type === 'status') {
       setStatus(typeof p.text === 'string' ? p.text : null);
+      // A `needsInstall` status re-arms the button (e.g. an install that failed);
+      // any other status during install is progress, so leave `installing` as-is.
+      if (p.needsInstall) {
+        setNeedsInstall(true);
+        setInstalling(false);
+      }
     }
     if (typeof p?.url === 'string') {
       setUrl(p.url);
@@ -48,6 +61,13 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
     if (!u) return;
     const withScheme = /^https?:\/\//i.test(u) ? u : `https://${u}`;
     surface.input({ type: 'navigate', url: withScheme });
+  };
+
+  const startInstall = (): void => {
+    setInstalling(true);
+    setNeedsInstall(false);
+    setStatus('Installing browser engine… (one-time, ~200MB)');
+    surface.input({ type: 'install' });
   };
 
   // Translate a pointer event in the frame box to normalized page coords.
@@ -132,8 +152,39 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
         {frame ? (
           <img src={frame} alt={url || 'browser'} style={{ width: '100%', height: 'auto', display: 'block' }} />
         ) : (
-          <div style={{ padding: 24, fontSize: 12, color: 'var(--color-text-dim)', textAlign: 'center' }}>
-            {status ?? (surface.ready ? 'Loading…' : 'Starting browser…')}
+          <div
+            style={{
+              padding: 24,
+              fontSize: 12,
+              color: 'var(--color-text-dim)',
+              textAlign: 'center',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 12,
+            }}
+          >
+            <div>{status ?? (surface.ready ? 'Loading…' : 'Starting browser…')}</div>
+            {(needsInstall || installing) && (
+              <button
+                type="button"
+                onClick={startInstall}
+                disabled={installing}
+                style={{
+                  padding: '7px 14px',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: '#fff',
+                  border: 'none',
+                  borderRadius: 8,
+                  cursor: installing ? 'default' : 'pointer',
+                  background: installing ? 'var(--color-text-dim)' : 'var(--color-accent, #6366f1)',
+                  opacity: installing ? 0.7 : 1,
+                }}
+              >
+                {installing ? 'Installing…' : 'Install browser engine (~200MB)'}
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/apps/desktop/src/shell/surfaces/TerminalPane.tsx
+++ b/apps/desktop/src/shell/surfaces/TerminalPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import '@xterm/xterm/css/xterm.css';
@@ -15,17 +15,29 @@ export function TerminalPane({ workspaceId }: { readonly workspaceId: string | n
   const hostRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
+  // Set when the runner can't start a real PTY (node-pty unavailable / failed):
+  // the piped fallback isn't an interactive terminal, so we show why instead of
+  // letting the box silently ignore keystrokes.
+  const [degraded, setDegraded] = useState<string | null>(null);
 
   // Mount xterm once. The surface hook (below) feeds it data + receives input.
   const surface = useSurface(workspaceId, 'terminal', {
     onSnapshot: (snap) => {
-      const s = snap as { data?: string } | undefined;
+      const s = snap as { data?: string; backend?: string; ptyError?: string | null } | undefined;
       if (s?.data && termRef.current) termRef.current.write(s.data);
+      if (s?.backend === 'pipe') {
+        setDegraded(
+          s.ptyError
+            ? `The PTY backend failed to start (${s.ptyError}).`
+            : 'A real PTY backend (node-pty) is not available.',
+        );
+      }
     },
     onData: (payload) => {
-      const p = payload as { type?: string; data?: string };
+      const p = payload as { type?: string; data?: string; text?: string };
       if (p?.type === 'data' && typeof p.data === 'string') termRef.current?.write(p.data);
       else if (p?.type === 'exit') termRef.current?.write('\r\n\x1b[2m[process exited]\x1b[0m\r\n');
+      else if (p?.type === 'status' && typeof p.text === 'string') setDegraded(p.text);
     },
   });
   // Stable ref so the mount effect can reach the latest input/resize senders.
@@ -109,9 +121,9 @@ export function TerminalPane({ workspaceId }: { readonly workspaceId: string | n
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
-      {surface.error && (
+      {(surface.error || degraded) && (
         <div style={{ padding: '8px 12px', fontSize: 11.5, color: 'var(--color-danger, #f87171)' }}>
-          Terminal unavailable: {surface.error}
+          Terminal unavailable: {surface.error ?? degraded}
         </div>
       )}
       <div

--- a/packages/desktop-host/src/installer.ts
+++ b/packages/desktop-host/src/installer.ts
@@ -10,7 +10,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { chmodSync, existsSync, readFileSync, statSync } from 'node:fs';
 import path, { dirname } from 'node:path';
 import { type BrowserWindow } from 'electron';
 import type { NodeProbe } from '@moxxy/desktop-ipc-contract';
@@ -164,8 +164,34 @@ export async function updateCli(userDataDir: string, window: BrowserWindow): Pro
     proc.stdout?.on('data', (b: Buffer) => stream(window, b.toString()));
     proc.stderr?.on('data', (b: Buffer) => stream(window, b.toString()));
     proc.on('error', reject);
-    proc.on('exit', (code) => resolve(code ?? -1));
+    proc.on('exit', (code) => {
+      // npm (and pnpm's store) can drop the executable bit on node-pty's macOS
+      // `spawn-helper`, which makes the terminal surface silently fall back to a
+      // dead piped shell. Repair it here so a fresh install gets a real PTY on
+      // first use. The runner also self-heals at spawn time, so this is belt-and-
+      // suspenders; never let it fail the install.
+      if (code === 0) chmodNodePtyHelpers(target);
+      resolve(code ?? -1);
+    });
   });
+}
+
+/** Re-add the executable bit to node-pty's prebuilt `spawn-helper` under a
+ *  freshly-installed CLI prefix (see {@link updateCli}). Best-effort + silent. */
+function chmodNodePtyHelpers(prefixRoot: string): void {
+  const base = path.join(prefixRoot, 'node_modules', 'node-pty');
+  const candidates = [
+    path.join(base, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper'),
+    path.join(base, 'build', 'Release', 'spawn-helper'),
+  ];
+  for (const file of candidates) {
+    try {
+      const st = statSync(file);
+      if (!(st.mode & 0o111)) chmodSync(file, st.mode | 0o111);
+    } catch {
+      /* not present / not permitted — runtime self-heal covers it */
+    }
+  }
 }
 
 function stream(window: BrowserWindow, chunk: string): void {

--- a/packages/plugin-browser/src/browser-session.test.ts
+++ b/packages/plugin-browser/src/browser-session.test.ts
@@ -5,6 +5,7 @@ import type { ToolContext } from '@moxxy/sdk';
 import {
   buildBrowserSessionTool,
   closeBrowserSidecar,
+  resolveBrowserInstallRoot,
   type SidecarStream,
 } from './browser-session.js';
 import { setSsrfDnsResolver } from './ssrf-guard.js';
@@ -27,6 +28,18 @@ const baseCtx = (): ToolContext => ({
   signal: new AbortController().signal,
   log: { length: 0, at: () => undefined, slice: () => [], ofType: () => [], byTurn: () => [], toJSON: () => [] },
   logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+});
+
+describe('resolveBrowserInstallRoot', () => {
+  it('returns the prefix root (the node_modules parent) for a packaged sidecar path', () => {
+    // The real installed layout: <root>/node_modules/@moxxy/cli/dist/sidecar.js
+    const sidecarPath = '/Users/me/Library/App/cli/node_modules/@moxxy/cli/dist/sidecar.js';
+    expect(resolveBrowserInstallRoot({ sidecarPath })).toBe('/Users/me/Library/App/cli');
+  });
+
+  it('falls back to the sidecar dir when no node_modules is on the path', () => {
+    expect(resolveBrowserInstallRoot({ sidecarPath: '/opt/app/dist/sidecar.js' })).toBe('/opt/app/dist');
+  });
 });
 
 function makeFakeSpawn(handler: (req: { id: string; method: string; params?: unknown }) => unknown): {

--- a/packages/plugin-browser/src/browser-session.ts
+++ b/packages/plugin-browser/src/browser-session.ts
@@ -178,7 +178,7 @@ class Sidecar {
       id?: string;
       ok?: boolean;
       result?: unknown;
-      error?: { message: string };
+      error?: { message: string; kind?: string };
       notice?: string;
     };
     try {
@@ -200,9 +200,12 @@ class Sidecar {
         p.resolve(reply.result);
       }
     } else {
-      p.reject(
-        new MoxxyError({ code: 'INTERNAL', message: reply.error?.message ?? 'sidecar error' }),
-      );
+      // Carry the sidecar's typed `kind` on the rejected error so the surface
+      // can tell "playwright not installed" (offer an Install button) apart from
+      // a generic failure. MoxxyError doesn't model it, so attach it as a tag.
+      const err = new MoxxyError({ code: 'INTERNAL', message: reply.error?.message ?? 'sidecar error' });
+      if (reply.error?.kind) (err as MoxxyError & { sidecarKind?: string }).sidecarKind = reply.error.kind;
+      p.reject(err);
     }
   }
 
@@ -288,6 +291,30 @@ function getSidecar(deps?: BrowserSessionDeps): Sidecar {
 function defaultSidecarPath(): string {
   const here = path.dirname(fileURLToPath(import.meta.url));
   return path.join(here, 'sidecar.js');
+}
+
+/** The sidecar-supplied error tag (see {@link Sidecar.handleLine}); 'needs-install'
+ *  means the `playwright` npm package isn't present yet. */
+export function sidecarErrorKind(err: unknown): string | undefined {
+  return (err as { sidecarKind?: string } | null)?.sidecarKind;
+}
+
+/**
+ * The directory whose `node_modules` the sidecar imports `playwright` from — the
+ * CLI install root (e.g. `<userData>/cli`). Found by walking up from the sidecar
+ * file to the nearest `node_modules` ancestor and returning ITS parent. Falls
+ * back to the sidecar's own dir if no `node_modules` is on the path (dev/tests).
+ */
+export function resolveBrowserInstallRoot(deps?: BrowserSessionDeps): string {
+  const start = deps?.sidecarPath ?? defaultSidecarPath();
+  let dir = path.dirname(start);
+  for (let i = 0; i < 12; i += 1) {
+    if (path.basename(dir) === 'node_modules') return path.dirname(dir);
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.dirname(start);
 }
 
 function defaultSpawn(scriptPath: string): SidecarStream {

--- a/packages/plugin-browser/src/browser-surface.test.ts
+++ b/packages/plugin-browser/src/browser-surface.test.ts
@@ -15,7 +15,7 @@ import { closeBrowserSidecar, type SidecarStream } from './browser-session.js';
 const FRAME_INTERVAL_MS = 450;
 const FAIL_GRACE = 4;
 
-type Reply = { ok: true; result: unknown } | { ok: false; message: string };
+type Reply = { ok: true; result: unknown } | { ok: false; message: string; kind?: string };
 
 interface FakeSidecar {
   spawn: (path: string) => SidecarStream;
@@ -43,7 +43,7 @@ function makeControllableSpawn(): FakeSidecar {
         const r = handler(reqMsg.method, reqMsg.params);
         const reply = r.ok
           ? { id: reqMsg.id, ok: true, result: r.result }
-          : { id: reqMsg.id, ok: false, error: { message: r.message } };
+          : { id: reqMsg.id, ok: false, error: { message: r.message, kind: r.kind } };
         stdout.write(JSON.stringify(reply) + '\n');
       }
     });
@@ -183,6 +183,31 @@ describe('browser surface polling lifecycle', () => {
     expect(statuses).toEqual([{ type: 'status', text: 'Browser disconnected: page crashed' }]);
     // The stale frame is still available via snapshot.
     expect(surface.snapshot()).toMatchObject({ type: 'frame' });
+
+    surface.close();
+  });
+
+  it('a needs-install error pauses polling and emits an install prompt', async () => {
+    vi.useFakeTimers();
+    const sidecar = makeControllableSpawn();
+    sidecar.setHandler(() => ({ ok: false, message: 'Playwright is not installed.', kind: 'needs-install' }));
+    const surface = buildBrowserSurface({ sidecarPath: '/fake.js', spawnFn: sidecar.spawn }).open();
+    const events: Array<{ type: string; needsInstall?: boolean; text?: string }> = [];
+    surface.onData((p) => events.push(p as { type: string; needsInstall?: boolean }));
+
+    await flush(); // the kick tick() hits the needs-install reply immediately
+    expect(events).toEqual([
+      expect.objectContaining({ type: 'status', needsInstall: true }),
+    ]);
+    // Snapshot for a late viewer also reports the install affordance.
+    expect(surface.snapshot()).toMatchObject({ type: 'status', needsInstall: true });
+
+    // Polling is paused: no further `frame` calls reach the sidecar (we don't
+    // spin on an import that will keep failing).
+    const before = sidecar.received.length;
+    await vi.advanceTimersByTimeAsync(FRAME_INTERVAL_MS * 4);
+    await flush();
+    expect(sidecar.received.length).toBe(before);
 
     surface.close();
   });

--- a/packages/plugin-browser/src/browser-surface.ts
+++ b/packages/plugin-browser/src/browser-surface.ts
@@ -1,5 +1,12 @@
 import { defineSurface, type SurfaceInstance } from '@moxxy/sdk';
-import { browserSidecarCall, type BrowserSessionDeps } from './browser-session.js';
+import {
+  browserSidecarCall,
+  closeBrowserSidecar,
+  resolveBrowserInstallRoot,
+  sidecarErrorKind,
+  type BrowserSessionDeps,
+} from './browser-session.js';
+import { installPlaywrightPackage } from './sidecar/install.js';
 
 /**
  * The `browser` surface: a live, in-window view of the SAME Playwright page the
@@ -43,13 +50,28 @@ export function buildBrowserSurface(deps?: BrowserSessionDeps) {
       let timer: ReturnType<typeof setInterval> | null = null;
       let inFlight = false;
       let fails = 0;
+      // Set once we detect the `playwright` npm package isn't installed. Polling
+      // pauses (no point retrying an import that will keep failing) and the pane
+      // shows an Install affordance; an `install` input clears it.
+      let needsInstall = false;
+      let installing = false;
 
       const emit = (payload: unknown): void => {
         for (const cb of dataSubs) cb(payload);
       };
 
+      const stopPolling = (): void => {
+        if (timer) clearInterval(timer);
+        timer = null;
+      };
+      const startPolling = (): void => {
+        if (timer) return;
+        void tick();
+        timer = setInterval(() => void tick(), FRAME_INTERVAL_MS);
+      };
+
       const tick = async (): Promise<void> => {
-        if (inFlight) return; // don't pile up frames if the page is busy
+        if (inFlight || needsInstall || installing) return; // don't pile up / retry a known-missing dep
         inFlight = true;
         try {
           const frame = (await browserSidecarCall('frame', {}, deps)) as Frame;
@@ -57,6 +79,19 @@ export function buildBrowserSurface(deps?: BrowserSessionDeps) {
           fails = 0;
           emit({ type: 'frame', base64: frame.base64, mime: frame.mediaType, url: frame.url });
         } catch (err) {
+          // The `playwright` npm package is simply absent — recoverable. Pause
+          // polling and ask the user (the download is ~200MB) rather than spin on
+          // a failing import or dump a raw "not installed" error.
+          if (sidecarErrorKind(err) === 'needs-install') {
+            needsInstall = true;
+            stopPolling();
+            emit({
+              type: 'status',
+              needsInstall: true,
+              text: 'The browser engine (Playwright) is not installed. It is a one-time ~200MB download.',
+            });
+            return;
+          }
           // The first failures are usually the browser still launching (or a
           // one-time binary install). Only surface a hard error once it's
           // clearly not transient, so the user isn't left on a silent spinner.
@@ -79,8 +114,33 @@ export function buildBrowserSurface(deps?: BrowserSessionDeps) {
       };
 
       // Kick an immediate frame (launches the browser), then poll.
-      void tick();
-      timer = setInterval(() => void tick(), FRAME_INTERVAL_MS);
+      startPolling();
+
+      const runInstall = async (): Promise<void> => {
+        if (installing) return;
+        installing = true;
+        stopPolling();
+        emit({ type: 'status', text: 'Installing browser engine… (one-time, ~200MB)' });
+        try {
+          await installPlaywrightPackage({
+            rootDir: resolveBrowserInstallRoot(deps),
+            onProgress: (line) => emit({ type: 'status', text: line }),
+          });
+          // The sidecar cached its failed `import('playwright')`; drop it so the
+          // next frame call respawns a fresh sidecar that imports the now-present
+          // package.
+          await closeBrowserSidecar();
+          needsInstall = false;
+          fails = 0;
+          emit({ type: 'status', text: 'Installed. Starting browser…' });
+          startPolling();
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          emit({ type: 'status', needsInstall: true, text: `Install failed: ${message}` });
+        } finally {
+          installing = false;
+        }
+      };
 
       return {
         id: 'browser',
@@ -90,10 +150,20 @@ export function buildBrowserSurface(deps?: BrowserSessionDeps) {
           return () => dataSubs.delete(cb);
         },
         snapshot: () =>
-          last
-            ? { type: 'frame', base64: last.base64, mime: last.mediaType, url: last.url }
-            : { type: 'status', text: 'Starting browser…' },
+          needsInstall
+            ? {
+                type: 'status',
+                needsInstall: true,
+                text: 'The browser engine (Playwright) is not installed. It is a one-time ~200MB download.',
+              }
+            : last
+              ? { type: 'frame', base64: last.base64, mime: last.mediaType, url: last.url }
+              : { type: 'status', text: 'Starting browser…' },
         input: async (msg) => {
+          if (msg.type === 'install') {
+            await runInstall();
+            return;
+          }
           const vw = last?.width ?? 1280;
           const vh = last?.height ?? 720;
           if (msg.type === 'navigate' && typeof msg.url === 'string') {

--- a/packages/plugin-browser/src/sidecar/install.ts
+++ b/packages/plugin-browser/src/sidecar/install.ts
@@ -23,12 +23,89 @@ export async function importPlaywright(): Promise<{
   try {
     return (await import('playwright')) as never;
   } catch (err) {
+    const underlying = err instanceof Error ? err.message : String(err);
+    // Distinguish "the npm package isn't installed" (recoverable — the surface
+    // can offer a one-click install, see `installPlaywrightPackage`) from any
+    // other import failure. The `kind` rides the JSON-RPC reply so the browser
+    // surface shows an "Install" affordance instead of a dead-end error.
     throw new SidecarError(
       `Playwright is not installed. Run \`pnpm add playwright\` (or \`npm i playwright\`) and then \`npx playwright install\` in the moxxy install dir.\n` +
-        `Underlying: ${err instanceof Error ? err.message : String(err)}`,
-      'init',
+        `Underlying: ${underlying}`,
+      isModuleNotFound(underlying) ? 'needs-install' : 'init',
     );
   }
+}
+
+/** True when an import failure is "the `playwright` package can't be found"
+ *  (vs. a load/runtime error inside an installed package). */
+function isModuleNotFound(message: string): boolean {
+  return (
+    /cannot find (package|module) ['"]?playwright/i.test(message) ||
+    /ERR_MODULE_NOT_FOUND/i.test(message) ||
+    /failed to resolve ['"]?playwright/i.test(message)
+  );
+}
+
+export interface InstallPlaywrightOptions {
+  /** Directory whose `node_modules` should receive `playwright` — the CLI
+   *  install root (e.g. `<userData>/cli`). `npm` runs with this as its cwd. */
+  readonly rootDir: string;
+  /** Which browser engine binary to download after the npm package lands. */
+  readonly browser?: BrowserKind;
+  /** Per-line progress (npm/npx stdout+stderr) for streaming to the UI. */
+  readonly onProgress?: (line: string) => void;
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Install the `playwright` npm package into `rootDir`, then download the browser
+ * engine binary — the two halves the desktop browser surface needs. Driven by
+ * the surface AFTER the user consents (the download is ~200MB). Streams progress
+ * via `onProgress`; resolves on success, rejects with the failing step's output.
+ *
+ * Lives next to {@link importPlaywright} (which reports the `needs-install` that
+ * triggers this) but is invoked in the RUNNER process — `rootDir`'s node_modules
+ * is the one the sidecar later imports `playwright` from.
+ */
+export async function installPlaywrightPackage(opts: InstallPlaywrightOptions): Promise<void> {
+  const which = opts.browser ?? 'chromium';
+  opts.onProgress?.(`Installing the playwright npm package into ${opts.rootDir}…`);
+  await runProcess('npm', ['install', '--no-fund', '--no-audit', 'playwright'], opts);
+  opts.onProgress?.(`Downloading the ${which} browser engine (~150MB, one-time)…`);
+  await runProcess('npx', ['playwright', 'install', which], opts);
+  opts.onProgress?.('Playwright installed.');
+}
+
+/** Spawn a child, forward its output to `onProgress`, resolve on exit-0. */
+function runProcess(cmd: string, args: string[], opts: InstallPlaywrightOptions): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (opts.signal?.aborted) return reject(new Error('install aborted'));
+    const child = spawn(cmd, args, { cwd: opts.rootDir, stdio: ['ignore', 'pipe', 'pipe'] });
+    let tail = '';
+    const onChunk = (chunk: Buffer): void => {
+      const text = chunk.toString('utf8');
+      for (const line of text.split(/\r?\n/)) if (line.trim()) opts.onProgress?.(line);
+      tail = (tail + text).slice(-4000);
+    };
+    child.stdout.on('data', onChunk);
+    child.stderr.on('data', onChunk);
+    const onAbort = (): void => {
+      child.kill();
+    };
+    opts.signal?.addEventListener('abort', onAbort, { once: true });
+    child.once('error', (err) => {
+      opts.signal?.removeEventListener('abort', onAbort);
+      reject(err);
+    });
+    child.once('close', (code) => {
+      opts.signal?.removeEventListener('abort', onAbort);
+      if (code === 0) resolve();
+      else
+        reject(
+          new Error(`\`${cmd} ${args.join(' ')}\` failed (exit ${code}): ${tail.trim() || '(no output)'}`),
+        );
+    });
+  });
 }
 
 /**

--- a/packages/plugin-browser/src/sidecar/types.ts
+++ b/packages/plugin-browser/src/sidecar/types.ts
@@ -1,6 +1,12 @@
 export type BrowserKind = 'chromium' | 'firefox' | 'webkit';
 
-export type ErrorKind = 'init' | 'navigation' | 'runtime' | 'timeout' | 'unknown';
+export type ErrorKind =
+  | 'init'
+  | 'needs-install' // the `playwright` npm package itself isn't installed yet
+  | 'navigation'
+  | 'runtime'
+  | 'timeout'
+  | 'unknown';
 
 export interface Req {
   readonly id: string;

--- a/packages/plugin-terminal/src/pty.test.ts
+++ b/packages/plugin-terminal/src/pty.test.ts
@@ -1,6 +1,9 @@
 import { EventEmitter } from 'node:events';
-import { describe, expect, it } from 'vitest';
-import { TerminalProcessImpl } from './pty.js';
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { makeExecutable, TerminalProcessImpl } from './pty.js';
 
 const MAX_SCROLLBACK = 200_000;
 
@@ -21,6 +24,38 @@ function fakeChild(): {
   proc.stdin = { write: () => {}, end: () => {} };
   return { stdout: proc.stdout, stderr: proc.stderr, proc };
 }
+
+describe('makeExecutable (node-pty spawn-helper repair)', () => {
+  let dir: string | null = null;
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    dir = null;
+  });
+
+  it('adds the executable bit to a file that lacks it', () => {
+    dir = mkdtempSync(join(tmpdir(), 'moxxy-pty-'));
+    const file = join(dir, 'spawn-helper');
+    writeFileSync(file, 'binary');
+    // Simulate the stripped-bit state that breaks node-pty's posix_spawnp.
+    const noExec = statSync(file).mode;
+    expect(noExec & 0o111).toBe(0);
+
+    expect(makeExecutable(file)).toBe(true);
+    expect(statSync(file).mode & 0o111).not.toBe(0);
+  });
+
+  it('is idempotent on an already-executable file', () => {
+    dir = mkdtempSync(join(tmpdir(), 'moxxy-pty-'));
+    const file = join(dir, 'spawn-helper');
+    writeFileSync(file, 'binary', { mode: 0o755 });
+    expect(makeExecutable(file)).toBe(true);
+    expect(statSync(file).mode & 0o111).not.toBe(0);
+  });
+
+  it('returns false (no throw) for a missing file', () => {
+    expect(makeExecutable(join(tmpdir(), 'moxxy-does-not-exist', 'spawn-helper'))).toBe(false);
+  });
+});
 
 describe('TerminalProcessImpl scrollback (hysteresis trim)', () => {
   it('keeps scrollback bounded to the cap and returns the true tail', () => {

--- a/packages/plugin-terminal/src/pty.ts
+++ b/packages/plugin-terminal/src/pty.ts
@@ -16,6 +16,9 @@
  */
 
 import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import { chmodSync, existsSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import * as nodePath from 'node:path';
 
 /** Minimal slice of node-pty we use — declared locally so typecheck never needs
  *  `@types/node-pty` (the dep is optional). */
@@ -45,6 +48,74 @@ function loadNodePty(): Promise<NodePtyModule | null> {
   return nodePtyPromise;
 }
 
+/** Add the executable bit (u+x,g+x,o+x) to a file if it lacks it. Returns true
+ *  when the file now has it (was already +x, or we just set it). Exported for
+ *  tests — the chmod logic is the load-bearing fix, so it's unit-tested directly
+ *  without needing node-pty present. */
+export function makeExecutable(filePath: string): boolean {
+  try {
+    const st = statSync(filePath);
+    if (st.mode & 0o111) return true; // already executable
+    chmodSync(filePath, st.mode | 0o111);
+    return true;
+  } catch {
+    return false; // not present / not permitted — caller treats as best-effort
+  }
+}
+
+/**
+ * node-pty ships a prebuilt `spawn-helper` binary on macOS that it exec()s to
+ * launch the shell inside the PTY. Several install/repack paths (notably
+ * `npm install` into the desktop's writable CLI prefix, and pnpm's content store)
+ * drop the executable bit on it — node-pty then loads fine but `pty.spawn`
+ * throws `posix_spawnp failed`, which used to be swallowed into the (effectively
+ * dead) piped fallback. So before we spawn, ensure the helper is executable.
+ * Best-effort: never throws; the spawn itself is the real test.
+ */
+function ensureSpawnHelperExecutable(): void {
+  if (process.platform === 'win32') return; // Windows uses conpty/winpty, no spawn-helper
+  try {
+    const root = nodePtyPackageRoot();
+    if (!root) return;
+    const candidates = [
+      // prebuildify layout (the published npm package)
+      nodePath.join(root, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper'),
+      // build-from-source layout (no prebuild for this platform)
+      nodePath.join(root, 'build', 'Release', 'spawn-helper'),
+    ];
+    for (const c of candidates) makeExecutable(c);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Resolve node-pty's package directory (the one containing `prebuilds/`),
+ *  resolving from THIS module so it works whether node-pty sits in a hoisted
+ *  root, a nested, or a pnpm store layout. */
+function nodePtyPackageRoot(): string | null {
+  try {
+    const require = createRequire(import.meta.url);
+    try {
+      return nodePath.dirname(require.resolve('node-pty/package.json'));
+    } catch {
+      // `exports` may hide package.json; resolve the entry and walk up to the
+      // first ancestor that has a `prebuilds/` (or `build/`) dir.
+      let dir = nodePath.dirname(require.resolve('node-pty'));
+      for (let i = 0; i < 6; i += 1) {
+        if (existsSync(nodePath.join(dir, 'prebuilds')) || existsSync(nodePath.join(dir, 'build'))) {
+          return dir;
+        }
+        const parent = nodePath.dirname(dir);
+        if (parent === dir) break;
+        dir = parent;
+      }
+      return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
 /** Pick the user's interactive shell per platform. */
 function defaultShell(): string {
   if (process.platform === 'win32') return process.env['COMSPEC'] ?? 'powershell.exe';
@@ -66,6 +137,10 @@ export type TerminalBackend = 'pty' | 'pipe';
 
 export interface TerminalProcess {
   readonly backend: TerminalBackend;
+  /** When `backend === 'pipe'`, the reason the real PTY couldn't start (so the
+   *  surface can show an honest "degraded" status instead of a silently-dead
+   *  box). Null when a real PTY is in use. */
+  readonly ptyError: string | null;
   /** Subscribe to output (utf8). Returns an unsubscribe fn. */
   onData(cb: (data: string) => void): () => void;
   /** Subscribe to process exit. */
@@ -90,6 +165,7 @@ export class TerminalProcessImpl implements TerminalProcess {
     readonly backend: TerminalBackend,
     private readonly pty: NodePtyProcess | null,
     private readonly child: ChildProcessWithoutNullStreams | null,
+    readonly ptyError: string | null = null,
   ) {
     if (pty) {
       pty.onData((d) => this.emitData(d));
@@ -188,22 +264,38 @@ export async function createTerminalProcess(cwd: string): Promise<TerminalProces
   const rows = 24;
   const env: NodeJS.ProcessEnv = { ...process.env, TERM: 'xterm-256color' };
   const pty = await loadNodePty();
+  let ptyError: string | null = pty ? null : 'node-pty is not installed';
   if (pty) {
+    const trySpawn = (): NodePtyProcess =>
+      pty.spawn(shell, [], { name: 'xterm-256color', cols, rows, cwd, env });
+    // Make sure the prebuilt spawn-helper is executable, then spawn. If the first
+    // spawn still fails (e.g. the bit was only just lost), repair + retry ONCE
+    // before giving up — most "posix_spawnp failed" cases clear on the retry.
+    ensureSpawnHelperExecutable();
     try {
-      const proc = pty.spawn(shell, [], { name: 'xterm-256color', cols, rows, cwd, env });
-      return new TerminalProcessImpl('pty', proc, null);
+      return new TerminalProcessImpl('pty', trySpawn(), null);
     } catch {
-      // Fall through to the piped backend if the native spawn fails.
+      ensureSpawnHelperExecutable();
+      try {
+        return new TerminalProcessImpl('pty', trySpawn(), null);
+      } catch (err2) {
+        // Don't swallow it: record WHY so the surface can show an honest status
+        // instead of a silently-dead piped terminal.
+        ptyError = err2 instanceof Error ? err2.message : String(err2);
+      }
     }
   }
   // Dependency-free fallback: an interactive shell with piped stdio. `-i` keeps
   // it from exiting immediately; non-Windows only — cmd/powershell are already
-  // interactive when stdin is piped.
+  // interactive when stdin is piped. NOTE: this has no TTY line discipline (a
+  // viewer's `\r` is never turned into `\n`, nothing echoes), so it is NOT a
+  // usable interactive terminal — `ptyError` is surfaced to the user so the pane
+  // reports the degraded state rather than appearing to ignore every keystroke.
   const args = process.platform === 'win32' ? [] : ['-i'];
   const child = spawn(shell, args, {
     cwd,
     env: { ...env, PS1: '$ ' },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
-  return new TerminalProcessImpl('pipe', null, child);
+  return new TerminalProcessImpl('pipe', null, child, ptyError);
 }

--- a/packages/plugin-terminal/src/terminal.test.ts
+++ b/packages/plugin-terminal/src/terminal.test.ts
@@ -9,6 +9,7 @@ function fakeTerminal(): TerminalProcess & { feed(s: string): void } {
   let listener: ((d: string) => void) | null = null;
   return {
     backend: 'pipe',
+    ptyError: null,
     onData: (cb) => {
       listener = cb;
       return () => {

--- a/packages/plugin-terminal/src/terminal.ts
+++ b/packages/plugin-terminal/src/terminal.ts
@@ -70,6 +70,17 @@ export function buildTerminalSurface() {
       };
       const unsubData = proc.onData((data) => emit({ type: 'data', data }));
       const unsubExit = proc.onExit((code) => emit({ type: 'exit', code }));
+      // Honest degraded state: without a real PTY the pane can't function as an
+      // interactive terminal (no echo, a viewer's Enter never reaches the shell).
+      // Tell the viewer rather than presenting a box that silently ignores input.
+      if (proc.backend === 'pipe') {
+        emit({
+          type: 'status',
+          text: proc.ptyError
+            ? `Terminal unavailable: the PTY backend failed to start (${proc.ptyError}).`
+            : 'Terminal unavailable: a real PTY backend (node-pty) is not available.',
+        });
+      }
       return {
         id: 'terminal',
         kind: 'terminal',
@@ -77,7 +88,12 @@ export function buildTerminalSurface() {
           dataSubs.add(cb);
           return () => dataSubs.delete(cb);
         },
-        snapshot: () => ({ type: 'snapshot', data: proc.scrollback(), backend: proc.backend }),
+        snapshot: () => ({
+          type: 'snapshot',
+          data: proc.scrollback(),
+          backend: proc.backend,
+          ptyError: proc.ptyError,
+        }),
         input: (msg) => {
           if (msg.type === 'data' && typeof msg.data === 'string') proc.write(msg.data);
         },


### PR DESCRIPTION
## What

Two desktop agentic-surface fixes:

**Terminal — accept input (be a real terminal).** node-pty's macOS `spawn-helper` binary ships **without the executable bit** (true for both pnpm dev installs and `npm install` into the desktop's CLI prefix). node-pty loaded fine but `pty.spawn` threw `posix_spawnp failed`, which was silently swallowed into the piped fallback — a shell with no TTY line discipline, so a viewer's Enter (`\r`) was never turned into `\n` and nothing echoed. The pane rendered a prompt but ignored every keystroke.
- `packages/plugin-terminal/src/pty.ts`: `ensureSpawnHelperExecutable()` repairs the exec bit (resolves node-pty's package root, chmods `prebuilds/*/spawn-helper`) before spawning, and retries once. On genuine failure it records the reason (`ptyError`) instead of swallowing it.
- `packages/desktop-host/src/installer.ts`: chmods the helper after `npm install` (defense-in-depth so a fresh install never first-fails).
- `terminal.ts` / `TerminalPane.tsx`: when a real PTY can't start, show an honest **"Terminal unavailable: …"** status instead of a silently-dead box.

**Browser — ask-first Playwright install.** When the `playwright` npm package is missing, the surface reports a distinct `needs-install` state and the pane shows an **"Install browser engine (~200MB)"** button. On click it installs the npm package + the Chromium engine with live progress, restarts the sidecar, and resumes.
- `sidecar/install.ts` tags the missing-package error `needs-install` (vs `init`) and adds `installPlaywrightPackage()`; `browser-session.ts` carries the kind to the surface (`sidecarErrorKind`) + resolves the install root; `browser-surface.ts` pauses polling and handles the `install` input; `BrowserPane.tsx` renders the button. No runner-protocol or SDK change (`SurfaceInputMessage`/payloads are open shapes).

## Why

The terminal "never accepted input" across PRs #205/#208/#211 — those fixed UI/sizing/ref-counting, but the PTY had **never actually spawned** because of the stripped exec bit (verified: `chmod +x spawn-helper` → node-pty spawns, runs commands, renders the prompt). The browser surface previously dead-ended on a "run `npm i playwright` yourself" error.

## Verification

- `pnpm build` (64/64), `pnpm -w typecheck` (126/126), `pnpm check:deps` clean (746 modules), lint 0 errors — run in a clean worktree off `origin/main`.
- Tests: plugin-terminal 18, plugin-browser 80, desktop-host 383 — all pass. New tests cover the spawn-helper chmod (`makeExecutable`), the `needs-install` detect-and-pause path, and `resolveBrowserInstallRoot`.
- End-to-end: stripped the exec bit to reproduce, then ran the built `createTerminalProcess` → returned `backend: pty` (self-healed), `\r`-terminated command ran, full colored prompt rendered.
- Changeset added; TECH_DEBT.md updated (resolves the "verify real PTY in a packaged launch" item with the root cause).