### PR TITLE
fix(cli): fresh-CLI provider default + generic special-mode mechanism

### DIFF
--- a/.changeset/special-modes.md
+++ b/.changeset/special-modes.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/cli': patch
+---
+
+Add a generic "special mode" mechanism. `ModeDef.special` (a `ModeSpecial` descriptor, optionally `{ invokedBy }`) marks a mode that is entered only via its own invocation — never offered in a mode list and never name-switched from `/mode`. Special modes are filtered uniformly via the new `isSelectableMode` predicate across every surface: `SessionInfo.modes` (mobile/desktop), the TUI `/mode` picker + by-name switch (which now points the user at `/<invokedBy>`), and the `/plugins` swap axis. The collaborative modes (`collaborative`, `collab-architect`, `collab-peer`) opt in — they're a separate system launched by `/collab` (TUI) or the desktop CollaboratePanel, not a pickable mode. Extensible: future special modes set the same flag.

--- a/packages/cli/src/setup/activate-provider.ts
+++ b/packages/cli/src/setup/activate-provider.ts
@@ -46,7 +46,11 @@ export async function activateProvider(args: ActivateProviderArgs): Promise<Acti
 
   const primaryProvider = providerDefault(config);
   const fallbacks = providerSlot(config).fallbacks ?? [];
-  const candidates = [primaryProvider, ...fallbacks];
+  // Drop an unset primary (a fresh config has no provider until init/provision)
+  // so the walk simply finds nothing → "continue without an active provider".
+  const candidates = [primaryProvider, ...fallbacks].filter(
+    (c): c is string => typeof c === 'string' && c.length > 0,
+  );
 
   let activated: { name: string; cfg: Record<string, unknown> } | null = null;
   let lastErr: unknown = null;

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -1,5 +1,5 @@
 import { runTurn, type Session } from '@moxxy/core';
-import { MoxxyError, type CategoryView, type Plugin } from '@moxxy/sdk';
+import { MoxxyError, isSelectableMode, type CategoryView, type Plugin } from '@moxxy/sdk';
 import type { MoxxyConfig } from '@moxxy/config';
 import {
   INSTALLABLE_PLUGIN_CATALOG,
@@ -165,7 +165,10 @@ function buildCategoryViews(session: Session): ReadonlyArray<CategoryView> {
       category,
       active,
       floor: r.getFloorName?.() ?? null,
-      items: r.list().map((d) => ({ name: d.name, isDefault: d.name === active })),
+      // Special modes (e.g. the collaborative system) are not swap-default
+      // targets — drop them from the swap axis. Harmless for non-mode kinds
+      // (their defs carry no `special`).
+      items: r.list().filter(isSelectableMode).map((d) => ({ name: d.name, isDefault: d.name === active })),
     });
   }
   return out;

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -127,7 +127,9 @@ export interface BuiltBuiltinsCore {
 /** Wire the plugin-management slice that backs the TUI `/plugins` picker. */
 /** Minimal active-def surface a category registry exposes for the swap UI. */
 interface CategoryRegistryLike {
-  list(): ReadonlyArray<{ name: string }>;
+  // `special?` lets the mode registry's special-mode marker flow through to the
+  // swap UI filter (isSelectableMode); non-mode defs simply omit it.
+  list(): ReadonlyArray<{ name: string; special?: unknown }>;
   getActiveName(): string | null;
   getFloorName?(): string | null;
   setActive(name: string): unknown;

--- a/packages/cli/src/setup/resolve-plugins-tree.ts
+++ b/packages/cli/src/setup/resolve-plugins-tree.ts
@@ -33,9 +33,14 @@ export function providerSlot(config: MoxxyConfig): ProviderSlot {
   return config.plugins?.provider ?? {};
 }
 
-/** The active provider contribution name (defaults to `anthropic`). */
-export function providerDefault(config: MoxxyConfig): string {
-  return config.plugins?.provider?.default ?? 'anthropic';
+/**
+ * The configured active provider contribution name, or undefined when none is
+ * set. No hardcoded fallback: providers are unbundled + installed on demand, so
+ * a fresh config genuinely has no provider until `init`/`provision` writes one
+ * (the caller then runs setup rather than pointing at a missing provider).
+ */
+export function providerDefault(config: MoxxyConfig): string | undefined {
+  return config.plugins?.provider?.default;
 }
 
 /** Per-item options (model/config) for a provider, defaulting to the active one. */

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -40,7 +40,7 @@ import { jsonlEventStore } from './sessions/jsonl-event-store.js';
 import { RequirementRegistry } from './requirements.js';
 import { PermissionEngine } from './permissions/engine.js';
 import { autoAllowResolver } from './permissions/resolvers.js';
-import { evaluateToolRule } from '@moxxy/sdk';
+import { evaluateToolRule, isSelectableMode } from '@moxxy/sdk';
 import type {
   ApprovalResolver,
   CredentialResolver,
@@ -256,7 +256,7 @@ export class Session implements ClientSession, SessionRuntime {
       tools: this.tools.list().map((t) => t.name),
       agents: this.agents.list().map((a) => a.name),
       providers: this.providers.list().map((p) => p.name),
-      modes: this.modes.list().map((m) => m.name),
+      modes: this.modes.list().filter(isSelectableMode).map((m) => m.name),
       compactors: this.compactors.list().map((c) => c.name),
       channels: this.channels.list().map((c) => c.name),
     }));
@@ -516,7 +516,7 @@ export class Session implements ClientSession, SessionRuntime {
       })),
       activeMode,
       activeModeBadge,
