### PR TITLE
feat(collaborative): git-first execution with a parallel lock-coordinated fallback (invisible)

### DIFF
--- a/.changeset/collab-hybrid-exec.md
+++ b/.changeset/collab-hybrid-exec.md
@@ -1,0 +1,28 @@
+---
+"@moxxy/mode-collaborative": minor
+"@moxxy/cli": patch
+---
+
+feat(collaborative): git-first execution with a parallel lock-coordinated fallback (invisible)
+
+The non-git path ran agents ONE AT A TIME (sequential) — slow, and it's why "the
+team doesn't respond" when a user runs in a plain folder (only one agent is ever
+live). Now the engine is git-first and always parallel, and picks the safest
+mechanism underneath without any user-facing jargon:
+
+- **Already a git repo** → worktrees + a clean, conflict-aware merge (unchanged).
+- **Plain folder** → we quietly `git init` + snapshot it, so it STILL gets full
+  worktree isolation + merge. Most "plain folder" runs now go fully parallel.
+- **Git genuinely unavailable** (not installed, or init/commit throws) → agents
+  run in PARALLEL in the shared workspace, coordinated by the file-lock board
+  (claim-before-edit). ownedPaths are pre-seeded as locks; an overlap is surfaced.
+- **`concurrency: 'sequential'`** remains as the explicit one-at-a-time fallback.
+
+Safety (from adversarial review): the shared-workspace prompt is hardened —
+claim before EVERY edit, narrowest paths, claim both old+new on rename, one owner
+for shared/aggregator files, only rely on a teammate's released work; the
+architect is required to hand out DISJOINT ownedPaths. peer-read on the shared
+tree reuses the path-traversal guard.
+
+Tests: auto-init → git-parallel; forced no-git → cwd-parallel (not sequential, no
+git repo); explicit sequential; cwd-parallel pre-seed + overlap surfacing.

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -111,7 +111,9 @@ export function buildSeedTurn(args: { role: string; parentTask: string; subtask:
     "user's goal + key requirements) and `.moxxy-collab/CONTRACTS.md` (the agreed " +
     'interfaces). Read them before you start so your work fits the real goal. If you ' +
     'need a detail the brief omits, read or grep `.moxxy-collab/CONVERSATION.md` (the ' +
-    'full transcript) — do not load it wholesale.';
+    'full transcript) — do not load it wholesale. You may share ONE live workspace ' +
+    'with the other agents (no isolation) — collab_claim before every edit, edit only ' +
+    'what you own, and release when done.';
   if (role === 'architect' || !parentTask || parentTask === subtask) {
     return subtask ? `${subtask}\n\n${pointer}` : pointer;
   }

--- a/packages/mode-collaborative/src/collab-loop.test.ts
+++ b/packages/mode-collaborative/src/collab-loop.test.ts
@@ -325,8 +325,8 @@ describe('collaborative coordinator (end-to-end, fake agents + real git)', () =>
     expect(completed.payload.total).toBe(2);
   });
 
-  it('falls back to sequential when the workspace is not a git repo', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'mc-nogit-'));
+  it('GIT-FIRST: auto-inits a plain folder and runs git-parallel (worktrees + merge)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mc-plain-'));
     cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
     const { ctx, events } = fakeCtx();
     const deps: CollabDeps = {
@@ -337,14 +337,109 @@ describe('collaborative coordinator (end-to-end, fake agents + real git)', () =>
 
     for await (const _ of runCollaborative(ctx, deps)) void _;
 
+    const exec = events.find((e) => (e as { subtype?: string }).subtype === 'collab_exec_mode') as {
+      payload: { mode: string };
+    };
+    expect(exec.payload.mode).toBe('git-parallel');
+    // the folder is now a git repo, and the work was integrated into it
+    expect(existsSync(join(dir, '.git'))).toBe(true);
+    expect(existsSync(join(dir, 'api.ts'))).toBe(true);
+    expect(existsSync(join(dir, 'api.test.ts'))).toBe(true);
+  });
+
+  it('NO GIT: runs cwd-parallel (all agents in the shared workspace, lock-coordinated)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mc-nogit-'));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    const { ctx, events } = fakeCtx();
+    const deps: CollabDeps = {
+      cwd: dir,
+      config: resolveCollabConfig(undefined, { requireRosterApproval: false }),
+      detectGit: async () => ({ installed: false, repo: false }), // force the no-git path
+      createSupervisor: (_opts, hub) => fakeSupervisor(hub),
+    };
+
+    for await (const _ of runCollaborative(ctx, deps)) void _;
+
+    const subtypes = events
+      .filter((e) => e.type === 'plugin_event')
+      .map((e) => (e as { subtype: string }).subtype);
+    const exec = events.find((e) => (e as { subtype?: string }).subtype === 'collab_exec_mode') as {
+      payload: { mode: string };
+    };
+    expect(exec.payload.mode).toBe('cwd-parallel');
+    // it is NOT the old sequential fallback, and there is no git repo
+    expect(subtypes).not.toContain('collab_fallback_sequential');
+    expect(existsSync(join(dir, '.git'))).toBe(false);
+    // edits land directly in the shared workspace
+    expect(existsSync(join(dir, 'api.ts'))).toBe(true);
+    expect(existsSync(join(dir, 'api.test.ts'))).toBe(true);
+    expect(subtypes).toContain('collab_completed');
+  });
+
+  it('SEQUENTIAL (explicit): one agent at a time in the shared workspace', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mc-seq-'));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    const { ctx, events } = fakeCtx();
+    const deps: CollabDeps = {
+      cwd: dir,
+      concurrencyOverride: 'sequential',
+      detectGit: async () => ({ installed: false, repo: false }),
+      config: resolveCollabConfig(undefined, { requireRosterApproval: false, concurrency: 'sequential' }),
+      createSupervisor: (_opts, hub) => fakeSupervisor(hub),
+    };
+
+    for await (const _ of runCollaborative(ctx, deps)) void _;
+
     const subtypes = events
       .filter((e) => e.type === 'plugin_event')
       .map((e) => (e as { subtype: string }).subtype);
     expect(subtypes).toContain('collab_fallback_sequential');
-    expect(subtypes).toContain('collab_completed');
-    // sequential edits land directly in the shared workspace
     expect(existsSync(join(dir, 'api.ts'))).toBe(true);
     expect(existsSync(join(dir, 'api.test.ts'))).toBe(true);
+  });
+
+  it('cwd-parallel pre-seeds ownedPaths as locks and surfaces an overlap', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mc-overlap-'));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    const { ctx, events } = fakeCtx();
+    const deps: CollabDeps = {
+      cwd: dir,
+      detectGit: async () => ({ installed: false, repo: false }),
+      config: resolveCollabConfig(undefined, { requireRosterApproval: false }),
+      createSupervisor: (_opts, hub) => ({
+        spawn({ entry, cwd }) {
+          if (entry.role === 'architect') {
+            mkdirSync(join(cwd, '.moxxy-collab'), { recursive: true });
+            writeFileSync(join(cwd, '.moxxy-collab', 'CONTRACTS.md'), '# C\n');
+            writeFileSync(
+              join(cwd, '.moxxy-collab', 'roster.json'),
+              JSON.stringify([
+                { id: 'a', name: 'A', role: 'writer', subtask: 'x', ownedPaths: ['shared.md'] },
+                { id: 'b', name: 'B', role: 'writer', subtask: 'y', ownedPaths: ['shared.md'] }, // overlap!
+              ]),
+            );
+            hub.state.markDone('architect', 'done');
+          } else {
+            writeFileSync(join(cwd, `${entry.id}.md`), '1');
+            hub.state.markDone(entry.id, 'done');
+          }
+          return { socket: 'fake.sock' };
+        },
+        stop: async () => undefined,
+        shutdownAll: async () => undefined,
+        stderrOf: () => [],
+        hasExited: () => false,
+      }),
+    };
+
+    for await (const _ of runCollaborative(ctx, deps)) void _;
+
+    const overlap = events.find(
+      (e) => (e as { subtype?: string }).subtype === 'collab_ownership_overlap',
+    ) as { payload: { id: string; ownedBy: string } } | undefined;
+    expect(overlap).toBeTruthy();
+    expect(overlap!.payload.id).toBe('b');
+    expect(overlap!.payload.ownedBy).toBe('a');
   });
 });
 

