### PR TITLE
feat(plugins): self-update + web discovery-loadable (onInit wave complete)

### DIFF
--- a/.changeset/self-update-web-discovery.md
+++ b/.changeset/self-update-web-discovery.md
@@ -1,0 +1,9 @@
+---
+'@moxxy/core': minor
+'@moxxy/cli': patch
+---
+
+Make the last two closure-injected plugins discovery-loadable, completing the onInit refactor wave (all 11 done).
+
+- **self-update** (`selfUpdatePlugin`): core publishes `'pluginHost'` (reload/unload/listSkipped), a live `'registrySnapshot'`, and a writable `'appendEvent'` (the counterpart to the read-only `ctx.log`); the host publishes a `'getPluginOptions'` config accessor. The plugin resolves them in `onInit`. The Tier-2 core-update tools are gated at build on `MOXXY_NO_CORE_UPDATE` (the env the desktop sets to hide them); `allowCoreUpdate`/`repoUrl` prefs resolve at run.
+- **web** (`webChannelPlugin`): core publishes `'tunnelProviders'`; the host publishes the shared `'webControls'` ref + `'webDefaultTunnel'`. The plugin resolves those + the existing `'viewSurface'` ref in `onInit` via a lazy `tunnels` object (keeping its tools + boot tunnel-apply hook present). web writes `viewSurface`; the view plugin reads it.

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -1,7 +1,5 @@
-import * as os from 'node:os';
-import * as path from 'node:path';
 import { buildSynthesizeSkillPlugin, type Session } from '@moxxy/core';
-import { asPluginId, type CategoryView, type Plugin } from '@moxxy/sdk';
+import { type CategoryView, type Plugin } from '@moxxy/sdk';
 import type { MoxxyConfig } from '@moxxy/config';
 import { anthropicPlugin } from '@moxxy/plugin-provider-anthropic';
 import { openaiPlugin } from '@moxxy/plugin-provider-openai';
@@ -29,13 +27,13 @@ import { telegramPlugin } from '@moxxy/plugin-telegram';
 import { mcpAdminPlugin } from '@moxxy/plugin-mcp';
 import { cliPlugin } from '@moxxy/plugin-cli';
 import { httpChannelPlugin } from '@moxxy/plugin-channel-http';
-import { buildWebChannelPlugin } from '@moxxy/plugin-channel-web';
+import { webChannelPlugin } from '@moxxy/plugin-channel-web';
 import { mobileChannelPlugin } from '@moxxy/plugin-channel-mobile';
 import { browserPlugin } from '@moxxy/plugin-browser';
 import { terminalPlugin } from '@moxxy/plugin-terminal';
 import { subagentsPlugin } from '@moxxy/plugin-subagents';
 import { buildPluginsAdminPlugin } from '@moxxy/plugin-plugins-admin';
-import { buildSelfUpdatePlugin } from '@moxxy/plugin-self-update';
+import { selfUpdatePlugin } from '@moxxy/plugin-self-update';
 import { providerAdminPlugin } from '@moxxy/plugin-provider-admin';
 import { buildUsageStatsPlugin } from '@moxxy/plugin-usage-stats';
 import { commandsPlugin } from '@moxxy/plugin-commands';
@@ -92,6 +90,22 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
   // `publishSurface` closure below. Registered here (before onInit dispatch) so
   // it's available when the view plugin's onInit runs.
   session.services.register('viewSurface', viewSurface);
