### PR TITLE
feat(memory): persistent user model — always-injected ~/.moxxy/memory/user-model.md + update tool

### DIFF
--- a/.changeset/user-model.md
+++ b/.changeset/user-model.md
@@ -1,0 +1,15 @@
+---
+'@moxxy/plugin-memory': minor
+'@moxxy/reflector-default': patch
+'@moxxy/cli': patch
+---
+
+feat(memory): persistent user model — always-injected `~/.moxxy/memory/user-model.md` + update tool
+
+A first-class user model (Identity / Preferences / Workflows / Context) is now
+ALWAYS injected into the system prompt as a delimited `<user-model>` block
+(capped at 4000 chars, idempotent per request, error-swallowing). It is updated
+only through the deliberate, permission-prompted `memory_update_user_model` tool
+— never silently written by the loop. The default reflector now steers durable
+user-trait proposals toward this tool, and `moxxy memory user-model` prints the
+current file.

--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, vi, afterEach } from 'vitest';
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { MemoryType } from '@moxxy/plugin-memory';
-import { formatRelative, formatSize, groupByType, mapBounded } from './memory.js';
+import { formatRelative, formatSize, groupByType, mapBounded, runMemoryCommand } from './memory.js';
+import type { ParsedArgv } from '../argv.js';
 
 /** Minimal stat object — groupByType only reads `entry.frontmatter.type`. */
 function statOfType(type: MemoryType): Parameters<typeof groupByType>[0][number] {
@@ -84,6 +88,47 @@ describe('mapBounded', () => {
     const out = await mapBounded([], async () => (calls += 1));
     expect(out).toEqual([]);
     expect(calls).toBe(0);
+  });
+});
+
+describe('memory user-model subcommand', () => {
+  let tmp: string;
+  let prevHome: string | undefined;
+  let out: string;
+
+  const argv = (): ParsedArgv => ({ command: 'memory', flags: {}, positional: ['user-model'] });
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-um-cli-'));
+    prevHome = process.env.MOXXY_HOME;
+    process.env.MOXXY_HOME = tmp;
+    out = '';
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      out += String(chunk);
+      return true;
+    });
+  });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (prevHome === undefined) delete process.env.MOXXY_HOME;
+    else process.env.MOXXY_HOME = prevHome;
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it('prints a "(none yet)" hint when no user model exists', async () => {
+    const code = await runMemoryCommand(argv());
+    expect(code).toBe(0);
+    expect(out).toContain('none yet');
+  });
+
+  it('prints the file contents when a user model exists', async () => {
+    const dir = path.join(tmp, 'memory');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'user-model.md'), '## Identity\n\nAlex, backend dev\n');
+    const code = await runMemoryCommand(argv());
+    expect(code).toBe(0);
+    expect(out).toContain('## Identity');
+    expect(out).toContain('Alex, backend dev');
   });
 });
 

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'node:fs';
-import { MemoryStore, defaultMemoryDir, type MemoryEntry, type MemoryType } from '@moxxy/plugin-memory';
+import { MemoryStore, UserModelStore, defaultMemoryDir, type MemoryEntry, type MemoryType } from '@moxxy/plugin-memory';
 import type { ParsedArgv } from '../argv.js';
 import { confirmedYes, helpRequested } from '../argv-helpers.js';
 import { printError } from '../errors.js';
@@ -18,6 +18,7 @@ const HELP = formatHelp({
         ['show <name>', 'print the body of a single entry'],
         ['revert <name>', 'delete a single entry'],
         ['prune-stale --days <n>', 'delete entries not updated in <n> days'],
+        ['user-model', 'print the persistent user model'],
         ['path', 'print the memory directory'],
       ],
     },
@@ -147,6 +148,17 @@ export async function runMemoryCommand(argv: ParsedArgv): Promise<number> {
         }
       }
       process.stdout.write(`deleted ${deleted} stale entries\n`);
