### PR TITLE
feat(voice): Telegram + Discord voice replies via the active Synthesizer (/voice toggle)

### DIFF
--- a/.changeset/channel-voice-replies.md
+++ b/.changeset/channel-voice-replies.md
@@ -1,0 +1,9 @@
+---
+'@moxxy/channel-kit': minor
+'@moxxy/plugin-telegram': patch
+'@moxxy/plugin-channel-discord': patch
+---
+
+Voice replies for the Telegram and Discord channels. When enabled with `/voice`, the channel synthesizes the final assistant reply through the session's active Synthesizer and sends it as a voice/audio message alongside the text.
+
+`@moxxy/channel-kit` gains the transport-agnostic pieces: `synthesizeReply` (TTS via `session.synthesizers.tryGetActive()` with markdown→speech cleanup), `ensureOggOpus` (passthrough or ffmpeg transcode, plain-audio fallback when ffmpeg is absent), `deliverVoiceReply`, and a shared `/voice` toggle resolver. The text reply always goes out first and every failure mode is a typed result, so a missing synthesizer, TTS error, or transcode failure never breaks the text answer. Messenger-specific delivery (grammy `sendVoice`/`sendAudio`, discord.js audio attachment) stays in each plugin.

--- a/packages/channel-kit/src/index.ts
+++ b/packages/channel-kit/src/index.ts
@@ -46,3 +46,21 @@ export {
   type IngestVerdict,
 } from './ingest/http-server.js';
 export { DeliveryDedupeCache } from './ingest/dedupe.js';
+export {
+  audioExtForMime,
+  deliverVoiceReply,
+  ensureOggOpus,
+  resolveVoiceToggle,
+  synthesizeReply,
+  toSpeech,
+  type DeliverVoiceReplyOptions,
+  type EnsureOggOpusOptions,
+  type EnsureOggOpusResult,
+  type SynthesizeReplyOptions,
+  type SynthesizeReplyResult,
+  type SynthesizerSource,
+  type VoiceReplyOutcome,
+  type VoiceReplySink,
+  type VoiceToggleInput,
+  type VoiceToggleResult,
+} from './voice-reply.js';

