### PR TITLE
feat(desktop): Apps gallery with install lifecycle + offline document anonymizer

### DIFF
--- a/.changeset/desktop-apps-anonymizer.md
+++ b/.changeset/desktop-apps-anonymizer.md
@@ -1,0 +1,28 @@
+---
+"@moxxy/anonymizer": minor
+"@moxxy/desktop-ipc-contract": minor
+"@moxxy/desktop-host": minor
+"@moxxy/client-core": minor
+"@moxxy/desktop": minor
+---
+
+feat(desktop): Apps gallery with install lifecycle + offline document anonymizer
+
+Adds an **Apps** section (a new top-level header tab next to Chat / Workflows) — a
+registry-backed gallery of self-contained mini-applications. Apps that need local
+assets show a predefined **Install** step that downloads everything they need
+before first use; installation is the only time the network is touched, runs in
+the main process, and is gated behind an explicit click.
+
+The first app is an **offline document anonymizer**. Paste text or open a
+document (PDF / Office / text, parsed locally via the existing officeparser
+pipeline) and it detects + redacts PII — emails, phone numbers, credit cards
+(Luhn), SSNs, IPs, MACs, IBANs (mod-97), URLs — plus a custom-terms list and an
+**on-device NER** model (`Xenova/bert-base-NER`, ~109 MB, downloaded on install)
+for names, organizations and locations. Redaction runs entirely in the renderer
+(`@moxxy/anonymizer`, a new pure, dependency-free, network-free engine) with
+labeled / pseudonym / hash styles. **Documents never leave the machine**: the
+analyze path touches no provider/runner/network, the CSP `connect-src` stays
+local-only (the NER model is served from a confined `moxxy-app://` scheme over
+`userData/moxxy-apps`), and the engine's emptiness of dependencies is enforced by
+a unit test.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -58,6 +58,43 @@ codebase keeps accruing debt; the audit backlog itself is cleared.
 
 ---
 
+## 2026-06-18 — Desktop Apps gallery + offline document anonymizer
+
+Added a registry-backed **Apps** section (new top-level header tab) with a
+predefined per-app **Install** lifecycle, and shipped an offline document
+anonymizer as the first app. New pure engine `@moxxy/anonymizer` (zero deps,
+network-free, enforced by `offline.test.ts`); main-process generic installer +
+hardened `moxxy-app://` asset scheme (`packages/desktop-host/src/apps/`); renderer
+gallery + NER worker (`@huggingface/transformers`, wasm).
+
+**Retired:** the per-file text-extraction logic was factored out of
+`attachments.ts` (`buildAttachments`/`extractText`) into an exported
+`parseFileToText(absPath)` reused by the anonymizer handler — one copy, two
+callers.
+
+**New debt logged on sight:**
+- **NER model E2E is verified only in unit tests** — the structured engine, the
+  installer/scheme (stubbed-fetch + temp-dir tests), the gallery, and the BIO
+  aggregation are covered, but the actual ~109 MB model download + transformers.js
+  wasm inference over `moxxy-app://` can only be confirmed in a **packaged/dev
+  Electron run** (no model is exercised in CI). Verify: install the app, confirm
+  the model loads from `moxxy-app://` (DevTools Network) with **zero** real
+  network, and that names redact. Until then NER degrades gracefully (structured
+  redaction always works; the toggle shows `unavailable`).
+- **transformers.js ↔ ORT wasm version coupling.** The ORT wasm runtime is bundled
+  by Vite from `@huggingface/transformers@^3.8.1` (loads from `'self'`); the model
+  is `Xenova/bert-base-NER` q8. Bumping the transformers.js dep can change the ORT
+  wasm and the expected model layout — re-verify the packaged NER run on any bump.
+- **Asset path coupling.** The installer `dest` mirrors the HF resolve path
+  verbatim because the worker's `remoteHost` rewrite maps 1:1 to it
+  (`packages/desktop-host/src/apps/registry.ts`). Changing one side silently 404s
+  the model; keep them in lockstep (commented at both ends).
+- **No on-disk integrity check.** Install assets have no sha256 pin (Content-Length
+  drives progress only); a corrupt/partial model surfaces as a runtime NER error,
+  not an install failure. Add per-asset hashes when the model set stabilizes.
+
+---
+
 ## 2026-06-18 — Repo-wide quality + performance sweep (audit-driven)
 
 A 240-agent, adversarially-verified audit of the whole monorepo produced

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -41,6 +41,7 @@ import {
   ensureDesktopVaultKey,
   activateManagedNode,
   startLoopbackServer,
+  installAppAssetProtocol,
   loadOrCreateSelfSignedCert,
   sendEvent,
   readPrefs,
@@ -79,9 +80,30 @@ if (app.isPackaged && !process.env.MOXXY_CLI_ENTRY) {
   const entry = preferredCliEntry(app.getPath('userData'), process.resourcesPath);
   if (entry) process.env.MOXXY_CLI_ENTRY = entry;
 }
-import { ipcMain, Tray, Menu, nativeImage, nativeTheme, globalShortcut, session, shell, systemPreferences } from 'electron';
+import { ipcMain, Tray, Menu, nativeImage, nativeTheme, globalShortcut, protocol, session, shell, systemPreferences } from 'electron';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Register the local-only `moxxy-app://` asset scheme as privileged BEFORE
+// app-ready (Electron only honors registerSchemesAsPrivileged pre-ready). It
+// serves an installed app's downloaded assets (the anonymizer's NER model) from
+// `userData/moxxy-apps` over a confined GET/HEAD handler (no network egress);
+// the renderer + its worker fetch the model with it (CSP allows `moxxy-app:` in
+// connect-src). `standard + secure` so it's a trusted, fetch/stream-capable
+// origin; `supportFetchAPI`/`stream`/`bytes` so transformers.js can fetch + range
+// the ~109 MB model; `corsEnabled` so a worker request isn't CORS-blocked.
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: 'moxxy-app',
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      stream: true,
+      corsEnabled: true,
+    },
+  },
+]);
 
 const isDev = !!process.env['ELECTRON_RENDERER_URL'];
 
@@ -578,6 +600,13 @@ app.whenReady().then(async () => {
     clerkPublishableKey: CLERK_PUBLISHABLE_KEY,
     loopbackOrigin: loopback?.origin ?? null,
   });
+
+  // Serve installed app assets (the anonymizer's NER model) over the confined,
+  // local-only `moxxy-app://` scheme registered privileged above. Rooted at
+  // `userData/moxxy-apps`; the installer creates that dir lazily on first
+  // install, and the handler 404s harmlessly until then. No network egress —
+  // it only reads files under that root (realpath-contained, GET/HEAD only).
+  installAppAssetProtocol(path.join(app.getPath('userData'), 'moxxy-apps'));
 
   // Allow the renderer's voice recorder to reach the microphone. Without this,
   // macOS hands getUserMedia a SILENT stream (no rejection), so voice

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,6 +28,8 @@
   "dependencies": {
     "@clerk/clerk-react": "^5.0.0",
     "@clerk/themes": "^2.4.57",
+    "@huggingface/transformers": "^3.8.1",
+    "@moxxy/anonymizer": "workspace:*",
     "@moxxy/chat-model": "workspace:*",
     "@moxxy/cli": "workspace:*",
     "@moxxy/client-core": "workspace:*",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -24,6 +24,7 @@ import { ContextRail, type RailPane } from './shell/ContextRail';
 import { WorkflowsPanel } from './workflows/WorkflowsPanel';
 import { CollaboratePanel } from './collaborate/CollaboratePanel';
 import { SettingsPanel } from './settings/SettingsPanel';
+import { AppsPanel } from './apps/AppsPanel';
 import { UpdateBanner } from './shell/UpdateBanner';
 import { Splash } from './Splash';
 import { api, toErrorMessage } from '@moxxy/client-core';
@@ -249,6 +250,11 @@ export function App(): JSX.Element {
       {view === 'settings' && (
         <main className="col-main col-main--flat">
           <SettingsPanel onView={setView} />
+        </main>
+      )}
+      {view === 'apps' && (
+        <main className="col-main col-main--flat">
+          <AppsPanel onView={setView} />
         </main>
       )}
       {!connected && <ReconnectBanner label={describePhase(phase)} />}

--- a/apps/desktop/src/apps/AppCard.tsx
+++ b/apps/desktop/src/apps/AppCard.tsx
@@ -1,0 +1,147 @@
+import { useAppInstall } from '@moxxy/client-core';
+import { Button, Icon } from '@moxxy/desktop-ui';
+import type { DesktopAppDef } from './registry';
+import { OfflineBadge } from './OfflineBadge';
+
+function mb(bytes: number): string {
+  return `${(bytes / 1_000_000).toFixed(0)} MB`;
+}
+
+/** One gallery tile. Apps that `requiresInstall` show the install lifecycle
+ *  (Install → progress → Open); others open directly. */
+export function AppCard({
+  def,
+  onOpen,
+}: {
+  readonly def: DesktopAppDef;
+  readonly onOpen: () => void;
+}): JSX.Element {
+  const { status, progress, installing, install, uninstall } = useAppInstall(def.id);
+  const needsInstall = def.requiresInstall === true;
+  const state = needsInstall ? (status?.state ?? null) : 'installed';
+
+  return (
+    <li
+      data-testid={`app-card-${def.id}`}
+      style={{
+        listStyle: 'none',
+        padding: '1rem 1.1rem',
+        background: 'var(--color-bg-card)',
+        border: '1px solid var(--color-border)',
+        borderRadius: 'var(--radius-block)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.75rem',
+        minHeight: 168,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+        <span
+          aria-hidden
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 40,
+            height: 40,
+            flexShrink: 0,
+            borderRadius: 10,
+            color: 'var(--color-primary)',
+            background: 'color-mix(in oklab, var(--color-primary) 12%, transparent)',
+          }}
+        >
+          <Icon name={def.icon} size={20} />
+        </span>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontWeight: 600, fontSize: '0.95rem' }}>{def.name}</div>
+          <div style={{ fontSize: '0.82rem', color: 'var(--color-text-muted)', marginTop: 3 }}>
+            {def.description}
+          </div>
+        </div>
+      </div>
+
+      {def.offline && (
+        <div>
+          <OfflineBadge />
+        </div>
+      )}
+
+      <div style={{ flex: 1 }} />
+
+      {state === 'installed' ? (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <Button variant="primary" data-testid={`open-${def.id}`} onClick={onOpen}>
+            Open
+          </Button>
+          {needsInstall && (
+            <button
+              type="button"
+              onClick={() => void uninstall()}
+              style={{
+                fontSize: 12,
+                color: 'var(--color-text-dim)',
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+              }}
+            >
+              Uninstall
+            </button>
+          )}
+        </div>
+      ) : state === 'installing' || installing ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <div style={{ fontSize: 12, color: 'var(--color-text-dim)' }}>
+            {progress && progress.totalBytes > 0
+              ? `Downloading… ${mb(progress.receivedBytes)} / ${mb(progress.totalBytes)}`
+              : 'Downloading…'}
+          </div>
+          <div
+            style={{
+              height: 6,
+              borderRadius: 999,
+              background: 'var(--color-border)',
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                height: '100%',
+                width:
+                  progress && progress.totalBytes > 0
+                    ? `${Math.min(100, (progress.receivedBytes / progress.totalBytes) * 100)}%`
+                    : '40%',
+                background: 'var(--color-primary)',
+                transition: 'width 200ms',
+              }}
+            />
+          </div>
+        </div>
+      ) : state === 'error' ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <div style={{ fontSize: 12, color: 'var(--color-pink)' }}>
+            {status?.error ?? 'Install failed.'}
+          </div>
+          <Button variant="secondary" onClick={() => void install()}>
+            Retry install
+          </Button>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {def.installSummary && (
+            <div style={{ fontSize: 12, color: 'var(--color-text-dim)' }}>{def.installSummary}</div>
+          )}
+          <div>
+            <Button
+              variant="primary"
+              data-testid={`install-${def.id}`}
+              onClick={() => void install()}
+            >
+              Install
+            </Button>
+          </div>
+        </div>
+      )}
+    </li>
+  );
+}

