### PR TITLE
fix(mobile): build workspace deps on EAS and pin the iOS submit target

### DIFF
--- a/.changeset/mobile-eas-build-workspace-deps.md
+++ b/.changeset/mobile-eas-build-workspace-deps.md
@@ -9,3 +9,7 @@ git-ignored and never produced on a fresh EAS checkout (EAS only runs
 `pnpm install`). Metro then failed to resolve `@moxxy/client-core` and friends.
 An `eas-build-post-install` hook now builds the app's transitive workspace dep
 closure after install and before bundling.
+
+Also pins the iOS `submit` target (`ascAppId` + `bundleIdentifier`) so
+`eas submit --non-interactive` resolves the App Store Connect app deterministically
+instead of running its auto app-creation path.

--- a/.changeset/mobile-eas-build-workspace-deps.md
+++ b/.changeset/mobile-eas-build-workspace-deps.md
@@ -1,0 +1,11 @@
+---
+"@moxxy/workspaces-app": patch
+---
+
+fix(mobile): build workspace deps on EAS before Metro bundles
+
+The app consumes `@moxxy/*` workspace packages from their built `dist/`, which is
+git-ignored and never produced on a fresh EAS checkout (EAS only runs
+`pnpm install`). Metro then failed to resolve `@moxxy/client-core` and friends.
+An `eas-build-post-install` hook now builds the app's transitive workspace dep
+closure after install and before bundling.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -88,6 +88,23 @@ pass also **retired the plugins-admin CLI install-hardening + dedup items** (for
 
 ---
 
+## 2026-06-23 — Mobile EAS build: workspace deps' `dist` missing on fresh checkout
+
+**Logged + fixed on sight:** the Expo app (`apps/mobile`) consumes its `@moxxy/*`
+workspace deps from their built `dist/` (their `main`/`exports` point there), but
+`dist/` is git-ignored and EAS only runs `pnpm install` — never builds the
+packages — so Metro on a fresh EAS checkout couldn't resolve `@moxxy/client-core`
+& friends and the iOS bundle failed at ~95%. Fixed with an `eas-build-post-install`
+hook that builds the app's transitive workspace dep closure
+(`pnpm --filter "@moxxy/workspaces-app^..." run build`) after install, before
+bundling. **Breadcrumb for future mobile-build work:** the local repro is
+misleading — deleting `dist/` but leaving the git-ignored `tsconfig.tsbuildinfo`
+makes `tsc` skip emit (false "Done", no output); a real EAS checkout has neither,
+so it builds clean. To reproduce EAS locally, wipe `dist` **and** `*.tsbuildinfo`.
+Considered but rejected: bundling `@moxxy/*` from TS source via a Metro resolver —
+cleaner in theory but leaks a babel-must-transpile-all-shared-TS coupling; the
+dist contract is kept uniform with every other consumer.
+
 ## 2026-06-22 — Mobile NativeWind cleanup
 
 **Retired:** the mobile app no longer depends on NativeWind/Tailwind runtime

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -103,7 +103,16 @@ makes `tsc` skip emit (false "Done", no output); a real EAS checkout has neither
 so it builds clean. To reproduce EAS locally, wipe `dist` **and** `*.tsbuildinfo`.
 Considered but rejected: bundling `@moxxy/*` from TS source via a Metro resolver —
 cleaner in theory but leaks a babel-must-transpile-all-shared-TS coupling; the
-dist contract is kept uniform with every other consumer.
+dist contract is kept uniform with every other consumer. **Submit follow-on:** the
+EAS *submit* step then failed with altool 1192 "No version found … on platform iOS
+App" — an App Store Connect-side condition (app/version not set up to receive a
+build, or inactive Paid/Free-Apps agreement), surfaced because the empty `submit`
+profile made `eas submit --non-interactive` auto-resolve a stub app. Pinned
+`submit.production.ios.{ascAppId,bundleIdentifier}` in `eas.json` to make the
+target deterministic; the upload itself still requires the ASC app record + active
+agreement (owner action, not a repo fix). `eas.json` can't env-drive `ascAppId`
+(no interpolation, no CLI flag), so it's committed despite the keep-identity-out
+pattern.
 
 ## 2026-06-22 — Mobile NativeWind cleanup
 

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -19,6 +19,11 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {
+        "ascAppId": "6775085563",
+        "bundleIdentifier": "ai.moxxy.workspaces"
+      }
+    }
   }
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "android": "expo run:android",
-    "ios": "expo run:ios"
+    "ios": "expo run:ios",
+    "eas-build-post-install": "pnpm --filter \"@moxxy/workspaces-app^...\" run build"
   },
   "dependencies": {
     "@expo/metro-runtime": "~6.1.2",


### PR DESCRIPTION
Two EAS fixes for `apps/mobile`: the iOS **build** (Metro couldn't resolve `@moxxy/*`) and the App Store **submit** (`altool` 1192).

## 1. Build — workspace deps' `dist` missing on EAS

`apps/mobile/package.json` gains an `eas-build-post-install` hook:

```json
"eas-build-post-install": "pnpm --filter \"@moxxy/workspaces-app^...\" run build"
```

**Why:** the app consumes `@moxxy/client-core`, `@moxxy/design-tokens`, `@moxxy/chat-model`, `@moxxy/client-transport-ws` (etc.) as `workspace:*`, and their `main`/`exports` point at `./dist/index.js`. On a fresh EAS checkout that `dist/` doesn't exist — it's git-ignored (never uploaded) and EAS only runs `pnpm install`, never building the packages. Metro found each package but couldn't resolve its `main`, failing the iOS bundle at ~95% (`Unable to resolve @moxxy/client-core … dist/index.js … none of these files exist`). The hook builds the app's transitive workspace dep closure (10 packages, topo order, skips packages without a `build` script) after install and before bundling.

Rejected alternative: resolving `@moxxy/*` from TS source in Metro (no build step) — it leaks a "babel must transpile all shared-package TS" coupling and diverges mobile from the `dist` contract every other consumer uses.

## 2. Submit — pin the iOS App Store Connect target

`apps/mobile/eas.json` `submit.production.ios` was empty; now:

```json
"ios": { "ascAppId": "6775085563", "bundleIdentifier": "ai.moxxy.workspaces" }
```

**Why:** with an empty submit profile, `eas submit --non-interactive` ran its auto app-resolution/creation path and `altool` then failed uploading the IPA with `1192 — No version found for '…' (6775085563 on platform iOS App)` (the blank app-name is the stub symptom). Pinning `ascAppId` makes EAS target that exact app and skip the app-creation step. `eas.json` can't env-drive `ascAppId` (no interpolation / CLI flag), so it's committed despite the keep-identity-out pattern — it's a low-sensitivity, reversible app identifier.

> Note: the eas.json change makes the submit *deterministic*, but the 1192 upload itself is an **App Store Connect-side** condition — the app record for `ai.moxxy.workspaces` must be fully created (iOS platform + a version) and the **Paid Apps / Free Apps agreement must be active**. That's an owner-side setup task, not a repo change.

## Verification

- **Build:** simulated a fresh EAS checkout (wiped `dist/` **and** the git-ignored `tsconfig.tsbuildinfo` for the dep closure — a stale `.tsbuildinfo` makes `tsc` skip emit and would mask the test), ran the hook → all 10 packages built, `dist/index.js` entrypoints produced, then ran the **exact** failing command `pnpm expo export:embed --eager --platform ios --dev false` → `iOS Bundled (1321 modules)`, wrote a 5.7 MB `main.jsbundle`, no resolution errors.
- **Submit:** config-only change; `eas.json` validated as JSON. The 1192 upload is unblocked by ASC setup (above), which this PR can't perform.
- Build-config-only diff — touches no compiled source, so the build/typecheck/test/lint gate is unaffected. Includes a patch changeset (`@moxxy/workspaces-app`, private — no npm publish) and a TECH_DEBT.md breadcrumb.