### PR TITLE
feat(voice): @moxxy/plugin-stt-local — offline Whisper STT (multilingual) with on-demand verified model downloads

### DIFF
--- a/.changeset/stt-local.md
+++ b/.changeset/stt-local.md
@@ -1,0 +1,27 @@
+---
+'@moxxy/plugin-stt-local': minor
+'@moxxy/plugin-plugins-admin': patch
+---
+
+feat(voice): @moxxy/plugin-stt-local — offline Whisper STT (multilingual) with on-demand verified model downloads
+
+Adds a fully local, on-device speech-to-text Transcriber — the input sibling of
+`@moxxy/plugin-tts-local`:
+
+- `@moxxy/plugin-stt-local` — the `local-whisper` transcriber running sherpa-onnx
+  multilingual Whisper (English + Polish are the priority) in a forked sidecar
+  (so the native addon's shared libs resolve via `DYLD_/LD_LIBRARY_PATH` set at
+  process start). Models (`tiny` / `base` / `small`; default `base`, `small`
+  recommended for Polish) download once on first use from sherpa-onnx's pinned
+  `asr-models` release, sha256-verified against its `checksum.txt`. No API key,
+  no network at transcription time.
+- Inbound audio is decoded to the Float32 mono @ 16 kHz sherpa wants: raw PCM16
+  (the mic contract) and 16-bit PCM WAV are converted + resampled IN-PROCESS
+  (no ffmpeg); compressed containers (ogg/opus voice notes, mp3, m4a, webm) go
+  through ffmpeg when present, and raise a clear install-hint error when it
+  isn't — raw PCM / WAV keep working regardless.
+- Registered side-effect free (no auto-adopt); the host/user activates it via
+  `session.transcribers.setActive('local-whisper', { model, language })`.
+  Channel voice notes (Telegram) consume the active transcriber transparently.
+
+plugins-admin gains an `stt-local` catalog entry for install-on-first-use.

--- a/packages/plugin-plugins-admin/src/catalog.ts
+++ b/packages/plugin-plugins-admin/src/catalog.ts
@@ -304,6 +304,15 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     provides: [{ category: 'synthesizer', name: 'local-piper' }],
   },
   {
+    id: 'stt-local',
+    label: 'Local voice input (offline STT)',
+    description:
+      'Fully on-device speech-to-text via sherpa-onnx multilingual Whisper (English + Polish). No API key; the model is a one-time verified download (base ~198 MB by default; small ~610 MB recommended for Polish).',
+    packageName: '@moxxy/plugin-stt-local',
+    installSpec: '@moxxy/plugin-stt-local',
+    provides: [{ category: 'transcriber', name: 'local-whisper' }],
+  },
+  {
     id: 'provider-admin',
     label: 'Provider admin tools',
     description: 'provider_add/list/remove/test — register OpenAI-compatible vendors at runtime.',

--- a/packages/plugin-stt-local/package.json
+++ b/packages/plugin-stt-local/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@moxxy/plugin-stt-local",
+  "version": "0.0.0",
+  "description": "Fully local, on-device speech-to-text Transcriber for moxxy. Runs multilingual Whisper (English + Polish) via sherpa-onnx in a forked sidecar process; models download once on first use from sherpa-onnx's pinned releases (sha256-verified). No API key, no network at transcription time. Plugs into the session TranscriberRegistry — the TUI and channel voice notes consume it transparently.",
+  "keywords": [
+    "moxxy",
+    "agent",
+    "stt",
+    "speech-to-text",
+    "whisper",
+    "offline",
+    "on-device",
+    "sherpa-onnx",
+    "transcriber"
+  ],
+  "homepage": "https://moxxy.ai",
+  "bugs": {
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
+    "directory": "packages/plugin-stt-local"
+  },
+  "author": "Michal Makowski <michal.makowski97@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "moxxy": {
+    "plugin": {
+      "entry": "./dist/index.js",
+      "kind": "transcriber"
+    }
+  },
+  "dependencies": {
+    "@moxxy/model-fetch": "workspace:*",
+    "@moxxy/sdk": "workspace:*",
+    "sherpa-onnx-node": "^1.13.3"
+  },
+  "devDependencies": {
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugin-stt-local/src/audio.test.ts
+++ b/packages/plugin-stt-local/src/audio.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  downmixToMono,
+  isRiffWave,
+  parseWav,
+  pcm16ToFloat32,
+  resampleLinear,
+} from './audio.js';
+
+/** Build a canonical PCM16 WAV buffer from interleaved int16 samples. */
+function buildWav(
+  int16: number[],
+  opts: { channels?: number; sampleRate?: number; audioFormat?: number; bitsPerSample?: number } = {},
+): Uint8Array {
+  const channels = opts.channels ?? 1;
+  const sampleRate = opts.sampleRate ?? 16_000;
+  const audioFormat = opts.audioFormat ?? 1;
+  const bitsPerSample = opts.bitsPerSample ?? 16;
+  const bytesPerSample = bitsPerSample / 8;
+  const dataSize = int16.length * bytesPerSample;
+  const buf = new Uint8Array(44 + dataSize);
+  const view = new DataView(buf.buffer);
+  const ascii = (o: number, s: string): void => {
+    for (let i = 0; i < s.length; i += 1) buf[o + i] = s.charCodeAt(i);
+  };
+  ascii(0, 'RIFF');
+  view.setUint32(4, 36 + dataSize, true);
+  ascii(8, 'WAVE');
+  ascii(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, audioFormat, true);
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * channels * bytesPerSample, true);
+  view.setUint16(32, channels * bytesPerSample, true);
+  view.setUint16(34, bitsPerSample, true);
+  ascii(36, 'data');
+  view.setUint32(40, dataSize, true);
+  let off = 44;
+  for (const s of int16) {
+    if (bitsPerSample === 16) view.setInt16(off, s, true);
+    else view.setUint8(off, s & 0xff);
+    off += bytesPerSample;
+  }
+  return buf;
+}
+
+describe('pcm16ToFloat32', () => {
+  it('maps int16 range edges to ~[-1, 1) and 0 to 0', () => {
+    const bytes = new Uint8Array(6);
+    const v = new DataView(bytes.buffer);
+    v.setInt16(0, 0, true);
+    v.setInt16(2, 32767, true);
+    v.setInt16(4, -32768, true);
+    const f = pcm16ToFloat32(bytes);
+    expect(f[0]).toBe(0);
+    expect(f[1]).toBeCloseTo(0.99997, 4);
+    expect(f[2]).toBe(-1); // -32768 / 32768
+  });
+
+  it('drops a trailing odd byte instead of misreading it', () => {
+    const bytes = new Uint8Array([0, 0, 0, 0, 7]); // 2 samples + 1 stray byte
+    expect(pcm16ToFloat32(bytes)).toHaveLength(2);
+  });
+
+  it('works on a non-2-aligned subarray view', () => {
+    const backing = new Uint8Array(5);
+    const v = new DataView(backing.buffer);
+    v.setInt16(1, 16384, true); // write at offset 1 (odd)
+    const f = pcm16ToFloat32(backing.subarray(1, 3));
+    expect(f[0]).toBeCloseTo(0.5, 5);
+  });
+});
+
+describe('downmixToMono', () => {
+  it('averages stereo frames', () => {
+    // interleaved L,R,L,R → [(1+3)/2, (0.5-0.5)/2]
+    const stereo = Float32Array.from([1, 3, 0.5, -0.5]);
+    const mono = downmixToMono(stereo, 2);
+    expect(Array.from(mono)).toEqual([2, 0]);
+  });
+
+  it('returns the input unchanged for mono', () => {
+    const mono = Float32Array.from([0.1, 0.2]);
+    expect(downmixToMono(mono, 1)).toBe(mono);
+  });
+
+  it('ignores a trailing partial frame', () => {
+    const stereo = Float32Array.from([1, 1, 2]); // 1.5 frames
+    expect(downmixToMono(stereo, 2)).toHaveLength(1);
+  });
+});
+
+describe('resampleLinear', () => {
+  it('returns the input unchanged when rates match', () => {
+    const x = Float32Array.from([0.1, 0.2, 0.3]);
+    expect(resampleLinear(x, 16_000, 16_000)).toBe(x);
+  });
+
+  it('preserves a DC (constant) signal', () => {
+    const x = new Float32Array(240).fill(0.42);
+    const y = resampleLinear(x, 24_000, 16_000);
+    expect(y.length).toBe(160);
+    for (const s of y) expect(s).toBeCloseTo(0.42, 6);
+  });
+
+  it('changes length by the rate ratio (24k → 16k ≈ 2/3)', () => {
+    const y = resampleLinear(new Float32Array(300), 24_000, 16_000);
+    expect(y.length).toBe(200);
+    const up = resampleLinear(new Float32Array(160), 16_000, 24_000);
+    expect(up.length).toBe(240);
+  });
+
+  it('tracks a sine wave in continuous time after resampling 24k → 16k', () => {
+    const fromRate = 24_000;
+    const toRate = 16_000;
+    const freq = 220; // Hz — well below Nyquist at both rates
+    const n = 2400; // 0.1 s
+    const src = new Float32Array(n);
+    for (let i = 0; i < n; i += 1) src[i] = Math.sin((2 * Math.PI * freq * i) / fromRate);
+    const out = resampleLinear(src, fromRate, toRate);
+    // Each output sample should approximate the same continuous sine sampled at
+    // the target rate (linear interpolation error is tiny for 220 Hz).
+    for (let i = 0; i < out.length - 1; i += 1) {
+      const expected = Math.sin((2 * Math.PI * freq * i) / toRate);
+      expect(out[i]).toBeCloseTo(expected, 2);
+    }
+  });
+});
+
+describe('isRiffWave', () => {
+  it('detects RIFF/WAVE magic', () => {
+    expect(isRiffWave(buildWav([0, 0]))).toBe(true);
+    expect(isRiffWave(new Uint8Array([1, 2, 3, 4]))).toBe(false);
+    expect(isRiffWave(new Uint8Array(0))).toBe(false);
+  });
+});
+
+describe('parseWav', () => {
+  it('parses a mono PCM16 file', () => {
+    const wav = buildWav([0, 16384, -16384], { channels: 1, sampleRate: 16_000 });
+    const parsed = parseWav(wav);
+    expect(parsed.channels).toBe(1);
+    expect(parsed.sampleRate).toBe(16_000);
+    expect(parsed.samples[1]).toBeCloseTo(0.5, 4);
+    expect(parsed.samples[2]).toBeCloseTo(-0.5, 4);
+  });
+
+  it('parses a stereo PCM16 file (interleaved, still needs downmix)', () => {
+    const wav = buildWav([1000, 2000, 3000, 4000], { channels: 2, sampleRate: 8_000 });
+    const parsed = parseWav(wav);
+    expect(parsed.channels).toBe(2);
+    expect(parsed.samples).toHaveLength(4);
+    expect(Array.from(downmixToMono(parsed.samples, parsed.channels))).toHaveLength(2);
+  });
+
+  it('rejects IEEE-float WAV politely', () => {
+    const wav = buildWav([0, 0], { audioFormat: 3, bitsPerSample: 32 });
+    expect(() => parseWav(wav)).toThrow(/IEEE float/);
+  });
+
+  it('rejects 8-bit PCM WAV', () => {
+    const wav = buildWav([0, 0], { audioFormat: 1, bitsPerSample: 8 });
+    expect(() => parseWav(wav)).toThrow(/8-bit PCM/);
+  });
+
+  it('throws CONFIG_INVALID for a non-RIFF buffer', () => {
+    expect(() => parseWav(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]))).toThrow(
+      /not a RIFF/,
+    );
+    try {
+      parseWav(new Uint8Array(12));
+    } catch (err) {
+      expect((err as { code?: string }).code).toBe('CONFIG_INVALID');
+    }
+  });
+
+  it('tolerates an extra chunk before data and a padded odd-size chunk', () => {
+    // Hand-build: RIFF WAVE | fmt(16) | LIST(3, padded to 4) | data(4)
+    const parts: number[] = [];
+    const push32 = (n: number): void => {
+      parts.push(n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >> 24) & 0xff);
+    };
+    const pushStr = (s: string): void => {
+      for (const c of s) parts.push(c.charCodeAt(0));
+    };
+    // placeholder RIFF size filled later
+    pushStr('RIFF');
+    push32(0);
+    pushStr('WAVE');
+    pushStr('fmt ');
+    push32(16);
+    parts.push(1, 0); // PCM
+    parts.push(1, 0); // mono
+    push32(16_000);
+    push32(16_000 * 2);
+    parts.push(2, 0); // block align
+    parts.push(16, 0); // bits
+    pushStr('LIST');
+    push32(3); // odd size
+    parts.push(9, 9, 9, 0); // 3 bytes + 1 pad
+    pushStr('data');
+    push32(4);
+    parts.push(0, 0, 0, 64); // two int16 samples: 0, 16384
+    const bytes = new Uint8Array(parts);
+    new DataView(bytes.buffer).setUint32(4, bytes.length - 8, true);
+    const parsed = parseWav(bytes);
+    expect(parsed.sampleRate).toBe(16_000);
+    expect(parsed.samples).toHaveLength(2);
+    expect(parsed.samples[1]).toBeCloseTo(0.5, 4);
+  });
+});

