### PR TITLE
feat(voice): @moxxy/plugin-tts-local — offline Piper TTS (EN+PL) with on-demand verified model downloads

### DIFF
--- a/.changeset/tts-local.md
+++ b/.changeset/tts-local.md
@@ -1,0 +1,25 @@
+---
+'@moxxy/model-fetch': minor
+'@moxxy/plugin-tts-local': minor
+'@moxxy/plugin-plugins-admin': patch
+---
+
+feat(voice): @moxxy/plugin-tts-local — offline Piper TTS (EN+PL) with on-demand verified model downloads
+
+Adds a fully local, on-device text-to-speech Synthesizer plus the shared
+download-and-verify helper it relies on:
+
+- `@moxxy/model-fetch` — HTTPS download with a host allow-list, streamed
+  mandatory-sha256 verification, `.partial`→atomic-rename publish, a size cap,
+  throttled progress, and hardened `.tar.bz2` extraction (path-traversal /
+  symlink rejection). `ensureModel` ties download + extract behind an
+  idempotent marker.
+- `@moxxy/plugin-tts-local` — the `local-piper` synthesizer running sherpa-onnx
+  Piper voices (English + Polish) in a forked sidecar (so the native addon's
+  shared libs resolve via `DYLD_/LD_LIBRARY_PATH` set at process start). Voice
+  models download once on first use from sherpa-onnx's pinned releases,
+  sha256-verified against its `checksum.txt`. No API key, no network at
+  synthesis time. Consumed transparently by desktop read-aloud, the TUI, and
+  channel voice replies via the runner-side SynthesizerRegistry.
+
+plugins-admin gains a `tts-local` catalog entry for install-on-first-use.

