### PR TITLE
feat(desktop): move mobile gateway to sidebar and make it on-demand

### DIFF
--- a/.changeset/desktop-mobile-on-demand.md
+++ b/.changeset/desktop-mobile-on-demand.md
@@ -1,0 +1,10 @@
+---
+"@moxxy/desktop": patch
+"@moxxy/desktop-ui": patch
+---
+
+Promote the mobile gateway to its own sidebar entry (above Settings) and make it on-demand only.
+
+- Move the mobile pairing surface out of Settings into a dedicated top-level **Mobile** view in the sidebar.
+- The gateway no longer auto-starts with the app — it stays off on every launch and is enabled explicitly per session (the persisted pairing token/identity are kept, so re-enabling reuses the same QR).
+- Tear the gateway down through its manager on quit so the end-to-end proxy tunnel is closed and the relay deregisters this machine — fixing the "unresponsive until you regenerate the code" pairing left behind by a leaked tunnel from the previous run.

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -759,12 +759,15 @@ app.whenReady().then(async () => {
     } catch (e) {
       console.error('[moxxy] WebSocket bridge failed to start:', e);
     }
-  } else if (mobileGateway) {
-    // No env override: re-start the gateway iff the user previously enabled it
-    // (persisted preference), so pairing survives a restart.
-    await mobileGateway.resume();
-    wsServer = mobileGateway.liveServer;
   }
+  // Without the env override the gateway stays OFF on boot — it is on-demand
+  // only and never auto-starts with the app. The user enables it explicitly
+  // from the Mobile view; we deliberately do NOT resume the persisted
+  // preference here. (Auto-resume re-opened a fresh proxy tunnel on every
+  // launch — racing the relay's still-registered tunnel from the previous run
+  // and leaving pairing "unresponsive until you regenerate the code".) The
+  // pairing token + identity are still persisted, so re-enabling reuses the
+  // same QR without re-pairing.
 
   // The renderer's DeepLinkBridge calls this once on mount: it returns +
   // clears any `moxxy://` links buffered before the renderer was listening
