### PR TITLE
feat(desktop): apps can send their output back to the active session

### DIFF
--- a/.changeset/apps-send-to-session.md
+++ b/.changeset/apps-send-to-session.md
@@ -1,0 +1,8 @@
+---
+'@moxxy/client-core': minor
+'@moxxy/desktop-app-sdk': minor
+'@moxxy/desktop': minor
+'@moxxy/desktop-host': patch
+---
+
+Desktop apps can send their output back to the active session instead of copy+paste. New shared `sendToSession()` + `composerDraftStore` in `@moxxy/client-core` prefill the chat composer and switch to the chat view for the user to review and send. The built-in document anonymizer gains a **Send to chat** button (opt-in per app via `DesktopAppDef.canSendToSession`, enriched with a context line + redaction count). A forward-looking `session.send` capability (permission + bridge method + client sugar) is added to `@moxxy/desktop-app-sdk` for sandboxed apps; it is renderer-dispatched, and the main-process bridge gate refuses it by design.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -119,6 +119,42 @@ blind-merged. This is the standing-job baseline, not a claim of a frozen zero.
 
 ---
 
+## 2026-06-19 — Desktop apps: "Send to chat" (send output back to the session)
+
+Desktop apps can now hand a payload to the user's active session instead of
+copy+paste. Shared core `composerDraftStore` + `sendToSession()` in
+`@moxxy/client-core` (review-in-composer: prefill the composer + switch to chat,
+the user reviews and sends); the built-in anonymizer gained a **Send to chat**
+button (opt-in via `DesktopAppDef.canSendToSession`); and a forward-looking
+`session.send` capability (permission + bridge method + client sugar) was added to
+`@moxxy/desktop-app-sdk` for sandboxed apps.
+
+**Retired:** the SDK's `BridgeMethods`/`BridgeServices` exhaustiveness was only
+half-enforced — the host gate's `_never` switch guaranteed every method had a
+*case*, but nothing guaranteed every method had a *home* (a main service OR a
+documented renderer-dispatch). `session.send` is the first renderer-dispatched
+method; it's now modelled explicitly (`RENDERER_DISPATCHED_METHODS` +
+`isRendererDispatched`), the gate refuses it defensively, and a runtime partition
+test (`bridge-host.test.ts`) asserts main-services and renderer-dispatched methods
+are disjoint and jointly cover every `BridgeMethod`. Closes the latent "a method
+with no service silently falls through" gap.
+
+**New debt logged on sight:**
+- **`RENDERER_DISPATCHED_METHODS` is a manually-maintained disjointness contract.**
+  The set in `bridge.ts` and the `BridgeServices` keys in `bridge-host.ts` must stay
+  disjoint + jointly exhaustive; today that's enforced by a runtime test, not the
+  type system. A type-level partition (or generating the services-key list from the
+  method map) would make a drifting addition a compile error. Low priority while the
+  method set is tiny.
+- **`session.send` is defined but not yet reachable by sandboxed apps.** The SDK
+  capability + host gate are in place, but the renderer iframe runtime / postMessage↔
+  IPC relay that would dispatch `session.send` for a third-party app does not exist
+  yet (the sandboxed-app platform is still foundation-only — `dispatchBridge`/
+  `discoverApps` are unwired). Only the built-in anonymizer path ships working
+  end-to-end. Wiring the relay is a separate, larger piece of work.
+
+---
+
 ## 2026-06-18 — Desktop Apps gallery + offline document anonymizer
 
 Added a registry-backed **Apps** section (new top-level header tab) with a

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -10,6 +10,7 @@ import {
   chatStore,
   usePrefs,
   useSessionInfoBridge,
+  useComposerChatViewRequest,
 } from '@moxxy/client-core';
 import { AskSheet } from './chat/AskSheet';
 import { useAskSurfaceClaimed } from '@/lib/askSurface';
