### PR TITLE
feat(desktop): inline context meter on the model control + collapsible prompt composition

### DIFF
--- a/.changeset/desktop-composer-context-meter.md
+++ b/.changeset/desktop-composer-context-meter.md
@@ -1,0 +1,8 @@
+---
+"@moxxy/desktop": patch
+---
+
+Desktop: show context usage at a glance on the composer's model control.
+
+- The borderless **model label** (e.g. `gpt-5.5 ▾`) now carries a hair-thin context-window meter directly beneath it — a tiny fill bar plus a tabular percentage that color-ramps to amber (≥60%) and red (≥85%) as the window fills, so current context usage is visible without opening the panel. It appears as soon as the active model's context window is known and stays in sync with the full meter inside **Model & context**.
+- In the **Model & context** panel, **Prompt composition** is now a collapsible section, collapsed by default. The header keeps its `N calls · … prompt` teaser and gains a disclosure caret; expanding it reveals the cache-read / fresh-input / cache-write breakdown, cache-hit/savings line, and the per-call sparkline.

--- a/apps/desktop/src/chat/composer/ModelContextControl.test.tsx
+++ b/apps/desktop/src/chat/composer/ModelContextControl.test.tsx
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { __setApiOverride } from '@moxxy/client-core';
+import { __setApiOverride, chatStore } from '@moxxy/client-core';
 import type { MoxxyApi } from '@moxxy/desktop-ipc-contract';
+import type { MoxxyEvent } from '@moxxy/sdk';
 import { ModelContextControl } from './ModelContextControl';
 import type { SessionInfo } from '../agent-picker/types';
 
