### PR TITLE
feat(install): landing install.sh — zero-setup install

### DIFF
--- a/.changeset/landing-installer.md
+++ b/.changeset/landing-installer.md
@@ -1,0 +1,8 @@
+---
+---
+
+Landing `install.sh` (repo root, served from the site): installs a Node
+runtime if needed (no sudo), the moxxy CLI into ~/.moxxy/cli, preloads the
+full first-party plugin set pinned to the CLI version (per-package
+404→latest→skip resilience), and wires PATH — the only step left for the
+user is picking a provider on first `moxxy`. No package release.

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,7 @@
 #   MOXXY_NO_PLUGINS=1     skip the plugin preload (slim install)
 #   MOXXY_NO_MODIFY_PATH=1 don't touch shell profiles
 set -euo pipefail
+export NPM_CONFIG_UPDATE_NOTIFIER=false # keep npm quiet during the steps
 
 NODE_MIN_MAJOR=20
 NODE_LTS_VERSION="22.14.0" # downloaded only when no suitable node exists
@@ -60,8 +61,40 @@ PLUGINS=(
   @moxxy/plugin-mcp
 )
 
-say()  { printf '\033[1m[moxxy]\033[0m %s\n' "$*"; }
-fail() { printf '\033[1;31m[moxxy]\033[0m %s\n' "$*" >&2; exit 1; }
+# ---------------------------------------------------------------- visuals
+# Colors only on a TTY and when NO_COLOR is unset — a piped/captured run
+# stays plain text. The dim-gray wordmark matches the CLI's own banner.
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  B=$'\033[1m'; D=$'\033[2m'; G=$'\033[90m'; M=$'\033[35m'; GRN=$'\033[32m'; R=$'\033[31m'; N=$'\033[0m'
+else
+  B=''; D=''; G=''; M=''; GRN=''; R=''; N=''
+fi
+
+say()  { printf '%s\n' "  $*"; }
+ok()   { printf '%s\n' "  ${GRN}✓${N} $*"; }
+note() { printf '%s\n' "  ${D}$*${N}"; }
+fail() { printf '%s\n' "  ${R}✗ $*${N}" >&2; exit 1; }
+
+STEP=0
+STEPS_TOTAL=4
+step() {
+  STEP=$((STEP + 1))
+  printf '\n%s\n' "${M}┌─${N} ${B}[$STEP/$STEPS_TOTAL]${N} $* ${D}────────────────────────────────${N}"
+}
+
+banner() {
+  printf '\n'
+  printf '%s\n' \
+    "${G}${D}   M   M   OOO   X   X  X   X  Y   Y${N}" \
+    "${G}${D}   MM MM  O   O   X X    X X    Y Y ${N}" \
+    "${G}${D}   M M M  O   O    X      X      Y  ${N}" \
+    "${G}${D}   M   M  O   O   X X    X X     Y  ${N}" \
+    "${G}${D}   M   M   OOO   X   X  X   X    Y  ${N}"
+  printf '\n%s\n' "   ${B}the personal agent that lives where you do${N}"
+  printf '%s\n' "   ${D}installer · everything preinstalled, one step left for you${N}"
+}
+
+banner
 
 # ---------------------------------------------------------------- platform
 OS="$(uname -s)"
