### PR TITLE
feat(collaborative): coordinator-authored role charters (proper, task-suited roles)

### DIFF
--- a/.changeset/collab-role-charters.md
+++ b/.changeset/collab-role-charters.md
@@ -1,0 +1,28 @@
+---
+"@moxxy/plugin-collab": minor
+"@moxxy/mode-collaborative": minor
+---
+
+feat(collaborative): coordinator-authored role charters (proper, task-suited roles)
+
+Every peer ran the SAME generic prompt and only a role LABEL was injected — so a
+"designer" and a "developer" behaved identically. Now the ARCHITECT authors, per
+roster agent, a tailored CHARTER (persona + responsibilities + quality bar +
+collaboration + definition-of-done) suited to THIS task, and each peer runs with
+that charter as part of its system prompt — proper roles created for the task,
+not pre-configured.
+
+- RosterEntry gains an optional `charter`; the architect prompt asks for a 4-8
+  sentence charter per agent.
+- The charter is written to the run dir (NOT the workspace/worktree, so it's
+  never committed), passed to the peer by PATH via a new `MOXXY_COLLAB_CHARTER_FILE`
+  env (never the body), and read at boot into the STATIC system-prompt prefix
+  (cached once, not re-billed per turn).
+- Safety: the charter is LLM-authored, so it is sanitised (NUL-stripped, capped
+  at 2000 chars) and APPENDED after the authoritative shared rules (never the
+  sole prompt); the roster-approval dialog shows a clipped charter preview — the
+  human gate on injected system-prompt text.
+
+Tests: charter carried + capped + written outside the committed tree + passed to
+the peer; peerPromptWithCharter appends-not-replaces; architect prompt asks for a
+charter.

--- a/packages/mode-collaborative/src/collab-loop.test.ts
+++ b/packages/mode-collaborative/src/collab-loop.test.ts
@@ -237,6 +237,57 @@ describe('collaborative coordinator (end-to-end, fake agents + real git)', () =>
     expect(byId.sneaky).toBe('implementer');
   });
 
