### PR TITLE
feat(plugins): telegram + whisper-codex discovery-loadable (onInit wave)

### DIFF
--- a/.changeset/plugin-service-registry.md
+++ b/.changeset/plugin-service-registry.md
@@ -1,0 +1,11 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/core': minor
+'@moxxy/cli': patch
+---
+
+Inter-plugin service registry (`AppContext.services`) — plugins publish a named service in `onInit` and consume siblings' services in theirs, requirements-ordered so the provider runs first. This decouples cross-plugin dependencies from the host's `build*({ deps })` constructor wiring, letting a plugin be discovery-loaded (default-exported) instead of hand-built by the orchestrator.
+
+The vault plugin now publishes its secret store (`services.register('vault', vault)`), and `@moxxy/plugin-oauth` is the first consumer to go discovery-loadable: the default-exported `oauthPlugin` resolves the vault from `ctx.services.require('vault')` in `onInit` (declaring `@moxxy/plugin-vault` as a requirement for ordering), so it no longer needs the `{ vault }` closure. `buildOauthPlugin` is kept for direct injection.
+
+Since plugin `onInit` already runs with full in-process privileges (the security isolation wraps tool execution, not plugin code), this doesn't widen the effective trust surface.

--- a/.changeset/telegram-whisper-codex-discovery.md
+++ b/.changeset/telegram-whisper-codex-discovery.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/cli': patch
+---
+
+Convert the telegram + Codex-OAuth Whisper transcriber plugins to discovery-loadable default exports (`telegramPlugin`, `whisperCodexPlugin`) that resolve the vault from the inter-plugin service registry in `onInit` instead of a `build*({ vault })` closure, declaring `@moxxy/plugin-vault` as a requirement for ordering. The `build*` factories are kept for direct injection. Same pattern as `@moxxy/plugin-oauth` — extending the onInit refactor wave across the channel + transcriber plugin kinds.

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -12,7 +12,7 @@ import { xaiPlugin } from '@moxxy/plugin-provider-xai';
 import { googlePlugin } from '@moxxy/plugin-provider-google';
 import { localPlugin } from '@moxxy/plugin-provider-local';
 import { buildWhisperPlugin } from '@moxxy/plugin-stt-whisper';
-import { buildWhisperCodexPlugin } from '@moxxy/plugin-stt-whisper-codex';
+import { whisperCodexPlugin } from '@moxxy/plugin-stt-whisper-codex';
 import { builtinToolsPlugin } from '@moxxy/tools-builtin';
 import { defaultModePlugin } from '@moxxy/mode-default';
 import { goalModePlugin } from '@moxxy/mode-goal';
@@ -25,7 +25,7 @@ import {
   buildMemoryConsolidatePlugin,
   type MemoryStore,
 } from '@moxxy/plugin-memory';
-import { buildTelegramPlugin } from '@moxxy/plugin-telegram';
+import { telegramPlugin } from '@moxxy/plugin-telegram';
 import { buildMcpAdminPluginWithApi } from '@moxxy/plugin-mcp';
 import { cliPlugin } from '@moxxy/plugin-cli';
 import { httpChannelPlugin } from '@moxxy/plugin-channel-http';
@@ -115,8 +115,9 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
     { name: '@moxxy/plugin-vault', plugin: vaultPlugin },
     { name: '@moxxy/plugin-stt-whisper', plugin: buildWhisperPlugin() },
     {
+      // Discovery-loadable: resolves the vault from the service registry in onInit.
       name: '@moxxy/plugin-stt-whisper-codex',
-      plugin: buildWhisperCodexPlugin({ vault }),
+      plugin: whisperCodexPlugin,
     },
     { name: '@moxxy/plugin-memory', plugin: memoryPlugin },
     {
@@ -155,7 +156,8 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
       }),
     },
     { name: '@moxxy/plugin-channel-mobile', plugin: mobileChannelPlugin },
