### PR TITLE
feat(workflows): add an `echo` step for deterministic output (no agent turn)

### DIFF
--- a/.changeset/workflow-echo-node.md
+++ b/.changeset/workflow-echo-node.md
@@ -1,0 +1,13 @@
+---
+"@moxxy/sdk": minor
+"@moxxy/plugin-workflows": minor
+---
+
+Add an `echo` workflow step — deterministic output with no agent turn.
+
+`echo` renders a template (`{{ steps.<id>.output }}`, `{{ vars.* }}`,
+`{{ inputs.* }}`, `{{ now }}`) and uses it verbatim as the step's output, without
+spawning a child agent. Use it for pure formatting/delivery steps (e.g. emit an
+already-written digest) where a `prompt` step would burn a model call and could
+re-interpret or loop on the content. The workflow drafter now prefers `echo` over
+a `prompt` for pass-through/delivery steps.

--- a/packages/plugin-workflows/src/draft.ts
+++ b/packages/plugin-workflows/src/draft.ts
@@ -47,7 +47,8 @@ A workflow is a DAG of steps. Schema:
 - steps: array of steps, each with:
     - id: slug, unique
     - label: short human title (match the user's language when possible)
-    - EXACTLY ONE action: skill | prompt | tool | workflow | bridge | condition | switch | loop
+    - EXACTLY ONE action: skill | prompt | tool | workflow | echo | bridge | condition | switch | loop
+    - echo: a template string rendered VERBATIM as the step output — NO agent turn. Use it for pure formatting/delivery steps (e.g. emit an already-written result with \`echo: "{{ steps.write_x.output }}"\`). PREFER echo over a prompt step when the step only needs to pass through / format existing content — a prompt step there burns a model call and can re-interpret or loop on the content.
     - bridge: instruction — logic step; agent returns JSON with vars (extract/transform data); optional format: plain
     - condition: instruction + then: [step ids] + else: [step ids] — agent returns JSON branch then|else
     - switch: instruction + cases: { <caseId>: [step ids], ... } + optional default: [step ids] — agent returns JSON branch matching a case id

--- a/packages/plugin-workflows/src/executor/dag.test.ts
+++ b/packages/plugin-workflows/src/executor/dag.test.ts
@@ -155,6 +155,26 @@ describe('dag executor', () => {
     expect(result.output).toBe('OUT_analyze'); // sink
   });
 
+  it('echo renders its template verbatim with NO agent turn', async () => {
+    const h = makeHarness();
+    const result = await dagExecutor.run(
+      wf({
+        name: 'echo',
+        description: 'x',
+        steps: [
+          { id: 'write', prompt: 'go' },
+          { id: 'deliver', needs: ['write'], echo: 'Final: {{ steps.write.output }}' },
+        ],
+      }),
+      h.deps,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe('Final: OUT_write'); // sink = rendered template
+    // The echo step must NOT spawn a child agent — only the prompt step did.
+    expect(h.specs.map((s) => s.label)).toEqual(['write']);
+    expect(h.order).not.toContain('deliver');
+  });
+
   it('fans out in parallel and fans back in', async () => {
     const h = makeHarness();
     const result = await dagExecutor.run(

--- a/packages/plugin-workflows/src/executor/steps.ts
+++ b/packages/plugin-workflows/src/executor/steps.ts
@@ -67,6 +67,13 @@ async function runStepOnce(
     return runLogicStep(step, scope, ctx, opts);
   }
 
+  if (step.echo != null) {
+    // Deterministic output: render the template and use it verbatim — no agent
+    // turn. Lets a workflow format/deliver an already-produced result without
+    // burning a model call or risking the model re-interpreting/looping on it.
+    return { ok: true, output: renderTemplate(step.echo, scope, opts) };
+  }
+
   if (step.tool) {
     const args = renderArgs(step.args ?? {}, scope, opts);
     const result = await deps.tools.execute(step.tool, args, deps.signal);

--- a/packages/plugin-workflows/src/schema.ts
+++ b/packages/plugin-workflows/src/schema.ts
@@ -15,6 +15,7 @@ const ACTION_KEYS = [
   'prompt',
   'tool',
   'workflow',
+  'echo',
   'bridge',
   'condition',
   'switch',
@@ -42,6 +43,7 @@ const stepSchema = z
     prompt: z.string().min(1).optional(),
     tool: z.string().min(1).optional(),
     workflow: z.string().min(1).optional(),
+    echo: z.string().min(1).optional(),
     bridge: z.string().min(1).optional(),
     condition: z.string().min(1).optional(),
     then: z.array(z.string().min(1)).optional(),
@@ -71,7 +73,10 @@ const stepSchema = z
     // mid-iteration (see the loop-body refinement below). Reject it elsewhere so
     // the author picks a supported action rather than hitting a runtime failure.
     const isLogic = step.bridge != null || step.condition != null || step.switch != null;
-    if (step.awaitInput && (step.tool != null || step.workflow != null || step.loop != null || isLogic)) {
+    if (
+      step.awaitInput &&
+      (step.tool != null || step.workflow != null || step.echo != null || step.loop != null || isLogic)
+    ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: `step "${step.id}": awaitInput is only allowed on prompt or skill steps`,

--- a/packages/sdk/src/workflow.ts
+++ b/packages/sdk/src/workflow.ts
@@ -68,6 +68,14 @@ export interface WorkflowStep {
   readonly prompt?: string;
   readonly tool?: string;
   readonly workflow?: string;
+  /**
+   * Deterministic output: render this template (with `{{ vars.* }}`,
+   * `{{ steps.<id>.output }}`, `{{ inputs.* }}`, `{{ now }}`) and use it verbatim
+   * as the step's output — NO agent turn. Use it for pure formatting/delivery
+   * steps (e.g. emit an already-written digest) where a `prompt` step would burn
+   * a model call and risk re-interpreting/looping on the content.
+   */
+  readonly echo?: string;
   /** Extract/transform upstream data into `vars` (and optional `text`). */
   readonly bridge?: string;
   /** If/else gate: agent returns `{"branch":"then"|"else"}`. */


### PR DESCRIPTION
## What

Adds an `echo` workflow step kind: it renders a template
(`{{ steps.<id>.output }}`, `{{ vars.* }}`, `{{ inputs.* }}`, `{{ now }}`) and uses
the result **verbatim as the step's output, with no child-agent turn**.

## Why

Today the only way to produce a step's output is to run an agent (`prompt`/`skill`)
or a `tool`. A common final step — "deliver / format this already-produced result"
— is written as a `prompt`, which burns a model call and, worse, lets the model
**re-interpret or loop** on the content. (A real digest workflow's `final_delivery`
`prompt` step that just re-emitted `{{ steps.write_digest.output }}` looped.)

`echo` is the deterministic complement to `prompt`: free, instant, and it passes the
content through unchanged.

```yaml
- id: deliver
  needs: [write_digest]
  echo: "{{ steps.write_digest.output }}"
```

## How

- **`@moxxy/sdk`** — `WorkflowStep.echo?: string`.
- **`@moxxy/plugin-workflows`** — `echo` added to the action kinds + zod schema
  (counts toward exactly-one-action; `awaitInput` rejected like other non-agent
  kinds); the executor renders the template via the existing `renderTemplate` and
  returns it (no `spawner.spawn`). The drafter prompt now prefers `echo` over a
  `prompt` for pass-through/delivery steps so generated workflows stop using a
  model call (and risking a loop) for plain output.

## Verification

- `pnpm build` (73) / `test` (sdk 281, plugin-workflows 125) / `lint` (0 errors) — green.
- New executor test: an `echo` step renders `Final: {{ steps.write.output }}` →
  `Final: OUT_write` as the sink output, and asserts it spawned **no** child agent.