### PR TITLE
feat(security): declare tool capabilities — admin + long-tail plugins

### DIFF
--- a/.changeset/caps-backfill-admin.md
+++ b/.changeset/caps-backfill-admin.md
@@ -1,0 +1,17 @@
+---
+'@moxxy/plugin-plugins-admin': patch
+'@moxxy/plugin-mcp': patch
+'@moxxy/config': patch
+'@moxxy/plugin-provider-admin': patch
+'@moxxy/plugin-memory': patch
+'@moxxy/plugin-voice-admin': patch
+'@moxxy/core': patch
+'@moxxy/mode-goal': patch
+'@moxxy/plugin-view': patch
+'@moxxy/plugin-terminal': patch
+'@moxxy/plugin-subagents': patch
+'@moxxy/plugin-channel-web': patch
+'@moxxy/plugin-telegram': patch
+---
+
+Declare honest `isolation` capability specs on the remaining admin and long-tail plugin tools (36 tools across 13 packages), completing the backfill that lets `security.requireDeclaration` be enabled.

--- a/packages/config/src/plugin.ts
+++ b/packages/config/src/plugin.ts
@@ -99,6 +99,19 @@ function parseValue(raw: string): unknown {
   }
 }
 
+// Capability fs globs shared by the tools below. The project-scope config can
+// resolve in an ANCESTOR directory (findUpward's bounded walk), so these
+// anchor on the well-known basenames rather than `$cwd` — the cap matcher
+// tests them against absolute paths. The editor tools only ever touch YAML;
+// reload/validate go through loadConfig, which also honors executable
+// configs (config.ts/js in ~/.moxxy, moxxy.config.ts/js in the project).
+const YAML_CONFIG_GLOBS = [
+  '~/.moxxy/config.yaml',
+  '/**/moxxy.config.yaml',
+  '/**/moxxy.config.yml',
+] as const;
+const LOADER_CONFIG_GLOBS = ['~/.moxxy/config.*', '/**/moxxy.config.*'] as const;
+
 export function buildConfigPlugin(
   opts: { cwd: string; applier?: ConfigApplier } = { cwd: process.cwd() },
 ): Plugin {
@@ -123,6 +136,13 @@ export function buildConfigPlugin(
           '(defaults to "project" — the moxxy.config.yaml in the current dir). ' +
           'Returns null if no file exists yet.',
         inputSchema: z.object({ scope: scopeSchemaOptional }),
+        isolation: {
+          capabilities: {
+            fs: { read: [...YAML_CONFIG_GLOBS] },
+            net: { mode: 'none' },
+            timeMs: 10_000,
+          },
+        },
         handler: async ({ scope }) => {
           const found = await findScopePath(scope, cwd);
           return { scope, path: found, defaultPath: scopeDefaultPath(scope, cwd) };
@@ -134,6 +154,13 @@ export function buildConfigPlugin(
           'Return the raw text of the moxxy config at the given scope (defaults to "project"). ' +
           'Useful when the agent needs to inspect or edit it.',
         inputSchema: z.object({ scope: scopeSchemaOptional }),
+        isolation: {
+          capabilities: {
+            fs: { read: [...YAML_CONFIG_GLOBS] },
+            net: { mode: 'none' },
+            timeMs: 10_000,
+          },
+        },
         handler: async ({ scope }) => {
           const found = await findScopePath(scope, cwd);
           if (!found) return { scope, path: null, text: '' };
@@ -146,6 +173,17 @@ export function buildConfigPlugin(
         description:
           'Read a single value from the config by dot-path (e.g. "provider.model"). Returns the parsed JSON value.',
         inputSchema: z.object({ scope: scopeSchemaOptional, path: z.string().min(1) }),
+        // `$cwd/*`: the `path` INPUT is a dot-path ("provider.model"), not a
+        // file, but the cap checker's key heuristic treats it as one and
+        // resolves it against cwd — cover that single-segment resolution so
+        // legitimate reads aren't denied. The real fs surface is the globs.
+        isolation: {
+          capabilities: {
+            fs: { read: [...YAML_CONFIG_GLOBS, '$cwd/*'] },
+            net: { mode: 'none' },
+            timeMs: 10_000,
+          },
+        },
         handler: async ({ scope, path: dotPath }) => {
           const found = await findScopePath(scope, cwd);
           if (!found) return null;
@@ -175,6 +213,17 @@ export function buildConfigPlugin(
           value: z.string(),
         }),
         permission: { action: 'prompt' },
+        // Comment-preserving read-modify-write of the YAML config. `$cwd/*`
+        // covers the dot-path `path` input, which the cap checker's key
+        // heuristic resolves against cwd (see config_get). The live applier
+        // is a host-owned closure; its runtime effects are the host's.
+        isolation: {
+          capabilities: {
+            fs: { read: [...YAML_CONFIG_GLOBS, '$cwd/*'], write: [...YAML_CONFIG_GLOBS] },
+            net: { mode: 'none' },
+            timeMs: 30_000,
+          },
+        },
         handler: async ({ scope, path: dotPath, value }) => {
           // ONE write implementation for every surface: the shared
           // schema-validated, comment-preserving, mutex-serialized writer
@@ -212,6 +261,19 @@ export function buildConfigPlugin(
         description:
           'Re-read the merged config from disk and apply the safe subset of changes (mode, compactor, plugin enable/disable) to the active session. Anything outside that subset is reported in `pending` and requires a restart.',
         inputSchema: z.object({}),
+        // loadConfig may execute a .ts/.js config via jiti, whose compile
+        // cache lands under node_modules/.cache. The applier is a host-owned
+        // closure; its runtime effects (plugin load/unload) are the host's.
+        isolation: {
+          capabilities: {
+            fs: {
+              read: [...LOADER_CONFIG_GLOBS],
+              write: ['/**/node_modules/.cache/**', '/tmp/**'],
+            },
+            net: { mode: 'none' },
+            timeMs: 30_000,
+          },
+        },
         handler: async () => {
           if (!applier) {
             return { applied: [], pending: ['(no runtime applier configured)'] };
@@ -226,6 +288,16 @@ export function buildConfigPlugin(
           'Create a starter moxxy config file at the given scope (yaml format), if one does not already exist.',
         inputSchema: z.object({ scope: scopeSchema }),
         permission: { action: 'prompt' },
+        isolation: {
+          capabilities: {
+            fs: {
+              read: [...YAML_CONFIG_GLOBS],
+              write: ['~/.moxxy/config.yaml', '$cwd/moxxy.config.yaml'],
+            },
+            net: { mode: 'none' },
+            timeMs: 30_000,
+          },
+        },
         handler: async ({ scope }) =>
           writeMutex.run(async () => {
             const existing = await findScopePath(scope, cwd);
@@ -262,6 +334,18 @@ plugins:
         description:
           'Re-run schema validation on the merged config (user + project) without applying any changes. Returns ok or the list of issues.',
         inputSchema: z.object({}),
+        // Same surface as config_reload: loadConfig may execute a .ts/.js
+        // config via jiti (compile cache under node_modules/.cache).
+        isolation: {
+          capabilities: {
+            fs: {
+              read: [...LOADER_CONFIG_GLOBS],
+              write: ['/**/node_modules/.cache/**', '/tmp/**'],
+            },
+            net: { mode: 'none' },
+            timeMs: 30_000,
+          },
+        },
         handler: async () => {
           try {
             await loadConfig({ cwd });

--- a/packages/core/src/skills/synthesize.ts
+++ b/packages/core/src/skills/synthesize.ts
@@ -213,6 +213,14 @@ export function buildSynthesizeSkillPlugin(
   session: Session,
   opts: SynthesizeOptions = {},
 ): Plugin {
+  // Capability fs globs for the tools below, resolved from the same option
+  // fallbacks the handlers use. The audit JSONL defaults under the DEFAULT
+  // user skills dir even when `userDir` is overridden (see synthesizeSkill).
+  const userSkillsGlob = `${opts.userDir ?? defaultUserSkillsDir()}/**`;
+  const projectSkillsGlob = `${opts.projectDir ?? defaultProjectSkillsDir(session.cwd)}/**`;
+  const auditGlob = opts.auditPath
+    ? `${path.dirname(opts.auditPath)}/**`
+    : `${defaultUserSkillsDir()}/**`;
   return definePlugin({
     name: '@moxxy/synthesize-skill',
     version: '0.0.0',
@@ -239,6 +247,19 @@ export function buildSynthesizeSkillPlugin(
             ),
         }),
         permission: { action: 'prompt' },
+        // Drafts the skill body via the active LLMProvider (host is
+        // provider-config dependent, hence net: any), then writes the skill
+        // file + the audit JSONL.
+        isolation: {
+          capabilities: {
+            fs: {
+              read: [auditGlob],
+              write: [userSkillsGlob, projectSkillsGlob, auditGlob],
+            },
+            net: { mode: 'any' },
+            timeMs: 120_000,
+          },
+        },
         handler: async ({ intent, scope }, ctx) => {
           const result = await synthesizeSkill(session, intent, scope, opts, ctx.turnId);
           return {
@@ -262,6 +283,8 @@ export function buildSynthesizeSkillPlugin(
             .min(1)
             .describe('The exact skill name from the "Available skills" list in the system prompt.'),
         }),
+        // Registry lookup — the skill body is already in memory.
+        isolation: { capabilities: { net: { mode: 'none' }, timeMs: 10_000 } },
         handler: async ({ name }, ctx) => {
           const skill = session.skills.byName(name);
           if (!skill) {
@@ -307,6 +330,23 @@ export function buildSynthesizeSkillPlugin(
         // tool inherits the channel resolver's default, which denies in
         // headless runs (the skill-author flow couldn't activate a new skill).
         permission: { action: 'allow' },
+        // Rescans every skill source the boot loader used — the builtin and
+        // plugin dirs live wherever those packages are installed, so they're
+        // covered explicitly from the configured options.
+        isolation: {
+          capabilities: {
+            fs: {
+              read: [
+                userSkillsGlob,
+                projectSkillsGlob,
+                ...(opts.builtinDir ? [`${opts.builtinDir}/**`] : []),
+                ...(opts.pluginDirs ?? []).map((d) => `${d}/**`),
+              ],
+            },
+            net: { mode: 'none' },
+            timeMs: 30_000,
+          },
+        },
         handler: async () => {
           const { discoverSkills } = await import('./loader.js');
           // Discover first, swap second: never empty the registry while
@@ -337,6 +377,8 @@ export function buildSynthesizeSkillPlugin(
           name: z.string().min(1).describe('Exact tool name from the "Loadable tools" index.'),
         }),
         permission: { action: 'allow' },
+        // Registry lookup — the schema inclusion happens on later requests.
+        isolation: { capabilities: { net: { mode: 'none' }, timeMs: 10_000 } },
         handler: ({ name }) => {
           // The call itself is recorded in the log; `applyLazyTools` reads that
           // to include the tool's schema on subsequent requests. Here we just

--- a/packages/mode-goal/src/goal-tools.ts
+++ b/packages/mode-goal/src/goal-tools.ts
@@ -28,6 +28,8 @@ export const goalCompleteTool = defineTool({
       .describe('Concrete proof the goal is met: commands run and their results, files changed, tests passed.'),
   }),
   permission: { action: 'allow' },
+  // Side-effect-free loop signal (see the module comment) — no capabilities.
+  isolation: { capabilities: { net: { mode: 'none' }, timeMs: 10_000 } },
   handler: (input) => {
     const { summary, evidence } = input as { summary: string; evidence?: string[] };
     return {
@@ -52,6 +54,8 @@ export const goalAbandonTool = defineTool({
       .describe('What the user must provide or decide for the goal to continue.'),
   }),
   permission: { action: 'allow' },
+  // Side-effect-free loop signal (see the module comment) — no capabilities.
+  isolation: { capabilities: { net: { mode: 'none' }, timeMs: 10_000 } },
   handler: (input) => {
     const { reason, needsFromUser } = input as { reason: string; needsFromUser?: string };
     return { acknowledged: true, reason, ...(needsFromUser ? { needsFromUser } : {}) };

--- a/packages/plugin-channel-web/src/index.ts
+++ b/packages/plugin-channel-web/src/index.ts
@@ -73,6 +73,19 @@ export function buildWebChannelPlugin(opts: BuildWebChannelOptions = {}): Plugin
             'Choose how the web app surface is exposed: "proxy" (public URL via the self-hosted relay, for remote channels like Telegram) or "none"/"localhost" (loopback only). Persisted to ~/.moxxy/web.json and applied immediately if a surface is live. Use when the user asks to change or disable the tunnel.',
           inputSchema: z.object({ provider: z.string().min(1) }),
           permission: { action: 'prompt' },
+          // Persists the choice, then (re)establishes the tunnel through the
+          // live surface controls — the relay host is config-dependent, so
+          // the net surface is genuinely dynamic.
+          isolation: {
+            capabilities: {
+              fs: {
+                read: [opts.settingsFile ?? '~/.moxxy/web.json'],
+                write: [opts.settingsFile ?? '~/.moxxy/web.json'],
+              },
+              net: { mode: 'any' },
+              timeMs: 60_000,
+            },
+          },
           handler: async ({ provider }) => {
             const name = normalizeTunnelName(provider);
             if (!tunnels.list().includes(name)) {
@@ -92,6 +105,8 @@ export function buildWebChannelPlugin(opts: BuildWebChannelOptions = {}): Plugin
           name: 'web_tunnel_status',
           description: 'Report the active web tunnel provider and the available options.',
           inputSchema: z.object({}),
+          // Pure registry view — no fs / net / subprocess.
+          isolation: { capabilities: { net: { mode: 'none' }, timeMs: 10_000 } },
           handler: () => ({ active: tunnels.active(), available: ['none', ...tunnels.list()] }),
         }),
       ]

--- a/packages/plugin-mcp/src/admin/tools/add.ts
+++ b/packages/plugin-mcp/src/admin/tools/add.ts
@@ -36,6 +36,23 @@ export function buildAddServerTool(deps: AddServerToolDeps): ToolDef {
       'persisted, and it is resolved only at connect time.',
     inputSchema: addServerInput,
     permission: { action: 'prompt' },
+    // Mirrors mcp_test_server's honest surface: the hot-attach spawns the
+    // user-named stdio command (subprocess + broad fs) or connects to an
+    // arbitrary http/sse URL (net: any). On top of that, this tool persists
+    // the entry to ~/.moxxy/mcp.json and writes the auto-generated usage
+    // skill into ~/.moxxy/skills/.
+    isolation: {
+      capabilities: {
+        subprocess: true,
+        fs: {
+          read: ['$cwd/**', '/tmp/**', '~/.moxxy/mcp.json'],
+          write: ['$cwd/**', '/tmp/**', '~/.moxxy/mcp.json', '~/.moxxy/skills/**'],
+        },
+        net: { mode: 'any' },
+        env: ['PATH', 'HOME', 'USER', 'SHELL', 'LANG', 'LC_ALL', 'TERM'],
+        timeMs: 600_000,
+      },
+    },
     handler: async (input) => {
       const server = validateAddServerInput(input);
       const cfg = await readMcpConfig();

--- a/packages/plugin-mcp/src/admin/tools/list.ts
+++ b/packages/plugin-mcp/src/admin/tools/list.ts
@@ -7,6 +7,13 @@ export function buildListServersTool(): ToolDef {
     description:
       'List every MCP server currently registered in ~/.moxxy/mcp.json. Returns name + transport kind + connection details (command/url) for each.',
     inputSchema: z.object({}),
+    isolation: {
+      capabilities: {
+        fs: { read: ['~/.moxxy/mcp.json'] },
+        net: { mode: 'none' },
+        timeMs: 10_000,
+      },
+    },
     handler: async () => {
       const cfg = await readMcpConfig();
       return cfg.servers.map((s) =>

--- a/packages/plugin-mcp/src/admin/tools/remove.ts
+++ b/packages/plugin-mcp/src/admin/tools/remove.ts
@@ -15,6 +15,16 @@ export function buildRemoveServerTool(deps: RemoveServerToolDeps): ToolDef {
       'The tools become uncallable immediately and the entry is gone on next restart.',
     inputSchema: z.object({ name: serverNameSchema }),
     permission: { action: 'prompt' },
+    // Rewrites ~/.moxxy/mcp.json; the runtime detach only CLOSES the existing
+    // client (kills a stdio child / aborts an http socket) — it never spawns
+    // or opens anything new.
+    isolation: {
+      capabilities: {
+        fs: { read: ['~/.moxxy/mcp.json'], write: ['~/.moxxy/mcp.json'] },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async ({ name }) => {
       // Read-modify-write under the shared config mutex so a concurrent
       // add/remove can't clobber the file.

--- a/packages/plugin-memory/src/consolidate.ts
+++ b/packages/plugin-memory/src/consolidate.ts
@@ -496,6 +496,16 @@ function makeMemoryConsolidatePlugin(
           dryRun: z.boolean().optional().default(false),
         }),
         permission: { action: 'prompt' },
+        isolation: {
+          capabilities: {
+            fs: { read: ['~/.moxxy/memory/**'], write: ['~/.moxxy/memory/**'] },
+            // Each cluster merge streams from the active LLMProvider; the
+            // inproc isolator can't pin the host (provider-config dependent).
+            net: { mode: 'any' },
+            // Many clusters × the 60s per-cluster provider-stream bound.
+            timeMs: 600_000,
+          },
+        },
         handler: async ({ tag, dryRun }) => {
           const outcome = await consolidateMemory(getStore(), getProvider(), {
             ...(tag ? { tag } : {}),
@@ -508,6 +518,13 @@ function makeMemoryConsolidatePlugin(
         name: 'memory_consolidate_plan',
         description: 'Return the consolidation plan (clusters that would be merged) without invoking the model.',
         inputSchema: z.object({ tag: z.string().optional() }),
+        isolation: {
+          capabilities: {
+            fs: { read: ['~/.moxxy/memory/**'] },
+            net: { mode: 'none' },
+            timeMs: 15_000,
+          },
+        },
         handler: async ({ tag }) => {
           const all = await getStore().list();
           return planConsolidation(all, { ...(tag ? { tag } : {}) });

--- a/packages/plugin-plugins-admin/src/defaults.ts
+++ b/packages/plugin-plugins-admin/src/defaults.ts
@@ -50,6 +50,8 @@ export function buildListDefaultsTool(deps: CategoryDefaultsDeps) {
       'Use before set_default to see the valid options per category.',
     inputSchema: z.object({}),
     permission: { action: 'allow' },
+    // Pure registry view — no fs / net / subprocess.
+    isolation: { capabilities: { net: { mode: 'none' }, timeMs: 10_000 } },
     handler: async () => ({ categories: deps.categories() }),
   });
 }

--- a/packages/plugin-plugins-admin/src/toggle.ts
+++ b/packages/plugin-plugins-admin/src/toggle.ts
@@ -33,6 +33,15 @@ export function buildDisablePluginTool(deps: PluginToggleDeps) {
         .describe('Plugin package name to disable, e.g. @moxxy/plugin-browser.'),
     }),
     permission: { action: 'prompt' },
+    // Persists the enabled flag (mirrors set_default); the live unload is an
+    // in-memory registry operation.
+    isolation: {
+      capabilities: {
+        fs: { write: ['~/.moxxy/config.yaml'] },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async ({ packageName }) => {
       const before = deps.snapshot();
       await deps.setEnabled(packageName, false);
@@ -61,6 +70,15 @@ export function buildEnablePluginTool(deps: PluginToggleDeps) {
         .describe('Plugin package name to enable, e.g. @moxxy/plugin-browser.'),
     }),
     permission: { action: 'prompt' },
+    // Persists the enabled flag; re-enabling an INSTALLED plugin re-discovers
+    // (imports) its code from the user plugin dir, hence the read glob.
+    isolation: {
+      capabilities: {
+        fs: { read: ['~/.moxxy/plugins/**'], write: ['~/.moxxy/config.yaml'] },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async ({ packageName }) => {
       const before = deps.snapshot();
       await deps.setEnabled(packageName, true);

--- a/packages/plugin-provider-admin/src/index.ts
+++ b/packages/plugin-provider-admin/src/index.ts
@@ -410,6 +410,9 @@ export function buildProviderAdminPlugin(
 ): Plugin {
   const engine = sharedEngine ?? createProviderAdminEngine(opts);
   const { providerRegistry, configPath } = engine;
+  // Stored vendors persist in the unified user config (or the injected
+  // override path in tests) — the fs surface of every tool below.
+  const configGlob = configPath ?? '~/.moxxy/config.yaml';
 
   return definePlugin({
     name: '@moxxy/plugin-provider-admin',
@@ -425,6 +428,17 @@ export function buildProviderAdminPlugin(
           'or set it as the default in moxxy.config.ts.',
         inputSchema: addProviderInput,
         permission: { action: 'prompt' },
+        // The handler performs NO network I/O itself (register + persist
+        // only), but the input carries the vendor `baseURL` — an arbitrary,
+        // caller-chosen endpoint the cap checker validates against `net` —
+        // so 'any' reflects the genuinely dynamic vendor host.
+        isolation: {
+          capabilities: {
+            fs: { read: [configGlob], write: [configGlob] },
+            net: { mode: 'any' },
+            timeMs: 30_000,
+          },
+        },
         handler: async (input) => {
           if (engine.isBuiltin(input.name)) {
             throw new MoxxyError({
@@ -478,6 +492,13 @@ export function buildProviderAdminPlugin(
           'List user-registered providers (persisted in the unified config (plugins.provider.items)) plus their default model and base URL. ' +
           'Built-in providers (anthropic, openai, openai-codex) are NOT included — query session.providers for those.',
         inputSchema: z.object({}),
+        isolation: {
+          capabilities: {
+            fs: { read: [configGlob] },
+            net: { mode: 'none' },
+            timeMs: 10_000,
+          },
+        },
         handler: async () => {
           const cfg = await readProvidersConfig(configPath);
           return {
@@ -500,6 +521,13 @@ export function buildProviderAdminPlugin(
           'Does NOT delete the stored API key — call vault_delete name=<NAME>_API_KEY separately if you also want to drop the credential.',
         inputSchema: removeProviderInput,
         permission: { action: 'prompt' },
+        isolation: {
+          capabilities: {
+            fs: { read: [configGlob], write: [configGlob] },
+            net: { mode: 'none' },
+            timeMs: 30_000,
+          },
+        },
         handler: async ({ name }) => {
           // Removing the ACTIVE provider leaves the registry with active=null, so
           // the next turn fails with a "no active provider" error. Mirror the
@@ -537,6 +565,15 @@ export function buildProviderAdminPlugin(
           '{ ok: false, message } with the vendor error verbatim.',
         inputSchema: testProviderInput,
         permission: { action: 'prompt' },
+        // Probes a caller-supplied endpoint (`baseURL`/v1/models) — the host
+        // is genuinely dynamic. The key comes via the brokered ctx.getSecret,
+        // not from fs or env.
+        isolation: {
+          capabilities: {
+            net: { mode: 'any' },
+            timeMs: 60_000,
+          },
+        },
         // The plaintext key is resolved HERE, at call time, via ctx.getSecret —
         // it never appears as tool input/output, so it stays out of the model
         // context, the runner session log, and the desktop NDJSON log.

--- a/packages/plugin-subagents/src/dispatch-agent.ts
+++ b/packages/plugin-subagents/src/dispatch-agent.ts
@@ -142,6 +142,11 @@ export function buildDispatchAgentTool(deps: DispatchAgentDeps) {
         })
         .describe('Specs for the agents to spawn. Run in parallel; results returned in order.'),
     }),
+    // The handler itself only resolves specs and delegates to the session's
+    // subagent spawner (ctx.subagents); each child's provider/tool traffic
+    // runs in its own session under its own tools' declarations. No timeMs:
+    // a legitimate research batch can run far longer than any fixed bound.
+    isolation: { capabilities: { net: { mode: 'none' } } },
     handler: async (input, ctx) => {
       if (!ctx.subagents) {
         throw new MoxxyError({

--- a/packages/plugin-telegram/src/index.ts
+++ b/packages/plugin-telegram/src/index.ts
@@ -217,6 +217,15 @@ function makeTelegramPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks):
           token: z.string().regex(/^\d+:[A-Za-z0-9_-]{20,}$/, 'token must look like 1234567890:ABC...'),
         }),
         permission: { action: 'prompt' },
+        // Vault writes land in ~/.moxxy/vault.json (key material in
+        // ~/.moxxy/vault.key) — hence the vault.* glob.
+        isolation: {
+          capabilities: {
+            fs: { read: ['~/.moxxy/vault.*'], write: ['~/.moxxy/vault.*'] },
+            net: { mode: 'none' },
+            timeMs: 10_000,
+          },
+        },
         handler: async ({ token }) => {
           await getVault().set(TOKEN_KEY, token, ['telegram']);
           return `stored Telegram token (${token.split(':')[0]}:…) in vault`;
@@ -226,6 +235,13 @@ function makeTelegramPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks):
         name: 'telegram_status',
         description: 'Report whether a Telegram token + an authorized chat are configured.',
         inputSchema: z.object({}),
+        isolation: {
+          capabilities: {
+            fs: { read: ['~/.moxxy/vault.*'] },
+            net: { mode: 'none' },
+            timeMs: 10_000,
+          },
+        },
         handler: async () => {
           const hasToken = await getVault().has(TOKEN_KEY);
           const authorized = await getVault().get(AUTHORIZED_CHAT_KEY);
@@ -255,6 +271,14 @@ function makeTelegramPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks):
           parseMode: z.enum(['MarkdownV2', 'Markdown', 'HTML']).optional(),
         }),
         permission: { action: 'prompt' },
+        isolation: {
+          capabilities: {
+            fs: { read: ['~/.moxxy/vault.*'] },
+            net: { mode: 'allowlist', hosts: ['api.telegram.org'] },
+            env: ['MOXXY_TELEGRAM_TOKEN'],
+            timeMs: 60_000,
+          },
+        },
         handler: async ({ text, chatId, parseMode }) => {
           const token = process.env.MOXXY_TELEGRAM_TOKEN ?? (await getVault().get(TOKEN_KEY));
           if (!token) {
@@ -303,6 +327,13 @@ function makeTelegramPlugin(getVault: () => VaultStore, hooks?: LifecycleHooks):
         description: 'Forget the currently authorized Telegram chat. The next /start will start a fresh pairing.',
         inputSchema: z.object({}),
         permission: { action: 'prompt' },
+        isolation: {
+          capabilities: {
+            fs: { read: ['~/.moxxy/vault.*'], write: ['~/.moxxy/vault.*'] },
+            net: { mode: 'none' },
+            timeMs: 10_000,
+          },
+        },
         handler: async () => {
           const removed = await getVault().delete(AUTHORIZED_CHAT_KEY);
           return removed ? 'unpaired' : 'no pairing was active';

--- a/packages/plugin-terminal/src/terminal.ts
+++ b/packages/plugin-terminal/src/terminal.ts
@@ -201,6 +201,20 @@ export function buildTerminalTool() {
       'Use this to run applications or commands for the user (builds, scripts, CLIs). ' +
       'For long-running/interactive programs, expect partial output up to the timeout.',
     inputSchema: terminalInputSchema,
+    // Bash-class honest caps: this drives a real shell (node-pty), so the
+    // command can touch anything the user could. The shared shell deliberately
+    // inherits the FULL runner env (see the SECURITY note in pty.ts); the env
+    // list below is the shell-relevant subset an enforcing isolator should
+    // provide when it re-spawns under a constrained env.
+    isolation: {
+      capabilities: {
+        subprocess: true,
+        fs: { read: ['$cwd/**', '/tmp/**'], write: ['$cwd/**', '/tmp/**'] },
+        net: { mode: 'any' },
+        env: ['PATH', 'HOME', 'USER', 'SHELL', 'COMSPEC', 'LANG', 'LC_ALL', 'TERM'],
+        timeMs: 600_000,
+      },
+    },
     handler: async (input, ctx) => {
       const proc = await getSharedTerminal(ctx.cwd ?? process.cwd());
       const timeoutMs = input.timeoutMs ?? 30_000;

--- a/packages/plugin-view/src/index.ts
+++ b/packages/plugin-view/src/index.ts
@@ -88,6 +88,9 @@ export function buildViewPlugin(opts: BuildViewPluginOptions, hooks?: LifecycleH
         .optional()
         .describe('Plain-text summary shown on channels that cannot render views.'),
     }),
+    // Parse + validate in-memory; delivery to the web surface happens outside
+    // the handler (the channel's projector observes the tool_result).
+    isolation: { capabilities: { net: { mode: 'none' }, timeMs: 10_000 } },
     handler: (input, ctx?: ToolContext): PresentViewResult => {
       // Short-circuit a cancelled turn before the heaviest work (parse + count
       // + AST serialization on a near-20k spec). ctx is optional only so unit

--- a/packages/plugin-voice-admin/src/index.ts
+++ b/packages/plugin-voice-admin/src/index.ts
@@ -70,6 +70,8 @@ function makeVoiceAdminPlugin(
           'plugin synthesizer active).',
         inputSchema: z.object({}),
         permission: { action: 'allow' },
+        // Pure registry view — no fs / net / subprocess.
+        isolation: { capabilities: { net: { mode: 'none' }, timeMs: 10_000 } },
         handler: () => ({
           active: getSynths().getActiveName() ?? 'system',
           available: voiceNames(),
@@ -94,6 +96,9 @@ function makeVoiceAdminPlugin(
         // network call happens at set_voice time — the first read-aloud builds
         // it under the same vault/network gates a registered plugin already has.
         permission: { action: 'allow' },
+        // Flips the registry's active slot only — the synthesizer is not
+        // built here (see the permission note above), so no secret/net work.
+        isolation: { capabilities: { net: { mode: 'none' }, timeMs: 10_000 } },
         handler: ({ synthesizer }) => {
           // Treat 'system' as the OS-voice sentinel only when no real
           // synthesizer claims that name. A backend literally named 'system'


### PR DESCRIPTION
Wave 3/3 of the capability backfill: every remaining `defineTool` in the admin + long-tail plugins now declares an honest `isolation: { capabilities }` spec. With the built-ins (wave 1) and the high-traffic plugins (wave 2) already declared, the full tool surface is covered — this unlocks flipping `security.requireDeclaration` on.

## Honesty rules applied

- Every declaration was written from the handler's actual code paths (including the helpers it calls), never from the tool description.
- Never under-declared: where a surface is genuinely dynamic (provider-config-dependent LLM host, caller-supplied endpoint, arbitrary stdio command) the cap says so (`net: any`, `subprocess: true`) with a comment explaining why.
- Narrow where certain: pure registry/loop tools get `net: none` + a small `timeMs`; file-touching tools declare the exact globs (`~/.moxxy/...`, `$cwd/...`, basename-anchored globs for the bounded upward config walk).
- Host-owned brokered closures (session event log, live config applier, subagent spawner) are not claimed as the tool's own capability — noted in comments where it could surprise.
- No `required` strength or `handlerModule` added anywhere (per convention, only where a file already used them).

## Per-plugin summary

**@moxxy/plugin-plugins-admin** (3)
- `list_defaults` — pure registry view: `net: none`
- `enable_plugin` — writes `~/.moxxy/config.yaml`; re-enabling an installed plugin re-discovers its code, so `read: ~/.moxxy/plugins/**`
- `disable_plugin` — writes `~/.moxxy/config.yaml`; live unload is in-memory

**@moxxy/plugin-mcp** (3)
- `mcp_add_server` — mirrors `mcp_test_server`'s honest surface (hot-attach spawns the user-named stdio command / connects to an arbitrary URL: `subprocess` + broad fs + `net: any`), plus `~/.moxxy/mcp.json` and the auto-generated usage skill in `~/.moxxy/skills/`
- `mcp_list_servers` — `read: ~/.moxxy/mcp.json` only
- `mcp_remove_server` — rewrites `mcp.json`; detach only closes existing clients (no spawn, no new connections): `net: none`

**@moxxy/config** (7)
- `config_path` / `config_show` / `config_get` — read-only over the YAML configs; the project config can resolve in an ancestor dir (bounded upward walk), so globs anchor on the well-known basenames (`/**/moxxy.config.yaml`) instead of `$cwd`
- `config_get` / `config_set` — also carry `$cwd/*` because the `path` input is a dot-path the cap checker's key heuristic resolves against cwd (documented inline)
- `config_set` / `config_init` — write the YAML config at either scope
- `config_reload` / `config_validate` — `loadConfig` may execute a `.ts/.js` config via jiti (compile cache under `node_modules/.cache`), hence the cache write glob

**@moxxy/plugin-provider-admin** (4)
- `provider_add` — persists to the unified user config; performs no network I/O itself, but the input carries the arbitrary vendor `baseURL` the checker validates against `net`, so `net: any` (documented inline)
- `provider_list` — config read only
- `provider_remove` — config read/write, `net: none`
- `provider_test` — probes the caller-supplied endpoint: `net: any`, 60s; key comes via brokered `ctx.getSecret` (no fs/env)

**@moxxy/plugin-memory** (2)
- `memory_consolidate` — `~/.moxxy/memory/**` read/write + `net: any` (per-cluster LLM stream) + 600s (many clusters × the 60s per-cluster bound)
- `memory_consolidate_plan` — memory read only, `net: none`

**@moxxy/plugin-voice-admin** (2) — `list_voices` / `set_voice` flip/inspect the registry's active slot only: `net: none`

**@moxxy/core** (4, purely additive)
- `synthesize_skill` — LLM draft (`net: any`, provider-config-dependent host) + skill file and audit JSONL writes under the configured skills dirs
- `load_skill` / `load_tool` — registry lookups: `net: none`
- `reload_skills` — reads every configured skill source (user/project/builtin/plugin dirs), `net: none`

**@moxxy/mode-goal** (2) — `goal_complete` / `goal_abandon` are side-effect-free loop signals: `net: none`

**@moxxy/plugin-view** (1) — `present_view` parses/validates in-memory; delivery happens outside the handler: `net: none`

**@moxxy/plugin-terminal** (1) — `terminal` is Bash-class: drives a real user-visible shell (`subprocess`, broad fs, `net: any`, shell env subset, 600s). The shared shell deliberately inherits the full runner env (pty.ts SECURITY note) — the declared env list is what a re-spawning isolator should provide.

**@moxxy/plugin-subagents** (1) — `dispatch_agent` only resolves specs and delegates to the session's spawner; children run under their own tools' declarations. `net: none`, no `timeMs` (legitimate batches run long).

**@moxxy/plugin-channel-web** (2)
- `web_set_tunnel` — persists `~/.moxxy/web.json` + re-establishes the tunnel to the config-dependent relay: `net: any`
- `web_tunnel_status` — registry view: `net: none`

**@moxxy/plugin-telegram** (4)
- `telegram_set_token` / `telegram_unpair` — vault read/write (`~/.moxxy/vault.*`), `net: none`
- `telegram_status` — vault read only
- `telegram_send_message` — vault read + `env: MOXXY_TELEGRAM_TOKEN` + `net: allowlist(api.telegram.org)`

## Verification

`pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm test` (132/132 tasks), `pnpm check:deps` — all green. No count-asserting tests needed updating (the security-matrix tests use synthetic tools).

Changeset: patch bumps for all 13 touched packages.