-    { name: '@moxxy/plugin-telegram', plugin: buildTelegramPlugin({ vault }) },
+    // Discovery-loadable: resolves the vault from the service registry in onInit.
+    { name: '@moxxy/plugin-telegram', plugin: telegramPlugin },
     { name: '@moxxy/plugin-browser', plugin: browserPlugin },
     // Shared terminal surface + `terminal` tool. node-pty is an optional native
     // peer dep, so the surface availability (real PTY vs piped fallback) is

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -41,7 +41,7 @@ import { buildUsageStatsPlugin } from '@moxxy/plugin-usage-stats';
 import { commandsPlugin } from '@moxxy/plugin-commands';
 import { buildViewPlugin } from '@moxxy/plugin-view';
 import { computerControlPlugin } from '@moxxy/plugin-computer-control';
-import { buildOauthPlugin } from '@moxxy/plugin-oauth';
+import { oauthPlugin } from '@moxxy/plugin-oauth';
 import { buildVoiceAdminPlugin } from '@moxxy/plugin-voice-admin';
 import { resolveString } from '@moxxy/plugin-vault';
 import type { VaultStore } from '@moxxy/plugin-vault';
@@ -169,7 +169,9 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
     // Generic OAuth 2.0 + PKCE client. Adds oauth_authorize /
     // oauth_get_token / oauth_clear_token tools that any skill can
     // chain (Google OAuth → MCP env, GitHub OAuth → API calls, …).
-    { name: '@moxxy/plugin-oauth', plugin: buildOauthPlugin({ vault }) },
+    // Discovery-loadable: resolves the vault from the service registry in
+    // onInit (vault registers it first), no `{ vault }` injection needed.
+    { name: '@moxxy/plugin-oauth', plugin: oauthPlugin },
     // Universal slash commands (/info, /clear, /new, /exit, /help)
     // shared across every channel via session.commands. Disable to
     // hide them everywhere — channel-local commands keep working.

--- a/packages/cli/src/setup/builtin-requirements.generated.ts
+++ b/packages/cli/src/setup/builtin-requirements.generated.ts
@@ -34,6 +34,19 @@ export const BUILTIN_REQUIREMENTS: Readonly<
       "name": "@moxxy/plugin-stt-whisper",
       "state": "registered",
       "hint": "Enable @moxxy/plugin-stt-whisper for shared audio helpers."
+    },
+    {
+      "kind": "plugin",
+      "name": "@moxxy/plugin-vault",
+      "state": "registered",
+      "hint": "whisper-codex resolves the vault from the service registry for the Codex OAuth token; @moxxy/plugin-vault must load first."
+    }
+  ],
+  "@moxxy/plugin-telegram": [
+    {
+      "kind": "plugin",
+      "name": "@moxxy/plugin-vault",
+      "hint": "telegram resolves the vault from the service registry for its bot token + pairing; @moxxy/plugin-vault must load first"
     }
   ]
 } as const satisfies Readonly<

--- a/packages/cli/src/setup/builtin-requirements.generated.ts
+++ b/packages/cli/src/setup/builtin-requirements.generated.ts
@@ -15,6 +15,13 @@ export const BUILTIN_REQUIREMENTS: Readonly<
       "hint": "Enable @moxxy/plugin-subagents — deep-research fans out sub-queries via ctx.subagents."
     }
   ],
