### PR TITLE
fix(desktop): app failed to start after the Apps Webhooks panel (#338)

### DIFF
--- a/.changeset/fix-desktop-webhooks-lazy-import.md
+++ b/.changeset/fix-desktop-webhooks-lazy-import.md
@@ -1,0 +1,21 @@
+---
+"@moxxy/desktop-host": patch
+"@moxxy/desktop": patch
+---
+
+fix(desktop): app failed to start after the Apps Webhooks panel (#338)
+
+#338 registered the webhooks IPC with a static top-level
+`import … from '@moxxy/plugin-webhooks'` in `@moxxy/desktop-host`, which is
+bundled into the Electron main entry (`BUNDLED_WORKSPACE_DEPS`). That dragged
+the webhooks plugin's proxy/E2E stack and, transitively, `ulid` into the main
+entry's eager module graph, reordering ESM init so `ulid` initialised before
+electron-vite's injected `require` shim. `ulid` then threw "secure crypto
+unusable, insecure Math.random not allowed" at boot, so the updated bundle
+(0.23.0) load-errored and fell back to the floor — the identical regression the
+0.22.3 mobile-proxy fix addressed.
+
+Fix: defer the webhooks plugin to a lazy `import()` inside the IPC handlers
+(only the erased `import type` stays static), so the proxy/E2E stack + `ulid`
+load on the first `webhooks.*` call — post `app.whenReady`, out of the startup
+path. App startup is restored; the Webhooks panel is unchanged.

--- a/packages/desktop-host/src/ipc/webhooks.ts
+++ b/packages/desktop-host/src/ipc/webhooks.ts
@@ -1,8 +1,38 @@
 import type { WebhookSummary } from '@moxxy/desktop-ipc-contract';
-import { WebhookStore, describeTrigger, type WebhookTrigger } from '@moxxy/plugin-webhooks';
+// TYPE-ONLY import (fully erased): the runtime value import of
+// `@moxxy/plugin-webhooks` is deferred to a lazy `import()` below. A static
+// value import here would be fatal — `@moxxy/desktop-host` is bundled into the
+// Electron main entry (BUNDLED_WORKSPACE_DEPS), so a static import drags the
+// webhooks plugin's proxy/E2E stack and, transitively, `ulid` into the main
+// entry's eager module graph. `ulid` eager-initialises before electron-vite's
+// injected `require` shim and throws "secure crypto unusable, insecure
+// Math.random not allowed" at boot, so the app never starts (see the desktop
+// 0.22.3 changelog for the identical mobile-proxy regression + fix).
+import type { WebhookStore, WebhookTrigger } from '@moxxy/plugin-webhooks';
 import { handle } from './shared';
 
-const defaultStore = new WebhookStore();
+interface WebhooksModule {
+  readonly store: WebhookStore;
+  readonly describeTrigger: (
+    trigger: WebhookTrigger,
+    publicUrl: string | undefined,
+  ) => Record<string, unknown>;
+}
+
+// First webhooks.* invocation pays the dynamic import + opens the default store;
+// the result is cached for the rest of the session. Crucially this runs on a
+// COMMAND, long after `app.whenReady` — so `ulid` initialises in a normal,
+// shim-ready context instead of during boot.
+let cached: Promise<WebhooksModule> | null = null;
+function loadWebhooks(): Promise<WebhooksModule> {
+  if (!cached) {
+    cached = import('@moxxy/plugin-webhooks').then((m) => ({
+      store: new m.WebhookStore(),
+      describeTrigger: m.describeTrigger,
+    }));
+  }
+  return cached;
+}
 
 /**
  * Webhook trigger management for the desktop — mirrors the scheduler handlers.
@@ -14,21 +44,34 @@ const defaultStore = new WebhookStore();
  *
  * Host-only: these are deliberately NOT in REMOTE_ALLOWED_COMMANDS — a paired
  * phone can't toggle or delete inbound triggers.
+ *
+ * @param injectedStore Tests pass a temp-file store so they don't touch the
+ *  real `~/.moxxy/webhooks.json`; production lazy-loads the default store.
  */
-export function registerWebhookHandlers(store: WebhookStore = defaultStore): void {
+export function registerWebhookHandlers(injectedStore?: WebhookStore): void {
+  const get: () => Promise<WebhooksModule> = injectedStore
+    ? async () => ({
+        store: injectedStore,
+        describeTrigger: (await import('@moxxy/plugin-webhooks')).describeTrigger,
+      })
+    : loadWebhooks;
+
   handle('webhooks.list', async () => {
+    const { store, describeTrigger } = await get();
     store.invalidate();
     const triggers = await store.list();
-    return triggers.map(toWebhookSummary);
+    return triggers.map((t) => toWebhookSummary(t, describeTrigger));
   });
 
   handle('webhooks.setEnabled', async ({ id, enabled }) => {
+    const { store, describeTrigger } = await get();
     store.invalidate();
     const updated = await store.update(id, { enabled });
-    return updated ? toWebhookSummary(updated) : null;
+    return updated ? toWebhookSummary(updated, describeTrigger) : null;
   });
 
   handle('webhooks.delete', async ({ id }) => {
+    const { store } = await get();
     store.invalidate();
     return { deleted: await store.delete(id) };
   });
@@ -40,6 +83,9 @@ export function registerWebhookHandlers(store: WebhookStore = defaultStore): voi
  * public `url` and the always-present `localPath`, which is what the panel
  * shows. Secrets are stripped by `describeTrigger`/`redactVerification`.
  */
-function toWebhookSummary(trigger: WebhookTrigger): WebhookSummary {
+function toWebhookSummary(
+  trigger: WebhookTrigger,
+  describeTrigger: WebhooksModule['describeTrigger'],
+): WebhookSummary {
   return describeTrigger(trigger, undefined) as unknown as WebhookSummary;
 }


### PR DESCRIPTION
## Symptom
After updating to the bundle that includes #338 (desktop `0.23.0`), the app **fails to boot** and falls back to the floor version. The boot log shows:

```
"picked": "0.23.0", "phase": "load-error",
"error": "secure crypto unusable, insecure Math.random not allowed"
```

(`0.23.0` is now quarantined in `bad.json`.)

## Root cause
This is the **identical regression the 0.22.3 changelog documents**. #338's webhooks IPC added a static top-level `import … from '@moxxy/plugin-webhooks'` in `@moxxy/desktop-host`, which is bundled into the Electron main entry (`BUNDLED_WORKSPACE_DEPS`). That static import drags the webhooks plugin's **proxy/E2E stack** (`@moxxy/plugin-tunnel-proxy`) and, transitively, **`ulid`** into the main entry's eager module graph, reordering ESM init so `ulid` initialises **before** electron-vite's injected `require` shim. `ulid` then throws `"secure crypto unusable, insecure Math.random not allowed"` at boot.

`plugin-scheduler` also uses `ulid` and was fine (0.22.8) because it doesn't pull the proxy/E2E stack — so it's specifically that stack reordering ulid's init that breaks boot.

## Fix
Defer the webhooks plugin to a **lazy `import()`** inside the IPC handlers (only an erased `import type` stays static), so the proxy/E2E stack + `ulid` load on the **first `webhooks.*` call** — post `app.whenReady`, out of the startup path. Mirrors the 0.22.3 mobile-proxy fix. The Webhooks panel behaviour is unchanged.

## Verification
- Rebuilt the desktop (`electron-vite build`) and confirmed the proxy/E2E stack is **no longer in the eager `index.js`** — `WebhookStore` + `ulid` now live in a lazy chunk loaded on demand. The eager entry returns to the known-good 0.22.8 shape.
- `desktop-host` tests (469) + typecheck pass; the IPC handler test still passes (it injects a temp-file store).
- Repo `typecheck` (143) + `lint` (0 errors) green.

Once released, the self-updater supersedes the quarantined `0.23.0`.