### PR TITLE
fix(collaborative): stop the 30-min hang, spawn crash, and worktree leaks

### DIFF
--- a/.changeset/collab-hang-spawn-leaks.md
+++ b/.changeset/collab-hang-spawn-leaks.md
@@ -1,0 +1,31 @@
+---
+"@moxxy/plugin-collab": patch
+"@moxxy/mode-collaborative": patch
+"@moxxy/cli": patch
+---
+
+fix(collaborative): stop the 30-minute hang, the spawn crash, and worktree leaks
+
+Agentic-collaborative mode could freeze for the full wall-clock (30 min) or take
+down the whole runner. Three root causes, fixed:
+
+- **30-minute hang.** A spawned agent only reported a terminal hub status when it
+  called `collab_done`. Every other way a turn can end (provider error, iteration
+  cap, idle, stuck-loop) left the process idling as `connected`, so the
+  coordinator polled the full wall-clock before giving up. Peers now report a new
+  terminal `failed` status when their turn ends without `collab_done`, and the
+  coordinator adds a short **boot deadline** plus reacts to an observed child
+  exit — so failures surface in seconds, not after 30 minutes.
+- **Coordinator crash on a bad spawn.** The peer `spawn()` had no `'error'`
+  listener, so a failed spawn became an uncaught exception. It is now captured as
+  a normal exit + diagnostic.
+- **Leaks.** Worktrees and the run's socket dir are now cleaned up on every exit
+  path (abort, 0-done, conflict), not just integrate()'s happy path. The
+  sequential fallback now awaits a peer's real exit before starting the next, so
+  two agents never edit the shared workspace at once.
+
+A `failed` agent also releases its file locks (like a crash), and agents now
+self-report `working` while a turn is in flight. Adds a deterministic
+fail-fast coordinator test and a real-process integration test that spawns the
+actual `moxxy agent` binary and asserts it registers and reports a terminal
+status (no LLM required).

