### PR TITLE
chore(ci): development/main branch model + on-demand releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "development",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.changeset/dev-main-pipeline.md
+++ b/.changeset/dev-main-pipeline.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: adopt a `development` / `main` branch model. Feature PRs target `development` (CI + changeset gate); `main` is production, updated only by an on-demand `development → main` release PR (or manual `workflow_dispatch`). CI now runs on both branches; the changeset gate applies only to PRs into `development`; changesets `baseBranch` is `development`. No code/release changes — versioning still rides changesets.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,15 @@
 name: CI
 
+# Branch model: `development` is the integration branch — every feature PR
+# targets it and must be green here. `main` is the production branch, updated
+# ONLY by a `development → main` release PR (which also runs CI). So CI runs on
+# pushes + PRs to BOTH branches; the changeset gate applies only to feature PRs
+# (→ development), since a dev→main release PR carries no NEW changeset.
 on:
   push:
-    branches: [main]
+    branches: [main, development]
   pull_request:
-    branches: [main]
+    branches: [main, development]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -22,9 +27,11 @@ jobs:
   changeset:
     name: Changeset present
     runs-on: ubuntu-latest
-    # Only PRs have a base branch to diff against; the push-to-main run is the
-    # merge result and doesn't need the gate.
-    if: github.event_name == 'pull_request'
+    # Only PRs have a base branch to diff against, and only FEATURE PRs (those
+    # targeting `development`) must add one. A `development → main` release PR
+    # carries the already-merged changesets, not new ones, so it's exempt — as
+    # is the push-to-branch merge result.
+    if: github.event_name == 'pull_request' && github.base_ref == 'development'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: Release
 
-# One pipeline for everything we ship, driven entirely by changesets.
+# Production release pipeline, driven entirely by changesets.
+#
+# Branch model: feature PRs land on `development` (each carrying a changeset);
+# `main` is production. A release is ON-DEMAND — you cut one by opening a
+# `development → main` PR and merging it (or by running this workflow manually
+# via the Actions tab / `workflow_dispatch`). Either way it ends as a push to
+# `main`, which is what triggers everything below.
 #
 # On push to main the first job has two modes:
 #   1. Pending changesets in `.changeset/`: open or update a "Version
@@ -36,6 +42,9 @@ name: Release
 on:
   push:
     branches: [main]
+  # Manual on-demand release (e.g. to re-run a publish, or to release without a
+  # dev→main merge). Same job, same changesets-driven modes.
+  workflow_dispatch:
 
 # Serialise releases. We do not cancel in flight because cancelling a
 # publish midway can leave one package on the registry and another not.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,9 +183,18 @@ not a separate chore someone else does.
 
 ---
 
+## Branching model
+
+Two long-lived branches:
+
+- **`development`** — the integration branch and the repo **default**. Every feature/fix PR targets it and must be green here (build + typecheck + lint + test + `Changeset present` + deps). This is where continuous development happens.
+- **`main`** — the **production** branch. It is updated **only** by a release: a `development → main` PR (CI runs, but the changeset gate is skipped — the changesets already merged into `development`). Merging that PR (a push to `main`) triggers `release.yml` (version + npm/desktop publish). You can also trigger a release manually via the **Release** workflow's `workflow_dispatch`.
+
+So: **branch off `development`, PR back into `development`. Releases to `main` are on-demand**, when you choose to cut one. Never target `main` with a feature PR.
+
 ## Releasing (changesets)
 
-Versioning and publishing are driven by **changesets** — there is no manual `npm version` / `npm publish`. **Every PR must include a changeset — CI (the `Changeset present` job) fails the PR without one.** A change that releases nothing (docs / CI / tests) still needs one: add an empty changeset with `pnpm changeset --empty`.
+Versioning and publishing are driven by **changesets** — there is no manual `npm version` / `npm publish`. **Every feature PR (→ `development`) must include a changeset — CI (the `Changeset present` job) fails it without one.** A change that releases nothing (docs / CI / tests) still needs one: add an empty changeset with `pnpm changeset --empty`. (A `development → main` release PR needs no new changeset — it carries the ones already merged.)
 
 - **Published packages:** only `@moxxy/cli` and `@moxxy/sdk` (everything else is `private` and bundled into the CLI binary by tsup). The private **`@moxxy/desktop`** also rides changesets — naming it cuts a desktop installer release (it is never published to npm), and because the desktop depends on `@moxxy/cli` / `@moxxy/sdk`, a CLI/SDK bump cascades a patch bump to it automatically.
 - **Add one:** `pnpm changeset` → pick the package(s) + bump (patch / minor / major) + write a one-line summary. This drops a file in `.changeset/`. Commit it with your PR.


### PR DESCRIPTION
## What

Adopts a two-branch model so `main` becomes the **production** branch and day-to-day work happens on **`development`**.

- **`development`** — integration branch + repo **default**. Every feature/fix PR targets it; full CI runs (build/typecheck/lint/test/deps + the changeset gate).
- **`main`** — production. Updated **only** by a `development → main` **release PR** (CI runs, changeset gate skipped) or a manual **Release** `workflow_dispatch`. A push to `main` triggers `release.yml` (changesets version + npm/desktop publish) — so **releases are on-demand**, cut when you choose.

### Changes
- **ci.yml** — runs on push + PR to `main` *and* `development`; the `Changeset present` gate now only applies to PRs into `development` (a dev→main release PR carries the already-merged changesets, not new ones).
- **release.yml** — adds `workflow_dispatch` (manual on-demand release) + documents the model. Mechanism unchanged (changesets-driven).
- **.changeset/config.json** — `baseBranch` → `development`.
- **AGENTS.md** — documents the branching model (branch off `development`, PR back into it; never target `main` with a feature PR).

### Rollout (after merge, by me with admin)
1. Create `development` from `main`.
2. Set `development` as the repo default branch.
3. Branch protection on both (require PR + green CI).

> This bootstrap PR targets `main` (one-time — `development` doesn't exist yet). It carries an empty changeset (no release). Future feature PRs target `development`.

Versioning is unchanged here — it still rides changesets; this only changes *where* PRs land and *when* releases happen.