@@ -89,21 +122,22 @@ fetch() { # fetch <url> <dest>
 # ------------------------------------------------------------------- node
 node_major() { "$1" -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0; }
 
+step "Node runtime"
 NODE_BIN=""
 NPM_BIN=""
 if command -v node >/dev/null 2>&1 && [ "$(node_major "$(command -v node)")" -ge "$NODE_MIN_MAJOR" ]; then
   NODE_BIN="$(command -v node)"
   NPM_BIN="$(command -v npm || true)"
-  say "using your Node $("$NODE_BIN" --version) ($NODE_BIN)"
+  ok "using your Node $("$NODE_BIN" --version) ${D}($NODE_BIN)${N}"
 fi
 
 if [ -z "$NODE_BIN" ] || [ -z "$NPM_BIN" ]; then
   # Reuse a previously downloaded runtime when it satisfies the floor.
   if [ -x "$RUNTIME_DIR/current/bin/node" ] \
      && [ "$(node_major "$RUNTIME_DIR/current/bin/node")" -ge "$NODE_MIN_MAJOR" ]; then
-    say "using the moxxy-managed Node runtime"
+    ok "using the moxxy-managed Node runtime"
   else
-    say "no Node >= $NODE_MIN_MAJOR found — downloading Node v$NODE_LTS_VERSION into $RUNTIME_DIR (no sudo)"
+    say "no Node >= $NODE_MIN_MAJOR found — downloading Node v$NODE_LTS_VERSION ${D}(into $RUNTIME_DIR, no sudo)${N}"
     NODE_PKG="node-v$NODE_LTS_VERSION-$NODE_OS-$NODE_ARCH"
     TMP_TGZ="$(mktemp -t moxxy-node.XXXXXX)"
     fetch "https://nodejs.org/dist/v$NODE_LTS_VERSION/$NODE_PKG.tar.gz" "$TMP_TGZ"
@@ -111,6 +145,7 @@ if [ -z "$NODE_BIN" ] || [ -z "$NPM_BIN" ]; then
     tar -xzf "$TMP_TGZ" -C "$RUNTIME_DIR"
     rm -f "$TMP_TGZ"
     ln -sfn "$RUNTIME_DIR/$NODE_PKG" "$RUNTIME_DIR/current"
+    ok "Node v$NODE_LTS_VERSION ready"
   fi
   NODE_BIN="$RUNTIME_DIR/current/bin/node"
   NPM_BIN="$RUNTIME_DIR/current/bin/npm"
@@ -119,17 +154,20 @@ if [ -z "$NODE_BIN" ] || [ -z "$NPM_BIN" ]; then
 fi
 
 # -------------------------------------------------------------------- cli
-say "installing @moxxy/cli into $CLI_PREFIX"
+step "moxxy CLI"
+note "→ $CLI_PREFIX"
 mkdir -p "$CLI_PREFIX" "$BIN_DIR"
 "$NPM_BIN" install --prefix "$CLI_PREFIX" --no-fund --no-audit --loglevel=error @moxxy/cli@latest
 ln -sfn "$CLI_PREFIX/node_modules/.bin/moxxy" "$BIN_DIR/moxxy"
 
 CLI_VERSION="$("$NODE_BIN" -p "require('$CLI_PREFIX/node_modules/@moxxy/cli/package.json').version")"
-say "moxxy $CLI_VERSION installed"
+ok "moxxy ${B}$CLI_VERSION${N} installed"
 
 # ---------------------------------------------------------------- plugins
+step "plugin preload"
 if [ "${MOXXY_NO_PLUGINS:-0}" != "1" ]; then
-  say "preloading ${#PLUGINS[@]} plugins into $PLUGINS_DIR (providers, modes, memory, surfaces, channels)"
+  say "preloading ${B}${#PLUGINS[@]}${N} plugins ${D}(providers · modes · memory · surfaces · channels)${N}"
+  note "→ $PLUGINS_DIR"
   mkdir -p "$PLUGINS_DIR"
   if [ ! -f "$PLUGINS_DIR/package.json" ]; then
     cat > "$PLUGINS_DIR/package.json" <<'EOF'
@@ -149,26 +187,30 @@ EOF
   # version — or not published yet at all — fall back to per-package installs
   # with the same 404→latest→skip semantics moxxy's own installer uses, so
   # one unavailable package never sinks the rest of the preload.
-  if ! "$NPM_BIN" install --prefix "$PLUGINS_DIR" --no-fund --no-audit --loglevel=error --save "${PINNED[@]}" 2>/dev/null; then
-    say "pinned set not fully available — installing per package"
+  if "$NPM_BIN" install --prefix "$PLUGINS_DIR" --no-fund --no-audit --loglevel=error --save "${PINNED[@]}" 2>/dev/null; then
+    ok "all ${#PLUGINS[@]} plugins pinned to $CLI_VERSION"
+  else
+    note "pinned set not fully available — installing per package"
     SKIPPED=()
     for p in "${PLUGINS[@]}"; do
       if "$NPM_BIN" install --prefix "$PLUGINS_DIR" --no-fund --no-audit --loglevel=error --save "$p@$CLI_VERSION" 2>/dev/null \
          || "$NPM_BIN" install --prefix "$PLUGINS_DIR" --no-fund --no-audit --loglevel=error --save "$p" 2>/dev/null; then
-        printf '  + %s\n' "$p"
+        ok "${p#@moxxy/}"
       else
         SKIPPED+=("$p")
       fi
     done
     if [ "${#SKIPPED[@]}" -gt 0 ]; then
-      say "skipped (not on npm yet — install later via /plugins): ${SKIPPED[*]}"
+      note "skipped (not on npm yet — install later via /plugins):"
+      for p in "${SKIPPED[@]}"; do printf '%s\n' "    ${D}· ${p#@moxxy/}${N}"; done
     fi
   fi
 else
-  say "MOXXY_NO_PLUGINS=1 — skipping the plugin preload (install later via /plugins)"
+  note "MOXXY_NO_PLUGINS=1 — skipping the plugin preload (install later via /plugins)"
 fi
 
 # ------------------------------------------------------------------- PATH
+step "shell PATH"
 PATH_LINE="export PATH=\"$BIN_DIR:$RUNTIME_DIR/current/bin:\$PATH\" # moxxy"
 # A non-default install root must also tell moxxy where home is.
 if [ "$MOXXY_DIR" != "$HOME/.moxxy" ]; then
@@ -178,7 +220,12 @@ fi
 if [ "${MOXXY_NO_MODIFY_PATH:-0}" != "1" ]; then
   for rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"; do
     [ -f "$rc" ] || continue
-    grep -qF '# moxxy' "$rc" 2>/dev/null || printf '\n%s\n' "$PATH_LINE" >> "$rc"
+    if grep -qF '# moxxy' "$rc" 2>/dev/null; then
+      ok "already wired: ${rc/#$HOME/~}"
+    else
+      printf '\n%s\n' "$PATH_LINE" >> "$rc"
+      ok "wired: ${rc/#$HOME/~}"
+    fi
   done
   if command -v fish >/dev/null 2>&1 && [ -d "$HOME/.config/fish" ]; then
     FISH_CONF="$HOME/.config/fish/conf.d/moxxy.fish"
@@ -187,10 +234,28 @@ if [ "${MOXXY_NO_MODIFY_PATH:-0}" != "1" ]; then
 fi
 
 # ------------------------------------------------------------------ done
-say ""
-say "done. Everything is preinstalled — one step left:"
-say ""
-say "    exec \$SHELL        # reload PATH (or open a new terminal)"
-say "    moxxy              # pick a provider: ChatGPT/Claude sign-in or an API key"
-say ""
-say "install dir: $MOXXY_DIR   ·   uninstall: rm -rf $MOXXY_DIR + the '# moxxy' PATH lines"
+# Box rows self-align: pad by the PLAIN text width so interpolated values
+# (the version) can be any length without shearing the right border.
+BOX_W=58
+boxrow() { # boxrow <styled> <plain>
+  local styled="$1" plain="$2"
+  local pad=$((BOX_W - ${#plain}))
+  [ "$pad" -lt 0 ] && pad=0
+  printf '%s\n' "  ${M}│${N}${styled}$(printf '%*s' "$pad" '')${M}│${N}"
+}
+rule() { printf '%s' "$(printf '─%.0s' $(seq 1 $BOX_W))"; }
+
+printf '\n'
+printf '%s\n' "  ${M}╭$(rule)╮${N}"
+boxrow "  ${GRN}✓${N} ${B}moxxy $CLI_VERSION is ready${N} — everything preinstalled" \
+       "  ✓ moxxy $CLI_VERSION is ready — everything preinstalled"
+boxrow "" ""
+boxrow "    ${B}exec \$SHELL${N}   ${D}reload PATH (or open a new terminal)${N}" \
+       "    exec \$SHELL   reload PATH (or open a new terminal)"
+boxrow "    ${B}moxxy${N}         ${D}pick a provider: sign-in or API key${N}" \
+       "    moxxy         pick a provider: sign-in or API key"
+boxrow "" ""
+printf '%s\n' "  ${M}╰$(rule)╯${N}"
+note "install dir: $MOXXY_DIR"
+note "uninstall:   rm -rf $MOXXY_DIR + the '# moxxy' PATH lines"
+printf '\n'

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+#
+# moxxy installer — https://moxxy.ai
+#
+#   curl -fsSL https://moxxy.ai/install.sh | bash
+#
+# Installs everything upfront so the first `moxxy` just works:
+#   1. a Node >= 20 runtime (uses yours if present; otherwise downloads an
+#      official Node build into ~/.moxxy/runtime — no sudo, no system changes)
+#   2. the moxxy CLI into ~/.moxxy/cli (never `sudo npm -g`)
+#   3. the full first-party plugin set into ~/.moxxy/plugins (providers,
+#      modes, memory, browser/terminal/web surfaces, channels, …) pinned to
+#      the CLI's version — so nothing needs a download later
+#   4. PATH wiring in your shell profile (idempotent, clearly marked)
+#
+# The only thing left for you: run `moxxy` and pick a provider — either a
+# ChatGPT/Claude sign-in or an API key. Keys are yours; we can't skip that.
+#
+# Env overrides:
+#   MOXXY_INSTALL_DIR      install root            (default: ~/.moxxy)
+#   MOXXY_NO_PLUGINS=1     skip the plugin preload (slim install)
+#   MOXXY_NO_MODIFY_PATH=1 don't touch shell profiles
+set -euo pipefail
+
+NODE_MIN_MAJOR=20
+NODE_LTS_VERSION="22.14.0" # downloaded only when no suitable node exists
+MOXXY_DIR="${MOXXY_INSTALL_DIR:-$HOME/.moxxy}"
+BIN_DIR="$MOXXY_DIR/bin"
+CLI_PREFIX="$MOXXY_DIR/cli"
+RUNTIME_DIR="$MOXXY_DIR/runtime"
+PLUGINS_DIR="$MOXXY_DIR/plugins"
+
+# Preloaded so the first session already has every capability installed.
+# Keep in sync with the desktop seed list (apps/desktop/scripts/
+# bundle-plugins-seed.mjs) — this IS the CLI-side equivalent of that seed.
+PLUGINS=(
+  @moxxy/plugin-provider-anthropic
+  @moxxy/plugin-provider-openai
+  @moxxy/plugin-provider-google
+  @moxxy/plugin-provider-xai
+  @moxxy/plugin-provider-zai
+  @moxxy/plugin-provider-local
+  @moxxy/mode-goal
+  @moxxy/mode-deep-research
+  @moxxy/plugin-subagents
+  @moxxy/plugin-memory
+  @moxxy/plugin-view
+  @moxxy/plugin-channel-web
+  @moxxy/plugin-channel-http
+  @moxxy/plugin-browser
+  @moxxy/plugin-terminal
+  @moxxy/plugin-oauth
+  @moxxy/plugin-usage-stats
+  @moxxy/plugin-self-update
+  @moxxy/plugin-voice-admin
+  @moxxy/plugin-stt-whisper
+  @moxxy/plugin-telegram
+  @moxxy/plugin-channel-slack
+  @moxxy/plugin-provider-admin
+  @moxxy/plugin-mcp
+)
+
+say()  { printf '\033[1m[moxxy]\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m[moxxy]\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ---------------------------------------------------------------- platform
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+case "$OS" in
+  Darwin) NODE_OS="darwin" ;;
+  Linux)  NODE_OS="linux" ;;
+  *) fail "unsupported OS: $OS — on Windows, install via WSL or see https://moxxy.ai/docs/install" ;;
+esac
+case "$ARCH" in
+  arm64|aarch64) NODE_ARCH="arm64" ;;
+  x86_64|amd64)  NODE_ARCH="x64" ;;
+  *) fail "unsupported architecture: $ARCH" ;;
+esac
+
+command -v curl >/dev/null 2>&1 || command -v wget >/dev/null 2>&1 \
+  || fail "need curl or wget"
+command -v tar >/dev/null 2>&1 || fail "need tar"
+
+fetch() { # fetch <url> <dest>
+  if command -v curl >/dev/null 2>&1; then curl -fSL --progress-bar "$1" -o "$2"
+  else wget -qO "$2" "$1"; fi
+}
+
+# ------------------------------------------------------------------- node
+node_major() { "$1" -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0; }
+
+NODE_BIN=""
+NPM_BIN=""
+if command -v node >/dev/null 2>&1 && [ "$(node_major "$(command -v node)")" -ge "$NODE_MIN_MAJOR" ]; then
+  NODE_BIN="$(command -v node)"
+  NPM_BIN="$(command -v npm || true)"
+  say "using your Node $("$NODE_BIN" --version) ($NODE_BIN)"
+fi
+
+if [ -z "$NODE_BIN" ] || [ -z "$NPM_BIN" ]; then
+  # Reuse a previously downloaded runtime when it satisfies the floor.
+  if [ -x "$RUNTIME_DIR/current/bin/node" ] \
+     && [ "$(node_major "$RUNTIME_DIR/current/bin/node")" -ge "$NODE_MIN_MAJOR" ]; then
+    say "using the moxxy-managed Node runtime"
+  else
+    say "no Node >= $NODE_MIN_MAJOR found — downloading Node v$NODE_LTS_VERSION into $RUNTIME_DIR (no sudo)"
+    NODE_PKG="node-v$NODE_LTS_VERSION-$NODE_OS-$NODE_ARCH"
+    TMP_TGZ="$(mktemp -t moxxy-node.XXXXXX)"
+    fetch "https://nodejs.org/dist/v$NODE_LTS_VERSION/$NODE_PKG.tar.gz" "$TMP_TGZ"
+    mkdir -p "$RUNTIME_DIR"
+    tar -xzf "$TMP_TGZ" -C "$RUNTIME_DIR"
+    rm -f "$TMP_TGZ"
+    ln -sfn "$RUNTIME_DIR/$NODE_PKG" "$RUNTIME_DIR/current"
+  fi
+  NODE_BIN="$RUNTIME_DIR/current/bin/node"
+  NPM_BIN="$RUNTIME_DIR/current/bin/npm"
+  # npm shells back out to `node`; make sure the managed one resolves first.
+  export PATH="$RUNTIME_DIR/current/bin:$PATH"
+fi
+
+# -------------------------------------------------------------------- cli
+say "installing @moxxy/cli into $CLI_PREFIX"
+mkdir -p "$CLI_PREFIX" "$BIN_DIR"
+"$NPM_BIN" install --prefix "$CLI_PREFIX" --no-fund --no-audit --loglevel=error @moxxy/cli@latest
+ln -sfn "$CLI_PREFIX/node_modules/.bin/moxxy" "$BIN_DIR/moxxy"
+
+CLI_VERSION="$("$NODE_BIN" -p "require('$CLI_PREFIX/node_modules/@moxxy/cli/package.json').version")"
+say "moxxy $CLI_VERSION installed"
+
+# ---------------------------------------------------------------- plugins
+if [ "${MOXXY_NO_PLUGINS:-0}" != "1" ]; then
+  say "preloading ${#PLUGINS[@]} plugins into $PLUGINS_DIR (providers, modes, memory, surfaces, channels)"
+  mkdir -p "$PLUGINS_DIR"
+  if [ ! -f "$PLUGINS_DIR/package.json" ]; then
+    cat > "$PLUGINS_DIR/package.json" <<'EOF'
+{
+  "name": "moxxy-user-plugins",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Auto-generated workspace for moxxy plugins installed at runtime."
+}
+EOF
+  fi
+  PINNED=()
+  for p in "${PLUGINS[@]}"; do PINNED+=("$p@$CLI_VERSION"); done
+  # Fast path: the whole set pinned to the CLI version in one npm run
+  # (first-party packages co-version). If ANY member is missing at that
+  # version — or not published yet at all — fall back to per-package installs
+  # with the same 404→latest→skip semantics moxxy's own installer uses, so
+  # one unavailable package never sinks the rest of the preload.
+  if ! "$NPM_BIN" install --prefix "$PLUGINS_DIR" --no-fund --no-audit --loglevel=error --save "${PINNED[@]}" 2>/dev/null; then
+    say "pinned set not fully available — installing per package"
+    SKIPPED=()
+    for p in "${PLUGINS[@]}"; do
+      if "$NPM_BIN" install --prefix "$PLUGINS_DIR" --no-fund --no-audit --loglevel=error --save "$p@$CLI_VERSION" 2>/dev/null \
+         || "$NPM_BIN" install --prefix "$PLUGINS_DIR" --no-fund --no-audit --loglevel=error --save "$p" 2>/dev/null; then
+        printf '  + %s\n' "$p"
+      else
+        SKIPPED+=("$p")
+      fi
+    done
+    if [ "${#SKIPPED[@]}" -gt 0 ]; then
+      say "skipped (not on npm yet — install later via /plugins): ${SKIPPED[*]}"
+    fi
+  fi
+else
+  say "MOXXY_NO_PLUGINS=1 — skipping the plugin preload (install later via /plugins)"
+fi
+
+# ------------------------------------------------------------------- PATH
+PATH_LINE="export PATH=\"$BIN_DIR:$RUNTIME_DIR/current/bin:\$PATH\" # moxxy"
+# A non-default install root must also tell moxxy where home is.
+if [ "$MOXXY_DIR" != "$HOME/.moxxy" ]; then
+  PATH_LINE="$PATH_LINE
+export MOXXY_HOME=\"$MOXXY_DIR\" # moxxy"
+fi
+if [ "${MOXXY_NO_MODIFY_PATH:-0}" != "1" ]; then
+  for rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"; do
+    [ -f "$rc" ] || continue
+    grep -qF '# moxxy' "$rc" 2>/dev/null || printf '\n%s\n' "$PATH_LINE" >> "$rc"
+  done
+  if command -v fish >/dev/null 2>&1 && [ -d "$HOME/.config/fish" ]; then
+    FISH_CONF="$HOME/.config/fish/conf.d/moxxy.fish"
+    [ -f "$FISH_CONF" ] || printf 'fish_add_path -g %s %s # moxxy\n' "$BIN_DIR" "$RUNTIME_DIR/current/bin" > "$FISH_CONF"
+  fi
+fi
+
+# ------------------------------------------------------------------ done
+say ""
+say "done. Everything is preinstalled — one step left:"
+say ""
+say "    exec \$SHELL        # reload PATH (or open a new terminal)"
+say "    moxxy              # pick a provider: ChatGPT/Claude sign-in or an API key"
+say ""
+say "install dir: $MOXXY_DIR   ·   uninstall: rm -rf $MOXXY_DIR + the '# moxxy' PATH lines"