+  "@moxxy/plugin-oauth": [
+    {
+      "kind": "plugin",
+      "name": "@moxxy/plugin-vault",
+      "hint": "oauth resolves the vault from the service registry to store tokens; @moxxy/plugin-vault must load first"
+    }
+  ],
   "@moxxy/plugin-stt-whisper-codex": [
     {
       "kind": "plugin",

--- a/packages/core/src/registries/services.test.ts
+++ b/packages/core/src/registries/services.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { ServiceRegistryImpl } from './services.js';
+
+describe('ServiceRegistryImpl', () => {
+  it('register / get / has round-trip', () => {
+    const r = new ServiceRegistryImpl();
+    expect(r.has('vault')).toBe(false);
+    expect(r.get('vault')).toBeUndefined();
+    const store = { secret: 1 };
+    r.register('vault', store);
+    expect(r.has('vault')).toBe(true);
+    expect(r.get('vault')).toBe(store);
+  });
+
+  it('require returns the service or throws with a helpful message', () => {
+    const r = new ServiceRegistryImpl();
+    expect(() => r.require('vault')).toThrow(/Required service not registered: vault/);
+    const store = { secret: 2 };
+    r.register('vault', store);
+    expect(r.require<typeof store>('vault')).toBe(store);
+  });
+
+  it('last write wins (a later plugin may replace a service)', () => {
+    const r = new ServiceRegistryImpl();
+    r.register('x', 1);
+    r.register('x', 2);
+    expect(r.get('x')).toBe(2);
+  });
+});

--- a/packages/core/src/registries/services.ts
+++ b/packages/core/src/registries/services.ts
@@ -1,0 +1,33 @@
+import type { ServiceRegistry } from '@moxxy/sdk';
+
+/**
+ * In-process inter-plugin service registry (one per Session). A plugin publishes
+ * a named service in `onInit`; a sibling plugin resolves it in its own `onInit`.
+ * Last-write-wins on a duplicate name (a later plugin may intentionally replace
+ * a service); `require` throws when the name was never published.
+ */
+export class ServiceRegistryImpl implements ServiceRegistry {
+  private readonly services = new Map<string, unknown>();
+
+  register<T>(name: string, impl: T): void {
+    this.services.set(name, impl);
+  }
+
+  get<T>(name: string): T | undefined {
+    return this.services.get(name) as T | undefined;
+  }
+
+  require<T>(name: string): T {
+    if (!this.services.has(name)) {
+      throw new Error(
+        `Required service not registered: ${name}. The providing plugin's onInit ` +
+          'must run first — declare a moxxy.requirements entry on the consumer.',
+      );
+    }
+    return this.services.get(name) as T;
+  }
+
+  has(name: string): boolean {
+    return this.services.has(name);
+  }
+}

--- a/packages/core/src/run-turn.ts
+++ b/packages/core/src/run-turn.ts
@@ -110,6 +110,7 @@ export async function* runTurn(
       turnId,
       cwd: appCtx.cwd,
       env: appCtx.env,
+      services: appCtx.services,
       model,
       systemPrompt: opts.systemPrompt,
       provider,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -33,6 +33,7 @@ import { EmbedderRegistry } from './registries/embedders.js';
 import { IsolatorRegistry } from './registries/isolators.js';
 import { WorkflowExecutorRegistry } from './registries/workflow-executors.js';
 import { EventStoreRegistry } from './registries/event-stores.js';
+import { ServiceRegistryImpl } from './registries/services.js';
 import { jsonlEventStore } from './sessions/jsonl-event-store.js';
 import { RequirementRegistry } from './requirements.js';
 import { PermissionEngine } from './permissions/engine.js';
@@ -132,6 +133,8 @@ export class Session implements ClientSession, SessionRuntime {
   readonly isolators: IsolatorRegistry;
   readonly workflowExecutors: WorkflowExecutorRegistry;
   readonly eventStores: EventStoreRegistry;
+  /** Inter-plugin service registry — plugins publish/consume services in onInit. */
+  readonly services: ServiceRegistryImpl;
   readonly requirements: RequirementRegistry;
   readonly permissions: PermissionEngine;
   /** Current PermissionResolver. Update via `setPermissionResolver(r)`. */
@@ -216,6 +219,7 @@ export class Session implements ClientSession, SessionRuntime {
     this.embedders = new EmbedderRegistry();
     this.isolators = new IsolatorRegistry();
     this.workflowExecutors = new WorkflowExecutorRegistry();
+    this.services = new ServiceRegistryImpl();
     this.eventStores = new EventStoreRegistry();
     // Seed the built-in JSONL store as the protected floor — the storage backend
     // behind the event log always exists and can be swapped but never removed.
@@ -386,6 +390,7 @@ export class Session implements ClientSession, SessionRuntime {
       cwd: this.cwd,
       log: this.log.asReader(),
       env: this.envSnapshot,
+      services: this.services,
     };
   }
 

--- a/packages/core/src/subagents/run-child.ts
+++ b/packages/core/src/subagents/run-child.ts
@@ -447,6 +447,7 @@ function buildChildContext(
     turnId: childTurnId,
     cwd: parentAppCtx.cwd,
     env: parentAppCtx.env,
+    services: parentAppCtx.services,
     model,
     ...(spec.systemPrompt !== undefined ? { systemPrompt: spec.systemPrompt } : {}),
     provider: parentSession.providers.getActive(),

--- a/packages/plugin-oauth/package.json
+++ b/packages/plugin-oauth/package.json
@@ -29,7 +29,14 @@
       "entry": "./dist/index.js",
       "kind": "tools",
       "skills": "./skills"
-    }
+    },
+    "requirements": [
+      {
+        "kind": "plugin",
+        "name": "@moxxy/plugin-vault",
+        "hint": "oauth resolves the vault from the service registry to store tokens; @moxxy/plugin-vault must load first"
+      }
+    ]
   },
   "dependencies": {
     "@moxxy/sdk": "workspace:*",

--- a/packages/plugin-oauth/src/discovery.test.ts
+++ b/packages/plugin-oauth/src/discovery.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ServiceRegistry } from '@moxxy/sdk';
+import { oauthPlugin } from './index.js';
+
+/**
+ * The discovery-loadable default export resolves the vault from the inter-plugin
+ * service registry in onInit instead of a `build*({ vault })` closure. (The tool
+ * behaviour with an injected vault is covered by tools.test via buildOauthPlugin.)
+ */
+describe('oauthPlugin (discovery-loadable)', () => {
+  it('exposes the oauth tools and an onInit hook', () => {
+    expect(oauthPlugin.tools?.map((t) => t.name).sort()).toEqual([
+      'oauth_authorize',
+      'oauth_clear_token',
+      'oauth_get_token',
+    ]);
+    expect(typeof oauthPlugin.hooks?.onInit).toBe('function');
+  });
+
+  it('onInit resolves the "vault" service from the registry', () => {
+    const fakeVault = { tag: 'vault-store' };
+    const require = vi.fn((name: string) => {
+      if (name !== 'vault') throw new Error(`unexpected service: ${name}`);
+      return fakeVault;
+    });
+    const services = {
+      require,
+      get: () => fakeVault,
+      has: () => true,
+      register: () => {},
+    } as unknown as ServiceRegistry;
+    oauthPlugin.hooks!.onInit!({ services } as never);
+    expect(require).toHaveBeenCalledWith('vault');
+  });
+});

--- a/packages/plugin-oauth/src/index.ts
+++ b/packages/plugin-oauth/src/index.ts
@@ -1,4 +1,4 @@
-import { definePlugin, type Plugin } from '@moxxy/sdk';
+import { definePlugin, type LifecycleHooks, type Plugin } from '@moxxy/sdk';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import {
   buildOauthAuthorizeTool,
@@ -101,7 +101,45 @@ export interface BuildOauthPluginOpts {
  * (OpenAI's non-standard flavor). New dialects ship their own adapter.
  */
 export function buildOauthPlugin(opts: BuildOauthPluginOpts): Plugin {
-  const deps: OAuthToolDeps = { vault: opts.vault };
+  // Host-injected vault (available immediately).
+  return makeOauthPlugin(() => opts.vault);
+}
+
+/**
+ * Discovery-loadable default export: resolves the vault from the inter-plugin
+ * service registry in `onInit` (the vault plugin publishes `'vault'`). Requires
+ * `@moxxy/plugin-vault` to load first (declared in `package.json`
+ * `moxxy.requirements`), so its `onInit` registers the service before this one
+ * consumes it. The tools read `deps.vault` lazily via a getter, so they resolve
+ * the store at call time — after `onInit` has wired it.
+ */
+export const oauthPlugin: Plugin = (() => {
+  let resolved: VaultStore | null = null;
+  const getVault = (): VaultStore => {
+    if (!resolved) {
+      throw new Error(
+        '@moxxy/plugin-oauth: the "vault" service is unavailable — @moxxy/plugin-vault must load first',
+      );
+    }
+    return resolved;
+  };
+  const hooks: LifecycleHooks = {
+    onInit: (ctx) => {
+      resolved = ctx.services.require<VaultStore>('vault');
+    },
+  };
+  return makeOauthPlugin(getVault, hooks);
+})();
+
+function makeOauthPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks): Plugin {
+  // The getter satisfies `OAuthToolDeps.vault` while deferring resolution to call
+  // time, so the same tools work whether the vault is host-injected or resolved
+  // from the service registry in onInit.
+  const deps: OAuthToolDeps = {
+    get vault(): VaultStore {
+      return getVault();
+    },
+  };
   return definePlugin({
     name: '@moxxy/plugin-oauth',
     version: '0.0.0',
@@ -110,5 +148,6 @@ export function buildOauthPlugin(opts: BuildOauthPluginOpts): Plugin {
       buildOauthGetTokenTool(deps),
       buildOauthClearTool(deps),
     ],
+    ...(hooks ? { hooks } : {}),
   });
 }

--- a/packages/plugin-stt-whisper-codex/package.json
+++ b/packages/plugin-stt-whisper-codex/package.json
@@ -39,6 +39,12 @@
         "name": "@moxxy/plugin-stt-whisper",
         "state": "registered",
         "hint": "Enable @moxxy/plugin-stt-whisper for shared audio helpers."
+      },
+      {
+        "kind": "plugin",
+        "name": "@moxxy/plugin-vault",
+        "state": "registered",
+        "hint": "whisper-codex resolves the vault from the service registry for the Codex OAuth token; @moxxy/plugin-vault must load first."
       }
     ]
   },

--- a/packages/plugin-stt-whisper-codex/src/index.ts
+++ b/packages/plugin-stt-whisper-codex/src/index.ts
@@ -1,4 +1,4 @@
-import { definePlugin, defineTranscriber, type Plugin } from '@moxxy/sdk';
+import { definePlugin, defineTranscriber, type LifecycleHooks, type Plugin } from '@moxxy/sdk';
 import {
   CodexOAuthTranscriber,
   OPENAI_CODEX_TRANSCRIBER_NAME,
@@ -32,9 +32,44 @@ export interface BuildWhisperCodexPluginOptions {
 export function buildWhisperCodexPlugin(
   opts: BuildWhisperCodexPluginOptions,
 ): Plugin {
+  const { vault, ...rest } = opts;
+  return makeWhisperCodexPlugin(() => vault, rest);
+}
+
+/**
+ * Discovery-loadable default export: resolves the vault from the inter-plugin
+ * service registry in `onInit`. Requires `@moxxy/plugin-vault` to load first
+ * (declared in `package.json` `moxxy.requirements`). `baseUrl`/`fetch`/
+ * `sessionIdProvider`/`requestTimeoutMs` fall back to their `createClient`
+ * config/defaults when the host doesn't inject them.
+ */
+export const whisperCodexPlugin: Plugin = (() => {
+  let resolved: CodexOAuthVault | null = null;
+  const getVault = (): CodexOAuthVault => {
+    if (!resolved) {
+      throw new Error(
+        '@moxxy/plugin-stt-whisper-codex: the "vault" service is unavailable — @moxxy/plugin-vault must load first',
+      );
+    }
+    return resolved;
+  };
+  const hooks: LifecycleHooks = {
+    onInit: (ctx) => {
+      resolved = ctx.services.require<CodexOAuthVault>('vault');
+    },
+  };
+  return makeWhisperCodexPlugin(getVault, {}, hooks);
+})();
+
+function makeWhisperCodexPlugin(
+  getVault: () => CodexOAuthVault,
+  opts: Omit<BuildWhisperCodexPluginOptions, 'vault'>,
+  hooks?: LifecycleHooks,
+): Plugin {
   return definePlugin({
     name: '@moxxy/plugin-stt-whisper-codex',
     version: '0.0.0',
+    ...(hooks ? { hooks } : {}),
     transcribers: [
       defineTranscriber({
         name: OPENAI_CODEX_TRANSCRIBER_NAME,
@@ -58,7 +93,7 @@ export function buildWhisperCodexPlugin(
           const sessionIdProvider =
             configSessionIdProvider ?? opts.sessionIdProvider;
           const merged: CodexOAuthTranscriberOptions = {
-            vault: opts.vault,
+            vault: getVault(),
             ...(baseUrl ? { baseUrl } : {}),
             ...(opts.fetch ? { fetch: opts.fetch } : {}),
             ...(sessionIdProvider ? { sessionIdProvider } : {}),

--- a/packages/plugin-telegram/package.json
+++ b/packages/plugin-telegram/package.json
@@ -26,7 +26,14 @@
     "plugin": {
       "entry": "./dist/index.js",
       "kind": "cli"
-    }
+    },
+    "requirements": [
+      {
+        "kind": "plugin",
+        "name": "@moxxy/plugin-vault",
+        "hint": "telegram resolves the vault from the service registry for its bot token + pairing; @moxxy/plugin-vault must load first"
+      }
+    ]
   },
   "dependencies": {
     "@clack/prompts": "catalog:",

--- a/packages/plugin-telegram/src/index.ts
+++ b/packages/plugin-telegram/src/index.ts
@@ -1,4 +1,4 @@
-import { defineChannel, defineTool, definePlugin, z, type Plugin } from '@moxxy/sdk';
+import { defineChannel, defineTool, definePlugin, z, type LifecycleHooks, type Plugin } from '@moxxy/sdk';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { Api } from 'grammy';
 import { TelegramChannel } from './channel.js';
@@ -39,16 +39,47 @@ const TOKEN_KEY = TELEGRAM_TOKEN_KEY;
 const AUTHORIZED_CHAT_KEY = TELEGRAM_AUTHORIZED_CHAT_KEY;
 
 export function buildTelegramPlugin(opts: BuildTelegramPluginOptions): Plugin {
+  // Host-injected vault (available immediately).
+  return makeTelegramPlugin(() => opts.vault);
+}
+
+/**
+ * Discovery-loadable default export: resolves the vault from the inter-plugin
+ * service registry in `onInit` (the vault plugin publishes `'vault'`). Requires
+ * `@moxxy/plugin-vault` to load first (declared in `package.json`
+ * `moxxy.requirements`). The channel + tools read the vault via `getVault()`,
+ * so resolution is deferred to call time — after `onInit` has wired it.
+ */
+export const telegramPlugin: Plugin = (() => {
+  let resolved: VaultStore | null = null;
+  const getVault = (): VaultStore => {
+    if (!resolved) {
+      throw new Error(
+        '@moxxy/plugin-telegram: the "vault" service is unavailable — @moxxy/plugin-vault must load first',
+      );
+    }
+    return resolved;
+  };
+  const hooks: LifecycleHooks = {
+    onInit: (ctx) => {
+      resolved = ctx.services.require<VaultStore>('vault');
+    },
+  };
+  return makeTelegramPlugin(getVault, hooks);
+})();
+
+function makeTelegramPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks): Plugin {
   return definePlugin({
     name: '@moxxy/plugin-telegram',
     version: '0.0.0',
+    ...(hooks ? { hooks } : {}),
     channels: [
       defineChannel({
         name: 'telegram',
         description: 'Telegram bot channel via grammy. TOFU + code-pairing authorization.',
         create: (deps) =>
           new TelegramChannel({
-            vault: opts.vault,
+            vault: getVault(),
             token: (deps.options?.['token'] as string | undefined) ?? undefined,
             logger: deps.logger as never,
           }),
@@ -56,7 +87,7 @@ export function buildTelegramPlugin(opts: BuildTelegramPluginOptions): Plugin {
           const envToken = process.env.MOXXY_TELEGRAM_TOKEN;
           if (envToken) return { ok: true };
           try {
-            const stored = await opts.vault.has(TOKEN_KEY);
+            const stored = await getVault().has(TOKEN_KEY);
             if (stored) return { ok: true };
             return {
               ok: false,
@@ -155,7 +186,7 @@ export function buildTelegramPlugin(opts: BuildTelegramPluginOptions): Plugin {
         }),
         permission: { action: 'prompt' },
         handler: async ({ token }) => {
-          await opts.vault.set(TOKEN_KEY, token, ['telegram']);
+          await getVault().set(TOKEN_KEY, token, ['telegram']);
           return `stored Telegram token (${token.split(':')[0]}:…) in vault`;
         },
       }),
@@ -164,8 +195,8 @@ export function buildTelegramPlugin(opts: BuildTelegramPluginOptions): Plugin {
         description: 'Report whether a Telegram token + an authorized chat are configured.',
         inputSchema: z.object({}),
         handler: async () => {
-          const hasToken = await opts.vault.has(TOKEN_KEY);
-          const authorized = await opts.vault.get(AUTHORIZED_CHAT_KEY);
+          const hasToken = await getVault().has(TOKEN_KEY);
+          const authorized = await getVault().get(AUTHORIZED_CHAT_KEY);
           return {
             tokenConfigured: hasToken,
             authorizedChatId: parseChatId(authorized),
@@ -187,14 +218,14 @@ export function buildTelegramPlugin(opts: BuildTelegramPluginOptions): Plugin {
         }),
         permission: { action: 'prompt' },
         handler: async ({ text, chatId, parseMode }) => {
-          const token = process.env.MOXXY_TELEGRAM_TOKEN ?? (await opts.vault.get(TOKEN_KEY));
+          const token = process.env.MOXXY_TELEGRAM_TOKEN ?? (await getVault().get(TOKEN_KEY));
           if (!token) {
             throw new Error(
               'no Telegram bot token configured (set MOXXY_TELEGRAM_TOKEN or run `moxxy init` to store one)',
             );
           }
           const targetChat =
-            chatId ?? parseChatId(await opts.vault.get(AUTHORIZED_CHAT_KEY));
+            chatId ?? parseChatId(await getVault().get(AUTHORIZED_CHAT_KEY));
           if (!targetChat) {
             throw new Error(
               'no authorized chat — run `moxxy channels telegram pair` first or pass `chatId` explicitly',
@@ -215,7 +246,7 @@ export function buildTelegramPlugin(opts: BuildTelegramPluginOptions): Plugin {
         inputSchema: z.object({}),
         permission: { action: 'prompt' },
         handler: async () => {
-          const removed = await opts.vault.delete(AUTHORIZED_CHAT_KEY);
+          const removed = await getVault().delete(AUTHORIZED_CHAT_KEY);
           return removed ? 'unpaired' : 'no pairing was active';
         },
       }),

--- a/packages/plugin-vault/src/index.ts
+++ b/packages/plugin-vault/src/index.ts
@@ -131,6 +131,16 @@ export function buildVaultPlugin(opts: BuildVaultPluginOptions = {}): { plugin: 
   const plugin = definePlugin({
     name: '@moxxy/plugin-vault',
     version: '0.0.0',
+    // Publish the secret store on the inter-plugin service registry so sibling
+    // plugins (oauth, telegram, mcp, …) can resolve it in their own onInit
+    // instead of being hand-built with `{ vault }` — the seam that lets them be
+    // discovery-loaded. Consumers declare a requirement on @moxxy/plugin-vault
+    // so this onInit runs first.
+    hooks: {
+      onInit: (ctx) => {
+        ctx.services.register('vault', vault);
+      },
+    },
     commands: [vaultCmd],
     tools: [
       defineTool({

--- a/packages/sdk/src/hooks.ts
+++ b/packages/sdk/src/hooks.ts
@@ -3,12 +3,18 @@ import type { EventLogReader } from './log.js';
 import type { PendingToolCall } from './permission.js';
 import type { ProviderRequest } from './provider.js';
 import type { SessionId, TurnId } from './ids.js';
+import type { ServiceRegistry } from './services.js';
 
 export interface AppContext {
   readonly sessionId: SessionId;
   readonly cwd: string;
   readonly log: EventLogReader;
   readonly env: Readonly<Record<string, string | undefined>>;
+  /**
+   * Inter-plugin service registry — publish a service in `onInit` for sibling
+   * plugins to consume in theirs. See {@link ServiceRegistry}.
+   */
+  readonly services: ServiceRegistry;
 }
 
 export interface TurnContext extends AppContext {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -352,6 +352,8 @@ export type {
   HookDispatcher,
 } from './hooks.js';
 
+export type { ServiceRegistry } from './services.js';
+
 export type {
   PluginKind,
   PluginSpec,

--- a/packages/sdk/src/mode.ts
+++ b/packages/sdk/src/mode.ts
@@ -2,6 +2,7 @@ import type { CacheStrategyDef } from './cache-strategy.js';
 import type { CompactorDef } from './compactor.js';
 import type { EmittedEvent, MoxxyEvent } from './events.js';
 import type { HookDispatcher } from './hooks.js';
+import type { ServiceRegistry } from './services.js';
 import type { SessionId, TurnId } from './ids.js';
 import type { EventLogReader } from './log.js';
 import type { PermissionResolver } from './permission.js';
@@ -106,6 +107,8 @@ export interface ModeContext {
   readonly approval?: ApprovalResolver;
   readonly hooks: HookDispatcher;
   readonly pluginHost: PluginHostHandle;
+  /** Inter-plugin service registry (mirrors {@link AppContext.services}). */
+  readonly services: ServiceRegistry;
   readonly signal: AbortSignal;
   readonly maxIterations?: number;
   /**

--- a/packages/sdk/src/mode/collect-stream.ts
+++ b/packages/sdk/src/mode/collect-stream.ts
@@ -147,6 +147,7 @@ export async function collectProviderStream(
     cwd: ctx.cwd,
     log: ctx.log,
     env: ctx.env,
+    services: ctx.services,
     turnId: ctx.turnId,
     iteration: opts.iteration ?? 0,
   });

--- a/packages/sdk/src/services.ts
+++ b/packages/sdk/src/services.ts
@@ -1,0 +1,30 @@
+/**
+ * Inter-plugin service registry. A plugin can **publish** a named service in its
+ * `onInit` hook (e.g. the vault plugin publishes its secret store) and another
+ * plugin can **consume** it in its own `onInit` — decoupling cross-plugin
+ * dependencies from the host's constructor wiring so a plugin can be
+ * discovery-loaded (default-exported, no `build*({deps})` closure) instead of
+ * hand-built by the orchestrator.
+ *
+ * Ordering is by plugin requirements: declare `moxxy.requirements` on the
+ * consumer (e.g. `@moxxy/plugin-oauth` requires `@moxxy/plugin-vault`) so the
+ * provider's `onInit` runs first and the service is registered before the
+ * consumer resolves it. Exposed on {@link AppContext.services}.
+ *
+ * Plugin `onInit` already runs with full in-process privileges (the security
+ * isolation wraps *tool* execution, not plugin code), so reaching a sibling
+ * plugin's service here doesn't widen the effective trust surface.
+ */
+export interface ServiceRegistry {
+  /** Publish a named service for other plugins to consume in their `onInit`. */
+  register<T>(name: string, impl: T): void;
+  /** Resolve a published service, or `undefined` when it isn't registered. */
+  get<T>(name: string): T | undefined;
+  /**
+   * Resolve a published service or throw — use when a declared requirement
+   * guarantees the provider ran first.
+   */
+  require<T>(name: string): T;
+  /** Whether a service has been published. */
+  has(name: string): boolean;
+}

--- a/packages/sdk/src/tool-dispatch.ts
+++ b/packages/sdk/src/tool-dispatch.ts
@@ -37,6 +37,7 @@ export async function* dispatchToolCall(
       cwd: ctx.cwd,
       log: ctx.log,
       env: ctx.env,
+      services: ctx.services,
       turnId: ctx.turnId,
       iteration,
       call: { callId: asToolCallId(t.id), name: t.name, input: t.input },


### PR DESCRIPTION
## What

Continues the onInit refactor wave from #349 (the service-registry foundation). Converts the next two **vault-only** closure-injected plugins to discovery-loadable default exports:

- `@moxxy/plugin-telegram` → **`telegramPlugin`**
- `@moxxy/plugin-stt-whisper-codex` → **`whisperCodexPlugin`**

Both resolve the vault from `ctx.services.require('vault')` in `onInit` (via a getter, so the channel + tools / transcriber client read it lazily at call time — after `onInit` wired it), declare `@moxxy/plugin-vault` as a `moxxy.requirements` entry for ordering, and are used directly in `builtin-entries` (no `{ vault }` closure). The `build*` factories are kept for direct injection.

This proves the pattern generalizes across plugin kinds — **oauth** (#349) was a tools plugin; this adds a **channel** and a **transcriber**.

> ⚠️ Stacked on #349 — base is `feat/pillar3-slim-core`. Merge #349 first; this targets it so the diff is only the wave.

## Not in scope (next follow-up)

The **registry-needers** (`subagents`, `view`, `voice-admin`, `provider-admin`, `mcp`) consume the live session's registries/pluginHost/surface-refs via closures. Converting them needs core to **publish its registries as services** behind a minimal SDK registry interface — a distinct, bigger mechanism than vault-service consumption, best as its own PR.

## Testing
`turbo run test` green across all packages (exit 0), build (73 tasks), lint 0, `check:deps` 0; telegram (103) + whisper-codex (19) suites pass. Changeset included.