### PR TITLE
feat(tui): install-on-first-use for missing capabilities (PLUGIN_NOT_INSTALLED)

### DIFF
--- a/.changeset/install-on-first-use.md
+++ b/.changeset/install-on-first-use.md
@@ -1,0 +1,16 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/plugin-plugins-admin': minor
+'@moxxy/cli': patch
+'@moxxy/plugin-cli': patch
+---
+
+Install-on-first-use: asking for a capability whose package isn't installed
+now offers to install it at the point of use instead of failing. `/goal` and
+`/collab` without their mode installed open an install-confirm picker and,
+after the install lands, re-run the original command; the `/mode` picker
+lists catalog-provided modes badged "installs on first use"; `set_default`
+naming an uninstalled contribution throws a typed `PLUGIN_NOT_INSTALLED`
+error carrying the providing package (so the model tool gets an actionable
+hint too). Catalog entries gain a `provides` mapping (category + contribution
+name) that powers the lookup.

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -3,6 +3,7 @@ import { MoxxyError, isSelectableMode, type CategoryView, type Plugin } from '@m
 import type { MoxxyConfig } from '@moxxy/config';
 import {
   diffSnapshot,
+  findCatalogEntryForContribution,
   INSTALLABLE_PLUGIN_CATALOG,
   installPluginPackagePinned,
   resolveCatalogEntry,
@@ -199,6 +200,18 @@ export function buildCategoryDefaultLive(session: Session): CategoryDefaultLive 
       // For a LIVE category, the name must be registered; persist-only kinds
       // (isolator/channel) are validated against the registry on the next boot.
       if (reg && !reg.list().some((d) => d.name === name)) {
+        // When the catalog knows which package provides it, surface a typed
+        // install affordance instead of a generic error — the TUI turns this
+        // into an "install now?" confirm and the model tool gets the package.
+        const provider = findCatalogEntryForContribution(category, name);
+        if (provider) {
+          throw new MoxxyError({
+            code: 'PLUGIN_NOT_INSTALLED',
+            message: `${category} '${name}' is not installed.`,
+            hint: `Install ${provider.packageName} (install_plugin, or \`moxxy plugins install ${provider.id}\`), then retry.`,
+            context: { category, contribution: name, package: provider.packageName },
+          });
+        }
         throw new MoxxyError({
           code: 'TOOL_ERROR',
           message: `${category} '${name}' is not registered.`,
@@ -262,6 +275,7 @@ function wirePluginsAdminView(
         installSpec: e.installSpec,
         ...(e.kind ? { kind: e.kind } : {}),
         ...(e.startCommand ? { startCommand: e.startCommand } : {}),
+        ...(e.provides ? { provides: e.provides } : {}),
       })),
     setEnabled: setPluginEnabledLive,
     categories: categoryLive.categories,

--- a/packages/cli/src/setup/category-default-live.test.ts
+++ b/packages/cli/src/setup/category-default-live.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { Session, silentLogger } from '@moxxy/core';
+import { MoxxyError } from '@moxxy/sdk';
+import { buildCategoryDefaultLive } from './builtins.js';
+
+describe('buildCategoryDefaultLive — missing-contribution errors', () => {
+  it('throws typed PLUGIN_NOT_INSTALLED when the catalog provides the contribution', async () => {
+    const session = new Session({ cwd: process.cwd(), logger: silentLogger });
+    const live = buildCategoryDefaultLive(session);
+    // Fresh session registers no modes; 'goal' is provided by @moxxy/mode-goal
+    // in the installable catalog.
+    const err = await live.setCategoryDefault('mode', 'goal').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(MoxxyError);
+    expect((err as MoxxyError).code).toBe('PLUGIN_NOT_INSTALLED');
+    expect((err as MoxxyError).context).toMatchObject({
+      category: 'mode',
+      contribution: 'goal',
+      package: '@moxxy/mode-goal',
+    });
+  });
+
+  it('keeps the generic TOOL_ERROR for contributions the catalog does not know', async () => {
+    const session = new Session({ cwd: process.cwd(), logger: silentLogger });
+    const live = buildCategoryDefaultLive(session);
+    const err = await live.setCategoryDefault('mode', 'no-such-mode').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(MoxxyError);
+    expect((err as MoxxyError).code).toBe('TOOL_ERROR');
+  });
+});

--- a/packages/plugin-cli/src/session/SessionView.tsx
+++ b/packages/plugin-cli/src/session/SessionView.tsx
@@ -220,6 +220,12 @@ export const SessionView: React.FC<SessionViewProps> = ({
     modelId: string;
   } | null>(null);
 
+  // Late-bound so the picker handler (memoized above handleSubmit's
+  // declaration) can re-dispatch a slash line through the normal submit path
+  // — used by install-confirm to re-run the command that hit the missing
+  // capability once its package is installed.
+  const rerunSlashRef = React.useRef<(line: string) => void>(() => undefined);
+
   const handlePickerSelect = React.useMemo(
     () =>
       makePickerHandler({
@@ -231,6 +237,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
         refreshMcpStatus,
         installInFlightRef,
         openProviderConnect: setProviderConnect,
+        rerunSlash: (line) => rerunSlashRef.current(line),
         ...(onSwitchSession ? { requestSessionSwitch: onSwitchSession } : {}),
       }),
     [session, providerName, refreshMcpStatus, onSwitchSession],
@@ -362,6 +369,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
     }
 
     await turn.runTurnWith(text, attachments);
+  };
+  rerunSlashRef.current = (line: string) => {
+    void handleSubmit(line);
   };
 
   // Hand off the prompt the user typed on the splash screen. Fires

--- a/packages/plugin-cli/src/session/picker-handlers.test.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.test.ts
@@ -203,3 +203,74 @@ describe('makePickerHandler — installable-tab install', () => {
     expect(setSystemNotice).toHaveBeenCalledWith('an install is already running — hang on…');
   });
 });
