### PR TITLE
feat(plugins): provider-admin discovery-loadable (first stash-capability plugin)

### DIFF
--- a/.changeset/provider-admin-discovery.md
+++ b/.changeset/provider-admin-discovery.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/core': minor
+'@moxxy/cli': patch
+---
+
+Make `@moxxy/plugin-provider-admin` discovery-loadable — the first of the "stash a session capability" plugins. `Session.providerAdmin` is now a getter over a published `'providerAdmin'` service (RemoteSession keeps its own field for thin clients), and core publishes a stable `'resolveCredentials'` accessor. The plugin's default export (`providerAdminPlugin`) resolves the `'providers'` registry + `'resolveCredentials'` from `ctx.services` in `onInit` (via a lazy `Proxy` so its tools + stored-provider re-registration run unchanged) and publishes its admin api as `'providerAdmin'` — replacing the host stash + `{ providerRegistry, resolveActiveConfig }` closure. The runner + desktop read `session.providerAdmin` exactly as before.

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -36,7 +36,7 @@ import { terminalPlugin } from '@moxxy/plugin-terminal';
 import { subagentsPlugin } from '@moxxy/plugin-subagents';
 import { buildPluginsAdminPlugin } from '@moxxy/plugin-plugins-admin';
 import { buildSelfUpdatePlugin } from '@moxxy/plugin-self-update';
-import { buildProviderAdminPluginWithApi } from '@moxxy/plugin-provider-admin';
+import { providerAdminPlugin } from '@moxxy/plugin-provider-admin';
 import { buildUsageStatsPlugin } from '@moxxy/plugin-usage-stats';
 import { commandsPlugin } from '@moxxy/plugin-commands';
 import { buildViewPlugin } from '@moxxy/plugin-view';
@@ -316,23 +316,11 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
     // ~/.moxxy/providers.json; the plugin's onInit re-registers them on
     // every boot. Pairs with the `add-provider` skill which walks the
     // model through gathering baseURL + models + key.
