### PR TITLE
Quality sweep wave 9 — close the last deferred items (targetInfo table-drive · voice-admin package · reasoning wired)

### DIFF
--- a/.changeset/desktop-reasoning-effort-live.md
+++ b/.changeset/desktop-reasoning-effort-live.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/cli': minor
+'@moxxy/desktop': minor
+---
+
+Wire the desktop Providers reasoning-effort selector live: it now maps onto the runner's `config.context.reasoning` instead of dead-ending in localStorage. Adds a `session.setReasoning` runner protocol method (v9) + a `settings.setReasoning` IPC command, surfaces `supportsReasoning` on `ProviderEntry` (derived from the runner's model catalog) so the selector only renders where it's honored, and removes the unchecked `(p as { supportsReasoning? })` cast.

--- a/.changeset/quality-sweep-zero.md
+++ b/.changeset/quality-sweep-zero.md
@@ -1,0 +1,18 @@
+---
+"@moxxy/cli": patch
+"@moxxy/desktop": patch
+---
+
+Quality sweep: close the last deferred audit items
+
+- **`RequirementChecker.targetInfo`** is now table-driven (`TARGET_DESCRIPTORS`
+  record, byte-identical to the old per-kind switch, with compile-time
+  exhaustiveness). Closes the types-generics-5 table-drive item.
+- **Voice-admin** is extracted into a first-class `@moxxy/plugin-voice-admin`
+  package (tools moved verbatim, registered via the cli builtin entries like the
+  other plugins). Closes u28-3.
+- **Reasoning-effort** is now wired end to end: the desktop Providers selector
+  flows through a typed IPC command to the runner's `config.context.reasoning`
+  (runner protocol bumped to v9 in lockstep with the desktop floor), instead of
+  persisting to local state and silently doing nothing. Closes the long-standing
+  reasoning TODO (audit c15 / R1).

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -60,22 +60,26 @@ duplicated PCM16 MIME constant + the `/compact` flow now route through the SDK,
 `computeElisionState` is memoized + threaded once per iteration, and workflow
 `onError:'retry'` now honours `step.retries`.
 
