### PR TITLE
fix(modes): loosen + make configurable the stuck-loop guard

### DIFF
--- a/.changeset/loop-guard-tolerance.md
+++ b/.changeset/loop-guard-tolerance.md
@@ -1,0 +1,10 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/core': minor
+'@moxxy/config': minor
+'@moxxy/cli': patch
+---
+
+Make the stuck-loop guard more tolerant + configurable. The detector was tripping turns too eagerly — its exact-repeat threshold was 3 (the same tool+input 3× in a window of 8), which legitimately-repeated work (re-reading a file, re-running `git status` across steps) could hit. Raised the defaults to exact=8 / near=10 / window=12, since `maxIterations` (500 in default mode) is the real runaway backstop and the guard only needs to catch a *tight* same-call loop.
+
+It's now tunable via `context.loopGuard` in config: `enabled` (set `false` to disable the guard entirely and rely on `maxIterations`), `windowSize`, `repeatThreshold`, `nearWindowSize`, `nearThreshold`. Threaded through the session → ModeContext → every loop strategy (default, goal, collaborative + subagents), and live-reloadable.

--- a/packages/cli/src/config-applier.ts
+++ b/packages/cli/src/config-applier.ts
@@ -105,6 +105,11 @@ export function buildSessionConfigApplier(
       applied.push('reasoning');
     }
 
