### PR TITLE
feat(registry): ed25519-signed plugin index — client verification, cache, and pin integration

### DIFF
--- a/.changeset/signed-registry-client.md
+++ b/.changeset/signed-registry-client.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/plugin-plugins-admin': minor
+'@moxxy/cli': patch
+---
+
+Signed plugin-registry v1, client side: Ed25519-verified `index.json` fetch with a re-verified 1h cache at `~/.moxxy/registry-cache.json` and hardcoded-catalog fallback on any failure (never throws into the install path). Catalog installs that resolve through a signed entry install the signature-covered exact version (pin precedence: user `--version` > signed index > cliVersion lockstep > latest), and `install_plugin` warns when the registered capability surface is wider than the signed manifest. Dormant until a maintainer key is baked into `REGISTRY_PUBLIC_KEY` (empty = disabled, exactly like the desktop update key).

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -8,6 +8,7 @@ import {
   removePluginPackage,
   resolveCatalogEntry,
   resolveCatalogPackageName,
+  resolveInstallSource,
   searchInstallablePlugins,
   setCategoryDefault,
   setPluginEnabled,
@@ -165,11 +166,25 @@ async function runInstall(argv: ParsedArgv): Promise<number> {
     printError('plugins install requires a catalog id, npm package, GitHub spec, or path');
     return 2;
   }
-  const spec = buildInstallSpec({
-    target,
-    ...(stringFlag(argv, 'version') ? { version: stringFlag(argv, 'version') } : {}),
-    ...(stringFlag(argv, 'ref') ? { ref: stringFlag(argv, 'ref') } : {}),
-  });
+  const version = stringFlag(argv, 'version');
+  const ref = stringFlag(argv, 'ref');
+  // Explicit --version / --ref always wins: skip the signed-registry lookup
+  // and pass the user's spec through untouched. Otherwise consult the signed
+  // index first (a no-op fallback to the hardcoded catalog while the
+  // maintainer key is unprovisioned) — a signed entry contributes its exact,
+  // signature-covered version as the pin. Pin precedence:
+  // user --version > signed index > cliVersion lockstep > latest.
+  const resolved =
+    version || ref
+      ? undefined
+      : await resolveInstallSource(target);
+  const spec =
+    resolved?.spec ??
+    buildInstallSpec({
+      target,
+      ...(version ? { version } : {}),
+      ...(ref ? { ref } : {}),
+    });
   const entry = resolveCatalogEntry(target);
   try {
     // Bare first-party specs pin to the CLI version (co-published via the
@@ -177,11 +192,17 @@ async function runInstall(argv: ParsedArgv): Promise<number> {
     // Explicit --version/--ref specs pass through untouched.
     const result = await installPluginPackagePinned({
       packageName: spec,
+      ...(resolved?.pinnedVersion ? { pinnedVersion: resolved.pinnedVersion } : {}),
       ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
       onWarn: (msg) => process.stderr.write(colors.dim(msg) + '\n'),
     });
+    if (resolved?.origin === 'signed' && resolved.pinnedVersion) {
+      process.stdout.write(
+        colors.dim(`signed registry pin: ${resolved.packageName}@${resolved.pinnedVersion}\n`),
+      );
+    }
     process.stdout.write(
-      `installed ${entry?.packageName ?? spec}\n` +
+      `installed ${resolved?.packageName ?? entry?.packageName ?? spec}\n` +
         `source: ${result.installed}\nplugins dir: ${result.dir}\n` +
         colors.dim('run `moxxy plugins reload` (or restart) to load it\n'),
     );

--- a/packages/plugin-plugins-admin/src/index.ts
+++ b/packages/plugin-plugins-admin/src/index.ts
@@ -68,6 +68,30 @@ export {
   type FetchLike,
 } from './search.js';
 
+// Signed plugin-registry v1 client: Ed25519-verified index fetch + cache +
+// fallback, install-source resolution with signed version pins, and the
+// capability-manifest comparison (see registry.ts for the format spec).
+export {
+  checkCapabilityManifest,
+  DEFAULT_REGISTRY_URL,
+  fetchSignedRegistry,
+  parseRegistryIndex,
+  REGISTRY_CACHE_TTL_MS,
+  REGISTRY_INDEX_VERSION,
+  resolveInstallSource,
+  verifyRegistryIndex,
+  type CapabilityManifestCheck,
+  type FetchSignedRegistryOptions,
+  type PluginRegistryEntry,
+  type PluginRegistryIndex,
+  type RegistryFallbackReason,
+  type RegistryFetchLike,
+  type RegistryResultEntry,
+  type ResolvedInstallSource,
+  type SignedRegistryResult,
+} from './registry.js';
+export { REGISTRY_PUBLIC_KEY } from './registry-key.js';
+
 // Enable/disable + category-default persistence (formerly
 // @moxxy/plugin-marketplace/config-state).
 export {

--- a/packages/plugin-plugins-admin/src/install.ts
+++ b/packages/plugin-plugins-admin/src/install.ts
@@ -13,6 +13,7 @@ import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { assertSafeNpmSpec, diffSnapshot, NPM_NAME_RE, type PluginSnapshot } from './shared.js';
 import { pinFirstPartySpec } from './pin.js';
 import { readPluginSetup } from './setup-spec.js';
+import { checkCapabilityManifest, resolveInstallSource } from './registry.js';
 
 export type { PluginSnapshot } from './shared.js';
 
@@ -142,6 +143,15 @@ export interface PinnedInstallOptions {
   readonly packageName: string;
   /** Explicit version/dist-tag — used verbatim, never retried. */
   readonly version?: string;
+  /**
+   * Exact version pin from a verified signed-registry entry (see
+   * registry.ts). Injected — so a pin that 404s (unpublished release) retries
+   * unpinned with a warning rather than failing the install (v1 is
+   * availability-first; fail-closed arrives with the consent phase). Ignored
+   * when `packageName` already carries a version or is a git/path spec.
+   * Precedence: explicit user `version` > this > `cliVersion` > latest.
+   */
+  readonly pinnedVersion?: string;
   /** Host CLI version to pin bare `@moxxy/*` names to. */
   readonly cliVersion?: string;
   /** Optional abort signal; aborting kills the npm child process. */
@@ -153,18 +163,25 @@ export interface PinnedInstallOptions {
 }
 
 /**
- * Install with the first-party version pin applied, falling back to the
- * unpinned spec when the pin itself is what failed. The retry only happens
- * for a pin WE injected (bare `@moxxy/*` name + cliVersion): an older CLI can
- * legitimately pin a package whose first co-versioned release is newer than
- * the CLI (`@pkg@0.25.0` 404s when the package first ships at 0.26.0). An
- * explicit user-provided version is never second-guessed.
+ * Install with the version pin applied, falling back to the unpinned spec
+ * when the pin itself is what failed. Pin precedence: explicit user `version`
+ * > signed-registry `pinnedVersion` > first-party `cliVersion` lockstep >
+ * latest. The retry only happens for a pin WE injected (a signed pin, or a
+ * bare `@moxxy/*` name + cliVersion): an older CLI can legitimately pin a
+ * package whose first co-versioned release is newer than the CLI
+ * (`@pkg@0.25.0` 404s when the package first ships at 0.26.0). An explicit
+ * user-provided version is never second-guessed.
  */
 export async function installPluginPackagePinned(
   opts: PinnedInstallOptions,
 ): Promise<InstallPluginPackageResult> {
   const install = opts.installFn ?? installPluginPackage;
-  const spec = pinFirstPartySpec(opts.packageName, opts.version, opts.cliVersion);
+  // A signed pin only applies to a bare package name — a spec that already
+  // carries a version (`@scope/name@1.2.3`) or points at git/path installs
+  // verbatim (appending `@x.y.z` to those would corrupt the spec).
+  const signedPin =
+    opts.pinnedVersion && NPM_NAME_RE.test(opts.packageName) ? opts.pinnedVersion : undefined;
+  const spec = pinFirstPartySpec(opts.packageName, opts.version ?? signedPin, opts.cliVersion);
   const injectedPin = !opts.version && spec !== opts.packageName;
   try {
     return await install({ packageName: spec, signal: opts.signal });
@@ -272,9 +289,19 @@ export function buildInstallPluginTool(deps: InstallPluginDeps) {
     },
     handler: async ({ packageName, version }, ctx) => {
       const before = deps.snapshot();
+      // Consult the signed registry (a no-op fallback while the maintainer
+      // key is unprovisioned): a signed entry contributes its exact version
+      // pin (unless the user gave one) and its declared capability manifest
+      // for the post-install comparison below. Never throws.
+      const signed = await resolveInstallSource(packageName, { signal: ctx.signal });
+      const signedPin =
+        signed.origin === 'signed' && signed.spec === packageName
+          ? signed.pinnedVersion
+          : undefined;
       const { installed } = await installPluginPackagePinned({
         packageName,
         ...(version ? { version } : {}),
+        ...(signedPin ? { pinnedVersion: signedPin } : {}),
         ...(deps.cliVersion ? { cliVersion: deps.cliVersion } : {}),
         signal: ctx.signal,
       });
@@ -287,10 +314,26 @@ export function buildInstallPluginTool(deps: InstallPluginDeps) {
       const capabilities = deps.toolIsolation
         ? buildCapabilityReport(registered.tools ?? [], deps.toolIsolation)
         : undefined;
+      // Signed capability manifest vs the surface the install actually
+      // registered. Warn-only in v1 (enforce comes with the consent phase).
+      const manifestCheck =
+        signed.origin === 'signed' && signed.capabilities && capabilities
+          ? checkCapabilityManifest(signed.capabilities, capabilities.surface)
+          : undefined;
       return {
         installed,
         registered,
         ...(capabilities ? { capabilities } : {}),
+        ...(manifestCheck?.capabilityMismatch
+          ? {
+              capabilityMismatch: true,
+              capabilityMismatchDetails: {
+                declared: signed.capabilities,
+                widened: manifestCheck.widened,
+                note: 'installed tools declare a wider surface than the signed registry manifest',
+              },
+            }
+          : {}),
         ...(setup
           ? {
               needsSetup: {

--- a/packages/plugin-plugins-admin/src/registry-key.ts
+++ b/packages/plugin-plugins-admin/src/registry-key.ts
@@ -1,0 +1,30 @@
+/**
+ * Baked Ed25519 PUBLIC key (SPKI PEM) — the root of trust for the signed
+ * plugin registry. `fetchSignedRegistry` accepts a remote `index.json` ONLY
+ * when `index.json.sig` is a valid signature from the matching private key
+ * (held by the registry maintainer in PRIVATE publisher tooling — never in
+ * this repo).
+ *
+ * EMPTY string ⇒ the remote registry is DISABLED entirely: every lookup
+ * short-circuits to the hardcoded `INSTALLABLE_PLUGIN_CATALOG` and no network
+ * request is ever made. This is the safe default — an unconfigured build can
+ * never be tricked into trusting an unsigned (or wrongly-signed) index.
+ * Mirrors `BUNDLED_UPDATE_PUBLIC_KEY` in the desktop self-update bootstrap.
+ *
+ * There is deliberately NO PKI and NO runtime key configuration: one
+ * maintainer key, baked as a constant. Key rotation = paste the new public
+ * key here and ship a new CLI release; older CLIs keep verifying against the
+ * old key until they update (indexes signed with the new key simply fail
+ * verification there and those CLIs fall back to their hardcoded catalog —
+ * degraded, never compromised).
+ *
+ * To provision, generate ONE keypair and paste the public SPKI PEM below
+ * (the private key stays with the publisher tooling in the private repo):
+ *
+ *   openssl genpkey -algorithm ed25519 -out moxxy-registry.key
+ *   openssl pkey -in moxxy-registry.key -pubout       # paste the output below
+ *
+ * The PEM must be the literal multi-line block, including the
+ * -----BEGIN/END PUBLIC KEY----- lines.
+ */
+export const REGISTRY_PUBLIC_KEY = '';

--- a/packages/plugin-plugins-admin/src/registry.test.ts
+++ b/packages/plugin-plugins-admin/src/registry.test.ts
@@ -1,0 +1,575 @@
+import { generateKeyPairSync, sign as cryptoSign, type KeyObject } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  checkCapabilityManifest,
+  fetchSignedRegistry,
+  parseRegistryIndex,
+  REGISTRY_CACHE_TTL_MS,
+  resolveInstallSource,
+  verifyRegistryIndex,
+  type RegistryFetchLike,
+} from './registry.js';
+import { installPluginPackagePinned } from './install.js';
+import { INSTALLABLE_PLUGIN_CATALOG } from './catalog.js';
+
+// ---------------------------------------------------------------------------
+// Test signing rig: an ephemeral Ed25519 keypair per suite. The production
+// REGISTRY_PUBLIC_KEY constant stays '' (feature dormant); tests inject the
+// ephemeral public key via the publicKeyPem opt.
+// ---------------------------------------------------------------------------
+
+let privateKey: KeyObject;
+let publicKeyPem: string;
+
+beforeEach(() => {
+  const pair = generateKeyPairSync('ed25519');
+  privateKey = pair.privateKey;
+  publicKeyPem = pair.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+});
+
+const VALID_INDEX = {
+  version: 1,
+  generatedAt: '2026-07-03T00:00:00Z',
+  entries: [
+    {
+      id: 'telegram',
+      label: 'Telegram channel',
+      description: 'Chat with moxxy from Telegram.',
+      packageName: '@moxxy/plugin-telegram',
+      installSpec: '@moxxy/plugin-telegram',
+      version: '0.26.0',
+      provides: [{ category: 'channel', name: 'telegram' }],
+      capabilities: { net: { mode: 'allowlist', hosts: ['api.telegram.org'] } },
+    },
+    {
+      id: 'virtual-office',
+      label: 'Virtual Office',
+      description: 'Pixel-art UI.',
+      packageName: '@moxxy/virtual-office-plugin',
+      installSpec: 'github:moxxy-ai/virtual-office-plugin#main',
+      version: '1.0.0',
+    },
+  ],
+};
+
+function signedIndex(index: unknown = VALID_INDEX): { bytes: Uint8Array; sig: string } {
+  const bytes = new Uint8Array(Buffer.from(JSON.stringify(index), 'utf8'));
+  const sig = cryptoSign(null, Buffer.from(bytes), privateKey).toString('base64');
+  return { bytes, sig };
+}
+
+function toArrayBuffer(u8: Uint8Array): ArrayBuffer {
+  const ab = new ArrayBuffer(u8.byteLength);
+  new Uint8Array(ab).set(u8);
+  return ab;
+}
+
+/** Fetch stub serving `index.json` + `index.json.sig` from memory. */
+function fetchServing(bytes: Uint8Array, sig: string): RegistryFetchLike {
+  return async (url) => ({
+    ok: true,
+    status: 200,
+    arrayBuffer: async () =>
+      url.endsWith('.sig') ? toArrayBuffer(new TextEncoder().encode(sig)) : toArrayBuffer(bytes),
+    text: async () => (url.endsWith('.sig') ? sig : Buffer.from(bytes).toString('utf8')),
+  });
+}
+
+let cacheDir: string;
+beforeEach(() => {
+  cacheDir = mkdtempSync(path.join(os.tmpdir(), 'mox-registry-'));
+});
+afterEach(() => {
+  rmSync(cacheDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+const cachePath = (): string => path.join(cacheDir, 'registry-cache.json');
+
+// ---------------------------------------------------------------------------
+// Verification + parsing
+// ---------------------------------------------------------------------------
+
+describe('verifyRegistryIndex / parseRegistryIndex', () => {
+  it('a valid index verifies and parses', () => {
+    const { bytes, sig } = signedIndex();
+    expect(verifyRegistryIndex(bytes, sig, publicKeyPem)).toBe(true);
+    const index = parseRegistryIndex(bytes);
+    expect(index?.entries).toHaveLength(2);
+    expect(index?.entries[0]?.version).toBe('0.26.0');
+    expect(index?.entries[0]?.capabilities?.net).toEqual({
+      mode: 'allowlist',
+      hosts: ['api.telegram.org'],
+    });
+  });
+
+  it('tampered index bytes are refused', () => {
+    const { bytes, sig } = signedIndex();
+    const tampered = Buffer.from(
+      Buffer.from(bytes).toString('utf8').replace('0.26.0', '9.9.9'),
+      'utf8',
+    );
+    expect(verifyRegistryIndex(tampered, sig, publicKeyPem)).toBe(false);
+  });
+
+  it('a bad or missing signature is refused', () => {
+    const { bytes, sig } = signedIndex();
+    expect(verifyRegistryIndex(bytes, '', publicKeyPem)).toBe(false);
+    expect(verifyRegistryIndex(bytes, 'not-base64!!', publicKeyPem)).toBe(false);
+    expect(verifyRegistryIndex(bytes, Buffer.from('junk').toString('base64'), publicKeyPem)).toBe(
+      false,
+    );
+    // A signature from a DIFFERENT key must not verify.
+    const other = generateKeyPairSync('ed25519');
+    const otherSig = cryptoSign(null, Buffer.from(bytes), other.privateKey).toString('base64');
+    expect(verifyRegistryIndex(bytes, otherSig, publicKeyPem)).toBe(false);
+    expect(verifyRegistryIndex(bytes, sig, '')).toBe(false);
+    expect(verifyRegistryIndex(bytes, sig, 'not a pem')).toBe(false);
+  });
+
+  it('schema-invalid entries refuse the whole index', () => {
+    const bad = {
+      ...VALID_INDEX,
+      entries: [
+        ...VALID_INDEX.entries,
+        // version is a RANGE, not an exact pin → invalid.
+        {
+          id: 'evil',
+          label: 'Evil',
+          description: '',
+          packageName: '@moxxy/plugin-evil',
+          installSpec: '@moxxy/plugin-evil',
+          version: '^1.0.0',
+        },
+      ],
+    };
+    expect(parseRegistryIndex(Buffer.from(JSON.stringify(bad), 'utf8'))).toBeUndefined();
+    expect(parseRegistryIndex(Buffer.from('not json', 'utf8'))).toBeUndefined();
+    expect(
+      parseRegistryIndex(Buffer.from(JSON.stringify({ ...VALID_INDEX, version: 2 }), 'utf8')),
+    ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchSignedRegistry: source selection + fallback semantics
+// ---------------------------------------------------------------------------
+
+describe('fetchSignedRegistry', () => {
+  it('empty baked key short-circuits to fallback without touching the network', async () => {
+    const fetchImpl = vi.fn();
+    // No publicKeyPem override → the baked REGISTRY_PUBLIC_KEY ('') applies.
+    const res = await fetchSignedRegistry({ fetch: fetchImpl, cacheDir });
+    expect(res.source).toBe('fallback');
+    expect(res.reason?.code).toBe('key-not-provisioned');
+    expect(res.entries).toEqual(INSTALLABLE_PLUGIN_CATALOG);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('a valid remote index is returned as source remote and cached', async () => {
+    const { bytes, sig } = signedIndex();
+    const res = await fetchSignedRegistry({
+      fetch: fetchServing(bytes, sig),
+      cacheDir,
+      publicKeyPem,
+    });
+    expect(res.source).toBe('remote');
+    expect(res.reason).toBeUndefined();
+    expect(res.entries.map((e) => e.id)).toEqual(['telegram', 'virtual-office']);
+    expect(res.entries[0]?.version).toBe('0.26.0');
+    const cached = JSON.parse(readFileSync(cachePath(), 'utf8'));
+    expect(cached.sig).toBe(sig);
+    expect(Buffer.from(cached.indexB64, 'base64')).toEqual(Buffer.from(bytes));
+  });
+
+  it('a fresh cache is reused without a network fetch, and re-verified on read', async () => {
+    const { bytes, sig } = signedIndex();
+    const t0 = 1_000_000;
+    await fetchSignedRegistry({
+      fetch: fetchServing(bytes, sig),
+      cacheDir,
+      publicKeyPem,
+      now: () => t0,
+    });
+    const fetchImpl = vi.fn();
+    const res = await fetchSignedRegistry({
+      fetch: fetchImpl,
+      cacheDir,
+      publicKeyPem,
+      now: () => t0 + REGISTRY_CACHE_TTL_MS - 1,
+    });
+    expect(res.source).toBe('cache');
+    expect(res.entries[0]?.id).toBe('telegram');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('an expired cache re-fetches remote', async () => {
+    const { bytes, sig } = signedIndex();
+    const t0 = 1_000_000;
+    await fetchSignedRegistry({
+      fetch: fetchServing(bytes, sig),
+      cacheDir,
+      publicKeyPem,
+      now: () => t0,
+    });
+    const fetchImpl = vi.fn(fetchServing(bytes, sig));
+    const res = await fetchSignedRegistry({
+      fetch: fetchImpl,
+      cacheDir,
+      publicKeyPem,
+      now: () => t0 + REGISTRY_CACHE_TTL_MS + 1,
+    });
+    expect(res.source).toBe('remote');
+    expect(fetchImpl).toHaveBeenCalled();
+  });
+
+  it('a tampered cache is discarded (never trusted), and remote is fetched', async () => {
+    const { bytes, sig } = signedIndex();
+    const t0 = 1_000_000;
+    await fetchSignedRegistry({
+      fetch: fetchServing(bytes, sig),
+      cacheDir,
+      publicKeyPem,
+      now: () => t0,
+    });
+    // Tamper: swap the cached index bytes for a different (unsigned) payload
+    // while keeping the original signature and a fresh timestamp.
+    const cached = JSON.parse(readFileSync(cachePath(), 'utf8'));
+    const evil = { ...VALID_INDEX, entries: [] };
+    cached.indexB64 = Buffer.from(JSON.stringify(evil), 'utf8').toString('base64');
+    writeFileSync(cachePath(), JSON.stringify(cached));
+    const fetchImpl = vi.fn(fetchServing(bytes, sig));
+    const res = await fetchSignedRegistry({
+      fetch: fetchImpl,
+      cacheDir,
+      publicKeyPem,
+      now: () => t0 + 1, // well within TTL — only the tamper check can reject it
+    });
+    expect(res.source).toBe('remote');
+    expect(res.entries).toHaveLength(2);
+    expect(fetchImpl).toHaveBeenCalled();
+  });
+
+  it('a future cache timestamp is treated as stale, not fresh', async () => {
+    const { bytes, sig } = signedIndex();
+    await fetchSignedRegistry({
+      fetch: fetchServing(bytes, sig),
+      cacheDir,
+      publicKeyPem,
+      now: () => 5_000_000, // cache stamped "in the future" relative to the next read
+    });
+    const fetchImpl = vi.fn(fetchServing(bytes, sig));
+    const res = await fetchSignedRegistry({
+      fetch: fetchImpl,
+      cacheDir,
+      publicKeyPem,
+      now: () => 1_000, // clock says the cache is from the future
+    });
+    expect(res.source).toBe('remote');
+    expect(fetchImpl).toHaveBeenCalled();
+  });
+
+  it('a bad remote signature falls back to the hardcoded catalog', async () => {
+    const { bytes } = signedIndex();
+    const other = generateKeyPairSync('ed25519');
+    const wrongSig = cryptoSign(null, Buffer.from(bytes), other.privateKey).toString('base64');
+    const res = await fetchSignedRegistry({
+      fetch: fetchServing(bytes, wrongSig),
+      cacheDir,
+      publicKeyPem,
+    });
+    expect(res.source).toBe('fallback');
+    expect(res.reason?.code).toBe('bad-signature');
+    expect(res.entries).toEqual(INSTALLABLE_PLUGIN_CATALOG);
+  });
+
+  it('a signed-but-schema-invalid remote index falls back', async () => {
+    const { bytes, sig } = signedIndex({ ...VALID_INDEX, version: 99 });
+    const res = await fetchSignedRegistry({
+      fetch: fetchServing(bytes, sig),
+      cacheDir,
+      publicKeyPem,
+    });
+    expect(res.source).toBe('fallback');
+    expect(res.reason?.code).toBe('invalid-schema');
+  });
+
+  it('network errors and non-2xx responses fall back, never throw', async () => {
+    const boom: RegistryFetchLike = async () => {
+      throw new Error('ECONNREFUSED');
+    };
+    const res1 = await fetchSignedRegistry({ fetch: boom, cacheDir, publicKeyPem });
+    expect(res1.source).toBe('fallback');
+    expect(res1.reason?.code).toBe('network-error');
+
+    const notFound: RegistryFetchLike = async () => ({
+      ok: false,
+      status: 404,
+      arrayBuffer: async () => new ArrayBuffer(0),
+      text: async () => '',
+    });
+    const res2 = await fetchSignedRegistry({ fetch: notFound, cacheDir, publicKeyPem });
+    expect(res2.source).toBe('fallback');
+    expect(res2.reason?.code).toBe('http-error');
+  });
+
+  it('MOXXY_REGISTRY_URL overrides the fetch URL (signature still required)', async () => {
+    vi.stubEnv('MOXXY_REGISTRY_URL', 'https://example.test/custom.json');
+    const { bytes, sig } = signedIndex();
+    const seen: string[] = [];
+    const fetchImpl: RegistryFetchLike = async (url, init) => {
+      seen.push(url);
+      return fetchServing(bytes, sig)(url, init);
+    };
+    const res = await fetchSignedRegistry({ fetch: fetchImpl, cacheDir, publicKeyPem });
+    expect(res.source).toBe('remote');
+    expect(seen).toEqual([
+      'https://example.test/custom.json',
+      'https://example.test/custom.json.sig',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveInstallSource
+// ---------------------------------------------------------------------------
+
+describe('resolveInstallSource', () => {
+  it('a signed entry wins and carries the exact version pin', async () => {
+    const { bytes, sig } = signedIndex();
+    const resolved = await resolveInstallSource('telegram', {
+      fetch: fetchServing(bytes, sig),
+      cacheDir,
+      publicKeyPem,
+    });
+    expect(resolved.origin).toBe('signed');
+    expect(resolved.spec).toBe('@moxxy/plugin-telegram');
+    expect(resolved.pinnedVersion).toBe('0.26.0');
+    expect(resolved.capabilities?.net).toEqual({
+      mode: 'allowlist',
+      hosts: ['api.telegram.org'],
+    });
+  });
+
+  it('matches signed entries by package name too', async () => {
+    const { bytes, sig } = signedIndex();
+    const resolved = await resolveInstallSource('@moxxy/plugin-telegram', {
+      fetch: fetchServing(bytes, sig),
+      cacheDir,
+      publicKeyPem,
+    });
+    expect(resolved.origin).toBe('signed');
+    expect(resolved.pinnedVersion).toBe('0.26.0');
+  });
+
+  it('a signed git installSpec is never version-pinned', async () => {
+    const { bytes, sig } = signedIndex();
+    const resolved = await resolveInstallSource('virtual-office', {
+      fetch: fetchServing(bytes, sig),
+      cacheDir,
+      publicKeyPem,
+    });
+    expect(resolved.origin).toBe('signed');
+    expect(resolved.spec).toBe('github:moxxy-ai/virtual-office-plugin#main');
+    expect(resolved.pinnedVersion).toBeUndefined();
+  });
+
+  it('falls back to the hardcoded catalog when the key is unprovisioned', async () => {
+    const fetchImpl = vi.fn();
+    const resolved = await resolveInstallSource('telegram', { fetch: fetchImpl, cacheDir });
+    expect(resolved.origin).toBe('catalog');
+    expect(resolved.spec).toBe('@moxxy/plugin-telegram');
+    expect(resolved.pinnedVersion).toBeUndefined();
+    expect(resolved.registryFallback?.code).toBe('key-not-provisioned');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('passes unknown raw specs through untouched', async () => {
+    const resolved = await resolveInstallSource('some-third-party-pkg', { cacheDir });
+    expect(resolved.origin).toBe('spec');
+    expect(resolved.spec).toBe('some-third-party-pkg');
+    expect(resolved.pinnedVersion).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pin precedence: user > signed > cliVersion > latest
+// ---------------------------------------------------------------------------
+
+describe('pin precedence (installPluginPackagePinned + pinnedVersion)', () => {
+  const okInstall = (spec: string) => ({ installed: spec, dir: '/p' });
+
+  it('explicit user version beats the signed pin', async () => {
+    const installFn = vi.fn(async (o: { packageName: string }) => okInstall(o.packageName));
+    await installPluginPackagePinned({
+      packageName: '@moxxy/plugin-telegram',
+      version: '0.9.0',
+      pinnedVersion: '0.26.0',
+      cliVersion: '0.25.0',
+      installFn,
+    });
+    expect(installFn).toHaveBeenCalledWith(
+      expect.objectContaining({ packageName: '@moxxy/plugin-telegram@0.9.0' }),
+    );
+  });
+
+  it('the signed pin beats cliVersion lockstep', async () => {
+    const installFn = vi.fn(async (o: { packageName: string }) => okInstall(o.packageName));
+    await installPluginPackagePinned({
+      packageName: '@moxxy/plugin-telegram',
+      pinnedVersion: '0.26.0',
+      cliVersion: '0.25.0',
+      installFn,
+    });
+    expect(installFn).toHaveBeenCalledWith(
+      expect.objectContaining({ packageName: '@moxxy/plugin-telegram@0.26.0' }),
+    );
+  });
+
+  it('without a signed pin, cliVersion lockstep applies as before', async () => {
+    const installFn = vi.fn(async (o: { packageName: string }) => okInstall(o.packageName));
+    await installPluginPackagePinned({
+      packageName: '@moxxy/plugin-telegram',
+      cliVersion: '0.25.0',
+      installFn,
+    });
+    expect(installFn).toHaveBeenCalledWith(
+      expect.objectContaining({ packageName: '@moxxy/plugin-telegram@0.25.0' }),
+    );
+  });
+
+  it('a signed pin applies to non-first-party packages too', async () => {
+    const installFn = vi.fn(async (o: { packageName: string }) => okInstall(o.packageName));
+    await installPluginPackagePinned({
+      packageName: 'third-party-pkg',
+      pinnedVersion: '2.0.0',
+      cliVersion: '0.25.0',
+      installFn,
+    });
+    expect(installFn).toHaveBeenCalledWith(
+      expect.objectContaining({ packageName: 'third-party-pkg@2.0.0' }),
+    );
+  });
+
+  it('a signed pin is ignored for specs that already carry a version or are git/path-like', async () => {
+    const installFn = vi.fn(async (o: { packageName: string }) => okInstall(o.packageName));
+    await installPluginPackagePinned({
+      packageName: '@moxxy/plugin-x@2.0.0',
+      pinnedVersion: '1.0.0',
+      installFn,
+    });
+    expect(installFn).toHaveBeenCalledWith(
+      expect.objectContaining({ packageName: '@moxxy/plugin-x@2.0.0' }),
+    );
+    await installPluginPackagePinned({
+      packageName: 'github:moxxy-ai/x#main',
+      pinnedVersion: '1.0.0',
+      installFn,
+    });
+    expect(installFn).toHaveBeenLastCalledWith(
+      expect.objectContaining({ packageName: 'github:moxxy-ai/x#main' }),
+    );
+  });
+
+  it('a signed pin that 404s retries unpinned with a warning (availability-first v1)', async () => {
+    const installFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('npm install failed (exit 1): 404 Not Found'))
+      .mockResolvedValueOnce({ installed: '@moxxy/plugin-telegram', dir: '/p' });
+    const onWarn = vi.fn();
+    const res = await installPluginPackagePinned({
+      packageName: '@moxxy/plugin-telegram',
+      pinnedVersion: '0.26.0',
+      installFn,
+      onWarn,
+    });
+    expect(installFn).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ packageName: '@moxxy/plugin-telegram@0.26.0' }),
+    );
+    expect(installFn).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ packageName: '@moxxy/plugin-telegram' }),
+    );
+    expect(onWarn).toHaveBeenCalledTimes(1);
+    expect(res.installed).toBe('@moxxy/plugin-telegram');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Capability-manifest comparison: fires ONLY on widening
+// ---------------------------------------------------------------------------
+
+describe('checkCapabilityManifest', () => {
+  const declared = {
+    net: { mode: 'allowlist' as const, hosts: ['api.telegram.org'] },
+    fs: { read: ['$cwd/**'] },
+    subprocess: true,
+    commands: ['npm'],
+  };
+
+  it('no mismatch when the actual surface equals the manifest', () => {
+    const check = checkCapabilityManifest(declared, declared);
+    expect(check.capabilityMismatch).toBe(false);
+    expect(check.widened).toEqual([]);
+  });
+
+  it('no mismatch when the actual surface is NARROWER', () => {
+    const check = checkCapabilityManifest(declared, {
+      net: { mode: 'allowlist', hosts: ['api.telegram.org'] },
+    });
+    expect(check.capabilityMismatch).toBe(false);
+  });
+
+  it('net widening: any > allowlist, extra hosts, and net vs none', () => {
+    expect(
+      checkCapabilityManifest(declared, { net: { mode: 'any' } }).capabilityMismatch,
+    ).toBe(true);
+    const extraHost = checkCapabilityManifest(declared, {
+      net: { mode: 'allowlist', hosts: ['api.telegram.org', 'evil.example'] },
+    });
+    expect(extraHost.capabilityMismatch).toBe(true);
+    expect(extraHost.widened.join(' ')).toContain('evil.example');
+    expect(
+      checkCapabilityManifest({}, { net: { mode: 'allowlist', hosts: ['x'] } })
+        .capabilityMismatch,
+    ).toBe(true);
+  });
+
+  it('fs / env / subprocess widening is reported', () => {
+    expect(
+      checkCapabilityManifest(declared, { fs: { read: ['$cwd/**'], write: ['/etc/**'] } })
+        .capabilityMismatch,
+    ).toBe(true);
+    expect(checkCapabilityManifest({}, { env: ['AWS_SECRET'] }).capabilityMismatch).toBe(true);
+    expect(checkCapabilityManifest({}, { subprocess: true }).capabilityMismatch).toBe(true);
+  });
+
+  it('command widening: extra commands and unrestricted-vs-allowlist', () => {
+    const extra = checkCapabilityManifest(declared, { subprocess: true, commands: ['npm', 'curl'] });
+    expect(extra.capabilityMismatch).toBe(true);
+    expect(extra.widened.join(' ')).toContain('curl');
+    // No command list under subprocess:true = unrestricted → wider than ['npm'].
+    const unrestricted = checkCapabilityManifest(declared, { subprocess: true });
+    expect(unrestricted.capabilityMismatch).toBe(true);
+    // But an unrestricted manifest accepts any command list.
+    expect(
+      checkCapabilityManifest({ subprocess: true }, { subprocess: true, commands: ['rm'] })
+        .capabilityMismatch,
+    ).toBe(false);
+  });
+
+  it('budget widening: exceeding or dropping a declared ceiling', () => {
+    expect(
+      checkCapabilityManifest({ timeMs: 1000 }, { timeMs: 2000 }).capabilityMismatch,
+    ).toBe(true);
+    expect(checkCapabilityManifest({ timeMs: 1000 }, {}).capabilityMismatch).toBe(true);
+    expect(
+      checkCapabilityManifest({ timeMs: 1000 }, { timeMs: 500 }).capabilityMismatch,
+    ).toBe(false);
+    expect(checkCapabilityManifest({}, { timeMs: 500 }).capabilityMismatch).toBe(false);
+  });
+});

--- a/packages/plugin-plugins-admin/src/registry.ts
+++ b/packages/plugin-plugins-admin/src/registry.ts
@@ -1,0 +1,547 @@
+/**
+ * Signed plugin-registry v1 — CLIENT side: verification, fetch, cache, and
+ * fallback. The publisher tooling (index generation + signing) lives in the
+ * PRIVATE infra repo and is deliberately absent from this monorepo.
+ *
+ * ## Index format (the contract the publisher must produce)
+ *
+ * Two sibling files, served over HTTPS (default: the `moxxy-ai/registry`
+ * GitHub repo, raw `main`):
+ *
+ *   `index.json` — UTF-8 JSON:
+ *     {
+ *       "version": 1,                 // format version; anything else is refused
+ *       "generatedAt": "<ISO 8601>",  // informational (NOT a freshness proof)
+ *       "entries": [
+ *         {
+ *           "id": "telegram",                        // catalog id (stable, human)
+ *           "label": "Telegram channel",
+ *           "description": "…",
+ *           "packageName": "@moxxy/plugin-telegram", // bare npm name
+ *           "installSpec": "@moxxy/plugin-telegram", // npm name / git / path spec
+ *           "version": "0.26.0",                     // EXACT semver — the pin
+ *           "provides":     [{ "category": "channel", "name": "telegram" }], // optional
+ *           "capabilities": { …CapabilitySpec… }                             // optional
+ *         }
+ *       ]
+ *     }
+ *
+ *   `index.json.sig` — base64 Ed25519 signature over the EXACT BYTES of
+ *   `index.json`, verified against the baked {@link REGISTRY_PUBLIC_KEY}.
+ *
+ * Unlike the desktop app-update manifest (whose signature is embedded inside
+ * the signed document and therefore needs a canonical field-subset
+ * serialization), the registry signature is DETACHED — it covers the raw file
+ * verbatim, so there is no canonicalization step to keep in lockstep between
+ * signer and verifier. The publisher signs the file it uploads; we verify the
+ * bytes we downloaded.
+ *
+ * `version` is the integrity anchor: what the maintainer signed is a specific
+ * pinned release of each package, so a catalog install that resolves through
+ * a signed entry installs `packageName@version` — npm's `latest` dist-tag
+ * (mutable, hijackable) stops being load-bearing. `capabilities` is the
+ * package's DECLARED capability manifest (the `CapabilitySpec` shape from
+ * `@moxxy/sdk`) so surfaces can show the blast radius before installing and
+ * compare it against the post-install report (see
+ * {@link checkCapabilityManifest} — warn-only in v1; enforcement arrives with
+ * the consent phase).
+ *
+ * ## Trust model
+ *
+ * Single maintainer Ed25519 key, baked as {@link REGISTRY_PUBLIC_KEY}. Empty
+ * key ⇒ the whole remote path is disabled (hardcoded catalog only). Key
+ * rotation = ship a new CLI (see registry-key.ts). The fetch URL is
+ * overridable via `MOXXY_REGISTRY_URL` (testing / self-hosting) — this is NOT
+ * a trust decision: whatever the URL serves must still verify against the
+ * baked key.
+ *
+ * ## Fallback semantics
+ *
+ * `fetchSignedRegistry` NEVER throws into the install path. Any failure —
+ * missing key, network error, timeout, non-2xx, bad signature, invalid
+ * schema, oversized body — degrades to the hardcoded
+ * `INSTALLABLE_PLUGIN_CATALOG` with `source: 'fallback'` and a structured
+ * `reason`. A verified index is cached at `~/.moxxy/registry-cache.json`
+ * (bytes + signature) and RE-VERIFIED on every read — the cache is an
+ * availability/latency optimization, never a trust anchor: a tampered cache
+ * is discarded, and a cache older than the TTL (or timestamped in the
+ * future) is ignored rather than reused, bounding how long a frozen/stale
+ * index can be replayed.
+ */
+
+import { createPublicKey, verify as cryptoVerify } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { z, type CapabilitySpec } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
+import { INSTALLABLE_PLUGIN_CATALOG, resolveCatalogEntry, type PluginCatalogEntry } from './catalog.js';
+import { NPM_NAME_RE } from './shared.js';
+import { REGISTRY_PUBLIC_KEY } from './registry-key.js';
+
+/** Signed index format version this client understands. */
+export const REGISTRY_INDEX_VERSION = 1;
+
+/** Default index location; `.sig` is fetched from `<url>.sig`. */
+export const DEFAULT_REGISTRY_URL = 'https://raw.githubusercontent.com/moxxy-ai/registry/main/index.json';
+
+/** Verified indexes are reused from cache for this long before re-fetching. */
+export const REGISTRY_CACHE_TTL_MS = 60 * 60 * 1000;
+
+/** Fail fast if the registry host stalls (mirrors the npm-search timeout). */
+const REGISTRY_FETCH_TIMEOUT_MS = 10_000;
+
+/** Cache file under `~/.moxxy` (bytes + sig; re-verified on read). */
+const REGISTRY_CACHE_FILENAME = 'registry-cache.json';
+
+/** Refuse absurd bodies before verifying/parsing them. A real index is a few
+ *  hundred KB at most; this bounds what an unauthenticated response (the
+ *  bytes arrive BEFORE signature verification) can make us JSON-parse. */
+const MAX_INDEX_BYTES = 5 * 1024 * 1024;
+
+/** Exact `x.y.z` (optionally prerelease-suffixed) — a pin, never a range. */
+const EXACT_SEMVER_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$/;
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const providesSchema = z.array(
+  z.object({ category: z.string().min(1), name: z.string().min(1) }),
+);
+
+const netCapabilitySchema = z.discriminatedUnion('mode', [
+  z.object({ mode: z.literal('none') }),
+  z.object({ mode: z.literal('any') }),
+  z.object({ mode: z.literal('allowlist'), hosts: z.array(z.string()) }),
+]);
+
+/** `CapabilitySpec` from @moxxy/sdk, as wire data. Unknown keys are stripped
+ *  (not refused) so an older CLI tolerates future additive fields. */
+const capabilitySpecSchema = z.object({
+  fs: z
+    .object({
+      read: z.array(z.string()).optional(),
+      write: z.array(z.string()).optional(),
+    })
+    .optional(),
+  net: netCapabilitySchema.optional(),
+  env: z.array(z.string()).optional(),
+  timeMs: z.number().nonnegative().optional(),
+  memMb: z.number().nonnegative().optional(),
+  subprocess: z.boolean().optional(),
+  commands: z.array(z.string()).optional(),
+});
+
+const registryEntrySchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  description: z.string(),
+  packageName: z.string().regex(NPM_NAME_RE, 'must be a bare npm package name'),
+  installSpec: z.string().min(1),
+  version: z.string().regex(EXACT_SEMVER_RE, 'must be an exact semver pin'),
+  provides: providesSchema.optional(),
+  capabilities: capabilitySpecSchema.optional(),
+});
+
+const registryIndexSchema = z.object({
+  version: z.literal(REGISTRY_INDEX_VERSION),
+  generatedAt: z.string().min(1),
+  // One malformed entry refuses the WHOLE index (unlike npm-search results,
+  // which skip bad entries): the maintainer signed this file as a unit, so a
+  // partially-valid signed index is a publisher bug, not something to paper
+  // over entry-by-entry.
+  entries: z.array(registryEntrySchema).max(5000),
+});
+
+const cacheFileSchema = z.object({
+  fetchedAtMs: z.number().int().nonnegative(),
+  indexB64: z.string().min(1),
+  sig: z.string().min(1),
+});
+
+/** One signed, pinned installable plugin. Structurally a superset of
+ *  {@link PluginCatalogEntry} plus the exact `version` pin. */
+export interface PluginRegistryEntry {
+  readonly id: string;
+  readonly label: string;
+  readonly description: string;
+  readonly packageName: string;
+  readonly installSpec: string;
+  /** Exact semver the signature vouches for — the install pin. */
+  readonly version: string;
+  readonly provides?: ReadonlyArray<{ readonly category: string; readonly name: string }>;
+  /** Declared capability manifest for pre-install display + post-install comparison. */
+  readonly capabilities?: CapabilitySpec;
+}
+
+export interface PluginRegistryIndex {
+  readonly version: typeof REGISTRY_INDEX_VERSION;
+  readonly generatedAt: string;
+  readonly entries: ReadonlyArray<PluginRegistryEntry>;
+}
+
+// ---------------------------------------------------------------------------
+// Verification
+// ---------------------------------------------------------------------------
+
+/**
+ * True iff `sigB64` is a valid Ed25519 signature over the exact `bytes` for
+ * `publicKeyPem` (an SPKI PEM). Returns false — never throws — on malformed
+ * key/signature so callers can simply fall back. Mirrors
+ * `verifyManifestSignature` in desktop-host's app-update path.
+ */
+export function verifyRegistryIndex(
+  bytes: Uint8Array,
+  sigB64: string,
+  publicKeyPem: string,
+): boolean {
+  if (!publicKeyPem || !sigB64) return false;
+  try {
+    const key = createPublicKey(publicKeyPem);
+    return cryptoVerify(null, Buffer.from(bytes), key, Buffer.from(sigB64, 'base64'));
+  } catch {
+    return false;
+  }
+}
+
+/** Parse + schema-check verified index bytes. Undefined on anything off. */
+export function parseRegistryIndex(bytes: Uint8Array): PluginRegistryIndex | undefined {
+  if (bytes.byteLength > MAX_INDEX_BYTES) return undefined;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(Buffer.from(bytes).toString('utf8'));
+  } catch {
+    return undefined;
+  }
+  const parsed = registryIndexSchema.safeParse(raw);
+  return parsed.success ? parsed.data : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Fetch + cache + fallback
+// ---------------------------------------------------------------------------
+
+/** Minimal byte-capable `fetch` surface, injectable for tests. The registry
+ *  needs raw bytes (the signature covers them verbatim), so this is distinct
+ *  from search.ts's JSON-only `FetchLike`. */
+export type RegistryFetchLike = (
+  url: string,
+  init?: { readonly signal?: AbortSignal },
+) => Promise<{
+  readonly ok: boolean;
+  readonly status: number;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  text(): Promise<string>;
+}>;
+
+export interface RegistryFallbackReason {
+  readonly code:
+    | 'key-not-provisioned'
+    | 'network-error'
+    | 'timeout'
+    | 'http-error'
+    | 'bad-signature'
+    | 'invalid-schema';
+  readonly message: string;
+}
+
+/** A catalog-compatible entry; `version`/`capabilities` present only when it
+ *  came from a verified signed index (never on fallback entries). */
+export type RegistryResultEntry = PluginCatalogEntry & {
+  readonly version?: string;
+  readonly capabilities?: CapabilitySpec;
+};
+
+export interface SignedRegistryResult {
+  /** Where the entries came from. `cache` is a verified, fresh cached index. */
+  readonly source: 'remote' | 'cache' | 'fallback';
+  readonly entries: ReadonlyArray<RegistryResultEntry>;
+  /** Set only for `source: 'fallback'` — why the signed path was unavailable. */
+  readonly reason?: RegistryFallbackReason;
+}
+
+export interface FetchSignedRegistryOptions {
+  readonly fetch?: RegistryFetchLike;
+  /** Index URL; default {@link DEFAULT_REGISTRY_URL}, overridable per-process
+   *  via `MOXXY_REGISTRY_URL` (testing / self-hosting; not a trust decision). */
+  readonly url?: string;
+  /** Directory holding the cache file; default `~/.moxxy`. */
+  readonly cacheDir?: string;
+  /** Clock, injectable for TTL tests. */
+  readonly now?: () => number;
+  /** Verifying key; default the baked {@link REGISTRY_PUBLIC_KEY}. Injectable
+   *  for tests — there is intentionally NO env/config override for the key. */
+  readonly publicKeyPem?: string;
+  /** Cancels in-flight fetches (combined with the internal 10s deadline). */
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Fetch the signed plugin index, preferring a fresh verified cache, and
+ * degrade to the hardcoded catalog on ANY failure. Never throws.
+ */
+export async function fetchSignedRegistry(
+  opts: FetchSignedRegistryOptions = {},
+): Promise<SignedRegistryResult> {
+  const publicKeyPem = opts.publicKeyPem ?? REGISTRY_PUBLIC_KEY;
+  if (!publicKeyPem) {
+    return fallback('key-not-provisioned', 'no registry public key baked into this build');
+  }
+  const now = opts.now ?? Date.now;
+  const cachePath = path.join(opts.cacheDir ?? moxxyPath(), REGISTRY_CACHE_FILENAME);
+
+  // 1. Fresh verified cache (availability/latency only — re-verified above).
+  const cached = await readVerifiedCache(cachePath, publicKeyPem);
+  if (cached) {
+    const age = now() - cached.fetchedAtMs;
+    // A future timestamp (age < 0) is treated as stale, not fresh — the
+    // timestamp is outside the signature, so it must never EXTEND trust.
+    if (age >= 0 && age <= REGISTRY_CACHE_TTL_MS) {
+      return { source: 'cache', entries: cached.index.entries };
+    }
+  }
+
+  // 2. Remote fetch, hard 10s deadline.
+  const fetchImpl = opts.fetch ?? (globalThis.fetch as RegistryFetchLike | undefined);
+  if (!fetchImpl) return fallback('network-error', 'no fetch implementation available');
+  const url = opts.url ?? process.env.MOXXY_REGISTRY_URL ?? DEFAULT_REGISTRY_URL;
+  const deadline = AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS);
+  const signal = opts.signal ? AbortSignal.any([opts.signal, deadline]) : deadline;
+  let bytes: Uint8Array;
+  let sig: string;
+  try {
+    const [indexRes, sigRes] = await Promise.all([
+      fetchImpl(url, { signal }),
+      fetchImpl(`${url}.sig`, { signal }),
+    ]);
+    if (!indexRes.ok || !sigRes.ok) {
+      return fallback(
+        'http-error',
+        `registry fetch failed: index ${indexRes.status}, sig ${sigRes.status}`,
+      );
+    }
+    bytes = new Uint8Array(await indexRes.arrayBuffer());
+    sig = (await sigRes.text()).trim();
+  } catch (err) {
+    if (deadline.aborted) {
+      return fallback('timeout', `registry fetch exceeded ${REGISTRY_FETCH_TIMEOUT_MS}ms`);
+    }
+    return fallback('network-error', err instanceof Error ? err.message : String(err));
+  }
+
+  // 3. Verify BEFORE parsing — unverified bytes get one cheap size check and
+  // one signature check, nothing else.
+  if (bytes.byteLength > MAX_INDEX_BYTES) {
+    return fallback('invalid-schema', `index body exceeds ${MAX_INDEX_BYTES} bytes`);
+  }
+  if (!verifyRegistryIndex(bytes, sig, publicKeyPem)) {
+    return fallback('bad-signature', 'index signature did not verify against the baked key');
+  }
+  const index = parseRegistryIndex(bytes);
+  if (!index) {
+    return fallback('invalid-schema', 'signed index failed schema validation');
+  }
+
+  // 4. Cache best-effort (bytes + sig, so the read path re-verifies).
+  try {
+    const cacheBody: z.infer<typeof cacheFileSchema> = {
+      fetchedAtMs: now(),
+      indexB64: Buffer.from(bytes).toString('base64'),
+      sig,
+    };
+    await writeFileAtomic(cachePath, JSON.stringify(cacheBody));
+  } catch {
+    // A read-only home dir must not break installs.
+  }
+  return { source: 'remote', entries: index.entries };
+}
+
+function fallback(
+  code: RegistryFallbackReason['code'],
+  message: string,
+): SignedRegistryResult {
+  return {
+    source: 'fallback',
+    entries: INSTALLABLE_PLUGIN_CATALOG,
+    reason: { code, message },
+  };
+}
+
+async function readVerifiedCache(
+  cachePath: string,
+  publicKeyPem: string,
+): Promise<{ fetchedAtMs: number; index: PluginRegistryIndex } | undefined> {
+  let rawText: string;
+  try {
+    rawText = await fs.readFile(cachePath, 'utf8');
+  } catch {
+    return undefined;
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(rawText);
+  } catch {
+    return undefined;
+  }
+  const parsed = cacheFileSchema.safeParse(raw);
+  if (!parsed.success) return undefined;
+  const bytes = Buffer.from(parsed.data.indexB64, 'base64');
+  // Tampered cache = bytes that no longer verify → discarded, remote re-fetch.
+  if (!verifyRegistryIndex(bytes, parsed.data.sig, publicKeyPem)) return undefined;
+  const index = parseRegistryIndex(bytes);
+  if (!index) return undefined;
+  return { fetchedAtMs: parsed.data.fetchedAtMs, index };
+}
+
+// ---------------------------------------------------------------------------
+// Install-source resolution (pin integration)
+// ---------------------------------------------------------------------------
+
+export interface ResolvedInstallSource {
+  /** npm spec to install (hand to `installPluginPackagePinned`). */
+  readonly spec: string;
+  /** Resolved bare package name (status / remove bookkeeping). */
+  readonly packageName: string;
+  /** `signed` = verified index entry; `catalog` = hardcoded entry; `spec` =
+   *  the input passed through untouched (raw npm/git/path spec). */
+  readonly origin: 'signed' | 'catalog' | 'spec';
+  /**
+   * Exact version pin from the signed index. Present only for `signed`
+   * origins whose installSpec is a plain npm name (a git/path installSpec is
+   * not version-pinnable). Pin precedence at install time:
+   * explicit user version > this signed pin > cliVersion lockstep > latest.
+   */
+  readonly pinnedVersion?: string;
+  /** Declared capability manifest from the signed entry, when it carries one. */
+  readonly capabilities?: CapabilitySpec;
+  /** Why the signed registry was unavailable, when it was. */
+  readonly registryFallback?: RegistryFallbackReason;
+}
+
+/**
+ * Resolve a `moxxy plugins install <target>` / `install_plugin` target —
+ * catalog id, package name, or raw spec — consulting the signed registry
+ * first (when the key is provisioned), then the hardcoded catalog, then
+ * passing the spec through untouched. Never throws.
+ */
+export async function resolveInstallSource(
+  idOrSpec: string,
+  opts: FetchSignedRegistryOptions = {},
+): Promise<ResolvedInstallSource> {
+  const registry = await fetchSignedRegistry(opts);
+  if (registry.source !== 'fallback') {
+    const entry = registry.entries.find(
+      (e) => e.id === idOrSpec || e.packageName === idOrSpec,
+    );
+    if (entry) {
+      // Only a plain npm-name installSpec can carry a version pin; a signed
+      // git/path spec installs verbatim (its ref is its own pin).
+      const pinnable = entry.version !== undefined && NPM_NAME_RE.test(entry.installSpec);
+      return {
+        spec: entry.installSpec,
+        packageName: entry.packageName,
+        origin: 'signed',
+        ...(pinnable ? { pinnedVersion: entry.version } : {}),
+        ...(entry.capabilities ? { capabilities: entry.capabilities } : {}),
+      };
+    }
+  }
+  const catalogEntry = resolveCatalogEntry(idOrSpec);
+  if (catalogEntry) {
+    return {
+      spec: catalogEntry.installSpec,
+      packageName: catalogEntry.packageName,
+      origin: 'catalog',
+      ...(registry.reason ? { registryFallback: registry.reason } : {}),
+    };
+  }
+  return {
+    spec: idOrSpec,
+    packageName: idOrSpec,
+    origin: 'spec',
+    ...(registry.reason ? { registryFallback: registry.reason } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Capability-manifest comparison (warn-only in v1)
+// ---------------------------------------------------------------------------
+
+export interface CapabilityManifestCheck {
+  /** True when `actual` claims ANY surface the signed manifest didn't declare. */
+  readonly capabilityMismatch: boolean;
+  /** Axis-by-axis description of where `actual` exceeds `declared`. */
+  readonly widened: ReadonlyArray<string>;
+}
+
+const NET_RANK = { none: 0, allowlist: 1, any: 2 } as const;
+
+/**
+ * Compare a signed entry's declared capability manifest against the
+ * post-install aggregate surface (`buildCapabilityReport(...).surface`).
+ * Fires only on WIDENING — a package using less than it declared is fine.
+ *
+ * Conservative by construction: fs globs / env / commands are compared as
+ * string sets (no glob-subsumption analysis), so a differently-spelled but
+ * equivalent glob reads as widening. That bias is deliberate for a warn-only
+ * v1 — enforcement (refusing the install) arrives with the consent phase.
+ */
+export function checkCapabilityManifest(
+  declared: CapabilitySpec,
+  actual: CapabilitySpec,
+): CapabilityManifestCheck {
+  const widened: string[] = [];
+
+  const extras = (
+    have: ReadonlyArray<string> | undefined,
+    allowed: ReadonlyArray<string> | undefined,
+  ): string[] => {
+    const ok = new Set(allowed ?? []);
+    return (have ?? []).filter((v) => !ok.has(v));
+  };
+
+  const extraRead = extras(actual.fs?.read, declared.fs?.read);
+  if (extraRead.length) widened.push(`fs.read: ${extraRead.join(', ')}`);
+  const extraWrite = extras(actual.fs?.write, declared.fs?.write);
+  if (extraWrite.length) widened.push(`fs.write: ${extraWrite.join(', ')}`);
+
+  const declaredNet = declared.net?.mode ?? 'none';
+  const actualNet = actual.net?.mode ?? 'none';
+  if (NET_RANK[actualNet] > NET_RANK[declaredNet]) {
+    widened.push(`net: ${actualNet} (declared: ${declaredNet})`);
+  } else if (actual.net?.mode === 'allowlist' && declared.net?.mode === 'allowlist') {
+    const extraHosts = extras(actual.net.hosts, declared.net.hosts);
+    if (extraHosts.length) widened.push(`net.hosts: ${extraHosts.join(', ')}`);
+  }
+
+  const extraEnv = extras(actual.env, declared.env);
+  if (extraEnv.length) widened.push(`env: ${extraEnv.join(', ')}`);
+
+  if (actual.subprocess && !declared.subprocess) {
+    widened.push('subprocess (not declared)');
+  } else if (actual.subprocess && declared.subprocess) {
+    // An absent/empty command list under subprocess:true means UNRESTRICTED,
+    // so "no commands" is wider than any allowlist — not narrower.
+    const declaredUnrestricted = !declared.commands?.length;
+    const actualUnrestricted = !actual.commands?.length;
+    if (!declaredUnrestricted) {
+      if (actualUnrestricted) {
+        widened.push(`commands: unrestricted (declared: ${(declared.commands ?? []).join(', ')})`);
+      } else {
+        const extraCmds = extras(actual.commands, declared.commands);
+        if (extraCmds.length) widened.push(`commands: ${extraCmds.join(', ')}`);
+      }
+    }
+  }
+
+  // Budgets: a declared ceiling the actual surface exceeds (or drops — no
+  // budget means unbounded) is a widening. No declared ceiling = no bound.
+  if (declared.timeMs !== undefined && (actual.timeMs === undefined || actual.timeMs > declared.timeMs)) {
+    widened.push(`timeMs: ${actual.timeMs ?? 'unbounded'} (declared: ${declared.timeMs})`);
+  }
+  if (declared.memMb !== undefined && (actual.memMb === undefined || actual.memMb > declared.memMb)) {
+    widened.push(`memMb: ${actual.memMb ?? 'unbounded'} (declared: ${declared.memMb})`);
+  }
+
+  return { capabilityMismatch: widened.length > 0, widened };
+}


### PR DESCRIPTION
> **Stacked on #426** (`feat/security-audit-package`) — this PR consumes `buildCapabilityReport` / `aggregateCapabilitySpecs` from that branch. Merge #426 first; this diff is only the registry-client commit.

Phase 4.4 of the security roadmap, **client side only**: verification, fetch, cache, and fallback for an Ed25519-signed plugin index. Ships dormant — the baked `REGISTRY_PUBLIC_KEY` is `''`, so every code path degrades to the hardcoded catalog until a maintainer key is provisioned. The publisher tooling and the `moxxy-ai/registry` repo live in private infra (see "what the publisher must produce" below); nothing in this monorepo signs anything.

## Index format spec (v1) — the contract for the publisher side

Two sibling files served over HTTPS (default `https://raw.githubusercontent.com/moxxy-ai/registry/main/index.json`, overridable via `MOXXY_REGISTRY_URL` for testing/self-hosting — not a trust decision, the signature still must verify):

**`index.json`** (UTF-8 JSON):

```jsonc
{
  "version": 1,                  // format version; anything else is refused (old clients fall back)
  "generatedAt": "<ISO 8601>",   // informational only — NOT a freshness proof
  "entries": [
    {
      "id": "telegram",                         // stable catalog id
      "label": "Telegram channel",
      "description": "…",
      "packageName": "@moxxy/plugin-telegram",  // bare npm name (NPM_NAME_RE)
      "installSpec": "@moxxy/plugin-telegram",  // npm name / git / path spec
      "version": "0.26.0",                      // EXACT semver — the integrity anchor
      "provides":     [{ "category": "channel", "name": "telegram" }],  // optional
      "capabilities": { /* CapabilitySpec from @moxxy/sdk */ }          // optional
    }
  ]
}
```

**`index.json.sig`**: base64 Ed25519 signature over the **exact bytes** of `index.json`.

Notes for the publisher:

- The signature is **detached** and covers the raw file verbatim — no canonicalization (unlike the desktop app-update manifest, whose signature is embedded and needs a canonical field-subset). Sign the file you upload, byte for byte.
- `version` must be an exact `x.y.z` (optional prerelease suffix) — ranges/dist-tags are schema-refused. It is what the signature vouches for: a catalog install resolving through a signed entry installs `packageName@version`, so npm's mutable `latest` dist-tag stops being load-bearing.
- One malformed entry refuses the **whole** index (it was signed as a unit; a partially-valid signed index is a publisher bug). Unknown *fields* are stripped, not refused, so additive evolution doesn't break older CLIs.
- `capabilities` is the package's declared capability manifest (`CapabilitySpec` shape: `fs.read/write`, `net`, `env`, `subprocess`, `commands`, `timeMs`, `memMb`) used for pre-install display and the post-install widening check.
- Bounds: index body ≤ 5 MB, ≤ 5000 entries.

## Trust model

- **Single maintainer Ed25519 key**, baked as `REGISTRY_PUBLIC_KEY` in `packages/plugin-plugins-admin/src/registry-key.ts` — the exact pattern of the desktop `BUNDLED_UPDATE_PUBLIC_KEY`. No PKI.
- **Empty key ⇒ feature disabled entirely**: no network request is ever made; everything short-circuits to the hardcoded `INSTALLABLE_PLUGIN_CATALOG`. An unconfigured build can never be tricked into trusting an unsigned index.
- **Rotation** = paste the new public key and ship a new CLI. Older CLIs fail verification of newly-signed indexes and fall back to their hardcoded catalog — degraded, never compromised.
- There is intentionally **no env/config override for the key** (tests inject one programmatically). `MOXXY_REGISTRY_URL` only moves *where* we fetch, never *what we trust*.

## Fallback semantics

`fetchSignedRegistry` **never throws into the install path**. Result is `{ source, entries, reason? }`:

| Condition | `source` | `entries` | `reason.code` |
|---|---|---|---|
| Baked key empty (today's state) | `fallback` | hardcoded catalog | `key-not-provisioned` |
| Fresh cache (≤ 1 h), re-verifies against the baked key | `cache` | signed entries | — |
| Remote fetch OK + signature OK + schema OK | `remote` | signed entries (then cached) | — |
| DNS/conn/abort failure | `fallback` | hardcoded catalog | `network-error` |
| > 10 s deadline | `fallback` | hardcoded catalog | `timeout` |
| non-2xx on index or sig | `fallback` | hardcoded catalog | `http-error` |
| signature does not verify | `fallback` | hardcoded catalog | `bad-signature` |
| verified but schema-invalid / oversized | `fallback` | hardcoded catalog | `invalid-schema` |

Cache (`~/.moxxy/registry-cache.json`) stores the raw bytes + sig and is **re-verified on every read** — a tampered cache is discarded and remote is re-fetched. A stale (or future-timestamped) cache is ignored rather than reused, bounding replay/freeze windows to the 1 h TTL. The cache is an availability optimization, never a trust anchor. Cache writes are best-effort (a read-only home dir doesn't break installs).

## Pin precedence

```
explicit user version (--version / tool `version` param)
  > signed-index exact version
    > cliVersion lockstep (bare @moxxy/* names)
      > latest
```

- A signed pin only applies to a **plain npm-name** `installSpec` — git/path specs install verbatim (their ref is their own pin); a spec already carrying `@x.y.z` is never rewritten.
- A signed pin that 404s (unpublished release) retries unpinned **with a warning** — v1 is availability-first; fail-closed arrives with the consent phase.
- `moxxy plugins install <id>` and the `install_plugin` tool both resolve through `resolveInstallSource(idOrSpec)`, which consults the signed registry first, then the hardcoded catalog, then passes raw specs through.

## Capability-manifest check (warn-only in v1)

When a signed entry carries `capabilities` and the post-install report (`buildCapabilityReport`, from #426) computes a **wider** surface, the `install_plugin` result carries `capabilityMismatch: true` + `capabilityMismatchDetails` (declared manifest + axis-by-axis widening: fs globs, net mode/hosts, env, subprocess, command allowlists — where "no command list under `subprocess: true`" correctly counts as *unrestricted*, i.e. wider than any allowlist — and time/mem budgets). String-set comparison, no glob subsumption — conservatively biased toward warning. Enforcement (refusing the install) comes with the consent phase.

## What the PRIVATE publisher tooling must produce

1. A repo (planned: `moxxy-ai/registry`) serving `index.json` + `index.json.sig` at the default raw URL.
2. `index.json` exactly per the spec above — format `version: 1`, exact-semver `version` per entry, `packageName` matching `NPM_NAME_RE`.
3. `index.json.sig` = `base64(ed25519_sign(private_key, raw bytes of index.json))` — e.g. `openssl pkeyutl -sign -inkey moxxy-registry.key -rawin -in index.json | base64`.
4. The keypair: `openssl genpkey -algorithm ed25519`; the public SPKI PEM gets pasted into `registry-key.ts` (that paste + release is the activation switch).
5. Recommended: derive each entry's `capabilities` from `moxxy security audit --package` output at publish time so the manifest matches reality.

## Verification

- Full gate, exit codes checked directly: `pnpm build` 0, `pnpm typecheck` 0, `pnpm lint` 0 (errors), `pnpm test` 0, `pnpm check:deps` 0; CI smokes `bin.js --help` / `plugins list` both 0.
- 31 new tests in `registry.test.ts` (ephemeral Ed25519 keypair generated per run): valid index verifies + parses; tampered bytes refused; bad/missing/foreign-key signature refused; schema-invalid entries refuse the whole index; empty baked key short-circuits to fallback **without touching the network**; remote→cache round-trip re-verifies and discards a tampered cache; expired/future-timestamped cache re-fetches; every failure class maps to its structured fallback reason; `MOXXY_REGISTRY_URL` override; pin precedence (user > signed > cliVersion, incl. non-first-party and 404-retry); capability-mismatch fires **only** on widening (equal/narrower surfaces pass).
- Not touched, per plan: config schema (env override only), picker-handlers/builtins consent flows (sibling branch), `TECH_DEBT.md`, and no publisher/signing scripts in this repo.