+
+describe('makePickerHandler — install-on-first-use', () => {
+  it('install-confirm: installs then re-runs the original slash line', async () => {
+    const install = vi.fn(async () => ({ installed: '@moxxy/mode-goal@1.0.0', registered: {} }));
+    const rerunSlash = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', pluginsAdmin: { install } } as never,
+        setSystemNotice: vi.fn(),
+        rerunSlash,
+        installInFlightRef: { current: false },
+      }),
+    );
+    handle(
+      {
+        kind: 'install-confirm',
+        title: 'goal is not installed',
+        catalogId: 'mode-goal',
+        rerun: '/goal ship it',
+        options: [],
+      },
+      'install',
+    );
+    await new Promise((r) => setImmediate(r));
+    expect(install).toHaveBeenCalledWith('mode-goal');
+    expect(rerunSlash).toHaveBeenCalledWith('/goal ship it');
+  });
+
+  it('install-confirm: cancel does nothing', async () => {
+    const install = vi.fn();
+    const rerunSlash = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', pluginsAdmin: { install } } as never,
+        rerunSlash,
+      }),
+    );
+    handle(
+      { kind: 'install-confirm', title: 't', catalogId: 'x', rerun: '/mode x', options: [] },
+      'cancel',
+    );
+    await new Promise((r) => setImmediate(r));
+    expect(install).not.toHaveBeenCalled();
+    expect(rerunSlash).not.toHaveBeenCalled();
+  });
+
+  it('mode picker install:: id installs the providing package then re-runs /mode', async () => {
+    const install = vi.fn(async () => ({ installed: 'x', registered: {} }));
+    const catalog = vi.fn(() => [
+      {
+        id: 'mode-goal',
+        label: 'Goal mode',
+        packageName: '@moxxy/mode-goal',
+        installSpec: '@moxxy/mode-goal',
+        provides: [{ category: 'mode', name: 'goal' }],
+      },
+    ]);
+    const rerunSlash = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', pluginsAdmin: { install, catalog } } as never,
+        rerunSlash,
+        installInFlightRef: { current: false },
+      }),
+    );
+    handle({ kind: 'mode', title: 'Switch mode', options: [] }, 'install::goal');
+    await new Promise((r) => setImmediate(r));
+    expect(install).toHaveBeenCalledWith('mode-goal');
+    expect(rerunSlash).toHaveBeenCalledWith('/mode goal');
+  });
+});

