### PR TITLE
feat(channels): add WhatsApp channel via Baileys (@moxxy/plugin-channel-whatsapp)

### DIFF
--- a/.changeset/whatsapp-channel-baileys.md
+++ b/.changeset/whatsapp-channel-baileys.md
@@ -1,0 +1,7 @@
+---
+'@moxxy/plugin-channel-whatsapp': minor
+'@moxxy/sdk': minor
+'@moxxy/cli': minor
+---
+
+Add a WhatsApp channel via Baileys (`@moxxy/plugin-channel-whatsapp`): QR device-link pairing, a mandatory typed consent gate for the unofficial-API/ban risk, JID allow-list (owner Note-to-Self allowed by default), fromMe-echo loop protection, voice-note transcription, and send-then-edit streaming over a swappable auth-state backend. Runs on its own dedicated isolated runner (`sessionSource: 'whatsapp'`, added to the SDK `SessionSource` union).

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -312,15 +312,30 @@ or recorded-on-purpose decision.
   (`IngestHttpServer`: routing/health/size-capped raw body/verify gate/500
   catch-all + `DeliveryDedupeCache`) and Slack's ingest is a thin pipeline on
   it. Migrating the remaining four is still the larger, lower-payoff refactor.
-- [note, channels] Channel scaffolding shared by telegram+slack+signal now lives
-  in `@moxxy/channel-kit` (FramePump, TurnCoordinator + turnId-filtered turn
-  helpers, host-code + TOFU pairing machines, `resolveSecret`, audited
-  allow-list resolver, ingest scaffold). Signal (2026-07-03) validated the
-  thin-adapter claim: it consumes TurnCoordinator/driveTurn/PlainTurnRenderer/
-  resolveSecret/createAuditedAllowListResolver and adds only signal-cli quirks.
-  New channels (Discord/WhatsApp) should be thin adapters over it — messenger
-  quirks (formatting, transport error mapping, signature schemes, pairing
-  wording) stay in each plugin.
+- [note, whatsapp, security] `@moxxy/plugin-channel-whatsapp` is the first channel
+  on an UNOFFICIAL client (Baileys / WhatsApp Web protocol): automating an account
+  violates WhatsApp's ToS and the number can be permanently BANNED. Two standing
+  tradeoffs recorded on purpose: (1) the rotating Baileys auth-state (signal
+  sessions/pre-keys/creds) is stored UNENCRYPTED at rest under
+  `~/.moxxy/whatsapp-auth` (dir 0700, files 0600) — the vault is the wrong home for
+  a high-write rotating key store, so it isn't used; anyone with file access to the
+  moxxy home can hijack the linked session. The `WhatsAppAuthStorage` interface
+  exists so an encrypted backend can be swapped in later without touching the
+  channel. (2) permission prompts are PLAIN-TEXT numbered replies (Baileys has no
+  reliable multi-device interactive buttons), captured as the owner's next short
+  message. Follow-ups: encrypted auth-state backend; per-chat concurrency (single
+  global `busy` today, like Slack v1); richer formatting.
+  `packages/plugin-channel-whatsapp/`.
+- [note, channels] Channel scaffolding shared by telegram+slack+signal+whatsapp
+  now lives in `@moxxy/channel-kit` (FramePump, TurnCoordinator + turnId-filtered
+  turn helpers, host-code + TOFU pairing machines, `resolveSecret`, audited
+  allow-list resolver, ingest scaffold, PlainTurnRenderer). Signal + WhatsApp
+  (2026-07-03) validated the thin-adapter claim: both consume
+  TurnCoordinator/driveTurn/PlainTurnRenderer/resolveSecret (Signal also
+  createAuditedAllowListResolver, WhatsApp also FramePump) and add only their
+  messenger's quirks. New channels (Discord) should be thin adapters over it —
+  messenger quirks (formatting, transport error mapping, signature schemes,
+  pairing wording) stay in each plugin.
   Deliberately NOT extracted (single-implementation or channel-specific):
   Telegram's rich TurnRenderer/HTML pipeline + inline-keyboard
   permission/approval prompts + grammy dispatch, Slack's HMAC verify + zod

--- a/apps/desktop/scripts/bundle-plugins-seed.mjs
+++ b/apps/desktop/scripts/bundle-plugins-seed.mjs
@@ -53,6 +53,7 @@ const SEED_PLUGINS = [
   'plugin-stt-whisper-codex',
   'plugin-telegram',
   'plugin-channel-slack',
+  'plugin-channel-whatsapp',
   'plugin-provider-admin',
   'plugin-mcp',
   'plugin-memory',

--- a/packages/cli/src/channel-hints.ts
+++ b/packages/cli/src/channel-hints.ts
@@ -13,6 +13,7 @@ const CHANNEL_COMMANDS: Readonly<Record<string, string>> = {
   telegram: '@moxxy/plugin-telegram',
   slack: '@moxxy/plugin-channel-slack',
   signal: '@moxxy/plugin-channel-signal',
+  whatsapp: '@moxxy/plugin-channel-whatsapp',
   web: '@moxxy/plugin-channel-web',
   http: '@moxxy/plugin-channel-http',
 };

--- a/packages/cli/src/setup/builtin-requirements.generated.ts
+++ b/packages/cli/src/setup/builtin-requirements.generated.ts
@@ -29,6 +29,13 @@ export const BUILTIN_REQUIREMENTS: Readonly<
       "hint": "slack resolves the vault from the service registry for its bot token + signing secret + pairing; @moxxy/plugin-vault must load first"
     }
   ],
+  "@moxxy/plugin-channel-whatsapp": [
+    {
+      "kind": "plugin",
+      "name": "@moxxy/plugin-vault",
+      "hint": "whatsapp resolves the vault from the service registry for its consent receipt + owner JID + allow-list; @moxxy/plugin-vault must load first"
+    }
+  ],
   "@moxxy/plugin-oauth": [
     {
       "kind": "plugin",

--- a/packages/cli/src/setup/persistence.ts
+++ b/packages/cli/src/setup/persistence.ts
@@ -68,7 +68,8 @@ function sessionSource(): SessionSource {
     explicit === 'cli' ||
     explicit === 'slack' ||
     explicit === 'telegram' ||
-    explicit === 'signal'
+    explicit === 'signal' ||
+    explicit === 'whatsapp'
   ) {
     return explicit;
   }

--- a/packages/desktop-host/src/channel-catalog.ts
+++ b/packages/desktop-host/src/channel-catalog.ts
@@ -117,6 +117,51 @@ export const CHANNEL_CATALOG: Readonly<Record<string, ChannelCatalogEntry>> = {
     vaultKeys: { account: 'signal_account' },
     requiredKeys: ['signal_account'],
   },
+  whatsapp: {
+    descriptor: {
+      id: 'whatsapp',
+      name: 'WhatsApp',
+      description:
+        'A WhatsApp bot via Baileys on its own dedicated runner. UNOFFICIAL API: automating an ' +
+        'account violates WhatsApp\'s ToS and the number can be PERMANENTLY BANNED — use a ' +
+        'secondary number. Links by QR (Linked devices); no public URL needed.',
+      docsUrl: 'https://baileys.wiki',
+      configFields: [
+        {
+          name: 'tosAcknowledged',
+          label: "Risk acknowledgment — type 'yes'",
+          type: 'text',
+          required: true,
+          help:
+            "Typing anything other than 'yes' keeps the channel disarmed. This is the consent " +
+            'gate for the unofficial-API ban risk.',
+        },
+        {
+          name: 'allowedJids',
+          label: 'Extra allowed JIDs (comma-separated)',
+          type: 'text',
+          required: false,
+          placeholder: '15551234567@s.whatsapp.net',
+          help: 'Your own Note-to-Self chat is always allowed once linked.',
+        },
+      ],
+      hasWebhookUrl: false,
+      runHint:
+        'On your phone: WhatsApp -> Settings -> Linked devices -> Link a device, then scan the QR.',
+      connect: {
+        kind: 'qr',
+        title: 'Link WhatsApp',
+        hint:
+          'Scan with the phone that owns the account: WhatsApp -> Settings -> Linked devices -> ' +
+          'Link a device. The QR refreshes periodically until scanned.',
+      },
+    },
+    vaultKeys: {
+      tosAcknowledged: 'whatsapp_tos_acknowledged',
+      allowedJids: 'whatsapp_allowed_jids',
+    },
+    requiredKeys: ['whatsapp_tos_acknowledged'],
+  },
 };
 
 /** Every catalog entry, in display order. */

--- a/packages/plugin-channel-whatsapp/package.json
+++ b/packages/plugin-channel-whatsapp/package.json
@@ -1,0 +1,99 @@
+{
+  "name": "@moxxy/plugin-channel-whatsapp",
+  "version": "0.26.0",
+  "description": "WhatsApp channel for moxxy via Baileys (UNOFFICIAL WhatsApp Web protocol — violates WhatsApp's Terms of Service; the linked number can be banned, use a secondary number). QR device-link pairing, JID allow-list, voice-note transcription, dedicated isolated runner.",
+  "keywords": [
+    "moxxy",
+    "agent",
+    "channel",
+    "whatsapp",
+    "baileys",
+    "bot"
+  ],
+  "homepage": "https://moxxy.ai",
+  "bugs": {
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
+    "directory": "packages/plugin-channel-whatsapp"
+  },
+  "author": "Michal Makowski <michal.makowski97@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "moxxy": {
+    "plugin": {
+      "entry": "./dist/index.js",
+      "kind": "cli"
+    },
+    "requirements": [
+      {
+        "kind": "plugin",
+        "name": "@moxxy/plugin-vault",
+        "hint": "whatsapp resolves the vault from the service registry for its consent receipt + owner JID + allow-list; @moxxy/plugin-vault must load first"
+      }
+    ],
+    "setup": {
+      "title": "WhatsApp channel (UNOFFICIAL API — read this first)",
+      "description": "This channel uses Baileys, an UNOFFICIAL WhatsApp Web client. Automating a personal account violates WhatsApp's Terms of Service and CAN GET THE PHONE NUMBER PERMANENTLY BANNED. Strongly consider a secondary number. Pairing itself happens later via QR (moxxy whatsapp setup).",
+      "fields": [
+        {
+          "key": "tosAcknowledged",
+          "label": "Type 'yes' to acknowledge the ToS/ban risk (anything else keeps the channel disabled)",
+          "kind": "secret",
+          "vaultKey": "whatsapp_tos_acknowledged",
+          "required": true
+        },
+        {
+          "key": "allowedJids",
+          "label": "Extra allowed WhatsApp JIDs (comma-separated, e.g. 15551234567@s.whatsapp.net) — your own Note-to-Self chat is always allowed",
+          "kind": "string",
+          "required": false,
+          "placeholder": "15551234567@s.whatsapp.net"
+        }
+      ]
+    }
+  },
+  "dependencies": {
+    "@clack/prompts": "catalog:",
+    "@moxxy/channel-kit": "workspace:*",
+    "@moxxy/core": "workspace:*",
+    "@moxxy/plugin-vault": "workspace:*",
+    "@moxxy/sdk": "workspace:*",
+    "@whiskeysockets/baileys": "^6.7.21",
+    "qrcode": "^1.5.4",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@moxxy/mode-default": "workspace:*",
+    "@moxxy/testing": "workspace:*",
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "@types/qrcode": "^1.5.5",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugin-channel-whatsapp/src/auth-state.test.ts
+++ b/packages/plugin-channel-whatsapp/src/auth-state.test.ts
@@ -1,0 +1,103 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createFileAuthStorage,
+  createWhatsAppAuthState,
+  hasStoredCreds,
+  sanitizeAuthKey,
+  type BaileysAuthBridge,
+  type WhatsAppAuthStorage,
+} from './auth-state.js';
+
+// A trivial bridge: identity JSON (no Buffer categories), fresh creds counter.
+function fakeBridge(): BaileysAuthBridge {
+  let n = 0;
+  return {
+    initAuthCreds: () => ({ me: `creds-${n++}` }),
+    BufferJSON: { reviver: (_k, v) => v, replacer: (_k, v) => v },
+  };
+}
+
+describe('sanitizeAuthKey', () => {
+  it('flattens signal key ids into safe filenames', () => {
+    expect(sanitizeAuthKey('pre-key-42')).toBe('pre-key-42');
+    expect(sanitizeAuthKey('session-15551234567:1.0')).toBe('session-15551234567_1.0');
+    expect(sanitizeAuthKey('../escape')).toBe('__escape');
+  });
+});
+
+describe('createWhatsAppAuthState (over an in-memory storage)', () => {
+  function memStorage(): WhatsAppAuthStorage & { map: Map<string, string> } {
+    const map = new Map<string, string>();
+    return {
+      map,
+      async read(k) {
+        return map.get(k) ?? null;
+      },
+      async write(k, v) {
+        map.set(k, v);
+      },
+      async delete(k) {
+        map.delete(k);
+      },
+      async clear() {
+        map.clear();
+      },
+    };
+  }
+
+  it('creates fresh creds when none stored, and persists them via saveCreds', async () => {
+    const storage = memStorage();
+    const { state, saveCreds } = await createWhatsAppAuthState(storage, fakeBridge());
+    expect(state.creds).toEqual({ me: 'creds-0' });
+    await saveCreds();
+    expect(storage.map.has('creds')).toBe(true);
+    expect(await hasStoredCreds(storage)).toBe(true);
+  });
+
+  it('round-trips key set/get and honors null-delete', async () => {
+    const storage = memStorage();
+    const { state } = await createWhatsAppAuthState(storage, fakeBridge());
+    await state.keys.set({ 'pre-key': { '1': { k: 'v' }, '2': { k: 'w' } } });
+    expect(await state.keys.get('pre-key', ['1', '2'])).toEqual({ '1': { k: 'v' }, '2': { k: 'w' } });
+
+    await state.keys.set({ 'pre-key': { '1': null } });
+    expect(await state.keys.get('pre-key', ['1', '2'])).toEqual({ '2': { k: 'w' } });
+  });
+
+  it('reuses stored creds on the next init', async () => {
+    const storage = memStorage();
+    const bridge = fakeBridge();
+    const first = await createWhatsAppAuthState(storage, bridge);
+    await first.saveCreds();
+    const second = await createWhatsAppAuthState(storage, bridge);
+    expect(second.state.creds).toEqual({ me: 'creds-0' });
+  });
+});
+
+describe('createFileAuthStorage', () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'wa-auth-'));
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('writes 0600 files and clears the whole dir', async () => {
+    const storage = createFileAuthStorage(path.join(dir, 'auth'));
+    await storage.write('creds', '{"x":1}');
+    expect(await storage.read('creds')).toBe('{"x":1}');
+    expect(await hasStoredCreds(storage)).toBe(true);
+
+    const file = path.join(dir, 'auth', 'creds.json');
+    const mode = (await fs.stat(file)).mode & 0o777;
+    expect(mode).toBe(0o600);
+
+    await storage.clear();
+    expect(await storage.read('creds')).toBeNull();
+    expect(await hasStoredCreds(storage)).toBe(false);
+  });
+});

