### PR TITLE
feat(collaborative): run archive/history + always-available "End & archive"

### DIFF
--- a/.changeset/collab-archive-lifecycle.md
+++ b/.changeset/collab-archive-lifecycle.md
@@ -1,0 +1,32 @@
+---
+"@moxxy/mode-collaborative": minor
+"@moxxy/desktop-ipc-contract": minor
+"@moxxy/desktop-host": minor
+"@moxxy/desktop": minor
+---
+
+feat(collaborative): run archive/history + an always-available "End & archive"
+
+Two gaps the user hit: a wedged/finished collaboration couldn't be ended (the
+"＋ New" button only appeared once a run had completed, so a stuck run — or a
+stale single-flight lock — left the Collaborate tab with no way forward), and
+there was no record of past runs at all (the transient run dirs were even left
+orphaned).
+
+- **Run archive.** Every run is now persisted as a JSON record under
+  `~/.moxxy/collab/runs/<runId>.json` on EVERY exit path (completed, aborted,
+  failed) — task, brief, roster + per-agent status/summaries, board, contracts,
+  merge result, and timings. New `@moxxy/mode-collaborative` archive API
+  (`listRunRecords` / `readRunRecord` / `writeRunRecord`).
+- **End & archive.** New `collab.end` IPC aborts the coordinator turn (its
+  finally tears the team down + archives) and force-releases the global lock —
+  so a stuck run or a stale lock can always be cleared. New
+  `forceReleaseCollabLock()` + `SessionDriver.abortActiveTurns()`.
+- **History view.** New `collab.history` IPC + a Collaborate-tab History list
+  (outcome, task, agent counts, per-run detail with brief + summaries).
+- The Collaborate header now always offers **End & archive** (while running or
+  while a lock is held) and the "already running" banner gained an inline
+  "end & archive it now" so a wedged run never blocks a fresh start.
+
+Adds archive + force-release + abort tests, and the coordinator e2e test now
+asserts the run is archived.

--- a/apps/desktop/src/collaborate/CollaboratePanel.tsx
+++ b/apps/desktop/src/collaborate/CollaboratePanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { api, useChat } from '@moxxy/client-core';
+import type { CollabRunSummary } from '@moxxy/desktop-ipc-contract';
 import { pairToolEvents } from '@moxxy/chat-model';
 import { Button, Icon } from '@moxxy/desktop-ui';
 import { ViewHeader, ViewSwitcher, type View } from '../shell/ViewHeader';
