### PR TITLE
feat(security): install-time capability consent + third-party requireDeclaration ratchet

### DIFF
--- a/.changeset/install-consent.md
+++ b/.changeset/install-consent.md
@@ -1,0 +1,24 @@
+---
+'@moxxy/cli': minor
+'@moxxy/sdk': minor
+'@moxxy/plugin-security': minor
+'@moxxy/plugin-plugins-admin': minor
+'@moxxy/plugin-cli': minor
+'@moxxy/config': patch
+---
+
+Install-time capability consent + third-party requireDeclaration ratchet.
+Installing a plugin now surfaces the package's combined capability surface
+(fs globs, net mode/hosts, env, exec commands, time/memory budgets) in
+human-readable rows shared across every surface. Third-party packages
+(outside the `@moxxy/` scope) require explicit consent to stay enabled:
+the TUI opens a fail-closed post-install picker (ESC = decline = disabled),
+`moxxy plugins install` asks a default-NO confirm on a TTY and headless runs
+need `--yes` (otherwise the package is left installed but disabled), and the
+permission-gated `install_plugin` model tool keeps returning the report
+non-interactively. Undeclared tools are called out loudly — their surface is
+unknown, not empty. New `security.thirdPartyRequireDeclaration: off|warn|enforce`
+('warn' by default while security is enabled) logs a once-per-tool structured
+warning — or denies with 'enforce' — when a third-party tool has no isolation
+declaration; unattributed tools (e.g. runtime-attached MCP tools) are exempt.
+`moxxy security status` prints the new mode.

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -1,19 +1,25 @@
 import {
   INSTALLABLE_PLUGIN_CATALOG,
+  buildCapabilityReport,
   buildInstallSpec,
   clearPluginState,
+  describeCapabilitySurface,
   formatPluginCatalogStatus,
   installPluginPackagePinned,
   loadDisabledPackageNames,
+  packageNameFromSpec,
   removePluginPackage,
   resolveCatalogEntry,
   resolveCatalogPackageName,
   searchInstallablePlugins,
   setCategoryDefault,
   setPluginEnabled,
+  undeclaredToolsWarning,
+  type InstallCapabilityReport,
 } from '@moxxy/plugin-plugins-admin';
+import { isFirstPartyPackage } from '@moxxy/sdk';
 import type { ParsedArgv } from '../argv.js';
-import { argvToSetupOptions, bootSession, helpRequested } from '../argv-helpers.js';
+import { argvToSetupOptions, bootSession, hasBoolFlag, helpRequested } from '../argv-helpers.js';
 import { probeSession } from '../setup.js';
 import { isCriticalPackage } from '../setup/critical-packages.js';
 import { printError } from '../errors.js';
@@ -31,7 +37,10 @@ const HELP = formatHelp({
       rows: [
         ['list', 'list loaded + disabled plugins and the install catalog'],
         ['search <query>', 'search npm + catalog for installable plugins'],
-        ['install <spec> [--version v] [--ref r]', 'install from catalog id, npm, GitHub, or path'],
+        [
+          'install <spec> [--version v] [--ref r] [--yes]',
+          'install from catalog id, npm, GitHub, or path (--yes: accept a third-party capability surface without prompting)',
+        ],
         ['remove <pkg>', 'uninstall a plugin package'],
         ['enable <pkg>', 'enable (plug in) a plugin'],
         ['disable <pkg>', 'disable (unplug) a plugin — kept installed'],
@@ -185,11 +194,165 @@ async function runInstall(argv: ParsedArgv): Promise<number> {
         `source: ${result.installed}\nplugins dir: ${result.dir}\n` +
         colors.dim('run `moxxy plugins reload` (or restart) to load it\n'),
     );
-    return 0;
+    return await reviewInstallCapabilities(argv, entry?.packageName ?? packageNameFromSpec(spec));
   } catch (err) {
     printError(errorMessage(err));
     return 1;
   }
+}
+
+/**
+ * Post-install capability review + consent. Every install gets its combined
+ * capability surface printed (first-party included — informational). For a
+ * THIRD-PARTY package (outside the `@moxxy/` scope) the surface must be
+ * consented to: on a TTY via an explicit confirm defaulting to NO; headless
+ * only with `--yes` — otherwise the package is left installed but DISABLED.
+ *
+ * The consent is post-hoc by design: npm lifecycle scripts have already run
+ * by the time we can inspect anything, so what consent actually governs is
+ * whether the plugin participates in sessions from here on.
+ */
+async function reviewInstallCapabilities(
+  argv: ParsedArgv,
+  packageName: string | undefined,
+): Promise<number> {
+  if (!packageName) {
+    // Git/path specs don't reveal their package name pre-load; nothing to
+    // attribute tools to, so no automated review (and nothing to disable).
+    process.stdout.write(
+      colors.dim(
+        "couldn't derive a package name from this spec — skipping capability review; " +
+          'inspect it with `moxxy security audit --by-package` after reload\n',
+      ),
+    );
+    return 0;
+  }
+  const probe = await probeInstalledCapabilities(argv, packageName);
+  renderCapabilityReview(packageName, probe);
+  if (isFirstPartyPackage(packageName)) return 0;
+
+  // Third-party: explicit consent required to keep it enabled. Acceptance
+  // writes an explicit enable so a stale `enabled: false` from a previously
+  // declined install of the same package can't survive a consented re-install.
+  if (hasBoolFlag(argv, 'yes')) {
+    await setPluginEnabled(packageName, true);
+    process.stdout.write(colors.dim(`--yes: keeping ${packageName} enabled\n`));
+    return 0;
+  }
+  const tty = process.stdout.isTTY === true && process.stdin.isTTY === true;
+  if (!tty) {
+    await setPluginEnabled(packageName, false);
+    process.stdout.write(
+      `${packageName} is a third-party plugin and was left ${colors.bold('DISABLED')} ` +
+        '(no TTY to ask for consent).\n' +
+        'Re-run with --yes to accept its capability surface, or enable it later with ' +
+        `\`moxxy plugins enable ${packageName}\`.\n`,
+    );
+    return 0;
+  }
+  const { confirm, isCancel } = await import('@clack/prompts');
+  const keep = await confirm({
+    message: `${packageName} is third-party code. Keep it enabled with this capability surface?`,
+    initialValue: false,
+  });
+  if (isCancel(keep) || keep !== true) {
+    await setPluginEnabled(packageName, false);
+    process.stdout.write(
+      `disabled ${packageName} — it stays installed but contributes nothing.\n` +
+        colors.dim(`re-enable it anytime with \`moxxy plugins enable ${packageName}\`\n`),
+    );
+    return 0;
+  }
+  await setPluginEnabled(packageName, true);
+  process.stdout.write(colors.dim(`${packageName} stays enabled\n`));
+  return 0;
+}
+
+interface InstalledCapabilityProbe {
+  readonly toolNames: ReadonlyArray<string>;
+  readonly report?: InstallCapabilityReport;
+}
+
+/**
+ * Boot a throwaway probe session (the freshly installed package loads with
+ * everything else) and collect the package's tools + their combined
+ * capability surface via plugin-host attribution. Null when the probe
+ * itself fails — the review then proceeds with an unknown surface.
+ */
+async function probeInstalledCapabilities(
+  argv: ParsedArgv,
+  packageName: string,
+): Promise<InstalledCapabilityProbe | null> {
+  try {
+    return await probeSession(
+      argvToSetupOptions(argv, {
+        skipKeyPrompt: true,
+        tolerateNoProvider: true,
+        skipProviderActivation: true,
+      }),
+      ({ session }) => {
+        const toolNames = session.tools
+          .list()
+          .map((t) => t.name)
+          .filter((name) => session.pluginHost.ownerOfTool?.(name) === packageName);
+        const report = buildCapabilityReport(
+          toolNames,
+          (name) => session.tools.get(name)?.isolation,
+        );
+        return { toolNames, ...(report ? { report } : {}) };
+      },
+    );
+  } catch {
+    return null;
+  }
+}
+
+function renderCapabilityReview(
+  packageName: string,
+  probe: InstalledCapabilityProbe | null,
+): void {
+  if (!probe) {
+    process.stdout.write(
+      colors.yellow(
+        `couldn't inspect ${packageName}'s capability surface (probe failed) — ` +
+          'review it with `moxxy security audit --package ' +
+          packageName +
+          '`\n',
+      ),
+    );
+    return;
+  }
+  if (!probe.report) {
+    process.stdout.write(
+      colors.dim(
+        `${packageName} registers no tools — no declared capability surface ` +
+          '(providers/modes/channels it contributes still run unconfined)\n',
+      ),
+    );
+    return;
+  }
+  const { report } = probe;
+  process.stdout.write(
+    '\n' +
+      colors.bold('CAPABILITY SURFACE') +
+      colors.dim(` — ${report.declared}/${report.total} tools declared`) +
+      '\n',
+  );
+  const rows = describeCapabilitySurface(report.surface);
+  if (rows.length === 0) {
+    process.stdout.write(colors.dim('  (nothing declared beyond running in-process)\n'));
+  }
+  const labelCol = Math.max(9, ...rows.map((r) => r.label.length));
+  for (const { label, value } of rows) {
+    process.stdout.write(`  ${colors.bold(label.padEnd(labelCol))}  ${colors.dim(value)}\n`);
+  }
+  if (report.undeclaredTools?.length) {
+    process.stdout.write(
+      colors.yellow(`  ⚠ ${undeclaredToolsWarning(report.undeclaredTools.length, report.total)}\n`) +
+        colors.yellow(`    undeclared: ${report.undeclaredTools.join(', ')}\n`),
+    );
+  }
+  process.stdout.write('\n');
 }
 
 async function runRemove(argv: ParsedArgv): Promise<number> {

--- a/packages/cli/src/commands/security.ts
+++ b/packages/cli/src/commands/security.ts
@@ -1,4 +1,5 @@
 import { aggregateCapabilitySpecs, type CapabilitySpec } from '@moxxy/sdk';
+import { describeCapabilitySurface, undeclaredToolsWarning } from '@moxxy/plugin-plugins-admin';
 import type { ParsedArgv } from '../argv.js';
 import { bootSessionWithConfig, hasBoolFlag, helpRequested, stringFlag } from '../argv-helpers.js';
 import { printError } from '../errors.js';
@@ -17,7 +18,7 @@ const HELP = formatHelp({
         ['audit --package <name>', "one package's tools + their COMBINED capability surface"],
         ['audit --by-package', 'declared/total rollup per contributing plugin'],
         ['isolators', 'list available Isolator impls'],
-        ['status', 'show whether security is enabled and the default isolator'],
+        ['status', 'show enabled state, default isolator, and declaration/ratchet modes'],
       ],
     },
   ],
@@ -39,6 +40,17 @@ export async function runSecurityCommand(argv: ParsedArgv): Promise<number> {
   if (sub === 'status') {
     const enabled = config.security?.enabled ?? false;
     const isolator = config.plugins?.isolator?.default ?? '(default: inproc)';
+    // 'warn' is the plugin-side default while security is enabled (grace
+    // mode); surface it as such rather than pretending the ratchet is off.
+    const ratchet = config.security?.thirdPartyRequireDeclaration ?? 'warn';
+    const ratchetNote =
+      ratchet === 'enforce'
+        ? colors.bold('enforce — undeclared third-party tools are denied')
+        : ratchet === 'off'
+          ? colors.dim('off')
+          : colors.dim(
+              `warn${config.security?.thirdPartyRequireDeclaration ? '' : ' (default)'} — undeclared third-party tools log a warning`,
+            );
     process.stdout.write(
       `${colors.bold('enabled')}   ${enabled ? colors.bold('yes') : colors.dim('no')}\n` +
         `${colors.bold('isolator')}  ${colors.dim(isolator)}\n` +
@@ -46,7 +58,8 @@ export async function runSecurityCommand(argv: ParsedArgv): Promise<number> {
           config.security?.requireDeclaration
             ? colors.bold('declaration required')
             : colors.dim('not enforced')
-        }\n`,
+        }\n` +
+        `${colors.bold('3rd-party')} ${ratchetNote}\n`,
     );
     return 0;
   }
@@ -175,14 +188,14 @@ function renderPackageAudit(entries: ReadonlyArray<AuditEntry>, pkg: string): nu
       declared.map((e) => e.capabilities as CapabilitySpec | undefined),
     );
     process.stdout.write('\n' + colors.bold('COMBINED CAPABILITY SURFACE') + '\n');
-    for (const [label, value] of surfaceRows(surface)) {
-      process.stdout.write(`  ${colors.bold(label.padEnd(9))}  ${colors.dim(value)}\n`);
+    const rows = describeCapabilitySurface(surface);
+    const labelCol = Math.max(9, ...rows.map((r) => r.label.length));
+    for (const { label, value } of rows) {
+      process.stdout.write(`  ${colors.bold(label.padEnd(labelCol))}  ${colors.dim(value)}\n`);
     }
     if (undeclared.length > 0) {
       process.stdout.write(
-        colors.yellow(
-          `  (+ ${undeclared.length} undeclared tool${undeclared.length === 1 ? '' : 's'} with an UNKNOWN surface)\n`,
-        ),
+        colors.yellow(`  ⚠ ${undeclaredToolsWarning(undeclared.length, mine.length)}\n`),
       );
     }
   }
@@ -213,24 +226,6 @@ function renderByPackage(entries: ReadonlyArray<AuditEntry>): number {
     );
   }
   return 0;