--- a/packages/plugin-channel-whatsapp/src/auth-state.ts
+++ b/packages/plugin-channel-whatsapp/src/auth-state.ts
@@ -1,0 +1,161 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Baileys auth-state persistence behind a swappable storage adapter.
+ *
+ * Baileys' multi-device auth is a ROTATING key store (signal sessions, pre-keys,
+ * sender keys, app-state sync keys) plus a creds record — dozens of small files
+ * that churn constantly. That churn is why the moxxy VAULT is the wrong home for
+ * it (the vault is an encrypted, tagged, human-curated secret store, not a
+ * high-write key-value backend); instead the state lives in a dedicated
+ * directory under the moxxy home with tight modes (dir 0700, files 0600).
+ * TRADE-OFF (recorded in TECH_DEBT + the PR): unlike vault entries, these files
+ * are NOT encrypted at rest — anyone with file access to the moxxy home can
+ * hijack the linked WhatsApp session. The {@link WhatsAppAuthStorage} interface
+ * exists precisely so an encrypted backend can be swapped in later without
+ * touching the channel.
+ */
+export interface WhatsAppAuthStorage {
+  read(key: string): Promise<string | null>;
+  write(key: string, value: string): Promise<void>;
+  delete(key: string): Promise<void>;
+  /** Wipe the whole store (logout / unpair). */
+  clear(): Promise<void>;
+}
+
+/** Signal key ids contain `/` and `:`; map every key to one safe flat filename. */
+export function sanitizeAuthKey(key: string): string {
+  return key.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/^\.+/, '_');
+}
+
+/**
+ * The default storage backend: one JSON file per key under `dir`, created 0700
+ * with 0600 files so the signal identity is at least owner-only on disk.
+ */
+export function createFileAuthStorage(dir: string): WhatsAppAuthStorage {
+  const fileFor = (key: string): string => path.join(dir, `${sanitizeAuthKey(key)}.json`);
+  const ensureDir = async (): Promise<void> => {
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+  };
+  return {
+    async read(key) {
+      try {
+        return await fs.readFile(fileFor(key), 'utf8');
+      } catch {
+        return null;
+      }
+    },
+    async write(key, value) {
+      await ensureDir();
+      const target = fileFor(key);
+      // Write-then-rename so a crash mid-write can't truncate the creds record;
+      // chmod explicitly because writeFile's mode option is masked by umask.
+      const tmp = `${target}.tmp`;
+      await fs.writeFile(tmp, value, { mode: 0o600 });
+      await fs.chmod(tmp, 0o600);
+      await fs.rename(tmp, target);
+    },
+    async delete(key) {
+      await fs.rm(fileFor(key), { force: true });
+    },
+    async clear() {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+/** The creds record's storage key (every other key is `<type>-<id>`). */
+const CREDS_KEY = 'creds';
+
+/** True when a linked-device credential record exists (i.e. paired before). */
+export async function hasStoredCreds(storage: WhatsAppAuthStorage): Promise<boolean> {
+  return (await storage.read(CREDS_KEY)) != null;
+}
+
+/**
+ * The tiny slice of Baileys this module needs — injected so unit tests never
+ * import the real package, and so the production wiring (`baileys-socket.ts`)
+ * can hand in the lazily-imported module.
+ */
+export interface BaileysAuthBridge {
+  initAuthCreds(): Record<string, unknown>;
+  readonly BufferJSON: {
+    readonly reviver: (key: string, value: unknown) => unknown;
+    readonly replacer: (key: string, value: unknown) => unknown;
+  };
+  /** `proto.Message.AppStateSyncKeyData.fromObject` — revives that one typed key
+   *  category the way Baileys' own `useMultiFileAuthState` does. Optional so a
+   *  fake bridge in tests can skip it. */
+  readonly reviveAppStateSyncKey?: (value: unknown) => unknown;
+}
+
+export interface WhatsAppAuthState {
+  /** Shaped exactly like Baileys' `AuthenticationState` (creds + keys store). */
+  readonly state: {
+    readonly creds: Record<string, unknown>;
+    readonly keys: {
+      get(type: string, ids: string[]): Promise<Record<string, unknown>>;
+      set(data: Record<string, Record<string, unknown | null>>): Promise<void>;
+    };
+  };
+  /** Persist the creds record; wire to the socket's `creds.update` event. */
+  saveCreds(): Promise<void>;
+}
+
+/**
+ * `useMultiFileAuthState` equivalent over a {@link WhatsAppAuthStorage} — the
+ * same creds + `<type>-<id>` key layout, serialized with Baileys' BufferJSON
+ * (signal keys are raw byte arrays), but with the storage backend swappable.
+ */
+export async function createWhatsAppAuthState(
+  storage: WhatsAppAuthStorage,
+  bridge: BaileysAuthBridge,
+): Promise<WhatsAppAuthState> {
+  const readJson = async (key: string): Promise<unknown> => {
+    const raw = await storage.read(key);
+    if (raw == null) return null;
+    try {
+      return JSON.parse(raw, bridge.BufferJSON.reviver);
+    } catch {
+      return null;
+    }
+  };
+  const writeJson = (key: string, value: unknown): Promise<void> =>
+    storage.write(key, JSON.stringify(value, bridge.BufferJSON.replacer));
+
+  const creds =
+    ((await readJson(CREDS_KEY)) as Record<string, unknown> | null) ?? bridge.initAuthCreds();
+
+  return {
+    state: {
+      creds,
+      keys: {
+        async get(type, ids) {
+          const data: Record<string, unknown> = {};
+          await Promise.all(
+            ids.map(async (id) => {
+              let value = await readJson(`${type}-${id}`);
+              if (type === 'app-state-sync-key' && value != null && bridge.reviveAppStateSyncKey) {
+                value = bridge.reviveAppStateSyncKey(value);
+              }
+              if (value != null) data[id] = value;
+            }),
+          );
+          return data;
+        },
+        async set(data) {
+          const tasks: Promise<void>[] = [];
+          for (const [category, entries] of Object.entries(data)) {
+            for (const [id, value] of Object.entries(entries)) {
+              const key = `${category}-${id}`;
+              tasks.push(value == null ? storage.delete(key) : writeJson(key, value));
+            }
+          }
+          await Promise.all(tasks);
+        },
+      },
+    },
+    saveCreds: () => writeJson(CREDS_KEY, creds),
+  };
+}

--- a/packages/plugin-channel-whatsapp/src/baileys-socket.ts
+++ b/packages/plugin-channel-whatsapp/src/baileys-socket.ts
@@ -1,0 +1,154 @@
+import { createWhatsAppAuthState, type BaileysAuthBridge } from './auth-state.js';
+import type {
+  WaConnectionUpdate,
+  WaMessageKey,
+  WaMessagesUpsert,
+  WaSentMessage,
+  WhatsAppSocket,
+  WhatsAppSocketFactory,
+  WhatsAppSocketLogger,
+} from './socket.js';
+
+/**
+ * The production {@link WhatsAppSocketFactory}: lazily imports Baileys (a heavy
+ * dependency tree — protobufjs, libsignal — that must NOT load at plugin
+ * discovery time, only when the channel actually starts; same lesson as the
+ * desktop-host eager-import boot crash), builds the swappable auth state, and
+ * adapts the socket down to the narrow contract the channel uses.
+ */
+export const openBaileysSocket: WhatsAppSocketFactory = async ({ storage, logger }) => {
+  const baileys = (await import('@whiskeysockets/baileys')) as unknown as BaileysModule;
+  const makeWASocket = baileys.makeWASocket ?? baileys.default?.makeWASocket ?? baileys.default;
+  if (typeof makeWASocket !== 'function') {
+    throw new Error('@whiskeysockets/baileys: could not resolve makeWASocket export');
+  }
+  const proto = baileys.proto ?? baileys.default?.proto;
+  const bridge: BaileysAuthBridge = {
+    initAuthCreds: baileys.initAuthCreds,
+    BufferJSON: baileys.BufferJSON,
+    ...(proto?.Message?.AppStateSyncKeyData
+      ? {
+          reviveAppStateSyncKey: (value: unknown) =>
+            proto.Message!.AppStateSyncKeyData!.fromObject(value as Record<string, unknown>),
+        }
+      : {}),
+  };
+  const { state, saveCreds } = await createWhatsAppAuthState(storage, bridge);
+
+  const sock = makeWASocket({
+    auth: state as never,
+    // The channel renders the QR itself (terminal QR / desktop panel status file).
+    printQRInTerminal: false,
+    logger: silentBaileysLogger() as never,
+    // Don't mark the linked device "online": keeps phone notifications working
+    // and keeps this client's footprint minimal (it is a bot, not a presence).
+    markOnlineOnConnect: false,
+    // No history backfill — the channel only reacts to live inbound messages;
+    // syncing message history would be both wasteful and a privacy liability.
+    syncFullHistory: false,
+    shouldSyncHistoryMessage: () => false,
+    generateHighQualityLinkPreview: false,
+    browser: ['moxxy', 'Desktop', '1.0.0'],
+  });
+  sock.ev.on('creds.update', () => {
+    void saveCreds().catch((err: unknown) => {
+      logger?.warn?.('whatsapp: failed to persist creds update', { err: String(err) });
+    });
+  });
+
+  return adaptBaileysSocket(sock, baileys, logger);
+};
+
+function adaptBaileysSocket(
+  sock: BaileysSock,
+  baileys: BaileysModule,
+  logger?: WhatsAppSocketLogger,
+): WhatsAppSocket {
+  const downloadMediaMessage =
+    baileys.downloadMediaMessage ?? baileys.default?.downloadMediaMessage;
+  return {
+    userJid: () => sock.user?.id ?? null,
+    onConnectionUpdate: (cb) =>
+      sock.ev.on('connection.update', (u: unknown) => cb(u as WaConnectionUpdate)),
+    onMessages: (cb) =>
+      sock.ev.on('messages.upsert', (u: unknown) => cb(u as WaMessagesUpsert)),
+    sendText: async (jid, text) => {
+      const sent = (await sock.sendMessage(jid, { text })) as { key?: WaMessageKey } | undefined;
+      return sent?.key ? ({ key: sent.key } satisfies WaSentMessage) : null;
+    },
+    editText: async (jid, key, text) => {
+      await sock.sendMessage(jid, { text, edit: key });
+    },
+    downloadMedia: async (message) => {
+      if (typeof downloadMediaMessage !== 'function') {
+        throw new Error('@whiskeysockets/baileys: downloadMediaMessage export missing');
+      }
+      const buf = (await downloadMediaMessage(
+        message as never,
+        'buffer',
+        {},
+        { logger: silentBaileysLogger() as never, reuploadRequest: sock.updateMediaMessage },
+      )) as Buffer;
+      return new Uint8Array(buf);
+    },
+    end: () => {
+      try {
+        sock.end(undefined);
+      } catch (err) {
+        logger?.debug?.('whatsapp: socket end threw', { err: String(err) });
+      }
+    },
+  };
+}
+
+/** Minimal Baileys ILogger that swallows everything (moxxy has its own logger). */
+function silentBaileysLogger(): Record<string, unknown> {
+  const noop = (): void => undefined;
+  const self: Record<string, unknown> = {
+    level: 'silent',
+    trace: noop,
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+    fatal: noop,
+  };
+  self.child = () => self;
+  return self;
+}
+
+// ---- Loosely-typed view of the dynamically imported module (the real types
+// stay out so this file compiles without deep Baileys type coupling; the
+// adapter boundary above is the single place the erasure happens). ----
+
+interface BaileysSock {
+  readonly user?: { id: string } | undefined;
+  readonly ev: { on(event: string, cb: (arg: never) => void): void };
+  sendMessage(jid: string, content: Record<string, unknown>): Promise<unknown>;
+  updateMediaMessage: unknown;
+  end(err: Error | undefined): void;
+}
+
+interface BaileysModule {
+  makeWASocket?: (config: Record<string, unknown>) => BaileysSock;
+  initAuthCreds: () => Record<string, unknown>;
+  BufferJSON: BaileysAuthBridge['BufferJSON'];
+  downloadMediaMessage?: (
+    message: never,
+    type: 'buffer',
+    options: Record<string, unknown>,
+    ctx: Record<string, unknown>,
+  ) => Promise<Buffer>;
+  proto?: BaileysProto;
+  default?: {
+    makeWASocket?: (config: Record<string, unknown>) => BaileysSock;
+    downloadMediaMessage?: BaileysModule['downloadMediaMessage'];
+    proto?: BaileysProto;
+  } & ((config: Record<string, unknown>) => BaileysSock);
+}
+
+interface BaileysProto {
+  Message?: {
+    AppStateSyncKeyData?: { fromObject(value: Record<string, unknown>): unknown };
+  };
+}

--- a/packages/plugin-channel-whatsapp/src/channel.test.ts
+++ b/packages/plugin-channel-whatsapp/src/channel.test.ts
@@ -1,0 +1,344 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Session, autoAllowResolver, silentLogger } from '@moxxy/core';
+import { FakeProvider, streamingTextReply } from '@moxxy/testing';
+import { definePlugin, defineProvider, defineTranscriber } from '@moxxy/sdk';
+import { defaultModePlugin } from '@moxxy/mode-default';
+import { VaultStore, createStaticKeySource, deriveKey, generateSalt } from '@moxxy/plugin-vault';
+import { WhatsAppChannel } from './channel.js';
+import type {
+  WaConnectionUpdate,
+  WaInboundMessage,
+  WaMessageKey,
+  WaMessagesUpsert,
+  WhatsAppSocket,
+  WhatsAppSocketFactoryOptions,
+} from './socket.js';
+import { createFileAuthStorage } from './auth-state.js';
+import { WHATSAPP_CONSENT_ENV } from './keys.js';
+
+const OWNER = '15550000000@s.whatsapp.net';
+const FRIEND = '15551111111@s.whatsapp.net';
+const STRANGER = '15559999999@s.whatsapp.net';
+
+interface SentRecord {
+  jid: string;
+  text: string;
+}
+
+/** Scriptable in-memory WhatsApp socket — no network, no Baileys. */
+class FakeSocket implements WhatsAppSocket {
+  connCb: ((u: WaConnectionUpdate) => void) | null = null;
+  msgCb: ((u: WaMessagesUpsert) => void) | null = null;
+  readonly sent: SentRecord[] = [];
+  readonly edits: Array<{ jid: string; id: string; text: string }> = [];
+  private jid: string | null = null;
+  private seq = 0;
+  downloadImpl: (m: WaInboundMessage) => Promise<Uint8Array> = async () => new Uint8Array();
+  ended = false;
+
+  userJid(): string | null {
+    return this.jid;
+  }
+  onConnectionUpdate(cb: (u: WaConnectionUpdate) => void): void {
+    this.connCb = cb;
+  }
+  onMessages(cb: (u: WaMessagesUpsert) => void): void {
+    this.msgCb = cb;
+  }
+  async sendText(jid: string, text: string): Promise<{ key: WaMessageKey } | null> {
+    const id = `out-${++this.seq}`;
+    this.sent.push({ jid, text });
+    return { key: { remoteJid: jid, fromMe: true, id } };
+  }
+  async editText(jid: string, key: WaMessageKey, text: string): Promise<void> {
+    this.edits.push({ jid, id: key.id ?? '', text });
+  }
+  async downloadMedia(m: WaInboundMessage): Promise<Uint8Array> {
+    return this.downloadImpl(m);
+  }
+  end(): void {
+    this.ended = true;
+  }
+
+  // ---- test drivers ----
+  open(jid: string): void {
+    this.jid = jid;
+    this.connCb?.({ connection: 'open' });
+  }
+  qr(payload: string): void {
+    this.connCb?.({ qr: payload });
+  }
+  close(err?: unknown): void {
+    this.connCb?.({ connection: 'close', lastDisconnect: err ? { error: err } : undefined });
+  }
+  inbound(message: WaInboundMessage, type = 'notify'): void {
+    this.msgCb?.({ type, messages: [message] });
+  }
+}
+
+function textMsg(remoteJid: string, text: string, fromMe = false, id = `in-${Math.random()}`): WaInboundMessage {
+  return { key: { remoteJid, fromMe, id }, message: { conversation: text } };
+}
+
+let tmp: string;
+let vault: VaultStore;
+let session: Session;
+let provider: FakeProvider;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-wa-chan-'));
+  process.env[WHATSAPP_CONSENT_ENV] = 'yes';
+  vault = new VaultStore({
+    filePath: path.join(tmp, 'vault.json'),
+    keySource: createStaticKeySource(deriveKey('test', generateSalt())),
+  });
+  provider = new FakeProvider({ script: [streamingTextReply(['Hello ', 'world'])] });
+  session = new Session({ cwd: tmp, logger: silentLogger, permissionResolver: autoAllowResolver });
+  session.pluginHost.registerStatic(
+    definePlugin({
+      name: 'shim',
+      providers: [
+        defineProvider({ name: provider.name, models: [...provider.models], createClient: () => provider }),
+      ],
+    }),
+  );
+  session.providers.setActive(provider.name);
+  session.pluginHost.registerStatic(defaultModePlugin);
+});
+
+afterEach(async () => {
+  await session.close('test').catch(() => undefined);
+  // The Baileys auth dir may still be mid-write from a socket that just closed;
+  // a single rm can race it (ENOTEMPTY). Retry briefly, then give up.
+  for (let i = 0; i < 5; i++) {
+    try {
+      await fs.rm(tmp, { recursive: true, force: true });
+      break;
+    } catch {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+  }
+  delete process.env[WHATSAPP_CONSENT_ENV];
+});
+
+function makeChannel(fake: FakeSocket, opts: Partial<{ allowedJids: string[] }> = {}): WhatsAppChannel {
+  return new WhatsAppChannel({
+    vault,
+    editFrameMs: 5,
+    socketFactory: async (_o: WhatsAppSocketFactoryOptions) => fake,
+    // Pre-seeded creds file so start() doesn't demand pair mode.
+    authStorage: seededStorage(),
+    ...(opts.allowedJids ? { allowedJids: opts.allowedJids } : {}),
+  });
+}
+
+/** A storage with a creds record present (simulates an already-linked account). */
+function seededStorage() {
+  const storage = createFileAuthStorage(path.join(tmp, 'auth'));
+  return {
+    ...storage,
+    read: async (k: string) => (k === 'creds' ? '{"me":1}' : storage.read(k)),
+  };
+}
+
+describe('WhatsAppChannel.start', () => {
+  it('refuses to start without consent', async () => {
+    delete process.env[WHATSAPP_CONSENT_ENV];
+    const channel = makeChannel(new FakeSocket());
+    session.setPermissionResolver(channel.permissionResolver);
+    await expect(channel.start({ session, dedicated: true })).rejects.toThrow(/ToS|acknowledg|ban/i);
+  });
+
+  it('refuses to start unlinked outside pair mode', async () => {
+    const fake = new FakeSocket();
+    const channel = new WhatsAppChannel({
+      vault,
+      socketFactory: async () => fake,
+      authStorage: createFileAuthStorage(path.join(tmp, 'empty-auth')),
+    });
+    session.setPermissionResolver(channel.permissionResolver);
+    await expect(channel.start({ session })).rejects.toThrow(/No WhatsApp account is linked/);
+  });
+
+  it('drives a full turn for the owner Note-to-Self chat and streams via edits', async () => {
+    const fake = new FakeSocket();
+    const channel = makeChannel(fake);
+    session.setPermissionResolver(channel.permissionResolver);
+    const handle = await channel.start({ session });
+    fake.open(OWNER);
+
+    fake.inbound(textMsg(OWNER, 'hi', true));
+    await vi.waitFor(() => {
+      const all = [...fake.sent.map((s) => s.text), ...fake.edits.map((e) => e.text)];
+      expect(all.join('')).toContain('Hello world');
+    });
+    expect(channel.connected).toBe(true);
+    await handle.stop('test done');
+  });
+
+  it('runs a turn for an allow-listed friend', async () => {
+    const fake = new FakeSocket();
+    const channel = makeChannel(fake, { allowedJids: [FRIEND] });
+    session.setPermissionResolver(channel.permissionResolver);
+    const handle = await channel.start({ session });
+    fake.open(OWNER);
+
+    fake.inbound(textMsg(FRIEND, 'hey bot'));
+    await vi.waitFor(() => expect(provider.received.length).toBeGreaterThan(0));
+    await handle.stop('test done');
+  });
+
+  it('drops an un-allow-listed stranger with no reply', async () => {
+    const fake = new FakeSocket();
+    const channel = makeChannel(fake);
+    session.setPermissionResolver(channel.permissionResolver);
+    const handle = await channel.start({ session });
+    fake.open(OWNER);
+
+    fake.inbound(textMsg(STRANGER, 'let me in'));
+    // Give the async dispatch a tick; nothing should be sent, no turn should run.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(provider.received.length).toBe(0);
+    expect(fake.sent).toHaveLength(0);
+    await handle.stop('test done');
+  });
+
+  it('does NOT reprocess its own outbound echo (loop protection)', async () => {
+    const fake = new FakeSocket();
+    const channel = makeChannel(fake);
+    session.setPermissionResolver(channel.permissionResolver);
+    const handle = await channel.start({ session });
+    fake.open(OWNER);
+
+    fake.inbound(textMsg(OWNER, 'hi', true));
+    await vi.waitFor(() => expect(fake.sent.length + fake.edits.length).toBeGreaterThan(0));
+    const turnsBefore = provider.received.length;
+
+    // Feed the channel's own last send back as an inbound (fromMe echo).
+    const lastOut = fake.sent[fake.sent.length - 1]!;
+    // Reconstruct the outbound key id: the fake numbers them out-N; grab it via
+    // a fresh send to learn the id shape isn't needed — echo by a known own id.
+    fake.inbound({ key: { remoteJid: OWNER, fromMe: true, id: 'out-1' }, message: { conversation: lastOut.text } });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(provider.received.length).toBe(turnsBefore);
+    await handle.stop('test done');
+  });
+
+  it('transcribes a voice note through the active transcriber, then runs a turn', async () => {
+    // Register a stub transcriber on the session, then activate it.
+    session.pluginHost.registerStatic(
+      definePlugin({
+        name: 'stub-stt',
+        transcribers: [
+          defineTranscriber({
+            name: 'stub',
+            createClient: () => ({
+              name: 'stub',
+              transcribe: async () => ({ text: 'transcribed prompt' }),
+            }),
+          }),
+        ],
+      }),
+    );
+    session.transcribers.setActive('stub');
+
+    const fake = new FakeSocket();
+    fake.downloadImpl = async () => new Uint8Array([1, 2, 3]);
+    const channel = makeChannel(fake);
+    session.setPermissionResolver(channel.permissionResolver);
+    const handle = await channel.start({ session });
+    fake.open(OWNER);
+
+    fake.inbound({
+      key: { remoteJid: OWNER, fromMe: true, id: 'v1' },
+      message: { audioMessage: { mimetype: 'audio/ogg', fileLength: 3, ptt: true } },
+    });
+    await vi.waitFor(() => {
+      expect(fake.sent.some((s) => s.text.includes('heard: transcribed prompt'))).toBe(true);
+    });
+    await vi.waitFor(() => expect(provider.received.length).toBeGreaterThan(0));
+    await handle.stop('test done');
+  });
+
+  it('guides the user when a voice note arrives with no transcriber', async () => {
+    const fake = new FakeSocket();
+    fake.downloadImpl = async () => new Uint8Array([1]);
+    const channel = makeChannel(fake);
+    session.setPermissionResolver(channel.permissionResolver);
+    const handle = await channel.start({ session });
+    fake.open(OWNER);
+
+    fake.inbound({
+      key: { remoteJid: OWNER, fromMe: true, id: 'v2' },
+      message: { audioMessage: { mimetype: 'audio/ogg', fileLength: 1 } },
+    });
+    await vi.waitFor(() => {
+      expect(fake.sent.some((s) => /speech-to-text/i.test(s.text))).toBe(true);
+    });
+    expect(provider.received.length).toBe(0);
+    await handle.stop('test done');
+  });
+
+  it('publishes rotating QR payloads as requestUrl in pair mode', async () => {
+    const fake = new FakeSocket();
+    const channel = new WhatsAppChannel({
+      vault,
+      socketFactory: async () => fake,
+      authStorage: createFileAuthStorage(path.join(tmp, 'pair-auth')),
+    });
+    session.setPermissionResolver(channel.permissionResolver);
+    const handle = await channel.start({ session, pair: true });
+    expect(channel.connected).toBe(false);
+
+    let changes = 0;
+    handle.onConnectChange?.(() => changes++);
+    fake.qr('qr-payload-1');
+    expect(channel.requestUrl).toBe('qr-payload-1');
+    expect(changes).toBe(1);
+
+    // Linking clears the QR and flips connected.
+    fake.open(OWNER);
+    expect(channel.requestUrl).toBeNull();
+    expect(channel.connected).toBe(true);
+    await handle.stop('test done');
+  });
+
+  it('stop() aborts pending permission prompts (no hang)', async () => {
+    const fake = new FakeSocket();
+    const channel = makeChannel(fake);
+    session.setPermissionResolver(channel.permissionResolver);
+    const handle = await channel.start({ session });
+    fake.open(OWNER);
+    // Set a chat as "last served" so the prompt has a target.
+    fake.inbound(textMsg(OWNER, 'hi', true));
+    await vi.waitFor(() => expect(fake.sent.length + fake.edits.length).toBeGreaterThan(0));
+
+    const pending = channel.permissionResolver.check(
+      { callId: 'c1', name: 'write_file', input: {} } as never,
+      {} as never,
+    );
+    await vi.waitFor(() =>
+      expect(fake.sent.some((s) => /Permission needed/.test(s.text))).toBe(true),
+    );
+    await handle.stop('shutdown');
+    expect((await pending).mode).toBe('deny');
+    expect(fake.ended).toBe(true);
+  });
+
+  it('re-pair guidance: a logout in non-pair mode fails the running promise', async () => {
+    const fake = new FakeSocket();
+    const channel = makeChannel(fake);
+    session.setPermissionResolver(channel.permissionResolver);
+    const handle = await channel.start({ session });
+    fake.open(OWNER);
+    const failed = handle.running.then(
+      () => 'resolved',
+      (err: Error) => err.message,
+    );
+    fake.close({ output: { statusCode: 401 } });
+    expect(await failed).toMatch(/logged this device out|re-link/i);
+  });
+});

--- a/packages/plugin-channel-whatsapp/src/channel.ts
+++ b/packages/plugin-channel-whatsapp/src/channel.ts
@@ -1,0 +1,571 @@
+import { newTurnId } from '@moxxy/core';
+import { TurnCoordinator } from '@moxxy/channel-kit';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import type { Channel, ChannelHandle, ChannelStartOptsBase, MoxxyEvent } from '@moxxy/sdk';
+import { moxxyPath } from '@moxxy/sdk/server';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import {
+  createFileAuthStorage,
+  hasStoredCreds,
+  type WhatsAppAuthStorage,
+} from './auth-state.js';
+import { CONSENT_REQUIRED_MESSAGE, hasConsent } from './consent.js';
+import {
+  WHATSAPP_ALLOWED_JIDS_KEY,
+  WHATSAPP_AUTH_DIR,
+  WHATSAPP_OWNER_JID_KEY,
+  normalizeJid,
+  parseAllowedJids,
+} from './keys.js';
+import { gateInboundMessage, type GateVerdict } from './message-gate.js';
+import {
+  createWhatsAppPermissionController,
+  type WhatsAppPermissionController,
+} from './permission.js';
+import { openBaileysSocket } from './baileys-socket.js';
+import {
+  WA_DISCONNECT,
+  disconnectStatusCode,
+  type WaConnectionUpdate,
+  type WaInboundMessage,
+  type WaMessageKey,
+  type WhatsAppSocket,
+  type WhatsAppSocketFactory,
+} from './socket.js';
+import { DEFAULT_EDIT_FRAME_MS, runWhatsAppTurn } from './channel/turn-runner.js';
+import { transcribeVoiceMessage } from './channel/voice-handler.js';
+
+/** Bound on remembered own-send message ids (echo/loop protection). */
+const MAX_SENT_IDS = 512;
+
+export interface WhatsAppChannelLogger {
+  debug?(msg: string, meta?: Record<string, unknown>): void;
+  info?(msg: string, meta?: Record<string, unknown>): void;
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface WhatsAppChannelOptions {
+  readonly vault: VaultStore;
+  readonly logger?: WhatsAppChannelLogger;
+  /** Debounce window for streaming edits (ms). Default 3000 — deliberately
+   *  slower than Telegram/Slack; see the turn-runner rationale. */
+  readonly editFrameMs?: number;
+  /** Injectable transport (tests). Defaults to the real Baileys socket. */
+  readonly socketFactory?: WhatsAppSocketFactory;
+  /** Injectable auth-state backend. Defaults to `~/.moxxy/whatsapp-auth`. */
+  readonly authStorage?: WhatsAppAuthStorage;
+  /** Extra allow-listed JIDs from channel config/flags. */
+  readonly allowedJids?: ReadonlyArray<string>;
+  /** Consecutive reconnect attempts before giving up. Default 5. */
+  readonly maxReconnectAttempts?: number;
+  /** Reconnect backoff base (ms). Default 2000; tests shrink it. */
+  readonly reconnectBaseMs?: number;
+}
+
+export interface WhatsAppStartOpts extends ChannelStartOptsBase {
+  readonly session: Session;
+  /** Open in pairing mode: an unlinked start publishes QR payloads instead of
+   *  refusing. Set by `moxxy channels whatsapp pair` / the setup wizard. */
+  readonly pair?: boolean;
+  /** Running GUI-supervised on a dedicated runner (desktop Channels panel) —
+   *  equivalent to `pair` for the unlinked case, so the desktop can render the
+   *  QR from the status file instead of a terminal. */
+  readonly dedicated?: boolean;
+}
+
+export class WhatsAppChannel implements Channel<WhatsAppStartOpts> {
+  readonly name = 'whatsapp';
+  private readonly permission: WhatsAppPermissionController;
+  private readonly opts: WhatsAppChannelOptions;
+  private readonly turns = new TurnCoordinator();
+
+  private session: Session | null = null;
+  private model: string | undefined;
+  private socket: WhatsAppSocket | null = null;
+  private storage: WhatsAppAuthStorage | null = null;
+  private handle: ChannelHandle | null = null;
+  private logUnsub: (() => void) | null = null;
+
+  private stopping = false;
+  private resolveRunning: (() => void) | null = null;
+  private rejectRunning: ((err: Error) => void) | null = null;
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private pairMode = false;
+  private pairedAnnounced = false;
+  private qrPayload: string | null = null;
+  private socketOpen = false;
+  private ownerJid: string | null = null;
+  private readonly allowSet = new Set<string>();
+
+  private currentJid: string | null = null;
+  private lastJid: string | null = null;
+
+  /** Recent OWN outbound message ids — Baileys echoes our sends back via
+   *  `messages.upsert`; without this the bot would converse with itself. */
+  private readonly sentIds = new Set<string>();
+
+  private readonly connectListeners = new Set<() => void>();
+  private readonly pairedListeners = new Set<(ownerJid: string) => void>();
+
+  constructor(opts: WhatsAppChannelOptions) {
+    this.opts = opts;
+    this.permission = createWhatsAppPermissionController();
+  }
+
+  get permissionResolver(): WhatsAppPermissionController['resolver'] {
+    return this.permission.resolver;
+  }
+
+  /** Connect value published to control surfaces (`connect.kind: 'qr'`): the
+   *  CURRENT Baileys QR pairing payload while unlinked (it rotates; each
+   *  rotation re-publishes via onConnectChange), null once linked. */
+  get requestUrl(): string | null {
+    return this.qrPayload;
+  }
+
+  /** Linked + socket open — control surfaces swap the QR for "Connected". */
+  get connected(): boolean {
+    return this.socketOpen && this.ownerJid != null;
+  }
+
+  /** Fires once when a fresh QR link completes (the pair flow waits on this). */
+  onPaired(listener: (ownerJid: string) => void): () => void {
+    this.pairedListeners.add(listener);
+    return () => this.pairedListeners.delete(listener);
+  }
+
+  async start(startOpts: WhatsAppStartOpts): Promise<ChannelHandle> {
+    if (this.handle) return this.handle;
+
+    // CONSENT GATE — defense in depth: the wizard/pair/subcommand paths check
+    // too, but start() is reachable headlessly (`moxxy whatsapp` with vault
+    // state, desktop supervisor), so the channel itself refuses un-acknowledged.
+    if (!(await hasConsent(this.opts.vault))) {
+      throw new Error(CONSENT_REQUIRED_MESSAGE);
+    }
+
+    this.session = startOpts.session;
+    this.model = startOpts.model;
+    this.storage =
+      this.opts.authStorage ?? createFileAuthStorage(moxxyPath(WHATSAPP_AUTH_DIR));
+
+    const dedicated =
+      startOpts.dedicated === true || process.env.MOXXY_DEDICATED_RUNNER === '1';
+    this.pairMode = startOpts.pair === true || dedicated;
+
+    const hadCreds = await hasStoredCreds(this.storage);
+    if (!hadCreds && !this.pairMode) {
+      throw new Error(
+        'No WhatsApp account is linked yet. Run `moxxy channels whatsapp pair` to scan ' +
+          'the QR, or start it from the desktop Channels panel.',
+      );
+    }
+    this.pairedAnnounced = hadCreds;
+
+    // Allow-list: the owner's own JID (Note to Self) is seeded on link; extra
+    // JIDs come from the vault and channel options. Persisted owner JID lets
+    // the gate work from the first inbound even before `open` resolves it.
+    this.ownerJid = normalizeJid(await this.opts.vault.get(WHATSAPP_OWNER_JID_KEY));
+    this.rebuildAllowList(
+      parseAllowedJids(await this.opts.vault.get(WHATSAPP_ALLOWED_JIDS_KEY)),
+    );
+
+    this.permission.setSender((text) => this.sendPermissionPrompt(text));
+
+    // Mirror-to-chat: post assistant prose for turns this channel did NOT
+    // initiate (co-attached surface) into the last chat served (invariant #8:
+    // own turns are filtered by turnId inside TurnCoordinator.mirrorText).
+    this.logUnsub = this.session.log.subscribe((event) => this.mirrorForeignTurn(event));
+
+    const running = new Promise<void>((resolve, reject) => {
+      this.resolveRunning = resolve;
+      this.rejectRunning = reject;
+    });
+
+    await this.connect();
+
+    this.opts.logger?.info?.('whatsapp channel starting', {
+      linked: hadCreds,
+      pairMode: this.pairMode,
+    });
+
+    this.handle = {
+      running,
+      onConnectChange: (listener) => {
+        this.connectListeners.add(listener);
+        return () => this.connectListeners.delete(listener);
+      },
+      stop: async (reason = 'shutdown') => {
+        this.teardown(reason);
+        this.resolveRunning?.();
+        this.resolveRunning = null;
+        this.rejectRunning = null;
+      },
+    };
+    return this.handle;
+  }
+
+  // ---- connection lifecycle -------------------------------------------------
+
+  private async connect(): Promise<void> {
+    if (this.stopping || !this.storage) return;
+    const factory = this.opts.socketFactory ?? openBaileysSocket;
+    const socket = await factory({
+      storage: this.storage,
+      ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+    });
+    this.socket = socket;
+    socket.onConnectionUpdate((update) => this.handleConnectionUpdate(update));
+    socket.onMessages((upsert) => {
+      for (const message of upsert.messages) {
+        this.dispatchInBackground(this.handleInbound(upsert.type, message), 'message');
+      }
+    });
+  }
+
+  private handleConnectionUpdate(update: WaConnectionUpdate): void {
+    if (update.qr) {
+      this.qrPayload = update.qr;
+      this.notifyConnectChange();
+    }
+    if (update.connection === 'open') {
+      this.reconnectAttempts = 0;
+      this.socketOpen = true;
+      this.qrPayload = null;
+      const owner = normalizeJid(this.socket?.userJid() ?? null);
+      if (owner) {
+        this.ownerJid = owner;
+        this.allowSet.add(owner);
+        void this.opts.vault
+          .set(WHATSAPP_OWNER_JID_KEY, owner, ['whatsapp'])
+          .catch((err: unknown) => {
+            this.opts.logger?.warn?.('whatsapp: could not persist owner jid', {
+              err: String(err),
+            });
+          });
+        if (!this.pairedAnnounced) {
+          this.pairedAnnounced = true;
+          this.emitPaired(owner);
+          void this.send(
+            owner,
+            'Linked with moxxy. Message yourself in this chat (Note to Self) to talk to ' +
+              'the agent. Commands: /cancel aborts the current turn, /new resets the session.',
+          );
+        }
+      }
+      this.notifyConnectChange();
+      return;
+    }
+    if (update.connection === 'close') {
+      this.socketOpen = false;
+      this.notifyConnectChange();
+      if (this.stopping) return;
+      this.handleClose(disconnectStatusCode(update.lastDisconnect?.error));
+    }
+  }
+
+  private handleClose(code: number | null): void {
+    if (code === WA_DISCONNECT.loggedOut) {
+      // The phone unlinked this device — the stored creds are dead. Clear them
+      // (standard Baileys practice) and either re-open a QR pairing window
+      // (pair/dedicated mode) or stop with re-pair guidance.
+      this.opts.logger?.warn?.('whatsapp: logged out by the phone — clearing local credentials');
+      this.pairedAnnounced = false;
+      void this.storage
+        ?.clear()
+        .catch(() => undefined)
+        .then(() => this.opts.vault.delete(WHATSAPP_OWNER_JID_KEY).catch(() => undefined))
+        .then(() => {
+          if (this.pairMode) this.scheduleReconnect(0);
+          else {
+            this.fail(
+              'WhatsApp logged this device out. Run `moxxy channels whatsapp pair` to re-link ' +
+                '(check `moxxy channels whatsapp status`).',
+            );
+          }
+        });
+      return;
+    }
+    if (code === WA_DISCONNECT.connectionReplaced) {
+      this.fail(
+        'Another WhatsApp Web session replaced this one (440). Stop the other client, then restart the channel.',
+      );
+      return;
+    }
+    if (code === WA_DISCONNECT.forbidden) {
+      this.fail(
+        'WhatsApp refused the connection (403). The number may have been blocked or banned — ' +
+          'this is the documented risk of the unofficial API.',
+      );
+      return;
+    }
+    // restartRequired (515) is the NORMAL post-QR-scan handoff: reconnect
+    // immediately. Everything else retries with exponential backoff.
+    if (code === WA_DISCONNECT.restartRequired) {
+      this.scheduleReconnect(0);
+      return;
+    }
+    this.reconnectAttempts += 1;
+    const max = this.opts.maxReconnectAttempts ?? 5;
+    if (this.reconnectAttempts > max) {
+      this.fail(`whatsapp: giving up after ${max} consecutive reconnect attempts (last code: ${code ?? 'unknown'})`);
+      return;
+    }
+    const base = this.opts.reconnectBaseMs ?? 2000;
+    this.scheduleReconnect(base * 2 ** (this.reconnectAttempts - 1));
+  }
+
+  private scheduleReconnect(delayMs: number): void {
+    if (this.stopping) return;
+    this.socket = null;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.connect().catch((err: unknown) => {
+        this.fail(
+          `whatsapp: reconnect failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    }, delayMs);
+    this.reconnectTimer.unref?.();
+  }
+
+  private fail(message: string): void {
+    if (this.stopping) return;
+    this.opts.logger?.warn?.(message);
+    this.teardown(message);
+    this.rejectRunning?.(new Error(message));
+    this.resolveRunning = null;
+    this.rejectRunning = null;
+  }
+
+  private teardown(reason: string): void {
+    this.stopping = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    // Abort the in-flight turn FIRST so the model loop stops spending the
+    // moment the operator asks to shut down; then deny pending permission
+    // prompts so no caller hangs (the audit's TuiChannel.stop lesson).
+    this.turns.abort(reason);
+    this.permission.abortAll(reason);
+    this.permission.setSender(null);
+    this.logUnsub?.();
+    this.logUnsub = null;
+    this.qrPayload = null;
+    this.socketOpen = false;
+    this.socket?.end();
+    this.socket = null;
+  }
+
+  // ---- inbound --------------------------------------------------------------
+
+  private async handleInbound(upsertType: string, raw: WaInboundMessage): Promise<void> {
+    const verdict: GateVerdict = gateInboundMessage(
+      {
+        ownJid: this.ownerJid,
+        allowedJids: this.allowSet,
+        isOwnSend: (id) => this.sentIds.has(id),
+      },
+      upsertType,
+      raw,
+    );
+    if (!verdict.ok) {
+      // Silent drop (no reply): replying to unauthorized senders would leak
+      // the bot's existence and look like spam — both ban vectors.
+      this.opts.logger?.debug?.('whatsapp: dropped inbound', { reason: verdict.reason });
+      return;
+    }
+
+    if (verdict.kind === 'text') {
+      await this.handleText(verdict.jid, verdict.text);
+      return;
+    }
+    await this.handleAudio(verdict.jid, verdict.mimeType, raw);
+  }
+
+  private async handleText(jid: string, text: string): Promise<void> {
+    // A pending permission prompt captures the next short reply — BEFORE the
+    // busy guard, because prompts happen mid-turn by construction.
+    if (this.permission.hasPending() && this.permission.offerReply(text)) return;
+
+    if (text === '/cancel') {
+      const controller = this.turns.controller;
+      if (controller && !controller.signal.aborted) {
+        controller.abort('user cancel');
+        await this.send(jid, 'cancelling current turn…');
+      } else {
+        await this.send(jid, 'nothing to cancel.');
+      }
+      return;
+    }
+    if (text === '/new') {
+      await this.resetSession(jid);
+      return;
+    }
+    if (this.turns.busy) {
+      await this.send(jid, 'I am still working on the previous prompt. Send /cancel to abort it.');
+      return;
+    }
+    await this.runUserTurn(jid, text);
+  }
+
+  private async handleAudio(
+    jid: string,
+    mimeType: string,
+    raw: WaInboundMessage,
+  ): Promise<void> {
+    if (!this.session || !this.socket) return;
+    if (this.turns.busy) {
+      await this.send(jid, 'I am still working on the previous prompt. Send /cancel to abort it.');
+      return;
+    }
+    const transcript = await transcribeVoiceMessage(
+      {
+        session: this.session,
+        socket: this.socket,
+        reply: (j, t) => this.send(j, t),
+        ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+      },
+      { jid, mimeType, raw },
+    );
+    if (transcript) await this.runUserTurn(jid, transcript);
+  }
+
+  private async resetSession(jid: string): Promise<void> {
+    if (!this.session) return;
+    const controller = this.turns.controller;
+    if (controller && !controller.signal.aborted) controller.abort('user reset');
+    this.permission.abortAll('session reset');
+    // Wipe history at its source; a mirror-only clear would desync (A10).
+    try {
+      if (typeof this.session.reset === 'function') await this.session.reset();
+      else this.session.log.clear();
+    } catch (err) {
+      await this.send(
+        jid,
+        `/new failed: ${err instanceof Error ? err.message : String(err)} — history NOT cleared`,
+      );
+      return;
+    }
+    await this.send(jid, 'new session — conversation history cleared');
+  }
+
+  private async runUserTurn(jid: string, text: string): Promise<void> {
+    if (!this.session || !this.socket) return;
+    // Atomic single-flight: `begin` claims the slot synchronously so two
+    // concurrently dispatched messages can't interleave per-turn state. The
+    // turnId is minted here so the coordinator records it as an own-turn id
+    // (mirrorForeignTurn filters on those, invariant #8).
+    const lease = this.turns.begin(newTurnId());
+    if (!lease) {
+      await this.send(jid, 'I am still working on the previous prompt. Send /cancel to abort it.');
+      return;
+    }
+    this.currentJid = jid;
+    this.lastJid = jid;
+    try {
+      await runWhatsAppTurn(
+        {
+          session: this.session,
+          socket: this.socket,
+          editFrameMs: this.opts.editFrameMs ?? DEFAULT_EDIT_FRAME_MS,
+          recordSentId: (key) => this.recordSentId(key),
+          ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+        },
+        {
+          jid,
+          text,
+          model: this.model,
+          controller: lease.controller,
+          turnId: lease.turnId,
+        },
+      );
+    } finally {
+      lease.end();
+      this.currentJid = null;
+    }
+  }
+
+  // ---- outbound -------------------------------------------------------------
+
+  /** Every outbound send goes through here so its id lands in the echo set. */
+  private async send(jid: string, text: string): Promise<void> {
+    if (!this.socket) return;
+    try {
+      const sent = await this.socket.sendText(jid, text);
+      this.recordSentId(sent?.key);
+    } catch (err) {
+      this.opts.logger?.warn?.('whatsapp send failed', { err: String(err) });
+    }
+  }
+
+  private sendPermissionPrompt(text: string): Promise<void> {
+    const target = this.currentJid ?? this.lastJid ?? this.ownerJid;
+    if (!target) return Promise.reject(new Error('no chat to prompt in'));
+    return this.send(target, text);
+  }
+
+  private recordSentId(key: WaMessageKey | null | undefined): void {
+    const id = key?.id;
+    if (!id) return;
+    this.sentIds.add(id);
+    if (this.sentIds.size > MAX_SENT_IDS) {
+      const oldest = this.sentIds.values().next().value;
+      if (oldest !== undefined) this.sentIds.delete(oldest);
+    }
+  }
+
+  private mirrorForeignTurn(event: MoxxyEvent): void {
+    const text = this.turns.mirrorText(event);
+    if (text == null) return;
+    const target = this.lastJid ?? this.ownerJid;
+    if (!target) return;
+    void this.send(target, text);
+  }
+
+  // ---- listeners ------------------------------------------------------------
+
+  private notifyConnectChange(): void {
+    for (const listener of this.connectListeners) {
+      try {
+        listener();
+      } catch (err) {
+        this.opts.logger?.warn?.('whatsapp connect-change listener threw', { err: String(err) });
+      }
+    }
+  }
+
+  private emitPaired(ownerJid: string): void {
+    for (const listener of this.pairedListeners) {
+      try {
+        listener(ownerJid);
+      } catch (err) {
+        this.opts.logger?.warn?.('whatsapp paired listener threw', { err: String(err) });
+      }
+    }
+  }
+
+  private rebuildAllowList(extra: ReadonlyArray<string>): void {
+    this.allowSet.clear();
+    if (this.ownerJid) this.allowSet.add(this.ownerJid);
+    for (const jid of this.opts.allowedJids ?? []) {
+      const normalized = normalizeJid(jid);
+      if (normalized) this.allowSet.add(normalized);
+    }
+    for (const jid of extra) this.allowSet.add(jid);
+  }
+
+  /**
+   * Run a handler detached from the socket's event dispatch (a whole user turn
+   * must not block Baileys' event loop). Errors are logged here — nothing above
+   * awaits the promise.
+   */
+  private dispatchInBackground(work: Promise<void>, kind: string): void {
+    void work.catch((err: unknown) => {
+      this.opts.logger?.warn?.('whatsapp handler failed', { kind, err: String(err) });
+    });
+  }
+}

--- a/packages/plugin-channel-whatsapp/src/channel/turn-runner.test.ts
+++ b/packages/plugin-channel-whatsapp/src/channel/turn-runner.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  splitWhatsAppText,
+  WHATSAPP_MAX_MESSAGE_CHARS,
+} from './turn-runner.js';
+
+describe('splitWhatsAppText', () => {
+  it('returns a single chunk when under the cap', () => {
+    expect(splitWhatsAppText('hello')).toEqual(['hello']);
+  });
+
+  it('splits on newline boundaries when possible', () => {
+    const a = 'a'.repeat(30);
+    const b = 'b'.repeat(30);
+    const chunks = splitWhatsAppText(`${a}\n${b}`, 40);
+    expect(chunks).toEqual([a, b]);
+  });
+
+  it('never emits a chunk longer than maxLen', () => {
+    const text = 'x'.repeat(WHATSAPP_MAX_MESSAGE_CHARS * 2 + 123);
+    const chunks = splitWhatsAppText(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(WHATSAPP_MAX_MESSAGE_CHARS);
+    expect(chunks.join('')).toBe(text);
+  });
+
+  it('hard-splits a single word with no separators', () => {
+    const chunks = splitWhatsAppText('y'.repeat(90), 40);
+    expect(chunks.map((c) => c.length)).toEqual([40, 40, 10]);
+  });
+});

--- a/packages/plugin-channel-whatsapp/src/channel/turn-runner.ts
+++ b/packages/plugin-channel-whatsapp/src/channel/turn-runner.ts
@@ -1,0 +1,156 @@
+import type { newTurnId } from '@moxxy/core';
+import { FramePump, PlainTurnRenderer, driveTurn, subscribeTurn } from '@moxxy/channel-kit';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import type { WaMessageKey, WhatsAppSocket } from '../socket.js';
+
+/**
+ * Streaming strategy (justified against the Baileys API):
+ *
+ * WhatsApp supports true message edits (a MESSAGE_EDIT protocol send —
+ * `sendMessage(jid, { text, edit: key })`, stable in Baileys since 6.5), so the
+ * channel streams the way Telegram/Slack do: send ONE message on the first
+ * frame, then edit it in place — the user watches a single message grow instead
+ * of a flood of partials that can't be assembled. Two WhatsApp-specific
+ * adjustments:
+ *
+ *  - `editFrameMs` defaults to 3000 (vs 1000 elsewhere): every edit is a full
+ *    outbound protocol message, and high-frequency automated edits are exactly
+ *    the anomalous traffic that gets numbers flagged on an UNOFFICIAL client.
+ *    Fewer, chunkier edits keep the visible behavior close to a human editing
+ *    a message. (WhatsApp's ~15-minute edit window is irrelevant at turn scale.)
+ *
+ *  - overflow splitting happens ONLY on the final frame: while streaming, the
+ *    frame is truncated to {@link WHATSAPP_MAX_MESSAGE_CHARS}; the final flush
+ *    edits the streamed message to the first chunk and sends the tail chunks as
+ *    follow-up messages (mirrors Telegram's split-tails). If a FINAL edit fails
+ *    (edit rejected / message gone), the sink falls back to sending the chunks
+ *    as new messages so the reply is never silently lost.
+ */
+export const WHATSAPP_MAX_MESSAGE_CHARS = 4000;
+export const DEFAULT_EDIT_FRAME_MS = 3000;
+
+/** Split text into ≤maxLen chunks, preferring newline then space boundaries. */
+export function splitWhatsAppText(
+  text: string,
+  maxLen: number = WHATSAPP_MAX_MESSAGE_CHARS,
+): string[] {
+  if (text.length <= maxLen) return [text];
+  const chunks: string[] = [];
+  let rest = text;
+  while (rest.length > maxLen) {
+    const window = rest.slice(0, maxLen);
+    let cut = window.lastIndexOf('\n');
+    if (cut < maxLen * 0.5) cut = window.lastIndexOf(' ');
+    if (cut < maxLen * 0.5) cut = maxLen;
+    chunks.push(rest.slice(0, cut));
+    rest = rest.slice(cut).replace(/^[\n ]/, '');
+  }
+  if (rest.length > 0) chunks.push(rest);
+  return chunks;
+}
+
+export interface TurnRunnerLogger {
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface RunWhatsAppTurnDeps {
+  readonly session: Session;
+  readonly socket: WhatsAppSocket;
+  readonly editFrameMs: number;
+  /** Record an outbound message id (echo/loop protection in the gate). */
+  readonly recordSentId: (key: WaMessageKey | null | undefined) => void;
+  readonly logger?: TurnRunnerLogger;
+}
+
+export interface RunWhatsAppTurnOptions {
+  readonly jid: string;
+  readonly text: string;
+  readonly model?: string | undefined;
+  readonly controller: AbortController;
+  /** Pre-minted turn id; the channel records it as an own-turn id (#8). */
+  readonly turnId: ReturnType<typeof newTurnId>;
+}
+
+/**
+ * Drive a single WhatsApp turn end-to-end: subscribe the frame pump to THIS
+ * turn's events (turnId-filtered — `session.log` fans out to every listener, so
+ * a concurrent turn on the same Session would otherwise stream into this chat,
+ * AGENTS.md invariant #8), run the turn, flush the final frame, unwind in
+ * `finally`.
+ */
+export async function runWhatsAppTurn(
+  deps: RunWhatsAppTurnDeps,
+  opts: RunWhatsAppTurnOptions,
+): Promise<void> {
+  const { session, socket, editFrameMs, recordSentId, logger } = deps;
+  const { jid, text, model, controller, turnId } = opts;
+
+  const renderer = new PlainTurnRenderer();
+
+  const sendChunks = async (chunks: ReadonlyArray<string>): Promise<WaMessageKey | null> => {
+    let firstKey: WaMessageKey | null = null;
+    for (const chunk of chunks) {
+      try {
+        const sent = await socket.sendText(jid, chunk);
+        recordSentId(sent?.key);
+        if (!firstKey && sent?.key) firstKey = sent.key;
+      } catch (err) {
+        logger?.warn?.('whatsapp send failed', { err: String(err) });
+      }
+    }
+    return firstKey;
+  };
+
+  const pump = new FramePump<WaMessageKey>({
+    editFrameMs,
+    frame: (final) => {
+      const snapshot = renderer.snapshot();
+      if (final || snapshot.length <= WHATSAPP_MAX_MESSAGE_CHARS) return snapshot;
+      // Streaming frame: hold to one editable message; overflow waits for the
+      // final flush, whose full text differs from this so a last flush is
+      // guaranteed to deliver the tails.
+      return `${snapshot.slice(0, WHATSAPP_MAX_MESSAGE_CHARS - 1)}…`;
+    },
+    emptyFinalText: '(no output)',
+    sink: {
+      send: async (t) => sendChunks(splitWhatsAppText(t)),
+      edit: async (key, t, final) => {
+        const chunks = splitWhatsAppText(t);
+        try {
+          await socket.editText(jid, key, chunks[0]!);
+        } catch (err) {
+          logger?.warn?.('whatsapp edit failed', { err: String(err), final });
+          if (final) {
+            // Never lose the final reply to a failed edit — resend it whole.
+            await sendChunks(chunks);
+            return;
+          }
+          return;
+        }
+        if (final && chunks.length > 1) await sendChunks(chunks.slice(1));
+      },
+    },
+  });
+
+  const unsubscribe = subscribeTurn(session, turnId, (event) => {
+    if (renderer.accept(event)) pump.scheduleEdit();
+  });
+
+  try {
+    await driveTurn(session, {
+      turnId,
+      prompt: text,
+      ...(model ? { model } : {}),
+      signal: controller.signal,
+    });
+    await pump.flush(true);
+  } catch (err) {
+    logger?.warn?.('whatsapp turn failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    await sendChunks([`Turn failed: ${err instanceof Error ? err.message : String(err)}`]);
+  } finally {
+    unsubscribe();
+    pump.dispose();
+  }
+}

--- a/packages/plugin-channel-whatsapp/src/channel/voice-handler.ts
+++ b/packages/plugin-channel-whatsapp/src/channel/voice-handler.ts
@@ -1,0 +1,83 @@
+import type { ClientSession as Session } from '@moxxy/sdk';
+import { MAX_AUDIO_BYTES } from '../message-gate.js';
+import type { WaInboundMessage, WhatsAppSocket } from '../socket.js';
+
+export interface VoiceHandlerDeps {
+  readonly session: Session;
+  readonly socket: WhatsAppSocket;
+  /** Reply into the originating chat (records sent ids for echo protection). */
+  readonly reply: (jid: string, text: string) => Promise<void>;
+  readonly logger?: { warn?(msg: string, meta?: Record<string, unknown>): void };
+}
+
+export interface VoiceHandlerInput {
+  readonly jid: string;
+  readonly mimeType: string;
+  /** The raw upsert message — Baileys needs it to decrypt/download the media. */
+  readonly raw: WaInboundMessage;
+}
+
+/**
+ * Handle an inbound voice note / audio message that already passed the gate
+ * (pairing + allow-list + declared-size cap): require an active Transcriber
+ * (guidance reply when none — mirror of the Telegram voice handler), download
+ * via Baileys' media pipeline, re-check the size cap on the REAL bytes, then
+ * transcribe. Returns the transcript for the caller to run as a normal user
+ * turn, or null when the message was fully handled (guidance/error reply sent).
+ */
+export async function transcribeVoiceMessage(
+  deps: VoiceHandlerDeps,
+  input: VoiceHandlerInput,
+): Promise<string | null> {
+  const { session, socket, reply, logger } = deps;
+  const { jid, mimeType, raw } = input;
+
+  const transcriber = session.transcribers.tryGetActive();
+  if (!transcriber) {
+    await reply(
+      jid,
+      'Heard a voice note, but no speech-to-text backend is configured. Install ' +
+        '@moxxy/plugin-stt-whisper and run `moxxy login openai` (or set OPENAI_API_KEY) ' +
+        'to enable voice input.',
+    );
+    return null;
+  }
+
+  let bytes: Uint8Array;
+  try {
+    bytes = await socket.downloadMedia(raw);
+  } catch (err) {
+    logger?.warn?.('whatsapp voice download failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    await reply(jid, 'Could not download that voice note.');
+    return null;
+  }
+  if (bytes.byteLength > MAX_AUDIO_BYTES) {
+    await reply(
+      jid,
+      `That audio is too large to transcribe (limit ${MAX_AUDIO_BYTES / (1024 * 1024)}MB).`,
+    );
+    return null;
+  }
+
+  let transcript: string;
+  try {
+    transcript = (await transcriber.transcribe(bytes, { mimeType })).text.trim();
+  } catch (err) {
+    logger?.warn?.('whatsapp voice transcription failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    await reply(jid, `Transcription failed: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
+  if (!transcript) {
+    await reply(jid, 'Could not transcribe the voice note (got empty text).');
+    return null;
+  }
+
+  // Echo what was heard so the user can spot misrecognitions before the agent
+  // acts on it (same contract as the Telegram voice handler).
+  await reply(jid, `heard: ${transcript}`);
+  return transcript;
+}

--- a/packages/plugin-channel-whatsapp/src/consent-prompt.ts
+++ b/packages/plugin-channel-whatsapp/src/consent-prompt.ts
@@ -1,0 +1,28 @@
+import { isCancel, log, note, text } from '@clack/prompts';
+import { CONSENT_WARNING, hasConsent, recordConsent, type ConsentVault } from './consent.js';
+
+/**
+ * The interactive consent gate — the FIRST step of every setup surface. Shows
+ * the unofficial-API warning and requires a literally typed "yes" before
+ * anything else may happen; anything less refuses. Returns true only when the
+ * risk is (or already was) acknowledged.
+ */
+export async function ensureConsentInteractive(vault: ConsentVault): Promise<boolean> {
+  if (await hasConsent(vault)) {
+    // Already acknowledged — keep the reminder visible but don't re-demand typing.
+    log.warn('Reminder: unofficial WhatsApp API — the linked number can be banned.');
+    return true;
+  }
+  note(CONSENT_WARNING, 'READ THIS FIRST');
+  const answer = await text({
+    message: "Type 'yes' to acknowledge the risk and continue (anything else aborts)",
+    placeholder: 'yes',
+  });
+  if (isCancel(answer) || String(answer).trim().toLowerCase() !== 'yes') {
+    log.error('Not acknowledged — leaving the WhatsApp channel disarmed.');
+    return false;
+  }
+  await recordConsent(vault);
+  log.success('Acknowledgment recorded.');
+  return true;
+}

--- a/packages/plugin-channel-whatsapp/src/consent.test.ts
+++ b/packages/plugin-channel-whatsapp/src/consent.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { WHATSAPP_CONSENT_ENV, WHATSAPP_CONSENT_KEY } from './keys.js';
+import { hasConsent, recordConsent, type ConsentVault } from './consent.js';
+
+function fakeVault(initial: Record<string, string> = {}): ConsentVault & {
+  store: Record<string, string>;
+} {
+  const store = { ...initial };
+  return {
+    store,
+    async get(name) {
+      return store[name] ?? null;
+    },
+    async set(name, value) {
+      store[name] = value;
+    },
+  };
+}
+
+afterEach(() => {
+  delete process.env[WHATSAPP_CONSENT_ENV];
+});
+
+describe('consent gate', () => {
+  it('is false with no receipt and no env override', async () => {
+    expect(await hasConsent(fakeVault())).toBe(false);
+    expect(await hasConsent(undefined)).toBe(false);
+  });
+
+  it('honors the env override even without a vault', async () => {
+    process.env[WHATSAPP_CONSENT_ENV] = 'yes';
+    expect(await hasConsent(undefined)).toBe(true);
+  });
+
+  it('does NOT accept a "no" env value', async () => {
+    process.env[WHATSAPP_CONSENT_ENV] = 'no';
+    expect(await hasConsent(fakeVault())).toBe(false);
+  });
+
+  it('accepts a recorded vault receipt', async () => {
+    const vault = fakeVault();
+    await recordConsent(vault);
+    expect(vault.store[WHATSAPP_CONSENT_KEY]).toMatch(/^acknowledged@/);
+    expect(await hasConsent(vault)).toBe(true);
+  });
+
+  it('treats a vault read error as no consent', async () => {
+    const vault: ConsentVault = {
+      async get() {
+        throw new Error('vault locked');
+      },
+      async set() {},
+    };
+    expect(await hasConsent(vault)).toBe(false);
+  });
+});

--- a/packages/plugin-channel-whatsapp/src/consent.ts
+++ b/packages/plugin-channel-whatsapp/src/consent.ts
@@ -1,0 +1,48 @@
+import { WHATSAPP_CONSENT_ENV, WHATSAPP_CONSENT_KEY, isConsentValue } from './keys.js';
+
+/** The read/write vault slice the consent gate needs. */
+export interface ConsentVault {
+  get(name: string): Promise<string | null>;
+  set(name: string, value: string, tags?: ReadonlyArray<string>): Promise<void>;
+}
+
+/**
+ * The non-negotiable warning shown as the FIRST step of every setup path.
+ * Baileys speaks the WhatsApp Web protocol without WhatsApp's blessing;
+ * users must opt in to that risk explicitly before anything else happens.
+ */
+export const CONSENT_WARNING =
+  'This channel uses Baileys, an UNOFFICIAL WhatsApp Web client.\n' +
+  '\n' +
+  '  - Automating an account this way violates WhatsApp\'s Terms of Service.\n' +
+  '  - WhatsApp actively detects unofficial clients and CAN PERMANENTLY BAN\n' +
+  '    the phone number — without warning and without appeal.\n' +
+  '  - Strongly consider linking a SECONDARY number, not your personal one.\n' +
+  '\n' +
+  'moxxy cannot make this safe; it can only make it explicit.';
+
+/** One-line refusal used by every path that hits the gate un-acknowledged. */
+export const CONSENT_REQUIRED_MESSAGE =
+  'WhatsApp channel not acknowledged: it relies on an unofficial API that violates ' +
+  "WhatsApp's ToS and can get the number banned. Run `moxxy whatsapp setup` and type " +
+  `'yes' to accept that risk (or set ${WHATSAPP_CONSENT_ENV}=yes for headless runs).`;
+
+/**
+ * Whether the operator has acknowledged the ToS/ban risk. Env override first
+ * (headless/dedicated runners), then the vault receipt written by the wizard or
+ * the desktop config panel. Vault errors (locked/unavailable) count as "no".
+ */
+export async function hasConsent(vault: ConsentVault | undefined): Promise<boolean> {
+  if (isConsentValue(process.env[WHATSAPP_CONSENT_ENV])) return true;
+  if (!vault) return false;
+  try {
+    return isConsentValue(await vault.get(WHATSAPP_CONSENT_KEY));
+  } catch {
+    return false;
+  }
+}
+
+/** Persist the wizard's typed acknowledgment as a dated receipt. */
+export async function recordConsent(vault: ConsentVault): Promise<void> {
+  await vault.set(WHATSAPP_CONSENT_KEY, `acknowledged@${new Date().toISOString()}`, ['whatsapp']);
+}

--- a/packages/plugin-channel-whatsapp/src/index.ts
+++ b/packages/plugin-channel-whatsapp/src/index.ts
@@ -1,0 +1,284 @@
+import { defineChannel, definePlugin, type LifecycleHooks, type Plugin } from '@moxxy/sdk';
+import { moxxyPath } from '@moxxy/sdk/server';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { createFileAuthStorage, hasStoredCreds } from './auth-state.js';
+import { WhatsAppChannel, type WhatsAppChannelOptions } from './channel.js';
+import { CONSENT_REQUIRED_MESSAGE, hasConsent } from './consent.js';
+import {
+  WHATSAPP_ALLOWED_JIDS_KEY,
+  WHATSAPP_AUTH_DIR,
+  WHATSAPP_CONSENT_KEY,
+  WHATSAPP_OWNER_JID_KEY,
+  parseAllowedJids,
+} from './keys.js';
+import { runWhatsAppWizard, unpairLocal } from './setup-wizard.js';
+import { runWhatsAppPairFlow } from './pair-flow.js';
+
+export { WhatsAppChannel, type WhatsAppChannelOptions, type WhatsAppStartOpts } from './channel.js';
+export {
+  createWhatsAppPermissionController,
+  parsePermissionReply,
+  formatPermissionPrompt,
+  type WhatsAppPermissionController,
+} from './permission.js';
+export {
+  createFileAuthStorage,
+  createWhatsAppAuthState,
+  hasStoredCreds,
+  sanitizeAuthKey,
+  type WhatsAppAuthStorage,
+  type BaileysAuthBridge,
+} from './auth-state.js';
+export {
+  gateInboundMessage,
+  MAX_AUDIO_BYTES,
+  MAX_TEXT_CHARS,
+  type GateVerdict,
+} from './message-gate.js';
+export {
+  runWhatsAppTurn,
+  splitWhatsAppText,
+  WHATSAPP_MAX_MESSAGE_CHARS,
+} from './channel/turn-runner.js';
+export { CONSENT_WARNING, CONSENT_REQUIRED_MESSAGE, hasConsent, recordConsent } from './consent.js';
+export {
+  WHATSAPP_CONSENT_KEY,
+  WHATSAPP_OWNER_JID_KEY,
+  WHATSAPP_ALLOWED_JIDS_KEY,
+  WHATSAPP_CONSENT_ENV,
+  WHATSAPP_AUTH_DIR,
+  normalizeJid,
+  parseAllowedJids,
+  isConsentValue,
+} from './keys.js';
+export {
+  disconnectStatusCode,
+  WA_DISCONNECT,
+  type WhatsAppSocket,
+  type WhatsAppSocketFactory,
+} from './socket.js';
+
+export interface BuildWhatsAppPluginOptions {
+  /** Host-injected encrypted secret store (available immediately). */
+  readonly vault: VaultStore;
+}
+
+/** Build the WhatsApp channel plugin with a host-injected vault (mirrors the
+ *  Telegram/Slack plugins' dual-export pattern). */
+export function buildWhatsAppPlugin(opts: BuildWhatsAppPluginOptions): Plugin {
+  return makeWhatsAppPlugin(() => opts.vault);
+}
+
+/**
+ * Discovery-loadable default export: resolves the vault from the inter-plugin
+ * service registry in `onInit` (the vault plugin publishes `'vault'`). Requires
+ * `@moxxy/plugin-vault` to load first (declared in `package.json`
+ * `moxxy.requirements`).
+ */
+export const whatsappPlugin: Plugin = (() => {
+  let resolved: VaultStore | null = null;
+  const getVault = (): VaultStore => {
+    if (!resolved) {
+      throw new Error(
+        '@moxxy/plugin-channel-whatsapp: the "vault" service is unavailable — @moxxy/plugin-vault must load first',
+      );
+    }
+    return resolved;
+  };
+  const hooks: LifecycleHooks = {
+    onInit: (ctx) => {
+      resolved = ctx.services.require<VaultStore>('vault');
+    },
+  };
+  return makeWhatsAppPlugin(getVault, hooks);
+})();
+
+export default whatsappPlugin;
+
+function readAllowedJids(options: Record<string, unknown> | undefined): string[] | undefined {
+  const raw = options?.['allowedJids'];
+  if (Array.isArray(raw)) return raw.map((x) => String(x));
+  if (typeof raw === 'string' && raw.trim().length > 0) return parseAllowedJids(raw);
+  return undefined;
+}
+
+function makeWhatsAppPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks): Plugin {
+  return definePlugin({
+    name: '@moxxy/plugin-channel-whatsapp',
+    version: '0.0.0',
+    ...(hooks ? { hooks } : {}),
+    channels: [
+      defineChannel({
+        name: 'whatsapp',
+        description:
+          'WhatsApp channel via Baileys — UNOFFICIAL API (violates WhatsApp ToS; the number ' +
+          'can be banned — use a secondary number). QR device-link pairing, JID allow-list.',
+        // Like Slack/Telegram: its own dedicated, isolated runner (separate
+        // socket + sticky session) so the bot keeps a persistent history apart
+        // from the user's desktop/TUI work. Baileys is an outbound WebSocket —
+        // no tunnel, no tunnelProvider registration.
+        dedicatedRunner: true,
+        sessionSource: 'whatsapp',
+        config: {
+          fields: [
+            {
+              name: 'tosAcknowledged',
+              label: "Risk acknowledgment — type 'yes'",
+              vaultKey: WHATSAPP_CONSENT_KEY,
+              required: true,
+              help:
+                'Unofficial WhatsApp API: violates the ToS and can get the number banned. ' +
+                "Typing anything other than 'yes' keeps the channel disarmed.",
+            },
+            {
+              name: 'allowedJids',
+              label: 'Extra allowed JIDs (comma-separated)',
+              vaultKey: WHATSAPP_ALLOWED_JIDS_KEY,
+              required: false,
+              placeholder: '15551234567@s.whatsapp.net',
+              help: 'Your own Note-to-Self chat is always allowed once linked.',
+            },
+          ],
+          hasRequestUrl: false,
+          runHint:
+            'On your phone: WhatsApp -> Settings -> Linked devices -> Link a device, then scan the QR.',
+          connect: {
+            kind: 'qr',
+            title: 'Link WhatsApp',
+            hint:
+              'Scan with the phone that owns the account: WhatsApp -> Settings -> Linked devices ' +
+              '-> Link a device. The QR refreshes periodically until scanned.',
+          },
+        },
+        create: (deps) => {
+          const options = deps.options;
+          const allowedJids = readAllowedJids(options);
+          const editFrameMs = options?.['editFrameMs'];
+          const channelOpts: WhatsAppChannelOptions = {
+            vault: getVault(),
+            ...(allowedJids ? { allowedJids } : {}),
+            ...(typeof editFrameMs === 'number' ? { editFrameMs } : {}),
+            logger: deps.logger as never,
+          };
+          return new WhatsAppChannel(channelOpts);
+        },
+        isAvailable: async () => {
+          // Cheap probes only: one vault read + one stat-shaped file read.
+          let consent = false;
+          try {
+            consent = await hasConsent(getVault());
+          } catch {
+            // Vault unavailable in a probe/listing context; the env override
+            // inside hasConsent(undefined) still counts.
+            consent = await hasConsent(undefined);
+          }
+          if (!consent) return { ok: false, reason: CONSENT_REQUIRED_MESSAGE };
+          const linked = await hasStoredCreds(
+            createFileAuthStorage(moxxyPath(WHATSAPP_AUTH_DIR)),
+          );
+          if (!linked) {
+            return {
+              ok: false,
+              reason:
+                'No WhatsApp account linked (or the phone logged this device out). Run ' +
+                '`moxxy channels whatsapp pair` to scan the QR.',
+            };
+          }
+          return { ok: true };
+        },
+        interactiveCommand: 'setup',
+        subcommands: {
+          setup: {
+            description:
+              'Interactive setup: acknowledge the unofficial-API risk (required first step), ' +
+              'link via QR, manage the allow-list, then start. Shown by default for ' +
+              '`moxxy whatsapp` on a TTY.',
+            run: async (ctx) => {
+              if (process.stdin.isTTY !== true) {
+                // Headless: the consent gate still holds — start refuses without
+                // an acknowledgment (vault receipt or MOXXY_WHATSAPP_TOS_ACK).
+                const vault = ctx.deps.vault as VaultStore | undefined;
+                if (!(await hasConsent(vault))) {
+                  process.stderr.write(`${CONSENT_REQUIRED_MESSAGE}\n`);
+                  return 1;
+                }
+                return ctx.startChannel();
+              }
+              return runWhatsAppWizard(ctx);
+            },
+          },
+          pair: {
+            description:
+              'Link a WhatsApp account: renders the rotating QR in the terminal; scan it from ' +
+              'WhatsApp -> Settings -> Linked devices. Requires the typed risk acknowledgment.',
+            run: async (ctx) => {
+              if (process.stdin.isTTY !== true) {
+                process.stderr.write(
+                  'Pairing needs a TTY to show the QR. Run `moxxy channels whatsapp pair` on a ' +
+                    'workstation, or pair from the desktop Channels panel.\n',
+                );
+                return 1;
+              }
+              return runWhatsAppPairFlow(ctx);
+            },
+          },
+          status: {
+            description:
+              'Report consent/link/allow-list state as JSON (with re-pair guidance after a logout).',
+            run: async (ctx) => {
+              const vault = ctx.deps.vault as VaultStore | undefined;
+              if (!vault) {
+                process.stderr.write('vault unavailable\n');
+                return 1;
+              }
+              const consentAcknowledged = await hasConsent(vault);
+              const linked = await hasStoredCreds(
+                createFileAuthStorage(moxxyPath(WHATSAPP_AUTH_DIR)),
+              );
+              const ownerJid = await vault.get(WHATSAPP_OWNER_JID_KEY);
+              const allowedJids = parseAllowedJids(await vault.get(WHATSAPP_ALLOWED_JIDS_KEY));
+              const state = !consentAcknowledged
+                ? 'needs-consent'
+                : !linked
+                  ? 'needs-pairing'
+                  : 'ready';
+              const guidance = !consentAcknowledged
+                ? 'Run `moxxy whatsapp setup` and type yes to acknowledge the unofficial-API risk.'
+                : !linked
+                  ? ownerJid
+                    ? 'The phone logged this device out (or credentials were cleared) — run `moxxy channels whatsapp pair` to re-link.'
+                    : 'Run `moxxy channels whatsapp pair` to link an account.'
+                  : null;
+              process.stdout.write(
+                JSON.stringify(
+                  { state, consentAcknowledged, linked, ownerJid, allowedJids, guidance },
+                  null,
+                  2,
+                ) + '\n',
+              );
+              return 0;
+            },
+          },
+          unpair: {
+            description:
+              'Forget the local WhatsApp credentials (also remove the device on the phone under Linked devices).',
+            run: async (ctx) => {
+              const vault = ctx.deps.vault as VaultStore | undefined;
+              if (!vault) {
+                process.stderr.write('vault unavailable\n');
+                return 1;
+              }
+              const removed = await unpairLocal(vault);
+              process.stdout.write(
+                removed
+                  ? 'unpaired — also remove the device on your phone: WhatsApp -> Settings -> Linked devices\n'
+                  : 'no linked account was stored\n',
+              );
+              return 0;
+            },
+          },
+        },
+      }),
+    ],
+  });
+}

--- a/packages/plugin-channel-whatsapp/src/keys.test.ts
+++ b/packages/plugin-channel-whatsapp/src/keys.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { isConsentValue, normalizeJid, parseAllowedJids } from './keys.js';
+
+describe('normalizeJid', () => {
+  it('strips device + agent suffixes off the user part', () => {
+    expect(normalizeJid('15551234567:12@s.whatsapp.net')).toBe('15551234567@s.whatsapp.net');
+    expect(normalizeJid('15551234567_1:3@s.whatsapp.net')).toBe('15551234567@s.whatsapp.net');
+  });
+
+  it('lowercases the server and keeps a bare jid', () => {
+    expect(normalizeJid('15551234567@S.Whatsapp.Net')).toBe('15551234567@s.whatsapp.net');
+    expect(normalizeJid('12345@g.us')).toBe('12345@g.us');
+  });
+
+  it('rejects garbage and malformed values', () => {
+    expect(normalizeJid('')).toBeNull();
+    expect(normalizeJid('   ')).toBeNull();
+    expect(normalizeJid('nope')).toBeNull();
+    expect(normalizeJid('@s.whatsapp.net')).toBeNull();
+    expect(normalizeJid('a@@b')).toBeNull();
+    expect(normalizeJid('u@bad server')).toBeNull();
+    expect(normalizeJid(null)).toBeNull();
+    expect(normalizeJid(undefined)).toBeNull();
+  });
+});
+
+describe('parseAllowedJids', () => {
+  it('parses comma/space-separated JIDs and de-dupes/normalizes', () => {
+    expect(parseAllowedJids('15551234567@s.whatsapp.net, 15551234567:9@s.whatsapp.net')).toEqual([
+      '15551234567@s.whatsapp.net',
+    ]);
+    expect(parseAllowedJids('a@g.us b@g.us')).toEqual(['a@g.us', 'b@g.us']);
+  });
+
+  it('parses a JSON array and drops non-JIDs', () => {
+    expect(parseAllowedJids('["1@s.whatsapp.net", "garbage", 42]')).toEqual(['1@s.whatsapp.net']);
+  });
+
+  it('returns [] for empty / broken input', () => {
+    expect(parseAllowedJids(null)).toEqual([]);
+    expect(parseAllowedJids('')).toEqual([]);
+    expect(parseAllowedJids('[not json')).toEqual([]);
+  });
+});
+
+describe('isConsentValue', () => {
+  it('accepts an explicit yes or a dated receipt', () => {
+    expect(isConsentValue('yes')).toBe(true);
+    expect(isConsentValue('YES')).toBe(true);
+    expect(isConsentValue('acknowledged@2026-07-03T00:00:00.000Z')).toBe(true);
+  });
+
+  it('rejects anything else', () => {
+    expect(isConsentValue('no')).toBe(false);
+    expect(isConsentValue('')).toBe(false);
+    expect(isConsentValue(null)).toBe(false);
+    expect(isConsentValue('maybe')).toBe(false);
+  });
+});

--- a/packages/plugin-channel-whatsapp/src/keys.ts
+++ b/packages/plugin-channel-whatsapp/src/keys.ts
@@ -1,0 +1,78 @@
+/**
+ * Vault keys + pure JID helpers shared by the channel, its subcommands, and the
+ * interactive setup wizard. Kept in their own module so the wizard / pair-flow
+ * helpers can import them without pulling in the plugin's full index (or, worse,
+ * Baileys — which stays behind a lazy import in `baileys-socket.ts`).
+ */
+
+/** Vault key holding the user's typed acknowledgment of the ToS/ban risk. */
+export const WHATSAPP_CONSENT_KEY = 'whatsapp_tos_acknowledged';
+/** Vault key holding the linked account's own (normalized) JID. */
+export const WHATSAPP_OWNER_JID_KEY = 'whatsapp_owner_jid';
+/** Vault key holding extra allow-listed JIDs (JSON array or comma-separated). */
+export const WHATSAPP_ALLOWED_JIDS_KEY = 'whatsapp_allowed_jids';
+/** Env override for the consent gate (headless/dedicated runners). */
+export const WHATSAPP_CONSENT_ENV = 'MOXXY_WHATSAPP_TOS_ACK';
+/** Directory (under the moxxy home) holding the rotating Baileys auth state. */
+export const WHATSAPP_AUTH_DIR = 'whatsapp-auth';
+
+/**
+ * Normalize a WhatsApp JID for identity comparison: the user part of a
+ * multi-device JID carries `:device` (and historically `_agent`) suffixes that
+ * vary per login (`1234567890:12@s.whatsapp.net`), so equality checks must
+ * compare the bare `user@server` form. Returns null for values that don't look
+ * like a JID at all, so callers treat garbage as "no identity" instead of
+ * silently allow-listing it.
+ */
+export function normalizeJid(raw: string | null | undefined): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0 || trimmed.length > 256) return null;
+  const at = trimmed.indexOf('@');
+  if (at <= 0 || at !== trimmed.lastIndexOf('@')) return null;
+  const server = trimmed.slice(at + 1).toLowerCase();
+  if (!/^[a-z0-9.-]+$/.test(server)) return null;
+  // Strip the device (`:NN`) and legacy agent (`_N`) suffixes off the user part.
+  const user = trimmed.slice(0, at).split(':')[0]!.split('_')[0]!;
+  if (user.length === 0) return null;
+  return `${user}@${server}`;
+}
+
+/**
+ * Parse a stored/configured allow-list. Accepts a JSON string array or a
+ * comma/whitespace-separated string; every entry is normalized and non-JIDs are
+ * dropped (never silently allow-listed). Returns a de-duplicated array.
+ */
+export function parseAllowedJids(raw: string | null | undefined): string[] {
+  if (raw == null) return [];
+  let entries: unknown[] = [];
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) entries = parsed;
+    } catch {
+      return [];
+    }
+  } else {
+    entries = trimmed.split(/[,\s]+/);
+  }
+  const out = new Set<string>();
+  for (const entry of entries) {
+    const jid = normalizeJid(typeof entry === 'string' ? entry : null);
+    if (jid) out.add(jid);
+  }
+  return [...out];
+}
+
+/**
+ * Whether a stored consent value counts as an actual acknowledgment. The setup
+ * wizard stores `acknowledged@<ISO date>`; the desktop panel / `moxxy init`
+ * declarative field stores whatever the user typed — only an affirmative "yes"
+ * counts, so typing "no" into the form does NOT arm the channel.
+ */
+export function isConsentValue(raw: string | null | undefined): boolean {
+  if (typeof raw !== 'string') return false;
+  const v = raw.trim().toLowerCase();
+  return v === 'yes' || v.startsWith('acknowledged@');
+}

