### PR TITLE
feat(plugins): inter-plugin service registry; oauth discovery-loadable

### DIFF
--- a/.changeset/plugin-service-registry.md
+++ b/.changeset/plugin-service-registry.md
@@ -1,0 +1,11 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/core': minor
+'@moxxy/cli': patch
+---
+
+Inter-plugin service registry (`AppContext.services`) — plugins publish a named service in `onInit` and consume siblings' services in theirs, requirements-ordered so the provider runs first. This decouples cross-plugin dependencies from the host's `build*({ deps })` constructor wiring, letting a plugin be discovery-loaded (default-exported) instead of hand-built by the orchestrator.
+
+The vault plugin now publishes its secret store (`services.register('vault', vault)`), and `@moxxy/plugin-oauth` is the first consumer to go discovery-loadable: the default-exported `oauthPlugin` resolves the vault from `ctx.services.require('vault')` in `onInit` (declaring `@moxxy/plugin-vault` as a requirement for ordering), so it no longer needs the `{ vault }` closure. `buildOauthPlugin` is kept for direct injection.
+
+Since plugin `onInit` already runs with full in-process privileges (the security isolation wraps tool execution, not plugin code), this doesn't widen the effective trust surface.

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -41,7 +41,7 @@ import { buildUsageStatsPlugin } from '@moxxy/plugin-usage-stats';
 import { commandsPlugin } from '@moxxy/plugin-commands';
 import { buildViewPlugin } from '@moxxy/plugin-view';
 import { computerControlPlugin } from '@moxxy/plugin-computer-control';
-import { buildOauthPlugin } from '@moxxy/plugin-oauth';
+import { oauthPlugin } from '@moxxy/plugin-oauth';
 import { buildVoiceAdminPlugin } from '@moxxy/plugin-voice-admin';
 import { resolveString } from '@moxxy/plugin-vault';
 import type { VaultStore } from '@moxxy/plugin-vault';
@@ -169,7 +169,9 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
     // Generic OAuth 2.0 + PKCE client. Adds oauth_authorize /
     // oauth_get_token / oauth_clear_token tools that any skill can
     // chain (Google OAuth → MCP env, GitHub OAuth → API calls, …).
-    { name: '@moxxy/plugin-oauth', plugin: buildOauthPlugin({ vault }) },
+    // Discovery-loadable: resolves the vault from the service registry in
+    // onInit (vault registers it first), no `{ vault }` injection needed.
+    { name: '@moxxy/plugin-oauth', plugin: oauthPlugin },
     // Universal slash commands (/info, /clear, /new, /exit, /help)
     // shared across every channel via session.commands. Disable to
     // hide them everywhere — channel-local commands keep working.

--- a/packages/cli/src/setup/builtin-requirements.generated.ts
+++ b/packages/cli/src/setup/builtin-requirements.generated.ts
@@ -15,6 +15,13 @@ export const BUILTIN_REQUIREMENTS: Readonly<
       "hint": "Enable @moxxy/plugin-subagents — deep-research fans out sub-queries via ctx.subagents."
     }
   ],
