### PR TITLE
feat(channels): declarative dedicated runner + Telegram parity

### DIFF
--- a/.changeset/channels-declarative-dedicated-runner.md
+++ b/.changeset/channels-declarative-dedicated-runner.md
@@ -1,0 +1,28 @@
+---
+"@moxxy/sdk": minor
+"@moxxy/plugin-telegram": minor
+"@moxxy/cli": patch
+"@moxxy/plugin-channel-slack": patch
+"@moxxy/desktop-ipc-contract": patch
+---
+
+Make "runs on a dedicated runner" a property a channel declares, and give
+Telegram the same dedicated-runner treatment as Slack.
+
+- `ChannelDef` gains optional `dedicatedRunner?: boolean` and
+  `sessionSource?: SessionSource`. A channel now declares for itself that it
+  should run on its own isolated runner (a distinct runner socket plus a sticky
+  session, separate from the runner serving your desktop/TUI). The CLI reads
+  this generically — there's no longer a hardcoded `name === 'slack'` check.
+  `--dedicated` / `MOXXY_DEDICATED_RUNNER=1` remain runtime opt-ins, and a
+  caller that already pinned the socket/session id/source (e.g. a supervisor)
+  still wins.
+- `@moxxy/plugin-telegram` now declares `dedicatedRunner: true` +
+  `sessionSource: 'telegram'`, so the Telegram bot runs on its own dedicated,
+  isolated runner with persistent history (`moxxy-channel-telegram`), matching
+  Slack. Telegram long-polls, so this needs no tunnel/webhook.
+- `@moxxy/plugin-channel-slack` now declares its dedicated-runner behavior
+  explicitly (previously implicit in the CLI). No behavior change.
+- `SessionSource` gains `'telegram'`. `DeskSession.source` in
+  `@moxxy/desktop-ipc-contract` now references the single `SessionSource` source
+  of truth in `@moxxy/sdk` instead of a hand-copied union.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -40,6 +40,11 @@ or recorded-on-purpose decision.
   on the `moxxy mobile` runner to make it airtight. `packages/plugin-channel-mobile`.
 - [note] Stress-test multi-session with a desk's SECOND (UUID) session — the first
   session has id === desk id, which masks pool-key regressions. `packages/desktop-host`.
+- [low] `SessionSource` literals are still hand-listed in one runtime spot:
+  `sessionSource()`'s validator in `packages/cli/src/setup/persistence.ts` (a type
+  can't be enumerated at runtime). `DeskSession.source` in `@moxxy/desktop-ipc-contract`
+  was unified onto the SDK type (2026-06-26); when adding a source, update the
+  union in `@moxxy/sdk` event-store.ts AND that guard.
 - [low] TUI `/sessions` switcher only works in self-host/standalone mode (the TUI
   owns the boot, so it can re-bootstrap onto a different session in place). In
   ATTACH mode (thin client against an external `moxxy serve`) the runner owns a

--- a/packages/cli/src/commands/run-channel.ts
+++ b/packages/cli/src/commands/run-channel.ts
@@ -5,7 +5,7 @@ import { argvToSetupOptions, hasBoolFlag } from '../argv-helpers.js';
 import { printError } from '../errors.js';
 import { probeSession, type SetupResult } from '../setup.js';
 import { runTuiWithBootstrap } from './run-tui.js';
