### PR TITLE
feat(anonymizer): region-aware PII dictionary (PL/UK/US) + multilingual NER

### DIFF
--- a/.changeset/anonymizer-pii-dictionary.md
+++ b/.changeset/anonymizer-pii-dictionary.md
@@ -1,0 +1,42 @@
+---
+"@moxxy/desktop": minor
+---
+
+feat(anonymizer): region-aware PII dictionary (PL/UK/US) + multilingual on-device NER
+
+The document anonymizer now *really* anonymises across markets instead of only
+catching a handful of English-shaped patterns.
+
+**Engine (`@moxxy/anonymizer`, still pure + offline + zero-dependency):**
+
+- A `DICTIONARY` of 47 checksum-backed detectors assembled from official sources
+  and adversarially verified, grouped by market:
+  - **Poland** — PESEL (checksum + embedded birth-date), NIP, REGON, dowód
+    osobisty, passport, NRB bank account (mod-97), driving licence, vehicle reg.
+  - **UK** — National Insurance Number, NHS number, UTR, postcode (BS7666),
+    passport, driving licence, sort code.
+  - **US** — SSN, ITIN, EIN, Medicare MBI, ABA routing, bank account, passport,
+    ZIP.
+  - **Global** — credit card, IBAN (+ per-country length), IMEI, VIN, BTC/ETH
+    wallets, and leaked secrets (AWS / GitHub / Stripe / Google / Slack / OpenAI
+    keys, JWTs, PEM private keys).
+- New `PiiCategory` buckets (`taxId`, `healthId`, `passport`, `driverLicense`,
+  `postalCode`, `bankAccount`, `crypto`, `deviceId`, `vehicleId`, `secret`) and a
+  `Region` axis; `detect`/`redact` gain `regions` and `detectorIds` options.
+  Spans carry a `subtype` so output is specific (`[PESEL]`, `[NHS]`).
+- Precision contract: the validator (checksum) is the primary lever; bare-numeric
+  / no-checksum identifiers are context-keyword-gated; weighted-mod validators
+  reject the degenerate all-zeros run.
+
+**Desktop app:**
+
+- A **Markets** selector (PL/UK/US; global always on) so a market's ID formats
+  can be scoped without false positives from the others.
+- The on-device NER model is swapped from English-only `Xenova/bert-base-NER` to
+  multilingual `tjruesch/xlm-roberta-base-ner-hrl-onnx`, so names are detected in
+  Polish and other languages (download ~110 MB → ~300 MB). The span aggregator
+  was made robust to SentencePiece sub-words so agglutinated names (e.g. Polish
+  surnames) are recovered rather than leaked.
+- Redaction-mode hints now state honestly that only `label` approaches true
+  anonymisation, while `pseudonym`/`hash` are pseudonymisation (still personal
+  data under GDPR).

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -21,6 +21,29 @@ It's dead weight — ~21 MB of orphan that nonetheless rides every Tier-1 hot-up
 bundle. Follow-up: stop Vite resolving that internal `new URL` (e.g. a resolve alias /
 `assetsInclude` exclusion) so only `dist/ort/` ships. `apps/desktop/electron.vite.config.ts`.
 
+**Accrued 2026-06-19 (anonymizer PII dictionary + multilingual NER).** The region-aware
+detector dictionary (`@moxxy/anonymizer`) and the English→multilingual NER swap
+**retired** the long-standing "`nationalId` declared but no detector" gap and the
+English-only name detection. New debt/follow-ups accrued by that work:
+- **NER Polish recall is unproven.** `tjruesch/xlm-roberta-base-ner-hrl-onnx` reaches
+  Polish via XLM-R cross-lingual transfer, NOT Polish gold fine-tuning. It degrades
+  gracefully (a model/runtime failure yields `[]`, structured redaction still runs), but
+  Polish PER/LOC recall needs a real-Polish-document eval harness before we lean on it;
+  `jiting/xlm-roberta-base-ner-hrl_onnx` (AFL-3.0) is the drop-in fallback if it underperforms.
+- **Crypto + secret checksums are structural-only.** Base58Check (BTC), Keccak-256/EIP-55
+  (ETH) and CRC32 (GitHub) would need a crypto dep or hand-rolled crypto, which breaks the
+  zero-dependency offline guarantee — so those detectors validate shape only. Acceptable
+  (both are opt-in / very-low-FP prefixes), but a pure-JS SHA-256/Keccak/CRC32 in `hash.ts`
+  would let them validate properly.
+- **No HIPAA Safe-Harbor profile.** `regions` defaults to ALL with category toggles; a
+  proper per-jurisdiction profile (PL/UK/US/HIPAA) would force-enable the right set —
+  including the opt-in `date` detector + an age-90+/date-shift rule and a generic
+  context-gated unique-id fallback (medical record numbers have no fixed format) — to
+  credibly claim Safe-Harbor coverage. `apps/desktop/src/apps/anonymizer/`.
+- **Context window is a flat 48 chars.** Keyword-gated detectors miss a label that sits a
+  line or two away (e.g. `Numer Identyfikacji Podatkowej` far above the digits). Consider a
+  per-detector window or line-aware context. `packages/anonymizer/src/dictionary.ts`.
+
 **Last refreshed:** 2026-06-09 (second pass) — **journal repair + audit intake.** PRs #113
 and #115 rebuilt this file from a branch cut before #107/#108 merged, silently resurrecting
 two entries those PRs had retired (P1 #2's growth defect, P2 #6 mode-loop scaffolding) and

--- a/apps/desktop/src/apps/anonymizer/AnonymizerApp.test.tsx
+++ b/apps/desktop/src/apps/anonymizer/AnonymizerApp.test.tsx
@@ -2,7 +2,7 @@
  * Component tests for the redesigned anonymizer flow (Import → Settings →
  * Output). The redaction engine is real (`@moxxy/anonymizer`); only the host
  * boundaries are stubbed:
- *   - the NER Worker (loads a ~109 MB model) → a no-op fake, so the on-device
+ *   - the NER Worker (loads a ~300 MB model) → a no-op fake, so the on-device
  *     name pass simply yields nothing and structured redaction still runs.
  *   - the desktop IPC api → a fake, so Save routes without a native dialog.
  *

--- a/apps/desktop/src/apps/anonymizer/AnonymizerApp.tsx
+++ b/apps/desktop/src/apps/anonymizer/AnonymizerApp.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
   redact,
-  STRUCTURED_CATEGORIES,
+  DEFAULT_CATEGORIES,
   type PiiCategory,
   type PiiSpan,
   type RedactionMode,
+  type Region,
 } from '@moxxy/anonymizer';
 import { useAnonymizer } from '@moxxy/client-core';
 import { Button, Icon, TextArea } from '@moxxy/desktop-ui';
@@ -13,7 +14,7 @@ import type { DesktopAppProps } from '../registry';
 import { OfflineBadge } from '../OfflineBadge';
 import { Counts } from './Counts';
 import { SpanHighlight } from './SpanHighlight';
-import { CATEGORY_LABELS, TOGGLE_CATEGORIES } from './labels';
+import { CATEGORY_LABELS, TOGGLE_CATEGORIES, REGION_LABELS, SELECTABLE_REGIONS } from './labels';
 import { FilterSelect, type FilterOption } from './FilterSelect';
 import { ImportStep, type ImportTab } from './ImportStep';
 import { useNer } from './ner/useNer';
@@ -27,9 +28,10 @@ const REDACT_MODES: ReadonlyArray<{ id: RedactionMode; label: string }> = [
 /** A short description of what each redaction style produces, shown under the
  *  segmented control so the choice is obvious without trying each one. */
 const MODE_HINT: Record<RedactionMode, string> = {
-  label: 'Replaces each item with its type, e.g. [EMAIL].',
-  pseudonym: 'Stable tokens, e.g. EMAIL_1 — the same value stays consistent.',
-  hash: 'Compact fingerprints, e.g. [EMAIL:a1b2c3d4].',
+  label: 'Replaces each item with its type, e.g. [EMAIL]. Irreversible — the only mode that truly anonymises.',
+  pseudonym:
+    'Stable tokens, e.g. EMAIL_1 — the same value stays consistent. Reversible, so this is pseudonymisation (still personal data under GDPR), not anonymisation.',
+  hash: 'Compact fingerprints, e.g. [EMAIL:a1b2c3d4]. Still pseudonymisation — a salted hash is not anonymisation.',
 };
 
 /** Synthetic filter id the multi-select adds on top of the structured
@@ -77,8 +79,10 @@ export function AnonymizerApp({ onExit, sendToSession }: DesktopAppProps): JSX.E
   // driving the multi-select. Custom terms are a separate input but their
   // `custom` category is always on (the term box is its own switch).
   const [filters, setFilters] = useState<ReadonlySet<FilterId>>(
-    () => new Set<FilterId>([...STRUCTURED_CATEGORIES, NAMES_FILTER]),
+    () => new Set<FilterId>([...DEFAULT_CATEGORIES, NAMES_FILTER]),
   );
+  // Markets whose region-specific detectors run (global detectors always run).
+  const [regions, setRegions] = useState<ReadonlySet<Region>>(() => new Set(SELECTABLE_REGIONS));
   const [customTermsText, setCustomTermsText] = useState('');
   const [mode, setMode] = useState<RedactionMode>('label');
   const [nerSpans, setNerSpans] = useState<readonly PiiSpan[]>([]);
@@ -106,15 +110,23 @@ export function AnonymizerApp({ onExit, sendToSession }: DesktopAppProps): JSX.E
     [filters],
   );
 
+  const regionList = useMemo(() => SELECTABLE_REGIONS.filter((r) => regions.has(r)), [regions]);
+
   const result = useMemo(
     () =>
       redact(input, {
         categories: categoryList,
+        regions: regionList,
         customTerms,
         extraSpans: nerEnabled ? nerSpans : [],
         mode,
       }),
-    [input, categoryList, customTerms, nerEnabled, nerSpans, mode],
+    [input, categoryList, regionList, customTerms, nerEnabled, nerSpans, mode],
+  );
+
+  const regionOptions = useMemo<ReadonlyArray<FilterOption<Region>>>(
+    () => SELECTABLE_REGIONS.map((r) => ({ id: r, label: REGION_LABELS[r] })),
+    [],
   );
 
   const hasInput = input.trim().length > 0;
@@ -280,6 +292,18 @@ export function AnonymizerApp({ onExit, sendToSession }: DesktopAppProps): JSX.E
                       {nerError}
                     </span>
                   )}
+                </Field>
+
+                <Field
+                  label="Markets"
+                  help="Which countries' ID formats to look for (PESEL, NHS, SSN…). Global formats (email, cards, IBAN) always apply."
+                >
+                  <FilterSelect
+                    options={regionOptions}
+                    selected={regions}
+                    onChange={setRegions}
+                    testId="anon-region-select"
+                  />
                 </Field>
 
                 <Field label="Redaction style">

--- a/apps/desktop/src/apps/anonymizer/labels.ts
+++ b/apps/desktop/src/apps/anonymizer/labels.ts
@@ -1,12 +1,22 @@
-import type { PiiCategory } from '@moxxy/anonymizer';
+import { ALL_CATEGORIES, DETECTABLE_CATEGORIES, type PiiCategory, type Region } from '@moxxy/anonymizer';
 
 /** Friendly labels for each detectable category (UI only). */
 export const CATEGORY_LABELS: Record<PiiCategory, string> = {
   email: 'Emails',
   phone: 'Phone numbers',
   creditCard: 'Credit cards',
-  ssn: 'SSNs',
+  ssn: 'US Social Security',
   nationalId: 'National IDs',
+  taxId: 'Tax IDs',
+  healthId: 'Health IDs',
+  passport: 'Passports',
+  driverLicense: 'Driver licenses',
+  postalCode: 'Postal codes',
+  bankAccount: 'Bank accounts',
+  crypto: 'Crypto wallets',
+  deviceId: 'Device IDs',
+  vehicleId: 'Vehicle IDs',
+  secret: 'API keys & secrets',
   ipv4: 'IPv4 addresses',
   ipv6: 'IPv6 addresses',
   mac: 'MAC addresses',
@@ -19,18 +29,21 @@ export const CATEGORY_LABELS: Record<PiiCategory, string> = {
   custom: 'Custom terms',
 };
 
-/** Built-in (regex) categories the user can toggle. `date` is included but
- *  defaults off (high false-positive rate). NER categories (person/org/location)
- *  are controlled by the separate "Detect names" toggle; `custom` by the terms box. */
-export const TOGGLE_CATEGORIES: readonly PiiCategory[] = [
-  'email',
-  'phone',
-  'creditCard',
-  'ssn',
-  'ipv4',
-  'ipv6',
-  'mac',
-  'iban',
-  'url',
-  'date',
-];
+/** Built-in (regex) categories the user can toggle, in canonical order. Derived
+ *  from the engine's dictionary so adding a detector surfaces its category
+ *  automatically. NER categories (person/org/location) are controlled by the
+ *  separate names toggle; `custom` by the terms box, so neither appears here. */
+export const TOGGLE_CATEGORIES: readonly PiiCategory[] = ALL_CATEGORIES.filter((c) =>
+  DETECTABLE_CATEGORIES.includes(c),
+);
+
+/** Human labels for the market selector (global detectors always run). */
+export const REGION_LABELS: Record<Region, string> = {
+  global: 'Global',
+  PL: 'Poland',
+  UK: 'United Kingdom',
+  US: 'United States',
+};
+
+/** Markets the user can scope detection to (global is implicit/always on). */
+export const SELECTABLE_REGIONS: readonly Region[] = ['PL', 'UK', 'US'];

--- a/apps/desktop/src/apps/anonymizer/ner/aggregate.test.ts
+++ b/apps/desktop/src/apps/anonymizer/ner/aggregate.test.ts
@@ -68,4 +68,15 @@ describe('aggregate', () => {
     const spans = aggregate([tok('B-PER', 'Sam'), tok('B-PER', 'Sam')], text);
     expect(spans.map((s) => s.start)).toEqual([0, 12]);
   });
+
+  it('rejoins SentencePiece (XLM-R) sub-words that decode WITHOUT a marker', () => {
+    // XLM-RoBERTa decodes each sub-word independently, so an agglutinated Polish
+    // surname 'Kowalski' arrives as bare parts ['Kowal','ski'] with NO '##' marker
+    // and NO separator in the source text. The whole name must still be recovered
+    // (a `+`-separator part match would drop 'ski' and leak the surname).
+    const text = 'pacjent Anna Kowalski zgłosił';
+    const tokens: NerToken[] = [tok('B-PER', 'Anna'), tok('I-PER', 'Kowal'), tok('I-PER', 'ski')];
+    const spans = aggregate(tokens, text);
+    expect(spans).toEqual([{ category: 'person', start: 8, end: 21, value: 'Anna Kowalski' }]);
+  });
 });

