### PR TITLE
feat(telegram): QR deep-link chat pairing (one mechanism, desktop + CLI)

### DIFF
--- a/.changeset/telegram-qr-pairing.md
+++ b/.changeset/telegram-qr-pairing.md
@@ -1,0 +1,13 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/cli': minor
+'@moxxy/desktop': minor
+---
+
+Telegram chat pairing now works from the desktop, via a single QR mechanism used everywhere.
+
+Previously, starting Telegram from the desktop Channels panel errored with "No Telegram chat is paired yet" — the channel refused to start unpaired and the only pairing path was the TTY-only paste-a-code flow. Now, when unpaired, Telegram opens a host-issued pairing window: it mints a one-time code, publishes a `t.me/<bot>?start=<code>` deep link as its connect value, and the panel renders it as a QR. The user scans → taps **START** in Telegram (or sends the 6 digits) and the chat pairs — zero typing — after which the panel shows "✓ Connected".
+
+This is the **single** pairing mechanism everywhere: `moxxy channels telegram pair` now renders the same QR in the terminal (and waits for the scan) instead of the old bot-DMs-a-code / paste-in-the-terminal flow, which is removed.
+
+New SDK surface: `Channel.connected` and `ChannelHandle.onConnectChange`, plus a `connected` field on the channel status file, so a dedicated-runner host can swap the QR for "Connected" live.

--- a/apps/desktop/src/apps/ChannelsPanel.tsx
+++ b/apps/desktop/src/apps/ChannelsPanel.tsx
@@ -238,9 +238,24 @@ function ChannelCard({
         </div>
       )}
 
-      {/* Running affordances: the declarative per-channel connect step (QR / URL /
+      {/* Running affordances: once the other side is connected (e.g. a Telegram
+          chat paired) the connect step is done — show a "✓ Connected" note.
+          Otherwise render the declarative per-channel connect step (QR / URL /
           instructions). Channels without a `connect` fall back to the legacy hint. */}
-      {status.running && descriptor.connect ? (
+      {status.running && status.connected ? (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            fontSize: '0.78rem',
+            color: 'var(--color-green)',
+          }}
+        >
+          <Icon name="check" size={14} />
+          Connected
+        </div>
+      ) : status.running && descriptor.connect ? (
         <ConnectStep connect={descriptor.connect} url={status.requestUrl} />
       ) : (
         status.running &&

--- a/packages/cli/src/commands/start-registered-channel.ts
+++ b/packages/cli/src/commands/start-registered-channel.ts
@@ -225,10 +225,14 @@ async function runSelfHostedChannel(
     }
   }
 
-  // The in-process Session satisfies ClientSession; the seam holds.
+  // The in-process Session satisfies ClientSession; the seam holds. `dedicated`
+  // is threaded so a channel that pairs the other side (Telegram) knows it runs
+  // under a GUI host with no terminal — it self-serves a host-issued pairing
+  // window + QR instead of demanding `moxxy channels telegram pair`.
   const handle = await startChannelWith(channel, {
     session,
     model: stringFlag(argv, 'model'),
+    dedicated,
     ...collectExtraFlags(argv),
   });
 
@@ -242,14 +246,23 @@ async function runSelfHostedChannel(
   // readiness + the public ingest URL (Slack's Request URL) without the runner
   // protocol. `channel.requestUrl` is set by the time `start()` resolved (Slack
   // opens its tunnel during start); null for channels with no inbound endpoint.
+  // We are the SOLE writer of this file: the initial write captures pid/startedAt,
+  // and `onConnectChange` re-publishes the same record (stable startedAt) when the
+  // channel's connect-state flips — e.g. a Telegram chat pairs (connected:true).
   if (dedicated) {
-    writeChannelStatus({
-      name,
-      pid: process.pid,
-      startedAt: new Date().toISOString(),
-      ...(process.env.MOXXY_SESSION_SOURCE ? { source: process.env.MOXXY_SESSION_SOURCE } : {}),
-      requestUrl: channel.requestUrl ?? null,
-    });
+    const startedAt = new Date().toISOString();
+    const publishStatus = (): void => {
+      writeChannelStatus({
+        name,
+        pid: process.pid,
+        startedAt,
+        ...(process.env.MOXXY_SESSION_SOURCE ? { source: process.env.MOXXY_SESSION_SOURCE } : {}),
+        requestUrl: channel.requestUrl ?? null,
+        ...(channel.connected !== undefined ? { connected: channel.connected } : {}),
+      });
+    };
+    publishStatus();
+    handle.onConnectChange?.(publishStatus);
   }
 
   // Re-entrancy guard (mirrors runAttachedChannel): a second Ctrl-C, or

--- a/packages/desktop-host/src/channel-catalog.ts
+++ b/packages/desktop-host/src/channel-catalog.ts
@@ -76,11 +76,11 @@ export const CHANNEL_CATALOG: Readonly<Record<string, ChannelCatalogEntry>> = {
       ],
       hasWebhookUrl: false,
       runHint:
-        'Message your bot on Telegram, then send the pairing code it replies with to authorize your chat.',
+        'Scan the QR (or open the link) and tap START in Telegram to pair your chat — no code to type.',
       connect: {
         kind: 'qr',
         title: 'Connect your Telegram',
-        hint: 'Scan the code, or open the link, and send /start to your bot — then send the pairing code it replies with.',
+        hint: 'Scan the QR with your phone (or tap Open in Telegram), then press START — your chat pairs automatically.',
         openable: true,
         openLabel: 'Open in Telegram',
       },

--- a/packages/desktop-host/src/channel-supervisor.ts
+++ b/packages/desktop-host/src/channel-supervisor.ts
@@ -23,10 +23,14 @@ import type { ChannelRuntimeStatus } from '@moxxy/desktop-ipc-contract';
 import { augmentedPaths, resolveMoxxyCli, spawnCli } from './cli-resolver';
 import { broadcastHostEvent } from './event-bus';
 
-/** How long to keep polling the status file for the public Request URL after a
- *  channel starts (its tunnel opens within a second or two). */
+/** How often / how long to poll the status file after a channel starts. A
+ *  channel publishes its connect value fast (Slack's Request URL within a second
+ *  or two; Telegram's pairing deep link at start), but the connect-state can flip
+ *  much later — when the user actually scans the QR and pairs — so we keep
+ *  watching for several minutes (the poll also stops the moment `connected`
+ *  becomes true, or the process exits). */
 const URL_POLL_INTERVAL_MS = 700;
-const URL_POLL_TIMEOUT_MS = 30_000;
+const URL_POLL_TIMEOUT_MS = 5 * 60_000;
 /** Cap the stderr we retain per channel for error reporting (avoid unbounded). */
 const STDERR_TAIL_CAP = 4096;
 
@@ -35,6 +39,7 @@ interface ChannelProc {
   readonly pid: number;
   readonly startedAtMs: number;
   requestUrl?: string;
+  connected?: boolean;
   error?: string;
   stderrTail: string;
   urlPoll?: ReturnType<typeof setInterval>;
@@ -52,6 +57,7 @@ export interface ChannelRuntime {
   readonly pid?: number;
   readonly startedAtMs?: number;
   readonly requestUrl?: string;
+  readonly connected?: boolean;
   readonly error?: string;
 }
 
@@ -63,6 +69,7 @@ export function channelRuntime(id: string): ChannelRuntime {
     pid: p.pid,
     startedAtMs: p.startedAtMs,
     ...(p.requestUrl ? { requestUrl: p.requestUrl } : {}),
+    ...(p.connected !== undefined ? { connected: p.connected } : {}),
     ...(p.error ? { error: p.error } : {}),
   };
 }
@@ -80,6 +87,7 @@ function broadcast(id: string, extra?: Partial<ChannelRuntimeStatus>): void {
     ...(rt.pid !== undefined ? { pid: rt.pid } : {}),
     ...(rt.startedAtMs !== undefined ? { startedAtMs: rt.startedAtMs } : {}),
     ...(rt.requestUrl !== undefined ? { requestUrl: rt.requestUrl } : {}),
+    ...(rt.connected !== undefined ? { connected: rt.connected } : {}),
     ...(rt.error !== undefined ? { error: rt.error } : {}),
     ...extra,
   });
@@ -133,16 +141,27 @@ export function startChannel(id: string): void {
     finalize(id, entry);
   });
 
