### PR TITLE
feat(providers): borrow credentials from installed claude/codex CLIs

### DIFF
--- a/.changeset/connect-installed-clis.md
+++ b/.changeset/connect-installed-clis.md
@@ -1,0 +1,12 @@
+---
+"@moxxy/cli": minor
+"@moxxy/sdk": minor
+"@moxxy/desktop": minor
+---
+
+Connect locally-installed `claude` and `codex` CLIs as providers, fix the desktop provider-config feedback, and stop claude-code defaulting to a gated model.
+
+- **Borrow credentials from an installed CLI.** `claude-code` and `openai-codex` now resolve credentials in the order vault (`moxxy login`) → env var → the installed CLI's own store — codex `~/.codex/auth.json` (honors `CODEX_HOME`), claude macOS Keychain (`Claude Code-credentials`) / `~/.claude/.credentials.json` (override via `MOXXY_CLAUDE_CREDENTIALS_FILE`). If you're already signed into `claude`/`codex`, the provider just works with no separate `moxxy login`. This is "borrow live": the installed CLI stays the owner that refreshes the token; moxxy only refreshes + writes the rotated bundle back when the CLI's own token has gone stale, so the two never invalidate each other's (rotating, single-use) refresh token.
+- **"Connected via installed CLI" badge.** A new optional `ProviderInfo.credentialSource` (`vault` | `env` | `installed-cli` | …) flows through the runner to desktop Settings → Providers, so an auto-borrowed provider reads "Active · connected via installed CLI" instead of looking unconfigured. Purely additive — no runner protocol bump.
+- **Desktop: provider config now gives feedback.** Completing an OAuth sign-in (or any provider-config change) now re-probes readiness on the runner before refetching, so the row's readiness dot and subtitle flip live instead of showing a stale snapshot. Previously the OAuth path refetched a cached snapshot and appeared to do nothing.
+- **Honor `provider.model` from config.** Turns fell back to the provider catalog's first model when `provider.model` wasn't applied; for the Anthropic/claude-code catalog that first entry is a reasoning-tier model some subscriptions can't access (the API 404s "use Opus instead"). The configured model is now applied as the session's initial model.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -129,11 +129,17 @@ or recorded-on-purpose decision.
   its next launch. Never fires on the common path (an active CLI keeps its token
   fresh, so moxxy only ever reads). A native Keychain binding that preserves the ACL
   on update would remove the caveat. `packages/plugin-provider-claude-code/src/cli-creds.ts`.
