### PR TITLE
[DRAFT — live-verify before merge] Migrate legacy NDJSON-only chats into the runner's authoritative log

### DIFF
--- a/.changeset/migrate-legacy-chats-to-runner.md
+++ b/.changeset/migrate-legacy-chats-to-runner.md
@@ -1,0 +1,26 @@
+---
+"@moxxy/core": minor
+"@moxxy/desktop": minor
+---
+
+feat(desktop): migrate legacy NDJSON-only chats into the runner's authoritative log
+
+The keystone of the dual-history consolidation: make the runner's session log the
+home of EVERY chat, including ones whose history previously lived only in the
+desktop's NDJSON mirror (localStorage-migrated / pre-runner-session chats). Without
+this, continuing such a chat would strand its old history in NDJSON while new turns
+go to the runner log — a split the per-slot single-source renderer can't show.
+
+- `@moxxy/core` gains `seedSessionLog(sessionId, events, dir?)` — writes a fresh
+  session JSONL from an event list IFF the session has none yet (idempotent;
+  never overwrites a session the runner already owns), re-sequenced to contiguous
+  `seq` 0..n-1 with ids/content preserved and written temp+rename.
+- The desktop runner pool seeds a workspace's session from its NDJSON mirror
+  (`seedChatIntoSession`) BEFORE that workspace's runner resumes its session id,
+  so the seed is in place when the runner reads it (race-free) and only for chats
+  actually opened. Best-effort and non-destructive — the NDJSON store is left
+  intact and remains the read fallback.
+
+This unblocks (and is a prerequisite for) the deferred follow-ups — stopping the
+NDJSON double-write, raising the desktop FLOOR to v10, and retiring the NDJSON
+store — each of which is a separate PR gated on packaged-desktop live-verify.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -116,10 +116,16 @@ that must not be rushed, because rushing it would *lower* quality, not raise it:
    with the source pinned per slot so the runner `seq` and NDJSON line cursors
    never mix. A GOLDEN render-equivalence test pins runner-stream+filter ==
    NDJSON across stream-without-seal / reasoning / tool / compaction / multi-page
-   fixtures. **Remaining (separate PRs, gated on packaged-desktop live-verify):**
-   (a) stop the NDJSON double-WRITE once v10 is the floor, then (b) physically
-   retire the NDJSON store. The renderer still WRITES NDJSON today so it stays a
-   working read fallback + the home of legacy-only chats.
+   fixtures. **Legacy migration landed (2026-06-18, the keystone):** core
+   `seedSessionLog` + the runner pool's `seedChatIntoSession` migrate a chat whose
+   history lived ONLY in the NDJSON mirror into the runner's authoritative log,
+   BEFORE that workspace's runner resumes its session id — so the runner owns
+   every chat (a legacy chat is no longer stranded when continued). Idempotent +
+   non-destructive (skips a session the runner already owns; NDJSON left intact).
+   **Remaining (separate PRs, each gated on packaged-desktop live-verify, IN
+   ORDER):** (a) stop the NDJSON double-WRITE; (b) raise desktop FLOOR to 10; (c)
+   physically retire the NDJSON store. The renderer still WRITES NDJSON today so
+   it stays the read fallback until (a)–(c) ship and verify.
 4. **One-shot CLI exit hygiene** (`moxxy -p` / `schedule run` / `doctor` / `login` /
    `init` boot a full session and never `close()`) — minor; a correct fix must drain
    persistence before exit (premature exit would drop the last event).

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,7 @@ export {
   restoreEvents as restoreSessionEvents,
   readEventPage as readSessionEventPage,
   pageEvents,
+  seedSessionLog,
   deleteSession,
   type SessionMeta,
   type SessionPersistenceOpts,

--- a/packages/core/src/sessions/page.test.ts
+++ b/packages/core/src/sessions/page.test.ts
@@ -3,7 +3,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { MoxxyEvent } from '@moxxy/sdk';
-import { pageEvents, readEventPage } from './persistence.js';
+import { pageEvents, readEventPage, restoreEvents, seedSessionLog } from './persistence.js';
 
 const tempDirs: string[] = [];
 
@@ -175,5 +175,36 @@ describe('readEventPage (paged JSONL reader)', () => {
     await readEventPage(id, { before: null, limit: 10 }, dir);
     const after = await fs.readFile(path.join(dir, `${id}.jsonl`), 'utf8');
     expect(after).toBe(before);
+  });
+});
+
+describe('seedSessionLog (NDJSON → runner-log migration)', () => {
+  it('writes a fresh session log, re-sequenced to 0..n-1, ids + content preserved', async () => {
+    const dir = await makeTempDir();
+    // Gapped original seqs — as rendered events pulled from the desktop mirror
+    // (which dropped the interleaved chunk/bookend events) would have.
+    const events = [
+      { id: 'a', seq: 3, ts: 0, sessionId: 'sess', turnId: 't0', source: 'user', type: 'user_prompt', text: 'q' },
+      { id: 'b', seq: 7, ts: 1, sessionId: 'sess', turnId: 't0', source: 'model', type: 'assistant_message', content: 'reply' },
+    ] as unknown as MoxxyEvent[];
+    expect(await seedSessionLog('sess', events, dir)).toBe(true);
+    // The runner restores it like any native log: contiguous seqs, ids preserved.
+    const restored = await restoreEvents('sess', dir);
+    expect(restored.map((e) => e.id)).toEqual(['a', 'b']);
+    expect(restored.map((e) => e.seq)).toEqual([0, 1]);
+    expect((restored[1] as { content?: string }).content).toBe('reply');
+  });
+
+  it('never overwrites a session the runner already owns', async () => {
+    const dir = await makeTempDir();
+    await writeLog(dir, 'sess', makeLog(2, 'sess')); // the runner already owns it
+    expect(await seedSessionLog('sess', makeLog(5, 'sess'), dir)).toBe(false);
+    const restored = await restoreEvents('sess', dir);
+    expect(restored).toHaveLength(2); // untouched
+  });
+
+  it('is a no-op for an empty event list', async () => {
+    const dir = await makeTempDir();
+    expect(await seedSessionLog('sess', [], dir)).toBe(false);
   });
 });

