### PR TITLE
fix(desktop): send pasted / dropped / browser-capture images to the model

### DIFF
--- a/.changeset/fix-browser-screenshot-attachment.md
+++ b/.changeset/fix-browser-screenshot-attachment.md
@@ -1,0 +1,20 @@
+---
+"@moxxy/desktop": patch
+---
+
+fix(desktop): send pasted / dropped / browser-capture images to the model
+
+Images that arrive as bytes — a clipboard paste, a drag-drop, or a
+browser-surface screenshot — are stashed to a temp file under `os.tmpdir()` and
+then ride the same attachment pipeline as a picked file. But `session.runTurn`'s
+provenance gate (`authorizeAttachments`) only trusts paths the native picker
+handed out or paths inside the workspace cwd, and `session.saveImageAttachment`
+— unlike `session.pickAttachment` — never remembered the temp path it wrote. So
+every byte-sourced image was silently dropped at send time (only a `console.warn`
+in the main process) and the prompt reached the model as text only. This was a
+regression: the provenance gate, added in the PR right after the chat
+image-paste feature, never vouched for the paste/capture path.
+
+`session.saveImageAttachment` now remembers the temp path it creates, mirroring
+`session.pickAttachment`, so pasted / dropped / captured images survive the gate
+and actually reach the model.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -44,6 +44,24 @@ English-only name detection. New debt/follow-ups accrued by that work:
   line or two away (e.g. `Numer Identyfikacji Podatkowej` far above the digits). Consider a
   per-detector window or line-aware context. `packages/anonymizer/src/dictionary.ts`.
 