+      return 0;
+    }
+    case 'user-model': {
+      const raw = await new UserModelStore().readRaw();
+      if (!raw || !raw.trim()) {
+        process.stdout.write(
+          colors.dim('(none yet — the agent maintains this via memory_update_user_model)') + '\n',
+        );
+        return 0;
+      }
+      process.stdout.write(raw.endsWith('\n') ? raw : raw + '\n');
       return 0;
     }
     case 'path': {

--- a/packages/plugin-memory/src/index.ts
+++ b/packages/plugin-memory/src/index.ts
@@ -1,6 +1,7 @@
-import { defineTool, defineEmbedder, definePlugin, z, type Plugin } from '@moxxy/sdk';
+import { defineTool, defineEmbedder, definePlugin, z, type Plugin, type ProviderRequest } from '@moxxy/sdk';
 import { MemoryStore, memoryTypeSchema, type MemoryStoreOptions } from './store.js';
 import { TfIdfEmbedder } from './tfidf.js';
+import { UserModelStore, userModelTool } from './user-model.js';
 
 export {
   MemoryStore,
@@ -19,6 +20,23 @@ export { recentExchanges, summarizeSession, type SessionFact } from './stm.js';
 export { TfIdfEmbedder, cosineSimilarity, tokenize } from './tfidf.js';
 export { EmbeddingIndex } from './embedding-cache.js';
 export {
+  UserModelStore,
+  userModelTool,
+  parseUserModel,
+  serializeUserModel,
+  renderInjectionBody,
+  defaultUserModelPath,
+  MAX_INJECTED_CHARS,
+  USER_MODEL_OPEN,
+  USER_MODEL_CLOSE,
+  FIXED_SECTIONS,
+  SECTION_TITLES,
+  type UserModel,
+  type UserModelSection,
+  type UserModelSectionKey,
+  type UserModelUpdateMode,
+} from './user-model.js';
+export {
   planConsolidation,
   consolidateMemory,
   buildMemoryConsolidatePlugin,
@@ -33,6 +51,10 @@ export interface BuildMemoryPluginOptions extends MemoryStoreOptions {}
 
 export function buildMemoryPlugin(opts: BuildMemoryPluginOptions = {}): { plugin: Plugin; store: MemoryStore } {
   const store = new MemoryStore(opts);
+  // The persistent user model lives alongside the episodic memories in the same
+  // memory dir. Both the always-on injection hook and the update tool close over
+  // this one instance so the mtime cache is shared.
+  const userModel = new UserModelStore(opts.dir);
   const plugin = definePlugin({
     name: '@moxxy/plugin-memory',
     version: '0.0.0',
@@ -45,6 +67,10 @@ export function buildMemoryPlugin(opts: BuildMemoryPluginOptions = {}): { plugin
       onInit: (ctx) => {
         ctx.services.register('memory', store);
       },
+      // ALWAYS-ON: prepend the delimited <user-model> block to every provider
+      // call when the file exists and has content. Idempotent (skips when the
+      // block is already present) and error-swallowing (never breaks a call).
+      onBeforeProviderCall: (req) => userModel.injectInto(req),
     },
     // The zero-dep TF-IDF embedder, contributed as a selectable embedder so it
     // sits in the same registry as openai/transformers/custom ones.
@@ -195,6 +221,7 @@ export function buildMemoryPlugin(opts: BuildMemoryPluginOptions = {}): { plugin
           return { name: updated.frontmatter.name, updatedAt: updated.frontmatter.updatedAt };
         },
       }),
+      userModelTool(userModel),
     ],
   });
   return { plugin, store };
@@ -232,12 +259,23 @@ export const memoryPlugin: Plugin = (() => {
     ...(base.embedders ? { embedders: base.embedders } : {}),
     tools: [...(base.tools ?? []), ...(consolidate.tools ?? [])],
     hooks: {
-      ...consolidate.hooks,
       onInit: async (ctx) => {
         embeddersReg =
           ctx.services.get<{ tryGetActive(): unknown }>('embedders') ?? null;
         await base.hooks?.onInit?.(ctx);
         await consolidate.hooks?.onInit?.(ctx);
+      },
+      // A Plugin has a single onBeforeProviderCall, but this composed plugin
+      // carries TWO: base's always-on user-model injection and consolidate's
+      // once-per-session nudge. Chain them so both run (injection prepends its
+      // block, the nudge appends its hint); either may return void to pass through.
+      onBeforeProviderCall: async (req, ctx) => {
+        let out: ProviderRequest | undefined;
+        const injected = await base.hooks?.onBeforeProviderCall?.(out ?? req, ctx);
+        if (injected) out = injected;
+        const nudged = await consolidate.hooks?.onBeforeProviderCall?.(out ?? req, ctx);
+        if (nudged) out = nudged;
+        return out;
       },
     },
   });

--- a/packages/plugin-memory/src/user-model.test.ts
+++ b/packages/plugin-memory/src/user-model.test.ts
@@ -1,0 +1,296 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ProviderRequest } from '@moxxy/sdk';
+import {
+  UserModelStore,
+  userModelTool,
+  parseUserModel,
+  serializeUserModel,
+  renderInjectionBody,
+  MAX_INJECTED_CHARS,
+  USER_MODEL_OPEN,
+  type UserModel,
+} from './user-model.js';
+
+let tmp: string;
+const newStore = () => new UserModelStore(tmp);
+const modelPath = () => path.join(tmp, 'user-model.md');
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-um-'));
+});
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+const req = (system?: string): ProviderRequest => ({
+  model: 'stub',
+  messages: [],
+  ...(system !== undefined ? { system } : {}),
+});
+
+// ── parse / serialize round-trip ─────────────────────────────────────────────
+
+describe('parseUserModel / serializeUserModel', () => {
+  it('round-trips fixed sections with content', () => {
+    const text = '## Identity\n\nAlex, a backend dev.\n\n## Preferences\n\nTerse replies.\n';
+    const model = parseUserModel(text);
+    expect(model.sections.map((s) => s.title)).toEqual(['Identity', 'Preferences']);
+    expect(model.sections[0]!.content).toBe('Alex, a backend dev.');
+    // serialize → parse is stable
+    const reparsed = parseUserModel(serializeUserModel(model));
+    expect(reparsed.sections).toEqual(model.sections);
+  });
+
+  it('preserves an unknown (hand-added) section verbatim across a round-trip', () => {
+    const text =
+      '<!-- comment -->\n\n## Identity\n\nA.\n\n## Notes\n\nhand-written aside\nsecond line\n';
+    const model = parseUserModel(text);
+    expect(model.preamble).toBe('<!-- comment -->');
+    const notes = model.sections.find((s) => s.title === 'Notes');
+    expect(notes?.content).toBe('hand-written aside\nsecond line');
+    // Notes survives serialize → parse.
+    const reparsed = parseUserModel(serializeUserModel(model));
+    expect(reparsed.sections.find((s) => s.title === 'Notes')?.content).toBe(
+      'hand-written aside\nsecond line',
+    );
+    expect(reparsed.preamble).toBe('<!-- comment -->');
+  });
+});
+
+// ── renderInjectionBody (size cap) ───────────────────────────────────────────
+
+describe('renderInjectionBody', () => {
+  it('omits empty sections and returns "" when nothing has content', () => {
+    const empty: UserModel = {
+      preamble: '',
+      sections: [
+        { title: 'Identity', content: '' },
+        { title: 'Preferences', content: '   ' },
+      ],
+    };
+    expect(renderInjectionBody(empty)).toBe('');
+  });
+
+  it('renders only non-empty sections', () => {
+    const model: UserModel = {
+      preamble: '',
+      sections: [
+        { title: 'Identity', content: 'A.' },
+        { title: 'Preferences', content: '' },
+        { title: 'Workflows', content: 'W.' },
+      ],
+    };
+    const body = renderInjectionBody(model);
+    expect(body).toContain('## Identity\nA.');
+    expect(body).toContain('## Workflows\nW.');
+    expect(body).not.toContain('## Preferences');
+  });
+
+  it('drops whole sections oldest-last and appends a (truncated) marker past the cap', () => {
+    const big = 'x'.repeat(1500);
+    const model: UserModel = {
+      preamble: '',
+      sections: [
+        { title: 'Identity', content: big },
+        { title: 'Preferences', content: big },
+        { title: 'Workflows', content: big }, // 3×~1500 > 4000 → this one drops
+      ],
+    };
+    const body = renderInjectionBody(model);
+    expect(body).toContain('## Identity');
+    expect(body).toContain('## Preferences');
+    expect(body).not.toContain('## Workflows');
+    expect(body).toContain('(truncated)');
+    // The kept content stays within the cap (marker excluded).
+    expect(body.replace('\n\n(truncated)', '').length).toBeLessThanOrEqual(MAX_INJECTED_CHARS);
+  });
+});
+
+// ── mtime-cached load ────────────────────────────────────────────────────────
+
+describe('UserModelStore.load (mtime cache)', () => {
+  it('returns null when the file is absent', async () => {
+    expect(await newStore().load()).toBeNull();
+  });
+
+  it('reads the file once, then serves an unchanged file from cache (no re-read)', async () => {
+    const store = newStore();
+    await store.update('identity', 'first', 'replace');
+    const spy = vi.spyOn(fs, 'readFile');
+    await store.load();
+    await store.load();
+    await store.load();
+    // Three loads of an unchanged file → a single readFile (mtime unchanged).
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates the cache when the file changes (via update)', async () => {
+    const store = newStore();
+    await store.update('identity', 'first', 'replace');
+    const before = await store.load();
+    expect(before?.sections.find((s) => s.title === 'Identity')?.content).toBe('first');
+    await new Promise((r) => setTimeout(r, 10)); // ensure a distinct mtime
+    await store.update('identity', 'second', 'replace');
+    const after = await store.load();
+    expect(after?.sections.find((s) => s.title === 'Identity')?.content).toBe('second');
+  });
+
+  it('picks up an out-of-band write with a newer mtime', async () => {
+    const store = newStore();
+    await store.update('identity', 'first', 'replace');
+    await store.load(); // prime the cache
+    await new Promise((r) => setTimeout(r, 10));
+    await fs.writeFile(modelPath(), '## Identity\n\nrewritten\n');
+    expect((await store.load())?.sections.find((s) => s.title === 'Identity')?.content).toBe(
+      'rewritten',
+    );
+  });
+});
+
+// ── update (template creation, replace/append) ───────────────────────────────
+
+describe('UserModelStore.update', () => {
+  it('creates the file with the commented template on first write', async () => {
+    const store = newStore();
+    await store.update('identity', 'Alex', 'replace');
+    const raw = await fs.readFile(modelPath(), 'utf8');
+    expect(raw).toContain('<!-- moxxy user model');
+    // All four fixed sections exist (template), with Identity filled.
+    for (const h of ['## Identity', '## Preferences', '## Workflows', '## Context']) {
+      expect(raw).toContain(h);
+    }
+    expect(raw).toContain('Alex');
+  });
+
+  it('replace overwrites the section content', async () => {
+    const store = newStore();
+    await store.update('preferences', 'terse', 'replace');
+    await store.update('preferences', 'verbose', 'replace');
+    const m = await store.load();
+    expect(m?.sections.find((s) => s.title === 'Preferences')?.content).toBe('verbose');
+  });
+
+  it('append adds to existing content on its own line', async () => {
+    const store = newStore();
+    await store.update('workflows', 'uses pnpm', 'replace');
+    await store.update('workflows', 'rebases often', 'append');
+    const content = (await store.load())?.sections.find((s) => s.title === 'Workflows')?.content;
+    expect(content).toBe('uses pnpm\nrebases often');
+  });
+
+  it('append on an empty section behaves like replace', async () => {
+    const store = newStore();
+    await store.update('context', 'sole line', 'append');
+    expect((await store.load())?.sections.find((s) => s.title === 'Context')?.content).toBe(
+      'sole line',
+    );
+  });
+
+  it('preserves an unknown section when a tool write touches a fixed one', async () => {
+    const store = newStore();
+    await store.update('identity', 'A', 'replace');
+    // Hand-add a section out of band, then update via the store.
+    const raw = await fs.readFile(modelPath(), 'utf8');
+    await fs.writeFile(modelPath(), raw + '\n## Notes\n\nkeep me\n');
+    await new Promise((r) => setTimeout(r, 10));
+    await store.update('preferences', 'terse', 'replace');
+    const raw2 = await fs.readFile(modelPath(), 'utf8');
+    expect(raw2).toContain('## Notes');
+    expect(raw2).toContain('keep me');
+  });
+});
+
+// ── injection hook ───────────────────────────────────────────────────────────
+
+describe('UserModelStore.injectInto', () => {
+  it('is a no-op when the file is absent', async () => {
+    expect(await newStore().injectInto(req('BASE'))).toBeUndefined();
+  });
+
+  it('is a no-op when the file has only the (empty) template', async () => {
+    const store = newStore();
+    // A template with no filled sections should not inject an empty block.
+    await fs.writeFile(modelPath(), '<!-- c -->\n\n## Identity\n\n## Preferences\n');
+    expect(await store.injectInto(req('BASE'))).toBeUndefined();
+  });
+
+  it('prepends a delimited <user-model> block plus the durable-context note', async () => {
+    const store = newStore();
+    await store.update('identity', 'Alex, backend dev', 'replace');
+    const out = (await store.injectInto(req('BASE SYSTEM'))) as ProviderRequest;
+    expect(out.system!.startsWith(USER_MODEL_OPEN)).toBe(true);
+    expect(out.system).toContain('## Identity\nAlex, backend dev');
+    expect(out.system).toContain('</user-model>');
+    expect(out.system).toContain('memory_update_user_model');
+    // Original system prompt is retained, AFTER the block.
+    expect(out.system).toContain('BASE SYSTEM');
+    expect(out.system!.indexOf(USER_MODEL_OPEN)).toBeLessThan(out.system!.indexOf('BASE SYSTEM'));
+  });
+
+  it('injects even when req.system is undefined', async () => {
+    const store = newStore();
+    await store.update('identity', 'A', 'replace');
+    const out = (await store.injectInto(req())) as ProviderRequest;
+    expect(out.system).toContain('<user-model>');
+  });
+
+  it('is idempotent: skips when a <user-model> block is already present', async () => {
+    const store = newStore();
+    await store.update('identity', 'A', 'replace');
+    const first = (await store.injectInto(req('BASE'))) as ProviderRequest;
+    // Re-entering with the already-injected system must NOT double-inject.
+    const second = await store.injectInto(first);
+    expect(second).toBeUndefined();
+    // Only one opening delimiter present.
+    expect(first.system!.match(/<user-model>/g)).toHaveLength(1);
+  });
+
+  it('returns the request unchanged when parsing/reading throws', async () => {
+    const store = newStore();
+    await store.update('identity', 'A', 'replace');
+    vi.spyOn(fs, 'readFile').mockRejectedValueOnce(new Error('disk on fire'));
+    expect(await store.injectInto(req('BASE'))).toBeUndefined();
+  });
+});
+
+// ── the tool ─────────────────────────────────────────────────────────────────
+
+describe('userModelTool', () => {
+  it('is prompt-permissioned and isolated to the memory dir', () => {
+    const tool = userModelTool(newStore());
+    expect(tool.name).toBe('memory_update_user_model');
+    expect(tool.permission).toEqual({ action: 'prompt' });
+    expect(tool.isolation?.capabilities?.fs?.write).toEqual(['~/.moxxy/memory/**']);
+    expect(tool.isolation?.capabilities?.net).toEqual({ mode: 'none' });
+  });
+
+  it('rejects an out-of-enum section and over-long content', () => {
+    const schema = userModelTool(newStore()).inputSchema;
+    expect(schema.safeParse({ section: 'identity', content: 'ok' }).success).toBe(true);
+    expect(schema.safeParse({ section: 'unknown', content: 'ok' }).success).toBe(false);
+    expect(schema.safeParse({ section: 'identity', content: 'x'.repeat(2001) }).success).toBe(false);
+  });
+
+  it("defaults mode to 'replace'", () => {
+    const schema = userModelTool(newStore()).inputSchema;
+    const parsed = schema.parse({ section: 'identity', content: 'A' });
+    expect(parsed.mode).toBe('replace');
+  });
+
+  it('writes through to the file and creates the template', async () => {
+    const store = newStore();
+    const tool = userModelTool(store);
+    const out = (await tool.handler(
+      { section: 'identity', content: 'Alex', mode: 'replace' },
+      {} as never,
+    )) as { section: string; mode: string; path: string };
+    expect(out.section).toBe('identity');
+    expect((await store.load())?.sections.find((s) => s.title === 'Identity')?.content).toBe('Alex');
+    const raw = await fs.readFile(modelPath(), 'utf8');
+    expect(raw).toContain('<!-- moxxy user model');
+  });
+});

