### PR TITLE
fix(cli): slim the npm tarball (drop sourcemap) + correct the ^B footer hint

### DIFF
--- a/.changeset/slim-quick-wins.md
+++ b/.changeset/slim-quick-wins.md
@@ -1,0 +1,9 @@
+---
+'@moxxy/cli': patch
+'@moxxy/plugin-cli': patch
+---
+
+Stop shipping the 16 MB `bin.js.map` sourcemap in the published npm tarball
+(unpacked size drops ~65%; local builds keep sourcemaps). Fix the TUI footer
+hint that advertised `^B toggle skills` — Ctrl+B drops the first queued
+message; the hint row now shows `^O tool detail` instead.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -309,9 +309,20 @@ or recorded-on-purpose decision.
 - [note, RESOLVED 2026-06-25] Pillar 2 done: the **EventStore** behind the event
   log is now a registry kind (`eventStore`) with a protected JSONL floor and an
   explicit-opt-in trust boundary, behaviour-identical (thin adapter over
-  `SessionPersistence`). Pillar 3 (slim-core kernel + publish ~40 plugins +
-  init-provisions + desktop seed-pack) remains planned but unstarted. Plan:
-  `~/.claude/plans/i-think-we-need-zany-wirth.md`.
+  `SessionPersistence`). Plan: `~/.claude/plans/i-think-we-need-zany-wirth.md`.
+- [note, updated 2026-07-03] Pillar 3 is HALF done, not unstarted: #363/#364
+  shipped the shared `provision()` engine + `moxxy provision`, reworked `init`
+  (catalog + `ensureProvider` npm-installs on demand), and unbundled the 6
+  API-key providers (published, fixed changeset group). Remaining, tracked in
+  plan `~/.claude/plans/cheerful-booping-nebula.md`: unbundle the ~20 still-private
+  discovery-loadable plugins in batches, pin on-demand installs to the CLI
+  version (currently `latest`), desktop seed pack, TUI install/connect
+  affordances.
+- [med, refactor] `plugin-memory`(+`memory-consolidate`) cannot unbundle as-is:
+  two Plugin instances in one package (discovery loads a single default export),
+  `moxxy memory`/`doctor` import `MemoryStore` directly, and setup builds it
+  with the embedder closure. Needs its own refactor PR (split package or teach
+  discovery multi-plugin entries); until then it stays bundled. `packages/plugin-memory/`.
 - [low, follow-up] EventStore: only the WRITE path routes through the active
   store (`attachSessionPersistence` → `getActive().open()`). The session-scoped
   READS (`restoreSessionEvents`/`readSessionEventPage` in build-session, runner

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,6 +43,7 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.map",
     "README.md"
   ],
   "publishConfig": {

--- a/packages/plugin-cli/src/components/FooterHints.tsx
+++ b/packages/plugin-cli/src/components/FooterHints.tsx
@@ -27,7 +27,7 @@ const HINTS: Record<FooterHintMode, ReadonlyArray<Hint>> = {
     { key: '/help', action: 'commands', priority: 2 },
     { key: 'Esc', action: 'clear / cancel', priority: 3 },
     { key: '⇧Enter', action: 'newline', priority: 4 },
-    { key: '^B', action: 'toggle skills', priority: 5 },
+    { key: '^O', action: 'tool detail', priority: 5 },
   ],
   picker: [
     { key: '↑↓', action: 'navigate', priority: 1 },


### PR DESCRIPTION
Phase 0 of the slim + configure-on-demand program (plan: cheerful-booping-nebula).

## Changes

- **Published tarball slimmed 3x**: `packages/cli` `files` now excludes `dist/**/*.map`. The 16 MB `bin.js.map` was the bulk of the unpacked install. Measured via `npm pack --dry-run`: **5.4 MB → 1.8 MB compressed, 24.9 MB → 7.9 MB unpacked**. `tsup` keeps `sourcemap: true` so local builds still debug normally; nothing at runtime consumes the maps (no `--enable-source-maps` anywhere in cli).
- **Fix wrong footer hint**: the TUI hint row advertised `^B toggle skills`, but Ctrl+B actually drops the first queued message (`SessionView.tsx` commandHotkeys). The always-visible row now advertises `^O tool detail` (expand/collapse tool blocks — always relevant), instead of a queue-contextual key with a false label.
- **TECH_DEBT refresh**: the "Pillar 3 … remains planned but unstarted" note predated #363/#364 (provision engine + API-key provider unbundling). Replaced with actual state + a pointer to the follow-up program plan; logged the `plugin-memory` unbundle blocker (two Plugin instances per package, direct `MemoryStore` imports) as a new item.

## Verification

- Full gate: build 74 tasks, typecheck, lint (0 errors), `check:deps` (0 errors), tests (exit 0).
- `npm pack --dry-run` in `packages/cli`: 23 files, no `.map` entries, sizes as above.