### PR TITLE
feat(tui): multi-session switcher

### DIFF
--- a/.changeset/tui-multi-session-switcher.md
+++ b/.changeset/tui-multi-session-switcher.md
@@ -1,0 +1,20 @@
+---
+"@moxxy/plugin-cli": minor
+"@moxxy/cli": patch
+---
+
+TUI: multi-session switcher (`/sessions`).
+
+- New `/sessions` slash command (alias `/switch`) opens a `ListPicker` overlay
+  listing your saved conversations — first-prompt title, last-active time, event
+  count and active model — sourced from the same `~/.moxxy/sessions` index the
+  desktop sidebar and `moxxy resume` already read. The session you're in is
+  marked, and a leading **+ New session** entry starts a fresh conversation.
+- Picking an entry re-points the TUI onto that session in place: the live session
+  is torn down (firing its `onShutdown` hooks and releasing the runner socket),
+  the chosen session is booted (resuming its persisted history, or a fresh one),
+  and the chat view re-mounts onto it. Your previous conversation stays saved, so
+  you can switch back and forth.
+- Works when the TUI hosts the session (the default self-host / `--standalone`
+  modes). When attached to an external `moxxy serve` (whose runner owns a single
+  fixed session) the switcher degrades to a notice pointing at `moxxy resume`.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -40,6 +40,17 @@ or recorded-on-purpose decision.
   on the `moxxy mobile` runner to make it airtight. `packages/plugin-channel-mobile`.
 - [note] Stress-test multi-session with a desk's SECOND (UUID) session — the first
   session has id === desk id, which masks pool-key regressions. `packages/desktop-host`.