--- a/packages/plugin-cli/src/session/picker-handlers.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.ts
@@ -29,6 +29,13 @@ export interface PickerHandlerDeps {
    * the "run moxxy init/login" notice.
    */
   openProviderConnect?: (target: { providerId: string; modelId: string }) => void;
+  /**
+   * Re-dispatch a slash line through the normal submit path. Used by the
+   * install-confirm picker to re-run the command that hit the missing
+   * capability (e.g. `/goal fix the build`) after the install lands — the
+   * original code path then finds the contribution registered.
+   */
+  rerunSlash?: (line: string) => void;
 }
 
 export function makePickerHandler(deps: PickerHandlerDeps): (picker: Picker, id: string) => void {
@@ -51,10 +58,75 @@ export function makePickerHandler(deps: PickerHandlerDeps): (picker: Picker, id:
     if (kind === 'plugins') {
       return handlePluginAction(id, deps);
     }
+    if (kind === 'install-confirm') {
+      return handleInstallConfirm(picker, id, deps);
+    }
     if (kind === 'sessions') {
       return handleSessionSelected(id, deps);
     }
   };
+}
+
+/**
+ * The shared picker-driven install flow: guard for capability + in-flight,
+ * progress/success/failure notices, then `after` (reopen a picker, re-run a
+ * slash line). Used by the /plugins Installable tab and install-confirm.
+ */
+function runPickerInstall(
+  deps: PickerHandlerDeps,
+  target: string,
+  opts: { reopenPluginsPicker?: boolean; onSuccess?: () => void } = {},
+): void {
+  const admin = deps.session.pluginsAdmin;
+  const install = admin?.install?.bind(admin);
+  if (!install) {
+    deps.setSystemNotice(`to install: run \`moxxy plugins install ${target}\``);
+    return;
+  }
+  if (deps.installInFlightRef?.current) {
+    deps.setSystemNotice('an install is already running — hang on…');
+    return;
+  }
+  if (deps.installInFlightRef) deps.installInFlightRef.current = true;
+  deps.setSystemNotice(`installing ${target} via npm — this can take a minute…`);
+  void (async () => {
+    let ok = false;
+    try {
+      const res = await install(target);
+      const kinds = Object.entries(res.registered)
+        .filter(([, names]) => names && names.length > 0)
+        .map(([kind, names]) => `${kind}: ${names!.join(', ')}`)
+        .join('; ');
+      deps.setSystemNotice(`✓ installed ${res.installed}${kinds ? ` — registered ${kinds}` : ''}`);
+      ok = true;
+    } catch (err) {
+      deps.setSystemNotice(
+        `install failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      if (deps.installInFlightRef) deps.installInFlightRef.current = false;
+      // Re-open with refreshed state: a success moves the plugin from the
+      // Installable tab into Packages; a failure keeps it installable.
+      if (opts.reopenPluginsPicker) openPluginsPicker(deps);
+    }
+    if (ok) opts.onSuccess?.();
+  })();
+}
+
+/**
+ * `install-confirm` picker: `install` runs the shared install flow and, on
+ * success, re-runs the original slash line so the user continues through the
+ * unmodified code path; anything else closes silently.
+ */
+function handleInstallConfirm(
+  picker: Extract<NonNullable<Picker>, { kind: 'install-confirm' }>,
+  id: string,
+  deps: PickerHandlerDeps,
+): void {
+  if (id !== 'install') return;
+  runPickerInstall(deps, picker.catalogId, {
+    onSuccess: () => deps.rerunSlash?.(picker.rerun),
+  });
 }
 
 /**
@@ -100,36 +172,7 @@ function handlePluginAction(id: string, deps: PickerHandlerDeps): void {
   const name = sep >= 0 ? id.slice(0, sep) : id;
   const action = sep >= 0 ? id.slice(sep + 2) : '';
   if (action === 'install') {
-    const install = admin?.install?.bind(admin);
-    if (!install) {
-      deps.setSystemNotice(`to install: run \`moxxy plugins install ${name}\``);
-      return;
-    }
-    if (deps.installInFlightRef?.current) {
-      deps.setSystemNotice('an install is already running — hang on…');
-      return;
-    }
-    if (deps.installInFlightRef) deps.installInFlightRef.current = true;
-    deps.setSystemNotice(`installing ${name} via npm — this can take a minute…`);
-    void (async () => {
-      try {
-        const res = await install(name);
-        const kinds = Object.entries(res.registered)
-          .filter(([, names]) => names && names.length > 0)
-          .map(([kind, names]) => `${kind}: ${names!.join(', ')}`)
-          .join('; ');
-        deps.setSystemNotice(`✓ installed ${res.installed}${kinds ? ` — registered ${kinds}` : ''}`);
-      } catch (err) {
-        deps.setSystemNotice(
-          `install failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      } finally {
-        if (deps.installInFlightRef) deps.installInFlightRef.current = false;
-        // Re-open with refreshed state: a success moves the plugin from the
-        // Installable tab into Packages; a failure keeps it installable.
-        openPluginsPicker(deps);
-      }
-    })();
+    runPickerInstall(deps, name, { reopenPluginsPicker: true });
     return;
   }
   if (action === 'core') {
@@ -341,6 +384,22 @@ export async function applyProviderModelSwitch(
 }
 
 function handleModeSelected(id: string, deps: PickerHandlerDeps): void {
+  // Catalog modes appended by openModePicker carry `install::<name>` ids —
+  // install the providing package, then re-run `/mode <name>`.
+  if (id.startsWith('install::')) {
+    const modeName = id.slice('install::'.length);
+    const entry = deps.session.pluginsAdmin
+      ?.catalog()
+      .find((e) => e.provides?.some((p) => p.category === 'mode' && p.name === modeName));
+    if (!entry) {
+      deps.setSystemNotice(`no installable package provides mode "${modeName}"`);
+      return;
+    }
+    runPickerInstall(deps, entry.id, {
+      onSuccess: () => deps.rerunSlash?.(`/mode ${modeName}`),
+    });
+    return;
+  }
   try {
     deps.session.modes.setActive(id);
     deps.setSystemNotice(`mode → ${id}`);

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -504,9 +504,11 @@ export function openPluginsPicker(deps: OpenPluginsPickerDeps): void {
 function startGoal(deps: SlashDeps, arg: string): void {
   const objective = arg.trim();
   const GOAL_MODE = 'goal';
-  // The mode is registered globally; if it's somehow absent, say so rather
+  // Missing mode: offer install-on-first-use when the catalog provides it
+  // (post-install the original /goal line re-runs); otherwise say so rather
   // than silently arming yolo with no behavior change.
   if (!deps.session.modes.list().some((m) => m.name === GOAL_MODE)) {
+    if (offerModeInstall(deps, GOAL_MODE, objective ? `/goal ${objective}` : '/goal')) return;
     deps.setSystemNotice('goal mode is not available (mode-goal plugin not loaded)');
     return;
   }
@@ -542,6 +544,13 @@ function startGoal(deps: SlashDeps, arg: string): void {
  */
 function startCollab(deps: SlashDeps, arg: string): void {
   const objective = arg.trim();
+  // The coordinator runner needs the collaborative mode package on disk —
+  // when it isn't loaded here it won't be there either. Offer the install.
+  if (!deps.session.modes.list().some((m) => m.name === 'collaborative')) {
+    if (offerModeInstall(deps, 'collaborative', objective ? `/collab ${objective}` : '/collab')) {
+      return;
+    }
+  }
   if (!deps.requestCollab) {
     deps.setSystemNotice(
       'collaboration runs on its own runner and needs an in-place session switch, which isn’t available here (attached to an external `moxxy serve`). Start it from the desktop Collaborate panel instead.',
@@ -588,6 +597,7 @@ function openModePicker(deps: SlashDeps, arg = ''): void {
       }
       return;
     }
+    if (offerModeInstall(deps, target, `/mode ${target}`)) return;
     deps.setSystemNotice(
       `no mode named "${arg.trim()}". Available: ${modes.map((m) => m.name).join(', ')}`,
     );
@@ -599,7 +609,66 @@ function openModePicker(deps: SlashDeps, arg = ''): void {
     current: s.name === deps.modeName,
     ...(s.description ? { description: truncate(s.description, 80) } : {}),
   }));
+  // Append catalog-provided modes whose package isn't installed, badged so
+  // picking one flows through install-confirm → install → `/mode <name>`.
+  const registered = new Set(all.map((m) => m.name));
+  for (const { entry, name } of installableCatalogModes(deps, registered)) {
+    options.push({
+      id: `install::${name}`,
+      label: name,
+      description: truncate(entry.description, 66),
+      badge: 'installs on first use',
+      badgeColor: 'yellow',
+    });
+  }
   deps.setPicker({ kind: 'mode', title: 'Switch mode', options });
+}
+
+/** Catalog entries providing a mode that isn't registered (install candidates). */
+function installableCatalogModes(
+  deps: SlashDeps,
+  registered: ReadonlySet<string>,
+): Array<{ entry: { id: string; description: string; packageName: string }; name: string }> {
+  const admin = deps.session.pluginsAdmin;
+  if (!admin?.install) return [];
+  const out: Array<{ entry: { id: string; description: string; packageName: string }; name: string }> = [];
+  for (const entry of admin.catalog()) {
+    for (const p of entry.provides ?? []) {
+      if (p.category === 'mode' && !registered.has(p.name)) {
+        out.push({ entry: { id: entry.id, description: entry.label, packageName: entry.packageName }, name: p.name });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Open the install-confirm picker for a mode the catalog can provide.
+ * Returns false when the session can't install or the catalog doesn't know
+ * the mode — callers fall back to their plain notice.
+ */
+function offerModeInstall(deps: SlashDeps, modeName: string, rerun: string): boolean {
+  const admin = deps.session.pluginsAdmin;
+  if (!admin?.install) return false;
+  const entry = admin
+    .catalog()
+    .find((e) => e.provides?.some((p) => p.category === 'mode' && p.name === modeName));
+  if (!entry) return false;
+  deps.setPicker({
+    kind: 'install-confirm',
+    title: `${modeName} mode isn't installed`,
+    catalogId: entry.id,
+    rerun,
+    options: [
+      {
+        id: 'install',
+        label: `Install ${entry.packageName}`,
+        description: 'npm install into ~/.moxxy/plugins, then continue where you left off',
+      },
+      { id: 'cancel', label: 'Cancel', description: 'close without installing' },
+    ],
+  });
+  return true;
 }
 
 /**

--- a/packages/plugin-cli/src/session/types.ts
+++ b/packages/plugin-cli/src/session/types.ts
@@ -48,6 +48,20 @@ export type Picker =
       title: string;
       serverName: string;
       options: ReadonlyArray<ListPickerOption>;
+    }
+  | {
+      /**
+       * Install-on-first-use confirm: a slash command or picker asked for a
+       * capability whose package isn't installed but the catalog provides.
+       * Picking `install` runs the picker install flow, then re-runs `rerun`
+       * (the original slash line) so the user lands exactly where they were
+       * headed — through the unmodified code path.
+       */
+      kind: 'install-confirm';
+      title: string;
+      options: ReadonlyArray<ListPickerOption>;
+      catalogId: string;
+      rerun: string;
     };
 
 export interface PendingPermission {

--- a/packages/plugin-plugins-admin/src/catalog.test.ts
+++ b/packages/plugin-plugins-admin/src/catalog.test.ts
@@ -83,3 +83,26 @@ describe('formatPluginCatalogStatus / buildPluginActionOptions', () => {
     expect(present.map((o) => o.value)).toEqual(['open', 'disable', 'remove', 'back']);
   });
 });
+
+describe('findCatalogEntryForContribution', () => {
+  it('maps a mode contribution to its providing package', async () => {
+    const { findCatalogEntryForContribution } = await import('./catalog.js');
+    expect(findCatalogEntryForContribution('mode', 'goal')?.packageName).toBe('@moxxy/mode-goal');
+    expect(findCatalogEntryForContribution('mode', 'research')?.packageName).toBe(
+      '@moxxy/mode-deep-research',
+    );
+    expect(findCatalogEntryForContribution('provider', 'anthropic')?.packageName).toBe(
+      '@moxxy/plugin-provider-anthropic',
+    );
+    // Multi-contribution package: both zai contributions resolve to one entry.
+    expect(findCatalogEntryForContribution('provider', 'zai-plan')?.packageName).toBe(
+      '@moxxy/plugin-provider-zai',
+    );
+  });
+
+  it('returns undefined for unknown contributions', async () => {
+    const { findCatalogEntryForContribution } = await import('./catalog.js');
+    expect(findCatalogEntryForContribution('mode', 'nope')).toBeUndefined();
+    expect(findCatalogEntryForContribution('compactor', 'goal')).toBeUndefined();
+  });
+});

--- a/packages/plugin-plugins-admin/src/catalog.ts
+++ b/packages/plugin-plugins-admin/src/catalog.ts
@@ -13,6 +13,14 @@ export interface PluginCatalogEntry {
   readonly startCommand?: string;
   readonly defaultPort?: number;
   readonly kind?: 'ui' | 'runtime' | 'cli';
+  /**
+   * Registry contributions this package provides, so surfaces can offer
+   * "install on first use" at the point a missing capability is asked for
+   * (`/goal` without mode-goal, an uninstalled mode in the picker, a
+   * `set_default` naming it). Category = registry kind (`mode`, `provider`,
+   * …), name = the contribution's registered name.
+   */
+  readonly provides?: ReadonlyArray<{ readonly category: string; readonly name: string }>;
 }
 
 export interface PluginPickerOption {
@@ -45,6 +53,7 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'Anthropic Claude models. Needs an API key (moxxy init or /vault).',
     packageName: '@moxxy/plugin-provider-anthropic',
     installSpec: '@moxxy/plugin-provider-anthropic',
+    provides: [{ category: 'provider', name: 'anthropic' }],
   },
   {
     id: 'provider-openai',
@@ -52,6 +61,7 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'OpenAI GPT models. Needs an API key (moxxy init or /vault).',
     packageName: '@moxxy/plugin-provider-openai',
     installSpec: '@moxxy/plugin-provider-openai',
+    provides: [{ category: 'provider', name: 'openai' }],
   },
   {
     id: 'provider-google',
@@ -59,6 +69,7 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'Google Gemini models. Needs an API key (moxxy init or /vault).',
     packageName: '@moxxy/plugin-provider-google',
     installSpec: '@moxxy/plugin-provider-google',
+    provides: [{ category: 'provider', name: 'google' }],
   },
   {
     id: 'provider-xai',
@@ -66,6 +77,7 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'xAI Grok models. Needs an API key (moxxy init or /vault).',
     packageName: '@moxxy/plugin-provider-xai',
     installSpec: '@moxxy/plugin-provider-xai',
+    provides: [{ category: 'provider', name: 'xai' }],
   },
   {
     id: 'provider-zai',
@@ -73,6 +85,10 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'z.ai GLM models (API + GLM Coding Plan). Needs an API key (moxxy init or /vault).',
     packageName: '@moxxy/plugin-provider-zai',
     installSpec: '@moxxy/plugin-provider-zai',
+    provides: [
+      { category: 'provider', name: 'zai' },
+      { category: 'provider', name: 'zai-plan' },
+    ],
   },
   {
     id: 'provider-local',
@@ -80,6 +96,35 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'Local models via an Ollama/OpenAI-compatible server. No API key needed.',
     packageName: '@moxxy/plugin-provider-local',
     installSpec: '@moxxy/plugin-provider-local',
+    provides: [{ category: 'provider', name: 'local' }],
+  },
+  // Modes — bundled today, unbundled in the slim wave. While bundled they're
+  // filtered off the Installable tab (already loaded); the `provides` mapping
+  // is what lets /goal and the mode picker offer install-on-first-use once
+  // the packages move out of the binary.
+  {
+    id: 'mode-goal',
+    label: 'Goal mode',
+    description: 'Autonomous goal loop — tools auto-approved until the objective is delivered.',
+    packageName: '@moxxy/mode-goal',
+    installSpec: '@moxxy/mode-goal',
+    provides: [{ category: 'mode', name: 'goal' }],
+  },
+  {
+    id: 'mode-deep-research',
+    label: 'Research mode',
+    description: 'Fan-out research: parallel queries + synthesis (needs subagents).',
+    packageName: '@moxxy/mode-deep-research',
+    installSpec: '@moxxy/mode-deep-research',
+    provides: [{ category: 'mode', name: 'research' }],
+  },
+  {
+    id: 'mode-collaborative',
+    label: 'Collaborative mode',
+    description: 'Multi-agent collaboration on a dedicated coordinator runner (/collab).',
+    packageName: '@moxxy/mode-collaborative',
+    installSpec: '@moxxy/mode-collaborative',
+    provides: [{ category: 'mode', name: 'collaborative' }],
   },
   {
     id: 'virtual-office',
@@ -105,6 +150,21 @@ export function resolveCatalogPackageName(
   catalog: ReadonlyArray<PluginCatalogEntry> = INSTALLABLE_PLUGIN_CATALOG,
 ): string {
   return resolveCatalogEntry(target, catalog)?.packageName ?? target;
+}
+
+/**
+ * The catalog entry (if any) whose package provides the named contribution —
+ * e.g. ('mode','goal') → the @moxxy/mode-goal entry. Lets surfaces turn a
+ * missing-capability moment into an install offer.
+ */
+export function findCatalogEntryForContribution(
+  category: string,
+  name: string,
+  catalog: ReadonlyArray<PluginCatalogEntry> = INSTALLABLE_PLUGIN_CATALOG,
+): PluginCatalogEntry | undefined {
+  return catalog.find((entry) =>
+    entry.provides?.some((p) => p.category === category && p.name === name),
+  );
 }
 
 export function buildPluginCatalogOptions(input: {

--- a/packages/plugin-plugins-admin/src/index.ts
+++ b/packages/plugin-plugins-admin/src/index.ts
@@ -76,6 +76,7 @@ export {
   buildInstallSpec,
   buildPluginActionOptions,
   buildPluginCatalogOptions,
+  findCatalogEntryForContribution,
   formatPluginCatalogStatus,
   INSTALLABLE_PLUGIN_CATALOG,
   resolveCatalogEntry,

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -49,6 +49,7 @@ export type MoxxyErrorCode =
   | 'CONFIG_INVALID'
   | 'PLUGIN_LOAD_FAILED'
   | 'PLUGIN_PROTECTED'          // a kernel/critical package can't be disabled — swap its default instead
+  | 'PLUGIN_NOT_INSTALLED'      // the capability exists in the catalog but its package isn't installed — offer the install
   | 'UNKNOWN_COMMAND'
   // --- Tool / runtime ---
   | 'TOOL_ERROR'               // a tool handler failed (bad input, not-found, exec error)

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -281,6 +281,9 @@ export interface InstallablePluginView {
   readonly installSpec: string;
   readonly kind?: string;
   readonly startCommand?: string;
+  /** Registry contributions the package provides (category + name) — lets
+   *  surfaces offer install-on-first-use for a missing capability. */
+  readonly provides?: ReadonlyArray<{ readonly category: string; readonly name: string }>;
 }
 
 /** One loaded plugin in {@link PluginsAdminView.loaded}, grouped by `kinds`. */


### PR DESCRIPTION
Phase 3 of the slim + configure-on-demand program. **Stacked on #396** (→ #395); merge those first — GitHub retargets down the stack as bases merge.

## What

The "configure on demand" moment: asking for a capability whose package isn't installed now offers the install **at the point of use** — the affordance that makes the upcoming unbundle wave invisible to users.

- **`/goal <objective>` / `/collab <goal>` without the mode installed** → an install-confirm picker naming the providing package; on install (npm, pinned, hot-reload) the **original slash line re-runs through the unmodified code path**, so `/goal ship it` lands in goal mode working on "ship it".
- **`/mode` picker** appends catalog-provided uninstalled modes badged `installs on first use` (`install::<name>` ids); `/mode goal` by name gets the same offer.
- **`set_default` (model tool + picker)** naming an uninstalled contribution now throws typed `PLUGIN_NOT_INSTALLED` with `{category, contribution, package}` context and an actionable hint, instead of a generic `TOOL_ERROR`.
- **Catalog** entries gain `provides: [{category, name}]` (modes + providers mapped, incl. zai's two contributions); new pure `findCatalogEntryForContribution`. Mirrored through `InstallablePluginView`.
- Mode catalog entries are inert while the packages are still bundled (the Installable tab filters loaded packages) — they light up exactly when Phase 4 unbundles them.

## Mechanics

Continuations are implemented as **re-running the original slash line** (`rerunSlash` → the normal submit path) rather than extracted tail functions — zero forked logic, and whatever the command does next (yolo arming, auto-submit, runner switch) happens exactly as if the mode had been installed all along. Shared `runPickerInstall` now backs both the Installable tab and install-confirm.

## Verification

Full gate green (build/typecheck/lint/deps/tests). New tests: catalog contribution lookup (multi-contribution package included), `PLUGIN_NOT_INSTALLED` vs `TOOL_ERROR` from `setCategoryDefault` on a bare session, install-confirm → install → rerun, cancel no-op, `install::` mode-id flow.