--- a/.claude/audits/COLLAB_AUDIT_2026-06-18.md
+++ b/.claude/audits/COLLAB_AUDIT_2026-06-18.md
@@ -1,0 +1,165 @@
+# Agentic-Collaborative Mode — Audit & Roadmap (2026-06-18)
+
+Scope: `@moxxy/mode-collaborative` + `@moxxy/plugin-collab` (coordinator, peer loop,
+hub, state, worktrees, integrate) and the desktop `Collaborate` surface. Branch
+`worktree-collab-audit-fix` off `main`@#272 (collab is merged + #243-hardened).
+
+Method: 5-lane parallel audit (work-breaking · context-access · performance/tokens ·
+security · feasibility/vision), each finding adversarially re-verified against the
+code (refute-by-default). **50 findings: 3 critical, 16 high, 18 medium, 13 low.
+All 19 critical+high survived verification** (one critical → medium for overstated
+wording). Plus a zero-LLM runtime probe proving the spawn/socket/register path works.
+Raw data: `collab-audit-2026-06-18.raw.json`.
+
+---
+
+## TL;DR
+
+The core plumbing is sound — a real spawned `moxxy agent` boots, connects to the hub
+socket, and registers (verified by probe). What's broken is **everything around the
+edges of the happy path**, and the product is **a much narrower thing than the
+vision**.
+
+The user's three asks map cleanly onto the findings:
+
+1. **"Make it work" →** one critical hang + two high crashers/leaks dominate the
+   "seems broken" experience.
+2. **"Agents need the whole workspace + the messages, to build memory/recall" →** a
+   confirmed, by-design context-starvation gap. Files are OK (worktree); **intent and
+   conversation are entirely lost**, and `MOXXY_COLLAB_PARENT_TASK` is dead code.
+3. **"A dynamic-role company that delivers the end result, token-efficiently" →** the
+   model is structurally a *fixed two-role, flat-parallel, git-file-merge pipeline*.
+   Real value today exists only for "an existing git repo + a feature that splits into
+   disjoint files" — the **opposite** of the non-expert / any-deliverable target.
+
+---
+
+## 1. Make it work — the "seems broken" cluster
+
+| # | Sev | Finding | Why it reads as "broken" |
+|---|-----|---------|--------------------------|
+| 1 | **CRIT** | `agent-exit-no-terminal-status-30min-hang` | A peer only reports a terminal status when it calls `collab_done`. **Every other exit** (provider error, iteration cap, idle, stuck-loop, missing key) returns from the loop but the process **keeps idling** (`runUntilSignal` blocks forever), so the socket never drops → hub never marks it `crashed` → the coordinator polls the full **30-minute** wall-clock. One bad peer freezes the whole run. |
+| 2 | HIGH | `spawn-error-unhandled-crashes-coordinator` | `spawn()` has **no `'error'` listener**. A failed spawn (bad path, ENOENT — plausible under Electron) emits `'error'`, which with no handler becomes an **uncaught exception that crashes the coordinator/runner**. Likely the hard-failure users hit. |
+| 3 | HIGH | `wallclock-30min-idle-burn` / `failure-modes-look-like-30min-hang` | No short *boot deadline*: if a peer never reaches `connected`, the coordinator still waits `wallClockMs`. Failures are indistinguishable from work. |
+| 4 | HIGH | `worktree-branch-leak-on-non-happy-path` | Worktrees/branches are cleaned only inside `integrate()`'s happy path → they leak on 0-done, abort, conflict, or integrate failure. (Confirmed: today's `~/.moxxy/collab/` has orphaned empty run dirs.) |
+| 5 | HIGH | `architect-cannot-broker-after-collab-done` | The architect *must* call `collab_done` to unblock the coordinator, but that **terminates its loop** — so the prompt's promise that it "stays available as the BROKER" is **structurally impossible**. Contract-change acks from the architect can never arrive → an implementer that proposes a change waits forever. |
+| 6 | HIGH | `real-process-path-completely-untested` | The only e2e test **fakes the supervisor**; the real spawn/env/register/crash/hang/conflict paths have **zero coverage**. |
+
+Plus medium: `sequential-fallback-overlapping-processes` (next agent spawns before
+prev exits — two writers in the shared dir), `peer-max-iterations-config-dead`,
+`verifygate-config-unused`, `roster-approval-fails-open-without-resolver`,
+`peerreader-diff-captures-prescaffold-base`, `stepin-wrong-workspace-no-hub`.
+
+## 2. Context access (the user's #1 ask)
+
+**Files: OK.** Git-mode peers get a worktree at `baseSha`, which includes tracked +
+*untracked* + dirty files (`git add -A` snapshot). **Caveat:** `.gitignore`d files
+(`.env`, local config, build state) are invisible in worktrees, with no warning
+(`gitignored-files-invisible-in-worktrees`).
+
+**Intent & messages: lost by design.** Each peer boots a **brand-new empty Session**
+(`<coord>::<agent>`, sticky not resumed) seeded with a **single string** — for
+implementers, their narrow `subtask`. Confirmed gaps:
+- `parent-task-set-but-never-read` — `MOXXY_COLLAB_PARENT_TASK` is *written* into every
+  peer's env and **read nowhere**. Implementers never see the overall goal.
+- `peers-lose-user-conversation` — the user's dialogue, clarifications, and constraints
+  never reach any agent; even the architect gets only `lastUserPromptText` (the last
+  message, not the conversation).
+- `architect-exploration-discarded` — the architect explores the repo, then everything
+  except `CONTRACTS.md` is thrown away; **every peer re-explores from scratch** (also a
+  major token cost).
+- `no-memory-recall-nudge-or-scoped-write` — memory *is* global+shared
+  (`~/.moxxy/memory`, inherited `MOXXY_HOME`), but **neither prompt mentions recall or
+  save**, there's no collab-scoped tag, and no distilled brief is written into the
+  scaffold. Agents can't build good memory/recall for the larger work.
+
+**Fix shape (implemented in this PR — see §6):** coordinator distills the conversation
+into a compact `.moxxy-collab/BRIEF.md` (overall goal + intent digest), committed into
+the scaffold so every worktree inherits it and it's archived; revive `PARENT_TASK` as a
+turn preamble; prompt agents to read the brief + recall/save memories.
+
+## 3. Performance & token efficiency
+
+Structurally inefficient: up to **6 fully-independent fresh Sessions** (1 architect +
+≤5 peers), each its own OS process with its own prompt cache, each **re-exploring the
+same codebase** (the architect already paid for that map). No cross-peer cache sharing;
+the awareness nudge is re-fetched + re-projected **every iteration**; `collab_peer_diff`
+can inject a **64MB** diff into a peer's context unbounded (`peer-diff-unbounded-injection`).
+Rough estimate from the lane: **3–5× the tokens** a well-briefed single agent would
+spend, dominated by redundant exploration. Highest-leverage reductions: share the
+architect's exploration as a committed `WORKSPACE`/`BRIEF` (kills re-exploration),
+seed contracts/roster into the cached system prefix instead of per-peer tool
+round-trips, cap `peer_diff`, throttle awareness to hub-signaled activity, and
+right-size models per role.
+
+## 4. Security
+
+The **#243 hardening holds**: peer-read traversal is segment-aware (`resolveWithin`),
+claim/release/board-id ownership is owner-checked, dead-agent locks are freed, sockets
+sit under `0700` dirs with `0600` nodes, and auto-approve still consults the user's
+deny policy (`~/.moxxy/permissions.json`) — invariant #6 preserved. Trust boundary is
+"same local user." Remaining gaps within it:
+- `architect-runs-before-approval-gate` (HIGH) — the architect runs a **full
+  auto-approved turn (bash/write/fetch) in the user's real repo BEFORE** the roster
+  gate; the gate also **fails open** when no approval resolver is installed.
+- `hub-register-identity-spoof` (HIGH) — `collab.register` accepts any roster id with no
+  binding to the connection; a misbehaving peer can register *as another agent* (incl.
+  the architect). Weaker than the hub's own docstring claims.
+- Medium/low: `peer-read-symlink-escape` (lexical guard doesn't stop symlinks),
+  `scaffold-wip-commits-mutate-user-branch` (history rewrite via real commits +
+  `--no-verify`), `full-env-provider-keys-to-children`, `peer-runner-socket-unauthenticated`,
+  `windows-child-leak-detached-false`.
+
+## 5. Feasibility & business value vs the vision
+
+The vision: a dynamically-assembled **company of fluid roles** (PM/designer/writer/QA/
+dev/architect) that takes a non-expert's vague prompt and delivers a finished
+**end-result of any kind**. The shipped code:
+- **Cannot express roles** — `AgentRole = 'architect' | 'implementer'` (closed union),
+  and `readRoster` **force-overwrites every proposed role to `'implementer'`**
+  (`roles-cannot-exist-fixed-two-role-pipeline`, CRIT).
+- **Assumes git + disjoint file ownership** — isolation = git worktree, integration =
+  file merge by claim-ownership. Doesn't fit docs/designs/plans/research or non-file
+  roles (`git-file-ownership-excludes-non-code-deliverables`).
+- **No requirements elicitation** — a vague prompt goes straight to decomposition.
+- **Flat parallel, no dependency DAG** — the architect must pretend subtasks are
+  independent; no design→build→QA sequencing.
+- **No QA/review gate, no iteration loop, no PM verification** — `verifyGate` is dead
+  config; one pass and done; nobody checks the result against intent.
+
+**Genuine value today** is narrow: an existing git repo + a feature that splits cleanly
+into disjoint files. That's the opposite of the target user.
+
+---
+
+## 6. What this PR changes (Wave 1 — "make it work" + context + archive)
+
+Implemented + tested:
+- **Hang/crash:** peers report a terminal `failed` status on any non-`collab_done`
+  exit; coordinator adds a **boot deadline** + reacts to observed child exit; `spawn()`
+  gets an `'error'` handler. → no more 30-min freeze, no coordinator crash.
+- **Context:** coordinator distills a `BRIEF.md` (goal + conversation intent) into the
+  committed scaffold; `PARENT_TASK` revived as a turn preamble; prompts tell agents to
+  read the brief and recall/save memories.
+- **Archive:** every run is persisted under `~/.moxxy/collab/runs/<runId>.json`
+  (task, brief, roster, per-agent status+summary, board, contracts, merge result,
+  timestamps) with artifacts; transient run dirs/worktrees/branches are cleaned up;
+  `collab.history` IPC + a desktop history view.
+- **Cheap wins:** self-reported `working` status; `peerMaxIterations` plumbed; capped
+  `peer_diff`; fail-closed roster approval; duplicate-register guard.
+- **Vision seed:** roles are first-class (architect can assemble a real PM/designer/dev/
+  QA/writer team; no more force-overwrite).
+
+## 7. Roadmap (deferred — logged to TECH_DEBT)
+
+- **S2 — Dynamic roles, properly:** a role-profile registry `{systemPrompt, tool/skill
+  allow-list, deliverable-kind}` (swappable-block pattern), per-role model right-sizing.
+- **S3 — Real pipeline:** roster `dependsOn` + topological/staged scheduling
+  (design→build→QA), a wired QA/verify gate (`verifyGate`) + reviewer role + an
+  iteration/rework loop, a PM/discovery phase with clarifying questions.
+- **S4 — Any deliverable:** abstract the workspace/deliverable seam off git+files
+  (artifact store + non-git isolation + assemble step) so docs/designs/research and
+  non-file roles work.
+- **Hardening:** isolate the architect behind the approval gate; bind hub identity to
+  the connection; realpath the peer-read guard; stash (not commit) the WIP snapshot;
+  curate child env; stream per-peer transcripts into the Collaborate view.

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -1,5 +1,6 @@
 import { startRunnerServer, type RunnerServer } from '@moxxy/runner';
 import type { Session } from '@moxxy/core';
+import { getProcessHubClient } from '@moxxy/plugin-collab';
 import type { ParsedArgv } from '../argv.js';
 import { bootSessionWithConfig, helpRequested } from '../argv-helpers.js';
 
@@ -61,6 +62,24 @@ export async function runAgentCommand(argv: ParsedArgv): Promise<number> {
       for await (const _ of session.runTurn(subtask)) void _;
     } catch {
       // the loop already emitted an error event
+    }
+    // Liveness: the autonomous loop ends by calling collab_done (→ hub status
+    // 'done') OR by giving up (fatal error / iteration-cap / idle / stuck) — and
+    // those paths leave NO hub status while this process keeps idling below so
+    // the desktop can attach. Without a signal the coordinator would poll the
+    // full wall-clock (30 min) before timing the agent out. Report a terminal
+    // 'failed' status when the turn ended without self-completing so the
+    // coordinator stops waiting immediately.
+    try {
+      const hub = await getProcessHubClient();
+      if (hub) {
+        const mine = (await hub.roster()).agents.find((a) => a.id === hub.agentId);
+        if (mine && mine.status !== 'done') {
+          await hub.setStatus('failed', 'turn ended without calling collab_done');
+        }
+      }
+    } catch {
+      // best-effort — never let liveness reporting crash the peer
     }
   })();
 