--- a/apps/desktop/src/apps/anonymizer/ner/aggregate.ts
+++ b/apps/desktop/src/apps/anonymizer/ner/aggregate.ts
@@ -68,13 +68,17 @@ function findAligned(text: string, surface: string, from: number): { start: numb
     }
   }
   // 2) The tokenizer normalizes the surface (diacritic stripping, hyphen/
-  //    apostrophe → space, WordPiece spacing), so the literal needle can be
-  //    absent even though the entity is present. Match the surface's word PARTS
-  //    separated by any run of non-word chars, anchored on word boundaries, so a
-  //    span is recovered (and redacted) instead of silently dropped.
+  //    apostrophe → space, WordPiece/SentencePiece spacing), so the literal
+  //    needle can be absent even though the entity is present. Match the
+  //    surface's word PARTS separated by ZERO-or-more non-word chars, anchored on
+  //    word boundaries, so a span is recovered (and redacted) instead of silently
+  //    dropped. The separator is `*` (not `+`) because SentencePiece models
+  //    (XLM-R) decode each sub-word independently with no marker — an
+  //    agglutinated surname like `Kowalski` arrives as parts ['Kowal','ski'] with
+  //    NO separator between them, and `+` would fail to rejoin it (→ name leak).
   const parts = surface.split(/[^\p{L}\p{N}]+/u).filter(Boolean).map(escapeRegExp);
   if (parts.length > 0) {
-    const re = new RegExp(`(?<![\\p{L}\\p{N}])${parts.join('[^\\p{L}\\p{N}]+')}(?![\\p{L}\\p{N}])`, 'iu');
+    const re = new RegExp(`(?<![\\p{L}\\p{N}])${parts.join('[^\\p{L}\\p{N}]*')}(?![\\p{L}\\p{N}])`, 'iu');
     const m = re.exec(text.slice(from));
     if (m && m.index != null) {
       return { start: from + m.index, end: from + m.index + m[0].length };
@@ -88,7 +92,7 @@ function findAligned(text: string, surface: string, from: number): { start: numb
   //    offsets line up.
   const foldedText = stripDiacritics(text);
   if (foldedText !== text && foldedText.length === text.length) {
-    const re = new RegExp(`(?<![\\p{L}\\p{N}])${parts.join('[^\\p{L}\\p{N}]+')}(?![\\p{L}\\p{N}])`, 'iu');
+    const re = new RegExp(`(?<![\\p{L}\\p{N}])${parts.join('[^\\p{L}\\p{N}]*')}(?![\\p{L}\\p{N}])`, 'iu');
     const m = re.exec(foldedText.slice(from));
     if (m && m.index != null) {
       return { start: from + m.index, end: from + m.index + m[0].length };

--- a/apps/desktop/src/apps/anonymizer/ner/ner.worker.ts
+++ b/apps/desktop/src/apps/anonymizer/ner/ner.worker.ts
@@ -1,6 +1,8 @@
 /**
- * On-device NER worker. Runs transformers.js (`Xenova/bert-base-NER`) on the
- * onnxruntime-web WASM backend, entirely offline.
+ * On-device NER worker. Runs transformers.js (`tjruesch/xlm-roberta-base-ner-hrl-onnx`,
+ * a multilingual XLM-RoBERTa NER model) on the onnxruntime-web WASM backend,
+ * entirely offline. XLM-R's 100-language pretraining gives it cross-lingual reach
+ * (Polish, German, French, …), unlike the prior English-only `Xenova/bert-base-NER`.
  *
  * Offline enforcement (defense in depth atop the renderer CSP):
  *   - `remoteHost` points transformers.js at the local `moxxy-app://` scheme, so
@@ -16,8 +18,14 @@
  *     `env.backends.onnx.wasm.wasmPaths` to that LOCAL base below, BEFORE the
  *     pipeline creates the ORT session — ORT then appends the filename and loads
  *     from `'self'`, never the CDN. See {@link ../../../../electron.vite.config.ts}.
- * The heavy work is here so the UI thread never blocks while a ~109 MB model
+ * The heavy work is here so the UI thread never blocks while a ~300 MB model
  * loads and runs.
+ *
+ * Quantisation: on the WASM backend transformers.js defaults to the `q8` dtype,
+ * whose file suffix is `_quantized` — so it requests `onnx/model_quantized.onnx`
+ * (the only ONNX weight we ship) without us passing an explicit `dtype`. (Do NOT
+ * pass `dtype: 'quantized'` — that is not a valid transformers.js dtype and
+ * throws; the equivalent value would be `'q8'`.)
  */
 import { env, pipeline } from '@huggingface/transformers';
 
@@ -68,7 +76,7 @@ if (wasmBackend) {
   wasmBackend.proxy = false;
 }
 
-const MODEL_ID = 'Xenova/bert-base-NER';
+const MODEL_ID = 'tjruesch/xlm-roberta-base-ner-hrl-onnx';
 type NerFn = (
   text: string,
 ) => Promise<Array<{ entity: string; word: string; index: number; score: number }>>;

--- a/apps/desktop/src/apps/anonymizer/ner/useNer.test.tsx
+++ b/apps/desktop/src/apps/anonymizer/ner/useNer.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Unit tests for the NER hook's worker lifecycle — specifically the failure
- * path. The hook owns a single Worker (which loads a ~109 MB model); when that
+ * path. The hook owns a single Worker (which loads a ~300 MB model); when that
  * worker dies, `detectNames` MUST short-circuit instead of posting to a dead
  * worker and leaking a forever-pending request per call.
  *

--- a/apps/desktop/src/apps/builtins.ts
+++ b/apps/desktop/src/apps/builtins.ts
@@ -15,7 +15,7 @@ registerDesktopApp({
   offline: true,
   requiresInstall: true,
   installSummary:
-    'Downloads a ~110 MB on-device model for detecting names. After install it runs fully offline.',
+    'Downloads a ~300 MB multilingual on-device model for detecting names (Polish, English & more). After install it runs fully offline.',
   canSendToSession: true,
   Component: AnonymizerApp,
 });

--- a/packages/anonymizer/README.md
+++ b/packages/anonymizer/README.md
@@ -1,6 +1,8 @@
 # @moxxy/anonymizer
 
-A pure, **dependency-free, network-free** PII detection + redaction engine.
+A pure, **dependency-free, network-free** PII detection + redaction engine with a
+**region-aware detector dictionary** (Poland 🇵🇱 / UK 🇬🇧 / US 🇺🇸 + global) and
+checksum-backed validators.
 
 ```ts
 import { redact } from '@moxxy/anonymizer';
@@ -19,35 +21,103 @@ emptiness is the load-bearing offline guarantee and is enforced by
 `offline.test.ts` (asserts `dependencies` is `{}` and the source references no
 `fetch` / `XMLHttpRequest` / `node:http` / etc.). **Keep `dependencies` empty.**
 
-## What it detects
+Crypto-wallet and secret detectors are therefore **structural** (prefix + charset
++ length), not cryptographic — implementing Base58Check / Keccak-256 / CRC32
+would either pull in a dependency or hand-roll crypto, so the engine validates
+shape and leaves the (rare) checksum false-positive to the high-priority
+overlap resolution.
 
-High-precision, validator-backed detectors (correctness over recall):
+## The dictionary
 
-| Category | Validation |
-| --- | --- |
-| `email`, `url` | shape + TLD |
-| `creditCard` | Luhn |
-| `iban` | mod-97 |
-| `ipv4` | octet ≤ 255 |
-| `ipv6` | group structure (a MAC is not an IPv6) |
-| `mac` | 6 hex groups |
-| `ssn` | US area/group/serial sanity |
-| `phone` | 7–15 digits, requires grouping, rejects date shapes |
-| `date` | opt-in (high false-positive rate) |
+Every detector lives in `dictionary.ts` as a `DetectorDef` — a candidate regex
+plus an optional pure validator (`validators.ts`) and an optional *context*
+keyword. The regex finds candidates; the **checksum/validator is the primary
+precision lever**, and bare-numeric / no-checksum identifiers additionally
+require a nearby keyword (e.g. `NIP`, `NHS`, `routing`) within 48 chars.
+
+| Region | Identifiers (subtype label) | Validation |
+| --- | --- | --- |
+| global | `EMAIL`, `URL`, `IP` (v4/v6), `MAC` | shape / octet / structure |
+| global | `CARD` | Luhn (+ all-zeros guard) |
+| global | `IBAN` | mod-97 + per-country length |
+| global | `PHONE` | 7–15 digits, grouped, not a date |
+| global · secrets | `AWS_KEY`, `GITHUB_TOKEN`, `STRIPE_KEY`, `GOOGLE_API_KEY`, `SLACK_TOKEN`, `OPENAI_KEY`, `JWT`, `PRIVATE_KEY` | structural prefix |
+| global · opt-in | `BTC`, `ETH` (crypto), `IMEI` (Luhn), `VIN` (ISO-3779), `DATE` | structural / Luhn / mod-11 |
+| 🇵🇱 PL | `PESEL` | weighted mod-10 + embedded birth-date |
+| 🇵🇱 PL | `NIP`, `REGON` | mod-11 |
+| 🇵🇱 PL | `DOWOD` (ID card), `PASSPORT` | weighted mod-10 |
+| 🇵🇱 PL | `NRB` (bank account) | mod-97 |
+| 🇵🇱 PL | `DL` (prawo jazdy), `REG_DOC` | structural + context |
+| 🇬🇧 UK | `NINO` | DWP prefix/suffix rules |
+| 🇬🇧 UK | `NHS`, `UTR` | mod-11 + context |
+| 🇬🇧 UK | `POSTCODE` | BS7666 grammar |
+| 🇬🇧 UK | `PASSPORT`, `DL`, `SORT_CODE` | structural + context |
+| 🇺🇸 US | `SSN` | area/group/serial rules |
+| 🇺🇸 US | `ITIN`, `EIN` | range / IRS prefix set |
+| 🇺🇸 US | `MBI` (Medicare) | CMS class pattern |
+| 🇺🇸 US | `ROUTING` (ABA) | weighted mod-10 + context |
+| 🇺🇸 US | `ACCOUNT`, `PASSPORT`, `ZIP` | structural + context |
 
 `custom` matches literal user-supplied terms (names, addresses) case-insensitively
 on word boundaries.
 
+## Selecting what runs
+
+```ts
+detect(text, {
+  categories: ['email', 'nationalId', 'healthId'], // default: DEFAULT_CATEGORIES
+  regions: ['PL', 'UK'],                            // default: every region; `global` always runs
+  detectorIds: ['pl-pesel'],                        // explicit allow-list (overrides the above)
+  customTerms: ['Project Bluebird'],
+  extraSpans: nerSpans,                             // person/org/location from NER
+});
+```
+
+- **`DEFAULT_CATEGORIES`** (the safe default profile): the global structured set
+  + secrets + Polish `PESEL`/`NIP` + US `SSN`. High-false-positive categories
+  (postcodes, passports, bank accounts, crypto, device/vehicle ids, dates) are
+  **opt-in**.
+- **`regions`** scopes the market-specific detectors so a Polish user isn't
+  hit with UK/US false positives. `global` detectors always run.
+- Each span carries a `subtype` (e.g. `PESEL`) used as the redaction label, plus
+  the `region` it came from.
+
 ## Names, orgs, locations (NER)
 
 The engine does **not** do named-entity recognition — that needs a model. The
-desktop app runs an on-device NER model and feeds its results in via
-`detect(text, { extraSpans })` / `redact(text, { extraSpans })`, where each span
-is `{ category: 'person' | 'org' | 'location', start, end, value }`. They merge
+desktop app runs an on-device **multilingual** NER model (XLM-RoBERTa) and feeds
+its results in via `detect(text, { extraSpans })`, where each span is
+`{ category: 'person' | 'org' | 'location', start, end, value }`. They merge
 through the same overlap-resolution pass as the built-in detectors.
 
 ## Redaction modes
 
-- `label` (default) — `[EMAIL]`
-- `pseudonym` — `EMAIL_1` (same value → same token, numbered in document order)
-- `hash` — `[EMAIL:a1b2c3d4]` (stable, compact; obfuscation, not cryptography)
+- `label` (default) — `[EMAIL]`. **Irreversible — the only mode that approaches
+  true anonymisation.**
+- `pseudonym` — `EMAIL_1` (same value → same token, numbered in document order).
+  Reversible, so legally this is **pseudonymisation**, not anonymisation.
+- `hash` — `[EMAIL:a1b2c3d4]` (stable, compact). A salted hash is still
+  pseudonymisation — the salt is the "additional information" — **not**
+  anonymisation.
+
+## Legal scope
+
+Detector coverage is chosen so the tool can credibly *anonymise* (not merely
+*redact*) documents across these regimes:
+
+- **GDPR (EU/Poland)** — Art. 4(1) personal data incl. online identifiers (IP,
+  device ids, cookies); Art. 9 special categories (health → `NHS`/`MBI`, etc.);
+  **Recital 26** is the anonymisation-vs-pseudonymisation line the redaction
+  modes are labelled against. Poland's RODO/UODO gives **PESEL** heightened
+  status, so it is a default-on detector.
+- **UK GDPR + DPA 2018** — mirrors EU GDPR; the **NHS number** is health data
+  (special category) and the ICO treats salted-hash output as pseudonymisation.
+- **US (sectoral)** — no single statute: **HIPAA** Safe Harbor (the 18
+  identifiers → names/dates/`SSN`/`MBI`/`ROUTING`/`ZIP`/IP/URL/`VIN`/`IMEI`),
+  **GLBA** (financial), the SSA (`SSN`), and **CCPA/CPRA** personal information.
+
+This is a detection aid, **not legal advice or a compliance guarantee** — a clean
+report does not by itself establish that a document is anonymised under any of
+these regimes (residual quasi-identifiers, free-text, scanned images, and the
+HIPAA "no actual knowledge" / Recital-26 "all means reasonably likely" tests
+still apply).

--- a/packages/anonymizer/package.json
+++ b/packages/anonymizer/package.json
@@ -2,7 +2,7 @@
   "name": "@moxxy/anonymizer",
   "private": true,
   "version": "0.1.0",
-  "description": "A pure, dependency-free, network-free PII detection + redaction engine. Detects structured PII (email, phone, credit card, SSN, IP, MAC, IBAN, URL, date) with high-precision validators and redacts it with labeled / pseudonym / hash modes. Has ZERO runtime dependencies and touches no network API — that emptiness is the load-bearing offline guarantee (enforced by offline.test.ts), so it bundles cleanly into the desktop renderer.",
+  "description": "A pure, dependency-free, network-free PII detection + redaction engine with a region-aware detector dictionary (Poland / UK / US + global). Detects structured PII, national/tax/health ids, bank accounts, passports, postcodes, crypto wallets, device/vehicle ids and leaked secrets with checksum-backed validators, and redacts it with labeled / pseudonym / hash modes. Has ZERO runtime dependencies and touches no network API — that emptiness is the load-bearing offline guarantee (enforced by offline.test.ts), so it bundles cleanly into the desktop renderer.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/anonymizer/src/detect.ts
+++ b/packages/anonymizer/src/detect.ts
@@ -1,35 +1,71 @@
 /**
- * Detection orchestration: run the enabled detectors, fold in custom-term and
- * external (NER) spans, then resolve overlaps so each character is claimed by at
- * most one category — the highest-priority one.
+ * Detection orchestration: select the enabled detectors (by category + region,
+ * or by an explicit id allow-list), run them, fold in custom-term and external
+ * (NER) spans, then resolve overlaps so each character is claimed by at most one
+ * category — the highest-priority one.
  */
 
-import { DETECTORS, detectCustom } from './detectors.js';
-import type { DetectOptions, PiiCategory, PiiSpan } from './types.js';
-import { STRUCTURED_CATEGORIES } from './types.js';
+import {
+  DICTIONARY,
+  DETECTOR_BY_ID,
+  DEFAULT_CATEGORIES,
+  detectCustom,
+  type DetectorDef,
+} from './dictionary.js';
+import type { DetectOptions, PiiCategory, PiiSpan, Region } from './types.js';
+import { ALL_REGIONS } from './types.js';
 
 /**
  * Overlap-resolution priority. A 16-digit Luhn-valid card overlaps a phone
  * pattern; keeping the higher-priority category stops it being mis-tagged.
- * Structured + validated categories outrank looser ones (phone, date).
+ * Structured + checksum-validated categories outrank looser ones (phone, date,
+ * postalCode). Higher number wins.
  */
 const PRIORITY: Record<PiiCategory, number> = {
+  // deviceId (IMEI) outranks creditCard because an IMEI is a 15-digit Luhn-valid
+  // run — a subset of the card pattern — and only fires when an `IMEI` keyword is
+  // nearby, so when both match the same digits the context-gated IMEI is the
+  // right call (a real Amex sitting next to the word "IMEI" is implausible).
+  deviceId: 102,
   creditCard: 100,
-  iban: 95,
-  ssn: 90,
-  email: 80,
+  iban: 98,
+  bankAccount: 96,
+  ssn: 94,
+  nationalId: 92,
+  taxId: 90,
+  healthId: 88,
+  vehicleId: 86,
+  crypto: 82,
+  secret: 80,
+  email: 78,
   url: 70,
-  ipv6: 66,
-  ipv4: 64,
+  passport: 68,
+  driverLicense: 66,
+  ipv6: 64,
+  ipv4: 62,
   mac: 60,
   person: 55,
   org: 50,
   location: 48,
-  nationalId: 45,
+  postalCode: 44,
   custom: 40,
   phone: 30,
   date: 10,
 };
+
+/** Resolve which detectors to run from the options. */
+export function selectDetectors(opts: DetectOptions = {}): DetectorDef[] {
+  if (opts.detectorIds) {
+    return opts.detectorIds
+      .map((id) => DETECTOR_BY_ID.get(id))
+      .filter((d): d is DetectorDef => !!d);
+  }
+  const categories = new Set<PiiCategory>(opts.categories ?? DEFAULT_CATEGORIES);
+  const regions = new Set<Region>(opts.regions ?? ALL_REGIONS);
+  return DICTIONARY.filter(
+    (d) => categories.has(d.category) && (d.region === 'global' || regions.has(d.region)),
+  );
+}
 
 /**
  * Detect PII in `text`. Returns non-overlapping spans in document order.
@@ -38,16 +74,10 @@ const PRIORITY: Record<PiiCategory, number> = {
  * `extraSpans` (e.g. on-device NER) are merged through the same overlap pass.
  */
 export function detect(text: string, opts: DetectOptions = {}): PiiSpan[] {
-  const categories = new Set(opts.categories ?? STRUCTURED_CATEGORIES);
   const raw: PiiSpan[] = [];
-
-  for (const cat of categories) {
-    const fn = DETECTORS[cat];
-    if (fn) raw.push(...fn(text));
-  }
+  for (const d of selectDetectors(opts)) raw.push(...d.detect(text));
   if (opts.customTerms?.length) raw.push(...detectCustom(text, opts.customTerms));
   if (opts.extraSpans?.length) raw.push(...opts.extraSpans);
-
   return resolveOverlaps(raw);
 }
 

--- a/packages/anonymizer/src/detectors.ts
+++ b/packages/anonymizer/src/detectors.ts
@@ -1,168 +1,61 @@
 /**
- * High-precision, validator-backed detectors — one per structured PII category.
+ * Backwards-compatible detector surface.
  *
- * Each detector returns the spans it finds; correctness over recall is the
- * priority, so every category that can be cheaply validated is (Luhn for cards,
- * mod-97 for IBANs, octet range for IPv4, area/group sanity for SSNs). This
- * keeps false positives low without any model or network call.
+ * The detectors now live in the {@link DICTIONARY} (see `dictionary.ts`), keyed
+ * by id and grouped by category + region. This module preserves the original
+ * category-keyed API (`DETECTORS[category](text)`) plus `detectCustom` and the
+ * validator `_internals` that existing tests and callers depend on.
  */
 
+import { DICTIONARY, detectCustom } from './dictionary.js';
 import type { PiiCategory, PiiSpan } from './types.js';
+import {
+  luhnValid,
+  ibanValid,
+  isIpv4,
+  isIpv6,
+  isSsn,
+  isPhone,
+  isPesel,
+  isNip,
+  isRegon,
+  isNhsNumber,
+  isAbaRouting,
+  isVin,
+  isImei,
+} from './validators.js';
 
-/** Run a global regex over `text`, optionally filtering matches with `accept`. */
-function scan(
-  text: string,
-  re: RegExp,
-  category: PiiCategory,
-  accept?: (match: string) => boolean,
-): PiiSpan[] {
-  const out: PiiSpan[] = [];
-  for (const m of text.matchAll(re)) {
-    const value = m[0] ?? '';
-    const start = m.index ?? -1;
-    if (!value || start < 0) continue;
-    if (accept && !accept(value)) continue;
-    out.push({ category, start, end: start + value.length, value });
+export { detectCustom };
+
+/** Category → a function running every dictionary detector of that category
+ *  (all regions). Built once from the dictionary. */
+export const DETECTORS: Partial<Record<PiiCategory, (text: string) => PiiSpan[]>> = (() => {
+  const byCategory = new Map<PiiCategory, Array<(t: string) => PiiSpan[]>>();
+  for (const d of DICTIONARY) {
+    const list = byCategory.get(d.category) ?? [];
+    list.push(d.detect);
+    byCategory.set(d.category, list);
+  }
+  const out: Partial<Record<PiiCategory, (text: string) => PiiSpan[]>> = {};
+  for (const [cat, fns] of byCategory) {
+    out[cat] = (text: string) => fns.flatMap((fn) => fn(text));
   }
   return out;
-}
+})();
 
-// ── email ──────────────────────────────────────────────────────────────────
-const EMAIL_RE = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,24}\b/g;
-
-// ── url ────────────────────────────────────────────────────────────────────
-// Stop at whitespace and trailing sentence punctuation/brackets.
-const URL_RE = /\bhttps?:\/\/[^\s<>"')\]}]+/g;
-
-// ── ipv4 ───────────────────────────────────────────────────────────────────
-const IPV4_RE = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
-function isIpv4(m: string): boolean {
-  const parts = m.split('.');
-  if (parts.length !== 4) return false;
-  return parts.every((p) => p.length <= 3 && Number(p) <= 255);
-}
-
-// ── ipv6 ───────────────────────────────────────────────────────────────────
-// Broad candidate (≥3 colon-separated hex groups), then a strict validator.
-const IPV6_RE = /[0-9A-Fa-f]{0,4}(?::[0-9A-Fa-f]{0,4}){2,7}/g;
-function isIpv6(m: string): boolean {
-  if (!/^[0-9A-Fa-f:]+$/.test(m)) return false;
-  if ((m.match(/::/g) ?? []).length > 1) return false; // at most one '::'
-  if (/:::/.test(m)) return false;
-  const hasDouble = m.includes('::');
-  const groups = m.split(':').filter((g) => g.length > 0);
-  if (groups.some((g) => !/^[0-9A-Fa-f]{1,4}$/.test(g))) return false;
-  // Without compression an address needs exactly 8 groups; with '::' it needs
-  // fewer (so a 6-group MAC like 01:23:45:67:89:ab is NOT a valid IPv6).
-  return hasDouble ? groups.length >= 1 && groups.length <= 7 : groups.length === 8;
-}
-
-// ── mac ────────────────────────────────────────────────────────────────────
-const MAC_RE = /\b[0-9A-Fa-f]{2}(?:[:-][0-9A-Fa-f]{2}){5}\b/g;
-
-// ── credit card ────────────────────────────────────────────────────────────
-const CC_RE = /\b\d(?:[ -]?\d){12,18}\b/g;
-function luhnValid(digits: string): boolean {
-  let sum = 0;
-  let alt = false;
-  for (let i = digits.length - 1; i >= 0; i--) {
-    let d = digits.charCodeAt(i) - 48;
-    if (d < 0 || d > 9) return false;
-    if (alt) {
-      d *= 2;
-      if (d > 9) d -= 9;
-    }
-    sum += d;
-    alt = !alt;
-  }
-  return sum % 10 === 0;
-}
-function isCreditCard(m: string): boolean {
-  const digits = m.replace(/[^0-9]/g, '');
-  return digits.length >= 13 && digits.length <= 19 && luhnValid(digits);
-}
-
-// ── ssn (US) ───────────────────────────────────────────────────────────────
-// Hyphenated form only — a bare 9-digit run is too ambiguous to claim.
-const SSN_RE = /\b(\d{3})-(\d{2})-(\d{4})\b/g;
-function isSsn(m: string): boolean {
-  const [area, group, serial] = m.split('-');
-  if (!area || !group || !serial) return false;
-  if (area === '000' || area === '666' || Number(area) >= 900) return false;
-  if (group === '00') return false;
-  if (serial === '0000') return false;
-  return true;
-}
-
-// ── iban ───────────────────────────────────────────────────────────────────
-// Compact or single-space-grouped; validated by mod-97.
-const IBAN_RE = /\b[A-Z]{2}\d{2}(?:[ ]?[A-Z0-9]){11,30}\b/g;
-function ibanValid(raw: string): boolean {
-  const s = raw.replace(/\s+/g, '').toUpperCase();
-  if (s.length < 15 || s.length > 34) return false;
-  if (!/^[A-Z]{2}\d{2}[A-Z0-9]+$/.test(s)) return false;
-  const rearranged = s.slice(4) + s.slice(0, 4);
-  let remainder = 0;
-  for (const ch of rearranged) {
-    const code = ch.charCodeAt(0);
-    const val = code >= 65 ? code - 55 : code - 48; // A-Z → 10..35, 0-9 → 0..9
-    remainder = (remainder * (val > 9 ? 100 : 10) + val) % 97;
-  }
-  return remainder === 1;
-}
-
-// ── phone ──────────────────────────────────────────────────────────────────
-// Requires separators between digit groups (so a bare ID number isn't a phone),
-// then validates 7–15 digits and rejects date-shaped matches.
-const PHONE_RE =
-  /(?<![\w.])(?:\+\d{1,3}[ .-]?)?(?:\(\d{1,4}\)[ .-]?)?\d{2,4}(?:[ .-]\d{2,4}){1,5}(?![\w])/g;
-function isPhone(m: string): boolean {
-  if (/^\d{4}[-/.]\d{1,2}[-/.]\d{1,2}$/.test(m)) return false; // ISO-ish date
-  if (/^\d{1,2}[-/.]\d{1,2}[-/.]\d{2,4}$/.test(m)) return false; // D/M/Y date
-  const digits = m.replace(/[^0-9]/g, '');
-  return digits.length >= 7 && digits.length <= 15;
-}
-
-// ── date (opt-in; high false-positive rate) ──────────────────────────────────
-const DATE_RE =
-  /\b(?:\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}\/\d{2,4}|(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+\d{4})\b/gi;
-
-/** Built-in detectors keyed by category. Categories absent here (`person`,
- *  `org`, `location`, `nationalId`) have no regex detector and only appear via
- *  `extraSpans`. */
-export const DETECTORS: Partial<Record<PiiCategory, (text: string) => PiiSpan[]>> = {
-  email: (t) => scan(t, EMAIL_RE, 'email'),
-  url: (t) => scan(t, URL_RE, 'url'),
-  ipv4: (t) => scan(t, IPV4_RE, 'ipv4', isIpv4),
-  ipv6: (t) => scan(t, IPV6_RE, 'ipv6', isIpv6),
-  mac: (t) => scan(t, MAC_RE, 'mac'),
-  creditCard: (t) => scan(t, CC_RE, 'creditCard', isCreditCard),
-  ssn: (t) => scan(t, SSN_RE, 'ssn', isSsn),
-  iban: (t) => scan(t, IBAN_RE, 'iban', ibanValid),
-  phone: (t) => scan(t, PHONE_RE, 'phone', isPhone),
-  date: (t) => scan(t, DATE_RE, 'date'),
+/** Validators exposed for unit tests. */
+export const _internals = {
+  luhnValid,
+  ibanValid,
+  isIpv4,
+  isIpv6,
+  isSsn,
+  isPhone,
+  isPesel,
+  isNip,
+  isRegon,
+  isNhsNumber,
+  isAbaRouting,
+  isVin,
+  isImei,
 };
-
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/** Literal, case-insensitive, word-boundary matches of user-supplied terms. */
-export function detectCustom(text: string, terms: readonly string[]): PiiSpan[] {
-  const spans: PiiSpan[] = [];
-  for (const term of terms) {
-    const t = term.trim();
-    if (!t) continue;
-    const re = new RegExp(`(?<!\\w)${escapeRegExp(t)}(?!\\w)`, 'gi');
-    for (const m of text.matchAll(re)) {
-      const value = m[0] ?? '';
-      const start = m.index ?? -1;
-      if (!value || start < 0) continue;
-      spans.push({ category: 'custom', start, end: start + value.length, value });
-    }
-  }
-  return spans;
-}
-
-// Exposed for unit tests.
-export const _internals = { luhnValid, ibanValid, isIpv4, isIpv6, isSsn, isPhone };

--- a/packages/anonymizer/src/dictionary.test.ts
+++ b/packages/anonymizer/src/dictionary.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import { detect } from './detect.js';
+import { redact } from './redact.js';
+import { DICTIONARY, DEFAULT_CATEGORIES } from './dictionary.js';
+
+/** Convenience: categories + subtype labels detect() finds in `text`. */
+function found(text: string, opts = {}): Array<[string, string]> {
+  return detect(text, opts).map((s) => [s.category, s.value] as [string, string]);
+}
+
+describe('dictionary wiring', () => {
+  it('every detector id is unique', () => {
+    const ids = DICTIONARY.map((d) => d.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+  it('DEFAULT_CATEGORIES are the categories with a defaultOn detector', () => {
+    expect(DEFAULT_CATEGORIES).toContain('email');
+    expect(DEFAULT_CATEGORIES).toContain('nationalId'); // PESEL is default-on
+    expect(DEFAULT_CATEGORIES).not.toContain('date'); // opt-in
+  });
+});
+
+describe('Poland', () => {
+  it('detects a labelled PESEL as a nationalId (no context needed — checksum+date)', () => {
+    expect(found('PESEL: 44051401359')).toEqual([['nationalId', '44051401359']]);
+  });
+  it('detects NIP only with the NIP keyword nearby (bare 10-digit run is ambiguous)', () => {
+    expect(found('NIP 1234563218')).toEqual([['taxId', '1234563218']]);
+    // No keyword → a bare valid-checksum 10-digit run is NOT claimed as a NIP.
+    expect(found('order ref 1234563218', { categories: ['taxId'] })).toEqual([]);
+  });
+  it('detects a PL-prefixed / dashed NIP', () => {
+    expect(found('faktura PL1234563218 zł', { categories: ['taxId'] }).length).toBe(1);
+  });
+  it('detects REGON with context', () => {
+    expect(found('REGON 123456785')).toEqual([['taxId', '123456785']]);
+  });
+});
+
+describe('UK', () => {
+  it('detects an NHS number with the NHS keyword (healthId is opt-in)', () => {
+    expect(found('NHS No: 943 476 5919', { categories: ['healthId'] })).toEqual([
+      ['healthId', '943 476 5919'],
+    ]);
+  });
+});
+
+describe('global device / vehicle (opt-in categories)', () => {
+  it('detects a VIN by checksum, no context', () => {
+    expect(found('Vehicle 1HGCM82633A004352 sold', { categories: ['vehicleId'] })).toEqual([
+      ['vehicleId', '1HGCM82633A004352'],
+    ]);
+  });
+  it('detects an IMEI with the IMEI keyword and outranks creditCard for the same digits', () => {
+    // 490154203237518 is a 15-digit Luhn run → both deviceId(IMEI) and creditCard
+    // match; deviceId outranks creditCard, and IMEI is context-gated on the keyword.
+    expect(found('IMEI 490154203237518', { categories: ['deviceId', 'creditCard'] })).toEqual([
+      ['deviceId', '490154203237518'],
+    ]);
+  });
+});
+
+describe('region filtering', () => {
+  it('skips PL detectors when only UK is selected', () => {
+    expect(found('PESEL 44051401359', { regions: ['UK'] })).toEqual([]);
+  });
+  it('detectorIds is an explicit allow-list', () => {
+    const spans = detect('PESEL 44051401359 NHS 943 476 5919', { detectorIds: ['pl-pesel'] });
+    expect(spans.map((s) => s.category)).toEqual(['nationalId']);
+  });
+});
+
+describe('redaction uses the specific subtype label', () => {
+  it('labels a PESEL as [PESEL], not [ID]', () => {
+    expect(redact('PESEL 44051401359').text).toBe('PESEL [PESEL]');
+  });
+  it('pseudonymises per specific label', () => {
+    expect(redact('PESEL 44051401359', { mode: 'pseudonym' }).text).toBe('PESEL PESEL_1');
+  });
+});
+
+describe('secrets (default-on, global, low FP)', () => {
+  it('detects an AWS key, a GitHub token and a JWT by default', () => {
+    expect(redact('aws AKIAIOSFODNN7EXAMPLE').text).toBe('aws [AWS_KEY]');
+    // Built at runtime so the source carries no contiguous `ghp_…` literal (GitHub
+    // push-protection would otherwise flag the file); still a valid token shape.
+    const ghToken = `ghp_${'a1B2c3D4'.repeat(4)}abcd`; // ghp_ + 36 base62 chars
+    expect(redact(`tok ${ghToken}`).text).toBe('tok [GITHUB_TOKEN]');
+    expect(
+      redact(
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+      ).text,
+    ).toBe('[JWT]');
+  });
+  it('redacts a whole PEM private key block, not just the header', () => {
+    const pem = '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJB\n-----END RSA PRIVATE KEY-----';
+    expect(redact(`key:\n${pem}\nend`).text).toBe('key:\n[PRIVATE_KEY]\nend');
+  });
+});
+
+describe('US identifiers (opt-in)', () => {
+  it('ITIN: accepts a valid group, rejects an invalid group via the regex ranges', () => {
+    const opt = { categories: ['taxId' as const], regions: ['US' as const] };
+    expect(found('911-70-1234', opt)).toEqual([['taxId', '911-70-1234']]);
+    expect(found('911-66-1234', opt)).toEqual([]); // group 66 not an ITIN range
+  });
+  it('EIN needs the EIN keyword', () => {
+    const opt = { categories: ['taxId' as const], regions: ['US' as const] };
+    expect(found('EIN 12-3456789', opt)).toEqual([['taxId', '12-3456789']]);
+    expect(found('ref 12-3456789', opt)).toEqual([]);
+  });
+  it('MBI by class pattern; US passport needs the passport keyword', () => {
+    expect(found('1EG4TE5MK73', { categories: ['healthId'], regions: ['US'] })).toEqual([
+      ['healthId', '1EG4TE5MK73'],
+    ]);
+    const pp = { categories: ['passport' as const], regions: ['US' as const] };
+    expect(found('passport A12345678', pp)).toEqual([['passport', 'A12345678']]);
+    expect(found('order A12345678', pp)).toEqual([]);
+  });
+});
+
+describe('UK identifiers (opt-in)', () => {
+  it('NINO by structural rules, rejects an excluded prefix', () => {
+    const opt = { categories: ['nationalId' as const], regions: ['UK' as const] };
+    expect(found('AB123456C', opt)).toEqual([['nationalId', 'AB123456C']]);
+    expect(found('QQ123456A', opt)).toEqual([]); // Q is an excluded first letter
+  });
+  it('UTR needs its keyword + mod-11 checksum', () => {
+    expect(found('UTR 2234567890', { categories: ['taxId'], regions: ['UK'] })).toEqual([
+      ['taxId', '2234567890'],
+    ]);
+  });
+  it('postcode by the BS7666 grammar', () => {
+    expect(found('SW1A 1AA', { categories: ['postalCode'], regions: ['UK'] })).toEqual([
+      ['postalCode', 'SW1A 1AA'],
+    ]);
+  });
+});
+
+describe('Poland identifiers (opt-in beyond PESEL/NIP)', () => {
+  it('dowód osobisty by checksum', () => {
+    expect(found('ABA300000', { categories: ['nationalId'], regions: ['PL'] })).toEqual([
+      ['nationalId', 'ABA300000'],
+    ]);
+  });
+  it('NRB bank account by mod-97', () => {
+    expect(
+      found('PL39101010230000261295100000', { categories: ['bankAccount'], regions: ['PL'] }),
+    ).toEqual([['bankAccount', 'PL39101010230000261295100000']]);
+  });
+});
+
+describe('crypto wallets (opt-in, structural)', () => {
+  it('detects an Ethereum address and a BTC address', () => {
+    expect(
+      found('0x52908400098527886E0F7030069857D2E4169EE7', { categories: ['crypto'] }),
+    ).toEqual([['crypto', '0x52908400098527886E0F7030069857D2E4169EE7']]);
+    expect(found('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', { categories: ['crypto'] })).toEqual([
+      ['crypto', '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'],
+    ]);
+  });
+});
+
+describe('default profile scope', () => {
+  it('runs global structured + secrets + PL PESEL/NIP + US SSN, but not opt-in categories', () => {
+    // A bare VIN / NHS / postcode is NOT redacted by default (opt-in categories).
+    expect(found('VIN 1HGCM82633A004352')).toEqual([]);
+    expect(found('SW1A 1AA')).toEqual([]);
+    // ...while a secret and a PESEL ARE.
+    expect(found('AKIAIOSFODNN7EXAMPLE')).toEqual([['secret', 'AKIAIOSFODNN7EXAMPLE']]);
+  });
+});

--- a/packages/anonymizer/src/dictionary.ts
+++ b/packages/anonymizer/src/dictionary.ts
@@ -1,0 +1,570 @@
+/**
+ * The detector dictionary — the heart of the engine.
+ *
+ * Each {@link DetectorDef} pairs a candidate regex with an optional validator
+ * (checksum / structural) and, for the loosest identifiers, an optional *context*
+ * requirement (a nearby keyword such as `PESEL` / `NIP` / `NHS`). The regex finds
+ * candidates; the validator and context keep precision high. A detector carries a
+ * `region` (so the UI can scope to a market) and a `label` (the specific
+ * identifier name used in redaction output, e.g. `[PESEL]`).
+ *
+ * The regexes and checksum algorithms here were assembled from official sources
+ * (government / standards bodies) and adversarially cross-checked. Adding a
+ * market identifier is a single entry here — nothing else changes.
+ *
+ * PRECISION CONTRACT (see `validators.ts` + `detect.ts`):
+ *  - checksum-validated detectors (PESEL, NIP, REGON, NHS, UTR, ABA, Luhn,
+ *    IBAN/NRB, VIN, dowód, passport) are safe to run unanchored;
+ *  - no-checksum / bare-numeric / region-ambiguous detectors are context-gated
+ *    (a keyword within {@link CONTEXT_WINDOW} chars) and/or `defaultOn:false`.
+ */
+
+import type { PiiCategory, PiiSpan, Region } from './types.js';
+import {
+  isCreditCard,
+  isImei,
+  ibanValid,
+  isPlNrb,
+  isIpv4,
+  isIpv6,
+  isSsn,
+  isItin,
+  isEin,
+  isPhone,
+  isPesel,
+  isNip,
+  isRegon,
+  isDowodOsobisty,
+  isPlPassport,
+  isNhsNumber,
+  isUtr,
+  isAbaRouting,
+  isVin,
+} from './validators.js';
+
+export interface DetectorDef {
+  /** Stable kebab id, e.g. `pl-pesel`. */
+  readonly id: string;
+  readonly category: PiiCategory;
+  readonly region: Region;
+  /** Specific identifier name shown in output (`PESEL`, `NHS`, …). */
+  readonly label: string;
+  /** Whether this detector's category is part of the default profile. */
+  readonly defaultOn: boolean;
+  readonly detect: (text: string) => PiiSpan[];
+}
+
+/** How many chars on each side of a match we look in for a context keyword. */
+const CONTEXT_WINDOW = 48;
+
+interface DetectorSpec {
+  readonly id: string;
+  readonly category: PiiCategory;
+  readonly region: Region;
+  readonly label: string;
+  readonly re: RegExp;
+  /** Validate / reject a raw match. Defaults to accept-all. */
+  readonly accept?: (match: string) => boolean;
+  /** When set, a match only counts if this keyword appears within
+   *  {@link CONTEXT_WINDOW} chars — cuts false positives on bare numeric IDs. */
+  readonly context?: RegExp;
+  /** Defaults to `true`. */
+  readonly defaultOn?: boolean;
+}
+
+/** Build a detector from a spec, wiring the `category`/`region`/`label`/context. */
+function make(spec: DetectorSpec): DetectorDef {
+  const flags = spec.re.flags.includes('g') ? spec.re.flags : `${spec.re.flags}g`;
+  return {
+    id: spec.id,
+    category: spec.category,
+    region: spec.region,
+    label: spec.label,
+    defaultOn: spec.defaultOn ?? true,
+    detect(text: string): PiiSpan[] {
+      const re = new RegExp(spec.re.source, flags);
+      const out: PiiSpan[] = [];
+      for (const m of text.matchAll(re)) {
+        const value = m[0] ?? '';
+        const start = m.index ?? -1;
+        if (!value || start < 0) continue;
+        if (spec.accept && !spec.accept(value)) continue;
+        if (spec.context && !hasContext(text, start, start + value.length, spec.context)) continue;
+        out.push({
+          category: spec.category,
+          start,
+          end: start + value.length,
+          value,
+          subtype: spec.label,
+          region: spec.region,
+        });
+      }
+      return out;
+    },
+  };
+}
+
+/** True when `keyword` appears within {@link CONTEXT_WINDOW} chars of the match. */
+function hasContext(text: string, start: number, end: number, keyword: RegExp): boolean {
+  const before = text.slice(Math.max(0, start - CONTEXT_WINDOW), start);
+  const after = text.slice(end, end + CONTEXT_WINDOW);
+  const re = new RegExp(keyword.source, keyword.flags.replace('g', ''));
+  return re.test(before) || re.test(after);
+}
+
+// ── global structured ─────────────────────────────────────────────────────────
+const GLOBAL: DetectorDef[] = [
+  make({
+    id: 'email',
+    category: 'email',
+    region: 'global',
+    label: 'EMAIL',
+    re: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,24}\b/,
+  }),
+  make({
+    id: 'url',
+    category: 'url',
+    region: 'global',
+    label: 'URL',
+    re: /\bhttps?:\/\/[^\s<>"')\]}]+/,
+  }),
+  make({
+    id: 'ipv4',
+    category: 'ipv4',
+    region: 'global',
+    label: 'IP',
+    re: /\b(?:\d{1,3}\.){3}\d{1,3}\b/,
+    accept: isIpv4,
+  }),
+  make({
+    id: 'ipv6',
+    category: 'ipv6',
+    region: 'global',
+    label: 'IP',
+    re: /[0-9A-Fa-f]{0,4}(?::[0-9A-Fa-f]{0,4}){2,7}/,
+    accept: isIpv6,
+  }),
+  make({
+    id: 'mac',
+    category: 'mac',
+    region: 'global',
+    label: 'MAC',
+    re: /\b[0-9A-Fa-f]{2}(?:[:-][0-9A-Fa-f]{2}){5}\b/,
+  }),
+  make({
+    id: 'credit-card',
+    category: 'creditCard',
+    region: 'global',
+    label: 'CARD',
+    re: /\b\d(?:[ -]?\d){12,18}\b/,
+    accept: isCreditCard,
+  }),
+  make({
+    id: 'iban',
+    category: 'iban',
+    region: 'global',
+    label: 'IBAN',
+    re: /\b[A-Z]{2}\d{2}(?:[ ]?[A-Z0-9]){11,30}\b/,
+    accept: ibanValid,
+  }),
+  make({
+    id: 'phone',
+    category: 'phone',
+    region: 'global',
+    label: 'PHONE',
+    re: /(?<![\w.])(?:\+\d{1,3}[ .-]?)?(?:\(\d{1,4}\)[ .-]?)?\d{2,4}(?:[ .-]\d{2,4}){1,5}(?![\w])/,
+    accept: isPhone,
+  }),
+  make({
+    id: 'imei',
+    category: 'deviceId',
+    region: 'global',
+    label: 'IMEI',
+    defaultOn: false,
+    re: /\b\d{2}[- ]?\d{6}[- ]?\d{6}[- ]?\d\b|\b\d{15}\b/,
+    accept: isImei,
+    context: /\bIMEI\b/i,
+  }),
+  make({
+    id: 'vin',
+    category: 'vehicleId',
+    region: 'global',
+    label: 'VIN',
+    defaultOn: false,
+    re: /\b[A-HJ-NPR-Z0-9]{17}\b/,
+    accept: isVin,
+  }),
+  make({
+    id: 'date',
+    category: 'date',
+    region: 'global',
+    label: 'DATE',
+    defaultOn: false,
+    re: /\b(?:\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}\/\d{2,4}|(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+\d{4})\b/i,
+  }),
+];
+
+// ── global crypto wallets (structural only — keeps the engine dependency-free) ─
+const CRYPTO: DetectorDef[] = [
+  make({
+    id: 'btc-base58check',
+    category: 'crypto',
+    region: 'global',
+    label: 'BTC',
+    defaultOn: false,
+    re: /\b[13][a-km-zA-HJ-NP-Z1-9]{25,34}\b/,
+  }),
+  make({
+    id: 'btc-bech32',
+    category: 'crypto',
+    region: 'global',
+    label: 'BTC',
+    defaultOn: false,
+    re: /\b(?:bc|tb)1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{6,87}\b/,
+  }),
+  make({
+    id: 'ethereum-address',
+    category: 'crypto',
+    region: 'global',
+    label: 'ETH',
+    defaultOn: false,
+    re: /\b0x[0-9a-fA-F]{40}\b/,
+  }),
+];
+
+// ── global secrets / credentials (structural prefix match — low FP, high harm) ─
+const SECRETS: DetectorDef[] = [
+  make({
+    id: 'aws-access-key-id',
+    category: 'secret',
+    region: 'global',
+    label: 'AWS_KEY',
+    re: /\b(?:AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}\b/,
+  }),
+  make({
+    id: 'github-token',
+    category: 'secret',
+    region: 'global',
+    label: 'GITHUB_TOKEN',
+    re: /\b(?:gh[pousr]_[A-Za-z0-9]{36,255}|github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{59})\b/,
+  }),
+  make({
+    id: 'stripe-secret-key',
+    category: 'secret',
+    region: 'global',
+    label: 'STRIPE_KEY',
+    re: /\b(?:sk|rk|pk)_(?:live|test|prod)_[A-Za-z0-9]{10,128}(?![A-Za-z0-9])/,
+  }),
+  make({
+    id: 'google-api-key',
+    category: 'secret',
+    region: 'global',
+    label: 'GOOGLE_API_KEY',
+    re: /\bAIza[0-9A-Za-z_-]{35}\b/,
+  }),
+  make({
+    id: 'slack-token',
+    category: 'secret',
+    region: 'global',
+    label: 'SLACK_TOKEN',
+    re: /\bxox[baprsoe]-(?:\d-)?[0-9A-Za-z]{8,48}(?:-[0-9A-Za-z]{8,48}){0,3}\b/,
+  }),
+  make({
+    id: 'openai-api-key',
+    category: 'secret',
+    region: 'global',
+    label: 'OPENAI_KEY',
+    re: /\bsk-[A-Za-z0-9]{48}\b|\bsk-(?:(?:proj|svcacct|admin|None)-)?[A-Za-z0-9_-]{20,}T3BlbkFJ[A-Za-z0-9_-]{20,}/,
+  }),
+  make({
+    id: 'jwt',
+    category: 'secret',
+    region: 'global',
+    label: 'JWT',
+    re: /(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*(?![A-Za-z0-9_-])/,
+  }),
+  make({
+    id: 'private-key-pem',
+    category: 'secret',
+    region: 'global',
+    label: 'PRIVATE_KEY',
+    // Match the whole PEM block when an END line is present (so the key material
+    // is removed, not just the header); fall back to the header alone otherwise.
+    re: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY(?: BLOCK)?-----(?:[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY(?: BLOCK)?-----)?/,
+  }),
+];
+
+// ── United States ─────────────────────────────────────────────────────────────
+const US: DetectorDef[] = [
+  make({
+    id: 'us-ssn',
+    category: 'ssn',
+    region: 'US',
+    label: 'SSN',
+    re: /\b(\d{3})-(\d{2})-(\d{4})\b/,
+    accept: isSsn,
+  }),
+  make({
+    id: 'us-itin',
+    category: 'taxId',
+    region: 'US',
+    label: 'ITIN',
+    defaultOn: false,
+    re: /\b9\d\d([- ]?)(?:5[0-9]|6[0-5]|7[0-9]|8[0-8]|9[0-24-9])\1\d{4}\b/,
+    accept: isItin,
+  }),
+  make({
+    id: 'us-ein',
+    category: 'taxId',
+    region: 'US',
+    label: 'EIN',
+    defaultOn: false,
+    re: /\b(?:0[1-6]|1[0-6]|2[0-7]|3[0-9]|4[0-8]|5[0-9]|6[0-8]|7[1-7]|8[0-8]|9[0-5]|98|99)-\d{7}\b/,
+    accept: isEin,
+    context: /\bEIN\b|employer id/i,
+  }),
+  make({
+    id: 'us-mbi',
+    category: 'healthId',
+    region: 'US',
+    label: 'MBI',
+    defaultOn: false,
+    re: /\b[1-9][ACDEFGHJKMNPQRTUVWXY][0-9ACDEFGHJKMNPQRTUVWXY][0-9][ACDEFGHJKMNPQRTUVWXY][0-9ACDEFGHJKMNPQRTUVWXY][0-9][ACDEFGHJKMNPQRTUVWXY][ACDEFGHJKMNPQRTUVWXY][0-9][0-9]\b/,
+  }),
+  make({
+    id: 'us-aba-routing',
+    category: 'bankAccount',
+    region: 'US',
+    label: 'ROUTING',
+    defaultOn: false,
+    re: /\b(?:0[0-9]|1[0-2]|2[1-9]|3[0-2]|6[1-9]|7[0-2]|80)\d{7}\b/,
+    accept: isAbaRouting,
+    context: /\b(?:routing|aba|rtn)\b/i,
+  }),
+  make({
+    id: 'us-bank-account',
+    category: 'bankAccount',
+    region: 'US',
+    label: 'ACCOUNT',
+    defaultOn: false,
+    re: /\b\d{8}\b/,
+    context: /\b(?:account|acct|a\/c)\b/i,
+  }),
+  make({
+    id: 'us-passport',
+    category: 'passport',
+    region: 'US',
+    label: 'PASSPORT',
+    defaultOn: false,
+    re: /\b(?:[A-Z][0-9]{8}|[0-9]{9})\b/,
+    context: /\bpassport\b/i,
+  }),
+  make({
+    id: 'us-zip',
+    category: 'postalCode',
+    region: 'US',
+    label: 'ZIP',
+    defaultOn: false,
+    re: /\b\d{5}(?:-\d{4})?\b/,
+    context: /\b(?:zip|postal)\b/i,
+  }),
+];
+
+// ── Poland ─────────────────────────────────────────────────────────────────────
+const PL: DetectorDef[] = [
+  make({
+    id: 'pl-pesel',
+    category: 'nationalId',
+    region: 'PL',
+    label: 'PESEL',
+    re: /\b\d{11}\b/,
+    accept: isPesel,
+  }),
+  make({
+    // Formatted NIP — a `PL` prefix or dashed grouping is itself strong evidence.
+    id: 'pl-nip',
+    category: 'taxId',
+    region: 'PL',
+    label: 'NIP',
+    re: /\bPL\s?\d{10}\b|\b\d{3}-\d{2,3}-\d{2,3}-\d{2,3}\b/,
+    accept: isNip,
+  }),
+  make({
+    // Bare 10-digit NIP — needs a nearby `NIP` keyword (mod-11 alone is common).
+    id: 'pl-nip-plain',
+    category: 'taxId',
+    region: 'PL',
+    label: 'NIP',
+    re: /\b\d{10}\b/,
+    accept: isNip,
+    context: /\bNIP\b/i,
+  }),
+  make({
+    id: 'pl-regon',
+    category: 'taxId',
+    region: 'PL',
+    label: 'REGON',
+    defaultOn: false,
+    re: /\b\d{9}\b|\b\d{14}\b/,
+    accept: isRegon,
+    context: /\bREGON\b/i,
+  }),
+  make({
+    id: 'pl-dowod-osobisty',
+    category: 'nationalId',
+    region: 'PL',
+    label: 'DOWOD',
+    defaultOn: false,
+    re: /(?<![0-9A-Za-z])[A-NP-Za-np-z]{3}[0-9]{6}(?![0-9A-Za-z])/,
+    accept: isDowodOsobisty,
+  }),
+  make({
+    id: 'pl-passport',
+    category: 'passport',
+    region: 'PL',
+    label: 'PASSPORT',
+    defaultOn: false,
+    re: /(?<![0-9A-Za-z])[A-Za-z]{2}[0-9]{7}(?![0-9A-Za-z])/,
+    accept: isPlPassport,
+  }),
+  make({
+    id: 'pl-nrb-iban',
+    category: 'bankAccount',
+    region: 'PL',
+    label: 'NRB',
+    defaultOn: false,
+    re: /(?<![0-9A-Za-z])(?:PL)?[0-9]{2}(?:[ \t-]?[0-9]{4}){6}(?![0-9])/i,
+    accept: isPlNrb,
+  }),
+  make({
+    id: 'pl-drivers-license',
+    category: 'driverLicense',
+    region: 'PL',
+    label: 'DL',
+    defaultOn: false,
+    re: /(?<![0-9])[0-9]{5}\/[0-9]{2}\/[0-9]{4,7}(?![0-9])/,
+    context: /prawo jazdy/i,
+  }),
+  make({
+    id: 'pl-dowod-rejestracyjny',
+    category: 'vehicleId',
+    region: 'PL',
+    label: 'REG_DOC',
+    defaultOn: false,
+    re: /(?<![0-9A-Za-z])DR\s*\/\s*BA[A-Z]\s*[0-9]{7}(?![0-9])/,
+  }),
+];
+
+// ── United Kingdom ──────────────────────────────────────────────────────────────
+const UK: DetectorDef[] = [
+  make({
+    id: 'uk-nino',
+    category: 'nationalId',
+    region: 'UK',
+    label: 'NINO',
+    defaultOn: false,
+    re: /\b(?![DFIQUV])[A-CEGHJ-PR-TW-Z](?![DFIOQUV])[A-CEGHJ-NPR-TW-Z](?<!BG)(?<!GB)(?<!KN)(?<!NK)(?<!NT)(?<!TN)(?<!ZZ)\s?\d{2}\s?\d{2}\s?\d{2}\s?[A-D]\b/,
+  }),
+  make({
+    id: 'uk-nhs-number',
+    category: 'healthId',
+    region: 'UK',
+    label: 'NHS',
+    defaultOn: false,
+    re: /\b\d{3}[ -]?\d{3}[ -]?\d{4}\b/,
+    accept: isNhsNumber,
+    context: /\bNHS\b/i,
+  }),
+  make({
+    id: 'uk-utr',
+    category: 'taxId',
+    region: 'UK',
+    label: 'UTR',
+    defaultOn: false,
+    re: /\b\d{5}\s?\d{5}K?\b/i,
+    accept: isUtr,
+    context: /\bUTR\b|unique taxpayer/i,
+  }),
+  make({
+    id: 'uk-postcode',
+    category: 'postalCode',
+    region: 'UK',
+    label: 'POSTCODE',
+    defaultOn: false,
+    re: /\b(?:GIR ?0AA|(?:[A-PR-UWYZ][0-9]{1,2}|[A-PR-UWYZ][A-HK-Y][0-9]{1,2}|[A-PR-UWYZ][0-9][A-HJKPSTUW]|[A-PR-UWYZ][A-HK-Y][0-9][ABEHMNPRV-Y]) ?[0-9][ABD-HJLNP-UW-Z]{2})\b/i,
+  }),
+  make({
+    id: 'uk-passport',
+    category: 'passport',
+    region: 'UK',
+    label: 'PASSPORT',
+    defaultOn: false,
+    re: /\b[A-Z0-9]\d{8}\b/i,
+    context: /\bpassport\b/i,
+  }),
+  make({
+    id: 'uk-driving-licence',
+    category: 'driverLicense',
+    region: 'UK',
+    label: 'DL',
+    defaultOn: false,
+    re: /\b[A-Z9]{5}[0-9]{6}[A-Z9]{2}[A-Z0-9]{3}\b/,
+  }),
+  make({
+    id: 'uk-sort-code',
+    category: 'bankAccount',
+    region: 'UK',
+    label: 'SORT_CODE',
+    defaultOn: false,
+    re: /\b\d{2}[- ]?\d{2}[- ]?\d{2}\b/,
+    context: /sort code/i,
+  }),
+];
+
+/** The full dictionary — every built-in detector. */
+export const DICTIONARY: readonly DetectorDef[] = [
+  ...GLOBAL,
+  ...CRYPTO,
+  ...SECRETS,
+  ...US,
+  ...PL,
+  ...UK,
+];
+
+/** Detector lookup by id. */
+export const DETECTOR_BY_ID: ReadonlyMap<string, DetectorDef> = new Map(
+  DICTIONARY.map((d) => [d.id, d]),
+);
+
+/** Categories that have at least one `defaultOn` detector — the engine default. */
+export const DEFAULT_CATEGORIES: readonly PiiCategory[] = [
+  ...new Set(DICTIONARY.filter((d) => d.defaultOn).map((d) => d.category)),
+];
+
+/** Every category that has at least one built-in detector (any `defaultOn`).
+ *  The UI derives its toggle list from this, so adding a detector surfaces its
+ *  category automatically. */
+export const DETECTABLE_CATEGORIES: readonly PiiCategory[] = [
+  ...new Set(DICTIONARY.map((d) => d.category)),
+];
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Literal, case-insensitive, word-boundary matches of user-supplied terms. */
+export function detectCustom(text: string, terms: readonly string[]): PiiSpan[] {
+  const spans: PiiSpan[] = [];
+  for (const term of terms) {
+    const t = term.trim();
+    if (!t) continue;
+    const re = new RegExp(`(?<!\\w)${escapeRegExp(t)}(?!\\w)`, 'gi');
+    for (const m of text.matchAll(re)) {
+      const value = m[0] ?? '';
+      const start = m.index ?? -1;
+      if (!value || start < 0) continue;
+      spans.push({ category: 'custom', start, end: start + value.length, value });
+    }
+  }
+  return spans;
+}

--- a/packages/anonymizer/src/index.ts
+++ b/packages/anonymizer/src/index.ts
@@ -7,12 +7,21 @@
  * renderer, where CSP `connect-src 'self'` already blocks all egress.
  */
 
-export { detect } from './detect.js';
+export { detect, selectDetectors } from './detect.js';
 export { redact } from './redact.js';
 export { shortHash } from './hash.js';
-export { ALL_CATEGORIES, STRUCTURED_CATEGORIES } from './types.js';
+export {
+  DICTIONARY,
+  DETECTOR_BY_ID,
+  DEFAULT_CATEGORIES,
+  DETECTABLE_CATEGORIES,
+  detectCustom,
+} from './dictionary.js';
+export type { DetectorDef } from './dictionary.js';
+export { ALL_CATEGORIES, ALL_REGIONS, STRUCTURED_CATEGORIES } from './types.js';
 export type {
   PiiCategory,
+  Region,
   PiiSpan,
   RedactionMode,
   DetectOptions,

--- a/packages/anonymizer/src/redact.ts
+++ b/packages/anonymizer/src/redact.ts
@@ -13,13 +13,24 @@ import type {
   RedactResult,
 } from './types.js';
 
-/** Human-facing label per category (also the pseudonym/hash prefix). */
+/** Coarse human-facing label per category. A span's specific {@link PiiSpan.subtype}
+ *  (e.g. `PESEL`, `NHS`) overrides this so output stays precise. */
 const LABELS: Record<PiiCategory, string> = {
   email: 'EMAIL',
   phone: 'PHONE',
   creditCard: 'CARD',
   ssn: 'SSN',
   nationalId: 'ID',
+  taxId: 'TAX_ID',
+  healthId: 'HEALTH_ID',
+  passport: 'PASSPORT',
+  driverLicense: 'LICENSE',
+  postalCode: 'POSTCODE',
+  bankAccount: 'BANK',
+  crypto: 'CRYPTO',
+  deviceId: 'DEVICE',
+  vehicleId: 'VEHICLE',
+  secret: 'SECRET',
   ipv4: 'IP',
   ipv6: 'IP',
   mac: 'MAC',
@@ -32,6 +43,12 @@ const LABELS: Record<PiiCategory, string> = {
   custom: 'REDACTED',
 };
 
+/** The label to emit for a span: its specific subtype when present, else the
+ *  coarse category label. */
+function labelFor(span: PiiSpan): string {
+  return span.subtype ?? LABELS[span.category];
+}
+
 function emptyCounts(): Record<PiiCategory, number> {
   return {
     email: 0,
@@ -39,6 +56,16 @@ function emptyCounts(): Record<PiiCategory, number> {
     creditCard: 0,
     ssn: 0,
     nationalId: 0,
+    taxId: 0,
+    healthId: 0,
+    passport: 0,
+    driverLicense: 0,
+    postalCode: 0,
+    bankAccount: 0,
+    crypto: 0,
+    deviceId: 0,
+    vehicleId: 0,
+    secret: 0,
     ipv4: 0,
     ipv6: 0,
     mac: 0,
@@ -62,20 +89,20 @@ export function redact(text: string, opts: RedactOptions = {}): RedactResult {
 
   // Compute the replacement string per span LEFT-TO-RIGHT so pseudonym numbers
   // follow reading order, ...
-  const counters = new Map<PiiCategory, number>();
-  const memo = new Map<string, string>(); // `${category}:${lower(value)}` → token
+  const counters = new Map<string, number>(); // label → next index
+  const memo = new Map<string, string>(); // `${label}:${lower(value)}` → token
   const replacementFor = (span: PiiSpan): string => {
-    const label = LABELS[span.category];
+    const label = labelFor(span);
     if (mode === 'label') return `[${label}]`;
-    const key = `${span.category}:${span.value.toLowerCase()}`;
+    const key = `${label}:${span.value.toLowerCase()}`;
     const existing = memo.get(key);
     if (existing) return existing;
     let token: string;
     if (mode === 'hash') {
       token = `[${label}:${shortHash(span.value.toLowerCase(), opts.hashSalt ?? '')}]`;
     } else {
-      const n = (counters.get(span.category) ?? 0) + 1;
-      counters.set(span.category, n);
+      const n = (counters.get(label) ?? 0) + 1;
+      counters.set(label, n);
       token = `${label}_${n}`;
     }
     memo.set(key, token);

--- a/packages/anonymizer/src/types.ts
+++ b/packages/anonymizer/src/types.ts
@@ -8,13 +8,15 @@
 /**
  * A class of personally-identifiable information.
  *
- * `email`..`date` are detected by built-in regex/validator detectors.
- * `person | org | location` come from an external NER pass (the desktop bundles
- * an on-device model and feeds its spans in via {@link DetectOptions.extraSpans});
- * the engine itself never does NER. `custom` is literal user-supplied terms
- * (names, addresses) the user wants redacted. `nationalId` is reserved for
- * region-specific detectors and has no default built-in (off unless provided as
- * an extra span).
+ * Most categories are detected by built-in regex/validator detectors in the
+ * {@link DICTIONARY}. `person | org | location` come from an external NER pass
+ * (the desktop bundles an on-device model and feeds its spans in via
+ * {@link DetectOptions.extraSpans}); the engine itself never does NER. `custom`
+ * is literal user-supplied terms (names, addresses) the user wants redacted.
+ *
+ * Several categories are buckets that span many region-specific identifiers
+ * distinguished by {@link PiiSpan.subtype} (e.g. `nationalId` covers Polish
+ * PESEL, the UK National Insurance Number, …; `taxId` covers NIP/REGON/EIN/…).
  */
 export type PiiCategory =
   | 'email'
@@ -22,6 +24,16 @@ export type PiiCategory =
   | 'creditCard'
   | 'ssn'
   | 'nationalId'
+  | 'taxId'
+  | 'healthId'
+  | 'passport'
+  | 'driverLicense'
+  | 'postalCode'
+  | 'bankAccount'
+  | 'crypto'
+  | 'deviceId'
+  | 'vehicleId'
+  | 'secret'
   | 'ipv4'
   | 'ipv6'
   | 'mac'
@@ -33,6 +45,13 @@ export type PiiCategory =
   | 'location'
   | 'custom';
 
+/**
+ * Market/jurisdiction a detector targets. `global` detectors are
+ * language/country-independent (email, credit card, IBAN, crypto, …) and always
+ * run; the rest are gated by {@link DetectOptions.regions}.
+ */
+export type Region = 'global' | 'PL' | 'UK' | 'US';
+
 /** A detected PII occurrence: a half-open `[start, end)` char range in the source. */
 export interface PiiSpan {
   readonly category: PiiCategory;
@@ -42,6 +61,11 @@ export interface PiiSpan {
   readonly end: number;
   /** The exact matched substring (`text.slice(start, end)`). */
   readonly value: string;
+  /** Specific identifier name within the category (e.g. `'PESEL'`, `'NHS'`).
+   *  Used as the redaction label so output is precise (`[PESEL]`, not `[ID]`). */
+  readonly subtype?: string;
+  /** Which market produced the span (for reporting); absent for NER/custom. */
+  readonly region?: Region;
 }
 
 /**
@@ -53,8 +77,15 @@ export interface PiiSpan {
 export type RedactionMode = 'label' | 'pseudonym' | 'hash';
 
 export interface DetectOptions {
-  /** Which built-in detectors to run. Defaults to {@link STRUCTURED_CATEGORIES}. */
+  /** Which built-in categories to run. Defaults to {@link DEFAULT_CATEGORIES}. */
   readonly categories?: readonly PiiCategory[];
+  /** Which markets' region-specific detectors to run (PL/UK/US). `global`
+   *  detectors always run regardless. Defaults to every region. */
+  readonly regions?: readonly Region[];
+  /** Explicit detector-id allow-list. When provided it takes precedence over
+   *  `categories`/`regions` (only these detectors run) — the precise control the
+   *  power-user UI / tests use. */
+  readonly detectorIds?: readonly string[];
   /** Literal terms (case-insensitive, word-boundary) to redact as `custom` —
    *  the deterministic path for names/addresses the user types in. */
   readonly customTerms?: readonly string[];
@@ -92,6 +123,16 @@ export const ALL_CATEGORIES: readonly PiiCategory[] = [
   'creditCard',
   'ssn',
   'nationalId',
+  'taxId',
+  'healthId',
+  'passport',
+  'driverLicense',
+  'postalCode',
+  'bankAccount',
+  'crypto',
+  'deviceId',
+  'vehicleId',
+  'secret',
   'ipv4',
   'ipv6',
   'mac',
@@ -104,10 +145,12 @@ export const ALL_CATEGORIES: readonly PiiCategory[] = [
   'custom',
 ];
 
+/** Every market, in a stable order. */
+export const ALL_REGIONS: readonly Region[] = ['global', 'PL', 'UK', 'US'];
+
 /**
- * The built-in detectors that run by default. `date` is omitted (high
- * false-positive rate — opt-in), as are `nationalId` (region-specific) and the
- * NER-only `person`/`org`/`location`/`custom` categories.
+ * Legacy structured set kept for backwards compatibility. The richer default is
+ * {@link DEFAULT_CATEGORIES} (derived from the dictionary's `defaultOn` flags).
  */
 export const STRUCTURED_CATEGORIES: readonly PiiCategory[] = [
   'email',

--- a/packages/anonymizer/src/validators.test.ts
+++ b/packages/anonymizer/src/validators.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import {
+  luhnValid,
+  isCreditCard,
+  isImei,
+  ibanValid,
+  isPlNrb,
+  isIpv4,
+  isIpv6,
+  isSsn,
+  isItin,
+  isEin,
+  isPhone,
+  isPesel,
+  isNip,
+  isRegon,
+  isDowodOsobisty,
+  isPlPassport,
+  isNhsNumber,
+  isUtr,
+  isAbaRouting,
+  isVin,
+} from './validators.js';
+
+// NOTE: every "valid" vector below is SYNTHETIC (fabricated) but constructed to
+// satisfy the real checksum, so these tests pin the checksum math itself.
+
+describe('luhn / credit card / IMEI', () => {
+  it('luhn', () => {
+    expect(luhnValid('4111111111111111')).toBe(true);
+    expect(luhnValid('4111111111111112')).toBe(false);
+  });
+  it('credit card length + luhn', () => {
+    expect(isCreditCard('4111 1111 1111 1111')).toBe(true);
+    expect(isCreditCard('4111 1111 1111 1112')).toBe(false);
+    expect(isCreditCard('411111')).toBe(false); // too short
+  });
+  it('IMEI is 15 digits + luhn', () => {
+    expect(isImei('490154203237518')).toBe(true);
+    expect(isImei('490154203237519')).toBe(false); // bad check
+    expect(isImei('4901542032375')).toBe(false); // wrong length
+  });
+});
+
+describe('iban (mod-97 + length)', () => {
+  it('accepts valid, rejects bad check / wrong length', () => {
+    expect(ibanValid('GB82 WEST 1234 5698 7654 32')).toBe(true);
+    expect(ibanValid('GB82WEST12345698765433')).toBe(false); // bad check digit
+    expect(ibanValid('GB82WEST123456987654')).toBe(false); // wrong length for GB
+  });
+});
+
+describe('ip', () => {
+  it('ipv4 octet range', () => {
+    expect(isIpv4('192.168.1.255')).toBe(true);
+    expect(isIpv4('999.1.1.1')).toBe(false);
+  });
+  it('ipv6 vs mac', () => {
+    expect(isIpv6('fe80::1')).toBe(true);
+    expect(isIpv6('01:23:45:67:89:ab')).toBe(false);
+  });
+});
+
+describe('us ssn / phone', () => {
+  it('ssn sanity', () => {
+    expect(isSsn('123-45-6789')).toBe(true);
+    expect(isSsn('000-45-6789')).toBe(false);
+    expect(isSsn('900-45-6789')).toBe(false);
+  });
+  it('phone rejects dates', () => {
+    expect(isPhone('+1 415 555 2671')).toBe(true);
+    expect(isPhone('2020-01-02')).toBe(false);
+  });
+});
+
+describe('Poland: PESEL', () => {
+  it('valid 20th + 21st century, rejects bad checksum and bad date', () => {
+    expect(isPesel('44051401359')).toBe(true); // 1944-05-14
+    expect(isPesel('00210100004')).toBe(true); // 2000-01-01 (month +20)
+    expect(isPesel('44051401358')).toBe(false); // bad control digit
+    expect(isPesel('44131401357')).toBe(false); // month 13 → invalid date
+  });
+});
+
+describe('Poland: NIP', () => {
+  it('valid, optional PL prefix + separators, rejects bad checksum', () => {
+    expect(isNip('1234563218')).toBe(true);
+    expect(isNip('PL 123-456-32-18')).toBe(true);
+    expect(isNip('1234563210')).toBe(false);
+  });
+});
+
+describe('Poland: REGON', () => {
+  it('REGON-9 and REGON-14', () => {
+    expect(isRegon('123456785')).toBe(true);
+    expect(isRegon('12345678512347')).toBe(true);
+    expect(isRegon('123456789')).toBe(false);
+  });
+});
+
+describe('UK: NHS number', () => {
+  it('mod-11, rejects bad check', () => {
+    expect(isNhsNumber('943 476 5919')).toBe(true);
+    expect(isNhsNumber('9434765918')).toBe(false);
+  });
+});
+
+describe('US: ABA routing', () => {
+  it('weighted mod-10', () => {
+    expect(isAbaRouting('011000015')).toBe(true);
+    expect(isAbaRouting('011000016')).toBe(false);
+  });
+});
+
+describe('Global: VIN', () => {
+  it('ISO 3779 check digit', () => {
+    expect(isVin('1HGCM82633A004352')).toBe(true);
+    expect(isVin('1HGCM82613A004352')).toBe(false); // bad check digit
+    expect(isVin('1HGCM82633A00435I')).toBe(false); // illegal letter I
+  });
+});
+
+describe('all-zeros / degenerate guards', () => {
+  it('rejects all-zeros runs that satisfy the raw mod math', () => {
+    expect(isCreditCard('0000000000000000')).toBe(false);
+    expect(isImei('000000000000000')).toBe(false);
+    expect(isNip('0000000000')).toBe(false);
+    expect(isRegon('000000000')).toBe(false);
+    expect(isAbaRouting('000000000')).toBe(false);
+  });
+});
+
+describe('US: ITIN / EIN', () => {
+  it('ITIN starts with 9, rejects bad leading digit / zero serial', () => {
+    expect(isItin('911701234')).toBe(true);
+    expect(isItin('811701234')).toBe(false);
+    expect(isItin('911700000')).toBe(false);
+  });
+  it('EIN prefix-set membership', () => {
+    expect(isEin('123456789')).toBe(true); // prefix 12 valid
+    expect(isEin('071234567')).toBe(false); // prefix 07 invalid
+    expect(isEin('001234567')).toBe(false); // prefix 00 invalid
+  });
+});
+
+describe('Poland: dowód / passport / NRB', () => {
+  it('dowód osobisty check digit', () => {
+    expect(isDowodOsobisty('ABA300000')).toBe(true);
+    expect(isDowodOsobisty('ABA300001')).toBe(false);
+  });
+  it('passport check digit', () => {
+    expect(isPlPassport('AB4123456')).toBe(true);
+    expect(isPlPassport('AB4123457')).toBe(false);
+  });
+  it('NRB via mod-97 (with or without PL prefix)', () => {
+    expect(isPlNrb('PL39101010230000261295100000')).toBe(true);
+    expect(isPlNrb('39101010230000261295100000')).toBe(true);
+    expect(isPlNrb('PL00101010230000261295100000')).toBe(false);
+  });
+});
+
+describe('UK: UTR', () => {
+  it('mod-11 with the check digit FIRST (optional trailing K)', () => {
+    expect(isUtr('2234567890')).toBe(true);
+    expect(isUtr('32468 01357K'.replace(/\s|K/g, ''))).toBe(true);
+    expect(isUtr('1234567890')).toBe(false);
+  });
+});

--- a/packages/anonymizer/src/validators.ts
+++ b/packages/anonymizer/src/validators.ts
@@ -1,0 +1,312 @@
+/**
+ * Pure validators — checksum / structural checks that turn loose regex
+ * candidates into high-precision detections. No I/O, no state.
+ *
+ * A detector's regex only finds *candidates*; the validator is what keeps false
+ * positives down (a Luhn check on a 16-digit run, mod-97 on an IBAN, the PESEL
+ * weighted checksum, …). Every validator here is exercised directly by
+ * `validators.test.ts` with synthetic-but-checksum-valid vectors.
+ *
+ * A recurring subtlety: pure weighted-mod schemes accept an all-zeros string
+ * (sum 0 ⇒ control 0). Such strings are never real identifiers, so the relevant
+ * validators reject all-zeros explicitly via {@link notAllZeros}.
+ */
+
+/** Strip everything but ASCII digits. */
+export function digitsOnly(s: string): string {
+  return s.replace(/[^0-9]/g, '');
+}
+
+/** Reject the degenerate all-zeros run that satisfies any weighted-mod check. */
+function notAllZeros(digits: string): boolean {
+  return /[1-9]/.test(digits);
+}
+
+/** Letter→number for ID checksums: A=10 … Z=35; digit = face value. */
+function alnumValue(ch: string): number {
+  const code = ch.charCodeAt(0);
+  if (code >= 48 && code <= 57) return code - 48;
+  if (code >= 65 && code <= 90) return code - 55;
+  if (code >= 97 && code <= 122) return code - 87;
+  return NaN;
+}
+
+/** Weighted sum of `digits` against `weights` (positionally aligned). */
+function weightedSum(digits: string, weights: readonly number[]): number {
+  let sum = 0;
+  for (let i = 0; i < weights.length; i++) sum += (digits.charCodeAt(i) - 48) * weights[i]!;
+  return sum;
+}
+
+// ── Luhn (credit cards, IMEI) ────────────────────────────────────────────────
+export function luhnValid(digits: string): boolean {
+  if (!/^\d+$/.test(digits)) return false;
+  let sum = 0;
+  let alt = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = digits.charCodeAt(i) - 48;
+    if (alt) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+    sum += d;
+    alt = !alt;
+  }
+  return sum % 10 === 0;
+}
+
+export function isCreditCard(m: string): boolean {
+  const d = digitsOnly(m);
+  return d.length >= 13 && d.length <= 19 && notAllZeros(d) && luhnValid(d);
+}
+
+/** IMEI: exactly 15 digits, Luhn-valid (the 15th is the Luhn check digit). */
+export function isImei(m: string): boolean {
+  const d = digitsOnly(m);
+  return d.length === 15 && notAllZeros(d) && luhnValid(d);
+}
+
+// ── IBAN (mod-97) ────────────────────────────────────────────────────────────
+/**
+ * Per-country IBAN length table (ISO 13616). Used so a `XX99…` run of the wrong
+ * length for its country is rejected before the (also-checked) mod-97 pass.
+ */
+export const IBAN_LENGTHS: Readonly<Record<string, number>> = {
+  AD: 24, AE: 23, AL: 28, AT: 20, AZ: 28, BA: 20, BE: 16, BG: 22, BH: 22, BR: 29,
+  BY: 28, CH: 21, CR: 22, CY: 28, CZ: 24, DE: 22, DK: 18, DO: 28, EE: 20, EG: 29,
+  ES: 24, FI: 18, FO: 18, FR: 27, GB: 22, GE: 22, GI: 23, GL: 18, GR: 27, GT: 28,
+  HR: 21, HU: 28, IE: 22, IL: 23, IS: 26, IT: 27, JO: 30, KW: 30, KZ: 20, LB: 28,
+  LC: 32, LI: 21, LT: 20, LU: 20, LV: 21, MC: 27, MD: 24, ME: 22, MK: 19, MR: 27,
+  MT: 31, MU: 30, NL: 18, NO: 15, PK: 24, PL: 28, PS: 29, PT: 25, QA: 29, RO: 24,
+  RS: 22, SA: 24, SC: 31, SE: 24, SI: 19, SK: 24, SM: 27, TN: 24, TR: 26, UA: 29,
+  VA: 22, VG: 24, XK: 20,
+};
+
+export function ibanValid(raw: string): boolean {
+  const s = raw.replace(/\s+/g, '').toUpperCase();
+  if (s.length < 15 || s.length > 34) return false;
+  if (!/^[A-Z]{2}\d{2}[A-Z0-9]+$/.test(s)) return false;
+  const expected = IBAN_LENGTHS[s.slice(0, 2)];
+  if (expected != null && s.length !== expected) return false;
+  const rearranged = s.slice(4) + s.slice(0, 4);
+  let remainder = 0;
+  for (const ch of rearranged) {
+    const code = ch.charCodeAt(0);
+    const val = code >= 65 ? code - 55 : code - 48; // A-Z → 10..35, 0-9 → 0..9
+    remainder = (remainder * (val > 9 ? 100 : 10) + val) % 97;
+  }
+  return remainder === 1;
+}
+
+/** Polish NRB (26 digits) — the body of a PL IBAN. Normalize, prepend `PL` if
+ *  absent, then mod-97 (PL IBANs are 28 chars: `PL` + 26-digit NRB). */
+export function isPlNrb(raw: string): boolean {
+  const s = raw.replace(/[ \t-]/g, '').toUpperCase();
+  const withPL = s.startsWith('PL') ? s : `PL${s}`;
+  if (!/^PL\d{26}$/.test(withPL)) return false;
+  return ibanValid(withPL);
+}
+
+// ── IPv4 / IPv6 ──────────────────────────────────────────────────────────────
+export function isIpv4(m: string): boolean {
+  const parts = m.split('.');
+  if (parts.length !== 4) return false;
+  return parts.every((p) => /^\d{1,3}$/.test(p) && Number(p) <= 255);
+}
+
+export function isIpv6(m: string): boolean {
+  if (!/^[0-9A-Fa-f:]+$/.test(m)) return false;
+  if ((m.match(/::/g) ?? []).length > 1) return false; // at most one '::'
+  if (/:::/.test(m)) return false;
+  const hasDouble = m.includes('::');
+  const groups = m.split(':').filter((g) => g.length > 0);
+  if (groups.some((g) => !/^[0-9A-Fa-f]{1,4}$/.test(g))) return false;
+  // Without compression an address needs exactly 8 groups; with '::' it needs
+  // fewer (so a 6-group MAC like 01:23:45:67:89:ab is NOT a valid IPv6).
+  return hasDouble ? groups.length >= 1 && groups.length <= 7 : groups.length === 8;
+}
+
+// ── US SSN ───────────────────────────────────────────────────────────────────
+export function isSsn(m: string): boolean {
+  const parts = m.split('-');
+  if (parts.length !== 3) return false;
+  const [area, group, serial] = parts as [string, string, string];
+  if (area === '000' || area === '666' || Number(area) >= 900) return false;
+  if (group === '00') return false;
+  if (serial === '0000') return false;
+  return true;
+}
+
+// ── US ITIN ──────────────────────────────────────────────────────────────────
+/** ITIN: 9-digit, starts with 9, group (4th-5th) in {50-65,70-88,90-92,94-99}.
+ *  No checksum — the regex encodes the ranges; reject an all-zero serial. */
+export function isItin(m: string): boolean {
+  const d = digitsOnly(m);
+  if (d.length !== 9 || d[0] !== '9') return false;
+  if (d.slice(5) === '0000') return false;
+  return true;
+}
+
+// ── US EIN ───────────────────────────────────────────────────────────────────
+const EIN_INVALID_PREFIXES = new Set([
+  '00', '07', '08', '09', '17', '18', '19', '28', '29', '49', '69', '70', '78',
+  '79', '89', '96', '97',
+]);
+/** EIN: `PP-NNNNNNN`; the two-digit IRS campus prefix must be a valid one. */
+export function isEin(m: string): boolean {
+  const d = digitsOnly(m);
+  if (d.length !== 9) return false;
+  if (EIN_INVALID_PREFIXES.has(d.slice(0, 2))) return false;
+  return notAllZeros(d.slice(2));
+}
+
+// ── Phone ────────────────────────────────────────────────────────────────────
+export function isPhone(m: string): boolean {
+  if (/^\d{4}[-/.]\d{1,2}[-/.]\d{1,2}$/.test(m)) return false; // ISO-ish date
+  if (/^\d{1,2}[-/.]\d{1,2}[-/.]\d{2,4}$/.test(m)) return false; // D/M/Y date
+  const d = digitsOnly(m);
+  return d.length >= 7 && d.length <= 15;
+}
+
+// ── Poland: PESEL ────────────────────────────────────────────────────────────
+const PESEL_WEIGHTS = [1, 3, 7, 9, 1, 3, 7, 9, 1, 3] as const;
+/** PESEL: 11 digits, weighted checksum (control = (10 − sum mod 10) mod 10) and a
+ *  sane embedded birth date (month carries the century offset). */
+export function isPesel(m: string): boolean {
+  const d = digitsOnly(m);
+  if (d.length !== 11) return false;
+  const sum = weightedSum(d, PESEL_WEIGHTS);
+  const control = (10 - (sum % 10)) % 10;
+  if (control !== d.charCodeAt(10) - 48) return false;
+  return peselDateValid(d);
+}
+
+function peselDateValid(d: string): boolean {
+  const yy = Number(d.slice(0, 2));
+  const mmRaw = Number(d.slice(2, 4));
+  const dd = Number(d.slice(4, 6));
+  // Month field encodes the century: +0 → 1900s, +20 → 2000s, +40 → 2100s,
+  // +60 → 2200s, +80 → 1800s.
+  const centuries: Record<number, number> = { 0: 1900, 20: 2000, 40: 2100, 60: 2200, 80: 1800 };
+  const offset = mmRaw - (((mmRaw - 1) % 20) + 1); // 0/20/40/60/80
+  const century = centuries[offset];
+  if (century == null) return false;
+  const month = mmRaw - offset;
+  if (month < 1 || month > 12) return false;
+  if (dd < 1 || dd > 31) return false;
+  const daysInMonth = new Date(century + yy, month, 0).getDate();
+  return dd <= daysInMonth;
+}
+
+// ── Poland: NIP (tax id) ─────────────────────────────────────────────────────
+const NIP_WEIGHTS = [6, 5, 7, 2, 3, 4, 5, 6, 7] as const;
+export function isNip(m: string): boolean {
+  const d = digitsOnly(m.replace(/^PL/i, ''));
+  if (d.length !== 10 || !notAllZeros(d)) return false;
+  const sum = weightedSum(d, NIP_WEIGHTS);
+  const control = sum % 11;
+  if (control === 10) return false; // never a valid NIP
+  return control === d.charCodeAt(9) - 48;
+}
+
+// ── Poland: REGON (statistical/business id) ──────────────────────────────────
+const REGON9_WEIGHTS = [8, 9, 2, 3, 4, 5, 6, 7] as const;
+const REGON14_WEIGHTS = [2, 4, 8, 5, 0, 9, 7, 3, 6, 1, 2, 4, 8] as const;
+export function isRegon(m: string): boolean {
+  const d = digitsOnly(m);
+  if (!notAllZeros(d)) return false;
+  if (d.length === 9) return regonCheck(d, REGON9_WEIGHTS, 8);
+  if (d.length === 14) return regonCheck(d, REGON14_WEIGHTS, 13);
+  return false;
+}
+function regonCheck(d: string, weights: readonly number[], checkIdx: number): boolean {
+  const control = (weightedSum(d, weights) % 11) % 10;
+  return control === d.charCodeAt(checkIdx) - 48;
+}
+
+// ── Poland: dowód osobisty (ID card) ─────────────────────────────────────────
+const DOWOD_WEIGHTS = [7, 3, 1, 9, 7, 3, 1, 7, 3] as const;
+/** ID card: 3 letters + 6 digits (c[3] is the check digit). Letters A=10…Z=35,
+ *  weighted by {@link DOWOD_WEIGHTS}; valid iff sum mod 10 === 0. */
+export function isDowodOsobisty(m: string): boolean {
+  const s = m.toUpperCase();
+  if (!/^[A-Z]{3}\d{6}$/.test(s)) return false;
+  let sum = 0;
+  for (let i = 0; i < 9; i++) {
+    const v = alnumValue(s[i]!);
+    if (Number.isNaN(v)) return false;
+    sum += v * DOWOD_WEIGHTS[i]!;
+  }
+  return sum % 10 === 0;
+}
+
+// ── Poland: passport ─────────────────────────────────────────────────────────
+const PL_PASSPORT_WEIGHTS = [7, 3, 9, 1, 7, 3, 1, 7, 3] as const;
+/** Passport: 2 letters + 7 digits (c[2] is the check digit). */
+export function isPlPassport(m: string): boolean {
+  const s = m.toUpperCase();
+  if (!/^[A-Z]{2}\d{7}$/.test(s)) return false;
+  let sum = 0;
+  for (let i = 0; i < 9; i++) {
+    const v = alnumValue(s[i]!);
+    if (Number.isNaN(v)) return false;
+    sum += v * PL_PASSPORT_WEIGHTS[i]!;
+  }
+  return sum % 10 === 0;
+}
+
+// ── UK: NHS number ───────────────────────────────────────────────────────────
+/** NHS number: 10 digits, Modulus-11 (weights 10..2 on the first 9; check digit
+ *  = 11 − (sum mod 11), 11→0, 10→invalid). */
+export function isNhsNumber(m: string): boolean {
+  const d = digitsOnly(m);
+  if (d.length !== 10) return false;
+  const weights = [10, 9, 8, 7, 6, 5, 4, 3, 2];
+  const sum = weightedSum(d, weights);
+  let check = 11 - (sum % 11);
+  if (check === 11) check = 0;
+  if (check === 10) return false;
+  return check === d.charCodeAt(9) - 48;
+}
+
+// ── UK: UTR (tax) ─────────────────────────────────────────────────────────────
+const UTR_WEIGHTS = [6, 7, 8, 9, 10, 5, 4, 3, 2] as const;
+const UTR_LOOKUP = [2, 1, 9, 8, 7, 6, 5, 4, 3, 2, 1] as const;
+/** UTR: 10 digits (optional trailing K). Modulus-11 with the check digit FIRST. */
+export function isUtr(m: string): boolean {
+  const d = digitsOnly(m);
+  if (d.length !== 10) return false;
+  const sum = weightedSum(d.slice(1), UTR_WEIGHTS);
+  const expected = UTR_LOOKUP[sum % 11]!;
+  return expected === d.charCodeAt(0) - 48;
+}
+
+// ── US: ABA routing number ───────────────────────────────────────────────────
+export function isAbaRouting(m: string): boolean {
+  const d = digitsOnly(m);
+  if (d.length !== 9 || !notAllZeros(d)) return false;
+  const w = [3, 7, 1, 3, 7, 1, 3, 7, 1];
+  return weightedSum(d, w) % 10 === 0;
+}
+
+// ── Global: VIN (vehicle) ────────────────────────────────────────────────────
+const VIN_TRANSLIT: Readonly<Record<string, number>> = {
+  A: 1, B: 2, C: 3, D: 4, E: 5, F: 6, G: 7, H: 8, J: 1, K: 2, L: 3, M: 4, N: 5,
+  P: 7, R: 9, S: 2, T: 3, U: 4, V: 5, W: 6, X: 7, Y: 8, Z: 9,
+};
+const VIN_WEIGHTS = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2] as const;
+/** ISO 3779 VIN check digit (position 9): transliterate, weight, mod 11 (X=10). */
+export function isVin(m: string): boolean {
+  const v = m.toUpperCase();
+  if (!/^[A-HJ-NPR-Z0-9]{17}$/.test(v)) return false;
+  let sum = 0;
+  for (let i = 0; i < 17; i++) {
+    const ch = v[i]!;
+    const val = /\d/.test(ch) ? ch.charCodeAt(0) - 48 : VIN_TRANSLIT[ch];
+    if (val == null) return false;
+    sum += val * VIN_WEIGHTS[i]!;
+  }
+  const remainder = sum % 11;
+  const expected = remainder === 10 ? 'X' : String(remainder);
+  return v[8] === expected;
+}

--- a/packages/desktop-host/src/apps/installer.ts
+++ b/packages/desktop-host/src/apps/installer.ts
@@ -69,7 +69,7 @@ const APP_ID = /^[a-z][a-z0-9-]*$/;
 const ALLOWED_ASSET_HOSTS = [/(^|\.)huggingface\.co$/, /(^|\.)hf\.co$/];
 
 /** Hard ceiling on any single downloaded asset. The largest real asset is the
- *  ~109 MB quantised NER model; 512 MB leaves generous headroom while still
+ *  ~278 MB quantised XLM-RoBERTa NER weight; 512 MB leaves headroom while still
  *  bounding a hostile/buggy server that streams an unbounded body (disk-fill
  *  DoS). Tunable per call via {@link installApp}'s `maxAssetBytes`. */
 export const MAX_ASSET_BYTES = 512 * 1024 * 1024;

--- a/packages/desktop-host/src/apps/registry.ts
+++ b/packages/desktop-host/src/apps/registry.ts
@@ -3,8 +3,10 @@
  *
  * Only apps that need a one-time local asset fetch appear here. Today that is
  * the document anonymizer, which downloads an on-device NER model (a quantised
- * `Xenova/bert-base-NER` ONNX bundle, ~109 MB) so it can detect names entirely
- * offline at use time. The onnxruntime-web wasm RUNTIME (~21 MB) is NOT fetched
+ * `tjruesch/xlm-roberta-base-ner-hrl-onnx` ONNX bundle, ~300 MB — multilingual,
+ * so it detects names in Polish and other languages, not just English) so it can
+ * detect names entirely offline at use time. The onnxruntime-web wasm RUNTIME
+ * (~21 MB) is NOT fetched
  * on demand — it ships as part of the app shell: Vite copies it from
  * `@huggingface/transformers` into the renderer build (`dist/ort/`, served from
  * `'self'`; see `apps/desktop/electron.vite.config.ts`), so only the large model
@@ -19,29 +21,37 @@
 
 import type { AppInstallSpec } from './installer.js';
 
-/** Hugging Face files that make up the quantised NER model bundle. */
+/**
+ * Hugging Face files that make up the quantised NER model bundle.
+ *
+ * XLM-RoBERTa is a SentencePiece tokenizer, so the bundle carries
+ * `sentencepiece.bpe.model` + `tokenizer.json` instead of WordPiece's `vocab.txt`.
+ * The weight file is `onnx/model_quantized.onnx`: on the WASM backend
+ * transformers.js defaults to the `q8` dtype (suffix `_quantized`), so the worker
+ * requests exactly this file — keep them in sync.
+ */
 const HF_MODEL_FILES = [
   'config.json',
   'tokenizer.json',
   'tokenizer_config.json',
   'special_tokens_map.json',
-  'vocab.txt',
+  'sentencepiece.bpe.model',
   'onnx/model_quantized.onnx',
 ] as const;
 
-const HF_RESOLVE_BASE = 'Xenova/bert-base-NER/resolve/main/';
+const HF_RESOLVE_BASE = 'tjruesch/xlm-roberta-base-ner-hrl-onnx/resolve/main/';
 const HF_URL_BASE = `https://huggingface.co/${HF_RESOLVE_BASE}`;
 
 const ANONYMIZER: AppInstallSpec = {
   id: 'anonymizer',
   // Bump this when the model bundle changes so existing installs re-download.
-  version: 'xenova-bert-base-ner-q8-v1',
+  version: 'xlmr-base-ner-hrl-q8-v1',
   assets: HF_MODEL_FILES.map((file) => ({
     url: HF_URL_BASE + file,
     // dest === the HF resolve path, so it lines up with the renderer's rewrite.
     dest: HF_RESOLVE_BASE + file,
     // No bytes/sha256: Content-Length drives the progress bar, and the HF
-    // resolve endpoint serves the canonical artifact (the onnx is ~109 MB).
+    // resolve endpoint serves the canonical artifact (the onnx is ~278 MB).
   })),
 };
 


### PR DESCRIPTION
## Why

The document anonymizer only caught a handful of English-shaped patterns, and its `nationalId` category had **no detector at all** — so Polish PESEL/NIP, UK NINO/NHS, US EIN/ITIN, bank accounts, passports, crypto wallets and leaked secrets all sailed through. The name model was English-only, so Polish (and other-language) names were missed. This makes it *really* anonymise across the Polish, UK and US markets.

The detector regexes + checksum algorithms were assembled from official sources and **adversarially verified** (a 52-agent research+verification pass over PL/UK/US/global formats, the legal scope, and the on-device model landscape).

## Engine — `@moxxy/anonymizer` (still pure, offline, **zero-dependency**)

- A `DICTIONARY` of **47 checksum-backed detectors**, grouped by market:
  - **🇵🇱 Poland** — PESEL (weighted mod-10 + embedded birth-date), NIP, REGON, dowód osobisty, passport, NRB bank account (mod-97), driving licence, vehicle reg.
  - **🇬🇧 UK** — National Insurance Number, NHS number (mod-11), UTR, postcode (BS7666), passport, driving licence, sort code.
  - **🇺🇸 US** — SSN, ITIN, EIN, Medicare MBI, ABA routing, bank account, passport, ZIP.
  - **🌐 Global** — credit card, IBAN (+ per-country length), IMEI, VIN, BTC/ETH wallets, and leaked secrets (AWS / GitHub / Stripe / Google / Slack / OpenAI keys, JWTs, PEM private keys).
- New `PiiCategory` buckets (`taxId`, `healthId`, `passport`, `driverLicense`, `postalCode`, `bankAccount`, `crypto`, `deviceId`, `vehicleId`, `secret`) and a **`Region`** axis. `detect()`/`redact()` gain `regions` and `detectorIds`; spans carry a `subtype` so output is specific (`[PESEL]`, `[NHS]`).
- **Precision contract**: the checksum/validator is the primary lever; bare-numeric / no-checksum identifiers are context-keyword-gated (a nearby `NIP`/`NHS`/`routing`); weighted-mod validators reject the degenerate all-zeros run (a recurring bug the research surfaced).
- Crypto/secret validation is **structural** (prefix + charset + length) to preserve the zero-dependency offline guarantee — no Base58Check/Keccak/CRC32 deps.

## Desktop app

- A **Markets** selector (PL/UK/US; global always on) so a market's ID formats are scoped without false positives from the others.
- On-device NER swapped from English-only `Xenova/bert-base-NER` to multilingual **`tjruesch/xlm-roberta-base-ner-hrl-onnx`** (verified ONNX, MIT) so names are detected in Polish & other languages (install ~110 MB → ~300 MB). The span aggregator was made robust to **SentencePiece** sub-words so agglutinated names (e.g. Polish surnames) are recovered, not leaked. Degrades gracefully — a model failure yields `[]` and structured redaction keeps working.
- Redaction-mode hints now state honestly that only `label` approaches true **anonymisation**; `pseudonym`/`hash` are **pseudonymisation** (still personal data under GDPR — Recital 26).

## Legal scope

Coverage is mapped to GDPR (EU/Poland RODO-UODO, incl. PESEL), UK GDPR + DPA 2018 (NHS number), and US sectoral law (HIPAA Safe Harbor, GLBA, SSA, CCPA/CPRA). See the package README; it's a detection aid, not a compliance guarantee.

## Tests & verification

- New `validators.test.ts` (21) pins every checksum with synthetic-but-valid vectors; `dictionary.test.ts` (25) covers wiring, region filtering, context-gating, the IMEI↔card priority, and per-market detectors; a new aggregate test pins SentencePiece sub-word recovery.
- Full gate green: build (70), typecheck (137), lint (0 errors), tests, `check:deps` (0 errors).
- Follow-ups logged in `TECH_DEBT.md` (Polish NER recall needs a real-doc eval; structural-only crypto/secret checksums; a HIPAA Safe-Harbor profile; per-detector context windows).