### PR TITLE
feat(desktop): redesign the Collaborate feed + task details, deliverables

### DIFF
--- a/.changeset/collab-observability-ui.md
+++ b/.changeset/collab-observability-ui.md
@@ -1,0 +1,23 @@
+---
+"@moxxy/chat-model": minor
+"@moxxy/desktop": minor
+---
+
+feat(desktop): redesign the Collaborate feed + task details, deliverables, message cards
+
+The Collaborate tab showed the team's messages as flat monospace rows
+(`agent → all · subject: body`) and gave no way to inspect a task or see what
+the run produced. Redesigned for observability:
+
+- **Message cards.** Each message is now a card with a coloured author chip
+  (human vs agent), a kind chip derived from the subject (kickoff / progress /
+  done / blocked / directive), a broadcast-vs-DM tag (`📣 all` vs `→ agent`), a
+  timestamp, and the body — so a long run reads like a team channel, and direct
+  messages are visually distinct from broadcasts.
+- **Tasks → modal.** Task-board rows are clickable and open a modal with status,
+  owner, detail, and the files the item covers.
+- **Deliverables.** A new rail section lists the distinct files the team
+  claimed/produced; the task view (`CollabTaskView`) now folds `paths` + `detail`
+  from the board stream.
+
+Adds folding-test coverage for the new task fields.

--- a/apps/desktop/src/collaborate/CollaboratePanel.tsx
+++ b/apps/desktop/src/collaborate/CollaboratePanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { api, useChat } from '@moxxy/client-core';
 import type { CollabRunSummary } from '@moxxy/desktop-ipc-contract';
 import { pairToolEvents } from '@moxxy/chat-model';
+import type { CollabMsgView, CollabTaskView } from '@moxxy/chat-model';
 import { Button, Icon } from '@moxxy/desktop-ui';
 import { ViewHeader, ViewSwitcher, type View } from '../shell/ViewHeader';
 import { dotColor, filterCollabMessages, latestCollab, taskChipBg } from './collab-view';
