### PR TITLE
feat(tui): /plugins installs for real + version-pinned on-demand installs

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,8 @@
       "@moxxy/core",
       "@moxxy/config",
       "@moxxy/agent",
-      "@moxxy/plugin-provider-*"
+      "@moxxy/plugin-*",
+      "@moxxy/mode-*"
     ]
   ],
   "linked": [],

--- a/.changeset/tui-real-install-pinning.md
+++ b/.changeset/tui-real-install-pinning.md
@@ -1,0 +1,20 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/plugin-plugins-admin': minor
+'@moxxy/cli': minor
+'@moxxy/plugin-cli': patch
+---
+
+The `/plugins` Installable tab now actually installs: selecting a catalog
+plugin npm-installs it into `~/.moxxy/plugins`, persists the enable,
+hot-reloads the plugin host, and reports which contributions registered —
+instead of printing a CLI command to run elsewhere. New optional
+`PluginsAdminView.install` seam (RemoteSession degrades to the printed
+command).
+
+On-demand installs are now version-pinned: bare `@moxxy/*` specs resolve at
+the CLI's own version across every install path (`install_plugin` tool,
+`moxxy plugins install`, init's provider/extras steps, the TUI picker), with
+a 404→latest retry for pins an older CLI can't satisfy. The changeset fixed
+group widens to all `@moxxy/plugin-*` + `@moxxy/mode-*` so future releases
+co-version. New `installPluginPackagePinned` / `pinFirstPartySpec` exports.

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -8,7 +8,7 @@ import { runSetupWizard } from '../wizard/run-setup-wizard.js';
 import { buildProviderAuthContext } from '../wizard/auth-context.js';
 import { PROVIDER_CATALOG, resolveProvider } from '../provision/provider-catalog.js';
 import {
-  installPluginPackage,
+  installPluginPackagePinned,
   resolveCatalogPackageName,
   INSTALLABLE_PLUGIN_CATALOG,
 } from '@moxxy/plugin-plugins-admin';
