### PR TITLE
feat(mobile): Stop button for the whole turn (cancel a running agent/workflow)

### DIFF
--- a/.changeset/mobile-stop-button.md
+++ b/.changeset/mobile-stop-button.md
@@ -1,0 +1,12 @@
+---
+"@moxxy/workspaces-app": patch
+---
+
+Mobile: show a Stop button for the whole turn so a running agent/workflow can be cancelled.
+
+The composer's primary action only became Stop during the brief send round-trip
+(`sending`), so once the agent moved into a long thinking/tool/subagent run the
+button flipped back to Send and there was no way to cancel from the phone. It now
+follows the whole turn (`activeTurnId !== null || sending`) — matching desktop —
+and presses through to the existing `abort()` (which already cancels spawned
+subagents via the parent turn signal).

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -190,6 +190,7 @@ function Chat() {
             text={composer.text}
             inputResetKey={composer.inputResetKey}
             sending={chat.sending}
+            running={chat.activeTurnId !== null || chat.sending}
             compacting={chat.compacting}
             autoApprove={autoApprove.enabled}
             readOnly={session.readOnly}

--- a/apps/mobile/src/components/ChatComposer.tsx
+++ b/apps/mobile/src/components/ChatComposer.tsx
@@ -11,6 +11,9 @@ interface ChatComposerProps {
   readonly text: string;
   readonly inputResetKey: number;
   readonly sending: boolean;
+  /** Whether a turn is in flight (agent working), so the button becomes Stop for
+   *  the whole run — not just the brief send round-trip. */
+  readonly running: boolean;
   readonly compacting: boolean;
   readonly autoApprove: boolean;
   readonly readOnly?: boolean;
@@ -32,6 +35,7 @@ export function ChatComposer(props: ChatComposerProps) {
   const ui = buildComposerUiState({
     text: props.text,
     sending: props.sending,
+    running: props.running,
     compacting: props.compacting,
     actionsOpen: false,
     autoApprove: props.autoApprove,
@@ -39,7 +43,7 @@ export function ChatComposer(props: ChatComposerProps) {
     voicePhase: props.voicePhase,
     readOnly: props.readOnly,
   });
-  const canPressSend = props.sending || ui.canSubmit;
+  const canPressSend = props.running || ui.canSubmit;
   const recording = ui.voiceTone === 'recording';
   const transcribing = props.voicePhase === 'transcribing';
   const placeholder = transcribing
@@ -104,11 +108,11 @@ export function ChatComposer(props: ChatComposerProps) {
           )}
 
           <Pressable
-            accessibilityLabel={props.sending ? 'Stop response' : 'Send message'}
+            accessibilityLabel={props.running ? 'Stop response' : 'Send message'}
             accessibilityRole="button"
             disabled={!canPressSend}
             hitSlop={6}
-            onPress={props.sending ? props.onAbort : props.onSubmit}
+            onPress={props.running ? props.onAbort : props.onSubmit}
             style={sx('items-center justify-center rounded-full', { backgroundColor: sendBackground, height: 38, marginLeft: 2, width: 38 })}
           >
             <MobileIcon name={ui.sendIcon} size={ui.sendIcon === 'send' ? 19 : 15} strokeWidth={2.6} color={sendIconColor} />

--- a/apps/mobile/src/composerUi.ts
+++ b/apps/mobile/src/composerUi.ts
@@ -1,6 +1,13 @@
 export interface ComposerUiInput {
   readonly text: string;
   readonly sending: boolean;
+  /**
+   * A turn is in flight (the agent is working — thinking, running tools or
+   * subagents), not just the brief send round-trip (`sending`). Drives the
+   * stop/abort affordance for the WHOLE turn so a long run can be cancelled.
+   * Defaults to `sending` when omitted.
+   */
+  readonly running?: boolean;
   readonly compacting: boolean;
   readonly actionsOpen: boolean;
   readonly autoApprove: boolean;
@@ -27,6 +34,10 @@ export function buildComposerUiState(input: ComposerUiInput): ComposerUiState {
   const voicePhase = input.voicePhase ?? 'idle';
   const disabled = input.compacting || input.readOnly === true || voicePhase === 'transcribing';
   const canSubmit = (input.text.trim().length > 0 || (input.attachmentCount ?? 0) > 0) && !disabled;
+  // The stop affordance follows the WHOLE turn (`running`), not just the brief
+  // send round-trip (`sending`) — so a long thinking/tool/subagent run stays
+  // cancellable. Falls back to `sending` for callers that don't pass `running`.
+  const running = input.running ?? input.sending;
   return {
     placeholder: input.readOnly
       ? 'Archived session - select the live session to send.'
@@ -35,8 +46,8 @@ export function buildComposerUiState(input: ComposerUiInput): ComposerUiState {
         : 'Send a message to the agent...',
     canSubmit,
     disabled,
-    sendIcon: input.sending ? 'stop' : 'send',
-    sendTone: input.sending ? 'danger' : canSubmit ? 'primary' : 'disabled',
+    sendIcon: running ? 'stop' : 'send',
+    sendTone: running ? 'danger' : canSubmit ? 'primary' : 'disabled',
     actionsTone: input.actionsOpen || input.autoApprove ? 'active' : 'neutral',
     frameTone: input.autoApprove ? 'bypass' : 'neutral',
     bypassActive: input.autoApprove,

--- a/apps/mobile/test/mobile-composer-ui.test.ts
+++ b/apps/mobile/test/mobile-composer-ui.test.ts
@@ -62,6 +62,32 @@ describe('mobile composer ui model', () => {
     });
   });
 
+  it('shows Stop for the whole turn (running) — not just the brief send round-trip', () => {
+    // The send round-trip is over (`sending: false`) but the agent is still
+    // working (`running: true`): the button must stay Stop so a long
+    // thinking/tool/subagent run can be cancelled.
+    expect(buildComposerUiState({
+      text: '',
+      sending: false,
+      running: true,
+      compacting: false,
+      actionsOpen: false,
+      autoApprove: false,
+    })).toMatchObject({
+      sendIcon: 'stop',
+      sendTone: 'danger',
+    });
+    // No turn in flight → back to Send.
+    expect(buildComposerUiState({
+      text: 'next',
+      sending: false,
+      running: false,
+      compacting: false,
+      actionsOpen: false,
+      autoApprove: false,
+    })).toMatchObject({ sendIcon: 'send', sendTone: 'primary' });
+  });
+
   it('shows recording and transcribing feedback while voice input is active', () => {
     expect(buildComposerUiState({
       text: '',


### PR DESCRIPTION
## What

The mobile composer now shows a **Stop** button for the entire duration of a turn, so a long-running agent/workflow can be cancelled from the phone.

## Why

The composer's primary action only became Stop during the brief send round-trip (`sending`). Once the agent moved into a long thinking / tool / subagent run, `sending` went back to `false` and the button flipped to **Send** — leaving no way to cancel from mobile (you'd be stuck watching "thinking…"). Desktop already gates its stop button on the whole turn (`Composer.tsx`: `inFlight = activeTurnId !== null || sending`); this brings mobile to parity.

## How

- `buildComposerUiState` gains an optional `running` input (falls back to `sending`); the Stop icon/tone now follow `running`.
- `ChatComposer` takes a `running` prop and gates the Stop affordance (icon, tone, press handler, a11y label, press-enabled) on it.
- `app/index.tsx` passes `running={chat.activeTurnId !== null || chat.sending}`.
- The press routes to the existing `abort()` → `session.abortTurn`, which already cancels spawned subagents/workflow steps via the parent turn's `AbortSignal` (`run-child.ts`: `signal: parentSignal`).

## Verification

- `pnpm build` (73) / `typecheck` / `test` (mobile 213) / `lint` (0 errors) — green.
- Added a `buildComposerUiState` test: `running: true` while `sending: false` → `sendIcon: 'stop'`/`sendTone: 'danger'`; `running: false` → back to Send.

## Note

This covers cancelling the **in-chat** agent/workflow turn (what the screenshots showed). Cancelling a **detached background workflow run** (`workflows.run` from the Workflows tab) is a separate, larger feature — there is currently no `workflows.cancel` at all (no run-tracking / IPC / runner-protocol method), so it needs its own design + PR.