### PR TITLE
feat(collaborative): brief is a SUMMARY, not the transcript — with on-demand recall

### DIFF
--- a/.changeset/collab-brief-summary.md
+++ b/.changeset/collab-brief-summary.md
@@ -1,0 +1,23 @@
+---
+"@moxxy/mode-collaborative": minor
+"@moxxy/cli": patch
+---
+
+feat(collaborative): brief is a SUMMARY, not the transcript — with on-demand recall
+
+The brief dumped up to ~6KB of the raw conversation into BRIEF.md, and every one
+of the N spawned agents was told to read it — so each peer re-ingested the whole
+dialogue. Now:
+
+- **BRIEF.md is a concise summary** — the goal + key requirements/constraints/
+  decisions — produced by a single coordinator-side LLM call (`summarize.ts`,
+  a direct off-log `provider.stream`, mirroring the summarize-compactor) with a
+  deterministic **heuristic fallback** when no provider is available, so a brief
+  never sinks the run.
+- **The full conversation goes to `.moxxy-collab/CONVERSATION.md`** for ON-DEMAND
+  recall — never auto-loaded into any agent's context. The prompts tell agents to
+  read or grep it only when they need a detail the summary omits.
+
+Net: peers get the intent cheaply instead of paying for the transcript N times.
+Adds summarizer (provider/model guard, error/empty → null), brief, and prompt
+tests; the e2e run now asserts CONVERSATION.md is written.

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -107,9 +107,11 @@ export async function runAgentCommand(argv: ParsedArgv): Promise<number> {
 export function buildSeedTurn(args: { role: string; parentTask: string; subtask: string }): string {
   const { role, parentTask, subtask } = args;
   const pointer =
-    'Shared team context is in `.moxxy-collab/BRIEF.md` (the user\'s overall goal + ' +
-    'the conversation/intent) and `.moxxy-collab/CONTRACTS.md` (the agreed interfaces). ' +
-    'Read them before you start so your work fits the real goal.';
+    'Shared team context is in `.moxxy-collab/BRIEF.md` (a concise summary of the ' +
+    "user's goal + key requirements) and `.moxxy-collab/CONTRACTS.md` (the agreed " +
+    'interfaces). Read them before you start so your work fits the real goal. If you ' +
+    'need a detail the brief omits, read or grep `.moxxy-collab/CONVERSATION.md` (the ' +
+    'full transcript) — do not load it wholesale.';
   if (role === 'architect' || !parentTask || parentTask === subtask) {
     return subtask ? `${subtask}\n\n${pointer}` : pointer;
   }

--- a/packages/mode-collaborative/src/brief.test.ts
+++ b/packages/mode-collaborative/src/brief.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildBrief, digestTurns } from './brief.js';
+import { buildBrief, buildConversation, digestTurns, heuristicSummary } from './brief.js';
 
 const ev = (o: Record<string, unknown>): unknown => o;
 
@@ -20,42 +20,56 @@ describe('digestTurns', () => {
   });
 });
 