--- a/packages/mode-collaborative/src/collab-loop.ts
+++ b/packages/mode-collaborative/src/collab-loop.ts
@@ -41,12 +41,14 @@ import { writeRunRecord, type CollabRunRecord } from './archive.js';
 import {
   addWorktree,
   commitAll,
+  cwdPeerReader,
   detectGit,
   git,
   headSha,
   peerReaderFor,
   removeWorktree,
   resolveBase,
+  tryInitGitRepo,
 } from './worktrees.js';
 import { PeerSupervisor, type PeerSupervisorOptions, type Supervisor } from './peer-supervisor.js';
 import { integrate } from './integrate.js';
@@ -64,6 +66,12 @@ const BOOT_DEADLINE_MS = 90_000;
 export interface CollabDeps {
   readonly cwd?: string;
   readonly config?: CollabConfig;
+  /** One-line override for `concurrency` without a full config (tests + a future
+   *  desktop pref). Ignored when `config` is provided. */
+  readonly concurrencyOverride?: 'parallel' | 'sequential';
+  /** Injection seam — defaults to the real git detector. Lets a test force the
+   *  no-git (cwd-parallel) path deterministically even where git is installed. */
+  readonly detectGit?: (cwd: string) => Promise<{ installed: boolean; repo: boolean }>;
   readonly createSupervisor?: (opts: PeerSupervisorOptions, hub: CollaborationHub) => Supervisor;
 }
 
