### PR TITLE
feat(slack): Slack bot channel on a dedicated, isolated runner

### DIFF
--- a/.changeset/slack-channel-dedicated-runner.md
+++ b/.changeset/slack-channel-dedicated-runner.md
@@ -1,0 +1,25 @@
+---
+"@moxxy/cli": minor
+"@moxxy/sdk": minor
+---
+
+Slack bot channel on a dedicated, isolated runner.
+
+- New built-in `@moxxy/plugin-channel-slack`: a Slack bot that ingests the Slack
+  Events API over the self-hosted proxy relay, verifies each request's HMAC
+  signature (Slack `v0` scheme + 5-minute replay window over the raw body), acks
+  within Slack's 3-second window and then drives the agent in the background,
+  dedupes Slack's at-least-once retries, and streams threaded replies via
+  `chat.update`. Permissions use an autonomous allow-list
+  (`channels.slack.allowedTools`; `['*']` = every tool, `[]` = read-only) — no
+  human in the loop — so the bot can act independently. Configure with
+  `moxxy slack setup` / `moxxy channels slack pair|status|unpair`; secrets live
+  in the vault (`slack_bot_token`, `slack_signing_secret`).
+- Channels can now run on their OWN dedicated runner — an isolated runner socket
+  plus a sticky session, separate from the runner serving your desktop/TUI — so a
+  channel acts as an independent agent thread that does work separately from
+  yours. `slack` is dedicated by default; any channel can opt in with
+  `--dedicated` (or `MOXXY_DEDICATED_RUNNER=1`). No runner-protocol change: one
+  dedicated runner is still one Session.
+- `SessionSource` gains `'slack'`, so a Slack runner's session is tagged
+  distinctly and stays out of the desktop workspace sidebar.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -142,8 +142,21 @@ or recorded-on-purpose decision.
 - [med] Channel→core prod dependency — `plugin-cli`/`plugin-telegram` still import
   core helpers; hoist provider-neutral ones into the SDK. 
 - [med] Shared HTTP-channel server base — `createServer`/`listen`/health/routing is
-  replicated across `plugin-channel-http`/`-web`/`webhooks`/`ipc-server-ws`; an
-  optional `HttpChannelServer` base would dedupe (larger refactor, lower payoff).
+  replicated across `plugin-channel-http`/`-web`/`webhooks`/`ipc-server-ws`/
+  `plugin-channel-slack` (the Slack ingest server is a 6th copy); an optional
+  `HttpChannelServer` base would dedupe (larger refactor, lower payoff).
+- [med, slack v1] Slack channel runs a SINGLE global `busy` single-flight — one
+  turn at a time across ALL threads/channels (a 2nd @mention while busy gets a
+  "still working" reply and is dropped). Per-thread concurrency (a turn per
+  thread, the isolation seam supports it) is deferred. `packages/plugin-channel-slack/`.
+- [med, slack v1, security] Slack channel is AUTONOMOUS — allow-list auto-approve
+  with no human-in-the-loop (mirrors the HTTP channel). There is no Slack
+  Interactivity button-approval flow; the operator must scope `allowedTools`
+  narrowly at setup (every auto-approved call is logged). Revisit human-in-the-loop
+  via Slack Interactivity (a 2nd Request URL) for v2. `packages/plugin-channel-slack/`.
+- [low, slack v1] Slack replies stream as PLAIN TEXT via `chat.update` (no
+  Block Kit / mrkdwn formatting, no message split for very long replies). A
+  Telegram-style renderer + Block Kit would improve fidelity. `packages/plugin-channel-slack/`.
 - [med, security] LAN pairing is cleartext `ws://` (RN/Expo can't trust a self-signed
   cert for a private IP); the secure phone path is the tunnel (`wss://`). Add optional
   `https.Server` + dev-build pinning only if direct-LAN encryption ever matters.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -81,6 +81,7 @@
     "@moxxy/plugin-browser": "workspace:*",
     "@moxxy/plugin-channel-http": "workspace:*",
     "@moxxy/plugin-channel-mobile": "workspace:*",
+    "@moxxy/plugin-channel-slack": "workspace:*",
     "@moxxy/plugin-channel-web": "workspace:*",
     "@moxxy/plugin-cli": "workspace:*",
     "@moxxy/plugin-collab": "workspace:*",

--- a/packages/cli/src/commands/start-registered-channel.ts
+++ b/packages/cli/src/commands/start-registered-channel.ts
@@ -1,6 +1,7 @@
 import {
   connectRemoteSession,
   isRunnerUp,
+  platformSocket,
   runnerSocketPath,
   startRunnerServer,
   type RemoteSession,
@@ -8,6 +9,7 @@ import {
 } from '@moxxy/runner';
 import type { Session } from '@moxxy/core';
 import { startChannelWith } from '@moxxy/sdk';
+import { moxxyPath } from '@moxxy/sdk/server';
 import type { ClientSession, SessionLike } from '@moxxy/sdk';
 import {
   argvToSetupOptions,
@@ -46,10 +48,48 @@ type _SessionIsSessionLike = _AssertAssignable<Session, SessionLike>;
  *    runner socket so other clients can attach too (Option A).
  */
 export async function startRegisteredChannel(name: string, argv: ParsedArgv): Promise<number> {
+  applyDedicatedRunnerEnv(name, argv);
   const standalone = hasBoolFlag(argv, 'standalone');
   const mode = chooseClientMode({ standalone, runnerUp: standalone ? false : await isRunnerUp() });
   if (mode === 'attach') return runAttachedChannel(name, argv);
   return runSelfHostedChannel(name, argv, mode === 'standalone');
+}
+
+/**
+ * A channel may declare itself a "dedicated runner": it runs as its OWN agent
+ * thread, isolated from whatever runner is serving the desktop/TUI, so it can
+ * act separately from the user's own work. We achieve that purely by addressing
+ * — a distinct runner socket + a stable sticky session id — with NO runner
+ * protocol change: one dedicated runner is still one Session, today's invariant.
+ *
+ * The env is set BEFORE `chooseClientMode`/`isRunnerUp` run, so the channel
+ * probes its own (empty) socket, falls into self-host mode, and boots an
+ * isolated Session instead of attaching to the user's main runner. The stable
+ * `MOXXY_SESSION_ID` persists that session's history across restarts.
+ *
+ * `slack` is dedicated by default (the whole point is to operate independently);
+ * any channel can opt in with `--dedicated` or `MOXXY_DEDICATED_RUNNER=1`. A
+ * caller that already pinned the socket/session id (e.g. the desktop supervisor)
+ * always wins — we only fill in what is unset.
+ */
+function applyDedicatedRunnerEnv(name: string, argv: ParsedArgv): void {
+  const dedicated =
+    name === 'slack' ||
+    hasBoolFlag(argv, 'dedicated') ||
+    process.env.MOXXY_DEDICATED_RUNNER === '1';
+  if (!dedicated) return;
+  if (!process.env.MOXXY_RUNNER_SOCKET) {
+    process.env.MOXXY_RUNNER_SOCKET = platformSocket(
+      `channel-${name}`,
+      moxxyPath(`channel-${name}.sock`),
+    );
+  }
+  if (!process.env.MOXXY_SESSION_ID) {
+    process.env.MOXXY_SESSION_ID = `moxxy-channel-${name}`;
+  }
+  if (!process.env.MOXXY_SESSION_SOURCE && name === 'slack') {
+    process.env.MOXXY_SESSION_SOURCE = 'slack';
+  }
 }
 
 /** Thin-client mode: run the channel against a RemoteSession. */

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -29,6 +29,7 @@ import { cliPlugin } from '@moxxy/plugin-cli';
 import { httpChannelPlugin } from '@moxxy/plugin-channel-http';
 import { webChannelPlugin } from '@moxxy/plugin-channel-web';
 import { mobileChannelPlugin } from '@moxxy/plugin-channel-mobile';
+import { slackPlugin } from '@moxxy/plugin-channel-slack';
 import { browserPlugin } from '@moxxy/plugin-browser';
 import { terminalPlugin } from '@moxxy/plugin-terminal';
 import { subagentsPlugin } from '@moxxy/plugin-subagents';
@@ -151,6 +152,10 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
     { name: '@moxxy/plugin-channel-mobile', plugin: mobileChannelPlugin },
     // Discovery-loadable: resolves the vault from the service registry in onInit.
     { name: '@moxxy/plugin-telegram', plugin: telegramPlugin },
+    // Discovery-loadable: resolves the vault from the service registry in onInit;
+    // opens its Events-API ingest tunnel via the proxy relay. Runs on its own
+    // dedicated runner (see start-registered-channel applyDedicatedRunnerEnv).
+    { name: '@moxxy/plugin-channel-slack', plugin: slackPlugin },
     { name: '@moxxy/plugin-browser', plugin: browserPlugin },
     // Shared terminal surface + `terminal` tool. node-pty is an optional native
     // peer dep, so the surface availability (real PTY vs piped fallback) is

--- a/packages/cli/src/setup/builtin-requirements.generated.ts
+++ b/packages/cli/src/setup/builtin-requirements.generated.ts
@@ -15,6 +15,13 @@ export const BUILTIN_REQUIREMENTS: Readonly<
       "hint": "Enable @moxxy/plugin-subagents — deep-research fans out sub-queries via ctx.subagents."
     }
   ],