@@ -43,6 +44,7 @@ export function CollaboratePanel({
   const [showHistory, setShowHistory] = useState(false);
   const [history, setHistory] = useState<CollabRunSummary[] | null>(null);
   const [globalActive, setGlobalActive] = useState<{ active: boolean; task?: string } | null>(null);
+  const [selectedTask, setSelectedTask] = useState<string | null>(null);
 
   // Poll the global single-flight lock so Start reflects a collaboration running
   // in ANY workspace (only one runs at a time).
@@ -293,7 +295,7 @@ export function CollaboratePanel({
   ];
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
+    <div style={{ position: 'relative', display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
       {header}
       <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
         {/* LEFT RAIL — agents · tasks · contracts */}
@@ -322,13 +324,32 @@ export function CollaboratePanel({
           <Section title={`Tasks · ${collab.tasks.filter((t) => t.status === 'done').length}/${collab.tasks.length}`}>
             {collab.tasks.length === 0 && <Empty>No board items yet.</Empty>}
             {collab.tasks.map((t) => (
-              <div key={t.id} style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '5px 12px' }}>
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setSelectedTask(t.id)}
+                title="Show details"
+                style={{ width: '100%', textAlign: 'left', background: 'none', border: 'none', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 7, padding: '5px 12px' }}
+              >
                 <span style={taskChip(t.status)}>{t.status}</span>
-                <span style={{ flex: 1, minWidth: 0, fontSize: 12.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{t.title}</span>
+                <span style={{ flex: 1, minWidth: 0, fontSize: 12.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--color-text)' }}>{t.title}</span>
+                {t.paths && t.paths.length > 0 && (
+                  <span className="mono" style={{ fontSize: 10, color: 'var(--color-text-dim)' }}>{t.paths.length}📄</span>
+                )}
                 {t.owner && <span className="mono" style={{ fontSize: 10.5, color: 'var(--color-text-dim)' }}>@{t.owner}</span>}
-              </div>
+              </button>
             ))}
           </Section>
+          {(() => {
+            const files = [...new Set(collab.tasks.flatMap((t) => t.paths ?? []))];
+            return files.length > 0 ? (
+              <Section title={`Deliverables · ${files.length}`}>
+                {files.map((f) => (
+                  <div key={f} className="mono" style={{ padding: '3px 12px', fontSize: 11.5, color: 'var(--color-text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{f}</div>
+                ))}
+              </Section>
+            ) : null;
+          })()}
           {collab.contracts.length > 0 && (
             <Section title="Contracts">
               {collab.contracts.map((c) => (
@@ -375,16 +396,7 @@ export function CollaboratePanel({
                 {channel === 'all' ? 'No team messages yet.' : 'No messages to or from this agent yet.'}
               </div>
             ) : (
-              visibleMessages.map((m) => (
-                <div key={m.id} style={{ fontSize: 13, lineHeight: 1.5 }}>
-                  <span className="mono" style={{ fontWeight: 600, color: m.from === 'human' ? 'var(--color-accent-strong)' : 'var(--color-primary-strong)' }}>
-                    {m.from}
-                  </span>
-                  <span className="mono" style={{ color: 'var(--color-text-dim)' }}> → {m.to}</span>
-                  {m.subject ? <span className="mono" style={{ color: 'var(--color-text-dim)' }}> · {m.subject}</span> : null}
-                  <span style={{ color: 'var(--color-text)' }}>: {m.body}</span>
-                </div>
-              ))
+              visibleMessages.map((m) => <MessageCard key={m.id} m={m} />)
             )}
           </div>
 
@@ -422,6 +434,12 @@ export function CollaboratePanel({
           </div>
         </div>
       </div>
+      {selectedTask && (
+        <TaskModal
+          task={collab.tasks.find((t) => t.id === selectedTask)}
+          onClose={() => setSelectedTask(null)}
+        />
+      )}
     </div>
   );
 }
@@ -720,6 +738,103 @@ function CollabHistory({ runs, onClose }: { readonly runs: CollabRunSummary[] | 
           </div>
         );
       })}
+    </div>
+  );
+}
+
+/** A short colour + label for a message's "kind", derived from its subject. */
+function msgKind(subject?: string): { label: string; color: string } | null {
+  if (!subject) return null;
+  const s = subject.toLowerCase();
+  if (s === 'directive') return { label: 'directive', color: 'var(--color-accent-strong)' };
+  if (s.startsWith('done') || s.includes('complete')) return { label: 'done', color: 'var(--color-green)' };
+  if (s.includes('block')) return { label: 'blocked', color: 'var(--color-amber-text)' };
+  if (s.includes('progress') || s.includes('claim') || s.includes('start')) return { label: 'progress', color: 'var(--color-primary)' };
+  if (s.includes('kickoff') || s.includes('ready')) return { label: 'kickoff', color: 'var(--color-primary-strong)' };
+  return { label: subject.slice(0, 24), color: 'var(--color-text-dim)' };
+}
+
+function whenShort(ms: number): string {
+  const s = Math.max(0, Math.round((Date.now() - ms) / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m`;
+  return `${Math.round(m / 60)}h`;
+}
+
+/** One message rendered as a chat card: author chip (human vs agent), a kind
+ *  chip from the subject, a broadcast/DM tag, a timestamp, and the body. */
+function MessageCard({ m }: { readonly m: CollabMsgView }): JSX.Element {
+  const isHuman = m.from === 'human';
+  const kind = msgKind(m.subject);
+  return (
+    <div
+      style={{
+        border: '1px solid var(--color-card-border)',
+        borderRadius: 10,
+        padding: '8px 11px',
+        background: isHuman ? 'color-mix(in srgb, var(--color-accent) 8%, transparent)' : 'var(--color-card-bg)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 7, flexWrap: 'wrap' }}>
+        <span className="mono" style={{ fontWeight: 700, fontSize: 12, color: isHuman ? 'var(--color-accent-strong)' : 'var(--color-primary-strong)' }}>
+          {m.from}
+        </span>
+        <span
+          className="mono"
+          style={{ fontSize: 10, color: 'var(--color-text-dim)', border: '1px solid var(--color-card-border)', borderRadius: 'var(--radius-pill)', padding: '0 6px' }}
+          title={m.to === 'all' ? 'broadcast to the whole team' : `direct message to ${m.to}`}
+        >
+          {m.to === 'all' ? '📣 all' : `→ ${m.to}`}
+        </span>
+        {kind && (
+          <span style={{ fontSize: 9.5, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.3, color: '#fff', background: kind.color, borderRadius: 'var(--radius-pill)', padding: '1px 6px' }}>
+            {kind.label}
+          </span>
+        )}
+        <span style={{ flex: 1 }} />
+        <span className="mono" style={{ fontSize: 10, color: 'var(--color-text-dim)' }}>{whenShort(m.atMs)}</span>
+      </div>
+      <div style={{ fontSize: 13, lineHeight: 1.5, color: 'var(--color-text)', whiteSpace: 'pre-wrap' }}>{m.body}</div>
+    </div>
+  );
+}
+
+/** Modal with a task-board item's full detail: status, owner, deliverable files. */
+function TaskModal({ task, onClose }: { readonly task?: CollabTaskView; readonly onClose: () => void }): JSX.Element | null {
+  if (!task) return null;
+  return (
+    <div
+      onClick={onClose}
+      style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.4)', display: 'grid', placeItems: 'center', zIndex: 50 }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{ width: 'min(520px, 90%)', maxHeight: '80%', overflowY: 'auto', background: 'var(--color-app-bg)', border: '1px solid var(--color-card-border)', borderRadius: 14, padding: 18, display: 'flex', flexDirection: 'column', gap: 12, boxShadow: '0 12px 40px rgba(0,0,0,0.3)' }}
+      >
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+          <span style={taskChip(task.status)}>{task.status}</span>
+          <span style={{ flex: 1, fontSize: 15, fontWeight: 700, color: 'var(--color-text)' }}>{task.title}</span>
+          <button type="button" onClick={onClose} className="btn-ghost" style={{ fontSize: 16, lineHeight: 1, padding: '0 6px' }} aria-label="Close">×</button>
+        </div>
+        {task.owner && (
+          <div className="mono" style={{ fontSize: 12, color: 'var(--color-text-muted)' }}>owner · @{task.owner}</div>
+        )}
+        {task.detail && (
+          <div style={{ fontSize: 13, lineHeight: 1.55, color: 'var(--color-text)' }}>{task.detail}</div>
+        )}
+        {task.paths && task.paths.length > 0 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <div style={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.4, color: 'var(--color-text-dim)' }}>Deliverables</div>
+            {task.paths.map((p) => (
+              <div key={p} className="mono" style={{ fontSize: 12, color: 'var(--color-text-muted)', wordBreak: 'break-all' }}>{p}</div>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/chat-model/src/collab-fold.test.ts
+++ b/packages/chat-model/src/collab-fold.test.ts
@@ -38,7 +38,7 @@ describe('collaboration fold', () => {
       }),
       ce('collab_agent_spawned', { id: 'backend', role: 'implementer' }),
       ce('collab_message', { kind: 'message', message: { id: 'm1', from: 'backend', to: 'all', body: 'starting', ts: 5000 } }),
-      ce('collab_board_update', { kind: 'board', action: 'claim', item: { id: 't1', title: 'api.ts', status: 'claimed', owner: 'backend' } }),
+      ce('collab_board_update', { kind: 'board', action: 'claim', item: { id: 't1', title: 'api.ts', status: 'claimed', owner: 'backend', paths: ['src/api.ts'], detail: 'build the api' } }),
       ce('collab_agent_done', { kind: 'agent_done', agentId: 'backend', summary: 'done api' }),
       ce('collab_control', { kind: 'control', control: { paused: true } }),
       ce('collab_conflict', { agentId: 'tests', files: ['shared.ts'] }),
@@ -57,6 +57,9 @@ describe('collaboration fold', () => {
     expect(collab.agents.find((a) => a.id === 'backend')?.summary).toBe('done api');
     expect(collab.messages.map((m) => m.body)).toEqual(['starting']);
     expect(collab.tasks[0]?.status).toBe('claimed');
+    // claimed paths fold into the task (the run's deliverables) + detail
+    expect(collab.tasks[0]?.paths).toEqual(['src/api.ts']);
+    expect(collab.tasks[0]?.detail).toBe('build the api');
     expect(collab.contracts[0]?.title).toBe('API');
     expect(collab.control?.paused).toBe(true);
     expect(collab.conflicts[0]?.files).toEqual(['shared.ts']);

--- a/packages/chat-model/src/pair-events.ts
+++ b/packages/chat-model/src/pair-events.ts
@@ -237,17 +237,23 @@ function handleCollabEvent(
       if (typeof item.id === 'string') {
         const existing = block.tasks.find((x) => x.id === item.id);
         const owner = typeof item.owner === 'string' ? item.owner : null;
+        const paths = Array.isArray(item.paths) ? item.paths.filter((x): x is string => typeof x === 'string') : undefined;
+        const detail = typeof item.detail === 'string' ? item.detail : undefined;
         if (!existing) {
           block.tasks.push({
             id: item.id,
             title: String(item.title ?? ''),
             status: String(item.status ?? 'open'),
             owner,
+            ...(paths && paths.length > 0 ? { paths } : {}),
+            ...(detail ? { detail } : {}),
           });
         } else {
           existing.title = String(item.title ?? existing.title);
           existing.status = String(item.status ?? existing.status);
           existing.owner = owner ?? existing.owner;
+          if (paths && paths.length > 0) existing.paths = paths;
+          if (detail) existing.detail = detail;
         }
       }
       break;

--- a/packages/chat-model/src/types.ts
+++ b/packages/chat-model/src/types.ts
@@ -42,6 +42,9 @@ export interface CollabTaskView {
   title: string;
   status: string;
   owner: string | null;
+  /** Files/areas this item covers (claimed paths) — the run's deliverables. */
+  paths?: ReadonlyArray<string>;
+  detail?: string;
 }
 
 /** One shared contract (agreed interface/boundary). */


### PR DESCRIPTION
## Why

**PR 5 of the collaborative-mode series** (follows #275, #277, #279, #280). The Collaborate tab showed the team's messages as flat monospace rows — `agent → all · subject: body` — and gave no way to inspect a task or see what a run actually produced. (Screenshot from the user's real pharmacy-workshop run was exactly this wall of mono text.)

## What changed

- **Message cards.** Each message renders as a card: a coloured author chip (human vs agent), a **kind chip** derived from the subject (`kickoff` / `progress` / `done` / `blocked` / `directive`), a **broadcast-vs-DM tag** (`📣 all` vs `→ agent`), a timestamp, and the body. A long run now reads like a team channel, and a direct message is visually distinct from a broadcast (directly addressing the "only 'all' messages are legible" complaint).
- **Tasks → modal.** Task-board rows are clickable and open a modal with status, owner, detail, and the **files the item covers**.
- **Deliverables.** A new rail section lists the distinct files the team claimed/produced. `CollabTaskView` now folds `paths` + `detail` from the board stream so this data is actually available to the UI.

## Tests

- `collab-fold.test.ts`: a board update with `paths` + `detail` folds into the task view.
- Existing chat-model folding (77) + desktop collab-view tests stay green; desktop typechecks.

This is the observability half of the user's request. The deeper item — streaming each agent's *full transcript* (their per-agent runner sockets already exist) into the panel — is noted as a follow-up in the audit roadmap.