--- a/apps/desktop/src/apps/AppsPanel.tsx
+++ b/apps/desktop/src/apps/AppsPanel.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { ViewHeader, ViewSwitcher, type View } from '../shell/ViewHeader';
+import { getDesktopApp, listDesktopApps } from './registry';
+import { AppCard } from './AppCard';
+import './builtins';
+
+/**
+ * Apps surface — two modes:
+ *   - gallery: a grid of registered app cards (each drives its own install
+ *     lifecycle when it needs assets).
+ *   - open: the selected app's full-pane component, with `onExit` back to gallery.
+ *
+ * One new `View` (`'apps'`) hosts every app via the sub-route below, so adding
+ * app #2..N never touches navigation.
+ */
+export function AppsPanel({
+  onView = () => undefined,
+}: {
+  readonly onView?: (v: View) => void;
+}): JSX.Element {
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  const open = openId ? getDesktopApp(openId) : undefined;
+  if (open) {
+    const App = open.Component;
+    return <App onExit={() => setOpenId(null)} />;
+  }
+
+  const apps = listDesktopApps();
+  return (
+    <>
+      <ViewHeader>
+        <ViewSwitcher view="apps" onView={onView} />
+        <span style={{ flex: 1 }} />
+      </ViewHeader>
+      <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '1.5rem 2rem' }}>
+        {apps.length === 0 ? (
+          <p style={{ color: 'var(--color-text-dim)' }}>No apps available.</p>
+        ) : (
+          <ul
+            role="list"
+            style={{
+              margin: 0,
+              padding: 0,
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+              gap: '1rem',
+            }}
+          >
+            {apps.map((def) => (
+              <AppCard key={def.id} def={def} onOpen={() => setOpenId(def.id)} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/desktop/src/apps/OfflineBadge.tsx
+++ b/apps/desktop/src/apps/OfflineBadge.tsx
@@ -1,0 +1,27 @@
+import { Icon } from '@moxxy/desktop-ui';
+
+/** "Offline · on-device" shield pill — shown on an offline app's gallery card
+ *  and in its header so the guarantee is visible at the point of use. */
+export function OfflineBadge(): JSX.Element {
+  return (
+    <span
+      title="Runs entirely on your machine — nothing is uploaded"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 5,
+        padding: '2px 8px',
+        fontSize: 11,
+        fontWeight: 600,
+        color: 'var(--color-green)',
+        background: 'color-mix(in oklab, var(--color-green) 14%, transparent)',
+        border: '1px solid color-mix(in oklab, var(--color-green) 35%, transparent)',
+        borderRadius: 999,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <Icon name="lock" size={12} />
+      Offline · on-device
+    </span>
+  );
+}

--- a/apps/desktop/src/apps/anonymizer/AnonymizerApp.tsx
+++ b/apps/desktop/src/apps/anonymizer/AnonymizerApp.tsx
@@ -1,0 +1,282 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  redact,
+  STRUCTURED_CATEGORIES,
+  type PiiCategory,
+  type PiiSpan,
+  type RedactionMode,
+} from '@moxxy/anonymizer';
+import { useAnonymizer } from '@moxxy/client-core';
+import { Button, Icon, TextArea } from '@moxxy/desktop-ui';
+import { Segmented, ViewHeader } from '../../shell/ViewHeader';
+import type { DesktopAppProps } from '../registry';
+import { OfflineBadge } from '../OfflineBadge';
+import { Counts } from './Counts';
+import { SpanHighlight } from './SpanHighlight';
+import { CATEGORY_LABELS, TOGGLE_CATEGORIES } from './labels';
+import { useNer } from './ner/useNer';
+
+const REDACT_MODES: ReadonlyArray<{ id: RedactionMode; label: string }> = [
+  { id: 'label', label: 'Label' },
+  { id: 'pseudonym', label: 'Pseudonym' },
+  { id: 'hash', label: 'Hash' },
+];
+
+function parseTerms(s: string): string[] {
+  return s
+    .split(/[\n,]+/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Offline document anonymizer. Paste text or open a document, and the redaction
+ * runs ENTIRELY in this renderer — structured PII via `@moxxy/anonymizer`
+ * (pure, no network) plus on-device NER for names. Nothing is uploaded; opening
+ * a file only reads it locally (in main) and returns the text here.
+ */
+export function AnonymizerApp({ onExit }: DesktopAppProps): JSX.Element {
+  const anon = useAnonymizer();
+  const { status: nerStatus, error: nerError, detectNames } = useNer();
+
+  const [sourceMode, setSourceMode] = useState<'paste' | 'file'>('paste');
+  const [input, setInput] = useState('');
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [categories, setCategories] = useState<ReadonlySet<PiiCategory>>(
+    () => new Set(STRUCTURED_CATEGORIES),
+  );
+  const [customTermsText, setCustomTermsText] = useState('');
+  const [mode, setMode] = useState<RedactionMode>('label');
+  const [nerEnabled, setNerEnabled] = useState(true);
+  const [nerSpans, setNerSpans] = useState<readonly PiiSpan[]>([]);
+  const [saved, setSaved] = useState<string | null>(null);
+
+  // Run on-device NER (debounced) whenever the text or the toggle changes.
+  useEffect(() => {
+    if (!nerEnabled || !input.trim()) {
+      setNerSpans([]);
+      return;
+    }
+    const handle = setTimeout(() => {
+      void detectNames(input).then(setNerSpans);
+    }, 350);
+    return () => clearTimeout(handle);
+  }, [input, nerEnabled, detectNames]);
+
+  const customTerms = useMemo(() => parseTerms(customTermsText), [customTermsText]);
+  const categoryList = useMemo(() => [...categories], [categories]);
+
+  const result = useMemo(
+    () =>
+      redact(input, {
+        categories: categoryList,
+        customTerms,
+        extraSpans: nerEnabled ? nerSpans : [],
+        mode,
+      }),
+    [input, categoryList, customTerms, nerEnabled, nerSpans, mode],
+  );
+
+  const toggleCategory = (c: PiiCategory): void => {
+    setCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(c)) next.delete(c);
+      else next.add(c);
+      return next;
+    });
+  };
+
+  const openDocument = async (): Promise<void> => {
+    setFileError(null);
+    const r = await anon.pickAndParse();
+    if (!r) return; // cancelled
+    if ('error' in r) {
+      setFileError(r.error);
+      return;
+    }
+    setInput(r.text);
+    setFileName('document');
+  };
+
+  const copyOut = (): void => {
+    void navigator.clipboard.writeText(result.text);
+  };
+
+  const saveOut = async (): Promise<void> => {
+    const name = fileName ? `${fileName}-redacted.txt` : 'redacted.txt';
+    const path = await anon.save(name, result.text);
+    if (path) setSaved(path);
+  };
+
+  return (
+    <>
+      <ViewHeader>
+        <Button variant="chip" onClick={onExit} style={{ borderRadius: 9 }}>
+          <Icon name="chevron-right" size={14} style={{ transform: 'rotate(180deg)' }} />
+          Apps
+        </Button>
+        <strong style={{ fontSize: 15 }}>Document anonymizer</strong>
+        <OfflineBadge />
+        <span style={{ flex: 1 }} />
+      </ViewHeader>
+
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          padding: '1.25rem 1.75rem',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(360px, 1fr))',
+          gap: '1.25rem',
+        }}
+      >
+        {/* ── Source + options ─────────────────────────────────────────── */}
+        <section style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem', minWidth: 0 }}>
+          <Segmented
+            items={[
+              { id: 'paste', label: 'Paste text' },
+              { id: 'file', label: 'Open document' },
+            ]}
+            value={sourceMode}
+            onChange={(id) => setSourceMode(id)}
+            testIdPrefix="anon-src-"
+          />
+
+          {sourceMode === 'paste' ? (
+            <TextArea
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Paste the text you want to anonymize…"
+              rows={10}
+              style={{ width: '100%', fontSize: 13, lineHeight: 1.5 }}
+            />
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <Button variant="secondary" data-testid="anon-pick" onClick={() => void openDocument()}>
+                <Icon name="attach" size={14} /> Choose a document…
+              </Button>
+              {anon.busy && <span style={dim}>Reading document…</span>}
+              {fileName && !anon.busy && (
+                <span style={dim}>Loaded {result.report.total} item(s) from your document.</span>
+              )}
+              {fileError && <span style={{ ...dim, color: 'var(--color-pink)' }}>{fileError}</span>}
+            </div>
+          )}
+
+          <label style={toggleRow}>
+            <input
+              type="checkbox"
+              checked={nerEnabled}
+              onChange={(e) => setNerEnabled(e.target.checked)}
+            />
+            <span>Detect names &amp; places (on-device AI)</span>
+            <span style={{ ...dim, marginLeft: 'auto' }}>
+              {nerStatus === 'loading'
+                ? 'loading model…'
+                : nerStatus === 'error'
+                  ? 'unavailable'
+                  : nerStatus === 'ready'
+                    ? 'ready'
+                    : ''}
+            </span>
+          </label>
+          {nerError && nerEnabled && (
+            <span style={{ ...dim, color: 'var(--color-pink)' }}>{nerError}</span>
+          )}
+
+          <div>
+            <div style={{ ...dim, marginBottom: 6 }}>Redaction style</div>
+            <Segmented items={REDACT_MODES} value={mode} onChange={setMode} testIdPrefix="anon-mode-" />
+          </div>
+
+          <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
+            <div style={{ ...dim, marginBottom: 6 }}>Detect</div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 14px' }}>
+              {TOGGLE_CATEGORIES.map((c) => (
+                <label key={c} style={toggleRow}>
+                  <input
+                    type="checkbox"
+                    checked={categories.has(c)}
+                    onChange={() => toggleCategory(c)}
+                  />
+                  <span>{CATEGORY_LABELS[c]}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <span style={dim}>Always redact these terms (names, addresses — one per line)</span>
+            <TextArea
+              value={customTermsText}
+              onChange={(e) => setCustomTermsText(e.target.value)}
+              placeholder={'Jane Doe\n123 Main St\nAcme Corp'}
+              rows={3}
+              style={{ width: '100%', fontSize: 13 }}
+            />
+          </label>
+        </section>
+
+        {/* ── Result ───────────────────────────────────────────────────── */}
+        <section style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', minWidth: 0 }}>
+          <Counts counts={result.report.counts} total={result.report.total} />
+
+          <div style={{ display: 'flex', gap: 8 }}>
+            <Button variant="primary" data-testid="anon-copy" onClick={copyOut} disabled={!input}>
+              <Icon name="copy" size={14} /> Copy redacted
+            </Button>
+            <Button variant="secondary" onClick={() => void saveOut()} disabled={!input}>
+              Save…
+            </Button>
+          </div>
+          {saved && <span style={dim}>Saved to {saved}</span>}
+
+          <div style={panelBox}>
+            <div style={{ ...dim, marginBottom: 6 }}>Redacted output</div>
+            <pre data-testid="anon-output" style={preBox}>
+              {result.text || (
+                <span style={{ color: 'var(--color-text-dim)' }}>
+                  The redacted text will appear here.
+                </span>
+              )}
+            </pre>
+          </div>
+
+          {result.report.total > 0 && (
+            <div style={panelBox}>
+              <div style={{ ...dim, marginBottom: 6 }}>Detected in source</div>
+              <SpanHighlight text={input} spans={result.report.spans} />
+            </div>
+          )}
+        </section>
+      </div>
+    </>
+  );
+}
+
+const dim: React.CSSProperties = { fontSize: 12, color: 'var(--color-text-dim)' };
+const toggleRow: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 7,
+  fontSize: 13,
+  cursor: 'pointer',
+};
+const panelBox: React.CSSProperties = {
+  border: '1px solid var(--color-border)',
+  background: 'var(--color-bg-card)',
+  borderRadius: 'var(--radius-block)',
+  padding: '0.7rem 0.85rem',
+};
+const preBox: React.CSSProperties = {
+  margin: 0,
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+  fontFamily: 'inherit',
+  fontSize: 13,
+  lineHeight: 1.5,
+  maxHeight: 360,
+  overflowY: 'auto',
+};

--- a/apps/desktop/src/apps/anonymizer/Counts.tsx
+++ b/apps/desktop/src/apps/anonymizer/Counts.tsx
@@ -1,0 +1,30 @@
+import type { PiiCategory, PiiCounts } from '@moxxy/anonymizer';
+import { CATEGORY_LABELS } from './labels';
+
+/** Per-category occurrence chips from a redaction report. */
+export function Counts({ counts, total }: { counts: PiiCounts; total: number }): JSX.Element {
+  const rows = (Object.keys(counts) as PiiCategory[]).filter((c) => counts[c] > 0);
+  if (total === 0) {
+    return <span style={{ fontSize: 13, color: 'var(--color-text-dim)' }}>Nothing detected.</span>;
+  }
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
+      <span style={{ fontSize: 13, fontWeight: 600 }}>{total} redacted:</span>
+      {rows.map((c) => (
+        <span
+          key={c}
+          style={{
+            fontSize: 12,
+            padding: '2px 8px',
+            borderRadius: 999,
+            background: 'var(--color-bg-card)',
+            border: '1px solid var(--color-border)',
+            color: 'var(--color-text-muted)',
+          }}
+        >
+          {CATEGORY_LABELS[c]} · {counts[c]}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/desktop/src/apps/anonymizer/SpanHighlight.tsx
+++ b/apps/desktop/src/apps/anonymizer/SpanHighlight.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from 'react';
+import type { PiiSpan } from '@moxxy/anonymizer';
+import { CATEGORY_LABELS } from './labels';
+
+/** Render `text` with detected spans highlighted in place. `spans` must be
+ *  sorted ascending and non-overlapping (as `detect`/`redact` return them). */
+export function SpanHighlight({
+  text,
+  spans,
+}: {
+  readonly text: string;
+  readonly spans: readonly PiiSpan[];
+}): JSX.Element {
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+  spans.forEach((s, i) => {
+    if (s.start > cursor) parts.push(text.slice(cursor, s.start));
+    parts.push(
+      <mark
+        key={i}
+        title={CATEGORY_LABELS[s.category]}
+        style={{
+          background: 'color-mix(in oklab, var(--color-primary) 22%, transparent)',
+          color: 'inherit',
+          borderRadius: 3,
+          padding: '0 1px',
+        }}
+      >
+        {text.slice(s.start, s.end)}
+      </mark>,
+    );
+    cursor = s.end;
+  });
+  if (cursor < text.length) parts.push(text.slice(cursor));
+
+  return (
+    <pre
+      style={{
+        margin: 0,
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+        fontFamily: 'inherit',
+        fontSize: 13,
+        lineHeight: 1.5,
+      }}
+    >
+      {parts}
+    </pre>
+  );
+}

--- a/apps/desktop/src/apps/anonymizer/labels.ts
+++ b/apps/desktop/src/apps/anonymizer/labels.ts
@@ -1,0 +1,36 @@
+import type { PiiCategory } from '@moxxy/anonymizer';
+
+/** Friendly labels for each detectable category (UI only). */
+export const CATEGORY_LABELS: Record<PiiCategory, string> = {
+  email: 'Emails',
+  phone: 'Phone numbers',
+  creditCard: 'Credit cards',
+  ssn: 'SSNs',
+  nationalId: 'National IDs',
+  ipv4: 'IPv4 addresses',
+  ipv6: 'IPv6 addresses',
+  mac: 'MAC addresses',
+  iban: 'IBANs',
+  url: 'URLs',
+  date: 'Dates',
+  person: 'Names',
+  org: 'Organizations',
+  location: 'Locations',
+  custom: 'Custom terms',
+};
+
+/** Built-in (regex) categories the user can toggle. `date` is included but
+ *  defaults off (high false-positive rate). NER categories (person/org/location)
+ *  are controlled by the separate "Detect names" toggle; `custom` by the terms box. */
+export const TOGGLE_CATEGORIES: readonly PiiCategory[] = [
+  'email',
+  'phone',
+  'creditCard',
+  'ssn',
+  'ipv4',
+  'ipv6',
+  'mac',
+  'iban',
+  'url',
+  'date',
+];

--- a/apps/desktop/src/apps/anonymizer/ner/aggregate.test.ts
+++ b/apps/desktop/src/apps/anonymizer/ner/aggregate.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { aggregate, type NerToken } from './aggregate';
+
+function tok(entity: string, word: string, index = 0): NerToken {
+  return { entity, word, index, score: 0.99 };
+}
+
+describe('aggregate', () => {
+  it('merges B-/I- tokens into one span with the right category + offsets', () => {
+    const text = 'Alice Smith met Bob';
+    const tokens: NerToken[] = [tok('B-PER', 'Alice'), tok('I-PER', 'Smith')];
+    const spans = aggregate(tokens, text);
+    expect(spans).toEqual([{ category: 'person', start: 0, end: 11, value: 'Alice Smith' }]);
+  });
+
+  it('joins WordPiece ## sub-words and recovers the offset', () => {
+    const text = 'Microsoft ships it';
+    const tokens: NerToken[] = [tok('B-ORG', 'Micro'), tok('I-ORG', '##soft')];
+    const spans = aggregate(tokens, text);
+    expect(spans).toEqual([{ category: 'org', start: 0, end: 9, value: 'Microsoft' }]);
+  });
+
+  it('maps LOC → location and ignores MISC/other types', () => {
+    const text = 'Berlin is nice, said misc';
+    const tokens: NerToken[] = [tok('B-LOC', 'Berlin'), tok('B-MISC', 'misc')];
+    const spans = aggregate(tokens, text);
+    expect(spans.map((s) => [s.category, s.value])).toEqual([['location', 'Berlin']]);
+  });
+
+  it('maps repeated surfaces to successive occurrences via the cursor', () => {
+    const text = 'Bob and Bob';
+    const tokens: NerToken[] = [tok('B-PER', 'Bob'), tok('B-PER', 'Bob')];
+    const spans = aggregate(tokens, text);
+    expect(spans.map((s) => s.start)).toEqual([0, 8]);
+  });
+});

--- a/apps/desktop/src/apps/anonymizer/ner/aggregate.ts
+++ b/apps/desktop/src/apps/anonymizer/ner/aggregate.ts
@@ -1,0 +1,98 @@
+import type { PiiCategory, PiiSpan } from '@moxxy/anonymizer';
+
+/** One per-token classification result from transformers.js (BIO-tagged). */
+export interface NerToken {
+  readonly entity: string; // e.g. 'B-PER', 'I-LOC'
+  readonly word: string; // decoded sub-word (may carry a '##' WordPiece prefix)
+  readonly index: number;
+  readonly score: number;
+}
+
+const TYPE_TO_CATEGORY: Readonly<Record<string, PiiCategory | undefined>> = {
+  PER: 'person',
+  PERSON: 'person',
+  ORG: 'org',
+  LOC: 'location',
+};
+
+function parseLabel(entity: string): { bio: string; type: string } {
+  const m = /^([BILUES])-(.+)$/.exec(entity);
+  if (m) return { bio: m[1]!, type: m[2]! };
+  return { bio: 'B', type: entity };
+}
+
+/** Reconstruct an entity's surface string from its WordPiece tokens. */
+function surfaceOf(words: readonly string[]): string {
+  let s = '';
+  for (const w of words) {
+    if (w.startsWith('##')) s += w.slice(2);
+    else s += (s ? ' ' : '') + w;
+  }
+  return s.trim();
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Find an entity's char range in the original text, advancing a cursor so
+ *  repeated surfaces map to successive occurrences. Tolerant of case and
+ *  whitespace differences the tokenizer introduces. */
+function locate(
+  text: string,
+  surface: string,
+  from: number,
+): { start: number; end: number } | null {
+  let idx = text.indexOf(surface, from);
+  if (idx >= 0) return { start: idx, end: idx + surface.length };
+  idx = text.toLowerCase().indexOf(surface.toLowerCase(), from);
+  if (idx >= 0) return { start: idx, end: idx + surface.length };
+  const parts = surface.split(/\s+/).filter(Boolean).map(escapeRegExp);
+  if (parts.length > 1) {
+    const re = new RegExp(parts.join('\\s+'), 'i');
+    const m = re.exec(text.slice(from));
+    if (m && m.index != null) return { start: from + m.index, end: from + m.index + m[0].length };
+  }
+  return null;
+}
+
+/**
+ * Aggregate per-token BIO labels into entity spans with character offsets.
+ *
+ * transformers.js' token-classification pipeline returns per-token labels with
+ * NO character offsets and does not merge sub-words, so we group consecutive
+ * `B-`/`I-` tokens of the same type, rebuild each surface, and recover its
+ * offset by searching the original text. Only `person`/`org`/`location` are
+ * kept (MISC and any other type are dropped).
+ */
+export function aggregate(tokens: readonly NerToken[], text: string): PiiSpan[] {
+  const groups: Array<{ type: string; words: string[] }> = [];
+  let cur: { type: string; words: string[] } | null = null;
+  for (const tok of tokens) {
+    const { bio, type } = parseLabel(tok.entity);
+    if (!TYPE_TO_CATEGORY[type]) {
+      cur = null;
+      continue;
+    }
+    if (bio === 'B' || !cur || cur.type !== type) {
+      cur = { type, words: [tok.word] };
+      groups.push(cur);
+    } else {
+      cur.words.push(tok.word);
+    }
+  }
+
+  const spans: PiiSpan[] = [];
+  let cursor = 0;
+  for (const g of groups) {
+    const category = TYPE_TO_CATEGORY[g.type];
+    if (!category) continue;
+    const surface = surfaceOf(g.words);
+    if (!surface) continue;
+    const at = locate(text, surface, cursor);
+    if (!at) continue;
+    spans.push({ category, start: at.start, end: at.end, value: text.slice(at.start, at.end) });
+    cursor = at.end;
+  }
+  return spans;
+}

--- a/apps/desktop/src/apps/anonymizer/ner/ner.worker.ts
+++ b/apps/desktop/src/apps/anonymizer/ner/ner.worker.ts
@@ -1,0 +1,72 @@
+/**
+ * On-device NER worker. Runs transformers.js (`Xenova/bert-base-NER`) on the
+ * onnxruntime-web WASM backend, entirely offline.
+ *
+ * Offline enforcement (defense in depth atop the renderer CSP):
+ *   - `remoteHost` points transformers.js at the local `moxxy-app://` scheme, so
+ *     the model is loaded from the install dir — a huggingface.co request can
+ *     never leave this worker (and CSP `connect-src` excludes all real network).
+ *   - The onnxruntime-web wasm runtime is bundled into the app by Vite (from
+ *     `@huggingface/transformers`) and loads from `'self'`, so no `wasmPaths`
+ *     override is needed; we only force single-threaded + no proxy worker.
+ * The heavy work is here so the UI thread never blocks while a ~109 MB model
+ * loads and runs.
+ */
+import { env, pipeline } from '@huggingface/transformers';
+
+const ctx = self as unknown as {
+  postMessage: (message: unknown) => void;
+  onmessage: ((e: MessageEvent) => void) | null;
+};
+
+// Load the model from the locally installed copy under our custom scheme.
+// `pathJoin` only trims boundary slashes, so the `://` in remoteHost survives:
+// final URL = moxxy-app://assets/anonymizer/<model>/resolve/<rev>/<file>, which
+// the asset protocol serves from `userData/moxxy-apps/anonymizer/...`.
+env.allowLocalModels = false;
+env.allowRemoteModels = true;
+env.useBrowserCache = false;
+env.remoteHost = 'moxxy-app://assets/anonymizer/';
+env.remotePathTemplate = '{model}/resolve/{revision}/';
+
+// onnxruntime-web: the wasm runtime is bundled by Vite (loads from 'self'), so
+// no wasmPaths override. Force single-threaded (no SharedArrayBuffer / COOP-COEP)
+// and no proxy worker so nothing tries to re-fetch a loader at runtime.
+const wasmBackend = env.backends?.onnx?.wasm;
+if (wasmBackend) {
+  wasmBackend.numThreads = 1;
+  wasmBackend.proxy = false;
+}
+
+const MODEL_ID = 'Xenova/bert-base-NER';
+type NerFn = (
+  text: string,
+) => Promise<Array<{ entity: string; word: string; index: number; score: number }>>;
+let nerPromise: Promise<NerFn> | null = null;
+
+function getNer(): Promise<NerFn> {
+  if (!nerPromise) {
+    nerPromise = pipeline('token-classification', MODEL_ID, {
+      progress_callback: (progress: unknown) => ctx.postMessage({ type: 'progress', progress }),
+    }) as unknown as Promise<NerFn>;
+  }
+  return nerPromise;
+}
+
+ctx.onmessage = (e: MessageEvent): void => {
+  const msg = e.data as { type?: string; id?: number; text?: string };
+  if (msg?.type !== 'infer' || typeof msg.text !== 'string') return;
+  void (async () => {
+    try {
+      const ner = await getNer();
+      const tokens = await ner(msg.text!);
+      ctx.postMessage({ type: 'result', id: msg.id, tokens });
+    } catch (err) {
+      ctx.postMessage({
+        type: 'error',
+        id: msg.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  })();
+};

--- a/apps/desktop/src/apps/anonymizer/ner/useNer.ts
+++ b/apps/desktop/src/apps/anonymizer/ner/useNer.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { PiiSpan } from '@moxxy/anonymizer';
+import { aggregate, type NerToken } from './aggregate';
+
+export type NerStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface UseNer {
+  readonly status: NerStatus;
+  readonly error: string | null;
+  /** Run on-device NER over `text` and return `person`/`org`/`location` spans.
+   *  Resolves to `[]` (never throws) if the model/runtime fails — the caller's
+   *  structured redaction keeps working. */
+  readonly detectNames: (text: string) => Promise<readonly PiiSpan[]>;
+}
+
+type WorkerReply = { type: string; id?: number; tokens?: NerToken[]; error?: string };
+
+/**
+ * Lazily spins up the NER worker (which loads the installed on-device model on
+ * first use) and exposes a promise-based `detectNames`. The model is large, so
+ * the first call shows `loading`; after that the worker is warm.
+ */
+export function useNer(): UseNer {
+  const workerRef = useRef<Worker | null>(null);
+  const pending = useRef(
+    new Map<number, { resolve: (t: NerToken[]) => void; reject: (e: Error) => void }>(),
+  );
+  const reqId = useRef(0);
+  const [status, setStatus] = useState<NerStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const worker = new Worker(new URL('./ner.worker.ts', import.meta.url), { type: 'module' });
+    worker.onmessage = (e: MessageEvent): void => {
+      const msg = e.data as WorkerReply;
+      if (msg.type === 'progress') {
+        setStatus((s) => (s === 'ready' ? s : 'loading'));
+        return;
+      }
+      if (msg.id == null) return;
+      const entry = pending.current.get(msg.id);
+      if (!entry) return;
+      pending.current.delete(msg.id);
+      if (msg.type === 'result') entry.resolve(msg.tokens ?? []);
+      else if (msg.type === 'error') entry.reject(new Error(msg.error ?? 'NER failed'));
+    };
+    worker.onerror = (e: ErrorEvent): void => {
+      setStatus('error');
+      setError(e.message || 'The name-detection model failed to load.');
+    };
+    workerRef.current = worker;
+    return () => {
+      worker.terminate();
+      workerRef.current = null;
+      pending.current.clear();
+    };
+  }, []);
+
+  const detectNames = useCallback(async (text: string): Promise<readonly PiiSpan[]> => {
+    const worker = workerRef.current;
+    if (!worker || !text.trim()) return [];
+    setStatus((s) => (s === 'ready' ? s : 'loading'));
+    const id = ++reqId.current;
+    try {
+      const tokens = await new Promise<NerToken[]>((resolve, reject) => {
+        pending.current.set(id, { resolve, reject });
+        worker.postMessage({ type: 'infer', id, text });
+      });
+      setStatus('ready');
+      setError(null);
+      return aggregate(tokens, text);
+    } catch (e) {
+      setStatus('error');
+      setError(e instanceof Error ? e.message : String(e));
+      return [];
+    }
+  }, []);
+
+  return { status, error, detectNames };
+}

--- a/apps/desktop/src/apps/builtins.ts
+++ b/apps/desktop/src/apps/builtins.ts
@@ -1,0 +1,20 @@
+/**
+ * First-party desktop apps. Imported once for side-effect registration (the way
+ * the core plugin builtins self-register). Add a new app here — navigation and
+ * the gallery pick it up automatically.
+ */
+import { registerDesktopApp } from './registry';
+import { AnonymizerApp } from './anonymizer/AnonymizerApp';
+
+registerDesktopApp({
+  id: 'anonymizer',
+  name: 'Document anonymizer',
+  description:
+    'Detect and redact personal data in documents — runs entirely on your machine. Nothing is uploaded.',
+  icon: 'lock',
+  offline: true,
+  requiresInstall: true,
+  installSummary:
+    'Downloads a ~110 MB on-device model for detecting names. After install it runs fully offline.',
+  Component: AnonymizerApp,
+});

--- a/apps/desktop/src/apps/registry.ts
+++ b/apps/desktop/src/apps/registry.ts
@@ -1,0 +1,48 @@
+import type { ComponentType } from 'react';
+import type { IconName } from '@moxxy/desktop-ui';
+
+export interface DesktopAppProps {
+  /** Return to the Apps gallery. */
+  readonly onExit: () => void;
+}
+
+/**
+ * A desktop "app" — a self-contained mini-application shown in the Apps gallery.
+ *
+ * Registry-backed (mirrors the core swappable-block registries) so a new app is
+ * one `registerDesktopApp` call and never touches navigation. Apps that need
+ * local assets before use set `requiresInstall` + `installSummary`; the gallery
+ * drives their `apps.status` / `apps.install` lifecycle (the main process owns
+ * the actual download — see `@moxxy/desktop-host`).
+ */
+export interface DesktopAppDef {
+  /** Stable slug — the sub-route key AND the install/asset id shared with main
+   *  (`userData/moxxy-apps/<id>`). Must match `/^[a-z][a-z0-9-]*$/`. */
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly icon: IconName;
+  /** Show the "Offline · on-device" badge on the card + in the app header. */
+  readonly offline?: boolean;
+  /** The app must be installed (assets downloaded) before it can be opened. */
+  readonly requiresInstall?: boolean;
+  /** One line describing what Install downloads (size, what it's for). */
+  readonly installSummary?: string;
+  /** Full-pane component, rendered inside `<main className="col-main col-main--flat">`. */
+  readonly Component: ComponentType<DesktopAppProps>;
+}
+
+const registry = new Map<string, DesktopAppDef>();
+
+export function registerDesktopApp(def: DesktopAppDef): void {
+  if (registry.has(def.id)) throw new Error(`duplicate desktop app: ${def.id}`);
+  registry.set(def.id, def);
+}
+
+export function listDesktopApps(): readonly DesktopAppDef[] {
+  return [...registry.values()];
+}
+
+export function getDesktopApp(id: string): DesktopAppDef | undefined {
+  return registry.get(id);
+}

--- a/apps/desktop/src/shell/ViewHeader.tsx
+++ b/apps/desktop/src/shell/ViewHeader.tsx
@@ -2,9 +2,9 @@ import type { ReactNode } from 'react';
 import { PanelLeftIcon } from './PanelLeftIcon';
 import { setSidebarCollapsed, useSidebarCollapsed } from '@/lib/useSidebarCollapsed';
 
-/** Top-level main-content views. Chat ↔ Workflows switch via the header's
- *  `ViewSwitcher`; Settings is reached from the sidebar. */
-export type View = 'chat' | 'workflows' | 'collaborate' | 'settings';
+/** Top-level main-content views. Chat ↔ Workflows ↔ Collaborate ↔ Apps switch
+ *  via the header's `ViewSwitcher`; Settings is reached from the sidebar. */
+export type View = 'chat' | 'workflows' | 'collaborate' | 'settings' | 'apps';
 
 /**
  * Shared section header — one 64px chrome bar so Chat / Workflows /
@@ -114,13 +114,17 @@ export function Segmented<T extends string>({
   );
 }
 
-const SWITCH_ITEMS: ReadonlyArray<{ readonly id: 'chat' | 'workflows' | 'collaborate'; readonly label: string }> = [
+const SWITCH_ITEMS: ReadonlyArray<{
+  readonly id: 'chat' | 'workflows' | 'collaborate' | 'apps';
+  readonly label: string;
+}> = [
   { id: 'chat', label: 'Chat' },
   { id: 'workflows', label: 'Workflows' },
   { id: 'collaborate', label: 'Collaborate' },
+  { id: 'apps', label: 'Apps' },
 ];
 
-/** Chat ↔ Workflows segmented switcher — the leading element of every
+/** Chat ↔ Workflows ↔ Apps segmented switcher — the leading element of every
  *  unified header, standing in for a per-view title. */
 export function ViewSwitcher({
   view,

--- a/packages/anonymizer/README.md
+++ b/packages/anonymizer/README.md
@@ -1,0 +1,53 @@
+# @moxxy/anonymizer
+
+A pure, **dependency-free, network-free** PII detection + redaction engine.
+
+```ts
+import { redact } from '@moxxy/anonymizer';
+
+const { text, report } = redact('Call me at john@acme.com or +1 (415) 555-2671');
+// text   → 'Call me at [EMAIL] or [PHONE]'
+// report → { counts: { email: 1, phone: 1, ... }, total: 2, spans: [...] }
+```
+
+## Why it has zero dependencies
+
+This package is imported into the desktop app's **renderer**, where CSP
+`connect-src 'self'` blocks all network egress. The engine's only inputs are
+strings and options — it never imports a network or filesystem API. That
+emptiness is the load-bearing offline guarantee and is enforced by
+`offline.test.ts` (asserts `dependencies` is `{}` and the source references no
+`fetch` / `XMLHttpRequest` / `node:http` / etc.). **Keep `dependencies` empty.**
+
+## What it detects
+
+High-precision, validator-backed detectors (correctness over recall):
+
+| Category | Validation |
+| --- | --- |
+| `email`, `url` | shape + TLD |
+| `creditCard` | Luhn |
+| `iban` | mod-97 |
+| `ipv4` | octet ≤ 255 |
+| `ipv6` | group structure (a MAC is not an IPv6) |
+| `mac` | 6 hex groups |
+| `ssn` | US area/group/serial sanity |
+| `phone` | 7–15 digits, requires grouping, rejects date shapes |
+| `date` | opt-in (high false-positive rate) |
+
+`custom` matches literal user-supplied terms (names, addresses) case-insensitively
+on word boundaries.
+
+## Names, orgs, locations (NER)
+
+The engine does **not** do named-entity recognition — that needs a model. The
+desktop app runs an on-device NER model and feeds its results in via
+`detect(text, { extraSpans })` / `redact(text, { extraSpans })`, where each span
+is `{ category: 'person' | 'org' | 'location', start, end, value }`. They merge
+through the same overlap-resolution pass as the built-in detectors.
+
+## Redaction modes
+
+- `label` (default) — `[EMAIL]`
+- `pseudonym` — `EMAIL_1` (same value → same token, numbered in document order)
+- `hash` — `[EMAIL:a1b2c3d4]` (stable, compact; obfuscation, not cryptography)

--- a/packages/anonymizer/package.json
+++ b/packages/anonymizer/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@moxxy/anonymizer",
+  "private": true,
+  "version": "0.0.0",
+  "description": "A pure, dependency-free, network-free PII detection + redaction engine. Detects structured PII (email, phone, credit card, SSN, IP, MAC, IBAN, URL, date) with high-precision validators and redacts it with labeled / pseudonym / hash modes. Has ZERO runtime dependencies and touches no network API — that emptiness is the load-bearing offline guarantee (enforced by offline.test.ts), so it bundles cleanly into the desktop renderer.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/anonymizer/src/detect.test.ts
+++ b/packages/anonymizer/src/detect.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { detect } from './detect.js';
+
+describe('detect', () => {
+  it('returns non-overlapping spans in document order', () => {
+    const text = 'mail a@b.com ip 10.0.0.1';
+    const spans = detect(text);
+    expect(spans.map((s) => [s.category, s.value])).toEqual([
+      ['email', 'a@b.com'],
+      ['ipv4', '10.0.0.1'],
+    ]);
+    // ascending, non-overlapping
+    for (let i = 1; i < spans.length; i++) {
+      expect(spans[i]!.start).toBeGreaterThanOrEqual(spans[i - 1]!.end);
+    }
+  });
+
+  it('keeps the higher-priority category when two detectors overlap', () => {
+    // A Luhn-valid 16-digit card whose digits a phone pattern could also grab.
+    const text = 'pay 4111-1111-1111-1111 now';
+    const spans = detect(text, { categories: ['creditCard', 'phone'] });
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.category).toBe('creditCard');
+  });
+
+  it('offsets slice back to the matched value', () => {
+    const text = 'contact John.Doe@example.com here';
+    const [span] = detect(text);
+    expect(text.slice(span!.start, span!.end)).toBe(span!.value);
+  });
+
+  it('merges extraSpans (e.g. NER) through overlap resolution', () => {
+    const text = 'Alice Smith wrote a@b.com';
+    const spans = detect(text, {
+      extraSpans: [{ category: 'person', start: 0, end: 11, value: 'Alice Smith' }],
+    });
+    expect(spans.map((s) => s.category)).toEqual(['person', 'email']);
+  });
+
+  it('runs custom terms regardless of categories', () => {
+    const spans = detect('secret-project launch', { categories: [], customTerms: ['secret-project'] });
+    expect(spans.map((s) => s.value)).toEqual(['secret-project']);
+  });
+});

--- a/packages/anonymizer/src/detect.ts
+++ b/packages/anonymizer/src/detect.ts
@@ -1,0 +1,70 @@
+/**
+ * Detection orchestration: run the enabled detectors, fold in custom-term and
+ * external (NER) spans, then resolve overlaps so each character is claimed by at
+ * most one category — the highest-priority one.
+ */
+
+import { DETECTORS, detectCustom } from './detectors.js';
+import type { DetectOptions, PiiCategory, PiiSpan } from './types.js';
+import { STRUCTURED_CATEGORIES } from './types.js';
+
+/**
+ * Overlap-resolution priority. A 16-digit Luhn-valid card overlaps a phone
+ * pattern; keeping the higher-priority category stops it being mis-tagged.
+ * Structured + validated categories outrank looser ones (phone, date).
+ */
+const PRIORITY: Record<PiiCategory, number> = {
+  creditCard: 100,
+  iban: 95,
+  ssn: 90,
+  email: 80,
+  url: 70,
+  ipv6: 66,
+  ipv4: 64,
+  mac: 60,
+  person: 55,
+  org: 50,
+  location: 48,
+  nationalId: 45,
+  custom: 40,
+  phone: 30,
+  date: 10,
+};
+
+/**
+ * Detect PII in `text`. Returns non-overlapping spans in document order.
+ *
+ * `customTerms` always run when provided (independent of `categories`).
+ * `extraSpans` (e.g. on-device NER) are merged through the same overlap pass.
+ */
+export function detect(text: string, opts: DetectOptions = {}): PiiSpan[] {
+  const categories = new Set(opts.categories ?? STRUCTURED_CATEGORIES);
+  const raw: PiiSpan[] = [];
+
+  for (const cat of categories) {
+    const fn = DETECTORS[cat];
+    if (fn) raw.push(...fn(text));
+  }
+  if (opts.customTerms?.length) raw.push(...detectCustom(text, opts.customTerms));
+  if (opts.extraSpans?.length) raw.push(...opts.extraSpans);
+
+  return resolveOverlaps(raw);
+}
+
+/** Greedy interval selection by priority: keep the strongest span, drop anything
+ *  overlapping it. Exact-duplicate spans collapse to one. */
+function resolveOverlaps(spans: readonly PiiSpan[]): PiiSpan[] {
+  const valid = spans.filter((s) => s.end > s.start);
+  const ordered = [...valid].sort(
+    (a, b) =>
+      PRIORITY[b.category] - PRIORITY[a.category] ||
+      b.end - b.start - (a.end - a.start) ||
+      a.start - b.start,
+  );
+  const kept: PiiSpan[] = [];
+  for (const span of ordered) {
+    const overlaps = kept.some((k) => span.start < k.end && k.start < span.end);
+    if (!overlaps) kept.push(span);
+  }
+  return kept.sort((a, b) => a.start - b.start);
+}

--- a/packages/anonymizer/src/detectors.test.ts
+++ b/packages/anonymizer/src/detectors.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { DETECTORS, detectCustom, _internals } from './detectors.js';
+import type { PiiCategory } from './types.js';
+
+function values(category: PiiCategory, text: string): string[] {
+  const fn = DETECTORS[category];
+  if (!fn) throw new Error(`no detector for ${category}`);
+  return fn(text).map((s) => s.value);
+}
+
+describe('email', () => {
+  it('matches addresses with a TLD', () => {
+    expect(values('email', 'reach me at John.Doe+tag@sub.example.co.uk please')).toEqual([
+      'John.Doe+tag@sub.example.co.uk',
+    ]);
+  });
+  it('ignores a bare @ handle with no domain', () => {
+    expect(values('email', 'ping @johnny on chat')).toEqual([]);
+  });
+});
+
+describe('credit card (Luhn)', () => {
+  it('accepts a Luhn-valid number with spaces', () => {
+    expect(values('creditCard', 'card 4111 1111 1111 1111 ok')).toEqual(['4111 1111 1111 1111']);
+  });
+  it('rejects a non-Luhn number', () => {
+    expect(values('creditCard', 'order 4111 1111 1111 1112')).toEqual([]);
+  });
+  it('luhnValid math', () => {
+    expect(_internals.luhnValid('4111111111111111')).toBe(true);
+    expect(_internals.luhnValid('4111111111111112')).toBe(false);
+  });
+});
+
+describe('ssn', () => {
+  it('accepts a sane hyphenated SSN', () => {
+    expect(values('ssn', 'SSN 123-45-6789.')).toEqual(['123-45-6789']);
+  });
+  it('rejects invalid area/group/serial', () => {
+    expect(values('ssn', '000-45-6789 666-45-6789 900-45-6789 123-00-6789 123-45-0000')).toEqual(
+      [],
+    );
+  });
+});
+
+describe('ipv4', () => {
+  it('accepts in-range octets', () => {
+    expect(values('ipv4', 'host 192.168.1.255')).toEqual(['192.168.1.255']);
+  });
+  it('rejects an out-of-range octet', () => {
+    expect(values('ipv4', 'bad 999.1.1.1')).toEqual([]);
+  });
+});
+
+describe('ipv6', () => {
+  it('accepts full and compressed forms', () => {
+    expect(values('ipv6', 'a 2001:0db8:85a3:0000:0000:8a2e:0370:7334 b fe80::1 c')).toEqual([
+      '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+      'fe80::1',
+    ]);
+  });
+  it('does not treat a MAC as IPv6', () => {
+    expect(values('ipv6', '01:23:45:67:89:ab')).toEqual([]);
+  });
+});
+
+describe('mac', () => {
+  it('matches colon and dash separated MACs', () => {
+    expect(values('mac', 'nic 01:23:45:67:89:AB and 01-23-45-67-89-ab')).toEqual([
+      '01:23:45:67:89:AB',
+      '01-23-45-67-89-ab',
+    ]);
+  });
+});
+
+describe('iban (mod-97)', () => {
+  it('accepts a valid IBAN', () => {
+    expect(values('iban', 'pay GB82WEST12345698765432 now')).toEqual(['GB82WEST12345698765432']);
+  });
+  it('rejects a bad check digit', () => {
+    expect(values('iban', 'pay GB82WEST12345698765433 now')).toEqual([]);
+  });
+});
+
+describe('phone', () => {
+  it('matches grouped numbers, rejects bare digit runs and dates', () => {
+    expect(values('phone', 'call +1 (415) 555-2671 today')).toEqual(['+1 (415) 555-2671']);
+    expect(values('phone', 'ref 1234567890123456')).toEqual([]); // bare run, no separators
+    expect(_internals.isPhone('2020-01-02')).toBe(false);
+  });
+});
+
+describe('custom terms', () => {
+  it('matches case-insensitively on word boundaries, including multi-word', () => {
+    // Raw (unresolved): 'Jane' also matches inside 'JANE DOE'; dedup is detect()'s job.
+    const spans = detectCustom('Jane and JANE DOE met Janet', ['jane doe', 'Jane']);
+    expect(spans.map((s) => s.value).sort()).toEqual(['JANE', 'JANE DOE', 'Jane']);
+  });
+});

--- a/packages/anonymizer/src/detectors.ts
+++ b/packages/anonymizer/src/detectors.ts
@@ -1,0 +1,168 @@
+/**
+ * High-precision, validator-backed detectors — one per structured PII category.
+ *
+ * Each detector returns the spans it finds; correctness over recall is the
+ * priority, so every category that can be cheaply validated is (Luhn for cards,
+ * mod-97 for IBANs, octet range for IPv4, area/group sanity for SSNs). This
+ * keeps false positives low without any model or network call.
+ */
+
+import type { PiiCategory, PiiSpan } from './types.js';
+
+/** Run a global regex over `text`, optionally filtering matches with `accept`. */
+function scan(
+  text: string,
+  re: RegExp,
+  category: PiiCategory,
+  accept?: (match: string) => boolean,
+): PiiSpan[] {
+  const out: PiiSpan[] = [];
+  for (const m of text.matchAll(re)) {
+    const value = m[0] ?? '';
+    const start = m.index ?? -1;
+    if (!value || start < 0) continue;
+    if (accept && !accept(value)) continue;
+    out.push({ category, start, end: start + value.length, value });
+  }
+  return out;
+}
+
+// ── email ──────────────────────────────────────────────────────────────────
+const EMAIL_RE = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,24}\b/g;
+
+// ── url ────────────────────────────────────────────────────────────────────
+// Stop at whitespace and trailing sentence punctuation/brackets.
+const URL_RE = /\bhttps?:\/\/[^\s<>"')\]}]+/g;
+
+// ── ipv4 ───────────────────────────────────────────────────────────────────
+const IPV4_RE = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
+function isIpv4(m: string): boolean {
+  const parts = m.split('.');
+  if (parts.length !== 4) return false;
+  return parts.every((p) => p.length <= 3 && Number(p) <= 255);
+}
+
+// ── ipv6 ───────────────────────────────────────────────────────────────────
+// Broad candidate (≥3 colon-separated hex groups), then a strict validator.
+const IPV6_RE = /[0-9A-Fa-f]{0,4}(?::[0-9A-Fa-f]{0,4}){2,7}/g;
+function isIpv6(m: string): boolean {
+  if (!/^[0-9A-Fa-f:]+$/.test(m)) return false;
+  if ((m.match(/::/g) ?? []).length > 1) return false; // at most one '::'
+  if (/:::/.test(m)) return false;
+  const hasDouble = m.includes('::');
+  const groups = m.split(':').filter((g) => g.length > 0);
+  if (groups.some((g) => !/^[0-9A-Fa-f]{1,4}$/.test(g))) return false;
+  // Without compression an address needs exactly 8 groups; with '::' it needs
+  // fewer (so a 6-group MAC like 01:23:45:67:89:ab is NOT a valid IPv6).
+  return hasDouble ? groups.length >= 1 && groups.length <= 7 : groups.length === 8;
+}
+
+// ── mac ────────────────────────────────────────────────────────────────────
+const MAC_RE = /\b[0-9A-Fa-f]{2}(?:[:-][0-9A-Fa-f]{2}){5}\b/g;
+
+// ── credit card ────────────────────────────────────────────────────────────
+const CC_RE = /\b\d(?:[ -]?\d){12,18}\b/g;
+function luhnValid(digits: string): boolean {
+  let sum = 0;
+  let alt = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = digits.charCodeAt(i) - 48;
+    if (d < 0 || d > 9) return false;
+    if (alt) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+    sum += d;
+    alt = !alt;
+  }
+  return sum % 10 === 0;
+}
+function isCreditCard(m: string): boolean {
+  const digits = m.replace(/[^0-9]/g, '');
+  return digits.length >= 13 && digits.length <= 19 && luhnValid(digits);
+}
+
+// ── ssn (US) ───────────────────────────────────────────────────────────────
+// Hyphenated form only — a bare 9-digit run is too ambiguous to claim.
+const SSN_RE = /\b(\d{3})-(\d{2})-(\d{4})\b/g;
+function isSsn(m: string): boolean {
+  const [area, group, serial] = m.split('-');
+  if (!area || !group || !serial) return false;
+  if (area === '000' || area === '666' || Number(area) >= 900) return false;
+  if (group === '00') return false;
+  if (serial === '0000') return false;
+  return true;
+}
+
+// ── iban ───────────────────────────────────────────────────────────────────
+// Compact or single-space-grouped; validated by mod-97.
+const IBAN_RE = /\b[A-Z]{2}\d{2}(?:[ ]?[A-Z0-9]){11,30}\b/g;
+function ibanValid(raw: string): boolean {
+  const s = raw.replace(/\s+/g, '').toUpperCase();
+  if (s.length < 15 || s.length > 34) return false;
+  if (!/^[A-Z]{2}\d{2}[A-Z0-9]+$/.test(s)) return false;
+  const rearranged = s.slice(4) + s.slice(0, 4);
+  let remainder = 0;
+  for (const ch of rearranged) {
+    const code = ch.charCodeAt(0);
+    const val = code >= 65 ? code - 55 : code - 48; // A-Z → 10..35, 0-9 → 0..9
+    remainder = (remainder * (val > 9 ? 100 : 10) + val) % 97;
+  }
+  return remainder === 1;
+}
+
+// ── phone ──────────────────────────────────────────────────────────────────
+// Requires separators between digit groups (so a bare ID number isn't a phone),
+// then validates 7–15 digits and rejects date-shaped matches.
+const PHONE_RE =
+  /(?<![\w.])(?:\+\d{1,3}[ .-]?)?(?:\(\d{1,4}\)[ .-]?)?\d{2,4}(?:[ .-]\d{2,4}){1,5}(?![\w])/g;
+function isPhone(m: string): boolean {
+  if (/^\d{4}[-/.]\d{1,2}[-/.]\d{1,2}$/.test(m)) return false; // ISO-ish date
+  if (/^\d{1,2}[-/.]\d{1,2}[-/.]\d{2,4}$/.test(m)) return false; // D/M/Y date
+  const digits = m.replace(/[^0-9]/g, '');
+  return digits.length >= 7 && digits.length <= 15;
+}
+
+// ── date (opt-in; high false-positive rate) ──────────────────────────────────
+const DATE_RE =
+  /\b(?:\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}\/\d{2,4}|(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+\d{4})\b/gi;
+
+/** Built-in detectors keyed by category. Categories absent here (`person`,
+ *  `org`, `location`, `nationalId`) have no regex detector and only appear via
+ *  `extraSpans`. */
+export const DETECTORS: Partial<Record<PiiCategory, (text: string) => PiiSpan[]>> = {
+  email: (t) => scan(t, EMAIL_RE, 'email'),
+  url: (t) => scan(t, URL_RE, 'url'),
+  ipv4: (t) => scan(t, IPV4_RE, 'ipv4', isIpv4),
+  ipv6: (t) => scan(t, IPV6_RE, 'ipv6', isIpv6),
+  mac: (t) => scan(t, MAC_RE, 'mac'),
+  creditCard: (t) => scan(t, CC_RE, 'creditCard', isCreditCard),
+  ssn: (t) => scan(t, SSN_RE, 'ssn', isSsn),
+  iban: (t) => scan(t, IBAN_RE, 'iban', ibanValid),
+  phone: (t) => scan(t, PHONE_RE, 'phone', isPhone),
+  date: (t) => scan(t, DATE_RE, 'date'),
+};
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Literal, case-insensitive, word-boundary matches of user-supplied terms. */
+export function detectCustom(text: string, terms: readonly string[]): PiiSpan[] {
+  const spans: PiiSpan[] = [];
+  for (const term of terms) {
+    const t = term.trim();
+    if (!t) continue;
+    const re = new RegExp(`(?<!\\w)${escapeRegExp(t)}(?!\\w)`, 'gi');
+    for (const m of text.matchAll(re)) {
+      const value = m[0] ?? '';
+      const start = m.index ?? -1;
+      if (!value || start < 0) continue;
+      spans.push({ category: 'custom', start, end: start + value.length, value });
+    }
+  }
+  return spans;
+}
+
+// Exposed for unit tests.
+export const _internals = { luhnValid, ibanValid, isIpv4, isIpv6, isSsn, isPhone };

--- a/packages/anonymizer/src/hash.ts
+++ b/packages/anonymizer/src/hash.ts
@@ -1,0 +1,18 @@
+/**
+ * A tiny, pure-JS, non-cryptographic hash (FNV-1a, 32-bit) used only to make
+ * `hash`-mode redaction tokens stable per value (`john@x.com` → `a1b2c3d4`).
+ *
+ * Deliberately NOT `node:crypto`: keeping zero Node-builtin coupling is what
+ * lets this package bundle into the browser renderer untouched. This is
+ * obfuscation for readability, NOT a security primitive — do not rely on it to
+ * make a value irreversible.
+ */
+export function shortHash(input: string, salt = ''): string {
+  const str = salt + input;
+  let h = 0x811c9dc5; // FNV offset basis
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193); // FNV prime, 32-bit via Math.imul
+  }
+  return (h >>> 0).toString(36).padStart(8, '0').slice(0, 8);
+}

--- a/packages/anonymizer/src/index.ts
+++ b/packages/anonymizer/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @moxxy/anonymizer — pure, dependency-free, network-free PII detection + redaction.
+ *
+ * The engine never touches the network or the filesystem; its only inputs are
+ * strings and options. That is the load-bearing offline guarantee (asserted by
+ * `offline.test.ts`) and is what lets it run inside the locked-down desktop
+ * renderer, where CSP `connect-src 'self'` already blocks all egress.
+ */
+
+export { detect } from './detect.js';
+export { redact } from './redact.js';
+export { shortHash } from './hash.js';
+export { ALL_CATEGORIES, STRUCTURED_CATEGORIES } from './types.js';
+export type {
+  PiiCategory,
+  PiiSpan,
+  RedactionMode,
+  DetectOptions,
+  RedactOptions,
+  PiiCounts,
+  RedactionReport,
+  RedactResult,
+} from './types.js';

--- a/packages/anonymizer/src/offline.test.ts
+++ b/packages/anonymizer/src/offline.test.ts
@@ -1,0 +1,44 @@
+/**
+ * The offline guarantee, codified. If this fails, the engine has grown a way to
+ * reach the network (a dependency or a network API) and is no longer provably
+ * offline — so the desktop's "documents never leave your machine" claim breaks.
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkgRoot = path.resolve(here, '..');
+
+describe('offline guarantee', () => {
+  it('declares no runtime dependencies', () => {
+    const pkg = JSON.parse(readFileSync(path.join(pkgRoot, 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>;
+    };
+    expect(pkg.dependencies ?? {}).toEqual({});
+  });
+
+  it('source references no network or filesystem API', () => {
+    const banned: Array<[RegExp, string]> = [
+      [/\bfetch\s*\(/, 'fetch()'],
+      [/XMLHttpRequest/, 'XMLHttpRequest'],
+      [/\bWebSocket\b/, 'WebSocket'],
+      [/\bEventSource\b/, 'EventSource'],
+      [/node:https?\b/, 'node:http(s)'],
+      [/node:net\b/, 'node:net'],
+      [/node:dns\b/, 'node:dns'],
+      [/node:tls\b/, 'node:tls'],
+      [/node:fs\b/, 'node:fs'],
+      [/\bnavigator\.sendBeacon\b/, 'sendBeacon'],
+    ];
+    const sources = readdirSync(here).filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'));
+    expect(sources.length).toBeGreaterThan(0);
+    for (const file of sources) {
+      const content = readFileSync(path.join(here, file), 'utf8');
+      for (const [re, label] of banned) {
+        expect(content, `${file} must not reference ${label}`).not.toMatch(re);
+      }
+    }
+  });
+});

--- a/packages/anonymizer/src/redact.test.ts
+++ b/packages/anonymizer/src/redact.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { redact } from './redact.js';
+
+describe('redact', () => {
+  it('labels by default', () => {
+    const { text, report } = redact('Call me at john@acme.com');
+    expect(text).toBe('Call me at [EMAIL]');
+    expect(report.total).toBe(1);
+    expect(report.counts.email).toBe(1);
+  });
+
+  it('pseudonyms are consistent and numbered in document order', () => {
+    const { text } = redact('a@x.com cc b@x.com, reply a@x.com', { mode: 'pseudonym' });
+    expect(text).toBe('EMAIL_1 cc EMAIL_2, reply EMAIL_1');
+  });
+
+  it('hash mode is deterministic per value', () => {
+    const r1 = redact('john@acme.com', { mode: 'hash' });
+    const r2 = redact('john@acme.com', { mode: 'hash' });
+    expect(r1.text).toBe(r2.text);
+    expect(r1.text).toMatch(/^\[EMAIL:[0-9a-z]{8}\]$/);
+  });
+
+  it('redacts multiple categories and offsets stay correct', () => {
+    const text = 'email a@b.com card 4111 1111 1111 1111 ip 10.0.0.1';
+    const { text: out, report } = redact(text);
+    expect(out).toBe('email [EMAIL] card [CARD] ip [IP]');
+    expect(report.total).toBe(3);
+    expect(report.counts.creditCard).toBe(1);
+    expect(report.counts.ipv4).toBe(1);
+  });
+
+  it('handles empty input', () => {
+    expect(redact('')).toEqual({
+      text: '',
+      report: { counts: expect.any(Object), total: 0, spans: [] },
+    });
+  });
+
+  it('keeps Unicode offsets intact', () => {
+    const { text } = redact('café → a@b.com ☕');
+    expect(text).toBe('café → [EMAIL] ☕');
+  });
+
+  it('redacts custom terms with the REDACTED label', () => {
+    const { text } = redact('Project Bluebird is internal', { customTerms: ['Project Bluebird'] });
+    expect(text).toBe('[REDACTED] is internal');
+  });
+});

--- a/packages/anonymizer/src/redact.ts
+++ b/packages/anonymizer/src/redact.ts
@@ -1,0 +1,97 @@
+/**
+ * Redaction: detect PII, then rewrite each span according to the chosen mode and
+ * return both the redacted text and a per-category report.
+ */
+
+import { detect } from './detect.js';
+import { shortHash } from './hash.js';
+import type {
+  PiiCategory,
+  PiiSpan,
+  RedactionMode,
+  RedactOptions,
+  RedactResult,
+} from './types.js';
+
+/** Human-facing label per category (also the pseudonym/hash prefix). */
+const LABELS: Record<PiiCategory, string> = {
+  email: 'EMAIL',
+  phone: 'PHONE',
+  creditCard: 'CARD',
+  ssn: 'SSN',
+  nationalId: 'ID',
+  ipv4: 'IP',
+  ipv6: 'IP',
+  mac: 'MAC',
+  iban: 'IBAN',
+  url: 'URL',
+  date: 'DATE',
+  person: 'PERSON',
+  org: 'ORG',
+  location: 'LOCATION',
+  custom: 'REDACTED',
+};
+
+function emptyCounts(): Record<PiiCategory, number> {
+  return {
+    email: 0,
+    phone: 0,
+    creditCard: 0,
+    ssn: 0,
+    nationalId: 0,
+    ipv4: 0,
+    ipv6: 0,
+    mac: 0,
+    iban: 0,
+    url: 0,
+    date: 0,
+    person: 0,
+    org: 0,
+    location: 0,
+    custom: 0,
+  };
+}
+
+/**
+ * Redact PII in `text`. Default mode is `label`. Pseudonyms are numbered in
+ * document order and are consistent within the call (same value → same token).
+ */
+export function redact(text: string, opts: RedactOptions = {}): RedactResult {
+  const spans = detect(text, opts);
+  const mode: RedactionMode = opts.mode ?? 'label';
+
+  // Compute the replacement string per span LEFT-TO-RIGHT so pseudonym numbers
+  // follow reading order, ...
+  const counters = new Map<PiiCategory, number>();
+  const memo = new Map<string, string>(); // `${category}:${lower(value)}` → token
+  const replacementFor = (span: PiiSpan): string => {
+    const label = LABELS[span.category];
+    if (mode === 'label') return `[${label}]`;
+    const key = `${span.category}:${span.value.toLowerCase()}`;
+    const existing = memo.get(key);
+    if (existing) return existing;
+    let token: string;
+    if (mode === 'hash') {
+      token = `[${label}:${shortHash(span.value.toLowerCase(), opts.hashSalt ?? '')}]`;
+    } else {
+      const n = (counters.get(span.category) ?? 0) + 1;
+      counters.set(span.category, n);
+      token = `${label}_${n}`;
+    }
+    memo.set(key, token);
+    return token;
+  };
+  const replacements = spans.map(replacementFor);
+
+  // ...then splice RIGHT-TO-LEFT so earlier offsets stay valid as we go.
+  let out = text;
+  for (let i = spans.length - 1; i >= 0; i--) {
+    const span = spans[i]!;
+    out = out.slice(0, span.start) + replacements[i] + out.slice(span.end);
+  }
+
+  const counts = emptyCounts();
+  for (const s of spans) counts[s.category] += 1;
+
+  return { text: out, report: { counts, total: spans.length, spans } };
+}

--- a/packages/anonymizer/src/types.ts
+++ b/packages/anonymizer/src/types.ts
@@ -1,0 +1,122 @@
+/**
+ * Public types for the anonymizer engine.
+ *
+ * Everything here is plain data — no classes, no I/O — so the engine stays a
+ * pure, dependency-free leaf that bundles into the desktop renderer unchanged.
+ */
+
+/**
+ * A class of personally-identifiable information.
+ *
+ * `email`..`date` are detected by built-in regex/validator detectors.
+ * `person | org | location` come from an external NER pass (the desktop bundles
+ * an on-device model and feeds its spans in via {@link DetectOptions.extraSpans});
+ * the engine itself never does NER. `custom` is literal user-supplied terms
+ * (names, addresses) the user wants redacted. `nationalId` is reserved for
+ * region-specific detectors and has no default built-in (off unless provided as
+ * an extra span).
+ */
+export type PiiCategory =
+  | 'email'
+  | 'phone'
+  | 'creditCard'
+  | 'ssn'
+  | 'nationalId'
+  | 'ipv4'
+  | 'ipv6'
+  | 'mac'
+  | 'iban'
+  | 'url'
+  | 'date'
+  | 'person'
+  | 'org'
+  | 'location'
+  | 'custom';
+
+/** A detected PII occurrence: a half-open `[start, end)` char range in the source. */
+export interface PiiSpan {
+  readonly category: PiiCategory;
+  /** Inclusive UTF-16 char offset. */
+  readonly start: number;
+  /** Exclusive UTF-16 char offset. */
+  readonly end: number;
+  /** The exact matched substring (`text.slice(start, end)`). */
+  readonly value: string;
+}
+
+/**
+ * How a detected span is rewritten:
+ *  - `label`      → `[EMAIL]` (clearest for a human reviewing what was removed)
+ *  - `pseudonym`  → `EMAIL_1` (same value → same token within a doc, so it stays coherent)
+ *  - `hash`       → `[EMAIL:a1b2c3d4]` (compact + consistent, less readable)
+ */
+export type RedactionMode = 'label' | 'pseudonym' | 'hash';
+
+export interface DetectOptions {
+  /** Which built-in detectors to run. Defaults to {@link STRUCTURED_CATEGORIES}. */
+  readonly categories?: readonly PiiCategory[];
+  /** Literal terms (case-insensitive, word-boundary) to redact as `custom` —
+   *  the deterministic path for names/addresses the user types in. */
+  readonly customTerms?: readonly string[];
+  /** Externally-detected spans (e.g. on-device NER `person`/`org`/`location`)
+   *  merged into the result through the same overlap-resolution pass. */
+  readonly extraSpans?: readonly PiiSpan[];
+}
+
+export interface RedactOptions extends DetectOptions {
+  /** Defaults to `label`. */
+  readonly mode?: RedactionMode;
+  /** Optional salt for `hash` mode so tokens differ across documents/users. */
+  readonly hashSalt?: string;
+}
+
+/** Per-category occurrence counts; every category is present (0 when absent). */
+export type PiiCounts = Readonly<Record<PiiCategory, number>>;
+
+export interface RedactionReport {
+  readonly counts: PiiCounts;
+  readonly total: number;
+  /** The non-overlapping spans that were redacted, in document order. */
+  readonly spans: readonly PiiSpan[];
+}
+
+export interface RedactResult {
+  readonly text: string;
+  readonly report: RedactionReport;
+}
+
+/** Every category, in a stable order (handy for building UI checklists). */
+export const ALL_CATEGORIES: readonly PiiCategory[] = [
+  'email',
+  'phone',
+  'creditCard',
+  'ssn',
+  'nationalId',
+  'ipv4',
+  'ipv6',
+  'mac',
+  'iban',
+  'url',
+  'date',
+  'person',
+  'org',
+  'location',
+  'custom',
+];
+
+/**
+ * The built-in detectors that run by default. `date` is omitted (high
+ * false-positive rate — opt-in), as are `nationalId` (region-specific) and the
+ * NER-only `person`/`org`/`location`/`custom` categories.
+ */
+export const STRUCTURED_CATEGORIES: readonly PiiCategory[] = [
+  'email',
+  'phone',
+  'creditCard',
+  'ssn',
+  'ipv4',
+  'ipv6',
+  'mac',
+  'iban',
+  'url',
+];

--- a/packages/anonymizer/tsconfig.json
+++ b/packages/anonymizer/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023"],
+    "types": []
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/anonymizer/vitest.config.ts
+++ b/packages/anonymizer/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/packages/client-core/src/index.ts
+++ b/packages/client-core/src/index.ts
@@ -38,3 +38,5 @@ export * from './useMobileGateway.js';
 export * from './useVoiceRecorder.js';
 export * from './useActiveModeBadge.js';
 export * from './useSessionInfoBridge.js';
+export * from './useApps.js';
+export * from './useAnonymizer.js';

--- a/packages/client-core/src/useAnonymizer.ts
+++ b/packages/client-core/src/useAnonymizer.ts
@@ -1,0 +1,56 @@
+import { useCallback, useState } from 'react';
+import { api } from './transport.js';
+import { toErrorMessage } from './errors.js';
+import type { AnonymizerParseResult } from '@moxxy/desktop-ipc-contract';
+
+export interface UseAnonymizer {
+  /** Open the document picker and parse the chosen file to text in main.
+   *  Returns null if the picker was cancelled. The parse result is a
+   *  discriminated union (`{text}` | `{error}`) — a bad parse is data, not a
+   *  thrown error. All redaction then happens in the renderer (offline). */
+  readonly pickAndParse: () => Promise<AnonymizerParseResult | null>;
+  /** Save renderer-produced redacted text via a native Save dialog. Returns the
+   *  chosen path, or null if cancelled. */
+  readonly save: (suggestedName: string, content: string) => Promise<string | null>;
+  readonly busy: boolean;
+  readonly error: string | null;
+}
+
+/** Thin wrapper over the host-only `anonymizer.*` IPC (native pickers + file
+ *  I/O). The actual PII detection + redaction is done in the renderer with
+ *  `@moxxy/anonymizer`, so documents never cross a network boundary. */
+export function useAnonymizer(): UseAnonymizer {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const pickAndParse = useCallback(async (): Promise<AnonymizerParseResult | null> => {
+    setBusy(true);
+    setError(null);
+    try {
+      const path = await api().invoke('anonymizer.pickDocument');
+      if (!path) return null;
+      return await api().invoke('anonymizer.parseDocument', { path });
+    } catch (e) {
+      const message = toErrorMessage(e);
+      setError(message);
+      return { error: message };
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const save = useCallback(
+    async (suggestedName: string, content: string): Promise<string | null> => {
+      setError(null);
+      try {
+        return await api().invoke('anonymizer.saveRedacted', { suggestedName, content });
+      } catch (e) {
+        setError(toErrorMessage(e));
+        return null;
+      }
+    },
+    [],
+  );
+
+  return { pickAndParse, save, busy, error };
+}

--- a/packages/client-core/src/useApps.ts
+++ b/packages/client-core/src/useApps.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from 'react';
+import { api } from './transport.js';
+import { toErrorMessage } from './errors.js';
+import type { AppInstallProgress, AppInstallStatus } from '@moxxy/desktop-ipc-contract';
+
+export interface UseAppInstall {
+  /** Current install state (null until the first `apps.status` resolves). */
+  readonly status: AppInstallStatus | null;
+  /** Live download progress while installing (cleared when idle). */
+  readonly progress: AppInstallProgress | null;
+  readonly installing: boolean;
+  readonly install: () => Promise<void>;
+  readonly uninstall: () => Promise<void>;
+  readonly refresh: () => Promise<void>;
+}
+
+/**
+ * Drives one app's install lifecycle from the Apps gallery: reads
+ * `apps.status`, runs `apps.install` / `apps.uninstall`, and tracks the
+ * streamed `apps.install.progress` (filtered to this `appId`).
+ */
+export function useAppInstall(appId: string): UseAppInstall {
+  const [status, setStatus] = useState<AppInstallStatus | null>(null);
+  const [progress, setProgress] = useState<AppInstallProgress | null>(null);
+  const [installing, setInstalling] = useState(false);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    try {
+      setStatus(await api().invoke('apps.status', { appId }));
+    } catch (e) {
+      setStatus({ appId, state: 'error', error: toErrorMessage(e) });
+    }
+  }, [appId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Progress is broadcast for ALL installs — keep only this app's.
+  useEffect(() => {
+    const off = api().subscribe('apps.install.progress', (p: AppInstallProgress) => {
+      if (p.appId !== appId) return;
+      setProgress(p.phase === 'done' || p.phase === 'error' ? null : p);
+    });
+    return off;
+  }, [appId]);
+
+  const install = useCallback(async (): Promise<void> => {
+    setInstalling(true);
+    try {
+      setStatus(await api().invoke('apps.install', { appId }));
+    } catch (e) {
+      setStatus({ appId, state: 'error', error: toErrorMessage(e) });
+    } finally {
+      setInstalling(false);
+      setProgress(null);
+    }
+  }, [appId]);
+
+  const uninstall = useCallback(async (): Promise<void> => {
+    try {
+      setStatus(await api().invoke('apps.uninstall', { appId }));
+    } catch (e) {
+      setStatus({ appId, state: 'error', error: toErrorMessage(e) });
+    }
+  }, [appId]);
+
+  return { status, progress, installing, install, uninstall, refresh };
+}

--- a/packages/desktop-host/src/apps/assets-protocol.test.ts
+++ b/packages/desktop-host/src/apps/assets-protocol.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile, symlink } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+// assets-protocol imports `electron` (for protocol.handle); stub it so the pure
+// `resolveAssetRequest` logic is unit-testable without the runtime.
+vi.mock('electron', () => ({ protocol: { handle: () => undefined } }));
+
+import { resolveAssetRequest } from './assets-protocol';
+
+let root: string;
+let appRoot: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), 'moxxy-asset-test-'));
+  appRoot = path.join(root, 'anonymizer');
+  await mkdir(path.join(appRoot, 'onnx'), { recursive: true });
+  await writeFile(path.join(appRoot, 'config.json'), '{"k":1}');
+  await writeFile(path.join(appRoot, 'onnx', 'model.onnx'), 'BYTES');
+  // A secret OUTSIDE the apps root that traversal attempts target.
+  await writeFile(path.join(root, 'secret.txt'), 'TOP SECRET');
+});
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe('resolveAssetRequest', () => {
+  it('resolves a real nested asset', () => {
+    const abs = resolveAssetRequest(root, 'moxxy-app://assets/anonymizer/onnx/model.onnx');
+    expect(abs).toBe(path.join(appRoot, 'onnx/model.onnx'));
+  });
+
+  it('resolves a top-level asset', () => {
+    expect(resolveAssetRequest(root, 'moxxy-app://assets/anonymizer/config.json')).toBe(
+      path.join(appRoot, 'config.json'),
+    );
+  });
+
+  it('rejects a wrong host bucket', () => {
+    expect(resolveAssetRequest(root, 'moxxy-app://other/anonymizer/config.json')).toBeNull();
+  });
+
+  it('rejects an unsafe app id', () => {
+    expect(resolveAssetRequest(root, 'moxxy-app://assets/Foo/config.json')).toBeNull();
+  });
+
+  it('rejects an empty rest', () => {
+    expect(resolveAssetRequest(root, 'moxxy-app://assets/anonymizer/')).toBeNull();
+  });
+
+  it('rejects a `..` traversal that escapes the app dir', () => {
+    // `..%2f` decodes to `../`; the resolved path lands at root/secret.txt,
+    // outside the app dir → null.
+    expect(resolveAssetRequest(root, 'moxxy-app://assets/anonymizer/..%2f..%2fsecret.txt')).toBeNull();
+    expect(resolveAssetRequest(root, 'moxxy-app://assets/anonymizer/../secret.txt')).toBeNull();
+  });
+
+  it('rejects a NUL byte', () => {
+    expect(resolveAssetRequest(root, 'moxxy-app://assets/anonymizer/config%00.json')).toBeNull();
+  });
+
+  it('returns null for a missing file', () => {
+    expect(resolveAssetRequest(root, 'moxxy-app://assets/anonymizer/nope.json')).toBeNull();
+  });
+
+  it('rejects a symlink that escapes the app dir', async () => {
+    // A symlink INSIDE the app dir pointing at the outside secret must not be
+    // served (realpath-escape insurance).
+    await symlink(path.join(root, 'secret.txt'), path.join(appRoot, 'leak.txt'));
+    expect(resolveAssetRequest(root, 'moxxy-app://assets/anonymizer/leak.txt')).toBeNull();
+  });
+});

--- a/packages/desktop-host/src/apps/assets-protocol.ts
+++ b/packages/desktop-host/src/apps/assets-protocol.ts
@@ -1,0 +1,155 @@
+/**
+ * A hardened, local-only `moxxy-app://` scheme handler that serves an installed
+ * app's downloaded assets to the renderer (and its workers).
+ *
+ * WHY a custom scheme: the document anonymizer's NER worker loads its model with
+ * transformers.js, which fetches files over HTTP(S). We rewrite those fetches to
+ * `moxxy-app://assets/anonymizer/<path>` so the model is read from the locally
+ * installed bundle under `userData/moxxy-apps/` — NO network egress at use time,
+ * which is the whole point of the offline anonymizer. The scheme is registered
+ * privileged (standard + secure + fetch + stream) by the Electron main so the
+ * renderer's CSP `connect-src moxxy-app:` allows it.
+ *
+ * Threat model: the renderer is untrusted (a single XSS would otherwise inherit
+ * main-process authority). So this handler is deliberately strict — exactly the
+ * same containment discipline as {@link ../loopback-server.ts}:
+ *   - GET/HEAD only (405 otherwise);
+ *   - host MUST be `assets`, the first path segment is a slug-validated appId,
+ *     the remainder is the file path (reject NUL / empty);
+ *   - the resolved path is confirmed (lexically AND via realpath) to stay inside
+ *     the app's own dir — no `..`, no symlink escape, nothing outside
+ *     `userData/moxxy-apps/<appId>/` is ever readable (404 on escape/miss).
+ * It serves static bytes only; there is no dynamic surface to exploit, and it
+ * opens no network path (it reads confined local files), so the offline
+ * guarantee holds even while the scheme is connectable.
+ */
+
+import { createReadStream } from 'node:fs';
+import { realpathSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+
+import { protocol } from 'electron';
+
+import { appDir } from './installer.js';
+
+/** The scheme this module serves. Registered privileged by the Electron main. */
+export const APP_ASSET_SCHEME = 'moxxy-app';
+
+/** extension → MIME. Small + explicit (no `mime` dep). Unknown ⇒ octet-stream;
+ *  `.wasm` gets the real `application/wasm` so the streaming compiler accepts
+ *  it under the renderer's CSP. */
+function mimeFor(filePath: string): string {
+  switch (path.extname(filePath).toLowerCase()) {
+    case '.json':
+      return 'application/json';
+    case '.txt':
+      return 'text/plain';
+    case '.wasm':
+      return 'application/wasm';
+    // ORT's loader is an ESM module the worker `import()`s — module scripts are
+    // MIME-checked, so it MUST be served with a JavaScript type or the import
+    // is blocked.
+    case '.mjs':
+    case '.js':
+      return 'text/javascript';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+const APP_ID = /^[a-z][a-z0-9-]*$/;
+
+/**
+ * Resolve a `moxxy-app://` request URL to a concrete, contained absolute file
+ * path under `appsRoot`, or `null` to reject (404/403). Pure (no Electron) so
+ * it's unit-testable. Expected URL form: `moxxy-app://assets/<appId>/<rest...>`.
+ */
+export function resolveAssetRequest(appsRoot: string, requestUrl: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(requestUrl);
+  } catch {
+    return null;
+  }
+  // Host must be the literal `assets` bucket.
+  if (parsed.hostname !== 'assets') return null;
+
+  // Decode the path; reject NUL (a classic truncation trick) before disk.
+  let pathname: string;
+  try {
+    pathname = decodeURIComponent(parsed.pathname);
+  } catch {
+    return null;
+  }
+  if (pathname.includes('\0')) return null;
+
+  // Split `/<appId>/<rest...>`.
+  const segments = pathname.replace(/^\/+/, '').split('/');
+  const appId = segments.shift();
+  const rest = segments.join('/');
+  if (!appId || !APP_ID.test(appId) || rest.length === 0) return null;
+
+  let dir: string;
+  try {
+    dir = appDir(appsRoot, appId);
+  } catch {
+    return null;
+  }
+
+  // Lexical containment is the security boundary: `path.resolve` collapses `..`
+  // and absolute segments, so the only thing that lands under `dir` is a real
+  // descendant.
+  const abs = path.resolve(dir, '.' + (rest.startsWith('/') ? rest : '/' + rest));
+  if (abs !== dir && !abs.startsWith(dir + path.sep)) return null;
+
+  // Must be an existing regular file.
+  let isFile: boolean;
+  try {
+    isFile = statSync(abs).isFile();
+  } catch {
+    return null;
+  }
+  if (!isFile) return null;
+
+  // Symlink-escape insurance: canonicalise the app dir AND the file, re-check
+  // containment. Belt-and-braces on top of the lexical check above.
+  try {
+    const realDir = realpathSync(dir);
+    const real = realpathSync(abs);
+    if (real !== realDir && !real.startsWith(realDir + path.sep)) return null;
+  } catch {
+    /* realpath unavailable — trust the lexical containment check above */
+  }
+  return abs;
+}
+
+/**
+ * Install the `moxxy-app://` protocol handler on Electron's default `protocol`.
+ * Confined to `appsRoot` (`userData/moxxy-apps`). Call once, after app ready.
+ */
+export function installAppAssetProtocol(appsRoot: string): void {
+  protocol.handle(APP_ASSET_SCHEME, (request) => {
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return new Response(null, { status: 405, headers: { Allow: 'GET, HEAD' } });
+    }
+    const abs = resolveAssetRequest(appsRoot, request.url);
+    if (!abs) return new Response(null, { status: 404 });
+
+    let size: number;
+    try {
+      size = statSync(abs).size;
+    } catch {
+      return new Response(null, { status: 404 });
+    }
+    const headers = {
+      'content-type': mimeFor(abs),
+      'content-length': String(size),
+    };
+    if (request.method === 'HEAD') return new Response(null, { status: 200, headers });
+    return new Response(Readable.toWeb(createReadStream(abs)) as ReadableStream, {
+      status: 200,
+      headers,
+    });
+  });
+}

--- a/packages/desktop-host/src/apps/installer.test.ts
+++ b/packages/desktop-host/src/apps/installer.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, rm, writeFile, mkdir } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  appDir,
+  appStatus,
+  installApp,
+  resolveAssetDest,
+  uninstallApp,
+  type AppInstallSpec,
+  type FetchLike,
+} from './installer';
+import type { AppInstallProgress } from '@moxxy/desktop-ipc-contract';
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), 'moxxy-apps-test-'));
+});
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+/** A `fetch` stub backed by an in-memory `url → bytes` map. Each call returns a
+ *  real web `Response` (so the installer's `.body.getReader()` /
+ *  `headers.get('content-length')` work unchanged). */
+function fakeFetch(files: Record<string, string>): FetchLike {
+  return (async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const body = files[url];
+    if (body === undefined) return new Response(null, { status: 404 });
+    const bytes = Buffer.from(body, 'utf8');
+    return new Response(bytes, {
+      status: 200,
+      headers: { 'content-length': String(bytes.byteLength) },
+    });
+  }) as FetchLike;
+}
+
+const sha256 = (s: string): string => createHash('sha256').update(s, 'utf8').digest('hex');
+
+describe('resolveAssetDest containment', () => {
+  it('rejects a `..` traversal dest', () => {
+    expect(() => resolveAssetDest(path.join(root, 'anonymizer'), '../x')).toThrow(/escapes/);
+  });
+  it('rejects an absolute dest', () => {
+    expect(() => resolveAssetDest(path.join(root, 'anonymizer'), '/etc/passwd')).toThrow(
+      /must be relative/,
+    );
+  });
+  it('rejects a NUL byte', () => {
+    expect(() => resolveAssetDest(path.join(root, 'anonymizer'), 'a\0b')).toThrow(/NUL/);
+  });
+  it('accepts a nested relative dest', () => {
+    const dir = path.join(root, 'anonymizer');
+    expect(resolveAssetDest(dir, 'onnx/model.onnx')).toBe(path.join(dir, 'onnx/model.onnx'));
+  });
+});
+
+describe('appDir', () => {
+  it('rejects an unsafe app id', () => {
+    expect(() => appDir(root, '../evil')).toThrow(/invalid app id/);
+    expect(() => appDir(root, 'Foo')).toThrow(/invalid app id/);
+  });
+});
+
+describe('install ↔ status lifecycle', () => {
+  const spec: AppInstallSpec = {
+    id: 'anonymizer',
+    version: 'v1',
+    assets: [
+      { url: 'https://example/config.json', dest: 'config.json' },
+      { url: 'https://example/onnx/model.onnx', dest: 'onnx/model.onnx' },
+    ],
+  };
+
+  it('reports not-installed before install', async () => {
+    expect(await appStatus(spec, root)).toEqual({ appId: 'anonymizer', state: 'not-installed' });
+  });
+
+  it('downloads every asset, writes the marker, and flips to installed', async () => {
+    const fetchImpl = fakeFetch({
+      'https://example/config.json': '{"k":1}',
+      'https://example/onnx/model.onnx': 'ONNXBYTES',
+    });
+    const phases: AppInstallProgress['phase'][] = [];
+    const status = await installApp(spec, root, (p) => phases.push(p.phase), fetchImpl);
+
+    expect(status).toEqual({ appId: 'anonymizer', state: 'installed', version: 'v1' });
+    expect(phases).toContain('downloading');
+    expect(phases.at(-1)).toBe('done');
+    expect(await readFile(path.join(root, 'anonymizer', 'config.json'), 'utf8')).toBe('{"k":1}');
+    expect(await readFile(path.join(root, 'anonymizer', 'onnx/model.onnx'), 'utf8')).toBe(
+      'ONNXBYTES',
+    );
+    expect(await appStatus(spec, root)).toEqual({
+      appId: 'anonymizer',
+      state: 'installed',
+      version: 'v1',
+    });
+  });
+
+  it('a version mismatch in the marker reports not-installed', async () => {
+    const fetchImpl = fakeFetch({
+      'https://example/config.json': '{"k":1}',
+      'https://example/onnx/model.onnx': 'ONNXBYTES',
+    });
+    await installApp(spec, root, () => {}, fetchImpl);
+    // The same files but the spec now wants a newer version.
+    const bumped: AppInstallSpec = { ...spec, version: 'v2' };
+    expect((await appStatus(bumped, root)).state).toBe('not-installed');
+  });
+
+  it('a missing asset file reports not-installed even with a matching marker', async () => {
+    const fetchImpl = fakeFetch({
+      'https://example/config.json': '{"k":1}',
+      'https://example/onnx/model.onnx': 'ONNXBYTES',
+    });
+    await installApp(spec, root, () => {}, fetchImpl);
+    await rm(path.join(root, 'anonymizer', 'onnx/model.onnx'));
+    expect((await appStatus(spec, root)).state).toBe('not-installed');
+  });
+
+  it('uninstall removes the dir and reports not-installed', async () => {
+    const fetchImpl = fakeFetch({
+      'https://example/config.json': '{"k":1}',
+      'https://example/onnx/model.onnx': 'ONNXBYTES',
+    });
+    await installApp(spec, root, () => {}, fetchImpl);
+    expect(await uninstallApp('anonymizer', root)).toEqual({
+      appId: 'anonymizer',
+      state: 'not-installed',
+    });
+    expect((await appStatus(spec, root)).state).toBe('not-installed');
+  });
+});
+
+describe('integrity verification', () => {
+  it('a sha256 mismatch returns an error status and writes no file', async () => {
+    const spec: AppInstallSpec = {
+      id: 'anonymizer',
+      version: 'v1',
+      assets: [{ url: 'https://example/a.bin', dest: 'a.bin', sha256: sha256('EXPECTED') }],
+    };
+    const fetchImpl = fakeFetch({ 'https://example/a.bin': 'WRONG' });
+    const phases: AppInstallProgress['phase'][] = [];
+    const status = await installApp(spec, root, (p) => phases.push(p.phase), fetchImpl);
+
+    expect(status.state).toBe('error');
+    expect(status.error).toMatch(/integrity check failed/);
+    expect(phases).toContain('verifying');
+    expect(phases.at(-1)).toBe('error');
+    // No file published, no marker → still not-installed.
+    expect((await appStatus(spec, root)).state).toBe('not-installed');
+  });
+
+  it('a matching sha256 installs and a re-run skips the verified asset', async () => {
+    const spec: AppInstallSpec = {
+      id: 'anonymizer',
+      version: 'v1',
+      assets: [{ url: 'https://example/a.bin', dest: 'a.bin', sha256: sha256('GOOD') }],
+    };
+    const fetchImpl = fakeFetch({ 'https://example/a.bin': 'GOOD' });
+    expect((await installApp(spec, root, () => {}, fetchImpl)).state).toBe('installed');
+
+    // A re-run with a fetch that would FAIL proves the present+correct asset is
+    // skipped (idempotent install).
+    const wouldThrow: FetchLike = (() => {
+      throw new Error('should not be called — asset already present');
+    }) as FetchLike;
+    expect((await installApp(spec, root, () => {}, wouldThrow)).state).toBe('installed');
+  });
+});
+
+describe('partial-install resume', () => {
+  it('a leftover .partial does not satisfy status; re-install completes', async () => {
+    const spec: AppInstallSpec = {
+      id: 'anonymizer',
+      version: 'v1',
+      assets: [{ url: 'https://example/a.bin', dest: 'a.bin' }],
+    };
+    // Simulate a crash mid-download: only the .partial exists.
+    await mkdir(path.join(root, 'anonymizer'), { recursive: true });
+    await writeFile(path.join(root, 'anonymizer', 'a.bin.partial'), 'half');
+    expect((await appStatus(spec, root)).state).toBe('not-installed');
+
+    const fetchImpl = fakeFetch({ 'https://example/a.bin': 'FULL' });
+    expect((await installApp(spec, root, () => {}, fetchImpl)).state).toBe('installed');
+    expect(await readFile(path.join(root, 'anonymizer', 'a.bin'), 'utf8')).toBe('FULL');
+  });
+});

