### PR TITLE
feat(security): declare tool capabilities — automation plugins (collab, webhooks, workflows, scheduler)

### DIFF
--- a/.changeset/caps-backfill-automation.md
+++ b/.changeset/caps-backfill-automation.md
@@ -1,0 +1,8 @@
+---
+'@moxxy/plugin-collab': patch
+'@moxxy/plugin-webhooks': patch
+'@moxxy/plugin-workflows': patch
+'@moxxy/plugin-scheduler': patch
+---
+
+Declare `isolation` capability specs on every collab, webhooks, workflows, and scheduler tool (wave 2/3 of the capability backfill toward `security.requireDeclaration`).

--- a/packages/plugin-collab/src/tools.ts
+++ b/packages/plugin-collab/src/tools.ts
@@ -5,12 +5,53 @@
  * is the hub's job, so these tools never carry an agent id.
  */
 
-import { defineTool, type ToolDef } from '@moxxy/sdk';
+import { defineTool, type ToolDef, type ToolIsolationSpec } from '@moxxy/sdk';
 import { z } from 'zod';
 import { getProcessHubClient } from './process-client.js';
 
 const NOT_IN_COLLAB = {
   error: 'Not in a collaboration. The collab_* tools only work for an agent running inside an agentic-collaborative team.',
+};
+
+/**
+ * Every collab_* tool is a thin JSON-RPC round-trip over the hub's unix
+ * socket (`$MOXXY_COLLAB_HUB`, under `~/.moxxy/collab/<runId>/`): no TCP
+ * network and no subprocesses — peer spawning lives in
+ * `@moxxy/mode-collaborative`, not in these handlers. The fs grant covers
+ * the socket path an fs-sandboxing isolator must let the client dial.
+ */
+const HUB_RPC_ISOLATION: ToolIsolationSpec = {
+  capabilities: {
+    fs: { read: ['~/.moxxy/collab/**'], write: ['~/.moxxy/collab/**'] },
+    net: { mode: 'none' },
+    env: ['MOXXY_COLLAB_HUB', 'MOXXY_COLLAB_AGENT_ID', 'MOXXY_RUNNER_SOCKET'],
+    timeMs: 30_000,
+  },
+};
+
+/**
+ * Variant for tools whose INPUT carries workspace file paths (claims,
+ * contract artifacts): the cap checker validates path-shaped inputs against
+ * `fs`, so the workspace must be in scope even though the paths only travel
+ * to the hub as data — this process never opens them.
+ */
+const HUB_RPC_WORKSPACE_ISOLATION: ToolIsolationSpec = {
+  capabilities: {
+    ...HUB_RPC_ISOLATION.capabilities,
+    fs: { read: ['$cwd/**', '~/.moxxy/collab/**'], write: ['~/.moxxy/collab/**'] },
+  },
+};
+
+/**
+ * Peer-inspection tools: same hub RPC, but the hub answers by reading files
+ * or running git (status/diff) in the peer's worktree, so a round-trip can
+ * legitimately take much longer than a board/messaging call.
+ */
+const HUB_RPC_PEER_ISOLATION: ToolIsolationSpec = {
+  capabilities: {
+    ...HUB_RPC_WORKSPACE_ISOLATION.capabilities,
+    timeMs: 120_000,
+  },
 };
 
 const collabSend = defineTool({
@@ -23,6 +64,7 @@ const collabSend = defineTool({
     subject: z.string().optional(),
   }),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_ISOLATION,
   handler: async ({ to, body, subject }) => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -35,6 +77,7 @@ const collabBroadcast = defineTool({
   description: 'Broadcast a message to the whole team (everyone\'s inbox). Use for status updates and announcements.',
   inputSchema: z.object({ body: z.string().min(1), subject: z.string().optional() }),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_ISOLATION,
   handler: async ({ body, subject }) => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -47,6 +90,7 @@ const collabInbox = defineTool({
   description: 'Read messages addressed to you (and team broadcasts) since you last checked. Call this at the start of each work cycle.',
   inputSchema: z.object({}),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_ISOLATION,
   handler: async () => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -60,6 +104,7 @@ const collabRoster = defineTool({
   description: 'List the team: every agent\'s id, role, sub-task, and current status. Use to learn who to coordinate with.',
   inputSchema: z.object({}),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_ISOLATION,
   handler: async () => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -72,6 +117,7 @@ const collabBoard = defineTool({
   description: 'Read the shared task board: items, statuses, owners, and claimed file paths.',
   inputSchema: z.object({}),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_ISOLATION,
   handler: async () => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -88,6 +134,7 @@ const collabAddTask = defineTool({
     paths: z.array(z.string()).optional(),
   }),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_WORKSPACE_ISOLATION,
   handler: async ({ title, detail, paths }) => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -104,6 +151,7 @@ const collabClaim = defineTool({
     id: z.string().optional().describe('Existing board item to attach the claim to'),
   }),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_WORKSPACE_ISOLATION,
   handler: async ({ paths, id }) => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -124,6 +172,7 @@ const collabRelease = defineTool({
   description: 'Release a file claim (or a board item) when you are done editing, so others can pick it up.',
   inputSchema: z.object({ id: z.string().optional(), paths: z.array(z.string()).optional() }),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_WORKSPACE_ISOLATION,
   handler: async ({ id, paths }) => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -140,6 +189,7 @@ const collabUpdate = defineTool({
     detail: z.string().optional(),
   }),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_ISOLATION,
   handler: async ({ id, status, detail }) => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -152,6 +202,7 @@ const collabDone = defineTool({
   description: 'Declare YOUR sub-task complete and verified. Provide a short summary (and any artifact paths). The run ends when everyone is done.',
   inputSchema: z.object({ summary: z.string().min(1), artifacts: z.array(z.string()).optional() }),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_ISOLATION,
   handler: async ({ summary, artifacts }) => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -164,6 +215,7 @@ const collabContracts = defineTool({
   description: 'List the shared contracts (agreed interfaces/boundaries) you must build to, with owner, consumers, and status.',
   inputSchema: z.object({}),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_ISOLATION,
   handler: async () => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -183,6 +235,7 @@ const collabContractPublish = defineTool({
     artifactPath: z.string().optional(),
   }),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_WORKSPACE_ISOLATION,
   handler: async (input) => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -196,6 +249,7 @@ const collabContractProposeChange = defineTool({
     'Propose a change to a shared contract. The owner and consumers are asked to ack; do NOT change a shared boundary unilaterally.',
   inputSchema: z.object({ id: z.string(), newSpec: z.string().min(1), reason: z.string().min(1) }),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_ISOLATION,
   handler: async ({ id, newSpec, reason }) => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -208,6 +262,7 @@ const collabContractAck = defineTool({
   description: 'Acknowledge a proposed contract change you were asked about. When owner + all consumers ack, the architect commits it.',
   inputSchema: z.object({ id: z.string() }),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_ISOLATION,
   handler: async ({ id }) => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -220,6 +275,7 @@ const collabPeerFiles = defineTool({
   description: 'List the files another agent has changed so far (their actual in-progress work).',
   inputSchema: z.object({ agentId: z.string() }),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_PEER_ISOLATION,
   handler: async ({ agentId }) => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -232,6 +288,7 @@ const collabPeerRead = defineTool({
   description: 'Read a file from another agent\'s in-progress work — get their real interface instead of guessing.',
   inputSchema: z.object({ agentId: z.string(), path: z.string() }),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_PEER_ISOLATION,
   handler: async ({ agentId, path }) => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;
@@ -244,6 +301,7 @@ const collabPeerDiff = defineTool({
   description: 'View another agent\'s full diff (vs the shared base) to see exactly what they have built.',
   inputSchema: z.object({ agentId: z.string() }),
   permission: { action: 'allow' },
+  isolation: HUB_RPC_PEER_ISOLATION,
   handler: async ({ agentId }) => {
     const c = await getProcessHubClient();
     if (!c) return NOT_IN_COLLAB;

--- a/packages/plugin-scheduler/src/tools.ts
+++ b/packages/plugin-scheduler/src/tools.ts
@@ -5,6 +5,14 @@ import { nextCronFire } from './poller.js';
 import { runSchedule, type InboxOptions, type SchedulePromptRunner } from './runner.js';
 import type { ScheduleEntry, ScheduleStore } from './store.js';
 
+/**
+ * Capability glob for the schedule store (`isolation.capabilities.fs`). Ends
+ * in `*` because the store quarantine-renames a corrupt file to
+ * `schedules.json.corrupt-<ts>` on ANY access — so even a read-only tool may
+ * legitimately write next to the file.
+ */
+const SCHEDULES_STORE_GLOB = '~/.moxxy/schedules.json*';
+
 const cronOrTimestamp = z
   .object({
     cron: z.string().optional(),
@@ -116,6 +124,13 @@ export function buildSchedulerTools(deps: SchedulerToolDeps): ReadonlyArray<Tool
         })
         .and(cronOrTimestamp),
       permission: { action: 'prompt' },
+      isolation: {
+        capabilities: {
+          fs: { read: [SCHEDULES_STORE_GLOB], write: [SCHEDULES_STORE_GLOB] },
+          net: { mode: 'none' },
+          timeMs: 30_000,
+        },
+      },
       handler: async (input) => {
         const runAt =
           typeof input.runAt === 'string' ? Date.parse(input.runAt) : input.runAt;
@@ -158,6 +173,13 @@ export function buildSchedulerTools(deps: SchedulerToolDeps): ReadonlyArray<Tool
         includeDisabled: z.boolean().default(true),
         source: z.enum(['manual', 'skill', 'all']).default('all'),
       }),
+      isolation: {
+        capabilities: {
+          fs: { read: [SCHEDULES_STORE_GLOB], write: [SCHEDULES_STORE_GLOB] },
+          net: { mode: 'none' },
+          timeMs: 30_000,
+        },
+      },
       handler: async ({ includeDisabled, source }) => {
         const entries = await store.list();
         const filtered = entries.filter((e) => {
@@ -177,6 +199,13 @@ export function buildSchedulerTools(deps: SchedulerToolDeps): ReadonlyArray<Tool
         'a durable user-deletion marker so they do not reappear on the next sync.',
       inputSchema: z.object({ id: z.string().min(1) }),
       permission: { action: 'prompt' },
+      isolation: {
+        capabilities: {
+          fs: { read: [SCHEDULES_STORE_GLOB], write: [SCHEDULES_STORE_GLOB] },
+          net: { mode: 'none' },
+          timeMs: 30_000,
+        },
+      },
       handler: async ({ id }) => {
         const ok = await store.delete(id);
         return { deleted: ok };
@@ -187,6 +216,13 @@ export function buildSchedulerTools(deps: SchedulerToolDeps): ReadonlyArray<Tool
       name: 'schedule_enable',
       description: 'Re-enable a previously disabled schedule.',
       inputSchema: z.object({ id: z.string().min(1) }),
+      isolation: {
+        capabilities: {
+          fs: { read: [SCHEDULES_STORE_GLOB], write: [SCHEDULES_STORE_GLOB] },
+          net: { mode: 'none' },
+          timeMs: 30_000,
+        },
+      },
       handler: async ({ id }) => {
         const updated = await store.update(id, { enabled: true });
         if (!updated) return { ok: false, reason: 'no schedule with that id' };
@@ -198,6 +234,13 @@ export function buildSchedulerTools(deps: SchedulerToolDeps): ReadonlyArray<Tool
       name: 'schedule_disable',
       description: 'Pause a schedule without deleting it. Re-enable later with schedule_enable.',
       inputSchema: z.object({ id: z.string().min(1) }),
+      isolation: {
+        capabilities: {
+          fs: { read: [SCHEDULES_STORE_GLOB], write: [SCHEDULES_STORE_GLOB] },
+          net: { mode: 'none' },
+          timeMs: 30_000,
+        },
+      },
       handler: async ({ id }) => {
         const updated = await store.update(id, { enabled: false });
         if (!updated) return { ok: false, reason: 'no schedule with that id' };
@@ -216,6 +259,13 @@ export function buildSchedulerTools(deps: SchedulerToolDeps): ReadonlyArray<Tool
         targetSessionId: z.string().min(1).optional(),
       }),
       permission: { action: 'prompt' },
+      isolation: {
+        capabilities: {
+          fs: { read: [SCHEDULES_STORE_GLOB], write: [SCHEDULES_STORE_GLOB] },
+          net: { mode: 'none' },
+          timeMs: 30_000,
+        },
+      },
       handler: async ({ id, targetSessionId }) => {
         const updated = await store.update(id, { ownerSessionId: targetSessionId });
         if (!updated) return { ok: false, reason: 'no schedule with that id' };
@@ -231,6 +281,21 @@ export function buildSchedulerTools(deps: SchedulerToolDeps): ReadonlyArray<Tool
         'if it had fired at the scheduled time.',
       inputSchema: z.object({ id: z.string().min(1) }),
       permission: { action: 'prompt' },
+      // A manual fire runs the schedule's prompt as a REAL turn on the active
+      // session before returning — model/provider calls happen inside this
+      // handler (hence net 'any' and the generous wall clock). Tools the fired
+      // turn invokes re-enter the session's tool pipeline and are bounded by
+      // their own capability specs, not this one.
+      isolation: {
+        capabilities: {
+          fs: {
+            read: [SCHEDULES_STORE_GLOB],
+            write: [SCHEDULES_STORE_GLOB, '~/.moxxy/inbox/**'],
+          },
+          net: { mode: 'any' },
+          timeMs: 600_000,
+        },
+      },
       handler: async ({ id }) => {
         const entry = await store.get(id);
         if (!entry) throw new Error(`no schedule with id "${id}"`);

--- a/packages/plugin-webhooks/src/tools/create.ts
+++ b/packages/plugin-webhooks/src/tools/create.ts
@@ -8,6 +8,9 @@ import {
   normalizeVerification,
   verificationInputSchema,
   writeSecretFile,
+  WEBHOOKS_CONFIG_GLOB,
+  WEBHOOKS_SECRETS_GLOB,
+  WEBHOOKS_STORE_GLOB,
   type ResolvedToolDeps,
 } from './shared.js';
 
@@ -67,6 +70,21 @@ export function defineWebhookCreateTool(deps: ResolvedToolDeps): ToolDef {
         ),
     }),
     permission: { action: 'prompt' },
+    isolation: {
+      capabilities: {
+        fs: {
+          // `$cwd/**` is for the cap checker, not real reads: a jsonPath
+          // filter rule's `path` ("pull_request.user.login") is a JSON body
+          // path, but the checker's key heuristic treats it as a file path
+          // resolved against cwd — without this scope such filters would be
+          // denied once enforcement is on.
+          read: ['$cwd/**', WEBHOOKS_STORE_GLOB, WEBHOOKS_CONFIG_GLOB],
+          write: [WEBHOOKS_STORE_GLOB, WEBHOOKS_SECRETS_GLOB],
+        },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async (input) => {
       const { verification, secretIssued } = normalizeVerification(input.verification);
       const filters: WebhookFilter = input.filters ?? { include: [], exclude: [] };

--- a/packages/plugin-webhooks/src/tools/delete.ts
+++ b/packages/plugin-webhooks/src/tools/delete.ts
@@ -1,6 +1,11 @@
 import { rm } from 'node:fs/promises';
 import { defineTool, z, type ToolDef } from '@moxxy/sdk';
-import { secretFilePath, type ResolvedToolDeps } from './shared.js';
+import {
+  secretFilePath,
+  WEBHOOKS_SECRETS_GLOB,
+  WEBHOOKS_STORE_GLOB,
+  type ResolvedToolDeps,
+} from './shared.js';
 
 export function defineWebhookDeleteTool(deps: ResolvedToolDeps): ToolDef {
   const { store, secretsDir } = deps;
@@ -12,6 +17,16 @@ export function defineWebhookDeleteTool(deps: ResolvedToolDeps): ToolDef {
       "the source's dashboard, otherwise it'll keep retrying.",
     inputSchema: z.object({ id: z.string().min(1) }),
     permission: { action: 'prompt' },
+    isolation: {
+      capabilities: {
+        fs: {
+          read: [WEBHOOKS_STORE_GLOB],
+          write: [WEBHOOKS_STORE_GLOB, WEBHOOKS_SECRETS_GLOB],
+        },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async ({ id }) => {
       const trigger = await store.get(id);
       const deleted = await store.delete(id);

--- a/packages/plugin-webhooks/src/tools/guide.ts
+++ b/packages/plugin-webhooks/src/tools/guide.ts
@@ -1,6 +1,6 @@
 import { defineTool, z, type ToolDef } from '@moxxy/sdk';
 import { buildSetupGuide } from './setup-guide.js';
-import type { ResolvedToolDeps } from './shared.js';
+import { WEBHOOKS_CONFIG_GLOB, type ResolvedToolDeps } from './shared.js';
 
 export function defineWebhookSetupGuideTool(deps: ResolvedToolDeps): ToolDef {
   const { store, config } = deps;
@@ -13,6 +13,13 @@ export function defineWebhookSetupGuideTool(deps: ResolvedToolDeps): ToolDef {
       'Use this whenever a user wants to wire up a webhook but does NOT know the ' +
       "specifics of the external system's signing scheme, event names, or secret format.",
     inputSchema: z.object({}),
+    isolation: {
+      capabilities: {
+        fs: { read: [WEBHOOKS_CONFIG_GLOB] },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async () => buildSetupGuide({ store, config }),
   });
 }

--- a/packages/plugin-webhooks/src/tools/list.ts
+++ b/packages/plugin-webhooks/src/tools/list.ts
@@ -1,6 +1,6 @@
 import { defineTool, z, type ToolDef } from '@moxxy/sdk';
 import { describeTrigger } from '../describe.js';
-import type { ResolvedToolDeps } from './shared.js';
+import { WEBHOOKS_CONFIG_GLOB, WEBHOOKS_STORE_GLOB, type ResolvedToolDeps } from './shared.js';
 
 export function defineWebhookListTool(deps: ResolvedToolDeps): ToolDef {
   const { store, config } = deps;
@@ -12,6 +12,18 @@ export function defineWebhookListTool(deps: ResolvedToolDeps): ToolDef {
     inputSchema: z.object({
       includeDisabled: z.boolean().default(true),
     }),
+    // Read-only, but the store may quarantine-rename a corrupt file on load —
+    // hence the write grant on the store glob (see shared.ts).
+    isolation: {
+      capabilities: {
+        fs: {
+          read: [WEBHOOKS_STORE_GLOB, WEBHOOKS_CONFIG_GLOB],
+          write: [WEBHOOKS_STORE_GLOB],
+        },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async ({ includeDisabled }) => {
       const triggers = await store.list();
       const cfg = await config.get();

--- a/packages/plugin-webhooks/src/tools/public-url.ts
+++ b/packages/plugin-webhooks/src/tools/public-url.ts
@@ -1,5 +1,10 @@
 import { defineTool, z, type ToolDef } from '@moxxy/sdk';
-import { fullUrl, type ResolvedToolDeps } from './shared.js';
+import {
+  fullUrl,
+  WEBHOOKS_CONFIG_GLOB,
+  WEBHOOKS_STORE_GLOB,
+  type ResolvedToolDeps,
+} from './shared.js';
 
 export function defineWebhookSetPublicUrlTool(deps: ResolvedToolDeps): ToolDef {
   const { store, config } = deps;
@@ -14,6 +19,20 @@ export function defineWebhookSetPublicUrlTool(deps: ResolvedToolDeps): ToolDef {
       publicUrl: z.string().url('publicUrl must be a full URL like https://example.com'),
     }),
     permission: { action: 'prompt' },
+    // The handler only PERSISTS the URL — no request is made. `net` is still
+    // 'any' because the cap checker validates URL-shaped inputs against it,
+    // and the public URL's host is user-chosen (no static allowlist exists);
+    // 'none' would deny every call.
+    isolation: {
+      capabilities: {
+        fs: {
+          read: [WEBHOOKS_STORE_GLOB, WEBHOOKS_CONFIG_GLOB],
+          write: [WEBHOOKS_STORE_GLOB, WEBHOOKS_CONFIG_GLOB],
+        },
+        net: { mode: 'any' },
+        timeMs: 30_000,
+      },
+    },
     handler: async ({ publicUrl }) => {
       const updated = await config.set({ publicUrl, publicUrlSource: 'manual' });
       const triggers = await store.list();
@@ -34,6 +53,13 @@ export function defineWebhookClearPublicUrlTool(deps: ResolvedToolDeps): ToolDef
       'will no longer be able to reach them until a new URL is set.',
     inputSchema: z.object({}),
     permission: { action: 'prompt' },
+    isolation: {
+      capabilities: {
+        fs: { read: [WEBHOOKS_CONFIG_GLOB], write: [WEBHOOKS_CONFIG_GLOB] },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async () => {
       await config.clearPublicUrl();
       return { ok: true };

--- a/packages/plugin-webhooks/src/tools/shared.ts
+++ b/packages/plugin-webhooks/src/tools/shared.ts
@@ -56,6 +56,17 @@ export function defaultWebhookSecretsDir(): string {
   return moxxyPath('webhooks-secrets');
 }
 
+/**
+ * Capability globs the webhook tools declare (`isolation.capabilities.fs`).
+ *
+ * The trigger-store glob ends in `*` because the store quarantine-renames a
+ * corrupt file to `webhooks.json.corrupt-<ts>` / `.quarantine-<ts>` on ANY
+ * access — so even a read-only tool may legitimately write next to the file.
+ */
+export const WEBHOOKS_STORE_GLOB = '~/.moxxy/webhooks.json*';
+export const WEBHOOKS_CONFIG_GLOB = '~/.moxxy/webhooks-config.json';
+export const WEBHOOKS_SECRETS_GLOB = '~/.moxxy/webhooks-secrets/**';
+
 export function generateSecret(): string {
   return randomBytes(32).toString('hex');
 }

--- a/packages/plugin-webhooks/src/tools/status.ts
+++ b/packages/plugin-webhooks/src/tools/status.ts
@@ -1,6 +1,6 @@
 import { defineTool, z, type ToolDef } from '@moxxy/sdk';
 import { isLoopbackHost } from '../config.js';
-import type { ResolvedToolDeps } from './shared.js';
+import { WEBHOOKS_CONFIG_GLOB, WEBHOOKS_STORE_GLOB, type ResolvedToolDeps } from './shared.js';
 
 export function defineWebhookStatusTool(deps: ResolvedToolDeps): ToolDef {
   const { store, config, tunnelHandle } = deps;
@@ -14,6 +14,16 @@ export function defineWebhookStatusTool(deps: ResolvedToolDeps): ToolDef {
       'enabled triggers use verification:"none" (any machine on the network could fire ' +
       'them). Call this as the first step when a user asks for webhook help.',
     inputSchema: z.object({}),
+    isolation: {
+      capabilities: {
+        fs: {
+          read: [WEBHOOKS_STORE_GLOB, WEBHOOKS_CONFIG_GLOB],
+          write: [WEBHOOKS_STORE_GLOB],
+        },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async () => {
       const cfg = await config.get();
       const triggers = await store.list();

--- a/packages/plugin-webhooks/src/tools/test.ts
+++ b/packages/plugin-webhooks/src/tools/test.ts
@@ -1,7 +1,7 @@
 import { defineTool, z, type ToolDef } from '@moxxy/sdk';
 import { shouldFire } from '../filter.js';
 import { renderPrompt } from '../template.js';
-import type { ResolvedToolDeps } from './shared.js';
+import { WEBHOOKS_STORE_GLOB, type ResolvedToolDeps } from './shared.js';
 
 export function defineWebhookTestTool(deps: ResolvedToolDeps): ToolDef {
   const { store, dispatcher } = deps;
@@ -19,6 +19,21 @@ export function defineWebhookTestTool(deps: ResolvedToolDeps): ToolDef {
       headers: z.record(z.string()).default({}),
     }),
     permission: { action: 'prompt' },
+    // A test fire runs the trigger's prompt as a REAL turn on the active
+    // session before returning — model/provider calls happen inside this
+    // handler (hence net 'any' and the generous wall clock). Tools the fired
+    // turn invokes re-enter the session's tool pipeline and are bounded by
+    // their own capability specs, not this one.
+    isolation: {
+      capabilities: {
+        fs: {
+          read: [WEBHOOKS_STORE_GLOB],
+          write: [WEBHOOKS_STORE_GLOB, '~/.moxxy/inbox/webhooks/**'],
+        },
+        net: { mode: 'any' },
+        timeMs: 600_000,
+      },
+    },
     handler: async ({ id, body, headers }) => {
       const trigger = await store.get(id);
       if (!trigger) throw new Error(`no trigger with id "${id}"`);

--- a/packages/plugin-webhooks/src/tools/tunnel.ts
+++ b/packages/plugin-webhooks/src/tools/tunnel.ts
@@ -1,6 +1,11 @@
 import { defineTool, z, type ToolDef } from '@moxxy/sdk';
 import { startTunnel } from '../tunnel.js';
-import { fullUrl, type ResolvedToolDeps } from './shared.js';
+import {
+  fullUrl,
+  WEBHOOKS_CONFIG_GLOB,
+  WEBHOOKS_STORE_GLOB,
+  type ResolvedToolDeps,
+} from './shared.js';
 
 export function defineWebhookTunnelStartTool(deps: ResolvedToolDeps): ToolDef {
   const { store, config, tunnelHandle } = deps;
@@ -14,6 +19,20 @@ export function defineWebhookTunnelStartTool(deps: ResolvedToolDeps): ToolDef {
       'Only one tunnel runs at a time; calling again stops the prior one first.',
     inputSchema: z.object({}),
     permission: { action: 'prompt' },
+    // Dials the proxy relay's control WebSocket (`wss://relay.<host>`); the
+    // host is env-overridable via MOXXY_PROXY_HOST, so no static allowlist.
+    // Also loads-or-mints the tunnel identity keypair on first use.
+    isolation: {
+      capabilities: {
+        fs: {
+          read: [WEBHOOKS_STORE_GLOB, WEBHOOKS_CONFIG_GLOB, '~/.moxxy/proxy-identity.key'],
+          write: [WEBHOOKS_STORE_GLOB, WEBHOOKS_CONFIG_GLOB, '~/.moxxy/proxy-identity.key'],
+        },
+        net: { mode: 'any' },
+        env: ['MOXXY_PROXY_HOST'],
+        timeMs: 60_000,
+      },
+    },
     handler: async () => {
       const cfg = await config.get();
       if (tunnelHandle.current) {
@@ -48,6 +67,15 @@ export function defineWebhookTunnelStopTool(deps: ResolvedToolDeps): ToolDef {
     description: 'Stop the running proxy tunnel started by `webhook_tunnel_start`, if any.',
     inputSchema: z.object({}),
     permission: { action: 'prompt' },
+    // Deregisters the target over the already-open relay connection — still a
+    // network send to the env-overridable relay host, hence 'any'.
+    isolation: {
+      capabilities: {
+        fs: { read: [WEBHOOKS_CONFIG_GLOB], write: [WEBHOOKS_CONFIG_GLOB] },
+        net: { mode: 'any' },
+        timeMs: 60_000,
+      },
+    },
     handler: async () => {
       if (!tunnelHandle.current) return { ok: false, reason: 'no tunnel running' };
       try {

--- a/packages/plugin-webhooks/src/tools/update.ts
+++ b/packages/plugin-webhooks/src/tools/update.ts
@@ -1,6 +1,11 @@
 import { defineTool, z, type ToolDef } from '@moxxy/sdk';
 import { describeTrigger } from '../describe.js';
-import { filterInputSchema, type ResolvedToolDeps } from './shared.js';
+import {
+  filterInputSchema,
+  WEBHOOKS_CONFIG_GLOB,
+  WEBHOOKS_STORE_GLOB,
+  type ResolvedToolDeps,
+} from './shared.js';
 
 export function defineWebhookUpdateTool(deps: ResolvedToolDeps): ToolDef {
   const { store, config } = deps;
@@ -27,6 +32,18 @@ export function defineWebhookUpdateTool(deps: ResolvedToolDeps): ToolDef {
         .describe('Reassign which session this webhook delivers to (where its runs execute + display).'),
     }),
     permission: { action: 'prompt' },
+    isolation: {
+      capabilities: {
+        fs: {
+          // `$cwd/**` mirrors webhook_create: a jsonPath filter rule's `path`
+          // field is a JSON body path the cap checker treats as a file path.
+          read: ['$cwd/**', WEBHOOKS_STORE_GLOB, WEBHOOKS_CONFIG_GLOB],
+          write: [WEBHOOKS_STORE_GLOB],
+        },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async ({ id, targetSessionId, ...patch }) => {
       // `targetSessionId` is the user-facing name for the stored `ownerSessionId`
       // routing key — map it so reassigning a webhook re-homes its deliveries.

--- a/packages/plugin-workflows/src/tools.ts
+++ b/packages/plugin-workflows/src/tools.ts
@@ -52,6 +52,14 @@ export interface WorkflowToolDeps {
 const PLUGIN_ID = asPluginId(WORKFLOWS_PLUGIN_NAME);
 
 /**
+ * On-disk workflow sources the store scans and edits (`isolation` fs globs).
+ * The store also discovers read-only builtin/plugin workflows inside their
+ * package dirs; those live in the plugin host's own module space and have no
+ * stable path to glob, so they are intentionally not listed here.
+ */
+const WORKFLOW_DIR_GLOBS = ['~/.moxxy/workflows/**', '$cwd/.moxxy/workflows/**'];
+
+/**
  * Build a {@link WorkflowRunDeps} for an in-turn run. The spawner comes from
  * the tool context (only present inside a run-turn loop); lifecycle events are
  * tagged to the current turn so the TUI threads them correctly.
@@ -134,6 +142,15 @@ function createTool(deps: WorkflowToolDeps): ToolDef {
       scope: z.enum(['user', 'project']).optional().default('user'),
     }),
     permission: { action: 'prompt' },
+    // Drafting calls the ACTIVE provider's model API — which host that is
+    // depends on the user's configuration, so no static allowlist exists.
+    isolation: {
+      capabilities: {
+        fs: { read: WORKFLOW_DIR_GLOBS, write: WORKFLOW_DIR_GLOBS },
+        net: { mode: 'any' },
+        timeMs: 120_000,
+      },
+    },
     handler: async ({ intent, scope }, ctx) => {
       const provider = deps.provider?.();
       if (!provider) {
@@ -176,6 +193,13 @@ function updateTool(deps: WorkflowToolDeps): ToolDef {
       yaml: z.string().min(1).describe('The complete new workflow YAML.'),
     }),
     permission: { action: 'prompt' },
+    isolation: {
+      capabilities: {
+        fs: { read: WORKFLOW_DIR_GLOBS, write: WORKFLOW_DIR_GLOBS },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async ({ name, yaml }, ctx) => {
       const parsed = parseWorkflowYaml(yaml);
       if (!parsed.ok || !parsed.workflow) {
@@ -200,6 +224,13 @@ function setEnabledTool(deps: WorkflowToolDeps): ToolDef {
       'triggers never fire and it is excluded from auto-runs (it can still be run explicitly).',
     inputSchema: z.object({ name: z.string().min(1), enabled: z.boolean() }),
     permission: { action: 'prompt' },
+    isolation: {
+      capabilities: {
+        fs: { read: WORKFLOW_DIR_GLOBS, write: WORKFLOW_DIR_GLOBS },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async ({ name, enabled }, ctx) => {
       const updated = await deps.store.setEnabled(name, enabled);
       if (!updated) throw new MoxxyError({ code: 'TOOL_ERROR', message: `workflow_set_enabled: no workflow "${name}".` });
@@ -216,6 +247,13 @@ function deleteTool(deps: WorkflowToolDeps): ToolDef {
     description: 'Delete a user/project workflow by name. Builtin/plugin workflows cannot be deleted.',
     inputSchema: z.object({ name: z.string().min(1) }),
     permission: { action: 'prompt' },
+    isolation: {
+      capabilities: {
+        fs: { read: WORKFLOW_DIR_GLOBS, write: WORKFLOW_DIR_GLOBS },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async ({ name }, ctx) => {
       const res = await deps.store.delete(name);
       if (!res.ok) throw new MoxxyError({ code: 'TOOL_ERROR', message: `workflow_delete: ${res.reason}.` });
@@ -239,6 +277,17 @@ function runTool(deps: WorkflowToolDeps): ToolDef {
       inputs: z.record(z.unknown()).optional().describe('Input overrides for this run.'),
     }),
     permission: { action: 'prompt' },
+    // Runs the whole DAG in-process: prompt steps are real subagent model
+    // turns (network), and tool steps re-enter the session's tool pipeline,
+    // where each nested call is bounded by its own capability spec — this
+    // spec covers only what happens directly in this handler's stack.
+    isolation: {
+      capabilities: {
+        fs: { read: WORKFLOW_DIR_GLOBS, write: ['~/.moxxy/workflow-runs/**'] },
+        net: { mode: 'any' },
+        timeMs: 600_000,
+      },
+    },
     handler: async ({ name, inputs }, ctx) => {
       const entry = await deps.store.get(name);
       if (!entry) {
@@ -284,6 +333,13 @@ function listTool(deps: WorkflowToolDeps): ToolDef {
     description: 'List all saved workflows with their status, scope, triggers, and step count.',
     inputSchema: z.object({}),
     permission: { action: 'allow' },
+    isolation: {
+      capabilities: {
+        fs: { read: WORKFLOW_DIR_GLOBS },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async () => {
       const all = await deps.store.list();
       return {
@@ -306,6 +362,13 @@ function getTool(deps: WorkflowToolDeps): ToolDef {
     description: 'Fetch one workflow by name as canonical YAML, plus its on-disk path and scope.',
     inputSchema: z.object({ name: z.string().min(1) }),
     permission: { action: 'allow' },
+    isolation: {
+      capabilities: {
+        fs: { read: WORKFLOW_DIR_GLOBS },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async ({ name }) => {
       const entry = await deps.store.get(name);
       if (!entry) throw new MoxxyError({ code: 'TOOL_ERROR', message: `workflow_get: no workflow "${name}".` });
@@ -328,6 +391,13 @@ function validateTool(deps: WorkflowToolDeps): ToolDef {
       })
       .refine((v) => v.yaml || v.name, { message: 'pass either `yaml` or `name`' }),
     permission: { action: 'allow' },
+    isolation: {
+      capabilities: {
+        fs: { read: WORKFLOW_DIR_GLOBS },
+        net: { mode: 'none' },
+        timeMs: 30_000,
+      },
+    },
     handler: async ({ yaml, name }) => {
       if (yaml) {
         const r = parseWorkflowYaml(yaml);


### PR DESCRIPTION
Wave 2/3 of the capability backfill: every tool in the four automation plugins now carries an honest `isolation` declaration (`ToolIsolationSpec`), moving the repo toward flipping on `security.requireDeclaration`. 43 tools declared: collab 17, webhooks 11, workflows 8, scheduler 7.

## Honesty rules applied

- Every declaration was written by reading the handler (and what it transitively awaits), not the tool description.
- Never under-declare: a too-narrow cap would break the tool the moment enforcement flips on. Where a width was uncertain, the wider-but-certain form was chosen and commented (`net: any` for user-configured or env-overridable hosts; `$cwd/**` where the cap checker's key heuristic inspects path-shaped inputs the handler never opens).
- Store globs end in `*` (`webhooks.json*`, `schedules.json*`) because both JSON stores quarantine-rename a corrupt file on ANY access — even read-only tools may legitimately write next to the store file.
- No `required` strength and no `handlerModule` anywhere (none of the touched files set them); tools stay `none`/`inproc`-executable, matching the current isolator.

## @moxxy/plugin-collab (17)

All collab_* tools are thin JSON-RPC round-trips over the hub's unix socket — no TCP, no subprocesses (peer spawning lives in `@moxxy/mode-collaborative`). Three shared specs:

| Tools | Caps |
| --- | --- |
| send, broadcast, inbox, roster, board, update, done, contracts, contract_propose_change, contract_ack | fs r/w `~/.moxxy/collab/**` (hub socket), net none, env `MOXXY_COLLAB_HUB`/`MOXXY_COLLAB_AGENT_ID`/`MOXXY_RUNNER_SOCKET`, 30s |
| add_task, claim, release, contract_publish | + fs read `$cwd/**` — their inputs carry workspace paths the cap checker validates; the paths travel to the hub as data only |
| peer_files, peer_read, peer_diff | + 120s — the hub answers by reading files / running git in the peer's worktree |

## @moxxy/plugin-webhooks (11)

| Tool | Notable caps |
| --- | --- |
| webhook_create | fs r `$cwd/**` (jsonPath filter `path` fields look like file paths to the checker) + store/config, w store + `webhooks-secrets/**`; net none |
| webhook_update | same jsonPath carve-out; w store; net none |
| webhook_list / webhook_status | store+config read (store glob also in write: quarantine rename); net none |
| webhook_delete | store r/w + secrets-file cleanup; net none |
| webhook_test | net **any** + 600s — fires the trigger's prompt as a real turn on the active session (provider calls inside the handler); w `~/.moxxy/inbox/webhooks/**` + store |
| webhook_set_public_url | net **any** — handler only persists the URL, but the host is user-chosen and the checker validates URL-shaped inputs; r/w store+config |
| webhook_clear_public_url | config r/w only; net none |
| webhook_tunnel_start | net **any** (relay host env-overridable via `MOXXY_PROXY_HOST`), r/w `~/.moxxy/proxy-identity.key` + config + store, env `MOXXY_PROXY_HOST`, 60s |
| webhook_tunnel_stop | net **any** (deregisters over the relay connection), config r/w, 60s |
| webhook_setup_guide | config read only; net none |

## @moxxy/plugin-workflows (8)

Store globs: `~/.moxxy/workflows/**` + `$cwd/.moxxy/workflows/**` (read-only builtin/plugin workflow dirs live in the plugin host's module space — no stable glob, noted in-code).

| Tool | Notable caps |
| --- | --- |
| workflow_create | net **any** (drafts via the ACTIVE provider's model API) + dir r/w, 120s |
| workflow_update / set_enabled / delete | dir r/w, net none, 30s |
| workflow_run | net **any** + 600s — prompt steps are real subagent model turns; tool steps re-enter the session pipeline under their own specs; w `~/.moxxy/workflow-runs/**` |
| workflow_list / get / validate | dir read, net none, 30s |

## @moxxy/plugin-scheduler (7)

| Tool | Notable caps |
| --- | --- |
| schedule_create / list / delete / enable / disable / set_target | `~/.moxxy/schedules.json*` r/w, net none, 30s |
| schedule_run_now | net **any** + 600s — fires the prompt as a real turn on the active session; w `~/.moxxy/inbox/**` + store |

## Verification

`pnpm build` / `typecheck` / `lint` / `test` / `check:deps` all pass (lint warnings and the one dep-cruiser warning are pre-existing on the base branch). No audit-count tests needed updating.
