### PR TITLE
fix(desktop): self-update downgrade + offline anonymizer + sidebar/header nav

### DIFF
--- a/.changeset/anonymizer-ort-and-doc-types.md
+++ b/.changeset/anonymizer-ort-and-doc-types.md
@@ -1,0 +1,36 @@
+---
+"@moxxy/desktop-ipc-contract": patch
+"@moxxy/desktop-host": patch
+"@moxxy/client-core": patch
+"@moxxy/desktop": patch
+---
+
+fix(desktop): anonymizer NER runs fully offline + reads every common document type
+
+Two fixes to the offline document anonymizer:
+
+- **ORT wasm backend no longer hits a CDN.** The NER model failed with
+  `no available backend found … Failed to fetch … cdn.jsdelivr.net/…/ort-wasm-simd-threaded.jsep.mjs`:
+  transformers.js / onnxruntime-web resolved its WASM runtime glue from jsdelivr
+  by default, which broke the offline guarantee and failed outright (CSP-blocked /
+  offline). The onnxruntime-web artifacts (`ort-wasm-simd-threaded.jsep.{mjs,wasm}`)
+  are now shipped as part of the app shell (copied from `@huggingface/transformers`
+  into the renderer build at `/ort/`, served from the app's own origin in dev,
+  loopback, and `file://`), and the worker pins `env.backends.onnx.wasm.wasmPaths`
+  at that local base before the ORT session is created — nothing is fetched from a
+  CDN. The renderer CSP already permits this (it all rides on `'self'`); no real
+  network origin was opened.
+
+- **Reads all common document types.** The anonymizer now accepts PDF, Word
+  (`.doc`/`.docx`), RTF, OpenDocument (`.odt`/`.ods`/`.odp`), spreadsheets,
+  slides, and plain text. PDF/Office/ODF go through the existing officeparser
+  pipeline; legacy binary `.doc` and `.rtf` (which officeparser doesn't handle)
+  get dependency-free local extractors in a shared `parseBufferToText` core (so
+  chat attachments benefit too). The "Open document" pane also accepts
+  drag-and-drop: the renderer reads the dropped file's BYTES (which it already
+  holds — no filesystem access) and sends them to a new host-only
+  `anonymizer.parseDocumentBytes` IPC for extraction. It deliberately sends bytes
+  rather than a path, so a compromised renderer can't forge a path to read an
+  arbitrary file — the picker's provenance gate (which guards `parseDocument`)
+  stays the only way main ever opens a renderer-named path. Everything stays
+  local — no provider, runner, or network.

--- a/.changeset/fix-self-update-scheme-downgrade.md
+++ b/.changeset/fix-self-update-scheme-downgrade.md
@@ -1,0 +1,24 @@
+---
+"@moxxy/desktop-host": patch
+"@moxxy/desktop": patch
+---
+
+fix(desktop): stop the `moxxy-app://` scheme registration from crashing hot-updates (0.10 → 0.8 downgrade)
+
+The Apps feature registered its `moxxy-app://` privileged scheme with a
+top-level `protocol.registerSchemesAsPrivileged` call in the hot-updatable
+`index.ts`. Electron only honors that API **before** `app` is ready, but the
+immutable bootstrap loads the real main via `import()` **after** `whenReady` —
+so every hot-updated bundle threw `"protocol.registerSchemesAsPrivileged should
+be called before app is ready"` on load, got poisoned, and reverted to the baked
+floor. Observed live as a 0.10.0 → 0.8.x downgrade.
+
+- Register the privileged scheme in the bootstrap's synchronous pre-ready
+  prologue (the one place guaranteed to run before ready); the privileges are
+  single-sourced in a new `app-scheme` module so the bootstrap and `index.ts`
+  can't disagree. The call in `index.ts` is now a defensive no-op post-ready, so
+  a new override no longer crashes even on an already-installed older bootstrap.
+- Pruning after staging now also keeps the last `confirmed` bundle — the exact
+  rollback target `recoverFromFailedBoot` needs — so a genuinely failed boot
+  rolls back to the last-good override instead of falling all the way to the
+  floor.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -11,6 +11,16 @@ you introduce or notice gets written down the moment you see it. See AGENTS.md �
 (merged, PR #6). What remains below is what was deliberately deferred, what was blocked
 as unsafe to do mechanically, and debt accrued since.
 
+**Accrued 2026-06-18 (anonymizer offline ORT).** Shipping the onnxruntime-web WASM
+runtime in the app shell (`apps/desktop` → `dist/ort/`, pinned via the worker's
+`wasmPaths`) makes the NER backend load from `'self'` instead of the jsdelivr CDN. But
+onnxruntime-web's internal `new URL('ort-wasm-simd-threaded.jsep.wasm', import.meta.url)`
+ALSO makes Vite emit a second, hashed copy of the same ~21 MB binary under
+`dist/assets/` that is never loaded at runtime (`proxy:false` + our `wasmPaths` win).
+It's dead weight — ~21 MB of orphan that nonetheless rides every Tier-1 hot-update
+bundle. Follow-up: stop Vite resolving that internal `new URL` (e.g. a resolve alias /
+`assetsInclude` exclusion) so only `dist/ort/` ships. `apps/desktop/electron.vite.config.ts`.
+
 **Last refreshed:** 2026-06-09 (second pass) — **journal repair + audit intake.** PRs #113
 and #115 rebuilt this file from a branch cut before #107/#108 merged, silently resurrecting
 two entries those PRs had retired (P1 #2's growth defect, P2 #6 mode-loop scaffolding) and

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,6 +1,113 @@
 import { defineConfig, externalizeDepsPlugin, loadEnv } from 'electron-vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
+import { createRequire } from 'node:module';
+import { copyFileSync, mkdirSync, existsSync, createReadStream } from 'node:fs';
+import type { Plugin } from 'vite';
+
+/**
+ * The onnxruntime-web WASM artifacts the anonymizer's NER worker needs at
+ * runtime. transformers.js (which bundles onnxruntime-web) dynamically
+ * `import()`s `ort-wasm-simd-threaded.jsep.mjs` (the JS glue), which in turn
+ * fetch-compiles `ort-wasm-simd-threaded.jsep.wasm` (the ~21 MB binary).
+ *
+ * By DEFAULT transformers.js resolves these from the jsdelivr CDN — which (a)
+ * breaks the offline guarantee and (b) is blocked by the renderer CSP (and just
+ * fails outright when the user is offline). So we ship them as part of the app
+ * shell, served from the renderer's OWN origin at `/ort/<file>`, and point ORT
+ * at that local base via `env.backends.onnx.wasm.wasmPaths` in the worker. They
+ * are part of the bundle (unlike the ~109 MB model, which is install-downloaded)
+ * because they are tiny relative to the app and always required.
+ *
+ * The exact set is read from the installed `@huggingface/transformers` so a
+ * version bump can't silently desync the shipped glue from the runtime that
+ * loads it.
+ */
+const ORT_WASM_FILES = [
+  'ort-wasm-simd-threaded.jsep.mjs',
+  'ort-wasm-simd-threaded.jsep.wasm',
+] as const;
+
+/** Base URL path (relative to the renderer origin) the worker's `wasmPaths`
+ *  points at; MUST match {@link ../desktop/src/apps/anonymizer/ner/ner.worker.ts}. */
+const ORT_SERVE_BASE = '/ort/';
+
+function transformersDistDir(): string {
+  const require = createRequire(import.meta.url);
+  // The package's `exports` map doesn't expose `./package.json`, so resolve the
+  // package entry itself — every conditional export lands in `dist/`, so its
+  // dirname IS the dist dir (where the ORT artifacts live). Robust to pnpm's
+  // symlink layout.
+  const entry = require.resolve('@huggingface/transformers');
+  return path.dirname(entry);
+}
+
+/**
+ * Vite plugin: ship the onnxruntime-web WASM artifacts at `/ort/<file>` from the
+ * renderer origin, in BOTH dev (a static middleware) and prod (copied into
+ * `dist/ort/` so electron-builder packs them and the loopback / file:// server
+ * serves them). Nothing is fetched from a CDN.
+ */
+function ortWasmAssets(): Plugin {
+  const distDir = transformersDistDir();
+  return {
+    name: 'moxxy-ort-wasm-assets',
+    apply: 'build',
+    writeBundle(options): void {
+      const outDir = options.dir ?? path.resolve(__dirname, 'dist');
+      const ortOut = path.join(outDir, 'ort');
+      mkdirSync(ortOut, { recursive: true });
+      for (const file of ORT_WASM_FILES) {
+        const src = path.join(distDir, file);
+        if (!existsSync(src)) {
+          throw new Error(
+            `[ort-wasm] expected ${file} in @huggingface/transformers/dist (${distDir}); ` +
+              `the NER worker would fall back to the jsdelivr CDN and break offline use. ` +
+              `Re-run pnpm install or update ORT_WASM_FILES for this transformers version.`,
+          );
+        }
+        copyFileSync(src, path.join(ortOut, file));
+      }
+    },
+  };
+}
+
+/** Dev-only twin of {@link ortWasmAssets}: serve `/ort/<file>` from the
+ *  installed transformers dist so the worker resolves the same local paths the
+ *  packaged build serves (the Vite dev server is the renderer origin in dev). */
+function ortWasmDevServer(): Plugin {
+  const distDir = transformersDistDir();
+  return {
+    name: 'moxxy-ort-wasm-dev-server',
+    apply: 'serve',
+    configureServer(server): void {
+      // Match on the FULL request path (not connect's mounted/stripped url) so
+      // the behaviour matches the packaged `/ort/<file>` serving exactly.
+      server.middlewares.use((req, res, next) => {
+        const pathname = (req.url ?? '').split('?')[0] ?? '';
+        if (!pathname.startsWith(ORT_SERVE_BASE)) {
+          next();
+          return;
+        }
+        const file = pathname.slice(ORT_SERVE_BASE.length);
+        if (!(ORT_WASM_FILES as readonly string[]).includes(file)) {
+          next();
+          return;
+        }
+        const abs = path.join(distDir, file);
+        if (!existsSync(abs)) {
+          next();
+          return;
+        }
+        res.setHeader(
+          'Content-Type',
+          file.endsWith('.wasm') ? 'application/wasm' : 'text/javascript',
+        );
+        createReadStream(abs).pipe(res);
+      });
+    },
+  };
+}
 
 /**
  * Workspace packages the main process imports at runtime. They MUST be
@@ -95,7 +202,7 @@ export default defineConfig(({ mode }) => {
   },
   renderer: {
     root: '.',
-    plugins: [react()],
+    plugins: [react(), ortWasmAssets(), ortWasmDevServer()],
     resolve: {
       alias: {
         '@': path.resolve(__dirname, 'src'),

--- a/apps/desktop/electron/main/app-scheme.test.ts
+++ b/apps/desktop/electron/main/app-scheme.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Regression guard for the 0.10 → 0.8 self-update downgrade: the `moxxy-app://`
+ * privileged scheme MUST be registered before `app` is ready, and the helper
+ * MUST NOT call `registerSchemesAsPrivileged` once ready (Electron throws then,
+ * which crashed the hot-updated override on load and reverted to the floor).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const registerSchemesAsPrivileged = vi.fn();
+let ready = false;
+
+vi.mock('electron', () => ({
+  app: { isReady: () => ready },
+  protocol: { registerSchemesAsPrivileged: (...a: unknown[]) => registerSchemesAsPrivileged(...a) },
+}));
+
+import { APP_ASSET_SCHEME, registerAppAssetSchemePrivileged } from './app-scheme.js';
+
+afterEach(() => {
+  registerSchemesAsPrivileged.mockClear();
+  ready = false;
+});
+
+describe('registerAppAssetSchemePrivileged', () => {
+  it('registers the privileged moxxy-app scheme when called before app is ready', () => {
+    ready = false;
+    registerAppAssetSchemePrivileged();
+    expect(registerSchemesAsPrivileged).toHaveBeenCalledTimes(1);
+    const [schemes] = registerSchemesAsPrivileged.mock.calls[0] as [
+      Array<{ scheme: string; privileges: Record<string, boolean> }>,
+    ];
+    expect(schemes).toEqual([
+      {
+        scheme: APP_ASSET_SCHEME,
+        privileges: {
+          standard: true,
+          secure: true,
+          supportFetchAPI: true,
+          stream: true,
+          corsEnabled: true,
+        },
+      },
+    ]);
+  });
+
+  it('is a no-op once the app is ready (registering then throws → would crash the override)', () => {
+    ready = true;
+    registerAppAssetSchemePrivileged();
+    expect(registerSchemesAsPrivileged).not.toHaveBeenCalled();
+  });
+
+  it('uses the same scheme string the desktop-host asset protocol serves', () => {
+    expect(APP_ASSET_SCHEME).toBe('moxxy-app');
+  });
+});

--- a/apps/desktop/electron/main/app-scheme.ts
+++ b/apps/desktop/electron/main/app-scheme.ts
@@ -1,0 +1,52 @@
+/**
+ * Registration of the local-only `moxxy-app://` app-asset scheme.
+ *
+ * Electron only honors `protocol.registerSchemesAsPrivileged` BEFORE the app
+ * `ready` event. In a packaged build the real main (`index.ts`) is loaded by the
+ * immutable bootstrap via a dynamic `import()` that runs AFTER `app.whenReady()`
+ * (the bootstrap awaits bundle resolution + the import before the override's
+ * module body executes). So a top-level `registerSchemesAsPrivileged` call inside
+ * the hot-updatable `index.ts` runs post-ready and throws
+ *   "protocol.registerSchemesAsPrivileged should be called before app is ready"
+ * — which crashes the override main on load, poisons the freshly hot-updated
+ * bundle, and reverts the app to the baked floor (observed live as a 0.10 → 0.8
+ * downgrade). The privileged registration therefore MUST happen from the
+ * bootstrap's synchronous prologue — the one piece of the app guaranteed to run
+ * pre-ready — NOT from `index.ts`.
+ *
+ * Single-sourced here so the bootstrap and `index.ts` can never disagree on the
+ * scheme's privileges.
+ */
+import { app, protocol } from 'electron';
+
+/** The local-only app-asset scheme. MUST equal `@moxxy/desktop-host`'s
+ *  `APP_ASSET_SCHEME`. Duplicated here as a bare string (rather than imported)
+ *  so the immutable bootstrap stays free of the desktop-host barrel — the same
+ *  discipline as the hand-duplicated `compareSemver` baked into the bootstrap. */
+export const APP_ASSET_SCHEME = 'moxxy-app';
+
+/**
+ * Register `moxxy-app://` as a privileged standard + secure scheme that the
+ * renderer (and its workers) can fetch/stream under CSP. A no-op once the app is
+ * ready — calling `registerSchemesAsPrivileged` post-ready throws, and by then
+ * the bootstrap's pre-ready call has already registered it — so it is safe to
+ * call from BOTH the bootstrap prologue (the authoritative pre-ready call) and a
+ * defensive fallback in `index.ts` (for a non-bootstrap entry, e.g. a test).
+ */
+export function registerAppAssetSchemePrivileged(): void {
+  // Too late to register (and it would throw): the bootstrap already did it
+  // pre-ready. Nothing to do.
+  if (app.isReady()) return;
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: APP_ASSET_SCHEME,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        stream: true,
+        corsEnabled: true,
+      },
+    },
+  ]);
+}

