### PR TITLE
refactor(sdk): export shared abort-backoff + migrate ad-hoc retry loops

### DIFF
--- a/.changeset/shared-abort-backoff.md
+++ b/.changeset/shared-abort-backoff.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/sdk': patch
+'@moxxy/cli': patch
+---
+
+refactor(sdk): surface the shared abort-backoff primitives (`sleepWithAbort`, `nextBackoffMs`) directly on the barrel (they were already exported, but buried in the mode-helpers block) and migrate the ad-hoc retry sleeps onto them: the runner's initial-connect retry + SIGTERM grace waits and the desktop supervisor's restart wait / socket poll / kill grace. All schedules and abort semantics preserved — no behavior change.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -33,6 +33,14 @@ or recorded-on-purpose decision.
   `apps/mobile/tsconfig.json`, `apps/mobile/src/pairingUrl.ts`,
   `apps/mobile/src/styles/tokens.ts`, `apps/mobile/src/hooks/useAttachments.ts`,
   `apps/mobile/src/hooks/useVoiceRecorder.ts`.
+- [low, dry, RESOLVED 2026-07-03] Ad-hoc retry/backoff sleeps consolidated onto the
+  sdk's shared `sleepWithAbort` (now surfaced directly on the barrel next to
+  `nextBackoffMs`, not buried in the mode-helpers block): the runner's
+  initial-connect retry + SIGTERM grace waits and the desktop supervisor's restart
+  wait (`forceRetry` now aborts the sleep) / socket poll / kill grace. Schedules
+  deliberately unchanged (linear connect retry, constant supervisor wait).
+  `packages/runner/src/remote-session.ts`,
+  `packages/desktop-host/src/runner-supervisor.ts`, `packages/sdk/src/index.ts`.
 - [low, focus, RESOLVED 2026-07-02] Focus Mode mini-chat no longer carries a
   separate text-only composer path: pasted screenshots now reuse the desktop
   attachment save/preview/send pipeline, zoomed image previews can be drag-panned,
@@ -159,6 +167,14 @@ or recorded-on-purpose decision.
 
 ## Runner / protocol & architecture
 
+- [note, dry] Three inline backoff/retry implementations remain ON PURPOSE and must
+  not be "deduped" onto `@moxxy/sdk`'s `sleepWithAbort`/`nextBackoffMs`:
+  `client-transport-ws/src/json-rpc-client.ts` (cancellable-timer reconnect; the
+  sdk barrel statically reaches `node:fs/promises`, which breaks its Metro/RN
+  bundle — rationale commented at the site), `plugin-channel-web/src/frontend/
+  socket.ts` (browser bundle), `plugin-provider-claude-code/src/login.ts`
+  (bespoke OAuth retry). Revisit only if the sdk grows a dependency-free
+  browser-safe subpath (like `@moxxy/sdk/tool-display`).
 - [high, architecture] Retype channel handlers to the SDK contract — `ClientSession`
   still exposes the full concrete registry surface; retype handler params to a
   minimal `SessionLike` slice (and verify graceful degradation) alongside the

