### PR TITLE
feat(security): package-level capability aggregation + audit --package

### DIFF
--- a/.changeset/security-audit-package.md
+++ b/.changeset/security-audit-package.md
@@ -1,0 +1,9 @@
+---
+"@moxxy/cli": minor
+"@moxxy/sdk": minor
+"@moxxy/core": patch
+"@moxxy/plugin-security": minor
+"@moxxy/plugin-plugins-admin": minor
+---
+
+Package-level capability aggregation: `moxxy security audit --package <name>` shows one package's tools plus their COMBINED capability surface (widest-wins union via the new `aggregateCapabilitySpecs` in the SDK), `--by-package` prints a declared/total rollup per plugin, and `install_plugin` now reports the just-installed package's capability surface (declared/total + undeclared tool names) next to the registration diff. Tool→plugin attribution comes from the plugin host's loaded records (`PluginHost.ownerOfTool`), which also makes the previously-dormant `security.perPlugin` isolator overrides actually route.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -13,6 +13,15 @@ or recorded-on-purpose decision.
 
 ## Resolved ledger
 
+- [med, security, RESOLVED 2026-07-03] `security.perPlugin` isolator overrides were
+  a dormant config option: real sessions wired `buildSecurityPlugin` with
+  `resolvePluginForTool: null` (plugin-level routing disabled), so the documented
+  `perPlugin` schema key never routed anything. The CLI now resolves tool → owning
+  plugin from the plugin host's loaded records (`PluginHost.ownerOfTool`, exposed on
+  the SDK `PluginHostHandle` as optional so thin clients may omit it), which also
+  powers the new `moxxy security audit --package <name>` / `--by-package` views and
+  install_plugin's combined-capability report. `packages/cli/src/setup/builtins.ts`,
+  `packages/core/src/plugins/host.ts`, `packages/plugin-security/src/index.ts`.
 - [med, dx, RESOLVED 2026-07-03] `service install` units no longer break under
   Electron-as-node: `installAndStartService` detects `process.versions.electron`
   and exports `ELECTRON_RUN_AS_NODE=1` into the unit env, so a desktop-spawned
@@ -20,7 +29,6 @@ or recorded-on-purpose decision.
   half was deliberately skipped — the env var fully fixes launch semantics and
   the Helper path is packaging-layout-dependent.
   `packages/cli/src/commands/service/index.ts`.
-
 - [low, sessions, RESOLVED 2026-07-03] `SessionSource` literals were hand-listed in
   one runtime spot (`sessionSource()`'s validator in
   `packages/cli/src/setup/persistence.ts`) — adding the Discord channel's

--- a/packages/cli/src/commands/security.ts
+++ b/packages/cli/src/commands/security.ts
@@ -1,8 +1,10 @@
+import { aggregateCapabilitySpecs, type CapabilitySpec } from '@moxxy/sdk';
 import type { ParsedArgv } from '../argv.js';
-import { bootSessionWithConfig, helpRequested } from '../argv-helpers.js';
+import { bootSessionWithConfig, hasBoolFlag, helpRequested, stringFlag } from '../argv-helpers.js';
 import { printError } from '../errors.js';
 import { colors } from '../colors.js';
 import { formatHelp } from './help-format.js';