--- a/packages/mode-collaborative/src/agent-loop.ts
+++ b/packages/mode-collaborative/src/agent-loop.ts
@@ -64,6 +64,9 @@ export async function* runCollabAgentLoop(
   };
 
   const hub = await getProcessHubClient();
+  // Announce active work so the roster/UI shows 'working' (not a stale
+  // 'connected') for the whole turn. Best-effort; the run proceeds regardless.
+  if (hub) await hub.setStatus('working').catch(() => undefined);
   const detector = createStuckLoopDetector();
   const maxIterations = ctx.maxIterations ?? DEFAULT_MAX_ITERATIONS;
   let noop = 0;

--- a/packages/mode-collaborative/src/collab-loop.test.ts
+++ b/packages/mode-collaborative/src/collab-loop.test.ts
@@ -87,6 +87,43 @@ function fakeSupervisor(hub: CollaborationHub): Supervisor {
     stop: async () => undefined,
     shutdownAll: async () => undefined,
     stderrOf: () => [],
+    hasExited: () => false,
+  };
+}
+
+/** Like {@link fakeSupervisor}, but `failingId` is spawned and then reports its
+ *  process exited WITHOUT ever marking done — simulating a crash / a turn that
+ *  ended without collab_done. Exercises the coordinator's fail-fast path. */
+function partiallyFailingSupervisor(hub: CollaborationHub, failingId: string): Supervisor {
+  const exited = new Set<string>();
+  return {
+    spawn({ entry, cwd }) {
+      if (entry.role === 'architect') {
+        mkdirSync(join(cwd, '.moxxy-collab'), { recursive: true });
+        writeFileSync(join(cwd, '.moxxy-collab', 'CONTRACTS.md'), '# Contracts\n');
+        writeFileSync(
+          join(cwd, '.moxxy-collab', 'roster.json'),
+          JSON.stringify([
+            { id: 'backend', name: 'Backend', role: 'implementer', subtask: 'build the API', ownedPaths: ['api.ts'] },
+            { id: 'flaky', name: 'Flaky', role: 'implementer', subtask: 'a doomed task', ownedPaths: ['flaky.ts'] },
+          ]),
+        );
+        hub.state.markDone('architect', 'design done');
+      } else if (entry.id === failingId) {
+        // No file, no done — the process simply dies.
+        exited.add(entry.id);
+      } else {
+        const file = `${entry.id}.ts`;
+        writeFileSync(join(cwd, file), `export const ${entry.id} = true;\n`);
+        hub.state.boardClaim(entry.id, [file]);
+        hub.state.markDone(entry.id, `${entry.id} done`);
+      }
+      return { socket: 'fake.sock' };
+    },
+    stop: async () => undefined,
+    shutdownAll: async () => undefined,
+    stderrOf: () => ['boom: simulated crash'],
+    hasExited: (id) => exited.has(id),
   };
 }
 