-import { startRegisteredChannel } from './start-registered-channel.js';
+import { startRegisteredChannel, type DedicatedRunnerOpts } from './start-registered-channel.js';
 
 /**
  * Smart channel dispatcher. Routes the `moxxy <channel>` invocation
@@ -29,6 +29,12 @@ export async function runChannelByName(name: string, argv: ParsedArgv): Promise<
   // default UI, not a cross-package concern.)
   if (name === 'tui') return runTuiWithBootstrap(argv);
 
+  // The channel's dedicated-runner declaration, captured from the registry
+  // during the probe below. `applyDedicatedRunnerEnv` runs before any session
+  // boots and so can't resolve the def itself — the probe is the earliest point
+  // the registry exists, so we read it here and thread it into the headless run.
+  let dedicated: DedicatedRunnerOpts = {};
+
   // Light boot (a probe: no init hooks/daemons, no persistence, closed before
   // the headless runner below boots the REAL session) to read the channel
   // registry without activating a provider: the interactive-command path
@@ -48,6 +54,10 @@ export async function runChannelByName(name: string, argv: ParsedArgv): Promise<
         );
         return { code: 2 };
       }
+      dedicated = {
+        ...(def.dedicatedRunner !== undefined ? { dedicatedRunner: def.dedicatedRunner } : {}),
+        ...(def.sessionSource !== undefined ? { sessionSource: def.sessionSource } : {}),
+      };
 
       // A channel may declare an interactive setup subcommand shown by default
       // for TTY users. Bypass on:
@@ -85,7 +95,7 @@ export async function runChannelByName(name: string, argv: ParsedArgv): Promise<
 
   // Probe is closed; the headless path boots the real session (with init
   // hooks, so the daemons run exactly once, in the session that owns them).
-  return startRegisteredChannel(name, argv);
+  return startRegisteredChannel(name, argv, dedicated);
 }
 
 /**

--- a/packages/cli/src/commands/start-registered-channel.test.ts
+++ b/packages/cli/src/commands/start-registered-channel.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { applyDedicatedRunnerEnv } from './start-registered-channel.js';
+import type { ParsedArgv } from '../argv.js';
+
+const argv = (flags: ParsedArgv['flags'] = {}): ParsedArgv => ({
+  command: 'channel',
+  positional: [],
+  flags,
+});
+
+/**
+ * `applyDedicatedRunnerEnv` mutates process.env, so snapshot + restore the four
+ * vars it touches around every test to keep them hermetic.
+ */
+const KEYS = [
+  'MOXXY_RUNNER_SOCKET',
+  'MOXXY_SESSION_ID',
+  'MOXXY_SESSION_SOURCE',
+  'MOXXY_DEDICATED_RUNNER',
+] as const;
+
+describe('applyDedicatedRunnerEnv', () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = Object.fromEntries(KEYS.map((k) => [k, process.env[k]]));
+    for (const k of KEYS) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('honors a channel that declares dedicatedRunner + sessionSource (slack)', () => {
+    applyDedicatedRunnerEnv('slack', argv(), { dedicatedRunner: true, sessionSource: 'slack' });
+    expect(process.env.MOXXY_RUNNER_SOCKET).toContain('channel-slack');
+    expect(process.env.MOXXY_SESSION_ID).toBe('moxxy-channel-slack');
+    expect(process.env.MOXXY_SESSION_SOURCE).toBe('slack');
+  });
+
+  it('is generic over the channel name and source (telegram)', () => {
+    applyDedicatedRunnerEnv('telegram', argv(), {
+      dedicatedRunner: true,
+      sessionSource: 'telegram',
+    });
+    expect(process.env.MOXXY_RUNNER_SOCKET).toContain('channel-telegram');
+    expect(process.env.MOXXY_SESSION_ID).toBe('moxxy-channel-telegram');
+    expect(process.env.MOXXY_SESSION_SOURCE).toBe('telegram');
+  });
+
+  it('does nothing for an undeclared channel with no flag/env opt-in', () => {
+    applyDedicatedRunnerEnv('web', argv(), {});
+    expect(process.env.MOXXY_RUNNER_SOCKET).toBeUndefined();
+    expect(process.env.MOXXY_SESSION_ID).toBeUndefined();
+    expect(process.env.MOXXY_SESSION_SOURCE).toBeUndefined();
+  });
+
+  it('opts in via the --dedicated flag even when not declared', () => {
+    applyDedicatedRunnerEnv('web', argv({ dedicated: true }), {});
+    expect(process.env.MOXXY_RUNNER_SOCKET).toContain('channel-web');
+    expect(process.env.MOXXY_SESSION_ID).toBe('moxxy-channel-web');
+    // No declared sessionSource and none provided -> left to default resolution.
+    expect(process.env.MOXXY_SESSION_SOURCE).toBeUndefined();
+  });
+
+  it('opts in via MOXXY_DEDICATED_RUNNER=1', () => {
+    process.env.MOXXY_DEDICATED_RUNNER = '1';
+    applyDedicatedRunnerEnv('web', argv(), {});
+    expect(process.env.MOXXY_SESSION_ID).toBe('moxxy-channel-web');
+  });
+
+  it('never overrides env a caller already pinned (desktop supervisor wins)', () => {
+    process.env.MOXXY_RUNNER_SOCKET = '/custom.sock';
+    process.env.MOXXY_SESSION_ID = 'pinned-id';
+    process.env.MOXXY_SESSION_SOURCE = 'desktop';
+    applyDedicatedRunnerEnv('slack', argv(), { dedicatedRunner: true, sessionSource: 'slack' });
+    expect(process.env.MOXXY_RUNNER_SOCKET).toBe('/custom.sock');
+    expect(process.env.MOXXY_SESSION_ID).toBe('pinned-id');
+    expect(process.env.MOXXY_SESSION_SOURCE).toBe('desktop');
+  });
+});