-    (() => {
-      const { plugin, api } = buildProviderAdminPluginWithApi({
-        providerRegistry: session.providers,
-        // Rebuild the ACTIVE provider's instance after a configure()/provider_add
-        // replace() drops its cached instance — otherwise getActive() throws on
-        // the next turn. Resolve credentials via the same boot-installed resolver
-        // the runner's setActive path uses (installed by activateProvider; read
-        // lazily here since it's set after plugins are built).
-        resolveActiveConfig: (name) =>
-          session.credentialResolver ? session.credentialResolver(name) : {},
-      });
-      // Stash the api on the session so the desktop (via the runner's
-      // `provider.configure`) can edit a stored provider without going
-      // through the model. Mirrors the mcpAdmin stash below.
-      session.providerAdmin = api;
-      return { name: '@moxxy/plugin-provider-admin', plugin };
-    })(),
+    // Discovery-loadable: resolves the providers registry + the credential
+    // accessor from the service registry in onInit, and publishes its admin api
+    // as the 'providerAdmin' service — which core's Session.providerAdmin getter
+    // exposes to the runner's `provider.configure` + the desktop. No host stash.
+    { name: '@moxxy/plugin-provider-admin', plugin: providerAdminPlugin },
     // Admin tools (mcp_add_server, mcp_list_servers, mcp_remove_server,
     // mcp_test_server) plus the boot-time lazy attach. Passing the
     // session's live tool registry enables both hot-attach for runtime

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -175,7 +175,6 @@ export class Session implements ClientSession, SessionRuntime {
   readyProviders?: Set<string>;
   credentialResolver?: CredentialResolver;
   mcpAdmin?: McpAdminView;
-  providerAdmin?: ProviderAdminView;
   workflows?: WorkflowsView;
   pluginsAdmin?: PluginsAdminView;
   readonly dispatcher: HookDispatcherImpl;
@@ -231,6 +230,16 @@ export class Session implements ClientSession, SessionRuntime {
     this.services.register('providers', this.providers);
     this.services.register('viewRenderers', this.viewRenderers);
     this.services.register('synthesizers', this.synthesizers);
+    // A stable accessor for the active provider's stored credentials. The
+    // resolver itself is installed late (by activateProvider, after plugins are
+    // built), so close over `this` and read it lazily at call time — lets
+    // provider-admin rebuild a reconfigured provider's instance without a
+    // host-injected `resolveActiveConfig` closure.
+    this.services.register(
+      'resolveCredentials',
+      (name: string): Promise<Record<string, unknown>> | Record<string, unknown> =>
+        this.credentialResolver ? this.credentialResolver(name) : {},
+    );
     this.eventStores = new EventStoreRegistry();
     // Seed the built-in JSONL store as the protected floor — the storage backend
     // behind the event log always exists and can be swapped but never removed.
@@ -391,6 +400,16 @@ export class Session implements ClientSession, SessionRuntime {
    * snapshot out from under another.
    */
   private envSnapshot: Readonly<NodeJS.ProcessEnv> | null = null;
+
+  /**
+   * The provider-admin capability (configure/refresh stored providers), read by
+   * the runner's provider handlers + the desktop. The @moxxy/plugin-provider-admin
+   * plugin publishes it on the service registry in its onInit, so discovery-loading
+   * it needs no host stash. (RemoteSession sets its own field for thin clients.)
+   */
+  get providerAdmin(): ProviderAdminView | undefined {
+    return this.services.get<ProviderAdminView>('providerAdmin');
+  }
 
   appContext(): AppContext {
     if (!this.envSnapshot) {

--- a/packages/plugin-provider-admin/src/discovery.test.ts
+++ b/packages/plugin-provider-admin/src/discovery.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ServiceRegistry } from '@moxxy/sdk';
+import { providerAdminPlugin } from './index.js';
+
+/**
+ * The discovery-loadable default export resolves the providers registry +
+ * credential accessor from the service registry in onInit and publishes its
+ * admin api as the 'providerAdmin' service (which Session.providerAdmin exposes),
+ * instead of the host `{ providerRegistry, resolveActiveConfig }` closure + stash.
+ */
+describe('providerAdminPlugin (discovery-loadable)', () => {
+  it('exposes the provider tools + an onInit hook', () => {
+    const names = providerAdminPlugin.tools?.map((t) => t.name) ?? [];
+    expect(names).toContain('provider_add');
+    expect(typeof providerAdminPlugin.hooks?.onInit).toBe('function');
+  });
+
+  it('onInit resolves providers + resolveCredentials and publishes providerAdmin', async () => {
+    const registry = {
+      list: () => [],
+      register: () => {},
+      replace: () => {},
+      unregister: () => {},
+      getActiveName: () => null,
+    };
+    const get = vi.fn((name: string) =>
+      name === 'providers' ? registry : name === 'resolveCredentials' ? () => ({}) : undefined,
+    );
+    const register = vi.fn();
+    const services = { get, register, require: () => undefined, has: () => true } as unknown as ServiceRegistry;
+
+    // The inner onInit reads ~/.moxxy/providers.json (absent on CI → caught +
+    // skipped); we only assert the service wiring here.
+    await providerAdminPlugin.hooks!.onInit!({ services } as never);
+
+    expect(get).toHaveBeenCalledWith('providers');
+    expect(get).toHaveBeenCalledWith('resolveCredentials');
+    expect(register).toHaveBeenCalledWith('providerAdmin', expect.anything());
+  });
+});

--- a/packages/plugin-provider-admin/src/index.ts
+++ b/packages/plugin-provider-admin/src/index.ts
@@ -603,3 +603,55 @@ export function buildProviderAdminPlugin(
     },
   });
 }
+
+/**
+ * Discovery-loadable default export. Resolves the provider registry (`'providers'`)
+ * and the credential accessor (`'resolveCredentials'`) from the inter-plugin
+ * service registry in `onInit`, then publishes its admin api as the
+ * `'providerAdmin'` service (which core's `Session.providerAdmin` getter exposes
+ * to the runner + desktop) — replacing the host stash + `{ providerRegistry,
+ * resolveActiveConfig }` closure. A lazy `Proxy` defers every registry call to
+ * the resolved instance, so the tools + the stored-provider re-registration run
+ * unchanged once `onInit` has wired it.
+ */
+type CredResolver = (name: string) => Promise<Record<string, unknown>> | Record<string, unknown>;
+
+export const providerAdminPlugin: Plugin = (() => {
+  let resolvedRegistry: ProviderRegistryLike | null = null;
+  let resolveCreds: CredResolver | null = null;
+
+  const lazyRegistry = new Proxy({} as ProviderRegistryLike, {
+    get(_target, prop) {
+      if (!resolvedRegistry) {
+        throw new Error(
+          '@moxxy/plugin-provider-admin: the "providers" service is unavailable — the host must publish it',
+        );
+      }
+      const value = (resolvedRegistry as unknown as Record<string | symbol, unknown>)[prop];
+      return typeof value === 'function'
+        ? (value as (...args: unknown[]) => unknown).bind(resolvedRegistry)
+        : value;
+    },
+  });
+
+  const { plugin, api } = buildProviderAdminPluginWithApi({
+    providerRegistry: lazyRegistry,
+    resolveActiveConfig: (name) => (resolveCreds ? resolveCreds(name) : {}),
+  });
+  const innerOnInit = plugin.hooks?.onInit;
+
+  return definePlugin({
+    ...plugin,
+    hooks: {
+      ...plugin.hooks,
+      onInit: async (ctx) => {
+        resolvedRegistry = ctx.services.get<ProviderRegistryLike>('providers') ?? null;
+        resolveCreds = ctx.services.get<CredResolver>('resolveCredentials') ?? null;
+        ctx.services.register('providerAdmin', api);
+        // Now that the registry is resolved, run the stored-provider
+        // re-registration (it drives the lazy registry).
+        await innerOnInit?.(ctx);
+      },
+    },
+  });
+})();

--- a/packages/runner/src/integration.test.ts
+++ b/packages/runner/src/integration.test.ts
@@ -1184,11 +1184,13 @@ describe('provider management (protocol v7)', () => {
     const provider = new FakeProvider({ script: [textReply('hi')] });
     const session = buildSession(provider);
     const configured: Array<{ name: string; patch: unknown }> = [];
-    session.providerAdmin = {
-      configure: async (name, patch) => {
+    // Session.providerAdmin is a getter over the 'providerAdmin' service the
+    // provider-admin plugin publishes in onInit — emulate that here.
+    session.services.register('providerAdmin', {
+      configure: async (name: string, patch: unknown) => {
         configured.push({ name, patch });
       },
-    };
+    });
     const server = await startRunnerServer(session, { socketPath });
     servers.push(server);
     const remote = await attach(socketPath);


### PR DESCRIPTION
## What

The first of the **"stash a session capability"** plugins goes discovery-loadable. provider-admin doesn't just consume deps — it *contributes* `session.providerAdmin`, which the runner's `provider.configure` handler + the desktop read. Today the host stashes it (`session.providerAdmin = api`); this decouples that:

- **`Session.providerAdmin` becomes a getter** over a published `'providerAdmin'` service (RemoteSession keeps its own settable field for thin clients — different class, same interface).
- **core publishes a stable `'resolveCredentials'` accessor** that reads the late-bound `credentialResolver` lazily at call time.
- **`providerAdminPlugin`** (default export) resolves the `'providers'` registry + `'resolveCredentials'` from `ctx.services` in `onInit` — via a lazy `Proxy` so the tools + the stored-provider re-registration run unchanged once wired — and publishes its admin api as `'providerAdmin'`. Then `builtin-entries` drops the stash + the `{ providerRegistry, resolveActiveConfig }` closure.

The runner + desktop read `session.providerAdmin` exactly as before (the getter returns the service). `buildProviderAdminPluginWithApi` is unchanged for direct callers.

That's **7 plugins** discovery-loadable across the wave (oauth, telegram, whisper-codex, subagents, voice-admin, memory-consolidate, provider-admin).

## Pattern for the remaining stash plugin
`mcp` follows the same shape (`session.mcpAdmin` getter + publish its api), plus it needs `'skills'` published and its `userSkillsDir` config. `self-update` still needs `pluginHost` published + a writable log-emit in the init context; `view`/`web` need the view-surface ref published.

## Testing
`turbo run test` green across all packages (exit 0) — includes fixing the runner integration test to publish the mock via `session.services.register('providerAdmin', …)` instead of assigning the now-getter field. Build (73), lint 0, deps 0; new discovery test for the plugin (provider-admin 59 + 2). Changeset included.