--- a/packages/plugin-channel-whatsapp/src/message-gate.test.ts
+++ b/packages/plugin-channel-whatsapp/src/message-gate.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { gateInboundMessage, MAX_TEXT_CHARS, type GateState } from './message-gate.js';
+import type { WaInboundMessage } from './socket.js';
+
+const OWNER = '15550000000@s.whatsapp.net';
+const FRIEND = '15551111111@s.whatsapp.net';
+const STRANGER = '15559999999@s.whatsapp.net';
+
+function state(overrides: Partial<GateState> = {}): GateState {
+  return {
+    ownJid: OWNER,
+    allowedJids: new Set([OWNER, FRIEND]),
+    isOwnSend: () => false,
+    ...overrides,
+  };
+}
+
+function textMsg(remoteJid: string, text: string, fromMe = false, id = 'm1'): WaInboundMessage {
+  return { key: { remoteJid, fromMe, id }, message: { conversation: text } };
+}
+
+describe('gateInboundMessage', () => {
+  it('accepts an allow-listed sender text message', () => {
+    const v = gateInboundMessage(state(), 'notify', textMsg(FRIEND, 'hi there'));
+    expect(v).toEqual({ ok: true, kind: 'text', jid: FRIEND, text: 'hi there' });
+  });
+
+  it("accepts the owner's own Note-to-Self message (fromMe in own chat)", () => {
+    const v = gateInboundMessage(state(), 'notify', textMsg(OWNER, 'note to self', true));
+    expect(v.ok && v.kind === 'text' && v.jid).toBe(OWNER);
+  });
+
+  it('drops a fromMe message in a FOREIGN chat (owner talking to others)', () => {
+    const v = gateInboundMessage(state(), 'notify', textMsg(FRIEND, 'private reply', true));
+    expect(v).toEqual({ ok: false, reason: 'own message in a foreign chat' });
+  });
+
+  it("drops the bot's OWN outbound echo by message id (loop protection)", () => {
+    const st = state({ isOwnSend: (id) => id === 'echo-1' });
+    const v = gateInboundMessage(st, 'notify', textMsg(FRIEND, 'my own send', false, 'echo-1'));
+    expect(v).toEqual({ ok: false, reason: 'own outbound echo' });
+  });
+
+  it('drops an un-allow-listed sender', () => {
+    const v = gateInboundMessage(state(), 'notify', textMsg(STRANGER, 'let me in'));
+    expect(v).toEqual({ ok: false, reason: 'sender not allow-listed' });
+  });
+
+  it('drops non-notify upserts (history sync / append)', () => {
+    expect(gateInboundMessage(state(), 'append', textMsg(FRIEND, 'x')).ok).toBe(false);
+    expect(gateInboundMessage(state(), 'history', textMsg(FRIEND, 'x')).ok).toBe(false);
+  });
+
+  it('drops status broadcasts', () => {
+    const v = gateInboundMessage(state(), 'notify', textMsg('status@broadcast', 'x'));
+    expect(v.ok).toBe(false);
+  });
+
+  it('validates the key shape (missing remoteJid rejected)', () => {
+    const v = gateInboundMessage(state(), 'notify', { key: { fromMe: false }, message: { conversation: 'x' } });
+    expect(v).toEqual({ ok: false, reason: 'invalid message key shape' });
+  });
+
+  it('caps oversized text', () => {
+    const big = 'a'.repeat(MAX_TEXT_CHARS + 1);
+    const v = gateInboundMessage(state(), 'notify', textMsg(FRIEND, big));
+    expect(v).toEqual({ ok: false, reason: 'text over size cap' });
+  });
+
+  it('unwraps ephemeral + extendedText messages', () => {
+    const msg: WaInboundMessage = {
+      key: { remoteJid: FRIEND, fromMe: false, id: 'e1' },
+      message: {
+        ephemeralMessage: { message: { extendedTextMessage: { text: 'ephemeral hi' } } },
+      },
+    };
+    const v = gateInboundMessage(state(), 'notify', msg);
+    expect(v).toEqual({ ok: true, kind: 'text', jid: FRIEND, text: 'ephemeral hi' });
+  });
+
+  it('accepts a voice/audio message and reports mime + declared size', () => {
+    const msg: WaInboundMessage = {
+      key: { remoteJid: FRIEND, fromMe: false, id: 'a1' },
+      message: { audioMessage: { mimetype: 'audio/ogg; codecs=opus', fileLength: '2048', ptt: true } },
+    };
+    const v = gateInboundMessage(state(), 'notify', msg);
+    expect(v).toEqual({
+      ok: true,
+      kind: 'audio',
+      jid: FRIEND,
+      mimeType: 'audio/ogg; codecs=opus',
+      declaredBytes: 2048,
+    });
+  });
+
+  it('rejects an audio message whose declared size exceeds the cap', () => {
+    const msg: WaInboundMessage = {
+      key: { remoteJid: FRIEND, fromMe: false, id: 'a2' },
+      message: { audioMessage: { mimetype: 'audio/ogg', fileLength: 999_999_999 } },
+    };
+    const v = gateInboundMessage(state(), 'notify', msg);
+    expect(v).toEqual({ ok: false, reason: 'audio over size cap' });
+  });
+
+  it('drops empty/unsupported content', () => {
+    expect(gateInboundMessage(state(), 'notify', textMsg(FRIEND, '   ')).ok).toBe(false);
+    const image: WaInboundMessage = {
+      key: { remoteJid: FRIEND, fromMe: false, id: 'i1' },
+      message: { imageMessage: { url: 'x' } },
+    };
+    expect(gateInboundMessage(state(), 'notify', image)).toEqual({
+      ok: false,
+      reason: 'unsupported message type',
+    });
+  });
+
+  it('drops a fromMe self-chat message when ownJid is not yet known', () => {
+    const v = gateInboundMessage(state({ ownJid: null }), 'notify', textMsg(OWNER, 'x', true));
+    expect(v).toEqual({ ok: false, reason: 'own message in a foreign chat' });
+  });
+});

