### PR TITLE
fix(surfaces): sharper + smoother in-window browser; region-capture to chat input

### DIFF
--- a/.changeset/browser-sharp-region-capture.md
+++ b/.changeset/browser-sharp-region-capture.md
@@ -1,0 +1,22 @@
+---
+"@moxxy/plugin-browser": patch
+"@moxxy/desktop": patch
+---
+
+fix(surfaces): sharper, smoother in-window browser + region-capture-to-chat
+
+**Sharpness.** The live view was blurry on HiDPI/Retina displays — it streamed a
+1× JPEG (quality 55) that the browser then upscaled into a 2× pane. The Playwright
+context now renders at `deviceScaleFactor: 2` and frames use JPEG quality 70, so
+text is crisp.
+
+**Less lag.** The poll interval dropped 450ms → 300ms (the `inFlight` guard still
+prevents pile-up), on top of the existing burst-frame-after-each-interaction.
+
+**Region capture → chat input (replaces element-pick).** The toolbar's selector
+button is now "Capture a region": drag a box over any part of the page and a sharp
+PNG of exactly that area is attached to the chat composer (with a "📎 added to the
+chat input" confirmation). You then describe the change and send — the agent SEES
+the pixels. This is more robust and usable than the old CSS-selector pick: it works
+for any content, not just DOM elements, and rides the normal attach→send flow. New
+sidecar `capture` method (clipped screenshot).

--- a/apps/desktop/src/shell/surfaces/BrowserPane.tsx
+++ b/apps/desktop/src/shell/surfaces/BrowserPane.tsx
@@ -1,15 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { api } from '@moxxy/client-core';
 import { Button, Icon, IconButton } from '@moxxy/desktop-ui';
+import { emitInsertPath } from '../WorkspaceFiles';
 import { useSurface } from './useSurface';
-
-/** An element the user pointed at in "select element" mode (from the `pick`
- *  sidecar method) — handed to the agent to act on. */
-interface PickedElement {
-  readonly selector: string;
-  readonly tag: string;
-  readonly text: string;
-}
 
 interface BrowserFrame {
   readonly type?: string;
@@ -21,8 +14,16 @@ interface BrowserFrame {
   /** Set on a status when the Playwright engine isn't installed — the pane shows
    *  an "Install" button (the download is ~200MB, so we ask first). */
   readonly needsInstall?: boolean;
-  /** Carried by `{ type: 'picked' }` — the element under the user's click. */
-  readonly element?: PickedElement | null;
+  /** Carried by `{ type: 'captured' }` — a PNG of the dragged region. */
+  readonly mediaType?: string;
+}
+
+/** A drag rectangle in pane-relative pixels (region-capture mode). */
+interface DragRect {
+  readonly x0: number;
+  readonly y0: number;
+  readonly x1: number;
+  readonly y1: number;
 }
 
 const ZOOM_MIN = 0.25;
@@ -69,11 +70,10 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
   const [url, setUrl] = useState('');
   const [editingUrl, setEditingUrl] = useState('');
   const [zoom, setZoom] = useState(1);
-  // "Select element" mode: the next click picks an element instead of clicking.
-  const [picking, setPicking] = useState(false);
-  const [picked, setPicked] = useState<PickedElement | null>(null);
-  const [change, setChange] = useState('');
-  const [sent, setSent] = useState(false);
+  // Region-capture mode: drag a box, screenshot it, attach to the chat input.
+  const [capturing, setCapturing] = useState(false);
+  const [drag, setDrag] = useState<DragRect | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const hostRef = useRef<HTMLDivElement | null>(null);
   const urlInputRef = useRef<HTMLInputElement | null>(null);
   const lastMoveRef = useRef(0);
@@ -94,12 +94,8 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
         setNeedsInstall(true);
         setInstalling(false);
       }
-    } else if (p?.type === 'picked') {
-      if (p.element) {
-        setPicked(p.element);
-        setChange('');
-        setSent(false);
-      }
+    } else if (p?.type === 'captured' && typeof p.base64 === 'string') {
+      void attachCapture(p.base64, p.mediaType);
     }
     if (typeof p?.url === 'string') {
       setUrl(p.url);
@@ -170,19 +166,27 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
     surface.input({ type: 'zoom', factor: z });
   };
 
