### PR TITLE
chore(mobile): bring tsconfig to repo strictness and migrate off expo-file-system/legacy

### DIFF
--- a/.changeset/mobile-tsconfig-strictness.md
+++ b/.changeset/mobile-tsconfig-strictness.md
@@ -1,0 +1,4 @@
+---
+---
+
+Bring `apps/mobile` up to repo TypeScript strictness: set `noUncheckedIndexedAccess` and `verbatimModuleSyntax` explicitly (it extends `expo/tsconfig.base`, which lacks both) and fix the surfaced errors. Types-only change, releases nothing.

--- a/.changeset/mobile-tsconfig-strictness.md
+++ b/.changeset/mobile-tsconfig-strictness.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Bring `apps/mobile` up to repo TypeScript strictness: set `noUncheckedIndexedAccess` and `verbatimModuleSyntax` explicitly (it extends `expo/tsconfig.base`, which lacks both) and fix the surfaced errors. Types-only change, releases nothing.
+Bring `apps/mobile` up to repo TypeScript strictness: set `noUncheckedIndexedAccess` and `verbatimModuleSyntax` explicitly (it extends `expo/tsconfig.base`, which lacks both), fix the surfaced errors, and migrate the app off `expo-file-system/legacy` onto the modern SDK 54 File API. Releases nothing.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -20,6 +20,16 @@ or recorded-on-purpose decision.
   methods to `unknown method` (`packages/plugin-browser/src/sidecar/dispatch.test.ts`).
 - [low, tools, RESOLVED 2026-07-03] `resolveSafe` deprecated alias for `resolvePath`
   removed (no callers remained). `packages/tools-builtin/src/util.ts`.
+- [med, mobile, RESOLVED 2026-07-03] `apps/mobile` was the only package in the
+  repo type-checking without `noUncheckedIndexedAccess` + `verbatimModuleSyntax`
+  (it extends `expo/tsconfig.base`, not the moxxy base, so it silently missed the
+  strict baseline). Both flags are now set explicitly in its tsconfig and the
+  surfaced errors fixed. Gotcha: `expo-file-system` ships raw TS source
+  (`"main": "src/index.ts"`) and the `/legacy` subpath has no `types` mapping, so
+  tsc type-checked Expo's own source under the new flag — worked around with a
+  types-only `paths` redirect to `build/legacy/index.d.ts` (Metro runtime
+  resolution unaffected). `apps/mobile/tsconfig.json`,
+  `apps/mobile/src/pairingUrl.ts`, `apps/mobile/src/styles/tokens.ts`.
 - [low, focus, RESOLVED 2026-07-02] Focus Mode mini-chat no longer carries a
   separate text-only composer path: pasted screenshots now reuse the desktop
   attachment save/preview/send pipeline, zoomed image previews can be drag-panned,

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -26,10 +26,13 @@ or recorded-on-purpose decision.
   strict baseline). Both flags are now set explicitly in its tsconfig and the
   surfaced errors fixed. Gotcha: `expo-file-system` ships raw TS source
   (`"main": "src/index.ts"`) and the `/legacy` subpath has no `types` mapping, so
-  tsc type-checked Expo's own source under the new flag — worked around with a
-  types-only `paths` redirect to `build/legacy/index.d.ts` (Metro runtime
-  resolution unaffected). `apps/mobile/tsconfig.json`,
-  `apps/mobile/src/pairingUrl.ts`, `apps/mobile/src/styles/tokens.ts`.
+  tsc type-checked Expo's own source under the new flag — resolved by migrating
+  the app's three read call sites off `expo-file-system/legacy` onto the modern
+  SDK 54 `File` API (`new File(uri).base64()/.text()`), whose root import
+  resolves through the shipped `.d.ts` where `skipLibCheck` applies.
+  `apps/mobile/tsconfig.json`, `apps/mobile/src/pairingUrl.ts`,
+  `apps/mobile/src/styles/tokens.ts`, `apps/mobile/src/hooks/useAttachments.ts`,
+  `apps/mobile/src/hooks/useVoiceRecorder.ts`.
 - [low, focus, RESOLVED 2026-07-02] Focus Mode mini-chat no longer carries a
   separate text-only composer path: pasted screenshots now reuse the desktop
   attachment save/preview/send pipeline, zoomed image previews can be drag-panned,

