### PR TITLE
feat(surfaces): interactive in-window browser + richer file preview

### DIFF
--- a/.changeset/interactive-browser-richer-file-preview.md
+++ b/.changeset/interactive-browser-richer-file-preview.md
@@ -1,0 +1,26 @@
+---
+"@moxxy/plugin-browser": patch
+"@moxxy/desktop-host": patch
+"@moxxy/desktop-ipc-contract": patch
+"@moxxy/desktop": patch
+---
+
+feat(surfaces): interactive in-window browser + richer file preview
+
+**Browser — a genuinely interactive, full-bleed view.** The live view now behaves
+like a real browser: click / double-click, hover (`:hover` styles + tooltips via
+pointer move), scroll, full keyboard incl. modifier shortcuts, and
+back/forward/reload — with a snappier refresh that bursts a fresh frame after each
+interaction. The page viewport is resized to the pane (`surface.resize` →
+`setviewport`) so the view fills the whole container instead of being letterboxed,
+and clicks map 1:1. The install/loading states are on-brand (spinner, primary
+Button, indeterminate progress bar, condensed progress line) instead of dumping
+raw npm output.
+
+**Files — preview opens far more types.** Images and PDFs render inline (PDF via
+Chromium's viewer in a `blob:` iframe — `frame-src blob:` added to the CSP);
+text/code open directly; binary-looking or very large files prompt before opening
+as text (a huge blob in a `<pre>` can crash the renderer). `workspace.readFile`
+gained a discriminated result (`kind: text | image | pdf | confirm` plus
+`mediaType` / `base64` / `reason` / `byteLength`) and a `force` flag, and reads
+only a head window via a file handle so a multi-GB file never loads whole.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -381,6 +381,22 @@ item — the debt it *creates* is logged here on sight:
   progress, then restarts the sidecar. **Constraint:** the install runs in the
   runner via PATH-resolved `npm`/`npx` (same assumption as the existing browser-
   binary auto-install) — a GUI launch must keep node/npm on the runner's PATH.
+- **Browser surface is now interactive + viewport-fitted (still polled JPEG).**
+  Added sidecar `mousemove`/`setviewport`/`back`/`forward`/`reload` + clickCount;
+  the surface `resize()` matches the page viewport to the pane (fills the
+  container, 1:1 click mapping) and bursts a follow-up frame after each input for
+  responsiveness. **Dormant debt:** it's still screenshot-polling, so there's no
+  true cursor/video and hover costs an RPC+frame per (throttled) move — if this
+  needs to feel fully native, revisit CDP screencast *with* a polling fallback
+  (the no-frame-on-blank-page trap that reverted it the first time).
+- **Files viewer renders images + PDFs inline; binary/large files gated.**
+  `workspace.readFile` gained a discriminated result (`kind: text|image|pdf|
+  confirm` + `mediaType`/`base64`/`reason`/`byteLength`) and a `force` arg;
+  it reads only a head window via a file handle (a multi-GB file never loads
+  whole). PDFs render in a `blob:` iframe — required adding `blob:` to the CSP
+  `frame-src` (`security.ts`). **Dormant debt:** non-PDF office docs (docx/xlsx)
+  still fall to the binary `confirm` → open-as-text (garbled); a real office
+  preview would need a converter.
 - **Surfaces are desktop-only — deliberately off the mobile WS allow-list**
   (`REMOTE_ALLOWED_COMMANDS`). A sandboxed shell/browser over a tunnel is a real
   feature with its own threat model; revisit when mobile needs it.

--- a/apps/desktop/src/shell/surfaces/BrowserPane.tsx
+++ b/apps/desktop/src/shell/surfaces/BrowserPane.tsx
@@ -1,5 +1,5 @@
-import { useRef, useState } from 'react';
-import { Icon } from '@moxxy/desktop-ui';
+import { useEffect, useRef, useState } from 'react';
+import { Button, Icon, IconButton } from '@moxxy/desktop-ui';
 import { useSurface } from './useSurface';
 
 interface BrowserFrame {
@@ -14,13 +14,37 @@ interface BrowserFrame {
   readonly needsInstall?: boolean;
 }
 
+/** Keys (beyond single printable chars) we forward to the page; everything else
+ *  — lone modifiers, F-keys, etc. — is ignored so it can't drive the host UI. */
+const NAMED_KEYS = new Set([
+  'Enter', 'Backspace', 'Tab', 'Escape', 'Delete',
+  'Home', 'End', 'PageUp', 'PageDown',
+  'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown',
+]);
+
+/** Brand spinner (matches ChatLoading) for the launching/installing states. */
+function Spinner({ size = 22 }: { readonly size?: number }): JSX.Element {
+  return (
+    <span
+      aria-hidden
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        border: '2.5px solid var(--color-card-border)',
+        borderTopColor: 'var(--color-primary)',
+        animation: 'moxxy-spin 0.8s linear infinite',
+      }}
+    />
+  );
+}
+
 /**
- * The in-window browser pane: a live view of the agent's Playwright page,
- * streamed as frames (`{ type: 'frame', base64, url }`). The user and the agent
- * share ONE page — the agent's navigations/clicks (via `browser_session`) show
- * up here, and the user's clicks/keys/scroll are proxied back to the same page
- * via `surface.input`. Coordinates are sent normalized (0..1) so the backend
- * maps them onto the page viewport regardless of pane size.
+ * The in-window browser pane: a live, interactive view of the agent's Playwright
+ * page. Frames stream in as JPEGs (`{ type: 'frame', base64, url }`); the user's
+ * clicks/hover/keys/scroll/navigation are proxied back to the SAME page via
+ * `surface.input`, and the pane resizes the page viewport to fill the container
+ * (`surface.resize`). The agent and the user share ONE page.
  */
 export function BrowserPane({ workspaceId }: { readonly workspaceId: string | null }): JSX.Element {
   const [frame, setFrame] = useState<string | null>(null);
@@ -29,7 +53,9 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
   const [installing, setInstalling] = useState(false);
   const [url, setUrl] = useState('');
   const [editingUrl, setEditingUrl] = useState('');
-  const imgRef = useRef<HTMLDivElement | null>(null);
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const urlInputRef = useRef<HTMLInputElement | null>(null);
+  const lastMoveRef = useRef(0);
 
   const apply = (payload: unknown): void => {
     const p = payload as BrowserFrame;
@@ -54,7 +80,42 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
   };
 
   const surface = useSurface(workspaceId, 'browser', { onSnapshot: apply, onData: apply });
-  const urlInputRef = useRef<HTMLInputElement | null>(null);
+  // Stable ref so the resize effect always reaches the latest sender.
+  const surfaceRef = useRef(surface);
+  surfaceRef.current = surface;
+
+  // Keep the page viewport matched to the pane so the live view fills the whole
+  // container (no letterbox) and click coords map 1:1. Debounced to one rAF.
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    let raf = 0;
+    const send = (): void => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        const width = Math.round(host.clientWidth);
+        const height = Math.round(host.clientHeight);
+        if (width > 0 && height > 0) surfaceRef.current.resize({ width, height });
+      });
+    };
+    const ro = new ResizeObserver(send);
+    ro.observe(host);
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      ro.disconnect();
+    };
+  }, []);
+
+  // Push the initial size once the surface attaches (the ResizeObserver's first
+  // fire may land before the runner is ready, when resize is a no-op).
+  useEffect(() => {
+    if (!surface.ready) return;
+    const host = hostRef.current;
+    if (host && host.clientWidth > 0 && host.clientHeight > 0) {
+      surface.resize({ width: Math.round(host.clientWidth), height: Math.round(host.clientHeight) });
+    }
+  }, [surface.ready]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const navigate = (raw: string): void => {
     const u = raw.trim();
@@ -70,51 +131,94 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
     surface.input({ type: 'install' });
   };
 
-  // Translate a pointer event in the frame box to normalized page coords.
+  // Pointer event → normalized page coords (0..1 of the frame box).
   const norm = (e: React.MouseEvent): { fx: number; fy: number } | null => {
-    const rect = imgRef.current?.getBoundingClientRect();
+    const rect = hostRef.current?.getBoundingClientRect();
     if (!rect || rect.width === 0 || rect.height === 0) return null;
     return { fx: (e.clientX - rect.left) / rect.width, fy: (e.clientY - rect.top) / rect.height };
   };
 
+  const onHover = (e: React.MouseEvent): void => {
+    const now = Date.now();
+    if (now - lastMoveRef.current < 90) return; // throttle hover RPCs
+    lastMoveRef.current = now;
+    const n = norm(e);
+    if (n) surface.input({ type: 'move', ...n });
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent): void => {
+    const printable = e.key.length === 1;
+    if (!printable && !NAMED_KEYS.has(e.key)) return; // ignore lone modifiers, F-keys, …
+    const hasMod = e.ctrlKey || e.metaKey || e.altKey;
+    e.preventDefault(); // keep Tab/arrows/space from scrolling or moving host focus
+    if (printable && !hasMod) {
+      surface.input({ type: 'key', key: e.key }); // type the character
+      return;
+    }
+    // Build a Playwright press() combo for control keys + shortcuts (e.g. Meta+a).
+    const mods: string[] = [];
+    if (e.ctrlKey) mods.push('Control');
+    if (e.metaKey) mods.push('Meta');
+    if (e.altKey) mods.push('Alt');
+    if (e.shiftKey) mods.push('Shift');
+    let base = e.key === ' ' ? 'Space' : e.key;
+    if (base.length === 1) base = base.toLowerCase();
+    surface.input({ type: 'key', key: [...mods, base].join('+') });
+  };
+
+  const hasView = frame != null;
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
-      {/* URL bar */}
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          navigate(editingUrl);
-        }}
+      {/* Toolbar: back / forward / reload + address bar */}
+      <div
         style={{
           display: 'flex',
           alignItems: 'center',
-          gap: 6,
-          padding: '8px 10px',
+          gap: 4,
+          padding: '6px 8px',
           borderBottom: '1px solid var(--color-card-border)',
           flexShrink: 0,
         }}
       >
