### PR TITLE
Security + correctness sweep of the new collab / anonymizer / mini-apps features

### DIFF
--- a/.changeset/quality-sweep-newmain.md
+++ b/.changeset/quality-sweep-newmain.md
@@ -1,0 +1,27 @@
+---
+"@moxxy/cli": patch
+"@moxxy/desktop": patch
+---
+
+Security + correctness audit of the newly-merged features (collab / anonymizer / mini-apps)
+
+Applied the quality sweep to the features that landed during it. Real bugs fixed,
+each with a regression test:
+
+- **mode-collaborative (security, high):** path-traversal / arbitrary-file-read in
+  the peer-read confinement — a `startsWith(dir)` prefix check let a peer agent
+  read sibling-dir files outside its worktree. Replaced with segment-aware
+  containment (`resolve`+`relative`). Also fixed abort-listener leaks in the poll
+  loops.
+- **plugin-collab (security/correctness):** `boardRelease`/`boardClaim` by public
+  id skipped the owner check (lock-stealing + ownership-hijack across peers), and
+  a crashed agent's file locks were never freed (deadlock). Ownership now enforced
+  on the id path; crashed/killed agents release their claims.
+- **anonymizer (security/perf):** NER span aggregation mislocated short entities
+  (a **PII-leak** — redacted the wrong region, left real PII), the worker leaked
+  in-flight promises on teardown/error, and overlap resolution was O(n²). Fixed.
+- **app installer (security):** the asset download had no source allow-list (SSRF)
+  and no size cap (disk-fill DoS); both added. The `moxxy-app://` protocol handler
+  was audited and confirmed escape-proof.
+- mini-apps framework + collaborate UI: worker-leak fix, IPC boundary Zod test
+  coverage, and extracted/tested pure render helpers.

--- a/apps/desktop/src/apps/anonymizer/ner/aggregate.test.ts
+++ b/apps/desktop/src/apps/anonymizer/ner/aggregate.test.ts
@@ -33,4 +33,39 @@ describe('aggregate', () => {
     const spans = aggregate(tokens, text);
     expect(spans.map((s) => s.start)).toEqual([0, 8]);
   });
+
+  it('locates a short entity at a WORD-ALIGNED offset, not inside a larger word', () => {
+    // Regression: a raw indexOf('Al') would land inside 'Alabama' (offset 0),
+    // redacting non-PII and leaving the real person 'Al' exposed. The span must
+    // land on the standalone 'Al'.
+    const text = 'Alabama is where Al lives';
+    const spans = aggregate([tok('B-PER', 'Al')], text);
+    expect(spans).toEqual([{ category: 'person', start: 17, end: 19, value: 'Al' }]);
+  });
+
+  it('recovers a hyphen-joined surface the tokenizer split into spaced parts', () => {
+    // 'Jean-Pierre' tokenizes to Jean / - / Pierre → surface 'Jean - Pierre',
+    // which indexOf can't find. The span must still be recovered (else the name
+    // leaks unredacted).
+    const text = 'Jean-Pierre called';
+    const spans = aggregate([tok('B-PER', 'Jean'), tok('I-PER', '-'), tok('I-PER', 'Pierre')], text);
+    expect(spans).toEqual([{ category: 'person', start: 0, end: 11, value: 'Jean-Pierre' }]);
+  });
+
+  it('recovers an accented name whose tokenized surface had diacritics stripped', () => {
+    // BERT tokenizers strip accents, so the surface is 'Zoe' but the source is
+    // 'Zoë'. The span (with the ORIGINAL accented value) must be recovered.
+    const text = 'hi Zoë there';
+    const spans = aggregate([tok('B-PER', 'Zoe')], text);
+    expect(spans).toEqual([{ category: 'person', start: 3, end: 6, value: 'Zoë' }]);
+  });
+
+  it('does not leak by dropping a found entity when the cursor overshot', () => {
+    // If an earlier group consumed text past a later entity's only occurrence,
+    // the cursor must not strand the later entity (which would leak). Here both
+    // 'Sam' occurrences are word-aligned; the second resolves correctly.
+    const text = 'Sam emailed Sam';
+    const spans = aggregate([tok('B-PER', 'Sam'), tok('B-PER', 'Sam')], text);
+    expect(spans.map((s) => s.start)).toEqual([0, 12]);
+  });
 });

