### PR TITLE
fix(channels): unstick the Telegram connect step (QR never showing)

### DIFF
--- a/.changeset/telegram-connect-step-stuck.md
+++ b/.changeset/telegram-connect-step-stuck.md
@@ -1,0 +1,10 @@
+---
+'@moxxy/cli': patch
+'@moxxy/desktop': patch
+---
+
+Fix: the Telegram connect step in the desktop Channels panel could stay stuck on "Connecting…" and never show the QR. The dedicated channel runner could be wedged before it published its status file in three independent ways, now all closed:
+
+- A desktop-spawned channel runner now opts out of the co-attached web surface (`MOXXY_NO_WEB_SURFACE`, mirroring `moxxy serve`). Without it a remote channel (Telegram) opened a proxy tunnel during startup — _before_ the status write — so a slow/unreachable relay blocked it indefinitely; it also raced the fixed web port (4040) with `serve` and other channel runners.
+- The dedicated runner writes its status file _before_ the optional web-surface co-attach, so its readiness/connect value is published independently of that tunnel.
+- The up-front `getMe` (which resolves the `t.me` link) is now bounded by a timeout, so a slow/unreachable Telegram can't wedge `start()` — the channel comes up (and pairing still works) even when the link can't be resolved.

--- a/packages/cli/src/commands/start-registered-channel.ts
+++ b/packages/cli/src/commands/start-registered-channel.ts
@@ -236,19 +236,20 @@ async function runSelfHostedChannel(
     ...collectExtraFlags(argv),
   });
 
-  // Co-attach the web surface to the SAME session (on by default) so
-  // present_view renders and the agent can hand the user a URL even when the
-  // primary channel is e.g. telegram. The primary's permission resolver governs.
-  const webHandle = name === 'web' ? null : await coAttachWebSurface({ primary: name, session, vault, config });
-
   // Publish a status file ONLY for a dedicated channel runner, so an
   // out-of-process supervisor (the desktop "Channels" panel) can observe
-  // readiness + the public ingest URL (Slack's Request URL) without the runner
-  // protocol. `channel.requestUrl` is set by the time `start()` resolved (Slack
-  // opens its tunnel during start); null for channels with no inbound endpoint.
+  // readiness + the channel's connect value (Slack's Request URL, Telegram's
+  // resolved `t.me/<bot>` link) without the runner protocol. `channel.requestUrl`
+  // is set by the time `start()` resolved (Slack opens its tunnel during start,
+  // Telegram resolves its bot link via getMe); null for channels with none.
   // We are the SOLE writer of this file: the initial write captures pid/startedAt,
   // and `onConnectChange` re-publishes the same record (stable startedAt) when the
   // channel's connect-state flips — e.g. a Telegram chat pairs (connected:true).