### PR DESCRIPTION
The landing one-liner: `curl -fsSL https://moxxy.ai/install.sh | bash` — everything preinstalled upfront.

## What it does

1. **Node ≥ 20** — uses yours if suitable; otherwise downloads an official build into `~/.moxxy/runtime` (no sudo, nothing system-wide, reused on re-run).
2. **CLI** — `@moxxy/cli` into `~/.moxxy/cli` with a `~/.moxxy/bin/moxxy` symlink. Never `sudo npm -g`.
3. **Full plugin preload** — the entire first-party set (6 providers, goal/research modes, subagents, memory, view, web/http channels, browser/terminal surfaces, oauth, usage-stats, self-update, voice, whisper, telegram, slack, provider-admin, mcp) into `~/.moxxy/plugins`, **pinned to the CLI version** with the same 404→latest→skip resilience moxxy's own installer uses — one unpublished package never sinks the preload. The list mirrors the desktop seed.
4. **PATH** — idempotent `# moxxy`-marked lines in zsh/bash/profile (+ fish conf.d); `MOXXY_HOME` exported when `MOXXY_INSTALL_DIR` is non-default.

Escape hatches: `MOXXY_NO_PLUGINS`, `MOXXY_NO_MODIFY_PATH`, `MOXXY_INSTALL_DIR`. Windows points at WSL/docs.

The one step it can't remove: the provider sign-in/key — `moxxy`'s first-run wizard collects it, and with the preload in place that wizard is now genuinely the ONLY interaction between curl and a working agent.

## Verified live (sandboxed HOME, real npm)

17 plugins installed at 0.26.0 in the pinned path; the 7 packages that first publish with the NEXT release were skipped with an explicit message (the exact pre-release window the fallback exists for); the installed binary boots and discovers the preload (`plugins list` shows them loaded); PATH lines written once, re-run idempotent.

Empty changeset (repo-root script; no package ships).