### PR TITLE
feat(plugins): mcp-admin discovery-loadable (second stash-capability plugin)

### DIFF
--- a/.changeset/mcp-admin-discovery.md
+++ b/.changeset/mcp-admin-discovery.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/core': minor
+'@moxxy/cli': patch
+---
+
+Make `@moxxy/plugin-mcp` discovery-loadable — the second "stash a session capability" plugin. `Session.mcpAdmin` is now a getter over a published `'mcpAdmin'` service, core publishes its `'skills'` registry, and the vault plugin additionally publishes a `'resolveSecrets'` accessor (a `${vault:NAME}`-placeholder resolver) so mcp can resolve secrets without depending on `@moxxy/plugin-vault`. The plugin's default export (`mcpAdminPlugin`) resolves `'tools'` + `'skills'` + `'resolveSecrets'` from `ctx.services` in `onInit` (via lazy `Proxy`s), then publishes its runtime control api as `'mcpAdmin'` — replacing the host stash + `{ toolRegistry, skillRegistry, secretResolver }` closure. `userSkillsDir` defaults to `~/.moxxy/skills`. The runner's mcp handlers + the desktop read `session.mcpAdmin` exactly as before.

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -26,7 +26,7 @@ import {
   type MemoryStore,
 } from '@moxxy/plugin-memory';
 import { telegramPlugin } from '@moxxy/plugin-telegram';
-import { buildMcpAdminPluginWithApi } from '@moxxy/plugin-mcp';
+import { mcpAdminPlugin } from '@moxxy/plugin-mcp';
 import { cliPlugin } from '@moxxy/plugin-cli';
 import { httpChannelPlugin } from '@moxxy/plugin-channel-http';
 import { buildWebChannelPlugin } from '@moxxy/plugin-channel-web';
@@ -43,7 +43,6 @@ import { buildViewPlugin } from '@moxxy/plugin-view';
 import { computerControlPlugin } from '@moxxy/plugin-computer-control';
 import { oauthPlugin } from '@moxxy/plugin-oauth';
 import { voiceAdminPlugin } from '@moxxy/plugin-voice-admin';
-import { resolveString } from '@moxxy/plugin-vault';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { BUILTIN_SKILLS_DIR_RESOLVED } from './builtin-skills-dir.js';
 
