### PR TITLE
feat(surfaces): browser zoom + select-element-for-agent; redesign Collaborate start

### DIFF
--- a/.changeset/browser-zoom-element-pick-collab-ux.md
+++ b/.changeset/browser-zoom-element-pick-collab-ux.md
@@ -1,0 +1,21 @@
+---
+"@moxxy/plugin-browser": patch
+"@moxxy/desktop": patch
+---
+
+feat(surfaces): browser zoom + "select element for the agent"; redesigned Collaborate start
+
+**Browser zoom.** ⌘+ / ⌘− / ⌘0 (and toolbar buttons) zoom the page in the
+in-window browser (CSS `zoom` via a new sidecar `zoom` method), intercepted so
+they zoom the page rather than the whole desktop app.
+
+**Select an element for the agent.** A new "select element" toggle lets you click
+any element on the page; the sidecar's `pick` method resolves a best-effort CSS
+selector + text snippet, and a bar appears where you describe a change ("make it
+blue") and hit **Ask agent** — which tasks the session (`session.runTurn`) to
+change that element via the browser tool. Aimed at the localhost dev loop
+("change this XXX to YYY").
+
+**Collaborate tab.** Redesigned the "Start a collaboration" empty state: a proper
+composer card (focus ring, ⌘↵ to start, primary action) plus quick-start example
+chips, replacing the bare input + button.

--- a/apps/desktop/src/collaborate/CollaboratePanel.tsx
+++ b/apps/desktop/src/collaborate/CollaboratePanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { api, useChat } from '@moxxy/client-core';
 import { pairToolEvents } from '@moxxy/chat-model';
-import { Icon } from '@moxxy/desktop-ui';
+import { Button, Icon } from '@moxxy/desktop-ui';
 import { ViewHeader, ViewSwitcher, type View } from '../shell/ViewHeader';
 import { dotColor, filterCollabMessages, latestCollab, taskChipBg } from './collab-view';
 
@@ -148,20 +148,48 @@ export function CollaboratePanel({
             flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
-            gap: 14,
+            gap: 18,
             padding: 24,
             textAlign: 'center',
           }}
         >
-          <Icon name="agent" size={28} />
-          <div style={{ fontWeight: 600, color: 'var(--color-text-muted)' }}>Start a collaboration</div>
-          <div style={{ fontSize: 13, maxWidth: 460, color: 'var(--color-text-dim)' }}>
-            Describe a goal and a team of agents — an architect plus implementers — will plan it,
-            propose a roster for you to approve, then build it in parallel. Only one collaboration
-            runs at a time.
+          <div
+            aria-hidden
+            style={{
+              width: 52,
+              height: 52,
+              borderRadius: 16,
+              display: 'grid',
+              placeItems: 'center',
+              color: 'var(--color-primary)',
+              background: 'color-mix(in srgb, var(--color-primary) 14%, transparent)',
+            }}
+          >
+            <Icon name="agent" size={26} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 7, alignItems: 'center' }}>
+            <div style={{ fontWeight: 700, fontSize: 19, color: 'var(--color-text)' }}>
+              Start a collaboration
+            </div>
+            <div style={{ fontSize: 13, maxWidth: 460, color: 'var(--color-text-dim)', lineHeight: 1.55 }}>
+              Describe a goal and a team of agents — an architect plus implementers — will plan it,
+              propose a roster for you to approve, then build it in parallel. Only one collaboration
+              runs at a time.
+            </div>
           </div>
           {globalActive?.active && (
-            <div style={{ fontSize: 12.5, color: 'var(--color-amber-text)', maxWidth: 460 }}>
+            <div
+              style={{
+                fontSize: 12.5,
+                color: 'var(--color-amber-text)',
+                maxWidth: 520,
+                background: 'color-mix(in srgb, var(--color-amber) 12%, transparent)',
+                border: '1px solid color-mix(in srgb, var(--color-amber) 35%, transparent)',
+                borderRadius: 10,
+                padding: '8px 12px',
+                lineHeight: 1.5,
+              }}
+            >
               A collaboration is already running{globalActive.task ? ` ("${globalActive.task}")` : ''}. Only one
               runs at a time to save resources — wait for it to finish, then start another.
             </div>
@@ -177,8 +205,8 @@ export function CollaboratePanel({
             <button
               type="button"
               onClick={() => setForceStart(false)}
-              className="btn-chip"
-              style={{ fontSize: 12, padding: '4px 10px', borderRadius: 8 }}
+              className="btn-ghost"
+              style={{ fontSize: 12.5, padding: '4px 10px', borderRadius: 8, color: 'var(--color-text-muted)' }}
             >
               ← Back to the current team
             </button>
@@ -421,6 +449,12 @@ function Empty({ children }: { readonly children: React.ReactNode }): JSX.Elemen
   return <div style={{ padding: '4px 12px', fontSize: 12, color: 'var(--color-text-dim)', fontStyle: 'italic' }}>{children}</div>;
 }
 
+const COLLAB_EXAMPLES = [
+  'Add a CSV export feature with tests and docs',
+  'Refactor the auth module into smaller files',
+  'Add dark-mode support across the settings screens',
+];
+
 function StartComposer({
   goal,
   setGoal,
@@ -434,41 +468,113 @@ function StartComposer({
   readonly blocked: boolean;
   readonly onStart: () => void;
 }): JSX.Element {
+  const [focused, setFocused] = useState(false);
   const disabled = starting || blocked || goal.trim().length === 0;
   return (
-    <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', width: '100%', maxWidth: 560 }}>
-      <textarea
-        value={goal}
-        onChange={(e) => setGoal(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-            e.preventDefault();
-            if (!disabled) onStart();
-          }
-        }}
-        placeholder="e.g. Add a CSV export feature with tests and docs"
-        rows={2}
+    <div style={{ width: '100%', maxWidth: 580, display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {/* Composer card — the textarea + actions read as one surface (focus ring
+       *  on the whole card), matching the chat composer rather than a bare box. */}
+      <div
         style={{
-          flex: 1,
-          resize: 'none',
-          padding: '10px 12px',
-          borderRadius: 12,
-          border: '1px solid var(--color-card-border)',
-          background: 'var(--color-input-soft)',
-          fontSize: 13,
-          color: 'var(--color-text)',
-          fontFamily: 'inherit',
+          border: `1px solid ${focused ? 'var(--color-primary)' : 'var(--color-card-border)'}`,
+          borderRadius: 16,
+          background: 'var(--color-surface)',
+          padding: 14,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 10,
+          textAlign: 'left',
+          boxShadow: focused
+            ? '0 0 0 3px color-mix(in srgb, var(--color-primary) 22%, transparent)'
+            : '0 1px 3px rgba(0, 0, 0, 0.18)',
+          transition: 'border-color 120ms, box-shadow 120ms',
         }}
-      />
-      <button
-        type="button"
-        onClick={onStart}
-        disabled={disabled}
-        className="btn-cta"
-        style={{ padding: '10px 16px', borderRadius: 12, fontWeight: 600, opacity: disabled ? 0.6 : 1 }}
       >
-        {starting ? 'Starting…' : 'Start'}
-      </button>
+        <textarea
+          value={goal}
+          onChange={(e) => setGoal(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              if (!disabled) onStart();
+            }
+          }}
+          autoFocus
+          placeholder="Describe what the team should build…"
+          rows={3}
+          style={{
+            resize: 'none',
+            border: 'none',
+            outline: 'none',
+            background: 'transparent',
+            fontSize: 14,
+            lineHeight: 1.55,
+            color: 'var(--color-text)',
+            fontFamily: 'inherit',
+            minHeight: 68,
+          }}
+        />
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+          <span style={{ fontSize: 11.5, color: 'var(--color-text-dim)' }}>
+            <Kbd>⌘</Kbd>
+            <Kbd>↵</Kbd> to start
+          </span>
+          <Button
+            variant="cta"
+            onClick={onStart}
+            disabled={disabled}
+            style={{ padding: '8px 18px', borderRadius: 10, opacity: disabled ? 0.55 : 1 }}
+          >
+            {starting ? 'Starting…' : 'Start collaboration'}
+          </Button>
+        </div>
+      </div>
+      {/* Quick-start examples — click to fill the goal. */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, justifyContent: 'center' }}>
+        {COLLAB_EXAMPLES.map((ex) => (
+          <button
+            key={ex}
+            type="button"
+            className="btn-chip"
+            onClick={() => setGoal(ex)}
+            style={{
+              fontSize: 12,
+              padding: '5px 11px',
+              borderRadius: 999,
+              maxWidth: '100%',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {ex}
+          </button>
+        ))}
+      </div>
     </div>
+  );
+}
+
+function Kbd({ children }: { readonly children: React.ReactNode }): JSX.Element {
+  return (
+    <kbd
+      style={{
+        display: 'inline-block',
+        minWidth: 16,
+        textAlign: 'center',
+        padding: '1px 4px',
+        margin: '0 2px',
+        fontSize: 10.5,
+        fontFamily: 'inherit',
+        color: 'var(--color-text-muted)',
+        background: 'var(--color-app-bg)',
+        border: '1px solid var(--color-card-border)',
+        borderRadius: 5,
+      }}
+    >
+      {children}
+    </kbd>
   );
 }

--- a/apps/desktop/src/shell/surfaces/BrowserPane.tsx
+++ b/apps/desktop/src/shell/surfaces/BrowserPane.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
+import { api } from '@moxxy/client-core';
 import { Button, Icon, IconButton } from '@moxxy/desktop-ui';
 import { useSurface } from './useSurface';
+
+/** An element the user pointed at in "select element" mode (from the `pick`
+ *  sidecar method) — handed to the agent to act on. */
+interface PickedElement {
+  readonly selector: string;
+  readonly tag: string;
+  readonly text: string;
+}
 
 interface BrowserFrame {
   readonly type?: string;
@@ -12,7 +21,13 @@ interface BrowserFrame {
   /** Set on a status when the Playwright engine isn't installed — the pane shows
    *  an "Install" button (the download is ~200MB, so we ask first). */
   readonly needsInstall?: boolean;
+  /** Carried by `{ type: 'picked' }` — the element under the user's click. */
+  readonly element?: PickedElement | null;
 }
+
+const ZOOM_MIN = 0.25;
+const ZOOM_MAX = 5;
+const clampZoom = (z: number): number => Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, Math.round(z * 100) / 100));
 
 /** Keys (beyond single printable chars) we forward to the page; everything else
  *  — lone modifiers, F-keys, etc. — is ignored so it can't drive the host UI. */
@@ -53,9 +68,16 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
   const [installing, setInstalling] = useState(false);
   const [url, setUrl] = useState('');
   const [editingUrl, setEditingUrl] = useState('');
+  const [zoom, setZoom] = useState(1);
+  // "Select element" mode: the next click picks an element instead of clicking.
+  const [picking, setPicking] = useState(false);
+  const [picked, setPicked] = useState<PickedElement | null>(null);
+  const [change, setChange] = useState('');
+  const [sent, setSent] = useState(false);
   const hostRef = useRef<HTMLDivElement | null>(null);
   const urlInputRef = useRef<HTMLInputElement | null>(null);
   const lastMoveRef = useRef(0);
+  const zoomRef = useRef(1); // latest zoom, read by keyboard handlers (no stale closure)
 
   const apply = (payload: unknown): void => {
     const p = payload as BrowserFrame;
@@ -71,6 +93,12 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
       if (p.needsInstall) {
         setNeedsInstall(true);
         setInstalling(false);
+      }
+    } else if (p?.type === 'picked') {
+      if (p.element) {
+        setPicked(p.element);
+        setChange('');
+        setSent(false);
       }
     }
     if (typeof p?.url === 'string') {
@@ -135,6 +163,28 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
     surface.input({ type: 'install' });
   };
 
+  const setZoomTo = (next: number): void => {
+    const z = clampZoom(next);
+    zoomRef.current = z;
+    setZoom(z);
+    surface.input({ type: 'zoom', factor: z });
+  };
+
+  // Task the agent to change the picked element (localhost dev loop). The agent's
+  // browser_session tool can act on the selector we captured.
+  const askAgent = (): void => {
+    if (!picked || !workspaceId) return;
+    const what = change.trim();
+    if (!what) return;
+    const where = url ? ` on ${url}` : '';
+    const ctx = picked.text ? ` (currently "${picked.text}")` : '';
+    const prompt = `Using the browser, change the element \`${picked.selector}\`${ctx}${where} to: ${what}`;
+    void api().invoke('session.runTurn', { workspaceId, prompt }).catch(() => undefined);
+    setSent(true);
+    setPicked(null);
+    setChange('');
+  };
+
   // Pointer event → normalized page coords (0..1 of the frame box).
   const norm = (e: React.MouseEvent): { fx: number; fy: number } | null => {
     const rect = hostRef.current?.getBoundingClientRect();
@@ -151,6 +201,30 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
   };
 
   const onKeyDown = (e: React.KeyboardEvent): void => {
+    // Browser zoom (⌘/Ctrl +/−/0) — intercept before key-forwarding so it zooms
+    // the PAGE, not the whole desktop app (Electron's default for these chords).
+    if ((e.metaKey || e.ctrlKey) && !e.altKey) {
+      if (e.key === '=' || e.key === '+') {
+        e.preventDefault();
+        setZoomTo(zoomRef.current + 0.1);
+        return;
+      }
+      if (e.key === '-' || e.key === '_') {
+        e.preventDefault();
+        setZoomTo(zoomRef.current - 0.1);
+        return;
+      }
+      if (e.key === '0') {
+        e.preventDefault();
+        setZoomTo(1);
+        return;
+      }
+    }
+    if (e.key === 'Escape' && picking) {
+      e.preventDefault();
+      setPicking(false);
+      return;
+    }
     const printable = e.key.length === 1;
     if (!printable && !NAMED_KEYS.has(e.key)) return; // ignore lone modifiers, F-keys, …
     const hasMod = e.ctrlKey || e.metaKey || e.altKey;
@@ -222,7 +296,115 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
             }}
           />
         </form>
+        {/* Zoom controls (⌘+/⌘−/⌘0 also work when the view is focused). */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2,
+            border: '1px solid var(--color-card-border)',
+            borderRadius: 999,
+            padding: '0 2px',
+          }}
+        >
+          <IconButton size={22} onClick={() => setZoomTo(zoom - 0.1)} title="Zoom out (⌘−)" aria-label="Zoom out">
+            <span style={{ fontSize: 14, lineHeight: 1 }}>−</span>
+          </IconButton>
+          <button
+            type="button"
+            onClick={() => setZoomTo(1)}
+            title="Reset zoom (⌘0)"
+            className="btn-ghost"
+            style={{ fontSize: 11, minWidth: 38, padding: '2px 2px', color: 'var(--color-text-dim)' }}
+          >
+            {Math.round(zoom * 100)}%
+          </button>
+          <IconButton size={22} onClick={() => setZoomTo(zoom + 0.1)} title="Zoom in (⌘+)" aria-label="Zoom in">
+            <span style={{ fontSize: 14, lineHeight: 1 }}>+</span>
+          </IconButton>
+        </div>
+        {/* "Select element" — pick an element on the page to hand to the agent. */}
+        <IconButton
+          size={26}
+          bordered={picking}
+          onClick={() => setPicking((v) => !v)}
+          title={picking ? 'Click an element to select it (Esc to cancel)' : 'Select an element for the agent'}
+          aria-label="Select element"
+          style={picking ? { color: 'var(--color-primary)' } : undefined}
+        >
+          <Icon name="context" size={14} />
+        </IconButton>
       </div>
+
+      {/* Picked element → task the agent to change it (localhost dev loop). */}
+      {(picked || sent) && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '8px 10px',
+            borderBottom: '1px solid var(--color-card-border)',
+            background: 'var(--color-input-soft)',
+            flexShrink: 0,
+          }}
+        >
+          {sent && !picked ? (
+            <span style={{ fontSize: 12, color: 'var(--color-green)' }}>
+              ✓ Asked the agent — see the Chat tab for the response.
+            </span>
+          ) : (
+            <>
+              <Icon name="context" size={13} />
+              <code
+                title={picked?.selector}
+                style={{
+                  fontSize: 11,
+                  color: 'var(--color-text-muted)',
+                  maxWidth: 200,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  flexShrink: 0,
+                }}
+              >
+                {picked?.selector}
+              </code>
+              <input
+                value={change}
+                onChange={(e) => setChange(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    askAgent();
+                  } else if (e.key === 'Escape') {
+                    setPicked(null);
+                  }
+                }}
+                autoFocus
+                placeholder="Describe the change for the agent… (e.g. make it blue)"
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  padding: '5px 10px',
+                  fontSize: 12,
+                  color: 'var(--color-text)',
+                  border: '1px solid var(--color-card-border)',
+                  borderRadius: 8,
+                  background: 'var(--color-surface)',
+                  outline: 'none',
+                }}
+              />
+              <Button variant="primary" size="sm" onClick={askAgent} disabled={change.trim().length === 0}>
+                Ask agent
+              </Button>
+              <IconButton size={22} onClick={() => setPicked(null)} title="Dismiss" aria-label="Dismiss">
+                <Icon name="x" size={13} />
+              </IconButton>
+            </>
+          )}
+        </div>
+      )}
 
       {surface.error && (
         <div style={{ padding: '8px 12px', fontSize: 11.5, color: 'var(--color-danger, #f87171)' }}>
@@ -237,7 +419,14 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
         onMouseDown={() => hostRef.current?.focus()}
         onClick={(e) => {
           const n = norm(e);
-          if (n) surface.input({ type: 'click', ...n });
+          if (!n) return;
+          if (picking) {
+            // Capture the element instead of clicking it through to the page.
+            surface.input({ type: 'pick', ...n });
+            setPicking(false);
+          } else {
+            surface.input({ type: 'click', ...n });
+          }
         }}
         onDoubleClick={(e) => {
           const n = norm(e);
@@ -253,6 +442,7 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
           overflow: 'hidden',
           background: '#0b0f17',
           outline: 'none',
+          cursor: picking ? 'crosshair' : 'default',
         }}
       >
         {hasView ? (

--- a/packages/plugin-browser/src/browser-surface.test.ts
+++ b/packages/plugin-browser/src/browser-surface.test.ts
@@ -291,6 +291,33 @@ describe('browser surface input mapping', () => {
     surface.close();
   });
 
+  it('zoom forwards the factor; pick maps coords and emits the element', async () => {
+    vi.useFakeTimers();
+    const sidecar = makeControllableSpawn();
+    sidecar.setHandler((method) => {
+      if (method === 'frame') return { ok: true, result: frame({ width: 1000, height: 500 }) };
+      if (method === 'pick') return { ok: true, result: { selector: 'button#go', tag: 'button', text: 'Go' } };
+      return { ok: true, result: {} };
+    });
+    const surface = buildBrowserSurface({ sidecarPath: '/fake.js', spawnFn: sidecar.spawn }).open();
+    const events: Array<{ type: string; element?: unknown }> = [];
+    surface.onData((p) => events.push(p as { type: string }));
+    await flush();
+
+    await surface.input({ type: 'zoom', factor: 1.5 });
+    await surface.input({ type: 'pick', fx: 0.5, fy: 0.2 });
+    await flush();
+
+    expect(sidecar.received.find((r) => r.method === 'zoom')?.params).toEqual({ factor: 1.5 });
+    expect(sidecar.received.find((r) => r.method === 'pick')?.params).toEqual({ x: 500, y: 100 });
+    expect(events.find((e) => e.type === 'picked')?.element).toEqual({
+      selector: 'button#go',
+      tag: 'button',
+      text: 'Go',
+    });
+    surface.close();
+  });
+
   it('navigate proxies goto and surfaces a goto rejection as a status line', async () => {
     vi.useFakeTimers();
     const sidecar = makeControllableSpawn();

--- a/packages/plugin-browser/src/browser-surface.ts
+++ b/packages/plugin-browser/src/browser-surface.ts
@@ -213,6 +213,16 @@ export function buildBrowserSurface(deps?: BrowserSessionDeps) {
               () => undefined,
             );
             void tick();
+          } else if (msg.type === 'pick' && typeof msg.fx === 'number' && typeof msg.fy === 'number') {
+            // Identify the element the user pointed at and hand it back to the
+            // pane (which lets the user task the agent to change it).
+            const element = await browserSidecarCall('pick', { x: msg.fx * vw, y: msg.fy * vh }, deps).catch(
+              () => null,
+            );
+            emit({ type: 'picked', element });
+          } else if (msg.type === 'zoom' && typeof msg.factor === 'number') {
+            await browserSidecarCall('zoom', { factor: msg.factor }, deps).catch(() => undefined);
+            bump();
           } else if (msg.type === 'key' && typeof msg.key === 'string') {
             await browserSidecarCall('key', { key: msg.key }, deps).catch(() => undefined);
             bump();

--- a/packages/plugin-browser/src/sidecar/dispatch.ts
+++ b/packages/plugin-browser/src/sidecar/dispatch.ts
@@ -215,6 +215,35 @@ async function dispatchInner(state: SidecarState, req: Req): Promise<Reply> {
       await h.page.mouse.wheel(0, dy ?? 0);
       return { id: req.id, ok: true };
     }
+    case 'zoom': {
+      // Page zoom for the surface (⌘+/⌘−). CSS `zoom` is the cheapest faithful
+      // way to scale a screenshot-streamed page; clamped to a sane range.
+      const { factor } = (req.params ?? {}) as { factor: number };
+      const f = Number.isFinite(factor) ? Math.min(5, Math.max(0.25, factor)) : 1;
+      const h = await ensurePlaywright(state, {});
+      await h.page.evaluate(`document.documentElement.style.zoom=String(${f})`);
+      return { id: req.id, ok: true };
+    }
+    case 'pick': {
+      // Identify the element at (x,y) so the user can hand it to the agent
+      // ("change this XXX to YYY"). Returns a best-effort CSS selector + a short
+      // text snippet; the agent's browser_session tool can act on the selector.
+      const { x, y } = (req.params ?? {}) as { x: number; y: number };
+      if (!Number.isFinite(x) || !Number.isFinite(y)) throw badParams('x and y must be finite numbers');
+      const h = await ensurePlaywright(state, {});
+      const expr =
+        `(() => { const x=${x}, y=${y}; const el=document.elementFromPoint(x,y);` +
+        ` if(!el) return null;` +
+        ` const sel=(e)=>{ if(e.id) return '#'+CSS.escape(e.id); const p=[]; let n=e;` +
+        ` while(n && n.nodeType===1 && n!==document.body){ let s=n.tagName.toLowerCase();` +
+        ` if(n.classList && n.classList.length) s+='.'+Array.from(n.classList).slice(0,2).map(c=>CSS.escape(c)).join('.');` +
+        ` const par=n.parentElement; if(par){ const same=Array.from(par.children).filter(c=>c.tagName===n.tagName);` +
+        ` if(same.length>1) s+=':nth-of-type('+(same.indexOf(n)+1)+')'; } p.unshift(s); n=n.parentElement; }` +
+        ` return p.join(' > '); };` +
+        ` return { selector: sel(el), tag: el.tagName.toLowerCase(), text: (el.textContent||'').replace(/\\s+/g,' ').trim().slice(0,140) }; })()`;
+      const info = await h.page.evaluate(expr);
+      return { id: req.id, ok: true, result: info };
+    }
     case 'eval': {
       const h = await ensurePlaywright(state, {});
       const { expression } = (req.params ?? {}) as { expression: string };


### PR DESCRIPTION
## What

Three desktop UX additions (all on the agentic surfaces + Collaborate tab).

**Browser — page zoom.** ⌘+ / ⌘− / ⌘0 (and toolbar −/%/+ buttons) zoom the in-window page via a new sidecar `zoom` method (CSS `zoom`). The chords are intercepted in the pane so they zoom the *page*, not the whole Electron app.

**Browser — "select an element for the agent".** A new toggle (target icon) lets you click any element on the page; the sidecar's `pick` method resolves a best-effort CSS selector + text snippet via `elementFromPoint`. A bar then appears — describe a change ("make it blue") and hit **Ask agent**, which tasks the session (`session.runTurn`) to change that element using the browser tool. Built for the localhost dev loop ("change this XXX to YYY"). Esc cancels.

**Collaborate — redesigned "Start a collaboration".** The bare input + button became a proper composer card (focus ring, ⌘↵ to start, primary CTA) with quick-start example chips.

## Verification

- `pnpm build` (68/68), `pnpm -w typecheck` (134/134), `pnpm check:deps` clean (993 modules), lint 0 errors — fresh worktree off latest `origin/main`.
- Tests: plugin-browser 84 (added coverage: zoom forwards factor, pick maps coords + emits the element), desktop 242 (existing BrowserPane keyboard test still green). Full `turbo run test` green.
- Changeset included.

Note: builds on the now-merged #237 (interactive browser + file preview).