### PR TITLE
feat(reflector): swappable reflector category + @moxxy/reflector-default learning loop

### DIFF
--- a/.changeset/reflector-category.md
+++ b/.changeset/reflector-category.md
@@ -1,0 +1,15 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/core': minor
+'@moxxy/config': minor
+'@moxxy/cli': minor
+'@moxxy/reflector-default': minor
+'@moxxy/plugin-plugins-admin': patch
+'@moxxy/plugin-cli': patch
+---
+
+feat(reflector): swappable `reflector` registry category + `@moxxy/reflector-default` learning loop.
+
+A new single-active registry category — the learning-loop block that watches a finished turn and *proposes* memory/skill improvements without ever writing silently. Mirrors the `eventStore` category across all 7 layers (config `plugins.reflector.default`, SDK `ReflectorDef`/`ReflectContext`/`ReflectionProposal` contract + plugin slot, core `ReflectorRegistry`, host registry-kind wiring, session field + `services('reflectors')`, CLI apply/category-swap, catalog), but NULLABLE: core seeds no floor, so reflection is opt-in (like transcriber/synthesizer).
+
+`@moxxy/reflector-default` (discovery-loaded) ships the default `ReflectorDef` `'default'` AND the driver in one plugin. The driver's `onTurnEnd` runs a cheap gate (≥5 tool results OR ≥1 error OR ≥8 mode iterations) under a one-reflection-per-session budget, then fires the reflection FIRE-AND-FORGET so it never blocks or throws into the turn. The reflector does one cheap side-channel LLM pass over a turn digest and returns 0-2 proposals; those are delivered as a ONE-TIME nudge on the next `onBeforeProviderCall`, phrased so the model MAY call `memory_save` / `synthesize_skill` — which still hit their own permission prompts. No silent writes. Graceful no-provider / provider-error skips; `memory_save` and `synthesize_skill` are declared as optional requirements. User-model injection of proposals is deferred to a follow-up PR.

--- a/packages/cli/src/setup/apply-plugins-tree.test.ts
+++ b/packages/cli/src/setup/apply-plugins-tree.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { Session, autoAllowResolver, silentLogger } from '@moxxy/core';
+import type { MoxxyConfig } from '@moxxy/config';
+import type { ReflectorDef } from '@moxxy/sdk';
+import { applyPluginsTree } from './apply-plugins-tree.js';
+
+function makeSession(): Session {
+  return new Session({ cwd: '/tmp', logger: silentLogger, permissionResolver: autoAllowResolver });
+}
+
+const def = (name: string): ReflectorDef => ({ name, reflect: async () => [] });
+
+function warnCollector(): { logger: { warn: (m: string, meta?: unknown) => void }; warns: string[] } {
+  const warns: string[] = [];
+  return { logger: { warn: (m: string) => void warns.push(m) }, warns };
+}
+
+describe('applyPluginsTree — reflector (nullable active-def kind)', () => {
+  it('leaves reflection off when no default is configured and none registered', () => {
+    const session = makeSession();
+    const { logger, warns } = warnCollector();
+    applyPluginsTree(session, {} as MoxxyConfig, logger);
+    expect(session.reflectors.getActiveName()).toBeNull();
+    expect(warns).toEqual([]);
+  });
+
+  it('activates an explicit reflector default that is registered', () => {
+    const session = makeSession();
+    session.reflectors.register(def('default'));
+    session.reflectors.register(def('smart'));
+    const { logger } = warnCollector();
+    const config = { plugins: { reflector: { default: 'smart' } } } as unknown as MoxxyConfig;
+    applyPluginsTree(session, config, logger);
+    expect(session.reflectors.getActiveName()).toBe('smart');
+  });
+
+  it('warns-and-skips an explicit reflector default that is not registered', () => {
+    const session = makeSession();
+    const { logger, warns } = warnCollector();
+    const config = { plugins: { reflector: { default: 'ghost' } } } as unknown as MoxxyConfig;
+    applyPluginsTree(session, config, logger);
+    // No floor to fall back to — stays null rather than throwing at boot.
+    expect(session.reflectors.getActiveName()).toBeNull();
+    expect(warns.some((w) => w.includes('reflector') && w.includes('ghost'))).toBe(true);
+  });
+});

