### PR TITLE
fix(mobile): pair over E2E proxy using text frames (iOS RN binary drop)

### DIFF
--- a/.changeset/mobile-e2e-text-frames.md
+++ b/.changeset/mobile-e2e-text-frames.md
@@ -1,0 +1,13 @@
+---
+'@moxxy/client-transport-ws': patch
+'@moxxy/plugin-channel-mobile': patch
+---
+
+Fix mobile (iOS) E2E pairing over the proxy relay. The encrypted channel framed
+each ciphertext message as a **binary** WebSocket frame, but React Native's iOS
+WebSocket silently drops binary frames — the phone's `ClientHello` never reached
+the agent shim, so pairing failed with "transport closed during handshake"
+(the relay, proxy, shim and handshake were all correct; a Node `ws` client
+paired fine through the same production relay). The phone client and the agent
+shim now exchange base64url **text** frames (delivered reliably across
+RN/iOS/Android/browser) and still accept binary from a binary-capable peer.

--- a/packages/client-transport-ws/src/e2e-socket.test.ts
+++ b/packages/client-transport-ws/src/e2e-socket.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+  base64urlDecode,
+  base64urlEncode,
+  connectResponder,
+  fingerprint,
+  generateIdentity,
+  utf8,
+  utf8Decode,
+  type MessageTransport,
+  type SecureChannel,
+} from '@moxxy/e2e';
+import { makeE2EWebSocketCtor } from './e2e-socket.js';
+import type { WebSocketCtor, WebSocketLike } from './json-rpc-client.js';
+
+/**
+ * A base WebSocket modelling iOS React Native: it can ONLY send text frames —
+ * a binary `send` throws (RN silently drops binary frames on iOS). Inbound
+ * frames are delivered as strings. It is pre-wired to a peer responder via an
+ * in-memory link carrying the on-the-wire strings, so the real e2e adapter runs
+ * the genuine `@moxxy/e2e` handshake against a real responder.
+ */
+class TextOnlyBaseWs {
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  readyState = 1;
+  binaryType = 'blob';
+  /** Number of non-string (binary) sends attempted — must stay 0 with the fix. */
+  binarySends = 0;
+  /** Wire strings to hand to the peer responder. */
+  toPeer: (wireText: string) => void = () => undefined;
+
+  constructor() {
+    queueMicrotask(() => this.onopen?.());
+  }
+  deliver(wireText: string): void {
+    queueMicrotask(() => this.onmessage?.({ data: wireText }));
+  }
+  send(data: unknown): void {
+    if (typeof data !== 'string') {
+      this.binarySends += 1;
+      throw new Error('RN WebSocket: binary send unsupported');
+    }
+    this.toPeer(data);
+  }
+  close(): void {
+    queueMicrotask(() => this.onclose?.());
+  }
+}
+
+/** Link a text-only base socket to a responder MessageTransport (both base64url). */
+function wireTextLink(): { base: TextOnlyBaseWs; peer: MessageTransport } {
+  const base = new TextOnlyBaseWs();
+  let peerOnMsg: ((b: Uint8Array) => void) | null = null;
+  base.toPeer = (wireText) => {
+    const bytes = base64urlDecode(wireText);
+    queueMicrotask(() => peerOnMsg?.(bytes));
+  };
+  const peer: MessageTransport = {
+    send: (bytes) => base.deliver(base64urlEncode(bytes)), // arrives as a string, like RN
+    onMessage: (h) => {
+      peerOnMsg = h;
+    },
+    onClose: () => undefined,
+    close: () => base.close(),
+  };
+  return { base, peer };
+}
+
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+describe('makeE2EWebSocketCtor wire framing', () => {
+  it('handshakes over a TEXT-only WebSocket (iOS RN) and never sends a binary frame', async () => {
+    const identity = generateIdentity();
+    const fp = fingerprint(identity.publicKey);
+    const { base, peer } = wireTextLink();
+
+    const responderReady: Promise<SecureChannel> = connectResponder(peer, identity);
+    // A constructable stand-in: `new baseCtor(url)` returns our pre-wired socket
+    // (arrow functions aren't constructable, so use a function expression).
+    const baseCtor = function () {
+      return base;
+    } as unknown as WebSocketCtor;
+    const Ctor = makeE2EWebSocketCtor(baseCtor, fp, 'bearer-tok');
+
+    const phone = new Ctor('ws://relay.example/mobile') as WebSocketLike;
+    const opened = new Promise<void>((resolve) => {
+      phone.onopen = resolve;
+    });
+
+    const responder = await responderReady;
+    await opened; // handshake completed over text frames only
+
+    // The agent shim sees the bearer as the FIRST encrypted frame, then JSON.
+    const agentGot: string[] = [];
+    responder.onMessage((pt) => agentGot.push(utf8Decode(pt)));
+    phone.send('{"id":1,"method":"ping"}');
+    await tick();
+
+    expect(agentGot[0]).toBe('bearer-tok');
+    expect(agentGot).toContain('{"id":1,"method":"ping"}');
+    expect(base.binarySends).toBe(0); // regression guard: text frames only
+
+    // And the reverse direction decodes a text frame back to plaintext.
+    const phoneGot: string[] = [];
+    phone.onmessage = (ev) => phoneGot.push(String((ev as { data: unknown }).data));
+    responder.send(utf8('{"echo":true}'));
+    await tick();
+    expect(phoneGot).toContain('{"echo":true}');
+  });
+});

