### PR TITLE
fix(desktop): backfill chat history when the runner connects

### DIFF
--- a/.changeset/chat-history-backfill-on-connect.md
+++ b/.changeset/chat-history-backfill-on-connect.md
@@ -1,0 +1,17 @@
+---
+"@moxxy/client-core": patch
+---
+
+Fix: opening a workspace/session showed the empty "Ready when you are" state on
+the first click and only loaded the conversation on a second click.
+
+The first open of a workspace races the runner spawn: `chat.loadHistory` returns
+`null` because no runner is attached yet, so `loadInitial` leaves the slot
+unloaded for a retry. But the renderer attaches with `replay:'none'` (history is
+pulled, never pushed), so nothing re-triggered the load once the runner reached
+`connected` — the transcript stayed empty until the user re-opened the workspace.
+
+`useChat` now re-runs the history load when the workspace's runner transitions to
+`connected` (via the per-workspace connection store), so the transcript backfills
+automatically. Idempotent — the load is guarded by `slot.loaded`, so a later
+reconnect never re-pages.

--- a/packages/client-core/src/useChat.test.tsx
+++ b/packages/client-core/src/useChat.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * useChat integration test — the first open of a workspace usually races the
+ * runner spawn: `chat.loadHistory` returns null (no attached runner yet) and
+ * `loadInitial` leaves the slot retryable. Because the runner attaches with
+ * `replay:'none'`, nothing pushes history in — so the hook MUST re-run the load
+ * once the workspace's runner reaches `connected`. Without that the transcript
+ * stays empty until the user re-opens the workspace ("first click empty, second
+ * click loads"). Each test uses a unique workspace id so the module-level
+ * chat/connection singletons stay isolated.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ConnectionSnapshot, MoxxyApi } from '@moxxy/desktop-ipc-contract';
+import type { MoxxyEvent } from '@moxxy/sdk';
+import { __setApiOverride } from './transport.js';
+import { connectionStore } from './useConnection.js';
+import { chatStore } from './chatStore.js';
+import { createIpcPersistence } from './chatPersistence.js';
+import { useChat } from './useChat.js';
+
+let wsSeq = 0;
+function ws(): string {
+  wsSeq += 1;
+  return `ws-usechat-${wsSeq}`;
+}
+
+function userPrompt(text: string): MoxxyEvent {
+  return {
+    id: `e-${text}`,
+    seq: 1,
+    ts: 1,
+    turnId: 'T1',
+    sessionId: 'S',
+    source: 'user',
+    type: 'user_prompt',
+    text,
+  } as unknown as MoxxyEvent;
+}
+
+function connectedSnapshot(): ConnectionSnapshot {
+  return {
+    phase: {
+      phase: 'connected',
+      socket: '/tmp/sock',
+      sessionId: 'S',
+      activeProvider: null,
+      activeMode: null,
+    },
+    cliPath: null,
+    attempts: 0,
+    log: [],
+  };
+}
+
+afterEach(() => {
+  __setApiOverride(null);
+});
+
+describe('useChat history backfill on runner connect', () => {
+  it('re-loads history once the workspace runner reaches connected', async () => {
+    const id = ws();
+    // The runner is "not connected" until the test flips this — chat.loadHistory
+    // returns null in that window, exactly like the IPC handler with no attached
+    // supervisor.
+    const state = { connected: false };
+    let loadCalls = 0;
+    const invoke = (async (cmd: string) => {
+      if (cmd === 'chat.loadHistory') {
+        loadCalls += 1;
+        return state.connected ? { events: [userPrompt('hello')], prevCursor: null } : null;
+      }
+      return undefined;
+    }) as unknown as MoxxyApi['invoke'];
+    __setApiOverride({ invoke, subscribe: () => () => {} });
+    chatStore.setPersistence(createIpcPersistence());
+
+    const { result } = renderHook(() => useChat(id));
+
+    // First open races the spawn: the load runs, returns null, and the
+    // transcript shows empty (retryable — slot left unloaded).
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.isEmpty).toBe(true);
+    expect(result.current.events).toHaveLength(0);
+    const callsBeforeConnect = loadCalls;
+    expect(callsBeforeConnect).toBeGreaterThan(0);
+
+    // Runner attaches → connection.changed flips the workspace to connected.
+    act(() => {
+      state.connected = true;
+      connectionStore.setSnapshot(id, connectedSnapshot());
+    });
+
+    // The hook re-runs loadInitial and the transcript backfills — no re-open.
+    await waitFor(() => expect(result.current.events).toHaveLength(1));
+    expect(result.current.isEmpty).toBe(false);
+    expect(loadCalls).toBeGreaterThan(callsBeforeConnect);
+  });
+
+  it('does not re-page once a load has already succeeded (idempotent on reconnect)', async () => {
+    const id = ws();
+    let loadCalls = 0;
+    const invoke = (async (cmd: string) => {
+      if (cmd === 'chat.loadHistory') {
+        loadCalls += 1;
+        return { events: [userPrompt('hi')], prevCursor: null };
+      }
+      return undefined;
+    }) as unknown as MoxxyApi['invoke'];
+    __setApiOverride({ invoke, subscribe: () => () => {} });
+    chatStore.setPersistence(createIpcPersistence());
+
+    // Already connected at first open.
+    connectionStore.setSnapshot(id, connectedSnapshot());
+    const { result } = renderHook(() => useChat(id));
+
+    await waitFor(() => expect(result.current.events).toHaveLength(1));
+    const callsAfterLoad = loadCalls;
+
+    // A reconnect (connected → reconnecting → connected) must NOT re-page: the
+    // window is already loaded (slot.loaded guards re-entry).
+    act(() => {
+      connectionStore.setSnapshot(id, {
+        ...connectedSnapshot(),
+        phase: { phase: 'reconnecting', reason: 'drop', attempt: 1 },
+      });
+    });
+    act(() => {
+      connectionStore.setSnapshot(id, connectedSnapshot());
+    });
+    await waitFor(() => expect(result.current.events).toHaveLength(1));
+    expect(loadCalls).toBe(callsAfterLoad);
+  });
+});

