### PR TITLE
feat(webhooks): multi-tenant delivery routing + tunnel auto-restore

### DIFF
--- a/.changeset/multitenant-webhooks.md
+++ b/.changeset/multitenant-webhooks.md
@@ -1,0 +1,16 @@
+---
+"@moxxy/cli": minor
+---
+
+Make webhook deliveries multi-tenant across concurrent runner processes, and auto-restore the proxy tunnel on boot.
+
+The webhook listener binds a single shared port, so with several runners (the desktop runs one `moxxy serve` per workspace) ONE runner received every delivery and fired it on **its own** session — a webhook created in workspace A's chat would fire in whatever workspace happened to win the port, or not reach A at all. And the proxy tunnel only ever lived in memory, so after a restart the saved public URL pointed at nothing (GitHub showed "We couldn't deliver this payload: timed out").
+
+Now:
+
+- Webhook triggers carry an optional `ownerSessionId`; `webhook_create` stamps it with the creating runner's `MOXXY_SESSION_ID`.
+- The runner that owns the listener routes each verified, filtered delivery: a trigger owned by **another** runner is handed off via a shared on-disk queue (`~/.moxxy/webhooks/queue/`); owner-less or own triggers fire in-process as before.
+- Every runner runs a drain poller that fires the queued deliveries addressed to **its** session — so the digest lands in the workspace that created the webhook. Deliveries for an offline workspace wait durably until it returns (with a 7-day stale sweep).
+- The runner that wins the listener bind **re-opens the proxy tunnel on boot** when the saved public URL came from the proxy, so "the app is running" once again means "the webhook URL is reachable." Only that one runner restores it, so the N runners don't collide on the single keypair-derived relay subdomain.
+
+Single-process CLI/TUI behavior is unchanged (no `MOXXY_SESSION_ID` → every delivery fires in-process, no queue/drain).

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -190,9 +190,18 @@ function buildWebhooksSlice(
   // to runTurn via the supplied runner. Agent-facing tools (webhook_create,
   // webhook_tunnel_start, webhook_setup_guide, …) let a non-technical user walk
   // through tunnel + provider setup in conversation.
+  //
+  // ownerSessionId binds triggers created here to THIS runner. With several
+  // runners (one `moxxy serve` per desktop workspace), only one wins the shared
+  // listener port, so it receives every delivery and hands off the ones owned by
+  // other runners through the shared queue; each runner drains and fires its own.
+  // The desktop sets MOXXY_SESSION_ID per workspace; a single-process CLI/TUI
+  // leaves it unset and fires every delivery in-process (no queue/drain).
+  const ownerSessionId = process.env.MOXXY_SESSION_ID?.trim() || undefined;
   const { plugin, store, config, stop } = buildWebhooksPlugin({
     runner: webhookRunner,
     logger,
+    ...(ownerSessionId ? { ownerSessionId } : {}),
   });
   return { entry: { name: '@moxxy/plugin-webhooks', plugin }, store, config, stop };
 }

--- a/packages/plugin-webhooks/src/drain.test.ts
+++ b/packages/plugin-webhooks/src/drain.test.ts
@@ -1,0 +1,85 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { WebhookDrainPoller } from './drain.js';
+import { WebhookDeliveryQueue } from './queue.js';
+import { WebhookDispatcher } from './runner.js';
+import { WebhookStore, type WebhookTrigger } from './store.js';
+
+describe('WebhookDrainPoller', () => {
+  let dir: string;
+  let store: WebhookStore;
+  let queue: WebhookDeliveryQueue;
+  let trigger: WebhookTrigger;
+  let calls: string[];
+  let dispatcher: WebhookDispatcher;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'moxxy-wh-drain-'));
+    store = new WebhookStore({ file: path.join(dir, 'webhooks.json') });
+    queue = new WebhookDeliveryQueue(path.join(dir, 'queue'));
+    trigger = await store.create({
+      name: 'gh',
+      prompt: 'p',
+      allowedTools: [],
+      verification: { type: 'none' },
+      ownerSessionId: 'runner-A',
+    });
+    calls = [];
+    dispatcher = new WebhookDispatcher({
+      store,
+      runner: {
+        runPrompt: async ({ prompt }) => {
+          calls.push(prompt);
+          return { text: 'ok' };
+        },
+      },
+      inbox: { dir: path.join(dir, 'inbox') },
+    });
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('fires only the records addressed to this runner, and removes them', async () => {
+    await queue.enqueue({
+      triggerId: trigger.id,
+      triggerName: trigger.name,
+      ownerSessionId: 'runner-A',
+      prompt: 'mine',
+      deliveryId: 'a1',
+    });
+    await queue.enqueue({
+      triggerId: trigger.id,
+      triggerName: trigger.name,
+      ownerSessionId: 'runner-B',
+      prompt: 'not mine',
+      deliveryId: 'b1',
+    });
+
+    const drain = new WebhookDrainPoller({ queue, store, dispatcher, ownerSessionId: 'runner-A' });
+    const fired = await drain.tickOnce();
+
+    expect(fired).toBe(1);
+    expect(calls).toEqual(['mine']);
+    // A's record is consumed; B's stays for B's own drain.
+    expect(await queue.listOwned('runner-A')).toHaveLength(0);
+    expect(await queue.listOwned('runner-B')).toHaveLength(1);
+  });
+
+  it('drops a queued delivery whose trigger has been deleted (no fire)', async () => {
+    await queue.enqueue({
+      triggerId: 'gone',
+      triggerName: 'gh',
+      ownerSessionId: 'runner-A',
+      prompt: 'orphan',
+      deliveryId: 'a1',
+    });
+    const drain = new WebhookDrainPoller({ queue, store, dispatcher, ownerSessionId: 'runner-A' });
+    const fired = await drain.tickOnce();
+    expect(fired).toBe(0);
+    expect(calls).toEqual([]);
+    expect(await queue.listOwned('runner-A')).toHaveLength(0);
+  });
+});

