### PR TITLE
feat(slim): unbundle plugin-memory — the kernel is done

### DIFF
--- a/.changeset/memory-unbundle.md
+++ b/.changeset/memory-unbundle.md
@@ -1,0 +1,17 @@
+---
+'@moxxy/plugin-memory': minor
+'@moxxy/core': patch
+'@moxxy/cli': minor
+'@moxxy/plugin-plugins-admin': patch
+'@moxxy/desktop': patch
+---
+
+The slim wave's last unbundle: `@moxxy/plugin-memory` moves out of the CLI
+binary as ONE merged plugin (long-term store + memory tools + the tfidf
+embedder + memory_consolidate and its nudge hooks — the two-plugins-in-one-
+package blocker is gone). The store's embedder now resolves lazily from the
+new core-published `embedders` service instead of a bootstrap closure.
+Installs on demand / rides the desktop seed; without it, `moxxy doctor`
+reports a warn ("memory plugin not installed") instead of failing and
+recall degrades exactly as before. The `@moxxy/memory-consolidate` ledger
+key is gone (clean-slate) — enable/disable the one package instead.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -326,11 +326,6 @@ or recorded-on-purpose decision.
   discovery-loadable plugins in batches, pin on-demand installs to the CLI
   version (currently `latest`), desktop seed pack, TUI install/connect
   affordances.