--- a/packages/model-fetch/package.json
+++ b/packages/model-fetch/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@moxxy/model-fetch",
+  "version": "0.0.0",
+  "description": "Download-and-verify helper for on-demand model assets. Streams an HTTPS download to a temp file while hashing, enforces a host allow-list + size cap, verifies a mandatory pinned sha256, publishes atomically, and safely extracts .tar.bz2 archives (path-traversal / symlink hardened). Shared by moxxy plugins that fetch models at first use (local TTS voices, on-device NER, …).",
+  "keywords": [
+    "moxxy",
+    "download",
+    "sha256",
+    "integrity",
+    "tar.bz2",
+    "model"
+  ],
+  "homepage": "https://moxxy.ai",
+  "bugs": {
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
+    "directory": "packages/model-fetch"
+  },
+  "author": "Michal Makowski <michal.makowski97@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "tar-stream": "^3.1.7",
+    "unbzip2-stream": "^1.4.3"
+  },
+  "devDependencies": {
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "@types/tar-stream": "^3.1.3",
+    "@types/unbzip2-stream": "^1.4.3",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/model-fetch/src/ensure-model.test.ts
+++ b/packages/model-fetch/src/ensure-model.test.ts
@@ -1,0 +1,113 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { ensureModel } from './ensure-model.js';
+import type { FetchLike } from './fetch-asset.js';
+
+function have(cmd: string): boolean {
+  try {
+    execFileSync('sh', ['-c', `command -v ${cmd}`], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const FIXTURES_OK = process.platform !== 'win32' && have('tar') && have('bzip2');
+const URL_BASE = 'https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models';
+
+let fixtureBytes: Uint8Array;
+let fixtureHash: string;
+
+beforeAll(async () => {
+  if (!FIXTURES_OK) return;
+  const base = await mkdtemp(path.join(tmpdir(), 'ensure-fix-'));
+  await mkdir(path.join(base, 'vits-piper-en_US-amy-medium'), { recursive: true });
+  await writeFile(path.join(base, 'vits-piper-en_US-amy-medium', 'en_US-amy-medium.onnx'), 'MODEL');
+  await writeFile(path.join(base, 'vits-piper-en_US-amy-medium', 'tokens.txt'), 'a 0');
+  const archive = path.join(base, 'voice.tar.bz2');
+  execFileSync('tar', ['-cjf', archive, '-C', base, 'vits-piper-en_US-amy-medium']);
+  fixtureBytes = new Uint8Array(await readFile(archive));
+  fixtureHash = createHash('sha256').update(fixtureBytes).digest('hex');
+  await rm(base, { recursive: true, force: true });
+});
+
+/** A `fetch` serving the fixture archive bytes; counts invocations. */
+function serveFixture(): { fetchImpl: FetchLike; calls: () => number } {
+  const state = { calls: 0 };
+  const fetchImpl = (async () => {
+    state.calls += 1;
+    return new Response(fixtureBytes, {
+      status: 200,
+      headers: { 'content-length': String(fixtureBytes.byteLength) },
+    });
+  }) as unknown as FetchLike;
+  return { fetchImpl, calls: () => state.calls };
+}
+
+let dir: string;
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), 'ensure-'));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+afterAll(() => {});
+
+describe.skipIf(!FIXTURES_OK)('ensureModel', () => {
+  it('downloads + extracts on first use, then skips on the second call', async () => {
+    const modelDir = path.join(dir, 'en_US-amy-medium');
+    const first = serveFixture();
+    const phases: string[] = [];
+    const res = await ensureModel({
+      url: `${URL_BASE}/voice.tar.bz2`,
+      sha256: fixtureHash,
+      dir: modelDir,
+      fetchImpl: first.fetchImpl,
+      onProgress: (p) => phases.push(p.phase),
+    });
+    expect(res.skipped).toBe(false);
+    expect(first.calls()).toBe(1);
+    // Extracted tree is present…
+    expect(
+      await readFile(path.join(modelDir, 'vits-piper-en_US-amy-medium', 'en_US-amy-medium.onnx'), 'utf8'),
+    ).toBe('MODEL');
+    // …the completion marker recorded the hash…
+    expect((await readFile(path.join(modelDir, '.model.ok'), 'utf8')).trim()).toBe(fixtureHash);
+    // …and the staged archive was reclaimed.
+    await expect(stat(path.join(dir, 'voice.tar.bz2'))).rejects.toThrow();
+    expect(phases).toContain('extracting');
+    expect(phases.at(-1)).toBe('done');
+
+    // Second call: the network must not be touched.
+    const explode = (async () => {
+      throw new Error('must not download again');
+    }) as unknown as FetchLike;
+    const again = await ensureModel({
+      url: `${URL_BASE}/voice.tar.bz2`,
+      sha256: fixtureHash,
+      dir: modelDir,
+      fetchImpl: explode,
+    });
+    expect(again.skipped).toBe(true);
+  });
+
+  it('propagates an integrity mismatch and leaves no marker', async () => {
+    const modelDir = path.join(dir, 'bad');
+    const { fetchImpl } = serveFixture();
+    await expect(
+      ensureModel({
+        url: `${URL_BASE}/voice.tar.bz2`,
+        sha256: 'a'.repeat(64),
+        dir: modelDir,
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({ code: 'INTEGRITY_MISMATCH' });
+    await expect(stat(path.join(modelDir, '.model.ok'))).rejects.toThrow();
+  });
+});

--- a/packages/model-fetch/src/ensure-model.ts
+++ b/packages/model-fetch/src/ensure-model.ts
@@ -1,0 +1,129 @@
+/**
+ * Convenience: ensure a model directory exists, downloading + extracting a
+ * pinned `.tar.bz2` on first use. Idempotent — a completed extraction records a
+ * `.model.ok` marker so subsequent calls short-circuit without touching the
+ * network or disk. The staged archive is removed after a successful extraction
+ * to reclaim the (typically tens-of-MB) download.
+ */
+
+import { readFile, rm, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { extractTarBz2 } from './extract.js';
+import { fetchModelAsset, type FetchLike } from './fetch-asset.js';
+
+export type EnsureModelPhase = 'downloading' | 'verifying' | 'extracting' | 'done';
+
+export interface EnsureModelProgress {
+  readonly phase: EnsureModelPhase;
+  /** Bytes downloaded so far (download phases only; 0 otherwise). */
+  readonly receivedBytes: number;
+  /** Download total from Content-Length, or 0 when unknown. */
+  readonly totalBytes: number;
+  /** Entries extracted so far (extract phase only). */
+  readonly entries: number;
+}
+
+export interface EnsureModelOptions {
+  /** Archive URL — `https:` on an allow-listed host. */
+  readonly url: string;
+  /** Pinned hex sha256 of the archive. MANDATORY. */
+  readonly sha256: string;
+  /** Final extracted directory. Its `.model.ok` marker gates idempotence. */
+  readonly dir: string;
+  /** Where the archive is staged before extraction. Default: `dirname(dir)`. */
+  readonly cacheDir?: string;
+  /** Archive basename to stage as. Default: derived from `url`. */
+  readonly archiveName?: string;
+  readonly fetchImpl?: FetchLike;
+  readonly onProgress?: (p: EnsureModelProgress) => void;
+  readonly maxBytes?: number;
+  readonly signal?: AbortSignal;
+  readonly allowedHosts?: readonly string[];
+}
+
+/** Marker written INTO `dir` once extraction completes; records the archive
+ *  hash so a re-run can trust the tree without re-hashing/re-extracting. */
+const MODEL_MARKER = '.model.ok';
+
+export interface EnsureModelResult {
+  /** Absolute path to the ready model directory. */
+  readonly dir: string;
+  /** True when an existing complete directory was reused. */
+  readonly skipped: boolean;
+}
+
+export async function ensureModel(opts: EnsureModelOptions): Promise<EnsureModelResult> {
+  const { url, dir, onProgress, signal } = opts;
+  const expected = opts.sha256.trim().toLowerCase();
+  const markerPath = path.join(dir, MODEL_MARKER);
+
+  // Fast path: a completed extraction with a matching recorded hash.
+  if ((await readMarker(markerPath)) === expected) {
+    onProgress?.({ phase: 'done', receivedBytes: 0, totalBytes: 0, entries: 0 });
+    return { dir, skipped: true };
+  }
+
+  signal?.throwIfAborted();
+  // A stale/partial directory (interrupted prior extraction, or a hash change)
+  // is removed so the atomic rename in extract can land on a clean target.
+  if (await dirExists(dir)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+
+  const cacheDir = opts.cacheDir ?? path.dirname(dir);
+  const asset = await fetchModelAsset({
+    url,
+    sha256: expected,
+    destDir: cacheDir,
+    ...(opts.archiveName ? { fileName: opts.archiveName } : {}),
+    ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+    ...(opts.maxBytes !== undefined ? { maxBytes: opts.maxBytes } : {}),
+    ...(signal ? { signal } : {}),
+    ...(opts.allowedHosts ? { allowedHosts: opts.allowedHosts } : {}),
+    // Forward download/verify progress; swallow fetch's own 'done' (extraction
+    // is still ahead — the overall 'done' fires at the end of this function).
+    onProgress: (p) => {
+      if (p.phase === 'done') return;
+      onProgress?.({
+        phase: p.phase,
+        receivedBytes: p.receivedBytes,
+        totalBytes: p.totalBytes,
+        entries: 0,
+      });
+    },
+  });
+
+  signal?.throwIfAborted();
+  await extractTarBz2(asset.path, dir, {
+    onProgress: (p) => {
+      if (p.phase === 'done') return;
+      onProgress?.({ phase: 'extracting', receivedBytes: 0, totalBytes: 0, entries: p.entries });
+    },
+  });
+
+  await writeFile(markerPath, `${expected}\n`, 'utf8');
+  // Reclaim the staged archive (+ its verification marker); the extracted tree
+  // is now the source of truth and the marker guards re-download.
+  await rm(asset.path, { force: true }).catch(() => {});
+  await rm(`${asset.path}.ok`, { force: true }).catch(() => {});
+
+  onProgress?.({ phase: 'done', receivedBytes: asset.bytes, totalBytes: asset.bytes, entries: 0 });
+  return { dir, skipped: false };
+}
+
+async function readMarker(markerPath: string): Promise<string | null> {
+  try {
+    return (await readFile(markerPath, 'utf8')).trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+async function dirExists(p: string): Promise<boolean> {
+  try {
+    return (await stat(p)).isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/packages/model-fetch/src/errors.ts
+++ b/packages/model-fetch/src/errors.ts
@@ -1,0 +1,39 @@
+/**
+ * The failure modes {@link fetchModelAsset} / {@link extractTarBz2} raise. A
+ * dedicated error (rather than @moxxy/sdk's `MoxxyError`) keeps this package
+ * free of internal deps and lets callers switch on a precise `code` — the
+ * MoxxyError code union has no integrity/traversal member to borrow. Plugins
+ * re-wrap these into a user-facing `MoxxyError` at their boundary when needed.
+ */
+export type ModelFetchErrorCode =
+  /** The url is not `https:` on an allow-listed host (SSRF / local-file guard). */
+  | 'HOST_DENIED'
+  /** The download completed but its sha256 didn't match the pinned value. */
+  | 'INTEGRITY_MISMATCH'
+  /** The server body exceeded `maxBytes` (declared or streamed). */
+  | 'TOO_LARGE'
+  /** A tar entry tried to escape the destination (absolute / `..` / symlink). */
+  | 'UNSAFE_ENTRY'
+  /** A non-2xx HTTP response, or a body-less response. */
+  | 'HTTP_ERROR'
+  /** The caller's `signal` aborted the operation. */
+  | 'ABORTED'
+  /** Malformed archive / underlying IO failure surfaced during extraction. */
+  | 'EXTRACT_FAILED';
+
+export class ModelFetchError extends Error {
+  readonly code: ModelFetchErrorCode;
+  /** Structured, log-safe context (url host, expected/actual hash, …). */
+  readonly context?: Readonly<Record<string, string | number>>;
+
+  constructor(
+    code: ModelFetchErrorCode,
+    message: string,
+    context?: Readonly<Record<string, string | number>>,
+  ) {
+    super(message);
+    this.name = 'ModelFetchError';
+    this.code = code;
+    if (context) this.context = context;
+  }
+}

--- a/packages/model-fetch/src/extract.test.ts
+++ b/packages/model-fetch/src/extract.test.ts
@@ -1,0 +1,125 @@
+import { execFileSync } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { pack as tarPack } from 'tar-stream';
+
+import { extractTarBz2, safeEntryPath } from './extract.js';
+
+/** Whether an executable is runnable (fixtures need system tar + bzip2). */
+function have(cmd: string): boolean {
+  try {
+    execFileSync(cmd, ['--help'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    // bzip2 exits non-zero for --help on some platforms but is still present.
+    try {
+      execFileSync('sh', ['-c', `command -v ${cmd}`], { stdio: 'ignore' });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+const FIXTURES_OK = process.platform !== 'win32' && have('tar') && have('bzip2');
+
+let root: string;
+let goodArchive: string;
+let symlinkArchive: string;
+let traversalArchive: string;
+
+beforeAll(async () => {
+  if (!FIXTURES_OK) return;
+  root = await mkdtemp(path.join(tmpdir(), 'extract-fix-'));
+
+  // A benign tree → payload/{a.txt, sub/b.txt}
+  const treeBase = path.join(root, 'tree');
+  await mkdir(path.join(treeBase, 'payload', 'sub'), { recursive: true });
+  await writeFile(path.join(treeBase, 'payload', 'a.txt'), 'alpha');
+  await writeFile(path.join(treeBase, 'payload', 'sub', 'b.txt'), 'beta');
+  goodArchive = path.join(root, 'good.tar.bz2');
+  execFileSync('tar', ['-cjf', goodArchive, '-C', treeBase, 'payload']);
+
+  // A tree containing a symlink that escapes the destination.
+  const symBase = path.join(root, 'symtree');
+  await mkdir(symBase, { recursive: true });
+  await symlink('/etc/passwd', path.join(symBase, 'evil'));
+  await writeFile(path.join(symBase, 'ok.txt'), 'fine');
+  symlinkArchive = path.join(root, 'sym.tar.bz2');
+  execFileSync('tar', ['-cjf', symlinkArchive, '-C', symBase, '.']);
+
+  // A hand-packed tar whose entry name traverses out of the destination.
+  const tarPath = path.join(root, 'traversal.tar');
+  await new Promise<void>((resolve, reject) => {
+    const p = tarPack();
+    const out = createWriteStream(tarPath);
+    out.on('finish', () => resolve());
+    out.on('error', reject);
+    p.on('error', reject);
+    p.pipe(out);
+    p.entry({ name: '../escape.txt' }, 'pwned');
+    p.finalize();
+  });
+  execFileSync('bzip2', ['-f', tarPath]);
+  traversalArchive = `${tarPath}.bz2`;
+});
+
+afterAll(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+});
+
+describe('safeEntryPath', () => {
+  const base = path.resolve('/tmp/dest');
+  it('resolves a nested relative entry under the root', () => {
+    expect(safeEntryPath(base, 'payload/sub/b.txt')).toBe(path.join(base, 'payload/sub/b.txt'));
+  });
+  it('rejects an absolute entry', () => {
+    expect(() => safeEntryPath(base, '/etc/passwd')).toThrow(/absolute/);
+  });
+  it('rejects a `..` traversal', () => {
+    expect(() => safeEntryPath(base, '../escape.txt')).toThrow(/\.\./);
+    expect(() => safeEntryPath(base, 'a/../../escape')).toThrow(/\.\./);
+  });
+  it('rejects a NUL byte', () => {
+    expect(() => safeEntryPath(base, 'a\0b')).toThrow(/NUL/);
+  });
+  it('rejects a Windows drive-absolute entry', () => {
+    expect(() => safeEntryPath(base, 'C:\\evil')).toThrow(/absolute/);
+  });
+});
+
+describe.skipIf(!FIXTURES_OK)('extractTarBz2 (fixture-driven)', () => {
+  it('extracts a benign archive and cleans up the temp dir', async () => {
+    const dest = path.join(root, 'out-good');
+    const phases: string[] = [];
+    await extractTarBz2(goodArchive, dest, { onProgress: (p) => phases.push(p.phase) });
+    expect(await readFile(path.join(dest, 'payload', 'a.txt'), 'utf8')).toBe('alpha');
+    expect(await readFile(path.join(dest, 'payload', 'sub', 'b.txt'), 'utf8')).toBe('beta');
+    expect(phases.at(-1)).toBe('done');
+    // No leftover .extracting-* temp beside the destination.
+    const siblings = await readdir(root);
+    expect(siblings.some((n) => n.includes('.extracting-'))).toBe(false);
+  });
+
+  it('refuses a symlink entry (would escape the destination)', async () => {
+    const dest = path.join(root, 'out-sym');
+    await expect(extractTarBz2(symlinkArchive, dest, {})).rejects.toMatchObject({
+      code: 'UNSAFE_ENTRY',
+    });
+    // The destination was never published (temp cleaned).
+    await expect(readdir(dest)).rejects.toThrow();
+  });
+
+  it('refuses a `..` traversal entry', async () => {
+    const dest = path.join(root, 'out-traversal');
+    await expect(extractTarBz2(traversalArchive, dest, {})).rejects.toMatchObject({
+      code: 'UNSAFE_ENTRY',
+    });
+    // The traversal target must NOT have been written outside the destination.
+    await expect(readFile(path.join(root, 'escape.txt'), 'utf8')).rejects.toThrow();
+  });
+});

--- a/packages/model-fetch/src/extract.ts
+++ b/packages/model-fetch/src/extract.ts
@@ -1,0 +1,179 @@
+/**
+ * Extract a `.tar.bz2` archive into a directory with hostile-archive defences.
+ *
+ * No tar/bzip2 capability exists elsewhere in the workspace, so this uses the
+ * pure-JS `unbzip2-stream` (bzip2 decompress) piped into `tar-stream` (tar
+ * parse). The security posture mirrors the desktop installer's containment
+ * discipline, applied per tar ENTRY: an entry whose name is absolute, contains
+ * a `..` traversal segment or a NUL, or that is a symlink / hard link / device
+ * node is REFUSED before a byte is written — a malicious tarball can't drop a
+ * file outside the destination or plant a symlink that later escapes it.
+ *
+ * Extraction runs into a sibling `.extracting-*` temp dir and is `rename`d into
+ * place only on success, so an interrupted extraction never leaves a partial
+ * tree masquerading as a complete model.
+ */
+
+import { createReadStream, createWriteStream } from 'node:fs';
+import { mkdir, rename, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+
+import bz2 from 'unbzip2-stream';
+import { extract as tarExtract, type Headers } from 'tar-stream';
+
+import { ModelFetchError } from './errors.js';
+
+export interface ExtractProgress {
+  readonly phase: 'extracting' | 'done';
+  /** Number of file/dir entries written so far. */
+  readonly entries: number;
+}
+
+export interface ExtractTarBz2Options {
+  readonly onProgress?: (p: ExtractProgress) => void;
+  /** Injected reader factory (tests). Defaults to `fs.createReadStream`. */
+  readonly createReadStreamImpl?: typeof createReadStream;
+}
+
+/** tar entry types we materialise. `contiguous-file` is an old synonym for a
+ *  regular file. Everything else (symlink/link/devices/fifo) is refused. */
+const FILE_TYPES = new Set(['file', 'contiguous-file']);
+/** tar meta-entries the parser may surface; drained and skipped, never written. */
+const META_TYPES = new Set(['pax-header', 'pax-global-header', 'gnu-long-path', 'gnu-long-link-path']);
+
+/** Validate a tar entry name and resolve it safely under `root`. Throws
+ *  `UNSAFE_ENTRY` on anything that could escape. Exported for unit tests. */
+export function safeEntryPath(root: string, name: string): string {
+  if (typeof name !== 'string' || name.length === 0) {
+    throw new ModelFetchError('UNSAFE_ENTRY', 'tar entry has an empty name');
+  }
+  if (name.includes('\0')) {
+    throw new ModelFetchError('UNSAFE_ENTRY', 'tar entry name contains NUL');
+  }
+  // Normalise separators (tar always uses `/`) and reject absolute paths.
+  const normalized = name.replace(/\\/g, '/');
+  if (path.posix.isAbsolute(normalized) || /^[a-zA-Z]:/.test(normalized)) {
+    throw new ModelFetchError('UNSAFE_ENTRY', `tar entry name is absolute: ${name}`);
+  }
+  // Reject any `..` traversal segment outright — cheaper and stricter than
+  // relying solely on the post-resolve containment check.
+  if (normalized.split('/').some((seg) => seg === '..')) {
+    throw new ModelFetchError('UNSAFE_ENTRY', `tar entry name escapes with '..': ${name}`);
+  }
+  const abs = path.resolve(root, normalized);
+  if (abs !== root && !abs.startsWith(root + path.sep)) {
+    throw new ModelFetchError('UNSAFE_ENTRY', `tar entry escapes destination: ${name}`);
+  }
+  return abs;
+}
+
+/**
+ * Extract `archivePath` (a `.tar.bz2`) into `destDir`. `destDir` must NOT
+ * already exist — extraction lands in a temp sibling and is renamed into place
+ * atomically. Rejects on the first unsafe entry, cleaning up the temp tree.
+ */
+export async function extractTarBz2(
+  archivePath: string,
+  destDir: string,
+  opts: ExtractTarBz2Options = {},
+): Promise<void> {
+  const openRead = opts.createReadStreamImpl ?? createReadStream;
+  const parent = path.dirname(destDir);
+  await mkdir(parent, { recursive: true });
+  const tmpDir = `${destDir}.extracting-${process.pid}-${Date.now().toString(36)}`;
+  await mkdir(tmpDir, { recursive: true });
+
+  const seenDirs = new Set<string>();
+  let entries = 0;
+  let lastEmit = 0;
+
+  // `tarExtract()` is a terminal Writable: tar bytes are written INTO it and it
+  // emits an 'entry' per member. It serialises entries — the next 'entry' won't
+  // fire until we call `next()` — so processing one at a time is safe, ordered,
+  // and its 'finish' (which resolves the pipeline) only fires after the last
+  // entry's `next()`, i.e. after every file has been fully written.
+  const extractor = tarExtract();
+  extractor.on('entry', (header: Headers, stream, next) => {
+    handleEntry(header, stream, tmpDir, seenDirs)
+      .then((wrote) => {
+        if (wrote) {
+          entries += 1;
+          const now = Date.now();
+          if (now - lastEmit >= 100) {
+            lastEmit = now;
+            opts.onProgress?.({ phase: 'extracting', entries });
+          }
+        }
+        next();
+      })
+      .catch((err) => {
+        // Drain the current entry so the parser doesn't stall, then tear down
+        // the pipeline with the real error.
+        stream.resume();
+        extractor.destroy(err instanceof Error ? err : new Error(String(err)));
+      });
+  });
+
+  try {
+    await pipeline(openRead(archivePath), bz2() as unknown as NodeJS.ReadWriteStream, extractor);
+  } catch (err) {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    if (err instanceof ModelFetchError) throw err;
+    throw new ModelFetchError('EXTRACT_FAILED', `failed to extract ${path.basename(archivePath)}: ${errMsg(err)}`);
+  }
+
+  try {
+    await rename(tmpDir, destDir);
+  } catch (err) {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    throw new ModelFetchError('EXTRACT_FAILED', `failed to publish extracted dir: ${errMsg(err)}`);
+  }
+  opts.onProgress?.({ phase: 'done', entries });
+}
+
+/** Process one tar entry. Returns true when a file/dir was written, false when
+ *  the entry was a drained meta-header. Throws `UNSAFE_ENTRY` for anything that
+ *  could escape (validated BEFORE any write). */
+async function handleEntry(
+  header: Headers,
+  stream: NodeJS.ReadableStream,
+  root: string,
+  seenDirs: Set<string>,
+): Promise<boolean> {
+  const type = header.type ?? 'file';
+
+  if (META_TYPES.has(type)) {
+    stream.resume();
+    return false;
+  }
+
+  if (type === 'directory') {
+    const abs = safeEntryPath(root, header.name);
+    await ensureDir(abs, seenDirs);
+    stream.resume();
+    return true;
+  }
+
+  if (!FILE_TYPES.has(type)) {
+    // symlink / link / character-device / block-device / fifo — any of these
+    // could be used to escape the destination or read/clobber an external path.
+    throw new ModelFetchError('UNSAFE_ENTRY', `refusing unsafe tar entry type '${type}': ${header.name}`);
+  }
+
+  const abs = safeEntryPath(root, header.name);
+  await ensureDir(path.dirname(abs), seenDirs);
+  // Backpressure-correct copy of the entry body to disk.
+  await pipeline(stream, createWriteStream(abs));
+  return true;
+}
+
+async function ensureDir(dir: string, seen: Set<string>): Promise<void> {
+  if (seen.has(dir)) return;
+  await mkdir(dir, { recursive: true });
+  seen.add(dir);
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/model-fetch/src/fetch-asset.test.ts
+++ b/packages/model-fetch/src/fetch-asset.test.ts
@@ -1,0 +1,223 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ModelFetchError } from './errors.js';
+import {
+  DEFAULT_ALLOWED_HOSTS,
+  fetchModelAsset,
+  isAllowedAssetUrl,
+  type FetchLike,
+} from './fetch-asset.js';
+
+const HOST_URL = 'https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/asset.bin';
+
+function sha256(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+/** A `fetch` returning fixed bytes with a matching Content-Length header. */
+function okFetch(bytes: Uint8Array, headers: Record<string, string> = {}): {
+  fetchImpl: FetchLike;
+  calls: number;
+} {
+  const state = { calls: 0 };
+  const fetchImpl = (async () => {
+    state.calls += 1;
+    return new Response(bytes, {
+      status: 200,
+      headers: { 'content-length': String(bytes.byteLength), ...headers },
+    });
+  }) as unknown as FetchLike;
+  return { fetchImpl, get calls() {
+    return state.calls;
+  } };
+}
+
+/** A `fetch` whose body streams one chunk, then stalls until `signal` aborts. */
+function stallingFetch(firstChunk: Uint8Array): FetchLike {
+  return (async (_url: string, init?: { signal?: AbortSignal }) => {
+    const signal = init?.signal;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(firstChunk);
+      },
+      pull(controller) {
+        return new Promise<void>((_resolve, reject) => {
+          const fail = (): void => {
+            controller.error(new DOMException('Aborted', 'AbortError'));
+            reject(new DOMException('Aborted', 'AbortError'));
+          };
+          if (signal?.aborted) fail();
+          else signal?.addEventListener('abort', fail, { once: true });
+        });
+      },
+    });
+    return new Response(body, { status: 200 });
+  }) as unknown as FetchLike;
+}
+
+let dir: string;
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), 'model-fetch-'));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('isAllowedAssetUrl', () => {
+  it('admits https on allow-listed hosts and their subdomains', () => {
+    expect(isAllowedAssetUrl('https://github.com/x')).toBe(true);
+    expect(isAllowedAssetUrl('https://objects.githubusercontent.com/x')).toBe(true);
+    expect(isAllowedAssetUrl('https://huggingface.co/x')).toBe(true);
+    expect(isAllowedAssetUrl('https://cdn-lfs.huggingface.co/x')).toBe(true);
+  });
+  it('refuses http, other schemes, and look-alike hosts', () => {
+    expect(isAllowedAssetUrl('http://github.com/x')).toBe(false);
+    expect(isAllowedAssetUrl('file:///etc/passwd')).toBe(false);
+    expect(isAllowedAssetUrl('https://github.com.evil.com/x')).toBe(false);
+    expect(isAllowedAssetUrl('https://raw.githubusercontent.com/x')).toBe(false);
+    expect(isAllowedAssetUrl('not a url')).toBe(false);
+  });
+  it('honors a custom allow-list', () => {
+    expect(isAllowedAssetUrl('https://example.com/x', ['example.com'])).toBe(true);
+    expect(isAllowedAssetUrl('https://github.com/x', ['example.com'])).toBe(false);
+  });
+});
+
+describe('fetchModelAsset', () => {
+  it('downloads, verifies, publishes atomically and records a .ok marker', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    const { fetchImpl } = okFetch(bytes);
+    const phases: string[] = [];
+    const res = await fetchModelAsset({
+      url: HOST_URL,
+      sha256: sha256(bytes),
+      destDir: dir,
+      fetchImpl,
+      onProgress: (p) => phases.push(p.phase),
+    });
+    expect(res.skipped).toBe(false);
+    expect(res.bytes).toBe(8);
+    expect(new Uint8Array(await readFile(res.path))).toEqual(bytes);
+    expect(await readFile(`${res.path}.ok`, 'utf8')).toBe(`${sha256(bytes)}\n`);
+    expect(phases.at(-1)).toBe('done');
+    expect(phases).toContain('verifying');
+  });
+
+  it('rejects a hash mismatch and cleans up the partial (no dest, no partial)', async () => {
+    const bytes = new Uint8Array([9, 9, 9, 9]);
+    const { fetchImpl } = okFetch(bytes);
+    const wrong = 'f'.repeat(64);
+    await expect(
+      fetchModelAsset({ url: HOST_URL, sha256: wrong, destDir: dir, fetchImpl }),
+    ).rejects.toMatchObject({ code: 'INTEGRITY_MISMATCH' });
+    const abs = path.join(dir, 'asset.bin');
+    await expect(stat(abs)).rejects.toThrow();
+    await expect(stat(`${abs}.partial`)).rejects.toThrow();
+  });
+
+  it('is idempotent: a second call with a matching marker skips the network', async () => {
+    const bytes = new Uint8Array([4, 4, 4, 4]);
+    const hash = sha256(bytes);
+    const first = okFetch(bytes);
+    await fetchModelAsset({ url: HOST_URL, sha256: hash, destDir: dir, fetchImpl: first.fetchImpl });
+    expect(first.calls).toBe(1);
+
+    const explode = (async () => {
+      throw new Error('network must not be touched on a cache hit');
+    }) as unknown as FetchLike;
+    const res = await fetchModelAsset({ url: HOST_URL, sha256: hash, destDir: dir, fetchImpl: explode });
+    expect(res.skipped).toBe(true);
+  });
+
+  it('refuses a url that is not on an allowed host (before any fetch)', async () => {
+    let touched = false;
+    const spy = (async () => {
+      touched = true;
+      return new Response(new Uint8Array());
+    }) as unknown as FetchLike;
+    await expect(
+      fetchModelAsset({ url: 'https://evil.example/x.bin', sha256: 'a'.repeat(64), destDir: dir, fetchImpl: spy }),
+    ).rejects.toMatchObject({ code: 'HOST_DENIED' });
+    expect(touched).toBe(false);
+  });
+
+  it('rejects an over-cap download up front via Content-Length', async () => {
+    const bytes = new Uint8Array(100);
+    const { fetchImpl } = okFetch(bytes);
+    await expect(
+      fetchModelAsset({ url: HOST_URL, sha256: sha256(bytes), destDir: dir, fetchImpl, maxBytes: 10 }),
+    ).rejects.toMatchObject({ code: 'TOO_LARGE' });
+  });
+
+  it('rejects an over-cap streamed body (no Content-Length) mid-stream', async () => {
+    const bytes = new Uint8Array(50);
+    // No content-length header ⇒ the up-front check is skipped; the streaming
+    // guard must still fire.
+    const fetchImpl = (async () => new Response(new Blob([bytes]).stream(), { status: 200 })) as unknown as FetchLike;
+    await expect(
+      fetchModelAsset({ url: HOST_URL, sha256: sha256(bytes), destDir: dir, fetchImpl, maxBytes: 10 }),
+    ).rejects.toMatchObject({ code: 'TOO_LARGE' });
+  });
+
+  it('aborts mid-download and leaves no partial behind', async () => {
+    const controller = new AbortController();
+    const fetchImpl = stallingFetch(new Uint8Array([1, 2, 3, 4]));
+    const p = fetchModelAsset({
+      url: HOST_URL,
+      sha256: 'a'.repeat(64),
+      destDir: dir,
+      fetchImpl,
+      signal: controller.signal,
+    });
+    // Let the first chunk land, then abort while the body stalls.
+    await new Promise((r) => setTimeout(r, 20));
+    controller.abort(new Error('user cancelled'));
+    await expect(p).rejects.toMatchObject({ code: 'ABORTED' });
+    await expect(stat(`${path.join(dir, 'asset.bin')}.partial`)).rejects.toThrow();
+  });
+
+  it('rejects a malformed sha256 pin', async () => {
+    const { fetchImpl } = okFetch(new Uint8Array([1]));
+    await expect(
+      fetchModelAsset({ url: HOST_URL, sha256: 'nothex', destDir: dir, fetchImpl }),
+    ).rejects.toBeInstanceOf(ModelFetchError);
+  });
+
+  it('surfaces a non-2xx response as HTTP_ERROR', async () => {
+    const fetchImpl = (async () => new Response('nope', { status: 404 })) as unknown as FetchLike;
+    await expect(
+      fetchModelAsset({ url: HOST_URL, sha256: 'a'.repeat(64), destDir: dir, fetchImpl }),
+    ).rejects.toMatchObject({ code: 'HTTP_ERROR' });
+  });
+
+  it('exposes the default allow-list', () => {
+    expect(DEFAULT_ALLOWED_HOSTS).toContain('github.com');
+    expect(DEFAULT_ALLOWED_HOSTS).toContain('huggingface.co');
+  });
+
+  it('derives the file name from the url when unspecified', async () => {
+    const bytes = new Uint8Array([7]);
+    const { fetchImpl } = okFetch(bytes);
+    const res = await fetchModelAsset({ url: HOST_URL, sha256: sha256(bytes), destDir: dir, fetchImpl });
+    expect(path.basename(res.path)).toBe('asset.bin');
+  });
+
+  it('honors an explicit fileName', async () => {
+    const bytes = new Uint8Array([7]);
+    const { fetchImpl } = okFetch(bytes);
+    const res = await fetchModelAsset({
+      url: HOST_URL,
+      sha256: sha256(bytes),
+      destDir: dir,
+      fileName: 'voice.tar.bz2',
+      fetchImpl,
+    });
+    expect(path.basename(res.path)).toBe('voice.tar.bz2');
+    await writeFile(res.path, await readFile(res.path)); // sanity: file readable
+  });
+});

--- a/packages/model-fetch/src/fetch-asset.ts
+++ b/packages/model-fetch/src/fetch-asset.ts
@@ -1,0 +1,366 @@
+/**
+ * Download one file over HTTPS and verify it against a pinned sha256.
+ *
+ * This is the extracted, Electron-free distillation of the desktop Apps
+ * installer's download core (`packages/desktop-host/src/apps/installer.ts`):
+ * an egress allow-list checked BEFORE the first byte, a streamed sha256, a
+ * `.partial`-then-`rename` atomic publish, a hard size cap so a chunked /
+ * content-length-lying server can't fill the disk, and throttled progress. The
+ * one deliberate divergence: the sha256 here is MANDATORY (no unhashed mode) —
+ * every asset this package fetches is content-addressed and pinned.
+ */
+
+import { createHash } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { ModelFetchError } from './errors.js';
+
+/** A `fetch`-compatible function. Defaults to the global `fetch` (Node 20+);
+ *  tests inject a stub so no real network is touched. */
+export type FetchLike = typeof fetch;
+
+/**
+ * Hosts an asset may be fetched FROM — exact-or-subdomain matchers (so
+ * `github.com` admits `objects.githubusercontent.com`'s parent forms but
+ * `…github.com.evil` is refused). GitHub release URLs 30x-redirect to
+ * `release-assets.githubusercontent.com`; like the desktop installer's gate we
+ * validate only the INITIAL url and let `fetch` follow the redirect to the
+ * GitHub/HF-operated CDN (a hostile initial url never reaches the network at
+ * all). The default set covers where moxxy's pinned models actually live.
+ */
+export const DEFAULT_ALLOWED_HOSTS: readonly string[] = [
+  'github.com',
+  'objects.githubusercontent.com',
+  'huggingface.co',
+  'cdn-lfs.huggingface.co',
+];
+
+/** Compile bare hostnames into exact-or-subdomain matchers. The hostname is
+ *  regex-escaped so a `.` can never act as a wildcard. */
+function compileHosts(hosts: readonly string[]): RegExp[] {
+  return hosts.map((h) => {
+    const escaped = h.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`(^|\\.)${escaped}$`);
+  });
+}
+
+/** Whether `url` is a fetch target we may reach: `https:` on an allow-listed
+ *  host. Exported so the gate is unit-testable in isolation. */
+export function isAllowedAssetUrl(
+  url: string,
+  allowedHosts: readonly string[] = DEFAULT_ALLOWED_HOSTS,
+): boolean {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return false;
+  }
+  if (u.protocol !== 'https:') return false;
+  return compileHosts(allowedHosts).some((re) => re.test(u.hostname));
+}
+
+/** Default hard ceiling on a single downloaded asset (1 GiB). Bounds a
+ *  hostile/buggy server streaming an unbounded body (disk-fill DoS). */
+export const DEFAULT_MAX_BYTES = 1024 * 1024 * 1024;
+
+export type FetchPhase = 'downloading' | 'verifying' | 'done';
+
+export interface FetchProgress {
+  readonly phase: FetchPhase;
+  readonly receivedBytes: number;
+  /** Total from Content-Length, or 0 when the server didn't declare one. */
+  readonly totalBytes: number;
+}
+
+export interface FetchModelAssetOptions {
+  /** Source URL — must be `https:` on an allow-listed host. */
+  readonly url: string;
+  /** Expected hex sha256 (case-insensitive). MANDATORY. */
+  readonly sha256: string;
+  /** Directory the verified file lands in (created if missing). */
+  readonly destDir: string;
+  /** Basename to save as. Default: the last path segment of `url`. */
+  readonly fileName?: string;
+  /** Injected `fetch` (tests). Defaults to the global. */
+  readonly fetchImpl?: FetchLike;
+  /** Throttled (~10/s) progress callback. */
+  readonly onProgress?: (p: FetchProgress) => void;
+  /** Per-download size cap. Default 1 GiB. */
+  readonly maxBytes?: number;
+  /** Cancellation signal — aborts the download and cleans up the partial. */
+  readonly signal?: AbortSignal;
+  /** Override the host allow-list (defaults to {@link DEFAULT_ALLOWED_HOSTS}). */
+  readonly allowedHosts?: readonly string[];
+}
+
+export interface FetchModelAssetResult {
+  /** Absolute path of the verified file. */
+  readonly path: string;
+  /** Byte length of the file. */
+  readonly bytes: number;
+  /** The verified (lowercase hex) sha256. */
+  readonly sha256: string;
+  /** True when an existing verified file was reused (no bytes fetched). */
+  readonly skipped: boolean;
+}
+
+/** Suffix of the sidecar marker recording a verified file's hash — its presence
+ *  (with a matching hash) lets a re-run skip re-hashing a multi-hundred-MB
+ *  file. Mirrors the installer's `installed.json` idea, per-file. */
+const OK_SUFFIX = '.ok';
+
+function deriveFileName(url: string): string {
+  let name = '';
+  try {
+    name = path.posix.basename(new URL(url).pathname);
+  } catch {
+    /* fall through to the error below */
+  }
+  if (!name) {
+    throw new ModelFetchError('HTTP_ERROR', `cannot derive a file name from url: ${url}`);
+  }
+  return name;
+}
+
+async function readOkMarker(markerPath: string): Promise<string | null> {
+  try {
+    return (await readFile(markerPath, 'utf8')).trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Download `url` into `destDir`, streaming to `<dest>.partial` while hashing,
+ * verify the pinned sha256, then atomically publish. Idempotent: a prior
+ * verified file (its `<dest>.ok` marker records a matching hash) is reused
+ * without touching the network.
+ */
+export async function fetchModelAsset(
+  opts: FetchModelAssetOptions,
+): Promise<FetchModelAssetResult> {
+  const {
+    url,
+    destDir,
+    onProgress,
+    signal,
+    fetchImpl = fetch,
+    maxBytes = DEFAULT_MAX_BYTES,
+    allowedHosts = DEFAULT_ALLOWED_HOSTS,
+  } = opts;
+  const expected = opts.sha256.trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(expected)) {
+    throw new ModelFetchError('INTEGRITY_MISMATCH', `sha256 must be 64 hex chars, got: ${opts.sha256}`);
+  }
+  signal?.throwIfAborted();
+
+  const fileName = opts.fileName ?? deriveFileName(url);
+  const abs = path.join(destDir, fileName);
+  const marker = `${abs}${OK_SUFFIX}`;
+
+  // Idempotent skip: a recorded matching hash + the file present ⇒ done. We
+  // trust the marker rather than re-hash a ~64 MB file on every first-use check.
+  const recorded = await readOkMarker(marker);
+  if (recorded === expected && (await fileExists(abs))) {
+    const bytes = await fileSize(abs);
+    onProgress?.({ phase: 'done', receivedBytes: bytes, totalBytes: bytes });
+    return { path: abs, bytes, sha256: expected, skipped: true };
+  }
+
+  // Egress gate: only https on an allow-listed host is ever fetched, checked
+  // BEFORE the network call so a bad url can't reach an arbitrary origin (SSRF)
+  // or a local file.
+  if (!isAllowedAssetUrl(url, allowedHosts)) {
+    throw new ModelFetchError('HOST_DENIED', `url is not on an allowed host: ${url}`, {
+      host: safeHost(url),
+    });
+  }
+
+  await mkdir(destDir, { recursive: true });
+  const partial = `${abs}.partial`;
+  try {
+    const result = await streamToPartial({
+      url,
+      partial,
+      expected,
+      fetchImpl,
+      maxBytes,
+      signal,
+      onProgress,
+    });
+    // Atomic publish: a crash before this leaves only the `.partial`.
+    await rename(partial, abs);
+    await writeFile(marker, `${expected}\n`, 'utf8');
+    onProgress?.({ phase: 'done', receivedBytes: result.bytes, totalBytes: result.bytes });
+    return { path: abs, bytes: result.bytes, sha256: expected, skipped: false };
+  } catch (err) {
+    // Never strand a partial download (orphaned ~100MB temp) on any failure.
+    await rm(partial, { force: true }).catch(() => {});
+    throw err;
+  }
+}
+
+interface StreamArgs {
+  readonly url: string;
+  readonly partial: string;
+  readonly expected: string;
+  readonly fetchImpl: FetchLike;
+  readonly maxBytes: number;
+  readonly signal?: AbortSignal;
+  readonly onProgress?: (p: FetchProgress) => void;
+}
+
+/** Stream the body to the partial file, hashing as bytes land, enforcing the
+ *  cap and throttled progress; verify the hash before returning. Throws
+ *  (leaving the partial for the caller to clean up) on any failure. */
+async function streamToPartial(args: StreamArgs): Promise<{ bytes: number }> {
+  const { url, partial, expected, fetchImpl, maxBytes, signal, onProgress } = args;
+
+  let res: Response;
+  try {
+    res = await fetchImpl(url, signal ? { signal } : {});
+  } catch (err) {
+    if (signal?.aborted) throw abortedError(signal);
+    throw new ModelFetchError('HTTP_ERROR', `download failed: ${errMsg(err)}`, { host: safeHost(url) });
+  }
+  if (!res.ok || !res.body) {
+    throw new ModelFetchError('HTTP_ERROR', `download failed: HTTP ${res.status}`, {
+      host: safeHost(url),
+      status: res.status,
+    });
+  }
+
+  // Parse Content-Length explicitly: absent/empty (chunked CDN responses) ⇒ 0
+  // total (indeterminate bar; the streaming cap still applies). Reject an
+  // honestly-over-cap body up front.
+  const rawLen = res.headers.get('content-length');
+  const declared = rawLen == null || rawLen === '' ? NaN : Number(rawLen);
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new ModelFetchError('TOO_LARGE', `asset exceeds the ${maxBytes}-byte cap (content-length ${declared})`);
+  }
+  const totalBytes = Number.isFinite(declared) && declared > 0 ? declared : 0;
+
+  const hash = createHash('sha256');
+  const out = createWriteStream(partial);
+  let writeErr: NodeJS.ErrnoException | null = null;
+  out.on('error', (e: NodeJS.ErrnoException) => {
+    writeErr = writeErr ?? e;
+  });
+
+  const reader = res.body.getReader();
+  let received = 0;
+  let lastEmit = 0;
+  let overCap = false;
+  const emit = (): void => {
+    const now = Date.now();
+    if (now - lastEmit < 100) return;
+    lastEmit = now;
+    onProgress?.({ phase: 'downloading', receivedBytes: received, totalBytes });
+  };
+
+  try {
+    for (;;) {
+      if (writeErr) throw writeErr;
+      if (signal?.aborted) throw abortedError(signal);
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      received += value.byteLength;
+      if (received > maxBytes) {
+        overCap = true;
+        break;
+      }
+      const chunk = Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+      hash.update(chunk);
+      // Backpressure: honor the write stream's drain signal, but race it against
+      // 'error' so a failing write rejects instead of hanging on a 'drain' that
+      // will never come. Each listener removes the OTHER so they don't
+      // accumulate across many chunks (a MaxListeners leak on a big download).
+      if (!out.write(chunk)) {
+        await new Promise<void>((resolve, reject) => {
+          const onDrain = (): void => {
+            out.removeListener('error', onError);
+            resolve();
+          };
+          const onError = (e: Error): void => {
+            out.removeListener('drain', onDrain);
+            reject(e);
+          };
+          out.once('drain', onDrain);
+          out.once('error', onError);
+        });
+      }
+      emit();
+    }
+    if (writeErr) throw writeErr;
+  } catch (err) {
+    // A body-stream error while the caller has aborted is a cancellation, not a
+    // transport failure — surface it as ABORTED regardless of which read/write
+    // step raised.
+    if (signal?.aborted && !(err instanceof ModelFetchError)) throw abortedError(signal);
+    throw err;
+  } finally {
+    await reader.cancel().catch(() => {});
+    if (writeErr) {
+      out.destroy();
+    } else {
+      await new Promise<void>((resolve, reject) => {
+        out.once('error', reject);
+        out.end((e?: NodeJS.ErrnoException | null) => (e ? reject(e) : resolve()));
+      }).catch((e) => {
+        writeErr = writeErr ?? (e as NodeJS.ErrnoException);
+      });
+    }
+  }
+  if (writeErr) throw writeErr;
+  if (overCap) {
+    throw new ModelFetchError('TOO_LARGE', `asset exceeds the ${maxBytes}-byte cap mid-stream`);
+  }
+
+  onProgress?.({ phase: 'verifying', receivedBytes: received, totalBytes: totalBytes || received });
+  const got = hash.digest('hex');
+  if (got !== expected) {
+    throw new ModelFetchError('INTEGRITY_MISMATCH', 'integrity check failed', {
+      expected,
+      actual: got,
+    });
+  }
+  return { bytes: received };
+}
+
+function abortedError(signal: AbortSignal): ModelFetchError {
+  const reason = signal.reason;
+  const detail = reason instanceof Error ? reason.message : reason ? String(reason) : 'aborted';
+  return new ModelFetchError('ABORTED', `download aborted: ${detail}`);
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    return (await stat(p)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function fileSize(p: string): Promise<number> {
+  try {
+    return (await stat(p)).size;
+  } catch {
+    return 0;
+  }
+}
+
+function safeHost(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return 'invalid-url';
+  }
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/model-fetch/src/index.ts
+++ b/packages/model-fetch/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * @moxxy/model-fetch — download-and-verify helper for on-demand model assets.
+ *
+ * The public surface:
+ *   - {@link fetchModelAsset}  https download → streamed sha256 → atomic publish
+ *   - {@link extractTarBz2}    hardened `.tar.bz2` extraction
+ *   - {@link ensureModel}      download-if-missing + extract-if-missing convenience
+ *   - {@link ModelFetchError}  typed failure with a precise `code`
+ */
+
+export { ModelFetchError, type ModelFetchErrorCode } from './errors.js';
+export {
+  fetchModelAsset,
+  isAllowedAssetUrl,
+  DEFAULT_ALLOWED_HOSTS,
+  DEFAULT_MAX_BYTES,
+  type FetchLike,
+  type FetchModelAssetOptions,
+  type FetchModelAssetResult,
+  type FetchProgress,
+  type FetchPhase,
+} from './fetch-asset.js';
+export {
+  extractTarBz2,
+  safeEntryPath,
+  type ExtractTarBz2Options,
+  type ExtractProgress,
+} from './extract.js';
+export {
+  ensureModel,
+  type EnsureModelOptions,
+  type EnsureModelResult,
+  type EnsureModelProgress,
+  type EnsureModelPhase,
+} from './ensure-model.js';

--- a/packages/model-fetch/tsconfig.json
+++ b/packages/model-fetch/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/model-fetch/vitest.config.ts
+++ b/packages/model-fetch/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/packages/plugin-plugins-admin/src/catalog.ts
+++ b/packages/plugin-plugins-admin/src/catalog.ts
@@ -295,6 +295,15 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     provides: [{ category: 'synthesizer', name: 'elevenlabs' }],
   },
   {
+    id: 'tts-local',
+    label: 'Local voice (offline TTS)',
+    description:
+      'Fully on-device text-to-speech (English + Polish) via sherpa-onnx Piper voices. No API key; each voice is a one-time ~64 MB verified download.',
+    packageName: '@moxxy/plugin-tts-local',
+    installSpec: '@moxxy/plugin-tts-local',
+    provides: [{ category: 'synthesizer', name: 'local-piper' }],
+  },
+  {
     id: 'provider-admin',
     label: 'Provider admin tools',
     description: 'provider_add/list/remove/test — register OpenAI-compatible vendors at runtime.',

--- a/packages/plugin-tts-local/package.json
+++ b/packages/plugin-tts-local/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@moxxy/plugin-tts-local",
+  "version": "0.0.0",
+  "description": "Fully local, on-device text-to-speech Synthesizer for moxxy. Runs Piper voices (English + Polish) via sherpa-onnx in a forked sidecar process; voice models download once on first use from sherpa-onnx's pinned releases (sha256-verified). No API key, no network at synthesis time. Plugs into the session SynthesizerRegistry — desktop read-aloud, the TUI, and channel voice replies consume it transparently.",
+  "keywords": [
+    "moxxy",
+    "agent",
+    "tts",
+    "text-to-speech",
+    "offline",
+    "on-device",
+    "piper",
+    "sherpa-onnx",
+    "synthesizer"
+  ],
+  "homepage": "https://moxxy.ai",
+  "bugs": {
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
+    "directory": "packages/plugin-tts-local"
+  },
+  "author": "Michal Makowski <michal.makowski97@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "moxxy": {
+    "plugin": {
+      "entry": "./dist/index.js",
+      "kind": "synthesizer"
+    }
+  },
+  "dependencies": {
+    "@moxxy/model-fetch": "workspace:*",
+    "@moxxy/sdk": "workspace:*",
+    "sherpa-onnx-node": "^1.13.3"
+  },
+  "devDependencies": {
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugin-tts-local/src/host-client.test.ts
+++ b/packages/plugin-tts-local/src/host-client.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import { HostClient, type ChildHandle, type ForkLike } from './host-client.js';
+import type { HostReply, HostRequest } from './host-protocol.js';
+
+/** A controllable fake sidecar: records sent requests + kill, and lets the test
+ *  drive `message`/`exit`/`error` back to the client. */
+class FakeChild implements ChildHandle {
+  readonly sent: HostRequest[] = [];
+  killed = false;
+  private readonly listeners: Record<string, Array<(...a: unknown[]) => void>> = {
+    message: [],
+    exit: [],
+    error: [],
+  };
+
+  send(message: unknown): boolean {
+    this.sent.push(message as HostRequest);
+    return true;
+  }
+  on(event: string, listener: (...args: unknown[]) => void): this {
+    this.listeners[event]!.push(listener);
+    return this;
+  }
+  kill(): boolean {
+    this.killed = true;
+    return true;
+  }
+
+  private emit(event: string, ...args: unknown[]): void {
+    for (const cb of [...this.listeners[event]!]) cb(...args);
+  }
+  /** Reply to the last request the client sent. */
+  replyOk(samples: number[], sampleRate = 22050): void {
+    this.replyOkTo(this.sent.at(-1)!.id, samples, sampleRate);
+  }
+  /** Reply to a specific request id (drives out-of-order correlation tests). */
+  replyOkTo(id: number, samples: number[], sampleRate = 22050): void {
+    this.emit('message', { id, ok: true, samples: new Float32Array(samples), sampleRate } satisfies HostReply);
+  }
+  replyErr(kind: 'init' | 'runtime', message: string): void {
+    const id = this.sent.at(-1)!.id;
+    this.emit('message', { id, ok: false, error: { kind, message } } satisfies HostReply);
+  }
+  crash(code = 1): void {
+    this.emit('exit', code, null);
+  }
+  errorOut(message: string): void {
+    this.emit('error', new Error(message));
+  }
+}
+
+/** A fork factory handing out a fixed list of children, tracking call count. */
+function forkFactory(children: FakeChild[]): { fork: ForkLike; calls: () => number } {
+  let n = 0;
+  const fork: ForkLike = () => {
+    const child = children[n];
+    n += 1;
+    if (!child) throw new Error(`unexpected fork #${n}`);
+    return child;
+  };
+  return { fork, calls: () => n };
+}
+
+const REQ = {
+  voiceKey: '/m/model.onnx',
+  model: '/m/model.onnx',
+  tokens: '/m/tokens.txt',
+  dataDir: '/m/espeak-ng-data',
+  numThreads: 2,
+  provider: 'cpu',
+  text: 'hello',
+  sid: 0,
+  speed: 1,
+};
+
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+describe('HostClient', () => {
+  it('does not fork until the first synthesize (lazy spawn)', async () => {
+    const child = new FakeChild();
+    const { fork, calls } = forkFactory([child]);
+    const host = new HostClient({ hostPath: '/x/sidecar.js', env: {}, forkImpl: fork });
+    expect(calls()).toBe(0);
+    const p = host.synthesize(REQ);
+    await tick();
+    expect(calls()).toBe(1);
+    child.replyOk([0.5, -0.5], 16000);
+    await expect(p).resolves.toEqual({ samples: new Float32Array([0.5, -0.5]), sampleRate: 16000 });
+    host.shutdown();
+  });
+
+  it('correlates replies by id and reuses one child across calls', async () => {
+    const child = new FakeChild();
+    const { fork, calls } = forkFactory([child]);
+    const host = new HostClient({ hostPath: '/x/sidecar.js', env: {}, forkImpl: fork });
+
+    const p1 = host.synthesize({ ...REQ, text: 'one' });
+    await tick();
+    const p2 = host.synthesize({ ...REQ, text: 'two' });
+    await tick();
+    // Two distinct ids were sent to the same child.
+    expect(child.sent.map((m) => m.id)).toEqual([1, 2]);
+    expect(calls()).toBe(1);
+    // Reply out of order — id correlation must still settle each promise.
+    child.replyOkTo(2, [2]);
+    child.replyOkTo(1, [1]);
+    await expect(p1).resolves.toMatchObject({ samples: new Float32Array([1]) });
+    await expect(p2).resolves.toMatchObject({ samples: new Float32Array([2]) });
+    host.shutdown();
+  });
+
+  it('rejects a synthesis error reply', async () => {
+    const child = new FakeChild();
+    const { fork } = forkFactory([child]);
+    const host = new HostClient({ hostPath: '/x/sidecar.js', env: {}, forkImpl: fork });
+    const p = host.synthesize(REQ);
+    await tick();
+    child.replyErr('runtime', 'boom');
+    await expect(p).rejects.toThrow(/runtime error: boom/);
+    host.shutdown();
+  });
+
+  it('restarts the sidecar once on a crash and completes on the fresh child', async () => {
+    const first = new FakeChild();
+    const second = new FakeChild();
+    const { fork, calls } = forkFactory([first, second]);
+    const host = new HostClient({ hostPath: '/x/sidecar.js', env: {}, forkImpl: fork });
+
+    const p = host.synthesize(REQ);
+    await tick();
+    expect(calls()).toBe(1);
+    first.crash(139); // dies with the request in flight
+    await tick();
+    // A fresh child was spawned for the retry.
+    expect(calls()).toBe(2);
+    second.replyOk([0.25], 8000);
+    await expect(p).resolves.toEqual({ samples: new Float32Array([0.25]), sampleRate: 8000 });
+    host.shutdown();
+  });
+
+  it('gives up after a second consecutive crash', async () => {
+    const first = new FakeChild();
+    const second = new FakeChild();
+    const { fork } = forkFactory([first, second]);
+    const host = new HostClient({ hostPath: '/x/sidecar.js', env: {}, forkImpl: fork });
+    const p = host.synthesize(REQ);
+    await tick();
+    first.crash();
+    await tick();
+    second.crash();
+    await expect(p).rejects.toThrow(/sidecar exited/);
+    host.shutdown();
+  });
+
+  it('treats a spawn error as a crash', async () => {
+    const child = new FakeChild();
+    const second = new FakeChild();
+    const { fork } = forkFactory([child, second]);
+    const host = new HostClient({ hostPath: '/x/sidecar.js', env: {}, forkImpl: fork });
+    const p = host.synthesize(REQ);
+    await tick();
+    child.errorOut('ENOENT node');
+    await tick();
+    second.replyOk([1]);
+    await expect(p).resolves.toMatchObject({ samples: new Float32Array([1]) });
+    host.shutdown();
+  });
+
+  it('times out a hung synthesis and kills the child', async () => {
+    const child = new FakeChild();
+    const { fork } = forkFactory([child]);
+    const host = new HostClient({
+      hostPath: '/x/sidecar.js',
+      env: {},
+      forkImpl: fork,
+      requestTimeoutMs: 10,
+    });
+    const p = host.synthesize(REQ);
+    await expect(p).rejects.toThrow(/timed out/);
+    expect(child.killed).toBe(true);
+    host.shutdown();
+  });
+
+  it('shutdown kills the child and rejects in-flight requests', async () => {
+    const child = new FakeChild();
+    const { fork } = forkFactory([child]);
+    const host = new HostClient({ hostPath: '/x/sidecar.js', env: {}, forkImpl: fork });
+    const p = host.synthesize(REQ);
+    await tick();
+    host.shutdown();
+    expect(child.killed).toBe(true);
+    await expect(p).rejects.toThrow(/shut down/);
+    // Further calls fail fast.
+    await expect(host.synthesize(REQ)).rejects.toThrow(/shut down/);
+  });
+});

--- a/packages/plugin-tts-local/src/host-client.ts
+++ b/packages/plugin-tts-local/src/host-client.ts
@@ -1,0 +1,205 @@
+/**
+ * Parent-side manager for the sherpa sidecar: lazy-spawn on first synthesize,
+ * a correlated request/reply protocol over the fork IPC channel, restart-once
+ * on a crash, and a clean shutdown. The `fork` itself is injectable (a
+ * {@link ForkLike}) so tests drive the whole protocol against a fake child with
+ * no real process.
+ */
+
+import { fork } from 'node:child_process';
+
+import type { HostReply, HostRequest } from './host-protocol.js';
+
+/** The minimal child-process surface the client drives — satisfied by a real
+ *  `ChildProcess` and by a test fake. */
+export interface ChildHandle {
+  send(message: unknown): boolean;
+  on(event: 'message', listener: (message: unknown) => void): this;
+  on(event: 'exit', listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  kill(signal?: NodeJS.Signals): boolean;
+}
+
+/** Fork the sidecar with the given env overrides. Injectable for tests. */
+export type ForkLike = (modulePath: string, env: NodeJS.ProcessEnv) => ChildHandle;
+
+/** Default fork: advanced serialization (Float32Array round-trip), an IPC
+ *  channel, and inherited std streams so sherpa's own diagnostics reach the
+ *  runner log. `env` already carries the platform loader-path var. */
+export const defaultFork: ForkLike = (modulePath, env) =>
+  fork(modulePath, [], {
+    serialization: 'advanced',
+    env,
+    execArgv: [],
+    stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+  }) as unknown as ChildHandle;
+
+export interface HostClientOptions {
+  /** Absolute path to the built sidecar (`dist/sidecar.js`). */
+  readonly hostPath: string;
+  /** Env the child is forked with (platform loader path merged over process.env). */
+  readonly env: NodeJS.ProcessEnv;
+  /** Injected fork (tests). Defaults to {@link defaultFork}. */
+  readonly forkImpl?: ForkLike;
+  /** Per-request deadline. Default 120s (a long read-aloud on CPU). */
+  readonly requestTimeoutMs?: number;
+  /** Optional diagnostic sink. */
+  readonly log?: (msg: string) => void;
+}
+
+/** The slice of a host the synthesizer depends on — lets tests swap a fake. */
+export interface HostClientLike {
+  synthesize(
+    req: Omit<HostRequest, 'id' | 'type'>,
+  ): Promise<{ samples: Float32Array; sampleRate: number }>;
+  shutdown(): void;
+}
+
+/** Raised when the sidecar dies with a request in flight; drives the one retry. */
+export class HostCrashError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'HostCrashError';
+  }
+}
+
+interface Pending {
+  readonly resolve: (r: { samples: Float32Array; sampleRate: number }) => void;
+  readonly reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+export class HostClient implements HostClientLike {
+  private readonly hostPath: string;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly forkImpl: ForkLike;
+  private readonly timeoutMs: number;
+  private readonly log: (msg: string) => void;
+
+  private child: ChildHandle | null = null;
+  private readonly pending = new Map<number, Pending>();
+  private nextId = 1;
+  private disposed = false;
+
+  constructor(opts: HostClientOptions) {
+    this.hostPath = opts.hostPath;
+    this.env = opts.env;
+    this.forkImpl = opts.forkImpl ?? defaultFork;
+    this.timeoutMs = opts.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.log = opts.log ?? (() => {});
+  }
+
+  /** Synthesize, restarting the sidecar ONCE if it crashes mid-request. */
+  async synthesize(
+    req: Omit<HostRequest, 'id' | 'type'>,
+  ): Promise<{ samples: Float32Array; sampleRate: number }> {
+    try {
+      return await this.send(req);
+    } catch (err) {
+      if (err instanceof HostCrashError && !this.disposed) {
+        this.log(`tts-local: sherpa sidecar crashed (${err.message}) — restarting once`);
+        return await this.send(req); // a second crash propagates
+      }
+      throw err;
+    }
+  }
+
+  private send(
+    req: Omit<HostRequest, 'id' | 'type'>,
+  ): Promise<{ samples: Float32Array; sampleRate: number }> {
+    if (this.disposed) return Promise.reject(new Error('tts-local host is shut down'));
+    const child = this.ensureChild();
+    const id = this.nextId++;
+    const message: HostRequest = { ...req, id, type: 'synthesize' };
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        // A hung synthesis is unrecoverable for this child — reset it so the
+        // next call starts fresh.
+        this.killChild();
+        reject(new Error(`tts-local synthesis timed out after ${this.timeoutMs} ms`));
+      }, this.timeoutMs);
+      timer.unref?.();
+      this.pending.set(id, { resolve, reject, timer });
+      try {
+        child.send(message);
+      } catch (err) {
+        this.settle(id, () =>
+          reject(err instanceof Error ? err : new Error(String(err))),
+        );
+      }
+    });
+  }
+
+  private ensureChild(): ChildHandle {
+    if (this.child) return this.child;
+    const child = this.forkImpl(this.hostPath, this.env);
+    this.child = child;
+    child.on('message', (msg: unknown) => this.onMessage(msg));
+    child.on('exit', (code, signal) => this.onExit(code, signal));
+    child.on('error', (err) => this.onError(err));
+    return child;
+  }
+
+  private onMessage(msg: unknown): void {
+    const reply = msg as HostReply;
+    if (!reply || typeof reply !== 'object' || typeof reply.id !== 'number') return;
+    const p = this.pending.get(reply.id);
+    if (!p) return;
+    this.settle(reply.id, () => {
+      if (reply.ok) p.resolve({ samples: reply.samples, sampleRate: reply.sampleRate });
+      else p.reject(new Error(`tts-local sidecar ${reply.error.kind} error: ${reply.error.message}`));
+    });
+  }
+
+  private onExit(code: number | null, signal: NodeJS.Signals | null): void {
+    this.child = null;
+    if (this.pending.size === 0) return;
+    const why = `sidecar exited (code=${code ?? 'null'}, signal=${signal ?? 'null'})`;
+    this.rejectAll(new HostCrashError(why));
+  }
+
+  private onError(err: Error): void {
+    this.child = null;
+    this.rejectAll(new HostCrashError(`sidecar spawn/runtime error: ${err.message}`));
+  }
+
+  /** Resolve/reject one pending request, clearing its timer and map entry. */
+  private settle(id: number, run: () => void): void {
+    const p = this.pending.get(id);
+    if (!p) return;
+    if (p.timer) clearTimeout(p.timer);
+    this.pending.delete(id);
+    run();
+  }
+
+  private rejectAll(err: Error): void {
+    for (const [id, p] of this.pending) {
+      if (p.timer) clearTimeout(p.timer);
+      this.pending.delete(id);
+      p.reject(err);
+    }
+  }
+
+  private killChild(): void {
+    const child = this.child;
+    this.child = null;
+    if (child) {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+
+  /** Kill the sidecar and fail any in-flight requests. Idempotent. */
+  shutdown(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.rejectAll(new Error('tts-local host shut down'));
+    this.killChild();
+  }
+}

--- a/packages/plugin-tts-local/src/host-protocol.test.ts
+++ b/packages/plugin-tts-local/src/host-protocol.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createMessageHandler,
+  type HostRequest,
+  type SherpaModule,
+  type SherpaOfflineTts,
+} from './host-protocol.js';
+
+function req(over: Partial<HostRequest> = {}): HostRequest {
+  return {
+    id: 1,
+    type: 'synthesize',
+    voiceKey: '/models/en/model.onnx',
+    model: '/models/en/model.onnx',
+    tokens: '/models/en/tokens.txt',
+    dataDir: '/models/en/espeak-ng-data',
+    numThreads: 2,
+    provider: 'cpu',
+    text: 'hello',
+    sid: 0,
+    speed: 1,
+    ...over,
+  };
+}
+
+/** A fake sherpa module recording how many OfflineTts instances + generate
+ *  calls it saw, with configurable behaviour. */
+function fakeSherpa(opts: {
+  onGenerate?: (args: { text: string; sid: number; speed: number }) => {
+    samples: Float32Array;
+    sampleRate: number;
+  };
+  throwOnConstruct?: boolean;
+  throwOnGenerate?: boolean;
+} = {}): { module: SherpaModule; constructed: number; generated: number; lastConfig: unknown } {
+  const state = { constructed: 0, generated: 0, lastConfig: undefined as unknown };
+  class FakeTts implements SherpaOfflineTts {
+    constructor(config: unknown) {
+      if (opts.throwOnConstruct) throw new Error('addon failed to load libonnxruntime.dylib');
+      state.constructed += 1;
+      state.lastConfig = config;
+    }
+    async generateAsync(args: { text: string; sid: number; speed: number }): Promise<{
+      samples: Float32Array;
+      sampleRate: number;
+    }> {
+      state.generated += 1;
+      if (opts.throwOnGenerate) throw new Error('generate blew up');
+      return opts.onGenerate?.(args) ?? { samples: new Float32Array([0.1, 0.2]), sampleRate: 22050 };
+    }
+  }
+  return {
+    module: { OfflineTts: FakeTts as unknown as SherpaModule['OfflineTts'] },
+    get constructed() {
+      return state.constructed;
+    },
+    get generated() {
+      return state.generated;
+    },
+    get lastConfig() {
+      return state.lastConfig;
+    },
+  };
+}
+
+describe('createMessageHandler', () => {
+  it('synthesizes and returns samples + sampleRate', async () => {
+    const s = fakeSherpa({ onGenerate: () => ({ samples: new Float32Array([1, -1]), sampleRate: 16000 }) });
+    const handle = createMessageHandler(() => s.module);
+    const reply = await handle(req({ id: 7, text: 'hi', speed: 1.25 }));
+    expect(reply).toMatchObject({ id: 7, ok: true, sampleRate: 16000 });
+    if (reply.ok) expect(Array.from(reply.samples)).toEqual([1, -1]);
+  });
+
+  it('passes the vits model config through to sherpa', async () => {
+    const s = fakeSherpa();
+    const handle = createMessageHandler(() => s.module);
+    await handle(req());
+    expect(s.lastConfig).toMatchObject({
+      model: {
+        vits: { model: '/models/en/model.onnx', tokens: '/models/en/tokens.txt', dataDir: '/models/en/espeak-ng-data' },
+        numThreads: 2,
+        provider: 'cpu',
+      },
+      maxNumSentences: 1,
+    });
+  });
+
+  it('caches one OfflineTts per voiceKey (loads the model once)', async () => {
+    const s = fakeSherpa();
+    let loads = 0;
+    const handle = createMessageHandler(() => {
+      loads += 1;
+      return s.module;
+    });
+    await handle(req({ id: 1 }));
+    await handle(req({ id: 2 }));
+    await handle(req({ id: 3, voiceKey: '/models/pl/model.onnx', model: '/models/pl/model.onnx' }));
+    expect(loads).toBe(1); // module loaded once
+    expect(s.constructed).toBe(2); // one OfflineTts per distinct voiceKey
+    expect(s.generated).toBe(3);
+  });
+
+  it('classifies a load/construct failure as an init error', async () => {
+    const s = fakeSherpa({ throwOnConstruct: true });
+    const handle = createMessageHandler(() => s.module);
+    const reply = await handle(req());
+    expect(reply.ok).toBe(false);
+    if (!reply.ok) expect(reply.error.kind).toBe('init');
+  });
+
+  it('classifies a load-time throw as an init error', async () => {
+    const handle = createMessageHandler(() => {
+      throw new Error('cannot find module sherpa-onnx-node');
+    });
+    const reply = await handle(req());
+    expect(reply.ok).toBe(false);
+    if (!reply.ok) expect(reply.error.kind).toBe('init');
+  });
+
+  it('classifies a synthesis failure as a runtime error', async () => {
+    const s = fakeSherpa({ throwOnGenerate: true });
+    const handle = createMessageHandler(() => s.module);
+    const reply = await handle(req());
+    expect(reply.ok).toBe(false);
+    if (!reply.ok) expect(reply.error.kind).toBe('runtime');
+  });
+});

--- a/packages/plugin-tts-local/src/host-protocol.ts
+++ b/packages/plugin-tts-local/src/host-protocol.ts
@@ -1,0 +1,127 @@
+/**
+ * The tiny JSON message protocol spoken between the parent (host-client) and
+ * the forked sherpa sidecar, plus the pure per-message handler the sidecar
+ * runs. Kept free of `node:child_process` so BOTH sides can import it (the
+ * parent for the types, the child for the handler) without dragging fork
+ * plumbing into either bundle.
+ *
+ * Wire shape (over the fork IPC channel, `serialization: 'advanced'` so the
+ * Float32Array round-trips intact):
+ *   parent → child:  SynthesizeRequest
+ *   child  → parent: HostReply
+ */
+
+/** One synthesis request. Carries the full model config so the sidecar is
+ *  stateless-per-message except for a model cache keyed by `voiceKey`. */
+export interface SynthesizeRequest {
+  readonly id: number;
+  readonly type: 'synthesize';
+  /** Cache key for the loaded model (the absolute `.onnx` path). */
+  readonly voiceKey: string;
+  /** Absolute path to the VITS `.onnx` model. */
+  readonly model: string;
+  /** Absolute path to `tokens.txt`. */
+  readonly tokens: string;
+  /** Absolute path to the `espeak-ng-data` directory. */
+  readonly dataDir: string;
+  /** Inference thread count. */
+  readonly numThreads: number;
+  /** Compute provider (`cpu`). */
+  readonly provider: string;
+  /** Text to speak. */
+  readonly text: string;
+  /** Speaker id within the model (0 for single-speaker Piper voices). */
+  readonly sid: number;
+  /** Speaking-rate multiplier already clamped by the caller. */
+  readonly speed: number;
+}
+
+export type HostRequest = SynthesizeRequest;
+
+export type HostErrorKind =
+  /** Model failed to load (bad/absent files, unsupported arch, addon dlopen). */
+  | 'init'
+  /** Synthesis itself threw. */
+  | 'runtime';
+
+export type HostReply =
+  | {
+      readonly id: number;
+      readonly ok: true;
+      readonly sampleRate: number;
+      /** Mono PCM in [-1, 1]; structured-cloned intact over advanced IPC. */
+      readonly samples: Float32Array;
+    }
+  | {
+      readonly id: number;
+      readonly ok: false;
+      readonly error: { readonly message: string; readonly kind: HostErrorKind };
+    };
+
+/** The subset of the sherpa-onnx-node surface the sidecar uses. Declared here
+ *  (rather than leaning on the addon's ambient types) so the handler is
+ *  unit-testable with a fake module and typechecks without the native addon. */
+export interface SherpaOfflineTts {
+  generateAsync(args: {
+    text: string;
+    sid: number;
+    speed: number;
+  }): Promise<{ samples: Float32Array; sampleRate: number }>;
+}
+
+export interface SherpaModule {
+  OfflineTts: new (config: unknown) => SherpaOfflineTts;
+}
+
+/** Lazily load the native sherpa module (so a dlopen failure surfaces as a
+ *  classified reply, not a boot crash). */
+export type LoadSherpa = () => SherpaModule;
+
+export type HostMessageHandler = (req: HostRequest) => Promise<HostReply>;
+
+/**
+ * Build the sidecar's message handler. Loads the sherpa module on first use and
+ * caches one `OfflineTts` per `voiceKey` so repeated calls on the same voice
+ * reuse the loaded model. Every failure becomes a typed `ok:false` reply —
+ * nothing throws out of `handle`.
+ */
+export function createMessageHandler(loadSherpa: LoadSherpa): HostMessageHandler {
+  const cache = new Map<string, SherpaOfflineTts>();
+  let mod: SherpaModule | null = null;
+
+  return async function handle(req: HostRequest): Promise<HostReply> {
+    let tts = cache.get(req.voiceKey);
+    if (!tts) {
+      try {
+        mod ??= loadSherpa();
+        tts = new mod.OfflineTts({
+          model: {
+            vits: { model: req.model, tokens: req.tokens, dataDir: req.dataDir },
+            numThreads: req.numThreads,
+            provider: req.provider,
+            debug: false,
+          },
+          maxNumSentences: 1,
+        });
+        cache.set(req.voiceKey, tts);
+      } catch (err) {
+        return { id: req.id, ok: false, error: { message: errMsg(err), kind: 'init' } };
+      }
+    }
+
+    try {
+      const out = await tts.generateAsync({ text: req.text, sid: req.sid, speed: req.speed });
+      const samples =
+        out.samples instanceof Float32Array
+          ? out.samples
+          : Float32Array.from(out.samples as ArrayLike<number>);
+      return { id: req.id, ok: true, sampleRate: out.sampleRate, samples };
+    } catch (err) {
+      return { id: req.id, ok: false, error: { message: errMsg(err), kind: 'runtime' } };
+    }
+  };
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/plugin-tts-local/src/index.ts
+++ b/packages/plugin-tts-local/src/index.ts
@@ -1,0 +1,90 @@
+import { definePlugin, defineSynthesizer, type Plugin } from '@moxxy/sdk';
+
+import {
+  createLocalPiperSynthesizer,
+  LOCAL_PIPER_SYNTHESIZER_NAME,
+  shutdownLocalTts,
+  type LocalPiperOptions,
+} from './local-tts.js';
+
+export {
+  LocalPiperSynthesizer,
+  createLocalPiperSynthesizer,
+  clampSpeed,
+  shutdownLocalTts,
+  LOCAL_PIPER_SYNTHESIZER_NAME,
+  type LocalPiperOptions,
+  type VoiceModelPaths,
+} from './local-tts.js';
+export { encodeWav, WAV_HEADER_BYTES } from './wav.js';
+export {
+  VOICE_CATALOG,
+  voiceIds,
+  findVoice,
+  routeVoice,
+  requireVoice,
+  DEFAULT_VOICE_ID,
+  DEFAULT_POLISH_VOICE_ID,
+  type VoiceEntry,
+  type VoiceLanguage,
+} from './voices.js';
+export { HostClient, type HostClientLike, type ForkLike, type ChildHandle } from './host-client.js';
+export {
+  sherpaPlatformPackage,
+  resolveSherpaLibDir,
+  sherpaEnv,
+  libraryPathVar,
+} from './platform.js';
+
+export interface BuildLocalTtsPluginOptions {
+  /** Build-time defaults / test seams for the synthesizer (injected
+   *  `ensureModelImpl`, `hostFactory`, `fetchImpl`, `modelsDir`, `log`). */
+  readonly defaults?: LocalPiperOptions;
+}
+
+/**
+ * Build the @moxxy/plugin-tts-local plugin. Registers exactly one synthesizer,
+ * `local-piper`, backed by sherpa-onnx Piper voices running in a forked
+ * sidecar. Side-effect free at load: no model is downloaded and no process is
+ * spawned until the first `synthesize`. Per-activation config
+ * (`session.synthesizers.setActive('local-piper', { voice, polishVoice,
+ * numThreads })`) overrides the build-time defaults.
+ */
+export function buildLocalTtsPlugin(opts: BuildLocalTtsPluginOptions = {}): Plugin {
+  const defaults = opts.defaults ?? {};
+  return definePlugin({
+    name: '@moxxy/plugin-tts-local',
+    version: '0.0.0',
+    synthesizers: [
+      defineSynthesizer({
+        name: LOCAL_PIPER_SYNTHESIZER_NAME,
+        displayName: 'Local (Piper — offline, EN+PL)',
+        // `create` runs lazily and may re-run (buildOnRead) — keep it cheap and
+        // side-effect free; the sidecar + download happen on first synthesize.
+        create: (ctx) =>
+          createLocalPiperSynthesizer({ ...defaults, ...configToOptions(ctx.config) }),
+      }),
+    ],
+    // Kill every spawned sidecar when the session/runner shuts down.
+    hooks: { onShutdown: () => shutdownLocalTts() },
+  });
+}
+
+/** Narrow the untrusted per-activation config into typed options — only the
+ *  known string `voice` / `polishVoice` and a positive-integer `numThreads` are
+ *  honored so a malformed config can't break `create` or route to a bad voice
+ *  (unknown ids are caught by `requireVoice` at construction). */
+function configToOptions(config: Record<string, unknown>): Partial<LocalPiperOptions> {
+  const out: { -readonly [K in keyof LocalPiperOptions]?: LocalPiperOptions[K] } = {};
+  if (typeof config.voice === 'string' && config.voice) out.voice = config.voice;
+  if (typeof config.polishVoice === 'string' && config.polishVoice) {
+    out.polishVoice = config.polishVoice;
+  }
+  if (typeof config.numThreads === 'number' && Number.isInteger(config.numThreads) && config.numThreads > 0) {
+    out.numThreads = config.numThreads;
+  }
+  return out;
+}
+
+// Discovery entry: `createPluginLoader` requires a default Plugin export.
+export default buildLocalTtsPlugin();

--- a/packages/plugin-tts-local/src/live.test.ts
+++ b/packages/plugin-tts-local/src/live.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createLocalPiperSynthesizer } from './local-tts.js';
+
+// vitest runs the TypeScript SOURCE, so `import.meta.url` here is src/. The
+// sidecar must be the COMPILED entry, so point at dist/sidecar.js (build first:
+// `pnpm -F @moxxy/plugin-tts-local build`).
+const SIDECAR_PATH = fileURLToPath(new URL('../dist/sidecar.js', import.meta.url));
+
+/**
+ * Opt-in end-to-end test that REALLY downloads a voice and runs the native
+ * sherpa sidecar — off by default (it fetches ~64 MB and needs the platform
+ * binary). Run manually with:
+ *
+ *   MOXXY_TTS_LOCAL_LIVE=1 pnpm -F @moxxy/plugin-tts-local test
+ */
+const LIVE = !!process.env.MOXXY_TTS_LOCAL_LIVE;
+
+let modelsDir: string;
+beforeAll(async () => {
+  if (!LIVE) return;
+  modelsDir = await mkdtemp(path.join(tmpdir(), 'tts-local-live-'));
+});
+afterAll(async () => {
+  if (modelsDir) await rm(modelsDir, { recursive: true, force: true });
+});
+
+describe.skipIf(!LIVE)('local TTS (live, real download + native sidecar)', () => {
+  it('synthesizes English audio', async () => {
+    const synth = createLocalPiperSynthesizer({ modelsDir, sidecarPath: SIDECAR_PATH });
+    try {
+      const out = await synth.synthesize('Hello from a fully local voice.', { language: 'en' });
+      expect(out.mimeType).toBe('audio/wav');
+      expect(String.fromCharCode(...out.audio.subarray(0, 4))).toBe('RIFF');
+      expect(out.audio.byteLength).toBeGreaterThan(44 + 1000);
+    } finally {
+      synth.shutdown();
+    }
+  }, 600_000);
+
+  it('synthesizes Polish audio', async () => {
+    const synth = createLocalPiperSynthesizer({ modelsDir, sidecarPath: SIDECAR_PATH });
+    try {
+      const out = await synth.synthesize('Dzień dobry, mówię po polsku.', { language: 'pl' });
+      expect(out.mimeType).toBe('audio/wav');
+      expect(out.audio.byteLength).toBeGreaterThan(44 + 1000);
+    } finally {
+      synth.shutdown();
+    }
+  }, 600_000);
+});

--- a/packages/plugin-tts-local/src/local-tts.test.ts
+++ b/packages/plugin-tts-local/src/local-tts.test.ts
@@ -1,0 +1,195 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { ensureModel } from '@moxxy/model-fetch';
+
+import {
+  clampSpeed,
+  createLocalPiperSynthesizer,
+  type LocalPiperOptions,
+} from './local-tts.js';
+import { buildLocalTtsPlugin, LOCAL_PIPER_SYNTHESIZER_NAME } from './index.js';
+import type { HostClientLike } from './host-client.js';
+import type { HostRequest } from './host-protocol.js';
+
+/** A fake host recording each synthesize request; returns canned samples. */
+function fakeHost(): { host: HostClientLike; reqs: Array<Omit<HostRequest, 'id' | 'type'>>; shutdowns: number } {
+  const state = { reqs: [] as Array<Omit<HostRequest, 'id' | 'type'>>, shutdowns: 0 };
+  const host: HostClientLike = {
+    async synthesize(req) {
+      state.reqs.push(req);
+      return { samples: new Float32Array([0.1, -0.1, 0.2]), sampleRate: 22050 };
+    },
+    shutdown() {
+      state.shutdowns += 1;
+    },
+  };
+  return { host, get reqs() {
+    return state.reqs;
+  }, get shutdowns() {
+    return state.shutdowns;
+  } };
+}
+
+/** A fake ensureModel recording the urls it was asked to fetch. */
+function fakeEnsure(): { impl: typeof ensureModel; urls: string[] } {
+  const urls: string[] = [];
+  const impl = (async (opts: Parameters<typeof ensureModel>[0]) => {
+    urls.push(opts.url);
+    return { dir: opts.dir, skipped: false };
+  }) as unknown as typeof ensureModel;
+  return { impl, urls };
+}
+
+function makeSynth(over: Partial<LocalPiperOptions> = {}): {
+  synth: ReturnType<typeof createLocalPiperSynthesizer>;
+  host: ReturnType<typeof fakeHost>;
+  ensure: ReturnType<typeof fakeEnsure>;
+} {
+  const host = fakeHost();
+  const ensure = fakeEnsure();
+  const synth = createLocalPiperSynthesizer({
+    modelsDir: '/models/tts',
+    ensureModelImpl: ensure.impl,
+    hostFactory: () => host.host,
+    log: () => {},
+    ...over,
+  });
+  return { synth, host, ensure };
+}
+
+describe('LocalPiperSynthesizer.synthesize', () => {
+  it('defaults to the English voice and returns WAV bytes', async () => {
+    const { synth, host, ensure } = makeSynth();
+    const out = await synth.synthesize('hello world');
+    expect(out.mimeType).toBe('audio/wav');
+    expect(String.fromCharCode(...out.audio.subarray(0, 4))).toBe('RIFF');
+    expect(ensure.urls).toEqual([
+      'https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/vits-piper-en_US-amy-medium.tar.bz2',
+    ]);
+    // The host got the en model path + default sid/speed.
+    expect(host.reqs[0]!.model).toBe(path.join('/models/tts/en_US-amy-medium/vits-piper-en_US-amy-medium/en_US-amy-medium.onnx'));
+    expect(host.reqs[0]!.dataDir).toContain('espeak-ng-data');
+    expect(host.reqs[0]!.text).toBe('hello world');
+    expect(host.reqs[0]!.speed).toBe(1);
+  });
+
+  it('routes a Polish language hint to the configured Polish voice', async () => {
+    const { synth, host, ensure } = makeSynth();
+    await synth.synthesize('cześć', { language: 'pl-PL' });
+    expect(ensure.urls[0]).toContain('vits-piper-pl_PL-gosia-medium');
+    expect(host.reqs[0]!.model).toContain('pl_PL-gosia-medium');
+  });
+
+  it('lets an explicit voice override language routing', async () => {
+    const { synth, host } = makeSynth();
+    await synth.synthesize('lektor', { language: 'pl', voice: 'pl_PL-darkman-medium' });
+    expect(host.reqs[0]!.model).toContain('pl_PL-darkman-medium');
+  });
+
+  it('honors a configured polishVoice default', async () => {
+    const { synth, host } = makeSynth({ polishVoice: 'pl_PL-darkman-medium' });
+    await synth.synthesize('dzień dobry', { language: 'pl' });
+    expect(host.reqs[0]!.model).toContain('pl_PL-darkman-medium');
+  });
+
+  it('rejects an unknown requested voice with a clear error', async () => {
+    const { synth } = makeSynth();
+    await expect(synth.synthesize('x', { voice: 'no-such-voice' })).rejects.toMatchObject({
+      code: 'CONFIG_INVALID',
+    });
+  });
+
+  it('downloads a given voice only once across calls', async () => {
+    const { synth, ensure } = makeSynth();
+    await synth.synthesize('one');
+    await synth.synthesize('two');
+    await synth.synthesize('three');
+    expect(ensure.urls.length).toBe(1); // en voice ensured once
+  });
+
+  it('maps and clamps rate onto sherpa speed', async () => {
+    const { synth, host } = makeSynth();
+    await synth.synthesize('fast', { rate: 5 });
+    await synth.synthesize('slow', { rate: 0.1 });
+    await synth.synthesize('normal');
+    expect(host.reqs.map((r) => r.speed)).toEqual([2.0, 0.5, 1.0]);
+  });
+
+  it('respects a pre-aborted signal', async () => {
+    const { synth } = makeSynth();
+    const ac = new AbortController();
+    ac.abort(new Error('stop'));
+    await expect(synth.synthesize('x', { signal: ac.signal })).rejects.toThrow(/stop/);
+  });
+
+  it('uses numThreads and provider defaults', async () => {
+    const { synth, host } = makeSynth({ numThreads: 4 });
+    await synth.synthesize('hi');
+    expect(host.reqs[0]!.numThreads).toBe(4);
+    expect(host.reqs[0]!.provider).toBe('cpu');
+    expect(host.reqs[0]!.sid).toBe(0);
+  });
+
+  it('shutdown tears down the host', async () => {
+    const { synth, host } = makeSynth();
+    await synth.synthesize('hi');
+    synth.shutdown();
+    expect(host.shutdowns).toBe(1);
+  });
+});
+
+describe('clampSpeed', () => {
+  it('clamps to 0.5–2.0 and defaults absent/non-finite to 1.0', () => {
+    expect(clampSpeed(undefined)).toBe(1.0);
+    expect(clampSpeed(Number.NaN)).toBe(1.0);
+    expect(clampSpeed(1.3)).toBe(1.3);
+    expect(clampSpeed(9)).toBe(2.0);
+    expect(clampSpeed(0.01)).toBe(0.5);
+  });
+});
+
+describe('constructor validation', () => {
+  it('throws CONFIG_INVALID for an unknown configured voice', () => {
+    expect(() => createLocalPiperSynthesizer({ voice: 'bogus' })).toThrow(/Unknown local voice/);
+  });
+  it('throws CONFIG_INVALID for an unknown configured polishVoice', () => {
+    expect(() => createLocalPiperSynthesizer({ polishVoice: 'nope' })).toThrow(/Unknown local voice/);
+  });
+});
+
+describe('buildLocalTtsPlugin', () => {
+  it('registers exactly one synthesizer named local-piper', () => {
+    const plugin = buildLocalTtsPlugin();
+    expect(plugin.synthesizers).toHaveLength(1);
+    const def = plugin.synthesizers![0]!;
+    expect(def.name).toBe(LOCAL_PIPER_SYNTHESIZER_NAME);
+    expect(def.displayName).toContain('Local');
+  });
+
+  it('create() flows per-activation voice config through to routing', async () => {
+    const host = fakeHost();
+    const ensure = fakeEnsure();
+    const plugin = buildLocalTtsPlugin({
+      defaults: {
+        modelsDir: '/models/tts',
+        ensureModelImpl: ensure.impl,
+        hostFactory: () => host.host,
+        log: () => {},
+      },
+    });
+    const inst = plugin.synthesizers![0]!.create({ config: { voice: 'pl_PL-gosia-medium' } });
+    await inst.synthesize('cześć');
+    expect(host.reqs[0]!.model).toContain('pl_PL-gosia-medium');
+  });
+
+  it('create() rejects an unknown voice in config at construction', () => {
+    const plugin = buildLocalTtsPlugin();
+    expect(() => plugin.synthesizers![0]!.create({ config: { voice: 'bad-id' } })).toThrow();
+  });
+
+  it('exposes an onShutdown hook', () => {
+    const plugin = buildLocalTtsPlugin();
+    expect(typeof plugin.hooks?.onShutdown).toBe('function');
+  });
+});

--- a/packages/plugin-tts-local/src/local-tts.ts
+++ b/packages/plugin-tts-local/src/local-tts.ts
@@ -1,0 +1,268 @@
+/**
+ * The `local-piper` Synthesizer: fully local, on-device text-to-speech.
+ *
+ * On the first synthesis for a voice it downloads + verifies that voice's Piper
+ * model (once, via @moxxy/model-fetch), then hands text to the sherpa sidecar
+ * ({@link HostClient}) and wraps the returned samples as WAV. No key, no network
+ * at synthesis time. Language routing sends `pl*` requests to the configured
+ * Polish voice; an explicit `opts.voice` (a catalog id) overrides everything.
+ *
+ * Every collaborator is injectable (`ensureModelImpl`, `hostFactory`, `log`,
+ * `modelsDir`, `fetchImpl`) so the whole flow is unit-testable without the
+ * native addon or a real download.
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { MoxxyError, type SynthesizeOptions, type SynthesisResult, type Synthesizer } from '@moxxy/sdk';
+import { moxxyPath } from '@moxxy/sdk/server';
+import {
+  ensureModel,
+  type EnsureModelProgress,
+  type EnsureModelResult,
+  type FetchLike,
+} from '@moxxy/model-fetch';
+
+import { HostClient, type HostClientLike } from './host-client.js';
+import { resolveSherpaLibDir, sherpaEnv, sherpaPlatformPackage } from './platform.js';
+import {
+  DEFAULT_POLISH_VOICE_ID,
+  DEFAULT_VOICE_ID,
+  requireVoice,
+  routeVoice,
+  type VoiceEntry,
+} from './voices.js';
+import { encodeWav } from './wav.js';
+
+/** The single registered synthesizer name — surfaces show this in `set_voice`. */
+export const LOCAL_PIPER_SYNTHESIZER_NAME = 'local-piper';
+
+/** Local speaking-rate bounds. Piper distorts badly outside this range. */
+const MIN_SPEED = 0.5;
+const MAX_SPEED = 2.0;
+const DEFAULT_NUM_THREADS = 2;
+
+/** Map a `SynthesizeOptions.rate` multiplier onto sherpa's `speed`, clamped.
+ *  An absent / non-finite rate yields 1.0 (natural speed). */
+export function clampSpeed(rate: number | undefined): number {
+  if (rate === undefined || !Number.isFinite(rate)) return 1.0;
+  return Math.min(MAX_SPEED, Math.max(MIN_SPEED, rate));
+}
+
+/** Resolved on-disk paths sherpa needs for one voice. */
+export interface VoiceModelPaths {
+  readonly model: string;
+  readonly tokens: string;
+  readonly dataDir: string;
+}
+
+export interface LocalPiperOptions {
+  /** Default (non-Polish) voice id. Default `en_US-amy-medium`. */
+  readonly voice?: string;
+  /** Voice used for `pl*` language requests. Default `pl_PL-gosia-medium`. */
+  readonly polishVoice?: string;
+  /** Inference threads. Default 2. */
+  readonly numThreads?: number;
+  /** Root for downloaded voices. Default `~/.moxxy/models/tts` (MOXXY_HOME-aware). */
+  readonly modelsDir?: string;
+  /** sherpa compute provider. Default `cpu`. */
+  readonly provider?: string;
+  /** Absolute path to the built sidecar entry. Default: `sidecar.js` beside
+   *  this module (i.e. `dist/sidecar.js` in a published build). Overridable so
+   *  the source-run live test can point at the compiled sidecar. */
+  readonly sidecarPath?: string;
+  /** Injected model-ensure (tests). Defaults to @moxxy/model-fetch `ensureModel`. */
+  readonly ensureModelImpl?: typeof ensureModel;
+  /** Injected `fetch`, threaded into `ensureModel` (tests). */
+  readonly fetchImpl?: FetchLike;
+  /** Injected sidecar host factory (tests). Defaults to a real {@link HostClient}. */
+  readonly hostFactory?: () => HostClientLike;
+  /** Diagnostic log sink (download progress etc.). Defaults to stderr. */
+  readonly log?: (msg: string) => void;
+}
+
+/** Process-wide set of live synthesizers so the plugin's `onShutdown` hook can
+ *  kill every sidecar it spawned. */
+const ACTIVE_SYNTHS = new Set<LocalPiperSynthesizer>();
+
+/** Shut down every live local synthesizer (kills their sidecars). */
+export function shutdownLocalTts(): void {
+  for (const s of ACTIVE_SYNTHS) s.shutdown();
+  ACTIVE_SYNTHS.clear();
+}
+
+export class LocalPiperSynthesizer implements Synthesizer {
+  readonly name = LOCAL_PIPER_SYNTHESIZER_NAME;
+  readonly mimeType = 'audio/wav';
+
+  private readonly voiceId: string;
+  private readonly polishVoiceId: string;
+  private readonly numThreads: number;
+  private readonly modelsDir: string;
+  private readonly provider: string;
+  private readonly sidecarPath: string | undefined;
+  private readonly ensureModelImpl: typeof ensureModel;
+  private readonly fetchImpl: FetchLike | undefined;
+  private readonly hostFactory: () => HostClientLike;
+  private readonly log: (msg: string) => void;
+
+  private host: HostClientLike | null = null;
+  /** In-flight per-voice download promises — de-dupes concurrent first-use. */
+  private readonly ensuring = new Map<string, Promise<EnsureModelResult>>();
+
+  constructor(opts: LocalPiperOptions = {}) {
+    // Validate configured voice ids up front so a bad config fails clearly at
+    // construction rather than on the first (possibly channel-triggered) call.
+    this.voiceId = requireVoice(opts.voice ?? DEFAULT_VOICE_ID, 'voice').id;
+    this.polishVoiceId = requireVoice(opts.polishVoice ?? DEFAULT_POLISH_VOICE_ID, 'polishVoice').id;
+    this.numThreads =
+      opts.numThreads && Number.isInteger(opts.numThreads) && opts.numThreads > 0
+        ? opts.numThreads
+        : DEFAULT_NUM_THREADS;
+    this.modelsDir = opts.modelsDir ?? moxxyPath('models', 'tts');
+    this.provider = opts.provider ?? 'cpu';
+    this.sidecarPath = opts.sidecarPath;
+    this.ensureModelImpl = opts.ensureModelImpl ?? ensureModel;
+    this.fetchImpl = opts.fetchImpl;
+    this.hostFactory = opts.hostFactory ?? (() => this.defaultHost());
+    this.log = opts.log ?? ((msg) => process.stderr.write(`${msg}\n`));
+    ACTIVE_SYNTHS.add(this);
+  }
+
+  async synthesize(text: string, opts: SynthesizeOptions = {}): Promise<SynthesisResult> {
+    opts.signal?.throwIfAborted();
+    const voice = routeVoice({
+      ...(opts.voice !== undefined ? { requestedVoice: opts.voice } : {}),
+      ...(opts.language !== undefined ? { language: opts.language } : {}),
+      defaultVoice: this.voiceId,
+      polishVoice: this.polishVoiceId,
+    });
+
+    const paths = await this.ensureVoice(voice, opts.signal);
+    opts.signal?.throwIfAborted();
+
+    const host = this.getHost();
+    const { samples, sampleRate } = await host.synthesize({
+      voiceKey: paths.model,
+      model: paths.model,
+      tokens: paths.tokens,
+      dataDir: paths.dataDir,
+      numThreads: this.numThreads,
+      provider: this.provider,
+      text,
+      sid: 0,
+      speed: clampSpeed(opts.rate),
+    });
+
+    if (!samples || samples.length === 0) {
+      throw new MoxxyError({
+        code: 'INTERNAL',
+        message: 'Local TTS produced no audio samples.',
+        context: { voice: voice.id },
+      });
+    }
+    return { audio: encodeWav(samples, sampleRate), mimeType: this.mimeType };
+  }
+
+  /** Kill this synthesizer's sidecar (if any) and drop registration. */
+  shutdown(): void {
+    this.host?.shutdown();
+    this.host = null;
+    ACTIVE_SYNTHS.delete(this);
+  }
+
+  private getHost(): HostClientLike {
+    this.host ??= this.hostFactory();
+    return this.host;
+  }
+
+  /** Resolve on-disk paths for `voice`, downloading + extracting it once. */
+  private async ensureVoice(voice: VoiceEntry, signal?: AbortSignal): Promise<VoiceModelPaths> {
+    const dir = path.join(this.modelsDir, voice.id);
+    let inflight = this.ensuring.get(voice.id);
+    if (!inflight) {
+      inflight = this.ensureModelImpl({
+        url: voice.url,
+        sha256: voice.sha256,
+        dir,
+        ...(this.fetchImpl ? { fetchImpl: this.fetchImpl } : {}),
+        ...(signal ? { signal } : {}),
+        onProgress: this.makeProgressLogger(voice),
+      });
+      this.ensuring.set(voice.id, inflight);
+      // On failure, forget the promise so a later call retries the download.
+      inflight.catch(() => this.ensuring.delete(voice.id));
+    }
+    await inflight;
+    return this.voicePaths(voice, dir);
+  }
+
+  private voicePaths(voice: VoiceEntry, dir: string): VoiceModelPaths {
+    const root = path.join(dir, voice.archiveRootDir);
+    return {
+      model: path.join(root, voice.modelFile),
+      tokens: path.join(root, 'tokens.txt'),
+      dataDir: path.join(root, 'espeak-ng-data'),
+    };
+  }
+
+  /** A progress callback that logs a single start line then ~every-10% ticks,
+   *  and an extraction line — but stays silent when the voice is already
+   *  present (ensureModel emits only `done`). */
+  private makeProgressLogger(voice: VoiceEntry): (p: EnsureModelProgress) => void {
+    let started = false;
+    let extracting = false;
+    let lastPct = -1;
+    return (p) => {
+      if (p.phase === 'downloading') {
+        if (!started) {
+          started = true;
+          this.log(
+            `tts-local: first use — downloading ${voice.id} (~${voice.approxMb} MB) to ${this.modelsDir}, one-time`,
+          );
+        }
+        if (p.totalBytes > 0) {
+          const pct = Math.floor((p.receivedBytes / p.totalBytes) * 100);
+          if (pct >= lastPct + 10) {
+            lastPct = pct - (pct % 10);
+            this.log(`tts-local: downloading ${voice.id} … ${lastPct}%`);
+          }
+        }
+      } else if (p.phase === 'extracting' && !extracting) {
+        extracting = true;
+        this.log(`tts-local: extracting ${voice.id} …`);
+      } else if (p.phase === 'done' && started) {
+        this.log(`tts-local: ${voice.id} ready.`);
+      }
+    };
+  }
+
+  /** Build a real sidecar-backed host, resolving the platform loader path.
+   *  Fails clearly when no sherpa binary exists for this platform/arch. */
+  private defaultHost(): HostClientLike {
+    const libDir = resolveSherpaLibDir();
+    if (!libDir) {
+      const pkg = sherpaPlatformPackage();
+      throw new MoxxyError({
+        code: 'PLUGIN_LOAD_FAILED',
+        message: pkg
+          ? `Local TTS could not load the sherpa-onnx binary (${pkg}). Reinstall @moxxy/plugin-tts-local so its platform dependency is fetched.`
+          : `Local TTS has no sherpa-onnx binary for ${process.platform}-${process.arch}.`,
+        hint: 'Use the OpenAI or ElevenLabs read-aloud backend instead, or run on a supported platform (macOS/Linux/Windows x64, macOS/Linux arm64).',
+        context: { platform: process.platform, arch: process.arch },
+      });
+    }
+    const hostPath =
+      this.sidecarPath ?? path.join(path.dirname(fileURLToPath(import.meta.url)), 'sidecar.js');
+    return new HostClient({
+      hostPath,
+      env: { ...process.env, ...sherpaEnv(libDir) },
+      log: this.log,
+    });
+  }
+}
+
+export function createLocalPiperSynthesizer(opts: LocalPiperOptions = {}): LocalPiperSynthesizer {
+  return new LocalPiperSynthesizer(opts);
+}

--- a/packages/plugin-tts-local/src/platform.test.ts
+++ b/packages/plugin-tts-local/src/platform.test.ts
@@ -1,0 +1,77 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  libraryPathVar,
+  resolveSherpaLibDir,
+  sherpaEnv,
+  sherpaPlatformPackage,
+} from './platform.js';
+
+describe('sherpaPlatformPackage', () => {
+  it.each([
+    ['darwin', 'arm64', 'sherpa-onnx-darwin-arm64'],
+    ['darwin', 'x64', 'sherpa-onnx-darwin-x64'],
+    ['linux', 'x64', 'sherpa-onnx-linux-x64'],
+    ['linux', 'arm64', 'sherpa-onnx-linux-arm64'],
+    ['win32', 'x64', 'sherpa-onnx-win-x64'],
+  ] as const)('maps %s-%s to %s', (platform, arch, pkg) => {
+    expect(sherpaPlatformPackage(platform as NodeJS.Platform, arch)).toBe(pkg);
+  });
+
+  it('returns null for an unsupported platform/arch', () => {
+    expect(sherpaPlatformPackage('linux', 'ia32')).toBeNull();
+    expect(sherpaPlatformPackage('freebsd', 'x64')).toBeNull();
+  });
+});
+
+describe('libraryPathVar', () => {
+  it('picks the platform dynamic-loader var, or null on Windows', () => {
+    expect(libraryPathVar('darwin')).toBe('DYLD_LIBRARY_PATH');
+    expect(libraryPathVar('linux')).toBe('LD_LIBRARY_PATH');
+    expect(libraryPathVar('win32')).toBeNull();
+  });
+});
+
+describe('sherpaEnv', () => {
+  it('sets the loader var to the lib dir when none is present', () => {
+    expect(sherpaEnv('/libs', 'darwin', {})).toEqual({ DYLD_LIBRARY_PATH: '/libs' });
+    expect(sherpaEnv('/libs', 'linux', {})).toEqual({ LD_LIBRARY_PATH: '/libs' });
+  });
+
+  it('prepends the lib dir to an existing loader path', () => {
+    expect(sherpaEnv('/libs', 'darwin', { DYLD_LIBRARY_PATH: '/other' })).toEqual({
+      DYLD_LIBRARY_PATH: `/libs${path.delimiter}/other`,
+    });
+  });
+
+  it('returns no env on Windows (DLLs resolve next to the addon)', () => {
+    expect(sherpaEnv('C:\\libs', 'win32', {})).toEqual({});
+  });
+});
+
+describe('resolveSherpaLibDir', () => {
+  it('returns the dirname of the resolved platform package.json', () => {
+    const fakeResolve = (req: string): string => {
+      expect(req).toBe('sherpa-onnx-darwin-arm64/package.json');
+      return '/store/sherpa-onnx-darwin-arm64/package.json';
+    };
+    expect(resolveSherpaLibDir('darwin', 'arm64', fakeResolve)).toBe('/store/sherpa-onnx-darwin-arm64');
+  });
+
+  it('returns null when the platform package cannot be resolved', () => {
+    const throwing = (): string => {
+      throw new Error('MODULE_NOT_FOUND');
+    };
+    expect(resolveSherpaLibDir('darwin', 'arm64', throwing)).toBeNull();
+  });
+
+  it('returns null for an unsupported platform without calling resolve', () => {
+    let called = false;
+    const spy = (): string => {
+      called = true;
+      return 'x';
+    };
+    expect(resolveSherpaLibDir('sunos' as NodeJS.Platform, 'x64', spy)).toBeNull();
+    expect(called).toBe(false);
+  });
+});

--- a/packages/plugin-tts-local/src/platform.ts
+++ b/packages/plugin-tts-local/src/platform.ts
@@ -1,0 +1,106 @@
+/**
+ * Resolve the sherpa-onnx platform binary package and the environment the
+ * sidecar must be spawned with.
+ *
+ * CRITICAL native gotcha (scout-verified): sherpa-onnx-node's addon dlopen's
+ * sibling shared libs (`libonnxruntime.dylib`, `libsherpa-onnx-c-api.dylib`, …)
+ * that live inside the per-platform package dir, and dyld/ld.so read
+ * `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` ONCE at process start. So the addon
+ * only resolves its libs when that env var already points at the platform
+ * package dir when the process launches — which is exactly why the host runs in
+ * a freshly-forked child: the PARENT resolves the dir here and sets the var in
+ * the fork's env. On Windows the DLLs sit next to the `.node`, so no env var is
+ * needed.
+ */
+
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+/** `${platform}-${arch}` → npm package that ships the native addon + libs.
+ *  Note the Windows package is `sherpa-onnx-win-x64` (renamed from win32-x64). */
+const PLATFORM_PACKAGES: Readonly<Record<string, string>> = {
+  'darwin-arm64': 'sherpa-onnx-darwin-arm64',
+  'darwin-x64': 'sherpa-onnx-darwin-x64',
+  'linux-x64': 'sherpa-onnx-linux-x64',
+  'linux-arm64': 'sherpa-onnx-linux-arm64',
+  'win32-x64': 'sherpa-onnx-win-x64',
+};
+
+/** The platform binary package name for a host, or null if unsupported. */
+export function sherpaPlatformPackage(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): string | null {
+  return PLATFORM_PACKAGES[`${platform}-${arch}`] ?? null;
+}
+
+/** A `require.resolve`-shaped function (injectable for tests). */
+export type ResolveLike = (request: string) => string;
+
+/**
+ * A `require.resolve` anchored at sherpa-onnx-node itself.
+ *
+ * Load-bearing: sherpa's per-platform binary packages are its OWN
+ * `optionalDependencies`, so under pnpm's strict layout they are visible from
+ * sherpa-onnx-node's `node_modules` but NOT hoisted into this plugin's — a
+ * resolve anchored here would `MODULE_NOT_FOUND`. So we first resolve
+ * sherpa-onnx-node, then resolve the platform package from ITS context. Cached
+ * because it walks two package boundaries.
+ */
+let cachedSherpaResolve: ResolveLike | null | undefined;
+function sherpaAnchoredResolve(): ResolveLike | null {
+  if (cachedSherpaResolve !== undefined) return cachedSherpaResolve;
+  try {
+    const pluginRequire = createRequire(import.meta.url);
+    const sherpaPkg = pluginRequire.resolve('sherpa-onnx-node/package.json');
+    cachedSherpaResolve = createRequire(sherpaPkg).resolve;
+  } catch {
+    cachedSherpaResolve = null;
+  }
+  return cachedSherpaResolve;
+}
+
+/**
+ * Absolute directory of the resolved platform package (which holds the `.node`
+ * addon and its sibling shared libraries), or null when the package can't be
+ * resolved (unsupported platform, or the optionalDependency didn't install).
+ * `resolve` is injectable for tests; the default is anchored at sherpa-onnx-node.
+ */
+export function resolveSherpaLibDir(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+  resolve?: ResolveLike,
+): string | null {
+  const pkg = sherpaPlatformPackage(platform, arch);
+  if (!pkg) return null;
+  const r = resolve ?? sherpaAnchoredResolve();
+  if (!r) return null;
+  try {
+    return path.dirname(r(`${pkg}/package.json`));
+  } catch {
+    return null;
+  }
+}
+
+/** The dynamic-loader env var name for a platform, or null on Windows. */
+export function libraryPathVar(platform: NodeJS.Platform = process.platform): string | null {
+  if (platform === 'win32') return null;
+  return platform === 'darwin' ? 'DYLD_LIBRARY_PATH' : 'LD_LIBRARY_PATH';
+}
+
+/**
+ * Build the env overrides the sidecar must launch with: the platform loader var
+ * with `libDir` PREPENDED to any existing value. Returns `{}` on Windows (DLLs
+ * resolve next to the addon). `existing` defaults to `process.env`.
+ */
+export function sherpaEnv(
+  libDir: string,
+  platform: NodeJS.Platform = process.platform,
+  existing: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const varName = libraryPathVar(platform);
+  if (!varName) return {};
+  const prev = existing[varName];
+  const value = prev ? `${libDir}${path.delimiter}${prev}` : libDir;
+  return { [varName]: value };
+}

--- a/packages/plugin-tts-local/src/sidecar.ts
+++ b/packages/plugin-tts-local/src/sidecar.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * sherpa-onnx TTS sidecar — a forked child that owns the native sherpa addon.
+ *
+ * It exists as a SEPARATE process for one hard reason (see ./platform.ts): the
+ * addon's shared libraries only resolve when `DYLD_LIBRARY_PATH` /
+ * `LD_LIBRARY_PATH` points at the platform package dir AT PROCESS START, so the
+ * parent forks this with that env pre-set. Forking (not `spawn`) gives us a
+ * structured IPC channel; the parent uses `serialization: 'advanced'` so the
+ * `Float32Array` of samples round-trips without manual byte packing.
+ *
+ * Protocol: {@link ./host-protocol.ts}. This module is the thin runtime glue —
+ * lazily `require`ing the native module (a dlopen failure becomes a classified
+ * `init` reply rather than a boot crash), plus lifecycle self-termination so an
+ * orphaned sidecar never lingers.
+ */
+
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+import {
+  createMessageHandler,
+  type HostReply,
+  type HostRequest,
+  type SherpaModule,
+} from './host-protocol.js';
+
+const require = createRequire(import.meta.url);
+
+/** Lazy native load — deferred so a missing/broken addon is a caught, reported
+ *  `init` error on the first synthesize, not an unhandled boot exception. */
+function loadSherpa(): SherpaModule {
+  return require('sherpa-onnx-node') as SherpaModule;
+}
+
+function send(reply: HostReply): void {
+  // `process.send` is defined only when spawned with an IPC channel (our fork).
+  process.send?.(reply);
+}
+
+function isRequest(msg: unknown): msg is HostRequest {
+  return (
+    typeof msg === 'object' &&
+    msg !== null &&
+    (msg as { type?: unknown }).type === 'synthesize' &&
+    typeof (msg as { id?: unknown }).id === 'number'
+  );
+}
+
+/**
+ * Self-terminate if the parent runner disappears. `fork` delivers a
+ * `disconnect` event when the IPC channel closes (parent exit / explicit
+ * disconnect); belt-and-braces, poll the parent PID too — a hard SIGKILL of the
+ * parent may not always close the channel promptly.
+ */
+function armLifecycle(): void {
+  process.on('disconnect', () => process.exit(0));
+  const parentPid = process.ppid;
+  if (!parentPid || parentPid <= 1) return;
+  const timer = setInterval(() => {
+    try {
+      process.kill(parentPid, 0); // existence probe, no signal delivered
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ESRCH') process.exit(0);
+      // EPERM ⇒ the process exists but we can't signal it — still alive.
+    }
+  }, 3000);
+  timer.unref?.();
+}
+
+function main(): void {
+  const handle = createMessageHandler(loadSherpa);
+  // Serialise requests: sherpa's OfflineTts is not re-entrant, and processing
+  // one at a time keeps memory bounded under a burst of read-aloud calls.
+  let queue: Promise<void> = Promise.resolve();
+  process.on('message', (msg: unknown) => {
+    if (!isRequest(msg)) return;
+    queue = queue
+      .then(async () => {
+        const reply = await handle(msg);
+        send(reply);
+      })
+      .catch((err) => {
+        send({
+          id: msg.id,
+          ok: false,
+          error: { message: err instanceof Error ? err.message : String(err), kind: 'runtime' },
+        });
+      });
+  });
+  armLifecycle();
+}
+
+// Run only when executed as the forked child, never when imported by a test.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/packages/plugin-tts-local/src/voices.test.ts
+++ b/packages/plugin-tts-local/src/voices.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_POLISH_VOICE_ID,
+  DEFAULT_VOICE_ID,
+  findVoice,
+  requireVoice,
+  routeVoice,
+  VOICE_CATALOG,
+  voiceIds,
+} from './voices.js';
+
+describe('VOICE_CATALOG', () => {
+  it('pins the three Piper voices with their sherpa checksum.txt sha256s', () => {
+    // These MUST match sherpa-onnx's tts-models/checksum.txt verbatim — the
+    // integrity story depends on them not drifting.
+    const byId = Object.fromEntries(VOICE_CATALOG.map((v) => [v.id, v]));
+    expect(byId['en_US-amy-medium']?.sha256).toBe(
+      '9a5d1fc497f85e8022b785bff5f8105203b1e33099ee6265203efc70b0cb0264',
+    );
+    expect(byId['pl_PL-gosia-medium']?.sha256).toBe(
+      '75bd34dcbdc4dd98d763954756b4b34b4208100497c836381542e4d73dcefa9c',
+    );
+    expect(byId['pl_PL-darkman-medium']?.sha256).toBe(
+      '444727aa46eb6db645a2bc88fe73868e4bd7596b7f56ca39fad5ef53c41210d4',
+    );
+  });
+
+  it('derives archive/model paths and language consistently', () => {
+    for (const v of VOICE_CATALOG) {
+      expect(v.archiveRootDir).toBe(`vits-piper-${v.id}`);
+      expect(v.modelFile).toBe(`${v.id}.onnx`);
+      expect(v.url).toBe(
+        `https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/vits-piper-${v.id}.tar.bz2`,
+      );
+      expect(/^[0-9a-f]{64}$/.test(v.sha256)).toBe(true);
+    }
+    expect(VOICE_CATALOG.filter((v) => v.language === 'pl').map((v) => v.id)).toEqual([
+      'pl_PL-gosia-medium',
+      'pl_PL-darkman-medium',
+    ]);
+  });
+
+  it('exposes the default voice ids from the catalog', () => {
+    expect(findVoice(DEFAULT_VOICE_ID)?.language).toBe('en');
+    expect(findVoice(DEFAULT_POLISH_VOICE_ID)?.language).toBe('pl');
+    expect(voiceIds()).toContain('en_US-amy-medium');
+  });
+});
+
+describe('routeVoice', () => {
+  const cfg = { defaultVoice: DEFAULT_VOICE_ID, polishVoice: DEFAULT_POLISH_VOICE_ID };
+
+  it('uses the default voice with no hints', () => {
+    expect(routeVoice({ ...cfg }).id).toBe('en_US-amy-medium');
+  });
+
+  it('routes pl* language hints to the Polish voice', () => {
+    expect(routeVoice({ ...cfg, language: 'pl' }).id).toBe('pl_PL-gosia-medium');
+    expect(routeVoice({ ...cfg, language: 'pl-PL' }).id).toBe('pl_PL-gosia-medium');
+    expect(routeVoice({ ...cfg, language: 'PL_pl' }).id).toBe('pl_PL-gosia-medium');
+  });
+
+  it('routes a non-pl language to the default voice', () => {
+    expect(routeVoice({ ...cfg, language: 'en-US' }).id).toBe('en_US-amy-medium');
+    expect(routeVoice({ ...cfg, language: 'de' }).id).toBe('en_US-amy-medium');
+  });
+
+  it('lets an explicit requestedVoice override everything', () => {
+    expect(routeVoice({ ...cfg, requestedVoice: 'pl_PL-darkman-medium', language: 'en' }).id).toBe(
+      'pl_PL-darkman-medium',
+    );
+    expect(routeVoice({ ...cfg, requestedVoice: 'en_US-amy-medium', language: 'pl' }).id).toBe(
+      'en_US-amy-medium',
+    );
+  });
+
+  it('honors a configured Polish voice override', () => {
+    expect(routeVoice({ defaultVoice: DEFAULT_VOICE_ID, polishVoice: 'pl_PL-darkman-medium', language: 'pl' }).id).toBe(
+      'pl_PL-darkman-medium',
+    );
+  });
+
+  it('throws a clear CONFIG_INVALID for an unknown requested voice, listing valid ids', () => {
+    try {
+      routeVoice({ ...cfg, requestedVoice: 'xx_ZZ-nobody' });
+      throw new Error('expected a throw');
+    } catch (err) {
+      expect((err as { code?: string }).code).toBe('CONFIG_INVALID');
+      expect((err as Error).message).toContain('xx_ZZ-nobody');
+      expect((err as { hint?: string }).hint).toContain('en_US-amy-medium');
+    }
+  });
+
+  it('throws when a configured polishVoice id is unknown', () => {
+    expect(() => routeVoice({ defaultVoice: DEFAULT_VOICE_ID, polishVoice: 'bogus', language: 'pl' })).toThrow();
+  });
+});
+
+describe('requireVoice', () => {
+  it('returns the entry for a valid id', () => {
+    expect(requireVoice('en_US-amy-medium', 'voice').id).toBe('en_US-amy-medium');
+  });
+  it('throws CONFIG_INVALID naming the field for an unknown id', () => {
+    expect(() => requireVoice('nope', 'polishVoice')).toThrow(/Unknown local voice/);
+  });
+});

--- a/packages/plugin-tts-local/src/voices.ts
+++ b/packages/plugin-tts-local/src/voices.ts
@@ -1,0 +1,135 @@
+/**
+ * The pinned local voice catalog.
+ *
+ * Every voice is a Piper VITS model published by the sherpa-onnx project as a
+ * `.tar.bz2` under its `tts-models` GitHub release. Each `sha256` is copied
+ * VERBATIM from that release's `checksum.txt` (re-verified 2026-07-05) — so a
+ * first-use download is content-addressed and tamper-evident, unlike an
+ * unverified blob fetch. The archive extracts to a single top directory
+ * (`archiveRootDir`) holding `<id>.onnx`, `tokens.txt`, and `espeak-ng-data/`.
+ */
+
+import { MoxxyError } from '@moxxy/sdk';
+
+export type VoiceLanguage = 'en' | 'pl';
+
+export interface VoiceEntry {
+  /** Stable voice id, e.g. `en_US-amy-medium` (also the `set_voice` name). */
+  readonly id: string;
+  /** BCP-47 primary language subtag used for language routing. */
+  readonly language: VoiceLanguage;
+  /** Human label for UI surfaces. */
+  readonly label: string;
+  /** Pinned archive URL (sherpa-onnx GitHub release). */
+  readonly url: string;
+  /** Pinned hex sha256 of the archive (from the release checksum.txt). */
+  readonly sha256: string;
+  /** Top directory the archive extracts to (`vits-piper-<id>`). */
+  readonly archiveRootDir: string;
+  /** The ONNX model filename inside `archiveRootDir` (`<id>.onnx`). */
+  readonly modelFile: string;
+  /** Approximate download size in MB (for the one-time first-use notice). */
+  readonly approxMb: number;
+}
+
+const RELEASE_BASE = 'https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models';
+
+function piperVoice(
+  id: string,
+  language: VoiceLanguage,
+  label: string,
+  sha256: string,
+  approxMb: number,
+): VoiceEntry {
+  const archiveRootDir = `vits-piper-${id}`;
+  return {
+    id,
+    language,
+    label,
+    url: `${RELEASE_BASE}/${archiveRootDir}.tar.bz2`,
+    sha256,
+    archiveRootDir,
+    modelFile: `${id}.onnx`,
+    approxMb,
+  };
+}
+
+export const VOICE_CATALOG: readonly VoiceEntry[] = [
+  piperVoice(
+    'en_US-amy-medium',
+    'en',
+    'Amy (English, US)',
+    '9a5d1fc497f85e8022b785bff5f8105203b1e33099ee6265203efc70b0cb0264',
+    63,
+  ),
+  piperVoice(
+    'pl_PL-gosia-medium',
+    'pl',
+    'Gosia (Polish)',
+    '75bd34dcbdc4dd98d763954756b4b34b4208100497c836381542e4d73dcefa9c',
+    63,
+  ),
+  piperVoice(
+    'pl_PL-darkman-medium',
+    'pl',
+    'Darkman (Polish)',
+    '444727aa46eb6db645a2bc88fe73868e4bd7596b7f56ca39fad5ef53c41210d4',
+    63,
+  ),
+];
+
+export const DEFAULT_VOICE_ID = 'en_US-amy-medium';
+export const DEFAULT_POLISH_VOICE_ID = 'pl_PL-gosia-medium';
+
+/** All valid voice ids, for error messages and validation. */
+export function voiceIds(): string[] {
+  return VOICE_CATALOG.map((v) => v.id);
+}
+
+export function findVoice(id: string): VoiceEntry | undefined {
+  return VOICE_CATALOG.find((v) => v.id === id);
+}
+
+/** Resolve a voice id to its catalog entry, or throw a clear, actionable error
+ *  listing the valid ids. `field` names where the bad id came from. */
+export function requireVoice(id: string, field: string): VoiceEntry {
+  const entry = findVoice(id);
+  if (!entry) {
+    throw new MoxxyError({
+      code: 'CONFIG_INVALID',
+      message: `Unknown local voice ${JSON.stringify(id)} (${field}).`,
+      hint: `Valid voices: ${voiceIds().join(', ')}.`,
+      context: { field, voice: id },
+    });
+  }
+  return entry;
+}
+
+export interface RouteVoiceInput {
+  /** Explicit per-call voice id (`SynthesizeOptions.voice`) — overrides all. */
+  readonly requestedVoice?: string;
+  /** Per-call BCP-47 language hint (`SynthesizeOptions.language`). */
+  readonly language?: string;
+  /** Configured default (non-Polish) voice id. */
+  readonly defaultVoice: string;
+  /** Configured Polish voice id. */
+  readonly polishVoice: string;
+}
+
+/**
+ * Pick the voice for a synthesis call:
+ *   1. an explicit `requestedVoice` (a catalog id) wins outright;
+ *   2. else a `language` starting with `pl` routes to the Polish voice;
+ *   3. else the configured default voice.
+ * An unknown id (in any of the three) throws a clear `CONFIG_INVALID` error.
+ */
+export function routeVoice(input: RouteVoiceInput): VoiceEntry {
+  if (input.requestedVoice) {
+    return requireVoice(input.requestedVoice, 'voice');
+  }
+  const lang = (input.language ?? '').trim().toLowerCase();
+  if (lang.startsWith('pl')) {
+    return requireVoice(input.polishVoice, 'polishVoice');
+  }
+  return requireVoice(input.defaultVoice, 'voice');
+}

--- a/packages/plugin-tts-local/src/wav.test.ts
+++ b/packages/plugin-tts-local/src/wav.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { encodeWav, WAV_HEADER_BYTES } from './wav.js';
+
+function ascii(bytes: Uint8Array, start: number, len: number): string {
+  return String.fromCharCode(...bytes.subarray(start, start + len));
+}
+
+describe('encodeWav', () => {
+  it('writes a canonical mono PCM16 header (golden)', () => {
+    const samples = new Float32Array([0, 1, -1, 0.5]);
+    const wav = encodeWav(samples, 8000);
+    const view = new DataView(wav.buffer, wav.byteOffset, wav.byteLength);
+    const dataSize = samples.length * 2;
+
+    expect(wav.byteLength).toBe(WAV_HEADER_BYTES + dataSize);
+    expect(ascii(wav, 0, 4)).toBe('RIFF');
+    expect(view.getUint32(4, true)).toBe(36 + dataSize);
+    expect(ascii(wav, 8, 4)).toBe('WAVE');
+    expect(ascii(wav, 12, 4)).toBe('fmt ');
+    expect(view.getUint32(16, true)).toBe(16); // PCM fmt size
+    expect(view.getUint16(20, true)).toBe(1); // PCM
+    expect(view.getUint16(22, true)).toBe(1); // mono
+    expect(view.getUint32(24, true)).toBe(8000); // sample rate
+    expect(view.getUint32(28, true)).toBe(8000 * 2); // byte rate (mono, 2 bytes)
+    expect(view.getUint16(32, true)).toBe(2); // block align
+    expect(view.getUint16(34, true)).toBe(16); // bits per sample
+    expect(ascii(wav, 36, 4)).toBe('data');
+    expect(view.getUint32(40, true)).toBe(dataSize);
+  });
+
+  it('maps full-scale samples to the int16 range edges', () => {
+    const wav = encodeWav(new Float32Array([0, 1, -1, 0.5]), 8000);
+    const view = new DataView(wav.buffer, wav.byteOffset, wav.byteLength);
+    expect(view.getInt16(WAV_HEADER_BYTES + 0, true)).toBe(0);
+    expect(view.getInt16(WAV_HEADER_BYTES + 2, true)).toBe(32767); // +1.0
+    expect(view.getInt16(WAV_HEADER_BYTES + 4, true)).toBe(-32768); // -1.0
+    expect(view.getInt16(WAV_HEADER_BYTES + 6, true)).toBe(16384); // +0.5
+  });
+
+  it('clamps out-of-range samples and encodes NaN as silence', () => {
+    const wav = encodeWav(new Float32Array([2, -2, Number.NaN]), 16000);
+    const view = new DataView(wav.buffer, wav.byteOffset, wav.byteLength);
+    expect(view.getInt16(WAV_HEADER_BYTES + 0, true)).toBe(32767);
+    expect(view.getInt16(WAV_HEADER_BYTES + 2, true)).toBe(-32768);
+    expect(view.getInt16(WAV_HEADER_BYTES + 4, true)).toBe(0);
+  });
+
+  it('encodes an empty sample array to a bare 44-byte header', () => {
+    const wav = encodeWav(new Float32Array([]), 22050);
+    expect(wav.byteLength).toBe(WAV_HEADER_BYTES);
+  });
+
+  it('rejects an invalid sample rate', () => {
+    expect(() => encodeWav(new Float32Array([0]), 0)).toThrow();
+    expect(() => encodeWav(new Float32Array([0]), Number.NaN)).toThrow();
+  });
+});

--- a/packages/plugin-tts-local/src/wav.ts
+++ b/packages/plugin-tts-local/src/wav.ts
@@ -1,0 +1,65 @@
+/**
+ * Minimal float32 → PCM16 mono WAV encoder.
+ *
+ * sherpa-onnx hands back `{ samples: Float32Array in [-1, 1], sampleRate }`.
+ * Read-aloud surfaces and channel voice replies want playable container bytes,
+ * so we wrap the samples in a canonical 44-byte RIFF/WAVE header + 16-bit PCM
+ * little-endian data. Kept dependency-free and self-contained (deliberately NOT
+ * imported from plugin-stt-whisper) and covered by golden tests — the header
+ * offsets are load-bearing.
+ */
+
+/** Bytes in the RIFF/WAVE header preceding the PCM data. */
+export const WAV_HEADER_BYTES = 44;
+
+function writeAscii(view: DataView, offset: number, text: string): void {
+  for (let i = 0; i < text.length; i += 1) view.setUint8(offset + i, text.charCodeAt(i));
+}
+
+/**
+ * Encode float samples as a mono 16-bit PCM WAV. `sampleRate` must be a
+ * positive integer (sherpa reports e.g. 22050). Samples are clamped to
+ * [-1, 1]; non-finite samples encode as silence.
+ */
+export function encodeWav(samples: Float32Array, sampleRate: number): Uint8Array {
+  if (!Number.isFinite(sampleRate) || sampleRate <= 0) {
+    throw new Error(`encodeWav: invalid sampleRate ${sampleRate}`);
+  }
+  const rate = Math.round(sampleRate);
+  const numSamples = samples.length;
+  const bytesPerSample = 2; // PCM16
+  const blockAlign = bytesPerSample; // mono
+  const byteRate = rate * blockAlign;
+  const dataSize = numSamples * bytesPerSample;
+  const buffer = new ArrayBuffer(WAV_HEADER_BYTES + dataSize);
+  const view = new DataView(buffer);
+
+  // RIFF chunk descriptor
+  writeAscii(view, 0, 'RIFF');
+  view.setUint32(4, 36 + dataSize, true); // ChunkSize = 4 + (8 + Subchunk1) + (8 + data)
+  writeAscii(view, 8, 'WAVE');
+  // fmt subchunk
+  writeAscii(view, 12, 'fmt ');
+  view.setUint32(16, 16, true); // Subchunk1Size for PCM
+  view.setUint16(20, 1, true); // AudioFormat = 1 (PCM)
+  view.setUint16(22, 1, true); // NumChannels = 1 (mono)
+  view.setUint32(24, rate, true); // SampleRate
+  view.setUint32(28, byteRate, true); // ByteRate
+  view.setUint16(32, blockAlign, true); // BlockAlign
+  view.setUint16(34, 16, true); // BitsPerSample
+  // data subchunk
+  writeAscii(view, 36, 'data');
+  view.setUint32(40, dataSize, true);
+
+  let offset = WAV_HEADER_BYTES;
+  for (let i = 0; i < numSamples; i += 1) {
+    const raw = samples[i];
+    const s = Number.isFinite(raw as number) ? Math.max(-1, Math.min(1, raw as number)) : 0;
+    // Asymmetric scaling so full-scale positive/negative map to the int16 range
+    // edges without overflow.
+    const int16 = s < 0 ? Math.round(s * 0x8000) : Math.round(s * 0x7fff);
+    view.setInt16(offset, int16, true);
+    offset += 2;
+  }
+  return new Uint8Array(buffer);
+}

--- a/packages/plugin-tts-local/tsconfig.json
+++ b/packages/plugin-tts-local/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/plugin-tts-local/vitest.config.ts
+++ b/packages/plugin-tts-local/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1293,6 +1293,37 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
 
+  packages/model-fetch:
+    dependencies:
+      tar-stream:
+        specifier: ^3.1.7
+        version: 3.2.0
+      unbzip2-stream:
+        specifier: ^1.4.3
+        version: 1.4.3
+    devDependencies:
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      '@types/tar-stream':
+        specifier: ^3.1.3
+        version: 3.1.4
+      '@types/unbzip2-stream':
+        specifier: ^1.4.3
+        version: 1.4.3
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
   packages/plugin-browser:
     dependencies:
       '@moxxy/sdk':
@@ -2447,6 +2478,34 @@ importers:
       '@moxxy/sdk':
         specifier: workspace:*
         version: link:../sdk
+    devDependencies:
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
+  packages/plugin-tts-local:
+    dependencies:
+      '@moxxy/model-fetch':
+        specifier: workspace:*
+        version: link:../model-fetch
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      sherpa-onnx-node:
+        specifier: ^1.13.3
+        version: 1.13.3
     devDependencies:
       '@moxxy/tsconfig':
         specifier: workspace:*
@@ -5841,6 +5900,15 @@ packages:
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
+  '@types/tar-stream@3.1.4':
+    resolution: {integrity: sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==}
+
+  '@types/through@0.0.33':
+    resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
+
+  '@types/unbzip2-stream@1.4.3':
+    resolution: {integrity: sha512-D8X5uuJRISqc8YtwL8jNW2FpPdUOCYXbfD6zNROCTbVXK9nawucxh10tVXE3MPjnHdRA1LvB0zDxVya/lBsnYw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -6333,6 +6401,14 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -6409,6 +6485,47 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.3:
+    resolution: {integrity: sha512-xRgplks8SvcKkdlv2M6Z2LZmRsmqd+x0nXXGXeMEjwdibj1HSDrlnqBRLeYdMvsgCox7Bq0e+DHwfczOfsn6IA==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.3:
+    resolution: {integrity: sha512-fF4Q7QsyKVF5Rj0qvI8BgUNjqzC2JvQlpTaPLjVJVxYVUX5Zr9un+y3w1HmA4nNKdFmRBT8z/WmrjvXzXVerKQ==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.1:
+    resolution: {integrity: sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.5:
+    resolution: {integrity: sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==}
 
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
@@ -7440,6 +7557,9 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -7689,6 +7809,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -10561,6 +10684,39 @@ packages:
     resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
+  sherpa-onnx-darwin-arm64@1.13.3:
+    resolution: {integrity: sha512-9x86Cbf+BDFONdtCPM3cnjvtAW0ER8tMaHK5pVfz+SHPt8GeuwRXaiR/BzcByFBUyxCgmceO09/WMZOCi44P/g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  sherpa-onnx-darwin-x64@1.13.3:
+    resolution: {integrity: sha512-TVQ35g7JIpDPB1lUDdcog+JtI0cI45ZzOnvHXm0DtWs/dgxnJXtWMY3uLRtBbLnysV9j5ljffwZ1IX9VDHsCzQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  sherpa-onnx-linux-arm64@1.13.3:
+    resolution: {integrity: sha512-uDtZkkoP6QQ/3DHOscCpEZ2WpaiHUQsDpbyYaHURrJ7DbsjqGnS6G8l+R589Ro5Bf282QElzBy3okwxXbt3Kxw==}
+    cpu: [arm64]
+    os: [linux]
+
+  sherpa-onnx-linux-x64@1.13.3:
+    resolution: {integrity: sha512-OFVK0GYwKwKNsjxbPmfcLQm/dfA0IwAoiIQJ96s+eFYcDqhlapcY06ocdb7SNluGBcM7xgU5jEW2QXBkMIOEvQ==}
+    cpu: [x64]
+    os: [linux]
+
+  sherpa-onnx-node@1.13.3:
+    resolution: {integrity: sha512-3XEiRvfZ73QoKDZqweAkAOb+OA2LPMKcLcRY6zngjhwZ1ymV6xagdahepYzeDRIzVq0nRjhUe8IaRdlRMYoamw==}
+
+  sherpa-onnx-win-ia32@1.13.3:
+    resolution: {integrity: sha512-VDZh1M7Ccx/bkP3WwBCFoJzwAwq+b5nR1KRkYRz5p1w5bfhzfa3ACBGr7vpUt5AGUge4qSLe0MSKXyKtSmy1uA==}
+    cpu: [ia32]
+    os: [win32]
+
+  sherpa-onnx-win-x64@1.13.3:
+    resolution: {integrity: sha512-ZQzcSmFvZK4jzmtWckqxocDUuEjYnBV2MHrDD21HPTeUMfGdE9yfvuSPpesIVfdzKbQzIQY42RAcfZEGWu0FbQ==}
+    cpu: [x64]
+    os: [win32]
+
   shiki@1.29.2:
     resolution: {integrity: sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==}
 
@@ -10736,6 +10892,9 @@ packages:
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
   strict-uri-encode@2.0.0:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
     engines: {node: '>=4'}
@@ -10866,6 +11025,9 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
@@ -10877,6 +11039,9 @@ packages:
 
   teamcity-service-messages@0.1.14:
     resolution: {integrity: sha512-29aQwaHqm8RMX74u2o/h1KbMLP89FjNiMxD9wbF2BbWOnbM+q+d1sCEC+MqCc4QW3NJykn77OMpTFw/xTHIc0w==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
@@ -10898,6 +11063,9 @@ packages:
     resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
     engines: {node: '>=18'}
 
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -10910,6 +11078,9 @@ packages:
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -11124,6 +11295,9 @@ packages:
 
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
+
+  unbzip2-stream@1.4.3:
+    resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
@@ -15128,6 +15302,18 @@ snapshots:
 
   '@types/stack-utils@2.0.3': {}
 
+  '@types/tar-stream@3.1.4':
+    dependencies:
+      '@types/node': 24.12.3
+
+  '@types/through@0.0.33':
+    dependencies:
+      '@types/node': 24.12.3
+
+  '@types/unbzip2-stream@1.4.3':
+    dependencies:
+      '@types/through': 0.0.33
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -15930,6 +16116,8 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  b4a@1.8.1: {}
+
   babel-jest@29.7.0(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
@@ -16099,6 +16287,39 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.9.1: {}
+
+  bare-fs@4.7.3:
+    dependencies:
+      bare-events: 2.9.1
+      bare-path: 3.0.1
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.4.5
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.9.3: {}
+
+  bare-path@3.0.1:
+    dependencies:
+      bare-os: 3.9.3
+
+  bare-stream@2.13.3(bare-events@2.9.1):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.5:
+    dependencies:
+      bare-path: 3.0.1
 
   base-64@1.0.0: {}
 
@@ -17319,6 +17540,12 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   events@3.3.0: {}
 
   eventsource-parser@3.0.8: {}
@@ -17649,6 +17876,8 @@ snapshots:
     optional: true
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -21587,6 +21816,33 @@ snapshots:
 
   shell-quote@1.8.4: {}
 
+  sherpa-onnx-darwin-arm64@1.13.3:
+    optional: true
+
+  sherpa-onnx-darwin-x64@1.13.3:
+    optional: true
+
+  sherpa-onnx-linux-arm64@1.13.3:
+    optional: true
+
+  sherpa-onnx-linux-x64@1.13.3:
+    optional: true
+
+  sherpa-onnx-node@1.13.3:
+    optionalDependencies:
+      sherpa-onnx-darwin-arm64: 1.13.3
+      sherpa-onnx-darwin-x64: 1.13.3
+      sherpa-onnx-linux-arm64: 1.13.3
+      sherpa-onnx-linux-x64: 1.13.3
+      sherpa-onnx-win-ia32: 1.13.3
+      sherpa-onnx-win-x64: 1.13.3
+
+  sherpa-onnx-win-ia32@1.13.3:
+    optional: true
+
+  sherpa-onnx-win-x64@1.13.3:
+    optional: true
+
   shiki@1.29.2:
     dependencies:
       '@shikijs/core': 1.29.2
@@ -21770,6 +22026,15 @@ snapshots:
 
   stream-replace-string@2.0.0: {}
 
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   strict-uri-encode@2.0.0: {}
 
   string-width@4.2.3:
@@ -21914,6 +22179,17 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.3
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar@6.2.1:
     dependencies:
       chownr: 2.0.0
@@ -21932,6 +22208,13 @@ snapshots:
       yallist: 5.0.0
 
   teamcity-service-messages@0.1.14: {}
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   temp-file@3.4.0:
     dependencies:
@@ -21962,6 +22245,12 @@ snapshots:
       glob: 10.5.0
       minimatch: 10.2.5
 
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -21975,6 +22264,8 @@ snapshots:
       real-require: 0.2.0
 
   throat@5.0.0: {}
+
+  through@2.3.8: {}
 
   tiny-inflate@1.0.3: {}
 
@@ -22167,6 +22458,11 @@ snapshots:
   ulid@2.4.0: {}
 
   ultrahtml@1.6.0: {}
+
+  unbzip2-stream@1.4.3:
+    dependencies:
+      buffer: 5.7.1
+      through: 2.3.8
 
   uncrypto@0.1.3: {}
 


### PR DESCRIPTION
## What

Two coupled additions: `@moxxy/model-fetch` (a small shared download-and-verify helper) and `@moxxy/plugin-tts-local` — fully local, on-device text-to-speech via **sherpa-onnx** running **Piper** voices (English + Polish), models downloaded on demand and integrity-verified. It plugs into the runner-side `SynthesizerRegistry`, so desktop read-aloud, the TUI, and channel voice replies consume it transparently — no API key, no network at synthesis time.

## Architecture — why a forked child host

sherpa-onnx-node's addon `dlopen`s sibling shared libs (`libonnxruntime.dylib`, `libsherpa-onnx-c-api.dylib`, …) that live inside its per-platform binary package, and **dyld/ld.so read `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` once, at process start**. So the addon only resolves its libs when that env var already points at the platform package dir when the process launches.

Therefore the native engine runs in a **forked sidecar** (`child_process.fork` of `dist/sidecar.js`): the parent resolves the platform package dir and sets the loader-path var in the fork's env, so the child comes up with dyld already pointed at the libs. `fork` (not `spawn`) gives a structured IPC channel; `serialization: 'advanced'` lets the `Float32Array` of samples round-trip without manual byte packing.

- Platform → package map: `darwin-arm64/x64`, `linux-x64/arm64`, `win32-x64` → `sherpa-onnx-{darwin,linux,win}-*`. **Windows needs no env var** (DLLs sit next to the `.node`).
- The platform package is resolved **anchored at sherpa-onnx-node** (its own `optionalDependency`), not at the plugin — pnpm's strict layout doesn't hoist it into the plugin's `node_modules`.
- Lazy-spawn on first `synthesize`; **restart-on-crash once**; killed on plugin `onShutdown`, and the sidecar self-terminates on IPC `disconnect` / a parent-PID watchdog so it never orphans.

**Child-host protocol** (parent → child `SynthesizeRequest`, child → parent `HostReply`, over the fork IPC channel):
```
→ { id, type:'synthesize', voiceKey, model, tokens, dataDir, numThreads, provider, text, sid, speed }
← { id, ok:true,  sampleRate, samples: Float32Array }
← { id, ok:false, error:{ message, kind:'init'|'runtime' } }
```
The sidecar caches one `OfflineTts` per `voiceKey` (loads each model once) and serialises requests; `init` vs `runtime` distinguishes a model-load/dlopen failure from a synthesis failure.

## Voice catalog + integrity story

Three pinned Piper voices, each a `.tar.bz2` from sherpa-onnx's `tts-models` GitHub release:

| id | lang | sha256 (from sherpa `checksum.txt`) |
|----|------|--------------------------------------|
| `en_US-amy-medium` | en | `9a5d1fc4…b0cb0264` |
| `pl_PL-gosia-medium` | pl | `75bd34dc…3dcefa9c` |
| `pl_PL-darkman-medium` | pl | `444727aa…c41210d4` |

All three sha256s were **re-verified against sherpa-onnx's `checksum.txt`** and matched exactly. Downloads land in `~/.moxxy/models/tts/<voiceId>/` (MOXXY_HOME-aware). Unlike the desktop anonymizer's unverified asset fetch, **every byte here is content-addressed and mandatory-verified**: `@moxxy/model-fetch` streams the download to `<dest>.partial` while hashing, rejects a mismatch (cleaning up the partial), publishes atomically, then extracts with hostile-archive defences (absolute-path / `..`-traversal / symlink / device-node entries refused; extract into a temp dir, rename on success). Egress is locked to an https-only host allow-list (`github.com`, `objects.githubusercontent.com`, `huggingface.co`, `cdn-lfs.huggingface.co`) checked before the first byte, with a size cap. An idempotent `.model.ok` marker makes first-use one-time.

First use logs a single start line + ~10% progress ticks, e.g.:
```
tts-local: first use — downloading pl_PL-gosia-medium (~63 MB) to ~/.moxxy/models/tts, one-time
tts-local: downloading pl_PL-gosia-medium … 40%
tts-local: extracting pl_PL-gosia-medium …
```

## Language routing

`SynthesizeOptions.voice` (a catalog id) overrides everything → `SynthesizeOptions.language` starting with `pl` → the configured `polishVoice` (default `pl_PL-gosia-medium`) → otherwise the default `voice` (default `en_US-amy-medium`). An unknown id anywhere throws a clear `CONFIG_INVALID` listing the valid ids. `rate` maps to sherpa `speed`, clamped to 0.5–2.0.

## Consumption map

- **Desktop read-aloud** — `session.synthesizers.getActive().synthesize(...)` returns `audio/wav` bytes the renderer plays.
- **TUI** — same registry; the WAV plays directly.
- **Channel voice replies** — channel-kit's `deliverVoiceReply` → `ensureOggOpus` transcodes the WAV to OGG/Opus for Telegram/Discord native voice notes (verified: WAV mime → ffmpeg transcode path), or falls back to a plain audio file when ffmpeg is absent.

A tiny, self-contained float32→PCM16 WAV encoder lives in the plugin (golden-tested; deliberately not imported from plugin-stt-whisper).

## Tests / gate

Everything is injectable — **no real native addon or real download runs in CI**: `@moxxy/model-fetch` unit tests (hash-mismatch cleanup, traversal/symlink rejection, idempotence, allow-list, abort-mid-download, size cap, real in-test `tar -cjf` fixtures); plugin tests with a **fake child transport** (protocol correlation, crash+restart-once, timeout, shutdown), a **fake sherpa module** for the handler, WAV golden tests, language-routing + catalog-id validation, and download-invoked-once with a fake `ensureModel`. One **opt-in** integration test (`describe.skipIf(!MOXXY_TTS_LOCAL_LIVE)`) does the real download + native synthesis.

Full gate green: `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm check:deps` all pass. Rebased onto latest `development` (after tts-elevenlabs #433 merged — the catalog entry is anchored directly after `tts-elevenlabs`).

## Manual verify

- [x] Live download + **audible EN** synthesis (ran `MOXXY_TTS_LOCAL_LIVE=1` — real ~63 MB amy download, native sidecar, non-empty WAV).
- [x] Live download + **audible PL** synthesis (gosia — real download + synth).
- [ ] Desktop **Read-aloud** button end-to-end with `local-piper` active (reviewer, on a packaged build).
- [ ] Telegram/Discord voice reply (OGG/Opus transcode) with a channel installed.
