### PR TITLE
fix(desktop): provision API-key providers on demand during onboarding

### DIFF
--- a/.changeset/fix-desktop-provider-provisioning.md
+++ b/.changeset/fix-desktop-provider-provisioning.md
@@ -1,0 +1,19 @@
+---
+"@moxxy/desktop": patch
+---
+
+fix(desktop): provision API-key providers on demand during onboarding
+
+The slim-kernel redesign stopped bundling API-key providers (anthropic, openai,
+…) into the CLI — they install on demand from npm. But the desktop's onboarding
+had no install step: picking the default `anthropic` (or any API-key provider)
+saved the key, then `setActive` threw "Provider not registered" and the
+onboarding / provider-recovery gate looped forever. Only the two bundled OAuth
+providers (claude-code, openai-codex) yielded a working desktop.
+
+Onboarding now runs the CLI's headless provisioner — a new
+`onboarding.provisionProvider` IPC that shells out to `moxxy provision <slug>`
+(the key was already stored via `saveProviderKey`) to install + enable the
+package and write `plugins.provider.default`, then restarts the runner so it
+discovers the freshly-installed package and its boot activation makes the
+provider active. OAuth providers keep their bundled `setProvider` path.

--- a/apps/desktop/src/onboarding/steps/ProviderStep.tsx
+++ b/apps/desktop/src/onboarding/steps/ProviderStep.tsx
@@ -103,7 +103,12 @@ export function ProviderStep({
         secret: secret.trim(),
       });
       setSecret('');
