### PR TITLE
feat(plugins): plugin-declared init hooks (moxxy.setup)

### DIFF
--- a/.changeset/plugin-setup-hooks.md
+++ b/.changeset/plugin-setup-hooks.md
@@ -1,0 +1,19 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/plugin-plugins-admin': minor
+'@moxxy/cli': minor
+'@moxxy/plugin-cli': patch
+'@moxxy/plugin-channel-http': minor
+---
+
+Plugin-declared init hooks: plugins can now ship a declarative setup step at
+`package.json#moxxy.setup` (title, required flag, typed fields:
+secret/string/boolean/select). `moxxy init` walks every installed plugin's
+step — secrets go to the VAULT with a `${vault:NAME}` ref written to the
+plugin's `options.<key>` (resolved at boot, never plaintext), other kinds
+persist through the shared schema-validated writer; skipping a
+`required: true` setup leaves the package DISABLED until configured; re-runs
+prefill ("enter to keep"). Installing such a plugin (tool or /plugins picker)
+surfaces `needsSetup` so the user is pointed at the configuration
+immediately. Proof: the HTTP channel declares its bearer token as a required
+secret field.

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,6 +4,7 @@ import { canonicalKey } from '../provider-keys.js';
 import type { ParsedArgv } from '../argv.js';
 import { cliVersion } from '../version.js';
 import { runSetupWizard } from '../wizard/run-setup-wizard.js';
+import { runPluginSetupSteps } from '../wizard/plugin-setup-steps.js';
 import { buildProviderSetupView } from '../setup/provider-setup.js';
 import { PROVIDER_CATALOG } from '../provision/provider-catalog.js';
 import {
@@ -209,6 +210,20 @@ async function runInteractiveInit(
     availablePlugins,
     ...(cliVersion() ? { version: cliVersion()! } : {}),
   });