-}
-
-/** Human rows for an aggregated CapabilitySpec (skips absent axes). */
-function surfaceRows(s: CapabilitySpec): Array<[string, string]> {
-  const rows: Array<[string, string]> = [];
-  if (s.fs?.read?.length) rows.push(['fs:read', s.fs.read.join(', ')]);
-  if (s.fs?.write?.length) rows.push(['fs:write', s.fs.write.join(', ')]);
-  if (s.net) {
-    rows.push([
-      'net',
-      s.net.mode === 'allowlist' ? `allowlist: ${s.net.hosts.join(', ')}` : s.net.mode,
-    ]);
-  }
-  if (s.env?.length) rows.push(['env', s.env.join(', ')]);
-  if (s.subprocess) rows.push(['exec', s.commands?.length ? s.commands.join(', ') : '(any command)']);
-  if (s.timeMs !== undefined) rows.push(['time', `≤ ${s.timeMs}ms`]);
-  if (s.memMb !== undefined) rows.push(['mem', `≤ ${s.memMb}MB`]);
-  return rows;
 }
 
 function formatCapabilities(caps: Readonly<Record<string, unknown>> | undefined): string {

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -2,11 +2,13 @@ import { runTurn, type Session } from '@moxxy/core';
 import { MoxxyError, isSelectableMode, type CategoryView, type Plugin } from '@moxxy/sdk';
 import type { MoxxyConfig } from '@moxxy/config';
 import {
+  buildCapabilityReport,
   diffSnapshot,
   findCatalogEntryForContribution,
   INSTALLABLE_PLUGIN_CATALOG,
   applySetupValues,
   installPluginPackagePinned,
+  packageNameFromSpec,
   readPluginSetup,
   resolveCatalogEntry,
   setCategoryDefault as persistCategoryDefault,
@@ -221,17 +223,6 @@ export function buildCategoryDefaultLive(session: Session): CategoryDefaultLive 
   };
 }
 
