### PR TITLE
feat(cli): headless provisioner foundation (provision engine + command + catalog)

### DIFF
--- a/.changeset/provision-foundation.md
+++ b/.changeset/provision-foundation.md
@@ -1,0 +1,9 @@
+---
+'@moxxy/cli': minor
+---
+
+Add the headless provisioner foundation for Pillar 3 (slim-core / on-demand setup): a shared `provision()` engine + a `moxxy provision` command + a first-party provider catalog.
+
+`provision({ provider, model, key, basics })` resolves the provider from the catalog, installs its package (skipping it when it's already registered — i.e. bundled — so it never duplicate-registers), installs accepted basics, stores the key in the vault, and writes the unified `plugins:` config — config last, so a mid-flight failure leaves no half-state. `moxxy provision` drives it headlessly via flags (`--provider anthropic --key … --model …`) or a JSON spec on stdin (`--spec -`) — the same engine the interactive `init` wizard + the desktop first-run will use.
+
+Safe + additive: providers stay bundled, `init` is unchanged. Includes `pinFirstPartySpec` (pins first-party installs to the CLI version, scoped to provision so it can't break the generic `install_plugin` path) and the `PROVIDER_CATALOG` (slug → package + auth + default model). Rewiring `init` + the actual unbundling/publishing are the gated follow-ups.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -9,6 +9,7 @@ import { runPluginsCommand } from './commands/plugins.js';
 import { runChannelsCommand } from './commands/channels.js';
 import { runChannelByName } from './commands/run-channel.js';
 import { runInitCommand } from './commands/init.js';
+import { runProvisionCommand } from './commands/provision.js';
 import { runPermsCommand } from './commands/perms.js';
 import { runMemoryCommand } from './commands/memory.js';
 import { runMcpCommand } from './commands/mcp.js';
@@ -53,6 +54,7 @@ const SECTIONS: ReadonlyArray<{ readonly title: string; readonly rows: ReadonlyA
     title: 'SETUP',
     rows: [
       ['init', 'interactive first-time setup (provider keys → vault)'],
+      ['provision', 'headless setup: install + configure a provider (flags or --spec -)'],
       ['login <provider>', 'OAuth sign-in for providers that don\'t use API keys'],
       ['login status|logout', 'inspect / remove stored OAuth credentials'],
       ['doctor [--check-keys]', 'diagnose config, vault, providers, channels, memory'],
@@ -199,6 +201,7 @@ const COMMANDS: Record<string, CommandHandler> = {
     return 0;
   },
   init: runInitCommand,
+  provision: runProvisionCommand,
   login: runLoginCommand,
   perms: runPermsCommand,
   memory: runMemoryCommand,

--- a/packages/cli/src/commands/provision.ts
+++ b/packages/cli/src/commands/provision.ts
@@ -1,0 +1,94 @@
+import { bootSessionWithConfig, stringFlag } from '../argv-helpers.js';
+import { closeSession } from '../setup/close-session.js';
+import { cliVersion } from '../version.js';
+import type { ParsedArgv } from '../argv.js';
+import { provision, type ProvisionSpec } from '../provision/provision.js';
+import { installPluginPackage, resolveCatalogPackageName } from '@moxxy/plugin-plugins-admin';
+import { setCategoryDefault, setPluginEnabled, setProviderModel } from '@moxxy/config';
+
+/**
+ * `moxxy provision` — headless first-run setup. Installs the chosen provider (+
+ * accepted basics) on demand, stores its key in the vault, and writes the
+ * unified `plugins:` config — the same `provision()` engine the interactive
+ * `init` wizard and (later) the desktop's first-run drive. Drive it with flags
+ * (`--provider anthropic --key … --model …`) or a JSON spec on stdin (`--spec -`).
+ */
+export async function runProvisionCommand(argv: ParsedArgv): Promise<number> {
+  let spec: ProvisionSpec;
+  try {
+    spec = await parseSpec(argv);
+  } catch (err) {
+    process.stderr.write(`moxxy provision: ${err instanceof Error ? err.message : String(err)}\n`);
+    return 2;
+  }
+
+  const { session, vault, persistence } = await bootSessionWithConfig(argv, {
+    skipKeyPrompt: true,
+    skipProviderActivation: true,
+  });
+  try {
+    const result = await provision(spec, {
+      loadedProviderNames: new Set(session.providers.list().map((p) => p.name)),
+      install: async (s) => {
+        await installPluginPackage({ packageName: s });
+      },
+      storeSecret: (name, value, tags) => vault.set(name, value, [...tags]),
+      resolveBasicPackage: (idOrName) => resolveCatalogPackageName(idOrName),
+      writeConfig: async (w) => {
+        // Enable the provider's package (only when it was installed — a bundled
+        // provider is already compiled in) + every accepted basic.
+        if (!w.providerBundled) await setPluginEnabled(w.providerPackage, true);
+        for (const pkg of w.basicsPackages) await setPluginEnabled(pkg, true);
+        await setCategoryDefault('provider', w.providerSlug);
+        if (w.model) await setProviderModel(w.providerSlug, w.model);
+      },
+      ...(cliVersion() ? { cliVersion: cliVersion() } : {}),
+      log: (m) => process.stderr.write(`moxxy provision: ${m}\n`),
+    });
+
+    // Make freshly-installed packages live in this session (best-effort).
+    if (result.installed.length > 0) {
+      await session.pluginHost.reload().catch(() => undefined);
+    }
+
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return 0;
+  } catch (err) {
+    process.stderr.write(`moxxy provision: ${err instanceof Error ? err.message : String(err)}\n`);
+    return 1;
+  } finally {
+    await closeSession(session, persistence);
+  }
+}
+
+async function parseSpec(argv: ParsedArgv): Promise<ProvisionSpec> {
+  // `--spec -` → read a JSON ProvisionSpec from stdin (the automation/desktop path).
+  if (stringFlag(argv, 'spec') === '-') {
+    const raw = await readStdin();
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || typeof (parsed as { provider?: unknown }).provider !== 'string') {
+      throw new Error('--spec JSON must be an object with a string "provider".');
+    }
+    return parsed as ProvisionSpec;
+  }
+  // Flag form.
+  const provider = stringFlag(argv, 'provider');
+  if (!provider) {
+    throw new Error('pass --provider <slug> (e.g. anthropic) plus optional --model/--key/--basics, or --spec - for JSON on stdin.');
+  }
+  const model = stringFlag(argv, 'model');
+  const key = stringFlag(argv, 'key');
+  const basics = stringFlag(argv, 'basics');
+  return {
+    provider,
+    ...(model ? { model } : {}),
+    ...(key ? { key } : {}),
+    ...(basics ? { basics: basics.split(',').map((s) => s.trim()).filter(Boolean) } : {}),
+  };
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString('utf8');
+}

--- a/packages/cli/src/provision/pin.ts
+++ b/packages/cli/src/provision/pin.ts
@@ -1,0 +1,28 @@
+const FIRST_PARTY_SCOPE = '@moxxy/';
+
+/**
+ * Pin a bare first-party plugin install to the CLI's version so a
+ * discovery-installed `@moxxy/plugin-*` matches the bundled `@moxxy/sdk` it
+ * links against (first-party packages version in lockstep via the fixed
+ * changeset group). An explicit version, a spec that already carries one, a
+ * non-`@moxxy` package, or a git/path spec is left untouched.
+ *
+ * Correct only once first-party packages are co-published at the CLI version,
+ * so this is used by `provision()` — which installs only providers NOT already
+ * loaded (i.e. ones that must come from npm) — and deliberately NOT by the
+ * generic `install_plugin` path, where pinning a third-party or
+ * differently-versioned package would break the install.
+ */
+export function pinFirstPartySpec(
+  packageName: string,
+  version: string | undefined,
+  cliVersion: string | undefined,
+): string {
+  if (version) return `${packageName}@${version}`;
+  // Already carries a version (`@scope/name@1.2.3` → the version `@` is past index 0).
+  if (packageName.lastIndexOf('@') > 0) return packageName;
+  if (cliVersion && packageName.startsWith(FIRST_PARTY_SCOPE)) {
+    return `${packageName}@${cliVersion}`;
+  }
+  return packageName;
+}

--- a/packages/cli/src/provision/provider-catalog.ts
+++ b/packages/cli/src/provision/provider-catalog.ts
@@ -1,0 +1,96 @@
+/**
+ * First-party provider catalog — the source of truth for `moxxy init` / `moxxy
+ * provision` when picking a provider. Maps a provider **slug** (the contribution
+ * name + vault-key base) to the npm package that contributes it, how its
+ * credentials are collected, and a best-effort default model.
+ *
+ * Today the providers are still bundled into the CLI, so `provision()` skips the
+ * install for any provider already registered in the session and just configures
+ * it. Once providers are unbundled + published (Pillar 3 slimming), the same
+ * catalog drives the on-demand install. `defaultModel` is only a pre-selection
+ * hint — the provider's own `models` list is authoritative once it loads.
+ */
+export type ProviderAuthKind = 'key' | 'oauth' | 'none';
+
+export interface ProviderCatalogEntry {
+  /** Contribution name (registry key) + vault-key base (e.g. `anthropic`). */
+  readonly slug: string;
+  readonly label: string;
+  readonly description: string;
+  /** npm package that contributes this provider. */
+  readonly packageName: string;
+  /** How `init` collects credentials: an API key, an OAuth sign-in, or none. */
+  readonly auth: ProviderAuthKind;
+  /** Best-effort default model to pre-select (the loaded provider is authoritative). */
+  readonly defaultModel?: string;
+  /** Recommended default pick for a fresh setup. */
+  readonly recommended?: boolean;
+}
+
+export const PROVIDER_CATALOG: ReadonlyArray<ProviderCatalogEntry> = [
+  {
+    slug: 'anthropic',
+    label: 'Anthropic (Claude)',
+    description: 'Claude models via the Anthropic API (API key).',
+    packageName: '@moxxy/plugin-provider-anthropic',
+    auth: 'key',
+    defaultModel: 'claude-opus-4-8',
+    recommended: true,
+  },
+  {
+    slug: 'openai',
+    label: 'OpenAI',
+    description: 'OpenAI models via the OpenAI API (API key).',
+    packageName: '@moxxy/plugin-provider-openai',
+    auth: 'key',
+  },
+  {
+    slug: 'claude-code',
+    label: 'Claude (Pro/Max sign-in)',
+    description: 'Claude via a Claude Pro/Max OAuth token — no separate API key.',
+    packageName: '@moxxy/plugin-provider-claude-code',
+    auth: 'oauth',
+  },
+  {
+    slug: 'openai-codex',
+    label: 'OpenAI Codex (ChatGPT sign-in)',
+    description: "Codex models via a ChatGPT account's OAuth token.",
+    packageName: '@moxxy/plugin-provider-openai-codex',
+    auth: 'oauth',
+  },
+  {
+    slug: 'google',
+    label: 'Google Gemini',
+    description: 'Gemini models via the Google Generative Language API (API key).',
+    packageName: '@moxxy/plugin-provider-google',
+    auth: 'key',
+  },
+  {
+    slug: 'xai',
+    label: 'xAI (Grok)',
+    description: 'Grok models via the xAI API (API key).',
+    packageName: '@moxxy/plugin-provider-xai',
+    auth: 'key',
+  },
+  {
+    slug: 'zai',
+    label: 'z.ai (GLM)',
+    description: 'GLM models via the z.ai API (API key).',
+    packageName: '@moxxy/plugin-provider-zai',
+    auth: 'key',
+  },
+  {
+    slug: 'local',
+    label: 'Local (Ollama / OpenAI-compatible)',
+    description: 'A local OpenAI-compatible server (Ollama, LM Studio, …) — no key.',
+    packageName: '@moxxy/plugin-provider-local',
+    auth: 'none',
+  },
+];
+
+/** Resolve a provider by slug or by package name. */
+export function resolveProvider(slugOrPackage: string): ProviderCatalogEntry | undefined {
+  return PROVIDER_CATALOG.find(
+    (p) => p.slug === slugOrPackage || p.packageName === slugOrPackage,
+  );
+}

--- a/packages/cli/src/provision/provision.test.ts
+++ b/packages/cli/src/provision/provision.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { pinFirstPartySpec } from './pin.js';
+import { provision, type ProvisionEffects } from './provision.js';
+
+describe('pinFirstPartySpec', () => {
+  it('pins a bare first-party package to the cli version', () => {
+    expect(pinFirstPartySpec('@moxxy/plugin-provider-anthropic', undefined, '1.2.3')).toBe(
+      '@moxxy/plugin-provider-anthropic@1.2.3',
+    );
+  });
+  it('respects an explicit version', () => {
+    expect(pinFirstPartySpec('@moxxy/plugin-x', '0.9.0', '1.2.3')).toBe('@moxxy/plugin-x@0.9.0');
+  });
+  it('leaves a version already embedded in the name', () => {
+    expect(pinFirstPartySpec('@moxxy/plugin-x@2.0.0', undefined, '1.2.3')).toBe('@moxxy/plugin-x@2.0.0');
+  });
+  it('leaves non-first-party packages alone', () => {
+    expect(pinFirstPartySpec('some-pkg', undefined, '1.2.3')).toBe('some-pkg');
+  });
+  it('is a no-op without a cli version', () => {
+    expect(pinFirstPartySpec('@moxxy/plugin-x', undefined, undefined)).toBe('@moxxy/plugin-x');
+  });
+});
+
+function makeEffects(overrides: Partial<ProvisionEffects> = {}): ProvisionEffects {
+  return {
+    loadedProviderNames: new Set<string>(),
+    install: vi.fn(async () => {}),
+    writeConfig: vi.fn(async () => {}),
+    storeSecret: vi.fn(async () => {}),
+    cliVersion: '1.0.0',
+    ...overrides,
+  };
+}
+
+describe('provision', () => {
+  it('skips installing a bundled provider but configures it + stores the key', async () => {
+    const eff = makeEffects({ loadedProviderNames: new Set(['anthropic']) });
+    const res = await provision(
+      { provider: 'anthropic', key: 'sk-x', model: 'claude-opus-4-8' },
+      eff,
+    );
+    expect(eff.install).not.toHaveBeenCalled();
+    expect(res.skipped).toContain('@moxxy/plugin-provider-anthropic');
+    expect(eff.storeSecret).toHaveBeenCalledWith(expect.any(String), 'sk-x', ['anthropic']);
+    expect(res.keyStored).toBe(true);
+    expect(eff.writeConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ providerSlug: 'anthropic', providerBundled: true, model: 'claude-opus-4-8' }),
+    );
+  });
+
+  it('installs a non-bundled provider (pinned) BEFORE writing config', async () => {
+    const order: string[] = [];
+    const eff = makeEffects({
+      loadedProviderNames: new Set(),
+      install: vi.fn(async (s: string) => {
+        order.push(`install:${s}`);
+      }),
+      writeConfig: vi.fn(async () => {
+        order.push('config');
+      }),
+    });
+    const res = await provision({ provider: 'openai' }, eff);
+    expect(res.installed).toContain('@moxxy/plugin-provider-openai');
+    expect(eff.install).toHaveBeenCalledWith('@moxxy/plugin-provider-openai@1.0.0'); // pinned to cli version
+    expect(order).toEqual(['install:@moxxy/plugin-provider-openai@1.0.0', 'config']); // config last
+  });
+
+  it('does not store a key for an oauth provider', async () => {
+    const eff = makeEffects({ loadedProviderNames: new Set(['claude-code']) });
+    const res = await provision({ provider: 'claude-code', key: 'should-ignore' }, eff);
+    expect(eff.storeSecret).not.toHaveBeenCalled();
+    expect(res.keyStored).toBe(false);
+  });
+
+  it('installs accepted basics too (pinned)', async () => {
+    const eff = makeEffects({ loadedProviderNames: new Set(['anthropic']) });
+    await provision({ provider: 'anthropic', basics: ['@moxxy/plugin-memory'] }, eff);
+    expect(eff.install).toHaveBeenCalledWith('@moxxy/plugin-memory@1.0.0');
+  });
+
+  it('throws on an unknown provider', async () => {
+    await expect(provision({ provider: 'nope' }, makeEffects())).rejects.toThrow(/unknown provider/);
+  });
+});

--- a/packages/cli/src/provision/provision.ts
+++ b/packages/cli/src/provision/provision.ts
@@ -1,0 +1,128 @@
+import { MoxxyError } from '@moxxy/sdk';
+import { canonicalKey } from '../provider-keys.js';
+import { pinFirstPartySpec } from './pin.js';
+import { PROVIDER_CATALOG, resolveProvider } from './provider-catalog.js';
+
+/**
+ * Shared, headless provisioner — the single code path that turns "I want
+ * provider X" into an installed + configured moxxy, used by both `moxxy
+ * provision` (CLI) and (later) the desktop's first-run over IPC.
+ *
+ * Steps (all idempotent; config written LAST so a mid-flight failure leaves no
+ * half-state): resolve provider → install its package unless it's already
+ * registered (bundled) → install accepted basics → store the key in the vault →
+ * write the unified `plugins:` config (enable the package, set the provider
+ * default + model). The bundled-skip is what keeps it safe today: installing a
+ * still-bundled provider on demand would duplicate-register it.
+ */
+export interface ProvisionSpec {
+  /** Provider slug (e.g. `anthropic`) or its package name. */
+  readonly provider: string;
+  /** Model to set as the provider's default (else the catalog's defaultModel). */
+  readonly model?: string;
+  /** API key for a key-auth provider → stored in the vault. */
+  readonly key?: string;
+  /** Override the vault key name (default `canonicalKey(slug)`). */
+  readonly keyName?: string;
+  /** Extra packages to install (catalog ids or npm names) — the recommended basics. */
+  readonly basics?: ReadonlyArray<string>;
+}
+
+export interface ProvisionConfigWrite {
+  readonly providerSlug: string;
+  readonly providerPackage: string;
+  readonly model?: string;
+  readonly basicsPackages: ReadonlyArray<string>;
+  /** True when the provider came from the bundle (no on-demand install happened). */
+  readonly providerBundled: boolean;
+}
+
+export interface ProvisionEffects {
+  /** Providers already registered in the session — installing these is skipped. */
+  readonly loadedProviderNames: ReadonlySet<string>;
+  /** Install a package spec into `~/.moxxy/plugins`. */
+  readonly install: (spec: string) => Promise<void>;
+  /** Persist the unified config (enable package + provider default + model). */
+  readonly writeConfig: (write: ProvisionConfigWrite) => Promise<void>;
+  /** Store a secret in the vault (required when a key is supplied). */
+  readonly storeSecret?: (name: string, value: string, tags: ReadonlyArray<string>) => Promise<void>;
+  /** Resolve a basic id/name → npm package (catalog-aware). Identity by default. */
+  readonly resolveBasicPackage?: (idOrName: string) => string;
+  /** CLI version, for pinning first-party installs. */
+  readonly cliVersion?: string;
+  readonly log?: (message: string) => void;
+}
+
+export interface ProvisionResult {
+  readonly provider: string;
+  readonly installed: ReadonlyArray<string>;
+  readonly skipped: ReadonlyArray<string>;
+  readonly keyStored: boolean;
+}
+
+export async function provision(
+  spec: ProvisionSpec,
+  effects: ProvisionEffects,
+): Promise<ProvisionResult> {
+  const entry = resolveProvider(spec.provider);
+  if (!entry) {
+    throw new MoxxyError({
+      code: 'CONFIG_INVALID',
+      message: `provision: unknown provider "${spec.provider}". Known: ${PROVIDER_CATALOG.map((p) => p.slug).join(', ')}.`,
+    });
+  }
+
+  const installed: string[] = [];
+  const skipped: string[] = [];
+
+  // Provider: skip the install when it's already registered (bundled) —
+  // installing a still-bundled provider would duplicate-register it.
+  const providerBundled = effects.loadedProviderNames.has(entry.slug);
+  if (providerBundled) {
+    skipped.push(entry.packageName);
+    effects.log?.(`provider "${entry.slug}" already available — skipping install`);
+  } else {
+    effects.log?.(`installing ${entry.packageName}…`);
+    await effects.install(pinFirstPartySpec(entry.packageName, undefined, effects.cliVersion));
+    installed.push(entry.packageName);
+  }
+
+  // Basics: install each (npm install is idempotent).
+  const basicsPackages: string[] = [];
+  for (const b of spec.basics ?? []) {
+    const pkg = effects.resolveBasicPackage?.(b) ?? b;
+    basicsPackages.push(pkg);
+    effects.log?.(`installing ${pkg}…`);
+    await effects.install(pinFirstPartySpec(pkg, undefined, effects.cliVersion));
+    installed.push(pkg);
+  }
+
+  // Key → vault (key-auth providers only; oauth/none collect creds elsewhere).
+  let keyStored = false;
+  if (spec.key && entry.auth === 'key') {
+    if (!effects.storeSecret) {
+      throw new MoxxyError({
+        code: 'CONFIG_INVALID',
+        message: 'provision: a key was supplied but no vault is available to store it.',
+      });
+    }
+    const keyName = spec.keyName ?? canonicalKey(entry.slug);
+    await effects.storeSecret(keyName, spec.key, [entry.slug]);
+    keyStored = true;
+    effects.log?.(`stored "${entry.slug}" key in the vault as ${keyName}`);
+  }
+
+  // Config LAST — only after installs + key succeed, so a failure leaves no
+  // half-written config pointing at a provider that isn't there.
+  const model = spec.model ?? entry.defaultModel;
+  await effects.writeConfig({
+    providerSlug: entry.slug,
+    providerPackage: entry.packageName,
+    ...(model ? { model } : {}),
+    basicsPackages,
+    providerBundled,
+  });
+  effects.log?.(`set provider default → ${entry.slug}${model ? ` (${model})` : ''}`);
+
+  return { provider: entry.slug, installed, skipped, keyStored };
+}


### PR DESCRIPTION
## What

The reusable core of **Pillar 3's on-demand setup** — built **safely + additive**: providers stay bundled, `init` is unchanged, nothing is unbundled or published. This is the engine the slim `init` + the desktop first-run will share.

- **`provision/provider-catalog.ts`** — `PROVIDER_CATALOG` mapping a provider **slug** → npm package + auth kind (`key`/`oauth`/`none`) + default model, for all 8 first-party providers.
- **`provision/provision.ts`** — the `provision({ provider, model, key, basics })` engine:
  1. resolve provider from the catalog
  2. install its package **unless it's already registered (bundled)** — so it never duplicate-registers a bundled provider (the key safety property today)
  3. install accepted basics
  4. store the key in the vault (key-auth providers only)
  5. write the unified `plugins:` config **last** — so a mid-flight failure leaves no half-state
- **`provision/pin.ts`** — `pinFirstPartySpec` pins a bare first-party install to the CLI version; **scoped to provision**, deliberately not the generic `install_plugin` path (where pinning a differently-versioned package would break the install).
- **`moxxy provision`** (`commands/provision.ts` + `bin.ts`) — headless: `--provider anthropic --key … --model …` or a JSON spec on stdin (`--spec -`).

Works **today** for bundled providers: `moxxy provision --provider anthropic --key sk-…` configures + stores the key headlessly (skips the install since anthropic is bundled).

## Not in scope (gated follow-ups)
Rewiring the `init` wizard to use `provision()` + the catalog; flipping `private:false` + the fixed changeset group (publish-prep); unbundling providers from tsup. Those are the irreversible distribution steps — I kept this PR safe so it can merge without touching first-run behavior.

## Testing
`turbo run test` green (exit 0), build 73, lint 0, deps 0; 10 new unit tests (pin logic + engine: skip-bundled, install-before-config ordering, oauth-no-key, basics, unknown provider). `moxxy provision` appears in `--help`. Targets `development`.