+  "@moxxy/plugin-channel-slack": [
+    {
+      "kind": "plugin",
+      "name": "@moxxy/plugin-vault",
+      "hint": "slack resolves the vault from the service registry for its bot token + signing secret + pairing; @moxxy/plugin-vault must load first"
+    }
+  ],
   "@moxxy/plugin-oauth": [
     {
       "kind": "plugin",

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -74,6 +74,7 @@ export const BUILTIN_REQUIREMENT_DECISIONS: Readonly<Record<string, BuiltinRequi
   '@moxxy/plugin-channel-web': { hardRequirements: false, reason: 'web surface is standalone; token auto-generated' },
   '@moxxy/plugin-channel-mobile': { hardRequirements: false, reason: 'mobile WS bridge is standalone; token auto-generated' },
   '@moxxy/plugin-telegram': { hardRequirements: false, reason: 'vault is injected by bootstrap closure' },
+  '@moxxy/plugin-channel-slack': { hardRequirements: false, reason: 'vault + proxy tunnel resolved from the service registry (both builtin); runs on its own dedicated runner' },
   '@moxxy/plugin-browser': { hardRequirements: false, reason: 'browser runtime is diagnosed at tool/runtime level' },
   '@moxxy/plugin-terminal': { hardRequirements: false, reason: 'node-pty is optional; falls back to a piped shell' },
   '@moxxy/plugin-computer-control': { hardRequirements: false, reason: 'platform constraints are handled by tools' },

--- a/packages/cli/src/setup/persistence.ts
+++ b/packages/cli/src/setup/persistence.ts
@@ -65,7 +65,8 @@ function sessionSource(): SessionSource {
     explicit === 'desktop' ||
     explicit === 'tui' ||
     explicit === 'mobile' ||
-    explicit === 'cli'
+    explicit === 'cli' ||
+    explicit === 'slack'
   ) {
     return explicit;
   }

--- a/packages/desktop-ipc-contract/src/desks.ts
+++ b/packages/desktop-ipc-contract/src/desks.ts
@@ -14,7 +14,7 @@ export interface DeskSession {
   eventCount?: number;
   provider?: string | null;
   model?: string | null;
-  source?: 'desktop' | 'tui' | 'mobile' | 'cli';
+  source?: 'desktop' | 'tui' | 'mobile' | 'cli' | 'slack';
 }
 
 export interface Desk {

--- a/packages/plugin-channel-slack/package.json
+++ b/packages/plugin-channel-slack/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@moxxy/plugin-channel-slack",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Slack bot channel for moxxy. Ingests Slack Events API over the proxy relay, drives the Session, and streams threaded replies. Autonomous allow-list permission model (no human in the loop).",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "moxxy": {
+    "plugin": {
+      "entry": "./dist/index.js",
+      "kind": "cli"
+    },
+    "requirements": [
+      {
+        "kind": "plugin",
+        "name": "@moxxy/plugin-vault",
+        "hint": "slack resolves the vault from the service registry for its bot token + signing secret + pairing; @moxxy/plugin-vault must load first"
+      }
+    ]
+  },
+  "dependencies": {
+    "@clack/prompts": "catalog:",
+    "@moxxy/config": "workspace:*",
+    "@moxxy/core": "workspace:*",
+    "@moxxy/plugin-tunnel-proxy": "workspace:*",
+    "@moxxy/plugin-vault": "workspace:*",
+    "@moxxy/sdk": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@moxxy/testing": "workspace:*",
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugin-channel-slack/src/channel.ts
+++ b/packages/plugin-channel-slack/src/channel.ts
@@ -1,0 +1,394 @@
+import { newTurnId } from '@moxxy/core';
+import { proxyTunnel } from '@moxxy/plugin-tunnel-proxy';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import type {
+  Channel,
+  ChannelHandle,
+  ChannelStartOptsBase,
+  MoxxyEvent,
+  PermissionResolver,
+  TunnelHandle,
+  TunnelProviderDef,
+} from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import {
+  SLACK_AUTHORIZED_KEY,
+  authorizationMatches,
+  parseAuthorization,
+  resolveBotToken,
+  resolveSigningSecret,
+  type SlackAuthorization,
+} from './keys.js';
+import { buildSlackPermissionResolver } from './permission.js';
+import { SlackClient } from './channel/slack-client.js';
+import { runSlackTurn } from './channel/turn-runner.js';
+import {
+  IngestServer,
+  SLACK_EVENTS_PATH,
+  type DispatchContext,
+} from './server/ingest-server.js';
+import type { SlackEventCallback } from './server/schema.js';
+
+/** Routing label the proxy relay exposes this channel under. */
+const TUNNEL_LABEL = 'slack';
+
+export interface SlackChannelLogger {
+  debug?(msg: string, meta?: Record<string, unknown>): void;
+  info?(msg: string, meta?: Record<string, unknown>): void;
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+  error?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface SlackChannelOptions {
+  readonly vault: VaultStore;
+  /**
+   * Tunnel provider used to expose the local ingest server publicly. Defaults to
+   * the self-hosted `proxyTunnel` (imported directly, like the webhooks tunnel);
+   * tests pass a fake provider so they never hit the network.
+   */
+  readonly tunnelProvider?: TunnelProviderDef;
+  /** Tools the model may call autonomously. `['*']` allows every registered tool. */
+  readonly allowedTools?: ReadonlyArray<string>;
+  /** Debounce window for streaming `chat.update` edits (ms). Default 1000. */
+  readonly editFrameMs?: number;
+  /** Bind host for the local ingest server. Default 127.0.0.1. */
+  readonly host?: string;
+  readonly logger?: SlackChannelLogger;
+  /** Injectable Slack client factory (tests). */
+  readonly makeClient?: (token: string) => SlackClient;
+}
+
+export interface SlackStartOpts extends ChannelStartOptsBase {
+  readonly session: Session;
+  /**
+   * If true, arm a TOFU pairing window: the first verified inbound event from a
+   * team/channel is captured and (via `onPairConfirm`) persisted to the vault.
+   */
+  readonly pair?: boolean;
+  /** Override allowedTools at start (the CLI forwards channel config / flags). */
+  readonly allowedTools?: ReadonlyArray<string>;
+}
+
+/** Fires when a verified event lands during a pairing window. */
+export interface PairCandidate {
+  readonly teamId: string;
+  readonly channelId: string;
+}
+
+export class SlackChannel implements Channel<SlackStartOpts> {
+  readonly name = 'slack';
+  /**
+   * Installed on the session by the CLI dispatcher. Replaced in `start()` once
+   * we can expand a `['*']` allow-list against the live tool registry; until
+   * then it denies everything (safe default before start).
+   */
+  permissionResolver: PermissionResolver;
+
+  private readonly opts: SlackChannelOptions;
+  private session: Session | null = null;
+  private client: SlackClient | null = null;
+  private ingest: IngestServer | null = null;
+  private tunnel: TunnelHandle | null = null;
+  private handle: ChannelHandle | null = null;
+  private resolveRunning: (() => void) | null = null;
+
+  private botUserId = '';
+  private authorization: SlackAuthorization | null = null;
+  private model: string | undefined;
+
+  /** Single-flight guard (v1: one turn at a time across all threads). */
+  private busy = false;
+  private turnController: AbortController | null = null;
+  // Per-turn target so foreign-turn mirroring + permission prompts know the thread.
+  private currentChannelId: string | null = null;
+  private currentThreadTs: string | null = null;
+  private lastChannelId: string | null = null;
+  private lastThreadTs: string | null = null;
+  private logUnsub: (() => void) | null = null;
+  /** turnIds THIS channel initiated — mirrorForeignTurn filters on these (#8). */
+  private readonly ownTurnIds = new Set<string>();
+
+  // Pairing (TOFU) state.
+  private pairing = false;
+  private pairListeners = new Set<(c: PairCandidate) => void>();
+  private publicUrl: string | null = null;
+
+  constructor(opts: SlackChannelOptions) {
+    this.opts = opts;
+    // Pre-start: deny-all. Replaced with the real allow-list resolver in start()
+    // once the tool registry is available (for `['*']` expansion).
+    this.permissionResolver = buildSlackPermissionResolver({
+      allowedTools: [],
+      allToolNames: [],
+      ...(opts.logger ? { logger: opts.logger } : {}),
+    });
+  }
+
+  /** The public Request URL to paste into Slack's Event Subscriptions. */
+  get requestUrl(): string | null {
+    return this.publicUrl;
+  }
+
+  /** Subscribe to pairing candidates (the setup/pair flows use this). */
+  onPairCandidate(listener: (c: PairCandidate) => void): () => void {
+    this.pairListeners.add(listener);
+    return () => this.pairListeners.delete(listener);
+  }
+
+  /** Persist a team/channel as authorized (called by the pair flow on confirm). */
+  async confirmPairing(candidate: PairCandidate): Promise<void> {
+    const auth: SlackAuthorization = {
+      teamId: candidate.teamId,
+      channelId: candidate.channelId,
+    };
+    await this.opts.vault.set(SLACK_AUTHORIZED_KEY, JSON.stringify(auth), ['slack']);
+    this.authorization = auth;
+    this.pairing = false;
+  }
+
+  async start(startOpts: SlackStartOpts): Promise<ChannelHandle> {
+    if (this.handle) return this.handle;
+    this.session = startOpts.session;
+    this.model = startOpts.model;
+    this.pairing = startOpts.pair === true;
+
+    const token = await resolveBotToken(this.opts.vault);
+    if (!token) {
+      throw new Error(
+        'Slack bot token not found. Run `moxxy channels slack setup`, set MOXXY_SLACK_BOT_TOKEN, ' +
+          'or store one in the vault under slack_bot_token.',
+      );
+    }
+    const signingSecret = await resolveSigningSecret(this.opts.vault);
+    if (!signingSecret) {
+      throw new Error(
+        'Slack signing secret not found. Run `moxxy channels slack setup`, set ' +
+          'MOXXY_SLACK_SIGNING_SECRET, or store one in the vault under slack_signing_secret.',
+      );
+    }
+
+    // Load any persisted pairing.
+    this.authorization = parseAuthorization(await this.opts.vault.get(SLACK_AUTHORIZED_KEY));
+    if (!this.pairing && !this.authorization) {
+      throw new Error(
+        'No Slack team/channel is paired yet. Run `moxxy channels slack pair` first.',
+      );
+    }
+
+    // Validate the token + capture the bot's own user id (for self-message drops).
+    this.client = this.opts.makeClient
+      ? this.opts.makeClient(token)
+      : new SlackClient({ token });
+    const auth = await this.client.authTest();
+    this.botUserId = auth.botUserId;
+    this.opts.logger?.info?.('slack: authenticated', {
+      botUserId: this.botUserId,
+      team: auth.team,
+    });
+
+    // Build the real allow-list resolver now that the tool registry is live, so
+    // `['*']` can expand to every registered tool name (mirror prompt.ts).
+    const allowedTools = startOpts.allowedTools ?? this.opts.allowedTools ?? [];
+    const allToolNames = this.session.tools.list().map((t) => t.name);
+    this.permissionResolver = buildSlackPermissionResolver({
+      allowedTools,
+      allToolNames,
+      ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+    });
+    // Swap the (now-final) resolver in — start() was called AFTER the CLI
+    // installed the pre-start one, so re-install via the documented seam.
+    this.session.setPermissionResolver(this.permissionResolver);
+
+    // Mirror-to-thread: post the assistant's prose for a turn this channel did
+    // NOT initiate (e.g. a co-attached surface ran one) into the last thread we
+    // served. Our OWN turns stream via the frame pump (filtered by turnId).
+    this.logUnsub = this.session.log.subscribe((event) => this.mirrorForeignTurn(event));
+
+    // Stand up the local ingest server, then expose it via the proxy tunnel.
+    this.ingest = new IngestServer({
+      ...(this.opts.host ? { host: this.opts.host } : {}),
+      signingSecret,
+      ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+      hooks: {
+        botUserId: this.botUserId,
+        isAuthorized: (teamId, channel) =>
+          authorizationMatches(this.authorization, teamId, channel),
+        onVerifiedEvent: (ev) => this.handlePairingCandidate(ev),
+        dispatch: (ctx) => this.dispatchTurn(ctx),
+      },
+    });
+    const bound = await this.ingest.start();
+
+    await this.openTunnel(bound.host, bound.port);
+
+    const running = new Promise<void>((resolve) => {
+      this.resolveRunning = resolve;
+    });
+
+    this.handle = {
+      running,
+      stop: async (reason = 'shutdown') => {
+        // Abort the in-flight turn FIRST so the model loop stops the moment the
+        // operator asks to shut down (shared/remote Session: spend continues
+        // otherwise and only its output is discarded).
+        if (this.turnController && !this.turnController.signal.aborted) {
+          this.turnController.abort(reason);
+        }
+        this.logUnsub?.();
+        this.logUnsub = null;
+        if (this.tunnel) {
+          try { await this.tunnel.close(); } catch { /* ignore */ }
+          this.tunnel = null;
+        }
+        if (this.ingest) {
+          await this.ingest.stop();
+          this.ingest = null;
+        }
+        this.publicUrl = null;
+        this.resolveRunning?.();
+        this.resolveRunning = null;
+      },
+    };
+    this.opts.logger?.info?.('slack: channel started', {
+      requestUrl: this.publicUrl,
+      paired: this.authorization != null,
+      pairing: this.pairing,
+    });
+    return this.handle;
+  }
+
+  private async openTunnel(host: string, port: number): Promise<void> {
+    // Default to the self-hosted proxy relay (imported directly, like the
+    // webhooks tunnel); tests inject a fake provider.
+    const provider = this.opts.tunnelProvider ?? proxyTunnel;
+    if (provider.name === 'localhost') {
+      // A no-op provider can't reach a loopback port from Slack. Surface the
+      // local URL so a manual reverse proxy can still be wired.
+      this.publicUrl = `http://${host}:${port}${SLACK_EVENTS_PATH}`;
+      this.opts.logger?.warn?.(
+        'slack: localhost tunnel provider — Slack cannot reach a loopback port',
+        { localUrl: this.publicUrl },
+      );
+      return;
+    }
+    try {
+      this.tunnel = await provider.open({ port, host, label: TUNNEL_LABEL });
+      this.publicUrl = `${this.tunnel.url.replace(/\/+$/, '')}${SLACK_EVENTS_PATH}`;
+      this.opts.logger?.info?.('slack: tunnel open', {
+        provider: provider.name,
+        requestUrl: this.publicUrl,
+      });
+    } catch (err) {
+      this.publicUrl = `http://${host}:${port}${SLACK_EVENTS_PATH}`;
+      this.opts.logger?.warn?.('slack: tunnel failed; using local URL', {
+        provider: provider.name,
+        err: String(err),
+      });
+    }
+  }
+
+  /**
+   * TOFU pairing hook: while a pairing window is armed, the first verified event
+   * captures the team/channel and notifies listeners. It's "consumed" (no turn)
+   * so the very first message just establishes trust. Returns true when consumed.
+   */
+  private handlePairingCandidate(ev: SlackEventCallback): boolean {
+    if (!this.pairing) return false;
+    const teamId = ev.team_id;
+    const channelId = ev.event.channel;
+    if (!teamId || !channelId) return false;
+    const candidate: PairCandidate = { teamId, channelId };
+    for (const listener of this.pairListeners) {
+      try {
+        listener(candidate);
+      } catch (err) {
+        this.opts.logger?.warn?.('slack: pair listener threw', { err: String(err) });
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Fire-and-forget a turn for an authorized event. Single-flight (v1): if a
+   * turn is already running we drop the new event with a thread reply rather
+   * than corrupting the per-turn state. The ingest handler has already ACKed.
+   */
+  private dispatchTurn(ctx: DispatchContext): void {
+    void this.runTurn(ctx).catch((err) => {
+      this.opts.logger?.warn?.('slack: turn dispatch failed', { err: String(err) });
+    });
+  }
+
+  private async runTurn(ctx: DispatchContext): Promise<void> {
+    if (!this.session || !this.client) return;
+    if (this.busy) {
+      // Politely decline; v1 has no per-thread concurrency (see TECH_DEBT).
+      try {
+        await this.client.postMessage({
+          channel: ctx.channel,
+          threadTs: ctx.threadTs,
+          text: 'I am still working on a previous request. One moment…',
+        });
+      } catch { /* ignore */ }
+      return;
+    }
+    this.busy = true;
+    this.currentChannelId = ctx.channel;
+    this.currentThreadTs = ctx.threadTs;
+    this.lastChannelId = ctx.channel;
+    this.lastThreadTs = ctx.threadTs;
+    const controller = new AbortController();
+    this.turnController = controller;
+
+    const turnId = newTurnId();
+    this.ownTurnIds.add(turnId);
+    if (this.ownTurnIds.size > 64) {
+      const oldest = this.ownTurnIds.values().next().value;
+      if (oldest !== undefined) this.ownTurnIds.delete(oldest);
+    }
+
+    try {
+      await runSlackTurn(
+        {
+          session: this.session,
+          client: this.client,
+          editFrameMs: this.opts.editFrameMs ?? 1000,
+          ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+        },
+        {
+          channel: ctx.channel,
+          threadTs: ctx.threadTs,
+          text: ctx.text,
+          ...(this.model ? { model: this.model } : {}),
+          controller,
+          turnId,
+        },
+      );
+    } finally {
+      this.busy = false;
+      this.turnController = null;
+      this.currentChannelId = null;
+      this.currentThreadTs = null;
+    }
+  }
+
+  /**
+   * Post the assistant's prose for a turn this channel did not initiate. Gated by
+   * `!busy` (our own turns stream via the frame pump) and by having served a
+   * thread at least once. Skipped for our own turnIds (robust to async ordering /
+   * replay, invariant #8).
+   */
+  private mirrorForeignTurn(event: MoxxyEvent): void {
+    if (event.type !== 'assistant_message') return;
+    if (this.ownTurnIds.has(event.turnId)) return;
+    if (this.busy) return;
+    if (!this.client || this.lastChannelId == null || this.lastThreadTs == null) return;
+    const text = event.content.trim();
+    if (!text) return;
+    void this.client
+      .postMessage({ channel: this.lastChannelId, threadTs: this.lastThreadTs, text })
+      .catch((err) => {
+        this.opts.logger?.warn?.('slack: mirror failed', { err: String(err) });
+      });
+  }
+}

--- a/packages/plugin-channel-slack/src/channel/frame-pump.ts
+++ b/packages/plugin-channel-slack/src/channel/frame-pump.ts
@@ -1,0 +1,143 @@
+import type { SlackClient } from './slack-client.js';
+
+export interface FramePumpLogger {
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface FramePumpOptions {
+  readonly client: SlackClient;
+  readonly channel: string;
+  /** Thread to reply under (`event.thread_ts ?? event.ts`). */
+  readonly threadTs: string;
+  /** Debounce window for `chat.update` edits (~1s). */
+  readonly editFrameMs: number;
+  readonly logger?: FramePumpLogger;
+}
+
+/**
+ * Drives the throttled "post once, then edit a single message" streaming loop
+ * for a Slack turn — the Slack analog of Telegram's FramePump. The turn-runner
+ * feeds it the latest snapshot; the pump posts a placeholder on the first real
+ * content (lazily, via `chat.postMessage`) and edits THAT message via
+ * `chat.update` for every subsequent frame, throttled to `editFrameMs`.
+ *
+ * Lifecycle per turn:
+ *   1. construct with `{ client, channel, threadTs }`.
+ *   2. `setText(latest)` whenever the rendered snapshot changes → schedules an
+ *      edit.
+ *   3. `flush(final=true)` on turn completion drains the final snapshot.
+ *   4. `dispose()` clears the timer.
+ */
+export class FramePump {
+  private readonly client: SlackClient;
+  private readonly channel: string;
+  private readonly threadTs: string;
+  private readonly editFrameMs: number;
+  private readonly logger: FramePumpLogger | undefined;
+
+  private messageTs: string | null = null;
+  private latest = '';
+  private lastSent = '';
+  private editTimer: ReturnType<typeof setTimeout> | null = null;
+  /** True while a post/update is in flight, so timer + flush never overlap. */
+  private sending = false;
+
+  constructor(opts: FramePumpOptions) {
+    this.client = opts.client;
+    this.channel = opts.channel;
+    this.threadTs = opts.threadTs;
+    this.editFrameMs = opts.editFrameMs;
+    this.logger = opts.logger;
+  }
+
+  /** The ts of the streamed message once posted (lets the runner know it exists). */
+  get postedTs(): string | null {
+    return this.messageTs;
+  }
+
+  /** Record the latest rendered text and schedule a throttled edit. */
+  setText(text: string): void {
+    this.latest = text;
+    this.scheduleEdit();
+  }
+
+  private scheduleEdit(): void {
+    if (this.editTimer || this.sending) return;
+    this.editTimer = setTimeout(() => {
+      this.editTimer = null;
+      void this.flush(false);
+    }, this.editFrameMs);
+  }
+
+  /**
+   * Drain the latest snapshot to Slack. On the first non-empty frame, posts a
+   * new threaded message; afterwards edits it in place. `final` guarantees at
+   * least one message even when the turn produced no streamed text.
+   */
+  async flush(final: boolean): Promise<void> {
+    this.cancelTimer();
+    if (this.sending) {
+      // A flush is already running; re-arm so the newest text is sent after it.
+      if (this.latest !== this.lastSent) this.scheduleEdit();
+      return;
+    }
+    const text = this.latest.trim();
+    if (!text) {
+      if (final && this.messageTs == null) {
+        await this.post('_(no output)_');
+      }
+      return;
+    }
+    if (text === this.lastSent) return;
+
+    this.sending = true;
+    try {
+      if (this.messageTs == null) {
+        await this.post(text);
+      } else {
+        await this.edit(this.messageTs, text);
+      }
+      this.lastSent = text;
+    } finally {
+      this.sending = false;
+    }
+    // If new text arrived while we were sending, schedule another edit.
+    if (final) {
+      if (this.latest.trim() !== this.lastSent) await this.flush(true);
+    } else if (this.latest.trim() !== this.lastSent) {
+      this.scheduleEdit();
+    }
+  }
+
+  private async post(text: string): Promise<void> {
+    try {
+      const res = await this.client.postMessage({
+        channel: this.channel,
+        text,
+        threadTs: this.threadTs,
+      });
+      this.messageTs = res.ts;
+    } catch (err) {
+      this.logger?.warn?.('slack chat.postMessage failed', { err: String(err) });
+    }
+  }
+
+  private async edit(ts: string, text: string): Promise<void> {
+    try {
+      await this.client.updateMessage({ channel: this.channel, ts, text });
+    } catch (err) {
+      this.logger?.warn?.('slack chat.update failed', { err: String(err) });
+    }
+  }
+
+  dispose(): void {
+    this.cancelTimer();
+  }
+
+  private cancelTimer(): void {
+    if (this.editTimer) {
+      clearTimeout(this.editTimer);
+      this.editTimer = null;
+    }
+  }
+}

--- a/packages/plugin-channel-slack/src/channel/slack-client.ts
+++ b/packages/plugin-channel-slack/src/channel/slack-client.ts
@@ -1,0 +1,123 @@
+/**
+ * Minimal hand-rolled Slack Web API client. The repo norm is hand-rolled
+ * `fetch` over a vendor SDK (only Telegram pulls in grammy), so there is NO
+ * `@slack/web-api` dependency: each method POSTs JSON to
+ * `https://slack.com/api/<method>` with `Authorization: Bearer <token>` and
+ * throws on a non-`ok` Slack response.
+ */
+
+const SLACK_API_BASE = 'https://slack.com/api';
+
+export interface SlackClientOptions {
+  readonly token: string;
+  /** Override the API base (tests). */
+  readonly baseUrl?: string;
+  /** Injectable fetch (tests). Defaults to the global `fetch`. */
+  readonly fetchImpl?: typeof fetch;
+}
+
+export interface AuthTestResult {
+  /** The bot's own user id — used to drop the bot's own messages. */
+  readonly botUserId: string;
+  readonly teamId?: string;
+  readonly team?: string;
+  readonly url?: string;
+}
+
+export interface PostMessageResult {
+  readonly channel: string;
+  /** The new message ts — used as the edit target for streaming. */
+  readonly ts: string;
+}
+
+/** Shape of every Slack API JSON response: a boolean `ok` plus method fields. */
+interface SlackApiResponse {
+  readonly ok: boolean;
+  readonly error?: string;
+  readonly [k: string]: unknown;
+}
+
+export class SlackClient {
+  private readonly token: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: SlackClientOptions) {
+    this.token = opts.token;
+    this.baseUrl = (opts.baseUrl ?? SLACK_API_BASE).replace(/\/+$/, '');
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  private async call(method: string, body: Record<string, unknown>): Promise<SlackApiResponse> {
+    const res = await this.fetchImpl(`${this.baseUrl}/${method}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        authorization: `Bearer ${this.token}`,
+      },
+      body: JSON.stringify(body),
+    });
+    // Slack always returns 200 with `{ ok: false, error }` for app-level errors;
+    // a non-2xx is a transport/auth problem worth surfacing distinctly.
+    if (!res.ok) {
+      throw new Error(`Slack ${method} HTTP ${res.status}`);
+    }
+    const json = (await res.json()) as SlackApiResponse;
+    if (!json.ok) {
+      throw new Error(`Slack ${method} failed: ${json.error ?? 'unknown_error'}`);
+    }
+    return json;
+  }
+
+  /** Validate the token and capture the bot's own user id. */
+  async authTest(): Promise<AuthTestResult> {
+    const json = await this.call('auth.test', {});
+    const botUserId = typeof json['user_id'] === 'string' ? json['user_id'] : '';
+    if (!botUserId) throw new Error('Slack auth.test returned no user_id');
+    return {
+      botUserId,
+      ...(typeof json['team_id'] === 'string' ? { teamId: json['team_id'] } : {}),
+      ...(typeof json['team'] === 'string' ? { team: json['team'] } : {}),
+      ...(typeof json['url'] === 'string' ? { url: json['url'] } : {}),
+    };
+  }
+
+  /** Post a message into a channel/thread. Returns the channel + new ts. */
+  async postMessage(args: {
+    channel: string;
+    text: string;
+    threadTs?: string;
+  }): Promise<PostMessageResult> {
+    const json = await this.call('chat.postMessage', {
+      channel: args.channel,
+      text: args.text,
+      ...(args.threadTs ? { thread_ts: args.threadTs } : {}),
+    });
+    const channel = typeof json['channel'] === 'string' ? json['channel'] : args.channel;
+    const ts = typeof json['ts'] === 'string' ? json['ts'] : '';
+    if (!ts) throw new Error('Slack chat.postMessage returned no ts');
+    return { channel, ts };
+  }
+
+  /** Edit an existing message (the streaming-update path). */
+  async updateMessage(args: { channel: string; ts: string; text: string }): Promise<void> {
+    await this.call('chat.update', {
+      channel: args.channel,
+      ts: args.ts,
+      text: args.text,
+    });
+  }
+
+  /** Optional: read a thread's replies (unused by v1 streaming, exposed for tools). */
+  async conversationsReplies(args: {
+    channel: string;
+    ts: string;
+  }): Promise<ReadonlyArray<Record<string, unknown>>> {
+    const json = await this.call('conversations.replies', {
+      channel: args.channel,
+      ts: args.ts,
+    });
+    const messages = json['messages'];
+    return Array.isArray(messages) ? (messages as Array<Record<string, unknown>>) : [];
+  }
+}

--- a/packages/plugin-channel-slack/src/channel/turn-runner.test.ts
+++ b/packages/plugin-channel-slack/src/channel/turn-runner.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MoxxyEvent } from '@moxxy/sdk';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import { runSlackTurn } from './turn-runner.js';
+import type { SlackClient } from './slack-client.js';
+
+/** A fake event log that fans out to subscribers, like the real session.log. */
+class FakeLog {
+  private readonly subs = new Set<(e: MoxxyEvent) => void>();
+  subscribe(fn: (e: MoxxyEvent) => void): () => void {
+    this.subs.add(fn);
+    return () => this.subs.delete(fn);
+  }
+  emit(e: MoxxyEvent): void {
+    for (const s of this.subs) s(e);
+  }
+}
+
+function chunk(turnId: string, delta: string): MoxxyEvent {
+  return {
+    id: `e_${Math.random()}`,
+    seq: 0,
+    ts: 0,
+    sessionId: 's1',
+    turnId,
+    source: 'model',
+    type: 'assistant_chunk',
+    delta,
+  } as MoxxyEvent;
+}
+
+function message(turnId: string, content: string): MoxxyEvent {
+  return {
+    id: `e_${Math.random()}`,
+    seq: 0,
+    ts: 0,
+    sessionId: 's1',
+    turnId,
+    source: 'model',
+    type: 'assistant_message',
+    content,
+    stopReason: 'end_turn',
+  } as MoxxyEvent;
+}
+
+/** Records every chat.postMessage / chat.update so the test can assert on Slack output. */
+function fakeClient(): {
+  client: SlackClient;
+  posts: Array<{ channel: string; text: string; threadTs?: string }>;
+  edits: Array<{ channel: string; ts: string; text: string }>;
+} {
+  const posts: Array<{ channel: string; text: string; threadTs?: string }> = [];
+  const edits: Array<{ channel: string; ts: string; text: string }> = [];
+  let n = 0;
+  const client = {
+    async postMessage(args: { channel: string; text: string; threadTs?: string }) {
+      posts.push(args);
+      return { channel: args.channel, ts: `ts_${++n}` };
+    },
+    async updateMessage(args: { channel: string; ts: string; text: string }) {
+      edits.push(args);
+    },
+  } as unknown as SlackClient;
+  return { client, posts, edits };
+}
+
+describe('runSlackTurn (turnId-filtered streaming)', () => {
+  it('streams only the matching turnId into the thread', async () => {
+    vi.useFakeTimers();
+    const log = new FakeLog();
+    const { client, posts, edits } = fakeClient();
+
+    // runTurn emits onto the shared log: our turn's chunks PLUS a foreign turn's
+    // chunk that must never reach Slack. Resolves after emitting.
+    const session = {
+      log,
+      runTurn(_prompt: string, opts: { turnId: string }) {
+        const ownTurn = opts.turnId;
+        return (async function* () {
+          log.emit(chunk('foreign-turn', 'SHOULD NOT APPEAR'));
+          log.emit(chunk(ownTurn, 'Hello'));
+          log.emit(chunk(ownTurn, ', world'));
+          log.emit(message(ownTurn, 'Hello, world!'));
+          log.emit(chunk('foreign-turn', 'ALSO NOT THIS'));
+          yield message(ownTurn, 'Hello, world!');
+        })();
+      },
+    } as unknown as Session;
+
+    const controller = new AbortController();
+    const promise = runSlackTurn(
+      { session, client, editFrameMs: 1000 },
+      {
+        channel: 'C1',
+        threadTs: '111.222',
+        text: '<@UBOT> hi',
+        controller,
+        turnId: 'own-turn',
+      },
+    );
+    // Drain timers (the debounced flush) and the turn.
+    await vi.runAllTimersAsync();
+    await promise;
+    vi.useRealTimers();
+
+    // Exactly one message posted into the right thread, carrying the final text.
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toMatchObject({ channel: 'C1', threadTs: '111.222' });
+    // The final flush carries the complete assistant_message content.
+    const finalText = edits.length > 0 ? edits[edits.length - 1]?.text : posts[0]?.text;
+    expect(finalText).toBe('Hello, world!');
+
+    // No foreign-turn text ever reached Slack.
+    const allText = [...posts.map((p) => p.text), ...edits.map((e) => e.text)].join('\n');
+    expect(allText).not.toContain('SHOULD NOT APPEAR');
+    expect(allText).not.toContain('ALSO NOT THIS');
+  });
+
+  it('posts a "(no output)" placeholder when a turn produces nothing', async () => {
+    vi.useFakeTimers();
+    const log = new FakeLog();
+    const { client, posts } = fakeClient();
+    const session = {
+      log,
+      runTurn() {
+        return (async function* () {
+          // no events
+        })();
+      },
+    } as unknown as Session;
+
+    const promise = runSlackTurn(
+      { session, client, editFrameMs: 1000 },
+      { channel: 'C1', threadTs: '1.2', text: 'hi', controller: new AbortController(), turnId: 't' },
+    );
+    await vi.runAllTimersAsync();
+    await promise;
+    vi.useRealTimers();
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0]?.text).toContain('no output');
+  });
+});

--- a/packages/plugin-channel-slack/src/channel/turn-runner.ts
+++ b/packages/plugin-channel-slack/src/channel/turn-runner.ts
@@ -1,0 +1,116 @@
+import type { newTurnId } from '@moxxy/core';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import type { MoxxyEvent } from '@moxxy/sdk';
+import { FramePump } from './frame-pump.js';
+import type { SlackClient } from './slack-client.js';
+
+export interface TurnRunnerLogger {
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface RunSlackTurnDeps {
+  readonly session: Session;
+  readonly client: SlackClient;
+  readonly editFrameMs: number;
+  readonly logger?: TurnRunnerLogger;
+}
+
+export interface RunSlackTurnOptions {
+  /** Channel the triggering event arrived in. */
+  readonly channel: string;
+  /** Thread root for the reply: `event.thread_ts ?? event.ts`. */
+  readonly threadTs: string;
+  readonly text: string;
+  readonly model?: string;
+  readonly controller: AbortController;
+  /** Pre-minted turn id; the channel records it as an own-turn id. */
+  readonly turnId: ReturnType<typeof newTurnId>;
+}
+
+/**
+ * Accumulate streamed assistant text from the event log into a single growing
+ * snapshot. We render `assistant_chunk` deltas live and fall back to the final
+ * `assistant_message` content (which supersedes the streamed deltas for the
+ * same turn) so the last edit always carries the complete reply.
+ */
+class TurnRenderer {
+  private streamed = '';
+  private finalText: string | null = null;
+
+  accept(event: MoxxyEvent): boolean {
+    if (event.type === 'assistant_chunk') {
+      this.streamed += event.delta;
+      return true;
+    }
+    if (event.type === 'assistant_message') {
+      this.finalText = event.content;
+      return true;
+    }
+    return false;
+  }
+
+  snapshot(): string {
+    return (this.finalText ?? this.streamed).trim();
+  }
+}
+
+/**
+ * Drive a single Slack turn end-to-end: subscribe the frame pump to THIS turn's
+ * events (filtered by turnId — `session.log` fans out to every listener, so a
+ * concurrent turn on the same Session would otherwise stream into this thread,
+ * AGENTS.md invariant #8), run the turn through `runTurn`, flush the final
+ * frame, and unwind in `finally`.
+ *
+ * The turnId is minted by the caller so the channel can also record it as an
+ * own-turn id (it filters foreign-turn mirroring on those).
+ */
+export async function runSlackTurn(
+  deps: RunSlackTurnDeps,
+  opts: RunSlackTurnOptions,
+): Promise<void> {
+  const { session, client, editFrameMs, logger } = deps;
+  const { channel, threadTs, text, model, controller, turnId } = opts;
+
+  const renderer = new TurnRenderer();
+  const pump = new FramePump({
+    client,
+    channel,
+    threadTs,
+    editFrameMs,
+    ...(logger ? { logger } : {}),
+  });
+
+  const unsubscribe = session.log.subscribe((event) => {
+    if (event.turnId !== turnId) return;
+    if (renderer.accept(event)) pump.setText(renderer.snapshot());
+  });
+
+  try {
+    for await (const _event of session.runTurn(text, {
+      turnId,
+      ...(model ? { model } : {}),
+      signal: controller.signal,
+    })) {
+      void _event;
+    }
+    await pump.flush(true);
+  } catch (err) {
+    logger?.warn?.('slack turn failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    // Surface the failure into the thread rather than leaving a dangling
+    // placeholder. Errors from this send are swallowed (best-effort).
+    try {
+      await client.postMessage({
+        channel,
+        threadTs,
+        text: `Turn failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    } catch {
+      /* ignore */
+    }
+  } finally {
+    unsubscribe();
+    pump.dispose();
+  }
+}

--- a/packages/plugin-channel-slack/src/index.ts
+++ b/packages/plugin-channel-slack/src/index.ts
@@ -1,0 +1,215 @@
+import {
+  defineChannel,
+  definePlugin,
+  type LifecycleHooks,
+  type Plugin,
+} from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { SlackChannel, type SlackChannelOptions } from './channel.js';
+import {
+  SLACK_AUTHORIZED_KEY,
+  SLACK_BOT_TOKEN_ENV,
+  SLACK_SIGNING_SECRET_ENV,
+  parseAuthorization,
+  resolveBotToken,
+  resolveSigningSecret,
+} from './keys.js';
+import { runSlackWizard } from './setup-wizard.js';
+import { runSlackPairFlow } from './pair-flow.js';
+
+export {
+  SlackChannel,
+  type SlackChannelOptions,
+  type SlackStartOpts,
+  type PairCandidate,
+} from './channel.js';
+export { buildSlackPermissionResolver } from './permission.js';
+export { SlackClient } from './channel/slack-client.js';
+export { verifySlackSignature, SLACK_REPLAY_WINDOW_SEC } from './server/verify.js';
+export { slackEnvelopeSchema, eventCallbackSchema, urlVerificationSchema } from './server/schema.js';
+export { DeliveryDedupeCache } from './server/dedupe.js';
+export { IngestServer, SLACK_EVENTS_PATH } from './server/ingest-server.js';
+export {
+  SLACK_BOT_TOKEN_KEY,
+  SLACK_SIGNING_SECRET_KEY,
+  SLACK_AUTHORIZED_KEY,
+  SLACK_BOT_TOKEN_ENV,
+  SLACK_SIGNING_SECRET_ENV,
+  resolveBotToken,
+  resolveSigningSecret,
+  parseAuthorization,
+  authorizationMatches,
+  type SlackAuthorization,
+} from './keys.js';
+
+export interface BuildSlackPluginOptions {
+  /** Host-injected encrypted secret store (available immediately). */
+  readonly vault: VaultStore;
+}
+
+/**
+ * Build the Slack channel plugin. The CLI passes the concrete vault (mirroring
+ * the Telegram plugin's vault injection). The channel exposes its own ingest
+ * server publicly via the self-hosted `proxyTunnel` (imported directly, like
+ * the webhooks tunnel).
+ */
+export function buildSlackPlugin(opts: BuildSlackPluginOptions): Plugin {
+  return makeSlackPlugin(() => opts.vault);
+}
+
+/**
+ * Discovery-loadable default export: resolves the vault from the inter-plugin
+ * service registry in `onInit` (the vault plugin publishes `'vault'`). Requires
+ * `@moxxy/plugin-vault` to load first (declared in `package.json`
+ * `moxxy.requirements`). The channel + subcommands read the vault via
+ * `getVault()`, so resolution is deferred to call time — after `onInit` wired it.
+ */
+export const slackPlugin: Plugin = (() => {
+  let resolved: VaultStore | null = null;
+  const getVault = (): VaultStore => {
+    if (!resolved) {
+      throw new Error(
+        '@moxxy/plugin-channel-slack: the "vault" service is unavailable — @moxxy/plugin-vault must load first',
+      );
+    }
+    return resolved;
+  };
+  const hooks: LifecycleHooks = {
+    onInit: (ctx) => {
+      resolved = ctx.services.require<VaultStore>('vault');
+    },
+  };
+  return makeSlackPlugin(getVault, hooks);
+})();
+
+export default slackPlugin;
+
+function readAllowedTools(options: Record<string, unknown> | undefined): string[] | undefined {
+  const raw = options?.['allowedTools'];
+  if (Array.isArray(raw)) return raw.map((x) => String(x));
+  return undefined;
+}
+
+function makeSlackPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks): Plugin {
+  return definePlugin({
+    name: '@moxxy/plugin-channel-slack',
+    version: '0.0.0',
+    ...(hooks ? { hooks } : {}),
+    // NB: we do NOT register a tunnelProvider here. The channel opens its ingest
+    // tunnel by importing `proxyTunnel` directly (see ingest-server), exactly like
+    // the webhooks plugin. Registering it would throw "already registered" when the
+    // web channel (which does register `proxyTunnel`) is also loaded, silently
+    // dropping this whole plugin — the tunnel-providers registry rejects duplicates.
+    channels: [
+      defineChannel({
+        name: 'slack',
+        description:
+          'Slack bot channel: ingests the Events API over the proxy relay and streams threaded replies. Autonomous allow-list permissions (no human in the loop).',
+        create: (deps) => {
+          const options = deps.options;
+          const allowedTools = readAllowedTools(options);
+          const editFrameMs = options?.['editFrameMs'];
+          const host = options?.['host'];
+          const channelOpts: SlackChannelOptions = {
+            vault: getVault(),
+            ...(allowedTools ? { allowedTools } : {}),
+            ...(typeof editFrameMs === 'number' ? { editFrameMs } : {}),
+            ...(typeof host === 'string' ? { host } : {}),
+            logger: deps.logger as never,
+          };
+          return new SlackChannel(channelOpts);
+        },
+        isAvailable: async () => {
+          // Env-first: a fully env-configured bot is available even in a probe
+          // context (e.g. the `moxxy channels` listing) where onInit has not yet
+          // wired the vault service, so `getVault()` would throw.
+          let hasToken = (process.env[SLACK_BOT_TOKEN_ENV]?.trim() ?? '') !== '';
+          let hasSecret = (process.env[SLACK_SIGNING_SECRET_ENV]?.trim() ?? '') !== '';
+          if (hasToken && hasSecret) return { ok: true };
+          try {
+            const vault = getVault();
+            if (!hasToken) hasToken = (await resolveBotToken(vault)) != null;
+            if (!hasSecret) hasSecret = (await resolveSigningSecret(vault)) != null;
+          } catch {
+            // Vault unavailable in a probe/listing context — fall through to the
+            // "missing secrets" message below (env was already checked above).
+          }
+          if (hasToken && hasSecret) return { ok: true };
+          const missing: string[] = [];
+          if (!hasToken) missing.push('bot token (slack_bot_token / MOXXY_SLACK_BOT_TOKEN)');
+          if (!hasSecret) missing.push('signing secret (slack_signing_secret / MOXXY_SLACK_SIGNING_SECRET)');
+          return {
+            ok: false,
+            reason: `Missing ${missing.join(' and ')}. Run \`moxxy channels slack setup\`.`,
+          };
+        },
+        interactiveCommand: 'setup',
+        subcommands: {
+          setup: {
+            description:
+              'Interactive setup: store the bot token + signing secret, validate via auth.test, pick the allow-list, open the tunnel, and print the Slack Request URL. Shown by default for `moxxy slack` on a TTY.',
+            run: async (ctx) => {
+              if (process.stdin.isTTY !== true) {
+                // Headless: just start the channel (secrets must already be set).
+                return ctx.startChannel();
+              }
+              return runSlackWizard(ctx);
+            },
+          },
+          pair: {
+            description:
+              'TOFU pairing: arm a window, then authorize the first team/channel that @mentions the bot.',
+            run: async (ctx) => {
+              if (process.stdin.isTTY !== true) {
+                process.stderr.write(
+                  'Pairing needs a TTY (you confirm the team/channel). Run `moxxy slack pair` interactively.\n',
+                );
+                return 1;
+              }
+              return runSlackPairFlow(ctx);
+            },
+          },
+          status: {
+            description: 'Report token/secret/authorization state as JSON.',
+            run: async (ctx) => {
+              const vault = ctx.deps.vault as VaultStore | undefined;
+              if (!vault) {
+                process.stderr.write('vault unavailable\n');
+                return 1;
+              }
+              const botTokenConfigured = (await resolveBotToken(vault)) != null;
+              const signingSecretConfigured = (await resolveSigningSecret(vault)) != null;
+              const authorized = parseAuthorization(await vault.get(SLACK_AUTHORIZED_KEY));
+              process.stdout.write(
+                JSON.stringify(
+                  {
+                    botTokenConfigured,
+                    signingSecretConfigured,
+                    authorized,
+                    tunnelUrl: null,
+                  },
+                  null,
+                  2,
+                ) + '\n',
+              );
+              return 0;
+            },
+          },
+          unpair: {
+            description: 'Forget the authorized Slack team/channel.',
+            run: async (ctx) => {
+              const vault = ctx.deps.vault as VaultStore | undefined;
+              if (!vault) {
+                process.stderr.write('vault unavailable\n');
+                return 1;
+              }
+              const removed = await vault.delete(SLACK_AUTHORIZED_KEY);
+              process.stdout.write(removed ? 'unpaired\n' : 'no pairing was active\n');
+              return 0;
+            },
+          },
+        },
+      }),
+    ],
+  });
+}

--- a/packages/plugin-channel-slack/src/keys.ts
+++ b/packages/plugin-channel-slack/src/keys.ts
@@ -1,0 +1,97 @@
+/**
+ * Vault keys + env overrides + token validators shared by the channel, its
+ * subcommands, and the interactive setup wizard. Kept in their own module so the
+ * wizard / pair-flow helpers can import them without pulling in the plugin's
+ * full index.
+ */
+import { z } from '@moxxy/sdk';
+
+/** Vault key for the Slack bot OAuth token (`xoxb-…`). */
+export const SLACK_BOT_TOKEN_KEY = 'slack_bot_token';
+/** Vault key for the Slack app signing secret (HMAC over the raw request body). */
+export const SLACK_SIGNING_SECRET_KEY = 'slack_signing_secret';
+/**
+ * Vault key for the authorized team/channel set (TOFU pairing). Stored as a
+ * JSON string of an authorization record so we can grow what we pin without a
+ * format change (today: `{ teamId, channelId? }`).
+ */
+export const SLACK_AUTHORIZED_KEY = 'slack_authorized';
+
+/** Env override for the bot token (beats the vault, matching every other channel). */
+export const SLACK_BOT_TOKEN_ENV = 'MOXXY_SLACK_BOT_TOKEN';
+/** Env override for the signing secret. */
+export const SLACK_SIGNING_SECRET_ENV = 'MOXXY_SLACK_SIGNING_SECRET';
+
+/** A Slack bot token always starts with `xoxb-`. */
+export const SLACK_BOT_TOKEN_RE = /^xoxb-[A-Za-z0-9-]{10,}$/;
+
+/** zod validator for a bot token (shape only — connectivity is tested via `auth.test`). */
+export const slackBotTokenSchema = z
+  .string()
+  .trim()
+  .regex(SLACK_BOT_TOKEN_RE, 'expected a Slack bot token like "xoxb-…"');
+
+/** zod validator for a signing secret (hex-ish; Slack uses a 32-byte hex secret). */
+export const slackSigningSecretSchema = z
+  .string()
+  .trim()
+  .min(16, 'signing secret looks too short')
+  .max(256, 'signing secret looks too long');
+
+/**
+ * Resolve the bot token: env override first, then the vault. Returns null when
+ * neither is set. Trimmed; never returns an empty string.
+ */
+export async function resolveBotToken(vault: {
+  get(name: string): Promise<string | null>;
+}): Promise<string | null> {
+  const fromEnv = process.env[SLACK_BOT_TOKEN_ENV]?.trim();
+  if (fromEnv) return fromEnv;
+  const stored = (await vault.get(SLACK_BOT_TOKEN_KEY))?.trim();
+  return stored || null;
+}
+
+/** Resolve the signing secret: env override first, then the vault. */
+export async function resolveSigningSecret(vault: {
+  get(name: string): Promise<string | null>;
+}): Promise<string | null> {
+  const fromEnv = process.env[SLACK_SIGNING_SECRET_ENV]?.trim();
+  if (fromEnv) return fromEnv;
+  const stored = (await vault.get(SLACK_SIGNING_SECRET_KEY))?.trim();
+  return stored || null;
+}
+
+/** What we persist under {@link SLACK_AUTHORIZED_KEY}. */
+export interface SlackAuthorization {
+  readonly teamId: string;
+  /** Optionally narrow authorization to a single channel. */
+  readonly channelId?: string;
+}
+
+/** Parse the stored authorization record. Returns null for missing/corrupt. */
+export function parseAuthorization(raw: string | null | undefined): SlackAuthorization | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<SlackAuthorization>;
+    if (typeof parsed?.teamId === 'string' && parsed.teamId) {
+      return parsed.channelId
+        ? { teamId: parsed.teamId, channelId: parsed.channelId }
+        : { teamId: parsed.teamId };
+    }
+  } catch {
+    /* corrupt — treat as unpaired */
+  }
+  return null;
+}
+
+/** Does an inbound event from `(teamId, channelId)` match the stored authorization? */
+export function authorizationMatches(
+  auth: SlackAuthorization | null,
+  teamId: string | undefined,
+  channelId: string | undefined,
+): boolean {
+  if (!auth || !teamId) return false;
+  if (auth.teamId !== teamId) return false;
+  if (auth.channelId && auth.channelId !== channelId) return false;
+  return true;
+}

--- a/packages/plugin-channel-slack/src/pair-flow.ts
+++ b/packages/plugin-channel-slack/src/pair-flow.ts
@@ -1,0 +1,111 @@
+import { confirm, isCancel, log, outro, spinner } from '@clack/prompts';
+import type { ChannelSubcommandContext } from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { SlackChannel, type PairCandidate } from './channel.js';
+
+const ANSI = process.stdout.isTTY && !process.env.NO_COLOR;
+const dim = (s: string): string => (ANSI ? `\x1b[2m${s}\x1b[22m` : s);
+
+/**
+ * Drive the TOFU pairing flow end-to-end.
+ *
+ *   1. Build a SlackChannel from the subcommand ctx + wire the session's
+ *      permission resolver.
+ *   2. Subscribe to pair candidates BEFORE starting so the first @mention can't
+ *      race past us.
+ *   3. Start in `pair` mode (opens the tunnel; prints the Request URL).
+ *   4. Wait (with spinner) for the first verified inbound event.
+ *   5. Ask the operator to confirm the team/channel; on yes, persist it.
+ *   6. Hand off the running bot until Ctrl+C.
+ *
+ * Uses the default `proxyTunnel` provider (the channel imports it directly), so
+ * the public Request URL is available once the channel starts.
+ */
+export async function runSlackPairFlow(ctx: ChannelSubcommandContext): Promise<number> {
+  const session = ctx.session;
+  const channel = new SlackChannel({
+    vault: ctx.deps.vault as VaultStore,
+    logger: ctx.deps.logger as never,
+  });
+  session.setPermissionResolver(channel.permissionResolver);
+
+  let candidateResolve: ((c: PairCandidate) => void) | null = null;
+  const firstCandidate = new Promise<PairCandidate>((resolve) => {
+    candidateResolve = resolve;
+  });
+  const unsubscribe = channel.onPairCandidate((c) => {
+    candidateResolve?.(c);
+    candidateResolve = null;
+  });
+
+  outro(dim('opening pairing window…'));
+
+  let handle;
+  try {
+    handle = await channel.start({ session, pair: true });
+  } catch (err) {
+    unsubscribe();
+    log.error(`Could not start the Slack channel: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+
+  const stopBot = async (): Promise<void> => {
+    unsubscribe();
+    try {
+      await handle.stop('wizard');
+    } catch {
+      /* ignore */
+    }
+  };
+
+  if (channel.requestUrl) {
+    log.info(
+      `Slack Request URL (paste into Event Subscriptions):\n  ${channel.requestUrl}\n` +
+        'Then mention the bot (@your-bot) in a channel to pair.',
+    );
+  }
+
+  const spin = spinner();
+  spin.start('Waiting for the first @mention from Slack…');
+
+  let candidate: PairCandidate;
+  try {
+    candidate = await firstCandidate;
+  } catch (err) {
+    spin.stop('pairing aborted');
+    log.error(`Pairing aborted: ${err instanceof Error ? err.message : String(err)}`);
+    await stopBot();
+    return 1;
+  }
+  spin.stop(`Got an event from team ${candidate.teamId}, channel ${candidate.channelId}.`);
+
+  const ok = await confirm({
+    message: `Authorize team ${candidate.teamId} / channel ${candidate.channelId}?`,
+  });
+  if (isCancel(ok) || !ok) {
+    log.warn('Pairing not confirmed.');
+    await stopBot();
+    return 0;
+  }
+
+  await channel.confirmPairing(candidate);
+  log.success(`Paired ✓ — team ${candidate.teamId} is authorized.`);
+  log.info('Bot is running. Press Ctrl+C to stop.');
+
+  const shutdown = async (): Promise<void> => {
+    await stopBot();
+    await session.close('SIGINT').catch(() => undefined);
+    process.exit(0);
+  };
+  const onSignal = (): void => void shutdown();
+  process.once('SIGINT', onSignal);
+  process.once('SIGTERM', onSignal);
+
+  try {
+    await handle.running;
+    return 0;
+  } finally {
+    process.removeListener('SIGINT', onSignal);
+    process.removeListener('SIGTERM', onSignal);
+  }
+}

--- a/packages/plugin-channel-slack/src/permission.test.ts
+++ b/packages/plugin-channel-slack/src/permission.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PendingToolCall, PermissionContext } from '@moxxy/sdk';
+import { buildSlackPermissionResolver } from './permission.js';
+
+const ctx: PermissionContext = { sessionId: 's1' };
+function call(name: string): PendingToolCall {
+  return { callId: `c_${name}`, name, input: {} };
+}
+
+describe('buildSlackPermissionResolver', () => {
+  it('auto-approves a listed tool', async () => {
+    const r = buildSlackPermissionResolver({
+      allowedTools: ['Read', 'Grep'],
+      allToolNames: ['Read', 'Grep', 'Bash', 'Write'],
+    });
+    const d = await r.check(call('Read'), ctx);
+    expect(d.mode).not.toBe('deny');
+  });
+
+  it('denies an unlisted tool', async () => {
+    const r = buildSlackPermissionResolver({
+      allowedTools: ['Read'],
+      allToolNames: ['Read', 'Bash'],
+    });
+    const d = await r.check(call('Bash'), ctx);
+    expect(d.mode).toBe('deny');
+  });
+
+  it('denies everything when the allow-list is empty (read-only)', async () => {
+    const r = buildSlackPermissionResolver({
+      allowedTools: [],
+      allToolNames: ['Read', 'Bash'],
+    });
+    expect((await r.check(call('Read'), ctx)).mode).toBe('deny');
+    expect((await r.check(call('Bash'), ctx)).mode).toBe('deny');
+  });
+
+  it('expands "*" to every registered tool name', async () => {
+    const r = buildSlackPermissionResolver({
+      allowedTools: ['*'],
+      allToolNames: ['Read', 'Bash', 'Write'],
+    });
+    expect((await r.check(call('Read'), ctx)).mode).not.toBe('deny');
+    expect((await r.check(call('Bash'), ctx)).mode).not.toBe('deny');
+    expect((await r.check(call('Write'), ctx)).mode).not.toBe('deny');
+    // A name not in the registry is still denied even under '*'.
+    expect((await r.check(call('NotRegistered'), ctx)).mode).toBe('deny');
+  });
+
+  it('logs each auto-approved call', async () => {
+    const info = vi.fn();
+    const r = buildSlackPermissionResolver({
+      allowedTools: ['Read'],
+      allToolNames: ['Read'],
+      logger: { info },
+    });
+    await r.check(call('Read'), ctx);
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(info.mock.calls[0]?.[0]).toMatch(/auto-approved/);
+    // A denial is NOT logged as an approval.
+    info.mockClear();
+    await r.check(call('Bash'), ctx);
+    expect(info).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-channel-slack/src/permission.ts
+++ b/packages/plugin-channel-slack/src/permission.ts
@@ -1,0 +1,56 @@
+import { createAllowListResolver } from '@moxxy/sdk';
+import type {
+  PendingToolCall,
+  PermissionContext,
+  PermissionDecision,
+  PermissionResolver,
+} from '@moxxy/sdk';
+
+export interface SlackPermissionLogger {
+  info?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+/**
+ * Build the Slack channel's autonomous permission resolver.
+ *
+ * The bot runs hands-off (no human-in-the-loop, like the HTTP channel): the
+ * operator declares trust upfront via `channels.slack.allowedTools`, and any
+ * tool NOT in that list is denied. We REUSE the shared
+ * {@link createAllowListResolver} (exact-name match → `allow_session`, else
+ * `deny`) rather than re-implementing the trust check; this wrapper adds:
+ *
+ *   - `'*'` expansion — the allow-list `['*']` means "allow every registered
+ *     tool". The CLI's `prompt.ts --allow-all` handles this by passing the full
+ *     tool list; we mirror that by expanding `*` against `allToolNames` at
+ *     start() time. An empty list denies everything (effectively read-only,
+ *     since no side-effecting tool can run without a clicker).
+ *   - audit logging — every auto-approved call is logged via the channel
+ *     logger, so an autonomous run leaves a trail of what it ran.
+ *
+ * (Autonomous allow-list safety is a known trade-off; see TECH_DEBT — v1 has no
+ * Slack-button approval flow.)
+ */
+export function buildSlackPermissionResolver(opts: {
+  allowedTools: ReadonlyArray<string>;
+  allToolNames: ReadonlyArray<string>;
+  logger?: SlackPermissionLogger;
+}): PermissionResolver {
+  const wildcard = opts.allowedTools.includes('*');
+  const effective = wildcard ? [...opts.allToolNames] : [...opts.allowedTools];
+  const inner = createAllowListResolver(effective);
+
+  return {
+    name: 'slack-allow-list',
+    async check(call: PendingToolCall, ctx: PermissionContext): Promise<PermissionDecision> {
+      const decision = await inner.check(call, ctx);
+      if (decision.mode !== 'deny') {
+        opts.logger?.info?.('slack: auto-approved tool call', {
+          tool: call.name,
+          callId: call.callId,
+          wildcard,
+        });
+      }
+      return decision;
+    },
+  };
+}

--- a/packages/plugin-channel-slack/src/server/dedupe.test.ts
+++ b/packages/plugin-channel-slack/src/server/dedupe.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeliveryDedupeCache } from './dedupe.js';
+
+describe('DeliveryDedupeCache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('admits a new event_id once, then rejects the repeat', () => {
+    const c = new DeliveryDedupeCache();
+    expect(c.check('Ev123')).toBe(true);
+    expect(c.check('Ev123')).toBe(false);
+    expect(c.check('Ev123')).toBe(false);
+  });
+
+  it('distinct event ids are independent', () => {
+    const c = new DeliveryDedupeCache();
+    expect(c.check('Ev1')).toBe(true);
+    expect(c.check('Ev2')).toBe(true);
+    expect(c.check('Ev1')).toBe(false);
+  });
+
+  it('re-admits an event after its TTL has elapsed', () => {
+    const c = new DeliveryDedupeCache({ ttlMs: 1000 });
+    expect(c.check('k')).toBe(true);
+    expect(c.check('k')).toBe(false);
+    vi.setSystemTime(1000);
+    expect(c.check('k')).toBe(false);
+    vi.setSystemTime(2001);
+    expect(c.check('k')).toBe(true);
+  });
+
+  it('evicts the oldest entry once maxEntries is exceeded', () => {
+    const c = new DeliveryDedupeCache({ maxEntries: 2 });
+    expect(c.check('a')).toBe(true);
+    vi.setSystemTime(1);
+    expect(c.check('b')).toBe(true);
+    expect(c.size()).toBe(2);
+    vi.setSystemTime(2);
+    expect(c.check('c')).toBe(true); // evicts 'a'
+    expect(c.size()).toBe(2);
+    expect(c.check('a')).toBe(true); // 'a' was dropped → new again
+  });
+
+  it('clear() empties the cache', () => {
+    const c = new DeliveryDedupeCache();
+    c.check('a');
+    c.check('b');
+    expect(c.size()).toBe(2);
+    c.clear();
+    expect(c.size()).toBe(0);
+    expect(c.check('a')).toBe(true);
+  });
+});

--- a/packages/plugin-channel-slack/src/server/dedupe.ts
+++ b/packages/plugin-channel-slack/src/server/dedupe.ts
@@ -1,0 +1,68 @@
+/**
+ * In-memory LRU for Slack event idempotency. Slack retries deliveries (with an
+ * `X-Slack-Retry-Num` header) and the same `event_id` may arrive more than
+ * once, so we dedupe by `event_id` for a bounded window. Copied from
+ * `@moxxy/plugin-webhooks/src/dedupe.ts` (the at-least-once delivery pattern is
+ * identical) — keyed by a single namespace here since one Slack app maps to one
+ * channel.
+ *
+ * Not persistent — a restart resets the cache, which is acceptable: worst case
+ * the agent processes one event twice immediately after restart, which is rare
+ * and self-limiting.
+ */
+export class DeliveryDedupeCache {
+  private readonly seen = new Map<string, number>();
+  private readonly maxEntries: number;
+  private readonly ttlMs: number;
+  /** Sweep TTL-expired entries at most once per this interval. The LRU overflow
+   *  cap already bounds memory, so the TTL sweep need not run on every check —
+   *  amortizing it keeps the pre-ACK path O(1) under retry storms. */
+  private readonly sweepEveryMs: number;
+  private lastSweepMs = -Infinity;
+
+  constructor(opts: { maxEntries?: number; ttlMs?: number; sweepEveryMs?: number } = {}) {
+    this.maxEntries = opts.maxEntries ?? 4096;
+    this.ttlMs = opts.ttlMs ?? 24 * 60 * 60 * 1000;
+    this.sweepEveryMs = opts.sweepEveryMs ?? Math.min(this.ttlMs, 15_000);
+  }
+
+  /** Returns true if this is a new key (now recorded); false if a duplicate. */
+  check(key: string): boolean {
+    const now = Date.now();
+    this.evictExpired(now);
+    const seenAt = this.seen.get(key);
+    // Honor the TTL on the looked-up key directly so amortizing the full sweep
+    // never makes an already-expired key read as a live duplicate.
+    if (seenAt !== undefined && seenAt >= now - this.ttlMs) {
+      this.seen.delete(key);
+      this.seen.set(key, now);
+      return false;
+    }
+    if (seenAt !== undefined) this.seen.delete(key);
+    this.seen.set(key, now);
+    if (this.seen.size > this.maxEntries) {
+      const first = this.seen.keys().next();
+      if (!first.done) this.seen.delete(first.value);
+    }
+    return true;
+  }
+
+  size(): number {
+    return this.seen.size;
+  }
+
+  clear(): void {
+    this.seen.clear();
+    this.lastSweepMs = -Infinity;
+  }
+
+  private evictExpired(now: number): void {
+    if (now - this.lastSweepMs < this.sweepEveryMs) return;
+    this.lastSweepMs = now;
+    const cutoff = now - this.ttlMs;
+    for (const [k, ts] of this.seen) {
+      if (ts >= cutoff) break;
+      this.seen.delete(k);
+    }
+  }
+}

--- a/packages/plugin-channel-slack/src/server/ingest-server.test.ts
+++ b/packages/plugin-channel-slack/src/server/ingest-server.test.ts
@@ -1,0 +1,280 @@
+import { createHmac } from 'node:crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+import { IngestServer, SLACK_EVENTS_PATH, type DispatchContext } from './ingest-server.js';
+import type { IngestServerHooks } from './ingest-server.js';
+import type { SlackEventCallback } from './schema.js';
+
+const SECRET = 'test-signing-secret-0123456789abcdef';
+const BOT_USER = 'UBOT';
+
+function sign(body: string, ts = Math.floor(Date.now() / 1000)): Record<string, string> {
+  const sig = `v0=${createHmac('sha256', SECRET).update(`v0:${ts}:${body}`).digest('hex')}`;
+  return { 'x-slack-request-timestamp': String(ts), 'x-slack-signature': sig };
+}
+
+interface Harness {
+  server: IngestServer;
+  url: string;
+  dispatched: DispatchContext[];
+  verified: SlackEventCallback[];
+  authorized: { teamId?: string; channel?: string } | null;
+  pairConsumes: boolean;
+  stop(): Promise<void>;
+}
+
+async function makeServer(over: Partial<IngestServerHooks> = {}): Promise<Harness> {
+  const dispatched: DispatchContext[] = [];
+  const verified: SlackEventCallback[] = [];
+  const state: { authorized: { teamId?: string; channel?: string } | null; pairConsumes: boolean } =
+    { authorized: { teamId: 'T1', channel: 'C1' }, pairConsumes: false };
+
+  const hooks: IngestServerHooks = {
+    botUserId: BOT_USER,
+    isAuthorized: (teamId, channel) =>
+      state.authorized != null &&
+      state.authorized.teamId === teamId &&
+      (state.authorized.channel === undefined || state.authorized.channel === channel),
+    onVerifiedEvent: (ev) => {
+      verified.push(ev);
+      return state.pairConsumes;
+    },
+    dispatch: (ctx) => dispatched.push(ctx),
+    ...over,
+  };
+
+  const server = new IngestServer({ signingSecret: SECRET, hooks });
+  const bound = await server.start();
+  const url = `http://${bound.host}:${bound.port}${SLACK_EVENTS_PATH}`;
+  return {
+    server,
+    url,
+    dispatched,
+    verified,
+    get authorized() {
+      return state.authorized;
+    },
+    set authorized(v) {
+      state.authorized = v;
+    },
+    get pairConsumes() {
+      return state.pairConsumes;
+    },
+    set pairConsumes(v) {
+      state.pairConsumes = v;
+    },
+    stop: () => server.stop(),
+  } as Harness;
+}
+
+function appMention(over: Partial<Record<string, unknown>> = {}): string {
+  return JSON.stringify({
+    type: 'event_callback',
+    team_id: 'T1',
+    event_id: 'Ev1',
+    event: {
+      type: 'app_mention',
+      user: 'U1',
+      text: '<@UBOT> hi',
+      channel: 'C1',
+      ts: '1700000000.000100',
+      ...over,
+    },
+  });
+}
+
+async function post(
+  url: string,
+  body: string,
+  headers: Record<string, string>,
+): Promise<{ status: number; json: unknown }> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body,
+  });
+  let json: unknown = null;
+  try {
+    json = await res.json();
+  } catch {
+    /* no body */
+  }
+  return { status: res.status, json };
+}
+
+describe('IngestServer', () => {
+  let h: Harness;
+  afterEach(async () => {
+    await h?.stop();
+  });
+
+  it('rejects an unsigned request with 401 (before the session)', async () => {
+    h = await makeServer();
+    const body = appMention();
+    const res = await post(h.url, body, {}); // no signature headers
+    expect(res.status).toBe(401);
+    expect(h.dispatched).toHaveLength(0);
+  });
+
+  it('rejects a tampered body with 401', async () => {
+    h = await makeServer();
+    const body = appMention();
+    const headers = sign(body);
+    const res = await post(h.url, appMention({ text: 'tampered' }), headers);
+    expect(res.status).toBe(401);
+    expect(h.dispatched).toHaveLength(0);
+  });
+
+  it('answers the url_verification challenge', async () => {
+    h = await makeServer();
+    const body = JSON.stringify({ type: 'url_verification', challenge: 'abc123' });
+    const res = await post(h.url, body, sign(body));
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({ challenge: 'abc123' });
+    expect(h.dispatched).toHaveLength(0);
+  });
+
+  it('rejects a signed-but-malformed envelope with 400', async () => {
+    h = await makeServer();
+    const body = JSON.stringify({ type: 'event_callback' /* no event */ });
+    const res = await post(h.url, body, sign(body));
+    expect(res.status).toBe(400);
+    expect(h.dispatched).toHaveLength(0);
+  });
+
+  it('acks 200 and dispatches an authorized app_mention', async () => {
+    h = await makeServer();
+    const body = appMention();
+    const res = await post(h.url, body, sign(body));
+    expect(res.status).toBe(200);
+    expect(h.dispatched).toHaveLength(1);
+    expect(h.dispatched[0]).toMatchObject({ channel: 'C1', text: '<@UBOT> hi', teamId: 'T1' });
+    // thread_ts falls back to ts when absent.
+    expect(h.dispatched[0]?.threadTs).toBe('1700000000.000100');
+  });
+
+  it('threads under thread_ts when present', async () => {
+    h = await makeServer();
+    const body = appMention({ thread_ts: '1699999999.000001' });
+    await post(h.url, body, sign(body));
+    expect(h.dispatched[0]?.threadTs).toBe('1699999999.000001');
+  });
+
+  it('drops a duplicate event_id (acks 200, does not re-dispatch)', async () => {
+    h = await makeServer();
+    const body = appMention();
+    const headers = sign(body);
+    const first = await post(h.url, body, headers);
+    const second = await post(h.url, body, sign(body));
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(h.dispatched).toHaveLength(1);
+  });
+
+  it('drops a Slack retry (X-Slack-Retry-Num) without dispatching', async () => {
+    h = await makeServer();
+    const body = appMention({ ts: '1700000000.999' });
+    const headers = { ...sign(body), 'x-slack-retry-num': '1' };
+    const res = await post(h.url, body, headers);
+    expect(res.status).toBe(200);
+    expect(h.dispatched).toHaveLength(0);
+  });
+
+  it("drops the bot's own message (bot_id / matching user)", async () => {
+    h = await makeServer();
+    const byBotId = appMention({ bot_id: 'B1', event_id: 'EvB1' });
+    await post(h.url, byBotId, sign(byBotId));
+    const byUser = appMention({ user: BOT_USER, event_id: 'EvB2' });
+    await post(h.url, byUser, sign(byUser));
+    expect(h.dispatched).toHaveLength(0);
+  });
+
+  it('drops an event from an unauthorized team/channel', async () => {
+    h = await makeServer();
+    h.authorized = { teamId: 'T-OTHER', channel: 'C-OTHER' };
+    const body = appMention();
+    const res = await post(h.url, body, sign(body));
+    expect(res.status).toBe(200);
+    expect(h.dispatched).toHaveLength(0);
+  });
+
+  it('lets the pairing hook consume the first verified event (no dispatch)', async () => {
+    h = await makeServer();
+    h.authorized = null; // not yet paired
+    h.pairConsumes = true;
+    const body = appMention();
+    const res = await post(h.url, body, sign(body));
+    expect(res.status).toBe(200);
+    expect(h.verified).toHaveLength(1);
+    expect(h.dispatched).toHaveLength(0);
+  });
+
+  it('ignores message events with an edit/system subtype', async () => {
+    h = await makeServer();
+    const body = JSON.stringify({
+      type: 'event_callback',
+      team_id: 'T1',
+      event_id: 'EvSub',
+      event: {
+        type: 'message',
+        subtype: 'message_changed',
+        channel: 'C1',
+        text: 'edited',
+        ts: '1700000000.1',
+      },
+    });
+    const res = await post(h.url, body, sign(body));
+    expect(res.status).toBe(200);
+    expect(h.dispatched).toHaveLength(0);
+  });
+
+  it('rejects an oversized body without ever dispatching', async () => {
+    const dispatched: DispatchContext[] = [];
+    const server = new IngestServer({
+      signingSecret: SECRET,
+      maxBodyBytes: 64,
+      hooks: {
+        botUserId: BOT_USER,
+        isAuthorized: () => true,
+        dispatch: (c) => dispatched.push(c),
+      },
+    });
+    const bound = await server.start();
+    const url = `http://${bound.host}:${bound.port}${SLACK_EVENTS_PATH}`;
+    const big = 'x'.repeat(500);
+    const body = JSON.stringify({ type: 'event_callback', big });
+    // readRequestBody destroys the socket once the cap is exceeded, so the
+    // client either sees a 413 or a dropped connection — both are acceptable
+    // "rejected, never reached the session" outcomes. What MUST hold is that
+    // the oversized body never drives a turn.
+    let status = 0;
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...sign(body) },
+        body,
+      });
+      status = res.status;
+    } catch {
+      status = -1; // connection dropped by the size-cap socket destroy
+    }
+    expect([413, -1]).toContain(status);
+    expect(dispatched).toHaveLength(0);
+    await server.stop();
+    // Reassign h so afterEach's stop() is a no-op on an already-stopped server.
+    h = { stop: async () => {} } as Harness;
+  });
+
+  it('a handler error never escalates (returns 404/4xx for junk)', async () => {
+    h = await makeServer();
+    // GET on the events path is a 404, not a thrown error.
+    const res = await fetch(h.url, { method: 'GET' });
+    expect(res.status).toBe(404);
+  });
+
+  it('serves a health probe', async () => {
+    h = await makeServer();
+    const base = h.url.replace(SLACK_EVENTS_PATH, '/slack/health');
+    const res = await fetch(base, { method: 'GET' });
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/plugin-channel-slack/src/server/ingest-server.ts
+++ b/packages/plugin-channel-slack/src/server/ingest-server.ts
@@ -1,0 +1,270 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { readRequestBody } from '@moxxy/sdk/server';
+import { DeliveryDedupeCache } from './dedupe.js';
+import { slackEnvelopeSchema, type SlackEventCallback } from './schema.js';
+import { verifySlackSignature } from './verify.js';
+
+/**
+ * The HTTP front-end for the Slack channel. Binds a `node:http` server to an
+ * ephemeral loopback port; the channel exposes it publicly via the proxy
+ * tunnel. Slack POSTs every event to `<public>/slack/events`.
+ *
+ * Handler order — every gate runs BEFORE the session is touched (skill A8/A46):
+ *   1. POST-only (+ a GET `/slack/health` liveness probe).
+ *   2. read the RAW body bytes (size cap) — required for the HMAC.
+ *   3. signature gate → 401 (verify over the raw bytes, before JSON.parse).
+ *   4. zod-validate the envelope → 400.
+ *   5. `url_verification` → echo `{ challenge }` (the handshake).
+ *   6. dedupe — drop on `X-Slack-Retry-Num` or a seen `event_id`.
+ *   7. drop the bot's own messages (`event.user === botUserId` / `event.bot_id`).
+ *   8. pairing gate — ignore unless the team/channel is authorized.
+ *   9. ACK 200 synchronously, THEN run the turn fire-and-forget (Slack's 3s
+ *      ack budget; never run `runTurn` on the request path).
+ *
+ * Every handler error is caught so a bad request can never escalate to a
+ * process-level uncaughtException.
+ */
+
+const EVENTS_PATH = '/slack/events';
+const HEALTH_PATH = '/slack/health';
+
+/** Decision the channel makes about an inbound event. */
+export interface DispatchContext {
+  readonly teamId: string | undefined;
+  readonly channel: string;
+  readonly text: string;
+  readonly user: string | undefined;
+  readonly threadTs: string;
+  readonly eventType: string;
+}
+
+export interface IngestServerHooks {
+  /** The bot's own user id, captured at start via `auth.test` (drop self-messages). */
+  readonly botUserId: string;
+  /** Is this team/channel authorized to drive the session? (pairing gate) */
+  isAuthorized(teamId: string | undefined, channel: string | undefined): boolean;
+  /**
+   * Observe a verified inbound event from a (possibly unauthorized) team/channel.
+   * Used by the TOFU `pair` flow to capture the first event and persist it.
+   * Returns true if the event was consumed by pairing (so it should NOT also
+   * drive a turn).
+   */
+  onVerifiedEvent?(ev: SlackEventCallback): boolean | Promise<boolean>;
+  /** Run a turn for an authorized, deduped, non-self event (fire-and-forget). */
+  dispatch(ctx: DispatchContext): void;
+}
+
+export interface IngestServerOptions {
+  readonly host?: string;
+  readonly signingSecret: string;
+  readonly hooks: IngestServerHooks;
+  /** Max request body size in bytes. Default 1MB. */
+  readonly maxBodyBytes?: number;
+  /** Override dedupe cache (tests). */
+  readonly dedupe?: DeliveryDedupeCache;
+  readonly logger?: {
+    info?(msg: string, meta?: Record<string, unknown>): void;
+    warn?(msg: string, meta?: Record<string, unknown>): void;
+  };
+}
+
+export interface IngestServerHandle {
+  readonly host: string;
+  readonly port: number;
+  stop(): Promise<void>;
+}
+
+export class IngestServer {
+  private server: Server | null = null;
+  private readonly host: string;
+  private readonly maxBodyBytes: number;
+  private readonly dedupe: DeliveryDedupeCache;
+  private boundPort = 0;
+
+  constructor(private readonly opts: IngestServerOptions) {
+    this.host = opts.host ?? '127.0.0.1';
+    this.maxBodyBytes = opts.maxBodyBytes ?? 1024 * 1024;
+    this.dedupe = opts.dedupe ?? new DeliveryDedupeCache();
+  }
+
+  get port(): number {
+    return this.boundPort;
+  }
+
+  /** Bind on an ephemeral loopback port. Resolves once listening. */
+  async start(): Promise<IngestServerHandle> {
+    if (this.server) {
+      return { host: this.host, port: this.boundPort, stop: () => this.stop() };
+    }
+    const server = createServer((req, res) => {
+      this.handle(req, res).catch((err) => {
+        this.opts.logger?.warn?.('slack: handler threw', { err: String(err) });
+        if (!res.headersSent) {
+          res.writeHead(500, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ error: 'internal' }));
+        } else {
+          try { res.end(); } catch { /* ignore */ }
+        }
+      });
+    });
+    this.server = server;
+
+    await new Promise<void>((resolve, reject) => {
+      const onError = (err: Error): void => reject(err);
+      server.once('error', onError);
+      // port 0 → OS assigns an ephemeral port; we read it back for the tunnel.
+      server.listen(0, this.host, () => {
+        server.off('error', onError);
+        const addr = server.address();
+        this.boundPort = addr && typeof addr === 'object' ? (addr as AddressInfo).port : 0;
+        this.opts.logger?.info?.('slack: ingest listening', {
+          host: this.host,
+          port: this.boundPort,
+        });
+        resolve();
+      });
+    });
+
+    return { host: this.host, port: this.boundPort, stop: () => this.stop() };
+  }
+
+  async stop(): Promise<void> {
+    const s = this.server;
+    if (!s) return;
+    this.server = null;
+    await new Promise<void>((resolve) => s.close(() => resolve()));
+  }
+
+  private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = (req.url ?? '/').split('?')[0] ?? '/';
+
+    // Liveness probe (the proxy relay / an operator can hit this).
+    if (req.method === 'GET' && url === HEALTH_PATH) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok', listener: 'slack' }));
+      return;
+    }
+
+    if (req.method !== 'POST' || url !== EVENTS_PATH) {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not_found' }));
+      return;
+    }
+
+    // 2) Raw body bytes (needed for the HMAC; verified BEFORE JSON.parse).
+    let raw: Buffer;
+    try {
+      raw = await readRequestBody(req, this.maxBodyBytes);
+    } catch (err) {
+      this.opts.logger?.warn?.('slack: rejected oversized body', {
+        limit: this.maxBodyBytes,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      res.writeHead(413, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'payload_too_large' }));
+      return;
+    }
+
+    // 3) Signature gate.
+    const verdict = verifySlackSignature({
+      rawBody: raw,
+      headers: req.headers,
+      signingSecret: this.opts.signingSecret,
+    });
+    if (!verdict.ok) {
+      this.opts.logger?.warn?.('slack: rejected delivery', { reason: verdict.reason });
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'verification_failed' }));
+      return;
+    }
+
+    // 4) zod-validate the envelope.
+    let parsedJson: unknown;
+    try {
+      parsedJson = JSON.parse(raw.toString('utf8'));
+    } catch {
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'invalid_json' }));
+      return;
+    }
+    const parsed = slackEnvelopeSchema.safeParse(parsedJson);
+    if (!parsed.success) {
+      this.opts.logger?.warn?.('slack: malformed envelope', {
+        issue: parsed.error.issues[0]?.message,
+      });
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'bad_request' }));
+      return;
+    }
+    const envelope = parsed.data;
+
+    // 5) url_verification handshake.
+    if (envelope.type === 'url_verification') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ challenge: envelope.challenge }));
+      return;
+    }
+
+    // From here on it's an event_callback. ACK fast; do everything else after
+    // (or fire-and-forget) so we stay inside Slack's 3-second ack budget.
+    const callback = envelope;
+
+    // 6) Dedupe — drop retries / repeated event ids. We record the id only for
+    // verified events so an unverified request can never poison the cache.
+    const isRetry = req.headers['x-slack-retry-num'] !== undefined;
+    const eventId = callback.event_id;
+    const dupe = isRetry || (eventId ? !this.dedupe.check(eventId) : false);
+
+    // 7) Self-message guard: never re-trigger on our own posts.
+    const ev = callback.event;
+    const isSelf =
+      ev.bot_id !== undefined ||
+      (ev.user !== undefined && ev.user === this.opts.hooks.botUserId);
+
+    // ACK synchronously BEFORE running anything.
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ status: 'ok' }));
+
+    if (dupe || isSelf) return;
+
+    // Pairing TOFU hook gets first crack at a verified event (even unauthorized),
+    // so it can capture + persist the first team/channel.
+    try {
+      const consumed = (await this.opts.hooks.onVerifiedEvent?.(callback)) ?? false;
+      if (consumed) return;
+    } catch (err) {
+      this.opts.logger?.warn?.('slack: pairing hook threw', { err: String(err) });
+    }
+
+    // 8) Pairing gate — only authorized team/channel drives the session.
+    if (!this.opts.hooks.isAuthorized(callback.team_id, ev.channel)) {
+      this.opts.logger?.info?.('slack: dropped event from unauthorized team/channel', {
+        team: callback.team_id,
+        channel: ev.channel,
+      });
+      return;
+    }
+
+    // Only act on message-ish events (we subscribe to app_mention primarily;
+    // message events with an edit/system subtype are ignored).
+    const eventType = ev.type;
+    if (eventType !== 'app_mention' && eventType !== 'message') return;
+    if (ev.subtype) return; // message_changed / message_deleted / channel_join …
+    const channel = ev.channel;
+    const text = (ev.text ?? '').trim();
+    if (!channel || !text) return;
+
+    // 9) Run the turn fire-and-forget (already ACKed).
+    this.opts.hooks.dispatch({
+      teamId: callback.team_id,
+      channel,
+      text,
+      user: ev.user,
+      threadTs: ev.thread_ts ?? ev.ts ?? channel,
+      eventType,
+    });
+  }
+}
+
+export { EVENTS_PATH as SLACK_EVENTS_PATH };