+
+  // Plugin-declared setup steps (`package.json#moxxy.setup`): every installed
+  // plugin that hooks into init gets its configuration walk — required steps
+  // left incomplete DISABLE that package until configured. Runs after the
+  // wizard so freshly-installed extras are included; re-runs prefill.
+  try {
+    await runPluginSetupSteps({ vault, cwd: process.cwd() });
+  } catch (err) {
+    process.stderr.write(
+      `plugin setup steps failed (config unchanged for the rest): ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
+  }
 
   return 0;
 }

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -6,6 +6,7 @@ import {
   findCatalogEntryForContribution,
   INSTALLABLE_PLUGIN_CATALOG,
   installPluginPackagePinned,
+  readPluginSetup,
   resolveCatalogEntry,
   setCategoryDefault as persistCategoryDefault,
   setPluginEnabled as persistPluginEnabled,
@@ -293,7 +294,14 @@ function wirePluginsAdminView(
       });
       if (packageName) await persistPluginEnabled(packageName, true);
       await session.pluginHost.reload();
-      return { installed, registered: diffSnapshot(before, buildPluginSnapshot(session)) };
+      const setup = packageName ? await readPluginSetup(packageName) : null;
+      return {
+        installed,
+        registered: diffSnapshot(before, buildPluginSnapshot(session)),
+        ...(setup
+          ? { needsSetup: { title: setup.title, required: setup.required === true } }
+          : {}),
+      };
     },
   };
 }

--- a/packages/cli/src/wizard/plugin-setup-steps.test.ts
+++ b/packages/cli/src/wizard/plugin-setup-steps.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { PluginSetupSpec } from '@moxxy/plugin-plugins-admin';
+
+// clack prompts are TTY-bound; script them per test.
+vi.mock('@clack/prompts', () => ({
+  confirm: vi.fn(),
+  isCancel: (v: unknown) => v === Symbol.for('cancel'),
+  log: { step: vi.fn(), message: vi.fn(), warn: vi.fn() },
+  password: vi.fn(),
+  select: vi.fn(),
+  text: vi.fn(),
+}));
+
+import { confirm, password } from '@clack/prompts';
+import { runPluginSetupSteps } from './plugin-setup-steps.js';
+
+let tmp: string;
+let prevHome: string | undefined;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-psetup-'));
+  prevHome = process.env.MOXXY_HOME;
+  process.env.MOXXY_HOME = tmp;
+});
+
+afterEach(async () => {
+  if (prevHome === undefined) delete process.env.MOXXY_HOME;
+  else process.env.MOXXY_HOME = prevHome;
+  await fs.rm(tmp, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+function fakeVault() {
+  const store = new Map<string, string>();
+  return {
+    get: async (k: string) => store.get(k) ?? null,
+    set: async (k: string, v: string) => void store.set(k, v),
+    _store: store,
+  };
+}
+
+const SPEC: PluginSetupSpec = {
+  title: 'HTTP channel auth token',
+  required: true,
+  fields: [
+    { key: 'authToken', label: 'Auth token', kind: 'secret', vaultKey: 'MOXXY_HTTP_TOKEN' },
+  ],
+};
+
+const list = async () => [{ packageName: '@moxxy/plugin-channel-http', setup: SPEC }];
+
+describe('runPluginSetupSteps', () => {
+  it('secret: stores in the vault and writes a ${vault:...} ref to options', async () => {
+    vi.mocked(password).mockResolvedValue('tok-123' as never);
+    const vault = fakeVault();
+    await runPluginSetupSteps({ vault, cwd: tmp, list });
+    expect(vault._store.get('MOXXY_HTTP_TOKEN')).toBe('tok-123');
+    const cfg = await fs.readFile(path.join(tmp, 'config.yaml'), 'utf8');
+    expect(cfg).toContain('authToken: ${vault:MOXXY_HTTP_TOKEN}');
+    expect(cfg).not.toContain('tok-123');
+  });
+
+  it('required setup left incomplete disables the package', async () => {
+    vi.mocked(password).mockResolvedValue(Symbol.for('cancel') as never);
+    const vault = fakeVault();
+    await runPluginSetupSteps({ vault, cwd: tmp, list });
+    const cfg = await fs.readFile(path.join(tmp, 'config.yaml'), 'utf8');
+    expect(cfg).toContain('enabled: false');
+  });
+
+  it('re-run keeps an existing secret on empty enter (no disable)', async () => {
+    vi.mocked(password).mockResolvedValue('' as never);
+    const vault = fakeVault();
+    await vault.set('MOXXY_HTTP_TOKEN', 'kept');
+    await runPluginSetupSteps({ vault, cwd: tmp, list });
+    expect(vault._store.get('MOXXY_HTTP_TOKEN')).toBe('kept');
+    const cfgExists = await fs
+      .readFile(path.join(tmp, 'config.yaml'), 'utf8')
+      .catch(() => '');
+    expect(cfgExists).not.toContain('enabled: false');
+  });
+
+  it('optional setup asks first and skips cleanly on decline', async () => {
+    const optional = async () => [
+      {
+        packageName: '@moxxy/plugin-x',
+        setup: { title: 'X', fields: [{ key: 'a', label: 'A', kind: 'string' as const }] },
+      },
+    ];
+    vi.mocked(confirm).mockResolvedValue(false as never);
+    const vault = fakeVault();
+    await runPluginSetupSteps({ vault, cwd: tmp, list: optional });
+    await expect(fs.readFile(path.join(tmp, 'config.yaml'), 'utf8')).rejects.toThrow();
+  });
+
+  it('respects the `only` filter (post-install path)', async () => {
+    vi.mocked(password).mockResolvedValue('never-asked' as never);
+    const vault = fakeVault();
+    await runPluginSetupSteps({ vault, cwd: tmp, list, only: ['@moxxy/other'] });
+    expect(vault._store.size).toBe(0);
+  });
+});

--- a/packages/cli/src/wizard/plugin-setup-steps.ts
+++ b/packages/cli/src/wizard/plugin-setup-steps.ts
@@ -1,0 +1,121 @@
+import { confirm, isCancel, log, password, select, text } from '@clack/prompts';
+import { setConfigValue, setPluginEnabled } from '@moxxy/config';
+import {
+  listPluginSetups,
+  setupFieldVaultKey,
+  type PluginSetupField,
+  type PluginSetupSpec,
+} from '@moxxy/plugin-plugins-admin';
+import { colors } from '../colors.js';
+
+/** The vault slice plugin setup needs (mirrors ProviderVault). */
+export interface SetupVault {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, tags?: ReadonlyArray<string>): Promise<void>;
+}
+
+export interface PluginSetupStepsOptions {
+  readonly vault: SetupVault;
+  readonly cwd: string;
+  /** Restrict to these packages (post-install); omit = every installed plugin. */
+  readonly only?: ReadonlyArray<string>;
+  /** Injectable for tests. */
+  readonly list?: () => Promise<ReadonlyArray<{ packageName: string; setup: PluginSetupSpec }>>;
+}
+
+/**
+ * Walk the declarative setup steps of installed plugins (`moxxy.setup`) —
+ * the plugin author's hook into `moxxy init`. Secrets go to the VAULT and
+ * the plugin's `options.<key>` gets a `${vault:<name>}` ref (resolved at
+ * boot); other kinds persist at `plugins.packages.<pkg>.options.<key>`.
+ * Re-runs prefill: an already-set secret offers "enter to keep". Skipping a
+ * `required: true` setup DISABLES the package (floor-safe: kernel packages
+ * never declare setup) so it can't half-run unconfigured.
+ */
+export async function runPluginSetupSteps(opts: PluginSetupStepsOptions): Promise<void> {
+  const all = await (opts.list ?? listPluginSetups)();
+  const targets = opts.only ? all.filter((e) => opts.only!.includes(e.packageName)) : all;
+  if (targets.length === 0) return;
+
+  for (const { packageName, setup } of targets) {
+    log.step(`${setup.title} ${colors.dim(`(${packageName})`)}`);
+    if (setup.description) log.message(colors.dim(setup.description));
+
+    if (!setup.required) {
+      const want = await confirm({ message: 'Configure it now?', initialValue: true });
+      if (isCancel(want) || !want) continue;
+    }
+
+    let complete = true;
+    for (const field of setup.fields) {
+      const done = await collectField(packageName, field, opts);
+      if (!done && field.required !== false && setup.required) complete = false;
+    }
+
+    if (!complete) {
+      await setPluginEnabled(packageName, false);
+      log.warn(
+        `${packageName} left DISABLED — its required setup is incomplete. ` +
+          `Re-run \`moxxy init\` (or \`moxxy plugins enable ${packageName}\` after configuring by hand).`,
+      );
+    }
+  }
+}
+
+/** Returns true when the field ended up with a value (kept or entered). */
+async function collectField(
+  packageName: string,
+  field: PluginSetupField,
+  opts: PluginSetupStepsOptions,
+): Promise<boolean> {
+  const optionsPath = `plugins.packages.${packageName}.options.${field.key}`;
+
+  if (field.kind === 'secret') {
+    const vaultKey = setupFieldVaultKey(packageName, field);
+    const existing = await opts.vault.get(vaultKey).catch(() => null);
+    const answer = await password({
+      message: `${field.label}${existing ? colors.dim(' (already set — enter to keep)') : ''}`,
+    });
+    if (isCancel(answer)) return Boolean(existing);
+    const value = typeof answer === 'string' ? answer.trim() : '';
+    if (value.length === 0) return Boolean(existing);
+    await opts.vault.set(vaultKey, value, [packageName]);
+    // The plugin reads options.<key>; config carries only the vault REF.
+    await setConfigValue({
+      scope: 'user',
+      cwd: opts.cwd,
+      path: optionsPath,
+      value: `\${vault:${vaultKey}}`,
+    });
+    return true;
+  }
+
+  if (field.kind === 'boolean') {
+    const answer = await confirm({ message: field.label, initialValue: true });
+    if (isCancel(answer)) return false;
+    await setConfigValue({ scope: 'user', cwd: opts.cwd, path: optionsPath, value: answer });
+    return true;
+  }
+
+  if (field.kind === 'select') {
+    const choices = field.options ?? [];
+    if (choices.length === 0) return false;
+    const answer = await select({
+      message: field.label,
+      options: choices.map((c) => ({ value: c, label: c })),
+    });
+    if (isCancel(answer)) return false;
+    await setConfigValue({ scope: 'user', cwd: opts.cwd, path: optionsPath, value: answer });
+    return true;
+  }
+
+  const answer = await text({
+    message: field.label,
+    ...(field.placeholder ? { placeholder: field.placeholder } : {}),
+  });
+  if (isCancel(answer)) return false;
+  const value = typeof answer === 'string' ? answer.trim() : '';
+  if (value.length === 0) return false;
+  await setConfigValue({ scope: 'user', cwd: opts.cwd, path: optionsPath, value });
+  return true;
+}