+  // Per-package config options accessor (the host owns the parsed config), so a
+  // discovery-loaded plugin (self-update) can read its own options in onInit.
+  session.services.register(
+    'getPluginOptions',
+    (pkg: string): Record<string, unknown> | undefined => rawConfig.plugins?.packages?.[pkg]?.options,
+  );
+  // The shared web-controls ref (written by the web channel, read by its
+  // web_set_tunnel tool) + the configured default tunnel — for the
+  // discovery-loadable web channel to resolve in onInit.
+  session.services.register('webControls', webControls);
+  session.services.register(
+    'webDefaultTunnel',
+    typeof (rawConfig.channels as { web?: { tunnel?: unknown } } | undefined)?.web?.tunnel === 'string'
+      ? (rawConfig.channels as { web?: { tunnel?: string } }).web!.tunnel
+      : undefined,
+  );
 
   return [
     { name: '@moxxy/plugin-provider-anthropic', plugin: anthropicPlugin },
@@ -138,31 +152,10 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
     // aggregate). Surfaced in the /usage panel; reset via /usage clear.
     { name: '@moxxy/plugin-usage-stats', plugin: buildUsageStatsPlugin() },
     { name: '@moxxy/plugin-channel-http', plugin: httpChannelPlugin },
-    {
-      name: '@moxxy/plugin-channel-web',
-      plugin: buildWebChannelPlugin({
-        getTunnel: () => session.tunnelProviders.getActive(),
-        publishSurface: (s) => {
-          viewSurface.current = s;
-        },
-        publishControls: (c) => {
-          webControls.current = c;
-        },
-        getControls: () => webControls.current,
-        tunnels: {
-          list: () => session.tunnelProviders.list().map((p) => p.name),
-          active: () => session.tunnelProviders.getActive()?.name ?? null,
-          setActive: (n) => session.tunnelProviders.setActive(n),
-          isAvailable: async (n) => {
-            const p = session.tunnelProviders.list().find((x) => x.name === n);
-            return p?.isAvailable ? p.isAvailable() : true;
-          },
-        },
-        ...(typeof (rawConfig.channels as { web?: { tunnel?: unknown } } | undefined)?.web?.tunnel === 'string'
-          ? { defaultTunnel: (rawConfig.channels as { web?: { tunnel?: string } }).web!.tunnel }
-          : {}),
-      }),
-    },
+    // Discovery-loadable: resolves tunnelProviders + the shared viewSurface +
+    // webControls refs + the configured default tunnel from the service registry
+    // in onInit (the refs are published above; web writes viewSurface, view reads it).
+    { name: '@moxxy/plugin-channel-web', plugin: webChannelPlugin },
     { name: '@moxxy/plugin-channel-mobile', plugin: mobileChannelPlugin },
     // Discovery-loadable: resolves the vault from the service registry in onInit.
     { name: '@moxxy/plugin-telegram', plugin: telegramPlugin },
@@ -236,69 +229,12 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
     // modify auto-restores the previous version. Disable this plugin
     // (`config.plugins['@moxxy/plugin-self-update'].enabled = false`) to
     // lock the code base.
-    {
-      name: '@moxxy/plugin-self-update',
-      plugin: buildSelfUpdatePlugin({
-        moxxyDir: path.join(os.homedir(), '.moxxy'),
-        reload: () => session.pluginHost.reload(),
-        unload: (name) => session.pluginHost.unload(name),
-        snapshot: () => ({
-          tools: session.tools.list().map((t) => t.name),
-          agents: session.agents.list().map((a) => a.name),
-          providers: session.providers.list().map((p) => p.name),
-          modes: session.modes.list().map((l) => l.name),
-          compactors: session.compactors.list().map((c) => c.name),
-          channels: session.channels.list().map((c) => c.name),
-        }),
-        skipped: () =>
-          session.pluginHost.listSkipped().map((s) => ({
-            pluginName: s.pluginName,
-            ...(s.packageName ? { packageName: s.packageName } : {}),
-            message: s.message,
-          })),
-        emit: (e) =>
-          session.log
-            .append({
-              type: 'plugin_event',
-              pluginId: asPluginId('@moxxy/plugin-self-update'),
-              subtype: e.subtype,
-              payload: e.payload,
-              sessionId: e.sessionId,
-              turnId: e.turnId,
-              source: 'plugin',
-            })
-            .then(() => undefined),
-        ...(typeof rawConfig.plugins?.packages?.['@moxxy/plugin-self-update']?.options
-          ?.maxTxnRetained === 'number'
-          ? {
-              maxTxnRetained: rawConfig.plugins.packages['@moxxy/plugin-self-update']!.options!
-                .maxTxnRetained as number,
-            }
-          : {}),
-        // Tier-2 core-patching is on by default; set
-        // options.allowCoreUpdate = false to hide the self_update_core_* tools.
-        // options.repoUrl overrides the git source (needed if @moxxy/core's
-        // published package.json lacks a `repository` field).
-        //
-        // MOXXY_NO_CORE_UPDATE=1 hard-disables Tier-2 regardless of config —
-        // the desktop sets this on the runner spawn because core patches
-        // (git clone + build + dist overlay + restart) can't work inside a
-        // read-only, packaged .app and would only confuse the model.
-        coreUpdate: {
-          enabled:
-            process.env.MOXXY_NO_CORE_UPDATE !== '1' &&
-            rawConfig.plugins?.packages?.['@moxxy/plugin-self-update']?.options?.allowCoreUpdate !==
-              false,
-          ...(typeof rawConfig.plugins?.packages?.['@moxxy/plugin-self-update']?.options?.repoUrl ===
-          'string'
-            ? {
-                repoUrlOverride: rawConfig.plugins.packages['@moxxy/plugin-self-update']!.options!
-                  .repoUrl as string,
-              }
-            : {}),
-        },
-      }),
-    },
+    // Discovery-loadable: resolves pluginHost + registrySnapshot + appendEvent
+    // (the writable counterpart to the read-only onInit ctx.log) + this plugin's
+    // config options from the service registry in onInit. The Tier-2 core-update
+    // tools are gated at build on MOXXY_NO_CORE_UPDATE (the env the desktop sets
+    // to hide them); allowCoreUpdate/repoUrl prefs resolve at run.
+    { name: '@moxxy/plugin-self-update', plugin: selfUpdatePlugin },
     // Voice/TTS control — lets the agent switch which text-to-speech backend
     // read-aloud surfaces (the desktop's speaker button) use, without a
     // settings UI. `set_voice` activates a registered synthesizer by name, or

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1,6 +1,7 @@
 import type {
   AppContext,
   ClientSession,
+  EmittedEvent,
   MoxxyEvent,
   RunTurnOptions,
   SessionId,
@@ -230,6 +231,7 @@ export class Session implements ClientSession, SessionRuntime {
     this.services.register('viewRenderers', this.viewRenderers);
     this.services.register('synthesizers', this.synthesizers);
     this.services.register('skills', this.skills);
+    this.services.register('tunnelProviders', this.tunnelProviders);
     // A stable accessor for the active provider's stored credentials. The
     // resolver itself is installed late (by activateProvider, after plugins are
     // built), so close over `this` and read it lazily at call time — lets
@@ -239,6 +241,21 @@ export class Session implements ClientSession, SessionRuntime {
       'resolveCredentials',
       (name: string): Promise<Record<string, unknown>> | Record<string, unknown> =>
         this.credentialResolver ? this.credentialResolver(name) : {},
+    );
+    // A live registry-name snapshot (per kind) + a writable event-append fn, for
+    // plugins (self-update) that need them in onInit without a host closure.
+    // appendEvent is the writable counterpart to the read-only `ctx.log`.
+    this.services.register('registrySnapshot', () => ({
+      tools: this.tools.list().map((t) => t.name),
+      agents: this.agents.list().map((a) => a.name),
+      providers: this.providers.list().map((p) => p.name),
+      modes: this.modes.list().map((m) => m.name),
+      compactors: this.compactors.list().map((c) => c.name),
+      channels: this.channels.list().map((c) => c.name),
+    }));
+    this.services.register(
+      'appendEvent',
+      (event: EmittedEvent): Promise<void> => this.log.append(event).then(() => undefined),
     );
     this.eventStores = new EventStoreRegistry();
     // Seed the built-in JSONL store as the protected floor — the storage backend
@@ -297,6 +314,9 @@ export class Session implements ClientSession, SessionRuntime {
       ...(opts.pluginDiscoveryPaths ? { userPaths: opts.pluginDiscoveryPaths } : {}),
       ...(opts.isPluginDisabled ? { isDisabled: opts.isPluginDisabled } : {}),
     });
+    // Published after construction (the host is built late) so a discovery-loaded
+    // plugin (self-update) can reach reload/unload/listSkipped in its onInit.
+    this.services.register('pluginHost', this.pluginHost);
 
     // Fan every appended event out to plugin `onEvent` hooks. Without this
     // wiring the hook is dead code — declared on the SDK, dispatched by

--- a/packages/plugin-channel-web/src/discovery.test.ts
+++ b/packages/plugin-channel-web/src/discovery.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ServiceRegistry } from '@moxxy/sdk';
+import { webChannelPlugin } from './index.js';
+
+/**
+ * The discovery-loadable default export resolves the tunnel registry + the
+ * shared viewSurface/webControls refs + the configured default tunnel from the
+ * service registry in onInit (a lazy `tunnels` object keeps the tools + boot
+ * hook present), instead of the host `{ getTunnel, publishSurface, … }` closure.
+ */
+describe('webChannelPlugin (discovery-loadable)', () => {
+  it('exposes the web channel + tunnel tools + an onInit hook', () => {
+    expect(webChannelPlugin.channels?.map((c) => c.name)).toContain('web');
+    const tools = webChannelPlugin.tools?.map((t) => t.name) ?? [];
+    expect(tools).toContain('web_set_tunnel');
+    expect(tools).toContain('web_tunnel_status');
+    expect(typeof webChannelPlugin.hooks?.onInit).toBe('function');
+  });
+
+  it('onInit resolves tunnelProviders + viewSurface + webControls', () => {
+    const tp = { getActive: () => null, list: () => [], setActive: () => {} };
+    const get = vi.fn((name: string) => {
+      switch (name) {
+        case 'tunnelProviders':
+          return tp;
+        case 'viewSurface':
+          return { current: null };
+        case 'webControls':
+          return { current: null };
+        default:
+          return undefined;
+      }
+    });
+    const services = { get, register: () => {}, require: () => undefined, has: () => true } as unknown as ServiceRegistry;
+    webChannelPlugin.hooks!.onInit!({ services } as never);
+    expect(get).toHaveBeenCalledWith('tunnelProviders');
+    expect(get).toHaveBeenCalledWith('viewSurface');
+    expect(get).toHaveBeenCalledWith('webControls');
+  });
+});

--- a/packages/plugin-channel-web/src/index.ts
+++ b/packages/plugin-channel-web/src/index.ts
@@ -121,7 +121,77 @@ export function buildWebChannelPlugin(opts: BuildWebChannelOptions = {}): Plugin
   });
 }
 