-  // Poll the channel's status file for its public Request URL (Slack). Stops
-  // once found, on timeout, or when the process goes away.
+  // Poll the channel's status file for its connect value (Slack's Request URL,
+  // Telegram's pairing deep link) AND its connect-state (Telegram pairing).
+  // Broadcasts on any change; stops once the channel reports connected, on
+  // timeout, or when the process goes away.
   entry.urlPoll = setInterval(() => {
     if (!procs.has(id)) return stopUrlPoll(entry);
     const status = readChannelStatus(id);
+    let changed = false;
     if (status?.requestUrl && status.requestUrl !== entry.requestUrl) {
       entry.requestUrl = status.requestUrl;
-      stopUrlPoll(entry);
-      broadcast(id);
-    } else if (Date.now() - entry.urlPollStartedAt > URL_POLL_TIMEOUT_MS) {
+      changed = true;
+    }
+    if (status?.connected !== undefined && status.connected !== entry.connected) {
+      entry.connected = status.connected;
+      changed = true;
+    }
+    if (changed) broadcast(id);
+    // Once the other side is connected (paired) there's nothing left to watch.
+    // Otherwise keep polling until the cap — the pairing transition can land
+    // minutes after start, when the user finally scans the QR.
+    if (entry.connected === true || Date.now() - entry.urlPollStartedAt > URL_POLL_TIMEOUT_MS) {
       stopUrlPoll(entry);
     }
   }, URL_POLL_INTERVAL_MS);

--- a/packages/desktop-host/src/ipc/channels.ts
+++ b/packages/desktop-host/src/ipc/channels.ts
@@ -37,6 +37,7 @@ function statusOf(id: string, configured: boolean): ChannelRuntimeStatus {
     ...(rt.pid !== undefined ? { pid: rt.pid } : {}),
     ...(rt.startedAtMs !== undefined ? { startedAtMs: rt.startedAtMs } : {}),
     ...(rt.requestUrl !== undefined ? { requestUrl: rt.requestUrl } : {}),
+    ...(rt.connected !== undefined ? { connected: rt.connected } : {}),
     ...(rt.error !== undefined ? { error: rt.error } : {}),
   };
 }

--- a/packages/desktop-ipc-contract/src/channels.ts
+++ b/packages/desktop-ipc-contract/src/channels.ts
@@ -77,8 +77,13 @@ export interface ChannelRuntimeStatus {
   readonly startedAtMs?: number;
   /** The channel's runtime connect value, rendered per `descriptor.connect`:
    *  Slack's public Request URL once the tunnel is up, or Telegram's resolved
-   *  `t.me/<bot>` link. Absent until resolved (or if the channel has none). */
+   *  `t.me/<bot>` link (while pairing, the `?start=<code>` deep link). Absent
+   *  until resolved (or if the channel has none). */
   readonly requestUrl?: string;
+  /** The "connect the other side" step is satisfied — e.g. a Telegram chat
+   *  paired. The panel shows "✓ Connected" instead of the connect QR/URL. Absent
+   *  for channels with no discrete connected state (Slack). */
+  readonly connected?: boolean;
   /** Last spawn/runtime error, surfaced so the UI can show why it stopped. */
   readonly error?: string;
 }

--- a/packages/plugin-telegram/package.json
+++ b/packages/plugin-telegram/package.json
@@ -2,7 +2,7 @@
   "name": "@moxxy/plugin-telegram",
   "private": true,
   "version": "0.1.1",
-  "description": "Telegram channel for moxxy via grammy. Treats Telegram chats as a bidirectional channel: prompts in, assistant + tool prompts out, inline-keyboard permission flow, TOFU + code-pairing authorization.",
+  "description": "Telegram channel for moxxy via grammy. Treats Telegram chats as a bidirectional channel: prompts in, assistant + tool prompts out, inline-keyboard permission flow, QR deep-link chat pairing.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -41,12 +41,14 @@
     "@moxxy/core": "workspace:*",
     "@moxxy/plugin-vault": "workspace:*",
     "@moxxy/sdk": "workspace:*",
-    "grammy": "^1.30.0"
+    "grammy": "^1.30.0",
+    "qrcode": "^1.5.4"
   },
   "devDependencies": {
     "@moxxy/tsconfig": "workspace:*",
     "@moxxy/vitest-preset": "workspace:*",
     "@types/node": "catalog:",
+    "@types/qrcode": "^1.5.5",
     "typescript": "catalog:",
     "vitest": "catalog:"
   }

--- a/packages/plugin-telegram/src/channel.ts
+++ b/packages/plugin-telegram/src/channel.ts
@@ -16,11 +16,7 @@ import { TelegramPermissionResolver } from './permission.js';
 import { TelegramApprovalResolver } from './approval.js';
 import { FramePump } from './channel/frame-pump.js';
 import { TypingIndicator } from './channel/typing-indicator.js';
-import {
-  PairingHandler,
-  type PairingConfirmResult,
-  type PairingIssuedEvent,
-} from './channel/pairing-handler.js';
+import { PairingHandler } from './channel/pairing-handler.js';
 import { askForPermission } from './channel/permission-prompt.js';
 import { askForApproval } from './channel/approval-prompt.js';
 import { publishBotCommands } from './channel/slash-handler.js';
@@ -34,18 +30,27 @@ import { handleVoiceMessage } from './channel/voice-handler.js';
 
 const TOKEN_KEY = 'telegram_bot_token';
 
-export type { PairingIssuedEvent, PairingConfirmResult } from './channel/pairing-handler.js';
+export type { PairingConfirmResult } from './channel/pairing-handler.js';
 
 export interface TelegramStartOpts extends ChannelStartOptsBase {
   readonly session: Session;
   /**
-   * If true, open a pairing window on startup. The window waits for the
-   * user to send /start to the bot in Telegram; when /start lands the
-   * bot DMs a 6-digit code to that chat. The host (terminal wizard)
-   * subscribes via `onPairingIssued` and prompts the user to paste the
-   * code, then calls `confirmPairingCode` to finalize.
+   * If true (and no chat is paired yet), open a host-issued QR pairing window on
+   * startup: mint a code, publish a `t.me/<bot>?start=<code>` deep link as the
+   * connect value, and pair whichever chat presents that code back (deep-link tap
+   * or a plain 6-digit message). Set by the `moxxy channels telegram pair` command
+   * (which renders the deep link as a terminal QR and waits via `onPaired`).
    */
   readonly pair?: boolean;
+  /**
+   * The channel is running on its own dedicated runner under a GUI control
+   * surface (the desktop Channels panel) rather than a terminal. Equivalent to
+   * `pair` for the unpaired case — `start()` opens the same host-issued QR
+   * pairing window instead of throwing — so the desktop pairs with the identical
+   * mechanism. Threaded by the CLI from `ChannelDef.dedicatedRunner` /
+   * `--dedicated` / `MOXXY_DEDICATED_RUNNER`.
+   */
+  readonly dedicated?: boolean;
 }
 
 export interface TelegramChannelOptions {
@@ -66,8 +71,18 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
   private bot: Bot | null = null;
   // The resolved bot's `t.me/<botname>` link (from getMe at start), published as
   // this channel's `requestUrl` connect value so control surfaces can render a
-  // QR / "open the bot" step. Null until resolved (or if getMe failed).
+  // QR / "open the bot" step. While a host-issued pairing window is open it
+  // carries the `?start=<code>` deep-link payload. Null until resolved (or if
+  // getMe failed).
   private botLink: string | null = null;
+  // The host-issued pairing code embedded in `botLink`'s `?start=` payload, set
+  // when `start()` opens a host pairing window (dedicated + unpaired). Null
+  // otherwise (terminal pairing, or already paired).
+  private hostPairingCode: string | null = null;
+  // Listeners notified when this channel's connect-state changes (i.e. a chat
+  // just paired). The dedicated-runner host subscribes via the handle to
+  // re-publish the channel's status file. See `onConnectChange` on the handle.
+  private readonly connectListeners = new Set<() => void>();
   private busy = false;
   private currentChatId: number | null = null;
   // Last chat we ran a turn for — the target for mirroring turns this channel
@@ -110,12 +125,33 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
       vault: opts.vault,
       ...(opts.logger ? { logger: opts.logger } : {}),
     });
+    // A completed pairing flips this channel's connect-state to "connected";
+    // notify the host so it can swap the QR for a "✓ Connected" affordance.
+    this.pairing.onPaired(() => this.notifyConnectChange());
   }
 
   /** This channel's connect value (see {@link Channel.requestUrl}): the resolved
-   *  bot's `t.me` link, surfaced by control surfaces as a QR / open-bot step. */
+   *  bot's `t.me` link, surfaced by control surfaces as a QR / open-bot step.
+   *  While a host pairing window is open it includes the `?start=<code>` payload. */
   get requestUrl(): string | null {
     return this.botLink;
+  }
+
+  /** Whether the "connect the other side" step is satisfied — i.e. a chat is
+   *  paired (see {@link Channel.connected}). A host shows "✓ Connected" instead
+   *  of the pairing QR once this is true. */
+  get connected(): boolean {
+    return this.pairing.phase() === 'paired';
+  }
+
+  private notifyConnectChange(): void {
+    for (const listener of this.connectListeners) {
+      try {
+        listener();
+      } catch (err) {
+        this.opts.logger?.warn?.('telegram connect-change listener threw', { err: String(err) });
+      }
+    }
   }
 
   async start(startOpts: TelegramStartOpts): Promise<ChannelHandle> {
@@ -138,13 +174,23 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
     }
     await this.pairing.loadAuthorized();
 