+    if (!deepEqual(next.context?.loopGuard, last.context?.loopGuard)) {
+      session.loopGuard = next.context?.loopGuard;
+      applied.push('loopGuard');
+    }
+
     if (next.hookTimeoutMs !== last.hookTimeoutMs) {
       // The dispatcher reads its timeout at construction. v0: pending.
       pending.push('hookTimeoutMs (restart required)');

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -201,6 +201,7 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
   // carried when the user customizes or disables it.
   if (config.context?.elision) session.elisionSettings = config.context.elision;
   if (config.context?.lazyTools) session.lazyTools = true;
+  if (config.context?.loopGuard) session.loopGuard = config.context.loopGuard;
 
   // No separate preferences overlay anymore: the persisted provider/mode IS the
   // manifest default, already applied by activateProvider + applyPluginsTree

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -121,6 +121,22 @@ export const contextConfigSchema = z.object({
   reasoning: z
     .union([z.boolean(), z.object({ effort: z.enum(['low', 'medium', 'high']).optional() })])
     .optional(),
+  /**
+   * Stuck-loop guard tuning. The guard bails a turn early when the model keeps
+   * making the same tool call; `maxIterations` is the hard backstop. Raise the
+   * thresholds if legitimately-repeated work is being cut short, or set
+   * `enabled: false` to disable the guard and rely on `maxIterations` alone.
+   */
+  loopGuard: z
+    .object({
+      enabled: z.boolean().optional(),
+      windowSize: z.number().int().positive().optional(),
+      repeatThreshold: z.number().int().positive().optional(),
+      nearWindowSize: z.number().int().positive().optional(),
+      nearThreshold: z.number().int().positive().optional(),
+    })
+    .strict()
+    .optional(),
 });
 
 export const moxxyConfigSchema = z.object({

--- a/packages/core/src/run-turn.ts
+++ b/packages/core/src/run-turn.ts
@@ -124,6 +124,7 @@ export async function* runTurn(
       // Reasoning preference (effort) — honored only by providers/models that
       // advertise `supportsReasoning` (gated in collectProviderStream).
       ...(session.reasoning ? { reasoning: session.reasoning } : {}),
+      ...(session.loopGuard ? { loopGuard: session.loopGuard } : {}),
       permissions: session.resolver,
       ...(session.approvalResolver ? { approval: session.approvalResolver } : {}),
       hooks: session.dispatcher,

--- a/packages/core/src/session-runtime.ts
+++ b/packages/core/src/session-runtime.ts
@@ -6,6 +6,7 @@ import type {
   ElisionSettings,
   HookDispatcher,
   LLMProvider,
+  LoopGuardSettings,
   ModeDef,
   PermissionResolver,
   PluginHostHandle,
@@ -59,6 +60,8 @@ export interface SessionRuntime {
   readonly lazyTools: boolean;
   /** Reasoning/thinking preference (effort), forwarded to each turn's ModeContext. */
   readonly reasoning?: { readonly effort?: 'low' | 'medium' | 'high' } | boolean | undefined;
+  /** Stuck-loop guard tuning, forwarded to each turn's ModeContext. */
+  readonly loopGuard?: LoopGuardSettings;
   readonly dispatcher: HookDispatcher;
   readonly pluginHost: PluginHostHandle;
   /**

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -2,6 +2,7 @@ import type {
   AppContext,
   ClientSession,
   EmittedEvent,
+  LoopGuardSettings,
   MoxxyEvent,
   RunTurnOptions,
   SessionId,
@@ -162,6 +163,12 @@ export class Session implements ClientSession, SessionRuntime {
    * when the active model advertises `supportsReasoning`. Undefined → off.
    */
   reasoning: { readonly effort?: 'low' | 'medium' | 'high' } | boolean | undefined = undefined;
+  /**
+   * Stuck-loop guard tuning, from `config.context.loopGuard`. Forwarded to each
+   * turn's ModeContext and on to the mode's stuck-loop detector. Undefined →
+   * the detector's defaults.
+   */
+  loopGuard: LoopGuardSettings | undefined = undefined;
   /**
    * Model id resolved by the most recent `runTurn()` (see SessionRuntime).
    * Last-writer-wins for concurrent turns; null until the first turn runs.

--- a/packages/core/src/subagents/run-child.ts
+++ b/packages/core/src/subagents/run-child.ts
@@ -458,6 +458,7 @@ function buildChildContext(
     cacheStrategy: parentSession.cacheStrategies.getActive(),
     ...(parentSession.elisionSettings ? { elision: parentSession.elisionSettings } : {}),
     ...(parentSession.lazyTools ? { lazyTools: true } : {}),
+    ...(parentSession.loopGuard ? { loopGuard: parentSession.loopGuard } : {}),
     permissions: parentSession.resolver,
     // Intentionally no `approval` — fanning approval gates out to N
     // children in parallel would prompt the user N times. Strategies

--- a/packages/mode-collaborative/src/agent-loop.ts
+++ b/packages/mode-collaborative/src/agent-loop.ts
@@ -76,7 +76,7 @@ export async function* runCollabAgentLoop(
   // Announce active work so the roster/UI shows 'working' (not a stale
   // 'connected') for the whole turn. Best-effort; the run proceeds regardless.
   if (hub) await hub.setStatus('working').catch(() => undefined);
-  const detector = createStuckLoopDetector();
+  const detector = createStuckLoopDetector(ctx.loopGuard);
   const maxIterations = ctx.maxIterations ?? peerMaxIterationsFromEnv() ?? DEFAULT_MAX_ITERATIONS;
   let noop = 0;
   let reactiveCompactions = 0;

--- a/packages/mode-default/src/turn-iterator.ts
+++ b/packages/mode-default/src/turn-iterator.ts
@@ -73,7 +73,7 @@ export async function* runDefaultMode(ctx: ModeContext): AsyncIterable<MoxxyEven
     typeof requestedMaxIterations === 'number' && Number.isFinite(requestedMaxIterations)
       ? Math.max(1, Math.floor(requestedMaxIterations))
       : 500;
-  const detector = createStuckLoopDetector();
+  const detector = createStuckLoopDetector(ctx.loopGuard);
   // Reactive-compaction budget per overflow episode. If the provider keeps
   // rejecting for context size even after compacting this many times, give up
   // (the overflow is in the recent, un-compactable tail). Reset on any clean

--- a/packages/mode-goal/src/goal-loop.ts
+++ b/packages/mode-goal/src/goal-loop.ts
@@ -125,7 +125,7 @@ export async function* runGoalMode(ctx: ModeContext): AsyncIterable<MoxxyEvent> 
     payload: { autoApprove: true, maxIterations: ctx.maxIterations ?? GOAL_MAX_ITERATIONS },
   });
 
-  const detector = createStuckLoopDetector();
+  const detector = createStuckLoopDetector(ctx.loopGuard);
   // Coerce a caller/config-supplied bound to a positive integer. A degenerate
   // value (0, negative, NaN, fractional) would otherwise make the for-loop
   // never run and fall straight to the "iteration cap reached" fatal — work was

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -241,6 +241,7 @@ export {
   type ProjectedMessages,
   type StuckLoopDetector,
   type StuckSignal,
+  type LoopGuardSettings,
 } from './mode-helpers.js';
 export {
   dispatchToolCall,

--- a/packages/sdk/src/mode-helpers.ts
+++ b/packages/sdk/src/mode-helpers.ts
@@ -30,5 +30,6 @@ export {
   createStuckLoopDetector,
   type StuckLoopDetector,
   type StuckSignal,
+  type LoopGuardSettings,
 } from './mode/stuck-loop.js';
 export { stableHash } from './mode/stable-hash.js';

--- a/packages/sdk/src/mode.ts
+++ b/packages/sdk/src/mode.ts
@@ -7,6 +7,7 @@ import type { SessionId, TurnId } from './ids.js';
 import type { EventLogReader } from './log.js';
 import type { PermissionResolver } from './permission.js';
 import type { LLMProvider } from './provider.js';
+import type { LoopGuardSettings } from './mode/stuck-loop.js';
 import type { Skill } from './skill.js';
 import type { SubagentSpawner } from './subagent.js';
 import type { ToolDef } from './tool.js';
@@ -111,6 +112,11 @@ export interface ModeContext {
   readonly services: ServiceRegistry;
   readonly signal: AbortSignal;
   readonly maxIterations?: number;
+  /**
+   * Loop-guard tuning (config `context.loopGuard`), forwarded to each mode's
+   * stuck-loop detector. When omitted the detector uses its defaults.
+   */
+  readonly loopGuard?: LoopGuardSettings;
   /**
    * Spawn one or more child agents that share the parent's registries
    * but run in isolation. Children stream their events back to the

--- a/packages/sdk/src/mode/stuck-loop.ts
+++ b/packages/sdk/src/mode/stuck-loop.ts
@@ -34,6 +34,27 @@ export interface StuckLoopDetector {
   record(toolName: string, input: unknown): StuckSignal;
 }
 
+/**
+ * User-tunable loop-guard settings (config `context.loopGuard`). All optional —
+ * omitted fields use the defaults below. Set `enabled: false` to turn the guard
+ * off entirely and rely solely on the mode's `maxIterations` cap.
+ */
+export interface LoopGuardSettings {
+  readonly enabled?: boolean;
+  readonly windowSize?: number;
+  readonly repeatThreshold?: number;
+  readonly nearWindowSize?: number;
+  readonly nearThreshold?: number;
+}
+
+/** Default exact-repeat window + trip count. Deliberately generous: the
+ *  `maxIterations` cap (500 in default mode) is the real runaway backstop, so
+ *  this only needs to catch a *tight* same-call loop, not legitimately repeated
+ *  work (re-reading a file, re-running `git status` across steps, a couple of
+ *  retries). Tunable via `context.loopGuard`. */
+export const DEFAULT_LOOP_WINDOW_SIZE = 12;
+export const DEFAULT_LOOP_REPEAT_THRESHOLD = 8;
+
 /** Identity arguments that pin "the same target" across volatile-arg variation,
  *  best-first. The first present string field wins. */
 const IDENTITY_ARG_KEYS = ['url', 'file_path', 'path', 'command', 'cmd', 'query', 'pattern'];
@@ -48,19 +69,13 @@ function identityArg(input: unknown): string | null {
   return null;
 }
 
-export function createStuckLoopDetector(
-  opts: {
-    windowSize?: number;
-    repeatThreshold?: number;
-    nearWindowSize?: number;
-    nearThreshold?: number;
-  } = {},
-): StuckLoopDetector {
-  const windowSize = opts.windowSize ?? 8;
-  const repeatThreshold = opts.repeatThreshold ?? 3;
+export function createStuckLoopDetector(opts: LoopGuardSettings = {}): StuckLoopDetector {
+  const enabled = opts.enabled ?? true;
+  const windowSize = opts.windowSize ?? DEFAULT_LOOP_WINDOW_SIZE;
+  const repeatThreshold = opts.repeatThreshold ?? DEFAULT_LOOP_REPEAT_THRESHOLD;
   // Near-dups need a higher count + a wider window (they're spread out across a
   // burst of other calls), and tolerate a couple of legit "bigger refetch" tries.
-  const nearWindowSize = opts.nearWindowSize ?? Math.max(windowSize * 2, 16);
+  const nearWindowSize = opts.nearWindowSize ?? Math.max(windowSize * 2, 24);
   const nearThreshold = opts.nearThreshold ?? Math.max(repeatThreshold + 2, 5);
   const recent: string[] = [];
   const recentNear: string[] = [];
@@ -68,6 +83,8 @@ export function createStuckLoopDetector(
     windowSize,
     repeatThreshold,
     record(toolName, input): StuckSignal {
+      // Disabled → never trip (rely on the maxIterations cap alone).
+      if (!enabled) return { stuck: false, count: 0, kind: 'exact' };
       const key = `${toolName}|${stableHash(input)}`;
       recent.push(key);
       if (recent.length > windowSize) recent.shift();

--- a/packages/sdk/src/stuck-loop.test.ts
+++ b/packages/sdk/src/stuck-loop.test.ts
@@ -3,7 +3,7 @@ import { createStuckLoopDetector, stableHash } from './mode-helpers.js';
 
 describe('createStuckLoopDetector', () => {
   it('trips on exact-input repeats at repeatThreshold', () => {
-    const d = createStuckLoopDetector(); // repeatThreshold 3
+    const d = createStuckLoopDetector({ repeatThreshold: 3 });
     const input = { x: 1 };
     expect(d.record('Read', input).stuck).toBe(false);
     expect(d.record('Read', input).stuck).toBe(false);
@@ -11,8 +11,21 @@ describe('createStuckLoopDetector', () => {
     expect(sig).toMatchObject({ stuck: true, count: 3, kind: 'exact' });
   });
 
+  it('uses a generous default exact threshold (does not trip on a few repeats)', () => {
+    const d = createStuckLoopDetector(); // default repeatThreshold = 8
+    const input = { x: 1 };
+    for (let i = 0; i < 7; i++) expect(d.record('Read', input).stuck).toBe(false);
+    expect(d.record('Read', input).stuck).toBe(true); // 8th identical call trips
+  });
+
+  it('never trips when disabled (relies on maxIterations alone)', () => {
+    const d = createStuckLoopDetector({ enabled: false, repeatThreshold: 2 });
+    const input = { x: 1 };
+    for (let i = 0; i < 20; i++) expect(d.record('Read', input).stuck).toBe(false);
+  });
+
   it('trips on same-target near-dups even when volatile args vary', () => {
-    const d = createStuckLoopDetector(); // nearThreshold 5
+    const d = createStuckLoopDetector({ repeatThreshold: 3 }); // nearThreshold → 5
     const url = 'https://example.com/big';
     // Same url, different maxBytes each time — exact check never fires.
     for (let i = 0; i < 4; i++) {
@@ -44,7 +57,7 @@ describe('createStuckLoopDetector', () => {
   // dispatch path; a throw there crashes the whole turn. These assert it stays
   // total on hostile/partial input — the worst case the provider can hand us.
   it('does not throw recording a tool input with a circular reference', () => {
-    const d = createStuckLoopDetector();
+    const d = createStuckLoopDetector({ repeatThreshold: 3 });
     const input: Record<string, unknown> = { a: 1 };
     input.self = input;
     expect(() => d.record('weird', input)).not.toThrow();


### PR DESCRIPTION
## What

The stuck-loop guard was tripping turns too eagerly. Its **exact-repeat threshold was 3** — the same `(tool, input)` 3× in a window of 8 — which legitimately-repeated work hits (re-reading a file at different steps, re-running `git status`, a couple of retries). Since `maxIterations` (500 in default mode) is the real runaway backstop, the guard only needs to catch a **tight** same-call loop.

- **Raised the defaults:** exact `3 → 8`, near `5 → 10`, window `8 → 12`.
- **Made it configurable** via `context.loopGuard` in `~/.moxxy/config.yaml`:
  ```yaml
  context:
    loopGuard:
      enabled: true          # set false to disable the guard (maxIterations only)
      repeatThreshold: 8      # exact (tool,input) repeats that trip
      windowSize: 12
      nearThreshold: 10       # same target (url/file/command) with volatile args
      nearWindowSize: 24
  ```
- Threaded `session.loopGuard` → `ModeContext` → **every loop strategy** (default, goal, collaborative, subagents); **live-reloadable** via the config-applier.
- `createStuckLoopDetector` gains an `enabled` flag + a `LoopGuardSettings` type.

So you can now bump it as high as you like (your "~50") or turn it off, without code changes — and the out-of-the-box default is already far less twitchy.

## Testing
`turbo run test` green (exit 0), build 73, lint 0, deps 0. Updated the threshold-dependent stuck-loop tests to be explicit + added coverage for the new generous default + `enabled: false`. sdk 289 / core 418 / all modes green.

> First PR under the new model — targets `development`.