### PR TITLE
feat(desktop): agent showcases its work in the rail + Preferences tab

### DIFF
--- a/.changeset/desktop-rail-agent-reveal.md
+++ b/.changeset/desktop-rail-agent-reveal.md
@@ -1,0 +1,19 @@
+---
+"@moxxy/desktop": patch
+---
+
+feat(desktop): agent showcases its work in the rail + Preferences tab
+
+**Agent opens the sidebar.** When the agent drives the browser (`browser_session`)
+or the terminal (`terminal`), the matching Context-rail pane now opens on its own
+so the user sees the work as it happens — no need to open the pane manually. It's
+renderer-only (it watches the existing `runner.event` stream and reveals the pane),
+reveals each pane at most once per session, and never auto-closes — the rail's
+close button stays authoritative.
+
+**Preferences tab.** The "Appearance" and "About" settings tabs are folded into a
+single **Preferences** tab (theme + version/update + CLI), so there's one place for
+"how the app looks and updates".
+
+Also adds the previously-missing regression test for the browser region-capture →
+chat-attach flow.

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -21,6 +21,7 @@ import { ChatSurface } from './chat/ChatSurface';
 import { WorkspaceSidebar } from './shell/WorkspaceSidebar';
 import type { View } from './shell/ViewHeader';
 import { ContextRail, type RailPane } from './shell/ContextRail';
+import { useAgentSurfaceReveal } from './shell/surfaces/useAgentSurfaceReveal';
 import { WorkflowsPanel } from './workflows/WorkflowsPanel';
 import { CollaboratePanel } from './collaborate/CollaboratePanel';
 import { SettingsPanel } from './settings/SettingsPanel';
