### PR TITLE
feat(voice): @moxxy/plugin-tts-openai — the first Synthesizer (OpenAI /v1/audio/speech)

### DIFF
--- a/.changeset/tts-openai.md
+++ b/.changeset/tts-openai.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/plugin-tts-openai': minor
+'@moxxy/plugin-plugins-admin': patch
+---
+
+New `@moxxy/plugin-tts-openai` — the first Synthesizer backend. Text-to-speech via OpenAI's `POST /v1/audio/speech` (one JSON POST returning audio bytes, no `openai` SDK dependency). Registers a single `openai-tts` synthesizer that the `SynthesizerRegistry` auto-adopts as the active read-aloud voice on install; the agent switches via `set_voice`. Config surface: `model` (default `gpt-4o-mini-tts`), `voice` (default `alloy`), `format` (default `mp3` → `audio/mpeg`; also `opus`/`wav`/`aac`). `SynthesizeOptions.voice` overrides the configured voice, `rate` maps to OpenAI `speed` clamped to 0.25–4.0, `signal` cancels the request, and input over OpenAI's 4096-char limit is truncated at a sentence boundary with an ellipsis. The API key rides the vault (`OPENAI_API_KEY`, shared with the OpenAI provider) with a `process.env` fallback; a missing key and HTTP/network failures surface as classified `MoxxyError`s. Added to the plugins-admin install catalog as `tts-openai`.

