### PR TITLE
feat(desktop): run Slack & Telegram channels from the Apps panel

### DIFF
--- a/.changeset/desktop-run-channels.md
+++ b/.changeset/desktop-run-channels.md
@@ -1,0 +1,28 @@
+---
+"@moxxy/desktop-ipc-contract": minor
+"@moxxy/desktop-host": minor
+"@moxxy/client-core": minor
+"@moxxy/sdk": minor
+"@moxxy/desktop": patch
+"@moxxy/cli": patch
+---
+
+Run Slack & Telegram channels from the desktop, each on its own dedicated runner.
+
+- **Apps → Channels** (new sub-tab): per channel, enter its secrets (stored in
+  the vault), Start/Stop its dedicated-runner subprocess, and — for Slack — copy
+  the public Request URL to paste into the Slack app once its proxy tunnel opens.
+  The channel runs as a separate isolated session, so its conversation is
+  intentionally not shown in the workspace sidebar; the panel manages the runner.
+- New IPC: `channels.list` / `channels.saveConfig` / `channels.start` /
+  `channels.stop` + a `channels.status` event (host-only — NOT remote-reachable).
+  A `ChannelSupervisor` in `@moxxy/desktop-host` spawns `moxxy <channel>` with
+  `MOXXY_DEDICATED_RUNNER=1`, supervises it, and reads the channel's status file
+  for the Request URL. Secrets are written to the same in-process vault the runner
+  reads, keyed by the names each channel plugin uses (a small static catalog).
+- A dedicated channel runner now publishes a tiny status file
+  (`~/.moxxy/channel-<name>.status.json`) with its pid + public ingest URL while
+  running, removed on shutdown — so a supervisor can observe it without the runner
+  protocol. New `@moxxy/sdk/server` helpers (`writeChannelStatus` /
+  `readChannelStatus` / `clearChannelStatus`) + an optional `Channel.requestUrl`
+  getter back this.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -142,6 +142,18 @@ or recorded-on-purpose decision.
 
 ## Channels, relay & HTTP
 
+- [low] Desktop channel catalog hand-copies each channel's vault key names +
+  config fields (`packages/desktop-host/src/channel-catalog.ts`) so the Channels
+  panel can render a form without booting plugin discovery in the Electron main.
+  The plugins' `keys.ts` stay the source of truth (a unit test pins the copy). A
+  `moxxy channels describe --json` command sourcing it from each `ChannelDef`
+  (now that `dedicatedRunner`/`sessionSource`/`requestUrl` are declarative) would
+  remove the duplication.
+- [low] Desktop-spawned channels are killed on app quit (a best-effort
+  `process.once('exit')` SIGTERM in `channel-supervisor.ts`); no cross-restart
+  re-adoption of an already-running channel by its status-file pid. Fine for v1
+  (no orphans, each session starts clean); revisit if channels should outlive the
+  desktop. `packages/desktop-host/src/channel-supervisor.ts`.
 - [med] Relay is the single-instance sole remote path — no fallback; needs uptime
   monitoring + redeploy story (decide on an emergency escape hatch). `plugin-tunnel-proxy`.
 - [med] Channel→core prod dependency — `plugin-cli`/`plugin-telegram` still import

--- a/apps/desktop/src/apps/AppsPanel.tsx
+++ b/apps/desktop/src/apps/AppsPanel.tsx
@@ -6,14 +6,16 @@ import { AppCard } from './AppCard';
 import { WorkflowsPanel } from '../workflows/WorkflowsPanel';
 import { SchedulesPanel } from './SchedulesPanel';
 import { WebhooksPanel } from './WebhooksPanel';