+- [low] TUI `/sessions` switcher only works in self-host/standalone mode (the TUI
+  owns the boot, so it can re-bootstrap onto a different session in place). In
+  ATTACH mode (thin client against an external `moxxy serve`) the runner owns a
+  single fixed session, so the switcher degrades to a notice. True attach-mode
+  switching needs a runner-side session pool (like desktop's `RunnerPool`) or a
+  spawn-a-second-runner flow; deferred as the larger architectural change.
+  `packages/cli/src/commands/run-tui.ts`, `packages/plugin-cli/src/session/sessions-picker.ts`.
+- [low] TUI `/sessions` switch re-runs the full `setupSessionWithConfig` per switch
+  (re-discovers plugins, re-fires onInit daemons for the new session). Correct but
+  not cheap; a warm-registry / session-pool reuse would make switching instant.
+  `packages/cli/src/commands/run-tui.ts`.
 
 ## Runner / protocol & architecture
 

--- a/packages/cli/src/commands/run-tui.ts
+++ b/packages/cli/src/commands/run-tui.ts
@@ -339,11 +339,78 @@ async function runSelfHostedTui(
   const updateNotice = resolveUpdateNotice(version);
 
   // Capture the resolved session + optional runner so shutdown can fire
-  // `onShutdown` hooks and release the socket.
+  // `onShutdown` hooks and release the socket. These are re-pointed in place
+  // when the user switches sessions via `/sessions` (see `switchSession`).
   let bootedSession: Session | null = null;
   let runnerServer: RunnerServer | null = null;
   let webHandle: ChannelHandle | null = null;
   let shuttingDown = false;
+  // Serializes session switches against each other and against shutdown so a
+  // switch in flight can't race a SIGINT teardown (or a second switch).
+  let switching: Promise<void> = Promise.resolve();
+
+  /**
+   * Tear down the surfaces wrapping the CURRENT session (web surface + runner
+   * socket) and close it, firing its `onShutdown` hooks. Used both by the
+   * top-level shutdown and by a session switch (which then boots a replacement).
+   */
+  const teardownCurrent = async (reason: NodeJS.Signals | 'switch' | 'normal'): Promise<void> => {
+    await webHandle?.stop('shutdown').catch(() => undefined);
+    webHandle = null;
+    await runnerServer?.close().catch(() => undefined);
+    runnerServer = null;
+    const s = bootedSession;
+    bootedSession = null;
+    if (!s) return;
+    try {
+      await s.close(reason === 'normal' ? undefined : reason);
+    } catch {
+      // Best-effort; never block on cleanup errors.
+    }
+  };
+
+  /**
+   * Boot a session (optionally resuming a persisted id) and wire its surfaces:
+   * open the runner socket (unless `--standalone`) so other clients can attach,
+   * and co-attach the web surface for `present_view`. Updates the captured refs.
+   * `onProgress` is only passed on the FIRST boot (the splash is on-screen);
+   * switches boot silently.
+   */
+  const bootSession = async (
+    opts: { resumeSessionId?: string; freshSessionId?: string },
+    progress?: (step: InteractiveBootStep) => void,
+  ): Promise<Session> => {
+    const result = await setupSessionWithConfig({
+      ...argvToSetupOptions(argv, tuiOpts.cwd ? { cwd: tuiOpts.cwd } : {}),
+      resolver,
+      ...(progress ? { onProgress: (step: BootStep) => progress(toInteractiveStep(step)) } : {}),
+      ...(opts.resumeSessionId ? { resumeSessionId: opts.resumeSessionId } : {}),
+      ...(opts.freshSessionId ? { sessionId: opts.freshSessionId } : {}),
+    });
+    bootedSession = result.session;
+    // Option A: open the socket so other clients can attach while this TUI is
+    // open. A lost race (someone else bound first) just means we run without
+    // sharing — not an error.
+    if (!standalone) {
+      try {
+        runnerServer = await startRunnerServer(result.session);
+      } catch {
+        runnerServer = null;
+      }
+    }
+    // Co-attach the web surface to THIS session so `present_view` returns a real
+    // URL (local by default — no public tunnel for the TUI). `write` is
+    // suppressed: the URL flows back through present_view → the agent's reply,
+    // and stdout would corrupt the Ink render.
+    webHandle = await coAttachWebSurface({
+      primary: 'tui',
+      session: result.session,
+      vault: result.vault,
+      config: result.config,
+      write: () => {},
+    });
+    return result.session;
+  };
 
   const shutdown = async (signal: NodeJS.Signals | 'normal'): Promise<void> => {
     if (shuttingDown) return;
@@ -355,16 +422,9 @@ async function runSelfHostedTui(
       const force = setTimeout(() => process.exit(0), 4000);
       force.unref?.();
     }
-    await webHandle?.stop('shutdown').catch(() => undefined);
-    await runnerServer?.close().catch(() => undefined);
-    const s = bootedSession;
-    bootedSession = null;
-    if (!s) return;
-    try {
-      await s.close(signal === 'normal' ? undefined : signal);
-    } catch {
-      // Best-effort; never block process exit on cleanup errors.
-    }
+    // Let an in-flight switch settle so we never close a half-booted session.
+    await switching.catch(() => undefined);
+    await teardownCurrent(signal);
   };
 
   const onSignal = (signal: NodeJS.Signals): void => {
@@ -373,42 +433,44 @@ async function runSelfHostedTui(
   process.once('SIGINT', onSignal);
   process.once('SIGTERM', onSignal);
 
+  /**
+   * `/sessions` switch: tear down the live session (firing its onShutdown
+   * hooks + releasing the socket), then boot the target — resuming its
+   * persisted log, or a fresh session (a new id is minted by setup when none is
+   * given). The TUI re-mounts onto the returned session. Serialized via
+   * `switching` so overlapping picks / a racing shutdown can't interleave.
+   */
+  const switchSession = async (
+    target: { kind: 'new' } | { kind: 'resume'; id: string },
+  ): Promise<Session> => {
+    if (shuttingDown) throw new Error('shutting down');
+    let resolveDone!: () => void;
+    const done = new Promise<void>((r) => {
+      resolveDone = r;
+    });
+    const prev = switching;
+    switching = done;
+    try {
+      await prev.catch(() => undefined);
+      if (shuttingDown) throw new Error('shutting down');
+      await teardownCurrent('switch');
+      return await bootSession(target.kind === 'resume' ? { resumeSessionId: target.id } : {});
+    } finally {
+      resolveDone();
+    }
+  };
+
   const { waitUntilExit } = render(
     React.createElement(InteractiveSession, {
-      bootstrap: async (progress: (step: InteractiveBootStep) => void) => {
-        const result = await setupSessionWithConfig({
-          ...argvToSetupOptions(argv, tuiOpts.cwd ? { cwd: tuiOpts.cwd } : {}),
-          resolver,
-          onProgress: (step: BootStep) => progress(toInteractiveStep(step)),
-          ...(tuiOpts.resumeSessionId ? { resumeSessionId: tuiOpts.resumeSessionId } : {}),
-        });
-        bootedSession = result.session;
-        // Option A: open the socket so other clients can attach while this TUI
-        // is open. A lost race (someone else bound first) just means we run
-        // without sharing - not an error.
-        if (!standalone) {
-          try {
-            runnerServer = await startRunnerServer(result.session);
-          } catch {
-            runnerServer = null;
-          }
-        }
-        // Co-attach the web surface to THIS session so `present_view` returns a
-        // real URL (local by default — no public tunnel for the TUI). `write` is
-        // suppressed: the URL flows back through present_view → the agent's reply,
-        // and stdout would corrupt the Ink render.
-        webHandle = await coAttachWebSurface({
-          primary: 'tui',
-          session: result.session,
-          vault: result.vault,
-          config: result.config,
-          write: () => {},
-        });
-        return result.session;
-      },
+      bootstrap: async (progress: (step: InteractiveBootStep) => void) =>
+        bootSession(
+          tuiOpts.resumeSessionId ? { resumeSessionId: tuiOpts.resumeSessionId } : {},
+          progress,
+        ),
       registerInteractiveResolver: (handler) => {
         promptHandler = handler;
       },
+      switchSession,
       ...(effectiveModel ? { model: effectiveModel } : {}),
       ...(version ? { version } : {}),
       ...(updateNotice ? { updateAvailable: updateNotice } : {}),

--- a/packages/plugin-cli/src/components/SlashCommands.tsx
+++ b/packages/plugin-cli/src/components/SlashCommands.tsx
@@ -40,6 +40,11 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<SlashCommand> = [
     argumentHint: '[mode]',
     aliases: ['loop'],
   },
+  {
+    name: 'sessions',
+    description: 'Switch between your conversations — opens a picker (+ new session)',
+    aliases: ['switch'],
+  },
   { name: 'mcp', description: 'Enable / disable / remove MCP servers' },
   { name: 'plugins', description: 'Plug / unplug & install plugins — opens a tabbed picker' },
   {

--- a/packages/plugin-cli/src/session/BootShell.tsx
+++ b/packages/plugin-cli/src/session/BootShell.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Box } from 'ink';
 import type { ClientSession as Session } from '@moxxy/sdk';
 import { BootScreen, type BootEvent, type BootEventId } from '../components/BootScreen.js';
@@ -7,6 +7,8 @@ import { FooterHints } from '../components/FooterHints.js';
 import { SessionView } from './SessionView.js';
 import { SystemNotice } from './OverlayOrNotice.js';
 import { useVoiceInput } from './use-voice-input.js';
+import { clearTerminalScreen } from './helpers.js';
+import type { SessionSwitchTarget } from './sessions-picker.js';
 import type { InteractiveSessionProps } from './props.js';
 
 /**
@@ -23,6 +25,7 @@ export const InteractiveSession: React.FC<InteractiveSessionProps> = ({
   version,
   updateAvailable,
   resumed,
+  switchSession,
 }) => {
   const [session, setSession] = useState<Session | null>(eagerSession ?? null);
   const [bootEvents, setBootEvents] = useState<ReadonlyArray<BootEvent>>([]);
@@ -34,7 +37,47 @@ export const InteractiveSession: React.FC<InteractiveSessionProps> = ({
   // then do we swap to the chat view — prevents the splash from
   // flashing past on fast boots.
   const [initialPrompt, setInitialPrompt] = useState<string | null>(null);
+  // True once the user has switched sessions at least once. A switched-into
+  // session always lands directly in the chat view (skips the first-prompt
+  // gate) — the user explicitly chose it, so re-typing a prompt to enter would
+  // be surprising.
+  const [landedViaSwitch, setLandedViaSwitch] = useState(false);
+  // Guards against overlapping switches (a second pick while the first is still
+  // booting). Off the render path — purely a re-entrancy latch.
+  const switchingRef = useRef(false);
+  // Surfaced as a notice on the switched-into session once it mounts.
+  const [switchNotice, setSwitchNotice] = useState<string | null>(null);
   const startedAt = React.useMemo(() => Date.now(), []);
+
+  // Resolves on a successful switch (the view re-mounts onto the new session);
+  // REJECTS on failure so the caller (SessionView's picker handler) can surface
+  // the error on the still-live session — a keyed re-mount wouldn't fire, since
+  // the session id is unchanged.
+  const handleSwitchSession = useCallback(
+    async (target: SessionSwitchTarget): Promise<void> => {
+      if (!switchSession) throw new Error('switching sessions is not available');
+      if (switchingRef.current) throw new Error('a session switch is already in progress');
+      switchingRef.current = true;
+      try {
+        const next = await switchSession(target);
+        // Wipe the prior conversation's scrollback so the switched-into session
+        // renders cleanly from the top — the old session's Static lines would
+        // otherwise linger above.
+        clearTerminalScreen();
+        setLandedViaSwitch(true);
+        setInitialPrompt(null);
+        setSwitchNotice(
+          target.kind === 'new'
+            ? 'started a new session — your previous conversation stays saved'
+            : 'switched session',
+        );
+        setSession(next);
+      } finally {
+        switchingRef.current = false;
+      }
+    },
+    [switchSession],
+  );
 
   useEffect(() => {
     if (eagerSession || !bootstrap) return;
@@ -78,9 +121,10 @@ export const InteractiveSession: React.FC<InteractiveSessionProps> = ({
   // Splash phase: render the BootScreen until the user submits the
   // first prompt. The input unlocks the moment a session resolves; the
   // submission flips us into the chat view AND becomes the first turn.
-  // Resumed sessions skip the splash entirely — the user wants to land
-  // back in their conversation without re-typing anything.
-  if (!session || (initialPrompt == null && !resumed)) {
+  // Resumed sessions (and sessions reached via the /sessions switcher)
+  // skip the splash entirely — the user wants to land back in their
+  // conversation without re-typing anything.
+  if (!session || (initialPrompt == null && !resumed && !landedViaSwitch)) {
     return (
       <Box flexDirection="column">
         <BootScreen
@@ -109,13 +153,20 @@ export const InteractiveSession: React.FC<InteractiveSessionProps> = ({
   }
 
   return (
+    // Key by session id so switching fully re-mounts the view — every
+    // session-keyed hook (event stream, turn runner, permission queue) resets to
+    // the new session instead of carrying the prior one's state across.
     <SessionView
+      key={session.id}
       session={session}
       registerInteractiveResolver={registerInteractiveResolver}
       {...(initialPrompt ? { initialPrompt } : {})}
+      {...(switchNotice ? { initialNotice: switchNotice } : {})}
       {...(model ? { model } : {})}
       {...(version ? { version } : {})}
       {...(updateAvailable ? { updateAvailable } : {})}
+      canSwitchSession={Boolean(switchSession)}
+      onSwitchSession={handleSwitchSession}
     />
   );
 };

--- a/packages/plugin-cli/src/session/InteractiveZone.tsx
+++ b/packages/plugin-cli/src/session/InteractiveZone.tsx
@@ -104,6 +104,10 @@ export const InteractiveZone: React.FC<InteractiveZoneProps> = ({
       <ListPicker
         title={picker.title}
         options={picker.options}
+        {...(picker.kind === 'sessions' && picker.searchable ? { searchable: true } : {})}
+        {...(picker.kind === 'sessions' && picker.searchPlaceholder
+          ? { searchPlaceholder: picker.searchPlaceholder }
+          : {})}
         onSelect={(id) => onPickerSelect(picker, id)}
         onCancel={onPickerCancel}
       />

--- a/packages/plugin-cli/src/session/SessionView.tsx
+++ b/packages/plugin-cli/src/session/SessionView.tsx
@@ -29,6 +29,7 @@ import { OverlayOrNotice } from './OverlayOrNotice.js';
 import { InteractiveZone } from './InteractiveZone.js';
 import type { InteractiveSessionProps } from './props.js';
 import type { Overlay, Picker } from './types.js';
+import type { SessionSwitchTarget } from './sessions-picker.js';
 
 interface SessionViewProps {
   readonly session: Session;
@@ -42,6 +43,22 @@ interface SessionViewProps {
    * have to retype it after the view transitions.
    */
   readonly initialPrompt?: string;
+  /**
+   * One-shot notice shown when the view mounts (e.g. "switched session"). Unlike
+   * `initialPrompt` it doesn't start a turn — it just seeds the notice strip.
+   */
+  readonly initialNotice?: string;
+  /**
+   * Whether the host can re-bootstrap onto a different session. Gates whether
+   * `/sessions` opens the switcher (true) or shows a degrade notice (false).
+   */
+  readonly canSwitchSession?: boolean;
+  /**
+   * Ask the host to switch the TUI onto another session. BootShell owns the
+   * session state + re-mount; this resolves on success and rejects on failure so
+   * the picker handler can surface the error on the still-live session.
+   */
+  readonly onSwitchSession?: (target: SessionSwitchTarget) => Promise<void>;
 }
 
 export const SessionView: React.FC<SessionViewProps> = ({
@@ -51,10 +68,13 @@ export const SessionView: React.FC<SessionViewProps> = ({
   version,
   updateAvailable,
   initialPrompt,
+  initialNotice,
+  canSwitchSession,
+  onSwitchSession,
 }) => {
   const { exit } = useApp();
   const stream = useEventStream(session);
-  const [systemNotice, setSystemNotice] = useState<string | null>(null);
+  const [systemNotice, setSystemNotice] = useState<string | null>(initialNotice ?? null);
   // Structured ephemeral overlay (mutually exclusive with systemNotice).
   // /skills and /tools render through here so they get full-color
   // typography instead of being squeezed into the yellow notice strip.
@@ -187,8 +207,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
         setSystemNotice,
         setActiveModelOverride,
         refreshMcpStatus,
+        ...(onSwitchSession ? { requestSessionSwitch: onSwitchSession } : {}),
       }),
-    [session, providerName, refreshMcpStatus],
+    [session, providerName, refreshMcpStatus, onSwitchSession],
   );
 
   // Channel-side handler for `session-action` outputs returned by
@@ -269,6 +290,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
         queueRef: turn.queueRef,
         setQueueCount: turn.setQueueCount,
         performSessionAction,
+        canSwitchSession: canSwitchSession ?? false,
         // Start a turn directly (e.g. /goal kicking off autonomous work)
         // without clearing the just-set system notice. Objectives are plain
         // text, so no image-attachment resolution is needed.

--- a/packages/plugin-cli/src/session/picker-handlers.test.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { makePickerHandler, type PickerHandlerDeps } from './picker-handlers.js';
+import { NEW_SESSION_OPTION_ID } from './sessions-picker.js';
+
+// picker-handlers imports setCategoryDefault/setProviderModel from @moxxy/config
+// and re-open helpers from run-slash; stub both so the session branch tests stay
+// isolated from the filesystem and the other picker flows.
+vi.mock('@moxxy/config', () => ({
+  setCategoryDefault: vi.fn(async () => undefined),
+  setProviderModel: vi.fn(async () => undefined),
+}));
+vi.mock('./run-slash.js', () => ({
+  openMcpPicker: vi.fn(),
+  openPluginsPicker: vi.fn(),
+}));
+
+function baseDeps(over: Partial<PickerHandlerDeps> = {}): PickerHandlerDeps {
+  return {
+    session: { id: 'sess-current' },
+    providerName: 'openai',
+    setPicker: vi.fn(),
+    setSystemNotice: vi.fn(),
+    setActiveModelOverride: vi.fn(),
+    refreshMcpStatus: vi.fn(async () => undefined),
+    ...over,
+  } as unknown as PickerHandlerDeps;
+}
+
+const sessionsPicker = { kind: 'sessions', title: 'Switch session', options: [] } as const;
+
+describe('makePickerHandler — sessions branch', () => {
+  it('requests a resume switch for a persisted session id', () => {
+    const requestSessionSwitch = vi.fn(async () => undefined);
+    const setPicker = vi.fn();
+    const handle = makePickerHandler(baseDeps({ requestSessionSwitch, setPicker }));
+    handle(sessionsPicker, 'sess-other');
+    expect(setPicker).toHaveBeenCalledWith(null); // picker dismissed
+    expect(requestSessionSwitch).toHaveBeenCalledWith({ kind: 'resume', id: 'sess-other' });
+  });
+
+  it('requests a fresh session for the new-session entry', () => {
+    const requestSessionSwitch = vi.fn(async () => undefined);
+    const handle = makePickerHandler(baseDeps({ requestSessionSwitch }));
+    handle(sessionsPicker, NEW_SESSION_OPTION_ID);
+    expect(requestSessionSwitch).toHaveBeenCalledWith({ kind: 'new' });
+  });
+
+  it('no-ops (with a notice) when picking the session you are already in', () => {
+    const requestSessionSwitch = vi.fn(async () => undefined);
+    const setSystemNotice = vi.fn();
+    const handle = makePickerHandler(baseDeps({ requestSessionSwitch, setSystemNotice }));
+    handle(sessionsPicker, 'sess-current');
+    expect(requestSessionSwitch).not.toHaveBeenCalled();
+    expect(setSystemNotice).toHaveBeenCalledWith("you're already in that session");
+  });
+
+  it('surfaces a switch failure on the still-live session', async () => {
+    const requestSessionSwitch = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const setSystemNotice = vi.fn();
+    const handle = makePickerHandler(baseDeps({ requestSessionSwitch, setSystemNotice }));
+    handle(sessionsPicker, 'sess-other');
+    await new Promise((r) => setImmediate(r));
+    expect(setSystemNotice).toHaveBeenCalledWith('failed to switch session: boom');
+  });
+
+  it('reports gracefully when no switch capability is wired', () => {
+    const setSystemNotice = vi.fn();
+    const handle = makePickerHandler(baseDeps({ setSystemNotice }));
+    handle(sessionsPicker, 'sess-other');
+    expect(setSystemNotice).toHaveBeenCalledWith(
+      'switching sessions is not available on this session',
+    );
+  });
+});

--- a/packages/plugin-cli/src/session/picker-handlers.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.ts
@@ -2,6 +2,7 @@ import type { ClientSession as Session } from '@moxxy/sdk';
 import { setCategoryDefault, setProviderModel } from '@moxxy/config';
 import type { Picker } from './types.js';
 import { openMcpPicker, openPluginsPicker } from './run-slash.js';
+import { NEW_SESSION_OPTION_ID, type SessionSwitchTarget } from './sessions-picker.js';
 
 export interface PickerHandlerDeps {
   session: Session;
@@ -10,6 +11,12 @@ export interface PickerHandlerDeps {
   setSystemNotice: (msg: string | null) => void;
   setActiveModelOverride: (id: string) => void;
   refreshMcpStatus: () => Promise<void>;
+  /**
+   * Re-point the TUI onto a different session. Provided by BootShell (it owns
+   * the session state + re-mount); resolves on success, rejects on failure.
+   * Absent ⇒ `/sessions` never opened a picker, so this branch is unreachable.
+   */
+  requestSessionSwitch?: (target: SessionSwitchTarget) => Promise<void>;
 }
 
 export function makePickerHandler(deps: PickerHandlerDeps): (picker: Picker, id: string) => void {
@@ -32,7 +39,39 @@ export function makePickerHandler(deps: PickerHandlerDeps): (picker: Picker, id:
     if (kind === 'plugins') {
       return handlePluginAction(id, deps);
     }
+    if (kind === 'sessions') {
+      return handleSessionSelected(id, deps);
+    }
   };
+}
+
+/**
+ * Apply a `/sessions` picker selection. The synthetic "+ New session" entry
+ * boots a fresh session; any other id resumes that persisted session. Picking
+ * the session you're already in is a no-op (avoids a pointless re-bootstrap).
+ * The actual switch — closing the live session, re-pointing the runner socket,
+ * booting the new one — is the host's job (BootShell's `requestSessionSwitch`).
+ */
+function handleSessionSelected(id: string, deps: PickerHandlerDeps): void {
+  const requestSwitch = deps.requestSessionSwitch;
+  if (!requestSwitch) {
+    deps.setSystemNotice('switching sessions is not available on this session');
+    return;
+  }
+  if (id === deps.session.id) {
+    deps.setSystemNotice("you're already in that session");
+    return;
+  }
+  const target: SessionSwitchTarget =
+    id === NEW_SESSION_OPTION_ID ? { kind: 'new' } : { kind: 'resume', id };
+  deps.setSystemNotice(id === NEW_SESSION_OPTION_ID ? 'starting a new session…' : 'switching…');
+  // On success the view re-mounts onto the new session (this strip is gone); on
+  // failure the current session stays and we surface the error here.
+  void requestSwitch(target).catch((err: unknown) => {
+    deps.setSystemNotice(
+      `failed to switch session: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  });
 }
 
 /**

--- a/packages/plugin-cli/src/session/props.ts
+++ b/packages/plugin-cli/src/session/props.ts
@@ -4,6 +4,7 @@ import type {
   PermissionDecision,
 } from '@moxxy/sdk';
 import type { ClientSession as Session } from '@moxxy/sdk';
+import type { SwitchSession } from './sessions-picker.js';
 
 /**
  * Generic shape of a boot-progress step. We keep this loose so the
@@ -59,4 +60,15 @@ export interface InteractiveSessionProps {
    * without the user having to type a first prompt.
    */
   readonly resumed?: boolean;
+  /**
+   * Host capability that re-points the TUI onto a different session (or a fresh
+   * one) in place: it closes the live session, re-opens the runner socket for
+   * the new one, and resolves with the new `Session` to re-mount onto. Powers
+   * the `/sessions` switcher.
+   *
+   * Omit it on transports that can't re-bootstrap in place (a thin client
+   * attached to an external `moxxy serve`, whose runner owns a single fixed
+   * session); `/sessions` then degrades to an explanatory notice.
+   */
+  readonly switchSession?: SwitchSession;
 }

--- a/packages/plugin-cli/src/session/run-slash.test.ts
+++ b/packages/plugin-cli/src/session/run-slash.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import { runSlash, type SlashDeps } from './run-slash.js';
 
-// run-slash.ts imports clearUsageStats from @moxxy/core and setCategoryDefault
-// from @moxxy/config; stub them so /goal's mode-default persist doesn't touch
-// ~/.moxxy during the unit test.
+// run-slash.ts imports clearUsageStats/readSessionIndex from @moxxy/core and
+// setCategoryDefault from @moxxy/config; stub them so /goal's mode-default
+// persist and /sessions' index read don't touch ~/.moxxy during the unit test.
+const sessionIndex = vi.hoisted(() => ({ value: [] as unknown[] }));
 vi.mock('@moxxy/core', () => ({
   clearUsageStats: vi.fn(async () => undefined),
+  readSessionIndex: vi.fn(async () => sessionIndex.value),
 }));
 vi.mock('@moxxy/config', () => ({
   setCategoryDefault: vi.fn(async () => undefined),
@@ -123,6 +125,66 @@ describe('runSlash dispatch safety', () => {
       setOverlay: (o) => overlays.push(typeof o === 'function' ? o(null) : o),
     } as unknown as SlashDeps);
     expect(overlays).toContainEqual({ kind: 'tools' });
+  });
+});
+
+describe('runSlash /sessions', () => {
+  it('degrades to a notice when the host cannot switch sessions', () => {
+    const notices: Array<string | null> = [];
+    const pickers: unknown[] = [];
+    runSlash('/sessions', {
+      ...baseDeps(),
+      canSwitchSession: false,
+      setSystemNotice: (n) => notices.push(n),
+      setPicker: (p) => pickers.push(p),
+    } as unknown as SlashDeps);
+    // No async index read / picker open on the degrade path.
+    expect(pickers).toEqual([]);
+    expect(notices.some((n) => typeof n === 'string' && /only available/.test(n))).toBe(true);
+  });
+
+  it('opens a sessions picker (with a new-session entry) when switching is available', async () => {
+    sessionIndex.value = [
+      {
+        id: 'sess-current',
+        cwd: '/x',
+        startedAt: new Date().toISOString(),
+        lastActivity: new Date().toISOString(),
+        eventCount: 4,
+        firstPrompt: 'fix the bug',
+        provider: 'openai',
+        model: 'gpt-test',
+      },
+      {
+        id: 'sess-other',
+        cwd: '/y',
+        startedAt: new Date().toISOString(),
+        lastActivity: new Date().toISOString(),
+        eventCount: 2,
+        firstPrompt: 'write docs',
+        provider: 'openai',
+        model: 'gpt-test',
+      },
+    ];
+    const pickers: unknown[] = [];
+    runSlash('/sessions', {
+      ...baseDeps(),
+      session: { id: 'sess-current', commands: { get: () => undefined } },
+      canSwitchSession: true,
+      setPicker: (p) => pickers.push(p),
+    } as unknown as SlashDeps);
+    // openSessionsPicker reads the index asynchronously, then sets the picker.
+    await new Promise((r) => setImmediate(r));
+    expect(pickers).toHaveLength(1);
+    const picker = pickers[0] as {
+      kind: string;
+      options: Array<{ id: string; current?: boolean }>;
+    };
+    expect(picker.kind).toBe('sessions');
+    // "+ New session" first, then the two persisted ones; current marked.
+    expect(picker.options[0]!.id).toBe('__new__');
+    expect(picker.options.find((o) => o.id === 'sess-current')!.current).toBe(true);
+    expect(picker.options.map((o) => o.id)).toContain('sess-other');
   });
 });
 

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { clearUsageStats } from '@moxxy/core';
+import { clearUsageStats, readSessionIndex } from '@moxxy/core';
 import { setCategoryDefault } from '@moxxy/config';
 import type { ClientSession as Session } from '@moxxy/sdk';
 import type { UserPromptAttachment } from '@moxxy/sdk';
@@ -7,6 +7,7 @@ import { isSelectableMode } from '@moxxy/sdk';
 import type { ListPickerOption, ListPickerTab } from '../components/ListPicker.js';
 import type { Overlay, Picker } from './types.js';
 import { formatTokensShort } from './helpers.js';
+import { buildSessionPickerOptions } from './sessions-picker.js';
 
 export interface SlashDeps {
   session: Session;
@@ -23,6 +24,13 @@ export interface SlashDeps {
   /** Start a turn with the given text (used by /goal to kick off autonomous
    *  work immediately). Does not clear the system notice, unlike handleSubmit. */
   submitPrompt: (text: string) => void;
+  /**
+   * Whether the host can re-bootstrap onto a different session. Gates whether
+   * `/sessions` opens the switcher or shows a degrade notice. `false` on a thin
+   * client attached to an external `moxxy serve` (its runner owns a single fixed
+   * session).
+   */
+  canSwitchSession?: boolean;
 }
 
 export function runSlash(cmd: string, deps: SlashDeps): void {
@@ -118,6 +126,9 @@ export function runSlash(cmd: string, deps: SlashDeps): void {
       return;
     case 'model':
       return openModelPicker(deps);
+    case 'sessions':
+    case 'switch':
+      return openSessionsPicker(deps);
     case 'mcp':
       return openMcpPicker(deps);
     case 'mode':
@@ -236,6 +247,54 @@ function openModelPicker(deps: SlashDeps): void {
       searchable: true,
       searchPlaceholder: 'filter models…',
     });
+  })();
+}
+
+/** Subset of deps `openSessionsPicker` touches. Exported so picker-handlers can
+ *  re-open the switcher (e.g. after a failed switch) without dragging in all of
+ *  SlashDeps. */
+export interface OpenSessionsPickerDeps {
+  session: Session;
+  setPicker: (p: Picker) => void;
+  setSystemNotice: (msg: string | null) => void;
+  canSwitchSession?: boolean;
+}
+
+/**
+ * `/sessions` — the multi-session switcher. Lists the persisted sessions (from
+ * the same `~/.moxxy/sessions` index the desktop sidebar and `moxxy resume`
+ * read) with their first-prompt title, last-active time and event count, marks
+ * the one you're in, and offers a "+ New session" entry. Picking one re-points
+ * the TUI onto that session via the host's switch capability.
+ *
+ * Degrades to a notice when `canSwitchSession` is false (a thin client attached
+ * to an external `moxxy serve`, whose runner owns a single fixed session): the
+ * user is told to start a separate `moxxy tui` or use `moxxy resume`.
+ */
+export function openSessionsPicker(deps: OpenSessionsPickerDeps): void {
+  if (!deps.canSwitchSession) {
+    deps.setSystemNotice(
+      'switching sessions is only available when this TUI hosts the session. ' +
+        "You're attached to a running `moxxy serve` — run `moxxy resume` in a separate terminal to open another.",
+    );
+    return;
+  }
+  void (async () => {
+    try {
+      const metas = await readSessionIndex();
+      const options = buildSessionPickerOptions(metas, deps.session.id);
+      deps.setPicker({
+        kind: 'sessions',
+        title: 'Switch session',
+        options,
+        searchable: true,
+        searchPlaceholder: 'filter sessions…',
+      });
+    } catch (err) {
+      deps.setSystemNotice(
+        `failed to list sessions: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   })();
 }
 

--- a/packages/plugin-cli/src/session/sessions-picker.test.ts
+++ b/packages/plugin-cli/src/session/sessions-picker.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionMeta } from '@moxxy/core';
+import {
+  buildSessionPickerOptions,
+  formatAgo,
+  NEW_SESSION_OPTION_ID,
+} from './sessions-picker.js';
+
+function meta(over: Partial<SessionMeta> & { id: string }): SessionMeta {
+  return {
+    cwd: '/repo',
+    startedAt: '2026-06-25T11:00:00.000Z',
+    lastActivity: '2026-06-25T12:00:00.000Z',
+    eventCount: 3,
+    firstPrompt: 'do a thing',
+    provider: 'openai',
+    model: 'gpt-test',
+    ...over,
+  };
+}
+
+describe('buildSessionPickerOptions', () => {
+  const NOW = Date.parse('2026-06-25T12:00:30.000Z');
+
+  it('always leads with a "new session" entry', () => {
+    const opts = buildSessionPickerOptions([], 'none', NOW);
+    expect(opts[0]!.id).toBe(NEW_SESSION_OPTION_ID);
+    expect(opts).toHaveLength(1);
+  });
+
+  it('marks the active session current with an "active" badge', () => {
+    const opts = buildSessionPickerOptions(
+      [meta({ id: 'a' }), meta({ id: 'b' })],
+      'b',
+      NOW,
+    );
+    const a = opts.find((o) => o.id === 'a')!;
+    const b = opts.find((o) => o.id === 'b')!;
+    expect(b.current).toBe(true);
+    expect(b.badge).toBe('active');
+    expect(a.current).toBeUndefined();
+    expect(a.badge).toBeUndefined();
+  });
+
+  it('uses the first prompt as the title and shows last-active + event count + model', () => {
+    const opts = buildSessionPickerOptions(
+      [meta({ id: 'a', firstPrompt: 'fix the login bug', eventCount: 7, model: 'gpt-test' })],
+      'other',
+      NOW,
+    );
+    const a = opts.find((o) => o.id === 'a')!;
+    expect(a.label).toBe('fix the login bug');
+    expect(a.description).toContain('7 ev');
+    expect(a.description).toContain('gpt-test');
+    expect(a.description).toContain('ago');
+  });
+
+  it('prefers a user-set title (rename) over the first prompt', () => {
+    const opts = buildSessionPickerOptions(
+      [meta({ id: 'a', title: 'Login work', firstPrompt: 'fix the login bug' })],
+      'other',
+      NOW,
+    );
+    expect(opts.find((o) => o.id === 'a')!.label).toBe('Login work');
+  });
+
+  it('truncates an over-long title to 60 chars with an ellipsis', () => {
+    const long = 'x'.repeat(120);
+    const opts = buildSessionPickerOptions([meta({ id: 'a', firstPrompt: long })], 'other', NOW);
+    const label = opts.find((o) => o.id === 'a')!.label;
+    expect(label.length).toBe(60);
+    expect(label.endsWith('…')).toBe(true);
+  });
+
+  it('hides empty non-active sessions but keeps an empty ACTIVE one', () => {
+    const opts = buildSessionPickerOptions(
+      [
+        meta({ id: 'empty-other', firstPrompt: null, eventCount: 0 }),
+        meta({ id: 'empty-active', firstPrompt: null, eventCount: 0 }),
+      ],
+      'empty-active',
+      NOW,
+    );
+    expect(opts.find((o) => o.id === 'empty-other')).toBeUndefined();
+    const active = opts.find((o) => o.id === 'empty-active')!;
+    expect(active).toBeDefined();
+    expect(active.label).toBe('(empty session)');
+  });
+
+  it('preserves the input order (newest-first as readSessionIndex returns)', () => {
+    const opts = buildSessionPickerOptions(
+      [meta({ id: 'newest' }), meta({ id: 'older' })],
+      'x',
+      NOW,
+    );
+    const ids = opts.filter((o) => o.id !== NEW_SESSION_OPTION_ID).map((o) => o.id);
+    expect(ids).toEqual(['newest', 'older']);
+  });
+});
+
+describe('formatAgo', () => {
+  const NOW = Date.parse('2026-06-25T12:00:00.000Z');
+  it('formats seconds / minutes / hours / days', () => {
+    expect(formatAgo('2026-06-25T11:59:30.000Z', NOW)).toBe('30s ago');
+    expect(formatAgo('2026-06-25T11:30:00.000Z', NOW)).toBe('30m ago');
+    expect(formatAgo('2026-06-25T09:00:00.000Z', NOW)).toBe('3h ago');
+    expect(formatAgo('2026-06-22T12:00:00.000Z', NOW)).toBe('3d ago');
+  });
+  it('returns the raw string for an unparseable timestamp', () => {
+    expect(formatAgo('not-a-date', NOW)).toBe('not-a-date');
+  });
+});

--- a/packages/plugin-cli/src/session/sessions-picker.ts
+++ b/packages/plugin-cli/src/session/sessions-picker.ts
@@ -1,0 +1,97 @@
+import type { SessionMeta } from '@moxxy/core';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import type { ListPickerOption } from '../components/ListPicker.js';
+
+/**
+ * What the TUI asks the host to switch to. `{ kind: 'new' }` boots a fresh
+ * session (empty log); `{ kind: 'resume', id }` re-bootstraps the host onto the
+ * persisted session with that id (seeding its event log from disk).
+ */
+export type SessionSwitchTarget = { kind: 'new' } | { kind: 'resume'; id: string };
+
+/**
+ * Host-provided capability the TUI calls when the user picks an entry in the
+ * `/sessions` switcher. The host owns the heavy lifting (closing the live
+ * session, re-pointing the runner socket, booting the new one) and resolves with
+ * the new `Session` the view should re-mount onto. Rejecting leaves the current
+ * session in place (the switcher surfaces the error as a notice).
+ *
+ * Absent on transports that can't re-bootstrap in place (e.g. a thin client
+ * attached to an external `moxxy serve`, whose runner owns a single fixed
+ * session) — there the switcher degrades to an explanatory notice.
+ */
+export type SwitchSession = (target: SessionSwitchTarget) => Promise<Session>;
+
+/** Synthetic option id for the "start a new session" entry. */
+export const NEW_SESSION_OPTION_ID = '__new__';
+
+/** Max chars of a first-prompt title shown in the picker row. */
+const TITLE_MAX = 60;
+
+/**
+ * Build the `ListPicker` options for the `/sessions` switcher from the persisted
+ * session index. Pure (no I/O) so it's unit-testable: the caller passes the
+ * already-read `SessionMeta[]` (newest-first, the order `readSessionIndex`
+ * returns) plus the id of the session the TUI is currently driving.
+ *
+ *  - The active session is marked `current` and badged `active` so it's obvious
+ *    which conversation you're in.
+ *  - Empty sessions (0 events, no first prompt) are dropped as noise — they're
+ *    the throwaway probe/boot artifacts the resume picker also hides, EXCEPT the
+ *    active one, which is always shown even when brand-new so the user can see
+ *    where they are.
+ *  - A leading "+ New session" entry boots a fresh conversation.
+ */
+export function buildSessionPickerOptions(
+  metas: ReadonlyArray<SessionMeta>,
+  activeId: string,
+  now: number = Date.now(),
+): ListPickerOption[] {
+  const options: ListPickerOption[] = [
+    {
+      id: NEW_SESSION_OPTION_ID,
+      label: '+ New session',
+      description: 'start a fresh conversation (the current one stays saved)',
+    },
+  ];
+  for (const m of metas) {
+    const isActive = m.id === activeId;
+    // Drop empty non-active sessions: a session with no first prompt and no
+    // events is a boot artifact, not something the user wants to resume.
+    if (!isActive && (m.firstPrompt == null || m.firstPrompt.trim() === '') && m.eventCount === 0) {
+      continue;
+    }
+    options.push({
+      id: m.id,
+      label: titleFor(m),
+      description: describe(m, now),
+      ...(isActive ? { current: true, badge: 'active', badgeColor: 'green' as const } : {}),
+    });
+  }
+  return options;
+}
+
+function titleFor(m: SessionMeta): string {
+  const raw = m.title?.trim() || m.firstPrompt?.trim();
+  if (!raw) return '(empty session)';
+  const oneLine = raw.replace(/\s+/g, ' ');
+  return oneLine.length > TITLE_MAX ? `${oneLine.slice(0, TITLE_MAX - 1)}…` : oneLine;
+}
+
+function describe(m: SessionMeta, now: number): string {
+  const when = formatAgo(m.lastActivity, now);
+  const events = `${m.eventCount} ev`;
+  const provider = m.model ?? m.provider;
+  return provider ? `${when} · ${events} · ${provider}` : `${when} · ${events}`;
+}
+
+/** Compact "Ns/Nm/Nh/Nd ago" — mirrors the `moxxy sessions list` formatting. */
+export function formatAgo(iso: string, now: number = Date.now()): string {
+  const then = Date.parse(iso);
+  if (!Number.isFinite(then)) return iso;
+  const diffSec = Math.max(0, Math.floor((now - then) / 1000));
+  if (diffSec < 60) return `${diffSec}s ago`;
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+  if (diffSec < 86_400) return `${Math.floor(diffSec / 3600)}h ago`;
+  return `${Math.floor(diffSec / 86_400)}d ago`;
+}

--- a/packages/plugin-cli/src/session/types.ts
+++ b/packages/plugin-cli/src/session/types.ts
@@ -27,6 +27,13 @@ export type Picker =
     }
   | { kind: 'mode'; title: string; options: ReadonlyArray<ListPickerOption> }
   | {
+      kind: 'sessions';
+      title: string;
+      options: ReadonlyArray<ListPickerOption>;
+      searchable?: boolean;
+      searchPlaceholder?: string;
+    }
+  | {
       kind: 'plugins';
       title: string;
       tabs: ReadonlyArray<ListPickerTab>;


### PR DESCRIPTION
## What

A **multi-session view/switcher for the moxxy TUI**: a new `/sessions` slash command (alias `/switch`) opens a `ListPicker` overlay of your saved conversations and switches the TUI onto the chosen session in place — like the desktop app's per-workspace session switcher, but in one terminal process.

Picking an entry:
- lists every saved session (first-prompt title / rename, last-active, event count, active model), marks the one you're in, and offers a leading **+ New session** entry;
- tears down the live session (firing its `onShutdown` hooks + releasing the runner socket), boots the chosen one (resuming its persisted history, or a fresh session), and re-mounts the chat view onto it;
- your previous conversation stays saved, so you can switch back and forth.

## How it reuses the existing model (no new protocol)

The runner is **1:1 with a session** — there is no multi-session enumeration over the runner protocol. The desktop achieves multi-session via a `RunnerPool` (one runner *process* per session) + the file-based session index; that pool lives in the Electron main process and isn't reusable in a single TUI process.

So this switcher reuses the TUI's own primitives instead of inventing a runner-level multiplex:
- **list** = `readSessionIndex()` from `@moxxy/core` — the *same* `SessionMeta[]` index the desktop sidebar and `moxxy resume` already read from `~/.moxxy/sessions`;
- **switch** = re-bootstrap a local `Session` via `setupSessionWithConfig({ resumeSessionId })` — the *same* path `moxxy resume` uses — then re-point the runner socket + web surface onto it.

## Key files

- `packages/plugin-cli/src/session/sessions-picker.ts` — pure `SessionMeta[] → ListPickerOption[]` builder + `SessionSwitchTarget`/`SwitchSession` contract (unit-tested).
- `packages/plugin-cli/src/session/run-slash.ts` — `/sessions` opens the picker when the host can re-bootstrap; degrades to a notice otherwise.
- `packages/plugin-cli/src/session/picker-handlers.ts` — session-selection branch (new / resume / already-here / failure handling).
- `packages/plugin-cli/src/session/BootShell.tsx` — owns the switch: tears down the live session, boots the target, re-mounts `SessionView` keyed by `session.id` so every session-keyed hook resets cleanly. Failures surface on the still-live session.
- `packages/cli/src/commands/run-tui.ts` (self-host path) — provides `switchSession`: serialized boot/teardown that re-points the runner socket + web surface; serialized against SIGINT so a switch can't race shutdown.

## What's done vs deferred

**Done:** list + switch among the runner's persisted sessions, in **self-host / `--standalone`** mode (the TUI owns the boot, so it can re-bootstrap in place). New-session and resume both work; the active session is marked.

**Deferred (logged in `TECH_DEBT.md`):**
- **Attach mode** (thin client against an external `moxxy serve`): the external runner owns a single fixed session, so the switcher degrades to a notice pointing at `moxxy resume`. True attach-mode switching needs a runner-side session pool (like desktop's `RunnerPool`) or a spawn-a-second-runner flow — the larger architectural change the brief said to avoid forcing.
- Each switch re-runs the full `setupSessionWithConfig` (re-discovers plugins, re-fires onInit daemons). Correct but not instant; a warm-registry / pool reuse would make switching cheap.

## Tests

- `sessions-picker.test.ts` — title/rename/truncation, active badge, empty-session hiding, ordering, `formatAgo`.
- `picker-handlers.test.ts` — new / resume / already-here / failure / no-capability branches.
- `run-slash.test.ts` — `/sessions` degrade-vs-open paths.

## Gate

- `pnpm -w typecheck` ✅ (139 tasks)
- `@moxxy/plugin-cli` build ✅ + 225 tests ✅; `@moxxy/cli` build ✅ + 266 tests ✅
- eslint on changed files: 0 errors

> Note: `pnpm build` currently fails on `@moxxy/desktop` with `Rollup failed to resolve import "yaml" from desktop-host/dist/ipc/workflows.js` — this is **pre-existing on `development`** (the `yaml` import predates this branch; this PR touches no desktop / desktop-host / workflows file) and is unrelated to the TUI change.

Changeset: `@moxxy/plugin-cli` minor, `@moxxy/cli` patch.