--- a/packages/plugin-stt-local/src/audio.ts
+++ b/packages/plugin-stt-local/src/audio.ts
@@ -1,0 +1,220 @@
+/**
+ * Pure, dependency-free audio DSP for the local Whisper transcriber. sherpa's
+ * OfflineRecognizer wants Float32 mono PCM in [-1, 1] at 16 kHz; inbound audio
+ * arrives in several shapes, so these helpers convert each to that canonical
+ * form IN-PROCESS (no ffmpeg for raw PCM / WAV):
+ *
+ *   - `pcm16ToFloat32`  int16 little-endian bytes → Float32 in [-1, 1]
+ *   - `downmixToMono`   interleaved N-channel Float32 → averaged mono
+ *   - `resampleLinear`  linear-interpolation resample between two rates
+ *   - `parseWav`        RIFF/WAVE header parse → PCM16 samples (float) + rate +
+ *                       channels; rejects non-PCM16 (float/compressed) WAV
+ *
+ * The `decodeToMono16k` orchestrator (in ./decode.ts) drives these plus the
+ * ffmpeg path. Everything here is synchronous and unit-tested against synthetic
+ * fixtures — the header offsets and the resampler math are load-bearing.
+ */
+
+import { MoxxyError } from '@moxxy/sdk';
+
+/** The sample rate sherpa's Whisper feature extractor expects. */
+export const TARGET_SAMPLE_RATE = 16_000;
+
+/** Full-scale divisor: int16 spans [-32768, 32767]; dividing by 32768 keeps
+ *  the result in [-1, 1) without clipping the negative rail. */
+const INT16_SCALE = 32_768;
+
+/**
+ * Convert raw 16-bit little-endian PCM bytes to Float32 in [-1, 1]. A trailing
+ * odd byte (half a sample) is dropped. Channel interleaving is preserved — a
+ * stereo buffer stays interleaved, so callers downmix afterwards.
+ */
+export function pcm16ToFloat32(pcm: Uint8Array | ArrayBuffer): Float32Array {
+  const bytes = pcm instanceof Uint8Array ? pcm : new Uint8Array(pcm);
+  const usable = bytes.byteLength & ~1; // drop a trailing odd byte
+  const count = usable / 2;
+  const out = new Float32Array(count);
+  // Read via DataView so we don't depend on the platform being little-endian
+  // and don't require the byte offset to be 2-aligned (a subarray view can
+  // start on an odd offset).
+  const view = new DataView(bytes.buffer, bytes.byteOffset, usable);
+  for (let i = 0; i < count; i += 1) {
+    out[i] = view.getInt16(i * 2, true) / INT16_SCALE;
+  }
+  return out;
+}
+
+/**
+ * Average `channels` interleaved Float32 channels down to mono. `channels` must
+ * be a positive integer; a value of 1 returns the input unchanged. Trailing
+ * samples that don't complete a frame are ignored.
+ */
+export function downmixToMono(interleaved: Float32Array, channels: number): Float32Array {
+  if (!Number.isInteger(channels) || channels < 1) {
+    throw new MoxxyError({
+      code: 'INTERNAL',
+      message: `downmixToMono: invalid channel count ${channels}.`,
+    });
+  }
+  if (channels === 1) return interleaved;
+  const frames = Math.floor(interleaved.length / channels);
+  const out = new Float32Array(frames);
+  for (let f = 0; f < frames; f += 1) {
+    let sum = 0;
+    const base = f * channels;
+    for (let c = 0; c < channels; c += 1) sum += interleaved[base + c]!;
+    out[f] = sum / channels;
+  }
+  return out;
+}
+
+/**
+ * Resample mono Float32 audio from `fromRate` to `toRate` by linear
+ * interpolation. Cheap and dependency-free — good enough for speech recognition
+ * (Whisper is robust to the mild low-pass a linear kernel imposes). Returns the
+ * input unchanged when the rates match, and an empty array for empty input.
+ */
+export function resampleLinear(
+  input: Float32Array,
+  fromRate: number,
+  toRate: number,
+): Float32Array {
+  if (!Number.isFinite(fromRate) || !Number.isFinite(toRate) || fromRate <= 0 || toRate <= 0) {
+    throw new MoxxyError({
+      code: 'INTERNAL',
+      message: `resampleLinear: invalid rate(s) from=${fromRate} to=${toRate}.`,
+    });
+  }
+  if (fromRate === toRate) return input;
+  if (input.length === 0) return new Float32Array(0);
+  if (input.length === 1) return Float32Array.of(input[0]!);
+
+  const ratio = fromRate / toRate;
+  const outLen = Math.max(1, Math.round(input.length / ratio));
+  const out = new Float32Array(outLen);
+  const lastIdx = input.length - 1;
+  for (let i = 0; i < outLen; i += 1) {
+    const srcPos = i * ratio;
+    const i0 = Math.floor(srcPos);
+    if (i0 >= lastIdx) {
+      out[i] = input[lastIdx]!;
+      continue;
+    }
+    const frac = srcPos - i0;
+    out[i] = input[i0]! * (1 - frac) + input[i0 + 1]! * frac;
+  }
+  return out;
+}
+
+/** True when `bytes` begins with the `RIFF….WAVE` magic of a WAV container. */
+export function isRiffWave(bytes: Uint8Array): boolean {
+  return (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 && // R
+    bytes[1] === 0x49 && // I
+    bytes[2] === 0x46 && // F
+    bytes[3] === 0x46 && // F
+    bytes[8] === 0x57 && // W
+    bytes[9] === 0x41 && // A
+    bytes[10] === 0x56 && // V
+    bytes[11] === 0x45 // E
+  );
+}
+
+export interface ParsedWav {
+  /** PCM samples as Float32 in [-1, 1], still interleaved if multi-channel. */
+  readonly samples: Float32Array;
+  readonly sampleRate: number;
+  readonly channels: number;
+}
+
+// WAV `fmt ` audio-format codes we care about.
+const WAVE_FORMAT_PCM = 1;
+const WAVE_FORMAT_IEEE_FLOAT = 3;
+const WAVE_FORMAT_EXTENSIBLE = 0xfffe;
+
+/**
+ * Parse a canonical RIFF/WAVE buffer into PCM16 samples. Only linear 16-bit PCM
+ * is accepted — IEEE-float, μ-law, and compressed WAV are rejected with a clear
+ * `CONFIG_INVALID` MoxxyError (the caller falls back to ffmpeg for real
+ * compressed formats, but a mislabelled/exotic WAV should fail loudly, not
+ * silently mis-decode). Walks the chunk list rather than assuming a fixed
+ * 44-byte header, so files with extra chunks (`LIST`, `fact`, …) still parse.
+ */
+export function parseWav(bytes: Uint8Array): ParsedWav {
+  if (!isRiffWave(bytes)) {
+    throw wavError('not a RIFF/WAVE file (bad magic).');
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+  let fmt: { format: number; channels: number; sampleRate: number; bitsPerSample: number } | null =
+    null;
+  let dataOffset = -1;
+  let dataLen = 0;
+
+  // Chunks begin right after `RIFF<size>WAVE` (offset 12). Each chunk is a
+  // 4-byte id + uint32 little-endian size + payload, word-aligned (odd payloads
+  // carry a pad byte).
+  let off = 12;
+  while (off + 8 <= bytes.byteLength) {
+    const id = ascii4(bytes, off);
+    const size = view.getUint32(off + 4, true);
+    const body = off + 8;
+    if (id === 'fmt ') {
+      if (body + 16 > bytes.byteLength) throw wavError('truncated fmt chunk.');
+      fmt = {
+        format: view.getUint16(body, true),
+        channels: view.getUint16(body + 2, true),
+        sampleRate: view.getUint32(body + 4, true),
+        bitsPerSample: view.getUint16(body + 14, true),
+      };
+    } else if (id === 'data') {
+      dataOffset = body;
+      // Clamp a declared size that overruns the buffer (some encoders write 0
+      // or 0xffffffff for streamed data) to what's actually present.
+      dataLen = Math.min(size, bytes.byteLength - body);
+    }
+    // Advance past the payload + pad byte. Guard against a zero/garbage size
+    // that would loop forever.
+    const advance = 8 + size + (size & 1);
+    if (advance <= 8) break;
+    off += advance;
+  }
+
+  if (!fmt) throw wavError('missing fmt chunk.');
+  if (dataOffset < 0) throw wavError('missing data chunk.');
+
+  const { format, channels, sampleRate, bitsPerSample } = fmt;
+  if (!Number.isInteger(channels) || channels < 1) {
+    throw wavError(`unsupported channel count ${channels}.`);
+  }
+  if (!Number.isInteger(sampleRate) || sampleRate <= 0) {
+    throw wavError(`unsupported sample rate ${sampleRate}.`);
+  }
+  // Accept plain PCM; also accept EXTENSIBLE only when it's declared 16-bit PCM
+  // (a common wrapper the codecs emit for the same data). Reject float/exotic.
+  const isPcm16 =
+    (format === WAVE_FORMAT_PCM || format === WAVE_FORMAT_EXTENSIBLE) && bitsPerSample === 16;
+  if (!isPcm16) {
+    const kind =
+      format === WAVE_FORMAT_IEEE_FLOAT
+        ? 'IEEE float'
+        : format === WAVE_FORMAT_PCM || format === WAVE_FORMAT_EXTENSIBLE
+          ? `${bitsPerSample}-bit PCM`
+          : `format 0x${format.toString(16)}`;
+    throw wavError(
+      `unsupported WAV encoding (${kind}). Only 16-bit PCM WAV is decoded in-process; re-export as PCM16 WAV, or install ffmpeg to decode other formats.`,
+    );
+  }
+
+  const pcm = bytes.subarray(dataOffset, dataOffset + dataLen);
+  return { samples: pcm16ToFloat32(pcm), sampleRate, channels };
+}
+
+function ascii4(bytes: Uint8Array, off: number): string {
+  return String.fromCharCode(bytes[off]!, bytes[off + 1]!, bytes[off + 2]!, bytes[off + 3]!);
+}
+
+function wavError(detail: string): MoxxyError {
+  return new MoxxyError({ code: 'CONFIG_INVALID', message: `Invalid WAV audio: ${detail}` });
+}

--- a/packages/plugin-stt-local/src/decode.test.ts
+++ b/packages/plugin-stt-local/src/decode.test.ts
@@ -1,0 +1,126 @@
+import { Buffer } from 'node:buffer';
+import { EventEmitter } from 'node:events';
+import type { spawn } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+
+import { MOXXY_PCM16_24KHZ_MIME } from '@moxxy/sdk';
+
+import { decodeToMono16k } from './decode.js';
+
+/** Minimal fake `spawn`: probe → exit 0, decode → emit the given f32le bytes. */
+function fakeSpawn(samples: Float32Array): typeof spawn {
+  return ((_cmd: string, args: readonly string[]) => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      stdin: { writable: boolean; on: () => void; end: () => void };
+      kill: () => boolean;
+      killed: boolean;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.killed = false;
+    child.kill = () => ((child.killed = true), true);
+    child.stdin = { writable: true, on: () => {}, end: () => {} };
+    const isProbe = args.includes('-version');
+    setImmediate(() => {
+      if (isProbe) {
+        child.emit('close', 0);
+        return;
+      }
+      if (samples.length > 0) child.stdout.emit('data', Buffer.from(samples.buffer.slice(0)));
+      child.emit('close', 0);
+    });
+    return child;
+  }) as unknown as typeof spawn;
+}
+
+/** Build raw PCM16 mono little-endian bytes for the given float samples. */
+function rawPcm16(samples: number[]): Uint8Array {
+  const bytes = new Uint8Array(samples.length * 2);
+  const view = new DataView(bytes.buffer);
+  samples.forEach((s, i) => view.setInt16(i * 2, Math.round(s * 32767), true));
+  return bytes;
+}
+
+/** Build a mono PCM16 WAV at the given sample rate. */
+function monoWav(samples: number[], sampleRate: number): Uint8Array {
+  const dataSize = samples.length * 2;
+  const buf = new Uint8Array(44 + dataSize);
+  const view = new DataView(buf.buffer);
+  const ascii = (o: number, s: string): void => {
+    for (let i = 0; i < s.length; i += 1) buf[o + i] = s.charCodeAt(i);
+  };
+  ascii(0, 'RIFF');
+  view.setUint32(4, 36 + dataSize, true);
+  ascii(8, 'WAVE');
+  ascii(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  ascii(36, 'data');
+  view.setUint32(40, dataSize, true);
+  samples.forEach((s, i) => view.setInt16(44 + i * 2, Math.round(s * 32767), true));
+  return buf;
+}
+
+describe('decodeToMono16k', () => {
+  it('converts raw PCM16 mono @24k and resamples to 16k (no ffmpeg)', async () => {
+    const dc = new Array<number>(240).fill(0.5); // 240 samples @24k → 160 @16k
+    const out = await decodeToMono16k(rawPcm16(dc), MOXXY_PCM16_24KHZ_MIME);
+    expect(out.length).toBe(160);
+    for (const s of out) expect(s).toBeCloseTo(0.5, 2);
+  });
+
+  it('parses a 16k mono WAV unchanged (no resample, no ffmpeg)', async () => {
+    const wav = monoWav([0, 0.5, -0.5], 16_000);
+    const out = await decodeToMono16k(wav, 'audio/wav');
+    expect(out.length).toBe(3);
+    expect(out[1]).toBeCloseTo(0.5, 3);
+  });
+
+  it('resamples a 8k WAV up to 16k', async () => {
+    const wav = monoWav(new Array<number>(80).fill(0.25), 8_000);
+    const out = await decodeToMono16k(wav, 'audio/x-wav');
+    expect(out.length).toBe(160);
+  });
+
+  it('sniffs RIFF/WAVE magic when the MIME is missing', async () => {
+    const wav = monoWav([0.1, 0.2], 16_000);
+    const out = await decodeToMono16k(wav, undefined);
+    expect(out.length).toBe(2);
+  });
+
+  it('routes compressed audio (audio/ogg) through ffmpeg', async () => {
+    const decoded = Float32Array.from([0.1, -0.2, 0.3]);
+    const out = await decodeToMono16k(new Uint8Array([1, 2, 3]), 'audio/ogg', {
+      spawnImpl: fakeSpawn(decoded),
+    });
+    expect(Array.from(out)).toEqual([
+      expect.closeTo(0.1, 5),
+      expect.closeTo(-0.2, 5),
+      expect.closeTo(0.3, 5),
+    ]);
+  });
+
+  it('handles a MIME with a codecs= parameter (case-insensitive)', async () => {
+    const decoded = Float32Array.from([0.42]);
+    const out = await decodeToMono16k(new Uint8Array([1]), 'AUDIO/OGG; codecs=opus', {
+      spawnImpl: fakeSpawn(decoded),
+    });
+    expect(out[0]).toBeCloseTo(0.42, 5);
+  });
+
+  it('rejects an IEEE-float WAV politely instead of mis-decoding', async () => {
+    // Build a float WAV header (format 3) — parseWav must reject it.
+    const buf = monoWav([0], 16_000);
+    new DataView(buf.buffer).setUint16(20, 3, true); // audioFormat = IEEE float
+    await expect(decodeToMono16k(buf, 'audio/wav')).rejects.toMatchObject({
+      code: 'CONFIG_INVALID',
+    });
+  });
+});

--- a/packages/plugin-stt-local/src/decode.ts
+++ b/packages/plugin-stt-local/src/decode.ts
@@ -1,0 +1,74 @@
+/**
+ * The single entry point that turns whatever audio a caller hands the local
+ * Whisper transcriber into the Float32 mono @ 16 kHz that sherpa wants. It
+ * dispatches on the MIME type (with a RIFF magic sniff as a backstop):
+ *
+ *   - `MOXXY_PCM16_24KHZ_MIME` (the TUI/desktop mic) → int16→float32, then
+ *     linear-resample 24 kHz → 16 kHz. Never touches ffmpeg.
+ *   - `audio/wav` / `audio/x-wav`, or any buffer whose bytes start with the WAV
+ *     magic → parse the RIFF header (PCM16 only), downmix, resample. No ffmpeg.
+ *   - everything else (ogg/opus, mp3, m4a, webm, flac, …) → ffmpeg.
+ *
+ * The MIME string is UNTRUSTED (channels forward a messenger's `mime_type`
+ * verbatim), so it's runtime-guarded and canonicalized before matching.
+ */
+
+import { MOXXY_PCM16_24KHZ_MIME } from '@moxxy/sdk';
+import type { spawn } from 'node:child_process';
+
+import {
+  downmixToMono,
+  isRiffWave,
+  parseWav,
+  pcm16ToFloat32,
+  resampleLinear,
+  TARGET_SAMPLE_RATE,
+} from './audio.js';
+import { decodeViaFfmpeg } from './ffmpeg.js';
+
+/** The raw mic contract carries mono int16 @ this rate (see the SDK MIME tag). */
+const MOXXY_PCM16_SAMPLE_RATE = 24_000;
+
+export interface DecodeOptions {
+  /** Injected `spawn` for the ffmpeg path (tests). Defaults to real `spawn`. */
+  readonly spawnImpl?: typeof spawn;
+}
+
+/**
+ * Decode `audio` to Float32 mono PCM in [-1, 1] at 16 kHz. Throws a MoxxyError
+ * for malformed WAV (non-PCM16) or when ffmpeg is needed but missing.
+ */
+export async function decodeToMono16k(
+  audio: Uint8Array | ArrayBuffer,
+  mimeType: string | undefined,
+  opts: DecodeOptions = {},
+): Promise<Float32Array> {
+  const bytes = audio instanceof Uint8Array ? audio : new Uint8Array(audio);
+  const mt = canonicalMime(mimeType);
+
+  // 1) Raw PCM16 mono @ 24 kHz from the moxxy mic recorder.
+  if (mt === MOXXY_PCM16_24KHZ_MIME) {
+    const mono = pcm16ToFloat32(bytes);
+    return resampleLinear(mono, MOXXY_PCM16_SAMPLE_RATE, TARGET_SAMPLE_RATE);
+  }
+
+  // 2) WAV — by declared MIME or by sniffing the RIFF/WAVE magic (a mislabelled
+  //    or MIME-less WAV still decodes in-process).
+  if (mt === 'audio/wav' || mt === 'audio/x-wav' || mt === 'audio/wave' || isRiffWave(bytes)) {
+    const wav = parseWav(bytes);
+    const mono = wav.channels > 1 ? downmixToMono(wav.samples, wav.channels) : wav.samples;
+    return wav.sampleRate === TARGET_SAMPLE_RATE
+      ? mono
+      : resampleLinear(mono, wav.sampleRate, TARGET_SAMPLE_RATE);
+  }
+
+  // 3) Everything else is a compressed container → ffmpeg (already resamples to
+  //    16 kHz mono for us).
+  return decodeViaFfmpeg(bytes, opts.spawnImpl);
+}
+
+/** Lower-case, strip a `; codecs=…` parameter, trim. Non-string → ''. */
+function canonicalMime(mimeType: string | undefined): string {
+  const raw = typeof mimeType === 'string' ? mimeType : '';
+  return raw.toLowerCase().split(';')[0]!.trim();
+}

--- a/packages/plugin-stt-local/src/ffmpeg.test.ts
+++ b/packages/plugin-stt-local/src/ffmpeg.test.ts
@@ -1,0 +1,142 @@
+import { Buffer } from 'node:buffer';
+import { EventEmitter } from 'node:events';
+import type { spawn } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { __resetFfmpegProbeForTest, decodeViaFfmpeg, missingFfmpegError } from './ffmpeg.js';
+
+/** A fake `spawn` that plays the ffmpeg probe (`-version`) and the decode
+ *  (`f32le` pipe) roles. Configurable per-role so tests drive deterministic
+ *  outcomes without a real ffmpeg. */
+interface FakeSpawnConfig {
+  /** Probe: 'ok' → exit 0, 'fail' → exit 1, 'enoent' → emit spawn error. */
+  readonly probe?: 'ok' | 'fail' | 'enoent';
+  /** Decode stdout samples (encoded as f32le), or null to emit none. */
+  readonly decodeSamples?: Float32Array | null;
+  /** Decode exit code (default 0). */
+  readonly decodeExit?: number;
+  /** Decode stderr text. */
+  readonly decodeStderr?: string;
+}
+
+function makeFakeSpawn(config: FakeSpawnConfig): {
+  spawnImpl: typeof spawn;
+  probeCalls: number;
+  decodeCalls: number;
+  fedStdin: Buffer[];
+} {
+  const stats = { probeCalls: 0, decodeCalls: 0, fedStdin: [] as Buffer[] };
+
+  const spawnImpl = ((_cmd: string, args: readonly string[]) => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      stdin: { writable: boolean; on: () => void; end: (b?: Buffer) => void };
+      kill: () => boolean;
+      killed: boolean;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.killed = false;
+    child.kill = () => {
+      child.killed = true;
+      return true;
+    };
+    const isProbe = args.includes('-version');
+    child.stdin = {
+      writable: true,
+      on: () => {},
+      end: (b?: Buffer) => {
+        if (b) stats.fedStdin.push(b);
+      },
+    };
+
+    if (isProbe) {
+      stats.probeCalls += 1;
+      setImmediate(() => {
+        if (config.probe === 'enoent') {
+          const err = Object.assign(new Error('spawn ffmpeg ENOENT'), { code: 'ENOENT' });
+          child.emit('error', err);
+          return;
+        }
+        child.emit('close', config.probe === 'fail' ? 1 : 0);
+      });
+      return child;
+    }
+
+    stats.decodeCalls += 1;
+    setImmediate(() => {
+      if (config.decodeStderr) child.stderr.emit('data', Buffer.from(config.decodeStderr));
+      const samples = config.decodeSamples;
+      if (samples && samples.length > 0) {
+        child.stdout.emit('data', Buffer.from(samples.buffer.slice(0)));
+      }
+      child.emit('close', config.decodeExit ?? 0);
+    });
+    return child;
+  }) as unknown as typeof spawn;
+
+  return {
+    spawnImpl,
+    get probeCalls() {
+      return stats.probeCalls;
+    },
+    get decodeCalls() {
+      return stats.decodeCalls;
+    },
+    get fedStdin() {
+      return stats.fedStdin;
+    },
+  };
+}
+
+afterEach(() => __resetFfmpegProbeForTest());
+
+describe('decodeViaFfmpeg', () => {
+  it('decodes to Float32 samples via ffmpeg, feeding the input on stdin', async () => {
+    const expected = Float32Array.from([0, 0.25, -0.5, 0.999]);
+    const fake = makeFakeSpawn({ probe: 'ok', decodeSamples: expected });
+    const input = new Uint8Array([1, 2, 3, 4]);
+    const out = await decodeViaFfmpeg(input, fake.spawnImpl);
+    expect(Array.from(out)).toEqual(Array.from(expected));
+    expect(fake.probeCalls).toBe(1);
+    expect(fake.decodeCalls).toBe(1);
+    expect(fake.fedStdin[0]!.equals(Buffer.from(input))).toBe(true);
+  });
+
+  it('throws a clear PLUGIN_LOAD_FAILED error with an install hint when ffmpeg is missing', async () => {
+    const fake = makeFakeSpawn({ probe: 'enoent' });
+    await expect(decodeViaFfmpeg(new Uint8Array([1]), fake.spawnImpl)).rejects.toMatchObject({
+      code: 'PLUGIN_LOAD_FAILED',
+    });
+    expect(fake.decodeCalls).toBe(0); // never attempted the decode
+  });
+
+  it('surfaces a non-zero ffmpeg exit as an INTERNAL error carrying stderr', async () => {
+    const fake = makeFakeSpawn({
+      probe: 'ok',
+      decodeSamples: null,
+      decodeExit: 1,
+      decodeStderr: 'Invalid data found when processing input',
+    });
+    await expect(decodeViaFfmpeg(new Uint8Array([9]), fake.spawnImpl)).rejects.toMatchObject({
+      code: 'INTERNAL',
+    });
+  });
+
+  it('errors when ffmpeg exits 0 but produces no audio', async () => {
+    const fake = makeFakeSpawn({ probe: 'ok', decodeSamples: null, decodeExit: 0 });
+    await expect(decodeViaFfmpeg(new Uint8Array([9]), fake.spawnImpl)).rejects.toThrow(
+      /produced no audio/,
+    );
+  });
+});
+
+describe('missingFfmpegError', () => {
+  it('is a PLUGIN_LOAD_FAILED MoxxyError naming ffmpeg and an install command', () => {
+    const err = missingFfmpegError();
+    expect(err.code).toBe('PLUGIN_LOAD_FAILED');
+    expect(err.message).toMatch(/ffmpeg/i);
+    expect(err.hint).toMatch(/install/i);
+  });
+});