-describe('buildBrief', () => {
-  it('always includes the goal', () => {
-    const brief = buildBrief('Ship the onboarding flow', []);
+describe('buildBrief (summary document)', () => {
+  it('renders the goal + the provided summary, and points at the recall file', () => {
+    const brief = buildBrief('Ship onboarding', '- must be mobile-first\n- no analytics');
     expect(brief).toContain('# Collaboration brief');
     expect(brief).toContain('## Goal');
-    expect(brief).toContain('Ship the onboarding flow');
+    expect(brief).toContain('Ship onboarding');
+    expect(brief).toContain('## Summary');
+    expect(brief).toContain('mobile-first');
+    // points at the recall file, does NOT embed the transcript
+    expect(brief).toContain('.moxxy-collab/CONVERSATION.md');
   });
 
-  it('includes the conversation but does not repeat the goal as the last user turn', () => {
-    const brief = buildBrief('next.js please', [
+  it('guards an oversized summary', () => {
+    const brief = buildBrief('goal', 'x'.repeat(9000));
+    expect(brief.length).toBeLessThan(5000);
+  });
+});
+
+describe('heuristicSummary (fallback)', () => {
+  it('summarizes the recent turns and flags itself as the fallback', () => {
+    const s = heuristicSummary('next.js please', [
       ev({ type: 'user_prompt', text: 'build a blog' }),
       ev({ type: 'assistant_message', source: 'model', content: 'what stack?' }),
       ev({ type: 'user_prompt', text: 'next.js please' }),
     ]);
-    expect(brief).toContain('## Conversation so far');
-    expect(brief).toContain('build a blog');
-    expect(brief).toContain('what stack?');
-    // the trailing user turn equals the goal → not duplicated in the conversation
-    expect(brief.match(/next\.js please/g)?.length).toBe(1);
+    expect(s).toContain('heuristic summary');
+    expect(s).toContain('build a blog');
+    // trailing user turn == goal is not duplicated
+    expect(s.match(/next\.js please/g)).toBeNull();
   });
 
-  it('keeps only the most recent turns (window)', () => {
+  it('handles an empty conversation', () => {
+    expect(heuristicSummary('goal', [])).toContain('no prior conversation');
+  });
+});
+
+describe('buildConversation (recall file)', () => {
+  it('includes EVERY turn (full transcript), not just a window', () => {
     const events = Array.from({ length: 40 }, (_, i) =>
-      ev({ type: 'user_prompt', text: `[i=${i}] short message` }),
+      ev({ type: 'user_prompt', text: `[i=${i}] message` }),
     );
-    const brief = buildBrief('goal', events);
-    // last 12 turns survive; older ones are dropped
-    expect(brief).toContain('[i=39]');
-    expect(brief).toContain('[i=28]');
-    expect(brief).not.toContain('[i=10]');
+    const conv = buildConversation('goal', events);
+    expect(conv).toContain('recall-only');
+    // the recall file keeps far more than the 12-turn brief window
+    expect(conv).toContain('[i=0]');
+    expect(conv).toContain('[i=39]');
   });
 
   it('caps total size even for a huge conversation', () => {
-    const huge = 'x'.repeat(5000);
-    const events = Array.from({ length: 40 }, () => ev({ type: 'user_prompt', text: huge }));
-    const brief = buildBrief('goal', events);
-    expect(brief.length).toBeLessThanOrEqual(6001);
+    const events = Array.from({ length: 200 }, () => ev({ type: 'user_prompt', text: 'x'.repeat(2000) }));
+    expect(buildConversation('goal', events).length).toBeLessThanOrEqual(48_001);
   });
 });

--- a/packages/mode-collaborative/src/brief.ts
+++ b/packages/mode-collaborative/src/brief.ts
@@ -1,21 +1,30 @@
 /**
- * The collaboration BRIEF — a compact, token-efficient digest of the user's
- * conversation that the coordinator writes into the scaffold (`.moxxy-collab/
- * BRIEF.md`) so EVERY spawned agent inherits the overall goal + intent, not just
- * its one-line subtask. Without it, peers boot fresh sessions that have never
- * seen the dialogue, clarifications, or constraints that produced the task.
+ * The collaboration BRIEF + the full-conversation recall file.
  *
- * Kept a pure function over the event log so it is unit-testable and cheap: it
- * distills (not dumps) — the most recent turns, each clipped — to stay well
- * under a few KB regardless of how long the conversation ran.
+ * BRIEF.md is a CONCISE summary (goal + key requirements/constraints/decisions)
+ * that every spawned agent reads up front — NOT the raw transcript, so the N
+ * peers don't each re-ingest the whole dialogue. The summary is normally written
+ * by a single coordinator LLM call (`summarize.ts`); `heuristicSummary` here is
+ * the deterministic fallback when no provider is available.
+ *
+ * CONVERSATION.md holds the full (clipped) transcript for ON-DEMAND recall — it
+ * is never loaded into an agent's context by default; an agent reads or greps it
+ * only when it needs a detail the summary omits.
+ *
+ * Pure functions over the event log, so they stay cheap + unit-testable.
  */
 
-/** How many recent user/assistant turns to include. */
+/** Heuristic-summary window (the fallback brief): recent turns, clipped, capped. */
 const MAX_TURNS = 12;
-/** Per-message clip (chars) — enough to convey intent, not the whole turn. */
 const MAX_MSG_CHARS = 600;
-/** Overall cap (chars) so a huge conversation still yields a small brief. */
 const MAX_TOTAL_CHARS = 6000;
+
+/** The recall file is allowed to be much bigger (it's read on demand, not in context). */
+const CONVERSATION_MSG_CHARS = 1200;
+const CONVERSATION_TOTAL_CHARS = 48_000;
+
+/** Guard on the (already-small) summary embedded into BRIEF.md. */
+const SUMMARY_GUARD_CHARS = 4000;
 
 interface DigestTurn {
   readonly role: 'user' | 'assistant';
@@ -46,44 +55,82 @@ export function digestTurns(events: ReadonlyArray<unknown>): DigestTurn[] {
   return out;
 }
 
-/**
- * Build the markdown brief. `task` is the headline goal (the last user prompt);
- * `events` is the coordinator's event log (`ctx.log.slice()`). The result is the
- * goal plus the tail of the conversation, clipped and total-capped.
- */
-export function buildBrief(task: string, events: ReadonlyArray<unknown>): string {
-  const turns = digestTurns(events);
-  // The headline goal is already `task`; avoid repeating the identical last user
-  // turn in the conversation section.
-  const trimmed =
-    turns.length > 0 && turns[turns.length - 1]!.role === 'user' && turns[turns.length - 1]!.text.trim() === task.trim()
-      ? turns.slice(0, -1)
-      : turns;
-  const recent = trimmed.slice(-MAX_TURNS);
+/** Drop the trailing user turn when it's identical to the goal headline. */
+function withoutGoalTail(turns: DigestTurn[], task: string): DigestTurn[] {
+  const last = turns[turns.length - 1];
+  return turns.length > 0 && last!.role === 'user' && last!.text.trim() === task.trim()
+    ? turns.slice(0, -1)
+    : turns;
+}
 
-  const lines: string[] = [
+/**
+ * The BRIEF.md document: the goal + a concise SUMMARY (produced upstream). It no
+ * longer carries the raw conversation — that's CONVERSATION.md.
+ */
+export function buildBrief(task: string, summary: string): string {
+  const lines = [
     '# Collaboration brief',
     '',
-    'This is the shared context for the whole team. It is the user\'s goal and the',
-    'conversation that led to it — read it before planning so your work fits the',
-    'real intent, not just your narrow sub-task.',
+    "This is the team's shared brief — the goal and the key requirements,",
+    "constraints, and decisions distilled from the user's conversation. The full",
+    'transcript is NOT in your context; if you need a specific detail this summary',
+    'omits, read or grep `.moxxy-collab/CONVERSATION.md` (do not load it wholesale).',
     '',
     '## Goal',
     '',
     clip(task, 1500) || '(no goal text)',
+    '',
+    '## Summary',
+    '',
+    clip(summary, SUMMARY_GUARD_CHARS) || '(no summary available)',
   ];
+  return `${lines.join('\n')}\n`;
+}
 
-  if (recent.length > 0) {
-    lines.push('', '## Conversation so far', '');
-    for (const t of recent) {
-      const who = t.role === 'user' ? 'User' : 'Assistant';
-      lines.push(`- **${who}:** ${clip(t.text, MAX_MSG_CHARS)}`);
+/**
+ * The deterministic fallback summary (used when the LLM summarizer is
+ * unavailable): the most recent turns, clipped + capped. Returned as the
+ * `summary` argument to {@link buildBrief}.
+ */
+export function heuristicSummary(task: string, events: ReadonlyArray<unknown>): string {
+  const recent = withoutGoalTail(digestTurns(events), task).slice(-MAX_TURNS);
+  if (recent.length === 0) return '(no prior conversation to summarize)';
+  const lines = ['(heuristic summary — LLM summarizer unavailable; recent turns:)'];
+  for (const t of recent) {
+    lines.push(`- **${t.role === 'user' ? 'User' : 'Assistant'}:** ${clip(t.text, MAX_MSG_CHARS)}`);
+  }
+  let body = lines.join('\n');
+  if (body.length > MAX_TOTAL_CHARS) body = `${body.slice(0, MAX_TOTAL_CHARS - 1)}…`;
+  return body;
+}
+
+/**
+ * The CONVERSATION.md recall file: the full (clipped) transcript. Generous caps
+ * because it's read on demand, never auto-loaded into an agent's context.
+ */
+export function buildConversation(task: string, events: ReadonlyArray<unknown>): string {
+  const turns = digestTurns(events);
+  const lines = [
+    '# Full conversation (recall-only)',
+    '',
+    'Not loaded into any agent by default. Read or grep this only when you need a',
+    'specific detail the brief summary omits.',
+    '',
+    '## Goal',
+    '',
+    clip(task, 1500) || '(no goal text)',
+    '',
+    '## Conversation',
+    '',
+  ];
+  if (turns.length === 0) {
+    lines.push('(no prior conversation)');
+  } else {
+    for (const t of turns) {
+      lines.push(`- **${t.role === 'user' ? 'User' : 'Assistant'}:** ${clip(t.text, CONVERSATION_MSG_CHARS)}`);
     }
   }
-
-  let brief = lines.join('\n');
-  if (brief.length > MAX_TOTAL_CHARS) {
-    brief = `${brief.slice(0, MAX_TOTAL_CHARS - 1)}…`;
-  }
-  return `${brief}\n`;
+  let body = lines.join('\n');
+  if (body.length > CONVERSATION_TOTAL_CHARS) body = `${body.slice(0, CONVERSATION_TOTAL_CHARS - 1)}…`;
+  return `${body}\n`;
 }

--- a/packages/mode-collaborative/src/collab-loop.test.ts
+++ b/packages/mode-collaborative/src/collab-loop.test.ts
@@ -166,10 +166,12 @@ describe('collaborative coordinator (end-to-end, fake agents + real git)', () =>
     expect(existsSync(join(repo, 'api.test.ts'))).toBe(true);
     // the agreed contracts landed too
     expect(existsSync(join(repo, '.moxxy-collab', 'CONTRACTS.md'))).toBe(true);
-    // the coordinator distilled a shared brief (goal + intent) into the scaffold
+    // the coordinator distilled a shared brief (goal + summary) into the scaffold,
+    // and wrote the full conversation to the on-demand recall file
     const briefPath = join(repo, '.moxxy-collab', 'BRIEF.md');
     expect(existsSync(briefPath)).toBe(true);
     expect(readFileSync(briefPath, 'utf8')).toContain('build the thing');
+    expect(existsSync(join(repo, '.moxxy-collab', 'CONVERSATION.md'))).toBe(true);
     expect(subtypes).toContain('collab_brief_written');
 
     // final synthesis names both agents

--- a/packages/mode-collaborative/src/collab-loop.ts
+++ b/packages/mode-collaborative/src/collab-loop.ts
@@ -24,6 +24,7 @@ import {
   COLLAB_PLUGIN_ID,
   COLLAB_SCAFFOLD_DIR,
   BRIEF_FILENAME,
+  CONVERSATION_FILENAME,
   ROSTER_FILENAME,
   collabBranch,
   collabRunDir,
@@ -33,7 +34,8 @@ import {
   worktreeRoot,
 } from './constants.js';
 import { resolveCollabConfig, type CollabConfig } from './config.js';
-import { buildBrief } from './brief.js';
+import { buildBrief, buildConversation, heuristicSummary } from './brief.js';
+import { summarizeConversation } from './summarize.js';
 import { writeRunRecord, type CollabRunRecord } from './archive.js';
 import {
   addWorktree,
@@ -166,16 +168,35 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
 
     yield await ctx.emit(plugin(ctx, 'collab_started', { task, parallel, gitInstalled, gitRepo }));
 
-    // Distil the user's conversation into a shared BRIEF the whole team inherits
-    // (the overall goal + intent — not just each agent's narrow subtask). Written
-    // into the scaffold up front so the architect reads it, and committed with the
-    // scaffold (parallel) so every worktree gets it. Best-effort: a brief-write
-    // failure must never sink the run.
+    // Distil the user's conversation for the whole team. BRIEF.md is a CONCISE
+    // SUMMARY (goal + key requirements/constraints/decisions) — one coordinator
+    // LLM call, with a deterministic heuristic fallback — so the N peers don't
+    // each re-ingest the raw transcript. The full conversation goes to
+    // CONVERSATION.md for on-demand recall (never auto-loaded). BOTH are written
+    // here, before the architect spawns + before the scaffold commit, so the
+    // architect reads them and worktrees inherit them. Best-effort throughout: a
+    // brief failure must never sink the run.
     try {
-      briefText = buildBrief(task, ctx.log.slice());
+      const events = ctx.log.slice();
       mkdirSync(join(cwd, COLLAB_SCAFFOLD_DIR), { recursive: true });
+      writeFileSync(join(cwd, COLLAB_SCAFFOLD_DIR, CONVERSATION_FILENAME), buildConversation(task, events));
+      const llmSummary = await summarizeConversation({
+        task,
+        events,
+        provider: ctx.provider,
+        model: ctx.model,
+        signal: ctx.signal,
+      }).catch(() => null);
+      const summary = llmSummary ?? heuristicSummary(task, events);
+      briefText = buildBrief(task, summary);
       writeFileSync(join(cwd, COLLAB_SCAFFOLD_DIR, BRIEF_FILENAME), briefText);
-      yield await ctx.emit(plugin(ctx, 'collab_brief_written', { path: join(COLLAB_SCAFFOLD_DIR, BRIEF_FILENAME) }));
+      yield await ctx.emit(
+        plugin(ctx, 'collab_brief_written', {
+          path: join(COLLAB_SCAFFOLD_DIR, BRIEF_FILENAME),
+          conversationPath: join(COLLAB_SCAFFOLD_DIR, CONVERSATION_FILENAME),
+          summarized: Boolean(llmSummary),
+        }),
+      );
     } catch {
       // brief is an enhancement, not a prerequisite
     }

--- a/packages/mode-collaborative/src/constants.ts
+++ b/packages/mode-collaborative/src/constants.ts
@@ -18,9 +18,14 @@ export const COLLAB_SCAFFOLD_DIR = '.moxxy-collab';
 export const CONTRACTS_FILENAME = 'CONTRACTS.md';
 /** Architect's machine-readable roster proposal, read by the coordinator. */
 export const ROSTER_FILENAME = 'roster.json';
-/** Coordinator-written brief: the overall goal + the user's conversation/intent,
- *  so every spawned agent inherits the full picture (not just its subtask). */
+/** Coordinator-written brief: a CONCISE summary (goal + key requirements/
+ *  constraints/decisions) every spawned agent reads up front — not the raw
+ *  transcript. */
 export const BRIEF_FILENAME = 'BRIEF.md';
+/** The full conversation, written for ON-DEMAND recall only — never loaded into
+ *  an agent's context by default. An agent reads/greps it if it needs a detail
+ *  the brief summary omits. */
+export const CONVERSATION_FILENAME = 'CONVERSATION.md';
 
 /** A short, filesystem-safe run id from the session + turn ids. */
 export function collabRunId(sessionId: string, turnId: string): string {

--- a/packages/mode-collaborative/src/prompts.test.ts
+++ b/packages/mode-collaborative/src/prompts.test.ts
@@ -10,6 +10,14 @@ describe('collaboration prompts', () => {
     }
   });
 
+  it('describe the brief as a summary + offer CONVERSATION.md for on-demand recall', () => {
+    for (const p of [COLLAB_ARCHITECT_PROMPT, COLLAB_PEER_PROMPT]) {
+      expect(p).toContain('.moxxy-collab/CONVERSATION.md');
+    }
+    // the shared prompt must say the full transcript is NOT auto-loaded
+    expect(COLLAB_PEER_PROMPT.toLowerCase()).toContain('do not load it wholesale');
+  });
+
   it('tell agents to reply to the human (not go silent on a directive/DM)', () => {
     for (const p of [COLLAB_ARCHITECT_PROMPT, COLLAB_PEER_PROMPT]) {
       expect(p).toContain('collab_send to "human"');

--- a/packages/mode-collaborative/src/prompts.ts
+++ b/packages/mode-collaborative/src/prompts.ts
@@ -4,13 +4,13 @@
  * contracts + roster) from an implementer (build to contracts, coordinate).
  */
 
-import { BRIEF_FILENAME, COLLAB_SCAFFOLD_DIR, CONTRACTS_FILENAME, ROSTER_FILENAME } from './constants.js';
+import { BRIEF_FILENAME, CONVERSATION_FILENAME, COLLAB_SCAFFOLD_DIR, CONTRACTS_FILENAME, ROSTER_FILENAME } from './constants.js';
 
 /** Shared rules every collaborating agent follows. */
 const COLLAB_COMMON = `You are one agent on a TEAM of separate agents collaborating on one task in a shared workspace. You are a peer, not in charge — you cooperate.
 
 Know the WHOLE picture before you act:
-- ${COLLAB_SCAFFOLD_DIR}/${BRIEF_FILENAME} is the shared brief — the user's overall goal and the conversation/intent behind it. Read it FIRST so your work serves the real goal, not just the literal words of your sub-task.
+- ${COLLAB_SCAFFOLD_DIR}/${BRIEF_FILENAME} is the shared brief — a concise summary of the user's goal and the key requirements/constraints/decisions. Read it FIRST so your work serves the real goal, not just the literal words of your sub-task. The full conversation is NOT in your context; if you need a specific detail the brief omits, read or grep ${COLLAB_SCAFFOLD_DIR}/${CONVERSATION_FILENAME} — do NOT load it wholesale.
 - Before planning, recall() any relevant prior knowledge about this workspace/task. When you discover a durable fact (a decision, a gotcha, an interface, a convention), memory_save it so the team — and future work — keeps it.
 
 The team coordinates through a shared hub (use these tools):
@@ -36,7 +36,7 @@ You are a TEAM MEMBER with a specific role (given below) and sub-task. Work as t
 export const COLLAB_ARCHITECT_PROMPT = `${COLLAB_COMMON}
 
 You are the ARCHITECT — you run FIRST and set the team up for success. Your job, in order:
-0. Read ${COLLAB_SCAFFOLD_DIR}/${BRIEF_FILENAME} — the user's goal and the conversation behind it — so you decompose toward what they actually want.
+0. Read ${COLLAB_SCAFFOLD_DIR}/${BRIEF_FILENAME} — the goal + key-requirements summary — so you decompose toward what the user actually wants. If you need a detail it omits, grep ${COLLAB_SCAFFOLD_DIR}/${CONVERSATION_FILENAME}.
 1. Explore the workspace to understand the task and its boundaries.
 2. Assemble the RIGHT TEAM for THIS deliverable and decompose into INDEPENDENT sub-tasks with DISJOINT ownership (minimize overlap). Pick the roles the work actually needs — a coding task wants developers + a QA reviewer; a document/plan/design deliverable wants a writer, a researcher, a designer, an editor; a product effort may want a PM to sequence + verify. Don't default everyone to a generic "implementer".
 3. Define the shared CONTRACTS — the interfaces, types, API shapes, section outlines, or boundaries where the team's work meets. Publish each with collab_contract_publish (give an owner + consumers).

--- a/packages/mode-collaborative/src/summarize.test.ts
+++ b/packages/mode-collaborative/src/summarize.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { LLMProvider } from '@moxxy/sdk';
+import { summarizeConversation } from './summarize.js';
+
+const events = [
+  { type: 'user_prompt', text: 'build a docs site' },
+  { type: 'assistant_message', source: 'model', content: 'markdown ok?' },
+  { type: 'user_prompt', text: 'yes, three pages' },
+];
+
+/** A fake provider whose stream yields the given events. */
+function fakeProvider(stream: (req: unknown) => AsyncIterable<{ type: string; delta?: string }>): LLMProvider {
+  return { name: 'fake', models: [{ id: 'm', name: 'm' }], stream } as unknown as LLMProvider;
+}
+
+describe('summarizeConversation', () => {
+  it('returns null (heuristic fallback) when no provider or model is given', async () => {
+    expect(await summarizeConversation({ task: 't', events })).toBeNull();
+    expect(await summarizeConversation({ task: 't', events, provider: fakeProvider(async function* () {}) })).toBeNull();
+  });
+
+  it('accumulates text_delta events into the summary', async () => {
+    const provider = fakeProvider(async function* () {
+      yield { type: 'text_delta', delta: '- goal: docs site\n' };
+      yield { type: 'text_delta', delta: '- 3 pages' };
+    });
+    const out = await summarizeConversation({ task: 't', events, provider, model: 'm' });
+    expect(out).toBe('- goal: docs site\n- 3 pages');
+  });
+
+  it('returns null on a provider error event', async () => {
+    const provider = fakeProvider(async function* () {
+      yield { type: 'text_delta', delta: 'partial' };
+      yield { type: 'error' };
+    });
+    expect(await summarizeConversation({ task: 't', events, provider, model: 'm' })).toBeNull();
+  });
+
+  it('returns null when the model produces no text', async () => {
+    const provider = fakeProvider(async function* () {
+      yield { type: 'text_delta', delta: '   ' };
+    });
+    expect(await summarizeConversation({ task: 't', events, provider, model: 'm' })).toBeNull();
+  });
+
+  it('returns null (never throws) when the provider throws', async () => {
+    const provider = fakeProvider(async function* () {
+      throw new Error('boom');
+    });
+    expect(await summarizeConversation({ task: 't', events, provider, model: 'm' })).toBeNull();
+  });
+});

--- a/packages/mode-collaborative/src/summarize.ts
+++ b/packages/mode-collaborative/src/summarize.ts
@@ -1,0 +1,80 @@
+/**
+ * Coordinator-side conversation summarizer for the collaboration BRIEF.
+ *
+ * One off-log provider call distils the user's dialogue into a short shared
+ * brief, so the N spawned agents inherit the INTENT without each re-ingesting
+ * the whole transcript (the full text lives in CONVERSATION.md for on-demand
+ * recall). Mirrors `@moxxy/plugin-compactor-summarize`'s `providerSummary`:
+ * a direct `provider.stream(...)` (NOT runSingleShotTurn, which would emit
+ * provider/assistant events into the coordinator's own session log + run
+ * compaction). Returns null on ANY failure so the caller falls back to a
+ * deterministic heuristic — a brief must never sink the run.
+ */
+
+import type { LLMProvider } from '@moxxy/sdk';
+import { digestTurns } from './brief.js';
+
+/** Cap on the conversation text fed to the summarizer (head+tail if longer). */
+const MAX_SUMMARIZE_INPUT_CHARS = 48_000;
+const SUMMARY_MAX_TOKENS = 700;
+
+export const COLLAB_SUMMARY_SYSTEM = `You write a SHORT shared brief for a team of AI agents about to build ONE deliverable together. From the user's conversation, extract ONLY:
+1. The overall goal, in one or two sentences.
+2. The concrete requirements and constraints.
+3. Any decisions already made, and the reason.
+4. Explicit do-nots / out-of-scope.
+Use terse bullet points. Do NOT restate the raw conversation, do NOT invent details, omit chit-chat and pleasantries. Output ONLY the brief text — no preamble, no sign-off. Keep it well under 400 words.`;
+
+/**
+ * Summarize the conversation into a brief, or null if no provider/model is
+ * available or the call fails. Never throws.
+ */
+export async function summarizeConversation(args: {
+  task: string;
+  events: ReadonlyArray<unknown>;
+  provider?: LLMProvider;
+  model?: string;
+  signal?: AbortSignal;
+}): Promise<string | null> {
+  const { task, events, provider, model, signal } = args;
+  // Explicit guard (must-fix): the coordinator ctx may carry neither provider
+  // nor model (synthetic/test contexts). Fall back intentionally, not by relying
+  // on an await rejection being swallowed downstream.
+  if (!provider || !model) return null;
+
+  const turns = digestTurns(events);
+  if (turns.length === 0) return null;
+  const joined = turns.map((t) => `[${t.role}] ${t.text}`).join('\n');
+  const input =
+    joined.length > MAX_SUMMARIZE_INPUT_CHARS
+      ? `${joined.slice(0, MAX_SUMMARIZE_INPUT_CHARS / 2)}\n[... transcript truncated ...]\n${joined.slice(-MAX_SUMMARIZE_INPUT_CHARS / 2)}`
+      : joined;
+
+  try {
+    let out = '';
+    for await (const event of provider.stream({
+      model,
+      system: COLLAB_SUMMARY_SYSTEM,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: `Task headline: ${task}\n\nThe user's conversation that produced this task:\n\n${input}`,
+            },
+          ],
+        },
+      ],
+      maxTokens: SUMMARY_MAX_TOKENS,
+      ...(signal ? { signal } : {}),
+    })) {
+      if (event.type === 'text_delta') out += event.delta;
+      if (event.type === 'error') return null;
+    }
+    const trimmed = out.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Why

You asked: *don't fill agents with the session's messages — give a summary + an option to recall a specific message if needed.* Today `buildBrief` dumps up to ~6KB of the raw conversation into `BRIEF.md`, and every one of the N spawned agents is told to read it — so each peer re-ingests the whole dialogue (token-wasteful and exactly what you flagged).

## What changed (design adversarially verified by a sub-agent workflow)

- **`BRIEF.md` is now a concise summary** — the goal + the key requirements / constraints / decisions — produced by a **single coordinator-side off-log `provider.stream` call** (`summarize.ts`, mirroring the proven summarize-compactor pattern: direct stream, accumulate `text_delta`, never touches the user's session log). It has a **deterministic heuristic fallback** (`heuristicSummary`) for when no provider/model is available, so a brief never sinks the run (verified: the test `fakeCtx` carries neither provider nor model → fallback).
- **The full conversation goes to `.moxxy-collab/CONVERSATION.md`** — written for **on-demand recall only**, never auto-loaded into any agent's context. The shared prompt + each peer's seed turn tell agents to read or grep it *only* when they need a detail the summary omits ("do not load it wholesale").

Net effect: peers get the *intent* cheaply (a few hundred words) instead of paying for the transcript N times, and the full detail is still one `grep` away.

## Tests

- `summarize.test.ts`: no-provider/no-model → null; `text_delta` accumulation; `error` event → null; empty → null; provider throw → null (never throws).
- `brief.test.ts`: new `buildBrief(task, summary)` API, `buildConversation` (keeps the full transcript), `heuristicSummary` (windowed fallback, flags itself).
- `collab-loop.test.ts`: the e2e run now asserts `CONVERSATION.md` is written; `prompts.test.ts` asserts the recall pointer.

Build / typecheck / lint / test green locally. Next in the series: coordinator-authored role charters, then the git-first / lock-fallback hybrid execution.