### PR TITLE
fix(desktop): erase session logs on workspace removal so deletes survive restart

### DIFF
--- a/.changeset/desk-remove-erases-session-logs.md
+++ b/.changeset/desk-remove-erases-session-logs.md
@@ -1,0 +1,17 @@
+---
+"@moxxy/desktop-host": patch
+---
+
+Desktop: removing a workspace now actually sticks across a restart.
+
+Deleting a desk tore down its runners and dropped it from the registry, but never
+erased the underlying session logs in `~/.moxxy/sessions/`. On the next launch
+`syncSessionIndexIntoRegistry()` re-imports every session whose sidecar still has
+a first prompt and a live cwd, so the "deleted" workspace's conversations
+resurrected (routed by cwd to another desk, or the Moxxy fallback) and piled up
+orphan logs.
+
+`desks.remove` now erases each removed session's on-disk log via `deleteSession`
+after stopping its runner — the same ordering and best-effort guard the
+single-session `sessions.remove` path already used — so a removed workspace stays
+removed. (Single-session deletes were already correct.)

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -1085,6 +1085,24 @@ channel end to end (QR pairing → chat → ask round-trip). The production mobi
   prompt before registering, workspace-registry ignores empty/stale sidecars and falls back to a
   safe managed cwd when a session cwd has disappeared, and desktop runner spawn errors are surfaced
   as controlled reconnect phases instead of uncaught main-process exceptions.
+- **Retired (2026-06-23): removing a desktop workspace didn't survive a restart.** Because the
+  on-disk session logs (`~/.moxxy/sessions/*.{jsonl,meta.json}`) are a SECOND source of truth that
+  `syncSessionIndexIntoRegistry()` re-imports on every launch, a delete that only updates
+  `desks.json` resurrects on the next boot. `sessions.remove` already erased the logs via
+  `deleteSession`, but `desks.remove` only tore down the runners — so a removed workspace's
+  conversations were re-imported (routed by cwd to another desk, or the Moxxy fallback). `desks.remove`
+  now erases each removed session's log after stopping its runner (same ordering/guard as
+  `sessions.remove`). `packages/desktop-host/src/ipc/desks.ts`.
+- **[low, hygiene] No GC for orphan session logs.** `~/.moxxy/sessions/` only shrinks when a session
+  is explicitly deleted; CLI/TUI sessions and any pre-fix orphans accumulate forever (a real machine
+  showed 57 sidecars vs 11 referenced by `desks.json`). `readIndex` already drops sidecars whose
+  `.jsonl` is gone, but nothing prunes the logs themselves. A periodic/age-based sweep (or a
+  "delete on registry eviction" pass) would bound the directory. `packages/core/src/sessions/persistence.ts`.
+- **[low, correctness] `WorkspaceRegistry.load()` doesn't dedupe sessions by id.** A legacy-corrupted
+  `desks.json` can hold the same session id many times under one desk (observed: one id ×5);
+  `normalizeSessions`/`hydrateLegacySessionNames` map but never collapse duplicates, so the corruption
+  persists across loads (delete still works — `removeSession` filters all copies). A de-dup-by-id pass
+  in `normalizeSessions` would self-heal these on next load. `packages/workspace-registry/src/index.ts`.
 
 ## 2026-06-10 round-2 audit intake — mobile gateway
 

