### PR TITLE
feat(channels): add Discord channel (@moxxy/plugin-channel-discord)

### DIFF
--- a/.changeset/discord-channel.md
+++ b/.changeset/discord-channel.md
@@ -1,0 +1,7 @@
+---
+'@moxxy/plugin-channel-discord': minor
+'@moxxy/sdk': minor
+'@moxxy/cli': minor
+---
+
+New Discord channel (`moxxy discord`): a discord.js gateway bot on a dedicated, isolated runner, built on @moxxy/channel-kit. DM code pairing (bot DMs a one-time code, pasted into the terminal wizard), a paired-principal + per-guild-channel allow-list (vault-persisted, managed via local /allow and /deny), edit-throttled streamed replies (≥1200ms, Discord's ~5 edits/5s limit) with 2000-char splitting, button-based permission/approval prompts, session commands published as Discord slash commands, and voice-message transcription. SDK gains the 'discord' SessionSource; the CLI gains the install-on-first-use hint and session-source stamping for it.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -13,6 +13,15 @@ or recorded-on-purpose decision.
 
 ## Resolved ledger
 
+- [low, sessions, RESOLVED 2026-07-03] `SessionSource` literals were hand-listed in
+  one runtime spot (`sessionSource()`'s validator in
+  `packages/cli/src/setup/persistence.ts`) — adding the Discord channel's
+  `'discord'` source hit exactly the two-spot update this entry warned about, so
+  the list is now a runtime constant: `SESSION_SOURCES` in `@moxxy/sdk`
+  event-store.ts, with the `SessionSource` type DERIVED from it
+  (`(typeof SESSION_SOURCES)[number]`) and the CLI guard doing an `includes()`
+  against the same array. New sources are now a one-line change that can't be
+  silently dropped by a stale validator.
 - [dormant, browser, RESOLVED 2026-07-03] CDP screencast push path (`startScreencast`/
   `stopScreencast` sidecar handlers) — the entry was stale: the handlers were already
   deleted in the PR #212 quality sweep; only screenshot-polling remains (rationale in
@@ -145,11 +154,6 @@ or recorded-on-purpose decision.
   on the `moxxy mobile` runner to make it airtight. `packages/plugin-channel-mobile`.
 - [note] Stress-test multi-session with a desk's SECOND (UUID) session — the first
   session has id === desk id, which masks pool-key regressions. `packages/desktop-host`.
-- [low] `SessionSource` literals are still hand-listed in one runtime spot:
-  `sessionSource()`'s validator in `packages/cli/src/setup/persistence.ts` (a type
-  can't be enumerated at runtime). `DeskSession.source` in `@moxxy/desktop-ipc-contract`
-  was unified onto the SDK type (2026-06-26); when adding a source, update the
-  union in `@moxxy/sdk` event-store.ts AND that guard.
 - [low] TUI `/sessions` switcher only works in self-host/standalone mode (the TUI
   owns the boot, so it can re-bootstrap onto a different session in place). In
   ATTACH mode (thin client against an external `moxxy serve`) the runner owns a
@@ -285,6 +289,14 @@ or recorded-on-purpose decision.
 
 ## Channels, relay & HTTP
 
+- [low] Discord channel pairing is terminal-only: the DM code flow (bot DMs a
+  one-time code → operator pastes it into `moxxy discord pair`) has no GUI
+  completion path, so the desktop Channels panel can start the bot dedicated
+  (window armed, codes issued) but the paste must happen in a terminal, and the
+  already-running dedicated runner only reloads the authorized principal at
+  start — pairing from the desktop means run `moxxy discord pair`, then restart
+  the channel. A `channels.confirmPairingCode` control-surface hook (status-file
+  or IPC) would close both gaps. `packages/plugin-channel-discord`.
 - [low] Desktop channel catalog is now a MIRROR, not the only copy: each channel
   self-describes its config on `ChannelDef.config` (`fields`/`vaultKey`/
   `hasRequestUrl`/`runHint`), which the TUI `/channels` panel + `moxxy channels`

--- a/packages/cli/src/channel-hints.ts
+++ b/packages/cli/src/channel-hints.ts
@@ -14,6 +14,7 @@ const CHANNEL_COMMANDS: Readonly<Record<string, string>> = {
   slack: '@moxxy/plugin-channel-slack',
   signal: '@moxxy/plugin-channel-signal',
   whatsapp: '@moxxy/plugin-channel-whatsapp',
+  discord: '@moxxy/plugin-channel-discord',
   web: '@moxxy/plugin-channel-web',
   http: '@moxxy/plugin-channel-http',
 };

--- a/packages/cli/src/setup/builtin-requirements.generated.ts
+++ b/packages/cli/src/setup/builtin-requirements.generated.ts
@@ -15,6 +15,13 @@ export const BUILTIN_REQUIREMENTS: Readonly<
       "hint": "Enable @moxxy/plugin-subagents — deep-research fans out sub-queries via ctx.subagents."
     }
   ],