--- a/packages/core/src/sessions/page.test.ts
+++ b/packages/core/src/sessions/page.test.ts
@@ -195,12 +195,19 @@ describe('seedSessionLog (NDJSON → runner-log migration)', () => {
     expect((restored[1] as { content?: string }).content).toBe('reply');
   });
 
-  it('never overwrites a session the runner already owns', async () => {
+  it('never overwrites a NON-EMPTY session the runner already owns', async () => {
     const dir = await makeTempDir();
     await writeLog(dir, 'sess', makeLog(2, 'sess')); // the runner already owns it
     expect(await seedSessionLog('sess', makeLog(5, 'sess'), dir)).toBe(false);
     const restored = await restoreEvents('sess', dir);
     expect(restored).toHaveLength(2); // untouched
+  });
+
+  it('seeds OVER a 0-byte session log (the empty file attach leaves on every spawn)', async () => {
+    const dir = await makeTempDir();
+    await writeLog(dir, 'sess', []); // 0-byte file, holds no history
+    expect(await seedSessionLog('sess', makeLog(3, 'sess'), dir)).toBe(true);
+    expect(await restoreEvents('sess', dir)).toHaveLength(3);
   });
 
   it('is a no-op for an empty event list', async () => {

--- a/packages/core/src/sessions/persistence.ts
+++ b/packages/core/src/sessions/persistence.ts
@@ -579,13 +579,16 @@ export function pageEvents(
  * own mirror (the desktop's NDJSON chat store) — after it runs, `loadHistory`
  * serves that chat from the runner like any other.
  *
- * Idempotent and NON-destructive: if `<sessionId>.jsonl` already exists — even
- * empty — this is a no-op returning `false`, so a session the runner already
- * owns is NEVER overwritten. Events are re-sequenced to contiguous `seq` 0..n-1
- * (order + ids preserved) so the seeded log satisfies {@link EventLog}'s seq
- * invariants when it is later restored. Written temp+rename so a crash mid-seed
- * can't leave a half-written log the existence check would treat as "owned".
- * Returns `true` iff it wrote a new log.
+ * Idempotent and NON-destructive: if `<sessionId>.jsonl` already exists AND is
+ * NON-EMPTY this is a no-op returning `false`, so a session the runner already
+ * owns is NEVER overwritten. A 0-byte log IS seeded: `persistence.attach`
+ * creates an empty `<id>.jsonl` on every spawn (even a session with zero
+ * events), so an existence-only guard would skip exactly the legacy chats this
+ * migration targets — and an empty file holds no history, so seeding over it
+ * loses nothing. Events are re-sequenced to contiguous `seq` 0..n-1 (order + ids
+ * preserved) so the seeded log satisfies {@link EventLog}'s seq invariants when
+ * it is later restored. Written temp+rename so a crash mid-seed can't leave a
+ * half-written log. Returns `true` iff it wrote the log.
  */
 export async function seedSessionLog(
   sessionId: string,
@@ -595,8 +598,9 @@ export async function seedSessionLog(
   if (events.length === 0) return false;
   const logPath = path.join(dir, `${sessionId}.jsonl`);
   try {
-    await fs.access(logPath);
-    return false; // already owned by the runner → never overwrite
+    // A non-empty log is a session the runner already owns → never overwrite.
+    // A 0-byte log is the empty file attach() left behind → seed over it.
+    if ((await fs.stat(logPath)).size > 0) return false;
   } catch {
     /* no log yet → seed below */
   }

--- a/packages/core/src/sessions/persistence.ts
+++ b/packages/core/src/sessions/persistence.ts
@@ -573,6 +573,40 @@ export function pageEvents(
 }
 
 /**
+ * Seed a session's event log from an external event list IFF the session has no
+ * log on disk yet. This is the migration that makes the runner's authoritative
+ * log the home of a chat whose history previously lived ONLY in a thin client's
+ * own mirror (the desktop's NDJSON chat store) — after it runs, `loadHistory`
+ * serves that chat from the runner like any other.
+ *
+ * Idempotent and NON-destructive: if `<sessionId>.jsonl` already exists — even
+ * empty — this is a no-op returning `false`, so a session the runner already
+ * owns is NEVER overwritten. Events are re-sequenced to contiguous `seq` 0..n-1
+ * (order + ids preserved) so the seeded log satisfies {@link EventLog}'s seq
+ * invariants when it is later restored. Written temp+rename so a crash mid-seed
+ * can't leave a half-written log the existence check would treat as "owned".
+ * Returns `true` iff it wrote a new log.
+ */
+export async function seedSessionLog(
+  sessionId: string,
+  events: ReadonlyArray<MoxxyEvent>,
+  dir = defaultSessionsDir(),
+): Promise<boolean> {
+  if (events.length === 0) return false;
+  const logPath = path.join(dir, `${sessionId}.jsonl`);
+  try {
+    await fs.access(logPath);
+    return false; // already owned by the runner → never overwrite
+  } catch {
+    /* no log yet → seed below */
+  }
+  await fs.mkdir(dir, { recursive: true });
+  const reseq = events.map((e, i) => (e.seq === i ? e : ({ ...e, seq: i } as MoxxyEvent)));
+  await writeFileAtomic(logPath, reseq.map((e) => JSON.stringify(e) + '\n').join(''));
+  return true;
+}
+
+/**
  * Remove a session's log file and its sidecar. A leftover legacy `index.json`
  * row, if any, is harmless — `readIndex` filters out sessions whose `.jsonl` is
  * gone, so the deleted session won't reappear.

--- a/packages/desktop-host/src/chat-log.test.ts
+++ b/packages/desktop-host/src/chat-log.test.ts
@@ -299,7 +299,7 @@ describe('seedChatIntoSession (NDJSON → runner session migration)', () => {
     expect(lines.map((e) => e.seq)).toEqual([0, 1, 2]);
   });
 
-  it('never overwrites a session the runner already owns; leaves the NDJSON intact', async () => {
+  it('never overwrites a NON-EMPTY session the runner already owns; leaves the NDJSON intact', async () => {
     await appendEvents('w1', [ev(0)]);
     await mkdir(sessionsDir, { recursive: true });
     await writeFile(path.join(sessionsDir, 'w1.jsonl'), '{"existing":true}\n', 'utf8');
@@ -307,6 +307,20 @@ describe('seedChatIntoSession (NDJSON → runner session migration)', () => {
     expect(await readFile(path.join(sessionsDir, 'w1.jsonl'), 'utf8')).toBe('{"existing":true}\n');
     // NDJSON untouched — still the read fallback.
     expect((await loadSegment('w1', null, 10)).events).toHaveLength(1);
+  });
+
+  it('seeds over a 0-byte session log left by a prior spawn (the key migration case)', async () => {
+    await appendEvents('w1', [ev(0), ev(1)]);
+    await mkdir(sessionsDir, { recursive: true });
+    // persistence.attach creates this empty file on every spawn — existence
+    // alone must NOT block the seed.
+    await writeFile(path.join(sessionsDir, 'w1.jsonl'), '', 'utf8');
+    expect(await seedChatIntoSession('w1', sessionsDir)).toBe(true);
+    const lines = (await readFile(path.join(sessionsDir, 'w1.jsonl'), 'utf8'))
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    expect(lines).toHaveLength(2);
   });
 
   it('is a no-op when the workspace has no NDJSON history', async () => {

--- a/packages/desktop-host/src/chat-log.test.ts
+++ b/packages/desktop-host/src/chat-log.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { MoxxyEvent } from '@moxxy/sdk';
-import { appendEvents, loadSegment, clearLog, migrate } from './chat-log';
+import { appendEvents, loadSegment, clearLog, migrate, seedChatIntoSession } from './chat-log';
 
 let dir: string;
 
@@ -275,5 +275,41 @@ describe('chat-log concurrency (per-file write mutex)', () => {
     const ids = seg.events.map((e) => (e as { id: string }).id);
     expect(new Set(ids).size).toBe(ids.length);
     await assertCursorsConsistent('w1', ids.length);
+  });
+});
+
+describe('seedChatIntoSession (NDJSON → runner session migration)', () => {
+  let sessionsDir: string;
+  beforeEach(async () => {
+    sessionsDir = await mkdtemp(path.join(tmpdir(), 'moxxy-sessions-'));
+  });
+  afterEach(async () => {
+    await rm(sessionsDir, { recursive: true, force: true });
+  });
+
+  it('seeds the runner session log from the NDJSON mirror when the runner has none', async () => {
+    await appendEvents('w1', [ev(0), ev(1), ev(2)]);
+    expect(await seedChatIntoSession('w1', sessionsDir)).toBe(true);
+    const body = await readFile(path.join(sessionsDir, 'w1.jsonl'), 'utf8');
+    const lines = body
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l) as { text: string; seq: number });
+    expect(lines.map((e) => e.text)).toEqual(['m0', 'm1', 'm2']);
+    expect(lines.map((e) => e.seq)).toEqual([0, 1, 2]);
+  });
+
+  it('never overwrites a session the runner already owns; leaves the NDJSON intact', async () => {
+    await appendEvents('w1', [ev(0)]);
+    await mkdir(sessionsDir, { recursive: true });
+    await writeFile(path.join(sessionsDir, 'w1.jsonl'), '{"existing":true}\n', 'utf8');
+    expect(await seedChatIntoSession('w1', sessionsDir)).toBe(false);
+    expect(await readFile(path.join(sessionsDir, 'w1.jsonl'), 'utf8')).toBe('{"existing":true}\n');
+    // NDJSON untouched — still the read fallback.
+    expect((await loadSegment('w1', null, 10)).events).toHaveLength(1);
+  });
+
+  it('is a no-op when the workspace has no NDJSON history', async () => {
+    expect(await seedChatIntoSession('never-chatted', sessionsDir)).toBe(false);
   });
 });

--- a/packages/desktop-host/src/chat-log.ts
+++ b/packages/desktop-host/src/chat-log.ts
@@ -15,10 +15,11 @@
  * search across thousands of messages later becomes a hard requirement.
  */
 
-import { appendFile, mkdir, open, readFile, rm, stat } from 'node:fs/promises';
+import { access, appendFile, mkdir, open, readFile, rm, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import { createMutex, type Mutex, type MoxxyEvent } from '@moxxy/sdk';
+import { defaultSessionsDir, seedSessionLog } from '@moxxy/core';
 
 /** Chats directory — env-overridable so tests can point at a tmp dir. */
 function chatsDir(): string {
@@ -335,4 +336,33 @@ export async function migrate(
       }
     });
   }
+}
+
+/**
+ * Migrate ONE workspace's history out of this NDJSON mirror into the runner's
+ * authoritative session log, IFF the runner doesn't already own that session
+ * (no `~/.moxxy/sessions/<id>.jsonl`). After this the renderer reads the chat
+ * from `session.loadHistory` like any native session, closing the dual-history
+ * split for legacy / localStorage-migrated chats whose history previously lived
+ * only here.
+ *
+ * Called from the runner pool BEFORE a workspace's runner resumes its session
+ * id, so the seed is in place when the runner reads it (no race). Idempotent +
+ * non-destructive: skips a session the runner already owns and never touches the
+ * NDJSON file (which stays the read fallback until the store is retired).
+ * Returns whether it seeded.
+ */
+export async function seedChatIntoSession(
+  workspaceId: string,
+  sessionsDir: string = defaultSessionsDir(),
+): Promise<boolean> {
+  try {
+    await access(path.join(sessionsDir, `${workspaceId}.jsonl`));
+    return false; // runner already owns this session → nothing to migrate
+  } catch {
+    /* no runner session yet → seed it from the NDJSON mirror below */
+  }
+  const events = await readLines(workspaceId);
+  if (events.length === 0) return false;
+  return seedSessionLog(workspaceId, events, sessionsDir);
 }

--- a/packages/desktop-host/src/chat-log.ts
+++ b/packages/desktop-host/src/chat-log.ts
@@ -15,7 +15,7 @@
  * search across thousands of messages later becomes a hard requirement.
  */
 
-import { access, appendFile, mkdir, open, readFile, rm, stat } from 'node:fs/promises';
+import { appendFile, mkdir, open, readFile, rm, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import { createMutex, type Mutex, type MoxxyEvent } from '@moxxy/sdk';
@@ -357,10 +357,13 @@ export async function seedChatIntoSession(
   sessionsDir: string = defaultSessionsDir(),
 ): Promise<boolean> {
   try {
-    await access(path.join(sessionsDir, `${workspaceId}.jsonl`));
-    return false; // runner already owns this session → nothing to migrate
+    // Non-empty → the runner already owns it. A 0-byte file is the empty log a
+    // prior spawn left behind (`persistence.attach` creates it even for a
+    // zero-event session), so fall through and migrate the NDJSON into it —
+    // else a legacy chat that was ever foregrounded would never migrate.
+    if ((await stat(path.join(sessionsDir, `${workspaceId}.jsonl`))).size > 0) return false;
   } catch {
-    /* no runner session yet → seed it from the NDJSON mirror below */
+    /* no runner session yet → seed from the NDJSON mirror below */
   }
   const events = await readLines(workspaceId);
   if (events.length === 0) return false;

--- a/packages/desktop-host/src/runner-pool.ts
+++ b/packages/desktop-host/src/runner-pool.ts
@@ -32,6 +32,10 @@ interface Entry {
 
 export class RunnerPool extends EventEmitter {
   private entries = new Map<string, Entry>();
+  /** In-flight creations, keyed by id, so two concurrent getOrCreate(id) calls
+   *  share ONE creation instead of both seeding + spawning (which would orphan
+   *  a supervisor and race two writes of the session log). */
+  private pending = new Map<string, Promise<RunnerSupervisor>>();
   private activeId: string | null = null;
 
   /**
@@ -46,6 +50,25 @@ export class RunnerPool extends EventEmitter {
       await existing.supervisor.setCwd(cwd);
       return existing.supervisor;
     }
+    // Serialize creation per id: Electron IPC dispatches concurrent invokes, and
+    // several handlers call getOrCreate for the same active session — without
+    // this, two calls both pass the `existing` check and both seed + spawn.
+    const inflight = this.pending.get(id);
+    if (inflight) {
+      const supervisor = await inflight;
+      await supervisor.setCwd(cwd);
+      return supervisor;
+    }
+    const created = this.createSupervisor(id, cwd);
+    this.pending.set(id, created);
+    try {
+      return await created;
+    } finally {
+      this.pending.delete(id);
+    }
+  }
+
+  private async createSupervisor(id: string, cwd: string | null): Promise<RunnerSupervisor> {
     const socketPath = socketFor(id);
     // Migrate a legacy / localStorage-only chat into the runner's authoritative
     // log BEFORE the runner resumes this session id, so the runner owns its full

--- a/packages/desktop-host/src/runner-pool.ts
+++ b/packages/desktop-host/src/runner-pool.ts
@@ -19,6 +19,7 @@ import path from 'node:path';
 import { platformSocket } from '@moxxy/runner';
 
 import { RunnerSupervisor } from './runner-supervisor';
+import { seedChatIntoSession } from './chat-log';
 
 /** Workspace id used for the "no workspace bound" runner. Stable across
  *  runs so the same socket is reused. */
@@ -46,6 +47,17 @@ export class RunnerPool extends EventEmitter {
       return existing.supervisor;
     }
     const socketPath = socketFor(id);
+    // Migrate a legacy / localStorage-only chat into the runner's authoritative
+    // log BEFORE the runner resumes this session id, so the runner owns its full
+    // history (else continuing the chat would strand the old history in the
+    // NDJSON mirror). Idempotent + non-destructive — skips a session the runner
+    // already owns and leaves the NDJSON file intact. Best-effort: a failed seed
+    // must not block opening the workspace (NDJSON stays the read fallback).
+    try {
+      await seedChatIntoSession(id);
+    } catch {
+      /* best-effort migration; the NDJSON read fallback still covers this chat */
+    }
     // Pass the workspace id as the runner's sticky session id so each
     // workspace resumes its own conversation + model context across app
     // restarts (the runner persists to ~/.moxxy/sessions/<id>.jsonl and


### PR DESCRIPTION
## ⚠️ DRAFT — do not merge until live-verified on a packaged desktop

The **keystone** of the dual-history consolidation. Makes the runner's session log the home of EVERY chat — including ones whose history previously lived only in the desktop's NDJSON mirror (localStorage-migrated / pre-runner-session chats). Without this, continuing such a chat strands its old history in NDJSON while new turns go to the runner log — the split the per-slot single-source renderer can't show. **This must land + live-verify before the next PR stops the double-write.**

### What it does
- **`@moxxy/core` `seedSessionLog(sessionId, events, dir?)`** — writes a fresh `<id>.jsonl` from an event list IFF the runner doesn't already own a NON-EMPTY one (re-sequenced to contiguous `seq` 0..n-1, ids/content preserved, temp+rename). Idempotent + non-destructive.
- **`seedChatIntoSession`** (runner pool) seeds a workspace's session from its NDJSON mirror **before** that workspace's runner resumes its session id — race-free (the seed completes before `new RunnerSupervisor` → `run()` spawns the child) and lazy (only chats you open). NDJSON is left **intact** as the read fallback.

### Review (adversarial, 10 agents) — fixed before this PR
- **HIGH (fixed):** `persistence.attach` creates a **0-byte** session file on every spawn, so any legacy chat ever foregrounded already had one — and an existence-only guard skipped exactly those chats (the keystone failing for its target population). Now seeds when the file is **absent or 0-byte** (an empty file holds no history). Regression tests added.
- **LOW (fixed):** a pre-existing concurrent-`getOrCreate` race (which the seed `await` widened) — now serialized per id via an in-flight Promise map.
- The "one-way door" concern was **refuted** (the seed is a faithful copy; NDJSON is never deleted; this is the intended end-state).

### Safety
- **Non-destructive:** never overwrites a non-empty runner log; never touches the NDJSON file (a test asserts it stays intact). The renderer still double-writes NDJSON, so it remains the read fallback until retirement.
- **Recoverable:** if a seed is ever wrong, the NDJSON still holds the original history (consulted again once the read path is adjusted).

### Please verify on a packaged desktop before merge
1. **Legacy chat migrates:** open an old localStorage-migrated chat (history only in `~/.moxxy/chats`) → it shows full history; a `~/.moxxy/sessions/<id>.jsonl` now exists with that history.
2. **Continue + reopen:** send a turn, restart the app, reopen → the FULL history (old + new) is shown from the runner (this is the split the keystone fixes).
3. **Normal chats untouched:** an existing runner-backed chat opens exactly as before (no reseed; its session log unchanged).
4. **Idempotent:** open/close/reopen several times — no duplication, no reseed.

### Next (separate PRs, each gated on live-verify, in order)
(a) stop the NDJSON double-write → (b) raise desktop FLOOR to v10 → (c) retire the NDJSON store. TECH_DEBT item 3.

**In-gate:** build · typecheck · tests (core 333, desktop-host 448, incl. seed + 0-byte cases) · lint 0 errors · check:deps clean.