--- a/packages/client-transport-ws/src/json-rpc-client.ts
+++ b/packages/client-transport-ws/src/json-rpc-client.ts
@@ -295,6 +295,14 @@ export class WsRpcClient {
     this.setStatus('reconnecting');
     // Reconnect with exponential backoff; subscriptions persist so
     // notifications resume on the next successful connection.
+    //
+    // This formula is `nextBackoffMs(attempts + 1, base, max)` from
+    // `@moxxy/sdk` — kept inline ON PURPOSE, do not "dedup" it: this package
+    // must stay dependency-minimal so it bundles under Metro/React Native, and
+    // the sdk main barrel statically reaches `node:fs/promises` (json-file-
+    // store), which breaks an RN bundle. The shape differs too: this is a
+    // cancellable timer cleared by connect()/close(), not an awaited sleep,
+    // so `sleepWithAbort` doesn't fit without restructuring the state machine.
     const delay = Math.min(
       RECONNECT_BASE_DELAY_MS * 2 ** this.reconnectAttempts,
       RECONNECT_MAX_DELAY_MS,

--- a/packages/desktop-host/src/runner-supervisor.ts
+++ b/packages/desktop-host/src/runner-supervisor.ts
@@ -25,6 +25,7 @@ import { EventEmitter } from 'node:events';
 import { Socket } from 'node:net';
 
 import { deleteSession } from '@moxxy/core';
+import { sleepWithAbort } from '@moxxy/sdk';
 import {
   connectRemoteSession,
   isNamedPipe,
@@ -533,7 +534,7 @@ export class RunnerSupervisor extends EventEmitter {
       } catch {
         /* ignore */
       }
-      await new Promise((r) => setTimeout(r, 400));
+      await sleepWithAbort(400);
       try {
         process.kill(pid, 0);
         process.kill(pid, 'SIGKILL');
@@ -585,7 +586,7 @@ export class RunnerSupervisor extends EventEmitter {
               `(code=${exited.code} signal=${exited.signal})`,
           );
         }
-        await sleep(pollMs);
+        await sleepWithAbort(pollMs);
         pollMs = Math.min(pollMs + 100, SOCKET_POLL_MAX_MS);
       }
       throw new Error(
@@ -597,16 +598,24 @@ export class RunnerSupervisor extends EventEmitter {
     }
   }
 
+  /**
+   * The restart wait between supervision-loop attempts: a CONSTANT
+   * {@link RECONNECT_BACKOFF_MS} (deliberately not the sdk's exponential
+   * `nextBackoffMs` — a growing delay would slow the desktop's self-heal, and
+   * `forceRetry()`/`stop()` already provide the pressure valve), expressed as
+   * the sdk's leak-safe `sleepWithAbort` with the notify hook wired to abort.
+   */
   private async waitForRetry(): Promise<void> {
     if (this.stopped) return;
-    await new Promise<void>((resolve) => {
-      const t = setTimeout(resolve, RECONNECT_BACKOFF_MS);
-      this.retryNotify = () => {
-        clearTimeout(t);
-        resolve();
-      };
-    });
-    this.retryNotify = () => {};
+    const wake = new AbortController();
+    this.retryNotify = () => wake.abort();
+    try {
+      await sleepWithAbort(RECONNECT_BACKOFF_MS, wake.signal);
+    } catch {
+      /* forceRetry()/stop() cut the wait short — proceed to the next attempt */
+    } finally {
+      this.retryNotify = () => {};
+    }
   }
 
   private setPhase(phase: ConnectionPhase): void {
@@ -664,10 +673,6 @@ function protocolIncompatiblePhase(msg: string): ConnectionPhase {
     detail: msg,
     hint: 'This app version needs a newer moxxy CLI. Update the CLI (or reinstall the app) to continue.',
   };
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 const SIGKILL_GRACE_MS = 2_000;

--- a/packages/runner/src/remote-session.test.ts
+++ b/packages/runner/src/remote-session.test.ts
@@ -9,12 +9,15 @@
  * accumulate one entry per turn forever — yet a genuine fast-turn completion,
  * buffered a tick before its `runTurn` registers, must still finish the stream.
  */
+import os from 'node:os';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { SessionInfo, TurnId } from '@moxxy/sdk';
 import { JsonRpcPeer } from './jsonrpc.js';
 import type { Transport } from './transport.js';
-import { RemoteSession, isMoxxyCommandLine, spawnText } from './remote-session.js';
+import { RemoteSession, connectWithRetry, isMoxxyCommandLine, spawnText } from './remote-session.js';
 import { RunnerMethod, RunnerNotification } from './protocol.js';
+import { createUnixSocketServer } from './unix-socket.js';
 
 /** A pair of in-memory transports wired to each other (mirrors jsonrpc.test). */
 function makePair(): [Transport, Transport] {
@@ -222,5 +225,32 @@ describe('spawnText (bounded recovery sub-command)', () => {
   it.skipIf(isWin)('returns the trimmed stdout of a fast command', async () => {
     const out = await spawnText('printf', ['hello'], 2_000);
     expect(out).toBe('hello');
+  });
+});
+
+describe('connectWithRetry (initial-connect linear backoff)', () => {
+  function tmpSocket(): string {
+    return path.join(os.tmpdir(), `moxxy-retry-${Math.random().toString(36).slice(2, 10)}.sock`);
+  }
+
+  it('retries until the socket starts accepting (rides over a late-binding runner)', async () => {
+    const socketPath = tmpSocket();
+    // Nothing listens yet — the first attempt(s) fail. Bring the server up
+    // shortly after, well inside the retry budget (100+200+…+500ms ≈ 1.5s).
+    const serverUp = (async () => {
+      await new Promise((r) => setTimeout(r, 150));
+      return createUnixSocketServer(socketPath);
+    })();
+    try {
+      const transport = await connectWithRetry(socketPath, 5);
+      transport.close();
+    } finally {
+      await (await serverUp).close();
+    }
+  });
+
+  it('rejects with the last connect error once retries are exhausted', async () => {
+    // No server ever appears; 1 retry keeps the test fast (~100ms backoff).
+    await expect(connectWithRetry(tmpSocket(), 1)).rejects.toThrow();
   });
 });

--- a/packages/runner/src/remote-session.ts
+++ b/packages/runner/src/remote-session.ts
@@ -30,6 +30,7 @@ import type {
   SynthesizersClientView,
   TurnId,
 } from '@moxxy/sdk';
+import { sleepWithAbort } from '@moxxy/sdk';
 import { JsonRpcPeer } from './jsonrpc.js';
 import {
   makeProvidersView,
@@ -814,7 +815,7 @@ async function terminate(pid: number): Promise<void> {
   } catch {
     /* may already be dead, or we lack permission */
   }
-  await new Promise((r) => setTimeout(r, 400));
+  await sleepWithAbort(400);
   try {
     process.kill(pid, 0); // 0 = liveness probe
     process.kill(pid, 'SIGKILL');
@@ -864,15 +865,22 @@ async function unlinkSocket(socketPath: string): Promise<void> {
   }
 }
 
-/** Connect, retrying with linear backoff to ride over a brief runner hiccup. */
-async function connectWithRetry(socketPath: string, retries: number): Promise<Transport> {
+/**
+ * Connect, retrying with LINEAR backoff (100ms, 200ms, … per attempt) to ride
+ * over a brief runner hiccup. Deliberately not the sdk's exponential
+ * `nextBackoffMs` schedule: the whole budget here is "the runner is up but the
+ * socket isn't accepting for a few hundred ms yet" — doubling delays would just
+ * slow every attach for no resilience gain. The sleep itself is the shared
+ * `sleepWithAbort` primitive. Exported for tests (like {@link spawnText}).
+ */
+export async function connectWithRetry(socketPath: string, retries: number): Promise<Transport> {
   let lastErr: unknown;
   for (let i = 0; i <= retries; i++) {
     try {
       return await connectUnixSocket(socketPath);
     } catch (err) {
       lastErr = err;
-      if (i < retries) await new Promise((r) => setTimeout(r, 100 * (i + 1)));
+      if (i < retries) await sleepWithAbort(100 * (i + 1));
     }
   }
   throw lastErr;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -228,6 +228,11 @@ export {
   type MoxxyErrorCode,
   type MoxxyErrorInit,
 } from './errors.js';
+// Shared retry primitives: a leak-safe, abort-aware sleep + the exponential
+// back-off schedule. General-purpose — not mode-loop internals: the runner's
+// connect retry and the desktop supervisor's restart wait use them too, so
+// don't reimplement an ad-hoc `new Promise(setTimeout)` back-off elsewhere.
+export { sleepWithAbort, nextBackoffMs } from './mode/abort-backoff.js';
 export {
   collectProviderStream,
   runSingleShotTurn,
@@ -236,8 +241,6 @@ export {
   buildSystemPromptWithSkills,
   createStuckLoopDetector,
   stableHash,
-  sleepWithAbort,
-  nextBackoffMs,
   type CollectedToolUse,
   type StreamResult,
   type ProjectMessagesOptions,


### PR DESCRIPTION
## What

Audit finding: retry/backoff is reimplemented across the repo while a clean primitive exists at `packages/sdk/src/mode/abort-backoff.ts`.

- **sdk barrel**: `sleepWithAbort` + `nextBackoffMs` were in fact already exported (since #297), but buried inside the mode-helpers export block. They're now surfaced as a direct, documented export from `./mode/abort-backoff.js` — same names, zero API change (hence **patch**, not minor: a minor for exports that already shipped in v0.24.x would be misleading).
- **Migrated** (`sleepWithAbort`, schedules preserved exactly):
  - `packages/runner/src/remote-session.ts` — `connectWithRetry` retry sleep (kept the deliberately **linear** 100/200/…ms schedule; documented why it's not `nextBackoffMs`) + the SIGTERM→SIGKILL 400ms grace. `connectWithRetry` exported for tests (same seam pattern as `spawnText`).
  - `packages/desktop-host/src/runner-supervisor.ts` — `waitForRetry` now expresses the constant-2s restart wait as `sleepWithAbort` with `forceRetry()`/`stop()` wired to an AbortController (policy unchanged: constant, user-interruptible — not exponential); socket poll + kill grace migrated; local `sleep()` helper deleted.
- **Skipped on purpose**:
  - `packages/client-transport-ws/src/json-rpc-client.ts` — its delay formula IS `nextBackoffMs(attempts+1, base, max)`, but the package must stay dependency-minimal to bundle under Metro/RN and the sdk main barrel statically reaches `node:fs/promises` (json-file-store); the reconnect is also a cancellable timer cleared by `connect()`/`close()`, not an awaited sleep. Rationale now commented at the site so a future dedup pass doesn't break the mobile bundle.
  - `plugin-channel-web/src/frontend/socket.ts` (browser bundle) and `plugin-provider-claude-code/src/login.ts` (bespoke OAuth retry) — untouched.
- TECH_DEBT: resolved-ledger entry for the consolidation + a `[note]` documenting the three intentionally-inline sites (revisit only if the sdk grows a dependency-free browser-safe subpath).

## Why

One leak-safe primitive (never leaks the abort listener/timer, rejects with the signal's reason) instead of N ad-hoc `new Promise(setTimeout)` back-offs; the barrel comment now steers future code to it.

## Verification

- pnpm build / typecheck / lint / test / check:deps green (74 build, 129 typecheck, 127 test tasks + script tests; lint 0 errors; deps 0 errors)
- Existing reconnect/supervisor tests pass **unmodified**: `runner-supervisor.test.ts` 9/9 (incl. "stop() short-circuits the retry wait" against the rewritten wait), `json-rpc-client.test.ts` 33/33
- Added 2 tests for `connectWithRetry` (previously uncovered): retries over a late-binding socket; rejects with the last error when retries exhaust
- CLI smokes: `bin.js --help`, `bin.js plugins list`