### PR TITLE
feat(collaborative): give every agent the whole goal + conversation, not just its subtask

### DIFF
--- a/.changeset/collab-context-brief.md
+++ b/.changeset/collab-context-brief.md
@@ -1,0 +1,26 @@
+---
+"@moxxy/mode-collaborative": minor
+"@moxxy/cli": patch
+---
+
+feat(collaborative): give every agent the whole goal + the conversation, not just its subtask
+
+Spawned agents booted fresh sessions seeded with only their one-line subtask, so
+they never saw the overall goal or the dialogue that produced it — and the
+`MOXXY_COLLAB_PARENT_TASK` env the coordinator already set was read nowhere.
+
+- The coordinator now distils the user's conversation into a compact, token-
+  capped **`.moxxy-collab/BRIEF.md`** (goal + recent intent) and writes it into
+  the scaffold before the architect runs, so it's committed into every worktree
+  (parallel) or present in the shared dir (sequential) — the whole team inherits
+  the real intent.
+- `moxxy agent` now reads `MOXXY_COLLAB_PARENT_TASK` and seeds each implementer's
+  first turn with the overall goal + its sub-task + a pointer to the brief and
+  contracts (the architect, whose sub-task already is the goal, just gets the
+  pointer).
+- The shared agent prompt now tells every agent to read the brief first and to
+  `recall()` prior knowledge + `memory_save` durable facts — so the team builds
+  memory/recall for the larger work.
+
+The brief is a pure, unit-tested digest (most-recent turns, clipped, total-
+capped) so a long conversation still yields a small file.