--- a/packages/plugin-channel-http/package.json
+++ b/packages/plugin-channel-http/package.json
@@ -46,6 +46,19 @@
     "plugin": {
       "entry": "./dist/index.js",
       "kind": "channel"
+    },
+    "setup": {
+      "title": "HTTP channel auth token",
+      "description": "Bearer token clients must send to the local HTTP API.",
+      "fields": [
+        {
+          "key": "authToken",
+          "label": "Auth token (bearer) for moxxy http",
+          "kind": "secret",
+          "vaultKey": "MOXXY_HTTP_TOKEN",
+          "required": true
+        }
+      ]
     }
   },
   "dependencies": {

--- a/packages/plugin-cli/src/session/picker-handlers.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.ts
@@ -159,7 +159,12 @@ function runPickerInstall(
         .filter(([, names]) => names && names.length > 0)
         .map(([kind, names]) => `${kind}: ${names!.join(', ')}`)
         .join('; ');
-      deps.setSystemNotice(`✓ installed ${res.installed}${kinds ? ` — registered ${kinds}` : ''}`);
+      const setupNote = res.needsSetup
+        ? `\n${res.needsSetup.required ? '⚠ required setup' : 'optional setup'}: "${res.needsSetup.title}" — run \`moxxy init\` to configure it.`
+        : '';
+      deps.setSystemNotice(
+        `✓ installed ${res.installed}${kinds ? ` — registered ${kinds}` : ''}${setupNote}`,
+      );
       ok = true;
     } catch (err) {
       deps.setSystemNotice(

--- a/packages/plugin-plugins-admin/src/index.ts
+++ b/packages/plugin-plugins-admin/src/index.ts
@@ -35,6 +35,13 @@ export {
 
 export { pinFirstPartySpec } from './pin.js';
 
+export {
+  listPluginSetups,
+  readPluginSetup,
+  setupFieldVaultKey,
+} from './setup-spec.js';
+export type { PluginSetupField, PluginSetupSpec } from '@moxxy/sdk';
+
 export { diffSnapshot, SNAPSHOT_KINDS } from './shared.js';
 
 export {

--- a/packages/plugin-plugins-admin/src/install.ts
+++ b/packages/plugin-plugins-admin/src/install.ts
@@ -5,6 +5,7 @@ import { createMutex, defineTool, z } from '@moxxy/sdk';
 import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { assertSafeNpmSpec, diffSnapshot, NPM_NAME_RE, type PluginSnapshot } from './shared.js';
 import { pinFirstPartySpec } from './pin.js';
+import { readPluginSetup } from './setup-spec.js';
 
 export type { PluginSnapshot } from './shared.js';
 
@@ -233,9 +234,21 @@ export function buildInstallPluginTool(deps: InstallPluginDeps) {
       });
       await deps.reload();
       const after = deps.snapshot();
+      // Surface the plugin's declarative setup step (moxxy.setup) so the
+      // caller can walk the user through it — the model relays the hint.
+      const setup = await readPluginSetup(packageName.replace(/@[^/@]+$/, ''));
       return {
         installed,
         registered: diffSnapshot(before, after),
+        ...(setup
+          ? {
+              needsSetup: {
+                title: setup.title,
+                required: setup.required === true,
+                hint: 'Run `moxxy init` to walk through its configuration.',
+              },
+            }
+          : {}),
       };
     },
   });

--- a/packages/plugin-plugins-admin/src/setup-spec.test.ts
+++ b/packages/plugin-plugins-admin/src/setup-spec.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { listPluginSetups, readPluginSetup, setupFieldVaultKey } from './setup-spec.js';
+
+let tmp: string;
+let prevHome: string | undefined;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-spec-'));
+  prevHome = process.env.MOXXY_HOME;
+  process.env.MOXXY_HOME = tmp;
+});
+
+afterEach(async () => {
+  if (prevHome === undefined) delete process.env.MOXXY_HOME;
+  else process.env.MOXXY_HOME = prevHome;
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+async function installFake(name: string, moxxy: unknown) {
+  const dir = path.join(tmp, 'plugins', 'node_modules', name);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, 'package.json'), JSON.stringify({ name, version: '1.0.0', moxxy }));
+}
+
+describe('readPluginSetup / listPluginSetups', () => {
+  it('reads a declared setup, ignores packages without one, survives bad JSON', async () => {
+    await installFake('@moxxy/plugin-channel-http', {
+      plugin: { entry: './dist/index.js' },
+      setup: { title: 'HTTP token', fields: [{ key: 'authToken', label: 'Token', kind: 'secret' }] },
+    });
+    await installFake('@moxxy/plugin-plain', { plugin: { entry: './dist/index.js' } });
+    await fs.mkdir(path.join(tmp, 'plugins', 'node_modules', 'broken'), { recursive: true });
+    await fs.writeFile(path.join(tmp, 'plugins', 'node_modules', 'broken', 'package.json'), '{nope');
+
+    expect((await readPluginSetup('@moxxy/plugin-channel-http'))?.title).toBe('HTTP token');
+    expect(await readPluginSetup('@moxxy/plugin-plain')).toBeNull();
+    expect(await readPluginSetup('@moxxy/not-installed')).toBeNull();
+
+    const all = await listPluginSetups();
+    expect(all.map((e) => e.packageName)).toEqual(['@moxxy/plugin-channel-http']);
+  });
+});
+
+describe('setupFieldVaultKey', () => {
+  it('explicit vaultKey wins; default derives <PKG>_<KEY> upper-snake', () => {
+    expect(
+      setupFieldVaultKey('@moxxy/plugin-channel-http', {
+        key: 'authToken', label: 'x', kind: 'secret', vaultKey: 'MOXXY_HTTP_TOKEN',
+      }),
+    ).toBe('MOXXY_HTTP_TOKEN');
+    expect(
+      setupFieldVaultKey('@moxxy/plugin-channel-http', { key: 'authToken', label: 'x', kind: 'secret' }),
+    ).toBe('PLUGIN_CHANNEL_HTTP_AUTH_TOKEN');
+  });
+});