--- a/packages/plugin-webhooks/src/drain.ts
+++ b/packages/plugin-webhooks/src/drain.ts
@@ -1,0 +1,119 @@
+import type { WebhookDeliveryQueue } from './queue.js';
+import type { WebhookDispatcher } from './runner.js';
+import type { WebhookStore } from './store.js';
+
+/**
+ * Drains this runner's queued webhook deliveries.
+ *
+ * The listener runs in only ONE runner (whoever bound the shared port); when a
+ * delivery's trigger is owned by a DIFFERENT runner, that listener enqueues it.
+ * Every runner runs one of these pollers, draining only the records addressed to
+ * its own `ownerSessionId` and firing them in-process — so the prompt lands in
+ * the workspace that created the webhook. Ticks are serialized (a long fire
+ * never overlaps the next tick), and a fired record is removed AFTER the attempt
+ * (a duplicate on a mid-fire crash beats a lost delivery; removing post-attempt
+ * stops a hard failure from looping).
+ */
+export interface WebhookDrainPollerOptions {
+  readonly queue: WebhookDeliveryQueue;
+  readonly store: WebhookStore;
+  readonly dispatcher: WebhookDispatcher;
+  /** This runner's identity; only records addressed to it are drained. */
+  readonly ownerSessionId: string;
+  /** Poll cadence in ms. Default 1500ms. Minimum 250ms. */
+  readonly intervalMs?: number;
+  /** Records older than this are swept regardless of owner. Default 7 days. */
+  readonly staleMs?: number;
+  readonly logger?: {
+    info?(msg: string, meta?: Record<string, unknown>): void;
+    warn?(msg: string, meta?: Record<string, unknown>): void;
+  };
+}
+
+const DEFAULT_STALE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export class WebhookDrainPoller {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private running = false;
+  private chain: Promise<void> = Promise.resolve();
+  private readonly intervalMs: number;
+  private readonly staleMs: number;
+
+  constructor(private readonly opts: WebhookDrainPollerOptions) {
+    this.intervalMs = Math.max(250, opts.intervalMs ?? 1_500);
+    this.staleMs = opts.staleMs ?? DEFAULT_STALE_MS;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.running = true;
+    // Drain immediately on start so deliveries that queued while this runner was
+    // down fire as soon as it's back.
+    this.chain = this.drain().then(
+      () => undefined,
+      () => undefined,
+    );
+    this.timer = setInterval(() => {
+      this.chain = this.chain.then(() => this.tick()).catch(() => undefined);
+    }, this.intervalMs);
+    this.timer.unref?.();
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    await this.chain.catch(() => undefined);
+  }
+
+  /** Drain now, ignoring the cadence; returns how many deliveries were fired. */
+  async tickOnce(): Promise<number> {
+    let fired = 0;
+    this.chain = this.chain.then(async () => {
+      fired = await this.drain();
+    });
+    await this.chain.catch(() => undefined);
+    return fired;
+  }
+
+  private async tick(): Promise<void> {
+    if (!this.running) return;
+    await this.drain();
+  }
+
+  private async drain(): Promise<number> {
+    let records;
+    try {
+      records = await this.opts.queue.listOwned(this.opts.ownerSessionId);
+    } catch (err) {
+      this.opts.logger?.warn?.('webhooks: queue read failed', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return 0;
+    }
+    let fired = 0;
+    for (const rec of records) {
+      const trigger = await this.opts.store.get(rec.triggerId);
+      if (!trigger) {
+        // The trigger was deleted after the delivery queued — drop it.
+        await this.opts.queue.remove(rec.id);
+        continue;
+      }
+      try {
+        await this.opts.dispatcher.fire(trigger, rec.prompt, rec.deliveryId);
+        fired += 1;
+      } catch (err) {
+        this.opts.logger?.warn?.('webhooks: drained delivery failed', {
+          trigger: trigger.name,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        await this.opts.queue.remove(rec.id);
+      }
+    }
+    await this.opts.queue.sweepStale(this.staleMs).catch(() => undefined);
+    return fired;
+  }
+}

--- a/packages/plugin-webhooks/src/index.ts
+++ b/packages/plugin-webhooks/src/index.ts
@@ -16,7 +16,14 @@ import {
   type WebhookFireOutcome,
   type WebhookPromptResult,
   type WebhookPromptRunner,
+  type WebhookRouteOutcome,
 } from './runner.js';
+import {
+  defaultWebhookQueueDir,
+  WebhookDeliveryQueue,
+  type QueuedDelivery,
+} from './queue.js';
+import { WebhookDrainPoller, type WebhookDrainPollerOptions } from './drain.js';
 import {
   WebhookServer,
   type WebhookServerHandle,
@@ -66,9 +73,12 @@ export {
   // Runtime
   WebhookDispatcher,
   WebhookServer,
+  WebhookDeliveryQueue,
+  WebhookDrainPoller,
   DeliveryDedupeCache,
   RateLimiter,
   defaultWebhookInboxDir,
+  defaultWebhookQueueDir,
   // Verification + templating
   verifyDelivery,
   idempotencyKey,
@@ -89,8 +99,11 @@ export {
   type WebhookStoreLogger,
   type WebhookStoreOptions,
   type WebhookDispatcherOptions,
+  type WebhookRouteOutcome,
   type WebhookServerOptions,
   type WebhookServerHandle,
+  type WebhookDrainPollerOptions,
+  type QueuedDelivery,
   type WebhookPromptRunner,
   type WebhookPromptResult,
   type WebhookFireOutcome,
@@ -132,6 +145,28 @@ export interface BuildWebhooksPluginOptions {
    * a non-loopback bind).
    */
   readonly ratePerSec?: number;
+  /**
+   * This runner's session identity (`MOXXY_SESSION_ID`). With several runners
+   * sharing the listener port, this is how a delivery reaches the runner that
+   * created the trigger: deliveries for triggers owned by ANOTHER runner are
+   * handed off via the shared queue, and a per-runner drain poller fires the
+   * records addressed to THIS id. Undefined → single-process behavior (every
+   * delivery fires in-process, no queue/drain).
+   */
+  readonly ownerSessionId?: string;
+  /** Shared delivery queue. Defaults to one at `~/.moxxy/webhooks/queue/`. */
+  readonly queue?: WebhookDeliveryQueue;
+  /** Drain poll cadence in ms (multi-runner only). Default 1500ms. */
+  readonly drainIntervalMs?: number;
+  /**
+   * Re-open the proxy tunnel on boot when the stored public URL came from the
+   * proxy (`publicUrlSource: 'proxy'`). Default true. The tunnel only lives in
+   * memory, so without this a restart leaves the saved URL pointing at nothing —
+   * the GitHub-side "delivery timed out" symptom. Only the runner that wins the
+   * listener bind restores it (so the N runners don't collide on the one relay
+   * subdomain). Set false to keep the legacy manual-only behavior (tests).
+   */
+  readonly restoreTunnelOnBoot?: boolean;
 }
 
 export interface BuiltWebhooksPlugin {
@@ -166,9 +201,12 @@ export interface BuiltWebhooksPlugin {
 export function buildWebhooksPlugin(opts: BuildWebhooksPluginOptions): BuiltWebhooksPlugin {
   const store = opts.store ?? new WebhookStore(opts.logger ? { logger: opts.logger } : {});
   const config = opts.config ?? new WebhookConfigStore();
+  const queue = opts.queue ?? new WebhookDeliveryQueue();
   const dispatcher = new WebhookDispatcher({
     store,
     runner: opts.runner,
+    queue,
+    ...(opts.ownerSessionId !== undefined ? { ownerSessionId: opts.ownerSessionId } : {}),
     ...(opts.inbox ? { inbox: opts.inbox } : {}),
     ...(opts.logger ? { logger: opts.logger } : {}),
     ...(opts.onFired ? { onFired: opts.onFired } : {}),
@@ -177,8 +215,27 @@ export function buildWebhooksPlugin(opts: BuildWebhooksPluginOptions): BuiltWebh
   const tunnelHandle: { current: RunningTunnel | null } = { current: null };
   let serverInstance: WebhookServer | null = null;
   let serverHandle: WebhookServerHandle | null = null;
+  // A runner only drains deliveries addressed to its own session id, so the
+  // drain poller only exists in the multi-runner case (an owner id is set).
+  // Single-process CLI fires every delivery in-process — nothing to drain.
+  const drain: WebhookDrainPoller | null = opts.ownerSessionId
+    ? new WebhookDrainPoller({
+        queue,
+        store,
+        dispatcher,
+        ownerSessionId: opts.ownerSessionId,
+        ...(opts.drainIntervalMs !== undefined ? { intervalMs: opts.drainIntervalMs } : {}),
+        ...(opts.logger ? { logger: opts.logger } : {}),
+      })
+    : null;
 
-  const tools = buildWebhookTools({ store, config, dispatcher, tunnelHandle });
+  const tools = buildWebhookTools({
+    store,
+    config,
+    dispatcher,
+    tunnelHandle,
+    ...(opts.ownerSessionId !== undefined ? { ownerSessionId: opts.ownerSessionId } : {}),
+  });
 
   const plugin = definePlugin({
     name: '@moxxy/plugin-webhooks',
@@ -228,9 +285,10 @@ export function buildWebhooksPlugin(opts: BuildWebhooksPluginOptions): BuiltWebh
         try {
           serverHandle = await serverInstance.start();
         } catch (err) {
-          // Port in use is the most common failure — log and let other
-          // plugins keep working. The agent can surface the issue via
-          // webhook_status (listener will show as down).
+          // Port in use is the most common failure — and the EXPECTED one for
+          // every runner except the one that wins the shared listener port. Log
+          // and carry on: this runner still drains its own handed-off deliveries
+          // below. The agent can surface a genuine failure via webhook_status.
           opts.logger?.warn?.('webhooks: listener failed to start', {
             err: err instanceof Error ? err.message : String(err),
             host,
@@ -238,12 +296,44 @@ export function buildWebhooksPlugin(opts: BuildWebhooksPluginOptions): BuiltWebh
           });
           serverInstance = null;
         }
+
+        // The drain poller runs in EVERY runner: the runners that did NOT win the
+        // listener port are exactly the ones that own triggers whose deliveries
+        // arrive at the winner and get handed off here for them to fire.
+        drain?.start();
+
+        // Only the runner that won the listener bind owns the public edge, so
+        // only it (re)opens the proxy tunnel — otherwise the N runners would all
+        // dial the relay under the one keypair-derived subdomain and fight over
+        // it. Restoring on boot is what fixes the "saved URL but delivery times
+        // out" symptom after a restart (the tunnel only ever lived in memory).
+        if (
+          serverHandle &&
+          opts.restoreTunnelOnBoot !== false &&
+          !tunnelHandle.current &&
+          cfg.publicUrl &&
+          cfg.publicUrlSource === 'proxy'
+        ) {
+          void startTunnel({ host, port })
+            .then((t) => {
+              tunnelHandle.current = t;
+              opts.logger?.info?.('webhooks: proxy tunnel restored on boot', { url: t.url });
+            })
+            .catch((err) =>
+              opts.logger?.warn?.('webhooks: proxy tunnel restore failed', {
+                err: err instanceof Error ? err.message : String(err),
+              }),
+            );
+        }
       },
       onShutdown: () => stopAll(),
     },
   });
 
   async function stopAll(): Promise<void> {
+    if (drain) {
+      try { await drain.stop(); } catch { /* ignore */ }
+    }
     if (serverInstance) {
       try { await serverInstance.stop(); } catch { /* ignore */ }
       serverInstance = null;

--- a/packages/plugin-webhooks/src/queue.test.ts
+++ b/packages/plugin-webhooks/src/queue.test.ts
@@ -1,0 +1,80 @@
+import { mkdtemp, rm, readdir, stat, utimes } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { WebhookDeliveryQueue } from './queue.js';
+
+describe('WebhookDeliveryQueue', () => {
+  let dir: string;
+  let queue: WebhookDeliveryQueue;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'moxxy-wh-queue-'));
+    queue = new WebhookDeliveryQueue(dir);
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const rec = (over: Partial<Parameters<WebhookDeliveryQueue['enqueue']>[0]> = {}) => ({
+    triggerId: 't1',
+    triggerName: 'gh',
+    ownerSessionId: 'runner-A',
+    prompt: 'digest please',
+    deliveryId: null,
+    ...over,
+  });
+
+  it('enqueues and lists only records for the requested owner', async () => {
+    await queue.enqueue(rec({ ownerSessionId: 'runner-A', deliveryId: 'a1' }));
+    await queue.enqueue(rec({ ownerSessionId: 'runner-B', deliveryId: 'b1' }));
+    await queue.enqueue(rec({ ownerSessionId: 'runner-A', deliveryId: 'a2' }));
+
+    const a = await queue.listOwned('runner-A');
+    expect(a.map((r) => r.deliveryId).sort()).toEqual(['a1', 'a2']);
+    const b = await queue.listOwned('runner-B');
+    expect(b.map((r) => r.deliveryId)).toEqual(['b1']);
+  });
+
+  it('uses the deliveryId as the record id so a provider retry overwrites (no dupes)', async () => {
+    await queue.enqueue(rec({ deliveryId: 'dup' }));
+    await queue.enqueue(rec({ deliveryId: 'dup', prompt: 'newer' }));
+    const owned = await queue.listOwned('runner-A');
+    expect(owned).toHaveLength(1);
+    expect(owned[0]!.prompt).toBe('newer');
+  });
+
+  it('remove drops a drained record', async () => {
+    const id = await queue.enqueue(rec({ deliveryId: 'x' }));
+    expect(await queue.listOwned('runner-A')).toHaveLength(1);
+    await queue.remove(id);
+    expect(await queue.listOwned('runner-A')).toHaveLength(0);
+  });
+
+  it('listOwned returns oldest-first and skips corrupt files', async () => {
+    await queue.enqueue(rec({ deliveryId: 'old', enqueuedAt: 1000 }));
+    await queue.enqueue(rec({ deliveryId: 'new', enqueuedAt: 2000 }));
+    // A stray non-JSON file in the dir must not break the drain.
+    await rm(path.join(dir, 'garbage.json'), { force: true });
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(path.join(dir, 'garbage.json'), 'not json', 'utf8');
+    const owned = await queue.listOwned('runner-A');
+    expect(owned.map((r) => r.deliveryId)).toEqual(['old', 'new']);
+  });
+
+  it('sweepStale removes records older than the max age', async () => {
+    const id = await queue.enqueue(rec({ deliveryId: 'stale' }));
+    await queue.enqueue(rec({ deliveryId: 'fresh' }));
+    // Backdate the "stale" record's mtime by 10 days.
+    const tenDaysAgo = Date.now() - 10 * 24 * 60 * 60 * 1000;
+    const file = path.join(dir, `${id}.json`);
+    await utimes(file, new Date(tenDaysAgo), new Date(tenDaysAgo));
+
+    const removed = await queue.sweepStale(7 * 24 * 60 * 60 * 1000);
+    expect(removed).toBe(1);
+    const remaining = (await readdir(dir)).filter((n) => n.endsWith('.json'));
+    expect(remaining).toEqual(['fresh.json']);
+    // keep the lints happy about the unused import in some toolchains
+    expect((await stat(path.join(dir, 'fresh.json'))).isFile()).toBe(true);
+  });
+});

--- a/packages/plugin-webhooks/src/queue.ts
+++ b/packages/plugin-webhooks/src/queue.ts
@@ -1,0 +1,127 @@
+import { readdir, readFile, stat, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
+import { ulid } from 'ulid';
+
+/**
+ * Shared on-disk hand-off queue for webhook deliveries.
+ *
+ * The listener binds a single port, so ONE runner process receives every
+ * delivery — but a trigger created in another workspace must fire on THAT
+ * workspace's runner (its chat). When the receiving runner isn't the trigger's
+ * owner, it drops a delivery record here; the owning runner's drain poller picks
+ * up its own records and fires them. The queue is a plain directory of atomic
+ * JSON files under `~/.moxxy/webhooks/queue/`, one per delivery — same
+ * file-store discipline as the rest of the framework, and durable so a delivery
+ * for a currently-offline workspace waits until that runner comes back.
+ */
+
+export interface QueuedDelivery {
+  /** Queue record id (the filename stem). */
+  readonly id: string;
+  readonly triggerId: string;
+  readonly triggerName: string;
+  /** The runner this delivery must fire on (the trigger's `ownerSessionId`). */
+  readonly ownerSessionId: string;
+  /** The fully-rendered prompt — it embeds the request body/headers, which are
+   *  NOT re-derivable from the trigger alone, so it must travel with the record. */
+  readonly prompt: string;
+  /** Idempotency key from the delivery headers, if any (for the fire's dedupe). */
+  readonly deliveryId: string | null;
+  readonly enqueuedAt: number;
+}
+
+export function defaultWebhookQueueDir(): string {
+  return moxxyPath('webhooks', 'queue');
+}
+
+function safeId(id: string): string {
+  return id.replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+export class WebhookDeliveryQueue {
+  constructor(private readonly dir: string = defaultWebhookQueueDir()) {}
+
+  /** Persist a delivery for its owner to drain. Returns the record id. */
+  async enqueue(
+    rec: Omit<QueuedDelivery, 'id' | 'enqueuedAt'> & { readonly enqueuedAt?: number },
+  ): Promise<string> {
+    // Prefer the delivery id (unique per delivery) so a provider's retry of the
+    // SAME delivery overwrites rather than enqueuing a duplicate; fall back to a
+    // ulid when there's no idempotency header.
+    const id = rec.deliveryId ? safeId(rec.deliveryId) : ulid();
+    const record: QueuedDelivery = {
+      id,
+      triggerId: rec.triggerId,
+      triggerName: rec.triggerName,
+      ownerSessionId: rec.ownerSessionId,
+      prompt: rec.prompt,
+      deliveryId: rec.deliveryId,
+      enqueuedAt: rec.enqueuedAt ?? Date.now(),
+    };
+    await writeFileAtomic(path.join(this.dir, `${id}.json`), JSON.stringify(record));
+    return id;
+  }
+
+  /** Every queued delivery for `ownerSessionId`, oldest first. Corrupt records
+   *  are skipped (not thrown), so one bad file never stalls the drain. */
+  async listOwned(ownerSessionId: string): Promise<QueuedDelivery[]> {
+    let names: string[];
+    try {
+      names = await readdir(this.dir);
+    } catch {
+      return [];
+    }
+    const out: QueuedDelivery[] = [];
+    for (const name of names) {
+      if (!name.endsWith('.json')) continue;
+      try {
+        const raw = await readFile(path.join(this.dir, name), 'utf8');
+        const rec = JSON.parse(raw) as QueuedDelivery;
+        if (rec && typeof rec === 'object' && rec.ownerSessionId === ownerSessionId) out.push(rec);
+      } catch {
+        // corrupt/partial/racing-unlink — skip.
+      }
+    }
+    out.sort((a, b) => a.enqueuedAt - b.enqueuedAt);
+    return out;
+  }
+
+  /** Remove one drained record. Best-effort. */
+  async remove(id: string): Promise<void> {
+    try {
+      await unlink(path.join(this.dir, `${safeId(id)}.json`));
+    } catch {
+      // already gone — fine.
+    }
+  }
+
+  /**
+   * Drop records older than `maxAgeMs` regardless of owner — covers deliveries
+   * addressed to a runner that never came back (a deleted workspace). Returns
+   * the count removed; best-effort.
+   */
+  async sweepStale(maxAgeMs: number, now: number = Date.now()): Promise<number> {
+    let names: string[];
+    try {
+      names = await readdir(this.dir);
+    } catch {
+      return 0;
+    }
+    let removed = 0;
+    for (const name of names) {
+      if (!name.endsWith('.json')) continue;
+      const file = path.join(this.dir, name);
+      try {
+        const st = await stat(file);
+        if (now - st.mtimeMs > maxAgeMs) {
+          await unlink(file);
+          removed += 1;
+        }
+      } catch {
+        // racing unlink / unreadable — skip.
+      }
+    }
+    return removed;
+  }
+}

--- a/packages/plugin-webhooks/src/runner.test.ts
+++ b/packages/plugin-webhooks/src/runner.test.ts
@@ -90,3 +90,82 @@ describe('WebhookDispatcher inbox filenames (burst uniqueness)', () => {
     expect(files).toHaveLength(1);
   });
 });
+
+describe('WebhookDispatcher.route (multi-runner hand-off)', () => {
+  let dir: string;
+  let store: WebhookStore;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'moxxy-wh-route-'));
+    store = noopStore(path.join(dir, 'webhooks.json'));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  function ownedTrigger(owner: string | undefined): Promise<WebhookTrigger> {
+    return store.create({
+      name: 'gh',
+      prompt: 'x',
+      allowedTools: [],
+      verification: { type: 'none' },
+      ...(owner !== undefined ? { ownerSessionId: owner } : {}),
+    });
+  }
+
+  it('hands a delivery owned by ANOTHER runner to the queue instead of firing', async () => {
+    const calls: string[] = [];
+    const { WebhookDeliveryQueue } = await import('./queue.js');
+    const queue = new WebhookDeliveryQueue(path.join(dir, 'queue'));
+    const dispatcher = new WebhookDispatcher({
+      store,
+      runner: { runPrompt: async ({ prompt }) => { calls.push(prompt); return { text: 'ok' }; } },
+      inbox: { dir: path.join(dir, 'inbox') },
+      ownerSessionId: 'runner-A',
+      queue,
+    });
+    const trigger = await ownedTrigger('runner-B');
+
+    const out = await dispatcher.route(trigger, 'for B', 'd1');
+    expect(out).toEqual({ handled: 'enqueued', ownerSessionId: 'runner-B' });
+    expect(calls).toEqual([]); // did NOT fire here
+    expect(await queue.listOwned('runner-B')).toHaveLength(1);
+  });
+
+  it('fires in-process when this runner owns the trigger', async () => {
+    const calls: string[] = [];
+    const { WebhookDeliveryQueue } = await import('./queue.js');
+    const queue = new WebhookDeliveryQueue(path.join(dir, 'queue'));
+    const dispatcher = new WebhookDispatcher({
+      store,
+      runner: { runPrompt: async ({ prompt }) => { calls.push(prompt); return { text: 'ok' }; } },
+      inbox: { dir: path.join(dir, 'inbox') },
+      ownerSessionId: 'runner-A',
+      queue,
+    });
+    const trigger = await ownedTrigger('runner-A');
+
+    const out = await dispatcher.route(trigger, 'mine', 'd1');
+    expect(out.handled).toBe('fired');
+    expect(calls).toEqual(['mine']);
+    expect(await queue.listOwned('runner-A')).toHaveLength(0);
+  });
+
+  it('fires in-process for an owner-less trigger (single-process / global)', async () => {
+    const calls: string[] = [];
+    const { WebhookDeliveryQueue } = await import('./queue.js');
+    const queue = new WebhookDeliveryQueue(path.join(dir, 'queue'));
+    const dispatcher = new WebhookDispatcher({
+      store,
+      runner: { runPrompt: async ({ prompt }) => { calls.push(prompt); return { text: 'ok' }; } },
+      inbox: { dir: path.join(dir, 'inbox') },
+      ownerSessionId: 'runner-A',
+      queue,
+    });
+    const trigger = await ownedTrigger(undefined);
+
+    const out = await dispatcher.route(trigger, 'global', 'd1');
+    expect(out.handled).toBe('fired');
+    expect(calls).toEqual(['global']);
+  });
+});

--- a/packages/plugin-webhooks/src/runner.ts
+++ b/packages/plugin-webhooks/src/runner.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
+import type { WebhookDeliveryQueue } from './queue.js';
 import type { WebhookStore, WebhookTrigger } from './store.js';
 
 /**
@@ -90,7 +91,24 @@ export interface WebhookDispatcherOptions {
   /** Optional hook fired after each delivery — channels use this to
    *  push a "your webhook fired" notification to the user. */
   readonly onFired?: (trigger: WebhookTrigger, outcome: WebhookFireOutcome) => void;
+  /**
+   * This runner's session identity (`MOXXY_SESSION_ID`), or undefined for a
+   * single-process CLI. {@link route} uses it to decide whether a delivery
+   * belongs to THIS runner (fire in-process) or another (hand off via the
+   * queue).
+   */
+  readonly ownerSessionId?: string;
+  /**
+   * Shared hand-off queue. Required for cross-runner routing in {@link route};
+   * without it, every delivery fires in-process (the single-process behavior).
+   */
+  readonly queue?: WebhookDeliveryQueue;
 }
+
+/** Outcome of {@link WebhookDispatcher.route}: either fired here, or handed off. */
+export type WebhookRouteOutcome =
+  | { readonly handled: 'fired'; readonly outcome: WebhookFireOutcome }
+  | { readonly handled: 'enqueued'; readonly ownerSessionId: string };
 
 /**
  * Runs prompts in response to verified webhook deliveries. Decoupled
@@ -100,6 +118,40 @@ export interface WebhookDispatcherOptions {
  */
 export class WebhookDispatcher {
   constructor(private readonly opts: WebhookDispatcherOptions) {}
+
+  /**
+   * Decide where a verified, filtered delivery runs, then act:
+   *  - owned by ANOTHER runner (and a queue is wired) → enqueue it for that
+   *    runner's drain to fire, so the prompt lands in the chat that created the
+   *    trigger rather than on whichever runner happens to own the listener port;
+   *  - owner-less, or owned by THIS runner → {@link fire} it in-process.
+   *
+   * This is the entry point the HTTP listener calls; {@link fire} stays the
+   * in-process executor (used here, by the drain poller, and by `webhook_test`).
+   */
+  async route(
+    trigger: WebhookTrigger,
+    prompt: string,
+    deliveryId: string | null,
+  ): Promise<WebhookRouteOutcome> {
+    const owner = trigger.ownerSessionId;
+    if (this.opts.queue && owner && owner !== this.opts.ownerSessionId) {
+      await this.opts.queue.enqueue({
+        triggerId: trigger.id,
+        triggerName: trigger.name,
+        ownerSessionId: owner,
+        prompt,
+        deliveryId,
+      });
+      this.opts.logger?.info?.('webhooks: delivery handed off to owner runner', {
+        trigger: trigger.name,
+        owner,
+      });
+      return { handled: 'enqueued', ownerSessionId: owner };
+    }
+    const outcome = await this.fire(trigger, prompt, deliveryId);
+    return { handled: 'fired', outcome };
+  }
 
   async fire(
     trigger: WebhookTrigger,

--- a/packages/plugin-webhooks/src/server.ts
+++ b/packages/plugin-webhooks/src/server.ts
@@ -238,7 +238,14 @@ export class WebhookServer {
       firedAt: new Date(),
     });
 
-    // Fire-and-forget. Errors are logged inside the dispatcher.
-    void this.opts.dispatcher.fire(trigger, prompt, idempKey);
+    // Fire-and-forget. `route` fires in-process when this runner owns the
+    // trigger (or it's owner-less), and otherwise hands the delivery to the
+    // owning runner via the shared queue. Errors are logged inside the dispatcher.
+    void this.opts.dispatcher.route(trigger, prompt, idempKey).catch((err) => {
+      this.opts.logger?.warn?.('webhooks: route failed', {
+        trigger: trigger.name,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    });
   }
 }

--- a/packages/plugin-webhooks/src/store.ts
+++ b/packages/plugin-webhooks/src/store.ts
@@ -138,6 +138,17 @@ export const webhookTriggerSchema = z.object({
   idempotencyHeader: z.string().optional(),
   /** Free-form note shown in `webhook_list`. */
   description: z.string().optional(),
+  /**
+   * The session that created this trigger (the creating runner's
+   * `MOXXY_SESSION_ID`). The webhook listener binds a single shared port, so
+   * one runner process receives EVERY delivery — but the prompt must fire on the
+   * runner whose chat asked for the webhook. This is the routing key: a delivery
+   * for a trigger owned by another runner is handed off to that runner (via the
+   * shared delivery queue) instead of firing on whoever received the HTTP
+   * request. Unset for a single-process CLI (no `MOXXY_SESSION_ID`) — those fire
+   * in-process as before.
+   */
+  ownerSessionId: z.string().optional(),
   enabled: z.boolean().default(true),
   createdAt: z.number().int(),
   lastFiredAt: z.number().int().optional(),

--- a/packages/plugin-webhooks/src/tools/create.ts
+++ b/packages/plugin-webhooks/src/tools/create.ts
@@ -70,6 +70,9 @@ export function defineWebhookCreateTool(deps: ResolvedToolDeps): ToolDef {
         filters,
         ...(input.idempotencyHeader ? { idempotencyHeader: input.idempotencyHeader } : {}),
         ...(input.description ? { description: input.description } : {}),
+        // Bind to the creating runner so its deliveries fire on this workspace's
+        // chat, even though another runner may own the shared listener port.
+        ...(deps.ownerSessionId !== undefined ? { ownerSessionId: deps.ownerSessionId } : {}),
       });
 
       const cfg = await config.get();

--- a/packages/plugin-webhooks/src/tools/index.ts
+++ b/packages/plugin-webhooks/src/tools/index.ts
@@ -31,6 +31,7 @@ export function buildWebhookTools(deps: WebhooksToolDeps): ReadonlyArray<ToolDef
     dispatcher: deps.dispatcher,
     tunnelHandle: deps.tunnelHandle,
     secretsDir: deps.secretsDir ?? defaultWebhookSecretsDir(),
+    ...(deps.ownerSessionId !== undefined ? { ownerSessionId: deps.ownerSessionId } : {}),
   };
 
   return [

--- a/packages/plugin-webhooks/src/tools/shared.ts
+++ b/packages/plugin-webhooks/src/tools/shared.ts
@@ -31,6 +31,13 @@ export interface WebhooksToolDeps {
    * user. Override — primarily for tests. Default: `~/.moxxy/webhooks-secrets/`.
    */
   readonly secretsDir?: string;
+  /**
+   * This runner's session identity (`MOXXY_SESSION_ID`). Stamped onto triggers
+   * created via `webhook_create` so their deliveries fire on the runner whose
+   * chat asked for the webhook, even though a different runner may own the shared
+   * listener port. Undefined for a single-process CLI.
+   */
+  readonly ownerSessionId?: string;
 }
 
 /** Per-tool factories receive the resolved deps (secretsDir defaulted). */
@@ -40,6 +47,8 @@ export interface ResolvedToolDeps {
   readonly dispatcher: WebhookDispatcher;
   readonly tunnelHandle: { current: RunningTunnel | null };
   readonly secretsDir: string;
+  /** See {@link WebhooksToolDeps.ownerSessionId}. */
+  readonly ownerSessionId?: string;
 }
 
 /** Owner-only directory where generated webhook secrets are written for the user. */


### PR DESCRIPTION
Companion to #330 (scheduler/workflows multi-tenancy); independent — reviewable/mergeable on its own.

## Problem
The webhook listener binds a **single shared port**, so with several runners (the desktop spawns one `moxxy serve` per workspace) **one** runner receives every delivery and fires it on **its own** session — a webhook created in workspace A fires wherever the port was won, not in A, so "set a webhook here" didn't route here and two webhooks on two workspaces couldn't both work. Separately, the proxy tunnel lived only in memory, so after a restart the saved public URL pointed at nothing → GitHub's **"We couldn't deliver this payload: timed out"** (the original report).

## Fix
- Triggers carry an optional `ownerSessionId`; `webhook_create` stamps it from the creating runner's `MOXXY_SESSION_ID`.
- The listener-owning runner **routes** each verified+filtered delivery (`WebhookDispatcher.route`): a trigger owned by **another** runner is handed off via a shared on-disk queue (`~/.moxxy/webhooks/queue/`); owner-less/own triggers fire in-process as before.
- Every runner runs a **drain poller** that fires the queued deliveries addressed to **its** session — so the digest lands in the workspace that created the webhook. A delivery for an offline workspace waits durably until it returns (7-day stale sweep). Drain ticks are serialized; a record is removed after the attempt (a duplicate on a mid-fire crash beats a lost delivery).
- **Tunnel auto-restore on boot:** the runner that wins the listener bind re-opens the proxy tunnel when the saved URL came from the proxy (`publicUrlSource: 'proxy'`) — fixing the post-restart timeout — and only that one does, so the N runners don't collide on the single keypair-derived relay subdomain.

So: 6 runners + a webhook set in workspace A → the winner receives the POST, hands it to A, A fires it in its chat. Two webhooks on two workspaces both route to their owners. A restart no longer strands the URL.

Single-process CLI/TUI behavior is unchanged (no `MOXXY_SESSION_ID` → fire in-process, no queue/drain).

## Tests
- `queue.test.ts` — enqueue/list-by-owner, delivery-id dedup, remove, oldest-first + corrupt-file skip, stale sweep.
- `runner.test.ts` — `route` hands off another runner's delivery to the queue (doesn't fire); fires own + owner-less in-process.
- `drain.test.ts` — fires only this runner's records and removes them; leaves other owners'; drops deliveries whose trigger was deleted.
- Full existing webhook suite still green (100 tests), incl. the listener path.

Gate green: build 73/73, typecheck 143/143, lint 0 errors, tests pass, deps 0 errors.

## Not covered (follow-up)
Multi-process packaged-desktop end-to-end with a live relay isn't exercisable in CI; the routing/queue/drain logic is unit-tested and the standalone CLI path builds/runs. A manual multi-workspace smoke is the remaining verification.