+import { ChannelsPanel } from './ChannelsPanel';
 import './builtins';
 
 /** Apps sub-surfaces. `gallery` is the installable-app grid (the landing); the
- *  other three are the ambient-automation surfaces reached from the header's
- *  right-side sub-nav chips. */
-type AppsTab = 'gallery' | 'workflows' | 'schedules' | 'webhooks';
+ *  others are the channel + ambient-automation surfaces reached from the
+ *  header's right-side sub-nav chips. */
+type AppsTab = 'gallery' | 'channels' | 'workflows' | 'schedules' | 'webhooks';
 
 const SUB_TABS = [
+  { id: 'channels', label: 'Channels' },
   { id: 'workflows', label: 'Workflows' },
   { id: 'schedules', label: 'Schedules' },
   { id: 'webhooks', label: 'Webhooks' },
@@ -77,6 +79,7 @@ export function AppsPanel({
         />
       </ViewHeader>
       {tab === 'gallery' && <Gallery onOpen={setOpenId} />}
+      {tab === 'channels' && <ChannelsPanel />}
       {tab === 'workflows' && <WorkflowsPanel embedded onView={onView} />}
       {tab === 'schedules' && <SchedulesPanel />}
       {tab === 'webhooks' && <WebhooksPanel />}

--- a/apps/desktop/src/apps/ChannelsPanel.tsx
+++ b/apps/desktop/src/apps/ChannelsPanel.tsx
@@ -1,0 +1,311 @@
+/**
+ * Channels sub-view of the Apps surface. Lists the communication channels the
+ * desktop can run (Slack, Telegram), each on its own dedicated, isolated runner.
+ * Per channel: enter its secrets (stored in the vault), Start/Stop the runner,
+ * and — for Slack — copy the public Request URL to paste into the Slack app once
+ * the tunnel is up. Content-only — the Apps header is owned by {@link AppsPanel}.
+ *
+ * The channel's conversation is intentionally NOT shown here (it runs as a
+ * separate isolated session); this panel manages the runner, not its chat.
+ */
+
+import { useState } from 'react';
+import { useChannels } from '@moxxy/client-core';
+import { Button, Icon, Skeleton, TextInput } from '@moxxy/desktop-ui';
+import type { ChannelEntry } from '@moxxy/desktop-ipc-contract';
+
+export function ChannelsPanel(): JSX.Element {
+  const channels = useChannels();
+
+  return (
+    <>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, padding: '12px 24px 0' }}>
+        <Button variant="chip" onClick={() => void channels.refresh()} style={{ borderRadius: 9 }}>
+          <Icon name="rotate" size={14} />
+          Refresh
+        </Button>
+      </div>
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          padding: '1.5rem 2rem',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1rem',
+        }}
+      >
+        {channels.error && (
+          <p
+            role="alert"
+            style={{
+              margin: 0,
+              padding: '0.45rem 0.65rem',
+              border: '1px solid var(--color-pink)',
+              background: 'color-mix(in oklab, var(--color-pink) 12%, transparent)',
+              borderRadius: 'var(--radius-block)',
+              fontSize: '0.85rem',
+            }}
+          >
+            {channels.error}
+          </p>
+        )}
+        {channels.loading && channels.list.length === 0 ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+            <Skeleton.Card />
+            <Skeleton.Card />
+          </div>
+        ) : (
+          channels.list.map((entry) => (
+            <ChannelCard
+              key={entry.descriptor.id}
+              entry={entry}
+              onSaveConfig={channels.saveConfig}
+              onStart={channels.start}
+              onStop={channels.stop}
+            />
+          ))
+        )}
+      </div>
+    </>
+  );
+}
+
+/** Status dot color: green running · red errored · grey configured-idle · faint
+ *  when not yet configured. */
+function statusColor(entry: ChannelEntry): string {
+  if (entry.status.running) return 'var(--color-green)';
+  if (entry.status.error) return 'var(--color-pink)';
+  if (entry.status.configured) return 'var(--color-text-dim)';
+  return 'var(--color-border)';
+}
+
+function statusLabel(entry: ChannelEntry): string {
+  if (entry.status.running) return 'Running';
+  if (entry.status.error) return 'Stopped (error)';
+  if (entry.status.configured) return 'Configured';
+  return 'Not configured';
+}
+
+function ChannelCard({
+  entry,
+  onSaveConfig,
+  onStart,
+  onStop,
+}: {
+  readonly entry: ChannelEntry;
+  readonly onSaveConfig: (id: string, values: Record<string, string>) => Promise<void>;
+  readonly onStart: (id: string) => Promise<void>;
+  readonly onStop: (id: string) => Promise<void>;
+}): JSX.Element {
+  const { descriptor, status } = entry;
+  // Open the config form by default when nothing is stored yet.
+  const [configuring, setConfiguring] = useState(!status.configured);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState(false);
+
+  const setField = (name: string, v: string): void => setValues((cur) => ({ ...cur, [name]: v }));
+
+  const save = async (): Promise<void> => {
+    setBusy(true);
+    try {
+      await onSaveConfig(descriptor.id, values);
+      setValues({}); // don't retain secrets in renderer memory
+      setConfiguring(false);
+    } catch {
+      /* error surfaced via the hook's error state */
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const toggleRun = async (): Promise<void> => {
+    setBusy(true);
+    try {
+      if (status.running) await onStop(descriptor.id);
+      else await onStart(descriptor.id);
+    } catch {
+      /* error surfaced via the hook's error state */
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      data-testid={`channel-row-${descriptor.id}`}
+      style={{
+        padding: '0.85rem 1rem',
+        background: 'var(--color-bg-card)',
+        border: '1px solid var(--color-border)',
+        borderRadius: 'var(--radius-block)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.6rem',
+      }}
+    >
+      {/* Header: icon · name + status · run/configure controls */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem' }}>
+        <Icon name="chat" size={18} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ fontWeight: 600, fontSize: '0.95rem' }}>{descriptor.name}</span>
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+              <span
+                aria-hidden
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  background: statusColor(entry),
+                }}
+              />
+              <span style={{ fontSize: '0.72rem', color: 'var(--color-text-dim)' }}>
+                {statusLabel(entry)}
+              </span>
+            </span>
+          </div>
+          <div style={{ fontSize: '0.8rem', color: 'var(--color-text-muted)', marginTop: 2 }}>
+            {descriptor.description}
+          </div>
+        </div>
+        <Button
+          variant="chip"
+          onClick={() => setConfiguring((v) => !v)}
+          style={{ borderRadius: 9 }}
+          data-testid={`channel-configure-${descriptor.id}`}
+        >
+          {configuring ? 'Hide' : status.configured ? 'Reconfigure' : 'Configure'}
+        </Button>
+        <Button
+          variant={status.running ? 'secondary' : 'cta'}
+          onClick={() => void toggleRun()}
+          disabled={busy || (!status.running && !status.configured)}
+          style={{ borderRadius: 9 }}
+          data-testid={`channel-toggle-${descriptor.id}`}
+        >
+          <Icon name={status.running ? 'stop' : 'spark'} size={14} />
+          {status.running ? 'Stop' : 'Start'}
+        </Button>
+      </div>
+
+      {/* Config form */}
+      {configuring && (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+            padding: '10px 12px',
+            background: 'var(--color-card-bg)',
+            border: '1px solid var(--color-card-border)',
+            borderRadius: 12,
+          }}
+        >
+          {descriptor.configFields.map((f) => (
+            <label key={f.name} style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+              <span style={{ fontSize: '0.78rem', color: 'var(--color-text-muted)' }}>
+                {f.label}
+                {f.required ? '' : ' (optional)'}
+              </span>
+              <TextInput
+                type={f.type === 'password' ? 'password' : 'text'}
+                value={values[f.name] ?? ''}
+                onChange={(e) => setField(f.name, e.target.value)}
+                placeholder={
+                  f.placeholder ?? (status.configured ? 'Stored — leave blank to keep' : '')
+                }
+                style={{ width: '100%', fontSize: 13, borderRadius: 9 }}
+              />
+              {f.help && (
+                <span style={{ fontSize: '0.7rem', color: 'var(--color-text-dim)' }}>{f.help}</span>
+              )}
+            </label>
+          ))}
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+            <Button
+              variant="cta"
+              onClick={() => void save()}
+              disabled={busy || Object.values(values).every((v) => !v.trim())}
+              style={{ borderRadius: 9, padding: '7px 14px', fontSize: 12.5 }}
+            >
+              {busy ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Running affordances: Slack's Request URL + the per-channel run hint */}
+      {status.running && descriptor.hasWebhookUrl && (
+        <RequestUrlRow url={status.requestUrl} />
+      )}
+      {status.running && descriptor.runHint && (
+        <div style={{ fontSize: '0.78rem', color: 'var(--color-text-dim)' }}>{descriptor.runHint}</div>
+      )}
+      {status.error && (
+        <div
+          role="alert"
+          className="mono"
+          style={{ fontSize: '0.72rem', color: 'var(--color-pink)', whiteSpace: 'pre-wrap' }}
+        >
+          {status.error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Slack's public Request URL with a copy button — shown once its tunnel opens.
+ *  While the URL is still resolving it reads as a muted placeholder. */
+function RequestUrlRow({ url }: { readonly url?: string }): JSX.Element {
+  const [copied, setCopied] = useState(false);
+  if (!url) {
+    return (
+      <div style={{ fontSize: '0.78rem', color: 'var(--color-text-dim)' }}>
+        Opening the proxy tunnel — the Request URL will appear here…
+      </div>
+    );
+  }
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '6px 8px',
+        background: 'var(--color-card-bg)',
+        border: '1px solid var(--color-card-border)',
+        borderRadius: 9,
+      }}
+    >
+      <span style={{ fontSize: '0.7rem', color: 'var(--color-text-muted)' }}>Request URL</span>
+      <span
+        className="mono"
+        title={url}
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontSize: '0.72rem',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {url}
+      </span>
+      <Button
+        variant="chip"
+        onClick={() => {
+          void navigator.clipboard?.writeText(url);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        }}
+        style={{ borderRadius: 9 }}
+      >
+        <Icon name={copied ? 'check' : 'copy'} size={14} />
+        {copied ? 'Copied' : 'Copy'}
+      </Button>
+    </div>
+  );
+}

--- a/packages/cli/src/commands/start-registered-channel.test.ts
+++ b/packages/cli/src/commands/start-registered-channel.test.ts
@@ -41,18 +41,20 @@ describe('applyDedicatedRunnerEnv', () => {
     expect(process.env.MOXXY_SESSION_SOURCE).toBe('slack');
   });
 
-  it('is generic over the channel name and source (telegram)', () => {
-    applyDedicatedRunnerEnv('telegram', argv(), {
+  it('returns true and is generic over the channel name and source (telegram)', () => {
+    const dedicated = applyDedicatedRunnerEnv('telegram', argv(), {
       dedicatedRunner: true,
       sessionSource: 'telegram',
     });
+    expect(dedicated).toBe(true);
     expect(process.env.MOXXY_RUNNER_SOCKET).toContain('channel-telegram');
     expect(process.env.MOXXY_SESSION_ID).toBe('moxxy-channel-telegram');
     expect(process.env.MOXXY_SESSION_SOURCE).toBe('telegram');
   });
 
-  it('does nothing for an undeclared channel with no flag/env opt-in', () => {
-    applyDedicatedRunnerEnv('web', argv(), {});
+  it('returns false and does nothing for an undeclared channel with no opt-in', () => {
+    const dedicated = applyDedicatedRunnerEnv('web', argv(), {});
+    expect(dedicated).toBe(false);
     expect(process.env.MOXXY_RUNNER_SOCKET).toBeUndefined();
     expect(process.env.MOXXY_SESSION_ID).toBeUndefined();
     expect(process.env.MOXXY_SESSION_SOURCE).toBeUndefined();

--- a/packages/cli/src/commands/start-registered-channel.ts
+++ b/packages/cli/src/commands/start-registered-channel.ts
@@ -9,7 +9,7 @@ import {
 } from '@moxxy/runner';
 import type { Session } from '@moxxy/core';
 import { startChannelWith } from '@moxxy/sdk';
-import { moxxyPath } from '@moxxy/sdk/server';
+import { moxxyPath, writeChannelStatus, clearChannelStatus } from '@moxxy/sdk/server';
 import type { ClientSession, SessionLike, SessionSource } from '@moxxy/sdk';
 import {
   argvToSetupOptions,
@@ -68,11 +68,11 @@ export async function startRegisteredChannel(
   argv: ParsedArgv,
   dedicated: DedicatedRunnerOpts = {},
 ): Promise<number> {
-  applyDedicatedRunnerEnv(name, argv, dedicated);
+  const isDedicated = applyDedicatedRunnerEnv(name, argv, dedicated);
   const standalone = hasBoolFlag(argv, 'standalone');
   const mode = chooseClientMode({ standalone, runnerUp: standalone ? false : await isRunnerUp() });
   if (mode === 'attach') return runAttachedChannel(name, argv);
-  return runSelfHostedChannel(name, argv, mode === 'standalone');
+  return runSelfHostedChannel(name, argv, mode === 'standalone', isDedicated);
 }
 
 /**
@@ -98,12 +98,12 @@ export function applyDedicatedRunnerEnv(
   name: string,
   argv: ParsedArgv,
   opts: DedicatedRunnerOpts,
-): void {
+): boolean {
   const dedicated =
     opts.dedicatedRunner === true ||
     hasBoolFlag(argv, 'dedicated') ||
     process.env.MOXXY_DEDICATED_RUNNER === '1';
-  if (!dedicated) return;
+  if (!dedicated) return false;
   if (!process.env.MOXXY_RUNNER_SOCKET) {
     process.env.MOXXY_RUNNER_SOCKET = platformSocket(
       `channel-${name}`,
@@ -116,6 +116,7 @@ export function applyDedicatedRunnerEnv(
   if (!process.env.MOXXY_SESSION_SOURCE && opts.sessionSource) {
     process.env.MOXXY_SESSION_SOURCE = opts.sessionSource;
   }
+  return true;
 }
 
 /** Thin-client mode: run the channel against a RemoteSession. */
@@ -190,6 +191,7 @@ async function runSelfHostedChannel(
   name: string,
   argv: ParsedArgv,
   standalone: boolean,
+  dedicated: boolean,
 ): Promise<number> {
   // `skipKeyPrompt: true` - channels like telegram run for hours; if the model
   // key resolves later from env/vault when a turn fires, that's fine. The
@@ -235,6 +237,21 @@ async function runSelfHostedChannel(
   // primary channel is e.g. telegram. The primary's permission resolver governs.
   const webHandle = name === 'web' ? null : await coAttachWebSurface({ primary: name, session, vault, config });
 
+  // Publish a status file ONLY for a dedicated channel runner, so an
+  // out-of-process supervisor (the desktop "Channels" panel) can observe
+  // readiness + the public ingest URL (Slack's Request URL) without the runner
+  // protocol. `channel.requestUrl` is set by the time `start()` resolved (Slack
+  // opens its tunnel during start); null for channels with no inbound endpoint.
+  if (dedicated) {
+    writeChannelStatus({
+      name,
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      ...(process.env.MOXXY_SESSION_SOURCE ? { source: process.env.MOXXY_SESSION_SOURCE } : {}),
+      requestUrl: channel.requestUrl ?? null,
+    });
+  }
+
   // Re-entrancy guard (mirrors runAttachedChannel): a second Ctrl-C, or
   // SIGINT+SIGTERM arriving close together, must not run teardown twice —
   // session.close() firing twice can double-flush plugin state (memory
@@ -249,6 +266,7 @@ async function runSelfHostedChannel(
     // runner socket + bound ports — a second Ctrl-C is swallowed by `stopping`.
     const force = setTimeout(() => process.exit(0), 4000);
     force.unref?.();
+    if (dedicated) clearChannelStatus(name);
     await webHandle?.stop('SIGINT').catch(() => undefined);
     await runnerServer?.close().catch(() => undefined);
     await handle.stop('SIGINT');

--- a/packages/client-core/src/index.ts
+++ b/packages/client-core/src/index.ts
@@ -31,6 +31,7 @@ export * from './useSessions.js';
 export * from './useWorkflows.js';
 export * from './useScheduler.js';
 export * from './useWebhooks.js';
+export * from './useChannels.js';
 export * from './usePausedWorkflows.js';
 export * from './useWorkflowBuilder.js';
 export * from './useActionCatalog.js';

--- a/packages/client-core/src/useChannels.ts
+++ b/packages/client-core/src/useChannels.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useState } from 'react';
+import { api } from './transport.js';
+import { toErrorMessage } from './errors.js';
+import type { ChannelEntry, ChannelRuntimeStatus } from '@moxxy/desktop-ipc-contract';
+
+export interface UseChannels {
+  readonly list: ReadonlyArray<ChannelEntry>;
+  readonly loading: boolean;
+  readonly error: string | null;
+  readonly refresh: () => Promise<void>;
+  /** Save a channel's secrets/settings (values keyed by ChannelConfigField.name).
+   *  Blank fields are ignored host-side so an untouched password isn't wiped. */
+  readonly saveConfig: (channelId: string, values: Record<string, string>) => Promise<void>;
+  readonly start: (channelId: string) => Promise<void>;
+  readonly stop: (channelId: string) => Promise<void>;
+}
+
+/**
+ * Drives the desktop "Channels" panel: lists the runnable channels (Slack,
+ * Telegram) with their config descriptors + live status, and starts/stops/configs
+ * them on their own dedicated runners. Subscribes to `channels.status` so a
+ * channel's card reflects start/stop/crash and the Request URL becoming available
+ * without polling.
+ */
+export function useChannels(): UseChannels {
+  const [list, setList] = useState<ReadonlyArray<ChannelEntry>>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const applyStatus = useCallback((status: ChannelRuntimeStatus): void => {
+    setList((cur) => cur.map((e) => (e.descriptor.id === status.id ? { ...e, status } : e)));
+  }, []);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    try {
+      const next = await api().invoke('channels.list');
+      setList(next);
+      setError(null);
+    } catch (e) {
+      setError(toErrorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Live updates (start / stop / crash / Request URL ready) — no polling.
+  useEffect(() => api().subscribe('channels.status', applyStatus), [applyStatus]);
+
+  const saveConfig = useCallback(
+    async (channelId: string, values: Record<string, string>): Promise<void> => {
+      try {
+        applyStatus(await api().invoke('channels.saveConfig', { channelId, values }));
+        setError(null);
+      } catch (e) {
+        setError(toErrorMessage(e));
+        throw e;
+      }
+    },
+    [applyStatus],
+  );
+
+  const start = useCallback(
+    async (channelId: string): Promise<void> => {
+      try {
+        applyStatus(await api().invoke('channels.start', { channelId }));
+        setError(null);
+      } catch (e) {
+        setError(toErrorMessage(e));
+        throw e;
+      }
+    },
+    [applyStatus],
+  );
+
+  const stop = useCallback(
+    async (channelId: string): Promise<void> => {
+      try {
+        applyStatus(await api().invoke('channels.stop', { channelId }));
+        setError(null);
+      } catch (e) {
+        setError(toErrorMessage(e));
+        throw e;
+      }
+    },
+    [applyStatus],
+  );
+
+  return { list, loading, error, refresh, saveConfig, start, stop };
+}

--- a/packages/desktop-host/src/channel-catalog.test.ts
+++ b/packages/desktop-host/src/channel-catalog.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { CHANNEL_CATALOG, listChannelCatalog } from './channel-catalog';
+
+describe('CHANNEL_CATALOG', () => {
+  it('pins the exact vault keys each channel plugin reads', () => {
+    // These MUST match the plugins' keys.ts (slack: SLACK_*_KEY, telegram:
+    // TELEGRAM_TOKEN_KEY). A drift here is a silent misconfig — the desktop would
+    // save a secret under a name the channel never reads. Pin them so it's caught.
+    expect(CHANNEL_CATALOG.slack?.vaultKeys).toEqual({
+      botToken: 'slack_bot_token',
+      signingSecret: 'slack_signing_secret',
+    });
+    expect(CHANNEL_CATALOG.slack?.requiredKeys).toEqual([
+      'slack_bot_token',
+      'slack_signing_secret',
+    ]);
+    expect(CHANNEL_CATALOG.telegram?.vaultKeys).toEqual({ botToken: 'telegram_bot_token' });
+    expect(CHANNEL_CATALOG.telegram?.requiredKeys).toEqual(['telegram_bot_token']);
+  });
+
+  it('keeps every entry internally consistent', () => {
+    for (const entry of listChannelCatalog()) {
+      const { descriptor, vaultKeys, requiredKeys } = entry;
+      // The catalog key equals the descriptor id (== the CLI subcommand).
+      expect(CHANNEL_CATALOG[descriptor.id]).toBe(entry);
+      // Every config field maps to a vault key, and every required key is one of
+      // those mapped keys (so saving the fields can satisfy "configured").
+      for (const field of descriptor.configFields) {
+        expect(vaultKeys[field.name]).toBeTruthy();
+      }
+      for (const key of requiredKeys) {
+        expect(Object.values(vaultKeys)).toContain(key);
+      }
+    }
+  });
+
+  it('only Slack advertises a public Request URL', () => {
+    expect(CHANNEL_CATALOG.slack?.descriptor.hasWebhookUrl).toBe(true);
+    expect(CHANNEL_CATALOG.telegram?.descriptor.hasWebhookUrl).toBe(false);
+  });
+});

--- a/packages/desktop-host/src/channel-catalog.ts
+++ b/packages/desktop-host/src/channel-catalog.ts
@@ -1,0 +1,84 @@
+/**
+ * The desktop-runnable communication channels and the secrets each needs.
+ *
+ * A small static table, keyed by channel id (== the CLI subcommand). It maps
+ * each config field to the vault key the channel plugin actually reads (the
+ * single source of truth for those names is the plugin's own `keys.ts`; the few
+ * lines are duplicated here so the desktop can render the config form + check
+ * "configured" WITHOUT booting plugin discovery in the Electron main). When a
+ * channel's vault keys change, update them here too. (Logged in TECH_DEBT: a
+ * future `moxxy channels describe --json` could source this from the ChannelDef.)
+ */
+
+import type { ChannelDescriptor } from '@moxxy/desktop-ipc-contract';
+
+export interface ChannelCatalogEntry {
+  readonly descriptor: ChannelDescriptor;
+  /** ChannelConfigField.name -> the vault key its value is stored under. */
+  readonly vaultKeys: Readonly<Record<string, string>>;
+  /** Vault keys that MUST be present for the channel to count as configured. */
+  readonly requiredKeys: ReadonlyArray<string>;
+}
+
+export const CHANNEL_CATALOG: Readonly<Record<string, ChannelCatalogEntry>> = {
+  slack: {
+    descriptor: {
+      id: 'slack',
+      name: 'Slack',
+      description:
+        'A Slack bot that answers mentions in your workspace, running on its own dedicated runner. Ingests the Events API over the proxy relay.',
+      docsUrl: 'https://api.slack.com/apps',
+      configFields: [
+        {
+          name: 'botToken',
+          label: 'Bot token',
+          type: 'password',
+          required: true,
+          placeholder: 'xoxb-…',
+          help: 'Slack app → OAuth & Permissions → Bot User OAuth Token',
+        },
+        {
+          name: 'signingSecret',
+          label: 'Signing secret',
+          type: 'password',
+          required: true,
+          help: 'Slack app → Basic Information → App Credentials → Signing Secret',
+        },
+      ],
+      hasWebhookUrl: true,
+      runHint:
+        'Paste the Request URL into your Slack app → Event Subscriptions, subscribe to the app_mention bot event, then mention the bot in a channel to pair.',
+    },
+    vaultKeys: { botToken: 'slack_bot_token', signingSecret: 'slack_signing_secret' },
+    requiredKeys: ['slack_bot_token', 'slack_signing_secret'],
+  },
+  telegram: {
+    descriptor: {
+      id: 'telegram',
+      name: 'Telegram',
+      description:
+        'A Telegram bot (grammy long-polling) on its own dedicated runner. No public URL needed; pairs a chat via a one-time code.',
+      docsUrl: 'https://core.telegram.org/bots#botfather',
+      configFields: [
+        {
+          name: 'botToken',
+          label: 'Bot token',
+          type: 'password',
+          required: true,
+          placeholder: '123456:ABC-DEF…',
+          help: 'Create a bot with @BotFather and paste its token',
+        },
+      ],
+      hasWebhookUrl: false,
+      runHint:
+        'Message your bot on Telegram, then send the pairing code it replies with to authorize your chat.',
+    },
+    vaultKeys: { botToken: 'telegram_bot_token' },
+    requiredKeys: ['telegram_bot_token'],
+  },
+};
+
+/** Every catalog entry, in display order. */
+export function listChannelCatalog(): ReadonlyArray<ChannelCatalogEntry> {
+  return Object.values(CHANNEL_CATALOG);
+}

--- a/packages/desktop-host/src/channel-supervisor.ts
+++ b/packages/desktop-host/src/channel-supervisor.ts
@@ -1,0 +1,208 @@
+/**
+ * Supervises communication-channel runners spawned from the desktop "Channels"
+ * panel. Each channel (Slack, Telegram) runs as its OWN dedicated, isolated
+ * runner subprocess — `moxxy <channelId>` with `MOXXY_DEDICATED_RUNNER=1`, which
+ * (via the channel's `ChannelDef.dedicatedRunner` declaration) binds a distinct
+ * runner socket + sticky session, separate from the desktop's workspace runners.
+ *
+ * This is a deliberately lighter sibling of {@link RunnerSupervisor}: a channel
+ * is fire-and-supervise (no reconnect/socket handshake, no per-workspace driver).
+ * We hold the child handle for liveness, tail stderr for error reporting, and
+ * read the channel's own status file (`channelStatusPath`) for its public Request
+ * URL once its tunnel opens. State changes broadcast `channels.status` so the
+ * panel re-renders without polling.
+ *
+ * Electron-free by construction (spawn + fs + the host event buses only), so it
+ * unit-tests against a fake CLI like the rest of desktop-host.
+ */
+
+import type { ChildProcess } from 'node:child_process';
+
+import { clearChannelStatus, readChannelStatus } from '@moxxy/sdk/server';
+import type { ChannelRuntimeStatus } from '@moxxy/desktop-ipc-contract';
+import { augmentedPaths, resolveMoxxyCli, spawnCli } from './cli-resolver';
+import { broadcastHostEvent } from './event-bus';
+
+/** How long to keep polling the status file for the public Request URL after a
+ *  channel starts (its tunnel opens within a second or two). */
+const URL_POLL_INTERVAL_MS = 700;
+const URL_POLL_TIMEOUT_MS = 30_000;
+/** Cap the stderr we retain per channel for error reporting (avoid unbounded). */
+const STDERR_TAIL_CAP = 4096;
+
+interface ChannelProc {
+  readonly child: ChildProcess;
+  readonly pid: number;
+  readonly startedAtMs: number;
+  requestUrl?: string;
+  error?: string;
+  stderrTail: string;
+  urlPoll?: ReturnType<typeof setInterval>;
+  urlPollStartedAt: number;
+}
+
+/** One process per channel id. Module-level singleton: the IPC handlers are
+ *  registered once per transport but share this map. */
+const procs = new Map<string, ChannelProc>();
+
+/** The live runtime view of a channel (sans `configured`, which the handler
+ *  derives from the vault). `running:false` when we hold no process for it. */
+export interface ChannelRuntime {
+  readonly running: boolean;
+  readonly pid?: number;
+  readonly startedAtMs?: number;
+  readonly requestUrl?: string;
+  readonly error?: string;
+}
+
+export function channelRuntime(id: string): ChannelRuntime {
+  const p = procs.get(id);
+  if (!p) return { running: false };
+  return {
+    running: true,
+    pid: p.pid,
+    startedAtMs: p.startedAtMs,
+    ...(p.requestUrl ? { requestUrl: p.requestUrl } : {}),
+    ...(p.error ? { error: p.error } : {}),
+  };
+}
+
+/** Broadcast a channel's status. `configured:true` is sound here — the
+ *  supervisor only ever tracks channels that were started, which requires being
+ *  configured; the full (possibly-false) `configured` is computed by the handler
+ *  for the not-running case in `channels.list`. */
+function broadcast(id: string, extra?: Partial<ChannelRuntimeStatus>): void {
+  const rt = channelRuntime(id);
+  broadcastHostEvent('channels.status', {
+    id,
+    configured: true,
+    running: rt.running,
+    ...(rt.pid !== undefined ? { pid: rt.pid } : {}),
+    ...(rt.startedAtMs !== undefined ? { startedAtMs: rt.startedAtMs } : {}),
+    ...(rt.requestUrl !== undefined ? { requestUrl: rt.requestUrl } : {}),
+    ...(rt.error !== undefined ? { error: rt.error } : {}),
+    ...extra,
+  });
+}
+
+/**
+ * Start a channel on its own dedicated runner subprocess. Idempotent: if it is
+ * already running, this is a no-op. Throws if the moxxy CLI can't be resolved or
+ * the spawn fails synchronously.
+ */
+export function startChannel(id: string): void {
+  if (procs.has(id)) return;
+
+  const cli = resolveMoxxyCli({ extraPaths: augmentedPaths() });
+  if (!cli) throw new Error('moxxy CLI not found');
+
+  // `MOXXY_DEDICATED_RUNNER=1` forces the isolated runner even if the channel
+  // didn't declare it; declared channels (slack/telegram) get it either way. We
+  // deliberately do NOT set MOXXY_SESSION_SOURCE — the channel stamps its own.
+  const child = spawnCli(cli, [id], {
+    env: { MOXXY_DEDICATED_RUNNER: '1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const entry: ChannelProc = {
+    child,
+    pid: child.pid ?? -1,
+    startedAtMs: Date.now(),
+    stderrTail: '',
+    urlPollStartedAt: Date.now(),
+  };
+  procs.set(id, entry);
+
+  const appendStderr = (b: Buffer): void => {
+    entry.stderrTail = (entry.stderrTail + b.toString()).slice(-STDERR_TAIL_CAP);
+  };
+  child.stderr?.on('data', appendStderr);
+  // Surface a crash/early-exit: record the error, drop the entry, broadcast.
+  child.on('error', (err) => {
+    entry.error = err instanceof Error ? err.message : String(err);
+    finalize(id, entry);
+  });
+  child.on('exit', (code, signal) => {
+    // A clean stop (we SIGTERM'd it) leaves no error; a non-zero/abnormal exit
+    // we didn't ask for carries the stderr tail so the panel can show why.
+    if (entry.error === undefined && code !== 0 && code !== null) {
+      entry.error = entry.stderrTail.trim() || `exited with code ${code}`;
+    } else if (entry.error === undefined && signal && signal !== 'SIGTERM') {
+      entry.error = entry.stderrTail.trim() || `killed by ${signal}`;
+    }
+    finalize(id, entry);
+  });
+
+  // Poll the channel's status file for its public Request URL (Slack). Stops
+  // once found, on timeout, or when the process goes away.
+  entry.urlPoll = setInterval(() => {
+    if (!procs.has(id)) return stopUrlPoll(entry);
+    const status = readChannelStatus(id);
+    if (status?.requestUrl && status.requestUrl !== entry.requestUrl) {
+      entry.requestUrl = status.requestUrl;
+      stopUrlPoll(entry);
+      broadcast(id);
+    } else if (Date.now() - entry.urlPollStartedAt > URL_POLL_TIMEOUT_MS) {
+      stopUrlPoll(entry);
+    }
+  }, URL_POLL_INTERVAL_MS);
+  entry.urlPoll.unref?.();
+
+  broadcast(id);
+}
+
+/** Stop a channel's runner (SIGTERM, then SIGKILL after a grace period). */
+export function stopChannel(id: string): void {
+  const entry = procs.get(id);
+  if (!entry) return;
+  stopUrlPoll(entry);
+  try {
+    entry.child.kill('SIGTERM');
+  } catch {
+    /* already gone */
+  }
+  // Backstop: if it ignores SIGTERM, force-kill. The 'exit' handler finalizes.
+  const force = setTimeout(() => {
+    try {
+      entry.child.kill('SIGKILL');
+    } catch {
+      /* already gone */
+    }
+  }, 4000);
+  force.unref?.();
+}
+
+/** Stop every supervised channel — called on app teardown. */
+export function stopAllChannels(): void {
+  for (const id of [...procs.keys()]) stopChannel(id);
+}
+
+function stopUrlPoll(entry: ChannelProc): void {
+  if (entry.urlPoll) {
+    clearInterval(entry.urlPoll);
+    entry.urlPoll = undefined;
+  }
+}
+
+/** Drop the entry, clean up the (possibly orphaned) status file, broadcast the
+ *  stopped status carrying any error so the panel can explain it. */
+function finalize(id: string, entry: ChannelProc): void {
+  stopUrlPoll(entry);
+  if (procs.get(id) !== entry) return;
+  procs.delete(id);
+  clearChannelStatus(id);
+  broadcast(id, entry.error !== undefined ? { error: entry.error } : undefined);
+}
+
+// Best-effort: never leave channel subprocesses orphaned when the app quits.
+// `exit` handlers must be synchronous; SIGTERM is, and the children's own
+// shutdown clears their status files.
+process.once('exit', () => {
+  for (const entry of procs.values()) {
+    try {
+      entry.child.kill('SIGTERM');
+    } catch {
+      /* ignore */
+    }
+  }
+});

--- a/packages/desktop-host/src/ipc.ts
+++ b/packages/desktop-host/src/ipc.ts
@@ -55,6 +55,7 @@ import { registerSettingsHandlers } from './ipc/settings';
 import { registerVaultHandlers } from './ipc/vault';
 import { registerChatHandlers } from './ipc/chat';
 import { registerMobileGatewayHandlers, type MobileGatewayController } from './ipc/mobile-gateway';
+import { registerChannelsHandlers } from './ipc/channels';
 
 export function registerIpcHandlers(
   buses: ReadonlyArray<CommandBus>,
@@ -98,6 +99,7 @@ export function registerIpcHandlers(
     registerVaultHandlers();
     registerChatHandlers(pool);
     registerMobileGatewayHandlers(opts.mobileGateway ?? null);
+    registerChannelsHandlers();
   }
 }
 

--- a/packages/desktop-host/src/ipc/channels.ts
+++ b/packages/desktop-host/src/ipc/channels.ts
@@ -1,0 +1,99 @@
+/**
+ * Communication-channel IPC: list / configure / start / stop the desktop-runnable
+ * channels (Slack, Telegram), each on its own dedicated, isolated runner.
+ *
+ * Secrets are written to the SAME in-process vault the runner reads (so a token
+ * saved here is immediately resolvable by the spawned channel), keyed by the
+ * vault names the channel plugins actually read (see {@link CHANNEL_CATALOG}).
+ * The subprocess lifecycle lives in {@link ChannelSupervisor}; these handlers are
+ * the thin IPC + "configured?" (vault) glue.
+ *
+ * Host-only: these run a local subprocess + read/write the vault, so they are
+ * deliberately NOT in REMOTE_ALLOWED_COMMANDS — a paired phone can't start a
+ * channel or save its secrets over the WS bridge.
+ */
+
+import type { ChannelEntry, ChannelRuntimeStatus } from '@moxxy/desktop-ipc-contract';
+import { getInProcessPlugins, handle, IpcError } from './shared';
+import { CHANNEL_CATALOG, listChannelCatalog, type ChannelCatalogEntry } from '../channel-catalog';
+import { channelRuntime, startChannel, stopChannel } from '../channel-supervisor';
+
+/** Configured == every required secret is present in the vault. */
+async function isConfigured(entry: ChannelCatalogEntry): Promise<boolean> {
+  const { vault } = getInProcessPlugins();
+  for (const key of entry.requiredKeys) {
+    if (!(await vault.has(key))) return false;
+  }
+  return true;
+}
+
+/** Merge the supervisor's live runtime with the vault-derived `configured`. */
+function statusOf(id: string, configured: boolean): ChannelRuntimeStatus {
+  const rt = channelRuntime(id);
+  return {
+    id,
+    configured,
+    running: rt.running,
+    ...(rt.pid !== undefined ? { pid: rt.pid } : {}),
+    ...(rt.startedAtMs !== undefined ? { startedAtMs: rt.startedAtMs } : {}),
+    ...(rt.requestUrl !== undefined ? { requestUrl: rt.requestUrl } : {}),
+    ...(rt.error !== undefined ? { error: rt.error } : {}),
+  };
+}
+
+function catalogEntry(channelId: string): ChannelCatalogEntry {
+  const entry = CHANNEL_CATALOG[channelId];
+  if (!entry) throw new IpcError('not-supported', `unknown channel: ${channelId}`);
+  return entry;
+}
+
+export function registerChannelsHandlers(): void {
+  handle('channels.list', async () => {
+    const out: ChannelEntry[] = [];
+    for (const entry of listChannelCatalog()) {
+      out.push({
+        descriptor: entry.descriptor,
+        status: statusOf(entry.descriptor.id, await isConfigured(entry)),
+      });
+    }
+    return out;
+  });
+
+  handle('channels.saveConfig', async ({ channelId, values }) => {
+    const entry = catalogEntry(channelId);
+    const { vault } = getInProcessPlugins();
+    for (const [field, value] of Object.entries(values)) {
+      const key = entry.vaultKeys[field];
+      if (!key) {
+        throw new IpcError('invalid-payload', `unknown config field for ${channelId}: ${field}`);
+      }
+      const trimmed = value.trim();
+      // Skip blanks: an untouched password field comes back empty and must not
+      // wipe a previously-saved secret.
+      if (trimmed) await vault.set(key, trimmed);
+    }
+    return statusOf(channelId, await isConfigured(entry));
+  });
+
+  handle('channels.start', async ({ channelId }) => {
+    const entry = catalogEntry(channelId);
+    if (!(await isConfigured(entry))) {
+      throw new IpcError('runner-error', `${channelId} is not configured yet`);
+    }
+    try {
+      startChannel(channelId);
+    } catch (e) {
+      throw new IpcError(
+        'runner-error',
+        e instanceof Error ? e.message : `failed to start ${channelId}`,
+      );
+    }
+    return statusOf(channelId, true);
+  });
+
+  handle('channels.stop', async ({ channelId }) => {
+    const entry = catalogEntry(channelId);
+    stopChannel(channelId);
+    return statusOf(channelId, await isConfigured(entry));
+  });
+}

--- a/packages/desktop-ipc-contract/src/channels.ts
+++ b/packages/desktop-ipc-contract/src/channels.ts
@@ -1,0 +1,64 @@
+// ---------- Communication channels (Slack / Telegram, run from desktop) ----
+//
+// Let the desktop user run a chat channel (Slack, Telegram) on its OWN dedicated,
+// isolated runner — configure its secrets, start/stop it, and (for Slack) see the
+// public Request URL to paste into the provider's app config. The host spawns
+// `moxxy <channelId>` as a supervised dedicated-runner subprocess; these shapes are
+// the renderer-facing contract for that. Host-only (NOT remote-allowed): running a
+// local subprocess is a desktop operation, like the apps gallery.
+
+/** One secret/setting a channel needs, rendered as a labelled form field. */
+export interface ChannelConfigField {
+  /** Logical field id the renderer keys its form value by (e.g. `botToken`). */
+  readonly name: string;
+  /** Human label (e.g. `Bot token`). */
+  readonly label: string;
+  /** `password` masks the input + is write-only; `text` is shown back. */
+  readonly type: 'password' | 'text';
+  readonly placeholder?: string;
+  readonly required?: boolean;
+  /** Optional one-line hint (e.g. where to find the value). */
+  readonly help?: string;
+}
+
+/** Static description of a runnable channel (its identity + what it needs). */
+export interface ChannelDescriptor {
+  /** Channel id == the CLI subcommand (`slack`, `telegram`). */
+  readonly id: string;
+  /** Display name (`Slack`). */
+  readonly name: string;
+  readonly description: string;
+  /** Icon name the renderer maps to its icon set. */
+  readonly icon?: string;
+  /** Optional setup docs link. */
+  readonly docsUrl?: string;
+  /** The secrets/settings the user must provide before it can start. */
+  readonly configFields: ReadonlyArray<ChannelConfigField>;
+  /** True when the channel exposes a public ingest URL once running (Slack);
+   *  false for poll-based channels (Telegram). Drives the URL affordance. */
+  readonly hasWebhookUrl: boolean;
+  /** Guidance shown once the channel is running (e.g. "paste the Request URL
+   *  into Slack → Event Subscriptions, then mention the bot to pair"). */
+  readonly runHint?: string;
+}
+
+/** Live runtime status of a channel's dedicated runner. */
+export interface ChannelRuntimeStatus {
+  readonly id: string;
+  /** Every required secret is present in the vault. */
+  readonly configured: boolean;
+  /** The dedicated-runner subprocess is currently up. */
+  readonly running: boolean;
+  readonly pid?: number;
+  readonly startedAtMs?: number;
+  /** Public ingest URL once the tunnel is up (Slack); absent otherwise. */
+  readonly requestUrl?: string;
+  /** Last spawn/runtime error, surfaced so the UI can show why it stopped. */
+  readonly error?: string;
+}
+
+/** A channel descriptor paired with its live status, as `channels.list` returns. */
+export interface ChannelEntry {
+  readonly descriptor: ChannelDescriptor;
+  readonly status: ChannelRuntimeStatus;
+}

--- a/packages/desktop-ipc-contract/src/commands.ts
+++ b/packages/desktop-ipc-contract/src/commands.ts
@@ -21,6 +21,7 @@ import type {
 import type { ScheduleSummary, SchedulerDeleteResult } from './scheduler.js';
 import type { WebhookSummary, WebhookDeleteResult } from './webhooks.js';
 import type { MobileGatewayStatus } from './mobile.js';
+import type { ChannelEntry, ChannelRuntimeStatus } from './channels.js';
 import type {
   ProviderEntry,
   McpServerEntry,
@@ -490,6 +491,26 @@ export interface IpcCommands {
    *  or pass `sessionId: null` to clear the binding. Maps to the trigger's stored
    *  `ownerSessionId`; the existing queue/drain routes the delivery. */
   'webhooks.setTargetSession': (args: { id: string; sessionId: string | null }) => Promise<WebhookSummary | null>;
+
+  // ---- Communication channels (Slack / Telegram on dedicated runners) --
+  // Host-only (run a local subprocess + read/write the vault): deliberately NOT
+  // in REMOTE_ALLOWED_COMMANDS, so a paired phone can't start a channel or save
+  // its secrets.
+  /** Every runnable channel with its descriptor (config fields, webhook-url
+   *  affordance) + live status (configured / running / requestUrl). */
+  'channels.list': () => Promise<ReadonlyArray<ChannelEntry>>;
+  /** Store a channel's secrets/settings in the vault (values keyed by
+   *  ChannelConfigField.name). Returns the refreshed status (now configured). */
+  'channels.saveConfig': (args: {
+    channelId: string;
+    values: Record<string, string>;
+  }) => Promise<ChannelRuntimeStatus>;
+  /** Start the channel on its own dedicated, isolated runner subprocess.
+   *  Rejects if it isn't configured yet. Streams live updates via
+   *  `channels.status`; resolves with the post-start status. */
+  'channels.start': (args: { channelId: string }) => Promise<ChannelRuntimeStatus>;
+  /** Stop the channel's dedicated-runner subprocess. */
+  'channels.stop': (args: { channelId: string }) => Promise<ChannelRuntimeStatus>;
 
   // ---- Desktop apps gallery (install lifecycle) ------------------------
   // All host-only (native pickers + filesystem + a network download). They are

--- a/packages/desktop-ipc-contract/src/events.ts
+++ b/packages/desktop-ipc-contract/src/events.ts
@@ -7,6 +7,7 @@ import type { DeepLinkPayload } from './deep-link.js';
 import type { MobileGatewayStatus } from './mobile.js';
 import type { AppInstallProgress } from './apps.js';
 import type { DesksOverview } from './desks.js';
+import type { ChannelRuntimeStatus } from './channels.js';
 
 // ---------- Events the renderer subscribes to ------------------------------
 
@@ -87,4 +88,8 @@ export interface IpcEvents {
   /** Streamed during `apps.install` — one event per download/verify step so the
    *  Apps gallery can show a progress bar while an app's assets download. */
   'apps.install.progress': AppInstallProgress;
+  /** A channel's dedicated-runner status changed (started / stopped / crashed,
+   *  or its public Request URL became available) — the Channels panel re-renders
+   *  that channel's card without polling. */
+  'channels.status': ChannelRuntimeStatus;
 }

--- a/packages/desktop-ipc-contract/src/index.ts
+++ b/packages/desktop-ipc-contract/src/index.ts
@@ -76,6 +76,14 @@ export type { WebhookLastResult, WebhookSummary, WebhookDeleteResult } from './w
 // ---------- Mobile gateway (WebSocket bridge) ------------------------------
 export type { MobileGatewayStatus } from './mobile.js';
 
+// ---------- Communication channels (Slack / Telegram on dedicated runners) -
+export type {
+  ChannelConfigField,
+  ChannelDescriptor,
+  ChannelRuntimeStatus,
+  ChannelEntry,
+} from './channels.js';
+
 // ---------- Settings -------------------------------------------------------
 export type {
   ProviderEntry,

--- a/packages/desktop-ipc-contract/src/validation.test.ts
+++ b/packages/desktop-ipc-contract/src/validation.test.ts
@@ -232,6 +232,39 @@ describe('IPC payload validation', () => {
     }
   });
 
+  it('confines channels.* channelId to a non-traversing slug', () => {
+    // channelId is spawned as `moxxy <channelId>`, so it must be a strict slug —
+    // no traversal, no separators, no leading dash (a flag), bounded length.
+    for (const cmd of ['channels.start', 'channels.stop'] as const) {
+      expect(() => validateIpcInput(cmd, { channelId: 'slack' })).not.toThrow();
+      expect(() => validateIpcInput(cmd, { channelId: '../evil' })).toThrow();
+      expect(() => validateIpcInput(cmd, { channelId: '-rf' })).toThrow();
+      expect(() => validateIpcInput(cmd, { channelId: 'Slack' })).toThrow();
+      expect(() => validateIpcInput(cmd, { channelId: '' })).toThrow();
+      expect(() => validateIpcInput(cmd, {})).toThrow();
+    }
+  });
+
+  it('bounds channels.saveConfig field count + value size (OOM/vault-bloat guard)', () => {
+    expect(() =>
+      validateIpcInput('channels.saveConfig', {
+        channelId: 'slack',
+        values: { botToken: 'xoxb-abc', signingSecret: 'sek' },
+      }),
+    ).not.toThrow();
+    // Oversized secret value is rejected.
+    expect(() =>
+      validateIpcInput('channels.saveConfig', {
+        channelId: 'slack',
+        values: { botToken: 'x'.repeat(8193) },
+      }),
+    ).toThrow();
+    // A traversing channelId is rejected even with a valid values bag.
+    expect(() =>
+      validateIpcInput('channels.saveConfig', { channelId: '../x', values: {} }),
+    ).toThrow();
+  });
+
   it('bounds anonymizer.parseDocument path + pins pickDocument to no payload', () => {
     expect(() => validateIpcInput('anonymizer.parseDocument', { path: '/a/b.txt' })).not.toThrow();
     expect(() => validateIpcInput('anonymizer.parseDocument', { path: '' })).toThrow();

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -119,6 +119,10 @@ const commandName = z
  *  must never traverse: lowercase letters/digits/hyphen only. */
 const appId = z.string().min(1).max(64).regex(/^[a-z][a-z0-9-]*$/, 'invalid app id');
 
+/** Channel id == the CLI subcommand spawned as `moxxy <channelId>`, so pin it to
+ *  a non-traversing, non-flag slug: lowercase letters/digits/hyphen only. */
+const channelId = z.string().min(1).max(64).regex(/^[a-z][a-z0-9-]*$/, 'invalid channel id');
+
 /** Workflow names come from workflow filenames — bounded, no traversal. */
 const workflowName = z
   .string()
@@ -325,6 +329,17 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
   'apps.status': z.object({ appId }),
   'apps.install': z.object({ appId }),
   'apps.uninstall': z.object({ appId }),
+  // Channels: channelId is spawned as `moxxy <channelId>`, so pin it to a
+  // non-traversing slug. saveConfig carries secrets — bound the field count +
+  // each value's length so a hostile renderer can't OOM the host / bloat the
+  // vault (the keys are bounded field ids; values are tokens).
+  'channels.list': z.undefined(),
+  'channels.saveConfig': z.object({
+    channelId,
+    values: z.record(z.string().min(1).max(64), z.string().max(8192)),
+  }),
+  'channels.start': z.object({ channelId }),
+  'channels.stop': z.object({ channelId }),
   // Anonymizer: parseDocument reads a file (bound the path), saveRedacted writes
   // one (bound name + cap content so a renderer can't OOM main). pickDocument
   // takes nothing — pin it to "nothing" so no args can be smuggled across.

--- a/packages/sdk/src/channel-status.ts
+++ b/packages/sdk/src/channel-status.ts
@@ -1,0 +1,55 @@
+import { readFileSync, rmSync } from 'node:fs';
+
+import { moxxyPath, writeFileAtomicSync } from './fs-utils.js';
+
+/**
+ * The on-disk status a dedicated channel runner publishes so an out-of-process
+ * supervisor (the desktop "Channels" panel) can observe it without the runner
+ * protocol. Written by `moxxy <channel>` when it self-hosts a dedicated runner,
+ * read by the desktop host; removed on graceful shutdown.
+ *
+ * It is intentionally tiny — readiness + the public ingest URL — not a mirror of
+ * the session. The supervisor owns liveness (it holds the child handle); this
+ * file is the channel's own report of "I'm up, and here's the URL to paste".
+ */
+export interface ChannelRunStatus {
+  /** Channel name (e.g. `slack`, `telegram`). */
+  readonly name: string;
+  /** PID of the channel runner process. */
+  readonly pid: number;
+  /** ISO timestamp the channel reported ready. */
+  readonly startedAt: string;
+  /** The session source the runner stamped (e.g. `slack`). */
+  readonly source?: string;
+  /** Public ingest URL (e.g. Slack's Events Request URL) once the tunnel is up;
+   *  null for channels with no inbound endpoint (Telegram long-polls). */
+  readonly requestUrl?: string | null;
+}
+
+/** `~/.moxxy/channel-<name>.status.json` (honors `$MOXXY_HOME`). */
+export function channelStatusPath(name: string): string {
+  return moxxyPath(`channel-${name}.status.json`);
+}
+
+/** Atomically publish a channel's run status (0600 — it may carry a URL). */
+export function writeChannelStatus(status: ChannelRunStatus): void {
+  writeFileAtomicSync(channelStatusPath(status.name), JSON.stringify(status), { mode: 0o600 });
+}
+
+/** Read a channel's published status, or null if absent/unparseable. */
+export function readChannelStatus(name: string): ChannelRunStatus | null {
+  try {
+    return JSON.parse(readFileSync(channelStatusPath(name), 'utf8')) as ChannelRunStatus;
+  } catch {
+    return null;
+  }
+}
+
+/** Remove a channel's status file (best-effort; called on graceful shutdown). */
+export function clearChannelStatus(name: string): void {
+  try {
+    rmSync(channelStatusPath(name), { force: true });
+  } catch {
+    /* best-effort */
+  }
+}

--- a/packages/sdk/src/channel.ts
+++ b/packages/sdk/src/channel.ts
@@ -26,6 +26,15 @@ export interface Channel<TStartOpts = unknown> {
    * resolves when the channel exits gracefully.
    */
   start(opts: TStartOpts): Promise<ChannelHandle>;
+
+  /**
+   * The public ingest URL this channel exposes once running — e.g. Slack's
+   * Events Request URL after its proxy tunnel opens — or null when it has none
+   * (Telegram long-polls). Read by the dedicated-runner host to publish the URL
+   * the user must paste into the provider's config. Optional: channels with no
+   * inbound endpoint omit it.
+   */
+  readonly requestUrl?: string | null;
 }
 
 export interface ChannelHandle {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -194,6 +194,7 @@ export type {
 // builtins and would break a browser/RN bundle. See ./server.ts.
 export { isRetryableError, toFriendlyError, zodToJsonSchema, estimateTextTokens, type StopReason } from './provider-utils.js';
 export type { WriteFileAtomicOptions } from './fs-utils.js';
+export type { ChannelRunStatus } from './channel-status.js';
 export type { CrossProcessFireLock, CrossProcessFireLockOptions } from './cross-process-lock.js';
 export { createMutex, type Mutex } from './mutex.js';
 export {

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -25,6 +25,15 @@ export {
 // options type is re-exported from the main barrel like other erased types.
 export { CrossProcessFireLock } from './cross-process-lock.js';
 export { readRequestBody, bearerTokenMatches } from './http-utils.js';
+// Dedicated-channel run-status file: a channel publishes readiness + its public
+// ingest URL so the desktop "Channels" supervisor can observe it out-of-process
+// (node:fs). The `ChannelRunStatus` *type* rides the main barrel like the others.
+export {
+  channelStatusPath,
+  writeChannelStatus,
+  readChannelStatus,
+  clearChannelStatus,
+} from './channel-status.js';
 export {
   resolveChannelToken,
   rotateChannelToken,


### PR DESCRIPTION
> Builds on #378 (declarative dedicated runner + Telegram parity), now **merged** — this is a clean single-commit PR on `development`.

## What

Adds an **Apps → Channels** sub-tab so desktop users can configure and run the communication channels (Slack, Telegram), each on its **own dedicated, isolated runner** subprocess — reusing the CLI dedicated-runner path #378 generalized.

Per channel: enter secrets (stored in the vault), **Start/Stop**, live status, and — for Slack — copy the public **Request URL** to paste into the Slack app once its proxy tunnel opens.

## Why

The dedicated-runner mechanism + proxy relay already work from the CLI (`moxxy slack` / `moxxy telegram`), but there was no way for a desktop user to run a channel or enter its config. This surfaces it where the ambient-automation features already live (the Apps panel's sub-tabs).

## How it fits together

- **IPC contract**: `channels.list` / `saveConfig` / `start` / `stop` + a `channels.status` event. Host-only — deliberately **not** in `REMOTE_ALLOWED_COMMANDS` (a paired phone can't spawn a local process or save secrets). Bounded input schemas (channelId slug like `apps.*`; saveConfig value caps).
- **`@moxxy/desktop-host`**: a `ChannelSupervisor` spawns `moxxy <channel>` with `MOXXY_DEDICATED_RUNNER=1` (via `spawnCli`/`resolveMoxxyCli`), supervises lifecycle (best-effort SIGTERM on app quit), tails stderr for error reporting, and polls the channel's status file for its Request URL. A small static `channel-catalog` maps each channel's config fields → the vault keys its plugin reads; secrets are written to the same in-process vault the runner reads (no new secret store). Status broadcasts via `broadcastHostEvent` (electron-free).
- **Status file**: a dedicated channel runner publishes `~/.moxxy/channel-<name>.status.json` (pid + public ingest URL) while up, removed on shutdown. New `@moxxy/sdk/server` helpers (`writeChannelStatus`/`readChannelStatus`/`clearChannelStatus`) + an optional `Channel.requestUrl` getter back it. Written only for dedicated runs.
- **Renderer**: `useChannels` hook (`@moxxy/client-core`, subscribes to `channels.status` for live updates) + `ChannelsPanel` + the Apps sub-tab.

The channel runs as a **separate isolated session** — its conversation is intentionally **not** shown in the workspace sidebar; the panel manages the runner, not its chat.

## Tests

- `channel-catalog`: pins the exact vault keys each plugin reads (guards silent misconfig) + structural invariants + the hasWebhookUrl flag.
- `channels.*` validation: channelId slug rejects traversal/flags; saveConfig bounds value size.
- `applyDedicatedRunnerEnv` now returns its decision (asserted).
- Full gate green: build 74/74, typecheck 141/141, lint 0 errors, deps 0 errors, tests 139/139 + scripts.

## Verify

Dev desktop (and a packaged build for the spawn path): Apps → Channels → configure Slack (bot token + signing secret) → Start → Request URL appears → paste into Slack Event Subscriptions → mention the bot → it replies (pairing). Configure Telegram (bot token) → Start → message the bot. Stop both → status flips to stopped and the subprocesses terminate.