### PR TITLE
feat(collaborative): dynamic, cross-functional roles (not a pool of identical implementers)

### DIFF
--- a/.changeset/collab-dynamic-roles.md
+++ b/.changeset/collab-dynamic-roles.md
@@ -1,0 +1,25 @@
+---
+"@moxxy/plugin-collab": minor
+"@moxxy/mode-collaborative": minor
+"@moxxy/cli": patch
+---
+
+feat(collaborative): dynamic, cross-functional roles (not a pool of identical implementers)
+
+The roster could only ever be `architect | implementer`, and `readRoster`
+force-overwrote every proposed role to `'implementer'` — so the architect's
+team was always a flat pool of clones, the opposite of the "a PM, a designer,
+some developers, a QA, a writer" vision.
+
+- `AgentRole` is now open (`'architect'` stays reserved for the coordinator's
+  planner; any other label is a free-form team function).
+- `readRoster` carries the architect's proposed `role` (sanitised; a proposed
+  `'architect'` is coerced to `'implementer'` since that's reserved) instead of
+  hardcoding `'implementer'`.
+- The architect prompt now tells it to assemble the RIGHT team for the
+  deliverable (developer/designer/pm/qa/writer/researcher/editor/…), not to
+  default everyone to "implementer". The peer prompt + seeded turn now lead with
+  the agent's role so a writer writes, a designer designs, a QA reviews.
+
+Roles flow straight into the existing roster/archive/UI, which already render
+`role`. Adds tests that proposed roles are carried and the reserved role coerced.

--- a/packages/cli/src/commands/agent.test.ts
+++ b/packages/cli/src/commands/agent.test.ts
@@ -25,6 +25,13 @@ describe('buildSeedTurn', () => {
     expect(turn).toContain('.moxxy-collab/BRIEF.md');
   });
 