-- [low, verify] Codex installed-CLI borrow is unit-tested (read/write/resolution) but
-  not live-rotated end-to-end — the local `~/.codex/auth.json` is months stale, so a
-  live run would refresh + write back the user's real codex token. Verify the
-  refresh+write-back against a fresh `codex` login before relying on it.
-  `packages/plugin-provider-openai-codex/src/cli-creds.ts`.
+- [note] Codex installed-CLI borrow is live-verified end-to-end: a stale
+  `~/.codex/auth.json` (access token 23h expired) auto-refreshed + wrote the rotated
+  bundle back (token went +240h, all fields preserved), then `gpt-5.5`/`5.4`/`5.4-mini`
+  returned real completions with NO billing gate (ChatGPT plan is in-plan, unlike
+  claude's extra-usage policy). `packages/plugin-provider-openai-codex/src/cli-creds.ts`.
+- [low] ChatGPT-account Codex rejects some catalog models with a 400 ("not supported
+  when using Codex with a ChatGPT account") — `gpt-5.2` and the `-codex` variants
+  (incl. `DEFAULT_CODEX_MODEL = gpt-5.3-codex`) fail; base models `gpt-5.5/5.4/5.4-mini`
+  work. run-turn defaults to `models[0]` (gpt-5.5) so the out-of-box path is fine, but
+  the provider's own `defaultModel` fallback would 400 on the OAuth path. Consider a
+  ChatGPT-vs-API-key-aware default. `packages/plugin-provider-openai-codex/src/models.ts`.
 - [note] Subscription OAuth tokens used by third-party apps (claude-code/openai-codex
   borrowing the installed CLI's token) are metered by the vendor against pay-as-you-go
   "extra usage", NOT plan limits — a real agentic request can 400 with "Add more at

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -123,6 +123,22 @@ or recorded-on-purpose decision.
   Anthropic round-trips fully. `packages/plugin-provider-*/`.
 - [low] Hardcoded catalogs span 5+ providers and drift — a shared
   OpenAI-compatible-vendor catalog or `/v1/models`-backed refresh would self-update.
+- [low, note] Installed-CLI "borrow live" write-back on macOS rewrites the Keychain
+  item via `security add-generic-password -U`, which can reset its ACL — so after a
+  moxxy-driven refresh of a STALE claude token the `claude` CLI may prompt once on
+  its next launch. Never fires on the common path (an active CLI keeps its token
+  fresh, so moxxy only ever reads). A native Keychain binding that preserves the ACL
+  on update would remove the caveat. `packages/plugin-provider-claude-code/src/cli-creds.ts`.
+- [low, verify] Codex installed-CLI borrow is unit-tested (read/write/resolution) but
+  not live-rotated end-to-end — the local `~/.codex/auth.json` is months stale, so a
+  live run would refresh + write back the user's real codex token. Verify the
+  refresh+write-back against a fresh `codex` login before relying on it.
+  `packages/plugin-provider-openai-codex/src/cli-creds.ts`.
+- [note] Subscription OAuth tokens used by third-party apps (claude-code/openai-codex
+  borrowing the installed CLI's token) are metered by the vendor against pay-as-you-go
+  "extra usage", NOT plan limits — a real agentic request can 400 with "Add more at
+  claude.ai/settings/usage". This is vendor billing policy, not a moxxy bug; the
+  provider already surfaces the message verbatim. Don't re-investigate as a request-shape bug.
 
 ## Channels, relay & HTTP
 

--- a/apps/desktop/src/settings/ProvidersTab.tsx
+++ b/apps/desktop/src/settings/ProvidersTab.tsx
@@ -181,10 +181,25 @@ export function ProvidersTab({
 
 function subtitleFor(p: ProviderRow): string {
   if (!p.enabled) return 'Disabled · excluded from activation';
-  if (p.ready) return 'Active · credentials resolved';
+  if (p.ready) return `Active · ${sourceLabel(p.credentialSource)}`;
   return p.authKind === 'oauth'
     ? 'Inactive · sign in to connect'
     : 'Inactive · add a key to use';
+}
+
+/** Human label for where a ready provider's credentials came from. */
+function sourceLabel(source: ProviderRow['credentialSource']): string {
+  switch (source) {
+    case 'installed-cli':
+      return 'connected via installed CLI';
+    case 'env':
+      return 'using an environment variable';
+    case 'vault':
+    case 'prompt':
+    case 'config':
+    default:
+      return 'credentials resolved';
+  }
 }
 
 /**

--- a/apps/desktop/src/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/settings/SettingsPanel.tsx
@@ -46,7 +46,10 @@ const TAB_DESCRIPTORS: ReadonlyArray<TabDescriptor> = [
         onToggle={s.setProviderEnabled}
         onConfigure={s.configureProvider}
         onSetKey={s.setProviderKey}
-        onRefresh={s.refresh}
+        // Re-probe readiness on any provider-config change (esp. after an OAuth
+        // sign-in) so the row's readiness + "connected via …" subtitle flip
+        // without a restart — a plain refresh would refetch a stale snapshot.
+        onRefresh={s.reprobeProviders}
         search={<SearchBox value={query} onChange={setQuery} placeholder="Search providers…" />}
       />
     ),

--- a/packages/cli/src/provider-credentials.test.ts
+++ b/packages/cli/src/provider-credentials.test.ts
@@ -3,17 +3,35 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { VaultStore, createStaticKeySource, deriveKey, generateSalt } from '@moxxy/plugin-vault';
-import { resolveProviderCredentials } from './provider-credentials.js';
+import {
+  resolveProviderCredentials,
+  resolveProviderCredentialsDetailed,
+} from './provider-credentials.js';
 
 let tmp: string;
 let vault: VaultStore;
+let codexAuth: string;
+let claudeCreds: string;
 const priorMoxxyHome = process.env.MOXXY_HOME;
+const priorCodexHome = process.env.CODEX_HOME;
+const priorClaudeFile = process.env.MOXXY_CLAUDE_CREDENTIALS_FILE;
+const CLAUDE_ENV_VARS = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_AUTH_TOKEN'] as const;
+const priorClaudeEnv = new Map(CLAUDE_ENV_VARS.map((k) => [k, process.env[k]] as const));
 
 beforeEach(async () => {
+  // A real token in the ambient env would win before the installed-CLI fallback
+  // and make these tests non-hermetic — clear them for the suite.
+  for (const k of CLAUDE_ENV_VARS) delete process.env[k];
   tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-creds-'));
   // storedProviderApiKeyName reads ~/.moxxy/providers.json via moxxyPath —
   // point MOXXY_HOME at the temp dir so tests never touch the real one.
   process.env.MOXXY_HOME = tmp;
+  // Point the installed-CLI sources at temp paths (missing by default) so the
+  // suite is hermetic and never reads this machine's real codex/claude creds.
+  process.env.CODEX_HOME = path.join(tmp, 'codex');
+  codexAuth = path.join(tmp, 'codex', 'auth.json');
+  claudeCreds = path.join(tmp, 'claude-creds.json');
+  process.env.MOXXY_CLAUDE_CREDENTIALS_FILE = claudeCreds;
   vault = new VaultStore({
     filePath: path.join(tmp, 'vault.json'),
     keySource: createStaticKeySource(deriveKey('test', generateSalt())),
@@ -21,10 +39,17 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  if (priorMoxxyHome === undefined) delete process.env.MOXXY_HOME;
-  else process.env.MOXXY_HOME = priorMoxxyHome;
+  restoreEnv('MOXXY_HOME', priorMoxxyHome);
+  restoreEnv('CODEX_HOME', priorCodexHome);
+  restoreEnv('MOXXY_CLAUDE_CREDENTIALS_FILE', priorClaudeFile);
+  for (const [k, v] of priorClaudeEnv) restoreEnv(k, v);
   await fs.rm(tmp, { recursive: true, force: true });
 });
+
+function restoreEnv(name: string, prior: string | undefined): void {
+  if (prior === undefined) delete process.env[name];
+  else process.env[name] = prior;
+}
 
 describe('resolveProviderCredentials', () => {
   it('honors the stored envVar override for runtime-registered providers', async () => {
@@ -90,5 +115,46 @@ describe('resolveProviderCredentials', () => {
     expect(cfg.reasoningEffort).toBe('high');
     expect(cfg.tokens).toMatchObject({ access: 'AT', refresh: 'RT' });
     expect(typeof cfg.onTokensRefreshed).toBe('function');
+  });
+
+  it('borrows the installed claude CLI token when the vault/env are empty', async () => {
+    await fs.writeFile(
+      claudeCreds,
+      JSON.stringify({
+        claudeAiOauth: { accessToken: 'borrowed-AT', refreshToken: 'RT', expiresAt: Date.now() + 3_600_000 },
+      }),
+      'utf8',
+    );
+    const { config, source } = await resolveProviderCredentialsDetailed('claude-code', vault);
+    expect(source).toBe('installed-cli');
+    expect(config.oauthToken).toBe('borrowed-AT');
+    // A refresh hook is wired because a refresh token is available.
+    expect(typeof config.oauthRefresh).toBe('function');
+  });
+
+  it('borrows the installed codex CLI auth.json when the vault is empty', async () => {
+    const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const payload = Buffer.from(JSON.stringify({ exp })).toString('base64url');
+    await fs.mkdir(path.dirname(codexAuth), { recursive: true });
+    await fs.writeFile(
+      codexAuth,
+      JSON.stringify({
+        auth_mode: 'chatgpt',
+        tokens: { access_token: `${header}.${payload}.s`, refresh_token: 'RT', account_id: 'acct' },
+      }),
+      'utf8',
+    );
+    const { config, source } = await resolveProviderCredentialsDetailed('openai-codex', vault);
+    expect(source).toBe('installed-cli');
+    expect(config.tokens).toMatchObject({ refresh: 'RT', accountId: 'acct' });
+    expect(typeof config.reloadTokens).toBe('function');
+  });
+
+  it('throws when no claude credentials are available anywhere', async () => {
+    // Vault empty, no env token, installed-CLI override points at a missing file.
+    await expect(resolveProviderCredentials('claude-code', vault)).rejects.toThrow(
+      /Claude subscription credentials/i,
+    );
   });
 });

--- a/packages/cli/src/provider-credentials.ts
+++ b/packages/cli/src/provider-credentials.ts
@@ -3,6 +3,8 @@ import { MoxxyError } from '@moxxy/sdk';
 import {
   persistCodexTokens,
   readStoredTokens,
+  readInstalledCodexTokens,
+  writeInstalledCodexTokens,
   type CodexTokens,
 } from '@moxxy/plugin-provider-openai-codex';
 import {
@@ -10,28 +12,63 @@ import {
   CLAUDE_TOKEN_ENV_VARS,
   ensureFreshClaudeTokens,
   refreshClaudeAccessToken,
+  refreshClaudeTokenDirect,
+  readInstalledClaudeCreds,
+  writeInstalledClaudeCreds,
 } from '@moxxy/plugin-provider-claude-code';
 import { storedProviderApiKeyName } from '@moxxy/plugin-provider-admin';
 import { resolveProviderApiKey, type ResolveOptions } from './provider-keys.js';
 
 /**
+ * Where a provider's resolved credentials came from. Surfaced through the
+ * runner's provider info so the desktop/CLI can show e.g. "Connected via
+ * installed Claude CLI" instead of leaving an auto-activated provider looking
+ * unconfigured. `'installed-cli'` is the borrow-from-the-installed-CLI path.
+ */
+export type CredentialSource = 'config' | 'vault' | 'env' | 'prompt' | 'installed-cli';
+
+export interface ResolvedCredentials {
+  readonly config: Record<string, unknown>;
+  readonly source: CredentialSource;
+}
+
+/**
  * Provider-aware credential resolution. The existing API-key flow (vault →
  * env → prompt) is unchanged for all providers EXCEPT the subscription-OAuth
- * ones: `openai-codex` pulls a ChatGPT token bundle (under
- * `oauth/openai-codex/*`), and `claude-code` pulls a Claude bearer (vault
- * `oauth/claude-code/*` or a `CLAUDE_CODE_OAUTH_TOKEN` env var) — each
- * exposing the live token plus a refresh hook the provider uses on a 401.
+ * ones: `openai-codex` and `claude-code` resolve in the order
+ *
+ *   moxxy vault (`moxxy login`) → env var → the INSTALLED CLI's own store
+ *
+ * The last step is "borrow live": if the user already signed into the `codex`
+ * or `claude` CLI, moxxy reads that CLI's token directly (codex
+ * `~/.codex/auth.json`; claude macOS Keychain / `~/.claude/.credentials.json`)
+ * and lets the CLI stay the owner — only refreshing + writing back when the
+ * CLI's own token has gone stale. This makes the provider work out of the box,
+ * with no separate `moxxy login`.
  *
  * For runtime-registered providers (~/.moxxy/providers.json) the stored
- * `envVar` override is honored: the lookup goes through the shared
- * key-name derivation in `@moxxy/plugin-provider-admin`, the same one the
- * admin tools and the desktop use.
+ * `envVar` override is honored via the shared key-name derivation in
+ * `@moxxy/plugin-provider-admin`.
  */
 export async function resolveProviderCredentials(
   providerName: string,
   vault: VaultStore,
   opts: ResolveOptions = {},
 ): Promise<Record<string, unknown>> {
+  return (await resolveProviderCredentialsDetailed(providerName, vault, opts)).config;
+}
+
+/**
+ * Like {@link resolveProviderCredentials} but also reports where the
+ * credentials came from (for the "connected via …" badge). Activation uses
+ * this; the plain variant above stays the hot path for callers that only need
+ * the config (the runtime credential resolver, the readiness probe).
+ */
+export async function resolveProviderCredentialsDetailed(
+  providerName: string,
+  vault: VaultStore,
+  opts: ResolveOptions = {},
+): Promise<ResolvedCredentials> {
   if (providerName === 'openai-codex') return resolveOAuthCodex(vault, opts);
   if (providerName === CLAUDE_CODE_PROVIDER_ID) return resolveClaudeCode(vault);
   // The `local` provider (Ollama / LM Studio / llama.cpp / vLLM) authenticates
@@ -42,79 +79,160 @@ export async function resolveProviderCredentials(
   // neither config nor env sets it.
   if (providerName === 'local') {
     return {
-      ...(opts.providerConfig ?? {}),
-      apiKey: process.env.LOCAL_API_KEY ?? 'local',
-      ...(process.env.LOCAL_MODEL_BASE_URL ? { baseURL: process.env.LOCAL_MODEL_BASE_URL } : {}),
+      config: {
+        ...(opts.providerConfig ?? {}),
+        apiKey: process.env.LOCAL_API_KEY ?? 'local',
+        ...(process.env.LOCAL_MODEL_BASE_URL ? { baseURL: process.env.LOCAL_MODEL_BASE_URL } : {}),
+      },
+      source: 'config',
     };
   }
   const storedKeyName = await storedProviderApiKeyName(providerName).catch(() => null);
-  const { providerConfig } = await resolveProviderApiKey(providerName, vault, {
+  const { providerConfig, source } = await resolveProviderApiKey(providerName, vault, {
     ...opts,
     ...(storedKeyName ? { keyName: storedKeyName } : {}),
   });
-  return providerConfig;
+  return { config: providerConfig, source };
 }
 
 /**
  * Claude subscription credentials. Prefer the vault bundle written by
- * `moxxy login claude-code` (refreshed proactively when near expiry); fall
- * back to a `claude setup-token` env var for CI / non-interactive use. The
- * `oauthRefresh` hook is wired only when a refresh_token is actually stored.
+ * `moxxy login claude-code` (refreshed proactively when near expiry); then a
+ * `claude setup-token` env var; then borrow the token from an installed
+ * `claude` CLI. The `oauthRefresh` hook is wired only when a refresh path
+ * actually exists.
  */
-async function resolveClaudeCode(vault: VaultStore): Promise<Record<string, unknown>> {
+async function resolveClaudeCode(vault: VaultStore): Promise<ResolvedCredentials> {
   const fresh = await ensureFreshClaudeTokens(vault);
   if (fresh) {
     return {
-      oauthToken: fresh.accessToken,
-      ...(fresh.expiresAt !== undefined ? { oauthExpiresAt: fresh.expiresAt } : {}),
-      ...(fresh.canRefresh ? { oauthRefresh: () => refreshClaudeAccessToken(vault) } : {}),
+      config: {
+        oauthToken: fresh.accessToken,
+        ...(fresh.expiresAt !== undefined ? { oauthExpiresAt: fresh.expiresAt } : {}),
+        ...(fresh.canRefresh ? { oauthRefresh: () => refreshClaudeAccessToken(vault) } : {}),
+      },
+      source: 'vault',
     };
   }
   for (const envVar of CLAUDE_TOKEN_ENV_VARS) {
     const token = process.env[envVar];
-    if (token) return { oauthToken: token };
+    if (token) return { config: { oauthToken: token }, source: 'env' };
+  }
+  const installed = await readInstalledClaudeCreds();
+  if (installed) {
+    return {
+      config: {
+        oauthToken: installed.accessToken,
+        ...(installed.expiresAt !== undefined ? { oauthExpiresAt: installed.expiresAt } : {}),
+        // Borrow-live refresh: re-read the CLI's store first (it may have
+        // rotated the token itself); only refresh + write back when the
+        // store's token is itself stale. Wired only when a refresh token
+        // exists to recover with.
+        ...(installed.refreshToken ? { oauthRefresh: borrowLiveClaudeRefresh } : {}),
+      },
+      source: 'installed-cli',
+    };
   }
   throw new MoxxyError({
     code: 'AUTH_NO_CREDENTIALS',
     message: 'No Claude subscription credentials found.',
     hint:
-      'Run `moxxy login claude-code` to sign in with your Claude Pro/Max account, ' +
-      'or set CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token`.',
+      'Sign in with the `claude` CLI (its token is picked up automatically), run ' +
+      '`moxxy login claude-code`, or set CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token`.',
     context: { provider: CLAUDE_CODE_PROVIDER_ID },
   });
+}
+
+/**
+ * Refresh hook for a token borrowed from the installed `claude` CLI. Defers to
+ * the CLI: first re-reads its store (picking up a token it refreshed itself for
+ * free), and only when that's still stale does it refresh against the IdP and
+ * write the rotated bundle back to the CLI's store so the two stay in sync.
+ */
+async function borrowLiveClaudeRefresh(): Promise<{ token: string; expiresAt?: number }> {
+  const current = await readInstalledClaudeCreds();
+  if (current && current.expiresAt !== undefined && current.expiresAt > Date.now() + 60_000) {
+    return { token: current.accessToken, ...(current.expiresAt !== undefined ? { expiresAt: current.expiresAt } : {}) };
+  }
+  const refreshToken = current?.refreshToken;
+  if (!refreshToken) {
+    throw new MoxxyError({
+      code: 'AUTH_EXPIRED',
+      message: 'The installed Claude CLI token expired and has no refresh token to recover with.',
+      hint: 'Run any `claude` command to refresh it, or run `moxxy login claude-code`.',
+      context: { provider: CLAUDE_CODE_PROVIDER_ID },
+    });
+  }
+  const refreshed = await refreshClaudeTokenDirect(refreshToken);
+  // Write the rotated bundle back to the CLI's store (best-effort): we already
+  // hold the fresh token, so a write failure must not fail the turn — it only
+  // means the CLI re-auths later.
+  await writeInstalledClaudeCreds({
+    accessToken: refreshed.accessToken,
+    refreshToken: refreshed.refreshToken ?? refreshToken,
+    ...(refreshed.expiresAt !== undefined ? { expiresAt: refreshed.expiresAt } : {}),
+    ...(current?.subscriptionType ? { subscriptionType: current.subscriptionType } : {}),
+  }).catch(() => {});
+  return {
+    token: refreshed.accessToken,
+    ...(refreshed.expiresAt !== undefined ? { expiresAt: refreshed.expiresAt } : {}),
+  };
 }
 
 async function resolveOAuthCodex(
   vault: VaultStore,
   opts: ResolveOptions = {},
-): Promise<Record<string, unknown>> {
+): Promise<ResolvedCredentials> {
   let tokens: CodexTokens | null = null;
   try {
     tokens = await readStoredTokens(vault);
   } catch {
     tokens = null;
   }
-  if (!tokens) {
-    throw new MoxxyError({
-      code: 'AUTH_NO_CREDENTIALS',
-      message: 'No ChatGPT OAuth credentials found in the vault.',
-      hint: 'Run `moxxy login openai-codex` to sign in with your ChatGPT Pro/Plus account.',
-      context: { provider: 'openai-codex' },
-    });
+  if (tokens) {
+    return {
+      config: {
+        // Pass user-supplied provider.config (moxxy.config.ts) through so
+        // options like `reasoningEffort` reach CodexProvider — previously this
+        // returned a fresh object and silently dropped every configured option.
+        ...(opts.providerConfig ?? {}),
+        tokens,
+        onTokensRefreshed: async (next: CodexTokens) => {
+          await persistCodexTokens(vault, next);
+        },
+        // Cross-process recovery: when a refresh hits invalid_grant because
+        // another moxxy process already rotated the single-use refresh token,
+        // the provider re-reads the vault through this hook and retries once
+        // with the fresher token instead of forcing a re-login.
+        reloadTokens: () => readStoredTokens(vault),
+      },
+      source: 'vault',
+    };
   }
-  return {
-    // Pass user-supplied provider.config (moxxy.config.ts) through so
-    // options like `reasoningEffort` reach CodexProvider — previously this
-    // returned a fresh object and silently dropped every configured option.
-    ...(opts.providerConfig ?? {}),
-    tokens,
-    onTokensRefreshed: async (next: CodexTokens) => {
-      await persistCodexTokens(vault, next);
-    },
-    // Cross-process recovery: when a refresh hits invalid_grant because another
-    // moxxy process already rotated the single-use refresh token, the provider
-    // re-reads the vault through this hook and retries once with the fresher
-    // token instead of forcing a re-login.
-    reloadTokens: () => readStoredTokens(vault),
-  };
+  // Borrow live from an installed `codex` CLI. Same provider hooks, but pointed
+  // at the CLI's `auth.json`: `reloadTokens` picks up a token the codex CLI
+  // rotated itself; `onTokensRefreshed` writes our rotations back so the CLI
+  // doesn't hit invalid_grant on its next run.
+  const installed = await readInstalledCodexTokens();
+  if (installed) {
+    return {
+      config: {
+        ...(opts.providerConfig ?? {}),
+        tokens: installed,
+        onTokensRefreshed: async (next: CodexTokens) => {
+          await writeInstalledCodexTokens(next).catch(() => {});
+        },
+        reloadTokens: () => readInstalledCodexTokens(),
+      },
+      source: 'installed-cli',
+    };
+  }
+  throw new MoxxyError({
+    code: 'AUTH_NO_CREDENTIALS',
+    message: 'No ChatGPT OAuth credentials found.',
+    hint:
+      'Sign in with the `codex` CLI (its token is picked up automatically) or run ' +
+      '`moxxy login openai-codex` to sign in with your ChatGPT Pro/Plus account.',
+    context: { provider: 'openai-codex' },
+  });
 }

--- a/packages/cli/src/setup/activate-provider.ts
+++ b/packages/cli/src/setup/activate-provider.ts
@@ -2,7 +2,10 @@ import type { Session } from '@moxxy/core';
 import type { MoxxyConfig } from '@moxxy/config';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { MoxxyError, type CredentialResolver } from '@moxxy/sdk';
-import { resolveProviderCredentials } from '../provider-credentials.js';
+import {
+  resolveProviderCredentialsDetailed,
+  type CredentialSource,
+} from '../provider-credentials.js';
 import type { BootStep } from './types.js';
 
 type Logger = {
@@ -49,6 +52,9 @@ export async function activateProvider(args: ActivateProviderArgs): Promise<Acti
 
   let activated: { name: string; cfg: Record<string, unknown> } | null = null;
   let lastErr: unknown = null;
+  // Provider name → where its credentials resolved from, surfaced via getInfo()
+  // so the UI can show "connected via installed Claude CLI" etc.
+  const credentialSources = new Map<string, CredentialSource>();
 
   if (args.skipProviderActivation) {
     logger.info('skipping provider activation (skipProviderActivation set)');
@@ -66,11 +72,12 @@ export async function activateProvider(args: ActivateProviderArgs): Promise<Acti
       // through fallbacks via prompts would be confusing.
       const interactive = i === 0 && !skipKeyPrompt && process.stdin.isTTY === true;
       try {
-        const resolved = await resolveProviderCredentials(candidate, vault, {
+        const resolved = await resolveProviderCredentialsDetailed(candidate, vault, {
           providerConfig: i === 0 ? providerConfig : {},
           interactive,
         });
-        activated = { name: candidate, cfg: resolved };
+        activated = { name: candidate, cfg: resolved.config };
+        credentialSources.set(candidate, resolved.source);
         break;
       } catch (err) {
         lastErr = err;
@@ -104,6 +111,15 @@ export async function activateProvider(args: ActivateProviderArgs): Promise<Acti
     if (activated.name !== primaryProvider) {
       logger.warn('using fallback provider', { primary: primaryProvider, active: activated.name });
     }
+    // Honor the configured model (`provider.model`) as the session's initial
+    // model. Without this, run-turn falls back to `provider.models[0]` — the
+    // first entry of the catalog — which for the Anthropic/claude-code catalog
+    // is `claude-fable-5`, a tier many subscriptions can't access (the API
+    // 404s "use Opus instead"). A resumed session's persisted model or an
+    // explicit `/model` pick still overrides this later.
+    if (config.provider?.model && !session.lastResolvedModel) {
+      session.lastResolvedModel = config.provider.model;
+    }
     progress({ kind: 'provider-activated', name: activated.name });
   }
 
@@ -119,8 +135,9 @@ export async function activateProvider(args: ActivateProviderArgs): Promise<Acti
   for (const p of session.providers.list()) {
     if (readyProviders.has(p.name)) continue;
     try {
-      await resolveProviderCredentials(p.name, vault, { interactive: false });
+      const resolved = await resolveProviderCredentialsDetailed(p.name, vault, { interactive: false });
       readyProviders.add(p.name);
+      credentialSources.set(p.name, resolved.source);
       session.requirements.setRuntime(`auth:provider:${p.name}`, 'ready');
     } catch {
       // not ready — leave out
@@ -128,14 +145,23 @@ export async function activateProvider(args: ActivateProviderArgs): Promise<Acti
     }
   }
   session.readyProviders = readyProviders;
+  session.credentialSources = credentialSources;
 
   // Expose a credential resolver so runtime provider switches (TUI
-  // /model picker, preference re-apply below) can re-resolve credentials
-  // before calling setActive — otherwise the new provider gets
-  // createClient({}) and OAuth-backed providers (openai-codex) throw
-  // "no credentials" on the next turn.
-  const credentialResolver: CredentialResolver = async (providerName) =>
-    resolveProviderCredentials(providerName, vault, { interactive: false });
+  // /model picker, preference re-apply below) and the runner's
+  // `provider.refreshReady` re-probe can re-resolve credentials before calling
+  // setActive — otherwise the new provider gets createClient({}) and
+  // OAuth-backed providers (openai-codex) throw "no credentials" on the next
+  // turn. Side-effects the shared source map so the "connected via …" badge
+  // stays current after a re-probe (a freshly-installed CLI / saved key flips
+  // both readiness and its source).
+  const credentialResolver: CredentialResolver = async (providerName) => {
+    const resolved = await resolveProviderCredentialsDetailed(providerName, vault, {
+      interactive: false,
+    });
+    credentialSources.set(providerName, resolved.source);
+    return resolved.config;
+  };
   session.credentialResolver = credentialResolver;
 
   return { activated, credentialResolver };

--- a/packages/client-core/src/useSettings.ts
+++ b/packages/client-core/src/useSettings.ts
@@ -32,6 +32,11 @@ export interface UseSettings {
    *  re-probe credentials so the readiness dot flips live. Throws for
    *  inline error rendering. */
   readonly setProviderKey: (keyName: string, value: string) => Promise<void>;
+  /** Ask the runner to re-probe every provider's credentials, then refetch the
+   *  list, so a readiness change (e.g. just completed an OAuth sign-in) shows up
+   *  without a restart. Best-effort on the re-probe (a pre-v7 runner just needs
+   *  a reboot to notice). */
+  readonly reprobeProviders: () => Promise<void>;
   readonly readSkill: (name: string) => Promise<string>;
   readonly writeSkill: (name: string, body: string) => Promise<void>;
   readonly deleteSkill: (name: string) => Promise<void>;
@@ -120,20 +125,25 @@ export function useSettings(): UseSettings {
     [refresh],
   );
 
+  const reprobeProviders = useCallback(async (): Promise<void> => {
+    // Have the runner re-resolve every provider's credentials so a readiness
+    // change flips without a restart. Best-effort — a pre-v7 runner lacks the
+    // method and just needs a reboot to notice.
+    try {
+      await api().invoke('settings.providerRefreshReady');
+    } catch {
+      /* pre-v7 runner — readiness updates on next boot */
+    }
+    await refresh();
+  }, [refresh]);
+
   const setProviderKey = useCallback(
     async (keyName: string, value: string): Promise<void> => {
       await api().invoke('settings.vaultSet', { name: keyName, value });
-      // The key is on disk; have the runner re-probe credentials so the
-      // readiness dot flips without a restart. Best-effort — an old runner
-      // without v7 still saved the key, it just needs a restart to see it.
-      try {
-        await api().invoke('settings.providerRefreshReady');
-      } catch {
-        /* pre-v7 runner — key saved, readiness updates on next boot */
-      }
-      await refresh();
+      // The key is on disk; re-probe so the readiness dot flips without a restart.
+      await reprobeProviders();
     },
-    [refresh],
+    [reprobeProviders],
   );
 
   const readSkill = useCallback(
@@ -199,6 +209,7 @@ export function useSettings(): UseSettings {
     setProviderEnabled,
     configureProvider,
     setProviderKey,
+    reprobeProviders,
     readSkill,
     writeSkill,
     deleteSkill,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -2,6 +2,7 @@ import type {
   AppContext,
   ClientSession,
   MoxxyEvent,
+  ProviderInfo,
   RunTurnOptions,
   SessionId,
   SessionInfo,
@@ -167,6 +168,12 @@ export class Session implements ClientSession, SessionRuntime {
    * type-checked access.
    */
   readyProviders?: Set<string>;
+  /**
+   * Per-provider credential source ('vault' | 'env' | 'installed-cli' | …),
+   * recorded during activation so `getInfo()` can surface a "connected via …"
+   * badge. Provider name → source. Absent until activation populates it.
+   */
+  credentialSources?: Map<string, ProviderInfo['credentialSource']>;
   credentialResolver?: CredentialResolver;
   mcpAdmin?: McpAdminView;
   providerAdmin?: ProviderAdminView;
@@ -432,6 +439,9 @@ export class Session implements ClientSession, SessionRuntime {
         supportsLiveModelDiscovery:
           (p as { supportsLiveModelDiscovery?: boolean }).supportsLiveModelDiscovery === true,
         enabled: this.providers.isEnabled(p.name),
+        ...(this.credentialSources?.get(p.name)
+          ? { credentialSource: this.credentialSources.get(p.name) }
+          : {}),
       })),
       activeMode,
       activeModeBadge,

--- a/packages/desktop-host/src/ipc/settings.ts
+++ b/packages/desktop-host/src/ipc/settings.ts
@@ -63,6 +63,9 @@ export function registerSettingsHandlers(pool: RunnerPool): void {
         // is the source of truth (the desktop never sees raw ModelDescriptors);
         // a provider supports it when ANY of its models advertises it.
         supportsReasoning: p.models.some((m) => m.supportsReasoning === true),
+        // Surface where credentials resolved from (older runners omit it) so the
+        // UI can show "Connected via installed CLI" for auto-borrowed tokens.
+        ...(p.credentialSource ? { credentialSource: p.credentialSource } : {}),
         ...(detail
           ? {
               baseURL: detail.baseURL,

--- a/packages/desktop-ipc-contract/src/settings.ts
+++ b/packages/desktop-ipc-contract/src/settings.ts
@@ -33,6 +33,11 @@ export interface ProviderEntry {
    *  selector. Derived from the runner's model catalog (the desktop never sees
    *  raw `ModelDescriptor`s). Absent ⇒ unknown/false. */
   supportsReasoning?: boolean;
+  /** Where the runner resolved this provider's credentials from, when known.
+   *  `'installed-cli'` = borrowed from a locally-installed `claude`/`codex`
+   *  CLI; lets the UI show "Connected via installed CLI" instead of leaving an
+   *  auto-activated provider looking unconfigured. Absent ⇒ unknown. */
+  credentialSource?: 'config' | 'vault' | 'env' | 'prompt' | 'installed-cli';
 }
 
 export interface McpServerEntry {

--- a/packages/plugin-provider-claude-code/src/cli-creds.test.ts
+++ b/packages/plugin-provider-claude-code/src/cli-creds.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { readInstalledClaudeCreds, writeInstalledClaudeCreds } from './cli-creds.js';
+
+let tmp: string;
+let credsFile: string;
+const priorOverride = process.env.MOXXY_CLAUDE_CREDENTIALS_FILE;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-cli-'));
+  credsFile = path.join(tmp, '.credentials.json');
+  // The override makes the reader/writer use this file and skip the Keychain,
+  // so the test is deterministic and never touches the real `claude` creds.
+  process.env.MOXXY_CLAUDE_CREDENTIALS_FILE = credsFile;
+});
+
+afterEach(async () => {
+  if (priorOverride === undefined) delete process.env.MOXXY_CLAUDE_CREDENTIALS_FILE;
+  else process.env.MOXXY_CLAUDE_CREDENTIALS_FILE = priorOverride;
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe('readInstalledClaudeCreds', () => {
+  it('returns null when the file is missing', async () => {
+    expect(await readInstalledClaudeCreds()).toBeNull();
+  });
+
+  it('returns null when there is no usable access token', async () => {
+    await fs.writeFile(credsFile, JSON.stringify({ claudeAiOauth: {} }), 'utf8');
+    expect(await readInstalledClaudeCreds()).toBeNull();
+  });
+
+  it('parses the nested claudeAiOauth bundle the CLI writes', async () => {
+    await fs.writeFile(
+      credsFile,
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'AT',
+          refreshToken: 'RT',
+          expiresAt: 1782407688118,
+          subscriptionType: 'max',
+        },
+      }),
+      'utf8',
+    );
+    expect(await readInstalledClaudeCreds()).toEqual({
+      accessToken: 'AT',
+      refreshToken: 'RT',
+      expiresAt: 1782407688118,
+      subscriptionType: 'max',
+    });
+  });
+
+  it('also accepts a flat (un-nested) bundle', async () => {
+    await fs.writeFile(credsFile, JSON.stringify({ accessToken: 'flat' }), 'utf8');
+    expect(await readInstalledClaudeCreds()).toEqual({ accessToken: 'flat' });
+  });
+});
+
+describe('writeInstalledClaudeCreds', () => {
+  it('round-trips through the override file', async () => {
+    await writeInstalledClaudeCreds({
+      accessToken: 'NEW',
+      refreshToken: 'NEWR',
+      expiresAt: 123,
+      subscriptionType: 'pro',
+    });
+    const reread = await readInstalledClaudeCreds();
+    expect(reread).toEqual({
+      accessToken: 'NEW',
+      refreshToken: 'NEWR',
+      expiresAt: 123,
+      subscriptionType: 'pro',
+    });
+    // Persisted under the nested key the CLI expects to read back.
+    const raw = JSON.parse(await fs.readFile(credsFile, 'utf8'));
+    expect(raw.claudeAiOauth.accessToken).toBe('NEW');
+  });
+});

--- a/packages/plugin-provider-claude-code/src/cli-creds.ts
+++ b/packages/plugin-provider-claude-code/src/cli-creds.ts
@@ -1,0 +1,195 @@
+/**
+ * Borrow the OAuth token minted by a locally-installed Claude Code CLI.
+ *
+ * The `claude` CLI persists its Pro/Max subscription OAuth bundle to the macOS
+ * Keychain (generic password, service `Claude Code-credentials`) or, on
+ * Linux/other, to `~/.claude/.credentials.json`. It's the SAME OAuth client
+ * moxxy's `claude-code` provider uses, so the bearer found there is directly
+ * usable against the Anthropic Messages API (verified end-to-end) — letting a
+ * user who already ran `claude` skip a separate `moxxy login claude-code`.
+ *
+ * Lifecycle ("borrow live"): the installed CLI stays the OWNER of the token.
+ * moxxy reads it on demand; the refresh hook re-reads the store first (so a
+ * token the CLI just rotated is picked up for free). Only when the store's
+ * token is itself stale does moxxy refresh against the IdP and WRITE THE
+ * ROTATED BUNDLE BACK to the same store, so the CLI doesn't hit `invalid_grant`
+ * on its next run. (Refresh tokens rotate + are single-use, so the write-back
+ * is what stops moxxy and the CLI invalidating each other.)
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { readFile, writeFile, rename, chmod, unlink } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { webcrypto } from 'node:crypto';
+
+const execFileAsync = promisify(execFile);
+
+/** Keychain service name the `claude` CLI stores its credentials under (macOS). */
+const KEYCHAIN_SERVICE = 'Claude Code-credentials';
+/** Default keychain account when the existing item's account can't be read. */
+const KEYCHAIN_DEFAULT_ACCOUNT = 'Claude Code';
+
+/** Normalized view of the installed CLI's stored Claude credentials. */
+export interface InstalledClaudeCreds {
+  readonly accessToken: string;
+  /** Present when the store carries a refresh token (drives stale-token recovery). */
+  readonly refreshToken?: string;
+  /** Epoch-ms expiry, when the store records one. */
+  readonly expiresAt?: number;
+  /** e.g. `max` / `pro` — informational, surfaced in the "connected via" badge. */
+  readonly subscriptionType?: string;
+}
+
+/** Linux/other fallback path for the credentials file. */
+function credentialsFilePath(): string {
+  return join(homedir(), '.claude', '.credentials.json');
+}
+
+/**
+ * Explicit override path for the credentials file. When set, the Keychain is
+ * bypassed entirely and this file is read/written instead. Doubles as the test
+ * seam (so tests never touch the real Keychain) and a production escape hatch
+ * for non-standard installs.
+ */
+function credentialsFileOverride(): string | undefined {
+  const v = process.env.MOXXY_CLAUDE_CREDENTIALS_FILE?.trim();
+  return v && v.length > 0 ? v : undefined;
+}
+
+/** Pull the `claudeAiOauth` bundle out of either nesting the CLI may write. */
+function parseClaudeCreds(raw: string): InstalledClaudeCreds | null {
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!json || typeof json !== 'object') return null;
+  const root = json as Record<string, unknown>;
+  const nested = root['claudeAiOauth'];
+  const o = (nested && typeof nested === 'object' ? nested : root) as Record<string, unknown>;
+  const accessToken = o['accessToken'];
+  if (typeof accessToken !== 'string' || accessToken.length === 0) return null;
+  const refreshToken = o['refreshToken'];
+  const expiresAt = o['expiresAt'];
+  const subscriptionType = o['subscriptionType'];
+  return {
+    accessToken,
+    ...(typeof refreshToken === 'string' && refreshToken ? { refreshToken } : {}),
+    ...(typeof expiresAt === 'number' && Number.isFinite(expiresAt) ? { expiresAt } : {}),
+    ...(typeof subscriptionType === 'string' && subscriptionType ? { subscriptionType } : {}),
+  };
+}
+
+/**
+ * Read the installed Claude CLI's stored credentials, or null when there's
+ * nothing usable (not signed in, `security` unavailable, file missing/garbled).
+ * macOS reads the Keychain via `security`; everything else reads the file.
+ */
+export async function readInstalledClaudeCreds(): Promise<InstalledClaudeCreds | null> {
+  const override = credentialsFileOverride();
+  if (override) {
+    try {
+      return parseClaudeCreds(await readFile(override, 'utf8'));
+    } catch {
+      return null;
+    }
+  }
+  if (process.platform === 'darwin') {
+    try {
+      const { stdout } = await execFileAsync('security', [
+        'find-generic-password',
+        '-s',
+        KEYCHAIN_SERVICE,
+        '-w',
+      ]);
+      const creds = parseClaudeCreds(stdout.trim());
+      if (creds) return creds;
+    } catch {
+      // Item missing / `security` not present / access denied — fall through to
+      // the file path, which some setups (or a future CLI) may use even on mac.
+    }
+  }
+  try {
+    return parseClaudeCreds(await readFile(credentialsFilePath(), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Build the on-disk/keychain JSON the `claude` CLI expects to read back. */
+function serializeClaudeCreds(creds: InstalledClaudeCreds): string {
+  return JSON.stringify({
+    claudeAiOauth: {
+      accessToken: creds.accessToken,
+      ...(creds.refreshToken ? { refreshToken: creds.refreshToken } : {}),
+      ...(creds.expiresAt !== undefined ? { expiresAt: creds.expiresAt } : {}),
+      ...(creds.subscriptionType ? { subscriptionType: creds.subscriptionType } : {}),
+    },
+  });
+}
+
+/** Read the existing keychain item's account name so write-back targets it. */
+async function keychainAccount(): Promise<string> {
+  try {
+    // Attributes only (no `-g`/`-w`, so the password is NOT printed). The
+    // account appears as: "acct"<blob>="<value>"
+    const { stdout } = await execFileAsync('security', [
+      'find-generic-password',
+      '-s',
+      KEYCHAIN_SERVICE,
+    ]);
+    const m = stdout.match(/"acct"<blob>="([^"]*)"/);
+    if (m && m[1]) return m[1];
+  } catch {
+    // fall through to the default account
+  }
+  return KEYCHAIN_DEFAULT_ACCOUNT;
+}
+
+/**
+ * Write a refreshed bundle back into the installed CLI's store so it stays in
+ * sync with moxxy after a moxxy-initiated refresh. Best-effort: a failure here
+ * must NOT break the in-memory session (the caller already holds the fresh
+ * token); the only cost is the CLI re-authing later.
+ *
+ * macOS caveat: `security add-generic-password -U` rewrites the item, which can
+ * reset its ACL — so after a moxxy-driven refresh of a STALE token the `claude`
+ * CLI may prompt once on its next launch. This never fires on the common path
+ * (an active CLI keeps its token fresh, so moxxy only ever reads).
+ */
+export async function writeInstalledClaudeCreds(creds: InstalledClaudeCreds): Promise<void> {
+  const payload = serializeClaudeCreds(creds);
+  const override = credentialsFileOverride();
+  if (!override && process.platform === 'darwin') {
+    const account = await keychainAccount();
+    // `-U` updates in place if the item exists. The token rides in argv (briefly
+    // visible to local `ps`), matching how the CLIs themselves shell out; this
+    // is the user's own machine and the write only happens on a stale-token
+    // refresh, so the exposure window is negligible.
+    await execFileAsync('security', [
+      'add-generic-password',
+      '-U',
+      '-s',
+      KEYCHAIN_SERVICE,
+      '-a',
+      account,
+      '-w',
+      payload,
+    ]);
+    return;
+  }
+  // File path (override or Linux/other default): atomic write (temp + rename) at 0600.
+  const path = override ?? credentialsFilePath();
+  const tmp = `${path}.${webcrypto.randomUUID()}.tmp`;
+  await writeFile(tmp, payload, { mode: 0o600 });
+  try {
+    await chmod(tmp, 0o600);
+    await rename(tmp, path);
+  } catch (err) {
+    await unlink(tmp).catch(() => {});
+    throw err;
+  }
+}

--- a/packages/plugin-provider-claude-code/src/index.ts
+++ b/packages/plugin-provider-claude-code/src/index.ts
@@ -42,6 +42,12 @@ export {
   claudeStatus,
   ensureFreshClaudeTokens,
   refreshClaudeAccessToken,
+  refreshClaudeTokenDirect,
   type FreshClaudeTokens,
 } from './login.js';
+export {
+  readInstalledClaudeCreds,
+  writeInstalledClaudeCreds,
+  type InstalledClaudeCreds,
+} from './cli-creds.js';
 export { createClaudeCodeClient, type ClaudeCodeProviderConfig } from './provider.js';

--- a/packages/plugin-provider-claude-code/src/login.ts
+++ b/packages/plugin-provider-claude-code/src/login.ts
@@ -322,6 +322,29 @@ async function exchangeClaudeCode(
   });
 }
 
+/**
+ * Vault-free refresh against the Claude token endpoint. Used by the
+ * installed-CLI ("borrow live") path, which keeps its tokens in the `claude`
+ * CLI's own store (keychain / `~/.claude/.credentials.json`) rather than the
+ * moxxy vault, so it can't go through {@link refreshClaudeAccessToken}. Reuses
+ * {@link postClaudeToken}'s retry/timeout hardening. Returns the rotated
+ * bundle flat; the caller writes it back to the CLI's store.
+ */
+export async function refreshClaudeTokenDirect(
+  refreshToken: string,
+): Promise<{ accessToken: string; refreshToken?: string; expiresAt?: number }> {
+  const { tokenSet } = await postClaudeToken({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: CLAUDE_CLIENT_ID,
+  });
+  return {
+    accessToken: tokenSet.accessToken,
+    ...(tokenSet.refreshToken ? { refreshToken: tokenSet.refreshToken } : {}),
+    ...(tokenSet.expiresAt !== undefined ? { expiresAt: tokenSet.expiresAt } : {}),
+  };
+}
+
 async function refreshAndPersist(
   vault: OAuthVault,
   refreshToken: string,

--- a/packages/plugin-provider-openai-codex/src/cli-creds.test.ts
+++ b/packages/plugin-provider-openai-codex/src/cli-creds.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Buffer } from 'node:buffer';
+import {
+  codexAuthPath,
+  readInstalledCodexTokens,
+  writeInstalledCodexTokens,
+} from './cli-creds.js';
+
+/** Build a minimal JWT carrying just an `exp` (seconds) claim. */
+function jwtWithExp(expSeconds: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ exp: expSeconds })).toString('base64url');
+  return `${header}.${payload}.sig`;
+}
+
+let tmp: string;
+const priorCodexHome = process.env.CODEX_HOME;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-cli-'));
+  process.env.CODEX_HOME = tmp;
+});
+
+afterEach(async () => {
+  if (priorCodexHome === undefined) delete process.env.CODEX_HOME;
+  else process.env.CODEX_HOME = priorCodexHome;
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe('readInstalledCodexTokens', () => {
+  it('honors CODEX_HOME for the auth.json path', () => {
+    expect(codexAuthPath()).toBe(path.join(tmp, 'auth.json'));
+  });
+
+  it('returns null when auth.json is missing', async () => {
+    expect(await readInstalledCodexTokens()).toBeNull();
+  });
+
+  it('returns null when the file is malformed', async () => {
+    await fs.writeFile(path.join(tmp, 'auth.json'), 'not json', 'utf8');
+    expect(await readInstalledCodexTokens()).toBeNull();
+  });
+
+  it('returns null when the access/refresh pair is incomplete', async () => {
+    await fs.writeFile(
+      path.join(tmp, 'auth.json'),
+      JSON.stringify({ tokens: { access_token: 'AT' } }),
+      'utf8',
+    );
+    expect(await readInstalledCodexTokens()).toBeNull();
+  });
+
+  it('normalizes a full bundle, deriving expiry from the access_token JWT', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    await fs.writeFile(
+      path.join(tmp, 'auth.json'),
+      JSON.stringify({
+        OPENAI_API_KEY: null,
+        auth_mode: 'chatgpt',
+        tokens: {
+          access_token: jwtWithExp(exp),
+          refresh_token: 'RT',
+          account_id: 'acct-123',
+        },
+        last_refresh: '2026-01-01T00:00:00Z',
+      }),
+      'utf8',
+    );
+    const tokens = await readInstalledCodexTokens();
+    expect(tokens).toMatchObject({ refresh: 'RT', accountId: 'acct-123', expires: exp * 1000 });
+  });
+});
+
+describe('writeInstalledCodexTokens', () => {
+  it('round-trips a rotated bundle and preserves untouched fields', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 7200;
+    await fs.writeFile(
+      path.join(tmp, 'auth.json'),
+      JSON.stringify({
+        OPENAI_API_KEY: 'sk-keep',
+        auth_mode: 'chatgpt',
+        tokens: { access_token: 'OLD', refresh_token: 'OLDR', id_token: 'ID', account_id: 'acct-1' },
+        last_refresh: 'old',
+      }),
+      'utf8',
+    );
+    await writeInstalledCodexTokens({
+      access: jwtWithExp(exp),
+      refresh: 'NEWR',
+      expires: exp * 1000,
+      accountId: 'acct-1',
+    });
+    const raw = JSON.parse(await fs.readFile(path.join(tmp, 'auth.json'), 'utf8'));
+    expect(raw.OPENAI_API_KEY).toBe('sk-keep'); // untouched
+    expect(raw.tokens.id_token).toBe('ID'); // preserved
+    expect(raw.tokens.refresh_token).toBe('NEWR'); // rotated
+    expect(raw.tokens.account_id).toBe('acct-1');
+    expect(raw.last_refresh).not.toBe('old'); // bumped
+    // And it reads back cleanly.
+    const reread = await readInstalledCodexTokens();
+    expect(reread).toMatchObject({ refresh: 'NEWR' });
+  });
+
+  it('writes a minimal valid file when none exists', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    await writeInstalledCodexTokens({ access: jwtWithExp(exp), refresh: 'R', expires: exp * 1000 });
+    const reread = await readInstalledCodexTokens();
+    expect(reread).toMatchObject({ refresh: 'R' });
+  });
+});

--- a/packages/plugin-provider-openai-codex/src/cli-creds.ts
+++ b/packages/plugin-provider-openai-codex/src/cli-creds.ts
@@ -1,0 +1,144 @@
+/**
+ * Borrow the OAuth tokens minted by a locally-installed Codex CLI.
+ *
+ * The `codex` CLI persists its ChatGPT-plan OAuth bundle to
+ * `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`) — the SAME OAuth
+ * client moxxy's `openai-codex` provider uses, so the access/refresh tokens
+ * found there are directly usable. This lets a user who has already signed in
+ * with `codex` skip a separate `moxxy login openai-codex`.
+ *
+ * Lifecycle ("borrow live"): the installed CLI stays the OWNER of the token.
+ * moxxy reads it on demand and, when the access token is near/at expiry,
+ * prefers a fresher token the CLI may have written since (via `reloadTokens`).
+ * Only when the CLI's stored token is itself stale does moxxy refresh — and it
+ * then WRITES THE ROTATED BUNDLE BACK to `auth.json` so the two stay in sync
+ * and the CLI doesn't hit `invalid_grant` on its next run. The refresh token
+ * rotates and is single-use, so this write-back is what keeps moxxy and the
+ * CLI from invalidating each other.
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { readFile, writeFile, rename, chmod, unlink } from 'node:fs/promises';
+import { webcrypto } from 'node:crypto';
+import { parseJwtClaims, extractAccountId } from './oauth.js';
+import type { CodexTokens } from './types.js';
+
+/** Shape of `auth.json` as written by codex-rs. Fields we don't touch are preserved. */
+interface CodexAuthFile {
+  readonly OPENAI_API_KEY?: string | null;
+  readonly auth_mode?: string;
+  readonly tokens?: {
+    readonly id_token?: string;
+    readonly access_token?: string;
+    readonly refresh_token?: string;
+    readonly account_id?: string;
+  };
+  readonly last_refresh?: string;
+  readonly [k: string]: unknown;
+}
+
+/** Absolute path to the installed CLI's auth file (honors `CODEX_HOME`). */
+export function codexAuthPath(): string {
+  const overridden = process.env.CODEX_HOME?.trim();
+  const base = overridden && overridden.length > 0 ? overridden : join(homedir(), '.codex');
+  return join(base, 'auth.json');
+}
+
+/** `exp` (seconds) from a JWT, in epoch-ms; undefined when absent/unparseable. */
+function jwtExpiryMs(jwt: string | undefined): number | undefined {
+  if (!jwt) return undefined;
+  const claims = parseJwtClaims(jwt);
+  const exp = claims?.['exp'];
+  return typeof exp === 'number' && Number.isFinite(exp) ? exp * 1000 : undefined;
+}
+
+/**
+ * Read the installed Codex CLI's stored tokens, normalized to `CodexTokens`.
+ * Returns null when the file is missing / unreadable / malformed, or when it
+ * doesn't carry the access+refresh pair the borrow-live lifecycle needs.
+ *
+ * `expires` comes from the access_token JWT's `exp` (authoritative); when that
+ * can't be read we fall back to the id_token's, and finally to "already
+ * expired" so the provider refreshes-and-writes-back on first use rather than
+ * firing a request on a token of unknown freshness.
+ */
+export async function readInstalledCodexTokens(): Promise<CodexTokens | null> {
+  let raw: string;
+  try {
+    raw = await readFile(codexAuthPath(), 'utf8');
+  } catch {
+    return null;
+  }
+  let parsed: CodexAuthFile;
+  try {
+    const json: unknown = JSON.parse(raw);
+    if (!json || typeof json !== 'object') return null;
+    parsed = json as CodexAuthFile;
+  } catch {
+    return null;
+  }
+  const t = parsed.tokens;
+  // Need BOTH tokens: the access token to call the API, the refresh token so
+  // the borrow-live path can recover when the access token has expired (which,
+  // for an unused CLI, it usually has).
+  if (!t || typeof t.access_token !== 'string' || typeof t.refresh_token !== 'string') {
+    return null;
+  }
+  const expires =
+    jwtExpiryMs(t.access_token) ?? jwtExpiryMs(t.id_token) ?? 0;
+  const accountId =
+    t.account_id ??
+    extractAccountId({
+      ...(t.id_token ? { id_token: t.id_token } : {}),
+      access_token: t.access_token,
+    });
+  return {
+    access: t.access_token,
+    refresh: t.refresh_token,
+    expires,
+    ...(accountId ? { accountId } : {}),
+  };
+}
+
+/**
+ * Write a refreshed token bundle back into the installed CLI's `auth.json`,
+ * preserving every other field (api key, auth_mode, id_token) so the codex CLI
+ * keeps working. Atomic (temp file + rename) and best-effort: a failure here
+ * must NOT break moxxy's in-memory session — the caller still has the fresh
+ * token; the only cost of a failed write-back is the CLI re-authing later.
+ */
+export async function writeInstalledCodexTokens(next: CodexTokens): Promise<void> {
+  const path = codexAuthPath();
+  let existing: CodexAuthFile = {};
+  try {
+    const json: unknown = JSON.parse(await readFile(path, 'utf8'));
+    if (json && typeof json === 'object') existing = json as CodexAuthFile;
+  } catch {
+    // No/garbled existing file — write a minimal valid one. The CLI rewrites
+    // the rest (id_token etc.) on its next refresh.
+  }
+  const merged = {
+    ...existing,
+    auth_mode: existing.auth_mode ?? 'chatgpt',
+    tokens: {
+      ...(existing.tokens ?? {}),
+      access_token: next.access,
+      refresh_token: next.refresh,
+      ...(next.accountId ? { account_id: next.accountId } : {}),
+    },
+    last_refresh: new Date().toISOString(),
+  };
+  // Same dir as the target so rename() is atomic (no cross-device copy), and a
+  // unique suffix so two concurrent writers don't clobber one temp file.
+  const tmp = `${path}.${webcrypto.randomUUID()}.tmp`;
+  await writeFile(tmp, JSON.stringify(merged, null, 2), { mode: 0o600 });
+  try {
+    await chmod(tmp, 0o600);
+    await rename(tmp, path);
+  } catch (err) {
+    // Clean up the temp file on a failed rename so we don't litter ~/.codex.
+    await unlink(tmp).catch(() => {});
+    throw err;
+  }
+}

--- a/packages/plugin-provider-openai-codex/src/index.ts
+++ b/packages/plugin-provider-openai-codex/src/index.ts
@@ -61,5 +61,10 @@ export {
   readStoredTokens,
   readStoredTokens as readCodexStoredTokens,
 } from './login.js';
+export {
+  codexAuthPath,
+  readInstalledCodexTokens,
+  writeInstalledCodexTokens,
+} from './cli-creds.js';
 export type { CodexProviderConfig } from './provider.js';
 export type { CodexTokens, PkceCodes, OAuthTokenResponse } from './types.js';

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -70,6 +70,16 @@ export interface ProviderInfo {
    * wire back-compat — an older runner omits it; treat absent as enabled.
    */
   readonly enabled?: boolean;
+  /**
+   * Where this provider's credentials were resolved from, when known:
+   * `'vault'` (a `moxxy login` / stored key), `'env'`, `'prompt'`, `'config'`,
+   * or `'installed-cli'` (borrowed from a locally-installed `claude`/`codex`
+   * CLI). Lets a UI show "Connected via installed Claude CLI" instead of
+   * leaving an auto-activated provider looking unconfigured. Only populated for
+   * providers that resolved during activation; absent (older runner / not
+   * probed) means "unknown source".
+   */
+  readonly credentialSource?: 'config' | 'vault' | 'env' | 'prompt' | 'installed-cli';
 }
 
 /** Serializable tool metadata for status lines / slash menus / compact rendering. */


### PR DESCRIPTION
## What

When the vault and env are empty, `claude-code` and `openai-codex` now resolve credentials from the **installed CLI's own store** — codex `~/.codex/auth.json` (honors `CODEX_HOME`), claude macOS Keychain (`Claude Code-credentials`) / `~/.claude/.credentials.json` (override via `MOXXY_CLAUDE_CREDENTIALS_FILE`). If you're already signed into `claude`/`codex`, the provider just works with no separate `moxxy login`.

Resolution order is now **vault (`moxxy login`) → env var → installed CLI**.

This is **borrow-live**: the installed CLI stays the owner that refreshes the token; moxxy only refreshes + writes the rotated bundle back when the CLI's token has gone stale, so the two never invalidate each other's rotating, single-use refresh token. Codex slots into `CodexProvider`'s existing `reloadTokens`/`onTokensRefreshed` hooks; claude gets a vault-free `refreshClaudeTokenDirect`.

Plus three smaller fixes uncovered along the way:

- **"Connected via installed CLI" badge.** New optional `ProviderInfo.credentialSource` (`vault` | `env` | `installed-cli` | …) flows runner → desktop Settings → Providers, so an auto-borrowed provider reads *"Active · connected via installed CLI"* instead of looking unconfigured. Additive — **no runner protocol bump**.
- **Desktop provider-config feedback.** The OAuth sign-in path refetched the provider list *without* re-probing readiness first, so it looked like nothing happened. Now any provider-config change (incl. OAuth sign-in) re-probes via a new `useSettings.reprobeProviders`, so the readiness dot + subtitle flip live.
- **Honor `config.provider.model`.** It was silently ignored, so turns fell back to `provider.models[0]` — for the Anthropic/claude-code catalog that's `claude-fable-5`, a tier many subscriptions can't access (API 404 "use Opus instead"). The configured model is now applied as the session's initial model.

## Why

`claude-code` looked broken. It wasn't broken at inference — moxxy's exact request shape returns **HTTP 200** against the real API with a real subscription token (verified across opus-4-8 / sonnet-4-6 / a dated model, and across streaming, tools, cache_control, and 128k `max_tokens`). The real breaks were credential *acquisition* (the brittle out-of-band login) and the gated default model. Borrowing the installed CLI's token fixes acquisition; honoring `provider.model` fixes the model. Same borrow path makes `openai-codex` work from an installed `codex` too.

> Note: a real claude-code turn can still 400 with *"Third-party apps now draw from your extra usage, not your plan limits."* That's Anthropic billing policy for subscription tokens used outside the official app (not a moxxy bug); the provider surfaces it verbatim. Enable extra usage to run turns.

## Verification

- `pnpm build` (73/73), `typecheck` (143/143), `lint` (0 errors), `check:deps` (0 errors), full `test` suite — all green. 12 new tests (codex/claude `cli-creds`, installed-CLI resolution + source).
- **Live, end-to-end:** ran a real `moxxy -p` turn on `claude-code` with an empty `MOXXY_HOME`; it auto-borrowed the Keychain token and authenticated successfully (got past auth to the model/billing layer).
- **Deferred:** codex live-rotate not exercised — the local `~/.codex` token is ~2 months stale, so a live run would refresh + write back the real codex credential. Unit-tested only (read/write/resolution); logged in TECH_DEBT.