+**Accrued 2026-06-19 (browser / clipboard image attachments).** Fixed THE
+"screenshot attached but never sent" bug: byte-sourced images (clipboard paste,
+drag-drop, browser-surface capture) are persisted to `os.tmpdir()` by
+`session.saveImageAttachment`, but the `session.runTurn` provenance gate
+(`authorizeAttachments`) only trusts picker paths or paths under the workspace
+cwd — and the save handler, unlike `session.pickAttachment`, never remembered the
+temp path it wrote. Every such image was silently dropped at send. The save
+handler now remembers its temp path (`packages/desktop-host/src/ipc/session.ts`),
+covered by `session.test.ts`. New debt logged on sight:
+- **Dropped attachments are invisible to the user.** When `authorizeAttachments`
+  rejects a path, or `buildAttachments` skips a file (oversized / unreadable /
+  binary), the only signal is a `console.warn` in the main process — the chip
+  stays in the composer and the prompt sends without it, so the user believes it
+  went. The renderer already surfaces a transient `attachError` for paste-time
+  failures; the dropped-at-send path should round-trip a similar notice (e.g.
+  `session.runTurn` returning the dropped names so the composer can flag them).
+  `packages/desktop-host/src/ipc/session.ts`, `attachments.ts`.
+
 **Last refreshed:** 2026-06-09 (second pass) — **journal repair + audit intake.** PRs #113
 and #115 rebuilt this file from a branch cut before #107/#108 merged, silently resurrecting
 two entries those PRs had retired (P1 #2's growth defect, P2 #6 mode-loop scaffolding) and

--- a/packages/desktop-host/src/ipc/session.test.ts
+++ b/packages/desktop-host/src/ipc/session.test.ts
@@ -1,0 +1,124 @@
+/**
+ * session.* handler tests — focused on the attachment provenance gate.
+ *
+ * Regression guard for the chat-image / browser-screenshot drop bug: a pasted,
+ * dropped, or browser-captured image is persisted to a temp file by
+ * `session.saveImageAttachment` (it lives under os.tmpdir(), NOT the workspace
+ * cwd, and the native picker never handed it out). `session.runTurn` then gates
+ * every attachment through `authorizeAttachments`, so unless saveImageAttachment
+ * REMEMBERS the temp path it just wrote, the image is silently dropped and the
+ * prompt reaches the model as text only — exactly the bug the user hit with a
+ * browser screenshot. These tests pin both halves: the saved path survives the
+ * gate, and an un-vouched path outside the cwd does not.
+ */
+
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+// session.ts pulls in electron (dialog / BrowserWindow — only pickAttachment
+// uses them) and, via shared.ts, the in-process plugin bag (STT + vault).
+// Neither is exercised here, so stub both so the test needs no GUI / keychain.
+vi.mock('electron', () => ({
+  dialog: { showOpenDialog: async () => ({ canceled: true, filePaths: [] }) },
+  BrowserWindow: { getFocusedWindow: () => null, getAllWindows: () => [] },
+}));
+vi.mock('../in-process-plugins', () => ({ buildInProcessPlugins: () => ({}) }));
+
+import type { CommandBus } from '@moxxy/desktop-ipc-contract/bus';
+import type { IpcCommandName } from '@moxxy/desktop-ipc-contract';
+import type { RunnerPool } from '../runner-pool';
+import type { SessionDriver } from '../session-driver';
+import { __resetPickedAttachments } from '../attachment-authz';
+import { publishDriver, setActiveBus, unpublishDriver } from './shared';
+import { registerSessionHandlers } from './session';
+
+type Handler = (...args: unknown[]) => Promise<unknown>;
+
+const WS = 'ws1';
+const CWD = path.join(os.tmpdir(), 'session-ipc-cwd');
+
+// 1x1 transparent PNG — the smallest blob persistImageBlob accepts.
+const PNG_1x1 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+function fakeBus(): { bus: CommandBus; handlers: Map<string, Handler> } {
+  const handlers = new Map<string, Handler>();
+  const bus = {
+    handle: (channel: IpcCommandName, fn: Handler) => handlers.set(channel, fn),
+  } as unknown as CommandBus;
+  return { bus, handlers };
+}
+
+let handlers: Map<string, Handler>;
+let driverRunTurn: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetPickedAttachments();
+  const { bus, handlers: h } = fakeBus();
+  handlers = h;
+  // A pool whose single workspace reports a cwd (a root for authz to test
+  // against) but no live RemoteSession — runTurn dispatches through the driver,
+  // so requireSession:false means a null session is fine.
+  const pool = {
+    activeWorkspaceId: () => WS,
+    get: (id: string) => (id === WS ? { getCwd: () => CWD, remote: () => null } : undefined),
+  } as unknown as RunnerPool;
+  driverRunTurn = vi.fn(async () => ({ turnId: 't1' }));
+  publishDriver(WS, { runTurn: driverRunTurn } as unknown as SessionDriver);
+  setActiveBus(bus);
+  registerSessionHandlers(pool);
+});
+
+afterEach(() => {
+  unpublishDriver(WS);
+});
+
+const invoke = (channel: string, args?: unknown): Promise<unknown> => handlers.get(channel)!(args);
+
+/** The attachments `session.runTurn` forwarded to the driver after the gate. */
+const forwardedAttachments = (): ReadonlyArray<unknown> =>
+  driverRunTurn.mock.calls[0]![2] as ReadonlyArray<unknown>;
+
+describe('session.* attachment provenance', () => {
+  it('saveImageAttachment remembers its temp path so a later runTurn keeps the image', async () => {
+    const saved = (await invoke('session.saveImageAttachment', {
+      dataBase64: PNG_1x1,
+      mediaType: 'image/png',
+      name: 'browser-capture.png',
+    })) as { path: string; name: string };
+    // Sanity: it really did land outside the workspace cwd — the whole reason
+    // the provenance gate would otherwise drop it.
+    expect(saved.path.startsWith(CWD)).toBe(false);
+
+    try {
+      await invoke('session.runTurn', {
+        workspaceId: WS,
+        prompt: 'what is in this screenshot?',
+        attachments: [saved],
+      });
+      expect(driverRunTurn).toHaveBeenCalledTimes(1);
+      expect(forwardedAttachments()).toEqual([saved]); // authorized, NOT dropped
+    } finally {
+      await rm(saved.path, { force: true });
+    }
+  });
+
+  it('drops an attachment that was neither picked nor under the workspace cwd', async () => {
+    const stray = path.join(os.tmpdir(), `session-ipc-stray-${process.pid}.png`);
+    await writeFile(stray, Buffer.from(PNG_1x1, 'base64'));
+    try {
+      await invoke('session.runTurn', {
+        workspaceId: WS,
+        prompt: 'read this',
+        attachments: [{ path: stray, name: 'stray.png' }],
+      });
+      expect(driverRunTurn).toHaveBeenCalledTimes(1);
+      expect(forwardedAttachments()).toEqual([]); // unauthorized → dropped
+    } finally {
+      await rm(stray, { force: true });
+    }
+  });
+});