-**Two items were closed as deliberate by-design decisions (not silent debt):**
-- `RequirementChecker.targetInfo` keeps its explicit per-kind `switch`. Each kind
-  reads a different registry with different active/version semantics; a clever
-  kind→table indirection in a correctness-critical requirement gate trades
-  clarity + safety for a DRY win that isn't worth it. The switch is the right
-  shape; kept intentionally (closes types-generics-5's table-drive half).
-- Voice-admin tools stay decomposed **in-place** within `cli/setup` (wave 10).
-  The atomicity goal (no god-function) is met; promoting them to a standalone
-  `@moxxy/plugin-voice-admin` package is a packaging-boundary preference, not a
-  quality fix, and is deliberately a non-goal for cli-bundled builtins.
+A final pass (wave 13) closed the last two items that had been left as judgement
+calls, implementing them rather than deferring:
+- **`RequirementChecker.targetInfo`** is now table-driven — a `TARGET_DESCRIPTORS`
+  `Record<RequirementKind, …>` (present/active/version per kind), byte-identical
+  to the old switch (every kind exercised by `requirements.targetinfo.test.ts`)
+  with stronger compile-time exhaustiveness than the old `assertNever` default.
+  Closes types-generics-5.
+- **Voice-admin** is now its own first-class plugin package
+  `@moxxy/plugin-voice-admin` (tools moved verbatim, registered via the cli
+  builtin entries exactly like the other plugins). Closes u28-3.
 
-Going forward this file resumes its normal role: the standing ledger where each
-future change retires ≥1 item and new debt is logged on sight (AGENTS.md → "Tech
-debt is a standing job"). A living codebase under active development keeps
-accruing debt (this very sweep integrated the concurrently-merged anonymizer +
-mode-collaborative features mid-flight); the audit backlog itself is cleared.
+Going forward this file resumes its normal role per AGENTS.md → "Tech debt is a
+standing job": every future change retires ≥1 item and logs new debt on sight.
+The audit backlog is cleared. The only items remaining in this ledger are
+infrastructure constraints that cannot be resolved from the normal CI gate and
+must NOT be blind-merged — chiefly the **node-gyp / @electron/rebuild bump**,
+which is a coupled `electron-builder` + `node-gyp 12` + `engines.node` floor
+change that only an actual `electron-builder` *packaging* run can verify (a blind
+bump has bricked the desktop native build before — see the 2026-06-17 entry).
+Those are scoped, owner-gated follow-ups, documented at their entries.
 
 ---
 
@@ -171,9 +175,11 @@ standing backlog — pick from it, newest-audit-first, on the next pass).
   `PolicyRule.inputMatches` + at the `matchRule` regex site and pinned by an
   explicit substring-vs-author-anchored test; unify `~/.moxxy` path derivation
   (`t2-moxxy-home-paths`).
-- **Completion:** wire or remove the desktop per-provider reasoning-effort
-  control (`t2-security`/`c15`/R1); the half-built encrypted-reasoning round-trip
-  (`u99-1`).
+- **Completion:** ✅ the desktop per-provider reasoning-effort control
+  (`t2-security`/`c15`/R1/`u11-2`/`u11-3`/`incomplete-1`) is now wired live to the
+  runner (`session.setReasoning` v9 + `settings.setReasoning` IPC →
+  `config.context.reasoning`); remaining: the half-built encrypted-reasoning
+  round-trip (`u99-1`).
 - **Long tail:** the remaining confirmed logic bugs (`t2-confirmed-logic-bugs`,
   `t2-more-logic-bugs`), embedding correctness + lifecycle/shutdown clusters,
   and all of Tier-3 (god-file splits `t3-god-files`, the test-harness gap
@@ -1395,12 +1401,15 @@ regressions. Restore the detail from git history (`TECH_DEBT.md` @ `b014c3a`) if
 Logged while shipping visible per-provider reasoning + the grouped sub-agents view. Reviewed the
 provider stream parsers, `chat-model` projection, and the subagent event bridge in passing.
 
-- **R1 — built-in reasoning config isn't wired live to the runner from the desktop.** The functional
-  path is `config.context.reasoning` (CLI + the desktop's runner read it). The desktop Settings →
-  Providers reasoning-effort control persists to local state only with a `TODO`; making it live needs
-  a typed `DesktopPrefs.reasoning` + `ProviderEntry.supportsReasoning` in `@moxxy/desktop-ipc-contract`
-  and a runner config-apply step. Until then the desktop control stays hidden (no row reports
-  `supportsReasoning`). `apps/desktop/src/settings/ProvidersTab.tsx`.
+- **R1 — built-in reasoning config isn't wired live to the runner from the desktop.** ✅ FIXED
+  (quality-sweep): the Providers reasoning-effort selector now maps onto the runner's
+  `config.context.reasoning` (the proven CLI path) over a new `session.setReasoning` runner protocol
+  method (v9, gated client-side) + a `settings.setReasoning` IPC command; `ProviderEntry.supportsReasoning`
+  is now typed and populated runner-side from the model catalog (any model advertising `supportsReasoning`),
+  so the selector renders only where it's honored and the `(p as { supportsReasoning? })` cast is gone.
+  Chose a session-scoped `session.setReasoning` rather than `DesktopPrefs.reasoning` because the runner
+  setting is session-scoped (see R2), not per-provider. Integration test in
+  `packages/runner/src/integration.test.ts` asserts the effort flows into the provider request.
 - **R2 — reasoning config is session-level, not per-provider-granular.** `session.reasoning` is one
   value applied to whichever provider is active (gated by `supportsReasoning`), not a per-provider
   map. Good enough for one PR ("only supporting providers honor it"); a true `{ [provider]: effort }`

--- a/apps/desktop/electron/main/floor-runner-protocol.ts
+++ b/apps/desktop/electron/main/floor-runner-protocol.ts
@@ -16,4 +16,4 @@
  * the release build asserts the two match (see scripts/build-app-bundle.mjs),
  * so a forgotten bump fails the build rather than shipping a wrong floor.
  */
-export const FLOOR_RUNNER_PROTOCOL = 8;
+export const FLOOR_RUNNER_PROTOCOL = 9;

--- a/apps/desktop/src/settings/ProvidersTab.test.tsx
+++ b/apps/desktop/src/settings/ProvidersTab.test.tsx
@@ -106,6 +106,31 @@ describe('ProvidersTab', () => {
     );
   });
 
+  it('shows the reasoning selector only for providers that support it', () => {
+    // anthropic carries no supportsReasoning flag → no selector.
+    renderTab();
+    fireEvent.click(screen.getByRole('button', { name: /configure anthropic/i }));
+    expect(screen.queryByTestId('provider-reasoning-select')).toBeNull();
+  });
+
+  it('applies the reasoning effort live via settings.setReasoning', async () => {
+    const invoke = vi.fn(() => Promise.resolve());
+    __setApiOverride({ invoke, subscribe: vi.fn(() => () => {}) } as never);
+    const reasoner: ProviderEntry = { ...anthropic, name: 'opus', active: false, supportsReasoning: true };
+    renderTab({ providers: [reasoner] });
+    fireEvent.click(screen.getByRole('button', { name: /configure opus/i }));
+    const select = screen.getByTestId('provider-reasoning-select');
+    fireEvent.change(select, { target: { value: 'high' } });
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith('settings.setReasoning', { effort: 'high' }),
+    );
+    // 'off' clears it through the same path.
+    fireEvent.change(select, { target: { value: 'off' } });
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith('settings.setReasoning', { effort: 'off' }),
+    );
+  });
+
   it('offers a real sign-in (not a key form) for OAuth providers', () => {
     // The OAuthSignIn flow subscribes to provider.login.* on mount, so the
     // configure sheet needs a transport even though the buttons aren't clicked.

--- a/apps/desktop/src/settings/ProvidersTab.tsx
+++ b/apps/desktop/src/settings/ProvidersTab.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useState } from 'react';
-import type { useSettings } from '@moxxy/client-core';
+import { api, type useSettings } from '@moxxy/client-core';
 import { Button, Icon, IconButton, Modal, TextInput } from '@moxxy/desktop-ui';
 import { Section, CardList, Row, Tile, StatusDot, Switch, Badge, EmptyState } from './settings-primitives';
 import { AgentTaskModal } from './shared/AgentTaskModal';
@@ -19,17 +19,16 @@ import { PROVIDER_PROMPT_TEMPLATE } from './provider-prompt';
 type ProviderRow = ReturnType<typeof useSettings>['providers'][number];
 
 /** Reasoning-effort levels offered for providers whose models support it.
- *  Mirrors the CLI's proven `config.context.reasoning` path. */
+ *  Mirrors the CLI's proven `config.context.reasoning` path. The order +
+ *  values match the contract's `ReasoningEffort` (and the runner protocol's
+ *  `ReasoningEffortLevel`), so the chosen level forwards verbatim. */
 const REASONING_LEVELS = ['off', 'low', 'medium', 'high'] as const;
 type ReasoningLevel = (typeof REASONING_LEVELS)[number];
 
