### PR TITLE
feat(collab): run collaboration on its own dedicated runner, separate from chats

### DIFF
--- a/.changeset/collab-separate-feature.md
+++ b/.changeset/collab-separate-feature.md
@@ -1,0 +1,19 @@
+---
+'@moxxy/mode-collaborative': minor
+'@moxxy/desktop-ipc-contract': minor
+'@moxxy/desktop-host': minor
+'@moxxy/desktop': minor
+'@moxxy/plugin-cli': minor
+'@moxxy/cli': minor
+---
+
+Make collaboration a fully separate feature that never touches your chats or their sessions.
+
+Previously `/collab` (and the desktop Collaborate tab) ran the coordinator **inside the active chat session** — it flipped that session's mode to `collaborative` and streamed the whole team's activity into the chat's own event log, so a collaboration polluted the chat thread and its transcript.
+
+Now the coordinator runs on its **own dedicated runner** — a new internal `moxxy collab` command that boots its own headless Session + runner socket, hosts the collab hub, and spawns the architect/implementer team exactly as before.
+
+- **Desktop:** the Collaborate panel supervises that coordinator (`CollabSupervisor`) and drives it over a dedicated `collab.*` IPC surface + `collab.event` / `collab.approval` broadcasts (a private `useCollab` hook, not `useChat`). The roster-approval checkpoint is answered inline in the panel.
+- **TUI:** `/collab <goal>` re-points the terminal onto the coordinator's own session (via the same in-place switch `/sessions` uses) and auto-submits the goal there — the roster approval and the live `◆ collab` block render as usual, but on the coordinator's session, not your chat. Bare `/collab` attaches to a running collaboration to view it; `/sessions` returns you to chat while the collaboration keeps running.
+
+Either way, a collaboration is entirely decoupled from every chat session — no mode-switch, no events in a chat's thread. The roster-approval checkpoint (the one human-in-the-loop gate) is preserved because the attaching UI drives the goal turn, so the coordinator's approval is forwarded to it. The single-flight lock now also records the coordinator's runner socket so a UI can discover and attach to a running coordinator (including one started elsewhere).

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -13,6 +13,19 @@ or recorded-on-purpose decision.
 
 ## Resolved ledger
 
+- [high, collab, RESOLVED 2026-07-01] Collaboration is now a SEPARATE feature on
+  BOTH surfaces: the coordinator runs on its own dedicated `moxxy collab` runner
+  (own Session + socket), never inside a chat session — no mode-flip, no team
+  activity in a chat's thread. Desktop: the Collaborate panel supervises it
+  (`CollabSupervisor`) over dedicated `collab.*` IPC + `collab.event`/`collab.approval`
+  (a private `useCollab` hook, not `useChat`). TUI: `/collab` re-points the terminal
+  onto the coordinator's own session via the in-place session switch (auto-submits
+  the goal via `initialPrompt`; bare `/collab` attaches-to-view), reusing the whole
+  SessionView (transcript, `CollabScopeView`, approval, step-in). `packages/cli/src/commands/{collab,run-tui}.ts`,
+  `packages/desktop-host/src/collab-supervisor.ts`,
+  `packages/plugin-cli/src/session/{run-slash,BootShell,SessionView,sessions-picker}.*`,
+  `packages/mode-collaborative/src/{constants,collab-store,collab-lock}.ts`,
+  `apps/desktop/src/collaborate/{useCollab.ts,CollaboratePanel.tsx}`.
 - [low, ux, RESOLVED 2026-06-25] `SkillGallery` now uses the shared
   `<SearchBox />` primitive and has regression tests for filtering by name and
   description. `apps/desktop/src/settings/skills/SkillGallery.tsx`.

--- a/apps/desktop/src/collaborate/CollaboratePanel.a11y.test.tsx
+++ b/apps/desktop/src/collaborate/CollaboratePanel.a11y.test.tsx
@@ -5,33 +5,35 @@
  * trigger on close. The pre-fix modal was a click-only div with none of this, so
  * a keyboard/AT user had no way to dismiss it and could Tab out into the
  * obscured page behind the scrim.
+ *
+ * The panel reads its collaboration from the dedicated coordinator via `useCollab`
+ * (not a chat session), so we mock that hook to render a running collaboration
+ * with a claimed board item — the task chip whose modal we exercise.
  */
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import { __setApiOverride, chatStore } from '@moxxy/client-core';
-import type { MoxxyEvent } from '@moxxy/sdk';
-import { CollaboratePanel } from './CollaboratePanel';
+import { __setApiOverride } from '@moxxy/client-core';
 
