### PR TITLE
fix(providers): correct Codex gpt-5.5/gpt-5.4 context window to 400k

### DIFF
--- a/.changeset/codex-context-window-400k.md
+++ b/.changeset/codex-context-window-400k.md
@@ -1,0 +1,7 @@
+---
+'@moxxy/plugin-provider-openai-codex': patch
+'@moxxy/cli': patch
+'@moxxy/desktop': patch
+---
+
+Fix Codex `gpt-5.5` / `gpt-5.4` advertising a 1,000,000-token context window when the ChatGPT-plan Codex backend only serves ~400k for these gpt-5-family models. The inflated window pushed the proactive compactor's `estimatedTokens > 0.75 * contextWindow` gate out to ~750k — unreachable before the backend rejected the request — so long sessions always fell through to the reactive compact-on-overflow retry ("context window exceeded — compacted older turns, retrying") instead of compacting cleanly ahead of the limit. Set both to `400_000`, matching the rest of the Codex catalog, so the proactive compactor trips before overflow.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -150,6 +150,17 @@ or recorded-on-purpose decision.
   Anthropic round-trips fully. `packages/plugin-provider-*/`.
 - [low] Hardcoded catalogs span 5+ providers and drift — a shared
   OpenAI-compatible-vendor catalog or `/v1/models`-backed refresh would self-update.
+- [med] Advertised `contextWindow` values are trusted blindly by the proactive
+  compactor (`estimatedTokens > 0.75 * contextWindow`, `compactor-summarize`). When
+  a catalog overshoots the backend-enforced window, the proactive gate becomes
+  unreachable and every long session degrades to the reactive compact-on-overflow
+  retry (`turn-iterator.ts` `isContextOverflowError`). Fixed one instance (Codex
+  gpt-5.5/gpt-5.4 1M→400k) but the failure mode is latent for any future catalog
+  drift; consider calibrating the effective window from real provider `usage` /
+  observed overflow rather than the static descriptor. Related: `resolveModelContext`
+  (`packages/sdk/src/compactor-helpers.ts`) silently falls back to `models[0]` on an
+  exact-id miss, so an unlisted/variant model id (e.g. a `[1m]` suffix) resolves the
+  wrong window with no signal.
 
 ## Channels, relay & HTTP
 

--- a/packages/plugin-provider-openai-codex/src/models.ts
+++ b/packages/plugin-provider-openai-codex/src/models.ts
@@ -10,8 +10,13 @@ import type { ModelDescriptor } from '@moxxy/sdk';
 // `supportsReasoning` — the request already sends `reasoning.summary: 'auto'`;
 // the per-provider toggle decides whether the summary is surfaced.
 export const codexModels: ReadonlyArray<ModelDescriptor> = [
-  { id: 'gpt-5.5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
-  { id: 'gpt-5.4', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  // The ChatGPT-plan Codex backend enforces a ~400k window for the gpt-5-family
+  // models it serves, well below the raw API ceiling. Advertising 1M here made
+  // the proactive compactor's `estimatedTokens > 0.75 * contextWindow` gate
+  // unreachable, so every overflow fell through to the reactive
+  // compact-on-overflow retry. Keep these in step with the rest of the catalog.
+  { id: 'gpt-5.5', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5.4', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
   { id: 'gpt-5.4-mini', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
   { id: 'gpt-5.3-codex', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
   { id: 'gpt-5.3-codex-spark', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },


### PR DESCRIPTION
## What

Set the advertised `contextWindow` for the Codex-served `gpt-5.5` and `gpt-5.4` models from `1_000_000` to `400_000`, matching the rest of the Codex catalog (`gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.2` are already 400k). One-line-per-model data change in `packages/plugin-provider-openai-codex/src/models.ts`.

## Why

The ChatGPT-plan Codex backend enforces a ~400k window for these gpt-5-family models — well below the raw-API ceiling. Advertising 1M broke context management:

- The proactive compactor triggers at `estimatedTokens > 0.75 * contextWindow` (`compactor-summarize`). With `contextWindow = 1M` the gate sat at ~750k — **unreachable**, because the backend rejects the request long before that.
- So every long session fell through to the *reactive* compact-on-overflow path (`turn-iterator.ts`, `isContextOverflowError`), surfacing the jarring **"Context compacted — freed ~N tokens"** + **"context window exceeded — compacted older turns, retrying"** pair mid-turn instead of compacting cleanly ahead of the limit.

With an accurate 400k window the proactive compactor trips at ~300k, before the backend can reject — the reactive fallback stays a genuine fallback.

The threshold ratio was deliberately left at 0.75 (accurate window + headroom beats a higher ratio, since the token estimate lags the provider's real tokenizer and reasoning tokens can undercount).

Also logged the broader latent issue in `TECH_DEBT.md` (Providers & model catalogs): advertised windows are trusted blindly, and `resolveModelContext` silently falls back to `models[0]` on an exact-id miss — so any future catalog drift or unlisted variant id re-triggers this class of bug.

## Verification

- `pnpm build` — 74/74 green
- `pnpm typecheck` — 141/141 green
- `pnpm --filter @moxxy/plugin-provider-openai-codex test` — 61/61 green
- `pnpm check:deps` — 0 errors (1 pre-existing unrelated orphan warning)
- `eslint` on the changed package — clean
- Changeset added (`@moxxy/plugin-provider-openai-codex` + `@moxxy/cli` + `@moxxy/desktop` patch, so the fix ships through both the published CLI and the bundled desktop app)