### PR TITLE
feat(tui): inline provider connect from /model (install + key + OAuth in-session)

### DIFF
--- a/.changeset/inline-provider-connect.md
+++ b/.changeset/inline-provider-connect.md
@@ -1,0 +1,18 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/core': patch
+'@moxxy/cli': minor
+'@moxxy/plugin-cli': minor
+---
+
+Connect a provider without leaving the TUI: picking an unconnected provider
+in `/model` now opens an inline connect dialog that installs the provider if
+needed (pinned npm install), collects + validates an API key (stored in the
+vault, never persisted plaintext), or drives the provider's OAuth sign-in —
+then completes the exact model switch that was picked. Previously the picker
+told you to quit and run `moxxy init` / `moxxy login` and restart.
+
+New optional `SessionLike.providerSetup` (`ProviderSetupView`) seam; the init
+wizard delegates to the same implementation so wizard and dialog semantics
+cannot drift (a provider without `validateKey` now accepts the key instead of
+pseudo-rejecting it). RemoteSession keeps the old guidance notice.

--- a/.changeset/install-on-first-use.md
+++ b/.changeset/install-on-first-use.md
@@ -1,0 +1,16 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/plugin-plugins-admin': minor
+'@moxxy/cli': patch
+'@moxxy/plugin-cli': patch
+---
+
+Install-on-first-use: asking for a capability whose package isn't installed
+now offers to install it at the point of use instead of failing. `/goal` and
+`/collab` without their mode installed open an install-confirm picker and,
+after the install lands, re-run the original command; the `/mode` picker
+lists catalog-provided modes badged "installs on first use"; `set_default`
+naming an uninstalled contribution throws a typed `PLUGIN_NOT_INSTALLED`
+error carrying the providing package (so the model tool gets an actionable
+hint too). Catalog entries gain a `provides` mapping (category + contribution
+name) that powers the lookup.

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,12 +1,11 @@
 import { bootSessionWithConfig } from '../argv-helpers.js';
 import { closeSession } from '../setup/close-session.js';
 import { canonicalKey } from '../provider-keys.js';
-import { validateProviderKey } from '../validate-key.js';
 import type { ParsedArgv } from '../argv.js';
 import { cliVersion } from '../version.js';
 import { runSetupWizard } from '../wizard/run-setup-wizard.js';