@@ -830,17 +833,24 @@ app.on('will-quit', () => {
 });
 
 async function shutdown(): Promise<void> {
-  // The runtime gateway may have replaced `wsServer` (toggled on/off from
-  // Settings), so close whichever server is currently live, preferring the
-  // controller's view.
-  const liveBridge = mobileGateway?.liveServer ?? wsServer;
+  // Tear the mobile gateway down THROUGH the manager (not just the raw server):
+  // `stop()` also closes the E2E proxy tunnel + shim, so the relay deregisters
+  // this machine's tunnel on quit. Closing only the WS server (the old path)
+  // left the relay holding a stale registration for the key-derived URL — the
+  // next launch's tunnel then collided with the dead one and pairing looked
+  // "unresponsive until you regenerate the code". When the manager is absent
+  // (bridge module failed to load) fall back to closing the env-boot server.
+  const stopGateway = mobileGateway
+    ? mobileGateway.stop().then(() => undefined)
+    : (wsServer?.close() ?? Promise.resolve());
   await Promise.race([
-    // Stop the runner children, the loopback server, AND the WS bridge (remote
-    // clients). allSettled never rejects, so one failing doesn't skip the others.
+    // Stop the runner children, the loopback server, AND the mobile gateway
+    // (remote clients + relay tunnel). allSettled never rejects, so one failing
+    // doesn't skip the others.
     Promise.allSettled([
       pool?.stopAll() ?? Promise.resolve(),
       loopback?.close() ?? Promise.resolve(),
-      liveBridge?.close() ?? Promise.resolve(),
+      stopGateway,
     ]),
     // Belt-and-braces timeout: don't hang the app on a stuck child.
     new Promise<void>((resolve) => setTimeout(resolve, 3000)),

--- a/apps/desktop/electron/main/ws-bridge.ts
+++ b/apps/desktop/electron/main/ws-bridge.ts
@@ -12,8 +12,10 @@
  *   - the env-gated BOOT path (`MOXXY_WS_BRIDGE=1`) — back-compat for power
  *     users / CI, started once at boot from {@link resolveWsBridgeConfig};
  *   - the runtime "mobile gateway" path — {@link MobileGatewayManager}, driven
- *     by the Settings → Mobile tab via IPC, which can START and STOP the bridge
- *     on demand and persists the on/off preference so it survives a restart.
+ *     by the Mobile view via IPC, which can START and STOP the bridge on demand.
+ *     It is ON-DEMAND ONLY: the gateway never auto-starts with the app (the boot
+ *     path does not resume the persisted preference), so each pairing session is
+ *     a fresh, explicit opt-in.
  *
  * SECURITY — the runtime gateway binds the LAN by default (so a phone on the
  * same Wi-Fi can actually reach it), which is a deliberate local-network
@@ -229,10 +231,16 @@ export class MobileGatewayManager {
   }
 
   /**
-   * Re-start the gateway on boot iff the persisted preference says it was on.
+   * Re-start the gateway iff the persisted preference says it was on.
+   *
+   * NOTE: the app no longer calls this at boot — the gateway is on-demand only
+   * and must never auto-start (see the boot path in the Electron main). This is
+   * retained as a self-contained capability (and is unit-tested) so a future
+   * opt-in "remember the gateway across restarts" toggle can wire it back in.
+   *
    * Best-effort: a start failure is swallowed (logged) so a transient port
-   * clash can't brick boot — the user can re-toggle from Settings. Serialized
-   * with start/stop/rotate so a user toggle that races boot can't double-bind.
+   * clash can't brick boot. Serialized with start/stop/rotate so a toggle that
+   * races it can't double-bind.
    */
   async resume(): Promise<void> {
     await this.runExclusive(async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -26,6 +26,7 @@ import { useAgentSurfaceReveal } from './shell/surfaces/useAgentSurfaceReveal';
 import { WorkflowsPanel } from './workflows/WorkflowsPanel';
 import { CollaboratePanel } from './collaborate/CollaboratePanel';
 import { SettingsPanel } from './settings/SettingsPanel';
+import { MobilePanel } from './mobile/MobilePanel';
 import { AppsPanel } from './apps/AppsPanel';
 import { UpdateBanner } from './shell/UpdateBanner';
 import { Splash } from './Splash';
@@ -334,6 +335,18 @@ export function App(): JSX.Element {
       {view === 'apps' && (
         <main className="col-main col-main--flat">
           <AppsPanel
+            onView={onView}
+            disabledViews={runnerTabsLocked ? RUNNER_LOCKED_VIEWS : undefined}
+            disabledViewReason={RUNNER_LOCKED_REASON}
+          />
+        </main>
+      )}
+      {/* Mobile is independent of the runner session (the gateway lives in the
+          main process), so it is never runner-locked — but the switcher still
+          needs the locked set so the OTHER segments disable in lockstep. */}
+      {view === 'mobile' && (
+        <main className="col-main col-main--flat">
+          <MobilePanel
             onView={onView}
             disabledViews={runnerTabsLocked ? RUNNER_LOCKED_VIEWS : undefined}
             disabledViewReason={RUNNER_LOCKED_REASON}

--- a/apps/desktop/src/mobile/MobilePanel.tsx
+++ b/apps/desktop/src/mobile/MobilePanel.tsx
@@ -1,0 +1,59 @@
+/**
+ * Mobile view — a top-level sidebar destination (above Settings) that hosts the
+ * mobile-gateway pairing surface.
+ *
+ * Previously this lived as a tab inside Settings. It was promoted to its own
+ * sidebar entry because the gateway is a stateful, on-demand service (start it,
+ * pair a phone, stop it) rather than a static preference — surfacing it at the
+ * top level keeps it one click away and out of the Settings tab churn.
+ *
+ * The panel is pure chrome: the {@link MobileTab} body owns all gateway state
+ * (enable toggle, QR, regenerate) via `useMobileGateway`. Unlike Workflows /
+ * Apps, this view does NOT depend on the runner session (the gateway lifecycle
+ * is main-process-side), so it is never runner-locked.
+ */
+
+import { MobileTab } from '../settings/MobileTab';
+import { ViewHeader, ViewSwitcher, type View } from '../shell/ViewHeader';
+
+export function MobilePanel({
+  // Optional so the panel can render standalone (tests); the app shell always
+  // wires it so the header switcher navigates back to Chat/Workflows/etc.
+  onView = () => undefined,
+  disabledViews,
+  disabledViewReason,
+}: {
+  readonly onView?: (v: View) => void;
+  readonly disabledViews?: ReadonlyArray<View>;
+  readonly disabledViewReason?: string;
+}): JSX.Element {
+  return (
+    <>
+      <ViewHeader>
+        <ViewSwitcher
+          view="mobile"
+          onView={onView}
+          disabledViews={disabledViews}
+          disabledReason={disabledViewReason}
+        />
+        <span style={{ flex: 1 }} />
+        <span style={{ fontSize: 13.5, fontWeight: 600, color: 'var(--color-text-muted)' }}>
+          Mobile
+        </span>
+      </ViewHeader>
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          padding: '20px 32px 40px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 20,
+        }}
+      >
+        <MobileTab />
+      </div>
+    </>
+  );
+}

--- a/apps/desktop/src/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/settings/SettingsPanel.tsx
@@ -5,7 +5,6 @@ import { SkillsView } from './SkillsView';
 import { ProvidersTab } from './ProvidersTab';
 import { McpTab } from './McpTab';
 import { VaultTab } from './VaultTab';
-import { MobileTab } from './MobileTab';
 import { PreferencesTab } from './PreferencesTab';
 import { SearchBox } from './settings-primitives';
 import { ViewHeader, ViewSwitcher, Segmented, type View } from '../shell/ViewHeader';
@@ -84,7 +83,6 @@ const TAB_DESCRIPTORS: ReadonlyArray<TabDescriptor> = [
       />
     ),
   },
-  { id: 'mobile', label: 'Mobile', standalone: true, render: () => <MobileTab /> },
   { id: 'preferences', label: 'Preferences', standalone: true, render: () => <PreferencesTab /> },
 ];
 
@@ -158,9 +156,9 @@ export function SettingsPanel({
         }}
       >
 
-      {/* Standalone tabs (Preferences / Mobile) are independent of the
-          runner-backed settings slice — render them without the shared
-          loading / error chrome below. */}
+      {/* Standalone tabs (Preferences) are independent of the runner-backed
+          settings slice — render them without the shared loading / error
+          chrome below. */}
       {active.standalone && active.render(ctx)}
 
       {!active.standalone && s.error && (

--- a/apps/desktop/src/shell/ViewHeader.tsx
+++ b/apps/desktop/src/shell/ViewHeader.tsx
@@ -5,8 +5,9 @@ import { setSidebarCollapsed, useSidebarCollapsed } from '@/lib/useSidebarCollap
 import { useMenuKeyboard } from './useMenuKeyboard';
 
 /** Top-level main-content views. Chat ↔ Workflows ↔ Collaborate ↔ Apps switch
- *  via the header's `ViewSwitcher`; Settings is reached from the sidebar. */
-export type View = 'chat' | 'workflows' | 'collaborate' | 'settings' | 'apps';
+ *  via the header's `ViewSwitcher`; Settings and Mobile are reached from the
+ *  sidebar (they own the pane with no active switcher segment). */
+export type View = 'chat' | 'workflows' | 'collaborate' | 'settings' | 'apps' | 'mobile';
 
 /**
  * Shared section header — one 64px chrome bar so Chat / Workflows /
@@ -480,13 +481,16 @@ export function ViewSwitcher({
   return (
     <Segmented
       items={SWITCH_ITEMS}
-      value={view === 'settings' ? null : view}
+      // Settings and Mobile are sidebar destinations, not switcher segments — so
+      // neither maps to a pill. The inline comparison also narrows `view` to the
+      // switcher's own ids in the else branch (keeps the value type exact).
+      value={view === 'settings' || view === 'mobile' ? null : view}
       onChange={onView}
       testIdPrefix="nav-"
       collapsible
       disabledIds={disabledIds}
       disabledReason={disabledReason}
-      // On the Settings view this switcher has no active segment; label the
+      // On a sidebar-owned view this switcher has no active segment; label the
       // folded button with the view family rather than a blank.
       collapsedLabel="Views"
     />

--- a/apps/desktop/src/shell/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/shell/WorkspaceSidebar.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useDesks } from '@moxxy/client-core';
-import { Skeleton, Icon, ConfirmModal } from '@moxxy/desktop-ui';
+import { Skeleton, Icon, ConfirmModal, type IconName } from '@moxxy/desktop-ui';
 import { useUnreadWorkspaces } from '@moxxy/client-core';
 import type { Desk, DeskSession } from '@moxxy/desktop-ipc-contract';
 import { Logo } from './workspace-sidebar/Logo';
@@ -188,45 +188,24 @@ export function WorkspaceSidebar({ view, onView }: Props): JSX.Element | null {
           />
         )}
       </div>
-      {/* Settings is the only sidebar destination — anchored just above
-       *  the profile's top border. Chat/Workflows switch in the main-pane
-       *  header instead. */}
-      <nav style={{ padding: '6px 12px 10px' }}>
-        <button
-          type="button"
-          data-testid="nav-settings"
-          data-active={view === 'settings'}
+      {/* Mobile + Settings are the sidebar destinations — anchored just above
+       *  the profile's top border, Mobile sitting above Settings.
+       *  Chat/Workflows switch in the main-pane header instead. */}
+      <nav style={{ padding: '6px 12px 10px', display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <NavItem
+          icon="smartphone"
+          label="Mobile"
+          testId="nav-mobile"
+          active={view === 'mobile'}
+          onClick={() => onView('mobile')}
+        />
+        <NavItem
+          icon="settings"
+          label="Settings"
+          testId="nav-settings"
+          active={view === 'settings'}
           onClick={() => onView('settings')}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 10,
-            width: '100%',
-            padding: '10px 12px',
-            fontSize: 13.5,
-            color:
-              view === 'settings'
-                ? 'var(--color-sidebar-text)'
-                : 'var(--color-sidebar-text-dim)',
-            background:
-              view === 'settings' ? 'var(--color-sidebar-bg-active)' : 'transparent',
-            borderRadius: 10,
-            fontWeight: view === 'settings' ? 600 : 500,
-          }}
-        >
-          <span
-            style={{
-              width: 20,
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              opacity: 0.85,
-            }}
-          >
-            <Icon name="settings" size={17} />
-          </span>
-          <span>Settings</span>
-        </button>
+        />
       </nav>
       <ProfilePill />
       {pendingFolder && (
@@ -288,5 +267,55 @@ export function WorkspaceSidebar({ view, onView }: Props): JSX.Element | null {
         />
       )}
     </aside>
+  );
+}
+
+/** A bottom-rail destination button (Mobile, Settings) — one shared row so the
+ *  two entries stay pixel-identical (active fill, icon tile, label weight). */
+function NavItem({
+  icon,
+  label,
+  testId,
+  active,
+  onClick,
+}: {
+  readonly icon: IconName;
+  readonly label: string;
+  readonly testId: string;
+  readonly active: boolean;
+  readonly onClick: () => void;
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      data-active={active}
+      onClick={onClick}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        width: '100%',
+        padding: '10px 12px',
+        fontSize: 13.5,
+        color: active ? 'var(--color-sidebar-text)' : 'var(--color-sidebar-text-dim)',
+        background: active ? 'var(--color-sidebar-bg-active)' : 'transparent',
+        borderRadius: 10,
+        fontWeight: active ? 600 : 500,
+      }}
+    >
+      <span
+        style={{
+          width: 20,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          opacity: 0.85,
+        }}
+      >
+        <Icon name={icon} size={17} />
+      </span>
+      <span>{label}</span>
+    </button>
   );
 }

--- a/packages/desktop-ipc-contract/src/prefs.ts
+++ b/packages/desktop-ipc-contract/src/prefs.ts
@@ -8,10 +8,12 @@ export interface DesktopPrefs {
   clerkUserId: string | null;
   clerkDisplayName: string | null;
   signedInAt: number | null;
-  /** Whether the user enabled the mobile gateway (the WebSocket bridge). The
-   *  main process re-starts the bridge on boot when this is true so pairing
-   *  survives a restart. Defaults to false (OFF) — exposing the host on the LAN
-   *  is always an explicit opt-in. */
+  /** Whether the user last had the mobile gateway (the WebSocket bridge) on.
+   *  Recorded when the gateway is toggled, but NOT acted on at boot: the gateway
+   *  is on-demand only and never auto-starts with the app (exposing the host on
+   *  the network is always an explicit, per-session opt-in from the Mobile view).
+   *  Kept for diagnostics / a possible future "remember" option. Defaults to
+   *  false (OFF). */
   mobileGatewayEnabled: boolean;
   /** Color scheme. The renderer's useTheme() controller maps it to
    *  `data-theme="dark"` on <html>; the main process mirrors it into

--- a/packages/desktop-ui/src/Icon.tsx
+++ b/packages/desktop-ui/src/Icon.tsx
@@ -41,6 +41,7 @@ export type IconName =
   | 'folder'
   | 'terminal'
   | 'globe'
+  | 'smartphone'
   | 'file'
   | 'diff';
 
@@ -259,6 +260,12 @@ const paths: Record<IconName, JSX.Element> = {
       <circle cx="12" cy="12" r="9" />
       <path d="M3 12h18" />
       <path d="M12 3a14 14 0 0 1 0 18 14 14 0 0 1 0-18z" />
+    </>
+  ),
+  smartphone: (
+    <>
+      <rect x="5" y="2" width="14" height="20" rx="2" ry="2" />
+      <path d="M12 18h.01" />
     </>
   ),
   file: (


### PR DESCRIPTION
## Why

Two issues with the desktop mobile gateway:

1. **It auto-started on every launch.** The boot path resumed the persisted `mobileGatewayEnabled` preference, so the bridge + E2E proxy tunnel came up unprompted every time (the repeating `e2e shim listening` / `proxy relay` log lines).
2. **Pairing went "unresponsive until you regenerate the code."** `shutdown()` closed only the raw WS server and never tore down the E2E proxy tunnel, so the relay kept a **stale registration** for the key-derived URL. The next launch's tunnel collided with the dead one, and only rotating the token (which re-opens the tunnel) recovered it.

Also: the gateway is a stateful, on-demand service, so it belongs at the top level rather than buried in a Settings tab.

## What

**Sidebar move**
- New top-level **Mobile** view in the sidebar, directly above **Settings** (both rendered via a shared `NavItem` row so they stay identical). Added a `smartphone` glyph to `@moxxy/desktop-ui`.
- New `MobilePanel` wraps the existing pairing UI (`MobileTab`/`useMobileGateway`) as a standalone view. It is **not** runner-locked — the gateway lifecycle lives in the main process.
- `'mobile'` is now a `View`; `ViewSwitcher` treats it like Settings (no active pill). Removed the Mobile tab from `SettingsPanel`.

**On-demand only**
- Removed the boot-time `resume()`. The gateway stays **off on every launch** and is enabled explicitly per session. The env power-user path (`MOXXY_WS_BRIDGE=1`) is unchanged. The pairing token + identity are still persisted, so re-enabling reuses the same QR without re-pairing.

**Clean teardown on quit**
- `shutdown()` now stops the gateway *through the manager* (`mobileGateway.stop()`), closing the proxy tunnel + shim + server so the relay deregisters this machine.

## Verification
- `pnpm build` 73/73 · `pnpm typecheck` (renderer + electron-main) · desktop tests 391/391 · desktop-host 514/514 · `eslint` 0 errors · `check:deps` 0 errors.
- Confirmed `.env` does not set `MOXXY_WS_BRIDGE`, so the auto-start was solely the persisted-pref resume.

## Notes
- `MobileGatewayManager.resume()` + `readEnabledPref` are retained (and still unit-tested) but no longer wired at boot — kept as a capability for a possible future opt-in "remember across restarts" toggle.