--- a/packages/desktop-host/src/ipc/desks.test.ts
+++ b/packages/desktop-host/src/ipc/desks.test.ts
@@ -1,0 +1,154 @@
+/**
+ * desks.* handler tests — same seam as sessions.test.ts: the registrar is
+ * wired onto a fake CommandBus with a recording RunnerPool stand-in and a REAL
+ * DeskStore on a tmp file. The load-bearing case here is that removing a desk
+ * ERASES every one of its sessions' on-disk runner logs — otherwise the next
+ * launch's syncSessionIndexIntoRegistry() re-imports them and the workspace
+ * resurrects (the "delete doesn't survive restart" bug).
+ */
+
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { mkdirSync, mkdtempSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// shared.ts (the `handle` choke point) transitively touches electron;
+// importing it must not require the GUI binary. Same stub as sessions.test.ts
+// (pickFolder's dialog/BrowserWindow are never invoked from these tests).
+vi.mock('electron', () => ({ ipcMain: { handle: () => undefined } }));
+
+// The handler erases each removed desk's persisted session logs via @moxxy/core
+// — record the calls instead of touching ~/.moxxy. The derived-title pass
+// (session-titles.ts) reads meta sidecars from defaultSessionsDir(); point it
+// at a directory that doesn't exist so every stored name passes through.
+const deleteSessionMock = vi.fn(async (_id: string) => {});
+const coreMockState = vi.hoisted(() => ({
+  sessionTitlesDir: '/nonexistent-session-titles-dir',
+}));
+vi.mock('@moxxy/core', () => ({
+  deleteSession: (id: string) => deleteSessionMock(id),
+  defaultSessionsDir: () => coreMockState.sessionTitlesDir,
+  readSessionIndex: async () => [],
+}));
+
+import type { CommandBus } from '@moxxy/desktop-ipc-contract/bus';
+import type { IpcCommandName } from '@moxxy/desktop-ipc-contract';
+import { DeskStore } from '../desks';
+import type { RunnerPool } from '../runner-pool';
+import { setActiveBus } from './shared';
+import { registerDesksHandlers } from './desks';
+
+type Handler = (...args: unknown[]) => Promise<unknown>;
+
+function fakeBus(): { bus: CommandBus; handlers: Map<string, Handler> } {
+  const handlers = new Map<string, Handler>();
+  const bus = {
+    handle: (channel: IpcCommandName, fn: Handler) => {
+      handlers.set(channel, fn);
+    },
+  } as unknown as CommandBus;
+  return { bus, handlers };
+}
+
+interface PoolCall {
+  readonly op: 'getOrCreate' | 'setActive' | 'remove';
+  readonly id: string;
+  readonly cwd?: string | null;
+}
+
+function fakePool(): { pool: RunnerPool; calls: PoolCall[] } {
+  const calls: PoolCall[] = [];
+  const known = new Set<string>();
+  const pool = {
+    getOrCreate: async (id: string, cwd: string | null) => {
+      calls.push({ op: 'getOrCreate', id, cwd });
+      known.add(id);
+      return {} as never;
+    },
+    setActive: (id: string) => {
+      calls.push({ op: 'setActive', id });
+      if (!known.has(id)) throw new Error(`RunnerPool.setActive: unknown workspace ${id}`);
+    },
+    remove: async (id: string) => {
+      calls.push({ op: 'remove', id });
+      known.delete(id);
+    },
+    activeWorkspaceId: () => null,
+  } as unknown as RunnerPool;
+  return { pool, calls };
+}
+
+let desks: DeskStore;
+let handlers: Map<string, Handler>;
+let calls: PoolCall[];
+let cwdA: string;
+let cwdB: string;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  const tmp = mkdtempSync(path.join(os.tmpdir(), 'desks-ipc-'));
+  coreMockState.sessionTitlesDir = path.join(tmp, 'session-titles');
+  mkdirSync(coreMockState.sessionTitlesDir, { recursive: true });
+  cwdA = path.join(tmp, 'a');
+  cwdB = path.join(tmp, 'b');
+  mkdirSync(cwdA, { recursive: true });
+  mkdirSync(cwdB, { recursive: true });
+  desks = new DeskStore(path.join(tmp, 'desks.json'));
+  const { bus, handlers: h } = fakeBus();
+  const { pool, calls: c } = fakePool();
+  handlers = h;
+  calls = c;
+  setActiveBus(bus);
+  registerDesksHandlers(pool, desks);
+});
+
+const invoke = (channel: string, args?: unknown): Promise<unknown> =>
+  handlers.get(channel)!(args);
+
+describe('desks.* handlers', () => {
+  it('registers the full command set', () => {
+    expect([...handlers.keys()].sort()).toEqual([
+      'desks.create',
+      'desks.list',
+      'desks.pickFolder',
+      'desks.remove',
+      'desks.rename',
+      'desks.setActive',
+    ]);
+  });
+
+  it('remove erases the on-disk runner log of EVERY session in the desk', async () => {
+    const desk = await desks.create({ name: 'A', cwd: cwdA });
+    // A desk can hold several conversations; add a second so we prove the erase
+    // covers all of them, not just the first.
+    const { session: second } = await desks.createSession(desk.id);
+
+    await invoke('desks.remove', { id: desk.id });
+
+    // Both runners torn down...
+    expect(calls).toContainEqual({ op: 'remove', id: desk.id });
+    expect(calls).toContainEqual({ op: 'remove', id: second.id });
+    // ...and both on-disk logs erased, so syncSessionIndexIntoRegistry() can't
+    // resurrect them on the next launch.
+    expect(deleteSessionMock).toHaveBeenCalledWith(desk.id);
+    expect(deleteSessionMock).toHaveBeenCalledWith(second.id);
+    // The desk is gone from the persisted registry.
+    expect((await desks.list()).some((d) => d.id === desk.id)).toBe(false);
+  });
+
+  it('remove foregrounds the next desk and never erases its sessions', async () => {
+    const a = await desks.create({ name: 'A', cwd: cwdA });
+    const b = await desks.create({ name: 'B', cwd: cwdB });
+    await desks.setActive(a.id);
+    calls.length = 0;
+    deleteSessionMock.mockClear();
+
+    await invoke('desks.remove', { id: a.id });
+
+    // Surviving desk B's session is spun up to keep a live chat surface...
+    expect(calls).toContainEqual({ op: 'getOrCreate', id: b.id, cwd: cwdB });
+    // ...and never had its log erased.
+    expect(deleteSessionMock).not.toHaveBeenCalledWith(b.id);
+    expect(deleteSessionMock).toHaveBeenCalledWith(a.id);
+  });
+});