--- a/apps/desktop/src/apps/anonymizer/ner/aggregate.ts
+++ b/apps/desktop/src/apps/anonymizer/ner/aggregate.ts
@@ -35,25 +35,91 @@ function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/** True when `text[i]` (or a position past either end) is NOT a word char, i.e.
+ *  a word boundary sits at offset `i`. Treats out-of-range as a boundary. Uses a
+ *  Unicode-aware "letter or number" notion so accented names count as word
+ *  chars. */
+function isBoundaryAt(text: string, i: number): boolean {
+  if (i < 0 || i >= text.length) return true;
+  return !/[\p{L}\p{N}]/u.test(text[i]!);
+}
+
+/** True when the half-open range `[start, end)` is bounded by non-word chars (or
+ *  the string edges) on both sides — i.e. it isn't a substring buried inside a
+ *  larger word like `Al` inside `Alabama`. */
+function isWordAligned(text: string, start: number, end: number): boolean {
+  return isBoundaryAt(text, start - 1) && isBoundaryAt(text, end);
+}
+
+/** Try to find `surface` (or a whitespace/punctuation-tolerant variant of it) at
+ *  a WORD-ALIGNED position at or after `from`. Returns the first such match, or
+ *  null. */
+function findAligned(text: string, surface: string, from: number): { start: number; end: number } | null {
+  // 1) Exact, then case-insensitive, scanning successive occurrences until one
+  //    is word-aligned (so `Al` is not matched inside `Alabama`).
+  for (const hay of [text, text.toLowerCase()]) {
+    const needle = hay === text ? surface : surface.toLowerCase();
+    let idx = hay.indexOf(needle, from);
+    while (idx >= 0) {
+      if (isWordAligned(text, idx, idx + needle.length)) {
+        return { start: idx, end: idx + needle.length };
+      }
+      idx = hay.indexOf(needle, idx + 1);
+    }
+  }
+  // 2) The tokenizer normalizes the surface (diacritic stripping, hyphen/
+  //    apostrophe → space, WordPiece spacing), so the literal needle can be
+  //    absent even though the entity is present. Match the surface's word PARTS
+  //    separated by any run of non-word chars, anchored on word boundaries, so a
+  //    span is recovered (and redacted) instead of silently dropped.
+  const parts = surface.split(/[^\p{L}\p{N}]+/u).filter(Boolean).map(escapeRegExp);
+  if (parts.length > 0) {
+    const re = new RegExp(`(?<![\\p{L}\\p{N}])${parts.join('[^\\p{L}\\p{N}]+')}(?![\\p{L}\\p{N}])`, 'iu');
+    const m = re.exec(text.slice(from));
+    if (m && m.index != null) {
+      return { start: from + m.index, end: from + m.index + m[0].length };
+    }
+  }
+  // 3) Diacritic mismatch: BERT tokenizers strip accents, so the surface `Zoe`
+  //    can't be found in the original `Zoë`. Fold accents off BOTH sides and
+  //    retry the part match against the folded text, then map the (length-
+  //    preserving) folded offset straight back to the original. NFD + combining-
+  //    mark removal preserves code-unit count for the Latin accents NER emits, so
+  //    offsets line up.
+  const foldedText = stripDiacritics(text);
+  if (foldedText !== text && foldedText.length === text.length) {
+    const re = new RegExp(`(?<![\\p{L}\\p{N}])${parts.join('[^\\p{L}\\p{N}]+')}(?![\\p{L}\\p{N}])`, 'iu');
+    const m = re.exec(foldedText.slice(from));
+    if (m && m.index != null) {
+      return { start: from + m.index, end: from + m.index + m[0].length };
+    }
+  }
+  return null;
+}
+
+/** Remove combining diacritical marks (NFD then drop the combining range). Used
+ *  only for length-preserving accent-insensitive matching — the original text's
+ *  offsets are what we return. */
+function stripDiacritics(s: string): string {
+  return s.normalize('NFD').replace(/[̀-ͯ]/g, '');
+}
+
 /** Find an entity's char range in the original text, advancing a cursor so
- *  repeated surfaces map to successive occurrences. Tolerant of case and
- *  whitespace differences the tokenizer introduces. */
+ *  repeated surfaces map to successive occurrences. Tolerant of case, whitespace,
+ *  punctuation and diacritic differences the tokenizer introduces.
+ *
+ *  CORRECTNESS/SAFETY: a raw `indexOf` can land the surface INSIDE a larger word
+ *  (e.g. NER tags the person `Al`, but `indexOf('Al')` hits `Alabama`), which
+ *  would redact the wrong text and leave the real PII exposed. So we only accept
+ *  a WORD-ALIGNED match (from `from` onward); if none exists from the cursor we
+ *  retry from 0 (the cursor is a best-effort de-dup hint, not a hard floor — a
+ *  missed alignment must never cause an entity to be dropped and leak). */
 function locate(
   text: string,
   surface: string,
   from: number,
 ): { start: number; end: number } | null {
-  let idx = text.indexOf(surface, from);
-  if (idx >= 0) return { start: idx, end: idx + surface.length };
-  idx = text.toLowerCase().indexOf(surface.toLowerCase(), from);
-  if (idx >= 0) return { start: idx, end: idx + surface.length };
-  const parts = surface.split(/\s+/).filter(Boolean).map(escapeRegExp);
-  if (parts.length > 1) {
-    const re = new RegExp(parts.join('\\s+'), 'i');
-    const m = re.exec(text.slice(from));
-    if (m && m.index != null) return { start: from + m.index, end: from + m.index + m[0].length };
-  }
-  return null;
+  return findAligned(text, surface, from) ?? (from > 0 ? findAligned(text, surface, 0) : null);
 }
 
 /**

--- a/apps/desktop/src/apps/anonymizer/ner/useNer.test.ts
+++ b/apps/desktop/src/apps/anonymizer/ner/useNer.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { rejectAllPending, type PendingEntry } from './useNer';
+import type { NerToken } from './aggregate';
+
+describe('rejectAllPending', () => {
+  it('rejects every in-flight request and empties the map', async () => {
+    const pending = new Map<number, PendingEntry>();
+    // Two in-flight requests, exactly as detectNames registers them.
+    const p1 = new Promise<NerToken[]>((resolve, reject) => pending.set(1, { resolve, reject }));
+    const p2 = new Promise<NerToken[]>((resolve, reject) => pending.set(2, { resolve, reject }));
+    expect(pending.size).toBe(2);
+
+    rejectAllPending(pending, 'NER worker stopped');
+
+    // Both settle (REJECT) — without the fix these promises would hang forever.
+    await expect(p1).rejects.toThrow('NER worker stopped');
+    await expect(p2).rejects.toThrow('NER worker stopped');
+    expect(pending.size).toBe(0);
+  });
+
+  it('is a no-op on an empty map', () => {
+    const pending = new Map<number, PendingEntry>();
+    expect(() => rejectAllPending(pending, 'stopped')).not.toThrow();
+    expect(pending.size).toBe(0);
+  });
+
+  it('clears the map before rejecting so a re-entrant teardown cannot double-settle', async () => {
+    const pending = new Map<number, PendingEntry>();
+    let observedSizeDuringReject = -1;
+    const p = new Promise<NerToken[]>((resolve, reject) => {
+      pending.set(1, {
+        resolve,
+        reject: (e) => {
+          // The map must already be empty by the time any reject runs, so a
+          // teardown that fires while a reject handler runs finds nothing left.
+          observedSizeDuringReject = pending.size;
+          reject(e);
+        },
+      });
+    });
+    rejectAllPending(pending, 'stopped');
+    await expect(p).rejects.toThrow('stopped');
+    expect(observedSizeDuringReject).toBe(0);
+  });
+});

--- a/apps/desktop/src/apps/anonymizer/ner/useNer.test.tsx
+++ b/apps/desktop/src/apps/anonymizer/ner/useNer.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for the NER hook's worker lifecycle — specifically the failure
+ * path. The hook owns a single Worker (which loads a ~109 MB model); when that
+ * worker dies, `detectNames` MUST short-circuit instead of posting to a dead
+ * worker and leaking a forever-pending request per call.
+ *
+ * The real worker (`ner.worker.ts`) loads transformers.js, so it's stubbed with
+ * a tiny fake whose `onmessage`/`onerror` the test drives directly. The fake
+ * also records posted messages so the leak claim is asserted, not assumed.
+ */
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useNer } from './useNer';
+import type { NerToken } from './aggregate';
+
+interface PostedInfer {
+  readonly type: string;
+  readonly id: number;
+  readonly text: string;
+}
+
+/** A controllable stand-in for the model worker: captures posted messages and
+ *  exposes hooks to drive a reply / a fatal error from the test. */
+class FakeWorker {
+  static instances: FakeWorker[] = [];
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onerror: ((e: ErrorEvent) => void) | null = null;
+  readonly posted: PostedInfer[] = [];
+  terminated = false;
+
+  constructor() {
+    FakeWorker.instances.push(this);
+  }
+
+  postMessage(msg: PostedInfer): void {
+    this.posted.push(msg);
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  /** Simulate the model emitting a per-token result for a request `id`. */
+  reply(id: number, tokens: NerToken[]): void {
+    this.onmessage?.({ data: { type: 'result', id, tokens } } as MessageEvent);
+  }
+
+  /** Simulate the worker dying (e.g. the model failed to load). */
+  fail(message = 'boom'): void {
+    this.onerror?.({ message } as ErrorEvent);
+  }
+}
+
+beforeEach(() => {
+  FakeWorker.instances = [];
+  vi.stubGlobal('Worker', FakeWorker as unknown as typeof Worker);
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useNer', () => {
+  it('aggregates the worker reply into PII spans on the happy path', async () => {
+    const { result } = renderHook(() => useNer());
+    const worker = FakeWorker.instances[0]!;
+
+    let spans: readonly unknown[] = [];
+    await act(async () => {
+      const p = result.current.detectNames('Alice Smith met Bob');
+      // The hook posts one infer request; answer it with two BIO tokens.
+      const req = worker.posted.at(-1)!;
+      worker.reply(req.id, [
+        { entity: 'B-PER', word: 'Alice', index: 0, score: 0.99 },
+        { entity: 'I-PER', word: 'Smith', index: 1, score: 0.99 },
+      ]);
+      spans = await p;
+    });
+
+    expect(spans).toEqual([{ category: 'person', start: 0, end: 11, value: 'Alice Smith' }]);
+    expect(result.current.status).toBe('ready');
+  });
+
+  it('short-circuits detectNames after the worker dies (no leaked pending request)', async () => {
+    const { result } = renderHook(() => useNer());
+    const worker = FakeWorker.instances[0]!;
+
+    // The worker fails to load — the hook flips to `error` and drops the worker.
+    await act(async () => {
+      worker.fail('model failed to load');
+    });
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toBe('model failed to load');
+
+    // A follow-up call must resolve to [] WITHOUT posting to the dead worker.
+    // Before the fix this posted an infer the dead worker never answered, so the
+    // promise hung forever and a `pending` entry leaked per call.
+    const before = worker.posted.length;
+    let spans: readonly unknown[] = [{ sentinel: true }];
+    await act(async () => {
+      spans = await result.current.detectNames('Alice Smith met Bob');
+    });
+    expect(spans).toEqual([]);
+    expect(worker.posted.length).toBe(before); // no new request posted to the dead worker
+  });
+
+  it('returns [] for blank input without touching the worker', async () => {
+    const { result } = renderHook(() => useNer());
+    const worker = FakeWorker.instances[0]!;
+    let spans: readonly unknown[] = [{ sentinel: true }];
+    await act(async () => {
+      spans = await result.current.detectNames('   ');
+    });
+    expect(spans).toEqual([]);
+    expect(worker.posted.length).toBe(0);
+  });
+
+  it('settles an in-flight request to [] on unmount instead of hanging forever', async () => {
+    const { result, unmount } = renderHook(() => useNer());
+
+    // Start a request and DO NOT reply — it stays in flight (a pending entry).
+    let spans: readonly unknown[] | 'unsettled' = 'unsettled';
+    const p = result.current.detectNames('Alice Smith met Bob').then((s) => {
+      spans = s;
+    });
+
+    // Tear the hook down while the request is pending. Before the fix the cleanup
+    // only clear()'d the map, orphaning this promise so it NEVER settled (a leak);
+    // now the pending request is rejected and detectNames maps it to [].
+    await act(async () => {
+      unmount();
+      await p;
+    });
+    expect(spans).toEqual([]);
+  });
+
+  it('settles in-flight requests to [] when the worker errors mid-flight', async () => {
+    const { result } = renderHook(() => useNer());
+    const worker = FakeWorker.instances[0]!;
+
+    let spans: readonly unknown[] | 'unsettled' = 'unsettled';
+    const p = result.current.detectNames('Alice Smith met Bob').then((s) => {
+      spans = s;
+    });
+
+    await act(async () => {
+      worker.fail('runtime crashed');
+      await p;
+    });
+    expect(spans).toEqual([]);
+    expect(result.current.status).toBe('error');
+  });
+});

--- a/apps/desktop/src/apps/anonymizer/ner/useNer.ts
+++ b/apps/desktop/src/apps/anonymizer/ner/useNer.ts
@@ -13,7 +13,23 @@ export interface UseNer {
   readonly detectNames: (text: string) => Promise<readonly PiiSpan[]>;
 }
 
+export type PendingEntry = { resolve: (t: NerToken[]) => void; reject: (e: Error) => void };
 type WorkerReply = { type: string; id?: number; tokens?: NerToken[]; error?: string };
+
+/**
+ * Reject every still-pending request, then clear the map. Used on worker
+ * teardown (unmount) and on a worker `onerror`. WITHOUT this, clearing the map
+ * silently orphaned the in-flight promises, so any awaiting `detectNames` call
+ * hung forever (a leak pinning its closure + the input text). Snapshot the
+ * entries and clear the map BEFORE rejecting, so a synchronous re-entrant
+ * teardown triggered by a reject handler finds nothing left to double-settle.
+ * Exported for unit testing; safe on an empty map.
+ */
+export function rejectAllPending(pending: Map<number, PendingEntry>, reason: string): void {
+  const entries = [...pending.values()];
+  pending.clear();
+  for (const entry of entries) entry.reject(new Error(reason));
+}
 
 /**
  * Lazily spins up the NER worker (which loads the installed on-device model on
@@ -22,9 +38,7 @@ type WorkerReply = { type: string; id?: number; tokens?: NerToken[]; error?: str
  */
 export function useNer(): UseNer {
   const workerRef = useRef<Worker | null>(null);
-  const pending = useRef(
-    new Map<number, { resolve: (t: NerToken[]) => void; reject: (e: Error) => void }>(),
-  );
+  const pending = useRef(new Map<number, PendingEntry>());
   const reqId = useRef(0);
   const [status, setStatus] = useState<NerStatus>('idle');
   const [error, setError] = useState<string | null>(null);
@@ -46,13 +60,23 @@ export function useNer(): UseNer {
     };
     worker.onerror = (e: ErrorEvent): void => {
       setStatus('error');
-      setError(e.message || 'The name-detection model failed to load.');
+      const message = e.message || 'The name-detection model failed to load.';
+      setError(message);
+      // The worker died (e.g. the model failed to load) and will never reply.
+      // Drop it so `detectNames`'s `if (!worker …)` guard short-circuits to `[]`
+      // instead of posting to a dead worker. Reject the in-flight requests too —
+      // a worker-level error delivers no per-request reply, so without this every
+      // awaiting `detectNames` promise would hang forever (leaking its closure).
+      workerRef.current = null;
+      rejectAllPending(pending.current, message);
     };
     workerRef.current = worker;
     return () => {
       worker.terminate();
       workerRef.current = null;
-      pending.current.clear();
+      // Settle in-flight requests so their awaiting promises don't dangle past
+      // teardown (terminate() never delivers their replies).
+      rejectAllPending(pending.current, 'NER worker stopped');
     };
   }, []);
 

