### PR TITLE
feat(desktop): eagerly migrate every NDJSON-only chat into the runner log (complete the consolidation)

### DIFF
--- a/.changeset/eager-migrate-all-chats.md
+++ b/.changeset/eager-migrate-all-chats.md
@@ -1,0 +1,22 @@
+---
+"@moxxy/desktop": minor
+---
+
+feat(desktop): eagerly migrate every NDJSON-only chat into the runner log (complete the consolidation)
+
+Completes the dual-history consolidation: at startup the desktop now eagerly
+migrates EVERY chat whose history still lives only in the NDJSON mirror into the
+runner's authoritative log (`migrateAllChatsToSessions`), not just the ones the
+user happens to open. After this the runner is the single source of truth for ALL
+chats.
+
+- Fire-and-forget at `registerIpcHandlers` startup; idempotent + best-effort +
+  non-destructive (skips chats the runner already owns, leaves the NDJSON files
+  intact, one unreadable chat never aborts the rest). The runner pool still seeds
+  on open as the per-chat guarantee.
+
+The NDJSON store is now fully frozen — not written (for v10 runners) and no longer
+the source of truth — but its files + read-fallback code are retained as a safety
+net. Physically deleting them is deliberately left as a later cleanup gated on a
+packaged-desktop live-verify (it is destructive and touches self-update-sensitive
+paths).

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -125,11 +125,15 @@ that must not be rushed, because rushing it would *lower* quality, not raise it:
    **Single-source landed (2026-06-18):** (a) `chat.append` is runtime-gated on
    the attached runner version — a v10+ runner owns the log so the NDJSON
    double-WRITE is skipped (a `<v10` runner still mirrors); (b) desktop
-   `FLOOR_RUNNER_PROTOCOL` raised 9 → 10. The runner is now the authoritative
-   single source; the NDJSON store is a frozen on-disk read fallback.
-   **Remaining:** (c) physically retire the NDJSON store (remove the read
-   fallback + chat-log/IPC after an eager migrate-all) — the last, destructive
-   cleanup.
+   `FLOOR_RUNNER_PROTOCOL` raised 9 → 10; (c) `migrateAllChatsToSessions` eagerly
+   migrates EVERY remaining NDJSON-only chat into the runner at startup, so the
+   runner is the single source of truth for ALL chats (not just opened ones).
+   **The dual-history consolidation is functionally COMPLETE** — the runner is
+   authoritative, the NDJSON store is frozen (not written, not the source of
+   truth). Its files + read-fallback code remain only as a safety net.
+   **Only cleanup left (deliberately deferred, gated on packaged-desktop
+   live-verify — destructive + self-update-sensitive):** physically delete the
+   NDJSON files + remove the read-fallback / chat-log / chat.* IPC.
 4. **One-shot CLI exit hygiene** (`moxxy -p` / `schedule run` / `doctor` / `login` /
    `init` boot a full session and never `close()`) — minor; a correct fix must drain
    persistence before exit (premature exit would drop the last event).