-- [med, refactor] `plugin-memory`(+`memory-consolidate`) cannot unbundle as-is:
-  two Plugin instances in one package (discovery loads a single default export),
-  `moxxy memory`/`doctor` import `MemoryStore` directly, and setup builds it
-  with the embedder closure. Needs its own refactor PR (split package or teach
-  discovery multi-plugin entries); until then it stays bundled. `packages/plugin-memory/`.
 - [low, follow-up] EventStore: only the WRITE path routes through the active
   store (`attachSessionPersistence` → `getActive().open()`). The session-scoped
   READS (`restoreSessionEvents`/`readSessionEventPage` in build-session, runner

--- a/apps/desktop/scripts/bundle-plugins-seed.mjs
+++ b/apps/desktop/scripts/bundle-plugins-seed.mjs
@@ -55,6 +55,7 @@ const SEED_PLUGINS = [
   'plugin-channel-slack',
   'plugin-provider-admin',
   'plugin-mcp',
+  'plugin-memory',
 ];
 
 /** First-party runtime deps of seed members — packed so the closure installs

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -98,7 +98,8 @@ interface DoctorChecksDeps {
   readonly config: MoxxyConfig;
   readonly configSources: ReadonlyArray<{ scope: 'project' | 'user' | 'explicit'; path: string }>;
   readonly vault: VaultStore;
-  readonly memory: MemoryStore;
+  /** Undefined on a slim boot without the memory plugin installed. */
+  readonly memory: MemoryStore | undefined;
   readonly pluginRegistration: RegistrationResult;
   readonly checks: Check[];
   readonly checkKeys: boolean;
@@ -209,26 +210,35 @@ async function runDoctorChecks(deps: DoctorChecksDeps): Promise<number> {
   // Plugins
   checks.push(...buildPluginDoctorChecks(pluginRegistration));
 
-  // Memory
-  const memDir = path.join(os.homedir(), '.moxxy', 'memory');
-  const memRes = await tryCatch(async () => {
-    await fs.mkdir(memDir, { recursive: true });
-    await fs.access(memDir, fs.constants.W_OK);
-    const entries = await memory.list();
-    return { count: entries.length };
-  });
-  if (memRes.ok) {
+  // Memory (slim kernel: the plugin may not be installed — that's a state,
+  // not a failure)
+  if (!memory) {
     checks.push({
       id: 'memory',
-      status: 'ok',
-      message: `${memDir} writable (${memRes.value.count} entries)`,
+      status: 'warn',
+      message: 'memory plugin not installed — long-term memory off (moxxy plugins install @moxxy/plugin-memory)',
     });
   } else {
-    checks.push({
-      id: 'memory',
-      status: 'fail',
-      message: `${memDir} not writable: ${memRes.error}`,
+    const memDir = path.join(os.homedir(), '.moxxy', 'memory');
+    const memRes = await tryCatch(async () => {
+      await fs.mkdir(memDir, { recursive: true });
+      await fs.access(memDir, fs.constants.W_OK);
+      const entries = await memory.list();
+      return { count: entries.length };
     });
+    if (memRes.ok) {
+      checks.push({
+        id: 'memory',
+        status: 'ok',
+        message: `${memDir} writable (${memRes.value.count} entries)`,
+      });
+    } else {
+      checks.push({
+        id: 'memory',
+        status: 'fail',
+        message: `${memDir} not writable: ${memRes.error}`,
+      });
+    }
   }
 
   // Skills

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -13,7 +13,7 @@ import type { Plugin } from '@moxxy/sdk';
 import { buildConfigPlugin, loadConfig as loadMergedConfig, loadDisabledProviders } from '@moxxy/config';
 import { BUILTIN_SKILLS_DIR_RESOLVED } from './setup/builtin-skills-dir.js';
 import { buildVaultPlugin } from '@moxxy/plugin-vault';
-import { buildMemoryPlugin } from '@moxxy/plugin-memory';
+import type { MemoryStore } from '@moxxy/plugin-memory';
 import { buildSessionConfigApplier } from './config-applier.js';
 import { loadRawConfig, resolveConfigPlaceholders } from './setup/load-config.js';
 import { selectEmbedder } from './setup/embedder.js';
@@ -101,13 +101,6 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
     secretResolver: (name) => vault.get(name),
   });
 
-  // Built AFTER the session so it can pull the registry-selected embedder
-  // lazily — the embedder isn't chosen until plugins have registered (see
-  // selectEmbedder below). A null active embedder → keyword recall.
-  const { plugin: memoryPlugin, store: memory } = buildMemoryPlugin({
-    embedder: () => session.embedders.tryGetActive(),
-  });
-
   // Build the builtin list first WITHOUT the config plugin so we can pass the
   // whole list to the ConfigApplier (used for hot-toggle of plugin enable/disable).
   const schedulerRunner = buildSchedulerRunner(session);
@@ -117,8 +110,6 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
     rawConfig,
     vault,
     vaultPlugin,
-    memory,
-    memoryPlugin,
     schedulerRunner,
     webhookRunner,
     disabledPackages,
@@ -256,6 +247,11 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
   progress({ kind: 'ready' });
 
   const persistence = attachSessionPersistence(session, opts.cwd, opts.disableSessionPersistence);
+
+  // The memory plugin (when installed/enabled) published its store as the
+  // 'memory' service during onInit; a slim boot without it leaves this
+  // undefined and consumers (doctor) degrade.
+  const memory = session.services.get<MemoryStore>('memory');
 
   return {
     session,

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -15,10 +15,6 @@ import { collaborativeModePlugin } from '@moxxy/mode-collaborative';
 import { collabPlugin } from '@moxxy/plugin-collab';
 import { summarizeCompactorPlugin } from '@moxxy/compactor-summarize';
 import { stablePrefixCacheStrategyPlugin } from '@moxxy/cache-strategy-stable-prefix';
-import {
-  memoryConsolidatePlugin,
-  type MemoryStore,
-} from '@moxxy/plugin-memory';
 import { cliPlugin } from '@moxxy/plugin-cli';
 import { mobileChannelPlugin } from '@moxxy/plugin-channel-mobile';
 import { buildPluginsAdminPlugin } from '@moxxy/plugin-plugins-admin';
@@ -48,8 +44,6 @@ export interface BuiltinEntriesArgs {
   readonly rawConfig: MoxxyConfig;
   readonly vault: VaultStore;
   readonly vaultPlugin: Plugin;
-  readonly memory: MemoryStore;
-  readonly memoryPlugin: Plugin;
   readonly viewSurface: ViewSurfaceRef;
   readonly webControls: WebControlsRef;
   readonly setPluginEnabledLive: (packageName: string, enabled: boolean) => Promise<void>;
@@ -67,7 +61,7 @@ export interface BuiltinEntriesArgs {
  * builtin set; do not reorder.
  */
 export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
-  const { session, rawConfig, vaultPlugin, memoryPlugin, viewSurface, webControls, setPluginEnabledLive, categoryLive } = args;
+  const { session, rawConfig, vaultPlugin, viewSurface, webControls, setPluginEnabledLive, categoryLive } = args;
 
   // Publish the shared web-surface ref so the (discovery-loadable) view plugin
   // can read it in onInit — the same mutable ref the web channel writes via its
@@ -112,14 +106,9 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
     { name: '@moxxy/plugin-vault', plugin: vaultPlugin },
     // plugin-stt-whisper(+codex) are NOT bundled — install on demand / seeded
     // by the desktop; both resolve their deps from the service registry.
-    { name: '@moxxy/plugin-memory', plugin: memoryPlugin },
-    {
-      // Discovery-loadable: resolves the memory store ('memory', published by
-      // @moxxy/plugin-memory above) + the active provider ('providers') from the
-      // service registry in onInit.
-      name: '@moxxy/memory-consolidate',
-      plugin: memoryConsolidatePlugin,
-    },
+    // plugin-memory is NOT bundled — one merged plugin (store + tools +
+    // tfidf embedder + consolidate) installs on demand / rides the desktop
+    // seed, resolving its lazy embedder from the 'embedders' service.
     { name: '@moxxy/plugin-cli', plugin: cliPlugin },
     // plugin-channel-web / plugin-browser / plugin-terminal are NOT bundled —
     // install on demand from npm (or the desktop plugins-seed) and load via

--- a/packages/cli/src/setup/builtins.test.ts
+++ b/packages/cli/src/setup/builtins.test.ts
@@ -3,7 +3,6 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { Session, silentLogger } from '@moxxy/core';
-import { buildMemoryPlugin } from '@moxxy/plugin-memory';
 import { buildVaultPlugin, createStaticKeySource, deriveKey, generateSalt } from '@moxxy/plugin-vault';
 import { BUILTIN_REQUIREMENT_DECISIONS, buildBuiltinsCore } from './builtins.js';
 
@@ -24,17 +23,11 @@ describe('builtin plugin requirement inventory', () => {
       filePath: path.join(tmp, 'vault.json'),
       keySource: createStaticKeySource(deriveKey('pw', generateSalt())),
     });
-    const { plugin: memoryPlugin, store: memory } = buildMemoryPlugin({
-      dir: path.join(tmp, 'memory'),
-      embedder: null,
-    });
     const built = buildBuiltinsCore({
       session,
       rawConfig: {},
       vault,
       vaultPlugin,
-      memory,
-      memoryPlugin,
       schedulerRunner: { runPrompt: async () => ({ text: '' }) },
       webhookRunner: { runPrompt: async () => ({ text: '' }) },
       logger: silentLogger,
@@ -45,9 +38,8 @@ describe('builtin plugin requirement inventory', () => {
       .filter((name) => BUILTIN_REQUIREMENT_DECISIONS[name] === undefined);
 
     expect(missing).toEqual([]);
-    expect(BUILTIN_REQUIREMENT_DECISIONS['@moxxy/memory-consolidate']).toMatchObject({
-      hardRequirements: true,
-    });
+    // memory(+consolidate, merged into one plugin) is no longer a builtin
+    // entry — the slim wave's last unbundle.
     // stt-whisper-codex is no longer a builtin entry (slim wave) — its
     // requirements gate now reads from the on-disk package.json at discovery.
   });

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -32,7 +32,6 @@ import { workerIsolator } from '@moxxy/isolator-worker';
 import { subprocessIsolator } from '@moxxy/isolator-subprocess';
 import { wasmIsolator } from '@moxxy/isolator-wasm';
 import type { VaultStore } from '@moxxy/plugin-vault';
-import type { MemoryStore } from '@moxxy/plugin-memory';
 import type { WorkflowStore } from '@moxxy/plugin-workflows';
 import {
   buildBuiltinEntries,
@@ -73,8 +72,6 @@ export const BUILTIN_REQUIREMENT_DECISIONS: Readonly<Record<string, BuiltinRequi
   '@moxxy/compactor-summarize': { hardRequirements: false, reason: 'compactor has no plugin dependency' },
   '@moxxy/cache-strategy-stable-prefix': { hardRequirements: false, reason: 'cache strategy has no plugin dependency' },
   '@moxxy/plugin-vault': { hardRequirements: false, reason: 'vault is the base secret store' },
-  '@moxxy/plugin-memory': { hardRequirements: false, reason: 'memory store is created by bootstrap' },
-  '@moxxy/memory-consolidate': { hardRequirements: true, reason: 'requires @moxxy/plugin-memory contributions' },
   '@moxxy/plugin-cli': { hardRequirements: false, reason: 'TUI channel is standalone' },
   '@moxxy/plugin-channel-http': { hardRequirements: false, reason: 'HTTP channel is standalone' },
   '@moxxy/plugin-channel-mobile': { hardRequirements: false, reason: 'mobile WS bridge is standalone; token auto-generated' },
@@ -97,8 +94,6 @@ export interface BuildBuiltinsArgs {
   readonly rawConfig: MoxxyConfig;
   readonly vault: VaultStore;
   readonly vaultPlugin: Plugin;
-  readonly memory: MemoryStore;
-  readonly memoryPlugin: Plugin;
   readonly schedulerRunner: SchedulePromptRunner;
   readonly webhookRunner: WebhookPromptRunner;
   /**
@@ -417,7 +412,7 @@ function buildSecuritySlice(
  * can drive the store/poller without going through a model turn.
  */
 export function buildBuiltinsCore(args: BuildBuiltinsArgs): BuiltBuiltinsCore {
-  const { session, rawConfig, vault, vaultPlugin, memory, memoryPlugin, schedulerRunner, webhookRunner, disabledPackages, logger } = args;
+  const { session, rawConfig, vault, vaultPlugin, schedulerRunner, webhookRunner, disabledPackages, logger } = args;
 
   // Shared handle linking the web surface to present_view: the web channel
   // publishes its live URL + view-id minter here on start; the view tool reads
@@ -445,8 +440,6 @@ export function buildBuiltinsCore(args: BuildBuiltinsArgs): BuiltBuiltinsCore {
     rawConfig,
     vault,
     vaultPlugin,
-    memory,
-    memoryPlugin,
     viewSurface,
     webControls,
     setPluginEnabledLive,

--- a/packages/cli/src/setup/plugins-admin-view.test.ts
+++ b/packages/cli/src/setup/plugins-admin-view.test.ts
@@ -3,7 +3,6 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { Session, silentLogger } from '@moxxy/core';
-import { buildMemoryPlugin } from '@moxxy/plugin-memory';
 import {
   buildVaultPlugin,
   createStaticKeySource,
@@ -47,17 +46,11 @@ function buildFixture() {
     filePath: path.join(tmp, 'vault.json'),
     keySource: createStaticKeySource(deriveKey('pw', generateSalt())),
   });
-  const { plugin: memoryPlugin, store: memory } = buildMemoryPlugin({
-    dir: path.join(tmp, 'memory'),
-    embedder: null,
-  });
   buildBuiltinsCore({
     session,
     rawConfig: {},
     vault,
     vaultPlugin,
-    memory,
-    memoryPlugin,
     schedulerRunner: { runPrompt: async () => ({ text: '' }) },
     webhookRunner: { runPrompt: async () => ({ text: '' }) },
     logger: silentLogger,

--- a/packages/cli/src/setup/types.ts
+++ b/packages/cli/src/setup/types.ts
@@ -100,7 +100,8 @@ export interface SetupResult {
   readonly config: MoxxyConfig;
   readonly configSources: ReadonlyArray<{ scope: 'project' | 'user' | 'explicit'; path: string }>;
   readonly vault: VaultStore;
-  readonly memory: MemoryStore;
+  /** The memory plugin's store ('memory' service); undefined on a slim boot without the plugin. */
+  readonly memory: MemoryStore | undefined;
   /** Scheduler store + poller, surfaced so the CLI subcommands
    *  (`moxxy schedule list|run`) can reach them without a model turn. */
   readonly scheduler: { readonly store: ScheduleStore; readonly poller: SchedulerPoller };

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -243,6 +243,8 @@ export class Session implements ClientSession, SessionRuntime {
     this.services.register('synthesizers', this.synthesizers);
     this.services.register('skills', this.skills);
     this.services.register('tunnelProviders', this.tunnelProviders);
+    // The memory plugin (discovery-loadable) resolves its lazy embedder here.
+    this.services.register('embedders', this.embedders);
     // A stable accessor for the active provider's stored credentials. The
     // resolver itself is installed late (by activateProvider, after plugins are
     // built), so close over `this` and read it lazily at call time — lets

--- a/packages/plugin-memory/package.json
+++ b/packages/plugin-memory/package.json
@@ -1,8 +1,28 @@
 {
   "name": "@moxxy/plugin-memory",
-  "private": true,
   "version": "0.26.0",
   "description": "Journal-based long-term memory for moxxy. Markdown files at ~/.moxxy/memory/ with type/description frontmatter + an index. Plus STM selectors over the event log.",
+  "keywords": [
+    "moxxy",
+    "agent",
+    "memory",
+    "recall",
+    "embeddings"
+  ],
+  "homepage": "https://moxxy.ai",
+  "bugs": {
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
+    "directory": "packages/plugin-memory"
+  },
+  "author": "Michal Makowski <michal.makowski97@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-memory/src/index.ts
+++ b/packages/plugin-memory/src/index.ts
@@ -27,6 +27,7 @@ export {
   type ConsolidateOptions,
   type ConsolidationOutcome,
 } from './consolidate.js';
+import { memoryConsolidatePlugin as memoryConsolidatePluginRef } from './consolidate.js';
 
 export interface BuildMemoryPluginOptions extends MemoryStoreOptions {}
 
@@ -198,3 +199,49 @@ export function buildMemoryPlugin(opts: BuildMemoryPluginOptions = {}): { plugin
   });
   return { plugin, store };
 }
+
+
+/**
+ * Discovery-loadable instance: the WHOLE memory feature (long-term store +
+ * memory_save/recall/… tools + the tfidf embedder + memory_consolidate and
+ * its nudge hooks) as ONE plugin, so the package unbundles cleanly — the
+ * loader takes a single default export per package. Composition over the
+ * existing builders:
+ *  - the store's embedder resolves LAZILY from the host-published
+ *    'embedders' registry service (captured in onInit, read on first
+ *    recall), replacing the bootstrap closure the CLI used to inject;
+ *  - our onInit registers the 'memory' service FIRST, then runs
+ *    consolidate's onInit, which resolves it — same ordering the two
+ *    separate builtin entries relied on.
+ * `buildMemoryPlugin` stays for hosts/tests that inject their own store.
+ */
+export const memoryPlugin: Plugin = (() => {
+  let embeddersReg: { tryGetActive(): unknown } | null = null;
+  const { plugin: base } = buildMemoryPlugin({
+    // The registry hands back an EmbedderClient-compatible instance; the
+    // structural cast keeps this file free of a core import.
+    embedder: () =>
+      (embeddersReg?.tryGetActive() ?? null) as ReturnType<
+        Extract<NonNullable<MemoryStoreOptions['embedder']>, () => unknown>
+      >,
+  });
+  const consolidate = memoryConsolidatePluginRef;
+  return definePlugin({
+    name: '@moxxy/plugin-memory',
+    version: '0.0.0',
+    ...(base.embedders ? { embedders: base.embedders } : {}),
+    tools: [...(base.tools ?? []), ...(consolidate.tools ?? [])],
+    hooks: {
+      ...consolidate.hooks,
+      onInit: async (ctx) => {
+        embeddersReg =
+          ctx.services.get<{ tryGetActive(): unknown }>('embedders') ?? null;
+        await base.hooks?.onInit?.(ctx);
+        await consolidate.hooks?.onInit?.(ctx);
+      },
+    },
+  });
+})();
+
+// Discovery entry: `createPluginLoader` requires a default Plugin export.
+export default memoryPlugin;

--- a/packages/plugin-plugins-admin/src/catalog.ts
+++ b/packages/plugin-plugins-admin/src/catalog.ts
@@ -205,6 +205,13 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     installSpec: '@moxxy/plugin-voice-admin',
   },
   {
+    id: 'memory',
+    label: 'Long-term memory',
+    description: 'memory_save/recall + consolidation + the tfidf embedder — persistent memory across sessions.',
+    packageName: '@moxxy/plugin-memory',
+    installSpec: '@moxxy/plugin-memory',
+  },
+  {
     id: 'telegram',
     label: 'Telegram channel',
     description: 'Chat with moxxy from Telegram (moxxy telegram; QR pairing).',


### PR DESCRIPTION
The last flagged follow-up with a code surface. **Stacked on #407** (this branch contains the fold commit); merge order #407 → this.

## What

`@moxxy/plugin-memory` — the one plugin TECH_DEBT said *couldn't* unbundle — moves out of the binary:

- **The two-plugins-in-one-package blocker is gone**: the default export is ONE merged plugin (long-term store + `memory_save/recall/…` + the tfidf embedder + `memory_consolidate` with its nudge hooks), composed over the existing builders — `buildMemoryPlugin` survives unchanged for injection/tests, and consolidate's service-resolving `onInit` chains after the store registers, preserving the exact ordering the two builtin entries relied on.
- **The bootstrap closure is gone**: the store's embedder resolves lazily from the new core-published `embedders` service.
- **Degradations**: `moxxy doctor` warns ("memory plugin not installed" + install hint) instead of failing; `selectEmbedder`'s tfidf fallback was already guarded; `moxxy memory` keeps its inlined `MemoryStore` lib import (instance-only unbundle, same pattern as provider-admin/mcp).
- Catalog entry + desktop seed extension; the `@moxxy/memory-consolidate` ledger key is gone (clean-slate; one package to enable/disable).

**With this, the bundled set is exactly the kernel**: TUI, tools-builtin, mode-default, context floors, vault, plugins-admin, commands, the two OAuth providers, mobile channel (private deps), security (trust boundary), dormant daemons — plus the OAuth pair's token helpers. Everything else installs on demand or rides the seed.

## Verified

Slim tarball smoke: boot shows memory only as a catalog row; installing the tarball loads the merged plugin at 0.26.0. Full gate green; builtin-inventory assertions updated.