### PR TITLE
feat(desktop): read chat history from the runner's authoritative log

### DIFF
--- a/.changeset/renderer-runner-history.md
+++ b/.changeset/renderer-runner-history.md
@@ -21,9 +21,17 @@ own NDJSON store, completing the renderer half of the dual-history consolidation
   source (runner `seq` cursor vs NDJSON line-index cursor) is decided once per
   slot and never mixed; if the runner drops mid-scroll the slot stays resumable
   rather than switching cursor spaces.
-- A GOLDEN render-equivalence test pins that runner-stream + `isRenderedEvent`
-  reconstructs the EXACT same transcript as the NDJSON `loadSegment` path, across
-  stream-without-seal, reasoning, tool, compaction, and multi-page fixtures.
+- Legacy completeness: a session whose runner log predates the seal feature can
+  hold a turn that streamed text then errored/aborted with no `assistant_message`.
+  The runner-read projection reconstructs that reply (mirroring the runner's own
+  seal) so it is never silently dropped — but only for turns the runner never
+  sealed, so a post-seal errored turn is not doubled.
+- A GOLDEN render-equivalence test pins that the runner-read projection
+  reconstructs the EXACT same transcript as the legacy NDJSON path — its ground
+  truth is built by an independent pass of the real live reducer (not by
+  re-applying the projection), across sealed, unsealed (reconstructed),
+  errored-then-sealed (not doubled), reasoning, tool, plugin, compaction, and
+  multi-page fixtures.
 
 The renderer still WRITES NDJSON (the double-write), so it remains a working read
 fallback and the home of legacy-only chats. Stopping the double-write and

--- a/.changeset/renderer-runner-history.md
+++ b/.changeset/renderer-runner-history.md
@@ -1,0 +1,31 @@
+---
+"@moxxy/desktop": minor
+---
+
+feat(desktop): read chat history from the runner's authoritative log (NDJSON kept as fallback)
+
+The desktop renderer now reads transcript history from the runner instead of its
+own NDJSON store, completing the renderer half of the dual-history consolidation
+(the runner v10 `session.loadHistory` foundation shipped separately).
+
+- New IPC `chat.loadHistory` proxies to the workspace's connected `RemoteSession`
+  (`session.loadHistory`, protocol v10). It returns `null` — so the renderer
+  falls back to the existing `chat.loadSegment` NDJSON path — whenever the runner
+  can't serve it: no connected runner for the workspace, a `<v10` runner (the
+  version gate throws), or a legacy-only chat that exists solely in
+  `~/.moxxy/chats`. No transcript ever goes blank.
+- `ChatPersistence.loadHistory` + a chat-store "page-until-K-rendered" cursor:
+  the runner returns RAW events (including non-rendered `assistant_chunk`/
+  provider bookends), so the store walks several raw pages and filters with
+  `isRenderedEvent` until it has a full window of rendered rows. The history
+  source (runner `seq` cursor vs NDJSON line-index cursor) is decided once per
+  slot and never mixed; if the runner drops mid-scroll the slot stays resumable
+  rather than switching cursor spaces.
+- A GOLDEN render-equivalence test pins that runner-stream + `isRenderedEvent`
+  reconstructs the EXACT same transcript as the NDJSON `loadSegment` path, across
+  stream-without-seal, reasoning, tool, compaction, and multi-page fixtures.
+
+The renderer still WRITES NDJSON (the double-write), so it remains a working read
+fallback and the home of legacy-only chats. Stopping the double-write and
+physically retiring the NDJSON store are deferred follow-ups, gated on a v10
+floor and packaged-desktop live-verify.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -107,9 +107,19 @@ that must not be rushed, because rushing it would *lower* quality, not raise it:
    its log is the complete authoritative history (no more renderer-only synth).
    The client method is version-gated (`requireServerProtocol(10)`); against an
    older runner it throws an actionable error the renderer can catch to fall back
-   to NDJSON, and the desktop FLOOR was deliberately NOT raised. **Remaining:** the
-   renderer migration to read history from the runner (with the NDJSON read
-   fallback retained) — a separate desktop-facing PR.
+   to NDJSON, and the desktop FLOOR was deliberately NOT raised.
+   **Renderer migration landed (2026-06-18):** the desktop now READS history from
+   the runner — IPC `chat.loadHistory` proxies to the workspace's `RemoteSession`
+   and returns `null` (→ NDJSON fallback) for a `<v10`/disconnected runner or a
+   legacy-only chat; `ChatPersistence.loadHistory` + a chat-store "page-until-K-
+   rendered" cursor walk the runner's RAW pages and filter with `isRenderedEvent`,
+   with the source pinned per slot so the runner `seq` and NDJSON line cursors
+   never mix. A GOLDEN render-equivalence test pins runner-stream+filter ==
+   NDJSON across stream-without-seal / reasoning / tool / compaction / multi-page
+   fixtures. **Remaining (separate PRs, gated on packaged-desktop live-verify):**
+   (a) stop the NDJSON double-WRITE once v10 is the floor, then (b) physically
+   retire the NDJSON store. The renderer still WRITES NDJSON today so it stays a
+   working read fallback + the home of legacy-only chats.
 4. **One-shot CLI exit hygiene** (`moxxy -p` / `schedule run` / `doctor` / `login` /
    `init` boot a full session and never `close()`) — minor; a correct fix must drain
    persistence before exit (premature exit would drop the last event).

--- a/packages/client-core/src/chat-store/history-equivalence.test.ts
+++ b/packages/client-core/src/chat-store/history-equivalence.test.ts
@@ -2,42 +2,57 @@
  * GOLDEN render-equivalence test for the dual-history consolidation.
  *
  * Proves that paging a workspace's history from the RUNNER's authoritative log
- * (`session.loadHistory` — RAW events, `seq` cursor, filtered client-side with
- * `isRenderedEvent`, "page-until-K-rendered") yields the EXACT same rendered
- * transcript as the legacy NDJSON path (`chat.loadSegment` — already-rendered
- * events, line-index cursor). If these two ever diverge, switching the renderer
- * onto the runner log would silently change what the user sees — this test is
- * the gate against that.
+ * (`session.loadHistory` — RAW events, `seq` cursor, projected client-side with
+ * the same rendered+reconstruct logic the live reducer uses) yields the EXACT
+ * same VISIBLE transcript as the legacy NDJSON path (`chat.loadSegment` — the
+ * already-rendered events the live reducer committed, line-index cursor). If
+ * these two ever diverge, switching the renderer onto the runner log would
+ * silently change what the user sees — this test is the gate against that.
  *
- * The fixture deliberately exercises the risky cases:
- *  - stream-without-seal turns (assistant_chunk deltas + the runner-sealed
- *    assistant_message): the chunks must be filtered, the message kept;
+ * The ground truth is NOT `RAW_LOG.filter(isRenderedEvent)` (which would be
+ * tautological with the production projection). It is built by running the RAW
+ * log through the REAL live reducer (`applyAction`, including its
+ * turn_complete synth) — an independent code path — so the test actually pins
+ * runner-projection == live-renderer.
+ *
+ * Fixtures exercise the risky cases:
+ *  - SEALED streamed turns (assistant_chunk deltas + a runner-sealed
+ *    assistant_message): chunks filtered, message kept;
+ *  - an UNSEALED turn (assistant_chunk deltas + a FATAL error, NO
+ *    assistant_message — a legacy log written before the runner sealed such
+ *    turns): the reply must be RECONSTRUCTED, not dropped;
  *  - reasoning (reasoning_chunk filtered, reasoning_message kept);
- *  - tool turns (tool_call_requested + tool_result kept);
- *  - a compaction event (non-rendered → dropped by BOTH paths);
- *  - provider_request/provider_response bookends (non-rendered);
- *  - enough rendered rows to span several scroll-up pages (multi-page), and
- *    enough RAW events that one runner window walks multiple raw pages.
+ *  - a tool turn (tool_call_requested + tool_result kept);
+ *  - a subagent plugin_event (the isRenderedEvent plugin branch);
+ *  - a compaction event (non-rendered → dropped by both);
+ *  - enough rendered rows to span several scroll-up pages.
  */
 
 import { describe, expect, it } from 'vitest';
 import type { MoxxyEvent } from '@moxxy/sdk';
 import { chatStore } from './store.js';
