### PR TITLE
feat(tui): /settings — curated config panel + tui: config section

### DIFF
--- a/.changeset/settings-overlay.md
+++ b/.changeset/settings-overlay.md
@@ -1,0 +1,17 @@
+---
+'@moxxy/config': minor
+'@moxxy/sdk': minor
+'@moxxy/core': patch
+'@moxxy/cli': minor
+'@moxxy/plugin-cli': minor
+---
+
+`/settings` (alias `/config`): a curated in-TUI config panel — reasoning,
+prompt caching, elision, lazy tools, loop guard, plugin security, TUI theme
+and footer hints toggle/cycle in place, persist to the user config through
+the ONE schema-validated comment-preserving writer (new `setConfigValue`,
+which the `config_set` tool now also delegates to), and live-apply via the
+new optional `SessionLike.configAdmin` seam (RemoteSession degrades to
+"applies on restart"). New `tui:` config section (`theme: default|mono`,
+`hints`, `keys` Ctrl-letter overrides for force-send/drop-queued/
+expand-tools) projected onto the TUI's env conventions at launch.

--- a/packages/cli/src/commands/run-tui.ts
+++ b/packages/cli/src/commands/run-tui.ts
@@ -187,10 +187,39 @@ export async function runTuiWithBootstrap(
   argv: ParsedArgv,
   tuiOpts: RunTuiOpts = {},
 ): Promise<number> {
+  await applyTuiPreferences(argv);
   const standalone = hasBoolFlag(argv, 'standalone');
   const mode = chooseClientMode({ standalone, runnerUp: standalone ? false : await isRunnerUp() });
   if (mode === 'attach') return await runAttachedTui(argv, tuiOpts);
   return await runSelfHostedTui(argv, tuiOpts, mode === 'standalone');
+}
+
+/**
+ * Project `config.tui` presentation preferences onto the env conventions the
+ * TUI already reads (NO_COLOR-style toggles) BEFORE Ink mounts — plugin-cli
+ * stays config-loader-free. Explicit env always wins over config so a user's
+ * one-off `MOXXY_NO_COLOR=1 moxxy` behaves as typed. Never blocks boot.
+ */
+async function applyTuiPreferences(argv: ParsedArgv): Promise<void> {
+  try {
+    const { config } = await loadConfig({
+      cwd: process.cwd(),
+      ...(stringFlag(argv, 'config') ? { explicitPath: stringFlag(argv, 'config')! } : {}),
+    });
+    const tui = config.tui;
+    if (!tui) return;
+    if (tui.theme === 'mono' && !process.env.NO_COLOR && !process.env.MOXXY_NO_COLOR) {
+      process.env.MOXXY_NO_COLOR = '1';
+    }
+    if (tui.hints === false && process.env.MOXXY_TUI_HINTS === undefined) {
+      process.env.MOXXY_TUI_HINTS = '0';
+    }
+    if (tui.keys && process.env.MOXXY_TUI_KEYS === undefined) {
+      process.env.MOXXY_TUI_KEYS = JSON.stringify(tui.keys);
+    }
+  } catch {
+    // Presentation prefs must never block the TUI from starting.
+  }
 }
 
 /** Thin-client mode: drive a `RemoteSession` against the running runner. */

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -10,7 +10,7 @@ import {
   silentLogger,
 } from '@moxxy/core';
 import type { Plugin } from '@moxxy/sdk';
-import { buildConfigPlugin, loadDisabledProviders } from '@moxxy/config';
+import { buildConfigPlugin, loadConfig as loadMergedConfig, loadDisabledProviders } from '@moxxy/config';
 import { BUILTIN_SKILLS_DIR_RESOLVED } from './setup/builtin-skills-dir.js';
 import { buildVaultPlugin } from '@moxxy/plugin-vault';
 import { buildMemoryPlugin } from '@moxxy/plugin-memory';
@@ -125,16 +125,30 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
     logger,
   });
 
+  // ONE applier instance shared by the config_set/config_reload tools AND the
+  // session's configAdmin view (the TUI /settings panel) — both surfaces
+  // live-apply through identical logic.
+  const configApplier = buildSessionConfigApplier(session, config, builtinsCore, disabledPackages);
+
   const builtins: Array<{ name: string; plugin: Plugin }> = [
     ...builtinsCore,
     {
       name: '@moxxy/plugin-config',
       plugin: buildConfigPlugin({
         cwd: opts.cwd,
-        applier: buildSessionConfigApplier(session, config, builtinsCore, disabledPackages),
+        applier: configApplier,
       }),
     },
   ];
