### PR TITLE
fix(core): validate event-log lines on read instead of casting

### DIFF
--- a/.changeset/validate-event-log-lines.md
+++ b/.changeset/validate-event-log-lines.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/cli': patch
+---
+
+Validate event-log lines on read instead of casting: session JSONL reads (restore, history paging, index hydration) now pass every parsed line through a shallow structural guard (`isMoxxyEventShape`) and skip wrong-shape lines with the same never-throw semantics as corrupt JSON, instead of trusting them as `MoxxyEvent`s that could crash replay (e.g. a compaction line missing `replacedRange` threw mid-projection).

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -41,6 +41,20 @@ or recorded-on-purpose decision.
   deliberately unchanged (linear connect retry, constant supervisor wait).
   `packages/runner/src/remote-session.ts`,
   `packages/desktop-host/src/runner-supervisor.ts`, `packages/sdk/src/index.ts`.
+- [med, sessions, RESOLVED 2026-07-03] Event-log READS no longer cast blindly:
+  all three JSONL parse sites (`restoreEvents`, `readEventPage`, index
+  hydration) route through a shallow structural guard (`isMoxxyEventShape`)
+  that skips wrong-shape-but-valid-JSON lines with the exact corrupt-line
+  semantics (never throw mid-replay; restore counts them as
+  `invalidShapeLines` and repairs the file). This closes the read-side leak in
+  the EventStore trust boundary (Pillar 2 note below): a junk line can no
+  longer drive replay (a `compaction` line missing `replacedRange` used to
+  throw inside `projectMessagesFromLog`'s unconditional dereference). The
+  guard is allocation-free per line, exhaustively typed against the
+  `MoxxyEvent` union (variant drift fails the build), and deliberately keeps
+  unknown NEWER event types with a valid envelope so a floor rollback can't
+  rewrite away a newer version's history.
+  `packages/core/src/sessions/event-shape.ts`.
 - [low, focus, RESOLVED 2026-07-02] Focus Mode mini-chat no longer carries a
   separate text-only composer path: pasted screenshots now reuse the desktop
   attachment save/preview/send pipeline, zoomed image previews can be drag-panned,
@@ -370,6 +384,9 @@ or recorded-on-purpose decision.
   log is now a registry kind (`eventStore`) with a protected JSONL floor and an
   explicit-opt-in trust boundary, behaviour-identical (thin adapter over
   `SessionPersistence`). Plan: `~/.claude/plans/i-think-we-need-zany-wirth.md`.
+  2026-07-03: the read-side gap this boundary still leaked (JSONL lines cast to
+  `MoxxyEvent` instead of validated) is closed — see the `isMoxxyEventShape`
+  entry in the resolved ledger.
 - [note, updated 2026-07-03] Pillar 3 is HALF done, not unstarted: #363/#364
   shipped the shared `provision()` engine + `moxxy provision`, reworked `init`
   (catalog + `ensureProvider` npm-installs on demand), and unbundled the 6

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,6 +83,7 @@ export {
   type SessionPersistenceOpts,
   type EventPage,
 } from './sessions/persistence.js';
+export { isMoxxyEventShape } from './sessions/event-shape.js';
 export {
   PluginHost,
   PluginRequirementError,

--- a/packages/core/src/sessions/event-shape.test.ts
+++ b/packages/core/src/sessions/event-shape.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+import type { MoxxyEventOfType, MoxxyEventType } from '@moxxy/sdk';
+import { isMoxxyEventShape } from './event-shape.js';
+
+/** Shared valid envelope for building variant samples. */
+const base = {
+  id: 'e1' as never,
+  seq: 0,
+  ts: 1,
+  sessionId: 's1' as never,
+  turnId: 't1' as never,
+  source: 'user' as const,
+};
+
+/**
+ * One valid sample of EVERY variant, typed as an exhaustive record over
+ * `MoxxyEventType` — adding a variant to the sdk union fails this file's
+ * typecheck until a sample (and thus guard coverage) is added, and a sample
+ * that drifts from its variant's shape fails to compile.
+ */
+const samples: { readonly [T in MoxxyEventType]: MoxxyEventOfType<T> } = {
+  user_prompt: { ...base, type: 'user_prompt', text: 'hello' },
+  assistant_chunk: { ...base, type: 'assistant_chunk', delta: 'hi ' },
+  assistant_message: {
+    ...base,
+    type: 'assistant_message',
+    content: 'hi there',
+    stopReason: 'end_turn',
+  },
+  reasoning_chunk: { ...base, type: 'reasoning_chunk', delta: 'thinking…' },
+  reasoning_message: { ...base, type: 'reasoning_message', content: 'thought about it' },
+  tool_call_requested: {
+    ...base,
+    type: 'tool_call_requested',
+    callId: 'c1' as never,
+    name: 'read_file',
+    input: { path: '/tmp/x' },
+  },
+  tool_call_approved: {
+    ...base,
+    type: 'tool_call_approved',
+    callId: 'c1' as never,
+    decidedBy: 'policy',
+    mode: 'allow',
+  },
+  tool_call_denied: {
+    ...base,
+    type: 'tool_call_denied',
+    callId: 'c1' as never,
+    decidedBy: 'resolver',
+    reason: 'denied by user',
+  },
+  tool_result: { ...base, type: 'tool_result', callId: 'c1' as never, ok: true, output: 'done' },
+  skill_invoked: {
+    ...base,
+    type: 'skill_invoked',
+    skillId: 'sk1' as never,
+    name: 'add-a-tool',
+    reason: 'manual',
+  },
+  skill_created: {
+    ...base,
+    type: 'skill_created',
+    skillId: 'sk1' as never,
+    name: 'new-skill',
+    path: '/tmp/skill.md',
+    scope: 'user',
+    originatingPrompt: 'make a skill',
+  },
+  plugin_registered: {
+    ...base,
+    type: 'plugin_registered',
+    pluginId: 'p1' as never,
+    name: '@moxxy/plugin-x',
+    version: '1.0.0',
+    kind: ['tools'],
+  },
+  plugin_unregistered: {
+    ...base,
+    type: 'plugin_unregistered',
+    pluginId: 'p1' as never,
+    name: '@moxxy/plugin-x',
+    reason: 'reload',
+  },
+  mode_iteration: { ...base, type: 'mode_iteration', strategy: 'default', iteration: 2 },
+  compaction: {
+    ...base,
+    type: 'compaction',
+    compactor: 'summarizer',
+    replacedRange: [0, 9],
+    summary: 'earlier chatter',
+    tokensSaved: 1234,
+  },
+  elision: {
+    ...base,
+    type: 'elision',
+    elidedThrough: 40,
+    stubbedRanges: [[0, 40]],
+    elideConversational: false,
+    conversationalRecallThreshold: 3,
+    maxRecallBytes: 65536,
+    neverElideTools: ['recall'],
+    tokensSaved: 5678,
+  },
+  provider_request: { ...base, type: 'provider_request', provider: 'anthropic', model: 'claude' },
+  provider_response: {
+    ...base,
+    type: 'provider_response',
+    provider: 'anthropic',
+    model: 'claude',
+    outputTokens: 10,
+  },
+  error: { ...base, type: 'error', kind: 'retryable', message: 'rate limited' },
+  abort: { ...base, type: 'abort', reason: 'user pressed esc' },
+  plugin_event: {
+    ...base,
+    type: 'plugin_event',
+    pluginId: 'p1' as never,
+    subtype: 'frame',
+    payload: { n: 1 },
+  },
+};
+
+/** Round-trip through JSON, faithful to how the real read path sees a line. */
+function throughJson(value: unknown): unknown {
+  return JSON.parse(JSON.stringify(value)) as unknown;
+}
+
+describe('isMoxxyEventShape', () => {
+  it('accepts a valid sample of every event variant (JSON round-tripped)', () => {
+    for (const [type, sample] of Object.entries(samples)) {
+      expect(isMoxxyEventShape(throughJson(sample)), `variant ${type}`).toBe(true);
+    }
+  });
+
+  it('rejects non-object values and objects missing the envelope', () => {
+    expect(isMoxxyEventShape(null)).toBe(false);
+    expect(isMoxxyEventShape(undefined)).toBe(false);
+    expect(isMoxxyEventShape('user_prompt')).toBe(false);
+    expect(isMoxxyEventShape(42)).toBe(false);
+    expect(isMoxxyEventShape([samples.user_prompt])).toBe(false);
+    expect(isMoxxyEventShape({})).toBe(false);
+    expect(isMoxxyEventShape({ foo: 'bar' })).toBe(false);
+    // Each strict envelope field, individually missing or mistyped.
+    const { id: _id, ...noId } = samples.user_prompt;
+    expect(isMoxxyEventShape(noId)).toBe(false);
+    const { seq: _seq, ...noSeq } = samples.user_prompt;
+    expect(isMoxxyEventShape(noSeq)).toBe(false);
+    const { ts: _ts, ...noTs } = samples.user_prompt;
+    expect(isMoxxyEventShape(noTs)).toBe(false);
+    const { type: _type, ...noType } = samples.user_prompt;
+    expect(isMoxxyEventShape(noType)).toBe(false);
+    expect(isMoxxyEventShape({ ...samples.user_prompt, seq: '0' })).toBe(false);
+    expect(isMoxxyEventShape({ ...samples.user_prompt, id: 7 })).toBe(false);
+  });
+
+  it('rejects non-finite numbers (JSON.parse CAN produce them: 1e999 → Infinity)', () => {
+    const line = JSON.stringify({ ...samples.user_prompt, seq: 0 }).replace('"seq":0', '"seq":1e999');
+    const parsed: unknown = JSON.parse(line);
+    expect((parsed as { seq: number }).seq).toBe(Number.POSITIVE_INFINITY);
+    expect(isMoxxyEventShape(parsed)).toBe(false);
+  });
+
+  it('tolerates absent sessionId/turnId/source (legacy logs) but rejects present-wrong-type', () => {
+    const { sessionId: _s, turnId: _t, source: _src, ...bare } = samples.user_prompt;
+    expect(isMoxxyEventShape(bare)).toBe(true);
+    expect(isMoxxyEventShape({ ...bare, sessionId: null })).toBe(true);
+    expect(isMoxxyEventShape({ ...samples.user_prompt, sessionId: 42 })).toBe(false);
+    expect(isMoxxyEventShape({ ...samples.user_prompt, turnId: {} })).toBe(false);
+    expect(isMoxxyEventShape({ ...samples.user_prompt, source: 9 })).toBe(false);
+  });
+
+  it('keeps an unknown (newer) event type with a valid envelope — floor-rollback forward-compat', () => {
+    expect(isMoxxyEventShape({ ...base, type: 'surface_frame_from_the_future', blob: 'x' })).toBe(
+      true,
+    );
+  });
+
+  it('keeps a known variant carrying an unknown enum member — forward-compat on enum drift', () => {
+    expect(
+      isMoxxyEventShape({ ...samples.assistant_message, stopReason: 'brand_new_reason' }),
+    ).toBe(true);
+  });
+
+  it('rejects known variants missing or mistyping their required fields', () => {
+    const { text: _text, ...promptNoText } = samples.user_prompt;
+    expect(isMoxxyEventShape(promptNoText)).toBe(false);
+    expect(isMoxxyEventShape({ ...samples.user_prompt, text: 42 })).toBe(false);
+    expect(isMoxxyEventShape({ ...samples.tool_result, ok: 'yes' })).toBe(false);
+    const { replacedRange: _rr, ...compactionNoRange } = samples.compaction;
+    expect(isMoxxyEventShape(compactionNoRange)).toBe(false);
+    expect(isMoxxyEventShape({ ...samples.compaction, replacedRange: ['0', '9'] })).toBe(false);
+    expect(isMoxxyEventShape({ ...samples.compaction, replacedRange: [0] })).toBe(false);
+    expect(isMoxxyEventShape({ ...samples.compaction, summary: null })).toBe(false);
+    const { maxRecallBytes: _mrb, ...elisionSlim } = samples.elision;
+    expect(isMoxxyEventShape(elisionSlim)).toBe(false);
+    expect(isMoxxyEventShape({ ...samples.mode_iteration, iteration: 'two' })).toBe(false);
+    expect(isMoxxyEventShape({ ...samples.plugin_registered, kind: 'tools' })).toBe(false);
+  });
+
+  it('tolerates a tool_call_requested whose input key was dropped by JSON.stringify', () => {
+    // `input: undefined` at emit time serializes to a line with NO input key —
+    // a presence check would drop a legitimate event.
+    const line = { ...samples.tool_call_requested, input: undefined };
+    expect(isMoxxyEventShape(throughJson(line))).toBe(true);
+  });
+});

--- a/packages/core/src/sessions/event-shape.ts
+++ b/packages/core/src/sessions/event-shape.ts
@@ -1,0 +1,196 @@
+/**
+ * Runtime shape guard for event-log lines — the read side of the EventStore
+ * trust boundary.
+ *
+ * The per-session JSONL is parsed back into `MoxxyEvent`s on every resume/
+ * attach (`restoreEvents`), every history page (`readEventPage`), and every
+ * index hydration (`matchingSessionStatsFromLog`). Corrupt-JSON lines were
+ * always skipped, but a structurally-valid-but-wrong-shape line used to be
+ * CAST straight to `MoxxyEvent` and then drive replay and state
+ * reconstruction — e.g. a `compaction` line missing `replacedRange`/`summary`
+ * throws inside `projectMessagesFromLog`'s unconditional
+ * `event.summary.trim()` / `event.replacedRange[0]` dereferences, mid-replay.
+ * This guard closes that gap: wrong-shape lines are skipped with the exact
+ * same semantics as corrupt lines (never throw, never truncate what follows).
+ *
+ * CALIBRATION — why this is a shallow structural check, not a full schema:
+ *
+ * `restoreEvents` REWRITES the repaired log after skipping bad lines, so a
+ * false positive here permanently deletes history. The guard therefore
+ * rejects only shapes that would actively corrupt replay, and tolerates
+ * benign drift:
+ *
+ *  - Envelope: strict on the fields the replay machinery itself dereferences
+ *    (`id`, `seq`, `ts`, `type` — mirrors dedupe by `id`, ingest/paging/
+ *    re-sequencing key on numeric `seq`). Lenient-if-present on `sessionId` /
+ *    `turnId` / `source`: the existing session-ownership path already
+ *    tolerates and normalizes a missing `sessionId`
+ *    (`eventBelongsToSession`), and none of these are dereferenced in a way
+ *    that can throw.
+ *  - Unknown `type` with a valid envelope is KEPT, not dropped: every
+ *    downstream fold pattern-matches known types and ignores the rest (there
+ *    is no exhaustive-switch throw), and the desktop floor mechanism makes
+ *    "older core replaying a newer log" a designed scenario — dropping (and
+ *    then rewriting away) a newer version's events on rollback would be
+ *    silent history loss. This matches the pre-guard behavior for that class
+ *    of line exactly.
+ *  - Known `type`: the variant's required primitive fields are checked
+ *    shallowly (`typeof` / `Array.isArray`), because the projection folds
+ *    dereference them unconditionally. Enum-valued strings (`stopReason`,
+ *    `decidedBy`, …) are checked as `string` only — a newer version adding an
+ *    enum member must not get its events dropped by an older reader.
+ *
+ * LOCKSTEP — the spec map below is typed so it cannot drift from the union:
+ * it is exhaustive over `MoxxyEventType` (adding a variant fails the build
+ * until a spec is added) and each spec's keys must be required non-envelope
+ * keys of that exact variant (renaming/removing a field fails the build).
+ * Listing a field is optional per-variant, so a future required field can be
+ * deliberately left unchecked for back-compat (old logs won't have it) — omit
+ * with a comment when doing so.
+ *
+ * PERFORMANCE — this runs once per line while iterating whole logs on the
+ * replay hot path. It allocates nothing per call: a handful of `typeof`
+ * checks plus an indexed walk over a per-variant spec array precomputed at
+ * module load. (This is also why it is hand-rolled rather than zod: a parsed
+ * schema library allocates per-line result/issue objects and would
+ * deep-validate bulky payloads — attachments, tool outputs — that replay
+ * never dereferences structurally.)
+ */
+
+import type { EventBase, MoxxyEvent, MoxxyEventOfType, MoxxyEventType } from '@moxxy/sdk';
+
+/** Shallow runtime kinds a required variant field can be checked as. */
+type FieldKind = 'string' | 'number' | 'boolean' | 'array' | 'seqRange';
+
+/**
+ * Keys of `T` that are required AND carry a checkable type. `undefined
+ * extends T[K]` excludes both optional fields and `unknown`-typed ones
+ * (`tool_call_requested.input`, `plugin_event.payload`) — the latter on
+ * purpose: any JSON value is a valid `unknown`, and `JSON.stringify` drops
+ * the key entirely when the value was `undefined` at emit time, so even a
+ * presence check would drop legitimate events.
+ */
+type CheckableKeys<T> = { [K in keyof T]-?: undefined extends T[K] ? never : K }[keyof T];
+
+/**
+ * The checkable fields of one variant: required keys that are NOT part of the
+ * shared envelope (`EventBase` + the discriminant). Keys are optional so a
+ * back-compat omission is possible, but any key listed must exist on the
+ * variant — a rename/removal in the sdk union breaks this file's typecheck.
+ */
+type VariantFieldSpec<T extends MoxxyEventType> = {
+  readonly [K in Exclude<
+    CheckableKeys<MoxxyEventOfType<T>>,
+    keyof EventBase | 'type'
+  >]?: FieldKind;
+};
+
+/** Exhaustive per-variant field specs — one entry per union member. */
+const VARIANT_SPECS: { readonly [T in MoxxyEventType]: VariantFieldSpec<T> } = {
+  user_prompt: { text: 'string' },
+  assistant_chunk: { delta: 'string' },
+  assistant_message: { content: 'string', stopReason: 'string' },
+  reasoning_chunk: { delta: 'string' },
+  reasoning_message: { content: 'string' },
+  tool_call_requested: { callId: 'string', name: 'string' },
+  tool_call_approved: { callId: 'string', decidedBy: 'string', mode: 'string' },
+  tool_call_denied: { callId: 'string', decidedBy: 'string', reason: 'string' },
+  tool_result: { callId: 'string', ok: 'boolean' },
+  skill_invoked: { skillId: 'string', name: 'string', reason: 'string' },
+  skill_created: {
+    skillId: 'string',
+    name: 'string',
+    path: 'string',
+    scope: 'string',
+    originatingPrompt: 'string',
+  },
+  plugin_registered: { pluginId: 'string', name: 'string', version: 'string', kind: 'array' },
+  plugin_unregistered: { pluginId: 'string', name: 'string', reason: 'string' },
+  mode_iteration: { strategy: 'string', iteration: 'number' },
+  compaction: {
+    compactor: 'string',
+    replacedRange: 'seqRange',
+    summary: 'string',
+    tokensSaved: 'number',
+  },
+  elision: {
+    elidedThrough: 'number',
+    stubbedRanges: 'array',
+    elideConversational: 'boolean',
+    conversationalRecallThreshold: 'number',
+    maxRecallBytes: 'number',
+    neverElideTools: 'array',
+    tokensSaved: 'number',
+  },
+  provider_request: { provider: 'string', model: 'string' },
+  provider_response: { provider: 'string', model: 'string' },
+  error: { kind: 'string', message: 'string' },
+  abort: { reason: 'string' },
+  plugin_event: { pluginId: 'string', subtype: 'string' },
+};
+
+/** Specs flattened to `[key, kind]` arrays ONCE at module load, so the per-line
+ *  check walks a plain array by index — no per-call object/iterator work. */
+const SPEC_ENTRIES: ReadonlyMap<string, ReadonlyArray<readonly [string, FieldKind]>> = new Map(
+  Object.entries(VARIANT_SPECS).map(([type, spec]) => [
+    type,
+    Object.entries(spec) as ReadonlyArray<readonly [string, FieldKind]>,
+  ]),
+);
+
+function fieldOk(value: unknown, kind: FieldKind): boolean {
+  switch (kind) {
+    case 'string':
+      return typeof value === 'string';
+    case 'number':
+      // JSON.parse CAN yield non-finite numbers (`1e999` → Infinity); a
+      // non-finite seq-adjacent number poisons every downstream comparison.
+      return typeof value === 'number' && Number.isFinite(value);
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'array':
+      return Array.isArray(value);
+    case 'seqRange':
+      // `[from, to]` seq bounds, compared against `event.seq` unconditionally
+      // by the projection fold — both must be real numbers.
+      return (
+        Array.isArray(value) &&
+        value.length === 2 &&
+        typeof value[0] === 'number' &&
+        Number.isFinite(value[0]) &&
+        typeof value[1] === 'number' &&
+        Number.isFinite(value[1])
+      );
+  }
+}
+
+/**
+ * True when `value` (a successfully-parsed JSONL line) is structurally safe to
+ * replay as a {@link MoxxyEvent}. See the module doc for what "safe" means —
+ * this is a calibrated floor (reject what corrupts replay, keep benign
+ * drift), not a proof of full conformance: an unknown newer event type with a
+ * valid envelope passes, exactly as it (unvalidated) did before this guard.
+ */
+export function isMoxxyEventShape(value: unknown): value is MoxxyEvent {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const e = value as Record<string, unknown>;
+  // Envelope — strict: replay machinery dereferences these on every event.
+  if (typeof e.type !== 'string') return false;
+  if (typeof e.id !== 'string') return false;
+  if (typeof e.seq !== 'number' || !Number.isFinite(e.seq)) return false;
+  if (typeof e.ts !== 'number' || !Number.isFinite(e.ts)) return false;
+  // Envelope — lenient-if-present: absent on some legacy logs (sessionId is
+  // normalized by `eventForSession`), but a present-with-wrong-type value is
+  // junk, not drift.
+  if (e.sessionId != null && typeof e.sessionId !== 'string') return false;
+  if (e.turnId != null && typeof e.turnId !== 'string') return false;
+  if (e.source != null && typeof e.source !== 'string') return false;
+  const fields = SPEC_ENTRIES.get(e.type);
+  // Unknown (newer) event type with a valid envelope: keep — see module doc.
+  if (!fields) return true;
+  for (let i = 0; i < fields.length; i += 1) {
+    const entry = fields[i]!;
+    if (!fieldOk(e[entry[0]], entry[1])) return false;
+  }
+  return true;
+}

--- a/packages/core/src/sessions/persistence.test.ts
+++ b/packages/core/src/sessions/persistence.test.ts
@@ -589,6 +589,138 @@ describe('SessionPersistence', () => {
     expect(again.lines).toHaveLength(0);
   });
 
+  it('restore skips valid-JSON wrong-shape lines exactly like corrupt ones and repairs the file', async () => {
+    const dir = await makeTempDir();
+    const id = '01BADSHAPE0000000000000000';
+    const mk = (seq: number, text: string) => ({
+      id: `e${seq}`,
+      seq,
+      ts: seq,
+      sessionId: id,
+      turnId: 't1',
+      source: 'user',
+      type: 'user_prompt',
+      text,
+    });
+    const lines = [
+      JSON.stringify(mk(0, 'zero')),
+      // Valid JSON, not an event at all (no envelope).
+      JSON.stringify({ foo: 'bar' }),
+      JSON.stringify(mk(2, 'two')),
+      // Valid envelope + known type, but missing the required fields the
+      // projection fold dereferences unconditionally (would throw mid-replay
+      // if trusted: `event.summary.trim()`, `event.replacedRange[0]`).
+      JSON.stringify({ id: 'junk', seq: 3, ts: 3, sessionId: id, turnId: 't1', source: 'compactor', type: 'compaction', compactor: 'x' }),
+      // Corrupt JSON still goes down its own (unchanged) path.
+      '{half a line',
+      JSON.stringify(mk(5, 'five')),
+    ];
+    await fs.writeFile(path.join(dir, `${id}.jsonl`), lines.join('\n') + '\n', 'utf8');
+
+    const { logger, lines: logged } = captureLogger();
+    const restored = await restoreEvents(id, dir, logger);
+
+    // Survivors only, re-sequenced to contiguous 0..n-1, order + ids preserved.
+    expect(restored.map((e) => e.id)).toEqual(['e0', 'e2', 'e5']);
+    expect(restored.map((e) => e.seq)).toEqual([0, 1, 2]);
+    expect(restored.map((e) => (e as { text?: string }).text)).toEqual(['zero', 'two', 'five']);
+    // One structured warn, counting shape-junk separately from corrupt JSON.
+    const warn = logged.find((l) => l.level === 'warn');
+    expect(warn?.meta).toMatchObject({ corruptLines: 1, invalidShapeLines: 2, restoredEvents: 3 });
+    // Never throws mid-replay: every survivor ingests into a fresh mirror.
+    const mirror = new EventLog();
+    for (const e of restored) mirror.ingest(e);
+    expect(mirror.length).toBe(3);
+    // The file was repaired on disk, so the next restore is clean.
+    const repaired = (await fs.readFile(path.join(dir, `${id}.jsonl`), 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { id: string });
+    expect(repaired.map((e) => e.id)).toEqual(['e0', 'e2', 'e5']);
+    const again = captureLogger();
+    await restoreEvents(id, dir, again.logger);
+    expect(again.lines).toHaveLength(0);
+  });
+
+  it('restore leaves a fully-valid log untouched on disk and replays it byte-identically', async () => {
+    const dir = await makeTempDir();
+    const id = '01ALLVALID0000000000000000';
+    const events = [
+      { id: 'e0', seq: 0, ts: 1, sessionId: id, turnId: 't1', source: 'user', type: 'user_prompt', text: 'hi' },
+      { id: 'e1', seq: 1, ts: 2, sessionId: id, turnId: 't1', source: 'model', type: 'assistant_message', content: 'hello', stopReason: 'end_turn' },
+      { id: 'e2', seq: 2, ts: 3, sessionId: id, turnId: 't1', source: 'compactor', type: 'compaction', compactor: 'x', replacedRange: [0, 1], summary: 's', tokensSaved: 10 },
+    ];
+    const original = events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+    await fs.writeFile(path.join(dir, `${id}.jsonl`), original, 'utf8');
+
+    const { logger, lines } = captureLogger();
+    const restored = await restoreEvents(id, dir, logger);
+
+    expect(restored).toEqual(events);
+    expect(lines).toHaveLength(0);
+    // No repair rewrite for a clean log — the bytes on disk are untouched.
+    expect(await fs.readFile(path.join(dir, `${id}.jsonl`), 'utf8')).toBe(original);
+  });
+
+  it('readEventPage skips wrong-shape lines like corrupt ones (read-only, no rewrite)', async () => {
+    const dir = await makeTempDir();
+    const id = '01PAGEBADSHAPE000000000000';
+    const mk = (seq: number, text: string) => ({
+      id: `e${seq}`,
+      seq,
+      ts: seq,
+      sessionId: id,
+      turnId: 't1',
+      source: 'user',
+      type: 'user_prompt',
+      text,
+    });
+    const lines = [
+      JSON.stringify(mk(0, 'zero')),
+      JSON.stringify({ notAnEvent: true }),
+      JSON.stringify(mk(1, 'one')),
+      '{corrupt',
+      JSON.stringify(mk(2, 'two')),
+    ];
+    const original = lines.join('\n') + '\n';
+    await fs.writeFile(path.join(dir, `${id}.jsonl`), original, 'utf8');
+
+    const page = await readEventPage(id, { before: null, limit: 10 }, dir);
+    expect(page.events.map((e) => e.seq)).toEqual([0, 1, 2]);
+    expect(page.prevCursor).toBeNull();
+    // Read-only: the junk stays on disk (restore owns the repair).
+    expect(await fs.readFile(path.join(dir, `${id}.jsonl`), 'utf8')).toBe(original);
+  });
+
+  it('readIndex hydration ignores a wrong-shape line when recovering firstPrompt', async () => {
+    const dir = await makeTempDir();
+    await fs.mkdir(dir, { recursive: true });
+    const id = '01HYDRATEBADSHAPE000000000';
+    await fs.writeFile(
+      path.join(dir, `${id}.json`),
+      JSON.stringify({ ...meta(id, 3), firstPrompt: null }, null, 2),
+      'utf8',
+    );
+    const junkPrompt = JSON.stringify({ type: 'user_prompt', text: 'junk without envelope' });
+    const validPrompt = JSON.stringify({
+      id: 'e1',
+      seq: 1,
+      ts: 2,
+      sessionId: id,
+      turnId: 't1',
+      source: 'user',
+      type: 'user_prompt',
+      text: 'real prompt',
+    });
+    await fs.writeFile(path.join(dir, `${id}.jsonl`), junkPrompt + '\n' + validPrompt + '\n', 'utf8');
+
+    const [restored] = await readIndex(dir);
+
+    // The junk line neither becomes the label nor hides the later valid prompt.
+    expect(restored?.firstPrompt).toBe('real prompt');
+    expect(restored?.eventCount).toBe(1);
+  });
+
   it('restore removes foreign-session events, creates a backup, and re-sequences survivors', async () => {
     const dir = await makeTempDir();
     const id = '01RESTOREFILTER000000000';

--- a/packages/core/src/sessions/persistence.ts
+++ b/packages/core/src/sessions/persistence.ts
@@ -22,6 +22,7 @@ import { createMutex, type Mutex, type MoxxyEvent, type SessionId } from '@moxxy
 import type { EventLogLike, EventPage, SessionMeta, SessionSource } from '@moxxy/sdk';
 import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { createLogger, type Logger } from '../logger.js';
+import { isMoxxyEventShape } from './event-shape.js';
 
 // `SessionSource`, `SessionMeta` and `EventPage` are the EventStore contract's
 // data shapes — defined in @moxxy/sdk so `EventStoreDef` can reference them.
@@ -529,7 +530,10 @@ async function matchingSessionStatsFromLog(
   for (const line of raw.split('\n')) {
     if (!line.trim()) continue;
     try {
-      events.push(JSON.parse(line) as MoxxyEvent);
+      const parsed: unknown = JSON.parse(line);
+      // Wrong-shape lines are skipped exactly like corrupt ones: neither a
+      // corrupt nor a junk line should hide a later valid prompt.
+      if (isMoxxyEventShape(parsed)) events.push(parsed);
     } catch {
       // A corrupt line should not hide a later valid prompt.
     }
@@ -549,10 +553,11 @@ function providerHeaderFromEvent(event: MoxxyEvent): { provider?: string | null;
  * Restore a previously-persisted session's events. Returns the full
  * event array suitable for passing into `new EventLog(events)`.
  *
- * Skips malformed lines (a single corrupted append shouldn't make the
- * rest of the conversation unreadable) and then RE-SEQUENCES the
- * survivors to contiguous `seq` 0..n-1, preserving order and ids. This
- * matters twice over:
+ * Skips malformed lines — corrupt JSON and valid-JSON-but-wrong-shape
+ * alike (see {@link isMoxxyEventShape}); a single bad append shouldn't
+ * make the rest of the conversation unreadable — and then RE-SEQUENCES
+ * the survivors to contiguous `seq` 0..n-1, preserving order and ids.
+ * This matters twice over:
  *
  *  - Mirror replay: `EventLog.ingest` accepts only `seq === length`, so
  *    a gap left by one corrupt middle line would silently truncate every
@@ -584,15 +589,25 @@ export async function restoreEvents(
   }
   const events: MoxxyEvent[] = [];
   let corruptLines = 0;
+  let invalidShapeLines = 0;
   let foreignEvents = 0;
   let normalizedSessionIds = 0;
   for (const line of raw.split('\n')) {
     if (!line.trim()) continue;
     try {
-      const event = JSON.parse(line) as MoxxyEvent;
-      const ownedEvent = eventForSession(event, sessionId);
+      const parsed: unknown = JSON.parse(line);
+      // Valid JSON but not a replayable event shape (see isMoxxyEventShape):
+      // skipped with the exact same semantics as a corrupt line — counted,
+      // re-sequenced around, and repaired away by the rewrite below. Casting
+      // it through instead used to let a junk line drive replay (a compaction
+      // line without `replacedRange` throws mid-projection).
+      if (!isMoxxyEventShape(parsed)) {
+        invalidShapeLines += 1;
+        continue;
+      }
+      const ownedEvent = eventForSession(parsed, sessionId);
       if (ownedEvent) {
-        if (ownedEvent !== event) normalizedSessionIds += 1;
+        if (ownedEvent !== parsed) normalizedSessionIds += 1;
         events.push(ownedEvent);
       } else {
         foreignEvents += 1;
@@ -612,7 +627,13 @@ export async function restoreEvents(
     }
   }
 
-  if (corruptLines > 0 || resequenced > 0 || foreignEvents > 0 || normalizedSessionIds > 0) {
+  if (
+    corruptLines > 0 ||
+    invalidShapeLines > 0 ||
+    resequenced > 0 ||
+    foreignEvents > 0 ||
+    normalizedSessionIds > 0
+  ) {
     const message =
       foreignEvents > 0
         ? 'session log restored with foreign-session events removed — re-sequenced to keep full history replayable'
@@ -621,6 +642,7 @@ export async function restoreEvents(
       sessionId,
       path: logPath,
       corruptLines,
+      invalidShapeLines,
       foreignEvents,
       normalizedSessionIds,
       resequencedEvents: resequenced,
@@ -695,7 +717,7 @@ export async function restoreEvents(
  * `prevCursor` is the `seq` of the page's oldest event, or `null` once the
  * first persisted event is included (no older page remains).
  *
- * Corrupt lines are skipped (matching {@link restoreEvents}); unlike
+ * Corrupt and wrong-shape lines are skipped (matching {@link restoreEvents}); unlike
  * `restoreEvents` this is a READ-ONLY reader — it never rewrites the file, so
  * it preserves the JSONL exactly (no atomic-write / mutex needed: there is no
  * mutation). Paging keys on each event's on-disk `seq`. Determinism holds for a
@@ -724,13 +746,16 @@ export async function readEventPage(
     return { events: [], prevCursor: null };
   }
 
-  // Parse the JSONL, skipping corrupt lines (one bad append must not make the
-  // rest unreadable). Read-only: we never rewrite the file here.
+  // Parse the JSONL, skipping corrupt AND wrong-shape lines (one bad append
+  // must not make the rest unreadable). Read-only: we never rewrite the file
+  // here.
   const all: MoxxyEvent[] = [];
   for (const line of raw.split('\n')) {
     if (!line.trim()) continue;
     try {
-      all.push(JSON.parse(line) as MoxxyEvent);
+      const parsed: unknown = JSON.parse(line);
+      // skip a valid-JSON-but-not-an-event line, same as restoreEvents
+      if (isMoxxyEventShape(parsed)) all.push(parsed);
     } catch {
       // skip a malformed/half-written line, same as restoreEvents
     }


### PR DESCRIPTION
## What

Event-log reads were cast, not validated: all three JSONL parse sites in `packages/core/src/sessions/persistence.ts` (`restoreEvents`, `readEventPage`, and the index-hydration reader) did `JSON.parse(line) as MoxxyEvent`. Corrupt-JSON lines were already skipped, but a structurally-valid-but-wrong-shape line was trusted as a `MoxxyEvent` and drove session replay/state reconstruction — the read side of the EventStore trust boundary leaked.

Concrete failure this closes: a `compaction` line missing `replacedRange`/`summary` throws inside `projectMessagesFromLog`'s unconditional `event.summary.trim()` / `event.replacedRange[0]` dereferences, mid-replay.

All three sites now route through a new `isMoxxyEventShape` guard (`packages/core/src/sessions/event-shape.ts`); wrong-shape lines skip with the exact corrupt-line semantics (never throw, never truncate what follows; `restoreEvents` counts them as `invalidShapeLines` in its repair warn and repairs the file, the two read-only sites skip silently, matching their corrupt path).

## Guard design (why not zod)

Shallow hand-rolled discriminated-union check, not a full schema:

- **Calibrated against permanent data loss.** `restoreEvents` REWRITES the repaired log, so a guard false positive deletes history forever. The guard rejects only shapes that corrupt replay: strict on the envelope fields the machinery dereferences (`id`, `seq`, `ts`, `type` — with `Number.isFinite`, since `JSON.parse('1e999')` → `Infinity` poisons seq paging), lenient-if-present on `sessionId`/`turnId`/`source` (the existing `eventForSession` path already tolerates+normalizes a missing `sessionId`), and unknown NEWER event types with a valid envelope are KEPT — the desktop floor mechanism makes "older core replaying a newer log" a designed scenario, and dropping them would rewrite away a newer version's history on rollback (pre-guard behavior for that class is preserved exactly).
- **Per-variant required-field checks** (`typeof`/`Array.isArray`, plus a `[from,to]` numeric check for `compaction.replacedRange`) because the projection folds dereference them unconditionally. Enum-valued strings (`stopReason`, `decidedBy`, …) are checked as `string` only so enum drift in a newer writer can't get events dropped by an older reader.
- **Typed in lockstep with the sdk union**: the spec map is exhaustive over `MoxxyEventType` and each spec's keys must be required non-envelope keys of that exact variant — adding/renaming/removing a variant or field fails the build. The test suite additionally keeps one valid sample per variant in an exhaustive typed record.
- **Hot-path cost**: zero allocations per line (precomputed spec arrays, indexed walk). zod would allocate per-line result objects and deep-validate bulky payloads (attachments, tool outputs) replay never dereferences structurally.

## Perf (100k-line synthetic log, mixed event types, best of 5)

- parse only (old): 57.2ms (572ns/line)
- parse + guard (new): 63.7ms (637ns/line) → **+65ns/line, +6.5ms per 100k lines (+11.4% of bare parse, ~4–5% of the ~145ms end-to-end `restoreEvents`)**; real logs (thousands of lines) pay well under 1ms.

## Verification

- pnpm build / typecheck / lint / test / check:deps green (lint/dep warnings pre-existing, none in touched files)
- CLI smokes: `bin.js --help`, `bin.js plugins list`
- New tests: guard unit suite (valid sample of every variant JSON-round-tripped; envelope/variant rejections; legacy-absence tolerance; unknown-type + unknown-enum forward-compat; non-finite-number rejection) + persistence integration (wrong-shape lines skipped+logged+repaired exactly like corrupt ones in `restoreEvents`; read-only skip in `readEventPage`; index hydration ignores junk without hiding the real first prompt; fully-valid log restores byte-identical with the on-disk file untouched)
- TECH_DEBT: EventStore trust-boundary note annotated + resolved-ledger entry added
- Changeset: `@moxxy/cli` patch (core is bundled into the CLI; no sdk type changes)