### PR TITLE
Finish runner/thin-client typing seam + one-shot CLI exit hygiene

### DIFF
--- a/.changeset/channel-dispatch-typed-seam.md
+++ b/.changeset/channel-dispatch-typed-seam.md
@@ -1,0 +1,21 @@
+---
+"@moxxy/sdk": minor
+"@moxxy/cli": patch
+---
+
+refactor(channel): close the runner/thin-client dispatch typing seam
+
+Add a single, audited `startChannelWith(channel, { session, ...overrides })`
+helper to `@moxxy/sdk` that owns the one structural erasure at the
+channel-dispatch boundary (`ChannelDef`/`Channel` are intentionally non-generic
+over their start-options type, so `start` takes `unknown`). The helper's
+signature now type-checks that every caller passes a real `ClientSession`, so a
+bare `RemoteSession` (the thin-client proxy) is proven assignable end-to-end
+even though the final hand-off to `start()` stays erased.
+
+Retarget the four CLI dispatch sites (`serve`, `web-surface`, and both the
+RemoteSession and in-process-Session paths in `start-registered-channel`) to
+call it, removing their inline `as never` casts, and add a compile-time
+conformance lock so a future regression that narrows `RemoteSession` or the
+concrete `Session` below `ClientSession`/`SessionLike` becomes a type error.
+No wire-shape or runner-protocol change.

--- a/.changeset/cli-one-shot-exit-hygiene.md
+++ b/.changeset/cli-one-shot-exit-hygiene.md
@@ -1,0 +1,15 @@
+---
+'@moxxy/cli': patch
+---
+
+fix(cli): drain persistence + close the session on one-shot command exit
+
+One-shot commands (`moxxy -p`, `moxxy schedule run`, `doctor`, `login`, `init`)
+booted a full session and returned without closing it, so the process relied on
+the event loop draining — open webhook/scheduler/timer handles delayed (or hung)
+exit, and the last appended event could still be in flight when the process
+ended. Add a shared `closeSession(session, persistence?)` helper that drains the
+index write (`flush`) + the append queue (`settleWrites`) so the LAST event is
+durably on disk, then fires `onShutdown` hooks / stops the boot daemons via
+`Session.close()`. Each command now calls it in a `finally` (preserving its exit
+code), so the process exits promptly without dropping the final event.

--- a/packages/cli/src/commands/doctor.lifecycle.test.ts
+++ b/packages/cli/src/commands/doctor.lifecycle.test.ts
@@ -1,0 +1,131 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { definePlugin, defineProvider } from '@moxxy/sdk';
+import type { ParsedArgv } from '../argv.js';
+
+/**
+ * Regression: `moxxy doctor` boots a full session for diagnostics and must
+ * drain persistence + close the session before returning — otherwise its boot
+ * daemons keep the process alive and the final index row may not reach disk.
+ *
+ * A REAL bare Session + REAL SessionPersistence (temp dir) backs the
+ * "session closed + last event on disk after the command returns" assertions;
+ * the diagnostic registries are empty on a bare session, so every check
+ * resolves trivially. Only the heavy externals (`setupSessionWithConfig`,
+ * voice-capture probe) are mocked.
+ */
+
+const tempDirs: string[] = [];
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-doctor-lifecycle-'));
+  tempDirs.push(dir);
+  return dir;
+}
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+const core = await vi.importActual<typeof import('@moxxy/core')>('@moxxy/core');
+
+let harness: {
+  session: import('@moxxy/core').Session;
+  persistence: import('@moxxy/core').SessionPersistence;
+  onShutdown: ReturnType<typeof vi.fn>;
+  dir: string;
+  id: string;
+};
+
+vi.mock('@moxxy/plugin-cli', () => ({
+  checkVoiceCaptureAvailable: async () => ({ ready: true, issues: [] }),
+}));
+
+vi.mock('../setup.js', () => ({
+  setupSessionWithConfig: vi.fn(async () => ({
+    session: harness.session,
+    persistence: harness.persistence,
+    config: {},
+    configSources: [],
+    vault: {
+      open: async () => undefined,
+      sourceName: 'env',
+      get: async () => null,
+    },
+    memory: { list: async () => [] },
+    pluginRegistration: { registered: new Set<string>(), skipped: [] },
+  })),
+}));
+
+const { runDoctorCommand } = await import('./doctor.js');
+
+function argv(): ParsedArgv {
+  return { positional: [], flags: { json: true } } as unknown as ParsedArgv;
+}
+
+describe('runDoctorCommand lifecycle', () => {
+  beforeEach(async () => {
+    const dir = await makeTempDir();
+    const session = new core.Session({ cwd: os.tmpdir(), logger: core.silentLogger });
+    const id = String(session.id);
+    const persistence = new core.SessionPersistence({
+      sessionId: session.id,
+      cwd: os.tmpdir(),
+      dir,
+    });
+    const detach = persistence.attach(session.log);
+    const onShutdown = vi.fn();
+    // Register the default-checked provider so its doctor row is a `warn`
+    // (no key in the fake vault) rather than a `fail` (not registered) — the
+    // lifecycle assertions want a clean exit code, not a green setup.
+    session.pluginHost.registerStatic(
+      definePlugin({
+        name: '@test/anthropic',
+        providers: [
+          defineProvider({
+            name: 'anthropic',
+            models: [],
+            createClient: () => ({
+              name: 'anthropic',
+              models: [],
+              stream: async function* () {},
+              countTokens: async () => 0,
+            }),
+          }),
+        ],
+      }),
+    );
+    session.pluginHost.registerStatic(
+      definePlugin({
+        name: '@test/persistence-handle',
+        hooks: { onShutdown: async () => detach() },
+      }),
+    );
+    session.pluginHost.registerStatic(
+      definePlugin({ name: '@test/close-spy', hooks: { onShutdown } }),
+    );
+    // Simulate the "last event" a prior turn would have left in this resumed
+    // session's log, so the drain assertion has something to observe on disk.
+    await session.log.append({
+      type: 'user_prompt',
+      sessionId: session.id,
+      turnId: 't1' as never,
+      source: 'user',
+      text: 'last event before doctor ran',
+    });
+    harness = { session, persistence, onShutdown, dir, id };
+  });
+
+  it('closes the session and leaves the last event on disk after returning', async () => {
+    const code = await runDoctorCommand(argv());
+    // Bare session has no failing checks.
+    expect(code).toBe(0);
+
+    // (a) session closed — onShutdown fired exactly once.
+    expect(harness.onShutdown).toHaveBeenCalledTimes(1);
+
+    // (b) drain happened: the last appended event survived to disk.
+    const restored = await core.restoreSessionEvents(harness.id, harness.dir);
+    expect(restored.at(-1)).toMatchObject({ text: 'last event before doctor ran' });
+  });
+});

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -2,12 +2,16 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { Session } from '@moxxy/core';
+import type { MoxxyConfig } from '@moxxy/config';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import type { MemoryStore } from '@moxxy/plugin-memory';
 import { checkVoiceCaptureAvailable } from '@moxxy/plugin-cli';
 import { corePreflight, detectCoreInstall } from '@moxxy/plugin-self-update';
 import type { RequirementIssue } from '@moxxy/sdk';
 import type { RequirementCheck } from '@moxxy/sdk';
 import type { ParsedArgv } from '../argv.js';
 import { setupSessionWithConfig } from '../setup.js';
