### PR TITLE
feat(tui): post-install plugin setup dialog + /setup command

### DIFF
--- a/.changeset/post-install-setup.md
+++ b/.changeset/post-install-setup.md
@@ -1,0 +1,15 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/plugin-plugins-admin': minor
+'@moxxy/cli': minor
+'@moxxy/plugin-cli': minor
+---
+
+Post-install setup resolves IN the TUI: installing a plugin that declares a
+`moxxy.setup` step now opens a configuration dialog on the spot (masked
+secrets, y/n booleans, select lists) instead of pointing at `moxxy init` —
+values persist through the same shared writer (secrets → vault +
+`${vault:NAME}` option refs). New `/setup [package]` command (re)configures
+any installed plugin and re-enables one left disabled by a skipped required
+setup. New `PluginsAdminView.setupSpec`/`applySetup` seams; the init wizard
+now shares the exact same `applySetupValues` write path.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -326,11 +326,6 @@ or recorded-on-purpose decision.
   discovery-loadable plugins in batches, pin on-demand installs to the CLI
   version (currently `latest`), desktop seed pack, TUI install/connect
   affordances.
-- [med, flaky] `workflows.test.ts` "a fileChanged edit runs the workflow ONCE
-  across two concurrent runners" fails under full-suite load (vi.waitFor 4s
-  timeout, file-watcher timing) but passes every isolated rerun — tripped 3×
-  in one day's gates. Raise the timeout / gate it behind a serial pool, or it
-  keeps costing a rerun per PR. `packages/cli/src/setup/workflows.test.ts:567`.
 - [med, refactor] `plugin-memory`(+`memory-consolidate`) cannot unbundle as-is:
   two Plugin instances in one package (discovery loads a single default export),
   `moxxy memory`/`doctor` import `MemoryStore` directly, and setup builds it

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -5,6 +5,7 @@ import {
   diffSnapshot,
   findCatalogEntryForContribution,
   INSTALLABLE_PLUGIN_CATALOG,
+  applySetupValues,
   installPluginPackagePinned,
   readPluginSetup,
   resolveCatalogEntry,
@@ -242,6 +243,7 @@ function wirePluginsAdminView(
   setPluginEnabledLive: (packageName: string, enabled: boolean) => Promise<void>,
   categoryLive: CategoryDefaultLive,
   logger: BuildBuiltinsArgs['logger'],
+  vault: BuildBuiltinsArgs['vault'],
 ): void {
   // The live disabled-set, the installable catalog, and the same plug/unplug +
   // swap-default closures the model tools use. A RemoteSession leaves this
@@ -293,6 +295,28 @@ function wirePluginsAdminView(
           ? { needsSetup: { title: setup.title, required: setup.required === true } }
           : {}),
       };
+    },
+    // Declarative setup step (moxxy.setup) — plain data for any renderer.
+    setupSpec: (packageName) => readPluginSetup(packageName),
+    // Persist collected values through the ONE shared writer (secrets → vault
+    // + ${vault:NAME} ref); completeness drives enable/disable exactly like
+    // the init wizard, so /setup can also RE-ENABLE a package a skipped
+    // required setup left disabled.
+    applySetup: async (packageName, values) => {
+      const setup = await readPluginSetup(packageName);
+      if (!setup) return { complete: true, missing: [] };
+      const result = await applySetupValues({
+        vault,
+        cwd: process.cwd(),
+        packageName,
+        setup,
+        values,
+      });
+      if (setup.required === true) {
+        await persistPluginEnabled(packageName, result.complete);
+        if (result.complete) await session.pluginHost.reload();
+      }
+      return result;
     },
   };
 }
@@ -429,7 +453,7 @@ export function buildBuiltinsCore(args: BuildBuiltinsArgs): BuiltBuiltinsCore {
     categoryLive,
   });
 
-  wirePluginsAdminView(session, disabledPackages, setPluginEnabledLive, categoryLive, logger);
+  wirePluginsAdminView(session, disabledPackages, setPluginEnabledLive, categoryLive, logger, vault);
 
   const scheduler = buildSchedulerSlice(session, schedulerRunner, logger);
   entries.push(scheduler.entry);

