### PR TITLE
fix(tui): hide special modes from Shift+Tab + load history on session switch

### DIFF
--- a/.changeset/fix-tui-secret-modes-session-history.md
+++ b/.changeset/fix-tui-secret-modes-session-history.md
@@ -1,0 +1,17 @@
+---
+"@moxxy/cli": patch
+---
+
+fix(tui): hide special modes from Shift+Tab + load history on session switch
+
+- **Secret modes leaked into Shift+Tab.** The Shift+Tab mode cycle used the raw
+  mode registry, so special modes (e.g. `collaborative`, entered via `/collab`)
+  showed up in the cycle. It now filters with `isSelectableMode`, matching the
+  `/mode` picker. The Telegram `/mode` picker and its by-name callback are
+  hardened the same way (special modes are never offered or name-switched).
+- **Session switch didn't load history.** Switching sessions in the TUI (and
+  `--resume`) changed the active session but rendered an empty chat body —
+  `bootSession` seeds the new `EventLog` directly, which doesn't fire
+  subscribers, so `useEventStream` (which only listened for future appends)
+  showed nothing while the status-line token count was correct. It now seeds the
+  renderer from the history the log already holds.

--- a/packages/plugin-cli/src/session/SessionView.tsx
+++ b/packages/plugin-cli/src/session/SessionView.tsx
@@ -3,6 +3,7 @@ import { Box } from 'ink';
 import { useApp } from 'ink';
 import type { UserPromptAttachment } from '@moxxy/sdk';
 import type { ClientSession as Session } from '@moxxy/sdk';
+import { isSelectableMode } from '@moxxy/sdk';
 import { setCategoryDefault } from '@moxxy/config';
 import { ChatView } from '../components/ChatView.js';
 import { StatusLine } from '../components/StatusLine.js';