--- a/packages/cli/src/commands/agent.test.ts
+++ b/packages/cli/src/commands/agent.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { buildSeedTurn } from './agent.js';
+
+describe('buildSeedTurn', () => {
+  it('frames an implementer with the overall goal, its sub-task, and the brief pointer', () => {
+    const turn = buildSeedTurn({
+      role: 'implementer',
+      parentTask: 'Build a documentation site',
+      subtask: 'Write the API reference page',
+    });
+    expect(turn).toContain('Overall team goal: Build a documentation site');
+    expect(turn).toContain('Your sub-task: Write the API reference page');
+    expect(turn).toContain('.moxxy-collab/BRIEF.md');
+    expect(turn).toContain('.moxxy-collab/CONTRACTS.md');
+  });
+
+  it('does not duplicate the goal for the architect (whose sub-task IS the goal)', () => {
+    const turn = buildSeedTurn({
+      role: 'architect',
+      parentTask: 'Build a documentation site',
+      subtask: 'Build a documentation site',
+    });
+    expect(turn).not.toContain('Overall team goal:');
+    expect(turn).toContain('Build a documentation site');
+    expect(turn).toContain('.moxxy-collab/BRIEF.md');
+  });
+
+  it('falls back to just the pointer when there is no sub-task text', () => {
+    const turn = buildSeedTurn({ role: 'implementer', parentTask: '', subtask: '' });
+    expect(turn).toContain('.moxxy-collab/BRIEF.md');
+    expect(turn).not.toContain('Your sub-task:');
+  });
+});

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -27,7 +27,17 @@ export async function runAgentCommand(argv: ParsedArgv): Promise<number> {
   const sessionId = process.env.MOXXY_SESSION_ID?.trim();
   const mode = process.env.MOXXY_MODE?.trim() || 'collab-peer';
   const subtask = process.env.MOXXY_COLLAB_SUBTASK ?? '';
+  const parentTask = process.env.MOXXY_COLLAB_PARENT_TASK?.trim() ?? '';
+  const role = process.env.MOXXY_COLLAB_ROLE?.trim() ?? '';
   const model = process.env.MOXXY_MODEL?.trim();
+
+  // Seed the turn with the WHOLE picture, not just this agent's narrow subtask:
+  // the overall team goal (previously plumbed into the env but never read) plus a
+  // pointer to the shared brief + contracts the coordinator/architect wrote. An
+  // implementer that knows the real goal builds the right thing instead of
+  // guessing from a one-line task. The architect's subtask already IS the goal,
+  // so it just gets the brief pointer.
+  const seededTurn = buildSeedTurn({ role, parentTask, subtask });
 
   const setup = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
@@ -59,7 +69,7 @@ export async function runAgentCommand(argv: ParsedArgv): Promise<number> {
   // Drive the sub-task turn (autonomous loop). Errors surface on the event log.
   const turnDone = (async () => {
     try {
-      for await (const _ of session.runTurn(subtask)) void _;
+      for await (const _ of session.runTurn(seededTurn)) void _;
     } catch {
       // the loop already emitted an error event
     }
@@ -85,6 +95,25 @@ export async function runAgentCommand(argv: ParsedArgv): Promise<number> {
 
   await runUntilSignal(runnerServer, session, turnDone);
   return 0;
+}
+
+/**
+ * Compose the first-turn prompt for a collaboration agent. The architect's
+ * subtask already is the full goal, so it only needs the brief pointer; an
+ * implementer is framed with the overall goal first, then its slice, then where
+ * to find the shared context. The pointer is cheap (one line) and the agent only
+ * pays for the brief's tokens if it actually reads the file.
+ */
+export function buildSeedTurn(args: { role: string; parentTask: string; subtask: string }): string {
+  const { role, parentTask, subtask } = args;
+  const pointer =
+    'Shared team context is in `.moxxy-collab/BRIEF.md` (the user\'s overall goal + ' +
+    'the conversation/intent) and `.moxxy-collab/CONTRACTS.md` (the agreed interfaces). ' +
+    'Read them before you start so your work fits the real goal.';
+  if (role === 'architect' || !parentTask || parentTask === subtask) {
+    return subtask ? `${subtask}\n\n${pointer}` : pointer;
+  }
+  return `Overall team goal: ${parentTask}\n\nYour sub-task: ${subtask}\n\n${pointer}`;
 }
 
 async function runUntilSignal(

--- a/packages/mode-collaborative/src/brief.test.ts
+++ b/packages/mode-collaborative/src/brief.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { buildBrief, digestTurns } from './brief.js';
+
+const ev = (o: Record<string, unknown>): unknown => o;
+
+describe('digestTurns', () => {
+  it('extracts user prompts and model assistant messages, in order', () => {
+    const turns = digestTurns([
+      ev({ type: 'user_prompt', text: 'build a blog' }),
+      ev({ type: 'assistant_message', source: 'model', content: 'sure, what stack?' }),
+      ev({ type: 'assistant_message', source: 'system', content: 'IGNORE system msg' }),
+      ev({ type: 'provider_request' }),
+      ev({ type: 'user_prompt', text: 'next.js please' }),
+    ]);
+    expect(turns).toEqual([
+      { role: 'user', text: 'build a blog' },
+      { role: 'assistant', text: 'sure, what stack?' },
+      { role: 'user', text: 'next.js please' },
+    ]);
+  });
+});
+
+describe('buildBrief', () => {
+  it('always includes the goal', () => {
+    const brief = buildBrief('Ship the onboarding flow', []);
+    expect(brief).toContain('# Collaboration brief');
+    expect(brief).toContain('## Goal');
+    expect(brief).toContain('Ship the onboarding flow');
+  });
+
+  it('includes the conversation but does not repeat the goal as the last user turn', () => {
+    const brief = buildBrief('next.js please', [
+      ev({ type: 'user_prompt', text: 'build a blog' }),
+      ev({ type: 'assistant_message', source: 'model', content: 'what stack?' }),
+      ev({ type: 'user_prompt', text: 'next.js please' }),
+    ]);
+    expect(brief).toContain('## Conversation so far');
+    expect(brief).toContain('build a blog');
+    expect(brief).toContain('what stack?');
+    // the trailing user turn equals the goal → not duplicated in the conversation
+    expect(brief.match(/next\.js please/g)?.length).toBe(1);
+  });
+
+  it('keeps only the most recent turns (window)', () => {
+    const events = Array.from({ length: 40 }, (_, i) =>
+      ev({ type: 'user_prompt', text: `[i=${i}] short message` }),
+    );
+    const brief = buildBrief('goal', events);
+    // last 12 turns survive; older ones are dropped
+    expect(brief).toContain('[i=39]');
+    expect(brief).toContain('[i=28]');
+    expect(brief).not.toContain('[i=10]');
+  });
+
+  it('caps total size even for a huge conversation', () => {
+    const huge = 'x'.repeat(5000);
+    const events = Array.from({ length: 40 }, () => ev({ type: 'user_prompt', text: huge }));
+    const brief = buildBrief('goal', events);
+    expect(brief.length).toBeLessThanOrEqual(6001);
+  });
+});

--- a/packages/mode-collaborative/src/brief.ts
+++ b/packages/mode-collaborative/src/brief.ts
@@ -1,0 +1,89 @@
+/**
+ * The collaboration BRIEF — a compact, token-efficient digest of the user's
+ * conversation that the coordinator writes into the scaffold (`.moxxy-collab/
+ * BRIEF.md`) so EVERY spawned agent inherits the overall goal + intent, not just
+ * its one-line subtask. Without it, peers boot fresh sessions that have never
+ * seen the dialogue, clarifications, or constraints that produced the task.
+ *
+ * Kept a pure function over the event log so it is unit-testable and cheap: it
+ * distills (not dumps) — the most recent turns, each clipped — to stay well
+ * under a few KB regardless of how long the conversation ran.
+ */
+
+/** How many recent user/assistant turns to include. */
+const MAX_TURNS = 12;
+/** Per-message clip (chars) — enough to convey intent, not the whole turn. */
+const MAX_MSG_CHARS = 600;
+/** Overall cap (chars) so a huge conversation still yields a small brief. */
+const MAX_TOTAL_CHARS = 6000;
+
+interface DigestTurn {
+  readonly role: 'user' | 'assistant';
+  readonly text: string;
+}
+
+function clip(s: string, n: number): string {
+  const t = s.trim().replace(/\s+/g, ' ');
+  return t.length > n ? `${t.slice(0, n - 1)}…` : t;
+}
+
+/** Pull the user/assistant turns out of the raw event log, in order. */
+export function digestTurns(events: ReadonlyArray<unknown>): DigestTurn[] {
+  const out: DigestTurn[] = [];
+  for (const raw of events) {
+    const e = raw as { type?: string; text?: string; content?: string; source?: string };
+    if (e.type === 'user_prompt' && typeof e.text === 'string' && e.text.trim()) {
+      out.push({ role: 'user', text: e.text });
+    } else if (
+      e.type === 'assistant_message' &&
+      e.source === 'model' &&
+      typeof e.content === 'string' &&
+      e.content.trim()
+    ) {
+      out.push({ role: 'assistant', text: e.content });
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the markdown brief. `task` is the headline goal (the last user prompt);
+ * `events` is the coordinator's event log (`ctx.log.slice()`). The result is the
+ * goal plus the tail of the conversation, clipped and total-capped.
+ */
+export function buildBrief(task: string, events: ReadonlyArray<unknown>): string {
+  const turns = digestTurns(events);
+  // The headline goal is already `task`; avoid repeating the identical last user
+  // turn in the conversation section.
+  const trimmed =
+    turns.length > 0 && turns[turns.length - 1]!.role === 'user' && turns[turns.length - 1]!.text.trim() === task.trim()
+      ? turns.slice(0, -1)
+      : turns;
+  const recent = trimmed.slice(-MAX_TURNS);
+
+  const lines: string[] = [
+    '# Collaboration brief',
+    '',
+    'This is the shared context for the whole team. It is the user\'s goal and the',
+    'conversation that led to it — read it before planning so your work fits the',
+    'real intent, not just your narrow sub-task.',
+    '',
+    '## Goal',
+    '',
+    clip(task, 1500) || '(no goal text)',
+  ];
+
+  if (recent.length > 0) {
+    lines.push('', '## Conversation so far', '');
+    for (const t of recent) {
+      const who = t.role === 'user' ? 'User' : 'Assistant';
+      lines.push(`- **${who}:** ${clip(t.text, MAX_MSG_CHARS)}`);
+    }
+  }
+
+  let brief = lines.join('\n');
+  if (brief.length > MAX_TOTAL_CHARS) {
+    brief = `${brief.slice(0, MAX_TOTAL_CHARS - 1)}…`;
+  }
+  return `${brief}\n`;
+}

--- a/packages/mode-collaborative/src/collab-loop.test.ts
+++ b/packages/mode-collaborative/src/collab-loop.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { getEventListeners } from 'node:events';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -158,6 +158,11 @@ describe('collaborative coordinator (end-to-end, fake agents + real git)', () =>
     expect(existsSync(join(repo, 'api.test.ts'))).toBe(true);
     // the agreed contracts landed too
     expect(existsSync(join(repo, '.moxxy-collab', 'CONTRACTS.md'))).toBe(true);
+    // the coordinator distilled a shared brief (goal + intent) into the scaffold
+    const briefPath = join(repo, '.moxxy-collab', 'BRIEF.md');
+    expect(existsSync(briefPath)).toBe(true);
+    expect(readFileSync(briefPath, 'utf8')).toContain('build the thing');
+    expect(subtypes).toContain('collab_brief_written');
 
     // final synthesis names both agents
     const finalMsg = events.filter((e) => e.type === 'assistant_message').pop() as { content: string } | undefined;

--- a/packages/mode-collaborative/src/collab-loop.ts
+++ b/packages/mode-collaborative/src/collab-loop.ts
@@ -7,7 +7,7 @@
  * the UI, integrates the work, and synthesizes the result.
  */
 
-import { mkdirSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync, existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import type { ModeContext, MoxxyEvent } from '@moxxy/sdk';
 import {
@@ -23,6 +23,7 @@ import {
   COLLAB_PEER_MODE_NAME,
   COLLAB_PLUGIN_ID,
   COLLAB_SCAFFOLD_DIR,
+  BRIEF_FILENAME,
   ROSTER_FILENAME,
   collabBranch,
   collabRunDir,
@@ -32,6 +33,7 @@ import {
   worktreeRoot,
 } from './constants.js';
 import { resolveCollabConfig, type CollabConfig } from './config.js';
+import { buildBrief } from './brief.js';
 import {
   addWorktree,
   commitAll,
@@ -152,6 +154,19 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
   supervisor = (deps.createSupervisor ?? ((o) => new PeerSupervisor(o)))(supervisorOpts, hub);
 
     yield await ctx.emit(plugin(ctx, 'collab_started', { task, parallel, gitInstalled, gitRepo }));
+
+    // Distil the user's conversation into a shared BRIEF the whole team inherits
+    // (the overall goal + intent — not just each agent's narrow subtask). Written
+    // into the scaffold up front so the architect reads it, and committed with the
+    // scaffold (parallel) so every worktree gets it. Best-effort: a brief-write
+    // failure must never sink the run.
+    try {
+      mkdirSync(join(cwd, COLLAB_SCAFFOLD_DIR), { recursive: true });
+      writeFileSync(join(cwd, COLLAB_SCAFFOLD_DIR, BRIEF_FILENAME), buildBrief(task, ctx.log.slice()));
+      yield await ctx.emit(plugin(ctx, 'collab_brief_written', { path: join(COLLAB_SCAFFOLD_DIR, BRIEF_FILENAME) }));
+    } catch {
+      // brief is an enhancement, not a prerequisite
+    }
 
     // --- Phase 0: architect designs the plan + contracts (runs in cwd) ---
     supervisor.spawn({ entry: architectEntry, cwd, mode: COLLAB_ARCHITECT_MODE_NAME });

--- a/packages/mode-collaborative/src/constants.ts
+++ b/packages/mode-collaborative/src/constants.ts
@@ -18,6 +18,9 @@ export const COLLAB_SCAFFOLD_DIR = '.moxxy-collab';
 export const CONTRACTS_FILENAME = 'CONTRACTS.md';
 /** Architect's machine-readable roster proposal, read by the coordinator. */
 export const ROSTER_FILENAME = 'roster.json';
+/** Coordinator-written brief: the overall goal + the user's conversation/intent,
+ *  so every spawned agent inherits the full picture (not just its subtask). */
+export const BRIEF_FILENAME = 'BRIEF.md';
 
 /** A short, filesystem-safe run id from the session + turn ids. */
 export function collabRunId(sessionId: string, turnId: string): string {

--- a/packages/mode-collaborative/src/prompts.ts
+++ b/packages/mode-collaborative/src/prompts.ts
@@ -4,10 +4,14 @@
  * contracts + roster) from an implementer (build to contracts, coordinate).
  */
 
-import { COLLAB_SCAFFOLD_DIR, CONTRACTS_FILENAME, ROSTER_FILENAME } from './constants.js';
+import { BRIEF_FILENAME, COLLAB_SCAFFOLD_DIR, CONTRACTS_FILENAME, ROSTER_FILENAME } from './constants.js';
 
 /** Shared rules every collaborating agent follows. */
-const COLLAB_COMMON = `You are one agent on a TEAM of separate agents collaborating on one task in a shared codebase. You are a peer, not in charge — you cooperate.
+const COLLAB_COMMON = `You are one agent on a TEAM of separate agents collaborating on one task in a shared workspace. You are a peer, not in charge — you cooperate.
+
+Know the WHOLE picture before you act:
+- ${COLLAB_SCAFFOLD_DIR}/${BRIEF_FILENAME} is the shared brief — the user's overall goal and the conversation/intent behind it. Read it FIRST so your work serves the real goal, not just the literal words of your sub-task.
+- Before planning, recall() any relevant prior knowledge about this workspace/task. When you discover a durable fact (a decision, a gotcha, an interface, a convention), memory_save it so the team — and future work — keeps it.
 
 The team coordinates through a shared hub (use these tools):
 - collab_roster — who is on the team, their roles, sub-tasks, and status.
@@ -27,12 +31,13 @@ Cooperation rules:
 
 export const COLLAB_PEER_PROMPT = `${COLLAB_COMMON}
 
-You are an IMPLEMENTER. Your sub-task is provided. Start by reading ${COLLAB_SCAFFOLD_DIR}/${CONTRACTS_FILENAME} and calling collab_contracts, collab_roster, and collab_board so you know the plan and who owns what. Claim your files, implement against the contracts, coordinate on intersections, then call collab_done.`;
+You are an IMPLEMENTER. Your sub-task is provided. Start by reading ${COLLAB_SCAFFOLD_DIR}/${BRIEF_FILENAME} (the goal + intent) and ${COLLAB_SCAFFOLD_DIR}/${CONTRACTS_FILENAME}, and calling collab_contracts, collab_roster, and collab_board so you know the plan and who owns what. Claim your files, implement against the contracts, coordinate on intersections, then call collab_done.`;
 
 export const COLLAB_ARCHITECT_PROMPT = `${COLLAB_COMMON}
 
 You are the ARCHITECT — you run FIRST and set the team up for success. Your job, in order:
-1. Explore the codebase to understand the task and its boundaries.
+0. Read ${COLLAB_SCAFFOLD_DIR}/${BRIEF_FILENAME} — the user's goal and the conversation behind it — so you decompose toward what they actually want.
+1. Explore the workspace to understand the task and its boundaries.
 2. Decompose the task into INDEPENDENT sub-tasks with DISJOINT file ownership (minimize overlap so agents rarely touch the same files).
 3. Define the shared CONTRACTS — the interfaces, types, API shapes, and module boundaries where the implementers' work meets. Publish each with collab_contract_publish (give an owner + consumers).
 4. Write two files into the repo:


### PR DESCRIPTION
## Why

**PR 2 of the collaborative-mode series** (follows #275). The audit's #1 user-facing gap: spawned agents boot fresh sessions seeded with only their one-line `subtask`, so they never see the overall goal or the conversation that produced it. The `MOXXY_COLLAB_PARENT_TASK` env the coordinator already set was **read nowhere** (dead code). Result: implementers guess at intent and re-derive everything.

This is the "agents need the whole workspace **and the messages**, to build memory/recall" ask. Workspace *files* were already fine (worktree checkout); **intent + conversation** were the gap.

## What changed

- **Shared brief.** The coordinator distils the user's conversation (`ctx.log`) into a compact, token-capped **`.moxxy-collab/BRIEF.md`** (goal + most-recent intent, each clipped, total ≤ ~6 KB) and writes it into the scaffold *before the architect runs*. In parallel mode it's committed → inherited by every worktree; in sequential mode it sits in the shared dir. The whole team reads the same intent.
- **Revived `PARENT_TASK`.** `moxxy agent` now reads it and seeds each implementer's first turn with `Overall team goal … / Your sub-task … / read BRIEF.md + CONTRACTS.md`. The architect (whose sub-task already *is* the goal) just gets the pointer.
- **Memory for the bigger work.** The shared prompt now tells every agent to read the brief first and to `recall()` prior knowledge + `memory_save` durable facts (decisions, gotchas, interfaces). Memory is the global `~/.moxxy/memory`, shared across all peers.

## Tests

- `brief.test.ts`: `digestTurns` + `buildBrief` — extraction, no-goal-duplication, windowing, total-cap.
- `agent.test.ts`: `buildSeedTurn` — implementer framing, architect de-dup, empty fallback.
- `collab-loop.test.ts`: asserts `BRIEF.md` is written into the scaffold (contains the goal) and `collab_brief_written` fires.

Build / typecheck / lint / test / check:deps green locally.

Next: archive/history + lifecycle "End & archive current", then the observability UI (agent details, tasks modal, files/deliverables, message-feed redesign).