--- a/packages/desktop-host/src/apps/installer.ts
+++ b/packages/desktop-host/src/apps/installer.ts
@@ -1,0 +1,298 @@
+/**
+ * Download + verify an installable desktop app's local assets.
+ *
+ * Some Apps-gallery apps need a one-time local asset fetch before first use —
+ * the document anonymizer downloads an on-device NER model. That fetch is the
+ * ONLY time the network is touched, runs in the MAIN process, and is gated
+ * behind an explicit "Install" click. After install everything the app reads is
+ * local, so its offline guarantee holds at use time.
+ *
+ * Kept free of any `electron` import (mirrors {@link ../loopback-server.ts}) so
+ * it stays unit-testable in plain Node — the caller passes `appsRoot` (the
+ * Electron `userData/moxxy-apps` dir) as a param.
+ *
+ * Security: every asset `dest` is a RELATIVE path resolved under the app's own
+ * directory and confirmed (lexically AND via realpath) to stay inside it before
+ * a single byte is written — the same path-traversal containment discipline as
+ * {@link ../loopback-server.ts}. An absolute dest, a `..` segment, a NUL byte,
+ * or a symlink that escapes the app dir is refused.
+ */
+
+import { createHash } from 'node:crypto';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { mkdir, rename, rm, stat, writeFile, readFile, realpath } from 'node:fs/promises';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+
+import type { AppInstallStatus, AppInstallProgress } from '@moxxy/desktop-ipc-contract';
+
+/** One downloadable file of an app's install bundle. */
+export interface AppAsset {
+  /** Source URL fetched over the network (MAIN process only). */
+  readonly url: string;
+  /** Destination RELATIVE path under the app dir. No `..`, never absolute. */
+  readonly dest: string;
+  /** Expected size, when known (advisory only — Content-Length drives bars). */
+  readonly bytes?: number;
+  /** Optional integrity hash (hex sha256); verified post-download when set. */
+  readonly sha256?: string;
+}
+
+/** The full install spec for one app. */
+export interface AppInstallSpec {
+  readonly id: string;
+  /** Opaque version marker recorded in `installed.json`; a mismatch ⇒ stale. */
+  readonly version: string;
+  readonly assets: readonly AppAsset[];
+}
+
+/** App ids index a filesystem dir + a custom-scheme host segment, so confine
+ *  them to a strict slug (no `..`, no separators, no scheme tricks). */
+const APP_ID = /^[a-z][a-z0-9-]*$/;
+
+/** Marker file written into an app's dir once every asset is present. */
+const INSTALLED_MARKER = 'installed.json';
+
+interface InstalledMarker {
+  readonly version: string;
+  readonly installedAt: number;
+  readonly assets: readonly string[];
+}
+
+/** A `fetch`-compatible function. Defaults to the global `fetch` (Node 20+);
+ *  tests inject a stub so no real network is touched. */
+export type FetchLike = typeof fetch;
+
+/**
+ * Resolve an app's directory under `appsRoot`, asserting the id is a safe slug.
+ * Exported so the asset protocol resolves the SAME dir for serving.
+ */
+export function appDir(appsRoot: string, appId: string): string {
+  if (!APP_ID.test(appId)) throw new Error(`invalid app id: ${JSON.stringify(appId)}`);
+  return path.join(appsRoot, appId);
+}
+
+/**
+ * Resolve an asset `dest` under `dir` and CONFIRM containment. Mirrors the
+ * loopback server's discipline: reject NUL, reject absolute, then resolve and
+ * verify the result is `dir` or a descendant of it (so `..` / encoded
+ * traversal can never escape). Lexical check is the security boundary; a
+ * realpath re-check (symlink-escape insurance) happens at write time.
+ */
+export function resolveAssetDest(dir: string, dest: string): string {
+  if (typeof dest !== 'string' || dest.length === 0) throw new Error('empty asset dest');
+  if (dest.includes('\0')) throw new Error('asset dest contains NUL');
+  if (path.isAbsolute(dest)) throw new Error(`asset dest must be relative: ${JSON.stringify(dest)}`);
+  const abs = path.resolve(dir, dest);
+  if (abs !== dir && !abs.startsWith(dir + path.sep)) {
+    throw new Error(`asset dest escapes app dir: ${JSON.stringify(dest)}`);
+  }
+  return abs;
+}
+
+/** Belt-and-braces symlink-escape re-check on a path that ALREADY passed the
+ *  lexical containment check, against the app dir. No-op if realpath fails
+ *  (the path may not exist yet — the lexical check above is authoritative). */
+async function assertRealpathContained(dir: string, abs: string): Promise<void> {
+  // Canonicalise the app dir once (macOS `/var` → `/private/var`, etc.) so the
+  // comparison is like-for-like.
+  let realDir: string;
+  try {
+    realDir = await realpath(dir);
+  } catch {
+    realDir = dir;
+  }
+  // The file's PARENT must canonicalise inside the app dir; the file itself may
+  // not exist yet (we resolve the parent, which the caller mkdir'd).
+  const parent = path.dirname(abs);
+  try {
+    const realParent = await realpath(parent);
+    if (realParent !== realDir && !realParent.startsWith(realDir + path.sep)) {
+      throw new Error(`asset path escapes app dir via symlink: ${abs}`);
+    }
+  } catch (e) {
+    // Re-throw our own escape error; swallow a plain ENOENT (parent freshly
+    // created, realpath race) and trust the lexical containment check.
+    if (e instanceof Error && e.message.startsWith('asset path escapes')) throw e;
+  }
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    return (await stat(p)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function readMarker(dir: string): Promise<InstalledMarker | null> {
+  try {
+    const raw = await readFile(path.join(dir, INSTALLED_MARKER), 'utf8');
+    const parsed = JSON.parse(raw) as InstalledMarker;
+    return parsed && typeof parsed.version === 'string' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Compute the hex sha256 of a file by streaming it (constant memory). */
+async function sha256File(p: string): Promise<string> {
+  const hash = createHash('sha256');
+  await pipeline(createReadStream(p), hash);
+  return hash.digest('hex');
+}
+
+/**
+ * Report whether `spec`'s assets are fully installed under `appsRoot`.
+ * 'installed' iff the marker exists, its `version` matches, AND every declared
+ * asset file is present; anything else (no marker, stale version, a missing
+ * file) reports 'not-installed' so a partial/aborted install re-installs.
+ */
+export async function appStatus(
+  spec: AppInstallSpec,
+  appsRoot: string,
+): Promise<AppInstallStatus> {
+  const dir = appDir(appsRoot, spec.id);
+  const marker = await readMarker(dir);
+  if (!marker || marker.version !== spec.version) {
+    return { appId: spec.id, state: 'not-installed' };
+  }
+  for (const asset of spec.assets) {
+    const abs = resolveAssetDest(dir, asset.dest);
+    if (!(await fileExists(abs))) return { appId: spec.id, state: 'not-installed' };
+  }
+  return { appId: spec.id, state: 'installed', version: spec.version };
+}
+
+/** Sum the declared/known byte totals so the progress bar has a denominator
+ *  before any Content-Length arrives. Falls back to 0 (indeterminate). */
+function knownTotal(spec: AppInstallSpec): number {
+  let total = 0;
+  for (const a of spec.assets) total += a.bytes ?? 0;
+  return total;
+}
+
+/**
+ * Download + verify every asset of `spec` into `<appsRoot>/<id>/`, streaming
+ * progress through `onProgress`. Idempotent: an asset already present with a
+ * matching sha256 (or, when no hash is declared, simply present) is skipped, so
+ * a re-run after a partial failure resumes rather than redownloads everything.
+ *
+ * Each asset streams to a `<dest>.partial` temp file then atomically `rename`s
+ * into place, so a crash mid-download never leaves a truncated file masquerading
+ * as complete. On success an `installed.json` marker is written; any failure
+ * emits a final `phase:'error'` progress event and returns an `error` status.
+ */
+export async function installApp(
+  spec: AppInstallSpec,
+  appsRoot: string,
+  onProgress: (p: AppInstallProgress) => void,
+  fetchImpl: FetchLike = fetch,
+): Promise<AppInstallStatus> {
+  const dir = appDir(appsRoot, spec.id);
+  // Sum of Content-Lengths discovered so far drives an honest total; seed it
+  // with any declared `bytes` so the bar isn't 0/0 before the first response.
+  let totalBytes = knownTotal(spec);
+  let receivedBytes = 0;
+  const emit = (
+    phase: AppInstallProgress['phase'],
+    extra: { file?: string; error?: string } = {},
+  ): void => {
+    onProgress({ appId: spec.id, phase, receivedBytes, totalBytes, ...extra });
+  };
+
+  try {
+    await mkdir(dir, { recursive: true });
+
+    for (const asset of spec.assets) {
+      const abs = resolveAssetDest(dir, asset.dest);
+      // Skip an already-correct asset (idempotent re-run).
+      if (await fileExists(abs)) {
+        if (!asset.sha256 || (await sha256File(abs)) === asset.sha256.toLowerCase()) {
+          // Count its bytes toward the running total so progress stays honest.
+          try {
+            receivedBytes += (await stat(abs)).size;
+          } catch {
+            /* ignore */
+          }
+          emit('downloading', { file: asset.dest });
+          continue;
+        }
+      }
+
+      await mkdir(path.dirname(abs), { recursive: true });
+      await assertRealpathContained(dir, abs);
+
+      emit('downloading', { file: asset.dest });
+      const res = await fetchImpl(asset.url);
+      if (!res.ok || !res.body) {
+        throw new Error(`download failed for ${asset.dest}: HTTP ${res.status}`);
+      }
+      const len = Number(res.headers.get('content-length'));
+      if (Number.isFinite(len) && len > 0) {
+        // Replace this asset's advisory `bytes` contribution with the real one.
+        totalBytes += len - (asset.bytes ?? 0);
+      }
+
+      const partial = `${abs}.partial`;
+      const out = createWriteStream(partial);
+      // Tee the stream so progress ticks as bytes land, then close it.
+      const reader = res.body.getReader();
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value) {
+            receivedBytes += value.byteLength;
+            // Backpressure: respect the write stream's drain signal.
+            if (!out.write(Buffer.from(value.buffer, value.byteOffset, value.byteLength))) {
+              await new Promise<void>((r) => out.once('drain', r));
+            }
+            emit('downloading', { file: asset.dest });
+          }
+        }
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          out.end((err?: NodeJS.ErrnoException | null) => (err ? reject(err) : resolve()));
+        });
+      }
+
+      if (asset.sha256) {
+        emit('verifying', { file: asset.dest });
+        const got = await sha256File(partial);
+        if (got !== asset.sha256.toLowerCase()) {
+          await rm(partial, { force: true });
+          throw new Error(
+            `integrity check failed for ${asset.dest}: expected ${asset.sha256}, got ${got}`,
+          );
+        }
+      }
+
+      // Atomic publish: a crash before this leaves only the `.partial`.
+      await rename(partial, abs);
+    }
+
+    const marker: InstalledMarker = {
+      version: spec.version,
+      installedAt: Date.now(),
+      assets: spec.assets.map((a) => a.dest),
+    };
+    await writeFile(path.join(dir, INSTALLED_MARKER), JSON.stringify(marker, null, 2), 'utf8');
+    emit('done');
+    return { appId: spec.id, state: 'installed', version: spec.version };
+  } catch (e) {
+    const error = e instanceof Error ? e.message : String(e);
+    emit('error', { error });
+    return { appId: spec.id, state: 'error', error };
+  }
+}
+
+/**
+ * Remove an app's installed assets. `rm -rf` the app dir; reports
+ * 'not-installed' (the post-condition) even if the dir was already absent.
+ */
+export async function uninstallApp(appId: string, appsRoot: string): Promise<AppInstallStatus> {
+  const dir = appDir(appsRoot, appId);
+  await rm(dir, { recursive: true, force: true });
+  return { appId, state: 'not-installed' };
+}