+  it('passes each peer its architect-authored charter (capped) and keeps it OUT of the committed tree', async () => {
+    const repo = await initRepo();
+    const { ctx } = fakeCtx();
+    const spawned: Array<{ id: string; charterFile?: string; content: string | null }> = [];
+    const longCharter = 'You are the WRITER. '.repeat(200); // >2000 chars → must be capped
+    const deps: CollabDeps = {
+      cwd: repo,
+      config: resolveCollabConfig(undefined, { requireRosterApproval: false }),
+      createSupervisor: (_opts, hub) => ({
+        spawn({ entry, cwd, charterFile }) {
+          if (entry.role === 'architect') {
+            mkdirSync(join(cwd, '.moxxy-collab'), { recursive: true });
+            writeFileSync(join(cwd, '.moxxy-collab', 'CONTRACTS.md'), '# C\n');
+            writeFileSync(
+              join(cwd, '.moxxy-collab', 'roster.json'),
+              JSON.stringify([
+                { id: 'writer', name: 'Writer', role: 'writer', subtask: 'docs', ownedPaths: ['intro.md'], charter: longCharter },
+              ]),
+            );
+            hub.state.markDone('architect', 'done');
+          } else {
+            spawned.push({
+              id: entry.id,
+              charterFile,
+              content: charterFile ? readFileSync(charterFile, 'utf8') : null,
+            });
+            writeFileSync(join(cwd, 'intro.md'), '# intro\n');
+            hub.state.boardClaim(entry.id, ['intro.md']);
+            hub.state.markDone(entry.id, 'done');
+          }
+          return { socket: 'fake.sock' };
+        },
+        stop: async () => undefined,
+        shutdownAll: async () => undefined,
+        stderrOf: () => [],
+        hasExited: () => false,
+      }),
+    };
+
+    for await (const _ of runCollaborative(ctx, deps)) void _;
+
+    const writer = spawned.find((s) => s.id === 'writer')!;
+    expect(writer.charterFile).toBeTruthy();
+    expect(writer.content).toContain('You are the WRITER.');
+    // capped at 2000 (+ trailing newline)
+    expect(writer.content!.trimEnd().length).toBeLessThanOrEqual(2000);
+    // the charter lives in the run dir, NOT the committed scaffold/worktree
+    expect(existsSync(join(repo, '.moxxy-collab', 'charter-writer.md'))).toBe(false);
+    expect(writer.charterFile).not.toContain(repo);
+  });
+
   it('does NOT hang on a failed agent: surfaces it and completes with the others', async () => {
     const repo = await initRepo();
     const { ctx, events } = fakeCtx();

--- a/packages/mode-collaborative/src/collab-loop.ts
+++ b/packages/mode-collaborative/src/collab-loop.ts
@@ -26,6 +26,7 @@ import {
   BRIEF_FILENAME,
   CONVERSATION_FILENAME,
   ROSTER_FILENAME,
+  charterFilePath,
   collabBranch,
   collabRunDir,
   collabRunId,
@@ -232,7 +233,18 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
     if (cfg.requireRosterApproval && ctx.approval) {
       const decision = await ctx.approval.confirm({
         title: `Team of ${roster.length} agent${roster.length === 1 ? '' : 's'} — review before launch`,
-        body: roster.map((r, i) => `${i + 1}. [${r.id}] ${r.name} — ${r.role}\n    ${r.subtask}`).join('\n\n'),
+        body: roster
+          .map((r, i) => {
+            // Surface a clipped charter preview — the architect-authored charter
+            // becomes the agent's system prompt, so the human roster review is the
+            // gate on that injected text. Strip newlines so one charter can't swamp
+            // the dialog.
+            const charterLine = r.charter
+              ? `\n    charter: ${r.charter.replace(/\s+/g, ' ').slice(0, 140)}${r.charter.length > 140 ? '…' : ''}`
+              : '';
+            return `${i + 1}. [${r.id}] ${r.name} — ${r.role}\n    ${r.subtask}${charterLine}`;
+          })
+          .join('\n\n'),
         kind: 'collab.roster',
         defaultOptionId: 'launch',
         options: [
@@ -262,7 +274,8 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
         const wt = worktreePath(runId, entry.id);
         await addWorktree({ repoCwd: cwd, path: wt, branch: collabBranch(runId, entry.id), baseSha });
         worktrees.set(entry.id, wt);
-        supervisor.spawn({ entry, cwd: wt, mode: COLLAB_PEER_MODE_NAME });
+        const charterFile = writeCharterFile(runId, entry);
+        supervisor.spawn({ entry, cwd: wt, mode: COLLAB_PEER_MODE_NAME, ...(charterFile ? { charterFile } : {}) });
         yield await ctx.emit(plugin(ctx, 'collab_agent_spawned', { id: entry.id, role: entry.role }));
       }
       await waitForAgents(hub, supervisor, roster.map((r) => r.id), ctx.signal, cfg.wallClockMs);
@@ -273,7 +286,8 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
       for (const entry of roster) {
         if (ctx.signal.aborted) break;
         hub.state.addAgent(entry);
-        supervisor.spawn({ entry, cwd, mode: COLLAB_PEER_MODE_NAME });
+        const charterFile = writeCharterFile(runId, entry);
+        supervisor.spawn({ entry, cwd, mode: COLLAB_PEER_MODE_NAME, ...(charterFile ? { charterFile } : {}) });
         yield await ctx.emit(plugin(ctx, 'collab_agent_spawned', { id: entry.id, role: entry.role }));
         const ok = await waitForAgent(hub, supervisor, entry.id, ctx.signal, cfg.wallClockMs);
         if (!ok) yield* surfaceFailures(ctx, hub, supervisor, [entry.id]);
@@ -441,6 +455,7 @@ function readRoster(path: string, maxAgents: number): RosterEntry[] {
         subtask: r.subtask,
         ...(Array.isArray(r.ownedPaths) ? { ownedPaths: r.ownedPaths.filter((p) => typeof p === 'string') } : {}),
         ...(typeof r.model === 'string' ? { model: r.model } : {}),
+        ...(typeof r.charter === 'string' && r.charter.trim() ? { charter: cleanCharter(r.charter) } : {}),
       });
       if (out.length >= maxAgents) break;
     }
@@ -462,6 +477,26 @@ function cleanRole(raw: unknown): string {
   const r = raw.toLowerCase().replace(/[^a-z0-9 -]/g, '').replace(/\s+/g, ' ').trim().slice(0, 24);
   if (!r || r === ARCHITECT_AGENT_ID) return 'implementer';
   return r;
+}
+
+/** Sanitise an architect-authored charter: strip NULs and cap length (it's
+ *  LLM-authored free text that lands in the peer's system prompt, so bound it). */
+function cleanCharter(raw: string): string {
+  return raw.replace(/\u0000/g, '').trim().slice(0, 2000);
+}
+
+/** Write a peer's charter to the run dir (outside cwd/worktrees, so it's never
+ *  committed) and return the path, or undefined when there's no charter / write
+ *  fails. Best-effort — a missing charter just falls back to the generic prompt. */
+function writeCharterFile(runId: string, entry: RosterEntry): string | undefined {
+  if (!entry.charter) return undefined;
+  const p = charterFilePath(runId, entry.id);
+  try {
+    writeFileSync(p, `${entry.charter}\n`);
+    return p;
+  } catch {
+    return undefined;
+  }
 }
 
 type HubLike = { state: { rosterView(): { agents: ReadonlyArray<{ id: string; status: string }> } } };

--- a/packages/mode-collaborative/src/constants.ts
+++ b/packages/mode-collaborative/src/constants.ts
@@ -46,6 +46,13 @@ export function peerSocketPath(runId: string, agentId: string): string {
   return join(collabRunDir(runId), `p-${agentId}.sock`);
 }
 
+/** Per-agent charter file (architect-authored role brief). Lives in the run dir
+ *  (NOT the workspace/worktree) so it's never swept into the scaffold commit, yet
+ *  is reachable by an absolute path from every peer regardless of git mode. */
+export function charterFilePath(runId: string, agentId: string): string {
+  return join(collabRunDir(runId), `charter-${agentId}.md`);
+}
+
 /** Per-run worktree root (kept out of the repo, under the OS temp dir). */
 export function worktreeRoot(runId: string): string {
   return join(tmpdir(), 'moxxy-collab', runId);

--- a/packages/mode-collaborative/src/modes.ts
+++ b/packages/mode-collaborative/src/modes.ts
@@ -5,9 +5,11 @@
  * `moxxy agent` processes via MOXXY_MODE, not by the user directly.
  */
 
+import { readFileSync } from 'node:fs';
 import { defineMode, type ModeDef } from '@moxxy/sdk';
+import { COLLAB_ENV } from '@moxxy/plugin-collab';
 import { COLLAB_ARCHITECT_MODE_NAME, COLLAB_PEER_MODE_NAME } from './constants.js';
-import { COLLAB_ARCHITECT_PROMPT, COLLAB_PEER_PROMPT } from './prompts.js';
+import { COLLAB_ARCHITECT_PROMPT, COLLAB_PEER_PROMPT, peerPromptWithCharter } from './prompts.js';
 import { runCollabAgentLoop } from './agent-loop.js';
 
 export const collabArchitectMode: ModeDef = defineMode({
@@ -17,9 +19,22 @@ export const collabArchitectMode: ModeDef = defineMode({
   run: (ctx) => runCollabAgentLoop(ctx, { systemPrompt: COLLAB_ARCHITECT_PROMPT }),
 });
 
+/** Read this peer's architect-authored charter (if any) so it lands in the
+ *  STATIC system-prompt prefix (cached once), not the per-turn message. Missing
+ *  / unreadable → the generic peer prompt. */
+function peerSystemPrompt(env: Readonly<Record<string, string | undefined>>): string {
+  const path = env[COLLAB_ENV.CharterFile]?.trim();
+  if (!path) return COLLAB_PEER_PROMPT;
+  try {
+    return peerPromptWithCharter(readFileSync(path, 'utf8'));
+  } catch {
+    return COLLAB_PEER_PROMPT;
+  }
+}
+
 export const collabPeerMode: ModeDef = defineMode({
   name: COLLAB_PEER_MODE_NAME,
-  description: 'Collaboration peer (internal): an implementer building to the shared contracts.',
+  description: 'Collaboration peer (internal): a team member building to the shared contracts.',
   badge: { label: 'TEAM', tone: 'attention' },
-  run: (ctx) => runCollabAgentLoop(ctx, { systemPrompt: COLLAB_PEER_PROMPT }),
+  run: (ctx) => runCollabAgentLoop(ctx, { systemPrompt: peerSystemPrompt(ctx.env) }),
 });

--- a/packages/mode-collaborative/src/peer-supervisor.ts
+++ b/packages/mode-collaborative/src/peer-supervisor.ts
@@ -27,6 +27,9 @@ export interface SpawnPeerArgs {
   readonly entry: RosterEntry;
   readonly cwd: string;
   readonly mode: string;
+  /** Path to this agent's architect-authored charter file (read at boot into the
+   *  peer's system prompt). Only the PATH crosses env, never the charter body. */
+  readonly charterFile?: string;
 }
 
 /**
@@ -72,6 +75,7 @@ export class PeerSupervisor implements Supervisor {
       [COLLAB_ENV.Subtask]: args.entry.subtask,
       [COLLAB_ENV.ParentTask]: this.opts.parentTask,
       [COLLAB_ENV.RunnerSocket]: socket,
+      ...(args.charterFile ? { [COLLAB_ENV.CharterFile]: args.charterFile } : {}),
       MOXXY_SESSION_ID: `${this.opts.coordinatorSessionId}::${args.entry.id}`,
       MOXXY_MODE: args.mode,
     };

--- a/packages/mode-collaborative/src/prompts.test.ts
+++ b/packages/mode-collaborative/src/prompts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { COLLAB_ARCHITECT_PROMPT, COLLAB_PEER_PROMPT } from './prompts.js';
+import { COLLAB_ARCHITECT_PROMPT, COLLAB_PEER_PROMPT, peerPromptWithCharter } from './prompts.js';
 
 describe('collaboration prompts', () => {
   it('point every agent at the shared brief + memory recall/save', () => {
@@ -31,5 +31,28 @@ describe('collaboration prompts', () => {
     expect(COLLAB_ARCHITECT_PROMPT.toLowerCase()).toContain('qa');
     // architect must not put itself in the roster
     expect(COLLAB_ARCHITECT_PROMPT).toContain('do NOT use "architect"');
+  });
+
+  it('ask the architect to author a per-agent charter', () => {
+    expect(COLLAB_ARCHITECT_PROMPT).toContain('"charter"');
+    expect(COLLAB_ARCHITECT_PROMPT.toLowerCase()).toContain('definition of done');
+  });
+});
+
+describe('peerPromptWithCharter', () => {
+  it('returns the generic peer prompt verbatim when there is no charter', () => {
+    expect(peerPromptWithCharter(undefined)).toBe(COLLAB_PEER_PROMPT);
+    expect(peerPromptWithCharter('   ')).toBe(COLLAB_PEER_PROMPT);
+  });
+
+  it('APPENDS the charter after the authoritative peer prompt (never replaces it)', () => {
+    const out = peerPromptWithCharter('You are the QA reviewer. Verify everything.');
+    // the authoritative shared rules come first...
+    expect(out.startsWith(COLLAB_PEER_PROMPT)).toBe(true);
+    // ...then the charter, as a delimited section
+    expect(out).toContain('## Your charter');
+    expect(out).toContain('You are the QA reviewer.');
+    // the charter is never the SOLE prompt — COLLAB_COMMON rules precede it
+    expect(out.indexOf('cooperate')).toBeLessThan(out.indexOf('## Your charter'));
   });
 });

--- a/packages/mode-collaborative/src/prompts.ts
+++ b/packages/mode-collaborative/src/prompts.ts
@@ -42,10 +42,22 @@ You are the ARCHITECT — you run FIRST and set the team up for success. Your jo
 3. Define the shared CONTRACTS — the interfaces, types, API shapes, section outlines, or boundaries where the team's work meets. Publish each with collab_contract_publish (give an owner + consumers).
 4. Write two files into the repo:
    - ${COLLAB_SCAFFOLD_DIR}/${CONTRACTS_FILENAME} — human-readable contracts/boundaries the team must follow.
-   - ${COLLAB_SCAFFOLD_DIR}/${ROSTER_FILENAME} — a JSON array proposing the team. Each entry: { "id": "kebab-slug", "name": "Display Name", "role": "<function>", "subtask": "what this agent delivers", "ownedPaths": ["dir/", "file.md"] }. "role" is the agent's FUNCTION — e.g. "developer", "designer", "pm", "qa", "writer", "researcher", "editor" — choose what fits. Do NOT include yourself, and do NOT use "architect" (that's you).
+   - ${COLLAB_SCAFFOLD_DIR}/${ROSTER_FILENAME} — a JSON array proposing the team. Each entry: { "id": "kebab-slug", "name": "Display Name", "role": "<function>", "subtask": "what this agent delivers", "ownedPaths": ["dir/", "file.md"], "charter": "..." }. "role" is the agent's FUNCTION — e.g. "developer", "designer", "pm", "qa", "writer", "researcher", "editor" — choose what fits. For EACH agent write a tailored "charter": a short system-prompt-style brief (roughly 4-8 sentences, plain prose in the second person — "You are …", no markdown headings) giving THIS agent, for THIS task: (a) its persona/expertise, (b) its concrete responsibilities and scope, (c) the quality bar it must hit, (d) how it works with the rest of the team, (e) its definition of done. Make each charter specific to the deliverable — this is how you create proper, task-suited roles instead of generic workers. Do NOT include yourself, and do NOT use "architect" (that's you).
 5. Broadcast a short kickoff summary, then call collab_done.
 
 After the implementers start, you stay available as the BROKER: answer interface questions, and when an implementer proposes a contract change, review it and (if sound) commit it with collab_contract_update so everyone re-syncs.`;
+
+/**
+ * Compose a peer's system prompt with its architect-authored charter. The
+ * generic COLLAB_PEER_PROMPT (which embeds the authoritative COLLAB_COMMON rules)
+ * stays FIRST and the charter is APPENDED as a clearly-delimited section — never
+ * the sole prompt — so the human-directive / contract / coordination rules
+ * always outrank the LLM-authored charter text. The architect never calls this.
+ */
+export function peerPromptWithCharter(charter: string | undefined): string {
+  if (!charter || !charter.trim()) return COLLAB_PEER_PROMPT;
+  return `${COLLAB_PEER_PROMPT}\n\n## Your charter\n\n${charter.trim()}`;
+}
 
 /** The JSON roster file the architect writes, parsed by the coordinator. */
 export const ROSTER_JSON_HINT = `${COLLAB_SCAFFOLD_DIR}/${ROSTER_FILENAME}`;

--- a/packages/plugin-collab/src/hub-types.ts
+++ b/packages/plugin-collab/src/hub-types.ts
@@ -40,6 +40,11 @@ export interface RosterEntry {
   readonly ownedPaths?: ReadonlyArray<string>;
   /** Optional per-agent model override (defaults to the coordinator's). */
   readonly model?: string;
+  /** Architect-authored persona + responsibilities + quality bar + collaboration
+   *  + definition-of-done for THIS agent, suited to this task. Becomes the peer's
+   *  system-prompt prefix. Optional — a missing charter falls back to the generic
+   *  peer prompt. */
+  readonly charter?: string;
 }
 
 /** A roster entry plus live runtime state, held by the hub. */

--- a/packages/plugin-collab/src/process-client.ts
+++ b/packages/plugin-collab/src/process-client.ts
@@ -14,6 +14,8 @@ export const COLLAB_ENV = {
   Subtask: 'MOXXY_COLLAB_SUBTASK',
   ParentTask: 'MOXXY_COLLAB_PARENT_TASK',
   RunnerSocket: 'MOXXY_RUNNER_SOCKET',
+  /** Path (never the body) of this agent's architect-authored role charter. */
+  CharterFile: 'MOXXY_COLLAB_CHARTER_FILE',
 } as const;
 
 let clientPromise: Promise<CollabHubClient | null> | null = null;


### PR DESCRIPTION
## Why

You asked: *remake the system so the coordinator creates proper roles suitable for the task, instead of having them pre-configured.* Today every peer runs the **same** generic prompt and only a role *label* is injected — so a "designer" and a "developer" behave identically.

## What changed (design adversarially verified by a sub-agent workflow)

- The **ARCHITECT authors a tailored `charter` per roster agent** — persona + responsibilities + quality bar + how it collaborates + definition-of-done, written for THIS task. That charter becomes the agent's system-prompt prefix, so a writer writes, a QA reviews, a PM sequences-and-verifies.
- `RosterEntry` gains an optional `charter`; the architect prompt asks for a 4-8 sentence charter per agent.
- The charter is written to the **run dir** (`~/.moxxy/collab/<runId>/charter-<id>.md`) — *outside* the workspace/worktree, so it's **never committed** — and passed to the peer by **PATH** via a new `MOXXY_COLLAB_CHARTER_FILE` env (never the body). The peer mode reads it at boot into the **static system-prompt prefix** (cached once, not re-billed per turn — verified it does NOT go into `buildSeedTurn`'s volatile user message).

### Safety (the must-fixes from adversarial review)
The charter is LLM-authored free text injected into a system prompt, so it's a prompt-injection surface. Mitigations: sanitised (NUL-stripped, **capped at 2000 chars**); **appended after** the authoritative shared rules (`COLLAB_COMMON` comes first — never the sole prompt); and the **roster-approval dialog shows a clipped charter preview** (newlines stripped) — the human gate on the injected text.

## Tests

- `collab-loop.test.ts`: charter carried + **capped** + written **outside the committed tree** + passed to the peer (path under the run dir, not the repo).
- `prompts.test.ts`: `peerPromptWithCharter` **appends, never replaces**; the authoritative rules precede the charter; the architect prompt asks for a charter.

Build / typecheck / lint / test green locally. Stacked logically on the brief-summary PR (#285, merged); rebased onto main. Next: the git-first / lock-fallback hybrid execution.