--- a/packages/desktop-host/src/ipc/session.ts
+++ b/packages/desktop-host/src/ipc/session.ts
@@ -273,10 +273,18 @@ export function registerSessionHandlers(pool: RunnerPool): void {
     await rememberPickedAttachment(picked);
     return picked;
   });
-  handle('session.saveImageAttachment', async ({ dataBase64, mediaType, name }) =>
-    // The renderer can't write files, so a pasted/dropped image's bytes
-    // are stashed to a temp file here; the returned path then rides the
+  handle('session.saveImageAttachment', async ({ dataBase64, mediaType, name }) => {
+    // The renderer can't write files, so a pasted/dropped/captured image's
+    // bytes are stashed to a temp file here; the returned path then rides the
     // same attachment pipeline as a picked file.
-    persistImageBlob(dataBase64, mediaType, name),
-  );
+    const saved = await persistImageBlob(dataBase64, mediaType, name);
+    // Remember the temp path so the later runTurn that references it clears the
+    // provenance gate. The file lives under os.tmpdir() — not the workspace cwd
+    // — and was never handed out by the picker, so without this
+    // authorizeAttachments drops it and the prompt is sent with NO image
+    // (clipboard paste, drag-drop, AND browser-capture screenshots all land
+    // here). Mirrors session.pickAttachment, which remembers its picked path.
+    await rememberPickedAttachment(saved.path);
+    return saved;
+  });
 }


### PR DESCRIPTION
## The bug

A browser-surface screenshot appeared **attached** in the chat composer, but when the message was sent only the text reached the agent — the image was silently dropped.

## Root cause

Images that arrive as **bytes** (clipboard paste, drag-drop, *and* browser-surface capture) are stashed to a temp file under `os.tmpdir()/moxxy-attachments/` by `session.saveImageAttachment`, then ride the same attachment pipeline as a picked file. But on send, `session.runTurn` runs every attachment through the provenance gate `authorizeAttachments`, which authorizes a path **only if** it is:

- a path the native file picker handed out, or
- inside the workspace cwd.

The temp path is **neither** — and `session.saveImageAttachment`, unlike `session.pickAttachment`, **never registered it**. So the gate dropped it (only a `console.warn` in the main process) and the prompt went to the model as text alone.

This is a **regression**: the provenance gate (#43) landed in the PR right after the chat image-paste feature (#42) and never vouched for the paste/capture path. It affected **all** byte-sourced images, not just browser screenshots — clipboard paste and drag-drop were dropping too. Only the file-picker path survived (it remembers its path).

## The fix

`session.saveImageAttachment` now remembers the temp path it just wrote, mirroring `session.pickAttachment`. The main process created that file from user-supplied bytes, so it's definitionally authorized — the one-line gap that broke all three input modes.

## Tests / verification

- **New** `packages/desktop-host/src/ipc/session.test.ts` drives the real `saveImageAttachment` → `runTurn` handlers through the actual gate: a saved image survives, an un-vouched path outside cwd is dropped. Fails without the fix.
- `@moxxy/desktop-host` suite: **427/427** · typecheck **137/137** · lint clean · build **70/70** · `check:deps` 0 errors.
- `@moxxy/desktop` patch changeset included. TECH_DEBT.md logs the residual gap (dropped attachments still give the user no UI feedback — only a `console.warn`).