--- a/packages/plugin-stt-local/src/ffmpeg.ts
+++ b/packages/plugin-stt-local/src/ffmpeg.ts
@@ -1,0 +1,215 @@
+/**
+ * The ffmpeg fallback for compressed audio (ogg/opus voice notes, mp3, m4a,
+ * webm, …) that we can't decode in-process. ffmpeg reads the container on stdin
+ * and writes raw 32-bit-float mono PCM at 16 kHz to stdout, which we read
+ * straight into a Float32Array — no intermediate WAV, no temp files.
+ *
+ * Gated behind a presence probe (mirrors channel-kit's voice-reply, cached per
+ * process; an injected `spawnImpl` bypasses the cache so tests are
+ * deterministic). When ffmpeg is absent we throw a clear, actionable MoxxyError
+ * — raw PCM16 and PCM16 WAV keep working without it, only compressed input
+ * needs it.
+ */
+
+import { Buffer } from 'node:buffer';
+import { spawn } from 'node:child_process';
+
+import { getInstallHint, MoxxyError } from '@moxxy/sdk';
+
+import { TARGET_SAMPLE_RATE } from './audio.js';
+
+/** ffmpeg args: decode any input container → f32le mono @ 16 kHz on stdout. */
+const DECODE_ARGS = [
+  '-hide_banner',
+  '-loglevel',
+  'error',
+  '-i',
+  'pipe:0',
+  '-f',
+  'f32le',
+  '-ac',
+  '1',
+  '-ar',
+  String(TARGET_SAMPLE_RATE),
+  'pipe:1',
+];
+
+/** Ceiling on decoded PCM we buffer. At 16 kHz f32 mono (64 KB/s) this is ~30
+ *  minutes — well past any voice note, and bounds an adversarial input. */
+const MAX_DECODED_BYTES = 120 * 1024 * 1024;
+
+const PROBE_TIMEOUT_MS = 1_500;
+const DECODE_TIMEOUT_MS = 60_000;
+
+/**
+ * Decode compressed audio bytes to Float32 mono @ 16 kHz via ffmpeg. Throws a
+ * `PLUGIN_LOAD_FAILED` MoxxyError (with an OS-specific install hint) when ffmpeg
+ * isn't on PATH, and an `INTERNAL` MoxxyError when ffmpeg runs but fails.
+ */
+export async function decodeViaFfmpeg(
+  audio: Uint8Array,
+  spawnImpl?: typeof spawn,
+): Promise<Float32Array> {
+  const available = await probeFfmpeg(spawnImpl);
+  if (!available) throw missingFfmpegError();
+  const raw = await runDecode(audio, spawnImpl ?? spawn);
+  return f32leToFloat32(raw);
+}
+
+/** The user-facing error raised when compressed audio arrives but ffmpeg is
+ *  absent. Exported so the decode orchestrator / tests can assert on it. */
+export function missingFfmpegError(): MoxxyError {
+  const hint = getInstallHint('ffmpeg');
+  return new MoxxyError({
+    code: 'PLUGIN_LOAD_FAILED',
+    message:
+      'Local Whisper needs ffmpeg to decode compressed audio (ogg/opus, mp3, m4a, webm). Raw PCM and 16-bit PCM WAV transcribe without it.',
+    hint: `Install ffmpeg via ${hint.manager}: \`${hint.command}\`.`,
+  });
+}
+
+// Process-cached ffmpeg availability (the probe spawns a subprocess; caching
+// keeps a chatty voice channel from re-probing on every note). An injected
+// `spawnImpl` (tests) bypasses the cache.
+let ffmpegAvailable: Promise<boolean> | null = null;
+
+async function probeFfmpeg(spawnImpl?: typeof spawn): Promise<boolean> {
+  if (spawnImpl) return runProbe(spawnImpl);
+  ffmpegAvailable ??= runProbe(spawn);
+  return ffmpegAvailable;
+}
+
+/** Reset the cached ffmpeg probe (tests only). */
+export function __resetFfmpegProbeForTest(): void {
+  ffmpegAvailable = null;
+}
+
+function runProbe(spawnImpl: typeof spawn, command = 'ffmpeg'): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (v: boolean): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(v);
+    };
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawnImpl(command, ['-version'], { stdio: ['ignore', 'ignore', 'ignore'] });
+    } catch {
+      resolve(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      try {
+        if (!child.killed) child.kill('SIGKILL');
+      } catch {
+        /* ignore */
+      }
+      done(false);
+    }, PROBE_TIMEOUT_MS);
+    timer.unref?.();
+    child.once('error', () => done(false));
+    child.once('close', (code) => done(code === 0));
+  });
+}
+
+function runDecode(audio: Uint8Array, spawnImpl: typeof spawn, command = 'ffmpeg'): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawnImpl(command, DECODE_ARGS, { stdio: ['pipe', 'pipe', 'pipe'] });
+    } catch (err) {
+      reject(decodeFailure(err instanceof Error ? err.message : String(err)));
+      return;
+    }
+    const out: Buffer[] = [];
+    const errChunks: Buffer[] = [];
+    let outBytes = 0;
+    let over = false;
+    let settled = false;
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    };
+    const timer = setTimeout(() => {
+      try {
+        if (!child.killed) child.kill('SIGKILL');
+      } catch {
+        /* ignore */
+      }
+      finish(() => reject(decodeFailure('ffmpeg decode timed out')));
+    }, DECODE_TIMEOUT_MS);
+    timer.unref?.();
+
+    child.stdout?.on('data', (c: Buffer) => {
+      if (over) return;
+      if (outBytes + c.byteLength > MAX_DECODED_BYTES) {
+        over = true;
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          /* ignore */
+        }
+        finish(() => reject(decodeFailure('decoded audio exceeded the size limit')));
+        return;
+      }
+      outBytes += c.byteLength;
+      out.push(Buffer.from(c));
+    });
+    child.stderr?.on('data', (c: Buffer) => {
+      errChunks.push(Buffer.from(c));
+      while (Buffer.concat(errChunks).byteLength > 4_096) errChunks.shift();
+    });
+    child.once('error', (err) =>
+      finish(() => reject(decodeFailure(err instanceof Error ? err.message : String(err)))),
+    );
+    child.once('close', (code) =>
+      finish(() => {
+        if (over) return; // already rejected on the size cap
+        if (code === 0 && out.length > 0) {
+          resolve(Buffer.concat(out));
+        } else if (code === 0) {
+          reject(decodeFailure('ffmpeg produced no audio'));
+        } else {
+          reject(
+            decodeFailure(`ffmpeg exited ${code}: ${Buffer.concat(errChunks).toString('utf8').trim()}`),
+          );
+        }
+      }),
+    );
+
+    const stdin = child.stdin;
+    if (stdin) {
+      stdin.on('error', () => {
+        // EPIPE if ffmpeg died before consuming stdin — the close/error handler
+        // reports the real failure; swallow this to avoid an unhandled 'error'.
+      });
+      try {
+        stdin.end(Buffer.from(audio));
+      } catch {
+        /* the close/error path reports it */
+      }
+    }
+  });
+}
+
+/** Reinterpret little-endian float32 bytes as a Float32Array. Copies through a
+ *  DataView so a non-4-aligned Buffer offset and big-endian hosts both work. */
+function f32leToFloat32(buf: Buffer): Float32Array {
+  const usable = buf.byteLength - (buf.byteLength % 4);
+  const count = usable / 4;
+  const out = new Float32Array(count);
+  const view = new DataView(buf.buffer, buf.byteOffset, usable);
+  for (let i = 0; i < count; i += 1) out[i] = view.getFloat32(i * 4, true);
+  return out;
+}
+
+function decodeFailure(detail: string): MoxxyError {
+  return new MoxxyError({
+    code: 'INTERNAL',
+    message: `Local Whisper failed to decode audio with ffmpeg: ${detail}`,
+  });
+}