+  //
+  // Write this BEFORE co-attaching the web surface: the status reflects the
+  // channel's OWN readiness, which must not be held hostage to the (optional)
+  // co-attached web surface — opening its proxy tunnel can be slow or hang, and
+  // that must never delay the supervisor seeing the connect step.
   if (dedicated) {
     const startedAt = new Date().toISOString();
     const publishStatus = (): void => {
@@ -264,6 +265,13 @@ async function runSelfHostedChannel(
     publishStatus();
     handle.onConnectChange?.(publishStatus);
   }
+
+  // Co-attach the web surface to the SAME session (on by default) so
+  // present_view renders and the agent can hand the user a URL even when the
+  // primary channel is e.g. telegram. The primary's permission resolver governs.
+  // The desktop opts out (MOXXY_NO_WEB_SURFACE) — it owns the UI and a channel
+  // runner must not race the fixed web port / open a tunnel of its own.
+  const webHandle = name === 'web' ? null : await coAttachWebSurface({ primary: name, session, vault, config });
 
   // Re-entrancy guard (mirrors runAttachedChannel): a second Ctrl-C, or
   // SIGINT+SIGTERM arriving close together, must not run teardown twice —

--- a/packages/desktop-host/src/channel-supervisor.test.ts
+++ b/packages/desktop-host/src/channel-supervisor.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+
+// Drive `startChannel` against a fake CLI: `resolveMoxxyCli` returns a stub and
+// `spawnCli` is a spy whose env we assert. `event-bus` is stubbed so broadcasts
+// are no-ops. (The module is Electron-free by construction — see its header.)
+const spawnCliMock = vi.fn();
+vi.mock('./cli-resolver', () => ({
+  augmentedPaths: () => [],
+  resolveMoxxyCli: () => ({ kind: 'direct', bin: '/fake/moxxy' }),
+  spawnCli: (...args: unknown[]) => spawnCliMock(...args),
+}));
+vi.mock('./event-bus', () => ({ broadcastHostEvent: vi.fn() }));
+
+import { startChannel } from './channel-supervisor';
+
+/** Minimal ChildProcess stand-in: enough surface for the supervisor's wiring. */
+function fakeChild(): ChildProcess {
+  const ee = new EventEmitter() as unknown as ChildProcess;
+  Object.assign(ee, { pid: 4242, stderr: new EventEmitter(), kill: vi.fn() });
+  return ee;
+}
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  // Isolate ~/.moxxy so finalize's clearChannelStatus can't touch the real home.
+  process.env.MOXXY_HOME = mkdtempSync(path.join(os.tmpdir(), 'chan-sup-'));
+  spawnCliMock.mockReturnValue(fakeChild());
+});
+
+afterEach(() => {
+  // Drive `exit` so the supervisor finalizes the entry (drops it from its
+  // singleton map + stops the URL poll), leaving no state for the next test.
+  const child = spawnCliMock.mock.results[0]?.value as ChildProcess | undefined;
+  child?.emit('exit', 0, null);
+  process.env = { ...originalEnv };
+  vi.clearAllMocks();
+});
+
+describe('channel-supervisor startChannel', () => {
+  it('opts the dedicated channel runner out of the co-attached web surface', () => {
+    startChannel('telegram');
+
+    expect(spawnCliMock).toHaveBeenCalledTimes(1);
+    const [, args, opts] = spawnCliMock.mock.calls[0] as [
+      unknown,
+      string[],
+      { env: Record<string, string> },
+    ];
+    expect(args).toEqual(['telegram']);
+    // The runner must opt out of the web surface (else a remote channel opens a
+    // proxy tunnel before writing its status file → the connect step hangs) and
+    // out of Tier-2 core updates, mirroring `moxxy serve`.
+    expect(opts.env).toMatchObject({
+      MOXXY_DEDICATED_RUNNER: '1',
+      MOXXY_NO_WEB_SURFACE: '1',
+      MOXXY_NO_CORE_UPDATE: '1',
+    });
+  });
+});