--- a/packages/channel-kit/src/voice-reply.test.ts
+++ b/packages/channel-kit/src/voice-reply.test.ts
@@ -1,0 +1,316 @@
+import { EventEmitter } from 'node:events';
+import { Buffer } from 'node:buffer';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Synthesizer } from '@moxxy/sdk';
+import {
+  __resetFfmpegProbeForTest,
+  audioExtForMime,
+  deliverVoiceReply,
+  ensureOggOpus,
+  resolveVoiceToggle,
+  synthesizeReply,
+  toSpeech,
+  type SynthesizerSource,
+  type VoiceReplySink,
+} from './voice-reply.js';
+
+beforeEach(() => __resetFfmpegProbeForTest());
+afterEach(() => __resetFfmpegProbeForTest());
+
+/** A session whose active synthesizer is `synth` (null = none active). */
+function sessionWith(synth: Synthesizer | null): SynthesizerSource {
+  return { synthesizers: { tryGetActive: () => synth } };
+}
+
+function fakeSynth(
+  impl: (text: string) => { audio: Uint8Array; mimeType: string } | Promise<never>,
+  name = 'fake',
+): Synthesizer {
+  return {
+    name,
+    synthesize: async (text: string) => impl(text) as { audio: Uint8Array; mimeType: string },
+  };
+}
+
+/**
+ * A fake `spawn`: the first arg selects behavior. `-version` probes resolve to
+ * `probeOk`; a transcode call pushes `output` to stdout then closes with
+ * `transcodeCode` (unless `transcodeThrows`).
+ */
+function makeSpawn(opts: {
+  probeOk?: boolean;
+  output?: Buffer;
+  transcodeCode?: number;
+  transcodeError?: boolean;
+}): { spawn: any; calls: string[][] } {
+  const calls: string[][] = [];
+  const spawn = (cmd: string, args: string[]) => {
+    calls.push([cmd, ...args]);
+    const child = new EventEmitter() as EventEmitter & {
+      stdin: { on: () => void; end: () => void };
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      kill: () => void;
+      killed: boolean;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.killed = false;
+    child.kill = () => {
+      child.killed = true;
+    };
+    child.stdin = { on: () => {}, end: () => {} };
+    const isProbe = args.includes('-version');
+    queueMicrotask(() => {
+      if (isProbe) {
+        child.emit('close', opts.probeOk ? 0 : 1);
+        return;
+      }
+      // transcode
+      if (opts.transcodeError) {
+        child.emit('error', new Error('spawn ENOENT'));
+        return;
+      }
+      if ((opts.transcodeCode ?? 0) === 0 && opts.output) {
+        child.stdout.emit('data', opts.output);
+      }
+      child.emit('close', opts.transcodeCode ?? 0);
+    });
+    return child;
+  };
+  return { spawn, calls };
+}
+
+describe('toSpeech — markdown → spoken text', () => {
+  it('replaces fenced code blocks with a spoken placeholder', () => {
+    const out = toSpeech('Here you go:\n```ts\nconst x = 1;\n```\nDone.');
+    expect(out).toContain('(code omitted)');
+    expect(out).not.toContain('const x');
+    expect(out).not.toContain('```');
+  });
+
+  it('handles an unterminated trailing fence', () => {
+    const out = toSpeech('Start\n```js\nleftover');
+    expect(out).toContain('(code omitted)');
+    expect(out).not.toContain('leftover');
+  });
+
+  it('keeps link labels and drops urls, strips emphasis/headings/quotes/bullets', () => {
+    const out = toSpeech(
+      '# Title\n\n**Bold** and _italic_ and `code` see [the docs](https://x.y)\n\n> quoted\n\n- item one\n- item two',
+    );
+    expect(out).toContain('Title');
+    expect(out).toContain('Bold and italic and code');
+    expect(out).toContain('the docs');
+    expect(out).not.toContain('https://x.y');
+    expect(out).not.toMatch(/[#>*_`]/);
+    expect(out).toContain('item one');
+  });
+
+  it('turns an image into its alt text', () => {
+    expect(toSpeech('![a cat](cat.png)')).toBe('a cat');
+  });
+});
+
+describe('audioExtForMime', () => {
+  it('maps common mimes', () => {
+    expect(audioExtForMime('audio/ogg')).toBe('ogg');
+    expect(audioExtForMime('audio/opus')).toBe('ogg');
+    expect(audioExtForMime('audio/mpeg')).toBe('mp3');
+    expect(audioExtForMime('audio/wav')).toBe('wav');
+    expect(audioExtForMime('audio/x-weird')).toBe('audio');
+  });
+});
+
+describe('synthesizeReply', () => {
+  it('returns no-synthesizer when none is active', async () => {
+    const r = await synthesizeReply(sessionWith(null), 'hello');
+    expect(r).toEqual({ ok: false, reason: 'no-synthesizer' });
+  });
+
+  it('returns empty when the reply has no speakable text', async () => {
+    const synth = fakeSynth(() => ({ audio: new Uint8Array([1]), mimeType: 'audio/ogg' }));
+    const r = await synthesizeReply(sessionWith(synth), '   \n  ');
+    expect(r).toEqual({ ok: false, reason: 'empty' });
+  });
+
+  it('returns audio on success and cleans markdown before synthesis', async () => {
+    let seen = '';
+    const synth = fakeSynth((text) => {
+      seen = text;
+      return { audio: new Uint8Array([9, 9]), mimeType: 'audio/mpeg' };
+    });
+    const r = await synthesizeReply(sessionWith(synth), 'Hello **world**');
+    expect(r).toEqual({ ok: true, audio: new Uint8Array([9, 9]), mimeType: 'audio/mpeg' });
+    expect(seen).toBe('Hello world');
+  });
+
+  it('truncates long text at a boundary', async () => {
+    let seen = '';
+    const synth = fakeSynth((text) => {
+      seen = text;
+      return { audio: new Uint8Array([1]), mimeType: 'audio/ogg' };
+    });
+    const long = `${'a'.repeat(50)}. ${'b'.repeat(50)}. ${'c'.repeat(50)}.`;
+    await synthesizeReply(sessionWith(synth), long, { maxChars: 60 });
+    expect(seen.length).toBeLessThanOrEqual(61);
+    expect(seen.endsWith('…')).toBe(true);
+  });
+
+  it('never throws when the backend rejects', async () => {
+    const synth: Synthesizer = {
+      name: 'boom',
+      synthesize: async () => {
+        throw new Error('tts down');
+      },
+    };
+    const r = await synthesizeReply(sessionWith(synth), 'hi');
+    expect(r).toEqual({ ok: false, reason: 'failed', error: 'tts down' });
+  });
+
+  it('treats empty audio as a failure', async () => {
+    const synth = fakeSynth(() => ({ audio: new Uint8Array(), mimeType: 'audio/ogg' }));
+    const r = await synthesizeReply(sessionWith(synth), 'hi');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('failed');
+  });
+});
+
+describe('ensureOggOpus', () => {
+  it('passes ogg/opus through untouched (no ffmpeg spawn)', async () => {
+    const { spawn, calls } = makeSpawn({});
+    const bytes = new Uint8Array([1, 2, 3]);
+    const r = await ensureOggOpus(bytes, 'audio/ogg', { spawnImpl: spawn });
+    expect(r).toEqual({ audio: bytes, mimeType: 'audio/ogg', transcoded: false, isOpus: true });
+    expect(calls).toHaveLength(0);
+  });
+
+  it('transcodes non-opus audio when ffmpeg is present', async () => {
+    const output = Buffer.from([7, 7, 7, 7]);
+    const { spawn, calls } = makeSpawn({ probeOk: true, output });
+    const r = await ensureOggOpus(new Uint8Array([1, 2]), 'audio/mpeg', { spawnImpl: spawn });
+    expect(r.isOpus).toBe(true);
+    expect(r.transcoded).toBe(true);
+    expect(r.mimeType).toBe('audio/ogg');
+    expect([...r.audio]).toEqual([7, 7, 7, 7]);
+    // probe + transcode.
+    expect(calls.length).toBe(2);
+    expect(calls[1]).toContain('libopus');
+  });
+
+  it('returns the ORIGINAL bytes with isOpus:false when ffmpeg is missing', async () => {
+    const { spawn } = makeSpawn({ probeOk: false });
+    const bytes = new Uint8Array([5, 6]);
+    const r = await ensureOggOpus(bytes, 'audio/mpeg', { spawnImpl: spawn });
+    expect(r).toEqual({ audio: bytes, mimeType: 'audio/mpeg', transcoded: false, isOpus: false });
+  });
+
+  it('falls back to original bytes when the transcode process fails', async () => {
+    const { spawn } = makeSpawn({ probeOk: true, transcodeCode: 1 });
+    const bytes = new Uint8Array([5, 6]);
+    const r = await ensureOggOpus(bytes, 'audio/mpeg', { spawnImpl: spawn });
+    expect(r.isOpus).toBe(false);
+    expect(r.audio).toBe(bytes);
+  });
+});
+
+describe('deliverVoiceReply', () => {
+  function recordingSink(): { sink: VoiceReplySink; sent: Array<{ meta: unknown; bytes: number[] }> } {
+    const sent: Array<{ meta: unknown; bytes: number[] }> = [];
+    return {
+      sent,
+      sink: { send: async (audio, meta) => void sent.push({ meta, bytes: [...audio] }) },
+    };
+  }
+
+  it('sends a voice note when a synthesizer is active and audio is opus', async () => {
+    const synth = fakeSynth(() => ({ audio: new Uint8Array([1, 2]), mimeType: 'audio/ogg' }));
+    const { sink, sent } = recordingSink();
+    const { spawn } = makeSpawn({});
+    const outcome = await deliverVoiceReply(sessionWith(synth), 'hello', sink, { spawnImpl: spawn });
+    expect(outcome).toEqual({ status: 'sent', transcoded: false, isVoiceNote: true });
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.meta).toMatchObject({ filename: 'reply.ogg', isVoiceNote: true });
+  });
+
+  it('sends plain audio (isVoiceNote:false, mime-named file) when ffmpeg is missing', async () => {
+    const synth = fakeSynth(() => ({ audio: new Uint8Array([1]), mimeType: 'audio/mpeg' }));
+    const { sink, sent } = recordingSink();
+    const { spawn } = makeSpawn({ probeOk: false });
+    const outcome = await deliverVoiceReply(sessionWith(synth), 'hi', sink, { spawnImpl: spawn });
+    expect(outcome).toEqual({ status: 'sent', transcoded: false, isVoiceNote: false });
+    expect(sent[0]!.meta).toMatchObject({ filename: 'reply.mp3', isVoiceNote: false });
+  });
+
+  it('skips (does not call the sink) when no synthesizer is active', async () => {
+    const { sink, sent } = recordingSink();
+    const outcome = await deliverVoiceReply(sessionWith(null), 'hi', sink);
+    expect(outcome).toEqual({ status: 'skipped', reason: 'no-synthesizer' });
+    expect(sent).toHaveLength(0);
+  });
+
+  it('reports a synth failure without calling the sink', async () => {
+    const synth: Synthesizer = {
+      name: 'boom',
+      synthesize: async () => {
+        throw new Error('nope');
+      },
+    };
+    const { sink, sent } = recordingSink();
+    const outcome = await deliverVoiceReply(sessionWith(synth), 'hi', sink);
+    expect(outcome).toEqual({ status: 'failed', reason: 'synth', error: 'nope' });
+    expect(sent).toHaveLength(0);
+  });
+
+  it('never throws when the sink throws — returns a delivery failure', async () => {
+    const synth = fakeSynth(() => ({ audio: new Uint8Array([1]), mimeType: 'audio/ogg' }));
+    const sink: VoiceReplySink = {
+      send: async () => {
+        throw new Error('network down');
+      },
+    };
+    const outcome = await deliverVoiceReply(sessionWith(synth), 'hi', sink);
+    expect(outcome).toEqual({ status: 'failed', reason: 'delivery', error: 'network down' });
+  });
+});
+
+describe('resolveVoiceToggle', () => {
+  const base = {
+    hasSynthesizer: true,
+    delivery: 'a voice note',
+    noSynthesizerHint: 'install tts',
+  };
+
+  it('toggles on an empty arg', () => {
+    expect(resolveVoiceToggle({ ...base, arg: '', enabled: false })).toMatchObject({
+      enabled: true,
+      persist: true,
+    });
+    expect(resolveVoiceToggle({ ...base, arg: '', enabled: true })).toMatchObject({
+      enabled: false,
+      persist: true,
+    });
+  });
+
+  it('honors explicit on/off', () => {
+    expect(resolveVoiceToggle({ ...base, arg: 'on', enabled: false }).enabled).toBe(true);
+    expect(resolveVoiceToggle({ ...base, arg: 'off', enabled: true }).enabled).toBe(false);
+  });
+
+  it('status never persists and reports current state', () => {
+    const r = resolveVoiceToggle({ ...base, arg: 'status', enabled: true });
+    expect(r.persist).toBe(false);
+    expect(r.enabled).toBe(true);
+    expect(r.reply).toContain('ON');
+  });
+
+  it('appends install guidance when enabling with no synthesizer', () => {
+    const r = resolveVoiceToggle({ ...base, arg: 'on', enabled: false, hasSynthesizer: false });
+    expect(r.reply).toContain('install tts');
+  });
+
+  it('does not append guidance when turning off', () => {
+    const r = resolveVoiceToggle({ ...base, arg: 'off', enabled: true, hasSynthesizer: false });
+    expect(r.reply).not.toContain('install tts');
+  });
+});

--- a/packages/channel-kit/src/voice-reply.ts
+++ b/packages/channel-kit/src/voice-reply.ts
@@ -1,0 +1,449 @@
+import { Buffer } from 'node:buffer';
+import { spawn } from 'node:child_process';
+import type { SynthesizeOptions, Synthesizer } from '@moxxy/sdk';
+
+/**
+ * Voice-reply machinery shared by messaging channels that can speak the final
+ * assistant reply through the session's active {@link Synthesizer}
+ * (text-to-speech). Everything here is transport-agnostic — turning text into
+ * audio, cleaning markdown for speech, transcoding to OGG/Opus, and picking a
+ * filename. The messenger-specific delivery (grammy `sendVoice`, a discord.js
+ * `AttachmentBuilder`) stays in each channel plugin behind the
+ * {@link VoiceReplySink}.
+ *
+ * The load-bearing guarantee is that NOTHING here throws into the turn path: a
+ * missing synthesizer, a TTS failure, a missing ffmpeg, or a transport error
+ * all resolve to a typed result. Callers send the text reply first and treat a
+ * voice reply as best-effort, so a synth/transcode/delivery failure never
+ * breaks the (already-sent) text answer.
+ */
+
+/** The slice of a session the voice-reply path needs: the synthesizer view. */
+export interface SynthesizerSource {
+  readonly synthesizers: { tryGetActive(): Synthesizer | null };
+}
+
+/**
+ * Strip markdown down to what should be *spoken*. Code fences become a short
+ * "(code omitted)" placeholder (reading a diff aloud is noise), links keep only
+ * their label, and the inline emphasis/heading/quote/bullet marks are removed
+ * so a TTS engine doesn't voice the punctuation. Whitespace is collapsed.
+ */
+export function toSpeech(markdown: string): string {
+  let t = markdown ?? '';
+  // Fenced code blocks (closed, then any unterminated trailing fence) → a short
+  // spoken placeholder. Must run BEFORE inline-code stripping (fences contain
+  // backticks).
+  t = t.replace(/```[\s\S]*?```/g, ' (code omitted) ');
+  t = t.replace(/```[\s\S]*$/g, ' (code omitted) ');
+  // Images `![alt](url)` → alt; links `[label](url)` → label.
+  t = t.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1');
+  t = t.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1');
+  // Inline code `x` → x.
+  t = t.replace(/`([^`]+)`/g, '$1');
+  // Emphasis / strikethrough marks.
+  t = t.replace(/(\*\*|__|~~|\*|_)/g, '');
+  // Leading heading / blockquote / list markers (line-anchored).
+  t = t.replace(/^\s{0,3}#{1,6}\s*/gm, '');
+  t = t.replace(/^\s{0,3}>\s?/gm, '');
+  t = t.replace(/^\s{0,3}[-*+]\s+/gm, '');
+  // Collapse runs of spaces/tabs and excess blank lines.
+  t = t.replace(/[ \t]+/g, ' ');
+  t = t.replace(/\n{3,}/g, '\n\n');
+  return t.trim();
+}
+
+/** Default ceiling on the characters we hand a TTS backend for one reply. Long
+ *  answers are truncated at a sentence/word boundary so synthesis stays fast
+ *  and cheap (a spoken 30-page essay helps no one). */
+const DEFAULT_MAX_SPEECH_CHARS = 1_200;
+
+function truncateForSpeech(text: string, max: number): string {
+  if (text.length <= max) return text;
+  const slice = text.slice(0, max);
+  const sentence = Math.max(
+    slice.lastIndexOf('. '),
+    slice.lastIndexOf('! '),
+    slice.lastIndexOf('? '),
+    slice.lastIndexOf('\n'),
+  );
+  const cut = sentence > max * 0.5 ? sentence + 1 : slice.lastIndexOf(' ');
+  const head = (cut > 0 ? slice.slice(0, cut) : slice).trim();
+  return `${head}…`;
+}
+
+export interface SynthesizeReplyOptions extends SynthesizeOptions {
+  /** Max characters of speech text handed to the backend. Default 1200. */
+  readonly maxChars?: number;
+}
+
+export type SynthesizeReplyResult =
+  | { readonly ok: true; readonly audio: Uint8Array; readonly mimeType: string }
+  // `no-synthesizer`: nothing active (caller may nudge the user to install one).
+  // `empty`: the reply had no speakable text (e.g. a tool-only turn).
+  // `failed`: the backend threw or returned no audio.
+  | { readonly ok: false; readonly reason: 'no-synthesizer' | 'empty' | 'failed'; readonly error?: string };
+
+/**
+ * Synthesize a reply through the session's active synthesizer. Cleans markdown
+ * for speech ({@link toSpeech}), truncates sensibly, and NEVER throws — every
+ * failure mode is a typed `ok:false` result so the turn path stays intact.
+ */
+export async function synthesizeReply(
+  session: SynthesizerSource,
+  text: string,
+  opts: SynthesizeReplyOptions = {},
+): Promise<SynthesizeReplyResult> {
+  let synth: Synthesizer | null;
+  try {
+    synth = session.synthesizers.tryGetActive();
+  } catch (err) {
+    return { ok: false, reason: 'failed', error: err instanceof Error ? err.message : String(err) };
+  }
+  if (!synth) return { ok: false, reason: 'no-synthesizer' };
+
+  const speech = truncateForSpeech(toSpeech(text), opts.maxChars ?? DEFAULT_MAX_SPEECH_CHARS);
+  if (!speech) return { ok: false, reason: 'empty' };
+
+  const synthOpts: SynthesizeOptions = {};
+  if (opts.voice !== undefined) (synthOpts as { voice?: string }).voice = opts.voice;
+  if (opts.language !== undefined) (synthOpts as { language?: string }).language = opts.language;
+  if (opts.rate !== undefined) (synthOpts as { rate?: number }).rate = opts.rate;
+  if (opts.signal !== undefined) (synthOpts as { signal?: AbortSignal }).signal = opts.signal;
+
+  try {
+    const result = await synth.synthesize(speech, synthOpts);
+    if (!result?.audio || result.audio.byteLength === 0) {
+      return { ok: false, reason: 'failed', error: 'synthesizer returned no audio' };
+    }
+    return { ok: true, audio: result.audio, mimeType: result.mimeType };
+  } catch (err) {
+    return { ok: false, reason: 'failed', error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/** True for a mime type Telegram accepts as a native voice note (OGG/Opus). */
+function isOggOpusMime(mimeType: string): boolean {
+  const m = mimeType.toLowerCase();
+  return m.includes('opus') || m.includes('ogg');
+}
+
+/** Map an audio mime type to a sensible file extension (for the attachment name
+ *  a messenger uses to sniff the format). Falls back to `audio` when unknown. */
+export function audioExtForMime(mimeType: string): string {
+  const m = (mimeType || '').toLowerCase();
+  if (m.includes('opus') || m.includes('ogg')) return 'ogg';
+  if (m.includes('mpeg') || m.includes('mp3')) return 'mp3';
+  if (m.includes('wav')) return 'wav';
+  if (m.includes('webm')) return 'webm';
+  if (m.includes('aac') || m.includes('m4a') || m.includes('mp4')) return 'm4a';
+  if (m.includes('flac')) return 'flac';
+  return 'audio';
+}
+
+export interface EnsureOggOpusOptions {
+  /** Injectable `spawn` for tests. When set, the ffmpeg presence probe is NOT
+   *  process-cached (so each test drives a deterministic outcome). */
+  readonly spawnImpl?: typeof spawn;
+}
+
+export interface EnsureOggOpusResult {
+  readonly audio: Uint8Array;
+  readonly mimeType: string;
+  /** True when ffmpeg ran to produce these bytes. */
+  readonly transcoded: boolean;
+  /** True when `audio` is OGG/Opus (safe to send as a native voice note); false
+   *  when we returned the ORIGINAL bytes because ffmpeg was unavailable — the
+   *  caller should then send plain audio instead of a voice note. */
+  readonly isOpus: boolean;
+}
+
+const TRANSCODE_ARGS = [
+  '-hide_banner',
+  '-loglevel',
+  'error',
+  '-i',
+  'pipe:0',
+  '-f',
+  'ogg',
+  '-c:a',
+  'libopus',
+  '-b:a',
+  '32k',
+  '-ac',
+  '1',
+  'pipe:1',
+];
+
+/** Ceiling on transcoded output we buffer (a runaway/adversarial input can't
+ *  grow memory without bound). 25MB is well past any spoken reply. */
+const MAX_TRANSCODE_OUTPUT_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Ensure audio is OGG/Opus for a native voice note. Passthrough when it already
+ * is; otherwise transcode via ffmpeg (stdin→stdout). Gated on an ffmpeg
+ * presence probe (mirrors `checkVoiceCaptureAvailable`, cached per process). On
+ * no-ffmpeg — or any transcode failure — returns the ORIGINAL bytes with
+ * `isOpus:false` so the caller falls back to a plain audio message. Never throws.
+ */
+export async function ensureOggOpus(
+  audio: Uint8Array,
+  mimeType: string,
+  opts: EnsureOggOpusOptions = {},
+): Promise<EnsureOggOpusResult> {
+  if (isOggOpusMime(mimeType)) {
+    return { audio, mimeType: 'audio/ogg', transcoded: false, isOpus: true };
+  }
+  const available = await probeFfmpeg(opts.spawnImpl);
+  if (!available) return { audio, mimeType, transcoded: false, isOpus: false };
+  try {
+    const out = await transcodeToOggOpus(audio, opts.spawnImpl ?? spawn);
+    if (out.byteLength === 0) return { audio, mimeType, transcoded: false, isOpus: false };
+    return { audio: out, mimeType: 'audio/ogg', transcoded: true, isOpus: true };
+  } catch {
+    return { audio, mimeType, transcoded: false, isOpus: false };
+  }
+}
+
+// Process-cached ffmpeg availability (the probe spawns a subprocess; caching
+// keeps a chatty channel from re-probing on every reply). Tests inject a
+// `spawnImpl`, which bypasses the cache.
+let ffmpegAvailable: Promise<boolean> | null = null;
+
+async function probeFfmpeg(spawnImpl?: typeof spawn): Promise<boolean> {
+  if (spawnImpl) return runFfmpegProbe(spawnImpl);
+  ffmpegAvailable ??= runFfmpegProbe(spawn);
+  return ffmpegAvailable;
+}
+
+/** Reset the cached ffmpeg probe (tests only). */
+export function __resetFfmpegProbeForTest(): void {
+  ffmpegAvailable = null;
+}
+
+function runFfmpegProbe(
+  spawnImpl: typeof spawn,
+  command = 'ffmpeg',
+  timeoutMs = 1_500,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (v: boolean): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(v);
+    };
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawnImpl(command, ['-version'], { stdio: ['ignore', 'ignore', 'ignore'] });
+    } catch {
+      resolve(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      try {
+        if (!child.killed) child.kill('SIGKILL');
+      } catch {
+        /* ignore */
+      }
+      done(false);
+    }, timeoutMs);
+    timer.unref?.();
+    child.once('error', () => done(false));
+    child.once('close', (code) => done(code === 0));
+  });
+}
+
+function transcodeToOggOpus(
+  audio: Uint8Array,
+  spawnImpl: typeof spawn,
+  command = 'ffmpeg',
+  timeoutMs = 15_000,
+): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawnImpl(command, TRANSCODE_ARGS, { stdio: ['pipe', 'pipe', 'pipe'] });
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+    const out: Buffer[] = [];
+    const errChunks: Buffer[] = [];
+    let outBytes = 0;
+    let over = false;
+    let settled = false;
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    };
+    const timer = setTimeout(() => {
+      try {
+        if (!child.killed) child.kill('SIGKILL');
+      } catch {
+        /* ignore */
+      }
+      finish(() => reject(new Error('ffmpeg transcode timed out')));
+    }, timeoutMs);
+    timer.unref?.();
+
+    child.stdout?.on('data', (c: Buffer) => {
+      if (over) return;
+      if (outBytes + c.byteLength > MAX_TRANSCODE_OUTPUT_BYTES) {
+        over = true;
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          /* ignore */
+        }
+        return;
+      }
+      outBytes += c.byteLength;
+      out.push(Buffer.from(c));
+    });
+    child.stderr?.on('data', (c: Buffer) => {
+      errChunks.push(Buffer.from(c));
+      while (Buffer.concat(errChunks).byteLength > 4_096) errChunks.shift();
+    });
+    child.once('error', (err) =>
+      finish(() => reject(err instanceof Error ? err : new Error(String(err)))),
+    );
+    child.once('close', (code) =>
+      finish(() => {
+        if (code === 0 && out.length > 0) {
+          resolve(new Uint8Array(Buffer.concat(out)));
+        } else if (code === 0) {
+          reject(new Error('ffmpeg produced no output'));
+        } else {
+          reject(new Error(`ffmpeg exited ${code}: ${Buffer.concat(errChunks).toString('utf8').trim()}`));
+        }
+      }),
+    );
+
+    const stdin = child.stdin;
+    if (stdin) {
+      stdin.on('error', () => {
+        // EPIPE if ffmpeg died before consuming stdin — the close/error handler
+        // reports the real failure; swallow this to avoid an unhandled 'error'.
+      });
+      try {
+        stdin.end(Buffer.from(audio));
+      } catch {
+        /* the close/error path reports it */
+      }
+    }
+  });
+}
+
+/** The transport boundary: a channel implements this to actually deliver the
+ *  synthesized audio (grammy `sendVoice`/`sendAudio`, discord.js attachment). */
+export interface VoiceReplySink {
+  send(
+    audio: Uint8Array,
+    meta: {
+      readonly mimeType: string;
+      /** Suggested attachment filename, e.g. `reply.ogg` / `reply.mp3`. */
+      readonly filename: string;
+      /** True when the bytes are OGG/Opus (send as a native voice note); false
+       *  when they are plain audio (no ffmpeg to transcode). */
+      readonly isVoiceNote: boolean;
+    },
+  ): Promise<void>;
+}
+
+export type VoiceReplyOutcome =
+  | { readonly status: 'sent'; readonly transcoded: boolean; readonly isVoiceNote: boolean }
+  | { readonly status: 'skipped'; readonly reason: 'no-synthesizer' | 'empty' }
+  | { readonly status: 'failed'; readonly reason: 'synth' | 'delivery'; readonly error?: string };
+
+export type DeliverVoiceReplyOptions = SynthesizeReplyOptions & EnsureOggOpusOptions;
+
+/**
+ * End-to-end best-effort voice reply: synthesize → ensure OGG/Opus → deliver
+ * through the channel's {@link VoiceReplySink}. NEVER throws — every failure is
+ * a typed outcome — so a caller can invoke it AFTER sending the text reply and
+ * be sure the (already-sent) text is never broken by a voice failure.
+ */
+export async function deliverVoiceReply(
+  session: SynthesizerSource,
+  text: string,
+  sink: VoiceReplySink,
+  opts: DeliverVoiceReplyOptions = {},
+): Promise<VoiceReplyOutcome> {
+  const synth = await synthesizeReply(session, text, opts);
+  if (!synth.ok) {
+    if (synth.reason === 'failed') {
+      return synth.error !== undefined
+        ? { status: 'failed', reason: 'synth', error: synth.error }
+        : { status: 'failed', reason: 'synth' };
+    }
+    return { status: 'skipped', reason: synth.reason };
+  }
+
+  const prepared = await ensureOggOpus(synth.audio, synth.mimeType, opts);
+  const filename = prepared.isOpus ? 'reply.ogg' : `reply.${audioExtForMime(prepared.mimeType)}`;
+  try {
+    await sink.send(prepared.audio, {
+      mimeType: prepared.mimeType,
+      filename,
+      isVoiceNote: prepared.isOpus,
+    });
+  } catch (err) {
+    return { status: 'failed', reason: 'delivery', error: err instanceof Error ? err.message : String(err) };
+  }
+  return { status: 'sent', transcoded: prepared.transcoded, isVoiceNote: prepared.isOpus };
+}
+
+export interface VoiceToggleInput {
+  /** The `/voice` argument (`''`, `on`, `off`, `status`, or anything → toggle). */
+  readonly arg: string;
+  /** Current persisted state. */
+  readonly enabled: boolean;
+  /** Whether a synthesizer is active right now. */
+  readonly hasSynthesizer: boolean;
+  /** How this channel delivers audio, e.g. `a voice note` / `an audio file`. */
+  readonly delivery: string;
+  /** Install-guidance line appended when enabling with no active synthesizer. */
+  readonly noSynthesizerHint: string;
+}
+
+export interface VoiceToggleResult {
+  /** Desired enabled state after the command. */
+  readonly enabled: boolean;
+  /** Whether the caller should persist `enabled` (false for `status`). */
+  readonly persist: boolean;
+  /** User-facing reply text. */
+  readonly reply: string;
+}
+
+/**
+ * Resolve a channel-agnostic `/voice` toggle command into the new state + the
+ * reply to show. `on`/`off` are explicit, `status` just reports, anything else
+ * flips. Enabling with no active synthesizer still turns the preference on (so
+ * replies start speaking once a backend is installed) but appends install
+ * guidance. Wording is parameterized (`delivery`, `noSynthesizerHint`) so each
+ * messenger keeps its own phrasing.
+ */
+export function resolveVoiceToggle(input: VoiceToggleInput): VoiceToggleResult {
+  const arg = input.arg.trim().toLowerCase();
+  const hint = input.hasSynthesizer ? '' : `\n\n${input.noSynthesizerHint}`;
+
+  if (arg === 'status') {
+    const state = input.enabled ? 'ON' : 'OFF';
+    const note = input.enabled ? hint : '';
+    return { enabled: input.enabled, persist: false, reply: `Voice replies are ${state}.${note}` };
+  }
+
+  const desired = arg === 'on' ? true : arg === 'off' ? false : !input.enabled;
+  if (!desired) {
+    return { enabled: false, persist: true, reply: '🔇 Voice replies OFF.' };
+  }
+  return {
+    enabled: true,
+    persist: true,
+    reply: `🔊 Voice replies ON — I'll speak my final reply as ${input.delivery}.${hint}`,
+  };
+}

