### PR TITLE
feat(desktop): stop the NDJSON double-write for v10 runners; raise FLOOR to v10

### DIFF
--- a/.changeset/stop-ndjson-double-write.md
+++ b/.changeset/stop-ndjson-double-write.md
@@ -1,0 +1,23 @@
+---
+"@moxxy/desktop": minor
+---
+
+feat(desktop): stop the NDJSON double-write for v10 runners; raise FLOOR to v10
+
+With the runner now authoritative for every chat (it owns the log and legacy
+chats are migrated into it on open), the desktop's NDJSON chat mirror is no
+longer load-bearing — so we stop writing it where the runner is authoritative
+and require a v10 runner.
+
+- `chat.append` is runtime-gated on the ATTACHED runner's protocol version (not
+  the baked FLOOR, so it stays correct when a JS hot-update outruns the bundled
+  CLI): a v10+ runner owns the authoritative log, so the NDJSON mirror is
+  skipped; a `<v10` runner (or an unknown version) still writes it so the
+  renderer's NDJSON fallback never loses an event.
+- `FLOOR_RUNNER_PROTOCOL` raised 9 → 10 (== `RUNNER_PROTOCOL_VERSION`): the
+  dual-history transition is complete, so the desktop drops `<v10` runner support
+  and v10 JS hot-updates can apply on fresh installs. The release/floor guard
+  (`FLOOR <= RUNNER`) is unchanged.
+
+The NDJSON store is left on disk as a frozen read fallback; physically retiring
+it is the final separate follow-up.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -122,10 +122,14 @@ that must not be rushed, because rushing it would *lower* quality, not raise it:
    BEFORE that workspace's runner resumes its session id — so the runner owns
    every chat (a legacy chat is no longer stranded when continued). Idempotent +
    non-destructive (skips a session the runner already owns; NDJSON left intact).
-   **Remaining (separate PRs, each gated on packaged-desktop live-verify, IN
-   ORDER):** (a) stop the NDJSON double-WRITE; (b) raise desktop FLOOR to 10; (c)
-   physically retire the NDJSON store. The renderer still WRITES NDJSON today so
-   it stays the read fallback until (a)–(c) ship and verify.
+   **Single-source landed (2026-06-18):** (a) `chat.append` is runtime-gated on
+   the attached runner version — a v10+ runner owns the log so the NDJSON
+   double-WRITE is skipped (a `<v10` runner still mirrors); (b) desktop
+   `FLOOR_RUNNER_PROTOCOL` raised 9 → 10. The runner is now the authoritative
+   single source; the NDJSON store is a frozen on-disk read fallback.
+   **Remaining:** (c) physically retire the NDJSON store (remove the read
+   fallback + chat-log/IPC after an eager migrate-all) — the last, destructive
+   cleanup.
 4. **One-shot CLI exit hygiene** (`moxxy -p` / `schedule run` / `doctor` / `login` /
    `init` boot a full session and never `close()`) — minor; a correct fix must drain
    persistence before exit (premature exit would drop the last event).

--- a/apps/desktop/electron/main/floor-runner-protocol.test.ts
+++ b/apps/desktop/electron/main/floor-runner-protocol.test.ts
@@ -8,13 +8,15 @@ import { FLOOR_RUNNER_PROTOCOL } from './floor-runner-protocol';
 // means the desktop would reject the runner it ships with (the bug that bricked
 // the v5 release when the floor was left at 4).
 //
