### PR TITLE
chore(mobile): rebrand app to "workspaces" (bundle id + package + slug)

### DIFF
--- a/.changeset/mobile-rebrand-workspaces.md
+++ b/.changeset/mobile-rebrand-workspaces.md
@@ -1,0 +1,9 @@
+---
+'@moxxy/workspaces-app': patch
+---
+
+Rebrand the mobile app to "workspaces". Rename the package
+`@moxxy/mobile-gateway-app` → `@moxxy/workspaces-app`, set the iOS bundle
+identifier to `ai.moxxy.workspaces` (app.json, the native Xcode project, and the
+matching bundle-id URL scheme in Info.plist — including the Live Activity
+extension), and set the Expo slug to `workspaces`.

--- a/apps/mobile/CHANGELOG.md
+++ b/apps/mobile/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @moxxy/mobile-gateway-app
+# @moxxy/workspaces-app
 
 ## 0.1.2
 

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
     "name": "Moxxy Mobile",
-    "slug": "moxxy-mobile-gateway",
+    "slug": "workspaces",
     "scheme": "moxxy-mobile",
     "icon": "./assets/icon.png",
     "orientation": "portrait",
@@ -19,7 +19,7 @@
         "NSLocalNetworkUsageDescription": "Connect to the Moxxy runner on your computer over your local Wi-Fi network.",
         "NSSupportsLiveActivities": true
       },
-      "bundleIdentifier": "com.kamiloxen1.moxxy-mobile-gateway"
+      "bundleIdentifier": "ai.moxxy.workspaces"
     },
     "plugins": [
       "expo-router",
@@ -50,6 +50,13 @@
           "photosPermission": "Allow Moxxy Mobile to attach screenshots and photos to your Moxxy messages."
         }
       ]
-    ]
+    ],
+    "extra": {
+      "router": {},
+      "eas": {
+        "projectId": "2a4d11ff-92b2-48e0-99d8-2bab5a637a10"
+      }
+    },
+    "owner": "moxxyai"
   }
 }

--- a/apps/mobile/ios/MoxxyMobileGateway.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/MoxxyMobileGateway.xcodeproj/project.pbxproj
@@ -481,7 +481,7 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.kamiloxen1.moxxy-mobile-gateway";
+				PRODUCT_BUNDLE_IDENTIFIER = "ai.moxxy.workspaces";
 				PRODUCT_NAME = MoxxyMobileGateway;
 				SWIFT_OBJC_BRIDGING_HEADER = "MoxxyMobileGateway/MoxxyMobileGateway-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -513,7 +513,7 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.kamiloxen1.moxxy-mobile-gateway";
+				PRODUCT_BUNDLE_IDENTIFIER = "ai.moxxy.workspaces";
 				PRODUCT_NAME = MoxxyMobileGateway;
 				SWIFT_OBJC_BRIDGING_HEADER = "MoxxyMobileGateway/MoxxyMobileGateway-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -657,7 +657,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.kamiloxen1.moxxy-mobile-gateway.MoxxyLiveActivityExtension";
+				PRODUCT_BUNDLE_IDENTIFIER = "ai.moxxy.workspaces.MoxxyLiveActivityExtension";
 				PRODUCT_NAME = MoxxyLiveActivityExtension;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -683,7 +683,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.kamiloxen1.moxxy-mobile-gateway.MoxxyLiveActivityExtension";
+				PRODUCT_BUNDLE_IDENTIFIER = "ai.moxxy.workspaces.MoxxyLiveActivityExtension";
 				PRODUCT_NAME = MoxxyLiveActivityExtension;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;

--- a/apps/mobile/ios/MoxxyMobileGateway/Info.plist
+++ b/apps/mobile/ios/MoxxyMobileGateway/Info.plist
@@ -28,7 +28,7 @@
         <key>CFBundleURLSchemes</key>
         <array>
           <string>moxxy-mobile</string>
-          <string>com.kamiloxen1.moxxy-mobile-gateway</string>
+          <string>ai.moxxy.workspaces</string>
         </array>
       </dict>
     </array>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@moxxy/mobile-gateway-app",
+  "name": "@moxxy/workspaces-app",
   "version": "0.1.2",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Rebrands the mobile app from the placeholder identity to **workspaces**, a follow-up to #309.

- **Package**: `@moxxy/mobile-gateway-app` → **`@moxxy/workspaces-app`** (`package.json` + `CHANGELOG.md` heading).
- **iOS bundle identifier**: `com.kamiloxen1.moxxy-mobile-gateway` (a personal placeholder) → **`ai.moxxy.workspaces`**. Updated in `app.json`, the native Xcode project (`PRODUCT_BUNDLE_IDENTIFIER` for both the app and the `MoxxyLiveActivityExtension` target), and the matching bundle-id URL scheme in `Info.plist`.
- **Expo slug**: `moxxy-mobile-gateway` → **`workspaces`**.
- Also carries the EAS project wiring (`extra.eas.projectId` + `owner`) added during setup.

### Verification
- `tsc --noEmit` clean; 203 mobile unit tests pass.
- `app.json` is valid JSON; no `mobile-gateway-app` / `kamiloxen1` strings remain anywhere in the tree.
- Workspace resolves the renamed package: `@moxxy/workspaces-app@0.1.2 (PRIVATE)`.