--- a/packages/plugin-channel-slack/src/server/schema.test.ts
+++ b/packages/plugin-channel-slack/src/server/schema.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { slackEnvelopeSchema, urlVerificationSchema, eventCallbackSchema } from './schema.js';
+
+describe('slack schemas', () => {
+  it('parses a url_verification challenge', () => {
+    const parsed = slackEnvelopeSchema.safeParse({
+      type: 'url_verification',
+      token: 'verif-token',
+      challenge: 'the-challenge-string',
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success && parsed.data.type === 'url_verification') {
+      expect(parsed.data.challenge).toBe('the-challenge-string');
+    }
+  });
+
+  it('rejects a url_verification with an empty challenge', () => {
+    const parsed = urlVerificationSchema.safeParse({ type: 'url_verification', challenge: '' });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('parses an app_mention event_callback', () => {
+    const parsed = slackEnvelopeSchema.safeParse({
+      type: 'event_callback',
+      team_id: 'T123',
+      event_id: 'Ev999',
+      event: {
+        type: 'app_mention',
+        user: 'U123',
+        text: '<@UBOT> hello',
+        channel: 'C123',
+        ts: '1700000000.000100',
+      },
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success && parsed.data.type === 'event_callback') {
+      expect(parsed.data.event.type).toBe('app_mention');
+      expect(parsed.data.team_id).toBe('T123');
+    }
+  });
+
+  it('rejects a body that is neither handshake nor event_callback', () => {
+    const parsed = slackEnvelopeSchema.safeParse({ type: 'something_else', foo: 1 });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects an event_callback whose event is not an object', () => {
+    const parsed = eventCallbackSchema.safeParse({ type: 'event_callback', event: 'nope' });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects an event_callback missing the inner event type', () => {
+    const parsed = eventCallbackSchema.safeParse({
+      type: 'event_callback',
+      event: { text: 'hi' },
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('tolerates unknown extra fields on the inner event (passthrough)', () => {
+    const parsed = eventCallbackSchema.safeParse({
+      type: 'event_callback',
+      event: { type: 'app_mention', some_future_field: { nested: true } },
+    });
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/packages/plugin-channel-slack/src/server/schema.ts
+++ b/packages/plugin-channel-slack/src/server/schema.ts
@@ -1,0 +1,77 @@
+import { z } from '@moxxy/sdk';
+
+/**
+ * zod schemas for the Slack Events API request bodies we accept. Every inbound
+ * body is validated against these BEFORE any field is read or the session is
+ * touched (AGENTS.md A8: validate inbound frames with zod first). Unknown event
+ * subtypes parse to the permissive envelope so we never throw on a Slack event
+ * type we don't subscribe to — we just ignore it.
+ */
+
+/** The URL-verification handshake Slack sends once when you set the Request URL. */
+export const urlVerificationSchema = z.object({
+  type: z.literal('url_verification'),
+  token: z.string().optional(),
+  challenge: z.string().min(1),
+});
+export type SlackUrlVerification = z.infer<typeof urlVerificationSchema>;
+
+/** A `message` or `app_mention` inner event. Loose on the many optional fields. */
+export const messageEventSchema = z.object({
+  type: z.enum(['message', 'app_mention']),
+  /** Author user id. Absent for some bot/system messages. */
+  user: z.string().optional(),
+  /** Set for messages posted by a bot integration (including our own). */
+  bot_id: z.string().optional(),
+  /** Message text (may be empty for attachment-only messages). */
+  text: z.string().optional(),
+  /** Channel the event occurred in. */
+  channel: z.string().optional(),
+  /** Message timestamp (also the thread root when no `thread_ts`). */
+  ts: z.string().optional(),
+  /** Present when the message is inside a thread. */
+  thread_ts: z.string().optional(),
+  /** `message_changed` / `message_deleted` etc. — we ignore edited/system subtypes. */
+  subtype: z.string().optional(),
+});
+export type SlackMessageEvent = z.infer<typeof messageEventSchema>;
+
+/** The `event_callback` envelope wrapping an inner event. */
+export const eventCallbackSchema = z.object({
+  type: z.literal('event_callback'),
+  /** Workspace/team id — the unit we pair against. */
+  team_id: z.string().optional(),
+  api_app_id: z.string().optional(),
+  /** Stable per-event id used for at-least-once dedupe. */
+  event_id: z.string().optional(),
+  event_time: z.number().optional(),
+  /** The actual event. We only act on message/app_mention; others pass through. */
+  event: z
+    .object({
+      type: z.string(),
+      user: z.string().optional(),
+      bot_id: z.string().optional(),
+      text: z.string().optional(),
+      channel: z.string().optional(),
+      ts: z.string().optional(),
+      thread_ts: z.string().optional(),
+      subtype: z.string().optional(),
+    })
+    .passthrough(),
+  /** Bot user ids this event was authorized for — lets us detect self-authored messages. */
+  authorizations: z
+    .array(z.object({ user_id: z.string().optional() }).passthrough())
+    .optional(),
+});
+export type SlackEventCallback = z.infer<typeof eventCallbackSchema>;
+
+/**
+ * The top-level Slack request envelope: either the one-off url_verification
+ * handshake or an event_callback. A discriminated union on `type` so a body
+ * that is neither is rejected with a clear error.
+ */
+export const slackEnvelopeSchema = z.discriminatedUnion('type', [
+  urlVerificationSchema,
+  eventCallbackSchema,
+]);
+export type SlackEnvelope = z.infer<typeof slackEnvelopeSchema>;

--- a/packages/plugin-channel-slack/src/server/verify.test.ts
+++ b/packages/plugin-channel-slack/src/server/verify.test.ts
@@ -1,0 +1,132 @@
+import { createHmac } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { SLACK_REPLAY_WINDOW_SEC, verifySlackSignature } from './verify.js';
+
+const SECRET = 'slack_signing_secret_abcdef0123456789';
+
+/** Build the headers Slack would send for `body` at epoch-seconds `ts`. */
+function sign(body: string, ts: number, secret = SECRET): Record<string, string> {
+  const base = `v0:${ts}:${body}`;
+  const sig = `v0=${createHmac('sha256', secret).update(base).digest('hex')}`;
+  return {
+    'x-slack-request-timestamp': String(ts),
+    'x-slack-signature': sig,
+  };
+}
+
+describe('verifySlackSignature', () => {
+  it('accepts a correctly signed request', () => {
+    const body = '{"type":"event_callback"}';
+    const ts = Math.floor(Date.now() / 1000);
+    const res = verifySlackSignature({
+      rawBody: Buffer.from(body),
+      headers: sign(body, ts),
+      signingSecret: SECRET,
+      nowMs: Date.now(),
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('verifies over the RAW bytes (a reserialized body fails)', () => {
+    // The signature is computed over the exact bytes; a body whose JSON has been
+    // reserialized (different whitespace) must not verify.
+    const rawBody = '{"a":1,"b":2}';
+    const ts = Math.floor(Date.now() / 1000);
+    const headers = sign(rawBody, ts);
+    const reserialized = JSON.stringify(JSON.parse(rawBody)); // identical here, so tweak spacing
+    const tweaked = '{ "a": 1, "b": 2 }';
+    expect(reserialized).not.toBe(tweaked);
+    const res = verifySlackSignature({
+      rawBody: Buffer.from(tweaked),
+      headers,
+      signingSecret: SECRET,
+      nowMs: Date.now(),
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects a wrong signature', () => {
+    const body = '{"x":1}';
+    const ts = Math.floor(Date.now() / 1000);
+    const headers = sign(body, ts);
+    headers['x-slack-signature'] = 'v0=deadbeef';
+    const res = verifySlackSignature({
+      rawBody: Buffer.from(body),
+      headers,
+      signingSecret: SECRET,
+      nowMs: Date.now(),
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects a request signed with a different secret', () => {
+    const body = '{"x":1}';
+    const ts = Math.floor(Date.now() / 1000);
+    const headers = sign(body, ts, 'a-different-secret-entirely');
+    const res = verifySlackSignature({
+      rawBody: Buffer.from(body),
+      headers,
+      signingSecret: SECRET,
+      nowMs: Date.now(),
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects a request outside the 5-minute replay window', () => {
+    const body = '{"x":1}';
+    const now = Date.now();
+    const oldTs = Math.floor(now / 1000) - (SLACK_REPLAY_WINDOW_SEC + 10);
+    const res = verifySlackSignature({
+      rawBody: Buffer.from(body),
+      headers: sign(body, oldTs),
+      signingSecret: SECRET,
+      nowMs: now,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/replay window/);
+  });
+
+  it('accepts a request at the edge of the replay window', () => {
+    const body = '{"x":1}';
+    const now = Date.now();
+    const edgeTs = Math.floor(now / 1000) - (SLACK_REPLAY_WINDOW_SEC - 5);
+    const res = verifySlackSignature({
+      rawBody: Buffer.from(body),
+      headers: sign(body, edgeTs),
+      signingSecret: SECRET,
+      nowMs: now,
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects when headers are missing', () => {
+    const res = verifySlackSignature({
+      rawBody: Buffer.from('{}'),
+      headers: {},
+      signingSecret: SECRET,
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects a non-numeric timestamp', () => {
+    const body = '{}';
+    const headers = sign(body, Math.floor(Date.now() / 1000));
+    headers['x-slack-request-timestamp'] = 'not-a-number';
+    const res = verifySlackSignature({
+      rawBody: Buffer.from(body),
+      headers,
+      signingSecret: SECRET,
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects when no signing secret is configured', () => {
+    const body = '{}';
+    const res = verifySlackSignature({
+      rawBody: Buffer.from(body),
+      headers: sign(body, Math.floor(Date.now() / 1000)),
+      signingSecret: '',
+    });
+    expect(res.ok).toBe(false);
+  });
+});

--- a/packages/plugin-channel-slack/src/server/verify.ts
+++ b/packages/plugin-channel-slack/src/server/verify.ts
@@ -1,0 +1,88 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Slack request-signature verification.
+ *
+ * Slack signs each request with HMAC-SHA256 over the string
+ * `v0:{X-Slack-Request-Timestamp}:{rawBody}`, hex-encoded and prefixed `v0=`,
+ * delivered in the `X-Slack-Signature` header. This is structurally identical
+ * to the Stripe HMAC scheme in `@moxxy/plugin-webhooks/src/verify.ts` — a
+ * timestamped HMAC over the raw bytes with a replay window — so the logic here
+ * mirrors it: verify over the EXACT raw body bytes (never the reserialized
+ * JSON), constant-time compare, and reject deliveries outside a ±5-minute
+ * window to bound replay.
+ *
+ * Always returns a structured verdict; the caller decides whether to log the
+ * reason (useful in dev) or hide it (preferable on a public endpoint).
+ *
+ * See: https://api.slack.com/authentication/verifying-requests-from-slack
+ */
+
+/** Slack's documented replay window: reject requests older than 5 minutes. */
+export const SLACK_REPLAY_WINDOW_SEC = 60 * 5;
+
+export type SlackVerifyResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: string };
+
+function lower(
+  headers: Record<string, string | string[] | undefined>,
+  name: string,
+): string | null {
+  const v = headers[name.toLowerCase()];
+  if (Array.isArray(v)) return v[0] ?? null;
+  return v ?? null;
+}
+
+/** Constant-time compare of two `v0=…` hex signatures. */
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  try {
+    return timingSafeEqual(ab, bb);
+  } catch {
+    return false;
+  }
+}
+
+export interface VerifySlackSignatureInput {
+  readonly rawBody: Buffer;
+  readonly headers: Record<string, string | string[] | undefined>;
+  readonly signingSecret: string;
+  /** Epoch-ms used to enforce the replay window. Defaults to `Date.now()`. */
+  readonly nowMs?: number;
+}
+
+/**
+ * Verify a Slack request signature against the raw body. Pass the EXACT bytes
+ * read off the socket, BEFORE `JSON.parse` — reserializing the body changes
+ * whitespace/key-order and breaks the HMAC.
+ */
+export function verifySlackSignature(input: VerifySlackSignatureInput): SlackVerifyResult {
+  const { rawBody, headers, signingSecret } = input;
+  if (!signingSecret) return { ok: false, reason: 'no signing secret configured' };
+
+  const timestamp = lower(headers, 'x-slack-request-timestamp');
+  const signature = lower(headers, 'x-slack-signature');
+  if (!timestamp) return { ok: false, reason: 'missing X-Slack-Request-Timestamp' };
+  if (!signature) return { ok: false, reason: 'missing X-Slack-Signature' };
+
+  const tsNum = Number(timestamp);
+  if (!Number.isFinite(tsNum)) return { ok: false, reason: 'non-numeric timestamp' };
+
+  const now = input.nowMs ?? Date.now();
+  const driftSec = Math.abs(now / 1000 - tsNum);
+  if (driftSec > SLACK_REPLAY_WINDOW_SEC) {
+    return { ok: false, reason: `timestamp drift ${Math.round(driftSec)}s exceeds replay window` };
+  }
+
+  // HMAC over `v0:{ts}:{rawBody}` — note the raw bytes, not a reserialized JSON.
+  const base = Buffer.concat([
+    Buffer.from(`v0:${timestamp}:`, 'utf8'),
+    rawBody,
+  ]);
+  const computed = `v0=${createHmac('sha256', signingSecret).update(base).digest('hex')}`;
+  if (safeEqual(computed, signature)) return { ok: true };
+  return { ok: false, reason: 'signature mismatch' };
+}

--- a/packages/plugin-channel-slack/src/setup-wizard.ts
+++ b/packages/plugin-channel-slack/src/setup-wizard.ts
@@ -1,0 +1,121 @@
+import {
+  cancel,
+  intro,
+  isCancel,
+  log,
+  note,
+  outro,
+  password,
+  spinner,
+  text,
+} from '@clack/prompts';
+import type { ChannelSubcommandContext } from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import {
+  SLACK_BOT_TOKEN_KEY,
+  SLACK_BOT_TOKEN_RE,
+  SLACK_SIGNING_SECRET_KEY,
+  slackSigningSecretSchema,
+} from './keys.js';
+import { SlackClient } from './channel/slack-client.js';
+
+const ANSI = process.stdout.isTTY && !process.env.NO_COLOR;
+const bold = (s: string): string => (ANSI ? `\x1b[1m${s}\x1b[22m` : s);
+const dim = (s: string): string => (ANSI ? `\x1b[2m${s}\x1b[22m` : s);
+
+/**
+ * Interactive Slack setup wizard (the channel's `interactiveCommand`).
+ *
+ * Walks the operator through:
+ *   1. paste the bot token (`xoxb-…`) into the vault,
+ *   2. paste the signing secret into the vault,
+ *   3. validate the token via `auth.test`,
+ *   4. choose the working folder + the autonomous tool allow-list,
+ *   5. start the channel (opens the proxy tunnel) and PRINT the public Request
+ *      URL to paste into the Slack app's Event Subscriptions.
+ *
+ * Headless invocations bypass this and start the channel directly (the dispatch
+ * caller decides; this is only reached on a TTY).
+ */
+export async function runSlackWizard(ctx: ChannelSubcommandContext): Promise<number> {
+  const vault = ctx.deps.vault as VaultStore;
+  intro(bold('moxxy slack setup'));
+
+  note(
+    'Create a Slack app at https://api.slack.com/apps → "From scratch".\n' +
+      '• OAuth & Permissions → add the bot scopes app_mentions:read, chat:write,\n' +
+      '  channels:history → Install to Workspace → copy the Bot User OAuth Token (xoxb-…).\n' +
+      '• Basic Information → App Credentials → copy the Signing Secret.\n' +
+      'Both go straight into the moxxy vault — no env vars needed.',
+    'create a Slack app',
+  );
+
+  const token = await password({
+    message: 'Paste the Bot User OAuth Token',
+    mask: '•',
+    validate: (v) => {
+      if (!v || !v.trim()) return 'required';
+      if (!SLACK_BOT_TOKEN_RE.test(v.trim())) return 'expected a token like "xoxb-…"';
+      return undefined;
+    },
+  });
+  if (isCancel(token)) {
+    cancel('cancelled.');
+    return 0;
+  }
+
+  const secret = await password({
+    message: 'Paste the Signing Secret',
+    mask: '•',
+    validate: (v) => {
+      const parsed = slackSigningSecretSchema.safeParse(v);
+      return parsed.success ? undefined : parsed.error.issues[0]?.message ?? 'invalid';
+    },
+  });
+  if (isCancel(secret)) {
+    cancel('cancelled.');
+    return 0;
+  }
+
+  // Validate the token before persisting anything the operator can act on.
+  const spin = spinner();
+  spin.start('Validating the bot token (auth.test)…');
+  try {
+    const client = new SlackClient({ token: String(token).trim() });
+    const auth = await client.authTest();
+    spin.stop(`Token OK — bot user ${auth.botUserId}${auth.team ? ` on ${auth.team}` : ''}.`);
+  } catch (err) {
+    spin.stop('Token validation failed.');
+    log.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+
+  await vault.set(SLACK_BOT_TOKEN_KEY, String(token).trim(), ['slack']);
+  await vault.set(SLACK_SIGNING_SECRET_KEY, String(secret).trim(), ['slack']);
+  log.success('Stored bot token + signing secret in the vault.');
+
+  const allow = await text({
+    message: 'Autonomous tool allow-list (comma-separated; "*" = all, blank = read-only)',
+    placeholder: 'Read, Grep, Glob',
+  });
+  if (isCancel(allow)) {
+    cancel('cancelled.');
+    return 0;
+  }
+  const allowedTools = String(allow)
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  note(
+    'Starting the channel — it opens a proxy tunnel and prints a public Request URL.\n' +
+      'Paste that URL into your Slack app → Event Subscriptions → Request URL, then\n' +
+      'subscribe to the bot event app_mention. Mention the bot in a channel to pair.',
+    'next steps',
+  );
+  log.info('Starting the bot. Press Ctrl+C to stop.');
+  outro(dim('handing off to the channel…'));
+
+  // Start in pairing mode so the first @mention establishes trust automatically.
+  return ctx.startChannel({ pair: true, allowedTools });
+}

--- a/packages/plugin-channel-slack/src/subcommands.test.ts
+++ b/packages/plugin-channel-slack/src/subcommands.test.ts
@@ -1,0 +1,189 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VaultStore, createStaticKeySource, deriveKey, generateSalt } from '@moxxy/plugin-vault';
+import type { ChannelDef } from '@moxxy/sdk';
+import { buildSlackPlugin } from './index.js';
+import {
+  SLACK_AUTHORIZED_KEY,
+  SLACK_BOT_TOKEN_KEY,
+  SLACK_SIGNING_SECRET_KEY,
+} from './keys.js';
+
+let tmp: string;
+let vault: VaultStore;
+let slackDef: ChannelDef;
+let writeOut: string[];
+let writeErr: string[];
+let origStdoutWrite: typeof process.stdout.write;
+let origStderrWrite: typeof process.stderr.write;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-slack-sub-'));
+  vault = new VaultStore({
+    filePath: path.join(tmp, 'vault.json'),
+    keySource: createStaticKeySource(deriveKey('test', generateSalt())),
+  });
+  const plugin = buildSlackPlugin({ vault });
+  slackDef = plugin.channels![0]!;
+  writeOut = [];
+  writeErr = [];
+  origStdoutWrite = process.stdout.write.bind(process.stdout);
+  origStderrWrite = process.stderr.write.bind(process.stderr);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    writeOut.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    writeErr.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+    return true;
+  }) as typeof process.stderr.write;
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+  process.stdout.write = origStdoutWrite;
+  process.stderr.write = origStderrWrite;
+  delete process.env.MOXXY_SLACK_BOT_TOKEN;
+  delete process.env.MOXXY_SLACK_SIGNING_SECRET;
+});
+
+function ctx(overrides: { startChannel?: () => Promise<number> } = {}) {
+  return {
+    deps: { cwd: tmp, vault, logger: undefined, options: {} },
+    args: { positional: [], flags: {} },
+    startChannel: overrides.startChannel ?? (async () => 0),
+    session: { setPermissionResolver: () => {} },
+  } as never;
+}
+
+describe('slack channel subcommands (registered on ChannelDef)', () => {
+  it('exposes setup, pair, status, unpair', () => {
+    expect(slackDef.subcommands).toBeDefined();
+    expect(Object.keys(slackDef.subcommands!)).toEqual(
+      expect.arrayContaining(['setup', 'pair', 'status', 'unpair']),
+    );
+    expect(slackDef.interactiveCommand).toBe('setup');
+  });
+
+  it('`status` reports unconfigured vault state as JSON', async () => {
+    const code = await slackDef.subcommands!.status!.run(ctx());
+    expect(code).toBe(0);
+    const parsed = JSON.parse(writeOut.join(''));
+    expect(parsed).toEqual({
+      botTokenConfigured: false,
+      signingSecretConfigured: false,
+      authorized: null,
+      tunnelUrl: null,
+    });
+  });
+
+  it('`status` surfaces stored token + secret + authorization', async () => {
+    await vault.set(SLACK_BOT_TOKEN_KEY, 'xoxb-1111-2222-abcdefghijklmnop');
+    await vault.set(SLACK_SIGNING_SECRET_KEY, '0123456789abcdef0123456789abcdef');
+    await vault.set(
+      SLACK_AUTHORIZED_KEY,
+      JSON.stringify({ teamId: 'T1', channelId: 'C1' }),
+    );
+    const code = await slackDef.subcommands!.status!.run(ctx());
+    expect(code).toBe(0);
+    const parsed = JSON.parse(writeOut.join(''));
+    expect(parsed).toEqual({
+      botTokenConfigured: true,
+      signingSecretConfigured: true,
+      authorized: { teamId: 'T1', channelId: 'C1' },
+      tunnelUrl: null,
+    });
+  });
+
+  it('`status` honors env overrides for token/secret', async () => {
+    process.env.MOXXY_SLACK_BOT_TOKEN = 'xoxb-env-token-abcdefghijkl';
+    process.env.MOXXY_SLACK_SIGNING_SECRET = 'env-signing-secret-0123456789';
+    const code = await slackDef.subcommands!.status!.run(ctx());
+    expect(code).toBe(0);
+    const parsed = JSON.parse(writeOut.join(''));
+    expect(parsed.botTokenConfigured).toBe(true);
+    expect(parsed.signingSecretConfigured).toBe(true);
+  });
+
+  it('`status` reports null for a corrupt authorization record', async () => {
+    await vault.set(SLACK_AUTHORIZED_KEY, 'not-json');
+    const code = await slackDef.subcommands!.status!.run(ctx());
+    expect(code).toBe(0);
+    const parsed = JSON.parse(writeOut.join(''));
+    expect(parsed.authorized).toBeNull();
+  });
+
+  it('`unpair` clears the authorization and reports', async () => {
+    await vault.set(SLACK_AUTHORIZED_KEY, JSON.stringify({ teamId: 'T1' }));
+    const code = await slackDef.subcommands!.unpair!.run(ctx());
+    expect(code).toBe(0);
+    expect(writeOut.join('')).toContain('unpaired');
+    expect(await vault.get(SLACK_AUTHORIZED_KEY)).toBeNull();
+  });
+
+  it('`unpair` is a no-op when nothing is paired', async () => {
+    const code = await slackDef.subcommands!.unpair!.run(ctx());
+    expect(code).toBe(0);
+    expect(writeOut.join('')).toContain('no pairing was active');
+  });
+
+  it('`pair` refuses to start without a TTY (interactive-only flow)', async () => {
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    try {
+      const startChannel = vi.fn(async () => 0);
+      const code = await slackDef.subcommands!.pair!.run(ctx({ startChannel }));
+      expect(code).toBe(1);
+      expect(startChannel).not.toHaveBeenCalled();
+      expect(writeErr.join('')).toMatch(/TTY/);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+    }
+  });
+
+  it('`setup` starts the channel directly when not on a TTY', async () => {
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    try {
+      const startChannel = vi.fn(async () => 0);
+      const code = await slackDef.subcommands!.setup!.run(ctx({ startChannel }));
+      expect(code).toBe(0);
+      expect(startChannel).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+    }
+  });
+
+  it('subcommands return 1 when vault is unavailable', async () => {
+    const badCtx = {
+      deps: { cwd: tmp, vault: undefined, logger: undefined, options: {} },
+      args: { positional: [], flags: {} },
+      startChannel: async () => 0,
+      session: { setPermissionResolver: () => {} },
+    } as never;
+    const code = await slackDef.subcommands!.status!.run(badCtx);
+    expect(code).toBe(1);
+    expect(writeErr.join('')).toContain('vault unavailable');
+  });
+
+  it('isAvailable gates on BOTH token and secret', async () => {
+    // Neither set → unavailable, reason names both.
+    let avail = await slackDef.isAvailable!({ cwd: tmp, vault });
+    expect(avail.ok).toBe(false);
+    expect(avail.reason).toMatch(/bot token/);
+    expect(avail.reason).toMatch(/signing secret/);
+
+    // Only token → still unavailable, reason names the secret.
+    await vault.set(SLACK_BOT_TOKEN_KEY, 'xoxb-1111-2222-abcdefghijklmnop');
+    avail = await slackDef.isAvailable!({ cwd: tmp, vault });
+    expect(avail.ok).toBe(false);
+    expect(avail.reason).toMatch(/signing secret/);
+
+    // Both → available.
+    await vault.set(SLACK_SIGNING_SECRET_KEY, '0123456789abcdef0123456789abcdef');
+    avail = await slackDef.isAvailable!({ cwd: tmp, vault });
+    expect(avail.ok).toBe(true);
+  });
+});

--- a/packages/plugin-channel-slack/tsconfig.json
+++ b/packages/plugin-channel-slack/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/plugin-channel-slack/vitest.config.ts
+++ b/packages/plugin-channel-slack/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/packages/sdk/src/event-store.ts
+++ b/packages/sdk/src/event-store.ts
@@ -13,7 +13,7 @@ import type { SessionId } from './ids.js';
  */
 
 /** Originating channel of a session (persisted into the meta sidecar). */
-export type SessionSource = 'cli' | 'tui' | 'desktop' | 'mobile';
+export type SessionSource = 'cli' | 'tui' | 'desktop' | 'mobile' | 'slack';
 
 /**
  * The single per-session metadata record (the JSONL impl writes it to

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -573,6 +573,9 @@ importers:
       '@moxxy/plugin-channel-mobile':
         specifier: workspace:*
         version: link:../plugin-channel-mobile
+      '@moxxy/plugin-channel-slack':
+        specifier: workspace:*
+        version: link:../plugin-channel-slack
       '@moxxy/plugin-channel-web':
         specifier: workspace:*
         version: link:../plugin-channel-web
@@ -1426,6 +1429,49 @@ importers:
       '@types/ws':
         specifier: 'catalog:'
         version: 8.18.1
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
+  packages/plugin-channel-slack:
+    dependencies:
+      '@clack/prompts':
+        specifier: 'catalog:'
+        version: 1.4.0
+      '@moxxy/config':
+        specifier: workspace:*
+        version: link:../config
+      '@moxxy/core':
+        specifier: workspace:*
+        version: link:../core
+      '@moxxy/plugin-tunnel-proxy':
+        specifier: workspace:*
+        version: link:../plugin-tunnel-proxy
+      '@moxxy/plugin-vault':
+        specifier: workspace:*
+        version: link:../plugin-vault
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
+    devDependencies:
+      '@moxxy/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
## What

A Slack bot as a first-class moxxy **channel** that runs on its **own dedicated agent runner**, isolated from your desktop/TUI work — so it can act separately from whatever you're doing.

### `@moxxy/plugin-channel-slack` (new built-in)
- **Inbound:** Slack **Events API over the self-hosted proxy relay** (no Socket Mode, no public host of your own). Own `node:http` ingest server behind `proxyTunnel` (`label: 'slack'`), like the webhooks/web channels.
- **Security:** verifies each request's HMAC signature (Slack `v0` scheme + 5-minute replay window, over the raw body), drops unverified/unauthorized/self events, and gates every session-reaching path behind signature + TOFU pairing.
- **Slack 3s ack:** acks synchronously, then drives the turn in the background; replies stream back into the triggering thread via `chat.update`.
- **At-least-once:** dedupes Slack retries (`X-Slack-Retry-Num` / `event_id`).
- **Autonomous allow-list permissions** (`channels.slack.allowedTools`; `['*']` = all, `[]` = read-only) — no human in the loop, so the bot acts independently. Reuses `createAllowListResolver`.
- **CLI/TUI:** `moxxy slack setup` (paste bot token + signing secret → vault, validate via `auth.test`, pick allow-list, open tunnel, print the Slack Request URL) + `moxxy channels slack pair|status|unpair`.
- 54 unit tests (signature accept/reject + replay window, challenge handshake, zod rejection, retry dedupe, allow-list, turnId-filtered streaming).

### Dedicated-runner capability (the "attach a channel to its own thread" ask)
- A channel can now run on its **own isolated runner** — a distinct runner socket + a stable sticky session — instead of attaching to whatever runner serves the desktop/TUI. Implemented purely by addressing in `startRegisteredChannel` (`applyDedicatedRunnerEnv`): **no runner-protocol change** (one dedicated runner is still one Session).
- `slack` is dedicated by default; any channel opts in with `--dedicated` / `MOXXY_DEDICATED_RUNNER=1`. Callers that pin the socket/session (e.g. a desktop supervisor) always win.
- The existing multi-runner machinery already makes this safe (graceful webhooks port-race, `ownerSessionId` gating) — no contention code needed.
- `SessionSource` gains `'slack'`, so the Slack runner's session is tagged distinctly and stays out of the desktop workspace sidebar.

## How to use
1. Create a Slack app → Event Subscriptions on, subscribe to `app_mention`.
2. `moxxy slack setup` → paste the bot token (`xoxb-…`) + signing secret, pick the allow-list. It prints the Request URL (`https://<uuid>.<host>/slack/events`) — paste it into the Slack app.
3. @mention the bot; it answers in-thread, streaming, on its own runner.

## Verification
- Full gate green: build / typecheck / lint / test / check:deps.
- Smoke-tested the real built CLI: `moxxy channels` lists `slack` (+ subcommands); reports `available` with env secrets and a clean "run setup" hint without; `moxxy channels slack status` returns JSON.

## Scope / follow-up
This ships the channel + CLI/TUI surface (satisfies "enable it from the TUI"). The **desktop Apps panel** (a `SlackRunnerManager` that spawns `moxxy slack` + IPC `slackBot.*` + UI, mirroring the Mobile gateway) is a documented fast-follow: because the bot runs as a separately-spawned process, the Electron main only needs child-process management (no plugin import → sidesteps the eager-import boot crash), but the user-secret-into-vault handling differs from mobile's self-generated token and is cleaner to land on top of this green base.