--- a/packages/client-transport-ws/src/e2e-socket.ts
+++ b/packages/client-transport-ws/src/e2e-socket.ts
@@ -12,6 +12,8 @@
  * Pure JS over `@moxxy/e2e` (no Node deps) so it bundles under Metro/RN.
  */
 import {
+  base64urlDecode,
+  base64urlEncode,
   connectInitiator,
   publicKeyFromFingerprint,
   utf8,
@@ -38,13 +40,24 @@ interface BinaryWs {
 }
 
 function toBytes(data: unknown): Uint8Array {
+  // The wire frames are base64url TEXT (see the send path): React Native's
+  // WebSocket reliably delivers/sends text but silently drops binary frames on
+  // iOS, so the encrypted channel rides as text. A text frame arrives as a
+  // string here; decode it. Binary frames are still accepted (a binary-capable
+  // peer — e.g. a Node `ws` client — interoperates unchanged).
+  if (typeof data === 'string') {
+    try {
+      return base64urlDecode(data);
+    } catch {
+      return new Uint8Array(0); // undecodable → the frame opener rejects it
+    }
+  }
   if (data instanceof Uint8Array) return data;
   if (data instanceof ArrayBuffer) return new Uint8Array(data);
   if (ArrayBuffer.isView(data)) {
     const view = data as ArrayBufferView;
     return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
   }
-  if (typeof data === 'string') return utf8(data);
   return new Uint8Array(0);
 }
 
@@ -83,7 +96,12 @@ export function makeE2EWebSocketCtor(
       }
 
       const transport: MessageTransport = {
-        send: (bytes) => this.base.send(bytes),
+        // Send each ciphertext frame as a base64url TEXT frame. iOS React
+        // Native's WebSocket silently fails to deliver binary frames, so a
+        // binary ClientHello never reaches the agent shim (the handshake hangs
+        // and the shim reports "transport closed during handshake"). Text frames
+        // are delivered reliably across RN/iOS/Android/browser.
+        send: (bytes) => this.base.send(base64urlEncode(bytes)),
         onMessage: (handler) => {
           this.msgHandler = handler;
           while (this.backlog.length > 0) handler(this.backlog.shift() as Uint8Array);

--- a/packages/plugin-channel-mobile/src/e2e-shim.test.ts
+++ b/packages/plugin-channel-mobile/src/e2e-shim.test.ts
@@ -1,0 +1,149 @@
+import { once } from 'node:events';
+import { createServer, type AddressInfo } from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  base64urlDecode,
+  base64urlEncode,
+  connectInitiator,
+  fingerprint,
+  generateIdentity,
+  publicKeyFromFingerprint,
+  utf8,
+  utf8Decode,
+  type MessageTransport,
+  type SecureChannel,
+} from '@moxxy/e2e';
+import { WebSocket, WebSocketServer, type RawData } from 'ws';
+import { startE2EShim, type E2EShimHandle } from './e2e-shim.js';
+
+/**
+ * The agent shim terminates the phone's encrypted channel before forwarding to
+ * the loopback bridge. The wire frames ride as base64url TEXT because iOS React
+ * Native's WebSocket silently drops binary frames — a binary ClientHello never
+ * reaches the shim and the handshake hangs ("transport closed during
+ * handshake"). These tests drive the shim from the phone side over a real `ws`
+ * connection to prove the text path works (and that a binary peer still
+ * interoperates).
+ */
+const TOKEN = 'shim-test-token';
+
+/** A dummy mobile bridge: checks the bearer header and echoes each text frame. */
+async function startBridge(): Promise<{
+  port: number;
+  lastAuth: () => string | undefined;
+  close: () => Promise<void>;
+}> {
+  const http = createServer();
+  const wss = new WebSocketServer({ server: http });
+  let lastAuth: string | undefined;
+  wss.on('connection', (ws, req) => {
+    lastAuth = req.headers['authorization'];
+    ws.on('message', (d: RawData) => ws.send(`echo:${d.toString()}`));
+  });
+  await new Promise<void>((r) => http.listen(0, '127.0.0.1', r));
+  return {
+    port: (http.address() as AddressInfo).port,
+    lastAuth: () => lastAuth,
+    close: () =>
+      new Promise<void>((r) => {
+        for (const c of wss.clients) c.terminate();
+        http.close(() => r());
+      }),
+  };
+}
+
+/**
+ * Drive the shim from the phone side over a real `ws` connection. `mode` selects
+ * the outbound framing: `text` mirrors iOS RN (base64url text), `binary` proves
+ * the shim still accepts a binary-capable peer (e.g. a Node `ws` client). The
+ * shim always replies with TEXT, so inbound decoding handles both.
+ */
+function phoneTransport(ws: WebSocket, mode: 'text' | 'binary'): MessageTransport {
+  let onMsg: ((b: Uint8Array) => void) | null = null;
+  let onClose: (() => void) | null = null;
+  const backlog: Uint8Array[] = [];
+  ws.on('message', (data: RawData, isBinary: boolean) => {
+    const buf = data as Buffer;
+    const bytes = isBinary ? new Uint8Array(buf) : base64urlDecode(buf.toString('utf8'));
+    if (onMsg) onMsg(bytes);
+    else backlog.push(bytes);
+  });
+  ws.on('close', () => onClose?.());
+  ws.on('error', () => onClose?.());
+  return {
+    send: (bytes) => {
+      if (ws.readyState !== ws.OPEN) return;
+      if (mode === 'text') ws.send(base64urlEncode(bytes));
+      else ws.send(Buffer.from(bytes), { binary: true });
+    },
+    onMessage: (h) => {
+      onMsg = h;
+      while (backlog.length > 0) h(backlog.shift() as Uint8Array);
+    },
+    onClose: (h) => {
+      onClose = h;
+    },
+    close: () => ws.close(),
+  };
+}
+
+async function dialPhone(
+  shim: E2EShimHandle,
+  fp: string,
+  mode: 'text' | 'binary',
+): Promise<SecureChannel> {
+  const ws = new WebSocket(`ws://127.0.0.1:${shim.port}`);
+  await once(ws, 'open');
+  return connectInitiator(phoneTransport(ws, mode), publicKeyFromFingerprint(fp));
+}
+
+describe('E2E shim wire framing', () => {
+  const cleanups: Array<() => Promise<void>> = [];
+  afterEach(async () => {
+    for (const c of cleanups.splice(0)) await c().catch(() => undefined);
+  });
+
+  async function setup(): Promise<{
+    bridge: Awaited<ReturnType<typeof startBridge>>;
+    shim: E2EShimHandle;
+    fp: string;
+  }> {
+    const bridge = await startBridge();
+    const identity = generateIdentity();
+    const shim = await startE2EShim({
+      identity,
+      token: TOKEN,
+      bridgePort: bridge.port,
+      bridgeHost: '127.0.0.1',
+    });
+    cleanups.push(() => shim.close(), bridge.close);
+    return { bridge, shim, fp: fingerprint(identity.publicKey) };
+  }
+
+  it('handshakes and round-trips when the phone can only send TEXT frames (iOS RN)', async () => {
+    const { bridge, shim, fp } = await setup();
+    const channel = await dialPhone(shim, fp, 'text');
+    const echoed = new Promise<string>((resolve) => channel.onMessage((pt) => resolve(utf8Decode(pt))));
+    channel.send(utf8(TOKEN)); // first ENCRYPTED frame is the bearer
+    channel.send(utf8('{"id":1,"method":"ping"}'));
+    expect(await echoed).toBe('echo:{"id":1,"method":"ping"}');
+    expect(bridge.lastAuth()).toBe(`Bearer ${TOKEN}`); // bearer reached the bridge, never the wire
+  });
+
+  it('also accepts a binary-sending peer (a Node ws client interoperates)', async () => {
+    const { shim, fp } = await setup();
+    const channel = await dialPhone(shim, fp, 'binary');
+    const echoed = new Promise<string>((resolve) => channel.onMessage((pt) => resolve(utf8Decode(pt))));
+    channel.send(utf8(TOKEN));
+    channel.send(utf8('{"ok":true}'));
+    expect(await echoed).toBe('echo:{"ok":true}');
+  });
+
+  it('closes the channel on a bad bearer without crashing', async () => {
+    const { shim, fp } = await setup();
+    const channel = await dialPhone(shim, fp, 'text');
+    const closed = new Promise<void>((resolve) => channel.onClose(() => resolve()));
+    channel.send(utf8('wrong-token'));
+    await closed; // the shim tears the channel down after a bad bearer
+  });
+});

--- a/packages/plugin-channel-mobile/src/e2e-shim.ts
+++ b/packages/plugin-channel-mobile/src/e2e-shim.ts
@@ -17,6 +17,8 @@ import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { bearerTokenMatches } from '@moxxy/sdk/server';
 import {
+  base64urlDecode,
+  base64urlEncode,
   connectResponder,
   type Identity,
   type MessageTransport,
@@ -58,8 +60,16 @@ function wsTransport(ws: WebSocket): MessageTransport {
   let onMsg: ((b: Uint8Array) => void) | null = null;
   let onClose: (() => void) | null = null;
   const backlog: Uint8Array[] = [];
-  ws.on('message', (data) => {
-    const bytes = rawToBytes(data);
+  ws.on('message', (data, isBinary) => {
+    // Frames ride as base64url TEXT so iOS React Native can deliver them (its
+    // WebSocket silently drops binary frames). A binary-capable peer that still
+    // sends binary (a Node `ws` client) is accepted unchanged.
+    let bytes: Uint8Array;
+    try {
+      bytes = isBinary ? rawToBytes(data) : base64urlDecode(rawTextOf(data));
+    } catch {
+      return; // undecodable frame — drop it (the handshake/opener handles silence)
+    }
     if (onMsg) onMsg(bytes);
     else backlog.push(bytes);
   });
@@ -67,7 +77,8 @@ function wsTransport(ws: WebSocket): MessageTransport {
   ws.on('error', () => onClose?.());
   return {
     send: (bytes) => {
-      if (ws.readyState === ws.OPEN) ws.send(bytes, { binary: true });
+      // Text frame (base64url) — see the inbound note above.
+      if (ws.readyState === ws.OPEN) ws.send(base64urlEncode(bytes));
     },
     onMessage: (handler) => {
       onMsg = handler;


### PR DESCRIPTION
## Problem

Pairing a real iPhone to the mobile gateway over the self-hosted proxy relay fails. The gateway logs, on every attempt:

```
[moxxy] e2e shim: connection failed { err: 'Error: proxy-e2e: transport closed during handshake' }
```

The phone shows "Could not connect to this gateway."

## Root cause

The agent **shim** completes the WebSocket upgrade with the phone but never receives the phone's encrypted `ClientHello`, so the handshake times out and the socket closes.

I reproduced the full path in Node — phone e2e adapter → **real production relay** (`*.proxy.moxxy.ai`) → proxy client → shim → bridge — and it **pairs and round-trips an encrypted frame flawlessly**. So the relay, proxy client, shim, and `@moxxy/e2e` handshake are all correct.

The only difference vs. production is the client: **iOS React Native's WebSocket silently drops binary frames**. The e2e channel framed every ciphertext message (including the `ClientHello`) as a *binary* WS frame, so on a real device the first frame never went out — exactly matching the "never receives the ClientHello" symptom.

## Fix

The phone transport (`@moxxy/client-transport-ws`) and the agent shim (`@moxxy/plugin-channel-mobile`) now exchange ciphertext as **base64url text frames**, which RN/iOS/Android/browser all deliver reliably. Both ends still **accept binary** inbound, so a binary-capable peer (e.g. a Node `ws` client) interoperates unchanged. The relay/proxy are below the WS layer (raw byte pipe) and are untouched.

## Tests

- `plugin-channel-mobile/src/e2e-shim.test.ts` — drives the real shim over a real `ws` connection: a **text-only (RN-style)** peer and a **binary** peer both complete the handshake and round-trip through the bridge; a bad bearer closes the channel cleanly.
- `client-transport-ws/src/e2e-socket.test.ts` — the real phone adapter completes the `@moxxy/e2e` handshake over a **text-only** base WebSocket (binary `send` throws, like iOS) and **never emits a binary frame** (regression guard).

Verified: both new suites pass; `build` 73/73, `typecheck` 143/143, lint 0 errors.