--- a/packages/plugin-channel-whatsapp/src/message-gate.ts
+++ b/packages/plugin-channel-whatsapp/src/message-gate.ts
@@ -1,0 +1,184 @@
+import { z } from 'zod';
+import { normalizeJid } from './keys.js';
+import type { WaInboundMessage } from './socket.js';
+
+/**
+ * The single inbound gate every session-reaching path goes through (AGENTS.md:
+ * gate EVERY session-reaching path behind pairing; A8: zod-validate inbound
+ * before it touches the session). Pure — the channel feeds it the message plus
+ * its identity/allow-list state and branches on the verdict.
+ *
+ * Order of checks (each is load-bearing):
+ *  1. only `notify` upserts — history syncs / appends are not fresh input.
+ *  2. shape-validate + size-cap the consumed fields (zod).
+ *  3. drop own echoes: Baileys receives this client's OWN outbound sends back
+ *     via `messages.upsert`; without the sent-id check the bot replies to
+ *     itself in a loop.
+ *  4. drop `fromMe` messages outside the owner's self-chat ("Note to Self"):
+ *     those are the owner talking to OTHER people from their phone — the bot
+ *     must never treat someone's private conversation as a prompt.
+ *  5. allow-list by normalized JID: the owner's self-chat is allowed by
+ *     default (seeded by the channel); everything else must be explicitly
+ *     allow-listed. Unauthorized senders are dropped SILENTLY — replying would
+ *     both leak the bot's existence and look like spam (ban risk).
+ */
+
+/** Cap on inbound prompt text (WhatsApp itself allows ~65k). */
+export const MAX_TEXT_CHARS = 16_000;
+/** Cap on a voice note / audio file we will download + buffer for transcription. */
+export const MAX_AUDIO_BYTES = 20 * 1024 * 1024;
+
+const keySchema = z.object({
+  remoteJid: z.string().min(1).max(256),
+  fromMe: z.boolean().nullish(),
+  id: z.string().min(1).max(256).nullish(),
+});
+
+const audioMessageSchema = z.object({
+  mimetype: z.string().max(256).nullish(),
+  fileLength: z.union([z.number(), z.string(), z.object({}).passthrough()]).nullish(),
+  seconds: z.number().nullish(),
+  ptt: z.boolean().nullish(),
+});
+
+export type GateVerdict =
+  | { readonly ok: false; readonly reason: string }
+  | { readonly ok: true; readonly kind: 'text'; readonly jid: string; readonly text: string }
+  | {
+      readonly ok: true;
+      readonly kind: 'audio';
+      readonly jid: string;
+      readonly mimeType: string;
+      readonly declaredBytes: number | null;
+    };
+
+export interface GateState {
+  /** The linked account's own normalized JID (null until the socket opens). */
+  readonly ownJid: string | null;
+  /** Normalized JIDs allowed to drive the session (includes ownJid). */
+  readonly allowedJids: ReadonlySet<string>;
+  /** Message ids of THIS client's own recent sends (echo/loop protection). */
+  readonly isOwnSend: (messageId: string) => boolean;
+}
+
+export function gateInboundMessage(
+  state: GateState,
+  upsertType: string,
+  raw: WaInboundMessage,
+): GateVerdict {
+  if (upsertType !== 'notify') return drop('not a live notify upsert');
+
+  const key = keySchema.safeParse(raw?.key ?? {});
+  if (!key.success) return drop('invalid message key shape');
+  const { remoteJid, fromMe, id } = key.data;
+  if (remoteJid === 'status@broadcast') return drop('status broadcast');
+
+  const jid = normalizeJid(remoteJid);
+  if (!jid) return drop('unparseable chat JID');
+
+  if (id && state.isOwnSend(id)) return drop('own outbound echo');
+
+  if (fromMe) {
+    // Same-account messages: only the owner's self-chat is a prompt surface.
+    if (state.ownJid == null || jid !== state.ownJid) {
+      return drop('own message in a foreign chat');
+    }
+  } else if (!state.allowedJids.has(jid)) {
+    return drop('sender not allow-listed');
+  }
+
+  const content = unwrapMessageContent(raw?.message ?? null);
+  if (!content) return drop('no message content');
+
+  const text = extractText(content);
+  if (text != null) {
+    const trimmed = text.trim();
+    if (trimmed.length === 0) return drop('empty text');
+    if (trimmed.length > MAX_TEXT_CHARS) return drop('text over size cap');
+    return { ok: true, kind: 'text', jid, text: trimmed };
+  }
+
+  const audioRaw = content['audioMessage'];
+  if (audioRaw != null && typeof audioRaw === 'object') {
+    const audio = audioMessageSchema.safeParse(audioRaw);
+    if (!audio.success) return drop('invalid audio message shape');
+    const declaredBytes = toFiniteNumber(audio.data.fileLength);
+    if (declaredBytes != null && declaredBytes > MAX_AUDIO_BYTES) {
+      return drop('audio over size cap');
+    }
+    return {
+      ok: true,
+      kind: 'audio',
+      jid,
+      mimeType: normalizeMime(audio.data.mimetype),
+      declaredBytes,
+    };
+  }
+
+  return drop('unsupported message type');
+}
+
+function drop(reason: string): GateVerdict {
+  return { ok: false, reason };
+}
+
+/**
+ * Unwrap the containers WhatsApp nests real content in (disappearing-message
+ * chats wrap everything in `ephemeralMessage`, view-once in `viewOnceMessage*`).
+ * Bounded depth — malformed nesting must not recurse forever.
+ */
+function unwrapMessageContent(
+  message: Record<string, unknown> | null,
+): Record<string, unknown> | null {
+  let current = message;
+  for (let depth = 0; current != null && depth < 4; depth++) {
+    const wrapper =
+      pickInner(current, 'ephemeralMessage') ??
+      pickInner(current, 'viewOnceMessage') ??
+      pickInner(current, 'viewOnceMessageV2') ??
+      pickInner(current, 'documentWithCaptionMessage');
+    if (!wrapper) return current;
+    current = wrapper;
+  }
+  return current;
+}
+
+function pickInner(
+  container: Record<string, unknown>,
+  field: string,
+): Record<string, unknown> | null {
+  const wrapper = container[field];
+  if (wrapper == null || typeof wrapper !== 'object') return null;
+  const inner = (wrapper as { message?: unknown }).message;
+  return inner != null && typeof inner === 'object' ? (inner as Record<string, unknown>) : null;
+}
+
+function extractText(content: Record<string, unknown>): string | null {
+  const conversation = content['conversation'];
+  if (typeof conversation === 'string') return conversation;
+  const extended = content['extendedTextMessage'];
+  if (extended != null && typeof extended === 'object') {
+    const text = (extended as { text?: unknown }).text;
+    if (typeof text === 'string') return text;
+  }
+  return null;
+}
+
+/** `fileLength` arrives as number, decimal string, or a Long-like object. */
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  if (value != null && typeof value === 'object') {
+    const n = Number((value as { toString(): string }).toString());
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function normalizeMime(mime: string | null | undefined): string {
+  const trimmed = mime?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : 'audio/ogg; codecs=opus';
+}

--- a/packages/plugin-channel-whatsapp/src/pair-flow.ts
+++ b/packages/plugin-channel-whatsapp/src/pair-flow.ts
@@ -1,0 +1,122 @@
+import { log, outro, spinner } from '@clack/prompts';
+import QRCode from 'qrcode';
+import type { ChannelSubcommandContext } from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { WhatsAppChannel } from './channel.js';
+import { CONSENT_REQUIRED_MESSAGE } from './consent.js';
+import { ensureConsentInteractive } from './consent-prompt.js';
+
+// Tiny zero-dep ANSI dim helper, so this flow stays inside the plugin.
+const ANSI = process.stdout.isTTY && !process.env.NO_COLOR;
+const dim = (s: string): string => (ANSI ? `\x1b[2m${s}\x1b[22m` : s);
+
+/**
+ * Drive the QR device-link pairing flow end-to-end in a terminal — the SAME
+ * mechanism the desktop Channels panel uses (it renders `channel.requestUrl`
+ * from the status file), just rendered inline here.
+ *
+ * Unlike Telegram's one-shot deep link, the Baileys QR payload ROTATES every
+ * ~20-60s while unlinked, so the flow re-renders on every connect-change until
+ * the scan lands.
+ */
+export async function runWhatsAppPairFlow(ctx: ChannelSubcommandContext): Promise<number> {
+  const vault = ctx.deps.vault as VaultStore;
+
+  // Consent gate FIRST — pairing is the moment the account actually links.
+  if (!(await ensureConsentInteractive(vault))) {
+    process.stderr.write(`${CONSENT_REQUIRED_MESSAGE}\n`);
+    return 1;
+  }
+
+  const session = ctx.session;
+  const channel = new WhatsAppChannel({
+    vault,
+    logger: ctx.deps.logger as never,
+  });
+  session.setPermissionResolver(channel.permissionResolver);
+
+  // Subscribe BEFORE start so a fast scan can't race us.
+  let pairedResolve: ((ownerJid: string) => void) | null = null;
+  const paired = new Promise<string>((resolve) => {
+    pairedResolve = resolve;
+  });
+  const unsubscribePaired = channel.onPaired((ownerJid) => {
+    pairedResolve?.(ownerJid);
+    pairedResolve = null;
+  });
+
+  outro(dim('opening WhatsApp pairing window...'));
+  const handle = await channel.start({ session, pair: true });
+
+  const stopChannel = async (): Promise<void> => {
+    unsubscribePaired();
+    try {
+      await handle.stop('pair flow');
+    } catch {
+      /* ignore */
+    }
+  };
+
+  if (channel.connected) {
+    log.info(
+      'A WhatsApp account is already linked. Run `moxxy channels whatsapp unpair` first to link a different one.',
+    );
+    await stopChannel();
+    return 0;
+  }
+
+  // Render every FRESH QR payload (they rotate while unlinked).
+  let lastQr: string | null = null;
+  const renderQr = async (): Promise<void> => {
+    const qr = channel.requestUrl;
+    if (!qr || qr === lastQr) return;
+    lastQr = qr;
+    await printPairQr(qr);
+    log.info(
+      'On your phone: WhatsApp -> Settings -> Linked devices -> Link a device, then scan the QR.',
+    );
+  };
+  const unsubscribeConnect = handle.onConnectChange?.(() => void renderQr()) ?? (() => undefined);
+  await renderQr();
+
+  let stopping = false;
+  const shutdown = async (): Promise<void> => {
+    if (stopping) return;
+    stopping = true;
+    unsubscribeConnect();
+    await stopChannel();
+    await session.close('SIGINT').catch(() => undefined);
+    process.exit(0);
+  };
+  const onSignal = (): void => void shutdown();
+  process.once('SIGINT', onSignal);
+  process.once('SIGTERM', onSignal);
+
+  const spin = spinner();
+  spin.start('Waiting for the scan (the QR refreshes periodically)...');
+  const ownerJid = await paired;
+  spin.stop(`Linked as ${ownerJid}. Your Note-to-Self chat now talks to moxxy.`);
+
+  log.info('Channel is running. Press Ctrl+C to stop.');
+  try {
+    await handle.running;
+    return 0;
+  } finally {
+    unsubscribeConnect();
+    process.removeListener('SIGINT', onSignal);
+    process.removeListener('SIGTERM', onSignal);
+  }
+}
+
+/** Render the rotating pairing payload as a scannable terminal QR. */
+async function printPairQr(payload: string): Promise<void> {
+  let qr = '';
+  try {
+    qr = await QRCode.toString(payload, { type: 'terminal', small: true });
+  } catch {
+    qr = '';
+  }
+  // CLI surface — intentional stdout. (The payload itself is an opaque pairing
+  // blob, not a URL, so there is no "open the link" fallback to print.)
+  console.log(['', qr].join('\n'));
+}

--- a/packages/plugin-channel-whatsapp/src/permission.test.ts
+++ b/packages/plugin-channel-whatsapp/src/permission.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PendingToolCall, PermissionContext } from '@moxxy/sdk';
+import {
+  createWhatsAppPermissionController,
+  formatPermissionPrompt,
+  parsePermissionReply,
+} from './permission.js';
+
+const call: PendingToolCall = {
+  callId: 'c1',
+  name: 'write_file',
+  input: { path: '/tmp/x', content: 'hi' },
+} as PendingToolCall;
+const ctx = {} as PermissionContext;
+
+describe('parsePermissionReply', () => {
+  it('maps allow/session/deny synonyms', () => {
+    expect(parsePermissionReply('1')?.mode).toBe('allow');
+    expect(parsePermissionReply('yes')?.mode).toBe('allow');
+    expect(parsePermissionReply('2')?.mode).toBe('allow_session');
+    expect(parsePermissionReply('always')?.mode).toBe('allow_session');
+    expect(parsePermissionReply('3')?.mode).toBe('deny');
+    expect(parsePermissionReply('no')?.mode).toBe('deny');
+  });
+
+  it('returns null for unrecognized replies', () => {
+    expect(parsePermissionReply('maybe later')).toBeNull();
+    expect(parsePermissionReply('')).toBeNull();
+  });
+});
+
+describe('formatPermissionPrompt', () => {
+  it('names the tool and lists the numbered options', () => {
+    const text = formatPermissionPrompt(call);
+    expect(text).toContain('write_file');
+    expect(text).toContain('1 = allow once');
+    expect(text).toContain('3 = deny');
+  });
+});
+
+describe('WhatsAppPermissionController', () => {
+  it('denies immediately when no sender is wired', async () => {
+    const ctrl = createWhatsAppPermissionController();
+    const decision = await ctrl.resolver.check(call, ctx);
+    expect(decision.mode).toBe('deny');
+  });
+
+  it('prompts, then resolves on the operator reply', async () => {
+    const ctrl = createWhatsAppPermissionController();
+    const sent: string[] = [];
+    ctrl.setSender(async (t) => void sent.push(t));
+
+    const pending = ctrl.resolver.check(call, ctx);
+    await vi.waitFor(() => expect(ctrl.hasPending()).toBe(true));
+    expect(sent[0]).toContain('write_file');
+
+    expect(ctrl.offerReply('1')).toBe(true);
+    expect((await pending).mode).toBe('allow');
+    expect(ctrl.hasPending()).toBe(false);
+  });
+
+  it('allow_session skips subsequent prompts for the same tool', async () => {
+    const ctrl = createWhatsAppPermissionController();
+    ctrl.setSender(async () => {});
+    const first = ctrl.resolver.check(call, ctx);
+    await vi.waitFor(() => expect(ctrl.hasPending()).toBe(true));
+    ctrl.offerReply('2');
+    expect((await first).mode).toBe('allow_session');
+
+    // Second call for the same tool name resolves WITHOUT a new prompt.
+    const second = await ctrl.resolver.check(call, ctx);
+    expect(second.mode).toBe('allow_session');
+    expect(ctrl.hasPending()).toBe(false);
+  });
+
+  it('ignores an unrecognized reply (keeps the prompt pending)', async () => {
+    const ctrl = createWhatsAppPermissionController();
+    ctrl.setSender(async () => {});
+    void ctrl.resolver.check(call, ctx);
+    await vi.waitFor(() => expect(ctrl.hasPending()).toBe(true));
+    expect(ctrl.offerReply('huh?')).toBe(false);
+    expect(ctrl.hasPending()).toBe(true);
+  });
+
+  it('abortAll denies in-flight prompts so callers never hang', async () => {
+    const ctrl = createWhatsAppPermissionController();
+    ctrl.setSender(async () => {});
+    const pending = ctrl.resolver.check(call, ctx);
+    await vi.waitFor(() => expect(ctrl.hasPending()).toBe(true));
+    ctrl.abortAll('channel closed');
+    expect((await pending).mode).toBe('deny');
+    expect(ctrl.hasPending()).toBe(false);
+  });
+});