--- a/packages/plugin-channel-discord/src/channel.ts
+++ b/packages/plugin-channel-discord/src/channel.ts
@@ -1,4 +1,6 @@
+import { Buffer } from 'node:buffer';
 import {
+  AttachmentBuilder,
   Client,
   Events,
   GatewayIntentBits,
@@ -7,7 +9,7 @@ import {
   type Message,
 } from 'discord.js';
 import { newTurnId } from '@moxxy/core';
-import { TurnCoordinator } from '@moxxy/channel-kit';
+import { TurnCoordinator, deliverVoiceReply, resolveVoiceToggle } from '@moxxy/channel-kit';
 import type { ClientSession as Session } from '@moxxy/sdk';
 import type {
   ApprovalRequest,
@@ -21,7 +23,12 @@ import type {
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { DiscordPermissionResolver } from './permission.js';
 import { DiscordApprovalResolver } from './approval.js';
-import { resolveBotToken, DISCORD_TOKEN_KEY } from './keys.js';
+import {
+  resolveBotToken,
+  DISCORD_TOKEN_KEY,
+  loadVoiceReplies,
+  saveVoiceReplies,
+} from './keys.js';
 import { extractInboundMessage } from './schema.js';
 import { splitForDiscord } from './render.js';
 import { AllowListStore } from './channel/allow-list-store.js';
@@ -49,6 +56,14 @@ const READY_TIMEOUT_MS = 15_000;
 /** Minimal permission bits for the invite link: View Channels + Send Messages
  *  + Read Message History. */
 const INVITE_PERMISSIONS = 1024 + 2048 + 65536;
+
+/**
+ * Install guidance shown when enabling `/voice` with no active synthesizer —
+ * mirrors the voice-handler's transcriber guidance wording, pointing at the TTS
+ * plugin instead of the STT one.
+ */
+const VOICE_NO_SYNTH_HINT =
+  'No text-to-speech backend is configured yet, so replies stay text-only. Install one with `moxxy plugins install tts-openai` and run `moxxy login openai` (or set OPENAI_API_KEY) to enable spoken replies.';
 
 export type { PairingConfirmResult } from './channel/pairing-handler.js';
 
@@ -100,6 +115,11 @@ export class DiscordChannel implements Channel<DiscordStartOpts> {
   private session: Session | null = null;
   private model: string | undefined;
   private yolo = false;
+  // When true, the final assistant reply of each turn is also synthesized (via
+  // the session's active Synthesizer) and sent as an audio attachment.
+  // Persisted per paired account in the vault (`discord_voice_replies`),
+  // toggled with `/voice`.
+  private voiceReplies = false;
   // Single-flight turn state: `busy` guard, per-turn AbortController (so
   // /cancel aborts only the current turn), and the bounded own-turn-id set
   // that mirrorForeignTurn filters on (AGENTS.md invariant #8).
@@ -176,6 +196,7 @@ export class DiscordChannel implements Channel<DiscordStartOpts> {
     }
     await this.pairing.loadAuthorized();
     await this.allowList.load();
+    this.voiceReplies = await loadVoiceReplies(this.opts.vault);
 
     // Arm the DM pairing window when a pairing surface asked for it (`pair`)
     // OR when running GUI-supervised on a dedicated runner and nothing is
@@ -383,6 +404,7 @@ export class DiscordChannel implements Channel<DiscordStartOpts> {
         setYolo: (value) => {
           this.yolo = value;
         },
+        voice: (arg) => this.voiceCommand(arg),
         runUserTurn: (c, text) => this.runUserTurn(c, text),
         runVoiceMessage: (c) =>
           handleVoiceMessage(
@@ -414,6 +436,7 @@ export class DiscordChannel implements Channel<DiscordStartOpts> {
           this.yolo = !this.yolo;
           return this.yolo;
         },
+        voice: (arg) => this.voiceCommand(arg),
         performSessionAction: (action, notice) =>
           performSessionAction(
             action,
@@ -461,12 +484,62 @@ export class DiscordChannel implements Channel<DiscordStartOpts> {
           typing: this.typing,
           editFrameMs: this.editFrameMs,
           ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+          onFinalReply: (finalText) => this.sendVoiceReply(ctx.channel, finalText),
         },
         { text, model: this.model, controller: lease.controller, turnId: lease.turnId },
       );
     } finally {
       lease.end();
       this.currentChannel = null;
+    }
+  }
+
+  /** Handle `/voice [on|off|status]`: persist + apply the preference, return the
+   *  reply text. Shared by the plain-text and application-command paths. */
+  private async voiceCommand(arg: string): Promise<string> {
+    const result = resolveVoiceToggle({
+      arg,
+      enabled: this.voiceReplies,
+      hasSynthesizer: this.session?.synthesizers.tryGetActive() != null,
+      delivery: 'an audio file',
+      noSynthesizerHint: VOICE_NO_SYNTH_HINT,
+    });
+    if (result.persist) await this.setVoiceReplies(result.enabled);
+    return result.reply;
+  }
+
+  private async setVoiceReplies(on: boolean): Promise<void> {
+    this.voiceReplies = on;
+    try {
+      await saveVoiceReplies(this.opts.vault, on);
+    } catch (err) {
+      this.opts.logger?.warn('discord voice-replies persist failed', { err: String(err) });
+    }
+  }
+
+  /**
+   * Attach the final assistant reply as synthesized audio, when enabled.
+   * Best-effort and fully isolated (never throws): synthesize via the session's
+   * active Synthesizer, transcode to OGG/Opus (or send the original format when
+   * ffmpeg is unavailable), and post as a file. The text reply already went out.
+   *
+   * NB: a plain audio attachment, not a true Discord voice-message bubble
+   * (MessageFlags.IsVoiceMessage + waveform) — deferred to a follow-up.
+   */
+  private async sendVoiceReply(channel: SendableChannelLike, text: string): Promise<void> {
+    if (!this.voiceReplies || !this.session) return;
+    const outcome = await deliverVoiceReply(this.session, text, {
+      send: async (audio, meta) => {
+        await channel.send({
+          files: [new AttachmentBuilder(Buffer.from(audio), { name: meta.filename })],
+        });
+      },
+    });
+    if (outcome.status === 'failed') {
+      this.opts.logger?.warn('discord voice reply failed', {
+        reason: outcome.reason,
+        ...(outcome.error ? { err: outcome.error } : {}),
+      });
     }
   }
 

--- a/packages/plugin-channel-discord/src/channel/discord-like.ts
+++ b/packages/plugin-channel-discord/src/channel/discord-like.ts
@@ -11,10 +11,14 @@ export interface SentMessageLike {
   edit(content: string): Promise<unknown>;
 }
 
-/** Payload accepted by `send` — text plus optional component rows (buttons). */
+/** Payload accepted by `send` — text plus optional component rows (buttons) or
+ *  file attachments (a synthesized voice reply). `content` is optional so a
+ *  file-only message (audio, no text) is expressible. */
 export interface OutboundPayload {
-  readonly content: string;
+  readonly content?: string;
   readonly components?: ReadonlyArray<unknown>;
+  /** File attachments (e.g. a discord.js `AttachmentBuilder`). */
+  readonly files?: ReadonlyArray<unknown>;
 }
 
 /** A channel (DM or guild text channel) we can post into. */

--- a/packages/plugin-channel-discord/src/channel/interaction-handler.ts
+++ b/packages/plugin-channel-discord/src/channel/interaction-handler.ts
@@ -47,6 +47,8 @@ export interface InteractionDeps {
 export interface InteractionCallbacks {
   readonly setAwaitingApprovalText: (state: AwaitingApprovalText | null) => void;
   readonly toggleYolo: () => boolean;
+  /** Handle `/voice [on|off|status]` — persist + apply, return the reply text. */
+  readonly voice: (arg: string) => Promise<string>;
   readonly performSessionAction: (
     action: 'new' | 'clear' | 'exit',
     notice: string | undefined,
@@ -178,6 +180,7 @@ async function handleSlashCommand(
   }
   const reply = await runSlash(name, '', state.session, {
     toggleYolo: cb.toggleYolo,
+    voice: cb.voice,
     performSessionAction: cb.performSessionAction,
   });
   await safeReply(interaction, reply.length > 1_900 ? reply.slice(0, 1_899) + '…' : reply, deps.logger);

--- a/packages/plugin-channel-discord/src/channel/message-handler.ts
+++ b/packages/plugin-channel-discord/src/channel/message-handler.ts
@@ -42,6 +42,8 @@ export interface MessageHandlerCallbacks {
   readonly setAwaitingApprovalText: (state: AwaitingApprovalText | null) => void;
   readonly toggleYolo: () => boolean;
   readonly setYolo: (value: boolean) => void;
+  /** Handle `/voice [on|off|status]` — persist + apply, return the reply text. */
+  readonly voice: (arg: string) => Promise<string>;
   readonly runUserTurn: (ctx: InboundContext, text: string) => Promise<void>;
   /** Handle audio attachments (voice messages). Returns true when it consumed
    *  the message (so the text path is skipped). */
@@ -130,6 +132,7 @@ export async function handleInboundMessage(
     const [head, ...rest] = text.split(/\s+/);
     const reply = await runSlash(head!.slice(1), rest.join(' '), state.session, {
       toggleYolo: cb.toggleYolo,
+      voice: cb.voice,
       performSessionAction: (action, notice) =>
         performSessionAction(action, notice, state, deps, cb),
     });

--- a/packages/plugin-channel-discord/src/channel/slash-handler.ts
+++ b/packages/plugin-channel-discord/src/channel/slash-handler.ts
@@ -4,6 +4,8 @@ import type { ChannelLogger } from './discord-like.js';
 export interface SlashCallbacks {
   /** Toggle yolo and return its new value (so we can echo the right message). */
   toggleYolo(): boolean;
+  /** Handle `/voice [on|off|status]` — persist + apply, return the reply text. */
+  voice(arg: string): Promise<string>;
   /** Apply a `session-action` result emitted from a registered command. */
   performSessionAction(action: 'new' | 'clear' | 'exit', notice: string | undefined): Promise<string>;
 }
@@ -52,6 +54,8 @@ export async function runSlash(
         ? '⚠ yolo mode ON — tool calls auto-approved for the rest of this session'
         : 'yolo mode OFF — tool prompts will resume';
     }
+    case 'voice':
+      return cb.voice(args);
     case 'tools': {
       const list = session.tools
         .list()
@@ -89,6 +93,7 @@ export interface AppCommandJson {
 export function buildAppCommands(session: Session): AppCommandJson[] {
   const LOCAL: AppCommandJson[] = [
     { name: 'yolo', description: 'Toggle auto-approve mode' },
+    { name: 'voice', description: 'Toggle spoken voice replies' },
     { name: 'tools', description: 'List the tools the active session can call' },
     { name: 'skills', description: 'List the discovered skills' },
     { name: 'cancel', description: 'Abort the current turn' },

--- a/packages/plugin-channel-discord/src/channel/turn-runner.ts
+++ b/packages/plugin-channel-discord/src/channel/turn-runner.ts
@@ -25,6 +25,12 @@ export interface RunDiscordTurnDeps {
   readonly typing: TypingIndicator;
   readonly editFrameMs: number;
   readonly logger?: ChannelLogger;
+  /**
+   * Called once with the FINAL assistant text after it has been flushed to the
+   * channel (so the text reply always lands first). Backs the optional voice
+   * reply. Best-effort — its failure is logged and never breaks the text turn.
+   */
+  readonly onFinalReply?: (text: string) => Promise<void>;
 }
 
 export interface RunDiscordTurnOptions {
@@ -53,7 +59,7 @@ export async function runDiscordTurn(
   deps: RunDiscordTurnDeps,
   opts: RunDiscordTurnOptions,
 ): Promise<void> {
-  const { session, channel, typing, editFrameMs, logger } = deps;
+  const { session, channel, typing, editFrameMs, logger, onFinalReply } = deps;
   const { text, model, controller, turnId } = opts;
 
   const renderer = new DiscordTurnRenderer();
@@ -105,6 +111,21 @@ export async function runDiscordTurn(
       signal: controller.signal,
     });
     await pump.flush(true);
+    // The text reply is now out. Speak the final assistant body if a voice
+    // reply is wired — isolated so a synth/transcode/transport failure can
+    // never break (or re-report) the already-delivered text turn.
+    if (onFinalReply) {
+      const finalText = renderer.finalText();
+      if (finalText) {
+        try {
+          await onFinalReply(finalText);
+        } catch (err) {
+          logger?.warn('discord voice reply hook failed', {
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }
   } catch (err) {
     logger?.warn('discord turn failed', {
       err: err instanceof Error ? err.message : String(err),

--- a/packages/plugin-channel-discord/src/channel/voice-reply.test.ts
+++ b/packages/plugin-channel-discord/src/channel/voice-reply.test.ts
@@ -1,0 +1,142 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { VaultStore, createStaticKeySource, deriveKey, generateSalt } from '@moxxy/plugin-vault';
+import { asTurnId, type MoxxyEvent } from '@moxxy/sdk';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import { DISCORD_VOICE_REPLIES_KEY, loadVoiceReplies, saveVoiceReplies } from '../keys.js';
+import { runSlash } from './slash-handler.js';
+import { runDiscordTurn } from './turn-runner.js';
+import type { SendableChannelLike, SentMessageLike } from './discord-like.js';
+import { TypingIndicator } from './typing-indicator.js';
+
+describe('discord voice-replies vault flag round-trip', () => {
+  let tmp: string;
+  let vault: VaultStore;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-dc-voice-'));
+    vault = new VaultStore({
+      filePath: path.join(tmp, 'vault.json'),
+      keySource: createStaticKeySource(deriveKey('test', generateSalt())),
+    });
+  });
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it('defaults to off, persists on, then off', async () => {
+    expect(await loadVoiceReplies(vault)).toBe(false);
+    await saveVoiceReplies(vault, true);
+    expect(await vault.get(DISCORD_VOICE_REPLIES_KEY)).toBe('1');
+    expect(await loadVoiceReplies(vault)).toBe(true);
+    await saveVoiceReplies(vault, false);
+    expect(await vault.get(DISCORD_VOICE_REPLIES_KEY)).toBe(null);
+    expect(await loadVoiceReplies(vault)).toBe(false);
+  });
+});
+
+describe('runSlash routes /voice to the channel callback', () => {
+  it('forwards the argument and returns the callback reply', async () => {
+    const args: string[] = [];
+    const session = { commands: { get: () => undefined } } as unknown as Session;
+    const reply = await runSlash('voice', 'on', session, {
+      toggleYolo: () => false,
+      voice: async (a) => {
+        args.push(a);
+        return '🔊 Voice replies ON';
+      },
+      performSessionAction: async () => '',
+    });
+    expect(args).toEqual(['on']);
+    expect(reply).toContain('Voice replies ON');
+  });
+});
+
+interface Recorded {
+  sends: string[];
+  channel: SendableChannelLike;
+}
+function recordedChannel(): Recorded {
+  const sends: string[] = [];
+  const channel: SendableChannelLike = {
+    send: async (payload) => {
+      sends.push(typeof payload === 'string' ? payload : payload.content ?? '');
+      const message: SentMessageLike = { edit: async () => {} };
+      return message;
+    },
+  };
+  return { sends, channel };
+}
+
+function fakeSession(script: (emit: (e: Record<string, unknown>) => void) => void): Session {
+  const listeners = new Set<(e: MoxxyEvent) => void>();
+  return {
+    log: {
+      subscribe(fn: (e: MoxxyEvent) => void) {
+        listeners.add(fn);
+        return () => listeners.delete(fn);
+      },
+    },
+    runTurn: (_p: string, opts: { turnId: string }) =>
+      (async function* () {
+        const emit = (e: Record<string, unknown>): void => {
+          const ev = { ...e, turnId: opts.turnId } as unknown as MoxxyEvent;
+          for (const fn of listeners) fn(ev);
+        };
+        script(emit);
+        yield undefined as never;
+      })(),
+  } as unknown as Session;
+}
+
+describe('runDiscordTurn onFinalReply seam (final assistant text)', () => {
+  it('calls onFinalReply with the assistant body after the text is flushed', async () => {
+    const { sends, channel } = recordedChannel();
+    const seen: string[] = [];
+    const session = fakeSession((emit) => {
+      emit({ type: 'assistant_chunk', delta: 'Hi' });
+      emit({ type: 'assistant_message', content: 'Hi there, done.' });
+    });
+    await runDiscordTurn(
+      { session, channel, typing: new TypingIndicator(), editFrameMs: 10, onFinalReply: async (t) => void seen.push(t) },
+      { text: 'hi', controller: new AbortController(), turnId: asTurnId('d1') },
+    );
+    expect(sends.length).toBeGreaterThanOrEqual(1);
+    expect(seen).toEqual(['Hi there, done.']);
+  });
+
+  it('does not speak a tool-only turn (empty assistant body)', async () => {
+    const { channel } = recordedChannel();
+    const seen: string[] = [];
+    const session = fakeSession((emit) => {
+      emit({ type: 'tool_call_requested', callId: 'c1', name: 'read', input: {} });
+    });
+    await runDiscordTurn(
+      { session, channel, typing: new TypingIndicator(), editFrameMs: 10, onFinalReply: async (t) => void seen.push(t) },
+      { text: 'hi', controller: new AbortController(), turnId: asTurnId('d2') },
+    );
+    expect(seen).toEqual([]);
+  });
+
+  it('never breaks the (already-sent) text turn when the voice hook rejects', async () => {
+    const { sends, channel } = recordedChannel();
+    const session = fakeSession((emit) => emit({ type: 'assistant_message', content: 'Done.' }));
+    await runDiscordTurn(
+      {
+        session,
+        channel,
+        typing: new TypingIndicator(),
+        editFrameMs: 10,
+        onFinalReply: async () => {
+          throw new Error('tts exploded');
+        },
+      },
+      { text: 'hi', controller: new AbortController(), turnId: asTurnId('d3') },
+    );
+    // The text still landed; the failed hook did NOT surface a "Turn failed".
+    expect(sends.join(' ')).toContain('Done.');
+    expect(sends.join(' ')).not.toContain('Turn failed');
+  });
+});

--- a/packages/plugin-channel-discord/src/keys.ts
+++ b/packages/plugin-channel-discord/src/keys.ts
@@ -16,6 +16,12 @@ export const DISCORD_AUTHORIZED_USER_KEY = 'discord_authorized_user_id';
 /** Vault key for the guild-channel allow-list (JSON array of channel ids the
  *  paired user may drive the bot from, beyond their own DM). */
 export const DISCORD_ALLOWED_CHANNELS_KEY = 'discord_allowed_channel_ids';
+/**
+ * Vault key for the voice-replies preference. Single-paired-account model, so a
+ * present-flag (`'1'` = on, absent = off) toggled from a DM / allow-listed
+ * channel via `/voice`.
+ */
+export const DISCORD_VOICE_REPLIES_KEY = 'discord_voice_replies';
 
 /** Env override for the bot token (beats the vault, matching every other channel). */
 export const DISCORD_TOKEN_ENV = 'MOXXY_DISCORD_TOKEN';
@@ -72,4 +78,23 @@ export function parseAllowedChannels(raw: string | null | undefined): ReadonlyAr
 /** Serialize the allow-list for the vault (deduplicated, stable order). */
 export function serializeAllowedChannels(ids: Iterable<string>): string {
   return JSON.stringify([...new Set(ids)]);
+}
+
+/** Read the persisted voice-replies preference (`'1'` → on). */
+export async function loadVoiceReplies(vault: {
+  get(name: string): Promise<string | null>;
+}): Promise<boolean> {
+  return (await vault.get(DISCORD_VOICE_REPLIES_KEY)) === '1';
+}
+
+/** Persist the voice-replies preference: store `'1'` when on, remove it when off. */
+export async function saveVoiceReplies(
+  vault: {
+    set(name: string, value: string): Promise<void>;
+    delete(name: string): Promise<boolean>;
+  },
+  on: boolean,
+): Promise<void> {
+  if (on) await vault.set(DISCORD_VOICE_REPLIES_KEY, '1');
+  else await vault.delete(DISCORD_VOICE_REPLIES_KEY);
 }

--- a/packages/plugin-channel-discord/src/render.ts
+++ b/packages/plugin-channel-discord/src/render.ts
@@ -97,10 +97,16 @@ export class DiscordTurnRenderer {
     const parts: string[] = [];
     const activity = this.renderActivity();
     if (activity) parts.push(activity);
-    const body = (this.finalAssistant ?? this.chunks.join('')).trim();
+    const body = this.finalText();
     if (body) parts.push(body);
     if (this.errorLine) parts.push(this.errorLine);
     return parts.join('\n\n').trim();
+  }
+
+  /** The assistant body alone (no activity/error block) — the text a voice
+   *  reply speaks. Empty for a tool-only turn. */
+  finalText(): string {
+    return (this.finalAssistant ?? this.chunks.join('')).trim();
   }
 
   reset(): void {

--- a/packages/plugin-telegram/src/channel.ts
+++ b/packages/plugin-telegram/src/channel.ts
@@ -1,7 +1,7 @@
-import { Bot, GrammyError, HttpError } from 'grammy';
+import { Bot, GrammyError, HttpError, InputFile } from 'grammy';
 import type { Context } from 'grammy';
 import { newTurnId } from '@moxxy/core';
-import { TurnCoordinator, resolveSecret } from '@moxxy/channel-kit';
+import { TurnCoordinator, deliverVoiceReply, resolveSecret } from '@moxxy/channel-kit';
 import type { ClientSession as Session } from '@moxxy/sdk';
 import type {
   ApprovalRequest,
@@ -28,6 +28,7 @@ import {
 import { runUserTurn } from './channel/turn-runner.js';
 import { handleTextMessage } from './channel/text-handler.js';
 import { handleVoiceMessage } from './channel/voice-handler.js';
+import { loadVoiceReplies, saveVoiceReplies } from './keys.js';
 
 const TOKEN_KEY = 'telegram_bot_token';
 
@@ -98,6 +99,10 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
   private model: string | undefined;
   private activeModelOverride: string | null = null;
   private yolo = false;
+  // When true, the final assistant reply of each turn is also synthesized (via
+  // the session's active Synthesizer) and sent as a voice note. Persisted per
+  // paired chat in the vault (`telegram_voice_replies`), toggled with `/voice`.
+  private voiceReplies = false;
   // Single-flight turn state: `busy` guard, per-turn AbortController (so
   // /cancel aborts only the current turn without poisoning the session-level
   // signal other channels share), and the bounded own-turn-id set that
@@ -182,6 +187,7 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
       );
     }
     await this.pairing.loadAuthorized();
+    this.voiceReplies = await loadVoiceReplies(this.opts.vault);
 
     // Open the single host-issued QR pairing window when a pairing surface asked
     // for it (`pair`, the terminal `pair` command) OR when running GUI-supervised
@@ -364,6 +370,7 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
         model: this.model,
         activeModelOverride: this.activeModelOverride,
         yolo: this.yolo,
+        voiceReplies: this.voiceReplies,
         busy: this.turns.busy,
         turnController: this.turns.controller,
         awaitingApprovalText: this.awaitingApprovalText,
@@ -386,10 +393,45 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
         setYolo: (value) => {
           this.yolo = value;
         },
+        setVoiceReplies: (on) => this.setVoiceReplies(on),
         runUserTurn: (c, chatId, text) => this.runUserTurn(c, chatId, text),
         tryHostPair: (chatId, text) => this.tryHostPair(ctx, chatId, text),
       },
     );
+  }
+
+  /** Persist + apply the voice-replies preference (the `/voice` toggle). */
+  private async setVoiceReplies(on: boolean): Promise<void> {
+    this.voiceReplies = on;
+    try {
+      await saveVoiceReplies(this.opts.vault, on);
+    } catch (err) {
+      this.opts.logger?.warn('telegram voice-replies persist failed', { err: String(err) });
+    }
+  }
+
+  /**
+   * Speak the final assistant reply as a voice note, when enabled. Best-effort
+   * and fully isolated (never throws): synthesize via the session's active
+   * Synthesizer, transcode to OGG/Opus (or send plain audio when ffmpeg is
+   * unavailable), and deliver via grammy. The text reply already went out.
+   */
+  private async sendVoiceReply(chatId: number, text: string): Promise<void> {
+    if (!this.voiceReplies || !this.bot || !this.session) return;
+    const bot = this.bot;
+    const outcome = await deliverVoiceReply(this.session, text, {
+      send: async (audio, meta) => {
+        const file = new InputFile(audio, meta.filename);
+        if (meta.isVoiceNote) await bot.api.sendVoice(chatId, file);
+        else await bot.api.sendAudio(chatId, file);
+      },
+    });
+    if (outcome.status === 'failed') {
+      this.opts.logger?.warn('telegram voice reply failed', {
+        reason: outcome.reason,
+        ...(outcome.error ? { err: outcome.error } : {}),
+      });
+    }
   }
 
   /**
@@ -449,6 +491,7 @@ export class TelegramChannel implements Channel<TelegramStartOpts> {
           framePump: this.framePump,
           typing: this.typing,
           ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+          onFinalReply: (finalText) => this.sendVoiceReply(chatId, finalText),
         },
         { chatId, text, model: effectiveModel, controller: lease.controller, turnId: lease.turnId },
       );

--- a/packages/plugin-telegram/src/channel/slash-handler.ts
+++ b/packages/plugin-telegram/src/channel/slash-handler.ts
@@ -1,17 +1,30 @@
 import { type Bot, type Context, InlineKeyboard } from 'grammy';
 import { isSelectableMode } from '@moxxy/sdk';
 import type { ClientSession as Session } from '@moxxy/sdk';
+import { resolveVoiceToggle } from '@moxxy/channel-kit';
+
+/**
+ * Install guidance shown when enabling `/voice` with no active synthesizer —
+ * mirrors the voice-handler's transcriber guidance wording, pointing at the TTS
+ * plugin instead of the STT one.
+ */
+export const VOICE_NO_SYNTH_HINT =
+  'No text-to-speech backend is configured yet, so replies stay text-only. Install one with `moxxy plugins install tts-openai` and run `moxxy login openai` (or set OPENAI_API_KEY) to enable spoken replies.';
 
 export interface SlashState {
   readonly session: Session | null;
   readonly model: string | undefined;
   readonly activeModelOverride: string | null;
   readonly yolo: boolean;
+  /** Whether voice replies are currently enabled (backs `/voice status`). */
+  readonly voiceReplies: boolean;
 }
 
 export interface SlashCallbacks {
   /** Toggle yolo and return its new value (so we can echo the right message). */
   toggleYolo(): boolean;
+  /** Persist + apply the voice-replies preference (backs `/voice on|off`). */
+  setVoiceReplies(on: boolean): Promise<void>;
   /** Apply a `session-action` result emitted from a registered command. */
   performSessionAction(
     ctx: Context,
@@ -84,6 +97,18 @@ export async function runSlash(
           ? '⚠ yolo mode ON — tool calls auto-approved for the rest of this session'
           : 'yolo mode OFF — tool prompts will resume',
       );
+      return;
+    }
+    case '/voice': {
+      const result = resolveVoiceToggle({
+        arg: args,
+        enabled: state.voiceReplies,
+        hasSynthesizer: session.synthesizers.tryGetActive() != null,
+        delivery: 'a voice note',
+        noSynthesizerHint: VOICE_NO_SYNTH_HINT,
+      });
+      if (result.persist) await cb.setVoiceReplies(result.enabled);
+      await ctx.reply(result.reply);
       return;
     }
     case '/tools': {
@@ -208,6 +233,7 @@ export async function publishBotCommands(
     { command: 'model', description: 'Switch provider + model (inline keyboard)' },
     { command: 'mode', description: 'Switch mode' },
     { command: 'yolo', description: 'Toggle auto-approve mode' },
+    { command: 'voice', description: 'Toggle spoken voice replies' },
     { command: 'tools', description: 'List the tools the active session can call' },
     { command: 'skills', description: 'List the discovered skills' },
     { command: 'cancel', description: 'Abort the current turn' },

--- a/packages/plugin-telegram/src/channel/text-handler.ts
+++ b/packages/plugin-telegram/src/channel/text-handler.ts
@@ -13,6 +13,7 @@ export interface TextHandlerState {
   readonly model: string | undefined;
   readonly activeModelOverride: string | null;
   readonly yolo: boolean;
+  readonly voiceReplies: boolean;
   readonly busy: boolean;
   readonly turnController: AbortController | null;
   readonly awaitingApprovalText: AwaitingApprovalText | null;
@@ -30,6 +31,7 @@ export interface TextHandlerCallbacks {
   readonly setAwaitingApprovalText: (state: AwaitingApprovalText | null) => void;
   readonly toggleYolo: () => boolean;
   readonly setYolo: (value: boolean) => void;
+  readonly setVoiceReplies: (on: boolean) => Promise<void>;
   readonly runUserTurn: (ctx: Context, chatId: number, text: string) => Promise<void>;
   /** Host-issued pairing fallback: try to pair an unauthorized chat whose message
    *  is the 6-digit code. Returns true when handled (so we skip the generic
@@ -98,9 +100,11 @@ export async function handleTextMessage(
         model: state.model,
         activeModelOverride: state.activeModelOverride,
         yolo: state.yolo,
+        voiceReplies: state.voiceReplies,
       },
       {
         toggleYolo: cb.toggleYolo,
+        setVoiceReplies: cb.setVoiceReplies,
         performSessionAction: (c, action, notice) =>
           performSessionAction(c, action, notice, state, deps, cb),
       },

--- a/packages/plugin-telegram/src/channel/turn-runner.ts
+++ b/packages/plugin-telegram/src/channel/turn-runner.ts
@@ -15,6 +15,12 @@ export interface TurnRunnerDeps {
   readonly framePump: FramePump;
   readonly typing: TypingIndicator;
   readonly logger?: TurnRunnerLogger;
+  /**
+   * Called once with the FINAL assistant text after it has been flushed to the
+   * chat (so the text reply always lands first). Backs the optional voice
+   * reply. Best-effort — its failure is logged and never breaks the text turn.
+   */
+  readonly onFinalReply?: (text: string) => Promise<void>;
 }
 
 export interface TurnRunnerOptions {
@@ -40,7 +46,7 @@ export async function runUserTurn(
   deps: TurnRunnerDeps,
   opts: TurnRunnerOptions,
 ): Promise<void> {
-  const { session, bot, framePump, typing, logger } = deps;
+  const { session, bot, framePump, typing, logger, onFinalReply } = deps;
   const { chatId, text, model, controller, turnId } = opts;
 
   framePump.beginTurn(chatId);
@@ -64,6 +70,21 @@ export async function runUserTurn(
   try {
     await driveTurn(session, { turnId, prompt: text, model, signal: controller.signal });
     await framePump.flush(true);
+    // The text reply is now out. Speak the final assistant body if a voice
+    // reply is wired — isolated so a synth/transcode/transport failure can
+    // never break (or re-report) the already-delivered text turn.
+    if (onFinalReply) {
+      const finalText = framePump.renderState.snapshot().body;
+      if (finalText.trim()) {
+        try {
+          await onFinalReply(finalText);
+        } catch (err) {
+          logger?.warn('telegram voice reply hook failed', {
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }
   } catch (err) {
     logger?.warn('telegram turn failed', {
       err: err instanceof Error ? err.message : String(err),

--- a/packages/plugin-telegram/src/channel/voice-reply.test.ts
+++ b/packages/plugin-telegram/src/channel/voice-reply.test.ts
@@ -1,0 +1,223 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { VaultStore, createStaticKeySource, deriveKey, generateSalt } from '@moxxy/plugin-vault';
+import { asTurnId, type MoxxyEvent } from '@moxxy/sdk';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import { loadVoiceReplies, saveVoiceReplies, TELEGRAM_VOICE_REPLIES_KEY } from '../keys.js';
+import { runSlash } from './slash-handler.js';
+import { runUserTurn } from './turn-runner.js';
+
+describe('telegram voice-replies vault flag round-trip', () => {
+  let tmp: string;
+  let vault: VaultStore;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-tg-voice-'));
+    vault = new VaultStore({
+      filePath: path.join(tmp, 'vault.json'),
+      keySource: createStaticKeySource(deriveKey('test', generateSalt())),
+    });
+  });
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it('defaults to off, persists on, then off', async () => {
+    expect(await loadVoiceReplies(vault)).toBe(false);
+    await saveVoiceReplies(vault, true);
+    expect(await vault.get(TELEGRAM_VOICE_REPLIES_KEY)).toBe('1');
+    expect(await loadVoiceReplies(vault)).toBe(true);
+    await saveVoiceReplies(vault, false);
+    expect(await vault.get(TELEGRAM_VOICE_REPLIES_KEY)).toBe(null);
+    expect(await loadVoiceReplies(vault)).toBe(false);
+  });
+});
+
+/** Minimal session: `/voice` only touches `commands.get` (miss → channel-local)
+ *  and `synthesizers.tryGetActive`. */
+function slashSession(opts: { synth?: unknown } = {}): Session {
+  return {
+    id: 'sess',
+    commands: { get: () => undefined },
+    synthesizers: { tryGetActive: () => opts.synth ?? null },
+  } as unknown as Session;
+}
+
+function slashCtx(): { ctx: any; replies: string[] } {
+  const replies: string[] = [];
+  return { replies, ctx: { reply: async (t: string) => void replies.push(t) } };
+}
+
+describe('/voice slash command', () => {
+  const cbBase = {
+    toggleYolo: () => false,
+    performSessionAction: async () => undefined,
+  };
+
+  it('enables + persists when a synthesizer is active', async () => {
+    const { ctx, replies } = slashCtx();
+    const persisted: boolean[] = [];
+    await runSlash(
+      ctx,
+      '/voice on',
+      { session: slashSession({ synth: { name: 'fake' } }), model: undefined, activeModelOverride: null, yolo: false, voiceReplies: false },
+      { ...cbBase, setVoiceReplies: async (on: boolean) => void persisted.push(on) },
+    );
+    expect(persisted).toEqual([true]);
+    expect(replies[0]).toContain('ON');
+    expect(replies[0]).not.toContain('tts-openai');
+  });
+
+  it('still enables but shows install guidance when no synthesizer is active', async () => {
+    const { ctx, replies } = slashCtx();
+    const persisted: boolean[] = [];
+    await runSlash(
+      ctx,
+      '/voice on',
+      { session: slashSession(), model: undefined, activeModelOverride: null, yolo: false, voiceReplies: false },
+      { ...cbBase, setVoiceReplies: async (on: boolean) => void persisted.push(on) },
+    );
+    expect(persisted).toEqual([true]);
+    expect(replies[0]).toContain('moxxy plugins install tts-openai');
+  });
+
+  it('toggles off and reports status without persisting', async () => {
+    const persisted: boolean[] = [];
+    const setVoiceReplies = async (on: boolean): Promise<void> => void persisted.push(on);
+
+    const off = slashCtx();
+    await runSlash(
+      off.ctx,
+      '/voice',
+      { session: slashSession(), model: undefined, activeModelOverride: null, yolo: false, voiceReplies: true },
+      { ...cbBase, setVoiceReplies },
+    );
+    expect(persisted).toEqual([false]);
+    expect(off.replies[0]).toContain('OFF');
+
+    const status = slashCtx();
+    await runSlash(
+      status.ctx,
+      '/voice status',
+      { session: slashSession(), model: undefined, activeModelOverride: null, yolo: false, voiceReplies: true },
+      { ...cbBase, setVoiceReplies },
+    );
+    // status did NOT persist anything new.
+    expect(persisted).toEqual([false]);
+    expect(status.replies[0]).toContain('ON');
+  });
+});
+
+/**
+ * Fake session whose `runTurn` fans scripted events (stamped with the turnId)
+ * through the log subscribers, mirroring the real Session. Matches the pattern
+ * in the Discord turn-runner test.
+ */
+function turnSession(
+  script: (emit: (e: Record<string, unknown>) => void) => void,
+): Session {
+  const listeners = new Set<(e: MoxxyEvent) => void>();
+  return {
+    log: {
+      subscribe(fn: (e: MoxxyEvent) => void) {
+        listeners.add(fn);
+        return () => listeners.delete(fn);
+      },
+    },
+    runTurn: (_p: string, opts: { turnId: string }) =>
+      (async function* () {
+        const emit = (e: Record<string, unknown>): void => {
+          const ev = { ...e, turnId: opts.turnId } as unknown as MoxxyEvent;
+          for (const fn of listeners) fn(ev);
+        };
+        script(emit);
+        yield undefined as never;
+      })(),
+  } as unknown as Session;
+}
+
+/** A frame-pump stand-in that captures the final assistant text the same way the
+ *  real renderer does (assistant_message overwrites the body). */
+function fakeFramePump(): { framePump: any; flushedFinal: boolean[] } {
+  let body = '';
+  const flushedFinal: boolean[] = [];
+  const framePump = {
+    beginTurn: () => {},
+    endTurn: () => {},
+    scheduleEdit: () => {},
+    flush: async (final: boolean) => void flushedFinal.push(final),
+    renderState: {
+      accept: (e: MoxxyEvent) => {
+        if (e.type === 'assistant_message') body = (e as { content: string }).content;
+        return { hasUpdate: true };
+      },
+      snapshot: () => ({ body }),
+    },
+  };
+  return { framePump, flushedFinal };
+}
+
+const typingNoop = { start: () => {}, stop: () => {} } as any;
+
+describe('turn-runner onFinalReply seam (final assistant text)', () => {
+  it('calls onFinalReply with the final assistant body AFTER flushing the text', async () => {
+    const { framePump, flushedFinal } = fakeFramePump();
+    const seen: string[] = [];
+    const session = turnSession((emit) => {
+      emit({ type: 'assistant_chunk', delta: 'Hel' });
+      emit({ type: 'assistant_message', content: 'Hello there.' });
+    });
+    await runUserTurn(
+      { reply: async () => {} } as any,
+      {
+        session,
+        bot: null,
+        framePump,
+        typing: typingNoop,
+        onFinalReply: async (t) => void seen.push(t),
+      },
+      { chatId: 1, text: 'hi', model: undefined, controller: new AbortController(), turnId: asTurnId('t1') },
+    );
+    expect(flushedFinal).toContain(true);
+    expect(seen).toEqual(['Hello there.']);
+  });
+
+  it('does not speak a tool-only turn (empty assistant body)', async () => {
+    const { framePump } = fakeFramePump();
+    const seen: string[] = [];
+    const session = turnSession((emit) => {
+      emit({ type: 'tool_call_requested', callId: 'c1', name: 'read', input: {} });
+    });
+    await runUserTurn(
+      { reply: async () => {} } as any,
+      { session, bot: null, framePump, typing: typingNoop, onFinalReply: async (t) => void seen.push(t) },
+      { chatId: 1, text: 'hi', model: undefined, controller: new AbortController(), turnId: asTurnId('t2') },
+    );
+    expect(seen).toEqual([]);
+  });
+
+  it('never breaks the (already-sent) text turn when the voice hook rejects', async () => {
+    const { framePump } = fakeFramePump();
+    const replies: string[] = [];
+    const session = turnSession((emit) => emit({ type: 'assistant_message', content: 'Done.' }));
+    await expect(
+      runUserTurn(
+        { reply: async (t: string) => void replies.push(t) } as any,
+        {
+          session,
+          bot: null,
+          framePump,
+          typing: typingNoop,
+          onFinalReply: async () => {
+            throw new Error('tts exploded');
+          },
+        },
+        { chatId: 1, text: 'hi', model: undefined, controller: new AbortController(), turnId: asTurnId('t3') },
+      ),
+    ).resolves.toBeUndefined();
+    // No "Turn failed" reply — the hook failure was swallowed.
+    expect(replies.join(' ')).not.toContain('Turn failed');
+  });
+});

--- a/packages/plugin-telegram/src/keys.ts
+++ b/packages/plugin-telegram/src/keys.ts
@@ -8,8 +8,35 @@
 export const TELEGRAM_TOKEN_KEY = 'telegram_bot_token';
 /** Vault key the plugin uses for the paired chat id. */
 export const TELEGRAM_AUTHORIZED_CHAT_KEY = 'telegram_authorized_chat_id';
+/**
+ * Vault key for the voice-replies preference. Single-paired-chat model, so a
+ * simple present-flag (`'1'` = on, absent = off) keyed like the other telegram
+ * keys, toggled from the paired chat via `/voice`.
+ */
+export const TELEGRAM_VOICE_REPLIES_KEY = 'telegram_voice_replies';
 /** Regex validating a Telegram bot token (`<digits>:<22+ url-safe>`). */
 export const TELEGRAM_TOKEN_RE = /^\d+:[A-Za-z0-9_-]{20,}$/;
+
+/** The narrow vault slice the voice-replies flag helpers use. */
+interface VoiceFlagVault {
+  get(name: string): Promise<string | null>;
+  set(name: string, value: string): Promise<void>;
+  delete(name: string): Promise<boolean>;
+}
+
+/** Read the persisted voice-replies preference (`'1'` → on). */
+export async function loadVoiceReplies(vault: Pick<VoiceFlagVault, 'get'>): Promise<boolean> {
+  return (await vault.get(TELEGRAM_VOICE_REPLIES_KEY)) === '1';
+}
+
+/** Persist the voice-replies preference: store `'1'` when on, remove it when off. */
+export async function saveVoiceReplies(
+  vault: Pick<VoiceFlagVault, 'set' | 'delete'>,
+  on: boolean,
+): Promise<void> {
+  if (on) await vault.set(TELEGRAM_VOICE_REPLIES_KEY, '1');
+  else await vault.delete(TELEGRAM_VOICE_REPLIES_KEY);
+}
 
 /**
  * Parse a stored chat-id (the vault keeps it as a string). Returns `null` for a


### PR DESCRIPTION
Voice replies for the **Telegram** and **Discord** channels: when enabled, the channel synthesizes the *final* assistant reply through the session's active `Synthesizer` and sends it as a voice/audio message alongside the text.

Built independently against the SDK Synthesizer contract only (`session.synthesizers.tryGetActive()` → `synthesize(text, opts)` → `{ audio, mimeType }`); a sibling branch ships the first real synthesizer. All tests use a fake Synthesizer.

## `/voice` semantics (per channel)

| command | effect |
| --- | --- |
| `/voice` | toggle on/off |
| `/voice on` / `/voice off` | set explicitly |
| `/voice status` | report current state (never persists) |

- **Telegram:** channel-local command in the slash-handler; added to the `/` bot-command menu. Preference persisted per paired chat in the vault key `telegram_voice_replies` (`'1'`/absent). Sends the reply as a native **voice note** (`sendVoice`), or `sendAudio` when the audio can't be made OGG/Opus.
- **Discord:** real `/voice` application command (+ plain-text `/voice`), published in the `/` picker. Preference persisted in `discord_voice_replies`. Sends the reply as an **audio attachment** (`AttachmentBuilder`). The Discord app-command path passes no args, so `/voice` there toggles; `on|off|status` are available via a typed `/voice …` message.
- Enabling with **no active synthesizer** still turns the preference on but replies with install guidance (mirrors the inbound voice-handler wording, pointing at `moxxy plugins install tts-openai`).

## ffmpeg fallback matrix (`ensureOggOpus`)

| synth output | ffmpeg | delivery |
| --- | --- | --- |
| already OGG/Opus | — | native voice note (Telegram) / `reply.ogg` (Discord) |
| e.g. `audio/mpeg` | present | transcoded `-f ogg -c:a libopus -b:a 32k -ac 1` → voice note / `reply.ogg` |
| e.g. `audio/mpeg` | **absent** | original bytes as plain audio (`sendAudio` / `reply.mp3`) — never a broken voice note |

The ffmpeg presence probe mirrors `checkVoiceCaptureAvailable` and is cached per process.

## Never-break-text guarantee

The text reply is flushed **first**; the voice reply runs from an isolated `onFinalReply` seam after that. `synthesizeReply`, `ensureOggOpus`, and `deliverVoiceReply` never throw — every failure (no synthesizer, TTS error, transcode failure, transport error) is a typed result and is only logged. The seam is also wrapped in try/catch, so a voice failure can never break or re-report the already-sent text answer.

## Architecture

Transport-agnostic pieces live in `@moxxy/channel-kit` (`voice-reply.ts`): `toSpeech` (markdown→speech: code fences → "(code omitted)", links → label), `synthesizeReply`, `ensureOggOpus`, `deliverVoiceReply` (behind a `VoiceReplySink` transport boundary), `audioExtForMime`, and the shared `resolveVoiceToggle`. Messenger quirks (grammy `InputFile`/`sendVoice`, discord.js `AttachmentBuilder`) stay in each plugin.

**Seam hooked for "final assistant text":**
- Telegram — `runUserTurn` (turn-runner) after `framePump.flush(true)`, reading `framePump.renderState.snapshot().body` (the accumulated `assistant_message` content, raw markdown).
- Discord — `runDiscordTurn` after `pump.flush(true)`, reading a new `DiscordTurnRenderer.finalText()`.

## Deferred

- Discord true voice-message bubble (`MessageFlags.IsVoiceMessage` + waveform) — v1 sends a plain audio attachment.
- Other channels (Slack/WhatsApp/Signal).

## Manual verify (needs a live bot + a real synthesizer)

- [ ] Telegram: pair, `/voice on`, run a turn → text + a playable voice note; `/voice off` → text only.
- [ ] Telegram: `/voice on` with no TTS installed → install-guidance reply; text unaffected.
- [ ] Discord: `/voice` in a DM/allow-listed channel, run a turn → text + audio attachment.
- [ ] Force a non-opus synth mime with ffmpeg absent → plain audio still delivered.

## Gate

`build` ✓ · `typecheck` ✓ · `lint` ✓ (0 errors) · `check:deps` ✓ (0 errors) · `test` ✓ (full suite) · `test:scripts` ✓. New unit tests: channel-kit voice-reply (fake synth + injectable spawn: passthrough / transcode / no-ffmpeg / code-block stripping / toggle), plus per-channel toggle round-trip (vault flag) and the turn-completion `onFinalReply` seam.
