### PR TITLE
Quality sweep wave 8 — finalize (SDK ./server subpath, deferred items closed)

### DIFF
--- a/.changeset/quality-sweep-finalize.md
+++ b/.changeset/quality-sweep-finalize.md
@@ -1,0 +1,10 @@
+---
+"@moxxy/desktop": patch
+---
+
+Quality sweep finalize: desktop side of the @moxxy/sdk ./server subpath split
+
+The desktop main process (ws-bridge + host modules) now imports Node-only SDK
+helpers from `@moxxy/sdk/server` rather than the main barrel, matching the
+boundary the dep-cruiser `no-node-builtins-in-renderer` rule now enforces. No
+behavior change.

--- a/.changeset/quality-sweep-pcm16-mime-source-of-truth.md
+++ b/.changeset/quality-sweep-pcm16-mime-source-of-truth.md
@@ -1,0 +1,24 @@
+---
+"@moxxy/sdk": patch
+"@moxxy/cli": patch
+---
+
+Quality sweep — single-source the `MOXXY_PCM16_24KHZ_MIME` wire constant (`u35-2`)
+
+Behavior-preserving (same string `audio/x-moxxy-pcm16-24khz`). The cross-package
+PCM16 MIME protocol tag was independently redeclared as a literal in three
+consumers; they now import the SDK's hoisted source of truth instead:
+
+- New dependency-free `@moxxy/sdk/transcriber` subpath export (mirrors
+  `./tool-display`) so the browser/RN `@moxxy/client-platform-web` package can
+  value-import the constant without dragging `node:*` builtins from the main
+  barrel. `transcriber.ts` is pure (consts + interfaces, zero imports), so the
+  subpath stays browser-safe.
+- `@moxxy/client-platform-web` (`src/pcm16.ts`) re-exports the constant from
+  `@moxxy/sdk/transcriber`; gains `@moxxy/sdk` as a dependency.
+- `@moxxy/plugin-stt-whisper` (`src/audio.ts`) imports + re-exports from
+  `@moxxy/sdk`, keeping its existing public surface stable.
+- `@moxxy/plugin-cli` (`src/session/use-voice-input.ts`) imports from
+  `@moxxy/sdk`, dropping the inline literal.
+
+No protocol bump; no cycles (`check:deps` clean); SDK keeps zero internal deps.

--- a/.changeset/quality-sweep-sdk-barrel.md
+++ b/.changeset/quality-sweep-sdk-barrel.md
@@ -1,0 +1,27 @@
+---
+"@moxxy/sdk": patch
+"@moxxy/cli": patch
+---
+
+Quality sweep — additive `@moxxy/sdk` surface + context-fold dedup
+
+Three purely-additive SDK changes (no removals, zero new internal deps):
+
+- `MOXXY_PCM16_24KHZ_MIME` (u35-2): hoisted the cross-package PCM16/24 kHz wire
+  MIME tag — previously redeclared as a bare literal in client-platform-web,
+  plugin-stt-whisper, and plugin-cli — onto the SDK's typed transcriber surface
+  as the single source of truth, with a lock test pinning the exact bytes.
+
+- `runManualCompaction` (u80-2): a thin, log-first manual-compaction helper
+  (compactor + log + provider/model + window → `{ compacted, tokensSaved,
+  eventsCompacted }`) so `/compact` can share the SDK's compaction flow instead
+  of hand-rolling it. `runCompactionIfNeeded`'s signature/behavior is unchanged.
+
+- `computeElisionState` memo + threaded elision state (complexity-hotspots-7 /
+  u122-2): the pure fold is now memoized on the input snapshot's identity, and
+  `runElisionIfNeeded`/`runCompactionIfNeeded` derive one `ElisionState` per
+  iteration and thread it into `estimateContextTokens` (and, opt-in, into
+  `projectMessages`) — collapsing the ~3x-per-iteration re-fold to one.
+  Byte-identical: the golden elision/projection tests still pass, plus a new
+  memo-correctness test (same snapshot → cached state; any new array →
+  recompute, never stale).

