### PR TITLE
feat(skills): usage stats — aggregate skill events into skills/.meta/usage.json + surface in /skills

### DIFF
--- a/.changeset/skill-usage-stats.md
+++ b/.changeset/skill-usage-stats.md
@@ -1,0 +1,21 @@
+---
+'@moxxy/core': patch
+'@moxxy/plugin-usage-stats': patch
+'@moxxy/cli': patch
+'@moxxy/plugin-cli': patch
+---
+
+Aggregate skill usage into `~/.moxxy/skills/.meta/usage.json` and surface it.
+
+A new best-effort store in `@moxxy/core` (`skill-usage.ts`) records per-skill-name
+`invocations` counts plus first-`createdAt` / latest-`lastInvokedAt` timestamps.
+`@moxxy/plugin-usage-stats` folds this run's `skill_invoked` / `skill_created`
+events past the same resume/`/new` seq boundary it already uses for token usage
+and merges the delta on shutdown (token behavior unchanged). `moxxy skills list`
+gains a dim `used` column and the `/skills` TUI panel shows a right-aligned `×N`
+badge.
+
+Known limitation: `skill_invoked` is only emitted by the `load_skill` tool today
+(reason `load_skill_tool`), so counts reflect explicit `load_skill` calls only.
+When trigger-match / classifier emission lands later, the same file simply starts
+counting more — no format change.

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { groupSimilarPrompts, runSkillsCommand, tokenize, type AuditEntry } from './skills.js';
+import { groupSimilarPrompts, runSkillsCommand, tokenize, usedLabel, type AuditEntry } from './skills.js';
 import type { ParsedArgv } from '../argv.js';
 
 // `removeAuditEntry` is module-private; we exercise it through the public
@@ -116,6 +116,15 @@ describe('tokenize', () => {
     expect(tokenize('Build a CLI for X')).toEqual(['build', 'cli', 'for']);
     expect(tokenize('snake_case-and-dashes')).toEqual(['snake_case-and-dashes']);
     expect(tokenize('go ok no a')).toEqual([]); // all under 3 chars
+  });
+});
+
+describe('usedLabel', () => {
+  it('renders a positive count as its number and everything else as a dash', () => {
+    expect(usedLabel(3)).toBe('3');
+    expect(usedLabel(1)).toBe('1');
+    expect(usedLabel(0)).toBe('-'); // recorded but never invoked
+    expect(usedLabel(undefined)).toBe('-'); // no usage entry at all
   });
 });
 

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,4 +1,10 @@
-import { defaultProjectSkillsDir, defaultUserSkillsDir, discoverSkills, silentLogger } from '@moxxy/core';
+import {
+  defaultProjectSkillsDir,
+  defaultUserSkillsDir,
+  discoverSkills,
+  loadSkillUsage,
+  silentLogger,
+} from '@moxxy/core';
 import { createMutex } from '@moxxy/sdk';
 import { writeFileAtomic } from '@moxxy/sdk/server';
 import { BUILTIN_SKILLS_DIR_RESOLVED } from '../setup/builtin-skills-dir.js';
@@ -62,13 +68,20 @@ export async function runSkillsCommand(argv: ParsedArgv): Promise<number> {
       process.stdout.write(colors.dim('(no skills discovered)') + '\n');
       return 0;
     }
+    // Best-effort cross-session invocation counts (~/.moxxy/skills/.meta/usage.json).
+    // A missing file reads as empty, so this is a silent no-op when unpopulated.
+    const usage = await loadSkillUsage();
+    const usedFor = (s: (typeof skills)[number]): string =>
+      usedLabel(usage.skills[s.frontmatter.name]?.invocations);
     const nameCol = Math.max(8, ...skills.map((s) => s.frontmatter.name.length));
     const scopeCol = Math.max(7, ...skills.map((s) => s.scope.length));
+    const usedCol = Math.max(4, ...skills.map((s) => usedFor(s).length));
     for (const s of skills) {
       const name = colors.bold(s.frontmatter.name.padEnd(nameCol));
       const scope = colors.dim(s.scope.padEnd(scopeCol));
+      const used = colors.dim(usedFor(s).padStart(usedCol));
       const desc = colors.dim(s.frontmatter.description);
-      process.stdout.write(`${name}  ${scope}  ${desc}\n`);
+      process.stdout.write(`${name}  ${scope}  ${used}  ${desc}\n`);
     }
     return 0;
   }
@@ -240,6 +253,14 @@ export function groupSimilarPrompts(entries: ReadonlyArray<AuditEntry>): AuditEn
     }
   }
   return groups;