-      await activateProvider();
+      // API-key providers are NOT bundled (slim kernel): install + provision the
+      // package on demand, which also restarts the runner so it activates the
+      // provider. Without this, `setActive` throws "Provider not registered" and
+      // onboarding loops forever. (OAuth providers are bundled → setProvider in
+      // onOauthSignedIn.)
+      await api().invoke('onboarding.provisionProvider', { provider });
       setDone(true);
     } catch (e) {
       setError(toErrorMessage(e));

--- a/packages/desktop-host/src/ipc/onboarding.ts
+++ b/packages/desktop-host/src/ipc/onboarding.ts
@@ -11,7 +11,7 @@
 import { app, shell, BrowserWindow as BrowserWindowApi } from 'electron';
 
 import type { RunnerPool } from '../runner-pool';
-import { probeOnboarding, saveProviderKey } from '../onboarding';
+import { probeOnboarding, provisionProvider, saveProviderKey } from '../onboarding';
 import { installMoxxyCli, probeNode } from '../installer';
 import { installManagedNode } from '../node-manager';
 import { assertSafeExternalUrl } from '../security';
@@ -44,8 +44,20 @@ export function registerOnboardingHandlers(pool: RunnerPool): void {
   });
   handle('onboarding.saveProviderKey', async ({ provider, secret }) => {
     await saveProviderKey(provider, secret);
+    // Best-effort early activation for a BUNDLED (OAuth) provider — an unbundled
+    // API-key provider isn't registered yet (it's installed by
+    // provisionProvider below), so tolerate its "not registered" rejection
+    // instead of leaving an unhandled promise.
     const session = pool.active()?.remote();
-    if (session) session.providers.setActive(provider);
+    if (session) void Promise.resolve(session.providers.setActive(provider)).catch(() => undefined);
+  });
+  handle('onboarding.provisionProvider', async ({ provider, model }) => {
+    await provisionProvider(provider, model);
+    // The provider package now lives in ~/.moxxy/plugins and the config names it
+    // as the default — but the runner(s) booted before it existed. Restart every
+    // runner so the fresh process discovers the package and its boot activation
+    // walk makes the provider active, clearing the onboarding/recovery gate.
+    await Promise.all(pool.list().map((e) => e.supervisor.restart()));
   });
   handle('onboarding.providerAuthKind', async ({ provider }) => {
     // Prefer the runner's own registry metadata — it knows every provider's

--- a/packages/desktop-host/src/onboarding.ts
+++ b/packages/desktop-host/src/onboarding.ts
@@ -84,6 +84,25 @@ export async function saveProviderKey(provider: string, secret: string): Promise
   await runCli(cli, ['vault', 'set', key], secret);
 }
 
+/**
+ * Install + configure a non-bundled provider on demand via the CLI's headless
+ * provisioner (`moxxy provision --provider <slug> [--model <id>]`). The slim
+ * kernel bundles only the OAuth providers; every API-key provider (anthropic,
+ * openai, …) lives on npm and must be installed before any runner can activate
+ * it. The key was already stored by {@link saveProviderKey}, so provision only
+ * installs + enables the package and writes `plugins.provider.default`. The
+ * caller restarts the runner so the new package is discovered and activated.
+ * Args are passed as argv (no shell), so the bounded `model` can't inject.
+ */
+export async function provisionProvider(provider: string, model?: string): Promise<void> {
+  assertSafeProviderName(provider);
+  const cli = resolveMoxxyCli({ extraPaths: augmentedPaths() });
+  if (!cli) throw new Error('moxxy CLI not found');
+  const args = ['provision', '--provider', provider];
+  if (model) args.push('--model', model);
+  await runCli(cli, args);
+}
+
 function runCli(cli: CliInvocation, args: string[], stdin?: string): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     // 'pipe' stdin so we can feed the secret to `vault set`.

--- a/packages/desktop-ipc-contract/src/commands.ts
+++ b/packages/desktop-ipc-contract/src/commands.ts
@@ -174,6 +174,14 @@ export interface IpcCommands {
   /** Returns how a provider authenticates so the wizard can pick the
    *  right UI affordance: a key field vs an OAuth button. */
   'onboarding.providerAuthKind': (args: { provider: string }) => Promise<'oauth' | 'api-key'>;
+  /** Install + provision a non-bundled provider on demand: runs the CLI's
+   *  headless `moxxy provision <provider>` (the API key was already stored via
+   *  `saveProviderKey`), then restarts the runner so it discovers the freshly
+   *  installed package and its boot activation makes the provider active. The
+   *  slim kernel bundles ONLY the OAuth providers; every API-key provider
+   *  (anthropic, openai, …) lives on npm and must be installed first, or
+   *  `setActive` throws "Provider not registered". */
+  'onboarding.provisionProvider': (args: { provider: string; model?: string }) => Promise<void>;
 
   // ---- Interactive provider sign-in (OAuth) ------------------------------
   /** Begin an interactive sign-in for `provider`, correlated by the

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -155,6 +155,10 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
     secret: z.string().min(1).max(8192),
   }),
   'onboarding.providerAuthKind': z.object({ provider: providerName }),
+  'onboarding.provisionProvider': z.object({
+    provider: providerName,
+    model: z.string().min(1).max(256).optional(),
+  }),
   // Interactive provider sign-in spawns `moxxy login <provider>` and feeds it
   // the user's pasted answers over stdin — guard the provider slug and the
   // correlation id, and bound the answer (a token / `code#state`) so a hostile


### PR DESCRIPTION
## Release-blocking desktop bug found in the pre-release review

The plugins-manifest / slim-kernel redesign (already on `development`) stopped bundling **API-key providers** (anthropic, openai, google, xai, zai, local) into the CLI — they install on demand from npm. But the **desktop onboarding has no install/provision step**: picking the default `anthropic` (or any API-key provider) saves the key, then `session.setProvider` → runner `setActive` throws **"Provider not registered"**, and the onboarding / provider-recovery gate (`activeProvider === null`) **loops forever**. Only the two bundled OAuth providers (claude-code, openai-codex) yielded a working desktop.

(Confirmed by a desktop impact review of the redesign; `config.provider`/`mode`/`embeddings`/`preferences.json` reads, the vault, and the OAuth path are all fine — this provisioning gap was the one behavioral break.)

## Fix
On-demand provisioning, reusing the proven `saveProviderKey` shell-out + `app.ts` runner-restart patterns:
- **`onboarding.provisionProvider` IPC** (`desktop-ipc-contract` command + zod schema) → desktop-host runs `moxxy provision <slug>` (key already in the vault) to install + enable the package and write `plugins.provider.default`, then **restarts the runner(s)** so the fresh process discovers the package and its boot activation makes the provider active (clearing the gate).
- `ProviderStep` API-key path calls `provisionProvider` instead of `setProvider`; OAuth providers keep the bundled `setProvider` path.
- Hardened the best-effort early `setActive` in `saveProviderKey` to tolerate the not-yet-installed case (no unhandled rejection).

## Verification
Full build green; `desktop-host` (469) + `desktop-ipc-contract` (incl. command/validation completeness) suites green; `spawnCli` passes argv (no shell → `model`/`provider` can't inject); provider slug guarded by `assertSafeProviderName`.

> ⚠️ **Needs manual desktop onboarding QA** before/after merge — this is an Electron first-run flow I can't exercise headless. Recommend: fresh `~/.moxxy`, launch desktop, pick `anthropic`, paste a key, confirm it installs + activates + the chat surface loads (and re-confirm the OAuth path still works).