@@ -72,6 +73,11 @@ export function App(): JSX.Element {
   useEffect(() => {
     chatStore.setActive(activeWorkspaceId);
   }, [activeWorkspaceId]);
+
+  // When an app (or other off-chat surface) does "Send to chat", it stages a
+  // composer draft and pulses a request to show the chat view — switch to it so
+  // the user lands on the prefilled composer.
+  useComposerChatViewRequest(() => setView('chat'));
 
   // When the agent drives the browser / terminal, open the matching rail
   // pane so its work is shown to the user (once per session per pane).

--- a/apps/desktop/src/apps/AppsPanel.tsx
+++ b/apps/desktop/src/apps/AppsPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { sendToSession } from '@moxxy/client-core';
 import { ViewHeader, ViewSwitcher, type View } from '../shell/ViewHeader';
 import { getDesktopApp, listDesktopApps } from './registry';
 import { AppCard } from './AppCard';
@@ -23,7 +24,14 @@ export function AppsPanel({
   const open = openId ? getDesktopApp(openId) : undefined;
   if (open) {
     const App = open.Component;
-    return <App onExit={() => setOpenId(null)} />;
+    // Only apps that opted in (`canSendToSession`) get the capability — the
+    // module-level `sendToSession` resolves the active workspace itself.
+    return (
+      <App
+        onExit={() => setOpenId(null)}
+        {...(open.canSendToSession ? { sendToSession } : {})}
+      />
+    );
   }
 
   const apps = listDesktopApps();

--- a/apps/desktop/src/apps/anonymizer/AnonymizerApp.test.tsx
+++ b/apps/desktop/src/apps/anonymizer/AnonymizerApp.test.tsx
@@ -127,4 +127,24 @@ describe('AnonymizerApp redesigned flow', () => {
     fireEvent.click(screen.getByRole('button', { name: /Apps/i }));
     expect(onExit).toHaveBeenCalledTimes(1);
   });
+
+  it('"Send to chat" hands the redacted text + a title to sendToSession', () => {
+    const sendToSession = vi.fn();
+    render(<AnonymizerApp onExit={vi.fn()} sendToSession={sendToSession} />);
+    paste(SAMPLE);
+    fireEvent.click(screen.getByTestId('anon-send-chat'));
+
+    expect(sendToSession).toHaveBeenCalledTimes(1);
+    const payload = sendToSession.mock.calls[0]?.[0];
+    expect(payload.text).toContain('[EMAIL]');
+    expect(payload.text).not.toContain('a@b.com');
+    expect(payload.title).toMatch(/Redacted document/);
+    expect(payload.meta).toMatchObject({ source: 'anonymizer' });
+  });
+
+  it('"Send to chat" is hidden when the capability was not granted', () => {
+    render(<AnonymizerApp onExit={vi.fn()} />);
+    paste(SAMPLE);
+    expect(screen.queryByTestId('anon-send-chat')).not.toBeInTheDocument();
+  });
 });

--- a/apps/desktop/src/apps/anonymizer/AnonymizerApp.tsx
+++ b/apps/desktop/src/apps/anonymizer/AnonymizerApp.tsx
@@ -63,7 +63,7 @@ function bytesToBase64(bytes: Uint8Array): string {
  * is uploaded; opening a file only reads it locally (in main) and returns the
  * text here.
  */
-export function AnonymizerApp({ onExit }: DesktopAppProps): JSX.Element {
+export function AnonymizerApp({ onExit, sendToSession }: DesktopAppProps): JSX.Element {
   const anon = useAnonymizer();
   const { status: nerStatus, error: nerError, detectNames } = useNer();
 
@@ -209,6 +209,18 @@ export function AnonymizerApp({ onExit }: DesktopAppProps): JSX.Element {
     }
   };
 
+  // Hand the redacted text straight to the agent — no copy+paste. Enriched with
+  // a short context line (so the agent knows it's redacted, and from which file)
+  // and a count for downstream use. Review-in-composer: it lands in the chat
+  // composer for the user to review and send.
+  const sendToChat = (): void => {
+    sendToSession?.({
+      title: `Redacted document${fileName && fileName !== 'Document' ? ` (${fileName})` : ''}`,
+      text: result.text,
+      meta: { source: 'anonymizer', redactions: result.report.total },
+    });
+  };
+
   return (
     <>
       <ViewHeader>
@@ -310,6 +322,12 @@ export function AnonymizerApp({ onExit }: DesktopAppProps): JSX.Element {
                     <Icon name={copied ? 'check' : 'copy'} size={14} />
                     {copied ? 'Copied' : 'Copy redacted'}
                   </Button>
+                  {sendToSession && (
+                    <Button variant="secondary" data-testid="anon-send-chat" onClick={sendToChat}>
+                      <Icon name="send" size={14} />
+                      Send to chat
+                    </Button>
+                  )}
                   <Button variant="secondary" data-testid="anon-save" onClick={() => void saveOut()}>
                     Save as…
                   </Button>

--- a/apps/desktop/src/apps/builtins.ts
+++ b/apps/desktop/src/apps/builtins.ts
@@ -16,5 +16,6 @@ registerDesktopApp({
   requiresInstall: true,
   installSummary:
     'Downloads a ~110 MB on-device model for detecting names. After install it runs fully offline.',
+  canSendToSession: true,
   Component: AnonymizerApp,
 });

--- a/apps/desktop/src/apps/registry.ts
+++ b/apps/desktop/src/apps/registry.ts
@@ -1,9 +1,15 @@
 import type { ComponentType } from 'react';
 import type { IconName } from '@moxxy/desktop-ui';
+import type { SendToSessionPayload } from '@moxxy/client-core';
 
 export interface DesktopAppProps {
   /** Return to the Apps gallery. */
   readonly onExit: () => void;
+  /** Hand a payload to the user's active session (review-in-composer): prefills
+   *  the chat composer + switches to chat for the user to review and send.
+   *  Present ONLY when the app declared `canSendToSession` — apps that didn't
+   *  opt in never receive it, so the capability can't be used by accident. */
+  readonly sendToSession?: (payload: SendToSessionPayload) => void;
 }
 
 /**
@@ -28,6 +34,10 @@ export interface DesktopAppDef {
   readonly requiresInstall?: boolean;
   /** One line describing what Install downloads (size, what it's for). */
   readonly installSummary?: string;
+  /** Opt in to the "send to chat" capability: when set, the gallery passes a
+   *  `sendToSession` to the component so it can push output into the active
+   *  session's composer. Off by default — a capability the app must request. */
+  readonly canSendToSession?: boolean;
   /** Full-pane component, rendered inside `<main className="col-main col-main--flat">`. */
   readonly Component: ComponentType<DesktopAppProps>;
 }

--- a/apps/desktop/src/chat/Composer.tsx
+++ b/apps/desktop/src/chat/Composer.tsx
@@ -13,6 +13,7 @@ import { useQueuedTurns } from '@moxxy/client-core';
 import { useVoiceRecorder } from '@moxxy/client-core';
 import { useActiveModeBadge } from '@moxxy/client-core';
 import { chatStore } from '@moxxy/client-core';
+import { composerDraftStore, usePendingComposerDraft } from '@moxxy/client-core';
 import { AgentPicker } from './AgentPicker';
 import { ModeBanner } from './composer/ModeBanner';
 import { ContextMeter } from './ContextMeter';
@@ -165,6 +166,24 @@ export function Composer({
         .catch(() => {});
     }
   }, [ready, workspaceId]);
+
+  // "Send to chat" from an app (or other off-chat surface) stages a draft for
+  // this workspace via composerDraftStore; drain it into the composer for the
+  // user to review and send. APPEND to an in-progress draft rather than clobber
+  // it (the user may have started typing), then focus + put the caret at the end
+  // so Enter sends immediately. The auto-grow effect below resizes for free.
+  const pendingDraft = usePendingComposerDraft(workspaceId);
+  useEffect(() => {
+    if (pendingDraft == null) return;
+    composerDraftStore.takeDraft(workspaceId);
+    setDraft((cur) => (cur.trim() ? `${cur.trimEnd()}\n\n${pendingDraft}` : pendingDraft));
+    requestAnimationFrame(() => {
+      const ta = taRef.current;
+      if (!ta) return;
+      ta.focus();
+      ta.selectionStart = ta.selectionEnd = ta.value.length;
+    });
+  }, [pendingDraft, workspaceId]);
 
   // Auto-grow: size the textarea to its content so the composer
   // expands as the draft gains lines — whether from a Shift+Enter

--- a/packages/client-core/src/composerDraftStore.test.ts
+++ b/packages/client-core/src/composerDraftStore.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { composerDraftStore, sendToSession } from './composerDraftStore';
+import { connectionStore } from './useConnection';
+
+afterEach(() => {
+  // Drain any state these singleton stores carry between tests.
+  composerDraftStore.takeDraft('ws-1');
+  composerDraftStore.takeDraft('ws-2');
+  composerDraftStore.consumeChatViewRequest();
+  connectionStore.setActive(null);
+  vi.restoreAllMocks();
+});
+
+describe('composerDraftStore', () => {
+  it('prefill stages a per-workspace draft and raises the chat-view pulse', () => {
+    composerDraftStore.prefill('ws-1', 'hello');
+    expect(composerDraftStore.peekDraft('ws-1')).toBe('hello');
+    expect(composerDraftStore.peekDraft('ws-2')).toBeNull();
+    expect(composerDraftStore.peekChatViewRequest()).toBe(true);
+  });
+
+  it('peekDraft does not consume; takeDraft consumes once (idempotent)', () => {
+    composerDraftStore.prefill('ws-1', 'x');
+    expect(composerDraftStore.peekDraft('ws-1')).toBe('x'); // peek leaves it
+    expect(composerDraftStore.peekDraft('ws-1')).toBe('x');
+    expect(composerDraftStore.takeDraft('ws-1')).toBe('x'); // take returns + clears
+    expect(composerDraftStore.takeDraft('ws-1')).toBeNull(); // second take → null
+    expect(composerDraftStore.peekDraft('ws-1')).toBeNull();
+  });
+
+  it('consumeChatViewRequest clears the pulse', () => {
+    composerDraftStore.prefill('ws-1', 'x');
+    composerDraftStore.consumeChatViewRequest();
+    expect(composerDraftStore.peekChatViewRequest()).toBe(false);
+  });
+
+  it('notifies subscribers on prefill and on take', () => {
+    const fn = vi.fn();
+    const unsub = composerDraftStore.subscribe(fn);
+    composerDraftStore.prefill('ws-1', 'x');
+    composerDraftStore.takeDraft('ws-1');
+    expect(fn).toHaveBeenCalledTimes(2);
+    unsub();
+  });
+});
+
+describe('sendToSession', () => {
+  it('is a no-op returning false when there is no active workspace', () => {
+    connectionStore.setActive(null);
+    expect(sendToSession({ text: 'hi' })).toBe(false);
+    expect(composerDraftStore.peekChatViewRequest()).toBe(false);
+  });
+
+  it('prefills the ACTIVE workspace and returns true', () => {
+    connectionStore.setActive('ws-1');
+    expect(sendToSession({ text: 'hi' })).toBe(true);
+    expect(composerDraftStore.peekDraft('ws-1')).toBe('hi');
+  });
+
+  it('folds title into a leading line; body unchanged without a title', () => {
+    connectionStore.setActive('ws-1');
+    sendToSession({ text: 'BODY', title: 'Redacted document' });
+    expect(composerDraftStore.takeDraft('ws-1')).toBe('Redacted document\n\nBODY');
+
+    sendToSession({ text: 'BODY' });
+    expect(composerDraftStore.takeDraft('ws-1')).toBe('BODY');
+  });
+});

--- a/packages/client-core/src/composerDraftStore.ts
+++ b/packages/client-core/src/composerDraftStore.ts
@@ -1,0 +1,129 @@
+import { useEffect, useRef, useSyncExternalStore } from 'react';
+import { createListenerSet } from './externalStore.js';
+import { connectionStore } from './useConnection.js';
+
+/**
+ * The "send to chat" seam.
+ *
+ * A surface OUTSIDE the chat view (today: a desktop "app" like the document
+ * anonymizer; tomorrow: a sandboxed app via the SDK `session.send` bridge
+ * method) can hand a payload to the user's ACTIVE session without copy+paste.
+ * The behaviour is REVIEW-IN-COMPOSER: the text is prefilled into that
+ * session's composer and the chat view is shown, so the user reviews/edits it
+ * and presses Send. Nothing reaches the model until the user sends — that
+ * review step is the consent gate.
+ *
+ * This is a hand-rolled module store (mirrors {@link ./askStore}) backing
+ * React's `useSyncExternalStore`: a per-workspace pending draft plus a transient
+ * "show the chat view" pulse. The Composer drains the draft; the App shell
+ * consumes the pulse to switch views.
+ */
+
+/** A payload an app hands to the active session. Enrichable: `text` is the body,
+ *  `title` becomes a short leading context line, `meta` rides along for the
+ *  future (not put into the prompt text today), and `submit` is reserved for a
+ *  future auto-send (ignored — the behaviour is always review-in-composer). */
+export interface SendToSessionPayload {
+  readonly text: string;
+  readonly title?: string;
+  readonly meta?: Readonly<Record<string, string | number | boolean>>;
+  /** Reserved: auto-submit instead of review-in-composer. Ignored today. */
+  readonly submit?: boolean;
+}
+
+class ComposerDraftStore {
+  /** workspaceId -> text waiting to be drained into that composer. */
+  private drafts = new Map<string, string>();
+  /** Transient "bring the chat view forward" request, consumed by the shell. */
+  private wantChatView = false;
+  private readonly listeners = createListenerSet();
+
+  subscribe = this.listeners.subscribe;
+
+  /** Stage `text` for `workspaceId`'s composer and ask the shell to show chat.
+   *  Always emits — even for an identical re-send — because the consumer clears
+   *  its snapshot on drain, so the next identical prefill is still observed. */
+  prefill(workspaceId: string, text: string): void {
+    this.drafts.set(workspaceId, text);
+    this.wantChatView = true;
+    this.listeners.emit();
+  }
+
+  /** Pending draft for a workspace, or null. PURE — safe as a
+   *  `useSyncExternalStore` snapshot getter (returns a primitive). */
+  peekDraft(workspaceId: string): string | null {
+    return this.drafts.get(workspaceId) ?? null;
+  }
+
+  /** Drain a workspace's pending draft (returns it, then clears). Emits so the
+   *  snapshot returns to null — idempotent: a second call returns null. */
+  takeDraft(workspaceId: string): string | null {
+    const text = this.drafts.get(workspaceId) ?? null;
+    if (text == null) return null;
+    this.drafts.delete(workspaceId);
+    this.listeners.emit();
+    return text;
+  }
+
+  /** Whether a "show the chat view" request is pending. PURE snapshot getter. */
+  peekChatViewRequest = (): boolean => this.wantChatView;
+
+  /** Clear the "show the chat view" request after the shell has acted on it. */
+  consumeChatViewRequest(): void {
+    if (!this.wantChatView) return;
+    this.wantChatView = false;
+    this.listeners.emit();
+  }
+}
+
+export const composerDraftStore = new ComposerDraftStore();
+
+/** Fold a payload into the single string the user reviews in the composer.
+ *  `title` becomes a leading line; `meta` is intentionally not serialised. */
+function formatPayload(payload: SendToSessionPayload): string {
+  const text = payload.text;
+  const title = payload.title?.trim();
+  return title ? `${title}\n\n${text}` : text;
+}
+
+/**
+ * Hand a payload to the user's ACTIVE session (review-in-composer). Resolves the
+ * active workspace from the connection store, prefills its composer, and pulses
+ * a chat-view request. Returns `false` (a no-op) when there is no active
+ * workspace yet — the caller can surface that, though in practice an app is only
+ * reachable once a workspace is connected.
+ */
+export function sendToSession(payload: SendToSessionPayload): boolean {
+  const workspaceId = connectionStore.active$();
+  if (!workspaceId) return false;
+  composerDraftStore.prefill(workspaceId, formatPayload(payload));
+  return true;
+}
+
+/** The pending composer prefill for `workspaceId` (null when none). The Composer
+ *  subscribes to this and drains it via {@link composerDraftStore.takeDraft}. */
+export function usePendingComposerDraft(workspaceId: string | null): string | null {
+  return useSyncExternalStore(composerDraftStore.subscribe, () =>
+    workspaceId ? composerDraftStore.peekDraft(workspaceId) : null,
+  );
+}
+
+/**
+ * Run `onRequested` once whenever a "show the chat view" pulse arrives (e.g. the
+ * user clicked an app's "Send to chat"). The shell wires this to its view-state
+ * setter. `onRequested` is held in a ref so an inline callback doesn't re-fire
+ * the effect every render.
+ */
+export function useComposerChatViewRequest(onRequested: () => void): void {
+  const cb = useRef(onRequested);
+  cb.current = onRequested;
+  const requested = useSyncExternalStore(
+    composerDraftStore.subscribe,
+    composerDraftStore.peekChatViewRequest,
+  );
+  useEffect(() => {
+    if (!requested) return;
+    composerDraftStore.consumeChatViewRequest();
+    cb.current();
+  }, [requested]);
+}

--- a/packages/client-core/src/index.ts
+++ b/packages/client-core/src/index.ts
@@ -19,6 +19,7 @@ export * from './chatModel.js';
 export * from './chatStore.js';
 export * from './chatPersistence.js';
 export * from './askStore.js';
+export * from './composerDraftStore.js';
 
 // Hooks.
 export * from './useChat.js';

--- a/packages/desktop-app-sdk/src/bridge.test.ts
+++ b/packages/desktop-app-sdk/src/bridge.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  METHOD_PERMISSION,
+  RENDERER_DISPATCHED_METHODS,
+  isRendererDispatched,
+  type BridgeMethod,
+} from './bridge';
+import { isAppPermission } from './permissions';
+
+/**
+ * Guards the renderer-dispatch contract: every bridge method maps to a real
+ * permission, `session.send` is renderer-dispatched, and the renderer-dispatched
+ * set stays a strict subset of the known methods. The DISJOINTNESS half of the
+ * invariant (renderer-dispatched ∩ main `BridgeServices` = ∅) is asserted on the
+ * host side in `@moxxy/desktop-host` where `BridgeServices` lives.
+ */
+describe('bridge method ↔ permission contract', () => {
+  it('maps every method to a known permission', () => {
+    for (const [method, perm] of Object.entries(METHOD_PERMISSION)) {
+      expect(isAppPermission(perm), `${method} → ${perm}`).toBe(true);
+    }
+  });
+
+  it('routes session.send through the session.send permission', () => {
+    expect(METHOD_PERMISSION['session.send']).toBe('session.send');
+  });
+});
+
+describe('RENDERER_DISPATCHED_METHODS', () => {
+  it('only contains known bridge methods', () => {
+    for (const method of RENDERER_DISPATCHED_METHODS) {
+      expect(Object.prototype.hasOwnProperty.call(METHOD_PERMISSION, method)).toBe(true);
+    }
+  });
+
+  it('marks session.send as renderer-dispatched and documents.open as not', () => {
+    expect(isRendererDispatched('session.send' as BridgeMethod)).toBe(true);
+    expect(isRendererDispatched('documents.open' as BridgeMethod)).toBe(false);
+  });
+});

--- a/packages/desktop-app-sdk/src/bridge.ts
+++ b/packages/desktop-app-sdk/src/bridge.ts
@@ -51,6 +51,23 @@ export interface BridgeMethods {
     params: { text: string; mode?: 'label' | 'pseudonym' | 'hash'; customTerms?: string[] };
     result: { spans: BridgeSpan[] };
   };
+  /** Push a payload into the user's ACTIVE chat composer (review-in-composer):
+   *  prefills the composer + shows the chat view; the user reviews/edits and
+   *  presses Send. `title` becomes a short leading context line; `meta` rides
+   *  along for the future and is not put into the prompt text today; `submit`
+   *  is reserved for a future auto-send and is IGNORED for now. Requires
+   *  `session.send`. RENDERER-DISPATCHED (see {@link RENDERER_DISPATCHED_METHODS}):
+   *  handled in the host renderer, never by a main-process service. */
+  'session.send': {
+    params: {
+      text: string;
+      title?: string;
+      meta?: Record<string, string | number | boolean>;
+      /** Reserved: auto-submit instead of review-in-composer. Ignored today. */
+      submit?: boolean;
+    };
+    result: { delivered: boolean };
+  };
 }
 
 export type BridgeMethod = keyof BridgeMethods;
@@ -61,7 +78,29 @@ export const METHOD_PERMISSION: Readonly<Record<BridgeMethod, AppPermission>> = 
   'documents.open': 'documents.open',
   'documents.save': 'documents.save',
   'anonymizer.detect': 'anonymizer.engine',
+  'session.send': 'session.send',
 };
