### PR TITLE
feat(channels): add Signal channel via signal-cli (@moxxy/plugin-channel-signal)

### DIFF
--- a/.changeset/signal-channel-sidecar.md
+++ b/.changeset/signal-channel-sidecar.md
@@ -1,0 +1,32 @@
+---
+"@moxxy/cli": minor
+"@moxxy/sdk": minor
+---
+
+Signal messenger channel via a signal-cli JSON-RPC sidecar (`@moxxy/plugin-channel-signal`).
+
+- New installable `@moxxy/plugin-channel-signal`: moxxy joins your Signal
+  account as a LINKED DEVICE (like Signal Desktop) through a `signal-cli`
+  daemon the plugin fully owns — spawned on `start()` (JSON-RPC over a UNIX
+  socket), health-checked (`version` round-trip), and killed on stop with a
+  SIGTERM→SIGKILL grace. `isAvailable` gates on the binary with a pure PATH
+  scan (no JVM spawn) and returns a `brew install signal-cli` hint instead of
+  ever crashing discovery.
+- Pairing is the linked-device flow: `moxxy channels signal pair` runs
+  `signal-cli link -n moxxy`, renders the `sgnl://linkdevice…` URI as a
+  terminal QR, and stores the account on completion; the desktop Channels
+  panel drives the same window via channel-status (`requestUrl` carries the
+  QR payload, `connected` flips when linked).
+- Every session-reaching path is gated on a sender allow-list (E.164/uuid,
+  vault key `signal_allowed_senders`); the owner's own "Note to Self" is
+  allowed by default after linking. Sync echoes of the bot's own sends are
+  dropped by sent-timestamp (loop protection), the owner's outbound
+  conversations are never reacted to, and every envelope is zod-validated +
+  size-capped before touching the session. Voice notes transcribe through the
+  session's active Transcriber (20MB cap, install guidance when absent).
+- Replies stream as buffered paragraph-aligned chunk sends plus a typing
+  indicator instead of FramePump edits — a Signal edit re-delivers the whole
+  body E2E to every device per frame, which burst-rate edits would turn into
+  notification spam and rate-limit bait.
+- Runs on its own dedicated, isolated runner (like Slack) — a linked device
+  sees all the owner's messages. `SessionSource` gains `'signal'`.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -312,12 +312,15 @@ or recorded-on-purpose decision.
   (`IngestHttpServer`: routing/health/size-capped raw body/verify gate/500
   catch-all + `DeliveryDedupeCache`) and Slack's ingest is a thin pipeline on
   it. Migrating the remaining four is still the larger, lower-payoff refactor.
-- [note, channels] Channel scaffolding shared by telegram+slack now lives in
-  `@moxxy/channel-kit` (FramePump, TurnCoordinator + turnId-filtered turn
+- [note, channels] Channel scaffolding shared by telegram+slack+signal now lives
+  in `@moxxy/channel-kit` (FramePump, TurnCoordinator + turnId-filtered turn
   helpers, host-code + TOFU pairing machines, `resolveSecret`, audited
-  allow-list resolver, ingest scaffold). New channels (Discord/WhatsApp/Signal)
-  should be thin adapters over it — messenger quirks (formatting, transport
-  error mapping, signature schemes, pairing wording) stay in each plugin.
+  allow-list resolver, ingest scaffold). Signal (2026-07-03) validated the
+  thin-adapter claim: it consumes TurnCoordinator/driveTurn/PlainTurnRenderer/
+  resolveSecret/createAuditedAllowListResolver and adds only signal-cli quirks.
+  New channels (Discord/WhatsApp) should be thin adapters over it — messenger
+  quirks (formatting, transport error mapping, signature schemes, pairing
+  wording) stay in each plugin.
   Deliberately NOT extracted (single-implementation or channel-specific):
   Telegram's rich TurnRenderer/HTML pipeline + inline-keyboard
   permission/approval prompts + grammy dispatch, Slack's HMAC verify + zod
@@ -335,6 +338,23 @@ or recorded-on-purpose decision.
 - [low, slack v1] Slack replies stream as PLAIN TEXT via `chat.update` (no
   Block Kit / mrkdwn formatting, no message split for very long replies). A
   Telegram-style renderer + Block Kit would improve fidelity. `packages/plugin-channel-slack/`.
+- [med, signal v1, security] Signal channel is AUTONOMOUS like Slack —
+  allow-list auto-approve, no human-in-the-loop (every auto-approved call is
+  logged). Signal has no server-side button UI, but a reply-keyword approval
+  flow ("reply YES/NO to approve") over the deferred resolver is feasible for
+  v2. Also v1 gates on a static sender allow-list edited only via the vault
+  key / `--allowedSenders`; an `allow <number>` subcommand would help.
+  `packages/plugin-channel-signal/`.
+- [med, signal v1] Signal channel is direct-message only (group envelopes are
+  dropped) and runs the same single global `busy` single-flight as Slack v1.
+  Group support needs a group-id trust story + `groupId` send targets.
+  `packages/plugin-channel-signal/`.
+- [low, signal v1] Replies are plain-text buffered chunk sends (justified in
+  `channel/chunker.ts` — Signal edits re-deliver the full body E2E per frame),
+  so there is no live-updating draft; liveness is the typing indicator only.
+  If signal-cli ever grows a cheap draft/edit path, revisit FramePump here.
+  Daemon crash recovery is exit-fatal (supervisor restart), not in-process
+  respawn. `packages/plugin-channel-signal/`.
 - [med, security] LAN pairing is cleartext `ws://` (RN/Expo can't trust a self-signed
   cert for a private IP); the secure phone path is the tunnel (`wss://`). Add optional
   `https.Server` + dev-build pinning only if direct-LAN encryption ever matters.

--- a/packages/cli/src/channel-hints.ts
+++ b/packages/cli/src/channel-hints.ts
@@ -12,6 +12,7 @@ import {
 const CHANNEL_COMMANDS: Readonly<Record<string, string>> = {
   telegram: '@moxxy/plugin-telegram',
   slack: '@moxxy/plugin-channel-slack',
+  signal: '@moxxy/plugin-channel-signal',
   web: '@moxxy/plugin-channel-web',
   http: '@moxxy/plugin-channel-http',
 };

--- a/packages/cli/src/setup/builtin-requirements.generated.ts
+++ b/packages/cli/src/setup/builtin-requirements.generated.ts
@@ -15,6 +15,13 @@ export const BUILTIN_REQUIREMENTS: Readonly<
       "hint": "Enable @moxxy/plugin-subagents — deep-research fans out sub-queries via ctx.subagents."
     }
   ],
