### PR TITLE
feat(collaborative): launch from the Collaborate tab; one collaboration at a time

### DIFF
--- a/.changeset/collab-tab-launch.md
+++ b/.changeset/collab-tab-launch.md
@@ -1,0 +1,27 @@
+---
+"@moxxy/mode-collaborative": minor
+"@moxxy/chat-model": patch
+"@moxxy/desktop-ipc-contract": minor
+"@moxxy/desktop-host": minor
+"@moxxy/desktop": minor
+"@moxxy/plugin-cli": minor
+---
+
+feat(collaborative): launch collaborations from the Collaborate tab; one at a time
+
+Collaboration is no longer started as a chat mode (any chat in a workspace could
+have kicked one off, clobbering the same repo's worktrees). It is launched from
+the Collaborate tab, and only ONE runs at a time across the app to save
+resources.
+
+- **Global single-flight lock** (`~/.moxxy/collab/active.lock`, cross-process,
+  with dead-pid reclaim): the coordinator acquires it before a run and refuses a
+  second with a clear message; released in `finally`.
+- **Collaborate tab Start composer** — type a goal → it sets the active
+  workspace's session to collaborative mode and runs it; a `＋ New` affordance
+  after a run finishes. A new read-only `collab.active` IPC lets the tab disable
+  Start (with a notice) while a collaboration runs in any workspace.
+- **Removed from the chat mode pickers** — `collaborative` and the internal
+  `collab-architect`/`collab-peer` modes no longer appear in the desktop
+  AgentPicker or the TUI `/mode` picker; `/mode collab*` points to `/collab`.
+- chat-model: a refused start no longer leaves an empty collaboration block.

--- a/apps/desktop/src/chat/agent-picker/AgentPicker.tsx
+++ b/apps/desktop/src/chat/agent-picker/AgentPicker.tsx
@@ -24,6 +24,14 @@ import { ChipSelect } from './ChipSelect';
 import { ProviderModelPicker } from './ProviderModelPicker';
 import { SESSION_INFO_REFRESH_EVENT, type SessionInfo } from './types';
 
+/** Modes hidden from the chat mode chip — collaboration is launched from the
+ *  Collaborate tab (single-flight), and its peer modes are internal. */
+const COLLAB_MODES: ReadonlySet<string> = new Set([
+  'collaborative',
+  'collab-architect',
+  'collab-peer',
+]);
+
 export function AgentPicker({
   workspaceId,
   disabled,
@@ -115,7 +123,9 @@ export function AgentPicker({
       <ChipSelect
         label="Mode"
         value={info.activeMode ?? ''}
-        options={[...info.modes]}
+        // Collaboration is launched from the Collaborate tab (one at a time),
+        // not as a chat mode — hide collaborative + its internal peer modes.
+        options={info.modes.filter((m) => !COLLAB_MODES.has(m))}
         badge={info.activeModeBadge}
         disabled={disabled || info.modes.length === 0}
         onChange={(v) => void onMode(v)}

--- a/apps/desktop/src/collaborate/CollaboratePanel.tsx
+++ b/apps/desktop/src/collaborate/CollaboratePanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { api, useChat } from '@moxxy/client-core';
 import { pairToolEvents, type Block, type CollaborationBlock } from '@moxxy/chat-model';
 import { Icon } from '@moxxy/desktop-ui';
@@ -57,9 +57,54 @@ export function CollaboratePanel({
   const [channel, setChannel] = useState<string>('all');
   const [text, setText] = useState('');
   const [directive, setDirective] = useState(false);
+  const [goal, setGoal] = useState('');
+  const [starting, setStarting] = useState(false);
+  const [forceStart, setForceStart] = useState(false);
+  const [globalActive, setGlobalActive] = useState<{ active: boolean; task?: string } | null>(null);
+
+  // Poll the global single-flight lock so Start reflects a collaboration running
+  // in ANY workspace (only one runs at a time).
+  useEffect(() => {
+    let alive = true;
+    const poll = (): void => {
+      void api()
+        .invoke('collab.active')
+        .then((r) => {
+          if (alive) setGlobalActive(r);
+        })
+        .catch(() => undefined);
+    };
+    poll();
+    const t = setInterval(poll, 2500);
+    return () => {
+      alive = false;
+      clearInterval(t);
+    };
+  }, [workspaceId]);
 
   const runCmd = async (name: string, args: string): Promise<void> => {
     await api().invoke('session.runCommand', { workspaceId, name, args }).catch(() => undefined);
+  };
+
+  const running = collab != null && collab.completedAtMs === null;
+
+  // Start a collaboration FROM THE TAB (not chat): switch this workspace's
+  // session to collaborative mode and submit the goal as its turn. The global
+  // single-flight lock (runner side) still guarantees only one runs at a time.
+  const startCollaboration = async (): Promise<void> => {
+    const g = goal.trim();
+    if (!g || starting) return;
+    setStarting(true);
+    setGoal('');
+    try {
+      await api().invoke('session.setMode', { workspaceId, mode: 'collaborative' });
+      await api().invoke('session.runTurn', { workspaceId, prompt: g });
+      setForceStart(false);
+    } catch {
+      // surfaced as an error/assistant message in the session log
+    } finally {
+      setStarting(false);
+    }
   };
 
   const send = async (): Promise<void> => {
@@ -102,10 +147,20 @@ export function CollaboratePanel({
             : `done · ${collab.agents.filter((a) => a.status === 'done').length}/${collab.agents.length}`}
         </span>
       )}
+      {collab && !running && !forceStart && (
+        <button
+          type="button"
+          onClick={() => setForceStart(true)}
+          className="btn-chip"
+          style={{ fontSize: 12, padding: '4px 10px', borderRadius: 8, fontWeight: 600 }}
+        >
+          ＋ New
+        </button>
+      )}
     </ViewHeader>
   );
 
-  if (!collab) {
+  if (!collab || forceStart) {
     return (
       <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
         {header}
@@ -116,18 +171,41 @@ export function CollaboratePanel({
             flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
-            gap: 8,
-            color: 'var(--color-text-dim)',
+            gap: 14,
             padding: 24,
             textAlign: 'center',
           }}
         >
           <Icon name="agent" size={28} />
-          <div style={{ fontWeight: 600, color: 'var(--color-text-muted)' }}>No collaboration running</div>
-          <div style={{ fontSize: 13, maxWidth: 420 }}>
-            Go to <strong>Chat</strong>, switch the mode to <strong>collaborative</strong>, and send a task.
-            A team of agents will appear here as they work.
+          <div style={{ fontWeight: 600, color: 'var(--color-text-muted)' }}>Start a collaboration</div>
+          <div style={{ fontSize: 13, maxWidth: 460, color: 'var(--color-text-dim)' }}>
+            Describe a goal and a team of agents — an architect plus implementers — will plan it,
+            propose a roster for you to approve, then build it in parallel. Only one collaboration
+            runs at a time.
           </div>
+          {globalActive?.active && (
+            <div style={{ fontSize: 12.5, color: 'var(--color-amber-text)', maxWidth: 460 }}>
+              A collaboration is already running{globalActive.task ? ` ("${globalActive.task}")` : ''}. Only one
+              runs at a time to save resources — wait for it to finish, then start another.
+            </div>
+          )}
+          <StartComposer
+            goal={goal}
+            setGoal={setGoal}
+            starting={starting}
+            blocked={globalActive?.active ?? false}
+            onStart={() => void startCollaboration()}
+          />
+          {collab && (
+            <button
+              type="button"
+              onClick={() => setForceStart(false)}
+              className="btn-chip"
+              style={{ fontSize: 12, padding: '4px 10px', borderRadius: 8 }}
+            >
+              ← Back to the current team
+            </button>
+          )}
         </div>
       </div>
     );
@@ -364,4 +442,56 @@ function RailRow({ active, onClick, children }: { readonly active: boolean; read
 
 function Empty({ children }: { readonly children: React.ReactNode }): JSX.Element {
   return <div style={{ padding: '4px 12px', fontSize: 12, color: 'var(--color-text-dim)', fontStyle: 'italic' }}>{children}</div>;
+}
+
+function StartComposer({
+  goal,
+  setGoal,
+  starting,
+  blocked,
+  onStart,
+}: {
+  readonly goal: string;
+  readonly setGoal: (v: string) => void;
+  readonly starting: boolean;
+  readonly blocked: boolean;
+  readonly onStart: () => void;
+}): JSX.Element {
+  const disabled = starting || blocked || goal.trim().length === 0;
+  return (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', width: '100%', maxWidth: 560 }}>
+      <textarea
+        value={goal}
+        onChange={(e) => setGoal(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault();
+            if (!disabled) onStart();
+          }
+        }}
+        placeholder="e.g. Add a CSV export feature with tests and docs"
+        rows={2}
+        style={{
+          flex: 1,
+          resize: 'none',
+          padding: '10px 12px',
+          borderRadius: 12,
+          border: '1px solid var(--color-card-border)',
+          background: 'var(--color-input-soft)',
+          fontSize: 13,
+          color: 'var(--color-text)',
+          fontFamily: 'inherit',
+        }}
+      />
+      <button
+        type="button"
+        onClick={onStart}
+        disabled={disabled}
+        className="btn-cta"
+        style={{ padding: '10px 16px', borderRadius: 12, fontWeight: 600, opacity: disabled ? 0.6 : 1 }}
+      >
+        {starting ? 'Starting…' : 'Start'}
+      </button>
+    </div>
+  );
 }

--- a/packages/chat-model/src/pair-events.ts
+++ b/packages/chat-model/src/pair-events.ts
@@ -177,12 +177,11 @@ function handleCollabEvent(
     root.push(block);
     return;
   }
-  let block = ref.current;
-  if (!block) {
-    block = newCollabBlock(e.id, atMs);
-    ref.current = block;
-    root.push(block);
-  }
+  // Only collab_started opens a run. Stray events with no open block — e.g. a
+  // `collab_blocked` from a refused start (its assistant_message carries the
+  // reason) — never create an empty block.
+  const block = ref.current;
+  if (!block) return;
   switch (e.subtype) {
     case 'collab_fallback_sequential':
       block.fallbackReason = String(p.reason ?? '');

--- a/packages/desktop-host/src/ipc/session.ts
+++ b/packages/desktop-host/src/ipc/session.ts
@@ -107,6 +107,32 @@ export function registerSessionHandlers(pool: RunnerPool): void {
     });
     return result;
   });
+  handle('collab.active', async () => {
+    // Read the global single-flight lock the collaborative coordinator writes
+    // (~/.moxxy/collab/active.lock). Read directly here (no runner round-trip)
+    // so the Collaborate tab sees a collaboration running in ANY workspace.
+    try {
+      const { readFileSync } = await import('node:fs');
+      const { homedir } = await import('node:os');
+      const { join } = await import('node:path');
+      const lockPath = process.env.MOXXY_COLLAB_LOCK || join(homedir(), '.moxxy', 'collab', 'active.lock');
+      const info = JSON.parse(readFileSync(lockPath, 'utf8')) as {
+        pid: number;
+        sessionId: string;
+        task: string;
+        startedAtMs: number;
+      };
+      // Liveness: a dead holder pid means the lock is stale → not active.
+      try {
+        process.kill(info.pid, 0);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'EPERM') return { active: false };
+      }
+      return { active: true, sessionId: info.sessionId, task: info.task, startedAtMs: info.startedAtMs };
+    } catch {
+      return { active: false };
+    }
+  });
   handle('session.hasTranscriber', async () => {
     // Voice is wired through the desktop's *in-process* Codex
     // transcriber (mirrors the TUI's self-host setup: same vault,

--- a/packages/desktop-ipc-contract/src/commands.ts
+++ b/packages/desktop-ipc-contract/src/commands.ts
@@ -237,6 +237,15 @@ export interface IpcCommands {
   /** True when the runner has an active transcriber plugin. UI uses
    *  this to enable/disable the mic button. */
   'session.hasTranscriber': () => Promise<boolean>;
+  /** The globally-active collaboration (only one runs at a time), or inactive.
+   *  Read from the single-flight lock file so it spans all workspaces' runners;
+   *  the Collaborate tab uses it to disable Start while one is running. */
+  'collab.active': () => Promise<{
+    readonly active: boolean;
+    readonly sessionId?: string;
+    readonly task?: string;
+    readonly startedAtMs?: number;
+  }>;
   /** Forward an audio blob to the runner's active transcriber.
    *  Audio must be base64-encoded; returns the recognised text. */
   'session.transcribe': (args: {

--- a/packages/mode-collaborative/src/collab-lock.test.ts
+++ b/packages/mode-collaborative/src/collab-lock.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readActiveCollab, releaseCollabLock, tryAcquireCollabLock } from './collab-lock.js';
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'mc-lock-'));
+  process.env.MOXXY_COLLAB_LOCK = join(dir, 'active.lock');
+});
+afterEach(() => {
+  delete process.env.MOXXY_COLLAB_LOCK;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('collab single-flight lock', () => {
+  it('grants the lock when free and reports the holder to others', () => {
+    expect(readActiveCollab()).toBeNull();
+    expect(tryAcquireCollabLock({ sessionId: 'A', task: 'build X', startedAtMs: 1 }).ok).toBe(true);
+
+    const second = tryAcquireCollabLock({ sessionId: 'B', task: 'build Y', startedAtMs: 2 });
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.holder.task).toBe('build X');
+
+    // the same session re-acquiring is idempotent
+    expect(tryAcquireCollabLock({ sessionId: 'A', task: 'build X', startedAtMs: 3 }).ok).toBe(true);
+  });
+
+  it('releases only when the holding session releases', () => {
+    tryAcquireCollabLock({ sessionId: 'A', task: 't', startedAtMs: 1 });
+    releaseCollabLock('B'); // not the holder — no-op
+    expect(readActiveCollab()?.sessionId).toBe('A');
+    releaseCollabLock('A');
+    expect(readActiveCollab()).toBeNull();
+    // now free for another session
+    expect(tryAcquireCollabLock({ sessionId: 'B', task: 't2', startedAtMs: 2 }).ok).toBe(true);
+  });
+
+  it('reclaims a stale lock whose process is dead', () => {
+    // A lock owned by a definitely-dead pid is reclaimed on read.
+    writeFileSync(
+      process.env.MOXXY_COLLAB_LOCK!,
+      JSON.stringify({ pid: 2147483646, sessionId: 'ghost', task: 'old', startedAtMs: 1 }),
+    );
+    expect(readActiveCollab()).toBeNull();
+    expect(tryAcquireCollabLock({ sessionId: 'A', task: 'fresh', startedAtMs: 2 }).ok).toBe(true);
+  });
+});

--- a/packages/mode-collaborative/src/collab-lock.ts
+++ b/packages/mode-collaborative/src/collab-lock.ts
@@ -1,0 +1,90 @@
+/**
+ * Global single-flight lock for collaborations. Only ONE collaboration may run
+ * at a time across the whole machine (each spawns a fleet of agent processes —
+ * running several would thrash resources and contend for the same repo's
+ * worktrees). The lock is a small JSON file at ~/.moxxy/collab/active.lock so it
+ * works across the separate runner processes the desktop spawns per workspace.
+ *
+ * Staleness: the lock records the holding runner's pid; if that process is gone
+ * (a crash) the lock is reclaimed automatically on the next attempt.
+ */
+
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+export const COLLAB_LOCK_PATH = join(homedir(), '.moxxy', 'collab', 'active.lock');
+
+/** Resolve the lock path; `MOXXY_COLLAB_LOCK` overrides it (tests, multi-tenant). */
+export function collabLockPath(): string {
+  return process.env.MOXXY_COLLAB_LOCK || COLLAB_LOCK_PATH;
+}
+
+export interface CollabLockInfo {
+  readonly pid: number;
+  readonly sessionId: string;
+  readonly task: string;
+  readonly startedAtMs: number;
+}
+
+function readRaw(): CollabLockInfo | null {
+  try {
+    return JSON.parse(readFileSync(collabLockPath(), 'utf8')) as CollabLockInfo;
+  } catch {
+    return null;
+  }
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM = exists but not ours to signal (still alive); ESRCH = gone.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/** The currently-active collaboration, or null. Reclaims a stale (dead-pid) lock. */
+export function readActiveCollab(): CollabLockInfo | null {
+  const info = readRaw();
+  if (!info) return null;
+  if (!isAlive(info.pid)) {
+    try {
+      unlinkSync(collabLockPath());
+    } catch {
+      // already gone / racing another reclaimer
+    }
+    return null;
+  }
+  return info;
+}
+
+/** Acquire the global lock, or report the live holder. The same session
+ *  re-acquiring (idempotent) is allowed. */
+export function tryAcquireCollabLock(args: {
+  sessionId: string;
+  task: string;
+  startedAtMs: number;
+}): { ok: true } | { ok: false; holder: CollabLockInfo } {
+  mkdirSync(dirname(collabLockPath()), { recursive: true });
+  const existing = readActiveCollab();
+  if (existing && existing.sessionId !== args.sessionId) {
+    return { ok: false, holder: existing };
+  }
+  const info: CollabLockInfo = { pid: process.pid, ...args };
+  writeFileSync(collabLockPath(), JSON.stringify(info));
+  return { ok: true };
+}
+
+/** Release the lock if (and only if) this session holds it. */
+export function releaseCollabLock(sessionId: string): void {
+  const info = readRaw();
+  if (info && info.sessionId === sessionId) {
+    try {
+      unlinkSync(collabLockPath());
+    } catch {
+      // already gone
+    }
+  }
+}

--- a/packages/mode-collaborative/src/collab-loop.test.ts
+++ b/packages/mode-collaborative/src/collab-loop.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -11,6 +11,18 @@ import { git } from './worktrees.js';
 
 const IDENT = ['-c', 'user.name=t', '-c', 'user.email=t@t'];
 const cleanups: Array<() => void> = [];
+
+beforeEach(() => {
+  // Isolate the global single-flight lock to a temp file so the e2e runs never
+  // touch (or get blocked by) a real ~/.moxxy collaboration lock.
+  const lockDir = mkdtempSync(join(tmpdir(), 'mc-loop-lock-'));
+  process.env.MOXXY_COLLAB_LOCK = join(lockDir, 'active.lock');
+  cleanups.push(() => {
+    delete process.env.MOXXY_COLLAB_LOCK;
+    rmSync(lockDir, { recursive: true, force: true });
+  });
+});
+
 afterEach(() => {
   for (const fn of cleanups.splice(0)) fn();
 });

--- a/packages/mode-collaborative/src/collab-loop.ts
+++ b/packages/mode-collaborative/src/collab-loop.ts
@@ -42,6 +42,7 @@ import {
 } from './worktrees.js';
 import { PeerSupervisor, type PeerSupervisorOptions, type Supervisor } from './peer-supervisor.js';
 import { integrate } from './integrate.js';
+import { releaseCollabLock, tryAcquireCollabLock } from './collab-lock.js';
 import type { CollaborationHub } from '@moxxy/plugin-collab';
 
 const POLL_MS = 500;
@@ -73,8 +74,27 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
     return;
   }
 
+  // Global single-flight: only one collaboration runs at a time (each spawns a
+  // fleet of agent processes). Refuse rather than thrash resources.
+  const lock = tryAcquireCollabLock({ sessionId: String(ctx.sessionId), task, startedAtMs: Date.now() });
+  if (!lock.ok) {
+    yield await ctx.emit(plugin(ctx, 'collab_blocked', { reason: 'already-running', holderTask: lock.holder.task }));
+    yield await ctx.emit(
+      assistant(
+        ctx,
+        `A collaboration is already running ("${lock.holder.task}"). Only one runs at a time to save resources — stop it first, then start again.`,
+      ),
+    );
+    return;
+  }
+
   const runId = collabRunId(String(ctx.sessionId), String(ctx.turnId));
-  mkdirSync(collabRunDir(runId), { recursive: true });
+  const worktrees = new Map<string, string>();
+  let hub: CollaborationHub | null = null;
+  let supervisor: Supervisor | null = null;
+  let unsubscribe: (() => void) | null = null;
+  try {
+    mkdirSync(collabRunDir(runId), { recursive: true });
 
   const { installed: gitInstalled, repo: gitRepo } = await detectGit(cwd);
   const parallel = cfg.concurrency === 'parallel' && gitRepo;
@@ -97,7 +117,6 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
     baseSha = base.baseSha;
   }
 
-  const worktrees = new Map<string, string>();
   const architectEntry: RosterEntry = {
     id: ARCHITECT_AGENT_ID,
     name: 'Architect',
@@ -105,14 +124,14 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
     subtask: task,
   };
 
-  const hub = await createCollaborationHub({
+  hub = await createCollaborationHub({
     socketPath: hubSocketPath(runId),
     task,
     roster: [architectEntry],
     peerReader: peerReaderFor(worktrees, baseSha),
   });
   registerActiveHub(String(ctx.sessionId), hub);
-  const unsubscribe = hub.subscribe((e) => {
+  unsubscribe = hub.subscribe((e) => {
     void ctx.emit(toCollabEvent(ctx, e));
   });
 
@@ -124,9 +143,8 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
     ...(cfg.defaultModel ? { defaultModel: cfg.defaultModel } : {}),
     signal: ctx.signal,
   };
-  const supervisor = (deps.createSupervisor ?? ((o) => new PeerSupervisor(o)))(supervisorOpts, hub);
+  supervisor = (deps.createSupervisor ?? ((o) => new PeerSupervisor(o)))(supervisorOpts, hub);
 
-  try {
     yield await ctx.emit(plugin(ctx, 'collab_started', { task, parallel, gitInstalled, gitRepo }));
 
     // --- Phase 0: architect designs the plan + contracts (runs in cwd) ---
@@ -244,10 +262,11 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
     );
     yield await ctx.emit(plugin(ctx, 'collab_completed', { done: doneIds, total: roster.length }));
   } finally {
-    await supervisor.shutdownAll('collaboration complete');
-    unsubscribe();
+    if (supervisor) await supervisor.shutdownAll('collaboration complete');
+    if (unsubscribe) unsubscribe();
     unregisterActiveHub(String(ctx.sessionId));
-    await hub.close();
+    if (hub) await hub.close();
+    releaseCollabLock(String(ctx.sessionId));
   }
 }
 

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -449,8 +449,16 @@ function startCollab(deps: SlashDeps, arg: string): void {
   if (objective) deps.submitPrompt(objective);
 }
 
+// Collaboration is launched via `/collab <goal>` (single-flight), not the mode
+// picker; its peer modes are internal. Hidden from `/mode`.
+const COLLAB_HIDDEN_MODES: ReadonlySet<string> = new Set([
+  'collaborative',
+  'collab-architect',
+  'collab-peer',
+]);
+
 function openModePicker(deps: SlashDeps, arg = ''): void {
-  const modes = deps.session.modes.list();
+  const modes = deps.session.modes.list().filter((m) => !COLLAB_HIDDEN_MODES.has(m.name));
   if (modes.length === 0) {
     deps.setSystemNotice('no modes registered');
     return;
@@ -459,6 +467,10 @@ function openModePicker(deps: SlashDeps, arg = ''): void {
   // otherwise (no arg, or no match) fall back to the interactive picker.
   const target = arg.trim().toLowerCase();
   if (target) {
+    if (COLLAB_HIDDEN_MODES.has(target)) {
+      deps.setSystemNotice('Use /collab <goal> to run a collaborative team (only one runs at a time).');
+      return;
+    }
     const match = modes.find((m) => m.name.toLowerCase() === target);
     if (match) {
       try {


### PR DESCRIPTION
Follow-up to the agentic-collaborative feature (#227). Addresses two issues with starting collaborations from chat.

## Problem

Collaboration was a chat **mode** — so any chat in a workspace (a workspace can have several) could start one, and multiple chats could spawn competing teams clobbering the same repo's git worktrees.

## Changes

- **Launch from the Collaborate tab, not chat.** The tab has a Start composer: type a goal → it sets the active workspace's session to `collaborative` and runs it, with a **＋ New** affordance after a run finishes.
- **Only one collaboration at a time** (each spawns a fleet of agent processes — running several thrashes resources). A **global single-flight lock** (`~/.moxxy/collab/active.lock`, cross-process, with dead-pid reclaim) is acquired by the coordinator before a run and released in `finally`; a second attempt is refused with a clear message. A new read-only **`collab.active` IPC** lets the tab disable Start (with a notice) while one runs in *any* workspace.
- **Removed `collaborative`** (and the internal `collab-architect`/`collab-peer` modes) **from the chat mode pickers** — desktop AgentPicker + TUI `/mode` (which now points to `/collab`).
- chat-model: a refused start no longer leaves an empty collaboration block in the transcript.

## Tests

3 new single-flight lock tests (acquire/refuse-other/idempotent-same/release/stale-reclaim, path-isolated via `MOXXY_COLLAB_LOCK`). Full gate green on the updated main: build 67/67 · typecheck 132/132 · tests (mode-collaborative 15, chat-model 77, desktop-ipc-contract 32, desktop-host 413) · lint 0 errors.