--- a/apps/desktop/src/collaborate/CollaboratePanel.tsx
+++ b/apps/desktop/src/collaborate/CollaboratePanel.tsx
@@ -1,42 +1,20 @@
 import { useEffect, useMemo, useState } from 'react';
 import { api, useChat } from '@moxxy/client-core';
-import { pairToolEvents, type Block, type CollaborationBlock } from '@moxxy/chat-model';
+import { pairToolEvents } from '@moxxy/chat-model';
 import { Icon } from '@moxxy/desktop-ui';
 import { ViewHeader, ViewSwitcher, type View } from '../shell/ViewHeader';
-
-function dotColor(status: string): string {
-  if (status === 'done') return 'var(--color-green)';
-  if (status === 'crashed' || status === 'killed') return 'var(--color-red)';
-  if (status === 'working') return 'var(--color-primary)';
-  return 'var(--color-text-dim)';
-}
+import { dotColor, filterCollabMessages, latestCollab, taskChipBg } from './collab-view';
 
 function taskChip(status: string): React.CSSProperties {
-  const bg =
-    status === 'done'
-      ? 'var(--color-green)'
-      : status === 'blocked'
-        ? 'var(--color-amber)'
-        : status === 'in_progress' || status === 'claimed'
-          ? 'var(--color-primary)'
-          : 'var(--color-text-dim)';
   return {
     fontSize: 10,
     fontWeight: 700,
     padding: '1px 6px',
     borderRadius: 'var(--radius-pill)',
     color: '#fff',
-    background: bg,
+    background: taskChipBg(status),
     flexShrink: 0,
   };
-}
-
-function latestCollab(blocks: ReadonlyArray<Block>): CollaborationBlock | undefined {
-  for (let i = blocks.length - 1; i >= 0; i--) {
-    const b = blocks[i]!;
-    if (b.kind === 'collab') return b;
-  }
-  return undefined;
 }
 
 /** The dedicated Collaborate workspace: left rail (agents · tasks · contracts),
@@ -117,11 +95,10 @@ export function CollaboratePanel({
 
   const paused = collab?.control?.paused ?? false;
 
-  const visibleMessages = useMemo(() => {
-    if (!collab) return [];
-    if (channel === 'all') return collab.messages;
-    return collab.messages.filter((m) => m.from === channel || m.to === channel || m.to === 'all');
-  }, [collab, channel]);
+  const visibleMessages = useMemo(
+    () => (collab ? filterCollabMessages(collab.messages, channel) : []),
+    [collab, channel],
+  );
 
   const header = (
     <ViewHeader>

--- a/apps/desktop/src/collaborate/collab-view.test.ts
+++ b/apps/desktop/src/collaborate/collab-view.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for the Collaborate panel's pure view helpers.
+ *
+ * These were inline in `CollaboratePanel.tsx` and so untestable without
+ * rendering React; extracting them lets the channel filter (the one piece of
+ * real logic) be exercised directly.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Block, CollabMsgView } from '@moxxy/chat-model';
+import { dotColor, filterCollabMessages, latestCollab, taskChipBg } from './collab-view';
+
+const msg = (over: Partial<CollabMsgView>): CollabMsgView => ({
+  id: Math.random().toString(36).slice(2),
+  from: 'a',
+  to: 'b',
+  body: 'hi',
+  atMs: 0,
+  ...over,
+});
+
+describe('filterCollabMessages', () => {
+  const messages: CollabMsgView[] = [
+    msg({ id: 'm1', from: 'human', to: 'all' }),
+    msg({ id: 'm2', from: 'alice', to: 'bob' }),
+    msg({ id: 'm3', from: 'bob', to: 'alice' }),
+    msg({ id: 'm4', from: 'carol', to: 'carol' }),
+  ];
+
+  it('returns every message for the "all" channel', () => {
+    expect(filterCollabMessages(messages, 'all')).toBe(messages);
+  });
+
+  it('keeps messages to/from the selected agent', () => {
+    expect(filterCollabMessages(messages, 'alice').map((m) => m.id)).toEqual([
+      'm1', // to === 'all' broadcast
+      'm2', // to alice
+      'm3', // from alice
+    ]);
+  });
+
+  it('always includes team broadcasts (to === all)', () => {
+    expect(filterCollabMessages(messages, 'carol').map((m) => m.id)).toEqual(['m1', 'm4']);
+  });
+
+  it('returns an empty list when nothing matches', () => {
+    expect(filterCollabMessages([msg({ from: 'x', to: 'y' })], 'z')).toEqual([]);
+  });
+});
+
+describe('latestCollab', () => {
+  it('returns the last collab block, ignoring later non-collab blocks', () => {
+    const blocks = [
+      { kind: 'collab', id: 'c1' },
+      { kind: 'event', id: 'e1' },
+      { kind: 'collab', id: 'c2' },
+      { kind: 'event', id: 'e2' },
+    ] as unknown as Block[];
+    expect(latestCollab(blocks)?.id).toBe('c2');
+  });
+
+  it('returns undefined when there is no collab block', () => {
+    const blocks = [{ kind: 'event', id: 'e1' }] as unknown as Block[];
+    expect(latestCollab(blocks)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty list', () => {
+    expect(latestCollab([])).toBeUndefined();
+  });
+});
+
+describe('dotColor', () => {
+  it('maps known statuses, falling back to dim', () => {
+    expect(dotColor('done')).toBe('var(--color-green)');
+    expect(dotColor('crashed')).toBe('var(--color-red)');
+    expect(dotColor('killed')).toBe('var(--color-red)');
+    expect(dotColor('working')).toBe('var(--color-primary)');
+    expect(dotColor('pending')).toBe('var(--color-text-dim)');
+  });
+});
+
+describe('taskChipBg', () => {
+  it('maps known statuses, falling back to dim', () => {
+    expect(taskChipBg('done')).toBe('var(--color-green)');
+    expect(taskChipBg('blocked')).toBe('var(--color-amber)');
+    expect(taskChipBg('in_progress')).toBe('var(--color-primary)');
+    expect(taskChipBg('claimed')).toBe('var(--color-primary)');
+    expect(taskChipBg('todo')).toBe('var(--color-text-dim)');
+  });
+});

--- a/apps/desktop/src/collaborate/collab-view.ts
+++ b/apps/desktop/src/collaborate/collab-view.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure view helpers for the Collaborate panel.
+ *
+ * Extracted verbatim from `CollaboratePanel.tsx` so the channel-filter and
+ * status-mapping logic can be unit-tested without rendering React. Behavior is
+ * unchanged; the panel imports these instead of declaring them inline.
+ */
+import type { Block, CollaborationBlock, CollabMsgView } from '@moxxy/chat-model';
+
+/** Status-dot colour for an agent row in the left rail. */
+export function dotColor(status: string): string {
+  if (status === 'done') return 'var(--color-green)';
+  if (status === 'crashed' || status === 'killed') return 'var(--color-red)';
+  if (status === 'working') return 'var(--color-primary)';
+  return 'var(--color-text-dim)';
+}
+
+/** Background colour for a task-board status chip. */
+export function taskChipBg(status: string): string {
+  if (status === 'done') return 'var(--color-green)';
+  if (status === 'blocked') return 'var(--color-amber)';
+  if (status === 'in_progress' || status === 'claimed') return 'var(--color-primary)';
+  return 'var(--color-text-dim)';
+}
+
+/** The most recent `collab` block in a folded block list, or undefined. */
+export function latestCollab(blocks: ReadonlyArray<Block>): CollaborationBlock | undefined {
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const b = blocks[i]!;
+    if (b.kind === 'collab') return b;
+  }
+  return undefined;
+}
+
+/**
+ * Messages visible in the selected channel. `'all'` shows the whole bus;
+ * a specific agent id shows messages to/from that agent plus team broadcasts
+ * (`to === 'all'`).
+ */
+export function filterCollabMessages(
+  messages: ReadonlyArray<CollabMsgView>,
+  channel: string,
+): ReadonlyArray<CollabMsgView> {
+  if (channel === 'all') return messages;
+  return messages.filter((m) => m.from === channel || m.to === channel || m.to === 'all');
+}

