### PR TITLE
feat(plugins): view discovery-loadable

### DIFF
--- a/.changeset/view-discovery.md
+++ b/.changeset/view-discovery.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/cli': patch
+---
+
+Convert `@moxxy/plugin-view` to a discovery-loadable default export (`viewPlugin`). The host publishes the shared web-surface ref as the `'viewSurface'` service (the same mutable ref the web channel writes via `publishSurface`), and `viewPlugin` resolves `'viewRenderers'` (active renderer) + `'viewSurface'` from `ctx.services` in `onInit` — typed against minimal inline interfaces so it needs no `@moxxy/core` import — instead of the `{ getRenderer, getSurface }` closure. `present_view` reads both lazily at call time and degrades gracefully when absent. `buildViewPlugin` is kept for direct injection.

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -39,7 +39,7 @@ import { buildSelfUpdatePlugin } from '@moxxy/plugin-self-update';
 import { providerAdminPlugin } from '@moxxy/plugin-provider-admin';
 import { buildUsageStatsPlugin } from '@moxxy/plugin-usage-stats';
 import { commandsPlugin } from '@moxxy/plugin-commands';
-import { buildViewPlugin } from '@moxxy/plugin-view';
+import { viewPlugin } from '@moxxy/plugin-view';
 import { computerControlPlugin } from '@moxxy/plugin-computer-control';
 import { oauthPlugin } from '@moxxy/plugin-oauth';
 import { voiceAdminPlugin } from '@moxxy/plugin-voice-admin';