+
+  // Re-read + live-apply seam for UI surfaces. A RemoteSession leaves it
+  // undefined; the /settings panel then reports "applies on restart".
+  session.configAdmin = {
+    apply: async () => {
+      const { config: fresh } = await loadMergedConfig({ cwd: opts.cwd });
+      return configApplier(fresh);
+    },
+  };
 
   const pluginRegistration = await registerPlugins(session, config, builtins, opts.cwd, logger);
   progress({

--- a/packages/config/src/config-writer.test.ts
+++ b/packages/config/src/config-writer.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { setConfigValue } from './config-writer.js';
+
+let tmp: string;
+let prevHome: string | undefined;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-cfgw-'));
+  prevHome = process.env.MOXXY_HOME;
+  process.env.MOXXY_HOME = path.join(tmp, 'home');
+});
+
+afterEach(async () => {
+  if (prevHome === undefined) delete process.env.MOXXY_HOME;
+  else process.env.MOXXY_HOME = prevHome;
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe('setConfigValue', () => {
+  it('creates the user config and sets a nested path', async () => {
+    const res = await setConfigValue({
+      scope: 'user',
+      cwd: tmp,
+      path: 'context.reasoning',
+      value: true,
+    });
+    expect(res.config.context?.reasoning).toBe(true);
+    const text = await fs.readFile(res.path, 'utf8');
+    expect(text).toContain('reasoning: true');
+  });
+
+  it('preserves comments on existing YAML', async () => {
+    const home = path.join(tmp, 'home');
+    await fs.mkdir(home, { recursive: true });
+    const file = path.join(home, 'config.yaml');
+    await fs.writeFile(file, '# keep me\ncontext:\n  caching: true # inline note\n');
+    await setConfigValue({ scope: 'user', cwd: tmp, path: 'tui.hints', value: false });
+    const text = await fs.readFile(file, 'utf8');
+    expect(text).toContain('# keep me');
+    expect(text).toContain('# inline note');
+    expect(text).toContain('hints: false');
+  });
+
+  it('rejects writes that would produce a schema-invalid config', async () => {
+    await expect(
+      setConfigValue({ scope: 'user', cwd: tmp, path: 'tui.theme', value: 'neon' }),
+    ).rejects.toThrow(/invalid config/);
+  });
+});

--- a/packages/config/src/config-writer.ts
+++ b/packages/config/src/config-writer.ts
@@ -1,0 +1,88 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { createMutex } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
+import { findUpward } from './loader.js';
+import { moxxyConfigSchema, type MoxxyConfig } from './schema.js';
+
+/**
+ * The ONE schema-validated, comment-preserving dot-path config writer. Both
+ * the model-facing `config_set` tool (plugin.ts) and UI surfaces (the TUI's
+ * /settings panel) write through here, sharing a single mutex, so concurrent
+ * writers can't interleave and no surface can persist a structurally-invalid
+ * config.
+ */
+export type ConfigScope = 'user' | 'project';
+
+const USER_YAML = (): string => moxxyPath('config.yaml');
+
+// YAML names only — the writer round-trips documents with `setIn`, which it
+// can't do for the .ts/.js configs loadConfig also honors.
+const PROJECT_YAML_NAMES = ['moxxy.config.yaml', 'moxxy.config.yml'] as const;
+
+/** Serializes every config write in this process (tool + UI surfaces). */
+export const configWriteMutex = createMutex();
+
+export async function findScopePath(scope: ConfigScope, cwd: string): Promise<string | null> {
+  if (scope === 'user') {
+    const yaml = USER_YAML();
+    try {
+      await fs.access(yaml);
+      return yaml;
+    } catch {
+      return null;
+    }
+  }
+  return findUpward(cwd, PROJECT_YAML_NAMES);
+}
+
+export function scopeDefaultPath(scope: ConfigScope, cwd: string): string {
+  return scope === 'user' ? USER_YAML() : path.join(cwd, 'moxxy.config.yaml');
+}
+
+export function parseDotPath(p: string): Array<string | number> {
+  return p.split('.').map((seg) => (/^\d+$/.test(seg) ? Number(seg) : seg));
+}
+
+export interface SetConfigValueOptions {
+  readonly scope: ConfigScope;
+  readonly cwd: string;
+  /** Dot path into the config (e.g. `context.reasoning`, `tui.hints`). */
+  readonly path: string;
+  /** The ALREADY-PARSED value to set (callers own string→value parsing). */
+  readonly value: unknown;
+}
+
+export interface SetConfigValueResult {
+  /** The file that was written. */
+  readonly path: string;
+  /** The full validated config snapshot after the write. */
+  readonly config: MoxxyConfig;
+}
+
+export async function setConfigValue(opts: SetConfigValueOptions): Promise<SetConfigValueResult> {
+  return configWriteMutex.run(async () => {
+    const target = (await findScopePath(opts.scope, opts.cwd)) ?? scopeDefaultPath(opts.scope, opts.cwd);
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    const yamlMod = (await import('yaml')) as typeof import('yaml');
+    let text = '';
+    try {
+      text = await fs.readFile(target, 'utf8');
+    } catch {
+      /* new file */
+    }
+    const doc = yamlMod.parseDocument(text);
+    doc.setIn(parseDotPath(opts.path), opts.value);
+    const candidate = String(doc);
+    const parsed = yamlMod.parse(candidate);
+    const validated = moxxyConfigSchema.safeParse(parsed ?? {});
+    if (!validated.success) {
+      throw new Error(
+        `config write to '${opts.path}' would produce an invalid config:\n` +
+          JSON.stringify(validated.error.issues, null, 2),
+      );
+    }
+    await writeFileAtomic(target, candidate);
+    return { path: target, config: validated.data };
+  });
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -50,3 +50,11 @@ export {
   type InitConfigSelections,
   type UserConfigOptions,
 } from './user-config.js';
+
+export {
+  configWriteMutex,
+  setConfigValue,
+  type ConfigScope,
+  type SetConfigValueOptions,
+  type SetConfigValueResult,
+} from './config-writer.js';

--- a/packages/config/src/plugin.ts
+++ b/packages/config/src/plugin.ts
@@ -4,6 +4,7 @@ import { z, createMutex, defineTool, definePlugin, type Plugin } from '@moxxy/sd
 import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { findUpward, loadConfig } from './loader.js';
 import { moxxyConfigSchema, type MoxxyConfig } from './schema.js';
+import { setConfigValue } from './config-writer.js';
 
 /**
  * Optional callback that the CLI (or any session host) can provide to apply
@@ -174,50 +175,37 @@ export function buildConfigPlugin(
           value: z.string(),
         }),
         permission: { action: 'prompt' },
-        handler: async ({ scope, path: dotPath, value }) =>
-          writeMutex.run(async () => {
-            const target = (await findScopePath(scope, cwd)) ?? scopeDefaultPath(scope, cwd);
-            await fs.mkdir(path.dirname(target), { recursive: true });
-            const { doc, text } = await readDoc(target);
-            const segs = parseDotPath(dotPath);
-            const parsedValue = parseValue(value);
-            doc.setIn(segs, parsedValue);
-            const yamlMod = (await import('yaml')) as typeof import('yaml');
+        handler: async ({ scope, path: dotPath, value }) => {
+          // ONE write implementation for every surface: the shared
+          // schema-validated, comment-preserving, mutex-serialized writer
+          // (config-writer.ts) — the TUI /settings panel writes through the
+          // same function, so tool and UI writes can't interleave or drift.
+          const written = await setConfigValue({
+            scope,
+            cwd,
+            path: dotPath,
+            value: parseValue(value),
+          });
 
-            const candidate = String(doc);
-            const candidateParsed = yamlMod.parse(candidate);
-            // Validate post-write through the schema so we never persist a
-            // structurally-invalid config.
-            const validated = moxxyConfigSchema.safeParse(candidateParsed ?? {});
-            if (!validated.success) {
-              throw new Error(
-                `config_set would produce an invalid config:\n` +
-                  JSON.stringify(validated.error.issues, null, 2),
-              );
+          // If a runtime applier is wired, try to reflect the change live.
+          let runtime: ConfigApplyResult = { applied: [], pending: [] };
+          if (applier) {
+            try {
+              runtime = await applier(written.config);
+            } catch (err) {
+              runtime = {
+                applied: [],
+                pending: [`reload-failed: ${err instanceof Error ? err.message : String(err)}`],
+              };
             }
-            await writeFileAtomic(target, candidate);
+          }
 
-            // If a runtime applier is wired, try to reflect the change live.
-            let runtime: ConfigApplyResult = { applied: [], pending: [] };
-            if (applier) {
-              try {
-                runtime = await applier(validated.data);
-              } catch (err) {
-                runtime = {
-                  applied: [],
-                  pending: [`reload-failed: ${err instanceof Error ? err.message : String(err)}`],
-                };
-              }
-            }
-
-            return {
-              path: target,
-              outsideCwd: scope === 'project' && isOutsideCwd(target, cwd),
-              previousSize: text.length,
-              newSize: candidate.length,
-              runtime,
-            };
-          }),
+          return {
+            path: written.path,
+            outsideCwd: scope === 'project' && isOutsideCwd(written.path, cwd),
+            runtime,
+          };
+        },
       }),
       defineTool({
         name: 'config_reload',

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -164,6 +164,28 @@ export const moxxyConfigSchema = z.object({
   channels: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
   permissions: permissionsConfigSchema.optional(),
   env: z.record(z.string(), z.string()).optional(),
+  /** TUI presentation preferences (read at TUI boot; edited via /settings). */
+  tui: z
+    .object({
+      /** `mono` drops color like NO_COLOR; `default` is the standard palette. */
+      theme: z.enum(['default', 'mono']).optional(),
+      /** Hide the footer key-hint row when false. */
+      hints: z.boolean().optional(),
+      /**
+       * Ctrl+<letter> overrides for the input-editor command hotkeys. Values
+       * are single letters; unknown/conflicting letters are ignored at boot.
+       */
+      keys: z
+        .object({
+          forceSend: z.string().length(1).optional(),
+          dropQueued: z.string().length(1).optional(),
+          toggleTools: z.string().length(1).optional(),
+        })
+        .strict()
+        .optional(),
+    })
+    .strict()
+    .optional(),
 });
 
 export type MoxxyConfig = z.infer<typeof moxxyConfigSchema>;

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -50,6 +50,7 @@ import type {
   WorkflowsView,
   PluginsAdminView,
   ProviderSetupView,
+  SessionLike,
   PendingToolCall,
   PermissionContext,
   PermissionDecision,
@@ -186,6 +187,7 @@ export class Session implements ClientSession, SessionRuntime {
   workflows?: WorkflowsView;
   pluginsAdmin?: PluginsAdminView;
   providerSetup?: ProviderSetupView;
+  configAdmin?: SessionLike['configAdmin'];
   readonly dispatcher: HookDispatcherImpl;
   readonly pluginHost: PluginHost;
   private readonly controller = new AbortController();

--- a/packages/plugin-cli/src/components/FooterHints.tsx
+++ b/packages/plugin-cli/src/components/FooterHints.tsx
@@ -54,6 +54,8 @@ const VOICE_HINT: Hint = { key: '^R', action: 'voice', priority: 2 };
  * even at 40 columns.
  */
 export const FooterHints: React.FC<FooterHintsProps> = ({ mode = 'default', voiceReady = false }) => {
+  // `tui.hints: false` in config (projected to env by the CLI launcher).
+  if (process.env.MOXXY_TUI_HINTS === '0') return null;
   const width = process.stdout.columns ?? 80;
   const base = HINTS[mode];
   const all = voiceReady && (mode === 'default' || mode === 'boot') ? [...base, VOICE_HINT] : base;

--- a/packages/plugin-cli/src/components/SlashCommands.tsx
+++ b/packages/plugin-cli/src/components/SlashCommands.tsx
@@ -47,6 +47,7 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<SlashCommand> = [
   },
   { name: 'mcp', description: 'Enable / disable / remove MCP servers' },
   { name: 'plugins', description: 'Plug / unplug & install plugins — opens a tabbed picker' },
+  { name: 'settings', description: 'Curated config panel: reasoning, caching, elision, theme… (alias /config)' },
   {
     name: 'channels',
     description: 'Run Slack / Telegram bots on their own runner — configure, start, stop',

--- a/packages/plugin-cli/src/session/SessionView.tsx
+++ b/packages/plugin-cli/src/session/SessionView.tsx
@@ -10,6 +10,7 @@ import { StatusLine } from '../components/StatusLine.js';
 import { estimateContextTokens } from '../context-estimate.js';
 import {
   buildSlashSuggestions,
+  parseTuiKeyOverrides,
   clearTerminalScreen,
   getModeBadge,
   getModeName,
@@ -125,8 +126,11 @@ export const SessionView: React.FC<SessionViewProps> = ({
   // Hotkeys that need to reach inside PromptInput. Routed through
   // parse-input.ts since Ink's useInput stops firing once the editor
   // owns the stdin stream (data-mode flowing vs. readable-mode read()).
+  // Ctrl+<letter> assignments honor `tui.keys` overrides (env-projected by
+  // the launcher); the voice key stays fixed on 'r'.
+  const tuiKeys = parseTuiKeyOverrides(process.env.MOXXY_TUI_KEYS);
   const commandHotkeys: Record<string, () => void> = {
-    t: () => {
+    [tuiKeys.forceSend]: () => {
       const moved = turn.forceSendFirst();
       setSystemNotice(
         moved
@@ -134,13 +138,13 @@ export const SessionView: React.FC<SessionViewProps> = ({
           : 'queue: nothing queued to force-send',
       );
     },
-    b: () => {
+    [tuiKeys.dropQueued]: () => {
       const dropped = turn.dropFirst();
       setSystemNotice(
         dropped ? 'queue: dropped the first queued message' : 'queue: nothing to drop',
       );
     },
-    o: () => {
+    [tuiKeys.toggleTools]: () => {
       setExpandToolOutputs((e) => {
         const next = !e;
         setSystemNotice(

--- a/packages/plugin-cli/src/session/helpers.ts
+++ b/packages/plugin-cli/src/session/helpers.ts
@@ -135,3 +135,37 @@ export function clearTerminalScreen(): void {
     process.stdout.write(keepScrollback ? '\x1b[2J\x1b[H' : '\x1b[3J\x1b[2J\x1b[H');
   }
 }
+
+
+/**
+ * Ctrl+<letter> hotkey overrides from `tui.keys` (projected to the
+ * MOXXY_TUI_KEYS env by the CLI launcher). Only single ascii letters are
+ * honored; anything else — bad JSON, multi-char values, collisions with the
+ * fixed voice key — falls back to the defaults so a bad config can't brick
+ * the editor.
+ */
+export interface TuiKeyOverrides {
+  readonly forceSend: string;
+  readonly dropQueued: string;
+  readonly toggleTools: string;
+}
+
+const TUI_KEY_DEFAULTS: TuiKeyOverrides = { forceSend: 't', dropQueued: 'b', toggleTools: 'o' };
+
+export function parseTuiKeyOverrides(raw: string | undefined): TuiKeyOverrides {
+  if (!raw) return TUI_KEY_DEFAULTS;
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return TUI_KEY_DEFAULTS;
+  }
+  const pick = (key: keyof TuiKeyOverrides): string => {
+    const v = parsed[key];
+    return typeof v === 'string' && /^[a-z]$/.test(v) && v !== 'r' ? v : TUI_KEY_DEFAULTS[key];
+  };
+  const out = { forceSend: pick('forceSend'), dropQueued: pick('dropQueued'), toggleTools: pick('toggleTools') };
+  // A collision (two actions on one letter) reverts to defaults wholesale.
+  const letters = new Set([out.forceSend, out.dropQueued, out.toggleTools]);
+  return letters.size === 3 ? out : TUI_KEY_DEFAULTS;
+}

--- a/packages/plugin-cli/src/session/picker-handlers.test.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.test.ts
@@ -9,10 +9,15 @@ import { openPluginsPicker } from './run-slash.js';
 vi.mock('@moxxy/config', () => ({
   setCategoryDefault: vi.fn(async () => undefined),
   setProviderModel: vi.fn(async () => undefined),
+  setConfigValue: vi.fn(async () => ({ path: '/tmp/config.yaml', config: {} })),
+  loadConfig: vi.fn(async () => ({ config: {}, sources: [] })),
 }));
 vi.mock('./run-slash.js', () => ({
   openMcpPicker: vi.fn(),
   openPluginsPicker: vi.fn(),
+  openModelPicker: vi.fn(),
+  openModePicker: vi.fn(),
+  openSettingsPicker: vi.fn(),
 }));
 
 function baseDeps(over: Partial<PickerHandlerDeps> = {}): PickerHandlerDeps {
@@ -272,5 +277,54 @@ describe('makePickerHandler — install-on-first-use', () => {
     await new Promise((r) => setImmediate(r));
     expect(install).toHaveBeenCalledWith('mode-goal');
     expect(rerunSlash).toHaveBeenCalledWith('/mode goal');
+  });
+});
+
+describe('makePickerHandler — settings panel', () => {
+  const settingsPicker = { kind: 'settings', title: 'Settings', options: [] } as const;
+
+  it('toggles a boolean knob: writes user scope, live-applies, reopens', async () => {
+    const { setConfigValue, loadConfig } = await import('@moxxy/config');
+    vi.mocked(loadConfig).mockResolvedValue({ config: {}, sources: [] } as never);
+    const apply = vi.fn(async () => ({ applied: ['context.caching'], pending: [] }));
+    const setSystemNotice = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', configAdmin: { apply } } as never,
+        setSystemNotice,
+      }),
+    );
+    handle(settingsPicker, 'caching');
+    await new Promise((r) => setImmediate(r));
+    expect(vi.mocked(setConfigValue)).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: 'user', path: 'context.caching', value: false }),
+    );
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(setSystemNotice).toHaveBeenCalledWith(expect.stringContaining('Prompt caching → false'));
+  });
+
+  it('without configAdmin the write still lands and the notice says restart', async () => {
+    const { setConfigValue, loadConfig } = await import('@moxxy/config');
+    vi.mocked(loadConfig).mockResolvedValue({ config: {}, sources: [] } as never);
+    vi.mocked(setConfigValue).mockClear();
+    const setSystemNotice = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({ session: { id: 's' } as never, setSystemNotice }),
+    );
+    handle(settingsPicker, 'security');
+    await new Promise((r) => setImmediate(r));
+    expect(vi.mocked(setConfigValue)).toHaveBeenCalledTimes(1);
+    expect(setSystemNotice).toHaveBeenCalledWith(expect.stringContaining('applies on restart'));
+  });
+
+  it('readonly rows only explain where to edit', async () => {
+    const { setConfigValue } = await import('@moxxy/config');
+    vi.mocked(setConfigValue).mockClear();
+    const setSystemNotice = vi.fn();
+    const handle = makePickerHandler(baseDeps({ setSystemNotice }));
+    handle(settingsPicker, 'system-prompt');
+    await new Promise((r) => setImmediate(r));
+    expect(vi.mocked(setConfigValue)).not.toHaveBeenCalled();
+    expect(setSystemNotice).toHaveBeenCalledWith(expect.stringContaining('config.yaml'));
   });
 });

--- a/packages/plugin-cli/src/session/picker-handlers.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.ts
@@ -1,7 +1,14 @@
 import type { ClientSession as Session } from '@moxxy/sdk';
-import { setCategoryDefault, setProviderModel } from '@moxxy/config';
+import { loadConfig, setCategoryDefault, setConfigValue, setProviderModel } from '@moxxy/config';
 import type { Picker } from './types.js';
-import { openMcpPicker, openPluginsPicker } from './run-slash.js';
+import {
+  openMcpPicker,
+  openModelPicker,
+  openModePicker,
+  openPluginsPicker,
+  openSettingsPicker,
+} from './run-slash.js';
+import { findKnob } from './settings-descriptors.js';
 import { NEW_SESSION_OPTION_ID, type SessionSwitchTarget } from './sessions-picker.js';
 
 export interface PickerHandlerDeps {
@@ -61,10 +68,65 @@ export function makePickerHandler(deps: PickerHandlerDeps): (picker: Picker, id:
     if (kind === 'install-confirm') {
       return handleInstallConfirm(picker, id, deps);
     }
+    if (kind === 'settings') {
+      return handleSettingSelected(id, deps);
+    }
     if (kind === 'sessions') {
       return handleSessionSelected(id, deps);
     }
   };
+}
+
+/**
+ * Apply a `/settings` knob pick: booleans toggle, enums cycle — persisted to
+ * the USER config through the shared schema-validated writer, then
+ * live-applied via `session.configAdmin` (absent on a RemoteSession → the
+ * write lands and the notice says it applies on restart). Link rows re-open
+ * the matching picker; readonly rows explain where to edit. The panel
+ * re-opens with fresh badges after every write.
+ */
+function handleSettingSelected(id: string, deps: PickerHandlerDeps): void {
+  const knob = findKnob(id);
+  if (!knob) return;
+  if (knob.kind === 'link') {
+    // Re-opening the model/mode picker needs the fuller SlashDeps surface;
+    // the ones the openers actually touch are present on PickerHandlerDeps.
+    if (knob.opens === 'model') openModelPicker(deps as never);
+    else openModePicker(deps as never);
+    return;
+  }
+  if (knob.kind === 'readonly') {
+    deps.setSystemNotice(`${knob.label}: ${knob.description}`);
+    return;
+  }
+  void (async () => {
+    try {
+      const { config } = await loadConfig({ cwd: process.cwd() });
+      const value = knob.next!(config);
+      await setConfigValue({
+        scope: 'user',
+        cwd: process.cwd(),
+        path: knob.dotPath!,
+        value,
+      });
+      const admin = deps.session.configAdmin;
+      if (admin) {
+        const res = await admin.apply();
+        const appliedNow = res.applied.length > 0;
+        deps.setSystemNotice(
+          `✓ ${knob.label} → ${JSON.stringify(value)}${appliedNow ? '' : ' — applies on restart'}`,
+        );
+      } else {
+        deps.setSystemNotice(`✓ ${knob.label} → ${JSON.stringify(value)} — applies on restart`);
+      }
+    } catch (err) {
+      deps.setSystemNotice(
+        `failed to update ${knob.label}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      openSettingsPicker(deps);
+    }
+  })();
 }
 
 /**

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -1,6 +1,7 @@
 import type React from 'react';
 import { clearUsageStats, readSessionIndex } from '@moxxy/core';
-import { setCategoryDefault } from '@moxxy/config';
+import { loadConfig, setCategoryDefault } from '@moxxy/config';
+import { SETTINGS_KNOBS } from './settings-descriptors.js';
 import type { ClientSession as Session } from '@moxxy/sdk';
 import type { UserPromptAttachment } from '@moxxy/sdk';
 import { isSelectableMode } from '@moxxy/sdk';
@@ -143,6 +144,9 @@ export function runSlash(cmd: string, deps: SlashDeps): void {
       return openModePicker(deps, args);
     case 'plugins':
       return openPluginsPicker(deps);
+    case 'settings':
+    case 'config':
+      return openSettingsPicker(deps);
     case 'channels':
       deps.setSystemNotice(null);
       deps.setOverlay({ kind: 'channels' });
@@ -191,7 +195,7 @@ function handleClearQueue(deps: SlashDeps): void {
   );
 }
 
-function openModelPicker(deps: SlashDeps): void {
+export function openModelPicker(deps: SlashDeps): void {
   // Build a flat list of all (provider, model) pairs across every
   // registered provider — the user can switch BOTH provider and
   // model in one pick. Grouping is by provider name. Providers whose
@@ -318,6 +322,45 @@ export function openSessionsPicker(deps: OpenSessionsPickerDeps): void {
 export interface OpenMcpPickerDeps {
   setPicker: (p: Picker) => void;
   setSystemNotice: (msg: string | null) => void;
+}
+
+/**
+ * `/settings` — the curated config panel. Options come from the pure
+ * SETTINGS_KNOBS table with the CURRENT value as the badge (re-read from
+ * disk on every open so external edits show up). Selection semantics live
+ * in picker-handlers: booleans toggle, enums cycle, links open the matching
+ * picker, readonly rows explain where to edit.
+ */
+export interface OpenSettingsPickerDeps {
+  session: Session;
+  setPicker: (p: Picker) => void;
+  setSystemNotice: (msg: string | null) => void;
+}
+
+export function openSettingsPicker(deps: OpenSettingsPickerDeps): void {
+  void (async () => {
+    try {
+      const { config } = await loadConfig({ cwd: process.cwd() });
+      const options: ListPickerOption[] = SETTINGS_KNOBS.map((k) => {
+        const badge = k.kind === 'link' ? 'open ›' : k.current(config);
+        return {
+          id: k.id,
+          label: k.label,
+          description: truncate(k.description, 66),
+          ...(badge ? { badge, badgeColor: k.kind === 'readonly' ? 'gray' : 'cyan' } : {}),
+        };
+      });
+      deps.setPicker({
+        kind: 'settings',
+        title: 'Settings — enter toggles · esc closes',
+        options,
+      });
+    } catch (err) {
+      deps.setSystemNotice(
+        `failed to load config: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  })();
 }
 
 export function openMcpPicker(deps: OpenMcpPickerDeps): void {
@@ -561,7 +604,7 @@ function startCollab(deps: SlashDeps, arg: string): void {
   deps.requestCollab(objective || undefined);
 }
 
-function openModePicker(deps: SlashDeps, arg = ''): void {
+export function openModePicker(deps: SlashDeps, arg = ''): void {
   const all = deps.session.modes.list();
   // Special modes (e.g. the collaborative system, entered via /collab) are never
   // listed or name-switched here — see ModeDef.special / isSelectableMode.

--- a/packages/plugin-cli/src/session/settings-descriptors.test.ts
+++ b/packages/plugin-cli/src/session/settings-descriptors.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { moxxyConfigSchema, type MoxxyConfig } from '@moxxy/config';
+import { findKnob, SETTINGS_KNOBS } from './settings-descriptors.js';
+import { parseTuiKeyOverrides } from './helpers.js';
+
+function withPath(path: string, value: unknown): Record<string, unknown> {
+  const root: Record<string, unknown> = {};
+  let cur = root;
+  const segs = path.split('.');
+  for (const [i, seg] of segs.entries()) {
+    if (i === segs.length - 1) cur[seg] = value;
+    else cur = cur[seg] = {} as Record<string, unknown>;
+  }
+  return root;
+}
+
+describe('SETTINGS_KNOBS', () => {
+  it('every writable knob produces schema-valid configs for its next() value', () => {
+    const empty = {} as MoxxyConfig;
+    for (const knob of SETTINGS_KNOBS) {
+      if (knob.kind === 'link' || knob.kind === 'readonly') continue;
+      const value = knob.next!(empty);
+      const candidate = withPath(knob.dotPath!, value);
+      const res = moxxyConfigSchema.safeParse(candidate);
+      expect(res.success, `${knob.id} → ${knob.dotPath} = ${JSON.stringify(value)}`).toBe(true);
+    }
+  });
+
+  it('reasoning cycles off → on → on (high) → off', () => {
+    const at = (r: unknown) => ({ context: { reasoning: r } }) as MoxxyConfig;
+    const knob = findKnob('reasoning')!;
+    expect(knob.next!({} as MoxxyConfig)).toBe(true);
+    expect(knob.next!(at(true))).toEqual({ effort: 'high' });
+    expect(knob.next!(at({ effort: 'high' }))).toBe(false);
+    expect(knob.current({} as MoxxyConfig)).toBe('off');
+    expect(knob.current(at(true))).toBe('on');
+    expect(knob.current(at({ effort: 'high' }))).toBe('on (high)');
+  });
+
+  it('booleans toggle against their documented defaults', () => {
+    expect(findKnob('caching')!.next!({} as MoxxyConfig)).toBe(false); // default on
+    expect(findKnob('security')!.next!({} as MoxxyConfig)).toBe(true); // default off
+    expect(findKnob('tui-hints')!.next!({} as MoxxyConfig)).toBe(false); // default on
+  });
+
+  it('theme cycles default ↔ mono', () => {
+    const knob = findKnob('tui-theme')!;
+    expect(knob.next!({} as MoxxyConfig)).toBe('mono');
+    expect(knob.next!({ tui: { theme: 'mono' } } as MoxxyConfig)).toBe('default');
+  });
+});
+
+describe('parseTuiKeyOverrides', () => {
+  it('defaults without env, on bad JSON, and on collisions', () => {
+    const dflt = { forceSend: 't', dropQueued: 'b', toggleTools: 'o' };
+    expect(parseTuiKeyOverrides(undefined)).toEqual(dflt);
+    expect(parseTuiKeyOverrides('not-json')).toEqual(dflt);
+    expect(parseTuiKeyOverrides(JSON.stringify({ forceSend: 'b' }))).toEqual(dflt); // collides with dropQueued
+    expect(parseTuiKeyOverrides(JSON.stringify({ forceSend: 'r' }))).toEqual(dflt); // voice key is fixed
+    expect(parseTuiKeyOverrides(JSON.stringify({ forceSend: 'TT' }))).toEqual(dflt);
+  });
+
+  it('applies valid single-letter overrides', () => {
+    expect(parseTuiKeyOverrides(JSON.stringify({ forceSend: 'f', toggleTools: 'x' }))).toEqual({
+      forceSend: 'f',
+      dropQueued: 'b',
+      toggleTools: 'x',
+    });
+  });
+});

--- a/packages/plugin-cli/src/session/settings-descriptors.ts
+++ b/packages/plugin-cli/src/session/settings-descriptors.ts
@@ -1,0 +1,153 @@
+import type { MoxxyConfig } from '@moxxy/config';
+
+/**
+ * The curated /settings knob table — pure data so the panel logic is fully
+ * unit-testable and the paths are validated against the schema in tests.
+ * NOT a generic YAML editor: each knob names one dot-path, how to render its
+ * current value, and what picking it writes (booleans toggle, enums cycle).
+ * `link` rows re-open an existing picker; `readonly` rows only display.
+ */
+export interface SettingsKnob {
+  readonly id: string;
+  readonly label: string;
+  readonly description: string;
+  readonly kind: 'boolean' | 'enum' | 'link' | 'readonly';
+  /** Config dot-path (user scope). Absent for link rows. */
+  readonly dotPath?: string;
+  /** Current value, rendered as the option badge. */
+  readonly current: (cfg: MoxxyConfig) => string;
+  /** The value to persist when picked (booleans toggle, enums cycle). */
+  readonly next?: (cfg: MoxxyConfig) => unknown;
+  /** For link rows: which picker to open. */
+  readonly opens?: 'model' | 'mode';
+}
+
+const onOff = (v: boolean | undefined, dflt: boolean): string =>
+  (v ?? dflt) ? 'on' : 'off';
+
+/** `reasoning` is boolean | {effort} — render + cycle off → on → high → off. */
+function reasoningLabel(cfg: MoxxyConfig): string {
+  const r = cfg.context?.reasoning;
+  if (r === undefined || r === false) return 'off';
+  if (r === true) return 'on';
+  return r.effort ? `on (${r.effort})` : 'on';
+}
+
+function reasoningNext(cfg: MoxxyConfig): unknown {
+  const r = cfg.context?.reasoning;
+  if (r === undefined || r === false) return true;
+  if (r === true) return { effort: 'high' };
+  return false;
+}
+
+export const SETTINGS_KNOBS: ReadonlyArray<SettingsKnob> = [
+  {
+    id: 'model',
+    label: 'Provider & model',
+    description: 'open the /model picker',
+    kind: 'link',
+    opens: 'model',
+    current: () => '',
+  },
+  {
+    id: 'mode',
+    label: 'Default mode',
+    description: 'open the /mode picker',
+    kind: 'link',
+    opens: 'mode',
+    current: () => '',
+  },
+  {
+    id: 'reasoning',
+    label: 'Model reasoning',
+    description: 'stream provider reasoning; cycles off → on → on (high)',
+    kind: 'enum',
+    dotPath: 'context.reasoning',
+    current: reasoningLabel,
+    next: reasoningNext,
+  },
+  {
+    id: 'caching',
+    label: 'Prompt caching',
+    description: 'provider prompt-cache breakpoints (lossless; default on)',
+    kind: 'boolean',
+    dotPath: 'context.caching',
+    current: (c) => onOff(c.context?.caching, true),
+    next: (c) => !(c.context?.caching ?? true),
+  },
+  {
+    id: 'elision',
+    label: 'Context elision',
+    description: 'turn-boundary elision of old tool output (default on)',
+    kind: 'boolean',
+    dotPath: 'context.elision.enabled',
+    current: (c) => onOff(c.context?.elision?.enabled, true),
+    next: (c) => !(c.context?.elision?.enabled ?? true),
+  },
+  {
+    id: 'lazy-tools',
+    label: 'Lazy tools',
+    description: 'defer tool schemas out of the system prompt (default off)',
+    kind: 'boolean',
+    dotPath: 'context.lazyTools',
+    current: (c) => onOff(c.context?.lazyTools, false),
+    next: (c) => !(c.context?.lazyTools ?? false),
+  },
+  {
+    id: 'loop-guard',
+    label: 'Stuck-loop guard',
+    description: 'bail a turn early on repeated identical tool calls (default on)',
+    kind: 'boolean',
+    dotPath: 'context.loopGuard.enabled',
+    current: (c) => onOff(c.context?.loopGuard?.enabled, true),
+    next: (c) => !(c.context?.loopGuard?.enabled ?? true),
+  },
+  {
+    id: 'security',
+    label: 'Plugin security',
+    description: 'opt-in capability isolation for plugin tools (default off)',
+    kind: 'boolean',
+    dotPath: 'security.enabled',
+    current: (c) => onOff(c.security?.enabled, false),
+    next: (c) => !(c.security?.enabled ?? false),
+  },
+  {
+    id: 'tui-theme',
+    label: 'TUI theme',
+    description: 'default palette or mono (NO_COLOR-style)',
+    kind: 'enum',
+    dotPath: 'tui.theme',
+    current: (c) => c.tui?.theme ?? 'default',
+    next: (c) => ((c.tui?.theme ?? 'default') === 'default' ? 'mono' : 'default'),
+  },
+  {
+    id: 'tui-hints',
+    label: 'Footer hints',
+    description: 'the dim key-hint row under the input',
+    kind: 'boolean',
+    dotPath: 'tui.hints',
+    current: (c) => onOff(c.tui?.hints, true),
+    next: (c) => !(c.tui?.hints ?? true),
+  },
+  {
+    id: 'system-prompt',
+    label: 'System prompt',
+    description: 'edit `systemPrompt` in ~/.moxxy/config.yaml',
+    kind: 'readonly',
+    dotPath: 'systemPrompt',
+    current: (c) =>
+      c.systemPrompt ? `set (${c.systemPrompt.length} chars)` : '(default)',
+  },
+  {
+    id: 'tui-keys',
+    label: 'Hotkey overrides',
+    description: 'edit `tui.keys` in ~/.moxxy/config.yaml — applies next boot',
+    kind: 'readonly',
+    dotPath: 'tui.keys',
+    current: (c) => (c.tui?.keys ? JSON.stringify(c.tui.keys) : '(defaults)'),
+  },
+];
+
+export function findKnob(id: string): SettingsKnob | undefined {
+  return SETTINGS_KNOBS.find((k) => k.id === id);
+}

--- a/packages/plugin-cli/src/session/types.ts
+++ b/packages/plugin-cli/src/session/types.ts
@@ -62,6 +62,13 @@ export type Picker =
       options: ReadonlyArray<ListPickerOption>;
       catalogId: string;
       rerun: string;
+    }
+  | {
+      /** `/settings` — curated config knobs (SETTINGS_KNOBS); selection
+       *  toggles/cycles the value, persists it, live-applies, and reopens. */
+      kind: 'settings';
+      title: string;
+      options: ReadonlyArray<ListPickerOption>;
     };
 
 export interface PendingPermission {

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -470,4 +470,16 @@ export interface SessionLike {
   pluginsAdmin?: PluginsAdminView;
   /** Provider onboarding slice backing in-channel connect (key entry / OAuth). */
   providerSetup?: ProviderSetupView;
+  /**
+   * Re-read the merged config from disk and live-apply the safe subset —
+   * backs the TUI /settings panel's write-then-apply. Structurally matches
+   * @moxxy/config's ConfigApplyResult (the SDK stays config-free). Absent on
+   * a RemoteSession: writes still land, but apply waits for a restart.
+   */
+  configAdmin?: {
+    apply(): Promise<{
+      readonly applied: ReadonlyArray<string>;
+      readonly pending: ReadonlyArray<string>;
+    }>;
+  };
 }


### PR DESCRIPTION
Phase 7 of the slim + configure-on-demand program. Independent of the unbundle track.

## What

**`/settings` (alias `/config`)** — the missing ergonomic surface for the config keys that previously required hand-editing YAML:

| knob | behavior |
|---|---|
| Provider & model / Default mode | link rows → the existing pickers |
| Model reasoning | cycles off → on → on (high) (`context.reasoning`) |
| Prompt caching / Context elision / Lazy tools / Stuck-loop guard / Plugin security | one-keystroke toggles |
| TUI theme | default ↔ mono (NO_COLOR-style) |
| Footer hints | toggle |
| System prompt / Hotkey overrides | readonly rows pointing at the YAML location |

Every value renders as the row's badge (re-read from disk on open, so external edits show). Selection persists to the **user** config and live-applies; the panel reopens with fresh state.

## Plumbing

- **One write implementation**: new `setConfigValue` in `@moxxy/config` (schema-validated, comment-preserving, mutex-serialized); the `config_set` tool now delegates to it, so tool + UI writes share the mutex and can't drift.
- **Live apply seam**: optional `SessionLike.configAdmin.apply()` wired from the SAME `buildSessionConfigApplier` instance the config tools use. RemoteSession → "saved — applies on restart".
- **New `tui:` config section** (`theme`, `hints`, `keys`) — projected onto the TUI's existing env conventions by the launcher before Ink mounts (explicit env always wins). Hotkey overrides parse defensively: single letters only, collisions revert wholesale, the voice key stays fixed.

## Verification

Full gate green. New tests: every writable knob's `next()` value validates against the schema; reasoning/theme cycle semantics; defensive key-override parsing; writer comment-preservation + invalid-write rejection; handler branch (toggle→write→apply→reopen, no-configAdmin restart notice, readonly no-write).