@@ -38,6 +39,9 @@ export function CollaboratePanel({
   const [goal, setGoal] = useState('');
   const [starting, setStarting] = useState(false);
   const [forceStart, setForceStart] = useState(false);
+  const [ending, setEnding] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
+  const [history, setHistory] = useState<CollabRunSummary[] | null>(null);
   const [globalActive, setGlobalActive] = useState<{ active: boolean; task?: string } | null>(null);
 
   // Poll the global single-flight lock so Start reflects a collaboration running
@@ -85,6 +89,29 @@ export function CollaboratePanel({
     }
   };
 
+  // End the current collaboration for good: aborts the coordinator (its finally
+  // archives the run + cleans up) and force-releases the global lock, so a new
+  // one can start — even if the current run is wedged or the lock is stale.
+  const endCollaboration = async (): Promise<void> => {
+    if (ending) return;
+    setEnding(true);
+    try {
+      await api().invoke('collab.end', { workspaceId });
+      const r = await api().invoke('collab.active').catch(() => null);
+      setGlobalActive(r);
+      setForceStart(true); // drop to the start composer for a fresh run
+    } catch {
+      // best-effort
+    } finally {
+      setEnding(false);
+    }
+  };
+
+  const loadHistory = async (): Promise<void> => {
+    const runs = await api().invoke('collab.history', { limit: 50 }).catch(() => []);
+    setHistory(runs as CollabRunSummary[]);
+  };
+
   const send = async (): Promise<void> => {
     const body = text.trim();
     if (!body) return;
@@ -124,7 +151,32 @@ export function CollaboratePanel({
             : `done · ${collab.agents.filter((a) => a.status === 'done').length}/${collab.agents.length}`}
         </span>
       )}
-      {collab && !running && !forceStart && (
+      <button
+        type="button"
+        onClick={() => {
+          const next = !showHistory;
+          setShowHistory(next);
+          if (next) void loadHistory();
+        }}
+        className="btn-chip"
+        style={{ fontSize: 12, padding: '4px 10px', borderRadius: 8, fontWeight: 600, ...(showHistory ? { color: 'var(--color-primary)' } : {}) }}
+        title="Past collaborations"
+      >
+        History
+      </button>
+      {(running || globalActive?.active) && (
+        <button
+          type="button"
+          onClick={() => void endCollaboration()}
+          disabled={ending}
+          className="btn-chip"
+          style={{ fontSize: 12, padding: '4px 10px', borderRadius: 8, fontWeight: 600, color: 'var(--color-red)' }}
+          title="Stop the team for good and archive this run"
+        >
+          {ending ? 'Ending…' : '■ End & archive'}
+        </button>
+      )}
+      {collab && !running && !forceStart && !globalActive?.active && (
         <button
           type="button"
           onClick={() => setForceStart(true)}
@@ -136,6 +188,15 @@ export function CollaboratePanel({
       )}
     </ViewHeader>
   );
+
+  if (showHistory) {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
+        {header}
+        <CollabHistory runs={history} onClose={() => setShowHistory(false)} />
+      </div>
+    );
+  }
 
   if (!collab || forceStart) {
     return (
@@ -191,7 +252,17 @@ export function CollaboratePanel({
               }}
             >
               A collaboration is already running{globalActive.task ? ` ("${globalActive.task}")` : ''}. Only one
-              runs at a time to save resources — wait for it to finish, then start another.
+              runs at a time to save resources — wait for it to finish, or
+              {' '}
+              <button
+                type="button"
+                onClick={() => void endCollaboration()}
+                disabled={ending}
+                style={{ background: 'none', border: 'none', padding: 0, font: 'inherit', color: 'var(--color-red)', cursor: 'pointer', textDecoration: 'underline' }}
+              >
+                {ending ? 'ending…' : 'end & archive it now'}
+              </button>
+              .
             </div>
           )}
           <StartComposer
@@ -576,5 +647,79 @@ function Kbd({ children }: { readonly children: React.ReactNode }): JSX.Element 
     >
       {children}
     </kbd>
+  );
+}
+
+function outcomeChip(outcome: string): React.CSSProperties {
+  const bg =
+    outcome === 'completed'
+      ? 'var(--color-green)'
+      : outcome === 'aborted'
+        ? 'var(--color-amber)'
+        : 'var(--color-red)';
+  return { fontSize: 10, fontWeight: 700, padding: '1px 7px', borderRadius: 'var(--radius-pill)', color: '#fff', background: bg, flexShrink: 0 };
+}
+
+function whenAgo(ms: number): string {
+  const s = Math.max(0, Math.round((Date.now() - ms) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.round(h / 24)}d ago`;
+}
+
+/** Past-collaborations list, read from the run archive (~/.moxxy/collab/runs). */
+function CollabHistory({ runs, onClose }: { readonly runs: CollabRunSummary[] | null; readonly onClose: () => void }): JSX.Element {
+  const [open, setOpen] = useState<string | null>(null);
+  if (runs === null) {
+    return <div style={{ flex: 1, display: 'grid', placeItems: 'center', color: 'var(--color-text-dim)' }}>Loading history…</div>;
+  }
+  if (runs.length === 0) {
+    return (
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 10, color: 'var(--color-text-dim)' }}>
+        <div style={{ fontSize: 14, fontWeight: 600 }}>No past collaborations yet</div>
+        <button type="button" className="btn-ghost" onClick={onClose} style={{ fontSize: 12.5 }}>← Back</button>
+      </div>
+    );
+  }
+  return (
+    <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '12px 16px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {runs.map((r) => {
+        const isOpen = open === r.runId;
+        return (
+          <div key={r.runId} style={{ border: '1px solid var(--color-card-border)', borderRadius: 10, background: 'var(--color-card-bg)' }}>
+            <button
+              type="button"
+              onClick={() => setOpen(isOpen ? null : r.runId)}
+              style={{ width: '100%', textAlign: 'left', background: 'none', border: 'none', cursor: 'pointer', padding: '10px 12px', display: 'flex', alignItems: 'center', gap: 10 }}
+            >
+              <span style={outcomeChip(r.outcome)}>{r.outcome}</span>
+              <span style={{ flex: 1, minWidth: 0, fontSize: 13, fontWeight: 600, color: 'var(--color-text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.task}</span>
+              <span className="mono" style={{ fontSize: 11, color: 'var(--color-text-dim)', flexShrink: 0 }}>
+                {r.doneCount}/{r.totalCount} · {whenAgo(r.startedAtMs)}
+              </span>
+            </button>
+            {isOpen && (
+              <div style={{ borderTop: '1px solid var(--color-card-border)', padding: '10px 12px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+                <div className="mono" style={{ fontSize: 11, color: 'var(--color-text-dim)' }}>
+                  {r.parallel ? 'parallel' : 'sequential'}
+                  {r.merge ? ` · merged ${r.merge.merged.length}${r.merge.promoted ? ' (promoted)' : ''}${r.merge.conflicts ? ` · ${r.merge.conflicts} conflicts` : ''}` : ''}
+                  {typeof r.messageCount === 'number' ? ` · ${r.messageCount} messages` : ''}
+                </div>
+                {r.agents.map((a) => (
+                  <div key={a.id} style={{ fontSize: 12.5, lineHeight: 1.5 }}>
+                    <span style={{ fontWeight: 600 }}>{a.name}</span>
+                    <span className="mono" style={{ color: 'var(--color-text-dim)' }}> · {a.role} · {a.status}</span>
+                    {a.doneSummary ? <div style={{ color: 'var(--color-text-muted)' }}>{a.doneSummary}</div> : null}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
   );
 }

--- a/packages/desktop-host/src/ipc/session.ts
+++ b/packages/desktop-host/src/ipc/session.ts
@@ -133,6 +133,59 @@ export function registerSessionHandlers(pool: RunnerPool): void {
       return { active: false };
     }
   });
+  handle('collab.end', async ({ workspaceId }) => {
+    // Abort the coordinator turn (its finally tears the team down + archives),
+    // then force-release the global lock so a new collaboration can start —
+    // covering a stale lock from a crashed run whose coordinator is unreachable.
+    const abortedTurns = resolveDriver(pool, workspaceId)?.abortActiveTurns() ?? 0;
+    let clearedTask: string | undefined;
+    try {
+      const { readFileSync, unlinkSync } = await import('node:fs');
+      const { homedir } = await import('node:os');
+      const { join } = await import('node:path');
+      const lockPath = process.env.MOXXY_COLLAB_LOCK || join(homedir(), '.moxxy', 'collab', 'active.lock');
+      try {
+        clearedTask = (JSON.parse(readFileSync(lockPath, 'utf8')) as { task?: string }).task;
+      } catch {
+        // no lock to read
+      }
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        // already gone
+      }
+    } catch {
+      // best-effort
+    }
+    return { ended: true, abortedTurns, ...(clearedTask ? { clearedTask } : {}) };
+  });
+  handle('collab.history', async (args) => {
+    // Read archived run records straight from ~/.moxxy/collab/runs (self-
+    // describing JSON), newest first — no runner round-trip, spans all workspaces.
+    try {
+      const { readFileSync, readdirSync } = await import('node:fs');
+      const { homedir } = await import('node:os');
+      const { join } = await import('node:path');
+      const home = process.env.MOXXY_HOME || join(homedir(), '.moxxy');
+      const dir = join(home, 'collab', 'runs');
+      const limit = args?.limit ?? 50;
+      const records = readdirSync(dir)
+        .filter((f) => f.endsWith('.json'))
+        .map((f) => {
+          try {
+            return JSON.parse(readFileSync(join(dir, f), 'utf8')) as { startedAtMs?: number };
+          } catch {
+            return null;
+          }
+        })
+        .filter((r): r is { startedAtMs?: number } => r !== null)
+        .sort((a, b) => (b.startedAtMs ?? 0) - (a.startedAtMs ?? 0))
+        .slice(0, limit);
+      return records as never;
+    } catch {
+      return [];
+    }
+  });
   handle('session.hasTranscriber', async () => {
     // Voice is wired through the desktop's *in-process* Codex
     // transcriber (mirrors the TUI's self-host setup: same vault,

--- a/packages/desktop-host/src/session-driver.ts
+++ b/packages/desktop-host/src/session-driver.ts
@@ -238,6 +238,18 @@ export class SessionDriver {
     this.turns.get(turnId)?.controller.abort();
   }
 
+  /** Abort every in-flight turn in this workspace without disposing the driver.
+   *  Used by the "End the collaboration" action: the coordinator turn aborts,
+   *  its finally tears the team down + archives, and the workspace stays usable. */
+  abortActiveTurns(): number {
+    let n = 0;
+    for (const turn of this.turns.values()) {
+      turn.controller.abort();
+      n += 1;
+    }
+    return n;
+  }
+
   /** Toggle auto-approve. When on, the permission resolver allows every tool
    *  call without opening the renderer's approval sheet. */
   setAutoApprove(on: boolean): void {

--- a/packages/desktop-ipc-contract/src/commands.ts
+++ b/packages/desktop-ipc-contract/src/commands.ts
@@ -38,6 +38,38 @@ import type { AppInstallStatus, AnonymizerParseResult } from './apps.js';
 
 // ---------- Invokable commands (renderer → main) --------------------------
 
+/** One archived collaboration run (mirrors `@moxxy/mode-collaborative`'s
+ *  CollabRunRecord; the main process reads `~/.moxxy/collab/runs/*.json`). */
+export interface CollabRunSummary {
+  readonly runId: string;
+  readonly task: string;
+  readonly startedAtMs: number;
+  readonly finishedAtMs: number;
+  readonly outcome: 'completed' | 'aborted' | 'failed';
+  readonly parallel: boolean;
+  readonly gitRepo: boolean;
+  readonly agents: ReadonlyArray<{
+    readonly id: string;
+    readonly name: string;
+    readonly role: string;
+    readonly status: string;
+    readonly subtask: string;
+    readonly doneSummary?: string;
+  }>;
+  readonly doneCount: number;
+  readonly totalCount: number;
+  readonly board?: ReadonlyArray<{ readonly id: string; readonly title: string; readonly status: string; readonly owner?: string }>;
+  readonly contracts?: ReadonlyArray<{ readonly id: string; readonly title: string; readonly owner: string; readonly status: string; readonly version: number }>;
+  readonly messageCount?: number;
+  readonly merge?: {
+    readonly merged: ReadonlyArray<string>;
+    readonly promoted: boolean;
+    readonly conflicts: number;
+    readonly stagingBranch?: string;
+  };
+  readonly brief?: string;
+}
+
 /**
  * Every invokable IPC command the renderer can call. The preload
  * surface is built mechanically from this; misnaming a command in the
@@ -247,6 +279,19 @@ export interface IpcCommands {
     readonly task?: string;
     readonly startedAtMs?: number;
   }>;
+  /** End the active collaboration: abort its coordinator turn (whose finally
+   *  tears the team down + archives) and force-release the global single-flight
+   *  lock so a new one can start — even if the holder is a stale/crashed run. */
+  'collab.end': (args: { workspaceId?: string }) => Promise<{
+    readonly ended: boolean;
+    readonly abortedTurns: number;
+    readonly clearedTask?: string;
+  }>;
+  /** Archived past collaborations (newest first), read from
+   *  `~/.moxxy/collab/runs`. Powers the Collaborate tab's run history. */
+  'collab.history': (args?: { limit?: number }) => Promise<
+    ReadonlyArray<CollabRunSummary>
+  >;
   /** Forward an audio blob to the runner's active transcriber.
    *  Audio must be base64-encoded; returns the recognised text. */
   'session.transcribe': (args: {

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -103,7 +103,7 @@ export type {
 export type { IpcEvents } from './events.js';
 
 // ---------- Invokable commands (renderer → main) --------------------------
-export type { IpcCommands, IpcCommandName } from './commands.js';
+export type { IpcCommands, IpcCommandName, CollabRunSummary } from './commands.js';
 
 // ---------- The remote / mobile trust surface -----------------------------
 export { REMOTE_ALLOWED_COMMANDS } from './remote.js';

--- a/packages/mode-collaborative/src/archive.test.ts
+++ b/packages/mode-collaborative/src/archive.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { collabRunsDir, listRunRecords, readRunRecord, writeRunRecord, type CollabRunRecord } from './archive.js';
+
+let home: string;
+const prev = process.env.MOXXY_HOME;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'mc-archive-'));
+  process.env.MOXXY_HOME = home;
+});
+afterEach(() => {
+  if (prev === undefined) delete process.env.MOXXY_HOME;
+  else process.env.MOXXY_HOME = prev;
+  rmSync(home, { recursive: true, force: true });
+});
+
+function rec(over: Partial<CollabRunRecord>): CollabRunRecord {
+  return {
+    runId: 'r1',
+    task: 'build it',
+    startedAtMs: 1000,
+    finishedAtMs: 2000,
+    outcome: 'completed',
+    parallel: true,
+    gitRepo: true,
+    agents: [{ id: 'backend', name: 'Backend', role: 'implementer', status: 'done', subtask: 'api', doneSummary: 'done' }],
+    doneCount: 1,
+    totalCount: 1,
+    board: [],
+    contracts: [],
+    messageCount: 0,
+    ...over,
+  };
+}
+
+describe('run archive', () => {
+  it('writes a record under ~/.moxxy/collab/runs and reads it back', () => {
+    writeRunRecord(rec({ runId: 'abc' }));
+    expect(collabRunsDir()).toBe(join(home, 'collab', 'runs'));
+    const got = readRunRecord('abc');
+    expect(got?.task).toBe('build it');
+    expect(got?.agents[0]?.id).toBe('backend');
+  });
+
+  it('lists runs newest-first and respects the limit', () => {
+    writeRunRecord(rec({ runId: 'old', startedAtMs: 100 }));
+    writeRunRecord(rec({ runId: 'new', startedAtMs: 9000 }));
+    writeRunRecord(rec({ runId: 'mid', startedAtMs: 5000 }));
+    const all = listRunRecords();
+    expect(all.map((r) => r.runId)).toEqual(['new', 'mid', 'old']);
+    expect(listRunRecords(2).map((r) => r.runId)).toEqual(['new', 'mid']);
+  });
+
+  it('skips a corrupt record instead of failing the whole list', () => {
+    writeRunRecord(rec({ runId: 'good' }));
+    writeFileSync(join(collabRunsDir(), 'broken.json'), '{ not json');
+    const all = listRunRecords();
+    expect(all.map((r) => r.runId)).toEqual(['good']);
+  });
+
+  it('returns [] when no archive dir exists', () => {
+    expect(listRunRecords()).toEqual([]);
+    expect(readRunRecord('nope')).toBeNull();
+  });
+});

--- a/packages/mode-collaborative/src/archive.ts
+++ b/packages/mode-collaborative/src/archive.ts
@@ -1,0 +1,99 @@
+/**
+ * Run archive — a durable history of every collaboration.
+ *
+ * Each finished run (completed, aborted, or failed) is written as one JSON
+ * record under `~/.moxxy/collab/runs/<runId>.json`. This is what gives the
+ * Collaborate UI a "past runs" list and lets a user revisit what a team
+ * produced — the transient socket/worktree dirs are cleaned up, but the record
+ * of the run survives. Kept self-describing (plain JSON, no imports needed to
+ * read it) so the desktop can list the directory directly.
+ */
+
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/** `$MOXXY_HOME` or `~/.moxxy` — the single source of truth for the home dir,
+ *  matching `@moxxy/sdk`'s `moxxyHome()` (inlined to avoid an entry-point dep). */
+function moxxyHome(): string {
+  return process.env.MOXXY_HOME ?? join(homedir(), '.moxxy');
+}
+
+export interface CollabRunAgent {
+  readonly id: string;
+  readonly name: string;
+  readonly role: string;
+  readonly status: string;
+  readonly subtask: string;
+  readonly doneSummary?: string;
+}
+
+export interface CollabRunRecord {
+  readonly runId: string;
+  readonly task: string;
+  readonly startedAtMs: number;
+  readonly finishedAtMs: number;
+  /** completed = reached collab_completed; aborted = user/abort; failed = error before completion. */
+  readonly outcome: 'completed' | 'aborted' | 'failed';
+  readonly parallel: boolean;
+  readonly gitRepo: boolean;
+  readonly agents: ReadonlyArray<CollabRunAgent>;
+  readonly doneCount: number;
+  readonly totalCount: number;
+  readonly board: ReadonlyArray<{ id: string; title: string; status: string; owner?: string; paths?: ReadonlyArray<string> }>;
+  readonly contracts: ReadonlyArray<{ id: string; title: string; owner: string; status: string; version: number }>;
+  readonly messageCount: number;
+  readonly merge?: {
+    readonly merged: ReadonlyArray<string>;
+    readonly promoted: boolean;
+    readonly conflicts: number;
+    readonly stagingBranch?: string;
+  };
+  /** The shared brief (goal + intent) the run was seeded with. */
+  readonly brief?: string;
+}
+
+/** `~/.moxxy/collab/runs` — the archive directory. */
+export function collabRunsDir(): string {
+  return join(moxxyHome(), 'collab', 'runs');
+}
+
+/** Persist one run record. Best-effort: never throws (archiving must not sink a run). */
+export function writeRunRecord(rec: CollabRunRecord): void {
+  try {
+    const dir = collabRunsDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${rec.runId}.json`), `${JSON.stringify(rec, null, 2)}\n`);
+  } catch {
+    // archiving is an enhancement, not a prerequisite
+  }
+}
+
+/** All archived runs, newest first (by start time), capped at `limit`. */
+export function listRunRecords(limit = 50): CollabRunRecord[] {
+  let files: string[];
+  try {
+    files = readdirSync(collabRunsDir()).filter((f) => f.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  const out: CollabRunRecord[] = [];
+  for (const f of files) {
+    try {
+      out.push(JSON.parse(readFileSync(join(collabRunsDir(), f), 'utf8')) as CollabRunRecord);
+    } catch {
+      // skip a corrupt record rather than failing the whole list
+    }
+  }
+  out.sort((a, b) => b.startedAtMs - a.startedAtMs);
+  return out.slice(0, limit);
+}
+
+/** One archived run by id, or null. */
+export function readRunRecord(runId: string): CollabRunRecord | null {
+  try {
+    return JSON.parse(readFileSync(join(collabRunsDir(), `${runId}.json`), 'utf8')) as CollabRunRecord;
+  } catch {
+    return null;
+  }
+}

--- a/packages/mode-collaborative/src/collab-lock.test.ts
+++ b/packages/mode-collaborative/src/collab-lock.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { readActiveCollab, releaseCollabLock, tryAcquireCollabLock } from './collab-lock.js';
+import { forceReleaseCollabLock, readActiveCollab, releaseCollabLock, tryAcquireCollabLock } from './collab-lock.js';
 
 let dir: string;
 beforeEach(() => {
@@ -35,6 +35,18 @@ describe('collab single-flight lock', () => {
     expect(readActiveCollab()).toBeNull();
     // now free for another session
     expect(tryAcquireCollabLock({ sessionId: 'B', task: 't2', startedAtMs: 2 }).ok).toBe(true);
+  });
+
+  it('force-releases regardless of holder (the user "End" action)', () => {
+    tryAcquireCollabLock({ sessionId: 'A', task: 'wedged run', startedAtMs: 1 });
+    // a different session can't release it...
+    releaseCollabLock('B');
+    expect(readActiveCollab()?.sessionId).toBe('A');
+    // ...but the explicit force-release clears it and returns the cleared holder
+    const cleared = forceReleaseCollabLock();
+    expect(cleared?.task).toBe('wedged run');
+    expect(readActiveCollab()).toBeNull();
+    expect(tryAcquireCollabLock({ sessionId: 'B', task: 'fresh', startedAtMs: 2 }).ok).toBe(true);
   });
 
   it('reclaims a stale lock whose process is dead', () => {

--- a/packages/mode-collaborative/src/collab-lock.ts
+++ b/packages/mode-collaborative/src/collab-lock.ts
@@ -88,3 +88,20 @@ export function releaseCollabLock(sessionId: string): void {
     }
   }
 }
+
+/**
+ * Force-release the lock regardless of holder. For the user's explicit "End the
+ * collaboration" action: if the coordinator turn is also aborted, its own finally
+ * releases the lock, but a stale lock from a crashed prior run (or one whose
+ * coordinator can't be reached) would otherwise block every new start forever.
+ * Returns the holder it cleared (if any) so the caller can report it.
+ */
+export function forceReleaseCollabLock(): CollabLockInfo | null {
+  const info = readRaw();
+  try {
+    unlinkSync(collabLockPath());
+  } catch {
+    // already gone
+  }
+  return info;
+}

--- a/packages/mode-collaborative/src/collab-loop.test.ts
+++ b/packages/mode-collaborative/src/collab-loop.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import type { ModeContext, MoxxyEvent } from '@moxxy/sdk';
 import type { CollaborationHub } from '@moxxy/plugin-collab';
 import { runCollaborative, sleep, type CollabDeps } from './collab-loop.js';
+import { listRunRecords } from './archive.js';
 import { resolveCollabConfig } from './config.js';
 import type { Supervisor } from './peer-supervisor.js';
 import { git } from './worktrees.js';
@@ -14,13 +15,20 @@ const IDENT = ['-c', 'user.name=t', '-c', 'user.email=t@t'];
 const cleanups: Array<() => void> = [];
 
 beforeEach(() => {
-  // Isolate the global single-flight lock to a temp file so the e2e runs never
-  // touch (or get blocked by) a real ~/.moxxy collaboration lock.
+  // Isolate the global single-flight lock AND the moxxy home (the run archive
+  // writes under ~/.moxxy/collab/runs) to temp dirs so the e2e runs never touch
+  // — or get blocked by — the developer's real ~/.moxxy.
   const lockDir = mkdtempSync(join(tmpdir(), 'mc-loop-lock-'));
+  const homeDir = mkdtempSync(join(tmpdir(), 'mc-loop-home-'));
   process.env.MOXXY_COLLAB_LOCK = join(lockDir, 'active.lock');
+  const prevHome = process.env.MOXXY_HOME;
+  process.env.MOXXY_HOME = homeDir;
   cleanups.push(() => {
     delete process.env.MOXXY_COLLAB_LOCK;
+    if (prevHome === undefined) delete process.env.MOXXY_HOME;
+    else process.env.MOXXY_HOME = prevHome;
     rmSync(lockDir, { recursive: true, force: true });
+    rmSync(homeDir, { recursive: true, force: true });
   });
 });
 
@@ -168,6 +176,15 @@ describe('collaborative coordinator (end-to-end, fake agents + real git)', () =>
     const finalMsg = events.filter((e) => e.type === 'assistant_message').pop() as { content: string } | undefined;
     expect(finalMsg?.content).toContain('backend');
     expect(finalMsg?.content).toContain('tests');
+
+    // the run was archived (durable history) with the right outcome + brief
+    const runs = listRunRecords();
+    expect(runs.length).toBe(1);
+    expect(runs[0]!.outcome).toBe('completed');
+    expect(runs[0]!.doneCount).toBe(2);
+    expect(runs[0]!.totalCount).toBe(2);
+    expect(runs[0]!.brief).toContain('build the thing');
+    expect(runs[0]!.agents.map((a) => a.id)).toContain('backend');
   });
 
   it('does NOT hang on a failed agent: surfaces it and completes with the others', async () => {

--- a/packages/mode-collaborative/src/collab-loop.ts
+++ b/packages/mode-collaborative/src/collab-loop.ts
@@ -34,6 +34,7 @@ import {
 } from './constants.js';
 import { resolveCollabConfig, type CollabConfig } from './config.js';
 import { buildBrief } from './brief.js';
+import { writeRunRecord, type CollabRunRecord } from './archive.js';
 import {
   addWorktree,
   commitAll,
@@ -97,15 +98,25 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
   }
 
   const runId = collabRunId(String(ctx.sessionId), String(ctx.turnId));
+  const startedAtMs = Date.now();
   const worktrees = new Map<string, string>();
   let hub: CollaborationHub | null = null;
   let supervisor: Supervisor | null = null;
   let unsubscribe: (() => void) | null = null;
+  // Captured through the run so the finally can archive it on EVERY exit path
+  // (completed, aborted, or failed), not just the happy one.
+  let archiveParallel = false;
+  let archiveGitRepo = false;
+  let briefText = '';
+  let mergeForArchive: CollabRunRecord['merge'];
+  let completed = false;
   try {
     mkdirSync(collabRunDir(runId), { recursive: true });
 
   const { installed: gitInstalled, repo: gitRepo } = await detectGit(cwd);
   const parallel = cfg.concurrency === 'parallel' && gitRepo;
+  archiveParallel = parallel;
+  archiveGitRepo = gitRepo;
   if (!parallel) {
     yield await ctx.emit(
       plugin(ctx, 'collab_fallback_sequential', {
@@ -161,8 +172,9 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
     // scaffold (parallel) so every worktree gets it. Best-effort: a brief-write
     // failure must never sink the run.
     try {
+      briefText = buildBrief(task, ctx.log.slice());
       mkdirSync(join(cwd, COLLAB_SCAFFOLD_DIR), { recursive: true });
-      writeFileSync(join(cwd, COLLAB_SCAFFOLD_DIR, BRIEF_FILENAME), buildBrief(task, ctx.log.slice()));
+      writeFileSync(join(cwd, COLLAB_SCAFFOLD_DIR, BRIEF_FILENAME), briefText);
       yield await ctx.emit(plugin(ctx, 'collab_brief_written', { path: join(COLLAB_SCAFFOLD_DIR, BRIEF_FILENAME) }));
     } catch {
       // brief is an enhancement, not a prerequisite
@@ -268,6 +280,12 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
         board: hub.state.boardItems(),
         mergePolicy: cfg.mergePolicy,
       });
+      mergeForArchive = {
+        merged: result.merged,
+        promoted: result.promoted,
+        conflicts: result.conflicts.length,
+        ...(result.stagingBranch ? { stagingBranch: result.stagingBranch } : {}),
+      };
       yield await ctx.emit(plugin(ctx, 'collab_merge', result));
       for (const c of result.conflicts) {
         yield await ctx.emit(plugin(ctx, 'collab_conflict', c));
@@ -290,9 +308,59 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
         `Collaboration complete — ${doneIds.length}/${roster.length} agents finished.\n\n${summaryBlock}${mergeNote ? `\n\n${mergeNote}` : ''}`,
       ),
     );
+    completed = true;
     yield await ctx.emit(plugin(ctx, 'collab_completed', { done: doneIds, total: roster.length }));
   } finally {
     if (supervisor) await supervisor.shutdownAll('collaboration complete');
+    // Archive the run (durable history) BEFORE tearing the hub down — the record
+    // is read from hub.state. Covers every outcome: completed, user-aborted, or
+    // failed. Best-effort; archiving must never throw out of the finally.
+    if (hub) {
+      try {
+        const agents = hub.state.rosterView().agents;
+        // Counts mirror collab_completed: implementers only (the architect is
+        // crew, not a deliverable owner).
+        const implementers = agents.filter((a) => a.role !== 'architect');
+        writeRunRecord({
+          runId,
+          task,
+          startedAtMs,
+          finishedAtMs: Date.now(),
+          outcome: completed ? 'completed' : ctx.signal.aborted ? 'aborted' : 'failed',
+          parallel: archiveParallel,
+          gitRepo: archiveGitRepo,
+          agents: agents.map((a) => ({
+            id: a.id,
+            name: a.name,
+            role: a.role,
+            status: a.status,
+            subtask: a.subtask,
+            ...(a.doneSummary ? { doneSummary: a.doneSummary } : {}),
+          })),
+          doneCount: implementers.filter((a) => a.status === 'done').length,
+          totalCount: implementers.length,
+          board: hub.state.boardItems().map((b) => ({
+            id: b.id,
+            title: b.title,
+            status: b.status,
+            ...(b.owner ? { owner: b.owner } : {}),
+            ...(b.paths ? { paths: b.paths } : {}),
+          })),
+          contracts: hub.state.contractList().map((c) => ({
+            id: c.id,
+            title: c.title,
+            owner: c.owner,
+            status: c.status,
+            version: c.version,
+          })),
+          messageCount: hub.state.allMessages().length,
+          ...(mergeForArchive ? { merge: mergeForArchive } : {}),
+          ...(briefText ? { brief: briefText } : {}),
+        });
+      } catch {
+        // archiving is an enhancement, not a prerequisite
+      }
+    }
     if (unsubscribe) unsubscribe();
     unregisterActiveHub(String(ctx.sessionId));
     if (hub) await hub.close();

--- a/packages/mode-collaborative/src/index.ts
+++ b/packages/mode-collaborative/src/index.ts
@@ -30,3 +30,12 @@ export {
   COLLAB_PEER_MODE_NAME,
 } from './constants.js';
 export { resolveCollabConfig, DEFAULT_COLLAB_CONFIG, type CollabConfig } from './config.js';
+export {
+  collabRunsDir,
+  listRunRecords,
+  readRunRecord,
+  writeRunRecord,
+  type CollabRunRecord,
+  type CollabRunAgent,
+} from './archive.js';
+export { forceReleaseCollabLock, readActiveCollab, type CollabLockInfo } from './collab-lock.js';


### PR DESCRIPTION
## Why

**PR 3 of the collaborative-mode series** (follows #275, #277). Fixes two things the user hit directly:

1. **A wedged/finished collaboration couldn't be ended.** The "＋ New" button only rendered *after* a run completed — so a stuck run (or a stale single-flight lock from a crashed run) left the Collaborate tab with no way to start fresh. "Clicking did nothing."
2. **No history.** There was no record of past runs at all — the transient run dirs were even left orphaned (fixed in #275; now they carry a durable record).

## What changed

**Run archive (engine).** Every run is persisted as `~/.moxxy/collab/runs/<runId>.json` on *every* exit path — completed, aborted, or failed — capturing task, brief, roster + per-agent status/summaries, board, contracts, merge result, and timings. New `@moxxy/mode-collaborative` API: `listRunRecords` / `readRunRecord` / `writeRunRecord` (`MOXXY_HOME`-aware, self-describing JSON).

**End & archive (lifecycle).** New `collab.end` IPC aborts the coordinator turn (its `finally` tears the team down + archives) **and** force-releases the global lock — so a stuck run or a stale lock can always be cleared. Backed by `forceReleaseCollabLock()` + `SessionDriver.abortActiveTurns()`.

**History view + UI.** New `collab.history` IPC + a Collaborate-tab **History** list (outcome chip, task, agent counts, per-run detail with brief + summaries). The header now always offers **■ End & archive** (while running or while a lock is held), and the "already running" banner gained an inline **end & archive it now** — so a wedged run never blocks a fresh start. This makes the previously-inert "＋ New" actually work.

## Tests

- `archive.test.ts`: write → list (newest-first, limit) → read roundtrip; corrupt-record skip; empty-dir.
- `collab-lock.test.ts`: `forceReleaseCollabLock` clears regardless of holder.
- `collab-loop.test.ts`: the e2e run now asserts a record is archived (outcome `completed`, counts, brief).

Build / typecheck / lint / test / check:deps green locally. The full message-feed/observability redesign (agent details, tasks modal, files/deliverables) is the next PR.