### PR TITLE
feat(channels): declarative per-channel connect step in the desktop (Telegram QR)

### DIFF
--- a/.changeset/channel-connect-step.md
+++ b/.changeset/channel-connect-step.md
@@ -1,0 +1,8 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/desktop': minor
+---
+
+Declarative per-channel "connect step" in the desktop Channels panel. A channel now declares how its post-start "connect the other side" affordance is presented (`ChannelConnectStep` on `ChannelConfigDescriptor`: `kind: 'qr' | 'url' | 'instructions'`), and the desktop renders it uniformly — no per-channel UI code.
+
+Telegram is the first consumer: on start it resolves its bot's `@username` (grammy `getMe`) and publishes a `https://t.me/<bot>` link through the existing `requestUrl` status spine, which the panel shows as a **QR + "Open in Telegram"** link. Slack's Request URL folds into the same mechanism (`kind: 'url'`). The QR renderer is shared between the Mobile gateway and the Channels panel.

--- a/apps/desktop/src/apps/ChannelsPanel.tsx
+++ b/apps/desktop/src/apps/ChannelsPanel.tsx
@@ -2,17 +2,19 @@
  * Channels sub-view of the Apps surface. Lists the communication channels the
  * desktop can run (Slack, Telegram), each on its own dedicated, isolated runner.
  * Per channel: enter its secrets (stored in the vault), Start/Stop the runner,
- * and — for Slack — copy the public Request URL to paste into the Slack app once
- * the tunnel is up. Content-only — the Apps header is owned by {@link AppsPanel}.
+ * and — once running — a declarative "connect step" (the channel's descriptor
+ * says how to render it: Slack's Request URL to paste, Telegram's t.me QR + link
+ * to open). Content-only — the Apps header is owned by {@link AppsPanel}.
  *
  * The channel's conversation is intentionally NOT shown here (it runs as a
  * separate isolated session); this panel manages the runner, not its chat.
  */
 
 import { useState } from 'react';
-import { useChannels } from '@moxxy/client-core';
+import { api, useChannels } from '@moxxy/client-core';
 import { Button, Icon, Skeleton, TextInput } from '@moxxy/desktop-ui';