-  // Task the agent to change the picked element (localhost dev loop). The agent's
-  // browser_session tool can act on the selector we captured.
-  const askAgent = (): void => {
-    if (!picked || !workspaceId) return;
-    const what = change.trim();
-    if (!what) return;
-    const where = url ? ` on ${url}` : '';
-    const ctx = picked.text ? ` (currently "${picked.text}")` : '';
-    const prompt = `Using the browser, change the element \`${picked.selector}\`${ctx}${where} to: ${what}`;
-    void api().invoke('session.runTurn', { workspaceId, prompt }).catch(() => undefined);
-    setSent(true);
-    setPicked(null);
-    setChange('');
+  const flashNotice = (text: string): void => {
+    setNotice(text);
+    window.setTimeout(() => setNotice((cur) => (cur === text ? null : cur)), 4000);
+  };
+
+  // The captured region (a sharp PNG) is saved to a temp file and dropped into
+  // the chat composer as an attachment — the user then describes the change and
+  // sends, and the agent SEES the area. Reuses the same insert event the file
+  // tree uses, so the chip appears in the (visible) composer.
+  const attachCapture = async (base64: string, mediaType?: string): Promise<void> => {
+    try {
+      const att = await api().invoke('session.saveImageAttachment', {
+        dataBase64: base64,
+        mediaType: mediaType ?? 'image/png',
+        name: 'browser-capture.png',
+      });
+      emitInsertPath({ relPath: att.name, absPath: att.path, name: att.name });
+      flashNotice('📎 Screenshot added to the chat input — describe the change and send.');
+    } catch {
+      flashNotice('Could not attach the screenshot.');
+    }
   };
 
   // Pointer event → normalized page coords (0..1 of the frame box).
@@ -190,6 +194,13 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
     const rect = hostRef.current?.getBoundingClientRect();
     if (!rect || rect.width === 0 || rect.height === 0) return null;
     return { fx: (e.clientX - rect.left) / rect.width, fy: (e.clientY - rect.top) / rect.height };
+  };
+
+  // Pointer event → pane-relative px (for the drag-selection overlay).
+  const relPos = (e: React.MouseEvent): { x: number; y: number } | null => {
+    const rect = hostRef.current?.getBoundingClientRect();
+    if (!rect) return null;
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top };
   };
 
   const onHover = (e: React.MouseEvent): void => {
@@ -220,9 +231,10 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
         return;
       }
     }
