### PR TITLE
feat: publish programmatic moxxy (setupAgent + @moxxy/agent) + sandboxed desktop-apps platform foundation

### DIFF
--- a/.changeset/feat-desktop-app-sdk.md
+++ b/.changeset/feat-desktop-app-sdk.md
@@ -1,0 +1,14 @@
+---
+"@moxxy/desktop-app-sdk": minor
+---
+
+feat(desktop): `@moxxy/desktop-app-sdk` — the contract for sandboxed desktop mini-apps
+
+The foundation of the custom-apps platform: a `moxxy-app.json` manifest schema
+(id, ui entry, install assets + per-app host allow-list, declared permissions),
+a closed capability list, the host↔app bridge protocol (typed postMessage RPC,
+one permission per method), and the browser-side `connectMoxxyApp()` client an
+app imports. Apps run as isolated web bundles in a cross-origin `moxxy-app://`
+iframe and reach host services only through declared permissions — so the
+manifest is the complete, auditable grant list. (Host discovery, the sandbox
+surface, the anonymizer migration, and the create-app skill build on this.)

--- a/.changeset/feat-publish-programmatic-core.md
+++ b/.changeset/feat-publish-programmatic-core.md
@@ -1,0 +1,32 @@
+---
+"@moxxy/core": minor
+"@moxxy/agent": minor
+"@moxxy/mode-default": minor
+"@moxxy/plugin-provider-openai": minor
+"@moxxy/plugin-provider-anthropic": minor
+---
+
+feat: publish the programmatic moxxy runtime + a one-call agent API
+
+Make the embeddable moxxy API public on npm so developers can build agents in
+their own code (alongside the already-public `@moxxy/sdk`):
+
+- **`@moxxy/core`** — the engine: `Session` + `runTurn`/`collectTurn`, the block
+  registries, the plugin host, persistence, the permission engine. Now also
+  ships **`setupAgent(...)`** — a one-call, synchronous, destructurable factory
+  (`const { ask, stream, session } = setupAgent({ plugins, provider, tools })`)
+  with `ask` (async final text), `stream` (async generator of events),
+  `collect`, and chainable hot-swap sugar (`setProvider`/`setMode`/`addTool`/…).
+  It accepts a single options object, a preset, or an **array of presets** that
+  merge (shared plugins de-duped, first provider active). The `@moxxy/sdk` types
+  in the surface are re-exported, so it's fully typed from one import.
+- **`@moxxy/agent`** — batteries-included: bundles core + the default loop + the
+  OpenAI and Anthropic providers behind drop-in presets.
+  `setupAgent(openaiPreset({ apiKey }))` is a complete, runnable agent in one
+  install + one call.
+- **`@moxxy/mode-default`**, **`@moxxy/plugin-provider-openai`**,
+  **`@moxxy/plugin-provider-anthropic`** — the minimal runnable block set.
+
+Every package ships a production-ready README with examples. Blocks stay
+swappable — nothing is built into core; publishing these changes no runtime
+behaviour of the CLI or desktop (which still bundle them internally).

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -1,0 +1,87 @@
+# @moxxy/agent
+
+The fastest way to run a [moxxy](https://moxxy.ai) agent — **one install, one
+call.** Batteries included: it bundles the runtime (`@moxxy/core`), the default
+loop, and the OpenAI + Anthropic providers behind drop-in presets.
+
+```bash
+npm i @moxxy/agent
+```
+
+## Hello, agent
+
+```ts
+import { setupAgent, openaiPreset } from '@moxxy/agent';
+
+const { ask } = setupAgent(openaiPreset({ apiKey: process.env.OPENAI_API_KEY }));
+
+console.log(await ask('Write a haiku about TypeScript.'));
+```
+
+Stream the events instead:
+
+```ts
+const { stream } = setupAgent(openaiPreset({ apiKey: process.env.OPENAI_API_KEY }));
+
+for await (const event of stream('Explain async generators.')) {
+  if (event.type === 'assistant_chunk') process.stdout.write(event.delta);
+}
+```
+
+## Claude, or both
+
+```ts
+import { setupAgent, openaiPreset, anthropicPreset } from '@moxxy/agent';
+
+// Just Claude:
+const claude = setupAgent(anthropicPreset({ apiKey: process.env.ANTHROPIC_API_KEY }));
+
+// Or register both and switch per turn (the first preset is active):
+const agent = setupAgent([
+  openaiPreset({ apiKey: process.env.OPENAI_API_KEY }),
+  anthropicPreset({ apiKey: process.env.ANTHROPIC_API_KEY }),
+]);
+await agent.ask('Hi from OpenAI');
+agent.setProvider('anthropic');
+await agent.ask('Now from Claude');
+```
+
+## Add tools, swap blocks live
+
+```ts
+import { setupAgent, openaiPreset } from '@moxxy/agent';
+import { defineTool } from '@moxxy/sdk';
+import { z } from 'zod';
+
+const agent = setupAgent(openaiPreset({ apiKey: process.env.OPENAI_API_KEY }));
+
+agent.addTool(
+  defineTool({
+    name: 'get_weather',
+    description: 'Current weather for a city.',
+    inputSchema: z.object({ city: z.string() }),
+    handler: async ({ city }) => `Sunny in ${city}.`,
+  }),
+);
+
+console.log(await agent.ask("What's the weather in Paris?"));
+```
+
+`agent.session` is the live moxxy [`Session`](https://www.npmjs.com/package/@moxxy/core)
+— full control for anything the sugar doesn't cover.
+
+## Presets
+
+| preset | options |
+|---|---|
+| `openaiPreset(opts?)` | `apiKey` (→ `OPENAI_API_KEY`), `model`, `baseURL` (OpenAI-compatible vendors: z.ai/xAI/Google/Ollama) |
+| `anthropicPreset(opts?)` | `apiKey` (→ `ANTHROPIC_API_KEY`), `model` |
+
+Need more control or a different provider/mode? Drop down to
+[`@moxxy/core`](https://www.npmjs.com/package/@moxxy/core)'s `setupAgent({ plugins, provider, tools, … })`
+and register any blocks you like — `@moxxy/agent` re-exports `setupAgent` and all
+its types.
+
+## License
+
+MIT

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@moxxy/plugin-provider-openai",
-  "version": "0.0.23",
-  "description": "OpenAI (and OpenAI-compatible: z.ai, xAI, Google, Ollama/local) LLMProvider plugin for moxxy. Streams Chat Completions with tool_calls; translates moxxy ProviderRequest/Event ↔ the OpenAI wire shape. Register it into an @moxxy/core Session to route turns to OpenAI-compatible models.",
-  "keywords": ["moxxy", "agent", "provider", "openai", "llm", "tool-calls"],
+  "name": "@moxxy/agent",
+  "version": "0.1.0",
+  "description": "Batteries-included entry to moxxy: one install + one call to run an agent. Bundles @moxxy/core, the default loop, and the OpenAI + Anthropic providers behind drop-in presets — `setupAgent(openaiPreset({ apiKey }))`.",
+  "keywords": ["moxxy", "agent", "agentic", "llm", "openai", "anthropic", "sdk"],
   "homepage": "https://moxxy.ai",
   "bugs": {
     "url": "https://github.com/moxxy-ai/moxxy/issues"
@@ -10,7 +10,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/moxxy-ai/moxxy.git",
-    "directory": "packages/plugin-provider-openai"
+    "directory": "packages/agent"
   },
   "author": "Michal Makowski <michal.makowski97@gmail.com>",
   "license": "MIT",
@@ -36,22 +36,18 @@
     "test": "vitest run",
     "clean": "rm -rf dist .turbo"
   },
-  "moxxy": {
-    "plugin": {
-      "entry": "./dist/index.js",
-      "kind": "provider"
-    }
-  },
   "dependencies": {
+    "@moxxy/core": "workspace:*",
     "@moxxy/sdk": "workspace:*",
-    "openai": "^4.80.0"
+    "@moxxy/mode-default": "workspace:*",
+    "@moxxy/plugin-provider-openai": "workspace:*",
+    "@moxxy/plugin-provider-anthropic": "workspace:*"
   },
   "devDependencies": {
     "@moxxy/tsconfig": "workspace:*",
     "@moxxy/vitest-preset": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:",
-    "zod": "catalog:"
+    "vitest": "catalog:"
   }
 }

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { setupAgent, openaiPreset, anthropicPreset } from './index.js';
+
+const ORIGINAL_OPENAI = process.env.OPENAI_API_KEY;
+afterEach(() => {
+  if (ORIGINAL_OPENAI === undefined) delete process.env.OPENAI_API_KEY;
+  else process.env.OPENAI_API_KEY = ORIGINAL_OPENAI;
+});
+
+describe('@moxxy/agent presets', () => {
+  it('openaiPreset → a single-call agent with openai active', () => {
+    const agent = setupAgent(openaiPreset({ apiKey: 'sk-test' }));
+    expect(agent.session.providers.getActiveName()).toBe('openai');
+    expect(typeof agent.ask).toBe('function');
+    expect(typeof agent.stream).toBe('function');
+  });
+
+  it('anthropicPreset → anthropic active', () => {
+    const agent = setupAgent(anthropicPreset({ apiKey: 'sk-ant' }));
+    expect(agent.session.providers.getActiveName()).toBe('anthropic');
+  });
+
+  it('an array of presets registers both providers (first active) and de-dupes the shared mode', () => {
+    const agent = setupAgent([openaiPreset({ apiKey: 'a' }), anthropicPreset({ apiKey: 'b' })]);
+    expect(agent.session.providers.getActiveName()).toBe('openai');
+    expect(
+      agent.session.providers
+        .list()
+        .map((d) => d.name)
+        .sort(),
+    ).toEqual(['anthropic', 'openai']);
+    agent.setProvider('anthropic');
+    expect(agent.session.providers.getActiveName()).toBe('anthropic');
+  });
+
+  it('falls back to the conventional env var for the api key', () => {
+    process.env.OPENAI_API_KEY = 'env-key';
+    expect(openaiPreset().provider?.config?.apiKey).toBe('env-key');
+    expect(openaiPreset({ apiKey: 'explicit' }).provider?.config?.apiKey).toBe('explicit');
+  });
+});

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,0 +1,88 @@
+/**
+ * `@moxxy/agent` — the batteries-included entry to moxxy.
+ *
+ * One install, one call. Where `@moxxy/core`'s {@link setupAgent} is the flexible,
+ * block-agnostic factory (you bring the plugins), this package bundles the
+ * default loop + the OpenAI and Anthropic providers behind drop-in **presets**:
+ *
+ *   import { setupAgent, openaiPreset } from '@moxxy/agent';
+ *   const { ask } = setupAgent(openaiPreset({ apiKey: process.env.OPENAI_API_KEY }));
+ *   console.log(await ask('Hello!'));
+ *
+ * A preset is just a pre-filled {@link AgentPreset}, so they compose — pass an
+ * array to register several providers at once (the first is active; swap with
+ * `agent.setProvider(name)`):
+ *
+ *   const agent = setupAgent([openaiPreset({ apiKey: a }), anthropicPreset({ apiKey: b })]);
+ *   agent.setProvider('anthropic'); // for the next turn
+ */
+
+import type { AgentPreset } from '@moxxy/core';
+import defaultModePlugin from '@moxxy/mode-default';
+import openaiPlugin from '@moxxy/plugin-provider-openai';
+import anthropicPlugin from '@moxxy/plugin-provider-anthropic';
+
+export interface ProviderPresetOptions {
+  /** API key. Defaults to the provider's conventional env var
+   *  (`OPENAI_API_KEY` / `ANTHROPIC_API_KEY`). */
+  readonly apiKey?: string;
+  /** Override the model id (otherwise the provider's default catalog applies). */
+  readonly model?: string;
+}
+
+export interface OpenAIPresetOptions extends ProviderPresetOptions {
+  /** Point at an OpenAI-compatible endpoint (z.ai, xAI, Google, Ollama/local). */
+  readonly baseURL?: string;
+}
+
+/** Drop `undefined` config fields so they don't override provider defaults. */
+function clean(config: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(config).filter(([, v]) => v !== undefined));
+}
+
+/**
+ * One-shop OpenAI (and OpenAI-compatible) preset: the default loop + the OpenAI
+ * provider, configured + activated. `setupAgent(openaiPreset({ apiKey }))`.
+ */
+export function openaiPreset(opts: OpenAIPresetOptions = {}): AgentPreset {
+  return {
+    plugins: [defaultModePlugin, openaiPlugin],
+    provider: {
+      name: 'openai',
+      config: clean({
+        apiKey: opts.apiKey ?? process.env.OPENAI_API_KEY,
+        model: opts.model,
+        baseURL: opts.baseURL,
+      }),
+    },
+  };
+}
+
+/**
+ * One-shop Anthropic (Claude) preset: the default loop + the Anthropic provider,
+ * configured + activated. `setupAgent(anthropicPreset({ apiKey }))`.
+ */
+export function anthropicPreset(opts: ProviderPresetOptions = {}): AgentPreset {
+  return {
+    plugins: [defaultModePlugin, anthropicPlugin],
+    provider: {
+      name: 'anthropic',
+      config: clean({
+        apiKey: opts.apiKey ?? process.env.ANTHROPIC_API_KEY,
+        model: opts.model,
+      }),
+    },
+  };
+}
+
+// Re-export the core entry + its types so an app needs only `@moxxy/agent`.
+export {
+  setupAgent,
+  type Agent,
+  type AgentPreset,
+  type SetupAgentOptions,
+  type MoxxyEvent,
+  type Plugin,
+  type ToolDef,
+  type PermissionResolver,
+} from '@moxxy/core';

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,125 @@
+# @moxxy/core
+
+The [moxxy](https://moxxy.ai) runtime, as a library. Construct an agentic
+**Session**, register the blocks you want (providers, tools, modes, compactors,
+channels, …), and run turns — embed moxxy's agent loop directly in your own code
+instead of going through the CLI or desktop app.
+
+`@moxxy/core` is the **engine + the block registries**. It ships *no* built-in
+LLM provider or loop strategy — those are swappable packages you register, so
+nothing is welded in.
+
+> **Just want to run an agent fast?** Use
+> [`@moxxy/agent`](https://www.npmjs.com/package/@moxxy/agent) —
+> `setupAgent(openaiPreset({ apiKey }))` and you're done. This package is the
+> layer underneath, for when you want full control of the blocks.
+
+## Install
+
+```bash
+npm i @moxxy/core @moxxy/sdk @moxxy/mode-default @moxxy/plugin-provider-openai
+```
+
+(`@moxxy/sdk` gives you the typed contracts + `define*` factories for authoring
+your own blocks.)
+
+## Quick start — `setupAgent`
+
+`setupAgent` wires a Session + your blocks in one synchronous call and hands back
+a small agent you destructure:
+
+```ts
+import { setupAgent } from '@moxxy/core';
+import defaultMode from '@moxxy/mode-default';
+import openai from '@moxxy/plugin-provider-openai';
+
+const { ask, stream, session } = setupAgent({
+  plugins: [defaultMode, openai],
+  provider: { name: 'openai', config: { apiKey: process.env.OPENAI_API_KEY } },
+});
+
+// `ask` → the final reply text (async):
+console.log(await ask('Say hello in French.'));
+
+// `stream` → an async generator yielding each event:
+for await (const event of stream('Now in German.')) {
+  if (event.type === 'assistant_chunk') process.stdout.write(event.delta);
+}
+```
+
+`collect(prompt)` resolves with every event; `session` is the live Session for
+anything the sugar doesn't cover.
+
+### Tools
+
+```ts
+import { defineTool } from '@moxxy/sdk';
+import { z } from 'zod';
+
+const { ask, addTool } = setupAgent({ plugins: [defaultMode, openai], provider: { name: 'openai' } });
+
+addTool(
+  defineTool({
+    name: 'get_weather',
+    description: 'Current weather for a city.',
+    inputSchema: z.object({ city: z.string() }),
+    handler: async ({ city }) => `It's sunny in ${city}.`,
+  }),
+);
+
+console.log(await ask("What's the weather in Paris?"));
+```
+
+### Hot-swap blocks between turns
+
+Nothing is hardcoded — the registries *are* the enable/disable/swap mechanism,
+exposed as chainable sugar (and on `agent.session` directly):
+
+```ts
+agent.setProvider('anthropic', { apiKey: process.env.ANTHROPIC_API_KEY }); // swap LLM
+agent.setMode('goal');                                                     // swap loop strategy
+agent.removeTool('get_weather');
+await agent.discover();                                                     // load npm plugins
+```
+
+## Under the hood (manual wiring)
+
+`setupAgent` is sugar over the raw API, which you can use directly:
+
+```ts
+import { Session, runTurn, autoAllowResolver } from '@moxxy/core';
+
+const session = new Session({ cwd: process.cwd(), permissionResolver: autoAllowResolver });
+session.pluginHost.registerStatic(defaultMode);
+session.pluginHost.registerStatic(openai);
+session.providers.setActive('openai', { apiKey: process.env.OPENAI_API_KEY });
+
+for await (const event of runTurn(session, 'Summarise the files in this repo.')) {
+  // …
+}
+```
+
+## What's in the box
+
+`setupAgent` + `Session` + `runTurn`/`collectTurn` · the registries
+(`ProviderRegistry`, `ToolRegistryImpl`, `ModeRegistry`, `CompactorRegistry`,
+`CacheStrategyRegistry`, `ChannelRegistryImpl`, `EmbedderRegistry`, …) ·
+`PluginHost` + plugin discovery/loading · `SessionPersistence` (save / resume) ·
+the `PermissionEngine` + resolvers (`autoAllowResolver`, `denyByDefaultResolver`,
+allow-list, callback) · the `EventLog` · skills · `createLogger`. The
+`@moxxy/sdk` types in the public surface (`MoxxyEvent`, `Plugin`, `ToolDef`,
+`PermissionResolver`, `RunTurnOptions`) are re-exported, so the API is fully
+typed from a single import.
+
+`packages/core/src/index.ts` is the curated public surface. The package is `0.x`:
+the API may still change between minor versions while it settles.
+
+## You bring the model
+
+`@moxxy/core` is provider-agnostic: it defines the `LLMProvider` contract (in
+`@moxxy/sdk`) but bundles no vendor. Register a provider plugin (or your own)
+before running a turn.
+
+## License
+
+MIT

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,22 @@
 {
   "name": "@moxxy/core",
-  "private": true,
   "version": "0.2.9",
-  "description": "Moxxy runtime: event log, plugin host, registries, permission engine.",
+  "description": "The moxxy runtime as a programmatic library: the agentic Session + runTurn loop, the event log, the plugin host, every block registry (providers, tools, modes, compactors, cache strategies, channels, …), session persistence, and the permission engine. Pair with @moxxy/sdk to build and embed moxxy agents in your own code.",
+  "keywords": ["moxxy", "agent", "agentic", "llm", "runtime", "framework", "plugins"],
+  "homepage": "https://moxxy.ai",
+  "bugs": {
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
+    "directory": "packages/core"
+  },
+  "author": "Michal Makowski <michal.makowski97@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,14 @@
 export { Session, type SessionOptions } from './session.js';
 export { runTurn, collectTurn, type RunTurnOptions } from './run-turn.js';
+export {
+  setupAgent,
+  type Agent,
+  type SetupAgentOptions,
+  type AgentPreset,
+} from './setup-agent.js';
+// Re-export the @moxxy/sdk types that appear in the setupAgent / Agent surface,
+// so the programmatic API is fully typed from a single `@moxxy/core` import.
+export type { MoxxyEvent, Plugin, ToolDef, PermissionResolver } from '@moxxy/sdk';
 export { createSubagentSpawner, clearRetainedChildren, type SubagentRuntime } from './subagents.js';
 export {
   loadPreferences,

--- a/packages/core/src/setup-agent.test.ts
+++ b/packages/core/src/setup-agent.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { definePlugin, defineProvider, defineTool, type LLMProvider } from '@moxxy/sdk';
+
+import { setupAgent } from './setup-agent.js';
+
+const tool = (name: string) =>
+  defineTool({ name, description: name, inputSchema: z.object({}), handler: () => 'ok' });
+
+const modePlugin = definePlugin({ name: 'mode-x', version: '0' });
+
+const providerPlugin = (provName: string) =>
+  definePlugin({
+    name: `prov-${provName}`,
+    version: '0',
+    providers: [
+      defineProvider({
+        name: provName,
+        models: [],
+        createClient: () => ({}) as unknown as LLMProvider,
+        validateKey: async () => ({ ok: true }),
+      }),
+    ],
+  });
+
+describe('setupAgent', () => {
+  it('returns a destructurable Agent with the expected methods', () => {
+    const { session, ask, stream, collect, discover, use, addTool, removeTool, setProvider, setMode } =
+      setupAgent();
+    for (const fn of [ask, stream, collect, discover, use, addTool, removeTool, setProvider, setMode]) {
+      expect(typeof fn).toBe('function');
+    }
+    expect(session.cwd).toBeTruthy();
+  });
+
+  it('registers tools from options and supports hot add/remove', () => {
+    const agent = setupAgent({ tools: [tool('a')] });
+    expect(agent.session.tools.has('a')).toBe(true);
+    agent.addTool(tool('b'));
+    expect(agent.session.tools.has('b')).toBe(true);
+    agent.removeTool('a');
+    expect(agent.session.tools.has('a')).toBe(false);
+  });
+
+  it('merges an array of presets, de-duping a shared plugin (no double-register throw)', () => {
+    // Both presets bring the same mode plugin → it must register once, not throw.
+    expect(() =>
+      setupAgent([{ plugins: [modePlugin] }, { plugins: [modePlugin], tools: [tool('t')] }]),
+    ).not.toThrow();
+  });
+
+  it('activates the FIRST preset provider; the others stay registered to swap to', () => {
+    const agent = setupAgent([
+      { plugins: [providerPlugin('openai')], provider: { name: 'openai' } },
+      { plugins: [providerPlugin('anthropic')], provider: { name: 'anthropic' } },
+    ]);
+    expect(agent.session.providers.getActiveName()).toBe('openai');
+    expect(
+      agent.session.providers
+        .list()
+        .map((d) => d.name)
+        .sort(),
+    ).toEqual(['anthropic', 'openai']);
+    agent.setProvider('anthropic');
+    expect(agent.session.providers.getActiveName()).toBe('anthropic');
+  });
+
+  it('hot-change methods are chainable (return the same agent)', () => {
+    const agent = setupAgent();
+    expect(agent.addTool(tool('x'))).toBe(agent);
+  });
+});

--- a/packages/core/src/setup-agent.ts
+++ b/packages/core/src/setup-agent.ts
@@ -1,0 +1,189 @@
+/**
+ * `setupAgent` — the one-call ergonomic entry to the moxxy runtime.
+ *
+ * Constructing a {@link Session}, registering a mode + provider plugins + tools,
+ * activating a provider, and calling {@link runTurn} is the standard boilerplate.
+ * This wraps all of it in a single SYNCHRONOUS call and hands back a small
+ * {@link Agent} you destructure:
+ *
+ *   import { setupAgent } from '@moxxy/core';
+ *   import defaultMode from '@moxxy/mode-default';
+ *   import openai from '@moxxy/plugin-provider-openai';
+ *
+ *   const { ask, stream, session } = setupAgent({
+ *     plugins: [defaultMode, openai],
+ *     provider: { name: 'openai', config: { apiKey: process.env.OPENAI_API_KEY } },
+ *     tools: [myTool],
+ *   });
+ *
+ *   console.log(await ask('Hello!'));               // final reply text (async)
+ *   for await (const e of stream('Go on…')) { … }   // event stream (async generator)
+ *
+ * Two ways to run a turn: `stream()` is a proper async generator that YIELDS each
+ * {@link MoxxyEvent} as it happens; `ask()`/`collect()` are async — the final
+ * text, or every event. The methods close over the session (no `this`), so
+ * destructuring is safe. `session` is the LIVE session — hot-change blocks
+ * between turns through it (or the `setProvider`/`setMode`/`use`/`addTool` sugar).
+ * It stays block-agnostic: you pass the provider/mode PLUGINS in, so `@moxxy/core`
+ * never depends on a vendor.
+ */
+
+import type { MoxxyEvent, PermissionResolver, Plugin, RunTurnOptions, ToolDef } from '@moxxy/sdk';
+
+import { Session, type SessionOptions } from './session.js';
+import { runTurn, collectTurn } from './run-turn.js';
+import { autoAllowResolver, denyByDefaultResolver } from './permissions/resolvers.js';
+
+export interface SetupAgentOptions {
+  /** Working directory the agent operates in. Defaults to `process.cwd()`. */
+  readonly cwd?: string;
+  /** Plugins to register up front — modes, providers, tool-packs, … (order kept). */
+  readonly plugins?: readonly Plugin[];
+  /** Tools to register directly (sugar over authoring a one-tool plugin). */
+  readonly tools?: readonly ToolDef[];
+  /** Activate a provider after registration: its registered `name` + the config
+   *  its `createClient` needs (e.g. `{ apiKey }`). */
+  readonly provider?: { readonly name: string; readonly config?: Record<string, unknown> };
+  /** Permission policy: `'auto'` (approve every tool call — frictionless headless
+   *  default), `'deny'` (refuse all), or a custom {@link PermissionResolver}. */
+  readonly permissions?: 'auto' | 'deny' | PermissionResolver;
+  /** Any other {@link SessionOptions} (logger, secretResolver, pluginLoader,
+   *  pluginDiscoveryPaths, …). */
+  readonly session?: Omit<SessionOptions, 'cwd' | 'permissionResolver'>;
+}
+
+export interface Agent {
+  /** The underlying live {@link Session} — full control + hot-change escape hatch
+   *  (`session.providers`, `session.tools`, `session.modes`, `session.pluginHost`). */
+  readonly session: Session;
+
+  /** Run one turn as an async generator, YIELDING each event as it happens:
+   *  `for await (const e of stream(prompt)) …`. */
+  stream(prompt: string, opts?: RunTurnOptions): AsyncGenerator<MoxxyEvent, void, void>;
+  /** Run one turn; resolve with the final assistant text (`''` if none). */
+  ask(prompt: string, opts?: RunTurnOptions): Promise<string>;
+  /** Run one turn; resolve with every emitted event. */
+  collect(prompt: string, opts?: RunTurnOptions): Promise<ReadonlyArray<MoxxyEvent>>;
+  /** Discover + load plugins from `node_modules` (and `pluginDiscoveryPaths`).
+   *  Async; resolves with this agent for chaining. */
+  discover(): Promise<Agent>;
+
+  // ---- hot-change sugar (mutates the live session; chainable) ----
+  /** Register another plugin (mode / provider / tool-pack) on the live session. */
+  use(plugin: Plugin): Agent;
+  /** Register a tool on the live session. */
+  addTool(tool: ToolDef): Agent;
+  /** Remove a registered tool by name. */
+  removeTool(name: string): Agent;
+  /** Swap the active provider (and its config) for subsequent turns. */
+  setProvider(name: string, config?: Record<string, unknown>): Agent;
+  /** Swap the active loop strategy (mode) for subsequent turns. */
+  setMode(name: string): Agent;
+}
+
+function resolvePermissions(p: SetupAgentOptions['permissions']): PermissionResolver {
+  if (p === 'deny') return denyByDefaultResolver;
+  if (p === undefined || p === 'auto') return autoAllowResolver;
+  return p;
+}
+
+function finalText(events: ReadonlyArray<MoxxyEvent>): string {
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const e = events[i]!;
+    if (e.type === 'assistant_message') return e.content;
+  }
+  return '';
+}
+
+/** A reusable, pre-filled chunk of {@link SetupAgentOptions} — e.g. a provider
+ *  "preset" that bundles a provider plugin + the default mode + its config, so
+ *  `setupAgent(openaiPreset({ apiKey }))` is a one-line drop-in. A preset is just
+ *  an options object, so presets compose: pass an array and they merge. */
+export type AgentPreset = SetupAgentOptions;
+
+/** Merge an array of presets into one options object: plugins concatenate
+ *  (de-duped by name, so two presets both bringing the default mode register it
+ *  once), tools concatenate, and the FIRST preset that names a provider wins as
+ *  the active one (the others are still registered, so you can `setProvider` to
+ *  swap). cwd/permissions take the first set; session options shallow-merge. */
+function mergePresets(presets: readonly SetupAgentOptions[]): SetupAgentOptions {
+  const plugins: Plugin[] = [];
+  const seen = new Set<string>();
+  const tools: ToolDef[] = [];
+  let provider: SetupAgentOptions['provider'];
+  let cwd: string | undefined;
+  let permissions: SetupAgentOptions['permissions'];
+  let session: SetupAgentOptions['session'];
+  for (const p of presets) {
+    for (const pl of p.plugins ?? []) {
+      if (seen.has(pl.name)) continue;
+      seen.add(pl.name);
+      plugins.push(pl);
+    }
+    if (p.tools) tools.push(...p.tools);
+    if (!provider && p.provider) provider = p.provider;
+    cwd ??= p.cwd;
+    permissions ??= p.permissions;
+    if (p.session) session = { ...session, ...p.session };
+  }
+  return { plugins, tools, provider, cwd, permissions, session };
+}
+
+/**
+ * Build a ready-to-run {@link Agent}. Synchronous — destructure the result.
+ * Accepts a full options object, a single {@link AgentPreset}, or an ARRAY of
+ * presets that are merged (see {@link mergePresets}):
+ *
+ *   setupAgent(openaiPreset({ apiKey }))
+ *   setupAgent([openaiPreset({ apiKey }), anthropicPreset({ apiKey })]) // both; openai active
+ */
+export function setupAgent(input: SetupAgentOptions | readonly SetupAgentOptions[] = {}): Agent {
+  const opts = Array.isArray(input) ? mergePresets(input) : (input as SetupAgentOptions);
+  const session = new Session({
+    cwd: opts.cwd ?? process.cwd(),
+    permissionResolver: resolvePermissions(opts.permissions),
+    ...opts.session,
+  });
+
+  for (const plugin of opts.plugins ?? []) session.pluginHost.registerStatic(plugin);
+  for (const tool of opts.tools ?? []) session.tools.register(tool);
+  if (opts.provider) session.providers.setActive(opts.provider.name, opts.provider.config);
+
+  const agent: Agent = {
+    session,
+    async *stream(prompt, runOpts) {
+      yield* runTurn(session, prompt, runOpts);
+    },
+    async ask(prompt, runOpts) {
+      return finalText(await collectTurn(session, prompt, runOpts));
+    },
+    collect(prompt, runOpts) {
+      return collectTurn(session, prompt, runOpts);
+    },
+    async discover() {
+      await session.pluginHost.discoverAndLoad();
+      return agent;
+    },
+    use(plugin) {
+      session.pluginHost.registerStatic(plugin);
+      return agent;
+    },
+    addTool(tool) {
+      session.tools.register(tool);
+      return agent;
+    },
+    removeTool(name) {
+      session.tools.unregister(name);
+      return agent;
+    },
+    setProvider(name, config) {
+      session.providers.setActive(name, config);
+      return agent;
+    },
+    setMode(name) {
+      session.modes.setActive(name);
+      return agent;
+    },
+  };
+  return agent;
+}

--- a/packages/desktop-app-sdk/package.json
+++ b/packages/desktop-app-sdk/package.json
@@ -1,8 +1,22 @@
 {
   "name": "@moxxy/desktop-app-sdk",
-  "private": true,
   "version": "0.1.0",
   "description": "The contract for moxxy desktop mini-apps: the moxxy-app.json manifest schema + capability list, the host<->app bridge protocol, and the tiny browser client an app imports to call host services over postMessage. Lets anyone (or an agent) build a sandboxed web app that installs into the desktop Apps gallery.",
+  "keywords": ["moxxy", "desktop", "electron", "mini-apps", "app-sdk", "sandbox"],
+  "homepage": "https://moxxy.ai",
+  "bugs": {
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
+    "directory": "packages/desktop-app-sdk"
+  },
+  "author": "Michal Makowski <michal.makowski97@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/desktop-app-sdk/package.json
+++ b/packages/desktop-app-sdk/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@moxxy/desktop-app-sdk",
+  "private": true,
+  "version": "0.1.0",
+  "description": "The contract for moxxy desktop mini-apps: the moxxy-app.json manifest schema + capability list, the host<->app bridge protocol, and the tiny browser client an app imports to call host services over postMessage. Lets anyone (or an agent) build a sandboxed web app that installs into the desktop Apps gallery.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "import": "./dist/client.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/desktop-app-sdk/src/bridge.ts
+++ b/packages/desktop-app-sdk/src/bridge.ts
@@ -1,0 +1,109 @@
+/**
+ * The host<->app bridge protocol.
+ *
+ * A mini-app runs in a cross-origin iframe (origin `moxxy-app://assets/<id>`),
+ * isolated from the host renderer by the same-origin policy. The only channel
+ * between them is `window.postMessage`. This module defines the wire envelopes
+ * and the typed method map carried over it; {@link ./client} is the app-side
+ * convenience wrapper, and the host renderer relays each request to the main
+ * process (which enforces the app's declared {@link ./permissions}).
+ *
+ * Each method maps to ONE permission. The host refuses (errors) any request for
+ * a method whose permission the app didn't declare in its manifest — so the
+ * manifest is the complete grant list and the bridge can't be used to reach a
+ * capability the user didn't consent to at install.
+ */
+
+import type { AppPermission } from './permissions.js';
+
+/** Minimal PII span shape the anonymizer bridge returns. Kept self-contained so
+ *  the SDK doesn't depend on `@moxxy/anonymizer`; the host maps its richer span
+ *  onto this. Offsets are into the text the app passed in. */
+export interface BridgeSpan {
+  readonly start: number;
+  readonly end: number;
+  readonly category: string;
+  /** The replacement the app should substitute (label / pseudonym / hash). */
+  readonly replacement: string;
+}
+
+/** The typed method map: method name -> its params and result. The host
+ *  implements each; the client calls each. Extend here (and add the matching
+ *  permission + host handler) to grow the platform. */
+export interface BridgeMethods {
+  /** Native open dialog -> the picked document's EXTRACTED TEXT (parsed in main:
+   *  PDF/Office/ODF/text). `null` when the user cancels. The app never gets a
+   *  path. Requires `documents.open`. */
+  'documents.open': {
+    params: undefined;
+    result: { text: string; name: string } | { error: string } | null;
+  };
+  /** Native save dialog -> writes `content` ONLY where the user points. Returns
+   *  the chosen path, or `null` if cancelled. Requires `documents.save`. */
+  'documents.save': {
+    params: { suggestedName: string; content: string };
+    result: { path: string } | null;
+  };
+  /** Run the on-device structured PII engine (`@moxxy/anonymizer`) — emails,
+   *  phones, cards, SSNs, IPs, IBANs, URLs, custom terms. Offline. Requires
+   *  `anonymizer.engine`. */
+  'anonymizer.detect': {
+    params: { text: string; mode?: 'label' | 'pseudonym' | 'hash'; customTerms?: string[] };
+    result: { spans: BridgeSpan[] };
+  };
+}
+
+export type BridgeMethod = keyof BridgeMethods;
+
+/** Permission required for each bridge method — the single source the host gate
+ *  checks. A method with no entry is host-internal and never app-callable. */
+export const METHOD_PERMISSION: Readonly<Record<BridgeMethod, AppPermission>> = {
+  'documents.open': 'documents.open',
+  'documents.save': 'documents.save',
+  'anonymizer.detect': 'anonymizer.engine',
+};
+
+/** Tag on every bridge envelope so unrelated `message` events are ignored. */
+export const BRIDGE_TAG = 'moxxy-app-bridge' as const;
+
+/** App -> host: invoke a method. `id` correlates the response. */
+export interface BridgeRequest<M extends BridgeMethod = BridgeMethod> {
+  readonly __moxxy: typeof BRIDGE_TAG;
+  readonly kind: 'request';
+  readonly id: number;
+  readonly method: M;
+  readonly params: BridgeMethods[M]['params'];
+}
+
+/** Host -> app: the result of a request (or an error). */
+export type BridgeResponse<M extends BridgeMethod = BridgeMethod> = {
+  readonly __moxxy: typeof BRIDGE_TAG;
+  readonly kind: 'response';
+  readonly id: number;
+} & (
+  | { readonly ok: true; readonly result: BridgeMethods[M]['result'] }
+  | { readonly ok: false; readonly error: string }
+);
+
+/** Host -> app, once, when the host has wired its listener: the app may start
+ *  calling methods. Carries the app's granted permissions so the client can
+ *  fail fast on an ungranted call without a round-trip. */
+export interface BridgeReady {
+  readonly __moxxy: typeof BRIDGE_TAG;
+  readonly kind: 'ready';
+  readonly permissions: readonly AppPermission[];
+}
+
+export type BridgeOutbound = BridgeResponse | BridgeReady;
+export type BridgeInbound = BridgeRequest;
+
+export function isBridgeRequest(value: unknown): value is BridgeRequest {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    (value as { __moxxy?: unknown }).__moxxy === BRIDGE_TAG &&
+    (value as { kind?: unknown }).kind === 'request' &&
+    typeof (value as { id?: unknown }).id === 'number' &&
+    typeof (value as { method?: unknown }).method === 'string'
+  );
+}

