### PR TITLE
fix(desktop): app fails to start after mobile proxy integration (#210 regression)

### DIFF
--- a/.changeset/desktop-mobile-proxy-startup.md
+++ b/.changeset/desktop-mobile-proxy-startup.md
@@ -1,0 +1,20 @@
+---
+'@moxxy/desktop': patch
+---
+
+fix(desktop): app failed to start after the mobile proxy integration
+
+The Start-mobile proxy wiring added a static top-level import of
+`@moxxy/plugin-channel-mobile/e2e-proxy` to the Electron main. Because that
+package is bundled into the main entry (it's in `BUNDLED_WORKSPACE_DEPS`), the
+import pulled the E2E stack — and transitively `ulid` — into the main entry's
+static module graph, reordering ESM init so `ulid`'s eager initialization ran
+before electron-vite's injected `require` shim. `ulid` then threw "secure crypto
+unusable, insecure Math.random not allowed" at boot, so the desktop app never
+started.
+
+Fix: load the proxy opener via a lazy `import()` (injected into
+`MobileGatewayManager`) so the E2E stack stays out of the startup path and is
+loaded only when the user enables the mobile gateway — in a `ulid`-free lazy
+chunk, post `app.whenReady`. App startup is restored; the proxy "Start mobile"
+behavior is unchanged.

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -58,7 +58,10 @@ import type { DeepLinkPayload, MobileGatewayStatus } from '@moxxy/desktop-ipc-co
 import type { WebSocketCommandBus, WebSocketBridgeServer } from '@moxxy/ipc-server-ws';
 
 import { resolveWsBridgeConfig, MobileGatewayManager } from './ws-bridge.js';
-import { openMobileProxyTunnel } from '@moxxy/plugin-channel-mobile/e2e-proxy';
+import type {
+  E2EProxyHandle,
+  OpenMobileProxyOptions,
+} from '@moxxy/plugin-channel-mobile/e2e-proxy';
 
 import { LOOPBACK_PORTS, LOOPBACK_PORTS_ALT } from '../loopback-ports.js';
 
@@ -694,8 +697,16 @@ app.whenReady().then(async () => {
         if (mainWindow) sendEvent(mainWindow, 'mobileGateway.changed', status);
       },
       // Expose the bridge off-LAN through the E2E proxy relay (best-effort; the
-      // manager falls back to a LAN URL if the relay is unreachable).
-      openProxyTunnel: openMobileProxyTunnel,
+      // manager falls back to a LAN URL if the relay is unreachable). Loaded
+      // LAZILY: the E2E stack (`@noble/*`, the tunnel client, and transitively
+      // `ulid`, whose eager init needs the runtime's `require` shim) must NOT be
+      // pulled into the main entry's static import graph — doing so reorders
+      // module init so `ulid` evaluates before that shim and throws "secure
+      // crypto unusable" at boot (the app fails to start). Deferring to a
+      // dynamic import keeps it out of the startup path; it loads only when the
+      // user enables mobile (post app-ready), in a ulid-free lazy chunk.
+      openProxyTunnel: (opts: OpenMobileProxyOptions): Promise<E2EProxyHandle> =>
+        import('@moxxy/plugin-channel-mobile/e2e-proxy').then((m) => m.openMobileProxyTunnel(opts)),
     });
   }
 


### PR DESCRIPTION
## Problem

PR #210 (merged to main as `b19d401d`) wired the desktop **Start mobile** toggle through the E2E proxy relay, but added a **static top-level import** of `@moxxy/plugin-channel-mobile/e2e-proxy` to the Electron main (`apps/desktop/electron/main/index.ts`).

That package is bundled *into* the main entry (it's in `BUNDLED_WORKSPACE_DEPS`), so the static import pulled the whole E2E stack — and transitively **`ulid`** — into the main entry's static ESM module graph. This reordered module initialization so `ulid`'s eager init (`const ulid = factory()`) ran **before** electron-vite's injected `require` shim. `ulid` then threw:

```
Error: secure crypto unusable, insecure Math.random not allowed  (source: 'ulid')
```

…at boot, so **the desktop app never started.**

## Fix

Load the proxy opener via a **lazy `import()`** (injected into `MobileGatewayManager`) so the E2E stack stays out of the startup path and loads only when the user enables the mobile gateway — in a `ulid`-free lazy chunk, after `app.whenReady`. The "Start mobile" proxy behavior is unchanged.

## Verification

- Reproduced the crash from the packaged main (`electron dist-electron/main/bootstrap.js`) → `secure crypto unusable`.
- After the fix, the packaged main boots cleanly (`[moxxy] renderer served at …`).
- Confirmed `startE2EShim`/`xchacha`/`ulid` are **gone from `dist-electron/main/index.js`** and live in a separate lazy chunk that contains **no `ulid`**.
- Desktop gate green: typecheck, 370 tests, electron-vite build.

Changeset bumps `@moxxy/desktop` (patch) so the release pipeline cuts a fixed `desktop-v*` build + self-update bundle.