-      modes: this.modes.list().map((m) => m.name),
+      modes: this.modes.list().filter(isSelectableMode).map((m) => m.name),
       tools: this.tools.list().map((t) => ({
         name: t.name,
         description: t.description,

--- a/packages/mode-collaborative/src/index.ts
+++ b/packages/mode-collaborative/src/index.ts
@@ -4,15 +4,18 @@ import { runCollaborativeMode } from './collab-loop.js';
 import { collabArchitectMode, collabPeerMode } from './modes.js';
 
 /**
- * @moxxy/mode-collaborative — agentic collaborative mode. The `collaborative`
- * mode is the user-selectable coordinator; `collab-architect` and `collab-peer`
- * are the internal modes the spawned agent processes run.
+ * @moxxy/mode-collaborative — agentic collaborative mode. All three modes are
+ * `special` (see {@link ModeDef.special}): the collaborative system is a
+ * separate flow entered via the `/collab` command, never picked from `/mode` —
+ * `collaborative` is the coordinator; `collab-architect`/`collab-peer` are the
+ * internal roles the spawned agent processes run (via `MOXXY_MODE`).
  */
 export const collaborativeMode: ModeDef = defineMode({
   name: COLLAB_MODE_NAME,
   description:
     'Agentic collaborative: a team of separate agents (an architect + implementers) work in parallel on one task.',
   badge: { label: 'TEAM', tone: 'attention' },
+  special: { invokedBy: 'collab' },
   run: runCollaborativeMode,
 });
 

--- a/packages/mode-collaborative/src/modes.ts
+++ b/packages/mode-collaborative/src/modes.ts
@@ -16,6 +16,8 @@ export const collabArchitectMode: ModeDef = defineMode({
   name: COLLAB_ARCHITECT_MODE_NAME,
   description: 'Collaboration architect (internal): designs the plan + shared contracts, then brokers.',
   badge: { label: 'ARCHITECT', tone: 'attention' },
+  // Internal role mode — entered via the spawned agent's MOXXY_MODE, never picked.
+  special: { invokedBy: "collab" },
   run: (ctx) => runCollabAgentLoop(ctx, { systemPrompt: COLLAB_ARCHITECT_PROMPT }),
 });
 
@@ -36,5 +38,7 @@ export const collabPeerMode: ModeDef = defineMode({
   name: COLLAB_PEER_MODE_NAME,
   description: 'Collaboration peer (internal): a team member building to the shared contracts.',
   badge: { label: 'TEAM', tone: 'attention' },
+  // Internal role mode — entered via the spawned agent's MOXXY_MODE, never picked.
+  special: { invokedBy: "collab" },
   run: (ctx) => runCollabAgentLoop(ctx, { systemPrompt: peerSystemPrompt(ctx.env) }),
 });

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -3,6 +3,7 @@ import { clearUsageStats } from '@moxxy/core';
 import { setCategoryDefault } from '@moxxy/config';
 import type { ClientSession as Session } from '@moxxy/sdk';
 import type { UserPromptAttachment } from '@moxxy/sdk';
+import { isSelectableMode } from '@moxxy/sdk';
 import type { ListPickerOption, ListPickerTab } from '../components/ListPicker.js';
 import type { Overlay, Picker } from './types.js';
 import { formatTokensShort } from './helpers.js';
@@ -490,16 +491,11 @@ function startCollab(deps: SlashDeps, arg: string): void {
   if (objective) deps.submitPrompt(objective);
 }
 
-// Collaboration is launched via `/collab <goal>` (single-flight), not the mode
-// picker; its peer modes are internal. Hidden from `/mode`.
-const COLLAB_HIDDEN_MODES: ReadonlySet<string> = new Set([
-  'collaborative',
-  'collab-architect',
-  'collab-peer',
-]);
-
 function openModePicker(deps: SlashDeps, arg = ''): void {
-  const modes = deps.session.modes.list().filter((m) => !COLLAB_HIDDEN_MODES.has(m.name));
+  const all = deps.session.modes.list();
+  // Special modes (e.g. the collaborative system, entered via /collab) are never
+  // listed or name-switched here — see ModeDef.special / isSelectableMode.
+  const modes = all.filter(isSelectableMode);
   if (modes.length === 0) {
     deps.setSystemNotice('no modes registered');
     return;
@@ -508,8 +504,14 @@ function openModePicker(deps: SlashDeps, arg = ''): void {
   // otherwise (no arg, or no match) fall back to the interactive picker.
   const target = arg.trim().toLowerCase();
   if (target) {
-    if (COLLAB_HIDDEN_MODES.has(target)) {
-      deps.setSystemNotice('Use /collab <goal> to run a collaborative team (only one runs at a time).');
+    const special = all.find((m) => m.name.toLowerCase() === target && !isSelectableMode(m));
+    if (special) {
+      const via = special.special?.invokedBy;
+      deps.setSystemNotice(
+        via
+          ? `"${special.name}" is a special mode — run /${via} to enter it.`
+          : `"${special.name}" is a special mode and can't be selected directly.`,
+      );
       return;
     }
     const match = modes.find((m) => m.name.toLowerCase() === target);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -335,6 +335,7 @@ export type {
   ModeContext,
   ModeDef,
   ModeBadge,
+  ModeSpecial,
   ElisionSettings,
   ApprovalResolver,
   ApprovalRequest,
@@ -445,7 +446,7 @@ export {
   defineWorkflowExecutor,
 } from './define.js';
 
-export { migrateModeName } from './mode.js';
+export { migrateModeName, isSelectableMode } from './mode.js';
 
 export {
   skillFrontmatterSchema,

--- a/packages/sdk/src/mode.test.ts
+++ b/packages/sdk/src/mode.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it } from 'vitest';
-import { migrateModeName } from './mode.js';
+import { migrateModeName, isSelectableMode } from './mode.js';
+
+describe('isSelectableMode', () => {
+  it('treats a plain mode (no `special`) as selectable', () => {
+    expect(isSelectableMode({ special: undefined })).toBe(true);
+    expect(isSelectableMode({})).toBe(true);
+  });
+  it('treats a special mode as NOT selectable (any descriptor, even empty)', () => {
+    expect(isSelectableMode({ special: {} })).toBe(false);
+    expect(isSelectableMode({ special: { invokedBy: 'collab' } })).toBe(false);
+  });
+  it('filters special modes out of a list, keeping plain ones', () => {
+    const modes = [
+      { name: 'default' },
+      { name: 'goal' },
+      { name: 'collaborative', special: { invokedBy: 'collab' } },
+    ];
+    expect(modes.filter(isSelectableMode).map((m) => m.name)).toEqual(['default', 'goal']);
+  });
+});
 
 describe('migrateModeName', () => {
   it('maps every legacy mode name to its current target', () => {

--- a/packages/sdk/src/mode.ts
+++ b/packages/sdk/src/mode.ts
@@ -234,9 +234,12 @@ export interface ModeSpecial {
 /**
  * Whether a mode is user-selectable — i.e. NOT a {@link ModeDef.special} mode.
  * The single predicate every surface (TUI/mobile/desktop mode lists + the
- * by-name mode-switch) uses to filter/refuse special modes uniformly.
+ * by-name mode-switch) uses to filter/refuse special modes uniformly. The
+ * parameter is intentionally loose (`{ special? }`) so it also applies to the
+ * minimal `{ name }` rows the swap-UI registries expose — non-mode defs simply
+ * carry no `special` and are always selectable.
  */
-export function isSelectableMode(mode: Pick<ModeDef, 'special'>): boolean {
+export function isSelectableMode(mode: { readonly special?: unknown }): boolean {
   return mode.special === undefined;
 }
 

--- a/packages/sdk/src/mode.ts
+++ b/packages/sdk/src/mode.ts
@@ -206,7 +206,38 @@ export interface ModeDef {
    * accent badge while this mode is active. See {@link ModeBadge}.
    */
   readonly badge?: ModeBadge;
+  /**
+   * Marks a "special" mode — one the user does NOT pick from `/mode`. Set this
+   * and the mode is, uniformly across every surface (TUI, mobile, desktop):
+   *   - **hidden** from every mode list / picker (presence), and
+   *   - **refused** by the normal mode-switch by name (execution) — it can only
+   *     be entered through its own invocation (a slash command, a spawned
+   *     agent's `MOXXY_MODE`, …) via the raw registry `setActive`.
+   * The mode stays registered + runnable; it's just never *offered* or
+   * name-switched. Extensible: any number of special modes (collaborative today,
+   * more later) opt in the same way. See {@link isSelectableMode}.
+   */
+  readonly special?: ModeSpecial;
   run(ctx: ModeContext): AsyncIterable<MoxxyEvent>;
+}
+
+/** Descriptor for a {@link ModeDef.special} mode — see that field. */
+export interface ModeSpecial {
+  /**
+   * Human-facing entry point that enters this mode, e.g. `'collab'` (the
+   * `/collab` command). Surfaced when the user tries to pick/switch it ("entered
+   * via /collab") so the UI can point at the right action.
+   */
+  readonly invokedBy?: string;
+}
+
+/**
+ * Whether a mode is user-selectable — i.e. NOT a {@link ModeDef.special} mode.
+ * The single predicate every surface (TUI/mobile/desktop mode lists + the
+ * by-name mode-switch) uses to filter/refuse special modes uniformly.
+ */
+export function isSelectableMode(mode: Pick<ModeDef, 'special'>): boolean {
+  return mode.special === undefined;
 }
 
 /**


### PR DESCRIPTION
Two slim/TUI polish items found while testing the slim CLI on a fresh `~/.moxxy`.

## 1. Fresh CLI no longer hardcodes `anthropic`
`providerDefault` returned `?? 'anthropic'` — but anthropic is now unbundled, so a fresh CLI pointed at a missing provider. Now it returns `undefined` when unset and `activate-provider` filters unset candidates, so a fresh slim CLI cleanly reports `PROVIDER_NOT_CONFIGURED` + "run `moxxy init`" (the TUI runs init automatically when there's no active provider).

## 2. Generic "special mode" mechanism
`ModeDef.special` (a `ModeSpecial` descriptor, optional `{ invokedBy }`) marks a mode entered **only via its own invocation** — never listed in a mode picker, never name-switched from `/mode`. Filtered uniformly via the new `isSelectableMode` predicate across **every surface**: `SessionInfo.modes` (mobile/desktop), the TUI `/mode` picker + by-name switch (now points the user at `/<invokedBy>`), and the `/plugins` swap axis.

The three collaborative modes (`collaborative`, `collab-architect`, `collab-peer`) opt in — collaboration is a separate system launched by `/collab` (TUI) or the desktop CollaboratePanel (`session.setMode`, deliberately left working), not a pickable mode. Extensible: future special modes set the same flag.

## Testing
`turbo build` green; sdk/core/plugin-cli/mode-collaborative suites pass (994 tests); new `isSelectableMode` unit tests. Targets `development`.