-import { buildProviderAuthContext } from '../wizard/auth-context.js';
-import { PROVIDER_CATALOG, resolveProvider } from '../provision/provider-catalog.js';
+import { buildProviderSetupView } from '../setup/provider-setup.js';
+import { PROVIDER_CATALOG } from '../provision/provider-catalog.js';
 import {
   installPluginPackagePinned,
   resolveCatalogPackageName,
@@ -119,28 +118,21 @@ async function runInteractiveInit(
     { id: 'none', label: 'None', description: 'Keyword recall only' },
   ];
 
+  // One provider-onboarding implementation for every frontend: the wizard
+  // delegates install/key/OAuth to the same ProviderSetupView the TUI's
+  // inline connect dialog drives (attached by setupSessionWithConfig; built
+  // here as a fallback for boot paths that skipped it).
+  const providerSetup = session.providerSetup ?? buildProviderSetupView({ session, vault });
+
   const controller = {
     async saveApiKey(providerId: string, key: string): Promise<void> {
-      await vault.set(canonicalKey(providerId), key, [providerId]);
+      await providerSetup.saveKey(providerId, key);
     },
     async ensureProvider(
       providerId: string,
     ): Promise<{ models: ReadonlyArray<{ id: string; label: string }>; authKind: ProviderAuthKind } | null> {
-      let def = session.providers.list().find((p) => p.name === providerId);
-      if (!def) {
-        // Catalog-only provider (a slim build hasn't bundled it) — install +
-        // enable it from npm, then it registers on the host reload. First-party
-        // installs pin to the CLI version (404 → retry latest).
-        const entry = resolveProvider(providerId);
-        if (!entry) return null;
-        await installPluginPackagePinned({
-          packageName: entry.packageName,
-          ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
-        });
-        await setPluginEnabled(entry.packageName, true);
-        await session.pluginHost.reload();
-        def = session.providers.list().find((p) => p.name === providerId);
-      }
+      if (!(await providerSetup.ensureInstalled(providerId))) return null;
+      const def = session.providers.list().find((p) => p.name === providerId);
       if (!def) return null;
       return {
         models: def.models.map((m) => ({ id: m.id, label: m.id })),
@@ -165,24 +157,12 @@ async function runInteractiveInit(
       providerId: string,
       key: string,
     ): Promise<{ ok: true } | { ok: false; message: string }> {
-      return await validateProviderKey(providerId, key, session.providers);
+      return await providerSetup.testKey(providerId, key);
     },
     async loginOAuth(providerId: string): Promise<void> {
-      const def = session.providers.list().find((p) => p.name === providerId);
-      if (!def || def.auth?.kind !== 'oauth') {
-        throw new MoxxyError({
-          code: 'OAUTH_FLOW_NOT_SUPPORTED',
-          message: `Provider "${providerId}" does not advertise an OAuth flow.`,
-          hint:
-            'This provider expects an API key. Re-run `moxxy init` and provide the key when prompted, ' +
-            'or set the relevant *_API_KEY environment variable.',
-          context: { provider: providerId },
-        });
-      }
-      // We already bailed to runHeadlessInit when stdin wasn't a TTY, so
-      // the browser flow is the default here.
-      const ctx = buildProviderAuthContext(vault, { headless: false });
-      await def.auth.login(ctx);
+      // No io → the shared view falls back to the clack/stdout auth context.
+      // (We already bailed to runHeadlessInit when stdin wasn't a TTY.)
+      await providerSetup.loginOAuth(providerId);
     },
     async installPlugins(ids: ReadonlyArray<string>): Promise<void> {
       for (const id of ids) {

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -23,6 +23,7 @@ import { buildSchedulerRunner } from './setup/scheduler-runner.js';
 import { buildWebhookRunner } from './setup/webhook-runner.js';
 import { registerPlugins } from './setup/register-plugins.js';
 import { activateProvider } from './setup/activate-provider.js';
+import { buildProviderSetupView } from './setup/provider-setup.js';
 import {
   applyPluginsTree,
   assertCriticalFloors,
@@ -183,6 +184,11 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
     progress,
     logger,
   });
+
+  // In-session provider onboarding (install / key entry / OAuth) — backs the
+  // TUI's inline connect dialog and shares its implementation with the init
+  // wizard. Attached after activation so readyProviders exists to mark into.
+  session.providerSetup = buildProviderSetupView({ session, vault });
 
   // Apply the manifest's per-category defaults (mode/compactor/cacheStrategy/
   // workflowExecutor/viewRenderer/tunnelProvider) in one table-driven pass. A

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -3,6 +3,7 @@ import { MoxxyError, isSelectableMode, type CategoryView, type Plugin } from '@m
 import type { MoxxyConfig } from '@moxxy/config';
 import {
   diffSnapshot,
+  findCatalogEntryForContribution,
   INSTALLABLE_PLUGIN_CATALOG,
   installPluginPackagePinned,
   resolveCatalogEntry,
@@ -199,6 +200,18 @@ export function buildCategoryDefaultLive(session: Session): CategoryDefaultLive 
       // For a LIVE category, the name must be registered; persist-only kinds
       // (isolator/channel) are validated against the registry on the next boot.
       if (reg && !reg.list().some((d) => d.name === name)) {
+        // When the catalog knows which package provides it, surface a typed
+        // install affordance instead of a generic error — the TUI turns this
+        // into an "install now?" confirm and the model tool gets the package.
+        const provider = findCatalogEntryForContribution(category, name);
+        if (provider) {
+          throw new MoxxyError({
+            code: 'PLUGIN_NOT_INSTALLED',
+            message: `${category} '${name}' is not installed.`,
+            hint: `Install ${provider.packageName} (install_plugin, or \`moxxy plugins install ${provider.id}\`), then retry.`,
+            context: { category, contribution: name, package: provider.packageName },
+          });
+        }
         throw new MoxxyError({
           code: 'TOOL_ERROR',
           message: `${category} '${name}' is not registered.`,
@@ -262,6 +275,7 @@ function wirePluginsAdminView(
         installSpec: e.installSpec,
         ...(e.kind ? { kind: e.kind } : {}),
         ...(e.startCommand ? { startCommand: e.startCommand } : {}),
+        ...(e.provides ? { provides: e.provides } : {}),
       })),
     setEnabled: setPluginEnabledLive,
     categories: categoryLive.categories,

--- a/packages/cli/src/setup/category-default-live.test.ts
+++ b/packages/cli/src/setup/category-default-live.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { Session, silentLogger } from '@moxxy/core';
+import { MoxxyError } from '@moxxy/sdk';
+import { buildCategoryDefaultLive } from './builtins.js';
+
+describe('buildCategoryDefaultLive — missing-contribution errors', () => {
+  it('throws typed PLUGIN_NOT_INSTALLED when the catalog provides the contribution', async () => {
+    const session = new Session({ cwd: process.cwd(), logger: silentLogger });
+    const live = buildCategoryDefaultLive(session);
+    // Fresh session registers no modes; 'goal' is provided by @moxxy/mode-goal
+    // in the installable catalog.
+    const err = await live.setCategoryDefault('mode', 'goal').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(MoxxyError);
+    expect((err as MoxxyError).code).toBe('PLUGIN_NOT_INSTALLED');
+    expect((err as MoxxyError).context).toMatchObject({
+      category: 'mode',
+      contribution: 'goal',
+      package: '@moxxy/mode-goal',
+    });
+  });
+
+  it('keeps the generic TOOL_ERROR for contributions the catalog does not know', async () => {
+    const session = new Session({ cwd: process.cwd(), logger: silentLogger });
+    const live = buildCategoryDefaultLive(session);
+    const err = await live.setCategoryDefault('mode', 'no-such-mode').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(MoxxyError);
+    expect((err as MoxxyError).code).toBe('TOOL_ERROR');
+  });
+});

--- a/packages/cli/src/setup/provider-setup.test.ts
+++ b/packages/cli/src/setup/provider-setup.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Never let ensureInstalled shell out to npm in tests.
+vi.mock('@moxxy/plugin-plugins-admin', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@moxxy/plugin-plugins-admin')>();
+  return {
+    ...actual,
+    installPluginPackagePinned: vi.fn(async () => ({ installed: 'x', dir: '/p' })),
+    setPluginEnabled: vi.fn(async () => undefined),
+  };
+});
+
+import { installPluginPackagePinned } from '@moxxy/plugin-plugins-admin';
+import { buildProviderSetupView } from './provider-setup.js';
+
+interface FakeDef {
+  name: string;
+  auth?: { kind: 'oauth' | 'apiKey'; login?: (ctx: unknown) => Promise<unknown> };
+  validateKey?: (key: string) => Promise<{ ok: true } | { ok: false; message: string }>;
+  models: [];
+}
+
+function fakeSession(defs: FakeDef[]) {
+  const runtime = new Map<string, string>();
+  return {
+    providers: { list: () => defs },
+    readyProviders: new Set<string>(),
+    requirements: { setRuntime: (k: string, v: string) => runtime.set(k, v) },
+    pluginHost: { reload: vi.fn(async () => undefined) },
+    _runtime: runtime,
+  };
+}
+
+function fakeVault() {
+  const store = new Map<string, string>();
+  return {
+    get: vi.fn(async (k: string) => store.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => void store.set(k, v)),
+    delete: vi.fn(async () => true),
+    _store: store,
+  };
+}
+
+describe('buildProviderSetupView', () => {
+  it('authKind: registered def wins, catalog falls back, unknown is null', () => {
+    const session = fakeSession([{ name: 'custom-oauth', auth: { kind: 'oauth' }, models: [] }]);
+    const view = buildProviderSetupView({ session: session as never, vault: fakeVault() as never });
+    expect(view.authKind('custom-oauth')).toBe('oauth');
+    // 'anthropic' is not registered here but is in PROVIDER_CATALOG (auth: key).
+    expect(view.authKind('anthropic')).toBe('apiKey');
+    expect(view.authKind('local')).toBe('none');
+    expect(view.authKind('definitely-not-a-provider')).toBeNull();
+  });
+
+  it('ensureInstalled: registered → true without installing; catalog → pinned install + enable + reload', async () => {
+    const session = fakeSession([{ name: 'openai', models: [] }]);
+    const view = buildProviderSetupView({ session: session as never, vault: fakeVault() as never });
+    await expect(view.ensureInstalled('openai')).resolves.toBe(true);
+    expect(installPluginPackagePinned).not.toHaveBeenCalled();
+
+    // Catalog-only: install runs; the provider still isn't registered after
+    // reload in this fake, so it reports false.
+    await expect(view.ensureInstalled('anthropic')).resolves.toBe(false);
+    expect(installPluginPackagePinned).toHaveBeenCalledWith(
+      expect.objectContaining({ packageName: '@moxxy/plugin-provider-anthropic' }),
+    );
+    expect(session.pluginHost.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('testKey: provider without validateKey accepts; with validateKey delegates', async () => {
+    const validateKey = vi.fn(async () => ({ ok: false, message: 'bad' }) as const);
+    const session = fakeSession([
+      { name: 'novalidate', models: [] },
+      { name: 'strict', validateKey, models: [] },
+    ]);
+    const view = buildProviderSetupView({ session: session as never, vault: fakeVault() as never });
+    await expect(view.testKey('novalidate', 'k')).resolves.toEqual({ ok: true });
+    await expect(view.testKey('strict', 'k')).resolves.toEqual({ ok: false, message: 'bad' });
+  });
+
+  it('saveKey stores under the canonical vault key and marks the provider ready', async () => {
+    const session = fakeSession([{ name: 'anthropic', models: [] }]);
+    const vault = fakeVault();
+    const view = buildProviderSetupView({ session: session as never, vault: vault as never });
+    await view.saveKey('anthropic', 'sk-ant-123');
+    expect(vault.set).toHaveBeenCalledWith('ANTHROPIC_API_KEY', 'sk-ant-123', ['anthropic']);
+    expect(session.readyProviders.has('anthropic')).toBe(true);
+    expect(session._runtime.get('auth:provider:anthropic')).toBe('ready');
+  });
+
+  it('loginOAuth rejects a non-OAuth provider and routes io into the auth context', async () => {
+    const login = vi.fn(async (ctx: { write: (s: string) => void; prompt?: unknown; headless: boolean }) => {
+      ctx.write('hello');
+      expect(ctx.headless).toBe(false);
+      return { accountId: 'acct' };
+    });
+    const session = fakeSession([
+      { name: 'keyed', models: [] },
+      { name: 'oauthy', auth: { kind: 'oauth', login }, models: [] },
+    ]);
+    const view = buildProviderSetupView({ session: session as never, vault: fakeVault() as never });
+
+    await expect(view.loginOAuth('keyed')).rejects.toThrow(/does not advertise an OAuth flow/);
+
+    const lines: string[] = [];
+    const result = await view.loginOAuth('oauthy', { write: (s) => lines.push(s) });
+    expect(result).toEqual({ accountId: 'acct' });
+    expect(lines).toEqual(['hello']);
+    expect(session.readyProviders.has('oauthy')).toBe(true);
+  });
+});

--- a/packages/cli/src/setup/provider-setup.ts
+++ b/packages/cli/src/setup/provider-setup.ts
@@ -1,0 +1,113 @@
+import type { Session } from '@moxxy/core';
+import {
+  MoxxyError,
+  type ProviderAuthContext,
+  type ProviderConnectIo,
+  type ProviderSetupView,
+} from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { installPluginPackagePinned, setPluginEnabled } from '@moxxy/plugin-plugins-admin';
+import { resolveProvider } from '../provision/provider-catalog.js';
+import { validateProviderKey } from '../validate-key.js';
+import { canonicalKey } from '../provider-keys.js';
+import { buildProviderAuthContext } from '../wizard/auth-context.js';
+import { cliVersion } from '../version.js';
+
+export interface BuildProviderSetupOptions {
+  readonly session: Session;
+  readonly vault: VaultStore;
+}
+
+/**
+ * The one provider-onboarding implementation behind every frontend: the
+ * clack wizard (`moxxy init`), `moxxy login`, and the TUI's inline connect
+ * dialog all route through these closures, so install/key/OAuth semantics
+ * cannot drift between them. Attached as `session.providerSetup` after
+ * provider activation in setup.ts; a RemoteSession never gets one.
+ */
+export function buildProviderSetupView(opts: BuildProviderSetupOptions): ProviderSetupView {
+  const { session, vault } = opts;
+
+  const registered = (providerId: string) =>
+    session.providers.list().find((p) => p.name === providerId);
+
+  const markReady = (providerId: string): void => {
+    session.requirements.setRuntime(`auth:provider:${providerId}`, 'ready');
+    session.readyProviders?.add(providerId);
+  };
+
+  return {
+    authKind: (providerId) => {
+      const def = registered(providerId);
+      if (def) return def.auth?.kind === 'oauth' ? 'oauth' : 'apiKey';
+      const entry = resolveProvider(providerId);
+      if (!entry) return null;
+      return entry.auth === 'oauth' ? 'oauth' : entry.auth === 'none' ? 'none' : 'apiKey';
+    },
+
+    ensureInstalled: async (providerId) => {
+      if (registered(providerId)) return true;
+      // Catalog-only provider (the slim build doesn't bundle it) — install +
+      // enable from npm, pinned to the CLI version (404 → retry latest), then
+      // it registers on the host reload. Mirrors init's ensureProvider.
+      const entry = resolveProvider(providerId);
+      if (!entry) return false;
+      await installPluginPackagePinned({
+        packageName: entry.packageName,
+        ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
+      });
+      await setPluginEnabled(entry.packageName, true);
+      await session.pluginHost.reload();
+      return registered(providerId) !== undefined;
+    },
+
+    testKey: async (providerId, key) => {
+      // A provider without validateKey can't reject a key — accept it rather
+      // than surfacing a "does not support validation" pseudo-rejection.
+      const def = registered(providerId);
+      if (def && !def.validateKey) return { ok: true };
+      return validateProviderKey(providerId, key, session.providers);
+    },
+
+    saveKey: async (providerId, key) => {
+      await vault.set(canonicalKey(providerId), key, [providerId]);
+      markReady(providerId);
+    },
+
+    loginOAuth: async (providerId, io) => {
+      const def = registered(providerId);
+      if (!def || def.auth?.kind !== 'oauth') {
+        throw new MoxxyError({
+          code: 'OAUTH_FLOW_NOT_SUPPORTED',
+          message: `Provider "${providerId}" does not advertise an OAuth flow.`,
+          hint:
+            'This provider expects an API key. Enter it when prompted, or set the ' +
+            'relevant *_API_KEY environment variable.',
+          context: { provider: providerId },
+        });
+      }
+      const ctx = io ? channelAuthContext(vault, io) : buildProviderAuthContext(vault, { headless: false });
+      const result = await def.auth.login(ctx);
+      markReady(providerId);
+      return result;
+    },
+  };
+}
+
+/**
+ * A `ProviderAuthContext` whose output/prompts route into a channel's own UI
+ * (the TUI connect dialog) instead of clack/stdout. Never headless — the
+ * channel IS the interactive surface, so browser-based flows stay available.
+ */
+function channelAuthContext(vault: VaultStore, io: ProviderConnectIo): ProviderAuthContext {
+  return {
+    headless: false,
+    write: io.write,
+    ...(io.prompt ? { prompt: io.prompt } : {}),
+    vault: {
+      get: (key) => vault.get(key),
+      set: (key, value, tags) => vault.set(key, value, tags ? [...tags] : undefined),
+      delete: (key) => vault.delete(key),
+    },
+  };
+}

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -49,6 +49,7 @@ import type {
   ProviderAdminView,
   WorkflowsView,
   PluginsAdminView,
+  ProviderSetupView,
   PendingToolCall,
   PermissionContext,
   PermissionDecision,
@@ -184,6 +185,7 @@ export class Session implements ClientSession, SessionRuntime {
   credentialResolver?: CredentialResolver;
   workflows?: WorkflowsView;
   pluginsAdmin?: PluginsAdminView;
+  providerSetup?: ProviderSetupView;
   readonly dispatcher: HookDispatcherImpl;
   readonly pluginHost: PluginHost;
   private readonly controller = new AbortController();

--- a/packages/plugin-cli/src/components/ProviderConnectDialog.tsx
+++ b/packages/plugin-cli/src/components/ProviderConnectDialog.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { ProviderSetupView } from '@moxxy/sdk';
+import { Colors } from '../theme.js';
+import { Modal } from './Modal.js';
+import {
+  createConnectFlow,
+  type ConnectFlow,
+  type ConnectPhase,
+} from '../session/provider-connect-flow.js';
+
+export interface ProviderConnectDialogProps {
+  readonly providerId: string;
+  readonly setup: ProviderSetupView;
+  /** Provider connected — parent applies the pending model switch + closes. */
+  readonly onSuccess: (note?: string) => void;
+  readonly onCancel: () => void;
+}
+
+/**
+ * Inline provider onboarding, rendered in the InteractiveZone's exclusive
+ * slot (so its useInput never fights PromptInput's raw stdin). All flow
+ * semantics live in provider-connect-flow.ts; this renders phases and
+ * forwards keystrokes.
+ */
+export const ProviderConnectDialog: React.FC<ProviderConnectDialogProps> = ({
+  providerId,
+  setup,
+  onSuccess,
+  onCancel,
+}) => {
+  const [phase, setPhase] = React.useState<ConnectPhase>({ kind: 'installing' });
+  const [buffer, setBuffer] = React.useState('');
+  const flowRef = React.useRef<ConnectFlow | null>(null);
+
+  React.useEffect(() => {
+    const flow = createConnectFlow({
+      setup,
+      providerId,
+      onPhase: setPhase,
+      onSuccess,
+    });
+    flowRef.current = flow;
+    void flow.start();
+    return () => flow.cancel();
+    // The dialog is remounted per providerId by its parent key.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [providerId]);
+
+  const promptActive =
+    phase.kind === 'key-entry' || (phase.kind === 'oauth' && phase.prompt !== null);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      flowRef.current?.cancel();
+      onCancel();
+      return;
+    }
+    if (phase.kind === 'failed') {
+      if (phase.retryable && input.toLowerCase() === 'r') {
+        setBuffer('');
+        void flowRef.current?.start();
+      }
+      return;
+    }
+    if (!promptActive) return;
+    if (phase.kind === 'key-entry' && phase.validating) return;
+    if (key.return) {
+      const value = buffer;
+      setBuffer('');
+      if (phase.kind === 'key-entry') void flowRef.current?.submitKey(value);
+      else flowRef.current?.answerPrompt(value);
+      return;
+    }
+    if (key.backspace || key.delete) {
+      setBuffer((b) => b.slice(0, -1));
+      return;
+    }
+    // Printable input only; ignore control sequences and arrows.
+    if (input && !key.ctrl && !key.meta && !key.tab && !key.upArrow && !key.downArrow) {
+      setBuffer((b) => b + input);
+    }
+  });
+
+  const masked =
+    phase.kind === 'key-entry' || (phase.kind === 'oauth' && phase.prompt?.mask === true);
+  const echo = masked ? '•'.repeat(buffer.length) : buffer;
+
+  return (
+    <Modal title={`connect ${providerId}`}>
+      {phase.kind === 'installing' ? (
+        <Text color={Colors.chrome}>installing {providerId} — this can take a minute…</Text>
+      ) : null}
+
+      {phase.kind === 'key-entry' ? (
+        <Box flexDirection="column">
+          {phase.error ? <Text color={Colors.danger}>{phase.error}</Text> : null}
+          {phase.validating ? (
+            <Text color={Colors.chrome}>validating key…</Text>
+          ) : (
+            <>
+              <Text>
+                API key: <Text color={Colors.active}>{echo}</Text>
+                <Text color={Colors.chrome}>▏</Text>
+              </Text>
+              <Text color={Colors.chrome}>enter save · esc cancel — stored in the vault, never in config</Text>
+            </>
+          )}
+        </Box>
+      ) : null}
+
+      {phase.kind === 'oauth' ? (
+        <Box flexDirection="column">
+          {phase.lines.slice(-8).map((line, i) => (
+            <Text key={`${i}-${line.slice(0, 12)}`} color={Colors.chrome} wrap="truncate-end">
+              {line}
+            </Text>
+          ))}
+          {phase.prompt ? (
+            <>
+              <Text>{phase.prompt.question}</Text>
+              <Text>
+                <Text color={Colors.active}>{echo}</Text>
+                <Text color={Colors.chrome}>▏</Text>
+              </Text>
+            </>
+          ) : (
+            <Text color={Colors.chrome}>waiting for sign-in to complete… esc to cancel</Text>
+          )}
+        </Box>
+      ) : null}
+
+      {phase.kind === 'done' ? (
+        <Text color={Colors.active}>✓ connected{phase.note ? ` — ${phase.note}` : ''}</Text>
+      ) : null}
+
+      {phase.kind === 'failed' ? (
+        <Box flexDirection="column">
+          <Text color={Colors.danger}>{phase.message}</Text>
+          <Text color={Colors.chrome}>{phase.retryable ? 'r retry · esc close' : 'esc close'}</Text>
+        </Box>
+      ) : null}
+    </Modal>
+  );
+};

--- a/packages/plugin-cli/src/session/InteractiveZone.tsx
+++ b/packages/plugin-cli/src/session/InteractiveZone.tsx
@@ -3,6 +3,7 @@ import { Box } from 'ink';
 import type { ClientSession as Session } from '@moxxy/sdk';
 import { PermissionDialog } from '../components/PermissionDialog.js';
 import { ApprovalDialog } from '../components/ApprovalDialog.js';
+import { ProviderConnectDialog } from '../components/ProviderConnectDialog.js';
 import { InputBox } from '../components/InputBox.js';
 import { ListPicker } from '../components/ListPicker.js';
 import { QueueView } from '../components/QueueView.js';
@@ -18,6 +19,10 @@ interface InteractiveZoneProps {
   pendingPermissionDepth: number;
   pendingApproval: PendingApproval | null;
   picker: Picker;
+  /** Inline provider-connect dialog target (SessionView owns the state). */
+  providerConnect: { providerId: string; modelId: string } | null;
+  onProviderConnectSuccess: (note?: string) => void;
+  onProviderConnectCancel: () => void;
   busy: boolean;
   voiceReady: boolean;
   voicePhase: VoicePhase;
@@ -54,6 +59,9 @@ export const InteractiveZone: React.FC<InteractiveZoneProps> = ({
   pendingPermissionDepth,
   pendingApproval,
   picker,
+  providerConnect,
+  onProviderConnectSuccess,
+  onProviderConnectCancel,
   busy,
   voiceReady,
   voicePhase,
@@ -86,6 +94,17 @@ export const InteractiveZone: React.FC<InteractiveZoneProps> = ({
       <ApprovalDialog
         request={pendingApproval.request}
         onDecide={(decision) => onApprovalDecide(decision)}
+      />
+    );
+  }
+  if (providerConnect && session.providerSetup) {
+    return (
+      <ProviderConnectDialog
+        key={providerConnect.providerId}
+        providerId={providerConnect.providerId}
+        setup={session.providerSetup}
+        onSuccess={onProviderConnectSuccess}
+        onCancel={onProviderConnectCancel}
       />
     );
   }

--- a/packages/plugin-cli/src/session/SessionView.tsx
+++ b/packages/plugin-cli/src/session/SessionView.tsx
@@ -220,6 +220,12 @@ export const SessionView: React.FC<SessionViewProps> = ({
     modelId: string;
   } | null>(null);
 
+  // Late-bound so the picker handler (memoized above handleSubmit's
+  // declaration) can re-dispatch a slash line through the normal submit path
+  // — used by install-confirm to re-run the command that hit the missing
+  // capability once its package is installed.
+  const rerunSlashRef = React.useRef<(line: string) => void>(() => undefined);
+
   const handlePickerSelect = React.useMemo(
     () =>
       makePickerHandler({
@@ -231,6 +237,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
         refreshMcpStatus,
         installInFlightRef,
         openProviderConnect: setProviderConnect,
+        rerunSlash: (line) => rerunSlashRef.current(line),
         ...(onSwitchSession ? { requestSessionSwitch: onSwitchSession } : {}),
       }),
     [session, providerName, refreshMcpStatus, onSwitchSession],
@@ -362,6 +369,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
     }
 
     await turn.runTurnWith(text, attachments);
+  };
+  rerunSlashRef.current = (line: string) => {
+    void handleSubmit(line);
   };
 
   // Hand off the prompt the user typed on the splash screen. Fires

--- a/packages/plugin-cli/src/session/SessionView.tsx
+++ b/packages/plugin-cli/src/session/SessionView.tsx
@@ -24,7 +24,7 @@ import { useTurnRunner } from './use-turn-runner.js';
 import { usePermissionQueue } from './use-permission-queue.js';
 import { useGlobalHotkeys } from './use-global-hotkeys.js';
 import { useVoiceInput } from './use-voice-input.js';
-import { makePickerHandler } from './picker-handlers.js';
+import { applyProviderModelSwitch, makePickerHandler } from './picker-handlers.js';
 import { runSlash } from './run-slash.js';
 import { OverlayOrNotice } from './OverlayOrNotice.js';
 import { InteractiveZone } from './InteractiveZone.js';
@@ -211,6 +211,15 @@ export const SessionView: React.FC<SessionViewProps> = ({
   // "still installing" notice instead of a silently queued second install).
   const installInFlightRef = React.useRef(false);
 
+  // Inline provider connect: `/model` on an unconnected provider opens the
+  // ProviderConnectDialog (install + key entry / OAuth) instead of telling
+  // the user to quit and run `moxxy init`. Carries the pending model pick so
+  // a successful connect completes the exact switch the user asked for.
+  const [providerConnect, setProviderConnect] = React.useState<{
+    providerId: string;
+    modelId: string;
+  } | null>(null);
+
   const handlePickerSelect = React.useMemo(
     () =>
       makePickerHandler({
@@ -221,6 +230,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
         setActiveModelOverride,
         refreshMcpStatus,
         installInFlightRef,
+        openProviderConnect: setProviderConnect,
         ...(onSwitchSession ? { requestSessionSwitch: onSwitchSession } : {}),
       }),
     [session, providerName, refreshMcpStatus, onSwitchSession],
@@ -411,6 +421,20 @@ export const SessionView: React.FC<SessionViewProps> = ({
         pendingPermissionDepth={Math.max(0, permissions.pendingPermissions.length - 1)}
         pendingApproval={pendingApproval}
         picker={picker}
+        providerConnect={providerConnect}
+        onProviderConnectSuccess={(note) => {
+          const target = providerConnect;
+          setProviderConnect(null);
+          if (note) setSystemNotice(note);
+          if (target) {
+            void applyProviderModelSwitch(
+              { session, providerName, setSystemNotice, setActiveModelOverride },
+              target.providerId,
+              target.modelId,
+            );
+          }
+        }}
+        onProviderConnectCancel={() => setProviderConnect(null)}
         busy={turn.busy}
         voiceReady={voice.ready}
         voicePhase={voice.phase}

--- a/packages/plugin-cli/src/session/picker-handlers.test.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.test.ts
@@ -76,6 +76,49 @@ describe('makePickerHandler — sessions branch', () => {
   });
 });
 
+const modelPicker = { kind: 'model', title: 'Model', tabs: [] } as const;
+
+describe('makePickerHandler — model branch, unconnected provider', () => {
+  it('opens the inline connect dialog when the session can connect', () => {
+    const openProviderConnect = vi.fn();
+    const setSystemNotice = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({
+        session: {
+          id: 's',
+          readyProviders: new Set(['openai']),
+          providerSetup: {},
+        } as never,
+        openProviderConnect,
+        setSystemNotice,
+      }),
+    );
+    handle(modelPicker, 'anthropic::claude-opus-4-8');
+    expect(openProviderConnect).toHaveBeenCalledWith({
+      providerId: 'anthropic',
+      modelId: 'claude-opus-4-8',
+    });
+    expect(setSystemNotice).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the init/login notice without providerSetup', () => {
+    const openProviderConnect = vi.fn();
+    const setSystemNotice = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', readyProviders: new Set() } as never,
+        openProviderConnect,
+        setSystemNotice,
+      }),
+    );
+    handle(modelPicker, 'anthropic::claude-opus-4-8');
+    expect(openProviderConnect).not.toHaveBeenCalled();
+    expect(setSystemNotice).toHaveBeenCalledWith(
+      expect.stringContaining("anthropic isn't connected"),
+    );
+  });
+});
+
 const pluginsPicker = { kind: 'plugins', title: 'Plugins', options: [] } as const;
 
 describe('makePickerHandler — installable-tab install', () => {

--- a/packages/plugin-cli/src/session/picker-handlers.test.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.test.ts
@@ -203,3 +203,74 @@ describe('makePickerHandler — installable-tab install', () => {
     expect(setSystemNotice).toHaveBeenCalledWith('an install is already running — hang on…');
   });
 });
+
+describe('makePickerHandler — install-on-first-use', () => {
+  it('install-confirm: installs then re-runs the original slash line', async () => {
+    const install = vi.fn(async () => ({ installed: '@moxxy/mode-goal@1.0.0', registered: {} }));
+    const rerunSlash = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', pluginsAdmin: { install } } as never,
+        setSystemNotice: vi.fn(),
+        rerunSlash,
+        installInFlightRef: { current: false },
+      }),
+    );
+    handle(
+      {
+        kind: 'install-confirm',
+        title: 'goal is not installed',
+        catalogId: 'mode-goal',
+        rerun: '/goal ship it',
+        options: [],
+      },
+      'install',
+    );
+    await new Promise((r) => setImmediate(r));
+    expect(install).toHaveBeenCalledWith('mode-goal');
+    expect(rerunSlash).toHaveBeenCalledWith('/goal ship it');
+  });
+
+  it('install-confirm: cancel does nothing', async () => {
+    const install = vi.fn();
+    const rerunSlash = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', pluginsAdmin: { install } } as never,
+        rerunSlash,
+      }),
+    );
+    handle(
+      { kind: 'install-confirm', title: 't', catalogId: 'x', rerun: '/mode x', options: [] },
+      'cancel',
+    );
+    await new Promise((r) => setImmediate(r));
+    expect(install).not.toHaveBeenCalled();
+    expect(rerunSlash).not.toHaveBeenCalled();
+  });
+
+  it('mode picker install:: id installs the providing package then re-runs /mode', async () => {
+    const install = vi.fn(async () => ({ installed: 'x', registered: {} }));
+    const catalog = vi.fn(() => [
+      {
+        id: 'mode-goal',
+        label: 'Goal mode',
+        packageName: '@moxxy/mode-goal',
+        installSpec: '@moxxy/mode-goal',
+        provides: [{ category: 'mode', name: 'goal' }],
+      },
+    ]);
+    const rerunSlash = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', pluginsAdmin: { install, catalog } } as never,
+        rerunSlash,
+        installInFlightRef: { current: false },
+      }),
+    );
+    handle({ kind: 'mode', title: 'Switch mode', options: [] }, 'install::goal');
+    await new Promise((r) => setImmediate(r));
+    expect(install).toHaveBeenCalledWith('mode-goal');
+    expect(rerunSlash).toHaveBeenCalledWith('/mode goal');
+  });
+});

--- a/packages/plugin-cli/src/session/picker-handlers.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.ts
@@ -29,6 +29,13 @@ export interface PickerHandlerDeps {
    * the "run moxxy init/login" notice.
    */
   openProviderConnect?: (target: { providerId: string; modelId: string }) => void;
+  /**
+   * Re-dispatch a slash line through the normal submit path. Used by the
+   * install-confirm picker to re-run the command that hit the missing
+   * capability (e.g. `/goal fix the build`) after the install lands — the
+   * original code path then finds the contribution registered.
+   */
+  rerunSlash?: (line: string) => void;
 }
 
 export function makePickerHandler(deps: PickerHandlerDeps): (picker: Picker, id: string) => void {
@@ -51,10 +58,75 @@ export function makePickerHandler(deps: PickerHandlerDeps): (picker: Picker, id:
     if (kind === 'plugins') {
       return handlePluginAction(id, deps);
     }
+    if (kind === 'install-confirm') {
+      return handleInstallConfirm(picker, id, deps);
+    }
     if (kind === 'sessions') {
       return handleSessionSelected(id, deps);
     }
   };
+}
+
+/**
+ * The shared picker-driven install flow: guard for capability + in-flight,
+ * progress/success/failure notices, then `after` (reopen a picker, re-run a
+ * slash line). Used by the /plugins Installable tab and install-confirm.
+ */
+function runPickerInstall(
+  deps: PickerHandlerDeps,
+  target: string,
+  opts: { reopenPluginsPicker?: boolean; onSuccess?: () => void } = {},
+): void {
+  const admin = deps.session.pluginsAdmin;
+  const install = admin?.install?.bind(admin);
+  if (!install) {
+    deps.setSystemNotice(`to install: run \`moxxy plugins install ${target}\``);
+    return;
+  }
+  if (deps.installInFlightRef?.current) {
+    deps.setSystemNotice('an install is already running — hang on…');
+    return;
+  }
+  if (deps.installInFlightRef) deps.installInFlightRef.current = true;
+  deps.setSystemNotice(`installing ${target} via npm — this can take a minute…`);
+  void (async () => {
+    let ok = false;
+    try {
+      const res = await install(target);
+      const kinds = Object.entries(res.registered)
+        .filter(([, names]) => names && names.length > 0)
+        .map(([kind, names]) => `${kind}: ${names!.join(', ')}`)
+        .join('; ');
+      deps.setSystemNotice(`✓ installed ${res.installed}${kinds ? ` — registered ${kinds}` : ''}`);
+      ok = true;
+    } catch (err) {
+      deps.setSystemNotice(
+        `install failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      if (deps.installInFlightRef) deps.installInFlightRef.current = false;
+      // Re-open with refreshed state: a success moves the plugin from the
+      // Installable tab into Packages; a failure keeps it installable.
+      if (opts.reopenPluginsPicker) openPluginsPicker(deps);
+    }
+    if (ok) opts.onSuccess?.();
+  })();
+}
+
+/**
+ * `install-confirm` picker: `install` runs the shared install flow and, on
+ * success, re-runs the original slash line so the user continues through the
+ * unmodified code path; anything else closes silently.
+ */
+function handleInstallConfirm(
+  picker: Extract<NonNullable<Picker>, { kind: 'install-confirm' }>,
+  id: string,
+  deps: PickerHandlerDeps,
+): void {
+  if (id !== 'install') return;
+  runPickerInstall(deps, picker.catalogId, {
+    onSuccess: () => deps.rerunSlash?.(picker.rerun),
+  });
 }
 
 /**
@@ -100,36 +172,7 @@ function handlePluginAction(id: string, deps: PickerHandlerDeps): void {
   const name = sep >= 0 ? id.slice(0, sep) : id;
   const action = sep >= 0 ? id.slice(sep + 2) : '';
   if (action === 'install') {
-    const install = admin?.install?.bind(admin);
-    if (!install) {
-      deps.setSystemNotice(`to install: run \`moxxy plugins install ${name}\``);
-      return;
-    }
-    if (deps.installInFlightRef?.current) {
-      deps.setSystemNotice('an install is already running — hang on…');
-      return;
-    }
-    if (deps.installInFlightRef) deps.installInFlightRef.current = true;
-    deps.setSystemNotice(`installing ${name} via npm — this can take a minute…`);
-    void (async () => {
-      try {
-        const res = await install(name);
-        const kinds = Object.entries(res.registered)
-          .filter(([, names]) => names && names.length > 0)
-          .map(([kind, names]) => `${kind}: ${names!.join(', ')}`)
-          .join('; ');
-        deps.setSystemNotice(`✓ installed ${res.installed}${kinds ? ` — registered ${kinds}` : ''}`);
-      } catch (err) {
-        deps.setSystemNotice(
-          `install failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      } finally {
-        if (deps.installInFlightRef) deps.installInFlightRef.current = false;
-        // Re-open with refreshed state: a success moves the plugin from the
-        // Installable tab into Packages; a failure keeps it installable.
-        openPluginsPicker(deps);
-      }
-    })();
+    runPickerInstall(deps, name, { reopenPluginsPicker: true });
     return;
   }
   if (action === 'core') {
@@ -341,6 +384,22 @@ export async function applyProviderModelSwitch(
 }
 
 function handleModeSelected(id: string, deps: PickerHandlerDeps): void {
+  // Catalog modes appended by openModePicker carry `install::<name>` ids —
+  // install the providing package, then re-run `/mode <name>`.
+  if (id.startsWith('install::')) {
+    const modeName = id.slice('install::'.length);
+    const entry = deps.session.pluginsAdmin
+      ?.catalog()
+      .find((e) => e.provides?.some((p) => p.category === 'mode' && p.name === modeName));
+    if (!entry) {
+      deps.setSystemNotice(`no installable package provides mode "${modeName}"`);
+      return;
+    }
+    runPickerInstall(deps, entry.id, {
+      onSuccess: () => deps.rerunSlash?.(`/mode ${modeName}`),
+    });
+    return;
+  }
   try {
     deps.session.modes.setActive(id);
     deps.setSystemNotice(`mode → ${id}`);

--- a/packages/plugin-cli/src/session/picker-handlers.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.ts
@@ -22,6 +22,13 @@ export interface PickerHandlerDeps {
    * "still installing" notice instead of silently queueing behind the mutex.
    */
   installInFlightRef?: { current: boolean };
+  /**
+   * Open the inline provider-connect dialog for an unconnected provider
+   * picked in `/model` (SessionView owns the dialog state). Absent — or when
+   * the session has no `providerSetup` capability — the picker falls back to
+   * the "run moxxy init/login" notice.
+   */
+  openProviderConnect?: (target: { providerId: string; modelId: string }) => void;
 }
 
 export function makePickerHandler(deps: PickerHandlerDeps): (picker: Picker, id: string) => void {
@@ -269,10 +276,15 @@ function handleModelSelected(id: string, deps: PickerHandlerDeps): void {
   const [providerId, modelId] = id.split('::');
   if (!providerId || !modelId) return;
   // If the provider wasn't in the boot probe's ready set, switching
-  // would surface a credential error on the next turn. Intercept
-  // here and surface the right configuration command instead.
+  // would surface a credential error on the next turn. Connect it inline
+  // when the session can (install + key entry / OAuth in a dialog);
+  // otherwise surface the right configuration command.
   const ready = deps.session.readyProviders ?? new Set<string>();
   if (!ready.has(providerId)) {
+    if (deps.session.providerSetup && deps.openProviderConnect) {
+      deps.openProviderConnect({ providerId, modelId });
+      return;
+    }
     const cmd =
       providerId === 'openai-codex'
         ? 'moxxy login openai-codex'
@@ -283,34 +295,49 @@ function handleModelSelected(id: string, deps: PickerHandlerDeps): void {
     );
     return;
   }
+  void applyProviderModelSwitch(deps, providerId, modelId);
+}
+
+/**
+ * The provider+model switch tail — credential resolution, instance replace,
+ * setActive, model override, persistence. Shared by the ready-provider path
+ * and the post-connect continuation (the connect dialog's onSuccess), so a
+ * freshly-connected provider switches through EXACTLY the same code.
+ */
+export async function applyProviderModelSwitch(
+  deps: Pick<
+    PickerHandlerDeps,
+    'session' | 'providerName' | 'setSystemNotice' | 'setActiveModelOverride'
+  >,
+  providerId: string,
+  modelId: string,
+): Promise<void> {
   // Provider switches must resolve credentials (vault tokens for
   // OAuth providers, API keys for the rest) before setActive — the
   // registry caches the instance on first activation, so passing
   // empty config strands the new provider without auth. The CLI
   // stashes a credentialResolver on the session at boot.
-  void (async () => {
-    try {
-      if (providerId !== deps.providerName) {
-        const resolver = deps.session.credentialResolver;
-        const cfg = resolver ? await resolver(providerId) : {};
-        // Drop any previously-cached instance for this provider so the
-        // freshly-resolved credentials actually take effect — setActive
-        // alone keeps the first-cached instance.
-        const def = deps.session.providers.list().find((p) => p.name === providerId);
-        if (def) deps.session.providers.replace(def);
-        deps.session.providers.setActive(providerId, cfg);
-      }
-      deps.setActiveModelOverride(modelId);
-      deps.setSystemNotice(`switched to ${providerId}:${modelId}`);
-      // Persist to the unified manifest so the next boot keeps this pick.
-      void setCategoryDefault('provider', providerId).catch(() => undefined);
-      void setProviderModel(providerId, modelId).catch(() => undefined);
-    } catch (err) {
-      deps.setSystemNotice(
-        `failed to switch: ${err instanceof Error ? err.message : String(err)}`,
-      );
+  try {
+    if (providerId !== deps.providerName) {
+      const resolver = deps.session.credentialResolver;
+      const cfg = resolver ? await resolver(providerId) : {};
+      // Drop any previously-cached instance for this provider so the
+      // freshly-resolved credentials actually take effect — setActive
+      // alone keeps the first-cached instance.
+      const def = deps.session.providers.list().find((p) => p.name === providerId);
+      if (def) deps.session.providers.replace(def);
+      deps.session.providers.setActive(providerId, cfg);
     }
-  })();
+    deps.setActiveModelOverride(modelId);
+    deps.setSystemNotice(`switched to ${providerId}:${modelId}`);
+    // Persist to the unified manifest so the next boot keeps this pick.
+    void setCategoryDefault('provider', providerId).catch(() => undefined);
+    void setProviderModel(providerId, modelId).catch(() => undefined);
+  } catch (err) {
+    deps.setSystemNotice(
+      `failed to switch: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 function handleModeSelected(id: string, deps: PickerHandlerDeps): void {

--- a/packages/plugin-cli/src/session/provider-connect-flow.test.ts
+++ b/packages/plugin-cli/src/session/provider-connect-flow.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ProviderSetupView } from '@moxxy/sdk';
+import { createConnectFlow, type ConnectPhase } from './provider-connect-flow.js';
+
+function makeSetup(over: Partial<ProviderSetupView> = {}): ProviderSetupView {
+  return {
+    authKind: vi.fn(() => 'apiKey' as const),
+    ensureInstalled: vi.fn(async () => true),
+    testKey: vi.fn(async () => ({ ok: true }) as const),
+    saveKey: vi.fn(async () => undefined),
+    loginOAuth: vi.fn(async () => ({})),
+    ...over,
+  };
+}
+
+function collector() {
+  const phases: ConnectPhase[] = [];
+  return { phases, onPhase: (p: ConnectPhase) => phases.push(p) };
+}
+
+describe('createConnectFlow — start', () => {
+  it('unknown provider fails non-retryable', async () => {
+    const { phases, onPhase } = collector();
+    const flow = createConnectFlow({
+      setup: makeSetup({ authKind: () => null }),
+      providerId: 'nope',
+      onPhase,
+      onSuccess: vi.fn(),
+    });
+    await flow.start();
+    expect(phases.at(-1)).toMatchObject({ kind: 'failed', retryable: false });
+  });
+
+  it('apiKey provider lands on key-entry after install', async () => {
+    const { phases, onPhase } = collector();
+    const setup = makeSetup();
+    const flow = createConnectFlow({ setup, providerId: 'anthropic', onPhase, onSuccess: vi.fn() });
+    await flow.start();
+    expect(setup.ensureInstalled).toHaveBeenCalledWith('anthropic');
+    expect(phases.map((p) => p.kind)).toEqual(['installing', 'key-entry']);
+  });
+
+  it('a no-auth provider succeeds immediately', async () => {
+    const onSuccess = vi.fn();
+    const { onPhase, phases } = collector();
+    const flow = createConnectFlow({
+      setup: makeSetup({ authKind: () => 'none' }),
+      providerId: 'local',
+      onPhase,
+      onSuccess,
+    });
+    await flow.start();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(phases.at(-1)?.kind).toBe('done');
+  });
+
+  it('install failure is retryable; not-registered-after-install is not', async () => {
+    const { onPhase, phases } = collector();
+    const failing = createConnectFlow({
+      setup: makeSetup({ ensureInstalled: vi.fn(async () => { throw new Error('npm 404'); }) }),
+      providerId: 'x',
+      onPhase,
+      onSuccess: vi.fn(),
+    });
+    await failing.start();
+    expect(phases.at(-1)).toMatchObject({ kind: 'failed', retryable: true });
+
+    const { onPhase: onPhase2, phases: phases2 } = collector();
+    const notRegistered = createConnectFlow({
+      setup: makeSetup({ ensureInstalled: vi.fn(async () => false) }),
+      providerId: 'x',
+      onPhase: onPhase2,
+      onSuccess: vi.fn(),
+    });
+    await notRegistered.start();
+    expect(phases2.at(-1)).toMatchObject({ kind: 'failed', retryable: false });
+  });
+});
+
+describe('createConnectFlow — submitKey', () => {
+  it('valid key: saves and succeeds', async () => {
+    const onSuccess = vi.fn();
+    const setup = makeSetup();
+    const { onPhase } = collector();
+    const flow = createConnectFlow({ setup, providerId: 'anthropic', onPhase, onSuccess });
+    await flow.submitKey('sk-ant-good');
+    expect(setup.saveKey).toHaveBeenCalledWith('anthropic', 'sk-ant-good');
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejected key: stays on key-entry with the error, never saves', async () => {
+    const setup = makeSetup({
+      testKey: vi.fn(async () => ({ ok: false, message: 'invalid x-api-key' }) as const),
+    });
+    const { onPhase, phases } = collector();
+    const onSuccess = vi.fn();
+    const flow = createConnectFlow({ setup, providerId: 'anthropic', onPhase, onSuccess });
+    await flow.submitKey('sk-bad');
+    expect(setup.saveKey).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(phases.at(-1)).toMatchObject({
+      kind: 'key-entry',
+      error: 'anthropic rejected the key: invalid x-api-key',
+    });
+  });
+
+  it('validator unreachable: saves unvalidated and says so', async () => {
+    const setup = makeSetup({
+      testKey: vi.fn(async () => {
+        throw new Error('ECONNREFUSED');
+      }),
+    });
+    const onSuccess = vi.fn();
+    const { onPhase } = collector();
+    const flow = createConnectFlow({ setup, providerId: 'anthropic', onPhase, onSuccess });
+    await flow.submitKey('sk-maybe');
+    expect(setup.saveKey).toHaveBeenCalledWith('anthropic', 'sk-maybe');
+    expect(onSuccess).toHaveBeenCalledWith(expect.stringContaining('saved unvalidated'));
+  });
+
+  it('empty key re-prompts', async () => {
+    const setup = makeSetup();
+    const { onPhase, phases } = collector();
+    const flow = createConnectFlow({ setup, providerId: 'a', onPhase, onSuccess: vi.fn() });
+    await flow.submitKey('   ');
+    expect(setup.testKey).not.toHaveBeenCalled();
+    expect(phases.at(-1)).toMatchObject({ kind: 'key-entry', error: expect.stringContaining('paste') });
+  });
+});
+
+describe('createConnectFlow — oauth', () => {
+  it('streams write lines, resolves a paste-back prompt, succeeds', async () => {
+    const onSuccess = vi.fn();
+    const { onPhase, phases } = collector();
+    const setup = makeSetup({
+      authKind: () => 'oauth',
+      loginOAuth: vi.fn(async (_id, io) => {
+        io!.write('open https://example.test/auth\n');
+        const code = await io!.prompt!('Paste the code:', { mask: true });
+        expect(code).toBe('the-code');
+        return { accountId: 'me@example.test' };
+      }),
+    });
+    const flow = createConnectFlow({ setup, providerId: 'claude-code', onPhase, onSuccess });
+    const started = flow.start();
+    // Wait for the prompt phase to appear, then answer it.
+    await vi.waitFor(() => {
+      const last = phases.at(-1);
+      expect(last?.kind === 'oauth' && last.prompt !== null).toBe(true);
+    });
+    flow.answerPrompt('the-code');
+    await started;
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    const oauthPhases = phases.filter((p) => p.kind === 'oauth');
+    expect(oauthPhases.some((p) => p.kind === 'oauth' && p.lines.some((l) => l.includes('example.test')))).toBe(true);
+  });
+
+  it('login failure is retryable', async () => {
+    const { onPhase, phases } = collector();
+    const setup = makeSetup({
+      authKind: () => 'oauth',
+      loginOAuth: vi.fn(async () => {
+        throw new Error('OAUTH_FLOW_TIMEOUT');
+      }),
+    });
+    const flow = createConnectFlow({ setup, providerId: 'codex', onPhase, onSuccess: vi.fn() });
+    await flow.start();
+    expect(phases.at(-1)).toMatchObject({ kind: 'failed', retryable: true });
+  });
+
+  it('cancel unblocks a pending prompt with an empty answer', async () => {
+    const { onPhase, phases } = collector();
+    let received: string | null = null;
+    const setup = makeSetup({
+      authKind: () => 'oauth',
+      loginOAuth: vi.fn(async (_id, io) => {
+        received = await io!.prompt!('Paste:', {});
+        throw new Error('cancelled');
+      }),
+    });
+    const flow = createConnectFlow({ setup, providerId: 'codex', onPhase, onSuccess: vi.fn() });
+    const started = flow.start();
+    await vi.waitFor(() => {
+      const last = phases.at(-1);
+      expect(last?.kind === 'oauth' && last.prompt !== null).toBe(true);
+    });
+    flow.cancel();
+    await started;
+    expect(received).toBe('');
+    // Cancelled flows go quiet — no failed phase after cancel.
+    expect(phases.at(-1)?.kind).not.toBe('failed');
+  });
+});

--- a/packages/plugin-cli/src/session/provider-connect-flow.ts
+++ b/packages/plugin-cli/src/session/provider-connect-flow.ts
@@ -1,0 +1,175 @@
+import type { ProviderSetupView } from '@moxxy/sdk';
+
+/**
+ * Headless state machine behind the inline provider-connect dialog. All
+ * transitions are emitted through `onPhase` so the Ink component is a dumb
+ * renderer and the semantics stay unit-testable without a terminal.
+ *
+ * Key-entry semantics mirror the init wizard's collectKey: an explicit
+ * provider rejection keeps the user on the input with the error (never
+ * persists a known-bad key); a validator-unreachable failure saves the key
+ * unvalidated (the network, not the key, may be the problem) and says so.
+ */
+export type ConnectPhase =
+  | { readonly kind: 'installing' }
+  | { readonly kind: 'key-entry'; readonly error?: string; readonly validating?: boolean }
+  | {
+      readonly kind: 'oauth';
+      readonly lines: ReadonlyArray<string>;
+      readonly prompt: { readonly question: string; readonly mask: boolean } | null;
+    }
+  | { readonly kind: 'done'; readonly note?: string }
+  | { readonly kind: 'failed'; readonly message: string; readonly retryable: boolean };
+
+export interface ConnectFlowDeps {
+  readonly setup: ProviderSetupView;
+  readonly providerId: string;
+  readonly onPhase: (phase: ConnectPhase) => void;
+  /** Fired exactly once when the provider is connected (key saved / OAuth done / no-auth). */
+  readonly onSuccess: (note?: string) => void;
+}
+
+export interface ConnectFlow {
+  start(): Promise<void>;
+  submitKey(key: string): Promise<void>;
+  /** Answer the pending OAuth paste-back prompt (no-op when none pending). */
+  answerPrompt(answer: string): void;
+  /** Unblocks any pending OAuth prompt with '' (providers treat it as cancel). */
+  cancel(): void;
+}
+
+export function createConnectFlow(deps: ConnectFlowDeps): ConnectFlow {
+  const { setup, providerId, onPhase } = deps;
+  let oauthLines: string[] = [];
+  let promptWaiter: ((answer: string) => void) | null = null;
+  let finished = false;
+
+  const succeed = (note?: string): void => {
+    if (finished) return;
+    finished = true;
+    onPhase({ kind: 'done', ...(note ? { note } : {}) });
+    deps.onSuccess(note);
+  };
+
+  const runOAuth = async (): Promise<void> => {
+    oauthLines = [];
+    onPhase({ kind: 'oauth', lines: [], prompt: null });
+    try {
+      await setup.loginOAuth(providerId, {
+        write: (chunk) => {
+          // Split multi-line chunks so the dialog renders a clean tail.
+          for (const line of chunk.split('\n')) {
+            if (line.trim().length > 0) oauthLines = [...oauthLines, line];
+          }
+          onPhase({ kind: 'oauth', lines: oauthLines, prompt: null });
+        },
+        prompt: (question, opts) =>
+          new Promise<string>((resolve) => {
+            promptWaiter = resolve;
+            onPhase({
+              kind: 'oauth',
+              lines: oauthLines,
+              prompt: { question, mask: opts?.mask === true },
+            });
+          }),
+      });
+      succeed();
+    } catch (err) {
+      if (finished) return;
+      onPhase({
+        kind: 'failed',
+        message: err instanceof Error ? err.message : String(err),
+        retryable: true,
+      });
+    }
+  };
+
+  return {
+    start: async () => {
+      const kind = setup.authKind(providerId);
+      if (kind === null) {
+        onPhase({ kind: 'failed', message: `unknown provider: ${providerId}`, retryable: false });
+        return;
+      }
+      onPhase({ kind: 'installing' });
+      let installed: boolean;
+      try {
+        installed = await setup.ensureInstalled(providerId);
+      } catch (err) {
+        onPhase({
+          kind: 'failed',
+          message: `install failed: ${err instanceof Error ? err.message : String(err)}`,
+          retryable: true,
+        });
+        return;
+      }
+      if (!installed) {
+        onPhase({
+          kind: 'failed',
+          message: `${providerId} did not register after install`,
+          retryable: false,
+        });
+        return;
+      }
+      if (kind === 'none') {
+        // No credentials to collect (e.g. a local model server).
+        succeed();
+        return;
+      }
+      if (kind === 'oauth') {
+        await runOAuth();
+        return;
+      }
+      onPhase({ kind: 'key-entry' });
+    },
+
+    submitKey: async (key) => {
+      const trimmed = key.trim();
+      if (trimmed.length === 0) {
+        onPhase({ kind: 'key-entry', error: 'paste your API key (esc to cancel)' });
+        return;
+      }
+      onPhase({ kind: 'key-entry', validating: true });
+      let rejected: string | null = null;
+      let unreachable: string | null = null;
+      try {
+        const result = await setup.testKey(providerId, trimmed);
+        if (!result.ok) rejected = result.message;
+      } catch (err) {
+        unreachable = err instanceof Error ? err.message : String(err);
+      }
+      if (rejected !== null) {
+        // The provider said the key is bad — never persist it.
+        onPhase({ kind: 'key-entry', error: `${providerId} rejected the key: ${rejected}` });
+        return;
+      }
+      try {
+        await setup.saveKey(providerId, trimmed);
+      } catch (err) {
+        onPhase({
+          kind: 'failed',
+          message: `could not store the key: ${err instanceof Error ? err.message : String(err)}`,
+          retryable: false,
+        });
+        return;
+      }
+      succeed(unreachable ? `saved unvalidated — could not reach the validator (${unreachable})` : undefined);
+    },
+
+    answerPrompt: (answer) => {
+      const waiter = promptWaiter;
+      promptWaiter = null;
+      if (waiter) {
+        onPhase({ kind: 'oauth', lines: oauthLines, prompt: null });
+        waiter(answer);
+      }
+    },
+
+    cancel: () => {
+      finished = true;
+      const waiter = promptWaiter;
+      promptWaiter = null;
+      waiter?.('');
+    },
+  };
+}

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -504,9 +504,11 @@ export function openPluginsPicker(deps: OpenPluginsPickerDeps): void {
 function startGoal(deps: SlashDeps, arg: string): void {
   const objective = arg.trim();
   const GOAL_MODE = 'goal';
-  // The mode is registered globally; if it's somehow absent, say so rather
+  // Missing mode: offer install-on-first-use when the catalog provides it
+  // (post-install the original /goal line re-runs); otherwise say so rather
   // than silently arming yolo with no behavior change.
   if (!deps.session.modes.list().some((m) => m.name === GOAL_MODE)) {
+    if (offerModeInstall(deps, GOAL_MODE, objective ? `/goal ${objective}` : '/goal')) return;
     deps.setSystemNotice('goal mode is not available (mode-goal plugin not loaded)');
     return;
   }
@@ -542,6 +544,13 @@ function startGoal(deps: SlashDeps, arg: string): void {
  */
 function startCollab(deps: SlashDeps, arg: string): void {
   const objective = arg.trim();
+  // The coordinator runner needs the collaborative mode package on disk —
+  // when it isn't loaded here it won't be there either. Offer the install.
+  if (!deps.session.modes.list().some((m) => m.name === 'collaborative')) {
+    if (offerModeInstall(deps, 'collaborative', objective ? `/collab ${objective}` : '/collab')) {
+      return;
+    }
+  }
   if (!deps.requestCollab) {
     deps.setSystemNotice(
       'collaboration runs on its own runner and needs an in-place session switch, which isn’t available here (attached to an external `moxxy serve`). Start it from the desktop Collaborate panel instead.',
@@ -588,6 +597,7 @@ function openModePicker(deps: SlashDeps, arg = ''): void {
       }
       return;
     }
+    if (offerModeInstall(deps, target, `/mode ${target}`)) return;
     deps.setSystemNotice(
       `no mode named "${arg.trim()}". Available: ${modes.map((m) => m.name).join(', ')}`,
     );
@@ -599,7 +609,66 @@ function openModePicker(deps: SlashDeps, arg = ''): void {
     current: s.name === deps.modeName,
     ...(s.description ? { description: truncate(s.description, 80) } : {}),
   }));
+  // Append catalog-provided modes whose package isn't installed, badged so
+  // picking one flows through install-confirm → install → `/mode <name>`.
+  const registered = new Set(all.map((m) => m.name));
+  for (const { entry, name } of installableCatalogModes(deps, registered)) {
+    options.push({
+      id: `install::${name}`,
+      label: name,
+      description: truncate(entry.description, 66),
+      badge: 'installs on first use',
+      badgeColor: 'yellow',
+    });
+  }
   deps.setPicker({ kind: 'mode', title: 'Switch mode', options });
+}
+
+/** Catalog entries providing a mode that isn't registered (install candidates). */
+function installableCatalogModes(
+  deps: SlashDeps,
+  registered: ReadonlySet<string>,
+): Array<{ entry: { id: string; description: string; packageName: string }; name: string }> {
+  const admin = deps.session.pluginsAdmin;
+  if (!admin?.install) return [];
+  const out: Array<{ entry: { id: string; description: string; packageName: string }; name: string }> = [];
+  for (const entry of admin.catalog()) {
+    for (const p of entry.provides ?? []) {
+      if (p.category === 'mode' && !registered.has(p.name)) {
+        out.push({ entry: { id: entry.id, description: entry.label, packageName: entry.packageName }, name: p.name });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Open the install-confirm picker for a mode the catalog can provide.
+ * Returns false when the session can't install or the catalog doesn't know
+ * the mode — callers fall back to their plain notice.
+ */
+function offerModeInstall(deps: SlashDeps, modeName: string, rerun: string): boolean {
+  const admin = deps.session.pluginsAdmin;
+  if (!admin?.install) return false;
+  const entry = admin
+    .catalog()
+    .find((e) => e.provides?.some((p) => p.category === 'mode' && p.name === modeName));
+  if (!entry) return false;
+  deps.setPicker({
+    kind: 'install-confirm',
+    title: `${modeName} mode isn't installed`,
+    catalogId: entry.id,
+    rerun,
+    options: [
+      {
+        id: 'install',
+        label: `Install ${entry.packageName}`,
+        description: 'npm install into ~/.moxxy/plugins, then continue where you left off',
+      },
+      { id: 'cancel', label: 'Cancel', description: 'close without installing' },
+    ],
+  });
+  return true;
 }
 
 /**

--- a/packages/plugin-cli/src/session/types.ts
+++ b/packages/plugin-cli/src/session/types.ts
@@ -48,6 +48,20 @@ export type Picker =
       title: string;
       serverName: string;
       options: ReadonlyArray<ListPickerOption>;
+    }
+  | {
+      /**
+       * Install-on-first-use confirm: a slash command or picker asked for a
+       * capability whose package isn't installed but the catalog provides.
+       * Picking `install` runs the picker install flow, then re-runs `rerun`
+       * (the original slash line) so the user lands exactly where they were
+       * headed — through the unmodified code path.
+       */
+      kind: 'install-confirm';
+      title: string;
+      options: ReadonlyArray<ListPickerOption>;
+      catalogId: string;
+      rerun: string;
     };
 
 export interface PendingPermission {

--- a/packages/plugin-plugins-admin/src/catalog.test.ts
+++ b/packages/plugin-plugins-admin/src/catalog.test.ts
@@ -83,3 +83,26 @@ describe('formatPluginCatalogStatus / buildPluginActionOptions', () => {
     expect(present.map((o) => o.value)).toEqual(['open', 'disable', 'remove', 'back']);
   });
 });
+
+describe('findCatalogEntryForContribution', () => {
+  it('maps a mode contribution to its providing package', async () => {
+    const { findCatalogEntryForContribution } = await import('./catalog.js');
+    expect(findCatalogEntryForContribution('mode', 'goal')?.packageName).toBe('@moxxy/mode-goal');
+    expect(findCatalogEntryForContribution('mode', 'research')?.packageName).toBe(
+      '@moxxy/mode-deep-research',
+    );
+    expect(findCatalogEntryForContribution('provider', 'anthropic')?.packageName).toBe(
+      '@moxxy/plugin-provider-anthropic',
+    );
+    // Multi-contribution package: both zai contributions resolve to one entry.
+    expect(findCatalogEntryForContribution('provider', 'zai-plan')?.packageName).toBe(
+      '@moxxy/plugin-provider-zai',
+    );
+  });
+
+  it('returns undefined for unknown contributions', async () => {
+    const { findCatalogEntryForContribution } = await import('./catalog.js');
+    expect(findCatalogEntryForContribution('mode', 'nope')).toBeUndefined();
+    expect(findCatalogEntryForContribution('compactor', 'goal')).toBeUndefined();
+  });
+});

--- a/packages/plugin-plugins-admin/src/catalog.ts
+++ b/packages/plugin-plugins-admin/src/catalog.ts
@@ -13,6 +13,14 @@ export interface PluginCatalogEntry {
   readonly startCommand?: string;
   readonly defaultPort?: number;
   readonly kind?: 'ui' | 'runtime' | 'cli';
+  /**
+   * Registry contributions this package provides, so surfaces can offer
+   * "install on first use" at the point a missing capability is asked for
+   * (`/goal` without mode-goal, an uninstalled mode in the picker, a
+   * `set_default` naming it). Category = registry kind (`mode`, `provider`,
+   * …), name = the contribution's registered name.
+   */
+  readonly provides?: ReadonlyArray<{ readonly category: string; readonly name: string }>;
 }
 
 export interface PluginPickerOption {
@@ -45,6 +53,7 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'Anthropic Claude models. Needs an API key (moxxy init or /vault).',
     packageName: '@moxxy/plugin-provider-anthropic',
     installSpec: '@moxxy/plugin-provider-anthropic',
+    provides: [{ category: 'provider', name: 'anthropic' }],
   },
   {
     id: 'provider-openai',
@@ -52,6 +61,7 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'OpenAI GPT models. Needs an API key (moxxy init or /vault).',
     packageName: '@moxxy/plugin-provider-openai',
     installSpec: '@moxxy/plugin-provider-openai',
+    provides: [{ category: 'provider', name: 'openai' }],
   },
   {
     id: 'provider-google',
@@ -59,6 +69,7 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'Google Gemini models. Needs an API key (moxxy init or /vault).',
     packageName: '@moxxy/plugin-provider-google',
     installSpec: '@moxxy/plugin-provider-google',
+    provides: [{ category: 'provider', name: 'google' }],
   },
   {
     id: 'provider-xai',
@@ -66,6 +77,7 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'xAI Grok models. Needs an API key (moxxy init or /vault).',
     packageName: '@moxxy/plugin-provider-xai',
     installSpec: '@moxxy/plugin-provider-xai',
+    provides: [{ category: 'provider', name: 'xai' }],
   },
   {
     id: 'provider-zai',
@@ -73,6 +85,10 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'z.ai GLM models (API + GLM Coding Plan). Needs an API key (moxxy init or /vault).',
     packageName: '@moxxy/plugin-provider-zai',
     installSpec: '@moxxy/plugin-provider-zai',
+    provides: [
+      { category: 'provider', name: 'zai' },
+      { category: 'provider', name: 'zai-plan' },
+    ],
   },
   {
     id: 'provider-local',
@@ -80,6 +96,35 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'Local models via an Ollama/OpenAI-compatible server. No API key needed.',
     packageName: '@moxxy/plugin-provider-local',
     installSpec: '@moxxy/plugin-provider-local',
+    provides: [{ category: 'provider', name: 'local' }],
+  },
+  // Modes — bundled today, unbundled in the slim wave. While bundled they're
+  // filtered off the Installable tab (already loaded); the `provides` mapping
+  // is what lets /goal and the mode picker offer install-on-first-use once
+  // the packages move out of the binary.
+  {
+    id: 'mode-goal',
+    label: 'Goal mode',
+    description: 'Autonomous goal loop — tools auto-approved until the objective is delivered.',
+    packageName: '@moxxy/mode-goal',
+    installSpec: '@moxxy/mode-goal',
+    provides: [{ category: 'mode', name: 'goal' }],
+  },
+  {
+    id: 'mode-deep-research',
+    label: 'Research mode',
+    description: 'Fan-out research: parallel queries + synthesis (needs subagents).',
+    packageName: '@moxxy/mode-deep-research',
+    installSpec: '@moxxy/mode-deep-research',
+    provides: [{ category: 'mode', name: 'research' }],
+  },
+  {
+    id: 'mode-collaborative',
+    label: 'Collaborative mode',
+    description: 'Multi-agent collaboration on a dedicated coordinator runner (/collab).',
+    packageName: '@moxxy/mode-collaborative',
+    installSpec: '@moxxy/mode-collaborative',
+    provides: [{ category: 'mode', name: 'collaborative' }],
   },
   {
     id: 'virtual-office',
@@ -105,6 +150,21 @@ export function resolveCatalogPackageName(
   catalog: ReadonlyArray<PluginCatalogEntry> = INSTALLABLE_PLUGIN_CATALOG,
 ): string {
   return resolveCatalogEntry(target, catalog)?.packageName ?? target;
+}
+
+/**
+ * The catalog entry (if any) whose package provides the named contribution —
+ * e.g. ('mode','goal') → the @moxxy/mode-goal entry. Lets surfaces turn a
+ * missing-capability moment into an install offer.
+ */
+export function findCatalogEntryForContribution(
+  category: string,
+  name: string,
+  catalog: ReadonlyArray<PluginCatalogEntry> = INSTALLABLE_PLUGIN_CATALOG,
+): PluginCatalogEntry | undefined {
+  return catalog.find((entry) =>
+    entry.provides?.some((p) => p.category === category && p.name === name),
+  );
 }
 
 export function buildPluginCatalogOptions(input: {

--- a/packages/plugin-plugins-admin/src/index.ts
+++ b/packages/plugin-plugins-admin/src/index.ts
@@ -76,6 +76,7 @@ export {
   buildInstallSpec,
   buildPluginActionOptions,
   buildPluginCatalogOptions,
+  findCatalogEntryForContribution,
   formatPluginCatalogStatus,
   INSTALLABLE_PLUGIN_CATALOG,
   resolveCatalogEntry,

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -49,6 +49,7 @@ export type MoxxyErrorCode =
   | 'CONFIG_INVALID'
   | 'PLUGIN_LOAD_FAILED'
   | 'PLUGIN_PROTECTED'          // a kernel/critical package can't be disabled — swap its default instead
+  | 'PLUGIN_NOT_INSTALLED'      // the capability exists in the catalog but its package isn't installed — offer the install
   | 'UNKNOWN_COMMAND'
   // --- Tool / runtime ---
   | 'TOOL_ERROR'               // a tool handler failed (bad input, not-found, exec error)

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -66,6 +66,8 @@ export type {
   LoadedPluginView,
   CategoryView,
   CategoryItemView,
+  ProviderSetupView,
+  ProviderConnectIo,
 } from './session-like.js';
 
 export type {

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -281,6 +281,9 @@ export interface InstallablePluginView {
   readonly installSpec: string;
   readonly kind?: string;
   readonly startCommand?: string;
+  /** Registry contributions the package provides (category + name) — lets
+   *  surfaces offer install-on-first-use for a missing capability. */
+  readonly provides?: ReadonlyArray<{ readonly category: string; readonly name: string }>;
 }
 
 /** One loaded plugin in {@link PluginsAdminView.loaded}, grouped by `kinds`. */

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -3,7 +3,7 @@ import type { SessionId, TurnId } from './ids.js';
 import type { EventLogReader } from './log.js';
 import type { ApprovalResolver, ModeBadge } from './mode.js';
 import type { PermissionResolver } from './permission.js';
-import type { ModelDescriptor } from './provider.js';
+import type { ModelDescriptor, ProviderKeyValidation } from './provider.js';
 import type { ToolCompactPresentation } from './tool.js';
 
 /**
@@ -365,6 +365,52 @@ export interface PluginsAdminView {
   }>;
 }
 
+/** IO a channel supplies to drive an interactive OAuth flow inside its own
+ *  UI — mirrors `ProviderAuthContext` minus vault/headless (the host adds
+ *  those). `write` receives the flow's progress lines (sign-in URL, status);
+ *  `prompt` renders a single-line input (paste-back codes), masked for
+ *  secrets. */
+export interface ProviderConnectIo {
+  readonly write: (chunk: string) => void;
+  readonly prompt?: (question: string, opts?: { readonly mask?: boolean }) => Promise<string>;
+}
+
+/**
+ * The slice of provider onboarding a channel needs to connect a provider
+ * WITHOUT leaving the session: install it if it's catalog-only, collect +
+ * validate + store an API key, or drive an OAuth sign-in. Present on a local
+ * Session (wired by the CLI, which owns vault + catalog); a `RemoteSession`
+ * leaves {@link SessionLike.providerSetup} undefined and the UI falls back
+ * to pointing at `moxxy init` / `moxxy login`.
+ */
+export interface ProviderSetupView {
+  /**
+   * How this provider authenticates: from its registered def, else the
+   * first-party catalog; null when the id is unknown to both.
+   */
+  authKind(providerId: string): 'apiKey' | 'oauth' | 'none' | null;
+  /**
+   * Ensure the provider's package is registered — a catalog-only provider is
+   * npm-installed + enabled + hot-reloaded. Resolves false when the provider
+   * still isn't registered afterwards (unknown id, bad install).
+   */
+  ensureInstalled(providerId: string): Promise<boolean>;
+  /** Validate a key against the provider's own `validateKey` (if it has one). */
+  testKey(providerId: string, key: string): Promise<ProviderKeyValidation>;
+  /** Store the key in the vault under the provider's canonical key name and
+   *  mark the provider ready for this session. */
+  saveKey(providerId: string, key: string): Promise<void>;
+  /**
+   * Drive the provider's OAuth flow. `io` routes the flow's output/prompts
+   * into the calling channel's UI; when omitted the host's default terminal
+   * prompting applies (the clack path `moxxy init`/`moxxy login` use).
+   */
+  loginOAuth(
+    providerId: string,
+    io?: ProviderConnectIo,
+  ): Promise<{ readonly accountId?: string | null; readonly expiresAt?: number }>;
+}
+
 /**
  * The session surface a `Channel` depends on, decoupled from whether the
  * session runs in-process (`@moxxy/core`'s `Session`) or is a thin-client
@@ -419,4 +465,6 @@ export interface SessionLike {
   workflows?: WorkflowsView;
   /** Plugin-management slice backing the `/plugins` picker. */
   pluginsAdmin?: PluginsAdminView;
+  /** Provider onboarding slice backing in-channel connect (key entry / OAuth). */
+  providerSetup?: ProviderSetupView;
 }


### PR DESCRIPTION
Phase 2 of the slim + configure-on-demand program. **Stacked on #395** (base = its branch; GitHub retargets to development when #395 merges).

## What

Picking an unconnected provider in `/model` now opens an **inline connect dialog** instead of "quit, run `moxxy init`, restart":

1. **Install if needed** — a catalog-only provider is npm-installed (pinned, 404→latest retry), enabled, hot-reloaded.
2. **API-key providers** — masked in-dialog key entry with live validation. Semantics mirror the init wizard's `collectKey`: an explicit provider rejection keeps you on the input and never persists the key; a validator-unreachable failure saves unvalidated and says so. Keys go to the vault under the canonical name — never plaintext config.
3. **OAuth providers** — the provider's own flow runs with its output and paste-back prompts routed into the dialog (`ProviderAuthContext` was already headless-capable; the dialog just supplies `write`/`prompt`).
4. On success the dialog completes the exact model switch that was picked, through the same `applyProviderModelSwitch` tail as the ready path.

## Seams

- New optional `SessionLike.providerSetup` (`ProviderSetupView`) — capability-detected like `pluginsAdmin`; RemoteSession keeps today's guidance notice. No runner protocol change.
- `buildProviderSetupView` (cli/setup/provider-setup.ts) is the ONE implementation; **`moxxy init`'s wizard controller now delegates to it** (ensureProvider/saveApiKey/testKey/loginOAuth), so wizard and dialog cannot drift.
- Vault-locked edge: boot's credential walk pre-warms the vault before Ink mounts in practice; a vault failure inside the dialog surfaces as a failed phase with the message + hint rather than a raw readline fight.

## Verification

- Full gate green: build / typecheck / lint / check:deps / **all tests** (no flake this run).
- New tests: connect-flow state machine (11 cases: key rejected/unreachable/empty, oauth prompt round-trip, cancel semantics, install failures), provider-setup view (authKind fallbacks, pinned install path, canonical vault key + ready marking, non-OAuth rejection, io routing), picker model-branch (dialog opens with capability, notice without).