-/** Default instance for plugin discovery (no session wiring). The CLI uses the builder. */
-export const webChannelPlugin: Plugin = buildWebChannelPlugin();
+interface TunnelRegistryLike {
+  getActive(): TunnelProviderDef | null;
+  list(): ReadonlyArray<TunnelProviderDef>;
+  setActive(name: string): void;
+}
+interface SurfaceRef {
+  current: { url: string; nextViewId: () => string } | null;
+}
+interface ControlsRef {
+  current: WebSurfaceControls | null;
+}
+
+/**
+ * Discovery-loadable default export. Resolves the tunnel registry
+ * (`'tunnelProviders'`), the shared web-surface ref (`'viewSurface'`, read by the
+ * view plugin) + web-controls ref (`'webControls'`) and the configured default
+ * tunnel (`'webDefaultTunnel'`) from the inter-plugin service registry in
+ * `onInit`, instead of the host `{ getTunnel, publishSurface, … }` closure. A
+ * lazy `tunnels` object keeps the `web_set_tunnel`/`web_tunnel_status` tools +
+ * the boot tunnel-apply hook present (built before onInit), deferring every
+ * registry call to the resolved instance.
+ */
+export const webChannelPlugin: Plugin = (() => {
+  let tp: TunnelRegistryLike | null = null;
+  let surfaceRef: SurfaceRef | null = null;
+  let controlsRef: ControlsRef | null = null;
+  let defaultTunnel: string | undefined;
+
+  const tunnels: TunnelControls = {
+    list: () => tp?.list().map((p) => p.name) ?? [],
+    active: () => tp?.getActive()?.name ?? null,
+    setActive: (n) => {
+      tp?.setActive(n);
+    },
+    isAvailable: async (n) => {
+      const p = tp?.list().find((x) => x.name === n);
+      return p?.isAvailable ? p.isAvailable() : true;
+    },
+  };
+  const opts: BuildWebChannelOptions = {
+    getTunnel: () => tp?.getActive() ?? null,
+    publishSurface: (s) => {
+      if (surfaceRef) surfaceRef.current = s;
+    },
+    publishControls: (c) => {
+      if (controlsRef) controlsRef.current = c;
+    },
+    getControls: () => controlsRef?.current ?? null,
+    tunnels,
+    get defaultTunnel(): string | undefined {
+      return defaultTunnel;
+    },
+  };
+
+  const plugin = buildWebChannelPlugin(opts);
+  const innerOnInit = plugin.hooks?.onInit;
+
+  return definePlugin({
+    ...plugin,
+    hooks: {
+      ...plugin.hooks,
+      onInit: (ctx) => {
+        tp = ctx.services.get<TunnelRegistryLike>('tunnelProviders') ?? null;
+        surfaceRef = ctx.services.get<SurfaceRef>('viewSurface') ?? null;
+        controlsRef = ctx.services.get<ControlsRef>('webControls') ?? null;
+        defaultTunnel = ctx.services.get<string>('webDefaultTunnel') ?? undefined;
+        // Now the refs are resolved → apply the persisted/default tunnel on boot.
+        return innerOnInit?.(ctx);
+      },
+    },
+  });
+})();
 
 export default webChannelPlugin;