@@ -71,6 +72,10 @@ export function App(): JSX.Element {
   useEffect(() => {
     chatStore.setActive(activeWorkspaceId);
   }, [activeWorkspaceId]);
+
+  // When the agent drives the browser / terminal, open the matching rail
+  // pane so its work is shown to the user (once per session per pane).
+  useAgentSurfaceReveal(activeWorkspaceId, setRailPane);
 
   // Cmd/Ctrl+B toggles the workspace sidebar (same window-level keydown
   // pattern as WorkflowCanvas's Delete handling). Skipped while typing —

--- a/apps/desktop/src/settings/PreferencesTab.tsx
+++ b/apps/desktop/src/settings/PreferencesTab.tsx
@@ -1,0 +1,17 @@
+/**
+ * Preferences tab — the app-level settings that don't read the runner-backed
+ * settings slice: appearance (theme) plus the About/update + CLI section.
+ * Folds the former "Appearance" and "About" tabs into one so there's a single
+ * place for "how the app looks and updates".
+ */
+import { AppearanceTab } from './AppearanceTab';
+import { AboutTab } from './AboutTab';
+
+export function PreferencesTab(): JSX.Element {
+  return (
+    <>
+      <AppearanceTab />
+      <AboutTab />
+    </>
+  );
+}

--- a/apps/desktop/src/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/settings/SettingsPanel.tsx
@@ -5,13 +5,12 @@ import { SkillsView } from './SkillsView';
 import { ProvidersTab } from './ProvidersTab';
 import { McpTab } from './McpTab';
 import { VaultTab } from './VaultTab';
-import { AboutTab } from './AboutTab';
 import { MobileTab } from './MobileTab';
-import { AppearanceTab } from './AppearanceTab';
+import { PreferencesTab } from './PreferencesTab';
 import { SearchBox } from './settings-primitives';
 import { ViewHeader, ViewSwitcher, Segmented, type View } from '../shell/ViewHeader';
 
-type Tab = 'providers' | 'mcp' | 'skills' | 'vault' | 'mobile' | 'appearance' | 'about';
+type Tab = 'providers' | 'mcp' | 'skills' | 'vault' | 'mobile' | 'preferences';
 
 const TABS: ReadonlyArray<{ id: Tab; label: string }> = [
   { id: 'providers', label: 'Providers' },
@@ -19,13 +18,12 @@ const TABS: ReadonlyArray<{ id: Tab; label: string }> = [
   { id: 'skills', label: 'Skills' },
   { id: 'vault', label: 'Vault' },
   { id: 'mobile', label: 'Mobile' },
-  { id: 'appearance', label: 'Appearance' },
-  { id: 'about', label: 'About' },
+  { id: 'preferences', label: 'Preferences' },
 ];
 
 // Tabs that don't read the runner-backed settings slice — render them outside
-// the shared loading / error chrome (like About).
-const STANDALONE_TABS: ReadonlySet<Tab> = new Set<Tab>(['about', 'mobile', 'appearance']);
+// the shared loading / error chrome (like Preferences / Mobile).
+const STANDALONE_TABS: ReadonlySet<Tab> = new Set<Tab>(['preferences', 'mobile']);
 
 /**
  * Tabbed settings panel — providers, MCP servers, skills, vault. Each tab
@@ -83,11 +81,10 @@ export function SettingsPanel({
         }}
       >
 
-      {/* About + Mobile are independent of the runner-backed settings slice —
-          render them without the shared loading / error chrome below. */}
-      {tab === 'about' && <AboutTab />}
+      {/* Preferences + Mobile are independent of the runner-backed settings
+          slice — render them without the shared loading / error chrome below. */}
+      {tab === 'preferences' && <PreferencesTab />}
       {tab === 'mobile' && <MobileTab />}
-      {tab === 'appearance' && <AppearanceTab />}
 
       {!STANDALONE_TABS.has(tab) && s.error && (
         <div

--- a/apps/desktop/src/shell/surfaces/BrowserPane.capture.test.tsx
+++ b/apps/desktop/src/shell/surfaces/BrowserPane.capture.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * BrowserPane region capture → chat attach.
+ *   1. Dragging a box in capture mode sends a `capture` surface input
+ *      (normalized region) to the runner.
+ *   2. A `captured` payload (the sharp PNG, streamed back as surface.data) is
+ *      persisted via session.saveImageAttachment AND emitted to the composer as
+ *      an attachment (the same FILE_INSERT_EVENT the file tree uses).
+ * Regression for "I select a region and nothing reaches the chat input".
+ */
+import { describe, expect, it, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import { __setApiOverride } from '@moxxy/client-core';
+import { BrowserPane } from './BrowserPane';
+import { FILE_INSERT_EVENT } from '../WorkspaceFiles';
+
+function installFakeApi(): {
+  inputs: Array<{ type: string; [k: string]: unknown }>;
+  saveCalls: unknown[];
+  fireData: (payload: unknown) => void;
+} {
+  const inputs: Array<{ type: string; [k: string]: unknown }> = [];
+  const saveCalls: unknown[] = [];
+  let dataCb: ((d: unknown) => void) | null = null;
+  __setApiOverride({
+    invoke: ((channel: string, args: unknown) => {
+      if (channel === 'surface.open') {
+        return Promise.resolve({
+          surfaceId: 'surf-1',
+          snapshot: { type: 'frame', base64: 'AAAA', mime: 'image/jpeg', url: 'https://e.com' },
+        });
+      }
+      if (channel === 'surface.input') {
+        inputs.push((args as { message: { type: string } }).message);
+        return Promise.resolve(undefined);
+      }
+      if (channel === 'session.saveImageAttachment') {
+        saveCalls.push(args);
+        return Promise.resolve({ path: '/tmp/x/browser-capture.png', name: 'browser-capture.png' });
+      }
+      return Promise.resolve(undefined);
+    }) as never,
+    subscribe: ((event: string, cb: (d: unknown) => void) => {
+      if (event === 'surface.data') dataCb = cb;
+      return () => undefined;
+    }) as never,
+  } as never);
+  return {
+    inputs,
+    saveCalls,
+    fireData: (payload) => dataCb?.({ workspaceId: 'ws-1', data: { surfaceId: 'surf-1', payload } }),
+  };
+}
+
+afterEach(async () => {
+  cleanup();
+  await Promise.resolve();
+  __setApiOverride(null);
+});
+
+describe('BrowserPane region capture → chat attach', () => {
+  it('drag in capture mode sends a normalized capture input', async () => {
+    const spy = installFakeApi();
+    const { container } = render(<BrowserPane workspaceId="ws-1" />);
+    await waitFor(() => expect(screen.queryByText(/Browser unavailable/i)).toBeNull());
+
+    fireEvent.click(screen.getByLabelText('Capture region'));
+    const host = container.querySelector('[tabindex="0"]') as HTMLElement;
+    // jsdom getBoundingClientRect is 0×0 — stub a real pane size.
+    host.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 800, height: 600, right: 800, bottom: 600, x: 0, y: 0, toJSON() {} }) as DOMRect;
+
+    fireEvent.mouseDown(host, { clientX: 80, clientY: 60 });
+    fireEvent.mouseMove(host, { clientX: 480, clientY: 360 });
+    fireEvent.mouseUp(host, { clientX: 480, clientY: 360 });
+
+    const cap = spy.inputs.find((m) => m.type === 'capture');
+    expect(cap, 'a capture input should be sent').toBeTruthy();
+    expect(cap).toMatchObject({ type: 'capture', fx: 0.1, fy: 0.1, fw: 0.5, fh: 0.5 });
+  });
+
+  it('a captured payload is saved and emitted to the composer as an attachment', async () => {
+    const spy = installFakeApi();
+    render(<BrowserPane workspaceId="ws-1" />);
+    await waitFor(() => expect(screen.queryByText(/Browser unavailable/i)).toBeNull());
+
+    const inserts: Array<{ absPath?: string }> = [];
+    const onInsert = (e: Event): void => {
+      inserts.push((e as CustomEvent).detail);
+    };
+    window.addEventListener(FILE_INSERT_EVENT, onInsert);
+
+    spy.fireData({ type: 'captured', base64: 'PNGDATA', mediaType: 'image/png' });
+
+    await waitFor(() => expect(spy.saveCalls.length).toBe(1));
+    expect(spy.saveCalls[0]).toMatchObject({ dataBase64: 'PNGDATA', mediaType: 'image/png' });
+    await waitFor(() => expect(inserts.length).toBe(1));
+    expect(inserts[0]).toMatchObject({ absPath: '/tmp/x/browser-capture.png' });
+    window.removeEventListener(FILE_INSERT_EVENT, onInsert);
+  });
+});

--- a/apps/desktop/src/shell/surfaces/useAgentSurfaceReveal.test.tsx
+++ b/apps/desktop/src/shell/surfaces/useAgentSurfaceReveal.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * useAgentSurfaceReveal — auto-open the rail pane that showcases the agent's
+ * work. Locks down:
+ *   1. browser_session → reveal 'browser'; terminal → reveal 'terminal'.
+ *   2. Events for OTHER workspaces are ignored.
+ *   3. Each pane is revealed at most once per session (no fighting the user).
+ *   4. Non-tool events / unrelated tools never reveal.
+ */
+import { describe, expect, it, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { __setApiOverride } from '@moxxy/client-core';
+import { useAgentSurfaceReveal } from './useAgentSurfaceReveal';
+
+function installFakeApi(): { emit: (payload: unknown) => void } {
+  const subs = new Set<(payload: unknown) => void>();
+  __setApiOverride({
+    invoke: (() => Promise.resolve(undefined)) as never,
+    subscribe: ((channel: string, cb: (payload: unknown) => void) => {
+      if (channel === 'runner.event') subs.add(cb);
+      return () => subs.delete(cb);
+    }) as never,
+  } as never);
+  return { emit: (payload) => subs.forEach((cb) => cb(payload)) };
+}
+
+const toolEvent = (workspaceId: string, name: string): unknown => ({
+  workspaceId,
+  event: { type: 'tool_call_requested', turnId: 't1', callId: 'c1', name, input: {} },
+});
+
+afterEach(() => __setApiOverride(null));
+
+describe('useAgentSurfaceReveal', () => {
+  it('reveals browser/terminal panes for the matching tool', () => {
+    const spy = installFakeApi();
+    const revealed: string[] = [];
+    renderHook(() => useAgentSurfaceReveal('ws-1', (p) => revealed.push(p)));
+
+    spy.emit(toolEvent('ws-1', 'browser_session'));
+    spy.emit(toolEvent('ws-1', 'terminal'));
+    expect(revealed).toEqual(['browser', 'terminal']);
+  });
+
+  it('ignores events for other workspaces and unrelated tools', () => {
+    const spy = installFakeApi();
+    const revealed: string[] = [];
+    renderHook(() => useAgentSurfaceReveal('ws-1', (p) => revealed.push(p)));
+
+    spy.emit(toolEvent('ws-OTHER', 'browser_session'));
+    spy.emit(toolEvent('ws-1', 'read_file'));
+    spy.emit({ workspaceId: 'ws-1', event: { type: 'assistant_chunk', turnId: 't1', delta: 'hi' } });
+    expect(revealed).toEqual([]);
+  });
+
+  it('reveals each pane at most once per session', () => {
+    const spy = installFakeApi();
+    const revealed: string[] = [];
+    renderHook(() => useAgentSurfaceReveal('ws-1', (p) => revealed.push(p)));
+
+    spy.emit(toolEvent('ws-1', 'browser_session'));
+    spy.emit(toolEvent('ws-1', 'browser_session'));
+    spy.emit(toolEvent('ws-1', 'browser_session'));
+    expect(revealed).toEqual(['browser']);
+  });
+});

--- a/apps/desktop/src/shell/surfaces/useAgentSurfaceReveal.ts
+++ b/apps/desktop/src/shell/surfaces/useAgentSurfaceReveal.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import { api } from '@moxxy/client-core';
+import type { RailPane } from '../ContextRail';
+
+/**
+ * Agent tool → the rail pane that showcases that tool's work. The agent and
+ * the user share ONE underlying resource per surface (the Playwright page /
+ * the PTY), so opening the pane shows exactly what the tool is doing.
+ */
+const TOOL_PANE: Readonly<Record<string, RailPane>> = {
+  browser_session: 'browser',
+  terminal: 'terminal',
+};
+
+/**
+ * Auto-reveal the matching rail pane the first time the agent uses its
+ * browser / terminal tool, so its work is shown to the user without them
+ * having to open the pane manually ("showcase its work"). Renderer-only: we
+ * observe the SAME `runner.event` stream the transcript renders and call
+ * `reveal` for the active workspace — no runner / protocol change.
+ *
+ * Each pane is revealed at most once per workspace session: the showcase
+ * happens at the meaningful moment (the agent's first navigation / first
+ * command) and we never fight the user by reopening a pane they've closed.
+ * We never auto-CLOSE — the rail's close button stays authoritative.
+ */
+export function useAgentSurfaceReveal(
+  workspaceId: string | null,
+  reveal: (pane: RailPane) => void,
+): void {
+  useEffect(() => {
+    if (!workspaceId) return;
+    // Reset per workspace — a fresh session showcases afresh.
+    const revealed = new Set<RailPane>();
+    return api().subscribe('runner.event', ({ workspaceId: wid, event }) => {
+      if (wid !== workspaceId || event.type !== 'tool_call_requested') return;
+      const pane = TOOL_PANE[event.name];
+      if (!pane || revealed.has(pane)) return;
+      revealed.add(pane);
+      reveal(pane);
+    });
+  }, [workspaceId, reveal]);
+}


### PR DESCRIPTION
## What

Two desktop UX changes (the "rail update"), built on top of the now-merged region-capture work (#249).

### 1. Agent opens the sidebar to showcase its work
When the agent drives the browser (`browser_session`) or the terminal (`terminal`), the matching **Context-rail pane opens on its own** so the user sees the work as it happens — no need to open the pane manually.

- **Renderer-only.** A small hook (`useAgentSurfaceReveal`) observes the existing `runner.event` stream and calls `setRailPane` — no runner / protocol / plugin change, no new tool.
- Reveals each pane **at most once per workspace session** (the meaningful moment — first navigation / first command) so it never fights a user who's closed it.
- **Never auto-closes** — the rail's close button stays authoritative.

### 2. Preferences tab
The **Appearance** and **About** settings tabs are folded into one **Preferences** tab (theme + version/update + CLI) — one place for "how the app looks and updates".

### 3. Regression test for region-capture → chat-attach
Adds the previously-missing end-to-end frontend test for the browser region-capture flow (drag a region → `capture` input → `captured` payload → `saveImageAttachment` → composer attachment chip). This path shipped in #249 untested.

## Why
- "Agent should be able to open the sidebar (browser/terminal) to showcase its work."
- Consolidate the two app-level settings tabs.

## Testing
- `pnpm build` 70/70, `pnpm typecheck` 137/137, `pnpm lint` 0 errors, desktop tests **268/268** (incl. 3 new reveal tests + 2 new capture tests), `pnpm check:deps` 0 errors.