### PR TITLE
feat(cli): moxxy config show|get|set|path

### DIFF
--- a/.changeset/config-cli.md
+++ b/.changeset/config-cli.md
@@ -1,0 +1,9 @@
+---
+'@moxxy/cli': minor
+---
+
+New `moxxy config show|get|set|path` command: read the merged config, print
+a value at a dot-path, and set values (JSON-parsed, schema-validated,
+comment-preserving — the same shared writer the `/settings` panel and the
+`config_set` tool use) from the command line. `--scope user|project` picks
+the target file for `set` (default: user).

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -343,6 +343,14 @@ or recorded-on-purpose decision.
   `deleteSession`/`seedSessionLog`) still call the standalone JSONL fns. Identical
   while JSONL is the only impl; route them through `getActive()` (and add a
   default-store seam for the no-session listing) when a 2nd store lands.
+- [med, coherence] `~/.moxxy/providers.json` is the LAST config store outside
+  the unified `plugins:` tree: custom OpenAI-compatible vendors persist there
+  (`plugin-provider-admin/store.ts`) while everything else lives in
+  config.yaml. Folding it into `plugins.provider.items.<name>.config` touches
+  the runner protocol's `provider.configure`, the desktop IPC settings sheet
+  (`desktop-host/provider-discovery.ts` reads the file directly), and the
+  freshly-unbundled provider-admin — deliberately deferred from the slim wave
+  to its own reviewed PR. Clean-slate (pre-1.0): no migration shim.
 - [low, dx] plugins-admin/runner/channels persist via raw-YAML `setIn` writers in
   `@moxxy/config/user-config.ts` — the typecheck can't catch a wrong path string;
   keep the round-trip tests honest and grep for `['plugins'` paths on changes.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -11,6 +11,7 @@ import { runChannelByName } from './commands/run-channel.js';
 import { runInitCommand } from './commands/init.js';
 import { runProvisionCommand } from './commands/provision.js';
 import { runPermsCommand } from './commands/perms.js';
+import { runConfigCommand } from './commands/config.js';
 import { runMemoryCommand } from './commands/memory.js';
 import { runMcpCommand } from './commands/mcp.js';
 import { runScheduleCommand } from './commands/schedule.js';