+
+/**
+ * Bridge methods handled in the HOST RENDERER (a UI concern), NOT by a
+ * main-process service. The renderer relay intercepts these and resolves them
+ * locally (e.g. `session.send` prefills the active chat composer), so they
+ * never reach the main-process gate; the gate (`@moxxy/desktop-host`) refuses
+ * them defensively so a forged direct-to-main dispatch can't reach a service
+ * that doesn't exist.
+ *
+ * INVARIANT: this set and the main-process `BridgeServices` keys are DISJOINT
+ * and, together, cover every {@link BridgeMethod}. The SDK keeps one unified
+ * method map; "where it runs" lives here.
+ */
+export const RENDERER_DISPATCHED_METHODS: ReadonlySet<BridgeMethod> = new Set<BridgeMethod>([
+  'session.send',
+]);
+
+/** True when `method` is resolved in the renderer (not a main service). */
+export function isRendererDispatched(method: BridgeMethod): boolean {
+  return RENDERER_DISPATCHED_METHODS.has(method);
+}
 
 /** Tag on every bridge envelope so unrelated `message` events are ignored. */
 export const BRIDGE_TAG = 'moxxy-app-bridge' as const;

--- a/packages/desktop-app-sdk/src/client.ts
+++ b/packages/desktop-app-sdk/src/client.ts
@@ -37,6 +37,12 @@ export interface MoxxyApp {
     suggestedName: string,
     content: string,
   ): Promise<BridgeMethods['documents.save']['result']>;