--- a/packages/cli/src/setup/apply-plugins-tree.ts
+++ b/packages/cli/src/setup/apply-plugins-tree.ts
@@ -95,6 +95,11 @@ const ACTIVE_DEF_KINDS: ReadonlyArray<KindBinding> = [
   { key: 'viewRenderer', registry: (s) => s.viewRenderers },
   { key: 'tunnelProvider', registry: (s) => s.tunnelProviders },
   { key: 'eventStore', registry: (s) => s.eventStores },
+  // Reflector is a nullable pure-def kind: there is no built-in default, so an
+  // unset slot is a silent skip (the registry auto-adopts the first registered
+  // reflector). An explicit `plugins.reflector.default` that names an
+  // uninstalled reflector warns-and-skips rather than throwing at boot.
+  { key: 'reflector', registry: (s) => s.reflectors },
 ];
 
 /**

--- a/packages/cli/src/setup/builtin-requirements.generated.ts
+++ b/packages/cli/src/setup/builtin-requirements.generated.ts
@@ -76,6 +76,22 @@ export const BUILTIN_REQUIREMENTS: Readonly<
       "name": "@moxxy/plugin-vault",
       "hint": "telegram resolves the vault from the service registry for its bot token + pairing; @moxxy/plugin-vault must load first"
     }
+  ],
+  "@moxxy/reflector-default": [
+    {
+      "kind": "tool",
+      "name": "memory_save",
+      "state": "active",
+      "optional": true,
+      "hint": "Install @moxxy/plugin-memory so the model can act on memory proposals."
+    },
+    {
+      "kind": "tool",
+      "name": "synthesize_skill",
+      "state": "active",
+      "optional": true,
+      "hint": "synthesize_skill (bundled with the CLI) lets the model act on skill proposals."
+    }
   ]
 } as const satisfies Readonly<
   Record<string, ReadonlyArray<MoxxyRequirement>>

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -150,6 +150,7 @@ const CATEGORY_REGISTRIES: ReadonlyArray<{
   { category: 'viewRenderer', reg: (s) => s.viewRenderers },
   { category: 'tunnelProvider', reg: (s) => s.tunnelProviders },
   { category: 'eventStore', reg: (s) => s.eventStores },
+  { category: 'reflector', reg: (s) => s.reflectors },
 ];
 
 function buildCategoryViews(session: Session): ReadonlyArray<CategoryView> {

--- a/packages/config/src/plugins-tree-schema.test.ts
+++ b/packages/config/src/plugins-tree-schema.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { PLUGIN_CATEGORY_KEYS, pluginsTreeSchema } from './plugins-tree-schema.js';
+
+describe('plugins-tree schema — reflector category', () => {
+  it('lists reflector as an active-def category key', () => {
+    expect(PLUGIN_CATEGORY_KEYS).toContain('reflector');
+  });
+
+  it('round-trips plugins.reflector.default', () => {
+    const tree = { reflector: { default: 'default' } };
+    const parsed = pluginsTreeSchema.parse(tree);
+    expect(parsed.reflector?.default).toBe('default');
+  });
+
+  it('accepts a per-item option bag on the reflector slot', () => {
+    const parsed = pluginsTreeSchema.parse({
+      reflector: { default: 'default', items: { default: { window: 'session' } } },
+    });
+    expect(parsed.reflector?.items?.default).toEqual({ window: 'session' });
+  });
+
+  it('rejects an unknown key inside the reflector slot (.strict())', () => {
+    expect(() => pluginsTreeSchema.parse({ reflector: { nope: true } })).toThrow();
+  });
+});

--- a/packages/config/src/plugins-tree-schema.ts
+++ b/packages/config/src/plugins-tree-schema.ts
@@ -77,6 +77,7 @@ export const pluginsTreeSchema = z
     viewRenderer: categorySlotSchema.optional(),
     tunnelProvider: categorySlotSchema.optional(),
     eventStore: categorySlotSchema.optional(),
+    reflector: categorySlotSchema.optional(),
     channel: categorySlotSchema.optional(),
   })
   .strict();
@@ -96,6 +97,7 @@ export const PLUGIN_CATEGORY_KEYS = [
   'viewRenderer',
   'tunnelProvider',
   'eventStore',
+  'reflector',
   'channel',
 ] as const;
 export type PluginCategoryKey = (typeof PLUGIN_CATEGORY_KEYS)[number];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,7 @@ export { SynthesizerRegistry } from './registries/synthesizers.js';
 export { EmbedderRegistry } from './registries/embedders.js';
 export { IsolatorRegistry as ContributedIsolatorRegistry } from './registries/isolators.js';
 export { EventStoreRegistry } from './registries/event-stores.js';
+export { ReflectorRegistry } from './registries/reflectors.js';
 export { jsonlEventStore } from './sessions/jsonl-event-store.js';
 export type {
   EventStoreDef,

--- a/packages/core/src/plugins/host-options.ts
+++ b/packages/core/src/plugins/host-options.ts
@@ -25,6 +25,7 @@ import type { EmbedderRegistry } from '../registries/embedders.js';
 import type { IsolatorRegistry } from '../registries/isolators.js';
 import type { WorkflowExecutorRegistry } from '../registries/workflow-executors.js';
 import type { EventStoreRegistry } from '../registries/event-stores.js';
+import type { ReflectorRegistry } from '../registries/reflectors.js';
 import type { HookDispatcherImpl } from './lifecycle.js';
 import type { RequirementRegistry } from '../requirements.js';
 
@@ -48,6 +49,7 @@ export interface PluginHostOptions {
   readonly isolators: IsolatorRegistry;
   readonly workflowExecutors: WorkflowExecutorRegistry;
   readonly eventStores: EventStoreRegistry;
+  readonly reflectors: ReflectorRegistry;
   readonly requirements: RequirementRegistry;
   readonly dispatcher: HookDispatcherImpl;
   readonly loader?: PluginLoader;

--- a/packages/core/src/plugins/registry-kinds.test.ts
+++ b/packages/core/src/plugins/registry-kinds.test.ts
@@ -37,6 +37,7 @@ import { EmbedderRegistry } from '../registries/embedders.js';
 import { IsolatorRegistry } from '../registries/isolators.js';
 import { WorkflowExecutorRegistry } from '../registries/workflow-executors.js';
 import { EventStoreRegistry } from '../registries/event-stores.js';
+import { ReflectorRegistry } from '../registries/reflectors.js';
 import { RequirementRegistry } from '../requirements.js';
 import { HookDispatcherImpl } from './lifecycle.js';
 import { PluginHost } from './host.js';
@@ -87,6 +88,7 @@ const everyKindPlugin = definePlugin({
       readPage: async () => ({ events: [], prevCursor: null }),
     },
   ],
+  reflectors: [{ name: 'refl-1', reflect: async () => [] }],
 });
 
 function makeHost() {
@@ -108,6 +110,7 @@ function makeHost() {
     isolators: new IsolatorRegistry(),
     workflowExecutors: new WorkflowExecutorRegistry(),
     eventStores: new EventStoreRegistry(),
+    reflectors: new ReflectorRegistry(),
   };
   const requirements = new RequirementRegistry({
     tools: registries.tools,
@@ -147,6 +150,7 @@ function makeHost() {
     isolator: registries.isolators,
     workflowExecutor: registries.workflowExecutors,
     eventStore: registries.eventStores,
+    reflector: registries.reflectors,
   };
   return { host, byKind };
 }

--- a/packages/core/src/plugins/registry-kinds.ts
+++ b/packages/core/src/plugins/registry-kinds.ts
@@ -17,6 +17,7 @@ import type {
   TunnelProviderDef,
   WorkflowExecutorDef,
   EventStoreDef,
+  ReflectorDef,
 } from '@moxxy/sdk';
 import type { PluginHostOptions } from './host-options.js';
 
@@ -44,6 +45,7 @@ export interface RegistryNameRecord {
   readonly isolatorNames: ReadonlyArray<string>;
   readonly workflowExecutorNames: ReadonlyArray<string>;
   readonly eventStoreNames: ReadonlyArray<string>;
+  readonly reflectorNames: ReadonlyArray<string>;
 }
 
 /**
@@ -243,4 +245,15 @@ export const REGISTRY_KINDS: ReadonlyArray<RegistryKind<unknown>> = [
     register: (o, e: EventStoreDef) => o.eventStores.register(e),
     unregister: (o, n) => o.eventStores.unregister(n),
   } satisfies RegistryKind<EventStoreDef>,
+  {
+    kind: 'reflector',
+    recordField: 'reflectorNames',
+    defs: (p) => p.reflectors ?? [],
+    nameOf: (r: ReflectorDef) => r.name,
+    // Throw-on-duplicate `register` (NOT `replace`): a discovered reflector is
+    // added but auto-adopts only when nothing is active yet (the registry is
+    // nullable — no core floor). The user swaps via `plugins.reflector.default`.
+    register: (o, r: ReflectorDef) => o.reflectors.register(r),
+    unregister: (o, n) => o.reflectors.unregister(n),
+  } satisfies RegistryKind<ReflectorDef>,
 ] as ReadonlyArray<RegistryKind<unknown>>;

--- a/packages/core/src/registries/reflectors.test.ts
+++ b/packages/core/src/registries/reflectors.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { ReflectorDef } from '@moxxy/sdk';
+import { Session, autoAllowResolver, silentLogger } from '../index.js';
+
+function makeSession(): Session {
+  return new Session({ cwd: '/tmp', logger: silentLogger, permissionResolver: autoAllowResolver });
+}
+
+const def = (name: string): ReflectorDef => ({ name, reflect: async () => [] });
+
+describe('Reflector registry (nullable, no floor)', () => {
+  it('starts empty — no core-seeded floor, reflection is off by default', () => {
+    const session = makeSession();
+    expect(session.reflectors.getActiveName()).toBeNull();
+    expect(session.reflectors.getFloorName()).toBeNull();
+    expect(session.reflectors.list()).toEqual([]);
+    expect(session.reflectors.getActive()).toBeNull();
+  });
+
+  it('publishes the registry on the service registry for the driver to resolve', () => {
+    const session = makeSession();
+    expect(session.services.get('reflectors')).toBe(session.reflectors);
+  });
+
+  it('auto-adopts the first registered reflector as active', () => {
+    const session = makeSession();
+    session.reflectors.register(def('default'));
+    expect(session.reflectors.getActiveName()).toBe('default');
+    expect(session.reflectors.getActive()?.name).toBe('default');
+  });
+
+  it('throws on a duplicate name and swaps via setActive', () => {
+    const session = makeSession();
+    session.reflectors.register(def('default'));
+    expect(() => session.reflectors.register(def('default'))).toThrow(/already registered/);
+    session.reflectors.register(def('smart'));
+    // Second registration does NOT steal active from the first.
+    expect(session.reflectors.getActiveName()).toBe('default');
+    session.reflectors.setActive('smart');
+    expect(session.reflectors.getActiveName()).toBe('smart');
+  });
+
+  it('reverts to null (no floor) when the active reflector is unregistered', () => {
+    const session = makeSession();
+    session.reflectors.register(def('default'));
+    session.reflectors.unregister('default');
+    expect(session.reflectors.getActiveName()).toBeNull();
+    expect(session.reflectors.getActive()).toBeNull();
+  });
+});

--- a/packages/core/src/registries/reflectors.ts
+++ b/packages/core/src/registries/reflectors.ts
@@ -1,0 +1,17 @@
+import type { ReflectorDef } from '@moxxy/sdk';
+import { ActiveDefRegistry } from './active-def-registry.js';
+
+/**
+ * The single-active Reflector registry (the learning-loop block that watches a
+ * finished turn and proposes memory/skill improvements). NULLABLE by design:
+ * unlike the event-store/compactor registries there is NO core-seeded protected
+ * floor, so `getActive()` returns null until a plugin registers one — reflection
+ * is opt-in exactly like transcriber/synthesizer. `autoAdoptFirst` (the default)
+ * means the first registered reflector becomes active, and `unregister` reverts
+ * to null (no floor to fall back to). Uses throw-on-duplicate `register`.
+ */
+export class ReflectorRegistry extends ActiveDefRegistry<ReflectorDef> {
+  constructor() {
+    super({ noun: 'Reflector', autoAdoptFirst: true });
+  }
+}

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -35,6 +35,7 @@ import { EmbedderRegistry } from './registries/embedders.js';
 import { IsolatorRegistry } from './registries/isolators.js';
 import { WorkflowExecutorRegistry } from './registries/workflow-executors.js';
 import { EventStoreRegistry } from './registries/event-stores.js';
+import { ReflectorRegistry } from './registries/reflectors.js';
 import { ServiceRegistryImpl } from './registries/services.js';
 import { jsonlEventStore } from './sessions/jsonl-event-store.js';
 import { RequirementRegistry } from './requirements.js';
