### PR TITLE
feat(tui): /plugins built-in vs installed + provider catalog

### DIFF
--- a/.changeset/plugins-view-catalog.md
+++ b/.changeset/plugins-view-catalog.md
@@ -1,0 +1,7 @@
+---
+'@moxxy/cli': minor
+'@moxxy/plugin-cli': minor
+'@moxxy/plugin-plugins-admin': minor
+---
+
+`/plugins` now distinguishes **built-in** (bundled) from **installed** (on-demand from `~/.moxxy/plugins`) packages instead of showing everything as "on": the plugin host reports `installed` (manifest present = discovered) and the Packages tab badges core / installed / built-in. The Installable catalog is also populated with the six unbundled API-key providers (anthropic, openai, google, xai, zai, local) so they can be installed from the picker (and the init optional-plugins step).

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -231,6 +231,7 @@ function wirePluginsAdminView(
         name: p.name,
         version: p.version,
         kinds: p.kinds,
+        installed: p.installed,
       })),
     disabled: () => [...disabledPackages],
     protectedPackages: () => [...CRITICAL_PACKAGES],

--- a/packages/core/src/plugins/host.test.ts
+++ b/packages/core/src/plugins/host.test.ts
@@ -96,7 +96,13 @@ describe('PluginHost', () => {
     expect(modes.list()).toHaveLength(1);
     expect(compactors.list()).toHaveLength(1);
     expect(host.list()).toEqual([
-      { name: 'demo', version: '0.0.0', loaded: true, kinds: ['provider', 'mode', 'compactor', 'tool'] },
+      {
+        name: 'demo',
+        version: '0.0.0',
+        loaded: true,
+        installed: false,
+        kinds: ['provider', 'mode', 'compactor', 'tool'],
+      },
     ]);
   });
 

--- a/packages/core/src/plugins/host.ts
+++ b/packages/core/src/plugins/host.ts
@@ -70,12 +70,20 @@ export class PluginHost implements PluginHostHandle {
     name: string;
     version: string;
     loaded: boolean;
+    /**
+     * True when this plugin was DISCOVERED from `~/.moxxy/plugins` (installed on
+     * demand), false when it was statically bundled into the binary. Discovered
+     * plugins carry a manifest (registerDiscovered); bundled ones don't
+     * (registerStatic). Lets the UI tell "built-in" from "installed".
+     */
+    installed: boolean;
     kinds: ReadonlyArray<string>;
   }> {
     return [...this.loaded.values()].map((r) => ({
       name: r.plugin.name,
       version: r.plugin.version,
       loaded: true,
+      installed: r.manifest != null,
       kinds: contributionKinds(r),
     }));
   }

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -364,17 +364,21 @@ export function openPluginsPicker(deps: OpenPluginsPickerDeps): void {
     });
   }
 