+  /** Hand a payload to the user's active chat (review-in-composer): it prefills
+   *  the composer and shows the chat view for the user to review + send. Needs
+   *  the `session.send` permission. */
+  sendToSession(
+    payload: BridgeMethods['session.send']['params'],
+  ): Promise<BridgeMethods['session.send']['result']>;
 }
 
 /**
@@ -112,6 +118,7 @@ export function connectMoxxyApp(timeoutMs = 8000): Promise<MoxxyApp> {
         openDocument: () => call('documents.open', undefined),
         saveDocument: (suggestedName, content) =>
           call('documents.save', { suggestedName, content }),
+        sendToSession: (payload) => call('session.send', payload),
       };
     }
   });

--- a/packages/desktop-app-sdk/src/index.ts
+++ b/packages/desktop-app-sdk/src/index.ts
@@ -28,7 +28,9 @@ export {
 export {
   BRIDGE_TAG,
   METHOD_PERMISSION,
+  RENDERER_DISPATCHED_METHODS,
   isBridgeRequest,
+  isRendererDispatched,
   type BridgeMethod,
   type BridgeMethods,
   type BridgeSpan,

--- a/packages/desktop-app-sdk/src/permissions.ts
+++ b/packages/desktop-app-sdk/src/permissions.ts
@@ -29,6 +29,11 @@ export const APP_PERMISSIONS = [
    *  only. (On-device NER needs no permission: an app runs its own model from
    *  its own installed assets, fetched same-origin inside its sandbox.) */
   'anonymizer.engine',