--- a/packages/desktop-app-sdk/src/client.ts
+++ b/packages/desktop-app-sdk/src/client.ts
@@ -1,0 +1,118 @@
+/**
+ * The app-side bridge client. A mini-app's web bundle imports
+ * `@moxxy/desktop-app-sdk/client`, calls {@link connectMoxxyApp}, and then uses
+ * typed promises — `await moxxy.openDocument()` — instead of hand-rolling
+ * `postMessage`. Everything is funnelled to the host renderer (the iframe
+ * parent), correlated by an incrementing id, and resolved when the matching
+ * response arrives. A call to a method the app didn't get permission for rejects
+ * immediately (the host told us the grant set in the ready handshake), without a
+ * round-trip.
+ *
+ * This file is the ONLY part of the SDK that touches `window`, so apps that only
+ * need the manifest types never pull DOM globals in.
+ */
+
+import {
+  BRIDGE_TAG,
+  METHOD_PERMISSION,
+  type BridgeMethod,
+  type BridgeMethods,
+  type BridgeOutbound,
+  type BridgeRequest,
+} from './bridge.js';
+import type { AppPermission } from './permissions.js';
+
+export interface MoxxyApp {
+  /** Capabilities the host granted this app (its manifest's `permissions`). */
+  readonly permissions: readonly AppPermission[];
+  /** Invoke a bridge method. Rejects if the method's permission wasn't granted,
+   *  or with the host's error message on failure. */
+  call<M extends BridgeMethod>(
+    method: M,
+    params: BridgeMethods[M]['params'],
+  ): Promise<BridgeMethods[M]['result']>;
+  /** Sugar for the common methods. */
+  openDocument(): Promise<BridgeMethods['documents.open']['result']>;
+  saveDocument(
+    suggestedName: string,
+    content: string,
+  ): Promise<BridgeMethods['documents.save']['result']>;
+}
+
+/**
+ * Connect to the host. Resolves once the host's `ready` handshake arrives (so
+ * the granted permission set is known). Rejects if no host responds within
+ * `timeoutMs` — i.e. the bundle was opened outside the desktop sandbox.
+ */
+export function connectMoxxyApp(timeoutMs = 8000): Promise<MoxxyApp> {
+  const parent = window.parent;
+  if (!parent || parent === window) {
+    return Promise.reject(new Error('not running inside the moxxy app host'));
+  }
+
+  let nextId = 1;
+  const pending = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+  >();
+  let granted: readonly AppPermission[] | null = null;
+
+  return new Promise<MoxxyApp>((resolveReady, rejectReady) => {
+    const timer = setTimeout(() => {
+      window.removeEventListener('message', onMessage);
+      rejectReady(new Error('moxxy app host did not respond'));
+    }, timeoutMs);
+
+    const onMessage = (e: MessageEvent): void => {
+      const data = e.data as BridgeOutbound | undefined;
+      if (!data || data.__moxxy !== BRIDGE_TAG) return;
+
+      if (data.kind === 'ready') {
+        if (granted) return; // already connected; ignore duplicates
+        granted = data.permissions;
+        clearTimeout(timer);
+        resolveReady(makeApp());
+        return;
+      }
+      if (data.kind === 'response') {
+        const waiter = pending.get(data.id);
+        if (!waiter) return;
+        pending.delete(data.id);
+        if (data.ok) waiter.resolve(data.result);
+        else waiter.reject(new Error(data.error));
+      }
+    };
+    window.addEventListener('message', onMessage);
+
+    function call<M extends BridgeMethod>(
+      method: M,
+      params: BridgeMethods[M]['params'],
+    ): Promise<BridgeMethods[M]['result']> {
+      const need = METHOD_PERMISSION[method];
+      if (!granted || !granted.includes(need)) {
+        return Promise.reject(
+          new Error(`this app is not permitted to call ${method} (needs "${need}")`),
+        );
+      }
+      const id = nextId++;
+      const req: BridgeRequest<M> = { __moxxy: BRIDGE_TAG, kind: 'request', id, method, params };
+      return new Promise((resolve, reject) => {
+        pending.set(id, { resolve: resolve as (v: unknown) => void, reject });
+        // Target the host origin loosely ('*') — the iframe only ever has ONE
+        // parent (the host renderer), and the host validates the source frame +
+        // app id on its side. No secrets travel in params.
+        parent.postMessage(req, '*');
+      });
+    }
+
+    function makeApp(): MoxxyApp {
+      return {
+        permissions: granted ?? [],
+        call,
+        openDocument: () => call('documents.open', undefined),
+        saveDocument: (suggestedName, content) =>
+          call('documents.save', { suggestedName, content }),
+      };
+    }
+  });
+}