--- a/packages/plugin-stt-local/src/host-client.test.ts
+++ b/packages/plugin-stt-local/src/host-client.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+import { HostClient, type ChildHandle, type ForkLike } from './host-client.js';
+import type { HostReply, HostRequest } from './host-protocol.js';
+
+/** A controllable fake sidecar: records sent requests + kill, and lets the test
+ *  drive `message`/`exit`/`error` back to the client. */
+class FakeChild implements ChildHandle {
+  readonly sent: HostRequest[] = [];
+  killed = false;
+  private readonly listeners: Record<string, Array<(...a: unknown[]) => void>> = {
+    message: [],
+    exit: [],
+    error: [],
+  };
+
+  send(message: unknown): boolean {
+    this.sent.push(message as HostRequest);
+    return true;
+  }
+  on(event: string, listener: (...args: unknown[]) => void): this {
+    this.listeners[event]!.push(listener);
+    return this;
+  }
+  kill(): boolean {
+    this.killed = true;
+    return true;
+  }
+
+  private emit(event: string, ...args: unknown[]): void {
+    for (const cb of [...this.listeners[event]!]) cb(...args);
+  }
+  /** Reply to the last request the client sent. */
+  replyOk(text: string, language?: string): void {
+    this.replyOkTo(this.sent.at(-1)!.id, text, language);
+  }
+  /** Reply to a specific request id (drives out-of-order correlation tests). */
+  replyOkTo(id: number, text: string, language?: string): void {
+    const reply: HostReply =
+      language !== undefined ? { id, ok: true, text, language } : { id, ok: true, text };
+    this.emit('message', reply);
+  }
+  replyErr(kind: 'init' | 'runtime', message: string): void {
+    const id = this.sent.at(-1)!.id;
+    this.emit('message', { id, ok: false, error: { kind, message } } satisfies HostReply);
+  }
+  crash(code = 1): void {
+    this.emit('exit', code, null);
+  }
+  errorOut(message: string): void {
+    this.emit('error', new Error(message));
+  }
+}
+
+/** A fork factory handing out a fixed list of children, tracking call count. */
+function forkFactory(children: FakeChild[]): { fork: ForkLike; calls: () => number } {
+  let n = 0;
+  const fork: ForkLike = () => {
+    const child = children[n];
+    n += 1;
+    if (!child) throw new Error(`unexpected fork #${n}`);
+    return child;
+  };
+  return { fork, calls: () => n };
+}
+
+const REQ = {
+  modelKey: '/m/base-encoder.onnx',
+  encoder: '/m/base-encoder.onnx',
+  decoder: '/m/base-decoder.onnx',
+  tokens: '/m/base-tokens.txt',
+  numThreads: 2,
+  provider: 'cpu',
+  language: '',
+  task: 'transcribe',
+  samples: new Float32Array([0.1, -0.1]),
+  sampleRate: 16_000,
+};
+
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+describe('HostClient', () => {
+  it('does not fork until the first transcribe (lazy spawn)', async () => {
+    const child = new FakeChild();
+    const { fork, calls } = forkFactory([child]);
+    const host = new HostClient({ hostPath: '/x/sidecar.js', env: {}, forkImpl: fork });
+    expect(calls()).toBe(0);
+    const p = host.transcribe(REQ);
+    await tick();
+    expect(calls()).toBe(1);
+    child.replyOk('hello', 'en');
+    await expect(p).resolves.toEqual({ text: 'hello', language: 'en' });
+    host.shutdown();
+  });
+
+  it('resolves text-only replies without a language field', async () => {
+    const child = new FakeChild();
+    const { fork } = forkFactory([child]);
+    const host = new HostClient({ hostPath: '/x/sidecar.js', env: {}, forkImpl: fork });
+    const p = host.transcribe(REQ);
+    await tick();
+    child.replyOk('just text');
+    await expect(p).resolves.toEqual({ text: 'just text' });
+    host.shutdown();
+  });
+
+  it('correlates replies by id and reuses one child across calls', async () => {
+    const child = new FakeChild();
+    const { fork, calls } = forkFactory([child]);
+    const host = new HostClient({ hostPath: '/x/sidecar.js', env: {}, forkImpl: fork });
+
+    const p1 = host.transcribe({ ...REQ, samples: new Float32Array([1]) });
+    await tick();
+    const p2 = host.transcribe({ ...REQ, samples: new Float32Array([2]) });
+    await tick();
+    expect(child.sent.map((m) => m.id)).toEqual([1, 2]);
+    expect(calls()).toBe(1);
+    // Reply out of order — id correlation must still settle each promise.
+    child.replyOkTo(2, 'two');
+    child.replyOkTo(1, 'one');
+    await expect(p1).resolves.toEqual({ text: 'one' });
+    await expect(p2).resolves.toEqual({ text: 'two' });
+    host.shutdown();
+  });
+
+  it('rejects a transcription error reply', async () => {
+    const child = new FakeChild();
+    const { fork } = forkFactory([child]);
+    const host = new HostClient({ hostPath: '/x/sidecar.js', env: {}, forkImpl: fork });
+    const p = host.transcribe(REQ);
+    await tick();
+    child.replyErr('runtime', 'boom');
+    await expect(p).rejects.toThrow(/runtime error: boom/);
+    host.shutdown();
+  });
+
+  it('restarts the sidecar once on a crash and completes on the fresh child', async () => {
+    const first = new FakeChild();
+    const second = new FakeChild();
+    const { fork, calls } = forkFactory([first, second]);
+    const host = new HostClient({ hostPath: '/x/sidecar.js', env: {}, forkImpl: fork });
+
+    const p = host.transcribe(REQ);
+    await tick();
+    expect(calls()).toBe(1);
+    first.crash(139); // dies with the request in flight
+    await tick();
+    expect(calls()).toBe(2);
+    second.replyOk('recovered');
+    await expect(p).resolves.toEqual({ text: 'recovered' });
+    host.shutdown();
+  });
+
+  it('gives up after a second consecutive crash', async () => {
+    const first = new FakeChild();
+    const second = new FakeChild();
+    const { fork } = forkFactory([first, second]);
+    const host = new HostClient({ hostPath: '/x/sidecar.js', env: {}, forkImpl: fork });
+    const p = host.transcribe(REQ);
+    await tick();
+    first.crash();
+    await tick();
+    second.crash();
+    await expect(p).rejects.toThrow(/sidecar exited/);
+    host.shutdown();
+  });
+
+  it('treats a spawn error as a crash', async () => {
+    const child = new FakeChild();
+    const second = new FakeChild();
+    const { fork } = forkFactory([child, second]);
+    const host = new HostClient({ hostPath: '/x/sidecar.js', env: {}, forkImpl: fork });
+    const p = host.transcribe(REQ);
+    await tick();
+    child.errorOut('ENOENT node');
+    await tick();
+    second.replyOk('after respawn');
+    await expect(p).resolves.toEqual({ text: 'after respawn' });
+    host.shutdown();
+  });
+
+  it('times out a hung transcription and kills the child', async () => {
+    const child = new FakeChild();
+    const { fork } = forkFactory([child]);
+    const host = new HostClient({
+      hostPath: '/x/sidecar.js',
+      env: {},
+      forkImpl: fork,
+      requestTimeoutMs: 10,
+    });
+    const p = host.transcribe(REQ);
+    await expect(p).rejects.toThrow(/timed out/);
+    expect(child.killed).toBe(true);
+    host.shutdown();
+  });
+
+  it('shutdown kills the child and rejects in-flight requests', async () => {
+    const child = new FakeChild();
+    const { fork } = forkFactory([child]);
+    const host = new HostClient({ hostPath: '/x/sidecar.js', env: {}, forkImpl: fork });
+    const p = host.transcribe(REQ);
+    await tick();
+    host.shutdown();
+    expect(child.killed).toBe(true);
+    await expect(p).rejects.toThrow(/shut down/);
+    // Further calls fail fast.
+    await expect(host.transcribe(REQ)).rejects.toThrow(/shut down/);
+  });
+});

--- a/packages/plugin-stt-local/src/host-client.ts
+++ b/packages/plugin-stt-local/src/host-client.ts
@@ -1,0 +1,200 @@
+/**
+ * Parent-side manager for the sherpa sidecar: lazy-spawn on first transcribe,
+ * a correlated request/reply protocol over the fork IPC channel, restart-once
+ * on a crash, and a clean shutdown. The `fork` itself is injectable (a
+ * {@link ForkLike}) so tests drive the whole protocol against a fake child with
+ * no real process.
+ */
+
+import { fork } from 'node:child_process';
+
+import type { HostReply, HostRequest, TranscribeResult } from './host-protocol.js';
+
+/** The minimal child-process surface the client drives — satisfied by a real
+ *  `ChildProcess` and by a test fake. */
+export interface ChildHandle {
+  send(message: unknown): boolean;
+  on(event: 'message', listener: (message: unknown) => void): this;
+  on(event: 'exit', listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  kill(signal?: NodeJS.Signals): boolean;
+}
+
+/** Fork the sidecar with the given env overrides. Injectable for tests. */
+export type ForkLike = (modulePath: string, env: NodeJS.ProcessEnv) => ChildHandle;
+
+/** Default fork: advanced serialization (Float32Array round-trip), an IPC
+ *  channel, and inherited std streams so sherpa's own diagnostics reach the
+ *  runner log. `env` already carries the platform loader-path var. */
+export const defaultFork: ForkLike = (modulePath, env) =>
+  fork(modulePath, [], {
+    serialization: 'advanced',
+    env,
+    execArgv: [],
+    stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+  }) as unknown as ChildHandle;
+
+export interface HostClientOptions {
+  /** Absolute path to the built sidecar (`dist/sidecar.js`). */
+  readonly hostPath: string;
+  /** Env the child is forked with (platform loader path merged over process.env). */
+  readonly env: NodeJS.ProcessEnv;
+  /** Injected fork (tests). Defaults to {@link defaultFork}. */
+  readonly forkImpl?: ForkLike;
+  /** Per-request deadline. Default 300s (a long clip on a big model on CPU). */
+  readonly requestTimeoutMs?: number;
+  /** Optional diagnostic sink. */
+  readonly log?: (msg: string) => void;
+}
+
+/** The slice of a host the transcriber depends on — lets tests swap a fake. */
+export interface HostClientLike {
+  transcribe(req: Omit<HostRequest, 'id' | 'type'>): Promise<TranscribeResult>;
+  shutdown(): void;
+}
+
+/** Raised when the sidecar dies with a request in flight; drives the one retry. */
+export class HostCrashError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'HostCrashError';
+  }
+}
+
+interface Pending {
+  readonly resolve: (r: TranscribeResult) => void;
+  readonly reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+const DEFAULT_TIMEOUT_MS = 300_000;
+
+export class HostClient implements HostClientLike {
+  private readonly hostPath: string;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly forkImpl: ForkLike;
+  private readonly timeoutMs: number;
+  private readonly log: (msg: string) => void;
+
+  private child: ChildHandle | null = null;
+  private readonly pending = new Map<number, Pending>();
+  private nextId = 1;
+  private disposed = false;
+
+  constructor(opts: HostClientOptions) {
+    this.hostPath = opts.hostPath;
+    this.env = opts.env;
+    this.forkImpl = opts.forkImpl ?? defaultFork;
+    this.timeoutMs = opts.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.log = opts.log ?? (() => {});
+  }
+
+  /** Transcribe, restarting the sidecar ONCE if it crashes mid-request. */
+  async transcribe(req: Omit<HostRequest, 'id' | 'type'>): Promise<TranscribeResult> {
+    try {
+      return await this.send(req);
+    } catch (err) {
+      if (err instanceof HostCrashError && !this.disposed) {
+        this.log(`stt-local: sherpa sidecar crashed (${err.message}) — restarting once`);
+        return await this.send(req); // a second crash propagates
+      }
+      throw err;
+    }
+  }
+
+  private send(req: Omit<HostRequest, 'id' | 'type'>): Promise<TranscribeResult> {
+    if (this.disposed) return Promise.reject(new Error('stt-local host is shut down'));
+    const child = this.ensureChild();
+    const id = this.nextId++;
+    const message: HostRequest = { ...req, id, type: 'transcribe' };
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        // A hung decode is unrecoverable for this child — reset it so the next
+        // call starts fresh.
+        this.killChild();
+        reject(new Error(`stt-local transcription timed out after ${this.timeoutMs} ms`));
+      }, this.timeoutMs);
+      timer.unref?.();
+      this.pending.set(id, { resolve, reject, timer });
+      try {
+        child.send(message);
+      } catch (err) {
+        this.settle(id, () => reject(err instanceof Error ? err : new Error(String(err))));
+      }
+    });
+  }
+
+  private ensureChild(): ChildHandle {
+    if (this.child) return this.child;
+    const child = this.forkImpl(this.hostPath, this.env);
+    this.child = child;
+    child.on('message', (msg: unknown) => this.onMessage(msg));
+    child.on('exit', (code, signal) => this.onExit(code, signal));
+    child.on('error', (err) => this.onError(err));
+    return child;
+  }
+
+  private onMessage(msg: unknown): void {
+    const reply = msg as HostReply;
+    if (!reply || typeof reply !== 'object' || typeof reply.id !== 'number') return;
+    const p = this.pending.get(reply.id);
+    if (!p) return;
+    this.settle(reply.id, () => {
+      if (reply.ok) {
+        p.resolve(reply.language !== undefined ? { text: reply.text, language: reply.language } : { text: reply.text });
+      } else {
+        p.reject(new Error(`stt-local sidecar ${reply.error.kind} error: ${reply.error.message}`));
+      }
+    });
+  }
+
+  private onExit(code: number | null, signal: NodeJS.Signals | null): void {
+    this.child = null;
+    if (this.pending.size === 0) return;
+    const why = `sidecar exited (code=${code ?? 'null'}, signal=${signal ?? 'null'})`;
+    this.rejectAll(new HostCrashError(why));
+  }
+
+  private onError(err: Error): void {
+    this.child = null;
+    this.rejectAll(new HostCrashError(`sidecar spawn/runtime error: ${err.message}`));
+  }
+
+  /** Resolve/reject one pending request, clearing its timer and map entry. */
+  private settle(id: number, run: () => void): void {
+    const p = this.pending.get(id);
+    if (!p) return;
+    if (p.timer) clearTimeout(p.timer);
+    this.pending.delete(id);
+    run();
+  }
+
+  private rejectAll(err: Error): void {
+    for (const [id, p] of this.pending) {
+      if (p.timer) clearTimeout(p.timer);
+      this.pending.delete(id);
+      p.reject(err);
+    }
+  }
+
+  private killChild(): void {
+    const child = this.child;
+    this.child = null;
+    if (child) {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+
+  /** Kill the sidecar and fail any in-flight requests. Idempotent. */
+  shutdown(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.rejectAll(new Error('stt-local host shut down'));
+    this.killChild();
+  }
+}

--- a/packages/plugin-stt-local/src/host-protocol.test.ts
+++ b/packages/plugin-stt-local/src/host-protocol.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createMessageHandler,
+  type HostRequest,
+  type SherpaModule,
+  type SherpaOfflineRecognizer,
+  type SherpaOfflineRecognizerResult,
+  type SherpaOfflineStream,
+} from './host-protocol.js';
+
+function req(over: Partial<HostRequest> = {}): HostRequest {
+  return {
+    id: 1,
+    type: 'transcribe',
+    modelKey: '/models/base/base-encoder.onnx',
+    encoder: '/models/base/base-encoder.onnx',
+    decoder: '/models/base/base-decoder.onnx',
+    tokens: '/models/base/base-tokens.txt',
+    numThreads: 2,
+    provider: 'cpu',
+    language: '',
+    task: 'transcribe',
+    samples: new Float32Array([0.1, -0.1, 0.2]),
+    sampleRate: 16_000,
+    ...over,
+  };
+}
+
+/** A fake sherpa module recording constructions + decode calls, with
+ *  configurable text/behaviour. */
+function fakeSherpa(
+  opts: {
+    text?: string;
+    lang?: string;
+    throwOnConstruct?: boolean;
+    throwOnDecode?: boolean;
+  } = {},
+): {
+  module: SherpaModule;
+  constructed: number;
+  decoded: number;
+  lastConfig: unknown;
+  lastSamples: Float32Array | null;
+} {
+  const state = {
+    constructed: 0,
+    decoded: 0,
+    lastConfig: undefined as unknown,
+    lastSamples: null as Float32Array | null,
+  };
+  class FakeStream implements SherpaOfflineStream {
+    accepted: Float32Array | null = null;
+    acceptWaveform(args: { sampleRate: number; samples: Float32Array }): void {
+      this.accepted = args.samples;
+      state.lastSamples = args.samples;
+    }
+  }
+  class FakeRecognizer implements SherpaOfflineRecognizer {
+    constructor(config: unknown) {
+      if (opts.throwOnConstruct) throw new Error('addon failed to load libonnxruntime.dylib');
+      state.constructed += 1;
+      state.lastConfig = config;
+    }
+    createStream(): SherpaOfflineStream {
+      return new FakeStream();
+    }
+    decode(): void {
+      state.decoded += 1;
+      if (opts.throwOnDecode) throw new Error('decode blew up');
+    }
+    getResult(): SherpaOfflineRecognizerResult {
+      return opts.lang !== undefined
+        ? { text: opts.text ?? 'hello world', lang: opts.lang }
+        : { text: opts.text ?? 'hello world' };
+    }
+  }
+  return {
+    module: { OfflineRecognizer: FakeRecognizer as unknown as SherpaModule['OfflineRecognizer'] },
+    get constructed() {
+      return state.constructed;
+    },
+    get decoded() {
+      return state.decoded;
+    },
+    get lastConfig() {
+      return state.lastConfig;
+    },
+    get lastSamples() {
+      return state.lastSamples;
+    },
+  };
+}
+
+describe('createMessageHandler', () => {
+  it('transcribes and returns the text', async () => {
+    const s = fakeSherpa({ text: 'the quick brown fox' });
+    const handle = createMessageHandler(() => s.module);
+    const reply = await handle(req({ id: 7 }));
+    expect(reply).toMatchObject({ id: 7, ok: true, text: 'the quick brown fox' });
+    expect(s.lastSamples).toEqual(new Float32Array([0.1, -0.1, 0.2]));
+  });
+
+  it('passes the whisper model config (encoder/decoder/tokens/language/task) through', async () => {
+    const s = fakeSherpa();
+    const handle = createMessageHandler(() => s.module);
+    await handle(req({ language: 'pl', task: 'transcribe' }));
+    expect(s.lastConfig).toMatchObject({
+      featConfig: { sampleRate: 16_000, featureDim: 80 },
+      modelConfig: {
+        whisper: {
+          encoder: '/models/base/base-encoder.onnx',
+          decoder: '/models/base/base-decoder.onnx',
+          language: 'pl',
+          task: 'transcribe',
+        },
+        tokens: '/models/base/base-tokens.txt',
+        numThreads: 2,
+        provider: 'cpu',
+      },
+    });
+  });
+
+  it('surfaces a detected language when the native result reports one', async () => {
+    const s = fakeSherpa({ text: 'cześć', lang: 'pl' });
+    const handle = createMessageHandler(() => s.module);
+    const reply = await handle(req());
+    expect(reply).toMatchObject({ ok: true, text: 'cześć', language: 'pl' });
+  });
+
+  it('caches one OfflineRecognizer per modelKey (loads the model once)', async () => {
+    const s = fakeSherpa();
+    let loads = 0;
+    const handle = createMessageHandler(() => {
+      loads += 1;
+      return s.module;
+    });
+    await handle(req({ id: 1 }));
+    await handle(req({ id: 2 }));
+    await handle(
+      req({ id: 3, modelKey: '/models/small/small-encoder.onnx', encoder: '/models/small/small-encoder.onnx' }),
+    );
+    expect(loads).toBe(1); // module loaded once
+    expect(s.constructed).toBe(2); // one recognizer per distinct modelKey
+    expect(s.decoded).toBe(3);
+  });
+
+  it('classifies a construct failure as an init error', async () => {
+    const s = fakeSherpa({ throwOnConstruct: true });
+    const handle = createMessageHandler(() => s.module);
+    const reply = await handle(req());
+    expect(reply.ok).toBe(false);
+    if (!reply.ok) expect(reply.error.kind).toBe('init');
+  });
+
+  it('classifies a load-time throw as an init error', async () => {
+    const handle = createMessageHandler(() => {
+      throw new Error('cannot find module sherpa-onnx-node');
+    });
+    const reply = await handle(req());
+    expect(reply.ok).toBe(false);
+    if (!reply.ok) expect(reply.error.kind).toBe('init');
+  });
+
+  it('classifies a decode failure as a runtime error', async () => {
+    const s = fakeSherpa({ throwOnDecode: true });
+    const handle = createMessageHandler(() => s.module);
+    const reply = await handle(req());
+    expect(reply.ok).toBe(false);
+    if (!reply.ok) expect(reply.error.kind).toBe('runtime');
+  });
+});