+  "@moxxy/plugin-oauth": [
+    {
+      "kind": "plugin",
+      "name": "@moxxy/plugin-vault",
+      "hint": "oauth resolves the vault from the service registry to store tokens; @moxxy/plugin-vault must load first"
+    }
+  ],
   "@moxxy/plugin-stt-whisper-codex": [
     {
       "kind": "plugin",

--- a/packages/core/src/registries/services.test.ts
+++ b/packages/core/src/registries/services.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { ServiceRegistryImpl } from './services.js';
+
+describe('ServiceRegistryImpl', () => {
+  it('register / get / has round-trip', () => {
+    const r = new ServiceRegistryImpl();
+    expect(r.has('vault')).toBe(false);
+    expect(r.get('vault')).toBeUndefined();
+    const store = { secret: 1 };
+    r.register('vault', store);
+    expect(r.has('vault')).toBe(true);
+    expect(r.get('vault')).toBe(store);
+  });
+
+  it('require returns the service or throws with a helpful message', () => {
+    const r = new ServiceRegistryImpl();
+    expect(() => r.require('vault')).toThrow(/Required service not registered: vault/);
+    const store = { secret: 2 };
+    r.register('vault', store);
+    expect(r.require<typeof store>('vault')).toBe(store);
+  });
+
+  it('last write wins (a later plugin may replace a service)', () => {
+    const r = new ServiceRegistryImpl();
+    r.register('x', 1);
+    r.register('x', 2);
+    expect(r.get('x')).toBe(2);
+  });
+});

--- a/packages/core/src/registries/services.ts
+++ b/packages/core/src/registries/services.ts
@@ -1,0 +1,33 @@
+import type { ServiceRegistry } from '@moxxy/sdk';
+
+/**
+ * In-process inter-plugin service registry (one per Session). A plugin publishes
+ * a named service in `onInit`; a sibling plugin resolves it in its own `onInit`.
+ * Last-write-wins on a duplicate name (a later plugin may intentionally replace
+ * a service); `require` throws when the name was never published.
+ */
+export class ServiceRegistryImpl implements ServiceRegistry {
+  private readonly services = new Map<string, unknown>();
+
+  register<T>(name: string, impl: T): void {
+    this.services.set(name, impl);
+  }
+
+  get<T>(name: string): T | undefined {
+    return this.services.get(name) as T | undefined;
+  }
+
+  require<T>(name: string): T {
+    if (!this.services.has(name)) {
+      throw new Error(
+        `Required service not registered: ${name}. The providing plugin's onInit ` +
+          'must run first — declare a moxxy.requirements entry on the consumer.',
+      );
+    }
+    return this.services.get(name) as T;
+  }
+
+  has(name: string): boolean {
+    return this.services.has(name);
+  }
+}

--- a/packages/core/src/run-turn.ts
+++ b/packages/core/src/run-turn.ts
@@ -110,6 +110,7 @@ export async function* runTurn(
       turnId,
       cwd: appCtx.cwd,
       env: appCtx.env,
+      services: appCtx.services,
       model,
       systemPrompt: opts.systemPrompt,
       provider,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -33,6 +33,7 @@ import { EmbedderRegistry } from './registries/embedders.js';
 import { IsolatorRegistry } from './registries/isolators.js';
 import { WorkflowExecutorRegistry } from './registries/workflow-executors.js';
 import { EventStoreRegistry } from './registries/event-stores.js';
+import { ServiceRegistryImpl } from './registries/services.js';
 import { jsonlEventStore } from './sessions/jsonl-event-store.js';
 import { RequirementRegistry } from './requirements.js';
 import { PermissionEngine } from './permissions/engine.js';
@@ -132,6 +133,8 @@ export class Session implements ClientSession, SessionRuntime {
   readonly isolators: IsolatorRegistry;
   readonly workflowExecutors: WorkflowExecutorRegistry;
   readonly eventStores: EventStoreRegistry;
+  /** Inter-plugin service registry — plugins publish/consume services in onInit. */
+  readonly services: ServiceRegistryImpl;
   readonly requirements: RequirementRegistry;
   readonly permissions: PermissionEngine;
   /** Current PermissionResolver. Update via `setPermissionResolver(r)`. */
@@ -216,6 +219,7 @@ export class Session implements ClientSession, SessionRuntime {
     this.embedders = new EmbedderRegistry();
     this.isolators = new IsolatorRegistry();
     this.workflowExecutors = new WorkflowExecutorRegistry();
+    this.services = new ServiceRegistryImpl();
     this.eventStores = new EventStoreRegistry();
     // Seed the built-in JSONL store as the protected floor — the storage backend
     // behind the event log always exists and can be swapped but never removed.
@@ -386,6 +390,7 @@ export class Session implements ClientSession, SessionRuntime {
       cwd: this.cwd,
       log: this.log.asReader(),
       env: this.envSnapshot,
+      services: this.services,
     };
   }
 

--- a/packages/core/src/subagents/run-child.ts
+++ b/packages/core/src/subagents/run-child.ts
@@ -447,6 +447,7 @@ function buildChildContext(
     turnId: childTurnId,
     cwd: parentAppCtx.cwd,
     env: parentAppCtx.env,
+    services: parentAppCtx.services,
     model,
     ...(spec.systemPrompt !== undefined ? { systemPrompt: spec.systemPrompt } : {}),
     provider: parentSession.providers.getActive(),

--- a/packages/plugin-oauth/package.json
+++ b/packages/plugin-oauth/package.json
@@ -29,7 +29,14 @@
       "entry": "./dist/index.js",
       "kind": "tools",
       "skills": "./skills"
-    }
+    },
+    "requirements": [
+      {
+        "kind": "plugin",
+        "name": "@moxxy/plugin-vault",
+        "hint": "oauth resolves the vault from the service registry to store tokens; @moxxy/plugin-vault must load first"
+      }
+    ]
   },
   "dependencies": {
     "@moxxy/sdk": "workspace:*",

--- a/packages/plugin-oauth/src/discovery.test.ts
+++ b/packages/plugin-oauth/src/discovery.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ServiceRegistry } from '@moxxy/sdk';
+import { oauthPlugin } from './index.js';
+
+/**
+ * The discovery-loadable default export resolves the vault from the inter-plugin
+ * service registry in onInit instead of a `build*({ vault })` closure. (The tool
+ * behaviour with an injected vault is covered by tools.test via buildOauthPlugin.)
+ */
+describe('oauthPlugin (discovery-loadable)', () => {
+  it('exposes the oauth tools and an onInit hook', () => {
+    expect(oauthPlugin.tools?.map((t) => t.name).sort()).toEqual([
+      'oauth_authorize',
+      'oauth_clear_token',
+      'oauth_get_token',
+    ]);
+    expect(typeof oauthPlugin.hooks?.onInit).toBe('function');
+  });
+
+  it('onInit resolves the "vault" service from the registry', () => {
+    const fakeVault = { tag: 'vault-store' };
+    const require = vi.fn((name: string) => {
+      if (name !== 'vault') throw new Error(`unexpected service: ${name}`);
+      return fakeVault;
+    });
+    const services = {
+      require,
+      get: () => fakeVault,
+      has: () => true,
+      register: () => {},
+    } as unknown as ServiceRegistry;
+    oauthPlugin.hooks!.onInit!({ services } as never);
+    expect(require).toHaveBeenCalledWith('vault');
+  });
+});

--- a/packages/plugin-oauth/src/index.ts
+++ b/packages/plugin-oauth/src/index.ts
@@ -1,4 +1,4 @@
-import { definePlugin, type Plugin } from '@moxxy/sdk';
+import { definePlugin, type LifecycleHooks, type Plugin } from '@moxxy/sdk';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import {
   buildOauthAuthorizeTool,
@@ -101,7 +101,45 @@ export interface BuildOauthPluginOpts {
  * (OpenAI's non-standard flavor). New dialects ship their own adapter.
  */
 export function buildOauthPlugin(opts: BuildOauthPluginOpts): Plugin {
-  const deps: OAuthToolDeps = { vault: opts.vault };
+  // Host-injected vault (available immediately).
+  return makeOauthPlugin(() => opts.vault);
+}
+
+/**
+ * Discovery-loadable default export: resolves the vault from the inter-plugin
+ * service registry in `onInit` (the vault plugin publishes `'vault'`). Requires
+ * `@moxxy/plugin-vault` to load first (declared in `package.json`
+ * `moxxy.requirements`), so its `onInit` registers the service before this one
+ * consumes it. The tools read `deps.vault` lazily via a getter, so they resolve
+ * the store at call time — after `onInit` has wired it.
+ */
+export const oauthPlugin: Plugin = (() => {
+  let resolved: VaultStore | null = null;
+  const getVault = (): VaultStore => {
+    if (!resolved) {
+      throw new Error(
+        '@moxxy/plugin-oauth: the "vault" service is unavailable — @moxxy/plugin-vault must load first',
+      );
+    }
+    return resolved;
+  };
+  const hooks: LifecycleHooks = {
+    onInit: (ctx) => {
+      resolved = ctx.services.require<VaultStore>('vault');
+    },
+  };
+  return makeOauthPlugin(getVault, hooks);
+})();
+
+function makeOauthPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks): Plugin {
+  // The getter satisfies `OAuthToolDeps.vault` while deferring resolution to call
+  // time, so the same tools work whether the vault is host-injected or resolved
+  // from the service registry in onInit.
+  const deps: OAuthToolDeps = {
+    get vault(): VaultStore {
+      return getVault();
+    },
+  };
   return definePlugin({
     name: '@moxxy/plugin-oauth',
     version: '0.0.0',
@@ -110,5 +148,6 @@ export function buildOauthPlugin(opts: BuildOauthPluginOpts): Plugin {
       buildOauthGetTokenTool(deps),
       buildOauthClearTool(deps),
     ],
+    ...(hooks ? { hooks } : {}),
   });
 }

--- a/packages/plugin-vault/src/index.ts
+++ b/packages/plugin-vault/src/index.ts
@@ -131,6 +131,16 @@ export function buildVaultPlugin(opts: BuildVaultPluginOptions = {}): { plugin: 
   const plugin = definePlugin({
     name: '@moxxy/plugin-vault',
     version: '0.0.0',
+    // Publish the secret store on the inter-plugin service registry so sibling
+    // plugins (oauth, telegram, mcp, …) can resolve it in their own onInit
+    // instead of being hand-built with `{ vault }` — the seam that lets them be
+    // discovery-loaded. Consumers declare a requirement on @moxxy/plugin-vault
+    // so this onInit runs first.
+    hooks: {
+      onInit: (ctx) => {
+        ctx.services.register('vault', vault);
+      },
+    },
     commands: [vaultCmd],
     tools: [
       defineTool({

--- a/packages/sdk/src/hooks.ts
+++ b/packages/sdk/src/hooks.ts
@@ -3,12 +3,18 @@ import type { EventLogReader } from './log.js';
 import type { PendingToolCall } from './permission.js';
 import type { ProviderRequest } from './provider.js';
 import type { SessionId, TurnId } from './ids.js';
+import type { ServiceRegistry } from './services.js';
 
 export interface AppContext {
   readonly sessionId: SessionId;
   readonly cwd: string;
   readonly log: EventLogReader;
   readonly env: Readonly<Record<string, string | undefined>>;
+  /**
+   * Inter-plugin service registry — publish a service in `onInit` for sibling
+   * plugins to consume in theirs. See {@link ServiceRegistry}.
+   */
+  readonly services: ServiceRegistry;
 }
 
 export interface TurnContext extends AppContext {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -352,6 +352,8 @@ export type {
   HookDispatcher,
 } from './hooks.js';
 
+export type { ServiceRegistry } from './services.js';
+
 export type {
   PluginKind,
   PluginSpec,

--- a/packages/sdk/src/mode.ts
+++ b/packages/sdk/src/mode.ts
@@ -2,6 +2,7 @@ import type { CacheStrategyDef } from './cache-strategy.js';
 import type { CompactorDef } from './compactor.js';
 import type { EmittedEvent, MoxxyEvent } from './events.js';
 import type { HookDispatcher } from './hooks.js';
+import type { ServiceRegistry } from './services.js';
 import type { SessionId, TurnId } from './ids.js';
 import type { EventLogReader } from './log.js';
 import type { PermissionResolver } from './permission.js';
@@ -106,6 +107,8 @@ export interface ModeContext {
   readonly approval?: ApprovalResolver;
   readonly hooks: HookDispatcher;
   readonly pluginHost: PluginHostHandle;
+  /** Inter-plugin service registry (mirrors {@link AppContext.services}). */
+  readonly services: ServiceRegistry;
   readonly signal: AbortSignal;
   readonly maxIterations?: number;
   /**

--- a/packages/sdk/src/mode/collect-stream.ts
+++ b/packages/sdk/src/mode/collect-stream.ts
@@ -147,6 +147,7 @@ export async function collectProviderStream(
     cwd: ctx.cwd,
     log: ctx.log,
     env: ctx.env,
+    services: ctx.services,
     turnId: ctx.turnId,
     iteration: opts.iteration ?? 0,
   });

--- a/packages/sdk/src/services.ts
+++ b/packages/sdk/src/services.ts
@@ -1,0 +1,30 @@
+/**
+ * Inter-plugin service registry. A plugin can **publish** a named service in its
+ * `onInit` hook (e.g. the vault plugin publishes its secret store) and another
+ * plugin can **consume** it in its own `onInit` — decoupling cross-plugin
+ * dependencies from the host's constructor wiring so a plugin can be
+ * discovery-loaded (default-exported, no `build*({deps})` closure) instead of
+ * hand-built by the orchestrator.
+ *
+ * Ordering is by plugin requirements: declare `moxxy.requirements` on the
+ * consumer (e.g. `@moxxy/plugin-oauth` requires `@moxxy/plugin-vault`) so the
+ * provider's `onInit` runs first and the service is registered before the
+ * consumer resolves it. Exposed on {@link AppContext.services}.
+ *
+ * Plugin `onInit` already runs with full in-process privileges (the security
+ * isolation wraps *tool* execution, not plugin code), so reaching a sibling
+ * plugin's service here doesn't widen the effective trust surface.
+ */
+export interface ServiceRegistry {
+  /** Publish a named service for other plugins to consume in their `onInit`. */
+  register<T>(name: string, impl: T): void;
+  /** Resolve a published service, or `undefined` when it isn't registered. */
+  get<T>(name: string): T | undefined;
+  /**
+   * Resolve a published service or throw — use when a declared requirement
+   * guarantees the provider ran first.
+   */
+  require<T>(name: string): T;
+  /** Whether a service has been published. */
+  has(name: string): boolean;
+}

--- a/packages/sdk/src/tool-dispatch.ts
+++ b/packages/sdk/src/tool-dispatch.ts
@@ -37,6 +37,7 @@ export async function* dispatchToolCall(
       cwd: ctx.cwd,
       log: ctx.log,
       env: ctx.env,
+      services: ctx.services,
       turnId: ctx.turnId,
       iteration,
       call: { callId: asToolCallId(t.id), name: t.name, input: t.input },


### PR DESCRIPTION
## What

The foundational seam for making closure-injected plugins **discovery-loadable** (Pillar 3 groundwork).

Today plugins like `oauth`/`telegram`/`mcp` are hand-built by the host with `build*({ vault, … })` closures because they depend on services owned by *other* plugins (the vault) — and `onInit`'s `AppContext` was intentionally minimal (`{ sessionId, cwd, log, env }`), with no way to reach a sibling plugin's service. This adds the missing mechanism:

- **`ServiceRegistry`** (`register` / `get` / `require` / `has`) in `@moxxy/sdk`, exposed on **`AppContext.services`**. A plugin **publishes** a named service in its `onInit`; a sibling **consumes** it in theirs. Ordering is by `moxxy.requirements`, so the provider's `onInit` runs first.
- Core's `ServiceRegistryImpl` backs `session.services` and is threaded through `AppContext → ModeContext →` the hook contexts.

### First conversions
- **vault** publishes its secret store: `services.register('vault', vault)`.
- **`@moxxy/plugin-oauth`** ships a discovery-loadable default export `oauthPlugin` that resolves the vault from `ctx.services.require('vault')` in `onInit` (via a getter, so the existing tools are untouched), and declares `@moxxy/plugin-vault` as a requirement for ordering. `buildOauthPlugin` is kept for direct injection. `builtin-entries` now uses `oauthPlugin` (no `{ vault }` closure).

Plugin `onInit` already runs with full in-process privileges (the security isolation wraps *tool* execution, not plugin code), so reaching a sibling's service here doesn't widen the effective trust surface.

## Why

It's the prerequisite for unbundling the ~12 closure-injected plugins (the rest follow this pattern in later PRs). The registry is also a genuine architecture improvement on its own — clean inter-plugin dependency resolution instead of bespoke host wiring.

## Testing
typecheck 0, build (73 tasks), lint 0, `check:deps` 0; new tests for `ServiceRegistryImpl` and the oauth↔vault `onInit` wiring; sdk/core/oauth/vault suites green. (The repo's pre-existing flaky `workflows.test.ts` file-watcher test is unrelated — it touches no code here.)

Changeset included.