--- a/packages/client-core/src/useChat.ts
+++ b/packages/client-core/src/useChat.ts
@@ -3,6 +3,7 @@ import { api, getTransportRevision, subscribeTransport } from './transport.js';
 import type { MoxxyEvent, UserPromptAttachment } from '@moxxy/sdk';
 import { chatStore, EMPTY_SNAPSHOT } from './chatStore.js';
 import { createIpcPersistence } from './chatPersistence.js';
+import { connectionStore } from './useConnection.js';
 import { wireAskBridge } from './askStore.js';
 import { toErrorMessage } from './errors.js';
 import { desksStore } from './useDesks.js';
@@ -213,11 +214,25 @@ export function useChat(workspaceId: string | null): UseChat {
     workspaceId ? chatStore.getChat(workspaceId) : EMPTY_SNAPSHOT,
   );
 
-  // Load the most-recent window from disk the first time this workspace
-  // is observed (idempotent — the store guards re-entry).
+  // Whether this workspace's runner has reached the `connected` phase. The
+  // history pull (`chat.loadHistory`) only succeeds once a runner is attached —
+  // before that the IPC returns null.
+  const runnerConnected = useSyncExternalStore(connectionStore.subscribe, () =>
+    workspaceId ? connectionStore.get(workspaceId)?.phase.phase === 'connected' : false,
+  );
+
+  // Load the most-recent window from the runner the first time this workspace is
+  // observed AND again once its runner reaches `connected`. The first open
+  // usually races the runner spawn: `chat.loadHistory` returns null (no attached
+  // runner yet), so `loadInitial` leaves the slot unloaded for a retry. The
+  // runner attaches with `replay:'none'`, so nothing pushes history in — without
+  // this re-run on connect the transcript stays empty until the user re-opens
+  // the workspace (the "first click shows empty, second click loads" bug).
+  // Idempotent: `loadInitial` bails once a load has succeeded (`slot.loaded`),
+  // so a later reconnect never re-pages.
   useEffect(() => {
     if (workspaceId) void chatStore.loadInitial(workspaceId);
-  }, [workspaceId]);
+  }, [workspaceId, runnerConnected]);
 
   const loadOlder = useCallback((): void => {
     if (workspaceId) void chatStore.loadOlder(workspaceId);


### PR DESCRIPTION
## What

Opening a workspace/session showed the empty **"Ready when you are"** state on the first click and only loaded the conversation on a second click.

`useChat` now re-runs the history load when the workspace's runner reaches the `connected` phase (observed via the per-workspace connection store), so the transcript backfills automatically — no second click. The re-run is idempotent: `loadInitial` bails once a load has succeeded (`slot.loaded`), so a later reconnect never re-pages.

## Why

The first-click empty state read "Ready when you are" — the `ready=true` variant — meaning the runner was already `connected` at render time, yet the transcript was empty. The load had silently given up:

1. Selecting a session changes `workspaceId` → `useChat`'s effect runs `loadInitial`.
2. The runner supervisor is still spawning/attaching, so the `chat.loadHistory` IPC resolves `supervisor.remote()` → `null` and returns `null`.
3. `loadInitial` sets `slot.loaded = false` ("retry on next open") and shows an empty transcript.
4. The runner finishes connecting, but the desktop attaches with **`replay:'none'`** (`runner-supervisor.ts`) — history is *pulled*, never *pushed*. Nothing re-ran `loadInitial`, so the transcript stayed empty until the user re-opened the workspace.

The store already anticipated this retry, but the only re-trigger was a `workspaceId` change. This wires the missing trigger: the runner reaching `connected`. The per-workspace connection store is used (not the active-only `shell.phase`) so it's also correct for background workspaces.

## Verification

- `pnpm build` (73/73), `typecheck` (143/143), `lint` (0 errors), `test` (168/168), `check:deps` (0 errors) — all green.
- New `useChat.test.tsx` (2 cases): transcript backfills when the runner flips to `connected` with no re-open; does **not** re-page on a `connected → reconnecting → connected` cycle.
- Manual: launching the packaged/dev desktop app and confirming a session loads on the first click.