### PR TITLE
feat(plugins): publish core registries as services; subagents + voice-admin discovery-loadable

### DIFF
--- a/.changeset/registry-services.md
+++ b/.changeset/registry-services.md
@@ -1,0 +1,9 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/core': minor
+'@moxxy/cli': patch
+---
+
+The host now publishes its core registries on the inter-plugin service registry under well-known names (`agents`, `tools`, `providers`, `viewRenderers`, `synthesizers`), and the SDK exposes a minimal `NamedRegistry<T>` view (`get`/`list`/`has`) so a discovery-loaded plugin can resolve one in `onInit` without importing `@moxxy/core`'s concrete registry types.
+
+Two more closure-injected plugins go discovery-loadable on this seam: `@moxxy/plugin-subagents` (`subagentsPlugin` — resolves the `agents` + `tools` registries for `dispatch_agent`'s kind lookup + parent-tool snapshot) and `@moxxy/plugin-voice-admin` (`voiceAdminPlugin` — resolves the `synthesizers` registry for `list_voices`/`set_voice`). Both read the registries lazily at tool-call time and keep their `build*` factories for direct injection. `builtin-entries` uses the default exports.

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -33,7 +33,7 @@ import { buildWebChannelPlugin } from '@moxxy/plugin-channel-web';
 import { mobileChannelPlugin } from '@moxxy/plugin-channel-mobile';
 import { browserPlugin } from '@moxxy/plugin-browser';
 import { terminalPlugin } from '@moxxy/plugin-terminal';
-import { buildSubagentsPlugin } from '@moxxy/plugin-subagents';
+import { subagentsPlugin } from '@moxxy/plugin-subagents';
 import { buildPluginsAdminPlugin } from '@moxxy/plugin-plugins-admin';
 import { buildSelfUpdatePlugin } from '@moxxy/plugin-self-update';
 import { buildProviderAdminPluginWithApi } from '@moxxy/plugin-provider-admin';
@@ -42,7 +42,7 @@ import { commandsPlugin } from '@moxxy/plugin-commands';
 import { buildViewPlugin } from '@moxxy/plugin-view';
 import { computerControlPlugin } from '@moxxy/plugin-computer-control';
 import { oauthPlugin } from '@moxxy/plugin-oauth';
-import { buildVoiceAdminPlugin } from '@moxxy/plugin-voice-admin';
+import { voiceAdminPlugin } from '@moxxy/plugin-voice-admin';
 import { resolveString } from '@moxxy/plugin-vault';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { BUILTIN_SKILLS_DIR_RESOLVED } from './builtin-skills-dir.js';
@@ -196,15 +196,12 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
     // Agent kinds (researcher, code-reviewer, ...) come from OTHER plugins
     // via `PluginSpec.agents`; the closure here reads the live registry.
     {
+      // Discovery-loadable: resolves the agents + tools registries from the
+      // service registry in onInit (the host publishes them). The live
+      // parent-tool snapshot still defaults a child to the parent's tools MINUS
+      // dispatch_agent — cutting unbounded recursive fan-out (8^N sessions).
       name: '@moxxy/plugin-subagents',
-      plugin: buildSubagentsPlugin({
-        getAgent: (name) => session.agents.get(name),
-        // Wire the live parent tool snapshot so a child that neither the caller
-        // nor its kind restricts is defaulted to the parent's tools MINUS
-        // dispatch_agent — cutting unbounded recursive fan-out (8^N sessions).
-        // Same snapshot the plugins-admin entry uses below.
-        getToolNames: () => session.tools.list().map((t) => t.name),
-      }),
+      plugin: subagentsPlugin,
     },
     // Runtime plugin management — exposes install_plugin / uninstall_plugin
     // (npm into ~/.moxxy/plugins) and enable_plugin / disable_plugin (config-
@@ -306,8 +303,10 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
     // what's available + which is active. A synthesizer authored via
     // self-update auto-activates on load, so this is for switching afterwards.
     {
+      // Discovery-loadable: resolves the synthesizers registry from the
+      // service registry in onInit (the host publishes it).
       name: '@moxxy/voice-admin',
-      plugin: buildVoiceAdminPlugin(session),
+      plugin: voiceAdminPlugin,
     },
     // Provider admin tools (provider_add, provider_list, provider_remove,
     // provider_test). Persists OpenAI-compatible vendor registrations to

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -220,6 +220,17 @@ export class Session implements ClientSession, SessionRuntime {
     this.isolators = new IsolatorRegistry();
     this.workflowExecutors = new WorkflowExecutorRegistry();
     this.services = new ServiceRegistryImpl();
+    // Publish the core registries on the inter-plugin service registry under
+    // well-known names, so a discovery-loaded plugin can resolve one in its
+    // onInit (typed as the SDK's minimal NamedRegistry) instead of being
+    // hand-built with a `() => session.<registry>` closure. The registry
+    // objects are stable; their contents grow as plugins register — consumers
+    // read them lazily at tool-call time, after all registration has run.
+    this.services.register('agents', this.agents);
+    this.services.register('tools', this.tools);
+    this.services.register('providers', this.providers);
+    this.services.register('viewRenderers', this.viewRenderers);
+    this.services.register('synthesizers', this.synthesizers);
     this.eventStores = new EventStoreRegistry();
     // Seed the built-in JSONL store as the protected floor — the storage backend
     // behind the event log always exists and can be swapped but never removed.

--- a/packages/plugin-subagents/src/discovery.test.ts
+++ b/packages/plugin-subagents/src/discovery.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ServiceRegistry } from '@moxxy/sdk';
+import { subagentsPlugin } from './index.js';
+
+/**
+ * The discovery-loadable default export resolves the `agents` + `tools`
+ * registries from the inter-plugin service registry in onInit instead of a
+ * `build*({ getAgent, getToolNames })` closure.
+ */
+describe('subagentsPlugin (discovery-loadable)', () => {
+  it('exposes dispatch_agent + an onInit hook', () => {
+    expect(subagentsPlugin.tools?.map((t) => t.name)).toEqual(['dispatch_agent']);
+    expect(typeof subagentsPlugin.hooks?.onInit).toBe('function');
+  });
+
+  it('onInit resolves the agents + tools registries from the service registry', () => {
+    const reg = { get: () => undefined, list: () => [], has: () => false };
+    const get = vi.fn(() => reg);
+    const services = {
+      get,
+      require: () => reg,
+      has: () => true,
+      register: () => {},
+    } as unknown as ServiceRegistry;
+    subagentsPlugin.hooks!.onInit!({ services } as never);
+    expect(get).toHaveBeenCalledWith('agents');
+    expect(get).toHaveBeenCalledWith('tools');
+  });
+});

--- a/packages/plugin-subagents/src/index.ts
+++ b/packages/plugin-subagents/src/index.ts
@@ -1,4 +1,10 @@
-import { definePlugin, type AgentDef, type Plugin } from '@moxxy/sdk';
+import {
+  definePlugin,
+  type AgentDef,
+  type LifecycleHooks,
+  type NamedRegistry,
+  type Plugin,
+} from '@moxxy/sdk';
 import { buildDispatchAgentTool, type DispatchAgentDeps } from './dispatch-agent.js';
 
 export { buildDispatchAgentTool, type DispatchAgentDeps } from './dispatch-agent.js';
@@ -35,7 +41,10 @@ export interface BuildSubagentsPluginOpts {
  * a freshly-installed agent kind becomes available the next time the
  * model calls dispatch_agent — no restart needed.
  */
-export function buildSubagentsPlugin(opts: BuildSubagentsPluginOpts = {}): Plugin {
+export function buildSubagentsPlugin(
+  opts: BuildSubagentsPluginOpts = {},
+  hooks?: LifecycleHooks,
+): Plugin {
   const deps: DispatchAgentDeps = {
     getAgent: opts.getAgent ?? (() => undefined),
     ...(opts.getToolNames ? { getToolNames: opts.getToolNames } : {}),
@@ -43,10 +52,35 @@ export function buildSubagentsPlugin(opts: BuildSubagentsPluginOpts = {}): Plugi
   return definePlugin({
     name: '@moxxy/plugin-subagents',
     version: '0.0.0',
+    ...(hooks ? { hooks } : {}),
     tools: [buildDispatchAgentTool(deps)],
   });
 }
 
-export const subagentsPlugin = buildSubagentsPlugin();
+/**
+ * Discovery-loadable default export: resolves the `agents` + `tools` registries
+ * from the inter-plugin service registry in `onInit` (the host publishes them),
+ * so `dispatch_agent` looks up agent kinds + the live parent-tool snapshot from
+ * the session without a host-injected closure. Both reads are lazy (at tool-call
+ * time, after all registration), and degrade to the standalone defaults if the
+ * host hasn't published them.
+ */
+export const subagentsPlugin: Plugin = (() => {
+  let agents: NamedRegistry<AgentDef> | null = null;
+  let tools: NamedRegistry<{ readonly name: string }> | null = null;
+  const hooks: LifecycleHooks = {
+    onInit: (ctx) => {
+      agents = ctx.services.get<NamedRegistry<AgentDef>>('agents') ?? null;
+      tools = ctx.services.get<NamedRegistry<{ readonly name: string }>>('tools') ?? null;
+    },
+  };
+  return buildSubagentsPlugin(
+    {
+      getAgent: (name) => agents?.get(name),
+      getToolNames: () => (tools ? tools.list().map((t) => t.name) : []),
+    },
+    hooks,
+  );
+})();
 
 export default subagentsPlugin;

--- a/packages/plugin-voice-admin/src/discovery.test.ts
+++ b/packages/plugin-voice-admin/src/discovery.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { ServiceRegistry } from '@moxxy/sdk';
+import { voiceAdminPlugin } from './index.js';
+
+function fakeSynths(active: string | null, names: string[]) {
+  let cur = active;
+  return {
+    list: () => names.map((name) => ({ name })),
+    has: (n: string) => names.includes(n),
+    getActiveName: () => cur,
+    setActive: (n: string) => {
+      cur = n;
+    },
+    clearActive: () => {
+      cur = null;
+    },
+  };
+}
+
+/**
+ * The discovery-loadable default export resolves the synthesizer registry from
+ * the inter-plugin service registry in onInit instead of a `build*(session)`
+ * closure.
+ */
+describe('voiceAdminPlugin (discovery-loadable)', () => {
+  it('exposes list_voices/set_voice + an onInit hook', () => {
+    expect(voiceAdminPlugin.tools?.map((t) => t.name).sort()).toEqual(['list_voices', 'set_voice']);
+    expect(typeof voiceAdminPlugin.hooks?.onInit).toBe('function');
+  });
+
+  it('onInit wires the synthesizers registry; the tools read it live', async () => {
+    const synths = fakeSynths('eleven', ['eleven', 'openai']);
+    const services = {
+      get: () => synths,
+      require: () => synths,
+      has: () => true,
+      register: () => {},
+    } as unknown as ServiceRegistry;
+    voiceAdminPlugin.hooks!.onInit!({ services } as never);
+
+    const listVoices = voiceAdminPlugin.tools!.find((t) => t.name === 'list_voices')!;
+    const listed = await listVoices.handler({} as never, {} as never);
+    expect(listed).toEqual({ active: 'eleven', available: ['system', 'eleven', 'openai'] });
+
+    const setVoice = voiceAdminPlugin.tools!.find((t) => t.name === 'set_voice')!;
+    const set = await setVoice.handler({ synthesizer: 'openai' } as never, {} as never);
+    expect(set).toEqual({ active: 'openai' });
+    expect(synths.getActiveName()).toBe('openai');
+  });
+});

--- a/packages/plugin-voice-admin/src/index.ts
+++ b/packages/plugin-voice-admin/src/index.ts
@@ -1,5 +1,5 @@
-import { type Session } from '@moxxy/core';
-import { definePlugin, defineTool, z, type Plugin } from '@moxxy/sdk';
+import { type Session, type SynthesizerRegistry } from '@moxxy/core';
+import { definePlugin, defineTool, z, type LifecycleHooks, type Plugin } from '@moxxy/sdk';
 
 /**
  * Voice/TTS control plugin — lets the agent switch which text-to-speech backend
@@ -14,6 +14,36 @@ import { definePlugin, defineTool, z, type Plugin } from '@moxxy/sdk';
  * and wired into the cli's builtin `entries` list.
  */
 export function buildVoiceAdminPlugin(session: Session): Plugin {
+  return makeVoiceAdminPlugin(() => session.synthesizers);
+}
+
+/**
+ * Discovery-loadable default export: resolves the synthesizer registry from the
+ * inter-plugin service registry in `onInit` (the host publishes `'synthesizers'`),
+ * so the tools control the live session's TTS backend without a host-injected
+ * `session` closure.
+ */
+export const voiceAdminPlugin: Plugin = (() => {
+  let reg: SynthesizerRegistry | null = null;
+  const hooks: LifecycleHooks = {
+    onInit: (ctx) => {
+      reg = ctx.services.get<SynthesizerRegistry>('synthesizers') ?? null;
+    },
+  };
+  return makeVoiceAdminPlugin(() => {
+    if (!reg) {
+      throw new Error(
+        '@moxxy/voice-admin: the "synthesizers" registry is unavailable — the host must publish it',
+      );
+    }
+    return reg;
+  }, hooks);
+})();
+
+function makeVoiceAdminPlugin(
+  getSynths: () => SynthesizerRegistry,
+  hooks?: LifecycleHooks,
+): Plugin {
   // 'system' (the OS voice) plus every registered synthesizer — the one
   // list both tools speak in terms of (list_voices' result and
   // set_voice's "unknown name" hint). The synthesizer namespace is
@@ -22,7 +52,7 @@ export function buildVoiceAdminPlugin(session: Session): Plugin {
   // otherwise it would be listed twice.
   const voiceNames = (): string[] => [
     'system',
-    ...session.synthesizers
+    ...getSynths()
       .list()
       .map((s) => s.name)
       .filter((n) => n !== 'system'),
@@ -30,6 +60,7 @@ export function buildVoiceAdminPlugin(session: Session): Plugin {
   return definePlugin({
     name: '@moxxy/voice-admin',
     version: '0.0.1',
+    ...(hooks ? { hooks } : {}),
     tools: [
       defineTool({
         name: 'list_voices',
@@ -40,7 +71,7 @@ export function buildVoiceAdminPlugin(session: Session): Plugin {
         inputSchema: z.object({}),
         permission: { action: 'allow' },
         handler: () => ({
-          active: session.synthesizers.getActiveName() ?? 'system',
+          active: getSynths().getActiveName() ?? 'system',
           available: voiceNames(),
         }),
       }),
@@ -68,16 +99,16 @@ export function buildVoiceAdminPlugin(session: Session): Plugin {
           // synthesizer claims that name. A backend literally named 'system'
           // (registrations are attacker-influenced) is otherwise permanently
           // unreachable; fall through to activate it.
-          if (synthesizer === 'system' && !session.synthesizers.has('system')) {
-            session.synthesizers.clearActive();
+          if (synthesizer === 'system' && !getSynths().has('system')) {
+            getSynths().clearActive();
             return { active: 'system' };
           }
-          if (!session.synthesizers.has(synthesizer)) {
+          if (!getSynths().has(synthesizer)) {
             throw new Error(
               `No synthesizer named "${synthesizer}". Available: ${voiceNames().join(', ')}.`,
             );
           }
-          session.synthesizers.setActive(synthesizer);
+          getSynths().setActive(synthesizer);
           return { active: synthesizer };
         },
       }),

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -352,7 +352,7 @@ export type {
   HookDispatcher,
 } from './hooks.js';
 
-export type { ServiceRegistry } from './services.js';
+export type { ServiceRegistry, NamedRegistry } from './services.js';
 
 export type {
   PluginKind,

--- a/packages/sdk/src/services.ts
+++ b/packages/sdk/src/services.ts
@@ -1,4 +1,21 @@
 /**
+ * Minimal read-only view of a name-keyed registry. The host publishes its core
+ * registries (agents, tools, …) on the {@link ServiceRegistry} under these
+ * names, so a discovery-loaded plugin can resolve one in `onInit` (e.g.
+ * `ctx.services.require<NamedRegistry<AgentDef>>('agents')`) without importing
+ * `@moxxy/core`'s concrete registry types. Core's `DefMapRegistry`-based
+ * registries satisfy it structurally.
+ *
+ * Well-known service names the host publishes: `'agents'`, `'tools'`,
+ * `'providers'`, `'viewRenderers'`, `'synthesizers'`.
+ */
+export interface NamedRegistry<T> {
+  get(name: string): T | undefined;
+  list(): ReadonlyArray<T>;
+  has(name: string): boolean;
+}
+
+/**
  * Inter-plugin service registry. A plugin can **publish** a named service in its
  * `onInit` hook (e.g. the vault plugin publishes its secret store) and another
  * plugin can **consume** it in its own `onInit` — decoupling cross-plugin


### PR DESCRIPTION
## What

Adds the **registry-needer** path to the onInit refactor wave (#349, #350 established the vault-service path).

- The host now **publishes its core registries** on the inter-plugin service registry under well-known names — `agents`, `tools`, `providers`, `viewRenderers`, `synthesizers` — at session construction.
- The SDK exposes a minimal **`NamedRegistry<T>`** view (`get` / `list` / `has`), so a discovery-loaded plugin can resolve a registry in `onInit` **without importing `@moxxy/core`'s concrete types** (core's `DefMapRegistry`-based registries satisfy it structurally).

### Conversions
- **`@moxxy/plugin-subagents`** → `subagentsPlugin` resolves the `agents` + `tools` registries (`dispatch_agent`'s agent-kind lookup + the live parent-tool snapshot that caps recursive fan-out). Uses the minimal `NamedRegistry`.
- **`@moxxy/plugin-voice-admin`** → `voiceAdminPlugin` resolves the `synthesizers` registry (`list_voices` / `set_voice`). It needs the fuller `SynthesizerRegistry` (active-def methods), imported type-only from core (erased at build, so no runtime core dep).

Both read the registries lazily at tool-call time (after all registration) and keep their `build*` factories for direct injection. `builtin-entries` uses the default exports.

## Not yet covered (next)
`view` (needs the view-surface ref published), `provider-admin` / `mcp` (need `credentialResolver` + the session-stashing of `providerAdmin`/`mcpAdmin`), and the hard ones (`web`, `self-update`, `memory-consolidate`). Daemons stay bundled-but-dormant. (Actual unbundling stays gated on the slimming → publish decision.)

## Testing
`turbo run test` green across all packages (exit 0), build (73 tasks), lint 0, `check:deps` 0; new discovery tests for both plugins (subagents 27, voice-admin 13). Changeset included.