+  /** Push a payload into the user's ACTIVE chat composer (review-in-composer):
+   *  the text is prefilled into the composer and the chat view is shown; the
+   *  user reviews/edits it and presses Send. The app cannot make the agent act
+   *  on its own — nothing reaches the model without the user pressing Send. */
+  'session.send',
 ] as const;
 
 export type AppPermission = (typeof APP_PERMISSIONS)[number];
@@ -45,4 +50,5 @@ export const PERMISSION_LABELS: Readonly<Record<AppPermission, string>> = {
   'documents.open': 'Open documents you choose (reads only what you pick)',
   'documents.save': 'Save its output to a location you choose',
   'anonymizer.engine': 'Detect & redact personal data on your device (offline)',
+  'session.send': 'Send text into your active chat (you review it before sending)',
 };

--- a/packages/desktop-host/src/apps/bridge-host.test.ts
+++ b/packages/desktop-host/src/apps/bridge-host.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { AppManifest } from '@moxxy/desktop-app-sdk';
+import {
+  METHOD_PERMISSION,
+  RENDERER_DISPATCHED_METHODS,
+  type AppManifest,
+} from '@moxxy/desktop-app-sdk';
 
 import { dispatchBridge, type BridgeServices } from './bridge-host';
 
@@ -66,6 +70,21 @@ describe('dispatchBridge (capability gate)', () => {
     expect(r).toEqual({ ok: false, error: 'engine boom' });
   });
 