--- a/packages/plugin-stt-local/src/host-protocol.ts
+++ b/packages/plugin-stt-local/src/host-protocol.ts
@@ -1,0 +1,152 @@
+/**
+ * The tiny message protocol spoken between the parent (host-client) and the
+ * forked sherpa sidecar, plus the pure per-message handler the sidecar runs.
+ * Kept free of `node:child_process` so BOTH sides can import it (the parent for
+ * the types, the child for the handler) without dragging fork plumbing into
+ * either bundle.
+ *
+ * Wire shape (over the fork IPC channel, `serialization: 'advanced'` so the
+ * `Float32Array` of samples round-trips intact):
+ *   parent → child:  TranscribeRequest  (carries the decoded 16 kHz mono PCM)
+ *   child  → parent: HostReply          (the transcript text)
+ */
+
+/** One transcription request. Carries the full model config so the sidecar is
+ *  stateless-per-message except for a recognizer cache keyed by `modelKey`. The
+ *  audio is already decoded to Float32 mono @ 16 kHz by the parent — the sidecar
+ *  only owns the native recognition. */
+export interface TranscribeRequest {
+  readonly id: number;
+  readonly type: 'transcribe';
+  /** Cache key for the loaded recognizer (the absolute encoder path). */
+  readonly modelKey: string;
+  /** Absolute path to the Whisper encoder `.onnx`. */
+  readonly encoder: string;
+  /** Absolute path to the Whisper decoder `.onnx`. */
+  readonly decoder: string;
+  /** Absolute path to `<id>-tokens.txt`. */
+  readonly tokens: string;
+  /** Inference thread count. */
+  readonly numThreads: number;
+  /** Compute provider (`cpu`). */
+  readonly provider: string;
+  /** Best-effort Whisper language tag; empty string ⇒ auto-detect. */
+  readonly language: string;
+  /** Whisper task: `transcribe` (same-language) or `translate` (→ English). */
+  readonly task: string;
+  /** Mono PCM in [-1, 1] at `sampleRate`; structured-cloned intact over IPC. */
+  readonly samples: Float32Array;
+  /** Sample rate of `samples` (16000 — the parent resamples before sending). */
+  readonly sampleRate: number;
+}
+
+export type HostRequest = TranscribeRequest;
+
+export type HostErrorKind =
+  /** Recognizer failed to load (bad/absent files, unsupported arch, dlopen). */
+  | 'init'
+  /** Decoding itself threw. */
+  | 'runtime';
+
+export interface TranscribeResult {
+  readonly text: string;
+  /** Whisper's detected language, when the native result reports one. */
+  readonly language?: string;
+}
+
+export type HostReply =
+  | ({ readonly id: number; readonly ok: true } & TranscribeResult)
+  | {
+      readonly id: number;
+      readonly ok: false;
+      readonly error: { readonly message: string; readonly kind: HostErrorKind };
+    };
+
+/** The subset of the sherpa-onnx-node surface the sidecar uses. Declared here
+ *  (rather than leaning on the addon's ambient types) so the handler is
+ *  unit-testable with a fake module and typechecks without the native addon. */
+export interface SherpaOfflineStream {
+  acceptWaveform(args: { sampleRate: number; samples: Float32Array }): void;
+}
+
+export interface SherpaOfflineRecognizerResult {
+  readonly text: string;
+  /** Whisper detected-language field on some builds; read defensively. */
+  readonly lang?: string;
+}
+
+export interface SherpaOfflineRecognizer {
+  createStream(): SherpaOfflineStream;
+  decode(stream: SherpaOfflineStream): void;
+  getResult(stream: SherpaOfflineStream): SherpaOfflineRecognizerResult;
+}
+
+export interface SherpaModule {
+  OfflineRecognizer: new (config: unknown) => SherpaOfflineRecognizer;
+}
+
+/** Lazily load the native sherpa module (so a dlopen failure surfaces as a
+ *  classified reply, not a boot crash). */
+export type LoadSherpa = () => SherpaModule;
+
+export type HostMessageHandler = (req: HostRequest) => Promise<HostReply>;
+
+/**
+ * Build the sidecar's message handler. Loads the sherpa module on first use and
+ * caches one `OfflineRecognizer` per `modelKey` so repeated calls on the same
+ * model reuse the loaded weights. Every failure becomes a typed `ok:false`
+ * reply — nothing throws out of `handle`.
+ */
+export function createMessageHandler(loadSherpa: LoadSherpa): HostMessageHandler {
+  const cache = new Map<string, SherpaOfflineRecognizer>();
+  let mod: SherpaModule | null = null;
+
+  return async function handle(req: HostRequest): Promise<HostReply> {
+    let recognizer = cache.get(req.modelKey);
+    if (!recognizer) {
+      try {
+        mod ??= loadSherpa();
+        recognizer = new mod.OfflineRecognizer({
+          featConfig: { sampleRate: 16_000, featureDim: 80 },
+          modelConfig: {
+            whisper: {
+              encoder: req.encoder,
+              decoder: req.decoder,
+              // `language`/`task` are present in the OfflineWhisperModelConfig
+              // types but exercised by no upstream example — pass them through
+              // best-effort (empty language ⇒ Whisper auto-detects anyway).
+              language: req.language,
+              task: req.task,
+            },
+            tokens: req.tokens,
+            numThreads: req.numThreads,
+            provider: req.provider,
+            debug: false,
+          },
+        });
+        cache.set(req.modelKey, recognizer);
+      } catch (err) {
+        return { id: req.id, ok: false, error: { message: errMsg(err), kind: 'init' } };
+      }
+    }
+
+    try {
+      const stream = recognizer.createStream();
+      stream.acceptWaveform({ sampleRate: req.sampleRate, samples: req.samples });
+      recognizer.decode(stream);
+      const result = recognizer.getResult(stream);
+      const text = typeof result?.text === 'string' ? result.text : '';
+      const reply: { id: number; ok: true } & TranscribeResult =
+        typeof result?.lang === 'string' && result.lang
+          ? { id: req.id, ok: true, text, language: result.lang }
+          : { id: req.id, ok: true, text };
+      return reply;
+    } catch (err) {
+      return { id: req.id, ok: false, error: { message: errMsg(err), kind: 'runtime' } };
+    }
+  };
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/plugin-stt-local/src/index.ts
+++ b/packages/plugin-stt-local/src/index.ts
@@ -1,0 +1,108 @@
+import { definePlugin, defineTranscriber, type Plugin } from '@moxxy/sdk';
+
+import {
+  createLocalWhisperTranscriber,
+  LOCAL_WHISPER_TRANSCRIBER_NAME,
+  shutdownLocalStt,
+  type LocalWhisperOptions,
+} from './local-stt.js';
+
+export {
+  LocalWhisperTranscriber,
+  createLocalWhisperTranscriber,
+  shutdownLocalStt,
+  LOCAL_WHISPER_TRANSCRIBER_NAME,
+  type LocalWhisperOptions,
+  type WhisperModelPaths,
+} from './local-stt.js';
+export {
+  MODEL_CATALOG,
+  DEFAULT_MODEL_ID,
+  modelIds,
+  findModel,
+  requireModel,
+  type WhisperModelEntry,
+  type WhisperModelId,
+} from './models.js';
+export {
+  pcm16ToFloat32,
+  downmixToMono,
+  resampleLinear,
+  parseWav,
+  isRiffWave,
+  TARGET_SAMPLE_RATE,
+  type ParsedWav,
+} from './audio.js';
+export { decodeToMono16k, type DecodeOptions } from './decode.js';
+export {
+  decodeViaFfmpeg,
+  missingFfmpegError,
+  __resetFfmpegProbeForTest,
+} from './ffmpeg.js';
+export { HostClient, type HostClientLike, type ForkLike, type ChildHandle } from './host-client.js';
+export {
+  sherpaPlatformPackage,
+  resolveSherpaLibDir,
+  sherpaEnv,
+  libraryPathVar,
+} from './platform.js';
+
+export interface BuildLocalSttPluginOptions {
+  /** Build-time defaults / test seams for the transcriber (injected
+   *  `ensureModelImpl`, `hostFactory`, `fetchImpl`, `modelsDir`, `log`, …). */
+  readonly defaults?: LocalWhisperOptions;
+}
+
+/**
+ * Build the @moxxy/plugin-stt-local plugin. Registers exactly one transcriber,
+ * `local-whisper`, backed by sherpa-onnx Whisper models running in a forked
+ * sidecar. Side-effect free at load: no model is downloaded and no process is
+ * spawned until the first `transcribe`. Per-activation config
+ * (`session.transcribers.setActive('local-whisper', { model, language,
+ * numThreads })`) overrides the build-time defaults.
+ *
+ * Like the OpenAI STT sibling, the plugin does NOT set itself active —
+ * registering it is side-effect free (no auto-adopt in TranscriberRegistry).
+ * The host/user activates it explicitly, so a local-only setup never
+ * surprises anyone with a network call (there isn't one here) and a mixed
+ * setup keeps whatever STT backend was chosen.
+ */
+export function buildLocalSttPlugin(opts: BuildLocalSttPluginOptions = {}): Plugin {
+  const defaults = opts.defaults ?? {};
+  return definePlugin({
+    name: '@moxxy/plugin-stt-local',
+    version: '0.0.0',
+    transcribers: [
+      defineTranscriber({
+        name: LOCAL_WHISPER_TRANSCRIBER_NAME,
+        displayName: 'Local Whisper (offline, multilingual)',
+        createClient: (config: Record<string, unknown>) =>
+          createLocalWhisperTranscriber({ ...defaults, ...configToOptions(config) }),
+      }),
+    ],
+    // Kill every spawned sidecar when the session/runner shuts down.
+    hooks: { onShutdown: () => shutdownLocalStt() },
+  });
+}
+
+/** Narrow the untrusted per-activation config into typed options — only the
+ *  known string `model` / `language` / `provider` and a positive-integer
+ *  `numThreads` are honored so a malformed config can't break `createClient` or
+ *  route to a bad model (unknown ids are caught by `requireModel`). */
+function configToOptions(config: Record<string, unknown>): Partial<LocalWhisperOptions> {
+  const out: { -readonly [K in keyof LocalWhisperOptions]?: LocalWhisperOptions[K] } = {};
+  if (typeof config.model === 'string' && config.model) out.model = config.model;
+  if (typeof config.language === 'string') out.language = config.language;
+  if (typeof config.provider === 'string' && config.provider) out.provider = config.provider;
+  if (
+    typeof config.numThreads === 'number' &&
+    Number.isInteger(config.numThreads) &&
+    config.numThreads > 0
+  ) {
+    out.numThreads = config.numThreads;
+  }
+  return out;
+}
+
+// Discovery entry: `createPluginLoader` requires a default Plugin export.
+export default buildLocalSttPlugin();

--- a/packages/plugin-stt-local/src/live.test.ts
+++ b/packages/plugin-stt-local/src/live.test.ts
@@ -1,0 +1,80 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createLocalWhisperTranscriber } from './local-stt.js';
+
+// vitest runs the TypeScript SOURCE, so `import.meta.url` here is src/. The
+// sidecar must be the COMPILED entry, so point at dist/sidecar.js (build first:
+// `pnpm -F @moxxy/plugin-stt-local build`).
+const SIDECAR_PATH = fileURLToPath(new URL('../dist/sidecar.js', import.meta.url));
+
+/**
+ * Opt-in end-to-end test that REALLY downloads the tiny Whisper model and runs
+ * the native sherpa sidecar — off by default (it fetches ~111 MB and needs the
+ * platform binary). Run manually with:
+ *
+ *   MOXXY_STT_LOCAL_LIVE=1 pnpm -F @moxxy/plugin-stt-local test
+ */
+const LIVE = !!process.env.MOXXY_STT_LOCAL_LIVE;
+
+/** Generate a 1-second 16 kHz mono PCM16 WAV of a 440 Hz tone as a fixture. The
+ *  transcript of a pure tone is meaningless — the assertion is that the whole
+ *  download → decode → recognize pipeline runs and yields a string. */
+function toneWav(): Uint8Array {
+  const rate = 16_000;
+  const n = rate; // 1 s
+  const dataSize = n * 2;
+  const buf = new Uint8Array(44 + dataSize);
+  const view = new DataView(buf.buffer);
+  const ascii = (o: number, s: string): void => {
+    for (let i = 0; i < s.length; i += 1) buf[o + i] = s.charCodeAt(i);
+  };
+  ascii(0, 'RIFF');
+  view.setUint32(4, 36 + dataSize, true);
+  ascii(8, 'WAVE');
+  ascii(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, rate, true);
+  view.setUint32(28, rate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  ascii(36, 'data');
+  view.setUint32(40, dataSize, true);
+  for (let i = 0; i < n; i += 1) {
+    const s = Math.sin((2 * Math.PI * 440 * i) / rate) * 0.3;
+    view.setInt16(44 + i * 2, Math.round(s * 32767), true);
+  }
+  return buf;
+}
+
+let modelsDir: string;
+beforeAll(async () => {
+  if (!LIVE) return;
+  modelsDir = await mkdtemp(path.join(tmpdir(), 'stt-local-live-'));
+});
+afterAll(async () => {
+  if (modelsDir) await rm(modelsDir, { recursive: true, force: true });
+});
+
+describe.skipIf(!LIVE)('local STT (live, real download + native sidecar)', () => {
+  it('downloads the tiny model and transcribes a generated WAV fixture', async () => {
+    const stt = createLocalWhisperTranscriber({
+      model: 'tiny',
+      modelsDir,
+      sidecarPath: SIDECAR_PATH,
+    });
+    try {
+      const out = await stt.transcribe(toneWav(), { mimeType: 'audio/wav' });
+      expect(typeof out.text).toBe('string');
+      expect(out.durationSec).toBeCloseTo(1, 1);
+    } finally {
+      stt.shutdown();
+    }
+  }, 600_000);
+});

--- a/packages/plugin-stt-local/src/local-stt.test.ts
+++ b/packages/plugin-stt-local/src/local-stt.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+
+import { MOXXY_PCM16_24KHZ_MIME } from '@moxxy/sdk';
+import { ensureModel } from '@moxxy/model-fetch';
+
+import {
+  createLocalWhisperTranscriber,
+  type LocalWhisperOptions,
+} from './local-stt.js';
+import { buildLocalSttPlugin, LOCAL_WHISPER_TRANSCRIBER_NAME } from './index.js';
+import type { HostClientLike } from './host-client.js';
+import type { HostRequest, TranscribeResult } from './host-protocol.js';
+
+/** Raw PCM16 mono little-endian bytes (the moxxy mic contract) for N samples. */
+function rawPcm16(n: number, value = 0.3): Uint8Array {
+  const bytes = new Uint8Array(n * 2);
+  const view = new DataView(bytes.buffer);
+  for (let i = 0; i < n; i += 1) view.setInt16(i * 2, Math.round(value * 32767), true);
+  return bytes;
+}
+
+const AUDIO = rawPcm16(240); // 240 @24k → 160 @16k after resample
+
+/** A fake host recording each transcribe request; returns a canned result. */
+function fakeHost(result: TranscribeResult = { text: 'hello world' }): {
+  host: HostClientLike;
+  reqs: Array<Omit<HostRequest, 'id' | 'type'>>;
+  shutdowns: number;
+} {
+  const state = { reqs: [] as Array<Omit<HostRequest, 'id' | 'type'>>, shutdowns: 0 };
+  const host: HostClientLike = {
+    async transcribe(req) {
+      state.reqs.push(req);
+      return result;
+    },
+    shutdown() {
+      state.shutdowns += 1;
+    },
+  };
+  return {
+    host,
+    get reqs() {
+      return state.reqs;
+    },
+    get shutdowns() {
+      return state.shutdowns;
+    },
+  };
+}
+
+/** A fake ensureModel recording the urls it was asked to fetch. */
+function fakeEnsure(): { impl: typeof ensureModel; urls: string[] } {
+  const urls: string[] = [];
+  const impl = (async (opts: Parameters<typeof ensureModel>[0]) => {
+    urls.push(opts.url);
+    return { dir: opts.dir, skipped: false };
+  }) as unknown as typeof ensureModel;
+  return { impl, urls };
+}
+
+function makeTranscriber(
+  over: Partial<LocalWhisperOptions> = {},
+  result?: TranscribeResult,
+): {
+  transcriber: ReturnType<typeof createLocalWhisperTranscriber>;
+  host: ReturnType<typeof fakeHost>;
+  ensure: ReturnType<typeof fakeEnsure>;
+} {
+  const host = fakeHost(result);
+  const ensure = fakeEnsure();
+  const transcriber = createLocalWhisperTranscriber({
+    modelsDir: '/models/stt',
+    ensureModelImpl: ensure.impl,
+    hostFactory: () => host.host,
+    log: () => {},
+    ...over,
+  });
+  return { transcriber, host, ensure };
+}
+
+describe('LocalWhisperTranscriber.transcribe', () => {
+  it('defaults to the base model, decodes raw PCM, and returns the transcript', async () => {
+    const { transcriber, host, ensure } = makeTranscriber();
+    const out = await transcriber.transcribe(AUDIO, { mimeType: MOXXY_PCM16_24KHZ_MIME });
+    expect(out.text).toBe('hello world');
+    expect(ensure.urls).toEqual([
+      'https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-whisper-base.tar.bz2',
+    ]);
+    const req = host.reqs[0]!;
+    expect(req.encoder).toContain('sherpa-onnx-whisper-base/base-encoder.onnx');
+    expect(req.decoder).toContain('base-decoder.onnx');
+    expect(req.tokens).toContain('base-tokens.txt');
+    expect(req.sampleRate).toBe(16_000);
+    expect(req.samples.length).toBe(160); // resampled 24k → 16k
+    expect(req.task).toBe('transcribe');
+    expect(out.durationSec).toBeCloseTo(160 / 16_000, 6);
+  });
+
+  it('selects a configured model (small) and its files', async () => {
+    const { transcriber, host, ensure } = makeTranscriber({ model: 'small' });
+    await transcriber.transcribe(AUDIO, { mimeType: MOXXY_PCM16_24KHZ_MIME });
+    expect(ensure.urls[0]).toContain('sherpa-onnx-whisper-small.tar.bz2');
+    expect(host.reqs[0]!.encoder).toContain('small-encoder.onnx');
+  });
+
+  it('passes a per-call language hint through to the recognizer', async () => {
+    const { transcriber, host } = makeTranscriber();
+    await transcriber.transcribe(AUDIO, { mimeType: MOXXY_PCM16_24KHZ_MIME, language: 'pl' });
+    expect(host.reqs[0]!.language).toBe('pl');
+  });
+
+  it('falls back to the configured default language when no per-call hint is given', async () => {
+    const { transcriber, host } = makeTranscriber({ language: 'en' });
+    await transcriber.transcribe(AUDIO, { mimeType: MOXXY_PCM16_24KHZ_MIME });
+    expect(host.reqs[0]!.language).toBe('en');
+  });
+
+  it('sends an empty language (auto-detect) when neither is set', async () => {
+    const { transcriber, host } = makeTranscriber();
+    await transcriber.transcribe(AUDIO, { mimeType: MOXXY_PCM16_24KHZ_MIME });
+    expect(host.reqs[0]!.language).toBe('');
+  });
+
+  it('prefers the language the recognizer detected in the result', async () => {
+    const { transcriber } = makeTranscriber({ language: 'en' }, { text: 'cześć', language: 'pl' });
+    const out = await transcriber.transcribe(AUDIO, {
+      mimeType: MOXXY_PCM16_24KHZ_MIME,
+      language: 'en',
+    });
+    expect(out.language).toBe('pl');
+  });
+
+  it('reports the hint language when the recognizer returns none', async () => {
+    const { transcriber } = makeTranscriber({}, { text: 'x' });
+    const out = await transcriber.transcribe(AUDIO, {
+      mimeType: MOXXY_PCM16_24KHZ_MIME,
+      language: 'de',
+    });
+    expect(out.language).toBe('de');
+  });
+
+  it('downloads the model only once across calls', async () => {
+    const { transcriber, ensure } = makeTranscriber();
+    await transcriber.transcribe(AUDIO, { mimeType: MOXXY_PCM16_24KHZ_MIME });
+    await transcriber.transcribe(AUDIO, { mimeType: MOXXY_PCM16_24KHZ_MIME });
+    await transcriber.transcribe(AUDIO, { mimeType: MOXXY_PCM16_24KHZ_MIME });
+    expect(ensure.urls.length).toBe(1);
+  });
+
+  it('returns empty text for empty/silent audio without touching the model', async () => {
+    const { transcriber, host, ensure } = makeTranscriber();
+    const out = await transcriber.transcribe(new Uint8Array(0), { mimeType: MOXXY_PCM16_24KHZ_MIME });
+    expect(out.text).toBe('');
+    expect(ensure.urls.length).toBe(0);
+    expect(host.reqs.length).toBe(0);
+  });
+
+  it('respects a pre-aborted signal', async () => {
+    const { transcriber } = makeTranscriber();
+    const ac = new AbortController();
+    ac.abort(new Error('stop'));
+    await expect(
+      transcriber.transcribe(AUDIO, { mimeType: MOXXY_PCM16_24KHZ_MIME, signal: ac.signal }),
+    ).rejects.toThrow(/stop/);
+  });
+
+  it('trims whitespace from the transcript', async () => {
+    const { transcriber } = makeTranscriber({}, { text: '  padded  ' });
+    const out = await transcriber.transcribe(AUDIO, { mimeType: MOXXY_PCM16_24KHZ_MIME });
+    expect(out.text).toBe('padded');
+  });
+
+  it('shutdown tears down the host', async () => {
+    const { transcriber, host } = makeTranscriber();
+    await transcriber.transcribe(AUDIO, { mimeType: MOXXY_PCM16_24KHZ_MIME });
+    transcriber.shutdown();
+    expect(host.shutdowns).toBe(1);
+  });
+});
+
+describe('constructor validation', () => {
+  it('throws CONFIG_INVALID for an unknown configured model', () => {
+    expect(() => createLocalWhisperTranscriber({ model: 'medium' })).toThrow(
+      /Unknown local Whisper model/,
+    );
+  });
+});
+
+describe('buildLocalSttPlugin', () => {
+  it('registers exactly one transcriber named local-whisper', () => {
+    const plugin = buildLocalSttPlugin();
+    expect(plugin.transcribers).toHaveLength(1);
+    const def = plugin.transcribers![0]!;
+    expect(def.name).toBe(LOCAL_WHISPER_TRANSCRIBER_NAME);
+    expect(def.displayName).toContain('Local Whisper');
+  });
+
+  it('createClient() flows per-activation model config through to routing', async () => {
+    const host = fakeHost();
+    const ensure = fakeEnsure();
+    const plugin = buildLocalSttPlugin({
+      defaults: {
+        modelsDir: '/models/stt',
+        ensureModelImpl: ensure.impl,
+        hostFactory: () => host.host,
+        log: () => {},
+      },
+    });
+    const inst = plugin.transcribers![0]!.createClient({ model: 'small', language: 'pl' });
+    await inst.transcribe(AUDIO, { mimeType: MOXXY_PCM16_24KHZ_MIME });
+    expect(ensure.urls[0]).toContain('sherpa-onnx-whisper-small.tar.bz2');
+    expect(host.reqs[0]!.language).toBe('pl');
+  });
+
+  it('createClient() rejects an unknown model in config at construction', () => {
+    const plugin = buildLocalSttPlugin();
+    expect(() => plugin.transcribers![0]!.createClient({ model: 'bad-id' })).toThrow();
+  });
+
+  it('exposes an onShutdown hook', () => {
+    const plugin = buildLocalSttPlugin();
+    expect(typeof plugin.hooks?.onShutdown).toBe('function');
+  });
+});

--- a/packages/plugin-stt-local/src/local-stt.ts
+++ b/packages/plugin-stt-local/src/local-stt.ts
@@ -1,0 +1,273 @@
+/**
+ * The `local-whisper` Transcriber: fully local, on-device speech-to-text.
+ *
+ * On the first transcription for a model it downloads + verifies that model's
+ * Whisper export (once, via @moxxy/model-fetch), then decodes the inbound audio
+ * to Float32 mono @ 16 kHz IN-PROCESS (raw PCM / WAV) or via ffmpeg (compressed
+ * containers) and hands the samples to the sherpa sidecar ({@link HostClient}).
+ * No key, no network at transcription time.
+ *
+ * Every collaborator is injectable (`ensureModelImpl`, `hostFactory`, `log`,
+ * `modelsDir`, `fetchImpl`, `spawnImpl`) so the whole flow is unit-testable
+ * without the native addon, a real download, or ffmpeg.
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { spawn } from 'node:child_process';
+
+import {
+  MoxxyError,
+  type TranscribeOptions,
+  type Transcriber,
+  type TranscriptionResult,
+} from '@moxxy/sdk';
+import { moxxyPath } from '@moxxy/sdk/server';
+import {
+  ensureModel,
+  type EnsureModelProgress,
+  type EnsureModelResult,
+  type FetchLike,
+} from '@moxxy/model-fetch';
+
+import { TARGET_SAMPLE_RATE } from './audio.js';
+import { decodeToMono16k } from './decode.js';
+import { HostClient, type HostClientLike } from './host-client.js';
+import { DEFAULT_MODEL_ID, requireModel, type WhisperModelEntry } from './models.js';
+import { resolveSherpaLibDir, sherpaEnv, sherpaPlatformPackage } from './platform.js';
+
+/** The single registered transcriber name. */
+export const LOCAL_WHISPER_TRANSCRIBER_NAME = 'local-whisper';
+
+const DEFAULT_NUM_THREADS = 2;
+
+/** Resolved on-disk paths sherpa needs for one model. */
+export interface WhisperModelPaths {
+  readonly encoder: string;
+  readonly decoder: string;
+  readonly tokens: string;
+}
+
+export interface LocalWhisperOptions {
+  /** Model id: `tiny` | `base` | `small`. Default `base` (`small` for Polish). */
+  readonly model?: string;
+  /** Default Whisper language tag (BCP-47-ish, e.g. `en`, `pl`). Per-call
+   *  `TranscribeOptions.language` overrides it; omit to let Whisper auto-detect. */
+  readonly language?: string;
+  /** Inference threads. Default 2. */
+  readonly numThreads?: number;
+  /** Root for downloaded models. Default `~/.moxxy/models/stt` (MOXXY_HOME-aware). */
+  readonly modelsDir?: string;
+  /** sherpa compute provider. Default `cpu`. */
+  readonly provider?: string;
+  /** Absolute path to the built sidecar entry. Default: `sidecar.js` beside
+   *  this module (i.e. `dist/sidecar.js` in a published build). */
+  readonly sidecarPath?: string;
+  /** Injected model-ensure (tests). Defaults to @moxxy/model-fetch `ensureModel`. */
+  readonly ensureModelImpl?: typeof ensureModel;
+  /** Injected `fetch`, threaded into `ensureModel` (tests). */
+  readonly fetchImpl?: FetchLike;
+  /** Injected sidecar host factory (tests). Defaults to a real {@link HostClient}. */
+  readonly hostFactory?: () => HostClientLike;
+  /** Injected `spawn` for the ffmpeg decode path (tests). */
+  readonly spawnImpl?: typeof spawn;
+  /** Diagnostic log sink (download progress etc.). Defaults to stderr. */
+  readonly log?: (msg: string) => void;
+}
+
+/** Process-wide set of live transcribers so the plugin's `onShutdown` hook can
+ *  kill every sidecar it spawned. */
+const ACTIVE_STT = new Set<LocalWhisperTranscriber>();
+
+/** Shut down every live local transcriber (kills their sidecars). */
+export function shutdownLocalStt(): void {
+  for (const t of ACTIVE_STT) t.shutdown();
+  ACTIVE_STT.clear();
+}
+
+export class LocalWhisperTranscriber implements Transcriber {
+  readonly name = LOCAL_WHISPER_TRANSCRIBER_NAME;
+
+  private readonly model: WhisperModelEntry;
+  private readonly defaultLanguage: string;
+  private readonly numThreads: number;
+  private readonly modelsDir: string;
+  private readonly provider: string;
+  private readonly sidecarPath: string | undefined;
+  private readonly ensureModelImpl: typeof ensureModel;
+  private readonly fetchImpl: FetchLike | undefined;
+  private readonly hostFactory: () => HostClientLike;
+  private readonly spawnImpl: typeof spawn | undefined;
+  private readonly log: (msg: string) => void;
+
+  private host: HostClientLike | null = null;
+  /** In-flight model download promise — de-dupes concurrent first-use. */
+  private ensuring: Promise<EnsureModelResult> | null = null;
+
+  constructor(opts: LocalWhisperOptions = {}) {
+    // Validate the configured model up front so a bad config fails clearly at
+    // construction rather than on the first (possibly channel-triggered) call.
+    this.model = requireModel(opts.model ?? DEFAULT_MODEL_ID, 'model');
+    this.defaultLanguage = typeof opts.language === 'string' ? opts.language.trim() : '';
+    this.numThreads =
+      opts.numThreads && Number.isInteger(opts.numThreads) && opts.numThreads > 0
+        ? opts.numThreads
+        : DEFAULT_NUM_THREADS;
+    this.modelsDir = opts.modelsDir ?? moxxyPath('models', 'stt');
+    this.provider = opts.provider ?? 'cpu';
+    this.sidecarPath = opts.sidecarPath;
+    this.ensureModelImpl = opts.ensureModelImpl ?? ensureModel;
+    this.fetchImpl = opts.fetchImpl;
+    this.hostFactory = opts.hostFactory ?? (() => this.defaultHost());
+    this.spawnImpl = opts.spawnImpl;
+    this.log = opts.log ?? ((msg) => process.stderr.write(`${msg}\n`));
+    ACTIVE_STT.add(this);
+  }
+
+  async transcribe(
+    audio: Uint8Array | ArrayBuffer,
+    opts: TranscribeOptions = {},
+  ): Promise<TranscriptionResult> {
+    opts.signal?.throwIfAborted();
+
+    // Decode to the canonical Float32 mono @ 16 kHz sherpa wants. This is where
+    // raw PCM / WAV are handled in-process and compressed audio goes to ffmpeg.
+    const samples = await decodeToMono16k(audio, opts.mimeType, {
+      ...(this.spawnImpl ? { spawnImpl: this.spawnImpl } : {}),
+    });
+    opts.signal?.throwIfAborted();
+
+    if (samples.length === 0) {
+      return { text: '' };
+    }
+
+    const paths = await this.ensureModelFiles(opts.signal);
+    opts.signal?.throwIfAborted();
+
+    const language = ((opts.language ?? this.defaultLanguage) || '').trim();
+    const host = this.getHost();
+    const result = await host.transcribe({
+      modelKey: paths.encoder,
+      encoder: paths.encoder,
+      decoder: paths.decoder,
+      tokens: paths.tokens,
+      numThreads: this.numThreads,
+      provider: this.provider,
+      language,
+      task: 'transcribe',
+      samples,
+      sampleRate: TARGET_SAMPLE_RATE,
+    });
+
+    const durationSec = samples.length / TARGET_SAMPLE_RATE;
+    // Prefer Whisper's detected language; else the caller/default hint (when
+    // set) so downstream still gets a BCP-47 tag.
+    const reported = result.language ?? (language || undefined);
+    const out: {
+      text: string;
+      language?: string;
+      durationSec?: number;
+    } = { text: result.text.trim(), durationSec };
+    if (reported) out.language = reported;
+    return out;
+  }
+
+  /** Kill this transcriber's sidecar (if any) and drop registration. */
+  shutdown(): void {
+    this.host?.shutdown();
+    this.host = null;
+    ACTIVE_STT.delete(this);
+  }
+
+  private getHost(): HostClientLike {
+    this.host ??= this.hostFactory();
+    return this.host;
+  }
+
+  /** Resolve on-disk paths for the model, downloading + extracting it once. */
+  private async ensureModelFiles(signal?: AbortSignal): Promise<WhisperModelPaths> {
+    const dir = path.join(this.modelsDir, this.model.id);
+    let inflight = this.ensuring;
+    if (!inflight) {
+      inflight = this.ensureModelImpl({
+        url: this.model.url,
+        sha256: this.model.sha256,
+        dir,
+        ...(this.fetchImpl ? { fetchImpl: this.fetchImpl } : {}),
+        ...(signal ? { signal } : {}),
+        onProgress: this.makeProgressLogger(),
+      });
+      this.ensuring = inflight;
+      // On failure, forget the promise so a later call retries the download.
+      inflight.catch(() => {
+        if (this.ensuring === inflight) this.ensuring = null;
+      });
+    }
+    await inflight;
+    const root = path.join(dir, this.model.archiveRootDir);
+    return {
+      encoder: path.join(root, this.model.encoderFile),
+      decoder: path.join(root, this.model.decoderFile),
+      tokens: path.join(root, this.model.tokensFile),
+    };
+  }
+
+  /** A progress callback that logs a single start line then ~every-10% ticks,
+   *  and an extraction line — but stays silent when the model is already
+   *  present (ensureModel emits only `done`). */
+  private makeProgressLogger(): (p: EnsureModelProgress) => void {
+    let started = false;
+    let extracting = false;
+    let lastPct = -1;
+    return (p) => {
+      if (p.phase === 'downloading') {
+        if (!started) {
+          started = true;
+          this.log(
+            `stt-local: first use — downloading Whisper ${this.model.id} (~${this.model.approxMb} MB) to ${this.modelsDir}, one-time`,
+          );
+        }
+        if (p.totalBytes > 0) {
+          const pct = Math.floor((p.receivedBytes / p.totalBytes) * 100);
+          if (pct >= lastPct + 10) {
+            lastPct = pct - (pct % 10);
+            this.log(`stt-local: downloading ${this.model.id} … ${lastPct}%`);
+          }
+        }
+      } else if (p.phase === 'extracting' && !extracting) {
+        extracting = true;
+        this.log(`stt-local: extracting ${this.model.id} …`);
+      } else if (p.phase === 'done' && started) {
+        this.log(`stt-local: ${this.model.id} ready.`);
+      }
+    };
+  }
+
+  /** Build a real sidecar-backed host, resolving the platform loader path.
+   *  Fails clearly when no sherpa binary exists for this platform/arch. */
+  private defaultHost(): HostClientLike {
+    const libDir = resolveSherpaLibDir();
+    if (!libDir) {
+      const pkg = sherpaPlatformPackage();
+      throw new MoxxyError({
+        code: 'PLUGIN_LOAD_FAILED',
+        message: pkg
+          ? `Local Whisper could not load the sherpa-onnx binary (${pkg}). Reinstall @moxxy/plugin-stt-local so its platform dependency is fetched.`
+          : `Local Whisper has no sherpa-onnx binary for ${process.platform}-${process.arch}.`,
+        hint: 'Use the OpenAI Whisper backend instead, or run on a supported platform (macOS/Linux/Windows x64, macOS/Linux arm64).',
+        context: { platform: process.platform, arch: process.arch },
+      });
+    }
+    const hostPath =
+      this.sidecarPath ?? path.join(path.dirname(fileURLToPath(import.meta.url)), 'sidecar.js');
+    return new HostClient({
+      hostPath,
+      env: { ...process.env, ...sherpaEnv(libDir) },
+      log: this.log,
+    });
+  }
+}
+
+export function createLocalWhisperTranscriber(opts: LocalWhisperOptions = {}): LocalWhisperTranscriber {
+  return new LocalWhisperTranscriber(opts);
+}

--- a/packages/plugin-stt-local/src/models.test.ts
+++ b/packages/plugin-stt-local/src/models.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_MODEL_ID,
+  MODEL_CATALOG,
+  findModel,
+  modelIds,
+  requireModel,
+} from './models.js';
+
+describe('MODEL_CATALOG', () => {
+  it('pins tiny/base/small multilingual models with their release URLs + hashes', () => {
+    expect(modelIds()).toEqual(['tiny', 'base', 'small']);
+    for (const m of MODEL_CATALOG) {
+      expect(m.url).toBe(
+        `https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-whisper-${m.id}.tar.bz2`,
+      );
+      expect(m.archiveRootDir).toBe(`sherpa-onnx-whisper-${m.id}`);
+      expect(m.encoderFile).toBe(`${m.id}-encoder.onnx`);
+      expect(m.decoderFile).toBe(`${m.id}-decoder.onnx`);
+      expect(m.tokensFile).toBe(`${m.id}-tokens.txt`);
+      // 64-hex sha256, lower-case.
+      expect(m.sha256).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it('records the scout-verified checksums verbatim', () => {
+    expect(findModel('tiny')!.sha256).toBe(
+      'c46116994e539aa165266d96b325252728429c12535eb9d8b6a2b10f129e66b1',
+    );
+    expect(findModel('base')!.sha256).toBe(
+      '911b2083efd7c0dca2ac3b358b75222660dc09fb716d64fbfc417ba6c99ff3de',
+    );
+    expect(findModel('small')!.sha256).toBe(
+      '486a46afbb7ba798507190ffe02fea2dd726049af212e774537efac6afb210a6',
+    );
+  });
+
+  it('defaults to base', () => {
+    expect(DEFAULT_MODEL_ID).toBe('base');
+    expect(findModel(DEFAULT_MODEL_ID)).toBeDefined();
+  });
+});
+
+describe('requireModel', () => {
+  it('returns the catalog entry for a known id', () => {
+    expect(requireModel('small', 'model').id).toBe('small');
+  });
+
+  it('throws CONFIG_INVALID with the valid ids for an unknown model', () => {
+    expect(() => requireModel('medium', 'model')).toThrow(/Unknown local Whisper model/);
+    try {
+      requireModel('medium', 'model');
+    } catch (err) {
+      expect((err as { code?: string }).code).toBe('CONFIG_INVALID');
+      expect((err as { hint?: string }).hint).toContain('tiny, base, small');
+    }
+  });
+});

--- a/packages/plugin-stt-local/src/models.ts
+++ b/packages/plugin-stt-local/src/models.ts
@@ -1,0 +1,111 @@
+/**
+ * The pinned Whisper model catalog.
+ *
+ * Every model is a multilingual sherpa-onnx Whisper export published as a
+ * `.tar.bz2` under the project's `asr-models` GitHub release. Each `sha256` is
+ * copied VERBATIM from that release's `checksum.txt` (re-verified 2026-07-05) —
+ * so a first-use download is content-addressed and tamper-evident, unlike an
+ * unverified blob fetch. The archive extracts to a single top directory
+ * (`archiveRootDir`) holding `<id>-encoder.onnx`, `<id>-decoder.onnx` (+ int8
+ * variants we don't use) and `<id>-tokens.txt`.
+ *
+ * All three are the MULTILINGUAL models (not the `.en` English-only exports),
+ * so Polish (and any other Whisper language) works — `small` is the accuracy
+ * sweet spot for Polish, `base` the balanced default, `tiny` the fastest.
+ */
+
+import { MoxxyError } from '@moxxy/sdk';
+
+export type WhisperModelId = 'tiny' | 'base' | 'small';
+
+export interface WhisperModelEntry {
+  /** Stable model id (also the `model` config value). */
+  readonly id: WhisperModelId;
+  /** Human label for UI surfaces / the first-use notice. */
+  readonly label: string;
+  /** Pinned archive URL (sherpa-onnx GitHub `asr-models` release). */
+  readonly url: string;
+  /** Pinned hex sha256 of the archive (from the release checksum.txt). */
+  readonly sha256: string;
+  /** Top directory the archive extracts to (`sherpa-onnx-whisper-<id>`). */
+  readonly archiveRootDir: string;
+  /** Encoder ONNX filename inside `archiveRootDir` (`<id>-encoder.onnx`). */
+  readonly encoderFile: string;
+  /** Decoder ONNX filename inside `archiveRootDir` (`<id>-decoder.onnx`). */
+  readonly decoderFile: string;
+  /** Tokens filename inside `archiveRootDir` (`<id>-tokens.txt`). */
+  readonly tokensFile: string;
+  /** Approximate download size in MB (for the one-time first-use notice). */
+  readonly approxMb: number;
+}
+
+const RELEASE_BASE = 'https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models';
+
+function whisperModel(
+  id: WhisperModelId,
+  label: string,
+  sha256: string,
+  approxMb: number,
+): WhisperModelEntry {
+  const archiveRootDir = `sherpa-onnx-whisper-${id}`;
+  return {
+    id,
+    label,
+    url: `${RELEASE_BASE}/${archiveRootDir}.tar.bz2`,
+    sha256,
+    archiveRootDir,
+    encoderFile: `${id}-encoder.onnx`,
+    decoderFile: `${id}-decoder.onnx`,
+    tokensFile: `${id}-tokens.txt`,
+    approxMb,
+  };
+}
+
+export const MODEL_CATALOG: readonly WhisperModelEntry[] = [
+  whisperModel(
+    'tiny',
+    'Whisper tiny (multilingual — fastest, lowest accuracy)',
+    'c46116994e539aa165266d96b325252728429c12535eb9d8b6a2b10f129e66b1',
+    111,
+  ),
+  whisperModel(
+    'base',
+    'Whisper base (multilingual — balanced; default)',
+    '911b2083efd7c0dca2ac3b358b75222660dc09fb716d64fbfc417ba6c99ff3de',
+    198,
+  ),
+  whisperModel(
+    'small',
+    'Whisper small (multilingual — best accuracy; recommended for Polish)',
+    '486a46afbb7ba798507190ffe02fea2dd726049af212e774537efac6afb210a6',
+    610,
+  ),
+];
+
+/** Default model when the caller doesn't pick one. `base` balances size vs.
+ *  accuracy; `small` is recommended for Polish (see the catalog description). */
+export const DEFAULT_MODEL_ID: WhisperModelId = 'base';
+
+/** All valid model ids, for error messages and validation. */
+export function modelIds(): string[] {
+  return MODEL_CATALOG.map((m) => m.id);
+}
+
+export function findModel(id: string): WhisperModelEntry | undefined {
+  return MODEL_CATALOG.find((m) => m.id === id);
+}
+
+/** Resolve a model id to its catalog entry, or throw a clear, actionable error
+ *  listing the valid ids. `field` names where the bad id came from. */
+export function requireModel(id: string, field: string): WhisperModelEntry {
+  const entry = findModel(id);
+  if (!entry) {
+    throw new MoxxyError({
+      code: 'CONFIG_INVALID',
+      message: `Unknown local Whisper model ${JSON.stringify(id)} (${field}).`,
+      hint: `Valid models: ${modelIds().join(', ')}.`,
+      context: { field, model: id },
+    });
+  }
+  return entry;
+}

--- a/packages/plugin-stt-local/src/platform.test.ts
+++ b/packages/plugin-stt-local/src/platform.test.ts
@@ -1,0 +1,77 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  libraryPathVar,
+  resolveSherpaLibDir,
+  sherpaEnv,
+  sherpaPlatformPackage,
+} from './platform.js';
+
+describe('sherpaPlatformPackage', () => {
+  it.each([
+    ['darwin', 'arm64', 'sherpa-onnx-darwin-arm64'],
+    ['darwin', 'x64', 'sherpa-onnx-darwin-x64'],
+    ['linux', 'x64', 'sherpa-onnx-linux-x64'],
+    ['linux', 'arm64', 'sherpa-onnx-linux-arm64'],
+    ['win32', 'x64', 'sherpa-onnx-win-x64'],
+  ] as const)('maps %s-%s to %s', (platform, arch, pkg) => {
+    expect(sherpaPlatformPackage(platform as NodeJS.Platform, arch)).toBe(pkg);
+  });
+
+  it('returns null for an unsupported platform/arch', () => {
+    expect(sherpaPlatformPackage('linux', 'ia32')).toBeNull();
+    expect(sherpaPlatformPackage('freebsd', 'x64')).toBeNull();
+  });
+});
+
+describe('libraryPathVar', () => {
+  it('picks the platform dynamic-loader var, or null on Windows', () => {
+    expect(libraryPathVar('darwin')).toBe('DYLD_LIBRARY_PATH');
+    expect(libraryPathVar('linux')).toBe('LD_LIBRARY_PATH');
+    expect(libraryPathVar('win32')).toBeNull();
+  });
+});
+
+describe('sherpaEnv', () => {
+  it('sets the loader var to the lib dir when none is present', () => {
+    expect(sherpaEnv('/libs', 'darwin', {})).toEqual({ DYLD_LIBRARY_PATH: '/libs' });
+    expect(sherpaEnv('/libs', 'linux', {})).toEqual({ LD_LIBRARY_PATH: '/libs' });
+  });
+
+  it('prepends the lib dir to an existing loader path', () => {
+    expect(sherpaEnv('/libs', 'darwin', { DYLD_LIBRARY_PATH: '/other' })).toEqual({
+      DYLD_LIBRARY_PATH: `/libs${path.delimiter}/other`,
+    });
+  });
+
+  it('returns no env on Windows (DLLs resolve next to the addon)', () => {
+    expect(sherpaEnv('C:\\libs', 'win32', {})).toEqual({});
+  });
+});
+
+describe('resolveSherpaLibDir', () => {
+  it('returns the dirname of the resolved platform package.json', () => {
+    const fakeResolve = (req: string): string => {
+      expect(req).toBe('sherpa-onnx-darwin-arm64/package.json');
+      return '/store/sherpa-onnx-darwin-arm64/package.json';
+    };
+    expect(resolveSherpaLibDir('darwin', 'arm64', fakeResolve)).toBe('/store/sherpa-onnx-darwin-arm64');
+  });
+
+  it('returns null when the platform package cannot be resolved', () => {
+    const throwing = (): string => {
+      throw new Error('MODULE_NOT_FOUND');
+    };
+    expect(resolveSherpaLibDir('darwin', 'arm64', throwing)).toBeNull();
+  });
+
+  it('returns null for an unsupported platform without calling resolve', () => {
+    let called = false;
+    const spy = (): string => {
+      called = true;
+      return 'x';
+    };
+    expect(resolveSherpaLibDir('sunos' as NodeJS.Platform, 'x64', spy)).toBeNull();
+    expect(called).toBe(false);
+  });
+});

--- a/packages/plugin-stt-local/src/platform.ts
+++ b/packages/plugin-stt-local/src/platform.ts
@@ -1,0 +1,109 @@
+/**
+ * Resolve the sherpa-onnx platform binary package and the environment the
+ * sidecar must be spawned with.
+ *
+ * CRITICAL native gotcha (scout-verified): sherpa-onnx-node's addon dlopen's
+ * sibling shared libs (`libonnxruntime.dylib`, `libsherpa-onnx-c-api.dylib`, …)
+ * that live inside the per-platform package dir, and dyld/ld.so read
+ * `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` ONCE at process start. So the addon
+ * only resolves its libs when that env var already points at the platform
+ * package dir when the process launches — which is exactly why the host runs in
+ * a freshly-forked child: the PARENT resolves the dir here and sets the var in
+ * the fork's env. On Windows the DLLs sit next to the `.node`, so no env var is
+ * needed.
+ *
+ * Shared verbatim with @moxxy/plugin-tts-local (deliberately duplicated rather
+ * than cross-imported so neither voice plugin depends on the other).
+ */
+
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+/** `${platform}-${arch}` → npm package that ships the native addon + libs.
+ *  Note the Windows package is `sherpa-onnx-win-x64` (renamed from win32-x64). */
+const PLATFORM_PACKAGES: Readonly<Record<string, string>> = {
+  'darwin-arm64': 'sherpa-onnx-darwin-arm64',
+  'darwin-x64': 'sherpa-onnx-darwin-x64',
+  'linux-x64': 'sherpa-onnx-linux-x64',
+  'linux-arm64': 'sherpa-onnx-linux-arm64',
+  'win32-x64': 'sherpa-onnx-win-x64',
+};
+
+/** The platform binary package name for a host, or null if unsupported. */
+export function sherpaPlatformPackage(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): string | null {
+  return PLATFORM_PACKAGES[`${platform}-${arch}`] ?? null;
+}
+
+/** A `require.resolve`-shaped function (injectable for tests). */
+export type ResolveLike = (request: string) => string;
+
+/**
+ * A `require.resolve` anchored at sherpa-onnx-node itself.
+ *
+ * Load-bearing: sherpa's per-platform binary packages are its OWN
+ * `optionalDependencies`, so under pnpm's strict layout they are visible from
+ * sherpa-onnx-node's `node_modules` but NOT hoisted into this plugin's — a
+ * resolve anchored here would `MODULE_NOT_FOUND`. So we first resolve
+ * sherpa-onnx-node, then resolve the platform package from ITS context. Cached
+ * because it walks two package boundaries.
+ */
+let cachedSherpaResolve: ResolveLike | null | undefined;
+function sherpaAnchoredResolve(): ResolveLike | null {
+  if (cachedSherpaResolve !== undefined) return cachedSherpaResolve;
+  try {
+    const pluginRequire = createRequire(import.meta.url);
+    const sherpaPkg = pluginRequire.resolve('sherpa-onnx-node/package.json');
+    cachedSherpaResolve = createRequire(sherpaPkg).resolve;
+  } catch {
+    cachedSherpaResolve = null;
+  }
+  return cachedSherpaResolve;
+}
+
+/**
+ * Absolute directory of the resolved platform package (which holds the `.node`
+ * addon and its sibling shared libraries), or null when the package can't be
+ * resolved (unsupported platform, or the optionalDependency didn't install).
+ * `resolve` is injectable for tests; the default is anchored at sherpa-onnx-node.
+ */
+export function resolveSherpaLibDir(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+  resolve?: ResolveLike,
+): string | null {
+  const pkg = sherpaPlatformPackage(platform, arch);
+  if (!pkg) return null;
+  const r = resolve ?? sherpaAnchoredResolve();
+  if (!r) return null;
+  try {
+    return path.dirname(r(`${pkg}/package.json`));
+  } catch {
+    return null;
+  }
+}
+
+/** The dynamic-loader env var name for a platform, or null on Windows. */
+export function libraryPathVar(platform: NodeJS.Platform = process.platform): string | null {
+  if (platform === 'win32') return null;
+  return platform === 'darwin' ? 'DYLD_LIBRARY_PATH' : 'LD_LIBRARY_PATH';
+}
+
+/**
+ * Build the env overrides the sidecar must launch with: the platform loader var
+ * with `libDir` PREPENDED to any existing value. Returns `{}` on Windows (DLLs
+ * resolve next to the addon). `existing` defaults to `process.env`.
+ */
+export function sherpaEnv(
+  libDir: string,
+  platform: NodeJS.Platform = process.platform,
+  existing: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const varName = libraryPathVar(platform);
+  if (!varName) return {};
+  const prev = existing[varName];
+  const value = prev ? `${libDir}${path.delimiter}${prev}` : libDir;
+  return { [varName]: value };
+}

--- a/packages/plugin-stt-local/src/sidecar.ts
+++ b/packages/plugin-stt-local/src/sidecar.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * sherpa-onnx STT sidecar — a forked child that owns the native sherpa addon.
+ *
+ * It exists as a SEPARATE process for one hard reason (see ./platform.ts): the
+ * addon's shared libraries only resolve when `DYLD_LIBRARY_PATH` /
+ * `LD_LIBRARY_PATH` points at the platform package dir AT PROCESS START, so the
+ * parent forks this with that env pre-set. Forking (not `spawn`) gives us a
+ * structured IPC channel; the parent uses `serialization: 'advanced'` so the
+ * `Float32Array` of samples round-trips without manual byte packing.
+ *
+ * Protocol: {@link ./host-protocol.ts}. This module is the thin runtime glue —
+ * lazily `require`ing the native module (a dlopen failure becomes a classified
+ * `init` reply rather than a boot crash), plus lifecycle self-termination so an
+ * orphaned sidecar never lingers.
+ */
+
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+import {
+  createMessageHandler,
+  type HostReply,
+  type HostRequest,
+  type SherpaModule,
+} from './host-protocol.js';
+
+const require = createRequire(import.meta.url);
+
+/** Lazy native load — deferred so a missing/broken addon is a caught, reported
+ *  `init` error on the first transcribe, not an unhandled boot exception. */
+function loadSherpa(): SherpaModule {
+  return require('sherpa-onnx-node') as SherpaModule;
+}
+
+function send(reply: HostReply): void {
+  // `process.send` is defined only when spawned with an IPC channel (our fork).
+  process.send?.(reply);
+}
+
+function isRequest(msg: unknown): msg is HostRequest {
+  return (
+    typeof msg === 'object' &&
+    msg !== null &&
+    (msg as { type?: unknown }).type === 'transcribe' &&
+    typeof (msg as { id?: unknown }).id === 'number'
+  );
+}
+
+/**
+ * Self-terminate if the parent runner disappears. `fork` delivers a
+ * `disconnect` event when the IPC channel closes (parent exit / explicit
+ * disconnect); belt-and-braces, poll the parent PID too — a hard SIGKILL of the
+ * parent may not always close the channel promptly.
+ */
+function armLifecycle(): void {
+  process.on('disconnect', () => process.exit(0));
+  const parentPid = process.ppid;
+  if (!parentPid || parentPid <= 1) return;
+  const timer = setInterval(() => {
+    try {
+      process.kill(parentPid, 0); // existence probe, no signal delivered
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ESRCH') process.exit(0);
+      // EPERM ⇒ the process exists but we can't signal it — still alive.
+    }
+  }, 3000);
+  timer.unref?.();
+}
+
+function main(): void {
+  const handle = createMessageHandler(loadSherpa);
+  // Serialise requests: sherpa's OfflineRecognizer is not re-entrant, and
+  // processing one at a time keeps memory bounded under a burst of voice notes.
+  let queue: Promise<void> = Promise.resolve();
+  process.on('message', (msg: unknown) => {
+    if (!isRequest(msg)) return;
+    queue = queue
+      .then(async () => {
+        const reply = await handle(msg);
+        send(reply);
+      })
+      .catch((err) => {
+        send({
+          id: msg.id,
+          ok: false,
+          error: { message: err instanceof Error ? err.message : String(err), kind: 'runtime' },
+        });
+      });
+  });
+  armLifecycle();
+}
+
+// Run only when executed as the forked child, never when imported by a test.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/packages/plugin-stt-local/tsconfig.json
+++ b/packages/plugin-stt-local/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/plugin-stt-local/vitest.config.ts
+++ b/packages/plugin-stt-local/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2311,6 +2311,34 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
 
+  packages/plugin-stt-local:
+    dependencies:
+      '@moxxy/model-fetch':
+        specifier: workspace:*
+        version: link:../model-fetch
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      sherpa-onnx-node:
+        specifier: ^1.13.3
+        version: 1.13.3
+    devDependencies:
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
   packages/plugin-stt-whisper:
     dependencies:
       '@moxxy/sdk':


### PR DESCRIPTION
## `@moxxy/plugin-stt-local` — fully local, on-device speech-to-text

The input sibling of `@moxxy/plugin-tts-local`: multilingual Whisper (English + Polish are the priority) running **fully on-device** via sherpa-onnx, with models downloaded once on first use and sha256-verified. No API key, no network at transcription time.

> **Stacked on #437** (`feat/tts-local`). This PR targets `feat/tts-local`, not `development` — its base already carries `@moxxy/model-fetch` and the forked sherpa-sidecar pattern. **Retarget to `development` / merge after #437 lands.**

### Architecture

Mirrors `plugin-tts-local` exactly:

- **Forked sherpa sidecar** (`sidecar.ts` + `host-client.ts` + `host-protocol.ts`). The native addon dlopen's its sibling shared libs, and dyld/ld.so read `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` **once at process start** — so the parent resolves the platform-package dir (anchored at `sherpa-onnx-node`, per pnpm's strict layout) and forks the child with that env pre-set. `fork` + `serialization: 'advanced'` round-trips the `Float32Array` samples intact. Lazy spawn, correlated request/reply, **restart-once** on a mid-request crash, per-request timeout, `onShutdown` kill.
- **Decode is in the parent, recognition in the sidecar.** The parent converts whatever audio arrives to the Float32 mono @ 16 kHz sherpa wants and ships only the samples across IPC; the sidecar owns the native `OfflineRecognizer` (`createStream` → `acceptWaveform` → `decode` → `getResult`), cached one per model. Every native failure becomes a typed `ok:false` reply, never a boot crash.
- **Everything injectable** (`ensureModelImpl`, `hostFactory`, `fetchImpl`, `spawnImpl`, `modelsDir`, `log`) so the whole flow is unit-tested without the native addon, a real download, or ffmpeg.
- **Registered side-effect free** — no download, no spawn until the first `transcribe`; no auto-adopt (the `TranscriberRegistry` has none). The host/user activates it explicitly: `session.transcribers.setActive('local-whisper', { model, language })`.

### Model matrix

Multilingual Whisper exports from sherpa-onnx's pinned `asr-models` release, into `~/.moxxy/models/stt/<model>/`. **All three sha256s were re-verified against the release `checksum.txt` and matched.**

| model | config `model` | download | notes |
|-------|----------------|----------|-------|
| tiny  | `tiny`         | ~111 MB  | fastest, lowest accuracy |
| base  | `base` (default) | ~198 MB | balanced |
| small | `small`        | ~610 MB  | best accuracy — **recommended for Polish** |

`language`/`task` are passed through to the Whisper config best-effort (empty language ⇒ auto-detect, which Whisper does anyway); the detected language is returned on the result when the native build reports one.

### Audio-input support matrix

sherpa wants Float32 mono @ 16 kHz. What needs ffmpeg vs. not:

| input | source | path | ffmpeg? |
|-------|--------|------|---------|
| raw PCM16 mono @ 24 kHz (`audio/x-moxxy-pcm16-24khz`) | TUI / desktop mic recorder | int16→float32 + linear resample 24k→16k, in-process | **no** |
| 16-bit PCM WAV (`audio/wav`, or sniffed by RIFF magic) | file uploads | RIFF header walk → downmix → resample, in-process | **no** |
| ogg/opus, mp3, m4a, webm, flac, … | Telegram voice notes, uploads | `ffmpeg -i pipe:0 -f f32le -ar 16000 -ac 1 pipe:1` | **yes** |

Non-PCM16 WAV (IEEE-float, 8-bit, exotic) is **rejected politely** rather than mis-decoded. When ffmpeg is absent, compressed audio raises a clear `PLUGIN_LOAD_FAILED` MoxxyError with an OS-specific install hint (via the SDK's `getInstallHint`) — **raw PCM and PCM16 WAV keep working without ffmpeg.** The ffmpeg presence probe is process-cached (an injected `spawn` bypasses the cache for deterministic tests), mirroring channel-kit's voice-reply.

### Known follow-up: desktop mic

The desktop mic path hardwires the in-process Codex transcriber (`RemoteSession.transcribers.setActive` throws), so **desktop voice input will not reach this plugin yet** — a separate follow-up. **Channel voice notes (Telegram) work today**: they consume `session.transcribers.getActive()` transparently, so activating `local-whisper` on the runner makes voice notes transcribe locally.

### Manual verify

- `MOXXY_STT_LOCAL_LIVE=1 pnpm -F @moxxy/plugin-stt-local test` — really downloads the tiny model and runs the native sidecar against a generated WAV fixture (off by default; needs the platform binary + ~111 MB fetch).
- Activate on a runner and send a Telegram voice note (ogg/opus → ffmpeg path).
- Feed a 16 kHz PCM16 WAV with no ffmpeg installed → transcribes; feed an ogg with no ffmpeg → clear install-hint error.

### Gate

`pnpm build` · `pnpm typecheck` · `pnpm lint` (0 errors) · `pnpm test` (80 new unit tests + full suite) · `pnpm check:deps` (0 errors) — all green.

One changeset: minor `@moxxy/plugin-stt-local`, patch `@moxxy/plugin-plugins-admin`.