--- a/packages/plugin-channel-whatsapp/src/permission.ts
+++ b/packages/plugin-channel-whatsapp/src/permission.ts
@@ -1,0 +1,114 @@
+import {
+  createDeferredPermissionResolver,
+  type DeferredPermissionResolver,
+  type PendingToolCall,
+  type PermissionDecision,
+} from '@moxxy/sdk';
+
+/**
+ * Human-in-the-loop permissions over plain WhatsApp messages. Baileys has no
+ * reliable interactive buttons on multi-device, so the prompt is text: the
+ * channel sends a numbered question into the owner's chat and interprets the
+ * owner's NEXT short reply (`1`/`yes` allow once, `2`/`always` allow for the
+ * session, `3`/`no` deny) — the same capture-next-message mechanism Telegram
+ * uses for approval follow-up text.
+ *
+ * Built ON `createDeferredPermissionResolver` (never re-implement the pending
+ * tracking — the audit caught a TUI hang from exactly that): the sdk scaffold
+ * owns session-allows + abort-on-stop; this wrapper only owns the reply
+ * queue + parsing.
+ */
+export interface WhatsAppPermissionController {
+  readonly resolver: DeferredPermissionResolver;
+  /** Wire the outbound sender once the socket is up (null on teardown). */
+  setSender(send: ((text: string) => Promise<void>) | null): void;
+  /** True while a prompt is awaiting the owner's reply. */
+  hasPending(): boolean;
+  /** Offer an owner message as a reply; true when it resolved a prompt. */
+  offerReply(text: string): boolean;
+  /** Deny every in-flight prompt (channel stop / session reset). */
+  abortAll(reason?: string): void;
+}
+
+interface PendingPrompt {
+  readonly resolve: (decision: PermissionDecision) => void;
+}
+
+export function parsePermissionReply(text: string): PermissionDecision | null {
+  const v = text.trim().toLowerCase();
+  if (v === '1' || v === 'yes' || v === 'y' || v === 'allow') {
+    return { mode: 'allow', reason: 'owner approved via WhatsApp' };
+  }
+  if (v === '2' || v === 'always') {
+    return { mode: 'allow_session', reason: 'owner approved for session via WhatsApp' };
+  }
+  if (v === '3' || v === 'no' || v === 'n' || v === 'deny') {
+    return { mode: 'deny', reason: 'owner denied via WhatsApp' };
+  }
+  return null;
+}
+
+export function formatPermissionPrompt(call: PendingToolCall): string {
+  let input = '';
+  try {
+    input = JSON.stringify(call.input ?? {});
+  } catch {
+    input = '(unserializable input)';
+  }
+  if (input.length > 400) input = `${input.slice(0, 400)}…`;
+  return (
+    `Permission needed: tool *${call.name}*\n` +
+    `${input}\n\n` +
+    'Reply: 1 = allow once, 2 = allow for session, 3 = deny'
+  );
+}
+
+export function createWhatsAppPermissionController(): WhatsAppPermissionController {
+  // FIFO of prompts awaiting a reply. Tool calls within a turn are sequential,
+  // so this is ~1 deep; the queue is defensive against overlap.
+  const pending: PendingPrompt[] = [];
+  let sender: ((text: string) => Promise<void>) | null = null;
+
+  const resolver = createDeferredPermissionResolver({
+    name: 'whatsapp',
+    prompt: (call) =>
+      new Promise<PermissionDecision>((resolve, reject) => {
+        if (!sender) {
+          resolve({ mode: 'deny', reason: 'whatsapp channel not connected' });
+          return;
+        }
+        pending.push({ resolve });
+        sender(formatPermissionPrompt(call)).catch((err: unknown) => {
+          const idx = pending.findIndex((p) => p.resolve === resolve);
+          if (idx >= 0) pending.splice(idx, 1);
+          reject(err instanceof Error ? err : new Error(String(err)));
+        });
+      }),
+  });
+
+  return {
+    resolver,
+    setSender(send) {
+      sender = send;
+    },
+    hasPending() {
+      return pending.length > 0;
+    },
+    offerReply(text) {
+      if (pending.length === 0) return false;
+      const decision = parsePermissionReply(text);
+      if (!decision) return false;
+      const prompt = pending.shift()!;
+      prompt.resolve(decision);
+      return true;
+    },
+    abortAll(reason = 'channel closed') {
+      // Resolve OUR pending prompt promises (deny) so the sdk scaffold's outer
+      // promises settle, then clear the scaffold's own in-flight set too.
+      for (const prompt of pending.splice(0)) {
+        prompt.resolve({ mode: 'deny', reason });
+      }
+      resolver.abortAll(reason);
+    },
+  };
+}