-import { isRenderedEvent } from '../chatModel.js';
+import { applyAction, createRuntime } from '../chatModel.js';
 import type { ChatPersistence } from '../chatPersistence.js';
 
-/** Build a realistic RAW runner log: contiguous seq 0..n-1, rendered and
- *  non-rendered events interleaved exactly as a real turn emits them. */
+const UNSEALED_TURN = 35; // legacy: streams text then a FATAL error, NO seal
+const SEALED_AFTER_ERROR_TURN = 22; // post-seal: chunks + error + the runner's REAL seal
+const PLUGIN_TURN = 12;
+const REASONING_TURN = 9;
+const TOOL_TURN = 17;
+const COMPACTION_TURN = 25;
+
+/** Build a realistic RAW runner log: contiguous seq 0..n-1, one logical turn at
+ *  a time, rendered and non-rendered events interleaved as a real turn emits. */
 function buildRawLog(): MoxxyEvent[] {
   const events: MoxxyEvent[] = [];
   let seq = 0;
-  const push = (type: string, extra: Record<string, unknown> = {}): void => {
+  const push = (turnId: string, type: string, extra: Record<string, unknown> = {}): void => {
     events.push({
       id: `e${seq}`,
       seq,
       ts: seq,
       sessionId: 'sess',
-      turnId: `t${Math.floor(seq / 16)}`,
+      turnId,
       source: 'system',
       type,
       ...extra,
@@ -45,35 +60,97 @@ function buildRawLog(): MoxxyEvent[] {
     seq += 1;
   };
   for (let turn = 0; turn < 40; turn += 1) {
-    push('user_prompt', { source: 'user', text: `q${turn}` }); // rendered
-    push('provider_request', { provider: 'fake', model: 'm' }); // non-rendered
-    // A streamed reply: several chunks (non-rendered) the runner then SEALS.
-    for (let c = 0; c < 8; c += 1) push('assistant_chunk', { delta: `${turn}.${c} ` });
-    if (turn === 9) {
-      push('reasoning_chunk', { delta: 'thinking…' }); // non-rendered
-      push('reasoning_message', { source: 'model', content: 'a thought' }); // rendered
+    const t = `t${turn}`;
+    push(t, 'user_prompt', { source: 'user', text: `q${turn}` }); // rendered
+    push(t, 'provider_request', { provider: 'fake', model: 'm' }); // non-rendered
+    for (let c = 0; c < 8; c += 1) push(t, 'assistant_chunk', { delta: `${turn}.${c} ` }); // non-rendered
+    if (turn === REASONING_TURN) {
+      push(t, 'reasoning_chunk', { delta: 'thinking…' }); // non-rendered
+      push(t, 'reasoning_message', { source: 'model', content: 'a thought' }); // rendered
     }
-    if (turn === 17) {
-      push('tool_call_requested', { source: 'model', name: 'Read', input: {}, callId: `c${turn}` }); // rendered
-      push('tool_result', { source: 'tool', callId: `c${turn}`, content: 'file body' }); // rendered
+    if (turn === TOOL_TURN) {
+      push(t, 'tool_call_requested', { source: 'model', name: 'Read', input: {}, callId: `c${turn}` });
+      push(t, 'tool_result', { source: 'tool', callId: `c${turn}`, content: 'file body' });
     }
-    push('assistant_message', { source: 'model', content: `a${turn}`, stopReason: 'end_turn' }); // rendered (the seal)
-    push('provider_response', { provider: 'fake', model: 'm' }); // non-rendered
-    if (turn === 25) push('compaction', { tokensSaved: 1234 }); // non-rendered → dropped by both
+    if (turn === PLUGIN_TURN) {
+      push(t, 'plugin_event', { pluginId: '@moxxy/subagents', kind: 'spawned', agentId: 'a1' }); // rendered
+    }
+    push(t, 'provider_response', { provider: 'fake', model: 'm' }); // non-rendered
+    if (turn === UNSEALED_TURN) {
+      // Streamed text then a FATAL error, NO assistant_message — the pre-seal
+      // legacy shape. The reply text must survive via reconstruction.
+      push(t, 'error', { source: 'system', kind: 'fatal', message: 'provider died mid-stream' }); // rendered
+    } else if (turn === SEALED_AFTER_ERROR_TURN) {
+      // Post-seal shape: the turn errored mid-stream but the runner THEN sealed
+      // the streamed text into a real assistant_message. The reconstruction must
+      // NOT fire here (that would double the reply) — the real seal stands.
+      push(t, 'error', { source: 'system', kind: 'fatal', message: 'transient' }); // rendered
+      push(t, 'assistant_message', { source: 'model', content: `a${turn}`, stopReason: 'end_turn' }); // the runner's seal
+    } else {
+      push(t, 'assistant_message', { source: 'model', content: `a${turn}`, stopReason: 'end_turn' }); // rendered (seal)
+    }
+    if (turn === COMPACTION_TURN) push(t, 'compaction', { tokensSaved: 1234 }); // non-rendered → dropped by both
   }
   return events;
 }
 
 const RAW_LOG = buildRawLog();
-/** Ground truth: exactly the events the renderer commits = isRenderedEvent. */
-const EXPECTED_RENDERED_IDS = RAW_LOG.filter(isRenderedEvent).map((e) => e.id);
 
-/** Page the RAW log newest-first by `seq` — the runner's `session.loadHistory`
+/** Independent ground truth: feed the RAW log through the REAL live reducer
+ *  (applyAction), firing turn_complete at each turn boundary so an unsealed
+ *  turn's streamed text is synthesized exactly as the old renderer committed it
+ *  to NDJSON. This is a DIFFERENT code path than the production runner
+ *  projection, so the equivalence assertion is not tautological. */
+function liveRenderedTranscript(raw: ReadonlyArray<MoxxyEvent>): MoxxyEvent[] {
+  const rt = createRuntime();
+  let curTurn: string | null = null;
+  for (const e of raw) {
+    if (curTurn !== null && e.turnId !== curTurn) {
+      applyAction(rt, { type: 'turn_complete', turnId: curTurn, error: null });
+    }
+    curTurn = e.turnId;
+    applyAction(rt, { type: 'event', event: e });
+  }
+  if (curTurn !== null) applyAction(rt, { type: 'turn_complete', turnId: curTurn, error: null });
+  return rt.log.toArray();
+}
+
+const NDJSON_TRANSCRIPT = liveRenderedTranscript(RAW_LOG);
+
+/** What the user actually SEES — id-independent (the runner reconstruction and
+ *  the live-reducer synth use different synth ids, but must show the same text
+ *  in the same order). */
+function visible(events: ReadonlyArray<MoxxyEvent>): string[] {
+  return events.map((e) => {
+    const ev = e as Record<string, unknown>;
+    switch (e.type) {
+      case 'user_prompt':
+        return `user:${ev.text as string}`;
+      case 'assistant_message':
+        return `assistant:${ev.content as string}`;
+      case 'reasoning_message':
+        return `reasoning:${ev.content as string}`;
+      case 'tool_call_requested':
+        return `tool_req:${ev.callId as string}`;
+      case 'tool_result':
+        return `tool_res:${ev.callId as string}`;
+      case 'plugin_event':
+        return `plugin:${ev.pluginId as string}`;
+      case 'error':
+        return `error:${ev.kind as string}`;
+      case 'abort':
+        return 'abort';
+      default:
+        return e.type;
+    }
+  });
+}
+
+const EXPECTED_VISIBLE = visible(NDJSON_TRANSCRIPT);
+
+/** Page the RAW log newest-first by `seq` — the runner's session.loadHistory
  *  semantics (matches @moxxy/core's pageEvents). */
-function pageRawBySeq(
-  before: number | null,
-  limit: number,
-): { events: MoxxyEvent[]; prevCursor: number | null } {
+function pageRawBySeq(before: number | null, limit: number): { events: MoxxyEvent[]; prevCursor: number | null } {
   let end = RAW_LOG.length;
   if (before !== null) {
     end = 0;
@@ -87,20 +164,19 @@ function pageRawBySeq(
   return { events: page, prevCursor: start <= 0 ? null : page[0]!.seq };
 }
 
-/** Page the RENDERED subset newest-first by line-index — the NDJSON
- *  `chat.loadSegment` semantics (matches desktop-host's chat-log). */
-const RENDERED = RAW_LOG.filter(isRenderedEvent);
-function pageRenderedByIndex(
+/** Page the NDJSON transcript newest-first by line-index — the NDJSON
+ *  chat.loadSegment semantics (matches desktop-host's chat-log). */
+function pageNdjsonByIndex(
   before: number | null,
   limit: number,
 ): { events: MoxxyEvent[]; prevCursor: number | null } {
-  const total = RENDERED.length;
+  const total = NDJSON_TRANSCRIPT.length;
   const end = before === null ? total : Math.min(before, total);
   const start = Math.max(0, end - limit);
-  return { events: RENDERED.slice(start, end), prevCursor: start > 0 ? start : null };
+  return { events: NDJSON_TRANSCRIPT.slice(start, end), prevCursor: start > 0 ? start : null };
 }
 
-/** A fake that serves history from the RUNNER (raw + seq cursor). */
+/** A fake serving history from the RUNNER (raw events + seq cursor). */
 const runnerBackend: ChatPersistence = {
   async loadHistory(_ws, before, limit) {
     return pageRawBySeq(before, limit);
@@ -113,61 +189,65 @@ const runnerBackend: ChatPersistence = {
 };
 
 /** A fake standing in for an OLDER (<v10) runner: loadHistory returns null, so
- *  the store falls back to the NDJSON loadSegment path (rendered + line cursor). */
+ *  the store falls back to the NDJSON loadSegment path. */
 const ndjsonBackend: ChatPersistence = {
   async loadHistory() {
     return null;
   },
   async loadSegment(_ws, before, limit) {
-    return pageRenderedByIndex(before, limit);
+    return pageNdjsonByIndex(before, limit);
   },
   async append() {},
   async clear() {},
 };
 
-/** Drive a workspace's full scroll-up to exhaustion and return the rendered
- *  transcript the store ended up with. */
-async function loadWholeTranscript(persistence: ChatPersistence, workspaceId: string): Promise<string[]> {
+async function loadWholeTranscript(persistence: ChatPersistence, workspaceId: string): Promise<MoxxyEvent[]> {
   chatStore.setPersistence(persistence);
   await chatStore.loadInitial(workspaceId);
   for (let guard = 0; guard < 100 && chatStore.getChat(workspaceId).hasOlder; guard += 1) {
     await chatStore.loadOlder(workspaceId);
   }
-  return chatStore.getChat(workspaceId).events.map((e) => e.id);
+  return [...chatStore.getChat(workspaceId).events];
 }
 
 describe('history render-equivalence: runner stream vs NDJSON', () => {
   it('the fixture actually exercises the hard cases', () => {
-    // Non-rendered events present (so filtering is meaningful)...
     expect(RAW_LOG.some((e) => e.type === 'assistant_chunk')).toBe(true);
     expect(RAW_LOG.some((e) => e.type === 'compaction')).toBe(true);
-    expect(RAW_LOG.some((e) => e.type === 'provider_request')).toBe(true);
+    expect(RAW_LOG.some((e) => e.type === 'plugin_event')).toBe(true);
+    // An UNSEALED turn really is present (chunks + fatal error, no message)...
+    const unsealed = RAW_LOG.filter((e) => e.turnId === `t${UNSEALED_TURN}`);
+    expect(unsealed.some((e) => e.type === 'assistant_chunk')).toBe(true);
+    expect(unsealed.some((e) => e.type === 'assistant_message')).toBe(false);
+    expect(unsealed.some((e) => e.type === 'error')).toBe(true);
+    // ...and the live reducer DID reconstruct its reply into the NDJSON truth.
+    const synthText = `${UNSEALED_TURN}.0 ${UNSEALED_TURN}.1 ${UNSEALED_TURN}.2 ${UNSEALED_TURN}.3 ${UNSEALED_TURN}.4 ${UNSEALED_TURN}.5 ${UNSEALED_TURN}.6 ${UNSEALED_TURN}.7 `;
+    expect(EXPECTED_VISIBLE).toContain(`assistant:${synthText}`);
+    // The post-seal errored turn yields EXACTLY ONE assistant reply (the real
+    // seal) — reconstruction must not double it.
+    expect(EXPECTED_VISIBLE.filter((v) => v === `assistant:a${SEALED_AFTER_ERROR_TURN}`)).toHaveLength(1);
     // ...and more rendered rows than one page, so scroll-up runs many times.
-    expect(EXPECTED_RENDERED_IDS.length).toBeGreaterThan(50);
-    // ...and more raw events than one runner window, so page-until-K loops.
+    expect(EXPECTED_VISIBLE.length).toBeGreaterThan(50);
     expect(RAW_LOG.length).toBeGreaterThan(200);
   });
 
-  it('runner-stream + isRenderedEvent reconstructs exactly the rendered transcript', async () => {
-    const ids = await loadWholeTranscript(runnerBackend, 'equiv-runner');
-    expect(ids).toEqual(EXPECTED_RENDERED_IDS); // order, no dupes, no gaps
+  it('runner-stream projection reconstructs exactly the live-rendered transcript (incl. the unsealed reply)', async () => {
+    const events = await loadWholeTranscript(runnerBackend, 'equiv-runner');
+    expect(visible(events)).toEqual(EXPECTED_VISIBLE);
   });
 
   it('NDJSON fallback (older runner) reconstructs exactly the same transcript', async () => {
-    const ids = await loadWholeTranscript(ndjsonBackend, 'equiv-ndjson');
-    expect(ids).toEqual(EXPECTED_RENDERED_IDS);
+    const events = await loadWholeTranscript(ndjsonBackend, 'equiv-ndjson');
+    expect(visible(events)).toEqual(EXPECTED_VISIBLE);
   });
 
   it('the two sources are render-equivalent', async () => {
     const viaRunner = await loadWholeTranscript(runnerBackend, 'equiv-runner-2');
     const viaNdjson = await loadWholeTranscript(ndjsonBackend, 'equiv-ndjson-2');
-    expect(viaRunner).toEqual(viaNdjson);
+    expect(visible(viaRunner)).toEqual(visible(viaNdjson));
   });
 
   it('a runner that drops mid-scroll keeps hasOlder so a later scroll resumes (no NDJSON cursor-mixing)', async () => {
-    // First window serves from the runner, then loadHistory starts returning
-    // null (runner disconnected). The slot stays on the runner source and keeps
-    // hasOlder set rather than silently switching to the NDJSON line cursor.
     let live = true;
     const flaky: ChatPersistence = {
       async loadHistory(_ws, before, limit) {
@@ -184,7 +264,6 @@ describe('history render-equivalence: runner stream vs NDJSON', () => {
     expect(chatStore.getChat('equiv-flaky').hasOlder).toBe(true);
     live = false; // runner drops
     await chatStore.loadOlder('equiv-flaky');
-    // No throw (didn't hit loadSegment), and still resumable.
     expect(chatStore.getChat('equiv-flaky').hasOlder).toBe(true);
   });
 });

--- a/packages/client-core/src/chat-store/history-equivalence.test.ts
+++ b/packages/client-core/src/chat-store/history-equivalence.test.ts
@@ -1,0 +1,190 @@
+/**
+ * GOLDEN render-equivalence test for the dual-history consolidation.
+ *
+ * Proves that paging a workspace's history from the RUNNER's authoritative log
+ * (`session.loadHistory` — RAW events, `seq` cursor, filtered client-side with
+ * `isRenderedEvent`, "page-until-K-rendered") yields the EXACT same rendered
+ * transcript as the legacy NDJSON path (`chat.loadSegment` — already-rendered
+ * events, line-index cursor). If these two ever diverge, switching the renderer
+ * onto the runner log would silently change what the user sees — this test is
+ * the gate against that.
+ *
+ * The fixture deliberately exercises the risky cases:
+ *  - stream-without-seal turns (assistant_chunk deltas + the runner-sealed
+ *    assistant_message): the chunks must be filtered, the message kept;
+ *  - reasoning (reasoning_chunk filtered, reasoning_message kept);
+ *  - tool turns (tool_call_requested + tool_result kept);
+ *  - a compaction event (non-rendered → dropped by BOTH paths);
+ *  - provider_request/provider_response bookends (non-rendered);
+ *  - enough rendered rows to span several scroll-up pages (multi-page), and
+ *    enough RAW events that one runner window walks multiple raw pages.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { MoxxyEvent } from '@moxxy/sdk';
+import { chatStore } from './store.js';
+import { isRenderedEvent } from '../chatModel.js';
+import type { ChatPersistence } from '../chatPersistence.js';
+
+/** Build a realistic RAW runner log: contiguous seq 0..n-1, rendered and
+ *  non-rendered events interleaved exactly as a real turn emits them. */
+function buildRawLog(): MoxxyEvent[] {
+  const events: MoxxyEvent[] = [];
+  let seq = 0;
+  const push = (type: string, extra: Record<string, unknown> = {}): void => {
+    events.push({
+      id: `e${seq}`,
+      seq,
+      ts: seq,
+      sessionId: 'sess',
+      turnId: `t${Math.floor(seq / 16)}`,
+      source: 'system',
+      type,
+      ...extra,
+    } as unknown as MoxxyEvent);
+    seq += 1;
+  };
+  for (let turn = 0; turn < 40; turn += 1) {
+    push('user_prompt', { source: 'user', text: `q${turn}` }); // rendered
+    push('provider_request', { provider: 'fake', model: 'm' }); // non-rendered
+    // A streamed reply: several chunks (non-rendered) the runner then SEALS.
+    for (let c = 0; c < 8; c += 1) push('assistant_chunk', { delta: `${turn}.${c} ` });
+    if (turn === 9) {
+      push('reasoning_chunk', { delta: 'thinking…' }); // non-rendered
+      push('reasoning_message', { source: 'model', content: 'a thought' }); // rendered
+    }
+    if (turn === 17) {
+      push('tool_call_requested', { source: 'model', name: 'Read', input: {}, callId: `c${turn}` }); // rendered
+      push('tool_result', { source: 'tool', callId: `c${turn}`, content: 'file body' }); // rendered
+    }
+    push('assistant_message', { source: 'model', content: `a${turn}`, stopReason: 'end_turn' }); // rendered (the seal)
+    push('provider_response', { provider: 'fake', model: 'm' }); // non-rendered
+    if (turn === 25) push('compaction', { tokensSaved: 1234 }); // non-rendered → dropped by both
+  }
+  return events;
+}
+
+const RAW_LOG = buildRawLog();
+/** Ground truth: exactly the events the renderer commits = isRenderedEvent. */
+const EXPECTED_RENDERED_IDS = RAW_LOG.filter(isRenderedEvent).map((e) => e.id);
+
+/** Page the RAW log newest-first by `seq` — the runner's `session.loadHistory`
+ *  semantics (matches @moxxy/core's pageEvents). */
+function pageRawBySeq(
+  before: number | null,
+  limit: number,
+): { events: MoxxyEvent[]; prevCursor: number | null } {
+  let end = RAW_LOG.length;
+  if (before !== null) {
+    end = 0;
+    for (let i = 0; i < RAW_LOG.length; i += 1) {
+      if (RAW_LOG[i]!.seq < before) end = i + 1;
+      else break;
+    }
+  }
+  const start = Math.max(0, end - limit);
+  const page = RAW_LOG.slice(start, end);
+  return { events: page, prevCursor: start <= 0 ? null : page[0]!.seq };
+}
+
+/** Page the RENDERED subset newest-first by line-index — the NDJSON
+ *  `chat.loadSegment` semantics (matches desktop-host's chat-log). */
+const RENDERED = RAW_LOG.filter(isRenderedEvent);
+function pageRenderedByIndex(
+  before: number | null,
+  limit: number,
+): { events: MoxxyEvent[]; prevCursor: number | null } {
+  const total = RENDERED.length;
+  const end = before === null ? total : Math.min(before, total);
+  const start = Math.max(0, end - limit);
+  return { events: RENDERED.slice(start, end), prevCursor: start > 0 ? start : null };
+}
+
+/** A fake that serves history from the RUNNER (raw + seq cursor). */
+const runnerBackend: ChatPersistence = {
+  async loadHistory(_ws, before, limit) {
+    return pageRawBySeq(before, limit);
+  },
+  async loadSegment() {
+    throw new Error('runner-backed slot must never hit loadSegment');
+  },
+  async append() {},
+  async clear() {},
+};
+
+/** A fake standing in for an OLDER (<v10) runner: loadHistory returns null, so
+ *  the store falls back to the NDJSON loadSegment path (rendered + line cursor). */
+const ndjsonBackend: ChatPersistence = {
+  async loadHistory() {
+    return null;
+  },
+  async loadSegment(_ws, before, limit) {
+    return pageRenderedByIndex(before, limit);
+  },
+  async append() {},
+  async clear() {},
+};
+
+/** Drive a workspace's full scroll-up to exhaustion and return the rendered
+ *  transcript the store ended up with. */
+async function loadWholeTranscript(persistence: ChatPersistence, workspaceId: string): Promise<string[]> {
+  chatStore.setPersistence(persistence);
+  await chatStore.loadInitial(workspaceId);
+  for (let guard = 0; guard < 100 && chatStore.getChat(workspaceId).hasOlder; guard += 1) {
+    await chatStore.loadOlder(workspaceId);
+  }
+  return chatStore.getChat(workspaceId).events.map((e) => e.id);
+}
+
+describe('history render-equivalence: runner stream vs NDJSON', () => {
+  it('the fixture actually exercises the hard cases', () => {
+    // Non-rendered events present (so filtering is meaningful)...
+    expect(RAW_LOG.some((e) => e.type === 'assistant_chunk')).toBe(true);
+    expect(RAW_LOG.some((e) => e.type === 'compaction')).toBe(true);
+    expect(RAW_LOG.some((e) => e.type === 'provider_request')).toBe(true);
+    // ...and more rendered rows than one page, so scroll-up runs many times.
+    expect(EXPECTED_RENDERED_IDS.length).toBeGreaterThan(50);
+    // ...and more raw events than one runner window, so page-until-K loops.
+    expect(RAW_LOG.length).toBeGreaterThan(200);
+  });
+
+  it('runner-stream + isRenderedEvent reconstructs exactly the rendered transcript', async () => {
+    const ids = await loadWholeTranscript(runnerBackend, 'equiv-runner');
+    expect(ids).toEqual(EXPECTED_RENDERED_IDS); // order, no dupes, no gaps
+  });
+
+  it('NDJSON fallback (older runner) reconstructs exactly the same transcript', async () => {
+    const ids = await loadWholeTranscript(ndjsonBackend, 'equiv-ndjson');
+    expect(ids).toEqual(EXPECTED_RENDERED_IDS);
+  });
+
+  it('the two sources are render-equivalent', async () => {
+    const viaRunner = await loadWholeTranscript(runnerBackend, 'equiv-runner-2');
+    const viaNdjson = await loadWholeTranscript(ndjsonBackend, 'equiv-ndjson-2');
+    expect(viaRunner).toEqual(viaNdjson);
+  });
+
+  it('a runner that drops mid-scroll keeps hasOlder so a later scroll resumes (no NDJSON cursor-mixing)', async () => {
+    // First window serves from the runner, then loadHistory starts returning
+    // null (runner disconnected). The slot stays on the runner source and keeps
+    // hasOlder set rather than silently switching to the NDJSON line cursor.
+    let live = true;
+    const flaky: ChatPersistence = {
+      async loadHistory(_ws, before, limit) {
+        return live ? pageRawBySeq(before, limit) : null;
+      },
+      async loadSegment() {
+        throw new Error('must not fall back to NDJSON mid-runner-scroll');
+      },
+      async append() {},
+      async clear() {},
+    };
+    chatStore.setPersistence(flaky);
+    await chatStore.loadInitial('equiv-flaky');
+    expect(chatStore.getChat('equiv-flaky').hasOlder).toBe(true);
+    live = false; // runner drops
+    await chatStore.loadOlder('equiv-flaky');
+    // No throw (didn't hit loadSegment), and still resumable.
+    expect(chatStore.getChat('equiv-flaky').hasOlder).toBe(true);
+  });
+});

--- a/packages/client-core/src/chat-store/history-equivalence.test.ts
+++ b/packages/client-core/src/chat-store/history-equivalence.test.ts
@@ -201,6 +201,20 @@ const ndjsonBackend: ChatPersistence = {
   async clear() {},
 };
 
+/** A foregrounded LEGACY-ONLY chat: its runner session resumed EMPTY (no
+ *  `~/.moxxy/sessions/<id>.jsonl`), so loadHistory returns an empty-but-non-null
+ *  page, while the NDJSON mirror still holds the chat's history. */
+const emptyRunnerWithNdjsonBackend: ChatPersistence = {
+  async loadHistory() {
+    return { events: [], prevCursor: null };
+  },
+  async loadSegment(_ws, before, limit) {
+    return pageNdjsonByIndex(before, limit);
+  },
+  async append() {},
+  async clear() {},
+};
+
 async function loadWholeTranscript(persistence: ChatPersistence, workspaceId: string): Promise<MoxxyEvent[]> {
   chatStore.setPersistence(persistence);
   await chatStore.loadInitial(workspaceId);
@@ -245,6 +259,13 @@ describe('history render-equivalence: runner stream vs NDJSON', () => {
     const viaRunner = await loadWholeTranscript(runnerBackend, 'equiv-runner-2');
     const viaNdjson = await loadWholeTranscript(ndjsonBackend, 'equiv-ndjson-2');
     expect(visible(viaRunner)).toEqual(visible(viaNdjson));
+  });
+
+  it('falls back to NDJSON when the runner session resumed EMPTY (legacy-only chat is not blanked)', async () => {
+    const events = await loadWholeTranscript(emptyRunnerWithNdjsonBackend, 'equiv-legacy-empty');
+    // The chat's history is shown from NDJSON, not hidden behind the empty runner.
+    expect(events.length).toBeGreaterThan(0);
+    expect(visible(events)).toEqual(EXPECTED_VISIBLE);
   });
 
   it('a runner that drops mid-scroll keeps hasOlder so a later scroll resumes (no NDJSON cursor-mixing)', async () => {

--- a/packages/client-core/src/chat-store/state.ts
+++ b/packages/client-core/src/chat-store/state.ts
@@ -59,9 +59,17 @@ export interface Slot {
   autoApprove: boolean;
   lastSeenRev: number;
   queue: ReadonlyArray<QueuedTurn>;
-  /** Cursor for the next-older page, or null at the start of history. */
+  /** Cursor for the next-older page, or null at the start of history. Its space
+   *  depends on {@link historySource}: a runner `seq` cursor (source 'runner')
+   *  or an NDJSON line-index cursor (source 'ndjson'). The two never mix within
+   *  a slot — the source is decided once, on the first load. */
   oldestCursor: number | null;
   hasOlder: boolean;
+  /** Which backend this slot's history is paged from. Decided on first load:
+   *  'runner' when the workspace's runner served a v10 page, else 'ndjson'
+   *  (older runner / no connected runner / legacy-only chat). 'unknown' until
+   *  the first load resolves it. */
+  historySource: 'unknown' | 'runner' | 'ndjson';
   /** Whether the initial window has been loaded from disk. */
   loaded: boolean;
   /** True while the first on-open disk read is in flight (drives the
@@ -105,6 +113,7 @@ export function createSlot(): Slot {
     queue: EMPTY_QUEUE,
     oldestCursor: null,
     hasOlder: false,
+    historySource: 'unknown',
     loaded: false,
     loadingInitial: false,
     loadingOlder: false,

--- a/packages/client-core/src/chat-store/store.ts
+++ b/packages/client-core/src/chat-store/store.ts
@@ -33,6 +33,73 @@ const RUNNER_RAW_PAGE = 200;
 // streamed reply (hundreds of assistant_chunks) can't spin forever — after this
 // many pages we return what we have and let the next scroll-up continue.
 const MAX_RUNNER_PAGES = 25;
+
+/**
+ * Project a RAW runner window (all event types, ascending `seq`) into the
+ * rendered transcript the chat shows — the read-time equivalent of what the live
+ * reducer commits. Keeps {@link isRenderedEvent} events AND reconstructs the
+ * reply for a turn that streamed assistant text but ended UNSEALED (a fatal
+ * error / abort with no `assistant_message`).
+ *
+ * Why the synth: the runner seals such turns into a real `assistant_message`
+ * (`sealUnsealedStreamedText`) and the live renderer used to synthesize one on
+ * `turn_complete` — but a LEGACY runner log written BEFORE the seal feature
+ * holds chunks + the terminal error/abort and NO message, so filtering with
+ * `isRenderedEvent` alone would silently drop the reply text. We detect the
+ * unsealed turn by its TERMINAL fatal-error/abort row (NOT a turn boundary — a
+ * SEALED reply whose chunks merely span a window edge must not be re-synthesized)
+ * and emit the reconstructed reply right after it, matching the runner's own seq
+ * order. The accumulator resets on a sealing `assistant_message` or a fresh
+ * `provider_request` (a new iteration), so only the final iteration's unsealed
+ * text is reconstructed — identical to the runner's seal.
+ */
+export function projectRunnerWindow(raw: ReadonlyArray<MoxxyEvent>): MoxxyEvent[] {
+  // Turns that carry a REAL sealing assistant_message anywhere in this window
+  // must never be reconstructed — a POST-seal runner errored turn holds chunks,
+  // the error, AND the seal the runner appended at turn end, so synthesizing at
+  // the error would double the reply. Only a LEGACY (pre-seal) turn lacks the
+  // message and needs reconstruction.
+  const sealedTurns = new Set<string>();
+  for (const e of raw) if (e.type === 'assistant_message') sealedTurns.add(e.turnId);
+
+  const out: MoxxyEvent[] = [];
+  const unsealed = new Map<string, string>();
+  for (const e of raw) {
+    if (e.type === 'assistant_chunk') {
+      const delta = (e as { delta?: string }).delta ?? '';
+      unsealed.set(e.turnId, (unsealed.get(e.turnId) ?? '') + delta);
+      continue;
+    }
+    // A sealing message or a new provider iteration drops the pending run.
+    if (e.type === 'assistant_message' || e.type === 'provider_request') unsealed.delete(e.turnId);
+    if (!isRenderedEvent(e)) continue;
+    out.push(e);
+    // Terminal unsealed end → reconstruct the reply after the error/abort row,
+    // but ONLY for a turn the runner never sealed (a legacy log).
+    const terminal =
+      e.type === 'abort' || (e.type === 'error' && (e as { kind?: string }).kind === 'fatal');
+    if (terminal && !sealedTurns.has(e.turnId)) {
+      const text = unsealed.get(e.turnId);
+      if (text && text.trim()) {
+        out.push({
+          type: 'assistant_message',
+          content: text,
+          stopReason: 'end_turn',
+          // Stable per-turn id: the terminal event is unique to the turn, so this
+          // synth is produced in exactly one window (no cross-window dup).
+          id: `synth-unsealed:${e.turnId}`,
+          seq: e.seq,
+          ts: (e as { ts?: number }).ts ?? e.seq,
+          sessionId: e.sessionId,
+          turnId: e.turnId,
+          source: 'model',
+        } as unknown as MoxxyEvent);
+      }
+      unsealed.delete(e.turnId);
+    }
+  }
+  return out;
+}
 import {
   buildSnapshot,
   createSlot,
@@ -220,6 +287,17 @@ class ChatStore {
         this.prependFresh(slot, runner.events);
         slot.oldestCursor = runner.prevCursor;
         slot.hasOlder = runner.prevCursor !== null;
+        // Defend the extreme case where the newest window was ALL non-rendered
+        // raw events (e.g. the tail of one very long streamed reply): never leave
+        // the transcript blank-but-has-more — pull older windows (bounded) until
+        // something renders or we reach the start of history.
+        for (let pump = 0; pump < 10 && slot.rt.log.length === 0 && slot.hasOlder; pump += 1) {
+          const more = await this.loadRunnerWindow(workspaceId, slot.oldestCursor, INITIAL_WINDOW);
+          if (!more) break;
+          this.prependFresh(slot, more.events);
+          slot.oldestCursor = more.prevCursor;
+          slot.hasOlder = more.prevCursor !== null;
+        }
       } else {
         slot.historySource = 'ndjson';
         const { events, prevCursor } = await this.persistence.loadSegment(
@@ -299,9 +377,11 @@ class ChatStore {
   ): Promise<{ events: MoxxyEvent[]; prevCursor: number | null } | null> {
     const loadHistory = this.persistence?.loadHistory?.bind(this.persistence);
     if (!loadHistory) return null;
-    const rendered: MoxxyEvent[] = [];
+    // Accumulate the RAW window (ascending seq) and project it as a whole, so
+    // an unsealed-turn reconstruction (projectRunnerWindow) sees a turn's chunks
+    // and its terminal row together rather than split per page.
+    const raw: MoxxyEvent[] = [];
     let cursor = before;
-    let renderedCount = 0;
     for (let page = 0; page < MAX_RUNNER_PAGES; page += 1) {
       const result = await loadHistory(workspaceId, cursor, RUNNER_RAW_PAGE);
       if (result === null) {
@@ -309,13 +389,12 @@ class ChatStore {
         break; // dropped mid-walk → return what we have
       }
       // Pages arrive newest-first; prepend each older page ahead of the ones we
-      // already have so `rendered` stays ascending (oldest-first) for prepend.
-      rendered.unshift(...result.events.filter(isRenderedEvent));
-      renderedCount = rendered.length;
+      // already have so `raw` stays ascending (oldest-first).
+      raw.unshift(...result.events);
       cursor = result.prevCursor;
-      if (cursor === null || renderedCount >= minRendered) break;
+      if (cursor === null || projectRunnerWindow(raw).length >= minRendered) break;
     }
-    return { events: rendered, prevCursor: cursor };
+    return { events: projectRunnerWindow(raw), prevCursor: cursor };
   }
 
   private prependFresh(slot: Slot, events: ReadonlyArray<MoxxyEvent>): void {

--- a/packages/client-core/src/chat-store/store.ts
+++ b/packages/client-core/src/chat-store/store.ts
@@ -16,8 +16,23 @@
  */
 
 import type { MoxxyEvent } from '@moxxy/sdk';
-import { applyAction, type ChatAction } from '../chatModel.js';
+import { applyAction, isRenderedEvent, type ChatAction } from '../chatModel.js';
 import { INITIAL_WINDOW, OLDER_PAGE, type ChatPersistence } from '../chatPersistence.js';
+
+/**
+ * Runner-history paging (the `session.loadHistory` path). The runner's pages are
+ * RAW events — they include non-rendered events (assistant_chunk deltas,
+ * provider bookends) that the renderer filters out — so one page yields fewer
+ * RENDERED rows than its size. {@link ChatStore.loadRunnerWindow} therefore
+ * walks several raw pages until it has enough rendered rows.
+ */
+// Raw events fetched per `session.loadHistory` round-trip (well under the
+// runner's MAX_HISTORY_PAGE_LIMIT of 2000).
+const RUNNER_RAW_PAGE = 200;
+// Safety bound on the raw-page walk for ONE window: a window dominated by a long
+// streamed reply (hundreds of assistant_chunks) can't spin forever — after this
+// many pages we return what we have and let the next scroll-up continue.
+const MAX_RUNNER_PAGES = 25;
 import {
   buildSnapshot,
   createSlot,
@@ -183,6 +198,13 @@ class ChatStore {
    * Load the most-recent window of a workspace's history on first open.
    * Idempotent — guarded by `loaded`. Loaded events are prepended (with
    * id-dedup) so any turn that raced ahead of the load stays newest.
+   *
+   * Prefers the RUNNER's authoritative log (`session.loadHistory`): the first
+   * load decides the slot's {@link Slot.historySource}. When the runner can't
+   * serve it (no connected runner for the workspace, a `<v10` runner, or a
+   * legacy-only chat with no runner session) it falls back to the NDJSON store —
+   * so no transcript goes blank. The two cursor spaces (runner `seq` vs NDJSON
+   * line-index) never mix within a slot.
    */
   async loadInitial(workspaceId: string): Promise<void> {
     const slot = this.ensure(workspaceId);
@@ -192,14 +214,23 @@ class ChatStore {
     slot.snap = null;
     this.emit();
     try {
-      const { events, prevCursor } = await this.persistence.loadSegment(
-        workspaceId,
-        null,
-        INITIAL_WINDOW,
-      );
-      this.prependFresh(slot, events);
-      slot.oldestCursor = prevCursor;
-      slot.hasOlder = prevCursor !== null;
+      const runner = await this.loadRunnerWindow(workspaceId, null, INITIAL_WINDOW);
+      if (runner) {
+        slot.historySource = 'runner';
+        this.prependFresh(slot, runner.events);
+        slot.oldestCursor = runner.prevCursor;
+        slot.hasOlder = runner.prevCursor !== null;
+      } else {
+        slot.historySource = 'ndjson';
+        const { events, prevCursor } = await this.persistence.loadSegment(
+          workspaceId,
+          null,
+          INITIAL_WINDOW,
+        );
+        this.prependFresh(slot, events);
+        slot.oldestCursor = prevCursor;
+        slot.hasOlder = prevCursor !== null;
+      }
     } catch {
       slot.loaded = false; // allow a retry on the next open
     } finally {
@@ -209,20 +240,33 @@ class ChatStore {
     }
   }
 
-  /** Fetch the page preceding the in-memory window (scroll-up). */
+  /** Fetch the page preceding the in-memory window (scroll-up), from whichever
+   *  source {@link loadInitial} settled on for this slot. */
   async loadOlder(workspaceId: string): Promise<void> {
     const slot = this.slots.get(workspaceId);
     if (!slot || !slot.hasOlder || slot.loadingOlder || !this.persistence) return;
     slot.loadingOlder = true;
     try {
-      const { events, prevCursor } = await this.persistence.loadSegment(
-        workspaceId,
-        slot.oldestCursor,
-        OLDER_PAGE,
-      );
-      this.prependFresh(slot, events);
-      slot.oldestCursor = prevCursor;
-      slot.hasOlder = prevCursor !== null;
+      if (slot.historySource === 'runner') {
+        const runner = await this.loadRunnerWindow(workspaceId, slot.oldestCursor, OLDER_PAGE);
+        if (runner) {
+          this.prependFresh(slot, runner.events);
+          slot.oldestCursor = runner.prevCursor;
+          slot.hasOlder = runner.prevCursor !== null;
+        }
+        // runner === null here means the runner dropped mid-scroll; leave the
+        // cursor/hasOlder untouched so a later scroll retries — we never switch
+        // cursor spaces to NDJSON mid-slot (its line-index cursor is unrelated).
+      } else {
+        const { events, prevCursor } = await this.persistence.loadSegment(
+          workspaceId,
+          slot.oldestCursor,
+          OLDER_PAGE,
+        );
+        this.prependFresh(slot, events);
+        slot.oldestCursor = prevCursor;
+        slot.hasOlder = prevCursor !== null;
+      }
     } catch {
       /* leave hasOlder set so the user can retry by scrolling */
     } finally {
@@ -233,6 +277,45 @@ class ChatStore {
       slot.snap = null;
       this.emit();
     }
+  }
+
+  /**
+   * Page the RUNNER's authoritative log into a window of at least `minRendered`
+   * RENDERED events (newest-first), filtering each raw page with
+   * {@link isRenderedEvent}. Walks `session.loadHistory`'s `seq` cursor until it
+   * has enough rendered rows, reaches the start of history, or the runner stops
+   * serving.
+   *
+   * Returns `null` (→ caller falls back to NDJSON) when the runner can't serve
+   * the FIRST page — no `loadHistory` backend, no connected runner, or a `<v10`
+   * runner. A `null` on a LATER page (the runner dropped mid-walk) just ends the
+   * window early with whatever rendered rows were gathered, keeping the `seq`
+   * cursor so the next scroll-up can resume.
+   */
+  private async loadRunnerWindow(
+    workspaceId: string,
+    before: number | null,
+    minRendered: number,
+  ): Promise<{ events: MoxxyEvent[]; prevCursor: number | null } | null> {
+    const loadHistory = this.persistence?.loadHistory?.bind(this.persistence);
+    if (!loadHistory) return null;
+    const rendered: MoxxyEvent[] = [];
+    let cursor = before;
+    let renderedCount = 0;
+    for (let page = 0; page < MAX_RUNNER_PAGES; page += 1) {
+      const result = await loadHistory(workspaceId, cursor, RUNNER_RAW_PAGE);
+      if (result === null) {
+        if (page === 0) return null; // runner can't serve → NDJSON fallback
+        break; // dropped mid-walk → return what we have
+      }
+      // Pages arrive newest-first; prepend each older page ahead of the ones we
+      // already have so `rendered` stays ascending (oldest-first) for prepend.
+      rendered.unshift(...result.events.filter(isRenderedEvent));
+      renderedCount = rendered.length;
+      cursor = result.prevCursor;
+      if (cursor === null || renderedCount >= minRendered) break;
+    }
+    return { events: rendered, prevCursor: cursor };
   }
 
   private prependFresh(slot: Slot, events: ReadonlyArray<MoxxyEvent>): void {

--- a/packages/client-core/src/chat-store/store.ts
+++ b/packages/client-core/src/chat-store/store.ts
@@ -281,23 +281,17 @@ class ChatStore {
     slot.snap = null;
     this.emit();
     try {
-      const runner = await this.loadRunnerWindow(workspaceId, null, INITIAL_WINDOW);
-      if (runner) {
+      // Prefer the runner, but only adopt it as the source if it actually
+      // yields RENDERED rows. An empty result — no runner backend, a `<v10`
+      // runner, or a legacy-only chat whose runner session resumed EMPTY — falls
+      // through to the NDJSON mirror so its history is never hidden behind an
+      // empty runner session.
+      const runner = await this.collectRunnerInitial(workspaceId);
+      if (runner && runner.events.length > 0) {
         slot.historySource = 'runner';
         this.prependFresh(slot, runner.events);
         slot.oldestCursor = runner.prevCursor;
         slot.hasOlder = runner.prevCursor !== null;
-        // Defend the extreme case where the newest window was ALL non-rendered
-        // raw events (e.g. the tail of one very long streamed reply): never leave
-        // the transcript blank-but-has-more — pull older windows (bounded) until
-        // something renders or we reach the start of history.
-        for (let pump = 0; pump < 10 && slot.rt.log.length === 0 && slot.hasOlder; pump += 1) {
-          const more = await this.loadRunnerWindow(workspaceId, slot.oldestCursor, INITIAL_WINDOW);
-          if (!more) break;
-          this.prependFresh(slot, more.events);
-          slot.oldestCursor = more.prevCursor;
-          slot.hasOlder = more.prevCursor !== null;
-        }
       } else {
         slot.historySource = 'ndjson';
         const { events, prevCursor } = await this.persistence.loadSegment(
@@ -316,6 +310,30 @@ class ChatStore {
       slot.snap = null;
       this.emit();
     }
+  }
+
+  /**
+   * Pull the newest runner window for {@link loadInitial}, walking past
+   * all-non-rendered windows (bounded) so a window that holds no rendered rows
+   * YET doesn't read as "no history". Returns `null` when there is no runner
+   * backend / the runner can't serve the first page; otherwise the accumulated
+   * rendered events (possibly EMPTY — an empty runner log, e.g. a legacy-only
+   * chat) and the cursor for the next older page.
+   */
+  private async collectRunnerInitial(
+    workspaceId: string,
+  ): Promise<{ events: MoxxyEvent[]; prevCursor: number | null } | null> {
+    const first = await this.loadRunnerWindow(workspaceId, null, INITIAL_WINDOW);
+    if (!first) return null;
+    const events = [...first.events];
+    let cursor = first.prevCursor;
+    for (let pump = 0; pump < 10 && events.length === 0 && cursor !== null; pump += 1) {
+      const more = await this.loadRunnerWindow(workspaceId, cursor, INITIAL_WINDOW);
+      if (!more) break;
+      events.unshift(...more.events);
+      cursor = more.prevCursor;
+    }
+    return { events, prevCursor: cursor };
   }
 
   /** Fetch the page preceding the in-memory window (scroll-up), from whichever

--- a/packages/client-core/src/chatPersistence.ts
+++ b/packages/client-core/src/chatPersistence.ts
@@ -24,6 +24,19 @@ export interface ChatPersistence {
     before: number | null,
     limit: number,
   ): Promise<{ events: ReadonlyArray<MoxxyEvent>; prevCursor: number | null }>;
+  /**
+   * Page history from the RUNNER's authoritative log (protocol v10) instead of
+   * the NDJSON mirror. `before` is a `seq` cursor and the page is RAW events
+   * (the caller filters to rendered rows). Resolves `null` when the runner can't
+   * serve it (no connected runner / a `<v10` runner) — the store then falls back
+   * to {@link loadSegment}. Optional so a backend without a runner path (or a
+   * test fake) simply degrades to NDJSON.
+   */
+  loadHistory?(
+    workspaceId: string,
+    before: number | null,
+    limit: number,
+  ): Promise<{ events: ReadonlyArray<MoxxyEvent>; prevCursor: number | null } | null>;
   append(workspaceId: string, events: ReadonlyArray<MoxxyEvent>): Promise<void>;
   clear(workspaceId: string): Promise<void>;
 }
@@ -39,6 +52,16 @@ export function createIpcPersistence(): ChatPersistence {
         return await api().invoke('chat.loadSegment', { workspaceId, before, limit });
       } catch {
         return { events: [], prevCursor: null };
+      }
+    },
+    async loadHistory(workspaceId, before, limit) {
+      try {
+        // null result = the runner can't serve it (no connected runner / <v10);
+        // a thrown transport error is treated the same. Either way the store
+        // falls back to loadSegment (NDJSON), so no transcript goes blank.
+        return await api().invoke('chat.loadHistory', { workspaceId, before, limit });
+      } catch {
+        return null;
       }
     },
     async append(workspaceId, events) {

--- a/packages/desktop-host/src/ipc.ts
+++ b/packages/desktop-host/src/ipc.ts
@@ -92,7 +92,7 @@ export function registerIpcHandlers(
     registerPrefsHandlers();
     registerSettingsHandlers(pool);
     registerVaultHandlers();
-    registerChatHandlers();
+    registerChatHandlers(pool);
     registerMobileGatewayHandlers(opts.mobileGateway ?? null);
   }
 }

--- a/packages/desktop-host/src/ipc/chat.ts
+++ b/packages/desktop-host/src/ipc/chat.ts
@@ -1,15 +1,21 @@
 /**
- * Chat transcript log (append-only NDJSON).
+ * Chat transcript log.
  *
- * Thin pass-throughs to the `chat-log` store, lazily imported. Append
- * is strictly additive (never re-serialises old events); loadSegment
- * pages backwards from a cursor; clearLog truncates; migrate seeds the
- * NDJSON logs from the renderer's legacy localStorage blobs.
+ * `chat.append` / `chat.loadSegment` / `chat.clearLog` / `chat.migrate` are
+ * thin pass-throughs to the append-only NDJSON `chat-log` store, lazily
+ * imported and keyed by `workspaceId`.
+ *
+ * `chat.loadHistory` is the runner-authoritative read path (protocol v10): it
+ * pages history straight from the workspace's connected `RemoteSession`'s log
+ * instead of the NDJSON mirror, and returns `null` when the runner can't serve
+ * it (no connected runner for the workspace, or a `<v10` runner) so the renderer
+ * falls back to `chat.loadSegment` — no transcript ever goes blank.
  */
 
-import { handle } from './shared';
+import type { RunnerPool } from '../runner-pool';
+import { handle, resolveSupervisor } from './shared';
 
-export function registerChatHandlers(): void {
+export function registerChatHandlers(pool: RunnerPool): void {
   // ---- Chat transcript log (append-only NDJSON) ---------------------------
 
   handle('chat.append', async ({ workspaceId, events }) => {
@@ -19,6 +25,19 @@ export function registerChatHandlers(): void {
   handle('chat.loadSegment', async ({ workspaceId, before, limit }) => {
     const { loadSegment } = await import('../chat-log');
     return loadSegment(workspaceId, before, limit);
+  });
+  // Runner-authoritative paged read (v10). Resolve the workspace's connected
+  // RemoteSession and page its log; any miss (no supervisor / not connected /
+  // older runner whose gate throws / transport error) returns null so the
+  // renderer transparently falls back to the NDJSON store.
+  handle('chat.loadHistory', async ({ workspaceId, before, limit }) => {
+    const session = resolveSupervisor(pool, workspaceId)?.remote();
+    if (!session) return null;
+    try {
+      return await session.loadHistory(before, limit);
+    } catch {
+      return null;
+    }
   });
   handle('chat.clearLog', async ({ workspaceId }) => {
     const { clearLog } = await import('../chat-log');

--- a/packages/desktop-ipc-contract/src/commands.ts
+++ b/packages/desktop-ipc-contract/src/commands.ts
@@ -373,6 +373,19 @@ export interface IpcCommands {
     before: number | null;
     limit: number;
   }) => Promise<{ events: ReadonlyArray<MoxxyEvent>; prevCursor: number | null }>;
+  /** Page the workspace's history from the RUNNER's authoritative log
+   *  (`session.loadHistory`, protocol v10) instead of the NDJSON mirror.
+   *  `before` is a `seq` cursor (NOT the line-index cursor `chat.loadSegment`
+   *  uses); the page is RAW events (includes non-rendered events like
+   *  `assistant_chunk`), so the renderer filters with `isRenderedEvent` and
+   *  pages until it has enough rendered rows. Returns `null` when the runner
+   *  can't serve it — no connected runner for the workspace, or a `<v10`
+   *  runner — so the caller falls back to `chat.loadSegment` (NDJSON). */
+  'chat.loadHistory': (args: {
+    workspaceId: string;
+    before: number | null;
+    limit: number;
+  }) => Promise<{ events: ReadonlyArray<MoxxyEvent>; prevCursor: number | null } | null>;
   /** Truncate a workspace's log (Clear conversation). */
   'chat.clearLog': (args: { workspaceId: string }) => Promise<void>;
   /** One-time migration: the renderer hands up the events it parsed from

--- a/packages/desktop-ipc-contract/src/remote.test.ts
+++ b/packages/desktop-ipc-contract/src/remote.test.ts
@@ -30,6 +30,7 @@ describe('REMOTE_ALLOWED_COMMANDS', () => {
       'session.transcribe',
       'chat.append',
       'chat.loadSegment',
+      'chat.loadHistory',
       'chat.clearLog',
       'chat.migrate',
       'workflows.list',

--- a/packages/desktop-ipc-contract/src/remote.ts
+++ b/packages/desktop-ipc-contract/src/remote.ts
@@ -65,6 +65,7 @@ export const REMOTE_ALLOWED_COMMANDS: ReadonlySet<IpcCommandName> = new Set<IpcC
   // these; they're scoped to a workspace's NDJSON log, not host config).
   'chat.append',
   'chat.loadSegment',
+  'chat.loadHistory',
   'chat.clearLog',
   'chat.migrate',
   // Workflows: READ + run an existing one only. Authoring (`workflows.save`,

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -276,6 +276,15 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
     before: z.number().int().nonnegative().nullable(),
     limit: z.number().int().positive().max(1000),
   }),
+  // Same shape as chat.loadSegment, but `before` is a runner `seq` cursor and
+  // the page is RAW events; the runner itself re-validates and caps at its own
+  // MAX_HISTORY_PAGE_LIMIT (2000), so bound the renderer's raw-window request to
+  // that ceiling.
+  'chat.loadHistory': z.object({
+    workspaceId: z.string().min(1).max(256),
+    before: z.number().int().nonnegative().nullable(),
+    limit: z.number().int().positive().max(2000),
+  }),
   'chat.clearLog': z.object({ workspaceId: z.string().min(1).max(256) }),
   // chat.migrate writes the supplied events straight into per-workspace NDJSON
   // logs on disk, so it's a filesystem-touching command: bound both the number


### PR DESCRIPTION
## ⚠️ DRAFT — do not merge until live-verified on a packaged desktop

Completes the **renderer half** of the dual-history consolidation (the runner-side v10 `session.loadHistory` foundation landed in #251). The desktop now **READS** transcript history from the runner instead of its own NDJSON store, with NDJSON retained as a read fallback. Fully green in-gate; the final transcript correctness needs a real packaged-desktop run before merge.

### What it does
- **IPC `chat.loadHistory`** proxies to the workspace's connected `RemoteSession` (`resolveSupervisor(pool, workspaceId)?.remote()` → `session.loadHistory`). Returns `null` — so the renderer falls back to the existing `chat.loadSegment` NDJSON path — whenever the runner can't serve it: no connected runner for the workspace, a `<v10` runner (the version gate throws), or a legacy-only chat in `~/.moxxy/chats`. Added to `REMOTE_ALLOWED_COMMANDS` (mobile parity; same read surface as `chat.loadSegment`).
- **`ChatPersistence.loadHistory` (optional) + chat-store "page-until-K-rendered"**: the runner returns RAW events (incl. `assistant_chunk`/provider bookends), so the store walks several raw pages and projects each window until it has a full window of rendered rows. The history source (runner `seq` cursor vs NDJSON line-index cursor) is **pinned per slot and never mixed**; a runner drop mid-scroll keeps the slot resumable rather than switching cursor spaces.
- **Legacy completeness:** a runner log written *before* the seal feature can hold a turn that streamed text then errored/aborted with no `assistant_message`. `projectRunnerWindow` reconstructs that reply (mirroring the runner's own `sealUnsealedStreamedText`) so it isn't silently dropped — two-pass, so a *post-seal* errored turn (chunks + error + the real seal) is **not doubled**.

### Safety properties
- **No data deleted/overwritten** — the renderer still WRITES NDJSON, so it stays a working read fallback and the home of legacy-only chats.
- **No FLOOR raise** — an older runner still attaches and the renderer falls back.
- Source decided once per slot; the two cursor spaces never mix.

### Review (adversarial, 8 agents) — fixed before this PR
- **HIGH (fixed):** pre-seal legacy unsealed replies vanishing on runner-read → reconstruction in `projectRunnerWindow` + GOLDEN fixture.
- **LOW (fixed):** an all-non-rendered window leaving a blank-but-has-more transcript → bounded pump in `loadInitial`.
- **LOW (fixed):** GOLDEN test was sealed-only / partly tautological → ground truth now from an independent live-reducer pass; fixtures for unsealed/errored-then-sealed/plugin_event.

### Please verify on a packaged desktop before merge
1. **v10-runner path:** open an existing chat, scroll up through several pages — transcript matches today (no missing/extra rows; replies present after a stream-without-seal turn; compaction turns render right).
2. **Fallback path:** same desktop against a shipped `<v10` CLI — history still loads via NDJSON (no blank transcript).
3. **Legacy-only chat:** a chat that exists only in `~/.moxxy/chats` (no runner session) still loads.
4. **Legacy errored reply:** an old chat whose runner log has a streamed-then-errored turn from before the seal feature — the reply text still appears (reconstructed), exactly once.

### Known residual (documented, not blocking)
- A turn whose chunks straddle a scroll-up window boundary *and* ended unsealed can show its reconstructed reply only partially — vanishingly rare (legacy + errored-mid-stream + exact-boundary). No total blank; NDJSON remains the safety net.

### Follow-ups (separate PRs, gated on a v10 floor + live-verify)
Stop the NDJSON double-**write**, then physically retire the NDJSON store. Tracked in TECH_DEBT item 3.

**In-gate verification:** build 70/70 · typecheck 137/137 · test all pass (incl. GOLDEN equivalence) · lint 0 errors · check:deps clean.