+}
+
+/**
+ * The `used` column cell for `moxxy skills list`: the cross-session invocation
+ * count, or `-` when a skill has never been invoked (or has no usage entry).
+ */
+export function usedLabel(count: number | undefined): string {
+  return count && count > 0 ? String(count) : '-';
 }
 
 export function tokenize(s: string): string[] {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,14 @@ export {
   type UsageStatsFile,
   type StoredModelUsage,
 } from './usage-stats.js';
+export {
+  loadSkillUsage,
+  mergeSkillUsage,
+  skillsUsagePath,
+  type SkillUsageFile,
+  type SkillUsage,
+  type SkillUsageDelta,
+} from './skill-usage.js';
 export { SkillRegistryImpl } from './registries/skills.js';
 export {
   parseSkillFile,

--- a/packages/core/src/skill-usage.test.ts
+++ b/packages/core/src/skill-usage.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { loadSkillUsage, mergeSkillUsage } from './skill-usage.js';
+
+let tmpDir: string;
+let usagePath: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-skill-usage-'));
+  usagePath = path.join(tmpDir, 'usage.json');
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('skill-usage store', () => {
+  it('returns an empty aggregate when the file is missing', async () => {
+    const file = await loadSkillUsage(usagePath);
+    expect(file.skills).toEqual({});
+    expect(file.version).toBe(1);
+  });
+
+  it('merges a delta and round-trips through disk', async () => {
+    await mergeSkillUsage(
+      { 'deploy-app': { invocations: 2, lastInvokedAt: '2026-07-03T10:00:00.000Z' } },
+      usagePath,
+    );
+    const file = await loadSkillUsage(usagePath);
+    expect(file.skills['deploy-app']!.invocations).toBe(2);
+    expect(file.skills['deploy-app']!.lastInvokedAt).toBe('2026-07-03T10:00:00.000Z');
+  });
+
+  it('accumulates invocations across merges and advances lastInvokedAt', async () => {
+    await mergeSkillUsage(
+      { 'deploy-app': { invocations: 1, lastInvokedAt: '2026-07-01T00:00:00.000Z' } },
+      usagePath,
+    );
+    await mergeSkillUsage(
+      { 'deploy-app': { invocations: 3, lastInvokedAt: '2026-07-02T00:00:00.000Z' } },
+      usagePath,
+    );
+    const file = await loadSkillUsage(usagePath);
+    expect(file.skills['deploy-app']!.invocations).toBe(4);
+    // The later timestamp wins even if a merge arrives out of order.
+    expect(file.skills['deploy-app']!.lastInvokedAt).toBe('2026-07-02T00:00:00.000Z');
+  });
+
+  it('keeps the earliest createdAt and never lets a later merge overwrite it', async () => {
+    await mergeSkillUsage(
+      { 'deploy-app': { invocations: 0, createdAt: '2026-06-01T00:00:00.000Z' } },
+      usagePath,
+    );
+    await mergeSkillUsage(
+      { 'deploy-app': { invocations: 1, createdAt: '2026-07-01T00:00:00.000Z' } },
+      usagePath,
+    );
+    const file = await loadSkillUsage(usagePath);
+    expect(file.skills['deploy-app']!.createdAt).toBe('2026-06-01T00:00:00.000Z');
+    expect(file.skills['deploy-app']!.invocations).toBe(1);
+  });
+
+  it('does not advance lastInvokedAt when an out-of-order (earlier) delta arrives', async () => {
+    await mergeSkillUsage(
+      { s: { invocations: 1, lastInvokedAt: '2026-07-05T00:00:00.000Z' } },
+      usagePath,
+    );
+    await mergeSkillUsage(
+      { s: { invocations: 1, lastInvokedAt: '2026-07-01T00:00:00.000Z' } },
+      usagePath,
+    );
+    const file = await loadSkillUsage(usagePath);
+    expect(file.skills['s']!.lastInvokedAt).toBe('2026-07-05T00:00:00.000Z');
+    expect(file.skills['s']!.invocations).toBe(2);
+  });
+
+  it('an empty delta is a no-op read (does not create the file)', async () => {
+    const file = await mergeSkillUsage({}, usagePath);
+    expect(file.skills).toEqual({});
+    await expect(fs.access(usagePath)).rejects.toThrow();
+  });
+
+  it('falls back to empty on a corrupt (unparseable) file', async () => {
+    await fs.writeFile(usagePath, '{ this is not json');
+    expect((await loadSkillUsage(usagePath)).skills).toEqual({});
+  });
+
+  it('falls back to empty on a shape-invalid file (non-numeric counter)', async () => {
+    // A hand-edited file with a string counter must not flow into the additive
+    // merge (which would corrupt the aggregate via string concatenation).
+    await fs.writeFile(
+      usagePath,
+      JSON.stringify({ version: 1, updatedAt: 'x', skills: { s: { invocations: '5' } } }),
+    );
+    expect((await loadSkillUsage(usagePath)).skills).toEqual({});
+    // A subsequent merge therefore starts fresh rather than concatenating.
+    await mergeSkillUsage({ s: { invocations: 2 } }, usagePath);
+    expect((await loadSkillUsage(usagePath)).skills['s']!.invocations).toBe(2);
+  });
+});

--- a/packages/core/src/skill-usage.ts
+++ b/packages/core/src/skill-usage.ts
@@ -1,0 +1,165 @@
+import { promises as fs } from 'node:fs';
+import { createMutex } from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
+import { z } from 'zod';
+
+/**
+ * Cross-session skill usage, persisted at `~/.moxxy/skills/.meta/usage.json`
+ * (next to the agent-created audit log). A forward-going aggregate keyed by
+ * skill NAME: each session folds its own `skill_invoked` / `skill_created`
+ * events and merges the delta in on shutdown (see `@moxxy/plugin-usage-stats`).
+ * Purely additive `invocations` counter plus first-`createdAt` / latest-
+ * `lastInvokedAt` timestamps — a session's contribution is added once and the
+ * file stays a monotone sum.
+ *
+ * KNOWN LIMITATION (as of this file's introduction): the only site that emits
+ * `skill_invoked` today is the `load_skill` tool (reason `'load_skill_tool'` —
+ * see `packages/core/src/skills/synthesize.ts`). The event type also carries
+ * `'trigger_match' | 'classifier' | 'manual'` reasons, but nothing emits those
+ * yet. So `invocations` counts ONLY explicit `load_skill` calls for now. When
+ * trigger-match / classifier emission lands later, this same file simply starts
+ * counting more — no format change required.
+ *
+ * Like `usage-stats.ts`, this is best-effort: a missing or malformed file reads
+ * as empty, and a write failure never blocks shutdown.
+ */
+export interface SkillUsage {
+  /** Total `load_skill`-driven invocations recorded across all sessions. */
+  readonly invocations: number;
+  /** ISO timestamp of the most recent recorded invocation, if any. */
+  readonly lastInvokedAt?: string;
+  /** ISO timestamp of when this skill was first agent-synthesized, if seen. */
+  readonly createdAt?: string;
+}
+
+export interface SkillUsageFile {
+  readonly version: 1;
+  /** ISO timestamp of the last merge. */
+  readonly updatedAt: string;
+  /** Per-skill-name lifetime usage. */
+  readonly skills: Record<string, SkillUsage>;
+}
+
+/**
+ * One session's contribution for a single skill: how many invocations it saw,
+ * the latest invocation timestamp within the run, and — if the skill was
+ * created during the run — its creation timestamp.
+ */
+export interface SkillUsageDelta {
+  readonly invocations: number;
+  readonly lastInvokedAt?: string;
+  readonly createdAt?: string;
+}
+
+export function skillsUsagePath(): string {
+  // Route through `moxxyPath` so a `$MOXXY_HOME` override relocates the skill
+  // usage aggregate alongside the rest of the data dir. Identical to
+  // `~/.moxxy/skills/.meta/usage.json` when MOXXY_HOME is unset.
+  return moxxyPath('skills/.meta/usage.json');
+}
+
+function emptyUsage(): SkillUsageFile {
+  return { version: 1, updatedAt: new Date().toISOString(), skills: {} };
+}
+
+// Validates the on-disk shape so a hand-edited or partially-written file with a
+// non-numeric counter (e.g. `invocations: "3"`) can't flow into the additive
+// merge and corrupt the persisted aggregate via string concatenation. A failed
+// parse falls through to `emptyUsage()`, exactly like malformed JSON.
+const skillUsageSchema = z.object({
+  invocations: z.number(),
+  lastInvokedAt: z.string().optional(),
+  createdAt: z.string().optional(),
+});
+
+const skillUsageFileSchema = z.object({
+  version: z.literal(1),
+  updatedAt: z.string(),
+  skills: z.record(z.string(), skillUsageSchema),
+});
+
+/**
+ * Read the skill usage aggregate. Returns an empty file when missing or
+ * unparseable — skill usage is an optional, non-load-blocking layer.
+ */
+export async function loadSkillUsage(
+  filePath: string = skillsUsagePath(),
+): Promise<SkillUsageFile> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const result = skillUsageFileSchema.safeParse(JSON.parse(raw));
+    if (result.success) return result.data;
+    // shape-invalid (e.g. a non-numeric counter) — start fresh rather than let
+    // a corrupt entry poison the aggregate via string-concat addition.
+  } catch {
+    // missing or malformed JSON — start fresh
+  }
+  return emptyUsage();
+}
+
+async function writeAtomic(file: SkillUsageFile, filePath: string): Promise<void> {
+  await writeFileAtomic(filePath, JSON.stringify(file, null, 2) + '\n');
+}
+
+// Serializes the read-modify-write in `mergeSkillUsage` so two concurrent merges
+// (e.g. overlapping shutdowns) can't both read the same snapshot and have the
+// second write clobber the first's delta.
+const mergeMutex = createMutex();
+
+/** Later of two ISO timestamps (lexicographic sort is correct for same-format
+ * UTC `toISOString()` output). Either may be absent. */
+function laterIso(a: string | undefined, b: string | undefined): string | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  return a >= b ? a : b;
+}
+
+/**
+ * Merge a session's per-skill delta into the persisted aggregate and write it
+ * back. Reads the current file, adds each `invocations` field-wise, keeps the
+ * earliest `createdAt` and the latest `lastInvokedAt`, and writes atomically.
+ * Returns the updated file.
+ *
+ * Best-effort: a write failure logs to stderr but does not throw — losing one
+ * session's stats must never block shutdown.
+ */
+export async function mergeSkillUsage(
+  delta: Record<string, SkillUsageDelta>,
+  filePath: string = skillsUsagePath(),
+): Promise<SkillUsageFile> {
+  // An empty delta writes nothing, so there's no read-modify-write to serialize:
+  // skip the mutex and read the current file directly. A session that exercised
+  // no skills produces an empty delta on every shutdown, so this avoids needless
+  // I/O + contention on the common no-op path.
+  const keys = Object.keys(delta);
+  if (keys.length === 0) return loadSkillUsage(filePath);
+
+  return mergeMutex.run(async () => {
+    const current = await loadSkillUsage(filePath);
+
+    const now = new Date().toISOString();
+    const skills: Record<string, SkillUsage> = { ...current.skills };
+    for (const key of keys) {
+      const d = delta[key]!;
+      const existing = skills[key];
+      const invocations = (existing?.invocations ?? 0) + d.invocations;
+      const lastInvokedAt = laterIso(existing?.lastInvokedAt, d.lastInvokedAt);
+      const createdAt = existing?.createdAt ?? d.createdAt;
+      skills[key] = {
+        invocations,
+        ...(lastInvokedAt ? { lastInvokedAt } : {}),
+        ...(createdAt ? { createdAt } : {}),
+      };
+    }
+    const next: SkillUsageFile = { version: 1, updatedAt: now, skills };
+    try {
+      await writeAtomic(next, filePath);
+    } catch (err) {
+      process.stderr.write(
+        `moxxy: failed to persist skill usage to ${filePath}: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+    return next;
+  });
+}

--- a/packages/plugin-cli/src/components/SkillsPanel.test.ts
+++ b/packages/plugin-cli/src/components/SkillsPanel.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { asSkillId, type Skill, type SkillScope } from '@moxxy/sdk';
+import { buildSkillRows } from './SkillsPanel.js';
+
+function skill(name: string, scope: SkillScope): Skill {
+  return {
+    id: asSkillId(`${scope}:${name}`),
+    path: `/tmp/${name}.md`,
+    scope,
+    frontmatter: { name, description: `does ${name}` },
+    body: '',
+  };
+}
+
+describe('buildSkillRows (SkillsPanel)', () => {
+  it('orders by scope (user, project, builtin, plugin) then name, and carries description', () => {
+    const rows = buildSkillRows([
+      skill('zeta', 'builtin'),
+      skill('beta', 'user'),
+      skill('alpha', 'user'),
+    ]);
+    expect(rows.map((r) => r.name)).toEqual(['alpha', 'beta', 'zeta']);
+    expect(rows[0]!.description).toBe('does alpha');
+  });
+
+  it('threads a positive invocation count into row.used, keyed by skill name', () => {
+    const rows = buildSkillRows([skill('deploy', 'user')], { deploy: 4 });
+    expect(rows[0]!.used).toBe(4);
+  });
+
+  it('omits used for a zero/absent count (badge stays hidden)', () => {
+    const rows = buildSkillRows(
+      [skill('deploy', 'user'), skill('lint', 'user')],
+      { deploy: 0 }, // recorded but never invoked; lint has no entry at all
+    );
+    const byName = Object.fromEntries(rows.map((r) => [r.name, r]));
+    expect(byName['deploy']!.used).toBeUndefined();
+    expect(byName['lint']!.used).toBeUndefined();
+  });
+
+  it('works with no usage map at all (all badges hidden)', () => {
+    const rows = buildSkillRows([skill('deploy', 'user')]);
+    expect(rows[0]!.used).toBeUndefined();
+  });
+});

--- a/packages/plugin-cli/src/components/SkillsPanel.tsx
+++ b/packages/plugin-cli/src/components/SkillsPanel.tsx
@@ -19,12 +19,20 @@ export interface SkillsPanelProps {
    * tab strip stays hidden.
    */
   readonly mcpServers?: ReadonlyArray<McpServerSummary>;
+  /**
+   * Optional per-skill-name cross-session invocation counts (loaded from
+   * `~/.moxxy/skills/.meta/usage.json`). A `×N` badge is shown for any skill
+   * with a positive count; absent/zero entries render nothing. Best-effort:
+   * omitting this prop just hides the badges.
+   */
+  readonly usage?: Readonly<Record<string, number>>;
   /** Called when the user presses Esc inside the modal. */
   readonly onClose?: () => void;
 }
 
 const NAME_COL = 28;
 const SCOPE_COL = 10;
+const USED_COL = 6;
 const WINDOW = 15;
 const ORDER: ReadonlyArray<SkillScope> = ['user', 'project', 'builtin', 'plugin'];
 
@@ -35,6 +43,31 @@ interface Row {
   readonly name: string;
   readonly scope: string;
   readonly description: string;
+  /** Cross-session invocation count; a `×N` badge when > 0, hidden otherwise. */
+  readonly used?: number;
+}
+
+/**
+ * Build the ordered skill rows for the panel, threading in cross-session
+ * invocation counts keyed by skill name. Pure and exported so it can be
+ * unit-tested without an Ink render harness.
+ */
+export function buildSkillRows(
+  skills: ReadonlyArray<Skill>,
+  usage?: Readonly<Record<string, number>>,
+): Row[] {
+  const out: Row[] = [];
+  for (const s of orderByScope(skills)) {
+    const count = usage?.[s.frontmatter.name];
+    out.push({
+      key: `skill:${s.id}`,
+      name: s.frontmatter.name,
+      scope: s.scope,
+      description: s.frontmatter.description ?? '',
+      ...(count && count > 0 ? { used: count } : {}),
+    });
+  }
+  return out;
 }
 
 /**
@@ -42,22 +75,11 @@ interface Row {
  * list; Esc closes (owned by Modal). When MCP servers are present, a
  * tab strip lets the user flip between skills and MCP servers with ←/→.
  */
-export const SkillsPanel: React.FC<SkillsPanelProps> = ({ skills, mcpServers, onClose }) => {
+export const SkillsPanel: React.FC<SkillsPanelProps> = ({ skills, mcpServers, usage, onClose }) => {
   const hasMcp = !!mcpServers && mcpServers.length > 0;
   const [activeTab, setActiveTab] = React.useState<TabId>('skills');
 
-  const skillRows: Row[] = React.useMemo(() => {
-    const out: Row[] = [];
-    for (const s of orderByScope(skills)) {
-      out.push({
-        key: `skill:${s.id}`,
-        name: s.frontmatter.name,
-        scope: s.scope,
-        description: s.frontmatter.description ?? '',
-      });
-    }
-    return out;
-  }, [skills]);
+  const skillRows: Row[] = React.useMemo(() => buildSkillRows(skills, usage), [skills, usage]);
 
   const mcpRows: Row[] = React.useMemo(() => {
     if (!hasMcp) return [];
@@ -87,7 +109,7 @@ export const SkillsPanel: React.FC<SkillsPanelProps> = ({ skills, mcpServers, on
   const hints = '↑↓ navigate · PgUp/PgDn fast · g/G top/bottom';
   const slice = rows.slice(scroll.visible.start, scroll.visible.end);
   const termWidth = process.stdout.columns ?? 80;
-  const descWidth = Math.max(20, termWidth - NAME_COL - SCOPE_COL - 12);
+  const descWidth = Math.max(20, termWidth - NAME_COL - SCOPE_COL - USED_COL - 12);
 
   return (
     <Modal
@@ -117,6 +139,9 @@ export const SkillsPanel: React.FC<SkillsPanelProps> = ({ skills, mcpServers, on
             </Box>
             <Box width={descWidth}>
               <Text dimColor wrap="truncate">{oneLine(row.description)}</Text>
+            </Box>
+            <Box width={USED_COL} justifyContent="flex-end">
+              {row.used ? <Text dimColor>{`×${row.used}`}</Text> : null}
             </Box>
           </Box>
         );

--- a/packages/plugin-cli/src/session/OverlayOrNotice.tsx
+++ b/packages/plugin-cli/src/session/OverlayOrNotice.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box, Text } from 'ink';
 import type { MoxxyEvent } from '@moxxy/sdk';
 import type { ClientSession as Session } from '@moxxy/sdk';
+import { loadSkillUsage } from '@moxxy/core';
 import { SkillsPanel } from '../components/SkillsPanel.js';
 import { ToolsPanel } from '../components/ToolsPanel.js';
 import { AgentsPanel } from '../components/AgentsPanel.js';
@@ -37,11 +38,34 @@ export const OverlayOrNotice: React.FC<OverlayOrNoticeProps> = ({
   getChannels,
   onClose,
 }) => {
+  // Best-effort cross-session skill invocation counts for the `/skills` panel.
+  // Loaded lazily when the skills overlay opens; a missing/corrupt file resolves
+  // to empty, so failing to load just hides the `×N` badges (never blocks).
+  const [skillUsage, setSkillUsage] = React.useState<Record<string, number>>({});
+  React.useEffect(() => {
+    if (overlay?.kind !== 'skills') return;
+    let cancelled = false;
+    void loadSkillUsage()
+      .then((file) => {
+        if (cancelled) return;
+        const counts: Record<string, number> = {};
+        for (const [name, u] of Object.entries(file.skills)) counts[name] = u.invocations;
+        setSkillUsage(counts);
+      })
+      .catch(() => {
+        /* best-effort: leave badges hidden */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [overlay?.kind]);
+
   if (overlay?.kind === 'skills') {
     return (
       <SkillsPanel
         skills={session.skills.list()}
         mcpServers={deriveMcpServers(session.tools.list())}
+        usage={skillUsage}
         onClose={onClose}
       />
     );

--- a/packages/plugin-usage-stats/src/index.test.ts
+++ b/packages/plugin-usage-stats/src/index.test.ts
@@ -5,13 +5,14 @@ import * as path from 'node:path';
 import {
   asEventId,
   asSessionId,
+  asSkillId,
   asTurnId,
   type AppContext,
   type EventLogReader,
   type MoxxyEvent,
 } from '@moxxy/sdk';
-import { loadUsageStats } from '@moxxy/core';
-import { buildUsageStatsPlugin } from './index.js';
+import { loadSkillUsage, loadUsageStats } from '@moxxy/core';
+import { buildUsageStatsPlugin, summarizeSkillEvents } from './index.js';
 
 const sid = asSessionId('s1');
 const tid = asTurnId('t1');
@@ -29,6 +30,38 @@ function resp(seq: number, model: string, inputTokens: number): MoxxyEvent {
     model,
     inputTokens,
     outputTokens: 1,
+  } as MoxxyEvent;
+}
+
+function skillInvoked(seq: number, name: string, ts: number): MoxxyEvent {
+  return {
+    id: asEventId(`e${seq}`),
+    seq,
+    ts,
+    sessionId: sid,
+    turnId: tid,
+    source: 'model',
+    type: 'skill_invoked',
+    skillId: asSkillId(name),
+    name,
+    reason: 'load_skill_tool',
+  } as MoxxyEvent;
+}
+
+function skillCreated(seq: number, name: string, ts: number): MoxxyEvent {
+  return {
+    id: asEventId(`e${seq}`),
+    seq,
+    ts,
+    sessionId: sid,
+    turnId: tid,
+    source: 'model',
+    type: 'skill_created',
+    skillId: asSkillId(name),
+    name,
+    path: `/tmp/${name}.md`,
+    scope: 'user',
+    originatingPrompt: `make ${name}`,
   } as MoxxyEvent;
 }
 
@@ -115,10 +148,12 @@ function ctxForLog(log: FakeLog, sessionId = sid): AppContext {
 
 let tmpDir: string;
 let statsPath: string;
+let skillUsagePath: string;
 
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-usage-plugin-'));
   statsPath = path.join(tmpDir, 'usage.json');
+  skillUsagePath = path.join(tmpDir, 'skill-usage.json');
 });
 
 afterEach(async () => {
@@ -453,5 +488,82 @@ describe('usage-stats plugin', () => {
     // the post-shutdown clear added nothing.
     expect(file.models['anthropic/opus']!.calls).toBe(1);
     expect(file.models['anthropic/opus']!.inputTokens).toBe(50);
+  });
+});
+
+describe('summarizeSkillEvents', () => {
+  it('counts invocations per name and keeps the latest invocation timestamp', () => {
+    const delta = summarizeSkillEvents(
+      [skillInvoked(0, 'deploy', 1000), skillInvoked(1, 'deploy', 3000), skillInvoked(2, 'lint', 2000)],
+      [],
+    );
+    expect(delta['deploy']!.invocations).toBe(2);
+    expect(delta['deploy']!.lastInvokedAt).toBe(new Date(3000).toISOString());
+    expect(delta['lint']!.invocations).toBe(1);
+  });
+
+  it('records createdAt for a created-but-never-invoked skill (invocations 0)', () => {
+    const delta = summarizeSkillEvents([], [skillCreated(0, 'fresh', 5000)]);
+    expect(delta['fresh']!.invocations).toBe(0);
+    expect(delta['fresh']!.createdAt).toBe(new Date(5000).toISOString());
+  });
+
+  it('is empty for no events', () => {
+    expect(summarizeSkillEvents([], [])).toEqual({});
+  });
+});
+
+describe('usage-stats plugin — skill folding', () => {
+  it('folds skill_invoked/skill_created into the skill usage store on shutdown', async () => {
+    const plugin = buildUsageStatsPlugin({ statsPath, skillUsagePath });
+    const events = [
+      skillCreated(0, 'deploy', 1000),
+      skillInvoked(1, 'deploy', 2000),
+      skillInvoked(2, 'deploy', 4000),
+      skillInvoked(3, 'lint', 3000),
+    ];
+
+    await plugin.hooks!.onInit!(ctxFor([]));
+    await plugin.hooks!.onShutdown!(ctxFor(events));
+
+    const file = await loadSkillUsage(skillUsagePath);
+    expect(file.skills['deploy']!.invocations).toBe(2);
+    expect(file.skills['deploy']!.createdAt).toBe(new Date(1000).toISOString());
+    expect(file.skills['deploy']!.lastInvokedAt).toBe(new Date(4000).toISOString());
+    expect(file.skills['lint']!.invocations).toBe(1);
+  });
+
+  it('counts only the live skill suffix on resume (skips restored skill events)', async () => {
+    const restored = [skillInvoked(0, 'deploy', 1000), skillInvoked(1, 'deploy', 2000)];
+    const live = [skillInvoked(2, 'deploy', 3000)];
+    const plugin = buildUsageStatsPlugin({ statsPath, skillUsagePath });
+
+    await plugin.hooks!.onInit!(ctxFor(restored));
+    await plugin.hooks!.onShutdown!(ctxFor([...restored, ...live]));
+
+    // Only the single live invocation is counted — not the 2 restored.
+    expect((await loadSkillUsage(skillUsagePath)).skills['deploy']!.invocations).toBe(1);
+  });
+
+  it('folds skill usage even when the run produced no provider_response (no token early-return)', async () => {
+    // Regression: the token fold used to `return` early when no responses were
+    // present, which would skip the skill fold entirely. They must be independent.
+    const plugin = buildUsageStatsPlugin({ statsPath, skillUsagePath });
+    const events = [skillInvoked(0, 'deploy', 1000)];
+
+    await plugin.hooks!.onInit!(ctxFor([]));
+    await plugin.hooks!.onShutdown!(ctxFor(events));
+
+    expect((await loadSkillUsage(skillUsagePath)).skills['deploy']!.invocations).toBe(1);
+    // No token usage was recorded (no provider_response events).
+    expect((await loadUsageStats(statsPath)).models).toEqual({});
+  });
+
+  it('writes no skill usage file when the run exercised no skills', async () => {
+    const plugin = buildUsageStatsPlugin({ statsPath, skillUsagePath });
+    await plugin.hooks!.onInit!(ctxFor([]));
+    await plugin.hooks!.onShutdown!(ctxFor([resp(0, 'opus', 100)]));
+    // Empty skill delta → merge never touches disk.
+    await expect(fs.access(skillUsagePath)).rejects.toThrow();
   });
 });

--- a/packages/plugin-usage-stats/src/index.ts
+++ b/packages/plugin-usage-stats/src/index.ts
@@ -4,12 +4,16 @@ import {
   type EventLogReader,
   type Plugin,
   type SessionId,
+  type SkillCreatedEvent,
+  type SkillInvokedEvent,
 } from '@moxxy/sdk';
-import { mergeUsageStats } from '@moxxy/core';
+import { mergeSkillUsage, mergeUsageStats, type SkillUsageDelta } from '@moxxy/core';
 
 export interface BuildUsageStatsPluginOptions {
-  /** Override the on-disk aggregate path. Tests inject a tmp file here. */
+  /** Override the on-disk token-usage aggregate path. Tests inject a tmp file here. */
   readonly statsPath?: string;
+  /** Override the on-disk skill-usage aggregate path. Tests inject a tmp file here. */
+  readonly skillUsagePath?: string;
 }
 
 /**
@@ -27,10 +31,20 @@ interface EventLogExtras {
 }
 
 /**
- * Records cross-session token usage. On shutdown it folds THIS run's
+ * Records cross-session token AND skill usage. On shutdown it folds THIS run's
  * `provider_response` events by `<provider>/<model>` and merges the delta into
  * `~/.moxxy/usage.json` — a forward-going aggregate the `/usage` panel renders
- * and `/usage clear` resets.
+ * and `/usage clear` resets. It ALSO folds this run's `skill_invoked` /
+ * `skill_created` events by skill name and merges them into
+ * `~/.moxxy/skills/.meta/usage.json` (surfaced in `/skills` and
+ * `moxxy skills list`). Both folds use the same resume/`/new` seq boundary, so
+ * each store counts a session's contribution exactly once.
+ *
+ * NOTE: `skill_invoked` is only emitted by the `load_skill` tool today (reason
+ * `'load_skill_tool'`), so the skill store counts explicit `load_skill` calls
+ * only — see `@moxxy/core`'s `skill-usage.ts`. The other reasons the event type
+ * allows (`trigger_match` / `classifier` / `manual`) have no emission site yet;
+ * when they land, this same fold starts counting them with no change here.
  *
  * Resume-safe by construction: restored events are seeded into the log WITHOUT
  * firing subscribers, and `onInit` runs after seeding. `onInit` records the
@@ -128,21 +142,44 @@ export function buildUsageStatsPlugin(opts: BuildUsageStatsPluginOptions = {}): 
         cursors.delete(ctx.sessionId);
         // Best-effort: a throwing reader or a failed fold degrades to "record
         // nothing for this run" rather than rejecting the hook (which the host
-        // would log as a spurious failure). `mergeUsageStats` already swallows
-        // its own write errors; this guards the read/fold side too.
+        // would log as a spurious failure). Each store folds in its own guarded
+        // block so a failure folding one family (tokens / skills) can't strand
+        // the other, and neither can crash the 5s-timeboxed shutdown path.
+        // `mergeUsageStats` / `mergeSkillUsage` already swallow their own write
+        // errors; these guards cover the read/fold side too.
+
+        // Only `provider_response` events carry token usage; scan that indexed
+        // subset (O(matches)) instead of copying + filtering the full event log
+        // (O(total session events)).
         try {
-          // Only `provider_response` events carry token usage; scan that indexed
-          // subset (O(matches)) instead of copying + filtering the full event log
-          // (O(total session events)) on this 5s-timeboxed shutdown path.
           const responses = ctx.log.ofType('provider_response');
           const live =
             initMaxSeq === null ? responses : responses.filter((e) => e.seq > initMaxSeq);
-          if (live.length === 0) return;
-          const delta = summarizeTokensByModel(live);
-          await mergeUsageStats(delta, opts.statsPath);
+          if (live.length > 0) {
+            const delta = summarizeTokensByModel(live);
+            await mergeUsageStats(delta, opts.statsPath);
+          }
         } catch {
-          // Drop this run's usage rather than crash shutdown — explicitly the
-          // accepted trade-off for an optional, contention-free aggregate.
+          // Drop this run's token usage rather than crash shutdown — explicitly
+          // the accepted trade-off for an optional, contention-free aggregate.
+        }
+
+        // Fold this run's live skill events past the SAME boundary and merge the
+        // per-skill-name delta into `~/.moxxy/skills/.meta/usage.json`.
+        try {
+          const invoked = ctx.log.ofType('skill_invoked');
+          const created = ctx.log.ofType('skill_created');
+          const skillDelta = summarizeSkillEvents(
+            initMaxSeq === null ? invoked : invoked.filter((e) => e.seq > initMaxSeq),
+            initMaxSeq === null ? created : created.filter((e) => e.seq > initMaxSeq),
+          );
+          // Only touch disk (even the read side) when there's something to add.
+          if (Object.keys(skillDelta).length > 0) {
+            await mergeSkillUsage(skillDelta, opts.skillUsagePath);
+          }
+        } catch {
+          // Drop this run's skill usage rather than crash shutdown — same
+          // best-effort trade-off as the token fold above.
         }
       },
     },
@@ -150,19 +187,73 @@ export function buildUsageStatsPlugin(opts: BuildUsageStatsPluginOptions = {}): 
 }
 
 /**
+ * Fold a run's live `skill_invoked` / `skill_created` events into a per-skill-
+ * name delta for `mergeSkillUsage`. Invocations are counted and the latest
+ * invocation timestamp kept; a creation event records the skill's `createdAt`.
+ * Timestamps convert the epoch-ms event `ts` to ISO to match the store's shape.
+ * Skills that only appear in a creation event still get an entry (invocations 0)
+ * so a freshly-synthesized-but-never-invoked skill still records its birth.
+ */
+export function summarizeSkillEvents(
+  invoked: ReadonlyArray<SkillInvokedEvent>,
+  created: ReadonlyArray<SkillCreatedEvent>,
+): Record<string, SkillUsageDelta> {
+  const acc = new Map<string, { invocations: number; lastInvokedAt?: string; createdAt?: string }>();
+  const entry = (name: string) => {
+    let e = acc.get(name);
+    if (!e) {
+      e = { invocations: 0 };
+      acc.set(name, e);
+    }
+    return e;
+  };
+  for (const e of invoked) {
+    const cur = entry(e.name);
+    cur.invocations += 1;
+    const iso = new Date(e.ts).toISOString();
+    if (!cur.lastInvokedAt || iso > cur.lastInvokedAt) cur.lastInvokedAt = iso;
+  }
+  for (const e of created) {
+    const cur = entry(e.name);
+    const iso = new Date(e.ts).toISOString();
+    // Earliest creation wins if (improbably) a name is created twice in one run.
+    if (!cur.createdAt || iso < cur.createdAt) cur.createdAt = iso;
+  }
+  const out: Record<string, SkillUsageDelta> = {};
+  for (const [name, e] of acc) {
+    out[name] = {
+      invocations: e.invocations,
+      ...(e.lastInvokedAt ? { lastInvokedAt: e.lastInvokedAt } : {}),
+      ...(e.createdAt ? { createdAt: e.createdAt } : {}),
+    };
+  }
+  return out;
+}
+
+// The event families `onShutdown` folds. The `baseSeq`-less fallback in
+// `boundarySeq` must scan the union of these so the resume boundary excludes
+// every restored event of ANY folded family — otherwise a session whose
+// restored prefix has, e.g., skill events but no `provider_response` would get a
+// too-low boundary and re-fold (double-count) those restored skill events.
+const FOLDED_EVENT_TYPES = ['provider_response', 'skill_invoked', 'skill_created'] as const;
+
+/**
  * Highest held seq — the resume boundary — without copying the log. Prefers the
  * O(1) `baseSeq + length - 1` identity (every held event has `seq === base +
- * index`); falls back to scanning the indexed `provider_response` subset when a
- * reader doesn't expose `baseSeq`. `null` for an empty log. Using the response
- * subset for the fallback is sound: `onShutdown` only folds responses, so a
- * boundary at the max restored response seq still excludes every restored
- * response and includes every live one.
+ * index`); falls back to scanning the indexed subsets `onShutdown` folds when a
+ * reader doesn't expose `baseSeq`. `null` for an empty log. Scanning the union
+ * of folded families (not just `provider_response`) keeps the fallback sound now
+ * that skills are folded too: the boundary sits at the max restored seq across
+ * every folded family, so each fold excludes its restored events and includes
+ * only its live ones.
  */
 function boundarySeq(log: EventLogReader & EventLogExtras): number | null {
   if (log.length === 0) return null;
   if (typeof log.baseSeq === 'number') return log.baseSeq + log.length - 1;
   let max: number | null = null;
-  for (const e of log.ofType('provider_response')) if (max === null || e.seq > max) max = e.seq;
+  for (const type of FOLDED_EVENT_TYPES) {
+    for (const e of log.ofType(type)) if (max === null || e.seq > max) max = e.seq;
+  }
   return max;
 }
 


### PR DESCRIPTION
## What

Aggregate the existing `skill_invoked` / `skill_created` events into a cross-session store and surface per-skill invocation counts in the `/skills` TUI panel and `moxxy skills list`.

## File format

New best-effort store at `~/.moxxy/skills/.meta/usage.json` (next to the agent-created audit log), managed by `@moxxy/core`'s `skill-usage.ts` — same Zod-validated / atomic-write / corrupt-to-empty semantics as `usage-stats.ts`:

```json
{
  "version": 1,
  "updatedAt": "2026-07-03T…Z",
  "skills": {
    "deploy-app": { "invocations": 3, "lastInvokedAt": "…Z", "createdAt": "…Z" }
  }
}
```

Keyed by skill **name**. `invocations` is a monotone sum; `createdAt` keeps the earliest, `lastInvokedAt` the latest.

## How it's aggregated

`@moxxy/plugin-usage-stats` (the existing pure-hooks plugin) now folds skill events on shutdown alongside its token fold, past the **same** per-session resume/`/new` seq boundary, and merges via `mergeSkillUsage`. Token behavior is unchanged — the two stores stay in separate files. The shared `boundarySeq` fallback (used only by readers that don't expose `baseSeq`) now scans the union of folded event families so a skill-only resume can't re-count its restored prefix.

## Where counts surface

- **CLI**: `moxxy skills list` gains a dim `used` column (the count, or `-` when zero/absent). Silent no-op when the file is missing.
- **TUI**: the `/skills` panel shows a right-aligned dim `×N` badge per skill; the overlay opener loads the usage file lazily (best-effort — a missing/corrupt file just hides the badges).

## Known limitation (honest)

`skill_invoked` is only emitted by the `load_skill` tool today (reason `load_skill_tool`); the `trigger_match` / `classifier` / `manual` reasons the event type allows have **no emission site yet**. So `invocations` counts explicit `load_skill` calls only for now. When trigger-match / classifier emission lands later, the same file simply starts counting more — no format change. This is documented in `skill-usage.ts` and the plugin doc comment. No new emission sites were added in this PR.

## Tests

- Store round-trip + accumulation + earliest-`createdAt` / latest-`lastInvokedAt` + corrupt-file + shape-invalid fallback (`skill-usage.test.ts`).
- Plugin folding + resume-suffix-only + independence from the token early-return + `summarizeSkillEvents` unit tests (existing plugin harness style).
- CLI `usedLabel` formatter unit test.
- `buildSkillRows` row-building helper unit test (no new UI harness — mirrors `UsagePanel.test.ts`).

## Gate

`pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm check:deps` — all pass (each exit code checked directly). One changeset: patch `@moxxy/core`, `@moxxy/plugin-usage-stats`, `@moxxy/cli`, `@moxxy/plugin-cli`.
