### PR TITLE
test(desktop): make ProfilePill keyless test independent of local .env

### DIFF
--- a/.changeset/clerk-profilepill-test-isolation.md
+++ b/.changeset/clerk-profilepill-test-isolation.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: make the desktop ProfilePill "no publishable key" test deterministic
+(stub `VITE_CLERK_PUBLISHABLE_KEY` empty + re-import) so a developer's local
+`apps/desktop/.env` no longer fails it. No runtime change.

--- a/apps/desktop/src/shell/workspace-sidebar/ProfilePill.test.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/ProfilePill.test.tsx
@@ -1,7 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
-
-import { ProfilePill } from './ProfilePill';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@moxxy/client-core', () => ({
   usePrefs: () => ({ prefs: null, update: vi.fn() }),
@@ -20,7 +18,21 @@ vi.mock('@clerk/clerk-react', () => ({
 }));
 
 describe('ProfilePill', () => {
-  it('renders without Clerk hooks when no publishable key is configured', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('renders without Clerk hooks when no publishable key is configured', async () => {
+    // ProfilePill picks the keyless vs Clerk branch from VITE_CLERK_PUBLISHABLE_KEY,
+    // read once at module load. Pin it empty and re-import so the module-level
+    // const re-evaluates — otherwise a developer's local apps/desktop/.env leaks a
+    // real key, flips the component to the Clerk branch, and this test fails only
+    // on their machine (not CI).
+    vi.stubEnv('VITE_CLERK_PUBLISHABLE_KEY', '');
+    vi.resetModules();
+    const { ProfilePill } = await import('./ProfilePill');
+
     render(<ProfilePill />);
 
     expect(screen.getByText('Sign in')).toBeTruthy();


### PR DESCRIPTION
## Problem

`ProfilePill.test.tsx > renders without Clerk hooks when no publishable key is configured` fails locally (passes in CI).

## Root cause

`ProfilePill.tsx` computes `HAS_CLERK_KEY` from `import.meta.env.VITE_CLERK_PUBLISHABLE_KEY` **once at module load**. The test assumes that var is absent — true in CI, but a developer's local `apps/desktop/.env` sets a real key. Vitest loads `.env`, so the component takes the **Clerk** branch, whose mocked hooks `throw` ("Clerk hook should not be called…"), and the test fails — only on that developer's machine.

## Fix

Pin `VITE_CLERK_PUBLISHABLE_KEY` empty with `vi.stubEnv` and re-import the module (`vi.resetModules` + dynamic import) so the module-level constant re-evaluates. The test is now deterministic regardless of the ambient `.env`. No runtime change.

Empty changeset (test-only, no release).