+  it('refuses a renderer-dispatched method even when granted', async () => {
+    // session.send is resolved in the renderer (review-in-composer); the main
+    // gate must refuse it rather than execute a service that doesn't exist —
+    // even for an app that declared the permission.
+    const r = await dispatchBridge(
+      manifest(['session.send']),
+      'session.send',
+      { text: 'hi' },
+      services(),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain('renderer');
+  });
+
   it('grant of one capability does not imply another', async () => {
     // App declared documents.open but tries documents.save → refused.
     const svc = services();
@@ -77,5 +96,20 @@ describe('dispatchBridge (capability gate)', () => {
     );
     expect(r.ok).toBe(false);
     expect(svc['documents.save']).not.toHaveBeenCalled();
+  });
+
+  it('main services and renderer-dispatched methods partition every bridge method', () => {
+    // Disjoint + jointly exhaustive: each BridgeMethod is EITHER a main service
+    // (a key of `services()`) OR renderer-dispatched, never both/neither. Guards
+    // the SDK↔host invariant from drift when a new method is added.
+    const mainServices = new Set(Object.keys(services()));
+    const rendererDispatched = new Set<string>(RENDERER_DISPATCHED_METHODS);
+    const allMethods = Object.keys(METHOD_PERMISSION);
+
+    for (const m of mainServices) expect(rendererDispatched.has(m)).toBe(false); // disjoint
+    for (const m of allMethods) {
+      expect(mainServices.has(m) !== rendererDispatched.has(m)).toBe(true); // exactly one
+    }
+    expect(mainServices.size + rendererDispatched.size).toBe(allMethods.length);
   });
 });

