### PR TITLE
feat(plugins): memory-consolidate discovery-loadable

### DIFF
--- a/.changeset/memory-consolidate-discovery.md
+++ b/.changeset/memory-consolidate-discovery.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/cli': patch
+---
+
+Convert `@moxxy/memory-consolidate` to a discovery-loadable default export (`memoryConsolidatePlugin`). The memory plugin now publishes its long-term store on the inter-plugin service registry (`services.register('memory', store)`), and memory-consolidate resolves both that store and the active provider (via the published `'providers'` registry) from `ctx.services` in `onInit` — typed against a minimal inline interface so it needs no `@moxxy/core` import — instead of the `(store, getProvider)` closure. The `buildMemoryConsolidatePlugin` factory is kept for direct injection; `builtin-entries` uses the default export.

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -22,7 +22,7 @@ import { collabPlugin } from '@moxxy/plugin-collab';
 import { summarizeCompactorPlugin } from '@moxxy/compactor-summarize';
 import { stablePrefixCacheStrategyPlugin } from '@moxxy/cache-strategy-stable-prefix';
 import {
-  buildMemoryConsolidatePlugin,
+  memoryConsolidatePlugin,
   type MemoryStore,
 } from '@moxxy/plugin-memory';
 import { telegramPlugin } from '@moxxy/plugin-telegram';