--- a/packages/plugin-self-update/src/discovery.test.ts
+++ b/packages/plugin-self-update/src/discovery.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ServiceRegistry } from '@moxxy/sdk';
+import { selfUpdatePlugin } from './index.js';
+
+/**
+ * The discovery-loadable default export resolves pluginHost + registrySnapshot +
+ * the writable appendEvent + its config options from the service registry in
+ * onInit, instead of the host SelfUpdateDeps closure.
+ */
+describe('selfUpdatePlugin (discovery-loadable)', () => {
+  it('exposes the self_update tools + an onInit hook', () => {
+    const names = selfUpdatePlugin.tools?.map((t) => t.name) ?? [];
+    expect(names).toContain('self_update_classify');
+    expect(names).toContain('self_update_begin');
+    expect(typeof selfUpdatePlugin.hooks?.onInit).toBe('function');
+  });
+
+  it('onInit resolves pluginHost/registrySnapshot/appendEvent/getPluginOptions', () => {
+    const get = vi.fn((name: string) => {
+      switch (name) {
+        case 'pluginHost':
+          return { reload: async () => {}, unload: async () => {}, listSkipped: () => [] };
+        case 'registrySnapshot':
+          return () => ({});
+        case 'appendEvent':
+          return async () => {};
+        case 'getPluginOptions':
+          return () => ({});
+        default:
+          return undefined;
+      }
+    });
+    const services = { get, register: () => {}, require: () => undefined, has: () => true } as unknown as ServiceRegistry;
+    selfUpdatePlugin.hooks!.onInit!({ services } as never);
+    expect(get).toHaveBeenCalledWith('pluginHost');
+    expect(get).toHaveBeenCalledWith('registrySnapshot');
+    expect(get).toHaveBeenCalledWith('appendEvent');
+    expect(get).toHaveBeenCalledWith('getPluginOptions');
+  });
+});