--- a/packages/plugin-plugins-admin/src/catalog.ts
+++ b/packages/plugin-plugins-admin/src/catalog.ts
@@ -270,6 +270,14 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     installSpec: '@moxxy/plugin-stt-whisper-codex',
   },
   {
+    id: 'tts-openai',
+    label: 'OpenAI read-aloud',
+    description: 'Text-to-speech via the OpenAI /v1/audio/speech API (reuses OPENAI_API_KEY).',
+    packageName: '@moxxy/plugin-tts-openai',
+    installSpec: '@moxxy/plugin-tts-openai',
+    provides: [{ category: 'synthesizer', name: 'openai-tts' }],
+  },
+  {
     id: 'provider-admin',
     label: 'Provider admin tools',
     description: 'provider_add/list/remove/test — register OpenAI-compatible vendors at runtime.',

--- a/packages/plugin-tts-openai/package.json
+++ b/packages/plugin-tts-openai/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@moxxy/plugin-tts-openai",
+  "version": "0.26.0",
+  "description": "OpenAI text-to-speech Synthesizer for moxxy. Text → spoken audio bytes via POST /v1/audio/speech. Plugs into the session's SynthesizerRegistry; read-aloud surfaces (desktop 'Read aloud', a voice channel) consume it transparently. The first shipped Synthesizer backend.",
+  "keywords": [
+    "moxxy",
+    "agent",
+    "tts",
+    "text-to-speech",
+    "openai",
+    "synthesizer"
+  ],
+  "homepage": "https://moxxy.ai",
+  "bugs": {
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
+    "directory": "packages/plugin-tts-openai"
+  },
+  "author": "Michal Makowski <michal.makowski97@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "moxxy": {
+    "plugin": {
+      "entry": "./dist/index.js",
+      "kind": "synthesizer"
+    },
+    "setup": {
+      "title": "OpenAI text-to-speech",
+      "description": "Read-aloud through OpenAI's /v1/audio/speech. Uses the same OPENAI_API_KEY as the OpenAI provider — if you already added that (via `moxxy init` or the OpenAI provider), you can skip this; leave it blank to reuse the existing key.",
+      "fields": [
+        {
+          "key": "apiKey",
+          "label": "OpenAI API key",
+          "kind": "secret",
+          "vaultKey": "OPENAI_API_KEY",
+          "required": false,
+          "placeholder": "sk-…",
+          "description": "Reuses the OpenAI provider key. Only needed if you haven't already stored OPENAI_API_KEY."
+        }
+      ]
+    }
+  },
+  "dependencies": {
+    "@moxxy/sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugin-tts-openai/src/index.ts
+++ b/packages/plugin-tts-openai/src/index.ts
@@ -1,0 +1,86 @@
+import { definePlugin, defineSynthesizer, type Plugin } from '@moxxy/sdk';
+import {
+  OpenAiSynthesizer,
+  type OpenAiSynthesizerOptions,
+  type OpenAiTtsFormat,
+} from './openai-tts.js';
+
+export {
+  OpenAiSynthesizer,
+  createOpenAiSynthesizer,
+  capInput,
+  clampSpeed,
+  type OpenAiSynthesizerOptions,
+  type OpenAiTtsFormat,
+  type FetchLike,
+} from './openai-tts.js';
+
+/** The single registered synthesizer name — surfaces show this in `set_voice`. */
+export const OPENAI_TTS_SYNTHESIZER_NAME = 'openai-tts';
+
+export interface BuildOpenAiTtsPluginOptions {
+  /**
+   * Build-time defaults baked into the synthesizer def. Per-activation config
+   * (`session.synthesizers.setActive(name, config)`) still overrides `model` /
+   * `voice` / `format`. Mainly a seam for tests to inject `fetchImpl` / `apiKey`.
+   */
+  readonly defaults?: Omit<OpenAiSynthesizerOptions, 'getSecret'>;
+}
+
+/**
+ * Build the @moxxy/plugin-tts-openai plugin. Registers exactly one synthesizer,
+ * `openai-tts`, backed by OpenAI's `/v1/audio/speech`.
+ *
+ * The plugin is intentionally side-effect free — it never calls `setActive`.
+ * The `SynthesizerRegistry` is `autoAdoptFirst`, so the first synthesizer
+ * registered (this one, on a fresh install) becomes active on read without any
+ * activation step here; the agent switches voices via the `set_voice` tool.
+ */
+export function buildOpenAiTtsPlugin(opts: BuildOpenAiTtsPluginOptions = {}): Plugin {
+  const defaults = opts.defaults ?? {};
+  return definePlugin({
+    name: '@moxxy/plugin-tts-openai',
+    version: '0.0.0',
+    synthesizers: [
+      defineSynthesizer({
+        name: OPENAI_TTS_SYNTHESIZER_NAME,
+        displayName: 'OpenAI TTS',
+        // `create` runs lazily and may re-run (buildOnRead) — keep it cheap and
+        // side-effect free; the key is resolved inside `synthesize`.
+        create: (ctx) =>
+          new OpenAiSynthesizer({
+            ...defaults,
+            ...configToOptions(ctx.config),
+            ...(ctx.getSecret ? { getSecret: ctx.getSecret } : {}),
+          }),
+      }),
+    ],
+  });
+}
+
+/** Narrow the untrusted per-activation config record into typed options. Only
+ *  string `model` / `voice` / `baseURL` / `apiKey` and a known `format` are
+ *  honored; anything else is ignored so a malformed config can't break create. */
+function configToOptions(config: Record<string, unknown>): Partial<OpenAiSynthesizerOptions> {
+  const out: { -readonly [K in keyof OpenAiSynthesizerOptions]?: OpenAiSynthesizerOptions[K] } = {};
+  if (typeof config.model === 'string' && config.model) out.model = config.model;
+  if (typeof config.voice === 'string' && config.voice) out.voice = config.voice;
+  if (typeof config.baseURL === 'string' && config.baseURL) out.baseURL = config.baseURL;
+  if (typeof config.apiKey === 'string' && config.apiKey) out.apiKey = config.apiKey;
+  const format = normalizeFormat(config.format);
+  if (format) out.format = format;
+  return out;
+}
+
+const KNOWN_FORMATS: ReadonlyArray<OpenAiTtsFormat> = ['mp3', 'opus', 'wav', 'aac'];
+
+/** Accept only the exact supported format strings (guards against inherited
+ *  keys like `constructor` slipping through an `in` check). */
+function normalizeFormat(value: unknown): OpenAiTtsFormat | undefined {
+  return typeof value === 'string' && (KNOWN_FORMATS as ReadonlyArray<string>).includes(value)
+    ? (value as OpenAiTtsFormat)
+    : undefined;
+}
+
+// Discovery entry: `createPluginLoader` requires a default Plugin export.
+export default buildOpenAiTtsPlugin();

--- a/packages/plugin-tts-openai/src/openai-tts.test.ts
+++ b/packages/plugin-tts-openai/src/openai-tts.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from 'vitest';
+import { OpenAiSynthesizer, capInput, clampSpeed, type FetchLike } from './openai-tts.js';
+import { buildOpenAiTtsPlugin, OPENAI_TTS_SYNTHESIZER_NAME } from './index.js';
+
+interface Captured {
+  url: string;
+  init: RequestInit;
+}
+
+/** A stub `fetch` that records the request and returns fixed audio bytes. */
+function okFetch(
+  bytes: Uint8Array = new Uint8Array([1, 2, 3, 4]),
+  status = 200,
+): { fetchImpl: FetchLike; calls: Captured[] } {
+  const calls: Captured[] = [];
+  const fetchImpl: FetchLike = async (url, init) => {
+    calls.push({ url, init });
+    return new Response(bytes, { status });
+  };
+  return { fetchImpl, calls };
+}
+
+/** A stub `fetch` that returns an error status with a body. */
+function statusFetch(status: number, body = 'boom'): FetchLike {
+  return async () => new Response(body, { status });
+}
+
+/** A `fetch` that never resolves and only rejects when its signal aborts —
+ *  checking `aborted` synchronously (as real fetch does) so it works even when
+ *  the signal fired before the request was issued. Drives abort + timeout. */
+const abortAwareFetch: FetchLike = (_url, init) =>
+  new Promise((_resolve, reject) => {
+    const signal = init.signal;
+    const fail = (): void => reject(new DOMException('Aborted', 'AbortError'));
+    if (signal?.aborted) fail();
+    else signal?.addEventListener('abort', fail, { once: true });
+  });
+
+/** Parse the JSON body a captured request carried. */
+function bodyOf(calls: Captured[]): Record<string, unknown> {
+  return JSON.parse(calls[0]!.init.body as string) as Record<string, unknown>;
+}
+
+describe('OpenAiSynthesizer.synthesize', () => {
+  it('returns audio bytes and the mp3 mimeType by default', async () => {
+    const { fetchImpl, calls } = okFetch(new Uint8Array([9, 8, 7]));
+    const synth = new OpenAiSynthesizer({ apiKey: 'sk-test', fetchImpl });
+    const out = await synth.synthesize('hello world');
+
+    expect(Array.from(out.audio)).toEqual([9, 8, 7]);
+    expect(out.mimeType).toBe('audio/mpeg');
+    expect(calls[0]!.url).toBe('https://api.openai.com/v1/audio/speech');
+    expect(calls[0]!.init.method).toBe('POST');
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    expect(headers.authorization).toBe('Bearer sk-test');
+    expect(headers['content-type']).toBe('application/json');
+    const body = bodyOf(calls);
+    expect(body.model).toBe('gpt-4o-mini-tts');
+    expect(body.voice).toBe('alloy');
+    expect(body.input).toBe('hello world');
+    expect(body.response_format).toBe('mp3');
+    expect(body.speed).toBeUndefined();
+  });
+
+  it.each([
+    ['mp3', 'audio/mpeg'],
+    ['opus', 'audio/ogg'],
+    ['wav', 'audio/wav'],
+    ['aac', 'audio/aac'],
+  ] as const)('maps format %s to mimeType %s', async (format, mimeType) => {
+    const { fetchImpl, calls } = okFetch();
+    const synth = new OpenAiSynthesizer({ apiKey: 'sk-test', fetchImpl, format });
+    const out = await synth.synthesize('hi');
+    expect(out.mimeType).toBe(mimeType);
+    expect(bodyOf(calls).response_format).toBe(format);
+  });
+
+  it('lets opts.voice override the configured voice', async () => {
+    const { fetchImpl, calls } = okFetch();
+    const synth = new OpenAiSynthesizer({ apiKey: 'sk-test', fetchImpl, voice: 'alloy' });
+    await synth.synthesize('hi', { voice: 'nova' });
+    expect(bodyOf(calls).voice).toBe('nova');
+  });
+
+  it('maps rate to speed', async () => {
+    const { fetchImpl, calls } = okFetch();
+    const synth = new OpenAiSynthesizer({ apiKey: 'sk-test', fetchImpl });
+    await synth.synthesize('hi', { rate: 1.5 });
+    expect(bodyOf(calls).speed).toBe(1.5);
+  });
+
+  it.each([
+    [10, 4.0],
+    [0.01, 0.25],
+    [Number.NaN, undefined],
+  ])('clamps rate %s to speed %s', async (rate, expected) => {
+    const { fetchImpl, calls } = okFetch();
+    const synth = new OpenAiSynthesizer({ apiKey: 'sk-test', fetchImpl });
+    await synth.synthesize('hi', { rate });
+    expect(bodyOf(calls).speed).toBe(expected);
+  });
+
+  it('truncates input over 4096 chars at a sentence boundary with an ellipsis', async () => {
+    const { fetchImpl, calls } = okFetch();
+    const synth = new OpenAiSynthesizer({ apiKey: 'sk-test', fetchImpl });
+    // 'a'*4000 + '. ' then more — the sentence boundary at index 4000 is the
+    // last one inside the 4095-char budget.
+    const long = `${'a'.repeat(4000)}. ${'b'.repeat(200)}. ${'c'.repeat(200)}`;
+    await synth.synthesize(long);
+    const input = bodyOf(calls).input as string;
+    expect(input.length).toBeLessThanOrEqual(4096);
+    expect(input.length).toBeLessThan(long.length);
+    expect(input.endsWith('…')).toBe(true);
+    // Cut fell right after the sentence-ending period, not mid-word.
+    expect(input.endsWith('.…')).toBe(true);
+  });
+
+  it('leaves short input untouched (no ellipsis)', async () => {
+    const { fetchImpl, calls } = okFetch();
+    const synth = new OpenAiSynthesizer({ apiKey: 'sk-test', fetchImpl });
+    await synth.synthesize('a short reply.');
+    expect(bodyOf(calls).input).toBe('a short reply.');
+  });
+
+  it('throws AUTH_NO_CREDENTIALS when no key is available anywhere', async () => {
+    const prev = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    try {
+      const { fetchImpl } = okFetch();
+      const synth = new OpenAiSynthesizer({ getSecret: async () => null, fetchImpl });
+      await expect(synth.synthesize('hi')).rejects.toMatchObject({
+        code: 'AUTH_NO_CREDENTIALS',
+      });
+    } finally {
+      if (prev !== undefined) process.env.OPENAI_API_KEY = prev;
+    }
+  });
+
+  it('reads the key from getSecret (OPENAI_API_KEY) when no explicit key', async () => {
+    const { fetchImpl, calls } = okFetch();
+    const synth = new OpenAiSynthesizer({
+      getSecret: async (name) => (name === 'OPENAI_API_KEY' ? 'sk-vault' : null),
+      fetchImpl,
+    });
+    await synth.synthesize('hi');
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    expect(headers.authorization).toBe('Bearer sk-vault');
+  });
+
+  it.each([
+    [401, 'AUTH_INVALID'],
+    [403, 'AUTH_DENIED'],
+    [429, 'PROVIDER_RATE_LIMITED'],
+    [500, 'PROVIDER_SERVER_ERROR'],
+    [503, 'PROVIDER_SERVER_ERROR'],
+  ])('maps HTTP %s to %s', async (status, code) => {
+    const synth = new OpenAiSynthesizer({ apiKey: 'sk-test', fetchImpl: statusFetch(status) });
+    await expect(synth.synthesize('hi')).rejects.toMatchObject({ code });
+  });
+
+  it('falls back to PROVIDER_BAD_REQUEST for an unmapped status', async () => {
+    const synth = new OpenAiSynthesizer({ apiKey: 'sk-test', fetchImpl: statusFetch(418) });
+    await expect(synth.synthesize('hi')).rejects.toMatchObject({
+      code: 'PROVIDER_BAD_REQUEST',
+      context: { status: 418 },
+    });
+  });
+
+  it('classifies a network failure', async () => {
+    const fetchImpl: FetchLike = async () => {
+      throw new Error('fetch failed');
+    };
+    const synth = new OpenAiSynthesizer({ apiKey: 'sk-test', fetchImpl });
+    await expect(synth.synthesize('hi')).rejects.toMatchObject({
+      code: 'NETWORK_UNREACHABLE',
+    });
+  });
+
+  it('honors an already-aborted signal, propagating its reason', async () => {
+    const { fetchImpl } = okFetch();
+    const synth = new OpenAiSynthesizer({ apiKey: 'sk-test', fetchImpl });
+    const ac = new AbortController();
+    const reason = new Error('user stopped');
+    ac.abort(reason);
+    await expect(synth.synthesize('hi', { signal: ac.signal })).rejects.toBe(reason);
+  });
+
+  it('honors an in-flight abort, propagating the caller reason', async () => {
+    const synth = new OpenAiSynthesizer({ apiKey: 'sk-test', fetchImpl: abortAwareFetch });
+    const ac = new AbortController();
+    const reason = new Error('cancelled mid-flight');
+    const p = synth.synthesize('hi', { signal: ac.signal });
+    ac.abort(reason);
+    await expect(p).rejects.toBe(reason);
+  });
+
+  it('times out a hung request as NETWORK_TIMEOUT', async () => {
+    const synth = new OpenAiSynthesizer({
+      apiKey: 'sk-test',
+      fetchImpl: abortAwareFetch,
+      timeoutMs: 10,
+    });
+    await expect(synth.synthesize('hi')).rejects.toMatchObject({ code: 'NETWORK_TIMEOUT' });
+  });
+});
+
+describe('capInput / clampSpeed helpers', () => {
+  it('capInput passes through under the limit', () => {
+    expect(capInput('short')).toBe('short');
+    expect(capInput('a'.repeat(4096))).toBe('a'.repeat(4096));
+  });
+
+  it('capInput hard-slices a single boundary-less sentence', () => {
+    const out = capInput('x'.repeat(5000));
+    expect(out.length).toBe(4096); // 4095 chars + the ellipsis
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('clampSpeed clamps and drops non-finite', () => {
+    expect(clampSpeed(undefined)).toBeUndefined();
+    expect(clampSpeed(Number.POSITIVE_INFINITY)).toBeUndefined();
+    expect(clampSpeed(1)).toBe(1);
+    expect(clampSpeed(9)).toBe(4);
+    expect(clampSpeed(0)).toBe(0.25);
+  });
+});
+
+describe('buildOpenAiTtsPlugin', () => {
+  it('registers exactly one synthesizer named openai-tts', () => {
+    const plugin = buildOpenAiTtsPlugin();
+    expect(plugin.synthesizers).toHaveLength(1);
+    const def = plugin.synthesizers![0]!;
+    expect(def.name).toBe(OPENAI_TTS_SYNTHESIZER_NAME);
+    expect(def.displayName).toBe('OpenAI TTS');
+  });
+
+  it('create() yields a synthesizer whose config voice/format flow through', async () => {
+    const { fetchImpl, calls } = okFetch();
+    const plugin = buildOpenAiTtsPlugin({ defaults: { fetchImpl, apiKey: 'sk-test' } });
+    const def = plugin.synthesizers![0]!;
+    const inst = def.create({ config: { voice: 'nova', format: 'opus' } });
+    expect(inst.name).toBe('openai-tts');
+    const out = await inst.synthesize('hi');
+    expect(out.mimeType).toBe('audio/ogg');
+    expect(bodyOf(calls).voice).toBe('nova');
+  });
+
+  it('create() wires ctx.getSecret through for key resolution', async () => {
+    const { fetchImpl, calls } = okFetch();
+    const plugin = buildOpenAiTtsPlugin({ defaults: { fetchImpl } });
+    const def = plugin.synthesizers![0]!;
+    const inst = def.create({
+      config: {},
+      getSecret: async (name) => (name === 'OPENAI_API_KEY' ? 'sk-ctx' : null),
+    });
+    await inst.synthesize('hi');
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    expect(headers.authorization).toBe('Bearer sk-ctx');
+  });
+
+  it('create() ignores an unknown config format', async () => {
+    const { fetchImpl } = okFetch();
+    const plugin = buildOpenAiTtsPlugin({ defaults: { fetchImpl, apiKey: 'sk-test' } });
+    const inst = plugin.synthesizers![0]!.create({ config: { format: 'flac' } });
+    const out = await inst.synthesize('hi');
+    // Unknown format ignored → default mp3.
+    expect(out.mimeType).toBe('audio/mpeg');
+  });
+});

--- a/packages/plugin-tts-openai/src/openai-tts.ts
+++ b/packages/plugin-tts-openai/src/openai-tts.ts
@@ -1,0 +1,233 @@
+import {
+  classifyHttpStatus,
+  classifyNetworkError,
+  MoxxyError,
+  type Synthesizer,
+  type SynthesizeOptions,
+  type SynthesisResult,
+} from '@moxxy/sdk';
+
+/** Provider tag attached to classified errors for logs/debug context. */
+const OPENAI_TTS_PROVIDER_ID = 'openai';
+
+/** OpenAI `/v1/audio/speech` response formats we expose, mapped to the MIME
+ *  type the desktop/channels play the returned bytes as. Kept a small closed
+ *  map (OpenAI also serves flac/pcm — not surfaced here). */
+const MIME_BY_FORMAT = {
+  mp3: 'audio/mpeg',
+  opus: 'audio/ogg',
+  wav: 'audio/wav',
+  aac: 'audio/aac',
+} as const;
+
+export type OpenAiTtsFormat = keyof typeof MIME_BY_FORMAT;
+
+/** OpenAI rejects `input` longer than 4096 characters. Channels routinely send
+ *  long replies, so we truncate at a sentence boundary rather than let the API
+ *  400 the whole read-aloud. */
+const MAX_INPUT_CHARS = 4096;
+
+/** OpenAI clamps `speed` to this inclusive range; anything outside 400s. */
+const MIN_SPEED = 0.25;
+const MAX_SPEED = 4.0;
+
+/** Default per-request deadline. Read-aloud is cancellable, but a hung socket
+ *  should still free itself so callers can fall back to the OS voice. */
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+/** Injectable `fetch` — the default is the global; tests pass a stub. Widened
+ *  from the global signature so a plain `(url, init) => Response` stub fits. */
+export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export interface OpenAiSynthesizerOptions {
+  /** Explicit API key. Normally omitted — the key is read via `getSecret`. */
+  readonly apiKey?: string;
+  /** Vault-backed secret resolver handed in by `SynthesizerCreateContext`. */
+  readonly getSecret?: (name: string) => Promise<string | null>;
+  /** API base, default `https://api.openai.com/v1`. Trailing slashes trimmed. */
+  readonly baseURL?: string;
+  /** TTS model, default `gpt-4o-mini-tts`. */
+  readonly model?: string;
+  /** Default voice, default `alloy`. Overridden per-call by `opts.voice`. */
+  readonly voice?: string;
+  /** Output container, default `mp3`. Determines the returned `mimeType`. */
+  readonly format?: OpenAiTtsFormat;
+  /** Injected `fetch` (tests). Defaults to the global. */
+  readonly fetchImpl?: FetchLike;
+  /** Per-request timeout in ms. Default 60000. */
+  readonly timeoutMs?: number;
+}
+
+/**
+ * `Synthesizer` backed by OpenAI's `POST /v1/audio/speech` endpoint — one JSON
+ * POST returning raw audio bytes, so there's no need for the `openai` SDK. The
+ * API key rides the vault (`ctx.getSecret('OPENAI_API_KEY')`, the same key the
+ * OpenAI provider uses) with a `process.env.OPENAI_API_KEY` fallback, resolved
+ * lazily on the first `synthesize` and cached so `create()` stays cheap.
+ */
+export class OpenAiSynthesizer implements Synthesizer {
+  readonly name = 'openai-tts';
+  /** MIME type of the bytes this instance returns (derived from `format`). */
+  readonly mimeType: string;
+
+  private readonly explicitKey: string | undefined;
+  private readonly getSecret: ((name: string) => Promise<string | null>) | undefined;
+  private readonly baseURL: string;
+  private readonly model: string;
+  private readonly voice: string;
+  private readonly format: OpenAiTtsFormat;
+  private readonly fetchImpl: FetchLike;
+  private readonly timeoutMs: number;
+  private key: string | null = null;
+
+  constructor(opts: OpenAiSynthesizerOptions = {}) {
+    this.explicitKey = opts.apiKey;
+    this.getSecret = opts.getSecret;
+    this.baseURL = (opts.baseURL ?? 'https://api.openai.com/v1').replace(/\/+$/, '');
+    this.model = opts.model ?? 'gpt-4o-mini-tts';
+    this.voice = opts.voice ?? 'alloy';
+    this.format = opts.format ?? 'mp3';
+    this.mimeType = MIME_BY_FORMAT[this.format];
+    this.fetchImpl = opts.fetchImpl ?? (globalThis.fetch as FetchLike);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  async synthesize(text: string, opts: SynthesizeOptions = {}): Promise<SynthesisResult> {
+    // Fast-path a caller who cancelled before we started — propagate their reason.
+    opts.signal?.throwIfAborted();
+
+    const key = await this.resolveKey();
+    const input = capInput(text);
+    const voice = opts.voice ?? this.voice;
+    const speed = clampSpeed(opts.rate);
+    const body = {
+      model: this.model,
+      voice,
+      input,
+      response_format: this.format,
+      ...(speed !== undefined ? { speed } : {}),
+    };
+    const url = `${this.baseURL}/audio/speech`;
+
+    // Chain the caller's abort signal with our own timeout onto one controller
+    // passed to fetch, so either cancels the request and frees the socket.
+    const controller = new AbortController();
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, this.timeoutMs);
+    const forward = (): void => controller.abort();
+    if (opts.signal) {
+      // The signal may have fired during key resolution above; a listener added
+      // to an already-aborted signal is never called, so abort directly here.
+      if (opts.signal.aborted) controller.abort();
+      else opts.signal.addEventListener('abort', forward, { once: true });
+    }
+
+    let res: Response;
+    try {
+      res = await this.fetchImpl(url, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      // Caller-initiated cancellation: re-throw their reason unchanged so a
+      // stopped read-aloud isn't masked as a provider/network error.
+      if (opts.signal?.aborted && !timedOut) throw opts.signal.reason ?? err;
+      if (timedOut) {
+        throw new MoxxyError({
+          code: 'NETWORK_TIMEOUT',
+          message: `OpenAI text-to-speech request timed out after ${this.timeoutMs} ms.`,
+          hint: 'Retry, or shorten the text being read aloud.',
+          context: { provider: OPENAI_TTS_PROVIDER_ID, url },
+        });
+      }
+      const network = classifyNetworkError(err, { provider: OPENAI_TTS_PROVIDER_ID, url });
+      if (network) throw network;
+      throw err;
+    } finally {
+      clearTimeout(timer);
+      opts.signal?.removeEventListener('abort', forward);
+    }
+
+    if (!res.ok) {
+      const classified = classifyHttpStatus(res.status, {
+        provider: OPENAI_TTS_PROVIDER_ID,
+        url,
+        body: await res.text().catch(() => ''),
+      });
+      if (classified) throw classified;
+      throw new MoxxyError({
+        code: 'PROVIDER_BAD_REQUEST',
+        message: `OpenAI text-to-speech returned HTTP ${res.status}.`,
+        context: { provider: OPENAI_TTS_PROVIDER_ID, url, status: res.status },
+      });
+    }
+
+    const audio = new Uint8Array(await res.arrayBuffer());
+    return { audio, mimeType: this.mimeType };
+  }
+
+  /**
+   * Resolve the API key lazily: explicit option → vault (`OPENAI_API_KEY`) →
+   * `process.env.OPENAI_API_KEY`. Cache only a successful resolution so a key
+   * added after a first failed attempt is still picked up on retry. A missing
+   * key becomes a classified, actionable `MoxxyError`.
+   */
+  private async resolveKey(): Promise<string> {
+    if (this.key) return this.key;
+    const resolved =
+      this.explicitKey ??
+      (await this.getSecret?.('OPENAI_API_KEY')) ??
+      process.env.OPENAI_API_KEY ??
+      null;
+    if (!resolved) {
+      throw new MoxxyError({
+        code: 'AUTH_NO_CREDENTIALS',
+        message:
+          'No OpenAI API key for text-to-speech. It rides the same OPENAI_API_KEY as the OpenAI provider.',
+        hint: 'Run `moxxy init` (stores it in the vault) or set OPENAI_API_KEY.',
+        context: { provider: OPENAI_TTS_PROVIDER_ID },
+      });
+    }
+    this.key = resolved;
+    return resolved;
+  }
+}
+
+/** Map a `SynthesizeOptions.rate` multiplier onto OpenAI's `speed`, clamped to
+ *  the accepted 0.25–4.0 range. Non-finite / absent rates yield `undefined` so
+ *  the field is omitted and OpenAI uses its default. */
+export function clampSpeed(rate: number | undefined): number | undefined {
+  if (rate === undefined || !Number.isFinite(rate)) return undefined;
+  return Math.min(MAX_SPEED, Math.max(MIN_SPEED, rate));
+}
+
+/**
+ * Cap `text` to OpenAI's 4096-char `input` limit. When over, truncate at the
+ * last sentence boundary (`. `, `! `, `? `, newline) inside the budget — as
+ * long as that keeps most of the text — else hard-slice, and append a single
+ * ellipsis so the result is always ≤ 4096 characters.
+ */
+export function capInput(text: string): string {
+  if (text.length <= MAX_INPUT_CHARS) return text;
+  const budget = MAX_INPUT_CHARS - 1; // leave room for the ellipsis
+  const slice = text.slice(0, budget);
+  const boundary = Math.max(
+    slice.lastIndexOf('. '),
+    slice.lastIndexOf('! '),
+    slice.lastIndexOf('? '),
+    slice.lastIndexOf('\n'),
+  );
+  // Only honor a boundary that doesn't discard more than half the budget,
+  // otherwise a single very long sentence would be cut to almost nothing.
+  const cut = boundary > budget * 0.5 ? boundary + 1 : budget;
+  return `${slice.slice(0, cut).trimEnd()}…`;
+}
+
+export function createOpenAiSynthesizer(opts: OpenAiSynthesizerOptions = {}): OpenAiSynthesizer {
+  return new OpenAiSynthesizer(opts);
+}

--- a/packages/plugin-tts-openai/tsconfig.json
+++ b/packages/plugin-tts-openai/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/plugin-tts-openai/vitest.config.ts
+++ b/packages/plugin-tts-openai/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2439,6 +2439,28 @@ importers:
         specifier: ^1.0.0
         version: 1.1.0
 
+  packages/plugin-tts-openai:
+    dependencies:
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+    devDependencies:
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
   packages/plugin-tunnel-proxy:
     dependencies:
       '@moxxy/e2e':


### PR DESCRIPTION
## What

`@moxxy/plugin-tts-openai` — moxxy's **first `Synthesizer` (text-to-speech) backend**. TTS was wired end-to-end (SDK type, `SynthesizerRegistry`, desktop `session.synthesize` IPC, `set_voice`/`list_voices` admin tools) but shipped with zero backends, so read-aloud fell back to the OS voice. This adds the first one.

`OpenAiSynthesizer` hits `POST https://api.openai.com/v1/audio/speech` — one JSON POST returning audio bytes, so there is **no `openai` SDK dependency** (deps are workspace-only: just `@moxxy/sdk`). `fetch` is injectable for testing.

Registers a single `openai-tts` synthesizer. The registry is `autoAdoptFirst`, so on a fresh install this becomes the active read-aloud voice with no activation step; the agent switches later via `set_voice`. The plugin is side-effect free (never calls `setActive`). Discovered via the default `Plugin` export; added to the plugins-admin install catalog as `tts-openai` (`provides: [{ category: 'synthesizer', name: 'openai-tts' }]`).

## Config surface

Read from `SynthesizerCreateContext.config`:

- `model` — default `gpt-4o-mini-tts`
- `voice` — default `alloy` (overridden per-call by `SynthesizeOptions.voice`)
- `format` — default `mp3` → `audio/mpeg`; also `opus` → `audio/ogg`, `wav` → `audio/wav`, `aac` → `audio/aac` (small closed map; unknown values ignored → mp3)

Per-call `SynthesizeOptions`: `voice` overrides the configured voice; `rate` maps to OpenAI `speed`, **clamped to 0.25–4.0** (non-finite → omitted); `signal` cancels the request (chained onto the fetch controller). A 60 s request timeout frees a hung socket. Input over OpenAI's **4096-char limit is truncated at a sentence boundary** (`. `/`! `/`? `/newline) with a single ellipsis, so long channel replies don't 400.

## Error semantics

Classified `MoxxyError`s (same helpers as `plugin-stt-whisper`) so raw vendor bodies never leak:

- **Missing key** → `AUTH_NO_CREDENTIALS` with a hint to run `moxxy init` / set `OPENAI_API_KEY`. The key is read via `ctx.getSecret('OPENAI_API_KEY')` (vault-backed, same key as the OpenAI provider) with a `process.env.OPENAI_API_KEY` fallback; resolved lazily and cached only on success.
- **HTTP** → `classifyHttpStatus` (401 `AUTH_INVALID`, 403 `AUTH_DENIED`, 429 `PROVIDER_RATE_LIMITED`, 5xx `PROVIDER_SERVER_ERROR`, else `PROVIDER_BAD_REQUEST`).
- **Network** → `classifyNetworkError` (`NETWORK_UNREACHABLE`, etc.).
- **Timeout** → `NETWORK_TIMEOUT`. **Caller abort** → the caller's signal reason is re-thrown unchanged (cancellation not masked).

`package.json#moxxy.setup` declares ONE optional secret field (label "OpenAI API key", `vaultKey OPENAI_API_KEY`, `required: false`) — the description says it reuses the OpenAI provider key, so you can skip it if that key already exists.

## Deferred — Codex-OAuth variant (NOT built)

The roadmap asked to check whether Codex/ChatGPT OAuth covers `/audio/speech` before assuming a `tts-openai-codex` sibling. **The check is done and the answer is no (for now):** the Codex token is a ChatGPT `backend-api` Bearer — in this repo it is only ever sent to `chatgpt.com/backend-api/*`, with scopes `openid/profile/email/offline_access`, not an `api.openai.com` credential — and there is no TTS `backend-api` path anywhere in the repo. A ChatGPT-OAuth-backed TTS plugin would need a **live probe** of an undocumented backend-api speech endpoint before anyone builds it. Left out deliberately.

## Manual verification (needs a live key)

Not run here (no key / no network in CI). With a real `OPENAI_API_KEY`:

- [ ] `moxxy plugins install tts-openai` (or drop the package under `~/.moxxy/plugins`) → it auto-adopts as the active voice.
- [ ] Desktop: press **Read aloud** → hear OpenAI TTS audio (played as `audio/mpeg`).
- [ ] TUI/desktop: `set_voice openai-tts` then `session.synthesize` a reply; `set_voice system` returns to the OS voice.
- [ ] `set_voice openai-tts` with a config `{ voice: 'nova', format: 'wav' }` → voice + `audio/wav` container change through.

## Gate status

All green from the worktree root (exit codes checked directly, no pipe masking):

- `pnpm build` ✅
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ (31 new tests: happy path + per-format mimeType, voice/rate/format mapping + speed clamping, 4096-char truncation, missing-key error, 401/403/429/5xx classification, network error, abort via signal, timeout, plugin registration)
- `pnpm check:deps` ✅
- Registry smoke (no OpenAI call): built default export → `SynthesizerRegistry.register` → `autoAdoptFirst` makes `openai-tts` active → `tryGetActive()` builds an instance with `mimeType audio/mpeg`. ✅

Changeset: `.changeset/tts-openai.md` (`@moxxy/plugin-tts-openai` minor, `@moxxy/plugin-plugins-admin` patch).
