### PR TITLE
feat(desktop): bundled plugins seed — offline first run on the slim CLI

### DIFF
--- a/.changeset/desktop-plugins-seed.md
+++ b/.changeset/desktop-plugins-seed.md
@@ -1,0 +1,14 @@
+---
+'@moxxy/desktop-host': minor
+'@moxxy/desktop': minor
+---
+
+Desktop plugins seed: the packaged app now bundles a ready-to-copy npm tree
+of the on-demand first-party plugins (API-key providers + the slim-wave
+unbundled set) and copies it into `~/.moxxy/plugins` on first launch —
+an OFFLINE first run with no npm and no network, while the CLI binary stays
+slim. Idempotent: never overwrites a user-updated install; merges the seed's
+dependency ledger into the target manifest so later `npm install --save`
+runs keep working. Assembled at build time from local pnpm-pack tarballs
+(including the sdk/core closure), so the desktop build does not depend on
+the same release's npm publish having landed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,6 +374,16 @@ jobs:
           # times". Drop the one symlink that points outside the bundle.
           rm -f apps/desktop/resources/moxxy-cli/node_modules/.pnpm/node_modules/@moxxy/cli
 
+      # Ready-to-copy npm tree of the on-demand first-party plugins (providers,
+      # modes, view, …) the desktop expects out of the box. Copied into
+      # ~/.moxxy/plugins on first launch by @moxxy/desktop-host seed-plugins —
+      # an OFFLINE first run (no npm, no network) while the CLI stays slim.
+      # Assembled from local pnpm-pack tarballs (incl. the sdk/core closure)
+      # so it does not depend on this release's npm publish having landed.
+      - name: Bundle plugins seed
+        shell: bash
+        run: node apps/desktop/scripts/bundle-plugins-seed.mjs
+
       # Developer ID signing + notarization turn on ONLY when the CSC_LINK
       # secret exists; otherwise the build stays ad-hoc/unsigned (today's
       # behaviour). See docs/desktop-code-signing.md. macOS only.

--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -5,3 +5,4 @@ release
 .turbo
 .vite
 resources/moxxy-cli/
