### PR TITLE
feat(mobile): over-the-air (OTA) updates via EAS Update

### DIFF
--- a/.changeset/mobile-ota-updates.md
+++ b/.changeset/mobile-ota-updates.md
@@ -1,0 +1,19 @@
+---
+'@moxxy/workspaces-app': minor
+---
+
+Over-the-air (OTA) updates for the Expo mobile app via EAS Update. The whole JS
+bundle + assets can now ship without an App Store / Play Store review.
+
+- `expo-updates` wired in: `updates.url` derived from the resolved EAS project id
+  in `app.config.ts`, `runtimeVersion` on the `appVersion` policy, `preview` /
+  `production` update channels stamped on the eas.json build profiles, and the
+  committed iOS `Expo.plist` flipped on.
+- A generic in-app update mechanism: the pure `reduceOta` state machine
+  (`src/otaUpdates.ts`) driving `useOtaUpdates`, mounted headlessly via
+  `<OtaUpdateController/>`. It checks on launch and on every foreground,
+  downloads silently, and applies the new bundle on the next activation. Dormant
+  in Expo Go, dev, and web.
+- A manual-trigger CI job (`.github/workflows/mobile-eas-update.yml`) that builds
+  the workspace deps, typechecks + tests the app, and publishes `eas update` to a
+  chosen channel.