@@ -177,7 +178,10 @@ export const SessionView: React.FC<SessionViewProps> = ({
   // survives across sessions. setSystemNotice forces the re-render that
   // refreshes the footer's mode label.
   const cycleMode = React.useCallback(() => {
-    const modes = session.modes.list();
+    // Only cycle user-selectable modes — special modes (e.g. collaborative,
+    // entered via /collab) are hidden from the Shift+Tab cycle the same way they
+    // are from the /mode picker. See ModeDef.special / isSelectableMode.
+    const modes = session.modes.list().filter(isSelectableMode);
     if (modes.length === 0) return;
     let current: string;
     try {

--- a/packages/plugin-cli/src/session/use-event-stream.test.ts
+++ b/packages/plugin-cli/src/session/use-event-stream.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MoxxyEvent } from '@moxxy/sdk';
+
+// Drive the hook without a React renderer, mirroring use-turn-runner.test.ts:
+// persistent state/ref cells + a useEffect that runs its body synchronously, so
+// the subscribe effect (which seeds `events`) executes during the mount call.
+const stateCells: Array<{ value: unknown }> = [];
+let stateIdx = 0;
+const refCells: Array<{ current: unknown }> = [];
+let refIdx = 0;
+
+vi.mock('react', () => {
+  const useState = (init: unknown) => {
+    const i = stateIdx++;
+    if (!stateCells[i]) {
+      stateCells[i] = { value: typeof init === 'function' ? (init as () => unknown)() : init };
+    }
+    const cell = stateCells[i]!;
+    const setter = (next: unknown) => {
+      cell.value = typeof next === 'function' ? (next as (p: unknown) => unknown)(cell.value) : next;
+    };
+    return [cell.value, setter];
+  };
+  const useRef = (init: unknown) => {
+    const i = refIdx++;
+    if (!refCells[i]) refCells[i] = { current: init };
+    return refCells[i]!;
+  };
+  const useEffect = (fn: () => void | (() => void)) => {
+    // Run the effect body now (mount). Ignore the returned cleanup.
+    fn();
+  };
+  const useCallback = (fn: unknown) => fn;
+  return { useState, useRef, useEffect, useCallback, default: { useState, useRef, useEffect, useCallback } };
+});
+
+const { useEventStream, seedFromLog } = await import('./use-event-stream.js');
+
+const ev = (type: string, extra: Record<string, unknown> = {}): MoxxyEvent =>
+  ({ type, ...extra }) as unknown as MoxxyEvent;
+
+/** A minimal session whose log mirrors core's EventLog seed+subscribe surface. */
+function fakeSession(held: ReadonlyArray<MoxxyEvent>) {
+  let listener: ((e: MoxxyEvent) => void) | null = null;
+  const live = [...held];
+  return {
+    session: {
+      log: {
+        toJSON: () => [...live],
+        // Seeded events do NOT fire subscribers (matches core EventLog) — only
+        // events pushed AFTER subscribe reach the listener.
+        subscribe: (fn: (e: MoxxyEvent) => void) => {
+          listener = fn;
+          return () => {
+            listener = null;
+          };
+        },
+      },
+    } as unknown as Parameters<typeof useEventStream>[0],
+    append: (e: MoxxyEvent) => {
+      live.push(e);
+      listener?.(e);
+    },
+  };
+}
+
+function mount(session: Parameters<typeof useEventStream>[0]) {
+  stateCells.length = 0;
+  stateIdx = 0;
+  refCells.length = 0;
+  refIdx = 0;
+  return useEventStream(session);
+}
+
+// `events` is the first useState in the hook → stateCells[0].
+const renderedEvents = () => stateCells[0]!.value as ReadonlyArray<MoxxyEvent>;
+
+describe('seedFromLog', () => {
+  it('returns the held events, dropping live-only chunk types', () => {
+    const seeded = seedFromLog({
+      toJSON: () => [
+        ev('user_message'),
+        ev('assistant_chunk'),
+        ev('reasoning_chunk'),
+        ev('assistant_message'),
+      ],
+    });
+    expect(seeded.map((e) => e.type)).toEqual(['user_message', 'assistant_message']);
+  });
+
+  it('tail-caps a very long history to the in-memory window', () => {
+    const many = Array.from({ length: 5_200 }, (_, i) => ev('user_message', { i }));
+    const seeded = seedFromLog({ toJSON: () => many });
+    expect(seeded).toHaveLength(5_000);
+    // Keeps the most recent tail.
+    expect((seeded[seeded.length - 1] as { i: number }).i).toBe(5_199);
+  });
+
+  it('an empty log seeds nothing', () => {
+    expect(seedFromLog({ toJSON: () => [] })).toEqual([]);
+  });
+});
+
+describe('useEventStream seeding (session switch / resume)', () => {
+  it('seeds the renderer from history the log already holds on mount', () => {
+    // The regression: a switched-to / resumed session whose EventLog is already
+    // populated rendered an EMPTY body because the hook only listened for future
+    // appends. It must now show the prior messages.
+    const { session } = fakeSession([ev('user_message'), ev('assistant_message')]);
+    mount(session);
+    expect(renderedEvents().map((e) => e.type)).toEqual(['user_message', 'assistant_message']);
+  });
+
+  it('a fresh (empty) session still starts empty', () => {
+    const { session } = fakeSession([]);
+    mount(session);
+    expect(renderedEvents()).toEqual([]);
+  });
+
+  it('appends live events after the seed without dropping or duplicating it', () => {
+    const { session, append } = fakeSession([ev('user_message')]);
+    mount(session);
+    append(ev('assistant_message'));
+    expect(renderedEvents().map((e) => e.type)).toEqual(['user_message', 'assistant_message']);
+  });
+});

--- a/packages/plugin-cli/src/session/use-event-stream.ts
+++ b/packages/plugin-cli/src/session/use-event-stream.ts
@@ -12,6 +12,28 @@ import type { MoxxyEvent, ClientSession as Session } from '@moxxy/sdk';
  */
 const MAX_RENDERED_EVENTS = 5_000;
 
+/**
+ * The events to seed the renderer with when (re)subscribing to a session: the
+ * history the log ALREADY holds, minus the live-only chunk types (never
+ * persisted, never rendered) and tail-capped to the same in-memory window as
+ * the live append path.
+ *
+ * This is what makes a resumed or switched-to session show its prior messages.
+ * On `/sessions` switch / `--resume`, `bootSession` seeds the new `EventLog`
+ * directly, which intentionally does NOT fire subscribers — so a fresh
+ * `useEventStream` that only listened for future appends rendered an empty body
+ * while the status line (which reads the full `log`) showed the correct token
+ * count. Seeding from the held log closes that gap.
+ */
+export function seedFromLog(log: Pick<Session['log'], 'toJSON'>): ReadonlyArray<MoxxyEvent> {
+  const held = log
+    .toJSON()
+    .filter((e) => e.type !== 'assistant_chunk' && e.type !== 'reasoning_chunk');
+  return held.length > MAX_RENDERED_EVENTS
+    ? held.slice(held.length - MAX_RENDERED_EVENTS)
+    : held;
+}
+
 export interface EventStreamHandle {
   events: ReadonlyArray<MoxxyEvent>;
   setEvents: React.Dispatch<React.SetStateAction<ReadonlyArray<MoxxyEvent>>>;
@@ -78,6 +100,12 @@ export function useEventStream(session: Session): EventStreamHandle {
   }, [cancelStreamFlush]);
 
   useEffect(() => {
+    // Seed from the history the log already holds before subscribing. Seeded
+    // EventLog events don't fire subscribers, so on a session switch / resume
+    // the body would otherwise render empty. Runs in the same synchronous tick
+    // as subscribe(), so no live append can interleave/duplicate; a fresh
+    // session's log is empty, leaving first-boot behavior unchanged.
+    setEvents(seedFromLog(session.log));
     const unsub = session.log.subscribe((event) => {
       // assistant_chunk events fire at provider-stream cadence (often
       // hundreds per turn). Don't push them into `events` — they render

--- a/packages/plugin-telegram/src/channel/callback-handler.test.ts
+++ b/packages/plugin-telegram/src/channel/callback-handler.test.ts
@@ -109,7 +109,10 @@ describe('handleCallback — model/mode persistence failure (u110-5)', () => {
         replace: vi.fn(),
         setActive: vi.fn(),
       },
-      modes: { setActive: vi.fn() },
+      modes: {
+        setActive: vi.fn(),
+        list: () => [{ name: 'default' }, { name: 'goal' }],
+      },
       credentialResolver: undefined,
     }) as unknown as CallbackState['session'];
 

--- a/packages/plugin-telegram/src/channel/callback-handler.ts
+++ b/packages/plugin-telegram/src/channel/callback-handler.ts
@@ -1,5 +1,6 @@
 import type { Bot, Context } from 'grammy';
 import { setCategoryDefault, setProviderModel } from '@moxxy/config';
+import { isSelectableMode } from '@moxxy/sdk';
 import type { ClientSession as Session } from '@moxxy/sdk';
 import type { PermissionDecision } from '@moxxy/sdk';
 import type { TelegramPermissionResolver } from '../permission.js';
@@ -219,6 +220,13 @@ async function handleMode(
   const modeName = data.slice(5);
   if (!modeName || !session) {
     await ctx.answerCallbackQuery({ text: 'invalid mode' });
+    return;
+  }
+  // Refuse a special mode reached by name (e.g. a stale callback) — special
+  // modes are entered only via their own command. Mirrors the TUI guard.
+  const target = session.modes.list().find((m) => m.name === modeName);
+  if (target && !isSelectableMode(target)) {
+    await ctx.answerCallbackQuery({ text: `"${modeName}" is a special mode` });
     return;
   }
   try {

--- a/packages/plugin-telegram/src/channel/slash-handler.ts
+++ b/packages/plugin-telegram/src/channel/slash-handler.ts
@@ -1,4 +1,5 @@
 import { type Bot, type Context, InlineKeyboard } from 'grammy';
+import { isSelectableMode } from '@moxxy/sdk';
 import type { ClientSession as Session } from '@moxxy/sdk';
 
 export interface SlashState {
@@ -169,7 +170,9 @@ async function renderModelPicker(
 }
 
 async function renderModePicker(ctx: Context, session: Session): Promise<void> {
-  const modes = session.modes.list();
+  // Special modes (e.g. collaborative, entered via /collab) are hidden from the
+  // picker the same way they are in the TUI. See ModeDef.special.
+  const modes = session.modes.list().filter(isSelectableMode);
   if (modes.length === 0) {
     await ctx.reply('no modes registered');
     return;


### PR DESCRIPTION
## What

Two TUI bug fixes reported during testing.

### 1. Secret modes leaked into Shift+Tab
The Shift+Tab mode cycle (`SessionView.cycleMode`) used the raw mode registry, so **special modes** (e.g. `collaborative`, entered via `/collab`) appeared in the cycle. They're now filtered with `isSelectableMode`, exactly like the `/mode` picker and the swap UI already do. The **Telegram** `/mode` picker and its by-name callback are hardened the same way (special modes never offered or name-switched).

### 2. Session switch didn't load history
Switching sessions in the TUI (and `--resume`) changed the active session but rendered an **empty chat body**. Root cause: `bootSession({resumeSessionId})` seeds the new `EventLog` directly, which intentionally does **not** fire subscribers, so `useEventStream` (which only listened for future appends) showed nothing — while the status-line token count (which reads the full log) was correct. `useEventStream` now seeds the renderer from the history the log already holds (`seedFromLog`, chunk-filtered + tail-capped).

## Tests
- New `use-event-stream.test.ts` (seed filters chunks / tail-caps / empty; hook seeds on mount; live appends don't duplicate the seed).
- Telegram callback mock updated; `plugin-cli` (223) + `plugin-telegram` (103) suites green; full build green.

Changeset: `@moxxy/cli` patch.