--- a/packages/plugin-channel-whatsapp/src/setup-wizard.ts
+++ b/packages/plugin-channel-whatsapp/src/setup-wizard.ts
@@ -1,0 +1,162 @@
+import { cancel, intro, isCancel, log, note, outro, select, text } from '@clack/prompts';
+import type { ChannelSubcommandContext } from '@moxxy/sdk';
+import { moxxyPath } from '@moxxy/sdk/server';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { createFileAuthStorage, hasStoredCreds } from './auth-state.js';
+import { ensureConsentInteractive } from './consent-prompt.js';
+import {
+  WHATSAPP_ALLOWED_JIDS_KEY,
+  WHATSAPP_AUTH_DIR,
+  WHATSAPP_OWNER_JID_KEY,
+  parseAllowedJids,
+} from './keys.js';
+import { runWhatsAppPairFlow } from './pair-flow.js';
+
+// Tiny zero-dep ANSI helpers so the wizard stays inside the plugin.
+const ANSI = process.stdout.isTTY && !process.env.NO_COLOR;
+const bold = (s: string): string => (ANSI ? `\x1b[1m${s}\x1b[22m` : s);
+const dim = (s: string): string => (ANSI ? `\x1b[2m${s}\x1b[22m` : s);
+
+interface State {
+  readonly linked: boolean;
+  readonly ownerJid: string | null;
+  readonly allowedJids: ReadonlyArray<string>;
+}
+
+type Action = 'pair' | 'unpair' | 'allow-list' | 'start' | 'quit';
+
+/**
+ * Interactive WhatsApp setup menu (the channel's `interactiveCommand`).
+ *
+ * The FIRST step — before any menu — is the consent gate: this channel rides an
+ * UNOFFICIAL WhatsApp client; the wizard states the ToS/ban risk plainly and
+ * requires a typed "yes" before anything else. No acknowledgment, no menu.
+ */
+export async function runWhatsAppWizard(ctx: ChannelSubcommandContext): Promise<number> {
+  const vault = ctx.deps.vault as VaultStore;
+  intro(bold('moxxy whatsapp setup'));
+
+  if (!(await ensureConsentInteractive(vault))) {
+    cancel('cancelled.');
+    return 1;
+  }
+
+  while (true) {
+    const state = await readState(vault);
+    printStatus(state);
+    const action = await pickAction(state);
+    if (action === null) {
+      cancel('cancelled.');
+      return 0;
+    }
+    if (action === 'quit') {
+      outro(dim('done.'));
+      return 0;
+    }
+    if (action === 'pair') {
+      return await runWhatsAppPairFlow(ctx);
+    }
+    if (action === 'unpair') {
+      await unpairLocal(vault);
+      log.success(
+        'Local credentials cleared. Also remove the device on your phone: WhatsApp -> Settings -> Linked devices.',
+      );
+      continue;
+    }
+    if (action === 'allow-list') {
+      await editAllowList(vault, state.allowedJids);
+      continue;
+    }
+    if (action === 'start') {
+      log.info('Starting the channel. Press Ctrl+C to stop.');
+      outro(dim('handing off to the channel...'));
+      return ctx.startChannel();
+    }
+  }
+}
+
+/** Clear the rotating auth-state dir + the persisted owner identity. */
+export async function unpairLocal(vault: VaultStore): Promise<boolean> {
+  const storage = createFileAuthStorage(moxxyPath(WHATSAPP_AUTH_DIR));
+  const had = await hasStoredCreds(storage);
+  await storage.clear();
+  await vault.delete(WHATSAPP_OWNER_JID_KEY).catch(() => undefined);
+  return had;
+}
+
+async function readState(vault: VaultStore): Promise<State> {
+  const storage = createFileAuthStorage(moxxyPath(WHATSAPP_AUTH_DIR));
+  return {
+    linked: await hasStoredCreds(storage),
+    ownerJid: await vault.get(WHATSAPP_OWNER_JID_KEY),
+    allowedJids: parseAllowedJids(await vault.get(WHATSAPP_ALLOWED_JIDS_KEY)),
+  };
+}
+
+function printStatus(state: State): void {
+  const lines: string[] = [];
+  lines.push(`Linked       ${state.linked ? bold(state.ownerJid ?? 'yes') : dim('no')}`);
+  lines.push(
+    `Allow-list   ${
+      state.allowedJids.length > 0
+        ? bold(state.allowedJids.join(', '))
+        : dim('only your own Note-to-Self chat')
+    }`,
+  );
+  note(lines.join('\n'), 'status');
+}
+
+async function pickAction(state: State): Promise<Action | null> {
+  const options: Array<{ value: Action; label: string; hint?: string }> = [];
+  if (state.linked) {
+    options.push({
+      value: 'start',
+      label: 'Start the channel',
+      hint: 'runs forever - Ctrl+C to stop',
+    });
+    options.push({
+      value: 'unpair',
+      label: 'Unpair (forget local credentials)',
+      hint: 'also remove the device under Linked devices on the phone',
+    });
+  } else {
+    options.push({
+      value: 'pair',
+      label: 'Link a WhatsApp account (scan QR)',
+      hint: 'WhatsApp -> Settings -> Linked devices -> Link a device',
+    });
+  }
+  options.push({
+    value: 'allow-list',
+    label: 'Edit the JID allow-list',
+    hint: 'who besides your own Note-to-Self chat may talk to the agent',
+  });
+  options.push({ value: 'quit', label: 'Quit' });
+
+  const choice = await select<Action>({ message: 'What do you want to do?', options });
+  if (isCancel(choice)) return null;
+  return choice as Action;
+}
+
+async function editAllowList(
+  vault: VaultStore,
+  current: ReadonlyArray<string>,
+): Promise<void> {
+  note(
+    'Comma-separated JIDs, e.g. 15551234567@s.whatsapp.net (a group JID ends in\n' +
+      '@g.us — allow-listing a group trusts EVERYONE in it). Empty input clears the\n' +
+      'list; your own Note-to-Self chat is always allowed.',
+    'allow-list',
+  );
+  const answer = await text({
+    message: 'Allowed JIDs',
+    initialValue: current.join(', '),
+    placeholder: '15551234567@s.whatsapp.net',
+  });
+  if (isCancel(answer)) return;
+  const parsed = parseAllowedJids(String(answer));
+  await vault.set(WHATSAPP_ALLOWED_JIDS_KEY, JSON.stringify(parsed), ['whatsapp']);
+  log.success(
+    parsed.length > 0 ? `Allow-list saved (${parsed.length} JIDs).` : 'Allow-list cleared.',
+  );
+}

--- a/packages/plugin-channel-whatsapp/src/socket.test.ts
+++ b/packages/plugin-channel-whatsapp/src/socket.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { disconnectStatusCode, WA_DISCONNECT } from './socket.js';
+
+describe('disconnectStatusCode', () => {
+  it('extracts a Boom-style statusCode', () => {
+    expect(disconnectStatusCode({ output: { statusCode: WA_DISCONNECT.loggedOut } })).toBe(401);
+    expect(disconnectStatusCode({ output: { statusCode: 515 } })).toBe(515);
+  });
+
+  it('returns null when no code is present', () => {
+    expect(disconnectStatusCode(undefined)).toBeNull();
+    expect(disconnectStatusCode(null)).toBeNull();
+    expect(disconnectStatusCode(new Error('boom'))).toBeNull();
+    expect(disconnectStatusCode({ output: {} })).toBeNull();
+    expect(disconnectStatusCode({ output: { statusCode: 'nope' } })).toBeNull();
+  });
+});