-        <Icon name="globe" size={14} />
-        <input
-          ref={urlInputRef}
-          type="text"
-          value={editingUrl}
-          placeholder="Enter a URL…"
-          onChange={(e) => setEditingUrl(e.target.value)}
-          spellCheck={false}
-          style={{
-            flex: 1,
-            minWidth: 0,
-            padding: '6px 9px',
-            fontSize: 12,
-            color: 'var(--color-text)',
-            border: '1px solid var(--color-card-border)',
-            borderRadius: 8,
-            background: 'var(--color-surface)',
-            outline: 'none',
+        <IconButton size={26} onClick={() => surface.input({ type: 'back' })} title="Back" aria-label="Back">
+          <Icon name="chevron-right" size={14} style={{ transform: 'rotate(180deg)' }} />
+        </IconButton>
+        <IconButton size={26} onClick={() => surface.input({ type: 'forward' })} title="Forward" aria-label="Forward">
+          <Icon name="chevron-right" size={14} />
+        </IconButton>
+        <IconButton size={26} onClick={() => surface.input({ type: 'reload' })} title="Reload" aria-label="Reload">
+          <Icon name="rotate" size={14} />
+        </IconButton>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            navigate(editingUrl);
+            hostRef.current?.focus();
           }}
-        />
-      </form>
+          style={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center' }}
+        >
+          <input
+            ref={urlInputRef}
+            type="text"
+            value={editingUrl}
+            placeholder="Search or enter a URL…"
+            onChange={(e) => setEditingUrl(e.target.value)}
+            spellCheck={false}
+            style={{
+              flex: 1,
+              minWidth: 0,
+              padding: '6px 11px',
+              fontSize: 12,
+              color: 'var(--color-text)',
+              border: '1px solid var(--color-card-border)',
+              borderRadius: 999,
+              background: 'var(--color-surface)',
+              outline: 'none',
+            }}
+          />
+        </form>
+      </div>
 
       {surface.error && (
         <div style={{ padding: '8px 12px', fontSize: 11.5, color: 'var(--color-danger, #f87171)' }}>
@@ -122,71 +226,133 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
         </div>
       )}
 
-      {/* Frame surface */}
+      {/* Live view / interaction surface — fills the container */}
       <div
-        ref={imgRef}
+        ref={hostRef}
         tabIndex={0}
+        onMouseDown={() => hostRef.current?.focus()}
         onClick={(e) => {
           const n = norm(e);
           if (n) surface.input({ type: 'click', ...n });
         }}
-        onWheel={(e) => surface.input({ type: 'scroll', dy: e.deltaY })}
-        onKeyDown={(e) => {
-          // Forward typing + common control keys to the page. preventDefault so
-          // the key drives the remote page only — otherwise Tab moves focus out
-          // of the surface and arrows/Backspace scroll or navigate the host UI.
-          if (e.key.length === 1 || ['Enter', 'Backspace', 'Tab', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
-            e.preventDefault();
-            surface.input({ type: 'key', key: e.key });
-          }
+        onDoubleClick={(e) => {
+          const n = norm(e);
+          if (n) surface.input({ type: 'dblclick', ...n });
         }}
+        onMouseMove={hasView ? onHover : undefined}
+        onWheel={(e) => surface.input({ type: 'scroll', dy: e.deltaY })}
+        onKeyDown={onKeyDown}
         style={{
           flex: 1,
           minHeight: 0,
+          position: 'relative',
           overflow: 'hidden',
           background: '#0b0f17',
-          display: 'flex',
-          alignItems: 'flex-start',
-          justifyContent: 'center',
           outline: 'none',
-          cursor: frame ? 'crosshair' : 'default',
         }}
       >
-        {frame ? (
-          <img src={frame} alt={url || 'browser'} style={{ width: '100%', height: 'auto', display: 'block' }} />
+        {hasView ? (
+          <img
+            src={frame ?? undefined}
+            alt={url || 'browser'}
+            draggable={false}
+            style={{
+              width: '100%',
+              height: '100%',
+              objectFit: 'contain',
+              display: 'block',
+              userSelect: 'none',
+            }}
+          />
         ) : (
           <div
             style={{
-              padding: 24,
-              fontSize: 12,
-              color: 'var(--color-text-dim)',
-              textAlign: 'center',
+              position: 'absolute',
+              inset: 0,
               display: 'flex',
               flexDirection: 'column',
               alignItems: 'center',
-              gap: 12,
+              justifyContent: 'center',
+              gap: 14,
+              padding: 24,
+              textAlign: 'center',
             }}
           >
-            <div>{status ?? (surface.ready ? 'Loading…' : 'Starting browser…')}</div>
-            {(needsInstall || installing) && (
-              <button
-                type="button"
-                onClick={startInstall}
-                disabled={installing}
-                style={{
-                  padding: '7px 14px',
-                  fontSize: 12,
-                  fontWeight: 600,
-                  color: '#fff',
-                  border: 'none',
-                  borderRadius: 8,
-                  cursor: installing ? 'default' : 'pointer',
-                  background: installing ? 'var(--color-text-dim)' : 'var(--color-accent, #6366f1)',
-                  opacity: installing ? 0.7 : 1,
-                }}
-              >
-                {installing ? 'Installing…' : 'Install browser engine (~200MB)'}
-              </button>
+            {needsInstall && !installing ? (
+              <>
+                <div
+                  style={{
+                    width: 46,
+                    height: 46,
+                    borderRadius: 12,
+                    display: 'grid',
+                    placeItems: 'center',
+                    background: 'color-mix(in srgb, var(--color-primary) 14%, transparent)',
+                    color: 'var(--color-primary)',
+                  }}
+                >
+                  <Icon name="globe" size={22} />
+                </div>
+                <div style={{ maxWidth: 280 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-text)' }}>
+                    Browser engine required
+                  </div>
+                  <div style={{ marginTop: 4, fontSize: 12, color: 'var(--color-text-dim)', lineHeight: 1.5 }}>
+                    The in-window browser needs Playwright + Chromium — a one-time ~200&nbsp;MB download.
+                  </div>
+                </div>
+                <Button variant="primary" size="sm" onClick={startInstall}>
+                  Install browser engine
+                </Button>
+              </>
+            ) : (
+              <>
+                <Spinner />
+                <div style={{ fontSize: 13, color: 'var(--color-text)' }}>
+                  {installing ? 'Installing browser engine…' : surface.ready ? 'Loading…' : 'Starting browser…'}
+                </div>
+                {installing && (
+                  <div style={{ width: 'min(320px, 80%)', display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {/* Indeterminate progress bar (mirrors the app-update look). */}
+                    <div
+                      style={{
+                        height: 6,
+                        borderRadius: 999,
+                        background: 'var(--color-card-border)',
+                        overflow: 'hidden',
+                      }}
+                    >
+                      <div
+                        style={{
+                          height: '100%',
+                          width: '40%',
+                          borderRadius: 999,
+                          background: 'var(--color-primary)',
+                          animation: 'moxxy-shimmer 1.1s linear infinite',
+                        }}
+                      />
+                    </div>
+                    {status && (
+                      <div
+                        style={{
+                          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+                          fontSize: 10.5,
+                          color: 'var(--color-text-dim)',
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                        }}
+                        title={status}
+                      >
+                        {status}
+                      </div>
+                    )}
+                  </div>
+                )}
+                {!installing && status && !surface.error && (
+                  <div style={{ fontSize: 12, color: 'var(--color-text-dim)', maxWidth: 320 }}>{status}</div>
+                )}
+              </>
             )}
           </div>
         )}

--- a/apps/desktop/src/shell/surfaces/BrowserPane.tsx
+++ b/apps/desktop/src/shell/surfaces/BrowserPane.tsx
@@ -99,6 +99,10 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
         if (width > 0 && height > 0) surfaceRef.current.resize({ width, height });
       });
     };
+    send(); // push an initial size (and cover envs without ResizeObserver)
+    // ResizeObserver is absent in some test/headless environments — degrade to
+    // the one-shot size above rather than throwing on mount.
+    if (typeof ResizeObserver === 'undefined') return;
     const ro = new ResizeObserver(send);
     ro.observe(host);
     return () => {

--- a/apps/desktop/src/shell/surfaces/FileViewer.tsx
+++ b/apps/desktop/src/shell/surfaces/FileViewer.tsx
@@ -1,13 +1,44 @@
 import { useEffect, useState } from 'react';
 import { api, toErrorMessage } from '@moxxy/client-core';
+import { Button, Icon } from '@moxxy/desktop-ui';
 import { DiffView } from './DiffView';
 
 export type FileViewMode = 'diff' | 'content';
 
+type Body =
+  | { readonly diff: string }
+  | { readonly kind: 'text'; readonly content: string; readonly truncated: boolean }
+  | { readonly kind: 'image'; readonly src: string }
+  | { readonly kind: 'pdf'; readonly base64: string }
+  | { readonly kind: 'confirm'; readonly reason?: 'binary' | 'large'; readonly byteLength: number };
+
+/** Decode a base64 payload into a Blob (for a PDF object URL — avoids the
+ *  data-URL size limits Chromium's PDF viewer hits on big files). */
+function base64ToBlob(b64: string, type: string): Blob {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i += 1) bytes[i] = bin.charCodeAt(i);
+  return new Blob([bytes], { type });
+}
+
+/** Human-readable byte size (e.g. "5.2 MB"). */
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  const units = ['KB', 'MB', 'GB'];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return `${v.toFixed(v >= 10 ? 0 : 1)} ${units[i]}`;
+}
+
 /**
- * The right-hand viewer for the Files pane. In `diff` mode it shows a changed
- * file's `git diff`; in `content` mode it shows the full file via
- * `workspace.readFile`. Empty until a file is selected.
+ * The right-hand viewer for the Files panes. `diff` mode shows a changed file's
+ * `git diff`; `content` mode opens any file via `workspace.readFile` — images
+ * render inline, text/code as UTF-8, and binary/large files prompt before being
+ * opened as text (a huge blob in a <pre> can crash the renderer).
  */
 export function FileViewer({
   workspaceId,
@@ -18,11 +49,27 @@ export function FileViewer({
   readonly path: string | null;
   readonly mode: FileViewMode;
 }): JSX.Element {
-  const [body, setBody] = useState<{ diff: string } | { content: string; truncated: boolean } | null>(
-    null,
-  );
+  const [body, setBody] = useState<Body | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  // Set when the user confirms "open anyway" past the binary/large gate.
+  const [force, setForce] = useState(false);
+  // Object URL for a PDF body, created/revoked alongside it.
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
+
+  // A fresh selection starts gated again.
+  useEffect(() => setForce(false), [path, mode]);
+
+  // Maintain a revocable object URL whenever the body is a PDF.
+  useEffect(() => {
+    if (!body || !('kind' in body) || body.kind !== 'pdf') {
+      setPdfUrl(null);
+      return;
+    }
+    const u = URL.createObjectURL(base64ToBlob(body.base64, 'application/pdf'));
+    setPdfUrl(u);
+    return () => URL.revokeObjectURL(u);
+  }, [body]);
 
   useEffect(() => {
     if (!workspaceId || !path) {
@@ -37,9 +84,18 @@ export function FileViewer({
         if (mode === 'diff') {
           const res = await api().invoke('git.diff', { workspaceId, path });
           if (!cancelled) setBody({ diff: res.diff });
+          return;
+        }
+        const res = await api().invoke('workspace.readFile', { workspaceId, path, force });
+        if (cancelled) return;
+        if (res.kind === 'image') {
+          setBody({ kind: 'image', src: `data:${res.mediaType ?? 'image/png'};base64,${res.base64 ?? ''}` });
+        } else if (res.kind === 'pdf') {
+          setBody({ kind: 'pdf', base64: res.base64 ?? '' });
+        } else if (res.kind === 'confirm') {
+          setBody({ kind: 'confirm', reason: res.reason, byteLength: res.byteLength });
         } else {
-          const res = await api().invoke('workspace.readFile', { workspaceId, path });
-          if (!cancelled) setBody({ content: res.content, truncated: res.truncated });
+          setBody({ kind: 'text', content: res.content, truncated: res.truncated });
         }
       } catch (err) {
         if (!cancelled) setError(toErrorMessage(err));
@@ -50,7 +106,7 @@ export function FileViewer({
     return () => {
       cancelled = true;
     };
-  }, [workspaceId, path, mode]);
+  }, [workspaceId, path, mode, force]);
 
   if (!path) {
     return (
@@ -64,6 +120,86 @@ export function FileViewer({
   if (!body) return <div style={pad} />;
 
   if ('diff' in body) return <DiffView diff={body.diff} />;
+
+  if (body.kind === 'image') {
+    return (
+      <div
+        style={{
+          height: '100%',
+          overflow: 'auto',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 12,
+          background: 'var(--color-input-soft)',
+          borderRadius: 8,
+        }}
+      >
+        <img
+          src={body.src}
+          alt={path}
+          style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain', display: 'block' }}
+        />
+      </div>
+    );
+  }
+
+  if (body.kind === 'pdf') {
+    return pdfUrl ? (
+      <iframe
+        src={pdfUrl}
+        title={path}
+        style={{ width: '100%', height: '100%', border: 'none', borderRadius: 8, background: '#fff' }}
+      />
+    ) : (
+      <div style={pad}>Loading…</div>
+    );
+  }
+
+  if (body.kind === 'confirm') {
+    const what =
+      body.reason === 'binary'
+        ? 'This looks like a binary file.'
+        : `This file is large (${formatBytes(body.byteLength)}).`;
+    return (
+      <div
+        style={{
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 12,
+          padding: 24,
+          textAlign: 'center',
+        }}
+      >
+        <div
+          style={{
+            width: 44,
+            height: 44,
+            borderRadius: 12,
+            display: 'grid',
+            placeItems: 'center',
+            background: 'color-mix(in srgb, var(--color-primary) 14%, transparent)',
+            color: 'var(--color-primary)',
+          }}
+        >
+          <Icon name="file" size={20} />
+        </div>
+        <div style={{ maxWidth: 300 }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-text)' }}>{what}</div>
+          <div style={{ marginTop: 4, fontSize: 12, color: 'var(--color-text-dim)', lineHeight: 1.5 }}>
+            Opening it as text may be slow or show garbled content.
+          </div>
+        </div>
+        <Button variant="primary" size="sm" onClick={() => setForce(true)}>
+          Open as text anyway
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <pre
       className="mono"

--- a/packages/desktop-host/src/ipc/workspace-fs.ts
+++ b/packages/desktop-host/src/ipc/workspace-fs.ts
@@ -39,9 +39,9 @@ export function registerWorkspaceFsHandlers(desks: DeskStore): void {
     return listDir(cwd, relPath);
   });
 
-  handle('workspace.readFile', async ({ workspaceId, path: relPath }) => {
+  handle('workspace.readFile', async ({ workspaceId, path: relPath, force }) => {
     const { readFile } = await import('../workspace-fs');
     const cwd = await cwdForWorkspace(desks, workspaceId);
-    return readFile(cwd, relPath);
+    return readFile(cwd, relPath, { force });
   });
 }

--- a/packages/desktop-host/src/security.ts
+++ b/packages/desktop-host/src/security.ts
@@ -373,7 +373,9 @@ function buildCspDirectives(extraClerkHosts: readonly string[]): string {
     // moxxy-app:: the anonymizer worker's local-only model fetches (above).
     `connect-src 'self' moxxy-app: https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com${extra}`,
     "worker-src 'self' blob:",
-    `frame-src https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com${extra}`,
+    // `blob:` lets the Files viewer render a PDF in an <iframe> via Chromium's
+    // built-in PDF viewer (the bytes are an app-created same-origin Blob URL).
+    `frame-src 'self' blob: https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com${extra}`,
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",

--- a/packages/desktop-host/src/workspace-fs.test.ts
+++ b/packages/desktop-host/src/workspace-fs.test.ts
@@ -63,18 +63,48 @@ describe('readFile shaping', () => {
     expect(r.content.length).toBe(1_000_000);
   });
 
-  it('returns a binary placeholder for a file with a NUL byte', async () => {
+  it('gates a NUL-byte file behind a binary confirm, then forces it to text', async () => {
     await writeFile(path.join(root, 'data.bin'), Buffer.from([1, 2, 0, 3, 4]));
     const r = await readFile(root, 'data.bin');
+    expect(r.kind).toBe('confirm');
+    expect(r.reason).toBe('binary');
     expect(r.text).toBe(false);
-    expect(r.content).toMatch(/^\[binary file — \d+ bytes\]$/);
+    // …and `force` decodes it as text anyway.
+    const forced = await readFile(root, 'data.bin', { force: true });
+    expect(forced.kind).toBe('text');
+    expect(forced.text).toBe(true);
   });
 
-  it('returns an empty non-text result for a non-file path', async () => {
+  it('gates a very large file behind a large confirm', async () => {
+    // Just over CONFIRM_BYTES (2MB) but not binary.
+    await writeFile(path.join(root, 'huge.txt'), 'a'.repeat(2_000_050));
+    const r = await readFile(root, 'huge.txt');
+    expect(r.kind).toBe('confirm');
+    expect(r.reason).toBe('large');
+  });
+
+  it('returns an image inline as base64', async () => {
+    // Minimal 1×1 PNG header is enough to exercise the image branch by ext.
+    await writeFile(path.join(root, 'pic.png'), Buffer.from([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]));
+    const r = await readFile(root, 'pic.png');
+    expect(r.kind).toBe('image');
+    expect(r.mediaType).toBe('image/png');
+    expect(typeof r.base64).toBe('string');
+  });
+
+  it('returns a pdf inline as base64', async () => {
+    await writeFile(path.join(root, 'doc.pdf'), Buffer.from('%PDF-1.4\n...'));
+    const r = await readFile(root, 'doc.pdf');
+    expect(r.kind).toBe('pdf');
+    expect(r.mediaType).toBe('application/pdf');
+    expect(typeof r.base64).toBe('string');
+  });
+
+  it('returns empty text for a non-file path', async () => {
     await mkdir(path.join(root, 'adir'));
     const r = await readFile(root, 'adir');
-    expect(r.text).toBe(false);
     expect(r.content).toBe('');
+    expect(r.kind).toBe('text');
   });
 });
 

--- a/packages/desktop-host/src/workspace-fs.ts
+++ b/packages/desktop-host/src/workspace-fs.ts
@@ -8,11 +8,29 @@
  * disk just because someone passed `../../etc/passwd` as `path`.
  */
 
-import { readFile as fsReadFile, readdir, realpath, stat } from 'node:fs/promises';
+import { readFile as fsReadFile, open, readdir, realpath, stat } from 'node:fs/promises';
 import path from 'node:path';
 
 /** Cap a single "Open" read so a giant log can't stream MBs into the renderer. */
 const MAX_READ_BYTES = 1_000_000;
+/** Above this, even a text file goes through the "open anyway?" confirm — a
+ *  multi-MB blob rendered in a <pre> can jank or crash the renderer. */
+const CONFIRM_BYTES = 2_000_000;
+/** Hard cap for inlining a binary doc (image/pdf) as base64 (base64 ~+33%). */
+const INLINE_MAX_BYTES = 40_000_000;
+
+/** Extensions we render as an inline image rather than text. */
+const IMAGE_MEDIA_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon',
+  '.avif': 'image/avif',
+  '.svg': 'image/svg+xml',
+};
 
 const HIDDEN_PREFIX = '.';
 const IGNORED_DIRS = new Set([
@@ -70,34 +88,92 @@ async function resolveInside(root: string, relPath: string | undefined): Promise
 
 export interface ReadFileResult {
   readonly path: string;
+  /**
+   * - `text`  — UTF-8 content to show in the viewer (`content`, maybe `truncated`)
+   * - `image` — inline image (`base64` + `mediaType`)
+   * - `confirm` — opening could be risky (binary blob / very large); the UI asks
+   *   before re-reading with `force` and showing it as text. `reason` says why.
+   */
+  readonly kind: 'text' | 'image' | 'pdf' | 'confirm';
   readonly content: string;
   readonly truncated: boolean;
+  /** Back-compat: true exactly when `kind === 'text'`. */
   readonly text: boolean;
+  readonly byteLength: number;
+  readonly mediaType?: string;
+  readonly base64?: string;
+  readonly reason?: 'binary' | 'large';
 }
 
 /**
- * Read a workspace file's UTF-8 contents for the "Open" file viewer, with the
- * SAME cwd-scoping + symlink guard as {@link listDir}. Binary files (a NUL byte
- * in the first chunk) return a placeholder rather than mojibake; oversized files
- * are truncated to a head excerpt. `relPath` must resolve inside the workspace.
+ * Read a workspace file for the "Open" viewer, with the SAME cwd-scoping +
+ * symlink guard as {@link listDir}. Images render inline; text/code render as
+ * UTF-8 (truncated past {@link MAX_READ_BYTES}). Anything that looks binary, or
+ * is larger than {@link CONFIRM_BYTES}, returns `kind: 'confirm'` so the UI can
+ * ask before opening (a huge blob decoded into the renderer can crash it) — a
+ * `force` re-read then decodes it as text anyway. `relPath` must resolve inside
+ * the workspace.
  */
-export async function readFile(cwd: string, relPath: string): Promise<ReadFileResult> {
+export async function readFile(
+  cwd: string,
+  relPath: string,
+  opts: { force?: boolean } = {},
+): Promise<ReadFileResult> {
   const root = await realpath(cwd).catch(() => path.resolve(cwd));
   const abs = await resolveInside(root, relPath);
   const rel = path.relative(root, abs) || path.basename(abs);
   const info = await stat(abs).catch(() => null);
+  const base = { path: rel, truncated: false, text: false as boolean };
   if (!info || !info.isFile()) {
-    return { path: rel, content: '', truncated: false, text: false };
+    return { ...base, kind: 'text', content: '', byteLength: 0, text: true };
   }
-  const buf = await fsReadFile(abs);
-  const slice = buf.subarray(0, MAX_READ_BYTES);
-  const truncated = buf.length > MAX_READ_BYTES;
-  // A NUL byte in the read window is the same binary heuristic buildAttachments
-  // uses — text decode would otherwise produce unreadable replacement chars.
-  if (slice.includes(0)) {
-    return { path: rel, content: `[binary file — ${buf.length} bytes]`, truncated: false, text: false };
+  const byteLength = info.size;
+  const ext = path.extname(abs).toLowerCase();
+
+  // Images + PDFs: inline as base64 so the viewer can render them natively
+  // (an <img> for images, Chromium's built-in PDF viewer for PDFs).
+  const imageType = IMAGE_MEDIA_TYPES[ext];
+  if (imageType || ext === '.pdf') {
+    if (byteLength > INLINE_MAX_BYTES && !opts.force) {
+      return { ...base, kind: 'confirm', reason: 'large', content: '', byteLength };
+    }
+    const buf = await fsReadFile(abs);
+    return {
+      ...base,
+      kind: imageType ? 'image' : 'pdf',
+      content: '',
+      byteLength,
+      mediaType: imageType ?? 'application/pdf',
+      base64: buf.toString('base64'),
+    };
   }
-  return { path: rel, content: slice.toString('utf8'), truncated, text: true };
+
+  // Read only the head window via a handle, so a multi-GB file never loads whole.
+  const slice = await readHead(abs, MAX_READ_BYTES);
+  const looksBinary = slice.includes(0);
+  if (!opts.force && (looksBinary || byteLength > CONFIRM_BYTES)) {
+    return { ...base, kind: 'confirm', reason: looksBinary ? 'binary' : 'large', content: '', byteLength };
+  }
+  return {
+    ...base,
+    kind: 'text',
+    content: slice.toString('utf8'),
+    truncated: byteLength > slice.length,
+    text: true,
+    byteLength,
+  };
+}
+
+/** Read at most `max` bytes from the start of a file without loading the rest. */
+async function readHead(abs: string, max: number): Promise<Buffer> {
+  const handle = await open(abs, 'r');
+  try {
+    const buf = Buffer.alloc(max);
+    const { bytesRead } = await handle.read(buf, 0, max, 0);
+    return buf.subarray(0, bytesRead);
+  } finally {
+    await handle.close();
+  }
 }
 
 export async function listDir(cwd: string, relPath?: string): Promise<ListDirResult> {

--- a/packages/desktop-ipc-contract/src/commands.ts
+++ b/packages/desktop-ipc-contract/src/commands.ts
@@ -292,19 +292,30 @@ export interface IpcCommands {
       readonly kind: 'file' | 'dir';
     }>;
   }>;
-  /** Read a workspace file's full UTF-8 contents for the "Open" file viewer.
-   *  Same cwd-scoping + symlink guard as `workspace.listDir`. Returns
-   *  `{ truncated: true }` + a head excerpt for very large / binary files
-   *  rather than streaming megabytes into the renderer. */
+  /** Read a workspace file for the "Open" file viewer. Same cwd-scoping +
+   *  symlink guard as `workspace.listDir`. Images come back inline
+   *  (`kind:'image'`); text/code as UTF-8 (`kind:'text'`, head-excerpt +
+   *  `truncated` past the cap). Binary-looking or very large files return
+   *  `kind:'confirm'` (with `reason`) so the UI can ask before opening — pass
+   *  `force: true` to then read it as text anyway. */
   'workspace.readFile': (args: {
     workspaceId: string;
     path: string;
+    /** Bypass the binary/large `confirm` gate and decode as text. */
+    force?: boolean;
   }) => Promise<{
     readonly path: string;
+    readonly kind: 'text' | 'image' | 'pdf' | 'confirm';
     readonly content: string;
     readonly truncated: boolean;
-    /** False when the file is detected as binary (content is a placeholder). */
+    /** Back-compat: true exactly when `kind === 'text'`. */
     readonly text: boolean;
+    readonly byteLength: number;
+    /** Set when `kind:'image'` — `data:<mediaType>;base64,<base64>`. */
+    readonly mediaType?: string;
+    readonly base64?: string;
+    /** Set when `kind:'confirm'` — why the gate fired. */
+    readonly reason?: 'binary' | 'large';
   }>;
 
   // ---- Git (Files-changed pane + diff viewer) ---------------------------

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -191,6 +191,11 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
     workspaceId: z.string().min(1).max(256),
     path: z.string().max(4096).optional(),
   }),
+  'workspace.readFile': z.object({
+    workspaceId: z.string().min(1).max(256),
+    path: z.string().min(1).max(4096),
+    force: z.boolean().optional(),
+  }),
   'settings.fetchProviderModels': z.object({ provider: providerName }),
   'settings.writeSkill': z.object({ name: skillName, body: z.string().max(1_000_000) }),
   'settings.readSkill': z.object({ name: skillName }),

--- a/packages/plugin-browser/src/browser-surface.test.ts
+++ b/packages/plugin-browser/src/browser-surface.test.ts
@@ -239,7 +239,7 @@ describe('browser surface input mapping', () => {
     await surface.input({ type: 'click', fx: 0.5, fy: 0.2 });
     await flush();
     const mouseCall = sidecar.received.find((r) => r.method === 'mouse');
-    expect(mouseCall?.params).toEqual({ x: 500, y: 100 });
+    expect(mouseCall?.params).toEqual({ x: 500, y: 100, count: 1 });
 
     surface.close();
   });
@@ -255,8 +255,39 @@ describe('browser surface input mapping', () => {
     await surface.input({ type: 'click', fx: 1, fy: 1 });
     await flush();
     const mouseCall = sidecar.received.find((r) => r.method === 'mouse');
-    expect(mouseCall?.params).toEqual({ x: 1280, y: 720 });
+    expect(mouseCall?.params).toEqual({ x: 1280, y: 720, count: 1 });
 
+    surface.close();
+  });
+
+  it('resize sets the page viewport so the view fills the pane', async () => {
+    vi.useFakeTimers();
+    const sidecar = makeControllableSpawn();
+    sidecar.setHandler(() => ({ ok: true, result: frame() }));
+    const surface = buildBrowserSurface({ sidecarPath: '/fake.js', spawnFn: sidecar.spawn }).open();
+    await flush();
+    await surface.resize?.({ width: 900, height: 600 });
+    await flush();
+    const vp = sidecar.received.find((r) => r.method === 'setviewport');
+    expect(vp?.params).toEqual({ width: 900, height: 600 });
+    surface.close();
+  });
+
+  it('dblclick forwards clickCount 2; hover + nav reach their sidecar methods', async () => {
+    vi.useFakeTimers();
+    const sidecar = makeControllableSpawn();
+    sidecar.setHandler((method) => (method === 'frame' ? { ok: true, result: frame({ width: 1000, height: 500 }) } : { ok: true, result: {} }));
+    const surface = buildBrowserSurface({ sidecarPath: '/fake.js', spawnFn: sidecar.spawn }).open();
+    await flush();
+
+    await surface.input({ type: 'dblclick', fx: 0.5, fy: 0.5 });
+    await surface.input({ type: 'move', fx: 0.1, fy: 0.2 });
+    await surface.input({ type: 'reload' });
+    await flush();
+
+    expect(sidecar.received.find((r) => r.method === 'mouse')?.params).toEqual({ x: 500, y: 250, count: 2 });
+    expect(sidecar.received.find((r) => r.method === 'mousemove')?.params).toEqual({ x: 100, y: 100 });
+    expect(sidecar.received.some((r) => r.method === 'reload')).toBe(true);
     surface.close();
   });
 

--- a/packages/plugin-browser/src/browser-surface.ts
+++ b/packages/plugin-browser/src/browser-surface.ts
@@ -113,6 +113,14 @@ export function buildBrowserSurface(deps?: BrowserSessionDeps) {
         }
       };
 
+      // After an interaction, grab a frame now and once more shortly after, so a
+      // click/keypress that kicks off async work (a navigation, a menu opening,
+      // an animation) shows up promptly instead of waiting for the next poll.
+      const bump = (): void => {
+        void tick();
+        setTimeout(() => void tick(), 140);
+      };
+
       // Kick an immediate frame (launches the browser), then poll.
       startPolling();
 
@@ -159,6 +167,15 @@ export function buildBrowserSurface(deps?: BrowserSessionDeps) {
             : last
               ? { type: 'frame', base64: last.base64, mime: last.mediaType, url: last.url }
               : { type: 'status', text: 'Starting browser…' },
+        resize: async (size) => {
+          // Match the page viewport to the pane so the live view fills the
+          // container (no letterboxing) and click coords map 1:1.
+          if (!size.width || !size.height) return;
+          await browserSidecarCall('setviewport', { width: size.width, height: size.height }, deps).catch(
+            () => undefined,
+          );
+          void tick();
+        },
         input: async (msg) => {
           if (msg.type === 'install') {
             await runInstall();
@@ -178,16 +195,33 @@ export function buildBrowserSurface(deps?: BrowserSessionDeps) {
               const text = err instanceof Error ? err.message : String(err);
               emit({ type: 'status', text });
             }
-            void tick();
-          } else if (msg.type === 'click' && typeof msg.fx === 'number' && typeof msg.fy === 'number') {
-            await browserSidecarCall('mouse', { x: msg.fx * vw, y: msg.fy * vh }, deps).catch(() => undefined);
+            bump();
+          } else if (
+            (msg.type === 'click' || msg.type === 'dblclick') &&
+            typeof msg.fx === 'number' &&
+            typeof msg.fy === 'number'
+          ) {
+            const count = msg.type === 'dblclick' ? 2 : 1;
+            await browserSidecarCall('mouse', { x: msg.fx * vw, y: msg.fy * vh, count }, deps).catch(
+              () => undefined,
+            );
+            bump();
+          } else if (msg.type === 'move' && typeof msg.fx === 'number' && typeof msg.fy === 'number') {
+            // Hover — drive the pointer so :hover styles/tooltips render. A single
+            // follow-up frame (not a bump) keeps the cost down at move frequency.
+            await browserSidecarCall('mousemove', { x: msg.fx * vw, y: msg.fy * vh }, deps).catch(
+              () => undefined,
+            );
             void tick();
           } else if (msg.type === 'key' && typeof msg.key === 'string') {
             await browserSidecarCall('key', { key: msg.key }, deps).catch(() => undefined);
-            void tick();
+            bump();
           } else if (msg.type === 'scroll' && typeof msg.dy === 'number') {
             await browserSidecarCall('scroll', { dy: msg.dy }, deps).catch(() => undefined);
-            void tick();
+            bump();
+          } else if (msg.type === 'back' || msg.type === 'forward' || msg.type === 'reload') {
+            await browserSidecarCall(msg.type, {}, deps).catch(() => undefined);
+            bump();
           }
         },
         close: () => {

--- a/packages/plugin-browser/src/sidecar/dispatch.ts
+++ b/packages/plugin-browser/src/sidecar/dispatch.ts
@@ -157,13 +157,47 @@ async function dispatchInner(state: SidecarState, req: Req): Promise<Reply> {
       };
     }
     case 'mouse': {
-      const { x, y } = (req.params ?? {}) as { x: number; y: number };
+      const { x, y, count } = (req.params ?? {}) as { x: number; y: number; count?: number };
       // Parity with `key`/`eval`: validate before launching/driving the page so
       // a malformed surface message (missing/NaN coords) surfaces a clean
       // `badParams` instead of an opaque Playwright throw from click(undefined).
       if (!Number.isFinite(x) || !Number.isFinite(y)) throw badParams('x and y must be finite numbers');
       const h = await ensurePlaywright(state, {});
-      await h.page.mouse.click(x, y);
+      await h.page.mouse.click(x, y, { clickCount: Math.min(3, Math.max(1, count ?? 1)) });
+      return { id: req.id, ok: true, result: { url: h.page.url() } };
+    }
+    case 'mousemove': {
+      // Hover: drives the page's pointer so :hover styles / tooltips render in
+      // the polled frame. Cheap; the surface throttles how often it sends these.
+      const { x, y } = (req.params ?? {}) as { x: number; y: number };
+      if (!Number.isFinite(x) || !Number.isFinite(y)) throw badParams('x and y must be finite numbers');
+      const h = await ensurePlaywright(state, {});
+      await h.page.mouse.move(x, y);
+      return { id: req.id, ok: true };
+    }
+    case 'setviewport': {
+      // Resize the page to the pane so the live view fills the container instead
+      // of being letterboxed at the default 1280×720.
+      const { width, height } = (req.params ?? {}) as { width: number; height: number };
+      if (!Number.isFinite(width) || !Number.isFinite(height) || width < 1 || height < 1) {
+        throw badParams('width and height must be positive finite numbers');
+      }
+      const h = await ensurePlaywright(state, {});
+      await h.page.setViewportSize({ width: Math.round(width), height: Math.round(height) });
+      return { id: req.id, ok: true };
+    }
+    case 'back':
+    case 'forward':
+    case 'reload': {
+      const h = await ensurePlaywright(state, {});
+      try {
+        if (req.method === 'back') await h.page.goBack();
+        else if (req.method === 'forward') await h.page.goForward();
+        else await h.page.reload();
+      } catch (err) {
+        // No history to go to is not an error worth failing the surface over.
+        return { id: req.id, ok: false, error: { message: errMsg(err), kind: 'navigation' } };
+      }
       return { id: req.id, ok: true, result: { url: h.page.url() } };
     }
     case 'key': {

--- a/packages/plugin-browser/src/sidecar/types.ts
+++ b/packages/plugin-browser/src/sidecar/types.ts
@@ -46,10 +46,15 @@ export interface PageHandle {
   evaluate(fn: string): Promise<unknown>;
   url(): string;
   close(): Promise<void>;
-  // Coordinate-based input for the live browser surface (loosely typed — the
-  // real Playwright Page provides all of these).
+  // Coordinate-based input + viewport control for the live browser surface
+  // (loosely typed — the real Playwright Page provides all of these).
   viewportSize(): { width: number; height: number } | null;
+  setViewportSize(size: { width: number; height: number }): Promise<void>;
+  goBack(opts?: unknown): Promise<unknown>;
+  goForward(opts?: unknown): Promise<unknown>;
+  reload(opts?: unknown): Promise<unknown>;
   readonly mouse: {
+    move(x: number, y: number, opts?: unknown): Promise<void>;
     click(x: number, y: number, opts?: unknown): Promise<void>;
     wheel(dx: number, dy: number): Promise<void>;
   };


### PR DESCRIPTION
## What

Follow-up polish to the agentic surfaces (builds on #228).

**Browser surface — genuinely interactive + full-bleed.**
- Click / double-click, **hover** (`:hover` styles + tooltips via a throttled `mousemove`), scroll, full keyboard incl. **modifier shortcuts** (e.g. ⌘A/⌘C), and **back / forward / reload** buttons.
- Snappier refresh: a burst frame fires right after each interaction instead of waiting for the next poll.
- **Fits the container**: the page viewport is resized to the pane (`surface.resize` → sidecar `setviewport` → `page.setViewportSize`), so the view fills the whole pane (no letterbox) and clicks map 1:1.
- On-brand install/loading states: spinner, primary `Button`, indeterminate progress bar, condensed progress line — instead of dumping raw npm output.
- New sidecar methods: `mousemove`, `setviewport`, `back`/`forward`/`reload`, `mouse` clickCount.

**Files viewer — opens far more types.**
- **Images** and **PDFs** render inline (PDF via Chromium's built-in viewer in a `blob:` iframe — added `blob:` to the CSP `frame-src`).
- Text/code open directly; **binary-looking or very large files prompt** before being opened as text (a huge blob in a `<pre>` can crash the renderer).
- `workspace.readFile` now returns a discriminated result (`kind: text | image | pdf | confirm` + `mediaType` / `base64` / `reason` / `byteLength`) and takes a `force` flag; it reads only a head window via a file handle so a multi-GB file never loads whole.

## Verification

- `pnpm build` (67/67), `pnpm -w typecheck` (132/132), `pnpm check:deps` clean (991 modules), lint 0 errors — fresh worktree off latest `origin/main`.
- Tests: plugin-browser 83, desktop-host 416 — all pass. New coverage: viewport resize, double-click/hover/nav inputs, and readFile image/pdf/binary-confirm/force paths.
- Changeset included.