--- a/packages/anonymizer/src/detect.test.ts
+++ b/packages/anonymizer/src/detect.test.ts
@@ -41,4 +41,43 @@ describe('detect', () => {
     const spans = detect('secret-project launch', { categories: [], customTerms: ['secret-project'] });
     expect(spans.map((s) => s.value)).toEqual(['secret-project']);
   });
+
+  it('resolves a chain of overlapping extraSpans by priority, keeping survivors sorted', () => {
+    // person(0..11) overlaps email(5..16); email outranks person → email wins.
+    // A non-overlapping later org(20..23) survives independently. The result must
+    // stay sorted by start and be non-overlapping.
+    const text = 'John smith@x.com here Foo elsewhere';
+    const spans = detect(text, {
+      categories: ['email'],
+      extraSpans: [
+        { category: 'person', start: 0, end: 11, value: text.slice(0, 11) },
+        { category: 'org', start: 22, end: 25, value: text.slice(22, 25) },
+      ],
+    });
+    expect(spans.map((s) => [s.category, s.start, s.end])).toEqual([
+      ['email', 5, 16],
+      ['org', 22, 25],
+    ]);
+    for (let i = 1; i < spans.length; i++) {
+      expect(spans[i]!.start).toBeGreaterThanOrEqual(spans[i - 1]!.end);
+    }
+  });
+
+  it('resolves a large fully-disjoint span set without quadratic blowup', () => {
+    // 40k non-overlapping custom hits is the pathological case for overlap
+    // resolution: a linear-scan resolver is O(n²) (multiple seconds and rising
+    // steeply); the binary-search resolver is O(n log n) (tens of ms). The bound
+    // is generous (3s) so it never flakes on a slow CI box yet still trips if the
+    // quadratic scan is reintroduced (which blows past it well before this size).
+    const term = 'zz';
+    const text = Array.from({ length: 40_000 }, () => term).join(' ');
+    const t0 = Date.now();
+    const spans = detect(text, { categories: [], customTerms: [term] });
+    expect(spans).toHaveLength(40_000);
+    expect(Date.now() - t0).toBeLessThan(3_000);
+    // Sorted + non-overlapping.
+    for (let i = 1; i < spans.length; i++) {
+      expect(spans[i]!.start).toBeGreaterThanOrEqual(spans[i - 1]!.end);
+    }
+  });
 });

--- a/packages/anonymizer/src/detect.ts
+++ b/packages/anonymizer/src/detect.ts
@@ -51,8 +51,28 @@ export function detect(text: string, opts: DetectOptions = {}): PiiSpan[] {
   return resolveOverlaps(raw);
 }
 