-  // 2. Enable/disable axis — every installed package, kernel ones marked.
+  // 2. Enable/disable axis — every loaded package, badged by source: a kernel
+  // `core` package (can't disable), an on-demand `installed` one (from
+  // ~/.moxxy/plugins), or a `built-in` (bundled into the binary).
   const pkgOptions: ListPickerOption[] = [];
   for (const p of [...loaded].sort((a, b) => a.name.localeCompare(b.name))) {
     const isCore = core.has(p.name);
+    const badge = isCore ? 'core' : p.installed ? 'installed' : 'built-in';
+    const badgeColor = isCore ? 'cyan' : p.installed ? 'yellow' : 'green';
     pkgOptions.push({
       // Kernel packages can't be disabled — a `::core` selection just explains why.
       id: isCore ? `${p.name}::core` : `${p.name}::disable`,
       label: shortPluginName(p.name),
       description: `${p.kinds && p.kinds.length ? p.kinds.join(', ') : 'plugin'} · @${p.version}`,
-      badge: isCore ? 'core' : 'on',
-      badgeColor: isCore ? 'cyan' : 'green',
+      badge,
+      badgeColor,
     });
   }
   for (const name of [...disabled].sort()) {

--- a/packages/plugin-plugins-admin/src/catalog.test.ts
+++ b/packages/plugin-plugins-admin/src/catalog.test.ts
@@ -9,7 +9,26 @@ import {
   resolveCatalogPackageName,
 } from './catalog.js';
 
-const entry = INSTALLABLE_PLUGIN_CATALOG[0];
+// A UI catalog entry (the action test exercises the `open` option, which is
+// UI-only). Pinning by kind keeps the test stable as catalog ordering changes.
+const entry = INSTALLABLE_PLUGIN_CATALOG.find((e) => e.kind === 'ui')!;
+
+describe('catalog: unbundled providers are installable', () => {
+  it('lists the 6 API-key providers with bare-npm install specs', () => {
+    for (const slug of ['anthropic', 'openai', 'google', 'xai', 'zai', 'local']) {
+      const pkg = `@moxxy/plugin-provider-${slug}`;
+      const e = resolveCatalogEntry(`provider-${slug}`);
+      expect(e, `provider-${slug} in catalog`).toBeDefined();
+      expect(e!.packageName).toBe(pkg);
+      // bare package name → npm latest (matches init/provision install-latest)
+      expect(e!.installSpec).toBe(pkg);
+      expect(e!.kind).toBeUndefined(); // not a UI plugin
+    }
+  });
+  it('resolves a provider by package name too', () => {
+    expect(resolveCatalogPackageName('provider-anthropic')).toBe('@moxxy/plugin-provider-anthropic');
+  });
+});
 
 describe('resolveCatalogEntry / resolveCatalogPackageName', () => {
   it('resolves by id and by package name', () => {

--- a/packages/plugin-plugins-admin/src/catalog.ts
+++ b/packages/plugin-plugins-admin/src/catalog.ts
@@ -34,6 +34,53 @@ export type PluginCatalogStatus = 'not installed' | 'installed' | 'disabled';
 /** Built-in, curated list of installable plugins. Users can also install any
  *  npm package / GitHub spec / local path directly by name. */
 export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
+  // API-key providers — NOT bundled into the binary (the kernel is slim); they
+  // install on demand from npm. `moxxy init` is the guided path (it also collects
+  // the key into the vault); installing one here drops in the package + enables
+  // it, then add its key via `moxxy init` / `/vault`. installSpec is the bare
+  // package (latest published), matching init/provision.
+  {
+    id: 'provider-anthropic',
+    label: 'Anthropic (Claude)',
+    description: 'Anthropic Claude models. Needs an API key (moxxy init or /vault).',
+    packageName: '@moxxy/plugin-provider-anthropic',
+    installSpec: '@moxxy/plugin-provider-anthropic',
+  },
+  {
+    id: 'provider-openai',
+    label: 'OpenAI (GPT)',
+    description: 'OpenAI GPT models. Needs an API key (moxxy init or /vault).',
+    packageName: '@moxxy/plugin-provider-openai',
+    installSpec: '@moxxy/plugin-provider-openai',
+  },
+  {
+    id: 'provider-google',
+    label: 'Google (Gemini)',
+    description: 'Google Gemini models. Needs an API key (moxxy init or /vault).',
+    packageName: '@moxxy/plugin-provider-google',
+    installSpec: '@moxxy/plugin-provider-google',
+  },
+  {
+    id: 'provider-xai',
+    label: 'xAI (Grok)',
+    description: 'xAI Grok models. Needs an API key (moxxy init or /vault).',
+    packageName: '@moxxy/plugin-provider-xai',
+    installSpec: '@moxxy/plugin-provider-xai',
+  },
+  {
+    id: 'provider-zai',
+    label: 'z.ai (GLM)',
+    description: 'z.ai GLM models (API + GLM Coding Plan). Needs an API key (moxxy init or /vault).',
+    packageName: '@moxxy/plugin-provider-zai',
+    installSpec: '@moxxy/plugin-provider-zai',
+  },
+  {
+    id: 'provider-local',
+    label: 'Local (Ollama)',
+    description: 'Local models via an Ollama/OpenAI-compatible server. No API key needed.',
+    packageName: '@moxxy/plugin-provider-local',
+    installSpec: '@moxxy/plugin-provider-local',
+  },
   {
     id: 'virtual-office',
     label: 'Virtual Office',

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -289,6 +289,13 @@ export interface LoadedPluginView {
   readonly version: string;
   /** Contribution categories (e.g. `['provider']`, `['tool','command']`). */
   readonly kinds: ReadonlyArray<string>;
+  /**
+   * True when discovered from `~/.moxxy/plugins` (installed on demand), false/
+   * absent when statically bundled into the binary. Lets surfaces distinguish
+   * "installed" from "built-in". Optional so a thin-client `RemoteSession` may
+   * omit it (treated as built-in).
+   */
+  readonly installed?: boolean;
 }
 
 /** One swappable contribution within a {@link CategoryView}. */


### PR DESCRIPTION
Addresses the `/plugins` feedback from TUI testing: it showed **every loaded plugin as "installed"**, and the Installable tab was nearly empty.

## Changes
- **Built-in vs installed:** the plugin host's `list()` now reports `installed` — true when a plugin was *discovered* from `~/.moxxy/plugins` (carries a manifest), false when *statically bundled*. Threaded through `LoadedPluginView` + `admin.loaded()`.
- **Badges:** the `/plugins` **Packages** tab now badges each package by source — `core` (cyan, kernel/can't-disable), `installed` (yellow, on-demand), `built-in` (green, bundled) — instead of a blanket `on`.
- **Catalog:** `INSTALLABLE_PLUGIN_CATALOG` gains the **6 unbundled API-key providers** (anthropic / openai / google / xai / zai / local) with bare-npm install specs, so they appear in the **Installable** tab and the init optional-plugins step. (The bundled OAuth providers stay loaded → filtered out of Installable automatically.)

## Testing
Gate green — `turbo build typecheck` 147 tasks, full `test` exit 0. Added unit tests: `host.list()` `installed` flag (static → false), and the provider catalog entries (bare-npm specs, not UI). Fixed the catalog test's `[0]` assumption (now finds the UI entry by kind). Targets `development`.

Built in parallel with the multi-session TUI work (separate PR).