--- a/packages/plugin-plugins-admin/src/setup-spec.ts
+++ b/packages/plugin-plugins-admin/src/setup-spec.ts
@@ -1,0 +1,66 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { moxxyPackageSchema, type PluginSetupField, type PluginSetupSpec } from '@moxxy/sdk';
+import { moxxyPath } from '@moxxy/sdk/server';
+
+// Same location install.ts manages; resolved directly (not imported from
+// install.ts) so install → setup-spec stays acyclic.
+const userPluginsDir = (): string => moxxyPath('plugins');
+
+/**
+ * Read a plugin's declarative setup step (`package.json#moxxy.setup`) from
+ * its INSTALLED location under `~/.moxxy/plugins` — no plugin code executes.
+ * Returns null when the package isn't installed or declares no setup.
+ * (Kernel-bundled plugins have no on-disk package.json; none declare setup.)
+ */
+export async function readPluginSetup(packageName: string): Promise<PluginSetupSpec | null> {
+  const pkgJson = path.join(userPluginsDir(), 'node_modules', packageName, 'package.json');
+  let raw: string;
+  try {
+    raw = await fs.readFile(pkgJson, 'utf8');
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = moxxyPackageSchema.safeParse(JSON.parse(raw)?.moxxy ?? {});
+    return parsed.success ? (parsed.data.setup ?? null) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Every user-scope installed package (name → setup spec) that declares one. */
+export async function listPluginSetups(): Promise<
+  ReadonlyArray<{ packageName: string; setup: PluginSetupSpec }>
+> {
+  const modules = path.join(userPluginsDir(), 'node_modules');
+  let names: string[] = [];
+  try {
+    for (const entry of await fs.readdir(modules)) {
+      if (entry.startsWith('.')) continue;
+      if (entry.startsWith('@')) {
+        for (const sub of await fs.readdir(path.join(modules, entry))) {
+          if (!sub.startsWith('.')) names.push(`${entry}/${sub}`);
+        }
+      } else {
+        names.push(entry);
+      }
+    }
+  } catch {
+    return [];
+  }
+  const out: Array<{ packageName: string; setup: PluginSetupSpec }> = [];
+  for (const name of names) {
+    const setup = await readPluginSetup(name);
+    if (setup) out.push({ packageName: name, setup });
+  }
+  return out;
+}
+
+/** Canonical vault entry name for a secret field: explicit `vaultKey`, else
+ *  `<PKG>_<KEY>` upper-snake (scope stripped: `@moxxy/plugin-x` → `PLUGIN_X`). */
+export function setupFieldVaultKey(packageName: string, field: PluginSetupField): string {
+  if (field.vaultKey) return field.vaultKey;
+  const pkg = packageName.replace(/^@[^/]+\//, '').replace(/[^a-zA-Z0-9]+/g, '_');
+  return `${pkg}_${field.key}`.replace(/([a-z])([A-Z])/g, '$1_$2').toUpperCase();
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -458,10 +458,14 @@ export {
   skillFrontmatterSchema,
   pluginManifestSchema,
   moxxyPackageSchema,
+  pluginSetupFieldSchema,
+  pluginSetupSchema,
   requirementSchema,
   type SkillFrontmatterInput,
   type PluginManifestInput,
   type MoxxyPackageInput,
+  type PluginSetupField,
+  type PluginSetupSpec,
 } from './schemas.js';
 
 export {

--- a/packages/sdk/src/schemas.ts
+++ b/packages/sdk/src/schemas.ts
@@ -89,11 +89,51 @@ export const pluginManifestSchema = z.object({
  *   requirements may be authored; per-tool/per-transcriber/per-anything
  *   runtime declarations were removed in favor of static analysis.
  */
+/**
+ * One field of a plugin's declarative setup step (`package.json#moxxy.setup`).
+ * Declarative-only so EVERY frontend (the init wizard, the TUI, desktop
+ * onboarding) can render it without executing plugin code:
+ * - `secret` values land in the VAULT (never plaintext config); the plugin's
+ *   `options.<key>` gets a `${vault:<name>}` ref, resolved at boot.
+ * - other kinds land at `plugins.packages.<pkg>.options.<key>` in the user
+ *   config through the shared schema-validated writer.
+ */
+export const pluginSetupFieldSchema = z.object({
+  key: z.string().min(1).regex(/^[a-zA-Z][a-zA-Z0-9_]*$/, 'key must be an identifier'),
+  label: z.string().min(1),
+  description: z.string().optional(),
+  kind: z.enum(['secret', 'string', 'boolean', 'select']),
+  /** Vault entry name for `secret` fields. Default: `<PKG>_<KEY>` upper-snake. */
+  vaultKey: z.string().min(1).optional(),
+  /** Choices for `select` fields. */
+  options: z.array(z.string().min(1)).optional(),
+  /** Required fields block completion; optional ones may stay unset. */
+  required: z.boolean().optional(),
+  placeholder: z.string().optional(),
+});
+
+/**
+ * A plugin's declarative configuration step, walked by `moxxy init` (and
+ * surfaced after an on-demand install). `required: true` means the plugin is
+ * left DISABLED until its required fields are provided — the author's way to
+ * say "this cannot work unconfigured".
+ */
+export const pluginSetupSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  required: z.boolean().optional(),
+  fields: z.array(pluginSetupFieldSchema).min(1),
+});
+
 export const moxxyPackageSchema = z.object({
   plugin: pluginManifestSchema.optional(),
   requirements: z.array(requirementSchema).optional(),
+  /** Declarative setup step users walk through in init / post-install. */
+  setup: pluginSetupSchema.optional(),
 });
 
+export type PluginSetupField = z.infer<typeof pluginSetupFieldSchema>;
+export type PluginSetupSpec = z.infer<typeof pluginSetupSchema>;
 export type SkillFrontmatterInput = z.infer<typeof skillFrontmatterSchema>;
 export type PluginManifestInput = z.infer<typeof pluginManifestSchema>;
 export type MoxxyPackageInput = z.infer<typeof moxxyPackageSchema>;

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -365,6 +365,8 @@ export interface PluginsAdminView {
   install?(idOrSpec: string): Promise<{
     readonly installed: string;
     readonly registered: Readonly<Partial<Record<string, ReadonlyArray<string>>>>;
+    /** Present when the package declares a `moxxy.setup` step to complete. */
+    readonly needsSetup?: { readonly title: string; readonly required: boolean };
   }>;
 }
 


### PR DESCRIPTION
Phase 9 — the final item of the slim + configure-on-demand program, kept last as ordered.

## What

Plugin authors can now hook into `moxxy init`: a **declarative setup step** at `package.json#moxxy.setup` — title, `required` flag, and typed fields (`secret` / `string` / `boolean` / `select`). Declarative-only by design: the wizard, the TUI, and desktop onboarding can all render it **without executing plugin code**, and specs are read straight from the installed `package.json`.

- **`moxxy init`** walks every installed plugin's step after the main wizard. Users with installed packages go through each plugin's configuration; authors choose `required: true` (skipping leaves the package **disabled** with a clear re-enable path) or optional ("configure it now?").
- **Where values land** — the vault pattern falls out cleanly: `secret` fields store in the VAULT and the plugin's `options.<key>` gets a `${vault:NAME}` ref (resolved at boot; the token never touches plaintext config — verified in tests). Other kinds persist at `plugins.packages.<pkg>.options.<key>` through the shared schema-validated writer.
- **Re-runs prefill**: an already-set secret shows "(already set — enter to keep)".
- **Post-install**: `install_plugin` and the `/plugins` picker surface `needsSetup` ("⚠ required setup: … — run \`moxxy init\`") the moment such a plugin lands.
- **Proof**: the HTTP channel declares its bearer token as a required secret field (`vaultKey: MOXXY_HTTP_TOKEN`, matching what it already reads from `options.authToken`/env).

## Follow-ups (documented, not in this PR)

In-TUI setup dialog reusing the provider-connect machinery (today the TUI points at `moxxy init`); desktop onboarding rendering the same specs over IPC; a generated mirror if a kernel-bundled plugin ever needs setup.

## Verification

Full gate green (a new install↔setup-spec import cycle was caught by `check:deps` and broken). 8 new tests across plugins-admin (spec reading, vault-key derivation, bad-JSON resilience) and the cli step walk (secret→vault+ref, required-skip disables, keep-on-enter, optional decline, `only` filter).