@@ -126,6 +163,43 @@ describe('collaborative coordinator (end-to-end, fake agents + real git)', () =>
     const finalMsg = events.filter((e) => e.type === 'assistant_message').pop() as { content: string } | undefined;
     expect(finalMsg?.content).toContain('backend');
     expect(finalMsg?.content).toContain('tests');
+  });
+
+  it('does NOT hang on a failed agent: surfaces it and completes with the others', async () => {
+    const repo = await initRepo();
+    const { ctx, events } = fakeCtx();
+    const deps: CollabDeps = {
+      cwd: repo,
+      config: resolveCollabConfig(undefined, { requireRosterApproval: false, wallClockMs: 60_000 }),
+      createSupervisor: (_opts, hub) => partiallyFailingSupervisor(hub, 'flaky'),
+    };
+
+    // The whole run must finish well under the wall-clock (the old code would
+    // have polled the full 60s for the never-done 'flaky' agent).
+    const started = Date.now();
+    for await (const _ of runCollaborative(ctx, deps)) void _;
+    expect(Date.now() - started).toBeLessThan(20_000);
+
+    const subtypes = events
+      .filter((e) => e.type === 'plugin_event')
+      .map((e) => (e as { subtype: string }).subtype);
+    // The failed agent was surfaced, not silently swallowed.
+    expect(subtypes).toContain('collab_agent_failed');
+    expect(subtypes).toContain('collab_completed');
+
+    const failed = events.find(
+      (e) => (e as { subtype?: string }).subtype === 'collab_agent_failed',
+    ) as { payload: { id: string; stderr: ReadonlyArray<string> } };
+    expect(failed.payload.id).toBe('flaky');
+    expect(failed.payload.stderr.join('\n')).toContain('simulated crash');
+
+    // The healthy agent's work still integrated; the completion counts 1/2 done.
+    expect(existsSync(join(repo, 'backend.ts'))).toBe(true);
+    const completed = events.find(
+      (e) => (e as { subtype?: string }).subtype === 'collab_completed',
+    ) as { payload: { done: string[]; total: number } };
+    expect(completed.payload.done).toEqual(['backend']);
+    expect(completed.payload.total).toBe(2);
   });
 
   it('falls back to sequential when the workspace is not a git repo', async () => {

--- a/packages/mode-collaborative/src/collab-loop.ts
+++ b/packages/mode-collaborative/src/collab-loop.ts
@@ -7,7 +7,7 @@
  * the UI, integrates the work, and synthesizes the result.
  */
 
-import { mkdirSync, readFileSync, existsSync } from 'node:fs';
+import { mkdirSync, readFileSync, existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import type { ModeContext, MoxxyEvent } from '@moxxy/sdk';
 import {
@@ -36,8 +36,10 @@ import {
   addWorktree,
   commitAll,
   detectGit,
+  git,
   headSha,
   peerReaderFor,
+  removeWorktree,
   resolveBase,
 } from './worktrees.js';
 import { PeerSupervisor, type PeerSupervisorOptions, type Supervisor } from './peer-supervisor.js';
@@ -46,6 +48,10 @@ import { releaseCollabLock, tryAcquireCollabLock } from './collab-lock.js';
 import type { CollaborationHub } from '@moxxy/plugin-collab';
 
 const POLL_MS = 500;
+/** Grace for a spawned agent to boot + register with the hub. Separate from the
+ *  overall wall-clock so a peer that never comes up (bad spawn, crash on boot)
+ *  fails in ~a minute instead of hanging the whole run for the wall-clock. */
+const BOOT_DEADLINE_MS = 90_000;
 
 /** Injection seam — defaults to the real process supervisor + the live cwd/config.
  *  Lets tests (and future remote executors) drive the coordinator deterministically. */
@@ -151,14 +157,19 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
     supervisor.spawn({ entry: architectEntry, cwd, mode: COLLAB_ARCHITECT_MODE_NAME });
     yield await ctx.emit(plugin(ctx, 'collab_agent_spawned', { id: ARCHITECT_AGENT_ID, role: 'architect' }));
 
-    const architectOk = await waitForAgent(hub, ARCHITECT_AGENT_ID, ctx.signal, cfg.wallClockMs);
+    const architectOk = await waitForAgent(hub, supervisor, ARCHITECT_AGENT_ID, ctx.signal, cfg.wallClockMs);
     if (ctx.signal.aborted) {
       yield await ctx.emit(emitAbort(ctx, 'aborted during design'));
       return;
     }
     if (!architectOk) {
+      const why = supervisor.stderrOf(ARCHITECT_AGENT_ID).slice(-4).join('\n');
+      yield await ctx.emit(plugin(ctx, 'collab_agent_failed', { id: ARCHITECT_AGENT_ID, status: statusOf(hub, ARCHITECT_AGENT_ID), stderr: supervisor.stderrOf(ARCHITECT_AGENT_ID).slice(-6) }));
       yield await ctx.emit(
-        assistant(ctx, 'The architect did not finish the design. Stopping the collaboration.'),
+        assistant(
+          ctx,
+          `The architect did not finish the design — stopping the collaboration.${why ? `\n\nLast diagnostics:\n${why}` : ''}`,
+        ),
       );
       return;
     }
@@ -206,7 +217,8 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
         supervisor.spawn({ entry, cwd: wt, mode: COLLAB_PEER_MODE_NAME });
         yield await ctx.emit(plugin(ctx, 'collab_agent_spawned', { id: entry.id, role: entry.role }));
       }
-      await waitForAgents(hub, roster.map((r) => r.id), ctx.signal, cfg.wallClockMs);
+      await waitForAgents(hub, supervisor, roster.map((r) => r.id), ctx.signal, cfg.wallClockMs);
+      yield* surfaceFailures(ctx, hub, supervisor, roster.map((r) => r.id));
       for (const r of roster) if (statusOf(hub, r.id) === 'done') doneIds.push(r.id);
     } else {
       // Sequential fallback (no git): one agent at a time, in the shared workspace.
@@ -215,7 +227,10 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
         hub.state.addAgent(entry);
         supervisor.spawn({ entry, cwd, mode: COLLAB_PEER_MODE_NAME });
         yield await ctx.emit(plugin(ctx, 'collab_agent_spawned', { id: entry.id, role: entry.role }));
-        const ok = await waitForAgent(hub, entry.id, ctx.signal, cfg.wallClockMs);
+        const ok = await waitForAgent(hub, supervisor, entry.id, ctx.signal, cfg.wallClockMs);
+        if (!ok) yield* surfaceFailures(ctx, hub, supervisor, [entry.id]);
+        // Await the child's real exit before starting the next agent — otherwise
+        // two peers briefly edit the shared workspace at once.
         await supervisor.stop(entry.id);
         if (ok && statusOf(hub, entry.id) === 'done') doneIds.push(entry.id);
       }
@@ -267,6 +282,25 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
     unregisterActiveHub(String(ctx.sessionId));
     if (hub) await hub.close();
     releaseCollabLock(String(ctx.sessionId));
+    // Cleanup leaked transient state. integrate() removes the done agents'
+    // worktrees on its happy path, but worktrees/sockets are orphaned on abort,
+    // 0-done, conflict, or any early return. Worktrees are throwaway working
+    // dirs (the branch keeps the commits), so removing them is always safe;
+    // git branches are intentionally left to integrate()'s conflict-aware logic.
+    for (const wt of worktrees.values()) {
+      await removeWorktree(cwd, wt).catch(() => undefined);
+    }
+    // Drop the transient socket dir; the durable run record is archived
+    // elsewhere (see the archive step), not here.
+    try {
+      rmSync(collabRunDir(runId), { recursive: true, force: true });
+      rmSync(worktreeRoot(runId), { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+    // Prune any worktree metadata left dangling by a hard-deleted dir (e.g. an
+    // integrate staging worktree that never reached its own removeWorktree).
+    if (worktrees.size > 0) await git(cwd, ['worktree', 'prune']).catch(() => undefined);
   }
 }
 
@@ -314,39 +348,101 @@ function slug(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 32);
 }
 
-function statusOf(hub: { state: { rosterView(): { agents: ReadonlyArray<{ id: string; status: string }> } } }, id: string): string | undefined {
+type HubLike = { state: { rosterView(): { agents: ReadonlyArray<{ id: string; status: string }> } } };
+type ExitProbe = Pick<Supervisor, 'hasExited'> | null;
+
+function statusOf(hub: HubLike, id: string): string | undefined {
   return hub.state.rosterView().agents.find((a) => a.id === id)?.status;
 }
 
-/** Poll until an agent is terminal (done/crashed/killed) or abort/timeout. Returns true iff done. */
+/**
+ * Has an agent reached a state we should stop waiting on? Returns 'done' (it
+ * finished cleanly), 'failed' (terminal but not done — crashed/killed/failed, OR
+ * its process exited with no terminal status, OR it never registered within the
+ * boot window), or undefined (still in flight). `connected` records which ids
+ * have registered so the boot deadline only applies before registration.
+ */
+function agentSettled(
+  hub: HubLike,
+  supervisor: ExitProbe,
+  id: string,
+  connected: Set<string>,
+  bootDeadlineAt: number,
+): 'done' | 'failed' | undefined {
+  const status = statusOf(hub, id);
+  if (status && status !== 'pending') connected.add(id); // any reported status ⇒ registered
+  if (status === 'done') return 'done';
+  if (status === 'failed' || status === 'crashed' || status === 'killed') return 'failed';
+  // Process gone but no terminal status: died before reporting, or the spawn
+  // itself failed (the supervisor's 'error'/'exit' handlers set hasExited).
+  if (supervisor?.hasExited(id)) return 'failed';
+  // Never registered within the boot window ⇒ it failed to come up.
+  if (!connected.has(id) && Date.now() > bootDeadlineAt) return 'failed';
+  return undefined;
+}
+
+/** Poll until an agent settles (done/failed) or abort/wall-clock. Returns true iff done. */
 async function waitForAgent(
-  hub: { state: { rosterView(): { agents: ReadonlyArray<{ id: string; status: string }> } } },
+  hub: HubLike,
+  supervisor: ExitProbe,
   id: string,
   signal: AbortSignal,
-  timeoutMs: number,
+  wallClockMs: number,
 ): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
+  const wallDeadline = Date.now() + wallClockMs;
+  const bootDeadlineAt = Date.now() + BOOT_DEADLINE_MS;
+  const connected = new Set<string>();
   for (;;) {
-    const status = statusOf(hub, id);
-    if (status === 'done') return true;
-    if (status === 'crashed' || status === 'killed') return false;
-    if (signal.aborted || Date.now() > deadline) return false;
+    const settled = agentSettled(hub, supervisor, id, connected, bootDeadlineAt);
+    if (settled === 'done') return true;
+    if (settled === 'failed') return false;
+    if (signal.aborted || Date.now() > wallDeadline) return false;
     await sleep(POLL_MS, signal);
   }
 }
 
 async function waitForAgents(
-  hub: { state: { rosterView(): { agents: ReadonlyArray<{ id: string; status: string }> } } },
+  hub: HubLike,
+  supervisor: ExitProbe,
   ids: ReadonlyArray<string>,
   signal: AbortSignal,
-  timeoutMs: number,
+  wallClockMs: number,
 ): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  const terminal = (s: string | undefined): boolean => s === 'done' || s === 'crashed' || s === 'killed';
+  const wallDeadline = Date.now() + wallClockMs;
+  const bootDeadlineAt = Date.now() + BOOT_DEADLINE_MS;
+  const connected = new Set<string>();
   for (;;) {
-    if (ids.every((id) => terminal(statusOf(hub, id)))) return;
-    if (signal.aborted || Date.now() > deadline) return;
+    if (ids.every((id) => agentSettled(hub, supervisor, id, connected, bootDeadlineAt) !== undefined)) return;
+    if (signal.aborted || Date.now() > wallDeadline) return;
     await sleep(POLL_MS, signal);
+  }
+}
+
+/**
+ * After a wait, any agent that isn't 'done' didn't succeed. Make its hub status
+ * terminal (so it frees its file locks + the UI updates) and surface the tail of
+ * its stderr as a `collab_agent_failed` event, so a boot/connect/run failure is
+ * a visible diagnostic instead of a silent gap.
+ */
+async function* surfaceFailures(
+  ctx: ModeContext,
+  hub: CollaborationHub,
+  supervisor: Supervisor,
+  ids: ReadonlyArray<string>,
+): AsyncGenerator<MoxxyEvent, void, unknown> {
+  for (const id of ids) {
+    const status = statusOf(hub, id);
+    if (status === 'done') continue;
+    if (status !== 'failed' && status !== 'crashed' && status !== 'killed') {
+      hub.state.setStatus(id, 'crashed', 'did not reach a terminal status');
+    }
+    yield await ctx.emit(
+      plugin(ctx, 'collab_agent_failed', {
+        id,
+        status: statusOf(hub, id),
+        stderr: supervisor.stderrOf(id).slice(-6),
+      }),
+    );
   }
 }
 

--- a/packages/mode-collaborative/src/peer-process.integration.test.ts
+++ b/packages/mode-collaborative/src/peer-process.integration.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Real-process integration test for the collaboration peer.
+ *
+ * Unlike collab-loop.test.ts (which injects a fake supervisor), this spawns the
+ * REAL `moxxy agent` child against a REAL hub over a unix socket — exercising
+ * the spawn → boot → collab.register → terminal-status path end to end, with NO
+ * LLM (the peer boots provider-less, so its turn ends immediately without
+ * collab_done). It is the regression guard for the "30-minute hang": a peer
+ * whose turn ends without collab_done MUST report a terminal status so the
+ * coordinator stops waiting.
+ *
+ * Guarded: skips when the CLI bundle isn't built (the cli is a *dependent* of
+ * this package, so a topological `^build` doesn't guarantee its dist exists);
+ * runs locally and in any job that builds the cli first.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createCollaborationHub, type CollaborationHub } from '@moxxy/plugin-collab';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CLI_BIN = resolve(HERE, '../../cli/dist/bin.js');
+const itIfBuilt = existsSync(CLI_BIN) ? it : it.skip;
+
+const cleanups: Array<() => void> = [];
+let child: ChildProcess | null = null;
+afterEach(async () => {
+  if (child && child.exitCode === null) {
+    child.kill('SIGKILL');
+  }
+  child = null;
+  for (const fn of cleanups.splice(0)) fn();
+});
+
+function status(hub: CollaborationHub, id: string): string | undefined {
+  return hub.state.rosterView().agents.find((a) => a.id === id)?.status;
+}
+
+async function waitFor(pred: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (pred()) return true;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return pred();
+}
+
+describe('real moxxy agent peer process', () => {
+  itIfBuilt(
+    'spawns, registers with the hub, and reports a terminal status when its turn ends without collab_done',
+    async () => {
+      const runDir = mkdtempSync(join(tmpdir(), 'mc-peerproc-'));
+      const home = mkdtempSync(join(tmpdir(), 'mc-peerproc-home-'));
+      const cwd = mkdtempSync(join(tmpdir(), 'mc-peerproc-wt-'));
+      cleanups.push(() => {
+        for (const d of [runDir, home, cwd]) rmSync(d, { recursive: true, force: true });
+      });
+
+      const hub = await createCollaborationHub({
+        socketPath: join(runDir, 'hub.sock'),
+        task: 'integration probe',
+        roster: [{ id: 'probe', name: 'Probe', role: 'implementer', subtask: 'noop' }],
+      });
+      cleanups.push(() => void hub.close());
+
+      child = spawn(process.execPath, [CLI_BIN, 'agent'], {
+        cwd,
+        env: {
+          ...process.env,
+          MOXXY_HOME: home, // isolate from the developer's real ~/.moxxy + providers
+          MOXXY_COLLAB_HUB: hub.socketPath,
+          MOXXY_COLLAB_AGENT_ID: 'probe',
+          MOXXY_COLLAB_ROLE: 'implementer',
+          MOXXY_COLLAB_SUBTASK: 'noop probe',
+          MOXXY_COLLAB_PARENT_TASK: 'integration probe',
+          MOXXY_SESSION_ID: 'probe::probe',
+          MOXXY_MODE: 'collab-peer',
+        },
+        stdio: ['ignore', 'ignore', 'pipe'],
+      });
+
+      // 1) The real child boots and registers over the socket.
+      const registered = await waitFor(() => {
+        const s = status(hub, 'probe');
+        return s !== undefined && s !== 'pending';
+      }, 30_000);
+      expect(registered, `agent never registered (status=${status(hub, 'probe')})`).toBe(true);
+
+      // 2) Its provider-less turn ends without collab_done, so it must report a
+      //    terminal status ('failed') instead of idling as 'connected' forever.
+      const settled = await waitFor(() => {
+        const s = status(hub, 'probe');
+        return s === 'failed' || s === 'done' || s === 'crashed';
+      }, 30_000);
+      expect(settled, `agent never reached a terminal status (status=${status(hub, 'probe')})`).toBe(
+        true,
+      );
+      expect(['failed', 'crashed']).toContain(status(hub, 'probe'));
+    },
+    70_000,
+  );
+});