-// The floor is allowed to LAG the runner only when the newer protocol is purely
-// ADDITIVE and every new method is version-gated with a graceful fallback (e.g.
-// v10 `session.loadHistory`: the renderer falls back to its NDJSON store against
-// a <v10 runner, so the desktop must keep accepting a v9 runner — raising the
-// floor to 10 would wrongly reject it and reintroduce the hot-update skew bug).
-// A BREAKING protocol change must instead raise BOTH the floor and the runner's
-// MIN_COMPATIBLE in the same change. This mirrors build-app-bundle.mjs's
+// The floor MAY lag the runner while a new protocol method is still additive +
+// version-gated with a graceful fallback (as v10 `session.loadHistory` was while
+// the renderer kept an NDJSON fallback). The dual-history consolidation has now
+// finished that transition — the runner is the authoritative chat-history store
+// and the desktop requires v10 — so the floor is raised to 10 (== RUNNER) to drop
+// <v10 runner support and let v10 JS hot-updates apply on fresh installs. The
+// guard stays `<=` so a FUTURE additive+gated bump may again lag briefly; a
+// BREAKING change must instead raise BOTH the floor and the runner's
+// MIN_COMPATIBLE together. This mirrors build-app-bundle.mjs's
 // FLOOR <= RUNNER_PROTOCOL_VERSION guard.
 describe('FLOOR_RUNNER_PROTOCOL', () => {
   it('never exceeds @moxxy/runner RUNNER_PROTOCOL_VERSION', () => {

--- a/apps/desktop/electron/main/floor-runner-protocol.ts
+++ b/apps/desktop/electron/main/floor-runner-protocol.ts
@@ -16,4 +16,4 @@
  * the release build asserts the two match (see scripts/build-app-bundle.mjs),
  * so a forgotten bump fails the build rather than shipping a wrong floor.
  */
-export const FLOOR_RUNNER_PROTOCOL = 9;
+export const FLOOR_RUNNER_PROTOCOL = 10;

--- a/packages/desktop-host/src/ipc/chat.test.ts
+++ b/packages/desktop-host/src/ipc/chat.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { shouldMirrorToNdjson } from './chat';
+
+describe('shouldMirrorToNdjson (double-write gate)', () => {
+  it('skips the NDJSON mirror for a v10+ runner (runner is authoritative)', () => {
+    expect(shouldMirrorToNdjson(10)).toBe(false);
+    expect(shouldMirrorToNdjson(11)).toBe(false);
+  });
+
+  it('keeps writing the mirror against a <v10 runner (renderer still falls back to NDJSON)', () => {
+    expect(shouldMirrorToNdjson(9)).toBe(true);
+    expect(shouldMirrorToNdjson(7)).toBe(true);
+  });
+
+  it('keeps writing the mirror when the runner version is unknown (no runner attached yet)', () => {
+    // Safe default — never drop an event because we couldn't read the version.
+    expect(shouldMirrorToNdjson(null)).toBe(true);
+  });
+});

--- a/packages/desktop-host/src/ipc/chat.ts
+++ b/packages/desktop-host/src/ipc/chat.ts
@@ -1,9 +1,11 @@
 /**
  * Chat transcript log.
  *
- * `chat.append` / `chat.loadSegment` / `chat.clearLog` / `chat.migrate` are
- * thin pass-throughs to the append-only NDJSON `chat-log` store, lazily
- * imported and keyed by `workspaceId`.
+ * `chat.loadSegment` / `chat.clearLog` / `chat.migrate` are thin pass-throughs
+ * to the append-only NDJSON `chat-log` store, lazily imported and keyed by
+ * `workspaceId`. `chat.append` is now runtime-gated: it writes the NDJSON mirror
+ * ONLY against a `<v10` runner — a v10+ runner owns the authoritative log, so the
+ * mirror is skipped (the double-write stops where the runner is authoritative).
  *
  * `chat.loadHistory` is the runner-authoritative read path (protocol v10): it
  * pages history straight from the workspace's connected `RemoteSession`'s log
@@ -15,10 +17,33 @@
 import type { RunnerPool } from '../runner-pool';
 import { handle, resolveSupervisor } from './shared';
 
+/**
+ * Whether to still write the NDJSON mirror for a workspace, given its ATTACHED
+ * runner's protocol version (`null` = no runner attached yet / version unknown).
+ * A v10+ runner owns the authoritative log (the renderer reads it via
+ * `chat.loadHistory`), so the mirror is redundant and skipped; against a `<v10`
+ * runner — or when the version isn't known yet — we keep writing it so the
+ * renderer's NDJSON fallback never loses an event.
+ */
+export function shouldMirrorToNdjson(runnerProtocolVersion: number | null): boolean {
+  return runnerProtocolVersion === null || runnerProtocolVersion < 10;
+}
+
 export function registerChatHandlers(pool: RunnerPool): void {
   // ---- Chat transcript log (append-only NDJSON) ---------------------------
 
   handle('chat.append', async ({ workspaceId, events }) => {
+    // Stop the NDJSON double-write once the runner is authoritative for this
+    // workspace: a v10+ runner persists every committed event to its own log
+    // (which the renderer now reads via chat.loadHistory), so the NDJSON mirror
+    // is redundant. Keep writing it ONLY against a <v10 runner, where the
+    // renderer still falls back to NDJSON for history. Gated on the ACTUAL
+    // attached runner version (not the baked FLOOR) so it stays correct on an
+    // existing install whose JS hot-updated ahead of its bundled CLI. When no
+    // runner is attached yet (version unknown) we keep the mirror — the safe
+    // default never drops an event.
+    const version = resolveSupervisor(pool, workspaceId)?.remote()?.runnerProtocolVersion ?? null;
+    if (!shouldMirrorToNdjson(version)) return; // v10+ runner owns the log → skip the mirror
     const { appendEvents } = await import('../chat-log');
     await appendEvents(workspaceId, events);
   });


### PR DESCRIPTION
Step (a)+(b) of finalizing the dual-history consolidation. The runner is now authoritative for every chat (#251/#261/#266), so the NDJSON mirror is no longer load-bearing.

- **`chat.append` runtime-gated** on the ATTACHED runner's protocol version (not the baked FLOOR — so it stays correct when a JS hot-update outruns the bundled CLI): a v10+ runner owns the authoritative log → the NDJSON mirror is **skipped**; a `<v10` runner (or unknown version) still writes it so the renderer's NDJSON fallback never loses an event. Pure `shouldMirrorToNdjson` helper + unit test.
- **`FLOOR_RUNNER_PROTOCOL` 9 → 10** (== `RUNNER_PROTOCOL_VERSION`): the transition is complete, so the desktop drops `<v10` runner support and v10 JS hot-updates can apply on fresh installs. The `FLOOR <= RUNNER` release/floor guard is unchanged (10 <= 10).

The NDJSON store stays on disk as a frozen read fallback; physically retiring it (remove the read path + chat-log/IPC after an eager migrate-all) is the final follow-up.

**Safety:** stopping the write loses nothing — every event the renderer commits originates from the runner, and the foundation's seal means the runner persists the unsealed-reply case the renderer used to synthesize, so the runner log already holds everything.

In-gate: build · typecheck · tests (desktop-host 451 incl. the gate test; floor test) · lint 0 errors · check:deps clean.