--- a/packages/cli/src/commands/start-registered-channel.ts
+++ b/packages/cli/src/commands/start-registered-channel.ts
@@ -10,7 +10,7 @@ import {
 import type { Session } from '@moxxy/core';
 import { startChannelWith } from '@moxxy/sdk';
 import { moxxyPath } from '@moxxy/sdk/server';
-import type { ClientSession, SessionLike } from '@moxxy/sdk';
+import type { ClientSession, SessionLike, SessionSource } from '@moxxy/sdk';
 import {
   argvToSetupOptions,
   bootSessionWithConfig,
@@ -39,6 +39,19 @@ type _SessionIsClientSession = _AssertAssignable<Session, ClientSession>;
 type _SessionIsSessionLike = _AssertAssignable<Session, SessionLike>;
 
 /**
+ * What a channel declares (via its {@link ChannelDef}) about running on its own
+ * dedicated runner. Resolved by the dispatcher from the channel registry and
+ * threaded in — `applyDedicatedRunnerEnv` runs before any session boots, so it
+ * can't look the def up itself.
+ */
+export interface DedicatedRunnerOpts {
+  /** The channel declared `dedicatedRunner: true`. */
+  readonly dedicatedRunner?: boolean;
+  /** The channel's declared `sessionSource` (stamped when running dedicated). */
+  readonly sessionSource?: SessionSource;
+}
+
+/**
  * Run a registered channel by name, headlessly (no wizard, no TUI hand-off).
  *
  * Like `moxxy tui`, a channel is a thin client of the runner:
@@ -46,9 +59,16 @@ type _SessionIsSessionLike = _AssertAssignable<Session, SessionLike>;
  *    the channel against a RemoteSession.
  *  - otherwise -> boot a local session and, unless `--standalone`, open the
  *    runner socket so other clients can attach too (Option A).
+ *
+ * `dedicated` carries the channel's own `ChannelDef` declaration (resolved by
+ * the dispatcher); see {@link applyDedicatedRunnerEnv}.
  */
-export async function startRegisteredChannel(name: string, argv: ParsedArgv): Promise<number> {
-  applyDedicatedRunnerEnv(name, argv);
+export async function startRegisteredChannel(
+  name: string,
+  argv: ParsedArgv,
+  dedicated: DedicatedRunnerOpts = {},
+): Promise<number> {
+  applyDedicatedRunnerEnv(name, argv, dedicated);
   const standalone = hasBoolFlag(argv, 'standalone');
   const mode = chooseClientMode({ standalone, runnerUp: standalone ? false : await isRunnerUp() });
   if (mode === 'attach') return runAttachedChannel(name, argv);
@@ -67,14 +87,20 @@ export async function startRegisteredChannel(name: string, argv: ParsedArgv): Pr
  * isolated Session instead of attaching to the user's main runner. The stable
  * `MOXXY_SESSION_ID` persists that session's history across restarts.
  *
- * `slack` is dedicated by default (the whole point is to operate independently);
- * any channel can opt in with `--dedicated` or `MOXXY_DEDICATED_RUNNER=1`. A
- * caller that already pinned the socket/session id (e.g. the desktop supervisor)
+ * Whether a channel is dedicated is DECLARED by the channel itself
+ * (`ChannelDef.dedicatedRunner`, resolved by the dispatcher and passed in via
+ * `opts`) — the CLI keeps no per-channel name list. Any channel can also opt in
+ * at runtime with `--dedicated` or `MOXXY_DEDICATED_RUNNER=1`. A caller that
+ * already pinned the socket/session id/source (e.g. the desktop supervisor)
  * always wins — we only fill in what is unset.
  */
-function applyDedicatedRunnerEnv(name: string, argv: ParsedArgv): void {
+export function applyDedicatedRunnerEnv(
+  name: string,
+  argv: ParsedArgv,
+  opts: DedicatedRunnerOpts,
+): void {
   const dedicated =
-    name === 'slack' ||
+    opts.dedicatedRunner === true ||
     hasBoolFlag(argv, 'dedicated') ||
     process.env.MOXXY_DEDICATED_RUNNER === '1';
   if (!dedicated) return;
@@ -87,8 +113,8 @@ function applyDedicatedRunnerEnv(name: string, argv: ParsedArgv): void {
   if (!process.env.MOXXY_SESSION_ID) {
     process.env.MOXXY_SESSION_ID = `moxxy-channel-${name}`;
   }
-  if (!process.env.MOXXY_SESSION_SOURCE && name === 'slack') {
-    process.env.MOXXY_SESSION_SOURCE = 'slack';
+  if (!process.env.MOXXY_SESSION_SOURCE && opts.sessionSource) {
+    process.env.MOXXY_SESSION_SOURCE = opts.sessionSource;
   }
 }
 

--- a/packages/cli/src/setup/persistence.ts
+++ b/packages/cli/src/setup/persistence.ts
@@ -66,7 +66,8 @@ function sessionSource(): SessionSource {
     explicit === 'tui' ||
     explicit === 'mobile' ||
     explicit === 'cli' ||
-    explicit === 'slack'
+    explicit === 'slack' ||
+    explicit === 'telegram'
   ) {
     return explicit;
   }

--- a/packages/desktop-ipc-contract/src/desks.ts
+++ b/packages/desktop-ipc-contract/src/desks.ts
@@ -1,5 +1,7 @@
 // ---------- Desks ---------------------------------------------------------
 
+import type { SessionSource } from '@moxxy/sdk';
+
 /** One conversation under a desk. Each session is backed by its own
  *  runner process (the pool keys supervisors by session id) with its
  *  own sticky runner log (`~/.moxxy/sessions/<id>.jsonl`) and chat
@@ -14,7 +16,9 @@ export interface DeskSession {
   eventCount?: number;
   provider?: string | null;
   model?: string | null;
-  source?: 'desktop' | 'tui' | 'mobile' | 'cli' | 'slack';
+  /** Originating channel; the single source of truth is `@moxxy/sdk`'s
+   *  {@link SessionSource} (was a hand-copied union — kept in lockstep here). */
+  source?: SessionSource;
 }
 
 export interface Desk {

--- a/packages/plugin-channel-slack/src/index.ts
+++ b/packages/plugin-channel-slack/src/index.ts
@@ -105,6 +105,11 @@ function makeSlackPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks): Pl
         name: 'slack',
         description:
           'Slack bot channel: ingests the Events API over the proxy relay and streams threaded replies. Autonomous allow-list permissions (no human in the loop).',
+        // Runs on its own dedicated, isolated runner (separate socket + sticky
+        // session) so the bot operates independently of the user's desktop/TUI.
+        // The CLI reads these generically — no per-channel name list.
+        dedicatedRunner: true,
+        sessionSource: 'slack',
         create: (deps) => {
           const options = deps.options;
           const allowedTools = readAllowedTools(options);

--- a/packages/plugin-telegram/src/index.ts
+++ b/packages/plugin-telegram/src/index.ts
@@ -77,6 +77,11 @@ function makeTelegramPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks):
       defineChannel({
         name: 'telegram',
         description: 'Telegram bot channel via grammy. TOFU + code-pairing authorization.',
+        // Like Slack, run on a dedicated, isolated runner (separate socket +
+        // sticky session) so the bot keeps its own persistent history apart from
+        // the user's desktop/TUI work. Telegram long-polls (no tunnel needed).
+        dedicatedRunner: true,
+        sessionSource: 'telegram',
         create: (deps) =>
           new TelegramChannel({
             vault: getVault(),

--- a/packages/sdk/src/channel.ts
+++ b/packages/sdk/src/channel.ts
@@ -1,5 +1,6 @@
 import type { PermissionResolver } from './permission.js';
 import type { ClientSession } from './client-session.js';
+import type { SessionSource } from './event-store.js';
 
 /**
  * A Channel is a bidirectional surface that drives a Session: it feeds user
@@ -134,6 +135,24 @@ export interface ChannelDef<TStartOpts = unknown> {
    * starts the channel.
    */
   readonly interactiveCommand?: string;
+  /**
+   * Declare that this channel runs on its OWN dedicated, isolated runner: a
+   * distinct runner socket (`channel-<name>.sock`) + a stable sticky session id
+   * (`moxxy-channel-<name>`), so the channel acts as its own agent thread,
+   * separate from whatever runner serves the desktop/TUI. NO runner-protocol
+   * change — one dedicated runner is still one Session. Channels that should
+   * operate autonomously (slack, telegram) set this; the CLI reads it generically
+   * (see `applyDedicatedRunnerEnv`) so no per-channel name list is needed. Any
+   * channel can also opt in at runtime via `--dedicated` / `MOXXY_DEDICATED_RUNNER=1`.
+   */
+  readonly dedicatedRunner?: boolean;
+  /**
+   * The {@link SessionSource} to stamp on this channel's sessions when it runs
+   * dedicated (persisted into the meta sidecar; surfaces filter history by it).
+   * Only honored alongside `dedicatedRunner`. When unset, the source falls back
+   * to the usual env/default resolution.
+   */
+  readonly sessionSource?: SessionSource;
 }
 
 export interface ChannelAvailability {

--- a/packages/sdk/src/event-store.ts
+++ b/packages/sdk/src/event-store.ts
@@ -13,7 +13,7 @@ import type { SessionId } from './ids.js';
  */
 
 /** Originating channel of a session (persisted into the meta sidecar). */
-export type SessionSource = 'cli' | 'tui' | 'desktop' | 'mobile' | 'slack';
+export type SessionSource = 'cli' | 'tui' | 'desktop' | 'mobile' | 'slack' | 'telegram';
 
 /**
  * The single per-session metadata record (the JSONL impl writes it to


### PR DESCRIPTION
## What

Makes "runs on a dedicated, isolated runner" a property a **channel declares** on its `ChannelDef`, read generically by the CLI — instead of the hardcoded `name === 'slack'` check that PR #377 introduced. Then gives **Telegram** the same dedicated-runner treatment as Slack.

This is groundwork for the desktop "Channels" panel (next PR), which lets desktop users start/stop Slack & Telegram, each on its own isolated runner.

## Why

PR #377 shipped the dedicated-runner mechanism but keyed it to Slack by name in two places inside `applyDedicatedRunnerEnv`. To reuse it for Telegram (and any future channel) without editing the CLI per channel, the policy should live on the channel plugin. Telegram benefits from an isolated, persistent session (`moxxy-channel-telegram`) exactly like Slack — it long-polls, so it needs no tunnel/webhook.

## Changes

- **`@moxxy/sdk`** — `ChannelDef` gains optional `dedicatedRunner?: boolean` and `sessionSource?: SessionSource`. `SessionSource` gains `'telegram'`.
- **CLI** — `run-channel.ts` captures the declaration from the channel registry during its existing probe and threads it into `startRegisteredChannel` → `applyDedicatedRunnerEnv`, which now reads `opts.dedicatedRunner` / `opts.sessionSource` (no name list). `--dedicated` / `MOXXY_DEDICATED_RUNNER=1` remain runtime opt-ins; a caller that already pinned the socket/session id/source still wins. `persistence.ts` `sessionSource()` guard accepts `'telegram'`.
- **`@moxxy/plugin-telegram`** — declares `dedicatedRunner: true` + `sessionSource: 'telegram'`.
- **`@moxxy/plugin-channel-slack`** — declares its (previously CLI-implicit) behavior explicitly. No behavior change.
- **`@moxxy/desktop-ipc-contract`** — `DeskSession.source` now references the SDK `SessionSource` source of truth instead of a hand-copied union (retires a latent duplication; the only remaining hand-list is the runtime validator in `persistence.ts`, logged in TECH_DEBT).

## Tests

- New unit test for `applyDedicatedRunnerEnv`: declared (slack/telegram), undeclared no-op, `--dedicated` + env opt-ins, and caller-pinned-env-wins.
- Full gate green: build 74/74, typecheck 141/141, lint 0 errors, deps 0 errors, tests 139/139 + scripts.

## Verify

With a bot token in the vault, run the built CLI `moxxy telegram` headless → it binds `~/.moxxy/channel-telegram.sock`, session `moxxy-channel-telegram`, source `telegram`. `moxxy slack` stays dedicated as before.