+/** First index `i` in the start-sorted `kept` array with `kept[i].start >= start`. */
+function lowerBoundByStart(kept: readonly PiiSpan[], start: number): number {
+  let lo = 0;
+  let hi = kept.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (kept[mid]!.start < start) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
 /** Greedy interval selection by priority: keep the strongest span, drop anything
- *  overlapping it. Exact-duplicate spans collapse to one. */
+ *  overlapping it. Exact-duplicate spans collapse to one.
+ *
+ *  `kept` is maintained sorted by `start` (insertion via binary search). Because
+ *  kept spans are mutually non-overlapping, a candidate overlaps some kept span
+ *  iff the single kept span with the greatest `start < candidate.end` also has
+ *  `end > candidate.start` — so the overlap test is O(log n), not a linear scan
+ *  over every kept span. This keeps the whole pass O(n log n) instead of O(n²),
+ *  which matters on large documents (tens of thousands of detections, e.g. a log
+ *  file full of IPs/emails) that would otherwise freeze the renderer. */
 function resolveOverlaps(spans: readonly PiiSpan[]): PiiSpan[] {
   const valid = spans.filter((s) => s.end > s.start);
   const ordered = [...valid].sort(
@@ -61,10 +81,15 @@ function resolveOverlaps(spans: readonly PiiSpan[]): PiiSpan[] {
       b.end - b.start - (a.end - a.start) ||
       a.start - b.start,
   );
-  const kept: PiiSpan[] = [];
+  const kept: PiiSpan[] = []; // invariant: sorted by start, mutually non-overlapping
   for (const span of ordered) {
-    const overlaps = kept.some((k) => span.start < k.end && k.start < span.end);
-    if (!overlaps) kept.push(span);
+    const i = lowerBoundByStart(kept, span.end);
+    // The only kept span that can overlap `span` is its left neighbour (the one
+    // with the largest start below `span.end`); every earlier kept span ends at
+    // or before that neighbour's start, so it cannot reach `span.start`.
+    const left = i > 0 ? kept[i - 1]! : null;
+    const overlaps = left ? span.start < left.end && left.start < span.end : false;
+    if (!overlaps) kept.splice(i, 0, span);
   }
-  return kept.sort((a, b) => a.start - b.start);
+  return kept;
 }

--- a/packages/desktop-host/src/apps/installer.test.ts
+++ b/packages/desktop-host/src/apps/installer.test.ts
@@ -8,6 +8,7 @@ import {
   appDir,
   appStatus,
   installApp,
+  isAllowedAssetUrl,
   resolveAssetDest,
   uninstallApp,
   type AppInstallSpec,
@@ -72,8 +73,8 @@ describe('install ↔ status lifecycle', () => {
     id: 'anonymizer',
     version: 'v1',
     assets: [
-      { url: 'https://example/config.json', dest: 'config.json' },
-      { url: 'https://example/onnx/model.onnx', dest: 'onnx/model.onnx' },
+      { url: 'https://huggingface.co/config.json', dest: 'config.json' },
+      { url: 'https://huggingface.co/onnx/model.onnx', dest: 'onnx/model.onnx' },
     ],
   };
 
@@ -83,8 +84,8 @@ describe('install ↔ status lifecycle', () => {
 
   it('downloads every asset, writes the marker, and flips to installed', async () => {
     const fetchImpl = fakeFetch({
-      'https://example/config.json': '{"k":1}',
-      'https://example/onnx/model.onnx': 'ONNXBYTES',
+      'https://huggingface.co/config.json': '{"k":1}',
+      'https://huggingface.co/onnx/model.onnx': 'ONNXBYTES',
     });
     const phases: AppInstallProgress['phase'][] = [];
     const status = await installApp(spec, root, (p) => phases.push(p.phase), fetchImpl);
@@ -105,8 +106,8 @@ describe('install ↔ status lifecycle', () => {
 
   it('a version mismatch in the marker reports not-installed', async () => {
     const fetchImpl = fakeFetch({
-      'https://example/config.json': '{"k":1}',
-      'https://example/onnx/model.onnx': 'ONNXBYTES',
+      'https://huggingface.co/config.json': '{"k":1}',
+      'https://huggingface.co/onnx/model.onnx': 'ONNXBYTES',
     });
     await installApp(spec, root, () => {}, fetchImpl);
     // The same files but the spec now wants a newer version.
@@ -116,8 +117,8 @@ describe('install ↔ status lifecycle', () => {
 
   it('a missing asset file reports not-installed even with a matching marker', async () => {
     const fetchImpl = fakeFetch({
-      'https://example/config.json': '{"k":1}',
-      'https://example/onnx/model.onnx': 'ONNXBYTES',
+      'https://huggingface.co/config.json': '{"k":1}',
+      'https://huggingface.co/onnx/model.onnx': 'ONNXBYTES',
     });
     await installApp(spec, root, () => {}, fetchImpl);
     await rm(path.join(root, 'anonymizer', 'onnx/model.onnx'));
@@ -126,8 +127,8 @@ describe('install ↔ status lifecycle', () => {
 
   it('uninstall removes the dir and reports not-installed', async () => {
     const fetchImpl = fakeFetch({
-      'https://example/config.json': '{"k":1}',
-      'https://example/onnx/model.onnx': 'ONNXBYTES',
+      'https://huggingface.co/config.json': '{"k":1}',
+      'https://huggingface.co/onnx/model.onnx': 'ONNXBYTES',
     });
     await installApp(spec, root, () => {}, fetchImpl);
     expect(await uninstallApp('anonymizer', root)).toEqual({
@@ -143,9 +144,9 @@ describe('integrity verification', () => {
     const spec: AppInstallSpec = {
       id: 'anonymizer',
       version: 'v1',
-      assets: [{ url: 'https://example/a.bin', dest: 'a.bin', sha256: sha256('EXPECTED') }],
+      assets: [{ url: 'https://huggingface.co/a.bin', dest: 'a.bin', sha256: sha256('EXPECTED') }],
     };
-    const fetchImpl = fakeFetch({ 'https://example/a.bin': 'WRONG' });
+    const fetchImpl = fakeFetch({ 'https://huggingface.co/a.bin': 'WRONG' });
     const phases: AppInstallProgress['phase'][] = [];
     const status = await installApp(spec, root, (p) => phases.push(p.phase), fetchImpl);
 
@@ -161,9 +162,9 @@ describe('integrity verification', () => {
     const spec: AppInstallSpec = {
       id: 'anonymizer',
       version: 'v1',
-      assets: [{ url: 'https://example/a.bin', dest: 'a.bin', sha256: sha256('GOOD') }],
+      assets: [{ url: 'https://huggingface.co/a.bin', dest: 'a.bin', sha256: sha256('GOOD') }],
     };
-    const fetchImpl = fakeFetch({ 'https://example/a.bin': 'GOOD' });
+    const fetchImpl = fakeFetch({ 'https://huggingface.co/a.bin': 'GOOD' });
     expect((await installApp(spec, root, () => {}, fetchImpl)).state).toBe('installed');
 
     // A re-run with a fetch that would FAIL proves the present+correct asset is
@@ -180,15 +181,96 @@ describe('partial-install resume', () => {
     const spec: AppInstallSpec = {
       id: 'anonymizer',
       version: 'v1',
-      assets: [{ url: 'https://example/a.bin', dest: 'a.bin' }],
+      assets: [{ url: 'https://huggingface.co/a.bin', dest: 'a.bin' }],
     };
     // Simulate a crash mid-download: only the .partial exists.
     await mkdir(path.join(root, 'anonymizer'), { recursive: true });
     await writeFile(path.join(root, 'anonymizer', 'a.bin.partial'), 'half');
     expect((await appStatus(spec, root)).state).toBe('not-installed');
 
-    const fetchImpl = fakeFetch({ 'https://example/a.bin': 'FULL' });
+    const fetchImpl = fakeFetch({ 'https://huggingface.co/a.bin': 'FULL' });
     expect((await installApp(spec, root, () => {}, fetchImpl)).state).toBe('installed');
     expect(await readFile(path.join(root, 'anonymizer', 'a.bin'), 'utf8')).toBe('FULL');
+  });
+});
+
+describe('download-source allow-list (SSRF / egress guard)', () => {
+  it('isAllowedAssetUrl admits https on huggingface.co + its CDN, refuses everything else', () => {
+    expect(isAllowedAssetUrl('https://huggingface.co/Xenova/x/resolve/main/config.json')).toBe(true);
+    expect(isAllowedAssetUrl('https://us.aws.cdn.hf.co/xet-bridge-us/abc')).toBe(true);
+    // Non-https, internal hosts, file scheme, and look-alike domains are all refused.
+    expect(isAllowedAssetUrl('http://huggingface.co/x')).toBe(false);
+    expect(isAllowedAssetUrl('https://169.254.169.254/latest/meta-data/')).toBe(false);
+    expect(isAllowedAssetUrl('https://localhost/x')).toBe(false);
+    expect(isAllowedAssetUrl('file:///etc/passwd')).toBe(false);
+    expect(isAllowedAssetUrl('https://huggingface.co.evil.test/x')).toBe(false);
+    expect(isAllowedAssetUrl('not a url')).toBe(false);
+  });
+
+  it('refuses to fetch an asset whose url is off-allow-list — no bytes touch the network', async () => {
+    const spec: AppInstallSpec = {
+      id: 'anonymizer',
+      version: 'v1',
+      // A url that the allow-list rejects (SSRF target / internal metadata host).
+      assets: [{ url: 'http://169.254.169.254/secret', dest: 'a.bin' }],
+    };
+    let fetched = false;
+    const spyFetch: FetchLike = (async () => {
+      fetched = true;
+      return new Response('SHOULD NEVER BE READ', { status: 200 });
+    }) as FetchLike;
+
+    const status = await installApp(spec, root, () => {}, spyFetch);
+    expect(status.state).toBe('error');
+    expect(status.error).toMatch(/not on an allowed host/);
+    // The gate fires BEFORE the network call — fetch is never reached.
+    expect(fetched).toBe(false);
+    // Nothing written, marker absent.
+    expect((await appStatus(spec, root)).state).toBe('not-installed');
+  });
+});
+
+describe('download size cap (disk-fill DoS guard)', () => {
+  const spec: AppInstallSpec = {
+    id: 'anonymizer',
+    version: 'v1',
+    assets: [{ url: 'https://huggingface.co/big.bin', dest: 'big.bin' }],
+  };
+
+  it('rejects up front when content-length declares more than the cap', async () => {
+    // Honest server: a content-length larger than the cap is refused before the
+    // body is read.
+    const cap = 8;
+    const oversized: FetchLike = (async () =>
+      new Response('x'.repeat(4), {
+        status: 200,
+        headers: { 'content-length': '999' },
+      })) as FetchLike;
+    const status = await installApp(spec, root, () => {}, oversized, cap);
+    expect(status.state).toBe('error');
+    expect(status.error).toMatch(/exceeds the 8-byte cap/);
+    expect((await appStatus(spec, root)).state).toBe('not-installed');
+  });
+
+  it('aborts mid-stream when a lying / chunked server streams past the cap, leaving no large partial', async () => {
+    const cap = 4;
+    // No content-length (chunked); the body is bigger than the cap, so only the
+    // streaming guard can catch it.
+    const lying: FetchLike = (async () =>
+      new Response('0123456789', { status: 200 })) as FetchLike;
+    const status = await installApp(spec, root, () => {}, lying, cap);
+    expect(status.state).toBe('error');
+    expect(status.error).toMatch(/exceeds the 4-byte cap mid-stream/);
+    // The aborted .partial must be cleaned up (don't strand a near-cap file).
+    expect((await appStatus(spec, root)).state).toBe('not-installed');
+    await expect(readFile(path.join(root, 'anonymizer', 'big.bin.partial'))).rejects.toThrow();
+  });
+
+  it('a download exactly at the cap still installs', async () => {
+    const cap = 5;
+    const exact = fakeFetch({ 'https://huggingface.co/big.bin': 'GROWS' }); // 5 bytes
+    const status = await installApp(spec, root, () => {}, exact, cap);
+    expect(status.state).toBe('installed');
+    expect(await readFile(path.join(root, 'anonymizer', 'big.bin'), 'utf8')).toBe('GROWS');
   });
 });

--- a/packages/desktop-host/src/apps/installer.ts
+++ b/packages/desktop-host/src/apps/installer.ts
@@ -16,6 +16,14 @@
  * a single byte is written — the same path-traversal containment discipline as
  * {@link ../loopback-server.ts}. An absolute dest, a `..` segment, a NUL byte,
  * or a symlink that escapes the app dir is refused.
+ *
+ * Network egress is also locked down (mirrors the Tier-2 stager's
+ * {@link ../app-update/stager.ts} `isAllowedUpdateHost` gate): every asset `url`
+ * MUST be `https:` on an allow-listed host before a single byte is fetched (so a
+ * future registry typo, a `file:`/`http:`/internal-host URL, or any other caller
+ * can't turn this into an SSRF or local-file read), and each download is capped
+ * at {@link MAX_ASSET_BYTES} so a hostile/buggy server can't fill the disk by
+ * streaming an unbounded body.
  */
 
 import { createHash } from 'node:crypto';
@@ -49,6 +57,37 @@ export interface AppInstallSpec {
 /** App ids index a filesystem dir + a custom-scheme host segment, so confine
  *  them to a strict slug (no `..`, no separators, no scheme tricks). */
 const APP_ID = /^[a-z][a-z0-9-]*$/;
+
+/** Hosts an asset may be fetched FROM. Mirrors the Tier-2 updater's
+ *  `ALLOWED_HOSTS` discipline: an exact-or-subdomain match so `huggingface.co`
+ *  and its LFS CDN are admitted but `…huggingface.co.evil` is not. The registry
+ *  only ships Hugging Face `resolve` URLs (which 30x-redirect to the HF CDN), so
+ *  this is the closed set of origins the installer is ever expected to reach.
+ *  Note: like the stager, the gate validates the INITIAL url only — a 30x to the
+ *  HF CDN is allowed to follow (the redirect target is HF-operated); a hostile
+ *  initial url can never reach the network at all. */
+const ALLOWED_ASSET_HOSTS = [/(^|\.)huggingface\.co$/, /(^|\.)hf\.co$/];
+
+/** Hard ceiling on any single downloaded asset. The largest real asset is the
+ *  ~109 MB quantised NER model; 512 MB leaves generous headroom while still
+ *  bounding a hostile/buggy server that streams an unbounded body (disk-fill
+ *  DoS). Tunable per call via {@link installApp}'s `maxAssetBytes`. */
+export const MAX_ASSET_BYTES = 512 * 1024 * 1024;
+
+/**
+ * Whether `url` is a fetch target the installer may reach: `https:` on an
+ * allow-listed host. Exported so the gate is unit-testable in isolation.
+ */
+export function isAllowedAssetUrl(url: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return false;
+  }
+  if (u.protocol !== 'https:') return false;
+  return ALLOWED_ASSET_HOSTS.some((re) => re.test(u.hostname));
+}
 
 /** Marker file written into an app's dir once every asset is present. */
 const INSTALLED_MARKER = 'installed.json';
@@ -188,6 +227,7 @@ export async function installApp(
   appsRoot: string,
   onProgress: (p: AppInstallProgress) => void,
   fetchImpl: FetchLike = fetch,
+  maxAssetBytes: number = MAX_ASSET_BYTES,
 ): Promise<AppInstallStatus> {
   const dir = appDir(appsRoot, spec.id);
   // Sum of Content-Lengths discovered so far drives an honest total; seed it
@@ -220,6 +260,13 @@ export async function installApp(
         }
       }
 
+      // Egress allow-list: only https on an allow-listed host is ever fetched,
+      // so a registry typo / injected url can never reach an arbitrary origin
+      // (SSRF) or a local file. Checked BEFORE the network call.
+      if (!isAllowedAssetUrl(asset.url)) {
+        throw new Error(`asset url is not on an allowed host: ${JSON.stringify(asset.url)}`);
+      }
+
       await mkdir(path.dirname(abs), { recursive: true });
       await assertRealpathContained(dir, abs);
 
@@ -229,6 +276,13 @@ export async function installApp(
         throw new Error(`download failed for ${asset.dest}: HTTP ${res.status}`);
       }
       const len = Number(res.headers.get('content-length'));
+      // Reject an over-cap download up front when the server is honest about its
+      // size (the streaming guard below still catches a lying / chunked server).
+      if (Number.isFinite(len) && len > maxAssetBytes) {
+        throw new Error(
+          `asset ${asset.dest} exceeds the ${maxAssetBytes}-byte cap (content-length ${len})`,
+        );
+      }
       if (Number.isFinite(len) && len > 0) {
         // Replace this asset's advisory `bytes` contribution with the real one.
         totalBytes += len - (asset.bytes ?? 0);
@@ -238,11 +292,23 @@ export async function installApp(
       const out = createWriteStream(partial);
       // Tee the stream so progress ticks as bytes land, then close it.
       const reader = res.body.getReader();
+      let assetBytes = 0;
+      let overCap = false;
       try {
         for (;;) {
           const { done, value } = await reader.read();
           if (done) break;
           if (value) {
+            assetBytes += value.byteLength;
+            // Hard ceiling: a chunked / content-length-lying server can't stream
+            // an unbounded body and fill the disk. Cancel the body and fail; the
+            // (now bounded-at-cap) partial is removed below so the abort leaves
+            // nothing large behind.
+            if (assetBytes > maxAssetBytes) {
+              overCap = true;
+              await reader.cancel().catch(() => {});
+              break;
+            }
             receivedBytes += value.byteLength;
             // Backpressure: respect the write stream's drain signal.
             if (!out.write(Buffer.from(value.buffer, value.byteOffset, value.byteLength))) {
@@ -255,6 +321,10 @@ export async function installApp(
         await new Promise<void>((resolve, reject) => {
           out.end((err?: NodeJS.ErrnoException | null) => (err ? reject(err) : resolve()));
         });
+      }
+      if (overCap) {
+        await rm(partial, { force: true });
+        throw new Error(`asset ${asset.dest} exceeds the ${maxAssetBytes}-byte cap mid-stream`);
       }
 
       if (asset.sha256) {

--- a/packages/desktop-ipc-contract/src/validation.test.ts
+++ b/packages/desktop-ipc-contract/src/validation.test.ts
@@ -231,6 +231,75 @@ describe('IPC payload validation', () => {
     }
   });
 
+  it('confines apps.* appId to a non-traversing slug', () => {
+    // appId keys a per-app install dir + a network download, so it must be a
+    // strict slug — no traversal, no separators, no uppercase, bounded length.
+    for (const cmd of ['apps.status', 'apps.install', 'apps.uninstall'] as const) {
+      expect(() => validateIpcInput(cmd, { appId: 'anonymizer' })).not.toThrow();
+      expect(() => validateIpcInput(cmd, { appId: '../evil' })).toThrow();
+      expect(() => validateIpcInput(cmd, { appId: 'a/b' })).toThrow();
+      expect(() => validateIpcInput(cmd, { appId: 'Anonymizer' })).toThrow();
+      expect(() => validateIpcInput(cmd, { appId: '' })).toThrow();
+      expect(() => validateIpcInput(cmd, { appId: 'a'.repeat(65) })).toThrow();
+      expect(() => validateIpcInput(cmd, {})).toThrow();
+    }
+  });
+
+  it('bounds anonymizer.parseDocument path + pins pickDocument to no payload', () => {
+    expect(() => validateIpcInput('anonymizer.parseDocument', { path: '/a/b.txt' })).not.toThrow();
+    expect(() => validateIpcInput('anonymizer.parseDocument', { path: '' })).toThrow();
+    expect(() =>
+      validateIpcInput('anonymizer.parseDocument', { path: 'x'.repeat(4097) }),
+    ).toThrow();
+    // pickDocument takes nothing — a payload can't be smuggled across.
+    expect(() => validateIpcInput('anonymizer.pickDocument', undefined)).not.toThrow();
+    expect(() => validateIpcInput('anonymizer.pickDocument', { sneaky: 1 })).toThrow();
+  });
+
+  it('caps anonymizer.parseDocumentBytes name + base64 size (OOM guard)', () => {
+    expect(() =>
+      validateIpcInput('anonymizer.parseDocumentBytes', { name: 'doc.pdf', dataBase64: 'AAAA' }),
+    ).not.toThrow();
+    expect(() =>
+      validateIpcInput('anonymizer.parseDocumentBytes', { name: '', dataBase64: 'AAAA' }),
+    ).toThrow();
+    expect(() =>
+      validateIpcInput('anonymizer.parseDocumentBytes', {
+        name: 'n'.repeat(256),
+        dataBase64: 'AAAA',
+      }),
+    ).toThrow();
+    // Empty body and an over-cap body both rejected at the boundary.
+    expect(() =>
+      validateIpcInput('anonymizer.parseDocumentBytes', { name: 'doc.pdf', dataBase64: '' }),
+    ).toThrow();
+    expect(() =>
+      validateIpcInput('anonymizer.parseDocumentBytes', {
+        name: 'doc.pdf',
+        dataBase64: 'A'.repeat(67_000_001),
+      }),
+    ).toThrow();
+  });
+
+  it('bounds anonymizer.saveRedacted name + content (OOM guard)', () => {
+    expect(() =>
+      validateIpcInput('anonymizer.saveRedacted', { suggestedName: 'out.txt', content: 'hi' }),
+    ).not.toThrow();
+    // Empty content is valid (a fully-redacted-to-nothing doc); name is required.
+    expect(() =>
+      validateIpcInput('anonymizer.saveRedacted', { suggestedName: 'out.txt', content: '' }),
+    ).not.toThrow();
+    expect(() =>
+      validateIpcInput('anonymizer.saveRedacted', { suggestedName: '', content: 'hi' }),
+    ).toThrow();
+    expect(() =>
+      validateIpcInput('anonymizer.saveRedacted', {
+        suggestedName: 'out.txt',
+        content: 'x'.repeat(20_000_001),
+      }),
+    ).toThrow();
+  });
+
   it('is a no-op for commands without a schema', () => {
     expect(() => validateIpcInput('desks.list', undefined)).not.toThrow();
     expect(() => validateIpcInput('connection.snapshotAll', undefined)).not.toThrow();

--- a/packages/mode-collaborative/src/agent-loop.ts
+++ b/packages/mode-collaborative/src/agent-loop.ts
@@ -278,15 +278,19 @@ function formatInboxNudge(messages: ReadonlyArray<CollabMessage>): string {
 function sleep(ms: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
     if (signal.aborted) return resolve();
-    const t = setTimeout(resolve, ms);
-    signal.addEventListener(
-      'abort',
-      () => {
-        clearTimeout(t);
-        resolve();
-      },
-      { once: true },
-    );
+    const onAbort = (): void => {
+      clearTimeout(t);
+      resolve();
+    };
+    const t = setTimeout(() => {
+      // Remove the abort listener on the normal-timeout path too; the pause
+      // poll loop runs this repeatedly and the listeners would otherwise pile
+      // up on the agent's long-lived signal.
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    t.unref?.();
+    signal.addEventListener('abort', onAbort, { once: true });
   });
 }
 

--- a/packages/mode-collaborative/src/collab-loop.test.ts
+++ b/packages/mode-collaborative/src/collab-loop.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { getEventListeners } from 'node:events';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { ModeContext, MoxxyEvent } from '@moxxy/sdk';
 import type { CollaborationHub } from '@moxxy/plugin-collab';
-import { runCollaborative, type CollabDeps } from './collab-loop.js';
+import { runCollaborative, sleep, type CollabDeps } from './collab-loop.js';
 import { resolveCollabConfig } from './config.js';
 import type { Supervisor } from './peer-supervisor.js';
 import { git } from './worktrees.js';
@@ -147,5 +148,24 @@ describe('collaborative coordinator (end-to-end, fake agents + real git)', () =>
     // sequential edits land directly in the shared workspace
     expect(existsSync(join(dir, 'api.ts'))).toBe(true);
     expect(existsSync(join(dir, 'api.test.ts'))).toBe(true);
+  });
+});
+
+describe('sleep (poll helper)', () => {
+  it('does not leak abort listeners on the normal-timeout path', async () => {
+    // A collaboration polls every ~500ms for up to its wall-clock guard
+    // (30 min default) — thousands of sleeps on ONE long-lived signal. A leak
+    // here means a MaxListenersExceededWarning + unbounded listener growth.
+    const ac = new AbortController();
+    for (let i = 0; i < 20; i++) await sleep(0, ac.signal);
+    expect(getEventListeners(ac.signal, 'abort').length).toBe(0);
+  });
+
+  it('still resolves and cleans up when aborted mid-sleep', async () => {
+    const ac = new AbortController();
+    const p = sleep(10_000, ac.signal);
+    ac.abort();
+    await p; // resolves immediately on abort rather than waiting out the timer
+    expect(getEventListeners(ac.signal, 'abort').length).toBe(0);
   });
 });

--- a/packages/mode-collaborative/src/collab-loop.ts
+++ b/packages/mode-collaborative/src/collab-loop.ts
@@ -350,12 +350,24 @@ async function waitForAgents(
   }
 }
 
-function sleep(ms: number, signal: AbortSignal): Promise<void> {
+/** Abortable delay. Exported for tests (it must not leak abort listeners over
+ *  the run's thousands of poll iterations). Internal otherwise. */
+export function sleep(ms: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
     if (signal.aborted) return resolve();
-    const t = setTimeout(resolve, ms);
+    const onAbort = (): void => {
+      clearTimeout(t);
+      resolve();
+    };
+    const t = setTimeout(() => {
+      // The poll loop calls this thousands of times over a run; remove the
+      // abort listener on the normal-timeout path too, or they accumulate on
+      // the long-lived coordinator signal (MaxListenersExceededWarning + leak).
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
     t.unref?.();
-    signal.addEventListener('abort', () => { clearTimeout(t); resolve(); }, { once: true });
+    signal.addEventListener('abort', onAbort, { once: true });
   });
 }
 

--- a/packages/mode-collaborative/src/worktrees.test.ts
+++ b/packages/mode-collaborative/src/worktrees.test.ts
@@ -73,7 +73,6 @@ describe('worktree git engine', () => {
 
   it('reports conflicts without leaving markers, then resolves by ownership', async () => {
     const repo = await initRepo();
-    const base = await headSha(repo);
     writeFileSync(join(repo, 'shared.ts'), 'export const v = 0;\n');
     await git(repo, ['add', '-A']);
     await git(repo, [...IDENT, 'commit', '-m', 'add shared']);
@@ -115,8 +114,37 @@ describe('worktree git engine', () => {
     const files = await reader.files('backend');
     expect(files.some((f) => f.path === 'feature.ts')).toBe(true);
     expect(await reader.read('backend', 'feature.ts')).toContain('feature = true');
+    // a nested path inside the worktree is still allowed
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(join(wt, 'sub'), { recursive: true });
+    writeFileSync(join(wt, 'sub', 'deep.ts'), 'export const deep = 1;\n');
+    expect(await reader.read('backend', 'sub/deep.ts')).toContain('deep = 1');
     expect(await reader.diff('backend')).toContain('feature.ts');
     await expect(reader.read('backend', '../escape')).rejects.toThrow();
+  });
+
+  it('peer-read confines untrusted paths to the worktree', async () => {
+    const repo = await initRepo();
+    const base = await headSha(repo);
+    // The worktree dir whose NAME a sibling can string-prefix: ".../a".
+    const wt = join(repo, '.wt', 'a');
+    await addWorktree({ repoCwd: repo, path: wt, branch: 'b/confine', baseSha: base });
+    writeFileSync(join(wt, 'inside.ts'), 'export const inside = true;\n');
+    // A would-be sibling that shares the worktree path as a plain string prefix.
+    const sibling = join(repo, '.wt', 'a-evil');
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(sibling, { recursive: true });
+    writeFileSync(join(sibling, 'secret.ts'), 'export const secret = "leak";\n');
+
+    const reader = peerReaderFor(new Map([['victim', wt]]), base);
+    // Parent-relative escape.
+    await expect(reader.read('victim', '../../escape')).rejects.toThrow(/escapes/);
+    // Sibling-prefix escape (the bug a naive startsWith() check let through).
+    await expect(reader.read('victim', '../a-evil/secret.ts')).rejects.toThrow(/escapes/);
+    // Absolute path spliced on (must not read /etc/passwd etc.).
+    await expect(reader.read('victim', '/etc/hostname')).rejects.toThrow(/escapes/);
+    // The legitimate in-worktree read still works.
+    expect(await reader.read('victim', 'inside.ts')).toContain('inside = true');
   });
 
   it('changedFiles lists work-in-progress edits', async () => {

--- a/packages/mode-collaborative/src/worktrees.ts
+++ b/packages/mode-collaborative/src/worktrees.ts
@@ -11,7 +11,7 @@
 
 import { execFile } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { isAbsolute, relative, resolve } from 'node:path';
 import type { PeerReader } from '@moxxy/plugin-collab';
 
 export interface GitResult {
@@ -217,6 +217,27 @@ export async function deleteBranch(repoCwd: string, name: string): Promise<void>
 }
 
 /**
+ * Resolve `requested` strictly inside `baseDir`, rejecting anything that would
+ * escape it. The coordinator runs `peerReaderFor` and has fs access to the
+ * whole machine, while `requested` is an UNTRUSTED, peer-supplied string (it
+ * arrives over the hub socket from another agent's `collab_peer_read` tool
+ * call), so this is a real trust boundary. A naive `join(dir, p).startsWith(dir)`
+ * check is unsafe: it accepts absolute paths spliced onto `dir`, AND it accepts
+ * a sibling whose name merely shares `dir` as a string prefix (e.g. `dir` =
+ * `/wt/a`, `p` = `../a-evil/secret` → `/wt/a-evil/secret`, which startsWith
+ * `/wt/a`). Resolve and compare via `relative`, which is path-segment aware.
+ */
+function resolveWithin(baseDir: string, requested: string): string {
+  const base = resolve(baseDir);
+  const target = resolve(base, requested);
+  const rel = relative(base, target);
+  if (rel === '' || rel === '.' || (!rel.startsWith('..') && !isAbsolute(rel))) {
+    return target;
+  }
+  throw new Error('path escapes the worktree');
+}
+
+/**
  * A {@link PeerReader} backed by the agents' worktrees — lets one agent read
  * another's actual in-progress files (served by the coordinator, which has fs
  * access to every worktree). Path traversal is contained to the worktree.
@@ -233,9 +254,7 @@ export function peerReaderFor(worktrees: ReadonlyMap<string, string>, baseSha: s
     },
     async read(agentId, path) {
       const dir = dirFor(agentId);
-      const resolved = join(dir, path);
-      if (!resolved.startsWith(dir)) throw new Error('path escapes the worktree');
-      return readFile(resolved, 'utf8');
+      return readFile(resolveWithin(dir, path), 'utf8');
     },
     async diff(agentId) {
       return diffVsBase(dirFor(agentId), baseSha);

--- a/packages/plugin-collab/src/hub.test.ts
+++ b/packages/plugin-collab/src/hub.test.ts
@@ -101,6 +101,44 @@ describe('CollaborationHub over a real socket', () => {
     if (!clash.ok) expect(clash.ownedBy).toBe('backend');
   });
 
+  it('does not let one connection release or steal another\'s lock by id', async () => {
+    const { hub, socketPath } = await startHub();
+    void hub;
+    const backend = await CollabHubClient.connect(socketPath, 'backend');
+    const tests = await CollabHubClient.connect(socketPath, 'tests');
+    cleanups.push(() => backend.close(), () => tests.close());
+
+    const claim = await backend.boardClaim(['src/api']);
+    expect(claim.ok).toBe(true);
+    const id = claim.ok ? claim.item.id : '';
+
+    // tests cannot release backend's lock by id...
+    await tests.boardRelease({ id });
+    expect((await tests.boardClaim(['src/api/routes.ts'])).ok).toBe(false);
+
+    // ...nor hijack the board item by id with disjoint paths
+    const hijack = await tests.boardClaim(['src/other'], id);
+    expect(hijack.ok).toBe(false);
+    const { items } = await tests.boardRead();
+    expect(items.find((it) => it.id === id)?.owner).toBe('backend');
+  });
+
+  it('frees a crashed peer\'s locks for survivors', async () => {
+    const { socketPath } = await startHub();
+    const backend = await CollabHubClient.connect(socketPath, 'backend');
+    const tests = await CollabHubClient.connect(socketPath, 'tests');
+    cleanups.push(() => tests.close());
+
+    const events: CollabEvent[] = [];
+    tests.onEvent((e) => events.push(e));
+
+    expect((await backend.boardClaim(['src/api'])).ok).toBe(true);
+    // backend's link drops → hub marks it crashed → its lock is freed
+    backend.close();
+    await waitFor(events, (e) => e.kind === 'agent_status' && e.agentId === 'backend' && e.status === 'crashed');
+    expect((await tests.boardClaim(['src/api/routes.ts'])).ok).toBe(true);
+  });
+
   it('serves contracts and peer-read across connections', async () => {
     const { hub, socketPath } = await startHub();
     void hub;

--- a/packages/plugin-collab/src/state.test.ts
+++ b/packages/plugin-collab/src/state.test.ts
@@ -75,6 +75,53 @@ describe('board file locks', () => {
 
     expect(events.some((e) => e.kind === 'board' && e.action === 'claim')).toBe(true);
   });
+
+  it('does not let a non-owner release another agent\'s claim by id', () => {
+    const { state } = mkState();
+    const claim = state.boardClaim('backend', ['src/api']);
+    expect(claim.ok).toBe(true);
+    const id = claim.ok ? claim.item.id : '';
+
+    // tests tries to release backend's lock by its (publicly visible) id
+    state.boardRelease('tests', { id });
+    // the lock must still be held by backend
+    const clash = state.boardClaim('tests', ['src/api/routes.ts']);
+    expect(clash).toEqual({ ok: false, ownedBy: 'backend', paths: ['src/api/routes.ts'] });
+
+    // the rightful owner can still release it
+    state.boardRelease('backend', { id });
+    expect(state.boardClaim('tests', ['src/api/routes.ts']).ok).toBe(true);
+  });
+
+  it('does not let a non-owner hijack another agent\'s board item by id', () => {
+    const { state } = mkState();
+    const claim = state.boardClaim('backend', ['src/api']);
+    expect(claim.ok).toBe(true);
+    const id = claim.ok ? claim.item.id : '';
+
+    // tests tries to reassign backend's item to itself with non-overlapping paths
+    const hijack = state.boardClaim('tests', ['src/other'], id);
+    expect(hijack.ok).toBe(false);
+
+    // backend must still own both the item and src/api
+    const item = state.boardItems().find((it) => it.id === id);
+    expect(item?.owner).toBe('backend');
+    expect(item?.paths).toEqual(['src/api']);
+    expect(state.boardClaim('tests', ['src/api']).ok).toBe(false);
+  });
+
+  it('releases a crashed agent\'s claims so survivors can proceed', () => {
+    const { state, events } = mkState();
+    expect(state.boardClaim('backend', ['src/api']).ok).toBe(true);
+
+    // backend's process dies → coordinator marks it crashed
+    state.setStatus('backend', 'crashed');
+
+    // a crashed owner must not hold the lock forever
+    expect(state.boardClaim('tests', ['src/api/routes.ts']).ok).toBe(true);
+    // and a release event was emitted for observers
+    expect(events.some((e) => e.kind === 'board' && e.action === 'release')).toBe(true);
+  });
 });
 
 describe('contracts', () => {

--- a/packages/plugin-collab/src/state.ts
+++ b/packages/plugin-collab/src/state.ts
@@ -108,6 +108,10 @@ export class CollaborationState {
     if (agent.status === status) return;
     agent.status = status;
     this.emitFn({ kind: 'agent_status', agentId, status, ...(detail ? { detail } : {}) });
+    // A dead agent can never release its own locks, so do it for it — otherwise
+    // its leases block every survivor forever (conflictingOwner only frees
+    // 'done' items, not abandoned ones).
+    if (status === 'crashed' || status === 'killed') this.releaseAllFor(agentId);
   }
 
   markDone(agentId: string, summary: string, artifacts?: ReadonlyArray<string>): void {
@@ -248,6 +252,13 @@ export class CollaborationState {
     const owner = this.conflictingOwner(by, paths);
     if (owner) return { ok: false, ownedBy: owner, paths };
     let item = id ? this.board.get(id) : undefined;
+    // (Re)assigning an existing item must not hijack one another agent already
+    // owns: an item's current owner still holds whatever paths it leased even if
+    // those paths don't overlap the freshly requested ones (which is why
+    // conflictingOwner can pass). Reject so a peer can't steal ownership by id.
+    if (item && item.owner && item.owner !== by) {
+      return { ok: false, ownedBy: item.owner, paths };
+    }
     if (!item) {
       item = {
         id: id ?? `t${++this.boardSeq}`,
@@ -272,14 +283,35 @@ export class CollaborationState {
   }
 
   boardRelease(by: string, opts: { id?: string; paths?: ReadonlyArray<string> }): void {
+    // Only the owner may release a lock — both the id path and the paths path.
+    // Releasing by id used to skip this check, letting any peer drop another
+    // agent's exclusive lease (the publicly-readable board ids are guessable),
+    // which silently defeated the cross-process file lock.
     const targets = opts.id
-      ? [this.board.get(opts.id)].filter(Boolean as unknown as (x: BoardItem | undefined) => x is BoardItem)
+      ? [this.board.get(opts.id)].filter(
+          (it): it is BoardItem => it !== undefined && it.owner === by,
+        )
       : this.boardOrder
           .map((id) => this.board.get(id)!)
           .filter((it) => it.owner === by && it.paths && opts.paths?.some((p) => it.paths!.some((q) => pathsConflict(p, q))));
     for (const item of targets) {
       delete item.owner;
       item.updatedBy = by;
+      item.updatedAt = this.now();
+      this.emitFn({ kind: 'board', action: 'release', item: { ...item } });
+    }
+  }
+
+  /** Drop every exclusive lease an agent holds (e.g. when it crashed/was
+   *  killed), emitting a release event per item so peers + the UI stay in sync.
+   *  Without this a dead owner would hold its file locks forever, deadlocking
+   *  any survivor that needs those paths. */
+  private releaseAllFor(agentId: string): void {
+    for (const id of this.boardOrder) {
+      const item = this.board.get(id)!;
+      if (item.owner !== agentId) continue;
+      delete item.owner;
+      item.updatedBy = agentId;
       item.updatedAt = this.now();
       this.emitFn({ kind: 'board', action: 'release', item: { ...item } });
     }


### PR DESCRIPTION
Extends the quality sweep to the features that merged to `main` during it (~7.3K LOC). Real, high-severity bugs found and fixed, each with a regression test.

- **mode-collaborative — path traversal (high):** peer-read confinement used a `startsWith(dir)` prefix check; a peer agent could read sibling-dir files outside its worktree. Now segment-aware (`resolve`+`relative`), proven by a fail-before test. + abort-listener leaks in poll loops.
- **plugin-collab — lock-stealing / hijack / deadlock:** `boardRelease`/`boardClaim` by public id skipped the owner check; a crashed agent's locks were never freed. Owner check enforced; crashed/killed agents release claims.
- **anonymizer — PII leak + perf:** NER span aggregation mislocated short entities (redacted the wrong text, left real PII); worker leaked in-flight promises; overlap resolution was O(n²). All fixed.
- **app installer — SSRF + DoS:** asset download had no source allow-list and no size cap; both added. The `moxxy-app://` protocol handler audited and confirmed escape-proof.
- mini-apps framework + collaborate UI: worker-leak fix, IPC-boundary Zod test coverage, extracted+tested pure helpers.

**Verification:** build 68/68 · typecheck 134/134 · test all pass · lint 0 errors · check:deps clean (995 modules).