--- a/.changeset/quality-sweep-sdk-server-subpath.md
+++ b/.changeset/quality-sweep-sdk-server-subpath.md
@@ -1,0 +1,27 @@
+---
+"@moxxy/sdk": patch
+"@moxxy/cli": patch
+---
+
+Quality sweep — split Node-only `@moxxy/sdk` helpers behind a `./server` subpath (browser/RN boundary)
+
+Purely structural, behavior-preserving (`t2-sdk-server-subpath`, retires TECH_DEBT #13):
+
+- New `@moxxy/sdk/server` subpath export. The Node-runtime VALUE helpers that
+  statically reach `node:*` builtins — `spawnCliTunnel`/`isCliTunnelAvailable`
+  (`node:child_process`), `writeFileAtomic`/`writeFileAtomicSync`/`moxxyHome`/
+  `moxxyPath` (`node:fs`/`os`), `readRequestBody`/`bearerTokenMatches`
+  (`node:http`/`crypto`), and the channel-auth helpers (`resolveChannelToken`/
+  `rotateChannelToken`/`bearerGuard`/`encodeWsBearerProtocol`/
+  `tokenFromWsProtocolHeader`/`MOXXY_WS_SUBPROTOCOL`/
+  `MOXXY_WS_BEARER_PROTOCOL_PREFIX`) — now live on `@moxxy/sdk/server` and are
+  dropped from the main barrel. The corresponding pure TYPE exports
+  (`TunnelHandle`, `WriteFileAtomicOptions`, `ChannelTokenOptions`, …) stay on
+  the main barrel (erased at build time). The main barrel + `./tool-display`
+  subpath are now provably free of Node builtins, so a browser/React-Native
+  bundle can value-import from them safely.
+
+- Every Node-side consumer re-pointed from `@moxxy/sdk` to `@moxxy/sdk/server`
+  for those symbols (cli, core, desktop-host, channel/oauth/webhooks/mcp/
+  workflows/scheduler/vault/memory plugins, ipc-server-ws, config, testing,
+  apps/desktop/electron).

--- a/.changeset/quality-sweep-workflow-retry-contract.md
+++ b/.changeset/quality-sweep-workflow-retry-contract.md
@@ -1,0 +1,22 @@
+---
+"@moxxy/cli": patch
+---
+
+Quality sweep — workflow retry contract + DAG concurrency claim (plugin-workflows)
+
+- **`onError: 'retry'` is now behaviorally distinct (u117-3):** the DAG executor
+  gates retries on the three-valued `onError` contract — `'retry'` runs
+  `1 + retries` attempts, while `'fail'` and `'continue'` run **exactly one**
+  attempt regardless of `retries`. Previously retries fired whenever
+  `retries > 0` independent of `onError`, so `onError: 'fail' + retries: 3`
+  silently retried (a latent trap). Schema/draft docs note the gate; new
+  regression tests pin the attempt count for each mode.
+
+- **DAG wave-concurrency claim corrected (u117-1):** the executor description and
+  scheduler comment now plainly describe the strictly-sequential within-wave
+  execution (`concurrency` caps the batch drained per pass, not wall-clock
+  latency) instead of implying parallelism is merely "deferred". Concurrent
+  execution of even the pure steps cannot preserve the observable contract
+  (atomic per-step event pairs in wave order, hard-failure-stops-the-rest-of-the-
+  wave error semantics, wave-ordered `vars` merges), so the behavior is left
+  sequential by design. No runtime behavior change for this item.

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -4,6 +4,12 @@
  *   2. @moxxy/core must not import from any plugin package
  *      (@moxxy/plugin-*, @moxxy/mode-*, @moxxy/compactor-*, @moxxy/cache-strategy-*,
  *      @moxxy/skills-builtin). Core can only import @moxxy/sdk + @moxxy/tools-builtin.
+ *   3. The desktop renderer (apps/desktop/src) and the React-Native PoC
+ *      (apps/mobile-poc/src) must never statically reach a `node:*` builtin —
+ *      those bundles run under a browser engine / Metro and cannot polyfill
+ *      node:child_process etc. (this is why @moxxy/sdk splits Node helpers into
+ *      the './server' subpath; value-importing them from the main barrel here
+ *      would drag a builtin into the bundle).
  *
  * Run with: `pnpm check:deps`
  *
@@ -38,6 +44,19 @@ module.exports = {
       },
     },
     {
+      name: 'no-node-builtins-in-renderer',
+      severity: 'error',
+      comment:
+        'The desktop renderer and the React-Native PoC must not statically reach a node:* builtin — ' +
+        'these bundles run under a browser engine / Metro, which cannot polyfill node:child_process etc. ' +
+        "Import Node helpers from '@moxxy/sdk/server' only in Node-side code; use the browser/RN-safe " +
+        'main barrel + ./tool-display subpath here.',
+      from: { path: '^apps/(desktop/src|mobile-poc/src)' },
+      // dep-cruiser strips the `node:` prefix and tags builtins with the `core`
+      // dependency type, so match on that (matching `^node:` would never fire).
+      to: { dependencyTypes: ['core'] },
+    },
+    {
       name: 'no-circular',
       severity: 'error',
       comment:
@@ -64,6 +83,8 @@ module.exports = {
           'src/index\\.ts$',
           'src/bin\\.ts$',
           'src/matchers\\.ts$',
+          // Vitest setup file — loaded via vitest.config `setupFiles`, not imported.
+          'src/test-setup\\.ts$',
           // Standalone executables shipped via a package's `bin` field
           // (consumed by spawning a child process, not by being imported).
           'src/sidecar\\.ts$',
@@ -71,6 +92,14 @@ module.exports = {
           // runtime / loaded as a window preload, never imported.
           'apps/desktop/electron/main/index\\.ts$',
           'apps/desktop/electron/preload/index\\.ts$',
+          // The renderer (Vite) and the RN PoC (Metro) are cruised ONLY for the
+          // no-node-builtins-in-renderer rule. Their extensionless, bundler-
+          // resolved imports aren't reliably linked by dep-cruiser's resolver, so
+          // orphan detection there is false-positive-prone (e.g. lib/asset.ts is
+          // imported by 10 components yet reported as an orphan). Skip orphan
+          // checking for them; dead-renderer-code is the bundler's/linter's job.
+          '^apps/desktop/src/',
+          '^apps/mobile-poc/src/',
         ],
       },
       to: {},
@@ -78,7 +107,14 @@ module.exports = {
   ],
   options: {
     doNotFollow: { path: 'node_modules' },
-    includeOnly: '^(packages/.*/src|apps/desktop/electron)',
+    // Node builtins are kept in the graph (despite the path scoping) so the
+    // `no-node-builtins-in-renderer` rule can actually see a renderer/RN module
+    // reaching one — `includeOnly` filters BOTH ends of a dependency, and a core
+    // module (dep-cruiser strips the `node:` prefix, so it resolves to a bare
+    // name like `fs`/`child_process`) outside this set would be invisible.
+    includeOnly:
+      '^(packages/.*/src|apps/desktop/electron|apps/desktop/src|apps/mobile-poc/src|' +
+      '(node:)?(assert|async_hooks|buffer|child_process|cluster|console|constants|crypto|dgram|diagnostics_channel|dns|domain|events|fs|http|http2|https|inspector|module|net|os|path|perf_hooks|process|punycode|querystring|readline|repl|stream|string_decoder|sys|timers|tls|trace_events|tty|url|util|v8|vm|wasi|worker_threads|zlib)(/|$))',
     exclude: {
       path: '(dist/|node_modules/|\\.turbo/|\\.test\\.ts$|\\.test-d\\.ts$|__fixtures__/)',
     },

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -51,10 +51,31 @@ a cross-package boundary change (e.g. `u117-3` retry semantics, `u40-2` permissi
 anchoring, relocating voice tools to a new package) and are called out at their
 original entries — those are scoped follow-ups, not open quality debt.
 
-**No open findings remain from this audit.** Going forward this file resumes its
-normal role: the standing ledger where each future change retires ≥1 item and new
-debt is logged on sight (AGENTS.md → "Tech debt is a standing job"). A living
-codebase keeps accruing debt; the audit backlog itself is cleared.
+**No open findings remain from this audit.** A final pass (wave 12) closed the
+last deferred-for-scope items by implementing them: the SDK Node-only helpers now
+live behind a `@moxxy/sdk/server` subpath (dropped from the browser/RN-safe main
+barrel; every node-side consumer re-pointed; dep-cruiser widened to cruise the
+renderer + mobile-poc with a `no-node-builtins-in-renderer` error rule), the
+duplicated PCM16 MIME constant + the `/compact` flow now route through the SDK,
+`computeElisionState` is memoized + threaded once per iteration, and workflow
+`onError:'retry'` now honours `step.retries`.
+
+**Two items were closed as deliberate by-design decisions (not silent debt):**
+- `RequirementChecker.targetInfo` keeps its explicit per-kind `switch`. Each kind
+  reads a different registry with different active/version semantics; a clever
+  kind→table indirection in a correctness-critical requirement gate trades
+  clarity + safety for a DRY win that isn't worth it. The switch is the right
+  shape; kept intentionally (closes types-generics-5's table-drive half).
+- Voice-admin tools stay decomposed **in-place** within `cli/setup` (wave 10).
+  The atomicity goal (no god-function) is met; promoting them to a standalone
+  `@moxxy/plugin-voice-admin` package is a packaging-boundary preference, not a
+  quality fix, and is deliberately a non-goal for cli-bundled builtins.
+
+Going forward this file resumes its normal role: the standing ledger where each
+future change retires ≥1 item and new debt is logged on sight (AGENTS.md → "Tech
+debt is a standing job"). A living codebase under active development keeps
+accruing debt (this very sweep integrated the concurrently-merged anonymizer +
+mode-collaborative features mid-flight); the audit backlog itself is cleared.
 
 ---
 

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -104,10 +104,15 @@ standing backlog — pick from it, newest-audit-first, on the next pass).
   `requirements.targetInfo` table-drive; shared one-shot-stream + frontmatter
   parser + external-store + OAuth helpers (`t2-oneshot-stream-helper`,
   `t2-frontmatter-parser-dup`, `t2-external-store-dup`, `t2-shared-oauth-helpers`).
-- **Boundaries:** wall the Node-only SDK helpers behind a `./server` subpath +
-  widen dep-cruiser to the renderer/mobile-poc (`t2-sdk-server-subpath`); the
-  permission `inputMatches` anchoring (`u40-2`, changes match semantics);
-  unify `~/.moxxy` path derivation (`t2-moxxy-home-paths`).
+- **Boundaries:** ~~wall the Node-only SDK helpers behind a `./server` subpath +
+  widen dep-cruiser to the renderer/mobile-poc (`t2-sdk-server-subpath`)~~ ✅ DONE
+  2026-06-18 (see item #13 above); ~~the permission `inputMatches` anchoring
+  (`u40-2`)~~ ✅ DONE 2026-06-18 — resolved as a *contract* fix, NOT a semantics
+  change: `inputMatches` values stay UNANCHORED substring regexes (anchoring
+  them would break existing permission files), now documented on
+  `PolicyRule.inputMatches` + at the `matchRule` regex site and pinned by an
+  explicit substring-vs-author-anchored test; unify `~/.moxxy` path derivation
+  (`t2-moxxy-home-paths`).
 - **Completion:** wire or remove the desktop per-provider reasoning-effort
   control (`t2-security`/`c15`/R1); the half-built encrypted-reasoning round-trip
   (`u99-1`).
@@ -148,6 +153,23 @@ focused PR with its tests) and the low-severity **long-tail** clusters
 `.claude/audits/quality-sweep-findings.json` — triage highest-severity first; a
 150k-LOC codebase always carries a longtail, so treat this as the ongoing
 chip-away, not a one-shot zero.
+
+**Update — 2026-06-18 (workflow retry contract + DAG concurrency claim):** the
+two deferred `@moxxy/plugin-workflows` items are now resolved.
+- **`u117-3` retry semantics (fixed, regression-tested):** `runStep`
+  (`executor/steps.ts`) now gates retries on the three-valued `onError` contract
+  — `'retry'` runs `1 + retries` attempts; `'fail'`/`'continue'` run **exactly
+  one** attempt regardless of `retries`. This removes the latent trap where
+  `onError: 'fail' + retries: 3` silently retried. Schema/draft docs updated to
+  state the gate. Three new dag tests pin the attempt count per mode.
+- **`u117-1` DAG "runs waves up to concurrency" claim (resolved as misleading-
+  claim, not a behavior change):** parity for concurrent pure-step execution is
+  **unprovable** against the current observable contract — atomic per-step
+  started→terminal event pairs in wave order, the hard-failure-stops-the-rest-of-
+  the-wave error semantics (its own test), and wave-ordered `vars` merges are all
+  externally observable and would change under overlap. The executor description
+  and the scheduler comment now describe the strictly-sequential behavior plainly
+  (no "yet"/"deferred" wording) with the parity rationale spelled out.
 
 ## 2026-06-17 — Skills gallery reimplements the shared settings `SearchBox`
 
@@ -1213,20 +1235,27 @@ macOS 26) — or better, resolve a real `node` from PATH for the unit and only f
 the Electron binary. Low blast radius today (services are normally installed from a real
 terminal CLI), but silently wrong when it happens.
 
-### 13. `@moxxy/sdk` barrel re-exports node-only code → browser/RN bundles break — OPEN (partially mitigated)
+### 13. `@moxxy/sdk` barrel re-exports node-only code → browser/RN bundles break — ✅ RESOLVED 2026-06-18 (`t2-sdk-server-subpath`)
 **Observed 2026-06-17** building the cross-channel file-diff preview. The `@moxxy/sdk`
-index barrel re-exports node-coupled modules (e.g. `tunnel.js` → `node:child_process` via
-`spawnCliTunnel`), so ANY browser/React-Native consumer that imports a **runtime value**
-from `@moxxy/sdk` pulls those built-ins and fails to bundle: the desktop vite renderer
-errored `"spawn" is not exported by "__vite-browser-external"`, and Metro would hit the
-same. Type-only imports are fine (erased); the trap is value imports (here the pure diff
-helpers `toDiffRows`/`fileDiffSummary`/`isFileDiffDisplay`/…). Mitigated for this feature
-by adding a **dependency-free `@moxxy/sdk/tool-display` subpath export** and importing the
-helpers from there in chat-model/desktop/mobile. But the trap recurs every time a new pure
-SDK helper is needed by a renderer. Fix shape: either split the SDK into a browser-safe
-pure core entry + a node-only entry, or systematically expose each pure leaf module as its
-own subpath export (and lint/forbid renderer code importing the barrel for values). Low
-blast radius today (one-off per helper) but a sharp edge for every future shared helper.
+index barrel re-exported node-coupled **runtime values** (`spawnCliTunnel`/`isCliTunnelAvailable`
+→ `node:child_process`; `writeFileAtomic*`/`moxxyHome`/`moxxyPath` → `node:fs`/`os`;
+`readRequestBody`/`bearerTokenMatches` → `node:http`/`crypto`; the channel-auth helpers →
+`node:crypto`/`fs`/`path`), so any browser/RN consumer value-importing from `@moxxy/sdk`
+dragged those builtins into the bundle (vite renderer errored `"spawn" is not exported by
+"__vite-browser-external"`; Metro would hit the same). The wall held only by `import type`
+discipline. **Fix:** moved every Node-runtime VALUE export behind a new `./server` subpath
+(`packages/sdk/src/server.ts` + the `"./server"` entry in `exports`); the main barrel now
+keeps only the pure type exports of those modules (`TunnelHandle`, `WriteFileAtomicOptions`,
+`ChannelTokenOptions`, …). Every node-side consumer (cli/runner/desktop-host/core/channel/
+oauth/webhooks/mcp/workflows/scheduler/vault/memory/… + apps/desktop/electron) re-pointed to
+`@moxxy/sdk/server`. The `tool-display` subpath stays as the browser-safe rich-result path.
+**CI guard:** dep-cruiser now cruises `apps/desktop/src` + `apps/mobile-poc/src` and a new
+`no-node-builtins-in-renderer` rule (severity error) forbids any renderer/RN module reaching
+a `node:*` builtin (core modules kept in the cruise graph via an expanded `includeOnly`,
+matched by `dependencyTypes:['core']` since dep-cruiser strips the `node:` prefix). A
+`package-root.test.ts` guard asserts the moved symbols are absent from the main barrel and
+present on `./server`. Verified: `pnpm typecheck` 130/130, `pnpm check:deps` 0 errors,
+the rule fires when a node import is injected into either renderer.
 
 ---
 

--- a/apps/desktop/electron/main/ws-bridge.ts
+++ b/apps/desktop/electron/main/ws-bridge.ts
@@ -30,7 +30,7 @@
 
 import path from 'node:path';
 
-import { resolveChannelToken, rotateChannelToken } from '@moxxy/sdk';
+import { resolveChannelToken, rotateChannelToken } from '@moxxy/sdk/server';
 import {
   advertisedHost,
   advertisedOrigins,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "turbo run test && pnpm run test:scripts",
     "test:scripts": "node --test scripts/*.test.mjs",
     "test:watch": "turbo run test:watch --concurrency=1",
-    "check:deps": "depcruise --config .dependency-cruiser.cjs packages apps/desktop/electron",
+    "check:deps": "depcruise --config .dependency-cruiser.cjs packages apps/desktop/electron apps/desktop/src apps/mobile-poc/src",
     "clean": "turbo run clean && rm -rf node_modules .turbo"
   },
   "devDependencies": {

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { moxxyHome } from '@moxxy/sdk';
+import { moxxyHome } from '@moxxy/sdk/server';
 import { finalizeStagedCoreUpdate } from '@moxxy/plugin-self-update';
 import { parseArgv, type ParsedArgv } from './argv.js';
 import { runPromptCommand } from './commands/prompt.js';

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,5 +1,6 @@
 import { defaultProjectSkillsDir, defaultUserSkillsDir, discoverSkills, silentLogger } from '@moxxy/core';
-import { createMutex, writeFileAtomic } from '@moxxy/sdk';
+import { createMutex } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 import { BUILTIN_SKILLS_DIR_RESOLVED } from '../setup/builtin-skills-dir.js';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';

--- a/packages/cli/src/setup/build-workflow-runner.ts
+++ b/packages/cli/src/setup/build-workflow-runner.ts
@@ -3,11 +3,10 @@ import * as path from 'node:path';
 import { createSubagentSpawner, type Session } from '@moxxy/core';
 import {
   asPluginId,
-  moxxyPath,
-  writeFileAtomic,
   type EmittedEvent,
   type WorkflowRunResult,
 } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import {
   WORKFLOWS_PLUGIN_NAME,
   type WorkflowStore,

--- a/packages/cli/src/update/check.ts
+++ b/packages/cli/src/update/check.ts
@@ -11,7 +11,7 @@
 
 import { readFileSync } from 'node:fs';
 
-import { moxxyPath, writeFileAtomicSync } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomicSync } from '@moxxy/sdk/server';
 
 import { fetchLatest, type FetchLatestOpts } from './registry.js';
 

--- a/packages/client-platform-web/package.json
+++ b/packages/client-platform-web/package.json
@@ -23,7 +23,8 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
-    "@moxxy/client-core": "workspace:*"
+    "@moxxy/client-core": "workspace:*",
+    "@moxxy/sdk": "workspace:*"
   },
   "devDependencies": {
     "@moxxy/tsconfig": "workspace:*",

--- a/packages/client-platform-web/src/pcm16.ts
+++ b/packages/client-platform-web/src/pcm16.ts
@@ -6,6 +6,12 @@
  * does the job). Plus the peak + base64 helpers the capture path needs.
  */
 
+/** The MIME tag the moxxy whisper helpers use to flag "raw PCM16 mono 24 kHz".
+ *  The Codex transcriber sees this and wraps the bytes in a WAV header.
+ *  Re-exported from the SDK's zero-dep `./transcriber` subpath (the cross-package
+ *  source of truth) via a browser-safe entry that never pulls node built-ins. */
+export { MOXXY_PCM16_24KHZ_MIME } from '@moxxy/sdk/transcriber';
+
 const TARGET_SAMPLE_RATE = 24_000;
 
 /**
@@ -20,10 +26,6 @@ export function getAudioContextCtor(): typeof AudioContext | undefined {
     (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
   );
 }
-
-/** The MIME tag the moxxy whisper helpers use to flag "raw PCM16 mono 24 kHz".
- *  The Codex transcriber sees this and wraps the bytes in a WAV header. */
-export const MOXXY_PCM16_24KHZ_MIME = 'audio/x-moxxy-pcm16-24khz';
 
 export async function audioToPcm16(blob: Blob): Promise<Uint8Array> {
   const arrayBuffer = await blob.arrayBuffer();

--- a/packages/config/src/loader.ts
+++ b/packages/config/src/loader.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { moxxyHome } from '@moxxy/sdk';
+import { moxxyHome } from '@moxxy/sdk/server';
 import { mergeConfigs } from './merge.js';
 import { moxxyConfigSchema, type MoxxyConfig } from './schema.js';
 

--- a/packages/config/src/plugin.ts
+++ b/packages/config/src/plugin.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
-import { z, createMutex, defineTool, definePlugin, moxxyPath, writeFileAtomic, type Plugin } from '@moxxy/sdk';
+import { z, createMutex, defineTool, definePlugin, type Plugin } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { findUpward, loadConfig } from './loader.js';
 import { moxxyConfigSchema, type MoxxyConfig } from './schema.js';
 

--- a/packages/core/src/permissions/engine.test.ts
+++ b/packages/core/src/permissions/engine.test.ts
@@ -52,6 +52,31 @@ describe('PermissionEngine', () => {
     expect(e.check(call('Bash', { cmd: 'rm -rf /' }))).toBeNull();
   });
 
+  it('inputMatches is an unanchored substring match by design (u40-2)', () => {
+    // Documented, stable contract: `inputMatches` values are UNANCHORED regexes
+    // (re.test → substring match). An author who needs a full match anchors
+    // their own pattern. We pin both halves of that contract so it can never be
+    // silently changed (anchoring it would break existing permission files).
+    const substring = new PermissionEngine({
+      allow: [{ name: 'Read', inputMatches: { path: 'config' } }],
+      deny: [],
+    });
+    // Substring pattern matches anywhere in the candidate — by design.
+    expect(substring.check(call('Read', { path: '/etc/config' }))?.mode).toBe('allow');
+    expect(substring.check(call('Read', { path: '/etc/config-evil' }))?.mode).toBe('allow');
+    expect(substring.check(call('Read', { path: '~/.ssh/config-backup' }))?.mode).toBe('allow');
+    // A path that does not contain the pattern at all is not matched.
+    expect(substring.check(call('Read', { path: '/etc/passwd' }))).toBeNull();
+
+    // An author who wants a full match supplies their own ^…$ anchors.
+    const anchored = new PermissionEngine({
+      allow: [{ name: 'Read', inputMatches: { path: '^/etc/config$' } }],
+      deny: [],
+    });
+    expect(anchored.check(call('Read', { path: '/etc/config' }))?.mode).toBe('allow');
+    expect(anchored.check(call('Read', { path: '/etc/config-evil' }))).toBeNull();
+  });
+
   it('deny rule with an invalid-regex inputMatches still denies (fails closed)', () => {
     // Unbalanced bracket = uncompilable regex. The user clearly intended to
     // block `rm -rf`; the old fallback (literal !== equality) silently turned

--- a/packages/core/src/permissions/engine.ts
+++ b/packages/core/src/permissions/engine.ts
@@ -1,4 +1,5 @@
-import { createMutex, writeFileAtomic, type Mutex, type PendingToolCall, type PermissionDecision } from '@moxxy/sdk';
+import { createMutex, type Mutex, type PendingToolCall, type PermissionDecision } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 import { promises as fs } from 'node:fs';
 import { z } from 'zod';
 
@@ -10,6 +11,20 @@ import { z } from 'zod';
  */
 export interface PolicyRule {
   readonly name: string;
+  /**
+   * Map of tool-input field name → regex source string. Each value is compiled
+   * with `new RegExp(value)` and tested with `.test(candidate)`, which is an
+   * UNANCHORED (substring / partial) match by design: the pattern matches if it
+   * occurs anywhere in the field's string form, not only when it spans the whole
+   * value. This is a deliberate, stable contract — existing user permission
+   * files rely on it, so it is never silently anchored.
+   *
+   * Consequence: an allow rule like `{ Read: { path: 'config' } }` matches
+   * `/etc/passwd#config` and `~/.ssh/config-backup` too. A rule that wants a
+   * FULL match must supply its own anchors, e.g. `'^/safe/dir/.*$'`. (Note this
+   * differs from {@link nameMatches}, which anchors its glob with `^...$`
+   * because a glob is a whole-name convention, not an author-supplied regex.)
+   */
   readonly inputMatches?: Record<string, string>;
   readonly reason?: string;
 }
@@ -157,6 +172,12 @@ function matchRule(rule: PolicyRule, call: PendingToolCall, intent: 'allow' | 'd
       const candidate = stringifyCandidate(input[k]);
       let re: RegExp;
       try {
+        // `inputMatches` values are UNANCHORED regexes by design: `.test` does a
+        // substring/partial match, so the pattern matches if it occurs anywhere
+        // in `candidate`. This is the documented, stable contract (see
+        // PolicyRule.inputMatches) — never wrap it in `^(?:…)$`, as that would
+        // silently break existing permission files. Authors who need a full
+        // match anchor their own pattern with `^…$`.
         re = new RegExp(v);
       } catch (err) {
         warnBadPattern(rule.name, k, v, intent, err);

--- a/packages/core/src/preferences.ts
+++ b/packages/core/src/preferences.ts
@@ -1,7 +1,8 @@
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { createMutex, migrateModeName, writeFileAtomic } from '@moxxy/sdk';
+import { createMutex, migrateModeName } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 
 /**
  * User-level runtime preferences persisted at ~/.moxxy/preferences.json.

--- a/packages/core/src/sessions/persistence.ts
+++ b/packages/core/src/sessions/persistence.ts
@@ -19,7 +19,8 @@
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { createMutex, writeFileAtomic, type Mutex, type MoxxyEvent, type SessionId } from '@moxxy/sdk';
+import { createMutex, type Mutex, type MoxxyEvent, type SessionId } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 import type { EventLog } from '../events/log.js';
 import { createLogger, type Logger } from '../logger.js';
 

--- a/packages/core/src/usage-stats.ts
+++ b/packages/core/src/usage-stats.ts
@@ -1,7 +1,8 @@
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { addModelTotals, createMutex, writeFileAtomic, type ModelUsageTotals } from '@moxxy/sdk';
+import { addModelTotals, createMutex, type ModelUsageTotals } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 
 /**
  * Cross-session token usage, persisted at ~/.moxxy/usage.json. A forward-going

--- a/packages/desktop-host/src/desks.ts
+++ b/packages/desktop-host/src/desks.ts
@@ -14,7 +14,8 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { createMutex, writeFileAtomic, type Mutex } from '@moxxy/sdk';
+import { createMutex, type Mutex } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 import type { Desk, DeskSession, SessionsOverview } from '@moxxy/desktop-ipc-contract';
 
 /**

--- a/packages/desktop-host/src/prefs.ts
+++ b/packages/desktop-host/src/prefs.ts
@@ -12,7 +12,8 @@
 import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
-import { createMutex, writeFileAtomic } from '@moxxy/sdk';
+import { createMutex } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 import type { DesktopPrefs } from '@moxxy/desktop-ipc-contract';
 
 const DEFAULTS: DesktopPrefs = {

--- a/packages/desktop-host/src/skills.ts
+++ b/packages/desktop-host/src/skills.ts
@@ -8,7 +8,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { readFile, readdir, unlink } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
-import { writeFileAtomic } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 import type { SkillFile } from '@moxxy/desktop-ipc-contract';
 
 /** Pull the frontmatter `description` (cheap regex — no YAML dep) so the

--- a/packages/desktop-host/src/vault-key.ts
+++ b/packages/desktop-host/src/vault-key.ts
@@ -25,7 +25,7 @@
 import { randomBytes } from 'node:crypto';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { moxxyPath } from '@moxxy/sdk';
+import { moxxyPath } from '@moxxy/sdk/server';
 
 /** AES-256 master key length, matching the vault's `deriveKey` output. */
 const KEY_BYTES = 32;

--- a/packages/ipc-server-ws/src/auth.test.ts
+++ b/packages/ipc-server-ws/src/auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { IncomingMessage } from 'node:http';
-import { encodeWsBearerProtocol, MOXXY_WS_SUBPROTOCOL } from '@moxxy/sdk';
+import { encodeWsBearerProtocol, MOXXY_WS_SUBPROTOCOL } from '@moxxy/sdk/server';
 import { checkWsAuth, checkWsOrigin } from './auth.js';
 
 function req(headers: Record<string, string>, url = '/'): IncomingMessage {

--- a/packages/ipc-server-ws/src/auth.ts
+++ b/packages/ipc-server-ws/src/auth.ts
@@ -23,7 +23,7 @@
  */
 
 import type { IncomingMessage } from 'node:http';
-import { bearerGuard, tokenFromWsProtocolHeader } from '@moxxy/sdk';
+import { bearerGuard, tokenFromWsProtocolHeader } from '@moxxy/sdk/server';
 
 const BEARER = 'Bearer ';
 

--- a/packages/ipc-server-ws/src/ws-transport.test.ts
+++ b/packages/ipc-server-ws/src/ws-transport.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import WebSocket from 'ws';
-import { encodeWsBearerProtocol, MOXXY_WS_SUBPROTOCOL } from '@moxxy/sdk';
+import { encodeWsBearerProtocol, MOXXY_WS_SUBPROTOCOL } from '@moxxy/sdk/server';
 import {
   createWebSocketTransportServer,
   SlowReaderGuard,

--- a/packages/ipc-server-ws/src/ws-transport.ts
+++ b/packages/ipc-server-ws/src/ws-transport.ts
@@ -18,7 +18,7 @@
 import type { IncomingMessage } from 'node:http';
 import { WebSocketServer, type WebSocket, type RawData } from 'ws';
 
-import { MOXXY_WS_SUBPROTOCOL } from '@moxxy/sdk';
+import { MOXXY_WS_SUBPROTOCOL } from '@moxxy/sdk/server';
 import type { Transport, TransportServer } from '@moxxy/runner';
 import { checkWsAuth, checkWsOrigin } from './auth.js';
 

--- a/packages/plugin-channel-http/src/router.ts
+++ b/packages/plugin-channel-http/src/router.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { readRequestBody, bearerTokenMatches } from '@moxxy/sdk';
+import { readRequestBody, bearerTokenMatches } from '@moxxy/sdk/server';
 import type { ClientSession as Session } from '@moxxy/sdk';
 import type { MoxxyEvent } from '@moxxy/sdk';
 

--- a/packages/plugin-channel-mobile/src/token.ts
+++ b/packages/plugin-channel-mobile/src/token.ts
@@ -5,7 +5,7 @@
  * SDK helper so every channel resolves auth the same way.
  */
 
-import { resolveChannelToken, rotateChannelToken } from '@moxxy/sdk';
+import { resolveChannelToken, rotateChannelToken } from '@moxxy/sdk/server';
 
 const TOKEN_FILE = 'mobile-token';
 

--- a/packages/plugin-channel-web/src/channel.ts
+++ b/packages/plugin-channel-web/src/channel.ts
@@ -5,7 +5,8 @@ import { fileURLToPath } from 'node:url';
 import * as path from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { WebSocketServer, type WebSocket } from 'ws';
-import { createAllowListResolver, bearerTokenMatches } from '@moxxy/sdk';
+import { createAllowListResolver } from '@moxxy/sdk';
+import { bearerTokenMatches } from '@moxxy/sdk/server';
 import type {
   Channel,
   ChannelHandle,

--- a/packages/plugin-channel-web/src/cloudflared.ts
+++ b/packages/plugin-channel-web/src/cloudflared.ts
@@ -1,4 +1,5 @@
-import { defineTunnelProvider, isCliTunnelAvailable, spawnCliTunnel, type TunnelHandle } from '@moxxy/sdk';
+import { defineTunnelProvider, type TunnelHandle } from '@moxxy/sdk';
+import { isCliTunnelAvailable, spawnCliTunnel } from '@moxxy/sdk/server';
 
 const TRYCLOUDFLARE_RE = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/i;
 const URL_TIMEOUT_MS = 30_000;

--- a/packages/plugin-channel-web/src/ngrok.ts
+++ b/packages/plugin-channel-web/src/ngrok.ts
@@ -1,4 +1,5 @@
-import { defineTunnelProvider, isCliTunnelAvailable, spawnCliTunnel, type TunnelHandle } from '@moxxy/sdk';
+import { defineTunnelProvider, type TunnelHandle } from '@moxxy/sdk';
+import { isCliTunnelAvailable, spawnCliTunnel } from '@moxxy/sdk/server';
 
 const NGROK_URL_RE = /https:\/\/[a-z0-9-]+\.ngrok(?:-free)?\.(?:app|io|dev)/i;
 const URL_TIMEOUT_MS = 30_000;

--- a/packages/plugin-channel-web/src/tunnel-settings.ts
+++ b/packages/plugin-channel-web/src/tunnel-settings.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
-import { createMutex, moxxyPath, writeFileAtomic, z } from '@moxxy/sdk';
+import { createMutex, z } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 
 /** Validates the on-disk web.json shape; a corrupt/foreign file is discarded. */
 const webSettingsSchema = z.object({ tunnel: z.string().optional() });

--- a/packages/plugin-cli/src/clipboard-image.ts
+++ b/packages/plugin-cli/src/clipboard-image.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { mkdirSync, readdirSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { moxxyPath } from '@moxxy/sdk';
+import { moxxyPath } from '@moxxy/sdk/server';
 import type { DetectedImagePath } from './image-attachments.js';
 
 /**

--- a/packages/plugin-cli/src/session/use-voice-input.ts
+++ b/packages/plugin-cli/src/session/use-voice-input.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ClientSession as Session } from '@moxxy/sdk';
-import { getInstallHint, type RequirementCheck, type RequirementIssue, type Transcriber } from '@moxxy/sdk';
+import { getInstallHint, MOXXY_PCM16_24KHZ_MIME, type RequirementCheck, type RequirementIssue, type Transcriber } from '@moxxy/sdk';
 import type { ExternalInsert } from '../components/prompt/external-insert.js';
 import {
   startVoiceRecording,
@@ -12,7 +12,6 @@ import {
 } from '../voice-input.js';
 
 const CODEX_TRANSCRIBER_NAME = 'openai-codex-transcribe';
-const MOXXY_PCM16_24KHZ_MIME = 'audio/x-moxxy-pcm16-24khz';
 
 export interface UseVoiceInputOptions {
   readonly session: Session;

--- a/packages/plugin-commands/src/commands.test.ts
+++ b/packages/plugin-commands/src/commands.test.ts
@@ -233,6 +233,50 @@ describe('@moxxy/plugin-commands', () => {
     expect(seenCtx?.model).toBe('claude-x');
   });
 
+  // u80-2: compactSession now delegates to the shared SDK runManualCompaction
+  // helper. The active model's real contextWindow must reach the budget the
+  // helper builds (it used to be resolved by the plugin's own duplicate
+  // resolveActiveContextWindow); a no-op formats "nothing to compact yet".
+  it('/compact forwards the active model contextWindow into the budget', async () => {
+    const existing = [
+      { type: 'user_prompt', seq: 0, sessionId: 'sess-1', turnId: 'turn-1', source: 'user', text: 'old' },
+    ] as unknown as MoxxyEvent[];
+    const fakeProvider = { name: 'anthropic', models: [{ id: 'claude-x', contextWindow: 123_456 }] };
+    let seenBudget: { contextWindow?: number } | undefined;
+    const session = {
+      ...fakeSession,
+      signal: new AbortController().signal,
+      providers: { getActiveName: () => 'anthropic', getActive: () => fakeProvider },
+      log: {
+        length: existing.length,
+        slice: () => existing,
+        append: async (event: EmittedEvent) => event as unknown as MoxxyEvent,
+      },
+      compactors: {
+        getActive: () => ({
+          name: 'fake-compact',
+          shouldCompact: () => false,
+          compact: async (_events: ReadonlyArray<MoxxyEvent>, ctx: { budget?: { contextWindow?: number } }) => {
+            seenBudget = ctx.budget;
+            return {
+              type: 'compaction',
+              compactor: 'fake-compact',
+              replacedRange: [0, 0],
+              summary: 's',
+              tokensSaved: 10,
+            } as const;
+          },
+        }),
+      },
+    };
+
+    const compact = (commandsPlugin.commands ?? []).find((c) => c.name === 'compact');
+    if (!compact) throw new Error('missing command: compact');
+    await compact.handler({ channel: 'tui', sessionId: 'sess-1' as never, args: '', session });
+
+    expect(seenBudget?.contextWindow).toBe(123_456);
+  });
+
   // Regression for u80-3: a spec-compliant compactor may return ONLY the
   // Omit<CompactionEvent, keyof EventBase> fields. The appended event must
   // still carry sessionId/turnId/source so replay/projection accepts it.

--- a/packages/plugin-commands/src/index.ts
+++ b/packages/plugin-commands/src/index.ts
@@ -1,6 +1,6 @@
 import {
   definePlugin,
-  estimateContextTokens,
+  runManualCompaction,
   type CommandDef,
   type CompactorDef,
   type EmittedEvent,
@@ -147,86 +147,52 @@ async function compactSession(session: unknown) {
   const compactor = s.compactors?.getActive?.();
   if (!compactor) return { kind: 'error' as const, message: 'no active compactor configured' };
 
+  // Distinguish an empty log up front so we can keep the specific
+  // message — `runManualCompaction` collapses every no-op (empty log,
+  // zero saving, blank summary) into the same `compacted: false`.
   const events = s.log?.slice?.() ?? [];
   if (events.length === 0) {
     return { kind: 'text' as const, text: 'nothing to compact: event log is empty' };
   }
 
-  // Resolve the active model's real contextWindow. The previous
-  // hardcoded Number.MAX_SAFE_INTEGER made `shouldCompact` always see
-  // a comfortable budget — fine for `/compact` since we ignore that
-  // gate manually, but it also meant compactors that want to size
-  // their summary against the real window couldn't. When no provider
-  // is wired (rare; only in tests), fall back to MAX_SAFE_INTEGER.
-  const providerCtxWindow = resolveActiveContextWindow(s);
   // Resolve the active provider/model so the default summarize compactor
-  // writes a REAL model summary instead of degrading to a lossy digest
-  // truncation. `runCompactionIfNeeded` forwards these too; omitting them
-  // here made every manual `/compact` strictly worse than the auto path.
+  // writes a REAL model summary (degrades to a lossy truncation otherwise),
+  // plus the model's real context window. We don't know which model id the
+  // user picked from this surface, so use the first-listed model's window as
+  // the conventional default (matches resolveContextWindow in plugin-cli).
+  // When no provider is wired (rare; tests), the helper falls back to a
+  // MAX_SAFE_INTEGER window — fine, since `/compact` forces past the gate.
   const provider = safe(() => s.providers?.getActive()) ?? undefined;
   const model = provider?.models[0]?.id;
+  const contextWindow = provider?.models[0]?.contextWindow;
 
   try {
-    const result = await compactor.compact(events, {
-      log: s.log.asReader ? s.log.asReader() : s.log,
-      budget: {
-        contextWindow: providerCtxWindow,
-        estimatedTokens: estimateContextTokens(s.log.asReader ? s.log.asReader() : s.log),
-        reserveForOutput: 0,
-      },
-      signal: s.signal ?? new AbortController().signal,
+    // Delegate the whole pipeline (budget build, compact(), no-op guard,
+    // defensive sessionId/turnId/source fill, append, replaced-range count)
+    // to the single shared SDK helper. The plugin only formats the message.
+    const result = await runManualCompaction({
+      compactor,
+      log: s.log,
+      signal: s.signal,
       ...(provider ? { provider } : {}),
-      ...(model ? { model } : {}),
+      ...(model !== undefined ? { model } : {}),
+      ...(contextWindow !== undefined ? { contextWindow } : {}),
+      ...(s.id !== undefined ? { sessionId: s.id } : {}),
     });
 
-    if (result.tokensSaved <= 0 || result.summary.trim().length === 0) {
+    if (!result.compacted) {
       return { kind: 'text' as const, text: 'nothing to compact yet' };
     }
 
-    // `compactor.compact` declares `Omit<CompactionEvent, keyof EventBase>`,
-    // so a spec-compliant compactor need not provide sessionId/turnId/source.
-    // Defensive-fill them (mirrors runCompactionIfNeeded) so a type-compliant
-    // compactor still emits a valid event that replay/projection accepts. The
-    // compactor's own values win if it supplied them (result spreads last).
-    const lastEvent = events[events.length - 1];
-    const emittable: EmittedEvent = {
-      sessionId: s.id ?? lastEvent?.sessionId,
-      turnId: lastEvent?.turnId,
-      source: 'compactor',
-      ...result,
-    } as EmittedEvent;
-    await s.log.append(emittable);
-    // `replacedRange` is an INCLUSIVE [fromSeq, toSeq] of event `seq` VALUES,
-    // not array indices — and `seq === arrayIndex` is not guaranteed for
-    // mirrors/partial views. Differencing the seqs would OVERSTATE the count
-    // across any seq gap. Count the events actually inside the range instead.
-    const [fromSeq, toSeq] = result.replacedRange;
-    const compactedEvents = events.filter(
-      (e) => e.seq >= fromSeq && e.seq <= toSeq,
-    ).length;
     return {
       kind: 'text' as const,
-      text: `context compacted: ${formatCount(compactedEvents)} ${plural(compactedEvents, 'event')}, ~${formatTokenCount(result.tokensSaved)} tokens saved`,
+      text: `context compacted: ${formatCount(result.eventsCompacted)} ${plural(result.eventsCompacted, 'event')}, ~${formatTokenCount(result.tokensSaved)} tokens saved`,
     };
   } catch (err) {
     return {
       kind: 'error' as const,
       message: err instanceof Error ? err.message : String(err),
     };
-  }
-}
-
-function resolveActiveContextWindow(s: CompactSessionShape): number {
-  try {
-    const provider = s.providers?.getActive();
-    if (!provider) return Number.MAX_SAFE_INTEGER;
-    // We don't know which model id the user picked from this surface,
-    // so use the first-listed model's window as the conventional
-    // default (matches resolveContextWindow in plugin-cli/helpers.ts).
-    const window = provider.models[0]?.contextWindow;
-    return window && window > 0 ? window : Number.MAX_SAFE_INTEGER;
-  } catch {
-    return Number.MAX_SAFE_INTEGER;
   }
 }
 

--- a/packages/plugin-mcp/src/admin/config-io.ts
+++ b/packages/plugin-mcp/src/admin/config-io.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
-import { createMutex, moxxyPath, writeFileAtomic } from '@moxxy/sdk';
+import { createMutex } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { mcpStoredConfigRootSchema, mcpStoredServerSchema } from './config-schema.js';
 import type { McpStoredConfig, McpStoredServer } from './types.js';
 

--- a/packages/plugin-mcp/src/admin/index.ts
+++ b/packages/plugin-mcp/src/admin/index.ts
@@ -1,4 +1,5 @@
-import { definePlugin, moxxyPath, type Plugin } from '@moxxy/sdk';
+import { definePlugin, type Plugin } from '@moxxy/sdk';
+import { moxxyPath } from '@moxxy/sdk/server';
 import { readMcpConfig } from './config-io.js';
 import { createMcpRuntime } from './runtime.js';
 import { createMcpUsageSkillWriter } from './skill.js';

--- a/packages/plugin-mcp/src/admin/skill.ts
+++ b/packages/plugin-mcp/src/admin/skill.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
-import { writeFileAtomic, type Skill } from '@moxxy/sdk';
+import { type Skill } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 import type { McpServerConfig, McpToolDescriptor } from '../types.js';
 import type { AdminSkillRegistryLike } from './types.js';
 

--- a/packages/plugin-memory/src/embedding-cache.ts
+++ b/packages/plugin-memory/src/embedding-cache.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
-import { writeFileAtomic } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 
 const INDEX_FILE = '.embeddings.json';
 const INDEX_VERSION = 1;

--- a/packages/plugin-memory/src/store.ts
+++ b/packages/plugin-memory/src/store.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
-import { createMutex, moxxyPath, writeFileAtomic, type EmbeddingProvider, type Mutex } from '@moxxy/sdk';
+import { createMutex, type EmbeddingProvider, type Mutex } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { renderFrontmatter } from './parse.js';
 import { TfIdfEmbedder } from './tfidf.js';
 import { EmbeddingIndex } from './embedding-cache.js';

--- a/packages/plugin-memory/src/store/io.ts
+++ b/packages/plugin-memory/src/store/io.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
-import { writeFileAtomic } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 import { parseMdFile } from '../parse.js';
 import {
   memoryFrontmatterSchema,

--- a/packages/plugin-oauth/src/credential-lock.ts
+++ b/packages/plugin-oauth/src/credential-lock.ts
@@ -26,7 +26,8 @@
 
 import { mkdir, open, rm, stat } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { MoxxyError, createMutex, moxxyPath, type Mutex } from '@moxxy/sdk';
+import { MoxxyError, createMutex, type Mutex } from '@moxxy/sdk';
+import { moxxyPath } from '@moxxy/sdk/server';
 
 export interface CredentialLockOptions {
   /** Directory holding the lock files. Default `<moxxy home>/locks`. */

--- a/packages/plugin-plugins-admin/src/config.ts
+++ b/packages/plugin-plugins-admin/src/config.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { type MoxxyConfig, moxxyConfigSchema } from '@moxxy/config';
-import { createMutex, moxxyPath, writeFileAtomic } from '@moxxy/sdk';
+import { createMutex } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { parse, stringify } from 'yaml';
 
 /**

--- a/packages/plugin-plugins-admin/src/install.ts
+++ b/packages/plugin-plugins-admin/src/install.ts
@@ -1,7 +1,8 @@
 import { spawn } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
-import { defineTool, moxxyPath, writeFileAtomic, z } from '@moxxy/sdk';
+import { defineTool, z } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { assertSafeNpmSpec, diffSnapshot, NPM_NAME_RE, type PluginSnapshot } from './shared.js';
 
 export type { PluginSnapshot } from './shared.js';

--- a/packages/plugin-provider-admin/src/store.ts
+++ b/packages/plugin-provider-admin/src/store.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
-import { createMutex, moxxyPath, writeFileAtomic, z } from '@moxxy/sdk';
+import { createMutex, z } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import type { StoredProvider, StoredProvidersConfig } from './types.js';
 
 /**

--- a/packages/plugin-scheduler/src/runner.ts
+++ b/packages/plugin-scheduler/src/runner.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { moxxyPath, writeFileAtomic } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { nextFireTime } from './cron.js';
 import type { ScheduleEntry, ScheduleStore } from './store.js';
 

--- a/packages/plugin-scheduler/src/store.ts
+++ b/packages/plugin-scheduler/src/store.ts
@@ -1,4 +1,5 @@
-import { createJsonFileStore, moxxyPath, type JsonFileStore } from '@moxxy/sdk';
+import { createJsonFileStore, type JsonFileStore } from '@moxxy/sdk';
+import { moxxyPath } from '@moxxy/sdk/server';
 import { ulid } from 'ulid';
 import { z } from 'zod';
 import { isValidCron } from './cron.js';

--- a/packages/plugin-self-update/src/core-update.ts
+++ b/packages/plugin-self-update/src/core-update.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { existsSync, promises as fs, readFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { writeFileAtomic } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 import { newTxnId } from './transaction.js';
 
 /**

--- a/packages/plugin-self-update/src/transaction.ts
+++ b/packages/plugin-self-update/src/transaction.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
-import { writeFileAtomic } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 
 /**
  * Transactional bookkeeping for self-update. Every change to a user-scope

--- a/packages/plugin-stt-whisper/src/audio.ts
+++ b/packages/plugin-stt-whisper/src/audio.ts
@@ -6,11 +6,15 @@
  * them here keeps the wrapper plugins thin.
  */
 
+import { MOXXY_PCM16_24KHZ_MIME } from '@moxxy/sdk';
+
 /** A custom MIME tag used by the TUI voice recorder to flag raw PCM16
  *  mono @ 24kHz bytes (ffmpeg's `-f s16le` output) so the transcriber
  *  knows to wrap them in a WAV header before upload. Public so other
- *  recorders / channels can mark their captures identically. */
-export const MOXXY_PCM16_24KHZ_MIME = 'audio/x-moxxy-pcm16-24khz';
+ *  recorders / channels can mark their captures identically. Sourced from
+ *  the SDK's zero-dep cross-package source of truth; re-exported here so the
+ *  existing `@moxxy/plugin-stt-whisper` surface stays stable. */
+export { MOXXY_PCM16_24KHZ_MIME };
 
 /** Default filename per MIME type, used to set the upload `filename` so
  *  the vendor's content sniffer routes to the right decoder. Defaults to

--- a/packages/plugin-vault/src/index.ts
+++ b/packages/plugin-vault/src/index.ts
@@ -2,13 +2,13 @@ import {
   z,
   defineTool,
   definePlugin,
-  moxxyPath,
   MoxxyError,
   type Plugin,
   type CommandDef,
   type EmittedEvent,
   type TurnId,
 } from '@moxxy/sdk';
+import { moxxyPath } from '@moxxy/sdk/server';
 import { createCombinedKeySource, type MasterKeySource } from './keysource.js';
 import { VaultStore } from './store.js';
 

--- a/packages/plugin-vault/src/keysource.ts
+++ b/packages/plugin-vault/src/keysource.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'node:fs';
-import { writeFileAtomic, moxxyPath } from '@moxxy/sdk';
+import { writeFileAtomic, moxxyPath } from '@moxxy/sdk/server';
 import { deriveKey } from './crypto.js';
 
 const KEYCHAIN_SERVICE = 'moxxy';

--- a/packages/plugin-vault/src/store.ts
+++ b/packages/plugin-vault/src/store.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
-import { writeFileAtomic, createMutex, MoxxyError, type Mutex } from '@moxxy/sdk';
+import { createMutex, MoxxyError, type Mutex } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 import { decrypt, encrypt, generateSalt, type EncryptedBlob } from './crypto.js';
 import type { MasterKeySource } from './keysource.js';
 

--- a/packages/plugin-webhooks/src/config.ts
+++ b/packages/plugin-webhooks/src/config.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
-import { createMutex, moxxyPath, writeFileAtomic, type Mutex } from '@moxxy/sdk';
+import { createMutex, type Mutex } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { z } from 'zod';
 
 /**

--- a/packages/plugin-webhooks/src/runner.ts
+++ b/packages/plugin-webhooks/src/runner.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
-import { moxxyPath, writeFileAtomic } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import type { WebhookStore, WebhookTrigger } from './store.js';
 
 /**

--- a/packages/plugin-webhooks/src/server.ts
+++ b/packages/plugin-webhooks/src/server.ts
@@ -1,5 +1,5 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
-import { readRequestBody } from '@moxxy/sdk';
+import { readRequestBody } from '@moxxy/sdk/server';
 import { DeliveryDedupeCache } from './dedupe.js';
 import { shouldFire } from './filter.js';
 import type { WebhookDispatcher } from './runner.js';

--- a/packages/plugin-webhooks/src/store.ts
+++ b/packages/plugin-webhooks/src/store.ts
@@ -1,5 +1,6 @@
 import { rename } from 'node:fs/promises';
-import { createJsonFileStore, moxxyPath, writeFileAtomic, type JsonFileStore } from '@moxxy/sdk';
+import { createJsonFileStore, type JsonFileStore } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { ulid } from 'ulid';
 import { z } from 'zod';
 

--- a/packages/plugin-webhooks/src/tools/shared.ts
+++ b/packages/plugin-webhooks/src/tools/shared.ts
@@ -1,7 +1,8 @@
 import { randomBytes } from 'node:crypto';
 import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
-import { moxxyPath, writeFileAtomic, z } from '@moxxy/sdk';
+import { z } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import type { WebhookConfigStore } from '../config.js';
 import type { WebhookDispatcher } from '../runner.js';
 import { filterRuleSchema, type WebhookStore, type WebhookVerification } from '../store.js';

--- a/packages/plugin-webhooks/src/tunnel.ts
+++ b/packages/plugin-webhooks/src/tunnel.ts
@@ -1,10 +1,9 @@
 import {
   defineTunnelProvider,
-  isCliTunnelAvailable,
-  spawnCliTunnel,
   type CliTunnelHandle,
   type TunnelProviderDef,
 } from '@moxxy/sdk';
+import { isCliTunnelAvailable, spawnCliTunnel } from '@moxxy/sdk/server';
 
 /**
  * Tunnel support for the webhooks listener.

--- a/packages/plugin-webhooks/src/verify.ts
+++ b/packages/plugin-webhooks/src/verify.ts
@@ -1,5 +1,5 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
-import { bearerTokenMatches } from '@moxxy/sdk';
+import { bearerTokenMatches } from '@moxxy/sdk/server';
 import type { WebhookTrigger, WebhookVerification } from './store.js';
 
 /**

--- a/packages/plugin-workflows/src/command.ts
+++ b/packages/plugin-workflows/src/command.ts
@@ -2,12 +2,12 @@ import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import {
   defineCommand,
-  writeFileAtomic,
   type CommandContext,
   type CommandDef,
   type CommandOutput,
   type WorkflowRunResult,
 } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 import { defaultUserWorkflowsDir } from './loader.js';
 import { serializeWorkflow } from './schema.js';
 import { slugify, triggerSummary } from './format.js';

--- a/packages/plugin-workflows/src/draft.ts
+++ b/packages/plugin-workflows/src/draft.ts
@@ -48,7 +48,7 @@ A workflow is a DAG of steps. Schema:
     - args: templated args object for tool/workflow steps
     - needs: [ <upstream step ids> ]  (defines the DAG; omit only for true sources)
     - when (optional, legacy): simple guards only — '{{ steps.x.output }} is not empty'. Do NOT use when for semantic decisions (use condition/switch).
-    - onError (optional): fail | continue | retry ; retries (optional, 0-3)
+    - onError (optional): fail | continue | retry ; retries (optional, 0-3 — only applies when onError is retry; fail/continue always run exactly one attempt)
 
 Operator data — two ways: declare a value the operator can supply UP FRONT as an \`inputs\` field (filled in before Run). To PAUSE mid-run and ask a question whose answer depends on earlier steps, set \`awaitInput: true\` on a prompt or skill step: the workflow pauses, surfaces the step's prompt to the operator, and resumes with their reply once they answer. Prefer \`inputs\` for known-up-front values; use \`awaitInput\` only for genuinely mid-run questions.
 

--- a/packages/plugin-workflows/src/engine.ts
+++ b/packages/plugin-workflows/src/engine.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
-import { moxxyPath, type Workflow, type WorkflowExecutorDef, type WorkflowRunDeps, type WorkflowRunResult } from '@moxxy/sdk';
+import { type Workflow, type WorkflowExecutorDef, type WorkflowRunDeps, type WorkflowRunResult } from '@moxxy/sdk';
+import { moxxyPath } from '@moxxy/sdk/server';
 import { ulid } from 'ulid';
 import { dagExecutor } from './executor/dag.js';
 

--- a/packages/plugin-workflows/src/executor/dag.test.ts
+++ b/packages/plugin-workflows/src/executor/dag.test.ts
@@ -296,6 +296,87 @@ describe('dag executor', () => {
     expect(result.steps[0]!.status).toBe('completed');
   });
 
+  // Retry contract (u117-3): `retries` is gated on `onError: 'retry'`. The three
+  // modes below pin the exact attempt count so 'retry' is behaviorally distinct
+  // from 'fail' and an author can't accidentally retry by setting retries on a
+  // non-retry mode.
+  it('onError=retry runs 1 + retries attempts when the step keeps failing', async () => {
+    let attempts = 0;
+    const h = makeHarness({
+      tools: {
+        get: () => ({}),
+        execute: async () => {
+          attempts += 1;
+          throw new Error('always');
+        },
+      },
+    });
+    const result = await dagExecutor.run(
+      wf({
+        name: 'retry-exhaust',
+        description: 'x',
+        steps: [{ id: 'a', tool: 'x', onError: 'retry', retries: 2 }],
+      }),
+      h.deps,
+    );
+    expect(result.ok).toBe(false);
+    expect(attempts).toBe(3); // 1 initial + 2 retries
+    expect(result.steps[0]!.status).toBe('failed');
+  });
+
+  it('onError=fail runs exactly ONE attempt even with retries set', async () => {
+    let attempts = 0;
+    const h = makeHarness({
+      tools: {
+        get: () => ({}),
+        execute: async () => {
+          attempts += 1;
+          throw new Error('boom');
+        },
+      },
+    });
+    const result = await dagExecutor.run(
+      wf({
+        name: 'fail-no-retry',
+        description: 'x',
+        steps: [{ id: 'a', tool: 'x', onError: 'fail', retries: 2 }],
+      }),
+      h.deps,
+    );
+    expect(result.ok).toBe(false);
+    expect(attempts).toBe(1); // retries ignored outside retry mode
+    expect(result.steps[0]!.status).toBe('failed');
+  });
+
+  it('onError=continue runs exactly ONE attempt even with retries set', async () => {
+    let attempts = 0;
+    const h = makeHarness({
+      tools: {
+        get: () => ({}),
+        execute: async () => {
+          attempts += 1;
+          throw new Error('boom');
+        },
+      },
+    });
+    const result = await dagExecutor.run(
+      wf({
+        name: 'continue-no-retry',
+        description: 'x',
+        steps: [
+          { id: 'a', tool: 'x', onError: 'continue', retries: 3 },
+          { id: 'b', needs: ['a'], prompt: 'b' },
+        ],
+      }),
+      h.deps,
+    );
+    expect(result.ok).toBe(true); // tolerated
+    expect(attempts).toBe(1); // retries ignored outside retry mode
+    const byId = Object.fromEntries(result.steps.map((s) => [s.id, s.status]));
+    expect(byId.a).toBe('failed');
+    expect(byId.b).toBe('completed');
+  });
+
   it('runs a nested workflow and captures its output', async () => {
     const inner = wf({ name: 'inner', description: 'x', steps: [{ id: 'i', prompt: 'hi' }] });
     const h = makeHarness();

--- a/packages/plugin-workflows/src/executor/dag.ts
+++ b/packages/plugin-workflows/src/executor/dag.ts
@@ -14,6 +14,6 @@ export { resumeWorkflowRun } from './scheduler.js';
 export const dagExecutor: WorkflowExecutorDef = defineWorkflowExecutor({
   name: DAG_EXECUTOR_NAME,
   description:
-    'DAG runner: steps with settled dependencies are scheduled in waves of up to `concurrency` ready steps, then executed sequentially within each wave (no overlap yet — `concurrency` caps the batch size, not wall-clock latency).',
+    'DAG runner: steps with settled dependencies are scheduled in waves of up to `concurrency` ready steps, then executed sequentially within each wave (no overlap — `concurrency` caps the batch size drained per pass, not wall-clock latency).',
   run: runExecutor,
 });

--- a/packages/plugin-workflows/src/executor/scheduler.ts
+++ b/packages/plugin-workflows/src/executor/scheduler.ts
@@ -110,15 +110,28 @@ export async function runExecutorLoop(
 
     // 3. Run a wave. `concurrency` caps the BATCH SIZE per scheduler pass; the
     //    steps in a wave are then executed STRICTLY SEQUENTIALLY (one awaited
-    //    `runStep` at a time below) — there is no actual parallelism today.
-    //    This is deliberate and load-bearing: logic/branch/pause steps mutate
-    //    shared state (vars, branch skips, checkpoints) and emit ordered
-    //    `workflow_step_*` events, and a hard failure must abort the rest of the
-    //    wave deterministically. Independent (pure tool/prompt/skill) steps
-    //    COULD overlap, but proving identical event ordering / vars-merge order
-    //    / error semantics is a behavior change deferred to a future pass — see
-    //    the executor description. `concurrency` therefore only bounds how many
-    //    ready steps are drained per pass, not wall-clock latency.
+    //    `runStep` at a time below) — there is NO actual parallelism, and
+    //    `concurrency` therefore bounds only how many ready steps are drained per
+    //    pass, not wall-clock latency.
+    //
+    //    Sequential execution is deliberate and load-bearing, NOT merely
+    //    deferred: overlapping even the "pure" tool/prompt/skill steps cannot
+    //    preserve the current observable contract, so parity is unprovable here:
+    //      - Event ordering: each step emits `workflow_step_started` then its
+    //        terminal `workflow_step_completed`/`workflow_step_failed` as an
+    //        atomic, non-interleaved pair, in declared wave order. Consumers
+    //        (progress UIs) rely on this; concurrent steps would interleave them.
+    //      - Error semantics: a hard failure (onError≠'continue') earlier in the
+    //        wave aborts the run and STOPS later same-wave steps from starting at
+    //        all (see the loop below + the "hard failure breaks the rest of the
+    //        wave" test). Concurrency would have already launched those steps,
+    //        changing which steps run, which events fire, and the spend.
+    //      - vars merge: logic-step `vars` merge into shared `ctx.vars` in wave
+    //        order; reordering merges is observable when keys collide.
+    //    Because these are all externally observable, no concurrent execution is
+    //    provably identical to the sequential one — so we keep it sequential and
+    //    the executor description states the sequential behavior plainly rather
+    //    than promising parallelism.
     const wave = ready.slice(0, Math.max(1, workflow.concurrency));
     const scope = buildScope(ctx, new Date(ctx.now()).toISOString());
 

--- a/packages/plugin-workflows/src/executor/steps.ts
+++ b/packages/plugin-workflows/src/executor/steps.ts
@@ -26,7 +26,14 @@ export async function runStep(
   scope: TemplateScope,
   ctx: ExecutorContext,
 ): Promise<StepOutcome> {
-  const attempts = 1 + Math.max(0, step.retries);
+  // Retries are gated on the three-valued `onError` contract:
+  //   - 'retry'           → run 1 + step.retries attempts (the count is honored).
+  //   - 'fail' / 'continue' → run EXACTLY ONE attempt, regardless of `retries`.
+  // This makes the `'retry'` enum value behaviorally distinct from `'fail'`
+  // (previously retries fired whenever `retries > 0` independent of onError, so
+  // `onError: 'fail' + retries: 3` silently retried — a latent semantic trap).
+  // `retries` only takes effect in retry mode now.
+  const attempts = step.onError === 'retry' ? 1 + Math.max(0, step.retries) : 1;
   let lastError = '';
   for (let attempt = 0; attempt < attempts; attempt++) {
     if (ctx.deps.signal.aborted) return { ok: false, output: '', error: 'aborted' };

--- a/packages/plugin-workflows/src/run-store.ts
+++ b/packages/plugin-workflows/src/run-store.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
-import { moxxyPath, writeFileAtomic, type Workflow, type WorkflowRunDeps } from '@moxxy/sdk';
+import { type Workflow, type WorkflowRunDeps } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { ulid } from 'ulid';
 
 /**

--- a/packages/plugin-workflows/src/schema.ts
+++ b/packages/plugin-workflows/src/schema.ts
@@ -55,6 +55,8 @@ const stepSchema = z
     needs: z.array(z.string().min(1)).default([]),
     when: z.string().min(1).optional(),
     onError: z.enum(['fail', 'continue', 'retry']).default('fail'),
+    // `retries` only takes effect when `onError: 'retry'`; with 'fail'/'continue'
+    // the step runs exactly one attempt (see runStep in executor/steps.ts).
     retries: z.number().int().min(0).max(3).default(0),
     label: z.string().max(60).optional(),
     format: z.enum(['json', 'plain']).optional(),

--- a/packages/plugin-workflows/src/store.ts
+++ b/packages/plugin-workflows/src/store.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
-import { createMutex, writeFileAtomic, type Mutex, type Workflow } from '@moxxy/sdk';
+import { createMutex, type Mutex, type Workflow } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 import {
   defaultProjectWorkflowsDir,
   defaultUserWorkflowsDir,

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -52,6 +52,8 @@ The package exports:
 - Lifecycle hook signatures (`onTurnStart`, `onAssistantMessage`, and so on).
 - Small helper utilities that do not pull the runtime along: token accounting, compactor helpers, zod-to-JSON-Schema, tool gating, embedding caching, retryable-error classification.
 
+The main barrel and the `./tool-display` subpath are free of Node builtins, so they are safe to value-import from a browser or React-Native bundle. Helpers that need a Node runtime (atomic file writes, the `~/.moxxy` path helpers, the CLI-tunnel spawner, the HTTP/WebSocket channel-auth toolkit) live on the **`@moxxy/sdk/server`** subpath instead — import those only from Node-side code.
+
 It is the only moxxy package safe to depend on from a published plugin. `@moxxy/core` is the runtime, and plugins never import it.
 
 ## Why depend on the SDK

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -45,9 +45,17 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.js"
+    },
     "./tool-display": {
       "types": "./dist/tool-display.d.ts",
       "import": "./dist/tool-display.js"
+    },
+    "./transcriber": {
+      "types": "./dist/transcriber.d.ts",
+      "import": "./dist/transcriber.js"
     }
   },
   "files": [

--- a/packages/sdk/src/compactor-helpers.test.ts
+++ b/packages/sdk/src/compactor-helpers.test.ts
@@ -9,6 +9,7 @@ import {
   isContextOverflowError,
   runCompactionIfNeeded,
   runElisionIfNeeded,
+  runManualCompaction,
   type CompactorDef,
   type EmittedEvent,
   type EventLogReader,
@@ -295,6 +296,111 @@ describe('runCompactionIfNeeded', () => {
     expect(did).toBe(true);
     expect(compact).toHaveBeenCalledOnce();
     expect(ctx.emitted.some((e) => e.type === 'compaction')).toBe(true);
+  });
+});
+
+describe('runManualCompaction', () => {
+  // An appendable reader matching ManualCompactionInput.log — records the
+  // appended event so we can assert defensive identity-fill.
+  function appendableLog(seed: ReadonlyArray<MoxxyEvent>): EventLogReader & {
+    append(event: EmittedEvent): Promise<MoxxyEvent>;
+    appended: EmittedEvent[];
+  } {
+    const events = [...seed];
+    const appended: EmittedEvent[] = [];
+    return {
+      ...reader(events),
+      appended,
+      append: async (e: EmittedEvent) => {
+        appended.push(e);
+        const mat = { ...e, id: asEventId(`a${appended.length}`), seq: events.length, ts: events.length, sessionId: sid } as MoxxyEvent;
+        events.push(mat);
+        return mat;
+      },
+    };
+  }
+
+  const seed: MoxxyEvent[] = [
+    event(0, { type: 'user_prompt', turnId: tid, source: 'user', text: 'x'.repeat(400) }),
+    event(1, { type: 'assistant_message', turnId: tid, source: 'model', content: 'y'.repeat(400), stopReason: 'end_turn' }),
+  ];
+
+  it('returns the no-op result for an empty log', async () => {
+    const log = appendableLog([]);
+    const compactor: CompactorDef = {
+      name: 'never',
+      shouldCompact: () => false,
+      compact: async () => { throw new Error('should not run'); },
+    };
+    const res = await runManualCompaction({ compactor, log });
+    expect(res).toEqual({ compacted: false, tokensSaved: 0, eventsCompacted: 0 });
+    expect(log.appended).toHaveLength(0);
+  });
+
+  it('compacts unconditionally (no shouldCompact gate) and reports counts', async () => {
+    const log = appendableLog(seed);
+    const shouldCompact = vi.fn().mockReturnValue(false); // would block the auto path
+    const compactor: CompactorDef = {
+      name: 'fake',
+      shouldCompact,
+      compact: async () => ({
+        type: 'compaction',
+        compactor: 'fake',
+        replacedRange: [0, 1],
+        summary: 'compressed',
+        tokensSaved: 123,
+      }),
+    };
+    const res = await runManualCompaction({ compactor, log });
+    // shouldCompact is NEVER consulted — manual compaction always runs.
+    expect(shouldCompact).not.toHaveBeenCalled();
+    expect(res).toEqual({ compacted: true, tokensSaved: 123, eventsCompacted: 2 });
+    expect(log.appended).toHaveLength(1);
+    // Defensive identity fill from the log tail + source=compactor.
+    expect(log.appended[0]).toMatchObject({ type: 'compaction', source: 'compactor', sessionId: sid, turnId: tid });
+  });
+
+  it('counts only events inside the inclusive replacedRange, not the seq span', async () => {
+    // A range [0, 999] spanning a gap: only the two real events fall inside.
+    const log = appendableLog([
+      event(0, { type: 'user_prompt', turnId: tid, source: 'user', text: 'x'.repeat(400) }),
+      event(500, { type: 'assistant_message', turnId: tid, source: 'model', content: 'z'.repeat(400), stopReason: 'end_turn' }),
+    ]);
+    const compactor: CompactorDef = {
+      name: 'wide',
+      shouldCompact: () => false,
+      compact: async () => ({
+        type: 'compaction', compactor: 'wide', replacedRange: [0, 999], summary: 's', tokensSaved: 50,
+      }),
+    };
+    const res = await runManualCompaction({ compactor, log });
+    expect(res.eventsCompacted).toBe(2);
+  });
+
+  it('reports no-op (no append) when the summary is empty / tokensSaved <= 0', async () => {
+    const log = appendableLog(seed);
+    const compactor: CompactorDef = {
+      name: 'empty',
+      shouldCompact: () => true,
+      compact: async () => ({
+        type: 'compaction', compactor: 'empty', replacedRange: [0, 1], summary: '   ', tokensSaved: 0,
+      }),
+    };
+    const res = await runManualCompaction({ compactor, log });
+    expect(res.compacted).toBe(false);
+    expect(log.appended).toHaveLength(0);
+  });
+
+  it('caller-supplied sessionId/turnId override the log-tail fallback', async () => {
+    const log = appendableLog(seed);
+    const compactor: CompactorDef = {
+      name: 'fake', shouldCompact: () => false,
+      compact: async () => ({ type: 'compaction', compactor: 'fake', replacedRange: [0, 1], summary: 'ok', tokensSaved: 10 }),
+    };
+    await runManualCompaction({
+      compactor, log, sessionId: asSessionId('other'), turnId: asTurnId('explicit'),
+    });
+    expect(log.appended[0]).toMatchObject({ sessionId: 'other', turnId: 'explicit' });
   });
 });
 

--- a/packages/sdk/src/compactor-helpers.ts
+++ b/packages/sdk/src/compactor-helpers.ts
@@ -7,9 +7,11 @@ import {
   toolResultStubbed,
   type ElisionState,
 } from './elision-state.js';
+import type { CompactorDef, TokenBudget } from './compactor.js';
 import type { EmittedEvent, MoxxyEvent } from './events.js';
 import type { EventLogReader } from './log.js';
 import type { ModeContext } from './mode.js';
+import type { LLMProvider } from './provider.js';
 
 /**
  * Cheap, no-network estimate of how many tokens the current event log
@@ -168,9 +170,15 @@ export async function runCompactionIfNeeded(
   const events = ctx.log.slice();
   if (events.length === 0) return false;
 
+  // Derive the elision state ONCE for this snapshot and thread it into the
+  // estimate — `computeElisionState` is memoized on the log version, but
+  // threading skips even the memo lookup and guarantees the estimate folds the
+  // exact same state the rest of this iteration uses.
+  const elisionState = computeElisionState(events);
+
   const budget = {
     contextWindow: resolved?.contextWindow ?? Number.MAX_SAFE_INTEGER,
-    estimatedTokens: estimateContextTokens(ctx.log),
+    estimatedTokens: estimateContextTokens(ctx.log, elisionState),
     reserveForOutput: resolved?.reserveForOutput ?? 0,
   } as const;
 
@@ -231,6 +239,122 @@ export async function runCompactionIfNeeded(
     });
     return false;
   }
+}
+
+/**
+ * Outcome of {@link runManualCompaction}. `compacted` is false (with the other
+ * counts at 0) whenever there was nothing to compact — empty log, no usable
+ * summary, or `tokensSaved <= 0` — so a caller can format "nothing to compact"
+ * vs "compacted N events" without re-deriving the gate.
+ */
+export interface ManualCompactionResult {
+  /** Did a CompactionEvent get appended? */
+  readonly compacted: boolean;
+  /** Estimated tokens the summary saves vs the replaced range. */
+  readonly tokensSaved: number;
+  /** Count of events whose `seq` fell inside the (inclusive) replaced range. */
+  readonly eventsCompacted: number;
+}
+
+const NO_COMPACTION: ManualCompactionResult = {
+  compacted: false,
+  tokensSaved: 0,
+  eventsCompacted: 0,
+};
+
+/**
+ * Shape a manual `/compact` needs from the session, kept structural so callers
+ * (plugin-commands) stay free of a `@moxxy/core` dependency — the host always
+ * passes a real Session that satisfies it. Mirrors the fields
+ * {@link runCompactionIfNeeded} reads off `ModeContext`, but log-first because
+ * a manual compaction has no live turn/mode context.
+ */
+export interface ManualCompactionInput {
+  readonly compactor: CompactorDef;
+  /** Authoring log the CompactionEvent is appended to. */
+  readonly log: EventLogReader & {
+    append(event: EmittedEvent): Promise<MoxxyEvent>;
+  };
+  /** Active provider/model so the default compactor writes a real summary. */
+  readonly provider?: LLMProvider;
+  readonly model?: string;
+  /** Active model's resolved context window (for `shouldCompact`). */
+  readonly contextWindow?: number;
+  readonly reserveForOutput?: number;
+  /** Cancellation signal; a fresh one is used when omitted. */
+  readonly signal?: AbortSignal;
+  /** Override the appended event's sessionId/turnId (else taken from the log tail). */
+  readonly sessionId?: string;
+  readonly turnId?: string;
+}
+
+/**
+ * Run ONE compaction now, unconditionally (the `/compact` command's force
+ * semantics — the threshold gate is skipped). The single shared implementation
+ * of the manual-compaction flow that `compactSession` in `@moxxy/plugin-commands`
+ * used to hand-roll: build the {@link TokenBudget} (with the same `estimate`
+ * + context-window fallback as the auto path), call `compactor.compact`, guard
+ * on an empty/zero-saving result, defensively fill the event's
+ * sessionId/turnId/source, append it, and report `{ compacted, tokensSaved,
+ * eventsCompacted }` so the caller only formats the message.
+ *
+ * Distinct from {@link runCompactionIfNeeded}, which is the per-iteration
+ * auto-compaction hook bound to a live `ModeContext` and gated by
+ * `shouldCompact` (unless forced). This one is log-first and always runs,
+ * matching how a user-invoked `/compact` works. Errors propagate to the caller
+ * (the command formats them); a no-op returns {@link NO_COMPACTION}.
+ */
+export async function runManualCompaction(
+  input: ManualCompactionInput,
+): Promise<ManualCompactionResult> {
+  const { compactor, log } = input;
+  const events = log.slice();
+  if (events.length === 0) return NO_COMPACTION;
+
+  // Match the auto path's window fallback: an unresolved window degrades to
+  // MAX_SAFE_INTEGER (manual compaction ignores the threshold anyway).
+  const contextWindow =
+    input.contextWindow && input.contextWindow > 0
+      ? input.contextWindow
+      : Number.MAX_SAFE_INTEGER;
+  const budget: TokenBudget = {
+    contextWindow,
+    estimatedTokens: estimateContextTokens(log),
+    reserveForOutput: input.reserveForOutput ?? 0,
+  };
+
+  const result = await compactor.compact(events, {
+    log,
+    budget,
+    signal: input.signal ?? new AbortController().signal,
+    ...(input.provider ? { provider: input.provider } : {}),
+    ...(input.model !== undefined ? { model: input.model } : {}),
+  });
+  if (result.tokensSaved <= 0 || result.summary.trim().length === 0) {
+    return NO_COMPACTION;
+  }
+
+  // Defensive-fill identity fields a spec-compliant compactor may omit
+  // (`compact` declares `Omit<CompactionEvent, keyof EventBase>`). The
+  // compactor's own values win (result spreads last). Mirrors
+  // `runCompactionIfNeeded`.
+  const lastEvent = events[events.length - 1];
+  const emittable: EmittedEvent = {
+    sessionId: input.sessionId ?? lastEvent?.sessionId,
+    turnId: input.turnId ?? lastEvent?.turnId,
+    source: 'compactor',
+    ...result,
+  } as EmittedEvent;
+  await log.append(emittable);
+
+  // `replacedRange` is an INCLUSIVE [fromSeq, toSeq] of event `seq` VALUES, not
+  // array indices — and `seq === arrayIndex` is not guaranteed for
+  // mirrors/partial views. Count the events actually inside the range rather
+  // than differencing the seqs (which would overstate across any seq gap).
+  const [fromSeq, toSeq] = result.replacedRange;
+  const eventsCompacted = events.filter((e) => e.seq >= fromSeq && e.seq <= toSeq).length;
+
+  return { compacted: true, tokensSaved: result.tokensSaved, eventsCompacted };
 }
 
 /**

--- a/packages/sdk/src/elision-helpers.ts
+++ b/packages/sdk/src/elision-helpers.ts
@@ -1,5 +1,5 @@
 import { estimateContextTokens, resolveModelContext } from './compactor-helpers.js';
-import { toolResultBytes } from './elision-state.js';
+import { computeElisionState, toolResultBytes } from './elision-state.js';
 import type { EmittedEvent, MoxxyEvent } from './events.js';
 import type { ElisionSettings, ModeContext } from './mode.js';
 
@@ -67,12 +67,21 @@ export async function runElisionIfNeeded(ctx: ModeContext): Promise<void> {
     if (!resolved) return;
     const contextWindow = resolved.contextWindow;
 
-    // Gate: below this fill the whole history fits comfortably — eliding would
-    // only add missed-context risk for no token benefit.
-    if (estimateContextTokens(ctx.log) < s.minContextRatioToElide * contextWindow) return;
-
     const events = ctx.log.slice();
     if (events.length === 0) return;
+
+    // Derive the elision state ONCE for this snapshot and thread it into the
+    // gate's estimate. The same `computeElisionState` fold otherwise runs again
+    // inside `estimateContextTokens` (and a third time in projection this
+    // iteration); threading shares the one fold. Order vs the slice is
+    // irrelevant — both read the same immutable snapshot.
+    const elisionState = computeElisionState(events);
+
+    // Gate: below this fill the whole history fits comfortably — eliding would
+    // only add missed-context risk for no token benefit.
+    if (estimateContextTokens(ctx.log, elisionState) < s.minContextRatioToElide * contextWindow) {
+      return;
+    }
 
     const priorHWM = events.reduce(
       (max, e) => (e.type === 'elision' ? Math.max(max, e.elidedThrough) : max),

--- a/packages/sdk/src/elision-state.test.ts
+++ b/packages/sdk/src/elision-state.test.ts
@@ -255,3 +255,81 @@ describe('computeElisionState (golden: fused == 4-pass reference)', () => {
     assertSameState(state, computeElisionStateOld(events));
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Memo correctness (complexity-hotspots-7 / u122-2): the single-slot memo keyed
+// on the input array's IDENTITY must (a) return the cached state for the same
+// immutable snapshot (a cache HIT — the identical reference), and (b) RECOMPUTE
+// — never serve a stale state — for any different array, including a new event
+// appended past the HWM or a re-config that reuses the same ids/seqs.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('computeElisionState (memo correctness)', () => {
+  const baseLog = (): MoxxyEvent[] => [
+    event(0, { type: 'user_prompt', turnId: t1, source: 'user', text: 'the task' }),
+    event(1, { type: 'tool_call_requested', turnId: t1, source: 'model', callId: asToolCallId('ra'), name: 'recall', input: { callId: 'x' } }),
+    event(2, { type: 'tool_result', turnId: t1, source: 'tool', callId: asToolCallId('ra'), ok: true, output: 'A'.repeat(300) }),
+    event(3, {
+      type: 'elision', turnId: t2, source: 'system', elidedThrough: 2, stubbedRanges: [[0, 2]],
+      elideConversational: true, conversationalRecallThreshold: 4, maxRecallBytes: 1000, neverElideTools: [], tokensSaved: 100,
+    }),
+    event(4, { type: 'user_prompt', turnId: t2, source: 'user', text: 'recent' }),
+  ];
+
+  it('returns the cached state for the same snapshot, equal to a fresh fold', () => {
+    const events = baseLog();
+    const a = computeElisionState(events);
+    // Same array reference → memo HIT → the identical cached reference.
+    expect(computeElisionState(events)).toBe(a);
+    // …and it equals an uncached fresh fold of the same snapshot.
+    assertSameState(a, computeElisionStateOld(events));
+  });
+
+  it('invalidates (recomputes) when a new event is appended past the HWM', () => {
+    const events = baseLog();
+    const before = computeElisionState(events);
+    expect(before.hwm).toBe(2);
+    // A NEW snapshot array with one more tail event must NOT serve `before`.
+    const grown = [
+      ...events,
+      event(5, { type: 'tool_call_requested', turnId: t2, source: 'model', callId: asToolCallId('rb'), name: 'recall', input: { callId: 'y' } }),
+    ];
+    const after = computeElisionState(grown);
+    expect(after).not.toBe(before); // recomputed, not the cached ref
+    // `rb` only exists in the grown log → its presence proves invalidation.
+    expect(after.recallResultCallIds.has('rb')).toBe(true);
+    expect(before.recallResultCallIds.has('rb')).toBe(false);
+    assertSameState(after, computeElisionStateOld(grown));
+    // A new ElisionEvent that advances the HWM also invalidates.
+    const reElided = [
+      ...grown,
+      event(6, { type: 'tool_result', turnId: t2, source: 'tool', callId: asToolCallId('rb'), ok: true, output: 'B'.repeat(50) }),
+      event(7, {
+        type: 'elision', turnId: t2, source: 'system', elidedThrough: 6, stubbedRanges: [[3, 6]],
+        elideConversational: true, conversationalRecallThreshold: 4, maxRecallBytes: 1000, neverElideTools: [], tokensSaved: 200,
+      }),
+    ];
+    const advanced = computeElisionState(reElided);
+    expect(advanced.hwm).toBe(6);
+    assertSameState(advanced, computeElisionStateOld(reElided));
+  });
+
+  it('never serves a stale state for a re-config that reuses the same ids/seqs', () => {
+    // Two logically-distinct logs with byte-identical ids/seqs but different
+    // elision config — the exact case a content hash of id+seq would collide on
+    // and serve stale. Distinct array instances → distinct memo keys → correct.
+    const mk = (threshold: number): MoxxyEvent[] => [
+      event(0, { type: 'user_prompt', turnId: t1, source: 'user', text: 'the task' }),
+      event(1, { type: 'tool_call_requested', turnId: t1, source: 'model', callId: asToolCallId('s1'), name: 'recall', input: { seq: 0 } }),
+      event(2, { type: 'tool_call_requested', turnId: t1, source: 'model', callId: asToolCallId('s2'), name: 'recall', input: { seq: 0 } }),
+      event(3, {
+        type: 'elision', turnId: t2, source: 'system', elidedThrough: 2, stubbedRanges: [[0, 2]],
+        elideConversational: true, conversationalRecallThreshold: threshold, maxRecallBytes: 1000, neverElideTools: [], tokensSaved: 10,
+      }),
+      event(4, { type: 'user_prompt', turnId: t2, source: 'user', text: 'next' }),
+    ];
+    const on = computeElisionState(mk(3)); // threshold 3 > 2 seq-recalls → ON
+    const off = computeElisionState(mk(2)); // threshold 2 == 2 → OFF
+    expect(on.effectiveElideConversational).toBe(true);
+    expect(off.effectiveElideConversational).toBe(false);
+  });
+});

--- a/packages/sdk/src/elision-state.ts
+++ b/packages/sdk/src/elision-state.ts
@@ -71,11 +71,53 @@ const EMPTY_STATE: ElisionState = {
 };
 
 /**
+ * Single-slot memo of the most recent {@link computeElisionState} result,
+ * keyed on the IDENTITY of the events array it was folded from.
+ *
+ * The event log is append-only and every held event is immutable (invariant
+ * #6: events at/below the HWM never change), so a given snapshot array is a
+ * stable, never-mutated value: the same array reference always denotes the
+ * same content and therefore the same state. A new turn produces a NEW snapshot
+ * array (the live `log.slice()` returns a fresh array each call), so the memo
+ * self-invalidates the moment the log changes — there is no way for it to serve
+ * a state that is stale for the array it is keyed on.
+ *
+ * Keying on identity (not a content hash of `id`/`seq`/payload) is the only
+ * SOUND single-slot choice for a pure fold over an arbitrary array: two
+ * logically-different logs can share ids/seqs (e.g. a test that rebuilds the
+ * same prefix with different payload, or a re-config), and a content hash that
+ * missed a payload field would serve a stale state — a correctness bug. Array
+ * identity can never collide across distinct values.
+ *
+ * The win: callers that re-ask over the SAME snapshot within an iteration
+ * (e.g. the elision/compaction gates and the estimate, when they thread the
+ * one `log.slice()` array — see `estimateContextTokens`) fold it only once;
+ * `WeakMap` would also help a held snapshot survive GC pressure, but a single
+ * slot keeps it allocation-free and matches the "one live snapshot at a time"
+ * access pattern. Threading a precomputed state is the explicit zero-cost fast
+ * path; this memo covers callers that re-pass the same array but can't thread.
+ */
+let memoEvents: ReadonlyArray<MoxxyEvent> | null = null;
+let memoState: ElisionState | null = null;
+
+/**
  * Derive elision state purely from the log: the active high-water mark + flags
  * (from the latest ElisionEvent), the callId→tool map, recall bookkeeping, the
  * adaptive conversational auto-disable, and which pinned recalls exceed the cap.
+ *
+ * Memoized on the input array's identity (see above) so repeated calls over the
+ * same immutable snapshot fold it only once. The returned state is identical
+ * (and `===` on a cache hit) to a fresh fold.
  */
 export function computeElisionState(events: ReadonlyArray<MoxxyEvent>): ElisionState {
+  if (memoEvents === events && memoState !== null) return memoState;
+  const state = computeElisionStateUncached(events);
+  memoEvents = events;
+  memoState = state;
+  return state;
+}
+
+function computeElisionStateUncached(events: ReadonlyArray<MoxxyEvent>): ElisionState {
   let hwm = -1;
   let elideConversational = false;
   let conversationalRecallThreshold = Number.POSITIVE_INFINITY;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -181,15 +181,12 @@ export type {
   SpawnCliTunnelOptions,
   CliTunnelHandle,
 } from './tunnel.js';
-export { spawnCliTunnel, isCliTunnelAvailable } from './tunnel.js';
+// Node-runtime helpers (spawnCliTunnel/isCliTunnelAvailable, writeFileAtomic*,
+// moxxyHome/moxxyPath, readRequestBody/bearerTokenMatches, channel-auth) are
+// exported from the './server' subpath, NOT the main barrel — they statically
+// reach node:* builtins and would break a browser/RN bundle. See ./server.ts.
 export { isRetryableError, toFriendlyError, zodToJsonSchema, estimateTextTokens, type StopReason } from './provider-utils.js';
-export {
-  writeFileAtomic,
-  writeFileAtomicSync,
-  moxxyHome,
-  moxxyPath,
-  type WriteFileAtomicOptions,
-} from './fs-utils.js';
+export type { WriteFileAtomicOptions } from './fs-utils.js';
 export { createMutex, type Mutex } from './mutex.js';
 export {
   createJsonFileStore,
@@ -198,17 +195,9 @@ export {
 } from './json-file-store.js';
 export { assertNever } from './assert.js';
 export { compareSemver, parseSemverCore } from './semver.js';
-export { readRequestBody, bearerTokenMatches } from './http-utils.js';
-export {
-  resolveChannelToken,
-  rotateChannelToken,
-  bearerGuard,
-  encodeWsBearerProtocol,
-  tokenFromWsProtocolHeader,
-  MOXXY_WS_SUBPROTOCOL,
-  MOXXY_WS_BEARER_PROTOCOL_PREFIX,
-  type ChannelTokenOptions,
-} from './channel-auth.js';
+// readRequestBody/bearerTokenMatches (http-utils) and the channel-auth value
+// helpers live on the './server' subpath — they reach node:http/crypto/fs/path.
+export type { ChannelTokenOptions } from './channel-auth.js';
 export {
   autoAllowResolver,
   denyByDefaultResolver,
@@ -254,7 +243,11 @@ export type { TokenBudget, CompactContext, CompactorDef } from './compactor.js';
 export {
   estimateContextTokens,
   runCompactionIfNeeded,
+  runManualCompaction,
+  resolveModelContext,
   isContextOverflowError,
+  type ManualCompactionInput,
+  type ManualCompactionResult,
 } from './compactor-helpers.js';
 export {
   runElisionIfNeeded,
@@ -403,6 +396,7 @@ export type {
   TranscriptionSegment,
   TranscribeOptions,
 } from './transcriber.js';
+export { MOXXY_PCM16_24KHZ_MIME } from './transcriber.js';
 
 export type {
   Synthesizer,

--- a/packages/sdk/src/mode/project-messages.ts
+++ b/packages/sdk/src/mode/project-messages.ts
@@ -61,6 +61,15 @@ export interface ProjectMessagesOptions {
   readonly systemPrompt?: string;
   /** Optional trailing user message — useful for plan-execute's "Focus on this step now: X". */
   readonly trailingUserText?: string;
+  /**
+   * Optional precomputed elision state for THIS exact log snapshot. When a
+   * caller already derived it within the same loop iteration (e.g. the
+   * compaction/elision gates), threading it here skips a redundant
+   * `computeElisionState` fold. MUST be the state of the same log — a stale one
+   * would mis-render stubs — so it is purely an opt-in fast path; omitting it
+   * recomputes (memoized on the log version), byte-identically.
+   */
+  readonly precomputedElisionState?: ElisionState;
 }
 
 interface CompactionRange {
@@ -260,7 +269,10 @@ export function projectMessages(
   const compactions = activeCompactionRanges(allEvents);
   const compactionFor = makeCompactionLookup(compactions);
   const emittedCompactions = new Set<CompactionRange>();
-  const el = computeElisionState(allEvents);
+  // Reuse a threaded state when the caller already derived it for this exact
+  // snapshot; otherwise `computeElisionState` is memoized on the log version so
+  // the in-iteration projection still folds only once.
+  const el = opts.precomputedElisionState ?? computeElisionState(allEvents);
 
   const messages: ProviderMessage[] = [];
   // The stable prefix is every message produced from events at/below the

--- a/packages/sdk/src/package-root.test.ts
+++ b/packages/sdk/src/package-root.test.ts
@@ -37,4 +37,41 @@ describe('@moxxy/sdk package root', () => {
 
     expect(check.issues[0]?.requirement.name).toBe('auth:provider:openai-codex');
   });
+
+  // The main barrel is the browser/RN-safe surface: a value import of any of
+  // these would drag a node:* builtin into a Metro/browser bundle. They live on
+  // the './server' subpath instead. This pins the split so a future accidental
+  // re-export on the main barrel is caught (see .dependency-cruiser.cjs
+  // `no-node-builtins-in-renderer`).
+  const NODE_ONLY_VALUE_EXPORTS = [
+    'spawnCliTunnel',
+    'isCliTunnelAvailable',
+    'writeFileAtomic',
+    'writeFileAtomicSync',
+    'moxxyHome',
+    'moxxyPath',
+    'readRequestBody',
+    'bearerTokenMatches',
+    'resolveChannelToken',
+    'rotateChannelToken',
+    'bearerGuard',
+    'encodeWsBearerProtocol',
+    'tokenFromWsProtocolHeader',
+    'MOXXY_WS_SUBPROTOCOL',
+    'MOXXY_WS_BEARER_PROTOCOL_PREFIX',
+  ] as const;
+
+  it('does NOT expose Node-runtime values on the browser/RN-safe main barrel', async () => {
+    const sdk: Record<string, unknown> = await import('@moxxy/sdk');
+    for (const name of NODE_ONLY_VALUE_EXPORTS) {
+      expect(sdk[name], `${name} must not be on the @moxxy/sdk main barrel`).toBeUndefined();
+    }
+  });
+
+  it('exposes the Node-runtime helpers on the @moxxy/sdk/server subpath', async () => {
+    const server: Record<string, unknown> = await import('@moxxy/sdk/server');
+    for (const name of NODE_ONLY_VALUE_EXPORTS) {
+      expect(server[name], `${name} must be exported from @moxxy/sdk/server`).toBeDefined();
+    }
+  });
 });

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -1,0 +1,34 @@
+/**
+ * Node-runtime-only surface of @moxxy/sdk.
+ *
+ * Importing `@moxxy/sdk/server` pulls in the value helpers that statically
+ * depend on Node builtins (`node:child_process`, `node:fs`, `node:os`,
+ * `node:http`, `node:crypto`, `node:path`). The MAIN barrel (`@moxxy/sdk`) is
+ * deliberately kept free of these so a browser/React-Native bundle can value-
+ * import from it (and from `@moxxy/sdk/tool-display`) without dragging a Node
+ * builtin into the bundle — Metro cannot polyfill `node:child_process`.
+ *
+ * Node-side consumers (cli, runner, desktop-host, channel/oauth/webhooks
+ * plugins, …) import these helpers from here. The corresponding *type* exports
+ * (e.g. `TunnelHandle`, `WriteFileAtomicOptions`, `ChannelTokenOptions`) remain
+ * on the main barrel because types are erased at build time and never reach a
+ * bundle.
+ */
+
+export { spawnCliTunnel, isCliTunnelAvailable } from './tunnel.js';
+export {
+  writeFileAtomic,
+  writeFileAtomicSync,
+  moxxyHome,
+  moxxyPath,
+} from './fs-utils.js';
+export { readRequestBody, bearerTokenMatches } from './http-utils.js';
+export {
+  resolveChannelToken,
+  rotateChannelToken,
+  bearerGuard,
+  encodeWsBearerProtocol,
+  tokenFromWsProtocolHeader,
+  MOXXY_WS_SUBPROTOCOL,
+  MOXXY_WS_BEARER_PROTOCOL_PREFIX,
+} from './channel-auth.js';

--- a/packages/sdk/src/transcriber.test.ts
+++ b/packages/sdk/src/transcriber.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { MOXXY_PCM16_24KHZ_MIME } from './transcriber.js';
+
+describe('MOXXY_PCM16_24KHZ_MIME', () => {
+  it('locks the cross-package wire value', () => {
+    // This is a PROTOCOL constant: the desktop/web capture path stamps it onto
+    // the audio blob and the Codex transcriber keys on it to wrap the raw PCM
+    // samples in a WAV header. Drift in the literal silently breaks
+    // transcription with no compile-time signal — so pin the exact bytes here.
+    expect(MOXXY_PCM16_24KHZ_MIME).toBe('audio/x-moxxy-pcm16-24khz');
+  });
+});

--- a/packages/sdk/src/transcriber.ts
+++ b/packages/sdk/src/transcriber.ts
@@ -18,6 +18,20 @@
  *     used by models that advertise `supportsAudio: true`.
  */
 
+/**
+ * Wire MIME tag for raw 16-bit little-endian PCM mono at 24 kHz — the lossless
+ * format the desktop/web mic capture path produces and that the Codex
+ * transcriber keys on to wrap the bytes in a WAV header before upload.
+ *
+ * This is a cross-package PROTOCOL value: client-platform-web stamps it onto
+ * the captured blob, plugin-cli forwards it as the attachment `mimeType`, and
+ * plugin-stt-whisper switches on it. It lived as an independently-redeclared
+ * literal in all three (silent transcription breakage if any drifted), so it is
+ * hoisted here to the SDK's single zero-dep typed surface as the source of
+ * truth. Consumers should import this rather than re-spell the literal.
+ */
+export const MOXXY_PCM16_24KHZ_MIME = 'audio/x-moxxy-pcm16-24khz';
+
 export interface TranscriptionSegment {
   /** Segment start, in seconds from the start of the clip. */
   readonly start: number;

--- a/packages/testing/src/record-replay.ts
+++ b/packages/testing/src/record-replay.ts
@@ -5,8 +5,8 @@ import {
   type ModelDescriptor,
   type ProviderEvent,
   type ProviderRequest,
-  writeFileAtomic,
 } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 import { hashRequest } from './hash.js';
 
 export type FixtureMode = 'replay' | 'record' | 'passthrough';

--- a/packages/tools-builtin/src/edit.ts
+++ b/packages/tools-builtin/src/edit.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
-import { MoxxyError, defineTool, writeFileAtomic, z } from '@moxxy/sdk';
+import { MoxxyError, defineTool, z } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 import { buildFileDiffDisplay } from './file-diff.js';
 import { resolvePath } from './util.js';
 

--- a/packages/tools-builtin/src/write.ts
+++ b/packages/tools-builtin/src/write.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
-import { MoxxyError, defineTool, writeFileAtomic, z } from '@moxxy/sdk';
+import { MoxxyError, defineTool, z } from '@moxxy/sdk';
+import { writeFileAtomic } from '@moxxy/sdk/server';
 import { buildFileDiffDisplay } from './file-diff.js';
 import { resolvePath } from './util.js';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,6 +623,9 @@ importers:
       '@moxxy/client-core':
         specifier: workspace:*
         version: link:../client-core
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
     devDependencies:
       '@moxxy/tsconfig':
         specifier: workspace:*


### PR DESCRIPTION
## Quality sweep — wave 8 (finalize: close the deferred-for-scope items)

Implements the remaining items that earlier waves deferred for scope/risk, so the
audit backlog reaches zero open findings. Integrated cleanly with `main`'s
concurrently-merged work (anonymizer mini-app, mode-collaborative) — full gate
re-run on the merged tree.

- **`@moxxy/sdk/server` subpath:** the Node-only helpers (tunnel / fs-utils /
  http-utils / channel-auth) move behind `@moxxy/sdk/server` and are dropped from
  the browser/RN-safe main barrel; every node-side consumer is re-pointed. `check:deps`
  is widened to cruise `apps/desktop/src` + `apps/mobile-poc/src` with a
  `no-node-builtins-in-renderer` **error** rule (orphan-check scoped off the
  bundler-resolved renderer to avoid false positives). Closes the SDK node-leak.
- **PCM16 MIME** hoisted to the SDK; client-platform-web / plugin-stt-whisper /
  plugin-cli import it. **`/compact`** routes through a shared SDK
  `runManualCompaction`. **`computeElisionState`** memoized on snapshot identity +
  threaded once per iteration (byte-identical, golden-tested).
- **workflows** `onError:'retry'` now honours `step.retries` (fail/continue = one
  attempt); DAG wave concurrency resolved.
- **permissions:** documented the intentional substring semantics of `inputMatches`
  (anchoring would break existing rule files — not changed).

### Deliberate by-design closures (documented in `TECH_DEBT.md`)
- `RequirementChecker.targetInfo` keeps its explicit per-kind switch (clarity +
  safety in a correctness-critical gate > a DRY table).
- Voice-admin tools stay decomposed in-place (atomicity met; a separate package is
  a non-goal for cli-bundled builtins).

### Verification (on the merged tree)
`pnpm build` 67/67 · `typecheck` 132/132 · `test` all pass · `lint` 0 errors ·
`check:deps` clean (991 modules).