--- a/packages/plugin-memory/src/user-model.ts
+++ b/packages/plugin-memory/src/user-model.ts
@@ -1,0 +1,293 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import {
+  z,
+  defineTool,
+  createMutex,
+  type Mutex,
+  type ProviderRequest,
+  type ToolDef,
+} from '@moxxy/sdk';
+import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
+
+/**
+ * The persistent USER MODEL — `~/.moxxy/memory/user-model.md`.
+ *
+ * A single, first-class Markdown file holding DURABLE facts about who the user
+ * is and how they work. Unlike episodic long-term memories (one file each,
+ * recalled on demand), the user model is ALWAYS injected into the system prompt
+ * as a delimited `<user-model>` block, and is updated ONLY through the
+ * deliberate, permission-prompted `memory_update_user_model` tool — never
+ * silently written by the loop.
+ *
+ * The file is a small set of fixed H2 sections (Identity / Preferences /
+ * Workflows / Context). Unknown sections a user hand-adds are parsed and
+ * preserved verbatim on the next write.
+ */
+
+// ── Block delimiters (also the idempotence sentinel) ────────────────────────
+export const USER_MODEL_OPEN = '<user-model>';
+export const USER_MODEL_CLOSE = '</user-model>';
+
+/**
+ * Hard cap on the injected block body. The block rides EVERY provider call, so
+ * an unbounded user model would silently inflate every request. When the
+ * rendered sections exceed this, whole sections are dropped oldest-last (from
+ * the bottom) and a `(truncated)` marker is appended.
+ */
+export const MAX_INJECTED_CHARS = 4000;
+
+/** The four fixed sections, in canonical order. */
+export const FIXED_SECTIONS = ['Identity', 'Preferences', 'Workflows', 'Context'] as const;
+
+/** Lowercase tool-facing section keys → canonical H2 titles. */
+export const SECTION_TITLES: Record<UserModelSectionKey, string> = {
+  identity: 'Identity',
+  preferences: 'Preferences',
+  workflows: 'Workflows',
+  context: 'Context',
+};
+
+export type UserModelSectionKey = 'identity' | 'preferences' | 'workflows' | 'context';
+export type UserModelUpdateMode = 'replace' | 'append';
+
+export interface UserModelSection {
+  readonly title: string;
+  content: string;
+}
+
+export interface UserModel {
+  /** Text before the first `## ` heading (kept verbatim — holds the template comment). */
+  preamble: string;
+  sections: UserModelSection[];
+}
+
+/** The commented template written when the file is first created. */
+const TEMPLATE_PREAMBLE = `<!-- moxxy user model — durable facts about who the user is and how they work.
+     This file is ALWAYS injected into the system prompt and is updated ONLY via the
+     permission-prompted memory_update_user_model tool. Keep entries terse and stable. -->`;
+
+function templateModel(): UserModel {
+  return {
+    preamble: TEMPLATE_PREAMBLE,
+    sections: FIXED_SECTIONS.map((title) => ({ title, content: '' })),
+  };
+}
+
+// ── parse / serialize (round-trips unknown sections) ─────────────────────────
+
+const HEADING_RE = /^##\s+(.+?)\s*$/;
+
+/**
+ * Parse the user-model Markdown into a preamble + ordered H2 sections. Any
+ * section title is preserved (not just the fixed four), so a user's hand-added
+ * `## Notes` survives the next tool write.
+ */
+export function parseUserModel(text: string): UserModel {
+  const preambleLines: string[] = [];
+  const sections: UserModelSection[] = [];
+  let current: { title: string; body: string[] } | null = null;
+  let seenHeading = false;
+
+  for (const line of text.split('\n')) {
+    const m = HEADING_RE.exec(line);
+    if (m) {
+      seenHeading = true;
+      if (current) sections.push({ title: current.title, content: current.body.join('\n').trim() });
+      current = { title: m[1]!.trim(), body: [] };
+    } else if (!seenHeading) {
+      preambleLines.push(line);
+    } else if (current) {
+      current.body.push(line);
+    }
+  }
+  if (current) sections.push({ title: current.title, content: current.body.join('\n').trim() });
+  return { preamble: preambleLines.join('\n').trim(), sections };
+}
+
+/** Serialize back to Markdown, preserving the preamble and every section. */
+export function serializeUserModel(model: UserModel): string {
+  const parts: string[] = [];
+  if (model.preamble.trim()) parts.push(model.preamble.trim());
+  for (const s of model.sections) {
+    const content = s.content.trim();
+    parts.push(content ? `## ${s.title}\n\n${content}` : `## ${s.title}`);
+  }
+  return parts.join('\n\n') + '\n';
+}
+
+/**
+ * Render the injected block body from a model, capped at {@link MAX_INJECTED_CHARS}.
+ * Empty sections are omitted. When the cap is hit, whole sections are dropped
+ * from the bottom (oldest-last) and a `(truncated)` marker is appended. Returns
+ * `''` when there is no non-empty content to inject.
+ */
+export function renderInjectionBody(model: UserModel, max: number = MAX_INJECTED_CHARS): string {
+  const chunks: string[] = [];
+  let used = 0;
+  let truncated = false;
+  for (const s of model.sections) {
+    const content = s.content.trim();
+    if (!content) continue;
+    const chunk = `## ${s.title}\n${content}`;
+    const cost = (chunks.length > 0 ? 2 : 0) + chunk.length; // 2 for the "\n\n" join
+    if (used + cost > max) {
+      truncated = true;
+      break;
+    }
+    chunks.push(chunk);
+    used += cost;
+  }
+  if (chunks.length === 0) return '';
+  return chunks.join('\n\n') + (truncated ? '\n\n(truncated)' : '');
+}
+
+function isEnoent(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: string }).code === 'ENOENT';
+}
+
+/** Default on-disk location: `~/.moxxy/memory/user-model.md` (MOXXY_HOME-aware). */
+export function defaultUserModelPath(): string {
+  return moxxyPath('memory', 'user-model.md');
+}
+
+/**
+ * The user-model store. One instance per plugin build; the injection hook and
+ * the update tool close over the same instance. `load()` is mtime-cached so the
+ * always-on injection does zero `readFile`s when the file is unchanged (a single
+ * `stat` per provider call); `update()` does an atomic read-modify-write under a
+ * mutex.
+ */
+export class UserModelStore {
+  readonly path: string;
+  private readonly mutex: Mutex = createMutex();
+  private cached: { mtimeMs: number; model: UserModel } | null = null;
+
+  /** @param dir the memory directory (defaults to `~/.moxxy/memory`). */
+  constructor(dir?: string) {
+    this.path = join(dir ?? moxxyPath('memory'), 'user-model.md');
+  }
+
+  /**
+   * mtime-cached load. Returns `null` when the file is absent. On an unchanged
+   * file this only `stat`s — no `readFile` — so it's cheap to call on every
+   * provider request.
+   */
+  async load(): Promise<UserModel | null> {
+    let mtimeMs: number;
+    try {
+      mtimeMs = (await fs.stat(this.path)).mtimeMs;
+    } catch (err) {
+      if (isEnoent(err)) {
+        this.cached = null;
+        return null;
+      }
+      throw err;
+    }
+    if (this.cached && this.cached.mtimeMs === mtimeMs) return this.cached.model;
+    const model = parseUserModel(await fs.readFile(this.path, 'utf8'));
+    this.cached = { mtimeMs, model };
+    return model;
+  }
+
+  /** Raw file text (or `null` when absent) — used by the CLI viewer. */
+  async readRaw(): Promise<string | null> {
+    try {
+      return await fs.readFile(this.path, 'utf8');
+    } catch (err) {
+      if (isEnoent(err)) return null;
+      throw err;
+    }
+  }
+
+  /**
+   * Set (`replace`) or extend (`append`) one section, atomically. Creates the
+   * file with the commented template on first write. Bypasses the mtime cache
+   * on read so a concurrent external edit is not clobbered, and invalidates the
+   * cache after the write.
+   */
+  async update(section: UserModelSectionKey, content: string, mode: UserModelUpdateMode): Promise<UserModel> {
+    const title = SECTION_TITLES[section];
+    return this.mutex.run(async () => {
+      const model = (await this.readDisk()) ?? templateModel();
+      let sec = model.sections.find((s) => s.title.toLowerCase() === title.toLowerCase());
+      if (!sec) {
+        sec = { title, content: '' };
+        model.sections.push(sec);
+      }
+      const incoming = content.trim();
+      const prior = sec.content.trim();
+      sec.content = mode === 'append' && prior ? `${prior}\n${incoming}`.trim() : incoming;
+      await writeFileAtomic(this.path, serializeUserModel(model));
+      this.cached = null; // next load() re-reads the fresh file
+      return model;
+    });
+  }
+
+  /** Uncached disk read (used inside the update RMW). */
+  private async readDisk(): Promise<UserModel | null> {
+    const raw = await this.readRaw();
+    return raw === null ? null : parseUserModel(raw);
+  }
+
+  /**
+   * The always-on injection: prepend a delimited `<user-model>` block to
+   * `req.system`. Returns the request unchanged (void) when the file is absent
+   * or has no non-empty content, when a `<user-model>` block is already present
+   * (side-channel calls re-enter this hook — inject exactly once), or on ANY
+   * error (injection must never break a provider call).
+   */
+  async injectInto(req: ProviderRequest): Promise<ProviderRequest | void> {
+    try {
+      if ((req.system ?? '').includes(USER_MODEL_OPEN)) return; // idempotent
+      const model = await this.load();
+      if (!model) return;
+      const body = renderInjectionBody(model);
+      if (!body) return;
+      const block =
+        `${USER_MODEL_OPEN}\n${body}\n${USER_MODEL_CLOSE}\n` +
+        'The block above is durable context about the user, maintained across sessions via the ' +
+        '`memory_update_user_model` tool. Treat it as reliable background on who the user is and how they work.';
+      return { ...req, system: `${block}\n\n${req.system ?? ''}`.trimEnd() };
+    } catch {
+      return; // any parse/fs error → leave the request untouched
+    }
+  }
+}
+
+// ── the update tool ──────────────────────────────────────────────────────────
+
+const sectionSchema = z.enum(['identity', 'preferences', 'workflows', 'context']);
+
+/**
+ * `memory_update_user_model` — the ONLY writer of the persistent user model.
+ * Permission-prompted like `memory_save`, and isolated to the memory dir.
+ */
+export function userModelTool(store: UserModelStore): ToolDef {
+  return defineTool({
+    name: 'memory_update_user_model',
+    description:
+      'Update the persistent USER MODEL (~/.moxxy/memory/user-model.md), which is ALWAYS injected ' +
+      'into your system prompt. PREFER this over memory_save for durable facts about WHO THE USER IS ' +
+      "and HOW THEY WORK — their identity, standing preferences, personal workflows, and lasting context — " +
+      'NOT for episodic facts (use memory_save for a one-off answer or project detail). ' +
+      "mode 'replace' overwrites the section; 'append' adds to it. Keep each section terse.",
+    inputSchema: z.object({
+      section: sectionSchema,
+      content: z.string().max(2000),
+      mode: z.enum(['replace', 'append']).default('replace'),
+    }),
+    permission: { action: 'prompt' },
+    isolation: {
+      capabilities: {
+        fs: { read: ['~/.moxxy/memory/**'], write: ['~/.moxxy/memory/**'] },
+        net: { mode: 'none' },
+        timeMs: 5_000,
+      },
+    },
+    handler: async ({ section, content, mode }) => {
+      await store.update(section, content, mode);
+      return { section, mode, path: store.path };
+    },
+  });
+}