@@ -129,13 +129,14 @@ async function runInteractiveInit(
       let def = session.providers.list().find((p) => p.name === providerId);
       if (!def) {
         // Catalog-only provider (a slim build hasn't bundled it) — install +
-        // enable it from npm, then it registers on the host reload.
+        // enable it from npm, then it registers on the host reload. First-party
+        // installs pin to the CLI version (404 → retry latest).
         const entry = resolveProvider(providerId);
         if (!entry) return null;
-        // Install the latest published version. (Pinning to the CLI version is
-        // the fixed-changeset-group future state; today providers publish on
-        // their own cadence, so latest is what actually resolves.)
-        await installPluginPackage({ packageName: entry.packageName });
+        await installPluginPackagePinned({
+          packageName: entry.packageName,
+          ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
+        });
         await setPluginEnabled(entry.packageName, true);
         await session.pluginHost.reload();
         def = session.providers.list().find((p) => p.name === providerId);
@@ -186,7 +187,10 @@ async function runInteractiveInit(
     async installPlugins(ids: ReadonlyArray<string>): Promise<void> {
       for (const id of ids) {
         const pkg = resolveCatalogPackageName(id);
-        await installPluginPackage({ packageName: pkg });
+        await installPluginPackagePinned({
+          packageName: pkg,
+          ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
+        });
         await setPluginEnabled(pkg, true);
       }
       // One reload after the batch so the new tools/contributions go live.

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -3,7 +3,7 @@ import {
   buildInstallSpec,
   clearPluginState,
   formatPluginCatalogStatus,
-  installPluginPackage,
+  installPluginPackagePinned,
   loadDisabledPackageNames,
   removePluginPackage,
   resolveCatalogEntry,
@@ -19,6 +19,7 @@ import { isCriticalPackage } from '../setup/critical-packages.js';
 import { printError } from '../errors.js';
 import { runPluginNewCommand } from './plugin-new.js';
 import { colors } from '../colors.js';
+import { cliVersion } from '../version.js';
 import { formatHelp } from './help-format.js';
 
 const HELP = formatHelp({
@@ -171,7 +172,14 @@ async function runInstall(argv: ParsedArgv): Promise<number> {
   });
   const entry = resolveCatalogEntry(target);
   try {
-    const result = await installPluginPackage({ packageName: spec });
+    // Bare first-party specs pin to the CLI version (co-published via the
+    // fixed changeset group); a pin that 404s retries latest with a warning.
+    // Explicit --version/--ref specs pass through untouched.
+    const result = await installPluginPackagePinned({
+      packageName: spec,
+      ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
+      onWarn: (msg) => process.stderr.write(colors.dim(msg) + '\n'),
+    });
     process.stdout.write(
       `installed ${entry?.packageName ?? spec}\n` +
         `source: ${result.installed}\nplugins dir: ${result.dir}\n` +

--- a/packages/cli/src/provision/pin.ts
+++ b/packages/cli/src/provision/pin.ts
@@ -1,28 +1,4 @@
-const FIRST_PARTY_SCOPE = '@moxxy/';
-
-/**
- * Pin a bare first-party plugin install to the CLI's version so a
- * discovery-installed `@moxxy/plugin-*` matches the bundled `@moxxy/sdk` it
- * links against (first-party packages version in lockstep via the fixed
- * changeset group). An explicit version, a spec that already carries one, a
- * non-`@moxxy` package, or a git/path spec is left untouched.
- *
- * Correct only once first-party packages are co-published at the CLI version,
- * so this is used by `provision()` — which installs only providers NOT already
- * loaded (i.e. ones that must come from npm) — and deliberately NOT by the
- * generic `install_plugin` path, where pinning a third-party or
- * differently-versioned package would break the install.
- */
-export function pinFirstPartySpec(
-  packageName: string,
-  version: string | undefined,
-  cliVersion: string | undefined,
-): string {
-  if (version) return `${packageName}@${version}`;
-  // Already carries a version (`@scope/name@1.2.3` → the version `@` is past index 0).
-  if (packageName.lastIndexOf('@') > 0) return packageName;
-  if (cliVersion && packageName.startsWith(FIRST_PARTY_SCOPE)) {
-    return `${packageName}@${cliVersion}`;
-  }
-  return packageName;
-}
+// The pin lives in @moxxy/plugin-plugins-admin so every install path (the
+// install_plugin tool, `moxxy plugins install`, the TUI picker, provision)
+// shares one implementation. Re-exported here to keep provision-local imports.
+export { pinFirstPartySpec } from '@moxxy/plugin-plugins-admin';

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -44,6 +44,8 @@ import { oauthPlugin } from '@moxxy/plugin-oauth';
 import { voiceAdminPlugin } from '@moxxy/plugin-voice-admin';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { BUILTIN_SKILLS_DIR_RESOLVED } from './builtin-skills-dir.js';
+import { buildPluginSnapshot } from './plugin-snapshot.js';
+import { cliVersion } from '../version.js';
 
 export interface BuiltinEntry {
   readonly name: string;
@@ -206,17 +208,11 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
       name: '@moxxy/plugin-plugins-admin',
       plugin: buildPluginsAdminPlugin({
         reload: () => session.pluginHost.reload(),
-        snapshot: () => ({
-          tools: session.tools.list().map((t) => t.name),
-          agents: session.agents.list().map((a) => a.name),
-          providers: session.providers.list().map((p) => p.name),
-          modes: session.modes.list().map((l) => l.name),
-          compactors: session.compactors.list().map((c) => c.name),
-          channels: session.channels.list().map((c) => c.name),
-        }),
+        snapshot: () => buildPluginSnapshot(session),
         setEnabled: setPluginEnabledLive,
         categories: categoryLive.categories,
         setCategoryDefault: categoryLive.setCategoryDefault,
+        ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
       }),
     },
     // Self-update — exposes self_update_* tools so the model can author

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -2,8 +2,12 @@ import { runTurn, type Session } from '@moxxy/core';
 import { MoxxyError, isSelectableMode, type CategoryView, type Plugin } from '@moxxy/sdk';
 import type { MoxxyConfig } from '@moxxy/config';
 import {
+  diffSnapshot,
   INSTALLABLE_PLUGIN_CATALOG,
+  installPluginPackagePinned,
+  resolveCatalogEntry,
   setCategoryDefault as persistCategoryDefault,
+  setPluginEnabled as persistPluginEnabled,
 } from '@moxxy/plugin-plugins-admin';
 import {
   buildSchedulerPlugin,
@@ -36,6 +40,8 @@ import {
 import { buildSetPluginEnabledLive } from './plugin-toggle.js';
 import { CRITICAL_PACKAGES } from './critical-packages.js';
 import { buildWorkflowsIntegration } from './workflows.js';
+import { buildPluginSnapshot } from './plugin-snapshot.js';
+import { cliVersion } from '../version.js';
 
 // Re-exported so existing consumers (register-plugins.ts) keep importing the
 // shape from here unchanged.
@@ -217,11 +223,23 @@ export function buildCategoryDefaultLive(session: Session): CategoryDefaultLive 
   };
 }
 
+/**
+ * The bare package name of an npm spec (`@moxxy/x@1.2.3` → `@moxxy/x`), or
+ * undefined for git/path specs whose installed package name isn't derivable
+ * pre-install (the enable write is skipped — absent means enabled anyway).
+ */
+function bareNameFromSpec(spec: string): string | undefined {
+  const at = spec.lastIndexOf('@');
+  const name = at > 0 ? spec.slice(0, at) : spec;
+  return /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(name) ? name : undefined;
+}
+
 function wirePluginsAdminView(
   session: Session,
   disabledPackages: Set<string>,
   setPluginEnabledLive: (packageName: string, enabled: boolean) => Promise<void>,
   categoryLive: CategoryDefaultLive,
+  logger: BuildBuiltinsArgs['logger'],
 ): void {
   // The live disabled-set, the installable catalog, and the same plug/unplug +
   // swap-default closures the model tools use. A RemoteSession leaves this
@@ -248,6 +266,24 @@ function wirePluginsAdminView(
     setEnabled: setPluginEnabledLive,
     categories: categoryLive.categories,
     setCategoryDefault: categoryLive.setCategoryDefault,
+    // Real install from the picker: npm into ~/.moxxy/plugins (pinned to the
+    // CLI version for first-party packages, 404 → retry latest), persist the
+    // enable, hot-reload, and report which contributions arrived. Same
+    // building blocks as the install_plugin model tool.
+    install: async (idOrSpec) => {
+      const entry = resolveCatalogEntry(idOrSpec);
+      const spec = entry?.installSpec ?? idOrSpec;
+      const packageName = entry?.packageName ?? bareNameFromSpec(spec);
+      const before = buildPluginSnapshot(session);
+      const { installed } = await installPluginPackagePinned({
+        packageName: spec,
+        ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
+        onWarn: (msg) => logger.warn(msg),
+      });
+      if (packageName) await persistPluginEnabled(packageName, true);
+      await session.pluginHost.reload();
+      return { installed, registered: diffSnapshot(before, buildPluginSnapshot(session)) };
+    },
   };
 }
 
@@ -383,7 +419,7 @@ export function buildBuiltinsCore(args: BuildBuiltinsArgs): BuiltBuiltinsCore {
     categoryLive,
   });
 
-  wirePluginsAdminView(session, disabledPackages, setPluginEnabledLive, categoryLive);
+  wirePluginsAdminView(session, disabledPackages, setPluginEnabledLive, categoryLive, logger);
 
   const scheduler = buildSchedulerSlice(session, schedulerRunner, logger);
   entries.push(scheduler.entry);

--- a/packages/cli/src/setup/plugin-snapshot.ts
+++ b/packages/cli/src/setup/plugin-snapshot.ts
@@ -1,0 +1,18 @@
+import type { Session } from '@moxxy/core';
+import type { PluginSnapshot } from '@moxxy/plugin-plugins-admin';
+
+/**
+ * Names of currently-registered contributions, per kind. One implementation
+ * shared by the plugins-admin model tools (install/uninstall diff reporting)
+ * and the `session.pluginsAdmin.install` view closure so the two can't drift.
+ */
+export function buildPluginSnapshot(session: Session): PluginSnapshot {
+  return {
+    tools: session.tools.list().map((t) => t.name),
+    agents: session.agents.list().map((a) => a.name),
+    providers: session.providers.list().map((p) => p.name),
+    modes: session.modes.list().map((l) => l.name),
+    compactors: session.compactors.list().map((c) => c.name),
+    channels: session.channels.list().map((c) => c.name),
+  };
+}

--- a/packages/cli/src/setup/plugins-admin-view.test.ts
+++ b/packages/cli/src/setup/plugins-admin-view.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Session, silentLogger } from '@moxxy/core';
+import { buildMemoryPlugin } from '@moxxy/plugin-memory';
+import {
+  buildVaultPlugin,
+  createStaticKeySource,
+  deriveKey,
+  generateSalt,
+} from '@moxxy/plugin-vault';
+
+// Partial-mock ONLY the npm-touching pieces: the install closure must never
+// shell out in tests, but the catalog/persist helpers the rest of builtins
+// pulls in stay real.
+vi.mock('@moxxy/plugin-plugins-admin', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@moxxy/plugin-plugins-admin')>();
+  return {
+    ...actual,
+    installPluginPackagePinned: vi.fn(async () => ({
+      installed: '@moxxy/mode-goal@1.2.3',
+      dir: '/tmp/plugins',
+    })),
+    setPluginEnabled: vi.fn(async () => undefined),
+  };
+});
+
+import { installPluginPackagePinned, setPluginEnabled } from '@moxxy/plugin-plugins-admin';
+import { buildBuiltinsCore } from './builtins.js';
+
+let tmp: string;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-padmin-view-'));
+  vi.mocked(installPluginPackagePinned).mockClear();
+  vi.mocked(setPluginEnabled).mockClear();
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+function buildFixture() {
+  const session = new Session({ cwd: tmp, logger: silentLogger });
+  const { plugin: vaultPlugin, vault } = buildVaultPlugin({
+    filePath: path.join(tmp, 'vault.json'),
+    keySource: createStaticKeySource(deriveKey('pw', generateSalt())),
+  });
+  const { plugin: memoryPlugin, store: memory } = buildMemoryPlugin({
+    dir: path.join(tmp, 'memory'),
+    embedder: null,
+  });
+  buildBuiltinsCore({
+    session,
+    rawConfig: {},
+    vault,
+    vaultPlugin,
+    memory,
+    memoryPlugin,
+    schedulerRunner: { runPrompt: async () => ({ text: '' }) },
+    webhookRunner: { runPrompt: async () => ({ text: '' }) },
+    logger: silentLogger,
+  });
+  return session;
+}
+
+describe('session.pluginsAdmin.install', () => {
+  it('installs (pinned), persists the enable, hot-reloads, and reports the diff', async () => {
+    const session = buildFixture();
+    const reload = vi.spyOn(session.pluginHost, 'reload').mockImplementation((async () => {
+      // Simulate the reload registering the new mode so the diff picks it up.
+      session.modes.register({
+        name: 'goal',
+        description: 'test',
+        run: async () => undefined,
+      } as never);
+      return undefined as never;
+    }) as never);
+
+    const admin = session.pluginsAdmin;
+    expect(admin?.install).toBeDefined();
+    // 'mode-goal' is not a catalog id today, so it resolves as a bare package
+    // name; the closure passes it through to the pinned installer.
+    const res = await admin!.install!('@moxxy/mode-goal');
+
+    expect(installPluginPackagePinned).toHaveBeenCalledWith(
+      expect.objectContaining({ packageName: '@moxxy/mode-goal' }),
+    );
+    expect(setPluginEnabled).toHaveBeenCalledWith('@moxxy/mode-goal', true);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(res.installed).toBe('@moxxy/mode-goal@1.2.3');
+    expect(res.registered['modes']).toEqual(['goal']);
+  });
+
+  it('skips the enable write for a git/path spec with no derivable package name', async () => {
+    const session = buildFixture();
+    vi.spyOn(session.pluginHost, 'reload').mockResolvedValue(undefined as never);
+    await session.pluginsAdmin!.install!('github:someone/some-plugin');
+    expect(setPluginEnabled).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-cli/src/session/SessionView.tsx
+++ b/packages/plugin-cli/src/session/SessionView.tsx
@@ -206,6 +206,11 @@ export const SessionView: React.FC<SessionViewProps> = ({
 
   const slashSuggestions = React.useMemo(() => buildSlashSuggestions(session), [session]);
 
+  // Guards against a second picker-driven npm install while one is running.
+  // npm itself is mutex-serialized host-side; this is purely UX (one clear
+  // "still installing" notice instead of a silently queued second install).
+  const installInFlightRef = React.useRef(false);
+
   const handlePickerSelect = React.useMemo(
     () =>
       makePickerHandler({
@@ -215,6 +220,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
         setSystemNotice,
         setActiveModelOverride,
         refreshMcpStatus,
+        installInFlightRef,
         ...(onSwitchSession ? { requestSessionSwitch: onSwitchSession } : {}),
       }),
     [session, providerName, refreshMcpStatus, onSwitchSession],

--- a/packages/plugin-cli/src/session/picker-handlers.test.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { makePickerHandler, type PickerHandlerDeps } from './picker-handlers.js';
 import { NEW_SESSION_OPTION_ID } from './sessions-picker.js';
+import { openPluginsPicker } from './run-slash.js';
 
 // picker-handlers imports setCategoryDefault/setProviderModel from @moxxy/config
 // and re-open helpers from run-slash; stub both so the session branch tests stay
@@ -72,5 +73,90 @@ describe('makePickerHandler — sessions branch', () => {
     expect(setSystemNotice).toHaveBeenCalledWith(
       'switching sessions is not available on this session',
     );
+  });
+});
+
+const pluginsPicker = { kind: 'plugins', title: 'Plugins', options: [] } as const;
+
+describe('makePickerHandler — installable-tab install', () => {
+  beforeEach(() => {
+    vi.mocked(openPluginsPicker).mockClear();
+  });
+
+  it('falls back to the printed command when the session cannot install', () => {
+    const setSystemNotice = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({ session: { id: 's', pluginsAdmin: {} } as never, setSystemNotice }),
+    );
+    handle(pluginsPicker, 'telegram::install');
+    expect(setSystemNotice).toHaveBeenCalledWith(
+      'to install: run `moxxy plugins install telegram`',
+    );
+    expect(openPluginsPicker).not.toHaveBeenCalled();
+  });
+
+  it('installs via the admin view, reports registrations, and reopens the picker', async () => {
+    const install = vi.fn(async () => ({
+      installed: '@moxxy/mode-goal@1.0.0',
+      registered: { modes: ['goal'], tools: [] },
+    }));
+    const setSystemNotice = vi.fn();
+    const installInFlightRef = { current: false };
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', pluginsAdmin: { install } } as never,
+        setSystemNotice,
+        installInFlightRef,
+      }),
+    );
+    handle(pluginsPicker, 'mode-goal::install');
+    expect(setSystemNotice).toHaveBeenCalledWith(
+      'installing mode-goal via npm — this can take a minute…',
+    );
+    expect(installInFlightRef.current).toBe(true);
+    await new Promise((r) => setImmediate(r));
+    expect(install).toHaveBeenCalledWith('mode-goal');
+    expect(setSystemNotice).toHaveBeenLastCalledWith(
+      '✓ installed @moxxy/mode-goal@1.0.0 — registered modes: goal',
+    );
+    expect(installInFlightRef.current).toBe(false);
+    expect(openPluginsPicker).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces an install failure and still reopens the picker', async () => {
+    const install = vi.fn(async () => {
+      throw new Error('npm install failed (exit 1): 404');
+    });
+    const setSystemNotice = vi.fn();
+    const installInFlightRef = { current: false };
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', pluginsAdmin: { install } } as never,
+        setSystemNotice,
+        installInFlightRef,
+      }),
+    );
+    handle(pluginsPicker, 'x::install');
+    await new Promise((r) => setImmediate(r));
+    expect(setSystemNotice).toHaveBeenLastCalledWith(
+      'install failed: npm install failed (exit 1): 404',
+    );
+    expect(installInFlightRef.current).toBe(false);
+    expect(openPluginsPicker).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a second install while one is in flight', () => {
+    const install = vi.fn(async () => ({ installed: 'x', registered: {} }));
+    const setSystemNotice = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', pluginsAdmin: { install } } as never,
+        setSystemNotice,
+        installInFlightRef: { current: true },
+      }),
+    );
+    handle(pluginsPicker, 'y::install');
+    expect(install).not.toHaveBeenCalled();
+    expect(setSystemNotice).toHaveBeenCalledWith('an install is already running — hang on…');
   });
 });