@@ -83,6 +84,7 @@ const SECTIONS: ReadonlyArray<{ readonly title: string; readonly rows: ReadonlyA
       ['plugins list|search|install|remove|enable|disable|reload|new', 'find, install + manage plugins'],
       ['self-update status|rollback', 'inspect / roll back self-update transactions'],
       ['perms list|allow|deny|remove|clear|path', 'view / edit the permission policy'],
+      ['config show|get|set|path', 'read / edit the moxxy config (user or project scope)'],
       ['memory list|audit|show|revert|prune-stale|path', 'curate long-term memory'],
       ['security audit|isolators|status', 'inspect plugin-security isolation state'],
       ['mcp list|enable|disable|remove|path', 'manage Model Context Protocol servers'],
@@ -207,6 +209,7 @@ const COMMANDS: Record<string, CommandHandler> = {
   provision: runProvisionCommand,
   login: runLoginCommand,
   perms: runPermsCommand,
+  config: runConfigCommand,
   memory: runMemoryCommand,
   mcp: runMcpCommand,
   schedule: runScheduleCommand,

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { runConfigCommand } from './config.js';
+import type { ParsedArgv } from '../argv.js';
+
+let tmp: string;
+let prevHome: string | undefined;
+let out: string[];
+let writeSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-cfgcmd-'));
+  prevHome = process.env.MOXXY_HOME;
+  process.env.MOXXY_HOME = tmp;
+  out = [];
+  writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+    out.push(String(chunk));
+    return true;
+  }) as never);
+});
+
+afterEach(async () => {
+  writeSpy.mockRestore();
+  if (prevHome === undefined) delete process.env.MOXXY_HOME;
+  else process.env.MOXXY_HOME = prevHome;
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+function argv(positional: string[], flags: Record<string, string> = {}): ParsedArgv {
+  return { command: 'config', positional, flags, raw: [] } as unknown as ParsedArgv;
+}
+
+describe('moxxy config', () => {
+  it('set writes the user config, get reads it back merged', async () => {
+    expect(await runConfigCommand(argv(['set', 'tui.hints', 'false']))).toBe(0);
+    const text = await fs.readFile(path.join(tmp, 'config.yaml'), 'utf8');
+    expect(text).toContain('hints: false');
+    out.length = 0;
+    expect(await runConfigCommand(argv(['get', 'tui.hints']))).toBe(0);
+    expect(out.join('')).toContain('false');
+  });
+
+  it('get on an unset path reports (unset) with exit 1', async () => {
+    expect(await runConfigCommand(argv(['get', 'tui.theme']))).toBe(1);
+    expect(out.join('')).toContain('(unset)');
+  });
+
+  it('set rejects schema-invalid values', async () => {
+    expect(await runConfigCommand(argv(['set', 'tui.theme', 'neon']))).toBe(1);
+  });
+
+  it('bare words parse as strings, JSON parses as JSON', async () => {
+    expect(await runConfigCommand(argv(['set', 'tui.theme', 'mono']))).toBe(0);
+    expect(await runConfigCommand(argv(['set', 'context.caching', 'false']))).toBe(0);
+    const text = await fs.readFile(path.join(tmp, 'config.yaml'), 'utf8');
+    expect(text).toContain('theme: mono');
+    expect(text).toContain('caching: false');
+  });
+
+  it('no subcommand prints help with exit 0; unknown subcommand exits 2', async () => {
+    expect(await runConfigCommand(argv([]))).toBe(0);
+    expect(out.join('')).toContain('moxxy config');
+    expect(await runConfigCommand(argv(['frobnicate']))).toBe(2);
+  });
+});

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,0 +1,128 @@
+import { loadConfig, setConfigValue, type ConfigScope } from '@moxxy/config';
+import type { ParsedArgv } from '../argv.js';
+import { stringFlag } from '../argv-helpers.js';
+import { printError } from '../errors.js';
+import { colors } from '../colors.js';
+import { formatHelp } from './help-format.js';
+
+const HELP = formatHelp({
+  title: 'moxxy config',
+  tagline: 'read and edit the moxxy config from the command line',
+  sections: [
+    {
+      title: 'COMMANDS',
+      rows: [
+        ['show', 'print the MERGED config (user + project) as JSON'],
+        ['get <path>', 'print the merged value at a dot-path (JSON)'],
+        ['set <path> <value>', 'set a value (JSON-parsed; bare words stay strings)'],
+        ['path', 'print which config files are in effect'],
+      ],
+    },
+    {
+      title: 'FLAGS',
+      rows: [
+        ['--scope user|project', 'where `set` writes (default: user — ~/.moxxy/config.yaml)'],
+      ],
+    },
+    {
+      title: 'EXAMPLES',
+      rows: [
+        ['moxxy config get plugins.mode.default', ''],
+        ['moxxy config set context.reasoning true', ''],
+        ['moxxy config set tui.theme mono', ''],
+      ],
+    },
+  ],
+});
+
+/** Mirror of the config_set tool's value parsing: JSON when it parses,
+ *  bare string otherwise — so `set tui.theme mono` needs no quoting. */
+function parseValue(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function valueAtPath(obj: unknown, dotPath: string): unknown {
+  let cur: unknown = obj;
+  for (const seg of dotPath.split('.')) {
+    if (cur === null || typeof cur !== 'object' || !Object.prototype.hasOwnProperty.call(cur, seg)) {
+      return undefined;
+    }
+    cur = (cur as Record<string, unknown>)[seg];
+  }
+  return cur;
+}
+
+export async function runConfigCommand(argv: ParsedArgv): Promise<number> {
+  const sub = argv.positional[0];
+  const scope = (stringFlag(argv, 'scope') ?? 'user') as ConfigScope;
+  if (scope !== 'user' && scope !== 'project') {
+    printError(`invalid --scope: ${scope} (use user|project)`);
+    return 2;
+  }
+
+  switch (sub) {
+    case 'show': {
+      const { config } = await loadConfig({ cwd: process.cwd() });
+      process.stdout.write(JSON.stringify(config, null, 2) + '\n');
+      return 0;
+    }
+    case 'get': {
+      const dotPath = argv.positional[1];
+      if (!dotPath) {
+        printError('config get requires a dot-path (e.g. plugins.mode.default)');
+        return 2;
+      }
+      const { config } = await loadConfig({ cwd: process.cwd() });
+      const value = valueAtPath(config, dotPath);
+      if (value === undefined) {
+        process.stdout.write(colors.dim('(unset)') + '\n');
+        return 1;
+      }
+      process.stdout.write(JSON.stringify(value, null, 2) + '\n');
+      return 0;
+    }
+    case 'set': {
+      const dotPath = argv.positional[1];
+      const raw = argv.positional[2];
+      if (!dotPath || raw === undefined) {
+        printError('config set requires a dot-path and a value');
+        return 2;
+      }
+      try {
+        const res = await setConfigValue({
+          scope,
+          cwd: process.cwd(),
+          path: dotPath,
+          value: parseValue(raw),
+        });
+        process.stdout.write(
+          `${colors.bold('✓')} ${dotPath} set in ${res.path}\n` +
+            colors.dim('running sessions pick it up via /settings, config_reload, or restart\n'),
+        );
+        return 0;
+      } catch (err) {
+        printError(err instanceof Error ? err.message : String(err));
+        return 1;
+      }
+    }
+    case 'path': {
+      const { sources } = await loadConfig({ cwd: process.cwd() });
+      if (sources.length === 0) {
+        process.stdout.write(colors.dim('no config files found (run `moxxy init`)\n'));
+        return 0;
+      }
+      const col = Math.max(...sources.map((s) => s.scope.length));
+      for (const s of sources) {
+        process.stdout.write(`${colors.bold(s.scope.padEnd(col))}  ${s.path}\n`);
+      }
+      return 0;
+    }
+    default:
+      process.stdout.write(HELP);
+      return sub ? 2 : 0;
+  }
+}


### PR DESCRIPTION
Phase 8 (config coherence) of the slim + configure-on-demand program — the CLI half.

## What

`moxxy config show | get <path> | set <path> <value> [--scope user|project] | path` — scripting/parity access to the same write pipeline every other surface uses: `set` goes through the shared schema-validated, comment-preserving, mutex-serialized writer from #401 (so CLI, `/settings`, and the `config_set` tool can't drift or interleave). Values JSON-parse with a bare-word string fallback (`set tui.theme mono` needs no quoting); invalid writes are rejected with the schema issues.

Verified live in a sandboxed `MOXXY_HOME`: set → comment-preserving YAML write → get reads it back → `set tui.theme neon` rejected. 5 new tests.

## Deliberately deferred: the providers.json fold

The plan's other Phase-8 item — folding `~/.moxxy/providers.json` (custom OpenAI-compatible vendors) into `plugins.provider.items.<name>.config` — is **deferred to its own PR** and logged in TECH_DEBT with the full blast radius: it touches the runner protocol's `provider.configure`, the desktop IPC settings sheet (`provider-discovery.ts` reads the file directly), and the just-unbundled provider-admin. Tail-of-wave was the wrong moment for that review.