@@ -86,6 +86,12 @@ export interface BuiltinEntriesArgs {
  */
 export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
   const { session, rawConfig, vaultPlugin, memoryPlugin, viewSurface, webControls, setPluginEnabledLive, categoryLive } = args;
+
+  // Publish the shared web-surface ref so the (discovery-loadable) view plugin
+  // can read it in onInit — the same mutable ref the web channel writes via its
+  // `publishSurface` closure below. Registered here (before onInit dispatch) so
+  // it's available when the view plugin's onInit runs.
+  session.services.register('viewSurface', viewSurface);
 
   return [
     { name: '@moxxy/plugin-provider-anthropic', plugin: anthropicPlugin },
@@ -182,15 +188,10 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
     { name: '@moxxy/plugin-commands', plugin: commandsPlugin },
     // Agent-authored UIs: present_view parses the model's JSX-like view-spec
     // (via the session's active, swappable view renderer) into a validated AST
-    // that the web surface renders as interactive UI. The renderer is reached
-    // through a closure since ToolContext exposes no session handle.
-    {
-      name: '@moxxy/plugin-view',
-      plugin: buildViewPlugin({
-        getRenderer: () => session.viewRenderers.getActive(),
-        getSurface: () => viewSurface.current,
-      }),
-    },
+    // that the web surface renders as interactive UI. Discovery-loadable:
+    // resolves the 'viewRenderers' registry + the 'viewSurface' ref from the
+    // service registry in onInit (no host closure).
+    { name: '@moxxy/plugin-view', plugin: viewPlugin },
     // Subagents are a swappable block: this plugin owns the
     // dispatch_agent tool and the auto-detection skill. Drop it
     // (`config.plugins['@moxxy/plugin-subagents'].enabled = false`) and

--- a/packages/plugin-view/src/discovery.test.ts
+++ b/packages/plugin-view/src/discovery.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ServiceRegistry } from '@moxxy/sdk';
+import { viewPlugin } from './index.js';
+
+/**
+ * The discovery-loadable default export resolves the active view-renderer
+ * registry + the shared web-surface ref from the service registry in onInit,
+ * instead of the host `{ getRenderer, getSurface }` closure.
+ */
+describe('viewPlugin (discovery-loadable)', () => {
+  it('exposes present_view + an onInit hook', () => {
+    expect(viewPlugin.tools?.map((t) => t.name)).toEqual(['present_view']);
+    expect(typeof viewPlugin.hooks?.onInit).toBe('function');
+  });
+
+  it('onInit resolves viewRenderers + viewSurface from the registry', () => {
+    const get = vi.fn((name: string) =>
+      name === 'viewRenderers'
+        ? { getActive: () => null }
+        : name === 'viewSurface'
+          ? { current: null }
+          : undefined,
+    );
+    const services = { get, register: () => {}, require: () => undefined, has: () => true } as unknown as ServiceRegistry;
+    viewPlugin.hooks!.onInit!({ services } as never);
+    expect(get).toHaveBeenCalledWith('viewRenderers');
+    expect(get).toHaveBeenCalledWith('viewSurface');
+  });
+});

--- a/packages/plugin-view/src/index.ts
+++ b/packages/plugin-view/src/index.ts
@@ -2,6 +2,7 @@ import {
   defineTool,
   definePlugin,
   z,
+  type LifecycleHooks,
   type Plugin,
   type ViewDoc,
   type ViewNode,
@@ -63,7 +64,7 @@ export interface BuildViewPluginOptions {
   getSurface?: () => ViewSurface | null;
 }
 
-export function buildViewPlugin(opts: BuildViewPluginOptions): Plugin {
+export function buildViewPlugin(opts: BuildViewPluginOptions, hooks?: LifecycleHooks): Plugin {
   const presentView = defineTool({
     name: 'present_view',
     description:
@@ -175,8 +176,43 @@ export function buildViewPlugin(opts: BuildViewPluginOptions): Plugin {
   return definePlugin({
     name: '@moxxy/plugin-view',
     tools: [presentView],
+    ...(hooks ? { hooks } : {}),
   });
 }
+
+/** Minimal views of the services view consumes — avoids importing @moxxy/core. */
+interface ActiveRendererSource {
+  getActive(): ViewRendererDef | null;
+}
+interface ViewSurfaceRef {
+  readonly current: ViewSurface | null;
+}
+
+/**
+ * Discovery-loadable default export. Resolves the active view-renderer registry
+ * (`'viewRenderers'`) and the shared web-surface ref (`'viewSurface'`, published
+ * by the host + written by the web channel) from the inter-plugin service
+ * registry in `onInit`, so `present_view` reaches them without a host-injected
+ * `{ getRenderer, getSurface }` closure. Both reads are lazy (at tool-call time),
+ * and degrade to "no renderer"/"no surface" if the host hasn't published them.
+ */
+export const viewPlugin: Plugin = (() => {
+  let renderers: ActiveRendererSource | null = null;
+  let surface: ViewSurfaceRef | null = null;
+  const hooks: LifecycleHooks = {
+    onInit: (ctx) => {
+      renderers = ctx.services.get<ActiveRendererSource>('viewRenderers') ?? null;
+      surface = ctx.services.get<ViewSurfaceRef>('viewSurface') ?? null;
+    },
+  };
+  return buildViewPlugin(
+    {
+      getRenderer: () => renderers?.getActive() ?? null,
+      getSurface: () => surface?.current ?? null,
+    },
+    hooks,
+  );
+})();
 
 export interface PresentViewResult {
   readonly ok: boolean;


### PR DESCRIPTION
## What

Converts `@moxxy/plugin-view` to a discovery-loadable default export (`viewPlugin`) — the cleanest of the remaining three (it only *consumes*, no session-capability stash).

- The host publishes the shared web-surface ref as the **`'viewSurface'`** service — the same mutable ref the web channel writes via its `publishSurface` closure (so view reads what web writes).
- `viewPlugin` resolves `'viewRenderers'` (active renderer) + `'viewSurface'` from `ctx.services` in `onInit`, typed against **minimal inline interfaces** so it needs no `@moxxy/core` import.
- `present_view` reads both lazily at call time and degrades gracefully (no renderer / no surface) when absent.

`buildViewPlugin` is kept for direct injection. No core/sdk change — only `builtin-entries` (publish the ref + use the default export).

**9 of 11 plugins** discovery-loadable now. Remaining: **self-update** (publish `pluginHost` + a writable `emit` service + `getPluginOptions`) and **web** (most entangled — also consumes `'viewSurface'`, plus `webControls` + tunnels).

## Testing
`turbo run test` green across all packages (exit 0), build (73), lint 0, deps 0; new discovery test (view 28 + 2). Changeset included.