### PR TITLE
chore(cleanup): remove dead resolveSafe alias, retire stale screencast/PTY TECH_DEBT entries

### DIFF
--- a/.ai/agents/tool-author.md
+++ b/.ai/agents/tool-author.md
@@ -35,7 +35,7 @@ export const greetTool = defineTool({
 - **Always respect `ctx.signal`.** Long-running tools (Bash, network) must check `signal.aborted` periodically; tools with their own subprocess (Bash) should also pipe abort → SIGTERM/SIGKILL.
 - **Use `ctx.cwd` not `process.cwd()`.** Cwd is per-session.
 - **Permission default.** Anything with side effects (Write, Bash, network): `{ action: 'prompt' }`. Read-only tools (Read, Glob, Grep) also use `prompt` by default — let the resolver decide.
-- **Path handling.** For filesystem tools, use `resolvePath(ctx.cwd, target)` from `@moxxy/tools-builtin/src/util` (or wrap with `resolveWithinCwd` if you want strict containment). The function name `resolveSafe` is kept as a deprecated alias; new code uses `resolvePath`. Real safety against unintended fs access lives at the permission layer, not the resolver.
+- **Path handling.** For filesystem tools, use `resolvePath(ctx.cwd, target)` from `@moxxy/tools-builtin/src/util` (or wrap with `resolveWithinCwd` if you want strict containment). Real safety against unintended fs access lives at the permission layer, not the resolver.
 - **No path-traversal sandboxes for the sake of it.** Adding `..` rejection by default breaks legitimate workflows ("read ~/.bashrc"). Only use `resolveWithinCwd` when the tool's *contract* is "inside cwd only."
 
 ## Hook ordering before your handler runs

--- a/.changeset/remove-resolve-safe-alias.md
+++ b/.changeset/remove-resolve-safe-alias.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/tools-builtin': patch
+'@moxxy/cli': patch
+---
+
+Dead-code cleanup: remove the deprecated `resolveSafe` alias from tools-builtin (no callers remained — use `resolvePath`), and retire/re-point stale TECH_DEBT entries (the CDP screencast sidecar handlers were already deleted in #212; the piped-shell fallback and terminal-sizing constraint notes now point at `packages/plugin-terminal` / `TerminalPane.tsx` where that code actually lives).

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -13,6 +13,13 @@ or recorded-on-purpose decision.
 
 ## Resolved ledger
 
+- [dormant, browser, RESOLVED 2026-07-03] CDP screencast push path (`startScreencast`/
+  `stopScreencast` sidecar handlers) — the entry was stale: the handlers were already
+  deleted in the PR #212 quality sweep; only screenshot-polling remains (rationale in
+  `packages/plugin-browser/src/browser-surface.ts`). A regression guard pins the former
+  methods to `unknown method` (`packages/plugin-browser/src/sidecar/dispatch.test.ts`).
+- [low, tools, RESOLVED 2026-07-03] `resolveSafe` deprecated alias for `resolvePath`
+  removed (no callers remained). `packages/tools-builtin/src/util.ts`.
 - [low, focus, RESOLVED 2026-07-02] Focus Mode mini-chat no longer carries a
   separate text-only composer path: pasted screenshots now reuse the desktop
   attachment save/preview/send pipeline, zoomed image previews can be drag-panned,
@@ -166,11 +173,13 @@ or recorded-on-purpose decision.
   if adding open/close call sites (a single viewer's close must not destroy a shared
   instance). `packages/core/src/surfaces/host.test.ts`.
 - [constraint] Terminal sizing depends on the pane being full-width at mount — never
-  push a transient/sub-full column count to a PTY-backed surface. `packages/core/src/surfaces/`.
-- [dormant] CDP screencast → screenshot-polling fallback is unused — remove, or
-  gate behind the polling fallback if screencast is revived. `plugin-browser/src/sidecar/`.
+  push a transient/sub-full column count to a PTY-backed surface. Guarded renderer-side
+  (120px-width floor + rAF-coalesced fit in `apps/desktop/src/shell/surfaces/TerminalPane.tsx`)
+  and validated/clamped in `packages/plugin-terminal/src/{terminal,pty}.ts`; keep new
+  viewers behind the same guard.
 - [dormant] Piped-shell fallback is intentionally non-interactive — needs CR→LF +
-  local echo if a no-prebuild platform ever needs it. `packages/core/src/surfaces/pty.ts`.
+  local echo if a no-prebuild platform ever needs it (the degraded state IS surfaced
+  to the viewer). `packages/plugin-terminal/src/pty.ts`.
 - [low] Files pane polls IPC instead of streaming via the Surface protocol — promote
   to a real Surface if a third live pane appears. `apps/desktop/src/shell/surfaces/`.
 - [low] "Add to agent" on a git-changed file assumes cwd === repo root. `FilesPane.tsx`.

--- a/packages/tools-builtin/src/index.test.ts
+++ b/packages/tools-builtin/src/index.test.ts
@@ -11,7 +11,7 @@ import { bashTool } from './bash.js';
 import { grepTool } from './grep.js';
 import { globTool } from './glob.js';
 import { sleepTool, resolveSleepMs, MAX_SLEEP_MS } from './sleep.js';
-import { resolvePath, resolveWithinCwd, resolveSafe } from './util.js';
+import { resolvePath, resolveWithinCwd } from './util.js';
 
 let tmp: string;
 
@@ -352,10 +352,6 @@ describe('path resolution helpers', () => {
     expect(resolvePath('/work', '/etc/passwd')).toBe(path.normalize('/etc/passwd'));
     // Traversal is allowed — the permission layer is what gates real access.
     expect(resolvePath('/work', '../outside')).toBe(path.resolve('/work', '../outside'));
-  });
-
-  it('resolveSafe is a backward-compat alias for resolvePath', () => {
-    expect(resolveSafe('/x', 'y')).toBe(resolvePath('/x', 'y'));
   });
 
   it('resolveWithinCwd allows paths inside cwd', () => {

--- a/packages/tools-builtin/src/util.ts
+++ b/packages/tools-builtin/src/util.ts
@@ -36,12 +36,6 @@ export function resolveWithinCwd(cwd: string, target: string): string {
 }
 
 /**
- * @deprecated Use `resolvePath` (no behavior change — only honest name).
- * Kept as a thin alias so external callers still compile.
- */
-export const resolveSafe = resolvePath;
-
-/**
  * Directory names skipped during recursive traversal by the Glob and Grep
  * tools — build outputs and VCS metadata that are never useful search targets.
  * Kept in one place so the two walkers stay in sync.


### PR DESCRIPTION
## What

Cleanup of three verified dead-code items from a fresh audit:

1. **CDP screencast handlers (plugin-browser sidecar)** — audit follow-up found the `startScreencast`/`stopScreencast` dispatch cases were ALREADY deleted in the #212 quality sweep; the `dispatch.test.ts` block is a deliberate regression guard asserting they report `unknown method` (and is the only coverage of the dispatch default branch), so it stays. Retired the stale `[dormant]` TECH_DEBT entry to the Resolved ledger with that provenance.
2. **`resolveSafe` deprecated alias (tools-builtin)** — removed from `packages/tools-builtin/src/util.ts`. Repo-wide grep found zero live callers: only the alias itself, its alias test in `index.test.ts` (removed), and a doc mention in `.ai/agents/tool-author.md` (updated). Logged in the Resolved ledger.
3. **Stale TECH_DEBT paths** — `packages/core/src/surfaces/pty.ts` no longer exists (PTY moved to plugin-terminal). Re-pointed two entries at reality:
   - `[dormant] Piped-shell fallback` → `packages/plugin-terminal/src/pty.ts` (the CR→LF / no-local-echo limitation is documented there verbatim; noted that the degraded state is now surfaced to the viewer instead of silently ignoring keystrokes).
   - `[constraint] Terminal sizing` → the full-width-at-mount constraint is guarded renderer-side in `apps/desktop/src/shell/surfaces/TerminalPane.tsx` (120px-width floor + rAF-coalesced fit) and validated/clamped in `packages/plugin-terminal/src/{terminal,pty}.ts`.

Behavior-neutral: only the unused alias is deleted; no live code paths refactored.

## Why

Dead exports and stale ledger entries send future work to files that no longer exist and imply cleanup work that was already done.

## Verification

- pnpm build / typecheck / lint / test / check:deps green from repo root (lint: 0 errors, pre-existing warnings only; check:deps: 0 errors, 1 pre-existing orphan warning)
- `@moxxy/tools-builtin` suite 67/67, `@moxxy/plugin-browser` suite 101/101 run directly
- `grep -rn resolveSafe` across packages/apps: no remaining references
- Changeset: `@moxxy/tools-builtin` + `@moxxy/cli` patch (tools-builtin is private/bundled — ships via the cli bump; plugin-browser has no code change, so no bump cut for it)