### PR TITLE
feat(security): declare tool capabilities — system plugins (computer-control, self-update, vault, oauth)

### DIFF
--- a/.changeset/caps-backfill-system.md
+++ b/.changeset/caps-backfill-system.md
@@ -1,0 +1,8 @@
+---
+"@moxxy/plugin-computer-control": patch
+"@moxxy/plugin-self-update": patch
+"@moxxy/plugin-vault": patch
+"@moxxy/plugin-oauth": patch
+---
+
+Declare honest `isolation` capability specs (fs/net/subprocess/env/time budgets) on every tool in the system plugins — computer-control, self-update, vault, and oauth.

--- a/packages/plugin-computer-control/src/tools/applescript.ts
+++ b/packages/plugin-computer-control/src/tools/applescript.ts
@@ -20,6 +20,18 @@ export const applescriptTool = defineTool({
       ),
   }),
   permission: { action: 'prompt' },
+  // Arbitrary AppleScript is an escape hatch on par with a shell: the script
+  // can itself shell out (`do shell script`) and reach the network, so the
+  // honest bounds are subprocess + any net — a confining isolator must not
+  // assume osascript stays offline. Budget = the 30s child timeout + kill grace.
+  isolation: {
+    capabilities: {
+      subprocess: true,
+      commands: ['osascript'],
+      net: { mode: 'any' },
+      timeMs: 40_000,
+    },
+  },
   async handler({ script }, ctx) {
     ensureDarwin('computer_applescript');
     const proc = await runProcess('osascript', ['-e', script], {

--- a/packages/plugin-computer-control/src/tools/click.ts
+++ b/packages/plugin-computer-control/src/tools/click.ts
@@ -20,6 +20,14 @@ export const clickTool = defineTool({
       .describe('Number of consecutive clicks. 1 = single, 2 = double, 3 = triple. Default 1.'),
   }),
   permission: { action: 'prompt' },
+  isolation: {
+    capabilities: {
+      subprocess: true,
+      commands: ['osascript'],
+      net: { mode: 'none' },
+      timeMs: 15_000,
+    },
+  },
   async handler({ x, y, count }, ctx) {
     ensureDarwin('computer_click');
     const n = count ?? 1;

--- a/packages/plugin-computer-control/src/tools/clipboard.ts
+++ b/packages/plugin-computer-control/src/tools/clipboard.ts
@@ -17,6 +17,14 @@ export const clipboardTool = defineTool({
       .describe('Text to put on the clipboard. Required when action="write".'),
   }),
   permission: { action: 'prompt' },
+  isolation: {
+    capabilities: {
+      subprocess: true,
+      commands: ['pbpaste', 'pbcopy'],
+      net: { mode: 'none' },
+      timeMs: 10_000,
+    },
+  },
   async handler({ action, text }, ctx) {
     ensureDarwin('computer_clipboard');
     if (action === 'read') {

--- a/packages/plugin-computer-control/src/tools/key.ts
+++ b/packages/plugin-computer-control/src/tools/key.ts
@@ -77,6 +77,14 @@ export const keyTool = defineTool({
       ),
   }),
   permission: { action: 'prompt' },
+  isolation: {
+    capabilities: {
+      subprocess: true,
+      commands: ['osascript'],
+      net: { mode: 'none' },
+      timeMs: 15_000,
+    },
+  },
   async handler({ key, modifiers }, ctx) {
     ensureDarwin('computer_key');
     const mods = modifiers ?? [];

--- a/packages/plugin-computer-control/src/tools/open.ts
+++ b/packages/plugin-computer-control/src/tools/open.ts
@@ -27,6 +27,20 @@ export const openTool = defineTool({
       .optional(),
   }),
   permission: { action: 'prompt' },
+  // `open` only messages LaunchServices: the file read / URL navigation happens
+  // in the launched app, outside this process tree — hence net 'none'. The
+  // broad fs.read is honest for this tool: any user-approved path is a
+  // legitimate `target`, and the cap check validates path-shaped inputs
+  // against these globs.
+  isolation: {
+    capabilities: {
+      subprocess: true,
+      commands: ['open'],
+      fs: { read: ['/**'] },
+      net: { mode: 'none' },
+      timeMs: 15_000,
+    },
+  },
   async handler({ target, app }, ctx) {
     ensureDarwin('computer_open');
     if (!target && !app) {

--- a/packages/plugin-computer-control/src/tools/screenshot.ts
+++ b/packages/plugin-computer-control/src/tools/screenshot.ts
@@ -68,6 +68,18 @@ export const screenshotTool = defineTool({
       ),
   }),
   permission: { action: 'prompt' },
+  // Capture + resize round-trips through temp files under os.tmpdir()
+  // (which is /var/folders/... on macOS, not /tmp). Budget covers the two
+  // 15s child stages plus encode/cleanup.
+  isolation: {
+    capabilities: {
+      subprocess: true,
+      commands: ['screencapture', 'sips'],
+      fs: { read: [`${os.tmpdir()}/**`], write: [`${os.tmpdir()}/**`] },
+      net: { mode: 'none' },
+      timeMs: 45_000,
+    },
+  },
   async handler({ region, maxDim, format, quality }, ctx) {
     ensureDarwin('computer_screenshot');
     const fmt = format ?? DEFAULT_FORMAT;

--- a/packages/plugin-computer-control/src/tools/type.ts
+++ b/packages/plugin-computer-control/src/tools/type.ts
@@ -17,6 +17,14 @@ export const typeTool = defineTool({
       ),
   }),
   permission: { action: 'prompt' },
+  isolation: {
+    capabilities: {
+      subprocess: true,
+      commands: ['osascript'],
+      net: { mode: 'none' },
+      timeMs: 40_000,
+    },
+  },
   async handler({ text }, ctx) {
     ensureDarwin('computer_type');
     if (text.length === 0) return { ok: true, length: 0 };

--- a/packages/plugin-oauth/src/tools.ts
+++ b/packages/plugin-oauth/src/tools.ts
@@ -1,4 +1,5 @@
 import { defineTool, MoxxyError, z } from '@moxxy/sdk';
+import { moxxyPath } from '@moxxy/sdk/server';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import {
   buildAuthUrl,
@@ -21,6 +22,15 @@ import { refreshAndStore, type RefreshSpec } from './ensure-fresh.js';
 export interface OAuthToolDeps {
   readonly vault: VaultStore;
 }
+
+/**
+ * Capability surface of the vault-backed credential store these tools share:
+ * the encrypted vault file and the cached master key, including their
+ * atomic-write `.tmp` siblings. A locked vault's first open() reads the
+ * passphrase env var and can block indefinitely on an interactive passphrase
+ * prompt — hence no timeMs on any of these tools.
+ */
+const VAULT_FS_GLOBS = [`${moxxyPath('vault.json')}*`, `${moxxyPath('vault.key')}*`];
 
 const providerNameField = z
   .string()
@@ -105,6 +115,20 @@ export function buildOauthAuthorizeTool(deps: OAuthToolDeps) {
         ),
     }),
     permission: { action: 'prompt' },
+    // Provider endpoints (authUrl / tokenUrl / deviceUrl) are model-supplied
+    // per call and loopback mode binds a localhost callback server, so the net
+    // surface is genuinely dynamic. The browser is launched via the platform
+    // opener (ComSpec is read for the win32 `cmd /c start` shim). The flow
+    // enforces its own deadline (loopback: 5 min; device: the code's expiry).
+    isolation: {
+      capabilities: {
+        subprocess: true,
+        commands: ['open', 'xdg-open', 'cmd.exe'],
+        net: { mode: 'any' },
+        fs: { read: VAULT_FS_GLOBS, write: VAULT_FS_GLOBS },
+        env: ['MOXXY_VAULT_PASSPHRASE', 'ComSpec'],
+      },
+    },
     async handler(input, ctx) {
       validateProvider(input.provider);
       const mode = input.mode ?? 'loopback';
@@ -225,6 +249,19 @@ export function buildOauthGetTokenTool(deps: OAuthToolDeps) {
         ),
     }),
     permission: { action: 'prompt' },
+    // Refresh POSTs go to the token endpoint persisted at authorize time —
+    // arbitrary per provider, so a static allowlist can't cover it. Rotation
+    // is serialized through the on-disk credential lock under ~/.moxxy/locks.
+    isolation: {
+      capabilities: {
+        net: { mode: 'any' },
+        fs: {
+          read: [...VAULT_FS_GLOBS, `${moxxyPath('locks')}/**`],
+          write: [...VAULT_FS_GLOBS, `${moxxyPath('locks')}/**`],
+        },
+        env: ['MOXXY_VAULT_PASSPHRASE'],
+      },
+    },
     async handler({ provider, forceRefresh, includeRefresh }, _ctx) {
       const stored = await readStoredCreds(deps.vault, provider);
       if (!stored) {
@@ -277,6 +314,13 @@ export function buildOauthClearTool(deps: OAuthToolDeps) {
       'the grant or re-do the flow with different scopes.',
     inputSchema: z.object({ provider: providerNameField }),
     permission: { action: 'prompt' },
+    isolation: {
+      capabilities: {
+        net: { mode: 'none' },
+        fs: { read: VAULT_FS_GLOBS, write: VAULT_FS_GLOBS },
+        env: ['MOXXY_VAULT_PASSPHRASE'],
+      },
+    },
     async handler({ provider }) {
       const removed = await clearStoredCreds(deps.vault, provider);
       return { ok: true, provider, removedKeys: removed };

--- a/packages/plugin-self-update/src/core-tools/apply.ts
+++ b/packages/plugin-self-update/src/core-tools/apply.ts
@@ -6,12 +6,25 @@ import { resolveCore, snapshotDir, type CoreToolDeps } from './shared.js';
 // ── self_update_core_apply ──────────────────────────────────────────────────
 export function coreApplyTool(cd: CoreToolDeps): ToolDef {
   const { deps } = cd;
+  const scopeDir = resolveCore(cd)?.scopeDir;
   return defineTool({
     name: 'self_update_core_apply',
     description:
       'Overlay the verified build into the live global install (snapshotting the previous dist for rollback) and stage a restart. The new core code only activates after moxxy restarts. Requires a prior successful self_update_core_verify.',
     inputSchema: z.object({ coreTxnId: z.string().min(1) }),
     permission: { action: 'prompt' },
+    // Swaps freshly-built dists into the live @moxxy install (snapshotting the
+    // old ones under the txn dir) — writes outside ~/.moxxy by design.
+    isolation: {
+      capabilities: {
+        fs: {
+          read: [...(scopeDir ? [`${scopeDir}/**`] : []), `${deps.moxxyDir}/self-update/**`],
+          write: [...(scopeDir ? [`${scopeDir}/**`] : []), `${deps.moxxyDir}/self-update/**`],
+        },
+        net: { mode: 'none' },
+        timeMs: 120_000,
+      },
+    },
     handler: async (input, ctx: ToolContext) => {
       const journal = await readCoreJournal(deps.moxxyDir, input.coreTxnId);
       if (journal.state !== 'verified') {

--- a/packages/plugin-self-update/src/core-tools/begin.ts
+++ b/packages/plugin-self-update/src/core-tools/begin.ts
@@ -14,6 +14,7 @@ import { resolveCore, type CoreToolDeps } from './shared.js';
 // ── self_update_core_begin ──────────────────────────────────────────────────
 export function coreBeginTool(cd: CoreToolDeps): ToolDef {
   const { deps } = cd;
+  const scopeDir = resolveCore(cd)?.scopeDir;
   return defineTool({
     name: 'self_update_core_begin',
     description:
@@ -25,6 +26,22 @@ export function coreBeginTool(cd: CoreToolDeps): ToolDef {
         .describe('Affected @moxxy/* package names, e.g. ["@moxxy/core"].'),
     }),
     permission: { action: 'prompt' },
+    // Provisions the pinned source clone under ~/.moxxy/self-update: git
+    // clone/fetch from the repo URL in the published @moxxy/core metadata (or
+    // the config override) plus a full `pnpm install` — the hosts are
+    // genuinely dynamic and first use legitimately takes minutes.
+    isolation: {
+      capabilities: {
+        subprocess: true,
+        commands: ['git', 'pnpm'],
+        net: { mode: 'any' },
+        fs: {
+          read: [...(scopeDir ? [`${scopeDir}/**`] : []), `${deps.moxxyDir}/self-update/**`],
+          write: [`${deps.moxxyDir}/self-update/**`],
+        },
+        timeMs: 1_800_000,
+      },
+    },
     handler: async (input, ctx: ToolContext) => {
       const install = resolveCore(cd);
       if (!install) throw new Error('could not resolve the installed @moxxy/core — cannot self-update core');

--- a/packages/plugin-self-update/src/core-tools/edit.ts
+++ b/packages/plugin-self-update/src/core-tools/edit.ts
@@ -18,6 +18,20 @@ export function coreEditTool(cd: CoreToolDeps): ToolDef {
       newString: z.string(),
     }),
     permission: { action: 'prompt' },
+    // All real I/O is confined to the provisioned clone + journal under
+    // ~/.moxxy/self-update (safeRepoPath refuses escapes). `$cwd/**` is
+    // declared read-only because the input-level cap check resolves the
+    // repo-relative `file` input against the session cwd, not the clone.
+    isolation: {
+      capabilities: {
+        fs: {
+          read: ['$cwd/**', `${deps.moxxyDir}/self-update/**`],
+          write: [`${deps.moxxyDir}/self-update/**`],
+        },
+        net: { mode: 'none' },
+        timeMs: 15_000,
+      },
+    },
     handler: async (input, ctx: ToolContext) => {
       const journal = await readCoreJournal(deps.moxxyDir, input.coreTxnId);
       const abs = safeRepoPath(journal.repoDir, input.file);

--- a/packages/plugin-self-update/src/core-tools/preflight.ts
+++ b/packages/plugin-self-update/src/core-tools/preflight.ts
@@ -4,12 +4,24 @@ import { resolveCore, type CoreToolDeps } from './shared.js';
 
 // ── self_update_core_preflight ──────────────────────────────────────────────
 export function corePreflightTool(cd: CoreToolDeps): ToolDef {
+  const scopeDir = resolveCore(cd)?.scopeDir;
   return defineTool({
     name: 'self_update_core_preflight',
     description:
       'Read-only. Check whether a Tier-2 core patch is even possible: git + pnpm present, @moxxy/core resolvable, a pinned source commit (gitHead) and repo URL in its published metadata. Run this BEFORE attempting to patch @moxxy/core; if any check fails, do not start — tell the user.',
     inputSchema: z.object({}),
     permission: { action: 'allow' },
+    // Probes `git --version` / `pnpm --version` (10s cap each) and resolves
+    // the live install — a package.json read under the @moxxy scope dir.
+    isolation: {
+      capabilities: {
+        subprocess: true,
+        commands: ['git', 'pnpm'],
+        ...(scopeDir ? { fs: { read: [`${scopeDir}/**`] } } : {}),
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async () => corePreflight(resolveCore(cd)),
   });
 }

--- a/packages/plugin-self-update/src/core-tools/rollback.ts
+++ b/packages/plugin-self-update/src/core-tools/rollback.ts
@@ -6,12 +6,25 @@ import { resolveCore, snapshotDir, type CoreToolDeps } from './shared.js';
 // ── self_update_core_rollback ───────────────────────────────────────────────
 export function coreRollbackTool(cd: CoreToolDeps): ToolDef {
   const { deps } = cd;
+  const scopeDir = resolveCore(cd)?.scopeDir;
   return defineTool({
     name: 'self_update_core_rollback',
     description:
       'Undo a core overlay: restore the previous dist from the snapshot. A restart is required to drop the patched code. Use if a core patch built+loaded but misbehaves.',
     inputSchema: z.object({ coreTxnId: z.string().min(1), reason: z.string().optional() }),
     permission: { action: 'allow' },
+    // Restores the snapshotted dists back over the live @moxxy install —
+    // like core_apply, it writes outside ~/.moxxy by design.
+    isolation: {
+      capabilities: {
+        fs: {
+          read: [...(scopeDir ? [`${scopeDir}/**`] : []), `${deps.moxxyDir}/self-update/**`],
+          write: [...(scopeDir ? [`${scopeDir}/**`] : []), `${deps.moxxyDir}/self-update/**`],
+        },
+        net: { mode: 'none' },
+        timeMs: 120_000,
+      },
+    },
     handler: async (input, ctx: ToolContext) => {
       const journal = await readCoreJournal(deps.moxxyDir, input.coreTxnId);
       const install = resolveCore(cd);

--- a/packages/plugin-self-update/src/core-tools/status.ts
+++ b/packages/plugin-self-update/src/core-tools/status.ts
@@ -10,6 +10,13 @@ export function coreStatusTool(cd: CoreToolDeps): ToolDef {
     description: 'List Tier-2 core-update transactions and their state.',
     inputSchema: z.object({}),
     permission: { action: 'allow' },
+    isolation: {
+      capabilities: {
+        fs: { read: [`${deps.moxxyDir}/self-update/**`] },
+        net: { mode: 'none' },
+        timeMs: 10_000,
+      },
+    },
     handler: async () => {
       const all = await listCoreTxns(deps.moxxyDir);
       return {

--- a/packages/plugin-self-update/src/core-tools/verify.ts
+++ b/packages/plugin-self-update/src/core-tools/verify.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import { defineTool, z, type ToolContext, type ToolDef } from '@moxxy/sdk';
 import { readCoreJournal, verifyCorePackages, writeCoreJournal } from '../core-update.js';
 import { emitSafe } from '../deps.js';
@@ -6,12 +7,34 @@ import { resolveCore, type CoreToolDeps } from './shared.js';
 // ── self_update_core_verify ─────────────────────────────────────────────────
 export function coreVerifyTool(cd: CoreToolDeps): ToolDef {
   const { deps } = cd;
+  const scopeDir = resolveCore(cd)?.scopeDir;
   return defineTool({
     name: 'self_update_core_verify',
     description:
       'Build, typecheck and test the affected core packages (and their dependents) in the clone, and confirm the patch adds no new runtime dependency. Returns stage results. Run AFTER edits; nothing in the live install changes here.',
     inputSchema: z.object({ coreTxnId: z.string().min(1) }),
     permission: { action: 'prompt' },
+    // Runs `pnpm --filter … build/typecheck/test` in the provisioned clone —
+    // three child stages capped at 12 minutes each. The repo's own test suites
+    // legitimately bind localhost sockets, but no registry access is needed
+    // (deps were installed at core_begin) — hence the loopback-only allowlist.
+    // The read glob over the live install's node_modules root covers the
+    // added-runtime-deps presence probes.
+    isolation: {
+      capabilities: {
+        subprocess: true,
+        commands: ['pnpm'],
+        net: { mode: 'allowlist', hosts: ['localhost', '127.0.0.1', '::1'] },
+        fs: {
+          read: [
+            ...(scopeDir ? [`${path.dirname(scopeDir)}/**`] : []),
+            `${deps.moxxyDir}/self-update/**`,
+          ],
+          write: [`${deps.moxxyDir}/self-update/**`],
+        },
+        timeMs: 2_400_000,
+      },
+    },
     handler: async (input, ctx: ToolContext) => {
       const journal = await readCoreJournal(deps.moxxyDir, input.coreTxnId);
       const install = resolveCore(cd);

--- a/packages/plugin-self-update/src/core-tools/write.ts
+++ b/packages/plugin-self-update/src/core-tools/write.ts
@@ -18,6 +18,20 @@ export function coreWriteTool(cd: CoreToolDeps): ToolDef {
       content: z.string(),
     }),
     permission: { action: 'prompt' },
+    // All real I/O is confined to the provisioned clone + journal under
+    // ~/.moxxy/self-update (safeRepoPath refuses escapes). `$cwd/**` is
+    // declared read-only because the input-level cap check resolves the
+    // repo-relative `file` input against the session cwd, not the clone.
+    isolation: {
+      capabilities: {
+        fs: {
+          read: ['$cwd/**', `${deps.moxxyDir}/self-update/**`],
+          write: [`${deps.moxxyDir}/self-update/**`],
+        },
+        net: { mode: 'none' },
+        timeMs: 15_000,
+      },
+    },
     handler: async (input, ctx: ToolContext) => {
       const journal = await readCoreJournal(deps.moxxyDir, input.coreTxnId);
       const abs = safeRepoPath(journal.repoDir, input.file);

--- a/packages/plugin-self-update/src/index.ts
+++ b/packages/plugin-self-update/src/index.ts
@@ -156,6 +156,8 @@ function classifyTool(deps: SelfUpdateDeps): ToolDef {
       text: z.string().optional().describe('The user request or a short description of the problem.'),
     }),
     permission: { action: 'allow' },
+    // Pure in-memory: scans ctx.log and the registry snapshot.
+    isolation: { capabilities: { net: { mode: 'none' }, timeMs: 10_000 } },
     handler: (input, ctx: ToolContext) => {
       const signals = gatherSignals(ctx.log, deps.snapshot().tools ?? []);
       return classify(input, signals);
@@ -177,6 +179,22 @@ function beginTool(deps: SelfUpdateDeps): ToolDef {
         .describe('Plugin directory name or skill slug (no path separators).'),
     }),
     permission: { action: 'allow' },
+    // Snapshots the target (source-only — SNAPSHOT_EXCLUDE drops
+    // node_modules/.git/dist) into the txn dir; nothing outside ~/.moxxy moves.
+    isolation: {
+      capabilities: {
+        fs: {
+          read: [
+            `${deps.moxxyDir}/plugins/**`,
+            `${deps.moxxyDir}/skills/**`,
+            `${deps.moxxyDir}/self-update/**`,
+          ],
+          write: [`${deps.moxxyDir}/self-update/**`],
+        },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async (input, ctx: ToolContext) => {
       // Single-flight per target (mirrors the Tier-2 core_begin guard): two
       // concurrent begins on the same plugin/skill snapshot independently, so a
@@ -225,6 +243,32 @@ function verifyTool(deps: SelfUpdateDeps): ToolDef {
       'Build, test and load-check the change in a transaction, then hot-reload it into the live session. Returns the stage results and what registered. On failure of a modify, the previous working version is automatically restored. Refuses after 2 failed cycles (escalate to the user). Run AFTER your edits; if it passes, call self_update_apply.',
     inputSchema: z.object({ txnId: z.string().min(1) }),
     permission: { action: 'prompt' },
+    // Runs the target plugin's own package-manager install/build/test as child
+    // processes (npm by default; pnpm/yarn/bun via its `packageManager` field).
+    // net 'any' is honest: `install` fetches from whatever registry the
+    // plugin's toolchain is configured for, and plugin test suites may
+    // legitimately open sockets. Budget covers the three child stages, each
+    // capped at 5 minutes, plus the reload.
+    isolation: {
+      capabilities: {
+        subprocess: true,
+        commands: ['npm', 'pnpm', 'yarn', 'bun'],
+        net: { mode: 'any' },
+        fs: {
+          read: [
+            `${deps.moxxyDir}/plugins/**`,
+            `${deps.moxxyDir}/skills/**`,
+            `${deps.moxxyDir}/self-update/**`,
+          ],
+          write: [
+            `${deps.moxxyDir}/plugins/**`,
+            `${deps.moxxyDir}/skills/**`,
+            `${deps.moxxyDir}/self-update/**`,
+          ],
+        },
+        timeMs: 960_000,
+      },
+    },
     handler: async (input, ctx: ToolContext) => {
       const journal = await readJournal(deps.moxxyDir, input.txnId);
 
@@ -356,6 +400,16 @@ function applyTool(deps: SelfUpdateDeps): ToolDef {
       'Finalize a verified self-update transaction: mark it committed and prune old snapshots. The change is already live (loaded during verify); this is the keep-it confirmation. Requires a prior successful self_update_verify.',
     inputSchema: z.object({ txnId: z.string().min(1) }),
     permission: { action: 'prompt' },
+    isolation: {
+      capabilities: {
+        fs: {
+          read: [`${deps.moxxyDir}/self-update/**`],
+          write: [`${deps.moxxyDir}/self-update/**`],
+        },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async (input, ctx: ToolContext) => {
       const journal = await readJournal(deps.moxxyDir, input.txnId);
       if (journal.state !== 'verified') {
@@ -383,6 +437,25 @@ function rollbackTool(deps: SelfUpdateDeps): ToolDef {
       reason: z.string().optional(),
     }),
     permission: { action: 'allow' },
+    // Restores the pre-change snapshot back over the live plugin/skill dir.
+    isolation: {
+      capabilities: {
+        fs: {
+          read: [
+            `${deps.moxxyDir}/plugins/**`,
+            `${deps.moxxyDir}/skills/**`,
+            `${deps.moxxyDir}/self-update/**`,
+          ],
+          write: [
+            `${deps.moxxyDir}/plugins/**`,
+            `${deps.moxxyDir}/skills/**`,
+            `${deps.moxxyDir}/self-update/**`,
+          ],
+        },
+        net: { mode: 'none' },
+        timeMs: 60_000,
+      },
+    },
     handler: async (input, ctx: ToolContext) => {
       const journal = await readJournal(deps.moxxyDir, input.txnId);
       await restoreSnapshot(deps.moxxyDir, journal);
@@ -405,6 +478,13 @@ function statusTool(deps: SelfUpdateDeps): ToolDef {
     description: 'List self-update transactions and their state (open / verified / committed / rolled_back / escalated).',
     inputSchema: z.object({ txnId: z.string().optional() }),
     permission: { action: 'allow' },
+    isolation: {
+      capabilities: {
+        fs: { read: [`${deps.moxxyDir}/self-update/**`] },
+        net: { mode: 'none' },
+        timeMs: 10_000,
+      },
+    },
     handler: async (input) => {
       const all = await listTransactions(deps.moxxyDir);
       const rows = (input.txnId ? all.filter((j) => j.txnId === input.txnId) : all).map((j) => ({

--- a/packages/plugin-vault/src/index.ts
+++ b/packages/plugin-vault/src/index.ts
@@ -42,6 +42,15 @@ export function buildVaultPlugin(opts: BuildVaultPluginOptions = {}): { plugin: 
     });
   const vault = new VaultStore({ filePath, keySource });
 
+  // Capability surface shared by every vault tool: the encrypted store file and
+  // the cached master key, INCLUDING their atomic-write temp siblings
+  // (`<file>.<pid>.<uuid>.tmp` — see writeFileAtomic). Read and write are
+  // declared together because any open() may create the store or backfill the
+  // key cache. No timeMs on these tools: a first open() can block indefinitely
+  // on an interactive passphrase prompt.
+  const vaultFsGlobs = [`${filePath}*`, `${moxxyPath('vault.key')}*`];
+  const vaultEnv = [opts.envVar ?? 'MOXXY_VAULT_PASSPHRASE'];
+
   // `/vault` slash command. Lets the USER store a secret out-of-band: the
   // value travels in the slash-command args, which channels intercept and
   // never send to the model. After storing, we inject a note into the event
@@ -165,6 +174,13 @@ export function buildVaultPlugin(opts: BuildVaultPluginOptions = {}): { plugin: 
           tags: z.array(z.string()).optional(),
         }),
         permission: { action: 'prompt' },
+        isolation: {
+          capabilities: {
+            fs: { read: vaultFsGlobs, write: vaultFsGlobs },
+            net: { mode: 'none' },
+            env: vaultEnv,
+          },
+        },
         handler: async ({ name, value, tags }) => {
           await vault.set(name, value, tags);
           return `stored ${name} (${value.length} chars) in vault`;
@@ -175,6 +191,13 @@ export function buildVaultPlugin(opts: BuildVaultPluginOptions = {}): { plugin: 
         description: 'Fetch a secret from the encrypted vault by name. Returns the plaintext value.',
         inputSchema: z.object({ name: z.string().min(1) }),
         permission: { action: 'prompt' },
+        isolation: {
+          capabilities: {
+            fs: { read: vaultFsGlobs, write: vaultFsGlobs },
+            net: { mode: 'none' },
+            env: vaultEnv,
+          },
+        },
         handler: async ({ name }) => {
           const value = await vault.get(name);
           if (value === null) {
@@ -193,6 +216,13 @@ export function buildVaultPlugin(opts: BuildVaultPluginOptions = {}): { plugin: 
         description: 'List entries in the vault. Returns names + metadata only, never plaintext.',
         inputSchema: z.object({}),
         permission: { action: 'prompt' },
+        isolation: {
+          capabilities: {
+            fs: { read: vaultFsGlobs, write: vaultFsGlobs },
+            net: { mode: 'none' },
+            env: vaultEnv,
+          },
+        },
         handler: async () => {
           const entries = await vault.list();
           return entries.map((e) => ({ name: e.name, createdAt: e.createdAt, tags: e.tags ?? [] }));
@@ -203,6 +233,13 @@ export function buildVaultPlugin(opts: BuildVaultPluginOptions = {}): { plugin: 
         description: 'Delete a vault entry by name.',
         inputSchema: z.object({ name: z.string().min(1) }),
         permission: { action: 'prompt' },
+        isolation: {
+          capabilities: {
+            fs: { read: vaultFsGlobs, write: vaultFsGlobs },
+            net: { mode: 'none' },
+            env: vaultEnv,
+          },
+        },
         handler: async ({ name }) => {
           const removed = await vault.delete(name);
           return removed ? `deleted ${name}` : `not found: ${name}`;
@@ -212,6 +249,13 @@ export function buildVaultPlugin(opts: BuildVaultPluginOptions = {}): { plugin: 
         name: 'vault_status',
         description: 'Report which key source unlocked the vault (keychain, env, passphrase).',
         inputSchema: z.object({}),
+        isolation: {
+          capabilities: {
+            fs: { read: vaultFsGlobs, write: vaultFsGlobs },
+            net: { mode: 'none' },
+            env: vaultEnv,
+          },
+        },
         handler: async () => {
           await vault.open();
           const entries = await vault.list();


### PR DESCRIPTION
Wave 1/3 of the capability backfill: every tool in the four system plugins now carries an honest `isolation` declaration (`ToolIsolationSpec`), moving the repo toward flipping on `security.requireDeclaration`. Each spec was written by reading the handler and tracing exactly what it touches — no copy-pasted templates.

## What was declared

### @moxxy/plugin-computer-control (7 tools)
| Tool | Notable caps |
|---|---|
| `computer_applescript` | subprocess `osascript`, **net any** (arbitrary scripts can `do shell script` / reach the network), 40s |
| `computer_click` / `computer_key` | subprocess `osascript`, net none, 15s |
| `computer_type` | subprocess `osascript`, net none, 40s |
| `computer_clipboard` | subprocess `pbpaste`/`pbcopy`, net none, 10s |
| `computer_open` | subprocess `open`, `fs.read /**` (any user-approved path is a legitimate target), **net none** — URL navigation happens in the launched app, outside the process tree |
| `computer_screenshot` | subprocess `screencapture`/`sips`, temp files under `os.tmpdir()` (not `/tmp` on macOS), 45s |

### @moxxy/plugin-self-update (14 tools)
| Tool | Notable caps |
|---|---|
| `self_update_classify` | pure in-memory: net none, 10s |
| `self_update_begin` | read plugins/skills, write only `self-update/**` (source-only snapshot) |
| `self_update_verify` | subprocess `npm`/`pnpm`/`yarn`/`bun`, **net any** (plugin-declared toolchain installs from its registry; plugin tests may open sockets), 16 min (3 stages × 5 min child cap) |
| `self_update_apply` / `status` | journal-only fs under `self-update/**`, net none |
| `self_update_rollback` | restores snapshot over live plugins/skills, net none |
| `self_update_core_preflight` | subprocess `git`/`pnpm` (`--version` probes), reads the live `@moxxy` scope dir |
| `self_update_core_begin` | subprocess `git`/`pnpm`, **net any** (clone URL from published metadata / config override), 30 min |
| `self_update_core_write` / `core_edit` | fs confined to the provisioned clone; `$cwd/**` declared **read-only** because the input-level cap check resolves the repo-relative `file` input against the session cwd |
| `self_update_core_verify` | subprocess `pnpm`, **net allowlist `localhost`/`127.0.0.1`/`::1`** (repo tests bind loopback sockets; no registry needed post-begin), 40 min (3 stages × 12 min child cap), reads live `node_modules` root for the added-deps probe |
| `self_update_core_apply` / `core_rollback` | write the live `@moxxy` install scope dir (dist overlay/restore) + txn snapshots, net none, 120s |
| `self_update_core_status` | read-only `self-update/**`, net none |

The `@moxxy` scope-dir globs are resolved once at tool-build time via the same memoized `resolveCore` the handlers use, and omitted when no live install resolves (the handlers throw in that case anyway).

### @moxxy/plugin-vault (5 tools)
All five (`vault_set`/`get`/`list`/`delete`/`status`): fs read+write on `vault.json*` and `vault.key*` — the `*` covers `writeFileAtomic`'s `.pid.uuid.tmp` siblings, and read+write are declared together because any `open()` may create the store or backfill the key cache; net none; `env: [MOXXY_VAULT_PASSPHRASE]` (or the configured `envVar`). **No `timeMs`**: a first `open()` can block indefinitely on an interactive passphrase prompt.

### @moxxy/plugin-oauth (3 tools)
| Tool | Notable caps |
|---|---|
| `oauth_authorize` | **net any** (provider endpoints are model-supplied per call + localhost callback server), subprocess `open`/`xdg-open`/`cmd.exe` (browser opener), vault globs, `env: [MOXXY_VAULT_PASSPHRASE, ComSpec]` |
| `oauth_get_token` | **net any** (refresh POSTs to the token endpoint persisted at authorize time), vault globs + `~/.moxxy/locks/**` (credential lock) |
| `oauth_clear_token` | net none, vault globs |

No `timeMs` on the oauth tools either: all three can hit the vault's interactive first-open, and authorize blocks on the user's consent dance (the flow enforces its own deadline).

## Honesty rules followed
- Every handler was read before declaring; caps reflect what the code actually touches (fs paths, hosts, spawned commands, env reads).
- Never under-declared — where enforcement heuristics would brick a legitimate call (e.g. repo-relative `file` inputs, atomic-write temp siblings), the spec covers it explicitly with a comment.
- `net` is `none` unless the handler (or its children) genuinely needs the network; `any` only where hosts are model-supplied or config-dynamic, with a comment saying why; a static allowlist where the surface is fixed (core_verify → loopback only).
- `subprocess`+`commands` only on tools that actually spawn, listing the exact binaries.
- `timeMs` sized to the operation's real ceiling (child-process caps + grace), omitted where a tool legitimately blocks on user interaction.
- No `required` strength or `handlerModule` introduced (none of these files set them today).

## Verification
`pnpm build`, `pnpm typecheck`, `pnpm lint` (0 errors; pre-existing warnings untouched), `pnpm test`, `pnpm check:deps` — all green. Runtime smoke: loaded the built vault and self-update plugins and confirmed every tool carries its resolved spec.