@@ -86,7 +85,7 @@ export interface BuiltinEntriesArgs {
  * builtin set; do not reorder.
  */
 export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
-  const { session, rawConfig, vault, vaultPlugin, memoryPlugin, viewSurface, webControls, setPluginEnabledLive, categoryLive } = args;
+  const { session, rawConfig, vaultPlugin, memoryPlugin, viewSurface, webControls, setPluginEnabledLive, categoryLive } = args;
 
   return [
     { name: '@moxxy/plugin-provider-anthropic', plugin: anthropicPlugin },
@@ -322,26 +321,12 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
     // exposes to the runner's `provider.configure` + the desktop. No host stash.
     { name: '@moxxy/plugin-provider-admin', plugin: providerAdminPlugin },
     // Admin tools (mcp_add_server, mcp_list_servers, mcp_remove_server,
-    // mcp_test_server) plus the boot-time lazy attach. Passing the
-    // session's live tool registry enables both hot-attach for runtime
-    // adds AND lazy stub registration in onInit for saved servers.
-    (() => {
-      const { plugin, api } = buildMcpAdminPluginWithApi({
-        toolRegistry: session.tools,
-        skillRegistry: session.skills,
-        userSkillsDir: rawConfig.skills?.userDir,
-        // Resolve `${vault:NAME}` placeholders in MCP env/header values at
-        // connect time. The persisted catalog (and tool args the model sees)
-        // keep the placeholder; the plaintext never leaves the connect path.
-        secretResolver: (value) => resolveString(value, vault),
-      });
-      // Stash the api on the session so the TUI / CLI can call
-      // enableAndAttach + detach without going through the model. `mcpAdmin` is
-      // a typed optional capability on Session (McpAdminView); McpAdminApi
-      // structurally satisfies it.
-      session.mcpAdmin = api;
-      return { name: '@moxxy/plugin-mcp-admin', plugin };
-    })(),
+    // mcp_test_server) plus the boot-time lazy attach. Discovery-loadable:
+    // resolves the tools + skills registries + the 'resolveSecrets' resolver
+    // from the service registry in onInit, and publishes its runtime control
+    // api as the 'mcpAdmin' service (exposed via Session.mcpAdmin getter to the
+    // runner + desktop). No host stash. userSkillsDir defaults to ~/.moxxy/skills.
+    { name: '@moxxy/plugin-mcp-admin', plugin: mcpAdminPlugin },
     {
       name: '@moxxy/synthesize-skill',
       // Thread the SAME directory set the boot scan uses so reload_skills

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -174,7 +174,6 @@ export class Session implements ClientSession, SessionRuntime {
    */
   readyProviders?: Set<string>;
   credentialResolver?: CredentialResolver;
-  mcpAdmin?: McpAdminView;
   workflows?: WorkflowsView;
   pluginsAdmin?: PluginsAdminView;
   readonly dispatcher: HookDispatcherImpl;
@@ -230,6 +229,7 @@ export class Session implements ClientSession, SessionRuntime {
     this.services.register('providers', this.providers);
     this.services.register('viewRenderers', this.viewRenderers);
     this.services.register('synthesizers', this.synthesizers);
+    this.services.register('skills', this.skills);
     // A stable accessor for the active provider's stored credentials. The
     // resolver itself is installed late (by activateProvider, after plugins are
     // built), so close over `this` and read it lazily at call time — lets
@@ -409,6 +409,15 @@ export class Session implements ClientSession, SessionRuntime {
    */
   get providerAdmin(): ProviderAdminView | undefined {
     return this.services.get<ProviderAdminView>('providerAdmin');
+  }
+
+  /**
+   * The MCP-admin capability (enable/detach/list MCP servers), read by the
+   * runner's mcp handlers + the desktop. @moxxy/plugin-mcp publishes it on the
+   * service registry in its onInit. (RemoteSession sets its own field.)
+   */
+  get mcpAdmin(): McpAdminView | undefined {
+    return this.services.get<McpAdminView>('mcpAdmin');
   }
 
   appContext(): AppContext {

--- a/packages/plugin-mcp/src/admin.ts
+++ b/packages/plugin-mcp/src/admin.ts
@@ -6,6 +6,7 @@
 export {
   buildMcpAdminPlugin,
   buildMcpAdminPluginWithApi,
+  mcpAdminPlugin,
   mcpConfigPath,
   readMcpConfig,
   removeServerFromConfig,

--- a/packages/plugin-mcp/src/admin/index.ts
+++ b/packages/plugin-mcp/src/admin/index.ts
@@ -1,5 +1,6 @@
-import { definePlugin, type Plugin } from '@moxxy/sdk';
+import { definePlugin, type LifecycleHooks, type Plugin } from '@moxxy/sdk';
 import { moxxyPath } from '@moxxy/sdk/server';
+import type { McpSecretResolver } from './secrets.js';
 import { readMcpConfig } from './config-io.js';
 import { createMcpRuntime } from './runtime.js';
 import { createMcpUsageSkillWriter } from './skill.js';
@@ -8,6 +9,8 @@ import { buildListServersTool } from './tools/list.js';
 import { buildRemoveServerTool } from './tools/remove.js';
 import { buildTestServerTool } from './tools/test.js';
 import type {
+  AdminSkillRegistryLike,
+  AdminToolRegistryLike,
   BuildMcpAdminPluginOptions,
   McpAdminApi,
   McpStoredConfig,
@@ -42,6 +45,62 @@ export function buildMcpAdminPluginWithApi(
 export function buildMcpAdminPlugin(opts: BuildMcpAdminPluginOptions = { toolRegistry: null }): Plugin {
   return buildMcpAdminPluginInternal(opts).plugin;
 }
+
+function lazyRegistryProxy<T extends object>(get: () => T | null, label: string): T {
+  return new Proxy({} as T, {
+    get(_target, prop) {
+      const resolved = get();
+      if (!resolved) {
+        throw new Error(`@moxxy/plugin-mcp: the "${label}" service is unavailable — the host must publish it`);
+      }
+      const value = (resolved as unknown as Record<string | symbol, unknown>)[prop];
+      return typeof value === 'function'
+        ? (value as (...args: unknown[]) => unknown).bind(resolved)
+        : value;
+    },
+  });
+}
+
+/**
+ * Discovery-loadable default export. Resolves the tool + skill registries and
+ * the secret resolver from the inter-plugin service registry in `onInit` (the
+ * host publishes `'tools'`/`'skills'`; the vault plugin publishes `'resolveSecrets'`),
+ * then publishes its runtime control api as the `'mcpAdmin'` service — which
+ * core's `Session.mcpAdmin` getter exposes to the runner + desktop. Lazy
+ * `Proxy`s defer every registry call to the resolved instance, so the tools +
+ * the boot-time lazy-stub registration run unchanged once `onInit` has wired it.
+ */
+export const mcpAdminPlugin: Plugin = (() => {
+  let resolvedTools: AdminToolRegistryLike | null = null;
+  let resolvedSkills: AdminSkillRegistryLike | null = null;
+  let resolvedSecrets: McpSecretResolver | null = null;
+
+  const lazyTools = lazyRegistryProxy<AdminToolRegistryLike>(() => resolvedTools, 'tools');
+  const lazySkills = lazyRegistryProxy<AdminSkillRegistryLike>(() => resolvedSkills, 'skills');
+  const secretResolver: McpSecretResolver = (value) =>
+    resolvedSecrets ? resolvedSecrets(value) : Promise.resolve(value);
+
+  const { plugin, api } = buildMcpAdminPluginWithApi({
+    toolRegistry: lazyTools,
+    skillRegistry: lazySkills,
+    secretResolver,
+  });
+  const innerOnInit = plugin.hooks?.onInit;
+
+  const hooks: LifecycleHooks = {
+    ...plugin.hooks,
+    onInit: async (ctx) => {
+      resolvedTools = ctx.services.get<AdminToolRegistryLike>('tools') ?? null;
+      resolvedSkills = ctx.services.get<AdminSkillRegistryLike>('skills') ?? null;
+      resolvedSecrets = ctx.services.get<McpSecretResolver>('resolveSecrets') ?? null;
+      ctx.services.register('mcpAdmin', api);
+      // Now the registry is resolved → register lazy stubs for saved servers.
+      await innerOnInit?.(ctx);
+    },
+  };
+
+  return definePlugin({ ...plugin, hooks });
+})();
 
 /**
  * Build the MCP admin plugin: tools that let the agent register and

--- a/packages/plugin-mcp/src/discovery.test.ts
+++ b/packages/plugin-mcp/src/discovery.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ServiceRegistry } from '@moxxy/sdk';
+import { mcpAdminPlugin } from './index.js';
+
+/**
+ * The discovery-loadable default export resolves the tools + skills registries
+ * and the secret resolver from the service registry in onInit, and publishes its
+ * runtime api as the 'mcpAdmin' service (which Session.mcpAdmin exposes), instead
+ * of the host `{ toolRegistry, skillRegistry, secretResolver }` closure + stash.
+ */
+describe('mcpAdminPlugin (discovery-loadable)', () => {
+  it('exposes the mcp tools + an onInit hook', () => {
+    const names = mcpAdminPlugin.tools?.map((t) => t.name) ?? [];
+    expect(names).toContain('mcp_add_server');
+    expect(typeof mcpAdminPlugin.hooks?.onInit).toBe('function');
+  });
+
+  it('onInit resolves tools/skills/resolveSecrets and publishes mcpAdmin', async () => {
+    const reg = {
+      has: () => false,
+      register: () => {},
+      unregister: () => {},
+      byName: () => undefined,
+      list: () => [],
+    };
+    const get = vi.fn((name: string) =>
+      name === 'tools' || name === 'skills'
+        ? reg
+        : name === 'resolveSecrets'
+          ? async (v: string) => v
+          : undefined,
+    );
+    const register = vi.fn();
+    const services = { get, register, require: () => undefined, has: () => true } as unknown as ServiceRegistry;
+
+    // The inner onInit reads ~/.moxxy/mcp.json (absent on CI → caught + skipped);
+    // we only assert the service wiring here.
+    await mcpAdminPlugin.hooks!.onInit!({ services } as never);
+
+    expect(get).toHaveBeenCalledWith('tools');
+    expect(get).toHaveBeenCalledWith('skills');
+    expect(get).toHaveBeenCalledWith('resolveSecrets');
+    expect(register).toHaveBeenCalledWith('mcpAdmin', expect.anything());
+  });
+});

--- a/packages/plugin-mcp/src/index.ts
+++ b/packages/plugin-mcp/src/index.ts
@@ -20,6 +20,7 @@ export { defaultClientFactory } from './client.js';
 export {
   buildMcpAdminPlugin,
   buildMcpAdminPluginWithApi,
+  mcpAdminPlugin,
   mcpConfigPath,
   readMcpConfig,
   removeServerFromConfig,

--- a/packages/plugin-vault/src/index.ts
+++ b/packages/plugin-vault/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from '@moxxy/sdk';
 import { moxxyPath } from '@moxxy/sdk/server';
 import { createCombinedKeySource, type MasterKeySource } from './keysource.js';
+import { resolveString } from './placeholder.js';
 import { VaultStore } from './store.js';
 
 export { VaultStore, VaultPassphraseError } from './store.js';
@@ -139,6 +140,13 @@ export function buildVaultPlugin(opts: BuildVaultPluginOptions = {}): { plugin: 
     hooks: {
       onInit: (ctx) => {
         ctx.services.register('vault', vault);
+        // Also publish a `${vault:NAME}`-placeholder resolver so consumers (mcp's
+        // server env/headers) can resolve secrets without depending on the vault
+        // package's `resolveString` helper directly.
+        ctx.services.register(
+          'resolveSecrets',
+          (value: string): Promise<string> => resolveString(value, vault),
+        );
       },
     },
     commands: [vaultCmd],


### PR DESCRIPTION
## What

The second *stash-a-session-capability* plugin goes discovery-loadable, mirroring provider-admin (#353).

- **`Session.mcpAdmin` becomes a getter** over a published `'mcpAdmin'` service (RemoteSession keeps its own field).
- **core publishes its `'skills'` registry** alongside the others.
- **the vault plugin additionally publishes `'resolveSecrets'`** — a `${vault:NAME}`-placeholder resolver — so mcp resolves secrets in MCP server env/headers without taking a dependency on `@moxxy/plugin-vault`.
- **`mcpAdminPlugin`** (default export) resolves `'tools'` + `'skills'` + `'resolveSecrets'` from `ctx.services` in `onInit` via lazy `Proxy`s (so the tools + the boot-time lazy-stub registration run unchanged), then publishes its runtime control api as `'mcpAdmin'`. `userSkillsDir` defaults to `~/.moxxy/skills`.

`builtin-entries` drops the stash + the `{ toolRegistry, skillRegistry, secretResolver }` closure + the now-unused `resolveString`/`vault`. The runner's mcp handlers + the desktop read `session.mcpAdmin` exactly as before.

**8 plugins** discovery-loadable now (oauth, telegram, whisper-codex, subagents, voice-admin, memory-consolidate, provider-admin, mcp-admin).

## Remaining
`view` + `self-update` (both scoped, MEDIUM — view needs a published `viewSurface` getter, self-update needs published `pluginHost` + a writable log-emit service); `web` (HIGH, most entangled — shares the `viewSurface`/`webControls` refs with view). Each touches `core/session.ts`, so they land sequentially.

## Testing
`turbo run test` green across all packages (exit 0), build (73 tasks), lint 0, deps 0; new discovery test (mcp 96 + 2); runner (129) + vault (60) + core (418) suites green. Changeset included.