### PR TITLE
feat(desktop): redesign the anonymizer app — guided import → settings → output

### DIFF
--- a/.changeset/feat-anonymizer-redesign.md
+++ b/.changeset/feat-anonymizer-redesign.md
@@ -1,0 +1,12 @@
+---
+"@moxxy/desktop": minor
+---
+
+feat(desktop): redesign the document anonymizer as a guided import → settings → output flow
+
+Simpler, clearer UX: a three-stage layout (Import / Settings / Output). Import has
+an Upload-vs-Paste toggle with a friendly drag-drop dropzone + file picker; Settings
+puts the redaction categories in a proper multi-select dropdown (checkboxes + All/None)
+alongside the mode control and custom terms; Output shows per-category counts with
+Copy + Save. The offline engine, on-device NER, document parsing, and the bytes-not-path
+drag-drop security model are unchanged.

--- a/apps/desktop/src/apps/anonymizer/AnonymizerApp.test.tsx
+++ b/apps/desktop/src/apps/anonymizer/AnonymizerApp.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Component tests for the redesigned anonymizer flow (Import → Settings →
+ * Output). The redaction engine is real (`@moxxy/anonymizer`); only the host
+ * boundaries are stubbed:
+ *   - the NER Worker (loads a ~109 MB model) → a no-op fake, so the on-device
+ *     name pass simply yields nothing and structured redaction still runs.
+ *   - the desktop IPC api → a fake, so Save routes without a native dialog.
+ *
+ * What's asserted: pasting text produces redacted output, the Filters
+ * multi-select toggles a category on/off and the output follows, the segmented
+ * mode control changes the redaction style, and Copy uses the clipboard.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { __setApiOverride } from '@moxxy/client-core';
+import { AnonymizerApp } from './AnonymizerApp';
+
+/** A Worker that never loads a model and never replies — `detectNames` then
+ *  short-circuits, so NER contributes no spans (structured redaction is intact). */
+class SilentWorker {
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onerror: ((e: ErrorEvent) => void) | null = null;
+  postMessage(): void {}
+  terminate(): void {}
+  addEventListener(): void {}
+  removeEventListener(): void {}
+}
+
+beforeEach(() => {
+  vi.stubGlobal('Worker', SilentWorker as never);
+  __setApiOverride({ invoke: vi.fn(() => Promise.resolve(null)), subscribe: vi.fn(() => () => {}) } as never);
+});
+
+afterEach(() => {
+  __setApiOverride(null);
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const SAMPLE = 'Email a@b.com and call 415-555-0100.';
+
+function paste(text: string): void {
+  fireEvent.click(screen.getByTestId('anon-src-paste'));
+  fireEvent.change(screen.getByTestId('anon-paste'), { target: { value: text } });
+}
+
+describe('AnonymizerApp redesigned flow', () => {
+  it('shows an empty output state until text is provided', () => {
+    render(<AnonymizerApp onExit={vi.fn()} />);
+    expect(screen.getByTestId('anon-output-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('anon-output')).not.toBeInTheDocument();
+  });
+
+  it('redacts pasted text with the default filters', () => {
+    render(<AnonymizerApp onExit={vi.fn()} />);
+    paste(SAMPLE);
+
+    const out = screen.getByTestId('anon-output');
+    expect(out.textContent).toContain('[EMAIL]');
+    expect(out.textContent).toContain('[PHONE]');
+    expect(out.textContent).not.toContain('a@b.com');
+  });
+
+  it('Filters is a multi-select dropdown that toggles a category', () => {
+    render(<AnonymizerApp onExit={vi.fn()} />);
+    paste(SAMPLE);
+
+    // Default count reflects all structured categories + the names group.
+    const trigger = screen.getByTestId('anon-filter-select');
+    expect(screen.getByTestId('anon-filter-select-count').textContent).not.toBe('0');
+
+    // Open the panel and turn Emails off.
+    fireEvent.click(trigger);
+    const panel = screen.getByTestId('anon-filter-select-panel');
+    const emailCheckbox = within(screen.getByTestId('anon-filter-select-opt-email')).getByRole(
+      'checkbox',
+    );
+    expect(emailCheckbox).toBeChecked();
+    fireEvent.click(emailCheckbox);
+
+    // Email is no longer redacted; phone still is.
+    const out = screen.getByTestId('anon-output');
+    expect(out.textContent).toContain('a@b.com');
+    expect(out.textContent).not.toContain('[EMAIL]');
+    expect(out.textContent).toContain('[PHONE]');
+    expect(panel).toBeInTheDocument();
+  });
+
+  it('"None" clears every filter so nothing structured is redacted', () => {
+    render(<AnonymizerApp onExit={vi.fn()} />);
+    paste(SAMPLE);
+
+    fireEvent.click(screen.getByTestId('anon-filter-select'));
+    fireEvent.click(screen.getByTestId('anon-filter-select-none'));
+
+    expect(screen.getByTestId('anon-filter-select-count').textContent).toBe('0');
+    const out = screen.getByTestId('anon-output');
+    expect(out.textContent).toContain('a@b.com');
+    expect(out.textContent).not.toContain('[EMAIL]');
+  });
+
+  it('switching redaction mode changes the token style', () => {
+    render(<AnonymizerApp onExit={vi.fn()} />);
+    paste(SAMPLE);
+
+    fireEvent.click(screen.getByTestId('anon-mode-pseudonym'));
+    const out = screen.getByTestId('anon-output');
+    expect(out.textContent).toContain('EMAIL_1');
+    expect(out.textContent).not.toContain('[EMAIL]');
+  });
+
+  it('Copy writes the redacted text to the clipboard', () => {
+    const writeText = vi.fn((_text: string) => Promise.resolve());
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<AnonymizerApp onExit={vi.fn()} />);
+    paste(SAMPLE);
+    fireEvent.click(screen.getByTestId('anon-copy'));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0]?.[0]).toContain('[EMAIL]');
+  });
+
+  it('the Apps back button exits', () => {
+    const onExit = vi.fn();
+    render(<AnonymizerApp onExit={onExit} />);
+    fireEvent.click(screen.getByRole('button', { name: /Apps/i }));
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/apps/anonymizer/AnonymizerApp.tsx
+++ b/apps/desktop/src/apps/anonymizer/AnonymizerApp.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
   redact,
   STRUCTURED_CATEGORIES,
@@ -14,6 +14,8 @@ import { OfflineBadge } from '../OfflineBadge';
 import { Counts } from './Counts';
 import { SpanHighlight } from './SpanHighlight';
 import { CATEGORY_LABELS, TOGGLE_CATEGORIES } from './labels';
+import { FilterSelect, type FilterOption } from './FilterSelect';
+import { ImportStep, type ImportTab } from './ImportStep';
 import { useNer } from './ner/useNer';
 
 const REDACT_MODES: ReadonlyArray<{ id: RedactionMode; label: string }> = [
@@ -21,6 +23,20 @@ const REDACT_MODES: ReadonlyArray<{ id: RedactionMode; label: string }> = [
   { id: 'pseudonym', label: 'Pseudonym' },
   { id: 'hash', label: 'Hash' },
 ];
+
+/** A short description of what each redaction style produces, shown under the
+ *  segmented control so the choice is obvious without trying each one. */
+const MODE_HINT: Record<RedactionMode, string> = {
+  label: 'Replaces each item with its type, e.g. [EMAIL].',
+  pseudonym: 'Stable tokens, e.g. EMAIL_1 — the same value stays consistent.',
+  hash: 'Compact fingerprints, e.g. [EMAIL:a1b2c3d4].',
+};
+
+/** Synthetic filter id the multi-select adds on top of the structured
+ *  `PiiCategory` toggles: the NER group (names/orgs/locations). Custom terms
+ *  are their own input below, so they aren't a filter row. */
+const NAMES_FILTER = 'names' as const;
+type FilterId = PiiCategory | typeof NAMES_FILTER;
 
 function parseTerms(s: string): string[] {
   return s
@@ -41,28 +57,36 @@ function bytesToBase64(bytes: Uint8Array): string {
 }
 
 /**
- * Offline document anonymizer. Paste text or open a document, and the redaction
- * runs ENTIRELY in this renderer — structured PII via `@moxxy/anonymizer`
- * (pure, no network) plus on-device NER for names. Nothing is uploaded; opening
- * a file only reads it locally (in main) and returns the text here.
+ * Offline document anonymizer — a guided three-step flow: Import → Settings →
+ * Output. Redaction runs ENTIRELY in this renderer: structured PII via
+ * `@moxxy/anonymizer` (pure, no network) plus on-device NER for names. Nothing
+ * is uploaded; opening a file only reads it locally (in main) and returns the
+ * text here.
  */
 export function AnonymizerApp({ onExit }: DesktopAppProps): JSX.Element {
   const anon = useAnonymizer();
   const { status: nerStatus, error: nerError, detectNames } = useNer();
 
-  const [sourceMode, setSourceMode] = useState<'paste' | 'file'>('paste');
+  const [importTab, setImportTab] = useState<ImportTab>('upload');
   const [input, setInput] = useState('');
   const [fileName, setFileName] = useState<string | null>(null);
   const [fileError, setFileError] = useState<string | null>(null);
   const [dragActive, setDragActive] = useState(false);
-  const [categories, setCategories] = useState<ReadonlySet<PiiCategory>>(
-    () => new Set(STRUCTURED_CATEGORIES),
+
+  // Filters: structured categories + the NER `names` group, as a single set
+  // driving the multi-select. Custom terms are a separate input but their
+  // `custom` category is always on (the term box is its own switch).
+  const [filters, setFilters] = useState<ReadonlySet<FilterId>>(
+    () => new Set<FilterId>([...STRUCTURED_CATEGORIES, NAMES_FILTER]),
   );
   const [customTermsText, setCustomTermsText] = useState('');
   const [mode, setMode] = useState<RedactionMode>('label');
-  const [nerEnabled, setNerEnabled] = useState(true);
   const [nerSpans, setNerSpans] = useState<readonly PiiSpan[]>([]);
   const [saved, setSaved] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const nerEnabled = filters.has(NAMES_FILTER);
+  const nerUnavailable = nerStatus === 'error';
 
   // Run on-device NER (debounced) whenever the text or the toggle changes.
   useEffect(() => {
@@ -77,7 +101,10 @@ export function AnonymizerApp({ onExit }: DesktopAppProps): JSX.Element {
   }, [input, nerEnabled, detectNames]);
 
   const customTerms = useMemo(() => parseTerms(customTermsText), [customTermsText]);
-  const categoryList = useMemo(() => [...categories], [categories]);
+  const categoryList = useMemo(
+    () => TOGGLE_CATEGORIES.filter((c) => filters.has(c)),
+    [filters],
+  );
 
   const result = useMemo(
     () =>
@@ -90,29 +117,48 @@ export function AnonymizerApp({ onExit }: DesktopAppProps): JSX.Element {
     [input, categoryList, customTerms, nerEnabled, nerSpans, mode],
   );
 
-  const toggleCategory = (c: PiiCategory): void => {
-    setCategories((prev) => {
-      const next = new Set(prev);
-      if (next.has(c)) next.delete(c);
-      else next.add(c);
-      return next;
-    });
-  };
+  const hasInput = input.trim().length > 0;
 
-  const applyParse = (r: { text: string } | { error: string }): void => {
+  const filterOptions = useMemo<ReadonlyArray<FilterOption<FilterId>>>(() => {
+    const structured: FilterOption<FilterId>[] = TOGGLE_CATEGORIES.map((c) => ({
+      id: c,
+      label: CATEGORY_LABELS[c],
+    }));
+    const names: FilterOption<FilterId> = {
+      id: NAMES_FILTER,
+      label: 'Names, organizations & places',
+      hint:
+        nerStatus === 'loading'
+          ? 'loading…'
+          : nerStatus === 'error'
+            ? 'unavailable'
+            : 'on-device AI',
+      disabled: nerUnavailable,
+    };
+    return [...structured, names];
+  }, [nerStatus, nerUnavailable]);
+
+  const applyParse = (r: { text: string } | { error: string }, name: string): void => {
     if ('error' in r) {
       setFileError(r.error);
       return;
     }
     setInput(r.text);
-    setFileName('document');
+    setFileName(name);
   };
 
   const openDocument = async (): Promise<void> => {
     setFileError(null);
     const r = await anon.pickAndParse();
     if (!r) return; // cancelled
-    applyParse(r);
+    applyParse(r, 'Document');
+  };
+
+  const clearDocument = (): void => {
+    setInput('');
+    setFileName(null);
+    setFileError(null);
+    setNerSpans([]);
   };
 
   // Drag-and-drop: read the dropped file's BYTES in the renderer (it already
@@ -128,7 +174,10 @@ export function AnonymizerApp({ onExit }: DesktopAppProps): JSX.Element {
     void (async () => {
       try {
         const bytes = new Uint8Array(await file.arrayBuffer());
-        applyParse(await anon.parseDroppedBytes(file.name || 'document', bytesToBase64(bytes)));
+        applyParse(
+          await anon.parseDroppedBytes(file.name || 'document', bytesToBase64(bytes)),
+          file.name || 'Document',
+        );
       } catch {
         setFileError('Could not read the dropped file.');
       }
@@ -146,12 +195,18 @@ export function AnonymizerApp({ onExit }: DesktopAppProps): JSX.Element {
 
   const copyOut = (): void => {
     void navigator.clipboard.writeText(result.text);
+    setCopied(true);
+    setSaved(null);
+    window.setTimeout(() => setCopied(false), 1600);
   };
 
   const saveOut = async (): Promise<void> => {
-    const name = fileName ? `${fileName}-redacted.txt` : 'redacted.txt';
-    const path = await anon.save(name, result.text);
-    if (path) setSaved(path);
+    const base = fileName && fileName !== 'Document' ? fileName.replace(/\.[^.]+$/, '') : 'document';
+    const path = await anon.save(`${base}-redacted.txt`, result.text);
+    if (path) {
+      setSaved(path);
+      setCopied(false);
+    }
   };
 
   return (
@@ -171,172 +226,256 @@ export function AnonymizerApp({ onExit }: DesktopAppProps): JSX.Element {
           flex: 1,
           minHeight: 0,
           overflowY: 'auto',
-          padding: '1.25rem 1.75rem',
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(360px, 1fr))',
-          gap: '1.25rem',
+          padding: '1.5rem 1.75rem 3rem',
         }}
       >
-        {/* ── Source + options ─────────────────────────────────────────── */}
-        <section style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem', minWidth: 0 }}>
-          <Segmented
-            items={[
-              { id: 'paste', label: 'Paste text' },
-              { id: 'file', label: 'Open document' },
-            ]}
-            value={sourceMode}
-            onChange={(id) => setSourceMode(id)}
-            testIdPrefix="anon-src-"
-          />
+        <div
+          style={{
+            maxWidth: 1180,
+            margin: '0 auto',
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(380px, 1fr))',
+            gap: '1.5rem',
+            alignItems: 'start',
+          }}
+        >
+          {/* ── Stage 1 + 2 — Import & Settings ─────────────────────────── */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem', minWidth: 0 }}>
+            <Stage n={1} title="Import" subtitle="Upload a document or paste text to anonymize.">
+              <ImportStep
+                tab={importTab}
+                onTab={setImportTab}
+                text={input}
+                onText={setInput}
+                fileName={importTab === 'upload' ? fileName : null}
+                busy={anon.busy}
+                error={fileError}
+                dragActive={dragActive}
+                onPick={() => void openDocument()}
+                onClear={clearDocument}
+                onDrop={onDrop}
+                onDragOver={onDragOver}
+                onDragLeave={onDragLeave}
+              />
+            </Stage>
 
-          {sourceMode === 'paste' ? (
-            <TextArea
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              placeholder="Paste the text you want to anonymize…"
-              rows={10}
-              style={{ width: '100%', fontSize: 13, lineHeight: 1.5 }}
-            />
-          ) : (
-            <div
-              data-testid="anon-dropzone"
-              onDrop={onDrop}
-              onDragOver={onDragOver}
-              onDragLeave={onDragLeave}
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 8,
-                alignItems: 'flex-start',
-                padding: '0.9rem',
-                border: `1px dashed ${
-                  dragActive ? 'var(--color-accent)' : 'var(--color-border)'
-                }`,
-                borderRadius: 'var(--radius-block)',
-                background: dragActive ? 'var(--color-bg-card)' : 'transparent',
-                transition: 'border-color 120ms, background 120ms',
-              }}
-            >
-              <Button variant="secondary" data-testid="anon-pick" onClick={() => void openDocument()}>
-                <Icon name="attach" size={14} /> Choose a document…
-              </Button>
-              <span style={dim}>or drag &amp; drop a file here</span>
-              <span style={dim}>
-                Supports PDF, Word (.doc/.docx), RTF, OpenDocument (.odt/.ods/.odp), spreadsheets,
-                slides, and plain text.
-              </span>
-              {anon.busy && <span style={dim}>Reading document…</span>}
-              {fileName && !anon.busy && (
-                <span style={dim}>Loaded {result.report.total} item(s) from your document.</span>
-              )}
-              {fileError && <span style={{ ...dim, color: 'var(--color-pink)' }}>{fileError}</span>}
-            </div>
-          )}
+            <Stage n={2} title="Settings" subtitle="Choose what to redact and how.">
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+                <Field label="Filters" help="Which kinds of information to find and redact.">
+                  <FilterSelect options={filterOptions} selected={filters} onChange={setFilters} />
+                  {nerEnabled && nerError && (
+                    <span style={{ ...dim, color: 'var(--color-pink)', marginTop: 2 }}>
+                      {nerError}
+                    </span>
+                  )}
+                </Field>
 
-          <label style={toggleRow}>
-            <input
-              type="checkbox"
-              checked={nerEnabled}
-              onChange={(e) => setNerEnabled(e.target.checked)}
-            />
-            <span>Detect names &amp; places (on-device AI)</span>
-            <span style={{ ...dim, marginLeft: 'auto' }}>
-              {nerStatus === 'loading'
-                ? 'loading model…'
-                : nerStatus === 'error'
-                  ? 'unavailable'
-                  : nerStatus === 'ready'
-                    ? 'ready'
-                    : ''}
-            </span>
-          </label>
-          {nerError && nerEnabled && (
-            <span style={{ ...dim, color: 'var(--color-pink)' }}>{nerError}</span>
-          )}
-
-          <div>
-            <div style={{ ...dim, marginBottom: 6 }}>Redaction style</div>
-            <Segmented items={REDACT_MODES} value={mode} onChange={setMode} testIdPrefix="anon-mode-" />
-          </div>
-
-          <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
-            <div style={{ ...dim, marginBottom: 6 }}>Detect</div>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 14px' }}>
-              {TOGGLE_CATEGORIES.map((c) => (
-                <label key={c} style={toggleRow}>
-                  <input
-                    type="checkbox"
-                    checked={categories.has(c)}
-                    onChange={() => toggleCategory(c)}
+                <Field label="Redaction style">
+                  <Segmented
+                    items={REDACT_MODES}
+                    value={mode}
+                    onChange={setMode}
+                    testIdPrefix="anon-mode-"
                   />
-                  <span>{CATEGORY_LABELS[c]}</span>
-                </label>
-              ))}
-            </div>
-          </fieldset>
+                  <span style={{ ...dim, marginTop: 6 }}>{MODE_HINT[mode]}</span>
+                </Field>
 
-          <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            <span style={dim}>Always redact these terms (names, addresses — one per line)</span>
-            <TextArea
-              value={customTermsText}
-              onChange={(e) => setCustomTermsText(e.target.value)}
-              placeholder={'Jane Doe\n123 Main St\nAcme Corp'}
-              rows={3}
-              style={{ width: '100%', fontSize: 13 }}
-            />
-          </label>
-        </section>
-
-        {/* ── Result ───────────────────────────────────────────────────── */}
-        <section style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', minWidth: 0 }}>
-          <Counts counts={result.report.counts} total={result.report.total} />
-
-          <div style={{ display: 'flex', gap: 8 }}>
-            <Button variant="primary" data-testid="anon-copy" onClick={copyOut} disabled={!input}>
-              <Icon name="copy" size={14} /> Copy redacted
-            </Button>
-            <Button variant="secondary" onClick={() => void saveOut()} disabled={!input}>
-              Save…
-            </Button>
-          </div>
-          {saved && <span style={dim}>Saved to {saved}</span>}
-
-          <div style={panelBox}>
-            <div style={{ ...dim, marginBottom: 6 }}>Redacted output</div>
-            <pre data-testid="anon-output" style={preBox}>
-              {result.text || (
-                <span style={{ color: 'var(--color-text-dim)' }}>
-                  The redacted text will appear here.
-                </span>
-              )}
-            </pre>
+                <Field
+                  label="Always redact these terms"
+                  help="Specific names, addresses or codes — one per line."
+                >
+                  <TextArea
+                    value={customTermsText}
+                    onChange={(e) => setCustomTermsText(e.target.value)}
+                    placeholder={'Jane Doe\n123 Main St\nAcme Corp'}
+                    rows={3}
+                    tone="soft"
+                    style={{ width: '100%', fontSize: 13 }}
+                  />
+                </Field>
+              </div>
+            </Stage>
           </div>
 
-          {result.report.total > 0 && (
-            <div style={panelBox}>
-              <div style={{ ...dim, marginBottom: 6 }}>Detected in source</div>
-              <SpanHighlight text={input} spans={result.report.spans} />
-            </div>
-          )}
-        </section>
+          {/* ── Stage 3 — Output ─────────────────────────────────────────── */}
+          <Stage n={3} title="Output" subtitle="Your redacted text, ready to copy or save.">
+            {!hasInput ? (
+              <EmptyOutput />
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+                <Counts counts={result.report.counts} total={result.report.total} />
+
+                <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                  <Button variant="primary" data-testid="anon-copy" onClick={copyOut}>
+                    <Icon name={copied ? 'check' : 'copy'} size={14} />
+                    {copied ? 'Copied' : 'Copy redacted'}
+                  </Button>
+                  <Button variant="secondary" data-testid="anon-save" onClick={() => void saveOut()}>
+                    Save as…
+                  </Button>
+                  {saved && (
+                    <span style={{ ...dim, display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+                      <Icon name="check" size={13} /> Saved to {saved}
+                    </span>
+                  )}
+                </div>
+
+                <Panel label="Redacted text">
+                  <pre data-testid="anon-output" style={preBox}>
+                    {result.text}
+                  </pre>
+                </Panel>
+
+                {result.report.total > 0 && (
+                  <Panel label="What was detected">
+                    <div style={{ maxHeight: 280, overflowY: 'auto' }}>
+                      <SpanHighlight text={input} spans={result.report.spans} />
+                    </div>
+                  </Panel>
+                )}
+              </div>
+            )}
+          </Stage>
+        </div>
       </div>
     </>
   );
 }
 
+/** A numbered stage card — the spine of the guided flow. The badge + title give
+ *  each of Import / Settings / Output the same legible visual weight. */
+function Stage({
+  n,
+  title,
+  subtitle,
+  children,
+}: {
+  readonly n: number;
+  readonly title: string;
+  readonly subtitle: string;
+  readonly children: ReactNode;
+}): JSX.Element {
+  return (
+    <section
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 16,
+        minWidth: 0,
+        padding: '1.1rem 1.25rem 1.25rem',
+        border: '1px solid var(--color-card-border)',
+        borderRadius: 'var(--radius-card)',
+        background: 'var(--color-card-bg)',
+        boxShadow: '0 1px 2px var(--color-card-shadow)',
+      }}
+    >
+      <header style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <span
+          aria-hidden
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 28,
+            height: 28,
+            flexShrink: 0,
+            borderRadius: 999,
+            fontSize: 13,
+            fontWeight: 700,
+            color: '#fff',
+            background: 'var(--color-primary-strong)',
+          }}
+        >
+          {n}
+        </span>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          <strong style={{ fontSize: 15 }}>{title}</strong>
+          <span style={{ fontSize: 12, color: 'var(--color-text-muted)' }}>{subtitle}</span>
+        </div>
+      </header>
+      {children}
+    </section>
+  );
+}
+
+/** A labelled settings field — a small caption + optional help line above its
+ *  control, so Settings reads as a clean form. */
+function Field({
+  label,
+  help,
+  children,
+}: {
+  readonly label: string;
+  readonly help?: string;
+  readonly children: ReactNode;
+}): JSX.Element {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <span style={{ fontSize: 12.5, fontWeight: 600, color: 'var(--color-text)' }}>{label}</span>
+        {help && <span style={dim}>{help}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Panel({ label, children }: { readonly label: string; readonly children: ReactNode }): JSX.Element {
+  return (
+    <div style={panelBox}>
+      <div style={{ ...dim, fontWeight: 600, marginBottom: 8 }}>{label}</div>
+      {children}
+    </div>
+  );
+}
+
+function EmptyOutput(): JSX.Element {
+  return (
+    <div
+      data-testid="anon-output-empty"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 12,
+        minHeight: 220,
+        textAlign: 'center',
+        color: 'var(--color-text-dim)',
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 48,
+          height: 48,
+          borderRadius: 14,
+          color: 'var(--color-text-muted)',
+          background: 'var(--color-input-soft)',
+          border: '1px solid var(--color-card-border)',
+        }}
+      >
+        <Icon name="file" size={22} />
+      </span>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+        <strong style={{ fontSize: 13.5, color: 'var(--color-text-muted)' }}>
+          Nothing to redact yet
+        </strong>
+        <span style={{ fontSize: 12.5 }}>Import a document or paste text to see the result here.</span>
+      </div>
+    </div>
+  );
+}
+
 const dim: React.CSSProperties = { fontSize: 12, color: 'var(--color-text-dim)' };
-const toggleRow: React.CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: 7,
-  fontSize: 13,
-  cursor: 'pointer',
-};
 const panelBox: React.CSSProperties = {
-  border: '1px solid var(--color-border)',
-  background: 'var(--color-bg-card)',
+  border: '1px solid var(--color-card-border)',
+  background: 'var(--color-surface)',
   borderRadius: 'var(--radius-block)',
-  padding: '0.7rem 0.85rem',
+  padding: '0.75rem 0.9rem',
 };
 const preBox: React.CSSProperties = {
   margin: 0,
@@ -344,7 +483,7 @@ const preBox: React.CSSProperties = {
   wordBreak: 'break-word',
   fontFamily: 'inherit',
   fontSize: 13,
-  lineHeight: 1.5,
+  lineHeight: 1.55,
   maxHeight: 360,
   overflowY: 'auto',
 };

--- a/apps/desktop/src/apps/anonymizer/Counts.tsx
+++ b/apps/desktop/src/apps/anonymizer/Counts.tsx
@@ -5,20 +5,51 @@ import { CATEGORY_LABELS } from './labels';
 export function Counts({ counts, total }: { counts: PiiCounts; total: number }): JSX.Element {
   const rows = (Object.keys(counts) as PiiCategory[]).filter((c) => counts[c] > 0);
   if (total === 0) {
-    return <span style={{ fontSize: 13, color: 'var(--color-text-dim)' }}>Nothing detected.</span>;
+    return (
+      <div
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 7,
+          alignSelf: 'flex-start',
+          padding: '6px 12px',
+          borderRadius: 999,
+          fontSize: 12.5,
+          color: 'var(--color-text-muted)',
+          background: 'var(--color-input-soft)',
+          border: '1px solid var(--color-card-border)',
+        }}
+      >
+        Nothing detected yet.
+      </div>
+    );
   }
   return (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
-      <span style={{ fontSize: 13, fontWeight: 600 }}>{total} redacted:</span>
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          fontSize: 12.5,
+          fontWeight: 700,
+          padding: '3px 10px',
+          borderRadius: 999,
+          color: '#fff',
+          background: 'var(--color-primary-strong)',
+        }}
+      >
+        {total} redacted
+      </span>
       {rows.map((c) => (
         <span
           key={c}
           style={{
             fontSize: 12,
-            padding: '2px 8px',
+            padding: '3px 9px',
             borderRadius: 999,
-            background: 'var(--color-bg-card)',
-            border: '1px solid var(--color-border)',
+            background: 'var(--color-surface)',
+            border: '1px solid var(--color-card-border)',
             color: 'var(--color-text-muted)',
           }}
         >

--- a/apps/desktop/src/apps/anonymizer/FilterSelect.tsx
+++ b/apps/desktop/src/apps/anonymizer/FilterSelect.tsx
@@ -1,0 +1,273 @@
+import { useEffect, useId, useRef, useState } from 'react';
+import { Icon } from '@moxxy/desktop-ui';
+
+/** One selectable filter row in the multi-select. `hint` surfaces a secondary
+ *  line (e.g. the on-device NER status) without crowding the label. */
+export interface FilterOption<Id extends string> {
+  readonly id: Id;
+  readonly label: string;
+  readonly hint?: string;
+  /** When set the row is shown but cannot be toggled (e.g. NER unavailable). */
+  readonly disabled?: boolean;
+}
+
+/**
+ * A compact multi-select dropdown with checkboxes — the redaction filters.
+ *
+ * Replaces the old long row of raw toggles: the trigger is a single chip
+ * showing how many filters are active ("Filters · 9"), and the panel lists
+ * every category with a checkbox, plus All / None shortcuts.
+ *
+ * Anchored-dropdown mechanics mirror RailMenu / the header's collapsible
+ * Segmented: outside-click + Escape dismiss. The panel is absolutely
+ * positioned and the wrapper is lifted (`zIndex` while open) because an
+ * ancestor `transform` (the app shell) would otherwise trap the panel in a
+ * local stacking context and let page content paint over it.
+ */
+export function FilterSelect<Id extends string>({
+  options,
+  selected,
+  onChange,
+  testId = 'anon-filter-select',
+}: {
+  readonly options: ReadonlyArray<FilterOption<Id>>;
+  readonly selected: ReadonlySet<Id>;
+  readonly onChange: (next: ReadonlySet<Id>) => void;
+  readonly testId?: string;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const labelId = useId();
+
+  // Dismiss on outside-click / Escape — the shared anchored-dropdown pattern.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent): void => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const selectable = options.filter((o) => !o.disabled);
+  const activeCount = selectable.filter((o) => selected.has(o.id)).length;
+  const allOn = activeCount === selectable.length && selectable.length > 0;
+
+  const toggle = (id: Id): void => {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    onChange(next);
+  };
+
+  const setAll = (on: boolean): void => {
+    const next = new Set(selected);
+    for (const o of selectable) {
+      if (on) next.add(o.id);
+      else next.delete(o.id);
+    }
+    onChange(next);
+  };
+
+  return (
+    <div
+      ref={rootRef}
+      style={{ position: 'relative', zIndex: open ? 50 : undefined, alignSelf: 'flex-start' }}
+    >
+      <button
+        type="button"
+        data-testid={testId}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className="btn-chip"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '8px 12px',
+          fontSize: 13,
+          fontWeight: 600,
+          borderRadius: 10,
+          color: 'var(--color-text)',
+          background: 'var(--color-surface)',
+          border: `1px solid ${open ? 'var(--color-accent)' : 'var(--color-card-border)'}`,
+          transition: 'border-color 140ms ease',
+        }}
+      >
+        <Icon name="sliders" size={14} />
+        <span>Filters</span>
+        <span
+          data-testid={`${testId}-count`}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minWidth: 20,
+            height: 20,
+            padding: '0 6px',
+            borderRadius: 999,
+            fontSize: 11.5,
+            fontWeight: 700,
+            color: activeCount > 0 ? '#fff' : 'var(--color-text-muted)',
+            background:
+              activeCount > 0
+                ? 'var(--color-primary-strong)'
+                : 'color-mix(in oklab, var(--color-text-dim) 14%, transparent)',
+          }}
+        >
+          {activeCount}
+        </span>
+        <span
+          aria-hidden
+          style={{
+            display: 'inline-flex',
+            transform: open ? 'rotate(-90deg)' : 'rotate(90deg)',
+            transition: 'transform 120ms ease',
+            color: 'var(--color-text-muted)',
+          }}
+        >
+          <Icon name="chevron-right" size={14} />
+        </span>
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          aria-multiselectable
+          aria-labelledby={labelId}
+          data-testid={`${testId}-panel`}
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 6px)',
+            left: 0,
+            zIndex: 50,
+            width: 300,
+            maxHeight: 360,
+            display: 'flex',
+            flexDirection: 'column',
+            background: 'var(--color-card-bg)',
+            border: '1px solid var(--color-card-border)',
+            borderRadius: 12,
+            boxShadow: '0 18px 40px -22px rgba(15, 23, 42, 0.45)',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 8,
+              padding: '10px 12px',
+              borderBottom: '1px solid var(--color-card-border)',
+            }}
+          >
+            <span id={labelId} style={{ fontSize: 12, fontWeight: 700, color: 'var(--color-text)' }}>
+              What to redact
+            </span>
+            <div style={{ display: 'flex', gap: 4 }}>
+              <button
+                type="button"
+                data-testid={`${testId}-all`}
+                onClick={() => setAll(true)}
+                disabled={allOn}
+                style={miniBtn(allOn)}
+              >
+                All
+              </button>
+              <span style={{ color: 'var(--color-text-dim)', fontSize: 11 }}>·</span>
+              <button
+                type="button"
+                data-testid={`${testId}-none`}
+                onClick={() => setAll(false)}
+                disabled={activeCount === 0}
+                style={miniBtn(activeCount === 0)}
+              >
+                None
+              </button>
+            </div>
+          </div>
+
+          <div style={{ overflowY: 'auto', padding: 4 }}>
+            {options.map((o) => {
+              const checked = selected.has(o.id);
+              return (
+                <label
+                  key={o.id}
+                  data-testid={`${testId}-opt-${o.id}`}
+                  className="row-button"
+                  aria-disabled={o.disabled}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 10,
+                    width: '100%',
+                    padding: '8px 10px',
+                    borderRadius: 8,
+                    fontSize: 13,
+                    cursor: o.disabled ? 'not-allowed' : 'pointer',
+                    opacity: o.disabled ? 0.55 : 1,
+                  }}
+                >
+                  <span
+                    aria-hidden
+                    style={{
+                      flexShrink: 0,
+                      width: 18,
+                      height: 18,
+                      borderRadius: 5,
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      color: '#fff',
+                      border: checked
+                        ? '1px solid var(--color-primary-strong)'
+                        : '1px solid var(--color-card-border-strong)',
+                      background: checked ? 'var(--color-primary-strong)' : 'transparent',
+                      transition: 'background 120ms, border-color 120ms',
+                    }}
+                  >
+                    {checked && <Icon name="check" size={12} />}
+                  </span>
+                  <span style={{ flex: 1, minWidth: 0, color: 'var(--color-text)' }}>{o.label}</span>
+                  {o.hint && (
+                    <span style={{ fontSize: 11, color: 'var(--color-text-dim)', flexShrink: 0 }}>
+                      {o.hint}
+                    </span>
+                  )}
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    disabled={o.disabled}
+                    onChange={() => toggle(o.id)}
+                    style={{ position: 'absolute', opacity: 0, pointerEvents: 'none' }}
+                  />
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function miniBtn(disabled: boolean): React.CSSProperties {
+  return {
+    padding: '2px 6px',
+    fontSize: 11.5,
+    fontWeight: 600,
+    borderRadius: 6,
+    color: disabled ? 'var(--color-text-dim)' : 'var(--color-accent-strong)',
+    background: 'transparent',
+    cursor: disabled ? 'default' : 'pointer',
+  };
+}

--- a/apps/desktop/src/apps/anonymizer/ImportStep.tsx
+++ b/apps/desktop/src/apps/anonymizer/ImportStep.tsx
@@ -1,0 +1,266 @@
+import { useState } from 'react';
+import { Button, Icon, TextArea } from '@moxxy/desktop-ui';
+import { Segmented } from '../../shell/ViewHeader';
+
+export type ImportTab = 'upload' | 'paste';
+
+const SUPPORTED =
+  'PDF, Word (.doc/.docx), RTF, OpenDocument (.odt/.ods/.odp), spreadsheets, slides, and plain text.';
+
+/**
+ * Step 1 — Import. A guided input step: toggle between "Upload a document" and
+ * "Paste text". Upload offers a drag-and-drop dropzone AND a "Choose file…"
+ * button; once a file is loaded it shows the name + a Replace / Clear affordance.
+ *
+ * Pure presentation — the parent owns the text/filename state and the actual
+ * parse IPC (so the offline guarantee + drop-bytes handling stay in one place).
+ */
+export function ImportStep({
+  tab,
+  onTab,
+  text,
+  onText,
+  fileName,
+  busy,
+  error,
+  dragActive,
+  onPick,
+  onClear,
+  onDrop,
+  onDragOver,
+  onDragLeave,
+}: {
+  readonly tab: ImportTab;
+  readonly onTab: (t: ImportTab) => void;
+  readonly text: string;
+  readonly onText: (t: string) => void;
+  readonly fileName: string | null;
+  readonly busy: boolean;
+  readonly error: string | null;
+  readonly dragActive: boolean;
+  readonly onPick: () => void;
+  readonly onClear: () => void;
+  readonly onDrop: (e: React.DragEvent) => void;
+  readonly onDragOver: (e: React.DragEvent) => void;
+  readonly onDragLeave: (e: React.DragEvent) => void;
+}): JSX.Element {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <Segmented
+        items={[
+          { id: 'upload', label: 'Upload a document' },
+          { id: 'paste', label: 'Paste text' },
+        ]}
+        value={tab}
+        onChange={onTab}
+        testIdPrefix="anon-src-"
+      />
+
+      {tab === 'upload' ? (
+        fileName ? (
+          <LoadedFile fileName={fileName} chars={text.length} busy={busy} onReplace={onPick} onClear={onClear} />
+        ) : (
+          <Dropzone
+            busy={busy}
+            dragActive={dragActive}
+            onPick={onPick}
+            onDrop={onDrop}
+            onDragOver={onDragOver}
+            onDragLeave={onDragLeave}
+          />
+        )
+      ) : (
+        <PasteArea text={text} onText={onText} />
+      )}
+
+      {error && (
+        <div
+          data-testid="anon-import-error"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '8px 12px',
+            fontSize: 12.5,
+            color: 'var(--color-red-text)',
+            background: 'var(--color-red-wash)',
+            border: '1px solid var(--color-red-border)',
+            borderRadius: 10,
+          }}
+        >
+          <Icon name="x" size={14} />
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Dropzone({
+  busy,
+  dragActive,
+  onPick,
+  onDrop,
+  onDragOver,
+  onDragLeave,
+}: {
+  readonly busy: boolean;
+  readonly dragActive: boolean;
+  readonly onPick: () => void;
+  readonly onDrop: (e: React.DragEvent) => void;
+  readonly onDragOver: (e: React.DragEvent) => void;
+  readonly onDragLeave: (e: React.DragEvent) => void;
+}): JSX.Element {
+  return (
+    <div
+      data-testid="anon-dropzone"
+      onDrop={onDrop}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 12,
+        padding: '2rem 1.5rem',
+        textAlign: 'center',
+        border: `1.5px dashed ${dragActive ? 'var(--color-accent)' : 'var(--color-card-border-strong)'}`,
+        borderRadius: 'var(--radius-block)',
+        background: dragActive
+          ? 'color-mix(in oklab, var(--color-accent) 8%, transparent)'
+          : 'var(--color-input-soft)',
+        transition: 'border-color 140ms, background 140ms',
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 44,
+          height: 44,
+          borderRadius: 12,
+          color: 'var(--color-accent-strong)',
+          background: 'color-mix(in oklab, var(--color-accent) 12%, transparent)',
+        }}
+      >
+        <Icon name="attach" size={20} />
+      </span>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+        <strong style={{ fontSize: 14 }}>
+          {dragActive ? 'Drop to load your document' : 'Drag & drop a document here'}
+        </strong>
+        <span style={{ fontSize: 12.5, color: 'var(--color-text-muted)' }}>or</span>
+      </div>
+      <Button variant="primary" data-testid="anon-pick" onClick={onPick} disabled={busy}>
+        <Icon name="attach" size={14} /> Choose a file…
+      </Button>
+      {busy ? (
+        <span style={{ fontSize: 12, color: 'var(--color-text-muted)' }}>Reading document…</span>
+      ) : (
+        <span style={{ fontSize: 11.5, color: 'var(--color-text-dim)', maxWidth: 420 }}>
+          Supports {SUPPORTED}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function LoadedFile({
+  fileName,
+  chars,
+  busy,
+  onReplace,
+  onClear,
+}: {
+  readonly fileName: string;
+  readonly chars: number;
+  readonly busy: boolean;
+  readonly onReplace: () => void;
+  readonly onClear: () => void;
+}): JSX.Element {
+  return (
+    <div
+      data-testid="anon-loaded-file"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '12px 14px',
+        border: '1px solid var(--color-card-border)',
+        borderRadius: 'var(--radius-block)',
+        background: 'var(--color-surface)',
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 36,
+          height: 36,
+          flexShrink: 0,
+          borderRadius: 9,
+          color: 'var(--color-green)',
+          background: 'var(--color-green-soft)',
+        }}
+      >
+        <Icon name="file" size={18} />
+      </span>
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <strong
+          data-testid="anon-file-name"
+          style={{
+            fontSize: 13.5,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {fileName}
+        </strong>
+        <span style={{ fontSize: 11.5, color: 'var(--color-text-dim)' }}>
+          {busy ? 'Reading document…' : `${chars.toLocaleString()} characters loaded`}
+        </span>
+      </div>
+      <Button variant="secondary" data-testid="anon-replace" onClick={onReplace} disabled={busy}>
+        Replace
+      </Button>
+      <Button variant="ghost" data-testid="anon-clear" onClick={onClear} aria-label="Clear document">
+        <Icon name="x" size={15} />
+      </Button>
+    </div>
+  );
+}
+
+function PasteArea({
+  text,
+  onText,
+}: {
+  readonly text: string;
+  readonly onText: (t: string) => void;
+}): JSX.Element {
+  // Keep a stable focus while typing — TextArea is uncontrolled-friendly here.
+  const [touched, setTouched] = useState(false);
+  return (
+    <TextArea
+      autoFocus
+      data-testid="anon-paste"
+      value={text}
+      onChange={(e) => onText(e.target.value)}
+      onBlur={() => setTouched(true)}
+      placeholder="Paste the text you want to anonymize…"
+      rows={10}
+      tone="soft"
+      style={{
+        width: '100%',
+        fontSize: 13,
+        lineHeight: 1.55,
+        minHeight: 200,
+        borderColor: touched && !text ? 'var(--color-card-border)' : undefined,
+      }}
+    />
+  );
+}


### PR DESCRIPTION
Complete UI/UX redesign of the offline document anonymizer into a simpler, guided flow — **import → set settings → get output** — as you asked. The engine, NER, document parsing, and the security-critical drag-drop model are untouched; this is presentation only.

## The new flow (three numbered stages, responsive two-column grid)

**1 · Import** — a `Segmented` toggle between *Upload a document* and *Paste text*. Upload shows a friendly centered dropzone (drag-active state + a prominent "Choose a file…" button + supported-types hint); once loaded it becomes a tidy file row (name, char count, **Replace** / **Clear**). Parse errors render inline.

**2 · Settings** — the redaction options as a clean form:
- **Filters in a proper multi-select dropdown** (`FilterSelect`) — a single chip trigger `⚙ Filters [count] ⌄` opening a checkbox list of every category + **All / None** shortcuts. Built on the anchored-dropdown pattern (outside-click + Escape, z-index lifted past the shell's `transform` stacking context). The synthetic **names** filter drives on-device NER with a live `loading… / unavailable / on-device AI` hint.
- Redaction **mode** (label / pseudonym / hash) segmented control with descriptions.
- **Custom terms** input.

**3 · Output** — empty state until there's text, then per-category **counts**, **Copy** (with a transient ✓) + **Save as…**, the redacted-text panel, and the `SpanHighlight` "what was detected" view.

## Preserved (verified)
Same `redact(input, { categories, customTerms, extraSpans: nerEnabled ? nerSpans : [] })` call, the debounced `useNer().detectNames`, `useAnonymizer()` pick/parse/save, and the drag-drop **reads bytes in the renderer, never sends a path** security model. Uses the design tokens + `@moxxy/desktop-ui` primitives; keeps the `OfflineBadge`.

## New / changed
`AnonymizerApp.tsx` (rebuilt), `ImportStep.tsx` + `FilterSelect.tsx` (new), `Counts.tsx` (restyled), `AnonymizerApp.test.tsx` (7 new tests).

**Verification:** `pnpm build` 70/70 · `typecheck` 137/137 · desktop tests **270/270** (39 files) · `lint` 0 errors · `check:deps` 0 errors. (Visual polish is best confirmed in a dev/packaged run.)