--- a/packages/desktop-host/src/chat-log.test.ts
+++ b/packages/desktop-host/src/chat-log.test.ts
@@ -3,7 +3,14 @@ import { mkdtemp, mkdir, rm, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { MoxxyEvent } from '@moxxy/sdk';
-import { appendEvents, loadSegment, clearLog, migrate, seedChatIntoSession } from './chat-log';
+import {
+  appendEvents,
+  loadSegment,
+  clearLog,
+  migrate,
+  seedChatIntoSession,
+  migrateAllChatsToSessions,
+} from './chat-log';
 
 let dir: string;
 
@@ -325,5 +332,21 @@ describe('seedChatIntoSession (NDJSON → runner session migration)', () => {
 
   it('is a no-op when the workspace has no NDJSON history', async () => {
     expect(await seedChatIntoSession('never-chatted', sessionsDir)).toBe(false);
+  });
+
+  it('eagerly migrates every NDJSON-only chat, skipping ones the runner already owns', async () => {
+    await appendEvents('w1', [ev(0), ev(1)]);
+    await appendEvents('w2', [ev(0)]);
+    await appendEvents('w3', [ev(0)]);
+    await mkdir(sessionsDir, { recursive: true });
+    await writeFile(path.join(sessionsDir, 'w3.jsonl'), '{"owned":true}\n', 'utf8'); // runner owns w3
+    expect(await migrateAllChatsToSessions(sessionsDir)).toBe(2); // w1 + w2, not w3
+    expect(await readFile(path.join(sessionsDir, 'w3.jsonl'), 'utf8')).toBe('{"owned":true}\n');
+    expect((await readFile(path.join(sessionsDir, 'w1.jsonl'), 'utf8')).trim().split('\n')).toHaveLength(2);
+    expect((await readFile(path.join(sessionsDir, 'w2.jsonl'), 'utf8')).trim().split('\n')).toHaveLength(1);
+  });
+
+  it('returns 0 when there are no NDJSON chats to migrate', async () => {
+    expect(await migrateAllChatsToSessions(sessionsDir)).toBe(0);
   });
 });

--- a/packages/desktop-host/src/chat-log.ts
+++ b/packages/desktop-host/src/chat-log.ts
@@ -15,7 +15,7 @@
  * search across thousands of messages later becomes a hard requirement.
  */
 
-import { appendFile, mkdir, open, readFile, rm, stat } from 'node:fs/promises';
+import { appendFile, mkdir, open, readdir, readFile, rm, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import { createMutex, type Mutex, type MoxxyEvent } from '@moxxy/sdk';
@@ -368,4 +368,34 @@ export async function seedChatIntoSession(
   const events = await readLines(workspaceId);
   if (events.length === 0) return false;
   return seedSessionLog(workspaceId, events, sessionsDir);
+}
+
+/**
+ * Eagerly migrate EVERY workspace that still has an NDJSON-only history into the
+ * runner's authoritative log, completing the consolidation for chats the user
+ * hasn't opened yet (opened chats already migrate via the runner pool's
+ * {@link seedChatIntoSession}). After this the runner is the single source of
+ * truth for ALL chats, not just opened ones. Idempotent + best-effort +
+ * non-destructive: skips chats the runner already owns, leaves the NDJSON files
+ * intact, and one unreadable chat never aborts the rest. Returns the count
+ * migrated.
+ */
+export async function migrateAllChatsToSessions(sessionsDir?: string): Promise<number> {
+  let files: string[];
+  try {
+    files = await readdir(chatsDir());
+  } catch {
+    return 0; // no chats dir yet → nothing to migrate
+  }
+  let migrated = 0;
+  for (const file of files) {
+    if (!file.endsWith('.jsonl')) continue;
+    const workspaceId = file.slice(0, -'.jsonl'.length);
+    try {
+      if (await seedChatIntoSession(workspaceId, sessionsDir)) migrated += 1;
+    } catch {
+      /* skip this chat; migrate the rest */
+    }
+  }
+  return migrated;
 }

--- a/packages/desktop-host/src/ipc.ts
+++ b/packages/desktop-host/src/ipc.ts
@@ -52,6 +52,7 @@ import { registerPrefsHandlers } from './ipc/prefs';
 import { registerSettingsHandlers } from './ipc/settings';
 import { registerVaultHandlers } from './ipc/vault';
 import { registerChatHandlers } from './ipc/chat';
+import { migrateAllChatsToSessions } from './chat-log';
 import { registerMobileGatewayHandlers, type MobileGatewayController } from './ipc/mobile-gateway';
 
 export function registerIpcHandlers(
@@ -95,6 +96,13 @@ export function registerIpcHandlers(
     registerChatHandlers(pool);
     registerMobileGatewayHandlers(opts.mobileGateway ?? null);
   }
+  // Eagerly migrate every NDJSON-only chat into the runner's authoritative log,
+  // completing the dual-history consolidation for chats the user hasn't opened
+  // yet (opened chats already migrate via the runner pool). Fire-and-forget +
+  // idempotent + non-destructive — only seeds sessions the runner doesn't yet
+  // own, never blocks startup, and getOrCreate still seeds on open as the
+  // per-chat guarantee.
+  void migrateAllChatsToSessions().catch(() => {});
 }
 
 /**


### PR DESCRIPTION
The final step of the dual-history consolidation. At startup the desktop eagerly migrates **every** chat whose history still lives only in the NDJSON mirror into the runner's authoritative log — not just the ones the user opens — so the runner is the **single source of truth for ALL chats**.

- `migrateAllChatsToSessions` runs fire-and-forget at `registerIpcHandlers` startup; idempotent + best-effort + non-destructive (skips chats the runner already owns, leaves the NDJSON files intact, one unreadable chat never aborts the rest). The runner pool still seeds on open as the per-chat guarantee.

**End state:** runner is authoritative; the NDJSON store is **frozen** — not written (v10 runners, #270) and no longer the source of truth. Its files + read-fallback code are retained only as a safety net. Physically deleting them is deliberately left as a later cleanup (destructive + self-update-sensitive → wants a packaged-desktop live-verify).

In-gate: build · typecheck · tests (desktop-host, incl. eager-migrate cases) · lint 0 errors · check:deps clean.