-// TODO(reasoning): this control persists the per-provider effort to
-// localStorage only — the runner doesn't yet pick it up live. The proven
-// functional path is the CLI's `config.context.reasoning`; wiring the desktop
-// session to it needs a typed `DesktopPrefs.reasoning` field (+ a
-// `ProviderEntry.supportsReasoning` flag) in @moxxy/desktop-ipc-contract and a
-// runner config-apply step — both outside this app/src change. Until then this
-// is a UI placeholder that round-trips the user's choice.
+// The runner's `session.reasoning` is session-scoped and resets when its runner
+// restarts, so we remember the user's per-provider pick here to seed the
+// selector on reopen and to re-apply it. The LIVE effect comes from the
+// `settings.setReasoning` IPC call below — this is just the UI's memory.
 const REASONING_PREF_KEY = 'moxxy.reasoning.effort';
 
 function reasoningEffortFor(providerName: string): ReasoningLevel {
@@ -54,11 +53,11 @@ function setReasoningEffortFor(providerName: string, level: ReasoningLevel): voi
   }
 }
 
-/** The runner's model descriptors carry `supportsReasoning?: boolean`; it is
- *  not yet surfaced on `ProviderEntry`, so read it defensively from whatever
- *  the row exposes (forward-compatible once the contract plumbs it through). */
+/** True when the provider's model catalog advertises reasoning support — now a
+ *  typed field on `ProviderEntry`, populated runner-side from the model
+ *  descriptors (see `settings.providers` in @moxxy/desktop-host). */
 function providerSupportsReasoning(p: ProviderRow): boolean {
-  return (p as { supportsReasoning?: boolean }).supportsReasoning === true;
+  return p.supportsReasoning === true;
 }
 
 export function ProvidersTab({
@@ -336,6 +335,11 @@ function ConfigureProviderModal({
                 const next = e.target.value as ReasoningLevel;
                 setReasoning(next);
                 setReasoningEffortFor(provider.name, next);
+                // Apply it live on the runner (maps onto config.context.reasoning).
+                void run(
+                  () => api().invoke('settings.setReasoning', { effort: next }),
+                  next === 'off' ? 'Reasoning effort cleared.' : `Reasoning effort set to ${next}.`,
+                );
               }}
               style={selectStyle}
               data-testid="provider-reasoning-select"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -94,6 +94,7 @@
     "@moxxy/plugin-plugins-admin": "workspace:*",
     "@moxxy/plugin-provider-admin": "workspace:*",
     "@moxxy/plugin-view": "workspace:*",
+    "@moxxy/plugin-voice-admin": "workspace:*",
     "@moxxy/plugin-provider-anthropic": "workspace:*",
     "@moxxy/plugin-provider-openai": "workspace:*",
     "@moxxy/plugin-provider-openai-codex": "workspace:*",

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -42,10 +42,10 @@ import { commandsPlugin } from '@moxxy/plugin-commands';
 import { buildViewPlugin } from '@moxxy/plugin-view';
 import { computerControlPlugin } from '@moxxy/plugin-computer-control';
 import { buildOauthPlugin } from '@moxxy/plugin-oauth';
+import { buildVoiceAdminPlugin } from '@moxxy/plugin-voice-admin';
 import { resolveString } from '@moxxy/plugin-vault';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { BUILTIN_SKILLS_DIR_RESOLVED } from './builtin-skills-dir.js';
-import { buildVoiceAdminPlugin } from './voice-admin-plugin.js';
 
 export interface BuiltinEntry {
   readonly name: string;

--- a/packages/core/src/requirements.targetinfo.test.ts
+++ b/packages/core/src/requirements.targetinfo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { RequirementKind } from '@moxxy/sdk';
+import { requirementSchema, type RequirementKind } from '@moxxy/sdk';
 import { RequirementRegistry } from './requirements.js';
 import { ToolRegistryImpl } from './registries/tools.js';
 import { ProviderRegistry } from './registries/providers.js';
@@ -25,31 +25,42 @@ const makeRequirements = () =>
     synthesizers: new SynthesizerRegistry(),
   });
 
-// Every variant of the closed RequirementKind union. If a kind is added to the
-// SDK union without a matching `targetInfo` case, the `assertNever` default in
-// targetInfo turns the gap into a compile error — this list keeps the runtime
-// smoke honest alongside that guard.
-const ALL_KINDS: ReadonlyArray<RequirementKind> = [
-  'plugin',
-  'provider',
-  'tool',
-  'transcriber',
-  'synthesizer',
-  'mode',
-  'compactor',
-  'channel',
-  'agent',
-  'command',
-  'runtime',
-];
+// Drive the exhaustiveness sweep off the SDK's zod enum rather than a hand-kept
+// list, so a kind added to the union (and its schema) is automatically exercised
+// here. `targetInfo` is a table (TARGET_DESCRIPTORS) plus two special cases
+// (plugin/runtime); the `Record<Exclude<RequirementKind,'plugin'|'runtime'>,_>`
+// type already makes a missing table entry a compile error — this loop keeps the
+// runtime smoke honest alongside that guard.
+const ALL_KINDS: ReadonlyArray<RequirementKind> = requirementSchema.shape.kind.options;
 
 describe('RequirementRegistry.targetInfo exhaustiveness', () => {
+  it('exercises every RequirementKind in the zod enum', () => {
+    // Sanity: the enum still spells out the full known set (catches an enum that
+    // accidentally shrank). Order-independent.
+    expect([...ALL_KINDS].sort()).toEqual(
+      [
+        'agent',
+        'channel',
+        'command',
+        'compactor',
+        'mode',
+        'plugin',
+        'provider',
+        'runtime',
+        'synthesizer',
+        'tool',
+        'transcriber',
+      ].sort(),
+    );
+  });
+
   it('resolves a check (never throws) for every RequirementKind', () => {
     const requirements = makeRequirements();
     for (const kind of ALL_KINDS) {
       // Routed through the public `check` API since targetInfo is private.
       // With nothing registered every kind reports a defined, blocking issue
-      // (missing / not_ready) rather than hitting the assertNever default.
+      // (missing / not_ready) rather than hitting the assertNever default — i.e.
+      // every kind has a table entry or special case backing it.
       const check = requirements.check([{ kind, name: `nonexistent-${kind}` }]);
       expect(check).toBeDefined();
       expect(check.issues).toHaveLength(1);

--- a/packages/core/src/requirements.ts
+++ b/packages/core/src/requirements.ts
@@ -1,4 +1,3 @@
-import { assertNever } from '@moxxy/sdk';
 import type {
   MoxxyRequirement,
   RequirementCheck,
@@ -66,6 +65,32 @@ interface TargetInfo {
   readonly version?: string;
   readonly active: boolean;
 }
+
+/**
+ * Per-kind recipe for {@link RequirementRegistry.targetInfo}. Every kind that
+ * resolves against a registry on `opts` differs only in two orthogonal aspects,
+ * so we table them rather than repeat the same `lookup -> {kind,name,active}`
+ * shape once per case:
+ *   - `present`  — does a def by this name exist? (`registry.get` or
+ *                  `list().some`, depending on the registry base)
+ *   - `active`   — is this the currently-active one? (a `getActiveName() === name`
+ *                  / `getActive()?.name === name` check, or always-true for kinds
+ *                  with no active/inactive distinction like tool/channel/agent)
+ *
+ * None of these kinds track a version (only `plugin` does, and it is
+ * special-cased — see {@link RequirementRegistry.targetInfo}), so a `version`
+ * aspect is deliberately omitted here. `runtime` is handled by `checkRuntime`
+ * before `targetInfo` is reached and so also has no descriptor.
+ */
+interface TargetDescriptor {
+  /** Whether a def with `name` is registered for this kind. */
+  readonly present: (opts: RequirementRegistryOptions, name: string) => boolean;
+  /** Whether the registered def is the currently-active one. */
+  readonly active: (opts: RequirementRegistryOptions, name: string) => boolean;
+}
+
+/** Active for kinds with no active/inactive distinction (tool/channel/agent/command). */
+const ALWAYS_ACTIVE = (): true => true;
 
 export class RequirementRegistry {
   private readonly runtime = new Map<string, RequirementState>();
@@ -142,60 +167,74 @@ export class RequirementRegistry {
   }
 
   private targetInfo(kind: RequirementKind, name: string): TargetInfo | null {
-    switch (kind) {
-      case 'plugin': {
-        const plugin = this.plugins.get(name);
-        return plugin ? { kind, name, version: plugin.version, active: true } : null;
-      }
-      case 'provider': {
-        const def = this.opts.providers.list().find((p) => p.name === name);
-        return def
-          ? { kind, name, active: this.opts.providers.getActiveName() === name }
-          : null;
-      }
-      case 'tool': {
-        const def = this.opts.tools.get(name);
-        return def ? { kind, name, active: true } : null;
-      }
-      case 'transcriber': {
-        const def = this.opts.transcribers.list().find((t) => t.name === name);
-        return def
-          ? { kind, name, active: this.opts.transcribers.getActiveName() === name }
-          : null;
-      }
-      case 'synthesizer': {
-        const def = this.opts.synthesizers.list().find((s) => s.name === name);
-        return def
-          ? { kind, name, active: this.opts.synthesizers.getActiveName() === name }
-          : null;
-      }
-      case 'mode': {
-        const def = this.opts.modes.list().find((m) => m.name === name);
-        return def ? { kind, name, active: activeModeName(this.opts.modes) === name } : null;
-      }
-      case 'compactor': {
-        const def = this.opts.compactors.list().find((c) => c.name === name);
-        return def ? { kind, name, active: this.opts.compactors.getActive()?.name === name } : null;
-      }
-      case 'channel': {
-        const def = this.opts.channels.get(name);
-        return def ? { kind, name, active: true } : null;
-      }
-      case 'agent': {
-        const def = this.opts.agents.get(name);
-        return def ? { kind, name, active: true } : null;
-      }
-      case 'command': {
-        const def = this.opts.commands.get(name);
-        return def ? { kind, name, active: true } : null;
-      }
-      case 'runtime':
-        return null;
-      default:
-        return assertNever(kind);
+    // `plugin` resolves against this instance's private registration map (not a
+    // registry on `opts`) and is the only kind carrying a version, so it stays a
+    // special case rather than being contorted into the shared table.
+    if (kind === 'plugin') {
+      const plugin = this.plugins.get(name);
+      return plugin ? { kind, name, version: plugin.version, active: true } : null;
     }
+    // `runtime` never reaches here — `checkOne` routes it to `checkRuntime` first.
+    if (kind === 'runtime') return null;
+
+    // Every remaining kind has a table entry: `TARGET_DESCRIPTORS` is a total
+    // `Record` over `Exclude<RequirementKind, 'plugin' | 'runtime'>`, so a kind
+    // added to the union without an entry is a compile error (the table-driven
+    // replacement for the old switch's `assertNever` default).
+    const descriptor = TARGET_DESCRIPTORS[kind];
+    if (!descriptor.present(this.opts, name)) return null;
+    return { kind, name, active: descriptor.active(this.opts, name) };
   }
 }
+
+/**
+ * Lookup table backing {@link RequirementRegistry.targetInfo} for every
+ * registry-backed {@link RequirementKind}. `plugin` (private map + version) and
+ * `runtime` (handled before `targetInfo`) are intentionally absent and dealt
+ * with as special cases; the `Partial`-free `Record` keyed on the remaining
+ * kinds keeps the set exhaustive (a new kind is a compile error until listed).
+ */
+const TARGET_DESCRIPTORS: Record<
+  Exclude<RequirementKind, 'plugin' | 'runtime'>,
+  TargetDescriptor
+> = {
+  provider: {
+    present: (opts, name) => opts.providers.list().some((p) => p.name === name),
+    active: (opts, name) => opts.providers.getActiveName() === name,
+  },
+  tool: {
+    present: (opts, name) => opts.tools.get(name) !== undefined,
+    active: ALWAYS_ACTIVE,
+  },
+  transcriber: {
+    present: (opts, name) => opts.transcribers.list().some((t) => t.name === name),
+    active: (opts, name) => opts.transcribers.getActiveName() === name,
+  },
+  synthesizer: {
+    present: (opts, name) => opts.synthesizers.list().some((s) => s.name === name),
+    active: (opts, name) => opts.synthesizers.getActiveName() === name,
+  },
+  mode: {
+    present: (opts, name) => opts.modes.list().some((m) => m.name === name),
+    active: (opts, name) => activeModeName(opts.modes) === name,
+  },
+  compactor: {
+    present: (opts, name) => opts.compactors.list().some((c) => c.name === name),
+    active: (opts, name) => opts.compactors.getActive()?.name === name,
+  },
+  channel: {
+    present: (opts, name) => opts.channels.get(name) !== undefined,
+    active: ALWAYS_ACTIVE,
+  },
+  agent: {
+    present: (opts, name) => opts.agents.get(name) !== undefined,
+    active: ALWAYS_ACTIVE,
+  },
+  command: {
+    present: (opts, name) => opts.commands.get(name) !== undefined,
+    active: ALWAYS_ACTIVE,
+  },
+};
 
 function issue(
   requirement: MoxxyRequirement,

--- a/packages/desktop-host/src/ipc/settings.ts
+++ b/packages/desktop-host/src/ipc/settings.ts
@@ -58,6 +58,11 @@ export function registerSettingsHandlers(pool: RunnerPool): void {
         authKind: p.authKind,
         kind: detail ? ('admin' as const) : ('builtin' as const),
         keyName: detail?.keyName ?? builtinProviderKeyName(p.name),
+        // Surface the reasoning capability so the Configure sheet can show the
+        // effort selector only where it's honored. The runner's model catalog
+        // is the source of truth (the desktop never sees raw ModelDescriptors);
+        // a provider supports it when ANY of its models advertises it.
+        supportsReasoning: p.models.some((m) => m.supportsReasoning === true),
         ...(detail
           ? {
               baseURL: detail.baseURL,
@@ -76,6 +81,12 @@ export function registerSettingsHandlers(pool: RunnerPool): void {
   });
   handle('settings.providerRefreshReady', async (args) => {
     await mustRemote(pool, args?.workspaceId).providerAdmin.refreshReady();
+  });
+  handle('settings.setReasoning', async ({ workspaceId, effort }) => {
+    // Session-scoped: maps onto the runner's `config.context.reasoning` (the
+    // proven CLI path). Gated on runner protocol v9 client-side — a pre-v9
+    // runner throws a clear "update the CLI" error rather than method-not-found.
+    await mustRemote(pool, workspaceId).providerAdmin.setReasoning(effort);
   });
   handle('settings.mcpServers', async (args) => {
     const session = mustSession(pool, args?.workspaceId);

--- a/packages/desktop-ipc-contract/src/commands.ts
+++ b/packages/desktop-ipc-contract/src/commands.ts
@@ -24,6 +24,7 @@ import type {
   McpServerEntry,
   VaultEntryName,
   SkillFile,
+  ReasoningEffort,
 } from './settings.js';
 import type { Desk, DeskSession, DesksOverview, SessionsOverview } from './desks.js';
 import type { PromptAttachment, RunTurnArgs, RunTurnResult } from './chat.js';
@@ -460,6 +461,14 @@ export interface IpcCommands {
   /** Re-probe every provider's credentials on the runner so a key just saved
    *  via `settings.vaultSet` flips readiness without a restart. */
   'settings.providerRefreshReady': (args?: { workspaceId?: string }) => Promise<void>;
+  /** Set the session's reasoning/thinking effort live on the runner — maps onto
+   *  `config.context.reasoning` (the proven CLI path). `off` clears it.
+   *  Session-scoped (not per-provider); honored only by models that advertise
+   *  `supportsReasoning`. Throws a coded error against a pre-v9 runner. */
+  'settings.setReasoning': (args: {
+    workspaceId?: string;
+    effort: ReasoningEffort;
+  }) => Promise<void>;
   /** Hit the provider's /v1/models endpoint and return the model ids
    *  it advertises. Useful for admin-registered providers whose
    *  providers.json entry didn't enumerate models upfront. */

--- a/packages/desktop-ipc-contract/src/remote.test.ts
+++ b/packages/desktop-ipc-contract/src/remote.test.ts
@@ -48,6 +48,10 @@ describe('REMOTE_ALLOWED_COMMANDS', () => {
       'desks.remove',
       'settings.vaultSet',
       'settings.vaultDelete',
+      // Session-config mutation (reasoning effort) — host-only, like the other
+      // settings writes; a paired phone holds a conversation, it doesn't retune
+      // the runner's generation config.
+      'settings.setReasoning',
       'app.updateCli',
       'prefs.update',
       'workflows.save',

--- a/packages/desktop-ipc-contract/src/settings.ts
+++ b/packages/desktop-ipc-contract/src/settings.ts
@@ -1,5 +1,11 @@
 // ---------- Settings -------------------------------------------------------
 
+/** Reasoning/thinking effort the desktop can request for the active session.
+ *  `off` clears the preference; the others map to `config.context.reasoning`
+ *  on the runner (`settings.setReasoning`). Mirrors the runner protocol's
+ *  `ReasoningEffortLevel`. */
+export type ReasoningEffort = 'off' | 'low' | 'medium' | 'high';
+
 export interface ProviderEntry {
   name: string;
   /** True when the runner has activated this provider (credentials
@@ -22,6 +28,11 @@ export interface ProviderEntry {
   baseURL?: string;
   defaultModel?: string;
   modelIds?: ReadonlyArray<string>;
+  /** True when at least one of this provider's models advertises
+   *  `supportsReasoning` — gates the Configure sheet's reasoning-effort
+   *  selector. Derived from the runner's model catalog (the desktop never sees
+   *  raw `ModelDescriptor`s). Absent ⇒ unknown/false. */
+  supportsReasoning?: boolean;
 }
 
 export interface McpServerEntry {

--- a/packages/desktop-ipc-contract/src/validation.test.ts
+++ b/packages/desktop-ipc-contract/src/validation.test.ts
@@ -48,6 +48,21 @@ describe('IPC payload validation', () => {
     expect(() => validateIpcInput('prefs.update', { evil: 'x' })).toThrow();
   });
 
+  it('pins settings.setReasoning effort to the known enum', () => {
+    for (const effort of ['off', 'low', 'medium', 'high'] as const) {
+      expect(() => validateIpcInput('settings.setReasoning', { effort })).not.toThrow();
+    }
+    expect(() =>
+      validateIpcInput('settings.setReasoning', { workspaceId: 'ws', effort: 'high' }),
+    ).not.toThrow();
+    // Arbitrary strings can't reach the runner / provider request.
+    expect(() => validateIpcInput('settings.setReasoning', { effort: 'maximum' })).toThrow();
+    expect(() => validateIpcInput('settings.setReasoning', {})).toThrow();
+    expect(() =>
+      validateIpcInput('settings.setReasoning', { workspaceId: '', effort: 'low' }),
+    ).toThrow();
+  });
+
   it('bounds session.runTurn prompt + attachments', () => {
     expect(() => validateIpcInput('session.runTurn', { prompt: 'hi' })).not.toThrow();
     expect(() =>

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -192,6 +192,12 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
     path: z.string().max(4096).optional(),
   }),
   'settings.fetchProviderModels': z.object({ provider: providerName }),
+  // Session config mutation — pin the effort to the known enum so a renderer
+  // can't push an arbitrary string through to the runner / provider request.
+  'settings.setReasoning': z.object({
+    workspaceId: optionalWorkspace,
+    effort: z.enum(['off', 'low', 'medium', 'high']),
+  }),
   'settings.writeSkill': z.object({ name: skillName, body: z.string().max(1_000_000) }),
   'settings.readSkill': z.object({ name: skillName }),
   'settings.deleteSkill': z.object({ name: skillName }),

--- a/packages/plugin-voice-admin/package.json
+++ b/packages/plugin-voice-admin/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@moxxy/plugin-voice-admin",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Voice/TTS control for moxxy. set_voice / list_voices let the agent switch which text-to-speech backend read-aloud surfaces use (a registered synthesizer, or 'system' for the OS voice) without a settings UI.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "moxxy": {
+    "plugin": {
+      "entry": "./dist/index.js",
+      "kind": "tools"
+    }
+  },
+  "dependencies": {
+    "@moxxy/sdk": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@moxxy/core": "workspace:*",
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugin-voice-admin/src/index.test.ts
+++ b/packages/plugin-voice-admin/src/index.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { Session, silentLogger } from '@moxxy/core';
-import { buildVoiceAdminPlugin } from './voice-admin-plugin.js';
+import { buildVoiceAdminPlugin } from './index.js';
 
 /**
- * Focused unit test for the inline voice-admin tools — previously impossible to
- * exercise without booting the whole builtins assembly. Drives the tool
- * handlers directly against a bare Session's synthesizer registry.
+ * Focused unit test for the voice-admin tools. Drives the tool handlers
+ * directly against a bare Session's synthesizer registry.
  */
 function tools(session: Session) {
   const plugin = buildVoiceAdminPlugin(session);

--- a/packages/plugin-voice-admin/src/index.ts
+++ b/packages/plugin-voice-admin/src/index.ts
@@ -9,9 +9,9 @@ import { definePlugin, defineTool, z, type Plugin } from '@moxxy/sdk';
  * + which is active. A synthesizer authored via self-update auto-activates on
  * load, so this is for switching afterwards.
  *
- * NOTE: this lives inline in cli for now; promoting it to its own
- * `@moxxy/voice-admin` package (so it joins `entries` like every other plugin)
- * is deferred — it is a cross-package boundary change.
+ * The synthesizer registry lives on the live Session, so this is built via a
+ * factory closing over it (mirroring `buildViewPlugin` / `buildSubagentsPlugin`)
+ * and wired into the cli's builtin `entries` list.
  */
 export function buildVoiceAdminPlugin(session: Session): Plugin {
   // 'system' (the OS voice) plus every registered synthesizer — the one

--- a/packages/plugin-voice-admin/tsconfig.json
+++ b/packages/plugin-voice-admin/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/plugin-voice-admin/vitest.config.ts
+++ b/packages/plugin-voice-admin/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/packages/runner/src/client-views/provider-admin.ts
+++ b/packages/runner/src/client-views/provider-admin.ts
@@ -1,5 +1,5 @@
 import type { ProviderAdminView } from '@moxxy/sdk';
-import { RunnerMethod } from '../protocol.js';
+import { RunnerMethod, type ReasoningEffortLevel } from '../protocol.js';
 import type { ViewContext } from './context.js';
 
 export interface ProviderAdminClientView extends ProviderAdminView {
@@ -7,6 +7,9 @@ export interface ProviderAdminClientView extends ProviderAdminView {
   setEnabled(name: string, enabled: boolean): Promise<void>;
   /** Re-probe every provider's credentials → fresh readyProviders. */
   refreshReady(): Promise<void>;
+  /** Set the session's reasoning/thinking effort (`off` clears it). Honored
+   *  only by models that advertise `supportsReasoning` (gated server-side). */
+  setReasoning(effort: ReasoningEffortLevel): Promise<void>;
 }
 
 // Provider management (protocol v7): backs the desktop's interactive
@@ -28,6 +31,10 @@ export function makeProviderAdminView(ctx: ViewContext): ProviderAdminClientView
     configure: async (name, patch) => {
       requireServerProtocol(7, 'Configuring a provider');
       await peer.request(RunnerMethod.ProviderConfigure, { name, patch });
+    },
+    setReasoning: async (effort) => {
+      requireServerProtocol(9, 'Setting reasoning effort');
+      await peer.request(RunnerMethod.SessionSetReasoning, { effort });
     },
   };
 }

--- a/packages/runner/src/handlers/index.ts
+++ b/packages/runner/src/handlers/index.ts
@@ -29,6 +29,7 @@ export {
 } from './surface-handlers.js';
 export {
   handleModeSetActive,
+  handleSessionSetReasoning,
   handlePermissionAddAllow,
   handleCommandRun,
 } from './session-handlers.js';

--- a/packages/runner/src/handlers/session-handlers.ts
+++ b/packages/runner/src/handlers/session-handlers.ts
@@ -2,6 +2,7 @@ import {
   commandRunParamsSchema,
   modeSetActiveParamsSchema,
   permissionAddAllowParamsSchema,
+  sessionSetReasoningParamsSchema,
   type CommandRunResult,
 } from '../protocol.js';
 import type { HandlerContext } from './context.js';
@@ -11,6 +12,24 @@ export function handleModeSetActive(ctx: HandlerContext, raw: unknown): Record<s
   // setActive fires onActiveChange → broadcastInfo (wired in the ctor), so
   // no explicit broadcast needed here.
   ctx.session.modes.setActive(name);
+  return {};
+}
+
+/**
+ * Set the session's reasoning/thinking effort (v9). Mirrors the CLI's proven
+ * `config.context.reasoning` path: `off` clears the preference, the others map
+ * onto `session.reasoning = { effort }`. `run-turn` forwards it to each turn's
+ * ModeContext, and `collectProviderStream` gates it on the active model's
+ * `supportsReasoning` flag — so a provider that ignores the knob is unaffected.
+ * Broadcast the fresh snapshot so attached clients reflect the new effort.
+ */
+export function handleSessionSetReasoning(
+  ctx: HandlerContext,
+  raw: unknown,
+): Record<string, never> {
+  const { effort } = sessionSetReasoningParamsSchema.parse(raw);
+  ctx.session.reasoning = effort === 'off' ? undefined : { effort };
+  ctx.broadcastInfo();
   return {};
 }
 

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -33,6 +33,8 @@ export {
   type RunTurnResult,
   type AbortParams,
   type SetResolverParams,
+  type ReasoningEffortLevel,
+  type SessionSetReasoningParams,
   type PermissionCheckParams,
   type PermissionCheckResult,
   type ApprovalConfirmParams,

--- a/packages/runner/src/integration.test.ts
+++ b/packages/runner/src/integration.test.ts
@@ -429,6 +429,45 @@ describe('runner end-to-end', () => {
     expect(result).toEqual({ kind: 'text', text: 'pong' });
   });
 
+  it('sets the session reasoning effort, which flows into the provider request (v9)', async () => {
+    // A reasoning-capable model — the effort is gated on the descriptor's
+    // `supportsReasoning` in collectProviderStream, so the catalog must opt in.
+    const provider = new FakeProvider({
+      models: [
+        {
+          id: 'reasoner',
+          contextWindow: 200_000,
+          maxOutputTokens: 8000,
+          supportsTools: true,
+          supportsStreaming: true,
+          supportsReasoning: true,
+        },
+      ],
+      script: [textReply('thought hard'), textReply('thought less')],
+    });
+    const { session, socketPath } = await serve(provider);
+    const remote = await attach(socketPath);
+
+    // Default: no reasoning preference, so the request carries none.
+    expect(session.reasoning).toBeUndefined();
+
+    // settings.setReasoning RPC maps the effort onto session.reasoning (the CLI's
+    // config.context.reasoning shape) and broadcasts info.changed.
+    await remote.providerAdmin.setReasoning('high');
+    await waitFor(() => session.reasoning !== undefined);
+    expect(session.reasoning).toEqual({ effort: 'high' });
+
+    // A turn now forwards it to the provider request (descriptor opts in).
+    for await (const _event of remote.runTurn('think')) void _event;
+    expect(provider.received.at(-1)?.reasoning).toEqual({ effort: 'high' });
+
+    // 'off' clears it — the next turn's request carries no reasoning param.
+    await remote.providerAdmin.setReasoning('off');
+    await waitFor(() => session.reasoning === undefined);
+    for await (const _event of remote.runTurn('think less')) void _event;
+    expect(provider.received.at(-1)?.reasoning).toBeUndefined();
+  });
+
   it('persists the picked provider to preferences so the next runner inherits it', async () => {
     // Regression: a remote `providers.setActive` only mutated THIS runner's
     // in-memory state. The desktop spawns one `moxxy serve` PER workspace, so

--- a/packages/runner/src/protocol.ts
+++ b/packages/runner/src/protocol.ts
@@ -118,11 +118,20 @@ import type {
  *   returns `[]` and `surface.open` throws a clear "no surface" error. A v8
  *   client gates the family on the server's reported version.
  *
- * Every change v1→v8 has been ADDITIVE, so MIN_COMPATIBLE stays at 1: today's
+ * v9: adds `session.setReasoning` — sets the session's reasoning/thinking
+ * effort live (`off` | `low` | `medium` | `high`), mirroring the CLI's proven
+ * `config.context.reasoning` path: the handler maps the level onto
+ * `session.reasoning`, which `run-turn` forwards to each turn's ModeContext and
+ * on to the provider (honored only by models that advertise `supportsReasoning`,
+ * gated in collectProviderStream). Backs the desktop's Settings → Providers
+ * reasoning-effort selector. A v9 client gates the method on the server's
+ * reported version. (Additive — a v8 server simply lacks this one method.)
+ *
+ * Every change v1→v9 has been ADDITIVE, so MIN_COMPATIBLE stays at 1: today's
  * server can serve any client back to v1, and any client v1+ can attach. Bump
  * MIN_COMPATIBLE to N only when landing a breaking change at version N.
  */
-export const RUNNER_PROTOCOL_VERSION = 8;
+export const RUNNER_PROTOCOL_VERSION = 9;
 
 /**
  * Lowest client protocol version this build's CORE session protocol is
@@ -155,6 +164,8 @@ export const RunnerMethod = {
   SetResolver: 'setResolver',
   /** client->server: switch the active mode. */
   ModeSetActive: 'mode.setActive',
+  /** client->server: set the session's reasoning/thinking effort (v9). */
+  SessionSetReasoning: 'session.setReasoning',
   /** client->server: switch the active provider (server resolves credentials). */
   ProviderSetActive: 'provider.setActive',
   /** client->server: enable/disable a provider (v7; persists to preferences). */
@@ -305,6 +316,15 @@ export interface SetResolverParams {
 
 export interface ModeSetActiveParams {
   readonly name: string;
+}
+
+/** Reasoning-effort levels accepted by `session.setReasoning` (v9). `off` clears
+ *  the preference (no reasoning requested); the others map to
+ *  `session.reasoning = { effort }`, the CLI's proven `config.context.reasoning`
+ *  shape. */
+export type ReasoningEffortLevel = 'off' | 'low' | 'medium' | 'high';
+export interface SessionSetReasoningParams {
+  readonly effort: ReasoningEffortLevel;
 }
 
 export interface ProviderSetActiveParams {
@@ -490,6 +510,10 @@ export const setResolverParamsSchema = z.object({
 });
 
 export const modeSetActiveParamsSchema = z.object({ name: z.string() });
+
+export const sessionSetReasoningParamsSchema = z.object({
+  effort: z.enum(['off', 'low', 'medium', 'high']),
+});
 
 export const providerSetActiveParamsSchema = z.object({
   name: z.string(),

--- a/packages/runner/src/server.ts
+++ b/packages/runner/src/server.ts
@@ -53,6 +53,7 @@ import {
   handleSurfaceResize,
   handleSurfaceClose,
   handleModeSetActive,
+  handleSessionSetReasoning,
   handlePermissionAddAllow,
   handleCommandRun,
   type HandlerContext,
@@ -210,6 +211,7 @@ export class RunnerServer {
     peer.handle(RunnerMethod.SessionReset, () => this.handleSessionReset());
     peer.handle(RunnerMethod.SetResolver, (raw) => this.handleSetResolver(client, raw));
     peer.handle(RunnerMethod.ModeSetActive, (raw) => handleModeSetActive(ctx, raw));
+    peer.handle(RunnerMethod.SessionSetReasoning, (raw) => handleSessionSetReasoning(ctx, raw));
     peer.handle(RunnerMethod.ProviderSetActive, (raw) => handleProviderSetActive(ctx, raw));
     peer.handle(RunnerMethod.ProviderSetEnabled, (raw) => handleProviderSetEnabled(ctx, raw));
     peer.handle(RunnerMethod.ProviderRefreshReady, () => handleProviderRefreshReady(ctx));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -540,6 +540,9 @@ importers:
       '@moxxy/plugin-view':
         specifier: workspace:*
         version: link:../plugin-view
+      '@moxxy/plugin-voice-admin':
+        specifier: workspace:*
+        version: link:../plugin-voice-admin
       '@moxxy/plugin-webhooks':
         specifier: workspace:*
         version: link:../plugin-webhooks
@@ -2108,6 +2111,34 @@ importers:
         version: 1.3.0
 
   packages/plugin-view:
+    dependencies:
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
+    devDependencies:
+      '@moxxy/core':
+        specifier: workspace:*
+        version: link:../core
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
+  packages/plugin-voice-admin:
     dependencies:
       '@moxxy/sdk':
         specifier: workspace:*


### PR DESCRIPTION
Implements the last audit items previously left as judgement calls — no by-design deferrals remain.

- **`targetInfo` table-drive** (`TARGET_DESCRIPTORS` record, byte-identical to the per-kind switch, compile-time exhaustive). Closes types-generics-5.
- **`@moxxy/plugin-voice-admin`** — voice/transcription admin tools extracted from `cli/setup` into a first-class builtin plugin (verbatim move, registered via the cli entries like the rest). Closes u28-3.
- **Reasoning-effort wired end to end**: desktop Providers selector → typed IPC → runner `config.context.reasoning` (runner protocol **v9**, desktop `FLOOR_RUNNER_PROTOCOL` bumped in lockstep). Was local-only/no-op before. Closes audit c15 / TECH_DEBT R1.

Every audit cluster is now fixed or implemented. Remaining `TECH_DEBT.md` entries are infrastructure constraints (chiefly the node-gyp/electron-builder/Node-floor bump) that can only be verified by a packaged-build harness and must not be blind-merged — documented as owner-gated follow-ups.

**Verification:** build 68/68 · typecheck 134/134 · test all pass · lint 0 errors · check:deps clean (renderer `node:*` rule enforced).