@@ -78,7 +86,9 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
     return;
   }
 
-  const cfg = deps.config ?? resolveCollabConfig();
+  const cfg =
+    deps.config ??
+    resolveCollabConfig(undefined, deps.concurrencyOverride ? { concurrency: deps.concurrencyOverride } : undefined);
   const cwd = deps.cwd ?? process.cwd();
   const task = lastUserPromptText(ctx) ?? '';
   if (!task.trim()) {
@@ -116,25 +126,34 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
   try {
     mkdirSync(collabRunDir(runId), { recursive: true });
 
-  const { installed: gitInstalled, repo: gitRepo } = await detectGit(cwd);
-  const parallel = cfg.concurrency === 'parallel' && gitRepo;
-  archiveParallel = parallel;
+  // GIT-FIRST execution. We prefer the git-worktree path (true isolation + a
+  // clean, conflict-aware merge). If this folder isn't a git repo yet, quietly
+  // try to make it one so it STILL gets that — so most "plain folder" runs get
+  // full isolation. Only when git genuinely can't be used (not installed, or
+  // init/commit throws) do we fall back to running the team in PARALLEL directly
+  // in the shared workspace, coordinated by the file-lock board. The user never
+  // sees git/worktree/lock jargon — the engine just picks the safest mechanism.
+  const { installed: gitInstalled, repo: alreadyGitRepo } = await (deps.detectGit ?? detectGit)(cwd);
+  let gitRepo = alreadyGitRepo;
+  if (!gitRepo && gitInstalled && cfg.concurrency !== 'sequential') {
+    gitRepo = await tryInitGitRepo(cwd).catch(() => false);
+  }
+  const execMode = resolveExecMode(cfg, gitRepo);
+  const usesGit = execMode === 'git-parallel';
+  const runsParallel = execMode !== 'sequential';
+  archiveParallel = runsParallel;
   archiveGitRepo = gitRepo;
-  if (!parallel) {
-    yield await ctx.emit(
-      plugin(ctx, 'collab_fallback_sequential', {
-        reason: !gitInstalled
-          ? 'git is not installed — running agents sequentially in your workspace'
-          : !gitRepo
-            ? 'this folder is not a git repository — running agents sequentially in your workspace'
-            : 'sequential mode selected',
-      }),
-    );
+  // Internal diagnostic (not user-facing jargon). Keep the legacy
+  // collab_fallback_sequential ONLY for the explicit sequential mode, so the
+  // existing UI + tests still observe it where it still applies.
+  yield await ctx.emit(plugin(ctx, 'collab_exec_mode', { mode: execMode, gitInstalled, gitRepo }));
+  if (execMode === 'sequential') {
+    yield await ctx.emit(plugin(ctx, 'collab_fallback_sequential', { reason: 'sequential mode — one agent at a time' }));
   }
 
   // Base commit (git path only). A dirty tree is snapshotted so work is never lost.
   let baseSha = '';
-  if (parallel) {
+  if (usesGit) {
     const base = await resolveBase(cwd, { snapshotDirty: true });
     baseSha = base.baseSha;
   }
@@ -150,7 +169,9 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
     socketPath: hubSocketPath(runId),
     task,
     roster: [architectEntry],
-    peerReader: peerReaderFor(worktrees, baseSha),
+    // git: read each agent's worktree. non-git: every agent shares one tree, so
+    // peer-read is just "read the live shared workspace".
+    peerReader: usesGit ? peerReaderFor(worktrees, baseSha) : cwdPeerReader(cwd),
   });
   registerActiveHub(String(ctx.sessionId), hub);
   unsubscribe = hub.subscribe((e) => {
@@ -167,7 +188,9 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
   };
   supervisor = (deps.createSupervisor ?? ((o) => new PeerSupervisor(o)))(supervisorOpts, hub);
 
-    yield await ctx.emit(plugin(ctx, 'collab_started', { task, parallel, gitInstalled, gitRepo }));
+    // Keep `parallel` (the chat-model folder binds it) — cwd-parallel IS parallel
+    // — and add execMode for finer-grained consumers.
+    yield await ctx.emit(plugin(ctx, 'collab_started', { task, parallel: runsParallel, execMode, gitInstalled, gitRepo }));
 
     // Distil the user's conversation for the whole team. BRIEF.md is a CONCISE
     // SUMMARY (goal + key requirements/constraints/decisions) — one coordinator
@@ -259,8 +282,10 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
     }
     yield await ctx.emit(plugin(ctx, 'collab_roster_confirmed', { roster }));
 
-    // Commit the scaffold (CONTRACTS.md, roster.json, any stubs) so worktrees inherit it.
-    if (parallel) {
+    // Commit the scaffold (CONTRACTS.md, roster.json, any stubs) so worktrees
+    // inherit it. Non-git: the scaffold + brief are already physically in cwd, so
+    // every shared-workspace peer sees them with no commit/checkout.
+    if (usesGit) {
       await commitAll(cwd, 'moxxy-collab: scaffold contracts');
       baseSha = await headSha(cwd);
       mkdirSync(worktreeRoot(runId), { recursive: true });
@@ -268,7 +293,7 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
 
     // --- Phase 1: implementers ---
     const doneIds: string[] = [];
-    if (parallel) {
+    if (execMode === 'git-parallel') {
       for (const entry of roster) {
         hub.state.addAgent(entry);
         const wt = worktreePath(runId, entry.id);
@@ -281,8 +306,30 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
       await waitForAgents(hub, supervisor, roster.map((r) => r.id), ctx.signal, cfg.wallClockMs);
       yield* surfaceFailures(ctx, hub, supervisor, roster.map((r) => r.id));
       for (const r of roster) if (statusOf(hub, r.id) === 'done') doneIds.push(r.id);
+    } else if (execMode === 'cwd-parallel') {
+      // No git: run the whole team in parallel directly in the shared workspace,
+      // coordinated by the file-lock board. Pre-seed each agent's declared
+      // ownedPaths as a claim so ownership is enforced from the very first edit;
+      // an overlap means the architect mis-decomposed — surface it but still run.
+      for (const entry of roster) {
+        hub.state.addAgent(entry);
+        if (entry.ownedPaths?.length) {
+          const res = hub.state.boardClaim(entry.id, entry.ownedPaths);
+          if (!res.ok) {
+            yield await ctx.emit(
+              plugin(ctx, 'collab_ownership_overlap', { id: entry.id, paths: entry.ownedPaths, ownedBy: res.ownedBy }),
+            );
+          }
+        }
+        const charterFile = writeCharterFile(runId, entry);
+        supervisor.spawn({ entry, cwd, mode: COLLAB_PEER_MODE_NAME, ...(charterFile ? { charterFile } : {}) });
+        yield await ctx.emit(plugin(ctx, 'collab_agent_spawned', { id: entry.id, role: entry.role }));
+      }
+      await waitForAgents(hub, supervisor, roster.map((r) => r.id), ctx.signal, cfg.wallClockMs);
+      yield* surfaceFailures(ctx, hub, supervisor, roster.map((r) => r.id));
+      for (const r of roster) if (statusOf(hub, r.id) === 'done') doneIds.push(r.id);
     } else {
-      // Sequential fallback (no git): one agent at a time, in the shared workspace.
+      // Explicit sequential mode: one agent at a time, in the shared workspace.
       for (const entry of roster) {
         if (ctx.signal.aborted) break;
         hub.state.addAgent(entry);
@@ -303,9 +350,9 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
       return;
     }
 
-    // --- Phase 2: integrate (git path only; sequential edits are already in cwd) ---
+    // --- Phase 2: integrate (git path only; shared-workspace edits are already in cwd) ---
     let mergeNote = '';
-    if (parallel && doneIds.length > 0) {
+    if (usesGit && doneIds.length > 0) {
       const result = await integrate({
         repoCwd: cwd,
         runId,
@@ -337,10 +384,17 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
     const summaryBlock = summaries.length
       ? summaries.map((s) => `- **${s.agentId}**: ${s.summary}`).join('\n')
       : '(no agent reported a completion summary)';
+    // For the lock-coordinated shared-workspace path there's no merge step — the
+    // edits are already live in the workspace. Add a light review nudge.
+    const cwdNote =
+      execMode === 'cwd-parallel'
+        ? 'The team worked together directly in your workspace; please review the result.'
+        : '';
+    const tail = [mergeNote, cwdNote].filter(Boolean).join('\n\n');
     yield await ctx.emit(
       assistant(
         ctx,
-        `Collaboration complete — ${doneIds.length}/${roster.length} agents finished.\n\n${summaryBlock}${mergeNote ? `\n\n${mergeNote}` : ''}`,
+        `Collaboration complete — ${doneIds.length}/${roster.length} agents finished.\n\n${summaryBlock}${tail ? `\n\n${tail}` : ''}`,
       ),
     );
     completed = true;
@@ -472,6 +526,23 @@ function slug(s: string): string {
 /** Normalize an architect-proposed role to a short, safe label. `'architect'` is
  *  reserved for the coordinator's planner, so a proposed 'architect' falls back to
  *  'implementer'. Anything unparseable also falls back to 'implementer'. */
+/**
+ * How the team is executed:
+ * - `git-parallel`: each agent in its own git worktree; staged, conflict-aware
+ *   merge into the user's branch (full isolation). The default whenever git is
+ *   usable — including a folder we just `git init`'d for the user.
+ * - `cwd-parallel`: no git available — agents run in parallel in the SHARED
+ *   workspace, coordinated only by the advisory file-lock board.
+ * - `sequential`: one agent at a time in the shared workspace (the safe, slow
+ *   fallback; only when the user explicitly pins concurrency: 'sequential').
+ */
+type ExecMode = 'git-parallel' | 'cwd-parallel' | 'sequential';
+
+function resolveExecMode(cfg: CollabConfig, gitRepo: boolean): ExecMode {
+  if (cfg.concurrency === 'sequential') return 'sequential';
+  return gitRepo ? 'git-parallel' : 'cwd-parallel';
+}
+
 function cleanRole(raw: unknown): string {
   if (typeof raw !== 'string') return 'implementer';
   const r = raw.toLowerCase().replace(/[^a-z0-9 -]/g, '').replace(/\s+/g, ' ').trim().slice(0, 24);

--- a/packages/mode-collaborative/src/config.ts
+++ b/packages/mode-collaborative/src/config.ts
@@ -18,7 +18,11 @@ export interface CollabConfig {
   readonly mergePolicy: 'auto-into-branch' | 'stage-only';
   /** Run the project's build/test on staging before promoting. */
   readonly verifyGate: boolean;
-  /** Parallel worktrees (git) vs sequential single-workspace (non-git fallback). */
+  /** `'parallel'` (default): git (incl. an auto-init'd folder) → worktrees + merge;
+   *  no git → agents run in parallel in the shared workspace, coordinated by file
+   *  locks. `'sequential'`: one agent at a time in the shared workspace (the safe,
+   *  slow fallback). NOTE: `resolveCollabConfig()` is currently called without
+   *  persisted prefs, so `'sequential'` isn't yet reachable from user prefs. */
   readonly concurrency: 'parallel' | 'sequential';
   /** Per-peer iteration cap. */
   readonly peerMaxIterations: number;

--- a/packages/mode-collaborative/src/prompts.test.ts
+++ b/packages/mode-collaborative/src/prompts.test.ts
@@ -37,6 +37,14 @@ describe('collaboration prompts', () => {
     expect(COLLAB_ARCHITECT_PROMPT).toContain('"charter"');
     expect(COLLAB_ARCHITECT_PROMPT.toLowerCase()).toContain('definition of done');
   });
+
+  it('harden the shared-workspace (no-isolation) reality', () => {
+    // every agent must claim before editing + rename rule
+    expect(COLLAB_PEER_PROMPT).toContain('BEFORE every edit');
+    expect(COLLAB_PEER_PROMPT.toLowerCase()).toContain('rename or move');
+    // the architect must hand out DISJOINT ownership
+    expect(COLLAB_ARCHITECT_PROMPT).toContain('DISJOINT');
+  });
 });
 
 describe('peerPromptWithCharter', () => {

--- a/packages/mode-collaborative/src/prompts.ts
+++ b/packages/mode-collaborative/src/prompts.ts
@@ -19,12 +19,13 @@ The team coordinates through a shared hub (use these tools):
 - collab_send / collab_broadcast — message a teammate by id, or the whole team.
 - collab_board / collab_add_task / collab_update — the shared task board (what's done / in progress / blocked).
 - collab_contracts — the agreed interfaces/boundaries you must build to.
-- collab_claim(paths) — claim files BEFORE editing them. If the claim is rejected, another agent owns them: message that owner and coordinate; do NOT edit files you don't own.
-- collab_release — release a claim when you're done with those files.
-- collab_peer_read / collab_peer_files / collab_peer_diff — read a teammate's ACTUAL in-progress work (get their real interface instead of guessing).
+- collab_claim(paths) — you may SHARE ONE LIVE WORKSPACE with the other agents (no isolation), so you MUST collab_claim a file BEFORE every edit and only edit files you currently own. If a claim is REJECTED another agent owns it: collab_send that owner, agree who edits, and do NOT touch it until you own it. Claim the NARROWEST set you need (single files, not whole dirs) so you don't block teammates. If you RENAME or MOVE a file, claim BOTH the old and the new path first.
+- collab_release — release a claim the moment you finish a file so others can proceed.
+- collab_peer_read / collab_peer_files / collab_peer_diff — read a teammate's ACTUAL in-progress work (get their real interface instead of guessing). Only rely on work a teammate has said is done — a file may be mid-write.
 
 Cooperation rules:
 - Build strictly to the shared contracts. If you must change a shared boundary, use collab_contract_propose_change and wait for acks — never break a contract unilaterally.
+- Shared/aggregator files (package.json, a lockfile, a barrel index, a shared types file) have ONE owner — never edit one you don't own; ask its owner via collab_send to make the change for you.
 - The human may step in at any time. When you receive a HUMAN directive or a message from "human", treat it as authoritative (it overrides your current plan), and REPLY to them with collab_send to "human" — acknowledge it and say what you'll do (or ask a brief clarifying question). Don't go silent on the human. If the team is paused, finish your current edit and wait.
 - Keep teammates informed: broadcast meaningful progress and blockers.
 - When YOUR sub-task is fully complete and verified, call collab_done with a short summary. The run finishes when everyone is done.`;
@@ -38,7 +39,7 @@ export const COLLAB_ARCHITECT_PROMPT = `${COLLAB_COMMON}
 You are the ARCHITECT — you run FIRST and set the team up for success. Your job, in order:
 0. Read ${COLLAB_SCAFFOLD_DIR}/${BRIEF_FILENAME} — the goal + key-requirements summary — so you decompose toward what the user actually wants. If you need a detail it omits, grep ${COLLAB_SCAFFOLD_DIR}/${CONVERSATION_FILENAME}.
 1. Explore the workspace to understand the task and its boundaries.
-2. Assemble the RIGHT TEAM for THIS deliverable and decompose into INDEPENDENT sub-tasks with DISJOINT ownership (minimize overlap). Pick the roles the work actually needs — a coding task wants developers + a QA reviewer; a document/plan/design deliverable wants a writer, a researcher, a designer, an editor; a product effort may want a PM to sequence + verify. Don't default everyone to a generic "implementer".
+2. Assemble the RIGHT TEAM for THIS deliverable and decompose into INDEPENDENT sub-tasks with DISJOINT ownership (minimize overlap). Pick the roles the work actually needs — a coding task wants developers + a QA reviewer; a document/plan/design deliverable wants a writer, a researcher, a designer, an editor; a product effort may want a PM to sequence + verify. Don't default everyone to a generic "implementer". The team may run together in ONE shared workspace with only advisory file locks, so ownedPaths MUST be DISJOINT — give each agent its own specific files/leaf dirs with NO overlap. If two roles would both need one shared file (a router, a barrel index, package.json), give it to ONE owner and have the other coordinate via collab_send or a contract; never assign the same path to two agents. Every roster entry MUST declare ownedPaths.
 3. Define the shared CONTRACTS — the interfaces, types, API shapes, section outlines, or boundaries where the team's work meets. Publish each with collab_contract_publish (give an owner + consumers).
 4. Write two files into the repo:
    - ${COLLAB_SCAFFOLD_DIR}/${CONTRACTS_FILENAME} — human-readable contracts/boundaries the team must follow.

--- a/packages/mode-collaborative/src/worktrees.ts
+++ b/packages/mode-collaborative/src/worktrees.ts
@@ -47,12 +47,29 @@ export async function isGitRepo(cwd: string): Promise<boolean> {
   return r.code === 0 && r.stdout.trim() === 'true';
 }
 
-/** Classify the workspace so the coordinator can pick parallel-worktrees vs the
- *  sequential single-workspace fallback, with a clear reason for the UI. */
+/** Classify the workspace so the coordinator can pick its execution mode. */
 export async function detectGit(cwd: string): Promise<{ installed: boolean; repo: boolean }> {
   const installed = await gitInstalled(cwd);
   const repo = installed ? await isGitRepo(cwd) : false;
   return { installed, repo };
+}
+
+/**
+ * Git-first auto-init: turn a plain folder into a git repo (with a base commit)
+ * so a non-git workspace still gets worktree isolation + a clean merge. Snapshots
+ * whatever is already in the folder as the initial commit; an empty folder gets
+ * an empty initial commit so worktrees can still branch off a HEAD. Returns true
+ * only when the folder is a usable repo with a base commit afterwards. Best-effort
+ * — any failure (no perms, weird FS) leaves it for the lock-coordinated fallback.
+ */
+export async function tryInitGitRepo(cwd: string): Promise<boolean> {
+  let r = await git(cwd, ['init', '-b', 'main']);
+  if (r.code !== 0) r = await git(cwd, ['init']); // older git without -b
+  if (r.code !== 0 || !(await isGitRepo(cwd))) return false;
+  await git(cwd, ['add', '-A']);
+  const c = await git(cwd, [...IDENTITY, 'commit', '--allow-empty', '-m', 'moxxy-collab: initial snapshot', '--no-verify']);
+  // Confirm a HEAD now exists (worktrees branch off it).
+  return c.code === 0 && (await headSha(cwd)).length > 0;
 }
 
 export async function headSha(cwd: string): Promise<string> {
@@ -258,6 +275,29 @@ export function peerReaderFor(worktrees: ReadonlyMap<string, string>, baseSha: s
     },
     async diff(agentId) {
       return diffVsBase(dirFor(agentId), baseSha);
+    },
+  };
+}
+
+/**
+ * A {@link PeerReader} for the lock-coordinated shared-workspace path: all agents
+ * share ONE tree, so peer-read is just "read the live shared workspace" (agent id
+ * is ignored). The same `resolveWithin` traversal guard applies — `path` is still
+ * untrusted peer input over the socket. Note: a read can catch a teammate's file
+ * mid-write (there is no isolation here); callers are told to read released work.
+ */
+export function cwdPeerReader(cwd: string): PeerReader {
+  return {
+    async files() {
+      // changedFiles needs git; without it there's no cheap "what changed" — so
+      // return [] rather than guess (the workspace itself is the source of truth).
+      return (await isGitRepo(cwd)) ? changedFiles(cwd) : [];
+    },
+    async read(_agentId, path) {
+      return readFile(resolveWithin(cwd, path), 'utf8');
+    },
+    async diff() {
+      return ''; // no base commit to diff against without git
     },
   };
 }


### PR DESCRIPTION
## Why

Your deepest-finding pick, refined to the **hybrid** you asked for. The non-git path ran agents **one at a time** (sequential) — slow, and the reason "the team doesn't respond" when you run in a plain folder: only one agent is ever live. Now the engine is **git-first and always parallel**, picking the safest mechanism underneath with **no user-facing jargon** ("invisible to non-technical people").

## Execution strategy (design adversarially verified by a sub-agent workflow)

1. **Already a git repo** → worktrees + a clean, conflict-aware merge (today's path).
2. **Plain folder** → quietly `git init` + snapshot it, so it STILL gets full **worktree isolation + merge**. Most "plain folder" runs (like your pharmacy-workshop) now go fully parallel + isolated.
3. **Git genuinely unavailable** (not installed, or `init`/commit throws) → agents run **in PARALLEL in the shared workspace**, coordinated by the **file-lock board** (claim-before-edit). `ownedPaths` are **pre-seeded as locks**; an overlap (architect mis-decomposition) is surfaced as `collab_ownership_overlap`.
4. **`concurrency: 'sequential'`** stays as the explicit one-at-a-time fallback.

**Invisible:** the old "this folder is not a git repository — running sequentially" messaging is gone. `collab_exec_mode` is an internal diagnostic; `collab_fallback_sequential` now fires only for explicit sequential. The chat-model still binds `parallel` (cwd-parallel IS parallel), so the UI shows a parallel team.

## Safety (the must-fixes from adversarial review)

The shared-workspace path has only **advisory** locks, so the prompts are hardened: claim before **every** edit, **narrowest** paths, claim **both old+new** on a rename/move, **one owner** for shared/aggregator files (package.json, a barrel index), and only rely on a teammate's **released** work. The architect is **required** to hand out **DISJOINT** `ownedPaths`. `cwdPeerReader` reuses the existing path-traversal guard for untrusted peer-read paths. A crashed/failed agent's locks are freed (existing `releaseAllFor`).

## Tests

- auto-init a plain folder → **git-parallel** (`.git` created, work integrated);
- forced no-git → **cwd-parallel** (not sequential, no git repo, edits land in cwd);
- explicit **sequential**;
- cwd-parallel **pre-seeds** `ownedPaths` as locks and **surfaces an overlap**.

Adds a `detectGit` injection seam so the no-git path is deterministically testable even where git is installed. Build / typecheck / lint / test green locally.

This is the last of the three follow-ups (brief-summary #285, role-charters #287, this).