### PR TITLE
fix(desktop): header collapse regression + PDF extraction + Office preview + remove gif

### DIFF
--- a/.changeset/fix-header-collapse-and-remove-gif.md
+++ b/.changeset/fix-header-collapse-and-remove-gif.md
@@ -1,0 +1,19 @@
+---
+"@moxxy/desktop": patch
+---
+
+fix(desktop): header nav collapsed even on wide windows; remove white-background brand GIF
+
+- **Header nav stuck collapsed.** The responsive `Segmented` collapse (shipped in
+  0.12.0) folded the nav groups into dropdowns even on wide screens. Once
+  collapsed, the live pill row unmounted, so the fit-measurer lost the natural
+  width and the container shrink-wrapped the small collapsed button — `available`
+  looked tiny and it could never tell it would fit again, so any transient narrow
+  moment (window opening, a resize) wedged it collapsed forever. Fixed by keeping
+  the inline row ALWAYS mounted as a hidden measuring layer at its natural width
+  inside a shrinkable, clipping box: the fit check now reads the true natural vs.
+  available width whether or not it's collapsed, so it collapses only when the row
+  genuinely doesn't fit and re-expands the instant room returns.
+- **Removed the white-background brand GIF** (`new-animation.gif`) — its white
+  matte can't be keyed out on the dark theme. Every use now points at the existing
+  transparent static `logo.png`; the CSS bob animation is preserved.

--- a/.changeset/fix-pdf-extraction-and-file-preview.md
+++ b/.changeset/fix-pdf-extraction-and-file-preview.md
@@ -1,0 +1,23 @@
+---
+"@moxxy/desktop-host": patch
+"@moxxy/desktop": patch
+---
+
+fix(desktop): robust PDF text extraction for the anonymizer + Office-doc previews in the Files pane
+
+- **Anonymizer "Could not extract text from this document" on real PDFs.**
+  officeparser's stale bundled pdf.js silently returns an EMPTY string for many
+  ordinary text-layer PDFs, surfacing as a generic extraction failure. PDF
+  extraction now runs through `pdfjs-dist` (pure-JS, offline, in the main
+  process — no native deps, no network): it concatenates every page's text
+  layer AND pulls AcroForm field values (fillable personal-details forms keep
+  their data in form fields, not the content stream). officeparser remains a
+  fallback only when pdfjs cannot open the file. A genuinely image-only /
+  scanned PDF (no text layer, no form fields) now gets a clear "looks like a
+  scanned image — needs OCR" message instead of a blank failure.
+- **Files explorer preview for Office/ODF docs.** `.docx`/`.xlsx`/`.pptx`/
+  `.odt`/`.ods`/`.odp`/`.rtf`/`.doc` opened in the Files pane now preview as
+  their EXTRACTED text rather than the confirm-gated "binary file" prompt that
+  would only ever show garbled zip bytes. (Images and PDFs already preview
+  natively — `<img>` and Chromium's PDF viewer — via the existing image/pdf
+  `workspace.readFile` branches.)

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -346,7 +346,7 @@ function ReconnectBanner({ label }: { readonly label: string }): JSX.Element {
       }}
     >
       <img
-        src={asset('new-animation.gif')}
+        src={asset('logo.png')}
         alt=""
         aria-hidden="true"
         className="moxxy-avatar-loader moxxy-avatar-loader--sm"

--- a/apps/desktop/src/chat/chat-surface/EmptyState.tsx
+++ b/apps/desktop/src/chat/chat-surface/EmptyState.tsx
@@ -12,7 +12,7 @@ export function EmptyState({ ready }: { readonly ready: boolean }): JSX.Element 
     >
       <div>
         <img
-          src={asset('new-animation.gif')}
+          src={asset('logo.png')}
           alt=""
           aria-hidden="true"
           className={ready ? '' : 'moxxy-avatar-loader'}

--- a/apps/desktop/src/connection/ConnectionScreen.tsx
+++ b/apps/desktop/src/connection/ConnectionScreen.tsx
@@ -83,7 +83,7 @@ export function ConnectionScreen({
         }}
       >
         <img
-          src={asset('new-animation.gif')}
+          src={asset('logo.png')}
           alt=""
           aria-hidden="true"
           style={{ width: 120, height: 'auto', objectFit: 'contain' }}

--- a/apps/desktop/src/lib/asset.ts
+++ b/apps/desktop/src/lib/asset.ts
@@ -2,9 +2,9 @@
  * Resolve a `public/` asset URL that works in BOTH the dev server and the
  * packaged `file://` build.
  *
- * Vite serves `public/` at the dev-server root (`/new-animation.gif`) but in a
+ * Vite serves `public/` at the dev-server root (`/logo.png`) but in a
  * production build the renderer is loaded from `file://…/dist/index.html`
- * with a relative base (`./`). A hard-coded absolute `"/new-animation.gif"` in JSX
+ * with a relative base (`./`). A hard-coded absolute `"/logo.png"` in JSX
  * is a string literal Vite never rewrites, so under `file://` it resolves to
  * the filesystem root and 404s — that's the broken logos/avatars in the
  * packaged app. Prefixing `import.meta.env.BASE_URL` (`/` in dev, `./` in the

--- a/apps/desktop/src/onboarding/chrome/Shell.tsx
+++ b/apps/desktop/src/onboarding/chrome/Shell.tsx
@@ -51,7 +51,7 @@ export function Shell({
       >
         <header style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
           <img
-            src={asset('new-animation.gif')}
+            src={asset('logo.png')}
             alt=""
             aria-hidden
             style={{ height: 40, width: 'auto', objectFit: 'contain', imageRendering: 'pixelated' }}

--- a/apps/desktop/src/onboarding/chrome/primitives.tsx
+++ b/apps/desktop/src/onboarding/chrome/primitives.tsx
@@ -168,7 +168,7 @@ export function Pulse({ label }: { readonly label: string }): JSX.Element {
       }}
     >
       <img
-        src={asset('new-animation.gif')}
+        src={asset('logo.png')}
         alt=""
         aria-hidden
         className="moxxy-avatar-loader moxxy-avatar-loader--sm"

--- a/apps/desktop/src/onboarding/steps/DoneStep.tsx
+++ b/apps/desktop/src/onboarding/steps/DoneStep.tsx
@@ -25,7 +25,7 @@ export function DoneStep({ onComplete }: { readonly onComplete: () => void }): J
       }}
     >
       <img