-let seq = 0;
-function ce(subtype: string, payload: unknown): MoxxyEvent {
-  seq += 1;
-  return {
-    type: 'plugin_event',
-    id: `e${seq}`,
-    ts: seq * 1000,
-    sessionId: 's',
-    turnId: 't',
-    source: 'plugin',
-    pluginId: '@moxxy/mode-collaborative',
-    subtype,
-    payload,
-  } as unknown as MoxxyEvent;
-}
-
-const WS = 'ws-collab';
-
-function seedCollab(): void {
-  for (const event of [
+// A running collaboration whose board has one claimed item ("api.ts") — folded
+// by pairToolEvents into the task chip the TaskModal opens from. Built via
+// vi.hoisted so the (hoisted) vi.mock factory below can reference it.
+const seeded = vi.hoisted(() => {
+  let seq = 0;
+  const ce = (subtype: string, payload: unknown): unknown => {
+    seq += 1;
+    return {
+      type: 'plugin_event',
+      id: `e${seq}`,
+      ts: seq * 1000,
+      sessionId: 's',
+      turnId: 't',
+      source: 'plugin',
+      pluginId: '@moxxy/mode-collaborative',
+      subtype,
+      payload,
+    };
+  };
+  return [
     ce('collab_started', { task: 'build the thing', parallel: true }),
     ce('collab_agent_spawned', { id: 'backend', role: 'implementer' }),
     ce('collab_board_update', {
@@ -39,10 +41,25 @@ function seedCollab(): void {
       action: 'claim',
       item: { id: 't1', title: 'api.ts', status: 'claimed', owner: 'backend', paths: ['src/api.ts'], detail: 'build the api' },
     }),
-  ]) {
-    chatStore.dispatch(WS, { type: 'event', event: event as never });
-  }
-}
+  ];
+});
+
+vi.mock('./useCollab', () => ({
+  useCollab: () => ({
+    events: seeded,
+    running: true,
+    task: 'build the thing',
+    approval: null,
+    start: async () => {},
+    end: async () => {},
+    command: async () => {},
+    respondApproval: () => {},
+  }),
+}));
+
+import { CollaboratePanel } from './CollaboratePanel';
+
+const WS = 'ws-collab';
 
 beforeEach(() => {
   __setApiOverride({
@@ -52,12 +69,10 @@ beforeEach(() => {
     }) as never,
     subscribe: (() => () => {}) as never,
   } as never);
-  chatStore.clear(WS);
 });
 
 afterEach(() => {
   __setApiOverride(null);
-  chatStore.clear(WS);
 });
 
 function openTaskModal(): HTMLElement {
@@ -69,7 +84,6 @@ function openTaskModal(): HTMLElement {
 
 describe('CollaboratePanel TaskModal accessibility', () => {
   it('opens a labelled dialog (role=dialog, aria-modal, aria-labelledby title)', () => {
-    seedCollab();
     render(<CollaboratePanel onView={() => {}} workspaceId={WS} />);
     openTaskModal();
 
@@ -82,7 +96,6 @@ describe('CollaboratePanel TaskModal accessibility', () => {
   });
 
   it('moves focus into the dialog on open (not left on the obscured trigger)', () => {
-    seedCollab();
     render(<CollaboratePanel onView={() => {}} workspaceId={WS} />);
     const trigger = openTaskModal();
     const dialog = screen.getByRole('dialog');
@@ -91,7 +104,6 @@ describe('CollaboratePanel TaskModal accessibility', () => {
   });
 
   it('closes on Escape and restores focus to the trigger', () => {
-    seedCollab();
     render(<CollaboratePanel onView={() => {}} workspaceId={WS} />);
     const trigger = openTaskModal();
 
@@ -102,7 +114,6 @@ describe('CollaboratePanel TaskModal accessibility', () => {
   });
 
   it('has an accessible close button', () => {
-    seedCollab();
     render(<CollaboratePanel onView={() => {}} workspaceId={WS} />);
     openTaskModal();
     const close = screen.getByRole('button', { name: /close/i });

--- a/apps/desktop/src/collaborate/CollaboratePanel.tsx
+++ b/apps/desktop/src/collaborate/CollaboratePanel.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
-import { api, useChat } from '@moxxy/client-core';
+import { api } from '@moxxy/client-core';
 import type { CollabRunSummary } from '@moxxy/desktop-ipc-contract';
+import type { ApprovalDecision } from '@moxxy/sdk';
 import { pairToolEvents } from '@moxxy/chat-model';
 import type { CollabMsgView, CollabTaskView } from '@moxxy/chat-model';
 import { Button, Icon } from '@moxxy/desktop-ui';
 import { ViewHeader, ViewSwitcher, type View } from '../shell/ViewHeader';
 import { useFocusTrap } from '../chat/useFocusTrap';
+import { useCollab, type CollabApproval } from './useCollab';
 import { dotColor, filterCollabMessages, latestCollab, taskChipBg } from './collab-view';
 
 function taskChip(status: string): React.CSSProperties {
@@ -35,8 +37,10 @@ export function CollaboratePanel({
   readonly disabledViews?: ReadonlyArray<View>;
   readonly disabledViewReason?: string;
 }): JSX.Element {
-  const chat = useChat(workspaceId);
-  const blocks = useMemo(() => pairToolEvents(chat.events), [chat.events]);
+  // The coordinator runs on its OWN dedicated runner (never this workspace's chat
+  // session); useCollab reads its live stream + roster-approval checkpoint.
+  const coord = useCollab(workspaceId);
+  const blocks = useMemo(() => pairToolEvents(coord.events), [coord.events]);
   const collab = useMemo(() => latestCollab(blocks), [blocks]);
 
   const [channel, setChannel] = useState<string>('all');
@@ -104,39 +108,39 @@ export function CollaboratePanel({
     };
   }, [workspaceId]);
 
+  // Step-in on the COORDINATOR session (not a chat session).
   const runCmd = async (name: string, args: string): Promise<void> => {
-    await api().invoke('session.runCommand', { workspaceId, name, args }).catch(() => undefined);
+    await coord.command(name, args);
   };
 
   const running = collab != null && collab.completedAtMs === null;
 
-  // Start a collaboration FROM THE TAB (not chat): switch this workspace's
-  // session to collaborative mode and submit the goal as its turn. The global
-  // single-flight lock (runner side) still guarantees only one runs at a time.
+  // Start a collaboration on the DEDICATED coordinator runner. No chat session is
+  // mode-switched or written to. The global single-flight lock (runner side)
+  // guarantees only one runs at a time.
   const startCollaboration = async (): Promise<void> => {
     const g = goal.trim();
     if (!g || starting) return;
     setStarting(true);
     setGoal('');
     try {
-      await api().invoke('session.setMode', { workspaceId, mode: 'collaborative' });
-      await api().invoke('session.runTurn', { workspaceId, prompt: g });
+      await coord.start(g, workspaceId);
       setForceStart(false);
     } catch {
-      // surfaced as an error/assistant message in the session log
+      // surfaced as an error/assistant message on the coordinator's own log
     } finally {
       setStarting(false);
     }
   };
 
-  // End the current collaboration for good: aborts the coordinator (its finally
+  // End the current collaboration for good: stops the coordinator (its finally
   // archives the run + cleans up) and force-releases the global lock, so a new
   // one can start — even if the current run is wedged or the lock is stale.
   const endCollaboration = async (): Promise<void> => {
     if (ending) return;
     setEnding(true);
     try {
-      await api().invoke('collab.end', { workspaceId });
+      await coord.end();
       const r = await api().invoke('collab.active').catch(() => null);
       setGlobalActive(r);
       setForceStart(true); // drop to the start composer for a fresh run
@@ -253,6 +257,11 @@ export function CollaboratePanel({
     return (
       <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
         {header}
+        {coord.approval && (
+          <div style={{ padding: '10px 16px', borderBottom: '1px solid var(--color-card-border)' }}>
+            <CollabApprovalCard approval={coord.approval} onRespond={coord.respondApproval} />
+          </div>
+        )}
         <div
           style={{
             flex: 1,
@@ -346,6 +355,11 @@ export function CollaboratePanel({
   return (
     <div style={{ position: 'relative', display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
       {header}
+      {coord.approval && (
+        <div style={{ padding: '10px 16px', borderBottom: '1px solid var(--color-card-border)' }}>
+          <CollabApprovalCard approval={coord.approval} onRespond={coord.respondApproval} />
+        </div>
+      )}
       <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
         {/* LEFT RAIL — agents · tasks · contracts */}
         <aside
@@ -491,6 +505,80 @@ export function CollaboratePanel({
           onClose={() => setSelectedTask(null)}
         />
       )}
+    </div>
+  );
+}
+
+/** The coordinator's roster-approval checkpoint — the single human gate in a
+ *  collaboration. Rendered inline in the Collaborate panel (never the chat ask
+ *  sheet) and answered via `collab.respondApproval`. */
+function CollabApprovalCard({
+  approval,
+  onRespond,
+}: {
+  readonly approval: CollabApproval;
+  readonly onRespond: (requestId: string, decision: ApprovalDecision) => void;
+}): JSX.Element {
+  const { request, requestId } = approval;
+  const [text, setText] = useState('');
+  const textOption = request.options.find((o) => o.requestsText);
+  return (
+    <div
+      role="group"
+      aria-label={request.title}
+      style={{
+        border: '1px solid var(--color-primary)',
+        borderRadius: 12,
+        padding: 14,
+        background: 'color-mix(in srgb, var(--color-primary) 8%, var(--color-surface))',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+      }}
+    >
+      <div style={{ fontWeight: 700, fontSize: 14, color: 'var(--color-text)' }}>{request.title}</div>
+      {request.body && (
+        <div style={{ fontSize: 12.5, whiteSpace: 'pre-wrap', color: 'var(--color-text-muted)', lineHeight: 1.5 }}>
+          {request.body}
+        </div>
+      )}
+      {textOption && (
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={textOption.textPrompt || 'Add a note…'}
+          rows={2}
+          style={{
+            resize: 'vertical',
+            padding: '8px 10px',
+            borderRadius: 8,
+            border: '1px solid var(--color-card-border)',
+            background: 'var(--color-input-soft)',
+            fontSize: 13,
+            color: 'var(--color-text)',
+            fontFamily: 'inherit',
+          }}
+        />
+      )}
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+        {request.options.map((opt) => (
+          <button
+            key={opt.id}
+            type="button"
+            className={opt.danger ? 'btn-chip' : 'btn-cta'}
+            onClick={() =>
+              onRespond(requestId, {
+                optionId: opt.id,
+                ...(opt.requestsText && text.trim() ? { text: text.trim() } : {}),
+              })
+            }
+            title={opt.description}
+            style={{ padding: '6px 14px', borderRadius: 9, fontWeight: 600, ...(opt.danger ? { color: 'var(--color-red)' } : {}) }}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/collaborate/useCollab.ts
+++ b/apps/desktop/src/collaborate/useCollab.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useState } from 'react';
+import { api } from '@moxxy/client-core';
+import type { ApprovalDecision, ApprovalRequest, MoxxyEvent } from '@moxxy/sdk';
+
+/**
+ * The Collaborate panel's data source — the DEDICATED collaboration coordinator,
+ * NOT a chat session. It reads the coordinator's live event stream (`collab.event`,
+ * seeded by `collab.snapshot`), its roster-approval checkpoint (`collab.approval`),
+ * and its liveness (`collab.status`), and drives it through the `collab.*` IPC.
+ *
+ * Deliberately does NOT use `useChat`/`chatStore` — those are per-workspace and
+ * would drag collab back into the chat machinery (persistence, desks, the chat
+ * ask sheet). Keeping a private event array here is what makes collaborate a
+ * self-contained feature that never touches a chat session's thread.
+ */
+export interface CollabApproval {
+  readonly requestId: string;
+  readonly request: ApprovalRequest;
+}
+
+export interface UseCollab {
+  /** The coordinator's event log (fold with `pairToolEvents` → `latestCollab`). */
+  readonly events: ReadonlyArray<MoxxyEvent>;
+  /** A coordinator is live (started here or elsewhere, e.g. the TUI). */
+  readonly running: boolean;
+  readonly task: string | null;
+  /** The pending roster-approval checkpoint, or null. */
+  readonly approval: CollabApproval | null;
+  start(goal: string, workspaceId?: string): Promise<void>;
+  end(): Promise<void>;
+  command(name: string, args: string): Promise<void>;
+  respondApproval(requestId: string, decision: ApprovalDecision): void;
+}
+
+export function useCollab(workspaceId?: string): UseCollab {
+  const [events, setEvents] = useState<ReadonlyArray<MoxxyEvent>>([]);
+  const [running, setRunning] = useState(false);
+  const [task, setTask] = useState<string | null>(null);
+  const [approval, setApproval] = useState<CollabApproval | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    // Seed from the coordinator's current log (this also opportunistically
+    // attaches to a coordinator started elsewhere so the desktop can view it).
+    void api()
+      .invoke('collab.snapshot')
+      .then((evs) => {
+        if (alive) setEvents(evs as MoxxyEvent[]);
+      })
+      .catch(() => undefined);
+
+    const offEvent = api().subscribe('collab.event', ({ event }) => {
+      setEvents((prev) => [...prev, event]);
+    });
+    const offApproval = api().subscribe('collab.approval', (p) => {
+      setApproval(p);
+    });
+    const offResolved = api().subscribe('collab.approval.resolved', ({ requestId }) => {
+      setApproval((cur) => (cur && cur.requestId === requestId ? null : cur));
+    });
+    const offStatus = api().subscribe('collab.status', ({ running: r, task: t }) => {
+      setRunning(r);
+      setTask(t ?? null);
+      if (!r) setApproval(null);
+    });
+    return () => {
+      alive = false;
+      offEvent();
+      offApproval();
+      offResolved();
+      offStatus();
+    };
+  }, []);
+
+  const start = useCallback(
+    async (goal: string, wid?: string) => {
+      // Fresh run: the coordinator is a brand-new process/session, so drop the
+      // previous run's events + any stale approval before its stream begins.
+      setEvents([]);
+      setApproval(null);
+      const wsid = wid ?? workspaceId;
+      await api().invoke('collab.start', wsid ? { goal, workspaceId: wsid } : { goal });
+    },
+    [workspaceId],
+  );
+
+  const end = useCallback(async () => {
+    await api().invoke('collab.end');
+  }, []);
+
+  const command = useCallback(async (name: string, args: string) => {
+    await api().invoke('collab.command', { name, args }).catch(() => undefined);
+  }, []);
+
+  const respondApproval = useCallback((requestId: string, decision: ApprovalDecision) => {
+    // Drop the card optimistically; the host also broadcasts collab.approval.resolved.
+    setApproval((cur) => (cur && cur.requestId === requestId ? null : cur));
+    void api().invoke('collab.respondApproval', { requestId, decision }).catch(() => undefined);
+  }, []);
+
+  return { events, running, task, approval, start, end, command, respondApproval };
+}

--- a/apps/desktop/src/collaborate/useCollab.ts
+++ b/apps/desktop/src/collaborate/useCollab.ts
@@ -44,8 +44,11 @@ export function useCollab(workspaceId?: string): UseCollab {
     // attaches to a coordinator started elsewhere so the desktop can view it).
     void api()
       .invoke('collab.snapshot')
+      // Never trust the payload into `pairToolEvents` (which iterates it): a
+      // malformed/empty IPC response must degrade to an empty stream, not crash
+      // the panel render.
       .then((evs) => {
-        if (alive) setEvents(evs as MoxxyEvent[]);
+        if (alive) setEvents(Array.isArray(evs) ? (evs as MoxxyEvent[]) : []);
       })
       .catch(() => undefined);
 

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -20,6 +20,7 @@ import { runResumeCommand } from './commands/resume.js';
 import { runServiceCommand } from './commands/service.js';
 import { runServeCommand } from './commands/serve.js';
 import { runAgentCommand } from './commands/agent.js';
+import { runCollabCommand } from './commands/collab.js';
 import { runSessionsCommand } from './commands/sessions.js';
 import { runSecurityCommand } from './commands/security.js';
 import { runSelfUpdateCommand } from './commands/self-update.js';
@@ -218,6 +219,8 @@ const COMMANDS: Record<string, CommandHandler> = {
   serve: runServeCommand,
   // Internal: a collaboration peer runner spawned by `collaborative` mode.
   agent: runAgentCommand,
+  // The dedicated collaboration coordinator runner (spawned by the collaborate UI).
+  collab: runCollabCommand,
   sessions: runSessionsCommand,
   security: runSecurityCommand,
   skills: runSkillsCommand,

--- a/packages/cli/src/commands/collab.ts
+++ b/packages/cli/src/commands/collab.ts
@@ -1,0 +1,97 @@
+import { startRunnerServer, type RunnerServer } from '@moxxy/runner';
+import type { Session } from '@moxxy/core';
+import { COLLAB_MODE_NAME, collabCoordinatorSocketPath } from '@moxxy/mode-collaborative';
+import type { ParsedArgv } from '../argv.js';
+import { bootSessionWithConfig, helpRequested } from '../argv-helpers.js';
+
+/**
+ * `moxxy collab` — the dedicated collaboration COORDINATOR runner. Spawned by a
+ * UI (the desktop Collaborate panel or the TUI `/collab` command) — not usually
+ * run by hand.
+ *
+ * The coordinator no longer runs inside a user's chat session (which polluted
+ * that chat's thread with the whole team's activity and flipped its mode). It
+ * runs here, headless, in its OWN Session on its OWN runner socket:
+ *   - boots a Session (own id, no port-binding daemons),
+ *   - activates the `collaborative` mode,
+ *   - starts a RunnerServer on the stable coordinator socket so a UI can attach,
+ *   - and then IDLES.
+ *
+ * It deliberately does NOT drive the goal turn itself. The attaching UI submits
+ * the goal via `runTurn`, which makes the turn client-scoped — so the roster
+ * approval checkpoint (and every event) is routed back to that UI. A turn we
+ * started locally would be UNSCOPED, and the runner would silently take the
+ * default approval option instead of asking the human (see RunnerServer's
+ * resolver routing). Hosting-only keeps the human-in-the-loop gate intact.
+ *
+ * Env: MOXXY_SESSION_ID (fresh per run, set by the spawner), MOXXY_RUNNER_SOCKET
+ * (defaults to the stable coordinator socket), MOXXY_MODEL.
+ */
+export async function runCollabCommand(argv: ParsedArgv): Promise<number> {
+  if (helpRequested(argv)) {
+    process.stdout.write(
+      'moxxy collab — the dedicated collaboration coordinator runner (spawned by the desktop/TUI collaborate UI).\n',
+    );
+    return 0;
+  }
+
+  // Bind the coordinator's runner socket BEFORE booting so `startRunnerServer`
+  // picks it up and the coordinator loop records it in the single-flight lock
+  // (that's how a UI discovers where to attach). A spawner may override it.
+  if (!process.env.MOXXY_RUNNER_SOCKET?.trim()) {
+    process.env.MOXXY_RUNNER_SOCKET = collabCoordinatorSocketPath();
+  }
+
+  const sessionId = process.env.MOXXY_SESSION_ID?.trim();
+  const model = process.env.MOXXY_MODEL?.trim();
+
+  const setup = await bootSessionWithConfig(argv, {
+    skipKeyPrompt: true,
+    tolerateNoProvider: true,
+    // A coordinator, like a peer, must NOT start the port-binding daemons
+    // (webhooks/scheduler) — it is a background runner, not a full `serve`.
+    // skipInitHooks still populates the plugin registries (modes, tools, hub).
+    skipInitHooks: true,
+    ...(sessionId ? { sessionId } : {}),
+    ...(model ? { model } : {}),
+  });
+  const { session } = setup;
+
+  // Activate the coordinator mode so the UI only has to submit the goal. We do
+  // NOT install a permission/approval resolver here: the RunnerServer's routing
+  // resolver forwards the client-scoped turn's approvals to the attached UI.
+  try {
+    session.modes.setActive(COLLAB_MODE_NAME);
+  } catch {
+    // mode plugin missing → the attaching UI will surface the failure
+  }
+
+  const runnerServer = await startRunnerServer(session);
+  await runUntilSignal(runnerServer, session);
+  return 0;
+}
+
+/**
+ * Idle until a shutdown signal. The RunnerServer stays up so the UI can attach,
+ * drive the goal turn, and monitor the run; the coordinator loop's own `finally`
+ * releases the collab lock and tears the team down when the turn ends or aborts.
+ */
+async function runUntilSignal(runnerServer: RunnerServer, session: Session): Promise<void> {
+  let stopping = false;
+  const shutdown = async (signal: string): Promise<void> => {
+    if (stopping) return;
+    stopping = true;
+    const force = setTimeout(() => process.exit(0), 3000);
+    force.unref?.();
+    await runnerServer.close().catch(() => undefined);
+    await session.close(signal).catch(() => undefined);
+    process.exit(0);
+  };
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+  setInterval(() => {}, 60_000).unref?.();
+
+  await new Promise<void>(() => {
+    /* until SIGTERM */
+  });
+}

--- a/packages/cli/src/commands/run-tui.ts
+++ b/packages/cli/src/commands/run-tui.ts
@@ -23,7 +23,9 @@ import {
   type RunnerServer,
 } from '@moxxy/runner';
 import { existsSync, readFileSync, unlinkSync } from 'node:fs';
-import { spawn, spawnSync } from 'node:child_process';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { collabCoordinatorSocketPath, readActiveCollab } from '@moxxy/mode-collaborative';
+import type { ClientSession } from '@moxxy/sdk';
 import { probeSession, setupSessionWithConfig, type BootStep } from '../setup.js';
 
 /** Best-effort recovery for "I had an older `moxxy serve` running
@@ -341,9 +343,16 @@ async function runSelfHostedTui(
   // Capture the resolved session + optional runner so shutdown can fire
   // `onShutdown` hooks and release the socket. These are re-pointed in place
   // when the user switches sessions via `/sessions` (see `switchSession`).
-  let bootedSession: Session | null = null;
+  // ClientSession (not the concrete core Session) because a `/collab` switch
+  // re-points the TUI onto the dedicated coordinator via a RemoteSession, which
+  // is a ClientSession, not a locally-booted core Session.
+  let bootedSession: ClientSession | null = null;
   let runnerServer: RunnerServer | null = null;
   let webHandle: ChannelHandle | null = null;
+  // The dedicated `moxxy collab` coordinator process, when a `/collab` spawned
+  // one. Kept so shutdown can reap it (it dies with the TUI, like the old in-chat
+  // collab did); switching AWAY only drops the client, leaving the run alive.
+  let collabChild: ChildProcess | null = null;
   // The live vault from the most recent boot, exposed to the TUI (via getVault)
   // so the `/channels` panel can store channel secrets in the SAME already-open
   // vault — re-opening a second VaultStore could re-trigger a passphrase prompt
@@ -435,6 +444,17 @@ async function runSelfHostedTui(
     // Let an in-flight switch settle so we never close a half-booted session.
     await switching.catch(() => undefined);
     await teardownCurrent(signal);
+    // Reap the collaboration coordinator we spawned (if any) — it's tied to our
+    // process group, but SIGTERM lets its finally archive the run + release the
+    // lock cleanly rather than dying abruptly with us.
+    if (collabChild) {
+      try {
+        collabChild.kill('SIGTERM');
+      } catch {
+        /* already gone */
+      }
+      collabChild = null;
+    }
   };
 
   const onSignal = (signal: NodeJS.Signals): void => {
@@ -450,9 +470,59 @@ async function runSelfHostedTui(
    * given). The TUI re-mounts onto the returned session. Serialized via
    * `switching` so overlapping picks / a racing shutdown can't interleave.
    */
+  /**
+   * Attach the TUI to the dedicated collaboration coordinator. Bare `/collab`
+   * (no goal) attaches to a live coordinator to view it; with a goal — or when
+   * none is running — spawn a fresh `moxxy collab` runner and connect. The goal
+   * itself is auto-submitted by the re-mounted SessionView (via initialPrompt),
+   * so its approval resolver is set before the roster checkpoint arrives.
+   */
+  const attachOrSpawnCollab = async (goal?: string): Promise<ClientSession> => {
+    if (!goal) {
+      const active = readActiveCollab();
+      const runningSocket = active?.runnerSocket?.trim();
+      if (runningSocket && (await isRunnerUp(runningSocket))) {
+        return connectRemoteSession({ role: 'tui', socketPath: runningSocket, replay: 'full' });
+      }
+    }
+    const entry = process.argv[1];
+    if (!entry) throw new Error('cannot locate the moxxy CLI entrypoint to start a collaboration');
+    const socket = collabCoordinatorSocketPath();
+    // Reap a coordinator we spawned earlier before starting a fresh one.
+    if (collabChild) {
+      try {
+        collabChild.kill('SIGTERM');
+      } catch {
+        /* already gone */
+      }
+      collabChild = null;
+    }
+    // `detached: false` ties the coordinator to the TUI's process group, so it
+    // dies with the TUI — matching the old in-chat collab's lifetime.
+    collabChild = spawn(process.execPath, [entry, 'collab'], {
+      cwd: tuiOpts.cwd ?? process.cwd(),
+      env: {
+        ...process.env,
+        MOXXY_DEDICATED_RUNNER: '1',
+        MOXXY_RUNNER_SOCKET: socket,
+        MOXXY_SESSION_ID: `collab-${Date.now().toString(36)}`,
+      },
+      stdio: ['ignore', 'ignore', 'ignore'],
+      detached: false,
+    });
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline && !(await isRunnerUp(socket))) {
+      await new Promise((r) => setTimeout(r, 120));
+    }
+    if (!(await isRunnerUp(socket))) {
+      throw new Error('the collaboration coordinator did not start in time');
+    }
+    return connectRemoteSession({ role: 'tui', socketPath: socket, replay: 'full' });
+  };
+
   const switchSession = async (
-    target: { kind: 'new' } | { kind: 'resume'; id: string },
-  ): Promise<Session> => {
+    target: { kind: 'new' } | { kind: 'resume'; id: string } | { kind: 'collab'; goal?: string },
+  ): Promise<ClientSession> => {
     if (shuttingDown) throw new Error('shutting down');
     let resolveDone!: () => void;
     const done = new Promise<void>((r) => {
@@ -464,6 +534,13 @@ async function runSelfHostedTui(
       await prev.catch(() => undefined);
       if (shuttingDown) throw new Error('shutting down');
       await teardownCurrent('switch');
+      if (target.kind === 'collab') {
+        // The coordinator RemoteSession becomes the live session; teardownCurrent
+        // on the next switch closes the client (the run keeps going).
+        const session = await attachOrSpawnCollab(target.goal);
+        bootedSession = session;
+        return session;
+      }
       return await bootSession(target.kind === 'resume' ? { resumeSessionId: target.id } : {});
     } finally {
       resolveDone();

--- a/packages/desktop-host/src/collab-supervisor.test.ts
+++ b/packages/desktop-host/src/collab-supervisor.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Guards for the collaboration coordinator supervisor's idle-state contract —
+ * the branches the IPC handlers hit when NO coordinator is running. (The
+ * spawn/attach paths are integration-shaped — real subprocess + runner socket —
+ * and are exercised by the collab-loop end-to-end suite + manual desktop runs;
+ * here we pin the safe no-op behavior so a regression can't wedge a turn or
+ * throw across the IPC boundary.)
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  collabRunning,
+  collabSnapshot,
+  respondCollabApproval,
+  runCollabCommand,
+  stopCollab,
+} from './collab-supervisor';
+
+describe('CollabSupervisor — idle state (no coordinator)', () => {
+  it('reports not-running and an empty snapshot', () => {
+    expect(collabRunning()).toBe(false);
+    expect(collabSnapshot()).toEqual([]);
+  });
+
+  it('stopCollab is a no-op that aborts zero turns', async () => {
+    await expect(stopCollab()).resolves.toEqual({ abortedTurns: 0 });
+  });
+
+  it('a step-in command with no coordinator returns a clean error (never throws)', async () => {
+    await expect(runCollabCommand('collab_say', 'all hi')).resolves.toEqual({
+      kind: 'error',
+      message: 'no collaboration is running',
+    });
+  });
+
+  it('answering an unknown approval id is a harmless no-op', () => {
+    expect(() => respondCollabApproval('does-not-exist', { optionId: 'approve' })).not.toThrow();
+  });
+});

--- a/packages/desktop-host/src/collab-supervisor.ts
+++ b/packages/desktop-host/src/collab-supervisor.ts
@@ -1,0 +1,329 @@
+/**
+ * Supervises THE collaboration coordinator — a single, dedicated `moxxy collab`
+ * runner subprocess, entirely separate from the desktop's per-workspace chat
+ * runners. This is what makes "collaborate" a self-contained feature: the
+ * coordinator no longer hijacks a chat session (flipping its mode + flooding its
+ * thread with the whole team's activity). It runs in its own Session on its own
+ * runner socket, and the Collaborate panel talks to it through the dedicated
+ * `collab.*` IPC + the `collab.event` / `collab.approval` broadcasts — never
+ * `runner.event` / the chat ask sheet.
+ *
+ * Single-flight: only one collaboration runs machine-wide (the coordinator's own
+ * `~/.moxxy/collab/active.lock` enforces it across processes). This supervisor
+ * holds at most one coordinator at a time.
+ *
+ * Lifecycle:
+ *   - start(): spawn `moxxy collab`, connect a RemoteSession to its socket, mirror
+ *     its log to `collab.event`, and DRIVE the goal turn (so the turn is
+ *     client-scoped and the coordinator's roster-approval checkpoint is forwarded
+ *     to us — we surface it as a `collab.approval` the panel answers).
+ *   - ensureAttached(): if a coordinator is already running (e.g. started from the
+ *     TUI, or a prior desktop run), connect read-only so the panel can view it.
+ *   - stop(): abort the coordinator turn (its finally archives + releases the
+ *     lock) and terminate the process.
+ *
+ * Electron-free by construction (spawn + the runner client + the host event bus),
+ * so it unit-tests against a fake CLI like the rest of desktop-host.
+ */
+
+import type { ChildProcess } from 'node:child_process';
+
+import {
+  connectRemoteSession,
+  isRunnerUp,
+  type RemoteSession,
+} from '@moxxy/runner';
+import {
+  collabCoordinatorSocketPath,
+  readActiveCollab,
+} from '@moxxy/mode-collaborative';
+import type { ApprovalDecision, ApprovalRequest, MoxxyEvent } from '@moxxy/sdk';
+
+import { augmentedPaths, resolveMoxxyCli, spawnCli } from './cli-resolver';
+import { broadcastHostEvent } from './event-bus';
+
+/** How long to wait for the freshly-spawned coordinator to bind its socket. */
+const SOCKET_WAIT_MS = 15_000;
+const SOCKET_POLL_MS = 120;
+
+interface Coordinator {
+  /** The spawned process, when WE spawned it (start). Absent for a read-only
+   *  attach to a coordinator started elsewhere (ensureAttached). */
+  child?: ChildProcess;
+  session: RemoteSession;
+  /** Aborts the driven goal turn (only set when we drive it). */
+  turnAbort?: AbortController;
+  logUnsub: () => void;
+  task: string;
+  stderrTail: string;
+}
+
+let coordinator: Coordinator | null = null;
+const pendingApprovals = new Map<string, (d: ApprovalDecision) => void>();
+let approvalCounter = 0;
+
+/** Broadcast a coordinator liveness change so the panel re-renders without
+ *  polling. `active` mirrors `collab.active`'s single-flight truth. */
+function broadcastStatus(): void {
+  broadcastHostEvent('collab.status', {
+    running: coordinator != null,
+    ...(coordinator?.task ? { task: coordinator.task } : {}),
+  });
+}
+
+/** True when this supervisor holds a live coordinator session. */
+export function collabRunning(): boolean {
+  return coordinator != null;
+}
+
+/** The coordinator's current event log (seed for a newly-mounted panel). */
+export function collabSnapshot(): ReadonlyArray<MoxxyEvent> {
+  try {
+    return coordinator?.session.log.toJSON() ?? [];
+  } catch {
+    return [];
+  }
+}
+
+async function waitForSocket(socket: string): Promise<boolean> {
+  const deadline = Date.now() + SOCKET_WAIT_MS;
+  while (Date.now() < deadline) {
+    if (await isRunnerUp(socket)) return true;
+    await new Promise((r) => setTimeout(r, SOCKET_POLL_MS));
+  }
+  return isRunnerUp(socket);
+}
+
+/** Wire a connected coordinator session: mirror its log to `collab.event` and
+ *  route its approval checkpoints to the panel via `collab.approval`. Returns the
+ *  held record so the caller can attach the driven turn/stderr without fighting
+ *  control-flow narrowing on the module-level singleton. */
+function bind(session: RemoteSession, task: string, child?: ChildProcess): Coordinator {
+  const logUnsub = session.log.subscribe((event) => {
+    broadcastHostEvent('collab.event', { event });
+  });
+
+  // The coordinator orchestrates (spawns processes, git ops) rather than making
+  // arbitrary model tool-calls, so auto-allow permission — there's no human at
+  // this headless runner to answer, and blocking would wedge the run.
+  session.setPermissionResolver({
+    name: 'collab-allow',
+    check: async () => ({ mode: 'allow' }),
+  });
+  // The roster-approval checkpoint (the ONE human gate) is surfaced to the panel.
+  session.setApprovalResolver({
+    name: 'collab-approve',
+    confirm: (request) => awaitApproval(request),
+  });
+
+  const c: Coordinator = { session, logUnsub, task, stderrTail: '', ...(child ? { child } : {}) };
+  coordinator = c;
+
+  session.onClose(() => {
+    if (coordinator?.session === session) teardown();
+  });
+  return c;
+}
+
+function awaitApproval(request: ApprovalRequest): Promise<ApprovalDecision> {
+  const requestId = `collab-ask-${++approvalCounter}`;
+  return new Promise<ApprovalDecision>((resolve) => {
+    pendingApprovals.set(requestId, resolve);
+    broadcastHostEvent('collab.approval', { requestId, request });
+  });
+}
+
+/** Answer a pending roster/approval prompt from the panel. */
+export function respondCollabApproval(requestId: string, decision: ApprovalDecision): void {
+  const resolve = pendingApprovals.get(requestId);
+  if (!resolve) return;
+  pendingApprovals.delete(requestId);
+  broadcastHostEvent('collab.approval.resolved', { requestId });
+  resolve(decision);
+}
+
+/** Drop every pending approval (teardown) so nothing leaks; the driven turn is
+ *  already aborting, so the resolved value is inconsequential. */
+function cancelApprovals(): void {
+  for (const [requestId, resolve] of pendingApprovals) {
+    broadcastHostEvent('collab.approval.resolved', { requestId });
+    resolve({ optionId: '' });
+  }
+  pendingApprovals.clear();
+}
+
+/**
+ * Start a collaboration: spawn the dedicated coordinator, connect, and drive the
+ * goal turn. Throws if the CLI can't be resolved or the coordinator never binds
+ * its socket. The coordinator's own lock refuses a second concurrent run.
+ */
+export async function startCollab(args: { cwd: string; goal: string }): Promise<{ started: boolean }> {
+  if (coordinator) return { started: false };
+
+  const cli = resolveMoxxyCli({ extraPaths: augmentedPaths() });
+  if (!cli) throw new Error('moxxy CLI not found');
+  const socket = collabCoordinatorSocketPath();
+
+  // Mirror the channel-supervisor env: a desktop-spawned runner lives in the
+  // read-only packaged app and must not co-attach a web surface, race the web
+  // port, or try to self-patch core. A fresh session id per run avoids resuming
+  // a stale coordinator log.
+  const child = spawnCli(cli, ['collab'], {
+    cwd: args.cwd,
+    env: {
+      MOXXY_DEDICATED_RUNNER: '1',
+      MOXXY_NO_WEB_SURFACE: '1',
+      MOXXY_NO_CORE_UPDATE: '1',
+      MOXXY_RUNNER_SOCKET: socket,
+      MOXXY_SESSION_ID: `collab-${Date.now().toString(36)}`,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let earlyExit = false;
+  let stderrTail = '';
+  child.stderr?.on('data', (b: Buffer) => {
+    stderrTail = (stderrTail + b.toString()).slice(-4096);
+  });
+  child.once('exit', () => {
+    earlyExit = true;
+    if (coordinator?.child === child) teardown();
+  });
+
+  const up = await waitForSocket(socket);
+  if (!up || earlyExit) {
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      /* already gone */
+    }
+    throw new Error(stderrTail.trim() || 'collaboration coordinator failed to start');
+  }
+
+  const session = await connectRemoteSession({ socketPath: socket, role: 'desktop', replay: 'full' });
+  const c = bind(session, args.goal, child);
+  c.stderrTail = stderrTail;
+  broadcastStatus();
+
+  // Drive the goal turn. Client-scoped, so the coordinator's approval.confirm is
+  // forwarded to us (→ collab.approval) instead of silently taking the default.
+  const turnAbort = new AbortController();
+  c.turnAbort = turnAbort;
+  void (async () => {
+    try {
+      for await (const _ of session.runTurn(args.goal, { signal: turnAbort.signal })) void _;
+    } catch {
+      // errors surface on the coordinator's own event log (→ collab.event)
+    }
+  })();
+
+  return { started: true };
+}
+
+/**
+ * If a coordinator is already running (started from the TUI or a prior desktop
+ * run) but this supervisor doesn't hold it, connect read-only so the panel can
+ * view the live run. No-op when we already hold one, or none is active.
+ */
+export async function ensureCollabAttached(): Promise<void> {
+  if (coordinator) return;
+  const active = readActiveCollab();
+  const socket = active?.runnerSocket?.trim();
+  if (!active || !socket) return;
+  if (!(await isRunnerUp(socket))) return;
+  try {
+    const session = await connectRemoteSession({ socketPath: socket, role: 'desktop', replay: 'full' });
+    bind(session, active.task, undefined); // no child: we don't own the process
+    broadcastStatus();
+  } catch {
+    // best-effort viewing; the panel still has collab.active + history
+  }
+}
+
+/** Run a step-in command (collab_say / collab_direct / collab_pause / collab_resume)
+ *  on the coordinator session. Returns a command-result envelope for the panel. */
+export async function runCollabCommand(
+  name: string,
+  cmdArgs: string,
+): Promise<{ kind: 'error'; message: string } | unknown> {
+  const session = coordinator?.session;
+  if (!session) return { kind: 'error', message: 'no collaboration is running' };
+  const def = session.commands.get(name);
+  if (!def) return { kind: 'error', message: `unknown command: /${name}` };
+  return def.handler({
+    channel: 'desktop',
+    sessionId: session.getInfo().sessionId,
+    args: cmdArgs,
+    // CommandContext.session is `unknown` (the SDK stays core-free); RemoteSession
+    // is assignable directly.
+    session,
+  });
+}
+
+/** End the collaboration: abort the driven turn (its finally archives + releases
+ *  the lock), then terminate the coordinator process. Returns how many turns we
+ *  aborted (0 when we were only viewing a coordinator we didn't drive). */
+export async function stopCollab(): Promise<{ abortedTurns: number }> {
+  const c = coordinator;
+  if (!c) return { abortedTurns: 0 };
+  let abortedTurns = 0;
+  if (c.turnAbort) {
+    c.turnAbort.abort();
+    abortedTurns = 1;
+  }
+  if (c.child) {
+    try {
+      c.child.kill('SIGTERM');
+    } catch {
+      /* already gone */
+    }
+    const child = c.child;
+    const force = setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* already gone */
+      }
+    }, 4000);
+    force.unref?.();
+  }
+  teardown();
+  return { abortedTurns };
+}
+
+/** Drop the held coordinator + all wiring. Idempotent. */
+function teardown(): void {
+  const c = coordinator;
+  coordinator = null;
+  cancelApprovals();
+  if (c) {
+    try {
+      c.logUnsub();
+    } catch {
+      /* ignore */
+    }
+    try {
+      c.session.close();
+    } catch {
+      /* ignore */
+    }
+  }
+  broadcastStatus();
+}
+
+/** App-teardown hook: stop any supervised coordinator. */
+export function stopAllCollab(): void {
+  if (coordinator) void stopCollab();
+}
+
+// Best-effort: never leave the coordinator subprocess orphaned when the app
+// quits. `exit` handlers must be synchronous — SIGTERM is; the coordinator's own
+// finally then archives the run + releases the lock. (Only fires for a
+// coordinator WE spawned; a read-only attach holds no child.)
+process.once('exit', () => {
+  try {
+    coordinator?.child?.kill('SIGTERM');
+  } catch {
+    /* ignore */
+  }
+});

--- a/packages/desktop-host/src/ipc/collab-lock.test.ts
+++ b/packages/desktop-host/src/ipc/collab-lock.test.ts
@@ -21,23 +21,29 @@ import { collabLockPath, parseCollabLock } from '@moxxy/mode-collaborative';
 describe('parseCollabLock (collab.active/end on-disk lock guard)', () => {
   it('parses a well-formed lock record', () => {
     const info = parseCollabLock(
-      JSON.stringify({ pid: 1234, sessionId: 's1', task: 'do a thing', startedAtMs: 1000 }),
+      JSON.stringify({ pid: 1234, sessionId: 's1', task: 'do a thing', startedAtMs: 1000, runnerSocket: '/tmp/c.sock' }),
     );
-    expect(info).toEqual({ pid: 1234, sessionId: 's1', task: 'do a thing', startedAtMs: 1000 });
+    expect(info).toEqual({
+      pid: 1234,
+      sessionId: 's1',
+      task: 'do a thing',
+      startedAtMs: 1000,
+      runnerSocket: '/tmp/c.sock',
+    });
   });
 
   it('defaults missing optional string/number fields rather than throwing', () => {
     const info = parseCollabLock(JSON.stringify({ pid: 42 }));
-    expect(info).toEqual({ pid: 42, sessionId: '', task: '', startedAtMs: 0 });
+    expect(info).toEqual({ pid: 42, sessionId: '', task: '', startedAtMs: 0, runnerSocket: '' });
   });
 
   it('coerces wrong-typed optional fields to safe defaults (never trusts them)', () => {
     const info = parseCollabLock(
-      JSON.stringify({ pid: 42, sessionId: 99, task: { x: 1 }, startedAtMs: 'soon' }),
+      JSON.stringify({ pid: 42, sessionId: 99, task: { x: 1 }, startedAtMs: 'soon', runnerSocket: 5 }),
     );
     // pid is the only field handed to process.kill; the rest are display-only
     // and must degrade to empty/zero, not propagate a wrong type to the UI.
-    expect(info).toEqual({ pid: 42, sessionId: '', task: '', startedAtMs: 0 });
+    expect(info).toEqual({ pid: 42, sessionId: '', task: '', startedAtMs: 0, runnerSocket: '' });
   });
 
   it('returns null on truncated / non-JSON (a half-written lock)', () => {

--- a/packages/desktop-host/src/ipc/session.ts
+++ b/packages/desktop-host/src/ipc/session.ts
@@ -146,11 +146,41 @@ export function registerSessionHandlers(pool: RunnerPool): void {
       return { active: false };
     }
   });
-  handle('collab.end', async ({ workspaceId }) => {
-    // Abort the coordinator turn (its finally tears the team down + archives),
-    // then force-release the global lock so a new collaboration can start —
-    // covering a stale lock from a crashed run whose coordinator is unreachable.
-    const abortedTurns = resolveDriver(pool, workspaceId)?.abortActiveTurns() ?? 0;
+  handle('collab.start', async ({ workspaceId, goal }) => {
+    // Start on the DEDICATED coordinator runner — never a chat session. The
+    // coordinator works in the target workspace's bound folder. Dynamically
+    // imported so the collab/runner stack stays off the Electron boot path.
+    const cwd = resolveSupervisor(pool, workspaceId)?.getCwd();
+    if (!cwd) throw new IpcError('no-workspace', 'bind a folder before collaborating');
+    const { startCollab } = await import('../collab-supervisor');
+    return startCollab({ cwd, goal });
+  });
+  handle('collab.snapshot', async () => {
+    // Seed a freshly-mounted panel — and opportunistically attach to a
+    // coordinator started elsewhere (e.g. from the TUI) so the desktop can view it.
+    const { ensureCollabAttached, collabSnapshot } = await import('../collab-supervisor');
+    await ensureCollabAttached().catch(() => undefined);
+    return collabSnapshot() as never;
+  });
+  handle('collab.command', async ({ name, args }) => {
+    const { runCollabCommand } = await import('../collab-supervisor');
+    return (await runCollabCommand(name, args)) as never;
+  });
+  handle('collab.respondApproval', async ({ requestId, decision }) => {
+    const { respondCollabApproval } = await import('../collab-supervisor');
+    respondCollabApproval(requestId, decision);
+  });
+  handle('collab.end', async () => {
+    // Stop the dedicated coordinator (abort its turn — whose finally archives the
+    // run — then terminate the process), then force-release the global lock so a
+    // new collaboration can start even if a stale/crashed run left it held.
+    let abortedTurns = 0;
+    try {
+      const { stopCollab } = await import('../collab-supervisor');
+      abortedTurns = (await stopCollab()).abortedTurns;
+    } catch {
+      // best-effort
+    }
     let clearedTask: string | undefined;
     try {
       // forceReleaseCollabLock removes the lock regardless of holder and returns

--- a/packages/desktop-ipc-contract/src/commands.ts
+++ b/packages/desktop-ipc-contract/src/commands.ts
@@ -1,4 +1,5 @@
 import type {
+  ApprovalDecision,
   MoxxyEvent,
   SessionInfo,
   OpenSurfaceResult,
@@ -296,10 +297,34 @@ export interface IpcCommands {
     readonly task?: string;
     readonly startedAtMs?: number;
   }>;
+  /** Start a collaboration on the DEDICATED coordinator runner (`moxxy collab`),
+   *  separate from every chat session. `cwd` (the repo to work in) defaults to the
+   *  given workspace's directory. The coordinator drives the goal turn; its events
+   *  arrive via `collab.event`, its roster approval via `collab.approval`. */
+  'collab.start': (args: { workspaceId?: string; goal: string }) => Promise<{
+    readonly started: boolean;
+  }>;
+  /** Seed a freshly-mounted Collaborate panel with the coordinator's current
+   *  event log (the live `collab.event` stream continues from there). */
+  'collab.snapshot': () => Promise<ReadonlyArray<MoxxyEvent>>;
+  /** Run a step-in command on the coordinator session (collab_say / collab_direct
+   *  / collab_pause / collab_resume) — the Collaborate panel's human-in-the-loop
+   *  controls. Never touches a chat session. */
+  'collab.command': (args: { name: string; args: string }) => Promise<{
+    readonly kind: 'text' | 'session-action' | 'noop' | 'error';
+    readonly text?: string;
+    readonly message?: string;
+    readonly notice?: string;
+  }>;
+  /** Answer the coordinator's roster-approval checkpoint from the panel. */
+  'collab.respondApproval': (args: {
+    requestId: string;
+    decision: ApprovalDecision;
+  }) => Promise<void>;
   /** End the active collaboration: abort its coordinator turn (whose finally
    *  tears the team down + archives) and force-release the global single-flight
    *  lock so a new one can start — even if the holder is a stale/crashed run. */
-  'collab.end': (args: { workspaceId?: string }) => Promise<{
+  'collab.end': (args?: { workspaceId?: string }) => Promise<{
     readonly ended: boolean;
     readonly abortedTurns: number;
     readonly clearedTask?: string;

--- a/packages/desktop-ipc-contract/src/events.ts
+++ b/packages/desktop-ipc-contract/src/events.ts
@@ -1,4 +1,4 @@
-import type { MoxxyEvent, SurfaceDataMessage } from '@moxxy/sdk';
+import type { ApprovalRequest, MoxxyEvent, SurfaceDataMessage } from '@moxxy/sdk';
 
 import type { AskRequest } from './ask.js';
 import type { ConnectionPhase } from './connection.js';
@@ -92,4 +92,17 @@ export interface IpcEvents {
    *  or its public Request URL became available) — the Channels panel re-renders
    *  that channel's card without polling. */
   'channels.status': ChannelRuntimeStatus;
+  /** A live event from the dedicated collaboration coordinator (`moxxy collab`),
+   *  forwarded off its own runner. The Collaborate panel folds these into its
+   *  view; they NEVER enter a chat session's `runner.event` stream — that is what
+   *  keeps collaborate a separate feature. */
+  'collab.event': { event: MoxxyEvent };
+  /** The coordinator's roster-approval checkpoint (the single human gate). The
+   *  panel renders it inline and answers via `collab.respondApproval`. */
+  'collab.approval': { requestId: string; request: ApprovalRequest };
+  /** A collab approval was answered (or the run ended) — drop the inline card. */
+  'collab.approval.resolved': { requestId: string };
+  /** The coordinator's liveness/task changed (started / ended / crashed) — the
+   *  panel reflects it without polling `collab.active`. */
+  'collab.status': { running: boolean; task?: string };
 }

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -430,7 +430,25 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
   //   - end: an optional, bounded workspace slug (the target runner to abort).
   'collab.active': z.undefined(),
   'collab.history': z.object({ limit: z.number().int().positive().max(200) }).partial().optional(),
-  'collab.end': z.object({ workspaceId: optionalWorkspace }).optional(),
+  // start: an optional workspace slug (whose cwd the coordinator works in) + a
+  // bounded goal string. snapshot: no-arg. command: a slug-like command name +
+  // bounded args (step-in). respondApproval: a known requestId + strict decision.
+  'collab.start': z
+    .object({ workspaceId: optionalWorkspace, goal: z.string().min(1).max(32_768) })
+    .strict(),
+  'collab.snapshot': z.undefined(),
+  'collab.command': z
+    .object({ name: z.string().min(1).max(64), args: z.string().max(32_768) })
+    .strict(),
+  'collab.respondApproval': z
+    .object({
+      requestId: z.string().min(1).max(128),
+      decision: z
+        .object({ optionId: z.string().max(128), text: z.string().max(10_000).optional() })
+        .strict(),
+    })
+    .strict(),
+  'collab.end': z.object({ workspaceId: optionalWorkspace }).partial().optional(),
   // Vault writes are security-sensitive: lock the key name to a safe slug
   // (letters/digits + . _ / - , no traversal) and bound the secret size.
   'settings.vaultSet': z.object({

--- a/packages/mode-collaborative/src/collab-lock.ts
+++ b/packages/mode-collaborative/src/collab-lock.ts
@@ -54,10 +54,19 @@ export function tryAcquireCollabLock(args: {
   sessionId: string;
   task: string;
   startedAtMs: number;
+  /** The coordinator runner socket a UI attaches to, recorded so readers can
+   *  discover it without knowing the run id. Defaults to '' when unknown. */
+  runnerSocket?: string;
 }): { ok: true } | { ok: false; holder: CollabLockInfo } {
   const path = collabLockPath();
   mkdirSync(dirname(path), { recursive: true });
-  const info: CollabLockInfo = { pid: process.pid, ...args };
+  const info: CollabLockInfo = {
+    pid: process.pid,
+    sessionId: args.sessionId,
+    task: args.task,
+    startedAtMs: args.startedAtMs,
+    runnerSocket: args.runnerSocket ?? '',
+  };
   const payload = JSON.stringify(info);
 
   // Bounded retries: each EEXIST either reports a live holder (fail) or reclaims

--- a/packages/mode-collaborative/src/collab-loop.ts
+++ b/packages/mode-collaborative/src/collab-loop.ts
@@ -98,7 +98,15 @@ export async function* runCollaborative(ctx: ModeContext, deps: CollabDeps): Asy
 
   // Global single-flight: only one collaboration runs at a time (each spawns a
   // fleet of agent processes). Refuse rather than thrash resources.
-  const lock = tryAcquireCollabLock({ sessionId: String(ctx.sessionId), task, startedAtMs: Date.now() });
+  // The coordinator now runs as its own headless runner process (`moxxy collab`),
+  // which sets MOXXY_RUNNER_SOCKET to its own socket. Record it in the lock so a
+  // UI can discover where to attach without knowing the run id.
+  const lock = tryAcquireCollabLock({
+    sessionId: String(ctx.sessionId),
+    task,
+    startedAtMs: Date.now(),
+    runnerSocket: process.env.MOXXY_RUNNER_SOCKET?.trim() || '',
+  });
   if (!lock.ok) {
     yield await ctx.emit(plugin(ctx, 'collab_blocked', { reason: 'already-running', holderTask: lock.holder.task }));
     yield await ctx.emit(

--- a/packages/mode-collaborative/src/collab-store.test.ts
+++ b/packages/mode-collaborative/src/collab-store.test.ts
@@ -21,10 +21,24 @@ import {
 } from './collab-store.js';
 
 describe('parseCollabLock', () => {
-  it('parses a well-formed lock record', () => {
+  it('parses a well-formed lock record (incl. the runner socket a UI attaches to)', () => {
+    expect(
+      parseCollabLock(
+        JSON.stringify({
+          pid: 1234,
+          sessionId: 's1',
+          task: 'do a thing',
+          startedAtMs: 1000,
+          runnerSocket: '/tmp/c.sock',
+        }),
+      ),
+    ).toEqual({ pid: 1234, sessionId: 's1', task: 'do a thing', startedAtMs: 1000, runnerSocket: '/tmp/c.sock' });
+  });
+
+  it('defaults a missing runnerSocket (older lock) to empty string', () => {
     expect(
       parseCollabLock(JSON.stringify({ pid: 1234, sessionId: 's1', task: 'do a thing', startedAtMs: 1000 })),
-    ).toEqual({ pid: 1234, sessionId: 's1', task: 'do a thing', startedAtMs: 1000 });
+    ).toEqual({ pid: 1234, sessionId: 's1', task: 'do a thing', startedAtMs: 1000, runnerSocket: '' });
   });
 
   it('defaults / coerces wrong-typed optional fields to safe values (never trusts them)', () => {
@@ -33,12 +47,18 @@ describe('parseCollabLock', () => {
       sessionId: '',
       task: '',
       startedAtMs: 0,
+      runnerSocket: '',
     });
-    expect(parseCollabLock(JSON.stringify({ pid: 42, sessionId: 99, task: { x: 1 }, startedAtMs: 'soon' }))).toEqual({
+    expect(
+      parseCollabLock(
+        JSON.stringify({ pid: 42, sessionId: 99, task: { x: 1 }, startedAtMs: 'soon', runnerSocket: 5 }),
+      ),
+    ).toEqual({
       pid: 42,
       sessionId: '',
       task: '',
       startedAtMs: 0,
+      runnerSocket: '',
     });
   });
 
@@ -102,8 +122,17 @@ describe('paths + readCollabLock', () => {
     // Point the lock at a path directly under `home` (no nested dir to create).
     process.env.MOXXY_COLLAB_LOCK = join(home, 'lock.json');
     expect(readCollabLock()).toBeNull(); // nothing written yet
-    writeFileSync(join(home, 'lock.json'), JSON.stringify({ pid: process.pid, sessionId: 'x', task: 't', startedAtMs: 7 }));
-    expect(readCollabLock()).toEqual({ pid: process.pid, sessionId: 'x', task: 't', startedAtMs: 7 });
+    writeFileSync(
+      join(home, 'lock.json'),
+      JSON.stringify({ pid: process.pid, sessionId: 'x', task: 't', startedAtMs: 7, runnerSocket: '/tmp/x.sock' }),
+    );
+    expect(readCollabLock()).toEqual({
+      pid: process.pid,
+      sessionId: 'x',
+      task: 't',
+      startedAtMs: 7,
+      runnerSocket: '/tmp/x.sock',
+    });
     writeFileSync(join(home, 'lock.json'), '{ truncated');
     expect(readCollabLock()).toBeNull();
   });

--- a/packages/mode-collaborative/src/collab-store.ts
+++ b/packages/mode-collaborative/src/collab-store.ts
@@ -39,12 +39,16 @@ export function collabRunsDir(): string {
 }
 
 /** The coordinator's single-flight lock record. `pid` is the only field handed
- *  to `process.kill` for the liveness probe; the rest are display-only. */
+ *  to `process.kill` for the liveness probe; the rest are display-only EXCEPT
+ *  `runnerSocket`, which a UI reads to attach to the (headless) coordinator's
+ *  runner and drive/monitor the run. Empty string when unknown (older lock, or a
+ *  coordinator without a runner socket). */
 export interface CollabLockInfo {
   readonly pid: number;
   readonly sessionId: string;
   readonly task: string;
   readonly startedAtMs: number;
+  readonly runnerSocket: string;
 }
 
 /**
@@ -69,6 +73,7 @@ export function parseCollabLock(raw: string): CollabLockInfo | null {
     sessionId: typeof rec.sessionId === 'string' ? rec.sessionId : '',
     task: typeof rec.task === 'string' ? rec.task : '',
     startedAtMs: typeof rec.startedAtMs === 'number' ? rec.startedAtMs : 0,
+    runnerSocket: typeof rec.runnerSocket === 'string' ? rec.runnerSocket : '',
   };
 }
 

--- a/packages/mode-collaborative/src/constants.ts
+++ b/packages/mode-collaborative/src/constants.ts
@@ -43,6 +43,17 @@ export function collabRunId(sessionId: string, turnId: string): string {
   return `${tail(sessionId)}-${tail(turnId)}-${suffix}`;
 }
 
+/** The dedicated collaboration coordinator's runner socket. The coordinator now
+ *  runs as its own headless runner process (`moxxy collab`) — never inside a chat
+ *  session — and UIs attach here to drive/monitor the run. Stable because the
+ *  single-flight lock guarantees one coordinator at a time, so a UI can attach
+ *  without knowing the run id; the path is ALSO recorded in the lock for
+ *  authoritative discovery. Kept short (macOS caps unix-socket paths at ~104
+ *  chars) and homedir-based (not MOXXY_HOME) to match the run/socket helpers. */
+export function collabCoordinatorSocketPath(): string {
+  return join(homedir(), '.moxxy', 'collab', 'coordinator.sock');
+}
+
 /** Per-run directory holding the hub + peer sockets. */
 export function collabRunDir(runId: string): string {
   return join(homedir(), '.moxxy', 'collab', runId);

--- a/packages/mode-collaborative/src/index.ts
+++ b/packages/mode-collaborative/src/index.ts
@@ -31,6 +31,7 @@ export {
   COLLAB_MODE_NAME,
   COLLAB_ARCHITECT_MODE_NAME,
   COLLAB_PEER_MODE_NAME,
+  collabCoordinatorSocketPath,
 } from './constants.js';
 export { resolveCollabConfig, DEFAULT_COLLAB_CONFIG, type CollabConfig } from './config.js';
 export {

--- a/packages/plugin-cli/src/session/BootShell.tsx
+++ b/packages/plugin-cli/src/session/BootShell.tsx
@@ -67,11 +67,16 @@ export const InteractiveSession: React.FC<InteractiveSessionProps> = ({
         // otherwise linger above.
         clearTerminalScreen();
         setLandedViaSwitch(true);
-        setInitialPrompt(null);
+        // A collab switch WITH a goal auto-submits it as the coordinator's first
+        // turn — SessionView owns the submission (so its approval resolver is set
+        // before the roster checkpoint arrives). Other switches carry no prompt.
+        setInitialPrompt(target.kind === 'collab' && target.goal ? target.goal : null);
         setSwitchNotice(
           target.kind === 'new'
             ? 'started a new session — your previous conversation stays saved'
-            : 'switched session',
+            : target.kind === 'collab'
+              ? '👥 collaboration — an architect will propose a team for you to approve (Esc leaves it running; /sessions to return to chat)'
+              : 'switched session',
         );
         setSession(next);
       } finally {

--- a/packages/plugin-cli/src/session/SessionView.tsx
+++ b/packages/plugin-cli/src/session/SessionView.tsx
@@ -299,6 +299,16 @@ export const SessionView: React.FC<SessionViewProps> = ({
         setQueueCount: turn.setQueueCount,
         performSessionAction,
         canSwitchSession: canSwitchSession ?? false,
+        // `/collab` re-points the TUI onto the dedicated coordinator via the same
+        // in-place switch machinery `/sessions` uses (so it needs the host's
+        // switch capability). A collab switch carries the goal to auto-submit.
+        ...(onSwitchSession
+          ? {
+              requestCollab: (goal?: string) => {
+                void onSwitchSession({ kind: 'collab', ...(goal ? { goal } : {}) });
+              },
+            }
+          : {}),
         // Start a turn directly (e.g. /goal kicking off autonomous work)
         // without clearing the just-set system notice. Objectives are plain
         // text, so no image-attachment resolution is needed.

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -31,6 +31,13 @@ export interface SlashDeps {
    * session).
    */
   canSwitchSession?: boolean;
+  /**
+   * Re-point the TUI onto the dedicated collaboration coordinator (spawning a
+   * fresh `moxxy collab` runner, or attaching to a live one). Powers `/collab`.
+   * Absent on transports that can't re-bootstrap in place (same gate as
+   * {@link canSwitchSession}) — `/collab` then degrades to a notice.
+   */
+  requestCollab?: (goal?: string) => void;
 }
 
 export function runSlash(cmd: string, deps: SlashDeps): void {
@@ -522,40 +529,27 @@ function startGoal(deps: SlashDeps, arg: string): void {
 }
 
 /**
- * `/collab <goal>` — the agentic-collaborative entry point. Switches to the
- * `collaborative` mode and, when a goal is given, kicks it off immediately: an
- * architect agent designs the plan + contracts and PROPOSES a roster, which
- * surfaces as the usual approval prompt (review/launch/cancel) — then the team
- * of agents runs in parallel and their live status renders inline as the
- * `◆ collab` block. Step in anytime with /collab_say, /collab_direct,
- * /collab_pause, /collab_resume. Bare `/collab` just arms the mode.
- *
- * Unlike /goal it does NOT force yolo: the roster-approval checkpoint (and any
- * conflict escalation) is intentional human-in-the-loop. The spawned peer
- * agents auto-approve inside their own processes.
+ * `/collab <goal>` — the agentic-collaborative entry point. Collaboration is a
+ * SEPARATE feature: rather than taking over the current chat session (flipping
+ * its mode + flooding its thread with the team's activity), it re-points the TUI
+ * onto a DEDICATED coordinator runner (`moxxy collab`) with its own session.
+ * `/collab <goal>` spawns a fresh coordinator and auto-submits the goal — an
+ * architect designs the plan + proposes a roster (the usual review/launch/cancel
+ * approval), then the team runs and its live status renders as the `◆ collab`
+ * block. Bare `/collab` attaches to a running collaboration to view it. Step in
+ * with /collab_say, /collab_direct, /collab_pause, /collab_resume. Return to your
+ * chat anytime with /sessions — the collaboration keeps running.
  */
 function startCollab(deps: SlashDeps, arg: string): void {
   const objective = arg.trim();
-  const COLLAB_MODE = 'collaborative';
-  if (!deps.session.modes.list().some((m) => m.name === COLLAB_MODE)) {
-    deps.setSystemNotice('collaborative mode is not available (mode-collaborative plugin not loaded)');
-    return;
-  }
-  try {
-    deps.session.modes.setActive(COLLAB_MODE);
-    void setCategoryDefault('mode', COLLAB_MODE).catch(() => undefined);
-  } catch (err) {
+  if (!deps.requestCollab) {
     deps.setSystemNotice(
-      `failed to switch to collaborative mode: ${err instanceof Error ? err.message : String(err)}`,
+      'collaboration runs on its own runner and needs an in-place session switch, which isn’t available here (attached to an external `moxxy serve`). Start it from the desktop Collaborate panel instead.',
     );
     return;
   }
-  deps.setSystemNotice(
-    objective
-      ? '👥 collaborative mode — the architect is designing the plan; you’ll be asked to approve the team roster. Press Esc to stop.'
-      : '👥 collaborative mode on. Send the goal as the next message — an architect will propose a team for you to approve.',
-  );
-  if (objective) deps.submitPrompt(objective);
+  deps.setSystemNotice(null);
+  deps.requestCollab(objective || undefined);
 }
 
 function openModePicker(deps: SlashDeps, arg = ''): void {

--- a/packages/plugin-cli/src/session/sessions-picker.ts
+++ b/packages/plugin-cli/src/session/sessions-picker.ts
@@ -5,9 +5,17 @@ import type { ListPickerOption } from '../components/ListPicker.js';
 /**
  * What the TUI asks the host to switch to. `{ kind: 'new' }` boots a fresh
  * session (empty log); `{ kind: 'resume', id }` re-bootstraps the host onto the
- * persisted session with that id (seeding its event log from disk).
+ * persisted session with that id (seeding its event log from disk);
+ * `{ kind: 'collab', goal? }` re-points the TUI onto the DEDICATED collaboration
+ * coordinator (a separate `moxxy collab` runner — never a chat session), attaching
+ * to a live one or spawning a fresh one. When a goal is given it's auto-submitted
+ * as the coordinator's first turn (so the roster-approval checkpoint is forwarded
+ * to the TUI); bare `/collab` attaches to a running collaboration to view it.
  */
-export type SessionSwitchTarget = { kind: 'new' } | { kind: 'resume'; id: string };
+export type SessionSwitchTarget =
+  | { kind: 'new' }
+  | { kind: 'resume'; id: string }
+  | { kind: 'collab'; goal?: string };
 
 /**
  * Host-provided capability the TUI calls when the user picks an entry in the


### PR DESCRIPTION
## What
Collaboration is now a fully separate feature that never touches your chats or their sessions — on both the desktop and the TUI.

Previously `/collab` (and the desktop Collaborate tab) ran the coordinator **inside the active chat session**: it flipped that session's mode to `collaborative` and streamed the whole team's activity into the chat's own event log, polluting the thread and its transcript.

Now the coordinator runs on its **own dedicated `moxxy collab` runner** — its own headless Session + socket, hosting the collab hub and spawning the architect/implementer team as before. It is *hosts-only*: the attaching UI drives the goal turn, so the turn is client-scoped and the coordinator's roster-approval checkpoint is forwarded to the UI (a locally-started turn would silently take the default).

- **Foundation** (`@moxxy/cli`, `@moxxy/mode-collaborative`): new internal `moxxy collab` command; the single-flight lock now records the coordinator's `runnerSocket` so a UI can discover + attach.
- **Desktop** (`@moxxy/desktop-host`, `@moxxy/desktop-ipc-contract`, `@moxxy/desktop`): `CollabSupervisor` spawns/attaches the coordinator; the Collaborate panel drives it over dedicated `collab.*` IPC + `collab.event`/`collab.approval` broadcasts (a private `useCollab` hook, not `useChat`); roster approval is answered inline in the panel.
- **TUI** (`@moxxy/plugin-cli`, `@moxxy/cli`): `/collab <goal>` re-points the terminal onto the coordinator's own session via the same in-place switch `/sessions` uses, auto-submitting the goal there (`initialPrompt`) — reusing the entire `SessionView` (transcript, `CollabScopeView`, approval, step-in). Bare `/collab` attaches to a running collaboration to view it; `/sessions` returns to chat while it keeps running. Step-in (`/collab_say` …) executes in the coordinator process (`command.run` forwards it there, where the hub lives).

## Why
So a collaboration is entirely decoupled from every chat session — no mode-switch, no team activity in a chat's thread — while preserving the roster-approval human-in-the-loop gate.

## Verification
- `pnpm build` 74/74 · typecheck · lint (0 errors) · `check:deps` (0 errors) — all green.
- Tests green: `@moxxy/mode-collaborative` 79, `@moxxy/desktop-host` 500 (incl. a new `CollabSupervisor` idle-state suite), `@moxxy/plugin-cli` 237, plus `@moxxy/cli` / `@moxxy/desktop-ipc-contract`.
- Not yet smoke-tested end-to-end in a packaged desktop / live terminal. The two spots that most warrant a live run: (1) the TUI spawn→attach→auto-submit→roster-approval sequence, and (2) the desktop `collab.start`→approval round-trip.