--- a/packages/plugin-cli/src/session/picker-handlers.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.ts
@@ -17,6 +17,11 @@ export interface PickerHandlerDeps {
    * Absent ⇒ `/sessions` never opened a picker, so this branch is unreachable.
    */
   requestSessionSwitch?: (target: SessionSwitchTarget) => Promise<void>;
+  /**
+   * True while a picker-driven npm install runs; a second install pick gets a
+   * "still installing" notice instead of silently queueing behind the mutex.
+   */
+  installInFlightRef?: { current: boolean };
 }
 
 export function makePickerHandler(deps: PickerHandlerDeps): (picker: Picker, id: string) => void {
@@ -77,8 +82,10 @@ function handleSessionSelected(id: string, deps: PickerHandlerDeps): void {
 /**
  * Apply a `/plugins` picker selection. Option ids are `<name>::<action>`:
  * `enable` / `disable` plug or unplug the plugin (persisted + hot-applied via
- * session.pluginsAdmin), `install` prints the install command. After a toggle
- * the picker re-opens so the user sees fresh state and can keep toggling.
+ * session.pluginsAdmin), `install` npm-installs + enables + hot-reloads it
+ * (falling back to printing the CLI command when the session can't install —
+ * e.g. a RemoteSession). After a toggle the picker re-opens so the user sees
+ * fresh state and can keep toggling.
  */
 function handlePluginAction(id: string, deps: PickerHandlerDeps): void {
   const admin = deps.session.pluginsAdmin;
@@ -86,7 +93,36 @@ function handlePluginAction(id: string, deps: PickerHandlerDeps): void {
   const name = sep >= 0 ? id.slice(0, sep) : id;
   const action = sep >= 0 ? id.slice(sep + 2) : '';
   if (action === 'install') {
-    deps.setSystemNotice(`to install: run \`moxxy plugins install ${name}\``);
+    const install = admin?.install?.bind(admin);
+    if (!install) {
+      deps.setSystemNotice(`to install: run \`moxxy plugins install ${name}\``);
+      return;
+    }
+    if (deps.installInFlightRef?.current) {
+      deps.setSystemNotice('an install is already running — hang on…');
+      return;
+    }
+    if (deps.installInFlightRef) deps.installInFlightRef.current = true;
+    deps.setSystemNotice(`installing ${name} via npm — this can take a minute…`);
+    void (async () => {
+      try {
+        const res = await install(name);
+        const kinds = Object.entries(res.registered)
+          .filter(([, names]) => names && names.length > 0)
+          .map(([kind, names]) => `${kind}: ${names!.join(', ')}`)
+          .join('; ');
+        deps.setSystemNotice(`✓ installed ${res.installed}${kinds ? ` — registered ${kinds}` : ''}`);
+      } catch (err) {
+        deps.setSystemNotice(
+          `install failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      } finally {
+        if (deps.installInFlightRef) deps.installInFlightRef.current = false;
+        // Re-open with refreshed state: a success moves the plugin from the
+        // Installable tab into Packages; a failure keeps it installable.
+        openPluginsPicker(deps);
+      }
+    })();
     return;
   }
   if (action === 'core') {

--- a/packages/plugin-plugins-admin/src/index.ts
+++ b/packages/plugin-plugins-admin/src/index.ts
@@ -21,15 +21,21 @@ export {
   buildInstallPluginTool,
   buildUninstallPluginTool,
   installPluginPackage,
+  installPluginPackagePinned,
   removePluginPackage,
   userPluginsDir,
   type InstallPluginDeps,
   type InstallPluginPackageOptions,
   type InstallPluginPackageResult,
+  type PinnedInstallOptions,
   type PluginSnapshot,
   type RemovePluginPackageOptions,
   type RemovePluginPackageResult,
 } from './install.js';
+
+export { pinFirstPartySpec } from './pin.js';
+
+export { diffSnapshot, SNAPSHOT_KINDS } from './shared.js';
 
 export {
   buildDisablePluginTool,
@@ -103,6 +109,8 @@ export interface BuildPluginsAdminOpts {
   readonly categories: CategoryDefaultsDeps['categories'];
   /** Persist + apply a category default swap (the `set_default` tool). */
   readonly setCategoryDefault: CategoryDefaultsDeps['setCategoryDefault'];
+  /** Host CLI version — pins bare `@moxxy/*` installs (see {@link InstallPluginDeps}). */
+  readonly cliVersion?: string;
 }
 
 /**
@@ -113,7 +121,11 @@ export interface BuildPluginsAdminOpts {
  * plugin set.
  */
 export function buildPluginsAdminPlugin(opts: BuildPluginsAdminOpts): Plugin {
-  const installDeps: InstallPluginDeps = { reload: opts.reload, snapshot: opts.snapshot };
+  const installDeps: InstallPluginDeps = {
+    reload: opts.reload,
+    snapshot: opts.snapshot,
+    ...(opts.cliVersion ? { cliVersion: opts.cliVersion } : {}),
+  };
   const toggleDeps: PluginToggleDeps = { setEnabled: opts.setEnabled, snapshot: opts.snapshot };
   const defaultsDeps: CategoryDefaultsDeps = {
     categories: opts.categories,

--- a/packages/plugin-plugins-admin/src/install.ts
+++ b/packages/plugin-plugins-admin/src/install.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { createMutex, defineTool, z } from '@moxxy/sdk';
 import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { assertSafeNpmSpec, diffSnapshot, NPM_NAME_RE, type PluginSnapshot } from './shared.js';
+import { pinFirstPartySpec } from './pin.js';
 
 export type { PluginSnapshot } from './shared.js';
 
@@ -58,6 +59,14 @@ export interface InstallPluginDeps {
    * package brought in. Returns names per kind.
    */
   readonly snapshot: () => PluginSnapshot;
+  /**
+   * Host CLI version. When set, bare `@moxxy/*` installs are pinned to it so
+   * an on-demand plugin matches the bundled `@moxxy/sdk` it links against
+   * (first-party packages co-version via the fixed changeset group). A pin
+   * that 404s falls back to `latest` with a warning — see
+   * {@link installPluginPackagePinned}.
+   */
+  readonly cliVersion?: string;
 }
 
 export interface InstallPluginPackageOptions {
@@ -110,6 +119,47 @@ export async function installPluginPackage(
     }
     return { installed: spec, dir };
   });
+}
+
+export interface PinnedInstallOptions {
+  /** Package name or full spec (name@version, git, path). */
+  readonly packageName: string;
+  /** Explicit version/dist-tag — used verbatim, never retried. */
+  readonly version?: string;
+  /** Host CLI version to pin bare `@moxxy/*` names to. */
+  readonly cliVersion?: string;
+  /** Optional abort signal; aborting kills the npm child process. */
+  readonly signal?: AbortSignal;
+  /** Surfaced when an injected pin 404s and the install retries unpinned. */
+  readonly onWarn?: (message: string) => void;
+  /** Injectable install fn for tests; defaults to {@link installPluginPackage}. */
+  readonly installFn?: (opts: InstallPluginPackageOptions) => Promise<InstallPluginPackageResult>;
+}
+
+/**
+ * Install with the first-party version pin applied, falling back to the
+ * unpinned spec when the pin itself is what failed. The retry only happens
+ * for a pin WE injected (bare `@moxxy/*` name + cliVersion): an older CLI can
+ * legitimately pin a package whose first co-versioned release is newer than
+ * the CLI (`@pkg@0.25.0` 404s when the package first ships at 0.26.0). An
+ * explicit user-provided version is never second-guessed.
+ */
+export async function installPluginPackagePinned(
+  opts: PinnedInstallOptions,
+): Promise<InstallPluginPackageResult> {
+  const install = opts.installFn ?? installPluginPackage;
+  const spec = pinFirstPartySpec(opts.packageName, opts.version, opts.cliVersion);
+  const injectedPin = !opts.version && spec !== opts.packageName;
+  try {
+    return await install({ packageName: spec, signal: opts.signal });
+  } catch (err) {
+    if (!injectedPin) throw err;
+    opts.onWarn?.(
+      `pinned install ${spec} failed (${err instanceof Error ? err.message : String(err)}); ` +
+        `retrying latest ${opts.packageName}`,
+    );
+    return await install({ packageName: opts.packageName, signal: opts.signal });
+  }
 }
 
 /**
@@ -174,9 +224,13 @@ export function buildInstallPluginTool(deps: InstallPluginDeps) {
       },
     },
     handler: async ({ packageName, version }, ctx) => {
-      const spec = version ? `${packageName}@${version}` : packageName;
       const before = deps.snapshot();
-      const { installed } = await installPluginPackage({ packageName: spec, signal: ctx.signal });
+      const { installed } = await installPluginPackagePinned({
+        packageName,
+        ...(version ? { version } : {}),
+        ...(deps.cliVersion ? { cliVersion: deps.cliVersion } : {}),
+        signal: ctx.signal,
+      });
       await deps.reload();
       const after = deps.snapshot();
       return {

--- a/packages/plugin-plugins-admin/src/pin.test.ts
+++ b/packages/plugin-plugins-admin/src/pin.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { pinFirstPartySpec } from './pin.js';
+import { installPluginPackagePinned } from './install.js';
+
+describe('pinFirstPartySpec', () => {
+  it('pins a bare first-party name to the CLI version', () => {
+    expect(pinFirstPartySpec('@moxxy/plugin-x', undefined, '1.2.3')).toBe('@moxxy/plugin-x@1.2.3');
+  });
+
+  it('an explicit version wins over the CLI version', () => {
+    expect(pinFirstPartySpec('@moxxy/plugin-x', '0.9.0', '1.2.3')).toBe('@moxxy/plugin-x@0.9.0');
+  });
+
+  it('a spec already carrying a version is untouched', () => {
+    expect(pinFirstPartySpec('@moxxy/plugin-x@2.0.0', undefined, '1.2.3')).toBe(
+      '@moxxy/plugin-x@2.0.0',
+    );
+  });
+
+  it('non-first-party packages are untouched', () => {
+    expect(pinFirstPartySpec('some-pkg', undefined, '1.2.3')).toBe('some-pkg');
+  });
+
+  it('no CLI version → no pin', () => {
+    expect(pinFirstPartySpec('@moxxy/plugin-x', undefined, undefined)).toBe('@moxxy/plugin-x');
+  });
+});
+
+describe('installPluginPackagePinned', () => {
+  it('installs the pinned spec when the pin resolves', async () => {
+    const installFn = vi.fn().mockResolvedValue({ installed: '@moxxy/plugin-x@1.2.3', dir: '/p' });
+    const res = await installPluginPackagePinned({
+      packageName: '@moxxy/plugin-x',
+      cliVersion: '1.2.3',
+      installFn,
+    });
+    expect(installFn).toHaveBeenCalledTimes(1);
+    expect(installFn).toHaveBeenCalledWith(
+      expect.objectContaining({ packageName: '@moxxy/plugin-x@1.2.3' }),
+    );
+    expect(res.installed).toBe('@moxxy/plugin-x@1.2.3');
+  });
+
+  it('retries unpinned (with a warning) when an injected pin fails', async () => {
+    const installFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('npm install failed (exit 1): 404 Not Found'))
+      .mockResolvedValueOnce({ installed: '@moxxy/plugin-x', dir: '/p' });
+    const onWarn = vi.fn();
+    const res = await installPluginPackagePinned({
+      packageName: '@moxxy/plugin-x',
+      cliVersion: '9.9.9',
+      installFn,
+      onWarn,
+    });
+    expect(installFn).toHaveBeenCalledTimes(2);
+    expect(installFn).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ packageName: '@moxxy/plugin-x@9.9.9' }),
+    );
+    expect(installFn).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ packageName: '@moxxy/plugin-x' }),
+    );
+    expect(onWarn).toHaveBeenCalledTimes(1);
+    expect(onWarn.mock.calls[0]![0]).toContain('@moxxy/plugin-x@9.9.9');
+    expect(res.installed).toBe('@moxxy/plugin-x');
+  });
+
+  it('never retries an explicit user version', async () => {
+    const installFn = vi.fn().mockRejectedValue(new Error('404'));
+    const onWarn = vi.fn();
+    await expect(
+      installPluginPackagePinned({
+        packageName: '@moxxy/plugin-x',
+        version: '0.1.0',
+        cliVersion: '1.2.3',
+        installFn,
+        onWarn,
+      }),
+    ).rejects.toThrow('404');
+    expect(installFn).toHaveBeenCalledTimes(1);
+    expect(onWarn).not.toHaveBeenCalled();
+  });
+
+  it('never retries a third-party or already-versioned spec', async () => {
+    const installFn = vi.fn().mockRejectedValue(new Error('boom'));
+    await expect(
+      installPluginPackagePinned({ packageName: 'other-pkg', cliVersion: '1.2.3', installFn }),
+    ).rejects.toThrow('boom');
+    await expect(
+      installPluginPackagePinned({
+        packageName: '@moxxy/plugin-x@2.0.0',
+        cliVersion: '1.2.3',
+        installFn,
+      }),
+    ).rejects.toThrow('boom');
+    expect(installFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/plugin-plugins-admin/src/pin.ts
+++ b/packages/plugin-plugins-admin/src/pin.ts
@@ -1,0 +1,26 @@
+const FIRST_PARTY_SCOPE = '@moxxy/';
+
+/**
+ * Pin a bare first-party plugin install to the CLI's version so a
+ * discovery-installed `@moxxy/plugin-*` matches the bundled `@moxxy/sdk` it
+ * links against (first-party packages version in lockstep via the fixed
+ * changeset group). An explicit version, a spec that already carries one, a
+ * non-`@moxxy` package, or a git/path spec is left untouched.
+ *
+ * A pinned version can 404 when an older CLI installs a package whose first
+ * co-versioned release is newer — callers that inject the pin should retry
+ * unpinned on failure (see `installPluginPackagePinned` in install.ts).
+ */
+export function pinFirstPartySpec(
+  packageName: string,
+  version: string | undefined,
+  cliVersion: string | undefined,
+): string {
+  if (version) return `${packageName}@${version}`;
+  // Already carries a version (`@scope/name@1.2.3` → the version `@` is past index 0).
+  if (packageName.lastIndexOf('@') > 0) return packageName;
+  if (cliVersion && packageName.startsWith(FIRST_PARTY_SCOPE)) {
+    return `${packageName}@${cliVersion}`;
+  }
+  return packageName;
+}

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -350,6 +350,19 @@ export interface PluginsAdminView {
    * (`setActive`). Rejects an unknown category or an unregistered name.
    */
   setCategoryDefault(category: string, name: string): Promise<void>;
+  /**
+   * Install a plugin (npm into `~/.moxxy/plugins`), persist its enable, and
+   * hot-reload the plugin host so its contributions register live. Accepts a
+   * catalog id, a package name, or a full npm spec. Resolves with the spec
+   * that installed plus the diff of contribution names that registered,
+   * keyed by kind (`tools`, `providers`, `modes`, …). Optional capability
+   * per the seam convention: a `RemoteSession` leaves it undefined and the
+   * picker falls back to printing the `moxxy plugins install` command.
+   */
+  install?(idOrSpec: string): Promise<{
+    readonly installed: string;
+    readonly registered: Readonly<Partial<Record<string, ReadonlyArray<string>>>>;
+  }>;
 }
 
 /**


### PR DESCRIPTION
Phase 1 of the slim + configure-on-demand program (plan: cheerful-booping-nebula). Depends on nothing; #394 (Phase 0) is independent.

## What

**The `/plugins` Installable tab now installs.** Selecting a catalog plugin runs the real flow — `npm install` into `~/.moxxy/plugins` (mutex-serialized), persist `plugins.packages.<pkg>.enabled`, `pluginHost.reload()` — and reports exactly which contributions registered (via the same snapshot-diff the `install_plugin` tool uses). Previously it printed `run moxxy plugins install X` and made you leave the TUI.

- New **optional** `PluginsAdminView.install` on the SDK seam — RemoteSession (attach mode) leaves it undefined and the picker falls back to the printed command, per the existing capability-detection convention. No runner protocol change.
- Snapshot closure extracted to a shared `buildPluginSnapshot` (cli/setup/plugin-snapshot.ts) so the model tool and the view can't drift.
- In-flight guard: a second install pick gets a clear notice instead of silently queueing.

**Version pinning switched on everywhere.** `pinFirstPartySpec` moves from cli/provision into `@moxxy/plugin-plugins-admin`; new `installPluginPackagePinned` applies the CLI-version pin on every install path (`install_plugin` tool, `moxxy plugins install`, init's `ensureProvider` + extras step, the TUI picker; `provision()` already pinned). A pin **we** injected that 404s (older CLI, newer package) retries `latest` with a warning; explicit user versions are never second-guessed.

**Fixed changeset group widened** to `@moxxy/plugin-*` + `@moxxy/mode-*` so every future release co-versions the packages the pin points at (private members just version-bump; only public ones publish).

## Verification

- Full gate: build/typecheck/lint/check:deps green; tests green except the documented pre-existing flaky `workflows.test.ts` two-concurrent-runners watcher test (fails under full-suite load only; passes in isolation — reran clean).
- New tests: pin behavior + 404-retry semantics (plugins-admin), install-closure wiring incl. enable-skip for git specs (cli), picker install/fallback/failure/in-flight (plugin-cli). 336 tests across the three touched suites.