--- a/apps/desktop/electron/main/bootstrap.ts
+++ b/apps/desktop/electron/main/bootstrap.ts
@@ -36,6 +36,7 @@ import {
 
 import { BUNDLED_UPDATE_PUBLIC_KEY } from './update-key.js';
 import { FLOOR_RUNNER_PROTOCOL } from './floor-runner-protocol.js';
+import { registerAppAssetSchemePrivileged } from './app-scheme.js';
 
 // MUST run before any `app.getPath('userData')` below. `userData` resolves to
 // `…/Application Support/<app.getName()>`, and in a packaged build Electron
@@ -48,6 +49,17 @@ import { FLOOR_RUNNER_PROTOCOL } from './floor-runner-protocol.js';
 // loader, so the app silently kept booting the floor. Keep this string in sync
 // with `index.ts`.
 app.setName('MoxxyAI Workspaces');
+
+// Register the `moxxy-app://` privileged scheme HERE, in the bootstrap's
+// synchronous prologue — the one piece of the app guaranteed to run BEFORE
+// `app` is ready. Electron only honors `registerSchemesAsPrivileged` pre-ready,
+// and the real main (`index.js`, floor OR a hot-updated override) is loaded
+// LATER via `import()` from `boot()`, after `whenReady` has fired. Doing it
+// there throws ("should be called before app is ready"), which crashed the
+// 0.10.0 override on load, poisoned it, and reverted to the floor (a 0.10 → 0.8
+// downgrade). The privileges live in `./app-scheme` so this and `index.ts`
+// can't disagree.
+registerAppAssetSchemePrivileged();
 
 /** Dir holding this bootstrap + the baked floor `index.js` (…/dist-electron/main). */
 const floorMainDir = import.meta.dirname;

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -68,6 +68,7 @@ import { buildOAuthHostPatterns, cleanOAuthUserAgent } from './oauth-window.js';
 import { makeCertVerifyProc, makeCertificateErrorHandler } from './loopback-tls.js';
 import { armBootProbe } from './boot-probe.js';
 import { installApplicationMenu } from './menus.js';
+import { registerAppAssetSchemePrivileged } from './app-scheme.js';
 
 // In a packaged build there is no global `moxxy` (and a GUI launch has no
 // shell PATH / system `node`). Point the CLI resolver at a self-contained,
@@ -80,30 +81,20 @@ if (app.isPackaged && !process.env.MOXXY_CLI_ENTRY) {
   const entry = preferredCliEntry(app.getPath('userData'), process.resourcesPath);
   if (entry) process.env.MOXXY_CLI_ENTRY = entry;
 }
-import { ipcMain, Tray, Menu, nativeImage, nativeTheme, globalShortcut, protocol, session, shell, systemPreferences } from 'electron';
+import { ipcMain, Tray, Menu, nativeImage, nativeTheme, globalShortcut, session, shell, systemPreferences } from 'electron';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// Register the local-only `moxxy-app://` asset scheme as privileged BEFORE
-// app-ready (Electron only honors registerSchemesAsPrivileged pre-ready). It
-// serves an installed app's downloaded assets (the anonymizer's NER model) from
-// `userData/moxxy-apps` over a confined GET/HEAD handler (no network egress);
-// the renderer + its worker fetch the model with it (CSP allows `moxxy-app:` in
-// connect-src). `standard + secure` so it's a trusted, fetch/stream-capable
-// origin; `supportFetchAPI`/`stream`/`bytes` so transformers.js can fetch + range
-// the ~109 MB model; `corsEnabled` so a worker request isn't CORS-blocked.
-protocol.registerSchemesAsPrivileged([
-  {
-    scheme: 'moxxy-app',
-    privileges: {
-      standard: true,
-      secure: true,
-      supportFetchAPI: true,
-      stream: true,
-      corsEnabled: true,
-    },
-  },
-]);
+// The local-only `moxxy-app://` asset scheme (serves an installed app's
+// downloaded assets — e.g. the anonymizer's NER model — from `userData/moxxy-apps`
+// over a confined GET/HEAD handler with no network egress) is registered as
+// privileged by the immutable bootstrap, which is the only code guaranteed to
+// run BEFORE `app` is ready (Electron only honors registerSchemesAsPrivileged
+// pre-ready). This module is loaded by the bootstrap via `import()` AFTER ready,
+// so a top-level registration here would throw and crash the override on load —
+// see ./app-scheme. This call is a defensive no-op in the normal (bootstrap)
+// path; it only does anything if `index.ts` is ever the direct pre-ready entry.
+registerAppAssetSchemePrivileged();
 
 const isDev = !!process.env['ELECTRON_RENDERER_URL'];
 

--- a/apps/desktop/src/apps/anonymizer/AnonymizerApp.tsx
+++ b/apps/desktop/src/apps/anonymizer/AnonymizerApp.tsx
@@ -29,6 +29,17 @@ function parseTerms(s: string): string[] {
     .filter(Boolean);
 }
 
+/** Base64-encode bytes for the drag-and-drop parse IPC. Chunked so a large file
+ *  doesn't exceed the argument-count limit of `String.fromCharCode(...)`. */
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
 /**
  * Offline document anonymizer. Paste text or open a document, and the redaction
  * runs ENTIRELY in this renderer — structured PII via `@moxxy/anonymizer`
@@ -43,6 +54,7 @@ export function AnonymizerApp({ onExit }: DesktopAppProps): JSX.Element {
   const [input, setInput] = useState('');
   const [fileName, setFileName] = useState<string | null>(null);
   const [fileError, setFileError] = useState<string | null>(null);
+  const [dragActive, setDragActive] = useState(false);
   const [categories, setCategories] = useState<ReadonlySet<PiiCategory>>(
     () => new Set(STRUCTURED_CATEGORIES),
   );
@@ -87,16 +99,49 @@ export function AnonymizerApp({ onExit }: DesktopAppProps): JSX.Element {
     });
   };
 
-  const openDocument = async (): Promise<void> => {
-    setFileError(null);
-    const r = await anon.pickAndParse();
-    if (!r) return; // cancelled
+  const applyParse = (r: { text: string } | { error: string }): void => {
     if ('error' in r) {
       setFileError(r.error);
       return;
     }
     setInput(r.text);
     setFileName('document');
+  };
+
+  const openDocument = async (): Promise<void> => {
+    setFileError(null);
+    const r = await anon.pickAndParse();
+    if (!r) return; // cancelled
+    applyParse(r);
+  };
+
+  // Drag-and-drop: read the dropped file's BYTES in the renderer (it already
+  // has them — no filesystem access needed), base64-encode, and parse them in
+  // main. We never send a path, so main can't be tricked into reading an
+  // arbitrary file.
+  const onDrop = (e: React.DragEvent): void => {
+    e.preventDefault();
+    setDragActive(false);
+    setFileError(null);
+    const file = e.dataTransfer.files?.[0];
+    if (!file) return;
+    void (async () => {
+      try {
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        applyParse(await anon.parseDroppedBytes(file.name || 'document', bytesToBase64(bytes)));
+      } catch {
+        setFileError('Could not read the dropped file.');
+      }
+    })();
+  };
+
+  const onDragOver = (e: React.DragEvent): void => {
+    e.preventDefault();
+    if (!dragActive) setDragActive(true);
+  };
+  const onDragLeave = (e: React.DragEvent): void => {
+    e.preventDefault();
+    setDragActive(false);
   };
 
   const copyOut = (): void => {
@@ -153,10 +198,33 @@ export function AnonymizerApp({ onExit }: DesktopAppProps): JSX.Element {
               style={{ width: '100%', fontSize: 13, lineHeight: 1.5 }}
             />
           ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div
+              data-testid="anon-dropzone"
+              onDrop={onDrop}
+              onDragOver={onDragOver}
+              onDragLeave={onDragLeave}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 8,
+                alignItems: 'flex-start',
+                padding: '0.9rem',
+                border: `1px dashed ${
+                  dragActive ? 'var(--color-accent)' : 'var(--color-border)'
+                }`,
+                borderRadius: 'var(--radius-block)',
+                background: dragActive ? 'var(--color-bg-card)' : 'transparent',
+                transition: 'border-color 120ms, background 120ms',
+              }}
+            >
               <Button variant="secondary" data-testid="anon-pick" onClick={() => void openDocument()}>
                 <Icon name="attach" size={14} /> Choose a document…
               </Button>
+              <span style={dim}>or drag &amp; drop a file here</span>
+              <span style={dim}>
+                Supports PDF, Word (.doc/.docx), RTF, OpenDocument (.odt/.ods/.odp), spreadsheets,
+                slides, and plain text.
+              </span>
               {anon.busy && <span style={dim}>Reading document…</span>}
               {fileName && !anon.busy && (
                 <span style={dim}>Loaded {result.report.total} item(s) from your document.</span>

--- a/apps/desktop/src/apps/anonymizer/ner/ner.worker.ts
+++ b/apps/desktop/src/apps/anonymizer/ner/ner.worker.ts
@@ -6,9 +6,16 @@
  *   - `remoteHost` points transformers.js at the local `moxxy-app://` scheme, so
  *     the model is loaded from the install dir — a huggingface.co request can
  *     never leave this worker (and CSP `connect-src` excludes all real network).
- *   - The onnxruntime-web wasm runtime is bundled into the app by Vite (from
- *     `@huggingface/transformers`) and loads from `'self'`, so no `wasmPaths`
- *     override is needed; we only force single-threaded + no proxy worker.
+ *   - The onnxruntime-web WASM runtime (the `ort-wasm-simd-threaded.jsep.{mjs,wasm}`
+ *     glue + binary) is NOT bundled into the worker chunk — onnxruntime-web
+ *     dynamically `import()`s its glue at session-create time, and by DEFAULT
+ *     transformers.js resolves that from the jsdelivr CDN. That would (a) break
+ *     the offline guarantee and (b) fail outright (CSP-blocked / offline). So we
+ *     ship those artifacts as part of the app shell (Vite copies them to
+ *     `dist/ort/`, served from the renderer's own origin) and pin
+ *     `env.backends.onnx.wasm.wasmPaths` to that LOCAL base below, BEFORE the
+ *     pipeline creates the ORT session — ORT then appends the filename and loads
+ *     from `'self'`, never the CDN. See {@link ../../../../electron.vite.config.ts}.
  * The heavy work is here so the UI thread never blocks while a ~109 MB model
  * loads and runs.
  */
@@ -18,6 +25,25 @@ const ctx = self as unknown as {
   postMessage: (message: unknown) => void;
   onmessage: ((e: MessageEvent) => void) | null;
 };
+
+/**
+ * Base URL the onnxruntime-web WASM artifacts are served from. They live at
+ * `/ort/` under the renderer origin in all three serving modes:
+ *   - dev:      the Vite dev server (a middleware serves `/ort/*`);
+ *   - prod:     the loopback HTTPS origin (`dist/ort/...`);
+ *   - fallback: `file://.../dist/ort/...`.
+ * For http(s) origins an origin-rooted `/ort/` is exact. For a `file://` worker
+ * `self.location.origin` is the opaque `"null"`, so resolve RELATIVE to the
+ * worker chunk instead (it lives in `dist/assets/`, so `../ort/` lands in
+ * `dist/ort/`). ORT appends the filename, so the path MUST end in a slash.
+ */
+function ortWasmBase(): string {
+  const here = self.location;
+  if (here.protocol === 'file:') {
+    return new URL('../ort/', here.href).href;
+  }
+  return new URL('/ort/', here.origin).href;
+}
 
 // Load the model from the locally installed copy under our custom scheme.
 // `pathJoin` only trims boundary slashes, so the `://` in remoteHost survives:
@@ -29,11 +55,15 @@ env.useBrowserCache = false;
 env.remoteHost = 'moxxy-app://assets/anonymizer/';
 env.remotePathTemplate = '{model}/resolve/{revision}/';
 
-// onnxruntime-web: the wasm runtime is bundled by Vite (loads from 'self'), so
-// no wasmPaths override. Force single-threaded (no SharedArrayBuffer / COOP-COEP)
-// and no proxy worker so nothing tries to re-fetch a loader at runtime.
+// onnxruntime-web: pin the WASM artifact base to our locally-served `/ort/` so
+// ORT loads `ort-wasm-simd-threaded.jsep.{mjs,wasm}` from the app's own origin
+// instead of the jsdelivr CDN (transformers.js only falls back to the CDN when
+// `wasmPaths` is unset — setting it here, before the pipeline creates the ORT
+// session, defeats that fallback). Force single-threaded (no SharedArrayBuffer /
+// COOP-COEP) and no proxy worker so nothing tries to re-fetch a loader at runtime.
 const wasmBackend = env.backends?.onnx?.wasm;
 if (wasmBackend) {
+  wasmBackend.wasmPaths = ortWasmBase();
   wasmBackend.numThreads = 1;
   wasmBackend.proxy = false;
 }

--- a/apps/desktop/src/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/settings/SettingsPanel.tsx
@@ -68,6 +68,7 @@ export function SettingsPanel({
             setQuery('');
           }}
           testIdPrefix="settings-tab-"
+          collapsible
         />
       </ViewHeader>
       <div

--- a/apps/desktop/src/shell/ViewHeader.test.tsx
+++ b/apps/desktop/src/shell/ViewHeader.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Responsive header tab groups (`Segmented collapsible`).
+ *
+ * The header carries two pill groups — the LEFT view switcher
+ * (Chat/Workflows/Collaborate/Apps) and, on Settings, the RIGHT tab group
+ * (Providers/MCP/Skills/Vault/Mobile/…). When the window is narrow the inline
+ * row would clip tabs off-screen, so each group folds into a single compact
+ * button + dropdown so every destination stays reachable.
+ *
+ * jsdom has neither layout nor ResizeObserver, so we install a controllable
+ * stub and pin the natural-vs-available widths to exercise both branches.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { Segmented } from './ViewHeader';
+
+// A ResizeObserver stub that lets the test fire a single observed callback.
+let fireResize: (() => void) | null = null;
+class FakeResizeObserver {
+  constructor(private readonly cb: ResizeObserverCallback) {
+    fireResize = () => this.cb([], this as unknown as ResizeObserver);
+  }
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+/**
+ * Force the fit decision. The component reads `nav.scrollWidth` (the inline
+ * row's natural width) and `container.clientWidth` (the squeezed width); we
+ * override each getter on the shared prototype so every element reports the
+ * value its branch needs.
+ */
+function pinWidths(natural: number, available: number): void {
+  Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+    configurable: true,
+    get() {
+      return natural;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get() {
+      return available;
+    },
+  });
+}
+
+const TABS = [
+  { id: 'providers', label: 'Providers' },
+  { id: 'mcp', label: 'MCP' },
+  { id: 'skills', label: 'Skills' },
+  { id: 'vault', label: 'Vault' },
+  { id: 'mobile', label: 'Mobile' },
+] as const;
+
+beforeEach(() => {
+  fireResize = null;
+  vi.stubGlobal('ResizeObserver', FakeResizeObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  // Drop the geometry overrides between tests.
+  for (const prop of ['scrollWidth', 'clientWidth'] as const) {
+    delete (HTMLElement.prototype as unknown as Record<string, unknown>)[prop];
+  }
+});
+
+describe('Segmented (collapsible)', () => {
+  it('renders all tabs inline when there is room (natural <= available)', () => {
+    pinWidths(300, 800);
+    render(
+      <Segmented items={TABS} value="providers" onChange={vi.fn()} testIdPrefix="t-" collapsible />,
+    );
+    // Every tab is reachable inline; no collapsed button.
+    for (const t of TABS) expect(screen.getByTestId(`t-${t.id}`)).toBeTruthy();
+    expect(screen.queryByTestId('t-collapsed')).toBeNull();
+  });
+
+  it('folds into one button + dropdown when the row does not fit', () => {
+    pinWidths(800, 300); // natural wider than available → collapse
+    render(
+      <Segmented items={TABS} value="vault" onChange={vi.fn()} testIdPrefix="t-" collapsible />,
+    );
+
+    // The inline pills are gone; a single compact control stands in, labelled
+    // with the ACTIVE tab — and it is focusable / operable.
+    const trigger = screen.getByTestId('t-collapsed');
+    expect(trigger).toBeTruthy();
+    expect(trigger.getAttribute('aria-haspopup')).toBe('menu');
+    expect(trigger.textContent).toContain('Vault');
+    // Closed: tabs are not yet in the tree (only behind the menu).
+    expect(screen.queryByTestId('t-providers')).toBeNull();
+
+    // Open the menu → every destination is reachable, active one marked.
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    for (const t of TABS) expect(screen.getByTestId(`t-${t.id}`)).toBeTruthy();
+    expect(screen.getByTestId('t-vault').getAttribute('data-active')).toBe('true');
+  });
+
+  it('picking a tab from the dropdown fires onChange and closes the menu', () => {
+    pinWidths(800, 300);
+    const onChange = vi.fn();
+    render(
+      <Segmented items={TABS} value="providers" onChange={onChange} testIdPrefix="t-" collapsible />,
+    );
+    fireEvent.click(screen.getByTestId('t-collapsed'));
+    fireEvent.click(screen.getByTestId('t-mobile'));
+    expect(onChange).toHaveBeenCalledWith('mobile');
+    // Menu closed after selection.
+    expect(screen.getByTestId('t-collapsed').getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('Escape closes the open dropdown', () => {
+    pinWidths(800, 300);
+    render(
+      <Segmented items={TABS} value="providers" onChange={vi.fn()} testIdPrefix="t-" collapsible />,
+    );
+    const trigger = screen.getByTestId('t-collapsed');
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('re-expands when room returns (no hysteresis: measurer is independent)', () => {
+    pinWidths(800, 300);
+    const { rerender } = render(
+      <Segmented items={TABS} value="providers" onChange={vi.fn()} testIdPrefix="t-" collapsible />,
+    );
+    expect(screen.getByTestId('t-collapsed')).toBeTruthy();
+
+    // Widen the window and re-fire the observer: it must fold back out even
+    // though the displayed row had been collapsed (the fit decision uses the
+    // natural width snapshotted while expanded, not the shrunken live row).
+    pinWidths(300, 800);
+    act(() => fireResize?.());
+    rerender(
+      <Segmented items={TABS} value="providers" onChange={vi.fn()} testIdPrefix="t-" collapsible />,
+    );
+    expect(screen.queryByTestId('t-collapsed')).toBeNull();
+    expect(screen.getByTestId('t-providers')).toBeTruthy();
+  });
+
+  it('non-collapsible Segmented always renders inline (unchanged behaviour)', () => {
+    // No widths pinned, no collapse ever — the Appearance theme toggle path.
+    render(<Segmented items={TABS} value="skills" onChange={vi.fn()} testIdPrefix="t-" />);
+    for (const t of TABS) expect(screen.getByTestId(`t-${t.id}`)).toBeTruthy();
+    expect(screen.queryByTestId('t-collapsed')).toBeNull();
+  });
+});

--- a/apps/desktop/src/shell/ViewHeader.tsx
+++ b/apps/desktop/src/shell/ViewHeader.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
+import { Icon } from '@moxxy/desktop-ui';
 import { PanelLeftIcon } from './PanelLeftIcon';
 import { setSidebarCollapsed, useSidebarCollapsed } from '@/lib/useSidebarCollapsed';
 
@@ -64,20 +65,66 @@ export function ViewHeader({ children }: { readonly children: ReactNode }): JSX.
  * pill), shared so the view switcher and the settings tabs read as one
  * control family. `value: null` renders with no active segment (used by
  * the switcher while Settings owns the pane).
+ *
+ * Pass `collapsible` to make it responsive: when the inline pill row would
+ * overflow its allotted width (a narrow window), the whole group folds into
+ * a single compact button — the active tab's label + a chevron — that opens
+ * a dropdown listing every tab. Nothing ever clips off-screen. At wide
+ * widths it renders the inline pills exactly as before. Non-collapsible
+ * call sites (Appearance theme toggle) are untouched.
  */
 export function Segmented<T extends string>({
   items,
   value,
   onChange,
   testIdPrefix,
+  collapsible = false,
+  collapsedLabel = 'Menu',
 }: {
   readonly items: ReadonlyArray<{ readonly id: T; readonly label: string }>;
   readonly value: T | null;
   readonly onChange: (id: T) => void;
   readonly testIdPrefix: string;
+  /** Fold into a dropdown when the inline row doesn't fit. Default off. */
+  readonly collapsible?: boolean;
+  /** Button label when collapsed and no tab is active (e.g. switcher on Settings). */
+  readonly collapsedLabel?: string;
+}): JSX.Element {
+  if (!collapsible) {
+    return (
+      <PillRow items={items} value={value} onChange={onChange} testIdPrefix={testIdPrefix} />
+    );
+  }
+
+  return (
+    <CollapsibleSegmented
+      items={items}
+      value={value}
+      onChange={onChange}
+      testIdPrefix={testIdPrefix}
+      collapsedLabel={collapsedLabel}
+    />
+  );
+}
+
+/** The inline grey-track / white-pill row — the un-collapsed look. `navRef`
+ *  lets the responsive wrapper read its natural width. */
+function PillRow<T extends string>({
+  items,
+  value,
+  onChange,
+  testIdPrefix,
+  navRef,
+}: {
+  readonly items: ReadonlyArray<{ readonly id: T; readonly label: string }>;
+  readonly value: T | null;
+  readonly onChange: (id: T) => void;
+  readonly testIdPrefix: string;
+  readonly navRef?: React.Ref<HTMLElement>;
 }): JSX.Element {
   return (
     <nav
+      ref={navRef}
       style={{
         display: 'inline-flex',
         gap: 2,
@@ -95,22 +142,242 @@ export function Segmented<T extends string>({
             data-testid={`${testIdPrefix}${t.id}`}
             data-active={active}
             onClick={() => onChange(t.id)}
-            style={{
-              padding: '6px 15px',
-              fontSize: 13,
-              fontWeight: 600,
-              borderRadius: 9,
-              color: active ? 'var(--color-text)' : 'var(--color-text-muted)',
-              background: active ? 'var(--color-surface)' : 'transparent',
-              boxShadow: active ? '0 1px 3px rgba(15, 23, 42, 0.12)' : 'none',
-              transition: 'background 140ms, color 140ms',
-            }}
+            style={pillStyle(active)}
           >
             {t.label}
           </button>
         );
       })}
     </nav>
+  );
+}
+
+function pillStyle(active: boolean): React.CSSProperties {
+  return {
+    padding: '6px 15px',
+    fontSize: 13,
+    fontWeight: 600,
+    borderRadius: 9,
+    whiteSpace: 'nowrap',
+    color: active ? 'var(--color-text)' : 'var(--color-text-muted)',
+    background: active ? 'var(--color-surface)' : 'transparent',
+    boxShadow: active ? '0 1px 3px rgba(15, 23, 42, 0.12)' : 'none',
+    transition: 'background 140ms, color 140ms',
+  };
+}
+
+/**
+ * The responsive shell around an inline Segmented row.
+ *
+ * Fit detection without a duplicate DOM subtree: the live inline row is
+ * always rendered first; while it's shown we snapshot its NATURAL width
+ * (`scrollWidth`) into a ref. A ResizeObserver on the outer (shrinkable)
+ * container then compares that remembered natural width against the available
+ * width and flips `collapsed`. Snapshotting the width (rather than re-reading
+ * the live row, which shrinks once collapsed) breaks the classic flip-flop
+ * loop — the decision input never changes just because we collapsed. When the
+ * container later grows back past the natural width we expand and re-snapshot.
+ *
+ * In a DOM without ResizeObserver (the real renderer's jsdom unit env) it
+ * stays expanded — the wide-window default — so the inline tabs render exactly
+ * as before and existing tab-by-text/-testid tests keep passing.
+ */
+function CollapsibleSegmented<T extends string>({
+  items,
+  value,
+  onChange,
+  testIdPrefix,
+  collapsedLabel,
+}: {
+  readonly items: ReadonlyArray<{ readonly id: T; readonly label: string }>;
+  readonly value: T | null;
+  readonly onChange: (id: T) => void;
+  readonly testIdPrefix: string;
+  readonly collapsedLabel: string;
+}): JSX.Element {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const navRef = useRef<HTMLElement | null>(null);
+  // Last natural (un-squeezed) width of the inline row, captured while it was
+  // displayed. Survives the collapse so the fit decision stays stable.
+  const naturalWidthRef = useRef(0);
+  const [collapsed, setCollapsed] = useState(false);
+  const [open, setOpen] = useState(false);
+  const menuRootRef = useRef<HTMLDivElement | null>(null);
+
+  // Re-evaluate fit on container/window resize and whenever the items change.
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    if (typeof ResizeObserver === 'undefined') return; // jsdom — stay expanded.
+
+    const evaluate = (): void => {
+      // Refresh the remembered natural width whenever the live row is shown.
+      const nav = navRef.current;
+      if (nav) naturalWidthRef.current = nav.scrollWidth;
+      const natural = naturalWidthRef.current;
+      const available = container.clientWidth;
+      // No layout yet (0 widths) → don't collapse. +1 slack absorbs sub-pixel
+      // rounding so we don't collapse on an exact fit.
+      if (natural <= 0 || available <= 0) {
+        setCollapsed(false);
+        return;
+      }
+      setCollapsed(natural > available + 1);
+    };
+
+    evaluate();
+    const ro = new ResizeObserver(evaluate);
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, [items, value]);
+
+  // When folded shut, dismiss on outside-click / Escape — matching RailMenu /
+  // the workspace RowMenu anchored-dropdown pattern.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent): void => {
+      if (!menuRootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const activeLabel = items.find((t) => t.id === value)?.label ?? collapsedLabel;
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        minWidth: 0, // allow the flex item to shrink so width tracks the squeeze
+        display: 'flex',
+        alignItems: 'center',
+        // While expanded, clip the inline row to its squeezed box so it can't
+        // spill past the header in the one frame before the observer collapses
+        // it. When collapsed, overflow MUST stay visible — the dropdown is
+        // absolutely positioned below this box.
+        overflow: collapsed ? 'visible' : 'hidden',
+      }}
+    >
+      {collapsed ? (
+        <div
+          ref={menuRootRef}
+          // The header pane sits inside a `transform`ed ancestor, which traps
+          // an absolutely-positioned child's z-index in a local stacking
+          // context. Lift this anchor while open so the dropdown paints ABOVE
+          // the page content instead of being covered. (See the same note on
+          // the workspace RowMenu.)
+          style={{
+            position: 'relative',
+            display: 'inline-flex',
+            zIndex: open ? 50 : undefined,
+          }}
+        >
+          <button
+            type="button"
+            data-testid={`${testIdPrefix}collapsed`}
+            aria-haspopup="menu"
+            aria-expanded={open}
+            aria-label={`${activeLabel} — open menu`}
+            onClick={() => setOpen((o) => !o)}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '7px 12px',
+              fontSize: 13,
+              fontWeight: 600,
+              borderRadius: 11,
+              whiteSpace: 'nowrap',
+              color: 'var(--color-text)',
+              background: 'var(--color-app-bg)',
+              transition: 'background 140ms',
+            }}
+          >
+            <span>{activeLabel}</span>
+            <span
+              aria-hidden
+              style={{
+                display: 'inline-flex',
+                transform: open ? 'rotate(-90deg)' : 'rotate(90deg)',
+                transition: 'transform 120ms ease',
+                color: 'var(--color-text-muted)',
+              }}
+            >
+              <Icon name="chevron-right" size={14} />
+            </span>
+          </button>
+          {open && (
+            <div
+              role="menu"
+              aria-label="Navigate"
+              style={{
+                position: 'absolute',
+                top: 'calc(100% + 6px)',
+                left: 0,
+                zIndex: 50,
+                minWidth: 168,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 2,
+                padding: 4,
+                background: 'var(--color-card-bg)',
+                border: '1px solid var(--color-card-border)',
+                borderRadius: 12,
+                boxShadow: '0 18px 40px -22px rgba(15, 23, 42, 0.45)',
+              }}
+            >
+              {items.map((t) => {
+                const active = value === t.id;
+                return (
+                  <button
+                    key={t.id}
+                    type="button"
+                    role="menuitem"
+                    data-testid={`${testIdPrefix}${t.id}`}
+                    data-active={active}
+                    onClick={() => {
+                      onChange(t.id);
+                      setOpen(false);
+                    }}
+                    className="row-button"
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 8,
+                      width: '100%',
+                      padding: '8px 10px',
+                      borderRadius: 8,
+                      fontSize: 13,
+                      fontWeight: active ? 600 : 500,
+                      textAlign: 'left',
+                      color: active ? 'var(--color-primary-strong)' : 'var(--color-text)',
+                    }}
+                  >
+                    {active && <Icon name="check" size={14} />}
+                    <span style={active ? undefined : { paddingLeft: 22 }}>{t.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      ) : (
+        <PillRow
+          items={items}
+          value={value}
+          onChange={onChange}
+          testIdPrefix={testIdPrefix}
+          navRef={navRef}
+        />
+      )}
+    </div>
   );
 }
 
@@ -139,6 +406,10 @@ export function ViewSwitcher({
       value={view === 'settings' ? null : view}
       onChange={onView}
       testIdPrefix="nav-"
+      collapsible
+      // On the Settings view this switcher has no active segment; label the
+      // folded button with the view family rather than a blank.
+      collapsedLabel="Views"
     />
   );
 }

--- a/apps/desktop/src/shell/workspace-sidebar/WorkspaceTree.test.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/WorkspaceTree.test.tsx
@@ -195,4 +195,24 @@ describe('WorkspaceTree', () => {
     );
     expect(h.onToggleCollapse).not.toHaveBeenCalled();
   });
+
+  // Regression: the ⋯ menu is anchored inside the row's subtree, and the
+  // ActionsOverlay's `transform` traps the menu's z-index in a local
+  // stacking context. Without lifting the owning row while its menu is
+  // open, a LATER sibling row paints over the menu (it looked see-through
+  // and overlapped the next folder). The row must carry a z-index only
+  // while its menu is open, and drop it again on close.
+  it('lifts the row that owns an open ⋯ menu above the rows below it', () => {
+    renderTree();
+    const row = screen.getByTestId('session-row-a2');
+    expect(row.style.zIndex).toBe(''); // idle: no stacking lift
+
+    fireEvent.click(screen.getByLabelText('session actions Fix the login bug'));
+    expect(row.style.zIndex).not.toBe(''); // open: lifted above following rows
+
+    // Closing the menu (Escape) drops the lift again so it never stacks
+    // permanently over its neighbours.
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(row.style.zIndex).toBe('');
+  });
 });

--- a/apps/desktop/src/shell/workspace-sidebar/WorkspaceTree.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/WorkspaceTree.tsx
@@ -230,6 +230,13 @@ function FolderRow({
       className="row-button"
       style={{
         position: 'relative',
+        // While its ⋯ menu is open this row must paint ABOVE the rows
+        // below it — the menu is anchored inside this row's subtree, and
+        // the ActionsOverlay's `transform` traps the menu's own z-index
+        // in a local stacking context, so without lifting the row a later
+        // sibling row would paint over the open menu (it appears
+        // see-through / overlapped). See RowMenu.
+        zIndex: menuOpen ? 30 : undefined,
         display: 'flex',
         alignItems: 'center',
         gap: 6,
@@ -385,6 +392,11 @@ function SessionRow({
         className={active ? undefined : 'row-button'}
         style={{
           position: 'relative',
+          // While its ⋯ menu is open, lift this row above the rows below
+          // so the menu (anchored in this row's subtree, with its z-index
+          // trapped inside the ActionsOverlay's transform stacking
+          // context) paints opaquely over them instead of being covered.
+          zIndex: menuOpen ? 30 : undefined,
           display: 'flex',
           alignItems: 'center',
           gap: 8,

--- a/packages/client-core/src/useAnonymizer.ts
+++ b/packages/client-core/src/useAnonymizer.ts
@@ -9,6 +9,12 @@ export interface UseAnonymizer {
    *  discriminated union (`{text}` | `{error}`) — a bad parse is data, not a
    *  thrown error. All redaction then happens in the renderer (offline). */
   readonly pickAndParse: () => Promise<AnonymizerParseResult | null>;
+  /** Parse a drag-and-dropped document from the base64 BYTES the renderer
+   *  already holds (the dropped file's contents) — no path crosses the boundary,
+   *  so main reads no arbitrary file. The caller reads the `File` + base64-encodes
+   *  it (this hook is DOM-free, so it takes plain strings). Same offline guarantee
+   *  + result shape as {@link pickAndParse}. */
+  readonly parseDroppedBytes: (name: string, dataBase64: string) => Promise<AnonymizerParseResult>;
   /** Save renderer-produced redacted text via a native Save dialog. Returns the
    *  chosen path, or null if cancelled. */
   readonly save: (suggestedName: string, content: string) => Promise<string | null>;
@@ -39,6 +45,23 @@ export function useAnonymizer(): UseAnonymizer {
     }
   }, []);
 
+  const parseDroppedBytes = useCallback(
+    async (name: string, dataBase64: string): Promise<AnonymizerParseResult> => {
+      setBusy(true);
+      setError(null);
+      try {
+        return await api().invoke('anonymizer.parseDocumentBytes', { name, dataBase64 });
+      } catch (e) {
+        const message = toErrorMessage(e);
+        setError(message);
+        return { error: message };
+      } finally {
+        setBusy(false);
+      }
+    },
+    [],
+  );
+
   const save = useCallback(
     async (suggestedName: string, content: string): Promise<string | null> => {
       setError(null);
@@ -52,5 +75,5 @@ export function useAnonymizer(): UseAnonymizer {
     [],
   );
 
-  return { pickAndParse, save, busy, error };
+  return { pickAndParse, parseDroppedBytes, save, busy, error };
 }

--- a/packages/desktop-host/src/apps/registry.ts
+++ b/packages/desktop-host/src/apps/registry.ts
@@ -4,9 +4,11 @@
  * Only apps that need a one-time local asset fetch appear here. Today that is
  * the document anonymizer, which downloads an on-device NER model (a quantised
  * `Xenova/bert-base-NER` ONNX bundle, ~109 MB) so it can detect names entirely
- * offline at use time. The onnxruntime-web wasm RUNTIME (~21 MB) is NOT here —
- * Vite bundles it into the app from `@huggingface/transformers` (served from
- * `'self'`); only the large model is fetched on demand.
+ * offline at use time. The onnxruntime-web wasm RUNTIME (~21 MB) is NOT fetched
+ * on demand — it ships as part of the app shell: Vite copies it from
+ * `@huggingface/transformers` into the renderer build (`dist/ort/`, served from
+ * `'self'`; see `apps/desktop/electron.vite.config.ts`), so only the large model
+ * is downloaded at install time.
  *
  * IMPORTANT — dest mirrors the URL the renderer will request EXACTLY. The
  * renderer's NER worker rewrites transformers.js model fetches to

--- a/packages/desktop-host/src/attachments.test.ts
+++ b/packages/desktop-host/src/attachments.test.ts
@@ -154,4 +154,55 @@ describe('parseFileToText', () => {
   it('returns null for an unreadable path', async () => {
     expect(await parseFileToText('/no/such/file.txt')).toBeNull();
   });
+
+  it('strips RTF control words to plain text (by extension)', async () => {
+    const rtf =
+      '{\\rtf1\\ansi\\deff0 {\\fonttbl{\\f0 Helvetica;}}\\f0\\fs24 ' +
+      'Hello \\b John Smith\\b0 from \\i Berlin\\i0 .\\par Email john@acme.com}';
+    const { path: p } = await tmpFile('memo.rtf', rtf);
+    const text = await parseFileToText(p);
+    expect(text).not.toBeNull();
+    expect(text).toContain('Hello John Smith from Berlin');
+    expect(text).toContain('john@acme.com');
+    // No RTF control words survive.
+    expect(text).not.toMatch(/\\rtf1|\\fonttbl|\\par|\\b0/);
+  });
+
+  it('detects RTF by its magic signature even without a .rtf extension', async () => {
+    const rtf = '{\\rtf1\\ansi Plain content here.\\par}';
+    const { path: p } = await tmpFile('mystery.dat', rtf);
+    expect(await parseFileToText(p)).toContain('Plain content here.');
+  });
+
+  it("decodes RTF \\'xx hex escapes", async () => {
+    // \'e9 is é in the default code page.
+    const rtf = "{\\rtf1\\ansi caf\\'e9 owner Ren\\'e9}";
+    const { path: p } = await tmpFile('accents.rtf', rtf);
+    const text = await parseFileToText(p);
+    expect(text).toContain('café');
+    expect(text).toContain('René');
+  });
+
+  it('recovers readable prose from a legacy binary .doc (OLE)', async () => {
+    // A synthetic OLE doc: the compound-doc magic header, then a WordDocument
+    // stream of readable prose interleaved with NUL/control noise (the shape
+    // legacyDocToText recovers).
+    const OLE_MAGIC = Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+    const noise = Buffer.from([0, 1, 0, 2, 0, 0, 3]);
+    const prose = Buffer.from('Dear Jane Doe, your account 12345 is ready.', 'latin1');
+    const more = Buffer.from('Contact: jane@example.com', 'latin1');
+    const buf = Buffer.concat([OLE_MAGIC, Buffer.alloc(20), noise, prose, noise, more, noise]);
+    const { path: p } = await tmpFile('letter.doc', buf);
+    const text = await parseFileToText(p);
+    expect(text).not.toBeNull();
+    expect(text).toContain('Dear Jane Doe, your account 12345 is ready.');
+    expect(text).toContain('jane@example.com');
+  });
+
+  it('returns null for a .doc with no recoverable text', async () => {
+    const OLE_MAGIC = Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+    const buf = Buffer.concat([OLE_MAGIC, Buffer.alloc(64, 0)]);
+    const { path: p } = await tmpFile('empty.doc', buf);
+    expect(await parseFileToText(p)).toBeNull();
+  });
 });

--- a/packages/desktop-host/src/attachments.ts
+++ b/packages/desktop-host/src/attachments.ts
@@ -61,6 +61,150 @@ function isPdf(buf: Buffer, ext: string): boolean {
   return ext === '.pdf' || (buf.length >= 5 && buf.toString('latin1', 0, 5) === '%PDF-');
 }
 
+/** RTF by extension or its `{\rtf` magic signature. */
+function isRtf(buf: Buffer, ext: string): boolean {
+  return ext === '.rtf' || buf.toString('latin1', 0, 5) === '{\\rtf';
+}
+
+/** Legacy binary Word (`.doc`) / OLE compound document magic
+ *  (`D0 CF 11 E0 A1 B1 1A E1`). officeparser only handles the OOXML `.docx`. */
+function isLegacyDoc(buf: Buffer, ext: string): boolean {
+  const OLE_MAGIC = Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+  return ext === '.doc' || (buf.length >= 8 && buf.subarray(0, 8).equals(OLE_MAGIC));
+}
+
+/** RTF control groups whose CONTENTS are metadata, not document prose — their
+ *  whole `{...}` group is skipped so font/colour/style names don't leak in. */
+const RTF_SKIP_GROUPS = new Set([
+  'fonttbl',
+  'colortbl',
+  'stylesheet',
+  'info',
+  'pntext',
+  'listtable',
+  'listoverridetable',
+  'rsidtbl',
+  'generator',
+  'themedata',
+  'colorschememapping',
+  'latentstyles',
+  'datastore',
+]);
+
+/**
+ * Strip RTF control words / groups to plain text — dependency-free (RTF is
+ * 7-bit ASCII: `\controlword`, `{`/`}` groups, and `\'xx` hex escapes). Skips
+ * metadata groups (font/colour/style tables) and any `{\*\...}` destination
+ * group, and treats a control word as a word boundary so adjacent runs don't
+ * fuse. Good enough to recover the document's prose for redaction without
+ * pulling in a heavyweight RTF parser. Returns null if nothing readable remains.
+ */
+function rtfToText(buf: Buffer): string | null {
+  const rtf = buf.toString('latin1');
+  let out = '';
+  // Group-depth stack: each entry says whether that group's text is suppressed
+  // (a metadata/destination group nests inside an already-suppressed one too).
+  const skipStack: boolean[] = [];
+  const suppressed = (): boolean => skipStack.some(Boolean);
+
+  for (let i = 0; i < rtf.length; i++) {
+    const ch = rtf[i]!;
+    if (ch === '{') {
+      // Open a group. Decide if it's a skip group by peeking the destination
+      // control word that (optionally after `\*`) starts it.
+      const after = rtf.slice(i + 1, i + 40);
+      const dest = /^\\\*?\\([a-z]+)/i.exec(after);
+      const isStar = /^\\\*/.test(after);
+      const skip = (dest && RTF_SKIP_GROUPS.has(dest[1]!.toLowerCase())) || isStar;
+      skipStack.push(Boolean(skip));
+      continue;
+    }
+    if (ch === '}') {
+      skipStack.pop();
+      continue;
+    }
+    if (ch === '\\') {
+      const next = rtf[i + 1];
+      // `\'xx` → a single byte; decode the hex pair.
+      if (next === "'") {
+        const hex = rtf.slice(i + 2, i + 4);
+        const code = Number.parseInt(hex, 16);
+        if (!suppressed() && Number.isFinite(code)) out += String.fromCharCode(code);
+        i += 3;
+        continue;
+      }
+      // A control word: `\word` optionally followed by a numeric arg, then a
+      // single optional space delimiter. `\par`/`\line`/`\tab` → whitespace;
+      // any other control word is a word boundary (emit a space so e.g.
+      // `Smith\b0 from` doesn't become `Smithfrom`).
+      const m = /^\\([a-z]+)(-?\d+)? ?/i.exec(rtf.slice(i));
+      if (m) {
+        const word = m[1]!.toLowerCase();
+        if (!suppressed()) {
+          if (word === 'par' || word === 'line' || word === 'sect') out += '\n';
+          else if (word === 'tab') out += '\t';
+          else out += ' ';
+        }
+        i += m[0].length - 1;
+        continue;
+      }
+      // An escaped literal (`\{`, `\}`, `\\`).
+      if (next === '{' || next === '}' || next === '\\') {
+        if (!suppressed()) out += next;
+        i += 1;
+        continue;
+      }
+      continue;
+    }
+    if (ch === '\r' || ch === '\n') continue; // raw line breaks are formatting
+    if (!suppressed()) out += ch;
+  }
+  const text = out
+    .replace(/[ \t]{2,}/g, ' ')
+    .replace(/ +\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+  return text.length > 0 ? text : null;
+}
+
+/**
+ * Best-effort plain-text recovery from a legacy binary `.doc` (OLE compound
+ * document). There is no dependency-free full parser, but the WordDocument
+ * stream stores the body as readable text interleaved with control/formatting
+ * bytes; pulling out the runs of printable characters recovers the prose well
+ * enough for PII redaction. We scan for runs of printable ASCII / Latin-1 (and
+ * common whitespace), drop short noise runs, and join them. Returns null when
+ * too little readable text is found (e.g. a corrupt or non-text doc).
+ */
+function legacyDocToText(buf: Buffer): string | null {
+  const runs: string[] = [];
+  let cur = '';
+  const flush = (): void => {
+    // Keep runs of ≥4 printable chars; shorter ones are almost always
+    // stray bytes from the binary structures, not prose.
+    if (cur.trim().length >= 4) runs.push(cur);
+    cur = '';
+  };
+  for (let i = 0; i < buf.length; i++) {
+    const b = buf[i]!;
+    const printable =
+      b === 0x09 || b === 0x0a || b === 0x0d || (b >= 0x20 && b !== 0x7f && b <= 0xfe);
+    if (printable) {
+      cur += String.fromCharCode(b);
+    } else {
+      flush();
+    }
+  }
+  flush();
+  const text = runs
+    .join('\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+  // Require a minimum signal so we don't hand back a pile of binary noise.
+  return text.length >= 16 ? text : null;
+}
+
 /** Extract plain text from an Office/ODF/PDF buffer. Returns null on failure
  *  (corrupt / unsupported / empty) so the caller can skip rather than throw. */
 async function extractText(buf: Buffer, name: string): Promise<string | null> {
@@ -74,32 +218,54 @@ async function extractText(buf: Buffer, name: string): Promise<string | null> {
 }
 
 /**
- * Read a file and return its plain text, mirroring {@link buildAttachments}'
- * per-file text logic WITHOUT the attachment/size machinery: PDFs and Office /
- * OpenDocument files go through officeparser; any other file is returned as
- * UTF-8 when it isn't binary (a NUL byte ⇒ binary ⇒ null). Returns null on a
- * read failure, on a binary/unsupported file, or when no text could be
- * extracted.
+ * Extract plain text from an already-read document BUFFER, dispatching by magic
+ * bytes + the supplied `name`'s extension. The format-handling core shared by
+ * {@link parseFileToText} (path-based — the picker flow) and the anonymizer's
+ * drag-and-drop path (which sends the bytes the renderer already holds). Handles:
+ *   - PDF + Office/ODF (`.docx`/`.xlsx`/`.pptx`/`.odt`/`.ods`/`.odp`) → officeparser
+ *   - RTF (`.rtf`)            → a dependency-free control-word stripper
+ *   - legacy Word (`.doc`)   → best-effort printable-run recovery from the OLE doc
+ *   - text / code            → UTF-8 (a NUL byte ⇒ binary ⇒ null)
+ * Returns null for a binary/unsupported buffer or when no text could be
+ * extracted. No provider, no runner, no network — just local parsing.
+ */
+export async function parseBufferToText(buf: Buffer, name: string): Promise<string | null> {
+  const ext = path.extname(name).toLowerCase();
+  // PDF (by extension or magic bytes) or Office/ODF → officeparser.
+  if (isPdf(buf, ext) || OFFICE_EXTENSIONS.has(ext)) {
+    return extractText(buf, name);
+  }
+  // RTF → strip control words locally (officeparser doesn't handle RTF, and the
+  // raw bytes are readable-but-noisy markup, so don't fall through to UTF-8).
+  if (isRtf(buf, ext)) {
+    return rtfToText(buf);
+  }
+  // Legacy binary `.doc` (OLE) → best-effort printable-run recovery (must come
+  // BEFORE the binary/NUL check below, since OLE docs are full of NUL bytes).
+  if (isLegacyDoc(buf, ext)) {
+    return legacyDocToText(buf);
+  }
+  // Anything else: UTF-8 text, unless it looks binary.
+  if (buf.includes(0)) return null;
+  return buf.toString('utf8');
+}
+
+/**
+ * Read a file and return its plain text via {@link parseBufferToText}. Returns
+ * null on a read failure (in addition to the buffer parser's null cases).
  *
- * Reused by the offline anonymizer (`anonymizer.parseDocument`): no provider, no
- * runner, no network — just readFile + officeparser.
+ * Reused by the offline anonymizer's picker flow (`anonymizer.parseDocument`),
+ * which provenance-gates the path BEFORE calling this — no provider, no runner,
+ * no network.
  */
 export async function parseFileToText(absPath: string): Promise<string | null> {
-  const ext = path.extname(absPath).toLowerCase();
-  const name = path.basename(absPath);
   let buf: Buffer;
   try {
     buf = await readFile(absPath);
   } catch {
     return null;
   }
-  // PDF (by extension or magic bytes) or Office/ODF → officeparser.
-  if (isPdf(buf, ext) || OFFICE_EXTENSIONS.has(ext)) {
-    return extractText(buf, name);
-  }
-  // Anything else: UTF-8 text, unless it looks binary.
-  if (buf.includes(0)) return null;
-  return buf.toString('utf8');
+  return parseBufferToText(buf, path.basename(absPath));
 }
 
 export async function buildAttachments(

--- a/packages/desktop-host/src/ipc/anonymizer.ts
+++ b/packages/desktop-host/src/ipc/anonymizer.ts
@@ -23,14 +23,16 @@ import { dialog, BrowserWindow as BrowserWindowApi } from 'electron';
 import type { RunnerPool } from '../runner-pool';
 import type { DeskStore } from '../desks';
 import { authorizeAttachments, rememberPickedAttachment } from '../attachment-authz';
-import { parseFileToText } from '../attachments.js';
+import { parseFileToText, parseBufferToText } from '../attachments.js';
 import { handle } from './shared';
 
 /** Document extensions the anonymizer can parse. Mirrors the picker filter and
- *  {@link parseFileToText}'s capabilities. */
+ *  {@link parseFileToText}'s capabilities (PDF + Office/ODF via officeparser,
+ *  legacy `.doc` + `.rtf` via the local recovery helpers, everything else as
+ *  UTF-8 text). */
 const DOCUMENT_EXTENSIONS = [
-  'pdf', 'docx', 'xlsx', 'pptx', 'odt', 'ods', 'odp',
-  'txt', 'md', 'markdown', 'csv', 'tsv', 'json', 'log', 'rtf', 'html', 'xml',
+  'pdf', 'doc', 'docx', 'xlsx', 'pptx', 'odt', 'ods', 'odp', 'rtf',
+  'txt', 'md', 'markdown', 'csv', 'tsv', 'json', 'log', 'html', 'xml',
 ];
 
 /**
@@ -82,10 +84,24 @@ export function registerAnonymizerHandlers(pool: RunnerPool, desks: DeskStore): 
     const cwds = await authorizedCwds(pool, desks);
     const { authorized } = await authorizeAttachments([{ path, name: basename(path) }], cwds);
     if (authorized.length === 0) {
-      return { error: "This file isn't authorized to read. Pick it via the document picker." };
+      return { error: "This file isn't authorized to read. Open it via the picker or drop it here." };
     }
-    // No provider, no runner, no network — just readFile + officeparser.
+    // No provider, no runner, no network — just local extraction.
     const text = await parseFileToText(path);
+    return text ? { text } : { error: 'Could not extract text from this document.' };
+  });
+
+  handle('anonymizer.parseDocumentBytes', async ({ name, dataBase64 }) => {
+    // A drag-and-drop sends the BYTES the renderer already legitimately holds
+    // (the dropped File's contents), NOT a path — so there is no provenance gate
+    // to run and no arbitrary-file-read to worry about: main never opens a
+    // renderer-named path, it only extracts text from the supplied buffer. (A
+    // path-based drop would let a compromised renderer forge a path and
+    // exfiltrate any file, defeating parseDocument's gate above.) Size is capped
+    // by the input schema. No provider, no runner, no network.
+    const buf = Buffer.from(dataBase64, 'base64');
+    if (buf.byteLength === 0) return { error: 'The dropped file was empty.' };
+    const text = await parseBufferToText(buf, name);
     return text ? { text } : { error: 'Could not extract text from this document.' };
   });
 

--- a/packages/desktop-host/src/ipc/update.ts
+++ b/packages/desktop-host/src/ipc/update.ts
@@ -169,8 +169,19 @@ export function registerUpdateHandlers(config: UpdateConfig): void {
           wsEventBus.broadcast('app.update.progress', p);
         },
       });
-      // Keep {active, previous} so a failed boot can roll back to the last-good.
-      pruneBundles(app.getPath('userData'), [version, currentVersion]);
+      // Keep the freshly-staged version, the currently-running one, AND the
+      // last confirmed-good — the exact bundle `recoverFromFailedBoot` rolls
+      // back to if the new version fails its boot health-check. Pruning to just
+      // {staged, running} drops the rollback target whenever they differ from
+      // `confirmed` (e.g. staging while running the FLOOR, where running ==
+      // floor but confirmed == an older override), so a failed boot falls all
+      // the way to the floor instead of the last-good override — part of the
+      // 0.10 → 0.8 downgrade.
+      const confirmed = readConfirmed(app.getPath('userData'));
+      pruneBundles(
+        app.getPath('userData'),
+        confirmed ? [version, currentVersion, confirmed] : [version, currentVersion],
+      );
       return { ok: true, version };
     } catch (e) {
       return { ok: false, version: null, error: messageOf(e) };

--- a/packages/desktop-host/src/security.ts
+++ b/packages/desktop-host/src/security.ts
@@ -351,6 +351,16 @@ export function clerkCspHostSources(publishableKey?: string | null): string[] {
  * from the publishable key (see {@link clerkCspHostSources}); empty for test
  * keys.
  *
+ * The anonymizer's NER worker loads onnxruntime-web's WASM artifacts
+ * (`ort-wasm-simd-threaded.jsep.{mjs,wasm}`) — the `.mjs` glue is a dynamic
+ * module `import()` and the `.wasm` is fetch-compiled. Both ride entirely on
+ * `'self'`: we ship them in the app shell at `/ort/` (served from the renderer's
+ * own origin — see `electron.vite.config.ts`'s `ortWasmAssets` plugin and the
+ * worker's `wasmPaths`), NOT from a CDN. So `script-src 'self'` covers the glue
+ * import, `worker-src 'self'` covers the worker, and `connect-src 'self'` +
+ * `'wasm-unsafe-eval'` cover the binary's fetch + compile — no extra origin and
+ * no CDN (e.g. jsdelivr) is ever permitted.
+ *
  * `connect-src` additionally allows the `moxxy-app:` scheme: the anonymizer's
  * renderer worker fetches its locally installed model files over
  * `moxxy-app://assets/<appId>/...`. That scheme is served by a confined,

--- a/packages/desktop-ipc-contract/src/commands.ts
+++ b/packages/desktop-ipc-contract/src/commands.ts
@@ -415,6 +415,18 @@ export interface IpcCommands {
    *  locally. The file is read ONLY if its provenance is authorized (picked or
    *  under a workspace cwd). No provider, no runner, no network. */
   'anonymizer.parseDocument': (args: { path: string }) => Promise<AnonymizerParseResult>;
+  /** Parse a document the user DRAG-AND-DROPPED onto the anonymizer, from the
+   *  base64 BYTES the renderer already holds (the dropped `File`'s contents) —
+   *  NOT a path. The renderer legitimately has the dropped file's content, so
+   *  this grants main no new authority: it extracts text from the supplied bytes
+   *  (no fs read of a renderer-named path, no provider/runner/network). This is
+   *  the safe alternative to taking a path, which a compromised renderer could
+   *  forge to read an arbitrary file — exactly what the picker's provenance gate
+   *  exists to prevent. Bounded size (see `ipcInputSchemas`). */
+  'anonymizer.parseDocumentBytes': (args: {
+    name: string;
+    dataBase64: string;
+  }) => Promise<AnonymizerParseResult>;
   /** Save renderer-produced redacted text to a user-chosen location via a
    *  native Save dialog. Main writes ONLY where the user pointed; returns the
    *  path or null if cancelled. */

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -205,6 +205,13 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
   // takes nothing — pin it to "nothing" so no args can be smuggled across.
   'anonymizer.pickDocument': z.undefined(),
   'anonymizer.parseDocument': z.object({ path: z.string().min(1).max(4096) }),
+  // A drag-dropped doc: the renderer sends the dropped file's BYTES (base64),
+  // not a path — so there's no arbitrary-file-read to gate, only a size to cap.
+  // ~67 MB of base64 ≈ 50 MB of file, matching the picker's practical ceiling.
+  'anonymizer.parseDocumentBytes': z.object({
+    name: z.string().min(1).max(255),
+    dataBase64: z.string().min(1).max(67_000_000),
+  }),
   'anonymizer.saveRedacted': z.object({
     suggestedName: z.string().min(1).max(255),
     content: z.string().max(20_000_000),


### PR DESCRIPTION
Follow-up bug-fixes to the Apps/anonymizer feature (#230) and the desktop self-update path. All four issues were reproduced from a real user install; fixes verified against the live boot-log + the full gate.

## 1. Self-update downgrade — **critical** (`0.10 → 0.8`, and `0.11` won't apply)

A hot-updated bundle threw on load and reverted to the baked floor. The user's boot-log:

```
boot 0.10.0 → load-error "protocol.registerSchemesAsPrivileged should be called before app is ready"
            → recover (unconfirmed-previous-boot) → boot floor (no-active)
```

The Apps feature registered its `moxxy-app://` privileged scheme with a **top-level `protocol.registerSchemesAsPrivileged` in the hot-updatable `index.ts`**. Electron only honors that API *before* `app` is ready, but the immutable bootstrap loads the real main via `import()` *after* `whenReady` — so **every** hot-updated bundle (0.10.0 *and* 0.11.0) crashed on load, got poisoned, and reverted. With the last `confirmed` bundle already pruned, it fell all the way to the floor.

- Register the scheme in the **bootstrap's synchronous pre-`ready` prologue** (the one place guaranteed to run before ready); privileges single-sourced in a new `app-scheme` module so bootstrap + `index.ts` can't drift. The `index.ts` call is now a **guarded no-op post-`ready`**, so a new override no longer crashes even on an already-installed *old* bootstrap → **this release self-heals stranded installs** (they hot-update and boot instead of reverting).
- Pruning after staging now also keeps the `confirmed` rollback target, so a genuinely failed boot rolls back to the last-good override instead of the floor.
- Regression test pins the pre/post-`ready` invariant.

## 2. Anonymizer NER ran against a CDN, not offline

The model failed with `no available backend found … Failed to fetch … cdn.jsdelivr.net/…/ort-wasm-simd-threaded.jsep.mjs`: onnxruntime-web resolves its WASM glue from jsdelivr by default (the worker's "loads from 'self'" assumption was false). The ORT artifacts now ship in the app shell (`dist/ort/`) and the worker pins `wasmPaths` there — nothing hits a CDN. CSP unchanged (all `'self'`).

## 3. Anonymizer couldn't read PDFs / all document types

PDF/Office/ODF go through the existing officeparser pipeline; added dependency-free local extractors for legacy `.doc` (OLE) and `.rtf` in a shared `parseBufferToText`. Added drag-and-drop — the renderer sends the dropped file's **bytes** (which it already holds) to a host-only `anonymizer.parseDocumentBytes` IPC, **not a path**: a path-based drop would let a compromised renderer forge a path and read any file, defeating the picker's provenance gate.

## 4. Sidebar `⋯` menu painted under the next row

A `transform` on `ActionsOverlay` created a stacking context that trapped the menu's `z-index`, so the following row painted over it. Lift the owning row while its menu is open.

## 5. Header nav unreachable when the window is narrow

The header tab groups never shrank/wrapped, so tabs clipped off-screen at small widths. `Segmented` now collapses each group into an anchored dropdown (active label + chevron) when the inline row won't fit, via a ResizeObserver; wide widths render inline as before.

---

**Note on branching:** this work was authored in a worktree that was stale at desktop `0.9.0`; the fixes are cherry-picked cleanly onto current `main` (`0.11.1`), where all four bugs still exist.

**Changesets:** two added (`@moxxy/desktop-host` + `@moxxy/desktop` patch for the self-update fix; the four anonymizer packages patch for ORT + doc types). Logged the ORT orphan-wasm size follow-up in TECH_DEBT.md.

**Verification:** `pnpm build` 67/67 · `typecheck` 132/132 · `test` all suites (desktop 240, desktop-host, client-core, ipc-contract) · `lint` 0 errors · `check:deps` clean. The packaged NER-model load + real drag-drop still want a packaged run (same caveat the original feature carried).