--- a/packages/plugin-channel-whatsapp/src/socket.ts
+++ b/packages/plugin-channel-whatsapp/src/socket.ts
@@ -1,0 +1,89 @@
+import type { WhatsAppAuthStorage } from './auth-state.js';
+
+/**
+ * The narrow transport contract the channel is written against — the slice of a
+ * Baileys socket it actually touches, adapted in `baileys-socket.ts`. Tests
+ * inject a fake implementing THIS, so no test ever opens a WhatsApp connection
+ * (and the heavyweight Baileys import stays out of unit tests entirely).
+ */
+
+export interface WaMessageKey {
+  readonly remoteJid?: string | null;
+  readonly fromMe?: boolean | null;
+  readonly id?: string | null;
+  readonly participant?: string | null;
+}
+
+/** The consumed subset of a Baileys `WAMessage` (validated in message-gate). */
+export interface WaInboundMessage {
+  readonly key?: WaMessageKey | null;
+  readonly message?: Record<string, unknown> | null;
+}
+
+export interface WaMessagesUpsert {
+  /** 'notify' = fresh inbound; 'append'/'history' = sync artifacts (dropped). */
+  readonly type: string;
+  readonly messages: ReadonlyArray<WaInboundMessage>;
+}
+
+export interface WaConnectionUpdate {
+  readonly connection?: 'close' | 'connecting' | 'open' | undefined;
+  /** Fresh QR pairing payload — rotates every ~20-60s while unlinked. */
+  readonly qr?: string | undefined;
+  readonly lastDisconnect?: { readonly error?: unknown } | undefined;
+}
+
+export interface WaSentMessage {
+  readonly key: WaMessageKey;
+}
+
+export interface WhatsAppSocket {
+  /** The linked account's raw JID once the connection is open; null before. */
+  userJid(): string | null;
+  onConnectionUpdate(cb: (update: WaConnectionUpdate) => void): void;
+  onMessages(cb: (upsert: WaMessagesUpsert) => void): void;
+  sendText(jid: string, text: string): Promise<WaSentMessage | null>;
+  /** Edit a previously sent message in place (WhatsApp MESSAGE_EDIT). */
+  editText(jid: string, key: WaMessageKey, text: string): Promise<void>;
+  /** Download a media message's bytes (voice notes). */
+  downloadMedia(message: WaInboundMessage): Promise<Uint8Array>;
+  /** Tear the connection down WITHOUT logging out (creds stay valid). */
+  end(): void;
+}
+
+export interface WhatsAppSocketLogger {
+  debug?(msg: string, meta?: Record<string, unknown>): void;
+  info?(msg: string, meta?: Record<string, unknown>): void;
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface WhatsAppSocketFactoryOptions {
+  readonly storage: WhatsAppAuthStorage;
+  readonly logger?: WhatsAppSocketLogger;
+}
+
+/** Opens one connection attempt; the channel owns the reconnect loop. */
+export type WhatsAppSocketFactory = (
+  opts: WhatsAppSocketFactoryOptions,
+) => Promise<WhatsAppSocket>;
+
+/**
+ * Extract the WhatsApp disconnect status code from a close error (Baileys
+ * throws Boom errors: `err.output.statusCode`). Pure so the reconnect policy is
+ * unit-testable. Returns null when no code can be found (treated as retriable).
+ */
+export function disconnectStatusCode(err: unknown): number | null {
+  if (typeof err !== 'object' || err === null) return null;
+  const output = (err as { output?: unknown }).output;
+  if (typeof output !== 'object' || output === null) return null;
+  const code = (output as { statusCode?: unknown }).statusCode;
+  return typeof code === 'number' && Number.isFinite(code) ? code : null;
+}
+
+/** WhatsApp disconnect reasons the channel branches on (Baileys' DisconnectReason). */
+export const WA_DISCONNECT = {
+  loggedOut: 401,
+  forbidden: 403,
+  connectionReplaced: 440,
+  restartRequired: 515,
+} as const;

--- a/packages/plugin-channel-whatsapp/src/subcommands.test.ts
+++ b/packages/plugin-channel-whatsapp/src/subcommands.test.ts
@@ -1,0 +1,198 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VaultStore, createStaticKeySource, deriveKey, generateSalt } from '@moxxy/plugin-vault';
+import type { ChannelDef } from '@moxxy/sdk';
+import { buildWhatsAppPlugin } from './index.js';
+import {
+  WHATSAPP_ALLOWED_JIDS_KEY,
+  WHATSAPP_CONSENT_ENV,
+  WHATSAPP_CONSENT_KEY,
+  WHATSAPP_OWNER_JID_KEY,
+} from './keys.js';
+
+let tmp: string;
+let vault: VaultStore;
+let def: ChannelDef;
+let writeOut: string[];
+let writeErr: string[];
+let origOut: typeof process.stdout.write;
+let origErr: typeof process.stderr.write;
+let origHome: string | undefined;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-wa-sub-'));
+  // Point the moxxy home at the tmp dir so `hasStoredCreds` reads an empty dir.
+  origHome = process.env.MOXXY_HOME;
+  process.env.MOXXY_HOME = tmp;
+  vault = new VaultStore({
+    filePath: path.join(tmp, 'vault.json'),
+    keySource: createStaticKeySource(deriveKey('test', generateSalt())),
+  });
+  def = buildWhatsAppPlugin({ vault }).channels![0]!;
+  writeOut = [];
+  writeErr = [];
+  origOut = process.stdout.write.bind(process.stdout);
+  origErr = process.stderr.write.bind(process.stderr);
+  process.stdout.write = ((c: string | Uint8Array) => {
+    writeOut.push(typeof c === 'string' ? c : Buffer.from(c).toString());
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((c: string | Uint8Array) => {
+    writeErr.push(typeof c === 'string' ? c : Buffer.from(c).toString());
+    return true;
+  }) as typeof process.stderr.write;
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+  process.stdout.write = origOut;
+  process.stderr.write = origErr;
+  if (origHome === undefined) delete process.env.MOXXY_HOME;
+  else process.env.MOXXY_HOME = origHome;
+  delete process.env[WHATSAPP_CONSENT_ENV];
+});
+
+function ctx(overrides: { startChannel?: () => Promise<number> } = {}) {
+  return {
+    deps: { cwd: tmp, vault, logger: undefined, options: {} },
+    args: { positional: [], flags: {} },
+    startChannel: overrides.startChannel ?? (async () => 0),
+    session: { setPermissionResolver: () => {} },
+  } as never;
+}
+
+describe('whatsapp channel def', () => {
+  it('declares dedicatedRunner + whatsapp session source + qr connect', () => {
+    expect(def.name).toBe('whatsapp');
+    expect(def.dedicatedRunner).toBe(true);
+    expect(def.sessionSource).toBe('whatsapp');
+    expect(def.config?.connect?.kind).toBe('qr');
+    expect(def.config?.hasRequestUrl).toBe(false);
+    expect(def.interactiveCommand).toBe('setup');
+  });
+
+  it('exposes setup, pair, status, unpair subcommands', () => {
+    expect(Object.keys(def.subcommands!)).toEqual(
+      expect.arrayContaining(['setup', 'pair', 'status', 'unpair']),
+    );
+  });
+
+  it('description carries the unofficial-API warning', () => {
+    expect(def.description).toMatch(/UNOFFICIAL/i);
+    expect(def.description).toMatch(/ban/i);
+  });
+});
+
+describe('isAvailable (consent gate + link state)', () => {
+  it('is unavailable without consent, naming the ToS risk', async () => {
+    const avail = await def.isAvailable!({ cwd: tmp, vault });
+    expect(avail.ok).toBe(false);
+    expect(avail.reason).toMatch(/ToS|acknowledg|ban/i);
+  });
+
+  it('is unavailable-but-needs-pairing once consent is given', async () => {
+    process.env[WHATSAPP_CONSENT_ENV] = 'yes';
+    const avail = await def.isAvailable!({ cwd: tmp, vault });
+    expect(avail.ok).toBe(false);
+    expect(avail.reason).toMatch(/pair/i);
+  });
+});
+
+describe('status subcommand', () => {
+  it('reports needs-consent when nothing configured', async () => {
+    const code = await def.subcommands!.status!.run(ctx());
+    expect(code).toBe(0);
+    const parsed = JSON.parse(writeOut.join(''));
+    expect(parsed.state).toBe('needs-consent');
+    expect(parsed.consentAcknowledged).toBe(false);
+    expect(parsed.linked).toBe(false);
+  });
+
+  it('reports needs-pairing after consent but before linking', async () => {
+    await vault.set(WHATSAPP_CONSENT_KEY, 'acknowledged@2026-01-01T00:00:00.000Z');
+    const code = await def.subcommands!.status!.run(ctx());
+    expect(code).toBe(0);
+    const parsed = JSON.parse(writeOut.join(''));
+    expect(parsed.state).toBe('needs-pairing');
+    expect(parsed.guidance).toMatch(/pair/i);
+  });
+
+  it('surfaces stored allow-list + owner jid', async () => {
+    await vault.set(WHATSAPP_CONSENT_KEY, 'yes');
+    await vault.set(WHATSAPP_OWNER_JID_KEY, '15550000000@s.whatsapp.net');
+    await vault.set(WHATSAPP_ALLOWED_JIDS_KEY, JSON.stringify(['15551111111@s.whatsapp.net']));
+    const code = await def.subcommands!.status!.run(ctx());
+    expect(code).toBe(0);
+    const parsed = JSON.parse(writeOut.join(''));
+    expect(parsed.ownerJid).toBe('15550000000@s.whatsapp.net');
+    expect(parsed.allowedJids).toEqual(['15551111111@s.whatsapp.net']);
+  });
+
+  it('returns 1 when the vault is unavailable', async () => {
+    const badCtx = {
+      deps: { cwd: tmp, vault: undefined, logger: undefined, options: {} },
+      args: { positional: [], flags: {} },
+      startChannel: async () => 0,
+      session: { setPermissionResolver: () => {} },
+    } as never;
+    const code = await def.subcommands!.status!.run(badCtx);
+    expect(code).toBe(1);
+    expect(writeErr.join('')).toContain('vault unavailable');
+  });
+});
+
+describe('unpair subcommand', () => {
+  it('is a no-op when nothing is linked', async () => {
+    const code = await def.subcommands!.unpair!.run(ctx());
+    expect(code).toBe(0);
+    expect(writeOut.join('')).toContain('no linked account');
+  });
+});
+
+describe('pair subcommand', () => {
+  it('refuses without a TTY (QR needs a terminal)', async () => {
+    const original = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    try {
+      const startChannel = vi.fn(async () => 0);
+      const code = await def.subcommands!.pair!.run(ctx({ startChannel }));
+      expect(code).toBe(1);
+      expect(startChannel).not.toHaveBeenCalled();
+      expect(writeErr.join('')).toMatch(/TTY/);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: original, configurable: true });
+    }
+  });
+});
+
+describe('setup subcommand (headless)', () => {
+  it('refuses to start headless without consent', async () => {
+    const original = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    try {
+      const startChannel = vi.fn(async () => 0);
+      const code = await def.subcommands!.setup!.run(ctx({ startChannel }));
+      expect(code).toBe(1);
+      expect(startChannel).not.toHaveBeenCalled();
+      expect(writeErr.join('')).toMatch(/acknowledg|ToS|ban/i);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: original, configurable: true });
+    }
+  });
+
+  it('starts the channel headless once consent is acknowledged', async () => {
+    process.env[WHATSAPP_CONSENT_ENV] = 'yes';
+    const original = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    try {
+      const startChannel = vi.fn(async () => 0);
+      const code = await def.subcommands!.setup!.run(ctx({ startChannel }));
+      expect(code).toBe(0);
+      expect(startChannel).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: original, configurable: true });
+    }
+  });
+});

