### PR TITLE
feat(cli): moxxy onboard — guided provider → channel → pairing → service setup

### DIFF
--- a/.changeset/onboard-command.md
+++ b/.changeset/onboard-command.md
@@ -1,0 +1,12 @@
+---
+"@moxxy/cli": minor
+"@moxxy/sdk": minor
+"@moxxy/plugin-plugins-admin": patch
+"@moxxy/plugin-telegram": patch
+"@moxxy/plugin-channel-slack": patch
+"@moxxy/plugin-channel-discord": patch
+"@moxxy/plugin-channel-signal": patch
+"@moxxy/plugin-channel-whatsapp": patch
+---
+
+`moxxy onboard` — one guided command from a fresh install to a paired, always-on agent: provider wizard (skipped when configured) → messenger pick from the install catalog → version-pinned install + `moxxy.setup` fields → the channel's own pairing in a new pair-then-return mode (`EXIT_AFTER_PAIR_FLAG` in the SDK, honored by all five pair flows) → a `moxxy serve --all` background unit. Also: channel install hints are now derived from catalog `provides` (telegram/slack/web/http entries gained theirs), Telegram + Slack declare `moxxy.setup` token steps, the `service` catalog's serve unit actually starts channels (`--all`, matching its description), and service units survive Electron-as-node installs (`ELECTRON_RUN_AS_NODE=1` exported into the unit).

--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ npm install -g @moxxy/cli      # or: npx @moxxy/cli init
 ```
 
 ```sh