+  "@moxxy/plugin-channel-signal": [
+    {
+      "kind": "plugin",
+      "name": "@moxxy/plugin-vault",
+      "hint": "signal resolves the vault from the service registry for its account number + sender allow-list; @moxxy/plugin-vault must load first"
+    }
+  ],
   "@moxxy/plugin-channel-slack": [
     {
       "kind": "plugin",

--- a/packages/cli/src/setup/persistence.ts
+++ b/packages/cli/src/setup/persistence.ts
@@ -67,7 +67,8 @@ function sessionSource(): SessionSource {
     explicit === 'mobile' ||
     explicit === 'cli' ||
     explicit === 'slack' ||
-    explicit === 'telegram'
+    explicit === 'telegram' ||
+    explicit === 'signal'
   ) {
     return explicit;
   }

--- a/packages/desktop-host/src/channel-catalog.ts
+++ b/packages/desktop-host/src/channel-catalog.ts
@@ -88,6 +88,35 @@ export const CHANNEL_CATALOG: Readonly<Record<string, ChannelCatalogEntry>> = {
     vaultKeys: { botToken: 'telegram_bot_token' },
     requiredKeys: ['telegram_bot_token'],
   },
+  signal: {
+    descriptor: {
+      id: 'signal',
+      name: 'Signal',
+      description:
+        'A Signal linked device (signal-cli sidecar) on its own dedicated runner. Message your "Note to Self" to talk to moxxy; requires the signal-cli binary on PATH.',
+      docsUrl: 'https://github.com/AsamK/signal-cli/wiki/Quickstart',
+      configFields: [
+        {
+          name: 'account',
+          label: 'Account number (E.164)',
+          type: 'text',
+          required: true,
+          placeholder: '+15551234567',
+          help: 'The Signal account moxxy links to as a secondary device',
+        },
+      ],
+      hasWebhookUrl: false,
+      runHint:
+        'Scan the QR with your phone (Signal → Settings → Linked Devices → Link New Device); then message your own "Note to Self" to talk to moxxy.',
+      connect: {
+        kind: 'qr',
+        title: 'Link your Signal',
+        hint: 'On your phone: Signal → Settings → Linked Devices → Link New Device, then scan the QR.',
+      },
+    },
+    vaultKeys: { account: 'signal_account' },
+    requiredKeys: ['signal_account'],
+  },
 };
 
 /** Every catalog entry, in display order. */

--- a/packages/plugin-channel-signal/package.json
+++ b/packages/plugin-channel-signal/package.json
@@ -1,0 +1,89 @@
+{
+  "name": "@moxxy/plugin-channel-signal",
+  "version": "0.26.0",
+  "description": "Signal messenger channel for moxxy via a signal-cli JSON-RPC sidecar. Links as a secondary Signal device (QR pairing), drives the Session from allow-listed senders (Note to Self by default), and replies with buffered chunked sends. Autonomous allow-list permission model.",
+  "keywords": [
+    "moxxy",
+    "agent",
+    "channel",
+    "signal",
+    "signal-cli",
+    "bot"
+  ],
+  "homepage": "https://moxxy.ai",
+  "bugs": {
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
+    "directory": "packages/plugin-channel-signal"
+  },
+  "author": "Michal Makowski <michal.makowski97@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "moxxy": {
+    "plugin": {
+      "entry": "./dist/index.js",
+      "kind": "channel"
+    },
+    "requirements": [
+      {
+        "kind": "plugin",
+        "name": "@moxxy/plugin-vault",
+        "hint": "signal resolves the vault from the service registry for its account number + sender allow-list; @moxxy/plugin-vault must load first"
+      }
+    ],
+    "setup": {
+      "title": "Signal account",
+      "description": "The phone number of the Signal account moxxy links to as a secondary device (like Signal Desktop). No API token: run `moxxy channels signal pair` afterwards and scan the QR with your phone (Signal → Settings → Linked Devices → Link New Device). Requires the signal-cli binary on PATH (`brew install signal-cli`).",
+      "fields": [
+        {
+          "key": "account",
+          "label": "Signal account number (E.164, e.g. +15551234567)",
+          "kind": "text",
+          "vaultKey": "signal_account",
+          "required": true
+        }
+      ]
+    }
+  },
+  "dependencies": {
+    "@clack/prompts": "catalog:",
+    "@moxxy/channel-kit": "workspace:*",
+    "@moxxy/core": "workspace:*",
+    "@moxxy/plugin-vault": "workspace:*",
+    "@moxxy/sdk": "workspace:*",
+    "qrcode": "^1.5.4",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "@types/qrcode": "^1.5.5",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugin-channel-signal/src/channel.test.ts
+++ b/packages/plugin-channel-signal/src/channel.test.ts
@@ -1,0 +1,364 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { SignalChannel, type SignalRpcLike } from './channel.js';
+import { SIGNAL_ACCOUNT_KEY, SIGNAL_ALLOWED_SENDERS_KEY } from './keys.js';
+import { MAX_INBOUND_TEXT_CHARS } from './schema.js';
+
+const OWNER = '+19998887777';
+const FRIEND = '+15550001111';
+const STRANGER = '+14440002222';
+
+function stubVault(seed: Record<string, string> = {}): VaultStore {
+  const map = new Map(Object.entries(seed));
+  return {
+    get: async (k: string) => map.get(k) ?? null,
+    set: async (k: string, v: string) => {
+      map.set(k, v);
+    },
+    has: async (k: string) => map.has(k),
+    delete: async (k: string) => map.delete(k),
+  } as unknown as VaultStore;
+}
+
+function makeFakeSession(opts: { hangTurns?: boolean } = {}) {
+  const listeners = new Set<(e: unknown) => void>();
+  const prompts: string[] = [];
+  let release: (() => void) | null = null;
+  const session = {
+    tools: { list: () => [{ name: 'Read' }, { name: 'Grep' }] },
+    transcribers: { tryGetActive: () => null },
+    setPermissionResolver: vi.fn(),
+    log: {
+      subscribe: (fn: (e: unknown) => void) => {
+        listeners.add(fn);
+        return () => listeners.delete(fn);
+      },
+    },
+    runTurn(prompt: string) {
+      prompts.push(prompt);
+      const hang = opts.hangTurns;
+      return (async function* () {
+        if (hang) {
+          await new Promise<void>((resolve) => {
+            release = resolve;
+          });
+        }
+      })();
+    },
+  };
+  return {
+    session: session as unknown as Session,
+    raw: session,
+    prompts,
+    emitLog: (e: unknown) => {
+      for (const fn of listeners) fn(e);
+    },
+    releaseTurn: () => release?.(),
+  };
+}
+
+class FakeRpc implements SignalRpcLike {
+  requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+  private readonly notif = new Map<string, Set<(p: unknown) => void>>();
+  private ts = 1_000;
+  async request(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    this.requests.push({ method, params });
+    if (method === 'send') return { timestamp: this.ts++ };
+    return {};
+  }
+  onNotification(method: string, listener: (params: unknown) => void): () => void {
+    let set = this.notif.get(method);
+    if (!set) {
+      set = new Set();
+      this.notif.set(method, set);
+    }
+    set.add(listener);
+    return () => set.delete(listener);
+  }
+  onClose(): () => void {
+    return () => undefined;
+  }
+  close(): void {}
+  /** Push one inbound `receive` notification into the channel. */
+  receive(params: unknown): void {
+    for (const fn of this.notif.get('receive') ?? []) fn(params);
+  }
+  sends(): Array<Record<string, unknown>> {
+    return this.requests.filter((r) => r.method === 'send').map((r) => r.params);
+  }
+}
+
+function makeChannel(overrides: {
+  vault?: VaultStore;
+  hangTurns?: boolean;
+  allowedTools?: string[];
+} = {}) {
+  const rpc = new FakeRpc();
+  const sidecarStops: number[] = [];
+  const sidecarAccounts: string[] = [];
+  const fake = makeFakeSession({ ...(overrides.hangTurns ? { hangTurns: true } : {}) });
+  const channel = new SignalChannel({
+    vault:
+      overrides.vault ??
+      stubVault({ [SIGNAL_ALLOWED_SENDERS_KEY]: JSON.stringify([FRIEND]) }),
+    account: OWNER,
+    ...(overrides.allowedTools ? { allowedTools: overrides.allowedTools } : {}),
+    findBinaryFn: () => '/fake/bin/signal-cli',
+    listAccountsFn: async () => [OWNER],
+    sidecarFactory: ({ account }) => {
+      sidecarAccounts.push(account);
+      return {
+        start: async () => rpc,
+        stop: async () => {
+          sidecarStops.push(1);
+        },
+        onExit: () => () => undefined,
+      };
+    },
+  });
+  return { channel, rpc, fake, sidecarStops, sidecarAccounts };
+}
+
+const dataEnvelope = (from: string, message: string | null, extra: Record<string, unknown> = {}) => ({
+  account: OWNER,
+  envelope: {
+    sourceNumber: from,
+    sourceUuid: null,
+    timestamp: 1,
+    dataMessage: { timestamp: 1, message, ...extra },
+  },
+});
+
+const noteToSelfEnvelope = (message: string, timestamp = 7_777) => ({
+  account: OWNER,
+  envelope: {
+    sourceNumber: OWNER,
+    syncMessage: { sentMessage: { timestamp, message, destinationNumber: OWNER } },
+  },
+});
+
+describe('SignalChannel start()', () => {
+  it('swaps in the real allow-list permission resolver on the session', async () => {
+    const { channel, fake } = makeChannel({ allowedTools: ['Read'] });
+    const handle = await channel.start({ session: fake.session });
+    expect(fake.raw.setPermissionResolver).toHaveBeenCalledWith(channel.permissionResolver);
+    expect(channel.permissionResolver.name).toBe('signal-allow-list');
+    expect(channel.connected).toBe(true);
+    await handle.stop();
+  });
+
+  it('throws a pairing hint when unlinked and not in pair/dedicated mode', async () => {
+    const { fake } = makeChannel();
+    const channel = new SignalChannel({
+      vault: stubVault(),
+      account: OWNER,
+      findBinaryFn: () => '/fake/bin/signal-cli',
+      listAccountsFn: async () => [], // nothing linked locally
+      sidecarFactory: () => {
+        throw new Error('daemon must not boot when unlinked');
+      },
+    });
+    await expect(channel.start({ session: fake.session })).rejects.toThrow(/signal pair/);
+  });
+
+  it('throws the install hint when signal-cli is missing', async () => {
+    const { fake } = makeChannel();
+    const channel = new SignalChannel({
+      vault: stubVault(),
+      account: OWNER,
+      findBinaryFn: () => null,
+    });
+    await expect(channel.start({ session: fake.session })).rejects.toThrow(/signal-cli not found/);
+  });
+});
+
+describe('inbound gating (every session-reaching path)', () => {
+  it('runs a turn for an allow-listed sender and replies to them', async () => {
+    const { channel, rpc, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+    rpc.receive(dataEnvelope(FRIEND, 'hello moxxy'));
+    await vi.waitFor(() => expect(fake.prompts).toEqual(['hello moxxy']));
+    await vi.waitFor(() => {
+      const sends = rpc.sends();
+      expect(sends.length).toBeGreaterThan(0);
+      expect(sends.at(-1)).toEqual({ recipient: [FRIEND], message: '(no output)' });
+    });
+    await handle.stop();
+  });
+
+  it('silently drops senders that are not allow-listed', async () => {
+    const { channel, rpc, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+    rpc.receive(dataEnvelope(STRANGER, 'let me in'));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fake.prompts).toEqual([]);
+    expect(rpc.sends()).toEqual([]); // no reply — a reply would leak the bot's existence
+    await handle.stop();
+  });
+
+  it('drops group messages (v1 is direct-message only)', async () => {
+    const { channel, rpc, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+    rpc.receive(dataEnvelope(FRIEND, 'in a group', { groupInfo: { groupId: 'g1' } }));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fake.prompts).toEqual([]);
+    await handle.stop();
+  });
+
+  it('drops data messages from our own account (echo path)', async () => {
+    const { channel, rpc, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+    rpc.receive(dataEnvelope(OWNER, 'talking to myself'));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fake.prompts).toEqual([]);
+    await handle.stop();
+  });
+
+  it('accepts the owner Note-to-Self and replies into it', async () => {
+    const { channel, rpc, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+    rpc.receive(noteToSelfEnvelope('remind me to stretch'));
+    await vi.waitFor(() => expect(fake.prompts).toEqual(['remind me to stretch']));
+    await vi.waitFor(() => {
+      expect(rpc.sends().at(-1)).toEqual({ noteToSelf: true, message: '(no output)' });
+    });
+    await handle.stop();
+  });
+
+  it("ignores the owner's outbound messages to other people", async () => {
+    const { channel, rpc, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+    rpc.receive({
+      account: OWNER,
+      envelope: {
+        sourceNumber: OWNER,
+        syncMessage: {
+          sentMessage: { timestamp: 5, message: 'private chat', destinationNumber: FRIEND },
+        },
+      },
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fake.prompts).toEqual([]);
+    await handle.stop();
+  });
+
+  it('drops sync echoes of its own sends (loop protection)', async () => {
+    const { channel, rpc, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+
+    // Run one Note-to-Self turn so the channel records its send timestamp.
+    rpc.receive(noteToSelfEnvelope('first', 1));
+    await vi.waitFor(() => expect(rpc.sends().length).toBe(1));
+    const echoedTimestamp = 1_000; // FakeRpc's first send timestamp
+
+    // The linked-device echo of OUR reply comes back as a sync sentMessage
+    // with the timestamp our send returned — must NOT trigger a turn.
+    rpc.receive(noteToSelfEnvelope('(no output)', echoedTimestamp));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fake.prompts).toEqual(['first']);
+
+    // A genuinely new Note-to-Self message still gets through.
+    rpc.receive(noteToSelfEnvelope('second', 2));
+    await vi.waitFor(() => expect(fake.prompts).toEqual(['first', 'second']));
+    await handle.stop();
+  });
+
+  it('drops schema-invalid and oversized payloads without crashing', async () => {
+    const { channel, rpc, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+    rpc.receive(null);
+    rpc.receive('garbage');
+    rpc.receive({ envelope: { dataMessage: { message: 42 } } });
+    rpc.receive(dataEnvelope(FRIEND, 'x'.repeat(MAX_INBOUND_TEXT_CHARS + 1)));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fake.prompts).toEqual([]);
+    // Still alive: a valid message afterwards works.
+    rpc.receive(dataEnvelope(FRIEND, 'still alive?'));
+    await vi.waitFor(() => expect(fake.prompts).toEqual(['still alive?']));
+    await handle.stop();
+  });
+
+  it('refuses overlapping turns with a busy reply (single-flight)', async () => {
+    const { channel, rpc, fake } = makeChannel({ hangTurns: true });
+    const handle = await channel.start({ session: fake.session });
+    rpc.receive(dataEnvelope(FRIEND, 'long task'));
+    await vi.waitFor(() => expect(fake.prompts).toEqual(['long task']));
+    rpc.receive(dataEnvelope(FRIEND, 'impatient follow-up'));
+    await vi.waitFor(() => {
+      expect(rpc.sends().some((s) => String(s['message']).includes('still working'))).toBe(true);
+    });
+    expect(fake.prompts).toEqual(['long task']);
+    fake.releaseTurn();
+    await handle.stop();
+  });
+});
+
+describe('lifecycle', () => {
+  it('stop() shuts the sidecar down and resolves running', async () => {
+    const { channel, fake, sidecarStops } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+    await handle.stop('test');
+    expect(sidecarStops).toEqual([1]);
+    await expect(handle.running).resolves.toBeUndefined();
+  });
+
+  it('pair mode opens a link window, then boots the daemon once linked', async () => {
+    const rpc = new FakeRpc();
+    const fake = makeFakeSession();
+    const vault = stubVault(); // no account stored yet
+    let completeLink: ((r: { account: string | null }) => void) | null = null;
+    const sidecarAccounts: string[] = [];
+    const channel = new SignalChannel({
+      vault,
+      findBinaryFn: () => '/fake/bin/signal-cli',
+      listAccountsFn: async () => [],
+      linkFactory: () => ({
+        uri: Promise.resolve('sgnl://linkdevice?uuid=abc&pub_key=def'),
+        completed: new Promise((resolve) => {
+          completeLink = resolve;
+        }),
+        cancel: () => undefined,
+      }),
+      sidecarFactory: ({ account }) => {
+        sidecarAccounts.push(account);
+        return { start: async () => rpc, stop: async () => undefined, onExit: () => () => undefined };
+      },
+    });
+    const linked: string[] = [];
+    channel.onLinked((account) => linked.push(account));
+
+    const handle = await channel.start({ session: fake.session, pair: true });
+    expect(channel.requestUrl).toBe('sgnl://linkdevice?uuid=abc&pub_key=def');
+    expect(channel.connected).toBe(false);
+
+    completeLink!({ account: OWNER });
+    await vi.waitFor(() => expect(channel.connected).toBe(true));
+    expect(channel.requestUrl).toBeNull();
+    expect(sidecarAccounts).toEqual([OWNER]);
+    expect(linked).toEqual([OWNER]);
+    expect(await vault.get(SIGNAL_ACCOUNT_KEY)).toBe(OWNER);
+
+    // The daemon is live: a Note-to-Self message drives a turn.
+    rpc.receive(noteToSelfEnvelope('hello after linking'));
+    await vi.waitFor(() => expect(fake.prompts).toEqual(['hello after linking']));
+    await handle.stop();
+  });
+
+  it('dedicated mode (desktop panel) opens the same link window without pair', async () => {
+    const fake = makeFakeSession();
+    const channel = new SignalChannel({
+      vault: stubVault(),
+      findBinaryFn: () => '/fake/bin/signal-cli',
+      listAccountsFn: async () => [],
+      linkFactory: () => ({
+        uri: Promise.resolve('sgnl://linkdevice?uuid=xyz'),
+        completed: new Promise(() => undefined), // never completes in this test
+        cancel: () => undefined,
+      }),
+    });
+    const handle = await channel.start({ session: fake.session, dedicated: true });
+    expect(channel.requestUrl).toBe('sgnl://linkdevice?uuid=xyz');
+    await handle.stop();
+  });
+});

--- a/packages/plugin-channel-signal/src/channel.ts
+++ b/packages/plugin-channel-signal/src/channel.ts
@@ -1,0 +1,607 @@
+import { newTurnId } from '@moxxy/core';
+import { TurnCoordinator, resolveSecret } from '@moxxy/channel-kit';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import type {
+  Channel,
+  ChannelHandle,
+  ChannelStartOptsBase,
+  MoxxyEvent,
+  PermissionResolver,
+} from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import {
+  SIGNAL_ACCOUNT_ENV,
+  SIGNAL_ACCOUNT_KEY,
+  SIGNAL_ALLOWED_SENDERS_KEY,
+  normalizeSender,
+  parseAllowedSenders,
+} from './keys.js';
+import {
+  receiveParamsSchema,
+  type SignalAttachment,
+  type SignalEnvelope,
+} from './schema.js';
+import {
+  SIGNAL_CLI_INSTALL_HINT,
+  SignalSidecar,
+  findSignalCliOnPath,
+  listSignalAccounts,
+  signalCliAttachmentsDir,
+  startLinkProcess,
+  type LinkProcessHandle,
+  type SpawnFn,
+} from './sidecar.js';
+import { buildSignalPermissionResolver } from './permission.js';
+import { runSignalTurn } from './channel/turn-runner.js';
+import { splitForSignal } from './channel/chunker.js';
+import { pickAudioAttachment, transcribeVoiceAttachment } from './channel/voice.js';
+
+/** Device name shown in the phone's "Linked Devices" list. */
+const LINK_DEVICE_NAME = 'moxxy';
+
+/** Bound on remembered own-send timestamps for the sync-echo drop. */
+const MAX_SENT_TIMESTAMPS = 256;
+
+/** Rate limit for "dropped invalid/unauthorized envelope" warnings. */
+const DROP_WARN_INTERVAL_MS = 5_000;
+
+export interface SignalChannelLogger {
+  debug?(msg: string, meta?: Record<string, unknown>): void;
+  info?(msg: string, meta?: Record<string, unknown>): void;
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+  error?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+/** Where a reply goes: the owner's Note-to-Self thread, or a direct recipient. */
+export type SendTarget = { readonly noteToSelf: true } | { readonly recipient: string };
+
+/** The RPC slice the channel drives (SignalRpcClient satisfies it; tests fake it). */
+export interface SignalRpcLike {
+  request(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  onNotification(method: string, listener: (params: unknown) => void): () => void;
+  onClose(listener: (reason: string) => void): () => void;
+  close(): void;
+}
+
+/** The sidecar slice the channel manages (SignalSidecar satisfies it). */
+export interface SignalSidecarLike {
+  start(): Promise<SignalRpcLike>;
+  stop(): Promise<void>;
+  onExit(listener: (code: number | null) => void): () => void;
+}
+
+export interface SignalStartOpts extends ChannelStartOptsBase {
+  readonly session: Session;
+  /**
+   * If true (and the account isn't linked yet), open a linking window on
+   * startup: spawn `signal-cli link`, publish the `sgnl://linkdevice…` URI as
+   * this channel's connect value (rendered as a QR by the pair flow / desktop
+   * Channels panel), and boot the daemon once the phone completes the link.
+   */
+  readonly pair?: boolean;
+  /**
+   * Running on a dedicated runner under a GUI control surface (the desktop
+   * Channels panel). Equivalent to `pair` for the unlinked case, so the desktop
+   * links with the identical mechanism instead of getting a throw.
+   */
+  readonly dedicated?: boolean;
+  /** Override the autonomous tool allow-list at start. */
+  readonly allowedTools?: ReadonlyArray<string>;
+}
+
+export interface SignalChannelOptions {
+  readonly vault: VaultStore;
+  /** Account override (E.164); beats env + vault. */
+  readonly account?: string;
+  /** signal-cli binary path/name override. Default: resolve from PATH. */
+  readonly binary?: string;
+  /** Tools the model may call autonomously. `['*']` allows every registered tool. */
+  readonly allowedTools?: ReadonlyArray<string>;
+  /** Extra allowed senders (E.164/uuid), merged with the vault allow-list. */
+  readonly allowedSenders?: ReadonlyArray<string>;
+  readonly logger?: SignalChannelLogger;
+  // --- test seams (production uses the real signal-cli) ---
+  readonly sidecarFactory?: (opts: { account: string; binary: string }) => SignalSidecarLike;
+  readonly linkFactory?: (opts: { deviceName: string; binary: string }) => LinkProcessHandle;
+  readonly listAccountsFn?: (opts: { binary: string }) => Promise<string[]>;
+  readonly findBinaryFn?: () => string | null;
+  readonly attachmentsDir?: string;
+  readonly spawnFn?: SpawnFn;
+}
+
+export class SignalChannel implements Channel<SignalStartOpts> {
+  readonly name = 'signal';
+  /**
+   * Installed on the session by the CLI dispatcher. Replaced in `start()` once
+   * the live tool registry is available for `['*']` expansion; until then it
+   * denies everything (safe default before start).
+   */
+  permissionResolver: PermissionResolver;
+
+  private readonly opts: SignalChannelOptions;
+  private session: Session | null = null;
+  private model: string | undefined;
+  private account: string | null = null;
+  private allowedSenders = new Set<string>();
+
+  private sidecar: SignalSidecarLike | null = null;
+  private rpc: SignalRpcLike | null = null;
+  private link: LinkProcessHandle | null = null;
+
+  private handle: ChannelHandle | null = null;
+  private runningSettled = false;
+  private resolveRunning: (() => void) | null = null;
+  private rejectRunning: ((err: Error) => void) | null = null;
+  private stopping = false;
+
+  // Single-flight turn state + the bounded own-turn-id set the foreign-turn
+  // mirror gate filters on (invariant #8).
+  private readonly turns = new TurnCoordinator();
+  private lastTarget: SendTarget | null = null;
+  private logUnsub: (() => void) | null = null;
+
+  /**
+   * Timestamps of messages WE sent through the daemon (signal-cli's `send`
+   * result). A linked device sees the account's sends come back as
+   * `syncMessage.sentMessage` envelopes — including its own — so any sync'd
+   * sent-message whose timestamp is in this set is an echo of ourselves and
+   * must be dropped (loop protection).
+   */
+  private readonly sentTimestamps = new Set<number>();
+
+  // Link-window connect state, published via requestUrl/connected + the
+  // dedicated-runner status file (the desktop panel renders the QR from it).
+  private linkUri: string | null = null;
+  private linked = false;
+  private readonly connectListeners = new Set<() => void>();
+  private readonly linkedListeners = new Set<(account: string) => void>();
+
+  private lastDropWarnAt = 0;
+
+  constructor(opts: SignalChannelOptions) {
+    this.opts = opts;
+    // Pre-start: deny-all (replaced with the real allow-list resolver in start()).
+    this.permissionResolver = buildSignalPermissionResolver({
+      allowedTools: [],
+      allToolNames: [],
+      ...(opts.logger ? { logger: opts.logger } : {}),
+    });
+  }
+
+  /** The `sgnl://linkdevice…` URI while a linking window is open; null otherwise. */
+  get requestUrl(): string | null {
+    return this.linkUri;
+  }
+
+  /** Whether the account is linked (the "connect the other side" step). */
+  get connected(): boolean {
+    return this.linked;
+  }
+
+  /** Fires when linking completes (the pair flow prints success off this). */
+  onLinked(listener: (account: string) => void): () => void {
+    this.linkedListeners.add(listener);
+    return () => this.linkedListeners.delete(listener);
+  }
+
+  async start(startOpts: SignalStartOpts): Promise<ChannelHandle> {
+    if (this.handle) return this.handle;
+    this.session = startOpts.session;
+    this.model = startOpts.model;
+
+    const findBinary = this.opts.findBinaryFn ?? (() => findSignalCliOnPath());
+    const binary = this.opts.binary ?? findBinary();
+    if (!binary) throw new Error(SIGNAL_CLI_INSTALL_HINT);
+
+    // Account: explicit option → env → vault (shared channel-kit precedence).
+    this.account =
+      this.opts.account ??
+      (await resolveSecret(this.opts.vault, {
+        envVar: SIGNAL_ACCOUNT_ENV,
+        vaultKey: SIGNAL_ACCOUNT_KEY,
+      }));
+
+    // Sender allow-list: vault + option extras. The owner's own Note-to-Self is
+    // allowed implicitly (see handleSyncSent) and needs no entry.
+    this.allowedSenders = new Set(
+      [
+        ...parseAllowedSenders(await this.opts.vault.get(SIGNAL_ALLOWED_SENDERS_KEY)),
+        ...(this.opts.allowedSenders ?? []).map(normalizeSender),
+      ].filter(Boolean),
+    );
+
+    // Linked yet? (One-shot `listAccounts` spawn — NOT in isAvailable, JVM
+    // spawns are too slow for discovery.) A probe failure is treated as
+    // "assume linked" when an account is configured: the daemon boot below
+    // surfaces the real error with signal-cli's own stderr, which beats
+    // guessing wrong and opening a spurious link window.
+    let isLinked = false;
+    if (this.account) {
+      try {
+        const listAccounts = this.opts.listAccountsFn ?? ((o: { binary: string }) => listSignalAccounts(o));
+        const accounts = await listAccounts({ binary });
+        isLinked = accounts.includes(this.account);
+      } catch (err) {
+        this.opts.logger?.warn?.('signal: listAccounts probe failed; assuming linked', {
+          err: err instanceof Error ? err.message : String(err),
+        });
+        isLinked = true;
+      }
+    }
+
+    // Swap in the real autonomous allow-list resolver now that the tool
+    // registry is live (mirrors the Slack channel; `['*']` expands here).
+    const allowedTools = startOpts.allowedTools ?? this.opts.allowedTools ?? [];
+    const allToolNames = this.session.tools.list().map((t) => t.name);
+    this.permissionResolver = buildSignalPermissionResolver({
+      allowedTools,
+      allToolNames,
+      ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+    });
+    this.session.setPermissionResolver(this.permissionResolver);
+
+    // Mirror-to-last-target: post assistant prose for turns this channel did
+    // NOT initiate (a co-attached surface ran one) into the last thread served.
+    this.logUnsub = this.session.log.subscribe((event) => this.mirrorForeignTurn(event));
+
+    const running = new Promise<void>((resolve, reject) => {
+      this.resolveRunning = resolve;
+      this.rejectRunning = reject;
+    });
+
+    const dedicated = startOpts.dedicated === true || process.env.MOXXY_DEDICATED_RUNNER === '1';
+    if (isLinked) {
+      this.linked = true;
+      await this.bootDaemon(binary, this.account!);
+    } else if (startOpts.pair || dedicated) {
+      await this.openLinkWindow(binary);
+    } else {
+      this.logUnsub?.();
+      this.logUnsub = null;
+      throw new Error(
+        'This machine is not linked to a Signal account yet. Run `moxxy channels signal pair` ' +
+          '(scan the QR with your phone: Signal → Settings → Linked Devices), or start it from the desktop Channels panel.',
+      );
+    }
+
+    this.handle = {
+      running,
+      onConnectChange: (listener) => {
+        this.connectListeners.add(listener);
+        return () => this.connectListeners.delete(listener);
+      },
+      stop: async (reason = 'shutdown') => {
+        this.stopping = true;
+        // Abort the in-flight turn FIRST so the model loop stops the moment the
+        // operator asks to shut down (shared/remote Session: spend continues
+        // otherwise and only its output is discarded).
+        this.turns.abort(reason);
+        this.link?.cancel();
+        this.link = null;
+        this.logUnsub?.();
+        this.logUnsub = null;
+        const sidecar = this.sidecar;
+        this.sidecar = null;
+        this.rpc = null;
+        if (sidecar) await sidecar.stop();
+        this.settleRunning();
+      },
+    };
+    this.opts.logger?.info?.('signal: channel started', {
+      linked: this.linked,
+      account: this.account,
+      allowedSenders: this.allowedSenders.size,
+    });
+    return this.handle;
+  }
+
+  // -------------------------------------------------------------------------
+  // Linking (secondary-device pairing)
+  // -------------------------------------------------------------------------
+
+  private async openLinkWindow(binary: string): Promise<void> {
+    const makeLink =
+      this.opts.linkFactory ??
+      ((o: { deviceName: string; binary: string }) =>
+        startLinkProcess({
+          deviceName: o.deviceName,
+          binary: o.binary,
+          ...(this.opts.spawnFn ? { spawnFn: this.opts.spawnFn } : {}),
+          ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+        }));
+    const link = makeLink({ deviceName: LINK_DEVICE_NAME, binary });
+    this.link = link;
+    this.linkUri = await link.uri; // throws when signal-cli can't start linking
+    this.notifyConnectChange();
+    this.opts.logger?.info?.('signal: linking window open');
+
+    // Completion is async (the user scans on their phone). Boot the daemon the
+    // moment linking lands; a failure at any point is fatal for the handle so
+    // a supervisor restarts us (and the pair flow surfaces the error).
+    void link.completed
+      .then(async ({ account }) => {
+        if (this.stopping) return;
+        const acct = account ?? this.account;
+        if (!acct) {
+          throw new Error(
+            'linking completed but signal-cli did not report the account number — ' +
+              `store it via \`moxxy channels signal setup\` (vault key ${SIGNAL_ACCOUNT_KEY}) and restart`,
+          );
+        }
+        this.account = acct;
+        await this.opts.vault.set(SIGNAL_ACCOUNT_KEY, acct, ['signal']);
+        this.link = null;
+        this.linkUri = null;
+        this.linked = true;
+        await this.bootDaemon(binary, acct);
+        this.notifyConnectChange();
+        for (const listener of this.linkedListeners) {
+          try {
+            listener(acct);
+          } catch {
+            /* listener errors are not ours */
+          }
+        }
+        this.opts.logger?.info?.('signal: linked', { account: acct });
+      })
+      .catch((err: unknown) => {
+        if (this.stopping) return;
+        this.fatal(
+          new Error(`Signal linking failed: ${err instanceof Error ? err.message : String(err)}`),
+        );
+      });
+  }
+
+  // -------------------------------------------------------------------------
+  // Daemon + inbound envelopes
+  // -------------------------------------------------------------------------
+
+  private async bootDaemon(binary: string, account: string): Promise<void> {
+    const makeSidecar =
+      this.opts.sidecarFactory ??
+      ((o: { account: string; binary: string }) =>
+        new SignalSidecar({
+          account: o.account,
+          binary: o.binary,
+          ...(this.opts.spawnFn ? { spawnFn: this.opts.spawnFn } : {}),
+          ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+        }));
+    const sidecar = makeSidecar({ account, binary });
+    this.sidecar = sidecar;
+    const rpc = await sidecar.start();
+    this.rpc = rpc;
+    rpc.onNotification('receive', (params) => this.handleReceive(params));
+    // An unexpected daemon death is fatal: reject `running` so the process
+    // exits non-zero and a supervisor (desktop panel / systemd) restarts it.
+    sidecar.onExit((code) => {
+      if (this.stopping) return;
+      this.fatal(new Error(`signal-cli daemon exited unexpectedly (code=${code ?? 'null'})`));
+    });
+  }
+
+  /** Every inbound notification funnels through here — zod-validate FIRST. */
+  private handleReceive(params: unknown): void {
+    const parsed = receiveParamsSchema.safeParse(params);
+    if (!parsed.success) {
+      this.warnDrop('invalid receive payload (schema mismatch)');
+      return;
+    }
+    const envelope = parsed.data.envelope;
+    if (envelope.dataMessage) {
+      this.handleDataMessage(envelope);
+      return;
+    }
+    const sent = envelope.syncMessage?.sentMessage;
+    if (sent) {
+      this.handleSyncSent(sent);
+      return;
+    }
+    // Typing / receipt / group-update envelopes: nothing to do.
+  }
+
+  /** A message from ANOTHER account — gate on the sender allow-list. */
+  private handleDataMessage(envelope: SignalEnvelope): void {
+    const data = envelope.dataMessage!;
+    const number = envelope.sourceNumber ?? null;
+    const uuid = envelope.sourceUuid ?? null;
+    const senderIds = [number, uuid, envelope.source ?? null]
+      .filter((x): x is string => typeof x === 'string' && x.length > 0)
+      .map(normalizeSender);
+    if (senderIds.length === 0) {
+      this.warnDrop('data message without a sender identity');
+      return;
+    }
+    // v1: direct messages only. Group fan-in needs its own trust story.
+    if (data.groupInfo) {
+      this.opts.logger?.debug?.('signal: ignoring group message');
+      return;
+    }
+    // Our own account as a dataMessage source is an echo path (legit owner
+    // prompts arrive as syncMessage.sentMessage) — never respond to ourselves.
+    if (this.account && senderIds.includes(normalizeSender(this.account))) {
+      this.opts.logger?.debug?.('signal: ignoring data message from own account');
+      return;
+    }
+    // THE allow-list gate: every session-reaching path passes through here or
+    // through handleSyncSent's owner check. Unknown senders are dropped
+    // silently (no reply) — answering would leak the bot's existence.
+    if (!senderIds.some((id) => this.allowedSenders.has(id))) {
+      this.warnDrop(`unauthorized sender (${senderIds[0] ?? 'unknown'})`);
+      return;
+    }
+    const target: SendTarget = { recipient: number ?? uuid ?? senderIds[0]! };
+    this.dispatchInBackground(
+      this.processMessage(target, data.message ?? null, data.attachments),
+      'data-message',
+    );
+  }
+
+  /**
+   * A sync'd copy of a message the ACCOUNT OWNER sent from another device.
+   * Two jobs: (1) drop echoes of OUR OWN sends (linked devices receive the
+   * account's sends back — loop protection), (2) accept the owner's
+   * Note-to-Self prompts, which are allowed by default after linking.
+   */
+  private handleSyncSent(sent: NonNullable<NonNullable<SignalEnvelope['syncMessage']>['sentMessage']>): void {
+    if (typeof sent.timestamp === 'number' && this.sentTimestamps.has(sent.timestamp)) {
+      this.opts.logger?.debug?.('signal: dropping sync echo of own send');
+      return;
+    }
+    if (sent.groupInfo) return;
+    // Only the owner's own Note-to-Self drives the session. Their outbound
+    // messages to OTHER people are private conversation traffic — never react.
+    const dest = sent.destinationNumber ?? sent.destination ?? null;
+    const isNoteToSelf = this.account != null && dest != null && dest === this.account;
+    if (!isNoteToSelf) return;
+    this.dispatchInBackground(
+      this.processMessage({ noteToSelf: true }, sent.message ?? null, sent.attachments),
+      'note-to-self',
+    );
+  }
+
+  /** Voice → transcript, busy gate, then one coordinated turn. */
+  private async processMessage(
+    target: SendTarget,
+    text: string | null,
+    attachments: ReadonlyArray<SignalAttachment> | undefined,
+  ): Promise<void> {
+    if (!this.session) return;
+    let prompt = text?.trim() ?? '';
+    if (!prompt) {
+      const audio = pickAudioAttachment(attachments);
+      if (!audio) return; // stickers/images/reactions — nothing to run
+      const transcript = await transcribeVoiceAttachment(
+        {
+          session: this.session,
+          attachmentsDir: this.opts.attachmentsDir ?? signalCliAttachmentsDir(),
+          reply: (t) => this.sendText(target, t),
+          ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+        },
+        audio,
+      );
+      if (!transcript) return;
+      prompt = transcript;
+    }
+
+    // Atomic single-flight guard (the coordinator claims the slot BEFORE any
+    // await); the turnId minted here is recorded as an own-turn id — that's
+    // what mirrorForeignTurn filters on (invariant #8).
+    const lease = this.turns.begin(newTurnId());
+    if (!lease) {
+      await this.sendText(target, 'I am still working on the previous prompt. One moment…');
+      return;
+    }
+    this.lastTarget = target;
+    try {
+      await runSignalTurn(
+        {
+          session: this.session,
+          send: (t) => this.sendText(target, t),
+          sendTyping: (stop) => this.sendTyping(target, stop),
+          ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+        },
+        {
+          text: prompt,
+          ...(this.model ? { model: this.model } : {}),
+          controller: lease.controller,
+          turnId: lease.turnId,
+        },
+      );
+    } finally {
+      lease.end();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Outbound
+  // -------------------------------------------------------------------------
+
+  /** Send one message and record its timestamp for the sync-echo drop. */
+  private async sendText(target: SendTarget, text: string): Promise<void> {
+    const rpc = this.rpc;
+    if (!rpc) throw new Error('signal daemon is not running');
+    const params: Record<string, unknown> =
+      'noteToSelf' in target ? { noteToSelf: true, message: text } : { recipient: [target.recipient], message: text };
+    const result = (await rpc.request('send', params)) as { timestamp?: unknown } | null | undefined;
+    const ts = result && typeof result === 'object' ? result.timestamp : undefined;
+    if (typeof ts === 'number') {
+      this.sentTimestamps.add(ts);
+      if (this.sentTimestamps.size > MAX_SENT_TIMESTAMPS) {
+        const oldest = this.sentTimestamps.values().next().value;
+        if (oldest !== undefined) this.sentTimestamps.delete(oldest);
+      }
+    }
+  }
+
+  private async sendTyping(target: SendTarget, stop: boolean): Promise<void> {
+    const rpc = this.rpc;
+    if (!rpc) return;
+    const recipient = 'noteToSelf' in target ? this.account : target.recipient;
+    if (!recipient) return;
+    await rpc.request('sendTyping', { recipient: [recipient], ...(stop ? { stop: true } : {}) });
+  }
+
+  /**
+   * Post the assistant's prose for a turn this channel did not initiate.
+   * Skipped for our own turnIds (robust to async ordering / replay, invariant
+   * #8) and while a turn of ours is streaming via the chunked sender.
+   */
+  private mirrorForeignTurn(event: MoxxyEvent): void {
+    const text = this.turns.mirrorText(event);
+    if (text == null) return;
+    const target = this.lastTarget;
+    if (!target || !this.rpc) return;
+    void (async () => {
+      for (const part of splitForSignal(text)) {
+        await this.sendText(target, part);
+      }
+    })().catch((err) => {
+      this.opts.logger?.warn?.('signal: mirror failed', { err: String(err) });
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Plumbing
+  // -------------------------------------------------------------------------
+
+  /**
+   * Run a handler detached from the socket read loop (an envelope handler that
+   * awaited a whole turn would park notification delivery for its duration).
+   * Errors are logged here — nothing upstream awaits this promise.
+   */
+  private dispatchInBackground(work: Promise<void>, kind: string): void {
+    void work.catch((err) => {
+      this.opts.logger?.warn?.('signal: handler failed', { kind, err: String(err) });
+    });
+  }
+
+  private warnDrop(reason: string): void {
+    const now = Date.now();
+    if (now - this.lastDropWarnAt < DROP_WARN_INTERVAL_MS) return;
+    this.lastDropWarnAt = now;
+    this.opts.logger?.warn?.(`signal: dropped inbound envelope — ${reason}`);
+  }
+
+  private notifyConnectChange(): void {
+    for (const listener of this.connectListeners) {
+      try {
+        listener();
+      } catch (err) {
+        this.opts.logger?.warn?.('signal: connect-change listener threw', { err: String(err) });
+      }
+    }
+  }
+
+  private settleRunning(): void {
+    if (this.runningSettled) return;
+    this.runningSettled = true;
+    this.resolveRunning?.();
+  }
+
+  private fatal(err: Error): void {
+    this.opts.logger?.error?.('signal: fatal channel error', { err: err.message });
+    if (this.runningSettled) return;
+    this.runningSettled = true;
+    this.rejectRunning?.(err);
+  }
+}

--- a/packages/plugin-channel-signal/src/channel/chunker.test.ts
+++ b/packages/plugin-channel-signal/src/channel/chunker.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ChunkedSender,
+  SIGNAL_CHUNK_HARD_LIMIT,
+  splitForSignal,
+  takeChunk,
+} from './chunker.js';
+
+describe('takeChunk', () => {
+  it('holds short text for the final flush', () => {
+    expect(takeChunk('hello world')).toBeNull();
+    expect(takeChunk('x'.repeat(1_500))).toBeNull();
+  });
+
+  it('splits at a paragraph boundary once past the soft limit', () => {
+    const text = 'a'.repeat(1_200) + '\n\n' + 'b'.repeat(600);
+    const taken = takeChunk(text);
+    expect(taken).not.toBeNull();
+    expect(taken!.chunk).toBe('a'.repeat(1_200));
+    expect(taken!.rest).toBe('b'.repeat(600));
+  });
+
+  it('falls back to newline, then word boundaries', () => {
+    const nl = 'a'.repeat(1_200) + '\n' + 'b'.repeat(600);
+    expect(takeChunk(nl)!.chunk).toBe('a'.repeat(1_200));
+    const word = 'a'.repeat(1_200) + ' ' + 'b'.repeat(600);
+    expect(takeChunk(word)!.chunk).toBe('a'.repeat(1_200));
+  });
+
+  it('never returns a chunk above the hard limit (hard cut when boundary-less)', () => {
+    const text = 'x'.repeat(SIGNAL_CHUNK_HARD_LIMIT + 500);
+    const taken = takeChunk(text);
+    expect(taken).not.toBeNull();
+    expect(taken!.chunk.length).toBe(SIGNAL_CHUNK_HARD_LIMIT);
+    expect(taken!.rest.length).toBe(500);
+  });
+
+  it('waits for more text when boundary-less but under the hard limit', () => {
+    expect(takeChunk('x'.repeat(1_800))).toBeNull();
+  });
+
+  it('ignores boundaries too early to form a meaningful chunk', () => {
+    const text = '\n\n' + 'x'.repeat(1_700);
+    // Only boundary is at position 0 — below the minimum cut, so buffer.
+    expect(takeChunk(text)).toBeNull();
+  });
+});
+
+describe('splitForSignal', () => {
+  it('returns short text as a single message', () => {
+    expect(splitForSignal('hi')).toEqual(['hi']);
+  });
+
+  it('drops pure whitespace', () => {
+    expect(splitForSignal('   \n ')).toEqual([]);
+  });
+
+  it('splits long text into under-limit pieces', () => {
+    const paragraphs = Array.from({ length: 8 }, (_, i) => `${'p'.repeat(700)}${i}`).join('\n\n');
+    const parts = splitForSignal(paragraphs);
+    expect(parts.length).toBeGreaterThan(1);
+    for (const part of parts) expect(part.length).toBeLessThanOrEqual(SIGNAL_CHUNK_HARD_LIMIT);
+    // Nothing lost (modulo boundary whitespace).
+    expect(parts.join('')).toContain('p'.repeat(700) + '7');
+  });
+});
+
+describe('ChunkedSender', () => {
+  function collector(): { sent: string[]; send: (t: string) => Promise<void> } {
+    const sent: string[] = [];
+    return {
+      sent,
+      send: async (t) => {
+        sent.push(t);
+      },
+    };
+  }
+
+  it('buffers below the soft limit and flushes once on finalize', async () => {
+    const { sent, send } = collector();
+    const sender = new ChunkedSender({ send });
+    sender.offer('Hello');
+    sender.offer('Hello world');
+    await sender.finalize('Hello world, done.');
+    expect(sent).toEqual(['Hello world, done.']);
+  });
+
+  it('streams paragraph chunks as the snapshot grows, then sends only the remainder', async () => {
+    const { sent, send } = collector();
+    const sender = new ChunkedSender({ send, limits: { softLimit: 20, hardLimit: 60 } });
+    sender.offer('first paragraph text\n\nsecond');
+    await sender.finalize('first paragraph text\n\nsecond part is done');
+    expect(sent).toEqual(['first paragraph text', 'second part is done']);
+  });
+
+  it('sends the empty-turn placeholder only when nothing was ever sent', async () => {
+    const { sent, send } = collector();
+    const sender = new ChunkedSender({ send });
+    await sender.finalize('   ', '(no output)');
+    expect(sent).toEqual(['(no output)']);
+  });
+
+  it('does not send the placeholder when chunks already went out', async () => {
+    const { sent, send } = collector();
+    const sender = new ChunkedSender({ send, limits: { softLimit: 5, hardLimit: 30 } });
+    sender.offer('streamed text already sent\n\nx');
+    await sender.finalize('', '(no output)');
+    expect(sent).toEqual(['streamed text already sent']);
+  });
+
+  it('re-sends the authoritative final text when it diverges from the streamed prefix', async () => {
+    const { sent, send } = collector();
+    const sender = new ChunkedSender({ send, limits: { softLimit: 10, hardLimit: 40 } });
+    sender.offer('streamed draft one\n\nmore text here');
+    await sender.finalize('a completely different final answer');
+    expect(sent[0]).toBe('streamed draft one');
+    expect(sent).toContain('a completely different final answer');
+  });
+
+  it('serializes sends in order', async () => {
+    const order: string[] = [];
+    const sender = new ChunkedSender({
+      send: async (t) => {
+        // Simulate slow transport; a racing offer must not interleave.
+        await new Promise((r) => setTimeout(r, 5));
+        order.push(t);
+      },
+      limits: { softLimit: 4, hardLimit: 12 },
+    });
+    sender.offer('one two\n\n');
+    sender.offer('one two\n\nthree four\n\n');
+    await sender.finalize('one two\n\nthree four\n\nfive');
+    expect(order).toEqual(['one two', 'three four', 'five']);
+  });
+});

--- a/packages/plugin-channel-signal/src/channel/chunker.ts
+++ b/packages/plugin-channel-signal/src/channel/chunker.ts
@@ -1,0 +1,147 @@
+/**
+ * Buffered chunked sends — Signal's streaming strategy.
+ *
+ * WHY NOT FramePump edits: signal-cli's `send` does support editing a previous
+ * message (`editTimestamp`), but every Signal edit is a full end-to-end
+ * re-delivery of the whole message body to every device in the conversation.
+ * Driving it at a streaming cadence (an edit per ~1s for a long turn) floods
+ * the recipient's devices with dozens of E2E deliveries per reply, official
+ * clients keep a bounded edit history per message, and burst sends are exactly
+ * what Signal's server-side spam heuristics rate-limit (challenge/backoff).
+ * So instead of "send once then edit" we buffer the streamed text and send
+ * coherent chunks: nothing goes out until a paragraph-aligned chunk is ready,
+ * and the remainder goes out once, at turn end. Liveness comes from the typing
+ * indicator (`sendTyping`), not message churn.
+ */
+
+/** Buffered text below this length is held for the final flush. */
+export const SIGNAL_CHUNK_SOFT_LIMIT = 1_500;
+/**
+ * Never send a single message longer than this. Signal itself allows long
+ * bodies, but clients render extremely long messages poorly and signal-cli
+ * sends the whole body per message; 2000 mirrors common client truncation.
+ */
+export const SIGNAL_CHUNK_HARD_LIMIT = 2_000;
+
+export interface ChunkLimits {
+  readonly softLimit?: number;
+  readonly hardLimit?: number;
+}
+
+/**
+ * If `text` has grown past the soft limit, split off one send-ready chunk at
+ * the best boundary (paragraph → line → word) at or below the hard limit.
+ * Returns null while the text should keep buffering.
+ */
+export function takeChunk(
+  text: string,
+  limits: ChunkLimits = {},
+): { chunk: string; rest: string } | null {
+  const soft = limits.softLimit ?? SIGNAL_CHUNK_SOFT_LIMIT;
+  const hard = limits.hardLimit ?? SIGNAL_CHUNK_HARD_LIMIT;
+  if (text.length <= soft) return null;
+  const window = text.slice(0, Math.min(text.length, hard));
+  // Prefer a paragraph break; a chunk that ends mid-sentence reads badly as a
+  // standalone Signal message. Require the boundary to keep a meaningful chunk
+  // (≥ half the soft limit) so a leading blank line can't produce confetti.
+  const minCut = Math.floor(soft / 2);
+  for (const boundary of ['\n\n', '\n', ' ']) {
+    const at = window.lastIndexOf(boundary);
+    if (at >= minCut) {
+      return { chunk: window.slice(0, at).trimEnd(), rest: text.slice(at + boundary.length) };
+    }
+  }
+  if (text.length <= hard) return null; // no boundary yet — wait for more text
+  return { chunk: window, rest: text.slice(window.length) }; // pathological: hard cut
+}
+
+/** Split a final remainder into hard-limit-sized pieces at the best boundaries. */
+export function splitForSignal(text: string, limits: ChunkLimits = {}): string[] {
+  const hard = limits.hardLimit ?? SIGNAL_CHUNK_HARD_LIMIT;
+  const parts: string[] = [];
+  let rest = text;
+  while (rest.length > hard) {
+    // Reuse takeChunk with soft==hard-ish so it only splits when forced.
+    const taken = takeChunk(rest, { softLimit: Math.floor(hard / 2), hardLimit: hard });
+    if (!taken) break;
+    if (taken.chunk) parts.push(taken.chunk);
+    rest = taken.rest;
+  }
+  const tail = rest.trim();
+  if (tail) parts.push(tail);
+  return parts;
+}
+
+export interface ChunkedSenderOptions {
+  /** Deliver one message. Errors should be handled by the caller-supplied fn
+   *  (log + swallow) — a failed chunk must never abort the turn. */
+  readonly send: (text: string) => Promise<void>;
+  readonly limits?: ChunkLimits;
+}
+
+/**
+ * Drives {@link takeChunk} over a GROWING renderer snapshot: `offer()` on every
+ * change (sends any ready chunk), `finalize()` at turn end (sends the
+ * remainder, or `emptyText` when the whole turn produced nothing). Sends are
+ * serialized on an internal queue so chunks can never interleave out of order.
+ */
+export class ChunkedSender {
+  private readonly opts: ChunkedSenderOptions;
+  /** The exact snapshot prefix already delivered (chunk boundaries included). */
+  private sentPrefix = '';
+  private sentAnything = false;
+  private queue: Promise<void> = Promise.resolve();
+
+  constructor(opts: ChunkedSenderOptions) {
+    this.opts = opts;
+  }
+
+  /** Called with the current full snapshot whenever it changes. */
+  offer(snapshot: string): void {
+    this.queue = this.queue.then(async () => {
+      // Streamed text only ever grows; if the snapshot diverged from what we
+      // already delivered (the final assistant_message rewrote history) hold
+      // everything for finalize(), which handles divergence explicitly.
+      if (!snapshot.startsWith(this.sentPrefix)) return;
+      let consumed = this.sentPrefix.length;
+      let taken = takeChunk(snapshot.slice(consumed), this.opts.limits);
+      while (taken) {
+        await this.deliver(taken.chunk);
+        consumed = snapshot.length - taken.rest.length;
+        this.sentPrefix = snapshot.slice(0, consumed);
+        taken = takeChunk(taken.rest, this.opts.limits);
+      }
+    });
+  }
+
+  /**
+   * Turn end: deliver whatever the final snapshot still owes. When the final
+   * text no longer extends what we already sent (a divergent final frame —
+   * rare), send the full final text so the user always receives the
+   * authoritative reply, accepting the duplication.
+   */
+  async finalize(snapshot: string, emptyText?: string): Promise<void> {
+    this.queue = this.queue.then(async () => {
+      const finalText = snapshot.trim();
+      if (!finalText) {
+        if (!this.sentAnything && emptyText) await this.deliver(emptyText);
+        return;
+      }
+      const remainder = snapshot.startsWith(this.sentPrefix)
+        ? snapshot.slice(this.sentPrefix.length)
+        : snapshot; // diverged: resend the authoritative text in full
+      for (const part of splitForSignal(remainder, this.opts.limits)) {
+        await this.deliver(part);
+      }
+      this.sentPrefix = snapshot;
+    });
+    await this.queue;
+  }
+
+  private async deliver(text: string): Promise<void> {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    this.sentAnything = true;
+    await this.opts.send(trimmed);
+  }
+}

--- a/packages/plugin-channel-signal/src/channel/turn-runner.ts
+++ b/packages/plugin-channel-signal/src/channel/turn-runner.ts
@@ -1,0 +1,97 @@
+import type { newTurnId } from '@moxxy/core';
+import { PlainTurnRenderer, driveTurn, subscribeTurn } from '@moxxy/channel-kit';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import { ChunkedSender, type ChunkLimits } from './chunker.js';
+
+export interface TurnRunnerLogger {
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface RunSignalTurnDeps {
+  readonly session: Session;
+  /** Deliver one outbound message to the turn's reply target. Must swallow its
+   *  own transport errors (log + resolve) — a failed send never aborts the turn. */
+  readonly send: (text: string) => Promise<void>;
+  /** Start/refresh the typing indicator (best-effort; errors swallowed). */
+  readonly sendTyping?: (stop: boolean) => Promise<void>;
+  readonly chunkLimits?: ChunkLimits;
+  readonly logger?: TurnRunnerLogger;
+}
+
+export interface RunSignalTurnOptions {
+  readonly text: string;
+  readonly model?: string;
+  readonly controller: AbortController;
+  /** Pre-minted turn id; the channel records it as an own-turn id (invariant #8). */
+  readonly turnId: ReturnType<typeof newTurnId>;
+}
+
+/** Signal shows a typing indicator for ~15s per sendTyping; refresh under that. */
+const TYPING_REFRESH_MS = 10_000;
+
+/**
+ * Drive a single Signal turn end-to-end: subscribe to THIS turn's events
+ * (filtered by turnId — `session.log` fans out to every listener, AGENTS.md
+ * invariant #8), stream the rendered snapshot through the buffered
+ * {@link ChunkedSender} (see chunker.ts for why Signal gets chunked sends
+ * instead of FramePump edits), keep a typing indicator alive for liveness, run
+ * the turn, flush the final remainder, and unwind in `finally`.
+ */
+export async function runSignalTurn(
+  deps: RunSignalTurnDeps,
+  opts: RunSignalTurnOptions,
+): Promise<void> {
+  const { session, send, sendTyping, logger } = deps;
+  const { text, model, controller, turnId } = opts;
+
+  const renderer = new PlainTurnRenderer();
+  const sender = new ChunkedSender({
+    send: async (t) => {
+      try {
+        await send(t);
+      } catch (err) {
+        logger?.warn?.('signal: send failed', { err: err instanceof Error ? err.message : String(err) });
+      }
+    },
+    ...(deps.chunkLimits ? { limits: deps.chunkLimits } : {}),
+  });
+
+  // Liveness: refresh the typing indicator while the turn runs (each
+  // sendTyping shows for ~15s). Best-effort — a failure only loses the
+  // indicator, never the turn.
+  const typing = (stop: boolean): void => {
+    if (!sendTyping) return;
+    void sendTyping(stop).catch(() => undefined);
+  };
+  typing(false);
+  const typingTimer = setInterval(() => typing(false), TYPING_REFRESH_MS);
+  typingTimer.unref?.();
+
+  const unsubscribe = subscribeTurn(session, turnId, (event) => {
+    if (renderer.accept(event)) sender.offer(renderer.snapshot());
+  });
+
+  try {
+    await driveTurn(session, {
+      turnId,
+      prompt: text,
+      ...(model ? { model } : {}),
+      signal: controller.signal,
+    });
+    await sender.finalize(renderer.snapshot(), '(no output)');
+  } catch (err) {
+    logger?.warn?.('signal: turn failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    // Surface the failure to the sender rather than going silent.
+    try {
+      await send(`Turn failed: ${err instanceof Error ? err.message : String(err)}`);
+    } catch {
+      /* best-effort */
+    }
+  } finally {
+    clearInterval(typingTimer);
+    typing(true);
+    unsubscribe();
+  }
+}

--- a/packages/plugin-channel-signal/src/channel/voice.test.ts
+++ b/packages/plugin-channel-signal/src/channel/voice.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import { MAX_AUDIO_BYTES, pickAudioAttachment, transcribeVoiceAttachment } from './voice.js';
+
+function fakeSession(transcriber: { transcribe: (bytes: Uint8Array, o: { mimeType: string }) => Promise<{ text: string }> } | null): Session {
+  return {
+    transcribers: { tryGetActive: () => transcriber },
+  } as unknown as Session;
+}
+
+function replies(): { sent: string[]; reply: (t: string) => Promise<void> } {
+  const sent: string[] = [];
+  return {
+    sent,
+    reply: async (t) => {
+      sent.push(t);
+    },
+  };
+}
+
+describe('pickAudioAttachment', () => {
+  it('picks the first audio/* attachment', () => {
+    expect(
+      pickAudioAttachment([
+        { id: 'a', contentType: 'image/png' },
+        { id: 'b', contentType: 'audio/aac' },
+        { id: 'c', contentType: 'audio/ogg' },
+      ])?.id,
+    ).toBe('b');
+  });
+
+  it('returns null when nothing is audio', () => {
+    expect(pickAudioAttachment([{ id: 'a', contentType: 'image/png' }])).toBeNull();
+    expect(pickAudioAttachment(undefined)).toBeNull();
+  });
+});
+
+describe('transcribeVoiceAttachment', () => {
+  it('replies with install guidance when no transcriber is configured', async () => {
+    const r = replies();
+    const out = await transcribeVoiceAttachment(
+      { session: fakeSession(null), attachmentsDir: '/tmp', reply: r.reply },
+      { id: 'abc', contentType: 'audio/aac', size: 10 },
+    );
+    expect(out).toBeNull();
+    expect(r.sent[0]).toMatch(/plugin-stt-whisper/);
+  });
+
+  it('rejects oversized audio from the declared size before reading', async () => {
+    const r = replies();
+    const readFile = vi.fn();
+    const out = await transcribeVoiceAttachment(
+      {
+        session: fakeSession({ transcribe: async () => ({ text: 'x' }) }),
+        attachmentsDir: '/tmp',
+        reply: r.reply,
+        readFile,
+      },
+      { id: 'abc', contentType: 'audio/aac', size: MAX_AUDIO_BYTES + 1 },
+    );
+    expect(out).toBeNull();
+    expect(readFile).not.toHaveBeenCalled();
+    expect(r.sent[0]).toMatch(/too large/);
+  });
+
+  it('rejects a body that lies about its declared size', async () => {
+    const r = replies();
+    const out = await transcribeVoiceAttachment(
+      {
+        session: fakeSession({ transcribe: async () => ({ text: 'x' }) }),
+        attachmentsDir: '/tmp',
+        reply: r.reply,
+        readFile: async () => new Uint8Array(MAX_AUDIO_BYTES + 1),
+      },
+      { id: 'abc', contentType: 'audio/aac', size: 10 },
+    );
+    expect(out).toBeNull();
+    expect(r.sent[0]).toMatch(/too large/);
+  });
+
+  it('drops attachments whose id could escape the attachments dir', async () => {
+    const r = replies();
+    const readFile = vi.fn();
+    const out = await transcribeVoiceAttachment(
+      {
+        session: fakeSession({ transcribe: async () => ({ text: 'x' }) }),
+        attachmentsDir: '/tmp',
+        reply: r.reply,
+        readFile,
+      },
+      { id: '../../etc/passwd' as never, contentType: 'audio/aac' },
+    );
+    expect(out).toBeNull();
+    expect(readFile).not.toHaveBeenCalled();
+    expect(r.sent).toEqual([]); // silent drop — nothing to say to a forged envelope
+  });
+
+  it('replies with the transcription error instead of throwing', async () => {
+    const r = replies();
+    const out = await transcribeVoiceAttachment(
+      {
+        session: fakeSession({
+          transcribe: async () => {
+            throw new Error('whisper 500');
+          },
+        }),
+        attachmentsDir: '/tmp',
+        reply: r.reply,
+        readFile: async () => new Uint8Array(4),
+      },
+      { id: 'abc', contentType: 'audio/aac' },
+    );
+    expect(out).toBeNull();
+    expect(r.sent[0]).toMatch(/whisper 500/);
+  });
+
+  it('transcribes, echoes "heard:", and returns the transcript', async () => {
+    const r = replies();
+    const transcribe = vi.fn(async () => ({ text: '  turn on the lights  ' }));
+    const out = await transcribeVoiceAttachment(
+      {
+        session: fakeSession({ transcribe }),
+        attachmentsDir: '/data/attachments',
+        reply: r.reply,
+        readFile: async (p) => {
+          expect(p).toBe('/data/attachments/12345.opus');
+          return new Uint8Array([1, 2, 3]);
+        },
+      },
+      { id: '12345.opus', contentType: 'audio/ogg', size: 3 },
+    );
+    expect(out).toBe('turn on the lights');
+    expect(transcribe).toHaveBeenCalledWith(expect.any(Uint8Array), { mimeType: 'audio/ogg' });
+    expect(r.sent[0]).toBe('heard: turn on the lights');
+  });
+});

--- a/packages/plugin-channel-signal/src/channel/voice.ts
+++ b/packages/plugin-channel-signal/src/channel/voice.ts
@@ -1,0 +1,118 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import { attachmentIdSchema, type SignalAttachment } from '../schema.js';
+
+/**
+ * Voice-note handling for the Signal channel. signal-cli writes received
+ * attachments to `<dataDir>/attachments/<id>` (it does NOT inline them in the
+ * receive notification), so the flow is: pick the first audio attachment,
+ * size-cap it, read the file, transcribe via the session's active Transcriber,
+ * and hand the transcript back for a normal text turn.
+ */
+
+/**
+ * Hard cap on an audio file we will buffer into memory before transcribing —
+ * matches the Telegram channel's ceiling so an authorized-but-compromised
+ * sender can't make the runner buffer an arbitrarily large blob.
+ */
+export const MAX_AUDIO_BYTES = 20 * 1024 * 1024;
+
+export interface VoiceLogger {
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface VoiceDeps {
+  readonly session: Session;
+  /** signal-cli's attachments dir (injectable for tests). */
+  readonly attachmentsDir: string;
+  /** Reply to the sender (guidance / error strings). */
+  readonly reply: (text: string) => Promise<void>;
+  /** Injectable file reader (tests). Defaults to fs.readFile. */
+  readonly readFile?: (filePath: string) => Promise<Uint8Array>;
+  readonly logger?: VoiceLogger;
+}
+
+/** The first audio attachment in a message, or null. */
+export function pickAudioAttachment(
+  attachments: ReadonlyArray<SignalAttachment> | undefined,
+): SignalAttachment | null {
+  if (!attachments) return null;
+  return attachments.find((a) => (a.contentType ?? '').toLowerCase().startsWith('audio/')) ?? null;
+}
+
+/**
+ * Transcribe a received audio attachment. Returns the transcript, or null when
+ * the message was fully handled with a reply (no transcriber configured,
+ * oversized, unreadable, transcription failed).
+ */
+export async function transcribeVoiceAttachment(
+  deps: VoiceDeps,
+  attachment: SignalAttachment,
+): Promise<string | null> {
+  const transcriber = deps.session.transcribers.tryGetActive();
+  if (!transcriber) {
+    await deps.reply(
+      'Heard a voice note, but no speech-to-text backend is configured. Install @moxxy/plugin-stt-whisper ' +
+        'and run `moxxy login openai` (or set OPENAI_API_KEY) to enable voice input.',
+    );
+    return null;
+  }
+
+  // Reject oversized audio up-front from the declared size, before any read.
+  if (typeof attachment.size === 'number' && attachment.size > MAX_AUDIO_BYTES) {
+    await deps.reply(
+      `That audio is too large (${Math.round(attachment.size / (1024 * 1024))}MB). The limit is ${MAX_AUDIO_BYTES / (1024 * 1024)}MB.`,
+    );
+    return null;
+  }
+
+  // The id becomes a filename under signal-cli's attachments dir; re-validate
+  // its charset here (defense in depth on top of the zod schema) so a crafted
+  // id can never traverse out of the directory.
+  const id = attachmentIdSchema.safeParse(attachment.id);
+  if (!id.success) {
+    deps.logger?.warn?.('signal: dropping voice note with invalid attachment id');
+    return null;
+  }
+  const filePath = path.join(deps.attachmentsDir, id.data);
+
+  const read = deps.readFile ?? ((p: string) => fs.readFile(p));
+  let bytes: Uint8Array;
+  try {
+    bytes = await read(filePath);
+  } catch (err) {
+    deps.logger?.warn?.('signal: could not read voice attachment', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    await deps.reply('Could not read that voice note from the signal-cli attachment store.');
+    return null;
+  }
+  if (bytes.byteLength > MAX_AUDIO_BYTES) {
+    await deps.reply('That audio is too large to transcribe.');
+    return null;
+  }
+
+  let transcript: string;
+  try {
+    const result = await transcriber.transcribe(bytes, {
+      mimeType: attachment.contentType ?? 'audio/aac',
+    });
+    transcript = result.text.trim();
+  } catch (err) {
+    deps.logger?.warn?.('signal: transcription failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    await deps.reply(`Transcription failed: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
+  if (!transcript) {
+    await deps.reply('Could not transcribe the voice note (got empty text).');
+    return null;
+  }
+
+  // Echo what we heard so the user can spot misrecognitions before the agent
+  // acts on it (same UX as the Telegram voice path).
+  await deps.reply(`heard: ${transcript}`);
+  return transcript;
+}

--- a/packages/plugin-channel-signal/src/index.ts
+++ b/packages/plugin-channel-signal/src/index.ts
@@ -1,0 +1,289 @@
+import { defineChannel, definePlugin, type LifecycleHooks, type Plugin } from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { SignalChannel, type SignalChannelOptions } from './channel.js';
+import {
+  SIGNAL_ACCOUNT_ENV,
+  SIGNAL_ACCOUNT_KEY,
+  SIGNAL_ALLOWED_SENDERS_KEY,
+  parseAllowedSenders,
+} from './keys.js';
+import {
+  SIGNAL_CLI_INSTALL_HINT,
+  findSignalCliOnPath,
+  listSignalAccounts,
+  signalCliDataDir,
+} from './sidecar.js';
+import { runSignalWizard } from './setup-wizard.js';
+import { runSignalPairFlow } from './pair-flow.js';
+
+export {
+  SignalChannel,
+  type SignalChannelOptions,
+  type SignalStartOpts,
+  type SendTarget,
+  type SignalRpcLike,
+  type SignalSidecarLike,
+} from './channel.js';
+export { buildSignalPermissionResolver } from './permission.js';
+export { SignalRpcClient, type RpcStream } from './jsonrpc.js';
+export {
+  SignalSidecar,
+  startLinkProcess,
+  listSignalAccounts,
+  findSignalCliOnPath,
+  signalCliDataDir,
+  signalCliAttachmentsDir,
+  SIGNAL_CLI_INSTALL_HINT,
+  type LinkProcessHandle,
+  type SpawnFn,
+  type SpawnedProcess,
+} from './sidecar.js';
+export {
+  receiveParamsSchema,
+  envelopeSchema,
+  attachmentSchema,
+  MAX_INBOUND_TEXT_CHARS,
+  type SignalEnvelope,
+  type SignalAttachment,
+} from './schema.js';
+export {
+  ChunkedSender,
+  takeChunk,
+  splitForSignal,
+  SIGNAL_CHUNK_SOFT_LIMIT,
+  SIGNAL_CHUNK_HARD_LIMIT,
+} from './channel/chunker.js';
+export {
+  SIGNAL_ACCOUNT_KEY,
+  SIGNAL_ACCOUNT_ENV,
+  SIGNAL_ALLOWED_SENDERS_KEY,
+  parseAllowedSenders,
+  normalizeSender,
+  E164_RE,
+} from './keys.js';
+
+export interface BuildSignalPluginOptions {
+  /** Host-injected encrypted secret store (available immediately). */
+  readonly vault: VaultStore;
+}
+
+/**
+ * Build the Signal channel plugin with a host-injected vault (mirrors the
+ * Telegram/Slack plugins' vault injection).
+ */
+export function buildSignalPlugin(opts: BuildSignalPluginOptions): Plugin {
+  return makeSignalPlugin(() => opts.vault);
+}
+
+/**
+ * Discovery-loadable default export: resolves the vault from the inter-plugin
+ * service registry in `onInit` (the vault plugin publishes `'vault'`). Requires
+ * `@moxxy/plugin-vault` to load first (declared in `package.json`
+ * `moxxy.requirements`). The channel + subcommands read the vault via
+ * `getVault()`, so resolution is deferred to call time — after `onInit` wired it.
+ */
+export const signalPlugin: Plugin = (() => {
+  let resolved: VaultStore | null = null;
+  const getVault = (): VaultStore => {
+    if (!resolved) {
+      throw new Error(
+        '@moxxy/plugin-channel-signal: the "vault" service is unavailable — @moxxy/plugin-vault must load first',
+      );
+    }
+    return resolved;
+  };
+  const hooks: LifecycleHooks = {
+    onInit: (ctx) => {
+      resolved = ctx.services.require<VaultStore>('vault');
+    },
+  };
+  return makeSignalPlugin(getVault, hooks);
+})();
+
+export default signalPlugin;
+
+function readStringArray(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) return value.map((x) => String(x));
+  if (typeof value === 'string' && value.trim()) {
+    return value
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return undefined;
+}
+
+function makeSignalPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks): Plugin {
+  return definePlugin({
+    name: '@moxxy/plugin-channel-signal',
+    version: '0.0.0',
+    ...(hooks ? { hooks } : {}),
+    channels: [
+      defineChannel({
+        name: 'signal',
+        description:
+          'Signal messenger channel via a signal-cli JSON-RPC sidecar. Links as a secondary device (QR); Note-to-Self + allow-listed senders drive the agent.',
+        // A linked device sees ALL the account owner's messages, so this
+        // channel runs on its own dedicated, isolated runner (separate socket +
+        // sticky session), like Slack — the bot keeps its own persistent
+        // history apart from the user's desktop/TUI work.
+        dedicatedRunner: true,
+        sessionSource: 'signal',
+        // Self-described config so a control surface (TUI `/channels`, `moxxy
+        // channels start`, the desktop panel) can configure + run Signal
+        // without a hardcoded table.
+        config: {
+          fields: [
+            {
+              name: 'account',
+              label: 'Account number (E.164)',
+              vaultKey: SIGNAL_ACCOUNT_KEY,
+              required: true,
+              secret: false,
+              placeholder: '+15551234567',
+              help: 'The Signal account moxxy links to as a secondary device (needs signal-cli on PATH)',
+            },
+          ],
+          hasRequestUrl: false,
+          runHint:
+            'Scan the QR with your phone (Signal → Settings → Linked Devices → Link New Device); then message your own "Note to Self" to talk to moxxy.',
+          connect: {
+            kind: 'qr',
+            title: 'Link your Signal',
+            hint: 'On your phone: Signal → Settings → Linked Devices → Link New Device, then scan the QR.',
+          },
+        },
+        create: (deps) => {
+          const options = deps.options;
+          const channelOpts: SignalChannelOptions = {
+            vault: getVault(),
+            ...(typeof options?.['account'] === 'string' ? { account: options['account'] } : {}),
+            ...(typeof options?.['binary'] === 'string' ? { binary: options['binary'] } : {}),
+            ...(() => {
+              const tools = readStringArray(options?.['allowedTools']);
+              return tools ? { allowedTools: tools } : {};
+            })(),
+            ...(() => {
+              const senders = readStringArray(options?.['allowedSenders']);
+              return senders ? { allowedSenders: senders } : {};
+            })(),
+            logger: deps.logger as never,
+          };
+          return new SignalChannel(channelOpts);
+        },
+        isAvailable: async () => {
+          // Gate 1: the signal-cli binary. A pure PATH scan (no spawn — this
+          // runs on every `moxxy channels list` / `moxxy doctor`), and a miss
+          // must NEVER crash discovery: return a friendly install hint.
+          try {
+            if (!findSignalCliOnPath()) {
+              return { ok: false, reason: SIGNAL_CLI_INSTALL_HINT };
+            }
+          } catch {
+            return { ok: false, reason: SIGNAL_CLI_INSTALL_HINT };
+          }
+          // Gate 2: an account number (env first — the vault may not be wired
+          // in a probe/listing context).
+          if (process.env[SIGNAL_ACCOUNT_ENV]?.trim()) return { ok: true };
+          try {
+            if (await getVault().has(SIGNAL_ACCOUNT_KEY)) return { ok: true };
+          } catch {
+            /* vault unavailable in a probe context — fall through */
+          }
+          return {
+            ok: false,
+            reason: `No Signal account configured. Run \`moxxy channels signal setup\`, set ${SIGNAL_ACCOUNT_ENV}, or store one in the vault as '${SIGNAL_ACCOUNT_KEY}'.`,
+          };
+        },
+        interactiveCommand: 'setup',
+        subcommands: {
+          setup: {
+            description:
+              'Interactive setup: check signal-cli, store the account number, pick the tool allow-list, then link + start. Shown by default for `moxxy signal` on a TTY.',
+            run: async (ctx) => {
+              if (process.stdin.isTTY !== true) {
+                // Headless: just start the channel (account must already be
+                // configured + linked).
+                return ctx.startChannel();
+              }
+              return runSignalWizard(ctx);
+            },
+          },
+          pair: {
+            description:
+              'Link this machine to your Signal account: prints a QR to scan from Signal → Settings → Linked Devices — the same mechanism the desktop uses.',
+            run: async (ctx) => {
+              if (process.stdin.isTTY !== true) {
+                process.stderr.write(
+                  'Pairing needs a TTY to show the QR. Run `moxxy channels signal pair` on a workstation, or pair from the desktop Channels panel.\n',
+                );
+                return 1;
+              }
+              return runSignalPairFlow(ctx);
+            },
+          },
+          status: {
+            description:
+              'Report signal-cli / account / linking / allow-list state as JSON.',
+            run: async (ctx) => {
+              const vault = ctx.deps.vault as VaultStore | undefined;
+              if (!vault) {
+                process.stderr.write('vault unavailable\n');
+                return 1;
+              }
+              const binary = findSignalCliOnPath();
+              const account =
+                process.env[SIGNAL_ACCOUNT_ENV]?.trim() || (await vault.get(SIGNAL_ACCOUNT_KEY));
+              const allowedSenders = parseAllowedSenders(
+                await vault.get(SIGNAL_ALLOWED_SENDERS_KEY),
+              );
+              // Linked state needs a one-shot signal-cli spawn (slow JVM);
+              // report null when the probe isn't possible/fails.
+              let linked: boolean | null = null;
+              if (binary && account) {
+                try {
+                  linked = (await listSignalAccounts({ binary })).includes(account);
+                } catch {
+                  linked = null;
+                }
+              }
+              process.stdout.write(
+                JSON.stringify(
+                  {
+                    binaryFound: binary != null,
+                    account: account || null,
+                    linked,
+                    allowedSenders,
+                    dataDir: signalCliDataDir(),
+                  },
+                  null,
+                  2,
+                ) + '\n',
+              );
+              return 0;
+            },
+          },
+          unpair: {
+            description:
+              "Forget the stored account + sender allow-list. (signal-cli's own linked-device store is untouched; remove the device from Signal → Linked Devices on your phone to fully unlink.)",
+            run: async (ctx) => {
+              const vault = ctx.deps.vault as VaultStore | undefined;
+              if (!vault) {
+                process.stderr.write('vault unavailable\n');
+                return 1;
+              }
+              const removedAccount = await vault.delete(SIGNAL_ACCOUNT_KEY);
+              await vault.delete(SIGNAL_ALLOWED_SENDERS_KEY);
+              process.stdout.write(
+                removedAccount
+                  ? 'unpaired (vault cleared). To fully unlink, remove the "moxxy" device in Signal → Settings → Linked Devices on your phone.\n'
+                  : 'no account was configured\n',
+              );
+              return 0;
+            },
+          },
+        },
+      }),
+    ],
+  });
+}

--- a/packages/plugin-channel-signal/src/jsonrpc.test.ts
+++ b/packages/plugin-channel-signal/src/jsonrpc.test.ts
@@ -1,0 +1,128 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { SignalRpcClient, type RpcStream } from './jsonrpc.js';
+
+class FakeStream extends EventEmitter implements RpcStream {
+  written: string[] = [];
+  ended = false;
+  write(data: string): boolean {
+    this.written.push(data);
+    return true;
+  }
+  end(): void {
+    this.ended = true;
+  }
+  /** Feed one raw chunk into the client. */
+  feed(raw: string): void {
+    this.emit('data', Buffer.from(raw, 'utf8'));
+  }
+  lastRequest(): { id: string; method: string; params: unknown } {
+    return JSON.parse(this.written.at(-1)!) as { id: string; method: string; params: unknown };
+  }
+}
+
+describe('SignalRpcClient', () => {
+  it('matches responses to requests by id', async () => {
+    const stream = new FakeStream();
+    const client = new SignalRpcClient({ stream });
+    const p = client.request('send', { message: 'hi' });
+    const req = stream.lastRequest();
+    expect(req.method).toBe('send');
+    stream.feed(`{"jsonrpc":"2.0","id":"${req.id}","result":{"timestamp":42}}\n`);
+    await expect(p).resolves.toEqual({ timestamp: 42 });
+  });
+
+  it('rejects on a JSON-RPC error reply', async () => {
+    const stream = new FakeStream();
+    const client = new SignalRpcClient({ stream });
+    const p = client.request('send', {});
+    const req = stream.lastRequest();
+    stream.feed(`{"jsonrpc":"2.0","id":"${req.id}","error":{"code":-32602,"message":"bad params"}}\n`);
+    await expect(p).rejects.toThrow(/bad params/);
+  });
+
+  it('dispatches notifications to subscribers and survives listener throw', () => {
+    const stream = new FakeStream();
+    const client = new SignalRpcClient({ stream });
+    const seen: unknown[] = [];
+    client.onNotification('receive', () => {
+      throw new Error('boom');
+    });
+    client.onNotification('receive', (params) => seen.push(params));
+    stream.feed('{"jsonrpc":"2.0","method":"receive","params":{"envelope":{"sourceNumber":"+1"}}}\n');
+    expect(seen).toEqual([{ envelope: { sourceNumber: '+1' } }]);
+  });
+
+  it('handles split + coalesced frames', async () => {
+    const stream = new FakeStream();
+    const client = new SignalRpcClient({ stream });
+    const p1 = client.request('a');
+    const p2 = client.request('b');
+    const id1 = JSON.parse(stream.written[0]!).id as string;
+    const id2 = JSON.parse(stream.written[1]!).id as string;
+    const line1 = `{"jsonrpc":"2.0","id":"${id1}","result":1}\n`;
+    const line2 = `{"jsonrpc":"2.0","id":"${id2}","result":2}\n`;
+    const combined = line1 + line2;
+    stream.feed(combined.slice(0, 10));
+    stream.feed(combined.slice(10));
+    await expect(p1).resolves.toBe(1);
+    await expect(p2).resolves.toBe(2);
+  });
+
+  it('times out a request the daemon never answers', async () => {
+    vi.useFakeTimers();
+    try {
+      const stream = new FakeStream();
+      const client = new SignalRpcClient({ stream, requestTimeoutMs: 500 });
+      const p = client.request('version');
+      const assertion = expect(p).rejects.toThrow(/timed out/);
+      await vi.advanceTimersByTimeAsync(600);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects pending requests when the stream closes', async () => {
+    const stream = new FakeStream();
+    const client = new SignalRpcClient({ stream });
+    const p = client.request('version');
+    stream.emit('close');
+    await expect(p).rejects.toThrow(/socket closed/);
+    await expect(client.request('version')).rejects.toThrow(/closed/);
+  });
+
+  it('notifies onClose listeners with the reason', () => {
+    const stream = new FakeStream();
+    const client = new SignalRpcClient({ stream });
+    const reasons: string[] = [];
+    client.onClose((r) => reasons.push(r));
+    stream.emit('error', new Error('ECONNRESET'));
+    expect(reasons).toEqual(['socket error: ECONNRESET']);
+  });
+
+  it('drops an oversized un-delimited line instead of buffering forever', () => {
+    const warn = vi.fn();
+    const stream = new FakeStream();
+    const client = new SignalRpcClient({ stream, logger: { warn } });
+    stream.feed('x'.repeat(9 * 1024 * 1024)); // > 8MB cap, no newline
+    expect(warn).toHaveBeenCalledWith(
+      'signal rpc: dropped oversized un-delimited line',
+      expect.objectContaining({ bytes: expect.any(Number) }),
+    );
+    // Client still works afterwards.
+    const p = client.request('version');
+    const req = stream.lastRequest();
+    stream.feed(`{"jsonrpc":"2.0","id":"${req.id}","result":"ok"}\n`);
+    return expect(p).resolves.toBe('ok');
+  });
+
+  it('ignores garbage lines and unknown ids', () => {
+    const stream = new FakeStream();
+    const client = new SignalRpcClient({ stream });
+    stream.feed('not json\n');
+    stream.feed('{"jsonrpc":"2.0","id":"999","result":1}\n');
+    // No throw — and the client still accepts requests.
+    void client;
+  });
+});

--- a/packages/plugin-channel-signal/src/jsonrpc.ts
+++ b/packages/plugin-channel-signal/src/jsonrpc.ts
@@ -1,0 +1,198 @@
+/**
+ * Minimal newline-delimited JSON-RPC 2.0 client for the signal-cli daemon
+ * socket (`signal-cli -a <account> daemon --socket <path>`).
+ *
+ * The daemon speaks one JSON object per line over the UNIX socket:
+ *   → {"jsonrpc":"2.0","id":"…","method":"send","params":{…}}
+ *   ← {"jsonrpc":"2.0","id":"…","result":{…}} | {"…","error":{code,message}}
+ *   ← {"jsonrpc":"2.0","method":"receive","params":{"envelope":{…}}}   (notification)
+ *
+ * The transport is injected as a plain duplex-ish stream so tests never open a
+ * real socket (mirrors the browser sidecar's injectable spawn).
+ */
+
+/** The stream slice this client needs — `net.Socket` satisfies it. */
+export interface RpcStream {
+  write(data: string): unknown;
+  on(event: 'data', listener: (chunk: Buffer | string) => void): unknown;
+  on(event: 'close', listener: () => void): unknown;
+  on(event: 'error', listener: (err: Error) => void): unknown;
+  end?(): unknown;
+  destroy?(): unknown;
+}
+
+export interface RpcLogger {
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface SignalRpcClientOptions {
+  readonly stream: RpcStream;
+  /** Per-request timeout. signal-cli sends synchronously to the Signal server,
+   *  so allow generous headroom. Default 30s. */
+  readonly requestTimeoutMs?: number;
+  readonly logger?: RpcLogger;
+}
+
+/**
+ * Cap on a single buffered line. Receive envelopes are small (attachments are
+ * written to signal-cli's data dir, not inlined), so anything beyond this is a
+ * malformed/hostile peer; we drop the buffer instead of growing unbounded.
+ */
+const MAX_LINE_BUFFER = 8 * 1024 * 1024;
+
+interface PendingCall {
+  resolve(value: unknown): void;
+  reject(err: Error): void;
+}
+
+export class SignalRpcClient {
+  private readonly stream: RpcStream;
+  private readonly requestTimeoutMs: number;
+  private readonly logger: RpcLogger | undefined;
+  private readonly pending = new Map<string, PendingCall>();
+  private readonly notificationListeners = new Map<string, Set<(params: unknown) => void>>();
+  private readonly closeListeners = new Set<(reason: string) => void>();
+  private buffer = '';
+  private nextId = 1;
+  private closed = false;
+
+  constructor(opts: SignalRpcClientOptions) {
+    this.stream = opts.stream;
+    this.requestTimeoutMs = opts.requestTimeoutMs ?? 30_000;
+    this.logger = opts.logger;
+    this.stream.on('data', (chunk) => this.onData(chunk));
+    this.stream.on('close', () => this.teardown('socket closed'));
+    this.stream.on('error', (err) => this.teardown(`socket error: ${err.message}`));
+  }
+
+  /** Subscribe to a JSON-RPC notification method (e.g. 'receive'). */
+  onNotification(method: string, listener: (params: unknown) => void): () => void {
+    let set = this.notificationListeners.get(method);
+    if (!set) {
+      set = new Set();
+      this.notificationListeners.set(method, set);
+    }
+    set.add(listener);
+    return () => set.delete(listener);
+  }
+
+  /** Fires once when the underlying stream closes/errors (daemon died). */
+  onClose(listener: (reason: string) => void): () => void {
+    this.closeListeners.add(listener);
+    return () => this.closeListeners.delete(listener);
+  }
+
+  request(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    if (this.closed) {
+      return Promise.reject(new Error(`signal-cli rpc closed (cannot call ${method})`));
+    }
+    const id = String(this.nextId++);
+    const payload = JSON.stringify({ jsonrpc: '2.0', id, method, params });
+    return new Promise<unknown>((resolve, reject) => {
+      // Per-call timeout so a wedged daemon never strands the caller.
+      const timer = setTimeout(() => {
+        if (this.pending.delete(id)) {
+          reject(new Error(`signal-cli rpc "${method}" timed out after ${this.requestTimeoutMs}ms`));
+        }
+      }, this.requestTimeoutMs);
+      timer.unref?.();
+      this.pending.set(id, {
+        resolve: (v) => {
+          clearTimeout(timer);
+          resolve(v);
+        },
+        reject: (e) => {
+          clearTimeout(timer);
+          reject(e);
+        },
+      });
+      try {
+        this.stream.write(payload + '\n');
+      } catch (err) {
+        this.pending.delete(id);
+        clearTimeout(timer);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  }
+
+  close(): void {
+    this.teardown('client closed');
+    try {
+      this.stream.end?.();
+      this.stream.destroy?.();
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  private teardown(reason: string): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const [, p] of this.pending) p.reject(new Error(`signal-cli rpc: ${reason}`));
+    this.pending.clear();
+    for (const listener of this.closeListeners) {
+      try {
+        listener(reason);
+      } catch {
+        /* listener errors must not break teardown */
+      }
+    }
+    this.closeListeners.clear();
+  }
+
+  private onData(chunk: Buffer | string): void {
+    this.buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    let nl: number;
+    while ((nl = this.buffer.indexOf('\n')) !== -1) {
+      const line = this.buffer.slice(0, nl);
+      this.buffer = this.buffer.slice(nl + 1);
+      if (line.trim()) this.handleLine(line);
+    }
+    if (this.buffer.length > MAX_LINE_BUFFER) {
+      this.logger?.warn?.('signal rpc: dropped oversized un-delimited line', {
+        bytes: this.buffer.length,
+      });
+      this.buffer = '';
+    }
+  }
+
+  private handleLine(line: string): void {
+    let msg: {
+      id?: string | number;
+      method?: string;
+      params?: unknown;
+      result?: unknown;
+      error?: { code?: number; message?: string };
+    };
+    try {
+      msg = JSON.parse(line) as typeof msg;
+    } catch {
+      this.logger?.warn?.('signal rpc: ignoring unparseable line');
+      return;
+    }
+    // Notification: has a method, no id.
+    if (msg.method !== undefined && msg.id === undefined) {
+      const listeners = this.notificationListeners.get(msg.method);
+      if (!listeners) return;
+      for (const listener of listeners) {
+        try {
+          listener(msg.params);
+        } catch (err) {
+          this.logger?.warn?.('signal rpc: notification listener threw', { err: String(err) });
+        }
+      }
+      return;
+    }
+    // Response: match by id.
+    const id = msg.id !== undefined ? String(msg.id) : null;
+    const p = id ? this.pending.get(id) : undefined;
+    if (!p || !id) return; // late/unknown reply — ignore
+    this.pending.delete(id);
+    if (msg.error) {
+      p.reject(new Error(`signal-cli rpc error ${msg.error.code ?? ''}: ${msg.error.message ?? 'unknown'}`));
+    } else {
+      p.resolve(msg.result);
+    }
+  }
+}

--- a/packages/plugin-channel-signal/src/keys.test.ts
+++ b/packages/plugin-channel-signal/src/keys.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { E164_RE, normalizeSender, parseAllowedSenders } from './keys.js';
+
+describe('E164_RE', () => {
+  it('accepts plausible numbers and rejects junk', () => {
+    expect(E164_RE.test('+15551234567')).toBe(true);
+    expect(E164_RE.test('+4915771234567')).toBe(true);
+    expect(E164_RE.test('15551234567')).toBe(false);
+    expect(E164_RE.test('+0155')).toBe(false);
+    expect(E164_RE.test('+1555123456789012345')).toBe(false);
+    expect(E164_RE.test('')).toBe(false);
+  });
+});
+
+describe('normalizeSender', () => {
+  it('lowercases UUIDs but preserves numbers', () => {
+    expect(normalizeSender(' +15551234567 ')).toBe('+15551234567');
+    expect(normalizeSender('AB0F5EAD-0000-4000-8000-00805F9B34FB')).toBe(
+      'ab0f5ead-0000-4000-8000-00805f9b34fb',
+    );
+  });
+});
+
+describe('parseAllowedSenders', () => {
+  it('parses a JSON array of numbers/uuids', () => {
+    const raw = JSON.stringify(['+15551234567', 'AB0F5EAD-0000-4000-8000-00805F9B34FB']);
+    expect(parseAllowedSenders(raw)).toEqual([
+      '+15551234567',
+      'ab0f5ead-0000-4000-8000-00805f9b34fb',
+    ]);
+  });
+
+  it('fails closed on corrupt values', () => {
+    expect(parseAllowedSenders(null)).toEqual([]);
+    expect(parseAllowedSenders('')).toEqual([]);
+    expect(parseAllowedSenders('not json')).toEqual([]);
+    expect(parseAllowedSenders('"a string"')).toEqual([]);
+    expect(parseAllowedSenders('{"a":1}')).toEqual([]);
+  });
+
+  it('drops entries that are neither E.164 nor uuid', () => {
+    const raw = JSON.stringify(['+15551234567', 'bob', 42, '../../etc/passwd']);
+    expect(parseAllowedSenders(raw)).toEqual(['+15551234567']);
+  });
+});

--- a/packages/plugin-channel-signal/src/keys.ts
+++ b/packages/plugin-channel-signal/src/keys.ts
@@ -1,0 +1,56 @@
+/**
+ * Vault keys + validation shared by the channel, its subcommands, and the
+ * interactive setup wizard. Kept in their own module (the telegram/slack
+ * `keys.ts` pattern) so wizard / pair-flow helpers can import them without
+ * pulling in the plugin's full index.
+ *
+ * Note on secret custody: signal-cli keeps the actual Signal identity keys +
+ * message store in ITS OWN data dir (`$XDG_DATA_HOME/signal-cli/`, i.e.
+ * `~/.local/share/signal-cli/` by default — see {@link signalCliDataDir}).
+ * The moxxy vault only stores the account NUMBER and the sender allow-list;
+ * there is no API token in this channel at all.
+ */
+
+/** Vault key for the linked Signal account number (E.164). */
+export const SIGNAL_ACCOUNT_KEY = 'signal_account';
+/** Env override for the account number — beats the vault (shared precedence). */
+export const SIGNAL_ACCOUNT_ENV = 'MOXXY_SIGNAL_ACCOUNT';
+/**
+ * Vault key for the sender allow-list: a JSON array of E.164 numbers and/or
+ * Signal account UUIDs that may drive the session. The linked account's own
+ * "Note to Self" is allowed implicitly and does not need an entry here.
+ */
+export const SIGNAL_ALLOWED_SENDERS_KEY = 'signal_allowed_senders';
+
+/** E.164 shape: `+` then 7–15 digits, no leading zero. */
+export const E164_RE = /^\+[1-9]\d{6,14}$/;
+
+/** Loose UUID shape (Signal ACIs are UUIDv4; accept any hex-dash UUID). */
+export const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+/** Canonical sender identity for allow-list comparisons: trimmed, UUIDs lowercased. */
+export function normalizeSender(raw: string): string {
+  const trimmed = raw.trim();
+  return UUID_RE.test(trimmed) ? trimmed.toLowerCase() : trimmed;
+}
+
+/**
+ * Parse the stored allow-list. Returns `[]` for a missing OR corrupt value
+ * rather than throwing — a corrupt vault entry must degrade to "nobody extra
+ * is allowed" (fail closed), never crash the channel or silently allow.
+ * Non-string entries and entries that look like neither an E.164 number nor a
+ * UUID are dropped.
+ */
+export function parseAllowedSenders(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((x): x is string => typeof x === 'string')
+      .map(normalizeSender)
+      .filter((x) => E164_RE.test(x) || UUID_RE.test(x));
+  } catch {
+    return [];
+  }
+}

--- a/packages/plugin-channel-signal/src/pair-flow.ts
+++ b/packages/plugin-channel-signal/src/pair-flow.ts
@@ -1,0 +1,142 @@
+import { log, outro, spinner } from '@clack/prompts';
+import QRCode from 'qrcode';
+import type { ChannelSubcommandContext } from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { SignalChannel } from './channel.js';
+
+// Tiny zero-dep ANSI dim helper, so this flow stays inside the plugin.
+const ANSI = process.stdout.isTTY && !process.env.NO_COLOR;
+const dim = (s: string): string => (ANSI ? `\x1b[2m${s}\x1b[22m` : s);
+
+/**
+ * Drive the Signal linked-device pairing end-to-end in a terminal — the SAME
+ * mechanism the desktop Channels panel uses (the channel's `pair: true` link
+ * window), just rendered inline here.
+ *
+ * Steps:
+ *   1. Build a SignalChannel from the subcommand ctx and wire the session's
+ *      permission resolver.
+ *   2. Subscribe to "linked" BEFORE starting so a fast scan can't race us.
+ *   3. Start the channel in pairing mode — it spawns `signal-cli link` and
+ *      publishes the `sgnl://linkdevice…` URI as `channel.requestUrl`.
+ *   4. Render that URI as a scannable QR (+ the raw URI).
+ *   5. On the phone: Signal → Settings → Linked Devices → Link New Device →
+ *      scan; the channel stores the account and boots the daemon.
+ *   6. Keep the channel running until the user Ctrl-Cs.
+ */
+export async function runSignalPairFlow(
+  ctx: ChannelSubcommandContext,
+  overrides: { readonly allowedTools?: ReadonlyArray<string> } = {},
+): Promise<number> {
+  const session = ctx.session;
+  const channel = new SignalChannel({
+    vault: ctx.deps.vault as VaultStore,
+    ...(typeof ctx.deps.options?.['account'] === 'string'
+      ? { account: ctx.deps.options['account'] as string }
+      : {}),
+    ...(overrides.allowedTools ? { allowedTools: overrides.allowedTools } : {}),
+    logger: ctx.deps.logger as never,
+  });
+  session.setPermissionResolver(channel.permissionResolver);
+
+  // Subscribe BEFORE start so the first scan can't fire before us.
+  let linkedResolve: ((account: string) => void) | null = null;
+  const linkedPromise = new Promise<string>((resolve) => {
+    linkedResolve = resolve;
+  });
+  const unsubscribe = channel.onLinked((account) => {
+    linkedResolve?.(account);
+    linkedResolve = null;
+  });
+
+  outro(dim('opening Signal linking window...'));
+
+  const handle = await channel.start({ session, pair: true });
+
+  const stopChannel = async (): Promise<void> => {
+    unsubscribe();
+    try {
+      await handle.stop('pair-flow');
+    } catch {
+      /* ignore */
+    }
+  };
+
+  // Already linked (no window was opened): nothing to scan.
+  if (channel.connected) {
+    log.info(
+      'This machine is already linked to a Signal account. The channel is running; ' +
+        'to link a different account, remove this device from Signal → Linked Devices first, ' +
+        'then run `moxxy channels signal unpair` and pair again.',
+    );
+    log.info('Press Ctrl+C to stop.');
+    installSignalHandlers(stopChannel, session);
+    await handle.running;
+    return 0;
+  }
+
+  const uri = channel.requestUrl;
+  if (!uri) {
+    log.error('Could not obtain a linking URI from signal-cli.');
+    await stopChannel();
+    return 1;
+  }
+
+  await printLinkQr(uri);
+  log.info(
+    'On your phone: Signal → Settings → Linked Devices → Link New Device, then scan the QR. ' +
+      'The QR expires after a few minutes; re-run `moxxy channels signal pair` if it does.',
+  );
+
+  installSignalHandlers(stopChannel, session);
+
+  const spin = spinner();
+  spin.start('Waiting for you to scan in Signal...');
+  const account = await Promise.race([
+    linkedPromise,
+    handle.running.then(() => null as string | null),
+  ]).catch((err: unknown) => {
+    spin.stop('Linking failed.');
+    log.error(err instanceof Error ? err.message : String(err));
+    return null;
+  });
+  if (account == null) {
+    await stopChannel();
+    return 1;
+  }
+  spin.stop(`Linked ✓ — this machine is now a device of ${account}.`);
+  log.info(
+    'Message your own "Note to Self" in Signal to talk to moxxy. The channel is running; press Ctrl+C to stop.',
+  );
+
+  await handle.running;
+  return 0;
+}
+
+function installSignalHandlers(
+  stopChannel: () => Promise<void>,
+  session: ChannelSubcommandContext['session'],
+): void {
+  let stopping = false;
+  const shutdown = async (): Promise<void> => {
+    if (stopping) return;
+    stopping = true;
+    await stopChannel();
+    await session.close('SIGINT').catch(() => undefined);
+    process.exit(0);
+  };
+  process.once('SIGINT', () => void shutdown());
+  process.once('SIGTERM', () => void shutdown());
+}
+
+/** Render the linking URI as a scannable terminal QR + the raw URI. */
+async function printLinkQr(uri: string): Promise<void> {
+  let qr = '';
+  try {
+    qr = await QRCode.toString(uri, { type: 'terminal', small: true });
+  } catch {
+    qr = '';
+  }
+  // CLI surface — intentional stdout.
+  console.log(['', qr, `  link URI: ${uri}`, ''].join('\n'));
+}

--- a/packages/plugin-channel-signal/src/permission.ts
+++ b/packages/plugin-channel-signal/src/permission.ts
@@ -1,0 +1,36 @@
+import { createAuditedAllowListResolver } from '@moxxy/channel-kit';
+import type { PermissionResolver } from '@moxxy/sdk';
+
+export interface SignalPermissionLogger {
+  info?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+/**
+ * Build the Signal channel's autonomous permission resolver.
+ *
+ * Like Slack (and unlike Telegram's inline-keyboard prompts), the Signal
+ * channel runs hands-off: the operator declares trust upfront via
+ * `channels.signal.allowedTools`, and any tool NOT in that list is denied.
+ * The trust check + `'*'` expansion + audit-on-auto-approve wiring is the
+ * shared {@link createAuditedAllowListResolver} from `@moxxy/channel-kit`;
+ * this wrapper binds it to the channel logger so every auto-approved call
+ * leaves a trail. An empty list denies everything (effectively read-only).
+ */
+export function buildSignalPermissionResolver(opts: {
+  allowedTools: ReadonlyArray<string>;
+  allToolNames: ReadonlyArray<string>;
+  logger?: SignalPermissionLogger;
+}): PermissionResolver {
+  return createAuditedAllowListResolver({
+    name: 'signal-allow-list',
+    allowedTools: opts.allowedTools,
+    allToolNames: opts.allToolNames,
+    onAutoApprove: (call, { wildcard }) => {
+      opts.logger?.info?.('signal: auto-approved tool call', {
+        tool: call.name,
+        callId: call.callId,
+        wildcard,
+      });
+    },
+  });
+}

--- a/packages/plugin-channel-signal/src/schema.ts
+++ b/packages/plugin-channel-signal/src/schema.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod';
+
+/**
+ * Zod validation for signal-cli `receive` notification params — every inbound
+ * envelope is validated + size-capped BEFORE any field reaches the session
+ * (channel invariant A8). We only type the fields the channel consumes;
+ * unknown extras pass through untouched so a newer signal-cli doesn't fail
+ * validation, but nothing un-modeled is ever read.
+ */
+
+/** Cap on inbound prompt text we will forward to the model. */
+export const MAX_INBOUND_TEXT_CHARS = 16_000;
+
+/**
+ * Attachment ids become filenames under signal-cli's attachments dir; a strict
+ * charset (no separators, no dots-only names) makes path traversal impossible
+ * before we ever join() it.
+ */
+export const attachmentIdSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/, 'invalid attachment id');
+
+export const attachmentSchema = z
+  .object({
+    id: attachmentIdSchema.optional(),
+    contentType: z.string().max(128).optional(),
+    filename: z.string().max(512).nullable().optional(),
+    size: z.number().int().nonnegative().optional(),
+  })
+  .passthrough();
+
+export type SignalAttachment = z.infer<typeof attachmentSchema>;
+
+const groupInfoSchema = z
+  .object({
+    groupId: z.string().max(256).optional(),
+  })
+  .passthrough();
+
+const dataMessageSchema = z
+  .object({
+    timestamp: z.number().int().optional(),
+    message: z.string().max(MAX_INBOUND_TEXT_CHARS).nullable().optional(),
+    groupInfo: groupInfoSchema.nullable().optional(),
+    attachments: z.array(attachmentSchema).max(16).optional(),
+  })
+  .passthrough();
+
+/**
+ * A sync'd copy of a message the ACCOUNT OWNER sent from another of their
+ * devices (their phone, Signal Desktop, …). "Note to Self" prompts arrive this
+ * way — and so can echoes of our OWN sends, which is why the channel filters
+ * these by sent-timestamp before acting (loop protection).
+ */
+const sentMessageSchema = z
+  .object({
+    timestamp: z.number().int().optional(),
+    message: z.string().max(MAX_INBOUND_TEXT_CHARS).nullable().optional(),
+    destination: z.string().max(128).nullable().optional(),
+    destinationNumber: z.string().max(32).nullable().optional(),
+    destinationUuid: z.string().max(64).nullable().optional(),
+    groupInfo: groupInfoSchema.nullable().optional(),
+    attachments: z.array(attachmentSchema).max(16).optional(),
+  })
+  .passthrough();
+
+const syncMessageSchema = z
+  .object({
+    sentMessage: sentMessageSchema.optional(),
+  })
+  .passthrough();
+
+export const envelopeSchema = z
+  .object({
+    source: z.string().max(128).nullable().optional(),
+    sourceNumber: z.string().max(32).nullable().optional(),
+    sourceUuid: z.string().max(64).nullable().optional(),
+    sourceName: z.string().max(256).nullable().optional(),
+    sourceDevice: z.number().int().optional(),
+    timestamp: z.number().int().optional(),
+    dataMessage: dataMessageSchema.nullable().optional(),
+    syncMessage: syncMessageSchema.nullable().optional(),
+    // typingMessage / receiptMessage / receiptMessage etc. pass through and are
+    // simply not consumed.
+  })
+  .passthrough();
+
+export const receiveParamsSchema = z
+  .object({
+    account: z.string().max(64).optional(),
+    envelope: envelopeSchema,
+  })
+  .passthrough();
+
+export type SignalEnvelope = z.infer<typeof envelopeSchema>;
+export type SignalReceiveParams = z.infer<typeof receiveParamsSchema>;

--- a/packages/plugin-channel-signal/src/setup-wizard.ts
+++ b/packages/plugin-channel-signal/src/setup-wizard.ts
@@ -1,0 +1,98 @@
+import { cancel, intro, isCancel, log, note, outro, text } from '@clack/prompts';
+import type { ChannelSubcommandContext } from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { E164_RE, SIGNAL_ACCOUNT_KEY } from './keys.js';
+import { SIGNAL_CLI_INSTALL_HINT, findSignalCliOnPath, listSignalAccounts } from './sidecar.js';
+import { runSignalPairFlow } from './pair-flow.js';
+
+const ANSI = process.stdout.isTTY && !process.env.NO_COLOR;
+const bold = (s: string): string => (ANSI ? `\x1b[1m${s}\x1b[22m` : s);
+const dim = (s: string): string => (ANSI ? `\x1b[2m${s}\x1b[22m` : s);
+
+/**
+ * Interactive Signal setup wizard (the channel's `interactiveCommand`).
+ *
+ * Walks the operator through:
+ *   1. verify the `signal-cli` binary is installed (install hint when missing),
+ *   2. store the account number (E.164) in the vault — no API token exists for
+ *      Signal; identity comes from device linking,
+ *   3. choose the autonomous tool allow-list,
+ *   4. hand off to the pair flow (QR link) when the account isn't linked yet,
+ *      or start the channel directly when it is.
+ */
+export async function runSignalWizard(ctx: ChannelSubcommandContext): Promise<number> {
+  const vault = ctx.deps.vault as VaultStore;
+  intro(bold('moxxy signal setup'));
+
+  const binary = findSignalCliOnPath();
+  if (!binary) {
+    log.error(SIGNAL_CLI_INSTALL_HINT);
+    return 1;
+  }
+  log.success(`Found signal-cli: ${binary}`);
+
+  note(
+    'moxxy joins your Signal account as a LINKED DEVICE (like Signal Desktop).\n' +
+      'It will see the messages your account receives, so it runs on its own\n' +
+      'dedicated, isolated runner. After linking, message your own "Note to Self"\n' +
+      'to talk to moxxy; other senders must be allow-listed explicitly.',
+    'how the Signal channel works',
+  );
+
+  const existing = await vault.get(SIGNAL_ACCOUNT_KEY);
+  const account = await text({
+    message: 'Your Signal account number (E.164)',
+    placeholder: '+15551234567',
+    ...(existing ? { initialValue: existing } : {}),
+    validate: (v) => {
+      if (!v || !v.trim()) return 'required';
+      if (!E164_RE.test(v.trim())) return 'expected E.164, e.g. +15551234567';
+      return undefined;
+    },
+  });
+  if (isCancel(account)) {
+    cancel('cancelled.');
+    return 0;
+  }
+  const accountNumber = String(account).trim();
+  await vault.set(SIGNAL_ACCOUNT_KEY, accountNumber, ['signal']);
+  log.success(`Stored account ${accountNumber} in the vault.`);
+
+  const allow = await text({
+    message: 'Autonomous tool allow-list (comma-separated; "*" = all, blank = read-only)',
+    placeholder: 'Read, Grep, Glob',
+  });
+  if (isCancel(allow)) {
+    cancel('cancelled.');
+    return 0;
+  }
+  const allowedTools = String(allow)
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  // Linked already? (one-shot listAccounts spawn; on probe failure fall through
+  // to the pair flow, which handles the already-linked case gracefully too).
+  let linked = false;
+  try {
+    linked = (await listSignalAccounts({ binary })).includes(accountNumber);
+  } catch {
+    linked = false;
+  }
+
+  if (linked) {
+    log.info('This machine is already linked. Starting the channel…');
+    outro(dim('handing off to the channel…'));
+    return ctx.startChannel({ allowedTools });
+  }
+
+  note(
+    'Next: link this machine to your Signal account. A QR will appear —\n' +
+      'on your phone open Signal → Settings → Linked Devices → Link New Device\n' +
+      'and scan it. signal-cli keeps the linked-device keys in\n' +
+      '~/.local/share/signal-cli/ (moxxy stores only the number + allow-list).',
+    'link your phone',
+  );
+  outro(dim('opening the linking QR…'));
+  return runSignalPairFlow(ctx, { allowedTools });
+}

--- a/packages/plugin-channel-signal/src/sidecar.test.ts
+++ b/packages/plugin-channel-signal/src/sidecar.test.ts
@@ -1,0 +1,276 @@
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { RpcStream } from './jsonrpc.js';
+import {
+  SignalSidecar,
+  findSignalCliOnPath,
+  listSignalAccounts,
+  signalCliAttachmentsDir,
+  signalCliDataDir,
+  startLinkProcess,
+  type SpawnedProcess,
+} from './sidecar.js';
+
+class FakeChild extends EventEmitter {
+  pid = 4242;
+  kills: string[] = [];
+  stderr = new EventEmitter();
+  stdout = new EventEmitter();
+  /** Which signal (if any) makes this child actually exit. */
+  exitOn: Set<string>;
+  constructor(exitOn: string[] = ['SIGTERM', 'SIGKILL']) {
+    super();
+    this.exitOn = new Set(exitOn);
+  }
+  kill(signal: NodeJS.Signals = 'SIGTERM'): boolean {
+    this.kills.push(signal);
+    if (this.exitOn.has(signal)) {
+      // Exit asynchronously, like a real process.
+      setImmediate(() => this.emit('exit', null));
+    }
+    return true;
+  }
+}
+
+class HealthyStream extends EventEmitter implements RpcStream {
+  written: string[] = [];
+  write(data: string): boolean {
+    this.written.push(data);
+    // Auto-answer any request (the health check's `version`).
+    const req = JSON.parse(data) as { id: string; method: string };
+    setImmediate(() => {
+      this.emit('data', `{"jsonrpc":"2.0","id":"${req.id}","result":{"version":"0.13.18"}}\n`);
+    });
+    return true;
+  }
+  end(): void {}
+  destroy(): void {}
+}
+
+describe('SignalSidecar lifecycle', () => {
+  it('spawns the daemon with account + unix socket args and health-checks it', async () => {
+    const child = new FakeChild();
+    let spawned: { command: string; args: ReadonlyArray<string> } | null = null;
+    const sidecar = new SignalSidecar({
+      account: '+15551234567',
+      binary: '/opt/bin/signal-cli',
+      spawnFn: (command, args) => {
+        spawned = { command, args };
+        return child as unknown as SpawnedProcess;
+      },
+      connectFn: async () => new HealthyStream(),
+    });
+    const rpc = await sidecar.start();
+    expect(spawned).not.toBeNull();
+    expect(spawned!.command).toBe('/opt/bin/signal-cli');
+    expect(spawned!.args).toEqual([
+      '-a',
+      '+15551234567',
+      'daemon',
+      '--socket',
+      sidecar.socketPath,
+      '--receive-mode',
+      'on-start',
+    ]);
+    expect(rpc).toBeTruthy();
+    await sidecar.stop();
+    expect(child.kills).toEqual(['SIGTERM']);
+  });
+
+  it('retries the socket until the daemon is up', async () => {
+    const child = new FakeChild();
+    let attempts = 0;
+    const sidecar = new SignalSidecar({
+      account: '+1',
+      spawnFn: () => child as unknown as SpawnedProcess,
+      connectFn: async () => {
+        attempts += 1;
+        if (attempts < 3) throw new Error('ECONNREFUSED');
+        return new HealthyStream();
+      },
+      bootTimeoutMs: 5_000,
+    });
+    await sidecar.start();
+    expect(attempts).toBe(3);
+    await sidecar.stop();
+  });
+
+  it('rejects with the stderr tail when the daemon exits during boot', async () => {
+    const child = new FakeChild();
+    const sidecar = new SignalSidecar({
+      account: '+1',
+      spawnFn: () => {
+        setImmediate(() => {
+          child.stderr.emit('data', Buffer.from('User +1 is not registered.\n'));
+          child.emit('exit', 1);
+        });
+        return child as unknown as SpawnedProcess;
+      },
+      connectFn: async () => {
+        throw new Error('ECONNREFUSED');
+      },
+      bootTimeoutMs: 5_000,
+    });
+    await expect(sidecar.start()).rejects.toThrow(/not registered/);
+  });
+
+  it('rejects when the socket never opens within the boot timeout', async () => {
+    const child = new FakeChild();
+    const sidecar = new SignalSidecar({
+      account: '+1',
+      spawnFn: () => child as unknown as SpawnedProcess,
+      connectFn: async () => {
+        throw new Error('ECONNREFUSED');
+      },
+      bootTimeoutMs: 600,
+      killGraceMs: 50,
+    });
+    await expect(sidecar.start()).rejects.toThrow(/did not open its socket within 600ms/);
+    // The child was reaped, not orphaned.
+    expect(child.kills).toContain('SIGTERM');
+  });
+
+  it('escalates SIGTERM → SIGKILL when the daemon ignores the grace window', async () => {
+    const child = new FakeChild(['SIGKILL']); // ignores SIGTERM
+    const sidecar = new SignalSidecar({
+      account: '+1',
+      spawnFn: () => child as unknown as SpawnedProcess,
+      connectFn: async () => new HealthyStream(),
+      killGraceMs: 60,
+    });
+    await sidecar.start();
+    await sidecar.stop();
+    expect(child.kills).toEqual(['SIGTERM', 'SIGKILL']);
+  });
+
+  it('notifies onExit when the daemon dies unexpectedly', async () => {
+    const child = new FakeChild();
+    const sidecar = new SignalSidecar({
+      account: '+1',
+      spawnFn: () => child as unknown as SpawnedProcess,
+      connectFn: async () => new HealthyStream(),
+    });
+    await sidecar.start();
+    const codes: Array<number | null> = [];
+    sidecar.onExit((code) => codes.push(code));
+    child.emit('exit', 137);
+    expect(codes).toEqual([137]);
+    await sidecar.stop();
+  });
+});
+
+describe('startLinkProcess', () => {
+  it('resolves the sgnl:// URI from stdout and the account on success', async () => {
+    const child = new FakeChild();
+    const link = startLinkProcess({
+      deviceName: 'moxxy',
+      spawnFn: (command, args) => {
+        expect(command).toBe('signal-cli');
+        expect(args).toEqual(['link', '-n', 'moxxy']);
+        return child as unknown as SpawnedProcess;
+      },
+    });
+    child.stdout.emit('data', Buffer.from('sgnl://linkdevice?uuid=abc&pub_key=def\n'));
+    await expect(link.uri).resolves.toBe('sgnl://linkdevice?uuid=abc&pub_key=def');
+    child.stdout.emit('data', Buffer.from('Associated with: +15551234567 (device id: 2)\n'));
+    child.emit('exit', 0);
+    await expect(link.completed).resolves.toEqual({ account: '+15551234567' });
+  });
+
+  it('understands the legacy tsdevice:/ URI form', async () => {
+    const child = new FakeChild();
+    const link = startLinkProcess({
+      deviceName: 'moxxy',
+      spawnFn: () => child as unknown as SpawnedProcess,
+    });
+    child.stdout.emit('data', Buffer.from('tsdevice:/?uuid=abc&pub_key=def\n'));
+    await expect(link.uri).resolves.toBe('tsdevice:/?uuid=abc&pub_key=def');
+    link.cancel();
+    expect(child.kills).toEqual(['SIGTERM']);
+    child.emit('exit', 1);
+    await expect(link.completed).rejects.toThrow(/exited with code 1/);
+  });
+
+  it('rejects both promises when linking fails before a URI appears', async () => {
+    const child = new FakeChild();
+    const link = startLinkProcess({
+      deviceName: 'moxxy',
+      spawnFn: () => child as unknown as SpawnedProcess,
+    });
+    child.emit('exit', 2);
+    await expect(link.uri).rejects.toThrow(/code 2/);
+    await expect(link.completed).rejects.toThrow(/code 2/);
+  });
+});
+
+describe('listSignalAccounts', () => {
+  it('parses --output=json account listings', async () => {
+    const child = new FakeChild();
+    const p = listSignalAccounts({
+      spawnFn: (command, args) => {
+        expect(args).toEqual(['--output=json', 'listAccounts']);
+        void command;
+        setImmediate(() => {
+          child.stdout.emit('data', Buffer.from('[{"number":"+15551234567"},{"number":"+491771234567"}]\n'));
+          child.emit('exit', 0);
+        });
+        return child as unknown as SpawnedProcess;
+      },
+    });
+    await expect(p).resolves.toEqual(['+15551234567', '+491771234567']);
+  });
+
+  it('falls back to scraping numbers from plain-text output', async () => {
+    const child = new FakeChild();
+    const p = listSignalAccounts({
+      spawnFn: () => {
+        setImmediate(() => {
+          child.stdout.emit('data', Buffer.from('Number: +15551234567\n'));
+          child.emit('exit', 0);
+        });
+        return child as unknown as SpawnedProcess;
+      },
+    });
+    await expect(p).resolves.toEqual(['+15551234567']);
+  });
+});
+
+describe('findSignalCliOnPath', () => {
+  it('returns null (never throws) when the binary is absent', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mox-sig-path-'));
+    try {
+      expect(findSignalCliOnPath({ PATH: tmp })).toBeNull();
+      expect(findSignalCliOnPath({ PATH: undefined as unknown as string })).toBeNull();
+      expect(findSignalCliOnPath({})).toBeNull();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('finds an executable signal-cli on PATH', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mox-sig-path-'));
+    try {
+      const bin = path.join(tmp, 'signal-cli');
+      fs.writeFileSync(bin, '#!/bin/sh\n', { mode: 0o755 });
+      expect(findSignalCliOnPath({ PATH: `/nonexistent${path.delimiter}${tmp}` })).toBe(bin);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('signal-cli data dirs', () => {
+  it('honors XDG_DATA_HOME', () => {
+    expect(signalCliDataDir({ XDG_DATA_HOME: '/x/data' })).toBe(path.join('/x/data', 'signal-cli'));
+    expect(signalCliAttachmentsDir({ XDG_DATA_HOME: '/x/data' })).toBe(
+      path.join('/x/data', 'signal-cli', 'attachments'),
+    );
+  });
+
+  it('defaults under the home dir', () => {
+    expect(signalCliDataDir({})).toBe(path.join(os.homedir(), '.local', 'share', 'signal-cli'));
+  });
+});

--- a/packages/plugin-channel-signal/src/sidecar.ts
+++ b/packages/plugin-channel-signal/src/sidecar.ts
@@ -1,0 +1,511 @@
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { sleepWithAbort } from '@moxxy/sdk';
+import { SignalRpcClient, type RpcStream } from './jsonrpc.js';
+
+/**
+ * signal-cli sidecar lifecycle — the plugin owns the external `signal-cli`
+ * process the way `@moxxy/plugin-browser` owns its Playwright sidecar:
+ * spawn on channel `start()`, health-check before use, SIGTERM→SIGKILL grace
+ * on stop (via the sdk's `sleepWithAbort`, the runner-supervisor pattern).
+ *
+ * Transport: `signal-cli -a <account> daemon --socket <path>` — JSON-RPC over
+ * a UNIX socket. Chosen over `--tcp`/`--http` because a filesystem socket is
+ * never remotely reachable and needs no port/auth story; the socket lives in a
+ * fresh per-process temp path so two channels can't collide.
+ *
+ * signal-cli keeps the actual Signal protocol store (identity keys, sessions,
+ * message queue) in ITS OWN data dir — `$XDG_DATA_HOME/signal-cli/`
+ * (`~/.local/share/signal-cli/` by default). moxxy never touches those files;
+ * attachments land in `<dataDir>/attachments/<id>`.
+ */
+
+export interface SidecarLogger {
+  info?(msg: string, meta?: Record<string, unknown>): void;
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+/** The slice of `child_process.ChildProcess` the sidecar manager needs. */
+export interface SpawnedProcess {
+  readonly pid?: number | undefined;
+  kill(signal?: NodeJS.Signals): boolean;
+  once(event: 'exit', listener: (code: number | null) => void): unknown;
+  once(event: 'error', listener: (err: Error) => void): unknown;
+  readonly stderr?: { on(event: 'data', listener: (chunk: Buffer | string) => void): unknown } | null;
+  readonly stdout?: { on(event: 'data', listener: (chunk: Buffer | string) => void): unknown } | null;
+}
+
+export type SpawnFn = (command: string, args: ReadonlyArray<string>) => SpawnedProcess;
+
+export type ConnectFn = (socketPath: string) => Promise<RpcStream>;
+
+const defaultSpawn: SpawnFn = (command, args) =>
+  spawn(command, [...args], { stdio: ['ignore', 'pipe', 'pipe'] });
+
+const defaultConnect: ConnectFn = (socketPath) =>
+  new Promise<RpcStream>((resolve, reject) => {
+    const socket = net.createConnection(socketPath);
+    socket.once('connect', () => resolve(socket));
+    socket.once('error', (err) => reject(err));
+  });
+
+/** `$XDG_DATA_HOME/signal-cli` (defaults to `~/.local/share/signal-cli`). */
+export function signalCliDataDir(env: NodeJS.ProcessEnv = process.env): string {
+  const xdg = env['XDG_DATA_HOME']?.trim();
+  const base = xdg && xdg.length > 0 ? xdg : path.join(os.homedir(), '.local', 'share');
+  return path.join(base, 'signal-cli');
+}
+
+/** Where the daemon writes received attachments (voice notes live here). */
+export function signalCliAttachmentsDir(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(signalCliDataDir(env), 'attachments');
+}
+
+/**
+ * Cheap PATH probe for the `signal-cli` binary — a directory scan with an
+ * exec-bit check, NO process spawn (signal-cli is a JVM app; spawning it takes
+ * seconds and `isAvailable` runs on every `moxxy channels list` / `doctor`).
+ * Returns the resolved path or null. Never throws: a missing/odd PATH must
+ * not crash discovery.
+ */
+export function findSignalCliOnPath(env: NodeJS.ProcessEnv = process.env): string | null {
+  try {
+    const raw = env['PATH'] ?? '';
+    const names = process.platform === 'win32' ? ['signal-cli.bat', 'signal-cli.cmd', 'signal-cli.exe', 'signal-cli'] : ['signal-cli'];
+    for (const dir of raw.split(path.delimiter)) {
+      if (!dir) continue;
+      for (const name of names) {
+        const candidate = path.join(dir, name);
+        try {
+          fs.accessSync(candidate, fs.constants.X_OK);
+          if (fs.statSync(candidate).isFile()) return candidate;
+        } catch {
+          /* not here — keep scanning */
+        }
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** One-line install guidance surfaced when the binary is missing. */
+export const SIGNAL_CLI_INSTALL_HINT =
+  'signal-cli not found on PATH. Install it: `brew install signal-cli` (macOS), ' +
+  'or see https://github.com/AsamK/signal-cli/wiki/Quickstart for Linux/Windows packages.';
+
+export interface SignalSidecarOptions {
+  /** E.164 account the daemon serves (`-a <account>`). */
+  readonly account: string;
+  /** Binary path/name. Default `signal-cli` (resolved by the OS from PATH). */
+  readonly binary?: string;
+  /** Socket path override (tests). Default: fresh path under the OS tmpdir. */
+  readonly socketPath?: string;
+  /** How long to wait for the daemon socket + health check. Default 45s —
+   *  signal-cli is a JVM app and cold-starts slowly. */
+  readonly bootTimeoutMs?: number;
+  /** SIGTERM grace before SIGKILL. Default 5s. */
+  readonly killGraceMs?: number;
+  readonly logger?: SidecarLogger;
+  readonly spawnFn?: SpawnFn;
+  readonly connectFn?: ConnectFn;
+}
+
+/** Poll cadence while waiting for the daemon socket to accept connections. */
+const CONNECT_POLL_MS = 250;
+
+export class SignalSidecar {
+  private readonly opts: SignalSidecarOptions;
+  private child: SpawnedProcess | null = null;
+  private exited = false;
+  private exitCode: number | null = null;
+  private client: SignalRpcClient | null = null;
+  private readonly recentStderr: string[] = [];
+  private readonly exitListeners = new Set<(code: number | null) => void>();
+  readonly socketPath: string;
+
+  constructor(opts: SignalSidecarOptions) {
+    this.opts = opts;
+    this.socketPath =
+      opts.socketPath ?? path.join(os.tmpdir(), `moxxy-signal-${process.pid}-${Date.now().toString(36)}.sock`);
+  }
+
+  /** Fires when the daemon exits (clean stop AND crash). */
+  onExit(listener: (code: number | null) => void): () => void {
+    this.exitListeners.add(listener);
+    return () => this.exitListeners.delete(listener);
+  }
+
+  get rpc(): SignalRpcClient | null {
+    return this.client;
+  }
+
+  /**
+   * Spawn the daemon and wait until it is actually serving: the socket accepts
+   * a connection AND a `version` JSON-RPC round-trips. Rejects (and reaps the
+   * child) when the child dies early or the boot deadline passes, carrying the
+   * daemon's stderr tail so the CAUSE ("User +… is not registered") surfaces
+   * instead of a bare timeout.
+   */
+  async start(): Promise<SignalRpcClient> {
+    if (this.client) return this.client;
+    const binary = this.opts.binary ?? 'signal-cli';
+    const spawnFn = this.opts.spawnFn ?? defaultSpawn;
+    const connectFn = this.opts.connectFn ?? defaultConnect;
+    const bootTimeoutMs = this.opts.bootTimeoutMs ?? 45_000;
+
+    // A stale socket file from a crashed previous run would make the daemon
+    // fail to bind; the path is per-process+time so this is belt-and-braces.
+    try {
+      fs.rmSync(this.socketPath, { force: true });
+    } catch {
+      /* best-effort */
+    }
+
+    const args = ['-a', this.opts.account, 'daemon', '--socket', this.socketPath, '--receive-mode', 'on-start'];
+    this.opts.logger?.info?.('signal: spawning signal-cli daemon', {
+      binary,
+      socket: this.socketPath,
+    });
+    let child: SpawnedProcess;
+    try {
+      child = spawnFn(binary, args);
+    } catch (err) {
+      throw new Error(`failed to spawn ${binary}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    this.child = child;
+    this.exited = false;
+    this.watchStderr(child);
+    child.once('error', (err) => {
+      // spawn-level failure (ENOENT etc.) — recorded like an exit so the boot
+      // loop below stops waiting on a process that never started.
+      this.recentStderr.push(`spawn error: ${err.message}`);
+      this.markExited(null);
+    });
+    child.once('exit', (code) => this.markExited(code));
+
+    const deadline = Date.now() + bootTimeoutMs;
+    let stream: RpcStream | null = null;
+    while (Date.now() < deadline) {
+      if (this.exited) {
+        throw new Error(this.describeEarlyExit());
+      }
+      try {
+        stream = await connectFn(this.socketPath);
+        break;
+      } catch {
+        await sleepWithAbort(CONNECT_POLL_MS);
+      }
+    }
+    if (!stream) {
+      await this.stop();
+      throw new Error(
+        `signal-cli daemon did not open its socket within ${bootTimeoutMs}ms` + this.stderrTailSuffix(),
+      );
+    }
+
+    const client = new SignalRpcClient({
+      stream,
+      ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+    });
+    // Health check: a cheap RPC proves the JSON-RPC dispatcher is live (the
+    // socket can accept before the daemon is ready to serve).
+    try {
+      await client.request('version', {});
+    } catch (err) {
+      client.close();
+      await this.stop();
+      throw new Error(
+        `signal-cli daemon failed its health check: ${err instanceof Error ? err.message : String(err)}` +
+          this.stderrTailSuffix(),
+      );
+    }
+    this.client = client;
+    this.opts.logger?.info?.('signal: daemon healthy', { pid: child.pid ?? null });
+    return client;
+  }
+
+  /**
+   * Graceful shutdown: close the RPC stream, SIGTERM, wait `killGraceMs` for a
+   * clean exit (aborting the wait the moment `exit` fires — the sdk's
+   * `sleepWithAbort` pattern from the runner supervisor), then SIGKILL a
+   * holdout so a wedged JVM can never outlive the channel as an orphan.
+   */
+  async stop(): Promise<void> {
+    const child = this.child;
+    this.client?.close();
+    this.client = null;
+    if (!child || this.exited) {
+      this.child = null;
+      this.removeSocketFile();
+      return;
+    }
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      /* already gone */
+    }
+    const graceMs = this.opts.killGraceMs ?? 5_000;
+    if (!(await this.waitForExit(child, graceMs))) {
+      this.opts.logger?.warn?.('signal: daemon ignored SIGTERM; escalating to SIGKILL');
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* already gone */
+      }
+      await this.waitForExit(child, 2_000);
+    }
+    this.child = null;
+    this.removeSocketFile();
+  }
+
+  /** Resolves true when the child exits within `ms`, false on timeout. */
+  private waitForExit(child: SpawnedProcess, ms: number): Promise<boolean> {
+    if (this.exited) return Promise.resolve(true);
+    return new Promise<boolean>((resolve) => {
+      const ac = new AbortController();
+      child.once('exit', () => ac.abort());
+      if (this.exited) {
+        resolve(true);
+        return;
+      }
+      sleepWithAbort(ms, ac.signal).then(
+        () => resolve(false), // timer ran out — still alive
+        () => resolve(true), // aborted — the child exited
+      );
+    });
+  }
+
+  private markExited(code: number | null): void {
+    if (this.exited) return;
+    this.exited = true;
+    this.exitCode = code;
+    this.client?.close();
+    this.client = null;
+    for (const listener of this.exitListeners) {
+      try {
+        listener(code);
+      } catch {
+        /* listener errors must not break teardown */
+      }
+    }
+  }
+
+  private watchStderr(child: SpawnedProcess): void {
+    let buf = '';
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      buf += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      let nl: number;
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (line) {
+          this.recentStderr.push(line);
+          if (this.recentStderr.length > 24) this.recentStderr.shift();
+        }
+      }
+      if (buf.length > 64 * 1024) buf = buf.slice(-64 * 1024);
+    });
+  }
+
+  private describeEarlyExit(): string {
+    return (
+      `signal-cli daemon exited during startup (code=${this.exitCode ?? 'null'})` + this.stderrTailSuffix()
+    );
+  }
+
+  private stderrTailSuffix(): string {
+    const tail = this.recentStderr.slice(-6).join('\n').trim();
+    return tail ? `:\n${tail}` : '';
+  }
+
+  private removeSocketFile(): void {
+    try {
+      fs.rmSync(this.socketPath, { force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// One-shot signal-cli invocations (link flow, account listing)
+// ---------------------------------------------------------------------------
+
+export interface LinkProcessHandle {
+  /** Resolves with the `sgnl://linkdevice…` URI to render as a QR. */
+  readonly uri: Promise<string>;
+  /** Resolves when the phone completed the link (process exited 0). Carries the
+   *  linked account number when signal-cli printed it. Rejects on failure. */
+  readonly completed: Promise<{ account: string | null }>;
+  cancel(): void;
+}
+
+/** Matches both the current `sgnl://linkdevice?...` URI and the legacy `tsdevice:/?...` form. */
+const LINK_URI_RE = /(sgnl:\/\/linkdevice\S+|tsdevice:\/?\?\S+)/;
+/** signal-cli prints `Associated with: +49… (device id: N)` on success. */
+const ASSOCIATED_RE = /Associated with:\s*(\+\d{7,15})/;
+
+/**
+ * Run `signal-cli link -n <deviceName>`: it prints the linking URI, then blocks
+ * until the phone scans it (or the QR expires, at which point it exits
+ * non-zero). Separate from the daemon — linking happens BEFORE an account
+ * exists locally, so the daemon (which requires one) can't do it.
+ */
+export function startLinkProcess(opts: {
+  readonly deviceName: string;
+  readonly binary?: string;
+  readonly spawnFn?: SpawnFn;
+  readonly logger?: SidecarLogger;
+}): LinkProcessHandle {
+  const spawnFn = opts.spawnFn ?? defaultSpawn;
+  const binary = opts.binary ?? 'signal-cli';
+  let child: SpawnedProcess;
+  let output = '';
+
+  let resolveUri: (uri: string) => void;
+  let rejectUri: (err: Error) => void;
+  const uri = new Promise<string>((resolve, reject) => {
+    resolveUri = resolve;
+    rejectUri = reject;
+  });
+  let resolveCompleted: (r: { account: string | null }) => void;
+  let rejectCompleted: (err: Error) => void;
+  const completed = new Promise<{ account: string | null }>((resolve, reject) => {
+    resolveCompleted = resolve;
+    rejectCompleted = reject;
+  });
+  // The two promises settle independently of consumption order (a caller may
+  // only await `uri` and cancel later) — pre-attach no-op catches so an
+  // unobserved rejection is never an unhandledRejection.
+  uri.catch(() => undefined);
+  completed.catch(() => undefined);
+
+  try {
+    child = spawnFn(binary, ['link', '-n', opts.deviceName]);
+  } catch (err) {
+    const e = new Error(`failed to spawn ${binary} link: ${err instanceof Error ? err.message : String(err)}`);
+    rejectUri!(e);
+    rejectCompleted!(e);
+    return { uri, completed, cancel: () => undefined };
+  }
+
+  let uriSettled = false;
+  const scan = (chunk: Buffer | string): void => {
+    output += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    if (output.length > 256 * 1024) output = output.slice(-256 * 1024);
+    if (!uriSettled) {
+      const m = LINK_URI_RE.exec(output);
+      if (m?.[1]) {
+        uriSettled = true;
+        resolveUri!(m[1]);
+      }
+    }
+  };
+  child.stdout?.on('data', scan);
+  child.stderr?.on('data', scan);
+  child.once('error', (err) => {
+    const e = new Error(`signal-cli link failed to start: ${err.message}`);
+    if (!uriSettled) {
+      uriSettled = true;
+      rejectUri!(e);
+    }
+    rejectCompleted!(e);
+  });
+  child.once('exit', (code) => {
+    if (code === 0) {
+      const account = ASSOCIATED_RE.exec(output)?.[1] ?? null;
+      resolveCompleted!({ account });
+    } else {
+      const tail = output.split('\n').slice(-4).join('\n').trim();
+      const e = new Error(
+        `signal-cli link exited with code ${code ?? 'null'} (QR expired or linking rejected)` +
+          (tail ? `:\n${tail}` : ''),
+      );
+      if (!uriSettled) {
+        uriSettled = true;
+        rejectUri!(e);
+      }
+      rejectCompleted!(e);
+    }
+  });
+
+  return {
+    uri,
+    completed,
+    cancel: () => {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        /* already gone */
+      }
+    },
+  };
+}
+
+/**
+ * List the accounts registered in the local signal-cli store (a one-shot
+ * `signal-cli --output=json listAccounts` spawn). Used at channel start to
+ * decide "linked already?" — NOT in `isAvailable` (JVM spawns are too slow for
+ * a discovery probe). Parses JSON output and falls back to scraping `+<digits>`
+ * so an older plain-text signal-cli still works.
+ */
+export async function listSignalAccounts(opts: {
+  readonly binary?: string;
+  readonly spawnFn?: SpawnFn;
+  readonly timeoutMs?: number;
+} = {}): Promise<string[]> {
+  const spawnFn = opts.spawnFn ?? defaultSpawn;
+  const binary = opts.binary ?? 'signal-cli';
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+  let child: SpawnedProcess;
+  try {
+    child = spawnFn(binary, ['--output=json', 'listAccounts']);
+  } catch (err) {
+    throw new Error(`failed to spawn ${binary}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  let out = '';
+  child.stdout?.on('data', (chunk: Buffer | string) => {
+    out += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    if (out.length > 1024 * 1024) out = out.slice(-1024 * 1024);
+  });
+  const exited = await new Promise<boolean>((resolve) => {
+    const ac = new AbortController();
+    child.once('exit', () => ac.abort());
+    child.once('error', () => ac.abort());
+    sleepWithAbort(timeoutMs, ac.signal).then(
+      () => resolve(false),
+      () => resolve(true),
+    );
+  });
+  if (!exited) {
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      /* ignore */
+    }
+    throw new Error(`signal-cli listAccounts timed out after ${timeoutMs}ms`);
+  }
+  const accounts = new Set<string>();
+  for (const line of out.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      const collect = (entry: unknown): void => {
+        const number = (entry as { number?: unknown })?.number;
+        if (typeof number === 'string' && number.startsWith('+')) accounts.add(number);
+      };
+      if (Array.isArray(parsed)) parsed.forEach(collect);
+      else collect(parsed);
+    } catch {
+      const m = /(\+\d{7,15})/.exec(trimmed);
+      if (m?.[1]) accounts.add(m[1]);
+    }
+  }
+  return [...accounts];
+}

--- a/packages/plugin-channel-signal/src/subcommands.test.ts
+++ b/packages/plugin-channel-signal/src/subcommands.test.ts
@@ -1,0 +1,206 @@
+import { promises as fs } from 'node:fs';
+import * as fsSync from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VaultStore, createStaticKeySource, deriveKey, generateSalt } from '@moxxy/plugin-vault';
+import type { ChannelDef } from '@moxxy/sdk';
+import { buildSignalPlugin } from './index.js';
+import { SIGNAL_ACCOUNT_KEY, SIGNAL_ALLOWED_SENDERS_KEY } from './keys.js';
+
+let tmp: string;
+let vault: VaultStore;
+let signalDef: ChannelDef;
+let writeOut: string[];
+let writeErr: string[];
+let origStdoutWrite: typeof process.stdout.write;
+let origStderrWrite: typeof process.stderr.write;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-sig-sub-'));
+  vault = new VaultStore({
+    filePath: path.join(tmp, 'vault.json'),
+    keySource: createStaticKeySource(deriveKey('test', generateSalt())),
+  });
+  const plugin = buildSignalPlugin({ vault });
+  signalDef = plugin.channels![0]!;
+  writeOut = [];
+  writeErr = [];
+  origStdoutWrite = process.stdout.write.bind(process.stdout);
+  origStderrWrite = process.stderr.write.bind(process.stderr);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    writeOut.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    writeErr.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+    return true;
+  }) as typeof process.stderr.write;
+  // Tests must never find a REAL signal-cli (CI may or may not have one).
+  vi.stubEnv('PATH', tmp);
+  vi.stubEnv('MOXXY_SIGNAL_ACCOUNT', '');
+});
+
+afterEach(async () => {
+  process.stdout.write = origStdoutWrite;
+  process.stderr.write = origStderrWrite;
+  vi.unstubAllEnvs();
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+function ctx(
+  overrides: {
+    startChannel?: () => Promise<number>;
+    session?: { setPermissionResolver: (r: unknown) => void };
+  } = {},
+) {
+  return {
+    deps: { cwd: tmp, vault, logger: undefined, options: {} },
+    args: { positional: [], flags: {} },
+    startChannel: overrides.startChannel ?? (async () => 0),
+    session: overrides.session ?? { setPermissionResolver: () => {} },
+  } as never;
+}
+
+describe('signal ChannelDef shape', () => {
+  it('declares a dedicated runner with the signal session source', () => {
+    expect(signalDef.name).toBe('signal');
+    expect(signalDef.dedicatedRunner).toBe(true);
+    expect(signalDef.sessionSource).toBe('signal');
+    expect(signalDef.interactiveCommand).toBe('setup');
+    expect(Object.keys(signalDef.subcommands!)).toEqual(
+      expect.arrayContaining(['setup', 'pair', 'status', 'unpair']),
+    );
+    expect(signalDef.config?.fields.map((f) => f.vaultKey)).toEqual([SIGNAL_ACCOUNT_KEY]);
+    expect(signalDef.config?.connect?.kind).toBe('qr');
+  });
+});
+
+describe('isAvailable', () => {
+  it('returns an install hint (never throws) when signal-cli is missing', async () => {
+    const availability = await signalDef.isAvailable!({ cwd: tmp, vault });
+    expect(availability.ok).toBe(false);
+    expect(availability.reason).toMatch(/brew install signal-cli/);
+  });
+
+  it('asks for an account once the binary exists', async () => {
+    fsSync.writeFileSync(path.join(tmp, 'signal-cli'), '#!/bin/sh\n', { mode: 0o755 });
+    const availability = await signalDef.isAvailable!({ cwd: tmp, vault });
+    expect(availability.ok).toBe(false);
+    expect(availability.reason).toMatch(/signal setup/);
+  });
+
+  it('is available with binary + env account', async () => {
+    fsSync.writeFileSync(path.join(tmp, 'signal-cli'), '#!/bin/sh\n', { mode: 0o755 });
+    vi.stubEnv('MOXXY_SIGNAL_ACCOUNT', '+15551234567');
+    const availability = await signalDef.isAvailable!({ cwd: tmp, vault });
+    expect(availability).toEqual({ ok: true });
+  });
+
+  it('is available with binary + vault account', async () => {
+    fsSync.writeFileSync(path.join(tmp, 'signal-cli'), '#!/bin/sh\n', { mode: 0o755 });
+    await vault.set(SIGNAL_ACCOUNT_KEY, '+15551234567');
+    const availability = await signalDef.isAvailable!({ cwd: tmp, vault });
+    expect(availability).toEqual({ ok: true });
+  });
+});
+
+describe('signal channel subcommands', () => {
+  it('`status` reports unconfigured state as JSON', async () => {
+    const code = await signalDef.subcommands!.status!.run(ctx());
+    expect(code).toBe(0);
+    const parsed = JSON.parse(writeOut.join(''));
+    expect(parsed).toEqual({
+      binaryFound: false,
+      account: null,
+      linked: null,
+      allowedSenders: [],
+      dataDir: expect.stringContaining('signal-cli'),
+    });
+  });
+
+  it('`status` surfaces the stored account + allow-list', async () => {
+    await vault.set(SIGNAL_ACCOUNT_KEY, '+15551234567');
+    await vault.set(SIGNAL_ALLOWED_SENDERS_KEY, JSON.stringify(['+14440002222']));
+    const code = await signalDef.subcommands!.status!.run(ctx());
+    expect(code).toBe(0);
+    const parsed = JSON.parse(writeOut.join(''));
+    expect(parsed.account).toBe('+15551234567');
+    expect(parsed.allowedSenders).toEqual(['+14440002222']);
+  });
+
+  it('`unpair` clears account + allow-list and points at the phone for full unlink', async () => {
+    await vault.set(SIGNAL_ACCOUNT_KEY, '+15551234567');
+    await vault.set(SIGNAL_ALLOWED_SENDERS_KEY, JSON.stringify(['+14440002222']));
+    const code = await signalDef.subcommands!.unpair!.run(ctx());
+    expect(code).toBe(0);
+    expect(writeOut.join('')).toContain('unpaired');
+    expect(writeOut.join('')).toContain('Linked Devices');
+    expect(await vault.get(SIGNAL_ACCOUNT_KEY)).toBeNull();
+    expect(await vault.get(SIGNAL_ALLOWED_SENDERS_KEY)).toBeNull();
+  });
+
+  it('`unpair` is a no-op when nothing is configured', async () => {
+    const code = await signalDef.subcommands!.unpair!.run(ctx());
+    expect(code).toBe(0);
+    expect(writeOut.join('')).toContain('no account was configured');
+  });
+
+  it('`pair` refuses to start without a TTY (interactive-only flow)', async () => {
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    try {
+      const startChannel = vi.fn(async () => 0);
+      const code = await signalDef.subcommands!.pair!.run(ctx({ startChannel }));
+      expect(code).toBe(1);
+      expect(startChannel).not.toHaveBeenCalled();
+      expect(writeErr.join('')).toMatch(/TTY/);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+    }
+  });
+
+  it('`pair` drives the in-process link flow on a TTY (fails fast without the binary)', async () => {
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    try {
+      const startChannel = vi.fn(async () => 0);
+      const setPermissionResolver = vi.fn();
+      // No signal-cli on the stubbed PATH -> channel.start throws the install
+      // hint before any process could spawn. We assert `pair` wires the
+      // session's resolver (the in-process flow) instead of delegating.
+      await expect(
+        signalDef.subcommands!.pair!.run(ctx({ startChannel, session: { setPermissionResolver } })),
+      ).rejects.toThrow(/signal-cli not found/);
+      expect(setPermissionResolver).toHaveBeenCalledTimes(1);
+      expect(startChannel).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+    }
+  });
+
+  it('`setup` starts the channel directly when headless', async () => {
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    try {
+      const startChannel = vi.fn(async () => 0);
+      const code = await signalDef.subcommands!.setup!.run(ctx({ startChannel }));
+      expect(code).toBe(0);
+      expect(startChannel).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+    }
+  });
+
+  it('subcommands return 1 when vault is unavailable', async () => {
+    const badCtx = {
+      deps: { cwd: tmp, vault: undefined, logger: undefined, options: {} },
+      args: { positional: [], flags: {} },
+      startChannel: async () => 0,
+      session: { setPermissionResolver: () => {} },
+    } as never;
+    const code = await signalDef.subcommands!.status!.run(badCtx);
+    expect(code).toBe(1);
+    expect(writeErr.join('')).toContain('vault unavailable');
+  });
+});

--- a/packages/plugin-channel-signal/tsconfig.json
+++ b/packages/plugin-channel-signal/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/plugin-channel-signal/vitest.config.ts
+++ b/packages/plugin-channel-signal/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/packages/plugin-plugins-admin/src/catalog.ts
+++ b/packages/plugin-plugins-admin/src/catalog.ts
@@ -226,6 +226,15 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     installSpec: '@moxxy/plugin-channel-slack',
   },
   {
+    id: 'signal',
+    label: 'Signal channel',
+    description:
+      'Signal messenger on a dedicated isolated runner via a signal-cli sidecar (moxxy signal; requires the signal-cli binary on PATH).',
+    packageName: '@moxxy/plugin-channel-signal',
+    installSpec: '@moxxy/plugin-channel-signal',
+    provides: [{ category: 'channel', name: 'signal' }],
+  },
+  {
     id: 'stt-whisper',
     label: 'Whisper voice input',
     description: 'Speech-to-text via the OpenAI Whisper API (Ctrl+R in the TUI).',

--- a/packages/sdk/src/event-store.ts
+++ b/packages/sdk/src/event-store.ts
@@ -13,7 +13,7 @@ import type { SessionId } from './ids.js';
  */
 
 /** Originating channel of a session (persisted into the meta sidecar). */
-export type SessionSource = 'cli' | 'tui' | 'desktop' | 'mobile' | 'slack' | 'telegram';
+export type SessionSource = 'cli' | 'tui' | 'desktop' | 'mobile' | 'slack' | 'telegram' | 'signal';
 
 /**
  * The single per-session metadata record (the JSONL impl writes it to

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1410,6 +1410,49 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
 
+  packages/plugin-channel-signal:
+    dependencies:
+      '@clack/prompts':
+        specifier: 'catalog:'
+        version: 1.4.0
+      '@moxxy/channel-kit':
+        specifier: workspace:*
+        version: link:../channel-kit
+      '@moxxy/core':
+        specifier: workspace:*
+        version: link:../core
+      '@moxxy/plugin-vault':
+        specifier: workspace:*
+        version: link:../plugin-vault
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
+    devDependencies:
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      '@types/qrcode':
+        specifier: ^1.5.5
+        version: 1.5.6
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
   packages/plugin-channel-slack:
     dependencies:
       '@clack/prompts':


### PR DESCRIPTION
## What

New installable `@moxxy/plugin-channel-signal`: a Signal messenger channel built as a thin adapter over `@moxxy/channel-kit` (TurnCoordinator/driveTurn/subscribeTurn, PlainTurnRenderer, resolveSecret, createAuditedAllowListResolver), modeled on plugin-telegram/plugin-channel-slack.

**Sidecar (design decision — UNIX socket daemon, plugin-owned lifecycle):** the plugin spawns `signal-cli -a <account> daemon --socket <path> --receive-mode on-start` and speaks newline-delimited JSON-RPC over the socket (incoming messages arrive as `receive` notifications). Socket over TCP/HTTP because a filesystem socket is never remotely reachable and needs no port/auth story; the socket lives at a fresh per-process tmp path. Lifecycle mirrors plugin-browser's Playwright sidecar: spawn on `start()`, boot loop that polls the socket + health-checks with a `version` round-trip (stderr tail carried into boot errors, so "User +… is not registered" surfaces instead of a bare timeout), and on stop SIGTERM → `sleepWithAbort` grace (5s, aborted early on exit) → SIGKILL so a wedged JVM can never orphan. Unexpected daemon death rejects `handle.running` (supervisor restarts). `isAvailable` gates on the binary with a pure PATH scan — **no JVM spawn** — and returns a `brew install signal-cli` hint; a missing binary can never crash discovery.

**Pairing (linked device):** `moxxy channels signal pair` runs `signal-cli link -n moxxy`, parses the `sgnl://linkdevice…` URI (legacy `tsdevice:/` accepted too), renders it as a terminal QR, stores the account (parsed from `Associated with: +…`) in the vault on completion, then boots the daemon. The desktop panel drives the *same* window: `dedicated` start opens it, `requestUrl` carries the URI (connect kind `qr` → channel status file), `connected` flips on link. signal-cli keeps the actual identity keys/store under `~/.local/share/signal-cli/` (`$XDG_DATA_HOME`); the vault stores only the number + sender allow-list. There is no API token anywhere.

**Message flow / security:**
- Every envelope is zod-validated + size-capped (`receiveParamsSchema`, 16k prompt cap, strict attachment-id charset so ids can't path-traverse) before anything touches the session.
- Allow-list gate on EVERY session-reaching path: senders by E.164/uuid (vault `signal_allowed_senders` + `--allowedSenders`); the owner's own **Note to Self** is allowed by default after linking. Unknown senders are dropped *silently* (a reply would leak the bot's existence).
- Loop protection: send timestamps returned by `send` are recorded (bounded set) and any `syncMessage.sentMessage` echo with a known timestamp is dropped; dataMessages from our own account are dropped; the owner's outbound messages to OTHER people are never reacted to. Group messages dropped (v1).
- Tool permissions: autonomous audited allow-list (`channels.signal.allowedTools`, `'*'` expansion), same model as Slack; every auto-approval is logged.
- Voice notes: audio attachment → 20MB cap (declared + actual) → read from signal-cli's attachments dir → `session.transcribers.tryGetActive()` → "heard: …" echo → normal turn; install guidance when no transcriber.

**Streaming (design decision — buffered chunk sends, NOT FramePump edits):** signal-cli *does* support message edits (`--edit-timestamp` / `editTimestamp`), but each Signal edit is a full E2E re-delivery of the whole body to every device in the conversation; a ~1s edit cadence for a long turn means dozens of deliveries per reply, clients keep a bounded edit history, and burst sends are exactly what Signal's server-side spam heuristics rate-limit. So replies stream as paragraph-aligned buffered chunks (soft 1500 / hard 2000 chars, serialized queue, divergent-final resend) with liveness from the typing indicator (`sendTyping` refreshed every 10s inside its 15s display window). Rationale documented in `channel/chunker.ts`.

**Wiring:** dedicated isolated runner (`dedicatedRunner: true`, `sessionSource: 'signal'` — a linked device sees all the owner's messages, so it is isolated like Slack); `SessionSource` union + the CLI runtime guard gain `'signal'`; catalog entry in plugins-admin (`provides: [{category:'channel', name:'signal'}]`); CLI channel-hint (`moxxy signal` → install hint); desktop `channel-catalog.ts` entry (`hasWebhookUrl: false`, QR connect step); subcommands `setup` (interactive wizard, `interactiveCommand`) / `pair` / `status` / `unpair`; dual export (`buildSignalPlugin({vault})` + discovery default resolving the vault in `onInit`); `package.json#moxxy` discovery block with `requirements: [@moxxy/plugin-vault]` and a `setup` step (account number field, link instructions — no token).

## Why

Signal as a first-class moxxy surface: message your own Note-to-Self (or an allow-listed number) and drive the agent, with the same dedicated-runner isolation story as Slack/Telegram.

## Verification

- `pnpm build` / `typecheck` / `lint` (0 errors) / `test` (exit 0; 80 new tests in the package) / `check:deps` — all green.
- CLI smokes: `bin.js --help`, `bin.js plugins list`, and `bin.js signal` → prints the `moxxy plugins install signal` hint (unbundled model).
- All tests mock the sidecar spawn + JSON-RPC socket — no signal-cli binary or live account required: sidecar lifecycle (spawn args, socket retry, boot timeout, early-exit stderr, SIGTERM→SIGKILL grace, onExit), link-process URI/account parsing (sgnl + tsdevice), listAccounts JSON + plain-text parsing, allow-list gating (allowed/stranger/group/self), Note-to-Self accept + reply target, sync-echo drop by timestamp, owner-outbound drop, schema-invalid/oversized payload drop, busy single-flight reply, pair/dedicated link-window flow (vault write, daemon boot, onLinked), chunker boundaries + divergence + ordering, voice caps + traversal-id drop + happy path, isAvailable missing-binary/missing-account paths, subcommand contracts.

### Needs a live linked Signal account (manual verify)

- `moxxy channels signal pair`: real `signal-cli link` QR render + scan from a phone, account auto-capture from `Associated with:`, daemon boot after link.
- Receive/send round-trip: Note-to-Self prompt → chunked replies + typing indicator; allow-listed second account round-trip.
- Confirming the sync-echo drop against real linked-device echo envelopes (shape assumed from signal-cli docs).
- Voice note round-trip (real attachment id/path under `~/.local/share/signal-cli/attachments/`, real transcriber).
- Daemon restart recovery: kill signal-cli mid-run → `running` rejects → supervisor restart re-attaches.
- Desktop Channels panel: QR from the status file, `connected` flip on link.