### PR TITLE
feat(triggers): pick the session ambient triggers run in + compact marker

### DIFF
--- a/.changeset/target-session-ambient-triggers.md
+++ b/.changeset/target-session-ambient-triggers.md
@@ -1,0 +1,48 @@
+---
+"@moxxy/sdk": minor
+"@moxxy/plugin-webhooks": minor
+"@moxxy/plugin-scheduler": minor
+"@moxxy/plugin-workflows": minor
+"@moxxy/desktop-ipc-contract": minor
+"@moxxy/client-core": minor
+"@moxxy/desktop": minor
+"@moxxy/core": patch
+"@moxxy/workflows-builder": patch
+"@moxxy/desktop-host": patch
+"@moxxy/plugin-channel-mobile": patch
+"@moxxy/cli": patch
+---
+
+feat: pick which session ambient triggers run in + a compact trigger marker
+
+Ambient triggers (webhooks, schedules, workflows) used to fire on whichever
+session **created** them, and the synthesized prompt — often a large block
+carrying an untrusted webhook payload — rendered as a giant user bubble. Two
+changes:
+
+**Pick the target session.** Each trigger can now be pinned to a chosen session
+(where its run executes *and* displays), decoupled from who created it:
+
+- `webhook_create` / `schedule_create` take an optional `targetSessionId`
+  (defaulting to the creating session), and `webhook_update` /
+  `schedule_set_target` reassign it. These map onto the existing
+  `ownerSessionId` routing key, so the webhook queue/drain and the scheduler
+  owner-gate already deliver to the right runner — no routing change.
+- Workflows gained a top-level `targetSessionId`. Scheduled workflows stamp it
+  onto their scheduler mirror row (reusing the owner-gate); `fileChanged` is
+  watched only by the target runner; a cross-session `afterWorkflow` dependent
+  is skipped with a warning (the completion event is in-process to the parent's
+  runner). The visual builder preserves the field across a round-trip.
+- Desktop: the Webhooks / Schedules / Workflows panels and the workflow builder
+  gain a session picker (new `*.setTargetSession` IPC commands), and each
+  summary surfaces the resolved target-session name.
+
+**Compact trigger marker.** A fired trigger now renders as a one-line,
+expandable chip ("Webhook received · github-issues", "Schedule fired · daily",
+"Workflow ran · digest") instead of the raw prompt — click to reveal the full
+payload. The prompt still lives in the model's context (security fences intact);
+only the display changes (new optional `origin` on the `user_prompt` event,
+threaded from the fired turn via `RunTurnOptions.origin`).
+
+Unset everywhere preserves today's behavior; single-process CLI/TUI is
+unaffected.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -150,6 +150,16 @@ or recorded-on-purpose decision.
 - [med] Mobile workflow builder name fields are free-text — populate from
   `workflows.list` like desktop. Add a settings error-row retry if `settings.read`
   failures prove common. `apps/mobile/app/workflow-edit.tsx`.