--- a/packages/desktop-host/src/apps/bridge-host.ts
+++ b/packages/desktop-host/src/apps/bridge-host.ts
@@ -12,6 +12,12 @@
  * complete, enforced grant list; a compromised app's UI can't reach a capability
  * it wasn't granted by forging a different method name.
  *
+ * Some bridge methods are RENDERER-DISPATCHED (see `RENDERER_DISPATCHED_METHODS`
+ * in the SDK) — they're resolved in the host renderer (e.g. `session.send`
+ * prefills the active chat composer) and should never reach this main-process
+ * gate. This gate refuses them by design, so a forged direct-to-main dispatch
+ * can't reach a service that doesn't exist here.
+ *
  * Electron-free + service-injected so it unit-tests in plain Node (the IPC layer
  * supplies the real dialog/parse/engine services); the gate logic is the part
  * worth testing in isolation.
@@ -19,6 +25,7 @@
 
 import {
   METHOD_PERMISSION,
+  isRendererDispatched,
   type AppManifest,
   type AppPermission,
   type BridgeMethod,
@@ -27,7 +34,11 @@ import {
 
 /** The host implementations behind each bridge method. The IPC layer provides
  *  these (native dialogs + main-process parsing + the anonymizer engine); the
- *  gate only calls one after the permission check passes. */
+ *  gate only calls one after the permission check passes.
+ *
+ *  INVARIANT: the keys here and `RENDERER_DISPATCHED_METHODS` (SDK) are DISJOINT
+ *  and jointly cover every {@link BridgeMethod} — a method is EITHER a main
+ *  service listed below OR renderer-dispatched, never both. */
 export interface BridgeServices {
   'documents.open': () => Promise<BridgeMethods['documents.open']['result']>;
   'documents.save': (
@@ -72,6 +83,15 @@ export async function dispatchBridge(
       error: `app "${manifest.id}" is not permitted to call ${method} (needs "${need}")`,
     };
   }
+  // Renderer-dispatched methods (e.g. session.send) have no main-process
+  // service; the renderer relay resolves them locally and never forwards them
+  // here. If one reaches main anyway, refuse it rather than fall through.
+  if (isRendererDispatched(method)) {
+    return {
+      ok: false,
+      error: `bridge method ${method} is handled in the renderer, not the main process`,
+    };
+  }
   try {
     switch (method) {
       case 'documents.open':
@@ -89,6 +109,14 @@ export async function dispatchBridge(
           result: await services['anonymizer.detect'](
             params as BridgeMethods['anonymizer.detect']['params'],
           ),
+        };
+      case 'session.send':
+        // Renderer-dispatched: no main service exists. Already refused above by
+        // the isRendererDispatched guard; this case keeps the exhaustive switch
+        // honest (and refuses defensively even if that guard were removed).
+        return {
+          ok: false,
+          error: 'session.send is renderer-dispatched and has no main service',
         };
       default: {
         // Exhaustiveness guard: a new BridgeMethod added to the SDK without a


### PR DESCRIPTION
## What & why

Desktop **apps** were a dead end — output left only via Copy or Save. This lets an app hand a payload to the user's **active session**, eliminating copy+paste, and lets developers **enrich** it (a context line + metadata) so apps feel connected to the workspace.

**Behaviour = review-in-composer:** the payload prefills the active session's chat composer and switches to the chat view; the user reviews/edits and presses **Send**. Nothing reaches the model until the user sends — that review step is the consent gate.

## Changes

- **`@moxxy/client-core`** — new shared `composerDraftStore` + `sendToSession()`: resolve the active workspace → prefill its composer → pulse a "show chat" request (consumed by the App shell). Appends to an in-progress draft rather than clobbering it; focuses + puts the caret at the end so Enter sends immediately.
- **`@moxxy/desktop` (renderer)** — the built-in **document anonymizer** gains a **Send to chat** button (opt-in per app via `DesktopAppDef.canSendToSession`), enriched with a "Redacted document" title line + redaction count. `Composer` drains the draft store; `App` switches to the chat view on the pulse.
- **`@moxxy/desktop-app-sdk`** — forward-looking `session.send` capability (permission + bridge method + `moxxy.sendToSession()` client sugar) for sandboxed apps. It is **renderer-dispatched** (`RENDERER_DISPATCHED_METHODS` / `isRendererDispatched`); the main-process bridge gate refuses it by design.
- **`@moxxy/desktop-host`** — the bridge gate keeps `BridgeServices` main-only, refuses renderer-dispatched methods defensively, and a partition test asserts main services and renderer-dispatched methods are **disjoint + jointly exhaustive** over every `BridgeMethod`.

## Scope note

The sandboxed-app **iframe runtime is still foundation-only** (`dispatchBridge`/`discoverApps` are unwired), so only the built-in anonymizer path ships working end-to-end today. Third-party apps inherit `session.send` once that runtime lands — this PR deliberately does **not** build it.

## Tests / verification

- New: `composerDraftStore.test.ts` (store + `sendToSession` semantics), `desktop-app-sdk/bridge.test.ts` (method↔permission + renderer-dispatch contract), `bridge-host.test.ts` (refuses `session.send` even when granted; partition guard), anonymizer "Send to chat" cases.
- Gate green: build 70/70, typecheck 137/137, lint 0 errors, full test suite passing, `check:deps` exit 0.
- Manual (dev Electron) still to do: open Apps → anonymizer, redact, click **Send to chat** → lands as a composer draft in the active session; append-not-clobber holds.

Changeset: `@moxxy/client-core` minor, `@moxxy/desktop-app-sdk` minor, `@moxxy/desktop` minor, `@moxxy/desktop-host` patch. TECH_DEBT.md updated (retire + log-on-sight).