-/**
- * The bare package name of an npm spec (`@moxxy/x@1.2.3` → `@moxxy/x`), or
- * undefined for git/path specs whose installed package name isn't derivable
- * pre-install (the enable write is skipped — absent means enabled anyway).
- */
-function bareNameFromSpec(spec: string): string | undefined {
-  const at = spec.lastIndexOf('@');
-  const name = at > 0 ? spec.slice(0, at) : spec;
-  return /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(name) ? name : undefined;
-}
-
 function wirePluginsAdminView(
   session: Session,
   disabledPackages: Set<string>,
@@ -273,7 +264,10 @@ function wirePluginsAdminView(
     install: async (idOrSpec) => {
       const entry = resolveCatalogEntry(idOrSpec);
       const spec = entry?.installSpec ?? idOrSpec;
-      const packageName = entry?.packageName ?? bareNameFromSpec(spec);
+      // Package name is derivable pre-install for catalog/npm specs but not
+      // for git/path specs (the enable write is skipped — absent means
+      // enabled anyway).
+      const packageName = entry?.packageName ?? packageNameFromSpec(spec);
       const before = buildPluginSnapshot(session);
       const { installed } = await installPluginPackagePinned({
         packageName: spec,
@@ -283,9 +277,18 @@ function wirePluginsAdminView(
       if (packageName) await persistPluginEnabled(packageName, true);
       await session.pluginHost.reload();
       const setup = packageName ? await readPluginSetup(packageName) : null;
+      const registered = diffSnapshot(before, buildPluginSnapshot(session));
+      // The just-registered tools' combined capability surface — what the
+      // TUI renders for post-install consent (third-party) or as an info
+      // line (first-party). Same helper the install_plugin model tool uses.
+      const capabilities = buildCapabilityReport(
+        registered.tools ?? [],
+        (name) => session.tools.get(name)?.isolation,
+      );
       return {
         installed,
-        registered: diffSnapshot(before, buildPluginSnapshot(session)),
+        registered,
+        ...(capabilities ? { capabilities } : {}),
         ...(setup
           ? { needsSetup: { title: setup.title, required: setup.required === true } }
           : {}),
@@ -376,11 +379,13 @@ function buildWebhooksSlice(
 function buildSecuritySlice(
   session: Session,
   rawConfig: MoxxyConfig,
+  logger: BuildBuiltinsArgs['logger'],
 ): { entry: BuiltinEntry; security: SecurityPluginHandle } {
   // Its onInit hook fires AFTER every other plugin has registered, so it sees
   // the fully-populated tool registry when wrapping declared-isolation tools.
   // Tools without an `isolation` declaration pass through untouched (unless
-  // `security.requireDeclaration` is set).
+  // `security.requireDeclaration` is set, or — for third-party packages —
+  // `security.thirdPartyRequireDeclaration` warns/denies).
   const security = buildSecurityPlugin({
     config: {
       enabled: rawConfig.security?.enabled ?? false,
@@ -394,8 +399,14 @@ function buildSecuritySlice(
       ...(rawConfig.security?.requireDeclaration !== undefined
         ? { requireDeclaration: rawConfig.security.requireDeclaration }
         : {}),
+      ...(rawConfig.security?.thirdPartyRequireDeclaration !== undefined
+        ? { thirdPartyRequireDeclaration: rawConfig.security.thirdPartyRequireDeclaration }
+        : {}),
     },
     toolRegistry: session.tools,
+    // Sink for the third-party grace-mode warnings; the hook context carries
+    // no logger, so the plugin needs the host's.
+    logger,
     // Tool → contributing-plugin attribution from the plugin host's loaded
     // records. Called lazily (post-boot), so the registries are populated by
     // the time the security plugin or an audit view asks. This is what makes
@@ -474,7 +485,7 @@ export function buildBuiltinsCore(args: BuildBuiltinsArgs): BuiltBuiltinsCore {
   const webhooks = buildWebhooksSlice(webhookRunner, logger);
   entries.push(webhooks.entry);
 
-  const security = buildSecuritySlice(session, rawConfig);
+  const security = buildSecuritySlice(session, rawConfig, logger);
   entries.push(security.entry);
 
   return {

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -57,6 +57,22 @@ export const securityConfigSchema = z.object({
    */
   requireDeclaration: z.boolean().optional(),
   /**
+   * The requireDeclaration ratchet for THIRD-PARTY plugins only — packages
+   * outside the trusted `@moxxy/` scope. Applies when a tool has no
+   * `isolation` declaration and the global `requireDeclaration` above did
+   * not already deny it:
+   * - 'off'     — third-party tools are treated like first-party ones.
+   * - 'warn'    — grace mode (the default while `security.enabled`): the
+   *               call runs, but a structured warning is logged once per
+   *               tool per process.
+   * - 'enforce' — the call is denied with a reason naming this flag.
+   * Tools with no resolvable owning plugin (e.g. runtime-attached MCP
+   * tools) are exempt — the npm-scope test is meaningless for them.
+   * Consumed by `@moxxy/plugin-security`
+   * (`SecurityPluginConfig.thirdPartyRequireDeclaration`).
+   */
+  thirdPartyRequireDeclaration: z.enum(['off', 'warn', 'enforce']).optional(),
+  /**
    * Tighten the in-process input cap-check from best-effort to fail-closed.
    * By default the fs/net checks only inspect string values under a recognized
    * key name (`file`, `path`, `url`, …), so a path/URL carried by an

--- a/packages/config/src/security-config.test.ts
+++ b/packages/config/src/security-config.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { moxxyConfigSchema, securityConfigSchema } from './schema.js';
+
+describe('security.thirdPartyRequireDeclaration schema round-trip', () => {
+  it.each(['off', 'warn', 'enforce'] as const)('accepts and preserves %s', (mode) => {
+    const parsed = moxxyConfigSchema.parse({
+      security: { enabled: true, thirdPartyRequireDeclaration: mode },
+    });
+    expect(parsed.security?.thirdPartyRequireDeclaration).toBe(mode);
+  });
+
+  it('stays absent when unset (consumer applies the warn default)', () => {
+    const parsed = moxxyConfigSchema.parse({ security: { enabled: true } });
+    expect(parsed.security?.thirdPartyRequireDeclaration).toBeUndefined();
+  });
+
+  it('rejects values outside the closed enum', () => {
+    expect(() =>
+      securityConfigSchema.parse({ thirdPartyRequireDeclaration: 'deny' }),
+    ).toThrow();
+    expect(() =>
+      securityConfigSchema.parse({ thirdPartyRequireDeclaration: true }),
+    ).toThrow();
+  });
+
+  it('validates as a partial block (the field alone parses)', () => {
+    const parsed = securityConfigSchema.parse({ thirdPartyRequireDeclaration: 'enforce' });
+    expect(parsed).toEqual({ thirdPartyRequireDeclaration: 'enforce' });
+  });
+});

--- a/packages/plugin-cli/package.json
+++ b/packages/plugin-cli/package.json
@@ -33,6 +33,7 @@
     "@moxxy/config": "workspace:*",
     "@moxxy/core": "workspace:*",
     "@moxxy/plugin-mcp": "workspace:*",
+    "@moxxy/plugin-plugins-admin": "workspace:*",
     "@moxxy/sdk": "workspace:*",
     "ink": "catalog:",
     "react": "catalog:"

--- a/packages/plugin-cli/src/session/SessionView.tsx
+++ b/packages/plugin-cli/src/session/SessionView.tsx
@@ -528,7 +528,16 @@ export const SessionView: React.FC<SessionViewProps> = ({
           resolve(decision);
         }}
         onPickerSelect={handlePickerSelect}
-        onPickerCancel={() => setPicker(null)}
+        onPickerCancel={() => {
+          // Third-party install consent fails CLOSED: dismissing the picker
+          // (ESC / ctrl-c) counts as declining, so the freshly installed
+          // package gets disabled instead of silently staying enabled.
+          if (picker?.kind === 'install-consent') {
+            handlePickerSelect(picker, 'disable');
+            return;
+          }
+          setPicker(null);
+        }}
         onSubmit={handleSubmit}
         onPasteText={images.handlePasteText}
       />

--- a/packages/plugin-cli/src/session/picker-handlers.test.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.test.ts
@@ -5,8 +5,11 @@ import { openPluginsPicker } from './run-slash.js';
 
 // picker-handlers imports setCategoryDefault/setProviderModel from @moxxy/config
 // and re-open helpers from run-slash; stub both so the session branch tests stay
-// isolated from the filesystem and the other picker flows.
-vi.mock('@moxxy/config', () => ({
+// isolated from the filesystem and the other picker flows. Partial mock: the
+// @moxxy/plugin-plugins-admin import (capability consent copy) pulls other
+// @moxxy/config exports, which must keep resolving to the real module.
+vi.mock('@moxxy/config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@moxxy/config')>()),
   setCategoryDefault: vi.fn(async () => undefined),
   setProviderModel: vi.fn(async () => undefined),
   setConfigValue: vi.fn(async () => ({ path: '/tmp/config.yaml', config: {} })),
@@ -255,7 +258,8 @@ describe('makePickerHandler — install-on-first-use', () => {
   });
 
   it('mode picker install:: id installs the providing package then re-runs /mode', async () => {
-    const install = vi.fn(async () => ({ installed: 'x', registered: {} }));
+    // First-party spec: catalog installs resolve to the pinned @moxxy package.
+    const install = vi.fn(async () => ({ installed: '@moxxy/mode-goal@1.0.0', registered: {} }));
     const catalog = vi.fn(() => [
       {
         id: 'mode-goal',
@@ -277,6 +281,157 @@ describe('makePickerHandler — install-on-first-use', () => {
     await new Promise((r) => setImmediate(r));
     expect(install).toHaveBeenCalledWith('mode-goal');
     expect(rerunSlash).toHaveBeenCalledWith('/mode goal');
+  });
+});
+
+describe('makePickerHandler — third-party install consent', () => {
+  beforeEach(() => {
+    vi.mocked(openPluginsPicker).mockClear();
+  });
+
+  it('a third-party install opens the consent picker instead of finishing silently', async () => {
+    const install = vi.fn(async () => ({
+      installed: 'evil-tools@1.0.0',
+      registered: { tools: ['hack'] },
+      capabilities: {
+        declared: 0,
+        total: 1,
+        surface: {},
+        undeclaredTools: ['hack'],
+      },
+    }));
+    const setPicker = vi.fn();
+    const setSystemNotice = vi.fn();
+    const rerunSlash = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', pluginsAdmin: { install } } as never,
+        setPicker,
+        setSystemNotice,
+        rerunSlash,
+        installInFlightRef: { current: false },
+      }),
+    );
+    handle(
+      { kind: 'install-confirm', title: 't', catalogId: 'evil-tools', rerun: '/x', options: [] },
+      'install',
+    );
+    await new Promise((r) => setImmediate(r));
+    // The surface is rendered as the notice, with undeclared tools called out.
+    expect(setSystemNotice).toHaveBeenCalledWith(expect.stringContaining('third-party plugin'));
+    expect(setSystemNotice).toHaveBeenCalledWith(
+      expect.stringContaining('1 of 1 tool declares NO capabilities'),
+    );
+    // Consent picker opened; the follow-up (rerun) is deferred behind `keep`.
+    const consent = setPicker.mock.calls.map((c) => c[0]).find((p) => p?.kind === 'install-consent');
+    expect(consent).toMatchObject({ kind: 'install-consent', packageName: 'evil-tools' });
+    expect(rerunSlash).not.toHaveBeenCalled();
+  });
+
+  it('a first-party install skips consent but shows the capability info line', async () => {
+    const install = vi.fn(async () => ({
+      installed: '@moxxy/plugin-nice@1.0.0',
+      registered: { tools: ['nice'] },
+      capabilities: {
+        declared: 1,
+        total: 1,
+        surface: { net: { mode: 'allowlist', hosts: ['api.nice.dev'] } },
+      },
+    }));
+    const setPicker = vi.fn();
+    const setSystemNotice = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', pluginsAdmin: { install } } as never,
+        setPicker,
+        setSystemNotice,
+        installInFlightRef: { current: false },
+      }),
+    );
+    handle(pluginsPicker, 'plugin-nice::install');
+    await new Promise((r) => setImmediate(r));
+    expect(setSystemNotice).toHaveBeenLastCalledWith(
+      expect.stringContaining('network: only these hosts: api.nice.dev'),
+    );
+    const consent = setPicker.mock.calls.map((c) => c[0]).find((p) => p?.kind === 'install-consent');
+    expect(consent).toBeUndefined();
+  });
+
+  it('decline disables the package and explains how to re-enable it', async () => {
+    const setEnabled = vi.fn(async () => undefined);
+    const setSystemNotice = vi.fn();
+    const onKeep = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', pluginsAdmin: { setEnabled } } as never,
+        setSystemNotice,
+      }),
+    );
+    handle(
+      {
+        kind: 'install-consent',
+        title: 't',
+        packageName: 'evil-tools',
+        options: [],
+        onKeep,
+      },
+      'disable',
+    );
+    await new Promise((r) => setImmediate(r));
+    expect(setEnabled).toHaveBeenCalledWith('evil-tools', false);
+    expect(onKeep).not.toHaveBeenCalled();
+    expect(setSystemNotice).toHaveBeenCalledWith(
+      expect.stringContaining('moxxy plugins enable evil-tools'),
+    );
+  });
+
+  it('keep leaves the package enabled and runs the deferred follow-up', async () => {
+    const setEnabled = vi.fn(async () => undefined);
+    const onKeep = vi.fn();
+    const setSystemNotice = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', pluginsAdmin: { setEnabled } } as never,
+        setSystemNotice,
+      }),
+    );
+    handle(
+      {
+        kind: 'install-consent',
+        title: 't',
+        packageName: 'evil-tools',
+        options: [],
+        onKeep,
+      },
+      'keep',
+    );
+    await new Promise((r) => setImmediate(r));
+    expect(setEnabled).not.toHaveBeenCalled();
+    expect(onKeep).toHaveBeenCalledTimes(1);
+    expect(setSystemNotice).toHaveBeenCalledWith(expect.stringContaining('stays enabled'));
+  });
+
+  it('the consent picker survives the reopenPluginsPicker flow (deferred reopen)', async () => {
+    const install = vi.fn(async () => ({
+      installed: 'evil-tools@1.0.0',
+      registered: { tools: ['hack'] },
+    }));
+    const setPicker = vi.fn();
+    const handle = makePickerHandler(
+      baseDeps({
+        session: { id: 's', pluginsAdmin: { install } } as never,
+        setPicker,
+        setSystemNotice: vi.fn(),
+        installInFlightRef: { current: false },
+      }),
+    );
+    handle(pluginsPicker, 'evil-tools::install');
+    await new Promise((r) => setImmediate(r));
+    // The consent picker must be the LAST picker set — openPluginsPicker
+    // (mocked) must not run while consent is pending.
+    expect(openPluginsPicker).not.toHaveBeenCalled();
+    const last = setPicker.mock.calls.at(-1)?.[0];
+    expect(last).toMatchObject({ kind: 'install-consent', reopenPluginsPicker: true });
   });
 });
 

--- a/packages/plugin-cli/src/session/picker-handlers.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.ts
@@ -1,4 +1,13 @@
-import type { ClientSession as Session } from '@moxxy/sdk';
+import {
+  isFirstPartyPackage,
+  type ClientSession as Session,
+  type PluginsAdminView,
+} from '@moxxy/sdk';
+import {
+  describeCapabilitySurface,
+  packageNameFromSpec,
+  undeclaredToolsWarning,
+} from '@moxxy/plugin-plugins-admin';
 import { loadConfig, setCategoryDefault, setConfigValue, setProviderModel } from '@moxxy/config';
 import type { Picker } from './types.js';
 import {
@@ -78,6 +87,9 @@ export function makePickerHandler(deps: PickerHandlerDeps): (picker: Picker, id:
     }
     if (kind === 'install-confirm') {
       return handleInstallConfirm(picker, id, deps);
+    }
+    if (kind === 'install-consent') {
+      return handleInstallConsent(picker, id, deps);
     }
     if (kind === 'settings') {
       return handleSettingSelected(id, deps);
@@ -167,32 +179,60 @@ function runPickerInstall(
   deps.setSystemNotice(`installing ${target} via npm — this can take a minute…`);
   void (async () => {
     let ok = false;
+    let consentPending = false;
     try {
+      // Loaded-package names BEFORE the install: the fallback way to learn
+      // the installed package's name when the spec doesn't reveal it
+      // (git/path installs) — whatever appears in `loaded()` afterwards is it.
+      const loadedBefore = new Set(admin?.loaded?.().map((p) => p.name) ?? []);
       const res = await install(target);
       const kinds = Object.entries(res.registered)
         .filter(([, names]) => names && names.length > 0)
         .map(([kind, names]) => `${kind}: ${names!.join(', ')}`)
         .join('; ');
-      deps.setSystemNotice(`✓ installed ${res.installed}${kinds ? ` — registered ${kinds}` : ''}`);
+      const pkgName =
+        packageNameFromSpec(res.installed) ??
+        deps.session.pluginsAdmin?.loaded?.().find((p) => !loadedBefore.has(p.name))?.name;
+      // THIRD-PARTY (outside the @moxxy scope): the capability surface must
+      // be consented to before the plugin keeps running. The follow-up
+      // (setup dialog, slash rerun) is deferred behind the `keep` choice.
+      if (pkgName && !isFirstPartyPackage(pkgName)) {
+        ok = true;
+        consentPending = true;
+        deps.setSystemNotice(consentSurfaceNotice(pkgName, res.capabilities));
+        deps.setPicker({
+          kind: 'install-consent',
+          title: `${pkgName} is third-party code — keep it enabled?`,
+          packageName: pkgName,
+          onKeep: () => {
+            void runPostInstallFollowUp(deps, res, target, opts.onSuccess);
+          },
+          ...(opts.reopenPluginsPicker ? { reopenPluginsPicker: true } : {}),
+          options: [
+            {
+              id: 'disable',
+              label: 'Disable it',
+              description: 'stays installed but contributes nothing until you re-enable it',
+            },
+            {
+              id: 'keep',
+              label: 'Keep it enabled',
+              description: 'accept the capability surface shown above',
+            },
+          ],
+        });
+        return;
+      }
+      // First-party (the trusted co-versioned set) — no consent, but the
+      // capability report still shows as an info line.
+      deps.setSystemNotice(
+        `✓ installed ${res.installed}${kinds ? ` — registered ${kinds}` : ''}` +
+          capabilityInfoLine(res.capabilities),
+      );
       ok = true;
-      // Configure right here when the plugin declares a setup step — the
-      // dialog collects the fields and applySetup persists them (secrets →
-      // vault). Fall back to pointing at `moxxy init` when the session can't
-      // (RemoteSession) so the hint never silently disappears.
       if (res.needsSetup) {
-        const admin2 = deps.session.pluginsAdmin;
-        const pkg = admin2?.catalog().find((e) => e.id === target || e.packageName === target)?.packageName ?? target;
-        const spec = await admin2?.setupSpec?.(pkg).catch(() => null);
-        if (spec && deps.openPluginSetup) {
-          const after = opts.onSuccess;
-          deps.openPluginSetup({ packageName: pkg, spec, ...(after ? { then: after } : {}) });
-          if (opts.reopenPluginsPicker) return; // dialog owns the zone; skip reopen
-          return;
-        }
-        deps.setSystemNotice(
-          `✓ installed ${res.installed} — ${res.needsSetup.required ? '⚠ required setup' : 'optional setup'}: ` +
-            `"${res.needsSetup.title}" — run \`moxxy init\` (or /setup ${pkg}) to configure it.`,
-        );
+        await runPostInstallFollowUp(deps, res, target, opts.onSuccess);
+        return; // follow-up owns onSuccess (directly or via the dialog's `then`)
       }
     } catch (err) {
       deps.setSystemNotice(
@@ -201,10 +241,133 @@ function runPickerInstall(
     } finally {
       if (deps.installInFlightRef) deps.installInFlightRef.current = false;
       // Re-open with refreshed state: a success moves the plugin from the
-      // Installable tab into Packages; a failure keeps it installable.
-      if (opts.reopenPluginsPicker) openPluginsPicker(deps);
+      // Installable tab into Packages; a failure keeps it installable. Never
+      // while consent is pending — that would clobber the consent picker
+      // (handleInstallConsent reopens after the decision instead).
+      if (opts.reopenPluginsPicker && !consentPending) openPluginsPicker(deps);
     }
     if (ok) opts.onSuccess?.();
+  })();
+}
+
+/** What `pluginsAdmin.install` resolves with — kept in lockstep with the SDK. */
+type PickerInstallResult = Awaited<ReturnType<NonNullable<PluginsAdminView['install']>>>;
+
+/**
+ * Post-install follow-up shared by the first-party path and consent-`keep`:
+ * when the plugin declares a setup step, open the setup dialog right here
+ * (deferring `onSuccess` to its `then`) or surface the `moxxy init` hint when
+ * the session can't (RemoteSession) — then run `onSuccess`.
+ */
+async function runPostInstallFollowUp(
+  deps: PickerHandlerDeps,
+  res: PickerInstallResult,
+  target: string,
+  onSuccess?: () => void,
+): Promise<void> {
+  if (res.needsSetup) {
+    const admin = deps.session.pluginsAdmin;
+    const pkg =
+      admin?.catalog().find((e) => e.id === target || e.packageName === target)?.packageName ??
+      target;
+    const spec = await admin?.setupSpec?.(pkg).catch(() => null);
+    if (spec && deps.openPluginSetup) {
+      deps.openPluginSetup({ packageName: pkg, spec, ...(onSuccess ? { then: onSuccess } : {}) });
+      return; // dialog's `then` runs onSuccess after configuration
+    }
+    deps.setSystemNotice(
+      `✓ installed ${res.installed} — ${res.needsSetup.required ? '⚠ required setup' : 'optional setup'}: ` +
+        `"${res.needsSetup.title}" — run \`moxxy init\` (or /setup ${pkg}) to configure it.`,
+    );
+  }
+  onSuccess?.();
+}
+
+/**
+ * The consent body: the package's combined capability surface as
+ * human-readable rows (shared copy from @moxxy/plugin-plugins-admin, so the
+ * TUI and `moxxy plugins install` describe the exact same thing), with
+ * undeclared tools called out loudly — their surface is unknown, not empty.
+ */
+function consentSurfaceNotice(
+  packageName: string,
+  caps: PickerInstallResult['capabilities'],
+): string {
+  const lines = [`⚠ ${packageName} is a third-party plugin (outside the @moxxy scope).`];
+  if (!caps) {
+    lines.push(
+      'It registered no tools, so there is no declared capability surface to review —',
+      'any providers/modes/channels it contributes still run with full host access.',
+    );
+    return lines.join('\n');
+  }
+  lines.push(`Its ${caps.total} tool${caps.total === 1 ? '' : 's'} may:`);
+  const rows = describeCapabilitySurface(caps.surface);
+  if (rows.length === 0) {
+    lines.push('  (nothing declared beyond running in-process)');
+  } else {
+    const labelCol = Math.max(...rows.map((r) => r.label.length));
+    for (const r of rows) lines.push(`  ${r.label.padEnd(labelCol)}  ${r.value}`);
+  }
+  if (caps.undeclaredTools?.length) {
+    lines.push(`⚠ ${undeclaredToolsWarning(caps.undeclaredTools.length, caps.total)}`);
+  }
+  return lines.join('\n');
+}
+
+/** Compact capability info line appended to a first-party install notice. */
+function capabilityInfoLine(caps: PickerInstallResult['capabilities']): string {
+  if (!caps) return '';
+  const rows = describeCapabilitySurface(caps.surface);
+  const summary = rows.length
+    ? rows.map((r) => `${r.label.toLowerCase()}: ${r.value}`).join(' · ')
+    : 'no capabilities declared';
+  const undeclared = caps.undeclaredTools?.length
+    ? ` — ⚠ ${undeclaredToolsWarning(caps.undeclaredTools.length, caps.total)}`
+    : '';
+  return `\ncapabilities (${caps.declared}/${caps.total} tools declared): ${summary}${undeclared}`;
+}
+
+/**
+ * `install-consent` decision. Only the explicit `keep` keeps the freshly
+ * installed third-party package enabled (and runs the deferred follow-up:
+ * setup dialog, slash rerun). ANY other outcome — the `Disable it` option or
+ * ESC (SessionView routes picker-cancel here as `disable`) — fails closed:
+ * the package is disabled via the same persist+live-apply path `/plugins`
+ * uses, and the notice explains how to re-enable it.
+ */
+function handleInstallConsent(
+  picker: Extract<NonNullable<Picker>, { kind: 'install-consent' }>,
+  id: string,
+  deps: PickerHandlerDeps,
+): void {
+  if (id === 'keep') {
+    deps.setSystemNotice(`✓ ${picker.packageName} stays enabled`);
+    picker.onKeep?.();
+    if (picker.reopenPluginsPicker) openPluginsPicker(deps);
+    return;
+  }
+  void (async () => {
+    try {
+      const admin = deps.session.pluginsAdmin;
+      if (!admin) {
+        deps.setSystemNotice(
+          `can't disable ${picker.packageName} from this session — run \`moxxy plugins disable ${picker.packageName}\``,
+        );
+        return;
+      }
+      await admin.setEnabled(picker.packageName, false);
+      deps.setSystemNotice(
+        `✗ disabled ${picker.packageName} — it stays installed but contributes nothing. ` +
+          `Re-enable it with \`moxxy plugins enable ${picker.packageName}\` or /plugins.`,
+      );
+    } catch (err) {
+      deps.setSystemNotice(
+        `failed to disable ${picker.packageName}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      if (picker.reopenPluginsPicker) openPluginsPicker(deps);
+    }
   })();
 }
 

--- a/packages/plugin-cli/src/session/types.ts
+++ b/packages/plugin-cli/src/session/types.ts
@@ -64,6 +64,24 @@ export type Picker =
       rerun: string;
     }
   | {
+      /**
+       * Post-install capability consent for a THIRD-PARTY package (outside
+       * the `@moxxy/` scope). The capability surface is rendered as a system
+       * notice alongside this picker; `keep` runs the deferred follow-up
+       * (setup dialog, slash rerun), anything else — including ESC, which
+       * SessionView routes here as `disable` so consent fails closed —
+       * disables the package (kept installed).
+       */
+      kind: 'install-consent';
+      title: string;
+      options: ReadonlyArray<ListPickerOption>;
+      packageName: string;
+      /** Deferred post-install follow-up, run only on explicit consent. */
+      onKeep?: () => void;
+      /** Re-open the `/plugins` picker after the decision (install came from there). */
+      reopenPluginsPicker?: boolean;
+    }
+  | {
       /** `/settings` — curated config knobs (SETTINGS_KNOBS); selection
        *  toggles/cycles the value, persists it, live-applies, and reopens. */
       kind: 'settings';

--- a/packages/plugin-plugins-admin/src/capability-copy.test.ts
+++ b/packages/plugin-plugins-admin/src/capability-copy.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  describeCapabilitySurface,
+  summarizeCapabilitySurface,
+  undeclaredToolsWarning,
+} from './capability-copy.js';
+
+describe('describeCapabilitySurface', () => {
+  it('returns no rows for an empty spec', () => {
+    expect(describeCapabilitySurface({})).toEqual([]);
+  });
+
+  it('renders every declared axis as a label/value row', () => {
+    const rows = describeCapabilitySurface({
+      fs: { read: ['$cwd/**', '/tmp/**'], write: ['/tmp/out/**'] },
+      net: { mode: 'allowlist', hosts: ['api.example.com', 'cdn.example.com'] },
+      env: ['HOME', 'PATH'],
+      subprocess: true,
+      commands: ['git', 'npm'],
+      timeMs: 30_000,
+      memMb: 256,
+    });
+    expect(rows).toEqual([
+      { label: 'Read files', value: '$cwd/**, /tmp/**' },
+      { label: 'Write files', value: '/tmp/out/**' },
+      { label: 'Network', value: 'only these hosts: api.example.com, cdn.example.com' },
+      { label: 'Environment', value: 'reads HOME, PATH' },
+      { label: 'Run commands', value: 'git, npm' },
+      { label: 'Time budget', value: 'up to 30s per call' },
+      { label: 'Memory', value: 'up to 256 MB' },
+    ]);
+  });
+
+  it('says the scary things plainly: any-host net and unrestricted exec', () => {
+    const rows = describeCapabilitySurface({ net: { mode: 'any' }, subprocess: true });
+    expect(rows).toEqual([
+      { label: 'Network', value: 'any host (unrestricted)' },
+      { label: 'Run commands', value: 'any command' },
+    ]);
+  });
+
+  it('renders net mode none as an explicit reassurance, not silence', () => {
+    expect(describeCapabilitySurface({ net: { mode: 'none' } })).toEqual([
+      { label: 'Network', value: 'no network access' },
+    ]);
+  });
+
+  it('keeps sub-second time budgets in milliseconds', () => {
+    expect(describeCapabilitySurface({ timeMs: 750 })).toEqual([
+      { label: 'Time budget', value: 'up to 750ms per call' },
+    ]);
+  });
+});
+
+describe('summarizeCapabilitySurface', () => {
+  it('joins rows into one compact line', () => {
+    expect(
+      summarizeCapabilitySurface({ fs: { read: ['$cwd/**'] }, net: { mode: 'any' } }),
+    ).toBe('read files: $cwd/** · network: any host (unrestricted)');
+  });
+
+  it('is explicit when nothing is declared', () => {
+    expect(summarizeCapabilitySurface({})).toBe('declares no capabilities');
+  });
+});
+
+describe('undeclaredToolsWarning', () => {
+  it('calls out unknown-surface tools loudly, with correct plurals', () => {
+    expect(undeclaredToolsWarning(2, 5)).toBe(
+      '2 of 5 tools declare NO capabilities — their surface is unknown, not empty.',
+    );
+    expect(undeclaredToolsWarning(1, 1)).toBe(
+      '1 of 1 tool declares NO capabilities — their surface is unknown, not empty.',
+    );
+  });
+});

--- a/packages/plugin-plugins-admin/src/capability-copy.ts
+++ b/packages/plugin-plugins-admin/src/capability-copy.ts
@@ -1,0 +1,74 @@
+import type { CapabilitySpec } from '@moxxy/sdk';
+
+/**
+ * The ONE place install-consent copy lives. Both consent surfaces (the TUI
+ * post-install picker and the `moxxy plugins install` CLI confirm) and the
+ * `moxxy security audit` views render a capability surface through these
+ * helpers, so the wording a user consents to is identical everywhere.
+ * Mirrors the spirit of desktop-app-sdk's PERMISSION_LABELS: plain sentences
+ * a non-expert can act on, never spec-internal jargon.
+ */
+export interface CapabilitySurfaceRow {
+  /** Short human label for the capability axis (e.g. "Read files"). */
+  readonly label: string;
+  /** Human-readable scope of that axis (globs, hosts, commands, budgets). */
+  readonly value: string;
+}
+
+/**
+ * Human-readable label/value rows for an (aggregated) {@link CapabilitySpec}.
+ * Absent axes are skipped — an empty array means the spec declares nothing
+ * beyond running in-process. Rendering (padding, colors, bullets) is the
+ * caller's job; the copy is fixed here.
+ */
+export function describeCapabilitySurface(s: CapabilitySpec): ReadonlyArray<CapabilitySurfaceRow> {
+  const rows: CapabilitySurfaceRow[] = [];
+  if (s.fs?.read?.length) rows.push({ label: 'Read files', value: s.fs.read.join(', ') });
+  if (s.fs?.write?.length) rows.push({ label: 'Write files', value: s.fs.write.join(', ') });
+  if (s.net) {
+    rows.push({
+      label: 'Network',
+      value:
+        s.net.mode === 'allowlist'
+          ? `only these hosts: ${s.net.hosts.join(', ')}`
+          : s.net.mode === 'any'
+            ? 'any host (unrestricted)'
+            : 'no network access',
+    });
+  }
+  if (s.env?.length) rows.push({ label: 'Environment', value: `reads ${s.env.join(', ')}` });
+  if (s.subprocess) {
+    rows.push({
+      label: 'Run commands',
+      value: s.commands?.length ? s.commands.join(', ') : 'any command',
+    });
+  }
+  if (s.timeMs !== undefined) rows.push({ label: 'Time budget', value: `up to ${formatMs(s.timeMs)} per call` });
+  if (s.memMb !== undefined) rows.push({ label: 'Memory', value: `up to ${s.memMb} MB` });
+  return rows;
+}
+
+/** One-line summary of a surface, for compact info lines after an install. */
+export function summarizeCapabilitySurface(s: CapabilitySpec): string {
+  const rows = describeCapabilitySurface(s);
+  if (rows.length === 0) return 'declares no capabilities';
+  return rows.map((r) => `${r.label.toLowerCase()}: ${r.value}`).join(' · ');
+}
+
+/**
+ * The loud call-out for tools that declared nothing. An undeclared tool's
+ * surface is UNKNOWN — not empty — so consent copy must never let "no rows"
+ * read as "harmless".
+ */
+export function undeclaredToolsWarning(undeclared: number, total: number): string {
+  const tools = undeclared === 1 ? 'tool declares' : 'tools declare';
+  return (
+    `${undeclared} of ${total} ${tools} NO capabilities — ` +
+    'their surface is unknown, not empty.'
+  );
+}
+
+function formatMs(ms: number): string {
+  if (ms >= 1000 && ms % 1000 === 0) return `${ms / 1000}s`;
+  return `${ms}ms`;
+}

--- a/packages/plugin-plugins-admin/src/index.ts
+++ b/packages/plugin-plugins-admin/src/index.ts
@@ -18,12 +18,14 @@ import {
 import { buildSearchPluginsTool } from './search.js';
 
 export {
+  buildCapabilityReport,
   buildInstallPluginTool,
   buildUninstallPluginTool,
   installPluginPackage,
   installPluginPackagePinned,
   removePluginPackage,
   userPluginsDir,
+  type InstallCapabilityReport,
   type InstallPluginDeps,
   type InstallPluginPackageOptions,
   type InstallPluginPackageResult,
@@ -32,6 +34,13 @@ export {
   type RemovePluginPackageOptions,
   type RemovePluginPackageResult,
 } from './install.js';
+
+export {
+  describeCapabilitySurface,
+  summarizeCapabilitySurface,
+  undeclaredToolsWarning,
+  type CapabilitySurfaceRow,
+} from './capability-copy.js';
 
 export { pinFirstPartySpec } from './pin.js';
 
@@ -47,7 +56,7 @@ export {
 } from './setup-spec.js';
 export type { PluginSetupField, PluginSetupSpec } from '@moxxy/sdk';
 
-export { diffSnapshot, SNAPSHOT_KINDS } from './shared.js';
+export { diffSnapshot, packageNameFromSpec, SNAPSHOT_KINDS } from './shared.js';
 
 export {
   buildDisablePluginTool,

--- a/packages/plugin-plugins-admin/src/shared.test.ts
+++ b/packages/plugin-plugins-admin/src/shared.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { assertSafeNpmSpec, diffSnapshot, NPM_NAME_RE, type PluginSnapshot } from './shared.js';
+import {
+  assertSafeNpmSpec,
+  diffSnapshot,
+  NPM_NAME_RE,
+  packageNameFromSpec,
+  type PluginSnapshot,
+} from './shared.js';
 import { installPluginPackage, removePluginPackage } from './install.js';
 
 describe('assertSafeNpmSpec', () => {
@@ -53,6 +59,24 @@ describe('NPM_NAME_RE', () => {
     expect(NPM_NAME_RE.test('@moxxy/plugin-browser')).toBe(true);
     expect(NPM_NAME_RE.test('NOT VALID')).toBe(false);
     expect(NPM_NAME_RE.test('pkg@1.2.3')).toBe(false);
+  });
+});
+
+describe('packageNameFromSpec', () => {
+  it('strips a version/tag from bare and scoped specs', () => {
+    expect(packageNameFromSpec('@moxxy/plugin-x@1.2.3')).toBe('@moxxy/plugin-x');
+    expect(packageNameFromSpec('left-pad@latest')).toBe('left-pad');
+  });
+
+  it('returns plain names unchanged', () => {
+    expect(packageNameFromSpec('@moxxy/plugin-x')).toBe('@moxxy/plugin-x');
+    expect(packageNameFromSpec('left-pad')).toBe('left-pad');
+  });
+
+  it('returns undefined for git/path specs (name not derivable)', () => {
+    expect(packageNameFromSpec('github:me/repo')).toBeUndefined();
+    expect(packageNameFromSpec('git+https://github.com/me/repo.git')).toBeUndefined();
+    expect(packageNameFromSpec('./local/dir')).toBeUndefined();
   });
 });
 

--- a/packages/plugin-plugins-admin/src/shared.ts
+++ b/packages/plugin-plugins-admin/src/shared.ts
@@ -56,6 +56,19 @@ export function assertSafeNpmSpec(spec: string): string {
   return trimmed;
 }
 
+/**
+ * The bare package name of an npm spec (`@moxxy/x@1.2.3` → `@moxxy/x`,
+ * `foo@latest` → `foo`), or undefined for git/path specs whose installed
+ * package name isn't derivable from the spec text alone. Callers that need
+ * a name for those (e.g. install consent) must resolve it another way, such
+ * as diffing the loaded-plugin list around the install.
+ */
+export function packageNameFromSpec(spec: string): string | undefined {
+  const at = spec.lastIndexOf('@');
+  const name = at > 0 ? spec.slice(0, at) : spec;
+  return NPM_NAME_RE.test(name) ? name : undefined;
+}
+
 /** Contributions present in `after` but not `before`, grouped by kind. */
 export function diffSnapshot(
   before: PluginSnapshot,

--- a/packages/plugin-security/src/index.test.ts
+++ b/packages/plugin-security/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { ToolCallContext, ToolDef, ToolContext } from '@moxxy/sdk';
 import {
   buildSecurityPlugin,
@@ -354,6 +354,122 @@ describe('onToolCall enforces caps on tools registered after onInit', () => {
       fakeToolCallCtx('early', { file: '/etc/passwd' }),
     );
     expect(v).toBeUndefined();
+  });
+});
+
+// Phase 4.3: the requireDeclaration ratchet for third-party plugins — tools
+// with NO isolation spec from packages outside the @moxxy scope get warned
+// about (grace mode, the default) or denied ('enforce'). First-party and
+// unattributed tools are exempt.
+describe('thirdPartyRequireDeclaration ratchet', () => {
+  const build = (
+    over: Partial<Parameters<typeof buildSecurityPlugin>[0]['config']> = {},
+    resolve: ((name: string) => string | undefined) | null = (name) =>
+      name === 'evil' ? 'evil-plugin' : name === 'good' ? '@moxxy/plugin-good' : undefined,
+    logger?: { warn(msg: string, meta?: Record<string, unknown>): void },
+  ) => {
+    const reg = new FakeToolRegistry()
+      .add(fakeTool({ name: 'evil' }))
+      .add(fakeTool({ name: 'good' }))
+      .add(fakeTool({ name: 'mystery' })); // no resolvable owner (e.g. MCP)
+    return buildSecurityPlugin({
+      config: { enabled: true, ...over },
+      toolRegistry: reg,
+      resolvePluginForTool: resolve,
+      ...(logger ? { logger } : {}),
+    });
+  };
+
+  it("'enforce' denies an undeclared third-party tool, naming the flag", async () => {
+    const handle = build({ thirdPartyRequireDeclaration: 'enforce' });
+    const v = await handle.plugin.hooks?.onToolCall?.(fakeToolCallCtx('evil', {}));
+    expect(v).toEqual({
+      action: 'deny',
+      reason: expect.stringContaining('security.thirdPartyRequireDeclaration=enforce'),
+    });
+    expect((v as { reason: string }).reason).toContain('evil-plugin');
+  });
+
+  it("'enforce' still allows undeclared FIRST-PARTY tools", async () => {
+    const handle = build({ thirdPartyRequireDeclaration: 'enforce' });
+    const v = await handle.plugin.hooks?.onToolCall?.(fakeToolCallCtx('good', {}));
+    expect(v).toBeUndefined();
+  });
+
+  it("'enforce' exempts unattributed tools (no resolvable owner)", async () => {
+    const handle = build({ thirdPartyRequireDeclaration: 'enforce' });
+    const v = await handle.plugin.hooks?.onToolCall?.(fakeToolCallCtx('mystery', {}));
+    expect(v).toBeUndefined();
+  });
+
+  it('defaults to warn (grace mode): allows the call but logs a structured warning', async () => {
+    const warn = vi.fn();
+    const handle = build({}, undefined, { warn }); // thirdPartyRequireDeclaration unset
+    const v = await handle.plugin.hooks?.onToolCall?.(fakeToolCallCtx('evil', {}));
+    expect(v).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("third-party tool 'evil'"),
+      expect.objectContaining({ tool: 'evil', plugin: 'evil-plugin', mode: 'warn' }),
+    );
+  });
+
+  it('warns ONCE per tool name — repeated calls do not spam', async () => {
+    const warn = vi.fn();
+    const handle = build({ thirdPartyRequireDeclaration: 'warn' }, undefined, { warn });
+    await handle.plugin.hooks?.onToolCall?.(fakeToolCallCtx('evil', {}));
+    await handle.plugin.hooks?.onToolCall?.(fakeToolCallCtx('evil', {}));
+    await handle.plugin.hooks?.onToolCall?.(fakeToolCallCtx('evil', {}));
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('warn mode does not warn about first-party or unattributed tools', async () => {
+    const warn = vi.fn();
+    const handle = build({ thirdPartyRequireDeclaration: 'warn' }, undefined, { warn });
+    await handle.plugin.hooks?.onToolCall?.(fakeToolCallCtx('good', {}));
+    await handle.plugin.hooks?.onToolCall?.(fakeToolCallCtx('mystery', {}));
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("'off' disables the ratchet entirely", async () => {
+    const warn = vi.fn();
+    const handle = build({ thirdPartyRequireDeclaration: 'off' }, undefined, { warn });
+    const v = await handle.plugin.hooks?.onToolCall?.(fakeToolCallCtx('evil', {}));
+    expect(v).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('the global requireDeclaration deny wins before the ratchet runs', async () => {
+    const warn = vi.fn();
+    const handle = build(
+      { requireDeclaration: true, thirdPartyRequireDeclaration: 'warn' },
+      undefined,
+      { warn },
+    );
+    const v = await handle.plugin.hooks?.onToolCall?.(fakeToolCallCtx('evil', {}));
+    expect(v).toEqual({
+      action: 'deny',
+      reason: expect.stringContaining('security.requireDeclaration'),
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('a tool WITH a declaration never hits the ratchet', async () => {
+    const reg = new FakeToolRegistry().add(
+      fakeTool({ name: 'evil', isolation: { capabilities: { fs: { read: ['$cwd/**'] } } } }),
+    );
+    const warn = vi.fn();
+    const handle = buildSecurityPlugin({
+      config: { enabled: true, isolator: 'inproc', thirdPartyRequireDeclaration: 'enforce' },
+      toolRegistry: reg,
+      resolvePluginForTool: () => 'evil-plugin',
+      logger: { warn },
+    });
+    const v = await handle.plugin.hooks?.onToolCall?.(
+      fakeToolCallCtx('evil', { file: '/work/ok.ts' }),
+    );
+    expect(v).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/plugin-security/src/index.ts
+++ b/packages/plugin-security/src/index.ts
@@ -1,6 +1,7 @@
 import {
   definePlugin,
   ISOLATION_RANK,
+  isFirstPartyPackage,
   type IsolatedToolCall,
   type Isolator,
   type LifecycleHooks,
@@ -72,6 +73,16 @@ export interface SecurityPluginConfig {
   readonly perPlugin?: Readonly<Record<string, string>>;
   readonly requireDeclaration?: boolean;
   /**
+   * The requireDeclaration ratchet for THIRD-PARTY plugins (packages outside
+   * the `@moxxy/` scope). Considered only when a tool has NO isolation spec
+   * and the global `requireDeclaration` did not already deny it:
+   * 'off' = no special handling; 'warn' (default while enabled) = grace mode,
+   * a structured warning is logged once per tool name per process; 'enforce'
+   * = the call is denied. Tools whose owning plugin cannot be resolved are
+   * exempt (see the comment at the enforcement site).
+   */
+  readonly thirdPartyRequireDeclaration?: 'off' | 'warn' | 'enforce';
+  /**
    * Tighten the in-process input cap-check from best-effort to fail-closed.
    *
    * By DEFAULT the fs/net checks only inspect string values under a recognized
@@ -102,6 +113,12 @@ export interface BuildSecurityPluginOptions {
    * overrides. Pass `null` to disable plugin-level routing entirely.
    */
   readonly resolvePluginForTool?: ((toolName: string) => string | undefined) | null;
+  /**
+   * Sink for the third-party grace-mode warnings (and any future advisory
+   * output). The hook context carries no logger, so the host injects its
+   * own; absent = warnings are dropped (enforcement is unaffected).
+   */
+  readonly logger?: { warn(msg: string, meta?: Record<string, unknown>): void };
 }
 
 export interface SecurityPluginHandle {
@@ -133,6 +150,14 @@ export function buildSecurityPlugin(opts: BuildSecurityPluginOptions): SecurityP
 
   const resolvePluginForTool =
     opts.resolvePluginForTool === null ? null : opts.resolvePluginForTool;
+
+  // Grace mode ('warn') is the default while security is enabled: existing
+  // third-party plugins keep working, but every undeclared tool gets flagged
+  // so the user can ratchet to 'enforce' deliberately.
+  const thirdPartyMode = cfg.thirdPartyRequireDeclaration ?? 'warn';
+  // Once per tool name for this plugin instance — one security plugin is
+  // built per process, so this is the "once per process" no-spam guarantee.
+  const warnedThirdPartyTools = new Set<string>();
 
   const pickIsolatorName = (toolName: string): string => {
     if (cfg.perTool?.[toolName]) return cfg.perTool[toolName]!;
@@ -181,6 +206,46 @@ export function buildSecurityPlugin(opts: BuildSecurityPluginOptions): SecurityP
             action: 'deny',
             reason: `security.requireDeclaration: tool '${tool.name}' has no isolation spec`,
           };
+        }
+        // The third-party ratchet: undeclared tools from packages OUTSIDE the
+        // trusted `@moxxy/` scope get warned about (grace mode, the default)
+        // or denied ('enforce'). Runs only when the global requireDeclaration
+        // above didn't already deny.
+        //
+        // Unattributed tools (no owner resolvable) are EXEMPT from this path:
+        // they weren't installed as an npm package — runtime-attached MCP
+        // tools and dynamically registered tools have no package name, so the
+        // first/third-party scope test is meaningless for them, and treating
+        // "unknown owner" as "third-party" would deny every MCP tool the
+        // moment a user sets 'enforce'. Their exposure is governed by the
+        // global `requireDeclaration` instead.
+        if (thirdPartyMode !== 'off') {
+          const owner =
+            resolvePluginForTool === null ? undefined : resolvePluginForTool?.(tool.name);
+          if (owner && !isFirstPartyPackage(owner)) {
+            if (thirdPartyMode === 'enforce') {
+              return {
+                action: 'deny',
+                reason:
+                  `security.thirdPartyRequireDeclaration=enforce: tool '${tool.name}' ` +
+                  `from third-party plugin '${owner}' has no isolation spec`,
+              };
+            }
+            if (!warnedThirdPartyTools.has(tool.name)) {
+              warnedThirdPartyTools.add(tool.name);
+              opts.logger?.warn(
+                `security: third-party tool '${tool.name}' (from ${owner}) has no isolation ` +
+                  `spec — running unconfined. Set security.thirdPartyRequireDeclaration to ` +
+                  `'enforce' to deny such calls.`,
+                {
+                  tool: tool.name,
+                  plugin: owner,
+                  mode: 'warn',
+                  config: 'security.thirdPartyRequireDeclaration',
+                },
+              );
+            }
+          }
         }
         return;
       }

--- a/packages/sdk/src/first-party.test.ts
+++ b/packages/sdk/src/first-party.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { FIRST_PARTY_PLUGIN_SCOPE, isFirstPartyPackage } from './first-party.js';
+
+describe('isFirstPartyPackage (third-party detection)', () => {
+  it('accepts packages under the @moxxy scope', () => {
+    expect(isFirstPartyPackage('@moxxy/plugin-channel-slack')).toBe(true);
+    expect(isFirstPartyPackage('@moxxy/sdk')).toBe(true);
+  });
+
+  it('rejects bare (unscoped) packages', () => {
+    expect(isFirstPartyPackage('left-pad')).toBe(false);
+    expect(isFirstPartyPackage('moxxy-plugin-evil')).toBe(false);
+  });
+
+  it('rejects other scopes, including lookalikes', () => {
+    expect(isFirstPartyPackage('@moxxyy/plugin-x')).toBe(false);
+    expect(isFirstPartyPackage('@moxxy-plugins/x')).toBe(false);
+    expect(isFirstPartyPackage('@evil/moxxy')).toBe(false);
+  });
+
+  it('rejects a scope-only prefix trick (@moxxy without the slash)', () => {
+    // `@moxxy` alone is not under the scope: the slash is part of the prefix.
+    expect(FIRST_PARTY_PLUGIN_SCOPE.endsWith('/')).toBe(true);
+    expect(isFirstPartyPackage('@moxxy')).toBe(false);
+  });
+});

--- a/packages/sdk/src/first-party.ts
+++ b/packages/sdk/src/first-party.ts
@@ -1,0 +1,19 @@
+/**
+ * The npm scope every first-party moxxy package lives under. First-party
+ * packages are the trusted, co-versioned set (published together via the
+ * fixed changeset group); anything outside this scope is third-party code
+ * the user pulled in from the registry and gets stricter treatment:
+ * post-install capability consent and the `thirdPartyRequireDeclaration`
+ * ratchet in `@moxxy/plugin-security`.
+ */
+export const FIRST_PARTY_PLUGIN_SCOPE = '@moxxy/';
+
+/**
+ * Whether a package name belongs to the trusted first-party scope. The input
+ * is a bare npm package name (`@moxxy/plugin-x`, `some-plugin`) — pass names,
+ * not install specs (`name@1.2.3` would still work, but git/path specs are
+ * not names and should be resolved to one first).
+ */
+export function isFirstPartyPackage(packageName: string): boolean {
+  return packageName.startsWith(FIRST_PARTY_PLUGIN_SCOPE);
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -119,6 +119,8 @@ export type {
 } from './isolation.js';
 export { ISOLATION_RANK, aggregateCapabilitySpecs } from './isolation.js';
 
+export { FIRST_PARTY_PLUGIN_SCOPE, isFirstPartyPackage } from './first-party.js';
+
 export type {
   SubagentSpec,
   SubagentResult,

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -1,5 +1,6 @@
 import type { MoxxyEvent, TriggerOrigin, UserPromptAttachment } from './events.js';
 import type { SessionId, TurnId } from './ids.js';
+import type { CapabilitySpec } from './isolation.js';
 import type { EventLogReader } from './log.js';
 import type { ApprovalResolver, ModeBadge } from './mode.js';
 import type { PermissionResolver } from './permission.js';
@@ -366,6 +367,23 @@ export interface PluginsAdminView {
   install?(idOrSpec: string): Promise<{
     readonly installed: string;
     readonly registered: Readonly<Partial<Record<string, ReadonlyArray<string>>>>;
+    /**
+     * Combined capability surface of the tools this install registered —
+     * the package's blast radius, so a channel can render post-install
+     * consent (third-party packages) or an info line (first-party). Absent
+     * when the install registered no tools or the host cannot introspect
+     * isolation specs.
+     */
+    readonly capabilities?: {
+      /** Tools that declared an isolation spec. */
+      readonly declared: number;
+      /** Tools the install registered. */
+      readonly total: number;
+      /** Widest-wins union of the declared specs. */
+      readonly surface: CapabilitySpec;
+      /** Tools with NO declaration: their surface is unknown, not empty. */
+      readonly undeclaredTools?: ReadonlyArray<string>;
+    };
     /** Present when the package declares a `moxxy.setup` step to complete. */
     readonly needsSetup?: { readonly title: string; readonly required: boolean };
   }>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1654,6 +1654,9 @@ importers:
       '@moxxy/plugin-mcp':
         specifier: workspace:*
         version: link:../plugin-mcp
+      '@moxxy/plugin-plugins-admin':
+        specifier: workspace:*
+        version: link:../plugin-plugins-admin
       '@moxxy/sdk':
         specifier: workspace:*
         version: link:../sdk


### PR DESCRIPTION
Phase 4.3 of the security roadmap: what a plugin *may do* is now shown — and, for third-party code, consented to — at install time, and undeclared third-party tools are put on a ratchet.

Originally stacked on #426 (package-level capability aggregation); that PR merged while this one was in flight, so this now targets `development` directly on top of it.

## What / why

Installing a plugin used to report *what registered* (tools, modes, …) but not *what it may touch*. #426 gave us the package-level capability aggregation (`buildCapabilityReport`, `ownerOfTool` attribution); this PR puts that report in front of the user at the moment it matters — install time — and adds an enforcement ratchet for third-party packages that declare nothing.

**Third-party** = the installed package name is outside the `@moxxy/` scope (`isFirstPartyPackage` in the SDK — one predicate, used by consent and the ratchet). First-party catalog installs are the trusted co-versioned set: no consent, but the capability report still shows as an info line.

## Consent UX flows

- **TUI** (`/plugins` installable tab, install-on-first-use `install-confirm`): after a third-party install completes, the capability surface renders as human-readable rows (fs read/write globs, net mode+hosts, env, exec commands, time/memory budgets) with undeclared tools called out loudly ("N of M tools declare NO capabilities — their surface is unknown, not empty."), and a minimal `install-consent` picker asks *Keep it enabled? / Disable it*. **Fails closed**: ESC/ctrl-c on the picker counts as decline. Decline → `setEnabled(pkg, false)` (persist + live-unplug) + a notice pointing at `moxxy plugins enable <pkg>`. The post-install follow-up (setup dialog, slash rerun) is deferred behind explicit *keep*.
- **CLI** (`moxxy plugins install`): every install prints the capability surface (post-install probe session + `ownerOfTool` attribution). Third-party on a TTY → clack confirm, **default NO**. Non-TTY → proceeds only with the new `--yes`; otherwise the package is left installed but **disabled**, with a clear message. Consent acceptance writes an explicit `enabled: true` so a stale decline can't survive a consented re-install.
- **Model tool** (`install_plugin`): no interactive consent — it is already permission-gated; it keeps returning the `capabilities` report (from #426) for the model to relay.

Consent copy lives in ONE place: `describeCapabilitySurface` / `summarizeCapabilitySurface` / `undeclaredToolsWarning` in `@moxxy/plugin-plugins-admin` (`capability-copy.ts`), in the spirit of desktop-app-sdk's `PERMISSION_LABELS` (plain sentences, no jargon). `surfaceRows` in `moxxy security audit` now renders through the same helper, so the audit view and both consent surfaces describe the exact same thing.

## The ratchet: `security.thirdPartyRequireDeclaration`

Applies only while `security.enabled`, only to tools with **no** `isolation` declaration, and only after the global `requireDeclaration` check (which still denies everything undeclared regardless of origin):

| mode | third-party tool with no isolation spec |
|---|---|
| `off` | treated like first-party — runs as-is |
| `warn` *(default while security is enabled — grace mode)* | call runs; structured warning logged **once per tool name per process** (no spam) |
| `enforce` | call denied, reason names the flag and the owning package |

Exemptions (by design, documented in code):
- first-party (`@moxxy/*`) tools — governed by the global `requireDeclaration` only;
- **unattributed** tools (no resolvable owner — e.g. runtime-attached MCP tools, dynamically registered tools): they were never installed as an npm package, so the scope test is meaningless, and treating "unknown owner" as third-party would deny every MCP tool under `enforce`.

`moxxy security status` prints the mode (`3rd-party  warn (default) — undeclared third-party tools log a warning`).

## Implementation notes

- SDK: `isFirstPartyPackage` + `FIRST_PARTY_PLUGIN_SCOPE`; `PluginsAdminView.install` result gains `capabilities?` (same shape as `InstallCapabilityReport`). No runner protocol change — `pluginsAdmin` is undefined on a `RemoteSession`.
- `pluginsAdmin.install` (builtins.ts) computes the report from the registered-tools diff via `buildCapabilityReport` + `session.tools.get(name)?.isolation` — same helper as `install_plugin`.
- Package-name resolution: `packageNameFromSpec` (shared) for npm specs; the TUI falls back to a loaded-package diff around the install, so git/path installs still get attributed. The CLI path skips the review for underivable specs with an explicit message (see limitations).
- Consent is **post-hoc** by design: npm lifecycle scripts have already run by the time anything is inspectable; what consent governs is whether the plugin participates in sessions from here on.

## Verification

Full gate from the worktree root after the rebase onto `development`, each exit code checked directly: `pnpm build` ✓, `pnpm typecheck` ✓, `pnpm lint` ✓ (0 errors; 34 pre-existing warnings), `pnpm test` ✓ (132/132 turbo tasks + 8/8 script tests), `pnpm check:deps` ✓ (1 pre-existing warning).

New tests: ratchet matrix in plugin-security (enforce deny naming the flag, warn-default, warn-once, first-party/unattributed exemptions, off, global-requireDeclaration precedence, declared-tool bypass); consent decline/keep + third-party-vs-first-party detection + deferred-picker-reopen in plugin-cli; `describeCapabilitySurface` formatting; config schema round-trip; `isFirstPartyPackage` lookalike-scope cases; `packageNameFromSpec`.

End-to-end smoke against a sandboxed `$HOME`: `moxxy plugins install left-pad` non-TTY → installed, surface printed, left **DISABLED** with the `--yes` hint, `plugins.packages.left-pad.enabled: false` persisted; re-run with `--yes` → kept + re-enabled. `moxxy security status` and `moxxy plugins help` render the new lines.

## Manual verification checklist (needs a real TTY)

- [ ] `moxxy plugins install <third-party npm pkg>` on a TTY: surface renders, confirm defaults to **No**, decline persists `enabled: false`, `moxxy plugins enable <pkg>` recovers.
- [ ] TUI `/plugins` → install a third-party package: notice shows the surface, consent picker appears; ESC disables; *Keep it enabled* runs the setup dialog / rerun follow-up.
- [ ] Third-party package with declared-isolation tools: rows show real globs/hosts/commands; undeclared-tools call-out appears when mixed.
- [ ] With `security.enabled: true`, call an undeclared third-party tool: one warning in the log (once per tool); set `thirdPartyRequireDeclaration: enforce` → deny naming the flag.

## Limitations / follow-ups

- No desktop consent modal — out of scope here; the desktop installs through its own flow and should get a modal fed by the same `capabilities` report (follow-up).
- CLI capability review is skipped for git/path install specs (package name not derivable pre-load); the TUI covers those via the loaded-diff fallback.
- The capability surface only covers *tools*; a third-party provider/mode/channel has no declaration surface yet — the consent copy says so explicitly instead of implying safety.