-    if (e.key === 'Escape' && picking) {
+    if (e.key === 'Escape' && capturing) {
       e.preventDefault();
-      setPicking(false);
+      setCapturing(false);
+      setDrag(null);
       return;
     }
     const printable = e.key.length === 1;
@@ -323,86 +335,43 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
             <span style={{ fontSize: 14, lineHeight: 1 }}>+</span>
           </IconButton>
         </div>
-        {/* "Select element" — pick an element on the page to hand to the agent. */}
+        {/* "Capture region" — drag a box; the screenshot is attached to the chat
+         *  input so you can ask the agent to change exactly that area. */}
         <IconButton
           size={26}
-          bordered={picking}
-          onClick={() => setPicking((v) => !v)}
-          title={picking ? 'Click an element to select it (Esc to cancel)' : 'Select an element for the agent'}
-          aria-label="Select element"
-          style={picking ? { color: 'var(--color-primary)' } : undefined}
+          bordered={capturing}
+          onClick={() => {
+            setCapturing((v) => !v);
+            setDrag(null);
+          }}
+          title={
+            capturing
+              ? 'Drag a box to capture it for the agent (Esc to cancel)'
+              : 'Capture a region for the agent'
+          }
+          aria-label="Capture region"
+          style={capturing ? { color: 'var(--color-primary)' } : undefined}
         >
-          <Icon name="context" size={14} />
+          <Icon name="attach" size={14} />
         </IconButton>
       </div>
 
-      {/* Picked element → task the agent to change it (localhost dev loop). */}
-      {(picked || sent) && (
+      {/* Capture mode hint / "added to chat input" confirmation. */}
+      {(capturing || notice) && (
         <div
           style={{
             display: 'flex',
             alignItems: 'center',
-            gap: 8,
-            padding: '8px 10px',
+            gap: 6,
+            padding: '6px 12px',
+            fontSize: 12,
+            color: notice ? 'var(--color-green)' : 'var(--color-text-muted)',
             borderBottom: '1px solid var(--color-card-border)',
             background: 'var(--color-input-soft)',
             flexShrink: 0,
           }}
         >
-          {sent && !picked ? (
-            <span style={{ fontSize: 12, color: 'var(--color-green)' }}>
-              ✓ Asked the agent — see the Chat tab for the response.
-            </span>
-          ) : (
-            <>
-              <Icon name="context" size={13} />
-              <code
-                title={picked?.selector}
-                style={{
-                  fontSize: 11,
-                  color: 'var(--color-text-muted)',
-                  maxWidth: 200,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  flexShrink: 0,
-                }}
-              >
-                {picked?.selector}
-              </code>
-              <input
-                value={change}
-                onChange={(e) => setChange(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault();
-                    askAgent();
-                  } else if (e.key === 'Escape') {
-                    setPicked(null);
-                  }
-                }}
-                autoFocus
-                placeholder="Describe the change for the agent… (e.g. make it blue)"
-                style={{
-                  flex: 1,
-                  minWidth: 0,
-                  padding: '5px 10px',
-                  fontSize: 12,
-                  color: 'var(--color-text)',
-                  border: '1px solid var(--color-card-border)',
-                  borderRadius: 8,
-                  background: 'var(--color-surface)',
-                  outline: 'none',
-                }}
-              />
-              <Button variant="primary" size="sm" onClick={askAgent} disabled={change.trim().length === 0}>
-                Ask agent
-              </Button>
-              <IconButton size={22} onClick={() => setPicked(null)} title="Dismiss" aria-label="Dismiss">
-                <Icon name="x" size={13} />
-              </IconButton>
-            </>
-          )}
+          {notice ?? 'Drag a box over the area to capture for the agent — Esc to cancel.'}
         </div>
       )}
 
@@ -416,23 +385,56 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
       <div
         ref={hostRef}
         tabIndex={0}
-        onMouseDown={() => hostRef.current?.focus()}
-        onClick={(e) => {
-          const n = norm(e);
-          if (!n) return;
-          if (picking) {
-            // Capture the element instead of clicking it through to the page.
-            surface.input({ type: 'pick', ...n });
-            setPicking(false);
-          } else {
-            surface.input({ type: 'click', ...n });
+        onMouseDown={(e) => {
+          if (capturing) {
+            const p = relPos(e);
+            if (p) {
+              e.preventDefault();
+              setDrag({ x0: p.x, y0: p.y, x1: p.x, y1: p.y });
+            }
+            return;
           }
+          hostRef.current?.focus();
+        }}
+        onMouseMove={(e) => {
+          if (capturing) {
+            if (drag) {
+              const p = relPos(e);
+              if (p) setDrag((d) => (d ? { ...d, x1: p.x, y1: p.y } : d));
+            }
+            return;
+          }
+          if (hasView) onHover(e);
+        }}
+        onMouseUp={() => {
+          if (!capturing || !drag) return;
+          const rect = hostRef.current?.getBoundingClientRect();
+          setDrag(null);
+          setCapturing(false);
+          if (!rect || rect.width === 0 || rect.height === 0) return;
+          const minX = Math.min(drag.x0, drag.x1);
+          const minY = Math.min(drag.y0, drag.y1);
+          const w = Math.abs(drag.x1 - drag.x0);
+          const h = Math.abs(drag.y1 - drag.y0);
+          if (w < 6 || h < 6) return; // too small — treat as a stray click
+          surface.input({
+            type: 'capture',
+            fx: minX / rect.width,
+            fy: minY / rect.height,
+            fw: w / rect.width,
+            fh: h / rect.height,
+          });
+        }}
+        onClick={(e) => {
+          if (capturing) return; // drag handles capture mode
+          const n = norm(e);
+          if (n) surface.input({ type: 'click', ...n });
         }}
         onDoubleClick={(e) => {
+          if (capturing) return;
           const n = norm(e);
           if (n) surface.input({ type: 'dblclick', ...n });
         }}
-        onMouseMove={hasView ? onHover : undefined}
         onWheel={(e) => surface.input({ type: 'scroll', dy: e.deltaY })}
         onKeyDown={onKeyDown}
         style={{
@@ -442,9 +444,25 @@ export function BrowserPane({ workspaceId }: { readonly workspaceId: string | nu
           overflow: 'hidden',
           background: '#0b0f17',
           outline: 'none',
-          cursor: picking ? 'crosshair' : 'default',
+          cursor: capturing ? 'crosshair' : 'default',
         }}
       >
+        {/* Drag-selection overlay (region capture). */}
+        {drag && (
+          <div
+            style={{
+              position: 'absolute',
+              left: Math.min(drag.x0, drag.x1),
+              top: Math.min(drag.y0, drag.y1),
+              width: Math.abs(drag.x1 - drag.x0),
+              height: Math.abs(drag.y1 - drag.y0),
+              border: '2px solid var(--color-primary)',
+              background: 'color-mix(in srgb, var(--color-primary) 14%, transparent)',
+              pointerEvents: 'none',
+              zIndex: 2,
+            }}
+          />
+        )}
         {hasView ? (
           <img
             src={frame ?? undefined}

--- a/packages/plugin-browser/src/browser-surface.test.ts
+++ b/packages/plugin-browser/src/browser-surface.test.ts
@@ -12,8 +12,8 @@ import { closeBrowserSidecar, type SidecarStream } from './browser-session.js';
  * input coordinate de-normalization are exercised without Playwright.
  */
 
-const FRAME_INTERVAL_MS = 450;
-const FAIL_GRACE = 4;
+const FRAME_INTERVAL_MS = 300;
+const FAIL_GRACE = 6;
 
 type Reply = { ok: true; result: unknown } | { ok: false; message: string; kind?: string };
 
@@ -291,30 +291,32 @@ describe('browser surface input mapping', () => {
     surface.close();
   });
 
-  it('zoom forwards the factor; pick maps coords and emits the element', async () => {
+  it('zoom forwards the factor; capture maps the region and emits the PNG', async () => {
     vi.useFakeTimers();
     const sidecar = makeControllableSpawn();
     sidecar.setHandler((method) => {
       if (method === 'frame') return { ok: true, result: frame({ width: 1000, height: 500 }) };
-      if (method === 'pick') return { ok: true, result: { selector: 'button#go', tag: 'button', text: 'Go' } };
+      if (method === 'capture') return { ok: true, result: { mediaType: 'image/png', base64: 'PNGDATA' } };
       return { ok: true, result: {} };
     });
     const surface = buildBrowserSurface({ sidecarPath: '/fake.js', spawnFn: sidecar.spawn }).open();
-    const events: Array<{ type: string; element?: unknown }> = [];
+    const events: Array<{ type: string; base64?: string }> = [];
     surface.onData((p) => events.push(p as { type: string }));
     await flush();
 
     await surface.input({ type: 'zoom', factor: 1.5 });
-    await surface.input({ type: 'pick', fx: 0.5, fy: 0.2 });
+    await surface.input({ type: 'capture', fx: 0.1, fy: 0.2, fw: 0.5, fh: 0.4 });
     await flush();
 
     expect(sidecar.received.find((r) => r.method === 'zoom')?.params).toEqual({ factor: 1.5 });
-    expect(sidecar.received.find((r) => r.method === 'pick')?.params).toEqual({ x: 500, y: 100 });
-    expect(events.find((e) => e.type === 'picked')?.element).toEqual({
-      selector: 'button#go',
-      tag: 'button',
-      text: 'Go',
+    // normalized region × viewport (1000×500) → CSS px clip.
+    expect(sidecar.received.find((r) => r.method === 'capture')?.params).toEqual({
+      x: 100,
+      y: 100,
+      width: 500,
+      height: 200,
     });
+    expect(events.find((e) => e.type === 'captured')?.base64).toBe('PNGDATA');
     surface.close();
   });
 

--- a/packages/plugin-browser/src/browser-surface.ts
+++ b/packages/plugin-browser/src/browser-surface.ts
@@ -27,10 +27,10 @@ import { installPlaywrightPackage } from './sidecar/install.js';
  * Chromium.
  */
 
-const FRAME_INTERVAL_MS = 450;
+const FRAME_INTERVAL_MS = 300;
 /** Consecutive `frame` failures (with no frame ever seen) before we stop
- *  assuming "still launching" and show the error. ~4 × 450ms ≈ 1.8s grace. */
-const FAIL_GRACE = 4;
+ *  assuming "still launching" and show the error. ~6 × 300ms ≈ 1.8s grace. */
+const FAIL_GRACE = 6;
 
 interface Frame {
   mediaType: string;
@@ -213,13 +213,21 @@ export function buildBrowserSurface(deps?: BrowserSessionDeps) {
               () => undefined,
             );
             void tick();
-          } else if (msg.type === 'pick' && typeof msg.fx === 'number' && typeof msg.fy === 'number') {
-            // Identify the element the user pointed at and hand it back to the
-            // pane (which lets the user task the agent to change it).
-            const element = await browserSidecarCall('pick', { x: msg.fx * vw, y: msg.fy * vh }, deps).catch(
-              () => null,
-            );
-            emit({ type: 'picked', element });
+          } else if (
+            msg.type === 'capture' &&
+            typeof msg.fx === 'number' &&
+            typeof msg.fy === 'number' &&
+            typeof msg.fw === 'number' &&
+            typeof msg.fh === 'number'
+          ) {
+            // Sharp PNG of the dragged region → handed back to the pane, which
+            // attaches it to the chat composer (the user then describes the change).
+            const shot = (await browserSidecarCall(
+              'capture',
+              { x: msg.fx * vw, y: msg.fy * vh, width: msg.fw * vw, height: msg.fh * vh },
+              deps,
+            ).catch(() => null)) as { base64: string; mediaType: string } | null;
+            if (shot) emit({ type: 'captured', base64: shot.base64, mediaType: shot.mediaType });
           } else if (msg.type === 'zoom' && typeof msg.factor === 'number') {
             await browserSidecarCall('zoom', { factor: msg.factor }, deps).catch(() => undefined);
             bump();

--- a/packages/plugin-browser/src/sidecar/dispatch.ts
+++ b/packages/plugin-browser/src/sidecar/dispatch.ts
@@ -142,7 +142,10 @@ async function dispatchInner(state: SidecarState, req: Req): Promise<Reply> {
       // plus the current url + viewport size, so the renderer can map clicks
       // back onto the page. One round-trip per frame.
       const h = await ensurePlaywright(state, {});
-      const buf = await h.page.screenshot({ type: 'jpeg', quality: 55 });
+      // quality 70 (was 55) + the context's deviceScaleFactor:2 = legible text in
+      // the live view. Reports the CSS viewport size (the image is 2× that) so the
+      // renderer keeps mapping clicks in CSS coords.
+      const buf = await h.page.screenshot({ type: 'jpeg', quality: 70 });
       const vp = h.page.viewportSize() ?? { width: 1280, height: 720 };
       return {
         id: req.id,
@@ -223,6 +226,23 @@ async function dispatchInner(state: SidecarState, req: Req): Promise<Reply> {
       const h = await ensurePlaywright(state, {});
       await h.page.evaluate(`document.documentElement.style.zoom=String(${f})`);
       return { id: req.id, ok: true };
+    }
+    case 'capture': {
+      // Sharp PNG of a region the user dragged — attached to the chat composer so
+      // the agent SEES the area ("change this to …"). Coords are CSS px; the
+      // context's deviceScaleFactor:2 makes the PNG 2× → crisp.
+      const { x, y, width, height } = (req.params ?? {}) as {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+      };
+      if (![x, y, width, height].every((n) => Number.isFinite(n)) || width < 1 || height < 1) {
+        throw badParams('x, y, width, height must be finite; width/height positive');
+      }
+      const h = await ensurePlaywright(state, {});
+      const buf = await h.page.screenshot({ type: 'png', clip: { x, y, width, height } });
+      return { id: req.id, ok: true, result: { mediaType: 'image/png', base64: buf.toString('base64') } };
     }
     case 'pick': {
       // Identify the element at (x,y) so the user can hand it to the agent

--- a/packages/plugin-browser/src/sidecar/install.ts
+++ b/packages/plugin-browser/src/sidecar/install.ts
@@ -149,7 +149,10 @@ export async function launchWithAutoInstall(
 
 async function launchOnce(browserType: BrowserType, headless: boolean): Promise<PlaywrightHandle> {
   const browser = await browserType.launch({ headless });
-  const context = (await browser.newContext()) as PlaywrightHandle['context'];
+  // deviceScaleFactor: 2 so the live-view / region screenshots are captured at
+  // Retina density — a 1× capture upscaled into a HiDPI pane is what made the
+  // surface look blurry. Costs ~2× the screenshot bytes; worth it for crisp text.
+  const context = (await browser.newContext({ deviceScaleFactor: 2 })) as PlaywrightHandle['context'];
   await installNavigationSsrfGuard(context);
   const page = (await context.newPage()) as unknown as PageHandle;
   return { browser, context, page };

--- a/packages/plugin-browser/src/sidecar/types.ts
+++ b/packages/plugin-browser/src/sidecar/types.ts
@@ -33,7 +33,7 @@ export type Reply = Ok | Err;
 export interface BrowserType {
   launch(opts: {
     headless: boolean;
-  }): Promise<{ close(): Promise<void>; newContext(): Promise<unknown> }>;
+  }): Promise<{ close(): Promise<void>; newContext(opts?: unknown): Promise<unknown> }>;
 }
 
 export interface PageHandle {


### PR DESCRIPTION
## What

Addresses the browser feedback: blurry, laggy, and the element-select being unusable.

**Sharpness (blur fix).** On Retina the live view streamed a 1× JPEG (q55) upscaled into a 2× pane → soft text. The Playwright context now renders at `deviceScaleFactor: 2` and frames use JPEG quality 70 → crisp.

**Less lag.** Poll interval 450ms → 300ms (the `inFlight` guard still prevents pile-up), on top of the existing burst-frame-after-each-interaction.

**Region capture → chat input** (replaces the CSS-selector element pick). The toolbar tool is now **"Capture a region"**: drag a box over any part of the page and a sharp PNG of exactly that area is attached to the chat composer, with a **"📎 added to the chat input"** confirmation. You then describe the change and send — the agent *sees* the pixels. More robust + usable than a selector (works for any content, rides the normal attach→send flow). New sidecar `capture` (clipped screenshot) + drag-selection overlay.

Note: zoom (⌘±/⌘0 + toolbar) shipped in #242 and works once the runner is on that build — the "zoom doesn't work" report was the running app still using the older CLI runner.

## Verification

- `pnpm build` 68/68, `pnpm -w typecheck` 134/134, `pnpm check:deps` clean (998 modules), lint 0 errors.
- Tests: plugin-browser 84 (updated coverage: zoom forwards factor; capture maps the region → emits the PNG), desktop 263 (BrowserPane keyboard test still green). Full `turbo run test` green.
- Changeset included.