+import { closeSession } from '../setup/close-session.js';
 import type { RegistrationResult } from '../setup/register-plugins.js';
 import { canonicalKey } from '../provider-keys.js';
 import { colors } from '../colors.js';
@@ -66,7 +70,43 @@ export async function runDoctorCommand(argv: ParsedArgv): Promise<number> {
     return emit(checks, asJson);
   }
 
-  const { session, config, configSources, vault, memory, pluginRegistration } = setupResult.value;
+  const { session, config, configSources, vault, memory, pluginRegistration, persistence } =
+    setupResult.value;
+
+  try {
+    return await runDoctorChecks({
+      session,
+      config,
+      configSources,
+      vault,
+      memory,
+      pluginRegistration,
+      checks,
+      checkKeys,
+      asJson,
+    });
+  } finally {
+    // Drain persistence + fire onShutdown hooks / stop the boot daemons so the
+    // process exits promptly. Best-effort — never masks the doctor exit code.
+    await closeSession(session, persistence);
+  }
+}
+
+interface DoctorChecksDeps {
+  readonly session: Session;
+  readonly config: MoxxyConfig;
+  readonly configSources: ReadonlyArray<{ scope: 'project' | 'user' | 'explicit'; path: string }>;
+  readonly vault: VaultStore;
+  readonly memory: MemoryStore;
+  readonly pluginRegistration: RegistrationResult;
+  readonly checks: Check[];
+  readonly checkKeys: boolean;
+  readonly asJson: boolean;
+}
+
+async function runDoctorChecks(deps: DoctorChecksDeps): Promise<number> {
+  const { session, config, configSources, vault, memory, pluginRegistration, checks, checkKeys, asJson } =
+    deps;
 
   // Config
   if (configSources.length > 0) {
@@ -148,8 +188,8 @@ export async function runDoctorCommand(argv: ParsedArgv): Promise<number> {
   }
 
   // Channels
-  const deps = { cwd: process.cwd(), vault, logger: session.logger, options: {} };
-  const channelEntries = await session.channels.listWithAvailability(deps);
+  const channelDeps = { cwd: process.cwd(), vault, logger: session.logger, options: {} };
+  const channelEntries = await session.channels.listWithAvailability(channelDeps);
   for (const { def, availability } of channelEntries) {
     if (availability.ok) {
       checks.push({ id: `channel:${def.name}`, status: 'ok', message: 'available' });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { bootSessionWithConfig } from '../argv-helpers.js';
+import { closeSession } from '../setup/close-session.js';
 import { canonicalKey } from '../provider-keys.js';
 import { validateProviderKey } from '../validate-key.js';
 import type { ParsedArgv } from '../argv.js';
@@ -36,16 +37,32 @@ export async function runInitCommand(argv: ParsedArgv): Promise<number> {
   // `passphrasePrompt` (TTY only) swaps the vault's bare readline prompt for
   // a @clack/prompts step, so the first-run passphrase reads as part of the
   // setup wizard rather than an unstyled prompt before it.
-  const { session, vault } = await bootSessionWithConfig(argv, {
+  const { session, vault, persistence } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
     skipProviderActivation: true,
     ...(interactive ? { passphrasePrompt: promptVaultPassphrase } : {}),
   });
 
-  if (!interactive) {
-    return await runHeadlessInit(session, vault);
+  // Tear the session down on every NORMAL exit so the boot daemons (scheduler
+  // poller, webhooks listener) don't keep the process alive after the wizard
+  // returns. The passphrase-cancel path inside `vault.open()` does a hard
+  // `process.exit(1)` (preserving the original cancel UX) — that intentionally
+  // bypasses this finally, which is fine because the process is terminating and
+  // no turn ran, so there is nothing to drain.
+  try {
+    if (!interactive) {
+      return await runHeadlessInit(session, vault);
+    }
+    return await runInteractiveInit(session, vault);
+  } finally {
+    await closeSession(session, persistence);
   }
+}
 
+async function runInteractiveInit(
+  session: import('@moxxy/core').Session,
+  vault: import('@moxxy/plugin-vault').VaultStore,
+): Promise<number> {
   // Logo first, so the whole flow reads as one screen: the (first-run only)
   // vault passphrase step and the wizard's `intro()` both render beneath it.
   process.stdout.write(renderLogo());

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,10 +1,12 @@
 import type { ParsedArgv } from '../argv.js';
 import { bootSessionWithConfig, hasBoolFlag } from '../argv-helpers.js';
+import { closeSession } from '../setup/close-session.js';
 import { colors } from '../colors.js';
 import { buildProviderAuthContext } from '../wizard/auth-context.js';
 import { formatHelp } from './help-format.js';
 import type { ProviderDef } from '@moxxy/sdk';
 import type { Session } from '@moxxy/core';
+import type { VaultStore } from '@moxxy/plugin-vault';
 
 /**
  * `moxxy login` — generic OAuth driver. Walks the session's provider
@@ -66,14 +68,22 @@ export async function runLoginCommand(argv: ParsedArgv): Promise<number> {
     // boot fails for any reason fall back to a generic help body.
     let session: Session | null = null;
     try {
-      const { session: s } = await bootSessionWithConfig(argv, {
+      const { session: s, persistence } = await bootSessionWithConfig(argv, {
         skipKeyPrompt: true,
         skipProviderActivation: true,
         tolerateNoProvider: true,
       });
       session = s;
+      // Read the registry for the help body, then tear the throwaway session
+      // down so its boot daemons don't keep the process alive.
+      try {
+        process.stdout.write(buildHelp(session));
+      } finally {
+        await closeSession(s, persistence);
+      }
+      return sub ? 0 : 2;
     } catch {
-      // ignore
+      // ignore — fall through to a generic help body
     }
     process.stdout.write(buildHelp(session));
     return sub ? 0 : 2;
@@ -87,11 +97,24 @@ export async function runLoginCommand(argv: ParsedArgv): Promise<number> {
 }
 
 async function loginProvider(argv: ParsedArgv, providerName: string): Promise<number> {
-  const { session, vault } = await bootSessionWithConfig(argv, {
+  const { session, vault, persistence } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
     skipProviderActivation: true,
     tolerateNoProvider: true,
   });
+  try {
+    return await runLoginProvider(argv, providerName, session, vault);
+  } finally {
+    await closeSession(session, persistence);
+  }
+}
+
+async function runLoginProvider(
+  argv: ParsedArgv,
+  providerName: string,
+  session: Session,
+  vault: VaultStore,
+): Promise<number> {
   const def = session.providers.list().find((d) => d.name === providerName);
   if (!def) {
     process.stderr.write(
@@ -165,11 +188,19 @@ async function loginProvider(argv: ParsedArgv, providerName: string): Promise<nu
 }
 
 async function loginStatus(argv: ParsedArgv): Promise<number> {
-  const { session, vault } = await bootSessionWithConfig(argv, {
+  const { session, vault, persistence } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
     skipProviderActivation: true,
     tolerateNoProvider: true,
   });
+  try {
+    return await runLoginStatus(argv, session, vault);
+  } finally {
+    await closeSession(session, persistence);
+  }
+}
+
+async function runLoginStatus(argv: ParsedArgv, session: Session, vault: VaultStore): Promise<number> {
   await vault.open();
   const ctx = buildProviderAuthContext(vault, { headless: true });
   const filter = argv.positional[1];
@@ -236,11 +267,23 @@ async function loginLogout(argv: ParsedArgv): Promise<number> {
     );
     return 2;
   }
-  const { session, vault } = await bootSessionWithConfig(argv, {
+  const { session, vault, persistence } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
     skipProviderActivation: true,
     tolerateNoProvider: true,
   });
+  try {
+    return await runLoginLogout(providerName, session, vault);
+  } finally {
+    await closeSession(session, persistence);
+  }
+}
+
+async function runLoginLogout(
+  providerName: string,
+  session: Session,
+  vault: VaultStore,
+): Promise<number> {
   await vault.open();
   const def = session.providers.list().find((d) => d.name === providerName);
   if (!def || def.auth?.kind !== 'oauth') {

--- a/packages/cli/src/commands/prompt.lifecycle.test.ts
+++ b/packages/cli/src/commands/prompt.lifecycle.test.ts
@@ -1,0 +1,132 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { definePlugin } from '@moxxy/sdk';
+import type { ParsedArgv } from '../argv.js';
+
+/**
+ * Regression: `moxxy -p` must drain persistence + close the session before it
+ * returns, so the process exits promptly without dropping the last event.
+ *
+ * We boot a REAL Session wired to a REAL SessionPersistence (temp dir) so the
+ * "last event is on disk after the command returns" assertion is genuine, and
+ * mock only `setupSessionWithConfig` (to hand that session back) and `runTurn`
+ * (to append the final event the way a real turn would).
+ */
+
+const tempDirs: string[] = [];
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-prompt-lifecycle-'));
+  tempDirs.push(dir);
+  return dir;
+}
+// Pretend stdin is a TTY so `readStdinIfPiped()` short-circuits instead of
+// draining a never-ending stream under the test runner.
+const realIsTTY = process.stdin.isTTY;
+afterEach(async () => {
+  vi.restoreAllMocks();
+  process.stdin.isTTY = realIsTTY;
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+const core = await vi.importActual<typeof import('@moxxy/core')>('@moxxy/core');
+
+// Built per-test in beforeEach.
+let harness: {
+  session: import('@moxxy/core').Session;
+  persistence: import('@moxxy/core').SessionPersistence;
+  onShutdown: ReturnType<typeof vi.fn>;
+  dir: string;
+  id: string;
+};
+
+// Swappable per-test turn behavior. Default appends one final event + yields it.
+let runTurnImpl: (session: import('@moxxy/core').Session) => AsyncGenerator<unknown>;
+
+vi.mock('@moxxy/core', async () => {
+  const actual = await vi.importActual<typeof import('@moxxy/core')>('@moxxy/core');
+  return {
+    ...actual,
+    runTurn: (session: import('@moxxy/core').Session) => runTurnImpl(session),
+  };
+});
+
+vi.mock('../setup.js', () => ({
+  setupSessionWithConfig: vi.fn(async () => ({
+    session: harness.session,
+    persistence: harness.persistence,
+  })),
+}));
+
+const { runPromptCommand } = await import('./prompt.js');
+
+function argv(): ParsedArgv {
+  return { positional: [], flags: { p: 'hello', 'output-format': 'stream-json' } } as unknown as ParsedArgv;
+}
+
+describe('runPromptCommand lifecycle', () => {
+  beforeEach(async () => {
+    process.stdin.isTTY = true;
+    runTurnImpl = async function* (session) {
+      const event = await session.log.append({
+        type: 'user_prompt',
+        sessionId: session.id,
+        turnId: 't1' as never,
+        source: 'user',
+        text: 'last event from the turn',
+      });
+      yield event;
+    };
+    const dir = await makeTempDir();
+    const session = new core.Session({ cwd: os.tmpdir(), logger: core.silentLogger });
+    const id = String(session.id);
+    const persistence = new core.SessionPersistence({ sessionId: session.id, cwd: os.tmpdir(), dir });
+    const detach = persistence.attach(session.log);
+    const onShutdown = vi.fn();
+    session.pluginHost.registerStatic(
+      definePlugin({
+        name: '@test/persistence-handle',
+        hooks: { onShutdown: async () => detach() },
+      }),
+    );
+    session.pluginHost.registerStatic(
+      definePlugin({ name: '@test/close-spy', hooks: { onShutdown } }),
+    );
+    harness = { session, persistence, onShutdown, dir, id };
+  });
+
+  it('closes the session and leaves the last event on disk after returning', async () => {
+    const code = await runPromptCommand(argv());
+    expect(code).toBe(0);
+
+    // (a) session closed — onShutdown fired.
+    expect(harness.onShutdown).toHaveBeenCalledTimes(1);
+
+    // (b) the drain happened: the last appended event is durably on disk.
+    const restored = await core.restoreSessionEvents(harness.id, harness.dir);
+    expect(restored).toHaveLength(1);
+    expect(restored[0]).toMatchObject({ type: 'user_prompt', text: 'last event from the turn' });
+  });
+
+  it('still closes the session (and drains) when the turn throws — exit code 1', async () => {
+    runTurnImpl = async function* (session) {
+      // Append the last event first so the drain assertion is meaningful, then
+      // blow up mid-stream.
+      yield await session.log.append({
+        type: 'user_prompt',
+        sessionId: session.id,
+        turnId: 't1' as never,
+        source: 'user',
+        text: 'last before crash',
+      });
+      throw new Error('provider exploded');
+    };
+
+    const code = await runPromptCommand(argv());
+    expect(code).toBe(1);
+    expect(harness.onShutdown).toHaveBeenCalledTimes(1);
+    const restored = await core.restoreSessionEvents(harness.id, harness.dir);
+    expect(restored.at(-1)).toMatchObject({ text: 'last before crash' });
+  });
+});

--- a/packages/cli/src/commands/prompt.ts
+++ b/packages/cli/src/commands/prompt.ts
@@ -1,6 +1,7 @@
 import { collectTurn, createAllowListResolver, denyByDefaultResolver, runTurn } from '@moxxy/core';
 import type { MoxxyEvent } from '@moxxy/sdk';
-import { setupSession } from '../setup.js';
+import { setupSessionWithConfig } from '../setup.js';
+import { closeSession } from '../setup/close-session.js';
 import { argvToSetupOptions, hasBoolFlag, stringFlag } from '../argv-helpers.js';
 import { printError } from '../errors.js';
 import type { ParsedArgv } from '../argv.js';
@@ -34,7 +35,7 @@ export async function runPromptCommand(argv: ParsedArgv): Promise<number> {
       ? createAllowListResolver(allowTools)
       : denyByDefaultResolver;
 
-  const session = await setupSession({
+  const { session, persistence } = await setupSessionWithConfig({
     ...argvToSetupOptions(argv),
     resolver,
   });
@@ -71,7 +72,12 @@ export async function runPromptCommand(argv: ParsedArgv): Promise<number> {
     }
   } catch (err) {
     printError(`fatal: ${err instanceof Error ? err.message : String(err)}`);
-    return 1;
+    exitCode = 1;
+  } finally {
+    // Drain persistence (last event + final index row) then fire onShutdown
+    // hooks / stop daemons so the process exits promptly. Best-effort — never
+    // masks the command's exit code.
+    await closeSession(session, persistence);
   }
   return exitCode;
 }

--- a/packages/cli/src/commands/schedule/handlers.ts
+++ b/packages/cli/src/commands/schedule/handlers.ts
@@ -3,6 +3,7 @@ import type { ScheduleStore } from '@moxxy/plugin-scheduler';
 import type { ParsedArgv } from '../../argv.js';
 import { colors } from '../../colors.js';
 import { setupSessionWithConfig } from '../../setup.js';
+import { closeSession } from '../../setup/close-session.js';
 import { fmtNext, flag } from './format.js';
 
 export async function listSchedules(store: ScheduleStore): Promise<number> {
@@ -106,8 +107,9 @@ export async function runScheduleNow(argv: ParsedArgv): Promise<number> {
   // independently fire a due schedule mid-`run` (double-dispatch), and the
   // webhooks listener would bind its port for an abandoned session. So skip
   // init hooks (provider activation runs before that gate) and close the
-  // session in a finally so onShutdown hooks (vault flush, etc.) fire.
-  const { session, scheduler: full } = await setupSessionWithConfig({
+  // session in a finally so persistence drains + onShutdown hooks (vault
+  // flush, etc.) fire and the process exits promptly.
+  const { session, scheduler: full, persistence } = await setupSessionWithConfig({
     cwd: process.cwd(),
     skipInitHooks: true,
   });
@@ -136,6 +138,6 @@ export async function runScheduleNow(argv: ParsedArgv): Promise<number> {
     );
     return outcome.ok ? 0 : 1;
   } finally {
-    await session.close('schedule-run').catch(() => undefined);
+    await closeSession(session, persistence);
   }
 }

--- a/packages/cli/src/commands/schedule/run-now.test.ts
+++ b/packages/cli/src/commands/schedule/run-now.test.ts
@@ -58,7 +58,9 @@ describe('runScheduleNow lifecycle (u24-1)', () => {
   it('closes the session after a successful run', async () => {
     await runScheduleNow(argv('s1'));
     expect(closeSpy).toHaveBeenCalledTimes(1);
-    expect(closeSpy).toHaveBeenCalledWith('schedule-run');
+    // Teardown now flows through the shared `closeSession` helper, which closes
+    // with a uniform 'cli-exit' reason after draining persistence.
+    expect(closeSpy).toHaveBeenCalledWith('cli-exit');
   });
 
   it('still closes the session when runSchedule throws', async () => {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,3 +1,4 @@
+import { startChannelWith } from '@moxxy/sdk';
 import type { Channel, ChannelDef, ChannelHandle } from '@moxxy/sdk';
 import { startRunnerServer, runnerSocketPath, type RunnerServer } from '@moxxy/runner';
 import type { ParsedArgv } from '../argv.js';
@@ -357,7 +358,7 @@ async function startChannel(
   if (installResolver) {
     session.setPermissionResolver(channel.permissionResolver);
   }
-  return channel.start({ session, ...channelOpts } as never);
+  return startChannelWith(channel, { session, ...channelOpts });
 }
 
 interface StartupSummary {

--- a/packages/cli/src/commands/start-registered-channel.ts
+++ b/packages/cli/src/commands/start-registered-channel.ts
@@ -3,8 +3,12 @@ import {
   isRunnerUp,
   runnerSocketPath,
   startRunnerServer,
+  type RemoteSession,
   type RunnerServer,
 } from '@moxxy/runner';
+import type { Session } from '@moxxy/core';
+import { startChannelWith } from '@moxxy/sdk';
+import type { ClientSession, SessionLike } from '@moxxy/sdk';
 import {
   argvToSetupOptions,
   bootSessionWithConfig,
@@ -16,6 +20,21 @@ import { printError } from '../errors.js';
 import type { ParsedArgv } from '../argv.js';
 import { chooseClientMode, collectExtraFlags } from './client-mode.js';
 import { coAttachWebSurface } from './web-surface.js';
+
+/**
+ * Compile-time conformance lock for the runner/thin-client seam. Both session
+ * implementations a channel ever receives — the thin-client `RemoteSession`
+ * proxy and the in-process `@moxxy/core` `Session` — MUST stay assignable to
+ * the typed views every channel is written against (`ClientSession`, and
+ * through it `SessionLike`). If a future change narrows either implementation
+ * or widens a *ClientView, this turns the regression into a compile error here
+ * instead of forcing a cast back onto a dispatch call site below.
+ */
+type _AssertAssignable<_T extends _U, _U> = true;
+type _RemoteIsClientSession = _AssertAssignable<RemoteSession, ClientSession>;
+type _RemoteIsSessionLike = _AssertAssignable<RemoteSession, SessionLike>;
+type _SessionIsClientSession = _AssertAssignable<Session, ClientSession>;
+type _SessionIsSessionLike = _AssertAssignable<Session, SessionLike>;
 
 /**
  * Run a registered channel by name, headlessly (no wizard, no TUI hand-off).
@@ -70,11 +89,12 @@ async function runAttachedChannel(name: string, argv: ParsedArgv): Promise<numbe
   });
   remote.setPermissionResolver(channel.permissionResolver);
 
-  const handle = await channel.start({
+  // RemoteSession is a ClientSession (thin-client proxy); the seam holds.
+  const handle = await startChannelWith(channel, {
     session: remote,
     model: stringFlag(argv, 'model'),
     ...collectExtraFlags(argv),
-  } as never);
+  });
 
   let stopping = false;
   const shutdown = async (code: number): Promise<void> => {
@@ -137,11 +157,12 @@ async function runSelfHostedChannel(
     }
   }
 
-  const handle = await channel.start({
+  // The in-process Session satisfies ClientSession; the seam holds.
+  const handle = await startChannelWith(channel, {
     session,
     model: stringFlag(argv, 'model'),
     ...collectExtraFlags(argv),
-  } as never);
+  });
 
   // Co-attach the web surface to the SAME session (on by default) so
   // present_view renders and the agent can hand the user a URL even when the

--- a/packages/cli/src/commands/web-surface.ts
+++ b/packages/cli/src/commands/web-surface.ts
@@ -1,3 +1,4 @@
+import { startChannelWith } from '@moxxy/sdk';
 import type { ChannelHandle } from '@moxxy/sdk';
 import type { Session } from '@moxxy/core';
 import type { MoxxyConfig } from '@moxxy/config';
@@ -49,7 +50,7 @@ export async function coAttachWebSurface(opts: CoAttachWebOptions): Promise<Chan
 
   try {
     const web = def.create({ cwd: process.cwd(), vault, logger: session.logger, options: webCfg });
-    const handle = await web.start({ session } as never);
+    const handle = await startChannelWith(web, { session });
     const url = (web as { shareUrl?: string }).shareUrl;
     if (url) write(`  web surface  ${url}\n`);
     return handle;

--- a/packages/cli/src/setup/close-session.test.ts
+++ b/packages/cli/src/setup/close-session.test.ts
@@ -1,0 +1,122 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Session, SessionPersistence, restoreSessionEvents, silentLogger } from '@moxxy/core';
+import { definePlugin } from '@moxxy/sdk';
+import { closeSession } from './close-session.js';
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-close-session-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+/**
+ * A real Session whose own log is wired to a real SessionPersistence against a
+ * temp dir, plus an `onShutdown` spy so we can assert close fired. This is the
+ * exact wiring `attachSessionPersistence` produces, minus the production sids.
+ */
+async function makeHarness(): Promise<{
+  session: Session;
+  persistence: SessionPersistence;
+  onShutdown: ReturnType<typeof vi.fn>;
+  dir: string;
+  id: string;
+  appendLast: () => Promise<void>;
+}> {
+  const dir = await makeTempDir();
+  const session = new Session({ cwd: os.tmpdir(), logger: silentLogger });
+  const id = String(session.id);
+  const persistence = new SessionPersistence({ sessionId: session.id, cwd: os.tmpdir(), dir });
+  const detach = persistence.attach(session.log);
+  const onShutdown = vi.fn();
+  session.pluginHost.registerStatic(
+    definePlugin({
+      name: '@test/close-session-handle',
+      hooks: { onShutdown: async () => detach() },
+    }),
+  );
+  // Track shutdown ordering separately so the test can assert the persistence
+  // drain ran BEFORE close fired its shutdown hooks (which detach persistence).
+  session.pluginHost.registerStatic(
+    definePlugin({ name: '@test/close-spy', hooks: { onShutdown } }),
+  );
+  const appendLast = async (): Promise<void> => {
+    await session.log.append({
+      type: 'user_prompt',
+      sessionId: session.id,
+      turnId: 't1' as never,
+      source: 'user',
+      text: 'the very last event',
+    });
+  };
+  return { session, persistence, onShutdown, dir, id, appendLast };
+}
+
+describe('closeSession', () => {
+  it('drains the append queue so the LAST event is on disk after it resolves', async () => {
+    const h = await makeHarness();
+    // append() only AWAITS the listener that enqueues the write fire-and-forget;
+    // the bytes are not guaranteed on disk yet. Without the drain, this would be
+    // racy — that race is exactly what closeSession fixes.
+    await h.appendLast();
+
+    await closeSession(h.session, h.persistence);
+
+    const restored = await restoreSessionEvents(h.id, h.dir);
+    expect(restored).toHaveLength(1);
+    expect(restored[0]).toMatchObject({ type: 'user_prompt', text: 'the very last event' });
+  });
+
+  it('fires onShutdown hooks (session closed)', async () => {
+    const h = await makeHarness();
+    await closeSession(h.session, h.persistence);
+    expect(h.onShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('drains persistence BEFORE close fires the detach shutdown hook', async () => {
+    const h = await makeHarness();
+    await h.appendLast();
+
+    const order: string[] = [];
+    const settleSpy = vi.spyOn(h.persistence, 'settleWrites');
+    settleSpy.mockImplementation(async () => {
+      order.push('settle');
+    });
+    h.onShutdown.mockImplementation(() => {
+      order.push('shutdown');
+    });
+
+    await closeSession(h.session, h.persistence);
+    expect(order).toEqual(['settle', 'shutdown']);
+  });
+
+  it('is idempotent and safe to call twice in a finally', async () => {
+    const h = await makeHarness();
+    await closeSession(h.session, h.persistence);
+    await closeSession(h.session, h.persistence);
+    // Session.close is idempotent, so the shutdown hook fires exactly once.
+    expect(h.onShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('tolerates a null persistence handle (persistence disabled)', async () => {
+    const h = await makeHarness();
+    await expect(closeSession(h.session, null)).resolves.toBeUndefined();
+    expect(h.onShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('never throws even if flush rejects — teardown must not mask the command result', async () => {
+    const h = await makeHarness();
+    vi.spyOn(h.persistence, 'flush').mockRejectedValue(new Error('disk gone'));
+    await expect(closeSession(h.session, h.persistence)).resolves.toBeUndefined();
+    // close still ran despite the flush failure.
+    expect(h.onShutdown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/setup/close-session.ts
+++ b/packages/cli/src/setup/close-session.ts
@@ -1,0 +1,43 @@
+import type { Session, SessionPersistence } from '@moxxy/core';
+
+/**
+ * Cleanly tear down a one-shot CLI session so the process can exit promptly
+ * WITHOUT dropping the last event.
+ *
+ * One-shot commands (`moxxy -p`, `moxxy schedule run`, `doctor`, `login`,
+ * `init`) boot a full session and then return — but a bare `return` leaves the
+ * event loop holding open handles (webhook listeners, the scheduler poller, the
+ * persistence debounce timer) and the persistence append queue's LAST write may
+ * still be in flight. Without an explicit teardown the process either hangs on
+ * those handles or exits before the final event reaches disk.
+ *
+ * Order matters and is the whole point of this helper:
+ *   1. `persistence.flush()` — collapse the debounced index write so the meta
+ *      sidecar reflects the final `lastActivity`/`eventCount` on disk.
+ *   2. `persistence.settleWrites()` — drain the append queue so the LAST
+ *      appended event line is on disk (appends are enqueued fire-and-forget).
+ *   3. `session.close()` — fire `onShutdown` hooks (which DETACH persistence,
+ *      flush the vault, etc.) and stop the init-time daemons/listeners.
+ *
+ * The persistence drain runs BEFORE `close()` so the last event is durable even
+ * though `close()`'s shutdown hook detaches the persistence listener.
+ *
+ * Idempotent and safe in a `finally`: `Session.close()` is a no-op after the
+ * first call, `flush()`/`settleWrites()` on an already-drained queue resolve
+ * immediately, and the persistence handle is optional (null when persistence
+ * was disabled). It never throws — a teardown failure must never mask the
+ * command's own result or exit code.
+ */
+export async function closeSession(
+  session: Session,
+  persistence?: SessionPersistence | null,
+): Promise<void> {
+  // Drain persistence FIRST so the last event + final index row are on disk
+  // before the shutdown hook detaches the listener. Best-effort: a flush
+  // failure must not block the session close that stops the daemons.
+  if (persistence) {
+    await persistence.flush().catch(() => undefined);
+    await persistence.settleWrites().catch(() => undefined);
+  }
+  await session.close('cli-exit').catch(() => undefined);
+}

--- a/packages/sdk/src/channel.ts
+++ b/packages/sdk/src/channel.ts
@@ -38,6 +38,43 @@ export interface ChannelHandle {
   stop(reason?: string): Promise<void>;
 }
 
+/**
+ * Start options accepted by {@link startChannelWith}. The `session` is typed —
+ * proving the runner/thin-client seam end-to-end — while the remaining
+ * forwarded flags stay loosely typed (a dispatcher merges config + CLI flags it
+ * can't know the shape of).
+ */
+export type ChannelStartArgs = { readonly session: ClientSession } & Record<string, unknown>;
+
+/**
+ * The single, audited dispatch boundary between a CLI/runner caller and a
+ * channel's `start()`.
+ *
+ * `ChannelDef` (and therefore the {@link Channel} a dispatcher gets back from
+ * `create`) is intentionally NOT generic over its start-options type: a
+ * dispatcher looks channels up by string name, so it can only ever hold a
+ * `Channel<unknown>` whose `start` takes `unknown`. Making the registry fully
+ * generic would ripple through `ChannelRegistry` and every `defineChannel`
+ * call, so it stays out of scope. The structural hand-off from a typed
+ * `{ session, ...overrides }` bag to `start(opts: unknown)` is therefore erased
+ * here — in ONE place — instead of an inline `as never` at each call site.
+ *
+ * What this helper *proves*, and what each caller now states at the type level
+ * by handing in a `ChannelStartArgs`, is the load-bearing half of the
+ * runner/thin-client seam: `session` is a real {@link ClientSession}. Every
+ * channel's concrete `StartOpts.session` is typed `ClientSession`, and
+ * `RemoteSession` (the thin-client proxy) `implements ClientSession`, so a bare
+ * `RemoteSession` is provably assignable end-to-end. The only thing the cast
+ * drops is the loosely-typed *rest* of the forwarded-flag bag, which channels
+ * already read defensively.
+ */
+export function startChannelWith(channel: Channel, opts: ChannelStartArgs): Promise<ChannelHandle> {
+  // Audited erasure: `Channel.start` takes `unknown` (the registry is
+  // non-generic, see above). `opts` is a proven { session: ClientSession } bag;
+  // the cast only erases its loose extra keys, not the typed session.
+  return channel.start(opts as never);
+}
+
 /** Common base shape for channel start options. */
 export interface ChannelStartOptsBase {
   readonly model?: string;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -350,9 +350,11 @@ export type {
   ResolvedPluginManifest,
 } from './plugin.js';
 
+export { startChannelWith } from './channel.js';
 export type {
   Channel,
   ChannelHandle,
+  ChannelStartArgs,
   ChannelStartOptsBase,
   ChannelFactoryDeps,
   ChannelDef,


### PR DESCRIPTION
Implements two of the three remaining architecture items (the third, dual-history consolidation, is staged separately — see below).

### U1 — runner/thin-client typing seam
The split was already complete (every channel consumer types to `ClientSession`; `RemoteSession` satisfies it and the graph is green). Closed the last residue — the dispatch-boundary `as never` cast at 4 sites (`start-registered-channel` ×2, `serve`, `web-surface`):
- Added one audited `startChannelWith()` helper in `@moxxy/sdk` owning the single unavoidable `TStartOpts` erasure; its signature proves every caller passes a real `ClientSession` (so a bare `RemoteSession` is assignable end-to-end).
- Added a compile-time conformance lock (`RemoteSession`/`Session` `satisfies ClientSession`/`SessionLike`) — verified it produces a TS error on a deliberate break.
- No hidden type gap existed; protocol/wire untouched.

### U3 — one-shot CLI exit hygiene
`moxxy -p` / `schedule run` / `doctor` / `login` / `init` booted a full session and never `close()`'d it. Added `setup/close-session.ts` (drains `flush()`+`settleWrites()` so the last event is on disk, then `session.close()` fires shutdown hooks), wired into all five in a `finally` with exit codes preserved. Lifecycle tests assert the session closes and the last event reaches disk.

### Deferred (intentionally): dual on-disk history consolidation
Deep analysis confirmed this is `cannot-verify-in-gate` — the two stores aren't semantically equal (the NDJSON store holds a synthesized reply absent from the runner log), a naive merge would **silently destroy legacy NDJSON-only chats**, and the protocol bump invites the hot-update skew bug. It needs a verified non-destructive migration + a live desktop run. Staged as its own PR.

**Verification:** build 68/68 · typecheck 134/134 · test all pass · lint 0 errors · check:deps clean (996 modules).