+- [med] Cross-session `afterWorkflow` can't route: the `workflow_completed` event is
+  observed in-process by ONLY the runner that ran the parent, so a dependent pinned
+  (`targetSessionId`) to a different session is skipped with a warning rather than
+  run there. A shared completion queue (mirror the webhooks queue/drain from #333)
+  would let any runner pick up its own-target dependents. `packages/cli/src/setup/wire-run-store.ts`.
+- [low] No validation that a trigger's `targetSessionId` names a live session: a
+  stale/mistyped id silently never fires (schedule owner-gates to an absent runner;
+  fileChanged/afterWorkflow skip on every runner). The desktop picker surfaces a
+  "(missing)" option, but `webhook_create`/`schedule_create`/workflow YAML can't
+  validate without a live-desk registry. `packages/plugin-{webhooks,scheduler}`, `packages/cli`.
 
 ## CLI / services
 

--- a/apps/desktop/src/apps/SchedulesPanel.tsx
+++ b/apps/desktop/src/apps/SchedulesPanel.tsx
@@ -8,6 +8,7 @@
 import { useScheduler } from '@moxxy/client-core';
 import { Button, Icon, Skeleton } from '@moxxy/desktop-ui';
 import type { ScheduleSummary } from '@moxxy/desktop-ipc-contract';
+import { TargetSessionPicker } from './TargetSessionPicker';
 
 function whenLabel(s: ScheduleSummary): string {
   if (s.cron) return `cron ${s.cron}${s.timeZone ? ` (${s.timeZone})` : ''}`;
@@ -95,6 +96,24 @@ export function SchedulesPanel(): JSX.Element {
                     {s.source === 'workflow' && s.workflowName ? ` · workflow: ${s.workflowName}` : ''}
                     {nextLabel(s) ? ` · ${nextLabel(s)}` : ''}
                     {s.lastResult ? ` · last: ${s.lastResult}` : ''}
+                  </div>
+                  <div style={{ marginTop: 6 }}>
+                    {s.source === 'manual' ? (
+                      <TargetSessionPicker
+                        label="Runs in"
+                        value={s.targetSessionId ?? null}
+                        valueName={s.targetSessionName ?? null}
+                        onChange={(sid) => void sched.setTargetSession(s.id, sid)}
+                      />
+                    ) : (
+                      // workflow/skill-driven rows have their owner re-stamped on every
+                      // sync from their source, so reassigning here wouldn't stick —
+                      // show it read-only and point at where to change it.
+                      <span style={{ fontSize: '0.72rem', color: 'var(--color-text-dim)' }}>
+                        Runs in: {s.targetSessionName ?? 'any session'}
+                        {s.source === 'workflow' ? ' (set on the workflow)' : ''}
+                      </span>
+                    )}
                   </div>
                 </div>
                 <Button

--- a/apps/desktop/src/apps/TargetSessionPicker.tsx
+++ b/apps/desktop/src/apps/TargetSessionPicker.tsx
@@ -1,0 +1,63 @@
+/**
+ * Picker for the session an ambient trigger (webhook / schedule / workflow)
+ * runs and displays in. Lists every session grouped by desk (from
+ * {@link useDesks}); the empty value means "no pinned session" (fire-once
+ * across runners / deliver in-process). When the trigger is bound to a session
+ * that no longer exists, a fallback option keeps the stored name visible so the
+ * user can see — and change — a dangling binding.
+ */
+
+import { useDesks } from '@moxxy/client-core';
+
+const selectStyle: React.CSSProperties = {
+  fontSize: '0.72rem',
+  padding: '2px 6px',
+  borderRadius: 7,
+  border: '1px solid var(--color-border)',
+  background: 'var(--color-bg-card)',
+  color: 'var(--color-text)',
+  maxWidth: 220,
+};
+
+export function TargetSessionPicker({
+  value,
+  valueName,
+  onChange,
+  label = 'Runs in',
+}: {
+  readonly value: string | null;
+  /** Resolved display name of `value` (its session title), or null. */
+  readonly valueName: string | null;
+  readonly onChange: (sessionId: string | null) => void;
+  readonly label?: string;
+}): JSX.Element {
+  const { desks } = useDesks();
+  const known = value === null || desks.some((d) => d.sessions.some((s) => s.id === value));
+
+  return (
+    <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: '0.72rem', color: 'var(--color-text-dim)' }}>
+      {label}
+      <select
+        value={value ?? ''}
+        onChange={(e) => onChange(e.target.value === '' ? null : e.target.value)}
+        style={selectStyle}
+      >
+        <option value="">Any session (unpinned)</option>
+        {/* A binding to a since-deleted session would otherwise show blank — keep
+            the stored name (or id) selectable so the dangling pin is visible. */}
+        {!known && value !== null && (
+          <option value={value}>{valueName ?? value} (missing)</option>
+        )}
+        {desks.map((desk) => (
+          <optgroup key={desk.id} label={desk.name}>
+            {desk.sessions.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/apps/desktop/src/apps/WebhooksPanel.tsx
+++ b/apps/desktop/src/apps/WebhooksPanel.tsx
@@ -11,6 +11,7 @@
 import { useWebhooks } from '@moxxy/client-core';
 import { Button, Icon, Skeleton } from '@moxxy/desktop-ui';
 import type { WebhookSummary } from '@moxxy/desktop-ipc-contract';
+import { TargetSessionPicker } from './TargetSessionPicker';
 
 /** One-line activity summary: fires + last fire time + model override. */
 function activityLabel(w: WebhookSummary): string {
@@ -108,6 +109,14 @@ export function WebhooksPanel(): JSX.Element {
                       {w.description}
                     </div>
                   )}
+                  <div style={{ marginTop: 6 }}>
+                    <TargetSessionPicker
+                      label="Delivers to"
+                      value={w.targetSessionId ?? null}
+                      valueName={w.targetSessionName ?? null}
+                      onChange={(sid) => void hooks.setTargetSession(w.id, sid)}
+                    />
+                  </div>
                 </div>
                 <Button
                   variant="chip"

--- a/apps/desktop/src/chat/blocks/EventBlockView.test.tsx
+++ b/apps/desktop/src/chat/blocks/EventBlockView.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * EventBlockView routing for ambient-trigger prompts: a `user_prompt` carrying
+ * an `origin` renders the compact, expandable trigger marker (NOT the raw user
+ * bubble), keeping the often-large untrusted payload collapsed until clicked.
+ * An ordinary user prompt still renders the user bubble.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { MoxxyEvent } from '@moxxy/sdk';
+import { EventBlockView } from './EventBlockView';
+
+function userPrompt(extra: Partial<MoxxyEvent>): MoxxyEvent {
+  return {
+    type: 'user_prompt',
+    id: 'e1' as MoxxyEvent['id'],
+    seq: 1,
+    ts: 0,
+    sessionId: 's1' as MoxxyEvent['sessionId'],
+    turnId: 't1' as MoxxyEvent['turnId'],
+    source: 'user',
+    text: 'PAYLOAD-BODY-12345',
+    ...extra,
+  } as MoxxyEvent;
+}
+
+describe('EventBlockView — ambient trigger marker', () => {
+  it('renders a collapsed trigger marker for a webhook-origin prompt', () => {
+    render(<EventBlockView event={userPrompt({ origin: { kind: 'webhook', name: 'github-issues' } })} />);
+    expect(screen.getByTestId('block-trigger')).toBeTruthy();
+    expect(screen.queryByTestId('block-user')).toBeNull();
+    // The raw payload is hidden until expanded.
+    expect(screen.queryByText(/PAYLOAD-BODY-12345/)).toBeNull();
+    expect(screen.getByText(/github-issues/)).toBeTruthy();
+  });
+
+  it('reveals the full prompt when the marker is expanded', () => {
+    render(<EventBlockView event={userPrompt({ origin: { kind: 'schedule', name: 'daily' } })} />);
+    fireEvent.click(screen.getByTestId('block-trigger').querySelector('button')!);
+    expect(screen.getByText(/PAYLOAD-BODY-12345/)).toBeTruthy();
+  });
+
+  it('renders an ordinary user bubble when there is no origin', () => {
+    render(<EventBlockView event={userPrompt({})} />);
+    expect(screen.getByTestId('block-user')).toBeTruthy();
+    expect(screen.queryByTestId('block-trigger')).toBeNull();
+  });
+});

--- a/apps/desktop/src/chat/blocks/EventBlockView.tsx
+++ b/apps/desktop/src/chat/blocks/EventBlockView.tsx
@@ -1,12 +1,19 @@
 import type { MoxxyEvent } from '@moxxy/sdk';
 import { UserBlock } from './UserBlock';
+import { TriggerBlock } from './TriggerBlock';
 import { AssistantBlock } from './AssistantBlock';
 import { ReasoningBlock } from './ReasoningBlock';
 
 export function EventBlockView({ event }: { readonly event: MoxxyEvent }): JSX.Element | null {
   switch (event.type) {
     case 'user_prompt':
-      return <UserBlock text={event.text} attachments={event.attachments} />;
+      // A machine-initiated turn (fired webhook/schedule/workflow) renders as a
+      // compact, expandable trigger marker instead of the raw synthesized prompt.
+      return event.origin ? (
+        <TriggerBlock origin={event.origin} text={event.text} />
+      ) : (
+        <UserBlock text={event.text} attachments={event.attachments} />
+      );
     case 'assistant_message':
       return <AssistantBlock text={event.content} streaming={false} stopReason={event.stopReason} />;
     case 'reasoning_message':

--- a/apps/desktop/src/chat/blocks/TriggerBlock.tsx
+++ b/apps/desktop/src/chat/blocks/TriggerBlock.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import type { TriggerOrigin } from '@moxxy/sdk';
+import { Icon, type IconName } from '@moxxy/desktop-ui';
+
+/**
+ * Compact marker for a machine-initiated turn (a fired webhook / schedule /
+ * triggered workflow). Replaces the raw synthesized prompt — which is often a
+ * large block carrying an untrusted webhook payload — with a one-line chip
+ * ("Webhook received · github-issues") that expands to reveal the full prompt
+ * for debugging. The prompt text still lives in the event (and the model's
+ * context); this only changes how it's displayed. See {@link TriggerOrigin}.
+ */
+
+const KIND_META: Record<TriggerOrigin['kind'], { readonly icon: IconName; readonly verb: string }> = {
+  webhook: { icon: 'bell', verb: 'received' },
+  schedule: { icon: 'rotate', verb: 'fired' },
+  workflow: { icon: 'workflow', verb: 'ran' },
+};
+
+function titleCase(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export function TriggerBlock({
+  origin,
+  text,
+}: {
+  readonly origin: TriggerOrigin;
+  readonly text: string;
+}): JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+  const meta = KIND_META[origin.kind];
+  const label = `${titleCase(origin.kind)} ${meta.verb}`;
+  return (
+    <div
+      data-testid="block-trigger"
+      style={{ alignSelf: 'flex-start', maxWidth: '78%', display: 'flex', flexDirection: 'column', gap: 6 }}
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        title={expanded ? 'Hide the trigger payload' : 'Show the trigger payload'}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '5px 12px',
+          background: 'var(--color-surface)',
+          border: '1px solid var(--color-card-border)',
+          borderRadius: 999,
+          fontSize: 12.5,
+          color: 'var(--color-text-dim)',
+          cursor: 'pointer',
+          fontWeight: 600,
+        }}
+      >
+        <Icon name={meta.icon} size={13} />
+        <span>
+          {label} · <span style={{ color: 'var(--color-text)' }}>{origin.name}</span>
+        </span>
+        <span
+          aria-hidden
+          style={{
+            display: 'inline-flex',
+            transform: expanded ? 'rotate(90deg)' : 'none',
+            transition: 'transform 120ms ease',
+            opacity: 0.7,
+          }}
+        >
+          <Icon name="chevron-right" size={12} />
+        </span>
+      </button>
+      {expanded && (
+        <div
+          className="mono"
+          style={{
+            padding: '10px 12px',
+            background: 'var(--color-surface)',
+            border: '1px solid var(--color-card-border)',
+            borderRadius: 12,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            fontSize: 12,
+            lineHeight: 1.5,
+            color: 'var(--color-text-dim)',
+            maxHeight: 360,
+            overflow: 'auto',
+          }}
+        >
+          {text}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/workflows/WorkflowBuilder.tsx
+++ b/apps/desktop/src/workflows/WorkflowBuilder.tsx
@@ -5,6 +5,7 @@ import { WORKFLOW_ERROR_KEY } from '@moxxy/workflows-builder';
 import { WorkflowCanvas } from './WorkflowCanvas';
 import { NodeInspector } from './NodeInspector';
 import { Palette } from './Palette';
+import { TargetSessionPicker } from '../apps/TargetSessionPicker';
 
 /**
  * The desktop visual builder: palette + drag canvas + node inspector, all
@@ -72,6 +73,17 @@ export function WorkflowBuilder({ name, onClose, onSaved }: Props): JSX.Element 
             value={state.meta.description}
             data-testid="builder-description"
             onChange={(e) => dispatch({ type: 'update-meta', patch: { description: e.target.value } })}
+          />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <span style={metaLabel}>triggered runs in</span>
+          <TargetSessionPicker
+            label=""
+            value={state.meta.targetSessionId ?? null}
+            valueName={null}
+            onChange={(sid) =>
+              dispatch({ type: 'update-meta', patch: { targetSessionId: sid ?? undefined } })
+            }
           />
         </div>
         <ValidityBadge valid={builder.valid} validating={builder.validating} />

--- a/apps/desktop/src/workflows/WorkflowsPanel.tsx
+++ b/apps/desktop/src/workflows/WorkflowsPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useWorkflows } from '@moxxy/client-core';
 import { Button, Icon, Skeleton } from '@moxxy/desktop-ui';
 import { AgentTaskModal } from '../settings/shared/AgentTaskModal';
+import { TargetSessionPicker } from '../apps/TargetSessionPicker';
 import { WorkflowBuilder } from './WorkflowBuilder';
 import { WORKFLOW_PROMPT_TEMPLATE } from './workflow-prompt';
 import { ViewHeader, ViewSwitcher, type View } from '../shell/ViewHeader';
@@ -177,6 +178,14 @@ export function WorkflowsPanel({
                     {w.description}
                   </div>
                 )}
+                <div style={{ marginTop: 6 }}>
+                  <TargetSessionPicker
+                    label="Triggered runs in"
+                    value={w.targetSessionId ?? null}
+                    valueName={w.targetSessionName ?? null}
+                    onChange={(sid) => void wf.setTargetSession(w.name, sid)}
+                  />
+                </div>
               </div>
               <button
                 type="button"

--- a/apps/mobile/test/mobileWorkflows.test.ts
+++ b/apps/mobile/test/mobileWorkflows.test.ts
@@ -36,6 +36,7 @@ afterEach(() => {
 
 const stableRefresh = async () => undefined;
 const stableSetEnabled = async () => undefined;
+const stableSetTargetSession = async () => undefined;
 const stableRun = async () => undefined;
 
 function coreWorkflows(overrides: Partial<UseWorkflows> = {}): UseWorkflows {
@@ -46,6 +47,7 @@ function coreWorkflows(overrides: Partial<UseWorkflows> = {}): UseWorkflows {
     lastRun: null,
     refresh: stableRefresh,
     setEnabled: stableSetEnabled,
+    setTargetSession: stableSetTargetSession,
     run: stableRun,
     ...overrides,
   };

--- a/packages/cli/src/setup/build-workflow-tools.ts
+++ b/packages/cli/src/setup/build-workflow-tools.ts
@@ -39,6 +39,7 @@ export function buildWorkflowsView(args: {
         scope: w.scope,
         steps: w.workflow.steps.length,
         triggers: triggerSummary(w.workflow.on),
+        targetSessionId: w.workflow.targetSessionId ?? null,
       })),
     setEnabled: async (name, enabled) => {
       await store.setEnabled(name, enabled);

--- a/packages/cli/src/setup/scheduler-runner.ts
+++ b/packages/cli/src/setup/scheduler-runner.ts
@@ -11,11 +11,14 @@ import type { SchedulePromptRunner } from '@moxxy/plugin-scheduler';
  */
 export function buildSchedulerRunner(session: Session): SchedulePromptRunner {
   return {
-    runPrompt: async ({ prompt, model }) => {
+    runPrompt: async ({ prompt, model, origin }) => {
       let text = '';
       let lastError: string | null = null;
       try {
-        for await (const event of runTurn(session, prompt, model ? { model } : {})) {
+        for await (const event of runTurn(session, prompt, {
+          ...(origin ? { origin } : {}),
+          ...(model ? { model } : {}),
+        })) {
           if (event.type === 'assistant_message') {
             text = event.content;
             // The latest assistant_message is authoritative for the final

--- a/packages/cli/src/setup/webhook-runner.ts
+++ b/packages/cli/src/setup/webhook-runner.ts
@@ -27,8 +27,11 @@ export function buildWebhookRunner(session: Session): WebhookPromptRunner {
       const target = scopedSessionView(session, allowedTools, triggerName);
       let text = '';
       let lastError: string | null = null;
+      // Stamp provenance so the UI renders a compact "Webhook received · <name>"
+      // marker instead of the raw (untrusted-payload-bearing) injected prompt.
+      const origin = { kind: 'webhook', name: triggerName } as const;
       try {
-        for await (const event of runTurn(target, prompt, model ? { model } : {})) {
+        for await (const event of runTurn(target, prompt, { origin, ...(model ? { model } : {}) })) {
           if (event.type === 'assistant_message') {
             text = event.content;
             // The latest assistant_message is authoritative for the final

--- a/packages/cli/src/setup/wire-run-store.ts
+++ b/packages/cli/src/setup/wire-run-store.ts
@@ -15,7 +15,7 @@ import type { MiniLogger, WorkflowRunner } from './build-workflow-runner.js';
 export const MAX_AFTER_WORKFLOW_CHAIN = 8;
 
 /** The trigger-relevant slice of a {@link Workflow} the cycle guards inspect. */
-export type AfterWorkflowNode = Pick<Workflow, 'name' | 'enabled' | 'on'>;
+export type AfterWorkflowNode = Pick<Workflow, 'name' | 'enabled' | 'on' | 'targetSessionId'>;
 
 /**
  * Find cycles in the `afterWorkflow` trigger graph among enabled workflows.
@@ -113,14 +113,37 @@ export async function fireAfterWorkflowDependents(args: {
   chain: ReadonlyArray<string>;
   workflows: ReadonlyArray<AfterWorkflowNode>;
   disabled: ReadonlySet<string>;
+  /**
+   * This runner's session identity. The `workflow_completed` event is observed
+   * in-process by only the runner that ran the parent, so a dependent pinned
+   * (via `targetSessionId`) to a *different* session can't be routed there —
+   * it's skipped with a warning. Undefined → single-process CLI/TUI (no gate).
+   */
+  thisRunnerSessionId?: string;
   run: (input: { name: string; trigger: string; chain: ReadonlyArray<string> }) => Promise<unknown>;
   logger?: MiniLogger;
 }): Promise<void> {
-  const { completed, workflows, disabled, run, logger } = args;
+  const { completed, workflows, disabled, thisRunnerSessionId, run, logger } = args;
   const nextChain = [...args.chain, completed];
   for (const workflow of workflows) {
     if (!workflow.enabled || !workflow.on?.afterWorkflow) continue;
     if (![workflow.on.afterWorkflow].flat().includes(completed)) continue;
+    // Target-session gate: a dependent pinned to another session must run on
+    // THAT runner to display there, but the completion event only reached this
+    // runner (in-process subscription). Skip + warn so the run never lands in
+    // the wrong session; co-locate the chain or use a schedule trigger to fan
+    // out across sessions. Unset target / single-process → no gate (today's path).
+    if (
+      workflow.targetSessionId &&
+      thisRunnerSessionId &&
+      workflow.targetSessionId !== thisRunnerSessionId
+    ) {
+      logger?.info?.(
+        'workflows: afterWorkflow dependent is pinned to another session; skipping (co-locate or use a schedule trigger)',
+        { workflow: workflow.name, after: completed, target: workflow.targetSessionId },
+      );
+      continue;
+    }
     if (disabled.has(workflow.name)) {
       logger?.info?.('workflows: afterWorkflow auto-refire disabled by the cycle guard; skipping', {
         workflow: workflow.name,
@@ -195,9 +218,18 @@ export function wireWorkflowTriggers(args: {
    * nothing to race and every debounced change should fire as before.
    */
   fireLock?: CrossProcessFireLock;
+  /**
+   * This runner process's session identity (`MOXXY_SESSION_ID`), or undefined
+   * for a single-process CLI/TUI. When a workflow declares `targetSessionId`,
+   * only the runner whose id matches it watches/fires that workflow's
+   * fileChanged trigger and runs its afterWorkflow dependents — pinning the run
+   * to the chosen session. Unset on a workflow → today's behavior (every runner
+   * watches; `fireLock` dedupes fileChanged).
+   */
+  thisRunnerSessionId?: string;
   logger?: MiniLogger;
 }): WorkflowTriggerWiring {
-  const { session, store, scheduleStore, runner, fireLock, logger } = args;
+  const { session, store, scheduleStore, runner, fireLock, thisRunnerSessionId, logger } = args;
 
   const watchers: FSWatcher[] = [];
   // Workflows whose afterWorkflow auto-refire is statically disabled because
@@ -251,6 +283,20 @@ export function wireWorkflowTriggers(args: {
     cancelPendingDebounces();
     for (const { workflow } of await store.list()) {
       if (!workflow.enabled || !workflow.on?.fileChanged) continue;
+      // Target-session gate: a pinned workflow's fileChanged trigger is watched
+      // ONLY by the target runner, so the run lands in the chosen session. A
+      // mismatched runner registers no watcher at all (no debounce timers, no
+      // wasted fs.watch handles). If the target runner is offline when the file
+      // changes the event is simply missed — there is no fs-event replay (unlike
+      // webhooks/schedules, which catch up). Unset target / single-process → every
+      // runner watches and `fireLock` dedupes (today's behavior).
+      if (
+        workflow.targetSessionId &&
+        thisRunnerSessionId &&
+        workflow.targetSessionId !== thisRunnerSessionId
+      ) {
+        continue;
+      }
       for (const glob of [workflow.on.fileChanged].flat()) {
         const base = globBaseDir(glob, session.cwd);
         const key = `${workflow.name}::${glob}`;
@@ -357,6 +403,14 @@ export function wireWorkflowTriggers(args: {
             ...(cron ? { cron } : {}),
             ...(runAt !== undefined ? { runAt } : {}),
             ...(timeZone ? { timeZone } : {}),
+            // Pin the synthetic schedule to the workflow's chosen session: the
+            // existing scheduler owner-gate then fires the run on (and displays
+            // it in) that runner. Unset → owner-less row → fire-once via the
+            // poller's cross-process lock (today's behavior). NOTE: a soft-deleted
+            // mirror row takes precedence in syncWorkflowSchedule, so retargeting
+            // a previously-deleted-then-re-enabled workflow won't re-stamp until
+            // its deletion marker clears (matches existing scheduler semantics).
+            ...(workflow.targetSessionId ? { ownerSessionId: workflow.targetSessionId } : {}),
             enabled: true,
             createdAt: 0,
             source: 'workflow',
@@ -407,6 +461,7 @@ export function wireWorkflowTriggers(args: {
         chain,
         workflows: (await store.list()).map((w) => w.workflow),
         disabled: cyclicTriggers,
+        ...(thisRunnerSessionId ? { thisRunnerSessionId } : {}),
         run: runner.runNow,
         ...(logger ? { logger } : {}),
       });

--- a/packages/cli/src/setup/workflows.test.ts
+++ b/packages/cli/src/setup/workflows.test.ts
@@ -22,12 +22,13 @@ import {
 
 function wf(
   name: string,
-  opts: { after?: string | string[]; enabled?: boolean } = {},
+  opts: { after?: string | string[]; enabled?: boolean; target?: string } = {},
 ): AfterWorkflowNode {
   return {
     name,
     enabled: opts.enabled ?? true,
     ...(opts.after ? { on: { afterWorkflow: opts.after } } : {}),
+    ...(opts.target ? { targetSessionId: opts.target } : {}),
   };
 }
 
@@ -133,6 +134,58 @@ describe('fireAfterWorkflowDependents', () => {
     expect(runs).toEqual(Array.from({ length: MAX_AFTER_WORKFLOW_CHAIN - 1 }, (_, i) => `w${i + 1}`));
     expect(warns).toHaveLength(1);
     expect(warns[0]).toContain(`depth cap of ${MAX_AFTER_WORKFLOW_CHAIN}`);
+  });
+
+  it('skips an afterWorkflow dependent pinned to a different session (info, no run)', async () => {
+    const workflows = [wf('a'), wf('b', { after: 'a', target: 'desk-B' })];
+    const { logger, infos } = captureLogger();
+    const runs: string[] = [];
+
+    await fireAfterWorkflowDependents({
+      completed: 'a',
+      chain: [],
+      workflows,
+      disabled: new Set(),
+      thisRunnerSessionId: 'desk-A',
+      run: async ({ name }) => void runs.push(name),
+      logger,
+    });
+
+    expect(runs).toEqual([]);
+    expect(infos.some((m) => m.includes('pinned to another session'))).toBe(true);
+  });
+
+  it('runs an afterWorkflow dependent pinned to THIS session', async () => {
+    const workflows = [wf('a'), wf('b', { after: 'a', target: 'desk-A' })];
+    const runs: string[] = [];
+
+    await fireAfterWorkflowDependents({
+      completed: 'a',
+      chain: [],
+      workflows,
+      disabled: new Set(),
+      thisRunnerSessionId: 'desk-A',
+      run: async ({ name }) => void runs.push(name),
+    });
+
+    expect(runs).toEqual(['b']);
+  });
+
+  it('does not gate when the runner has no id (single-process): a pinned dependent still runs', async () => {
+    const workflows = [wf('a'), wf('b', { after: 'a', target: 'desk-Z' })];
+    const runs: string[] = [];
+
+    // thisRunnerSessionId omitted → the gate short-circuits, preserving today's
+    // behavior for a single-process CLI/TUI.
+    await fireAfterWorkflowDependents({
+      completed: 'a',
+      chain: [],
+      workflows,
+      disabled: new Set(),
+      run: async ({ name }) => void runs.push(name),
+    });
+
+    expect(runs).toEqual(['b']);
   });
 
   it('skips workflows the static cycle guard disabled (info, no run)', async () => {
@@ -643,6 +696,47 @@ describe('buildWorkflowsIntegration afterWorkflow wiring', () => {
       expect(byWorkflow.get('b-good')?.cron).toBe('0 9 * * *');
       // ...and the malformed one was skipped, not scheduled with garbage.
       expect(byWorkflow.has('a-bad')).toBe(false);
+    } finally {
+      integration.stop();
+    }
+  });
+
+  it("stamps a scheduled workflow's mirror row with its targetSessionId as ownerSessionId", async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-workflows-target-'));
+    tempDirs.push(cwd);
+    process.env.HOME = cwd;
+    process.env.MOXXY_HOME = path.join(cwd, '.moxxy-home');
+
+    const projectDir = path.join(cwd, '.moxxy', 'workflows');
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.writeFile(
+      path.join(projectDir, 'pinned.yaml'),
+      [
+        'name: pinned',
+        'description: pinned to a chosen session',
+        'targetSessionId: desk-B',
+        'on:',
+        '  schedule:',
+        "    cron: '0 9 * * *'",
+        'delivery:',
+        '  inbox: false',
+        'steps:',
+        '  - id: s1',
+        '    prompt: hi',
+        '',
+      ].join('\n'),
+    );
+
+    const session = new Session({ cwd, logger: silentLogger });
+    session.workflowExecutors.register({ name: 'stub', run: async () => ({ ok: true, steps: [], output: '' }) });
+    const scheduleStore = new ScheduleStore({ file: path.join(cwd, 'sched.json') });
+    const integration = buildWorkflowsIntegration({ session, scheduleStore });
+    session.pluginHost.registerStatic(integration.plugin);
+    try {
+      await session.dispatcher.dispatchInit(session.appContext());
+      const entry = (await scheduleStore.list()).find((e) => e.workflowName === 'pinned');
+      // The owner-gate then fires the synthetic turn on the desk-B runner.
+      expect(entry?.ownerSessionId).toBe('desk-B');
     } finally {
       integration.stop();
     }

--- a/packages/cli/src/setup/workflows.ts
+++ b/packages/cli/src/setup/workflows.ts
@@ -92,6 +92,9 @@ export function buildWorkflowsIntegration(args: {
     scheduleStore,
     runner,
     ...(fileLock ? { fireLock: fileLock } : {}),
+    // Pin a workflow's fileChanged/afterWorkflow triggers to its `targetSessionId`
+    // by telling the wiring which runner this is. Unset for single-process CLI/TUI.
+    ...(ownerSessionId ? { thisRunnerSessionId: ownerSessionId } : {}),
     ...(logger ? { logger } : {}),
   });
 

--- a/packages/client-core/src/useScheduler.ts
+++ b/packages/client-core/src/useScheduler.ts
@@ -9,6 +9,9 @@ export interface UseScheduler {
   readonly error: string | null;
   readonly refresh: () => Promise<void>;
   readonly setEnabled: (id: string, enabled: boolean) => Promise<void>;
+  /** Reassign which session a schedule fires in (where its run runs +
+   *  display), or pass `null` to clear the binding. */
+  readonly setTargetSession: (id: string, sessionId: string | null) => Promise<void>;
   readonly deleteSchedule: (id: string) => Promise<void>;
 }
 
@@ -51,6 +54,19 @@ export function useScheduler(): UseScheduler {
     [refresh],
   );
 
+  const setTargetSession = useCallback(
+    async (id: string, sessionId: string | null): Promise<void> => {
+      try {
+        const updated = await api().invoke('scheduler.setTargetSession', { id, sessionId });
+        if (updated) setList((cur) => cur.map((s) => (s.id === id ? updated : s)));
+        await refresh();
+      } catch (e) {
+        setError(toErrorMessage(e));
+      }
+    },
+    [refresh],
+  );
+
   const deleteSchedule = useCallback(
     async (id: string): Promise<void> => {
       try {
@@ -66,5 +82,5 @@ export function useScheduler(): UseScheduler {
     [refresh],
   );
 
-  return { list, loading, error, refresh, setEnabled, deleteSchedule };
+  return { list, loading, error, refresh, setEnabled, setTargetSession, deleteSchedule };
 }

--- a/packages/client-core/src/useWebhooks.ts
+++ b/packages/client-core/src/useWebhooks.ts
@@ -9,6 +9,9 @@ export interface UseWebhooks {
   readonly error: string | null;
   readonly refresh: () => Promise<void>;
   readonly setEnabled: (id: string, enabled: boolean) => Promise<void>;
+  /** Reassign which session a webhook delivers to (where its runs fire +
+   *  display), or pass `null` to clear the binding. */
+  readonly setTargetSession: (id: string, sessionId: string | null) => Promise<void>;
   readonly deleteWebhook: (id: string) => Promise<void>;
 }
 
@@ -56,6 +59,19 @@ export function useWebhooks(): UseWebhooks {
     [refresh],
   );
 
+  const setTargetSession = useCallback(
+    async (id: string, sessionId: string | null): Promise<void> => {
+      try {
+        const updated = await api().invoke('webhooks.setTargetSession', { id, sessionId });
+        if (updated) setList((cur) => cur.map((w) => (w.id === id ? updated : w)));
+        await refresh();
+      } catch (e) {
+        setError(toErrorMessage(e));
+      }
+    },
+    [refresh],
+  );
+
   const deleteWebhook = useCallback(
     async (id: string): Promise<void> => {
       try {
@@ -71,5 +87,5 @@ export function useWebhooks(): UseWebhooks {
     [refresh],
   );
 
-  return { list, loading, error, refresh, setEnabled, deleteWebhook };
+  return { list, loading, error, refresh, setEnabled, setTargetSession, deleteWebhook };
 }

--- a/packages/client-core/src/useWorkflows.ts
+++ b/packages/client-core/src/useWorkflows.ts
@@ -10,6 +10,9 @@ export interface UseWorkflows {
   readonly lastRun: { name: string; result: WorkflowRun } | null;
   readonly refresh: () => Promise<void>;
   readonly setEnabled: (name: string, enabled: boolean) => Promise<void>;
+  /** Pin a workflow's triggered runs to a session (where they run + display),
+   *  or pass `null` to clear the pin. */
+  readonly setTargetSession: (name: string, sessionId: string | null) => Promise<void>;
   readonly run: (name: string) => Promise<void>;
 }
 
@@ -55,6 +58,19 @@ export function useWorkflows(): UseWorkflows {
     [refresh],
   );
 
+  const setTargetSession = useCallback(
+    async (name: string, sessionId: string | null): Promise<void> => {
+      try {
+        const updated = await api().invoke('workflows.setTargetSession', { name, sessionId });
+        if (updated) setList((cur) => cur.map((w) => (w.name === name ? updated : w)));
+        await refresh();
+      } catch (e) {
+        setError(toErrorMessage(e));
+      }
+    },
+    [refresh],
+  );
+
   const run = useCallback(
     async (name: string): Promise<void> => {
       try {
@@ -73,5 +89,5 @@ export function useWorkflows(): UseWorkflows {
     [],
   );
 
-  return { list, loading, error, lastRun, refresh, setEnabled, run };
+  return { list, loading, error, lastRun, refresh, setEnabled, setTargetSession, run };
 }

--- a/packages/core/src/run-turn.ts
+++ b/packages/core/src/run-turn.ts
@@ -55,6 +55,7 @@ export async function* runTurn(
       ...(opts.attachments && opts.attachments.length > 0
         ? { attachments: opts.attachments }
         : {}),
+      ...(opts.origin ? { origin: opts.origin } : {}),
     });
 
     // Resolve provider + model AFTER the prompt is recorded so a

--- a/packages/desktop-host/package.json
+++ b/packages/desktop-host/package.json
@@ -39,7 +39,8 @@
     "@moxxy/sdk": "workspace:*",
     "@moxxy/workspace-registry": "workspace:*",
     "officeparser": "~5.1.1",
-    "pdfjs-dist": "4.10.38"
+    "pdfjs-dist": "4.10.38",
+    "yaml": "^2.6.0"
   },
   "devDependencies": {
     "@moxxy/testing": "workspace:*",

--- a/packages/desktop-host/src/ipc.ts
+++ b/packages/desktop-host/src/ipc.ts
@@ -90,9 +90,9 @@ export function registerIpcHandlers(
     registerGitHandlers(desks);
     registerSurfaceHandlers(pool);
     registerDesksHandlers(pool, desks);
-    registerWorkflowsHandlers(pool);
-    registerSchedulerHandlers();
-    registerWebhookHandlers();
+    registerWorkflowsHandlers(pool, desks);
+    registerSchedulerHandlers(undefined, desks);
+    registerWebhookHandlers(undefined, desks);
     registerPrefsHandlers();
     registerSettingsHandlers(pool);
     registerVaultHandlers();

--- a/packages/desktop-host/src/ipc/scheduler.ts
+++ b/packages/desktop-host/src/ipc/scheduler.ts
@@ -1,20 +1,32 @@
 import type { ScheduleSummary } from '@moxxy/desktop-ipc-contract';
 import { ScheduleStore, describeScheduleEntry } from '@moxxy/plugin-scheduler';
-import { handle } from './shared';
+import type { DeskStore } from '../desks';
+import { buildSessionNameResolver, handle, type SessionNameResolver } from './shared';
 
 const defaultStore = new ScheduleStore();
 
-export function registerSchedulerHandlers(store: ScheduleStore = defaultStore): void {
+export function registerSchedulerHandlers(
+  store: ScheduleStore = defaultStore,
+  desks?: DeskStore,
+): void {
   handle('scheduler.list', async () => {
     store.invalidate();
-    const entries = await store.list();
-    return entries.map(toScheduleSummary);
+    const [entries, resolveName] = await Promise.all([store.list(), buildSessionNameResolver(desks)]);
+    return entries.map((e) => toScheduleSummary(e, resolveName));
   });
 
   handle('scheduler.setEnabled', async ({ id, enabled }) => {
     store.invalidate();
     const updated = await store.update(id, { enabled });
-    return updated ? toScheduleSummary(updated) : null;
+    return updated ? toScheduleSummary(updated, await buildSessionNameResolver(desks)) : null;
+  });
+
+  handle('scheduler.setTargetSession', async ({ id, sessionId }) => {
+    store.invalidate();
+    // `ownerSessionId` is the stored routing key the poller owner-gate honors,
+    // so reassigning here re-homes which runner fires the schedule.
+    const updated = await store.update(id, { ownerSessionId: sessionId ?? undefined });
+    return updated ? toScheduleSummary(updated, await buildSessionNameResolver(desks)) : null;
   });
 
   handle('scheduler.delete', async ({ id }) => {
@@ -23,6 +35,10 @@ export function registerSchedulerHandlers(store: ScheduleStore = defaultStore): 
   });
 }
 
-function toScheduleSummary(entry: Parameters<typeof describeScheduleEntry>[0]): ScheduleSummary {
-  return describeScheduleEntry(entry) as unknown as ScheduleSummary;
+function toScheduleSummary(
+  entry: Parameters<typeof describeScheduleEntry>[0],
+  resolveName: SessionNameResolver,
+): ScheduleSummary {
+  const described = describeScheduleEntry(entry) as unknown as ScheduleSummary;
+  return { ...described, targetSessionName: resolveName(described.targetSessionId) };
 }

--- a/packages/desktop-host/src/ipc/shared.ts
+++ b/packages/desktop-host/src/ipc/shared.ts
@@ -39,7 +39,31 @@ export { IpcError };
 import type { RunnerSupervisor } from '../runner-supervisor';
 import type { RunnerPool } from '../runner-pool';
 import type { SessionDriver } from '../session-driver';
+import type { DeskStore } from '../desks';
 import { buildInProcessPlugins, type InProcessPlugins } from '../in-process-plugins';
+
+/**
+ * A `targetSessionId → display name` lookup, for stamping `targetSessionName`
+ * onto the automation summaries (webhooks / schedules / workflows). Returns
+ * null for an unknown id — e.g. a trigger bound to a since-deleted session.
+ */
+export type SessionNameResolver = (id: string | null | undefined) => string | null;
+
+/**
+ * Build a {@link SessionNameResolver} from the desk registry with a single
+ * `desks.list()` read (so a list handler resolves N triggers without N disk
+ * reads). Returns an all-null resolver when no registry is wired (the
+ * injected-store test variants pass none).
+ */
+export async function buildSessionNameResolver(desks?: DeskStore): Promise<SessionNameResolver> {
+  const names = new Map<string, string>();
+  if (desks) {
+    for (const desk of await desks.list()) {
+      for (const session of desk.sessions) names.set(session.id, session.name);
+    }
+  }
+  return (id) => (id ? (names.get(id) ?? null) : null);
+}
 
 /** Driver lookup shared across the IPC handlers + bindWindow. Keyed by
  *  workspace id so runTurn / abortTurn target the right runner. The primary

--- a/packages/desktop-host/src/ipc/webhooks.ts
+++ b/packages/desktop-host/src/ipc/webhooks.ts
@@ -9,7 +9,8 @@ import type { WebhookSummary } from '@moxxy/desktop-ipc-contract';
 // Math.random not allowed" at boot, so the app never starts (see the desktop
 // 0.22.3 changelog for the identical mobile-proxy regression + fix).
 import type { WebhookStore, WebhookTrigger } from '@moxxy/plugin-webhooks';
-import { handle } from './shared';
+import type { DeskStore } from '../desks';
+import { buildSessionNameResolver, handle, type SessionNameResolver } from './shared';
 
 interface WebhooksModule {
   readonly store: WebhookStore;
@@ -47,8 +48,10 @@ function loadWebhooks(): Promise<WebhooksModule> {
  *
  * @param injectedStore Tests pass a temp-file store so they don't touch the
  *  real `~/.moxxy/webhooks.json`; production lazy-loads the default store.
+ * @param desks The desk registry, used to resolve a trigger's `targetSessionId`
+ *  to a display name for the panel. Omitted by the injected-store tests.
  */
-export function registerWebhookHandlers(injectedStore?: WebhookStore): void {
+export function registerWebhookHandlers(injectedStore?: WebhookStore, desks?: DeskStore): void {
   const get: () => Promise<WebhooksModule> = injectedStore
     ? async () => ({
         store: injectedStore,
@@ -59,15 +62,24 @@ export function registerWebhookHandlers(injectedStore?: WebhookStore): void {
   handle('webhooks.list', async () => {
     const { store, describeTrigger } = await get();
     store.invalidate();
-    const triggers = await store.list();
-    return triggers.map((t) => toWebhookSummary(t, describeTrigger));
+    const [triggers, resolveName] = await Promise.all([store.list(), buildSessionNameResolver(desks)]);
+    return triggers.map((t) => toWebhookSummary(t, describeTrigger, resolveName));
   });
 
   handle('webhooks.setEnabled', async ({ id, enabled }) => {
     const { store, describeTrigger } = await get();
     store.invalidate();
     const updated = await store.update(id, { enabled });
-    return updated ? toWebhookSummary(updated, describeTrigger) : null;
+    return updated ? toWebhookSummary(updated, describeTrigger, await buildSessionNameResolver(desks)) : null;
+  });
+
+  handle('webhooks.setTargetSession', async ({ id, sessionId }) => {
+    const { store, describeTrigger } = await get();
+    store.invalidate();
+    // `ownerSessionId` is the stored routing key; the queue/drain already
+    // honors it, so reassigning here re-homes the trigger's deliveries.
+    const updated = await store.update(id, { ownerSessionId: sessionId ?? undefined });
+    return updated ? toWebhookSummary(updated, describeTrigger, await buildSessionNameResolver(desks)) : null;
   });
 
   handle('webhooks.delete', async ({ id }) => {
@@ -86,6 +98,10 @@ export function registerWebhookHandlers(injectedStore?: WebhookStore): void {
 function toWebhookSummary(
   trigger: WebhookTrigger,
   describeTrigger: WebhooksModule['describeTrigger'],
+  resolveName: SessionNameResolver,
 ): WebhookSummary {
-  return describeTrigger(trigger, undefined) as unknown as WebhookSummary;
+  // `describeTrigger` already carries `targetSessionId` (the stored
+  // ownerSessionId); the host adds the resolved display name on top.
+  const described = describeTrigger(trigger, undefined) as unknown as WebhookSummary;
+  return { ...described, targetSessionName: resolveName(described.targetSessionId) };
 }

--- a/packages/desktop-host/src/ipc/workflows.ts
+++ b/packages/desktop-host/src/ipc/workflows.ts
@@ -7,17 +7,25 @@
  * a clear error so the renderer can surface it.
  */
 
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import type { RunnerPool } from '../runner-pool';
-import { handle, mustSession } from './shared';
+import type { DeskStore } from '../desks';
+import { buildSessionNameResolver, handle, mustSession } from './shared';
 
-export function registerWorkflowsHandlers(pool: RunnerPool): void {
+export function registerWorkflowsHandlers(pool: RunnerPool, desks?: DeskStore): void {
   // ---- Workflows -----------------------------------------------------------
 
   handle('workflows.list', async () => {
     const session = mustSession(pool);
     const view = session.workflows;
     if (!view) return [];
-    return await view.list();
+    const [summaries, resolveName] = await Promise.all([view.list(), buildSessionNameResolver(desks)]);
+    // The runner-side view carries `targetSessionId` (read from the YAML); the
+    // host adds the resolved display name (it owns the desk registry).
+    return summaries.map((s) => {
+      const targetSessionId = s.targetSessionId ?? null;
+      return { ...s, targetSessionId, targetSessionName: resolveName(targetSessionId) };
+    });
   });
   handle('workflows.setEnabled', async ({ name, enabled }) => {
     const session = mustSession(pool);
@@ -46,6 +54,30 @@ export function registerWorkflowsHandlers(pool: RunnerPool): void {
     const session = mustSession(pool);
     if (!session.workflows?.getRun) throw new Error('workflows builder not supported on this session');
     return await session.workflows.getRun(name);
+  });
+
+  // Reassign a workflow's target session by flipping the top-level
+  // `targetSessionId` key in its YAML and re-saving via the existing builder
+  // save path (no new runner RPC). The edit is a single-key set/delete on the
+  // parsed object — `view.save` re-parses + schema-validates server-side. We use
+  // the pure `yaml` lib (not `@moxxy/plugin-workflows`, whose static import would
+  // drag the engine + eager `ulid` into the bundled Electron main and crash boot).
+  handle('workflows.setTargetSession', async ({ name, sessionId }) => {
+    const session = mustSession(pool);
+    const view = session.workflows;
+    if (!view?.getRun || !view?.save) throw new Error('workflows builder not supported on this session');
+    const detail = await view.getRun(name);
+    if (!detail) return null;
+    const obj = (parseYaml(detail.yaml) ?? {}) as Record<string, unknown>;
+    if (sessionId) obj.targetSessionId = sessionId;
+    else delete obj.targetSessionId;
+    // lineWidth:0 matches the plugin's canonical serializer (no long-line wraps).
+    await view.save(stringifyYaml(obj, { lineWidth: 0 }), name);
+    const [summaries, resolveName] = await Promise.all([view.list(), buildSessionNameResolver(desks)]);
+    const updated = summaries.find((s) => s.name === name);
+    if (!updated) return null;
+    const targetSessionId = updated.targetSessionId ?? null;
+    return { ...updated, targetSessionId, targetSessionName: resolveName(targetSessionId) };
   });
 
   // ---- Human-in-the-loop: resume a paused awaitInput run ------------------

--- a/packages/desktop-ipc-contract/src/commands.ts
+++ b/packages/desktop-ipc-contract/src/commands.ts
@@ -441,6 +441,10 @@ export interface IpcCommands {
   'workflows.save': (args: { yaml: string; previousName?: string }) => Promise<WorkflowSave>;
   /** Fetch one saved workflow as canonical YAML (null when unknown). */
   'workflows.getRun': (args: { name: string }) => Promise<WorkflowDetail | null>;
+  /** Pin a workflow's triggered runs to a session (where they run + display),
+   *  or pass `sessionId: null` to clear the pin (revert to fire-once across
+   *  runners). The host loads the YAML, sets `targetSessionId`, and re-saves. */
+  'workflows.setTargetSession': (args: { name: string; sessionId: string | null }) => Promise<WorkflowSummary | null>;
   /**
    * Answer a paused workflow's `awaitInput` question and resume the run (the
    * human-in-the-loop flow). `runId` comes from the `workflow_paused` plugin
@@ -458,6 +462,10 @@ export interface IpcCommands {
   'scheduler.setEnabled': (args: { id: string; enabled: boolean }) => Promise<ScheduleSummary | null>;
   /** Permanently remove an existing scheduler entry by id. */
   'scheduler.delete': (args: { id: string }) => Promise<SchedulerDeleteResult>;
+  /** Reassign which session a schedule fires in (where its run runs + displays),
+   *  or pass `sessionId: null` to clear the binding. Maps to the entry's stored
+   *  `ownerSessionId`; the existing poller owner-gate routes the fire. */
+  'scheduler.setTargetSession': (args: { id: string; sessionId: string | null }) => Promise<ScheduleSummary | null>;
 
   // Webhooks
   /** List every persisted webhook trigger. The host reads the shared webhooks
@@ -470,6 +478,10 @@ export interface IpcCommands {
   'webhooks.setEnabled': (args: { id: string; enabled: boolean }) => Promise<WebhookSummary | null>;
   /** Permanently remove an existing webhook trigger by id. */
   'webhooks.delete': (args: { id: string }) => Promise<WebhookDeleteResult>;
+  /** Reassign which session a webhook delivers to (where its run runs + displays),
+   *  or pass `sessionId: null` to clear the binding. Maps to the trigger's stored
+   *  `ownerSessionId`; the existing queue/drain routes the delivery. */
+  'webhooks.setTargetSession': (args: { id: string; sessionId: string | null }) => Promise<WebhookSummary | null>;
 
   // ---- Desktop apps gallery (install lifecycle) ------------------------
   // All host-only (native pickers + filesystem + a network download). They are

--- a/packages/desktop-ipc-contract/src/scheduler.ts
+++ b/packages/desktop-ipc-contract/src/scheduler.ts
@@ -15,6 +15,12 @@ export interface ScheduleSummary {
   readonly source: ScheduleSource;
   readonly skillName: string | null;
   readonly workflowName: string | null;
+  /** Session this schedule fires in (where its run runs + displays), or null
+   *  when owner-less. Optional for back-compat with older summary producers. */
+  readonly targetSessionId?: string | null;
+  /** Resolved display name of `targetSessionId` (its session title), or null
+   *  when owner-less or the bound session no longer exists. */
+  readonly targetSessionName?: string | null;
   readonly createdAt: number;
   readonly lastRunAt: number | null;
   readonly lastResult: 'ok' | 'error' | null;

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -128,6 +128,8 @@ const workflowName = z
 
 const scheduleId = z.string().min(1).max(256);
 const webhookId = z.string().min(1).max(256);
+/** A target session id (same shape as a session/desk id), or null to clear it. */
+const sessionRef = z.string().min(1).max(256).nullable();
 
 export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
   // No-arg, but spawns a child process (npm install) — pin the payload to
@@ -260,13 +262,18 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
     previousName: workflowName.optional(),
   }),
   'workflows.getRun': z.object({ name: workflowName }),
+  // Reassign a trigger's target session. `sessionId` is a session id (same shape
+  // as the scheduler/webhook ids) or null to clear the binding.
+  'workflows.setTargetSession': z.object({ name: workflowName, sessionId: sessionRef }),
   'scheduler.list': z.undefined(),
   'scheduler.setEnabled': z.object({ id: scheduleId, enabled: z.boolean() }),
+  'scheduler.setTargetSession': z.object({ id: scheduleId, sessionId: sessionRef }),
   'scheduler.delete': z.object({ id: scheduleId }),
   // Webhooks: host-only management of inbound triggers. Lock the id like the
   // scheduler entries; list takes no args.
   'webhooks.list': z.undefined(),
   'webhooks.setEnabled': z.object({ id: webhookId, enabled: z.boolean() }),
+  'webhooks.setTargetSession': z.object({ id: webhookId, sessionId: sessionRef }),
   'webhooks.delete': z.object({ id: webhookId }),
   // Human-in-the-loop resume: bound the run id + the operator reply (the reply
   // is forwarded into the paused step's child agent, so cap it to avoid OOM).

--- a/packages/desktop-ipc-contract/src/webhooks.ts
+++ b/packages/desktop-ipc-contract/src/webhooks.ts
@@ -26,6 +26,12 @@ export interface WebhookSummary {
   readonly lastResult: WebhookLastResult | null;
   readonly lastError: string | null;
   readonly createdAt: number;
+  /** Session this webhook delivers to (where its runs fire + display), or null
+   *  when owner-less. Optional for back-compat with older summary producers. */
+  readonly targetSessionId?: string | null;
+  /** Resolved display name of `targetSessionId` (its session title), or null
+   *  when owner-less or the bound session no longer exists. */
+  readonly targetSessionName?: string | null;
 }
 
 export interface WebhookDeleteResult {

--- a/packages/desktop-ipc-contract/src/workflows.ts
+++ b/packages/desktop-ipc-contract/src/workflows.ts
@@ -7,6 +7,13 @@ export interface WorkflowSummary {
   scope: string;
   steps: number;
   triggers: string;
+  /** Session this workflow's triggered runs are pinned to (where they run +
+   *  display), or null when unpinned. Optional for back-compat with older
+   *  summary producers. */
+  targetSessionId?: string | null;
+  /** Resolved display name of `targetSessionId` (its session title), or null
+   *  when unpinned or the bound session no longer exists. */
+  targetSessionName?: string | null;
 }
 
 export interface WorkflowRun {

--- a/packages/plugin-channel-mobile/src/single-session-host.ts
+++ b/packages/plugin-channel-mobile/src/single-session-host.ts
@@ -235,7 +235,16 @@ export class MobileSessionHost {
     // @moxxy/plugin-workflows is wired — `moxxy mobile` runs the full CLI setup,
     // so it normally is). Absent ⇒ list degrades to empty / setEnabled no-ops
     // (desktop parity) and run fails coded so the UI can hide the surface.
-    this.bus.handle('workflows.list', async () => this.session.workflows?.list() ?? []);
+    this.bus.handle('workflows.list', async () => {
+      const summaries = (await this.session.workflows?.list()) ?? [];
+      // Mobile has no desk registry to resolve a target session's display name;
+      // it surfaces the id only (the picker is a desktop affordance).
+      return summaries.map((s) => ({
+        ...s,
+        targetSessionId: s.targetSessionId ?? null,
+        targetSessionName: null,
+      }));
+    });
     this.bus.handle('workflows.setEnabled', async ({ name, enabled }) => {
       if (this.session.workflows) await this.session.workflows.setEnabled(name, enabled);
     });

--- a/packages/plugin-scheduler/src/runner.ts
+++ b/packages/plugin-scheduler/src/runner.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import type { TriggerOrigin } from '@moxxy/sdk';
 import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import type { ScheduleEntry, ScheduleStore } from './store.js';
 
@@ -19,7 +20,17 @@ export interface SchedulePromptResult {
 }
 
 export interface SchedulePromptRunner {
-  runPrompt(input: { prompt: string; model?: string; scheduleName: string }): Promise<SchedulePromptResult>;
+  runPrompt(input: {
+    prompt: string;
+    model?: string;
+    scheduleName: string;
+    /**
+     * Provenance for the fired turn, so the host can render a compact marker
+     * instead of the raw prompt. A workflow-mirror schedule reports
+     * `kind:'workflow'`; an ordinary schedule reports `kind:'schedule'`.
+     */
+    origin?: TriggerOrigin;
+  }): Promise<SchedulePromptResult>;
 }
 
 export interface ScheduleRunOutcome {
@@ -82,6 +93,12 @@ export async function runSchedule(
       prompt: entry.prompt,
       ...(entry.model ? { model: entry.model } : {}),
       scheduleName: entry.name,
+      // A workflow-mirror row (source='workflow') reads as "Workflow ran";
+      // every other schedule reads as "Schedule fired".
+      origin:
+        entry.source === 'workflow' && entry.workflowName
+          ? { kind: 'workflow', name: entry.workflowName }
+          : { kind: 'schedule', name: entry.name },
     });
   } catch (err) {
     result = {

--- a/packages/plugin-scheduler/src/tools.test.ts
+++ b/packages/plugin-scheduler/src/tools.test.ts
@@ -61,3 +61,54 @@ describe('schedule_create tool — input validation hardening', () => {
     expect((await store.list())).toHaveLength(1);
   });
 });
+
+describe('schedule target session (ownerSessionId routing)', () => {
+  let dir: string;
+  let store: ScheduleStore;
+
+  const tools = (ownerSessionId?: string): ReadonlyArray<ToolDef> =>
+    buildSchedulerTools({
+      store,
+      runner: { runPrompt: async () => ({ text: 'ok' }) },
+      ...(ownerSessionId ? { ownerSessionId } : {}),
+    });
+  const handler = (list: ReadonlyArray<ToolDef>, name: string): ToolDef['handler'] =>
+    list.find((t) => t.name === name)!.handler;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'moxxy-sched-target-'));
+    store = new ScheduleStore({ file: path.join(dir, 'schedules.json') });
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('stamps ownerSessionId from an explicit targetSessionId, overriding the creator', async () => {
+    const out = (await handler(tools('creator'), 'schedule_create')(
+      { name: 'pinned', prompt: 'x', cron: '0 9 * * *', targetSessionId: 'desk-B' },
+      ctx,
+    )) as { id: string };
+    expect((await store.get(out.id))?.ownerSessionId).toBe('desk-B');
+  });
+
+  it('defaults to the creating runner when no targetSessionId is given', async () => {
+    const out = (await handler(tools('creator'), 'schedule_create')(
+      { name: 'default', prompt: 'x', cron: '0 9 * * *' },
+      ctx,
+    )) as { id: string };
+    expect((await store.get(out.id))?.ownerSessionId).toBe('creator');
+  });
+
+  it('schedule_set_target reassigns and clears the binding', async () => {
+    const list = tools('creator');
+    const created = (await handler(list, 'schedule_create')(
+      { name: 'movable', prompt: 'x', cron: '0 9 * * *' },
+      ctx,
+    )) as { id: string };
+    await handler(list, 'schedule_set_target')({ id: created.id, targetSessionId: 'desk-C' }, ctx);
+    expect((await store.get(created.id))?.ownerSessionId).toBe('desk-C');
+    // Omitting targetSessionId clears it (revert to owner-less fire-once).
+    await handler(list, 'schedule_set_target')({ id: created.id }, ctx);
+    expect((await store.get(created.id))?.ownerSessionId).toBeUndefined();
+  });
+});

--- a/packages/plugin-scheduler/src/tools.ts
+++ b/packages/plugin-scheduler/src/tools.ts
@@ -51,6 +51,9 @@ export function describeScheduleEntry(entry: ScheduleEntry): Record<string, unkn
     promptPreview: entry.prompt.slice(0, 200),
     source: entry.source,
     skillName: entry.skillName ?? null,
+    // The session this schedule fires in (where its run executes + displays).
+    // null = owner-less (fires once across runners via the cross-process lock).
+    targetSessionId: entry.ownerSessionId ?? null,
     createdAt: entry.createdAt,
     lastRunAt: entry.lastRunAt ?? null,
     lastResult: entry.lastResult ?? null,
@@ -102,6 +105,14 @@ export function buildSchedulerTools(deps: SchedulerToolDeps): ReadonlyArray<Tool
           prompt: z.string().min(1),
           channel: z.string().optional(),
           model: z.string().optional(),
+          targetSessionId: z
+            .string()
+            .min(1)
+            .optional()
+            .describe(
+              'Session id to fire this schedule in (where its run executes + displays). ' +
+                'Defaults to the session that created the schedule.',
+            ),
         })
         .and(cronOrTimestamp),
       permission: { action: 'prompt' },
@@ -124,9 +135,15 @@ export function buildSchedulerTools(deps: SchedulerToolDeps): ReadonlyArray<Tool
           ...(input.timeZone ? { timeZone: input.timeZone } : {}),
           ...(input.channel ? { channel: input.channel } : {}),
           ...(input.model ? { model: input.model } : {}),
-          // Bind to the creating runner so a multi-runner desktop fires this on
-          // the workspace that asked for it, not whichever poller ticks first.
-          ...(deps.ownerSessionId !== undefined ? { ownerSessionId: deps.ownerSessionId } : {}),
+          // Bind to a target session (where the run fires + displays). An explicit
+          // `targetSessionId` wins; otherwise default to the creating runner so a
+          // multi-runner desktop fires this on the workspace that asked for it, not
+          // whichever poller ticks first. Unset on both → owner-less (fire-once).
+          ...(input.targetSessionId !== undefined
+            ? { ownerSessionId: input.targetSessionId }
+            : deps.ownerSessionId !== undefined
+              ? { ownerSessionId: deps.ownerSessionId }
+              : {}),
         });
         return describeScheduleEntry(created);
       },
@@ -183,6 +200,24 @@ export function buildSchedulerTools(deps: SchedulerToolDeps): ReadonlyArray<Tool
       inputSchema: z.object({ id: z.string().min(1) }),
       handler: async ({ id }) => {
         const updated = await store.update(id, { enabled: false });
+        if (!updated) return { ok: false, reason: 'no schedule with that id' };
+        return { ok: true, schedule: describeScheduleEntry(updated) };
+      },
+    }),
+
+    defineTool({
+      name: 'schedule_set_target',
+      description:
+        'Reassign which session a schedule fires in (where its run executes + displays). ' +
+        'Pass `targetSessionId` to re-home it, or omit it to clear the binding (revert to ' +
+        'owner-less fire-once across runners).',
+      inputSchema: z.object({
+        id: z.string().min(1),
+        targetSessionId: z.string().min(1).optional(),
+      }),
+      permission: { action: 'prompt' },
+      handler: async ({ id, targetSessionId }) => {
+        const updated = await store.update(id, { ownerSessionId: targetSessionId });
         if (!updated) return { ok: false, reason: 'no schedule with that id' };
         return { ok: true, schedule: describeScheduleEntry(updated) };
       },

--- a/packages/plugin-webhooks/src/describe.ts
+++ b/packages/plugin-webhooks/src/describe.ts
@@ -24,6 +24,9 @@ export function describeTrigger(
     verification: redactVerification(trigger.verification),
     filters: trigger.filters,
     idempotencyHeader: trigger.idempotencyHeader ?? null,
+    // The session this webhook delivers to (where its runs fire + display).
+    // null = owner-less (legacy single-process / fire in-process).
+    targetSessionId: trigger.ownerSessionId ?? null,
     fireCount: trigger.fireCount,
     lastFiredAt: trigger.lastFiredAt ?? null,
     lastResult: trigger.lastResult ?? null,

--- a/packages/plugin-webhooks/src/tools.test.ts
+++ b/packages/plugin-webhooks/src/tools.test.ts
@@ -315,3 +315,78 @@ describe('webhook tools', () => {
     });
   });
 });
+
+describe('webhook target session (ownerSessionId routing)', () => {
+  let dir: string;
+  let store: WebhookStore;
+  let tools: ReadonlyArray<ToolDef>;
+
+  const call = async (name: string, input: unknown): Promise<unknown> => {
+    const t = tools.find((x) => x.name === name);
+    if (!t) throw new Error(`no tool ${name}`);
+    return t.handler(t.inputSchema.parse(input), ctx);
+  };
+
+  const build = (ownerSessionId?: string): void => {
+    tools = buildWebhookTools({
+      store,
+      config: new WebhookConfigStore({ file: path.join(dir, 'webhooks-config.json') }),
+      dispatcher: { fire: async () => ({ ok: true, text: '' }) } as unknown as WebhookDispatcher,
+      tunnelHandle: { current: null },
+      secretsDir: path.join(dir, 'secrets'),
+      ...(ownerSessionId ? { ownerSessionId } : {}),
+    });
+  };
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'moxxy-webhook-target-'));
+    store = new WebhookStore({ file: path.join(dir, 'webhooks.json') });
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('stamps ownerSessionId from an explicit targetSessionId', async () => {
+    build();
+    const created = (await call('webhook_create', {
+      name: 'pinned',
+      prompt: 'x',
+      verification: { type: 'none' },
+      targetSessionId: 'desk-B',
+    })) as { trigger: { id: string } };
+    expect((await store.get(created.trigger.id))?.ownerSessionId).toBe('desk-B');
+  });
+
+  it('targetSessionId overrides the creating runner', async () => {
+    build('creator-session');
+    const created = (await call('webhook_create', {
+      name: 'override',
+      prompt: 'x',
+      verification: { type: 'none' },
+      targetSessionId: 'desk-B',
+    })) as { trigger: { id: string } };
+    expect((await store.get(created.trigger.id))?.ownerSessionId).toBe('desk-B');
+  });
+
+  it('defaults to the creating runner when no targetSessionId is given', async () => {
+    build('creator-session');
+    const created = (await call('webhook_create', {
+      name: 'default-owner',
+      prompt: 'x',
+      verification: { type: 'none' },
+    })) as { trigger: { id: string } };
+    expect((await store.get(created.trigger.id))?.ownerSessionId).toBe('creator-session');
+  });
+
+  it('webhook_update reassigns the target session', async () => {
+    build('creator-session');
+    const created = (await call('webhook_create', {
+      name: 'movable',
+      prompt: 'x',
+      verification: { type: 'none' },
+    })) as { trigger: { id: string } };
+    await call('webhook_update', { id: created.trigger.id, targetSessionId: 'desk-C' });
+    expect((await store.get(created.trigger.id))?.ownerSessionId).toBe('desk-C');
+  });
+});

--- a/packages/plugin-webhooks/src/tools/create.ts
+++ b/packages/plugin-webhooks/src/tools/create.ts
@@ -56,6 +56,15 @@ export function defineWebhookCreateTool(deps: ResolvedToolDeps): ToolDef {
       filters: filterInputSchema.optional(),
       idempotencyHeader: z.string().optional(),
       description: z.string().optional(),
+      targetSessionId: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          'Session id to deliver this webhook to (where its runs execute + display). ' +
+            'Defaults to the session that created the trigger. On the desktop this is a ' +
+            "session's id; the runner owning that session drains and fires the delivery.",
+        ),
     }),
     permission: { action: 'prompt' },
     handler: async (input) => {
@@ -70,9 +79,15 @@ export function defineWebhookCreateTool(deps: ResolvedToolDeps): ToolDef {
         filters,
         ...(input.idempotencyHeader ? { idempotencyHeader: input.idempotencyHeader } : {}),
         ...(input.description ? { description: input.description } : {}),
-        // Bind to the creating runner so its deliveries fire on this workspace's
-        // chat, even though another runner may own the shared listener port.
-        ...(deps.ownerSessionId !== undefined ? { ownerSessionId: deps.ownerSessionId } : {}),
+        // Bind to a target session (where deliveries fire + display). An explicit
+        // `targetSessionId` wins; otherwise default to the creating runner so its
+        // deliveries fire on this workspace's chat, even though another runner may
+        // own the shared listener port. Unset on both → owner-less (legacy).
+        ...(input.targetSessionId !== undefined
+          ? { ownerSessionId: input.targetSessionId }
+          : deps.ownerSessionId !== undefined
+            ? { ownerSessionId: deps.ownerSessionId }
+            : {}),
       });
 
       const cfg = await config.get();

--- a/packages/plugin-webhooks/src/tools/update.ts
+++ b/packages/plugin-webhooks/src/tools/update.ts
@@ -20,10 +20,20 @@ export function defineWebhookUpdateTool(deps: ResolvedToolDeps): ToolDef {
       description: z.string().optional(),
       idempotencyHeader: z.string().optional(),
       filters: filterInputSchema.optional(),
+      targetSessionId: z
+        .string()
+        .min(1)
+        .optional()
+        .describe('Reassign which session this webhook delivers to (where its runs execute + display).'),
     }),
     permission: { action: 'prompt' },
-    handler: async ({ id, ...patch }) => {
-      const updated = await store.update(id, patch);
+    handler: async ({ id, targetSessionId, ...patch }) => {
+      // `targetSessionId` is the user-facing name for the stored `ownerSessionId`
+      // routing key — map it so reassigning a webhook re-homes its deliveries.
+      const updated = await store.update(id, {
+        ...patch,
+        ...(targetSessionId !== undefined ? { ownerSessionId: targetSessionId } : {}),
+      });
       if (!updated) return { ok: false, reason: 'no trigger with that id' };
       const cfg = await config.get();
       return { ok: true, trigger: describeTrigger(updated, cfg.publicUrl) };

--- a/packages/plugin-workflows/src/schema.ts
+++ b/packages/plugin-workflows/src/schema.ts
@@ -215,6 +215,10 @@ export const workflowSchema = z
     enabled: z.boolean().default(true),
     inputs: z.record(inputSpecSchema).default({}),
     on: triggerSchema.optional(),
+    // Pin triggered runs (schedule/fileChanged/afterWorkflow) to a chosen
+    // runner's session so the run executes + displays there. Unset → ambient
+    // fire-once across runners (today's behavior). See `Workflow.targetSessionId`.
+    targetSessionId: z.string().min(1).optional(),
     delivery: z
       .object({
         channel: z.string().optional(),

--- a/packages/sdk/src/events.ts
+++ b/packages/sdk/src/events.ts
@@ -32,10 +32,27 @@ export interface UserPromptAttachment {
   readonly mediaType?: string;
 }
 
+/**
+ * Provenance of a machine-initiated prompt: an ambient trigger (a fired
+ * webhook, a fired schedule, or a triggered workflow) ran a turn rather than a
+ * human typing it. Carried on {@link UserPromptEvent.origin} so renderers can
+ * collapse the (often large, untrusted-payload-bearing) synthesized prompt into
+ * a compact "trigger fired" marker instead of a giant user bubble. The prompt
+ * text stays in the event (and thus in the model's context) — only the *display*
+ * changes. Absent for an ordinary user-typed prompt.
+ */
+export interface TriggerOrigin {
+  readonly kind: 'webhook' | 'schedule' | 'workflow';
+  /** The trigger's name (webhook/schedule/workflow), for the marker label. */
+  readonly name: string;
+}
+
 export interface UserPromptEvent extends EventBase {
   readonly type: 'user_prompt';
   readonly text: string;
   readonly attachments?: ReadonlyArray<UserPromptAttachment>;
+  /** Set when an ambient trigger fired this turn (see {@link TriggerOrigin}). */
+  readonly origin?: TriggerOrigin;
 }
 
 export interface AssistantChunkEvent extends EventBase {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -17,6 +17,7 @@ export type {
   EmittedEvent,
   UserPromptEvent,
   UserPromptAttachment,
+  TriggerOrigin,
   AssistantChunkEvent,
   AssistantMessageEvent,
   ReasoningChunkEvent,

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -1,4 +1,4 @@
-import type { MoxxyEvent, UserPromptAttachment } from './events.js';
+import type { MoxxyEvent, TriggerOrigin, UserPromptAttachment } from './events.js';
 import type { SessionId, TurnId } from './ids.js';
 import type { EventLogReader } from './log.js';
 import type { ApprovalResolver, ModeBadge } from './mode.js';
@@ -22,6 +22,13 @@ export interface RunTurnOptions {
   readonly signal?: AbortSignal;
   /** Inline attachments shipped alongside the prompt (images, audio, stdin). */
   readonly attachments?: ReadonlyArray<UserPromptAttachment>;
+  /**
+   * Provenance for a machine-initiated turn (a fired webhook/schedule/workflow).
+   * Stamped onto the resulting {@link UserPromptEvent} so renderers show a
+   * compact "trigger fired" marker instead of the raw synthesized prompt. Omit
+   * for an ordinary user-typed turn.
+   */
+  readonly origin?: TriggerOrigin;
   /**
    * Pre-minted turn id. When omitted, `runTurn` mints one. The runner passes
    * this so it can return the id to the client *before* the turn starts and
@@ -191,6 +198,12 @@ export interface WorkflowSummaryView {
   readonly steps: number;
   /** Human-readable trigger summary, e.g. `cron(0 8 * * *)` or `on-demand`. */
   readonly triggers: string;
+  /**
+   * Session this workflow's triggered runs are pinned to (where they run +
+   * display), or null when unpinned. Optional for wire back-compat — an older
+   * runner omits it; the desktop treats absent as null.
+   */
+  readonly targetSessionId?: string | null;
 }
 
 /** Result of running a workflow from the modal. */

--- a/packages/sdk/src/workflow.ts
+++ b/packages/sdk/src/workflow.ts
@@ -151,6 +151,26 @@ export interface Workflow {
   readonly enabled: boolean;
   readonly inputs: Record<string, WorkflowInputSpec>;
   readonly on?: WorkflowTrigger;
+  /**
+   * Pin this workflow's *triggered* runs (schedule / fileChanged / afterWorkflow)
+   * to one chosen runner's session — identified by that runner's
+   * `MOXXY_SESSION_ID` — so the run executes and displays in the session the user
+   * picked. On the desktop, one `moxxy serve` runner == one session.
+   *
+   * - schedule: the scheduler mirror row is stamped with this as its owner, so the
+   *   existing poller owner-gate fires the run on the target runner.
+   * - fileChanged: only the runner whose id matches watches/fires the trigger. If
+   *   that runner is offline when the file changes, the event is missed — there is
+   *   no fs-event replay (unlike webhooks/schedules, which catch up).
+   * - afterWorkflow: a dependent pinned to a *different* session than the runner
+   *   that observed the parent's completion is skipped (the completion event is
+   *   in-process); co-locate the chain or use a schedule trigger for fan-out.
+   *
+   * Unset (the default) preserves today's ambient behavior: triggered runs fire
+   * once across runners via the cross-process lock. Ignored in single-process
+   * CLI/TUI (no `MOXXY_SESSION_ID`).
+   */
+  readonly targetSessionId?: string;
   readonly delivery?: WorkflowDelivery;
   /** GUI-only metadata persisted with the YAML artifact. */
   readonly ui?: WorkflowUi;

--- a/packages/workflows-builder/src/serialize.test.ts
+++ b/packages/workflows-builder/src/serialize.test.ts
@@ -54,6 +54,18 @@ describe('serialize → Workflow', () => {
     expect(yaml).toContain('loop:');
   });
 
+  it('round-trips targetSessionId through serialize → hydrate → hydrateYaml', () => {
+    let s = refineFixture();
+    s = updateMeta(s, { targetSessionId: 'desk-B' });
+    const { workflow, yaml } = serialize(s);
+    // Survives serialize (the field-by-field serializer would otherwise drop it).
+    expect(workflow.targetSessionId).toBe('desk-B');
+    expect(yaml).toContain('targetSessionId: desk-B');
+    // ...and the inverse: hydrate from the object and from the YAML both keep it.
+    expect(hydrate(workflow).meta.targetSessionId).toBe('desk-B');
+    expect(hydrateYaml(yaml).meta.targetSessionId).toBe('desk-B');
+  });
+
   it('serializes multiline prompts as block scalars that round-trip', () => {
     const s = refineFixture();
     const { yaml } = serialize(s);

--- a/packages/workflows-builder/src/serialize.ts
+++ b/packages/workflows-builder/src/serialize.ts
@@ -74,6 +74,7 @@ export function serialize(state: BuilderState): SerializeResult {
     enabled: state.meta.enabled,
     inputs: state.meta.inputs,
     ...(state.meta.on ? { on: state.meta.on } : {}),
+    ...(state.meta.targetSessionId ? { targetSessionId: state.meta.targetSessionId } : {}),
     ...(state.meta.delivery ? { delivery: state.meta.delivery } : {}),
     ui: { layout },
     concurrency: state.meta.concurrency,
@@ -139,6 +140,7 @@ export function hydrate(workflow: Workflow): BuilderState {
     concurrency: workflow.concurrency,
     inputs: workflow.inputs ?? {},
     ...(workflow.on ? { on: workflow.on } : {}),
+    ...(workflow.targetSessionId ? { targetSessionId: workflow.targetSessionId } : {}),
     ...(workflow.delivery ? { delivery: workflow.delivery } : {}),
   };
   const viewport = workflow.ui?.layout?.viewport ?? DEFAULT_VIEWPORT;
@@ -192,6 +194,7 @@ function normalizeWorkflow(raw: Partial<Workflow>): Workflow {
     enabled: raw.enabled ?? true,
     inputs: raw.inputs ?? {},
     ...(raw.on ? { on: raw.on } : {}),
+    ...(raw.targetSessionId ? { targetSessionId: raw.targetSessionId } : {}),
     ...(raw.delivery ? { delivery: raw.delivery } : {}),
     ...(raw.ui ? { ui: raw.ui } : {}),
     concurrency: raw.concurrency ?? 4,

--- a/packages/workflows-builder/src/types.ts
+++ b/packages/workflows-builder/src/types.ts
@@ -108,6 +108,8 @@ export interface BuilderMeta {
   concurrency: number;
   inputs: Record<string, WorkflowInputSpec>;
   on?: WorkflowTrigger;
+  /** Session this workflow's triggered runs are pinned to (where they run + display). */
+  targetSessionId?: string;
   delivery?: WorkflowDelivery;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -989,6 +989,9 @@ importers:
       pdfjs-dist:
         specifier: 4.10.38
         version: 4.10.38
+      yaml:
+        specifier: ^2.6.0
+        version: 2.9.0
     devDependencies:
       '@moxxy/testing':
         specifier: workspace:*


### PR DESCRIPTION
## What

Two related changes to ambient triggers (webhooks, schedules, workflows):

**1. Pick the target session.** Each trigger can be pinned to a chosen session — where its run executes *and* displays — decoupled from who created it.
- `webhook_create` / `schedule_create` take an optional `targetSessionId` (defaults to the creating session); `webhook_update` / the new `schedule_set_target` reassign it. These map onto the existing `ownerSessionId` routing key, so the webhook queue/drain and the scheduler owner-gate already deliver to the right runner — **no routing change**.
- Workflows gained a top-level `targetSessionId` (they had no owner concept): scheduled workflows stamp it onto their scheduler-mirror row (reuses the owner-gate); `fileChanged` is watched only by the target runner; a cross-session `afterWorkflow` dependent is skipped with a warning (the completion event is in-process to the parent's runner — logged in TECH_DEBT). The visual builder serializer preserves the field.
- Desktop: the Webhooks / Schedules / Workflows panels and the workflow builder gain a session picker (new `*.setTargetSession` IPC commands); each summary surfaces the resolved target-session name.

**2. Compact trigger marker.** A fired trigger renders as a one-line, expandable chip ("Webhook received · github-issues", "Schedule fired · daily", "Workflow ran · digest") instead of the raw prompt — click to reveal the full payload. The prompt still lives in the model's context (untrusted-payload fences intact); only the display changes (new optional `origin` on the `user_prompt` event, threaded from the fired turn via `RunTurnOptions.origin`).

## Why

`ownerSessionId` already decided which runner executes + displays a trigger, but it was auto-stamped to the *creating* session with no way to choose. And the synthesized prompt — frequently a large block carrying an untrusted webhook payload — rendered as a giant user bubble, burying the agent's actual answer. This makes the destination pickable and declutters the transcript.

Unset everywhere preserves today's behavior; single-process CLI/TUI is unaffected.

## Verification

- `pnpm build` / `typecheck` (143 tasks) / `test` / `lint` (0 errors) / `check:deps` — all green, after rebasing onto latest `origin/main`.
- Added 15 tests: webhook/schedule `targetSessionId` stamping + reassign, the workflow target-session gate matrix (match fires / mismatch skips / single-process no-gate) + scheduled-workflow mirror stamping, builder round-trip preserves the field, and the renderer trigger-marker (collapsed → hides payload, expand → reveals it).
- **Not exercised in CI (manual, pre-release):** packaged-desktop end-to-end — create a webhook in session A, retarget to B, deliver a payload → run lands in B as a collapsed marker. The host gained a static `yaml` import (pure JS, no eager-crypto like the `ulid` boot hazard); worth a `verify-desktop-packaged` smoke.