--- a/packages/desktop-host/src/apps/registry.ts
+++ b/packages/desktop-host/src/apps/registry.ts
@@ -1,0 +1,50 @@
+/**
+ * The registry of installable desktop apps (their downloadable asset bundles).
+ *
+ * Only apps that need a one-time local asset fetch appear here. Today that is
+ * the document anonymizer, which downloads an on-device NER model (a quantised
+ * `Xenova/bert-base-NER` ONNX bundle, ~109 MB) so it can detect names entirely
+ * offline at use time. The onnxruntime-web wasm RUNTIME (~21 MB) is NOT here —
+ * Vite bundles it into the app from `@huggingface/transformers` (served from
+ * `'self'`); only the large model is fetched on demand.
+ *
+ * IMPORTANT — dest mirrors the URL the renderer will request EXACTLY. The
+ * renderer's NER worker rewrites transformers.js model fetches to
+ * `moxxy-app://assets/anonymizer/<hf-resolve-path>`; the asset protocol serves
+ * `<appsRoot>/anonymizer/<that-same-path>`. So each asset's `dest` is that path
+ * verbatim — URL and dest must line up or the worker 404s on its own model.
+ */
+
+import type { AppInstallSpec } from './installer.js';
+
+/** Hugging Face files that make up the quantised NER model bundle. */
+const HF_MODEL_FILES = [
+  'config.json',
+  'tokenizer.json',
+  'tokenizer_config.json',
+  'special_tokens_map.json',
+  'vocab.txt',
+  'onnx/model_quantized.onnx',
+] as const;
+
+const HF_RESOLVE_BASE = 'Xenova/bert-base-NER/resolve/main/';
+const HF_URL_BASE = `https://huggingface.co/${HF_RESOLVE_BASE}`;
+
+const ANONYMIZER: AppInstallSpec = {
+  id: 'anonymizer',
+  // Bump this when the model bundle changes so existing installs re-download.
+  version: 'xenova-bert-base-ner-q8-v1',
+  assets: HF_MODEL_FILES.map((file) => ({
+    url: HF_URL_BASE + file,
+    // dest === the HF resolve path, so it lines up with the renderer's rewrite.
+    dest: HF_RESOLVE_BASE + file,
+    // No bytes/sha256: Content-Length drives the progress bar, and the HF
+    // resolve endpoint serves the canonical artifact (the onnx is ~109 MB).
+  })),
+};
+
+/** Installable apps keyed by id. Apps NOT listed here need no asset install
+ *  (they're trivially "installed" from the gallery's perspective). */
+export const APP_INSTALLERS: Readonly<Record<string, AppInstallSpec>> = {
+  [ANONYMIZER.id]: ANONYMIZER,
+};