--- a/packages/desktop-app-sdk/src/index.ts
+++ b/packages/desktop-app-sdk/src/index.ts
@@ -1,0 +1,40 @@
+/**
+ * `@moxxy/desktop-app-sdk` — the contract for moxxy desktop mini-apps.
+ *
+ * Host + renderer import this barrel for the manifest schema, the capability
+ * list, and the bridge protocol types. Apps import `@moxxy/desktop-app-sdk/client`
+ * for the browser-side bridge client (the only DOM-touching entry).
+ */
+
+export {
+  APP_ID_RE,
+  appAssetSchema,
+  appInstallSchema,
+  appManifestSchema,
+  parseAppManifest,
+  type AppManifest,
+  type AppAssetManifest,
+  type ManifestParseOk,
+  type ManifestParseError,
+} from './manifest.js';
+
+export {
+  APP_PERMISSIONS,
+  PERMISSION_LABELS,
+  isAppPermission,
+  type AppPermission,
+} from './permissions.js';
+
+export {
+  BRIDGE_TAG,
+  METHOD_PERMISSION,
+  isBridgeRequest,
+  type BridgeMethod,
+  type BridgeMethods,
+  type BridgeSpan,
+  type BridgeRequest,
+  type BridgeResponse,
+  type BridgeReady,
+  type BridgeInbound,
+  type BridgeOutbound,
+} from './bridge.js';