--- a/packages/reflector-default/src/index.test.ts
+++ b/packages/reflector-default/src/index.test.ts
@@ -20,6 +20,7 @@ import type { Session } from '@moxxy/core';
 import {
   REFLECT_MIN_ITERATIONS,
   REFLECT_MIN_TOOL_RESULTS,
+  REFLECT_SYSTEM_PROMPT,
   buildReflectorPlugin,
   buildTurnDigest,
   parseReflectionReply,
@@ -229,6 +230,16 @@ describe('parseReflectionReply', () => {
   it('returns [] for a non-array and an empty array', () => {
     expect(parseReflectionReply('{"kind":"memory"}')).toEqual([]);
     expect(parseReflectionReply('[]')).toEqual([]);
+  });
+});
+
+// ── REFLECT_SYSTEM_PROMPT (the strategy prompt) ─────────────────────────────
+
+describe('REFLECT_SYSTEM_PROMPT', () => {
+  it('points durable user-trait memories at memory_update_user_model', () => {
+    expect(REFLECT_SYSTEM_PROMPT).toContain('memory_update_user_model');
+    // still steers episodic facts to memory_save
+    expect(REFLECT_SYSTEM_PROMPT).toContain('memory_save');
   });
 });
 

--- a/packages/reflector-default/src/index.ts
+++ b/packages/reflector-default/src/index.ts
@@ -56,6 +56,8 @@ Look for exactly two things:
 
 Be strict. Most turns warrant NOTHING. Never propose transient chit-chat, one-off values, or things already obvious from context.
 
+When a "memory" proposal is really about WHO THE USER IS or HOW THEY WORK — a stable identity detail, a standing preference, or a personal workflow — say so in the nudge and suggest the assistant record it with \`memory_update_user_model\` (the persistent user model) rather than \`memory_save\`, which is for episodic facts.
+
 Output ONLY a JSON array with 0, 1, or 2 items — no prose, no code fences. Each item:
   { "kind": "memory" | "skill", "title": "<= 80 chars", "nudge": "one paragraph addressed to the assistant, suggesting it consider saving this" }
 Return [] when nothing is worth proposing.`;


### PR DESCRIPTION
## Persistent user model

A first-class **user model** at `~/.moxxy/memory/user-model.md` — durable facts about *who the user is* and *how they work* — that is ALWAYS injected into the system prompt and updated only through a deliberate, permission-prompted tool. It lives inside `@moxxy/plugin-memory` (which owns `~/.moxxy/memory`), alongside the episodic long-term store.

### Injection contract
On **every** provider call, `@moxxy/plugin-memory`'s `onBeforeProviderCall` prepends a delimited block to `req.system`:

```
<user-model>
## Identity
…
## Preferences
…
</user-model>
The block above is durable context about the user, maintained across sessions via the `memory_update_user_model` tool. Treat it as reliable background on who the user is and how they work.

<existing system prompt…>
```

- **Format**: an opening `<user-model>` / closing `</user-model>` delimiter wrapping the non-empty H2 sections, followed by a one-line note pointing the model at the update tool.
- **Cap**: the rendered body is capped at **4000 chars**; over the cap, whole sections are dropped oldest-last (from the bottom) with a `(truncated)` marker.
- **Idempotence**: skipped entirely when `req.system` already contains `<user-model>`, so side-channel calls that re-enter the hook never double-inject.
- **Fail-safe**: any parse/fs error returns the request unchanged — injection can never break a provider call.
- **Cheap**: `loadUserModel()` is mtime-cached per process — the always-on path does a single `stat` and zero `readFile`s when the file is unchanged. No-op (returns void) when the file is absent or holds only the empty template.

### Update only via a prompted tool
`memory_update_user_model` is the ONLY writer. `inputSchema { section: enum(identity|preferences|workflows|context), content: string(≤2000), mode: enum(replace|append)=replace }`, `permission: { action: 'prompt' }`, isolation mirroring `memory_save` (fs `~/.moxxy/memory/**`, net none). Its model-facing description tells the agent to PREFER it over `memory_save` for durable identity/preference/workflow facts (not episodic ones). First write creates the file with a commented template of the four fixed sections; hand-added unknown sections are parsed and preserved verbatim across writes. Writes are atomic (`writeFileAtomic`) under a per-instance mutex.

### Reflector tie-in (minimal)
`@moxxy/reflector-default`'s reflection system prompt now instructs that when a "memory" proposal is really about who the user is / how they work, the nudge should suggest `memory_update_user_model` rather than `memory_save`. Only the prompt string and its test expectation changed.

### CLI
`moxxy memory user-model` prints the current file, or a `(none yet)` hint when it doesn't exist yet.

### Prompt-cache note
The injected block is stable for the duration of a session (it only changes when the tool writes the file, which is rare and deliberate), so it participates in the provider prompt cache as a fixed prefix — a one-time cache write, then cache hits for the rest of the session. Because it's *prepended* it sits at the front of `system`, keeping the cacheable prefix contiguous.

### Gate
`pnpm build` ✅ · `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm test` ✅ · `pnpm check:deps` ✅ — all green. New tests: 24 in `plugin-memory` (store round-trip incl. unknown-section preservation, mtime-cache read/invalidation, size-cap truncation, injection once/idempotent/absent/error, tool replace/append + template creation, schema/permission/isolation), +1 reflector prompt-string assertion, +2 CLI subcommand tests.
