### PR TITLE
chore(ci): add "Open release PR" workflow (development → main, on-demand)

### DIFF
--- a/.changeset/open-release-pr-workflow.md
+++ b/.changeset/open-release-pr-workflow.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: add an "Open release PR" workflow (`workflow_dispatch`) that opens a `development → main` release PR listing the pending changesets — the on-demand cut mechanism for the new branch model. Documented in AGENTS.md. No code/release changes.

--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -1,0 +1,78 @@
+name: Open release PR
+
+# On-demand: open (or reuse) a `development → main` release PR. Merging it is a
+# production release — the push to `main` then triggers `release.yml` (which opens
+# the changesets "Version Packages" PR, and publishes once that merges).
+#
+# Run it from the Actions tab (it's a workflow_dispatch). The PR body lists the
+# pending changesets so you can see exactly what the release will version/publish.
+#
+# Note: a PR opened by the built-in GITHUB_TOKEN does not itself start CI — but
+# every commit on `development` was already gated by CI before it landed, and the
+# push to `main` on merge runs CI again, so the release is doubly covered.
+on:
+  workflow_dispatch:
+    inputs:
+      title:
+        description: 'Release PR title'
+        required: false
+        default: 'Release: development → main'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-release-pr:
+    name: Open development → main PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Open or reuse the release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: ${{ inputs.title }}
+        run: |
+          set -euo pipefail
+
+          # Nothing to ship if development is already in sync with main.
+          if git diff --quiet origin/main origin/development; then
+            echo "::notice::development is already in sync with main — nothing to release."
+            exit 0
+          fi
+
+          existing="$(gh pr list --base main --head development --state open \
+            --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            url="$(gh pr view "$existing" --json url --jq .url)"
+            echo "::notice::Release PR already open: $url"
+            exit 0
+          fi
+
+          # Compose a body that lists the pending changesets (what gets
+          # versioned + published when this merges).
+          {
+            echo "## Release: \`development\` → \`main\`"
+            echo
+            echo "Merging this promotes \`development\` to production. The push to \`main\` then"
+            echo "triggers the **Release** workflow (opens the changesets \"Version Packages\" PR;"
+            echo "publishes npm + desktop once that merges)."
+            echo
+            echo "### Pending changesets"
+            found=0
+            for f in .changeset/*.md; do
+              base="$(basename "$f")"
+              [ "$base" = "README.md" ] && continue
+              [ -f "$f" ] || continue
+              found=1
+              echo "- \`$base\`"
+            done
+            [ "$found" = 0 ] && echo "_(none — nothing will be versioned/published)_"
+          } > /tmp/release-body.md
+
+          gh pr create --base main --head development \
+            --title "$TITLE" --body-file /tmp/release-body.md
+          echo "Opened release PR."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,8 @@ Two long-lived branches:
 
 So: **branch off `development`, PR back into `development`. Releases to `main` are on-demand**, when you choose to cut one. Never target `main` with a feature PR.
 
+**Cutting a release:** run the **Open release PR** workflow (Actions tab → `workflow_dispatch`) — it opens (or reuses) a `development → main` PR listing the pending changesets. Review it and merge; the push to `main` then runs `release.yml` (which opens the changesets "Version Packages" PR and publishes once that merges).
+
 ## Releasing (changesets)
 
 Versioning and publishing are driven by **changesets** — there is no manual `npm version` / `npm publish`. **Every feature PR (→ `development`) must include a changeset — CI (the `Changeset present` job) fails it without one.** A change that releases nothing (docs / CI / tests) still needs one: add an empty changeset with `pnpm changeset --empty`. (A `development → main` release PR needs no new changeset — it carries the ones already merged.)


### PR DESCRIPTION
## What

Adds the missing **on-demand "cut a release" button** for the two-branch model: a `workflow_dispatch` workflow that opens (or reuses) a **`development → main` release PR**.

- Run it from the **Actions tab** → **Open release PR**.
- It opens a `development → main` PR whose body **lists the pending changesets** (exactly what the release will version + publish).
- Merging that PR is the release: the push to `main` triggers `release.yml`, which opens the changesets "Version Packages" PR and publishes once that merges.
- No-ops cleanly if `development` is already in sync with `main`, or if a release PR is already open.

This completes the flow you described: *"open a version bump PR on main merge"* (that's `release.yml`, already working) **+** *"some option to create release PRs from develop → main"* (this workflow).

> Note: a PR opened by `GITHUB_TOKEN` doesn't itself start CI, but every commit on `development` was already CI-gated before landing, and the push to `main` on merge runs CI again — so the release is doubly covered.

Documented in AGENTS.md. Carries an empty changeset (CI/no-release).