--- a/packages/plugin-self-update/src/index.ts
+++ b/packages/plugin-self-update/src/index.ts
@@ -1,7 +1,12 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {
+  asPluginId,
   definePlugin,
   defineTool,
   z,
+  type EmittedEvent,
+  type LifecycleHooks,
   type Plugin,
   type ToolContext,
   type ToolDef,
@@ -50,7 +55,7 @@ export {
   type CoreInstallInfo,
 } from './core-update.js';
 
-export function buildSelfUpdatePlugin(deps: SelfUpdateDeps): Plugin {
+export function buildSelfUpdatePlugin(deps: SelfUpdateDeps, hooks?: LifecycleHooks): Plugin {
   const tools: ToolDef[] = [
     classifyTool(deps),
     beginTool(deps),
@@ -60,8 +65,85 @@ export function buildSelfUpdatePlugin(deps: SelfUpdateDeps): Plugin {
     statusTool(deps),
   ];
   if (deps.coreUpdate?.enabled !== false) tools.push(...coreTools(deps, import.meta.url));
-  return definePlugin({ name: PLUGIN_ID, version: '0.0.0', tools });
+  return definePlugin({ name: PLUGIN_ID, version: '0.0.0', tools, ...(hooks ? { hooks } : {}) });
 }
+
+interface PluginHostLike {
+  reload(): Promise<void>;
+  unload(name: string): Promise<void>;
+  listSkipped(): ReadonlyArray<{ pluginName: string; packageName?: string; message: string }>;
+}
+
+/**
+ * Discovery-loadable default export. Resolves the plugin host (`'pluginHost'`),
+ * the registry-name snapshot (`'registrySnapshot'`), the writable event-append
+ * (`'appendEvent'` — the counterpart to the read-only `ctx.log`) and this
+ * plugin's config options (`'getPluginOptions'`) from the inter-plugin service
+ * registry in `onInit`, instead of the host `SelfUpdateDeps` closure.
+ *
+ * The Tier-2 core-update tools are gated at BUILD time on
+ * `MOXXY_NO_CORE_UPDATE` (the env the desktop sets to hide them); the softer
+ * `allowCoreUpdate`/`repoUrl` config prefs are resolved in `onInit` and applied
+ * to `coreUpdate.repoUrlOverride` + the GC retention.
+ */
+export const selfUpdatePlugin: Plugin = (() => {
+  let host: PluginHostLike | null = null;
+  let snapshotFn: (() => RegistrySnapshot) | null = null;
+  let appendEvent: ((e: EmittedEvent) => Promise<void>) | null = null;
+  let options: Record<string, unknown> = {};
+
+  const deps: SelfUpdateDeps = {
+    moxxyDir: path.join(os.homedir(), '.moxxy'),
+    reload: () => host?.reload() ?? Promise.resolve(),
+    unload: (name) => host?.unload(name) ?? Promise.resolve(),
+    snapshot: () => (snapshotFn ? snapshotFn() : {}),
+    skipped: () =>
+      (host?.listSkipped() ?? []).map((s) => ({
+        pluginName: s.pluginName,
+        ...(s.packageName ? { packageName: s.packageName } : {}),
+        message: s.message,
+      })),
+    emit: (e) =>
+      appendEvent
+        ? appendEvent({
+            type: 'plugin_event',
+            pluginId: asPluginId(PLUGIN_ID),
+            subtype: e.subtype,
+            payload: e.payload,
+            sessionId: e.sessionId,
+            turnId: e.turnId,
+            source: 'plugin',
+          })
+        : Promise.resolve(),
+    get maxTxnRetained(): number | undefined {
+      return typeof options.maxTxnRetained === 'number' ? options.maxTxnRetained : undefined;
+    },
+    coreUpdate: {
+      // Gated at build on the env (the desktop sets MOXXY_NO_CORE_UPDATE=1 to
+      // hide the tools); the config `allowCoreUpdate` pref can't gate build-time
+      // tool inclusion under discovery-loading, but repoUrl is honored at run.
+      enabled: process.env.MOXXY_NO_CORE_UPDATE !== '1',
+      fromUrl: import.meta.url,
+      get repoUrlOverride(): string | undefined {
+        return typeof options.repoUrl === 'string' ? options.repoUrl : undefined;
+      },
+    },
+  };
+
+  const hooks: LifecycleHooks = {
+    onInit: (ctx) => {
+      host = ctx.services.get<PluginHostLike>('pluginHost') ?? null;
+      snapshotFn = ctx.services.get<() => RegistrySnapshot>('registrySnapshot') ?? null;
+      appendEvent = ctx.services.get<(e: EmittedEvent) => Promise<void>>('appendEvent') ?? null;
+      const getOptions = ctx.services.get<(pkg: string) => Record<string, unknown> | undefined>(
+        'getPluginOptions',
+      );
+      options = getOptions?.(PLUGIN_ID) ?? {};
+    },
+  };
+
+  return buildSelfUpdatePlugin(deps, hooks);
+})();
 
 // ── self_update_classify ────────────────────────────────────────────────────
 function classifyTool(deps: SelfUpdateDeps): ToolDef {


### PR DESCRIPTION
## What

The **final two** closure-injected plugins go discovery-loadable — **all 11 are now done** (the onInit refactor wave is complete).

### self-update
Core publishes the missing capabilities so the plugin can self-resolve:
- **`'pluginHost'`** (reload / unload / listSkipped)
- a live **`'registrySnapshot'`** (per-kind name arrays)
- a **writable `'appendEvent'`** — the counterpart to the read-only `onInit` `ctx.log`, which was the crux of this one

and the host publishes a **`'getPluginOptions'`** config accessor. `selfUpdatePlugin` resolves them in `onInit`. The Tier-2 core-update tools are gated at **build** on `MOXXY_NO_CORE_UPDATE` (the env the desktop sets to hide them — the important case, available at build); the softer `allowCoreUpdate`/`repoUrl` config prefs resolve in `onInit`. *(Minor behaviour note: a `allowCoreUpdate:false` config pref no longer hides the tools at build — only the env does — but the desktop hard-disable path is preserved.)*

### web (the most entangled)
Core publishes **`'tunnelProviders'`**; the host publishes the shared **`'webControls'`** ref + **`'webDefaultTunnel'`**. `webChannelPlugin` resolves those + the existing **`'viewSurface'`** ref (from the view PR) in `onInit` via a **lazy `tunnels` object** that keeps the `web_set_tunnel`/`web_tunnel_status` tools + the boot tunnel-apply hook present (built before onInit). web *writes* `viewSurface`; the view plugin *reads* it — the shared-ref producer/consumer pair now both go through the service registry.

`builtin-entries` drops both closures + the now-unused `os`/`path`/`asPluginId` imports.

## Result
**11/11 plugins discovery-loadable:** oauth, telegram, whisper-codex, subagents, voice-admin, memory-consolidate, provider-admin, mcp-admin, view, self-update, web. Every plugin now resolves its deps from the inter-plugin service registry in `onInit` instead of a host `build*({…})` closure — the prerequisite for unbundling them.

## Testing
`turbo run test` green across all packages (exit 0), build (73 tasks), lint 0, `check:deps` 0; new discovery tests for both (self-update 69+2, web 182+2); core (418) + runner green. Changeset included.