-    if (startOpts.pair) {
-      this.pairing.beginWindow();
-      this.opts.logger?.info?.('telegram pairing window open');
-    } else if (this.pairing.phase() !== 'paired') {
-      throw new Error(
-        'No Telegram chat is paired yet. Run `moxxy channels telegram pair` to start a pairing window first.',
-      );
+    // Open the single host-issued QR pairing window when a pairing surface asked
+    // for it (`pair`, the terminal `pair` command) OR when running GUI-supervised
+    // on a dedicated runner (the desktop) and no chat is paired yet. The code is
+    // minted now so we can embed it in the `t.me/<bot>?start=<code>` deep link
+    // below; the surface renders that as a QR, and pairing completes when the
+    // user taps START (or sends the digits) — no terminal round-trip. Only a
+    // headless start with neither signal still errors with a pairing hint.
+    const dedicated = startOpts.dedicated === true || process.env.MOXXY_DEDICATED_RUNNER === '1';
+    if (this.pairing.phase() !== 'paired') {
+      if (startOpts.pair || dedicated) {
+        this.hostPairingCode = this.pairing.beginHostWindow();
+        this.opts.logger?.info?.('telegram pairing window open');
+      } else {
+        throw new Error(
+          'No Telegram chat is paired yet. Run `moxxy channels telegram pair` to pair, or start it from the desktop Channels panel.',
+        );
+      }
     }
 
     this.bot = new Bot(token);
@@ -207,7 +253,14 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
     try {
       await bot.init();
       const username = bot.botInfo.username;
-      if (username) this.botLink = `https://t.me/${username}`;
+      if (username) {
+        // Embed the host-issued code as the `?start=` deep-link payload so a scan
+        // → tap-START round-trips `/start <code>` back to us, pairing with zero
+        // typing. Plain `t.me/<bot>` once paired (or in terminal-pair mode).
+        this.botLink = this.hostPairingCode
+          ? `https://t.me/${username}?start=${this.hostPairingCode}`
+          : `https://t.me/${username}`;
+      }
     } catch (err) {
       this.opts.logger?.warn?.('telegram: could not resolve bot identity (getMe)', {
         error: err instanceof Error ? err.message : String(err),
@@ -217,6 +270,12 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
     const running = bot.start({ drop_pending_updates: false });
     this.handle = {
       running,
+      // Let the dedicated-runner host re-publish our status file when a chat
+      // pairs (connect-state → connected), so its panel swaps QR for "Connected".
+      onConnectChange: (listener) => {
+        this.connectListeners.add(listener);
+        return () => this.connectListeners.delete(listener);
+      },
       stop: async (reason = 'shutdown') => {
         // Abort the in-flight turn FIRST so the model loop stops generating
         // tokens / executing side-effecting tools the moment the operator
@@ -238,10 +297,6 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
     return this.handle;
   }
 
-  beginPairingWindow(): void {
-    this.pairing.beginWindow();
-  }
-
   pairingPhase(): ReturnType<PairingHandler['phase']> {
     return this.pairing.phase();
   }
@@ -250,12 +305,13 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
     this.pairing.unpair();
   }
 
-  onPairingIssued(listener: (e: PairingIssuedEvent) => void): () => void {
-    return this.pairing.onIssued(listener);
-  }
-
-  async confirmPairingCode(rawInput: string): Promise<PairingConfirmResult> {
-    return this.pairing.confirmCode(rawInput);
+  /**
+   * Subscribe to "a chat just paired" — fires once when the host-issued QR
+   * pairing completes. The `moxxy channels telegram pair` command uses this to
+   * print success and stop waiting; returns an unsubscribe function.
+   */
+  onPaired(listener: (chatId: number) => void): () => void {
+    return this.pairing.onPaired(listener);
   }
 
   private handleVoice(ctx: Context, token: string): Promise<void> {
@@ -307,8 +363,26 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
           this.yolo = value;
         },
         runUserTurn: (c, chatId, text) => this.runUserTurn(c, chatId, text),
+        tryHostPair: (chatId, text) => this.tryHostPair(ctx, chatId, text),
       },
     );
+  }
+
+  /**
+   * Plain-message fallback for host-issued pairing: if a host window is open and
+   * an unauthorized chat sends exactly the 6-digit code, pair it (covers clients
+   * that don't auto-deliver the `?start=` deep-link payload). Returns true when
+   * the message was a pairing attempt we handled (paired, or a wrong-code reply)
+   * so the caller doesn't also emit the generic "not paired" rejection.
+   */
+  private async tryHostPair(ctx: Context, chatId: number, text: string): Promise<boolean> {
+    if (this.pairing.phase() !== 'awaiting-host-code') return false;
+    const normalized = text.replace(/\s+/g, '');
+    if (!/^\d{6}$/.test(normalized)) return false;
+    const result = await this.pairing.confirmChatCode(chatId, normalized);
+    if (result.ok) return true; // confirmChatCode greeted + fired onPaired
+    await ctx.reply(result.message);
+    return true;
   }
 
   /**

--- a/packages/plugin-telegram/src/channel/pairing-handler.ts
+++ b/packages/plugin-telegram/src/channel/pairing-handler.ts
@@ -1,12 +1,12 @@
 import type { Bot, Context } from 'grammy';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import {
-  beginPairing,
+  beginHostIssuedPairing,
   clearPairing,
   createPairingState,
   handleStart,
   isAuthorized,
-  submitTerminalCode,
+  submitChatCode,
   type PairingDecision,
   type PairingState,
 } from '../pairing.js';
@@ -14,13 +14,7 @@ import { parseChatId, TELEGRAM_AUTHORIZED_CHAT_KEY } from '../keys.js';
 
 const AUTHORIZED_CHAT_KEY = TELEGRAM_AUTHORIZED_CHAT_KEY;
 
-/** Fires when /start lands in `pair` mode and a code is DM'd to the chat. */
-export interface PairingIssuedEvent {
-  readonly code: string;
-  readonly chatId: number;
-}
-
-/** Result returned by `confirmPairingCode`. */
+/** Result returned by `confirmChatCode`. */
 export type PairingConfirmResult =
   | { ok: true; chatId: number }
   | { ok: false; reason: 'mismatch' | 'expired' | 'not-pending' | 'no-window'; message: string };
@@ -34,15 +28,16 @@ export interface PairingHandlerOptions {
 }
 
 /**
- * Owns the pairing state machine + the bot-side `/start` handler + the
- * terminal-side `confirmPairingCode` flow. Keeps the bot reference
- * (re-)settable so the TelegramChannel can wire it up after construction.
+ * Owns the pairing state machine + the bot-side `/start` handler for the
+ * host-issued QR pairing flow (see {@link beginHostWindow}). Keeps the bot
+ * reference (re-)settable so the TelegramChannel can wire it up after
+ * construction.
  */
 export class PairingHandler {
   private state: PairingState = createPairingState();
   private bot: Bot | null = null;
   private readonly opts: PairingHandlerOptions;
-  private readonly issuedListeners = new Set<(e: PairingIssuedEvent) => void>();
+  private readonly pairedListeners = new Set<(chatId: number) => void>();
 
   constructor(opts: PairingHandlerOptions) {
     this.opts = opts;
@@ -72,13 +67,16 @@ export class PairingHandler {
   }
 
   /**
-   * Begin a pairing window. The terminal calls this before /start lands
-   * in Telegram. No code is generated yet — `handleStart` issues the
-   * code once /start arrives, so it can be DM'd to the specific chat
-   * that asked for it.
+   * Open a host-issued pairing window and return the code to embed in the
+   * `t.me/<bot>?start=<code>` deep link / QR the control surface renders. The
+   * user proves ownership by presenting THIS code back to the bot (deep-link tap
+   * or a plain message), which `handleStartCommand` / `confirmChatCode`
+   * validate. Returns the generated code.
    */
-  beginWindow(): void {
-    this.state = beginPairing(this.state);
+  beginHostWindow(): string {
+    const { state, code } = beginHostIssuedPairing(this.state);
+    this.state = state;
+    return code;
   }
 
   unpair(): void {
@@ -86,58 +84,89 @@ export class PairingHandler {
   }
 
   /**
-   * Subscribe to "code issued" events. Fires each time /start lands in
-   * the pair window (including re-issues to the same chat). The wizard
-   * subscribes before `start()` so the first /start can't race past it.
-   * Returns an unsubscribe function.
+   * Subscribe to "a chat just became authorized" — fires once each time pairing
+   * completes. The channel uses this to publish its "connected" connect-state so
+   * a watching control surface can swap the QR for a "✓ Connected" affordance,
+   * and the `pair` terminal command uses it to know pairing finished. Returns an
+   * unsubscribe function.
    */
-  onIssued(listener: (e: PairingIssuedEvent) => void): () => void {
-    this.issuedListeners.add(listener);
-    return () => this.issuedListeners.delete(listener);
+  onPaired(listener: (chatId: number) => void): () => void {
+    this.pairedListeners.add(listener);
+    return () => this.pairedListeners.delete(listener);
   }
 
   /**
-   * Called by the terminal wizard when the user pastes a code. Returns a
-   * structured result the wizard can branch on (success / mismatch /
-   * expired / not-pending). On success the chat-id is persisted to the
-   * vault by this method directly; callers don't need to remember to
-   * write it.
+   * A chat presented a code (deep-link `/start <code>` payload or a plain 6-digit
+   * message). On match the chat is authorized, persisted to the vault, and
+   * greeted. Returns a structured result the caller can branch on.
    */
-  async confirmCode(rawInput: string): Promise<PairingConfirmResult> {
-    if (this.state.phase === 'idle') {
-      return { ok: false, reason: 'no-window', message: 'No pairing window is open.' };
-    }
-    const decision = submitTerminalCode(this.state, rawInput);
+  async confirmChatCode(chatId: number, rawCode: string): Promise<PairingConfirmResult> {
+    const decision = submitChatCode(this.state, chatId, rawCode);
+    return this.applyConfirmDecision(decision);
+  }
+
+  /** Persist + greet + notify on a 'paired' decision; map every decision kind to
+   *  a {@link PairingConfirmResult}. */
+  private async applyConfirmDecision(decision: PairingDecision): Promise<PairingConfirmResult> {
     this.state = decision.state;
     const action = decision.action;
     if (action.kind === 'paired') {
       await this.opts.vault.set(AUTHORIZED_CHAT_KEY, String(action.chatId));
-      // Greet the chat that just got authorized so the user has a
-      // confirmation on the Telegram side too — symmetric with the
-      // success message they'll see in the terminal.
+      // Greet the chat that just got authorized so the user has a confirmation
+      // on the Telegram side too — symmetric with the success the surface shows.
       if (this.bot) {
         try {
           await this.bot.api.sendMessage(
             action.chatId,
-            '✅ Paired with the moxxy terminal. Send a prompt to begin.',
+            '✅ Paired with moxxy. Send a prompt to begin.',
           );
         } catch (err) {
           this.opts.logger?.warn('pairing: greeting send failed', { err: String(err) });
         }
       }
+      this.emitPaired(action.chatId);
       return { ok: true, chatId: action.chatId };
     }
     if (action.kind === 'still-paired') return { ok: true, chatId: action.chatId };
     if (action.kind === 'mismatch') return { ok: false, reason: 'mismatch', message: action.message };
     if (action.kind === 'expired') return { ok: false, reason: 'expired', message: action.message };
     if (action.kind === 'not-pending') return { ok: false, reason: 'not-pending', message: action.message };
+    if (action.kind === 'reject') return { ok: false, reason: 'not-pending', message: action.message };
     return { ok: false, reason: 'mismatch', message: 'unexpected pairing state' };
   }
 
-  /** Bot-side /start handler — issues a code (or greets) based on phase. */
+  private emitPaired(chatId: number): void {
+    for (const listener of this.pairedListeners) {
+      try {
+        listener(chatId);
+      } catch (err) {
+        this.opts.logger?.warn('pairing paired-listener threw', { err: String(err) });
+      }
+    }
+  }
+
+  /** Bot-side `/start` handler. */
   async handleStartCommand(ctx: Context): Promise<void> {
     const chatId = ctx.chat?.id;
     if (!chatId) return;
+
+    // Host-issued direction: the deep link the user scanned carries the code as
+    // the /start payload (grammy exposes it as `ctx.match`). Validate it here so
+    // "scan QR → tap START → paired" needs no typing. A bare /start (no payload —
+    // e.g. the user opened the chat manually) falls through to `handleStart`,
+    // which nudges them to use the link or send the digits (the message handler
+    // also accepts a bare 6-digit code).
+    if (this.state.phase === 'awaiting-host-code') {
+      const payload = typeof ctx.match === 'string' ? ctx.match.trim() : '';
+      if (payload) {
+        const result = await this.confirmChatCode(chatId, payload);
+        if (!result.ok && result.reason !== 'not-pending') {
+          await ctx.reply(result.message);
+        }
+        return;
+      }
+    }
+
     const decision: PairingDecision = handleStart(this.state, chatId);
     this.state = decision.state;
     const action = decision.action;
@@ -145,28 +174,7 @@ export class PairingHandler {
       await ctx.reply('Welcome back! Send me a prompt.');
       return;
     }
-    if (action.kind === 'issue-code') {
-      // DM the code to the user, then notify the terminal wizard so it
-      // can prompt for the code in the host.
-      const body =
-        `${action.message}\n\n` +
-        `<b><code>${action.code}</code></b>\n\n` +
-        `<i>Open your moxxy terminal and paste these 6 digits when prompted.</i>`;
-      try {
-        await ctx.reply(body, { parse_mode: 'HTML' });
-      } catch (err) {
-        this.opts.logger?.warn('telegram pair: failed to send code', { err: String(err) });
-      }
-      for (const listener of this.issuedListeners) {
-        try {
-          listener({ code: action.code, chatId: action.chatId });
-        } catch (err) {
-          this.opts.logger?.warn('pairing listener threw', { err: String(err) });
-        }
-      }
-      return;
-    }
-    if (action.kind === 'reject' || action.kind === 'wait' || action.kind === 'expired') {
+    if (action.kind === 'reject' || action.kind === 'expired') {
       await ctx.reply(action.message);
     }
   }

--- a/packages/plugin-telegram/src/channel/text-handler.test.ts
+++ b/packages/plugin-telegram/src/channel/text-handler.test.ts
@@ -75,13 +75,15 @@ const makeHarness = (over: Partial<TextHandlerState> = {}): Harness => {
     permissionResolver: { abortAll: vi.fn() } as never,
     framePump: { resetRenderer: vi.fn() } as never,
   };
+  const tryHostPair = vi.fn(async () => false);
   const cb: TextHandlerCallbacks = {
     setAwaitingApprovalText,
     toggleYolo: () => false,
     setYolo: () => undefined,
     runUserTurn,
+    tryHostPair,
   };
-  return { state, deps, cb, runUserTurn, resolvePendingWithText, setAwaitingApprovalText };
+  return { state, deps, cb, runUserTurn, resolvePendingWithText, setAwaitingApprovalText, tryHostPair };
 };
 
 describe('handleTextMessage — authorization gate', () => {

--- a/packages/plugin-telegram/src/channel/text-handler.ts
+++ b/packages/plugin-telegram/src/channel/text-handler.ts
@@ -31,6 +31,10 @@ export interface TextHandlerCallbacks {
   readonly toggleYolo: () => boolean;
   readonly setYolo: (value: boolean) => void;
   readonly runUserTurn: (ctx: Context, chatId: number, text: string) => Promise<void>;
+  /** Host-issued pairing fallback: try to pair an unauthorized chat whose message
+   *  is the 6-digit code. Returns true when handled (so we skip the generic
+   *  "not paired" reply). See {@link TelegramChannel.tryHostPair}. */
+  readonly tryHostPair: (chatId: number, text: string) => Promise<boolean>;
 }
 
 /**
@@ -49,6 +53,9 @@ export async function handleTextMessage(
   if (!chatId || !text) return;
 
   if (!deps.pairing.isAuthorized(chatId)) {
+    // Host-issued pairing: a bare 6-digit message from an unpaired chat may be
+    // the code presented back to us. If so, pair and stop here.
+    if (await cb.tryHostPair(chatId, text)) return;
     await ctx.reply(
       'This bot is paired with a different chat (or not paired yet). Run `moxxy telegram pair` to (re-)pair.',
     );

--- a/packages/plugin-telegram/src/index.ts
+++ b/packages/plugin-telegram/src/index.ts
@@ -17,16 +17,16 @@ export { TelegramPermissionResolver, type PendingPermission } from './permission
 export { TelegramApprovalResolver, type PendingApproval } from './approval.js';
 export {
   createPairingState,
-  beginPairing,
+  beginHostIssuedPairing,
   handleStart,
-  submitTerminalCode,
+  submitChatCode,
   isAuthorized,
   clearPairing,
   type PairingPhase,
   type PairingState,
   type PairingDecision,
 } from './pairing.js';
-export type { PairingIssuedEvent, PairingConfirmResult } from './channel.js';
+export type { PairingConfirmResult } from './channel.js';
 export { TurnRenderer, splitForTelegram } from './render.js';
 export { markdownToTelegramHtml } from './format.js';
 
@@ -78,7 +78,7 @@ function makeTelegramPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks):
     channels: [
       defineChannel({
         name: 'telegram',
-        description: 'Telegram bot channel via grammy. TOFU + code-pairing authorization.',
+        description: 'Telegram bot channel via grammy. QR deep-link chat pairing.',
         // Like Slack, run on a dedicated, isolated runner (separate socket +
         // sticky session) so the bot keeps its own persistent history apart from
         // the user's desktop/TUI work. Telegram long-polls (no tunnel needed).
@@ -100,11 +100,11 @@ function makeTelegramPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks):
           ],
           hasRequestUrl: false,
           runHint:
-            'Message your bot on Telegram, then send the pairing code it replies with to authorize your chat.',
+            'Scan the QR (or open the link) and tap START in Telegram to pair your chat — no code to type.',
           connect: {
             kind: 'qr',
             title: 'Connect your Telegram',
-            hint: 'Scan the code, or open the link, and send /start to your bot — then send the pairing code it replies with.',
+            hint: 'Scan the QR with your phone (or tap Open in Telegram), then press START — your chat pairs automatically.',
             openable: true,
             openLabel: 'Open in Telegram',
           },
@@ -153,16 +153,16 @@ function makeTelegramPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks):
           },
           pair: {
             description:
-              'Open a pairing window. Send /start to your bot in Telegram; it will DM a 6-digit code to paste back in the terminal.',
+              'Open a pairing window and print a QR. Scan it (or open the link) and tap START in Telegram to pair your chat — the same mechanism the desktop uses.',
             run: async (ctx) => {
-              // Pairing requires an interactive terminal - the user
-              // must paste the bot-issued code into a prompt. In a
-              // headless invocation we bail with a clear message
-              // instead of silently starting a bot that nobody can
-              // confirm.
+              // Pairing renders a QR for the user to scan, so it needs an
+              // interactive terminal. In a headless invocation we bail with a
+              // clear message instead of starting a bot nobody can pair. (The
+              // desktop Channels panel pairs the same way without a TTY — it
+              // renders the QR in the GUI.)
               if (process.stdin.isTTY !== true) {
                 process.stderr.write(
-                  'Pairing needs a TTY. Run `moxxy telegram` (interactively) on a workstation, then copy the resulting vault to this host.\n',
+                  'Pairing needs a TTY to show the QR. Run `moxxy channels telegram pair` on a workstation, or pair from the desktop Channels panel.\n',
                 );
                 return 1;
               }

--- a/packages/plugin-telegram/src/pair-flow.ts
+++ b/packages/plugin-telegram/src/pair-flow.ts
@@ -1,27 +1,27 @@
-import { cancel, isCancel, log, outro, spinner, text } from '@clack/prompts';
+import { log, outro, spinner } from '@clack/prompts';
+import QRCode from 'qrcode';
 import type { ChannelSubcommandContext } from '@moxxy/sdk';
 import type { VaultStore } from '@moxxy/plugin-vault';
-import { TelegramChannel, type PairingIssuedEvent } from './channel.js';
+import { TelegramChannel } from './channel.js';
 
 // Tiny zero-dep ANSI dim helper, so this flow stays inside the plugin.
 const ANSI = process.stdout.isTTY && !process.env.NO_COLOR;
 const dim = (s: string): string => (ANSI ? `\x1b[2m${s}\x1b[22m` : s);
 
 /**
- * Drive the bot-issued pairing flow end-to-end.
+ * Drive the host-issued QR pairing flow end-to-end in a terminal — the SAME
+ * mechanism the desktop Channels panel uses, just rendered inline here.
  *
  * Steps:
- *   1. Build a TelegramChannel directly from the subcommand ctx and wire the
- *      session's permission resolver.
- *   2. Subscribe to pairing-issued events BEFORE starting the bot so
- *      we can't race past the first /start.
- *   3. Start the bot in `pair` mode.
- *   4. Wait (with spinner) for the user to send /start in Telegram.
- *   5. Prompt the user for the 6-digit code the bot DM'd them; on
- *      mismatch let them retry (up to 3 tries inside the same window).
- *   6. On success, the channel persists the authorized chat id to the
- *      vault and DMs a confirmation; we then hand off SIGINT to keep
- *      the bot running until the user Ctrl-Cs.
+ *   1. Build a TelegramChannel from the subcommand ctx and wire the session's
+ *      permission resolver.
+ *   2. Subscribe to "paired" BEFORE starting the bot so a fast scan can't race us.
+ *   3. Start the bot in pairing mode — it mints a code and publishes a
+ *      `t.me/<bot>?start=<code>` deep link as `channel.requestUrl`.
+ *   4. Render that deep link as a scannable QR (+ the plain link).
+ *   5. The user scans / opens the link and taps START (or sends the 6 digits);
+ *      the bot authorizes that chat and `onPaired` fires.
+ *   6. Hand off SIGINT to keep the bot running until the user Ctrl-Cs.
  */
 export async function runPairFlow(ctx: ChannelSubcommandContext): Promise<number> {
   const session = ctx.session;
@@ -32,22 +32,23 @@ export async function runPairFlow(ctx: ChannelSubcommandContext): Promise<number
   });
   session.setPermissionResolver(channel.permissionResolver);
 
-  // Subscribe BEFORE start so the first /start can't fire before us.
-  let issuedResolve: ((e: PairingIssuedEvent) => void) | null = null;
-  const issued = new Promise<PairingIssuedEvent>((resolve) => {
-    issuedResolve = resolve;
+  // Subscribe BEFORE start so the first scan can't fire before us.
+  let pairedResolve: ((chatId: number) => void) | null = null;
+  const paired = new Promise<number>((resolve) => {
+    pairedResolve = resolve;
   });
-  const unsubscribe = channel.onPairingIssued((e) => {
-    issuedResolve?.(e);
-    issuedResolve = null;
+  const unsubscribe = channel.onPaired((chatId) => {
+    pairedResolve?.(chatId);
+    pairedResolve = null;
   });
 
   outro(dim('opening pairing window...'));
 
+  // `pair: true` opens the host-issued QR window and resolves the bot's deep link.
   const handle = await channel.start({ session, pair: true });
 
   // From here on we own the bot lifecycle. Any failure path needs to
-  // call handle.stop() before returning.
+  // call stopBot() before returning.
   const stopBot = async (): Promise<void> => {
     unsubscribe();
     try {
@@ -57,74 +58,45 @@ export async function runPairFlow(ctx: ChannelSubcommandContext): Promise<number
     }
   };
 
-  const spin = spinner();
-  spin.start('Waiting for /start from a Telegram chat...');
-
-  let event: PairingIssuedEvent;
-  try {
-    event = await issued;
-  } catch (err) {
-    spin.stop('pairing aborted');
-    log.error(`Pairing aborted: ${err instanceof Error ? err.message : String(err)}`);
+  // Already paired (no window was opened): there's nothing to scan. Tell the
+  // user how to re-pair rather than hanging on a pairing that can't happen.
+  if (channel.connected) {
+    log.info(
+      'This bot is already paired. Run `moxxy channels telegram unpair` first to pair a different chat.',
+    );
     await stopBot();
-    return 1;
+    return 0;
   }
-  spin.stop(`Code sent to Telegram chat ${event.chatId}.`);
-  log.info(
-    'Open the bot in Telegram. You should see the 6-digit code there.\n' +
-      'Paste it below to authorize this chat.',
-  );
 
-  let confirmed = false;
-  for (let attempt = 0; attempt < 5; attempt += 1) {
-    const entered = await text({
-      message: 'Enter the 6-digit code',
-      placeholder: '123456',
-      validate: (v) => {
-        const normalized = (v ?? '').replace(/\s+/g, '');
-        if (!/^\d{6}$/.test(normalized)) return 'Enter the 6 digits the bot sent you';
-        return undefined;
-      },
-    });
-    if (isCancel(entered)) {
-      cancel('pairing cancelled');
-      await stopBot();
-      return 0;
-    }
-    const result = await channel.confirmPairingCode(String(entered));
-    if (result.ok) {
-      log.success(`Paired ✓ - chat ${result.chatId} is authorized.`);
-      confirmed = true;
-      break;
-    }
-    if (result.reason === 'expired' || result.reason === 'no-window') {
-      log.error(result.message);
-      await stopBot();
-      return 1;
-    }
-    log.warn(result.message);
-  }
-  if (!confirmed) {
-    log.error('Too many wrong attempts. Run the pair flow again.');
+  const url = channel.requestUrl;
+  if (!url) {
+    log.error('Could not resolve the bot link — check the token is valid and the network is reachable.');
     await stopBot();
     return 1;
   }
 
-  log.info('Bot is running. Press Ctrl+C to stop.');
+  await printPairQr(url);
+  log.info('Scan the QR with your phone (or open the link and tap START) — your chat pairs automatically.');
 
-  // Hand off the running bot. SIGINT shuts it down cleanly and exits.
+  // Graceful Ctrl-C while waiting (or once running): stop the bot and exit.
+  let stopping = false;
   const shutdown = async (): Promise<void> => {
+    if (stopping) return;
+    stopping = true;
     await stopBot();
     await session.close('SIGINT').catch(() => undefined);
     process.exit(0);
   };
   const onSignal = (): void => void shutdown();
-  // `once`, not `on`: a second signal during shutdown is moot (we exit), and
-  // `once` + explicit removal below means a wizard that loops back into this
-  // flow doesn't accumulate handlers (MaxListeners warning / double-shutdown).
   process.once('SIGINT', onSignal);
   process.once('SIGTERM', onSignal);
 
+  const spin = spinner();
+  spin.start('Waiting for you to pair in Telegram...');
+  const chatId = await paired;
+  spin.stop(`Paired ✓ — chat ${chatId} is authorized.`);
+
+  log.info('Bot is running. Press Ctrl+C to stop.');
   try {
     // Only reached if the bot stops on its own (a signal path exits via
     // shutdown()); remove our handlers so they don't outlive this flow.
@@ -134,4 +106,16 @@ export async function runPairFlow(ctx: ChannelSubcommandContext): Promise<number
     process.removeListener('SIGINT', onSignal);
     process.removeListener('SIGTERM', onSignal);
   }
+}
+
+/** Render the pairing deep link as a scannable terminal QR + the plain link. */
+async function printPairQr(url: string): Promise<void> {
+  let qr = '';
+  try {
+    qr = await QRCode.toString(url, { type: 'terminal', small: true });
+  } catch {
+    qr = '';
+  }
+  // CLI surface — intentional stdout.
+  console.log(['', qr, `  link: ${url}`, ''].join('\n'));
 }

--- a/packages/plugin-telegram/src/pairing.test.ts
+++ b/packages/plugin-telegram/src/pairing.test.ts
@@ -1,13 +1,13 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
-  beginPairing,
+  beginHostIssuedPairing,
   createPairingState,
   handleStart,
   isAuthorized,
-  submitTerminalCode,
+  submitChatCode,
 } from './pairing.js';
 
-describe('pairing protocol', () => {
+describe('pairing protocol (host-issued QR code)', () => {
   it('starts in idle phase', () => {
     const s = createPairingState();
     expect(s.phase).toBe('idle');
@@ -21,108 +21,93 @@ describe('pairing protocol', () => {
     expect(isAuthorized(s, 99)).toBe(false);
   });
 
-  it('beginPairing transitions to awaiting-start without issuing a code yet', () => {
-    const state = beginPairing(createPairingState());
-    expect(state.phase).toBe('awaiting-start');
-    expect(state.code).toBeNull();
-    expect(state.expiresAt).toBeGreaterThan(Date.now() - 1);
+  it('beginHostIssuedPairing mints a 6-digit code up front and opens the window', () => {
+    const { state, code } = beginHostIssuedPairing(createPairingState());
+    expect(state.phase).toBe('awaiting-host-code');
+    expect(code).toMatch(/^\d{6}$/);
+    expect(state.code).toBe(code);
+    // No TTL by default — the window lives as long as the channel runs unpaired.
+    expect(state.expiresAt).toBeNull();
   });
 
-  it('handleStart rejects when no pairing window is open', () => {
-    const s = createPairingState();
-    const r = handleStart(s, 1);
-    expect(r.action.kind).toBe('reject');
-    if (r.action.kind !== 'reject') return;
-    expect(r.action.message).toMatch(/No pairing window/);
-  });
-
-  it('handleStart in awaiting-start issues a fresh 6-digit code to the chat', () => {
-    const state = beginPairing(createPairingState());
-    const r = handleStart(state, 1);
-    expect(r.action.kind).toBe('issue-code');
-    if (r.action.kind !== 'issue-code') return;
-    expect(r.action.code).toMatch(/^\d{6}$/);
-    expect(r.action.chatId).toBe(1);
-    expect(r.state.phase).toBe('awaiting-terminal');
-    expect(r.state.pendingChatId).toBe(1);
-    expect(r.state.code).toBe(r.action.code);
-  });
-
-  it('handleStart re-issues the same code when the same chat re-sends /start', () => {
-    const state = beginPairing(createPairingState());
-    const first = handleStart(state, 1);
-    if (first.action.kind !== 'issue-code') throw new Error('expected issue-code');
-    const second = handleStart(first.state, 1);
-    expect(second.action.kind).toBe('issue-code');
-    if (second.action.kind !== 'issue-code') return;
-    expect(second.action.code).toBe(first.action.code);
-  });
-
-  it('handleStart tells a competing chat to wait when one is already pending', () => {
-    const state = beginPairing(createPairingState());
-    const after = handleStart(state, 1).state;
-    const r = handleStart(after, 2);
-    expect(r.action.kind).toBe('wait');
-  });
-
-  it('handleStart for an already-paired chat acknowledges', () => {
-    const s = createPairingState({ authorizedChatId: 7 });
-    const r = handleStart(s, 7);
-    expect(r.action.kind).toBe('still-paired');
-  });
-
-  it('handleStart for a different chat when one is paired rejects', () => {
-    const s = createPairingState({ authorizedChatId: 7 });
-    const r = handleStart(s, 999);
-    expect(r.action.kind).toBe('reject');
-  });
-
-  it('submitTerminalCode pairs on the correct code', () => {
-    const state = beginPairing(createPairingState());
-    const issued = handleStart(state, 1);
-    if (issued.action.kind !== 'issue-code') throw new Error('expected issue-code');
-    const r = submitTerminalCode(issued.state, issued.action.code);
+  it('submitChatCode pairs the presenting chat on the correct code', () => {
+    const { state, code } = beginHostIssuedPairing(createPairingState());
+    const r = submitChatCode(state, 1, code);
     expect(r.action.kind).toBe('paired');
     expect(r.state.phase).toBe('paired');
     expect(r.state.authorizedChatId).toBe(1);
+    expect(isAuthorized(r.state, 1)).toBe(true);
   });
 
-  it('submitTerminalCode reports a mismatch on a wrong code', () => {
-    const state = beginPairing(createPairingState());
-    const issued = handleStart(state, 1);
-    const r = submitTerminalCode(issued.state, '000000');
+  it('submitChatCode accepts the code with surrounding whitespace', () => {
+    const { state, code } = beginHostIssuedPairing(createPairingState());
+    const r = submitChatCode(state, 7, `  ${code} `);
+    expect(r.action.kind).toBe('paired');
+    expect(r.state.authorizedChatId).toBe(7);
+  });
+
+  it('submitChatCode reports a mismatch on a wrong code', () => {
+    const { state, code } = beginHostIssuedPairing(createPairingState());
+    const wrong = code === '000000' ? '111111' : '000000';
+    const r = submitChatCode(state, 1, wrong);
     expect(r.action.kind).toBe('mismatch');
     if (r.action.kind !== 'mismatch') return;
     expect(r.action.message).toMatch(/didn't match/);
   });
 
-  it('submitTerminalCode rejects non-digit input as a mismatch', () => {
-    const state = beginPairing(createPairingState());
-    const issued = handleStart(state, 1);
-    const r = submitTerminalCode(issued.state, 'hello');
+  it('submitChatCode treats non-digit input as a mismatch', () => {
+    const { state } = beginHostIssuedPairing(createPairingState());
+    const r = submitChatCode(state, 1, 'hello!');
     expect(r.action.kind).toBe('mismatch');
-    if (r.action.kind !== 'mismatch') return;
-    expect(r.action.message).toMatch(/6-digit/);
   });
 
-  it('submitTerminalCode reports not-pending when no /start has landed', () => {
-    const state = beginPairing(createPairingState());
-    const r = submitTerminalCode(state, '123456');
+  it('submitChatCode reports not-pending when no window is open', () => {
+    const r = submitChatCode(createPairingState(), 1, '123456');
     expect(r.action.kind).toBe('not-pending');
   });
 
-  it('expires after the TTL window', () => {
-    vi.useFakeTimers();
-    try {
-      const t0 = Date.now();
-      const state = beginPairing(createPairingState(), t0, 1000);
-      const issued = handleStart(state, 1, t0 + 500);
-      if (issued.action.kind !== 'issue-code') throw new Error('expected issue-code');
-      const r = submitTerminalCode(issued.state, issued.action.code, t0 + 2000);
-      expect(r.action.kind).toBe('expired');
-      expect(r.state.phase).toBe('expired');
-    } finally {
-      vi.useRealTimers();
-    }
+  it('submitChatCode acknowledges the already-paired chat (idempotent)', () => {
+    const r = submitChatCode(createPairingState({ authorizedChatId: 5 }), 5, '123456');
+    expect(r.action.kind).toBe('still-paired');
+  });
+
+  it('submitChatCode rejects a different chat once one is paired', () => {
+    const r = submitChatCode(createPairingState({ authorizedChatId: 5 }), 6, '123456');
+    expect(r.action.kind).toBe('reject');
+  });
+
+  it('expires after the (optional) TTL window', () => {
+    const t0 = 1_000_000;
+    const { state, code } = beginHostIssuedPairing(createPairingState(), undefined, t0, 1000);
+    const r = submitChatCode(state, 1, code, t0 + 2000);
+    expect(r.action.kind).toBe('expired');
+    expect(r.state.phase).toBe('expired');
+  });
+});
+
+describe('handleStart (bare /start, no code payload)', () => {
+  it('rejects with a "start pairing" nudge when no window is open', () => {
+    const r = handleStart(createPairingState(), 1);
+    expect(r.action.kind).toBe('reject');
+    if (r.action.kind !== 'reject') return;
+    expect(r.action.message).toMatch(/No pairing window/);
+  });
+
+  it('nudges to use the QR / send the code while a host window is open', () => {
+    const { state } = beginHostIssuedPairing(createPairingState());
+    const r = handleStart(state, 1);
+    expect(r.action.kind).toBe('reject');
+    if (r.action.kind !== 'reject') return;
+    expect(r.action.message).toMatch(/QR|code/i);
+  });
+
+  it('acknowledges the already-paired chat', () => {
+    const r = handleStart(createPairingState({ authorizedChatId: 7 }), 7);
+    expect(r.action.kind).toBe('still-paired');
+  });
+
+  it('rejects a different chat when one is paired', () => {
+    const r = handleStart(createPairingState({ authorizedChatId: 7 }), 999);
+    expect(r.action.kind).toBe('reject');
   });
 });

--- a/packages/plugin-telegram/src/pairing.ts
+++ b/packages/plugin-telegram/src/pairing.ts
@@ -1,26 +1,29 @@
 import { randomCode } from '@moxxy/plugin-vault';
 
 /**
- * Pairing state machine — bot-issued code direction.
+ * Pairing state machine — one mechanism, host-issued QR code.
  *
- * Flow:
- *   1. Terminal opens a pairing window (`beginPairing`).
- *   2. User sends /start to the bot in Telegram (`handleStart`).
- *      The bot generates a 6-digit code and DMs it back to that chat.
- *   3. User reads the code in Telegram and pastes it into the moxxy
- *      terminal (`submitTerminalCode`). On match the chat is authorized.
+ * A control surface (the desktop "Channels" panel, or `moxxy channels telegram
+ * pair` in a terminal) opens a window with `beginHostIssuedPairing`: the 6-digit
+ * code is generated UP FRONT so the surface can embed it in a
+ * `t.me/<bot>?start=<code>` deep link and render that as a QR. The user scans /
+ * opens the link and taps START — the bot receives `/start <code>` — or simply
+ * sends the 6 digits as a message. `submitChatCode` matches the presented code
+ * and authorizes that chat.
  *
- * Why this direction (vs. the older "terminal shows code, user types it
- * in Telegram"): copying digits *out* of an auth-trusted device is the
- * natural pattern (Authy / Signal device-link / GitHub mobile all work
- * this way), and the terminal can validate the code synchronously
- * inside the wizard instead of waiting for a chat round-trip.
+ * Why this single direction (it replaced an older bot-issues-a-code /
+ * paste-in-the-terminal flow): it works identically whether the surface is a GUI
+ * with no terminal (the desktop) or a terminal (the `pair` command renders the
+ * QR inline) — one affordance everywhere, zero manual code entry — while keeping
+ * the "prove you can see the host's screen" security property (the code only
+ * ever lived on the surface).
  */
 
 export type PairingPhase =
   | 'idle'
-  | 'awaiting-start'
-  | 'awaiting-terminal'
+  // Host generated a code and is waiting for a chat to present it (via a
+  // `?start=<code>` deep link or a plain message). See `beginHostIssuedPairing`.
+  | 'awaiting-host-code'
   | 'paired'
   | 'expired';
 
@@ -36,16 +39,12 @@ export interface PairingDecision {
   readonly state: PairingState;
   readonly action:
     | { kind: 'reject'; message: string }
-    | { kind: 'issue-code'; message: string; code: string; chatId: number }
     | { kind: 'paired'; chatId: number }
     | { kind: 'still-paired'; chatId: number }
     | { kind: 'mismatch'; message: string }
     | { kind: 'expired'; message: string }
-    | { kind: 'not-pending'; message: string }
-    | { kind: 'wait'; message: string };
+    | { kind: 'not-pending'; message: string };
 }
-
-const DEFAULT_TTL_MS = 5 * 60 * 1000;
 
 export function createPairingState(opts: { authorizedChatId?: number | null } = {}): PairingState {
   return {
@@ -58,40 +57,44 @@ export function createPairingState(opts: { authorizedChatId?: number | null } = 
 }
 
 /**
- * Open a pairing window from the terminal side. The state flips to
- * `awaiting-start`; no code is generated yet — the code is created when
- * /start arrives so it can be DM'd to the chat that initiated it.
+ * Open a host-issued pairing window. The code is generated immediately so the
+ * surface can embed it in the deep link / QR it shows the user.
+ *
+ * No TTL by default: the window's lifetime is the channel process's lifetime
+ * while unpaired (the surface tears it down by stopping the channel), and the
+ * security boundary is "could see the host's screen", not a clock. A caller may
+ * still pass a `ttlMs` to bound it.
  */
-export function beginPairing(
+export function beginHostIssuedPairing(
   state: PairingState,
+  code: string = randomCode(6),
   now: number = Date.now(),
-  ttlMs: number = DEFAULT_TTL_MS,
-): PairingState {
+  ttlMs: number | null = null,
+): { state: PairingState; code: string } {
   return {
-    ...state,
-    phase: 'awaiting-start',
-    code: null,
-    pendingChatId: null,
-    expiresAt: now + ttlMs,
+    state: {
+      ...state,
+      phase: 'awaiting-host-code',
+      code,
+      pendingChatId: null,
+      expiresAt: ttlMs == null ? null : now + ttlMs,
+    },
+    code,
   };
 }
 
 /**
- * Called when the bot receives a /start from `chatId`.
+ * Called when the bot receives a BARE `/start` (no code payload) — i.e. the user
+ * opened the chat manually rather than via the pairing deep link. The code path
+ * for a `/start <code>` payload (and plain-message codes) is `submitChatCode`.
  *
  * Behavior depends on phase:
  *   - paired (same chat)   → still-paired (already authorized; greet)
  *   - paired (other chat)  → reject (the bot is owned by someone else)
- *   - idle / expired       → reject with hint to run the wizard
- *   - awaiting-start       → generate code, transition to awaiting-terminal, return code to DM
- *   - awaiting-terminal    → re-issue the same code to the same chat;
- *                            tell a different chat to wait its turn
+ *   - awaiting-host-code   → reject with a nudge to use the QR / send the code
+ *   - idle / expired       → reject with a nudge to start pairing
  */
-export function handleStart(
-  state: PairingState,
-  chatId: number,
-  now: number = Date.now(),
-): PairingDecision {
+export function handleStart(state: PairingState, chatId: number): PairingDecision {
   if (state.authorizedChatId === chatId && state.phase === 'paired') {
     return { state, action: { kind: 'still-paired', chatId } };
   }
@@ -101,108 +104,60 @@ export function handleStart(
       action: { kind: 'reject', message: 'This bot is paired with a different chat. Access denied.' },
     };
   }
-  if (state.phase === 'idle' || state.phase === 'expired') {
+  if (state.phase === 'awaiting-host-code') {
     return {
       state,
       action: {
         kind: 'reject',
         message:
-          'No pairing window is open. Run `moxxy channels telegram pair` in your terminal first, then send /start again.',
+          'Scan the QR (or open the link) shown in moxxy, or send the 6-digit code it shows, to finish pairing.',
       },
     };
   }
-  if (state.expiresAt !== null && now > state.expiresAt) {
-    return {
-      state: { ...state, phase: 'expired', code: null, pendingChatId: null, expiresAt: null },
-      action: { kind: 'expired', message: 'Pairing window expired. Re-run `moxxy channels telegram pair`.' },
-    };
-  }
-  if (state.phase === 'awaiting-terminal') {
-    if (state.pendingChatId === chatId && state.code) {
-      return {
-        state,
-        action: {
-          kind: 'issue-code',
-          chatId,
-          code: state.code,
-          message: 'Your pairing code is still active:',
-        },
-      };
-    }
-    return {
-      state,
-      action: {
-        kind: 'wait',
-        message:
-          'Another chat started pairing first. Wait for that window to finish or expire, then try again.',
-      },
-    };
-  }
-  // awaiting-start → issue a new code for this chat. Preserve the
-  // original expiry set by `beginPairing` so the user can't extend the
-  // window by re-triggering /start.
-  const code = randomCode(6);
-  const nextState: PairingState = {
-    ...state,
-    phase: 'awaiting-terminal',
-    code,
-    pendingChatId: chatId,
-  };
   return {
-    state: nextState,
+    state,
     action: {
-      kind: 'issue-code',
-      chatId,
-      code,
+      kind: 'reject',
       message:
-        'Your pairing code is valid for 5 minutes. Paste it into the moxxy terminal to authorize this chat.',
+        'No pairing window is open. Start pairing from the moxxy desktop Channels panel, or run `moxxy channels telegram pair`.',
     },
   };
 }
 
 /**
- * Called when the user pastes a code in the moxxy terminal.
+ * Called when a chat PRESENTS a host-issued code — either as the payload of a
+ * `/start <code>` deep link or as a plain 6-digit message. On match the chat is
+ * authorized.
  */
-export function submitTerminalCode(
+export function submitChatCode(
   state: PairingState,
-  rawInput: string,
+  chatId: number,
+  rawCode: string,
   now: number = Date.now(),
 ): PairingDecision {
-  if (state.phase === 'paired' && state.authorizedChatId !== null) {
-    return { state, action: { kind: 'still-paired', chatId: state.authorizedChatId } };
+  if (state.phase === 'paired' && state.authorizedChatId === chatId) {
+    return { state, action: { kind: 'still-paired', chatId } };
   }
-  if (state.phase === 'idle') {
+  if (state.authorizedChatId !== null && state.authorizedChatId !== chatId) {
     return {
       state,
-      action: { kind: 'not-pending', message: 'No pairing in progress.' },
+      action: { kind: 'reject', message: 'This bot is paired with a different chat. Access denied.' },
     };
   }
-  if (state.phase === 'awaiting-start') {
-    return {
-      state,
-      action: {
-        kind: 'not-pending',
-        message: 'No /start received yet — open Telegram and send /start to your bot first.',
-      },
-    };
+  if (state.phase !== 'awaiting-host-code') {
+    return { state, action: { kind: 'not-pending', message: 'No pairing window is open.' } };
   }
-  if (state.phase === 'expired' || (state.expiresAt !== null && now > state.expiresAt)) {
+  if (state.expiresAt !== null && now > state.expiresAt) {
     return {
       state: { ...state, phase: 'expired', code: null, pendingChatId: null, expiresAt: null },
-      action: { kind: 'expired', message: 'Pairing window expired. Re-run `moxxy channels telegram pair`.' },
+      action: { kind: 'expired', message: 'Pairing window expired. Start the channel again to retry.' },
     };
   }
-  const normalized = rawInput.replace(/\s+/g, '');
-  if (!/^\d{6}$/.test(normalized)) {
+  const normalized = rawCode.replace(/\s+/g, '');
+  if (!/^\d{6}$/.test(normalized) || normalized !== state.code) {
     return {
       state,
-      action: { kind: 'mismatch', message: 'Enter the 6-digit code (digits only).' },
-    };
-  }
-  if (normalized !== state.code || state.pendingChatId === null) {
-    return {
-      state,
-      action: { kind: 'mismatch', message: "Code didn't match. Check the digits and try again." },
+      action: { kind: 'mismatch', message: "Code didn't match. Check the digits shown in moxxy and try again." },
     };
   }
   return {
@@ -211,9 +166,9 @@ export function submitTerminalCode(
       code: null,
       pendingChatId: null,
       expiresAt: null,
-      authorizedChatId: state.pendingChatId,
+      authorizedChatId: chatId,
     },
-    action: { kind: 'paired', chatId: state.pendingChatId },
+    action: { kind: 'paired', chatId },
   };
 }
 

--- a/packages/plugin-telegram/src/setup-wizard.ts
+++ b/packages/plugin-telegram/src/setup-wizard.ts
@@ -46,9 +46,10 @@ type Action = 'set-token' | 'pair' | 'unpair' | 'start' | 'quit';
  *   - token, not paired   -> "Pair this terminal" + "Change token" + "Quit"
  *   - token + paired      -> "Start bot" + "Unpair" + "Change token" + "Quit"
  *
- * Pairing is driven by the wizard end-to-end: the wizard opens a pair
- * window, the bot waits for /start, on /start it DMs a 6-digit code to
- * the user, and the user pastes the code back into this wizard.
+ * Pairing is driven by the wizard end-to-end via the host-issued QR flow: the
+ * wizard opens a pair window, prints a `t.me/<bot>?start=<code>` QR, and the user
+ * scans it (or opens the link) and taps START to pair — the same mechanism the
+ * desktop Channels panel uses.
  */
 export async function runTelegramWizard(ctx: ChannelSubcommandContext): Promise<number> {
   const vault = ctx.deps.vault as VaultStore;
@@ -135,7 +136,7 @@ async function pickAction(state: State): Promise<Action | null> {
     options.push({
       value: 'pair',
       label: 'Pair a Telegram chat',
-      hint: 'bot sends you a code in chat; paste it here',
+      hint: 'scan a QR (or open the link) and tap START in Telegram',
     });
   }
   options.push({

--- a/packages/sdk/src/channel-status.ts
+++ b/packages/sdk/src/channel-status.ts
@@ -22,8 +22,14 @@ export interface ChannelRunStatus {
   /** The session source the runner stamped (e.g. `slack`). */
   readonly source?: string;
   /** Public ingest URL (e.g. Slack's Events Request URL) once the tunnel is up;
-   *  null for channels with no inbound endpoint (Telegram long-polls). */
+   *  null for channels with no inbound endpoint (Telegram long-polls). While a
+   *  Telegram host-pairing window is open this carries the `?start=<code>`
+   *  deep-link the panel renders as a QR. */
   readonly requestUrl?: string | null;
+  /** The "connect the other side" step is satisfied (e.g. a Telegram chat
+   *  paired) — a supervisor swaps the connect QR/URL for a "✓ Connected" note.
+   *  Absent for channels with no discrete connected state (Slack). */
+  readonly connected?: boolean;
 }
 
 /** `~/.moxxy/channel-<name>.status.json` (honors `$MOXXY_HOME`). */

--- a/packages/sdk/src/channel.ts
+++ b/packages/sdk/src/channel.ts
@@ -37,6 +37,17 @@ export interface Channel<TStartOpts = unknown> {
    * the dedicated-runner host and written to the channel's status file.
    */
   readonly requestUrl?: string | null;
+
+  /**
+   * Whether the channel's "connect the other side" step is satisfied — e.g.
+   * Telegram has paired a chat. A control surface shows a "✓ Connected"
+   * affordance instead of the connect QR/URL once this is true. `undefined` for
+   * channels with no discrete connected state (e.g. Slack, whose Request URL
+   * stays relevant for the channel's lifetime). Written to the status file and
+   * mirrored by the dedicated-runner host. Pair with {@link ChannelHandle.onConnectChange}
+   * to learn when it flips after start.
+   */
+  readonly connected?: boolean;
 }
 
 export interface ChannelHandle {
@@ -48,6 +59,16 @@ export interface ChannelHandle {
 
   /** Request graceful shutdown. Implementations should abort any in-flight work. */
   stop(reason?: string): Promise<void>;
+
+  /**
+   * Subscribe to post-start changes in the channel's connect-state
+   * ({@link Channel.requestUrl} / {@link Channel.connected}) — e.g. a chat
+   * pairing. The dedicated-runner host uses this to re-publish the channel's
+   * status file so a watching panel updates live (swap the QR for "Connected")
+   * without polling the channel object. Optional: channels whose connect-state
+   * is fixed at start (Slack) omit it. Returns an unsubscribe function.
+   */
+  onConnectChange?(listener: () => void): () => void;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2272,6 +2272,9 @@ importers:
       grammy:
         specifier: ^1.30.0
         version: 1.42.0(encoding@0.1.13)
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
     devDependencies:
       '@moxxy/tsconfig':
         specifier: workspace:*
@@ -2282,6 +2285,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.18
+      '@types/qrcode':
+        specifier: ^1.5.5
+        version: 1.5.6
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
## Why

Starting Telegram from the desktop **Channels** panel errored with **"No Telegram chat is paired yet."** The connect-step feature (#384) shipped the QR *display*, but `TelegramChannel.start()` threw before ever resolving the bot link or publishing the QR — the only pairing path was the TTY-only `moxxy channels telegram pair` (bot DMs a code → paste it in the terminal), which the desktop can't drive. So a fresh desktop Telegram setup was a dead end.

## What

One pairing mechanism — **host-issued QR deep link** — used identically by the desktop **and** the terminal `pair` command. The old paste-a-code flow is removed.

- Unpaired Telegram opens a host-issued window: mints a one-time code, resolves the bot via `getMe`, and publishes `https://t.me/<bot>?start=<code>` as its connect value.
- Desktop renders that as the QR (existing connect-step UI); `moxxy channels telegram pair` renders the **same** deep link as a terminal QR.
- User scans → taps **START** in Telegram → the bot gets `/start <code>`, matches, pairs that chat. Zero typing. (A plain 6-digit message is a fallback for clients that don't auto-deliver the payload.)
- On pairing, the channel fires `onConnectChange` → the runner re-publishes its status file with `connected: true` → the panel swaps the QR for **"✓ Connected"** live.

## SDK surface (minor)

- `Channel.connected` + `ChannelHandle.onConnectChange`
- `connected` field on the channel status file (`ChannelRunStatus`)

The pairing state machine collapsed from two directions to one (`pairing.ts`); `pair-flow.ts` and the setup wizard now drive the QR flow.

## Test

- `pnpm build`: 74/74 packages.
- Tests green: plugin-telegram 122, sdk 301, cli 275, desktop-host 488, desktop-ipc-contract 47, desktop 423. Pairing tests rewritten for the new mechanism; no dangling refs to the removed API.
- Not exercised in CI: the live GUI + a real bot-token scan→pair round-trip — worth a manual confirm.

Follow-up to #384.