+  "@moxxy/plugin-channel-discord": [
+    {
+      "kind": "plugin",
+      "name": "@moxxy/plugin-vault",
+      "hint": "discord resolves the vault from the service registry for its bot token + pairing; @moxxy/plugin-vault must load first"
+    }
+  ],
   "@moxxy/plugin-channel-signal": [
     {
       "kind": "plugin",

--- a/packages/cli/src/setup/persistence.ts
+++ b/packages/cli/src/setup/persistence.ts
@@ -1,4 +1,4 @@
-import { type EventStoreSession, type Session, type SessionSource } from '@moxxy/core';
+import { SESSION_SOURCES, type EventStoreSession, type Session, type SessionSource } from '@moxxy/core';
 import { definePlugin } from '@moxxy/sdk';
 
 /**
@@ -61,17 +61,11 @@ export function attachSessionPersistence(
  *  id implies a desktop-spawned runner, otherwise the interactive TUI. */
 function sessionSource(): SessionSource {
   const explicit = process.env['MOXXY_SESSION_SOURCE'];
-  if (
-    explicit === 'desktop' ||
-    explicit === 'tui' ||
-    explicit === 'mobile' ||
-    explicit === 'cli' ||
-    explicit === 'slack' ||
-    explicit === 'telegram' ||
-    explicit === 'signal' ||
-    explicit === 'whatsapp'
-  ) {
-    return explicit;
+  // Validated against the SDK's runtime SESSION_SOURCES list — the same array
+  // the SessionSource type is derived from, so a newly added source can never
+  // be silently dropped by a stale hand-listed check here.
+  if (explicit && (SESSION_SOURCES as readonly string[]).includes(explicit)) {
+    return explicit as SessionSource;
   }
   return process.env['MOXXY_SESSION_ID'] ? 'desktop' : 'tui';
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,6 +78,7 @@ export {
   setSessionGroup,
   seedSessionMeta,
   SESSION_META_VERSION,
+  SESSION_SOURCES,
   type SessionMeta,
   type SessionSource,
   type SessionPersistenceOpts,

--- a/packages/core/src/sessions/persistence.ts
+++ b/packages/core/src/sessions/persistence.ts
@@ -29,6 +29,7 @@ import { isMoxxyEventShape } from './event-shape.js';
 // Re-exported here (and onward from @moxxy/core) so existing importers are
 // unaffected by the move.
 export type { EventLogLike, EventPage, SessionMeta, SessionSource } from '@moxxy/sdk';
+export { SESSION_SOURCES } from '@moxxy/sdk';
 
 /** Schema version of the per-session metadata file (`<id>.json`). Bump when the
  *  shape changes incompatibly; readers tolerate a missing/older version. */

--- a/packages/desktop-host/src/channel-catalog.ts
+++ b/packages/desktop-host/src/channel-catalog.ts
@@ -162,6 +162,37 @@ export const CHANNEL_CATALOG: Readonly<Record<string, ChannelCatalogEntry>> = {
     },
     requiredKeys: ['whatsapp_tos_acknowledged'],
   },
+  discord: {
+    descriptor: {
+      id: 'discord',
+      name: 'Discord',
+      description:
+        'A Discord bot (gateway WebSocket) on its own dedicated runner. No public URL needed; pairs an account via a DM code.',
+      docsUrl: 'https://discord.com/developers/applications',
+      configFields: [
+        {
+          name: 'botToken',
+          label: 'Bot token',
+          type: 'password',
+          required: true,
+          placeholder: 'MTIz…abc.def…',
+          help: 'Developer Portal → your app → Bot → Reset Token. Enable the MESSAGE CONTENT privileged intent on the same page.',
+        },
+      ],
+      hasWebhookUrl: false,
+      runHint:
+        'Open the invite link to add the bot to a server, then DM it — it replies with a one-time code; finish pairing with `moxxy discord pair` in a terminal.',
+      connect: {
+        kind: 'url',
+        title: 'Invite the bot',
+        hint: 'Open the link to invite the bot to your server, then DM it to receive a pairing code and finish with `moxxy discord pair`.',
+        openable: true,
+        openLabel: 'Open Discord authorization',
+      },
+    },
+    vaultKeys: { botToken: 'discord_bot_token' },
+    requiredKeys: ['discord_bot_token'],
+  },
 };
 
 /** Every catalog entry, in display order. */

--- a/packages/plugin-channel-discord/package.json
+++ b/packages/plugin-channel-discord/package.json
@@ -1,0 +1,89 @@
+{
+  "name": "@moxxy/plugin-channel-discord",
+  "version": "0.26.0",
+  "description": "Discord channel for moxxy via discord.js. Treats Discord DMs and allow-listed guild channels as a bidirectional channel: prompts in, streamed assistant replies out (edit-throttled), button-based permission prompts, DM code pairing.",
+  "keywords": [
+    "moxxy",
+    "agent",
+    "channel",
+    "discord",
+    "bot"
+  ],
+  "homepage": "https://moxxy.ai",
+  "bugs": {
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
+    "directory": "packages/plugin-channel-discord"
+  },
+  "author": "Michal Makowski <michal.makowski97@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "moxxy": {
+    "plugin": {
+      "entry": "./dist/index.js",
+      "kind": "cli"
+    },
+    "requirements": [
+      {
+        "kind": "plugin",
+        "name": "@moxxy/plugin-vault",
+        "hint": "discord resolves the vault from the service registry for its bot token + pairing; @moxxy/plugin-vault must load first"
+      }
+    ],
+    "setup": {
+      "title": "Discord bot",
+      "description": "Create an application at https://discord.com/developers/applications, add a Bot, and under Bot → Privileged Gateway Intents enable MESSAGE CONTENT INTENT (required — without it the bot receives empty messages). Then paste the bot token below.",
+      "required": true,
+      "fields": [
+        {
+          "key": "botToken",
+          "label": "Bot token",
+          "kind": "secret",
+          "vaultKey": "discord_bot_token",
+          "required": true,
+          "placeholder": "MTIz…abc.def…",
+          "description": "Developer Portal → your app → Bot → Reset Token. Remember to enable the MESSAGE CONTENT privileged intent on the same page."
+        }
+      ]
+    }
+  },
+  "dependencies": {
+    "@clack/prompts": "catalog:",
+    "@moxxy/channel-kit": "workspace:*",
+    "@moxxy/core": "workspace:*",
+    "@moxxy/plugin-vault": "workspace:*",
+    "@moxxy/sdk": "workspace:*",
+    "discord.js": "^14.16.0"
+  },
+  "devDependencies": {
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugin-channel-discord/src/allow-list.test.ts
+++ b/packages/plugin-channel-discord/src/allow-list.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { gateInbound } from './allow-list.js';
+import {
+  parseAllowedChannels,
+  parseAuthorizedUser,
+  serializeAllowedChannels,
+} from './keys.js';
+
+const PAIRED = '111111111111';
+const OTHER = '222222222222';
+const GUILD = '333333333333';
+const CHAN = '444444444444';
+
+describe('gateInbound (authorization gate on every session-reaching path)', () => {
+  it('denies everything when unpaired', () => {
+    expect(
+      gateInbound({ authorId: PAIRED, guildId: null, channelId: CHAN }, null, new Set()),
+    ).toEqual({ ok: false, reason: 'not-paired' });
+  });
+
+  it('denies a foreign user even in an allow-listed channel', () => {
+    expect(
+      gateInbound({ authorId: OTHER, guildId: GUILD, channelId: CHAN }, PAIRED, new Set([CHAN])),
+    ).toEqual({ ok: false, reason: 'foreign-user' });
+  });
+
+  it('allows the paired user in a DM', () => {
+    expect(
+      gateInbound({ authorId: PAIRED, guildId: null, channelId: CHAN }, PAIRED, new Set()),
+    ).toEqual({ ok: true, context: 'dm' });
+  });
+
+  it('denies the paired user in a guild channel that is not allow-listed', () => {
+    expect(
+      gateInbound({ authorId: PAIRED, guildId: GUILD, channelId: CHAN }, PAIRED, new Set()),
+    ).toEqual({ ok: false, reason: 'channel-not-allowed' });
+  });
+
+  it('allows the paired user in an allow-listed guild channel', () => {
+    expect(
+      gateInbound({ authorId: PAIRED, guildId: GUILD, channelId: CHAN }, PAIRED, new Set([CHAN])),
+    ).toEqual({ ok: true, context: 'guild' });
+  });
+});
+
+describe('vault value parsers (corrupt values fail closed)', () => {
+  it('parseAuthorizedUser accepts a snowflake, rejects junk', () => {
+    expect(parseAuthorizedUser('123456789')).toBe('123456789');
+    expect(parseAuthorizedUser(' 123456789 ')).toBe('123456789');
+    expect(parseAuthorizedUser('not-a-user')).toBeNull();
+    expect(parseAuthorizedUser('')).toBeNull();
+    expect(parseAuthorizedUser(null)).toBeNull();
+    expect(parseAuthorizedUser('123; DROP TABLE')).toBeNull();
+  });
+
+  it('parseAllowedChannels round-trips and rejects corrupt JSON / junk entries', () => {
+    const raw = serializeAllowedChannels(['111111', '222222', '111111']);
+    expect(parseAllowedChannels(raw)).toEqual(['111111', '222222']);
+    expect(parseAllowedChannels('not json')).toEqual([]);
+    expect(parseAllowedChannels('{"a":1}')).toEqual([]);
+    expect(parseAllowedChannels(JSON.stringify(['111111', 'nope']))).toEqual([]);
+    expect(parseAllowedChannels(null)).toEqual([]);
+  });
+});

--- a/packages/plugin-channel-discord/src/allow-list.ts
+++ b/packages/plugin-channel-discord/src/allow-list.ts
@@ -1,0 +1,30 @@
+import type { InboundMessage } from './schema.js';
+
+/**
+ * Where the paired principal may drive the session from:
+ *   - their own DM with the bot — always allowed once paired;
+ *   - a guild channel — only when that channel id is on the allow-list
+ *     (managed by the paired user via the local /allow and /deny commands).
+ *
+ * Authorship is checked FIRST: a message from anyone but the paired user never
+ * reaches the session, no matter where it was sent (single-operator model,
+ * matching Telegram's single paired chat).
+ */
+export type GateVerdict =
+  | { readonly ok: true; readonly context: 'dm' | 'guild' }
+  | {
+      readonly ok: false;
+      readonly reason: 'not-paired' | 'foreign-user' | 'channel-not-allowed';
+    };
+
+export function gateInbound(
+  msg: Pick<InboundMessage, 'authorId' | 'guildId' | 'channelId'>,
+  authorizedUserId: string | null,
+  allowedChannels: ReadonlySet<string>,
+): GateVerdict {
+  if (!authorizedUserId) return { ok: false, reason: 'not-paired' };
+  if (msg.authorId !== authorizedUserId) return { ok: false, reason: 'foreign-user' };
+  if (msg.guildId == null) return { ok: true, context: 'dm' };
+  if (allowedChannels.has(msg.channelId)) return { ok: true, context: 'guild' };
+  return { ok: false, reason: 'channel-not-allowed' };
+}

--- a/packages/plugin-channel-discord/src/approval.ts
+++ b/packages/plugin-channel-discord/src/approval.ts
@@ -1,0 +1,76 @@
+import type { ApprovalDecision, ApprovalRequest, ApprovalResolver } from '@moxxy/sdk';
+
+export interface PendingApproval {
+  readonly id: string;
+  readonly request: ApprovalRequest;
+  readonly resolve: (decision: ApprovalDecision) => void;
+}
+
+/**
+ * Generic approval resolver for the Discord channel — counterpart to the TUI's
+ * ApprovalDialog. The channel renders the request as a message with a button
+ * per option and routes the user's click (or follow-up text, for options with
+ * `requestsText: true`) back here via `resolvePending` /
+ * `resolvePendingWithText`. Mirrors the Telegram approval resolver's shape.
+ */
+export class DiscordApprovalResolver implements ApprovalResolver {
+  readonly name = 'discord-approval';
+  private readonly pending = new Map<string, PendingApproval>();
+  private deciderFn: ((id: string, request: ApprovalRequest) => Promise<void>) | null = null;
+  private nextId = 1;
+
+  setDecider(fn: (id: string, request: ApprovalRequest) => Promise<void>): void {
+    this.deciderFn = fn;
+  }
+
+  async confirm(request: ApprovalRequest): Promise<ApprovalDecision> {
+    if (!this.deciderFn) {
+      // No bot wired up — best fallback is the request's defaultOptionId.
+      return { optionId: request.defaultOptionId ?? request.options[0]?.id ?? 'approve' };
+    }
+    const id = `appr_${this.nextId++}`;
+    return new Promise<ApprovalDecision>((resolve) => {
+      this.pending.set(id, { id, request, resolve });
+      this.deciderFn!(id, request).catch((err) => {
+        this.pending.delete(id);
+        resolve({
+          optionId: request.defaultOptionId ?? request.options[0]?.id ?? 'cancel',
+          text: `decider failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      });
+    });
+  }
+
+  /** Look up a pending approval without resolving it (text follow-up latch). */
+  getPending(id: string): PendingApproval | undefined {
+    return this.pending.get(id);
+  }
+
+  /** Resolve directly with an option id (no text). */
+  resolvePending(id: string, optionId: string): boolean {
+    const pending = this.pending.get(id);
+    if (!pending) return false;
+    this.pending.delete(id);
+    pending.resolve({ optionId });
+    return true;
+  }
+
+  /** Resolve with an option id AND a free-text follow-up. */
+  resolvePendingWithText(id: string, optionId: string, text: string): boolean {
+    const pending = this.pending.get(id);
+    if (!pending) return false;
+    this.pending.delete(id);
+    pending.resolve({ optionId, text });
+    return true;
+  }
+
+  abortAll(reason = 'channel closed'): void {
+    for (const pending of this.pending.values()) {
+      pending.resolve({
+        optionId: pending.request.defaultOptionId ?? pending.request.options[0]?.id ?? 'cancel',
+        text: reason,
+      });
+    }
+    this.pending.clear();
+  }
+}

--- a/packages/plugin-channel-discord/src/channel.ts
+++ b/packages/plugin-channel-discord/src/channel.ts
@@ -1,0 +1,509 @@
+import {
+  Client,
+  Events,
+  GatewayIntentBits,
+  Partials,
+  type Interaction,
+  type Message,
+} from 'discord.js';
+import { newTurnId } from '@moxxy/core';
+import { TurnCoordinator } from '@moxxy/channel-kit';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import type {
+  ApprovalRequest,
+  Channel,
+  ChannelHandle,
+  ChannelStartOptsBase,
+  MoxxyEvent,
+  PendingToolCall,
+  PermissionContext,
+} from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { DiscordPermissionResolver } from './permission.js';
+import { DiscordApprovalResolver } from './approval.js';
+import { resolveBotToken, DISCORD_TOKEN_KEY } from './keys.js';
+import { extractInboundMessage } from './schema.js';
+import { splitForDiscord } from './render.js';
+import { AllowListStore } from './channel/allow-list-store.js';
+import type { ChannelLogger, SendableChannelLike } from './channel/discord-like.js';
+import {
+  handleInboundMessage,
+  performSessionAction,
+  type AwaitingApprovalText,
+  type InboundContext,
+} from './channel/message-handler.js';
+import { handleInteraction, type InteractionLike } from './channel/interaction-handler.js';
+import { PairingHandler, type PairingConfirmResult } from './channel/pairing-handler.js';
+import { askForPermission } from './channel/permission-prompt.js';
+import { askForApproval } from './channel/approval-prompt.js';
+import { publishAppCommands } from './channel/slash-handler.js';
+import { clampEditFrameMs, runDiscordTurn } from './channel/turn-runner.js';
+import { handleVoiceMessage } from './channel/voice-handler.js';
+import { TypingIndicator } from './channel/typing-indicator.js';
+
+/** Cap on waiting for the gateway READY event (bot identity → invite link).
+ *  Identity resolution must never wedge `start()`; on timeout we proceed
+ *  without the invite URL and the gateway surfaces real token errors itself. */
+const READY_TIMEOUT_MS = 15_000;
+
+/** Minimal permission bits for the invite link: View Channels + Send Messages
+ *  + Read Message History. */
+const INVITE_PERMISSIONS = 1024 + 2048 + 65536;
+
+export type { PairingConfirmResult } from './channel/pairing-handler.js';
+
+export interface DiscordStartOpts extends ChannelStartOptsBase {
+  readonly session: Session;
+  /**
+   * If true (and no account is paired yet), arm the DM pairing window on
+   * startup: an unauthorized user who DMs the bot is issued a one-time code,
+   * and the terminal `moxxy discord pair` flow confirms the pasted code. Set
+   * by the `pair` subcommand.
+   */
+  readonly pair?: boolean;
+  /**
+   * The channel is running on its own dedicated runner under a GUI control
+   * surface (the desktop Channels panel). Arms the same pairing window as
+   * `pair` for the unpaired case so DM-ing users at least receive codes —
+   * completing the paste still needs the terminal `moxxy discord pair` flow.
+   */
+  readonly dedicated?: boolean;
+}
+
+export interface DiscordChannelOptions {
+  readonly vault: VaultStore;
+  readonly token?: string;
+  readonly logger?: ChannelLogger;
+  /** Streaming edit throttle; clamped to ≥1200ms (Discord's ~5 edits/5s per
+   *  channel rate limit). */
+  readonly editFrameMs?: number;
+}
+
+export class DiscordChannel implements Channel<DiscordStartOpts> {
+  readonly name = 'discord';
+  readonly permissionResolver: DiscordPermissionResolver;
+  readonly approvalResolver: DiscordApprovalResolver;
+  private readonly opts: DiscordChannelOptions;
+  private readonly editFrameMs: number;
+  private client: Client | null = null;
+  private botUserId: string | null = null;
+  // The bot's OAuth2 invite URL (resolved from the application id after the
+  // gateway READY), published as this channel's `requestUrl` connect value so
+  // control surfaces can render an "invite the bot" step. Null until resolved.
+  private inviteUrl: string | null = null;
+  private readonly connectListeners = new Set<() => void>();
+  // Channel the CURRENT turn runs in (target for permission/approval prompts).
+  private currentChannel: SendableChannelLike | null = null;
+  // Last channel we served — the target for mirroring foreign turns.
+  private lastChannel: SendableChannelLike | null = null;
+  private logUnsub: (() => void) | null = null;
+  private session: Session | null = null;
+  private model: string | undefined;
+  private yolo = false;
+  // Single-flight turn state: `busy` guard, per-turn AbortController (so
+  // /cancel aborts only the current turn), and the bounded own-turn-id set
+  // that mirrorForeignTurn filters on (AGENTS.md invariant #8).
+  private readonly turns = new TurnCoordinator();
+  private awaitingApprovalText: AwaitingApprovalText | null = null;
+  private handle: ChannelHandle | null = null;
+  private readonly typing = new TypingIndicator();
+  private readonly pairing: PairingHandler;
+  private readonly allowList: AllowListStore;
+  // Rate-limit the "dropped invalid payload" warning so a hostile sender
+  // can't turn the log into a firehose.
+  private lastInvalidWarnAt = 0;
+
+  constructor(opts: DiscordChannelOptions) {
+    this.opts = opts;
+    this.editFrameMs = clampEditFrameMs(opts.editFrameMs);
+    this.permissionResolver = new DiscordPermissionResolver();
+    this.approvalResolver = new DiscordApprovalResolver();
+    this.pairing = new PairingHandler({
+      vault: opts.vault,
+      ...(opts.logger ? { logger: opts.logger } : {}),
+    });
+    this.allowList = new AllowListStore(opts.vault);
+    // A completed pairing flips this channel's connect-state to "connected".
+    this.pairing.onPaired((userId) => {
+      this.notifyConnectChange();
+      this.greetPairedUser(userId);
+    });
+  }
+
+  /** This channel's connect value (see {@link Channel.requestUrl}): the bot's
+   *  OAuth2 invite URL, surfaced by control surfaces as an "invite the bot"
+   *  step. */
+  get requestUrl(): string | null {
+    return this.inviteUrl;
+  }
+
+  /** Whether an account is paired (see {@link Channel.connected}). */
+  get connected(): boolean {
+    return this.pairing.phase() === 'paired';
+  }
+
+  pairingPhase(): ReturnType<PairingHandler['phase']> {
+    return this.pairing.phase();
+  }
+
+  unpair(): void {
+    this.pairing.unpair();
+  }
+
+  /** Subscribe to "an account just paired" (fires once per completed pairing).
+   *  Returns an unsubscribe function. */
+  onPaired(listener: (userId: string) => void): () => void {
+    return this.pairing.onPaired(listener);
+  }
+
+  /** The terminal pair flow submits the operator-pasted code here. */
+  confirmPairingCode(rawCode: string): Promise<PairingConfirmResult> {
+    return this.pairing.confirmCode(rawCode);
+  }
+
+  async start(startOpts: DiscordStartOpts): Promise<ChannelHandle> {
+    if (this.handle) return this.handle;
+    this.session = startOpts.session;
+    this.model = startOpts.model;
+
+    // Precedence mirrors the other channels (and this channel's isAvailable
+    // gate): explicit option, then MOXXY_DISCORD_TOKEN, then the vault.
+    const token = this.opts.token ?? (await resolveBotToken(this.opts.vault));
+    if (!token) {
+      throw new Error(
+        `Discord bot token not found. Store one via vault_set('${DISCORD_TOKEN_KEY}', ...) or set MOXXY_DISCORD_TOKEN.`,
+      );
+    }
+    await this.pairing.loadAuthorized();
+    await this.allowList.load();
+
+    // Arm the DM pairing window when a pairing surface asked for it (`pair`)
+    // OR when running GUI-supervised on a dedicated runner and nothing is
+    // paired yet. A headless start with neither signal errors with a hint.
+    const dedicated = startOpts.dedicated === true || process.env.MOXXY_DEDICATED_RUNNER === '1';
+    if (this.pairing.phase() !== 'paired') {
+      if (startOpts.pair || dedicated) {
+        this.pairing.arm();
+        this.opts.logger?.info?.('discord pairing window armed');
+      } else {
+        throw new Error(
+          'No Discord account is paired yet. Run `moxxy discord pair`, DM the bot, and paste the code it replies with.',
+        );
+      }
+    }
+
+    // MessageContent is a PRIVILEGED intent — the setup wizard tells the user
+    // to enable it in the Developer Portal; without it every guild message
+    // arrives with empty content. Partials.Channel is required for DMs (they
+    // are not cached when the first event for them arrives).
+    const client = new Client({
+      intents: [
+        GatewayIntentBits.Guilds,
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.DirectMessages,
+        GatewayIntentBits.MessageContent,
+      ],
+      partials: [Partials.Channel],
+    });
+    this.client = client;
+    this.permissionResolver.setDecider((call, ctx) => this.askForPermission(call, ctx));
+    this.approvalResolver.setDecider((id, request) => this.askForApproval(id, request));
+    // Register the approval resolver on the session so loop strategies
+    // (plan-execute) surface their validation dialog on this channel;
+    // stop() tears it down so headless paths never see a stale handler.
+    this.session.setApprovalResolver(this.approvalResolver);
+
+    // Mirror-to-both: when the session runs a turn this channel did NOT
+    // initiate (e.g. a co-attached web surface), post the assistant's prose
+    // into the last channel we served. Our OWN turns render via the pump.
+    this.logUnsub = this.session.log.subscribe((event) => this.mirrorForeignTurn(event));
+
+    // discord.js does not await event handlers, but we still fire-and-track so
+    // rejections are logged (they would otherwise be unhandled rejections).
+    client.on(Events.MessageCreate, (message) =>
+      this.dispatchInBackground(this.handleMessage(message), 'message'),
+    );
+    client.on(Events.InteractionCreate, (interaction) =>
+      this.dispatchInBackground(this.handleInteractionEvent(interaction), 'interaction'),
+    );
+    client.on(Events.Error, (err) => {
+      this.opts.logger?.warn('discord client error', { err: String(err) });
+    });
+
+    // Resolve the bot's identity (application id → invite URL, own user id)
+    // from the READY event, BOUNDED so a slow gateway can't wedge start() —
+    // on timeout we proceed without the invite link (mirrors Telegram's getMe
+    // timeout). `login` itself rejects fast on an invalid token.
+    const ready = new Promise<void>((resolve) => {
+      client.once(Events.ClientReady, () => resolve());
+    });
+    await client.login(token);
+    const readyTimer = new Promise<never>((_, reject) => {
+      const t = setTimeout(
+        () => reject(new Error(`gateway READY timed out after ${READY_TIMEOUT_MS}ms`)),
+        READY_TIMEOUT_MS,
+      );
+      t.unref?.();
+    });
+    try {
+      await Promise.race([ready, readyTimer]);
+      this.botUserId = client.user?.id ?? null;
+      const appId = client.application?.id ?? null;
+      if (appId) {
+        this.inviteUrl = `https://discord.com/oauth2/authorize?client_id=${appId}&scope=bot%20applications.commands&permissions=${INVITE_PERMISSIONS}`;
+      }
+      // Surface the shared registry commands in Discord's "/" picker. Best
+      // effort — a failure never blocks startup (text commands still work).
+      const commands = client.application?.commands;
+      void publishAppCommands(
+        commands ? { set: (defs) => commands.set([...defs]) } : null,
+        this.session,
+        this.opts.logger,
+      );
+    } catch (err) {
+      this.opts.logger?.warn('discord: could not resolve bot identity (READY timeout)', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    this.opts.logger?.info?.('discord channel starting', {
+      paired: this.pairing.phase() === 'paired',
+    });
+
+    // The gateway has no "runs until stopped" promise; resolve on stop().
+    let resolveRunning: () => void = () => undefined;
+    const running = new Promise<void>((resolve) => {
+      resolveRunning = resolve;
+    });
+    this.handle = {
+      running,
+      onConnectChange: (listener) => {
+        this.connectListeners.add(listener);
+        return () => this.connectListeners.delete(listener);
+      },
+      stop: async (reason = 'shutdown') => {
+        // Abort the in-flight turn FIRST so the model loop stops generating /
+        // executing the moment the operator asks to shut down; then reject
+        // pending prompts so no caller hangs (audit: TuiChannel.stop hang).
+        this.turns.abort(reason);
+        this.permissionResolver.abortAll(reason);
+        this.approvalResolver.abortAll(reason);
+        this.logUnsub?.();
+        this.logUnsub = null;
+        if (this.session) this.session.setApprovalResolver(null);
+        this.typing.stop();
+        if (this.client) {
+          await this.client.destroy().catch(() => undefined);
+          this.client = null;
+        }
+        resolveRunning();
+      },
+    };
+    return this.handle;
+  }
+
+  private notifyConnectChange(): void {
+    for (const listener of this.connectListeners) {
+      try {
+        listener();
+      } catch (err) {
+        this.opts.logger?.warn('discord connect-change listener threw', { err: String(err) });
+      }
+    }
+  }
+
+  /** DM a confirmation to the freshly paired account. Best-effort. */
+  private greetPairedUser(userId: string): void {
+    const client = this.client;
+    if (!client) return;
+    void client.users
+      .fetch(userId)
+      .then((user) => user.send('✅ Paired with moxxy. Send a prompt to begin.'))
+      .catch((err) => {
+        this.opts.logger?.warn('discord pairing greeting failed', { err: String(err) });
+      });
+  }
+
+  /**
+   * Run a handler promise detached from the event dispatch. Errors are logged
+   * here — discord.js does not surface handler rejections anywhere useful.
+   */
+  private dispatchInBackground(work: Promise<void>, kind: string): void {
+    void work.catch((err) => {
+      this.opts.logger?.warn('discord handler failed', { kind, err: String(err) });
+    });
+  }
+
+  private async handleMessage(raw: Message): Promise<void> {
+    // Boundary validation (invariant A8): extract ONLY the fields we consume
+    // and zod-validate them; drop invalid/oversized payloads with a
+    // rate-limited warning.
+    const msg = extractInboundMessage(raw);
+    if (!msg) {
+      const now = Date.now();
+      if (now - this.lastInvalidWarnAt > 10_000) {
+        this.lastInvalidWarnAt = now;
+        this.opts.logger?.warn('discord: dropped invalid inbound message payload');
+      }
+      return;
+    }
+    const channel = raw.channel as unknown as { send?: unknown };
+    if (typeof channel.send !== 'function') return;
+    const ctx: InboundContext = {
+      msg,
+      channel: raw.channel as unknown as SendableChannelLike,
+      reply: (text) => raw.reply(text),
+    };
+    const deps = {
+      pairing: this.pairing,
+      allowList: this.allowList,
+      approvalResolver: this.approvalResolver,
+      permissionResolver: this.permissionResolver,
+      ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+    };
+    await handleInboundMessage(
+      ctx,
+      {
+        session: this.session,
+        busy: this.turns.busy,
+        turnController: this.turns.controller,
+        awaitingApprovalText: this.awaitingApprovalText,
+        handle: this.handle,
+        botUserId: this.botUserId,
+      },
+      deps,
+      {
+        setAwaitingApprovalText: (state) => {
+          this.awaitingApprovalText = state;
+        },
+        toggleYolo: () => {
+          this.yolo = !this.yolo;
+          return this.yolo;
+        },
+        setYolo: (value) => {
+          this.yolo = value;
+        },
+        runUserTurn: (c, text) => this.runUserTurn(c, text),
+        runVoiceMessage: (c) =>
+          handleVoiceMessage(
+            c,
+            { session: this.session, busy: this.turns.busy },
+            this.opts.logger ? { logger: this.opts.logger } : {},
+            { runUserTurn: (cc, text) => this.runUserTurn(cc, text) },
+          ),
+      },
+    );
+  }
+
+  private async handleInteractionEvent(interaction: Interaction): Promise<void> {
+    await handleInteraction(
+      interaction as unknown as InteractionLike,
+      { session: this.session, turnController: this.turns.controller },
+      {
+        pairing: this.pairing,
+        allowList: this.allowList,
+        permissionResolver: this.permissionResolver,
+        approvalResolver: this.approvalResolver,
+        ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+      },
+      {
+        setAwaitingApprovalText: (state) => {
+          this.awaitingApprovalText = state;
+        },
+        toggleYolo: () => {
+          this.yolo = !this.yolo;
+          return this.yolo;
+        },
+        performSessionAction: (action, notice) =>
+          performSessionAction(
+            action,
+            notice,
+            {
+              session: this.session,
+              turnController: this.turns.controller,
+              handle: this.handle,
+            },
+            {
+              approvalResolver: this.approvalResolver,
+              permissionResolver: this.permissionResolver,
+            },
+            {
+              setAwaitingApprovalText: (state) => {
+                this.awaitingApprovalText = state;
+              },
+              setYolo: (value) => {
+                this.yolo = value;
+              },
+            },
+          ),
+      },
+    );
+  }
+
+  private async runUserTurn(ctx: InboundContext, text: string): Promise<void> {
+    if (!this.session) throw new Error('DiscordChannel.start() must be called first');
+    // Atomic single-flight guard: `begin` claims the slot synchronously so a
+    // concurrently dispatched second turn can't slip past the busy check. The
+    // turnId is minted here so the coordinator records it as an own-turn id
+    // (mirrorForeignTurn filters on those).
+    const lease = this.turns.begin(newTurnId());
+    if (!lease) {
+      await ctx.reply('I am still working on the previous prompt. Send /cancel to abort it.');
+      return;
+    }
+    this.currentChannel = ctx.channel;
+    this.lastChannel = ctx.channel;
+    try {
+      await runDiscordTurn(
+        {
+          session: this.session,
+          channel: ctx.channel,
+          typing: this.typing,
+          editFrameMs: this.editFrameMs,
+          ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+        },
+        { text, model: this.model, controller: lease.controller, turnId: lease.turnId },
+      );
+    } finally {
+      lease.end();
+      this.currentChannel = null;
+    }
+  }
+
+  /**
+   * Post the assistant's prose for a turn this channel did not initiate. The
+   * coordinator skips turns THIS channel started, by turnId (invariant #8),
+   * and yields the trimmed prose; we only need a served channel to post into.
+   */
+  private mirrorForeignTurn(event: MoxxyEvent): void {
+    const text = this.turns.mirrorText(event);
+    if (text == null) return;
+    const target = this.lastChannel;
+    if (!target) return;
+    void (async () => {
+      for (const part of splitForDiscord(text)) {
+        await target.send(part);
+      }
+    })().catch((err) => {
+      this.opts.logger?.warn('discord mirror failed', { err: String(err) });
+    });
+  }
+
+  private askForPermission(call: PendingToolCall, ctx: PermissionContext): Promise<void> {
+    return askForPermission(call, ctx, {
+      channel: this.currentChannel,
+      session: this.session,
+      resolver: this.permissionResolver,
+      yolo: this.yolo,
+      ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+    });
+  }
+
+  private askForApproval(id: string, request: ApprovalRequest): Promise<void> {
+    return askForApproval(id, request, {
+      channel: this.currentChannel,
+      resolver: this.approvalResolver,
+      ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+    });
+  }
+}

--- a/packages/plugin-channel-discord/src/channel/allow-list-store.ts
+++ b/packages/plugin-channel-discord/src/channel/allow-list-store.ts
@@ -1,0 +1,52 @@
+import type { VaultStore } from '@moxxy/plugin-vault';
+import {
+  DISCORD_ALLOWED_CHANNELS_KEY,
+  parseAllowedChannels,
+  serializeAllowedChannels,
+  snowflakeSchema,
+} from '../keys.js';
+
+/**
+ * Vault-backed guild-channel allow-list: the channels (beyond the paired
+ * user's DM) the paired user may drive the session from. Managed via the
+ * local `/allow` and `/deny` commands; persisted as a JSON snowflake array
+ * under {@link DISCORD_ALLOWED_CHANNELS_KEY} (corrupt values read as empty —
+ * deny-by-default).
+ */
+export class AllowListStore {
+  private ids = new Set<string>();
+
+  constructor(private readonly vault: VaultStore) {}
+
+  async load(): Promise<void> {
+    this.ids = new Set(parseAllowedChannels(await this.vault.get(DISCORD_ALLOWED_CHANNELS_KEY)));
+  }
+
+  snapshot(): ReadonlySet<string> {
+    return this.ids;
+  }
+
+  has(channelId: string): boolean {
+    return this.ids.has(channelId);
+  }
+
+  /** Add a channel id. Returns false (no write) for a non-snowflake id. */
+  async add(channelId: string): Promise<boolean> {
+    if (!snowflakeSchema.safeParse(channelId).success) return false;
+    if (this.ids.has(channelId)) return true;
+    this.ids.add(channelId);
+    await this.persist();
+    return true;
+  }
+
+  /** Remove a channel id. Returns true when it was present. */
+  async remove(channelId: string): Promise<boolean> {
+    const removed = this.ids.delete(channelId);
+    if (removed) await this.persist();
+    return removed;
+  }
+
+  private async persist(): Promise<void> {
+    await this.vault.set(DISCORD_ALLOWED_CHANNELS_KEY, serializeAllowedChannels(this.ids));
+  }
+}

--- a/packages/plugin-channel-discord/src/channel/approval-prompt.ts
+++ b/packages/plugin-channel-discord/src/channel/approval-prompt.ts
@@ -1,0 +1,43 @@
+import type { ApprovalRequest } from '@moxxy/sdk';
+import type { DiscordApprovalResolver } from '../approval.js';
+import { BUTTON_STYLE, button, packRows } from './components.js';
+import type { ChannelLogger, SendableChannelLike } from './discord-like.js';
+
+export interface ApprovalPromptDeps {
+  readonly channel: SendableChannelLike | null;
+  readonly resolver: DiscordApprovalResolver;
+  readonly logger?: ChannelLogger;
+}
+
+/**
+ * Render an approval request (e.g. plan-execute "validate plan") as a message
+ * with a button per option. Options with `requestsText` are still picked here;
+ * the interaction handler then captures the user's NEXT message as the
+ * follow-up text via the channel's awaiting-text state.
+ */
+export async function askForApproval(
+  id: string,
+  request: ApprovalRequest,
+  deps: ApprovalPromptDeps,
+): Promise<void> {
+  if (!deps.channel) return;
+  const rows = packRows(
+    request.options.map((opt) =>
+      button(`appr:${id}:${opt.id}`, opt.label, BUTTON_STYLE.secondary),
+    ),
+  );
+  // Discord caps messages at 2000 chars; keep the body well under so the
+  // prompt always sends. The full plan streams in as assistant messages.
+  const body = request.body.length > 1500 ? request.body.slice(0, 1499) + '…' : request.body;
+  const summary =
+    `📋 **${request.title}**\n\n${body}\n\n` +
+    `Pick an option below. Some options (e.g. Redraft) prompt for follow-up text after you click.`;
+  try {
+    await deps.channel.send({ content: summary, components: rows });
+  } catch (err) {
+    deps.logger?.warn('discord approval send failed', { err: String(err) });
+    // Default-resolve on send failure so the loop strategy doesn't hang.
+    const fallback = request.defaultOptionId ?? request.options[0]?.id ?? 'cancel';
+    deps.resolver.resolvePending(id, fallback);
+  }
+}

--- a/packages/plugin-channel-discord/src/channel/components.ts
+++ b/packages/plugin-channel-discord/src/channel/components.ts
@@ -1,0 +1,49 @@
+/**
+ * Raw Discord message-component JSON (API shape) for the button rows the
+ * channel renders. Built as plain objects rather than discord.js Builders so
+ * the prompt modules stay dependency-free and unit-testable — discord.js
+ * accepts raw API component data in `send()` payloads.
+ */
+
+/** Discord API button styles. */
+export const BUTTON_STYLE = {
+  primary: 1,
+  secondary: 2,
+  success: 3,
+  danger: 4,
+} as const;
+
+export interface ApiButton {
+  readonly type: 2;
+  readonly style: number;
+  readonly label: string;
+  readonly custom_id: string;
+}
+
+export interface ApiActionRow {
+  readonly type: 1;
+  readonly components: ReadonlyArray<ApiButton>;
+}
+
+const MAX_LABEL_CHARS = 80;
+const MAX_CUSTOM_ID_CHARS = 100;
+const MAX_BUTTONS_PER_ROW = 5;
+const MAX_ROWS = 5;
+
+export function button(customId: string, label: string, style: number): ApiButton {
+  return {
+    type: 2,
+    style,
+    label: label.slice(0, MAX_LABEL_CHARS) || '…',
+    custom_id: customId.slice(0, MAX_CUSTOM_ID_CHARS),
+  };
+}
+
+/** Pack buttons into action rows (5 per row, 5 rows max — 25 button cap). */
+export function packRows(buttons: ReadonlyArray<ApiButton>): ApiActionRow[] {
+  const rows: ApiActionRow[] = [];
+  for (let i = 0; i < buttons.length && rows.length < MAX_ROWS; i += MAX_BUTTONS_PER_ROW) {
+    rows.push({ type: 1, components: buttons.slice(i, i + MAX_BUTTONS_PER_ROW) });
+  }
+  return rows;
+}

--- a/packages/plugin-channel-discord/src/channel/discord-like.ts
+++ b/packages/plugin-channel-discord/src/channel/discord-like.ts
@@ -1,0 +1,30 @@
+/**
+ * Structural slices of the discord.js surface the handlers touch. Keeping the
+ * handlers typed against these (instead of discord.js classes) keeps the
+ * messenger-specific transport at the channel edge and lets unit tests drive
+ * every gating / streaming / pairing path with plain fake objects — no gateway
+ * connection, no discord.js instances.
+ */
+
+/** A message we sent and can edit in place (the streamed frame). */
+export interface SentMessageLike {
+  edit(content: string): Promise<unknown>;
+}
+
+/** Payload accepted by `send` — text plus optional component rows (buttons). */
+export interface OutboundPayload {
+  readonly content: string;
+  readonly components?: ReadonlyArray<unknown>;
+}
+
+/** A channel (DM or guild text channel) we can post into. */
+export interface SendableChannelLike {
+  send(payload: string | OutboundPayload): Promise<SentMessageLike>;
+  /** Discord's typing indicator lasts ~10s per call; refresh to keep it alive. */
+  sendTyping?(): Promise<unknown>;
+}
+
+export interface ChannelLogger {
+  info?(msg: string, meta?: Record<string, unknown>): void;
+  warn(msg: string, meta?: Record<string, unknown>): void;
+}

--- a/packages/plugin-channel-discord/src/channel/interaction-handler.test.ts
+++ b/packages/plugin-channel-discord/src/channel/interaction-handler.test.ts
@@ -1,0 +1,212 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VaultStore, createStaticKeySource, deriveKey, generateSalt } from '@moxxy/plugin-vault';
+import type { PendingToolCall, PermissionContext } from '@moxxy/sdk';
+import { DISCORD_AUTHORIZED_USER_KEY } from '../keys.js';
+import { DiscordApprovalResolver } from '../approval.js';
+import { DiscordPermissionResolver } from '../permission.js';
+import { AllowListStore } from './allow-list-store.js';
+import { PairingHandler } from './pairing-handler.js';
+import { handleInteraction, type InteractionLike } from './interaction-handler.js';
+
+const PAIRED = '111111111111';
+const STRANGER = '222222222222';
+const GUILD = '333333333333';
+const CHAN = '444444444444';
+
+let tmp: string;
+let vault: VaultStore;
+let pairing: PairingHandler;
+let allowList: AllowListStore;
+let approvalResolver: DiscordApprovalResolver;
+let permissionResolver: DiscordPermissionResolver;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-dc-int-'));
+  vault = new VaultStore({
+    filePath: path.join(tmp, 'vault.json'),
+    keySource: createStaticKeySource(deriveKey('test', generateSalt())),
+  });
+  pairing = new PairingHandler({ vault });
+  allowList = new AllowListStore(vault);
+  approvalResolver = new DiscordApprovalResolver();
+  permissionResolver = new DiscordPermissionResolver();
+  await vault.set(DISCORD_AUTHORIZED_USER_KEY, PAIRED);
+  await pairing.loadAuthorized();
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+interface FakeInteraction extends InteractionLike {
+  readonly replies: Array<{ content: string; ephemeral?: boolean }>;
+  readonly updates: unknown[];
+}
+
+function buttonInteraction(customId: string, userId = PAIRED): FakeInteraction {
+  const replies: Array<{ content: string; ephemeral?: boolean }> = [];
+  const updates: unknown[] = [];
+  return {
+    replies,
+    updates,
+    isButton: () => true,
+    isChatInputCommand: () => false,
+    customId,
+    user: { id: userId },
+    reply: async (p) => {
+      replies.push(p);
+    },
+    update: async (p) => {
+      updates.push(p);
+    },
+    followUp: async (p) => {
+      replies.push(p);
+    },
+  };
+}
+
+function slashInteraction(
+  commandName: string,
+  opts: { userId?: string; guildId?: string | null; channelId?: string | null } = {},
+): FakeInteraction {
+  const replies: Array<{ content: string; ephemeral?: boolean }> = [];
+  return {
+    replies,
+    updates: [],
+    isButton: () => false,
+    isChatInputCommand: () => true,
+    commandName,
+    user: { id: opts.userId ?? PAIRED },
+    guildId: opts.guildId ?? null,
+    channelId: opts.channelId ?? null,
+    reply: async (p) => {
+      replies.push(p);
+    },
+  };
+}
+
+function deps() {
+  return { pairing, allowList, permissionResolver, approvalResolver };
+}
+
+function callbacks() {
+  return {
+    setAwaitingApprovalText: vi.fn(),
+    toggleYolo: vi.fn(() => true),
+    performSessionAction: vi.fn(async () => '✓ done'),
+  };
+}
+
+const state = { session: null, turnController: null };
+
+describe('handleInteraction — authorization gate', () => {
+  it('refuses button clicks from an unpaired user (buttons are visible to a whole guild)', async () => {
+    // Park a real pending permission so a bypass would be observable.
+    permissionResolver.setDecider(async () => undefined);
+    const decision = permissionResolver.check(
+      { callId: 'c1', name: 'bash', input: {} } as PendingToolCall,
+      {} as PermissionContext,
+    );
+    const interaction = buttonInteraction('perm:c1:allow', STRANGER);
+    await handleInteraction(interaction, state, deps(), callbacks());
+    expect(interaction.replies[0]?.content).toMatch(/different Discord account/);
+    expect(interaction.updates).toEqual([]);
+    // The prompt is still pending — the stranger's click resolved nothing.
+    permissionResolver.abortAll('test done');
+    await expect(decision).resolves.toEqual({ mode: 'deny', reason: 'test done' });
+  });
+
+  it('refuses slash commands from an unpaired user', async () => {
+    const interaction = slashInteraction('info', { userId: STRANGER });
+    await handleInteraction(interaction, state, deps(), callbacks());
+    expect(interaction.replies[0]?.content).toMatch(/different Discord account/);
+  });
+});
+
+describe('handleInteraction — permission buttons', () => {
+  it.each([
+    ['allow', { mode: 'allow' }],
+    ['allow_session', { mode: 'allow_session' }],
+    ['deny', { mode: 'deny', reason: 'denied by user' }],
+  ] as const)('maps %s clicks to the resolver decision', async (choice, expected) => {
+    permissionResolver.setDecider(async () => undefined);
+    const decision = permissionResolver.check(
+      { callId: 'c1', name: 'bash', input: {} } as PendingToolCall,
+      {} as PermissionContext,
+    );
+    const interaction = buttonInteraction(`perm:c1:${choice}`);
+    await handleInteraction(interaction, state, deps(), callbacks());
+    await expect(decision).resolves.toEqual(expected);
+    // Buttons cleared so the user can't double-click.
+    expect(interaction.updates).toEqual([{ components: [] }]);
+  });
+
+  it('answers "no pending permission" for a stale click', async () => {
+    const interaction = buttonInteraction('perm:ghost:allow');
+    await handleInteraction(interaction, state, deps(), callbacks());
+    expect(interaction.replies[0]?.content).toMatch(/no pending permission/);
+  });
+});
+
+describe('handleInteraction — approval buttons', () => {
+  it('resolves a pending approval by option id', async () => {
+    approvalResolver.setDecider(async () => undefined);
+    const decision = approvalResolver.confirm({
+      title: 't',
+      body: 'b',
+      options: [
+        { id: 'approve', label: 'Approve' },
+        { id: 'cancel', label: 'Cancel' },
+      ],
+      defaultOptionId: 'approve',
+    } as never);
+    const interaction = buttonInteraction('appr:appr_1:approve');
+    await handleInteraction(interaction, state, deps(), callbacks());
+    await expect(decision).resolves.toEqual({ optionId: 'approve' });
+  });
+
+  it('latches awaiting-text for options that request follow-up text', async () => {
+    approvalResolver.setDecider(async () => undefined);
+    void approvalResolver.confirm({
+      title: 't',
+      body: 'b',
+      options: [{ id: 'redraft', label: 'Redraft', requestsText: true, textPrompt: 'Say more' }],
+      defaultOptionId: 'redraft',
+    } as never);
+    const cb = callbacks();
+    const interaction = buttonInteraction('appr:appr_1:redraft');
+    await handleInteraction(interaction, state, deps(), cb);
+    expect(cb.setAwaitingApprovalText).toHaveBeenCalledWith({
+      approvalId: 'appr_1',
+      optionId: 'redraft',
+    });
+    expect(interaction.replies[0]?.content).toMatch(/Say more/);
+    approvalResolver.abortAll('test done');
+  });
+});
+
+describe('handleInteraction — slash commands', () => {
+  it('/allow works in a guild channel that is NOT yet allow-listed', async () => {
+    const interaction = slashInteraction('allow', { guildId: GUILD, channelId: CHAN });
+    await handleInteraction(interaction, state, deps(), callbacks());
+    expect(allowList.has(CHAN)).toBe(true);
+    expect(interaction.replies[0]?.content).toMatch(/✓/);
+  });
+
+  it('other commands in a non-allow-listed guild channel get the /allow hint', async () => {
+    const interaction = slashInteraction('info', { guildId: GUILD, channelId: CHAN });
+    await handleInteraction(interaction, state, deps(), callbacks());
+    expect(interaction.replies[0]?.content).toMatch(/\/allow/);
+  });
+
+  it('/cancel aborts the in-flight turn', async () => {
+    const controller = new AbortController();
+    const interaction = slashInteraction('cancel');
+    await handleInteraction(interaction, { session: null, turnController: controller }, deps(), callbacks());
+    expect(controller.signal.aborted).toBe(true);
+    expect(interaction.replies[0]?.content).toMatch(/cancelling/);
+  });
+});

--- a/packages/plugin-channel-discord/src/channel/interaction-handler.ts
+++ b/packages/plugin-channel-discord/src/channel/interaction-handler.ts
@@ -1,0 +1,234 @@
+import type { ClientSession as Session } from '@moxxy/sdk';
+import type { PermissionDecision } from '@moxxy/sdk';
+import type { DiscordApprovalResolver } from '../approval.js';
+import type { DiscordPermissionResolver } from '../permission.js';
+import type { AllowListStore } from './allow-list-store.js';
+import type { ChannelLogger } from './discord-like.js';
+import type { AwaitingApprovalText } from './message-handler.js';
+import type { PairingHandler } from './pairing-handler.js';
+import { runSlash } from './slash-handler.js';
+
+/**
+ * Structural slice of a discord.js Interaction the handler needs — buttons
+ * (permission / approval prompts) and chat-input (slash) commands. Kept
+ * structural so tests drive it with plain objects.
+ */
+export interface InteractionLike {
+  isButton(): boolean;
+  isChatInputCommand(): boolean;
+  /** Button custom id (`perm:<callId>:<choice>` / `appr:<id>:<optionId>`). */
+  readonly customId?: string;
+  /** Slash-command name. */
+  readonly commandName?: string;
+  readonly user: { readonly id: string };
+  readonly channelId?: string | null;
+  readonly guildId?: string | null;
+  reply(payload: { content: string; ephemeral?: boolean }): Promise<unknown>;
+  /** Buttons only: edit the prompt message (used to clear the button row).
+   *  NB: this ACKS the interaction — any later message must use followUp. */
+  update?(payload: { components: ReadonlyArray<unknown> }): Promise<unknown>;
+  /** Post-ack follow-up message (valid only after update/reply succeeded). */
+  followUp?(payload: { content: string; ephemeral?: boolean }): Promise<unknown>;
+}
+
+export interface InteractionState {
+  readonly session: Session | null;
+  readonly turnController: AbortController | null;
+}
+
+export interface InteractionDeps {
+  readonly pairing: PairingHandler;
+  readonly allowList: AllowListStore;
+  readonly permissionResolver: DiscordPermissionResolver;
+  readonly approvalResolver: DiscordApprovalResolver;
+  readonly logger?: ChannelLogger;
+}
+
+export interface InteractionCallbacks {
+  readonly setAwaitingApprovalText: (state: AwaitingApprovalText | null) => void;
+  readonly toggleYolo: () => boolean;
+  readonly performSessionAction: (
+    action: 'new' | 'clear' | 'exit',
+    notice: string | undefined,
+  ) => Promise<string>;
+}
+
+/**
+ * Interaction router (button clicks + slash commands). The authorization gate
+ * runs FIRST and for EVERY path (AGENTS.md A46 — Telegram's callback handlers
+ * once skipped it): button clicks resolve permission prompts and approvals,
+ * slash commands reach the session, and a prompt message can be seen (and its
+ * buttons clicked) by any member of a guild channel — so an unpaired user's
+ * interactions must be refused exactly like their messages.
+ */
+export async function handleInteraction(
+  interaction: InteractionLike,
+  state: InteractionState,
+  deps: InteractionDeps,
+  cb: InteractionCallbacks,
+): Promise<void> {
+  if (!interaction.isButton() && !interaction.isChatInputCommand()) return;
+
+  if (!deps.pairing.isAuthorized(interaction.user.id)) {
+    await safeReply(interaction, 'This bot is paired with a different Discord account.', deps.logger);
+    return;
+  }
+
+  if (interaction.isButton()) {
+    await handleButton(interaction, deps, cb);
+    return;
+  }
+  await handleSlashCommand(interaction, state, deps, cb);
+}
+
+async function handleButton(
+  interaction: InteractionLike,
+  deps: InteractionDeps,
+  cb: InteractionCallbacks,
+): Promise<void> {
+  const data = interaction.customId ?? '';
+  if (data.startsWith('perm:')) {
+    const parts = data.split(':');
+    if (parts.length !== 3 || !parts[1] || !parts[2]) return;
+    const handled = deps.permissionResolver.resolvePending(parts[1], mapChoice(parts[2]));
+    const acked = await clearButtons(interaction, deps.logger);
+    if (!handled) await respond(interaction, 'no pending permission', acked, deps.logger);
+    // A click must always be acked or Discord shows "interaction failed".
+    else if (!acked) await respond(interaction, `→ ${parts[2]}`, acked, deps.logger);
+    return;
+  }
+  if (data.startsWith('appr:')) {
+    const idx = data.indexOf(':', 5);
+    if (idx < 0) return;
+    const approvalId = data.slice(5, idx);
+    const optionId = data.slice(idx + 1);
+    const pending = deps.approvalResolver.getPending(approvalId);
+    if (!pending) {
+      await safeReply(interaction, 'no pending approval', deps.logger);
+      return;
+    }
+    const option = pending.request.options.find((o) => o.id === optionId);
+    if (!option) {
+      await safeReply(interaction, 'unknown option', deps.logger);
+      return;
+    }
+    const acked = await clearButtons(interaction, deps.logger);
+    if (option.requestsText) {
+      // Don't resolve yet — capture the user's next message as the follow-up
+      // text. Mirrors the TUI dialog's text-entry sub-mode.
+      cb.setAwaitingApprovalText({ approvalId, optionId });
+      const prompt =
+        option.textPrompt ??
+        `Send your message — the next text you type becomes the ${optionId} input.`;
+      await respond(interaction, `✏️ ${prompt}`, acked, deps.logger);
+      return;
+    }
+    deps.approvalResolver.resolvePending(approvalId, optionId);
+    await respond(interaction, `→ ${option.label}`, acked, deps.logger);
+  }
+}
+
+async function handleSlashCommand(
+  interaction: InteractionLike,
+  state: InteractionState,
+  deps: InteractionDeps,
+  cb: InteractionCallbacks,
+): Promise<void> {
+  const name = interaction.commandName ?? '';
+  const channelId = interaction.channelId ?? null;
+  const inGuild = interaction.guildId != null;
+
+  // Allow-list management works from the guild channel itself; /allow is the
+  // one command that must work BEFORE the channel is allow-listed.
+  if (name === 'allow' && inGuild && channelId) {
+    await deps.allowList.add(channelId);
+    await safeReply(interaction, '✓ this channel can now drive moxxy. Use /deny here to revoke.', deps.logger);
+    return;
+  }
+  if (name === 'deny' && inGuild && channelId) {
+    const removed = await deps.allowList.remove(channelId);
+    await safeReply(
+      interaction,
+      removed ? '✓ channel removed from the allow-list.' : 'this channel was not allow-listed.',
+      deps.logger,
+    );
+    return;
+  }
+
+  // Everything else obeys the same channel gate as plain messages: a guild
+  // channel must be allow-listed (DMs with the paired user always pass).
+  if (inGuild && channelId && !deps.allowList.has(channelId)) {
+    await safeReply(interaction, 'This channel is not allow-listed. Send /allow here to enable it.', deps.logger);
+    return;
+  }
+
+  if (name === 'cancel') {
+    if (state.turnController && !state.turnController.signal.aborted) {
+      state.turnController.abort('user cancel');
+      await safeReply(interaction, 'cancelling current turn…', deps.logger);
+    } else {
+      await safeReply(interaction, 'nothing to cancel.', deps.logger);
+    }
+    return;
+  }
+
+  if (!state.session) {
+    await safeReply(interaction, 'Session is not ready yet.', deps.logger);
+    return;
+  }
+  const reply = await runSlash(name, '', state.session, {
+    toggleYolo: cb.toggleYolo,
+    performSessionAction: cb.performSessionAction,
+  });
+  await safeReply(interaction, reply.length > 1_900 ? reply.slice(0, 1_899) + '…' : reply, deps.logger);
+}
+
+function mapChoice(choice: string): PermissionDecision {
+  if (choice === 'allow') return { mode: 'allow' };
+  if (choice === 'allow_session') return { mode: 'allow_session' };
+  return { mode: 'deny', reason: 'denied by user' };
+}
+
+/** Clear the prompt's button row. Returns true when the update ACKED the
+ *  interaction (later messages must then use followUp, not reply). */
+async function clearButtons(interaction: InteractionLike, logger?: ChannelLogger): Promise<boolean> {
+  if (!interaction.update) return false;
+  try {
+    await interaction.update({ components: [] });
+    return true;
+  } catch (err) {
+    logger?.warn('discord clear-buttons failed', { err: String(err) });
+    return false;
+  }
+}
+
+/** Send a user-visible ack: followUp when the interaction was already acked
+ *  (a successful `update`), plain ephemeral reply otherwise. */
+async function respond(
+  interaction: InteractionLike,
+  content: string,
+  acked: boolean,
+  logger?: ChannelLogger,
+): Promise<void> {
+  try {
+    if (acked && interaction.followUp) {
+      await interaction.followUp({ content, ephemeral: true });
+    } else {
+      await interaction.reply({ content, ephemeral: true });
+    }
+  } catch (err) {
+    logger?.warn('discord interaction respond failed', { err: String(err) });
+  }
+}
+
+async function safeReply(
+  interaction: InteractionLike,
+  content: string,
+  logger?: ChannelLogger,
+): Promise<void> {
+  try {
+    await interaction.reply({ content, ephemeral: true });
+  } catch (err) {
+    logger?.warn('discord interaction reply failed', { err: String(err) });
+  }
+}

--- a/packages/plugin-channel-discord/src/channel/message-handler.test.ts
+++ b/packages/plugin-channel-discord/src/channel/message-handler.test.ts
@@ -1,0 +1,295 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VaultStore, createStaticKeySource, deriveKey, generateSalt } from '@moxxy/plugin-vault';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import { DISCORD_AUTHORIZED_USER_KEY } from '../keys.js';
+import type { InboundMessage } from '../schema.js';
+import { extractInboundMessage, MAX_CONTENT_CHARS } from '../schema.js';
+import { DiscordApprovalResolver } from '../approval.js';
+import { DiscordPermissionResolver } from '../permission.js';
+import { AllowListStore } from './allow-list-store.js';
+import { PairingHandler } from './pairing-handler.js';
+import {
+  handleInboundMessage,
+  type InboundContext,
+  type MessageHandlerCallbacks,
+  type MessageHandlerState,
+} from './message-handler.js';
+
+const PAIRED = '111111111111';
+const STRANGER = '222222222222';
+const GUILD = '333333333333';
+const CHAN = '444444444444';
+const DM_CHAN = '555555555555';
+
+let tmp: string;
+let vault: VaultStore;
+let pairing: PairingHandler;
+let allowList: AllowListStore;
+let approvalResolver: DiscordApprovalResolver;
+let permissionResolver: DiscordPermissionResolver;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-dc-msg-'));
+  vault = new VaultStore({
+    filePath: path.join(tmp, 'vault.json'),
+    keySource: createStaticKeySource(deriveKey('test', generateSalt())),
+  });
+  pairing = new PairingHandler({ vault });
+  allowList = new AllowListStore(vault);
+  approvalResolver = new DiscordApprovalResolver();
+  permissionResolver = new DiscordPermissionResolver();
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+async function pairAs(userId: string): Promise<void> {
+  await vault.set(DISCORD_AUTHORIZED_USER_KEY, userId);
+  await pairing.loadAuthorized();
+}
+
+function msg(overrides: Partial<InboundMessage> = {}): InboundMessage {
+  return {
+    id: '999999999999',
+    content: 'hello',
+    channelId: DM_CHAN,
+    guildId: null,
+    authorId: PAIRED,
+    authorIsBot: false,
+    attachments: [],
+    ...overrides,
+  };
+}
+
+interface Ctxed {
+  ctx: InboundContext;
+  replies: string[];
+}
+
+function makeCtx(m: InboundMessage): Ctxed {
+  const replies: string[] = [];
+  return {
+    replies,
+    ctx: {
+      msg: m,
+      channel: { send: async () => ({ edit: async () => undefined }) },
+      reply: async (text: string) => {
+        replies.push(text);
+      },
+    },
+  };
+}
+
+function makeState(overrides: Partial<MessageHandlerState> = {}): MessageHandlerState {
+  return {
+    session: null,
+    busy: false,
+    turnController: null,
+    awaitingApprovalText: null,
+    handle: null,
+    botUserId: null,
+    ...overrides,
+  };
+}
+
+function makeCallbacks(overrides: Partial<MessageHandlerCallbacks> = {}): MessageHandlerCallbacks & {
+  runUserTurn: ReturnType<typeof vi.fn>;
+  runVoiceMessage: ReturnType<typeof vi.fn>;
+} {
+  const runUserTurn = vi.fn(async () => undefined);
+  const runVoiceMessage = vi.fn(async () => false);
+  return {
+    setAwaitingApprovalText: () => undefined,
+    toggleYolo: () => false,
+    setYolo: () => undefined,
+    runUserTurn,
+    runVoiceMessage,
+    ...overrides,
+  } as never;
+}
+
+function deps() {
+  return { pairing, allowList, approvalResolver, permissionResolver };
+}
+
+describe('handleInboundMessage — gating (every session-reaching path)', () => {
+  it('drops an unpaired DM with pairing guidance (no window armed)', async () => {
+    const { ctx, replies } = makeCtx(msg({ authorId: STRANGER }));
+    const cb = makeCallbacks();
+    await handleInboundMessage(ctx, makeState(), deps(), cb);
+    expect(cb.runUserTurn).not.toHaveBeenCalled();
+    expect(replies.join(' ')).toMatch(/pairing window/i);
+  });
+
+  it('issues a pairing code to an unpaired DM when the window is armed', async () => {
+    pairing.arm();
+    const { ctx, replies } = makeCtx(msg({ authorId: STRANGER }));
+    const cb = makeCallbacks();
+    await handleInboundMessage(ctx, makeState(), deps(), cb);
+    expect(cb.runUserTurn).not.toHaveBeenCalled();
+    expect(replies[0]).toMatch(/pairing code/i);
+  });
+
+  it('silently drops unpaired GUILD messages (no server spam)', async () => {
+    pairing.arm();
+    const { ctx, replies } = makeCtx(msg({ authorId: STRANGER, guildId: GUILD, channelId: CHAN }));
+    const cb = makeCallbacks();
+    await handleInboundMessage(ctx, makeState(), deps(), cb);
+    expect(cb.runUserTurn).not.toHaveBeenCalled();
+    expect(replies).toEqual([]);
+  });
+
+  it('drops a foreign user in a guild even when the channel is allow-listed', async () => {
+    await pairAs(PAIRED);
+    await allowList.add(CHAN);
+    const { ctx, replies } = makeCtx(msg({ authorId: STRANGER, guildId: GUILD, channelId: CHAN }));
+    const cb = makeCallbacks();
+    await handleInboundMessage(ctx, makeState(), deps(), cb);
+    expect(cb.runUserTurn).not.toHaveBeenCalled();
+    expect(replies).toEqual([]);
+  });
+
+  it('blocks the paired user in a non-allow-listed guild channel with a hint', async () => {
+    await pairAs(PAIRED);
+    const { ctx, replies } = makeCtx(msg({ guildId: GUILD, channelId: CHAN }));
+    const cb = makeCallbacks();
+    await handleInboundMessage(ctx, makeState(), deps(), cb);
+    expect(cb.runUserTurn).not.toHaveBeenCalled();
+    expect(replies[0]).toMatch(/\/allow/);
+  });
+
+  it('/allow from the paired user opts a guild channel in; messages then flow', async () => {
+    await pairAs(PAIRED);
+    const first = makeCtx(msg({ guildId: GUILD, channelId: CHAN, content: '/allow' }));
+    const cb = makeCallbacks();
+    await handleInboundMessage(first.ctx, makeState(), deps(), cb);
+    expect(first.replies[0]).toMatch(/✓/);
+    expect(allowList.has(CHAN)).toBe(true);
+
+    const second = makeCtx(msg({ guildId: GUILD, channelId: CHAN, content: 'do the thing' }));
+    await handleInboundMessage(second.ctx, makeState(), deps(), cb);
+    expect(cb.runUserTurn).toHaveBeenCalledWith(second.ctx, 'do the thing');
+  });
+
+  it('/deny removes a guild channel from the allow-list', async () => {
+    await pairAs(PAIRED);
+    await allowList.add(CHAN);
+    const { ctx, replies } = makeCtx(msg({ guildId: GUILD, channelId: CHAN, content: '/deny' }));
+    await handleInboundMessage(ctx, makeState(), deps(), makeCallbacks());
+    expect(replies[0]).toMatch(/removed/);
+    expect(allowList.has(CHAN)).toBe(false);
+  });
+
+  it('never reacts to bot-authored messages (paired or not)', async () => {
+    await pairAs(PAIRED);
+    const { ctx, replies } = makeCtx(msg({ authorIsBot: true }));
+    const cb = makeCallbacks();
+    await handleInboundMessage(ctx, makeState(), deps(), cb);
+    expect(cb.runUserTurn).not.toHaveBeenCalled();
+    expect(replies).toEqual([]);
+  });
+
+  it('drops oversized content at the validation boundary (extractInboundMessage)', () => {
+    const raw = {
+      id: '999999999999',
+      content: 'x'.repeat(MAX_CONTENT_CHARS + 1),
+      channelId: DM_CHAN,
+      guildId: null,
+      author: { id: PAIRED, bot: false },
+      attachments: null,
+    };
+    expect(extractInboundMessage(raw)).toBeNull();
+    // Under the cap it validates.
+    expect(extractInboundMessage({ ...raw, content: 'ok' })).not.toBeNull();
+  });
+});
+
+describe('handleInboundMessage — dispatch', () => {
+  it('runs a user turn for a paired DM', async () => {
+    await pairAs(PAIRED);
+    const { ctx } = makeCtx(msg({ content: 'what time is it' }));
+    const cb = makeCallbacks();
+    await handleInboundMessage(ctx, makeState(), deps(), cb);
+    expect(cb.runUserTurn).toHaveBeenCalledWith(ctx, 'what time is it');
+  });
+
+  it('refuses new prompts while busy', async () => {
+    await pairAs(PAIRED);
+    const { ctx, replies } = makeCtx(msg());
+    const cb = makeCallbacks();
+    await handleInboundMessage(ctx, makeState({ busy: true }), deps(), cb);
+    expect(cb.runUserTurn).not.toHaveBeenCalled();
+    expect(replies[0]).toMatch(/still working/);
+  });
+
+  it('/cancel aborts the in-flight turn even while busy', async () => {
+    await pairAs(PAIRED);
+    const controller = new AbortController();
+    const { ctx, replies } = makeCtx(msg({ content: '/cancel' }));
+    await handleInboundMessage(
+      ctx,
+      makeState({ busy: true, turnController: controller }),
+      deps(),
+      makeCallbacks(),
+    );
+    expect(controller.signal.aborted).toBe(true);
+    expect(replies[0]).toMatch(/cancelling/);
+  });
+
+  it('captures awaiting-approval text before the busy guard', async () => {
+    await pairAs(PAIRED);
+    // Wire a decider so confirm() parks as pending (id 'appr_1').
+    approvalResolver.setDecider(async () => undefined);
+    const pendingDecision = approvalResolver.confirm({
+      title: 't',
+      body: 'b',
+      options: [{ id: 'redraft', label: 'Redraft', requestsText: true }],
+      defaultOptionId: 'redraft',
+    } as never);
+
+    const setAwaiting = vi.fn();
+    const { ctx, replies } = makeCtx(msg({ content: 'my feedback here' }));
+    await handleInboundMessage(
+      ctx,
+      makeState({ busy: true, awaitingApprovalText: { approvalId: 'appr_1', optionId: 'redraft' } }),
+      deps(),
+      makeCallbacks({ setAwaitingApprovalText: setAwaiting }),
+    );
+    expect(setAwaiting).toHaveBeenCalledWith(null);
+    expect(replies[0]).toMatch(/✓ submitted/);
+    await expect(pendingDecision).resolves.toEqual({ optionId: 'redraft', text: 'my feedback here' });
+  });
+
+  it('routes registry slash commands through session.commands', async () => {
+    await pairAs(PAIRED);
+    const handler = vi.fn(async () => ({ kind: 'text', text: 'info output' }));
+    const session = {
+      id: 'sess',
+      commands: { get: (name: string) => (name === 'info' ? { handler } : undefined) },
+    } as unknown as Session;
+    const { ctx, replies } = makeCtx(msg({ content: '/info' }));
+    await handleInboundMessage(ctx, makeState({ session }), deps(), makeCallbacks());
+    expect(handler).toHaveBeenCalled();
+    expect(replies[0]).toBe('info output');
+  });
+
+  it('dispatches audio attachments to the voice path instead of a text turn', async () => {
+    await pairAs(PAIRED);
+    const { ctx } = makeCtx(
+      msg({
+        content: '',
+        attachments: [
+          { id: '888888888888', url: 'https://cdn.example/x.ogg', contentType: 'audio/ogg', size: 100, name: 'v.ogg' },
+        ],
+      }),
+    );
+    const cb = makeCallbacks({ runVoiceMessage: vi.fn(async () => true) });
+    await handleInboundMessage(ctx, makeState(), deps(), cb);
+    expect(cb.runVoiceMessage).toHaveBeenCalledWith(ctx);
+    expect(cb.runUserTurn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-channel-discord/src/channel/message-handler.ts
+++ b/packages/plugin-channel-discord/src/channel/message-handler.ts
@@ -1,0 +1,192 @@
+import type { ChannelHandle, ClientSession as Session } from '@moxxy/sdk';
+import { gateInbound } from '../allow-list.js';
+import type { InboundMessage } from '../schema.js';
+import type { DiscordApprovalResolver } from '../approval.js';
+import type { DiscordPermissionResolver } from '../permission.js';
+import type { AllowListStore } from './allow-list-store.js';
+import type { ChannelLogger, SendableChannelLike } from './discord-like.js';
+import type { PairingHandler } from './pairing-handler.js';
+import { runSlash } from './slash-handler.js';
+
+export interface AwaitingApprovalText {
+  approvalId: string;
+  optionId: string;
+}
+
+/** A validated inbound message plus the transport bits needed to answer it. */
+export interface InboundContext {
+  readonly msg: InboundMessage;
+  readonly channel: SendableChannelLike;
+  reply(text: string): Promise<unknown>;
+}
+
+export interface MessageHandlerState {
+  readonly session: Session | null;
+  readonly busy: boolean;
+  readonly turnController: AbortController | null;
+  readonly awaitingApprovalText: AwaitingApprovalText | null;
+  readonly handle: ChannelHandle | null;
+  /** The bot's own user id (ignore self-authored messages defensively). */
+  readonly botUserId: string | null;
+}
+
+export interface MessageHandlerDeps {
+  readonly pairing: PairingHandler;
+  readonly allowList: AllowListStore;
+  readonly approvalResolver: DiscordApprovalResolver;
+  readonly permissionResolver: DiscordPermissionResolver;
+  readonly logger?: ChannelLogger;
+}
+
+export interface MessageHandlerCallbacks {
+  readonly setAwaitingApprovalText: (state: AwaitingApprovalText | null) => void;
+  readonly toggleYolo: () => boolean;
+  readonly setYolo: (value: boolean) => void;
+  readonly runUserTurn: (ctx: InboundContext, text: string) => Promise<void>;
+  /** Handle audio attachments (voice messages). Returns true when it consumed
+   *  the message (so the text path is skipped). */
+  readonly runVoiceMessage: (ctx: InboundContext) => Promise<boolean>;
+}
+
+/**
+ * Top-level dispatch for inbound Discord messages. Every session-reaching path
+ * is behind the pairing + allow-list gate (AGENTS.md A46: gate EVERY path):
+ * validation happened upstream (the caller only builds an {@link
+ * InboundContext} from a zod-validated extraction), authorization happens
+ * here, and only then do approval-capture / cancel / slash / turn paths run.
+ */
+export async function handleInboundMessage(
+  ctx: InboundContext,
+  state: MessageHandlerState,
+  deps: MessageHandlerDeps,
+  cb: MessageHandlerCallbacks,
+): Promise<void> {
+  const { msg } = ctx;
+  // Never react to bots (including ourselves) — bot-to-bot loops.
+  if (msg.authorIsBot || (state.botUserId != null && msg.authorId === state.botUserId)) return;
+
+  const text = msg.content.trim();
+  const verdict = gateInbound(msg, deps.pairing.authorizedUserId(), deps.allowList.snapshot());
+
+  if (!verdict.ok) {
+    if (verdict.reason === 'not-paired' || verdict.reason === 'foreign-user') {
+      // DMs get pairing guidance (a fresh code when a window is armed, a
+      // rejection for a foreign account); guild messages are dropped silently
+      // so an unpaired bot can't be made to spam a server.
+      if (msg.guildId == null) {
+        const reply = deps.pairing.handleUnpairedDm(msg.authorId);
+        if (reply) await ctx.reply(reply);
+      }
+      return;
+    }
+    // Paired user in a guild channel that isn't allow-listed: /allow opts the
+    // channel in (this is the ONE command that must work pre-allow-list —
+    // it's how the list gets populated); anything else gets a hint.
+    if (text === '/allow') {
+      await deps.allowList.add(msg.channelId);
+      await ctx.reply('✓ this channel can now drive moxxy. Use /deny here to revoke.');
+      return;
+    }
+    await ctx.reply('This channel is not allow-listed. Send /allow here to enable it.');
+    return;
+  }
+
+  if (!text && msg.attachments.length === 0) return;
+
+  // Capture awaiting-text BEFORE the busy guard so the user can answer an
+  // approval text prompt even while the strategy is technically mid-turn
+  // (it's pending on us).
+  if (state.awaitingApprovalText && text) {
+    const { approvalId, optionId } = state.awaitingApprovalText;
+    cb.setAwaitingApprovalText(null);
+    const handled = deps.approvalResolver.resolvePendingWithText(approvalId, optionId, text);
+    await ctx.reply(handled ? `✓ submitted (${optionId})` : 'that approval is no longer pending');
+    return;
+  }
+
+  // /cancel works even while busy; everything else routes below.
+  if (text === '/cancel') {
+    if (state.turnController && !state.turnController.signal.aborted) {
+      state.turnController.abort('user cancel');
+      await ctx.reply('cancelling current turn…');
+    } else {
+      await ctx.reply('nothing to cancel.');
+    }
+    return;
+  }
+
+  if (text === '/deny' && msg.guildId != null) {
+    const removed = await deps.allowList.remove(msg.channelId);
+    await ctx.reply(removed ? '✓ channel removed from the allow-list.' : 'this channel was not allow-listed.');
+    return;
+  }
+  if (text === '/allow' && msg.guildId != null) {
+    await ctx.reply('this channel is already allow-listed.');
+    return;
+  }
+
+  if (text.startsWith('/')) {
+    if (!state.session) return;
+    const [head, ...rest] = text.split(/\s+/);
+    const reply = await runSlash(head!.slice(1), rest.join(' '), state.session, {
+      toggleYolo: cb.toggleYolo,
+      performSessionAction: (action, notice) =>
+        performSessionAction(action, notice, state, deps, cb),
+    });
+    if (reply) await ctx.reply(reply.length > 1_900 ? reply.slice(0, 1_899) + '…' : reply);
+    return;
+  }
+
+  // Voice messages / audio uploads take the transcribe-then-turn path.
+  if (await cb.runVoiceMessage(ctx)) return;
+  if (!text) return;
+
+  if (state.busy) {
+    await ctx.reply('I am still working on the previous prompt. Send /cancel to abort it.');
+    return;
+  }
+
+  await cb.runUserTurn(ctx, text);
+}
+
+/**
+ * Channel-side handler for `session-action` outputs from registered commands.
+ * Mirrors the Telegram channel's semantics; returns the reply text. Shared by
+ * the plain-text slash path (above) and the interaction (slash-command) path
+ * in the channel.
+ */
+export async function performSessionAction(
+  action: 'new' | 'clear' | 'exit',
+  notice: string | undefined,
+  state: Pick<MessageHandlerState, 'session' | 'turnController' | 'handle'>,
+  deps: Pick<MessageHandlerDeps, 'approvalResolver' | 'permissionResolver'>,
+  cb: Pick<MessageHandlerCallbacks, 'setAwaitingApprovalText' | 'setYolo'>,
+): Promise<string> {
+  if (!state.session) return 'session is not ready yet.';
+  if (action === 'exit') {
+    // Fire the stop AFTER we return so the reply can still be delivered.
+    setTimeout(() => void state.handle?.stop('user /exit'), 250);
+    return notice ?? 'closing Discord channel';
+  }
+  if (action === 'clear') {
+    return `✓ ${notice ?? 'cleared'}`;
+  }
+  // action === 'new'
+  if (state.turnController && !state.turnController.signal.aborted) {
+    state.turnController.abort('user reset');
+  }
+  cb.setYolo(false);
+  cb.setAwaitingApprovalText(null);
+  deps.approvalResolver.abortAll('session reset');
+  deps.permissionResolver.abortAll('session reset');
+  // Wipe the history at its source (RemoteSession.reset() asks the runner; a
+  // mirror-only log.clear() would desync) and only claim success when the
+  // reset actually happened (AGENTS.md A10).
+  try {
+    if (typeof state.session.reset === 'function') await state.session.reset();
+    else state.session.log.clear();
+  } catch (err) {
+    return `⚠ /new failed: ${err instanceof Error ? err.message : String(err)} — history NOT cleared`;
+  }
+  return `✓ ${notice ?? 'new session — conversation history cleared'}`;
+}

--- a/packages/plugin-channel-discord/src/channel/pairing-handler.ts
+++ b/packages/plugin-channel-discord/src/channel/pairing-handler.ts
@@ -1,0 +1,147 @@
+import type { VaultStore } from '@moxxy/plugin-vault';
+import {
+  armPairing,
+  clearDiscordPairing,
+  confirmPendingCode,
+  createDiscordPairingState,
+  isUserAuthorized,
+  mintCodeForPeer,
+  pairingPhase,
+  type DiscordPairingDecision,
+  type DiscordPairingPhase,
+  type DiscordPairingState,
+} from '../pairing.js';
+import { DISCORD_AUTHORIZED_USER_KEY, parseAuthorizedUser } from '../keys.js';
+
+/** Result returned by {@link PairingHandler.confirmCode}. */
+export type PairingConfirmResult =
+  | { ok: true; userId: string }
+  | { ok: false; reason: 'mismatch' | 'expired' | 'not-pending'; message: string };
+
+export interface PairingHandlerOptions {
+  readonly vault: VaultStore;
+  readonly logger?: {
+    info?(msg: string, meta?: Record<string, unknown>): void;
+    warn(msg: string, meta?: Record<string, unknown>): void;
+  };
+}
+
+/**
+ * Owns the pairing state machine + vault persistence for the DM code flow
+ * (see `../pairing.ts` for the flow + security property). The channel feeds it
+ * DMs from unauthorized users ({@link handleUnpairedDm}) and the terminal
+ * wizard feeds it pasted codes ({@link confirmCode}).
+ */
+export class PairingHandler {
+  private state: DiscordPairingState = createDiscordPairingState();
+  private readonly opts: PairingHandlerOptions;
+  private readonly pairedListeners = new Set<(userId: string) => void>();
+
+  constructor(opts: PairingHandlerOptions) {
+    this.opts = opts;
+  }
+
+  async loadAuthorized(): Promise<void> {
+    const raw = await this.opts.vault.get(DISCORD_AUTHORIZED_USER_KEY);
+    const authorizedUserId = parseAuthorizedUser(raw);
+    if (authorizedUserId == null && raw) {
+      this.opts.logger?.warn(
+        'discord pairing: stored user id is not a snowflake — treating as unpaired',
+        { raw },
+      );
+    }
+    this.state = createDiscordPairingState({ authorizedUserId });
+  }
+
+  phase(): DiscordPairingPhase {
+    return pairingPhase(this.state);
+  }
+
+  isAuthorized(userId: string): boolean {
+    return isUserAuthorized(this.state, userId);
+  }
+
+  authorizedUserId(): string | null {
+    return this.state.kit.phase === 'paired' ? this.state.kit.authorizedPeer : null;
+  }
+
+  /** Arm the pairing window: unauthorized DMs will now be issued codes. */
+  arm(): void {
+    this.state = armPairing(this.state);
+  }
+
+  unpair(): void {
+    this.state = clearDiscordPairing(this.state);
+  }
+
+  /**
+   * Subscribe to "a user just became authorized" — fires once each time pairing
+   * completes. The `pair` terminal flow uses it to print success; the channel
+   * uses it to flip its connect-state. Returns an unsubscribe function.
+   */
+  onPaired(listener: (userId: string) => void): () => void {
+    this.pairedListeners.add(listener);
+    return () => this.pairedListeners.delete(listener);
+  }
+
+  /**
+   * An unauthorized user DMed the bot. Returns the reply text to DM back:
+   * a freshly minted one-time code (window armed), a nudge to open a window,
+   * or a foreign-account rejection. Null when no reply is warranted.
+   */
+  handleUnpairedDm(userId: string): string | null {
+    const decision = mintCodeForPeer(this.state, userId);
+    this.state = decision.state;
+    const action = decision.action;
+    if (action.kind === 'code-minted') {
+      this.opts.logger?.info?.('discord pairing: code minted', { userId });
+      return (
+        `Your one-time pairing code is: **${action.code}**\n` +
+        'Paste it into the moxxy terminal (`moxxy discord pair`) to finish pairing.'
+      );
+    }
+    if (action.kind === 'still-paired') return 'Already paired — send me a prompt.';
+    if (action.kind === 'reject') return action.message;
+    return null;
+  }
+
+  /**
+   * The operator pasted a code into the terminal. On match the pending DM user
+   * is authorized + persisted. The vault write happens BEFORE listeners fire so
+   * a `pair`-flow exit right after success never loses the pairing.
+   */
+  async confirmCode(rawCode: string): Promise<PairingConfirmResult> {
+    const decision = confirmPendingCode(this.state, rawCode);
+    return this.applyConfirmDecision(decision);
+  }
+
+  private async applyConfirmDecision(
+    decision: DiscordPairingDecision,
+  ): Promise<PairingConfirmResult> {
+    this.state = decision.state;
+    const action = decision.action;
+    if (action.kind === 'paired') {
+      await this.opts.vault.set(DISCORD_AUTHORIZED_USER_KEY, action.userId);
+      this.emitPaired(action.userId);
+      return { ok: true, userId: action.userId };
+    }
+    if (action.kind === 'still-paired') return { ok: true, userId: action.userId };
+    if (action.kind === 'mismatch') return { ok: false, reason: 'mismatch', message: action.message };
+    if (action.kind === 'expired') return { ok: false, reason: 'expired', message: action.message };
+    if (action.kind === 'not-pending' || action.kind === 'reject') {
+      return { ok: false, reason: 'not-pending', message: action.message };
+    }
+    // 'code-minted' can't come out of a confirm; treat as a mismatch.
+    return { ok: false, reason: 'mismatch', message: 'unexpected pairing state' };
+  }
+
+  private emitPaired(userId: string): void {
+    for (const listener of this.pairedListeners) {
+      try {
+        listener(userId);
+      } catch (err) {
+        this.opts.logger?.warn('discord pairing paired-listener threw', { err: String(err) });
+      }
+    }
+  }
+}

--- a/packages/plugin-channel-discord/src/channel/permission-prompt.ts
+++ b/packages/plugin-channel-discord/src/channel/permission-prompt.ts
@@ -1,0 +1,54 @@
+import type { PendingToolCall, PermissionContext } from '@moxxy/sdk';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import type { DiscordPermissionResolver } from '../permission.js';
+import { BUTTON_STYLE, button, packRows } from './components.js';
+import type { ChannelLogger, SendableChannelLike } from './discord-like.js';
+
+export interface PermissionPromptDeps {
+  readonly channel: SendableChannelLike | null;
+  readonly session: Session | null;
+  readonly resolver: DiscordPermissionResolver;
+  readonly yolo: boolean;
+  readonly logger?: ChannelLogger;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + '…';
+}
+
+/**
+ * Render a button-row permission prompt for a pending tool call (the Discord
+ * mapping of Telegram's inline keyboard). The decider promise resolves when
+ * the paired user clicks a button (routed back via the interaction handler)
+ * or when the resolver aborts on stop.
+ */
+export async function askForPermission(
+  call: PendingToolCall,
+  ctx: PermissionContext,
+  deps: PermissionPromptDeps,
+): Promise<void> {
+  void ctx;
+  if (!deps.channel || !deps.session) return;
+  // YOLO short-circuit: resolve immediately without rendering a prompt.
+  if (deps.yolo) {
+    deps.resolver.resolvePending(call.callId, { mode: 'allow', reason: 'yolo mode' });
+    return;
+  }
+  const rows = packRows([
+    button(`perm:${call.callId}:allow`, 'Allow once', BUTTON_STYLE.success),
+    button(`perm:${call.callId}:allow_session`, 'Allow session', BUTTON_STYLE.primary),
+    button(`perm:${call.callId}:deny`, 'Deny', BUTTON_STYLE.danger),
+  ]);
+  const description = deps.session.tools.get(call.name)?.description ?? '';
+  const summary =
+    `🔐 **Tool permission requested**\n` +
+    `Tool: \`${call.name}\`\n` +
+    (description ? `Desc: ${truncate(description, 200)}\n` : '') +
+    `Input: \`${truncate(JSON.stringify(call.input), 300)}\``;
+  try {
+    await deps.channel.send({ content: summary, components: rows });
+  } catch (err) {
+    deps.logger?.warn('discord permission send failed', { err: String(err) });
+    deps.resolver.resolvePending(call.callId, { mode: 'deny', reason: 'unable to render prompt' });
+  }
+}

--- a/packages/plugin-channel-discord/src/channel/slash-handler.ts
+++ b/packages/plugin-channel-discord/src/channel/slash-handler.ts
@@ -1,0 +1,131 @@
+import type { ClientSession as Session } from '@moxxy/sdk';
+import type { ChannelLogger } from './discord-like.js';
+
+export interface SlashCallbacks {
+  /** Toggle yolo and return its new value (so we can echo the right message). */
+  toggleYolo(): boolean;
+  /** Apply a `session-action` result emitted from a registered command. */
+  performSessionAction(action: 'new' | 'clear' | 'exit', notice: string | undefined): Promise<string>;
+}
+
+/**
+ * Slash-command dispatcher shared by the plain-text path (`/info` typed as a
+ * message) and the application-command path (a real Discord slash command —
+ * the interaction handler routes both here). Returns the reply text to send.
+ *
+ * First tries the shared `session.commands` registry — the universal commands
+ * (/info, /clear, /new, /exit, /help) plus plugin-contributed ones — then
+ * falls through to Discord-local cases (/yolo, /tools, /skills). /cancel and
+ * /allow, /deny are handled by the message/interaction layer (they need channel
+ * state this dispatcher doesn't carry).
+ */
+export async function runSlash(
+  name: string,
+  args: string,
+  session: Session,
+  cb: SlashCallbacks,
+): Promise<string> {
+  const registered = session.commands.get(name);
+  if (registered) {
+    try {
+      const result = await registered.handler({
+        channel: 'discord',
+        sessionId: session.id,
+        args,
+        session,
+      });
+      if (result.kind === 'text') return result.text;
+      if (result.kind === 'session-action') {
+        return cb.performSessionAction(result.action, result.notice);
+      }
+      if (result.kind === 'error') return `error: ${result.message}`;
+      return `✓ /${name}`;
+    } catch (err) {
+      return `command /${name} failed: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  }
+
+  switch (name) {
+    case 'yolo': {
+      const enabled = cb.toggleYolo();
+      return enabled
+        ? '⚠ yolo mode ON — tool calls auto-approved for the rest of this session'
+        : 'yolo mode OFF — tool prompts will resume';
+    }
+    case 'tools': {
+      const list = session.tools
+        .list()
+        .map((t) => `${t.name} — ${t.description}`)
+        .join('\n');
+      return list || '(no tools registered)';
+    }
+    case 'skills': {
+      const list = session.skills
+        .list()
+        .map((s) => `${s.frontmatter.name} — ${s.frontmatter.description}`)
+        .join('\n');
+      return list || '(no skills discovered)';
+    }
+    default:
+      return `unknown command: /${name} (try /help)`;
+  }
+}
+
+/** Discord application-command name constraint. */
+const COMMAND_NAME_RE = /^[a-z0-9_-]{1,32}$/;
+
+export interface AppCommandJson {
+  readonly name: string;
+  readonly description: string;
+}
+
+/**
+ * Build the application-command list to publish: the shared registry commands
+ * (parity with Telegram's `publishBotCommands`) plus the Discord-local ones.
+ * Names that don't fit Discord's `^[a-z0-9_-]{1,32}$` constraint are skipped
+ * (they remain reachable as plain-text `/name` messages); descriptions are
+ * clamped to Discord's 1..100 chars.
+ */
+export function buildAppCommands(session: Session): AppCommandJson[] {
+  const LOCAL: AppCommandJson[] = [
+    { name: 'yolo', description: 'Toggle auto-approve mode' },
+    { name: 'tools', description: 'List the tools the active session can call' },
+    { name: 'skills', description: 'List the discovered skills' },
+    { name: 'cancel', description: 'Abort the current turn' },
+    { name: 'allow', description: 'Allow this guild channel to drive moxxy (paired user only)' },
+    { name: 'deny', description: 'Remove this guild channel from the allow-list' },
+  ];
+  const shared = session.commands
+    .listForChannel('discord')
+    .map((c) => ({ name: c.name, description: c.description }));
+  const seen = new Set(shared.map((c) => c.name));
+  return [...shared, ...LOCAL.filter((c) => !seen.has(c.name))]
+    .filter((c) => COMMAND_NAME_RE.test(c.name))
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((c) => ({ name: c.name, description: (c.description || c.name).slice(0, 100) || c.name }));
+}
+
+/** The slice of a discord.js application-command manager we publish through. */
+export interface AppCommandPublisher {
+  set(commands: ReadonlyArray<AppCommandJson>): Promise<unknown>;
+}
+
+/**
+ * Publish the commands to Discord so they appear in the client's "/" picker.
+ * Best-effort: a network failure here doesn't block channel startup — the
+ * commands still work as plain-text messages.
+ */
+export async function publishAppCommands(
+  publisher: AppCommandPublisher | null,
+  session: Session | null,
+  logger?: ChannelLogger,
+): Promise<void> {
+  if (!publisher || !session) return;
+  try {
+    await publisher.set(buildAppCommands(session));
+  } catch (err) {
+    logger?.warn('discord commands.set failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/packages/plugin-channel-discord/src/channel/turn-runner.test.ts
+++ b/packages/plugin-channel-discord/src/channel/turn-runner.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import { asTurnId, type MoxxyEvent } from '@moxxy/sdk';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import type { SendableChannelLike, SentMessageLike } from './discord-like.js';
+import { TypingIndicator } from './typing-indicator.js';
+import {
+  clampEditFrameMs,
+  DEFAULT_EDIT_FRAME_MS,
+  MIN_EDIT_FRAME_MS,
+  runDiscordTurn,
+} from './turn-runner.js';
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+describe('clampEditFrameMs (Discord edit rate limit ~5 edits/5s)', () => {
+  it('defaults when unset and floors configured values at 1200ms', () => {
+    expect(clampEditFrameMs(undefined)).toBe(DEFAULT_EDIT_FRAME_MS);
+    expect(DEFAULT_EDIT_FRAME_MS).toBeGreaterThanOrEqual(1_200);
+    expect(clampEditFrameMs(50)).toBe(MIN_EDIT_FRAME_MS);
+    expect(MIN_EDIT_FRAME_MS).toBeGreaterThanOrEqual(1_200);
+    expect(clampEditFrameMs(5_000)).toBe(5_000);
+    expect(clampEditFrameMs(Number.NaN)).toBe(DEFAULT_EDIT_FRAME_MS);
+  });
+});
+
+interface Recorded {
+  sends: string[];
+  edits: string[];
+  channel: SendableChannelLike;
+}
+
+function recordedChannel(): Recorded {
+  const sends: string[] = [];
+  const edits: string[] = [];
+  const channel: SendableChannelLike = {
+    send: async (payload) => {
+      sends.push(typeof payload === 'string' ? payload : payload.content);
+      const message: SentMessageLike = {
+        edit: async (content: string) => {
+          edits.push(content);
+        },
+      };
+      return message;
+    },
+  };
+  return { sends, edits, channel };
+}
+
+/**
+ * Fake session: `runTurn` pushes scripted events (stamped with the given
+ * turnId) through the log subscribers, mirroring how the real Session fans
+ * out; the async iterable then completes.
+ */
+function fakeSession(
+  script: (emit: (e: Record<string, unknown>) => Promise<void>) => Promise<void>,
+): Session {
+  const listeners = new Set<(e: MoxxyEvent) => void>();
+  return {
+    log: {
+      subscribe(fn: (e: MoxxyEvent) => void) {
+        listeners.add(fn);
+        return () => listeners.delete(fn);
+      },
+    },
+    runTurn: (_prompt: string, opts: { turnId: string }) =>
+      (async function* () {
+        const emit = async (e: Record<string, unknown>): Promise<void> => {
+          const event = { ...e, turnId: opts.turnId } as unknown as MoxxyEvent;
+          for (const fn of listeners) fn(event);
+        };
+        await script(emit);
+        // The iterator yields nothing extra — rendering happens via the log.
+        yield undefined as never;
+      })(),
+  } as unknown as Session;
+}
+
+describe('runDiscordTurn — send-once-then-edit streaming', () => {
+  it('sends the first frame, edits it as chunks stream, edits the final in place', async () => {
+    const { sends, edits, channel } = recordedChannel();
+    const session = fakeSession(async (emit) => {
+      await emit({ type: 'assistant_chunk', delta: 'Hello' });
+      await sleep(30);
+      await emit({ type: 'assistant_chunk', delta: ', world' });
+      await sleep(30);
+      await emit({ type: 'assistant_message', content: 'Hello, world. Done.' });
+    });
+    await runDiscordTurn(
+      { session, channel, typing: new TypingIndicator(), editFrameMs: 10 },
+      { text: 'hi', controller: new AbortController(), turnId: asTurnId('turn-1') },
+    );
+    // Exactly one streamed message; later frames are edits of it.
+    expect(sends).toHaveLength(1);
+    expect(sends[0]!.startsWith('Hello')).toBe(true);
+    expect(edits.length).toBeGreaterThanOrEqual(1);
+    expect(edits[edits.length - 1]).toBe('Hello, world. Done.');
+  });
+
+  it('splits a long FINAL frame: edits the head, sends the tails as follow-ups', async () => {
+    const { sends, edits, channel } = recordedChannel();
+    const line = 'y'.repeat(100);
+    const long = Array.from({ length: 45 }, () => line).join('\n'); // ~4545 chars > 1900*2
+    const session = fakeSession(async (emit) => {
+      await emit({ type: 'assistant_chunk', delta: 'start' });
+      await sleep(30);
+      await emit({ type: 'assistant_message', content: long });
+    });
+    await runDiscordTurn(
+      { session, channel, typing: new TypingIndicator(), editFrameMs: 10 },
+      { text: 'hi', controller: new AbortController(), turnId: asTurnId('turn-2') },
+    );
+    // First send is the streamed head; final tails arrive as extra sends.
+    expect(sends.length).toBeGreaterThanOrEqual(3); // head + >=2 tails
+    const finalHead = edits[edits.length - 1]!;
+    expect(finalHead.length).toBeLessThanOrEqual(1_900);
+    // Reassembling head + tails recovers the whole final text.
+    const reassembled = [finalHead, ...sends.slice(1)].join('\n');
+    expect(reassembled).toBe(long);
+  });
+
+  it('posts a placeholder when the turn rendered nothing', async () => {
+    const { sends, channel } = recordedChannel();
+    const session = fakeSession(async () => undefined);
+    await runDiscordTurn(
+      { session, channel, typing: new TypingIndicator(), editFrameMs: 10 },
+      { text: 'hi', controller: new AbortController(), turnId: asTurnId('turn-3') },
+    );
+    expect(sends).toEqual(['*(no output)*']);
+  });
+
+  it('ignores events from OTHER turns (invariant #8: filter by turnId)', async () => {
+    const { sends, edits, channel } = recordedChannel();
+    const listeners = new Set<(e: MoxxyEvent) => void>();
+    const session = {
+      log: {
+        subscribe(fn: (e: MoxxyEvent) => void) {
+          listeners.add(fn);
+          return () => listeners.delete(fn);
+        },
+      },
+      runTurn: (_prompt: string, opts: { turnId: string }) =>
+        (async function* () {
+          const fan = (e: Record<string, unknown>): void => {
+            for (const fn of listeners) fn(e as unknown as MoxxyEvent);
+          };
+          // A concurrent foreign turn's chunk must NOT render here.
+          fan({ type: 'assistant_chunk', delta: 'FOREIGN', turnId: 'other-turn' });
+          fan({ type: 'assistant_message', content: 'mine', turnId: opts.turnId });
+          yield undefined as never;
+        })(),
+    } as unknown as Session;
+    await runDiscordTurn(
+      { session, channel, typing: new TypingIndicator(), editFrameMs: 10 },
+      { text: 'hi', controller: new AbortController(), turnId: asTurnId('turn-4') },
+    );
+    const all = [...sends, ...edits].join(' ');
+    expect(all).toContain('mine');
+    expect(all).not.toContain('FOREIGN');
+  });
+
+  it('surfaces a failed turn into the channel instead of dangling', async () => {
+    const { sends, channel } = recordedChannel();
+    const session = {
+      log: { subscribe: () => () => undefined },
+      runTurn: () =>
+        (async function* () {
+          yield undefined as never;
+          throw new Error('provider exploded');
+        })(),
+    } as unknown as Session;
+    await runDiscordTurn(
+      { session, channel, typing: new TypingIndicator(), editFrameMs: 10 },
+      { text: 'hi', controller: new AbortController(), turnId: asTurnId('turn-5') },
+    );
+    expect(sends.join(' ')).toMatch(/Turn failed: provider exploded/);
+  });
+});

--- a/packages/plugin-channel-discord/src/channel/turn-runner.ts
+++ b/packages/plugin-channel-discord/src/channel/turn-runner.ts
@@ -1,0 +1,118 @@
+import type { newTurnId } from '@moxxy/core';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import { FramePump, driveTurn, subscribeTurn } from '@moxxy/channel-kit';
+import { DiscordTurnRenderer, splitForDiscord } from '../render.js';
+import type { ChannelLogger, SendableChannelLike, SentMessageLike } from './discord-like.js';
+import type { TypingIndicator } from './typing-indicator.js';
+
+/**
+ * Discord's per-channel edit budget is ~5 edits / 5s; the streaming edit
+ * throttle must stay at or above 1200ms so a long turn never trips the rate
+ * limiter (which would delay-queue frames and lag the stream).
+ */
+export const MIN_EDIT_FRAME_MS = 1_200;
+export const DEFAULT_EDIT_FRAME_MS = 1_500;
+
+/** Clamp a configured editFrameMs to the Discord-safe floor. */
+export function clampEditFrameMs(requested: number | undefined): number {
+  if (typeof requested !== 'number' || !Number.isFinite(requested)) return DEFAULT_EDIT_FRAME_MS;
+  return Math.max(MIN_EDIT_FRAME_MS, requested);
+}
+
+export interface RunDiscordTurnDeps {
+  readonly session: Session;
+  readonly channel: SendableChannelLike;
+  readonly typing: TypingIndicator;
+  readonly editFrameMs: number;
+  readonly logger?: ChannelLogger;
+}
+
+export interface RunDiscordTurnOptions {
+  readonly text: string;
+  readonly model?: string | undefined;
+  readonly controller: AbortController;
+  /** Pre-minted turn id; the channel records it as an own-turn id. */
+  readonly turnId: ReturnType<typeof newTurnId>;
+}
+
+/**
+ * Drive a single Discord turn end-to-end: start typing, subscribe the frame
+ * pump to THIS turn's events (filtered by turnId — `session.log` fans out to
+ * every listener, so a concurrent turn on the same Session would otherwise
+ * stream into this channel, AGENTS.md invariant #8), run the turn, flush the
+ * final frame, unwind in `finally`.
+ *
+ * The streaming loop is `@moxxy/channel-kit`'s {@link FramePump} ("send once,
+ * then edit that message", throttled to `editFrameMs`) over a
+ * {@link DiscordTurnRenderer} snapshot. Delivery handles the 2000-char cap:
+ * mid-stream frames edit only the first split part; the FINAL frame sends the
+ * overflow tail parts as follow-up messages (`alwaysFlushFinal` so the sink's
+ * final-only work is never skipped).
+ */
+export async function runDiscordTurn(
+  deps: RunDiscordTurnDeps,
+  opts: RunDiscordTurnOptions,
+): Promise<void> {
+  const { session, channel, typing, editFrameMs, logger } = deps;
+  const { text, model, controller, turnId } = opts;
+
+  const renderer = new DiscordTurnRenderer();
+  const sendPart = async (part: string): Promise<SentMessageLike | null> => {
+    try {
+      return await channel.send(part);
+    } catch (err) {
+      logger?.warn('discord send failed', { err: String(err) });
+      return null;
+    }
+  };
+  const pump = new FramePump<SentMessageLike>({
+    editFrameMs,
+    frame: () => renderer.snapshot(),
+    // Guarantee at least one message even when the turn produced no text.
+    emptyFinalText: '*(no output)*',
+    // The sink does final-only work (split-overflow tails), so the final frame
+    // must reach it even when the text didn't change since the last edit.
+    alwaysFlushFinal: true,
+    sink: {
+      send: async (t, final) => {
+        const parts = splitForDiscord(t);
+        const sent = await sendPart(parts[0]!);
+        if (final) for (const tail of parts.slice(1)) await sendPart(tail);
+        return sent;
+      },
+      edit: async (message, t, final) => {
+        const parts = splitForDiscord(t);
+        try {
+          await message.edit(parts[0]!);
+        } catch (err) {
+          logger?.warn('discord edit failed', { err: String(err) });
+        }
+        if (final) for (const tail of parts.slice(1)) await sendPart(tail);
+      },
+    },
+  });
+
+  typing.start(channel);
+  const unsubscribe = subscribeTurn(session, turnId, (event) => {
+    if (renderer.accept(event)) pump.scheduleEdit();
+  });
+
+  try {
+    await driveTurn(session, {
+      turnId,
+      prompt: text,
+      ...(model ? { model } : {}),
+      signal: controller.signal,
+    });
+    await pump.flush(true);
+  } catch (err) {
+    logger?.warn('discord turn failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    await sendPart(`Turn failed: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    typing.stop();
+    unsubscribe();
+    pump.dispose();
+  }
+}

--- a/packages/plugin-channel-discord/src/channel/typing-indicator.ts
+++ b/packages/plugin-channel-discord/src/channel/typing-indicator.ts
@@ -1,0 +1,31 @@
+import type { SendableChannelLike } from './discord-like.js';
+
+/** Discord's typing indicator expires ~10s after `sendTyping`; refresh under that. */
+const REFRESH_MS = 8_000;
+
+/**
+ * Keeps the "moxxy is typing…" indicator alive for the duration of a turn.
+ * Best-effort: transport errors are swallowed (a failed typing ping must never
+ * abort a turn).
+ */
+export class TypingIndicator {
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  start(channel: SendableChannelLike): void {
+    this.stop();
+    if (!channel.sendTyping) return;
+    const ping = (): void => {
+      void channel.sendTyping?.()?.catch?.(() => undefined);
+    };
+    ping();
+    this.timer = setInterval(ping, REFRESH_MS);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/packages/plugin-channel-discord/src/channel/voice-handler.test.ts
+++ b/packages/plugin-channel-discord/src/channel/voice-handler.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import type { InboundMessage } from '../schema.js';
+import { MAX_AUDIO_BYTES } from '../schema.js';
+import type { InboundContext } from './message-handler.js';
+import { handleVoiceMessage, pickAudioAttachment } from './voice-handler.js';
+
+function audioMsg(overrides: Partial<InboundMessage['attachments'][number]> = {}): InboundMessage {
+  return {
+    id: '999999999999',
+    content: '',
+    channelId: '555555555555',
+    guildId: null,
+    authorId: '111111111111',
+    authorIsBot: false,
+    attachments: [
+      {
+        id: '888888888888',
+        url: 'https://cdn.example/voice.ogg',
+        contentType: 'audio/ogg',
+        size: 1_000,
+        name: 'voice-message.ogg',
+        ...overrides,
+      },
+    ],
+  };
+}
+
+function makeCtx(msg: InboundMessage): { ctx: InboundContext; replies: string[] } {
+  const replies: string[] = [];
+  return {
+    replies,
+    ctx: {
+      msg,
+      channel: { send: async () => ({ edit: async () => undefined }) },
+      reply: async (text: string) => {
+        replies.push(text);
+      },
+    },
+  };
+}
+
+function sessionWithTranscriber(transcribe: ((bytes: Uint8Array, o: { mimeType: string }) => Promise<{ text: string }>) | null): Session {
+  return {
+    transcribers: {
+      tryGetActive: () => (transcribe ? { transcribe } : null),
+    },
+  } as unknown as Session;
+}
+
+const okFetch = (bytes = 16) =>
+  vi.fn(async () => ({
+    ok: true,
+    headers: { get: () => String(bytes) },
+    arrayBuffer: async () => new ArrayBuffer(bytes),
+  }));
+
+describe('pickAudioAttachment', () => {
+  it('picks the first audio/* attachment and ignores others', () => {
+    const msg = audioMsg();
+    expect(pickAudioAttachment(msg.attachments)?.contentType).toBe('audio/ogg');
+    expect(pickAudioAttachment([{ ...msg.attachments[0]!, contentType: 'image/png' }])).toBeNull();
+    expect(pickAudioAttachment([{ ...msg.attachments[0]!, contentType: null }])).toBeNull();
+  });
+});
+
+describe('handleVoiceMessage', () => {
+  it('returns false for messages without audio (text path proceeds)', async () => {
+    const { ctx } = makeCtx({ ...audioMsg(), attachments: [] });
+    const consumed = await handleVoiceMessage(
+      ctx,
+      { session: sessionWithTranscriber(null), busy: false },
+      {},
+      { runUserTurn: vi.fn() },
+    );
+    expect(consumed).toBe(false);
+  });
+
+  it('guides the user when no transcriber is configured', async () => {
+    const { ctx, replies } = makeCtx(audioMsg());
+    const runUserTurn = vi.fn();
+    const consumed = await handleVoiceMessage(
+      ctx,
+      { session: sessionWithTranscriber(null), busy: false },
+      {},
+      { runUserTurn },
+    );
+    expect(consumed).toBe(true);
+    expect(replies[0]).toMatch(/plugin-stt-whisper/);
+    expect(runUserTurn).not.toHaveBeenCalled();
+  });
+
+  it('rejects a declared-oversized attachment BEFORE downloading', async () => {
+    const fetchAudio = okFetch();
+    const { ctx, replies } = makeCtx(audioMsg({ size: MAX_AUDIO_BYTES + 1 }));
+    await handleVoiceMessage(
+      ctx,
+      { session: sessionWithTranscriber(async () => ({ text: 'x' })), busy: false },
+      {},
+      { runUserTurn: vi.fn(), fetchAudio },
+    );
+    expect(replies[0]).toMatch(/too large/);
+    expect(fetchAudio).not.toHaveBeenCalled();
+  });
+
+  it('rejects on a lying Content-Length header before buffering', async () => {
+    const fetchAudio = vi.fn(async () => ({
+      ok: true,
+      headers: { get: () => String(MAX_AUDIO_BYTES + 1) },
+      arrayBuffer: async () => new ArrayBuffer(8),
+    }));
+    const { ctx, replies } = makeCtx(audioMsg());
+    await handleVoiceMessage(
+      ctx,
+      { session: sessionWithTranscriber(async () => ({ text: 'x' })), busy: false },
+      {},
+      { runUserTurn: vi.fn(), fetchAudio },
+    );
+    expect(replies[0]).toMatch(/too large/);
+  });
+
+  it('rejects an oversized BUFFERED body (no content-length)', async () => {
+    const fetchAudio = vi.fn(async () => ({
+      ok: true,
+      headers: { get: () => null },
+      arrayBuffer: async () => new ArrayBuffer(MAX_AUDIO_BYTES + 1),
+    }));
+    const { ctx, replies } = makeCtx(audioMsg());
+    await handleVoiceMessage(
+      ctx,
+      { session: sessionWithTranscriber(async () => ({ text: 'x' })), busy: false },
+      {},
+      { runUserTurn: vi.fn(), fetchAudio },
+    );
+    expect(replies[0]).toMatch(/too large/);
+  });
+
+  it('refuses while busy', async () => {
+    const { ctx, replies } = makeCtx(audioMsg());
+    await handleVoiceMessage(
+      ctx,
+      { session: sessionWithTranscriber(async () => ({ text: 'x' })), busy: true },
+      {},
+      { runUserTurn: vi.fn() },
+    );
+    expect(replies[0]).toMatch(/still working/);
+  });
+
+  it('transcribes and runs a user turn with a "heard:" echo', async () => {
+    const transcribe = vi.fn(async () => ({ text: '  turn on the lights  ' }));
+    const runUserTurn = vi.fn();
+    const { ctx, replies } = makeCtx(audioMsg());
+    const consumed = await handleVoiceMessage(
+      ctx,
+      { session: sessionWithTranscriber(transcribe), busy: false },
+      {},
+      { runUserTurn, fetchAudio: okFetch() },
+    );
+    expect(consumed).toBe(true);
+    expect(transcribe).toHaveBeenCalledWith(expect.any(Uint8Array), { mimeType: 'audio/ogg' });
+    expect(replies[0]).toBe('*heard:* turn on the lights');
+    expect(runUserTurn).toHaveBeenCalledWith(ctx, 'turn on the lights');
+  });
+
+  it('reports empty transcriptions instead of running an empty turn', async () => {
+    const runUserTurn = vi.fn();
+    const { ctx, replies } = makeCtx(audioMsg());
+    await handleVoiceMessage(
+      ctx,
+      { session: sessionWithTranscriber(async () => ({ text: '   ' })), busy: false },
+      {},
+      { runUserTurn, fetchAudio: okFetch() },
+    );
+    expect(replies[0]).toMatch(/empty text/);
+    expect(runUserTurn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-channel-discord/src/channel/voice-handler.ts
+++ b/packages/plugin-channel-discord/src/channel/voice-handler.ts
@@ -1,0 +1,150 @@
+import type { ClientSession as Session } from '@moxxy/sdk';
+import { MAX_AUDIO_BYTES, type InboundAttachment } from '../schema.js';
+import type { ChannelLogger } from './discord-like.js';
+import type { InboundContext } from './message-handler.js';
+
+/** Abort the attachment download if Discord's CDN hasn't responded in this window. */
+const DOWNLOAD_TIMEOUT_MS = 30_000;
+
+export interface VoiceHandlerState {
+  readonly session: Session | null;
+  readonly busy: boolean;
+}
+
+export interface VoiceHandlerDeps {
+  readonly logger?: ChannelLogger;
+}
+
+export interface VoiceHandlerCallbacks {
+  readonly runUserTurn: (ctx: InboundContext, text: string) => Promise<void>;
+  /** Override the network fetch for tests. Defaults to global `fetch`. */
+  readonly fetchAudio?: (
+    url: string,
+    init?: { signal?: AbortSignal },
+  ) => Promise<{
+    ok: boolean;
+    status?: number;
+    statusText?: string;
+    headers?: { get(name: string): string | null };
+    arrayBuffer(): Promise<ArrayBuffer>;
+  }>;
+}
+
+/** The first audio attachment on the message (Discord voice messages arrive as
+ *  an `audio/ogg` attachment; uploaded audio files carry their own mime). */
+export function pickAudioAttachment(
+  attachments: ReadonlyArray<InboundAttachment>,
+): InboundAttachment | null {
+  return attachments.find((a) => (a.contentType ?? '').startsWith('audio/')) ?? null;
+}
+
+/**
+ * Handle a Discord voice message / uploaded audio file. Called AFTER the
+ * pairing + allow-list gate (the message handler owns authorization). Returns
+ * true when the message carried audio and was consumed here (successfully or
+ * not), false when there was no audio and the text path should proceed.
+ *
+ * Mirrors the Telegram voice handler: size caps (declared size, then
+ * Content-Length, then the buffered body), bounded download, transcriber gate
+ * with install guidance, a "heard:" echo, then a normal user turn.
+ */
+export async function handleVoiceMessage(
+  ctx: InboundContext,
+  state: VoiceHandlerState,
+  deps: VoiceHandlerDeps,
+  cb: VoiceHandlerCallbacks,
+): Promise<boolean> {
+  const audio = pickAudioAttachment(ctx.msg.attachments);
+  if (!audio) return false;
+
+  if (state.busy) {
+    await ctx.reply('I am still working on the previous prompt. Send /cancel to abort it.');
+    return true;
+  }
+  if (!state.session) {
+    await ctx.reply('Session is not ready yet.');
+    return true;
+  }
+
+  const transcriber = state.session.transcribers.tryGetActive();
+  if (!transcriber) {
+    await ctx.reply(
+      'Heard a voice message, but no speech-to-text backend is configured. Install @moxxy/plugin-stt-whisper and run `moxxy login openai` (or set OPENAI_API_KEY) to enable voice input.',
+    );
+    return true;
+  }
+
+  // Reject oversized uploads up-front using the size Discord reports, before
+  // we spend a download or any memory on it.
+  if (audio.size > MAX_AUDIO_BYTES) {
+    await ctx.reply(
+      `That audio is too large (${Math.round(audio.size / (1024 * 1024))}MB). The limit is ${MAX_AUDIO_BYTES / (1024 * 1024)}MB.`,
+    );
+    return true;
+  }
+
+  const fetcher = cb.fetchAudio ?? ((u: string, init?: { signal?: AbortSignal }) => fetch(u, init));
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), DOWNLOAD_TIMEOUT_MS);
+  let bytes: Uint8Array;
+  try {
+    const response = await fetcher(audio.url, { signal: ac.signal });
+    if (!response.ok) {
+      deps.logger?.warn('discord voice download failed', {
+        ...(response.status !== undefined ? { status: response.status } : {}),
+        ...(response.statusText ? { statusText: response.statusText } : {}),
+      });
+      await ctx.reply('Failed to download the voice message from Discord.');
+      return true;
+    }
+    // Trust the Content-Length header (when present) to bail before buffering
+    // a body that lies about its size on the attachment object.
+    const declaredLen = Number(response.headers?.get('content-length') ?? '');
+    if (Number.isFinite(declaredLen) && declaredLen > MAX_AUDIO_BYTES) {
+      await ctx.reply('That audio is too large to transcribe.');
+      return true;
+    }
+    const buf = await response.arrayBuffer();
+    if (buf.byteLength > MAX_AUDIO_BYTES) {
+      await ctx.reply('That audio is too large to transcribe.');
+      return true;
+    }
+    bytes = new Uint8Array(buf);
+  } catch (err) {
+    deps.logger?.warn('discord voice fetch failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    await ctx.reply(
+      ac.signal.aborted
+        ? 'Downloading the voice message timed out.'
+        : 'Failed to download the voice message from Discord.',
+    );
+    return true;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const mimeType = audio.contentType ?? 'audio/ogg';
+  let transcript: string;
+  try {
+    const result = await transcriber.transcribe(bytes, { mimeType });
+    transcript = result.text.trim();
+  } catch (err) {
+    deps.logger?.warn('discord voice transcription failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    await ctx.reply(`Transcription failed: ${err instanceof Error ? err.message : String(err)}`);
+    return true;
+  }
+
+  if (!transcript) {
+    await ctx.reply('Could not transcribe the voice message (got empty text).');
+    return true;
+  }
+
+  // Echo what we heard so the user can spot misrecognitions before the agent
+  // acts on it. Italics keep it visually distinct from a normal reply.
+  await ctx.reply(`*heard:* ${transcript}`);
+  await cb.runUserTurn(ctx, transcript);
+  return true;
+}

--- a/packages/plugin-channel-discord/src/index.ts
+++ b/packages/plugin-channel-discord/src/index.ts
@@ -1,0 +1,247 @@
+import { defineChannel, definePlugin, type LifecycleHooks, type Plugin } from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { DiscordChannel } from './channel.js';
+import {
+  DISCORD_ALLOWED_CHANNELS_KEY,
+  DISCORD_AUTHORIZED_USER_KEY,
+  DISCORD_TOKEN_ENV,
+  DISCORD_TOKEN_KEY,
+  parseAllowedChannels,
+  parseAuthorizedUser,
+  resolveBotToken,
+} from './keys.js';
+import { runDiscordWizard } from './setup-wizard.js';
+import { runPairFlow } from './pair-flow.js';
+
+export {
+  DiscordChannel,
+  type DiscordChannelOptions,
+  type DiscordStartOpts,
+  type PairingConfirmResult,
+} from './channel.js';
+export { DiscordPermissionResolver, type PendingPermission } from './permission.js';
+export { DiscordApprovalResolver, type PendingApproval } from './approval.js';
+export {
+  armPairing,
+  clearDiscordPairing,
+  confirmPendingCode,
+  createDiscordPairingState,
+  isUserAuthorized,
+  mintCodeForPeer,
+  pairingPhase,
+  type DiscordPairingDecision,
+  type DiscordPairingPhase,
+  type DiscordPairingState,
+} from './pairing.js';
+export { gateInbound, type GateVerdict } from './allow-list.js';
+export { DiscordTurnRenderer, splitForDiscord, DISCORD_MESSAGE_LIMIT } from './render.js';
+export {
+  extractInboundMessage,
+  inboundMessageSchema,
+  MAX_AUDIO_BYTES,
+  MAX_CONTENT_CHARS,
+  type InboundAttachment,
+  type InboundMessage,
+} from './schema.js';
+export {
+  DISCORD_TOKEN_KEY,
+  DISCORD_AUTHORIZED_USER_KEY,
+  DISCORD_ALLOWED_CHANNELS_KEY,
+  DISCORD_TOKEN_ENV,
+  DISCORD_TOKEN_RE,
+  parseAuthorizedUser,
+  parseAllowedChannels,
+  serializeAllowedChannels,
+  resolveBotToken,
+} from './keys.js';
+
+export interface BuildDiscordPluginOptions {
+  /** Host-injected encrypted secret store (available immediately). */
+  readonly vault: VaultStore;
+}
+
+/**
+ * Build the Discord channel plugin with a host-injected vault (mirroring the
+ * Telegram plugin's vault injection).
+ */
+export function buildDiscordPlugin(opts: BuildDiscordPluginOptions): Plugin {
+  return makeDiscordPlugin(() => opts.vault);
+}
+
+/**
+ * Discovery-loadable default export: resolves the vault from the inter-plugin
+ * service registry in `onInit` (the vault plugin publishes `'vault'`). Requires
+ * `@moxxy/plugin-vault` to load first (declared in `package.json`
+ * `moxxy.requirements`). The channel + subcommands read the vault via
+ * `getVault()`, so resolution is deferred to call time — after `onInit` wired it.
+ */
+export const discordPlugin: Plugin = (() => {
+  let resolved: VaultStore | null = null;
+  const getVault = (): VaultStore => {
+    if (!resolved) {
+      throw new Error(
+        '@moxxy/plugin-channel-discord: the "vault" service is unavailable — @moxxy/plugin-vault must load first',
+      );
+    }
+    return resolved;
+  };
+  const hooks: LifecycleHooks = {
+    onInit: (ctx) => {
+      resolved = ctx.services.require<VaultStore>('vault');
+    },
+  };
+  return makeDiscordPlugin(getVault, hooks);
+})();
+
+// Discovery entry: `createPluginLoader` requires a default Plugin export.
+export default discordPlugin;
+
+function makeDiscordPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks): Plugin {
+  return definePlugin({
+    name: '@moxxy/plugin-channel-discord',
+    version: '0.0.0',
+    ...(hooks ? { hooks } : {}),
+    channels: [
+      defineChannel({
+        name: 'discord',
+        description:
+          'Discord bot channel via discord.js (gateway). DM code pairing; streamed replies via message edits; button-based permission prompts.',
+        // Like Slack/Telegram, run on a dedicated, isolated runner (separate
+        // socket + sticky session) so the bot keeps its own persistent history
+        // apart from the user's desktop/TUI work. The gateway is an outbound
+        // WebSocket — no tunnel needed.
+        dedicatedRunner: true,
+        sessionSource: 'discord',
+        // Self-described config so a control surface (TUI `/channels`, `moxxy
+        // channels start`) can configure + run Discord without a hardcoded table.
+        config: {
+          fields: [
+            {
+              name: 'botToken',
+              label: 'Bot token',
+              vaultKey: DISCORD_TOKEN_KEY,
+              required: true,
+              secret: true,
+              placeholder: 'MTIz…abc.def…',
+              help: 'discord.com/developers → your app → Bot → Reset Token. Enable the MESSAGE CONTENT privileged intent on the same page.',
+            },
+          ],
+          hasRequestUrl: false,
+          runHint:
+            'Invite the bot to a server via the link shown, then DM it — it replies with a one-time code; finish with `moxxy discord pair` in a terminal.',
+          connect: {
+            kind: 'url',
+            title: 'Invite the bot',
+            hint: 'Open the link to invite the bot to your server, then DM it to receive a pairing code and finish with `moxxy discord pair`.',
+            openable: true,
+            openLabel: 'Open Discord authorization',
+          },
+        },
+        create: (deps) =>
+          new DiscordChannel({
+            vault: getVault(),
+            token: (deps.options?.['token'] as string | undefined) ?? undefined,
+            logger: deps.logger as never,
+            ...(typeof deps.options?.['editFrameMs'] === 'number'
+              ? { editFrameMs: deps.options['editFrameMs'] as number }
+              : {}),
+          }),
+        isAvailable: async () => {
+          // Env-first: a fully env-configured bot is available even in a probe
+          // context (e.g. the `moxxy channels` listing) where onInit has not
+          // yet wired the vault service, so `getVault()` would throw.
+          if (process.env[DISCORD_TOKEN_ENV]?.trim()) return { ok: true };
+          try {
+            if ((await resolveBotToken(getVault())) != null) return { ok: true };
+            return {
+              ok: false,
+              reason:
+                "No bot token. Set MOXXY_DISCORD_TOKEN, or store one in the vault as '" +
+                DISCORD_TOKEN_KEY +
+                "' via `moxxy discord setup`.",
+            };
+          } catch {
+            return {
+              ok: false,
+              reason: 'Set MOXXY_DISCORD_TOKEN to skip the vault, or unlock the vault first.',
+            };
+          }
+        },
+        interactiveCommand: 'setup',
+        subcommands: {
+          setup: {
+            description:
+              'Interactive setup: store a bot token (with privileged-intent guidance), pair an account, then start the bot. Shown by default for `moxxy discord` on a TTY.',
+            run: async (ctx) => {
+              // The wizard drives token entry + pairing through clack prompts,
+              // so it needs an interactive terminal. In a headless invocation
+              // we just start the bot directly.
+              if (process.stdin.isTTY !== true) {
+                return ctx.startChannel();
+              }
+              return runDiscordWizard(ctx);
+            },
+          },
+          pair: {
+            description:
+              'DM code pairing: start the bot with a pairing window armed, DM it from your account, then paste the code it replies with.',
+            run: async (ctx) => {
+              // Pairing needs the operator to paste a code, so it needs an
+              // interactive terminal. In a headless invocation we bail with a
+              // clear message instead of starting a bot nobody can pair.
+              if (process.stdin.isTTY !== true) {
+                process.stderr.write(
+                  'Pairing needs a TTY (you paste the code the bot DMs back). Run `moxxy channels discord pair` on a workstation.\n',
+                );
+                return 1;
+              }
+              return runPairFlow(ctx);
+            },
+          },
+          unpair: {
+            description: 'Forget the currently authorized Discord account.',
+            run: async (ctx) => {
+              const vault = ctx.deps.vault as VaultStore | undefined;
+              if (!vault) {
+                process.stderr.write('vault unavailable\n');
+                return 1;
+              }
+              const removed = await vault.delete(DISCORD_AUTHORIZED_USER_KEY);
+              process.stdout.write(removed ? 'unpaired\n' : 'no pairing was active\n');
+              return 0;
+            },
+          },
+          status: {
+            description:
+              'Report whether a Discord token + an authorized account + allow-listed channels are configured.',
+            run: async (ctx) => {
+              const vault = ctx.deps.vault as VaultStore | undefined;
+              if (!vault) {
+                process.stderr.write('vault unavailable\n');
+                return 1;
+              }
+              const hasToken =
+                !!process.env[DISCORD_TOKEN_ENV]?.trim() || (await vault.has(DISCORD_TOKEN_KEY));
+              const authorized = await vault.get(DISCORD_AUTHORIZED_USER_KEY);
+              const allowed = parseAllowedChannels(
+                await vault.get(DISCORD_ALLOWED_CHANNELS_KEY),
+              );
+              process.stdout.write(
+                JSON.stringify(
+                  {
+                    tokenConfigured: hasToken,
+                    authorizedUserId: parseAuthorizedUser(authorized),
+                    allowedChannelIds: allowed,
+                  },
+                  null,
+                  2,
+                ) + '\n',
+              );
+              return 0;
+            },
+          },
+        },
+      }),
+    ],
+  });
+}

--- a/packages/plugin-channel-discord/src/keys.ts
+++ b/packages/plugin-channel-discord/src/keys.ts
@@ -1,0 +1,75 @@
+/**
+ * Vault keys + env overrides + validators shared by the channel, its
+ * subcommands, and the interactive setup wizard. Kept in their own module so
+ * the wizard / pair-flow helpers can import them without pulling in the
+ * plugin's full index. The names here are the single source of truth for what
+ * the channel reads at boot (mirrored by the desktop channel catalog).
+ */
+import { z } from '@moxxy/sdk';
+import { resolveSecret } from '@moxxy/channel-kit';
+
+/** Vault key for the Discord bot token. */
+export const DISCORD_TOKEN_KEY = 'discord_bot_token';
+/** Vault key for the paired (authorized) Discord user id — the sole principal
+ *  allowed to drive the session. */
+export const DISCORD_AUTHORIZED_USER_KEY = 'discord_authorized_user_id';
+/** Vault key for the guild-channel allow-list (JSON array of channel ids the
+ *  paired user may drive the bot from, beyond their own DM). */
+export const DISCORD_ALLOWED_CHANNELS_KEY = 'discord_allowed_channel_ids';
+
+/** Env override for the bot token (beats the vault, matching every other channel). */
+export const DISCORD_TOKEN_ENV = 'MOXXY_DISCORD_TOKEN';
+
+/**
+ * Shape-only validation of a Discord bot token: three dot-separated url-safe
+ * base64 segments (id.timestamp.hmac). Connectivity is proven by the gateway
+ * login, not here.
+ */
+export const DISCORD_TOKEN_RE = /^[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{20,}$/;
+
+/** A Discord snowflake id — numeric string, 5..25 digits. */
+export const snowflakeSchema = z.string().regex(/^\d{5,25}$/, 'expected a Discord snowflake id');
+
+/**
+ * Resolve the bot token: env override first, then the vault (the shared
+ * env→vault resolution in @moxxy/channel-kit). Returns null when neither is
+ * set. Trimmed; never returns an empty string.
+ */
+export async function resolveBotToken(vault: {
+  get(name: string): Promise<string | null>;
+}): Promise<string | null> {
+  return resolveSecret(vault, { envVar: DISCORD_TOKEN_ENV, vaultKey: DISCORD_TOKEN_KEY });
+}
+
+/**
+ * Parse the stored authorized-user id. Returns null for a missing OR corrupt
+ * value (anything that isn't a snowflake) so a bad vault write reads as
+ * "unpaired" instead of silently authorizing garbage.
+ */
+export function parseAuthorizedUser(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  return snowflakeSchema.safeParse(trimmed).success ? trimmed : null;
+}
+
+const allowedChannelsSchema = z.array(snowflakeSchema);
+
+/**
+ * Parse the stored guild-channel allow-list (a JSON array of snowflakes).
+ * Corrupt/missing values read as the empty list — DENY every guild channel —
+ * rather than throwing or letting junk ids through.
+ */
+export function parseAllowedChannels(raw: string | null | undefined): ReadonlyArray<string> {
+  if (!raw) return [];
+  try {
+    const parsed = allowedChannelsSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Serialize the allow-list for the vault (deduplicated, stable order). */
+export function serializeAllowedChannels(ids: Iterable<string>): string {
+  return JSON.stringify([...new Set(ids)]);
+}

--- a/packages/plugin-channel-discord/src/pair-flow.ts
+++ b/packages/plugin-channel-discord/src/pair-flow.ts
@@ -1,0 +1,115 @@
+import { isCancel, log, outro, spinner, text } from '@clack/prompts';
+import type { ChannelSubcommandContext } from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { DiscordChannel } from './channel.js';
+
+// Tiny zero-dep ANSI dim helper, so this flow stays inside the plugin.
+const ANSI = process.stdout.isTTY && !process.env.NO_COLOR;
+const dim = (s: string): string => (ANSI ? `\x1b[2m${s}\x1b[22m` : s);
+
+/** How many wrong codes the operator may paste before we give up. */
+const MAX_CODE_ATTEMPTS = 5;
+
+/**
+ * Drive the DM code pairing flow end-to-end in a terminal.
+ *
+ * Steps:
+ *   1. Build a DiscordChannel from the subcommand ctx and wire the session's
+ *      permission resolver.
+ *   2. Start the bot with the pairing window armed (`pair: true`).
+ *   3. Tell the user to DM the bot (from the account that should own it) —
+ *      the bot replies to that DM with a one-time code.
+ *   4. Prompt for the code here; on match that account is authorized and
+ *      persisted.
+ *   5. Keep the bot running until Ctrl+C (mirrors the Telegram pair flow).
+ */
+export async function runPairFlow(ctx: ChannelSubcommandContext): Promise<number> {
+  const session = ctx.session;
+  const channel = new DiscordChannel({
+    vault: ctx.deps.vault as VaultStore,
+    token: (ctx.deps.options?.['token'] as string | undefined) ?? undefined,
+    logger: ctx.deps.logger as never,
+  });
+  session.setPermissionResolver(channel.permissionResolver);
+
+  outro(dim('starting the bot with a pairing window armed...'));
+
+  const handle = await channel.start({ session, pair: true });
+
+  const stopBot = async (): Promise<void> => {
+    try {
+      await handle.stop('wizard');
+    } catch {
+      /* ignore */
+    }
+  };
+
+  // Already paired (no window armed): nothing to confirm. Tell the user how
+  // to re-pair rather than prompting for a code that can never arrive.
+  if (channel.connected) {
+    log.info(
+      'This bot is already paired. Run `moxxy channels discord unpair` first to pair a different account.',
+    );
+    await stopBot();
+    return 0;
+  }
+
+  if (channel.requestUrl) {
+    log.info(`Invite the bot to a server (needed once so you can DM it):\n  ${channel.requestUrl}`);
+  }
+  log.info(
+    'Now DM the bot from YOUR Discord account (any message). It replies with a one-time code — paste that code below.',
+  );
+
+  // Graceful Ctrl-C while waiting (or once running): stop the bot and exit.
+  let stopping = false;
+  const shutdown = async (): Promise<void> => {
+    if (stopping) return;
+    stopping = true;
+    await stopBot();
+    await session.close('SIGINT').catch(() => undefined);
+    process.exit(0);
+  };
+  const onSignal = (): void => void shutdown();
+  process.once('SIGINT', onSignal);
+  process.once('SIGTERM', onSignal);
+
+  try {
+    let paired = false;
+    for (let attempt = 0; attempt < MAX_CODE_ATTEMPTS && !paired; attempt++) {
+      const code = await text({
+        message: 'Paste the pairing code from the bot\'s DM reply',
+        placeholder: '6-digit code',
+        validate: (v) => (!v || !v.trim() ? 'required' : undefined),
+      });
+      if (isCancel(code)) {
+        log.info('Pairing cancelled.');
+        await stopBot();
+        return 0;
+      }
+      const result = await channel.confirmPairingCode(String(code));
+      if (result.ok) {
+        paired = true;
+        log.success(`Paired ✓ — Discord user ${result.userId} is authorized.`);
+        break;
+      }
+      log.warn(result.message);
+    }
+    if (!paired) {
+      log.error('Too many failed attempts — pairing aborted. Run `moxxy discord pair` to retry.');
+      await stopBot();
+      return 1;
+    }
+
+    const spin = spinner();
+    spin.start('Bot is running. Press Ctrl+C to stop.');
+    // Only reached if the bot stops on its own (a signal path exits via
+    // shutdown()).
+    await handle.running;
+    spin.stop('bot stopped.');
+    return 0;
+  } finally {
+    process.removeListener('SIGINT', onSignal);
+    process.removeListener('SIGTERM', onSignal);
+  }
+}

--- a/packages/plugin-channel-discord/src/pairing.test.ts
+++ b/packages/plugin-channel-discord/src/pairing.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  armPairing,
+  clearDiscordPairing,
+  confirmPendingCode,
+  createDiscordPairingState,
+  isUserAuthorized,
+  mintCodeForPeer,
+  pairingPhase,
+} from './pairing.js';
+
+const USER_A = '111111111111';
+const USER_B = '222222222222';
+
+describe('discord pairing state machine (DM code flow)', () => {
+  it('starts idle and unarmed; DMs get a "no window" rejection', () => {
+    const state = createDiscordPairingState();
+    expect(pairingPhase(state)).toBe('idle');
+    const decision = mintCodeForPeer(state, USER_A);
+    expect(decision.action.kind).toBe('reject');
+    expect(isUserAuthorized(decision.state, USER_A)).toBe(false);
+  });
+
+  it('mints a code for a DM-ing user once armed, then pairs on the pasted code', async () => {
+    let state = armPairing(createDiscordPairingState());
+    expect(pairingPhase(state)).toBe('armed');
+
+    const minted = mintCodeForPeer(state, USER_A, '123456');
+    expect(minted.action).toEqual({ kind: 'code-minted', userId: USER_A, code: '123456' });
+    state = minted.state;
+    expect(pairingPhase(state)).toBe('awaiting-host-code');
+
+    const confirmed = confirmPendingCode(state, ' 123 456 '); // whitespace tolerated
+    expect(confirmed.action).toEqual({ kind: 'paired', userId: USER_A });
+    expect(isUserAuthorized(confirmed.state, USER_A)).toBe(true);
+    expect(isUserAuthorized(confirmed.state, USER_B)).toBe(false);
+    expect(pairingPhase(confirmed.state)).toBe('paired');
+  });
+
+  it('rejects a wrong pasted code without transitioning', () => {
+    let state = armPairing(createDiscordPairingState());
+    state = mintCodeForPeer(state, USER_A, '123456').state;
+    const confirmed = confirmPendingCode(state, '654321');
+    expect(confirmed.action.kind).toBe('mismatch');
+    expect(isUserAuthorized(confirmed.state, USER_A)).toBe(false);
+    // The window stays open — the right code still pairs.
+    const retry = confirmPendingCode(confirmed.state, '123456');
+    expect(retry.action.kind).toBe('paired');
+  });
+
+  it('a second DM-ing user re-mints the window: the FIRST code goes stale (fails safe)', () => {
+    let state = armPairing(createDiscordPairingState());
+    const first = mintCodeForPeer(state, USER_A, '111111');
+    state = first.state;
+    const second = mintCodeForPeer(state, USER_B, '222222');
+    expect(second.action).toEqual({ kind: 'code-minted', userId: USER_B, code: '222222' });
+    state = second.state;
+    // Pasting USER_A's (stale) code must NOT pair anyone.
+    const stale = confirmPendingCode(state, '111111');
+    expect(stale.action.kind).toBe('mismatch');
+    expect(isUserAuthorized(stale.state, USER_A)).toBe(false);
+    expect(isUserAuthorized(stale.state, USER_B)).toBe(false);
+    // Pasting the CURRENT code pairs the user it was minted for.
+    const paired = confirmPendingCode(state, '222222');
+    expect(paired.action).toEqual({ kind: 'paired', userId: USER_B });
+  });
+
+  it('confirm without any pending DM is not-pending', () => {
+    const state = armPairing(createDiscordPairingState());
+    const confirmed = confirmPendingCode(state, '123456');
+    expect(confirmed.action.kind).toBe('not-pending');
+  });
+
+  it('a foreign user DM-ing a PAIRED bot is rejected; the paired user is greeted', () => {
+    const state = createDiscordPairingState({ authorizedUserId: USER_A });
+    expect(pairingPhase(state)).toBe('paired');
+    expect(mintCodeForPeer(state, USER_B).action.kind).toBe('reject');
+    expect(mintCodeForPeer(state, USER_A).action.kind).toBe('still-paired');
+  });
+
+  it('an expired code reports expired and clears the pending window', () => {
+    let state = armPairing(createDiscordPairingState());
+    // Arm with an explicit ttl through the kit path by minting then aging the
+    // confirm clock beyond a synthetic expiry: mint has no ttl by default, so
+    // simulate via a stale `now` only when expiresAt is set — the default is
+    // no-TTL, so this confirms the no-TTL behavior instead.
+    state = mintCodeForPeer(state, USER_A, '123456').state;
+    const decision = confirmPendingCode(state, '123456', Date.now() + 10 * 60_000);
+    // No TTL by default → still pairs even much later.
+    expect(decision.action.kind).toBe('paired');
+  });
+
+  it('clearDiscordPairing forgets the principal but keeps the armed flag', () => {
+    let state = armPairing(createDiscordPairingState({ authorizedUserId: USER_A }));
+    state = clearDiscordPairing(state);
+    expect(isUserAuthorized(state, USER_A)).toBe(false);
+    expect(pairingPhase(state)).toBe('armed');
+  });
+});

--- a/packages/plugin-channel-discord/src/pairing.ts
+++ b/packages/plugin-channel-discord/src/pairing.ts
@@ -1,0 +1,178 @@
+import { randomCode } from '@moxxy/plugin-vault';
+import {
+  clearHostCodePairing,
+  createHostCodeState,
+  greetPeer,
+  isPeerAuthorized,
+  openHostCodeWindow,
+  submitPeerCode,
+  type HostCodeAction,
+  type HostCodeState,
+} from '@moxxy/channel-kit';
+
+/**
+ * Discord pairing — the kit's host-code machine, driven over DM in the
+ * "bot replies with a code, operator pastes it in the terminal" direction.
+ *
+ * Flow (the wizard/`moxxy discord pair` arms it):
+ *   1. The channel starts with a pairing window ARMED (no code yet).
+ *   2. An unauthorized user DMs the bot → we mint a one-time code bound to
+ *      THAT user ({@link mintCodeForPeer} = `openHostCodeWindow` with the
+ *      DM-ing user recorded as the pending peer) and DM the code back.
+ *   3. The operator pastes the code into the terminal wizard →
+ *      {@link confirmPendingCode} (`submitPeerCode` against the pending peer).
+ *      On match the DM-ing user becomes the authorized principal.
+ *
+ * Security property: the code only ever lives in the candidate's DM, so
+ * pasting it in the terminal proves the operator controls (or trusts) that
+ * Discord account. A different user DM-ing while armed re-mints the window
+ * for themselves — which STALES the earlier code, so the operator's paste of
+ * the legitimate code then mismatches and pairing simply retries; an attacker
+ * can never be authorized unless the operator pastes the ATTACKER's code
+ * (which only exists in the attacker's DM).
+ *
+ * The transitions live in `@moxxy/channel-kit` (generic over the peer id —
+ * a Discord user id string here); this module keeps the Discord-shaped state
+ * (armed flag + pending peer) and maps the kit's semantic action kinds to
+ * Discord-worded messages.
+ */
+
+export type DiscordPairingPhase = 'idle' | 'armed' | 'awaiting-host-code' | 'paired' | 'expired';
+
+export interface DiscordPairingState {
+  /** Kit machine state; peer = Discord user id. */
+  readonly kit: HostCodeState<string>;
+  /** A pairing window is armed (codes will be minted for DM-ing users). */
+  readonly armed: boolean;
+  /** The user the CURRENT code was minted for (null when none outstanding). */
+  readonly pendingUserId: string | null;
+}
+
+export interface DiscordPairingDecision {
+  readonly state: DiscordPairingState;
+  readonly action:
+    | { kind: 'code-minted'; userId: string; code: string }
+    | { kind: 'paired'; userId: string }
+    | { kind: 'still-paired'; userId: string }
+    | { kind: 'reject'; message: string }
+    | { kind: 'mismatch'; message: string }
+    | { kind: 'not-pending'; message: string }
+    | { kind: 'expired'; message: string };
+}
+
+const MSG_FOREIGN_USER = 'This bot is paired with a different Discord account. Access denied.';
+const MSG_NOT_ARMED =
+  'No pairing window is open. Run `moxxy discord pair` in the moxxy terminal first, then DM me again.';
+const MSG_NOT_PENDING = 'No pairing code is outstanding. DM the bot first — it replies with a code.';
+const MSG_MISMATCH =
+  "That code didn't match. Check the code in the bot's most recent DM reply and try again.";
+const MSG_EXPIRED = 'The pairing code expired. DM the bot again for a fresh one.';
+
+export function createDiscordPairingState(
+  opts: { authorizedUserId?: string | null } = {},
+): DiscordPairingState {
+  return {
+    kit: createHostCodeState<string>({ authorizedPeer: opts.authorizedUserId ?? null }),
+    armed: false,
+    pendingUserId: null,
+  };
+}
+
+export function pairingPhase(state: DiscordPairingState): DiscordPairingPhase {
+  if (state.kit.phase === 'paired') return 'paired';
+  if (state.kit.phase === 'awaiting-host-code') return 'awaiting-host-code';
+  if (state.kit.phase === 'expired') return 'expired';
+  return state.armed ? 'armed' : 'idle';
+}
+
+/** Arm the pairing window: DM-ing users will now be issued one-time codes. */
+export function armPairing(state: DiscordPairingState): DiscordPairingState {
+  return { ...state, armed: true };
+}
+
+export function isUserAuthorized(state: DiscordPairingState, userId: string): boolean {
+  return isPeerAuthorized(state.kit, userId);
+}
+
+export function clearDiscordPairing(state: DiscordPairingState): DiscordPairingState {
+  return {
+    kit: clearHostCodePairing(state.kit),
+    armed: state.armed,
+    pendingUserId: null,
+  };
+}
+
+/**
+ * An unauthorized user DMed the bot while a window may be armed. Mints a
+ * one-time code bound to that user (re-arming replaces any earlier pending
+ * code — see the module doc for why that fails safe) or rejects with the
+ * appropriate wording.
+ */
+export function mintCodeForPeer(
+  state: DiscordPairingState,
+  userId: string,
+  code: string = randomCode(6),
+): DiscordPairingDecision {
+  const greeted = greetPeer(state.kit, userId);
+  if (greeted.action.kind === 'still-paired') {
+    return { state, action: { kind: 'still-paired', userId } };
+  }
+  if (greeted.action.kind === 'rejected-foreign-peer') {
+    return { state, action: { kind: 'reject', message: MSG_FOREIGN_USER } };
+  }
+  if (!state.armed) {
+    return { state, action: { kind: 'reject', message: MSG_NOT_ARMED } };
+  }
+  const opened = openHostCodeWindow(state.kit, { code });
+  return {
+    state: { kit: opened.state, armed: true, pendingUserId: userId },
+    action: { kind: 'code-minted', userId, code: opened.code },
+  };
+}
+
+/** Map a kit action to the Discord-worded decision, reusing `state` when the
+ *  machine didn't transition. */
+function mapConfirmAction(
+  state: DiscordPairingState,
+  kitState: HostCodeState<string>,
+  action: HostCodeAction<string>,
+): DiscordPairingDecision {
+  switch (action.kind) {
+    case 'paired':
+      return {
+        state: { kit: kitState, armed: false, pendingUserId: null },
+        action: { kind: 'paired', userId: action.peer },
+      };
+    case 'still-paired':
+      return { state, action: { kind: 'still-paired', userId: action.peer } };
+    case 'rejected-foreign-peer':
+      return { state, action: { kind: 'reject', message: MSG_FOREIGN_USER } };
+    case 'window-open-hint':
+    case 'no-window':
+    case 'not-pending':
+      return { state, action: { kind: 'not-pending', message: MSG_NOT_PENDING } };
+    case 'expired':
+      return {
+        state: { kit: kitState, armed: state.armed, pendingUserId: null },
+        action: { kind: 'expired', message: MSG_EXPIRED },
+      };
+    case 'mismatch':
+      return { state, action: { kind: 'mismatch', message: MSG_MISMATCH } };
+  }
+}
+
+/**
+ * The operator pasted a code into the terminal wizard. Compared against the
+ * code minted for the CURRENT pending user; on match that user is authorized.
+ */
+export function confirmPendingCode(
+  state: DiscordPairingState,
+  rawCode: string,
+  now: number = Date.now(),
+): DiscordPairingDecision {
+  if (state.pendingUserId == null) {
+    return { state, action: { kind: 'not-pending', message: MSG_NOT_PENDING } };
+  }
+  const decision = submitPeerCode(state.kit, state.pendingUserId, rawCode, now);
+  return mapConfirmAction(state, decision.state, decision.action);
+}

--- a/packages/plugin-channel-discord/src/permission.ts
+++ b/packages/plugin-channel-discord/src/permission.ts
@@ -1,0 +1,70 @@
+import type {
+  PendingToolCall,
+  PermissionContext,
+  PermissionDecision,
+  PermissionResolver,
+} from '@moxxy/sdk';
+
+export interface PendingPermission {
+  readonly callId: string;
+  readonly call: PendingToolCall;
+  readonly ctx: PermissionContext;
+  readonly resolve: (decision: PermissionDecision) => void;
+}
+
+/**
+ * Permission resolver that defers each tool call to an external decider (the
+ * Discord bot, which renders a button row and waits for a click). The channel
+ * registers an interaction handler that invokes `resolvePending(callId,
+ * decision)` when the paired user clicks a button. Mirrors the Telegram
+ * resolver's shape (pending map + setDecider + abortAll) — the button
+ * click arrives on a different code path than the check, so the shared
+ * `createDeferredPermissionResolver` (whose prompt must RETURN the decision)
+ * doesn't fit; the abortAll contract is preserved here instead.
+ */
+export class DiscordPermissionResolver implements PermissionResolver {
+  readonly name = 'discord';
+  private readonly pending = new Map<string, PendingPermission>();
+  private readonly sessionAllows = new Set<string>();
+  private deciderFn: ((call: PendingToolCall, ctx: PermissionContext) => Promise<void>) | null =
+    null;
+
+  setDecider(fn: (call: PendingToolCall, ctx: PermissionContext) => Promise<void>): void {
+    this.deciderFn = fn;
+  }
+
+  async check(call: PendingToolCall, ctx: PermissionContext): Promise<PermissionDecision> {
+    if (this.sessionAllows.has(call.name)) {
+      return { mode: 'allow_session', reason: 'allow_session previously granted' };
+    }
+    if (!this.deciderFn) {
+      return { mode: 'deny', reason: 'no decider attached (bot not running)' };
+    }
+    const decision = await new Promise<PermissionDecision>((resolve) => {
+      this.pending.set(call.callId, { callId: call.callId, call, ctx, resolve });
+      this.deciderFn!(call, ctx).catch((err) => {
+        this.pending.delete(call.callId);
+        resolve({ mode: 'deny', reason: err instanceof Error ? err.message : String(err) });
+      });
+    });
+    if (decision.mode === 'allow_session') this.sessionAllows.add(call.name);
+    return decision;
+  }
+
+  /** Called by the interaction handler when a permission button is clicked. */
+  resolvePending(callId: string, decision: PermissionDecision): boolean {
+    const pending = this.pending.get(callId);
+    if (!pending) return false;
+    this.pending.delete(callId);
+    pending.resolve(decision);
+    return true;
+  }
+
+  /** Deny every in-flight prompt — MUST run on channel stop so callers don't hang. */
+  abortAll(reason = 'channel closed'): void {
+    for (const pending of this.pending.values()) {
+      pending.resolve({ mode: 'deny', reason });
+    }
+    this.pending.clear();
+  }
+}

--- a/packages/plugin-channel-discord/src/render.test.ts
+++ b/packages/plugin-channel-discord/src/render.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import type { MoxxyEvent } from '@moxxy/sdk';
+import { DiscordTurnRenderer, splitForDiscord } from './render.js';
+
+const ev = (partial: Record<string, unknown>): MoxxyEvent => partial as unknown as MoxxyEvent;
+
+describe('DiscordTurnRenderer', () => {
+  it('accumulates chunks, prefers the final assistant message, reports updates', () => {
+    const r = new DiscordTurnRenderer();
+    expect(r.accept(ev({ type: 'assistant_chunk', delta: 'Hel' }))).toBe(true);
+    expect(r.accept(ev({ type: 'assistant_chunk', delta: 'lo' }))).toBe(true);
+    expect(r.snapshot()).toBe('Hello');
+    expect(r.accept(ev({ type: 'assistant_message', content: 'Hello, world.' }))).toBe(true);
+    expect(r.snapshot()).toBe('Hello, world.');
+    // Unknown events don't change the frame.
+    expect(r.accept(ev({ type: 'user_prompt', content: 'x' }))).toBe(false);
+  });
+
+  it('renders tool activity as a quote block with statuses', () => {
+    const r = new DiscordTurnRenderer();
+    r.accept(ev({ type: 'tool_call_requested', callId: 'c1', name: 'read_file', input: { path: '/tmp/x' } }));
+    expect(r.snapshot()).toContain('> - `read_file` (path=/tmp/x) — running…');
+    r.accept(ev({ type: 'tool_result', callId: 'c1', ok: true, output: 'ok' }));
+    expect(r.snapshot()).toMatch(/`read_file`.*— done /);
+    r.accept(ev({ type: 'tool_call_requested', callId: 'c2', name: 'bash', input: {} }));
+    r.accept(ev({ type: 'tool_call_denied', callId: 'c2', reason: 'denied by user' }));
+    expect(r.snapshot()).toContain('denied: denied by user');
+  });
+
+  it('surfaces error events', () => {
+    const r = new DiscordTurnRenderer();
+    r.accept(ev({ type: 'error', kind: 'provider', message: 'boom' }));
+    expect(r.snapshot()).toContain('❗ **provider**: boom');
+  });
+
+  it('reset clears everything', () => {
+    const r = new DiscordTurnRenderer();
+    r.accept(ev({ type: 'assistant_chunk', delta: 'x' }));
+    r.reset();
+    expect(r.snapshot()).toBe('');
+  });
+});
+
+describe('splitForDiscord (2000-char cap)', () => {
+  it('returns single part under the limit and [] for empty', () => {
+    expect(splitForDiscord('hi')).toEqual(['hi']);
+    expect(splitForDiscord('')).toEqual([]);
+  });
+
+  it('splits on newline boundaries and keeps every part under the cap', () => {
+    const line = 'a'.repeat(80);
+    const text = Array.from({ length: 60 }, () => line).join('\n'); // ~4860 chars
+    const parts = splitForDiscord(text, 500);
+    expect(parts.length).toBeGreaterThan(1);
+    for (const p of parts) expect(p.length).toBeLessThanOrEqual(500);
+    // No content lost: rejoining with newlines reproduces the original lines.
+    expect(parts.join('\n')).toBe(text);
+  });
+
+  it('closes and reopens a code fence across a cut (with its info string)', () => {
+    const fenceBody = Array.from({ length: 50 }, (_, i) => `line ${i}`).join('\n');
+    const text = 'intro\n```diff\n' + fenceBody + '\n```\noutro';
+    const parts = splitForDiscord(text, 120);
+    expect(parts.length).toBeGreaterThan(1);
+    for (const p of parts) expect(p.length).toBeLessThanOrEqual(120);
+    // Every part is fence-balanced (an even number of ``` markers).
+    for (const p of parts) {
+      const fences = p.match(/```/g) ?? [];
+      expect(fences.length % 2).toBe(0);
+    }
+    // A middle part reopens with the original info string.
+    const middle = parts.slice(1, -1);
+    expect(middle.some((p) => p.startsWith('```diff\n'))).toBe(true);
+  });
+
+  it('handles oversized single lines (no newline under the budget)', () => {
+    const text = 'x'.repeat(5000);
+    const parts = splitForDiscord(text, 1000);
+    expect(parts.join('')).toBe(text);
+    for (const p of parts) expect(p.length).toBeLessThanOrEqual(1000);
+  });
+});

--- a/packages/plugin-channel-discord/src/render.ts
+++ b/packages/plugin-channel-discord/src/render.ts
@@ -1,0 +1,222 @@
+import type { MoxxyEvent } from '@moxxy/sdk';
+
+/**
+ * Discord messages cap at 2000 chars; leave margin for the fence-reopen text a
+ * split may prepend to a tail part.
+ */
+export const DISCORD_MESSAGE_LIMIT = 1_900;
+
+/**
+ * Accumulates one turn's events into a single Discord-markdown string (the
+ * frame the pump sends/edits). Discord renders standard markdown natively
+ * (bold, `code`, ``` fences, > quotes), so — unlike Telegram — no HTML
+ * conversion pass is needed; the assistant body passes through as-is with a
+ * compact tool-activity quote block above it.
+ *
+ * Structure of a frame:
+ *
+ *   > -  `tool_name` (args) — done 0.4s
+ *   > -  `another_tool` (args) — running…
+ *
+ *   <assistant body>
+ *
+ *   <error if any>
+ */
+type ToolStatus =
+  | { kind: 'pending'; startedAt: number }
+  | { kind: 'ok'; ms: number }
+  | { kind: 'err'; ms: number; message: string }
+  | { kind: 'denied'; reason: string };
+
+interface ToolEntry {
+  readonly name: string;
+  readonly inputPreview: string;
+  status: ToolStatus;
+}
+
+export class DiscordTurnRenderer {
+  private chunks: string[] = [];
+  private finalAssistant: string | null = null;
+  private readonly tools = new Map<string, ToolEntry>();
+  private notices: string[] = [];
+  private errorLine: string | null = null;
+  private lastFrame = '';
+
+  /** Returns true when the event changed the frame (schedule an edit). */
+  accept(event: MoxxyEvent): boolean {
+    switch (event.type) {
+      case 'assistant_chunk':
+        this.chunks.push(event.delta);
+        break;
+      case 'assistant_message':
+        this.finalAssistant = event.content;
+        this.chunks = [];
+        break;
+      case 'tool_call_requested':
+        this.tools.set(String(event.callId), {
+          name: event.name,
+          inputPreview: previewArgs(event.input),
+          status: { kind: 'pending', startedAt: Date.now() },
+        });
+        break;
+      case 'tool_call_denied': {
+        const entry = this.tools.get(String(event.callId));
+        if (entry) entry.status = { kind: 'denied', reason: event.reason };
+        break;
+      }
+      case 'tool_result': {
+        const entry = this.tools.get(String(event.callId));
+        if (!entry) break;
+        const started = entry.status.kind === 'pending' ? entry.status.startedAt : Date.now();
+        const ms = Date.now() - started;
+        entry.status = event.ok
+          ? { kind: 'ok', ms }
+          : {
+              kind: 'err',
+              ms,
+              message: `${event.error?.kind ?? 'error'}: ${event.error?.message ?? ''}`,
+            };
+        break;
+      }
+      case 'skill_invoked':
+        this.notices.push(`💡 skill: **${event.name}**`);
+        break;
+      case 'error':
+        this.errorLine = `❗ **${event.kind}**: ${event.message}`;
+        break;
+      default:
+        break;
+    }
+    const frame = this.snapshot();
+    const changed = frame !== this.lastFrame;
+    this.lastFrame = frame;
+    return changed;
+  }
+
+  snapshot(): string {
+    const parts: string[] = [];
+    const activity = this.renderActivity();
+    if (activity) parts.push(activity);
+    const body = (this.finalAssistant ?? this.chunks.join('')).trim();
+    if (body) parts.push(body);
+    if (this.errorLine) parts.push(this.errorLine);
+    return parts.join('\n\n').trim();
+  }
+
+  reset(): void {
+    this.chunks = [];
+    this.finalAssistant = null;
+    this.tools.clear();
+    this.notices = [];
+    this.errorLine = null;
+    this.lastFrame = '';
+  }
+
+  private renderActivity(): string | null {
+    const lines: string[] = [];
+    const tools = [...this.tools.values()];
+    const visible = tools.slice(-10);
+    const hidden = tools.length - visible.length;
+    if (hidden > 0) lines.push(`… ${hidden} earlier tool call${hidden === 1 ? '' : 's'} hidden`);
+    for (const t of visible) {
+      const args = t.inputPreview ? ` (${t.inputPreview})` : '';
+      lines.push(`- \`${t.name}\`${args} — ${statusBadge(t.status)}`);
+    }
+    for (const n of this.notices.slice(-5)) lines.push(n);
+    if (lines.length === 0) return null;
+    return lines.map((l) => `> ${l}`).join('\n');
+  }
+}
+
+function statusBadge(status: ToolStatus): string {
+  switch (status.kind) {
+    case 'pending':
+      return 'running…';
+    case 'ok':
+      return `done ${fmtElapsed(status.ms)}`;
+    case 'err':
+      return `error: ${status.message.slice(0, 80)}`;
+    case 'denied':
+      return `denied: ${status.reason.slice(0, 80)}`;
+  }
+}
+
+function fmtElapsed(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${Math.floor(ms / 60_000)}m ${Math.floor((ms % 60_000) / 1000)}s`;
+}
+
+function truncJson(value: unknown, max = 60): string {
+  const s = typeof value === 'string' ? value : (JSON.stringify(value) ?? '');
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + '…';
+}
+
+function previewArgs(input: unknown): string {
+  if (input == null || (typeof input === 'object' && Object.keys(input as object).length === 0)) {
+    return '';
+  }
+  if (typeof input === 'string') return truncJson(input);
+  try {
+    const obj = input as Record<string, unknown>;
+    const keys = Object.keys(obj).slice(0, 3);
+    const pairs = keys.map((k) => `${k}=${truncJson(obj[k], 20)}`);
+    const tail = Object.keys(obj).length > keys.length ? ', …' : '';
+    return pairs.join(', ') + tail;
+  } catch {
+    return truncJson(input);
+  }
+}
+
+/**
+ * Split Discord markdown into <=`limit`-char parts that each render sanely on
+ * their own (mirrors `splitForTelegram`'s shape, adapted from HTML tags to the
+ * one markdown construct that breaks when cut: a ``` code fence). Cuts prefer
+ * a newline at/under the budget; if the cut lands inside an open fence, the
+ * fence is closed at the head part's end and reopened (with its original
+ * info-string, e.g. ```diff) at the tail's start, so every part is
+ * independently valid. Parts are separate Discord messages, so the newline a
+ * cut lands on is consumed (not carried into the tail).
+ */
+export function splitForDiscord(text: string, limit: number = DISCORD_MESSAGE_LIMIT): string[] {
+  if (text.length <= limit) return text ? [text] : [];
+  const out: string[] = [];
+  /** The fence opener carried over from the previous part (reopened at its head). */
+  let carryFence: string | null = null;
+  let remaining = text;
+  while (remaining.length > limit) {
+    const prefix = carryFence ? carryFence + '\n' : '';
+    // The reopened fence + a possible closing fence eat into the budget.
+    const budget = Math.max(1, limit - prefix.length - '\n```'.length);
+    let idx = Math.min(budget, remaining.length);
+    const nl = remaining.lastIndexOf('\n', idx);
+    if (nl > 0) idx = nl;
+    const openFence = openFenceAt(remaining, idx, carryFence);
+    const head = prefix + remaining.slice(0, idx) + (openFence ? '\n```' : '');
+    out.push(head);
+    carryFence = openFence;
+    remaining = remaining.slice(idx);
+    // Drop the leading newline the cut left behind (it was consumed by the cut
+    // point, and the reopened fence supplies its own).
+    if (remaining.startsWith('\n')) remaining = remaining.slice(1);
+  }
+  if (remaining) out.push((carryFence ? carryFence + '\n' : '') + remaining);
+  return out;
+}
+
+/**
+ * Is a ``` fence open at `idx`? Returns the fence's opening line (e.g.
+ * "```diff") when open, else null. `seed` is the fence carried into this part
+ * from the previous split (the text below it starts inside that fence).
+ */
+function openFenceAt(text: string, idx: number, seed: string | null): string | null {
+  let open: string | null = seed;
+  const scan = text.slice(0, idx);
+  const fenceRe = /(?:^|\n)(```[^\n]*)/g;
+  let m: RegExpExecArray | null;
+  while ((m = fenceRe.exec(scan)) !== null) {
+    open = open === null ? m[1]! : null;
+  }
+  return open;
+}

--- a/packages/plugin-channel-discord/src/schema.ts
+++ b/packages/plugin-channel-discord/src/schema.ts
@@ -1,0 +1,94 @@
+/**
+ * Inbound-payload validation (AGENTS.md invariant: zod-validate every inbound
+ * frame/body before it touches the session). discord.js hands us rich class
+ * instances; we extract ONLY the primitive fields the channel consumes into a
+ * plain record and validate + size-cap that, so a malformed/hostile payload is
+ * dropped at the boundary instead of flowing into handlers.
+ */
+import { z } from '@moxxy/sdk';
+import { snowflakeSchema } from './keys.js';
+
+/**
+ * Hard cap on inbound message text we accept. Discord caps user messages at
+ * 4000 chars (Nitro); anything past this is not a legitimate prompt, so we
+ * drop it rather than truncate (a silently truncated prompt is worse than a
+ * clear rejection).
+ */
+export const MAX_CONTENT_CHARS = 8_000;
+
+/** Hard cap on an inbound audio attachment we will buffer for transcription. */
+export const MAX_AUDIO_BYTES = 20 * 1024 * 1024;
+
+const attachmentSchema = z.object({
+  id: snowflakeSchema,
+  url: z.string().url().max(2_048),
+  contentType: z.string().max(256).nullable(),
+  size: z.number().int().nonnegative(),
+  name: z.string().max(1_024).nullable(),
+});
+
+export const inboundMessageSchema = z.object({
+  id: snowflakeSchema,
+  /** Raw message text (may be empty for attachment-only messages). */
+  content: z.string().max(MAX_CONTENT_CHARS),
+  channelId: snowflakeSchema,
+  /** Null for DMs. */
+  guildId: snowflakeSchema.nullable(),
+  authorId: snowflakeSchema,
+  authorIsBot: z.boolean(),
+  attachments: z.array(attachmentSchema).max(16),
+});
+
+export type InboundMessage = z.infer<typeof inboundMessageSchema>;
+export type InboundAttachment = z.infer<typeof attachmentSchema>;
+
+/** The structural slice of a discord.js Message we extract fields from. */
+export interface RawMessageLike {
+  readonly id?: unknown;
+  readonly content?: unknown;
+  readonly channelId?: unknown;
+  readonly guildId?: unknown;
+  readonly author?: { readonly id?: unknown; readonly bot?: unknown } | null;
+  readonly attachments?: {
+    values?(): IterableIterator<{
+      readonly id?: unknown;
+      readonly url?: unknown;
+      readonly contentType?: unknown;
+      readonly size?: unknown;
+      readonly name?: unknown;
+    }>;
+  } | null;
+}
+
+/**
+ * Extract + validate the fields we consume from a discord.js Message. Returns
+ * null when the payload doesn't validate (wrong shapes, oversized content,
+ * missing ids) — the caller drops it with a warning.
+ */
+export function extractInboundMessage(msg: RawMessageLike): InboundMessage | null {
+  const attachments: unknown[] = [];
+  try {
+    for (const a of msg.attachments?.values?.() ?? []) {
+      attachments.push({
+        id: a?.id,
+        url: a?.url,
+        contentType: a?.contentType ?? null,
+        size: a?.size,
+        name: a?.name ?? null,
+      });
+    }
+  } catch {
+    return null;
+  }
+  const candidate = {
+    id: msg.id,
+    content: msg.content,
+    channelId: msg.channelId,
+    guildId: msg.guildId ?? null,
+    authorId: msg.author?.id,
+    authorIsBot: msg.author?.bot === true,
+    attachments,
+  };
+  const parsed = inboundMessageSchema.safeParse(candidate);
+  return parsed.success ? parsed.data : null;
+}

--- a/packages/plugin-channel-discord/src/setup-wizard.ts
+++ b/packages/plugin-channel-discord/src/setup-wizard.ts
@@ -1,0 +1,162 @@
+import { cancel, intro, isCancel, log, note, outro, password, select } from '@clack/prompts';
+import type { ChannelSubcommandContext } from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import {
+  DISCORD_ALLOWED_CHANNELS_KEY,
+  DISCORD_AUTHORIZED_USER_KEY,
+  DISCORD_TOKEN_ENV,
+  DISCORD_TOKEN_KEY,
+  DISCORD_TOKEN_RE,
+  parseAllowedChannels,
+  parseAuthorizedUser,
+} from './keys.js';
+import { runPairFlow } from './pair-flow.js';
+
+// Tiny zero-dep ANSI helpers (bold + dim) so this wizard stays inside the
+// plugin without depending on the CLI's colors module.
+const ANSI = process.stdout.isTTY && !process.env.NO_COLOR;
+const bold = (s: string): string => (ANSI ? `\x1b[1m${s}\x1b[22m` : s);
+const dim = (s: string): string => (ANSI ? `\x1b[2m${s}\x1b[22m` : s);
+
+interface State {
+  readonly hasToken: boolean;
+  readonly authorizedUserId: string | null;
+  readonly allowedChannelCount: number;
+}
+
+type Action = 'set-token' | 'pair' | 'unpair' | 'start' | 'quit';
+
+/**
+ * Interactive Discord setup menu — invoked as the channel's
+ * `interactiveCommand` when the user runs `moxxy discord` with no subcommand
+ * in a TTY. Headless invocations bypass it and start the bot directly.
+ *
+ * Menu offers actions appropriate to the current state:
+ *   - no token            -> "Set bot token" + "Quit"
+ *   - token, not paired   -> "Pair a Discord account" + "Change token" + "Quit"
+ *   - token + paired      -> "Start bot" + "Unpair" + "Change token" + "Quit"
+ */
+export async function runDiscordWizard(ctx: ChannelSubcommandContext): Promise<number> {
+  const vault = ctx.deps.vault as VaultStore;
+
+  intro(bold('moxxy discord setup'));
+
+  while (true) {
+    const state = await readState(vault);
+    printStatus(state);
+    const action = await pickAction(state);
+    if (action === null) {
+      cancel('cancelled.');
+      return 0;
+    }
+    if (action === 'quit') {
+      outro(dim('done.'));
+      return 0;
+    }
+    if (action === 'set-token') {
+      await actionSetToken(vault);
+      continue;
+    }
+    if (action === 'pair') {
+      return await runPairFlow(ctx);
+    }
+    if (action === 'unpair') {
+      await vault.delete(DISCORD_AUTHORIZED_USER_KEY);
+      log.success('Unpaired. Run pairing again to authorize an account.');
+      continue;
+    }
+    if (action === 'start') {
+      log.info('Starting the bot. Press Ctrl+C to stop.');
+      outro(dim('handing off to bot...'));
+      return ctx.startChannel();
+    }
+  }
+}
+
+async function readState(vault: VaultStore): Promise<State> {
+  // env beats vault for the token (matches the channel's own precedence) so
+  // the wizard reflects what the bot would actually see at start time.
+  const envToken = process.env[DISCORD_TOKEN_ENV];
+  const vaultToken = envToken ?? (await vault.get(DISCORD_TOKEN_KEY));
+  const authorized = await vault.get(DISCORD_AUTHORIZED_USER_KEY);
+  const allowed = parseAllowedChannels(await vault.get(DISCORD_ALLOWED_CHANNELS_KEY));
+  return {
+    hasToken: !!vaultToken,
+    authorizedUserId: parseAuthorizedUser(authorized),
+    allowedChannelCount: allowed.length,
+  };
+}
+
+function printStatus(state: State): void {
+  const lines: string[] = [];
+  lines.push(`Token           ${state.hasToken ? bold('set') : dim('not set')}`);
+  lines.push(
+    `Paired account  ${state.authorizedUserId != null ? bold(state.authorizedUserId) : dim('none')}`,
+  );
+  lines.push(
+    `Guild channels  ${state.allowedChannelCount > 0 ? bold(String(state.allowedChannelCount)) : dim('none allow-listed (DM works once paired)')}`,
+  );
+  note(lines.join('\n'), 'status');
+}
+
+async function pickAction(state: State): Promise<Action | null> {
+  const options: Array<{ value: Action; label: string; hint?: string }> = [];
+  if (state.hasToken && state.authorizedUserId != null) {
+    options.push({
+      value: 'start',
+      label: 'Start the bot',
+      hint: 'runs forever - Ctrl+C to stop',
+    });
+    options.push({
+      value: 'unpair',
+      label: 'Unpair this account',
+      hint: 'pairing must be run again before the bot answers anyone',
+    });
+  } else if (state.hasToken) {
+    options.push({
+      value: 'pair',
+      label: 'Pair a Discord account',
+      hint: 'DM the bot; it replies with a code you paste here',
+    });
+  }
+  options.push({
+    value: 'set-token',
+    label: state.hasToken ? 'Change the bot token' : 'Set the bot token',
+    hint: state.hasToken ? undefined : 'create an app + bot at discord.com/developers',
+  });
+  options.push({ value: 'quit', label: 'Quit' });
+
+  const choice = await select<Action>({ message: 'What do you want to do?', options });
+  if (isCancel(choice)) return null;
+  return choice as Action;
+}
+
+async function actionSetToken(vault: VaultStore): Promise<boolean> {
+  note(
+    'Open https://discord.com/developers/applications, create an application, add a Bot,\n' +
+      'and copy its token (Bot → Reset Token). IMPORTANT: on the same Bot page, under\n' +
+      '"Privileged Gateway Intents", enable ' +
+      bold('MESSAGE CONTENT INTENT') +
+      ' — without it the bot\n' +
+      'receives empty messages. The token goes straight into the moxxy vault under\n' +
+      "'" +
+      DISCORD_TOKEN_KEY +
+      "' - no env var needed.",
+    'get a bot token',
+  );
+  const token = await password({
+    message: 'Paste the Discord bot token',
+    mask: '•',
+    validate: (v) => {
+      if (!v || v.trim().length === 0) return 'required';
+      if (!DISCORD_TOKEN_RE.test(v.trim())) {
+        return 'doesn\'t look like a Discord bot token - expected three dot-separated segments';
+      }
+      return undefined;
+    },
+  });
+  if (isCancel(token)) return false;
+  await vault.set(DISCORD_TOKEN_KEY, String(token).trim(), ['discord']);
+  log.success('Token stored in vault.');
+  return true;
+}

--- a/packages/plugin-channel-discord/src/subcommands.test.ts
+++ b/packages/plugin-channel-discord/src/subcommands.test.ts
@@ -1,0 +1,182 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VaultStore, createStaticKeySource, deriveKey, generateSalt } from '@moxxy/plugin-vault';
+import type { ChannelDef } from '@moxxy/sdk';
+import { buildDiscordPlugin } from './index.js';
+import {
+  DISCORD_ALLOWED_CHANNELS_KEY,
+  DISCORD_AUTHORIZED_USER_KEY,
+  DISCORD_TOKEN_KEY,
+  serializeAllowedChannels,
+} from './keys.js';
+
+let tmp: string;
+let vault: VaultStore;
+let discordDef: ChannelDef;
+let writeOut: string[];
+let writeErr: string[];
+let origStdoutWrite: typeof process.stdout.write;
+let origStderrWrite: typeof process.stderr.write;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-dc-sub-'));
+  vault = new VaultStore({
+    filePath: path.join(tmp, 'vault.json'),
+    keySource: createStaticKeySource(deriveKey('test', generateSalt())),
+  });
+  const plugin = buildDiscordPlugin({ vault });
+  discordDef = plugin.channels![0]!;
+  writeOut = [];
+  writeErr = [];
+  origStdoutWrite = process.stdout.write.bind(process.stdout);
+  origStderrWrite = process.stderr.write.bind(process.stderr);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    writeOut.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    writeErr.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+    return true;
+  }) as typeof process.stderr.write;
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+  process.stdout.write = origStdoutWrite;
+  process.stderr.write = origStderrWrite;
+});
+
+function ctx(
+  overrides: {
+    startChannel?: () => Promise<number>;
+    session?: { setPermissionResolver: (r: unknown) => void };
+  } = {},
+) {
+  return {
+    deps: { cwd: tmp, vault, logger: undefined, options: {} },
+    args: { positional: [], flags: {} },
+    startChannel: overrides.startChannel ?? (async () => 0),
+    session: overrides.session ?? { setPermissionResolver: () => {} },
+  } as never;
+}
+
+describe('discord ChannelDef', () => {
+  it('declares the dedicated-runner + session-source contract', () => {
+    expect(discordDef.name).toBe('discord');
+    expect(discordDef.dedicatedRunner).toBe(true);
+    expect(discordDef.sessionSource).toBe('discord');
+    expect(discordDef.interactiveCommand).toBe('setup');
+    expect(discordDef.config?.fields[0]?.vaultKey).toBe(DISCORD_TOKEN_KEY);
+  });
+
+  it('is unavailable without a token, available with one in the vault', async () => {
+    const unavailable = await discordDef.isAvailable!({ cwd: tmp, vault });
+    expect(unavailable.ok).toBe(false);
+    expect(unavailable.reason).toMatch(/MOXXY_DISCORD_TOKEN/);
+    await vault.set(DISCORD_TOKEN_KEY, 'x'.repeat(24) + '.abcdef.' + 'y'.repeat(28));
+    const available = await discordDef.isAvailable!({ cwd: tmp, vault });
+    expect(available.ok).toBe(true);
+  });
+});
+
+describe('discord channel subcommands (registered on ChannelDef)', () => {
+  it('exposes setup, pair, unpair, status', () => {
+    expect(Object.keys(discordDef.subcommands!)).toEqual(
+      expect.arrayContaining(['setup', 'pair', 'unpair', 'status']),
+    );
+  });
+
+  it('`status` reports unconfigured vault state as JSON', async () => {
+    const code = await discordDef.subcommands!.status!.run(ctx());
+    expect(code).toBe(0);
+    const parsed = JSON.parse(writeOut.join(''));
+    expect(parsed).toEqual({
+      tokenConfigured: false,
+      authorizedUserId: null,
+      allowedChannelIds: [],
+    });
+  });
+
+  it('`status` surfaces stored token + authorized user + allow-list', async () => {
+    await vault.set(DISCORD_TOKEN_KEY, 'x'.repeat(24) + '.abcdef.' + 'y'.repeat(28));
+    await vault.set(DISCORD_AUTHORIZED_USER_KEY, '987654321');
+    await vault.set(DISCORD_ALLOWED_CHANNELS_KEY, serializeAllowedChannels(['123456789']));
+    const code = await discordDef.subcommands!.status!.run(ctx());
+    expect(code).toBe(0);
+    const parsed = JSON.parse(writeOut.join(''));
+    expect(parsed).toEqual({
+      tokenConfigured: true,
+      authorizedUserId: '987654321',
+      allowedChannelIds: ['123456789'],
+    });
+  });
+
+  it('`status` reports null (not junk) for a corrupt stored user id', async () => {
+    await vault.set(DISCORD_AUTHORIZED_USER_KEY, 'not-a-snowflake');
+    const code = await discordDef.subcommands!.status!.run(ctx());
+    expect(code).toBe(0);
+    const parsed = JSON.parse(writeOut.join(''));
+    expect(parsed.authorizedUserId).toBeNull();
+  });
+
+  it('`unpair` clears the authorized user and reports', async () => {
+    await vault.set(DISCORD_AUTHORIZED_USER_KEY, '111');
+    const code = await discordDef.subcommands!.unpair!.run(ctx());
+    expect(code).toBe(0);
+    expect(writeOut.join('')).toContain('unpaired');
+    expect(await vault.get(DISCORD_AUTHORIZED_USER_KEY)).toBeNull();
+  });
+
+  it('`unpair` is a no-op when nothing is paired', async () => {
+    const code = await discordDef.subcommands!.unpair!.run(ctx());
+    expect(code).toBe(0);
+    expect(writeOut.join('')).toContain('no pairing was active');
+  });
+
+  it('`pair` drives the pairing flow on the session in an interactive TTY', async () => {
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    try {
+      const startChannel = vi.fn(async () => 0);
+      const setPermissionResolver = vi.fn();
+      // No token in the vault -> the channel throws before it can open a real
+      // gateway connection, so the flow fails fast (no network). We only
+      // assert that `pair` drives the in-process pairing flow (wires the
+      // session's permission resolver) instead of delegating to startChannel.
+      await expect(
+        discordDef.subcommands!.pair!.run(ctx({ startChannel, session: { setPermissionResolver } })),
+      ).rejects.toThrow(/token/i);
+      expect(setPermissionResolver).toHaveBeenCalledTimes(1);
+      expect(startChannel).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+    }
+  });
+
+  it('`pair` refuses to start without a TTY (interactive-only flow)', async () => {
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    try {
+      const startChannel = vi.fn(async () => 0);
+      const code = await discordDef.subcommands!.pair!.run(ctx({ startChannel }));
+      expect(code).toBe(1);
+      expect(startChannel).not.toHaveBeenCalled();
+      expect(writeErr.join('')).toMatch(/TTY/);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+    }
+  });
+
+  it('subcommands return 1 when vault is unavailable', async () => {
+    const badCtx = {
+      deps: { cwd: tmp, vault: undefined, logger: undefined, options: {} },
+      args: { positional: [], flags: {} },
+      startChannel: async () => 0,
+    };
+    const code = await discordDef.subcommands!.status!.run(badCtx as never);
+    expect(code).toBe(1);
+    expect(writeErr.join('')).toContain('vault unavailable');
+  });
+});

--- a/packages/plugin-channel-discord/tsconfig.json
+++ b/packages/plugin-channel-discord/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/plugin-channel-discord/vitest.config.ts
+++ b/packages/plugin-channel-discord/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/packages/plugin-plugins-admin/src/catalog.ts
+++ b/packages/plugin-plugins-admin/src/catalog.ts
@@ -244,6 +244,14 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     provides: [{ category: 'channel', name: 'whatsapp' }],
   },
   {
+    id: 'discord',
+    label: 'Discord channel',
+    description: 'Discord bot on a dedicated isolated runner (moxxy discord; DM code pairing).',
+    packageName: '@moxxy/plugin-channel-discord',
+    installSpec: '@moxxy/plugin-channel-discord',
+    provides: [{ category: 'channel', name: 'discord' }],
+  },
+  {
     id: 'stt-whisper',
     label: 'Whisper voice input',
     description: 'Speech-to-text via the OpenAI Whisper API (Ctrl+R in the TUI).',

--- a/packages/sdk/src/event-store.ts
+++ b/packages/sdk/src/event-store.ts
@@ -12,16 +12,23 @@ import type { SessionId } from './ids.js';
  * event (prompts, tool I/O), so that explicit opt-in is the trust boundary.
  */
 
+/** Every valid {@link SessionSource}, as a runtime constant — so validators
+ *  (e.g. the CLI's `MOXXY_SESSION_SOURCE` guard) enumerate the same list the
+ *  type is derived from instead of hand-listing the literals. */
+export const SESSION_SOURCES = [
+  'cli',
+  'tui',
+  'desktop',
+  'mobile',
+  'slack',
+  'telegram',
+  'signal',
+  'whatsapp',
+  'discord',
+] as const;
+
 /** Originating channel of a session (persisted into the meta sidecar). */
-export type SessionSource =
-  | 'cli'
-  | 'tui'
-  | 'desktop'
-  | 'mobile'
-  | 'slack'
-  | 'telegram'
-  | 'signal'
-  | 'whatsapp';
+export type SessionSource = (typeof SESSION_SOURCES)[number];
 
 /**
  * The single per-session metadata record (the JSONL impl writes it to

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -190,6 +190,7 @@ export type {
   SessionMeta,
   SessionSource,
 } from './event-store.js';
+export { SESSION_SOURCES } from './event-store.js';
 // Node-runtime helpers (writeFileAtomic*, moxxyHome/moxxyPath,
 // readRequestBody/bearerTokenMatches, channel-auth) are exported from the
 // './server' subpath, NOT the main barrel — they statically reach node:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1318,6 +1318,43 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
 
+  packages/plugin-channel-discord:
+    dependencies:
+      '@clack/prompts':
+        specifier: 'catalog:'
+        version: 1.4.0
+      '@moxxy/channel-kit':
+        specifier: workspace:*
+        version: link:../channel-kit
+      '@moxxy/core':
+        specifier: workspace:*
+        version: link:../core
+      '@moxxy/plugin-vault':
+        specifier: workspace:*
+        version: link:../plugin-vault
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      discord.js:
+        specifier: ^14.16.0
+        version: 14.26.4
+    devDependencies:
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
   packages/plugin-channel-http:
     dependencies:
       '@moxxy/sdk':
@@ -3490,6 +3527,34 @@ packages:
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
     engines: {node: '>= 8.9.0'}
 
+  '@discordjs/builders@1.14.1':
+    resolution: {integrity: sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/collection@1.5.3':
+    resolution: {integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/collection@2.1.1':
+    resolution: {integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/formatters@0.6.2':
+    resolution: {integrity: sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/rest@2.6.1':
+    resolution: {integrity: sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/util@1.2.0':
+    resolution: {integrity: sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/ws@1.2.3':
+    resolution: {integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==}
+    engines: {node: '>=16.11.0'}
+
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
     engines: {node: '>=0.8.0'}
@@ -5421,6 +5486,22 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sapphire/async-queue@1.5.5':
+    resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@sapphire/shapeshift@4.0.0':
+    resolution: {integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==}
+    engines: {node: '>=v16'}
+
+  '@sapphire/snowflake@3.5.3':
+    resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@sapphire/snowflake@3.5.5':
+    resolution: {integrity: sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
   '@shikijs/core@1.29.2':
     resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
 
@@ -5816,6 +5897,10 @@ packages:
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@vladfrangu/async_event_emitter@2.4.7':
+    resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -6931,6 +7016,13 @@ packages:
   direction@2.0.1:
     resolution: {integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==}
     hasBin: true
+
+  discord-api-types@0.38.49:
+    resolution: {integrity: sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg==}
+
+  discord.js@14.26.4:
+    resolution: {integrity: sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==}
+    engines: {node: '>=18'}
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
@@ -8564,6 +8656,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash.snakecase@4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
 
@@ -8623,6 +8718,9 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
+
+  magic-bytes.js@1.13.0:
+    resolution: {integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -10796,6 +10894,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  ts-mixer@6.0.4:
+    resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
+
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
@@ -10924,6 +11025,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@6.24.1:
+    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+    engines: {node: '>=18.17'}
 
   undici@6.26.0:
     resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
@@ -12523,6 +12628,55 @@ snapshots:
     dependencies:
       ajv: 6.15.0
       ajv-keywords: 3.5.2(ajv@6.15.0)
+
+  '@discordjs/builders@1.14.1':
+    dependencies:
+      '@discordjs/formatters': 0.6.2
+      '@discordjs/util': 1.2.0
+      '@sapphire/shapeshift': 4.0.0
+      discord-api-types: 0.38.49
+      fast-deep-equal: 3.1.3
+      ts-mixer: 6.0.4
+      tslib: 2.8.1
+
+  '@discordjs/collection@1.5.3': {}
+
+  '@discordjs/collection@2.1.1': {}
+
+  '@discordjs/formatters@0.6.2':
+    dependencies:
+      discord-api-types: 0.38.49
+
+  '@discordjs/rest@2.6.1':
+    dependencies:
+      '@discordjs/collection': 2.1.1
+      '@discordjs/util': 1.2.0
+      '@sapphire/async-queue': 1.5.5
+      '@sapphire/snowflake': 3.5.5
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.49
+      magic-bytes.js: 1.13.0
+      tslib: 2.8.1
+      undici: 6.24.1
+
+  '@discordjs/util@1.2.0':
+    dependencies:
+      discord-api-types: 0.38.49
+
+  '@discordjs/ws@1.2.3':
+    dependencies:
+      '@discordjs/collection': 2.1.1
+      '@discordjs/rest': 2.6.1
+      '@discordjs/util': 1.2.0
+      '@sapphire/async-queue': 1.5.5
+      '@types/ws': 8.18.1
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.49
+      tslib: 2.8.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@egjs/hammerjs@2.0.17':
     dependencies:
@@ -14548,6 +14702,17 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.3':
     optional: true
 
+  '@sapphire/async-queue@1.5.5': {}
+
+  '@sapphire/shapeshift@4.0.0':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      lodash: 4.18.1
+
+  '@sapphire/snowflake@3.5.3': {}
+
+  '@sapphire/snowflake@3.5.5': {}
+
   '@shikijs/core@1.29.2':
     dependencies:
       '@shikijs/engine-javascript': 1.29.2
@@ -15140,6 +15305,8 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  '@vladfrangu/async_event_emitter@2.4.7': {}
 
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:
@@ -16547,6 +16714,27 @@ snapshots:
       p-limit: 3.1.0
 
   direction@2.0.1: {}
+
+  discord-api-types@0.38.49: {}
+
+  discord.js@14.26.4:
+    dependencies:
+      '@discordjs/builders': 1.14.1
+      '@discordjs/collection': 1.5.3
+      '@discordjs/formatters': 0.6.2
+      '@discordjs/rest': 2.6.1
+      '@discordjs/util': 1.2.0
+      '@discordjs/ws': 1.2.3
+      '@sapphire/snowflake': 3.5.3
+      discord-api-types: 0.38.49
+      fast-deep-equal: 3.1.3
+      lodash.snakecase: 4.1.1
+      magic-bytes.js: 1.13.0
+      tslib: 2.8.1
+      undici: 6.24.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   dlv@1.1.3: {}
 
@@ -18558,6 +18746,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash.snakecase@4.1.1: {}
+
   lodash.throttle@4.1.1: {}
 
   lodash.union@4.6.0: {}
@@ -18607,6 +18797,8 @@ snapshots:
   lru-cache@7.18.3: {}
 
   lz-string@1.5.0: {}
+
+  magic-bytes.js@1.13.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -21707,6 +21899,8 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-mixer@6.0.4: {}
+
   tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
@@ -21828,6 +22022,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
+
+  undici@6.24.1: {}
 
   undici@6.26.0: {}
 


### PR DESCRIPTION
## What

New `@moxxy/plugin-channel-discord`: a Discord bot channel (discord.js v14, gateway WebSocket) built on `@moxxy/channel-kit`, modeled on the Telegram plugin. Unbundled (slim kernel): publishable package with a `moxxy` discovery manifest + `moxxy.setup` declarative step, installed on demand via the plugins-admin catalog (`provides: [{category:'channel', name:'discord'}]`).

- **Transport:** gateway intents Guilds/GuildMessages/DirectMessages/MessageContent (privileged — the setup wizard and `moxxy.setup` description tell the user to enable it in the Developer Portal), `Partials.Channel` for DMs. Outbound connection only — no tunnel, no tunnelProvider registration.
- **Pairing (kit's host-code machine over DM):** `moxxy discord pair` arms a window; an unauthorized user DMs the bot; the bot mints a one-time code bound to THAT user (`openHostCodeWindow`) and DMs it back; the operator pastes it into the terminal wizard (`submitPeerCode` against the pending peer). A second DM re-mints and stales the first code, so a hostile DM can never get authorized unless the operator pastes the attacker's code. Paired principal + guild-channel allow-list persisted via vault keys (`keys.ts`), corrupt values fail closed.
- **Authorization:** `gateInbound` runs on EVERY session-reaching path (messages, button interactions, slash commands, voice) — paired author required everywhere; guild channels additionally need to be on the allow-list (managed in-channel via local `/allow` + `/deny`, the one pre-allow-list command). Unpaired guild traffic is dropped silently (no server spam).
- **Message flow:** zod boundary validation of extracted payload fields (`extractInboundMessage`, content cap 8k, snowflake ids, attachment caps) with a rate-limited drop warning → `TurnCoordinator` single-flight + per-turn AbortController → `driveTurn`/`subscribeTurn` (turnId-filtered, invariant #8) → kit `FramePump` over message edits. **editFrameMs clamped to ≥1200ms** (Discord ~5 edits/5s per channel; default 1500ms). 2000-char cap handled by `splitForDiscord` (newline-preferring cuts, code fences closed + reopened with their info string across parts — mirrors `splitForTelegram`'s shape); final-frame overflow goes out as follow-up messages (`alwaysFlushFinal`).
- **Permission/approval prompts:** Telegram's inline keyboard maps cleanly to Discord button rows (raw API component JSON, `customId` `perm:<callId>:<choice>` / `appr:<id>:<optionId>`); `requestsText` approval options latch the next message as follow-up text, exactly like Telegram. Interaction acks respect Discord's one-ack rule (`update` to clear buttons, then `followUp`).
- **Slash commands:** `session.commands.listForChannel('discord')` + local yolo/tools/skills/cancel/allow/deny published via `application.commands.set` (names filtered to Discord's `^[a-z0-9_-]{1,32}$`, descriptions clamped to 100 chars); the same dispatcher serves plain-text `/cmd` messages.
- **Voice messages:** audio attachments → declared-size cap → Content-Length cap → buffered-size cap (20MB) → bounded download (30s abort) → `session.transcribers.tryGetActive()` with install guidance when absent → *heard:* echo → normal turn.
- **ChannelDef:** `dedicatedRunner: true` + `sessionSource: 'discord'` (matching Telegram/Slack), `interactiveCommand: 'setup'`, subcommands `setup`/`pair`/`status`/`unpair`, self-described `config` (vault key `discord_bot_token`), cheap `isAvailable` (env → vault probe). `requestUrl` publishes the OAuth2 invite URL; `connected` + `onConnectChange` flip on pairing for the status file.
- **Wiring:** SDK `SessionSource` gains `'discord'` — and the union is now DERIVED from a new runtime `SESSION_SOURCES` constant, with the CLI's `MOXXY_SESSION_SOURCE` guard doing `includes()` against it (retires the TECH_DEBT "hand-listed validator" item; `'signal'` from #418 folded in). CLI `channel-hints.ts` install-on-first-use hint; plugins-admin catalog entry; desktop `channel-catalog.ts` entry (`hasWebhookUrl: false`) — dedicated-runner status publishing (`writeChannelStatus`/`clearChannelStatus`) comes for free from `start-registered-channel.ts`.

## Design decisions

- **Permission prompts → Discord buttons:** the inline-keyboard pattern maps cleanly (ActionRows of buttons, custom ids mirroring Telegram's callback data), so button-based prompts shipped; no text-prompt fallback needed. Constraints handled: 5 buttons/row, 5 rows, 80-char labels, 100-char custom ids, one interaction ack.
- **dedicatedRunner: true** — parity with Telegram's current ChannelDef (own socket `channel-discord.sock`, sticky session `moxxy-channel-discord`, source-stamped history).
- **Pairing direction is bot→terminal** per the DM-code design: the code lives only in the candidate's DM, so the paste proves the operator controls that account. Consequence (logged in TECH_DEBT): pairing has no GUI-only completion path — the desktop panel can start the bot with the window armed, but the paste happens in `moxxy discord pair`.
- **No model/mode pickers** (Telegram-local nicety) in v1 — registry commands, yolo, tools, skills, cancel are wired; pickers need select-menu plumbing and can follow.

## Verification

- `pnpm build` / `typecheck` / `lint` (0 errors) / `test` (131/131 tasks green, exit 0) / `check:deps` (0 errors; the 1 warning — `desktop-host/src/apps/bridge-host.ts` orphan — pre-exists on development) — all from repo root, after rebasing onto `67a3387f` (Signal channel) and folding both channels into the shared tables.
- 75 new unit tests: pairing machine (incl. the stale-code/foreign-DM safety property), `gateInbound` on every path, boundary validation + size caps, edit-throttle clamp (≥1200ms), send-once-then-edit streaming + long-final splitting + turnId filtering against a scripted fake session, fence-aware splitter, voice caps/transcriber guidance, interaction gating + perm/approval mapping, subcommands against a real temp vault (Telegram's `subcommands.test.ts` pattern).
- Built-CLI smoke: `node packages/cli/dist/bin.js discord` → prints the install-on-first-use hint (`moxxy plugins install discord`).

## Needs a live Discord bot to verify manually

No live credentials were available; everything gateway-side is untested against real Discord:

1. **Pair flow end-to-end:** `moxxy discord setup` → token → `pair` → DM the bot → code arrives in DM → paste → paired greeting DM.
2. **Privileged intent:** with MESSAGE CONTENT INTENT disabled, confirm messages arrive empty and the wizard guidance is sufficient; with it enabled, content flows.
3. **Streaming edits under the real rate limiter:** long turn stays smooth at 1500ms edit cadence; 2000+ char finals split into follow-ups without a 400.
4. **Slash-command registration:** commands appear in the client "/" picker after start (global command propagation can take up to ~1h); interaction replies + button prompts ack without "interaction failed".
5. **Voice message:** press-and-hold voice message → transcription → turn (and the no-transcriber guidance path).
6. **Dedicated runner:** desktop Channels panel start → status file carries the invite URL; `connected` flips after a terminal pair + channel restart.