--- a/packages/desktop-app-sdk/src/manifest.test.ts
+++ b/packages/desktop-app-sdk/src/manifest.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseAppManifest, appManifestSchema } from './manifest';
+
+const VALID = {
+  manifestVersion: 1,
+  id: 'my-app',
+  name: 'My App',
+  description: 'Does a thing.',
+  icon: 'sparkles',
+  version: '1.0.0',
+  permissions: ['documents.open'],
+};
+
+describe('parseAppManifest', () => {
+  it('accepts a minimal valid manifest and fills UI/permission defaults', () => {
+    const r = parseAppManifest(JSON.stringify({ ...VALID, permissions: undefined }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.manifest.ui.entry).toBe('index.html'); // default
+    expect(r.manifest.permissions).toEqual([]); // default
+  });
+
+  it('reports malformed JSON cleanly', () => {
+    expect(parseAppManifest('{not json')).toEqual({ ok: false, error: 'manifest is not valid JSON' });
+  });
+
+  it('rejects a bad id (path-unsafe)', () => {
+    const r = parseAppManifest(JSON.stringify({ ...VALID, id: '../evil' }));
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain('id');
+  });
+
+  it('rejects an unknown permission', () => {
+    const r = parseAppManifest(JSON.stringify({ ...VALID, permissions: ['fs.readAll'] }));
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects unknown top-level fields (strict schema)', () => {
+    const r = parseAppManifest(JSON.stringify({ ...VALID, danger: true }));
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects a traversal in ui.entry', () => {
+    const r = parseAppManifest(JSON.stringify({ ...VALID, ui: { entry: '../../etc/passwd' } }));
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires allowedHosts when install assets are present', () => {
+    const r = parseAppManifest(
+      JSON.stringify({
+        ...VALID,
+        install: { version: 'v1', assets: [{ url: 'https://x.co/a', dest: 'a' }] },
+      }),
+    );
+    expect(r.ok).toBe(false); // allowedHosts missing
+  });
+
+  it('accepts an install bundle with assets + allowedHosts', () => {
+    const r = parseAppManifest(
+      JSON.stringify({
+        ...VALID,
+        permissions: ['anonymizer.engine'],
+        install: {
+          version: 'model-v1',
+          assets: [{ url: 'https://huggingface.co/m/resolve/main/model.onnx', dest: 'model.onnx' }],
+          allowedHosts: ['huggingface.co'],
+        },
+      }),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects an absolute asset dest', () => {
+    const parsed = appManifestSchema.safeParse({
+      ...VALID,
+      install: { version: 'v1', assets: [{ url: 'https://x.co/a', dest: '/etc/passwd' }], allowedHosts: ['x.co'] },
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/packages/desktop-app-sdk/src/manifest.ts
+++ b/packages/desktop-app-sdk/src/manifest.ts
@@ -1,0 +1,129 @@
+/**
+ * The `moxxy-app.json` manifest — the single declarative description of a
+ * desktop mini-app. A first-party app (anonymizer) ships one in its bundle; a
+ * custom/third-party app is just a folder under `userData/moxxy-apps/<id>/`
+ * containing this file, its `ui/` web bundle, and any installed assets. The
+ * desktop discovers + validates the manifest at runtime — no recompile.
+ *
+ * Everything an app can do is declared here (its UI entry, the assets it
+ * downloads + the hosts it may reach to do so, and the host capabilities it
+ * requests), so the manifest is the complete, auditable security surface. The
+ * schema is strict (`.strict()`): an unknown field is a validation error, not
+ * silently ignored, so a typo never grants something unintended.
+ */
+
+import { z } from 'zod';
+
+import { APP_PERMISSIONS } from './permissions.js';
+
+/** A slug used as the app id AND a filesystem dir AND a `moxxy-app://` host
+ *  segment — so it must be a strict, separator-free, traversal-free token. */
+export const APP_ID_RE = /^[a-z][a-z0-9-]{0,62}$/;
+
+/** A relative path inside the app dir (for `ui.entry` and asset `dest`): no
+ *  absolute paths, no `..` segment, no backslashes, no NUL, no leading slash. */
+const relPath = z
+  .string()
+  .min(1)
+  .max(1024)
+  .refine(
+    (p) =>
+      !p.includes('\0') &&
+      !p.includes('\\') &&
+      !p.startsWith('/') &&
+      !p.split('/').some((seg) => seg === '..' || seg === ''),
+    'must be a relative path with no "..", leading slash, backslash, or empty segment',
+  );
+
+/** One downloadable install asset. Mirrors the host installer's `AppAsset` so a
+ *  manifest's `install.assets` drop straight into the existing download path. */
+export const appAssetSchema = z
+  .object({
+    /** Source URL — fetched once at install (main process), host-allow-listed. */
+    url: z.string().url().max(2048),
+    /** Destination relative path under the app dir; also the `moxxy-app://`
+     *  sub-path the UI fetches it back from. */
+    dest: relPath,
+    /** Advisory expected size (drives the progress bar before Content-Length). */
+    bytes: z.number().int().nonnegative().optional(),
+    /** Optional hex sha256, verified post-download when present. */
+    sha256: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/i)
+      .optional(),
+  })
+  .strict();
+
+export const appInstallSchema = z
+  .object({
+    /** Bump to force existing installs to re-download (recorded in installed.json). */
+    version: z.string().min(1).max(128),
+    assets: z.array(appAssetSchema).min(1).max(256),
+    /** Hostnames this app may fetch its assets FROM (exact or subdomain match).
+     *  REQUIRED when there are assets — there is no global default host, so each
+     *  app's egress is explicit + auditable (no app inherits another's allow-list). */
+    allowedHosts: z.array(z.string().min(1).max(253)).min(1).max(32),
+  })
+  .strict();
+
+export const appManifestSchema = z
+  .object({
+    /** Schema version — bump on a breaking manifest change. */
+    manifestVersion: z.literal(1),
+    id: z.string().regex(APP_ID_RE),
+    name: z.string().min(1).max(80),
+    description: z.string().min(1).max(400),
+    /** An icon name from the host's icon set (validated against it at register
+     *  time; kept a plain string here so the SDK stays UI-framework-neutral). */
+    icon: z.string().min(1).max(64),
+    /** App version — distinct from `install.version`; shown in the gallery. */
+    version: z.string().min(1).max(64),
+    /** Show the "Offline · on-device" badge. Apps that declare NO network at
+     *  install (no `install`) and no networking permission are offline by nature. */
+    offline: z.boolean().optional(),
+    ui: z
+      .object({
+        /** Entry HTML relative to `<appDir>/ui/`, loaded in the sandbox iframe. */
+        entry: relPath.default('index.html'),
+      })
+      .strict()
+      .default({ entry: 'index.html' }),
+    install: appInstallSchema.optional(),
+    /** Host capabilities the app may call over the bridge (closed set). */
+    permissions: z.array(z.enum(APP_PERMISSIONS)).max(APP_PERMISSIONS.length).default([]),
+  })
+  .strict();
+
+export type AppManifest = z.infer<typeof appManifestSchema>;
+export type AppAssetManifest = z.infer<typeof appAssetSchema>;
+
+export interface ManifestParseOk {
+  ok: true;
+  manifest: AppManifest;
+}
+export interface ManifestParseError {
+  ok: false;
+  error: string;
+}
+
+/**
+ * Parse + validate raw manifest JSON text. Returns a discriminated result (never
+ * throws) so callers — the host discovery scan and the create-app skill's
+ * validator — can surface a precise message for a malformed manifest without a
+ * try/catch. The first zod issue is formatted as `path: message`.
+ */
+export function parseAppManifest(text: string): ManifestParseOk | ManifestParseError {
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    return { ok: false, error: 'manifest is not valid JSON' };
+  }
+  const result = appManifestSchema.safeParse(json);
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const where = issue?.path.length ? issue.path.join('.') : 'manifest';
+    return { ok: false, error: `${where}: ${issue?.message ?? 'invalid manifest'}` };
+  }
+  return { ok: true, manifest: result.data };
+}

--- a/packages/desktop-app-sdk/src/permissions.ts
+++ b/packages/desktop-app-sdk/src/permissions.ts
@@ -1,0 +1,48 @@
+/**
+ * The capability model for desktop mini-apps.
+ *
+ * A sandboxed app (a web bundle loaded in a cross-origin iframe from
+ * `moxxy-app://`) can reach NOTHING by default — it has no Node, no IPC, no
+ * filesystem. Every host service it wants must be (a) declared in its
+ * `moxxy-app.json` `permissions` and (b) actually requested by the user/host at
+ * install time. The host bridge refuses any bridge call whose backing permission
+ * the app didn't declare, so the manifest is the complete, auditable list of
+ * what an app can do.
+ *
+ * Keep this list SMALL and purpose-specific (capability per task, not "fs
+ * access"): each permission maps to one confined host service, never a generic
+ * primitive a malicious app could turn into arbitrary file/network access.
+ */
+
+/** Every capability a mini-app may declare. Closed set — the host only honours
+ *  these strings; an unknown permission in a manifest is rejected. */
+export const APP_PERMISSIONS = [
+  /** Open a document through the native picker and receive its EXTRACTED TEXT
+   *  (PDF/Office/ODF/text, parsed in the main process). The app never sees a
+   *  path and cannot read arbitrary files — only what the user explicitly picks. */
+  'documents.open',
+  /** Save app-produced text/bytes to a user-chosen location via the native Save
+   *  dialog. The app names a default; main writes ONLY where the user points. */
+  'documents.save',
+  /** Run the on-device `@moxxy/anonymizer` engine (pure, offline PII detection +
+   *  redaction) as a host service. No network, no model — structured detectors
+   *  only. (On-device NER needs no permission: an app runs its own model from
+   *  its own installed assets, fetched same-origin inside its sandbox.) */
+  'anonymizer.engine',
+] as const;
+
+export type AppPermission = (typeof APP_PERMISSIONS)[number];
+
+const PERMISSION_SET: ReadonlySet<string> = new Set(APP_PERMISSIONS);
+
+export function isAppPermission(value: unknown): value is AppPermission {
+  return typeof value === 'string' && PERMISSION_SET.has(value);
+}
+
+/** Human-readable summary of each permission, shown in the install consent UI so
+ *  the user sees exactly what an app is asking for before they install it. */
+export const PERMISSION_LABELS: Readonly<Record<AppPermission, string>> = {
+  'documents.open': 'Open documents you choose (reads only what you pick)',
+  'documents.save': 'Save its output to a location you choose',
+  'anonymizer.engine': 'Detect & redact personal data on your device (offline)',
+};

--- a/packages/desktop-app-sdk/tsconfig.json
+++ b/packages/desktop-app-sdk/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": []
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/desktop-app-sdk/vitest.config.ts
+++ b/packages/desktop-app-sdk/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/packages/desktop-host/package.json
+++ b/packages/desktop-host/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@moxxy/core": "workspace:*",
+    "@moxxy/desktop-app-sdk": "workspace:*",
     "@moxxy/desktop-ipc-contract": "workspace:*",
     "@moxxy/plugin-stt-whisper-codex": "workspace:*",
     "@moxxy/plugin-vault": "workspace:*",

--- a/packages/desktop-host/src/apps/bridge-host.test.ts
+++ b/packages/desktop-host/src/apps/bridge-host.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AppManifest } from '@moxxy/desktop-app-sdk';
+
+import { dispatchBridge, type BridgeServices } from './bridge-host';
+
+const manifest = (permissions: AppManifest['permissions']): AppManifest => ({
+  manifestVersion: 1,
+  id: 'demo',
+  name: 'Demo',
+  description: 'd',
+  icon: 'sparkles',
+  version: '1.0.0',
+  ui: { entry: 'index.html' },
+  permissions,
+});
+
+const services = (): BridgeServices => ({
+  'documents.open': vi.fn(async () => ({ text: 'hello', name: 'a.txt' })),
+  'documents.save': vi.fn(async () => ({ path: '/tmp/out.txt' })),
+  'anonymizer.detect': vi.fn(async () => ({ spans: [] })),
+});
+
+describe('dispatchBridge (capability gate)', () => {
+  it('refuses a method whose permission the app did not declare', async () => {
+    const svc = services();
+    const r = await dispatchBridge(manifest([]), 'documents.open', undefined, svc);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain('not permitted');
+    expect(svc['documents.open']).not.toHaveBeenCalled(); // never ran
+  });
+
+  it('dispatches a granted method to its service', async () => {
+    const svc = services();
+    const r = await dispatchBridge(manifest(['documents.open']), 'documents.open', undefined, svc);
+    expect(r).toEqual({ ok: true, result: { text: 'hello', name: 'a.txt' } });
+    expect(svc['documents.open']).toHaveBeenCalledOnce();
+  });
+
+  it('refuses an unknown / forged method name', async () => {
+    const r = await dispatchBridge(manifest(['documents.open']), 'fs.readAll', undefined, services());
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain('unknown bridge method');
+  });
+
+  it('passes params through to documents.save and returns its result', async () => {
+    const svc = services();
+    const r = await dispatchBridge(
+      manifest(['documents.save']),
+      'documents.save',
+      { suggestedName: 'redacted.txt', content: 'x' },
+      svc,
+    );
+    expect(r).toEqual({ ok: true, result: { path: '/tmp/out.txt' } });
+    expect(svc['documents.save']).toHaveBeenCalledWith({ suggestedName: 'redacted.txt', content: 'x' });
+  });
+
+  it('turns a service error into a clean { ok:false } (never throws)', async () => {
+    const svc = services();
+    svc['anonymizer.detect'] = vi.fn(async () => {
+      throw new Error('engine boom');
+    });
+    const r = await dispatchBridge(manifest(['anonymizer.engine']), 'anonymizer.detect', { text: 'x' }, svc);
+    expect(r).toEqual({ ok: false, error: 'engine boom' });
+  });
+
+  it('grant of one capability does not imply another', async () => {
+    // App declared documents.open but tries documents.save → refused.
+    const svc = services();
+    const r = await dispatchBridge(
+      manifest(['documents.open']),
+      'documents.save',
+      { suggestedName: 'x', content: 'y' },
+      svc,
+    );
+    expect(r.ok).toBe(false);
+    expect(svc['documents.save']).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop-host/src/apps/bridge-host.ts
+++ b/packages/desktop-host/src/apps/bridge-host.ts
@@ -1,0 +1,103 @@
+/**
+ * The host side of the app<->host bridge: the capability GATE.
+ *
+ * A sandboxed app posts a {@link BridgeRequest} (it reaches the host renderer,
+ * which forwards it here over IPC with the app's id). Before ANY host service
+ * runs, this checks two things against the app's discovered manifest:
+ *   1. the requested `method` is a known bridge method, and
+ *   2. the permission that method requires is in the app's declared
+ *      `manifest.permissions`.
+ * A request for a method the app didn't declare is refused with a clear error —
+ * never executed. So the manifest the user consented to at install is the
+ * complete, enforced grant list; a compromised app's UI can't reach a capability
+ * it wasn't granted by forging a different method name.
+ *
+ * Electron-free + service-injected so it unit-tests in plain Node (the IPC layer
+ * supplies the real dialog/parse/engine services); the gate logic is the part
+ * worth testing in isolation.
+ */
+
+import {
+  METHOD_PERMISSION,
+  type AppManifest,
+  type AppPermission,
+  type BridgeMethod,
+  type BridgeMethods,
+} from '@moxxy/desktop-app-sdk';
+
+/** The host implementations behind each bridge method. The IPC layer provides
+ *  these (native dialogs + main-process parsing + the anonymizer engine); the
+ *  gate only calls one after the permission check passes. */
+export interface BridgeServices {
+  'documents.open': () => Promise<BridgeMethods['documents.open']['result']>;
+  'documents.save': (
+    p: BridgeMethods['documents.save']['params'],
+  ) => Promise<BridgeMethods['documents.save']['result']>;
+  'anonymizer.detect': (
+    p: BridgeMethods['anonymizer.detect']['params'],
+  ) => Promise<BridgeMethods['anonymizer.detect']['result']>;
+}
+
+export type BridgeDispatchResult =
+  | { readonly ok: true; readonly result: unknown }
+  | { readonly ok: false; readonly error: string };
+
+function isKnownMethod(method: string): method is BridgeMethod {
+  return Object.prototype.hasOwnProperty.call(METHOD_PERMISSION, method);
+}
+
+function granted(manifest: AppManifest, perm: AppPermission): boolean {
+  return manifest.permissions.includes(perm);
+}
+
+/**
+ * Validate + dispatch one bridge request for the app described by `manifest`.
+ * Never throws — a refused permission, an unknown method, or a service error all
+ * come back as `{ ok: false, error }` so the IPC layer relays a clean response
+ * to the app instead of a crash.
+ */
+export async function dispatchBridge(
+  manifest: AppManifest,
+  method: string,
+  params: unknown,
+  services: BridgeServices,
+): Promise<BridgeDispatchResult> {
+  if (!isKnownMethod(method)) {
+    return { ok: false, error: `unknown bridge method: ${method}` };
+  }
+  const need = METHOD_PERMISSION[method];
+  if (!granted(manifest, need)) {
+    return {
+      ok: false,
+      error: `app "${manifest.id}" is not permitted to call ${method} (needs "${need}")`,
+    };
+  }
+  try {
+    switch (method) {
+      case 'documents.open':
+        return { ok: true, result: await services['documents.open']() };
+      case 'documents.save':
+        return {
+          ok: true,
+          result: await services['documents.save'](
+            params as BridgeMethods['documents.save']['params'],
+          ),
+        };
+      case 'anonymizer.detect':
+        return {
+          ok: true,
+          result: await services['anonymizer.detect'](
+            params as BridgeMethods['anonymizer.detect']['params'],
+          ),
+        };
+      default: {
+        // Exhaustiveness guard: a new BridgeMethod added to the SDK without a
+        // case here is a compile error, not a silent passthrough.
+        const _never: never = method;
+        return { ok: false, error: `unhandled bridge method: ${String(_never)}` };
+      }
+    }
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/packages/desktop-host/src/apps/discover.test.ts
+++ b/packages/desktop-host/src/apps/discover.test.ts
@@ -1,0 +1,80 @@
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { discoverApps } from './discover';
+
+let root: string;
+
+const manifest = (over: Record<string, unknown> = {}): string =>
+  JSON.stringify({
+    manifestVersion: 1,
+    id: 'demo',
+    name: 'Demo',
+    description: 'A demo app.',
+    icon: 'sparkles',
+    version: '1.0.0',
+    permissions: ['documents.open'],
+    ...over,
+  });
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), 'moxxy-apps-'));
+});
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+async function writeApp(name: string, manifestText: string | null): Promise<void> {
+  const dir = path.join(root, name);
+  await mkdir(dir, { recursive: true });
+  if (manifestText !== null) await writeFile(path.join(dir, 'moxxy-app.json'), manifestText);
+}
+
+describe('discoverApps', () => {
+  it('returns an empty result when the root does not exist', async () => {
+    expect(await discoverApps(path.join(root, 'nope'))).toEqual({ apps: [], skipped: [] });
+  });
+
+  it('discovers a valid app folder', async () => {
+    await writeApp('demo', manifest());
+    const { apps, skipped } = await discoverApps(root);
+    expect(skipped).toEqual([]);
+    expect(apps).toHaveLength(1);
+    expect(apps[0]!.manifest.id).toBe('demo');
+    expect(apps[0]!.dir).toBe(path.join(root, 'demo'));
+  });
+
+  it('skips a folder whose manifest id != folder name (no masquerade)', async () => {
+    await writeApp('demo', manifest({ id: 'other' }));
+    const { apps, skipped } = await discoverApps(root);
+    expect(apps).toEqual([]);
+    expect(skipped[0]?.name).toBe('demo');
+    expect(skipped[0]?.reason).toContain('does not match folder name');
+  });
+
+  it('skips a malformed manifest but keeps scanning the rest', async () => {
+    await writeApp('bad', '{not json');
+    await writeApp('good', manifest({ id: 'good' }));
+    const { apps, skipped } = await discoverApps(root);
+    expect(apps.map((a) => a.manifest.id)).toEqual(['good']);
+    expect(skipped.map((s) => s.name)).toEqual(['bad']);
+  });
+
+  it('ignores plain asset dirs (no manifest) and non-slug names', async () => {
+    await writeApp('assets-only', null); // dir without a manifest
+    await writeApp('Bad_Name', manifest({ id: 'Bad_Name' })); // not a valid slug → never considered
+    const { apps, skipped } = await discoverApps(root);
+    expect(apps).toEqual([]);
+    expect(skipped).toEqual([]); // both silently ignored, not "skipped with reason"
+  });
+
+  it('sorts discovered apps by id deterministically', async () => {
+    await writeApp('zeta', manifest({ id: 'zeta' }));
+    await writeApp('alpha', manifest({ id: 'alpha' }));
+    const { apps } = await discoverApps(root);
+    expect(apps.map((a) => a.manifest.id)).toEqual(['alpha', 'zeta']);
+  });
+});

--- a/packages/desktop-host/src/apps/discover.ts
+++ b/packages/desktop-host/src/apps/discover.ts
@@ -1,0 +1,104 @@
+/**
+ * Runtime discovery of installed desktop mini-apps.
+ *
+ * A custom/third-party app is a folder under `<appsRoot>/<id>/` (the same
+ * `userData/moxxy-apps` root the installer + asset protocol use) containing a
+ * `moxxy-app.json` manifest, its `ui/` web bundle, and any downloaded assets.
+ * This scans that root, validates each manifest against the SDK schema, and
+ * returns the apps the desktop should surface in the gallery — no recompile,
+ * no hardcoded registry.
+ *
+ * Electron-free (mirrors {@link ./installer}) so it unit-tests in plain Node;
+ * the caller passes `appsRoot`. Every result is SAFE to trust downstream: the
+ * dir name must be a valid slug, it must equal the manifest `id` (so an app
+ * can't claim another's id / asset dir), and the manifest must fully validate.
+ * A bad app folder is skipped (with its reason) rather than failing the scan, so
+ * one broken app never hides the others.
+ */
+
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+import { parseAppManifest, APP_ID_RE, type AppManifest } from '@moxxy/desktop-app-sdk';
+
+export interface DiscoveredApp {
+  readonly manifest: AppManifest;
+  /** Absolute app dir (`<appsRoot>/<id>`). */
+  readonly dir: string;
+}
+
+export interface DiscoverySkip {
+  /** The offending folder name. */
+  readonly name: string;
+  readonly reason: string;
+}
+
+export interface DiscoveryResult {
+  readonly apps: DiscoveredApp[];
+  readonly skipped: DiscoverySkip[];
+}
+
+const MANIFEST_FILE = 'moxxy-app.json';
+/** A manifest larger than this is certainly malformed; bound the read. */
+const MAX_MANIFEST_BYTES = 64 * 1024;
+
+/**
+ * Scan `appsRoot` for valid app folders. Returns the discovered apps plus the
+ * folders skipped (and why), never throwing for a single bad app. A missing
+ * `appsRoot` yields an empty result (no apps installed yet).
+ */
+export async function discoverApps(appsRoot: string): Promise<DiscoveryResult> {
+  let entries: string[];
+  try {
+    entries = await readdir(appsRoot);
+  } catch {
+    return { apps: [], skipped: [] }; // root not created yet
+  }
+
+  const apps: DiscoveredApp[] = [];
+  const skipped: DiscoverySkip[] = [];
+
+  for (const name of entries) {
+    // Only ever consider strict-slug dirs — the same constraint the id, the
+    // asset dir, and the `moxxy-app://` host segment all share.
+    if (!APP_ID_RE.test(name)) continue;
+    const dir = path.join(appsRoot, name);
+    try {
+      if (!(await stat(dir)).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
+    const manifestPath = path.join(dir, MANIFEST_FILE);
+    let raw: string;
+    try {
+      const info = await stat(manifestPath);
+      if (!info.isFile()) continue; // a plain asset dir, not an app
+      if (info.size > MAX_MANIFEST_BYTES) {
+        skipped.push({ name, reason: 'manifest too large' });
+        continue;
+      }
+      raw = await readFile(manifestPath, 'utf8');
+    } catch {
+      continue; // no manifest here
+    }
+
+    const parsed = parseAppManifest(raw);
+    if (!parsed.ok) {
+      skipped.push({ name, reason: parsed.error });
+      continue;
+    }
+    // The folder name is the authoritative id (it names the asset dir + the
+    // `moxxy-app://` host). A manifest claiming a different id is rejected so an
+    // app can't masquerade as / serve from another app's directory.
+    if (parsed.manifest.id !== name) {
+      skipped.push({ name, reason: `manifest id "${parsed.manifest.id}" does not match folder name` });
+      continue;
+    }
+    apps.push({ manifest: parsed.manifest, dir });
+  }
+
+  // Deterministic order (gallery stability) — by name.
+  apps.sort((a, b) => (a.manifest.id < b.manifest.id ? -1 : a.manifest.id > b.manifest.id ? 1 : 0));
+  return { apps, skipped };
+}

--- a/packages/mode-default/README.md
+++ b/packages/mode-default/README.md
@@ -1,0 +1,46 @@
+# @moxxy/mode-default
+
+The **default loop strategy** (mode) for [moxxy](https://moxxy.ai) — a Claude
+Code-style ReAct loop: the agent thinks, optionally calls tools, sees the
+results, and continues until it produces a final answer. It also handles
+retryable provider errors (e.g. 429s) with backoff.
+
+A "mode" is the turn-by-turn brain of a moxxy [`Session`](https://www.npmjs.com/package/@moxxy/core);
+register this one to get sensible default agent behaviour, or author your own
+against `@moxxy/sdk`'s `defineMode`.
+
+## Install
+
+```bash
+npm i @moxxy/core @moxxy/sdk @moxxy/mode-default
+```
+
+## Usage
+
+```ts
+import { Session, collectTurn, autoAllowResolver } from '@moxxy/core';
+import defaultModePlugin from '@moxxy/mode-default';
+import openaiPlugin from '@moxxy/plugin-provider-openai';
+
+const session = new Session({ cwd: process.cwd(), permissionResolver: autoAllowResolver });
+
+session.pluginHost.registerStatic(defaultModePlugin); // ← the loop strategy
+session.pluginHost.registerStatic(openaiPlugin);
+session.providers.setActive('openai', { apiKey: process.env.OPENAI_API_KEY });
+
+const events = await collectTurn(session, 'What is 2+2? Use a tool if you have one.');
+```
+
+The mode is selected automatically once registered (it registers as the default).
+To run a different strategy, register another mode package and switch with
+`session.modes.setActive(name)`.
+
+## Exports
+
+- `default` / `defaultModePlugin` — the moxxy plugin to register.
+- `defaultMode` — the underlying `Mode` (if you compose registries yourself).
+- `DEFAULT_MODE_NAME` — its registered name.
+
+## License
+
+MIT

--- a/packages/mode-default/package.json
+++ b/packages/mode-default/package.json
@@ -1,8 +1,22 @@
 {
   "name": "@moxxy/mode-default",
-  "private": true,
   "version": "0.0.23",
-  "description": "Default loop strategy for moxxy — Claude Code-style ReAct loop.",
+  "description": "Default loop strategy (mode) for moxxy — a Claude Code-style ReAct tool-use loop. Register it into an @moxxy/core Session to give your agent its turn-by-turn reasoning + tool-calling behaviour.",
+  "keywords": ["moxxy", "agent", "mode", "loop", "react", "tool-use"],
+  "homepage": "https://moxxy.ai",
+  "bugs": {
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
+    "directory": "packages/mode-default"
+  },
+  "author": "Michal Makowski <michal.makowski97@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-provider-anthropic/README.md
+++ b/packages/plugin-provider-anthropic/README.md
@@ -1,0 +1,54 @@
+# @moxxy/plugin-provider-anthropic
+
+The **Anthropic (Claude)** `LLMProvider` for [moxxy](https://moxxy.ai) — streams
+the Messages API with tool use and adaptive extended thinking, and translates
+moxxy's `ProviderRequest`/event shape ↔ the Anthropic wire format. Register it
+into a [`Session`](https://www.npmjs.com/package/@moxxy/core) to route turns to
+Claude.
+
+## Install
+
+```bash
+npm i @moxxy/core @moxxy/sdk @moxxy/mode-default @moxxy/plugin-provider-anthropic
+```
+
+## Usage
+
+```ts
+import { Session, runTurn, autoAllowResolver } from '@moxxy/core';
+import defaultModePlugin from '@moxxy/mode-default';
+import anthropicPlugin from '@moxxy/plugin-provider-anthropic';
+
+const session = new Session({ cwd: process.cwd(), permissionResolver: autoAllowResolver });
+session.pluginHost.registerStatic(defaultModePlugin);
+session.pluginHost.registerStatic(anthropicPlugin);
+
+session.providers.setActive('anthropic', {
+  apiKey: process.env.ANTHROPIC_API_KEY,
+  // model: 'claude-opus-4-8',   // optional — defaults to the built-in catalog
+});
+
+for await (const e of runTurn(session, 'Write a haiku about TypeScript.')) {
+  if (e.type === 'assistant_chunk') process.stdout.write(e.delta);
+}
+```
+
+## Config
+
+| field | meaning |
+|---|---|
+| `apiKey` | your Anthropic API key (or wire it through the Session's `secretResolver`) |
+| `model` / `models` | pick / override the advertised model catalog |
+
+Mix it with [`@moxxy/plugin-provider-openai`](https://www.npmjs.com/package/@moxxy/plugin-provider-openai):
+register both and `setActive('anthropic' | 'openai', …)` to switch vendors per
+turn.
+
+## Exports
+
+`default` / `anthropicPlugin` (register this), `anthropicProviderDef`,
+`AnthropicProvider`, `anthropicModels`, `validateKey`.
+
+## License
+
+MIT

--- a/packages/plugin-provider-anthropic/package.json
+++ b/packages/plugin-provider-anthropic/package.json
@@ -1,8 +1,22 @@
 {
   "name": "@moxxy/plugin-provider-anthropic",
-  "private": true,
   "version": "0.1.17",
-  "description": "Anthropic LLMProvider plugin for moxxy.",
+  "description": "Anthropic (Claude) LLMProvider plugin for moxxy. Streams the Messages API with tool use + adaptive thinking; translates moxxy ProviderRequest/Event ↔ the Anthropic wire shape. Register it into an @moxxy/core Session to route turns to Claude models.",
+  "keywords": ["moxxy", "agent", "provider", "anthropic", "claude", "llm"],
+  "homepage": "https://moxxy.ai",
+  "bugs": {
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
+    "directory": "packages/plugin-provider-anthropic"
+  },
+  "author": "Michal Makowski <michal.makowski97@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-provider-openai/README.md
+++ b/packages/plugin-provider-openai/README.md
@@ -1,0 +1,63 @@
+# @moxxy/plugin-provider-openai
+
+The **OpenAI** `LLMProvider` for [moxxy](https://moxxy.ai) — streams Chat
+Completions with `tool_calls` and translates moxxy's `ProviderRequest`/event
+shape ↔ the OpenAI wire format. Register it into a
+[`Session`](https://www.npmjs.com/package/@moxxy/core) to route turns to OpenAI.
+
+Because it speaks the OpenAI Chat Completions API, it also drives any
+**OpenAI-compatible** endpoint (z.ai, xAI, Google's OpenAI shim, Ollama / local)
+via the `baseURL` override.
+
+## Install
+
+```bash
+npm i @moxxy/core @moxxy/sdk @moxxy/mode-default @moxxy/plugin-provider-openai
+```
+
+## Usage
+
+```ts
+import { Session, collectTurn, autoAllowResolver } from '@moxxy/core';
+import defaultModePlugin from '@moxxy/mode-default';
+import openaiPlugin from '@moxxy/plugin-provider-openai';
+
+const session = new Session({ cwd: process.cwd(), permissionResolver: autoAllowResolver });
+session.pluginHost.registerStatic(defaultModePlugin);
+session.pluginHost.registerStatic(openaiPlugin);
+
+session.providers.setActive('openai', {
+  apiKey: process.env.OPENAI_API_KEY,
+  // model: 'gpt-5.2',          // optional — defaults to the built-in catalog
+});
+
+console.log((await collectTurn(session, 'Hello!')).findLast((e) => e.type === 'assistant_message')?.content);
+```
+
+### Point at an OpenAI-compatible vendor
+
+```ts
+session.providers.setActive('openai', {
+  apiKey: process.env.GROQ_API_KEY,
+  baseURL: 'https://api.groq.com/openai/v1',
+  // model: '...'   // the vendor's model id
+});
+```
+
+## Config (`OpenAIProviderConfig`)
+
+| field | meaning |
+|---|---|
+| `apiKey` | the API key (or wire it through the Session's `secretResolver`) |
+| `baseURL` | override the API base for an OpenAI-compatible vendor |
+| `model` / `models` | pick / override the advertised model catalog |
+
+## Exports
+
+`default` / `openaiPlugin` (register this), `openaiProviderDef`, `OpenAIProvider`,
+`openAIModels`, `validateKey`, and `defineOpenAICompatProvider` (build a provider
+for another OpenAI-compatible vendor in a few lines).
+
+## License
+
+MIT

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -794,6 +794,28 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
 
+  packages/desktop-app-sdk:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
+    devDependencies:
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
   packages/desktop-host:
     dependencies:
       '@moxxy/core':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -821,6 +821,9 @@ importers:
       '@moxxy/core':
         specifier: workspace:*
         version: link:../core
+      '@moxxy/desktop-app-sdk':
+        specifier: workspace:*
+        version: link:../desktop-app-sdk
       '@moxxy/desktop-ipc-contract':
         specifier: workspace:*
         version: link:../desktop-ipc-contract

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,6 +331,40 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  packages/agent:
+    dependencies:
+      '@moxxy/core':
+        specifier: workspace:*
+        version: link:../core
+      '@moxxy/mode-default':
+        specifier: workspace:*
+        version: link:../mode-default
+      '@moxxy/plugin-provider-anthropic':
+        specifier: workspace:*
+        version: link:../plugin-provider-anthropic
+      '@moxxy/plugin-provider-openai':
+        specifier: workspace:*
+        version: link:../plugin-provider-openai
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+    devDependencies:
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
   packages/anonymizer:
     devDependencies:
       '@moxxy/tsconfig':


### PR DESCRIPTION
Two related pieces toward "extend moxxy": a public **programmatic API** (embed moxxy in your own code) and the **foundation** for sandboxed custom desktop apps.

## 1. Programmatic moxxy goes public (complete, shippable)

Make the embeddable runtime installable from npm, with a one-call ergonomic entry.

**`@moxxy/agent`** (new) — batteries-included, one install + one call:
```ts
import { setupAgent, openaiPreset } from '@moxxy/agent';
const { ask, stream } = setupAgent(openaiPreset({ apiKey: process.env.OPENAI_API_KEY }));
console.log(await ask('Hello!'));
```
Presets compose — `setupAgent([openaiPreset({…}), anthropicPreset({…})])` registers both (shared mode de-duped, first active; `agent.setProvider('anthropic')` to swap).

**`@moxxy/core`** (now public) — the engine + `setupAgent()`:
- Synchronous + destructurable factory. `ask` (async → final text), `stream` (async generator of `MoxxyEvent`), `collect` (all events), live `session`, and chainable hot-swap sugar (`setProvider`/`setMode`/`addTool`/`removeTool`/`use`/`discover`).
- Accepts an options object, a single preset, or an **array of presets** (merge + de-dupe + first-provider-active).
- Re-exports the `@moxxy/sdk` surface types — fully typed from one import.

**Also public:** `@moxxy/mode-default`, `@moxxy/plugin-provider-openai` (OpenAI-compatible: z.ai/xAI/Google/local), `@moxxy/plugin-provider-anthropic` — the minimal runnable block set. Closure is clean (only `@moxxy/sdk` + public npm libs; no private cascade). The CLI/desktop still bundle these internally, so **no runtime change** to either.

Each package ships a production-ready README. Blocks stay swappable — nothing is welded into core.

## 2. Sandboxed desktop-apps platform — foundation (dormant)

The groundwork for custom desktop apps (chosen model: isolated web bundles in a cross-origin `moxxy-app://` iframe + a capability-gated bridge):
- **`@moxxy/desktop-app-sdk`** (new, public) — the `moxxy-app.json` manifest schema (zod, strict), the capability list, the host↔app bridge protocol, and the browser `connectMoxxyApp()` client.
- **Host**: `discoverApps()` (scan `userData/moxxy-apps/<id>/` for manifests; id-must-equal-folder, one bad app never breaks the scan) + `dispatchBridge()` (the capability gate — refuses any method whose permission the app didn't declare; never throws).

This is **foundation-only** — not yet wired into the running desktop (the bridge IPC, the iframe sandbox surface, the anonymizer migration, and the create-app skill are the remaining phases). `bridge-host` shows a dormant-orphan dep-cruiser **warning** (not an error) for that reason.

---

**Verification:** `pnpm build` 70/70 · `typecheck` 137/137 · tests pass (core 44 files incl. `setupAgent` + `@moxxy/agent` presets, desktop-app-sdk, desktop-host) · `lint` 0 errors · `check:deps` 0 errors (1 dormant-orphan warning).

**Changesets:** minor for the published programmatic packages + `@moxxy/desktop-app-sdk`.