@@ -137,6 +138,12 @@ export class Session implements ClientSession, SessionRuntime {
   readonly isolators: IsolatorRegistry;
   readonly workflowExecutors: WorkflowExecutorRegistry;
   readonly eventStores: EventStoreRegistry;
+  /**
+   * The learning-loop block: watches finished turns and proposes memory/skill
+   * improvements. NULLABLE — no core-seeded floor, so it stays empty until a
+   * reflector plugin (e.g. @moxxy/reflector-default) registers one.
+   */
+  readonly reflectors: ReflectorRegistry;
   /** Inter-plugin service registry — plugins publish/consume services in onInit. */
   readonly services: ServiceRegistryImpl;
   readonly requirements: RequirementRegistry;
@@ -274,6 +281,12 @@ export class Session implements ClientSession, SessionRuntime {
     // Seed the built-in JSONL store as the protected floor — the storage backend
     // behind the event log always exists and can be swapped but never removed.
     this.eventStores.register(jsonlEventStore, { protected: true });
+    // Reflectors are nullable — no core floor is seeded, so reflection stays off
+    // until a reflector plugin registers one. Published on the service registry
+    // so a discovery-loaded driver (the reflector plugin's own hooks) can resolve
+    // the active reflector in onTurnEnd without importing @moxxy/core.
+    this.reflectors = new ReflectorRegistry();
+    this.services.register('reflectors', this.reflectors);
     this.requirements = new RequirementRegistry({
       tools: this.tools,
       providers: this.providers,
@@ -321,6 +334,7 @@ export class Session implements ClientSession, SessionRuntime {
       isolators: this.isolators,
       workflowExecutors: this.workflowExecutors,
       eventStores: this.eventStores,
+      reflectors: this.reflectors,
       requirements: this.requirements,
       dispatcher: this.dispatcher,
       loader: opts.pluginLoader,

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -479,6 +479,7 @@ const CATEGORY_LABELS: Record<string, string> = {
   tunnelProvider: 'Tunnels',
   isolator: 'Isolators',
   eventStore: 'Storage',
+  reflector: 'Learning loop',
   channel: 'Channels',
 };
 

--- a/packages/plugin-plugins-admin/src/catalog.ts
+++ b/packages/plugin-plugins-admin/src/catalog.ts
@@ -214,6 +214,15 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     installSpec: '@moxxy/plugin-memory',
   },
   {
+    id: 'reflector',
+    label: 'Learning loop',
+    description:
+      'Watches finished turns and proposes memory/skill improvements as a one-time nudge (never a silent write) — the model may act via memory_save/synthesize_skill.',
+    packageName: '@moxxy/reflector-default',
+    installSpec: '@moxxy/reflector-default',
+    provides: [{ category: 'reflector', name: 'default' }],
+  },
+  {
     id: 'telegram',
     label: 'Telegram channel',
     description: 'Chat with moxxy from Telegram (moxxy telegram; QR pairing).',

--- a/packages/reflector-default/package.json
+++ b/packages/reflector-default/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@moxxy/reflector-default",
+  "version": "0.26.0",
+  "description": "The default learning-loop reflector: watches finished turns and proposes memory/skill improvements as a one-time nudge on the next provider call — never a silent write. The model may act via memory_save/synthesize_skill, which still hit their own permission prompts.",
+  "keywords": [
+    "moxxy",
+    "agent",
+    "reflector",
+    "learning-loop",
+    "memory"
+  ],
+  "homepage": "https://moxxy.ai",
+  "bugs": {
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
+    "directory": "packages/reflector-default"
+  },
+  "author": "Michal Makowski <michal.makowski97@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "moxxy": {
+    "plugin": {
+      "entry": "./dist/index.js",
+      "kind": "reflector"
+    },
+    "requirements": [
+      {
+        "kind": "tool",
+        "name": "memory_save",
+        "state": "active",
+        "optional": true,
+        "hint": "Install @moxxy/plugin-memory so the model can act on memory proposals."
+      },
+      {
+        "kind": "tool",
+        "name": "synthesize_skill",
+        "state": "active",
+        "optional": true,
+        "hint": "synthesize_skill (bundled with the CLI) lets the model act on skill proposals."
+      }
+    ]
+  },
+  "dependencies": {
+    "@moxxy/sdk": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@moxxy/core": "workspace:*",
+    "@moxxy/testing": "workspace:*",
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/reflector-default/src/index.test.ts
+++ b/packages/reflector-default/src/index.test.ts
@@ -1,0 +1,461 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  asEventId,
+  asSessionId,
+  asToolCallId,
+  asTurnId,
+  type EventLogReader,
+  type LLMProvider,
+  type MoxxyEvent,
+  type ProviderEvent,
+  type ProviderRequest,
+  type ReflectContext,
+  type ReflectionProposal,
+  type ReflectorDef,
+  type ServiceRegistry,
+  type TurnContext,
+} from '@moxxy/sdk';
+import { FakeProvider, createFakeSession, textReply } from '@moxxy/testing';
+import type { Session } from '@moxxy/core';
+import {
+  REFLECT_MIN_ITERATIONS,
+  REFLECT_MIN_TOOL_RESULTS,
+  buildReflectorPlugin,
+  buildTurnDigest,
+  parseReflectionReply,
+  reflectorDefaultDef,
+  shouldReflect,
+} from './index.js';
+
+// ── event + context fakes ───────────────────────────────────────────────────
+
+const sid = asSessionId('s1');
+const tid = asTurnId('t1');
+
+function makeEvents(): {
+  userPrompt: (text: string) => MoxxyEvent;
+  toolCall: (name: string) => MoxxyEvent;
+  toolResult: (ok: boolean, errMsg?: string) => MoxxyEvent;
+  errorEv: (message: string) => MoxxyEvent;
+  modeIter: (iteration: number) => MoxxyEvent;
+  assistantMsg: (content: string) => MoxxyEvent;
+} {
+  let seq = 0;
+  const base = (): { id: ReturnType<typeof asEventId>; seq: number; ts: number; sessionId: typeof sid; turnId: typeof tid; source: 'system' } => ({
+    id: asEventId(`e${seq}`),
+    seq: seq++,
+    ts: seq,
+    sessionId: sid,
+    turnId: tid,
+    source: 'system',
+  });
+  return {
+    userPrompt: (text) => ({ ...base(), type: 'user_prompt', text }) as MoxxyEvent,
+    toolCall: (name) => ({ ...base(), type: 'tool_call_requested', callId: asToolCallId(`c${name}`), name, input: {} }) as MoxxyEvent,
+    toolResult: (ok, errMsg) =>
+      ({
+        ...base(),
+        type: 'tool_result',
+        callId: asToolCallId('c'),
+        ok,
+        ...(errMsg ? { error: { message: errMsg, kind: 'threw' } } : {}),
+      }) as MoxxyEvent,
+    errorEv: (message) => ({ ...base(), type: 'error', kind: 'fatal', message }) as MoxxyEvent,
+    modeIter: (iteration) => ({ ...base(), type: 'mode_iteration', strategy: 'default', iteration }) as MoxxyEvent,
+    assistantMsg: (content) => ({ ...base(), type: 'assistant_message', content, stopReason: 'end_turn' }) as MoxxyEvent,
+  };
+}
+
+/** A busy turn that trips the gate (5 tool results) + a prompt + assistant text. */
+function busyTurn(): MoxxyEvent[] {
+  const e = makeEvents();
+  return [
+    e.userPrompt('deploy the service'),
+    e.toolCall('Bash'),
+    e.toolResult(true),
+    e.toolResult(true),
+    e.toolResult(true),
+    e.toolResult(true),
+    e.toolResult(true),
+    e.assistantMsg('done, deployed'),
+  ];
+}
+
+function reader(events: ReadonlyArray<MoxxyEvent>): EventLogReader {
+  const arr = [...events];
+  const base = arr.length > 0 ? arr[0]!.seq : 0;
+  return {
+    length: arr.length,
+    at: (seq: number) => arr[seq - base],
+    slice: (from = base, to = base + arr.length) =>
+      arr.slice(Math.max(0, from - base), Math.max(0, to - base)),
+    ofType: ((type: string) => arr.filter((ev) => ev.type === type)) as EventLogReader['ofType'],
+    byTurn: (turnId) => arr.filter((ev) => ev.turnId === turnId),
+    toJSON: () => arr,
+  };
+}
+
+function services(map: Record<string, unknown>): ServiceRegistry {
+  return {
+    register: () => {},
+    get: (<T>(name: string) => map[name] as T | undefined) as ServiceRegistry['get'],
+    require: (<T>(name: string) => {
+      const v = map[name];
+      if (v === undefined) throw new Error(`missing service ${name}`);
+      return v as T;
+    }) as ServiceRegistry['require'],
+    has: (name: string) => name in map,
+  };
+}
+
+function providersStub(provider: LLMProvider | null): unknown {
+  return {
+    getActiveName: () => (provider ? provider.name : null),
+    getActive: () => {
+      if (!provider) throw new Error('no active provider');
+      return provider;
+    },
+  };
+}
+
+function reflectorsStub(def: ReflectorDef | null): unknown {
+  return { getActive: () => def };
+}
+
+function turnCtx(events: ReadonlyArray<MoxxyEvent>, svc: ServiceRegistry): TurnContext {
+  return { sessionId: sid, turnId: tid, cwd: '/tmp', log: reader(events), env: {}, services: svc, iteration: 0 };
+}
+
+function reflectCtx(events: ReadonlyArray<MoxxyEvent>, svc: ServiceRegistry): ReflectContext {
+  return {
+    sessionId: sid,
+    turnId: tid,
+    cwd: '/tmp',
+    log: reader(events),
+    services: svc,
+    signal: AbortSignal.timeout(30_000),
+  };
+}
+
+const replyJson = (proposals: ReadonlyArray<ReflectionProposal>): string => JSON.stringify(proposals);
+
+// ── shouldReflect (the gate) ────────────────────────────────────────────────
+
+describe('shouldReflect', () => {
+  const e = makeEvents();
+
+  it('is false for a quiet turn (below every threshold)', () => {
+    const events = [e.userPrompt('hi'), e.toolCall('Bash'), e.toolResult(true), e.assistantMsg('hello')];
+    expect(shouldReflect(events)).toBe(false);
+  });
+
+  it(`fires at ${REFLECT_MIN_TOOL_RESULTS} tool results`, () => {
+    const events = Array.from({ length: REFLECT_MIN_TOOL_RESULTS }, () => e.toolResult(true));
+    expect(shouldReflect(events)).toBe(true);
+    expect(shouldReflect(events.slice(0, REFLECT_MIN_TOOL_RESULTS - 1))).toBe(false);
+  });
+
+  it('fires on a single error event', () => {
+    expect(shouldReflect([e.errorEv('boom')])).toBe(true);
+  });
+
+  it(`fires at ${REFLECT_MIN_ITERATIONS} mode iterations`, () => {
+    const events = Array.from({ length: REFLECT_MIN_ITERATIONS }, (_, i) => e.modeIter(i));
+    expect(shouldReflect(events)).toBe(true);
+    expect(shouldReflect(events.slice(0, REFLECT_MIN_ITERATIONS - 1))).toBe(false);
+  });
+});
+
+// ── buildTurnDigest ─────────────────────────────────────────────────────────
+
+describe('buildTurnDigest', () => {
+  it('summarizes prompt, tool names, error snippets, and final assistant text', () => {
+    const e = makeEvents();
+    const digest = buildTurnDigest([
+      e.userPrompt('fix the build'),
+      e.toolCall('Bash'),
+      e.toolCall('Bash'),
+      e.toolResult(false, 'exit code 1'),
+      e.assistantMsg('fixed it'),
+    ]);
+    expect(digest).toContain('USER: fix the build');
+    expect(digest).toContain('Bash×2');
+    expect(digest).toContain('ERRORS: exit code 1');
+    expect(digest).toContain('ASSISTANT: fixed it');
+  });
+
+  it('is empty for an empty turn', () => {
+    expect(buildTurnDigest([])).toBe('');
+  });
+});
+
+// ── parseReflectionReply ────────────────────────────────────────────────────
+
+describe('parseReflectionReply', () => {
+  it('parses a well-formed array', () => {
+    const out = parseReflectionReply(
+      replyJson([{ kind: 'memory', title: 'prefers pnpm', nudge: 'save that they use pnpm' }]),
+    );
+    expect(out).toEqual([{ kind: 'memory', title: 'prefers pnpm', nudge: 'save that they use pnpm' }]);
+  });
+
+  it('unwraps a ```json fenced block', () => {
+    const out = parseReflectionReply('```json\n[{"kind":"skill","title":"t","nudge":"n"}]\n```');
+    expect(out).toHaveLength(1);
+    expect(out[0]!.kind).toBe('skill');
+  });
+
+  it('clamps to at most 2 proposals', () => {
+    const out = parseReflectionReply(
+      replyJson([
+        { kind: 'memory', title: 'a', nudge: 'x' },
+        { kind: 'memory', title: 'b', nudge: 'y' },
+        { kind: 'skill', title: 'c', nudge: 'z' },
+      ]),
+    );
+    expect(out).toHaveLength(2);
+  });
+
+  it('returns [] on malformed JSON', () => {
+    expect(parseReflectionReply('not json at all')).toEqual([]);
+    expect(parseReflectionReply('[{"kind": "memory"')).toEqual([]);
+  });
+
+  it('returns [] on a wrong-shape item (bad kind / missing field)', () => {
+    expect(parseReflectionReply(replyJson([{ kind: 'other' as 'memory', title: 't', nudge: 'n' }]))).toEqual([]);
+    expect(parseReflectionReply('[{"kind":"memory","title":"t"}]')).toEqual([]);
+  });
+
+  it('returns [] for a non-array and an empty array', () => {
+    expect(parseReflectionReply('{"kind":"memory"}')).toEqual([]);
+    expect(parseReflectionReply('[]')).toEqual([]);
+  });
+});
+
+// ── reflectorDefaultDef.reflect (the strategy) ──────────────────────────────
+
+describe('reflectorDefaultDef.reflect', () => {
+  it('runs one provider pass and returns parsed proposals', async () => {
+    const provider = new FakeProvider({
+      name: 'fake',
+      script: [textReply(replyJson([{ kind: 'skill', title: 'deploy flow', nudge: 'capture it' }]))],
+    });
+    const svc = services({ providers: providersStub(provider) });
+    const out = await reflectorDefaultDef.reflect(reflectCtx(busyTurn(), svc));
+    expect(out).toEqual([{ kind: 'skill', title: 'deploy flow', nudge: 'capture it' }]);
+    expect(provider.received).toHaveLength(1);
+    expect(provider.received[0]!.system).toContain('review a single finished agent turn');
+  });
+
+  it('skips silently when there is no active provider', async () => {
+    const svc = services({ providers: providersStub(null) });
+    expect(await reflectorDefaultDef.reflect(reflectCtx(busyTurn(), svc))).toEqual([]);
+  });
+
+  it('skips silently when the providers service is absent', async () => {
+    const svc = services({});
+    expect(await reflectorDefaultDef.reflect(reflectCtx(busyTurn(), svc))).toEqual([]);
+  });
+
+  it('returns [] (never throws) on a provider error', async () => {
+    const errorScript: ReadonlyArray<ProviderEvent> = [
+      { type: 'message_start', model: 'fake' },
+      { type: 'error', message: 'upstream 500', retryable: false },
+    ];
+    const provider = new FakeProvider({ name: 'fake', script: [errorScript] });
+    const svc = services({ providers: providersStub(provider) });
+    expect(await reflectorDefaultDef.reflect(reflectCtx(busyTurn(), svc))).toEqual([]);
+  });
+
+  it('does not call the provider for an empty digest', async () => {
+    const provider = new FakeProvider({ name: 'fake', script: [] });
+    const svc = services({ providers: providersStub(provider) });
+    expect(await reflectorDefaultDef.reflect(reflectCtx([], svc))).toEqual([]);
+    expect(provider.received).toHaveLength(0);
+  });
+});
+
+// ── the driver (buildReflectorPlugin hooks) ─────────────────────────────────
+
+function driverServices(provider: LLMProvider | null, def: ReflectorDef | null = reflectorDefaultDef): ServiceRegistry {
+  return services({ reflectors: reflectorsStub(def), providers: providersStub(provider) });
+}
+
+const goodReflection = (): FakeProvider =>
+  new FakeProvider({
+    name: 'fake',
+    script: [textReply(replyJson([{ kind: 'memory', title: 'uses pnpm', nudge: 'remember pnpm' }]))],
+  });
+
+describe('reflector driver', () => {
+  it('does not reflect on a quiet turn (gate)', async () => {
+    const { plugin, internals } = buildReflectorPlugin();
+    const provider = goodReflection();
+    const e = makeEvents();
+    const quiet = [e.userPrompt('hi'), e.toolResult(true), e.assistantMsg('hello')];
+    await plugin.hooks!.onTurnEnd!(turnCtx(quiet, driverServices(provider)));
+    await internals.settle(sid);
+    expect(internals.budget(sid)).toBeUndefined();
+    expect(internals.pendingNudge(sid)).toBeNull();
+    expect(provider.received).toHaveLength(0);
+  });
+
+  it('reflects past the gate and stages a pending nudge', async () => {
+    const { plugin, internals } = buildReflectorPlugin();
+    const provider = goodReflection();
+    await plugin.hooks!.onTurnEnd!(turnCtx(busyTurn(), driverServices(provider)));
+    await internals.settle(sid);
+    expect(internals.budget(sid)?.count).toBe(1);
+    const nudge = internals.pendingNudge(sid);
+    expect(nudge).toContain('[reflection]');
+    expect(nudge).toContain('uses pnpm');
+    expect(nudge).toContain('memory_save');
+  });
+
+  it('enforces a one-reflection-per-session budget', async () => {
+    const { plugin, internals } = buildReflectorPlugin();
+    const provider = goodReflection();
+    await plugin.hooks!.onTurnEnd!(turnCtx(busyTurn(), driverServices(provider)));
+    await internals.settle(sid);
+    // A second busy turn must NOT fire a second reflection.
+    await plugin.hooks!.onTurnEnd!(turnCtx(busyTurn(), driverServices(provider)));
+    await internals.settle(sid);
+    expect(provider.received).toHaveLength(1);
+    expect(internals.budget(sid)?.count).toBe(1);
+  });
+
+  it('does not reflect (or spend budget) when no reflector is active', async () => {
+    const { plugin, internals } = buildReflectorPlugin();
+    const provider = goodReflection();
+    await plugin.hooks!.onTurnEnd!(turnCtx(busyTurn(), driverServices(provider, null)));
+    await internals.settle(sid);
+    expect(internals.budget(sid)).toBeUndefined();
+    expect(provider.received).toHaveLength(0);
+  });
+
+  it('injects the nudge exactly once on the next provider call, then clears it', async () => {
+    const { plugin, internals } = buildReflectorPlugin();
+    const provider = goodReflection();
+    const ctx = turnCtx(busyTurn(), driverServices(provider));
+    await plugin.hooks!.onTurnEnd!(ctx);
+    await internals.settle(sid);
+
+    const req: ProviderRequest = { model: 'm', system: 'BASE', messages: [] };
+    const first = (await plugin.hooks!.onBeforeProviderCall!(req, ctx)) as ProviderRequest | undefined;
+    expect(first?.system).toContain('BASE');
+    expect(first?.system).toContain('uses pnpm');
+    expect(internals.pendingNudge(sid)).toBeNull();
+
+    const second = await plugin.hooks!.onBeforeProviderCall!(req, ctx);
+    expect(second).toBeUndefined();
+  });
+
+  it('onTurnEnd returns without blocking on the reflection (fire-and-forget)', async () => {
+    const { plugin, internals } = buildReflectorPlugin();
+    const provider = goodReflection();
+    const ret = plugin.hooks!.onTurnEnd!(turnCtx(busyTurn(), driverServices(provider)));
+    // Resolves immediately; the reflection has NOT completed yet.
+    expect(internals.pendingNudge(sid)).toBeNull();
+    await ret; // onTurnEnd itself resolves fast
+    await internals.settle(sid); // now the detached reflection has finished
+    expect(internals.pendingNudge(sid)).not.toBeNull();
+  });
+
+  it('never throws into the turn when the reflector rejects', async () => {
+    const throwing: ReflectorDef = {
+      name: 'boom',
+      reflect: () => Promise.reject(new Error('reflector exploded')),
+    };
+    const { plugin, internals } = buildReflectorPlugin();
+    const svc = services({ reflectors: reflectorsStub(throwing), providers: providersStub(goodReflection()) });
+    // onTurnEnd is synchronous (fire-and-forget): it must not throw, and the
+    // rejected reflection must not surface after it settles.
+    expect(() => plugin.hooks!.onTurnEnd!(turnCtx(busyTurn(), svc))).not.toThrow();
+    await internals.settle(sid);
+    expect(internals.pendingNudge(sid)).toBeNull();
+  });
+
+  it('never throws into the turn when the log reader is hostile', async () => {
+    const { plugin } = buildReflectorPlugin();
+    const hostileLog = {
+      ...reader(busyTurn()),
+      byTurn: () => {
+        throw new Error('reader exploded');
+      },
+    } as EventLogReader;
+    const ctx: TurnContext = {
+      sessionId: sid,
+      turnId: tid,
+      cwd: '/tmp',
+      log: hostileLog,
+      env: {},
+      services: driverServices(goodReflection()),
+      iteration: 0,
+    };
+    // The synchronous gate swallows the hostile reader rather than throwing.
+    expect(() => plugin.hooks!.onTurnEnd!(ctx)).not.toThrow();
+  });
+
+  it('is silent when the provider errors (no nudge, no throw)', async () => {
+    const provider = new FakeProvider({
+      name: 'fake',
+      script: [[
+        { type: 'message_start', model: 'fake' },
+        { type: 'error', message: 'boom', retryable: false },
+      ]],
+    });
+    const { plugin, internals } = buildReflectorPlugin();
+    await plugin.hooks!.onTurnEnd!(turnCtx(busyTurn(), driverServices(provider)));
+    await internals.settle(sid);
+    expect(internals.pendingNudge(sid)).toBeNull();
+    // Budget is still spent — one attempt was made.
+    expect(internals.budget(sid)?.count).toBe(1);
+  });
+
+  it('clears per-session state on shutdown', async () => {
+    const { plugin, internals } = buildReflectorPlugin();
+    const ctx = turnCtx(busyTurn(), driverServices(goodReflection()));
+    await plugin.hooks!.onTurnEnd!(ctx);
+    await internals.settle(sid);
+    expect(internals.pendingNudge(sid)).not.toBeNull();
+    await plugin.hooks!.onShutdown!(ctx);
+    expect(internals.pendingNudge(sid)).toBeNull();
+    expect(internals.budget(sid)).toBeUndefined();
+  });
+});
+
+// ── integration through a real Session (registry + provider resolution) ─────
+
+describe('reflector integration (createFakeSession)', () => {
+  let session: Session | undefined;
+  afterEach(async () => {
+    await session?.close();
+    session = undefined;
+  });
+
+  it('auto-adopts the default reflector and resolves it through the live registry', async () => {
+    const provider = new FakeProvider({
+      name: 'fake',
+      script: [textReply(replyJson([{ kind: 'skill', title: 'deploy runbook', nudge: 'capture the deploy steps' }]))],
+    });
+    const { plugin, internals } = buildReflectorPlugin();
+    session = createFakeSession({ provider, plugins: [plugin] });
+
+    // The reflector def registered + auto-adopted through the real registry.
+    expect(session.reflectors.getActiveName()).toBe('default');
+
+    // Drive the driver against the REAL session services (reflectors + providers).
+    const ctx = turnCtx(busyTurn(), session.services);
+    await plugin.hooks!.onTurnEnd!(ctx);
+    await internals.settle(sid);
+
+    const nudge = internals.pendingNudge(sid);
+    expect(nudge).toContain('deploy runbook');
+
+    const injected = (await plugin.hooks!.onBeforeProviderCall!(
+      { model: 'm', messages: [] },
+      ctx,
+    )) as ProviderRequest;
+    expect(injected.system).toContain('deploy runbook');
+  });
+});

--- a/packages/reflector-default/src/index.ts
+++ b/packages/reflector-default/src/index.ts
@@ -1,0 +1,428 @@
+import {
+  definePlugin,
+  z,
+  type LifecycleHooks,
+  type LLMProvider,
+  type MoxxyEvent,
+  type Plugin,
+  type ProviderRequest,
+  type ReflectContext,
+  type ReflectionProposal,
+  type ReflectorDef,
+  type SessionId,
+} from '@moxxy/sdk';
+
+/**
+ * @moxxy/reflector-default — the default learning-loop block.
+ *
+ * TWO parts ship in one plugin:
+ *   1. a {@link ReflectorDef} named `'default'` (the strategy): one cheap
+ *      side-channel LLM pass over a finished turn that returns 0-2
+ *      {@link ReflectionProposal}s;
+ *   2. the DRIVER (lifecycle hooks): decides WHEN to reflect (a cheap gate +
+ *      a one-per-session budget), runs the active reflector fire-and-forget on
+ *      `onTurnEnd`, and delivers any proposals as a ONE-TIME nudge on the next
+ *      `onBeforeProviderCall`.
+ *
+ * The load-bearing property is "propose, don't write": a proposal never mutates
+ * memory or skills. It is injected into the next request's system prompt phrased
+ * so the MODEL may call `memory_save` / `synthesize_skill` — which still hit
+ * their own permission prompts. The reflection itself is best-effort: it runs
+ * detached from the turn, catches everything, and skips silently when there is
+ * no provider or the provider errors.
+ */
+
+// ── Gate thresholds ─────────────────────────────────────────────────────────
+/** Reflect when a turn did at least this many tool calls (busy/procedural turn). */
+export const REFLECT_MIN_TOOL_RESULTS = 5;
+/** Reflect when a turn ran at least this many mode-loop rounds (a hard task). */
+export const REFLECT_MIN_ITERATIONS = 8;
+/** Upper bound on the whole reflection (side-channel LLM pass). */
+export const REFLECT_TIMEOUT_MS = 30_000;
+/** Cap on the model reply span we'll JSON-parse — past this is malformed/hostile. */
+const MAX_JSON_SPAN = 32 * 1024;
+/** Cap on the turn digest handed to the reflection model. */
+const MAX_DIGEST_CHARS = 4000;
+/** Cap on a single snippet (prompt / assistant text / one error) inside the digest. */
+const MAX_SNIPPET_CHARS = 600;
+/** Tokens for the reflection pass — proposals are tiny. */
+const REFLECT_MAX_TOKENS = 1200;
+
+export const REFLECT_SYSTEM_PROMPT = `You review a single finished agent turn and decide whether anything is worth remembering for the future.
+
+Look for exactly two things:
+- a durable FACT worth saving to long-term memory (a stable preference, a project detail, a hard-won answer) → kind "memory"
+- a repeated multi-step PROCEDURE worth capturing as a reusable skill → kind "skill"
+
+Be strict. Most turns warrant NOTHING. Never propose transient chit-chat, one-off values, or things already obvious from context.
+
+Output ONLY a JSON array with 0, 1, or 2 items — no prose, no code fences. Each item:
+  { "kind": "memory" | "skill", "title": "<= 80 chars", "nudge": "one paragraph addressed to the assistant, suggesting it consider saving this" }
+Return [] when nothing is worth proposing.`;
+
+// ── Pure helpers (exported for tests) ───────────────────────────────────────
+
+/**
+ * The cheap gate, run synchronously on `onTurnEnd` against the turn's events.
+ * A turn is worth reflecting on when it was busy (≥{@link REFLECT_MIN_TOOL_RESULTS}
+ * tool results), hit an error, or ground through ≥{@link REFLECT_MIN_ITERATIONS}
+ * mode-loop rounds. A quiet turn (a quick Q&A) is skipped.
+ */
+export function shouldReflect(events: ReadonlyArray<MoxxyEvent>): boolean {
+  let toolResults = 0;
+  let errors = 0;
+  let iterations = 0;
+  for (const e of events) {
+    if (e.type === 'tool_result') toolResults++;
+    else if (e.type === 'error') errors++;
+    else if (e.type === 'mode_iteration') iterations++;
+  }
+  return (
+    toolResults >= REFLECT_MIN_TOOL_RESULTS || errors >= 1 || iterations >= REFLECT_MIN_ITERATIONS
+  );
+}
+
+function clip(text: string, max: number): string {
+  const t = text.trim();
+  return t.length > max ? t.slice(0, max) + '…' : t;
+}
+
+/**
+ * Build a compact text digest of a turn from its events: the user prompt, the
+ * tool names invoked (with counts), any error snippets, and the final assistant
+ * text — each snippet clipped, the whole thing capped at {@link MAX_DIGEST_CHARS}.
+ * This is what the reflection model reads instead of the raw event stream.
+ */
+export function buildTurnDigest(events: ReadonlyArray<MoxxyEvent>): string {
+  const parts: string[] = [];
+
+  const prompt = events.find((e) => e.type === 'user_prompt');
+  if (prompt && prompt.type === 'user_prompt') {
+    parts.push(`USER: ${clip(prompt.text, MAX_SNIPPET_CHARS)}`);
+  }
+
+  const toolCounts = new Map<string, number>();
+  for (const e of events) {
+    if (e.type === 'tool_call_requested') {
+      toolCounts.set(e.name, (toolCounts.get(e.name) ?? 0) + 1);
+    }
+  }
+  if (toolCounts.size > 0) {
+    const list = [...toolCounts.entries()]
+      .map(([name, n]) => (n > 1 ? `${name}×${n}` : name))
+      .join(', ');
+    parts.push(`TOOLS: ${list}`);
+  }
+
+  const errorSnippets: string[] = [];
+  for (const e of events) {
+    if (e.type === 'tool_result' && e.ok === false && e.error?.message) {
+      errorSnippets.push(clip(e.error.message, 200));
+    } else if (e.type === 'error') {
+      errorSnippets.push(clip(e.message, 200));
+    }
+  }
+  if (errorSnippets.length > 0) {
+    parts.push(`ERRORS: ${errorSnippets.slice(0, 5).join(' | ')}`);
+  }
+
+  // Last finalized assistant message is the turn's conclusion.
+  let finalText: string | null = null;
+  for (const e of events) {
+    if (e.type === 'assistant_message' && e.content.trim()) finalText = e.content;
+  }
+  if (finalText) parts.push(`ASSISTANT: ${clip(finalText, MAX_SNIPPET_CHARS)}`);
+
+  return clip(parts.join('\n'), MAX_DIGEST_CHARS);
+}
+
+const proposalSchema = z.object({
+  kind: z.enum(['memory', 'skill']),
+  title: z.string().min(1).max(200),
+  nudge: z.string().min(1).max(2000),
+});
+const proposalsSchema = z.array(proposalSchema);
+
+/**
+ * Defensively parse the reflection model's reply into 0-2 proposals. Strips an
+ * optional ```json fence, takes the first `[` … last `]` span, refuses an
+ * oversized span, JSON-parses, validates each item, and clamps to 2. ANY
+ * failure (no array, malformed JSON, wrong shape) yields `[]` — a bad reply
+ * silently produces no nudge rather than throwing into the detached reflection.
+ */
+export function parseReflectionReply(text: string): ReflectionProposal[] {
+  try {
+    const fenced = /```(?:json)?\n?([\s\S]*?)```/.exec(text);
+    const candidate = fenced ? fenced[1]! : text;
+    const start = candidate.indexOf('[');
+    const end = candidate.lastIndexOf(']');
+    if (start === -1 || end <= start) return [];
+    const span = candidate.slice(start, end + 1);
+    if (span.length > MAX_JSON_SPAN) return [];
+    const parsed = proposalsSchema.safeParse(JSON.parse(span));
+    if (!parsed.success) return [];
+    return parsed.data.slice(0, 2).map((p) => ({ kind: p.kind, title: p.title, nudge: p.nudge }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The one-time nudge injected into the next provider request's system prompt.
+ * Phrased as a suggestion the model MAY act on via `memory_save` /
+ * `synthesize_skill` (each of which asks the user for permission) — never a
+ * directive, never a silent write.
+ */
+export function buildNudgeBlock(proposals: ReadonlyArray<ReflectionProposal>): string {
+  const lines = proposals.map((p) => `- (${p.kind}) ${p.title}: ${p.nudge}`).join('\n');
+  return (
+    `\n\n[reflection] A background review of the last turn surfaced ${proposals.length} ` +
+    `suggestion(s) you MAY act on if genuinely useful (otherwise ignore):\n${lines}\n` +
+    'To persist one, you may call `memory_save` (a durable fact) or `synthesize_skill` ' +
+    '(a repeatable procedure) — each asks the user for permission first. Do not act unless it clearly helps.'
+  );
+}
+
+// ── The `default` reflector (the strategy) ──────────────────────────────────
+
+/** Minimal view of the provider registry the reflection pass needs. */
+interface ActiveProviderSource {
+  getActiveName(): string | null;
+  getActive(): LLMProvider;
+}
+
+/** Collect a provider stream into text, honoring the abort signal. */
+async function streamText(provider: LLMProvider, req: ProviderRequest): Promise<string> {
+  let out = '';
+  const iterable = provider.stream(req);
+  const iterator = iterable[Symbol.asyncIterator]();
+  try {
+    for (;;) {
+      if (req.signal?.aborted) break;
+      const step = await raceAbort(iterator.next(), req.signal);
+      if (step === ABORTED) break;
+      if (step.done) break;
+      const event = step.value;
+      if (event.type === 'text_delta') out += event.delta;
+      else if (event.type === 'error') throw new Error(event.message);
+    }
+  } finally {
+    if (req.signal?.aborted) void iterator.return?.(undefined).catch(() => {});
+  }
+  return out;
+}
+
+const ABORTED = Symbol('aborted');
+function raceAbort<T>(step: Promise<T>, signal: AbortSignal | undefined): Promise<T | typeof ABORTED> {
+  if (!signal) return step;
+  if (signal.aborted) {
+    void step.catch(() => {});
+    return Promise.resolve(ABORTED);
+  }
+  return new Promise<T | typeof ABORTED>((resolve, reject) => {
+    const onAbort = () => {
+      void step.catch(() => {});
+      resolve(ABORTED);
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    step.then(
+      (v) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(v);
+      },
+      (e) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(e);
+      },
+    );
+  });
+}
+
+/**
+ * The default reflector: one cheap side-channel LLM pass over the finished
+ * turn. Resolves the active provider from the service registry, streams a
+ * strict-JSON reply, and parses it into 0-2 proposals. Returns `[]` (never
+ * throws) when there is no active provider or the provider errors — reflection
+ * degrades to a no-op rather than surfacing anything into the session.
+ */
+export const reflectorDefaultDef: ReflectorDef = {
+  name: 'default',
+  displayName: 'Default learning loop',
+  async reflect(ctx: ReflectContext): Promise<ReadonlyArray<ReflectionProposal>> {
+    const providers = ctx.services.get<ActiveProviderSource>('providers');
+    // Graceful no-provider skip: nothing to reflect with.
+    if (!providers || providers.getActiveName() == null) return [];
+    let provider: LLMProvider;
+    try {
+      provider = providers.getActive();
+    } catch {
+      return [];
+    }
+
+    const digest = buildTurnDigest(ctx.log.byTurn(ctx.turnId));
+    if (!digest) return [];
+
+    const req: ProviderRequest = {
+      model: provider.models[0]?.id ?? 'unknown',
+      system: REFLECT_SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: [{ type: 'text', text: digest }] }],
+      maxTokens: REFLECT_MAX_TOKENS,
+      signal: ctx.signal,
+    };
+    try {
+      const reply = await streamText(provider, req);
+      return parseReflectionReply(reply);
+    } catch {
+      // Provider error / abort → degrade to a no-op rather than surfacing.
+      return [];
+    }
+  },
+};
+
+// ── The driver (lifecycle hooks) ────────────────────────────────────────────
+
+/** Per-session reflection budget: window = the whole session for v1. */
+export interface SessionBudget {
+  /** Reflections fired this window (v1 cap = 1). */
+  readonly count: number;
+  /** Seq of the last turn's last event reflected on (future windowing aid). */
+  readonly lastSeq: number;
+}
+
+/** Minimal view of the reflector registry the driver resolves the active def from. */
+interface ActiveReflectorSource {
+  getActive(): ReflectorDef | null;
+}
+
+/** Test-facing handle into the driver's private per-session state. */
+export interface ReflectorInternals {
+  /** Await the (fire-and-forget) reflection kicked off for a session, if any. */
+  settle(sessionId: SessionId): Promise<void>;
+  /** The pending one-time nudge for a session, or null. */
+  pendingNudge(sessionId: SessionId): string | null;
+  /** The session's reflection budget, or undefined when it never fired the gate. */
+  budget(sessionId: SessionId): SessionBudget | undefined;
+}
+
+export interface BuildReflectorPluginResult {
+  readonly plugin: Plugin;
+  readonly internals: ReflectorInternals;
+}
+
+/**
+ * Build the reflector plugin. The default export calls this with no options;
+ * tests use the returned `internals` handle to await the detached reflection
+ * and inspect the budget / pending nudge deterministically.
+ */
+export function buildReflectorPlugin(): BuildReflectorPluginResult {
+  // All keyed by sessionId so one shared instance stays correct across the many
+  // sessions a runner hosts in one process; every map self-cleans in onShutdown.
+  const budgets = new Map<SessionId, SessionBudget>();
+  const pending = new Map<SessionId, string>();
+  const inFlight = new Map<SessionId, Promise<void>>();
+  const shutdownControllers = new Map<SessionId, AbortController>();
+
+  function cleanup(sessionId: SessionId): void {
+    try {
+      shutdownControllers.get(sessionId)?.abort();
+    } catch {
+      // aborting a controller never throws in practice; guard anyway.
+    }
+    shutdownControllers.delete(sessionId);
+    budgets.delete(sessionId);
+    pending.delete(sessionId);
+    inFlight.delete(sessionId);
+  }
+
+  const hooks: LifecycleHooks = {
+    // AWAITED by the lifecycle dispatcher (with a per-plugin timeout), so this
+    // MUST return fast: the gate + budget check are synchronous, and the actual
+    // reflection is kicked off FIRE-AND-FORGET (a guarded detached promise) so
+    // it never blocks the turn and can never throw into it.
+    onTurnEnd(ctx) {
+      try {
+        const events = ctx.log.byTurn(ctx.turnId);
+        if (!shouldReflect(events)) return;
+
+        const prior = budgets.get(ctx.sessionId) ?? { count: 0, lastSeq: -1 };
+        // Budget: at most one reflection per session window (v1 = whole session).
+        if (prior.count >= 1) return;
+
+        const reflectors = ctx.services.get<ActiveReflectorSource>('reflectors');
+        const reflector = reflectors?.getActive() ?? null;
+        // Nullable registry: no active reflector → reflection is off. Do NOT
+        // consume the budget (so activating one later still gets a chance).
+        if (!reflector) return;
+
+        // Reserve the budget slot BEFORE going async so a rapid next turn can't
+        // double-fire while this reflection is still in flight.
+        const lastSeq = events.length > 0 ? events[events.length - 1]!.seq : prior.lastSeq;
+        budgets.set(ctx.sessionId, { count: prior.count + 1, lastSeq });
+
+        let sc = shutdownControllers.get(ctx.sessionId);
+        if (!sc) {
+          sc = new AbortController();
+          shutdownControllers.set(ctx.sessionId, sc);
+        }
+        const signal = AbortSignal.any([sc.signal, AbortSignal.timeout(REFLECT_TIMEOUT_MS)]);
+        const reflectCtx: ReflectContext = {
+          sessionId: ctx.sessionId,
+          turnId: ctx.turnId,
+          cwd: ctx.cwd,
+          log: ctx.log,
+          services: ctx.services,
+          signal,
+        };
+
+        const p = (async () => {
+          try {
+            const proposals = await reflector.reflect(reflectCtx);
+            if (proposals.length > 0) pending.set(ctx.sessionId, buildNudgeBlock(proposals));
+          } catch {
+            // Best-effort: a no-provider skip, provider error, or reflector
+            // throw must never surface. The budget stays spent (one attempt).
+          }
+        })();
+        inFlight.set(ctx.sessionId, p);
+        // Detach: do NOT return `p` — onTurnEnd resolves immediately.
+        void p;
+      } catch {
+        // The gate itself (a hostile log reader, etc.) must never take down the
+        // awaited onTurnEnd hook.
+      }
+    },
+
+    // Deliver a pending reflection as a ONE-TIME nudge on the next provider call.
+    onBeforeProviderCall(req, ctx) {
+      const nudge = pending.get(ctx.sessionId);
+      if (!nudge) return;
+      pending.delete(ctx.sessionId); // one-shot: cleared after injection
+      return { ...req, system: (req.system ?? '') + nudge };
+    },
+
+    onShutdown(ctx) {
+      cleanup(ctx.sessionId);
+    },
+  };
+
+  const plugin = definePlugin({
+    name: '@moxxy/reflector-default',
+    version: '0.0.0',
+    reflectors: [reflectorDefaultDef],
+    hooks,
+  });
+
+  const internals: ReflectorInternals = {
+    async settle(sessionId) {
+      await inFlight.get(sessionId)?.catch(() => {});
+    },
+    pendingNudge: (sessionId) => pending.get(sessionId) ?? null,
+    budget: (sessionId) => budgets.get(sessionId),
+  };
+
+  return { plugin, internals };
+}
+
+/** Discovery-loadable default export (the plain plugin, no test handle). */
+const reflectorPlugin: Plugin = buildReflectorPlugin().plugin;
+export default reflectorPlugin;

--- a/packages/reflector-default/tsconfig.json
+++ b/packages/reflector-default/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/sdk/src/events.ts
+++ b/packages/sdk/src/events.ts
@@ -176,6 +176,7 @@ export interface PluginRegisteredEvent extends EventBase {
     | 'isolator'
     | 'workflow-executor'
     | 'event-store'
+    | 'reflector'
   >;
 }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -193,6 +193,11 @@ export type {
   SessionSource,
 } from './event-store.js';
 export { SESSION_SOURCES } from './event-store.js';
+export type {
+  ReflectorDef,
+  ReflectContext,
+  ReflectionProposal,
+} from './reflector.js';
 // Node-runtime helpers (writeFileAtomic*, moxxyHome/moxxyPath,
 // readRequestBody/bearerTokenMatches, channel-auth) are exported from the
 // './server' subpath, NOT the main barrel — they statically reach node:*

--- a/packages/sdk/src/plugin.ts
+++ b/packages/sdk/src/plugin.ts
@@ -17,8 +17,9 @@ import type { ViewRendererDef } from './view-renderer.js';
 import type { TunnelProviderDef } from './tunnel.js';
 import type { WorkflowExecutorDef } from './workflow.js';
 import type { EventStoreDef } from './event-store.js';
+import type { ReflectorDef } from './reflector.js';
 
-export type PluginKind = 'tools' | 'provider' | 'mode' | 'compactor' | 'cache-strategy' | 'view-renderer' | 'tunnel-provider' | 'mcp' | 'cli' | 'channel' | 'surface' | 'hooks' | 'agent' | 'command' | 'transcriber' | 'synthesizer' | 'embedder' | 'isolator' | 'workflow-executor' | 'event-store';
+export type PluginKind = 'tools' | 'provider' | 'mode' | 'compactor' | 'cache-strategy' | 'view-renderer' | 'tunnel-provider' | 'mcp' | 'cli' | 'channel' | 'surface' | 'hooks' | 'agent' | 'command' | 'transcriber' | 'synthesizer' | 'embedder' | 'isolator' | 'workflow-executor' | 'event-store' | 'reflector';
 
 export interface PluginSpec {
   readonly name: string;
@@ -53,6 +54,14 @@ export interface PluginSpec {
    * boundary, since the store sees every event). See {@link EventStoreDef}.
    */
   readonly eventStores?: ReadonlyArray<EventStoreDef>;
+  /**
+   * Reflector backends — the learning-loop block that watches a finished turn
+   * and *proposes* memory/skill improvements without silently writing. One
+   * active at a time, selected via `plugins.reflector.default`. NULLABLE: core
+   * seeds no floor, so reflection is opt-in — no registered reflector means the
+   * session never reflects. See {@link ReflectorDef}.
+   */
+  readonly reflectors?: ReadonlyArray<ReflectorDef>;
   readonly channels?: ReadonlyArray<ChannelDef>;
   /**
    * Interactive surfaces contributed by the plugin — long-lived panes a human

--- a/packages/sdk/src/reflector.ts
+++ b/packages/sdk/src/reflector.ts
@@ -1,0 +1,61 @@
+import type { EventLogReader } from './log.js';
+import type { SessionId, TurnId } from './ids.js';
+import type { ServiceRegistry } from './services.js';
+
+/**
+ * The learning-loop block — a swappable strategy that watches a finished turn
+ * and *proposes* (never silently writes) memory/skill improvements. It is the
+ * def-only sibling of the other single-active registries (compactor, cache
+ * strategy, …) but NULLABLE: core seeds NO floor, so reflection is entirely
+ * opt-in — a session with no registered reflector simply never reflects.
+ *
+ * The trust boundary is the "propose, don't write" contract. A reflector reads
+ * the turn's events and returns {@link ReflectionProposal}s; the driver that
+ * hosts it delivers those as a one-time nudge on the next provider call, phrased
+ * so the *model* may choose to call `memory_save` / `synthesize_skill` — which
+ * still go through the existing permission prompts. Nothing a reflector returns
+ * mutates memory or skills on its own.
+ */
+
+/**
+ * The context handed to {@link ReflectorDef.reflect}. Scoped to one finished
+ * turn: `log.byTurn(turnId)` yields exactly that turn's events. `services`
+ * exposes the host's inter-plugin registry (e.g. `services.get('providers')`
+ * for a side-channel LLM pass); `signal` bounds the whole reflection (a timeout
+ * and/or session shutdown) so a slow provider can never wedge it.
+ */
+export interface ReflectContext {
+  readonly sessionId: SessionId;
+  readonly turnId: TurnId;
+  readonly cwd: string;
+  readonly log: EventLogReader;
+  readonly services: ServiceRegistry;
+  readonly signal: AbortSignal;
+}
+
+/**
+ * One improvement a reflector suggests. `kind` picks the target surface
+ * (`'memory'` → a fact worth `memory_save`; `'skill'` → a repeated procedure
+ * worth `synthesize_skill`); `title` is a short label; `nudge` is a
+ * one-paragraph suggestion addressed to the assistant. A proposal is a HINT,
+ * not a command — the model decides whether to act, and any resulting write
+ * still hits its own permission prompt.
+ */
+export interface ReflectionProposal {
+  readonly kind: 'memory' | 'skill';
+  readonly title: string;
+  /** One-paragraph suggestion addressed to the assistant. */
+  readonly nudge: string;
+}
+
+/**
+ * A registered reflector backend. `reflect` inspects the just-finished turn and
+ * returns 0 or more proposals (an empty array = "nothing worth suggesting").
+ * It MUST be side-effect-free with respect to memory/skills — it only reads and
+ * proposes — and MUST honor `ctx.signal` (abort/timeout).
+ */
+export interface ReflectorDef {
+  readonly name: string;
+  readonly displayName?: string;
+  reflect(ctx: ReflectContext): Promise<ReadonlyArray<ReflectionProposal>>;
+}

--- a/packages/sdk/src/schemas.ts
+++ b/packages/sdk/src/schemas.ts
@@ -16,6 +16,7 @@ const pluginKindSchema = z.enum([
   'command',
   'transcriber',
   'synthesizer',
+  'reflector',
 ]);
 
 export const requirementSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2645,6 +2645,37 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
 
+  packages/reflector-default:
+    dependencies:
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
+    devDependencies:
+      '@moxxy/core':
+        specifier: workspace:*
+        version: link:../core
+      '@moxxy/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
   packages/runner:
     dependencies:
       '@moxxy/config':


### PR DESCRIPTION
## What

Adds a new swappable registry category — **`reflector`** — the learning-loop block that watches a finished turn and *proposes* memory/skill improvements **without ever writing silently**, plus the default implementation `@moxxy/reflector-default`.

Mirrors the `eventStore` category across all 7 layers, but the registry is **NULLABLE**: core seeds no floor, so reflection is entirely opt-in (like transcriber/synthesizer). No registered reflector ⇒ the session never reflects.

## The contract (`@moxxy/sdk`)

```ts
interface ReflectContext {
  sessionId; turnId; cwd;
  log: EventLogReader;
  services: ServiceRegistry;
  signal: AbortSignal;
}
interface ReflectionProposal {
  kind: 'memory' | 'skill';
  title: string;
  nudge: string; // one-paragraph suggestion addressed to the assistant
}
interface ReflectorDef {
  name: string;
  displayName?: string;
  reflect(ctx: ReflectContext): Promise<ReadonlyArray<ReflectionProposal>>;
}
```

## Nudge-not-write design (the permission story)

`@moxxy/reflector-default` ships the default `ReflectorDef` `'default'` **and** the driver (lifecycle hooks) in one plugin:

- **`onTurnEnd`** runs a cheap synchronous gate, then fires the reflection **FIRE-AND-FORGET** (a guarded detached promise) — it returns immediately, so it never blocks the awaited hook and can never throw into the turn.
- The reflector does **one** cheap side-channel LLM pass over a turn digest (user prompt + tool names + error snippets + final assistant text, char-capped) and returns **0-2** proposals, parsed defensively from a strict JSON array.
- Proposals are delivered as a **one-time nudge** on the next `onBeforeProviderCall` (`{ ...req, system: req.system + nudgeBlock }`), phrased so the **model MAY** call `memory_save` / `synthesize_skill` — which still hit their **existing permission prompts**. **No silent writes**; one pending-nudge slot per session, cleared after injection.

## Gate / budget semantics

- **Gate** (on `ctx.log.byTurn(turnId)`): reflect only when a turn had **≥5 tool_result** events **OR ≥1 error** event **OR ≥8 mode iterations**.
- **Budget**: at most **one reflection per session** window (v1 = whole session). State is `Map<SessionId, {count, lastSeq}>`, self-cleaned in `onShutdown` alongside the pending-nudge and in-flight maps.

## Requirements / degradation

- `package.json#moxxy.requirements` declares `memory_save` and `synthesize_skill` as **optional** tool requirements (`optional: true`) — the plugin loads fine without `@moxxy/plugin-memory` / the skill tool; proposals just have nothing to act on.
- Graceful **no-provider** and **provider-error** paths: the reflection returns `[]` silently.

## Deferred

- **User-model injection** of proposals (surfacing them to the human directly, not only via the model nudge) is a **separate follow-up PR** — intentionally not built here.

## Layers touched

`config` (schema slot + `PLUGIN_CATEGORY_KEYS`) · `sdk` (`reflector.ts` contract, `PluginKind`, `reflectors` slot, `PluginRegisteredEvent.kind`, manifest-kind enum) · `core` (`ReflectorRegistry`, registry-kind wiring, host options, `Session` field + `services('reflectors')`) · `cli` (`applyPluginsTree` ACTIVE_DEF_KINDS warn-and-skip, category-swap table) · `plugin-plugins-admin` (catalog) · `plugin-cli` (swap-tab label) · new `@moxxy/reflector-default`.

## Tests

- **Plumbing**: config schema round-trip (`plugins.reflector.default`), nullable registry (no floor, autoAdopt-first, setActive, unregister→null), `applyPluginsTree` warn-and-skip, REGISTRY_KINDS lockstep coverage.
- **Driver** (`@moxxy/testing` FakeProvider + createFakeSession): gate fires only past thresholds; one-reflection-per-session budget; nudge injected exactly once and cleared; fire-and-forget never blocks/never throws; no-provider + provider-error are silent; defensive parse of a scripted reply; end-to-end resolution through a live `Session` registry.

## Gate status

`pnpm build` ✓ · `typecheck` ✓ · `lint` ✓ (0 errors) · `test` ✓ · `check:deps` ✓ — all exit 0.
