### PR TITLE
feat: Dual-history consolidation: runner-authoritative paged history

### DIFF
--- a/.changeset/runner-load-history-paging.md
+++ b/.changeset/runner-load-history-paging.md
@@ -1,0 +1,33 @@
+---
+"@moxxy/core": minor
+"@moxxy/cli": patch
+---
+
+feat(runner): paged `session.loadHistory` + complete authoritative log
+
+Add the runner-side foundation for retiring the desktop's dual chat history (the
+renderer will later read transcript history from the runner instead of its own
+NDJSON store).
+
+- New runner protocol method `session.loadHistory` ({ before, limit } →
+  { events, prevCursor }) — newest-first paging over the runner's authoritative
+  event history. Bumps `RUNNER_PROTOCOL_VERSION` to 10; the change is purely
+  additive, so `MIN_COMPATIBLE_PROTOCOL_VERSION` stays at 1 and an older client
+  still attaches. `RemoteSession.loadHistory` gates the call on the server
+  reporting v10+ and throws a clear, actionable "update the CLI" error against
+  an older runner — which the desktop catches to fall back to its existing
+  NDJSON path, so no transcript ever goes blank. The desktop FLOOR is
+  intentionally NOT raised (the fallback keeps an older runner working); the
+  release-build lockstep guard now allows the floor to lag an additive,
+  version-gated runner bump.
+- `@moxxy/core` gains a PAGED JSONL reader (`readSessionEventPage` + the pure
+  `pageEvents` helper) that reads one `(before, limit)` page WITHOUT
+  re-materializing the whole log, so `loadHistory` works even when the log isn't
+  all in memory. Read-only — it preserves persistence's atomic-write + mutex
+  invariants (it never mutates the file).
+- Log completeness: when a turn streams assistant text but the provider never
+  seals it with an `assistant_message` (e.g. an error/abort mid-stream — the
+  case the renderer used to paper over by synthesizing a message that lived in
+  no runner log), the runner now persists a REAL `assistant_message` on turn
+  completion so its log is the complete authoritative history. Behavior-
+  preserving for the normal sealed path.

--- a/.changeset/runner-load-history-paging.md
+++ b/.changeset/runner-load-history-paging.md
@@ -1,5 +1,6 @@
 ---
 "@moxxy/core": minor
+"@moxxy/runner": patch
 "@moxxy/cli": patch
 ---
 

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -100,6 +100,16 @@ that must not be rushed, because rushing it would *lower* quality, not raise it:
 3. **Dual on-disk history consolidation** — likewise a designed, deferred decision
    (the NDJSON store is the renderer's only history source under `replay:'none'`;
    consolidating means migrating to paged runner-log reads, with real counter-risks).
+   **Runner-side foundation landed (2026-06-18):** runner protocol v10 adds the
+   paged `session.loadHistory` ({ before, limit } → { events, prevCursor }) backed
+   by a core paged-JSONL reader (`readSessionEventPage`/`pageEvents`), and the
+   runner now seals stream-without-seal turns into a REAL `assistant_message` so
+   its log is the complete authoritative history (no more renderer-only synth).
+   The client method is version-gated (`requireServerProtocol(10)`); against an
+   older runner it throws an actionable error the renderer can catch to fall back
+   to NDJSON, and the desktop FLOOR was deliberately NOT raised. **Remaining:** the
+   renderer migration to read history from the runner (with the NDJSON read
+   fallback retained) — a separate desktop-facing PR.
 4. **One-shot CLI exit hygiene** (`moxxy -p` / `schedule run` / `doctor` / `login` /
    `init` boot a full session and never `close()`) — minor; a correct fix must drain
    persistence before exit (premature exit would drop the last event).

--- a/apps/desktop/electron/main/floor-runner-protocol.test.ts
+++ b/apps/desktop/electron/main/floor-runner-protocol.test.ts
@@ -3,13 +3,21 @@ import { RUNNER_PROTOCOL_VERSION } from '@moxxy/runner';
 import { FLOOR_RUNNER_PROTOCOL } from './floor-runner-protocol';
 
 // Lockstep guard (catches in normal CI what build-app-bundle.mjs's assertion