+import type { AuditEntry } from '@moxxy/plugin-security';
 
 const HELP = formatHelp({
   title: 'moxxy security',
@@ -12,6 +14,8 @@ const HELP = formatHelp({
       title: 'COMMANDS',
       rows: [
         ['audit', 'list every tool, its declared capabilities, and the resolved isolator'],
+        ['audit --package <name>', "one package's tools + their COMBINED capability surface"],
+        ['audit --by-package', 'declared/total rollup per contributing plugin'],
         ['isolators', 'list available Isolator impls'],
         ['status', 'show whether security is enabled and the default isolator'],
       ],
@@ -64,6 +68,10 @@ export async function runSecurityCommand(argv: ParsedArgv): Promise<number> {
       process.stdout.write(colors.dim('(no tools registered)') + '\n');
       return 0;
     }
+
+    const packageFilter = stringFlag(argv, 'package');
+    if (packageFilter) return renderPackageAudit(entries, packageFilter);
+    if (hasBoolFlag(argv, 'by-package')) return renderByPackage(entries);
 
     const declared = entries.filter((e) => e.declared);
     const undeclared = entries.filter((e) => !e.declared);
@@ -118,6 +126,111 @@ export async function runSecurityCommand(argv: ParsedArgv): Promise<number> {
 
   printError(`unknown 'security' subcommand: ${sub}\n${HELP}`);
   return 2;
+}
+
+/**
+ * One package's audit view: its tools (declared + undeclared) and the
+ * widest-wins UNION of everything its declared tools may touch — the
+ * package's blast radius, for install-consent decisions and reviews.
+ */
+function renderPackageAudit(entries: ReadonlyArray<AuditEntry>, pkg: string): number {
+  const mine = entries.filter((e) => e.plugin === pkg);
+  if (mine.length === 0) {
+    const known = [...new Set(entries.map((e) => e.plugin).filter(Boolean))].sort();
+    process.stderr.write(
+      colors.red(`no tools attributed to package: ${pkg}`) +
+        '\n' +
+        colors.dim(
+          known.length
+            ? `  known packages:\n${known.map((p) => `    ${p}`).join('\n')}\n`
+            : '  (no plugin attribution available on this session)\n',
+        ),
+    );
+    return 2;
+  }
+
+  const declared = mine.filter((e) => e.declared);
+  const undeclared = mine.filter((e) => !e.declared);
+  process.stdout.write(
+    `${colors.bold(pkg)} · ${mine.length} tools · ` +
+      `${colors.bold(String(declared.length))} declared · ` +
+      `${
+        undeclared.length
+          ? colors.yellow(`${undeclared.length} undeclared`)
+          : colors.dim('0 undeclared')
+      }\n\n`,
+  );
+
+  const nameCol = Math.max(8, ...mine.map((e) => e.tool.length));
+  for (const e of mine) {
+    const mark = e.declared ? (e.hasModuleRef ? colors.bold('◊ ') : '  ') : colors.yellow('! ');
+    const caps = e.declared ? formatCapabilities(e.capabilities) : colors.yellow('undeclared');
+    process.stdout.write(
+      `  ${mark}${colors.bold(e.tool.padEnd(nameCol))}  ${colors.dim('→ ' + e.resolvedIsolator)}  ${caps}\n`,
+    );
+  }
+
+  if (declared.length > 0) {
+    const surface = aggregateCapabilitySpecs(
+      declared.map((e) => e.capabilities as CapabilitySpec | undefined),
+    );
+    process.stdout.write('\n' + colors.bold('COMBINED CAPABILITY SURFACE') + '\n');
+    for (const [label, value] of surfaceRows(surface)) {
+      process.stdout.write(`  ${colors.bold(label.padEnd(9))}  ${colors.dim(value)}\n`);
+    }
+    if (undeclared.length > 0) {
+      process.stdout.write(
+        colors.yellow(
+          `  (+ ${undeclared.length} undeclared tool${undeclared.length === 1 ? '' : 's'} with an UNKNOWN surface)\n`,
+        ),
+      );
+    }
+  }
+  return 0;
+}
+
+/** Rollup: declared/total per contributing plugin, gaps first. */
+function renderByPackage(entries: ReadonlyArray<AuditEntry>): number {
+  const groups = new Map<string, { declared: number; total: number }>();
+  for (const e of entries) {
+    const key = e.plugin ?? '(unattributed)';
+    const g = groups.get(key) ?? { declared: 0, total: 0 };
+    g.total += 1;
+    if (e.declared) g.declared += 1;
+    groups.set(key, g);
+  }
+  const rows = [...groups.entries()].sort(
+    (a, b) => b[1].total - b[1].declared - (a[1].total - a[1].declared) || a[0].localeCompare(b[0]),
+  );
+  const nameCol = Math.max(8, ...rows.map(([n]) => n.length));
+  for (const [name, g] of rows) {
+    const complete = g.declared === g.total;
+    const count = `${g.declared}/${g.total}`;
+    process.stdout.write(
+      `  ${colors.bold(name.padEnd(nameCol))}  ${
+        complete ? colors.dim(count + ' ✓') : colors.yellow(count)
+      }\n`,
+    );
+  }
+  return 0;
+}
+
+/** Human rows for an aggregated CapabilitySpec (skips absent axes). */
+function surfaceRows(s: CapabilitySpec): Array<[string, string]> {
+  const rows: Array<[string, string]> = [];
+  if (s.fs?.read?.length) rows.push(['fs:read', s.fs.read.join(', ')]);
+  if (s.fs?.write?.length) rows.push(['fs:write', s.fs.write.join(', ')]);
+  if (s.net) {
+    rows.push([
+      'net',
+      s.net.mode === 'allowlist' ? `allowlist: ${s.net.hosts.join(', ')}` : s.net.mode,
+    ]);
+  }
+  if (s.env?.length) rows.push(['env', s.env.join(', ')]);
+  if (s.subprocess) rows.push(['exec', s.commands?.length ? s.commands.join(', ') : '(any command)']);
+  if (s.timeMs !== undefined) rows.push(['time', `≤ ${s.timeMs}ms`]);
+  if (s.memMb !== undefined) rows.push(['mem', `≤ ${s.memMb}MB`]);
+  return rows;
 }
 
 function formatCapabilities(caps: Readonly<Record<string, unknown>> | undefined): string {

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -147,6 +147,9 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
         categories: categoryLive.categories,
         setCategoryDefault: categoryLive.setCategoryDefault,
         ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
+        // Lets install_plugin report the just-installed package's combined
+        // capability surface (union of its tools' isolation declarations).
+        toolIsolation: (name) => session.tools.get(name)?.isolation,
       }),
     },
     {

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -396,7 +396,11 @@ function buildSecuritySlice(
         : {}),
     },
     toolRegistry: session.tools,
-    resolvePluginForTool: null,
+    // Tool → contributing-plugin attribution from the plugin host's loaded
+    // records. Called lazily (post-boot), so the registries are populated by
+    // the time the security plugin or an audit view asks. This is what makes
+    // `security.perPlugin` overrides and `security audit --package` work.
+    resolvePluginForTool: (toolName) => session.pluginHost.ownerOfTool?.(toolName),
     // Register the worker_threads isolator so users can opt in via
     // `security: { isolator: 'worker' }`. It coexists with the built-in
     // `none` + `inproc` isolators; unused isolators have no runtime cost.

--- a/packages/core/src/plugins/host.ts
+++ b/packages/core/src/plugins/host.ts
@@ -92,6 +92,20 @@ export class PluginHost implements PluginHostHandle {
     return [...this.skipped.values()];
   }
 
+  /**
+   * The plugin that contributed the named tool — the `loaded` map key, i.e.
+   * the package name for discovered plugins and the declared plugin name for
+   * statically bundled ones. Linear scan over per-plugin name lists: the
+   * registries are small (~40 plugins × a handful of tools) and callers
+   * (security routing, audit views) are not hot paths.
+   */
+  ownerOfTool(toolName: string): string | undefined {
+    for (const [key, record] of this.loaded) {
+      if (record.toolNames.includes(toolName)) return key;
+    }
+    return undefined;
+  }
+
   registerStatic(plugin: Plugin, opts: RegisterStaticOptions = {}): void {
     if (this.loaded.has(plugin.name)) {
       throw new Error(`Plugin already registered: ${plugin.name}`);

--- a/packages/plugin-plugins-admin/src/index.ts
+++ b/packages/plugin-plugins-admin/src/index.ts
@@ -124,6 +124,8 @@ export interface BuildPluginsAdminOpts {
   readonly setCategoryDefault: CategoryDefaultsDeps['setCategoryDefault'];
   /** Host CLI version — pins bare `@moxxy/*` installs (see {@link InstallPluginDeps}). */
   readonly cliVersion?: string;
+  /** Live tool isolation lookup for the install capability report (see {@link InstallPluginDeps}). */
+  readonly toolIsolation?: InstallPluginDeps['toolIsolation'];
 }
 
 /**
@@ -138,6 +140,7 @@ export function buildPluginsAdminPlugin(opts: BuildPluginsAdminOpts): Plugin {
     reload: opts.reload,
     snapshot: opts.snapshot,
     ...(opts.cliVersion ? { cliVersion: opts.cliVersion } : {}),
+    ...(opts.toolIsolation ? { toolIsolation: opts.toolIsolation } : {}),
   };
   const toggleDeps: PluginToggleDeps = { setEnabled: opts.setEnabled, snapshot: opts.snapshot };
   const defaultsDeps: CategoryDefaultsDeps = {

--- a/packages/plugin-plugins-admin/src/install.test.ts
+++ b/packages/plugin-plugins-admin/src/install.test.ts
@@ -3,6 +3,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  buildCapabilityReport,
   buildInstallPluginTool,
   buildUninstallPluginTool,
   installPluginPackage,
@@ -59,6 +60,35 @@ describe('install_plugin tool', () => {
     for (const version of ['--evil', '-g', '-rc', '--registry=http://evil']) {
       expect(tool.inputSchema.safeParse({ packageName: 'left-pad', version }).success).toBe(false);
     }
+  });
+});
+
+describe('buildCapabilityReport', () => {
+  it('returns undefined when the install registered no tools', () => {
+    expect(buildCapabilityReport([], () => undefined)).toBeUndefined();
+  });
+
+  it('unions declared specs and names the undeclared tools', () => {
+    const report = buildCapabilityReport(['a', 'b', 'c'], (name) =>
+      name === 'a'
+        ? { capabilities: { net: { mode: 'allowlist', hosts: ['x.com'] }, subprocess: true } }
+        : name === 'b'
+          ? { capabilities: { net: { mode: 'any' }, timeMs: 60_000 } }
+          : undefined,
+    );
+    expect(report).toEqual({
+      declared: 2,
+      total: 3,
+      surface: { net: { mode: 'any' }, timeMs: 60_000, subprocess: true },
+      undeclaredTools: ['c'],
+    });
+  });
+
+  it('omits undeclaredTools when every tool declares', () => {
+    const report = buildCapabilityReport(['a'], () => ({
+      capabilities: { net: { mode: 'none' } },
+    }));
+    expect(report).toEqual({ declared: 1, total: 1, surface: { net: { mode: 'none' } } });
   });
 });
 

--- a/packages/plugin-plugins-admin/src/install.ts
+++ b/packages/plugin-plugins-admin/src/install.ts
@@ -1,7 +1,14 @@
 import { spawn } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
-import { createMutex, defineTool, z } from '@moxxy/sdk';
+import {
+  aggregateCapabilitySpecs,
+  createMutex,
+  defineTool,
+  z,
+  type CapabilitySpec,
+  type ToolIsolationSpec,
+} from '@moxxy/sdk';
 import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { assertSafeNpmSpec, diffSnapshot, NPM_NAME_RE, type PluginSnapshot } from './shared.js';
 import { pinFirstPartySpec } from './pin.js';
@@ -68,6 +75,14 @@ export interface InstallPluginDeps {
    * {@link installPluginPackagePinned}.
    */
   readonly cliVersion?: string;
+  /**
+   * The live isolation spec of a registered tool, when the host can provide
+   * it (typically `session.tools.get(name)?.isolation`). Lets install_plugin
+   * report the just-installed package's COMBINED capability surface next to
+   * the registration diff, so consent decisions see the blast radius, not
+   * just tool names. Optional: absent = the report is omitted.
+   */
+  readonly toolIsolation?: (toolName: string) => ToolIsolationSpec | undefined;
 }
 
 export interface InstallPluginPackageOptions {
@@ -184,6 +199,37 @@ export async function removePluginPackage(
   });
 }
 
+export interface InstallCapabilityReport {
+  /** Tools that declared an isolation spec. */
+  readonly declared: number;
+  /** Tools the install registered. */
+  readonly total: number;
+  /** Widest-wins union of the declared specs — the package's blast radius. */
+  readonly surface: CapabilitySpec;
+  /** Tools with NO declaration: their surface is unknown, not empty. */
+  readonly undeclaredTools?: ReadonlyArray<string>;
+}
+
+/**
+ * Combined capability surface of the tools an install just registered.
+ * Returns undefined when the install registered no tools (nothing to
+ * report — other contribution kinds carry no capability declarations).
+ */
+export function buildCapabilityReport(
+  newTools: ReadonlyArray<string>,
+  toolIsolation: NonNullable<InstallPluginDeps['toolIsolation']>,
+): InstallCapabilityReport | undefined {
+  if (newTools.length === 0) return undefined;
+  const specs = newTools.map((n) => toolIsolation(n)?.capabilities);
+  const undeclaredTools = newTools.filter((_, i) => !specs[i]);
+  return {
+    declared: newTools.length - undeclaredTools.length,
+    total: newTools.length,
+    surface: aggregateCapabilitySpecs(specs),
+    ...(undeclaredTools.length ? { undeclaredTools } : {}),
+  };
+}
+
 export function buildInstallPluginTool(deps: InstallPluginDeps) {
   return defineTool({
     name: 'install_plugin',
@@ -237,9 +283,14 @@ export function buildInstallPluginTool(deps: InstallPluginDeps) {
       // Surface the plugin's declarative setup step (moxxy.setup) so the
       // caller can walk the user through it — the model relays the hint.
       const setup = await readPluginSetup(packageName.replace(/@[^/@]+$/, ''));
+      const registered = diffSnapshot(before, after);
+      const capabilities = deps.toolIsolation
+        ? buildCapabilityReport(registered.tools ?? [], deps.toolIsolation)
+        : undefined;
       return {
         installed,
-        registered: diffSnapshot(before, after),
+        registered,
+        ...(capabilities ? { capabilities } : {}),
         ...(setup
           ? {
               needsSetup: {

--- a/packages/plugin-security/src/index.test.ts
+++ b/packages/plugin-security/src/index.test.ts
@@ -159,6 +159,31 @@ describe('buildSecurityPlugin', () => {
     expect(entries.find((e) => e.tool === 'a')?.declared).toBe(true);
     expect(entries.find((e) => e.tool === 'b')?.declared).toBe(false);
   });
+
+  it('audit() attributes tools to plugins when resolvePluginForTool is wired', () => {
+    const reg = new FakeToolRegistry()
+      .add(fakeTool({ name: 'a', isolation: { capabilities: { timeMs: 1000 } } }))
+      .add(fakeTool({ name: 'b' }));
+    const handle = buildSecurityPlugin({
+      config: { enabled: true },
+      toolRegistry: reg,
+      resolvePluginForTool: (name) => (name === 'a' ? '@moxxy/plugin-a' : undefined),
+    });
+    const entries = handle.audit();
+    expect(entries.find((e) => e.tool === 'a')?.plugin).toBe('@moxxy/plugin-a');
+    // Unattributed tools omit the field rather than carrying a placeholder.
+    expect(entries.find((e) => e.tool === 'b')?.plugin).toBeUndefined();
+  });
+
+  it('audit() omits plugin attribution when routing is disabled (null)', () => {
+    const reg = new FakeToolRegistry().add(fakeTool({ name: 'a' }));
+    const handle = buildSecurityPlugin({
+      config: { enabled: true },
+      toolRegistry: reg,
+      resolvePluginForTool: null,
+    });
+    expect(handle.audit()[0]?.plugin).toBeUndefined();
+  });
 });
 
 // u105-2 regression: re-running onInit must NOT double-wrap.

--- a/packages/plugin-security/src/index.ts
+++ b/packages/plugin-security/src/index.ts
@@ -113,6 +113,8 @@ export interface SecurityPluginHandle {
 
 export interface AuditEntry {
   readonly tool: string;
+  /** Contributing plugin/package, when `resolvePluginForTool` is wired. */
+  readonly plugin?: string;
   readonly declared: boolean;
   readonly required?: string;
   readonly resolvedIsolator: string;
@@ -236,8 +238,11 @@ export function buildSecurityPlugin(opts: BuildSecurityPluginOptions): SecurityP
       return tools.list().map((t) => {
         const declared = Boolean(t.isolation);
         const resolved = pickIsolatorName(t.name);
+        const plugin =
+          resolvePluginForTool === null ? undefined : resolvePluginForTool?.(t.name);
         return {
           tool: t.name,
+          ...(plugin ? { plugin } : {}),
           declared,
           ...(t.isolation?.required ? { required: t.isolation.required } : {}),
           resolvedIsolator: resolved,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -117,7 +117,7 @@ export type {
   Isolator,
   HandlerModuleRef,
 } from './isolation.js';
-export { ISOLATION_RANK } from './isolation.js';
+export { ISOLATION_RANK, aggregateCapabilitySpecs } from './isolation.js';
 
 export type {
   SubagentSpec,

--- a/packages/sdk/src/isolation-aggregate.test.ts
+++ b/packages/sdk/src/isolation-aggregate.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateCapabilitySpecs, type CapabilitySpec } from './isolation.js';
+
+describe('aggregateCapabilitySpecs', () => {
+  it('empty / all-undefined input aggregates to an empty surface', () => {
+    expect(aggregateCapabilitySpecs([])).toEqual({});
+    expect(aggregateCapabilitySpecs([undefined, undefined])).toEqual({});
+  });
+
+  it('unions fs globs, env, and commands (sorted, deduped)', () => {
+    const a: CapabilitySpec = {
+      fs: { read: ['$cwd/**', '/tmp/**'], write: ['/tmp/**'] },
+      env: ['PATH', 'HOME'],
+      subprocess: true,
+      commands: ['npm'],
+    };
+    const b: CapabilitySpec = {
+      fs: { read: ['/tmp/**'] },
+      env: ['PATH'],
+      subprocess: true,
+      commands: ['git', 'npm'],
+    };
+    expect(aggregateCapabilitySpecs([a, b])).toEqual({
+      fs: { read: ['$cwd/**', '/tmp/**'], write: ['/tmp/**'] },
+      env: ['HOME', 'PATH'],
+      subprocess: true,
+      commands: ['git', 'npm'],
+    });
+  });
+
+  it('net takes the strongest mode: any > allowlist > none', () => {
+    const none: CapabilitySpec = { net: { mode: 'none' } };
+    const list: CapabilitySpec = { net: { mode: 'allowlist', hosts: ['b.com', 'a.com'] } };
+    const any: CapabilitySpec = { net: { mode: 'any' } };
+
+    expect(aggregateCapabilitySpecs([none])).toEqual({ net: { mode: 'none' } });
+    expect(aggregateCapabilitySpecs([none, list])).toEqual({
+      net: { mode: 'allowlist', hosts: ['a.com', 'b.com'] },
+    });
+    expect(aggregateCapabilitySpecs([list, any, none])).toEqual({ net: { mode: 'any' } });
+  });
+
+  it('merges allowlist hosts across specs', () => {
+    const a: CapabilitySpec = { net: { mode: 'allowlist', hosts: ['registry.npmjs.org'] } };
+    const b: CapabilitySpec = { net: { mode: 'allowlist', hosts: ['api.slack.com'] } };
+    expect(aggregateCapabilitySpecs([a, b])).toEqual({
+      net: { mode: 'allowlist', hosts: ['api.slack.com', 'registry.npmjs.org'] },
+    });
+  });
+
+  it('timeMs and memMb take the max; undeclared entries contribute nothing', () => {
+    const a: CapabilitySpec = { timeMs: 30_000, memMb: 128 };
+    const b: CapabilitySpec = { timeMs: 600_000 };
+    expect(aggregateCapabilitySpecs([a, undefined, b])).toEqual({
+      timeMs: 600_000,
+      memMb: 128,
+    });
+  });
+
+  it('an "any" net dropped into a wide union does not resurrect allowlist hosts', () => {
+    // Regression guard: once mode is 'any', collected hosts must not leak
+    // back into the result as a misleading narrower-looking allowlist.
+    const spec = aggregateCapabilitySpecs([
+      { net: { mode: 'allowlist', hosts: ['a.com'] } },
+      { net: { mode: 'any' } },
+    ]);
+    expect(spec.net).toEqual({ mode: 'any' });
+  });
+});

--- a/packages/sdk/src/isolation.ts
+++ b/packages/sdk/src/isolation.ts
@@ -146,3 +146,70 @@ export const ISOLATION_RANK: Readonly<Record<IsolationStrength, number>> = Objec
   wasm: 5,
   docker: 6,
 });
+
+/**
+ * Widest-wins union of capability declarations — the combined blast radius
+ * if every contributing tool exercised its full declared surface. Used for
+ * package-level views: `moxxy security audit --package`, the install-time
+ * capability report, and (later) signed-index capability manifests.
+ *
+ * Union semantics per axis: fs globs / env vars / commands are set-unions
+ * (sorted, deduped); net takes the strongest mode (`any` > `allowlist` with
+ * merged hosts > `none`); `subprocess` is an OR; `timeMs` / `memMb` take the
+ * max. `undefined` entries (undeclared tools) contribute nothing — callers
+ * report their count separately so a wide-open undeclared tool is never
+ * hidden behind a tidy aggregate.
+ */
+export function aggregateCapabilitySpecs(
+  specs: ReadonlyArray<CapabilitySpec | undefined>,
+): CapabilitySpec {
+  const read = new Set<string>();
+  const write = new Set<string>();
+  const env = new Set<string>();
+  const commands = new Set<string>();
+  const hosts = new Set<string>();
+  let netMode: NetCapability['mode'] | undefined;
+  let subprocess = false;
+  let timeMs: number | undefined;
+  let memMb: number | undefined;
+
+  for (const spec of specs) {
+    if (!spec) continue;
+    for (const g of spec.fs?.read ?? []) read.add(g);
+    for (const g of spec.fs?.write ?? []) write.add(g);
+    if (spec.net) {
+      if (spec.net.mode === 'any') netMode = 'any';
+      else if (spec.net.mode === 'allowlist') {
+        if (netMode !== 'any') netMode = 'allowlist';
+        for (const h of spec.net.hosts) hosts.add(h);
+      } else netMode ??= 'none';
+    }
+    for (const e of spec.env ?? []) env.add(e);
+    if (spec.subprocess) subprocess = true;
+    for (const c of spec.commands ?? []) commands.add(c);
+    if (spec.timeMs !== undefined) timeMs = Math.max(timeMs ?? 0, spec.timeMs);
+    if (spec.memMb !== undefined) memMb = Math.max(memMb ?? 0, spec.memMb);
+  }
+
+  const sorted = (s: Set<string>): string[] => [...s].sort();
+  return {
+    ...(read.size || write.size
+      ? {
+          fs: {
+            ...(read.size ? { read: sorted(read) } : {}),
+            ...(write.size ? { write: sorted(write) } : {}),
+          },
+        }
+      : {}),
+    ...(netMode === 'allowlist'
+      ? { net: { mode: 'allowlist' as const, hosts: sorted(hosts) } }
+      : netMode
+        ? { net: { mode: netMode } }
+        : {}),
+    ...(env.size ? { env: sorted(env) } : {}),
+    ...(timeMs !== undefined ? { timeMs } : {}),
+    ...(memMb !== undefined ? { memMb } : {}),
+    ...(subprocess ? { subprocess: true } : {}),
+    ...(commands.size ? { commands: sorted(commands) } : {}),
+  };
+}

--- a/packages/sdk/src/mode.ts
+++ b/packages/sdk/src/mode.ts
@@ -46,6 +46,13 @@ export interface PluginHostHandle {
     kinds?: ReadonlyArray<string>;
   }>;
   reload(): Promise<void>;
+  /**
+   * The plugin (package) that contributed the named tool, or undefined for
+   * unknown / dynamically-attached tools. Optional so a thin-client
+   * `RemoteSession` can omit it; powers plugin-level security routing
+   * (`security.perPlugin`) and package-scoped audit views.
+   */
+  ownerOfTool?(toolName: string): string | undefined;
 }
 
 /**


### PR DESCRIPTION
## What

Phase 4.2 of the security-moat roadmap: capability declarations become *package-level* facts you can act on.

- **`moxxy security audit --package <name>`** — one package's tools plus their **COMBINED CAPABILITY SURFACE**: the widest-wins union (new `aggregateCapabilitySpecs` in the SDK) of everything its declared tools may touch, with undeclared tools called out as an UNKNOWN surface, never hidden behind a tidy aggregate.
- **`moxxy security audit --by-package`** — declared/total rollup per contributing plugin, gaps first. (Doubles as the live progress tracker for the #423/#424/#425 backfill wave.)
- **`install_plugin` reports the blast radius**: the tool's result now carries `capabilities: {declared, total, surface, undeclaredTools?}` next to the registration diff — groundwork for install-time consent (phase 4.3).
- **Bug fix en route**: `security.perPlugin` isolator overrides were dormant — real sessions wired `resolvePluginForTool: null`, so the documented config key never routed anything. Tool→plugin attribution now comes from the plugin host's loaded records (`PluginHost.ownerOfTool`, optional on the SDK `PluginHostHandle` so thin clients may omit it).

## Verification

- Full gate green (build/typecheck/lint/test/check:deps, exit-code-verified — no pipe masking).
- New unit tests: aggregation semantics (union/strongest-mode/max + the any-vs-allowlist regression guard), audit attribution (wired/null), install capability report.
- Live smoke on the built CLI: `--by-package` rollup and `--package @moxxy/plugin-plugins-admin` render correctly against a real session.

## Merge notes

- Independent of the backfill PRs (#423/#424/#425) — different files; merge in any order relative to them.
- **TECH_DEBT.md will conflict with #421** (both prepend to the Resolved ledger) — trivial keep-both-sides resolution; I'll rebase after #421 lands.