-        src={asset('new-animation.gif')}
+        src={asset('logo.png')}
         alt=""
         aria-hidden
         style={{ width: 200, height: 'auto', imageRendering: 'pixelated' }}

--- a/apps/desktop/src/onboarding/steps/WelcomeStep.tsx
+++ b/apps/desktop/src/onboarding/steps/WelcomeStep.tsx
@@ -14,7 +14,7 @@ export function WelcomeStep({ onNext }: { readonly onNext: () => void }): JSX.El
       style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center', gap: 18 }}
     >
       <img
-        src={asset('new-animation.gif')}
+        src={asset('logo.png')}
         alt=""
         aria-hidden
         className="moxxy-avatar-loader"

--- a/apps/desktop/src/settings/skills/heroes.tsx
+++ b/apps/desktop/src/settings/skills/heroes.tsx
@@ -19,7 +19,7 @@ export function LoadingHero(): JSX.Element {
       }}
     >
       <img
-        src={asset('new-animation.gif')}
+        src={asset('logo.png')}
         alt=""
         aria-hidden
         className="moxxy-avatar-loader moxxy-avatar-loader--sm"

--- a/apps/desktop/src/shell/ViewHeader.tsx
+++ b/apps/desktop/src/shell/ViewHeader.tsx
@@ -107,24 +107,26 @@ export function Segmented<T extends string>({
   );
 }
 