--- a/packages/cli/src/setup/workflows.test.ts
+++ b/packages/cli/src/setup/workflows.test.ts
@@ -563,9 +563,12 @@ describe('buildWorkflowsIntegration afterWorkflow wiring', () => {
     const b = await boot('runner-B');
     try {
       await fs.writeFile(path.join(watchedDir, 'note.txt'), 'hello');
-      // Wait until at least one runner has fired...
+      // Wait until at least one runner has fired. Generous timeout: under
+      // full-suite load the fs watcher + debounce routinely exceeded 4s,
+      // making this the repo's flakiest test (TECH_DEBT 2026-07-03) — the
+      // assertion is about AT-MOST-ONCE semantics, not latency.
       await vi.waitFor(() => expect(runs.length).toBeGreaterThanOrEqual(1), {
-        timeout: 4000,
+        timeout: 20000,
         interval: 50,
       });
       // ...then give the other runner ample time to (wrongly) also fire. It must

--- a/packages/cli/src/wizard/plugin-setup-steps.ts
+++ b/packages/cli/src/wizard/plugin-setup-steps.ts
@@ -1,10 +1,12 @@
 import { confirm, isCancel, log, password, select, text } from '@clack/prompts';
-import { setConfigValue, setPluginEnabled } from '@moxxy/config';
+import { setPluginEnabled } from '@moxxy/config';
 import {
+  applySetupValues,
   listPluginSetups,
   setupFieldVaultKey,
   type PluginSetupField,
   type PluginSetupSpec,
+  type SetupFieldValue,
 } from '@moxxy/plugin-plugins-admin';
 import { colors } from '../colors.js';
 
@@ -46,13 +48,22 @@ export async function runPluginSetupSteps(opts: PluginSetupStepsOptions): Promis
       if (isCancel(want) || !want) continue;
     }
 
-    let complete = true;
+    const values: Record<string, SetupFieldValue> = {};
     for (const field of setup.fields) {
-      const done = await collectField(packageName, field, opts);
-      if (!done && field.required !== false && setup.required) complete = false;
+      const v = await collectField(packageName, field, opts);
+      if (v !== undefined) values[field.key] = v;
     }
+    // ONE write implementation for every frontend (TUI dialog included):
+    // secrets → vault + ${vault:NAME} ref; the rest → options.<key>.
+    const result = await applySetupValues({
+      vault: opts.vault,
+      cwd: opts.cwd,
+      packageName,
+      setup,
+      values,
+    });
 
-    if (!complete) {
+    if (!result.complete && setup.required) {
       await setPluginEnabled(packageName, false);
       log.warn(
         `${packageName} left DISABLED — its required setup is incomplete. ` +
@@ -62,60 +73,43 @@ export async function runPluginSetupSteps(opts: PluginSetupStepsOptions): Promis
   }
 }
 
-/** Returns true when the field ended up with a value (kept or entered). */
+/** Collect one field's value (undefined = skipped / keep-existing). */
 async function collectField(
   packageName: string,
   field: PluginSetupField,
   opts: PluginSetupStepsOptions,
-): Promise<boolean> {
-  const optionsPath = `plugins.packages.${packageName}.options.${field.key}`;
-
+): Promise<SetupFieldValue | undefined> {
   if (field.kind === 'secret') {
     const vaultKey = setupFieldVaultKey(packageName, field);
     const existing = await opts.vault.get(vaultKey).catch(() => null);
     const answer = await password({
       message: `${field.label}${existing ? colors.dim(' (already set — enter to keep)') : ''}`,
     });
-    if (isCancel(answer)) return Boolean(existing);
+    if (isCancel(answer)) return undefined;
     const value = typeof answer === 'string' ? answer.trim() : '';
-    if (value.length === 0) return Boolean(existing);
-    await opts.vault.set(vaultKey, value, [packageName]);
-    // The plugin reads options.<key>; config carries only the vault REF.
-    await setConfigValue({
-      scope: 'user',
-      cwd: opts.cwd,
-      path: optionsPath,
-      value: `\${vault:${vaultKey}}`,
-    });
-    return true;
+    return value.length > 0 ? value : undefined;
   }
 
   if (field.kind === 'boolean') {
     const answer = await confirm({ message: field.label, initialValue: true });
-    if (isCancel(answer)) return false;
-    await setConfigValue({ scope: 'user', cwd: opts.cwd, path: optionsPath, value: answer });
-    return true;
+    return isCancel(answer) ? undefined : answer;
   }
 
   if (field.kind === 'select') {
     const choices = field.options ?? [];
-    if (choices.length === 0) return false;
+    if (choices.length === 0) return undefined;
     const answer = await select({
       message: field.label,
       options: choices.map((c) => ({ value: c, label: c })),
     });
-    if (isCancel(answer)) return false;
-    await setConfigValue({ scope: 'user', cwd: opts.cwd, path: optionsPath, value: answer });
-    return true;
+    return isCancel(answer) ? undefined : (answer as string);
   }
 
   const answer = await text({
     message: field.label,
     ...(field.placeholder ? { placeholder: field.placeholder } : {}),
   });
-  if (isCancel(answer)) return false;
+  if (isCancel(answer)) return undefined;
   const value = typeof answer === 'string' ? answer.trim() : '';
-  if (value.length === 0) return false;
-  await setConfigValue({ scope: 'user', cwd: opts.cwd, path: optionsPath, value });
-  return true;
+  return value.length > 0 ? value : undefined;
 }

--- a/packages/plugin-cli/src/components/PluginSetupDialog.tsx
+++ b/packages/plugin-cli/src/components/PluginSetupDialog.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { PluginSetupSpec } from '@moxxy/sdk';
+import { Colors } from '../theme.js';
+import { Modal } from './Modal.js';
+import {
+  createPluginSetupFlow,
+  type PluginSetupFlow,
+} from '../session/plugin-setup-flow.js';
+
+export interface PluginSetupDialogProps {
+  readonly packageName: string;
+  readonly spec: PluginSetupSpec;
+  /** Collected values (null = cancelled). Parent persists via applySetup. */
+  readonly onFinish: (values: Readonly<Record<string, string | boolean>> | null) => void;
+}
+
+/**
+ * Post-install / `/setup` configuration dialog: walks the plugin's declared
+ * fields right in the InteractiveZone slot — no leaving the TUI for
+ * `moxxy init`. Secrets render masked; booleans are y/n; selects cycle with
+ * ↑/↓. Tab skips optional fields; Esc cancels the whole step (a required
+ * setup then leaves the package disabled, exactly like skipping it in init).
+ */
+export const PluginSetupDialog: React.FC<PluginSetupDialogProps> = ({
+  packageName,
+  spec,
+  onFinish,
+}) => {
+  const flowRef = React.useRef<PluginSetupFlow | null>(null);
+  if (flowRef.current === null) {
+    flowRef.current = createPluginSetupFlow(spec, onFinish);
+  }
+  const flow = flowRef.current;
+  const [, bump] = React.useReducer((n: number) => n + 1, 0);
+  const [buffer, setBuffer] = React.useState('');
+  const [selectIndex, setSelectIndex] = React.useState(0);
+
+  const field = flow.current();
+  const state = flow.state();
+
+  useInput((input, key) => {
+    if (key.escape) {
+      flow.cancel();
+      return;
+    }
+    if (!field) return;
+    if (key.tab) {
+      flow.skip();
+      setBuffer('');
+      setSelectIndex(0);
+      bump();
+      return;
+    }
+    if (field.kind === 'boolean') {
+      const ch = input.toLowerCase();
+      if (ch === 'y') flow.submit(true);
+      else if (ch === 'n') flow.submit(false);
+      else return;
+      bump();
+      return;
+    }
+    if (field.kind === 'select') {
+      const choices = field.options ?? [];
+      if (key.upArrow) setSelectIndex((i) => (i - 1 + choices.length) % choices.length);
+      else if (key.downArrow) setSelectIndex((i) => (i + 1) % choices.length);
+      else if (key.return && choices.length > 0) {
+        flow.submit(choices[selectIndex]!);
+        setSelectIndex(0);
+        bump();
+      }
+      return;
+    }
+    // secret / string
+    if (key.return) {
+      flow.submit(buffer);
+      setBuffer('');
+      bump();
+      return;
+    }
+    if (key.backspace || key.delete) {
+      setBuffer((b) => b.slice(0, -1));
+      return;
+    }
+    if (input && !key.ctrl && !key.meta && !key.upArrow && !key.downArrow) {
+      setBuffer((b) => b + input);
+    }
+  });
+
+  const progress = `${Math.min(state.index + 1, spec.fields.length)}/${spec.fields.length}`;
+
+  return (
+    <Modal title={`setup ${packageName}`} subtitle={spec.title}>
+      {spec.description ? <Text color={Colors.chrome}>{spec.description}</Text> : null}
+      {field ? (
+        <Box flexDirection="column">
+          {state.error ? <Text color={Colors.danger}>{state.error}</Text> : null}
+          <Text>
+            <Text color={Colors.chrome}>[{progress}] </Text>
+            {field.label}
+            {field.required === false ? <Text color={Colors.chrome}> (optional)</Text> : null}
+          </Text>
+          {field.description ? <Text color={Colors.chrome}>{field.description}</Text> : null}
+          {field.kind === 'boolean' ? (
+            <Text color={Colors.chrome}>y yes · n no · tab skip · esc cancel</Text>
+          ) : field.kind === 'select' ? (
+            <Box flexDirection="column">
+              {(field.options ?? []).map((c, i) => (
+                <Text key={c} color={i === selectIndex ? Colors.active : undefined}>
+                  {i === selectIndex ? '› ' : '  '}
+                  {c}
+                </Text>
+              ))}
+              <Text color={Colors.chrome}>↑↓ choose · enter confirm · esc cancel</Text>
+            </Box>
+          ) : (
+            <>
+              <Text>
+                <Text color={Colors.active}>
+                  {field.kind === 'secret' ? '•'.repeat(buffer.length) : buffer}
+                </Text>
+                <Text color={Colors.chrome}>▏</Text>
+              </Text>
+              <Text color={Colors.chrome}>
+                {field.kind === 'secret'
+                  ? 'enter save (empty keeps an existing value) · esc cancel'
+                  : 'enter save · tab skip · esc cancel'}
+              </Text>
+            </>
+          )}
+        </Box>
+      ) : (
+        <Text color={Colors.chrome}>saving…</Text>
+      )}
+    </Modal>
+  );
+};

--- a/packages/plugin-cli/src/components/SlashCommands.tsx
+++ b/packages/plugin-cli/src/components/SlashCommands.tsx
@@ -48,6 +48,7 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: 'mcp', description: 'Enable / disable / remove MCP servers' },
   { name: 'plugins', description: 'Plug / unplug & install plugins — opens a tabbed picker' },
   { name: 'settings', description: 'Curated config panel: reasoning, caching, elision, theme… (alias /config)' },
+  { name: 'setup', description: 'Configure an installed plugin\u2019s declared setup step (/setup [package])' },
   {
     name: 'channels',
     description: 'Run Slack / Telegram bots on their own runner — configure, start, stop',

--- a/packages/plugin-cli/src/session/InteractiveZone.tsx
+++ b/packages/plugin-cli/src/session/InteractiveZone.tsx
@@ -4,6 +4,7 @@ import type { ClientSession as Session } from '@moxxy/sdk';
 import { PermissionDialog } from '../components/PermissionDialog.js';
 import { ApprovalDialog } from '../components/ApprovalDialog.js';
 import { ProviderConnectDialog } from '../components/ProviderConnectDialog.js';
+import { PluginSetupDialog } from '../components/PluginSetupDialog.js';
 import { InputBox } from '../components/InputBox.js';
 import { ListPicker } from '../components/ListPicker.js';
 import { QueueView } from '../components/QueueView.js';
@@ -19,6 +20,12 @@ interface InteractiveZoneProps {
   pendingPermissionDepth: number;
   pendingApproval: PendingApproval | null;
   picker: Picker;
+  /** Post-install / /setup plugin-configuration dialog target. */
+  pluginSetup: {
+    packageName: string;
+    spec: import('@moxxy/sdk').PluginSetupSpec;
+  } | null;
+  onPluginSetupFinish: (values: Readonly<Record<string, string | boolean>> | null) => void;
   /** Inline provider-connect dialog target (SessionView owns the state). */
   providerConnect: { providerId: string; modelId: string } | null;
   onProviderConnectSuccess: (note?: string) => void;
@@ -59,6 +66,8 @@ export const InteractiveZone: React.FC<InteractiveZoneProps> = ({
   pendingPermissionDepth,
   pendingApproval,
   picker,
+  pluginSetup,
+  onPluginSetupFinish,
   providerConnect,
   onProviderConnectSuccess,
   onProviderConnectCancel,
@@ -94,6 +103,16 @@ export const InteractiveZone: React.FC<InteractiveZoneProps> = ({
       <ApprovalDialog
         request={pendingApproval.request}
         onDecide={(decision) => onApprovalDecide(decision)}
+      />
+    );
+  }
+  if (pluginSetup) {
+    return (
+      <PluginSetupDialog
+        key={pluginSetup.packageName}
+        packageName={pluginSetup.packageName}
+        spec={pluginSetup.spec}
+        onFinish={onPluginSetupFinish}
       />
     );
   }

--- a/packages/plugin-cli/src/session/SessionView.tsx
+++ b/packages/plugin-cli/src/session/SessionView.tsx
@@ -224,6 +224,14 @@ export const SessionView: React.FC<SessionViewProps> = ({
     modelId: string;
   } | null>(null);
 
+  // Post-install / /setup plugin-configuration dialog. Carries an optional
+  // continuation (install-confirm's slash rerun waits for configuration).
+  const [pluginSetup, setPluginSetup] = React.useState<{
+    packageName: string;
+    spec: import('@moxxy/sdk').PluginSetupSpec;
+    then?: () => void;
+  } | null>(null);
+
   // Late-bound so the picker handler (memoized above handleSubmit's
   // declaration) can re-dispatch a slash line through the normal submit path
   // — used by install-confirm to re-run the command that hit the missing
@@ -241,6 +249,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
         refreshMcpStatus,
         installInFlightRef,
         openProviderConnect: setProviderConnect,
+        openPluginSetup: setPluginSetup,
         rerunSlash: (line) => rerunSlashRef.current(line),
         ...(onSwitchSession ? { requestSessionSwitch: onSwitchSession } : {}),
       }),
@@ -307,6 +316,12 @@ export const SessionView: React.FC<SessionViewProps> = ({
       session.log.clear();
       if (notice) setSystemNotice(notice);
     }
+  };
+
+  // A cancelled REQUIRED setup mirrors init's skip semantics: applySetup with
+  // no values computes incompleteness and disables the package.
+  const deactivateIncompleteSetup = (packageName: string): void => {
+    void session.pluginsAdmin?.applySetup?.(packageName, {}).catch(() => undefined);
   };
 
   const handleSubmit = async (text: string): Promise<void> => {
@@ -435,6 +450,44 @@ export const SessionView: React.FC<SessionViewProps> = ({
         pendingPermissionDepth={Math.max(0, permissions.pendingPermissions.length - 1)}
         pendingApproval={pendingApproval}
         picker={picker}
+        pluginSetup={pluginSetup}
+        onPluginSetupFinish={(values) => {
+          const target = pluginSetup;
+          setPluginSetup(null);
+          if (!target) return;
+          const after = target.then;
+          if (values === null) {
+            if (target.spec.required) {
+              deactivateIncompleteSetup(target.packageName);
+              setSystemNotice(
+                `setup cancelled — ${target.packageName} stays disabled until configured (/setup ${target.packageName})`,
+              );
+            } else {
+              setSystemNotice(`setup skipped — /setup ${target.packageName} to configure later`);
+            }
+            after?.();
+            return;
+          }
+          void (async () => {
+            try {
+              const res = await session.pluginsAdmin?.applySetup?.(target.packageName, values);
+              if (res && !res.complete) {
+                setSystemNotice(
+                  `⚠ ${target.packageName} setup incomplete (missing: ${res.missing.join(', ')})` +
+                    (target.spec.required ? ' — package disabled until configured' : ''),
+                );
+              } else {
+                setSystemNotice(`✓ ${target.packageName} configured`);
+              }
+            } catch (err) {
+              setSystemNotice(
+                `setup failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            } finally {
+              after?.();
+            }
+          })();
+        }}
         providerConnect={providerConnect}
         onProviderConnectSuccess={(note) => {
           const target = providerConnect;

--- a/packages/plugin-cli/src/session/picker-handlers.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.ts
@@ -43,6 +43,17 @@ export interface PickerHandlerDeps {
    * original code path then finds the contribution registered.
    */
   rerunSlash?: (line: string) => void;
+  /**
+   * Open the plugin-setup dialog (SessionView owns the state). `then` runs
+   * after the setup finishes or is cancelled — the install-confirm rerun
+   * waits for configuration so e.g. a freshly-installed channel is usable
+   * the moment the original command re-executes.
+   */
+  openPluginSetup?: (target: {
+    packageName: string;
+    spec: import('@moxxy/sdk').PluginSetupSpec;
+    then?: () => void;
+  }) => void;
 }
 
 export function makePickerHandler(deps: PickerHandlerDeps): (picker: Picker, id: string) => void {
@@ -70,6 +81,9 @@ export function makePickerHandler(deps: PickerHandlerDeps): (picker: Picker, id:
     }
     if (kind === 'settings') {
       return handleSettingSelected(id, deps);
+    }
+    if (kind === 'plugin-setup-pick') {
+      return handlePluginSetupPicked(id, deps);
     }
     if (kind === 'sessions') {
       return handleSessionSelected(id, deps);
@@ -159,13 +173,27 @@ function runPickerInstall(
         .filter(([, names]) => names && names.length > 0)
         .map(([kind, names]) => `${kind}: ${names!.join(', ')}`)
         .join('; ');
-      const setupNote = res.needsSetup
-        ? `\n${res.needsSetup.required ? '⚠ required setup' : 'optional setup'}: "${res.needsSetup.title}" — run \`moxxy init\` to configure it.`
-        : '';
-      deps.setSystemNotice(
-        `✓ installed ${res.installed}${kinds ? ` — registered ${kinds}` : ''}${setupNote}`,
-      );
+      deps.setSystemNotice(`✓ installed ${res.installed}${kinds ? ` — registered ${kinds}` : ''}`);
       ok = true;
+      // Configure right here when the plugin declares a setup step — the
+      // dialog collects the fields and applySetup persists them (secrets →
+      // vault). Fall back to pointing at `moxxy init` when the session can't
+      // (RemoteSession) so the hint never silently disappears.
+      if (res.needsSetup) {
+        const admin2 = deps.session.pluginsAdmin;
+        const pkg = admin2?.catalog().find((e) => e.id === target || e.packageName === target)?.packageName ?? target;
+        const spec = await admin2?.setupSpec?.(pkg).catch(() => null);
+        if (spec && deps.openPluginSetup) {
+          const after = opts.onSuccess;
+          deps.openPluginSetup({ packageName: pkg, spec, ...(after ? { then: after } : {}) });
+          if (opts.reopenPluginsPicker) return; // dialog owns the zone; skip reopen
+          return;
+        }
+        deps.setSystemNotice(
+          `✓ installed ${res.installed} — ${res.needsSetup.required ? '⚠ required setup' : 'optional setup'}: ` +
+            `"${res.needsSetup.title}" — run \`moxxy init\` (or /setup ${pkg}) to configure it.`,
+        );
+      }
     } catch (err) {
       deps.setSystemNotice(
         `install failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -177,6 +205,20 @@ function runPickerInstall(
       if (opts.reopenPluginsPicker) openPluginsPicker(deps);
     }
     if (ok) opts.onSuccess?.();
+  })();
+}
+
+/** `/setup` pick list: open the setup dialog for the chosen package. */
+function handlePluginSetupPicked(id: string, deps: PickerHandlerDeps): void {
+  const admin = deps.session.pluginsAdmin;
+  if (!admin?.setupSpec || !deps.openPluginSetup) return;
+  void (async () => {
+    const spec = await admin.setupSpec!(id).catch(() => null);
+    if (!spec) {
+      deps.setSystemNotice(`${id} declares no setup step`);
+      return;
+    }
+    deps.openPluginSetup!({ packageName: id, spec });
   })();
 }
 

--- a/packages/plugin-cli/src/session/plugin-setup-flow.test.ts
+++ b/packages/plugin-cli/src/session/plugin-setup-flow.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PluginSetupSpec } from '@moxxy/sdk';
+import { createPluginSetupFlow } from './plugin-setup-flow.js';
+
+const SPEC: PluginSetupSpec = {
+  title: 'T',
+  required: true,
+  fields: [
+    { key: 'token', label: 'Token', kind: 'secret' },
+    { key: 'region', label: 'Region', kind: 'select', options: ['eu', 'us'], required: false },
+    { key: 'verbose', label: 'Verbose', kind: 'boolean', required: false },
+  ],
+};
+
+describe('createPluginSetupFlow', () => {
+  it('walks fields, accumulates values, finishes with the collected map', () => {
+    const onFinish = vi.fn();
+    const flow = createPluginSetupFlow(SPEC, onFinish);
+    expect(flow.current()?.key).toBe('token');
+    flow.submit('sk-1');
+    expect(flow.current()?.key).toBe('region');
+    flow.submit('eu');
+    flow.submit(false);
+    expect(onFinish).toHaveBeenCalledWith({ token: 'sk-1', region: 'eu', verbose: false });
+    expect(flow.state().done).toBe(true);
+  });
+
+  it('refuses to skip a required non-secret field, allows optional skips', () => {
+    const spec: PluginSetupSpec = {
+      title: 'T',
+      fields: [
+        { key: 'name', label: 'Name', kind: 'string' },
+        { key: 'note', label: 'Note', kind: 'string', required: false },
+      ],
+    };
+    const onFinish = vi.fn();
+    const flow = createPluginSetupFlow(spec, onFinish);
+    flow.skip();
+    expect(flow.state().error).toContain('required');
+    flow.submit('moxxy');
+    flow.skip();
+    expect(onFinish).toHaveBeenCalledWith({ name: 'moxxy' });
+  });
+
+  it('empty submit on a required SECRET advances (existing vault value may satisfy)', () => {
+    const onFinish = vi.fn();
+    const flow = createPluginSetupFlow(SPEC, onFinish);
+    flow.submit('');
+    expect(flow.state().error).toBeNull();
+    expect(flow.current()?.key).toBe('region');
+  });
+
+  it('cancel finishes with null exactly once', () => {
+    const onFinish = vi.fn();
+    const flow = createPluginSetupFlow(SPEC, onFinish);
+    flow.cancel();
+    flow.cancel();
+    flow.submit('late');
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(onFinish).toHaveBeenCalledWith(null);
+  });
+});

--- a/packages/plugin-cli/src/session/plugin-setup-flow.ts
+++ b/packages/plugin-cli/src/session/plugin-setup-flow.ts
@@ -1,0 +1,88 @@
+import type { PluginSetupField, PluginSetupSpec } from '@moxxy/sdk';
+
+/**
+ * Headless field-walk behind the post-install / `/setup` dialog: one field
+ * at a time, values accumulate, Tab skips an optional field, Esc cancels the
+ * whole step. Pure state transitions so the Ink component stays a renderer
+ * and the semantics are unit-testable.
+ */
+export interface PluginSetupFlowState {
+  readonly index: number;
+  readonly values: Readonly<Record<string, string | boolean>>;
+  readonly error: string | null;
+  readonly done: boolean;
+  readonly cancelled: boolean;
+}
+
+export interface PluginSetupFlow {
+  readonly spec: PluginSetupSpec;
+  state(): PluginSetupFlowState;
+  current(): PluginSetupField | null;
+  /** Submit the current field's value. Empty string on a required field
+   *  errors (secrets excluded — an existing vault entry may satisfy it;
+   *  completeness is decided by applySetup). */
+  submit(value: string | boolean): void;
+  /** Skip the current field (optional fields; secrets = keep existing). */
+  skip(): void;
+  cancel(): void;
+}
+
+export function createPluginSetupFlow(
+  spec: PluginSetupSpec,
+  onFinish: (values: Readonly<Record<string, string | boolean>> | null) => void,
+): PluginSetupFlow {
+  let index = 0;
+  let error: string | null = null;
+  let done = false;
+  let cancelled = false;
+  const values: Record<string, string | boolean> = {};
+
+  const finish = (): void => {
+    if (done || cancelled) return;
+    done = true;
+    onFinish(values);
+  };
+
+  const advance = (): void => {
+    error = null;
+    index += 1;
+    if (index >= spec.fields.length) finish();
+  };
+
+  return {
+    spec,
+    state: () => ({ index, values: { ...values }, error, done, cancelled }),
+    current: () => (done || cancelled ? null : (spec.fields[index] ?? null)),
+    submit: (value) => {
+      const field = spec.fields[index];
+      if (!field || done || cancelled) return;
+      if (typeof value === 'string' && value.trim().length === 0) {
+        // Empty submit = skip semantics; required non-secret fields refuse
+        // (a required SECRET may be satisfied by an existing vault entry —
+        // applySetup decides completeness).
+        if (field.required !== false && field.kind !== 'secret') {
+          error = `${field.label} is required`;
+          return;
+        }
+        advance();
+        return;
+      }
+      values[field.key] = typeof value === 'string' ? value.trim() : value;
+      advance();
+    },
+    skip: () => {
+      const field = spec.fields[index];
+      if (!field || done || cancelled) return;
+      if (field.required !== false && field.kind !== 'secret') {
+        error = `${field.label} is required (esc to cancel the whole setup)`;
+        return;
+      }
+      advance();
+    },
+    cancel: () => {
+      if (done || cancelled) return;
+      cancelled = true;
+      onFinish(null);
+    },
+  };
+}

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -39,6 +39,11 @@ export interface SlashDeps {
    * {@link canSwitchSession}) — `/collab` then degrades to a notice.
    */
   requestCollab?: (goal?: string) => void;
+  /** Open the plugin-setup dialog (SessionView owns the state). */
+  openPluginSetup?: (target: {
+    packageName: string;
+    spec: import('@moxxy/sdk').PluginSetupSpec;
+  }) => void;
 }
 
 export function runSlash(cmd: string, deps: SlashDeps): void {
@@ -147,6 +152,8 @@ export function runSlash(cmd: string, deps: SlashDeps): void {
     case 'settings':
     case 'config':
       return openSettingsPicker(deps);
+    case 'setup':
+      return openPluginSetupEntry(deps, args);
     case 'channels':
       deps.setSystemNotice(null);
       deps.setOverlay({ kind: 'channels' });
@@ -335,6 +342,61 @@ export interface OpenSettingsPickerDeps {
   session: Session;
   setPicker: (p: Picker) => void;
   setSystemNotice: (msg: string | null) => void;
+}
+
+/**
+ * `/setup [package]` — (re)configure an installed plugin's declared setup
+ * step in place: with an argument opens its dialog directly (catalog ids
+ * accepted); bare `/setup` lists installed plugins that declare one. Also
+ * the recovery path for a required setup skipped at init (completing it
+ * re-enables the package).
+ */
+export function openPluginSetupEntry(deps: SlashDeps, arg = ''): void {
+  const admin = deps.session.pluginsAdmin;
+  if (!admin?.setupSpec || !deps.openPluginSetup) {
+    deps.setSystemNotice('plugin setup is not available on this session — run `moxxy init` instead');
+    return;
+  }
+  const target = arg.trim();
+  void (async () => {
+    try {
+      if (target) {
+        const pkg =
+          admin.catalog().find((e) => e.id === target || e.packageName === target)?.packageName ??
+          target;
+        const spec = await admin.setupSpec!(pkg);
+        if (!spec) {
+          deps.setSystemNotice(`${pkg} is not installed or declares no setup step`);
+          return;
+        }
+        deps.openPluginSetup!({ packageName: pkg, spec });
+        return;
+      }
+      // Bare /setup: list installed plugins that declare a setup step.
+      const installed = admin.loaded().filter((pl) => pl.installed);
+      const withSpecs: ListPickerOption[] = [];
+      for (const pl of installed) {
+        const spec = await admin.setupSpec!(pl.name).catch(() => null);
+        if (spec) {
+          withSpecs.push({
+            id: pl.name,
+            label: pl.name,
+            description: truncate(spec.title, 66),
+            ...(spec.required ? { badge: 'required', badgeColor: 'yellow' } : {}),
+          });
+        }
+      }
+      if (withSpecs.length === 0) {
+        deps.setSystemNotice('no installed plugin declares a setup step');
+        return;
+      }
+      deps.setPicker({ kind: 'plugin-setup-pick', title: 'Configure a plugin', options: withSpecs });
+    } catch (err) {
+      deps.setSystemNotice(
+        `setup failed to open: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  })();
 }
 
 export function openSettingsPicker(deps: OpenSettingsPickerDeps): void {

--- a/packages/plugin-cli/src/session/types.ts
+++ b/packages/plugin-cli/src/session/types.ts
@@ -69,6 +69,13 @@ export type Picker =
       kind: 'settings';
       title: string;
       options: ReadonlyArray<ListPickerOption>;
+    }
+  | {
+      /** `/setup` with no argument — pick an installed plugin that declares
+       *  a moxxy.setup step; selection opens the setup dialog. */
+      kind: 'plugin-setup-pick';
+      title: string;
+      options: ReadonlyArray<ListPickerOption>;
     };
 
 export interface PendingPermission {

--- a/packages/plugin-plugins-admin/src/index.ts
+++ b/packages/plugin-plugins-admin/src/index.ts
@@ -36,9 +36,14 @@ export {
 export { pinFirstPartySpec } from './pin.js';
 
 export {
+  applySetupValues,
   listPluginSetups,
   readPluginSetup,
   setupFieldVaultKey,
+  type ApplySetupOptions,
+  type ApplySetupResult,
+  type SetupFieldValue,
+  type SetupSpecVault,
 } from './setup-spec.js';
 export type { PluginSetupField, PluginSetupSpec } from '@moxxy/sdk';
 

--- a/packages/plugin-plugins-admin/src/setup-spec.ts
+++ b/packages/plugin-plugins-admin/src/setup-spec.ts
@@ -64,3 +64,74 @@ export function setupFieldVaultKey(packageName: string, field: PluginSetupField)
   const pkg = packageName.replace(/^@[^/]+\//, '').replace(/[^a-zA-Z0-9]+/g, '_');
   return `${pkg}_${field.key}`.replace(/([a-z])([A-Z])/g, '$1_$2').toUpperCase();
 }
+
+/** The vault slice setup writes need (structural — implemented by the CLI's
+ *  VaultStore; kept here so both the init wizard and the TUI's post-install
+ *  dialog share ONE write implementation). */
+export interface SetupSpecVault {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, tags?: ReadonlyArray<string>): Promise<void>;
+}
+
+export type SetupFieldValue = string | boolean;
+
+export interface ApplySetupOptions {
+  readonly vault: SetupSpecVault;
+  readonly cwd: string;
+  readonly packageName: string;
+  readonly setup: PluginSetupSpec;
+  /** Collected values keyed by field key. Missing keys are left untouched. */
+  readonly values: Readonly<Record<string, SetupFieldValue>>;
+  /** Injectable config writer (tests). Defaults to @moxxy/config setConfigValue. */
+  readonly writeConfig?: (path: string, value: unknown) => Promise<void>;
+}
+
+export interface ApplySetupResult {
+  /** True when every required field now has a value (written or pre-existing). */
+  readonly complete: boolean;
+  /** Required field keys still unsatisfied. */
+  readonly missing: ReadonlyArray<string>;
+}
+
+/**
+ * Persist collected setup values — THE single write implementation behind
+ * every frontend (init wizard, TUI dialog, /setup): secrets go to the vault
+ * and the plugin's `options.<key>` gets a `${vault:<name>}` ref (resolved at
+ * boot, never plaintext); other kinds land at
+ * `plugins.packages.<pkg>.options.<key>` via the shared validated writer.
+ * Completeness counts a required secret as satisfied when the vault already
+ * holds it (re-runs / enter-to-keep).
+ */
+export async function applySetupValues(opts: ApplySetupOptions): Promise<ApplySetupResult> {
+  const writeConfig =
+    opts.writeConfig ??
+    (async (path: string, value: unknown) => {
+      const { setConfigValue } = await import('@moxxy/config');
+      await setConfigValue({ scope: 'user', cwd: opts.cwd, path, value });
+    });
+
+  const missing: string[] = [];
+  for (const field of opts.setup.fields) {
+    const optionsPath = `plugins.packages.${opts.packageName}.options.${field.key}`;
+    const provided = opts.values[field.key];
+
+    if (field.kind === 'secret') {
+      const vaultKey = setupFieldVaultKey(opts.packageName, field);
+      if (typeof provided === 'string' && provided.trim().length > 0) {
+        await opts.vault.set(vaultKey, provided.trim(), [opts.packageName]);
+        await writeConfig(optionsPath, `\${vault:${vaultKey}}`);
+      } else if (field.required !== false) {
+        const existing = await opts.vault.get(vaultKey).catch(() => null);
+        if (!existing) missing.push(field.key);
+      }
+      continue;
+    }
+
+    if (provided !== undefined && provided !== '') {
+      await writeConfig(optionsPath, provided);
+    } else if (field.required !== false) {
+      missing.push(field.key);
+    }
+  }
+  return { complete: missing.length === 0, missing };
+}

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -4,6 +4,7 @@ import type { EventLogReader } from './log.js';
 import type { ApprovalResolver, ModeBadge } from './mode.js';
 import type { PermissionResolver } from './permission.js';
 import type { ModelDescriptor, ProviderKeyValidation } from './provider.js';
+import type { PluginSetupSpec } from './schemas.js';
 import type { ToolCompactPresentation } from './tool.js';
 
 /**
@@ -368,6 +369,22 @@ export interface PluginsAdminView {
     /** Present when the package declares a `moxxy.setup` step to complete. */
     readonly needsSetup?: { readonly title: string; readonly required: boolean };
   }>;
+  /**
+   * The package's declarative setup step (`moxxy.setup`), read from its
+   * installed package.json — plain data, safe to render anywhere. Null when
+   * absent. Powers the post-install dialog and `/setup`.
+   */
+  setupSpec?(packageName: string): Promise<PluginSetupSpec | null>;
+  /**
+   * Persist collected setup values: secrets → vault + `${vault:NAME}` option
+   * ref; other kinds → `plugins.packages.<pkg>.options.<key>`. A complete
+   * required setup re-enables the package; an incomplete one disables it
+   * (mirrors the init wizard). Optional capability per the seam convention.
+   */
+  applySetup?(
+    packageName: string,
+    values: Readonly<Record<string, string | boolean>>,
+  ): Promise<{ readonly complete: boolean; readonly missing: ReadonlyArray<string> }>;
 }
 
 /** IO a channel supplies to drive an interactive OAuth flow inside its own


### PR DESCRIPTION
Follow-up to #405, per review feedback: **needsSetup now resolves inline instead of sending users back to `moxxy init`.**

## What

- **Install → configure, one motion**: a picker install of a plugin declaring `moxxy.setup` opens the setup dialog immediately in the InteractiveZone slot — masked secret entry, y/n booleans, arrow-key selects, Tab skips optional fields. Values persist through the SAME `applySetupValues` path as the init wizard (secrets → vault + `${vault:NAME}` option ref, never plaintext). Esc on a `required: true` setup disables the package (init's skip semantics) with the recovery path named in the notice.
- **The continuation chain holds**: `/goal` → install-confirm → install → **setup dialog** → the original slash line re-runs — a freshly-installed, freshly-configured capability executes your original command without one wasted step.
- **`/setup [package]`**: reconfigure any installed plugin at any time (bare `/setup` lists candidates, required ones badged); completing a previously-skipped required setup **re-enables** the package.
- **Model/tool path**: `install_plugin` keeps returning `needsSetup` — the model can now direct users to `/setup <pkg>` instead of a full init.
- RemoteSession degrades to the previous pointing notice (seams are optional per convention).

## Also in here

Retired the workflows-watcher flake TECH_DEBT entry for real: the 4s `vi.waitFor` tripped 5 gates today; raised to 20s (the test asserts at-most-once firing, not latency). The full-suite run that previously needed a rerun per PR is green first-try in this gate.

## Verification

Full gate green (isolator-subprocess flaked under load once, passes isolated — pre-existing, untouched by this diff). New tests: headless flow (walk/accumulate/refuse-required-skip/empty-secret-advance/cancel-once) + the wizard's refactored write path reuses the existing plugin-setup-steps suite unchanged in behavior.