### PR TITLE
fix(mobile): make pairing over the proxy relay work (Hermes WebCrypto RNG + Metro crawl)

### DIFF
--- a/.changeset/mobile-e2e-crypto-rng.md
+++ b/.changeset/mobile-e2e-crypto-rng.md
@@ -1,0 +1,17 @@
+---
+'@moxxy/mobile-gateway-app': patch
+---
+
+Fix mobile pairing over the proxy relay (`wss://…?fp=…`). The `@moxxy/e2e` Noise
+handshake draws its nonces and ephemeral keys from
+`globalThis.crypto.getRandomValues`, which Hermes (React Native) does not
+provide — so the encrypted handshake threw `crypto.getRandomValues must be
+defined` before the socket ever opened, and pairing failed with a generic
+"couldn't connect to this gateway". Install a WebCrypto `getRandomValues`
+polyfill backed by `expo-crypto` as the first import in the app entry (works in
+Expo Go and native builds).
+
+Also narrow the Metro crawl: keep `watchFolders` at the repo root (so transitive
+`@moxxy/*` workspace deps still resolve) but add a `blockList` for `.git`, the
+multi-GB `.claude/worktrees`, and the other monorepo apps, so a cold start no
+longer traverses the whole workspace.

--- a/.changeset/mobile-metro-workspace-root.md
+++ b/.changeset/mobile-metro-workspace-root.md
@@ -1,0 +1,10 @@
+---
+'@moxxy/mobile-gateway-app': patch
+---
+
+Fix the mobile Metro `workspaceRoot` after the move to `apps/mobile`. It was
+`path.resolve(projectRoot, '../../..')`, correct for the old three-deep
+`apps/mobile-plugin/mobile` path but now resolving to the directory *above* the
+repo. That gave Metro the wrong watch folder and `nodeModulesPaths`, so it
+resolved/served the workspace `@moxxy/*` packages incorrectly (e.g. a stale
+`@moxxy/client-transport-ws`). Now `../..` → the repo root.

--- a/apps/mobile/index.ts
+++ b/apps/mobile/index.ts
@@ -1,3 +1,8 @@
+// MUST be first: installs globalThis.crypto.getRandomValues (via expo-crypto)
+// before any transport module runs, so the E2E pairing handshake has the RNG
+// Hermes otherwise lacks. Side-effect import — keep it above everything else.
+import './src/cryptoPolyfill';
+
 import { installConsoleFilters } from './src/consoleFilters';
 
 installConsoleFilters();

--- a/apps/mobile/metro.config.cjs
+++ b/apps/mobile/metro.config.cjs
@@ -6,6 +6,12 @@ const workspaceRoot = path.resolve(projectRoot, '../..');
 
 const config = getDefaultConfig(projectRoot);
 