-moxxy init      # interactive: choose a provider, paste an API key (stored in the vault)
+moxxy onboard   # guided: provider → messaging channel (Discord/Telegram/…) → pairing → background service
 moxxy           # launch the interactive TUI
 ```
+
+Prefer the pieces? `moxxy init` does just the provider wizard; `moxxy <channel>` sets up one channel; `moxxy service install serve` makes it permanent.
 
 One-shot, straight from the shell:
 

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -13,6 +13,14 @@ or recorded-on-purpose decision.
 
 ## Resolved ledger
 
+- [med, dx, RESOLVED 2026-07-03] `service install` units no longer break under
+  Electron-as-node: `installAndStartService` detects `process.versions.electron`
+  and exports `ELECTRON_RUN_AS_NODE=1` into the unit env, so a desktop-spawned
+  install can't boot the GUI as a ghost daemon. The "prefer the Helper binary"
+  half was deliberately skipped — the env var fully fixes launch semantics and
+  the Helper path is packaging-layout-dependent.
+  `packages/cli/src/commands/service/index.ts`.
+
 - [low, sessions, RESOLVED 2026-07-03] `SessionSource` literals were hand-listed in
   one runtime spot (`sessionSource()`'s validator in
   `packages/cli/src/setup/persistence.ts`) — adding the Discord channel's
@@ -455,9 +463,18 @@ or recorded-on-purpose decision.
 
 ## CLI / services
 
-- [med, dx] `service install` units break under Electron-as-node (`nodeBin()` returns
-  the Electron binary, no `ELECTRON_RUN_AS_NODE=1` → GUI ghost). Detect run-as-node,
-  export the env var, prefer the Helper binary. `packages/cli/src/commands/service/common.ts`.
+- [med, channels, security] The serve.ts "first interactive channel wins the shared
+  permission resolver" note is aspirational, not real: the `resolverSetByChannel`
+  gate only exists in the `serve --all` startup loop (`serve.ts` `startChannel`),
+  while every pairing/attach path calls `session.setPermissionResolver`
+  UNCONDITIONALLY (`start-registered-channel.ts` both attach modes, each channel's
+  `pair-flow.ts`, mobile `single-session-host.ts`) — so in practice the resolver is
+  last-writer-wins: pair Discord then WhatsApp and Discord silently stops receiving
+  permission prompts (they route to the most recent channel's surface). One Session
+  has exactly one resolver slot (`core/src/session.ts setPermissionResolver`).
+  `moxxy onboard` sidesteps it (single channel pick, pair-then-return), but a real
+  fix needs either per-source resolver routing on the Session or a documented
+  broker. Surfaced 2026-07-03 while building onboard.
 - [med] One-shot CLI commands (`-p`, `schedule run`, `doctor`, `login`, `init`) never
   `close()` — drain persistence before exit. `packages/cli/`.
 - [low, security-dx] SECURITY.md's hardening checklist recommends rotating channel

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -9,6 +9,7 @@ import { runPluginsCommand } from './commands/plugins.js';
 import { runChannelsCommand } from './commands/channels.js';
 import { runChannelByName } from './commands/run-channel.js';
 import { runInitCommand } from './commands/init.js';
+import { runOnboardCommand } from './commands/onboard.js';
 import { runProvisionCommand } from './commands/provision.js';
 import { runPermsCommand } from './commands/perms.js';
 import { runConfigCommand } from './commands/config.js';
@@ -55,6 +56,7 @@ const SECTIONS: ReadonlyArray<{ readonly title: string; readonly rows: ReadonlyA
   {
     title: 'SETUP',
     rows: [
+      ['onboard', 'guided setup: provider → messaging channel → pairing → background service'],
       ['init', 'interactive first-time setup (provider keys → vault)'],
       ['provision', 'headless setup: install + configure a provider (flags or --spec -)'],
       ['login <provider>', 'OAuth sign-in for providers that don\'t use API keys'],
@@ -181,7 +183,7 @@ function renderHelp(): string {
     `${' '.repeat(RULE_INDENT)}${colors.dim('prompted values are saved back to the vault).')}`,
   );
   out.push('');
-  out.push(`${colors.dim('Run')} ${colors.bold('moxxy init')} ${colors.dim('to get started.')}`);
+  out.push(`${colors.dim('Run')} ${colors.bold('moxxy onboard')} ${colors.dim('to get started.')}`);
   out.push(`${colors.dim('See')} ${colors.bold('moxxy <command> --help')} ${colors.dim('for per-command details.')}`);
 
   return out.join('\n') + '\n';
@@ -206,6 +208,7 @@ const COMMANDS: Record<string, CommandHandler> = {
     return 0;
   },
   init: runInitCommand,
+  onboard: runOnboardCommand,
   provision: runProvisionCommand,
   login: runLoginCommand,
   perms: runPermsCommand,

--- a/packages/cli/src/channel-hints.test.ts
+++ b/packages/cli/src/channel-hints.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { findCatalogEntryForChannel } from './channel-hints.js';
+
+describe('findCatalogEntryForChannel', () => {
+  // The hint is derived from catalog `provides` declarations — every channel
+  // shipped as an unbundled package must resolve, or `moxxy <name>` on a slim
+  // kernel degrades to a bare "unknown command" instead of an install hint.
+  it.each([
+    ['telegram', '@moxxy/plugin-telegram'],
+    ['slack', '@moxxy/plugin-channel-slack'],
+    ['signal', '@moxxy/plugin-channel-signal'],
+    ['whatsapp', '@moxxy/plugin-channel-whatsapp'],
+    ['discord', '@moxxy/plugin-channel-discord'],
+    ['web', '@moxxy/plugin-channel-web'],
+    ['http', '@moxxy/plugin-channel-http'],
+  ])('%s → %s', (command, packageName) => {
+    expect(findCatalogEntryForChannel(command)?.packageName).toBe(packageName);
+  });
+
+  it('is case-insensitive on the command', () => {
+    expect(findCatalogEntryForChannel('Telegram')?.packageName).toBe('@moxxy/plugin-telegram');
+  });
+
+  it('unknown names stay unknown', () => {
+    expect(findCatalogEntryForChannel('imessage')).toBeUndefined();
+    expect(findCatalogEntryForChannel('')).toBeUndefined();
+  });
+
+  it('never resolves non-channel catalog entries', () => {
+    // Providers/modes share the catalog; a provider slug must not read as a channel.
+    expect(findCatalogEntryForChannel('anthropic')).toBeUndefined();
+    expect(findCatalogEntryForChannel('goal')).toBeUndefined();
+  });
+});

--- a/packages/cli/src/channel-hints.ts
+++ b/packages/cli/src/channel-hints.ts
@@ -4,23 +4,20 @@ import {
 } from '@moxxy/plugin-plugins-admin';
 
 /**
- * Channel-command → installable-package mapping for the slim kernel: when
+ * Channel-command → installable-package lookup for the slim kernel: when
  * `moxxy <name>` doesn't match a registered channel, this answers "is that a
  * channel whose package installs on demand?" so bin.ts / `moxxy channels
  * start` print an install hint instead of "unknown command".
+ *
+ * Derived from the catalog's `provides` declarations — a channel is hintable
+ * exactly when its catalog entry declares `{category: 'channel', name}`. The
+ * previous hand-listed command→package map here drifted one entry behind
+ * every new channel; now the catalog entry (which every channel needs anyway
+ * for install-on-first-use) is the single source.
  */
-const CHANNEL_COMMANDS: Readonly<Record<string, string>> = {
-  telegram: '@moxxy/plugin-telegram',
-  slack: '@moxxy/plugin-channel-slack',
-  signal: '@moxxy/plugin-channel-signal',
-  whatsapp: '@moxxy/plugin-channel-whatsapp',
-  discord: '@moxxy/plugin-channel-discord',
-  web: '@moxxy/plugin-channel-web',
-  http: '@moxxy/plugin-channel-http',
-};
-
 export function findCatalogEntryForChannel(command: string): PluginCatalogEntry | undefined {
-  const pkg = CHANNEL_COMMANDS[command.toLowerCase()];
-  if (!pkg) return undefined;
-  return INSTALLABLE_PLUGIN_CATALOG.find((e) => e.packageName === pkg);
+  const name = command.toLowerCase();
+  return INSTALLABLE_PLUGIN_CATALOG.find((e) =>
+    e.provides?.some((p) => p.category === 'channel' && p.name === name),
+  );
 }

--- a/packages/cli/src/commands/onboard.test.ts
+++ b/packages/cli/src/commands/onboard.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { buildChannelChoices, catalogChannelEntry } from './onboard.js';
+
+describe('catalogChannelEntry', () => {
+  it('resolves every onboardable messenger through catalog `provides`', () => {
+    for (const name of ['discord', 'telegram', 'whatsapp', 'signal', 'slack']) {
+      const entry = catalogChannelEntry(name);
+      expect(entry, name).toBeDefined();
+      expect(entry!.provides).toEqual(
+        expect.arrayContaining([{ category: 'channel', name }]),
+      );
+    }
+  });
+
+  it('returns undefined for non-channels', () => {
+    expect(catalogChannelEntry('anthropic')).toBeUndefined();
+  });
+});
+
+describe('buildChannelChoices', () => {
+  it('keeps the curated presentation order', () => {
+    const choices = buildChannelChoices(new Set());
+    expect(choices.map((c) => c.value)).toEqual([
+      'discord',
+      'telegram',
+      'whatsapp',
+      'signal',
+      'slack',
+    ]);
+  });
+
+  it('marks already-registered channels as installed', () => {
+    const choices = buildChannelChoices(new Set(['telegram']));
+    const telegram = choices.find((c) => c.value === 'telegram')!;
+    const discord = choices.find((c) => c.value === 'discord')!;
+    expect(telegram.installed).toBe(true);
+    expect(telegram.hint).toMatch(/^installed · /);
+    expect(discord.installed).toBe(false);
+    expect(discord.hint).not.toMatch(/installed/);
+  });
+
+  it('labels come from the catalog, not the curated list', () => {
+    for (const choice of buildChannelChoices(new Set())) {
+      expect(choice.label).toBe(choice.entry.label);
+      expect(choice.entry.packageName.startsWith('@moxxy/')).toBe(true);
+    }
+  });
+
+  it('surfaces the WhatsApp ToS warning in its hint', () => {
+    const whatsapp = buildChannelChoices(new Set()).find((c) => c.value === 'whatsapp')!;
+    expect(whatsapp.hint).toMatch(/ToS|UNOFFICIAL/i);
+  });
+});

--- a/packages/cli/src/commands/onboard.ts
+++ b/packages/cli/src/commands/onboard.ts
@@ -1,0 +1,342 @@
+import { cancel, confirm, isCancel, intro, log, note, outro, select, spinner } from '@clack/prompts';
+import { loadActiveProvider, setPluginEnabled } from '@moxxy/config';
+import {
+  INSTALLABLE_PLUGIN_CATALOG,
+  installPluginPackagePinned,
+  type PluginCatalogEntry,
+} from '@moxxy/plugin-plugins-admin';
+import { EXIT_AFTER_PAIR_FLAG } from '@moxxy/sdk';
+import type { ParsedArgv } from '../argv.js';
+import { hasBoolFlag, helpRequested, stringFlag } from '../argv-helpers.js';
+import { colors } from '../colors.js';
+import { probeSession } from '../setup.js';
+import { cliVersion } from '../version.js';
+import { runPluginSetupSteps } from '../wizard/plugin-setup-steps.js';
+import { formatHelp } from './help-format.js';
+import { runInitCommand } from './init.js';
+import { runChannelSubcommand } from './run-channel.js';
+import { serveSpec } from './serve.js';
+import {
+  getServiceStatus,
+  installAndStartService,
+  servicePlatform,
+} from './service/index.js';
+
+/**
+ * `moxxy onboard` — the one guided path from a fresh install to a paired,
+ * always-on agent:
+ *
+ *   1. provider  — `moxxy init`'s wizard, skipped when one is configured
+ *   2. channel   — pick a messenger from the install catalog
+ *   3. install   — catalog install (version-pinned) + `moxxy.setup` fields
+ *   4. pair      — the channel's own pair flow, in pair-then-return mode
+ *   5. service   — a `moxxy serve --all` launchd/systemd unit (opt-out)
+ *
+ * Every step delegates to the machinery that owns it (init wizard, plugin
+ * setup steps, channel subcommands, service installer) — onboard only
+ * sequences them, so each step keeps behaving identically when run standalone.
+ */
+
+/**
+ * Messengers offered by the pick, in presentation order. Metadata (label,
+ * package) comes from the install catalog's `provides` declarations; this
+ * list only curates WHICH channel-category entries read as "message your
+ * agent from your phone" (web/http are transports, not messengers) and the
+ * one-line trade-off shown next to each.
+ */
+const ONBOARD_CHANNELS: ReadonlyArray<{ readonly name: string; readonly hint: string }> = [
+  { name: 'discord', hint: 'official API · DM code pairing' },
+  { name: 'telegram', hint: 'official API · QR pairing' },
+  { name: 'whatsapp', hint: 'UNOFFICIAL (Baileys) — ToS/ban risk, use a spare number' },
+  { name: 'signal', hint: 'QR device link · needs signal-cli on PATH' },
+  { name: 'slack', hint: 'workspace bot · needs a public Request URL' },
+];
+
+export interface OnboardChannelChoice {
+  readonly value: string;
+  readonly label: string;
+  readonly hint: string;
+  readonly entry: PluginCatalogEntry;
+  readonly installed: boolean;
+}
+
+/** The catalog entry that `provides` the named channel, if any. */
+export function catalogChannelEntry(name: string): PluginCatalogEntry | undefined {
+  return INSTALLABLE_PLUGIN_CATALOG.find((e) =>
+    e.provides?.some((p) => p.category === 'channel' && p.name === name),
+  );
+}
+
+/**
+ * Build the channel pick list: the curated messengers, each resolved against
+ * the catalog (drops silently if its entry disappears) and marked installed
+ * when the channel is already registered in the session.
+ */
+export function buildChannelChoices(installed: ReadonlySet<string>): OnboardChannelChoice[] {
+  const choices: OnboardChannelChoice[] = [];
+  for (const { name, hint } of ONBOARD_CHANNELS) {
+    const entry = catalogChannelEntry(name);
+    if (!entry) continue;
+    const isInstalled = installed.has(name);
+    choices.push({
+      value: name,
+      label: entry.label,
+      hint: isInstalled ? `installed · ${hint}` : hint,
+      entry,
+      installed: isInstalled,
+    });
+  }
+  return choices;
+}
+
+const HELP = formatHelp({
+  title: 'moxxy onboard',
+  tagline: 'guided setup: provider → messaging channel → pairing → background service',
+  sections: [
+    {
+      title: 'FLAGS',
+      rows: [
+        ['--channel <name>', 'skip the pick: onboard this channel (discord|telegram|whatsapp|signal|slack)'],
+        ['--no-service', 'skip the background-service step'],
+        ['--reinit', 'run the provider wizard even when a provider is already configured'],
+      ],
+    },
+    {
+      title: 'NOTES',
+      rows: [
+        ['Interactive', 'onboard needs a TTY. For scripted setup use `moxxy provision`; for env-key bootstrap use headless `moxxy init`.'],
+        ['Service', 'installs a `moxxy serve --all` launchd/systemd unit — every channel + scheduler + webhooks in one background process.'],
+        ['Re-run', 'onboard is idempotent: configured steps are skipped or re-offered with their current values.'],
+      ],
+    },
+  ],
+});
+
+export async function runOnboardCommand(argv: ParsedArgv): Promise<number> {
+  if (helpRequested(argv)) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (process.stdin.isTTY !== true) {
+    process.stderr.write(
+      colors.red('moxxy onboard is interactive and needs a TTY.') +
+        '\n' +
+        colors.dim(
+          '  Scripted setup: `moxxy provision` (flags or --spec -). Env-key bootstrap: headless `moxxy init`.\n',
+        ),
+    );
+    return 1;
+  }
+
+  // ── Step 1: provider ────────────────────────────────────────────────────
+  // `moxxy init` owns this flow (vault passphrase, wizard, plugin setup
+  // steps). Skip it when a default provider is already configured.
+  const provider = await loadActiveProvider();
+  if (!provider || hasBoolFlag(argv, 'reinit')) {
+    const code = await runInitCommand(argv);
+    if (code !== 0) return code;
+  }
+
+  intro(colors.bold('moxxy onboard'));
+  const activeProvider = provider ?? (await loadActiveProvider());
+  if (provider) {
+    log.info(`Provider already configured: ${colors.bold(provider)} ${colors.dim('(--reinit to change)')}`);
+  }
+
+  // ── Step 2: pick a channel ──────────────────────────────────────────────
+  const installedChannels = await probeSession(
+    {
+      cwd: process.cwd(),
+      skipKeyPrompt: true,
+      tolerateNoProvider: true,
+      skipProviderActivation: true,
+    },
+    ({ session }) => new Set(session.channels.list().map((d) => d.name)),
+  );
+  const choices = buildChannelChoices(installedChannels);
+
+  const preset = stringFlag(argv, 'channel')?.toLowerCase();
+  let picked: OnboardChannelChoice | null = null;
+  if (preset) {
+    picked = choices.find((c) => c.value === preset) ?? null;
+    if (!picked) {
+      process.stderr.write(
+        colors.red(`--channel ${preset} is not an onboardable channel.`) +
+          '\n' +
+          colors.dim(`  known: ${choices.map((c) => c.value).join(', ')}\n`),
+      );
+      return 2;
+    }
+  } else {
+    const answer = await select<string>({
+      message: 'Where do you want to message your agent?',
+      options: [
+        ...choices.map((c) => ({ value: c.value, label: c.label, hint: c.hint })),
+        { value: '', label: 'Skip — terminal only', hint: '`moxxy` starts the TUI' },
+      ],
+    });
+    if (isCancel(answer)) {
+      cancel('Onboarding cancelled — run `moxxy onboard` anytime.');
+      return 0;
+    }
+    picked = choices.find((c) => c.value === answer) ?? null;
+  }
+
+  if (!picked) {
+    // Terminal-only: nothing to install or keep alive; the TUI self-hosts.
+    outro(
+      `You're set. ${colors.bold('moxxy')} starts the TUI` +
+        (activeProvider ? colors.dim(` (provider: ${activeProvider})`) : '') +
+        '.',
+    );
+    return 0;
+  }
+
+  // ── Step 3: install + declared setup fields ─────────────────────────────
+  if (!picked.installed) {
+    const s = spinner();
+    s.start(`Installing ${picked.entry.packageName}…`);
+    try {
+      await installPluginPackagePinned({
+        packageName: picked.entry.packageName,
+        ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
+      });
+      await setPluginEnabled(picked.entry.packageName, true);
+      s.stop(`Installed ${picked.entry.packageName} ✓`);
+    } catch (err) {
+      s.stop('Install failed.');
+      log.error(err instanceof Error ? err.message : String(err));
+      process.stderr.write(
+        colors.dim(`  Retry with: moxxy plugins install ${picked.entry.id}\n`),
+      );
+      return 1;
+    }
+  }
+
+  // ── Step 4: setup fields + pair (one probe session, post-install so
+  // discovery sees the new package — same daemon-less probe the standalone
+  // `moxxy <channel> pair` path runs on) ──────────────────────────────────
+  type PairOutcome = 'paired' | 'skipped' | 'no-pair' | 'failed' | 'missing';
+  const channelName = picked.value;
+  const packageName = picked.entry.packageName;
+  const pairOutcome = await probeSession(
+    {
+      cwd: process.cwd(),
+      skipKeyPrompt: true,
+      tolerateNoProvider: true,
+      skipProviderActivation: true,
+    },
+    async ({ session, vault, config }): Promise<PairOutcome> => {
+      const def = session.channels.get(channelName);
+      if (!def) {
+        log.error(
+          `channel "${channelName}" did not register after install — check \`moxxy plugins list\`.`,
+        );
+        return 'missing';
+      }
+
+      // The plugin's declared `moxxy.setup` fields (tokens → vault). Re-runs
+      // prefill, so an already-configured channel just confirms through.
+      try {
+        await runPluginSetupSteps({ vault, cwd: process.cwd(), only: [packageName] });
+      } catch (err) {
+        log.warn(
+          `setup fields failed (continuing — \`moxxy ${channelName}\` re-runs them): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+
+      if (!def.subcommands?.['pair']) return 'no-pair';
+      const wantPair = await confirm({
+        message: `Pair ${def.name} now?`,
+        initialValue: true,
+      });
+      if (isCancel(wantPair) || !wantPair) return 'skipped';
+
+      const code = await runChannelSubcommand(def, 'pair', {
+        session,
+        vault,
+        config,
+        argv: {
+          command: channelName,
+          positional: [],
+          // Pair-then-return: the channel restarts under the service below.
+          flags: { [EXIT_AFTER_PAIR_FLAG]: true },
+        },
+      });
+      return code === 0 ? 'paired' : 'failed';
+    },
+  );
+  if (pairOutcome === 'missing') return 1;
+  if (pairOutcome === 'failed') {
+    log.warn(
+      `Pairing didn't complete. Finish it later with ${colors.bold(`moxxy ${channelName}`)} — the rest of onboarding continues.`,
+    );
+  }
+
+  // ── Step 5: background service ──────────────────────────────────────────
+  const spec = serveSpec(new Set(), true);
+  let serviceState: 'installed' | 'skipped' | 'unsupported' | 'failed' = 'skipped';
+  if (!hasBoolFlag(argv, 'no-service')) {
+    if (servicePlatform() === 'unsupported') {
+      serviceState = 'unsupported';
+      note(
+        `Background services aren't wired up on ${process.platform} yet.\n` +
+          `Keep the agent reachable with a foreground ${colors.bold('moxxy serve --all')}.`,
+        'always on',
+      );
+    } else {
+      const status = await getServiceStatus(spec);
+      const wantService = await confirm({
+        message: status.installed
+          ? 'Restart the background service so it picks up the new channel?'
+          : 'Run moxxy as a background service? (always on — survives logout and reboot)',
+        initialValue: true,
+      });
+      if (!isCancel(wantService) && wantService) {
+        const result = await installAndStartService(spec);
+        if (result.ok) {
+          serviceState = 'installed';
+          log.success(`Service installed ✓ ${colors.dim(`(log: ${result.logPath})`)}`);
+        } else {
+          serviceState = 'failed';
+          log.error(`Service install failed: ${result.message}`);
+          process.stderr.write(colors.dim('  Run it in the foreground instead: moxxy serve --all\n'));
+        }
+      }
+    }
+  }
+
+  // ── Outro: what you have now ────────────────────────────────────────────
+  const lines: string[] = [];
+  if (activeProvider) lines.push(`Provider  ${colors.bold(activeProvider)}`);
+  lines.push(
+    `Channel   ${colors.bold(channelName)}  ${
+      pairOutcome === 'paired'
+        ? 'paired ✓'
+        : pairOutcome === 'no-pair'
+          ? colors.dim('(no pairing step)')
+          : colors.dim(`(pair later: moxxy ${channelName})`)
+    }`,
+  );
+  lines.push(
+    `Service   ${
+      serviceState === 'installed'
+        ? `running ✓  ${colors.dim('moxxy service status|logs|stop serve')}`
+        : serviceState === 'unsupported'
+          ? colors.dim('unsupported platform — moxxy serve --all')
+          : serviceState === 'failed'
+            ? colors.dim('failed — moxxy serve --all runs it in the foreground')
+            : colors.dim('skipped — moxxy service install serve when ready')
+    }`,
+  );
+  note(lines.join('\n'), 'your agent');
+
+  outro(
+    pairOutcome === 'paired' && serviceState === 'installed'
+      ? `Message your agent now — it answers on ${colors.bold(channelName)}. The terminal works too: ${colors.bold('moxxy')}.`
+      : `Almost there — finish the steps above, then message your agent on ${colors.bold(channelName)}.`,
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -137,7 +137,7 @@ export async function runServeCommand(argv: ParsedArgv): Promise<number> {
   return await runServeForeground(argv, except, all);
 }
 
-function serveSpec(except: Set<string>, all = false): ServiceSpec {
+export function serveSpec(except: Set<string>, all = false): ServiceSpec {
   const args = ['serve'];
   if (all) args.push('--all');
   if (all && except.size > 0) {
@@ -145,8 +145,9 @@ function serveSpec(except: Set<string>, all = false): ServiceSpec {
   }
   return {
     id: 'serve',
-    description:
-      'moxxy serve — every channel + scheduler + webhooks in ONE process, sharing a session',
+    description: all
+      ? 'moxxy serve --all — every registered channel + scheduler + webhooks in ONE process, sharing a session'
+      : 'moxxy serve — bare runner: session + scheduler + webhooks on the socket; channels attach as clients',
     execArgs: args,
   };
 }

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -35,9 +35,12 @@ const CATALOG: ReadonlyArray<ServiceSpec> = [
   {
     id: 'serve',
     description:
-      'moxxy serve — every registered channel + scheduler + webhooks in ONE process. ' +
-      'Use this when you want a single background unit instead of separate per-channel units.',
-    execArgs: ['serve'],
+      'moxxy serve --all — every registered channel + scheduler + webhooks in ONE process. ' +
+      'Use this when you want a single background unit instead of separate per-channel units. ' +
+      '(For a bare runner unit — no channels, clients attach — use `moxxy serve --background`.)',
+    // `--all` matches the description above: without it a serve unit starts
+    // NO channels (bare runner) and a paired bot would stay offline.
+    execArgs: ['serve', '--all'],
   },
   {
     id: 'telegram',

--- a/packages/cli/src/commands/service/index.ts
+++ b/packages/cli/src/commands/service/index.ts
@@ -66,7 +66,14 @@ export async function installAndStartService(spec: ServiceSpec): Promise<Service
     };
   }
   await mkdir(path.dirname(log), { recursive: true });
-  return provider.install(spec, { node: nodeBin(), cli, log, home: homedir() });
+  // Under Electron-as-node (the desktop app running the CLI with
+  // ELECTRON_RUN_AS_NODE), `nodeBin()` is the Electron binary. A unit that
+  // exec's it WITHOUT that env var would boot the full desktop GUI as a
+  // ghost daemon — export it into the unit so the binary stays plain Node.
+  const unitSpec: ServiceSpec = process.versions.electron
+    ? { ...spec, env: { ELECTRON_RUN_AS_NODE: '1', ...spec.env } }
+    : spec;
+  return provider.install(unitSpec, { node: nodeBin(), cli, log, home: homedir() });
 }
 
 export async function stopAndUninstallService(spec: ServiceSpec): Promise<SimpleResult> {

--- a/packages/plugin-channel-discord/src/pair-flow.ts
+++ b/packages/plugin-channel-discord/src/pair-flow.ts
@@ -1,5 +1,5 @@
 import { isCancel, log, outro, spinner, text } from '@clack/prompts';
-import type { ChannelSubcommandContext } from '@moxxy/sdk';
+import { exitAfterPairRequested, type ChannelSubcommandContext } from '@moxxy/sdk';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { DiscordChannel } from './channel.js';
 
@@ -99,6 +99,13 @@ export async function runPairFlow(ctx: ChannelSubcommandContext): Promise<number
       log.error('Too many failed attempts — pairing aborted. Run `moxxy discord pair` to retry.');
       await stopBot();
       return 1;
+    }
+
+    if (exitAfterPairRequested(ctx)) {
+      // Orchestrated pairing (`moxxy onboard`): hand control back — the
+      // caller starts the bot under its own service afterwards.
+      await stopBot();
+      return 0;
     }
 
     const spin = spinner();

--- a/packages/plugin-channel-signal/src/pair-flow.ts
+++ b/packages/plugin-channel-signal/src/pair-flow.ts
@@ -1,6 +1,6 @@
 import { log, outro, spinner } from '@clack/prompts';
 import QRCode from 'qrcode';
-import type { ChannelSubcommandContext } from '@moxxy/sdk';
+import { exitAfterPairRequested, type ChannelSubcommandContext } from '@moxxy/sdk';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { SignalChannel } from './channel.js';
 
@@ -69,6 +69,10 @@ export async function runSignalPairFlow(
         'to link a different account, remove this device from Signal → Linked Devices first, ' +
         'then run `moxxy channels signal unpair` and pair again.',
     );
+    if (exitAfterPairRequested(ctx)) {
+      await stopChannel();
+      return 0;
+    }
     log.info('Press Ctrl+C to stop.');
     installSignalHandlers(stopChannel, session);
     await handle.running;
@@ -88,7 +92,7 @@ export async function runSignalPairFlow(
       'The QR expires after a few minutes; re-run `moxxy channels signal pair` if it does.',
   );
 
-  installSignalHandlers(stopChannel, session);
+  const removeSignalHandlers = installSignalHandlers(stopChannel, session);
 
   const spin = spinner();
   spin.start('Waiting for you to scan in Signal...');
@@ -105,6 +109,16 @@ export async function runSignalPairFlow(
     return 1;
   }
   spin.stop(`Linked ✓ — this machine is now a device of ${account}.`);
+
+  if (exitAfterPairRequested(ctx)) {
+    // Orchestrated pairing (`moxxy onboard`): hand control back — the caller
+    // starts the channel under its own service afterwards. Our SIGINT
+    // handlers would `process.exit` the orchestrator, so drop them first.
+    removeSignalHandlers();
+    await stopChannel();
+    return 0;
+  }
+
   log.info(
     'Message your own "Note to Self" in Signal to talk to moxxy. The channel is running; press Ctrl+C to stop.',
   );
@@ -116,7 +130,7 @@ export async function runSignalPairFlow(
 function installSignalHandlers(
   stopChannel: () => Promise<void>,
   session: ChannelSubcommandContext['session'],
-): void {
+): () => void {
   let stopping = false;
   const shutdown = async (): Promise<void> => {
     if (stopping) return;
@@ -125,8 +139,13 @@ function installSignalHandlers(
     await session.close('SIGINT').catch(() => undefined);
     process.exit(0);
   };
-  process.once('SIGINT', () => void shutdown());
-  process.once('SIGTERM', () => void shutdown());
+  const onSignal = (): void => void shutdown();
+  process.once('SIGINT', onSignal);
+  process.once('SIGTERM', onSignal);
+  return () => {
+    process.removeListener('SIGINT', onSignal);
+    process.removeListener('SIGTERM', onSignal);
+  };
 }
 
 /** Render the linking URI as a scannable terminal QR + the raw URI. */

--- a/packages/plugin-channel-slack/package.json
+++ b/packages/plugin-channel-slack/package.json
@@ -53,7 +53,28 @@
         "name": "@moxxy/plugin-vault",
         "hint": "slack resolves the vault from the service registry for its bot token + signing secret + pairing; @moxxy/plugin-vault must load first"
       }
-    ]
+    ],
+    "setup": {
+      "title": "Slack bot",
+      "description": "Create an app at https://api.slack.com/apps → install it to your workspace and copy the Bot User OAuth Token (xoxb-…) plus the Signing Secret (Basic Information). Events arrive over an HTTP ingest URL — after setup, `moxxy slack pair` prints the Request URL to paste into Event Subscriptions; pairing is trust-on-first-@mention.",
+      "fields": [
+        {
+          "key": "botToken",
+          "label": "Bot User OAuth Token (xoxb-…)",
+          "kind": "secret",
+          "vaultKey": "slack_bot_token",
+          "required": true,
+          "placeholder": "xoxb-…"
+        },
+        {
+          "key": "signingSecret",
+          "label": "Signing Secret",
+          "kind": "secret",
+          "vaultKey": "slack_signing_secret",
+          "required": true
+        }
+      ]
+    }
   },
   "dependencies": {
     "@clack/prompts": "catalog:",

--- a/packages/plugin-channel-slack/src/pair-flow.ts
+++ b/packages/plugin-channel-slack/src/pair-flow.ts
@@ -1,5 +1,5 @@
 import { confirm, isCancel, log, outro, spinner } from '@clack/prompts';
-import type { ChannelSubcommandContext } from '@moxxy/sdk';
+import { exitAfterPairRequested, type ChannelSubcommandContext } from '@moxxy/sdk';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { SlackChannel, type PairCandidate } from './channel.js';
 
@@ -90,6 +90,14 @@ export async function runSlackPairFlow(ctx: ChannelSubcommandContext): Promise<n
 
   await channel.confirmPairing(candidate);
   log.success(`Paired ✓ — team ${candidate.teamId} is authorized.`);
+
+  if (exitAfterPairRequested(ctx)) {
+    // Orchestrated pairing (`moxxy onboard`): hand control back — the caller
+    // starts the bot under its own service afterwards.
+    await stopBot();
+    return 0;
+  }
+
   log.info('Bot is running. Press Ctrl+C to stop.');
 
   const shutdown = async (): Promise<void> => {

--- a/packages/plugin-channel-whatsapp/src/pair-flow.ts
+++ b/packages/plugin-channel-whatsapp/src/pair-flow.ts
@@ -1,6 +1,6 @@
 import { log, outro, spinner } from '@clack/prompts';
 import QRCode from 'qrcode';
-import type { ChannelSubcommandContext } from '@moxxy/sdk';
+import { exitAfterPairRequested, type ChannelSubcommandContext } from '@moxxy/sdk';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { WhatsAppChannel } from './channel.js';
 import { CONSENT_REQUIRED_MESSAGE } from './consent.js';
@@ -96,6 +96,17 @@ export async function runWhatsAppPairFlow(ctx: ChannelSubcommandContext): Promis
   spin.start('Waiting for the scan (the QR refreshes periodically)...');
   const ownerJid = await paired;
   spin.stop(`Linked as ${ownerJid}. Your Note-to-Self chat now talks to moxxy.`);
+
+  if (exitAfterPairRequested(ctx)) {
+    // Orchestrated pairing (`moxxy onboard`): hand control back — the caller
+    // starts the channel under its own service afterwards. Our SIGINT
+    // handlers would `process.exit` the orchestrator, so drop them first.
+    unsubscribeConnect();
+    process.removeListener('SIGINT', onSignal);
+    process.removeListener('SIGTERM', onSignal);
+    await stopChannel();
+    return 0;
+  }
 
   log.info('Channel is running. Press Ctrl+C to stop.');
   try {

--- a/packages/plugin-plugins-admin/src/catalog.ts
+++ b/packages/plugin-plugins-admin/src/catalog.ts
@@ -154,6 +154,7 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'Drive moxxy over a local HTTP API (moxxy http).',
     packageName: '@moxxy/plugin-channel-http',
     installSpec: '@moxxy/plugin-channel-http',
+    provides: [{ category: 'channel', name: 'http' }],
   },
   {
     id: 'usage-stats',
@@ -196,6 +197,7 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'Local web chat surface + the canvas present_view renders into (moxxy web).',
     packageName: '@moxxy/plugin-channel-web',
     installSpec: '@moxxy/plugin-channel-web',
+    provides: [{ category: 'channel', name: 'web' }],
   },
   {
     id: 'voice-admin',
@@ -217,6 +219,7 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'Chat with moxxy from Telegram (moxxy telegram; QR pairing).',
     packageName: '@moxxy/plugin-telegram',
     installSpec: '@moxxy/plugin-telegram',
+    provides: [{ category: 'channel', name: 'telegram' }],
   },
   {
     id: 'slack',
@@ -224,6 +227,7 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     description: 'Slack bot on a dedicated isolated runner (moxxy slack).',
     packageName: '@moxxy/plugin-channel-slack',
     installSpec: '@moxxy/plugin-channel-slack',
+    provides: [{ category: 'channel', name: 'slack' }],
   },
   {
     id: 'signal',

--- a/packages/plugin-telegram/package.json
+++ b/packages/plugin-telegram/package.json
@@ -53,7 +53,22 @@
         "name": "@moxxy/plugin-vault",
         "hint": "telegram resolves the vault from the service registry for its bot token + pairing; @moxxy/plugin-vault must load first"
       }
-    ]
+    ],
+    "setup": {
+      "title": "Telegram bot",
+      "description": "Create a bot with @BotFather in Telegram (/newbot) and paste its token below. It goes into the encrypted vault. Pairing happens afterwards via QR (`moxxy telegram` → pair).",
+      "fields": [
+        {
+          "key": "botToken",
+          "label": "Bot token",
+          "kind": "secret",
+          "vaultKey": "telegram_bot_token",
+          "required": true,
+          "placeholder": "123456789:AA…",
+          "description": "From @BotFather → /newbot (or /token for an existing bot)."
+        }
+      ]
+    }
   },
   "dependencies": {
     "@clack/prompts": "catalog:",

--- a/packages/plugin-telegram/src/pair-flow.ts
+++ b/packages/plugin-telegram/src/pair-flow.ts
@@ -1,6 +1,6 @@
 import { log, outro, spinner } from '@clack/prompts';
 import QRCode from 'qrcode';
-import type { ChannelSubcommandContext } from '@moxxy/sdk';
+import { exitAfterPairRequested, type ChannelSubcommandContext } from '@moxxy/sdk';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { TelegramChannel } from './channel.js';
 
@@ -95,6 +95,16 @@ export async function runPairFlow(ctx: ChannelSubcommandContext): Promise<number
   spin.start('Waiting for you to pair in Telegram...');
   const chatId = await paired;
   spin.stop(`Paired ✓ — chat ${chatId} is authorized.`);
+
+  if (exitAfterPairRequested(ctx)) {
+    // Orchestrated pairing (`moxxy onboard`): hand control back — the caller
+    // starts the bot under its own service afterwards. Our SIGINT handlers
+    // would `process.exit` the orchestrator, so drop them first.
+    process.removeListener('SIGINT', onSignal);
+    process.removeListener('SIGTERM', onSignal);
+    await stopBot();
+    return 0;
+  }
 
   log.info('Bot is running. Press Ctrl+C to stop.');
   try {

--- a/packages/sdk/src/channel.ts
+++ b/packages/sdk/src/channel.ts
@@ -301,6 +301,31 @@ export interface ChannelSubcommand {
 }
 
 /**
+ * Flag an orchestrator (e.g. `moxxy onboard`) passes to a channel's `pair`
+ * subcommand to say "hand control back once pairing succeeds". Every pair
+ * flow's default is to keep the just-paired channel running until Ctrl+C —
+ * right for a human running `moxxy <name> pair` standalone, wrong for a
+ * caller that pairs as one step of a longer flow (its SIGINT handlers call
+ * `process.exit`, which would kill the orchestrator). Pair flows check this
+ * via {@link exitAfterPairRequested} after a successful pairing and stop the
+ * channel + return 0 instead of blocking forever.
+ */
+export const EXIT_AFTER_PAIR_FLAG = 'exit-after-pair';
+
+/** Whether the subcommand invocation asked for the pair-then-return contract. */
+export function exitAfterPairRequested(
+  ctx: Pick<ChannelSubcommandContext, 'args' | 'deps'>,
+): boolean {
+  // The CLI forwards subcommand argv flags both as `args.flags` and merged
+  // into `deps.options`; accept either carrier so programmatic callers that
+  // only build one of the two still opt in.
+  return (
+    ctx.args.flags[EXIT_AFTER_PAIR_FLAG] === true ||
+    ctx.deps.options?.[EXIT_AFTER_PAIR_FLAG] === true
+  );
+}
+
+/**
  * Read-only registry of channels available in a Session. Implementation lives
  * in @moxxy/core.
  */

--- a/packages/sdk/src/exit-after-pair.test.ts
+++ b/packages/sdk/src/exit-after-pair.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { EXIT_AFTER_PAIR_FLAG, exitAfterPairRequested } from './channel.js';
+
+function ctx(
+  flags: Record<string, string | boolean | undefined>,
+  options?: Record<string, unknown>,
+): Parameters<typeof exitAfterPairRequested>[0] {
+  return {
+    args: { positional: [], flags },
+    deps: { cwd: '/tmp', ...(options ? { options } : {}) },
+  };
+}
+
+describe('exitAfterPairRequested', () => {
+  it('defaults to false (standalone pair keeps the channel running)', () => {
+    expect(exitAfterPairRequested(ctx({}))).toBe(false);
+  });
+
+  it('honors the flag via args.flags', () => {
+    expect(exitAfterPairRequested(ctx({ [EXIT_AFTER_PAIR_FLAG]: true }))).toBe(true);
+  });
+
+  it('honors the flag via deps.options (programmatic callers)', () => {
+    expect(exitAfterPairRequested(ctx({}, { [EXIT_AFTER_PAIR_FLAG]: true }))).toBe(true);
+  });
+
+  it('requires boolean true — a string "true" flag is not an opt-in', () => {
+    // argv flags are string|boolean; only an explicit boolean true counts, so
+    // `--exit-after-pair=weird` values can't accidentally change lifecycle.
+    expect(exitAfterPairRequested(ctx({ [EXIT_AFTER_PAIR_FLAG]: 'true' }))).toBe(false);
+  });
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -371,7 +371,7 @@ export type {
   ResolvedPluginManifest,
 } from './plugin.js';
 
-export { startChannelWith } from './channel.js';
+export { startChannelWith, EXIT_AFTER_PAIR_FLAG, exitAfterPairRequested } from './channel.js';
 export type {
   Channel,
   ChannelHandle,


### PR DESCRIPTION
## What

`moxxy onboard` — the one guided path from a fresh install to a paired, always-on agent:

1. **provider** — delegates to the `moxxy init` wizard, skipped when a provider is already configured (`--reinit` to force)
2. **channel** — pick a messenger (Discord / Telegram / WhatsApp / Signal / Slack); labels + packages derived from the install catalog's `provides`
3. **install + setup** — version-pinned catalog install, then the plugin's declared `moxxy.setup` fields (tokens → vault)
4. **pair** — the channel's own pair flow, in a new **pair-then-return** mode
5. **service** — a `moxxy serve --all` launchd/systemd unit (opt-out with `--no-service`), then a "message your agent now" summary

Every step delegates to the machinery that owns it — onboard only sequences, so each step behaves identically standalone.

## New SDK contract

`EXIT_AFTER_PAIR_FLAG` + `exitAfterPairRequested(ctx)`: every pair flow deliberately runs the just-paired channel until Ctrl+C, and its SIGINT handler calls `process.exit` — which would kill an orchestrator mid-flow. All five pair flows now check the flag after a successful pairing and stop + return 0 instead (removing their signal handlers first). Standalone `moxxy <channel> pair` behavior is unchanged.

## Bugs fixed en route

- **`moxxy service install serve` never started channels**: the catalog spec ran bare `serve` (bare runner = no channels) while its description promised "every registered channel in ONE process". A freshly-paired bot would go silent the moment onboarding ended. The unit now runs `serve --all`; `moxxy serve --background` still installs the bare-runner variant.
- **Electron-as-node service installs** (desktop-spawned) exec'd the Electron binary without `ELECTRON_RUN_AS_NODE=1` → GUI ghost daemon. The env var is now exported into the unit (retires the TECH_DEBT entry).

## Also

- Channel install hints derived from catalog `provides` — the drift-prone hand-listed `CHANNEL_COMMANDS` map is gone; telegram/slack/web/http catalog entries gained `provides` declarations.
- Telegram + Slack now declare `package.json#moxxy.setup` (parity with the wave-1 channels; powers the TUI/desktop post-install dialogs and onboard's token step).
- README quickstart leads with `moxxy onboard`; TECH_DEBT logs the corrected serve-resolver finding (pairing/attach paths are last-writer-wins, not "first channel wins").

## Verification

- Full gate green: build, typecheck, lint, tests (incl. new unit tests for the choice builder, hint derivation, and the pair-return contract), check:deps.
- Smoke on the built binary: `onboard --help`, non-TTY guard, top-level help listing.
- **Manual verify (needs live accounts + a TTY)**: `moxxy onboard` on a clean `MOXXY_HOME` end-to-end with Discord (install → token → DM-code pair returns to onboard → service unit runs the bot); re-run idempotency (provider skip note, "restart service?" variant); `--channel telegram` preset; `--no-service`.