--- a/packages/desktop-host/src/channel-supervisor.ts
+++ b/packages/desktop-host/src/channel-supervisor.ts
@@ -107,8 +107,21 @@ export function startChannel(id: string): void {
   // `MOXXY_DEDICATED_RUNNER=1` forces the isolated runner even if the channel
   // didn't declare it; declared channels (slack/telegram) get it either way. We
   // deliberately do NOT set MOXXY_SESSION_SOURCE — the channel stamps its own.
+  //
+  // The remaining two mirror `moxxy serve` (see runner-supervisor.spawnServe),
+  // for the same reasons — a desktop-spawned channel runner lives in the same
+  // read-only packaged app and must not behave like a standalone CLI:
+  //  - MOXXY_NO_WEB_SURFACE: a remote channel (Telegram) otherwise co-attaches a
+  //    web surface and opens a proxy tunnel during startup (start-registered-
+  //    channel), BEFORE it writes its status file. If that tunnel is slow or
+  //    unreachable the write never runs and the panel's connect step (QR /
+  //    Request URL) hangs on "Connecting…"; it also races the fixed web port
+  //    (4040) with serve and every other channel runner. The desktop owns the
+  //    UI, so opt out.
+  //  - MOXXY_NO_CORE_UPDATE: Tier-2 self_update_core_* can't patch a read-only
+  //    .app; hide those tools here as serve does.
   const child = spawnCli(cli, [id], {
-    env: { MOXXY_DEDICATED_RUNNER: '1' },
+    env: { MOXXY_DEDICATED_RUNNER: '1', MOXXY_NO_WEB_SURFACE: '1', MOXXY_NO_CORE_UPDATE: '1' },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 

--- a/packages/plugin-telegram/src/channel.ts
+++ b/packages/plugin-telegram/src/channel.ts
@@ -30,6 +30,11 @@ import { handleVoiceMessage } from './channel/voice-handler.js';
 
 const TOKEN_KEY = 'telegram_bot_token';
 
+/** Cap on the up-front `getMe` (bot identity → `t.me` connect link). It must
+ *  never gate channel startup: if Telegram is slow/unreachable, we proceed
+ *  without the link rather than wedge `start()` (and the readiness it unblocks). */
+const BOT_IDENTITY_TIMEOUT_MS = 8_000;
+
 export type { PairingConfirmResult } from './channel/pairing-handler.js';
 
 export interface TelegramStartOpts extends ChannelStartOptsBase {
@@ -246,12 +251,29 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
 
     // Resolve the bot's own identity up front (getMe) so a control surface can
     // show a `t.me/<botname>` connect step. grammy caches this on `bot.botInfo`,
-    // and `bot.start()` below reuses it instead of calling getMe again. Non-fatal:
-    // a transient getMe failure must not block the channel from starting — the
-    // poll loop surfaces a genuinely invalid token on its own.
+    // and `bot.start()` below reuses it instead of calling getMe again. Non-fatal
+    // AND non-blocking: a transient getMe failure must not block the channel from
+    // starting — and neither must a STALLED one. We bound it with a timeout so a
+    // slow/unreachable Telegram can't wedge `start()` (which gates bot polling,
+    // the web-surface co-attach, and the dedicated runner's status file). On
+    // timeout/error we proceed without the link; the poll loop surfaces a
+    // genuinely invalid token on its own. (We race a timer rather than pass
+    // grammy an AbortSignal — its `init(signal)` types the param against the
+    // `abort-controller` polyfill, not the global signal.)
     const bot = this.bot;
+    const init = bot.init();
+    init.catch(() => undefined); // a late rejection (post-timeout) isn't unhandled
     try {
-      await bot.init();
+      await Promise.race([
+        init,
+        new Promise<never>((_, reject) => {
+          const t = setTimeout(
+            () => reject(new Error(`getMe timed out after ${BOT_IDENTITY_TIMEOUT_MS}ms`)),
+            BOT_IDENTITY_TIMEOUT_MS,
+          );
+          t.unref?.();
+        }),
+      ]);
       const username = bot.botInfo.username;
       if (username) {
         // Embed the host-issued code as the `?start=` deep-link payload so a scan


### PR DESCRIPTION
## Problem

In the desktop **Apps → Channels** panel, a running Telegram channel sat on **"Connecting — the link will appear here once the bot is reachable…"** and never showed the QR.

The QR is rendered from `requestUrl` in the dedicated runner's status file (`~/.moxxy/channel-telegram.status.json`). On a wedged machine the runner had **bound its socket but never written that file** — i.e. something between the socket bind and the status write hung. There were **three independent ways** to get stuck there, all live:

1. **The channel supervisor spawned the runner without `MOXXY_NO_WEB_SURFACE`.** A remote channel (Telegram) then co-attaches a web surface and opens the **proxy relay tunnel** *during startup, before the status write*. A slow/unreachable relay blocks it indefinitely — and it races the fixed web port (4040) with `serve` and other channel runners. `moxxy serve` (`runner-supervisor.spawnServe`) already opts out of the web surface for exactly these reasons; the channel supervisor didn't.
2. **The status file was written *after* the optional web-surface co-attach** — so anything slow in that step delays the connect value.
3. **The up-front `getMe`** (which resolves the `t.me/<bot>` link) **had no timeout** — a stalled call wedges `start()`, which gates bot polling, the co-attach, *and* the status write.

## Fix

- `channel-supervisor.ts` — spawn channel runners with `MOXXY_NO_WEB_SURFACE=1` (and `MOXXY_NO_CORE_UPDATE=1`), mirroring `moxxy serve`. The desktop owns the UI; a channel runner shouldn't co-attach a web surface or race the web port. + a regression test.
- `start-registered-channel.ts` — write the dedicated runner's status file **before** the web-surface co-attach, so the connect value is published independently of that tunnel.
- `plugin-telegram/channel.ts` — bound `getMe` with an 8s timeout (via `Promise.race`, since grammy types its `init(signal)` against the `abort-controller` polyfill). On timeout the channel still comes up and pairing still works — just without the link.

## Trade-off

Desktop-spawned channel runners no longer co-attach a web surface, so `present_view`-to-URL isn't available for them. This matches `moxxy serve` and was already unreliable (only the first runner to win port 4040 got one) — opting out makes it consistent.

## Verify

Build 74/74 · typecheck green · lint 0 errors · affected tests pass (`channel-supervisor`, `plugin-telegram`, `start-registered-channel`).