-/** The inline grey-track / white-pill row — the un-collapsed look. `navRef`
- *  lets the responsive wrapper read its natural width. */
+/** The inline grey-track / white-pill row — the un-collapsed look. When
+ *  `measureOnly` it is rendered solely so the responsive wrapper can read its
+ *  natural width (the parent hides it): it drops the testids — so they don't
+ *  duplicate the dropdown's — and is taken out of the tab order. */
 function PillRow<T extends string>({
   items,
   value,
   onChange,
   testIdPrefix,
-  navRef,
+  measureOnly = false,
 }: {
   readonly items: ReadonlyArray<{ readonly id: T; readonly label: string }>;
   readonly value: T | null;
   readonly onChange: (id: T) => void;
   readonly testIdPrefix: string;
-  readonly navRef?: React.Ref<HTMLElement>;
+  readonly measureOnly?: boolean;
 }): JSX.Element {
   return (
     <nav
-      ref={navRef}
+      aria-hidden={measureOnly || undefined}
       style={{
         display: 'inline-flex',
         gap: 2,
@@ -139,8 +141,9 @@ function PillRow<T extends string>({
           <button
             key={t.id}
             type="button"
-            data-testid={`${testIdPrefix}${t.id}`}
+            data-testid={measureOnly ? undefined : `${testIdPrefix}${t.id}`}
             data-active={active}
+            tabIndex={measureOnly ? -1 : undefined}
             onClick={() => onChange(t.id)}
             style={pillStyle(active)}
           >
@@ -169,18 +172,22 @@ function pillStyle(active: boolean): React.CSSProperties {
 /**
  * The responsive shell around an inline Segmented row.
  *
- * Fit detection without a duplicate DOM subtree: the live inline row is
- * always rendered first; while it's shown we snapshot its NATURAL width
- * (`scrollWidth`) into a ref. A ResizeObserver on the outer (shrinkable)
- * container then compares that remembered natural width against the available
- * width and flips `collapsed`. Snapshotting the width (rather than re-reading
- * the live row, which shrinks once collapsed) breaks the classic flip-flop
- * loop — the decision input never changes just because we collapsed. When the
- * container later grows back past the natural width we expand and re-snapshot.
+ * Fit detection: the inline row is ALWAYS mounted as a measuring layer at its
+ * natural width (`flex-shrink:0`) inside a shrinkable, clipping outer box whose
+ * width tracks the available slot. `collapsed = row's natural width >
+ * box's available width`. Crucially the measuring layer stays mounted even while
+ * collapsed (hidden via `visibility`, but still laid out), so `available >=
+ * natural` is detected the instant room returns.
  *
- * In a DOM without ResizeObserver (the real renderer's jsdom unit env) it
- * stays expanded — the wide-window default — so the inline tabs render exactly
- * as before and existing tab-by-text/-testid tests keep passing.
+ * This is the fix for the earlier "collapsed all the time / stuck on wide
+ * screens" bug: the previous version unmounted the live row on collapse and
+ * remembered a stale natural width, while the box then shrink-wrapped the small
+ * collapsed button — so `available` looked tiny and it could never tell it would
+ * fit again. Any transient narrow moment (window opening, a resize) wedged it
+ * collapsed forever.
+ *
+ * In a DOM without ResizeObserver (jsdom unit env) it stays expanded — the
+ * wide-window default — so existing tab-by-testid tests keep passing.
  */
 function CollapsibleSegmented<T extends string>({
   items,
@@ -195,43 +202,37 @@ function CollapsibleSegmented<T extends string>({
   readonly testIdPrefix: string;
   readonly collapsedLabel: string;
 }): JSX.Element {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const navRef = useRef<HTMLElement | null>(null);
-  // Last natural (un-squeezed) width of the inline row, captured while it was
-  // displayed. Survives the collapse so the fit decision stays stable.
-  const naturalWidthRef = useRef(0);
+  const outerRef = useRef<HTMLDivElement | null>(null);
+  const measureRef = useRef<HTMLDivElement | null>(null);
+  const menuRootRef = useRef<HTMLDivElement | null>(null);
   const [collapsed, setCollapsed] = useState(false);
   const [open, setOpen] = useState(false);
-  const menuRootRef = useRef<HTMLDivElement | null>(null);
 
-  // Re-evaluate fit on container/window resize and whenever the items change.
+  // Re-evaluate fit on slot/window resize and whenever the items/value change.
   useLayoutEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
+    const outer = outerRef.current;
+    const measure = measureRef.current;
+    if (!outer || !measure) return;
     if (typeof ResizeObserver === 'undefined') return; // jsdom — stay expanded.
 
     const evaluate = (): void => {
-      // Refresh the remembered natural width whenever the live row is shown.
-      const nav = navRef.current;
-      if (nav) naturalWidthRef.current = nav.scrollWidth;
-      const natural = naturalWidthRef.current;
-      const available = container.clientWidth;
-      // No layout yet (0 widths) → don't collapse. +1 slack absorbs sub-pixel
-      // rounding so we don't collapse on an exact fit.
-      if (natural <= 0 || available <= 0) {
-        setCollapsed(false);
-        return;
-      }
+      // The measuring layer is always mounted at the row's natural width, so
+      // this reads the true content width whether or not we're collapsed; the
+      // outer box's clientWidth is the available slot (it shrinks below content
+      // via min-width:0). +1 slack absorbs sub-pixel rounding.
+      const natural = measure.scrollWidth;
+      const available = outer.clientWidth;
+      if (natural <= 0 || available <= 0) return; // pre-layout — don't flip
       setCollapsed(natural > available + 1);
     };
 
     evaluate();
     const ro = new ResizeObserver(evaluate);
-    ro.observe(container);
+    ro.observe(outer);
     return () => ro.disconnect();
   }, [items, value]);
 
-  // When folded shut, dismiss on outside-click / Escape — matching RailMenu /
+  // When folded open, dismiss on outside-click / Escape — matching RailMenu /
   // the workspace RowMenu anchored-dropdown pattern.
   useEffect(() => {
     if (!open) return;
@@ -249,33 +250,61 @@ function CollapsibleSegmented<T extends string>({
     };
   }, [open]);
 
+  // Close the menu if a resize folds the group back out (the trigger is gone).
+  useEffect(() => {
+    if (!collapsed) setOpen(false);
+  }, [collapsed]);
+
   const activeLabel = items.find((t) => t.id === value)?.label ?? collapsedLabel;
 
   return (
     <div
-      ref={containerRef}
+      ref={outerRef}
       style={{
-        minWidth: 0, // allow the flex item to shrink so width tracks the squeeze
+        position: 'relative',
         display: 'flex',
         alignItems: 'center',
-        // While expanded, clip the inline row to its squeezed box so it can't
-        // spill past the header in the one frame before the observer collapses
-        // it. When collapsed, overflow MUST stay visible — the dropdown is
-        // absolutely positioned below this box.
+        minWidth: 0, // shrink below content so clientWidth tracks the slot, not the row
+        // Clip the natural-width measuring layer when squeezed. Must go visible
+        // once collapsed so the absolutely-positioned dropdown isn't clipped.
         overflow: collapsed ? 'visible' : 'hidden',
       }}
     >
-      {collapsed ? (
+      {/* Always-mounted measuring layer: the real inline row at natural width
+          (flex-shrink:0). Hidden but still laid out when collapsed, so the fit
+          check keeps seeing the true natural width and can re-expand. */}
+      <div
+        ref={measureRef}
+        style={{
+          display: 'flex',
+          flexShrink: 0,
+          visibility: collapsed ? 'hidden' : undefined,
+          pointerEvents: collapsed ? 'none' : undefined,
+        }}
+      >
+        <PillRow
+          items={items}
+          value={value}
+          onChange={onChange}
+          testIdPrefix={testIdPrefix}
+          measureOnly={collapsed}
+        />
+      </div>
+      {collapsed && (
         <div
           ref={menuRootRef}
-          // The header pane sits inside a `transform`ed ancestor, which traps
-          // an absolutely-positioned child's z-index in a local stacking
-          // context. Lift this anchor while open so the dropdown paints ABOVE
-          // the page content instead of being covered. (See the same note on
-          // the workspace RowMenu.)
+          // Absolutely positioned so it does NOT contribute to the outer box's
+          // width — the hidden measuring layer is what defines (and lets us
+          // measure) that. The header sits inside a `transform`ed ancestor,
+          // which traps an absolute child's z-index in a local stacking context,
+          // so lift this anchor while open to paint above page content.
           style={{
-            position: 'relative',
-            display: 'inline-flex',
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            bottom: 0,
+            display: 'flex',
+            alignItems: 'center',
             zIndex: open ? 50 : undefined,
           }}
         >
@@ -290,7 +319,7 @@ function CollapsibleSegmented<T extends string>({
               display: 'inline-flex',
               alignItems: 'center',
               gap: 6,
-              padding: '7px 12px',
+              padding: '6px 12px',
               fontSize: 13,
               fontWeight: 600,
               borderRadius: 11,
@@ -368,14 +397,6 @@ function CollapsibleSegmented<T extends string>({
             </div>
           )}
         </div>
-      ) : (
-        <PillRow
-          items={items}
-          value={value}
-          onChange={onChange}
-          testIdPrefix={testIdPrefix}
-          navRef={navRef}
-        />
       )}
     </div>
   );

--- a/packages/desktop-host/package.json
+++ b/packages/desktop-host/package.json
@@ -33,7 +33,8 @@
     "@moxxy/plugin-vault": "workspace:*",
     "@moxxy/runner": "workspace:*",
     "@moxxy/sdk": "workspace:*",
-    "officeparser": "~5.1.1"
+    "officeparser": "~5.1.1",
+    "pdfjs-dist": "4.10.38"
   },
   "devDependencies": {
     "@moxxy/testing": "workspace:*",

--- a/packages/desktop-host/src/attachments.test.ts
+++ b/packages/desktop-host/src/attachments.test.ts
@@ -18,6 +18,87 @@ afterEach(async () => {
 
 const b64 = (bytes: Buffer): string => bytes.toString('base64');
 
+/**
+ * Build a minimal, valid single-page text-layer PDF (no deps) whose visible
+ * text is `text`. Just enough structure for pdfjs to read a `Tj` showing op.
+ */
+function makeTextPdf(text: string): Buffer {
+  const esc = (s: string): string => s.replace(/([\\()])/g, '\\$1');
+  const content = `BT /F1 24 Tf 72 700 Td (${esc(text)}) Tj ET`;
+  const objs: string[] = [];
+  objs[1] = '<< /Type /Catalog /Pages 2 0 R >>';
+  objs[2] = '<< /Type /Pages /Kids [3 0 R] /Count 1 >>';
+  objs[3] =
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] ' +
+    '/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>';
+  objs[4] = `<< /Length ${content.length} >>\nstream\n${content}\nendstream`;
+  objs[5] = '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>';
+  return assemblePdf(objs);
+}
+
+/**
+ * Build a minimal fillable AcroForm PDF (no deps) with one text field named
+ * `name` holding `value` — the shape a personal-details form uses (data lives
+ * in the field, not the content stream).
+ */
+function makeFormPdf(name: string, value: string): Buffer {
+  const objs: string[] = [];
+  objs[1] =
+    '<< /Type /Catalog /Pages 2 0 R ' +
+    '/AcroForm << /Fields [5 0 R] /NeedAppearances true >> >>';
+  objs[2] = '<< /Type /Pages /Kids [3 0 R] /Count 1 >>';
+  objs[3] =
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Annots [5 0 R] ' +
+    '/Resources << /Font << /Helv 6 0 R >> >> /Contents 4 0 R >>';
+  objs[4] = '<< /Length 5 >>\nstream\nBT ET\nendstream';
+  objs[5] =
+    '<< /Type /Annot /Subtype /Widget /FT /Tx ' +
+    `/T (${name}) /V (${value}) /Rect [72 700 300 720] /P 3 0 R ` +
+    '/DA (/Helv 12 Tf 0 g) >>';
+  objs[6] = '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>';
+  return assemblePdf(objs);
+}
+
+/** Assemble PDF objects (1-indexed) into a valid file with an xref table. */
+function assemblePdf(objs: string[]): Buffer {
+  let pdf = '%PDF-1.4\n';
+  const offsets: number[] = [];
+  for (let i = 1; i < objs.length; i++) {
+    offsets[i] = Buffer.byteLength(pdf, 'latin1');
+    pdf += `${i} 0 obj\n${objs[i]}\nendobj\n`;
+  }
+  const xrefStart = Buffer.byteLength(pdf, 'latin1');
+  pdf += `xref\n0 ${objs.length}\n0000000000 65535 f \n`;
+  for (let i = 1; i < objs.length; i++) {
+    pdf += `${String(offsets[i]).padStart(10, '0')} 00000 n \n`;
+  }
+  pdf += `trailer\n<< /Size ${objs.length} /Root 1 0 R >>\nstartxref\n${xrefStart}\n%%EOF`;
+  return Buffer.from(pdf, 'latin1');
+}
+
+/**
+ * Build a single-page PDF that is a pure raster image (no text layer, no form
+ * fields) — the "scanned document" shape pdfjs cannot extract any text from.
+ * Uses a 1×1 DeviceGray image so the structure is valid and image-only.
+ */
+function makeImageOnlyPdf(): Buffer {
+  // A 1-byte raw DeviceGray image (one black pixel).
+  const imgData = Buffer.from([0x00]);
+  const objs: string[] = [];
+  objs[1] = '<< /Type /Catalog /Pages 2 0 R >>';
+  objs[2] = '<< /Type /Pages /Kids [3 0 R] /Count 1 >>';
+  objs[3] =
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] ' +
+    '/Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>';
+  const content = 'q 612 0 0 792 0 0 cm /Im0 Do Q';
+  objs[4] = `<< /Length ${content.length} >>\nstream\n${content}\nendstream`;
+  objs[5] =
+    '<< /Type /XObject /Subtype /Image /Width 1 /Height 1 ' +
+    `/ColorSpace /DeviceGray /BitsPerComponent 8 /Length ${imgData.length} >>\n` +
+    `stream\n${imgData.toString('latin1')}\nendstream`;
+  return assemblePdf(objs);
+}
+
 /** Write `bytes` to a fresh temp file named `name`, returning {path, name}. */
 async function tmpFile(name: string, bytes: Buffer | string): Promise<{ path: string; name: string }> {
   const dir = await mkdtemp(path.join(os.tmpdir(), 'moxxy-attach-test-'));
@@ -203,6 +284,36 @@ describe('parseFileToText', () => {
     const OLE_MAGIC = Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
     const buf = Buffer.concat([OLE_MAGIC, Buffer.alloc(64, 0)]);
     const { path: p } = await tmpFile('empty.doc', buf);
+    expect(await parseFileToText(p)).toBeNull();
+  });
+
+  it('extracts the text layer from a real PDF via pdfjs', async () => {
+    // officeparser's bundled pdf.js returns "" for many such PDFs (the bug);
+    // pdfjs reads the content-stream text reliably.
+    const { path: p } = await tmpFile('details.pdf', makeTextPdf('Hello John Doe 555-1234'));
+    const text = await parseFileToText(p);
+    expect(text).not.toBeNull();
+    expect(text).toContain('Hello John Doe 555-1234');
+  });
+
+  it('detects a PDF by magic bytes even with a non-.pdf extension', async () => {
+    const { path: p } = await tmpFile('scan.dat', makeTextPdf('Contact: jane@acme.com'));
+    expect(await parseFileToText(p)).toContain('jane@acme.com');
+  });
+
+  it('pulls AcroForm field values out of a fillable PDF form', async () => {
+    // Personal-details forms store data in form fields, not the page content.
+    const { path: p } = await tmpFile('form.pdf', makeFormPdf('FullName', 'Jane Q. Doe'));
+    const text = await parseFileToText(p);
+    expect(text).not.toBeNull();
+    expect(text).toContain('Jane Q. Doe');
+    // The field name is kept as a label so the redactor sees the context.
+    expect(text).toContain('FullName');
+  });
+
+  it('returns null for an image-only PDF (no text layer, no form fields)', async () => {
+    // A scanned document — only OCR (out of scope) could recover its content.
+    const { path: p } = await tmpFile('scanned.pdf', makeImageOnlyPdf());
     expect(await parseFileToText(p)).toBeNull();
   });
 });

--- a/packages/desktop-host/src/attachments.ts
+++ b/packages/desktop-host/src/attachments.ts
@@ -28,6 +28,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type { UserPromptAttachment } from '@moxxy/sdk';
 import { parseOfficeAsync } from 'officeparser';
+import { extractPdfText } from './pdf-text.js';
 
 /** Image extensions we forward as inline base64 with a real mediaType. */
 const IMAGE_MEDIA_TYPES: Readonly<Record<string, string>> = {
@@ -205,8 +206,9 @@ function legacyDocToText(buf: Buffer): string | null {
   return text.length >= 16 ? text : null;
 }
 
-/** Extract plain text from an Office/ODF/PDF buffer. Returns null on failure
- *  (corrupt / unsupported / empty) so the caller can skip rather than throw. */
+/** Extract plain text from an Office/ODF buffer via officeparser. Returns null
+ *  on failure (corrupt / unsupported / empty) so the caller can skip rather than
+ *  throw. NOT for PDFs — those go through {@link extractPdf}. */
 async function extractText(buf: Buffer, name: string): Promise<string | null> {
   try {
     const text = await parseOfficeAsync(buf, { outputErrorToConsole: false });
@@ -218,11 +220,43 @@ async function extractText(buf: Buffer, name: string): Promise<string | null> {
 }
 
 /**
+ * Extract plain text from a PDF buffer. Tries pdfjs-dist first — it reads the
+ * text layer AND AcroForm field values, and handles far more PDFs than
+ * officeparser's stale bundled pdf.js (which silently returns "" for many
+ * ordinary text PDFs — the bug this fixes).
+ *
+ *   - pdfjs got text/fields → use it.
+ *   - pdfjs opened the PDF but found no text and no fields → it's image-only
+ *     (a scan); return null. We do NOT fall back to officeparser here: it can't
+ *     do better on an image-only PDF, and its stale bundled worker can emit an
+ *     unhandled rejection on some byte layouts.
+ *   - pdfjs could not open the PDF (corrupt/encrypted) → last-resort
+ *     officeparser, then null.
+ */
+async function extractPdf(buf: Buffer, name: string): Promise<string | null> {
+  const result = await extractPdfText(buf);
+  if (result.kind === 'text') return result.text;
+  if (result.kind === 'empty') {
+    console.warn(
+      `[attachments] no extractable text in ${name} (likely a scanned / image-only PDF)`,
+    );
+    return null;
+  }
+  // pdfjs could not parse the file — give officeparser a shot before giving up.
+  const viaOffice = await extractText(buf, name);
+  if (viaOffice && viaOffice.trim().length > 0) return viaOffice;
+  console.warn(`[attachments] could not extract text from PDF ${name}`);
+  return null;
+}
+
+/**
  * Extract plain text from an already-read document BUFFER, dispatching by magic
  * bytes + the supplied `name`'s extension. The format-handling core shared by
  * {@link parseFileToText} (path-based — the picker flow) and the anonymizer's
  * drag-and-drop path (which sends the bytes the renderer already holds). Handles:
- *   - PDF + Office/ODF (`.docx`/`.xlsx`/`.pptx`/`.odt`/`.ods`/`.odp`) → officeparser
+ *   - PDF (`.pdf`)           → pdfjs-dist (text layer + AcroForm fields), with an
+ *                              officeparser fallback (see {@link extractPdf})
+ *   - Office/ODF (`.docx`/`.xlsx`/`.pptx`/`.odt`/`.ods`/`.odp`) → officeparser
  *   - RTF (`.rtf`)            → a dependency-free control-word stripper
  *   - legacy Word (`.doc`)   → best-effort printable-run recovery from the OLE doc
  *   - text / code            → UTF-8 (a NUL byte ⇒ binary ⇒ null)
@@ -231,8 +265,12 @@ async function extractText(buf: Buffer, name: string): Promise<string | null> {
  */
 export async function parseBufferToText(buf: Buffer, name: string): Promise<string | null> {
   const ext = path.extname(name).toLowerCase();
-  // PDF (by extension or magic bytes) or Office/ODF → officeparser.
-  if (isPdf(buf, ext) || OFFICE_EXTENSIONS.has(ext)) {
+  // PDF (by extension or magic bytes) → pdfjs (text layer + AcroForm fields),
+  // falling back to officeparser. Office/ODF → officeparser.
+  if (isPdf(buf, ext)) {
+    return extractPdf(buf, name);
+  }
+  if (OFFICE_EXTENSIONS.has(ext)) {
     return extractText(buf, name);
   }
   // RTF → strip control words locally (officeparser doesn't handle RTF, and the
@@ -299,7 +337,7 @@ export async function buildAttachments(
             name: f.name,
           });
         } else {
-          const text = await extractText(buf, f.name);
+          const text = await extractPdf(buf, f.name);
           if (text) out.push(await largeFileFallback(text, f.name, null));
           else
             console.warn(

--- a/packages/desktop-host/src/ipc/anonymizer.ts
+++ b/packages/desktop-host/src/ipc/anonymizer.ts
@@ -9,14 +9,15 @@
  *   - `anonymizer.pickDocument`  — native open dialog (remembers the pick so the
  *     follow-up parse is authorized).
  *   - `anonymizer.parseDocument` — read + extract text from the picked/workspace
- *     file. NO provider, NO runner, NO network — only readFile + officeparser
- *     (see {@link parseFileToText}). Provenance-gated before any byte is read.
+ *     file. NO provider, NO runner, NO network — only readFile + local parsers
+ *     (pdfjs for PDFs, officeparser for Office/ODF — see {@link parseFileToText}).
+ *     Provenance-gated before any byte is read.
  *   - `anonymizer.saveRedacted`  — write the redacted text to a user-chosen path
  *     (save dialog only; never auto-writes anywhere).
  */
 
-import { basename } from 'node:path';
-import { writeFile } from 'node:fs/promises';
+import { basename, extname } from 'node:path';
+import { readFile, writeFile } from 'node:fs/promises';
 
 import { dialog, BrowserWindow as BrowserWindowApi } from 'electron';
 
@@ -26,10 +27,24 @@ import { authorizeAttachments, rememberPickedAttachment } from '../attachment-au
 import { parseFileToText, parseBufferToText } from '../attachments.js';
 import { handle } from './shared';
 
+/** True when these bytes are a PDF (by `%PDF-` magic). */
+function looksLikePdf(buf: Buffer): boolean {
+  return buf.length >= 5 && buf.toString('latin1', 0, 5) === '%PDF-';
+}
+
+/** The error to show when extraction yields nothing — a PDF with no text layer
+ *  is almost always a scan, which only OCR (out of scope) could read. */
+function noTextError(isPdf: boolean): string {
+  return isPdf
+    ? 'No text found in this PDF — it looks like a scanned image (no selectable text). ' +
+        'Scanned documents need OCR, which the offline anonymizer does not do.'
+    : 'Could not extract text from this document.';
+}
+
 /** Document extensions the anonymizer can parse. Mirrors the picker filter and
- *  {@link parseFileToText}'s capabilities (PDF + Office/ODF via officeparser,
- *  legacy `.doc` + `.rtf` via the local recovery helpers, everything else as
- *  UTF-8 text). */
+ *  {@link parseFileToText}'s capabilities (PDF via pdfjs — text layer + AcroForm
+ *  fields, Office/ODF via officeparser, legacy `.doc` + `.rtf` via the local
+ *  recovery helpers, everything else as UTF-8 text). */
 const DOCUMENT_EXTENSIONS = [
   'pdf', 'doc', 'docx', 'xlsx', 'pptx', 'odt', 'ods', 'odp', 'rtf',
   'txt', 'md', 'markdown', 'csv', 'tsv', 'json', 'log', 'html', 'xml',
@@ -88,7 +103,13 @@ export function registerAnonymizerHandlers(pool: RunnerPool, desks: DeskStore): 
     }
     // No provider, no runner, no network — just local extraction.
     const text = await parseFileToText(path);
-    return text ? { text } : { error: 'Could not extract text from this document.' };
+    if (text) return { text };
+    // Distinguish a scanned PDF (image, no text layer) from a truly unsupported
+    // file so the user knows it isn't a bug.
+    const isPdf =
+      extname(path).toLowerCase() === '.pdf' ||
+      (await readFile(path).then(looksLikePdf).catch(() => false));
+    return { error: noTextError(isPdf) };
   });
 
   handle('anonymizer.parseDocumentBytes', async ({ name, dataBase64 }) => {
@@ -102,7 +123,9 @@ export function registerAnonymizerHandlers(pool: RunnerPool, desks: DeskStore): 
     const buf = Buffer.from(dataBase64, 'base64');
     if (buf.byteLength === 0) return { error: 'The dropped file was empty.' };
     const text = await parseBufferToText(buf, name);
-    return text ? { text } : { error: 'Could not extract text from this document.' };
+    if (text) return { text };
+    const isPdf = extname(name).toLowerCase() === '.pdf' || looksLikePdf(buf);
+    return { error: noTextError(isPdf) };
   });
 
   handle('anonymizer.saveRedacted', async ({ suggestedName, content }) => {

--- a/packages/desktop-host/src/pdf-text.ts
+++ b/packages/desktop-host/src/pdf-text.ts
@@ -1,0 +1,189 @@
+/**
+ * Robust, dependency-light PDF → plain-text extraction for the offline
+ * anonymizer (and the attachment text fallback).
+ *
+ * Why this exists: officeparser bundles an old pdf.js build that returns an
+ * EMPTY string for a great many ordinary text-layer PDFs (and silently so — no
+ * throw), which surfaced to the user as "Could not extract text from this
+ * document." This module uses `pdfjs-dist` (the maintained pure-JS engine — no
+ * native deps, no network) directly:
+ *
+ *   - concatenates every page's `getTextContent()` items (the visible text
+ *     layer), inserting line breaks at vertical gaps so prose stays readable;
+ *   - pulls AcroForm field VALUES (fillable personal-details forms store data in
+ *     form fields, not the content stream) via `getFieldObjects()` + per-page
+ *     Widget annotations.
+ *
+ * It runs entirely in the main process with the worker disabled (`getDocument`
+ * runs the parser on the calling thread in Node), no `eval`, and no network
+ * (`disableFontFace`, no `standardFontDataUrl`/`cMapUrl` fetches). Returns null
+ * when the PDF has no extractable text AND no form values — i.e. a scanned
+ * image-only PDF, where only OCR (out of scope) could recover the content.
+ */
+
+// pdfjs-dist 4.x ships an ESM "legacy" build that works under Node without the
+// modern top-level-await / DOM globals the default build assumes. Import it
+// lazily so the (sizable) module only loads when a PDF is actually parsed.
+type PdfjsModule = typeof import('pdfjs-dist/legacy/build/pdf.mjs');
+let pdfjsPromise: Promise<PdfjsModule> | null = null;
+async function loadPdfjs(): Promise<PdfjsModule> {
+  if (!pdfjsPromise) {
+    pdfjsPromise = (async () => {
+      const m = await import('pdfjs-dist/legacy/build/pdf.mjs');
+      // In Node there is no real Web Worker; pdfjs runs a "fake worker" inline.
+      // Setting up that fake worker needs the worker module loaded in this
+      // realm — otherwise getDocument throws "No GlobalWorkerOptions.workerSrc
+      // specified". Importing the worker module registers it AND sets a
+      // workerSrc, with NO runtime path resolution — so it survives Rollup
+      // bundling into the Electron main bundle (where node_modules isn't
+      // packed and `require.resolve` of a worker file would fail). This is the
+      // bundler-safe way to run pdfjs offline on the main thread.
+      await import('pdfjs-dist/legacy/build/pdf.worker.mjs');
+      return m;
+    })();
+  }
+  return pdfjsPromise;
+}
+
+/** A page's text items as exposed by pdfjs (the subset we read). */
+interface TextItemLike {
+  str?: string;
+  /** Set on hard line breaks between runs; we honour it for readability. */
+  hasEOL?: boolean;
+}
+
+/**
+ * Outcome of {@link extractPdfText}:
+ *   - `text`     — pdfjs read content (text layer and/or form fields);
+ *   - `empty`    — pdfjs opened the PDF fine but it has NO text and NO form
+ *                  fields (a scanned/image-only PDF — OCR territory, out of
+ *                  scope). The caller should NOT bother officeparser: it can't
+ *                  do better and its stale worker may even crash on the bytes;
+ *   - `failed`   — pdfjs could not open/parse the PDF (corrupt/encrypted). The
+ *                  caller may fall back to officeparser as a last resort.
+ */
+export type PdfExtractResult =
+  | { kind: 'text'; text: string }
+  | { kind: 'empty' }
+  | { kind: 'failed' };
+
+/**
+ * Extract plain text from a PDF buffer. Concatenates the text layer of every
+ * page and appends any AcroForm field values. Never throws — failures resolve
+ * to a `failed`/`empty` result the caller dispatches on (see
+ * {@link PdfExtractResult}).
+ */
+export async function extractPdfText(buf: Buffer): Promise<PdfExtractResult> {
+  let pdfjs: PdfjsModule;
+  try {
+    pdfjs = await loadPdfjs();
+  } catch {
+    // pdfjs failed to load (should not happen) — let the caller fall back.
+    return { kind: 'failed' };
+  }
+
+  // pdfjs takes ownership of the TypedArray it parses, so hand it a private
+  // copy (Buffer's backing ArrayBuffer may be shared/pooled by Node).
+  const data = new Uint8Array(buf.byteLength);
+  data.set(buf);
+
+  let doc: Awaited<ReturnType<PdfjsModule['getDocument']>['promise']> | null = null;
+  try {
+    doc = await pdfjs.getDocument({
+      data,
+      // Main-process, offline-only hardening:
+      useWorkerFetch: false, // never fetch worker assets over the network
+      isEvalSupported: false, // no eval() in the font/JS interpreter
+      disableFontFace: true, // we only want text, not rendering
+      // No standardFontDataUrl / cMapUrl: we intentionally do not fetch font or
+      // CMap data. Missing CMaps can drop the odd CJK glyph, but it keeps the
+      // path strictly offline and is far better than the empty-string failure.
+    }).promise;
+
+    const parts: string[] = [];
+
+    for (let p = 1; p <= doc.numPages; p++) {
+      const page = await doc.getPage(p);
+      try {
+        const content = await page.getTextContent();
+        const pageText = joinTextItems(content.items as TextItemLike[]);
+        if (pageText.trim().length > 0) parts.push(pageText);
+      } finally {
+        // Free per-page parse state so big PDFs don't accumulate memory.
+        page.cleanup();
+      }
+    }
+
+    // AcroForm field values (fillable forms keep data in fields, not the page
+    // content stream). getFieldObjects() returns a map of field name → entries.
+    try {
+      const fields = await doc.getFieldObjects();
+      const formText = fields ? collectFieldValues(fields) : '';
+      if (formText.trim().length > 0) parts.push(formText);
+    } catch {
+      /* no AcroForm / unreadable fields — ignore */
+    }
+
+    const text = parts
+      .join('\n\n')
+      .replace(/[ \t]+\n/g, '\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim();
+    // Opened fine: either we got text, or it's genuinely image-only (`empty`).
+    return text.length > 0 ? { kind: 'text', text } : { kind: 'empty' };
+  } catch {
+    // Corrupt / unsupported / encrypted PDF — let the caller fall back.
+    return { kind: 'failed' };
+  } finally {
+    // Always release the worker/parser resources.
+    await doc?.destroy().catch(() => {});
+  }
+}
+
+/**
+ * Join a page's text items into readable prose. pdfjs emits one item per text
+ * run; `hasEOL` marks the end of a visual line. We insert a newline on EOL and a
+ * space otherwise so words from adjacent runs don't fuse.
+ */
+function joinTextItems(items: readonly TextItemLike[]): string {
+  let out = '';
+  for (const it of items) {
+    const s = typeof it.str === 'string' ? it.str : '';
+    out += s;
+    if (it.hasEOL) out += '\n';
+    else if (s.length > 0 && !s.endsWith(' ')) out += ' ';
+  }
+  return out;
+}
+
+/**
+ * Pull human-readable values out of pdfjs's `getFieldObjects()` map. Each entry
+ * carries the field's current `value` (and for some widgets a `defaultValue`);
+ * we keep the field name alongside its value so the redactor sees the label too
+ * (e.g. "Full name: Jane Doe").
+ */
+function collectFieldValues(fields: Record<string, unknown>): string {
+  const lines: string[] = [];
+  for (const [name, entries] of Object.entries(fields)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      const value = fieldValue(entry);
+      if (value && value.trim().length > 0) {
+        const label = name.trim();
+        lines.push(label ? `${label}: ${value}` : value);
+      }
+    }
+  }
+  return lines.join('\n');
+}
+
+/** Best-effort read of a field entry's display value as a string. */
+function fieldValue(entry: unknown): string | null {
+  if (!entry || typeof entry !== 'object') return null;
+  const e = entry as { value?: unknown; defaultValue?: unknown };
+  const raw = e.value ?? e.defaultValue;
+  if (typeof raw === 'string') return raw;
+  if (typeof raw === 'number' || typeof raw === 'boolean') return String(raw);
+  if (Array.isArray(raw)) return raw.filter((v) => typeof v === 'string').join(', ');
+  return null;
+}

--- a/packages/desktop-host/src/pdfjs-worker.d.ts
+++ b/packages/desktop-host/src/pdfjs-worker.d.ts
@@ -1,0 +1,7 @@
+/**
+ * The pdfjs-dist worker is a side-effect-only ESM module (it registers the
+ * worker in the current realm so the main-thread "fake worker" can run — see
+ * {@link ../src/pdf-text.ts}). It ships no type declarations, so declare it as
+ * an empty module to satisfy the dynamic `import()`.
+ */
+declare module 'pdfjs-dist/legacy/build/pdf.worker.mjs';

--- a/packages/desktop-host/src/workspace-fs.test.ts
+++ b/packages/desktop-host/src/workspace-fs.test.ts
@@ -100,6 +100,27 @@ describe('readFile shaping', () => {
     expect(typeof r.base64).toBe('string');
   });
 
+  it('previews an Office/ODF doc as its extracted text, not raw bytes', async () => {
+    // RTF is an Office-family format parseBufferToText handles dependency-free,
+    // so it exercises the office-text branch without needing a real .docx zip.
+    const rtf = '{\\rtf1\\ansi\\deff0 Hello \\b Jane Doe\\b0 from Berlin.\\par}';
+    await writeFile(path.join(root, 'memo.rtf'), rtf);
+    const r = await readFile(root, 'memo.rtf');
+    expect(r.kind).toBe('text');
+    expect(r.text).toBe(true);
+    expect(r.content).toContain('Hello Jane Doe from Berlin');
+    // No RTF control words leak into the preview.
+    expect(r.content).not.toMatch(/\\rtf1|\\par/);
+  });
+
+  it('confirms (no preview) for an Office doc with no extractable text', async () => {
+    // A .docx that is not a valid zip → no text → a clear confirm, not garbage.
+    await writeFile(path.join(root, 'broken.docx'), Buffer.from('PK\x03\x04 not a real docx'));
+    const r = await readFile(root, 'broken.docx');
+    expect(r.kind).toBe('confirm');
+    expect(r.reason).toBe('binary');
+  });
+
   it('returns empty text for a non-file path', async () => {
     await mkdir(path.join(root, 'adir'));
     const r = await readFile(root, 'adir');

--- a/packages/desktop-host/src/workspace-fs.ts
+++ b/packages/desktop-host/src/workspace-fs.ts
@@ -32,6 +32,20 @@ const IMAGE_MEDIA_TYPES: Record<string, string> = {
   '.svg': 'image/svg+xml',
 };
 
+/** Office / OpenDocument extensions we preview as EXTRACTED TEXT rather than as
+ *  a confirm-gated binary blob (they are zip containers — raw bytes are useless
+ *  to a human). Text is pulled via the same offline parser the anonymizer uses. */
+const OFFICE_EXTENSIONS: ReadonlySet<string> = new Set([
+  '.docx',
+  '.xlsx',
+  '.pptx',
+  '.odt',
+  '.ods',
+  '.odp',
+  '.rtf',
+  '.doc',
+]);
+
 const HIDDEN_PREFIX = '.';
 const IGNORED_DIRS = new Set([
   'node_modules',
@@ -107,8 +121,9 @@ export interface ReadFileResult {
 
 /**
  * Read a workspace file for the "Open" viewer, with the SAME cwd-scoping +
- * symlink guard as {@link listDir}. Images render inline; text/code render as
- * UTF-8 (truncated past {@link MAX_READ_BYTES}). Anything that looks binary, or
+ * symlink guard as {@link listDir}. Images + PDFs render inline (base64);
+ * Office/ODF docs render as their EXTRACTED text; text/code render as UTF-8
+ * (truncated past {@link MAX_READ_BYTES}). Anything else that looks binary, or
  * is larger than {@link CONFIRM_BYTES}, returns `kind: 'confirm'` so the UI can
  * ask before opening (a huge blob decoded into the renderer can crash it) — a
  * `force` re-read then decodes it as text anyway. `relPath` must resolve inside
@@ -146,6 +161,27 @@ export async function readFile(
       mediaType: imageType ?? 'application/pdf',
       base64: buf.toString('base64'),
     };
+  }
+
+  // Office / OpenDocument (zip containers): the raw bytes are NUL-heavy binary,
+  // so the generic binary gate would only offer to show garbage. Instead pull
+  // the document's plain text via the offline parser and show THAT. Falls
+  // through to a clear "no preview" confirm if nothing extractable is found.
+  if (OFFICE_EXTENSIONS.has(ext)) {
+    if (byteLength > INLINE_MAX_BYTES && !opts.force) {
+      return { ...base, kind: 'confirm', reason: 'large', content: '', byteLength };
+    }
+    const buf = await fsReadFile(abs);
+    const { parseBufferToText } = await import('./attachments.js');
+    const text = await parseBufferToText(buf, path.basename(abs));
+    if (text && text.trim().length > 0) {
+      const truncated = Buffer.byteLength(text, 'utf8') > MAX_READ_BYTES;
+      const shown = truncated ? text.slice(0, MAX_READ_BYTES) : text;
+      return { ...base, kind: 'text', content: shown, truncated, text: true, byteLength };
+    }
+    // No extractable text (e.g. an image-only PDF or empty doc) — let the user
+    // know rather than dumping zip bytes into a <pre>.
+    return { ...base, kind: 'confirm', reason: 'binary', content: '', byteLength };
   }
 
   // Read only the head window via a handle, so a multi-GB file never loads whole.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -817,6 +817,9 @@ importers:
       officeparser:
         specifier: ~5.1.1
         version: 5.1.1
+      pdfjs-dist:
+        specifier: 4.10.38
+        version: 4.10.38
     devDependencies:
       '@moxxy/testing':
         specifier: workspace:*
@@ -4153,6 +4156,81 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.100':
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/keyring-darwin-arm64@1.3.0':
     resolution: {integrity: sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==}
@@ -8807,6 +8885,10 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pdfjs-dist@4.10.38:
+    resolution: {integrity: sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==}
+    engines: {node: '>=20'}
+
   pe-library@0.4.1:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
     engines: {node: '>=12', npm: '>=6'}
@@ -12759,6 +12841,54 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas@0.1.100':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    optional: true
 
   '@napi-rs/keyring-darwin-arm64@1.3.0':
     optional: true
@@ -18949,6 +19079,10 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  pdfjs-dist@4.10.38:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
 
   pe-library@0.4.1: {}
 


### PR DESCRIPTION
Follow-ups to the desktop-v0.12.0 fixes, all reported from the running app.

## 1. Header nav collapsed even on wide windows (regression in 0.12.0)
The responsive header collapse folded the nav groups into dropdowns even when there was plenty of room. Once collapsed, the live pill row unmounted, so the fit-measurer lost the natural width and the container shrink-wrapped the small collapsed button — `available` looked tiny and it could never tell it would fit again. Any transient narrow moment (the window opening, a resize) wedged it collapsed forever.

**Fix:** keep the inline row ALWAYS mounted as a hidden measuring layer (natural width, `flex-shrink:0`) inside a shrinkable clipping box. The fit check reads the true natural-vs-available width whether or not it's collapsed, so it collapses only when the row genuinely doesn't fit and re-expands the instant room returns. (6/6 ViewHeader tests pass.)

## 2. Remove the white-background brand GIF
`new-animation.gif`'s white matte can't be keyed transparent on the dark theme. Replaced every use (8 components) with the existing transparent static `logo.png`; the CSS bob animation is preserved, so the "working" feel stays.

## 3. Anonymizer "could not extract text" on a PDF
The user's `anonymizer_test_personal_details.pdf` turned out to be a **pure scanned-image PDF** (5 full-page JPEGs, no text layer, no form fields) — only OCR could read it, and it now says so clearly instead of a generic error. The broader fix: officeparser silently returned empty for many *text* PDFs, so added **`pdfjs-dist`** as the PDF extractor — concatenates page text **and** pulls AcroForm field values (forms store data in fields, not the content stream). Lazy-imported (only on PDF parse, never at boot) with a try/catch fallback, worker disabled (runs inline in the main process), bundler-safe.

## 4. Files-preview pane
Image/PDF preview already landed via #237 (data:/blob: URLs, Chromium PDFium). Closed the remaining gap: Office/ODF docs now show extracted text instead of garbled binary.

---

**Note:** the user's specific test PDF is image-only (scanned) and needs OCR to anonymize — out of scope here, but easy to add as a follow-up (tesseract.js, fitting the per-app install pattern) if wanted.

**Changesets:** `@moxxy/desktop` + `@moxxy/desktop-host` (patch) — drives a 0.12.x desktop follow-up release.

**Verification:** `pnpm build` 68/68 · `typecheck` 134/134 · `test` all suites (desktop-host 432, desktop incl. ViewHeader) · `lint` 0 errors · `check:deps` clean. pdfjs in the packaged main + a real text-PDF parse want a packaged run to confirm (graceful failure if not — it can't crash boot).