### PR TITLE
fix(collaborative): agents reply to the human instead of going silent

### DIFF
--- a/.changeset/collab-human-responsiveness.md
+++ b/.changeset/collab-human-responsiveness.md
@@ -1,0 +1,14 @@
+---
+"@moxxy/mode-collaborative": patch
+---
+
+fix(collaborative): agents reply to the human instead of going silent
+
+Stepping into a running collaboration felt one-way: a human directive or direct
+message reached a live agent (via the awareness nudge), but agents only ever
+broadcast progress to the team — they never addressed the human back, so it
+looked like "the team doesn't respond". The shared prompt now tells every agent
+to treat a human directive/message as authoritative AND reply to them with
+`collab_send` to "human" — acknowledge it and say what they'll do (or ask a brief
+clarifying question). Adds prompt-content regression tests (brief pointer +
+memory recall/save + the human-reply rule + cross-functional roster guidance).

--- a/packages/mode-collaborative/src/prompts.test.ts
+++ b/packages/mode-collaborative/src/prompts.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { COLLAB_ARCHITECT_PROMPT, COLLAB_PEER_PROMPT } from './prompts.js';
+
+describe('collaboration prompts', () => {
+  it('point every agent at the shared brief + memory recall/save', () => {
+    for (const p of [COLLAB_ARCHITECT_PROMPT, COLLAB_PEER_PROMPT]) {
+      expect(p).toContain('.moxxy-collab/BRIEF.md');
+      expect(p).toContain('recall()');
+      expect(p).toContain('memory_save');
+    }
+  });
+
+  it('tell agents to reply to the human (not go silent on a directive/DM)', () => {
+    for (const p of [COLLAB_ARCHITECT_PROMPT, COLLAB_PEER_PROMPT]) {
+      expect(p).toContain('collab_send to "human"');
+      expect(p.toLowerCase()).toContain('human directive');
+    }
+  });
+
+  it('let the architect assemble a cross-functional team (not all implementers)', () => {
+    expect(COLLAB_ARCHITECT_PROMPT).toContain('"role"');
+    expect(COLLAB_ARCHITECT_PROMPT.toLowerCase()).toContain('designer');
+    expect(COLLAB_ARCHITECT_PROMPT.toLowerCase()).toContain('qa');
+    // architect must not put itself in the roster
+    expect(COLLAB_ARCHITECT_PROMPT).toContain('do NOT use "architect"');
+  });
+});

--- a/packages/mode-collaborative/src/prompts.ts
+++ b/packages/mode-collaborative/src/prompts.ts
@@ -25,7 +25,7 @@ The team coordinates through a shared hub (use these tools):
 
 Cooperation rules:
 - Build strictly to the shared contracts. If you must change a shared boundary, use collab_contract_propose_change and wait for acks — never break a contract unilaterally.
-- The human may step in at any time: honor any directive you receive (it overrides your current plan), and if the team is paused, finish your current edit and wait.
+- The human may step in at any time. When you receive a HUMAN directive or a message from "human", treat it as authoritative (it overrides your current plan), and REPLY to them with collab_send to "human" — acknowledge it and say what you'll do (or ask a brief clarifying question). Don't go silent on the human. If the team is paused, finish your current edit and wait.
 - Keep teammates informed: broadcast meaningful progress and blockers.
 - When YOUR sub-task is fully complete and verified, call collab_done with a short summary. The run finishes when everyone is done.`;
 


### PR DESCRIPTION
## Why

**PR 6 of the collaborative-mode series.** The last piece of the user's "the team doesn't respond" complaint. Stepping into a running collaboration was effectively one-way: a human directive or DM *did* reach a live agent (via the awareness nudge), but agents only ever **broadcast** progress to the team — they never addressed the **human** back. So a directive looked like it vanished.

## What changed

The shared collaboration prompt now tells every agent to treat a human directive / a message from `"human"` as authoritative **and reply to them** with `collab_send` to `"human"` — acknowledge it and say what they'll do (or ask one brief clarifying question). Replies to `"human"` are relayed to the coordinator log and show up in the Collaborate feed (and, after #281, as a distinct DM card), so step-in is now visibly two-way.

(Note: in the *sequential* fallback — a non-git workspace, which is what the user's pharmacy-workshop run used — only one agent is live at a time, so only that agent can respond. Making non-git runs parallel via a scratch repo is the related follow-up in the audit roadmap.)

## Tests

`prompts.test.ts`: regression coverage that both role prompts carry the brief pointer + `recall()`/`memory_save`, the human-reply rule, and the cross-functional roster guidance.