+// Watch the repo root so Metro can follow this app's workspace deps (and their
+// transitive `@moxxy/*` deps, e.g. `@moxxy/e2e`, which are symlinked under
+// `node_modules` but live elsewhere in the tree). The root is broad, so the
+// blockList below keeps Metro from crawling the parts that aren't in this app's
+// module graph — rather than a narrower `watchFolders` that would break that
+// transitive resolution.
 config.watchFolders = [...new Set([...(config.watchFolders ?? []), workspaceRoot])];
 config.resolver.nodeModulesPaths = [
   ...new Set([
@@ -13,6 +19,23 @@ config.resolver.nodeModulesPaths = [
     path.resolve(projectRoot, 'node_modules'),
     path.resolve(workspaceRoot, 'node_modules'),
   ]),
+];
+
+// Shrink the crawl: exclude trees under the repo root that are not part of
+// apps/mobile's module graph. The big wins are `.git` and the multi-GB
+// `.claude/worktrees`, plus the other monorepo apps (desktop/docs/…). We do NOT
+// block `packages/*` — the shared `@moxxy/*` packages are consumed from their
+// built `dist`, which must stay resolvable.
+const blockedTrees = [
+  /[\\/]\.git[\\/].*/,
+  /[\\/]\.claude[\\/].*/,
+  // Any app other than this one (the negative lookahead keeps `apps/mobile`).
+  /[\\/]apps[\\/](?!mobile[\\/])[^\\/]+[\\/].*/,
+];
+const existingBlock = config.resolver.blockList;
+config.resolver.blockList = [
+  ...(Array.isArray(existingBlock) ? existingBlock : existingBlock ? [existingBlock] : []),
+  ...blockedTrees,
 ];
 
 const singletons = ['react', 'react-dom'];

--- a/apps/mobile/metro.config.cjs
+++ b/apps/mobile/metro.config.cjs
@@ -2,7 +2,7 @@ const { getDefaultConfig } = require('expo/metro-config');
 const path = require('node:path');
 
 const projectRoot = __dirname;
-const workspaceRoot = path.resolve(projectRoot, '../../..');
+const workspaceRoot = path.resolve(projectRoot, '../..');
 
 const config = getDefaultConfig(projectRoot);
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -25,6 +25,7 @@
     "expo-camera": "~17.0.10",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",
+    "expo-crypto": "~15.0.9",
     "expo-document-picker": "~14.0.8",
     "expo-file-system": "~19.0.23",
     "expo-image-picker": "~17.0.11",

--- a/apps/mobile/src/cryptoPolyfill.ts
+++ b/apps/mobile/src/cryptoPolyfill.ts
@@ -1,0 +1,36 @@
+/**
+ * Installs the WebCrypto RNG the E2E pairing handshake needs under Hermes.
+ *
+ * Pairing over the proxy relay (`wss://…?fp=…`) runs the `@moxxy/e2e` Noise
+ * handshake (via `@noble`), which draws its nonces and ephemeral keys from
+ * `globalThis.crypto.getRandomValues`. Hermes (React Native) ships no global
+ * WebCrypto RNG, so without this the first handshake frame throws
+ * `crypto.getRandomValues must be defined` and the connection dies before the
+ * socket opens — the symptom is a pairing that never reaches `open`. Back it
+ * with `expo-crypto`, which exposes a synchronous, WebCrypto-shaped
+ * `getRandomValues` (and is available both in Expo Go and a native build).
+ *
+ * This is a side-effect module: importing it installs the RNG. It MUST be the
+ * first import in the app entry (`index.ts`), before any transport/router module
+ * can run, so the global is in place no matter when the handshake fires.
+ */
+import * as ExpoCrypto from 'expo-crypto';
+
+type CryptoLike = { getRandomValues?: <T extends ArrayBufferView>(array: T) => T };
+const g = globalThis as typeof globalThis & { crypto?: CryptoLike };
+
+if (typeof g.crypto?.getRandomValues !== 'function') {
+  const impl = <T extends ArrayBufferView>(array: T): T =>
+    ExpoCrypto.getRandomValues(array as never) as unknown as T;
+  if (g.crypto) {
+    // `globalThis.crypto` may exist but lack a usable RNG; install onto it,
+    // falling back to defineProperty if the host object is frozen.
+    try {
+      g.crypto.getRandomValues = impl;
+    } catch {
+      Object.defineProperty(g.crypto, 'getRandomValues', { value: impl, configurable: true });
+    }
+  } else {
+    Object.defineProperty(g, 'crypto', { value: { getRandomValues: impl }, configurable: true });
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,9 @@ importers:
       expo-constants:
         specifier: ~18.0.13
         version: 18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))
+      expo-crypto:
+        specifier: ~15.0.9
+        version: 15.0.9(expo@54.0.35)
       expo-document-picker:
         specifier: ~14.0.8
         version: 14.0.8(expo@54.0.35)
@@ -2664,7 +2667,7 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       typescript-eslint:
         specifier: ^8.20.0
-        version: 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
 
   tooling/tsconfig: {}
 
@@ -7077,6 +7080,11 @@ packages:
       expo: '*'
       react-native: '*'
 
+  expo-crypto@15.0.9:
+    resolution: {integrity: sha512-SNWKa2fXx7v9gkp1h/7nqXY5XN7qgNDn3yRc2aO0gWGbeMbvob/haMxxsPFe9f51aqH5NjNCqHf2kvLhvAd8KQ==}
+    peerDependencies:
+      expo: '*'
+
   expo-document-picker@14.0.8:
     resolution: {integrity: sha512-3tyQKpPqWWFlI8p9RiMX1+T1Zge5mEKeBuXWp1h8PEItFMUDSiOJbQ112sfdC6Hxt8wSxreV9bCRl/NgBdt+fA==}
     peerDependencies:
@@ -10523,6 +10531,11 @@ packages:
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -14460,40 +14473,40 @@ snapshots:
       '@types/node': 24.12.3
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.59.2
-      '@typescript-eslint/type-utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.2
       eslint: 9.39.4(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.2
       '@typescript-eslint/types': 8.59.2
-      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.2
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.7.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.2(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.59.2(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@6.0.3)
       '@typescript-eslint/types': 8.59.2
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14502,47 +14515,47 @@ snapshots:
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/visitor-keys': 8.59.2
 
-  '@typescript-eslint/tsconfig-utils@8.59.2(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.2(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.2
-      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.7.0)
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.59.2': {}
 
-  '@typescript-eslint/typescript-estree@8.59.2(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.59.2(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.59.2(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.59.2(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@6.0.3)
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/visitor-keys': 8.59.2
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.0
       tinyglobby: 0.2.16
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.59.2
       '@typescript-eslint/types': 8.59.2
-      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16483,6 +16496,11 @@ snapshots:
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
+
+  expo-crypto@15.0.9(expo@54.0.35):
+    dependencies:
+      base64-js: 1.5.1
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-document-picker@14.0.8(expo@54.0.35):
     dependencies:
@@ -20973,9 +20991,9 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.5
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   ts-interface-checker@0.1.13: {}
 
@@ -21070,18 +21088,20 @@ snapshots:
     dependencies:
       semver: 7.8.0
 
-  typescript-eslint@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+  typescript-eslint@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
 
   ua-parser-js@1.0.41: {}
 


### PR DESCRIPTION
Makes `apps/mobile` actually pair with the gateway over the self-hosted proxy relay (`wss://…?fp=…`). Three parts, all on the mobile app's connection path.

## 1. Hermes WebCrypto RNG (the bug that broke pairing)

Pairing over the relay runs the `@moxxy/e2e` Noise handshake (via `@noble`), which draws its nonces and ephemeral keys from `globalThis.crypto.getRandomValues`. **Hermes (React Native) ships no global WebCrypto RNG**, so the very first handshake frame threw `crypto.getRandomValues must be defined`, the socket closed before it opened, and pairing failed with the generic *"Couldn't connect to this gateway…"*.

Fix: a side-effect `src/cryptoPolyfill.ts` that installs a WebCrypto-shaped `getRandomValues` backed by `expo-crypto` (works in Expo Go **and** native builds), imported **first** in `index.ts` before any transport/router module runs.

## 2. Metro `workspaceRoot` (original fix)

`metro.config.cjs` computed `path.resolve(projectRoot, '../../..')` — correct when the app lived three deep at `apps/mobile-plugin/mobile`, but after the move to `apps/mobile` (#304) it resolves to **one level above the repo**. Fixed to `../..` (the repo root).

## 3. Trim the Metro crawl

Watching the repo root made Metro crawl the whole monorepo on cold start (`.git`, the multi-GB `.claude/worktrees`, the other apps). Added a `blockList` for those trees. `watchFolders` stays at the repo root on purpose — transitive `@moxxy/*` deps (e.g. `@moxxy/e2e`, pulled in by `@moxxy/client-transport-ws`) are symlinked under `node_modules` but live elsewhere in the tree, so a narrower `watchFolders` would break resolution. `packages/*` is **not** blocked (the shared packages are consumed from their built `dist`).

## Verification

- Stood up `moxxy mobile` behind the live proxy relay and ran the app on an iOS simulator (Expo Go). The **real** `pairFromQrPayload` flow paired in ~1s and reached `transportReady = true` — the app showed **Chat · Connected** with the live session. (A diagnostic confirmed Hermes reports `nativeGetRandomValues = undefined`, so the polyfill is load-bearing; an identical isolated POC failed without it and succeeded with it.)
- `npx expo export --platform ios` succeeds with the new `blockList` (full Hermes bundle), confirming transitive `@moxxy/*` resolution is intact.
- `tsc --noEmit` clean; 203 mobile unit tests pass; `eslint` clean.