--- a/packages/desktop-host/src/attachments.test.ts
+++ b/packages/desktop-host/src/attachments.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { mkdtemp, readFile, rm, unlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { buildAttachments, persistImageBlob } from './attachments';
+import { buildAttachments, parseFileToText, persistImageBlob } from './attachments';
 
 /** Temp files persistImageBlob writes; cleaned up after each test. */
 const written: string[] = [];
@@ -132,5 +132,26 @@ describe('buildAttachments', () => {
   it('drops an unreadable path without throwing', async () => {
     const out = await buildAttachments([{ path: '/no/such/file.txt', name: 'file.txt' }]);
     expect(out).toEqual([]);
+  });
+});
+
+describe('parseFileToText', () => {
+  it('returns UTF-8 text for a plain text file', async () => {
+    const { path: p } = await tmpFile('notes.txt', 'Alice met Bob in Berlin.');
+    expect(await parseFileToText(p)).toBe('Alice met Bob in Berlin.');
+  });
+
+  it('returns null for a binary (NUL-containing) file', async () => {
+    const { path: p } = await tmpFile('blob.bin', Buffer.from([0x00, 0x01, 0x02, 0x00]));
+    expect(await parseFileToText(p)).toBeNull();
+  });
+
+  it('returns null for a corrupt Office file rather than throwing', async () => {
+    const { path: p } = await tmpFile('broken.docx', Buffer.from('not really a docx'));
+    expect(await parseFileToText(p)).toBeNull();
+  });
+
+  it('returns null for an unreadable path', async () => {
+    expect(await parseFileToText('/no/such/file.txt')).toBeNull();
   });
 });

--- a/packages/desktop-host/src/attachments.ts
+++ b/packages/desktop-host/src/attachments.ts
@@ -73,6 +73,35 @@ async function extractText(buf: Buffer, name: string): Promise<string | null> {
   }
 }
 