+  it('leads with the agent\'s role when it is a named function (not generic implementer)', () => {
+    const writer = buildSeedTurn({ role: 'writer', parentTask: 'Write the launch blog', subtask: 'Draft the intro section' });
+    expect(writer).toContain('Your role on the team: writer.');
+    const impl = buildSeedTurn({ role: 'implementer', parentTask: 'Build X', subtask: 'the API' });
+    expect(impl).not.toContain('Your role on the team:');
+  });
+
   it('falls back to just the pointer when there is no sub-task text', () => {
     const turn = buildSeedTurn({ role: 'implementer', parentTask: '', subtask: '' });
     expect(turn).toContain('.moxxy-collab/BRIEF.md');

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -113,7 +113,8 @@ export function buildSeedTurn(args: { role: string; parentTask: string; subtask:
   if (role === 'architect' || !parentTask || parentTask === subtask) {
     return subtask ? `${subtask}\n\n${pointer}` : pointer;
   }
-  return `Overall team goal: ${parentTask}\n\nYour sub-task: ${subtask}\n\n${pointer}`;
+  const roleLine = role && role !== 'implementer' ? `Your role on the team: ${role}.\n` : '';
+  return `${roleLine}Overall team goal: ${parentTask}\n\nYour sub-task: ${subtask}\n\n${pointer}`;
 }
 
 async function runUntilSignal(

--- a/packages/mode-collaborative/src/collab-loop.test.ts
+++ b/packages/mode-collaborative/src/collab-loop.test.ts
@@ -187,6 +187,54 @@ describe('collaborative coordinator (end-to-end, fake agents + real git)', () =>
     expect(runs[0]!.agents.map((a) => a.id)).toContain('backend');
   });
 
+  it('carries the architect-proposed roles (a cross-functional team, not all implementers)', async () => {
+    const repo = await initRepo();
+    const { ctx, events } = fakeCtx();
+    const deps: CollabDeps = {
+      cwd: repo,
+      config: resolveCollabConfig(undefined, { requireRosterApproval: false }),
+      createSupervisor: (_opts, hub) => ({
+        spawn({ entry, cwd }) {
+          if (entry.role === 'architect') {
+            mkdirSync(join(cwd, '.moxxy-collab'), { recursive: true });
+            writeFileSync(join(cwd, '.moxxy-collab', 'CONTRACTS.md'), '# C\n');
+            writeFileSync(
+              join(cwd, '.moxxy-collab', 'roster.json'),
+              JSON.stringify([
+                { id: 'writer', name: 'Writer', role: 'writer', subtask: 'docs', ownedPaths: ['intro.md'] },
+                { id: 'dev', name: 'Dev', role: 'developer', subtask: 'code', ownedPaths: ['app.ts'] },
+                // an agent that tries to claim the reserved architect role → coerced to implementer
+                { id: 'sneaky', name: 'Sneaky', role: 'architect', subtask: 'x', ownedPaths: ['x.ts'] },
+              ]),
+            );
+            hub.state.markDone('architect', 'done');
+          } else {
+            const f = `${entry.id}.ts`;
+            writeFileSync(join(cwd, f), `export const ${entry.id}=1;\n`);
+            hub.state.boardClaim(entry.id, [f]);
+            hub.state.markDone(entry.id, `${entry.id} done`);
+          }
+          return { socket: 'fake.sock' };
+        },
+        stop: async () => undefined,
+        shutdownAll: async () => undefined,
+        stderrOf: () => [],
+        hasExited: () => false,
+      }),
+    };
+
+    for await (const _ of runCollaborative(ctx, deps)) void _;
+
+    const proposed = events.find(
+      (e) => (e as { subtype?: string }).subtype === 'collab_roster_proposed',
+    ) as { payload: { roster: Array<{ id: string; role: string }> } };
+    const byId = Object.fromEntries(proposed.payload.roster.map((r) => [r.id, r.role]));
+    expect(byId.writer).toBe('writer');
+    expect(byId.dev).toBe('developer');
+    // the reserved 'architect' role is coerced to 'implementer'
+    expect(byId.sneaky).toBe('implementer');
+  });
+
   it('does NOT hang on a failed agent: surfaces it and completes with the others', async () => {
     const repo = await initRepo();
     const { ctx, events } = fakeCtx();

--- a/packages/mode-collaborative/src/collab-loop.ts
+++ b/packages/mode-collaborative/src/collab-loop.ts
@@ -414,7 +414,9 @@ function readRoster(path: string, maxAgents: number): RosterEntry[] {
       out.push({
         id,
         name: typeof r.name === 'string' ? r.name : id,
-        role: 'implementer',
+        // Carry the architect's proposed role (pm/designer/developer/qa/writer/…)
+        // so the team is cross-functional, not a pool of identical implementers.
+        role: cleanRole(r.role),
         subtask: r.subtask,
         ...(Array.isArray(r.ownedPaths) ? { ownedPaths: r.ownedPaths.filter((p) => typeof p === 'string') } : {}),
         ...(typeof r.model === 'string' ? { model: r.model } : {}),
@@ -429,6 +431,16 @@ function readRoster(path: string, maxAgents: number): RosterEntry[] {
 
 function slug(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 32);
+}
+
+/** Normalize an architect-proposed role to a short, safe label. `'architect'` is
+ *  reserved for the coordinator's planner, so a proposed 'architect' falls back to
+ *  'implementer'. Anything unparseable also falls back to 'implementer'. */
+function cleanRole(raw: unknown): string {
+  if (typeof raw !== 'string') return 'implementer';
+  const r = raw.toLowerCase().replace(/[^a-z0-9 -]/g, '').replace(/\s+/g, ' ').trim().slice(0, 24);
+  if (!r || r === ARCHITECT_AGENT_ID) return 'implementer';
+  return r;
 }
 
 type HubLike = { state: { rosterView(): { agents: ReadonlyArray<{ id: string; status: string }> } } };

--- a/packages/mode-collaborative/src/prompts.ts
+++ b/packages/mode-collaborative/src/prompts.ts
@@ -31,18 +31,18 @@ Cooperation rules:
 
 export const COLLAB_PEER_PROMPT = `${COLLAB_COMMON}
 
-You are an IMPLEMENTER. Your sub-task is provided. Start by reading ${COLLAB_SCAFFOLD_DIR}/${BRIEF_FILENAME} (the goal + intent) and ${COLLAB_SCAFFOLD_DIR}/${CONTRACTS_FILENAME}, and calling collab_contracts, collab_roster, and collab_board so you know the plan and who owns what. Claim your files, implement against the contracts, coordinate on intersections, then call collab_done.`;
+You are a TEAM MEMBER with a specific role (given below) and sub-task. Work as that role — a writer writes, a designer designs, a developer builds, a QA reviews, a PM sequences + verifies. Start by reading ${COLLAB_SCAFFOLD_DIR}/${BRIEF_FILENAME} (the goal + intent) and ${COLLAB_SCAFFOLD_DIR}/${CONTRACTS_FILENAME}, and calling collab_contracts, collab_roster, and collab_board so you know the plan and who owns what. Claim your files, deliver your part against the contracts, coordinate on intersections, then call collab_done.`;
 
 export const COLLAB_ARCHITECT_PROMPT = `${COLLAB_COMMON}
 
 You are the ARCHITECT — you run FIRST and set the team up for success. Your job, in order:
 0. Read ${COLLAB_SCAFFOLD_DIR}/${BRIEF_FILENAME} — the user's goal and the conversation behind it — so you decompose toward what they actually want.
 1. Explore the workspace to understand the task and its boundaries.
-2. Decompose the task into INDEPENDENT sub-tasks with DISJOINT file ownership (minimize overlap so agents rarely touch the same files).
-3. Define the shared CONTRACTS — the interfaces, types, API shapes, and module boundaries where the implementers' work meets. Publish each with collab_contract_publish (give an owner + consumers).
+2. Assemble the RIGHT TEAM for THIS deliverable and decompose into INDEPENDENT sub-tasks with DISJOINT ownership (minimize overlap). Pick the roles the work actually needs — a coding task wants developers + a QA reviewer; a document/plan/design deliverable wants a writer, a researcher, a designer, an editor; a product effort may want a PM to sequence + verify. Don't default everyone to a generic "implementer".
+3. Define the shared CONTRACTS — the interfaces, types, API shapes, section outlines, or boundaries where the team's work meets. Publish each with collab_contract_publish (give an owner + consumers).
 4. Write two files into the repo:
-   - ${COLLAB_SCAFFOLD_DIR}/${CONTRACTS_FILENAME} — human-readable contracts/boundaries the implementers must follow.
-   - ${COLLAB_SCAFFOLD_DIR}/${ROSTER_FILENAME} — a JSON array proposing the implementer roster. Each entry: { "id": "kebab-slug", "name": "Role Name", "role": "implementer", "subtask": "what this agent builds", "ownedPaths": ["dir/", "file.ts"] }. Do NOT include yourself.
+   - ${COLLAB_SCAFFOLD_DIR}/${CONTRACTS_FILENAME} — human-readable contracts/boundaries the team must follow.
+   - ${COLLAB_SCAFFOLD_DIR}/${ROSTER_FILENAME} — a JSON array proposing the team. Each entry: { "id": "kebab-slug", "name": "Display Name", "role": "<function>", "subtask": "what this agent delivers", "ownedPaths": ["dir/", "file.md"] }. "role" is the agent's FUNCTION — e.g. "developer", "designer", "pm", "qa", "writer", "researcher", "editor" — choose what fits. Do NOT include yourself, and do NOT use "architect" (that's you).
 5. Broadcast a short kickoff summary, then call collab_done.
 
 After the implementers start, you stay available as the BROKER: answer interface questions, and when an implementer proposes a contract change, review it and (if sound) commit it with collab_contract_update so everyone re-syncs.`;

--- a/packages/plugin-collab/src/hub-types.ts
+++ b/packages/plugin-collab/src/hub-types.ts
@@ -16,7 +16,16 @@ export type AgentStatus =
   | 'crashed' // process died unexpectedly
   | 'killed'; // shut down by the coordinator
 
-export type AgentRole = 'architect' | 'implementer';
+/**
+ * An agent's function on the team. `'architect'` is RESERVED for the coordinator's
+ * up-front planner (it runs first + designs the roster); every other agent carries
+ * a free-form role the architect assigns — `'implementer'`, but also `'pm'`,
+ * `'designer'`, `'developer'`, `'qa'`, `'writer'`, `'researcher'`, … — so a team can
+ * be a real cross-functional "company", not just a pool of identical implementers.
+ * The string is display + prompt flavor; the coordinator runs every non-architect
+ * agent through the same peer loop regardless of label.
+ */
+export type AgentRole = 'architect' | 'implementer' | (string & {});
 
 /** What the architect proposes (and the user can edit) before launch. */
 export interface RosterEntry {


### PR DESCRIPTION
## Why

**PR 4 of the collaborative-mode series** (follows #275, #277, #279). The audit's top *vision* gap: the type system could only express `architect | implementer`, and `readRoster` **force-overwrote every proposed role to `'implementer'`** — so the architect's "team" was always a flat pool of clones. That's the opposite of the product goal (a PM, a designer, some developers, a QA, a writer — assembled per deliverable).

## What changed

- **`AgentRole` is now open.** `'architect'` stays reserved for the coordinator's planner; any other label is a free-form team function. (`packages/plugin-collab`)
- **`readRoster` carries the proposed role** (sanitised to a short safe label; a proposed `'architect'` is coerced to `'implementer'` since it's reserved) instead of hardcoding `'implementer'`.
- **Prompts.** The architect is now told to assemble the *right* team for the deliverable — `developer` / `designer` / `pm` / `qa` / `writer` / `researcher` / `editor` / … — not to default everyone to "implementer". The peer prompt is role-neutral and the seeded turn leads with the agent's role, so a writer writes and a QA reviews.

Roles already flow into the roster view, the run archive, and the Collaborate UI (all render `role`), so a real cross-functional team now shows up everywhere with zero extra plumbing. Your real pharmacy-workshop run already *named* agents this way (`workshop-strategy`, `exercises-designer`, …) — now their **role** is first-class too.

## Tests

- `collab-loop.test.ts`: architect-proposed roles (`writer`, `developer`) are carried through; a sneaky `'architect'` role is coerced to `'implementer'`.
- `agent.test.ts`: the seeded turn leads with the role for a named function, and omits it for a generic implementer.

Build / typecheck / lint / test green locally.