-import type { ChannelEntry } from '@moxxy/desktop-ipc-contract';
+import type { ChannelDescriptor, ChannelEntry } from '@moxxy/desktop-ipc-contract';
+import { QrCode } from '../components/QrCode';
 
 export function ChannelsPanel(): JSX.Element {
   const channels = useChannels();
@@ -236,12 +238,17 @@ function ChannelCard({
         </div>
       )}
 
-      {/* Running affordances: Slack's Request URL + the per-channel run hint */}
-      {status.running && descriptor.hasWebhookUrl && (
-        <RequestUrlRow url={status.requestUrl} />
-      )}
-      {status.running && descriptor.runHint && (
-        <div style={{ fontSize: '0.78rem', color: 'var(--color-text-dim)' }}>{descriptor.runHint}</div>
+      {/* Running affordances: the declarative per-channel connect step (QR / URL /
+          instructions). Channels without a `connect` fall back to the legacy hint. */}
+      {status.running && descriptor.connect ? (
+        <ConnectStep connect={descriptor.connect} url={status.requestUrl} />
+      ) : (
+        status.running &&
+        descriptor.runHint && (
+          <div style={{ fontSize: '0.78rem', color: 'var(--color-text-dim)' }}>
+            {descriptor.runHint}
+          </div>
+        )
       )}
       {status.error && (
         <div
@@ -256,17 +263,89 @@ function ChannelCard({
   );
 }
 
-/** Slack's public Request URL with a copy button — shown once its tunnel opens.
- *  While the URL is still resolving it reads as a muted placeholder. */
-function RequestUrlRow({ url }: { readonly url?: string }): JSX.Element {
-  const [copied, setCopied] = useState(false);
-  if (!url) {
+/** The declarative per-channel connect step, shown once the channel is running.
+ *  The descriptor's `kind` picks the presentation; the runtime value is the
+ *  channel's `requestUrl` (Slack's Request URL, Telegram's t.me link). A new
+ *  channel plugs in by declaring a `connect` — no edits here. */
+function ConnectStep({
+  connect,
+  url,
+}: {
+  readonly connect: NonNullable<ChannelDescriptor['connect']>;
+  readonly url?: string;
+}): JSX.Element {
+  if (connect.kind === 'instructions') {
     return (
-      <div style={{ fontSize: '0.78rem', color: 'var(--color-text-dim)' }}>
-        Opening the proxy tunnel — the Request URL will appear here…
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {connect.title && <ConnectTitle>{connect.title}</ConnectTitle>}
+        <ol
+          style={{
+            margin: 0,
+            paddingLeft: '1.1rem',
+            fontSize: '0.78rem',
+            color: 'var(--color-text-dim)',
+          }}
+        >
+          {(connect.steps ?? []).map((s) => (
+            <li key={s} style={{ marginBottom: 3 }}>
+              {s}
+            </li>
+          ))}
+        </ol>
       </div>
     );
   }
+  // 'qr' and 'url' both render a runtime value; until it resolves, show a hint.
+  if (!url) {
+    return (
+      <div style={{ fontSize: '0.78rem', color: 'var(--color-text-dim)' }}>
+        {connect.kind === 'qr'
+          ? 'Connecting — the link will appear here once the bot is reachable…'
+          : 'Opening the proxy tunnel — the Request URL will appear here…'}
+      </div>
+    );
+  }
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {connect.title && <ConnectTitle>{connect.title}</ConnectTitle>}
+      {connect.kind === 'qr' && (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '2px 0' }}>
+          <QrCode
+            value={url}
+            size={180}
+            alt={connect.title ?? 'Connect QR code'}
+            testId="channel-connect-qr"
+          />
+        </div>
+      )}
+      <ConnectUrlRow url={url} openable={connect.openable} openLabel={connect.openLabel} />
+      {connect.hint && (
+        <div style={{ fontSize: '0.74rem', color: 'var(--color-text-dim)' }}>{connect.hint}</div>
+      )}
+    </div>
+  );
+}
+
+function ConnectTitle({ children }: { readonly children: string }): JSX.Element {
+  return (
+    <span style={{ fontSize: '0.78rem', fontWeight: 600, color: 'var(--color-text)' }}>
+      {children}
+    </span>
+  );
+}
+
+/** A connect value (URL / link) with Copy and — when `openable` — an "open
+ *  externally" button via the https-validated onboarding.openExternal IPC. */
+function ConnectUrlRow({
+  url,
+  openable,
+  openLabel,
+}: {
+  readonly url: string;
+  readonly openable?: boolean;
+  readonly openLabel?: string;
+}): JSX.Element {
+  const [copied, setCopied] = useState(false);
   return (
     <div
       style={{
@@ -279,7 +358,6 @@ function RequestUrlRow({ url }: { readonly url?: string }): JSX.Element {
         borderRadius: 9,
       }}
     >
-      <span style={{ fontSize: '0.7rem', color: 'var(--color-text-muted)' }}>Request URL</span>
       <span
         className="mono"
         title={url}
@@ -294,6 +372,17 @@ function RequestUrlRow({ url }: { readonly url?: string }): JSX.Element {
       >
         {url}
       </span>
+      {openable && (
+        <Button
+          variant="chip"
+          onClick={() => void api().invoke('onboarding.openExternal', { url })}
+          style={{ borderRadius: 9 }}
+          data-testid="channel-connect-open"
+        >
+          <Icon name="globe" size={14} />
+          {openLabel ?? 'Open'}
+        </Button>
+      )}
       <Button
         variant="chip"
         onClick={() => {

--- a/apps/desktop/src/components/QrCode.tsx
+++ b/apps/desktop/src/components/QrCode.tsx
@@ -1,0 +1,76 @@
+/**
+ * Render a string (a connect URL / link) as a scannable QR (SVG).
+ *
+ * Pure-JS via the `qrcode` package's `toString` — no canvas, builds cleanly in
+ * the renderer. The SVG is wrapped in an <img> data URL rather than injected via
+ * dangerouslySetInnerHTML: an <img>-referenced SVG runs in the browser's
+ * restricted mode (no scripts, no external fetches), so even a compromised
+ * `qrcode` package cannot inject executable markup into the privileged renderer
+ * DOM.
+ *
+ * Shared by the Mobile gateway pairing UI (settings/MobileTab) and the Channels
+ * panel's per-channel connect step (apps/ChannelsPanel).
+ */
+
+import { useEffect, useState } from 'react';
+import QRCode from 'qrcode';
+
+export function QrCode({
+  value,
+  size = 220,
+  alt = 'QR code',
+  testId,
+}: {
+  readonly value: string;
+  /** Outer box (and QR module) size in px. The image is inset by the 10px quiet-zone padding. */
+  readonly size?: number;
+  readonly alt?: string;
+  readonly testId?: string;
+}): JSX.Element {
+  const [src, setSrc] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    setFailed(false);
+    QRCode.toString(value, { type: 'svg', margin: 1, width: size })
+      .then((markup) => {
+        if (alive) setSrc(`data:image/svg+xml;utf8,${encodeURIComponent(markup)}`);
+      })
+      .catch(() => {
+        if (alive) setFailed(true);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [value, size]);
+
+  if (failed) {
+    return (
+      <p style={{ margin: 0, fontSize: 12.5, color: 'var(--color-red)' }}>
+        Could not render the QR code. Use the link below instead.
+      </p>
+    );
+  }
+  const inner = Math.max(0, size - 20);
+  return (
+    <div
+      data-testid={testId}
+      style={{
+        width: size,
+        height: size,
+        // Deliberate literal: QR codes need a white quiet zone for scanner
+        // contrast in BOTH themes — never theme this surface.
+        background: '#fff',
+        borderRadius: 14,
+        padding: 10,
+        border: '1px solid var(--color-card-border)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      {src && <img src={src} alt={alt} width={inner} height={inner} style={{ display: 'block' }} />}
+    </div>
+  );
+}

--- a/apps/desktop/src/settings/MobileTab.tsx
+++ b/apps/desktop/src/settings/MobileTab.tsx
@@ -14,73 +14,10 @@
  */
 
 import { useEffect, useRef, useState } from 'react';
-import QRCode from 'qrcode';
 import { useMobileGateway } from '@moxxy/client-core';
 import { Button, Icon } from '@moxxy/desktop-ui';
+import { QrCode } from '../components/QrCode';
 import { Section, Switch } from './settings-primitives';
-
-/** Render a connect URL as a scannable QR (SVG). Pure-JS via the `qrcode`
- *  package's `toString` — no canvas, builds cleanly in the renderer. The SVG
- *  is wrapped in an <img> data URL rather than injected via
- *  dangerouslySetInnerHTML: an <img>-referenced SVG runs in the browser's
- *  restricted mode (no scripts, no external fetches), so even a compromised
- *  `qrcode` package cannot inject executable markup into the privileged
- *  renderer DOM. */
-function QrCode({ value }: { readonly value: string }): JSX.Element {
-  const [src, setSrc] = useState<string | null>(null);
-  const [failed, setFailed] = useState(false);
-
-  useEffect(() => {
-    let alive = true;
-    setFailed(false);
-    QRCode.toString(value, { type: 'svg', margin: 1, width: 220 })
-      .then((markup) => {
-        if (alive) setSrc(`data:image/svg+xml;utf8,${encodeURIComponent(markup)}`);
-      })
-      .catch(() => {
-        if (alive) setFailed(true);
-      });
-    return () => {
-      alive = false;
-    };
-  }, [value]);
-
-  if (failed) {
-    return (
-      <p style={{ margin: 0, fontSize: 12.5, color: 'var(--color-red)' }}>
-        Could not render the QR code. Use the connect URL below instead.
-      </p>
-    );
-  }
-  return (
-    <div
-      data-testid="mobile-qr"
-      style={{
-        width: 220,
-        height: 220,
-        // Deliberate literal: QR codes need a white quiet zone for scanner
-        // contrast in BOTH themes — never theme this surface.
-        background: '#fff',
-        borderRadius: 14,
-        padding: 10,
-        border: '1px solid var(--color-card-border)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      {src && (
-        <img
-          src={src}
-          alt="Pairing QR code"
-          width={200}
-          height={200}
-          style={{ display: 'block' }}
-        />
-      )}
-    </div>
-  );
-}
 
 export function MobileTab(): JSX.Element {
   const { status, loading, busy, error, setEnabled, rotateToken } = useMobileGateway();
@@ -268,7 +205,7 @@ export function MobileTab(): JSX.Element {
         {/* Pairing surface */}
         {status.enabled && status.connectUrl && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 14, alignItems: 'center' }}>
-            <QrCode value={status.connectUrl} />
+            <QrCode value={status.connectUrl} testId="mobile-qr" />
 
             <div style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 6 }}>
               <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-text-muted)' }}>

--- a/packages/desktop-host/src/channel-catalog.test.ts
+++ b/packages/desktop-host/src/channel-catalog.test.ts
@@ -38,4 +38,29 @@ describe('CHANNEL_CATALOG', () => {
     expect(CHANNEL_CATALOG.slack?.descriptor.hasWebhookUrl).toBe(true);
     expect(CHANNEL_CATALOG.telegram?.descriptor.hasWebhookUrl).toBe(false);
   });
+
+  // The `connect` descriptor is exactly what the Channels panel renders as the
+  // post-start "connect the other side" step, so a typo'd/missing kind is caught
+  // here rather than by eyeballing the running app.
+  it('Telegram declares a QR connect step that opens the bot link', () => {
+    const connect = CHANNEL_CATALOG.telegram?.descriptor.connect;
+    expect(connect?.kind).toBe('qr');
+    // The t.me link is an https URL the user OPENS (not pastes) → open affordance.
+    expect(connect?.openable).toBe(true);
+    expect(connect?.openLabel).toBeTruthy();
+  });
+
+  it('Slack declares a URL connect step the user pastes (not opens)', () => {
+    const connect = CHANNEL_CATALOG.slack?.descriptor.connect;
+    expect(connect?.kind).toBe('url');
+    expect(connect?.openable).toBeFalsy();
+  });
+
+  it('every declared connect kind is one the renderer handles', () => {
+    const handled = new Set(['qr', 'url', 'instructions']);
+    for (const entry of listChannelCatalog()) {
+      const c = entry.descriptor.connect;
+      if (c) expect(handled.has(c.kind)).toBe(true);
+    }
+  });
 });

--- a/packages/desktop-host/src/channel-catalog.ts
+++ b/packages/desktop-host/src/channel-catalog.ts
@@ -48,6 +48,11 @@ export const CHANNEL_CATALOG: Readonly<Record<string, ChannelCatalogEntry>> = {
       hasWebhookUrl: true,
       runHint:
         'Paste the Request URL into your Slack app → Event Subscriptions, subscribe to the app_mention bot event, then mention the bot in a channel to pair.',
+      connect: {
+        kind: 'url',
+        title: 'Request URL',
+        hint: 'Paste this into your Slack app → Event Subscriptions, subscribe to the app_mention bot event, then mention the bot in a channel to pair.',
+      },
     },
     vaultKeys: { botToken: 'slack_bot_token', signingSecret: 'slack_signing_secret' },
     requiredKeys: ['slack_bot_token', 'slack_signing_secret'],
@@ -72,6 +77,13 @@ export const CHANNEL_CATALOG: Readonly<Record<string, ChannelCatalogEntry>> = {
       hasWebhookUrl: false,
       runHint:
         'Message your bot on Telegram, then send the pairing code it replies with to authorize your chat.',
+      connect: {
+        kind: 'qr',
+        title: 'Connect your Telegram',
+        hint: 'Scan the code, or open the link, and send /start to your bot — then send the pairing code it replies with.',
+        openable: true,
+        openLabel: 'Open in Telegram',
+      },
     },
     vaultKeys: { botToken: 'telegram_bot_token' },
     requiredKeys: ['telegram_bot_token'],

--- a/packages/desktop-ipc-contract/src/channels.ts
+++ b/packages/desktop-ipc-contract/src/channels.ts
@@ -21,6 +21,27 @@ export interface ChannelConfigField {
   readonly help?: string;
 }
 
+/**
+ * Declares how the renderer presents a channel's post-start "connect" step (the
+ * "now connect the other side" affordance). The runtime VALUE this renders is the
+ * channel's {@link ChannelRuntimeStatus.requestUrl} (Slack's Request URL,
+ * Telegram's `t.me/<bot>` link); this only says HOW to render it, so a new
+ * channel plugs in by declaring a `kind` rather than shipping bespoke UI. Mirrors
+ * `ChannelConnectStep` in `@moxxy/sdk` (the desktop catalog is a manual copy of
+ * the plugin descriptors — see channel-catalog.ts).
+ */
+export interface ChannelConnectStep {
+  /** `qr` → QR + the value; `url` → copyable URL to paste; `instructions` → static steps. */
+  readonly kind: 'qr' | 'url' | 'instructions';
+  readonly title?: string;
+  readonly hint?: string;
+  /** Value is an https URL the user should OPEN (not paste) → show an open button. */
+  readonly openable?: boolean;
+  readonly openLabel?: string;
+  /** For `kind: 'instructions'` — static steps, no runtime value. */
+  readonly steps?: ReadonlyArray<string>;
+}
+
 /** Static description of a runnable channel (its identity + what it needs). */
 export interface ChannelDescriptor {
   /** Channel id == the CLI subcommand (`slack`, `telegram`). */
@@ -40,6 +61,9 @@ export interface ChannelDescriptor {
   /** Guidance shown once the channel is running (e.g. "paste the Request URL
    *  into Slack → Event Subscriptions, then mention the bot to pair"). */
   readonly runHint?: string;
+  /** How to render the post-start connect step (QR / URL / instructions). When
+   *  present, the renderer uses this instead of the bare `hasWebhookUrl` URL row. */
+  readonly connect?: ChannelConnectStep;
 }
 
 /** Live runtime status of a channel's dedicated runner. */
@@ -51,7 +75,9 @@ export interface ChannelRuntimeStatus {
   readonly running: boolean;
   readonly pid?: number;
   readonly startedAtMs?: number;
-  /** Public ingest URL once the tunnel is up (Slack); absent otherwise. */
+  /** The channel's runtime connect value, rendered per `descriptor.connect`:
+   *  Slack's public Request URL once the tunnel is up, or Telegram's resolved
+   *  `t.me/<bot>` link. Absent until resolved (or if the channel has none). */
   readonly requestUrl?: string;
   /** Last spawn/runtime error, surfaced so the UI can show why it stopped. */
   readonly error?: string;

--- a/packages/plugin-channel-slack/src/index.ts
+++ b/packages/plugin-channel-slack/src/index.ts
@@ -138,6 +138,11 @@ function makeSlackPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks): Pl
           hasRequestUrl: true,
           runHint:
             'Paste the Request URL into your Slack app → Event Subscriptions, subscribe to the app_mention bot event, then mention the bot in a channel to pair.',
+          connect: {
+            kind: 'url',
+            title: 'Request URL',
+            hint: 'Paste this into your Slack app → Event Subscriptions, subscribe to the app_mention bot event, then mention the bot in a channel to pair.',
+          },
         },
         create: (deps) => {
           const options = deps.options;

--- a/packages/plugin-telegram/src/channel.ts
+++ b/packages/plugin-telegram/src/channel.ts
@@ -64,6 +64,10 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
   readonly approvalResolver: TelegramApprovalResolver;
   private readonly opts: TelegramChannelOptions;
   private bot: Bot | null = null;
+  // The resolved bot's `t.me/<botname>` link (from getMe at start), published as
+  // this channel's `requestUrl` connect value so control surfaces can render a
+  // QR / "open the bot" step. Null until resolved (or if getMe failed).
+  private botLink: string | null = null;
   private busy = false;
   private currentChatId: number | null = null;
   // Last chat we ran a turn for — the target for mirroring turns this channel
@@ -106,6 +110,12 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
       vault: opts.vault,
       ...(opts.logger ? { logger: opts.logger } : {}),
     });
+  }
+
+  /** This channel's connect value (see {@link Channel.requestUrl}): the resolved
+   *  bot's `t.me` link, surfaced by control surfaces as a QR / open-bot step. */
+  get requestUrl(): string | null {
+    return this.botLink;
   }
 
   async start(startOpts: TelegramStartOpts): Promise<ChannelHandle> {
@@ -188,7 +198,23 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
       paired: this.pairing.phase() === 'paired',
     });
 
-    const running = this.bot.start({ drop_pending_updates: false });
+    // Resolve the bot's own identity up front (getMe) so a control surface can
+    // show a `t.me/<botname>` connect step. grammy caches this on `bot.botInfo`,
+    // and `bot.start()` below reuses it instead of calling getMe again. Non-fatal:
+    // a transient getMe failure must not block the channel from starting — the
+    // poll loop surfaces a genuinely invalid token on its own.
+    const bot = this.bot;
+    try {
+      await bot.init();
+      const username = bot.botInfo.username;
+      if (username) this.botLink = `https://t.me/${username}`;
+    } catch (err) {
+      this.opts.logger?.warn?.('telegram: could not resolve bot identity (getMe)', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    const running = bot.start({ drop_pending_updates: false });
     this.handle = {
       running,
       stop: async (reason = 'shutdown') => {

--- a/packages/plugin-telegram/src/index.ts
+++ b/packages/plugin-telegram/src/index.ts
@@ -101,6 +101,13 @@ function makeTelegramPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks):
           hasRequestUrl: false,
           runHint:
             'Message your bot on Telegram, then send the pairing code it replies with to authorize your chat.',
+          connect: {
+            kind: 'qr',
+            title: 'Connect your Telegram',
+            hint: 'Scan the code, or open the link, and send /start to your bot — then send the pairing code it replies with.',
+            openable: true,
+            openLabel: 'Open in Telegram',
+          },
         },
         create: (deps) =>
           new TelegramChannel({

--- a/packages/sdk/src/channel.ts
+++ b/packages/sdk/src/channel.ts
@@ -28,11 +28,13 @@ export interface Channel<TStartOpts = unknown> {
   start(opts: TStartOpts): Promise<ChannelHandle>;
 
   /**
-   * The public ingest URL this channel exposes once running — e.g. Slack's
-   * Events Request URL after its proxy tunnel opens — or null when it has none
-   * (Telegram long-polls). Read by the dedicated-runner host to publish the URL
-   * the user must paste into the provider's config. Optional: channels with no
-   * inbound endpoint omit it.
+   * The channel's runtime "connect value" — published once running and surfaced
+   * by control surfaces per the channel's declared {@link ChannelConnectStep}.
+   * Its meaning depends on `connect.kind`: for Slack it is the Events Request URL
+   * the user pastes into the app (after its proxy tunnel opens); for Telegram it
+   * is the `https://t.me/<botname>` link of the resolved bot. Null when the
+   * channel has no connect value yet (still resolving) or none at all. Read by
+   * the dedicated-runner host and written to the channel's status file.
    */
   readonly requestUrl?: string | null;
 }
@@ -201,6 +203,40 @@ export interface ChannelConfigDescriptor {
   readonly hasRequestUrl?: boolean;
   /** Post-start pairing/setup instructions to show the user. */
   readonly runHint?: string;
+  /** How a control surface should present the "now connect the other side" step
+   *  once the channel is running — declaratively, so each channel renders the
+   *  same way without per-channel UI code. See {@link ChannelConnectStep}. */
+  readonly connect?: ChannelConnectStep;
+}
+
+/**
+ * Declares how a control surface (TUI `/channels`, the desktop Channels panel)
+ * presents a channel's post-start "connect" step. The runtime VALUE this step
+ * renders is the channel's {@link Channel.requestUrl} (Slack's Request URL,
+ * Telegram's `t.me/<bot>` link); this descriptor only says how to render it, so
+ * a new channel plugs in by declaring a `kind` rather than shipping bespoke UI.
+ */
+export interface ChannelConnectStep {
+  /**
+   * Presentation of the channel's runtime connect value:
+   * - `qr`: render a QR of the value plus the value itself (e.g. scan/open a
+   *   `t.me/<bot>` link, or a mobile pairing URL).
+   * - `url`: show the value as a copyable URL the user pastes elsewhere
+   *   (Slack's Events Request URL).
+   * - `instructions`: static `steps`, no runtime value.
+   */
+  readonly kind: 'qr' | 'url' | 'instructions';
+  /** Heading for the step, e.g. "Connect your Telegram". */
+  readonly title?: string;
+  /** One-line helper under the value, e.g. "Scan, or open the link and send /start". */
+  readonly hint?: string;
+  /** When true and the value is an https URL the user should OPEN (not paste),
+   *  a control surface may show an "open externally" affordance. */
+  readonly openable?: boolean;
+  /** Label for the open affordance, e.g. "Open in Telegram". */
+  readonly openLabel?: string;
+  /** For `kind: 'instructions'` — static steps shown verbatim (no runtime value). */
+  readonly steps?: ReadonlyArray<string>;
 }
 
 export interface ChannelAvailability {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -375,6 +375,7 @@ export type {
   ChannelDef,
   ChannelConfigField,
   ChannelConfigDescriptor,
+  ChannelConnectStep,
   ChannelAvailability,
   ChannelRegistry,
   ChannelSubcommand,


### PR DESCRIPTION
## Why

The desktop **Apps→Channels** panel only rendered a key→value config form plus — for Slack — a hardcoded "Request URL" row. There was no uniform way for a channel to say *"now connect the other side."* So Telegram, after you saved its token and started it, gave you nothing to act on.

## What

A **declarative per-channel connect step**. A channel declares how its post-start connect affordance is presented — `ChannelConnectStep` on `ChannelConfigDescriptor` (`kind: 'qr' | 'url' | 'instructions'`) — and the Channels panel renders it uniformly. A new channel plugs in by declaring a `kind`, not by shipping UI.

- **Telegram (first consumer):** on start it resolves its bot's `@username` (grammy `getMe`/`bot.init()`) and publishes `https://t.me/<bot>` through the **existing** `requestUrl` status spine (the same path Slack already uses — no new plumbing). The panel shows a **QR + "Open in Telegram"** link. getMe is non-fatal: a transient failure doesn't block channel start.
- **Slack** folds its Request URL into the same mechanism (`kind: 'url'`).
- The XSS-safe `QrCode` component is **extracted** from `MobileTab` into a shared `apps/desktop/src/components/QrCode.tsx` (retires a duplication), reused by both Mobile and Channels.
- "Open in Telegram" reuses the existing https-validated `onboarding.openExternal` IPC.

## Files
SDK descriptor (`packages/sdk/src/channel.ts`), Telegram channel + index, Slack index, IPC contract (`desktop-ipc-contract/src/channels.ts`) + the desktop catalog (its manual mirror — pre-existing TECH_DEBT noted), and the renderer (shared `QrCode` + a `ConnectStep` component in `ChannelsPanel.tsx`). Changeset: minor `@moxxy/sdk` + `@moxxy/desktop`.

## Out of scope (noted)
- A live "N chats" count in the connect step (status doesn't carry it).
- Folding the separate `Mobile` sidebar view into this mechanism.

## Verification
- `pnpm typecheck` (141/141), `pnpm build` (74/74), `pnpm lint` (0 errors), `pnpm check:deps` — all green.
- New tests in `channel-catalog.test.ts` assert the Telegram/Slack `connect` descriptors. Affected suites pass in isolation: `cli` 275/275, `desktop` 423/423, `desktop-host` 488/488. (The full parallel `turbo run test` flaked on the known test-oversubscription issue, not these changes — every affected package is green run alone.)
- Manual (recommended): Apps→Channels → Telegram → paste a BotFather token → Save → Start → confirm the QR for `t.me/<botname>` + "Open in Telegram".