-// otherwise only catches at release time): the desktop's baked floor protocol
-// MUST equal the runner's current protocol. When you bump
-// RUNNER_PROTOCOL_VERSION, bump FLOOR_RUNNER_PROTOCOL in the same change — this
-// test fails otherwise (as the desktop release build did when v5 shipped with
-// the floor left at 4).
+// otherwise only catches at release time). The desktop's baked floor protocol
+// must never EXCEED the runner's current protocol — a floor above the runner
+// means the desktop would reject the runner it ships with (the bug that bricked
+// the v5 release when the floor was left at 4).
+//
+// The floor is allowed to LAG the runner only when the newer protocol is purely
+// ADDITIVE and every new method is version-gated with a graceful fallback (e.g.
+// v10 `session.loadHistory`: the renderer falls back to its NDJSON store against
+// a <v10 runner, so the desktop must keep accepting a v9 runner — raising the
+// floor to 10 would wrongly reject it and reintroduce the hot-update skew bug).
+// A BREAKING protocol change must instead raise BOTH the floor and the runner's
+// MIN_COMPATIBLE in the same change. This mirrors build-app-bundle.mjs's
+// FLOOR <= RUNNER_PROTOCOL_VERSION guard.
 describe('FLOOR_RUNNER_PROTOCOL', () => {
-  it('equals @moxxy/runner RUNNER_PROTOCOL_VERSION', () => {
-    expect(FLOOR_RUNNER_PROTOCOL).toBe(RUNNER_PROTOCOL_VERSION);
+  it('never exceeds @moxxy/runner RUNNER_PROTOCOL_VERSION', () => {
+    expect(FLOOR_RUNNER_PROTOCOL).toBeLessThanOrEqual(RUNNER_PROTOCOL_VERSION);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,9 +56,12 @@ export {
   defaultSessionsDir,
   readIndex as readSessionIndex,
   restoreEvents as restoreSessionEvents,
+  readEventPage as readSessionEventPage,
+  pageEvents,
   deleteSession,
   type SessionMeta,
   type SessionPersistenceOpts,
+  type EventPage,
 } from './sessions/persistence.js';
 export {
   PluginHost,

--- a/packages/core/src/sessions/page.test.ts
+++ b/packages/core/src/sessions/page.test.ts
@@ -130,6 +130,20 @@ describe('readEventPage (paged JSONL reader)', () => {
     });
   });
 
+  it('agrees with pageEvents on an empty/missing log for any before/limit (incl. limit 0)', async () => {
+    // The disk reader delegates clamping to pageEvents, so the two paths cannot
+    // diverge — pin it, including the limit===0 corner the wire schema forbids
+    // but a direct in-process caller could still hit.
+    const dir = await makeTempDir();
+    for (const before of [null, 5] as const) {
+      for (const limit of [0, 3]) {
+        await expect(readEventPage('missing', { before, limit }, dir)).resolves.toEqual(
+          pageEvents([], before, limit),
+        );
+      }
+    }
+  });
+
   it('skips a corrupt line and pages the survivors deterministically', async () => {
     const dir = await makeTempDir();
     const id = 'disk4';

--- a/packages/core/src/sessions/page.test.ts
+++ b/packages/core/src/sessions/page.test.ts
@@ -1,0 +1,165 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { MoxxyEvent } from '@moxxy/sdk';
+import { pageEvents, readEventPage } from './persistence.js';
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-page-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+/** A contiguous 0..n-1 log of user_prompt events with predictable text. */
+function makeLog(n: number, sessionId = 'pagesession'): MoxxyEvent[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `e${i}`,
+    seq: i,
+    ts: i,
+    sessionId,
+    turnId: `t${i}`,
+    source: 'user',
+    type: 'user_prompt',
+    text: `m${i}`,
+  })) as unknown as MoxxyEvent[];
+}
+
+async function writeLog(dir: string, id: string, events: MoxxyEvent[]): Promise<void> {
+  const body = events.map((e) => JSON.stringify(e) + '\n').join('');
+  await fs.writeFile(path.join(dir, `${id}.jsonl`), body, 'utf8');
+}
+
+describe('pageEvents (pure newest-first paging)', () => {
+  it('newest page (before=null) returns the last `limit` events with a prevCursor', () => {
+    const log = makeLog(10);
+    const page = pageEvents(log, null, 3);
+    expect(page.events.map((e) => e.seq)).toEqual([7, 8, 9]);
+    // prevCursor is the seq of the oldest event in THIS page → pass it next.
+    expect(page.prevCursor).toBe(7);
+  });
+
+  it('older page via prevCursor returns the events immediately preceding it', () => {
+    const log = makeLog(10);
+    const newest = pageEvents(log, null, 3); // [7,8,9], prevCursor 7
+    const older = pageEvents(log, newest.prevCursor, 3);
+    expect(older.events.map((e) => e.seq)).toEqual([4, 5, 6]);
+    expect(older.prevCursor).toBe(4);
+  });
+
+  it('prevCursor is null once the page includes the start of history', () => {
+    const log = makeLog(5);
+    // Walk back from the newest until the start is reached.
+    const p1 = pageEvents(log, null, 2); // [3,4] cursor 3
+    expect(p1.prevCursor).toBe(3);
+    const p2 = pageEvents(log, p1.prevCursor, 2); // [1,2] cursor 1
+    expect(p2.events.map((e) => e.seq)).toEqual([1, 2]);
+    expect(p2.prevCursor).toBe(1);
+    const p3 = pageEvents(log, p2.prevCursor, 2); // [0] — start reached
+    expect(p3.events.map((e) => e.seq)).toEqual([0]);
+    expect(p3.prevCursor).toBeNull();
+  });
+
+  it('limit larger than history returns the whole log and a null cursor', () => {
+    const log = makeLog(4);
+    const page = pageEvents(log, null, 100);
+    expect(page.events.map((e) => e.seq)).toEqual([0, 1, 2, 3]);
+    expect(page.prevCursor).toBeNull();
+  });
+
+  it('empty log returns no events and a null cursor regardless of before', () => {
+    expect(pageEvents([], null, 5)).toEqual({ events: [], prevCursor: null });
+    expect(pageEvents([], 3, 5)).toEqual({ events: [], prevCursor: null });
+  });
+
+  it('walking all pages reconstructs the full log exactly once, in order', () => {
+    const log = makeLog(23);
+    const collected: number[] = [];
+    let before: number | null = null;
+    // Guard the loop so a paging bug can't spin forever.
+    for (let guard = 0; guard < 100; guard += 1) {
+      const page: ReturnType<typeof pageEvents> = pageEvents(log, before, 5);
+      collected.unshift(...page.events.map((e) => e.seq));
+      if (page.prevCursor === null) break;
+      before = page.prevCursor;
+    }
+    expect(collected).toEqual(log.map((e) => e.seq));
+  });
+});
+
+describe('readEventPage (paged JSONL reader)', () => {
+  it('pages the newest events off disk without materializing the whole log', async () => {
+    const dir = await makeTempDir();
+    const id = 'disk1';
+    await writeLog(dir, id, makeLog(8, id));
+    const page = await readEventPage(id, { before: null, limit: 3 }, dir);
+    expect(page.events.map((e) => (e as { text?: string }).text)).toEqual(['m5', 'm6', 'm7']);
+    expect(page.prevCursor).toBe(5);
+  });
+
+  it('steps to the older page via prevCursor', async () => {
+    const dir = await makeTempDir();
+    const id = 'disk2';
+    await writeLog(dir, id, makeLog(8, id));
+    const newest = await readEventPage(id, { before: null, limit: 3 }, dir);
+    const older = await readEventPage(id, { before: newest.prevCursor, limit: 3 }, dir);
+    expect(older.events.map((e) => e.seq)).toEqual([2, 3, 4]);
+    expect(older.prevCursor).toBe(2);
+  });
+
+  it('returns prevCursor=null at the start of history', async () => {
+    const dir = await makeTempDir();
+    const id = 'disk3';
+    await writeLog(dir, id, makeLog(3, id));
+    const page = await readEventPage(id, { before: 1, limit: 10 }, dir);
+    expect(page.events.map((e) => e.seq)).toEqual([0]);
+    expect(page.prevCursor).toBeNull();
+  });
+
+  it('treats a missing log file as empty history (no throw)', async () => {
+    const dir = await makeTempDir();
+    await expect(readEventPage('never-written', { before: null, limit: 5 }, dir)).resolves.toEqual({
+      events: [],
+      prevCursor: null,
+    });
+  });
+
+  it('skips a corrupt line and pages the survivors deterministically', async () => {
+    const dir = await makeTempDir();
+    const id = 'disk4';
+    const events = makeLog(5, id);
+    const body =
+      events
+        .slice(0, 2)
+        .map((e) => JSON.stringify(e) + '\n')
+        .join('') +
+      '{not json\n' +
+      events
+        .slice(2)
+        .map((e) => JSON.stringify(e) + '\n')
+        .join('');
+    await fs.writeFile(path.join(dir, `${id}.jsonl`), body, 'utf8');
+    const page = await readEventPage(id, { before: null, limit: 10 }, dir);
+    // The corrupt line is dropped; the four survivors page in seq order.
+    expect(page.events.map((e) => e.seq)).toEqual([0, 1, 2, 3, 4]);
+    expect(page.prevCursor).toBeNull();
+  });
+
+  it('does NOT rewrite the file on disk (read-only reader)', async () => {
+    const dir = await makeTempDir();
+    const id = 'disk5';
+    // A gapped/corrupt log — restoreEvents would repair it, readEventPage must not.
+    const body = '{corrupt\n' + makeLog(2, id).map((e) => JSON.stringify(e) + '\n').join('');
+    await fs.writeFile(path.join(dir, `${id}.jsonl`), body, 'utf8');
+    const before = await fs.readFile(path.join(dir, `${id}.jsonl`), 'utf8');
+    await readEventPage(id, { before: null, limit: 10 }, dir);
+    const after = await fs.readFile(path.join(dir, `${id}.jsonl`), 'utf8');
+    expect(after).toBe(before);
+  });
+});

--- a/packages/core/src/sessions/persistence.ts
+++ b/packages/core/src/sessions/persistence.ts
@@ -496,8 +496,12 @@ export interface EventPage {
  * Corrupt lines are skipped (matching {@link restoreEvents}); unlike
  * `restoreEvents` this is a READ-ONLY reader — it never rewrites the file, so
  * it preserves the JSONL exactly (no atomic-write / mutex needed: there is no
- * mutation). Paging keys on each event's on-disk `seq`, so a not-yet-repaired
- * gapped log still pages deterministically (the next resume repairs it).
+ * mutation). Paging keys on each event's on-disk `seq`. Determinism holds for a
+ * MONOTONICALLY-INCREASING seq sequence — including a gapped-but-increasing one
+ * (the append path guarantees this; the next resume re-sequences to contiguous
+ * 0..n-1 anyway). DUPLICATE / non-strictly-increasing seqs are only reachable
+ * via external file corruption, and a backward `prevCursor` walk over them can
+ * drop events page-size-dependently until that next resume repairs the log.
  *
  * A missing log file is treated as an EMPTY history (`{ events: [], prevCursor:
  * null }`), not an error — a freshly-created session whose JSONL hasn't been
@@ -508,9 +512,6 @@ export async function readEventPage(
   opts: { before: number | null; limit: number },
   dir = defaultSessionsDir(),
 ): Promise<EventPage> {
-  const limit = Math.max(0, Math.floor(opts.limit));
-  if (limit === 0) return { events: [], prevCursor: opts.before };
-
   const logPath = path.join(dir, `${sessionId}.jsonl`);
   let raw: string;
   try {
@@ -531,7 +532,10 @@ export async function readEventPage(
       // skip a malformed/half-written line, same as restoreEvents
     }
   }
-  return pageEvents(all, opts.before, limit);
+  // Delegate ALL paging (including the limit/cursor clamping) to pageEvents so
+  // the disk and in-memory paths are identical by construction — no separate
+  // limit handling here that could diverge from the in-memory page.
+  return pageEvents(all, opts.before, opts.limit);
 }
 
 /**

--- a/packages/core/src/sessions/persistence.ts
+++ b/packages/core/src/sessions/persistence.ts
@@ -463,6 +463,111 @@ export async function restoreEvents(
   return events;
 }
 
+/** One page of persisted events, newest-page-first paging (see
+ *  {@link readEventPage}). */
+export interface EventPage {
+  /** The events in this page, in ascending `seq` order. */
+  readonly events: MoxxyEvent[];
+  /**
+   * Cursor to pass as `before` for the NEXT (older) page — the `seq` of the
+   * OLDEST event in this page. `null` once the start of history (the first
+   * persisted event) is included, signalling there is no older page.
+   */
+  readonly prevCursor: number | null;
+}
+
+/**
+ * Read ONE page of a persisted session's events without re-materializing the
+ * whole conversation into a live {@link EventLog}. Backs the runner's
+ * `session.loadHistory` so a thin client (the desktop) can page history from
+ * the runner's authoritative JSONL instead of its own NDJSON mirror.
+ *
+ * Paging is newest-first, walking backwards:
+ *   - `before == null` — the NEWEST page: the last `limit` events on disk.
+ *   - `before == N` — the page of (up to) `limit` events strictly OLDER than
+ *     `seq === N` (the events immediately preceding the cursor). Pass the
+ *     previous page's `prevCursor` here to step one page further back.
+ *
+ * The returned `events` are always in ascending `seq` order (oldest-first
+ * WITHIN the page) so a caller can prepend a page to an in-order transcript.
+ * `prevCursor` is the `seq` of the page's oldest event, or `null` once the
+ * first persisted event is included (no older page remains).
+ *
+ * Corrupt lines are skipped (matching {@link restoreEvents}); unlike
+ * `restoreEvents` this is a READ-ONLY reader — it never rewrites the file, so
+ * it preserves the JSONL exactly (no atomic-write / mutex needed: there is no
+ * mutation). Paging keys on each event's on-disk `seq`, so a not-yet-repaired
+ * gapped log still pages deterministically (the next resume repairs it).
+ *
+ * A missing log file is treated as an EMPTY history (`{ events: [], prevCursor:
+ * null }`), not an error — a freshly-created session whose JSONL hasn't been
+ * written yet must page as empty rather than throw.
+ */
+export async function readEventPage(
+  sessionId: string,
+  opts: { before: number | null; limit: number },
+  dir = defaultSessionsDir(),
+): Promise<EventPage> {
+  const limit = Math.max(0, Math.floor(opts.limit));
+  if (limit === 0) return { events: [], prevCursor: opts.before };
+
+  const logPath = path.join(dir, `${sessionId}.jsonl`);
+  let raw: string;
+  try {
+    raw = await fs.readFile(logPath, 'utf8');
+  } catch {
+    // No log on disk yet → empty history, not an error.
+    return { events: [], prevCursor: null };
+  }
+
+  // Parse the JSONL, skipping corrupt lines (one bad append must not make the
+  // rest unreadable). Read-only: we never rewrite the file here.
+  const all: MoxxyEvent[] = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      all.push(JSON.parse(line) as MoxxyEvent);
+    } catch {
+      // skip a malformed/half-written line, same as restoreEvents
+    }
+  }
+  return pageEvents(all, opts.before, limit);
+}
+
+/**
+ * Slice one newest-first page out of an ascending-`seq` event array. Pure +
+ * exported so the runner can reuse the EXACT paging semantics when it serves a
+ * page out of its in-memory log instead of disk — the two paths must agree
+ * byte-for-byte or a client crossing between them (in-memory → disk fallback)
+ * would see a discontinuity. `events` MUST be ordered oldest-first (the on-disk
+ * / append order); `before`/`limit` follow {@link readEventPage}.
+ */
+export function pageEvents(
+  events: ReadonlyArray<MoxxyEvent>,
+  before: number | null,
+  limit: number,
+): EventPage {
+  const cap = Math.max(0, Math.floor(limit));
+  if (cap === 0 || events.length === 0) {
+    return { events: [], prevCursor: events.length === 0 ? null : before };
+  }
+  // Exclusive upper bound by `seq`: the first index whose event is NOT older
+  // than `before`. `before == null` (newest page) keeps the whole array.
+  let end = events.length;
+  if (before !== null) {
+    end = 0;
+    for (let i = 0; i < events.length; i += 1) {
+      if (events[i]!.seq < before) end = i + 1;
+      else break;
+    }
+  }
+  const start = Math.max(0, end - cap);
+  const page = events.slice(start, end);
+  // `null` once this page reaches the very first event on disk — no older page.
+  const prevCursor = start <= 0 ? null : page[0]!.seq;
+  return { events: page, prevCursor };
+}
+
 /**
  * Remove a session's log file and its sidecar. A leftover legacy `index.json`
  * row, if any, is harmless — `readIndex` filters out sessions whose `.jsonl` is

--- a/packages/runner/src/handlers/context.ts
+++ b/packages/runner/src/handlers/context.ts
@@ -23,4 +23,12 @@ export interface HandlerContext {
   readonly prefsMutex: Mutex;
   /** Push the fresh registry snapshot to every attached client. */
   readonly broadcastInfo: () => void;
+  /**
+   * Directory holding the persisted session JSONLs. Used by
+   * `session.loadHistory` (v10) ONLY as the disk fallback when the runner's
+   * in-memory log doesn't reach the start of history (a tail-seeded log) —
+   * the common case pages straight out of the in-memory log. Defaults to
+   * core's `defaultSessionsDir()`; overridable for tests.
+   */
+  readonly sessionsDir?: string;
 }

--- a/packages/runner/src/handlers/index.ts
+++ b/packages/runner/src/handlers/index.ts
@@ -30,6 +30,7 @@ export {
 export {
   handleModeSetActive,
   handleSessionSetReasoning,
+  handleSessionLoadHistory,
   handlePermissionAddAllow,
   handleCommandRun,
 } from './session-handlers.js';

--- a/packages/runner/src/handlers/session-handlers.ts
+++ b/packages/runner/src/handlers/session-handlers.ts
@@ -1,9 +1,12 @@
+import { pageEvents, readSessionEventPage } from '@moxxy/core';
 import {
   commandRunParamsSchema,
   modeSetActiveParamsSchema,
   permissionAddAllowParamsSchema,
+  sessionLoadHistoryParamsSchema,
   sessionSetReasoningParamsSchema,
   type CommandRunResult,
+  type SessionLoadHistoryResult,
 } from '../protocol.js';
 import type { HandlerContext } from './context.js';
 
@@ -31,6 +34,39 @@ export function handleSessionSetReasoning(
   ctx.session.reasoning = effort === 'off' ? undefined : { effort };
   ctx.broadcastInfo();
   return {};
+}
+
+/**
+ * Page the runner's AUTHORITATIVE event history (v10). Backs the desktop's
+ * dual-history retirement — the renderer reads transcript history from here
+ * instead of its own NDJSON store. Newest-first paging: `before: null` is the
+ * newest page; `prevCursor` is the cursor for the next older page (`null` once
+ * the start of history is reached).
+ *
+ * Source of truth: the runner's in-memory `EventLog` is the live, append-only
+ * authority and (for the runner's own session) always holds the conversation
+ * from seq 0 — `restoreEvents` re-sequences a resumed log to 0..n-1 and live
+ * turns append from there. So when `log.baseSeq === 0` we page straight out of
+ * the in-memory log (no disk read; includes live-streamed events not yet
+ * flushed). The disk reader is the fallback for the "log isn't all in memory"
+ * case (a future tail-seeded log, `baseSeq > 0`): it pages one window out of the
+ * persisted JSONL without re-materializing the whole conversation. Both paths
+ * share {@link pageEvents}' exact semantics so a client crossing between them
+ * sees no discontinuity.
+ */
+export async function handleSessionLoadHistory(
+  ctx: HandlerContext,
+  raw: unknown,
+): Promise<SessionLoadHistoryResult> {
+  const { before, limit } = sessionLoadHistoryParamsSchema.parse(raw);
+  const log = ctx.session.log;
+  if (log.baseSeq === 0) {
+    // The in-memory log holds the start of history — page it directly.
+    return pageEvents(log.toJSON(), before, limit);
+  }
+  // Tail-seeded / partial in-memory log: read one page off disk instead so the
+  // oldest history (below the in-memory base) is still reachable.
+  return readSessionEventPage(String(ctx.session.id), { before, limit }, ctx.sessionsDir);
 }
 
 export async function handlePermissionAddAllow(

--- a/packages/runner/src/integration.test.ts
+++ b/packages/runner/src/integration.test.ts
@@ -32,13 +32,18 @@ import type {
   SurfaceDataMessage,
   SurfaceInstance,
 } from '@moxxy/sdk';
-import { FakeProvider, textReply, toolUseReply } from '@moxxy/testing';
+import { FakeProvider, streamingTextReply, textReply, toolUseReply } from '@moxxy/testing';
 import { defaultModePlugin } from '@moxxy/mode-default';
 import { startRunnerServer, type RunnerServer } from './server.js';
-import { connectRemoteSession, type RemoteSession } from './remote-session.js';
+import { connectRemoteSession, RemoteSession } from './remote-session.js';
 import { connectUnixSocket } from './unix-socket.js';
 import { JsonRpcPeer } from './jsonrpc.js';
-import { RUNNER_PROTOCOL_VERSION, RunnerMethod } from './protocol.js';
+import {
+  RUNNER_PROTOCOL_VERSION,
+  RunnerMethod,
+  type SessionLoadHistoryResult,
+} from './protocol.js';
+import type { ProviderEvent } from '@moxxy/sdk';
 
 function buildSession(provider: FakeProvider, logger: Logger = silentLogger): Session {
   const session = new Session({
@@ -1348,5 +1353,219 @@ describe('surfaces (protocol v8)', () => {
     const { socketPath } = await serve(new FakeProvider({ script: [textReply('hi')] }));
     const remote = await attach(socketPath);
     await expect(remote.openSurface('terminal')).rejects.toThrow(/No surface registered/);
+  });
+});
+
+/** A reply that STREAMS text deltas then fails mid-stream WITHOUT a clean
+ *  message_end — collectProviderStream returns `{ text, error }`, so the
+ *  default mode loop returns without sealing an assistant_message. */
+function streamThenError(chunks: ReadonlyArray<string>): ReadonlyArray<ProviderEvent> {
+  return [
+    { type: 'message_start', model: 'fake' },
+    ...chunks.map<ProviderEvent>((c) => ({ type: 'text_delta', delta: c })),
+    { type: 'error', message: 'provider blew up mid-stream', retryable: false },
+  ];
+}
+
+describe('session.loadHistory paging (protocol v10)', () => {
+  it('returns the newest page and walks older pages via prevCursor to a null start', async () => {
+    // Build a multi-turn conversation so the log has many events to page.
+    const { socketPath } = await serve(
+      new FakeProvider({
+        script: [textReply('a1'), textReply('a2'), textReply('a3')],
+      }),
+    );
+    const remote = await attach(socketPath);
+    for await (const _e of remote.runTurn('q1')) void _e;
+    for await (const _e of remote.runTurn('q2')) void _e;
+    for await (const _e of remote.runTurn('q3')) void _e;
+    const total = remote.log.length;
+    expect(total).toBeGreaterThan(3);
+
+    // Newest page.
+    const newest = await remote.loadHistory(null, 4);
+    expect(newest.events.length).toBe(4);
+    // It is the tail of the log, in ascending seq order.
+    expect(newest.events.map((e) => e.seq)).toEqual([total - 4, total - 3, total - 2, total - 1]);
+    expect(newest.prevCursor).toBe(total - 4);
+
+    // Walk all the way back; the collected seqs reconstruct the whole log once.
+    const collected: number[] = [...newest.events.map((e) => e.seq)];
+    let before = newest.prevCursor;
+    for (let guard = 0; guard < 100 && before !== null; guard += 1) {
+      const page: SessionLoadHistoryResult = await remote.loadHistory(before, 4);
+      collected.unshift(...page.events.map((e) => e.seq));
+      before = page.prevCursor;
+    }
+    expect(collected).toEqual(Array.from({ length: total }, (_, i) => i));
+  });
+
+  it('returns an empty page with a null cursor for an empty log', async () => {
+    const { socketPath } = await serve(new FakeProvider({ script: [textReply('unused')] }));
+    const remote = await attach(socketPath);
+    const page = await remote.loadHistory(null, 10);
+    expect(page.events).toEqual([]);
+    expect(page.prevCursor).toBeNull();
+  });
+
+  it('returns the whole log and a null cursor when limit exceeds history', async () => {
+    const { socketPath } = await serve(new FakeProvider({ script: [textReply('only answer')] }));
+    const remote = await attach(socketPath);
+    for await (const _e of remote.runTurn('q')) void _e;
+    const total = remote.log.length;
+
+    const page = await remote.loadHistory(null, 1000);
+    expect(page.events.map((e) => e.seq)).toEqual(Array.from({ length: total }, (_, i) => i));
+    // The start of history is included → no older page.
+    expect(page.prevCursor).toBeNull();
+    // The page IS the authoritative log (same content the mirror holds).
+    expect(JSON.stringify(page.events)).toBe(JSON.stringify(remote.log.toJSON()));
+  });
+});
+
+describe('session.loadHistory version gate (protocol v10)', () => {
+  /** A pair of in-memory transports wired to each other (mirrors remote-session.test). */
+  function makePair(): [import('./transport.js').Transport, import('./transport.js').Transport] {
+    let aOnFrame: ((f: unknown) => void) | undefined;
+    let bOnFrame: ((f: unknown) => void) | undefined;
+    let aOnClose: ((e?: Error) => void) | undefined;
+    let bOnClose: ((e?: Error) => void) | undefined;
+    let closed = false;
+    const closeBoth = (): void => {
+      if (closed) return;
+      closed = true;
+      queueMicrotask(() => {
+        aOnClose?.();
+        bOnClose?.();
+      });
+    };
+    const a: import('./transport.js').Transport = {
+      send: (f) => {
+        if (!closed) queueMicrotask(() => bOnFrame?.(f));
+      },
+      onFrame: (h) => {
+        aOnFrame = h;
+      },
+      onClose: (h) => {
+        aOnClose = h;
+      },
+      close: closeBoth,
+    };
+    const b: import('./transport.js').Transport = {
+      send: (f) => {
+        if (!closed) queueMicrotask(() => aOnFrame?.(f));
+      },
+      onFrame: (h) => {
+        bOnFrame = h;
+      },
+      onClose: (h) => {
+        bOnClose = h;
+      },
+      close: closeBoth,
+    };
+    return [a, b];
+  }
+
+  const fakeInfo = {
+    sessionId: 'fake',
+    cwd: process.cwd(),
+    providers: [],
+    tools: [],
+    modes: [],
+    skills: [],
+    commands: [],
+    readyProviders: [],
+    activeProvider: null,
+    activeMode: null,
+  } as const;
+
+  it('throws an actionable error against a runner reporting protocol < 10', async () => {
+    const [clientT, serverT] = makePair();
+    const server = new JsonRpcPeer(serverT);
+    let loadHistoryCalled = false;
+    // An OLDER runner: reports v9 and has no session.loadHistory handler.
+    server.handle(RunnerMethod.Attach, () => ({
+      sessionId: 'fake',
+      protocolVersion: 9,
+      info: fakeInfo,
+    }));
+    server.handle(RunnerMethod.SessionLoadHistory, () => {
+      loadHistoryCalled = true;
+      return { events: [], prevCursor: null };
+    });
+    const client = new RemoteSession(clientT);
+    await client.attach('desktop', 0);
+    expect(client.runnerProtocolVersion).toBe(9);
+
+    // The client must NOT hit the wire — it gates and throws a clear, actionable
+    // "update the CLI" error so the desktop can catch it and fall back to NDJSON.
+    await expect(client.loadHistory(null, 50)).rejects.toThrow(/update the moxxy CLI/i);
+    await expect(client.loadHistory(null, 50)).rejects.toThrow(/v9, needs v10/);
+    expect(loadHistoryCalled).toBe(false);
+    clientT.close();
+  });
+
+  it('reaches the runner when it reports protocol >= 10', async () => {
+    const [clientT, serverT] = makePair();
+    const server = new JsonRpcPeer(serverT);
+    server.handle(RunnerMethod.Attach, () => ({
+      sessionId: 'fake',
+      protocolVersion: 10,
+      info: fakeInfo,
+    }));
+    server.handle(RunnerMethod.SessionLoadHistory, (raw) => {
+      const { before, limit } = raw as { before: number | null; limit: number };
+      return { events: [], prevCursor: before === null ? null : limit };
+    });
+    const client = new RemoteSession(clientT);
+    await client.attach('desktop', 0);
+    const page = await client.loadHistory(null, 50);
+    expect(page).toEqual({ events: [], prevCursor: null });
+    clientT.close();
+  });
+});
+
+describe('log completeness: stream-without-seal', () => {
+  it('persists a REAL assistant_message when streamed text was never sealed', async () => {
+    // The provider streams text deltas then errors before a clean message_end,
+    // so the default-mode loop returns without emitting an assistant_message.
+    // The runner must seal the streamed text into a real assistant_message so
+    // the runner log is the complete authoritative history (no renderer synth).
+    const { session, socketPath } = await serve(
+      new FakeProvider({ script: [streamThenError(['par', 'tial ', 'reply'])] }),
+    );
+    const remote = await attach(socketPath);
+
+    // Drive the turn to completion (it ends in a fatal error event).
+    const streamedTypes: string[] = [];
+    for await (const event of remote.runTurn('go')) streamedTypes.push(event.type);
+
+    // Chunks DID stream (so the renderer would otherwise have to synthesize)...
+    expect(streamedTypes).toContain('assistant_chunk');
+
+    // ...and the AUTHORITATIVE runner log now carries a REAL assistant_message
+    // reconstructed from those chunks — with a normal seq, not the renderer's -1.
+    const sealed = session.log.ofType('assistant_message');
+    expect(sealed.length).toBe(1);
+    expect((sealed[0] as AssistantMessageEvent).content).toBe('partial reply');
+    expect(sealed[0]!.seq).toBeGreaterThanOrEqual(0);
+
+    // The mirror received it as a normal streamed event too.
+    const mirrored = remote.log.ofType('assistant_message')[0] as AssistantMessageEvent | undefined;
+    expect(mirrored?.content).toBe('partial reply');
+  });
+
+  it('does NOT double-seal the normal (provider-sealed) path', async () => {
+    // A clean reply seals its own assistant_message; the runner must not append
+    // a second one. Behavior-preserving for the common case.
+    const { session, socketPath } = await serve(
+      new FakeProvider({ script: [streamingTextReply(['hel', 'lo'])] }),
+    );
+    const remote = await attach(socketPath);
+    for await (const _e of remote.runTurn('hi')) void _e;
+
+    const sealed = session.log.ofType('assistant_message');
+    expect(sealed.length).toBe(1);
+    expect((sealed[0] as AssistantMessageEvent).content).toBe('hello');
   });
 });

--- a/packages/runner/src/integration.test.ts
+++ b/packages/runner/src/integration.test.ts
@@ -1367,6 +1367,18 @@ function streamThenError(chunks: ReadonlyArray<string>): ReadonlyArray<ProviderE
   ];
 }
 
+/** Like {@link streamThenError} but the mid-stream error is RETRYABLE, so the
+ *  default-mode loop backs off and RETRIES (consuming the NEXT scripted reply)
+ *  instead of ending the turn — leaving this iteration's streamed chunks in the
+ *  log with no sealing `assistant_message`. */
+function streamThenRetryable(chunks: ReadonlyArray<string>): ReadonlyArray<ProviderEvent> {
+  return [
+    { type: 'message_start', model: 'fake' },
+    ...chunks.map<ProviderEvent>((c) => ({ type: 'text_delta', delta: c })),
+    { type: 'error', message: 'transient blip — retry', retryable: true },
+  ];
+}
+
 describe('session.loadHistory paging (protocol v10)', () => {
   it('returns the newest page and walks older pages via prevCursor to a null start', async () => {
     // Build a multi-turn conversation so the log has many events to page.
@@ -1567,5 +1579,28 @@ describe('log completeness: stream-without-seal', () => {
     const sealed = session.log.ofType('assistant_message');
     expect(sealed.length).toBe(1);
     expect((sealed[0] as AssistantMessageEvent).content).toBe('hello');
+  });
+
+  it('seals only the FINAL iteration text, not an abandoned retryable attempt', async () => {
+    // A turn can stream text, hit a RETRYABLE provider error (transient
+    // 429/outage), retry, stream MORE text, then end without a clean
+    // assistant_message. The seal must keep only the final attempt's text — the
+    // abandoned attempt's chunks must NOT bleed into the sealed reply, which
+    // would durably corrupt the authoritative log ("ABANDONED-final").
+    const { session, socketPath } = await serve(
+      new FakeProvider({
+        // iter 1: streams "ABANDONED-" then a RETRYABLE error → the loop retries.
+        // iter 2: streams "final" then a NON-retryable error → turn ends unsealed.
+        script: [streamThenRetryable(['ABAN', 'DONED-']), streamThenError(['fin', 'al'])],
+      }),
+    );
+    const remote = await attach(socketPath);
+    // One retryable retry incurs a single ~500ms back-off; the turn still ends
+    // in a fatal error event.
+    for await (const _e of remote.runTurn('go')) void _e;
+
+    const sealed = session.log.ofType('assistant_message');
+    expect(sealed.length).toBe(1);
+    expect((sealed[0] as AssistantMessageEvent).content).toBe('final');
   });
 });

--- a/packages/runner/src/protocol.ts
+++ b/packages/runner/src/protocol.ts
@@ -127,11 +127,26 @@ import type {
  * reasoning-effort selector. A v9 client gates the method on the server's
  * reported version. (Additive — a v8 server simply lacks this one method.)
  *
- * Every change v1→v9 has been ADDITIVE, so MIN_COMPATIBLE stays at 1: today's
+ * v10: adds `session.loadHistory` — a paged reader over the runner's
+ * AUTHORITATIVE event history (params `{ before, limit }`, result
+ * `{ events, prevCursor }`). It backs the desktop's dual-history retirement:
+ * the renderer will read transcript history from the runner instead of its own
+ * NDJSON chat store. Paging is newest-first — `before: null` is the newest page;
+ * `prevCursor` is the cursor to pass for the next OLDER page (`null` once the
+ * start of history is reached). The handler serves a page out of the runner's
+ * in-memory log when it reaches seq 0, else falls through to a paged JSONL
+ * reader so it works even when the whole log isn't in memory. A v10 client gates
+ * the method on the server's reported version (see {@link AttachResult}) so a
+ * newer desktop attached to an OLDER runner gets a clear "update the CLI" error
+ * — which the renderer CATCHES to fall back to its existing NDJSON path, so no
+ * transcript ever goes blank. (Additive — a v9 server simply lacks this one
+ * method.)
+ *
+ * Every change v1→v10 has been ADDITIVE, so MIN_COMPATIBLE stays at 1: today's
  * server can serve any client back to v1, and any client v1+ can attach. Bump
  * MIN_COMPATIBLE to N only when landing a breaking change at version N.
  */
-export const RUNNER_PROTOCOL_VERSION = 9;
+export const RUNNER_PROTOCOL_VERSION = 10;
 
 /**
  * Lowest client protocol version this build's CORE session protocol is
@@ -160,6 +175,13 @@ export const RunnerMethod = {
    * attached clients so every mirror clears in lockstep.
    */
   SessionReset: 'session.reset',
+  /**
+   * client->server: page the runner's authoritative event history (v10).
+   * `{ before, limit }` → `{ events, prevCursor }`, newest-first. Backs the
+   * desktop dual-history retirement; a v10 client gates it on the server's
+   * reported version and falls back to its NDJSON store against an older runner.
+   */
+  SessionLoadHistory: 'session.loadHistory',
   /** client->server: declare which resolvers this client will answer. */
   SetResolver: 'setResolver',
   /** client->server: switch the active mode. */
@@ -325,6 +347,27 @@ export interface ModeSetActiveParams {
 export type ReasoningEffortLevel = 'off' | 'low' | 'medium' | 'high';
 export interface SessionSetReasoningParams {
   readonly effort: ReasoningEffortLevel;
+}
+
+/**
+ * Params for `session.loadHistory` (v10). `before` is a `seq` cursor: `null`
+ * requests the NEWEST page; a number requests the page of events strictly OLDER
+ * than that seq (pass a prior result's `prevCursor` to step back). `limit`
+ * bounds the page size.
+ */
+export interface SessionLoadHistoryParams {
+  readonly before: number | null;
+  readonly limit: number;
+}
+/**
+ * Result of `session.loadHistory` (v10). `events` is one page in ascending
+ * `seq` order (oldest-first within the page). `prevCursor` is the cursor to
+ * pass as `before` for the NEXT older page — the seq of this page's oldest
+ * event — or `null` once the start of history is reached (no older page).
+ */
+export interface SessionLoadHistoryResult {
+  readonly events: ReadonlyArray<MoxxyEvent>;
+  readonly prevCursor: number | null;
 }
 
 export interface ProviderSetActiveParams {
@@ -513,6 +556,18 @@ export const modeSetActiveParamsSchema = z.object({ name: z.string() });
 
 export const sessionSetReasoningParamsSchema = z.object({
   effort: z.enum(['off', 'low', 'medium', 'high']),
+});
+
+/**
+ * Params for `session.loadHistory` (v10). `before` is a non-negative seq cursor
+ * (or null for the newest page); `limit` is bounded so a hostile client can't
+ * demand the entire conversation as one page (the renderer pages incrementally,
+ * well under this cap). `nullable()` keeps `before: null` explicit on the wire.
+ */
+export const MAX_HISTORY_PAGE_LIMIT = 2_000;
+export const sessionLoadHistoryParamsSchema = z.object({
+  before: z.number().int().nonnegative().nullable(),
+  limit: z.number().int().positive().max(MAX_HISTORY_PAGE_LIMIT),
 });
 
 export const providerSetActiveParamsSchema = z.object({

--- a/packages/runner/src/protocol.ts
+++ b/packages/runner/src/protocol.ts
@@ -353,7 +353,7 @@ export interface SessionSetReasoningParams {
  * Params for `session.loadHistory` (v10). `before` is a `seq` cursor: `null`
  * requests the NEWEST page; a number requests the page of events strictly OLDER
  * than that seq (pass a prior result's `prevCursor` to step back). `limit`
- * bounds the page size.
+ * bounds the page size in RAW events (see {@link SessionLoadHistoryResult}).
  */
 export interface SessionLoadHistoryParams {
   readonly before: number | null;
@@ -364,6 +364,13 @@ export interface SessionLoadHistoryParams {
  * `seq` order (oldest-first within the page). `prevCursor` is the cursor to
  * pass as `before` for the NEXT older page — the seq of this page's oldest
  * event — or `null` once the start of history is reached (no older page).
+ *
+ * `events` is the RAW authoritative log: it includes non-rendered events
+ * (e.g. `assistant_chunk` deltas, `provider_request`/`provider_response`
+ * bookends), and `limit` counts those too. So a page of `limit` raw events can
+ * project to far fewer rendered messages — the renderer filters with
+ * `isRenderedEvent` and keeps paging until it has enough RENDERED events
+ * ("page-until-K-rendered"), rather than assuming one page == K messages.
  */
 export interface SessionLoadHistoryResult {
   readonly events: ReadonlyArray<MoxxyEvent>;

--- a/packages/runner/src/remote-session.ts
+++ b/packages/runner/src/remote-session.ts
@@ -63,6 +63,8 @@ import {
   type PermissionCheckParams,
   type ReplayStartNotification,
   type RunTurnResult,
+  type SessionLoadHistoryParams,
+  type SessionLoadHistoryResult,
   type SurfaceDataNotification,
   type SurfaceListResult,
   type TurnCompleteNotification,
@@ -420,6 +422,30 @@ export class RemoteSession implements ClientSession {
    */
   async reset(): Promise<void> {
     await this.peer.request(RunnerMethod.SessionReset, {});
+  }
+
+  /**
+   * Page the runner's AUTHORITATIVE event history (protocol v10). Backs the
+   * desktop's dual-history retirement — the renderer reads transcript history
+   * from the runner instead of its own NDJSON chat store. Newest-first paging:
+   * pass `before: null` for the newest page, then feed each result's
+   * `prevCursor` back as `before` to walk older pages until `prevCursor` is
+   * `null` (start of history).
+   *
+   * GATED on the server reporting protocol v10+. Against an OLDER runner this
+   * throws a clear, actionable error (not a raw method-not-found) — the desktop
+   * CATCHES it and falls back to its existing NDJSON path, so no transcript
+   * ever goes blank when the runner predates this method.
+   */
+  async loadHistory(
+    before: number | null,
+    limit: number,
+  ): Promise<SessionLoadHistoryResult> {
+    this.requireServerProtocol(10, 'Loading session history from the runner');
+    return this.peer.request<SessionLoadHistoryResult>(RunnerMethod.SessionLoadHistory, {
+      before,
+      limit,
+    } satisfies SessionLoadHistoryParams);
   }
 
   getInfo(): SessionInfo {

--- a/packages/runner/src/server.ts
+++ b/packages/runner/src/server.ts
@@ -54,6 +54,7 @@ import {
   handleSurfaceClose,
   handleModeSetActive,
   handleSessionSetReasoning,
+  handleSessionLoadHistory,
   handlePermissionAddAllow,
   handleCommandRun,
   type HandlerContext,
@@ -209,6 +210,7 @@ export class RunnerServer {
     peer.handle(RunnerMethod.RunTurn, (raw) => this.handleRunTurn(client, raw));
     peer.handle(RunnerMethod.Abort, (raw) => this.handleAbort(client, raw));
     peer.handle(RunnerMethod.SessionReset, () => this.handleSessionReset());
+    peer.handle(RunnerMethod.SessionLoadHistory, (raw) => handleSessionLoadHistory(ctx, raw));
     peer.handle(RunnerMethod.SetResolver, (raw) => this.handleSetResolver(client, raw));
     peer.handle(RunnerMethod.ModeSetActive, (raw) => handleModeSetActive(ctx, raw));
     peer.handle(RunnerMethod.SessionSetReasoning, (raw) => handleSessionSetReasoning(ctx, raw));
@@ -332,6 +334,16 @@ export class RunnerServer {
       } finally {
         this.turnControllers.delete(turnId);
         client.turns.delete(turnId);
+        // LOG COMPLETENESS: a turn can stream assistant text (assistant_chunk
+        // events) yet never SEAL it with an assistant_message — e.g. the
+        // provider errors or the turn aborts mid-stream after some text landed.
+        // The renderer used to paper over this by SYNTHESIZING the missing
+        // assistant_message on turn-complete, so that reply existed in NO runner
+        // log. Persist a REAL one here (before turn.complete) so the runner log
+        // is the complete authoritative history — and it streams to every mirror
+        // as a normal event. No-op on the normal sealed path. Awaited so the
+        // event is on the wire/disk before clients learn the turn finished.
+        await this.sealUnsealedStreamedText(turnId);
         this.broadcast(RunnerNotification.TurnComplete, {
           turnId,
           ...(error ? { error } : {}),
@@ -391,6 +403,44 @@ export class RunnerServer {
     }
     this.session.log.clear();
     return {};
+  }
+
+  /**
+   * If this turn streamed assistant text (`assistant_chunk`) that no
+   * `assistant_message` ever sealed, append a REAL `assistant_message` to the
+   * authoritative log so it persists + replays like any other reply. Mirrors
+   * the desktop renderer's old turn-complete synthesis exactly: it accumulates
+   * chunk deltas and clears them on an `assistant_message`, then synthesizes
+   * from whatever text remains — so we seal only the trailing run of chunks
+   * AFTER the turn's last `assistant_message` (an empty/whitespace remainder is
+   * a no-op, which is the normal sealed path). The append flows through
+   * `session.log` → persistence + the broadcast stream, so mirrors ingest it as
+   * a normal event and never need to synthesize their own.
+   */
+  private async sealUnsealedStreamedText(turnId: TurnId): Promise<void> {
+    const events = this.session.log.byTurn(turnId);
+    if (events.length === 0) return;
+    let unsealed = '';
+    for (const event of events) {
+      if (event.type === 'assistant_message') unsealed = '';
+      else if (event.type === 'assistant_chunk') unsealed += event.delta;
+    }
+    if (!unsealed.trim()) return; // normal sealed path (or no text) — nothing to do
+    try {
+      await this.session.log.append({
+        type: 'assistant_message',
+        sessionId: this.session.id,
+        turnId,
+        source: 'model',
+        content: unsealed,
+        // The turn ended without the provider sealing the message (error/abort
+        // after partial text); 'end_turn' matches the renderer's prior synth.
+        stopReason: 'end_turn',
+      });
+    } catch {
+      // Sealing is best-effort completeness, not correctness-critical: a failed
+      // append must not break turn-complete fan-out or abort handling.
+    }
   }
 
   private handleSetResolver(client: ConnectedClient, raw: unknown): Record<string, never> {

--- a/packages/runner/src/server.ts
+++ b/packages/runner/src/server.ts
@@ -408,21 +408,35 @@ export class RunnerServer {
   /**
    * If this turn streamed assistant text (`assistant_chunk`) that no
    * `assistant_message` ever sealed, append a REAL `assistant_message` to the
-   * authoritative log so it persists + replays like any other reply. Mirrors
-   * the desktop renderer's old turn-complete synthesis exactly: it accumulates
-   * chunk deltas and clears them on an `assistant_message`, then synthesizes
-   * from whatever text remains — so we seal only the trailing run of chunks
-   * AFTER the turn's last `assistant_message` (an empty/whitespace remainder is
-   * a no-op, which is the normal sealed path). The append flows through
-   * `session.log` → persistence + the broadcast stream, so mirrors ingest it as
-   * a normal event and never need to synthesize their own.
+   * authoritative log so it persists + replays like any other reply. It
+   * accumulates chunk deltas and seals whatever text remains at turn end — so a
+   * cleanly sealed reply (the normal path) leaves an empty remainder and this is
+   * a no-op.
+   *
+   * The accumulator resets on BOTH per-iteration boundaries — an
+   * `assistant_message` (a reply was sealed) AND a `provider_request` (a fresh
+   * provider iteration begins). Resetting on `provider_request` is what scopes
+   * the seal to the FINAL iteration: a retryable provider error can abandon a
+   * partially-streamed iteration WITHOUT sealing it (the mode loop emits the
+   * error and `continue`s), and a later iteration then streams fresh text and
+   * may itself end unsealed (a fatal error / abort / max-iterations). Without
+   * the `provider_request` reset, the abandoned attempt's chunks would be
+   * concatenated INTO the sealed reply ("ABANDONED-final" instead of "final"),
+   * durably corrupting authoritative/replayed history. (This is a deliberate
+   * improvement over the desktop renderer's old turn-complete synthesis, which
+   * accumulated across iterations and had exactly that defect — and which this
+   * seal retires.)
+   *
+   * The append flows through `session.log` → persistence + the broadcast stream,
+   * so mirrors ingest it as a normal event and never need to synthesize their
+   * own.
    */
   private async sealUnsealedStreamedText(turnId: TurnId): Promise<void> {
     const events = this.session.log.byTurn(turnId);
     if (events.length === 0) return;
     let unsealed = '';
     for (const event of events) {
-      if (event.type === 'assistant_message') unsealed = '';
+      if (event.type === 'assistant_message' || event.type === 'provider_request') unsealed = '';
       else if (event.type === 'assistant_chunk') unsealed += event.delta;
     }
     if (!unsealed.trim()) return; // normal sealed path (or no text) — nothing to do
@@ -434,7 +448,7 @@ export class RunnerServer {
         source: 'model',
         content: unsealed,
         // The turn ended without the provider sealing the message (error/abort
-        // after partial text); 'end_turn' matches the renderer's prior synth.
+        // after partial text); record it as a normal completed reply.
         stopReason: 'end_turn',
       });
     } catch {

--- a/scripts/build-app-bundle.mjs
+++ b/scripts/build-app-bundle.mjs
@@ -105,20 +105,28 @@ function main() {
   }
 
   // Lockstep guard: the immutable bootstrap bakes FLOOR_RUNNER_PROTOCOL and uses
-  // it as the ceiling for any hot-update. If a runner-protocol bump forgot to
-  // update that floor constant, the gate would mis-judge skew — fail the build
-  // here rather than ship a wrong floor.
+  // it as the ceiling for any hot-update — a staged JS bundle whose signed
+  // `runnerProtocol` EXCEEDS the floor would strand the desktop with a client
+  // newer than any runner its bundled CLI can spawn. The floor is therefore a
+  // guaranteed-serveable MINIMUM, so it must never be HIGHER than
+  // RUNNER_PROTOCOL_VERSION (that would promise a protocol the CLI can't serve).
+  // It MAY legitimately LAG when the runner adds an OPTIONAL, version-gated
+  // method (e.g. v10's `session.loadHistory`, which the renderer feature-detects
+  // and falls back from): such skew is additive and the desktop keeps working
+  // against the floor runner. So assert `floor <= RUNNER_PROTOCOL_VERSION` rather
+  // than strict equality — a forgotten bump that pushes the floor ABOVE the
+  // runner still fails the build.
   const floorSrc = readFileSync(
     path.join(desktopDir, 'electron', 'main', 'floor-runner-protocol.ts'),
     'utf8',
   );
   const floorMatch = /FLOOR_RUNNER_PROTOCOL\s*=\s*(\d+)/.exec(floorSrc);
   const floorProtocol = floorMatch ? Number.parseInt(floorMatch[1], 10) : NaN;
-  if (floorProtocol !== RUNNER_PROTOCOL_VERSION) {
+  if (!Number.isFinite(floorProtocol) || floorProtocol > RUNNER_PROTOCOL_VERSION) {
     console.error(
-      `build-app-bundle: FLOOR_RUNNER_PROTOCOL (${floorProtocol}) != ` +
+      `build-app-bundle: FLOOR_RUNNER_PROTOCOL (${floorProtocol}) must be <= ` +
         `@moxxy/runner RUNNER_PROTOCOL_VERSION (${RUNNER_PROTOCOL_VERSION}) — ` +
-        'update apps/desktop/electron/main/floor-runner-protocol.ts to match.',
+        'update apps/desktop/electron/main/floor-runner-protocol.ts.',
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Runner-authoritative paged history — **foundation only** (renderer migration is a separate followup)

> **Scope correction:** this PR is the **runner/core foundation**. The renderer still reads history from its own NDJSON store; the desktop-facing renderer migration (IPC `chat.loadHistory`, `ChatPersistence` runner-prefer + NDJSON fallback, chat-store page-until-K-rendered, golden render-equivalence test) is a **separate followup PR**, as TECH_DEBT item 3 records.

Makes the **runner log authoritative** and adds a paged read path — additively and version-gated, WITHOUT deleting data or breaking older runners.

**Runner / core** (protocol **v10**, additive; desktop `FLOOR` stays **9**):
- `session.loadHistory({before,limit}) → {events, prevCursor}` — newest-first paging over the authoritative log (in-memory `EventLog`, or `readEventPage` off the JSONL; both share `pageEvents` so they can't diverge). `RemoteSession.loadHistory` gates on the server reporting v10+ and throws an actionable error against an older runner.
- **Log completeness:** the runner seals a *real* `assistant_message` for a turn that streamed text but was never sealed (error/abort mid-stream), **scoped to the final provider iteration** so an abandoned retryable attempt's text never bleeds in.
- Floor guard relaxed to `FLOOR ≤ RUNNER` for additive, version-gated bumps.

### Review fixes folded in (post-confirmation)
- **Fixed a real correctness bug**: the seal accumulated `assistant_chunk` text across *all* provider iterations → a retryable-error-then-fail turn persisted `"ABANDONED-final"` instead of `"final"`. Now resets on `provider_request`. Regression test added.
- `readEventPage` limit===0 aligned to `pageEvents` (consistency pin); duplicate-seq + raw-event-limit docs tightened; changeset adds `@moxxy/runner`.

### Safety
- No data deleted/overwritten; NDJSON store remains a working read fallback.
- No FLOOR raise — an older runner still attaches and the renderer falls back.

**Gates:** build 68/68 · typecheck 134/134 · tests pass (incl. paging + seal regression) · lint 0 errors · check:deps clean.