--- a/apps/mobile/src/hooks/useAttachments.ts
+++ b/apps/mobile/src/hooks/useAttachments.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import * as Clipboard from 'expo-clipboard';
 import * as DocumentPicker from 'expo-document-picker';
-import * as FileSystem from 'expo-file-system/legacy';
+import { File as FileSystemFile } from 'expo-file-system';
 import * as ImagePicker from 'expo-image-picker';
 import {
   buildPromptAttachment,
@@ -155,10 +155,10 @@ export function useAttachments(options: { readonly disabled?: boolean } = {}) {
 }
 
 async function readBase64(uri: string): Promise<string> {
-  return await FileSystem.readAsStringAsync(uri, { encoding: FileSystem.EncodingType.Base64 });
+  return await new FileSystemFile(uri).base64();
 }
 
 async function readText(asset: DocumentPicker.DocumentPickerAsset): Promise<string> {
   if (asset.file && typeof asset.file.text === 'function') return await asset.file.text();
-  return await FileSystem.readAsStringAsync(asset.uri, { encoding: FileSystem.EncodingType.UTF8 });
+  return await new FileSystemFile(asset.uri).text();
 }

--- a/apps/mobile/src/hooks/useVoiceRecorder.ts
+++ b/apps/mobile/src/hooks/useVoiceRecorder.ts
@@ -8,7 +8,7 @@ import {
   useAudioRecorder,
   useAudioRecorderState,
 } from 'expo-audio';
-import * as FileSystem from 'expo-file-system/legacy';
+import { File as FileSystemFile } from 'expo-file-system';
 
 export type VoicePhase = 'idle' | 'recording' | 'transcribing' | 'error';
 
@@ -172,7 +172,7 @@ async function stopNativeRecording(nativeRecorder: ReturnType<typeof useAudioRec
   const uri = nativeRecorder.uri;
   if (!uri) throw new Error('Voice recorder did not produce an audio file.');
   return {
-    audioBase64: await FileSystem.readAsStringAsync(uri, { encoding: FileSystem.EncodingType.Base64 }),
+    audioBase64: await new FileSystemFile(uri).base64(),
     mimeType: NATIVE_MIME_TYPE,
   };
 }

--- a/apps/mobile/src/pairingUrl.ts
+++ b/apps/mobile/src/pairingUrl.ts
@@ -39,7 +39,7 @@ export function normalizeGatewayUrl(value: string): string {
 function recoverLatestAbsoluteUrl(value: string): string {
   const matches = [...value.matchAll(/(?:https?|wss?):\/\//gi)];
   for (let index = matches.length - 1; index >= 0; index -= 1) {
-    const start = matches[index].index;
+    const start = matches[index]?.index;
     if (typeof start !== 'number') continue;
     const candidate = value.slice(start).trim();
     try {
@@ -69,6 +69,6 @@ function extractHost(hostUri?: string | null): string | null {
   if (!hostUri) return null;
   const withoutProtocol = hostUri.replace(/^[a-z]+:\/\//i, '');
   const hostWithPort = withoutProtocol.split('/')[0] ?? '';
-  const host = hostWithPort.split(':')[0];
+  const host = hostWithPort.split(':')[0] ?? '';
   return host.length > 0 ? host : null;
 }

--- a/apps/mobile/src/styles/tokens.ts
+++ b/apps/mobile/src/styles/tokens.ts
@@ -470,7 +470,9 @@ function parseUtility(token: string): AnyStyle | undefined {
       bottom: 'bottom',
       left: 'left',
     };
-    return { [map[key]]: value } as ViewStyle;
+    // The regex alternation guarantees `key` is captured and present in `map`.
+    const styleKey = map[key!];
+    if (styleKey) return { [styleKey]: value } as ViewStyle;
   }
 
   const fontMatch = /^text-\[(\d+)px\]$/.exec(token);

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -11,9 +11,6 @@
     "paths": {
       "@/*": [
         "./src/*"
-      ],
-      "expo-file-system/legacy": [
-        "./node_modules/expo-file-system/build/legacy/index.d.ts"
       ]
     }
   },

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
     "jsx": "react-jsx",
     "jsxImportSource": "react",
     "moduleResolution": "Bundler",
@@ -9,6 +11,9 @@
     "paths": {
       "@/*": [
         "./src/*"
+      ],
+      "expo-file-system/legacy": [
+        "./node_modules/expo-file-system/build/legacy/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
## What

Two related cleanups in `apps/mobile` (types-only + a mechanical API migration, no behavior changes):

**1. Repo TypeScript strictness.** `apps/mobile` extends `expo/tsconfig.base` (not the moxxy base) and was the only package in the repo type-checking without `noUncheckedIndexedAccess` and `verbatimModuleSyntax`. Both flags are now set explicitly in `apps/mobile/tsconfig.json` (still extending Expo's base — no fight with Metro/Expo conventions), and everything that surfaced is fixed:

- `src/pairingUrl.ts` — `matches[index].index` → optional chaining (the next line already guards `typeof start !== 'number'`); `split(':')[0]` → `?? ''` (split always yields one element, mirrors the adjacent line's idiom).
- `src/styles/tokens.ts` — unchecked computed key `{ [map[key]]: value }` → look up `map[key!]` (the regex alternation guarantees the capture) and guard the result before building the style object.

**2. Off `expo-file-system/legacy`.** Enabling `verbatimModuleSyntax` exposed that the `/legacy` subpath resolves to Expo's raw vendored TS source (`"main": "src/index.ts"`, no `types` mapping on the subpath), which tsc then type-checks. Rather than paper over it with a tsconfig `paths` redirect, the app's three legacy call sites — all simple reads — are migrated to the modern SDK 54 `File` API, whose root import resolves through the shipped `.d.ts`:

- `src/hooks/useVoiceRecorder.ts` — recorded-clip base64 read: `readAsStringAsync(uri, Base64)` → `new File(uri).base64()`.
- `src/hooks/useAttachments.ts` — `readBase64` (picked image/document): same conversion; `readText` (text document fallback): `readAsStringAsync(uri, UTF8)` → `new File(uri).text()`.

Nothing remains on `/legacy`. Behavior equivalence, checked against the SDK 54 sources: `File` instances are handles ("does not need to exist on the filesystem during creation"), so errors surface at read time exactly where the legacy rejection did, inside the same try/catch → `fail()` paths; `base64()` returns a plain base64 string (no data-URL prefix) matching `EncodingType.Base64`; `text()` is a UTF-8 read matching `EncodingType.UTF8`; all native call sites feed `file://` URIs (expo-audio output, ImagePicker/DocumentPicker cache copies via `copyToCacheDirectory: true`). On web the legacy calls threw `UnavailabilityError` in these fallbacks; the new API ships a web implementation, so behavior is equal or better and still funnels into the existing error handlers.

Also logs the item as resolved in TECH_DEBT.md.

## Why

Every other package inherits the strict baseline from `tsconfig.base.json`; mobile silently missed it, letting unchecked-index and type-import drift accumulate. And the app should not depend on Expo's deprecated legacy filesystem API when the modern one expresses the same three reads directly.

## Verification

- `pnpm --filter @moxxy/workspaces-app typecheck` clean with the new flags and no `paths` workaround
- `pnpm --filter @moxxy/workspaces-app test` — 231 tests / 47 files green
- Full gate: `pnpm build` / `typecheck` / `lint` / `test` / `check:deps` green (lint warnings and the desktop-host orphan warning pre-existing)
- Migration semantics verified against the vendored SDK 54 `expo-file-system` sources (constructor/read/error/encoding behavior, per call site above)