### PR TITLE
fix(desktop): universal macOS build (x86_64 + arm64) so Intel Macs can launch

### DIFF
--- a/.changeset/desktop-mac-universal-build.md
+++ b/.changeset/desktop-mac-universal-build.md
@@ -1,0 +1,28 @@
+---
+"@moxxy/desktop": patch
+---
+
+fix(desktop): build the macOS app as a universal binary (x86_64 + arm64)
+
+The macOS installers were arm64-only, so Intel Macs — including many still on
+Sonoma/Ventura/Monterey — could not launch the app at all (an arm64-only binary
+cannot run on Intel; Rosetta only translates x86→arm). The mac `build.target`
+now requests `arch: ["universal"]` for both the dmg and zip, producing a single
+`moxxy-desktop-<v>-universal.{dmg,zip}` that runs on both architectures.
+
+Supporting changes that were required for the universal merge to succeed and for
+all native features to work on Intel:
+- `build/after-pack.cjs` no longer ad-hoc signs the per-arch staging dirs
+  (`mac-universal-*-temp`); signing them before the merge makes their
+  `_CodeSignature` diverge and `@electron/universal` aborts. It now signs the
+  merged universal app instead.
+- `mac.x64ArchFiles` whitelists the single-arch native binaries the app bundles
+  (sharp, @napi-rs/canvas, onnxruntime-node, node-pty, keyring) so the merge
+  keeps them as-is while still lipo-merging the compiled `node-pty` addon.
+- Root `pnpm.supportedArchitectures` installs both x64 and arm64 builds of the
+  platform-split native deps (sharp / canvas / keyring), so each architecture
+  loads its matching binary at runtime instead of degrading on Intel.
+
+Also declares `minimumSystemVersion: 11.0.0` so Catalina (10.15) and older show
+a clean "requires macOS 11" message (Electron 33's floor) instead of a confusing
+launch failure.

--- a/apps/desktop/build/after-pack.cjs
+++ b/apps/desktop/build/after-pack.cjs
@@ -21,6 +21,20 @@ const path = require('node:path');
 exports.default = async function afterPack(context) {
   if (context.electronPlatformName !== 'darwin') return;
 
+  // Universal builds: electron-builder packs each arch into a
+  // `mac-universal-<arch>-temp` dir, then @electron/universal lipo-merges the
+  // two apps and REQUIRES every non-binary file — including
+  // `_CodeSignature/CodeResources` — to be byte-identical across both arch
+  // apps. Ad-hoc signing the per-arch temps here makes those signatures diverge
+  // and the merge aborts ("Expected all non-binary files to have identical
+  // SHAs ... Electron Framework.framework/.../CodeResources did not"). So skip
+  // the staging temps; electron-builder runs afterPack again on the MERGED
+  // universal app (a non-temp dir), which is where we ad-hoc sign instead.
+  if (context.appOutDir.endsWith('-temp')) {
+    console.log(`afterPack: skipping universal staging dir ${context.appOutDir}`);
+    return;
+  }
+
   // When a real Developer ID cert is present (CSC_LINK set), electron-builder
   // does the proper hardened-runtime signing + notarization — ad-hoc signing
   // here would clobber it. Only ad-hoc sign the unsigned fallback build.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -110,10 +110,18 @@
     "mac": {
       "category": "public.app-category.productivity",
       "artifactName": "moxxy-desktop-${version}-${arch}.${ext}",
+      "minimumSystemVersion": "11.0.0",
       "target": [
-        "dmg",
-        "zip"
+        {
+          "target": "dmg",
+          "arch": ["universal"]
+        },
+        {
+          "target": "zip",
+          "arch": ["universal"]
+        }
       ],
+      "x64ArchFiles": "{*.node,*.dylib,spawn-helper,python3}",
       "icon": "public/logo.png",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,11 @@
       "electron",
       "electron-winstaller",
       "node-pty"
-    ]
+    ],
+    "supportedArchitectures": {
+      "os": ["current"],
+      "cpu": ["x64", "arm64"]
+    }
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Problem

The macOS desktop installers ship **arm64-only** — across `desktop-v0.12.5/0.12.4/0.12.2` the only Mac assets are `-arm64.dmg`/`-arm64.zip` (no x64/universal), while Linux ships `x86_64`. Cause: `apps/desktop/package.json` `build.mac.target` had **no `arch`**, and `macos-latest` is now an Apple-Silicon runner, so electron-builder built only the host arch.

An arm64-only app **cannot launch on an Intel Mac** (Rosetta only translates x86→arm, not the reverse). "Older Macs," including many still on **Sonoma/Ventura/Monterey**, are Intel — so the app errored / wouldn't run for them. (This is *not* a min-version gate — the floor is Big Sur 11 — and *not* signing — 0.12.5 is Developer-ID signed + notarized.)

## Fix — universal (x86_64 + arm64) build

- `build.mac.target` → `arch: ["universal"]` for dmg + zip → a single `moxxy-desktop-<v>-universal.{dmg,zip}` that runs on both architectures.
- `build/after-pack.cjs` skips the per-arch staging dirs (`mac-universal-*-temp`): ad-hoc signing them before the merge makes their `_CodeSignature` diverge and `@electron/universal` aborts (`Expected all non-binary files to have identical SHAs …`). It now signs the **merged** universal app instead.
- `mac.x64ArchFiles` whitelists the single-arch native binaries the app bundles (sharp, `@napi-rs/canvas`, onnxruntime-node, node-pty, keyring) so the merge keeps them as-is while still lipo-merging the compiled `node-pty` addon.
- Root `pnpm.supportedArchitectures` installs **both** x64 and arm64 builds of the platform-split native deps (sharp / canvas / keyring) so each architecture loads its matching binary at runtime — full feature parity on Intel.
- Declares `minimumSystemVersion: 11.0.0` (Electron 33 floor) so Catalina (10.15) and older get a clean "requires macOS 11" message instead of a confusing failure.

## Verification

Packaged the universal app locally (`electron-builder --mac --universal --dir`) and inspected the Mach-O slices:

- Main executable, Electron Framework, and compiled `node-pty` (`build/Release/pty.node` + `spawn-helper`) are all true fat `x86_64 arm64`.
- Both x64 **and** arm64 variants of sharp / canvas / keyring are bundled (x64 files `x86_64`, arm64 files `arm64`).
- Deployment target `minos 11.0`; `Info.plist` `LSMinimumSystemVersion 11.0.0`.
- `codesign --verify --deep --strict` → OK.
- Full gate green: build 70/70, typecheck 137/137, lint 0 errors, deps 0 errors, tests pass.

**Not verifiable on the build machine (Apple Silicon):** an actual Intel *boot*. The x86_64 slices are present and valid, but an end-to-end Intel launch + feature smoke should be done on Intel hardware or a CI runner before/after release.

> Note: CI's macOS leg already pins Python 3.11 for node-gyp; the universal build additionally downloads the x64 Electron dist and cross-rebuilds `node-pty` for x64 (≈2× Mac build time + larger artifacts).