--- a/packages/desktop-host/src/ipc/desks.ts
+++ b/packages/desktop-host/src/ipc/desks.ts
@@ -10,6 +10,8 @@
 
 import { dialog, BrowserWindow as BrowserWindowApi } from 'electron';
 
+import { deleteSession } from '@moxxy/core';
+
 import type { RunnerPool } from '../runner-pool';
 import { cwdForSession, type DeskStore } from '../desks';
 import { broadcastHostEvent } from '../event-bus';
@@ -34,10 +36,22 @@ export function registerDesksHandlers(pool: RunnerPool, desks: DeskStore): void 
   });
   handle('desks.remove', async ({ id }) => {
     // The pool is keyed by SESSION id (a desk can hold several), so tear down
-    // every one of the removed desk's session runners — not just one entry.
+    // every one of the removed desk's session runners — not just one entry —
+    // then ERASE each session's on-disk runner log. Without the erase, the next
+    // launch's syncSessionIndexIntoRegistry() re-imports every session whose
+    // sidecar still has a first prompt + live cwd, so a "deleted" workspace's
+    // conversations resurrect (routed by cwd to another desk, or the Moxxy
+    // fallback) and the removal never sticks. Stop the runner FIRST so the dying
+    // child can't re-flush its meta sidecar after we delete it — same ordering
+    // and best-effort guard as sessions.remove.
     const removed = await desks.remove(id);
     for (const session of removed?.sessions ?? []) {
       await pool.remove(session.id);
+      try {
+        await deleteSession(session.id);
+      } catch {
+        // Best-effort: a missing log just means there was nothing to clear.
+      }
     }
     // Defensive: also drop a pool entry keyed by the bare desk id (the
     // pre-multi-session key; normally identical to the first session's id).


### PR DESCRIPTION
## What

Removing a workspace (desk) on desktop now actually sticks across an app restart. `desks.remove` erases each removed session's on-disk runner log (`~/.moxxy/sessions/<id>.{jsonl,meta.json}`) via `deleteSession`, after stopping its runner.

## Why

There are two sources of truth that get reconciled at boot:

1. `~/.moxxy/desktop/desks.json` — the workspace/session registry (what delete updated).
2. `~/.moxxy/sessions/<id>.{jsonl,meta.json}` — the runner's per-session conversation logs.

At every launch, `main/index.ts` calls `syncSessionIndexIntoRegistry()`, which **re-imports into `desks.json` any session log whose sidecar still has a first prompt and a still-existing `cwd`.**

- The single-session delete handler (`sessions.remove`) was already correct — it calls `deleteSession(id)` after the runner exits, so the log is gone before the next boot's re-import.
- The **desk delete handler (`desks.remove`) tore down the runners but never erased the logs.** So a removed workspace's conversations were re-imported on the next launch (routed by cwd to another desk, or the Moxxy fallback) — the "deleted" workspace came back, and orphan logs piled up. A live machine showed 57 meta sidecars vs. only 11 referenced by `desks.json`, plus a desk with one session id duplicated 5×.

The fix mirrors the established pattern in `sessions.remove` and `runner-supervisor.resetSession`: stop the runner first (so the dying child can't re-flush its sidecar after we delete it), then erase the log with a best-effort guard.

## Verification

- `pnpm build` / `typecheck` / `test` / `lint` / `check:deps` — green (0 errors; remaining lint/dep warnings are pre-existing, in files this PR doesn't touch).
  - Note: a repo-wide `turbo run test` showed flaky failures in 4 unrelated packages (`tools-builtin`, `client-platform-web`, `isolator-subprocess`, `plugin-stt-whisper-codex`) from test oversubscription on a fresh worktree install; all pass when run individually. None depend on `@moxxy/desktop-host`.
- New `packages/desktop-host/src/ipc/desks.test.ts` (3 tests): asserts `desks.remove` erases the log of **every** session in a multi-session desk, tears down their runners, drops the desk from the registry, and never erases a surviving desk's sessions while foregrounding it.
- All 90 `desktop-host` IPC handler tests pass.

## Follow-ups (logged in TECH_DEBT.md, not in scope here)

- No GC for orphan session logs — `~/.moxxy/sessions/` only shrinks on explicit delete; CLI/TUI sessions and pre-fix orphans accumulate.
- `WorkspaceRegistry.load()` doesn't dedupe sessions by id, so a legacy-corrupted `desks.json` keeps duplicate session ids across loads (delete still removes all copies). A de-dup pass in `normalizeSessions` would self-heal these.