+resources/plugins-seed/

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -45,6 +45,7 @@ import {
   clerkAccountPortalHost,
   installAccountPortalRecovery,
   preferredCliEntry,
+  seedPluginsFromResources,
   ensureDesktopVaultKey,
   activateManagedNode,
   startLoopbackServer,
@@ -628,6 +629,26 @@ app.whenReady().then(async () => {
   // can't answer — the first provider install otherwise fails on Windows (no OS
   // keychain) with "vault: passphrase required but no interactive terminal".
   ensureDesktopVaultKey();
+
+  // First-launch plugin seeding: copy the bundled plugins-seed npm tree into
+  // ~/.moxxy/plugins so the slim CLI runner finds the on-demand plugins
+  // (providers, modes, view, …) OFFLINE — no npm, no network. Idempotent and
+  // never overwrites a user-updated install; must complete before any runner
+  // spawns so the first session's discovery scan sees the seeded packages.
+  if (app.isPackaged) {
+    const moxxyHome =
+      process.env.MOXXY_HOME?.trim() || path.join(app.getPath('home'), '.moxxy');
+    try {
+      await seedPluginsFromResources({
+        resourcesPath: process.resourcesPath,
+        moxxyHome,
+        log: (msg) => console.log(`[moxxy] ${msg}`),
+      });
+    } catch (err) {
+      // Seeding is best-effort: a failure degrades to on-demand npm installs.
+      console.warn('[moxxy] plugins-seed copy failed:', err);
+    }
+  }
 
   // If the user auto-installed Node on a previous run (onboarding's "Install
   // automatically"), put that managed Node back on PATH before any runner

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,7 +23,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "bundle:cli": "rm -rf resources/moxxy-cli && pnpm --filter @moxxy/cli --legacy deploy --prod resources/moxxy-cli && rm -f resources/moxxy-cli/node_modules/.pnpm/node_modules/@moxxy/cli",
-    "clean": "rm -rf dist dist-electron .turbo node_modules/.vite"
+    "clean": "rm -rf dist dist-electron .turbo node_modules/.vite",
+    "bundle:plugins-seed": "node scripts/bundle-plugins-seed.mjs"
   },
   "dependencies": {
     "@clerk/clerk-react": "^5.0.0",
@@ -107,6 +108,10 @@
       {
         "from": "resources/moxxy-cli",
         "to": "moxxy-cli"
+      },
+      {
+        "from": "resources/plugins-seed",
+        "to": "plugins-seed"
       }
     ],
     "mac": {

--- a/apps/desktop/scripts/bundle-plugins-seed.mjs
+++ b/apps/desktop/scripts/bundle-plugins-seed.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * Assemble `resources/plugins-seed` — a ready-to-copy npm prefix tree of the
+ * on-demand first-party plugins the desktop expects out of the box. The
+ * packaged app copies it into `~/.moxxy/plugins` on first launch (see
+ * `@moxxy/desktop-host` seed-plugins.ts), giving an OFFLINE first run: no
+ * npm, no network, while the npm CLI itself stays slim.
+ *
+ * Run from the repo root (workspace context required):
+ *   node apps/desktop/scripts/bundle-plugins-seed.mjs
+ *
+ * Mechanics: `pnpm pack` each seed package (rewrites workspace:* to exact
+ * versions) plus its first-party dep closure (sdk/core/vault), then
+ * `npm install --prefix resources/plugins-seed <tarballs...>` so third-party
+ * deps resolve at BUILD time. Installing the closure from local tarballs
+ * (not the registry) keeps this runnable before the release publishes.
+ *
+ * IMPORTANT: build the workspace first — a package packed without dist/ is
+ * silently skipped by plugin discovery at runtime.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+/** On-demand plugins seeded into the desktop. Extend as batches unbundle. */
+const SEED_PLUGINS = [
+  // API-key providers (init/provision normally install these on demand).
+  'plugin-provider-anthropic',
+  'plugin-provider-openai',
+  'plugin-provider-google',
+  'plugin-provider-xai',
+  'plugin-provider-zai',
+  'plugin-provider-local',
+  // Slim-wave batch 1.
+  'mode-goal',
+  'mode-deep-research',
+  'plugin-subagents',
+  'plugin-oauth',
+  'plugin-computer-control',
+  'plugin-channel-http',
+  'plugin-usage-stats',
+  // Slim-wave batch 2.
+  'plugin-view',
+  'plugin-self-update',
+  'plugin-voice-admin',
+];
+
+/** First-party runtime deps of seed members — packed so the closure installs
+ *  from local tarballs (usage-stats→core, oauth→vault, everything→sdk). */
+const CLOSURE = ['sdk', 'core', 'plugin-vault'];
+
+const repo = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+const seedDir = path.join(repo, 'apps/desktop/resources/plugins-seed');
+const tarDir = mkdtempSync(path.join(tmpdir(), 'moxxy-seed-tars-'));
+
+const run = (cmd, args, opts = {}) =>
+  execFileSync(cmd, args, { stdio: ['ignore', 'inherit', 'inherit'], ...opts });
+
+rmSync(seedDir, { recursive: true, force: true });
+mkdirSync(seedDir, { recursive: true });
+
+for (const p of [...SEED_PLUGINS, ...CLOSURE]) {
+  run('pnpm', ['pack', '--out', path.join(tarDir, `${p}.tgz`)], {
+    cwd: path.join(repo, 'packages', p),
+  });
+}
+
+const tarballs = readdirSync(tarDir).map((f) => path.join(tarDir, f));
+run('npm', [
+  'install',
+  '--prefix',
+  seedDir,
+  '--no-fund',
+  '--no-audit',
+  '--install-links=false',
+  ...tarballs,
+]);
+
+rmSync(tarDir, { recursive: true, force: true });
+console.log(`plugins-seed assembled at ${seedDir} (${SEED_PLUGINS.length} plugins + closure)`);

--- a/packages/desktop-host/src/index.ts
+++ b/packages/desktop-host/src/index.ts
@@ -13,6 +13,7 @@ export { ElectronCommandBus } from './bus/electron-bus.js';
 export { EventBus, wsEventBus } from './event-bus.js';
 export { type UpdateConfig } from './ipc/update.js';
 export { preferredCliEntry } from './cli-resolver.js';
+export { seedPluginsFromResources, type SeedPluginsResult } from './seed-plugins.js';
 export { activateManagedNode } from './node-manager.js';
 export { ensureDesktopVaultKey } from './vault-key.js';
 export {

--- a/packages/desktop-host/src/seed-plugins.test.ts
+++ b/packages/desktop-host/src/seed-plugins.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { seedPluginsFromResources } from './seed-plugins.js';
+
+let tmp: string;
+let resources: string;
+let home: string;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-seed-'));
+  resources = path.join(tmp, 'resources');
+  home = path.join(tmp, 'home');
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+async function makeSeed(pkgs: Record<string, { version: string; extra?: string }>) {
+  const modules = path.join(resources, 'plugins-seed', 'node_modules');
+  const deps: Record<string, string> = {};
+  for (const [name, spec] of Object.entries(pkgs)) {
+    const dir = path.join(modules, name);
+    await fs.mkdir(path.join(dir, 'dist'), { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ name, version: spec.version }),
+    );
+    await fs.writeFile(path.join(dir, 'dist', 'index.js'), spec.extra ?? 'export default {}');
+    deps[name] = spec.version;
+  }
+  await fs.writeFile(
+    path.join(resources, 'plugins-seed', 'package.json'),
+    JSON.stringify({ name: 'seed', dependencies: deps }),
+  );
+}
+
+describe('seedPluginsFromResources', () => {
+  it('no-ops without a bundled seed (dev run)', async () => {
+    await fs.mkdir(resources, { recursive: true });
+    const res = await seedPluginsFromResources({ resourcesPath: resources, moxxyHome: home });
+    expect(res.copied).toEqual([]);
+  });
+
+  it('copies the whole tree on first launch and writes the manifest', async () => {
+    await makeSeed({
+      '@moxxy/mode-goal': { version: '1.0.0' },
+      '@moxxy/sdk': { version: '1.0.0' },
+      zod: { version: '3.24.0' },
+    });
+    const res = await seedPluginsFromResources({ resourcesPath: resources, moxxyHome: home });
+    expect(res.copied.sort()).toEqual(['@moxxy/mode-goal', '@moxxy/sdk', 'zod']);
+    const pkg = JSON.parse(
+      await fs.readFile(path.join(home, 'plugins', 'package.json'), 'utf8'),
+    );
+    expect(pkg.dependencies['@moxxy/mode-goal']).toBe('1.0.0');
+    expect(pkg.private).toBe(true);
+    await expect(
+      fs.readFile(
+        path.join(home, 'plugins', 'node_modules', '@moxxy', 'mode-goal', 'dist', 'index.js'),
+        'utf8',
+      ),
+    ).resolves.toContain('export default');
+  });
+
+  it('never overwrites an existing (possibly user-updated) package', async () => {
+    await makeSeed({ '@moxxy/mode-goal': { version: '1.0.0', extra: 'SEED' } });
+    const existing = path.join(home, 'plugins', 'node_modules', '@moxxy', 'mode-goal');
+    await fs.mkdir(existing, { recursive: true });
+    await fs.writeFile(path.join(existing, 'package.json'), JSON.stringify({ name: '@moxxy/mode-goal', version: '9.9.9' }));
+    const res = await seedPluginsFromResources({ resourcesPath: resources, moxxyHome: home });
+    expect(res.copied).toEqual([]);
+    expect(res.skipped).toEqual(['@moxxy/mode-goal']);
+    const kept = JSON.parse(await fs.readFile(path.join(existing, 'package.json'), 'utf8'));
+    expect(kept.version).toBe('9.9.9');
+  });
+
+  it('keeps existing target manifest dependencies over seed entries', async () => {
+    await makeSeed({ '@moxxy/mode-goal': { version: '1.0.0' } });
+    await fs.mkdir(path.join(home, 'plugins'), { recursive: true });
+    await fs.writeFile(
+      path.join(home, 'plugins', 'package.json'),
+      JSON.stringify({ name: 'moxxy-user-plugins', dependencies: { '@moxxy/mode-goal': '2.0.0' } }),
+    );
+    await seedPluginsFromResources({ resourcesPath: resources, moxxyHome: home });
+    const pkg = JSON.parse(await fs.readFile(path.join(home, 'plugins', 'package.json'), 'utf8'));
+    expect(pkg.dependencies['@moxxy/mode-goal']).toBe('2.0.0');
+  });
+
+  it('skips npm bookkeeping entries (.bin, .package-lock.json)', async () => {
+    await makeSeed({ '@moxxy/mode-goal': { version: '1.0.0' } });
+    const modules = path.join(resources, 'plugins-seed', 'node_modules');
+    await fs.mkdir(path.join(modules, '.bin'), { recursive: true });
+    await fs.writeFile(path.join(modules, '.package-lock.json'), '{}');
+    const res = await seedPluginsFromResources({ resourcesPath: resources, moxxyHome: home });
+    expect(res.copied).toEqual(['@moxxy/mode-goal']);
+  });
+});

--- a/packages/desktop-host/src/seed-plugins.ts
+++ b/packages/desktop-host/src/seed-plugins.ts
@@ -1,0 +1,129 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * First-launch plugin seeding: copy the packaged app's bundled
+ * `plugins-seed` npm tree (assembled at build time by
+ * apps/desktop/scripts/bundle-plugins-seed.mjs) into `<moxxyHome>/plugins`
+ * so the spawned slim CLI runner finds the on-demand plugins WITHOUT npm or
+ * network. Electron-free and idempotent:
+ *
+ * - The seed's own `package.json#dependencies` is the manifest (an npm
+ *   prefix tree always has one) — no second list to drift.
+ * - Existing directories are NEVER overwritten: a user-updated install of a
+ *   plugin (possibly newer than the seed) survives app updates.
+ * - Later `npm install --save` runs in the target keep working: the seed's
+ *   dependency entries are merged into the target package.json.
+ */
+export interface SeedPluginsOptions {
+  /** `process.resourcesPath` of the packaged app (contains `plugins-seed`). */
+  readonly resourcesPath: string;
+  /** The moxxy home dir (usually `~/.moxxy`; respect MOXXY_HOME upstream). */
+  readonly moxxyHome: string;
+  readonly log?: (msg: string) => void;
+}
+
+export interface SeedPluginsResult {
+  /** Top-level node_modules entries copied from the seed. */
+  readonly copied: ReadonlyArray<string>;
+  /** Seed entries skipped because the target already has them. */
+  readonly skipped: ReadonlyArray<string>;
+}
+
+const NOOP: SeedPluginsResult = { copied: [], skipped: [] };
+
+export async function seedPluginsFromResources(
+  opts: SeedPluginsOptions,
+): Promise<SeedPluginsResult> {
+  const seedDir = path.join(opts.resourcesPath, 'plugins-seed');
+  const seedModules = path.join(seedDir, 'node_modules');
+  if (!(await isDir(seedModules))) return NOOP; // dev run / seed not bundled
+
+  const targetDir = path.join(opts.moxxyHome, 'plugins');
+  const targetModules = path.join(targetDir, 'node_modules');
+  await fs.mkdir(targetModules, { recursive: true });
+
+  // Copy every top-level entry (scoped dirs one level deeper) that the
+  // target doesn't already have. npm hoists flat, so top-level coverage
+  // carries the transitive closure; skip npm's internal `.bin`/`.package-lock`
+  // bookkeeping — the target tree manages its own.
+  const copied: string[] = [];
+  const skipped: string[] = [];
+  for (const entry of await listModuleEntries(seedModules)) {
+    const from = path.join(seedModules, entry);
+    const to = path.join(targetModules, entry);
+    if (await exists(to)) {
+      skipped.push(entry);
+      continue;
+    }
+    await fs.mkdir(path.dirname(to), { recursive: true });
+    await fs.cp(from, to, { recursive: true, force: false, errorOnExist: false });
+    copied.push(entry);
+  }
+
+  await mergeManifest(seedDir, targetDir);
+  opts.log?.(
+    `plugins-seed: copied ${copied.length} package(s) into ${targetDir}` +
+      (skipped.length > 0 ? ` (${skipped.length} already present)` : ''),
+  );
+  return { copied, skipped };
+}
+
+/** Top-level module names, descending one level into @scopes. */
+async function listModuleEntries(modulesDir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const name of await fs.readdir(modulesDir)) {
+    if (name.startsWith('.')) continue;
+    if (name.startsWith('@')) {
+      for (const sub of await fs.readdir(path.join(modulesDir, name))) {
+        if (!sub.startsWith('.')) out.push(`${name}/${sub}`);
+      }
+    } else {
+      out.push(name);
+    }
+  }
+  return out;
+}
+
+/** Merge the seed's dependency ledger into the target package.json (creating
+ *  the standard user-plugins stub when absent) so future `npm install --save`
+ *  runs in the target tree keep every seeded package on their ledger. */
+async function mergeManifest(seedDir: string, targetDir: string): Promise<void> {
+  const seedPkg = await readJson(path.join(seedDir, 'package.json'));
+  const seedDeps = (seedPkg?.dependencies ?? {}) as Record<string, string>;
+  const targetPath = path.join(targetDir, 'package.json');
+  const targetPkg = (await readJson(targetPath)) ?? {
+    name: 'moxxy-user-plugins',
+    version: '0.0.0',
+    private: true,
+    type: 'module',
+    description: 'Auto-generated workspace for moxxy plugins installed at runtime.',
+  };
+  targetPkg.dependencies = { ...seedDeps, ...(targetPkg.dependencies ?? {}) };
+  await fs.writeFile(targetPath, JSON.stringify(targetPkg, null, 2) + '\n');
+}
+
+async function readJson(p: string): Promise<Record<string, any> | null> {
+  try {
+    return JSON.parse(await fs.readFile(p, 'utf8')) as Record<string, any>;
+  } catch {
+    return null;
+  }
+}
+
+async function isDir(p: string): Promise<boolean> {
+  try {
+    return (await fs.stat(p)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Phase 5 of the slim + configure-on-demand program. Independent of the merged batches; **unblocks the remaining unbundle batches** (browser/terminal/web, whisper pair, telegram/slack, provider-admin/mcp) whose absence would otherwise break desktop surfaces/Settings on the spawned slim runner.

## What

- **Build-time assembly** (`apps/desktop/scripts/bundle-plugins-seed.mjs`, run in `release.yml` desktop-build after "Bundle moxxy CLI", also available as `bundle:plugins-seed`): `pnpm pack` the 16 on-demand plugins (6 API-key providers + the batch-1/2 set) **plus the sdk/core/vault closure**, then `npm install --prefix resources/plugins-seed <tarballs>` so every third-party dep resolves at build time. Ships via `extraResources` (~30 MB in the .app — irrelevant next to Electron). Installing the closure from local tarballs means the desktop build never depends on the same release's npm publish having landed.
- **First-launch copy** (`@moxxy/desktop-host` `seedPluginsFromResources`, invoked in the packaged main before any runner spawns): copies the tree into `~/.moxxy/plugins`. The seed's own `package.json#dependencies` is the manifest (no second list to drift); existing — possibly user-updated — packages are **never overwritten**; the dependency ledger merges into the target manifest so later `npm install --save` runs keep every seeded entry. Electron-free, 5 unit tests.
- Best-effort: a copy failure logs and degrades to on-demand npm installs.

## Verified

- Assembly run locally: 16 plugins + closure, one hoisted `@moxxy/sdk`.
- Runtime copy against the real seed: 62 packages into a fresh home; **the slim CLI then discovers + loads mode-goal / anthropic / view / voice-admin fully offline**.
- Idempotency: second run copies 0, skips all; user-newer package preserved (unit-tested).
- Full gate green.

## Follow-ups (tracked in the plan)

- `verify-desktop-packaged` cold-OFFLINE first-run leg — needs an electron-builder packaging run; belongs to the first desktop release cut after this merges.
- Desktop channels "Install" IPC fallback lands with the telegram/slack unbundle batch.