@@ -14,12 +15,38 @@ const info: SessionInfo = {
 };
 
 function installApi(): void {
+  // session.info (fetched by useContextUsage) carries the active model's context
+  // window — without it the meters can't compute a fraction, so seed one here.
+  const sessionInfo = {
+    ...info,
+    providers: [{ name: 'openai-codex', models: [{ id: 'gpt-5', contextWindow: 1000 }] }],
+  };
   const invoke = vi.fn(async (cmd: string) => {
-    if (cmd === 'session.info') return info;
+    if (cmd === 'session.info') return sessionInfo;
     if (cmd === 'settings.adminProviders') return [];
     return undefined;
   });
   __setApiOverride({ invoke, subscribe: () => () => {} } as unknown as MoxxyApi);
+}
+
+/** Fold one prompt-bearing provider_response into the store so the workspace
+ *  reports `inputTokens` of used context (drives the meter + composition). */
+function seedUsage(workspaceId: string, inputTokens: number): void {
+  chatStore.dispatch(workspaceId, {
+    type: 'event',
+    event: {
+      id: 'e1',
+      seq: 1,
+      ts: 1,
+      turnId: 'T1',
+      sessionId: 'S',
+      source: 'model',
+      type: 'provider_response',
+      provider: 'p',
+      model: 'm',
+      inputTokens,
+    } as unknown as MoxxyEvent,
+  });
 }
 
 afterEach(() => {
@@ -64,5 +91,44 @@ describe('ModelContextControl', () => {
     expect(onPick).toHaveBeenCalledWith('openai-codex', 'gpt-5');
     // Picking a model closes the panel.
     await waitFor(() => expect(screen.queryByText('Model & context')).toBeNull());
+  });
+
+  it('renders an inline context-usage percentage on the trigger button', async () => {
+    installApi();
+    // 100 used tokens against a 1.0k window → 10%.
+    seedUsage('ws-meter', 100);
+    render(
+      <ModelContextControl
+        workspaceId="ws-meter"
+        info={info}
+        selectedModel={null}
+        disabled={false}
+        onPick={vi.fn()}
+      />,
+    );
+    // The meter waits on the async session.info fetch for the context window.
+    expect(await screen.findByText('10%')).toBeInTheDocument();
+  });
+
+  it('keeps the prompt-composition detail collapsed until expanded', async () => {
+    installApi();
+    seedUsage('ws-collapse', 100);
+    render(
+      <ModelContextControl
+        workspaceId="ws-collapse"
+        info={info}
+        selectedModel={null}
+        disabled={false}
+        onPick={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /open model & context/i }));
+    // The composition header shows by default, but its breakdown rows stay hidden.
+    expect(await screen.findByText('Prompt composition')).toBeInTheDocument();
+    expect(screen.queryByText('Cache read')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /prompt composition/i }));
+    expect(await screen.findByText('Cache read')).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/chat/composer/ModelContextControl.tsx
+++ b/apps/desktop/src/chat/composer/ModelContextControl.tsx
@@ -3,7 +3,7 @@ import { Button, Modal } from '@moxxy/desktop-ui';
 import { useContextUsage } from '@moxxy/client-core';
 import type { SessionInfo } from '../agent-picker/types';
 import { ProviderModelGrid } from '../agent-picker/ProviderModelGrid';
-import { UsagePanel } from './UsagePanel';
+import { UsagePanel, fillColor } from './UsagePanel';
 
 /**
  * The composer's right-aligned model control — a subtle, borderless text label
@@ -39,22 +39,38 @@ export function ModelContextControl({
         disabled={disabled}
         onClick={() => setOpen(true)}
         title="Model & context"
-        aria-label={`Model ${label} — open model & context`}
-        style={{ gap: 5, padding: '6px 8px', fontSize: 12.5, maxWidth: 220, fontWeight: 600 }}
+        aria-label={
+          usage.fraction != null
+            ? `Model ${label}, context ${pct(usage.fraction)} used — open model & context`
+            : `Model ${label} — open model & context`
+        }
+        style={{
+          flexDirection: 'column',
+          alignItems: 'stretch',
+          gap: 3,
+          padding: '4px 9px',
+          fontSize: 12.5,
+          minWidth: 96,
+          maxWidth: 220,
+          fontWeight: 600,
+        }}
       >
-        <span
-          style={{
-            color: 'var(--color-text)',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {label}
+        <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 5 }}>
+          <span
+            style={{
+              color: 'var(--color-text)',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {label}
+          </span>
+          <span aria-hidden style={{ color: 'var(--color-text-dim)' }}>
+            ▾
+          </span>
         </span>
-        <span aria-hidden style={{ color: 'var(--color-text-dim)' }}>
-          ▾
-        </span>
+        {usage.fraction != null && <ContextMeter fraction={usage.fraction} />}
       </Button>
       {open && (
         <Modal title="Model & context" width={620} onClose={() => setOpen(false)}>
@@ -78,5 +94,57 @@ export function ModelContextControl({
         </Modal>
       )}
     </>
+  );
+}
+
+function pct(f: number): string {
+  return `${Math.round(f * 100)}%`;
+}
+
+/**
+ * The inline context-window mini-meter that rides under the model name: a hair-
+ * thin fill bar plus a tabular percent, color-ramped (amber/red) as the window
+ * fills — a quiet at-a-glance gauge that the full panel expands on. Sized to sit
+ * inside the ghost button without changing its rhythm.
+ */
+function ContextMeter({ fraction }: { readonly fraction: number }): JSX.Element {
+  const f = Math.max(0, Math.min(1, fraction));
+  const color = fillColor(f);
+  return (
+    <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+      <span
+        style={{
+          flex: 1,
+          height: 3,
+          borderRadius: 999,
+          background: 'color-mix(in srgb, var(--color-text-dim) 22%, transparent)',
+          overflow: 'hidden',
+        }}
+      >
+        <span
+          style={{
+            display: 'block',
+            width: `${f * 100}%`,
+            height: '100%',
+            borderRadius: 999,
+            background: color,
+            transition: 'width 240ms ease',
+          }}
+        />
+      </span>
+      <span
+        className="mono"
+        style={{
+          flexShrink: 0,
+          fontSize: 9.5,
+          fontWeight: 600,
+          lineHeight: 1,
+          color,
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        {pct(f)}
+      </span>
+    </span>
   );
 }

--- a/apps/desktop/src/chat/composer/UsagePanel.tsx
+++ b/apps/desktop/src/chat/composer/UsagePanel.tsx
@@ -15,7 +15,9 @@ function pct(f: number): string {
   return `${Math.round(f * 100)}%`;
 }
 
-function fillColor(f: number): string {
+/** Context-fill color ramp — primary → amber (≥60%) → red (≥85%). Shared with
+ *  the composer's inline mini-meter so both read the same severity at a glance. */
+export function fillColor(f: number): string {
   return f >= 0.85 ? 'var(--color-red)' : f >= 0.6 ? 'var(--color-amber)' : 'var(--color-primary)';
 }
 
@@ -36,6 +38,10 @@ export function UsagePanel({
 }): JSX.Element {
   const [compacting, setCompacting] = useState(false);
   const [note, setNote] = useState<{ kind: 'ok' | 'error'; text: string } | null>(null);
+  // Prompt composition is detail-on-demand — collapsed by default so the panel
+  // leads with the context-window fill; the header still shows the calls/prompt
+  // teaser so it's worth expanding.
+  const [compOpen, setCompOpen] = useState(false);
   // The shared per-workspace compaction lock. Reading it (not just our local
   // `compacting`) keeps the button disabled even if the panel is closed and
   // reopened mid-compaction — otherwise a second compaction could race the
@@ -105,7 +111,12 @@ export function UsagePanel({
       </Section>
 
       {s.calls > 0 && (
-        <Section title="Prompt composition" subtitle={`${s.calls} calls · ${fmt(s.totalPrompt)} prompt`}>
+        <CollapsibleSection
+          title="Prompt composition"
+          subtitle={`${s.calls} calls · ${fmt(s.totalPrompt)} prompt`}
+          open={compOpen}
+          onToggle={() => setCompOpen((v) => !v)}
+        >
           <CompRow label="Cache read" frac={readFrac} value={s.totalCacheRead} color="var(--color-green)" />
           <CompRow label="Fresh input" frac={freshFrac} value={s.totalInput} color="var(--color-primary)" />
           <CompRow label="Cache write" frac={writeFrac} value={s.totalCacheCreation} color="var(--color-amber)" />
@@ -131,7 +142,7 @@ export function UsagePanel({
             )}
           </div>
           {usage.perCall.length >= 2 && <Sparkline series={usage.perCall} />}
-        </Section>
+        </CollapsibleSection>
       )}
 
       <footer style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 2 }}>
@@ -186,6 +197,77 @@ function Section({
         )}
       </div>
       {children}
+    </section>
+  );
+}
+
+/**
+ * A `Section` whose body collapses behind its header. The header stays a full
+ * status line — title + subtitle teaser — with a rotating disclosure caret, so
+ * the summary is readable even while closed and one click reveals the detail.
+ */
+function CollapsibleSection({
+  title,
+  subtitle,
+  open,
+  onToggle,
+  children,
+}: {
+  readonly title: string;
+  readonly subtitle?: string;
+  readonly open: boolean;
+  readonly onToggle: () => void;
+  readonly children: React.ReactNode;
+}): JSX.Element {
+  const bodyId = `comp-${title.replace(/\s+/g, '-').toLowerCase()}`;
+  return (
+    <section style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        aria-controls={bodyId}
+        title={open ? 'Hide details' : 'Show details'}
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          gap: 8,
+          width: '100%',
+          padding: 0,
+          background: 'transparent',
+          border: 'none',
+          textAlign: 'left',
+          cursor: 'pointer',
+          color: 'inherit',
+        }}
+      >
+        <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span
+            aria-hidden
+            style={{
+              display: 'inline-block',
+              fontSize: 9,
+              color: 'var(--color-text-dim)',
+              transform: open ? 'rotate(90deg)' : 'none',
+              transition: 'transform 160ms ease',
+            }}
+          >
+            ▶
+          </span>
+          <h3 style={{ margin: 0, fontSize: 12, fontWeight: 700, color: 'var(--color-text)' }}>{title}</h3>
+        </span>
+        {subtitle && (
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--color-text-dim)' }}>
+            {subtitle}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div id={bodyId} style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {children}
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## What

Two composer refinements to surface context-window usage at a glance and declutter the **Model & context** panel.

### Inline context meter on the model control
The borderless model label (e.g. `gpt-5.5 ▾`) now carries a hair-thin context-window meter directly beneath it — a tiny fill bar plus a tabular percentage that color-ramps to **amber (≥60%)** and **red (≥85%)** as the window fills. So current context usage is visible without opening the panel.

- Reuses the existing `useContextUsage` hook already in `ModelContextControl`.
- Shares the `fillColor` ramp with `UsagePanel` (now exported) so the inline meter and the full panel read identical severity.
- Renders as soon as the active model's context window is known (matching the panel's "shows at 0% on fresh connect" semantics) and stays in sync with the full meter.

### Collapsible "Prompt composition"
In the **Model & context** panel, **Prompt composition** is now a collapsible section, **collapsed by default**. The header keeps its `N calls · … prompt` teaser and gains a rotating disclosure caret; expanding reveals the cache-read / fresh-input / cache-write breakdown, the cache-hit/savings line, and the per-call sparkline. The context-window fill stays always-visible above it, so the panel leads with the headline number.

## Changes
- `apps/desktop/src/chat/composer/ModelContextControl.tsx` — vertical button layout + new `ContextMeter`.
- `apps/desktop/src/chat/composer/UsagePanel.tsx` — export `fillColor`; new `CollapsibleSection`; Prompt composition collapsed by default.
- `apps/desktop/src/chat/composer/ModelContextControl.test.tsx` — 2 new tests (inline `%` renders; composition stays collapsed until expanded).

## Verification
- `pnpm build`: 73/73 tasks ✓
- Desktop typecheck: clean ✓
- ESLint (changed files): clean ✓
- Tests: 9 pass (incl. 2 new) ✓
- Changeset added (`@moxxy/desktop` patch).