--- a/packages/mode-collaborative/src/peer-supervisor.ts
+++ b/packages/mode-collaborative/src/peer-supervisor.ts
@@ -39,6 +39,10 @@ export interface Supervisor {
   stop(agentId: string): Promise<void>;
   shutdownAll(reason?: string): Promise<void>;
   stderrOf(agentId: string): ReadonlyArray<string>;
+  /** True once the child process has exited (cleanly, by signal, or because the
+   *  spawn itself failed). Lets the coordinator fail fast instead of polling the
+   *  wall-clock for an agent whose process is already gone. */
+  hasExited(agentId: string): boolean;
 }
 
 interface PeerProc {
@@ -95,7 +99,24 @@ export class PeerSupervisor implements Supervisor {
     child.on('exit', () => {
       proc.exited = true;
     });
+    // A failed spawn (bad path, ENOENT — plausible when re-invoking the CLI
+    // under a packaged/Electron host) emits 'error'; with NO listener Node
+    // re-throws it as an uncaught exception that takes down the whole
+    // coordinator/runner. Capture it as a normal exit + stderr line so the
+    // coordinator surfaces it and fails fast instead of crashing.
+    child.on('error', (err: Error) => {
+      proc.exited = true;
+      proc.stderr.push(`spawn error: ${err.message}`);
+    });
     return { socket };
+  }
+
+  /** True once the child has exited or its spawn failed. */
+  hasExited(agentId: string): boolean {
+    const proc = this.peers.get(agentId);
+    // No entry → never spawned (treat as not-exited); a tracked proc reports
+    // its real exit/spawn-failure state.
+    return proc ? proc.exited : false;
   }
 
   /** Last stderr lines from a peer — used to diagnose a crash. */
@@ -103,7 +124,9 @@ export class PeerSupervisor implements Supervisor {
     return this.peers.get(agentId)?.stderr ?? [];
   }
 
-  /** Best-effort: abort a single peer's in-flight turn via its runner, then kill. */
+  /** Stop a single peer and AWAIT its real exit (with a force-kill fallback), so
+   *  callers — e.g. the sequential fallback — can rely on the workspace being
+   *  free before the next agent starts. */
   async stop(agentId: string): Promise<void> {
     const proc = this.peers.get(agentId);
     if (!proc || proc.exited) return;
@@ -112,6 +135,26 @@ export class PeerSupervisor implements Supervisor {
     } catch {
       // already gone
     }
+    await new Promise<void>((resolve) => {
+      if (proc.exited) return resolve();
+      let settled = false;
+      const done = (): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      proc.child.once('exit', done);
+      const timer = setTimeout(() => {
+        try {
+          proc.child.kill('SIGKILL');
+        } catch {
+          // already gone
+        }
+        done();
+      }, FORCE_KILL_GRACE_MS);
+      timer.unref?.();
+    });
   }
 
   async shutdownAll(_reason?: string): Promise<void> {

--- a/packages/plugin-collab/src/client.ts
+++ b/packages/plugin-collab/src/client.ts
@@ -71,7 +71,10 @@ export class CollabHubClient {
   roster(): Promise<RosterView> {
     return this.peer.request(CollabHubMethod.Roster);
   }
-  setStatus(status: 'working' | 'blocked' | 'connected', detail?: string): Promise<{ ok: boolean }> {
+  setStatus(
+    status: 'working' | 'blocked' | 'connected' | 'failed',
+    detail?: string,
+  ): Promise<{ ok: boolean }> {
     return this.peer.request(CollabHubMethod.StatusSet, { status, detail });
   }
   done(summary: string, artifacts?: ReadonlyArray<string>): Promise<{ ok: boolean }> {

--- a/packages/plugin-collab/src/hub-types.ts
+++ b/packages/plugin-collab/src/hub-types.ts
@@ -12,6 +12,7 @@ export type AgentStatus =
   | 'working' // actively running a turn
   | 'blocked' // waiting on a peer / contract decision
   | 'done' // called collab_done
+  | 'failed' // its turn ended (error / iteration-cap / idle) without calling collab_done
   | 'crashed' // process died unexpectedly
   | 'killed'; // shut down by the coordinator
 

--- a/packages/plugin-collab/src/hub.ts
+++ b/packages/plugin-collab/src/hub.ts
@@ -223,10 +223,17 @@ export async function createCollaborationHub(opts: CreateHubOptions): Promise<Co
 
     peer.onClose(() => {
       connections.delete(peer);
-      // A registered agent whose link dropped before finishing crashed.
+      // A registered agent whose link dropped before reaching a terminal status
+      // crashed. Don't clobber a status the agent already reported for itself
+      // ('done' / 'failed') or one the coordinator set ('killed').
       if (agentId) {
         const agent = state.rosterView().agents.find((a) => a.id === agentId);
-        if (agent && agent.status !== 'done' && agent.status !== 'killed') {
+        if (
+          agent &&
+          agent.status !== 'done' &&
+          agent.status !== 'failed' &&
+          agent.status !== 'killed'
+        ) {
           state.setStatus(agentId, 'crashed');
         }
       }

--- a/packages/plugin-collab/src/state.test.ts
+++ b/packages/plugin-collab/src/state.test.ts
@@ -76,6 +76,16 @@ describe('board file locks', () => {
     expect(events.some((e) => e.kind === 'board' && e.action === 'claim')).toBe(true);
   });
 
+  it('frees a failed agent\'s locks so survivors can claim its paths', () => {
+    const { state, events } = mkState();
+    expect(state.boardClaim('backend', ['src/api']).ok).toBe(true);
+    // backend's turn ended without collab_done → reported 'failed'.
+    state.setStatus('backend', 'failed', 'turn ended without calling collab_done');
+    // its exclusive lease is released (like a crash), so a survivor can take over.
+    expect(state.boardClaim('tests', ['src/api/routes.ts']).ok).toBe(true);
+    expect(events.some((e) => e.kind === 'board' && e.action === 'release')).toBe(true);
+  });
+
   it('does not let a non-owner release another agent\'s claim by id', () => {
     const { state } = mkState();
     const claim = state.boardClaim('backend', ['src/api']);

--- a/packages/plugin-collab/src/state.ts
+++ b/packages/plugin-collab/src/state.ts
@@ -108,10 +108,10 @@ export class CollaborationState {
     if (agent.status === status) return;
     agent.status = status;
     this.emitFn({ kind: 'agent_status', agentId, status, ...(detail ? { detail } : {}) });
-    // A dead agent can never release its own locks, so do it for it — otherwise
-    // its leases block every survivor forever (conflictingOwner only frees
-    // 'done' items, not abandoned ones).
-    if (status === 'crashed' || status === 'killed') this.releaseAllFor(agentId);
+    // A dead/failed agent can never release its own locks, so do it for it —
+    // otherwise its leases block every survivor forever (conflictingOwner only
+    // frees 'done' items, not abandoned ones).
+    if (status === 'crashed' || status === 'killed' || status === 'failed') this.releaseAllFor(agentId);
   }
 
   markDone(agentId: string, summary: string, artifacts?: ReadonlyArray<string>): void {
@@ -126,7 +126,7 @@ export class CollaborationState {
   allDone(): boolean {
     const live = this.agentOrder
       .map((id) => this.agents.get(id)!)
-      .filter((a) => a.status !== 'crashed' && a.status !== 'killed');
+      .filter((a) => a.status !== 'crashed' && a.status !== 'killed' && a.status !== 'failed');
     return live.length > 0 && live.every((a) => a.status === 'done');
   }
 


### PR DESCRIPTION
## Why

I audited agentic-collaborative mode (5-lane parallel audit + adversarial verification — full report in `.claude/audits/COLLAB_AUDIT_2026-06-18.md`). The headline "it seems broken" experience traces to three concrete defects on the non-happy path. This is **PR 1 of a series**: the engine "make it work" foundation.

## What broke

1. **30-minute hang (critical).** A spawned agent only reported a terminal hub status when it called `collab_done`. Every other way a turn ends (provider error, iteration cap, idle, stuck-loop, missing key) left the process idling as `connected` with its socket open, so the hub never marked it crashed and the coordinator polled the full `wallClockMs` (30 min) before giving up. One bad peer froze the whole run.
2. **Coordinator crash on a bad spawn (high).** `spawn()` had no `'error'` listener — a failed spawn became an uncaught exception that took down the coordinator/runner.
3. **Worktree / run-dir leaks (high).** Cleanup only happened inside `integrate()`'s happy path, so worktrees + the socket dir leaked on abort, 0-done, conflict, or any early return (confirmed: orphaned empty run dirs under `~/.moxxy/collab/`).

## The fix

- New terminal **`failed`** agent status; a peer reports it when its turn ends without `collab_done` (in `moxxy agent`, after the turn drains). A `failed` agent releases its file locks like a crash.
- Coordinator gains a short **boot deadline** (90s to register) separate from the wall-clock, and `waitFor*` now react to an observed child exit via a new `Supervisor.hasExited()` — so boot/connect failures fail fast. Failures are surfaced as a `collab_agent_failed` event carrying the stderr tail (no more silent gap).
- `spawn()` gets an `'error'` handler (captured as a normal exit + diagnostic).
- `finally` cleans up worktrees + the run socket dir on every path; the sequential fallback now **awaits a peer's real exit** before starting the next (no two writers in the shared workspace).
- Agents self-report **`working`** while a turn runs (the status was previously dead).

## Tests

- `collab-loop.test.ts`: a fail-fast case — one agent never finishes; the run completes in ~1s (not 30 min), surfaces `collab_agent_failed`, and still integrates the healthy agent.
- `peer-process.integration.test.ts`: **real-process** test — spawns the actual `moxxy agent` binary against a real hub and asserts it registers and reports a terminal status when its turn ends without `collab_done`. No LLM; ~0.5s; skips if the CLI bundle isn't built.
- `state.test.ts`: a `failed` agent frees its locks.

Build / typecheck / lint / test / check:deps all green locally.

Follow-up PRs (context brief, archive/history, lifecycle "End & archive", observability UI, dynamic roles) build on this.