--- a/.github/workflows/mobile-eas-update.yml
+++ b/.github/workflows/mobile-eas-update.yml
@@ -1,0 +1,128 @@
+name: Mobile EAS Update (OTA)
+
+# Publish an over-the-air (OTA) update of the Expo mobile app — apps/mobile — to
+# an EAS Update channel, so the JS bundle + assets reach installed apps WITHOUT
+# waiting for an App Store / Play Store review.
+#
+# What OTA can and cannot ship:
+#   • JS, TypeScript, React components, images and other bundled assets  → YES
+#   • New native code / native modules / permissions / app icon / SDK bump → NO
+#     (those change the runtime version — see `runtimeVersion` in app.json — and
+#      require a fresh `eas build` + store release; this workflow won't reach
+#      those builds until they're rebuilt.)
+#
+# Channels ↔ branches: each `eas build` profile in eas.json is stamped with a
+# channel (`preview`, `production`). This job publishes to the EAS *branch* of
+# the same name, which those channels point to — so a `production` build picks
+# up `production` updates, a `preview` build picks up `preview` updates.
+#
+# Secrets (identical to Mobile EAS Build — nothing about the account is committed):
+#   EXPO_TOKEN       - Expo access token (the real secret) — used by eas-cli.
+#   EXPO_OWNER       - Expo account/org username (the project owner).
+#   EAS_PROJECT_ID   - the EAS project UUID.
+#
+# Trigger manually from the Actions tab; pick the channel, platform, and message.
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Update channel (which installed builds receive it)
+        type: choice
+        options: [preview, production]
+        default: preview
+      platform:
+        description: Platform to publish for
+        type: choice
+        options: [all, ios, android]
+        default: all
+      message:
+        description: Update message (defaults to the commit if left blank)
+        type: string
+        required: false
+        default: ''
+      skip_checks:
+        description: Skip typecheck + tests before publishing (emergency only)
+        type: boolean
+        default: false
+
+concurrency:
+  # Serialize per channel so two publishes to the same channel can't race.
+  group: mobile-eas-update-${{ inputs.channel }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    name: EAS update (${{ inputs.channel }} / ${{ inputs.platform }})
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mobile
+    env:
+      # Injected into app.config.ts so the account identity is never committed.
+      # app.config.ts also derives the EAS Update URL from EAS_PROJECT_ID.
+      EXPO_OWNER: ${{ secrets.EXPO_OWNER }}
+      EAS_PROJECT_ID: ${{ secrets.EAS_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.0
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: pnpm
+
+      # Install the whole workspace (the mobile app pulls in @moxxy/client-core,
+      # @moxxy/client-transport-ws, etc. as workspace deps).
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: ${{ github.workspace }}
+
+      - name: Guard required secrets
+        run: |
+          if [ -z "${EXPO_OWNER}" ] || [ -z "${EAS_PROJECT_ID}" ]; then
+            echo "::error::Set the EXPO_OWNER and EAS_PROJECT_ID repository secrets (and EXPO_TOKEN) before running this workflow."
+            exit 1
+          fi
+
+      # `eas update` bundles the JS locally (unlike `eas build`, which runs the
+      # post-install on EAS servers). Metro resolves the @moxxy/* workspace deps
+      # from their built `dist`, so they must be compiled first.
+      - name: Build workspace dependencies
+        run: pnpm --filter "@moxxy/workspaces-app^..." run build
+        working-directory: ${{ github.workspace }}
+
+      # OTA updates skip store review, so gate them on the app's own checks by
+      # default. `skip_checks` is an emergency escape hatch.
+      - name: Typecheck & test mobile app
+        if: ${{ !inputs.skip_checks }}
+        run: pnpm --filter "@moxxy/workspaces-app" run typecheck && pnpm --filter "@moxxy/workspaces-app" run test
+        working-directory: ${{ github.workspace }}
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Publish EAS update
+        run: |
+          MSG="${{ inputs.message }}"
+          if [ -z "$MSG" ]; then
+            MSG="Manual OTA update from ${GITHUB_SHA::7}"
+          fi
+          echo "Publishing to branch/channel '${{ inputs.channel }}' (${{ inputs.platform }}): $MSG"
+          eas update \
+            --non-interactive \
+            --branch "${{ inputs.channel }}" \
+            --platform "${{ inputs.platform }}" \
+            --message "$MSG"

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -209,6 +209,19 @@ or recorded-on-purpose decision.
   `apps/mobile/src/hooks/useMoxxyLiveActivity.ts`,
   `apps/mobile/ios/MoxxyMobileGateway/MoxxyLiveActivity.swift`.
 
+- [note, mobile, OTA] EAS Update runtime version uses the `appVersion` policy
+  (not `fingerprint`) because iOS native is COMMITTED (`apps/mobile/ios/` holds
+  custom Live Activity Swift, so no full CNG). The consequence: the iOS runtime
+  version + updates URL live STATICALLY in `ios/.../Supporting/Expo.plist`
+  (`EXUpdatesRuntimeVersion=1.0.0`, `EXUpdatesEnabled`, `EXUpdatesURL`), so when
+  you bump `version` in `app.json` for a native release you MUST also update that
+  plist (or re-run `expo prebuild -p ios`) or iOS builds silently stop matching
+  their OTA channel. Android is CNG and reconfigured by EAS automatically, so it
+  doesn't have this hazard. Recorded on purpose; revisit if the committed iOS
+  project is ever replaced by prebuild-on-build.
+  `apps/mobile/app.json`, `apps/mobile/app.config.ts`,
+  `apps/mobile/ios/MoxxyMobileGateway/Supporting/Expo.plist`.
+
 ## Runner / protocol & architecture
 
 - [note, dry] Three inline backoff/retry implementations remain ON PURPOSE and must

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -51,3 +51,65 @@ eas build --profile preview --platform all
 
 Build profiles live in `eas.json`. If `EAS_PROJECT_ID` is unset, `eas` falls
 back to interactive `eas init` to link/create a project under your account.
+
+## Over-the-air updates (EAS Update)
+
+The whole JS/TypeScript bundle and its assets can be shipped **over-the-air** with
+[EAS Update](https://docs.expo.dev/eas-update/introduction/) — no App Store /
+Play Store review, updates land the next time the app is opened. This covers
+everything that isn't native: React components, screens, business logic, images,
+copy, styling, bug fixes.
+
+**What OTA cannot ship:** native code / native modules, new permissions, the app
+icon or splash, or an Expo SDK bump. Those change the **runtime version** and
+require a fresh `eas build` + store release. See _Runtime versions_ below.
+
+### How it's wired
+
+| Piece | Where |
+| ----- | ----- |
+| `expo-updates` config (`updates.url`, `runtimeVersion`) | `app.json` + derived URL in `app.config.ts` |
+| Update channels per build profile (`preview`, `production`) | `eas.json` → `build.*.channel` |
+| Native enable flags (iOS is committed) | `ios/.../Supporting/Expo.plist` |
+| In-app "check → download → apply on next open" | `src/otaUpdates.ts` + `useOtaUpdates` + `<OtaUpdateController/>` (mounted in `app/_layout.tsx`) |
+| Manual publish CI job | `.github/workflows/mobile-eas-update.yml` |
+
+The `<OtaUpdateController/>` mounted at the root checks for an update on launch
+and on every return to the foreground, downloads it silently, and applies it the
+next time the app becomes active — so a fresh bundle boots in without interrupting
+whoever is using the app. All the decision logic is the pure `reduceOta` state
+machine in `src/otaUpdates.ts`; the flow is dormant in Expo Go, in dev, and on
+web. To add a visible "update ready" banner later, read `useOtaUpdates()`.
+
+### Publish an update from CI
+
+Run the **Mobile EAS Update (OTA)** workflow from the Actions tab
+(`.github/workflows/mobile-eas-update.yml`) — pick the **channel** (`preview` /
+`production`), platform, and a message. It builds the workspace deps, typechecks
+and tests the app (OTA skips store review, so this gate is on by default —
+`skip_checks` bypasses it for emergencies), then runs `eas update`. The update is
+published to the EAS branch of the same name as the channel, so a build made with
+that channel picks it up.
+
+> First-time setup: run **Mobile EAS Build** once per channel (e.g. a
+> `production` build) so EAS creates the channel and links it to its branch.
+> After that, OTA publishes flow to installed builds on that channel.
+
+### Publish an update locally
+
+```sh
+cd apps/mobile
+pnpm --filter "@moxxy/workspaces-app^..." run build   # build workspace deps first
+export EXPO_TOKEN=...                                  # or `eas login`
+eas update --branch preview --message "Fix chat scroll"
+```
+
+### Runtime versions
+
+`runtimeVersion` uses the `appVersion` policy, so the runtime version is the app
+`version` in `app.json` (currently `1.0.0`). An OTA update only reaches builds
+whose runtime version matches. **Bump `version` whenever you ship a native change**
+(new native module, permission, SDK bump) and cut a new `eas build` — this starts
+a fresh runtime line so old builds don't receive a bundle that needs native code
+they don't have. For iOS, the committed `Expo.plist`'s `EXUpdatesRuntimeVersion`
+must match; re-run `expo prebuild -p ios` (or edit it) when you bump the version.

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -20,7 +20,14 @@ import type { ConfigContext, ExpoConfig } from 'expo/config';
  */
 export default ({ config }: ConfigContext): ExpoConfig => {
   const owner = process.env.EXPO_OWNER?.trim();
-  const projectId = process.env.EAS_PROJECT_ID?.trim();
+  const envProjectId = process.env.EAS_PROJECT_ID?.trim();
+
+  // Resolve the EAS project id from the env override first, then the value
+  // committed in app.json (`extra.eas.projectId`). It drives both `eas build`'s
+  // project link and the EAS Update (OTA) endpoint derived below.
+  const committedProjectId =
+    typeof config.extra?.eas?.projectId === 'string' ? config.extra.eas.projectId : undefined;
+  const projectId = envProjectId || committedProjectId;
 
   return {
     ...config,
@@ -36,5 +43,18 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       // committed.
       ...(projectId ? { eas: { projectId } } : {}),
     },
+    // EAS Update (OTA) endpoint. The static `updates` knobs (enabled /
+    // checkAutomatically / fallbackToCacheTimeout) and the `runtimeVersion`
+    // policy live in app.json; only the account-specific URL is injected here so
+    // it always tracks the resolved project id. Without a project id (plain
+    // `expo start`) OTA is simply left unconfigured.
+    ...(projectId
+      ? {
+          updates: {
+            ...config.updates,
+            url: `https://u.expo.dev/${projectId}`,
+          },
+        }
+      : {}),
   };
 };

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,10 +2,19 @@
   "expo": {
     "name": "Moxxy Mobile",
     "slug": "workspaces",
+    "version": "1.0.0",
     "scheme": "moxxy-mobile",
     "icon": "./assets/icon.png",
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
+    "updates": {
+      "enabled": true,
+      "checkAutomatically": "ON_LOAD",
+      "fallbackToCacheTimeout": 0
+    },
     "platforms": [
       "ios",
       "android",

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -2,6 +2,7 @@ import { Stack } from 'expo-router';
 import { LogBox } from 'react-native';
 import { GatewayProvider } from '@/hooks/useGatewayStore';
 import { MoxxyLiveActivityController } from '@/components/MoxxyLiveActivityController';
+import { OtaUpdateController } from '@/components/OtaUpdateController';
 import { ThemeProvider, ThemedStatusBar, useTheme } from '@/theme/ThemeProvider';
 
 LogBox.ignoreLogs(['props.pointerEvents is deprecated. Use style.pointerEvents']);
@@ -10,6 +11,7 @@ export default function Layout() {
   return (
     <ThemeProvider>
       <GatewayProvider>
+        <OtaUpdateController />
         <MoxxyLiveActivityController />
         <ThemedStatusBar />
         <RootStack />

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -10,12 +10,14 @@
     },
     "preview": {
       "distribution": "internal",
+      "channel": "preview",
       "ios": {
         "simulator": false
       }
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "channel": "production"
     }
   },
   "submit": {

--- a/apps/mobile/ios/MoxxyMobileGateway/Supporting/Expo.plist
+++ b/apps/mobile/ios/MoxxyMobileGateway/Supporting/Expo.plist
@@ -5,8 +5,12 @@
     <key>EXUpdatesCheckOnLaunch</key>
     <string>ALWAYS</string>
     <key>EXUpdatesEnabled</key>
-    <false/>
+    <true/>
     <key>EXUpdatesLaunchWaitMs</key>
     <integer>0</integer>
+    <key>EXUpdatesRuntimeVersion</key>
+    <string>1.0.0</string>
+    <key>EXUpdatesURL</key>
+    <string>https://u.expo.dev/2a4d11ff-92b2-48e0-99d8-2bab5a637a10</string>
   </dict>
 </plist>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -35,6 +35,7 @@
     "expo-router": "~6.0.24",
     "expo-secure-store": "~15.0.8",
     "expo-status-bar": "~3.0.9",
+    "expo-updates": "~29.0.18",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-native": "^0.81.5",

--- a/apps/mobile/src/components/OtaUpdateController.tsx
+++ b/apps/mobile/src/components/OtaUpdateController.tsx
@@ -1,0 +1,14 @@
+import { useOtaUpdates } from '@/hooks/useOtaUpdates';
+
+/**
+ * Headless controller that keeps the app's JS bundle current over-the-air.
+ *
+ * Mounted once at the root (see `app/_layout.tsx`), alongside the other
+ * app-wide controllers. It renders nothing — updates are downloaded silently
+ * and applied on the next foreground. Surface `useOtaUpdates()` in a banner if
+ * you ever want a visible "update ready" affordance.
+ */
+export function OtaUpdateController() {
+  useOtaUpdates();
+  return null;
+}

--- a/apps/mobile/src/hooks/useOtaUpdates.ts
+++ b/apps/mobile/src/hooks/useOtaUpdates.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AppState, Platform } from 'react-native';
+import * as Updates from 'expo-updates';
+
+import {
+  initialOtaState,
+  otaUpdatesActive,
+  reduceOta,
+  type OtaEvent,
+  type OtaState,
+} from '@/otaUpdates';
+
+export interface UseOtaUpdatesResult {
+  /** current lifecycle status — drive an optional UI surface off this */
+  status: OtaState['status'];
+  /** an update has downloaded and will apply on the next activation */
+  pending: boolean;
+  /** false in Expo Go / dev / web — the whole mechanism is dormant */
+  isActive: boolean;
+  /** force a check now (applies immediately if an update is already downloaded) */
+  checkNow: () => void;
+  /** apply a downloaded update immediately by reloading the JS bundle */
+  reloadNow: () => void;
+}
+
+/**
+ * Drives EAS Update over-the-air delivery for the whole app.
+ *
+ * On launch and on every return to the foreground it asks the EAS Update server
+ * for a newer JS bundle, downloads it, and applies it the next time the app
+ * becomes active. All the decision logic lives in the pure `reduceOta` state
+ * machine (`src/otaUpdates.ts`); this hook is only the `expo-updates` adapter.
+ *
+ * It is a complete no-op in Expo Go, in dev (Metro owns the bundle), and on the
+ * web — see `otaUpdatesActive`.
+ */
+export function useOtaUpdates(): UseOtaUpdatesResult {
+  const isActive = otaUpdatesActive({
+    isEnabled: Updates.isEnabled,
+    isDev: __DEV__,
+    isWeb: Platform.OS === 'web',
+  });
+
+  const [state, setState] = useState<OtaState>(initialOtaState);
+  const stateRef = useRef(state);
+  // Guards against overlapping async check/download chains (e.g. a manual
+  // `checkNow` landing while a foreground-triggered check is still running).
+  const runningRef = useRef(false);
+
+  const apply = useCallback((event: OtaEvent) => {
+    const { state: next, action } = reduceOta(stateRef.current, event);
+    stateRef.current = next;
+    setState(next);
+    return action;
+  }, []);
+
+  const trigger = useCallback(
+    async (event: OtaEvent) => {
+      if (!isActive || runningRef.current) return;
+      runningRef.current = true;
+      try {
+        let action = apply(event);
+        // Walk the action chain the reducer hands back until it settles.
+        while (action !== 'none') {
+          if (action === 'reload') {
+            await Updates.reloadAsync();
+            return; // the JS runtime is about to restart
+          }
+          if (action === 'check') {
+            const result = await Updates.checkForUpdateAsync();
+            action = apply({ type: 'checked', available: result.isAvailable });
+          } else if (action === 'download') {
+            await Updates.fetchUpdateAsync();
+            action = apply({ type: 'downloaded', ok: true });
+          }
+        }
+      } catch {
+        // Network hiccup / server error — recorded as an error and retried on
+        // the next activation. Never surfaced as a crash.
+        apply({ type: 'failed' });
+      } finally {
+        runningRef.current = false;
+      }
+    },
+    [apply, isActive],
+  );
+
+  // Check once on mount (a warm start where the native ON_LOAD check may have
+  // already run) — the reducer no-ops if nothing is available.
+  useEffect(() => {
+    void trigger({ type: 'app-active' });
+  }, [trigger]);
+
+  // Re-check on every background → foreground transition, and apply a pending
+  // update at that moment so a fresh bundle boots without interrupting use.
+  useEffect(() => {
+    if (!isActive) return;
+    const appState = { current: AppState.currentState };
+    const subscription = AppState.addEventListener('change', (next) => {
+      const previous = appState.current;
+      appState.current = next;
+      if (next === 'active' && previous !== 'active') {
+        void trigger({ type: 'app-active' });
+      }
+    });
+    return () => subscription.remove();
+  }, [isActive, trigger]);
+
+  const checkNow = useCallback(() => {
+    void trigger({ type: 'app-active' });
+  }, [trigger]);
+
+  const reloadNow = useCallback(() => {
+    if (!isActive) return;
+    void Updates.reloadAsync().catch(() => {
+      // A failed reload is non-fatal: the downloaded update still applies on the
+      // next cold launch via the native ON_LOAD check.
+    });
+  }, [isActive]);
+
+  return { status: state.status, pending: state.pending, isActive, checkNow, reloadNow };
+}

--- a/apps/mobile/src/otaUpdates.ts
+++ b/apps/mobile/src/otaUpdates.ts
@@ -1,0 +1,133 @@
+/**
+ * Over-the-air (OTA) update state machine.
+ *
+ * This is the platform-agnostic brain of the app's EAS Update integration. It
+ * holds NO React and NO `expo-updates` import so it stays trivially unit
+ * testable; `useOtaUpdates` is the thin adapter that turns the actions below
+ * into real `expo-updates` calls (see `src/hooks/useOtaUpdates.ts`).
+ *
+ * Lifecycle, driven entirely by `reduceOta`:
+ *
+ *   app becomes active ─▶ check ─▶ (available) ─▶ download ─▶ ready(pending)
+ *                                    │                            │
+ *                            (up to date) ─▶ idle                 │
+ *                                                                 ▼
+ *   app becomes active again ────────────────────────────────▶ reload
+ *
+ * A downloaded update is deliberately applied on the *next* activation rather
+ * than mid-session, so a fresh JS bundle boots in without yanking the screen
+ * out from under whoever is using the app right now. (`expo-updates` also
+ * applies it on the next cold launch, so nothing is ever lost.)
+ */
+
+export type OtaStatus =
+  /** nothing in flight, bundle is current (or not yet checked) */
+  | 'idle'
+  /** asking the EAS Update server whether a newer bundle exists */
+  | 'checking'
+  /** a newer bundle exists and is being downloaded */
+  | 'downloading'
+  /** a bundle has been downloaded and is waiting to be applied on next activation */
+  | 'ready'
+  /** the last check or download failed; will retry on the next activation */
+  | 'error';
+
+export interface OtaState {
+  status: OtaStatus;
+  /** true once an update has downloaded and is waiting for a reload */
+  pending: boolean;
+}
+
+/** Side effect the host (the hook) should perform after a transition. */
+export type OtaAction = 'none' | 'check' | 'download' | 'reload';
+
+export type OtaEvent =
+  /** the app came to the foreground (also fired once on mount) */
+  | { type: 'app-active' }
+  /** result of `checkForUpdateAsync` */
+  | { type: 'checked'; available: boolean }
+  /** result of `fetchUpdateAsync` */
+  | { type: 'downloaded'; ok: boolean }
+  /** any `expo-updates` call threw */
+  | { type: 'failed' };
+
+export interface OtaTransition {
+  state: OtaState;
+  action: OtaAction;
+}
+
+export const initialOtaState: OtaState = { status: 'idle', pending: false };
+
+/** True while an async check/download chain is in flight and shouldn't be re-entered. */
+export function otaBusy(state: OtaState): boolean {
+  return state.status === 'checking' || state.status === 'downloading';
+}
+
+/**
+ * Pure transition function: given the current state and an event, return the
+ * next state plus the single side effect the host should run.
+ */
+export function reduceOta(state: OtaState, event: OtaEvent): OtaTransition {
+  switch (event.type) {
+    case 'app-active': {
+      // A previously downloaded update is applied now, on the fresh activation.
+      if (state.pending) {
+        return { state: { status: 'ready', pending: true }, action: 'reload' };
+      }
+      // Don't stack a second check/download on top of one already running.
+      if (otaBusy(state)) {
+        return { state, action: 'none' };
+      }
+      return { state: { status: 'checking', pending: false }, action: 'check' };
+    }
+    case 'checked': {
+      if (event.available) {
+        return { state: { status: 'downloading', pending: false }, action: 'download' };
+      }
+      return { state: { status: 'idle', pending: false }, action: 'none' };
+    }
+    case 'downloaded': {
+      if (event.ok) {
+        // Hold the update; it applies on the next 'app-active'.
+        return { state: { status: 'ready', pending: true }, action: 'none' };
+      }
+      return { state: { status: 'error', pending: false }, action: 'none' };
+    }
+    case 'failed': {
+      return { state: { status: 'error', pending: false }, action: 'none' };
+    }
+  }
+}
+
+export interface OtaEnv {
+  /** `Updates.isEnabled` — false in Expo Go and when no update URL is configured */
+  isEnabled: boolean;
+  /** `__DEV__` — never OTA in development; Metro owns the bundle there */
+  isDev: boolean;
+  /** running under the web platform, where `expo-updates` is a no-op */
+  isWeb: boolean;
+}
+
+/**
+ * Whether the OTA machinery should run at all. Keeping this pure lets the hook
+ * stay a no-op in Expo Go / dev / web without duplicating the condition.
+ */
+export function otaUpdatesActive(env: OtaEnv): boolean {
+  return env.isEnabled && !env.isDev && !env.isWeb;
+}
+
+/** Human-readable label for the current status (for an optional UI surface). */
+export function otaStatusLabel(state: OtaState): string {
+  switch (state.status) {
+    case 'checking':
+      return 'Checking for updates…';
+    case 'downloading':
+      return 'Downloading update…';
+    case 'ready':
+      return 'Update ready — applying on next open';
+    case 'error':
+      return 'Update check failed';
+    case 'idle':
+      return 'Up to date';
+  }
+}

--- a/apps/mobile/test/ota-updates.test.ts
+++ b/apps/mobile/test/ota-updates.test.ts
@@ -1,0 +1,170 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  initialOtaState,
+  otaBusy,
+  otaStatusLabel,
+  otaUpdatesActive,
+  reduceOta,
+  type OtaState,
+} from '../src/otaUpdates';
+
+describe('OTA update reducer', () => {
+  it('starts idle with nothing pending', () => {
+    expect(initialOtaState).toEqual({ status: 'idle', pending: false });
+  });
+
+  it('checks for an update when the app becomes active', () => {
+    const { state, action } = reduceOta(initialOtaState, { type: 'app-active' });
+    expect(action).toBe('check');
+    expect(state).toEqual({ status: 'checking', pending: false });
+  });
+
+  it('downloads when a check reports an available update', () => {
+    const { state, action } = reduceOta(
+      { status: 'checking', pending: false },
+      { type: 'checked', available: true },
+    );
+    expect(action).toBe('download');
+    expect(state.status).toBe('downloading');
+  });
+
+  it('settles back to idle when already up to date', () => {
+    const { state, action } = reduceOta(
+      { status: 'checking', pending: false },
+      { type: 'checked', available: false },
+    );
+    expect(action).toBe('none');
+    expect(state).toEqual({ status: 'idle', pending: false });
+  });
+
+  it('holds a downloaded update pending instead of reloading mid-session', () => {
+    const { state, action } = reduceOta(
+      { status: 'downloading', pending: false },
+      { type: 'downloaded', ok: true },
+    );
+    expect(action).toBe('none');
+    expect(state).toEqual({ status: 'ready', pending: true });
+  });
+
+  it('applies a pending update the next time the app becomes active', () => {
+    const { state, action } = reduceOta(
+      { status: 'ready', pending: true },
+      { type: 'app-active' },
+    );
+    expect(action).toBe('reload');
+    expect(state.pending).toBe(true);
+  });
+
+  it('does not stack a second check while one is in flight', () => {
+    for (const status of ['checking', 'downloading'] as const) {
+      const state: OtaState = { status, pending: false };
+      expect(reduceOta(state, { type: 'app-active' })).toEqual({ state, action: 'none' });
+    }
+  });
+
+  it('records download/network failures as an error and retries on next activation', () => {
+    const failed = reduceOta({ status: 'downloading', pending: false }, { type: 'downloaded', ok: false });
+    expect(failed).toEqual({ state: { status: 'error', pending: false }, action: 'none' });
+
+    const errored = reduceOta({ status: 'checking', pending: false }, { type: 'failed' });
+    expect(errored.state.status).toBe('error');
+
+    // An error is not terminal — the next activation checks again.
+    const retry = reduceOta({ status: 'error', pending: false }, { type: 'app-active' });
+    expect(retry.action).toBe('check');
+  });
+
+  it('runs a full launch → download → apply lifecycle', () => {
+    let state = initialOtaState;
+    const run = (event: Parameters<typeof reduceOta>[1]) => {
+      const t = reduceOta(state, event);
+      state = t.state;
+      return t.action;
+    };
+
+    expect(run({ type: 'app-active' })).toBe('check'); // launch
+    expect(run({ type: 'checked', available: true })).toBe('download');
+    expect(run({ type: 'downloaded', ok: true })).toBe('none'); // held pending
+    expect(state).toEqual({ status: 'ready', pending: true });
+    expect(run({ type: 'app-active' })).toBe('reload'); // next foreground applies it
+  });
+
+  it('reports busy only while checking or downloading', () => {
+    expect(otaBusy({ status: 'checking', pending: false })).toBe(true);
+    expect(otaBusy({ status: 'downloading', pending: false })).toBe(true);
+    expect(otaBusy({ status: 'idle', pending: false })).toBe(false);
+    expect(otaBusy({ status: 'ready', pending: true })).toBe(false);
+    expect(otaBusy({ status: 'error', pending: false })).toBe(false);
+  });
+});
+
+describe('otaUpdatesActive gate', () => {
+  it('runs only when updates are enabled, not in dev, and not on web', () => {
+    expect(otaUpdatesActive({ isEnabled: true, isDev: false, isWeb: false })).toBe(true);
+    expect(otaUpdatesActive({ isEnabled: false, isDev: false, isWeb: false })).toBe(false);
+    expect(otaUpdatesActive({ isEnabled: true, isDev: true, isWeb: false })).toBe(false);
+    expect(otaUpdatesActive({ isEnabled: true, isDev: false, isWeb: true })).toBe(false);
+  });
+});
+
+describe('otaStatusLabel', () => {
+  it('has a label for every status', () => {
+    const statuses: OtaState['status'][] = ['idle', 'checking', 'downloading', 'ready', 'error'];
+    for (const status of statuses) {
+      expect(otaStatusLabel({ status, pending: false })).toBeTruthy();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config wiring — guards the pieces that actually make OTA reach a device.
+// ---------------------------------------------------------------------------
+
+const read = (relativeToApp: string) => readFileSync(resolve(process.cwd(), relativeToApp), 'utf8');
+
+describe('EAS Update configuration is wired up', () => {
+  it('declares expo-updates with an appVersion runtime policy in app config', () => {
+    const app = JSON.parse(read('app.json')).expo;
+    expect(app.version).toBe('1.0.0');
+    expect(app.runtimeVersion).toEqual({ policy: 'appVersion' });
+    expect(app.updates.enabled).toBe(true);
+    expect(app.updates.checkAutomatically).toBe('ON_LOAD');
+
+    const pkg = JSON.parse(read('package.json'));
+    expect(pkg.dependencies['expo-updates']).toBeTruthy();
+  });
+
+  it('derives the EAS Update URL from the resolved project id', () => {
+    const config = read('app.config.ts');
+    expect(config).toContain('https://u.expo.dev/');
+    expect(config).toContain('updates');
+  });
+
+  it('stamps every build profile with an update channel', () => {
+    const eas = JSON.parse(read('eas.json'));
+    expect(eas.build.preview.channel).toBe('preview');
+    expect(eas.build.production.channel).toBe('production');
+  });
+
+  it('enables OTA in the committed iOS native project', () => {
+    const plist = read('ios/MoxxyMobileGateway/Supporting/Expo.plist');
+    expect(plist).toMatch(/<key>EXUpdatesEnabled<\/key>\s*<true\/>/);
+    expect(plist).toMatch(/<key>EXUpdatesURL<\/key>\s*<string>https:\/\/u\.expo\.dev\//);
+    expect(plist).toMatch(/<key>EXUpdatesRuntimeVersion<\/key>\s*<string>1\.0\.0<\/string>/);
+  });
+
+  it('mounts the OTA controller at the app root', () => {
+    const layout = read('app/_layout.tsx');
+    expect(layout).toContain('OtaUpdateController');
+  });
+
+  it('ships a manual-trigger OTA publish workflow', () => {
+    const workflow = read('../../.github/workflows/mobile-eas-update.yml');
+    expect(workflow).toContain('workflow_dispatch');
+    expect(workflow).toContain('eas update');
+    expect(workflow).toContain('--branch');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,6 +370,9 @@ importers:
       expo-status-bar:
         specifier: ~3.0.9
         version: 3.0.9(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-updates:
+        specifier: ~29.0.18
+        version: 29.0.18(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -6226,6 +6229,9 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
+  arg@4.1.0:
+    resolution: {integrity: sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -7515,6 +7521,9 @@ packages:
     peerDependencies:
       expo: '*'
 
+  expo-eas-client@1.0.8:
+    resolution: {integrity: sha512-5or11NJhSeDoHHI6zyvQDW2cz/yFyE+1Cz8NTs5NK8JzC7J0JrkUgptWtxyfB6Xs/21YRNifd3qgbBN3hfKVgA==}
+
   expo-file-system@19.0.23:
     resolution: {integrity: sha512-MeGkid9OeNILfT/qonaXHp4f2c15xaB28U/bcN7pqZej0Kx0+6+V7e9ZIXpPHm07zVatxA+QkMTPQEGfmvVOxA==}
     peerDependencies:
@@ -7538,6 +7547,9 @@ packages:
     peerDependencies:
       expo: '*'
 
+  expo-json-utils@0.15.0:
+    resolution: {integrity: sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==}
+
   expo-keep-awake@15.0.8:
     resolution: {integrity: sha512-YK9M1VrnoH1vLJiQzChZgzDvVimVoriibiDIFLbQMpjYBnvyfUeHJcin/Gx1a+XgupNXy92EQJLgI/9ZuXajYQ==}
     peerDependencies:
@@ -7549,6 +7561,11 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  expo-manifests@1.0.11:
+    resolution: {integrity: sha512-6zItytTewN37Cjhp3glUg0ozrgW2GwB8x9wtfzUNoJIMmxO38nnGdTLMaotYhRqdf5PP2Dzdmej1HDHXVNUpRw==}
+    peerDependencies:
+      expo: '*'
 
   expo-modules-autolinking@3.0.26:
     resolution: {integrity: sha512-WOaud6UKg16ciCOj8raKcMOoKFMHLXKI29U29yhgu1lf+Y7VxJyCktUcYo6AM+ccZ7zLD1uWZdMtgnpf+95OXA==}
@@ -7606,6 +7623,22 @@ packages:
   expo-status-bar@3.0.9:
     resolution: {integrity: sha512-xyYyVg6V1/SSOZWh4Ni3U129XHCnFHBTcUo0dhWtFDrZbNp/duw5AGsQfb2sVeU0gxWHXSY1+5F0jnKYC7WuOw==}
     peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  expo-structured-headers@5.0.0:
+    resolution: {integrity: sha512-RmrBtnSphk5REmZGV+lcdgdpxyzio5rJw8CXviHE6qH5pKQQ83fhMEcigvrkBdsn2Efw2EODp4Yxl1/fqMvOZw==}
+
+  expo-updates-interface@2.0.0:
+    resolution: {integrity: sha512-pTzAIufEZdVPKql6iMi5ylVSPqV1qbEopz9G6TSECQmnNde2nwq42PxdFBaUEd8IZJ/fdJLQnOT3m6+XJ5s7jg==}
+    peerDependencies:
+      expo: '*'
+
+  expo-updates@29.0.18:
+    resolution: {integrity: sha512-qn0YDM7wVwghQAaxb9NYzzwrmj+v8Djz5H+Zft4/myG9SPg4ICAfDy52IVF0K+/GH/oNgsFfzmmLl6hIkDu42g==}
+    hasBin: true
+    peerDependencies:
+      expo: '*'
       react: '*'
       react-native: '*'
 
@@ -15710,6 +15743,8 @@ snapshots:
       delegates: 1.0.0
       readable-stream: 3.6.2
 
+  arg@4.1.0: {}
+
   arg@5.0.2: {}
 
   argparse@1.0.10:
@@ -17370,6 +17405,8 @@ snapshots:
     dependencies:
       expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
+  expo-eas-client@1.0.8: {}
+
   expo-file-system@19.0.23(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
       expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
@@ -17391,6 +17428,8 @@ snapshots:
       expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-image-loader: 6.0.0(expo@54.0.35)
 
+  expo-json-utils@0.15.0: {}
+
   expo-keep-awake@15.0.8(expo@54.0.35)(react@19.1.0):
     dependencies:
       expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
@@ -17404,6 +17443,14 @@ snapshots:
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - expo
+      - supports-color
+
+  expo-manifests@1.0.11(expo@54.0.35):
+    dependencies:
+      '@expo/config': 12.0.13
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-json-utils: 0.15.0
+    transitivePeerDependencies:
       - supports-color
 
   expo-modules-autolinking@3.0.26:
@@ -17474,6 +17521,34 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
       react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+
+  expo-structured-headers@5.0.0: {}
+
+  expo-updates-interface@2.0.0(expo@54.0.35):
+    dependencies:
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+
+  expo-updates@29.0.18(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@expo/code-signing-certificates': 0.0.6
+      '@expo/plist': 0.4.9
+      '@expo/spawn-async': 1.8.0
+      arg: 4.1.0
+      chalk: 4.1.2
+      debug: 4.4.3
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-eas-client: 1.0.8
+      expo-manifests: 1.0.11(expo@54.0.35)
+      expo-structured-headers: 5.0.0
+      expo-updates-interface: 2.0.0(expo@54.0.35)
+      getenv: 2.0.0
+      glob: 13.0.6
+      ignore: 5.3.2
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0)
+      resolve-from: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   expo@54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(graphql@15.8.0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## What

Makes the Expo mobile app (`apps/mobile`) updatable **over-the-air** via [EAS Update](https://docs.expo.dev/eas-update/introduction/), so the whole JS/TS bundle + assets ship to installed apps without an App Store / Play Store review.

- **`expo-updates@~29.0.18`** (SDK-54 pin) added. `updates` (enabled / `ON_LOAD` / `fallbackToCacheTimeout: 0`) + `runtimeVersion: { policy: appVersion }` + explicit `version` in `app.json`; the account-specific `updates.url` (`https://u.expo.dev/<projectId>`) is **derived in `app.config.ts`** from the resolved project id, so it keeps the existing "no identity committed" pattern.
- **Update channels** `preview` / `production` stamped on the `eas.json` build profiles.
- **Native iOS enabled**: the committed `ios/.../Supporting/Expo.plist` flipped on (`EXUpdatesEnabled`, `EXUpdatesURL`, `EXUpdatesRuntimeVersion=1.0.0`). Android is CNG and configured by EAS automatically.
- **Generic in-app updater**: a pure `reduceOta` state machine (`src/otaUpdates.ts`) drives the `useOtaUpdates` hook (an `expo-updates` adapter), mounted headlessly via `<OtaUpdateController/>` in `app/_layout.tsx`. It checks on launch and on every foreground, downloads silently, and applies the new bundle on the next activation — no mid-session yank. Dormant in Expo Go, dev, and web.
- **Manual-trigger CI job** `.github/workflows/mobile-eas-update.yml` (`workflow_dispatch`: channel / platform / message / skip_checks). It builds the workspace deps (required because `eas update` bundles JS locally and Metro reads `@moxxy/*` from `dist`), typechecks + tests the app, then runs `eas update`. Reuses the existing `EXPO_TOKEN` / `EXPO_OWNER` / `EAS_PROJECT_ID` secrets — no new secrets.

## Why

Store review turnaround blocks shipping JS-only fixes. EAS Update lets everything non-native (components, screens, logic, assets, copy) go out immediately, while native changes still correctly require a rebuild.

## Notes / operational

- Runtime policy is **`appVersion`, not `fingerprint`** — deliberate, because iOS native is committed (custom Live Activity Swift, no full CNG), so a fingerprint hash would go stale in the committed `Expo.plist` and silently break delivery. When you ship a native change, bump `version` in `app.json`, update the committed `Expo.plist` (or re-run `expo prebuild -p ios`), and cut a new `eas build`. Logged in `TECH_DEBT.md`.
- First time per channel: run **Mobile EAS Build** once so EAS creates the channel and links it to its same-named branch; OTA publishes flow after that. Documented in `apps/mobile/README.md`.

## Verification

- `pnpm build` (81/81), `typecheck` (137/137), `lint` (0 errors), `test`, `check:deps` (0 errors) — all green on the rebased tree.
- `expo config` resolves `updates.url` + `runtimeVersion` with the env id **and** the committed fallback.
- `expo export --platform ios` bundles the real OTA payload cleanly (1321 modules → Hermes `.hbc`).
- 18 new tests (`test/ota-updates.test.ts`) cover the reducer lifecycle, the dev/web/Expo-Go gate, and the config wiring; full mobile suite 249 tests pass.