@@ -86,7 +86,7 @@ export interface BuiltinEntriesArgs {
  * builtin set; do not reorder.
  */
 export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
-  const { session, rawConfig, vault, vaultPlugin, memory, memoryPlugin, viewSurface, webControls, setPluginEnabledLive, categoryLive } = args;
+  const { session, rawConfig, vault, vaultPlugin, memoryPlugin, viewSurface, webControls, setPluginEnabledLive, categoryLive } = args;
 
   return [
     { name: '@moxxy/plugin-provider-anthropic', plugin: anthropicPlugin },
@@ -121,8 +121,11 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
     },
     { name: '@moxxy/plugin-memory', plugin: memoryPlugin },
     {
+      // Discovery-loadable: resolves the memory store ('memory', published by
+      // @moxxy/plugin-memory above) + the active provider ('providers') from the
+      // service registry in onInit.
       name: '@moxxy/memory-consolidate',
-      plugin: buildMemoryConsolidatePlugin(memory, () => session.providers.getActive()),
+      plugin: memoryConsolidatePlugin,
     },
     { name: '@moxxy/plugin-cli', plugin: cliPlugin },
     // Cross-session token usage. onShutdown folds this run's provider_response

--- a/packages/plugin-memory/src/consolidate.ts
+++ b/packages/plugin-memory/src/consolidate.ts
@@ -1,4 +1,11 @@
-import { z, defineTool, definePlugin, type LLMProvider, type Plugin } from '@moxxy/sdk';
+import {
+  z,
+  defineTool,
+  definePlugin,
+  type LifecycleHooks,
+  type LLMProvider,
+  type Plugin,
+} from '@moxxy/sdk';
 import type { MemoryStore} from './store.js';
 import { memoryTypeSchema, type MemoryEntry, type MemoryType } from './store.js';
 
@@ -390,27 +397,76 @@ export interface BuildMemoryConsolidateOptions {
   readonly autoNudgeThreshold?: number;
 }
 
+/** Minimal view of the provider registry — just what consolidation needs (the
+ *  active provider at call time). The host publishes the full registry under
+ *  `'providers'`; this avoids importing `@moxxy/core`'s concrete type. */
+interface ActiveProviderSource {
+  getActive(): LLMProvider | null;
+}
+
 export function buildMemoryConsolidatePlugin(
   store: MemoryStore,
   getProvider: () => LLMProvider,
   opts: BuildMemoryConsolidateOptions = {},
 ): Plugin {
+  // Host-injected store + provider accessor (available immediately).
+  return makeMemoryConsolidatePlugin(() => store, getProvider, opts);
+}
+
+/**
+ * Discovery-loadable default export: resolves the long-term store (`'memory'`,
+ * published by @moxxy/plugin-memory) and the active provider (via the `'providers'`
+ * registry) from the inter-plugin service registry in `onInit`, so it no longer
+ * needs the `(store, getProvider)` closure. @moxxy/plugin-memory is registered
+ * first, so its onInit publishes the store before this one resolves it.
+ */
+export const memoryConsolidatePlugin: Plugin = (() => {
+  let store: MemoryStore | null = null;
+  let providers: ActiveProviderSource | null = null;
+  const onInit: LifecycleHooks['onInit'] = (ctx) => {
+    store = ctx.services.get<MemoryStore>('memory') ?? null;
+    providers = ctx.services.get<ActiveProviderSource>('providers') ?? null;
+  };
+  return makeMemoryConsolidatePlugin(
+    () => {
+      if (!store) {
+        throw new Error(
+          '@moxxy/memory-consolidate: the "memory" service is unavailable — @moxxy/plugin-memory must load first',
+        );
+      }
+      return store;
+    },
+    () => {
+      const p = providers?.getActive();
+      if (!p) {
+        throw new Error('@moxxy/memory-consolidate: no active provider to consolidate with');
+      }
+      return p;
+    },
+    {},
+    onInit,
+  );
+})();
+
+function makeMemoryConsolidatePlugin(
+  getStore: () => MemoryStore,
+  getProvider: () => LLMProvider,
+  opts: BuildMemoryConsolidateOptions = {},
+  extraOnInit?: LifecycleHooks['onInit'],
+): Plugin {
   const threshold = opts.autoNudgeThreshold ?? 30;
   let nudged = false;
 
-  return definePlugin({
-    name: '@moxxy/memory-consolidate',
-    version: '0.0.0',
-    hooks:
-      threshold > 0
-        ? {
-            onBeforeProviderCall: async (req) => {
+  const nudgeHook: LifecycleHooks =
+    threshold > 0
+      ? {
+          onBeforeProviderCall: async (req) => {
               if (nudged) return; // one nudge per session
               // Count only — capStatus() serves the in-memory index-row cache,
               // so a below-threshold store doesn't re-scan + re-parse every
               // memory file on every single provider call for the whole session
               // (store.list() did a full disk read+parse each time).
-              const count = (await store.capStatus()).count;
+              const count = (await getStore().capStatus()).count;
               if (count <= threshold) return;
               nudged = true;
               const hint =
@@ -419,7 +475,15 @@ export function buildMemoryConsolidatePlugin(
               return { ...req, system: (req.system ?? '') + hint };
             },
           }
-        : {},
+        : {};
+
+  const hooks: LifecycleHooks = extraOnInit
+    ? { ...nudgeHook, onInit: extraOnInit }
+    : nudgeHook;
+  return definePlugin({
+    name: '@moxxy/memory-consolidate',
+    version: '0.0.0',
+    hooks,
     tools: [
       defineTool({
         name: 'memory_consolidate',
@@ -433,7 +497,7 @@ export function buildMemoryConsolidatePlugin(
         }),
         permission: { action: 'prompt' },
         handler: async ({ tag, dryRun }) => {
-          const outcome = await consolidateMemory(store, getProvider(), {
+          const outcome = await consolidateMemory(getStore(), getProvider(), {
             ...(tag ? { tag } : {}),
             ...(dryRun !== undefined ? { dryRun } : {}),
           });
@@ -445,7 +509,7 @@ export function buildMemoryConsolidatePlugin(
         description: 'Return the consolidation plan (clusters that would be merged) without invoking the model.',
         inputSchema: z.object({ tag: z.string().optional() }),
         handler: async ({ tag }) => {
-          const all = await store.list();
+          const all = await getStore().list();
           return planConsolidation(all, { ...(tag ? { tag } : {}) });
         },
       }),

--- a/packages/plugin-memory/src/discovery.test.ts
+++ b/packages/plugin-memory/src/discovery.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ServiceRegistry } from '@moxxy/sdk';
+import { memoryConsolidatePlugin } from './index.js';
+
+/**
+ * The discovery-loadable default export resolves the long-term store ('memory',
+ * published by the memory plugin) + the active provider (via 'providers') from
+ * the inter-plugin service registry in onInit, instead of a `(store, getProvider)`
+ * closure. (Behaviour with an injected store is covered by consolidate.test.)
+ */
+describe('memoryConsolidatePlugin (discovery-loadable)', () => {
+  it('exposes the consolidate tools + an onInit hook (alongside the nudge hook)', () => {
+    expect(memoryConsolidatePlugin.tools?.map((t) => t.name).sort()).toEqual([
+      'memory_consolidate',
+      'memory_consolidate_plan',
+    ]);
+    expect(typeof memoryConsolidatePlugin.hooks?.onInit).toBe('function');
+    expect(typeof memoryConsolidatePlugin.hooks?.onBeforeProviderCall).toBe('function');
+  });
+
+  it('onInit resolves the memory + providers services from the registry', () => {
+    const get = vi.fn(() => ({ getActive: () => null }));
+    const services = {
+      get,
+      require: () => ({}),
+      has: () => true,
+      register: () => {},
+    } as unknown as ServiceRegistry;
+    memoryConsolidatePlugin.hooks!.onInit!({ services } as never);
+    expect(get).toHaveBeenCalledWith('memory');
+    expect(get).toHaveBeenCalledWith('providers');
+  });
+});

--- a/packages/plugin-memory/src/index.ts
+++ b/packages/plugin-memory/src/index.ts
@@ -22,6 +22,7 @@ export {
   planConsolidation,
   consolidateMemory,
   buildMemoryConsolidatePlugin,
+  memoryConsolidatePlugin,
   type ConsolidatePlan,
   type ConsolidateOptions,
   type ConsolidationOutcome,
@@ -34,6 +35,16 @@ export function buildMemoryPlugin(opts: BuildMemoryPluginOptions = {}): { plugin
   const plugin = definePlugin({
     name: '@moxxy/plugin-memory',
     version: '0.0.0',
+    // Publish the long-term store on the inter-plugin service registry so the
+    // sibling @moxxy/memory-consolidate plugin can resolve it in its own onInit
+    // instead of being hand-built with the store — the seam that lets both be
+    // discovery-loaded. memory-consolidate is registered after this plugin, so
+    // this onInit runs first.
+    hooks: {
+      onInit: (ctx) => {
+        ctx.services.register('memory', store);
+      },
+    },
     // The zero-dep TF-IDF embedder, contributed as a selectable embedder so it
     // sits in the same registry as openai/transformers/custom ones.
     embedders: [


### PR DESCRIPTION
## What

Continues the onInit refactor wave. Converts `@moxxy/memory-consolidate` to a discovery-loadable default export (`memoryConsolidatePlugin`).

This one combines both seams established so far:
- the **memory plugin publishes** its long-term store on the service registry (`services.register('memory', store)`) — the vault-style publish/consume pattern, now within one package
- **memory-consolidate consumes** that store *and* the active provider (via the host-published `'providers'` registry) from `ctx.services` in `onInit`, typed against a **minimal inline interface** (`{ getActive(): LLMProvider | null }`) so it needs no `@moxxy/core` import

memory is registered before consolidate, so its `onInit` publishes the store before consolidate resolves it. `buildMemoryConsolidatePlugin` is kept for direct injection; `builtin-entries` uses the default export.

That makes **6 plugins** discovery-loadable across the wave (oauth, telegram, whisper-codex, subagents, voice-admin, memory-consolidate) — covering vault-service, published-registry, and plugin-published-service consumption.

## Remaining (the hard ones)
`view` (publish the view-surface ref), `provider-admin` / `mcp` (need `credentialResolver` + publishing back the `providerAdmin`/`mcpAdmin` handles they stash on the session — a consumer-side change in the runner), `web` (tunnel + surface refs), `self-update` (publish `pluginHost` + log-emit). Daemons stay bundled-but-dormant.

## Testing
`turbo run test` green across all packages (exit 0), build (73 tasks), lint 0 errors, `check:deps` 0; new discovery test for the plugin; plugin-memory suite (89) green. Changeset included.