--- a/packages/plugin-channel-whatsapp/tsconfig.json
+++ b/packages/plugin-channel-whatsapp/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/plugin-channel-whatsapp/vitest.config.ts
+++ b/packages/plugin-channel-whatsapp/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/packages/plugin-plugins-admin/src/catalog.ts
+++ b/packages/plugin-plugins-admin/src/catalog.ts
@@ -235,6 +235,15 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     provides: [{ category: 'channel', name: 'signal' }],
   },
   {
+    id: 'whatsapp',
+    label: 'WhatsApp channel',
+    description:
+      'WhatsApp via Baileys — UNOFFICIAL API: violates WhatsApp ToS, the number can be banned; use a secondary number (moxxy whatsapp).',
+    packageName: '@moxxy/plugin-channel-whatsapp',
+    installSpec: '@moxxy/plugin-channel-whatsapp',
+    provides: [{ category: 'channel', name: 'whatsapp' }],
+  },
+  {
     id: 'stt-whisper',
     label: 'Whisper voice input',
     description: 'Speech-to-text via the OpenAI Whisper API (Ctrl+R in the TUI).',

--- a/packages/sdk/src/event-store.ts
+++ b/packages/sdk/src/event-store.ts
@@ -13,7 +13,15 @@ import type { SessionId } from './ids.js';
  */
 
 /** Originating channel of a session (persisted into the meta sidecar). */
-export type SessionSource = 'cli' | 'tui' | 'desktop' | 'mobile' | 'slack' | 'telegram' | 'signal';
+export type SessionSource =
+  | 'cli'
+  | 'tui'
+  | 'desktop'
+  | 'mobile'
+  | 'slack'
+  | 'telegram'
+  | 'signal'
+  | 'whatsapp';
 
 /**
  * The single per-session metadata record (the JSONL impl writes it to

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1551,6 +1551,58 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
 
+  packages/plugin-channel-whatsapp:
+    dependencies:
+      '@clack/prompts':
+        specifier: 'catalog:'
+        version: 1.4.0
+      '@moxxy/channel-kit':
+        specifier: workspace:*
+        version: link:../channel-kit
+      '@moxxy/core':
+        specifier: workspace:*
+        version: link:../core
+      '@moxxy/plugin-vault':
+        specifier: workspace:*
+        version: link:../plugin-vault
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      '@whiskeysockets/baileys':
+        specifier: ^6.7.21
+        version: 6.17.16(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
+    devDependencies:
+      '@moxxy/mode-default':
+        specifier: workspace:*
+        version: link:../mode-default
+      '@moxxy/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      '@types/qrcode':
+        specifier: ^1.5.5
+        version: 1.5.6
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
   packages/plugin-cli:
     dependencies:
       '@moxxy/chat-model':
@@ -2769,6 +2821,9 @@ packages:
       graphql:
         optional: true
 
+  '@adiwajshing/keyed-db@0.2.4':
+    resolution: {integrity: sha512-yprSnAtj80/VKuDqRcFFLDYltoNV8tChNwFfIgcf6PGD4sjzWIBgs08pRuTqGH5mk5wgL6PBRSsMCZqtZwzFEw==}
+
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
@@ -3353,6 +3408,16 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@cacheable/memory@2.2.0':
+    resolution: {integrity: sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==}
+
+  '@cacheable/node-cache@1.7.6':
+    resolution: {integrity: sha512-6Omk2SgNnjtxB5f/E6bTIWIt5xhdpx39fGNRQgU9lojvRxU68v+qY+SXXLsp3ZGukqoPjsK21wZ6XABFr/Ge3A==}
+    engines: {node: '>=18'}
+
+  '@cacheable/utils@2.5.0':
+    resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
+
   '@capsizecss/unpack@4.0.0':
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
     engines: {node: '>=18'}
@@ -3930,6 +3995,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eshaz/web-worker@1.2.2':
+    resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
+
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -4112,6 +4180,9 @@ packages:
 
   '@grammyjs/types@3.26.0':
     resolution: {integrity: sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A==}
+
+  '@hapi/boom@9.1.4':
+    resolution: {integrity: sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==}
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -4489,6 +4560,15 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@keyv/bigmap@1.3.1':
+    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      keyv: ^5.6.0
+
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
     engines: {node: '>= 12.13.0'}
@@ -4739,6 +4819,9 @@ packages:
     resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
     cpu: [x64]
     os: [win32]
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -5432,6 +5515,14 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@thi.ng/bitstream@2.4.54':
+    resolution: {integrity: sha512-uInkAJge5O0bWWEaYKrQpMccPbFg0z6eIA5NDCJXPm7l3rjlDje6RBHBXll3LiQz9Y051EdzlAEQRaB5hEifdg==}
+    engines: {node: '>=18'}
+
+  '@thi.ng/errors@2.6.16':
+    resolution: {integrity: sha512-a7Lv/G0La5eTNUEIyLldpeYziyFSj3rOlWNeXFu8v+ZSb8w8EnQ/L0r0sKHux7Ru6RhUkAXrcaHU7xd1ZkWovA==}
+    engines: {node: '>=18'}
+
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
@@ -5752,6 +5843,46 @@ packages:
   '@vscode/l10n@0.0.18':
     resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
 
+  '@wasm-audio-decoders/common@9.0.7':
+    resolution: {integrity: sha512-WRaUuWSKV7pkttBygml/a6dIEpatq2nnZGFIoPTc5yPLkxL6Wk4YaslPM98OPQvWacvNZ+Py9xROGDtrFBDzag==}
+
+  '@wasm-audio-decoders/flac@0.2.10':
+    resolution: {integrity: sha512-YfcyoD2rYRBa6ffawZKNi5qvV5HArJmNmuMVUPoutuZ2hhGi6WNSWIzgvbROGmPbFivLL764Am7xxJENWJDhjw==}
+
+  '@wasm-audio-decoders/ogg-vorbis@0.1.20':
+    resolution: {integrity: sha512-zaQPasU5usRjUDXtXOHYED5tfkR4QMXd+EH3Nrz1+4+M5pCsdD+s9YxJqb0oqnTyRu/KUujOmu5Z/m/NT47vwg==}
+
+  '@wasm-audio-decoders/opus-ml@0.0.2':
+    resolution: {integrity: sha512-58rWEqDGg+CKCyEeKm2KoxxSwTWtHh/NLTW9ObR4K8CGF6VwuuGudEI1CtniS/oSRmL1nJq/eh8MKARiluw4DQ==}
+
+  '@whiskeysockets/baileys@6.17.16':
+    resolution: {integrity: sha512-cZoUaKpO4fsDUNiCtyZfbjkW0Bjl/IudzHLCvpqfqtq5TACQzNynYsYdKPJz1I8Cu/SSEvmewk0RorIs0zDWyw==}
+    deprecated: |-
+      This version is affected by a zero-day vulnerability that allows spoofing of messages, please update to
+        the latest versions (6.7.22^ or 7.0.0-rc12^)! For more information, check out the public advisory at
+        https://github.com/WhiskeySockets/Baileys/security/advisories/GHSA-qvv5-jq5g-4cgg
+    peerDependencies:
+      jimp: ^0.16.1
+      link-preview-js: ^3.0.0
+      qrcode-terminal: ^0.12.0
+      sharp: ^0.32.6
+    peerDependenciesMeta:
+      jimp:
+        optional: true
+      link-preview-js:
+        optional: true
+      qrcode-terminal:
+        optional: true
+      sharp:
+        optional: true
+
+  '@whiskeysockets/eslint-config@https://codeload.github.com/whiskeysockets/eslint-config/tar.gz/299e8389baf62f9aa3034de18ff0d62cc0a5e838':
+    resolution: {tarball: https://codeload.github.com/whiskeysockets/eslint-config/tar.gz/299e8389baf62f9aa3034de18ff0d62cc0a5e838}
+    version: 1.0.0
+    peerDependencies:
+      eslint: ^9.31.0
+      typescript: '>=4'
+
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
@@ -5995,6 +6126,9 @@ packages:
   async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
 
+  async-lock@1.4.1:
+    resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
+
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
@@ -6005,9 +6139,26 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  audio-buffer@5.0.0:
+    resolution: {integrity: sha512-gsDyj1wwUp8u7NBB+eW6yhLb9ICf+0eBmDX8NGaAS00w8/fLqFdxUlL5Ge/U8kB64DlQhdonxYC59dXy1J7H/w==}
+
+  audio-decode@2.2.3:
+    resolution: {integrity: sha512-Z0lHvMayR/Pad9+O9ddzaBJE0DrhZkQlStrC1RwcAHF3AhQAsdwKHeLGK8fYKyp2DDU6xHxzGb4CLMui12yVrg==}
+
+  audio-type@2.4.1:
+    resolution: {integrity: sha512-dK9Z/P83C/rBfTrXXgPD3jZ+aXxx2o/P4rq8+H1JqxbXklitEeJw4CrcwMC5CkON3CX3yy2gaWnIEVYejYh0zQ==}
+    engines: {node: '>=14'}
+
   auto-bind@5.0.1:
     resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -6213,6 +6364,10 @@ packages:
     resolution: {integrity: sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  cache-manager@5.7.6:
+    resolution: {integrity: sha512-wBxnBHjDxF1RXpHCBD6HGvKER003Ts7IIm0CHpggliHzN1RZditb7rXoduE1rplc2DEFYKxhLKgFuchXMJje9w==}
+    engines: {node: '>= 18'}
+
   cacheable-lookup@5.0.4:
     resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
     engines: {node: '>=10.6.0'}
@@ -6220,6 +6375,9 @@ packages:
   cacheable-request@7.0.4:
     resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
     engines: {node: '>=8'}
+
+  cacheable@2.5.0:
+    resolution: {integrity: sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -6389,6 +6547,9 @@ packages:
   code-excerpt@4.0.0:
     resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  codec-parser@2.5.0:
+    resolution: {integrity: sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ==}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -6619,6 +6780,9 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  curve25519-js@0.0.4:
+    resolution: {integrity: sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==}
 
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
@@ -7008,6 +7172,11 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+
+  eslint-plugin-simple-import-sort@12.1.1:
+    resolution: {integrity: sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==}
+    peerDependencies:
+      eslint: '>=5.0.0'
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -7423,6 +7592,15 @@ packages:
   flow-enums-runtime@0.0.6:
     resolution: {integrity: sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   fontace@0.4.1:
     resolution: {integrity: sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==}
 
@@ -7646,6 +7824,10 @@ packages:
   has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
 
+  hashery@1.5.1:
+    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
+    engines: {node: '>=20'}
+
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
@@ -7750,6 +7932,12 @@ packages:
   hono@4.12.18:
     resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
+
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
+
+  hookified@2.2.0:
+    resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
 
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
@@ -8215,6 +8403,9 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
@@ -8241,6 +8432,13 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libphonenumber-js@1.13.8:
+    resolution: {integrity: sha512-80xal1m93rADejw2pMp2MSzFhHCPLEspjHxnH2UtqI+DgAmElsbmLMiqk9niwH9NWAfjsRtaJI+qBrOEmRx9nQ==}
+
+  libsignal@https://codeload.github.com/WhiskeySockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7:
+    resolution: {tarball: https://codeload.github.com/WhiskeySockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7}
+    version: 6.0.0
 
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
@@ -8337,6 +8535,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -8951,6 +9152,9 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
+  mpg123-decoder@1.0.3:
+    resolution: {integrity: sha512-+fjxnWigodWJm3+4pndi+KUg9TBojgn31DPk85zEsim7C6s0X5Ztc/hQYdytXkwuGXH+aB0/aEkG40Emukv6oQ==}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -8963,6 +9167,10 @@ packages:
 
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
+  music-metadata@7.14.0:
+    resolution: {integrity: sha512-xrm3w7SV0Wk+OythZcSbaI8mcr/KHd0knJieu8bVpaPfMv/Agz5EooCAPz3OR5hbYMiUG6dgAPKZKnMzV+3amA==}
+    engines: {node: '>=10'}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -9060,6 +9268,10 @@ packages:
     resolution: {integrity: sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==}
     engines: {node: '>=0.12.0'}
 
+  node-wav@0.0.2:
+    resolution: {integrity: sha512-M6Rm/bbG6De/gKGxOpeOobx/dnGuP0dz40adqx38boqHhlWssBJZgLCPBNtb9NkrmnKYiV04xELq+R6PFOnoLA==}
+    engines: {node: '>=4.4.0'}
+
   nopt@6.0.0:
     resolution: {integrity: sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -9126,8 +9338,15 @@ packages:
     resolution: {integrity: sha512-trBCPmYQDFUCmch6YBxHhMFkDyhTl+vG8PDQHPOwRyeCDKnrrKpph2W7og7hg5T5RRF0yeyaOMasN7GZWbYuCA==}
     hasBin: true
 
+  ogg-opus-decoder@1.7.3:
+    resolution: {integrity: sha512-w47tiZpkLgdkpa+34VzYD8mHUj8I9kfWVZa82mBbNwDvB1byfLXSSzW/HxA4fI3e9kVlICSpXGFwMLV1LPdjwg==}
+
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
 
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
@@ -9201,6 +9420,9 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  opus-decoder@0.7.11:
+    resolution: {integrity: sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==}
 
   ora@3.4.0:
     resolution: {integrity: sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==}
@@ -9357,6 +9579,16 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    hasBin: true
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -9468,6 +9700,9 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -9475,6 +9710,10 @@ packages:
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  promise-coalesce@1.5.0:
+    resolution: {integrity: sha512-cTJ30U+ur1LD7pMPyQxiKIwxjtAjLsyU7ivRhVWZrX9BNIXtf78pc37vSMc8Vikx7DVzEKNk2SEJ5KWUpSG2ig==}
+    engines: {node: '>=16'}
 
   promise-inflight@1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
@@ -9509,12 +9748,23 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qified@0.10.1:
+    resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
+    engines: {node: '>=20'}
+
+  qoa-format@1.0.1:
+    resolution: {integrity: sha512-dMB0Z6XQjdpz/Cw4Rf6RiBpQvUSPCfYlQMWvmuWlWkAT7nDQD29cVZ1SwDUB6DYJSitHENwbt90lqfI+7bvMcw==}
 
   qrcode-terminal@0.11.0:
     resolution: {integrity: sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==}
@@ -9538,6 +9788,9 @@ packages:
 
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
@@ -9746,6 +9999,10 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -9981,6 +10238,10 @@ packages:
   safe-regex@2.1.1:
     resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -10133,6 +10394,9 @@ packages:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
 
+  simple-yenc@1.0.4:
+    resolution: {integrity: sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -10181,6 +10445,9 @@ packages:
     resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -10206,6 +10473,10 @@ packages:
   split-on-first@1.1.0:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
     engines: {node: '>=6'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -10424,6 +10695,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thread-stream@3.2.0:
+    resolution: {integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==}
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
@@ -10837,6 +11111,11 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
@@ -11358,6 +11637,8 @@ snapshots:
   '@0no-co/graphql.web@1.2.0(graphql@15.8.0)':
     optionalDependencies:
       graphql: 15.8.0
+
+  '@adiwajshing/keyed-db@0.2.4': {}
 
   '@adobe/css-tools@4.5.0': {}
 
@@ -12153,6 +12434,24 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@cacheable/memory@2.2.0':
+    dependencies:
+      '@cacheable/utils': 2.5.0
+      '@keyv/bigmap': 1.3.1(keyv@5.6.0)
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/node-cache@1.7.6':
+    dependencies:
+      cacheable: 2.5.0
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/utils@2.5.0':
+    dependencies:
+      hashery: 1.5.1
+      keyv: 5.6.0
+
   '@capsizecss/unpack@4.0.0':
     dependencies:
       fontkitten: 1.0.3
@@ -12553,6 +12852,8 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@eshaz/web-worker@1.2.2': {}
+
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
@@ -12943,8 +13244,11 @@ snapshots:
 
   '@grammyjs/types@3.26.0': {}
 
-  '@hapi/hoek@9.3.0':
-    optional: true
+  '@hapi/boom@9.1.4':
+    dependencies:
+      '@hapi/hoek': 9.3.0
+
+  '@hapi/hoek@9.3.0': {}
 
   '@hapi/topo@5.1.0':
     dependencies:
@@ -13262,6 +13566,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@keyv/bigmap@1.3.1(keyv@5.6.0)':
+    dependencies:
+      hashery: 1.5.1
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@keyv/serialize@1.1.1': {}
+
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:
       cross-spawn: 7.0.6
@@ -13484,6 +13796,8 @@ snapshots:
 
   '@pagefind/windows-x64@1.5.2':
     optional: true
+
+  '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -14361,6 +14675,12 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@thi.ng/bitstream@2.4.54':
+    dependencies:
+      '@thi.ng/errors': 2.6.16
+
+  '@thi.ng/errors@2.6.16': {}
+
   '@tokenizer/token@0.3.0': {}
 
   '@tootallnate/once@2.0.1': {}
@@ -14559,6 +14879,22 @@ snapshots:
       '@types/node': 24.12.3
     optional: true
 
+  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/type-utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.2
+      eslint: 9.39.4(jiti@2.7.0)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -14575,6 +14911,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.2
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.2
@@ -14584,6 +14932,15 @@ snapshots:
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.7.0)
       typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.2(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.2
+      debug: 4.4.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14601,9 +14958,25 @@ snapshots:
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/visitor-keys': 8.59.2
 
+  '@typescript-eslint/tsconfig-utils@8.59.2(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
   '@typescript-eslint/tsconfig-utils@8.59.2(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
+
+  '@typescript-eslint/type-utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/type-utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -14619,6 +14992,21 @@ snapshots:
 
   '@typescript-eslint/types@8.59.2': {}
 
+  '@typescript-eslint/typescript-estree@8.59.2(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/visitor-keys': 8.59.2
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.0
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/typescript-estree@8.59.2(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.59.2(typescript@6.0.3)
@@ -14631,6 +15019,17 @@ snapshots:
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14791,6 +15190,61 @@ snapshots:
       vscode-uri: 3.1.0
 
   '@vscode/l10n@0.0.18': {}
+
+  '@wasm-audio-decoders/common@9.0.7':
+    dependencies:
+      '@eshaz/web-worker': 1.2.2
+      simple-yenc: 1.0.4
+
+  '@wasm-audio-decoders/flac@0.2.10':
+    dependencies:
+      '@wasm-audio-decoders/common': 9.0.7
+      codec-parser: 2.5.0
+
+  '@wasm-audio-decoders/ogg-vorbis@0.1.20':
+    dependencies:
+      '@wasm-audio-decoders/common': 9.0.7
+      codec-parser: 2.5.0
+
+  '@wasm-audio-decoders/opus-ml@0.0.2':
+    dependencies:
+      '@wasm-audio-decoders/common': 9.0.7
+
+  '@whiskeysockets/baileys@6.17.16(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@adiwajshing/keyed-db': 0.2.4
+      '@cacheable/node-cache': 1.7.6
+      '@hapi/boom': 9.1.4
+      '@whiskeysockets/eslint-config': https://codeload.github.com/whiskeysockets/eslint-config/tar.gz/299e8389baf62f9aa3034de18ff0d62cc0a5e838(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      async-lock: 1.4.1
+      audio-decode: 2.2.3
+      axios: 1.18.1
+      cache-manager: 5.7.6
+      libphonenumber-js: 1.13.8
+      libsignal: https://codeload.github.com/WhiskeySockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7
+      lodash: 4.18.1
+      music-metadata: 7.14.0
+      pino: 9.14.0
+      protobufjs: 7.5.7
+      uuid: 10.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - eslint
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@whiskeysockets/eslint-config@https://codeload.github.com/whiskeysockets/eslint-config/tar.gz/299e8389baf62f9aa3034de18ff0d62cc0a5e838(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-plugin-simple-import-sort: 12.1.1(eslint@9.39.4(jiti@2.7.0))
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@xmldom/xmldom@0.8.13': {}
 
@@ -15157,13 +15611,42 @@ snapshots:
 
   async-limiter@1.0.1: {}
 
+  async-lock@1.4.1: {}
+
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
 
   at-least-node@1.0.0: {}
 
+  atomic-sleep@1.0.0: {}
+
+  audio-buffer@5.0.0: {}
+
+  audio-decode@2.2.3:
+    dependencies:
+      '@wasm-audio-decoders/flac': 0.2.10
+      '@wasm-audio-decoders/ogg-vorbis': 0.1.20
+      audio-buffer: 5.0.0
+      audio-type: 2.4.1
+      mpg123-decoder: 1.0.3
+      node-wav: 0.0.2
+      ogg-opus-decoder: 1.7.3
+      qoa-format: 1.0.1
+
+  audio-type@2.4.1: {}
+
   auto-bind@5.0.1: {}
+
+  axios@1.18.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -15520,6 +16003,13 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
 
+  cache-manager@5.7.6:
+    dependencies:
+      eventemitter3: 5.0.4
+      lodash.clonedeep: 4.5.0
+      lru-cache: 10.4.3
+      promise-coalesce: 1.5.0
+
   cacheable-lookup@5.0.4: {}
 
   cacheable-request@7.0.4:
@@ -15531,6 +16021,14 @@ snapshots:
       lowercase-keys: 2.0.0
       normalize-url: 6.1.0
       responselike: 2.0.1
+
+  cacheable@2.5.0:
+    dependencies:
+      '@cacheable/memory': 2.2.0
+      '@cacheable/utils': 2.5.0
+      hookified: 1.15.1
+      keyv: 5.6.0
+      qified: 0.10.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -15692,6 +16190,8 @@ snapshots:
   code-excerpt@4.0.0:
     dependencies:
       convert-to-spaces: 2.0.1
+
+  codec-parser@2.5.0: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -15917,6 +16417,8 @@ snapshots:
   csstype@3.1.3: {}
 
   csstype@3.2.3: {}
+
+  curve25519-js@0.0.4: {}
 
   data-urls@5.0.0:
     dependencies:
@@ -16398,6 +16900,10 @@ snapshots:
       zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -16936,6 +17442,8 @@ snapshots:
 
   flow-enums-runtime@0.0.6: {}
 
+  follow-redirects@1.16.0: {}
+
   fontace@0.4.1:
     dependencies:
       fontkitten: 1.0.3
@@ -17193,6 +17701,10 @@ snapshots:
 
   has-unicode@2.0.1: {}
 
+  hashery@1.5.1:
+    dependencies:
+      hookified: 1.15.1
+
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
@@ -17428,6 +17940,10 @@ snapshots:
       react-is: 16.13.1
 
   hono@4.12.18: {}
+
+  hookified@1.15.1: {}
+
+  hookified@2.2.0: {}
 
   hosted-git-info@4.1.0:
     dependencies:
@@ -17924,6 +18440,10 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
+
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
@@ -17942,6 +18462,13 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libphonenumber-js@1.13.8: {}
+
+  libsignal@https://codeload.github.com/WhiskeySockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7:
+    dependencies:
+      curve25519-js: 0.0.4
+      protobufjs: 7.5.7
 
   lighthouse-logger@1.4.2:
     dependencies:
@@ -18012,6 +18539,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.clonedeep@4.5.0: {}
 
   lodash.debounce@4.0.8: {}
 
@@ -19255,6 +19784,10 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.4
 
+  mpg123-decoder@1.0.3:
+    dependencies:
+      '@wasm-audio-decoders/common': 9.0.7
+
   mrmime@2.0.1: {}
 
   ms@2.0.0: {}
@@ -19262,6 +19795,18 @@ snapshots:
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
+
+  music-metadata@7.14.0:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      content-type: 1.0.5
+      debug: 4.4.3
+      file-type: 16.5.4
+      media-typer: 1.1.0
+      strtok3: 6.3.0
+      token-types: 4.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   mz@2.7.0:
     dependencies:
@@ -19349,6 +19894,8 @@ snapshots:
   node-stream-zip@1.15.0:
     optional: true
 
+  node-wav@0.0.2: {}
+
   nopt@6.0.0:
     dependencies:
       abbrev: 1.1.1
@@ -19417,7 +19964,16 @@ snapshots:
       node-ensure: 0.0.0
       yauzl: 3.3.2
 
+  ogg-opus-decoder@1.7.3:
+    dependencies:
+      '@wasm-audio-decoders/common': 9.0.7
+      '@wasm-audio-decoders/opus-ml': 0.0.2
+      codec-parser: 2.5.0
+      opus-decoder: 0.7.11
+
   ohash@2.0.11: {}
+
+  on-exit-leak-free@2.1.2: {}
 
   on-finished@2.3.0:
     dependencies:
@@ -19513,6 +20069,10 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  opus-decoder@0.7.11:
+    dependencies:
+      '@wasm-audio-decoders/common': 9.0.7
 
   ora@3.4.0:
     dependencies:
@@ -19671,6 +20231,26 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.2.0
+
   pirates@4.0.7: {}
 
   pkce-challenge@5.0.1: {}
@@ -19766,9 +20346,13 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  process-warning@5.0.0: {}
+
   process@0.11.10: {}
 
   progress@2.0.3: {}
+
+  promise-coalesce@1.5.0: {}
 
   promise-inflight@1.0.1: {}
 
@@ -19812,12 +20396,22 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  proxy-from-env@2.1.0: {}
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  qified@0.10.1:
+    dependencies:
+      hookified: 2.2.0
+
+  qoa-format@1.0.1:
+    dependencies:
+      '@thi.ng/bitstream': 2.4.54
 
   qrcode-terminal@0.11.0: {}
 
@@ -19844,6 +20438,8 @@ snapshots:
   queue@6.0.2:
     dependencies:
       inherits: 2.0.4
+
+  quick-format-unescaped@4.0.4: {}
 
   quick-lru@5.1.1: {}
 
@@ -20129,6 +20725,8 @@ snapshots:
   readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
+
+  real-require@0.2.0: {}
 
   rechoir@0.8.0:
     dependencies:
@@ -20477,6 +21075,8 @@ snapshots:
     dependencies:
       regexp-tree: 0.1.27
 
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
 
   sanitize-filename@1.6.4:
@@ -20712,6 +21312,8 @@ snapshots:
     dependencies:
       semver: 7.8.0
 
+  simple-yenc@1.0.4: {}
+
   sisteransi@1.0.5: {}
 
   sitemap@9.0.1:
@@ -20766,6 +21368,10 @@ snapshots:
       ip-address: 10.2.0
       smart-buffer: 4.2.0
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -20782,6 +21388,8 @@ snapshots:
   space-separated-tokens@2.0.2: {}
 
   split-on-first@1.1.0: {}
+
+  split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
 
@@ -21017,6 +21625,10 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  thread-stream@3.2.0:
+    dependencies:
+      real-require: 0.2.0
+
   throat@5.0.0: {}
 
   tiny-inflate@1.0.3: {}
@@ -21084,6 +21696,10 @@ snapshots:
   truncate-utf8-bytes@1.0.2:
     dependencies:
       utf8-byte-length: 1.0.5
+
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -21355,6 +21971,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@10.0.0: {}
 
   uuid@7.0.3: {}
 


### PR DESCRIPTION
## What

New messaging channel **`@moxxy/plugin-channel-whatsapp`** built on `@moxxy/channel-kit` and modeled on the Telegram plugin. Transport is **Baileys** (`@whiskeysockets/baileys`), the unofficial WhatsApp Web multi-device protocol — an outbound WebSocket, so **no tunnel / no tunnelProvider registration**. Runs on its own **dedicated isolated runner** (`dedicatedRunner: true`, `sessionSource: 'whatsapp'`).

Highlights:
- **Consent gate (non-negotiable).** The first step of every setup surface states plainly that unofficial WhatsApp clients violate WhatsApp's ToS and can get the number **permanently banned**, recommends a secondary number, and requires a typed `yes`. `start()` itself refuses un-acknowledged (vault receipt or `MOXXY_WHATSAPP_TOS_ACK=yes`) — defense in depth for headless/desktop-supervised boots.
- **QR device-link pairing.** The rotating Baileys QR payload renders in the terminal (`pair` / wizard) **and** is published via `channel.requestUrl` + the channel status file so the desktop Channels panel can show it. A phone-side logout (401) clears local creds and gives re-pair guidance (`status` reports `needs-pairing`).
- **Inbound gating on every session-reaching path** (`message-gate.ts`, pure + unit-tested): `notify`-only, zod-validated + size-capped fields, **own-send/`fromMe` echo drop** (Baileys receives your own outbound — loop protection), and a **JID allow-list** (owner's own Note-to-Self chat allowed by default; unauthorized senders dropped silently). Then `@moxxy/channel-kit` `driveTurn` with a turnId-filtered subscriber (invariant #8).
- **Voice notes** → `session.transcribers.tryGetActive()` → text turn (size cap + install guidance, mirrors the Telegram voice handler).
- **Human-in-the-loop permissions** over plain numbered replies (`1`/`2`/`3`), built on core's `createDeferredPermissionResolver`; `stop()` calls `abortAll` so no pending prompt hangs.
- **Swappable auth-state.** A `useMultiFileAuthState` equivalent (`auth-state.ts`) behind a `WhatsAppAuthStorage` interface, default file backend under `~/.moxxy/whatsapp-auth` (dir `0700`, files `0600`).
- **Unbundled/discovery-loaded** (dual export), with catalog, desktop `channel-catalog`, plugins-seed, `SessionSource` union, and the `persistence.ts` runtime guard all extended.

## Design decisions

**Streaming — send-then-edit (not buffered chunks).** WhatsApp supports true message edits (`sendMessage(jid, { text, edit: key })`, the MESSAGE_EDIT protocol, stable in Baileys ≥6.5), so the channel streams one growing message like Telegram/Slack rather than flooding partials. Two WhatsApp-specific adjustments: `editFrameMs` defaults to **3000ms** (vs 1000 elsewhere) because every edit is a full outbound protocol message and high-frequency automated edits are exactly the anomalous traffic that gets numbers flagged on an unofficial client; and **overflow splitting happens only on the final frame** (streaming frames truncate to a single editable message; the final flush edits to the first chunk and sends the tails). A failed **final** edit falls back to re-sending the whole reply so it's never lost.

**Auth-state at rest — dedicated dir, not the vault.** Baileys' auth is a *rotating* key store (signal sessions/pre-keys/sender+app-state-sync keys + creds) that churns constantly; the vault is an encrypted, tagged, human-curated secret store, not a high-write KV backend, so it's the wrong home. State lives under `~/.moxxy/whatsapp-auth` with tight modes. **Tradeoff (recorded in the PR + a TECH_DEBT `[note]`):** unlike vault entries, these files are **not encrypted at rest** — anyone with file access to the moxxy home can hijack the linked session. The `WhatsAppAuthStorage` interface exists so an encrypted backend can be swapped in later without touching the channel.

## Testing (no live WhatsApp account)

70 tests, all green — the Baileys socket is mocked end-to-end (`FakeSocket` implementing the narrow `WhatsAppSocket` contract; the real Baileys import stays behind a lazy `import()` in `baileys-socket.ts` and never loads in tests):
- consent-gate refusal (env/vault, "no" rejected, vault-error = no),
- allow-list gating incl. `fromMe`-foreign-chat drop, own-echo drop, stranger drop,
- payload validation + text/audio size caps + ephemeral/extendedText unwrap,
- auth-state adapter round-trip (creds reuse, null-delete, 0600 files),
- permission reply parsing + `abortAll`-denies-pending,
- streaming split boundaries + disconnect-code policy,
- full channel start-flow driving a real turn through a `FakeProvider` session (owner Note-to-Self + allow-listed friend), voice-note transcription, rotating-QR publish, `stop()` aborts a pending prompt, and 401-logout re-pair failure.

### Needs a live number to verify (can't in CI)
- QR scan → device link round-trip (Linked devices) and the greeting.
- Real edit-vs-chunked streaming fidelity + the ≥4000-char final split tails.
- Voice-note round-trip (ogg/opus download + transcribe) with a real STT backend.
- Re-auth after a phone-side logout (401 → clear creds → re-pair) and the 440/403 failure messages.
- Behavior under WhatsApp's own rate-limiting / anomaly detection.

## Verification
- `pnpm build` / `typecheck` / `lint` (0 errors) / `test` (exit 0) / `check:deps` (0 errors) all green.
- CLI smokes: `bin.js --help` and `bin.js plugins list` OK.
- Changeset added (`@moxxy/plugin-channel-whatsapp` minor, `@moxxy/sdk` minor for the `SessionSource` export, `@moxxy/cli` minor).
- TECH_DEBT updated: at-rest auth-state tradeoff + plain-text permission prompts + follow-ups.

> Note: `@moxxy/plugin-channel-whatsapp` ships an **unofficial** WhatsApp client. It is opt-in, disabled until the user types the consent acknowledgment, and carries the ban warning in its description, catalog entry, setup wizard, and desktop panel.