+/**
+ * Read a file and return its plain text, mirroring {@link buildAttachments}'
+ * per-file text logic WITHOUT the attachment/size machinery: PDFs and Office /
+ * OpenDocument files go through officeparser; any other file is returned as
+ * UTF-8 when it isn't binary (a NUL byte ⇒ binary ⇒ null). Returns null on a
+ * read failure, on a binary/unsupported file, or when no text could be
+ * extracted.
+ *
+ * Reused by the offline anonymizer (`anonymizer.parseDocument`): no provider, no
+ * runner, no network — just readFile + officeparser.
+ */
+export async function parseFileToText(absPath: string): Promise<string | null> {
+  const ext = path.extname(absPath).toLowerCase();
+  const name = path.basename(absPath);
+  let buf: Buffer;
+  try {
+    buf = await readFile(absPath);
+  } catch {
+    return null;
+  }
+  // PDF (by extension or magic bytes) or Office/ODF → officeparser.
+  if (isPdf(buf, ext) || OFFICE_EXTENSIONS.has(ext)) {
+    return extractText(buf, name);
+  }
+  // Anything else: UTF-8 text, unless it looks binary.
+  if (buf.includes(0)) return null;
+  return buf.toString('utf8');
+}
+
 export async function buildAttachments(
   files: ReadonlyArray<{ path: string; name: string }>,
 ): Promise<UserPromptAttachment[]> {

--- a/packages/desktop-host/src/index.ts
+++ b/packages/desktop-host/src/index.ts
@@ -42,6 +42,7 @@ export {
   type LoopbackServer,
   type LoopbackServerOptions,
 } from './loopback-server.js';
+export { installAppAssetProtocol, APP_ASSET_SCHEME } from './apps/assets-protocol.js';
 export {
   DESKTOP_APP_HOST,
   generateSelfSignedCert,

--- a/packages/desktop-host/src/ipc.ts
+++ b/packages/desktop-host/src/ipc.ts
@@ -42,6 +42,8 @@ import { registerProviderLoginHandlers } from './ipc/provider-login';
 import { registerSessionHandlers } from './ipc/session';
 import { registerSessionsHandlers } from './ipc/sessions';
 import { registerWorkspaceFsHandlers } from './ipc/workspace-fs';
+import { registerAppsHandlers } from './ipc/apps';
+import { registerAnonymizerHandlers } from './ipc/anonymizer';
 import { registerGitHandlers } from './ipc/git';
 import { registerSurfaceHandlers } from './ipc/surfaces';
 import { registerDesksHandlers } from './ipc/desks';
@@ -81,6 +83,8 @@ export function registerIpcHandlers(
     registerSessionHandlers(pool);
     registerSessionsHandlers(pool, desks);
     registerWorkspaceFsHandlers(desks);
+    registerAppsHandlers();
+    registerAnonymizerHandlers(pool, desks);
     registerGitHandlers(desks);
     registerSurfaceHandlers(pool);
     registerDesksHandlers(pool, desks);

--- a/packages/desktop-host/src/ipc/anonymizer.ts
+++ b/packages/desktop-host/src/ipc/anonymizer.ts
@@ -1,0 +1,106 @@
+/**
+ * Offline document anonymizer — MAIN-process file I/O for the gallery app.
+ *
+ * The anonymizer redacts PII from a document entirely on-device: the renderer's
+ * NER worker runs a locally installed model (downloaded once via `apps.install`,
+ * served over `moxxy-app://`). These handlers are the only main-process surface
+ * it needs:
+ *
+ *   - `anonymizer.pickDocument`  — native open dialog (remembers the pick so the
+ *     follow-up parse is authorized).
+ *   - `anonymizer.parseDocument` — read + extract text from the picked/workspace
+ *     file. NO provider, NO runner, NO network — only readFile + officeparser
+ *     (see {@link parseFileToText}). Provenance-gated before any byte is read.
+ *   - `anonymizer.saveRedacted`  — write the redacted text to a user-chosen path
+ *     (save dialog only; never auto-writes anywhere).
+ */
+
+import { basename } from 'node:path';
+import { writeFile } from 'node:fs/promises';
+
+import { dialog, BrowserWindow as BrowserWindowApi } from 'electron';
+
+import type { RunnerPool } from '../runner-pool';
+import type { DeskStore } from '../desks';
+import { authorizeAttachments, rememberPickedAttachment } from '../attachment-authz';
+import { parseFileToText } from '../attachments.js';
+import { handle } from './shared';
+
+/** Document extensions the anonymizer can parse. Mirrors the picker filter and
+ *  {@link parseFileToText}'s capabilities. */
+const DOCUMENT_EXTENSIONS = [
+  'pdf', 'docx', 'xlsx', 'pptx', 'odt', 'ods', 'odp',
+  'txt', 'md', 'markdown', 'csv', 'tsv', 'json', 'log', 'rtf', 'html', 'xml',
+];
+
+/**
+ * Collect every workspace cwd the user could legitimately have selected a file
+ * from: each open workspace's runner cwd plus the active desk's cwd. A file
+ * under any of these — or one the picker handed out — is authorized to read.
+ */
+async function authorizedCwds(pool: RunnerPool, desks: DeskStore): Promise<string[]> {
+  const cwds = new Set<string>();
+  for (const { supervisor } of pool.list()) {
+    const cwd = supervisor.getCwd();
+    if (cwd) cwds.add(cwd);
+  }
+  try {
+    const active = await desks.getActive();
+    if (active?.cwd) cwds.add(active.cwd);
+  } catch {
+    /* desks unreadable — fall through with whatever the pool gave us */
+  }
+  return [...cwds];
+}
+
+export function registerAnonymizerHandlers(pool: RunnerPool, desks: DeskStore): void {
+  handle('anonymizer.pickDocument', async () => {
+    const window = BrowserWindowApi.getFocusedWindow() ?? BrowserWindowApi.getAllWindows()[0];
+    const opts: Electron.OpenDialogOptions = {
+      title: 'Pick a document to anonymize',
+      properties: ['openFile'],
+      filters: [
+        { name: 'Documents', extensions: DOCUMENT_EXTENSIONS },
+        { name: 'All files', extensions: ['*'] },
+      ],
+    };
+    const result = window
+      ? await dialog.showOpenDialog(window, opts)
+      : await dialog.showOpenDialog(opts);
+    if (result.canceled || result.filePaths.length === 0) return null;
+    const picked = result.filePaths[0]!;
+    // Remember the choice so the follow-up parseDocument is authorized even
+    // though the file lives outside any workspace cwd.
+    await rememberPickedAttachment(picked);
+    return picked;
+  });
+
+  handle('anonymizer.parseDocument', async ({ path }) => {
+    // Provenance gate (same as session.runTurn): only a user-picked path or a
+    // path under an open workspace cwd may be read, so a compromised renderer
+    // can't read arbitrary files by feeding parseDocument a path.
+    const cwds = await authorizedCwds(pool, desks);
+    const { authorized } = await authorizeAttachments([{ path, name: basename(path) }], cwds);
+    if (authorized.length === 0) {
+      return { error: "This file isn't authorized to read. Pick it via the document picker." };
+    }
+    // No provider, no runner, no network — just readFile + officeparser.
+    const text = await parseFileToText(path);
+    return text ? { text } : { error: 'Could not extract text from this document.' };
+  });
+
+  handle('anonymizer.saveRedacted', async ({ suggestedName, content }) => {
+    const window = BrowserWindowApi.getFocusedWindow() ?? BrowserWindowApi.getAllWindows()[0];
+    const opts: Electron.SaveDialogOptions = {
+      title: 'Save redacted document',
+      defaultPath: suggestedName,
+    };
+    const result = window
+      ? await dialog.showSaveDialog(window, opts)
+      : await dialog.showSaveDialog(opts);
+    if (result.canceled || !result.filePath) return null;
+    // Write ONLY to the user-chosen path — no auto-write anywhere else.
+    await writeFile(result.filePath, content, 'utf8');
+    return result.filePath;
+  });
+}

--- a/packages/desktop-host/src/ipc/apps.ts
+++ b/packages/desktop-host/src/ipc/apps.ts
@@ -1,0 +1,77 @@
+/**
+ * Apps-gallery install lifecycle IPC.
+ *
+ * Some apps need a one-time local asset download before first use (the document
+ * anonymizer's on-device NER model). These handlers drive that: status, install
+ * (streaming `apps.install.progress` so the gallery shows a bar), and uninstall.
+ * The actual download + verify + containment lives in {@link ../apps/installer}
+ * (electron-free, unit-tested); this module is the thin IPC + Electron glue.
+ *
+ * The fetch in `apps.install` is the ONLY network the anonymizer ever touches,
+ * it runs here in the MAIN process, and it's gated behind an explicit Install
+ * click. Assets land under `userData/moxxy-apps/<appId>/` and are served back to
+ * the renderer over the confined `moxxy-app://` scheme — no use-time egress.
+ */
+
+import { app, BrowserWindow } from 'electron';
+
+import type { AppInstallProgress, AppInstallStatus } from '@moxxy/desktop-ipc-contract';
+import { sendEvent } from '../send-event';
+import { wsEventBus } from '../event-bus';
+import { appStatus, installApp, uninstallApp } from '../apps/installer.js';
+import { APP_INSTALLERS } from '../apps/registry.js';
+import { handle, IpcError } from './shared';
+
+/** Root for every app's installed assets: `userData/moxxy-apps`. */
+function appsRoot(): string {
+  return `${app.getPath('userData')}/moxxy-apps`;
+}
+
+/**
+ * Push an `apps.install.progress` event both to the focused renderer window
+ * (Electron path) AND to any WS-bridge sinks — mirrors the dual-emit
+ * `update.ts` uses for `app.update.progress`. No-op without a window / bridge.
+ */
+function broadcastProgress(p: AppInstallProgress): void {
+  const target = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0] ?? null;
+  if (target) sendEvent(target, 'apps.install.progress', p);
+  wsEventBus.broadcast('apps.install.progress', p);
+}
+
+/** Ids whose install is in flight — a re-entrant `apps.install` for the same
+ *  app no-ops (returns current status) instead of racing two downloaders. */
+const installing = new Set<string>();
+
+export function registerAppsHandlers(): void {
+  handle('apps.status', async ({ appId }) => {
+    const spec = APP_INSTALLERS[appId];
+    // Unknown ids have no installable assets — report not-installed gracefully
+    // rather than throwing (status is only meaningfully called for installable
+    // apps, but a stale renderer id must not error).
+    if (!spec) return { appId, state: 'not-installed' };
+    return appStatus(spec, appsRoot());
+  });
+
+  handle('apps.install', async ({ appId }) => {
+    const spec = APP_INSTALLERS[appId];
+    if (!spec) throw new IpcError('not-supported', `no installer for app: ${appId}`);
+    const root = appsRoot();
+    // Concurrency guard: a second click while a download runs returns the live
+    // status (already 'installing' from the renderer's view) instead of
+    // spawning a competing installer.
+    if (installing.has(appId)) {
+      const current = await appStatus(spec, root);
+      return current.state === 'installed'
+        ? current
+        : ({ appId, state: 'installing' } satisfies AppInstallStatus);
+    }
+    installing.add(appId);
+    try {
+      return await installApp(spec, root, broadcastProgress);
+    } finally {
+      installing.delete(appId);
+    }
+  });
+
+  handle('apps.uninstall', async ({ appId }) => uninstallApp(appId, appsRoot()));
+}

--- a/packages/desktop-host/src/security.ts
+++ b/packages/desktop-host/src/security.ts
@@ -342,23 +342,36 @@ export function clerkCspHostSources(publishableKey?: string | null): string[] {
  * Clerk-compatible CSP for the packaged app. Scripts stay strict
  * (`'self'` + the Clerk/Cloudflare-Turnstile origins clerk-js needs —
  * no `'unsafe-inline'`/`'unsafe-eval'` because the bundle ships only
- * external module scripts). Styles allow `'unsafe-inline'` because the
- * UI uses inline style objects + the splash `<style>` block + Google
- * Fonts. `extraClerkHosts` are the prod Frontend API sources derived from
- * the publishable key (see {@link clerkCspHostSources}); empty for test keys.
+ * external module scripts). `'wasm-unsafe-eval'` is the ONE narrow
+ * exception: it permits WebAssembly compilation (and nothing else — it does
+ * NOT re-enable `eval`/`new Function`), which onnxruntime-web needs to run the
+ * anonymizer's on-device NER model in a worker. Styles allow `'unsafe-inline'`
+ * because the UI uses inline style objects + the splash `<style>` block +
+ * Google Fonts. `extraClerkHosts` are the prod Frontend API sources derived
+ * from the publishable key (see {@link clerkCspHostSources}); empty for test
+ * keys.
+ *
+ * `connect-src` additionally allows the `moxxy-app:` scheme: the anonymizer's
+ * renderer worker fetches its locally installed model files over
+ * `moxxy-app://assets/<appId>/...`. That scheme is served by a confined,
+ * GET/HEAD-only handler that reads files under `userData/moxxy-apps` and reaches
+ * NO network host (see {@link ../apps/assets-protocol.ts}) — so it enables zero
+ * network egress and the anonymizer's offline guarantee at use time still holds.
+ * It is deliberately NOT a real http(s) host: `connect-src` is not widened.
  */
 function buildCspDirectives(extraClerkHosts: readonly string[]): string {
   const extra = extraClerkHosts.length ? ` ${extraClerkHosts.join(' ')}` : '';
   return [
     "default-src 'self'",
-    `script-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com${extra}`,
+    `script-src 'self' 'wasm-unsafe-eval' https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com${extra}`,
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     `img-src 'self' data: blob: https://img.clerk.com https://*.clerk.com${extra}`,
     "font-src 'self' data: https://fonts.gstatic.com",
     // challenges.cloudflare.com: Clerk's bot-protection (Turnstile) runs on
     // sign-up — Clerk's documented CSP needs it in connect-src too, not just
     // script/frame-src, or the captcha can fail and sign-up dead-ends.
-    `connect-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com${extra}`,
+    // moxxy-app:: the anonymizer worker's local-only model fetches (above).
+    `connect-src 'self' moxxy-app: https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com${extra}`,
     "worker-src 'self' blob:",
     `frame-src https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com${extra}`,
     "object-src 'none'",

--- a/packages/desktop-ipc-contract/src/apps.ts
+++ b/packages/desktop-ipc-contract/src/apps.ts
@@ -1,0 +1,37 @@
+// ---------- Desktop "apps" gallery: install lifecycle + anonymizer ----------
+//
+// Desktop apps are self-contained mini-applications shown in the Apps gallery.
+// Some need local assets before first use (the document anonymizer downloads an
+// on-device NER model). That fetch is the ONLY time the network is touched, it
+// runs in the MAIN process, and it's gated behind an explicit "Install" click —
+// at use time everything is local, so the app's offline guarantee holds.
+
+/** Lifecycle of an installable app's local assets. */
+export type AppInstallState = 'not-installed' | 'installing' | 'installed' | 'error';
+
+export interface AppInstallStatus {
+  readonly appId: string;
+  readonly state: AppInstallState;
+  /** Version marker of the installed assets (from the app's `installed.json`). */
+  readonly version?: string;
+  /** Set when `state === 'error'`. */
+  readonly error?: string;
+  /** Best-effort progress, present while `state === 'installing'`. */
+  readonly receivedBytes?: number;
+  readonly totalBytes?: number;
+}
+
+/** Streamed during `apps.install` so the gallery can show a progress bar. */
+export interface AppInstallProgress {
+  readonly appId: string;
+  readonly phase: 'downloading' | 'verifying' | 'done' | 'error';
+  readonly receivedBytes: number;
+  readonly totalBytes: number;
+  /** The file currently downloading (relative path), when known. */
+  readonly file?: string;
+  readonly error?: string;
+}
+
+/** Result of parsing a picked/workspace document to plain text. A discriminated
+ *  union so a parse failure is data, not a thrown IPC error. */
+export type AnonymizerParseResult = { readonly text: string } | { readonly error: string };

--- a/packages/desktop-ipc-contract/src/commands.ts
+++ b/packages/desktop-ipc-contract/src/commands.ts
@@ -33,6 +33,7 @@ import type {
   AppUpdateDiagnostics,
 } from './app-update.js';
 import type { DeepLinkPayload } from './deep-link.js';
+import type { AppInstallStatus, AnonymizerParseResult } from './apps.js';
 
 // ---------- Invokable commands (renderer → main) --------------------------
 
@@ -383,6 +384,35 @@ export interface IpcCommands {
    * run result. Throws a coded error when the host predates the resume path.
    */
   'workflows.resume': (args: { runId: string; reply: string }) => Promise<WorkflowRun>;
+
+  // ---- Desktop apps gallery (install lifecycle) ------------------------
+  // All host-only (native pickers + filesystem + a network download). They are
+  // deliberately NOT in REMOTE_ALLOWED_COMMANDS — a paired phone can't trigger
+  // a desktop download or read/write local files.
+  /** Current install state of an app's local assets. */
+  'apps.status': (args: { appId: string }) => Promise<AppInstallStatus>;
+  /** Download + install an app's local assets (e.g. the anonymizer's NER
+   *  model). Streams `apps.install.progress`; resolves with the final status. */
+  'apps.install': (args: { appId: string }) => Promise<AppInstallStatus>;
+  /** Remove an app's installed local assets. */
+  'apps.uninstall': (args: { appId: string }) => Promise<AppInstallStatus>;
+
+  // ---- Document anonymizer (offline; the first app) --------------------
+  /** Open a native picker scoped to anonymizable documents; returns the
+   *  absolute path (remembered for authz) or null if cancelled. */
+  'anonymizer.pickDocument': () => Promise<string | null>;
+  /** Parse a user-picked / workspace document to plain text in main (reusing
+   *  the attachment officeparser pipeline) so the renderer can redact it
+   *  locally. The file is read ONLY if its provenance is authorized (picked or
+   *  under a workspace cwd). No provider, no runner, no network. */
+  'anonymizer.parseDocument': (args: { path: string }) => Promise<AnonymizerParseResult>;
+  /** Save renderer-produced redacted text to a user-chosen location via a
+   *  native Save dialog. Main writes ONLY where the user pointed; returns the
+   *  path or null if cancelled. */
+  'anonymizer.saveRedacted': (args: {
+    suggestedName: string;
+    content: string;
+  }) => Promise<string | null>;
 
   // Settings
   // Desktop preferences (separate from runner preferences).

--- a/packages/desktop-ipc-contract/src/events.ts
+++ b/packages/desktop-ipc-contract/src/events.ts
@@ -5,6 +5,7 @@ import type { ConnectionPhase } from './connection.js';
 import type { AppUpdateProgress } from './app-update.js';
 import type { DeepLinkPayload } from './deep-link.js';
 import type { MobileGatewayStatus } from './mobile.js';
+import type { AppInstallProgress } from './apps.js';
 
 // ---------- Events the renderer subscribes to ------------------------------
 
@@ -66,4 +67,7 @@ export interface IpcEvents {
    *  matching pane by `data.surfaceId` and ignores frames for panes it isn't
    *  showing. Forwarded verbatim from the runner's `surface.data`. */
   'surface.data': { workspaceId: string; data: SurfaceDataMessage };
+  /** Streamed during `apps.install` — one event per download/verify step so the
+   *  Apps gallery can show a progress bar while an app's assets download. */
+  'apps.install.progress': AppInstallProgress;
 }

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -91,6 +91,14 @@ export type {
 // ---------- Deep links (moxxy:// URLs) -------------------------------------
 export type { DeepLinkPayload } from './deep-link.js';
 
+// ---------- Desktop apps gallery (install lifecycle + anonymizer) ----------
+export type {
+  AppInstallState,
+  AppInstallStatus,
+  AppInstallProgress,
+  AnonymizerParseResult,
+} from './apps.js';
+
 // ---------- Events the renderer subscribes to ------------------------------
 export type { IpcEvents } from './events.js';
 

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -65,6 +65,11 @@ const commandName = z
   .max(64)
   .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/, 'invalid command name');
 
+/** Desktop-app id — a registry slug keying both the renderer app registry and
+ *  the main installer/asset directory (`userData/moxxy-apps/<appId>`), so it
+ *  must never traverse: lowercase letters/digits/hyphen only. */
+const appId = z.string().min(1).max(64).regex(/^[a-z][a-z0-9-]*$/, 'invalid app id');
+
 /** Workflow names come from workflow filenames — bounded, no traversal. */
 const workflowName = z
   .string()
@@ -190,6 +195,20 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
   'settings.writeSkill': z.object({ name: skillName, body: z.string().max(1_000_000) }),
   'settings.readSkill': z.object({ name: skillName }),
   'settings.deleteSkill': z.object({ name: skillName }),
+  // Desktop apps: appId keys the per-app install dir + a network download, so
+  // pin it to a non-traversing slug. (pickDocument is no-arg → see below.)
+  'apps.status': z.object({ appId }),
+  'apps.install': z.object({ appId }),
+  'apps.uninstall': z.object({ appId }),
+  // Anonymizer: parseDocument reads a file (bound the path), saveRedacted writes
+  // one (bound name + cap content so a renderer can't OOM main). pickDocument
+  // takes nothing — pin it to "nothing" so no args can be smuggled across.
+  'anonymizer.pickDocument': z.undefined(),
+  'anonymizer.parseDocument': z.object({ path: z.string().min(1).max(4096) }),
+  'anonymizer.saveRedacted': z.object({
+    suggestedName: z.string().min(1).max(255),
+    content: z.string().max(20_000_000),
+  }),
   'desks.create': z.object({ name: z.string().min(1).max(200), cwd: z.string().min(1).max(4096) }),
   // Mirror desks.create's name bounds — rename writes the name into the desks
   // JSON, so an unbounded string would let a renderer bloat the state file.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,12 @@ importers:
       '@clerk/themes':
         specifier: ^2.4.57
         version: 2.4.57(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@huggingface/transformers':
+        specifier: ^3.8.1
+        version: 3.8.1
+      '@moxxy/anonymizer':
+        specifier: workspace:*
+        version: link:../../packages/anonymizer
       '@moxxy/chat-model':
         specifier: workspace:*
         version: link:../../packages/chat-model
@@ -324,6 +330,24 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+
+  packages/anonymizer:
+    devDependencies:
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
 
   packages/cache-strategy-stable-prefix:
     dependencies:


### PR DESCRIPTION
## What

Adds an **Apps** section (a new top-level header tab next to Chat / Workflows) — a registry-backed gallery of self-contained mini-applications — and ships an **offline document anonymizer** as the first app.

Apps that need local assets show a predefined **Install** step that downloads everything they need before first use. Install is the only time the network is touched, runs in the main process, and is gated behind an explicit click — so this doubles as a general, extensible "apps" plugin mechanism for the desktop.

## The anonymizer

Paste text or open a document (PDF / Office / text, parsed locally via the existing officeparser pipeline) and it detects + redacts PII:

- **Structured detectors** (high precision, validator-backed): emails, phone numbers, credit cards (Luhn), SSNs, IPv4/IPv6, MACs, IBANs (mod-97), URLs, dates.
- **Custom terms** — a box for names/addresses/company to always redact.
- **On-device NER** (`Xenova/bert-base-NER`, ~109 MB, downloaded on install via transformers.js wasm) for names, organizations and locations.
- Styles: labeled `[EMAIL]` (default), consistent pseudonyms, or short hashes.

## Documents never leave the machine

- Redaction runs **entirely in the renderer** with the new pure `@moxxy/anonymizer` engine (zero dependencies, network-free — enforced by `offline.test.ts`). Opening a file only reads bytes in main and returns text.
- The analyze path touches **no provider, runner, or network**.
- CSP change is minimal and narrows nothing: `+'wasm-unsafe-eval'` (wasm compile) and `+moxxy-app:` (a local-only, realpath-confined GET/HEAD scheme over `userData/moxxy-apps`). `connect-src` still excludes all real network — the NER model is served from `moxxy-app://`, never the CDN at use time.
- File reads are provenance-gated (picked or workspace cwd only); saves go only to a user-chosen dialog path; the new IPC is **host-only** (kept out of `REMOTE_ALLOWED_COMMANDS`).

## Structure

- `packages/anonymizer` — new pure PII detection + redaction engine (30 unit tests incl. the offline guarantee).
- `packages/desktop-host/src/apps` — generic installer + hardened `moxxy-app://` asset scheme (22 unit tests: containment, escape, version/sha mismatch).
- `packages/desktop-ipc-contract` — `apps.*` install + `anonymizer.*` document commands (host-only) + validation.
- `apps/desktop/src/apps` — Apps registry + gallery + anonymizer UI + wasm NER worker (BIO aggregation unit-tested).
- ORT wasm runtime (~21 MB) is bundled by Vite from `'self'`; only the model is install-downloaded.

## Verification

- ✅ Gate green: build, typecheck, lint (0 errors), test, `check:deps`.
- ⚠️ The 109 MB model download + live wasm inference over `moxxy-app://` can only be confirmed in a packaged/dev Electron run (no model is exercised in CI) — logged in `TECH_DEBT.md`. NER degrades gracefully: structured redaction always works; the toggle shows "unavailable" if the model can't load.