### PR TITLE
refactor(goal): guardrail-free one-shot goal mode — deliver the outcome, then hand back

### DIFF
--- a/.ai/skills/add-a-mode/SKILL.md
+++ b/.ai/skills/add-a-mode/SKILL.md
@@ -6,7 +6,7 @@ description: Build a new mode (loop strategy) package like default/goal/research
 # Add a mode
 
 Full workflow: **`.claude/agents/loop-strategy-author.md`**. Existing modes:
-`mode-default` (ReAct), `mode-goal` (autonomous auto-approve), 
+`mode-default` (ReAct), `mode-goal` (autonomous auto-approve, one-shot),
 `mode-deep-research` (fan-out + synthesis). The FIRST registered mode
 auto-activates — registration order in `packages/cli/src/setup/builtins.ts`
 matters.
@@ -14,23 +14,37 @@ matters.
 Checklist:
 - `defineMode({ name, run })` in a new `packages/mode-<name>/` package
   (add-a-plugin skill for scaffolding/wiring).
-- **Compose the SDK loop helpers** — do not hand-roll the tool batch loop:
-  `executeToolUses` + `emitRequestsAndDetectStuck` (`sdk/src/tool-dispatch.ts`,
-  parameterized by your `StuckLoopReport`) carry the load-bearing
-  orphaned-tool_call_requested fix; `collectProviderStream`,
-  `projectMessagesFromLog`, `runSingleShotTurn` for the provider side.
+- **Build on `runReactLoop`** (`sdk/src/mode/react-loop.ts`) — do not hand-roll
+  the loop: it owns provider retry back-off, reactive compaction, elision,
+  stuck detection, abort handling, and the turn-end checkpoint gate
+  (`TurnCheckpoint`). Your mode contributes POLICY via hooks
+  (`onIterationStart` / `onProviderSuccess` / `onToolBatchEnd` /
+  `onMaxIterations`) and checkpoints. Mirror `mode-goal`/`mode-default`.
+- **Stuck-loop policy**: `stuck.action: 'abort'` (default — attended modes) vs
+  `'nudge'` (unattended modes: the trip warns + steers with a volatile nudge,
+  never kills the run — goal-mode lesson: near-repeat heuristics trip on
+  legitimate edit→build→test cycles).
+- **Unattended / per-objective modes**: set `transient: true` on the ModeDef —
+  it is then never persisted as the boot/category default, and your loop should
+  hand back via `ctx.requestModeSwitch(ctx.previousModeName ?? 'default')` when
+  the objective concludes. Do NOT have channels flip session-wide
+  yolo/auto-approve for your mode; swap a run-scoped permission resolver
+  instead (see `runGoalMode`).
 - **Auto-approve must still consult policy**: call the resolver's prompt-free
   `policyCheck` before allowing (A3, goal-mode lesson) — replacing the
   resolver with unconditional-allow discards the user's
   `~/.moxxy/permissions.json` deny rules.
 - **Skip whitespace-only assistant messages** when emitting (A26) — empty text
   blocks wedge provider replays.
-- Volatile per-iteration nudges: mark them via
-  `CacheStrategyContext.volatileTailMessageCount` so they don't defeat the
-  stable-prefix cache (A42).
-- Overflow → reactive compaction handling: copy the pattern from
-  `mode-default`'s loop (currently per-mode by design).
+- Volatile per-iteration nudges: return them from `onIterationStart` (or
+  checkpoint `inject` with `volatile: true`) — the loop wires
+  `volatileTailCount` so they don't defeat the stable-prefix cache (A42).
+- Checkpoint injection budget (`maxInjections`) is per idle-EPISODE — it resets
+  whenever a tool batch executes, so it bounds no-progress wedges, not long
+  productive runs.
 - `zod` used at runtime ⇒ `dependencies`, not dev (A21).
 
 Tests: mode packages have full loop tests with FakeProvider — mirror
-`packages/mode-goal/src/*.test.ts` (incl. a deny-under-auto-approve case).
+`packages/mode-goal/src/*.test.ts` (incl. a deny-under-auto-approve case and,
+for transient modes, revert/stay-armed coverage). Gate/checkpoint behavior:
+`packages/mode-default/src/react-loop-gate.test.ts`.

--- a/.changeset/goal-mode-one-shot-no-guardrails.md
+++ b/.changeset/goal-mode-one-shot-no-guardrails.md
@@ -1,0 +1,7 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/cli': minor
+'@moxxy/desktop': patch
+---
+
+Goal mode refactor: deliver the outcome, then get out of the way. Goal runs are now guardrail-free — no iteration cap, no token budget, and a stuck-loop trip steers the model with a nudge instead of killing the run (the only terminals are goal_complete, goal_abandon, an idle stall, user abort, or a genuinely fatal error). Goal mode is also one-shot (`ModeDef.transient`): it arms per objective, hands the session back to the previous mode when the goal concludes, is never persisted as the boot/category default, and channels no longer flip session-wide yolo/auto-approve (the run auto-approves via its own scoped resolver). Also fixes the shared ReAct loop's checkpoint injection budget to be per idle-episode, so long autonomous runs no longer die on their Nth spread-out idle round. SDK additions: `emitRequestsAndNudgeOnStuck`, `stuck.action: 'nudge'` on `runReactLoop`, `StuckLoopDetector.reset()`, `ModeDef.transient`, `ModeContext.previousModeName`.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -13,6 +13,20 @@ or recorded-on-purpose decision.
 
 ## Resolved ledger
 
+- [high, modes, RESOLVED 2026-07-05] Goal mode killed its own runs and never let
+  go: the iteration cap (150), a 4M token budget, and a stuck-loop FATAL abort
+  (whose near-repeat heuristic trips on a legitimate edit→build→test cycle) all
+  ended unattended runs mid-delivery, and the checkpoint injection budget never
+  reset within a turn so the 4th *spread-out* idle nudge died with "checkpoint
+  budget exhausted". Worse, `/goal` persisted `goal` as the config-wide mode
+  default (future sessions BOOTED autonomous) and flipped session-wide
+  yolo/auto-approve that nothing ever reverted. Fixed: goal runs are
+  guardrail-free (terminals only: complete/abandon/idle-stall/abort/fatal; stuck
+  trips now steer via `stuck.action: 'nudge'`), the injection budget is
+  per idle-episode (`react-loop.ts`), and goal is `ModeDef.transient` — arms per
+  objective, reverts to `ctx.previousModeName` on completion, refused as a
+  boot/category default, and no channel flips session-wide approval anymore
+  (the run's own scoped resolver auto-approves).
 - [med, modes, RESOLVED 2026-07-05] Every ReAct-shaped mode duplicated ~250 lines
   of loop plumbing — `mode-default`, `mode-goal`, and the collab agent loop each
   carried a divergent copy of retry back-off / reactive compaction / stuck
@@ -164,6 +178,12 @@ or recorded-on-purpose decision.
   `credentialResolver` capability, per-owner browser sidecar registry, warm
   subprocess pool are consciously deferred (surface/risk for no current win);
   revisit when a concrete need appears.
+- **Goal runs have no spend ceiling — on purpose (2026-07-05).** Guardrails
+  (iteration cap, token budget, stuck-abort) killed real deliveries, so goal mode
+  removed them by explicit product decision; the backstops are the always-visible
+  GOAL badge, Esc/abort, the idle-stall soft-terminal, and stuck-NUDGE steering.
+  If runaway-spend reports appear, add an opt-in `context.goal.budget` config
+  (off by default) rather than reintroducing silent hard stops.
 
 ## Sessions / workspace
 

--- a/apps/desktop/src/chat/composer/GoalModal.tsx
+++ b/apps/desktop/src/chat/composer/GoalModal.tsx
@@ -8,15 +8,16 @@ interface GoalModalProps {
   readonly defaultObjective?: string;
   readonly onCancel: () => void;
   /** Approve: hand the objective back so the composer can switch to goal
-   *  mode, turn auto-approve on, and submit it. */
+   *  mode and submit it. */
   readonly onStart: (objective: string) => void;
 }
 
 /**
  * Goal composer. Opened from the composer's "+" menu — the user states
- * an objective, and approving it switches the session to goal mode,
- * enables auto-approve, and sends the objective so the agent works
- * autonomously until it's delivered. Closes on Escape / backdrop click.
+ * an objective, and approving it switches the session to goal mode and
+ * sends the objective so the agent works autonomously (tool calls
+ * auto-approved for the run) until it's delivered, then the session
+ * returns to the previous mode. Closes on Escape / backdrop click.
  */
 export function GoalModal({
   defaultObjective = '',
@@ -115,7 +116,7 @@ export function GoalModal({
                 color: 'var(--color-text-dim)',
               }}
             >
-              The agent works autonomously (auto-approve on) until it's done.
+              The agent works autonomously (tools auto-approved) until it's done, then hands back.
             </p>
           </div>
         </div>

--- a/apps/desktop/src/chat/composer/useComposerSubmit.ts
+++ b/apps/desktop/src/chat/composer/useComposerSubmit.ts
@@ -4,7 +4,9 @@
  * Owns the three send-side callbacks: `submit` (ship the draft + staged
  * attachments, then clear), `setAutoApprove` (mirror the per-workspace
  * auto-approve flag to the runner driver), and `startGoal` (the one-click
- * goal: switch to goal mode, turn auto-approve ON, submit the objective).
+ * goal: switch to goal mode and submit the objective — goal mode auto-approves
+ * its own tool calls internally and hands back to the previous mode when the
+ * objective concludes, so no session-wide auto-approve flip is needed).
  *
  * Extracted verbatim from `Composer.tsx`; behavior is unchanged. The composer
  * still owns the draft/attachment STATE and passes the values + clear callbacks
@@ -39,14 +41,15 @@ export interface ComposerSubmit {
   readonly startGoal: (objective: string) => void;
 }
 
-/** Drive the runner-side config (mode / auto-approve) and resolve once it has
- *  applied, so a goal's first tool call can't race the approve flip. */
+/** Switch the runner to goal mode and resolve once it has applied, so the
+ *  objective turn can't run under the previous mode. No auto-approve flip:
+ *  goal mode auto-approves its own tool calls via a run-scoped resolver, so a
+ *  session-wide flag (which would outlive the run) is redundant — and it made
+ *  the session permanently promptless after the goal finished. */
 async function applyGoalConfig(workspaceId: string): Promise<void> {
-  const a = api();
-  // Sequential: set the mode first, THEN auto-approve, so neither RPC can be
-  // reordered ahead of the turn we enqueue afterwards.
-  await a.invoke('session.setMode', { workspaceId, mode: 'goal' }).catch(() => {});
-  await a.invoke('session.setAutoApprove', { workspaceId, enabled: true }).catch(() => {});
+  await api()
+    .invoke('session.setMode', { workspaceId, mode: 'goal' })
+    .catch(() => {});
 }
 
 export function useComposerSubmit({
@@ -77,22 +80,19 @@ export function useComposerSubmit({
     [workspaceId],
   );
 
-  // One-click goal: switch to goal mode, turn auto-approve ON, and start
-  // working on the typed objective. Mirrors the TUI's `/goal <objective>`
-  // (switch mode + yolo + submit). Needs an objective in the draft.
+  // One-click goal: switch to goal mode and start working on the typed
+  // objective. Mirrors the TUI's `/goal <objective>`. Needs an objective in
+  // the draft.
   //
-  // The mode + auto-approve RPCs are AWAITED before the turn is enqueued: if
-  // the turn were sent before they applied, the goal's first tool call could
-  // hit the approval sheet (or run under the wrong mode), breaking the
-  // one-click "auto-approve on until done" contract the UI advertises.
+  // The mode RPC is AWAITED before the turn is enqueued: if the turn were
+  // sent before it applied, the objective would run under the wrong mode.
+  // Tool approval needs no flip here — goal mode auto-approves internally
+  // for the duration of the run only.
   const startGoal = useCallback(
     (objective: string): void => {
       if (!ready) return;
       const trimmed = objective.trim();
       if (!trimmed) return;
-      // Optimistically mirror the auto-approve flag to the store so the UI
-      // reflects it immediately; the awaited RPC below is what actually gates.
-      chatStore.setAutoApprove(workspaceId, true);
       // Close the modal + clear the composer up front (the input is consumed).
       clearDraft();
       clearAttachments();

--- a/apps/mobile/src/clientFrames.ts
+++ b/apps/mobile/src/clientFrames.ts
@@ -153,9 +153,11 @@ export function buildNewSessionFrame(input: WorkspaceInput): Record<string, unkn
 }
 
 export function buildGoalFrames(input: GoalInput): ReadonlyArray<Record<string, unknown>> {
+  // No auto-approve frame: goal mode auto-approves its own tool calls via a
+  // run-scoped resolver, and a session-wide flag would outlive the run —
+  // leaving the session permanently promptless after the goal finished.
   return [
     buildSetModeFrame({ workspaceId: input.workspaceId, mode: 'goal' }),
-    buildSetAutoApproveFrame({ workspaceId: input.workspaceId, enabled: true }),
     buildRunTurnFrame({ workspaceId: input.workspaceId, prompt: input.objective }),
   ];
 }

--- a/apps/mobile/test/mobile-client-frames.test.ts
+++ b/apps/mobile/test/mobile-client-frames.test.ts
@@ -37,10 +37,12 @@ describe('mobile client frame builders', () => {
     });
   });
 
-  it('builds goal mode as mode switch, auto-approve, then runTurn', () => {
+  it('builds goal mode as mode switch then runTurn — no session-wide auto-approve flip', () => {
+    // Goal mode auto-approves its own tool calls via a run-scoped resolver; a
+    // setAutoApprove frame would outlive the run and leave the session
+    // permanently promptless after the goal finished.
     expect(buildGoalFrames({ workspaceId: 'workspace-1', objective: 'Finish the feature' })).toEqual([
       expect.objectContaining({ type: 'setMode', workspaceId: 'workspace-1', mode: 'goal' }),
-      expect.objectContaining({ type: 'setAutoApprove', workspaceId: 'workspace-1', enabled: true }),
       expect.objectContaining({ type: 'runTurn', workspaceId: 'workspace-1', prompt: 'Finish the feature' }),
     ]);
   });

--- a/packages/cli/src/setup/apply-plugins-tree.test.ts
+++ b/packages/cli/src/setup/apply-plugins-tree.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { Session, autoAllowResolver, silentLogger } from '@moxxy/core';
 import type { MoxxyConfig } from '@moxxy/config';
 import type { ReflectorDef } from '@moxxy/sdk';
+import { defineMode } from '@moxxy/sdk';
 import { applyPluginsTree } from './apply-plugins-tree.js';
 
 function makeSession(): Session {
@@ -42,5 +43,35 @@ describe('applyPluginsTree — reflector (nullable active-def kind)', () => {
     // No floor to fall back to — stays null rather than throwing at boot.
     expect(session.reflectors.getActiveName()).toBeNull();
     expect(warns.some((w) => w.includes('reflector') && w.includes('ghost'))).toBe(true);
+  });
+});
+
+describe('applyPluginsTree — transient modes are refused as the boot default', () => {
+  const mode = (name: string, transient?: boolean) =>
+    defineMode({ name, ...(transient ? { transient } : {}), run: async function* () {} });
+
+  it('warns-and-keeps the protected default when the configured mode is transient', () => {
+    // A leftover `plugins.mode.default: goal` (written before transient modes
+    // stopped being persisted) must not boot every session straight into an
+    // autonomous, auto-approving run.
+    const session = makeSession();
+    session.modes.register(mode('default'));
+    session.modes.register(mode('goal', true));
+    const { logger, warns } = warnCollector();
+    const config = { plugins: { mode: { default: 'goal' } } } as unknown as MoxxyConfig;
+    applyPluginsTree(session, config, logger);
+    expect(session.modes.getActiveName()).toBe('default');
+    expect(warns.some((w) => w.includes('transient'))).toBe(true);
+  });
+
+  it('still applies a non-transient configured mode', () => {
+    const session = makeSession();
+    session.modes.register(mode('default'));
+    session.modes.register(mode('research'));
+    const { logger, warns } = warnCollector();
+    const config = { plugins: { mode: { default: 'research' } } } as unknown as MoxxyConfig;
+    applyPluginsTree(session, config, logger);
+    expect(session.modes.getActiveName()).toBe('research');
+    expect(warns).toEqual([]);
   });
 });

--- a/packages/cli/src/setup/apply-plugins-tree.ts
+++ b/packages/cli/src/setup/apply-plugins-tree.ts
@@ -131,6 +131,23 @@ export function applyPluginsTree(session: Session, config: MoxxyConfig, logger: 
     if (name === undefined) name = categoryDefault(config, key);
     if (!name) continue;
 
+    // A transient mode (goal) arms per objective and disarms itself — it must
+    // never be the session's BOOT default (a leftover `plugins.mode.default:
+    // goal` from before transient modes stopped being persisted would boot
+    // every session straight into an autonomous, auto-approving run).
+    if (key === 'mode') {
+      const target = name;
+      const def = session.modes.list().find((m) => m.name === target);
+      if (def?.transient) {
+        if (explicit) {
+          logger.warn(
+            `configured mode '${name}' is transient (armed per objective) and can't be the boot default; keeping '${reg.getActiveName()}'`,
+          );
+        }
+        continue;
+      }
+    }
+
     if (reg.has(name)) {
       try {
         reg.setActive(name);

--- a/packages/core/src/registries/modes.test.ts
+++ b/packages/core/src/registries/modes.test.ts
@@ -84,3 +84,30 @@ describe('ModeRegistry legacy-name migration', () => {
     expect(after).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('ModeRegistry previous-mode tracking', () => {
+  it('records the previously active mode across switches', () => {
+    const reg = new ModeRegistry();
+    reg.register(mode('default')); // auto-active, no previous
+    expect(reg.getPreviousActiveName()).toBeNull();
+
+    reg.register(mode('goal'));
+    reg.setActive('goal');
+    expect(reg.getPreviousActiveName()).toBe('default');
+
+    // Reverting (a transient mode handing back) updates previous too.
+    reg.setActive('default');
+    expect(reg.getPreviousActiveName()).toBe('goal');
+  });
+
+  it('a same-name setActive does not clobber the previous mode', () => {
+    const reg = new ModeRegistry();
+    reg.register(mode('default'));
+    reg.register(mode('goal'));
+    reg.setActive('goal');
+    // Re-arming goal (e.g. /goal twice in a row) keeps 'default' as the mode
+    // to hand back to — activate() early-returns on the name match.
+    reg.setActive('goal');
+    expect(reg.getPreviousActiveName()).toBe('default');
+  });
+});

--- a/packages/core/src/registries/modes.ts
+++ b/packages/core/src/registries/modes.ts
@@ -3,6 +3,7 @@ import { migrateModeName, type ModeDef } from '@moxxy/sdk';
 export class ModeRegistry {
   private readonly modes = new Map<string, ModeDef>();
   private active: string | null = null;
+  private previous: string | null = null;
   private readonly changeListeners = new Set<() => void>();
 
   /** Observe active-mode changes — used by the runner to broadcast
@@ -67,6 +68,16 @@ export class ModeRegistry {
     return this.active;
   }
 
+  /**
+   * Name of the mode that was active before the current one, or null when
+   * there is no history (session boot). Lets a transient mode (goal) revert
+   * to whatever the user was in before arming it — carried onto the
+   * ModeContext as `previousModeName` by run-turn.
+   */
+  getPreviousActiveName(): string | null {
+    return this.previous;
+  }
+
   setActive(name: string): void {
     // Prefer the literal name; only when it isn't registered fall back to the
     // legacy-name map (e.g. a persisted "tool-use" → "default"). This never
@@ -86,6 +97,7 @@ export class ModeRegistry {
 
   private activate(mode: ModeDef): void {
     if (this.active === mode.name) return;
+    this.previous = this.active;
     this.active = mode.name;
     this.notifyChange();
   }

--- a/packages/core/src/run-turn.ts
+++ b/packages/core/src/run-turn.ts
@@ -94,6 +94,7 @@ export async function* runTurn(
     session.lastResolvedModel = model;
 
     const strategy = session.modes.getActive();
+    const previousModeName = session.modes.getPreviousActiveName();
     // Combine the session's signal, the per-turn one (if provided), and the
     // generator-scoped abandonment signal so any of them firing cancels the turn.
     const effectiveSignal = AbortSignal.any(
@@ -140,6 +141,10 @@ export async function* runTurn(
       requestModeSwitch: (modeName: string) => {
         requestedModeSwitch = modeName;
       },
+      // Only surface a previous mode that is STILL registered — a transient
+      // mode reverting to an since-unregistered name would throw in the
+      // post-turn setActive and strand the session in the transient mode.
+      ...(previousModeName && session.modes.has(previousModeName) ? { previousModeName } : {}),
       emit: (event: EmittedEvent) => session.log.append(event),
     };
 

--- a/packages/core/src/session-runtime.ts
+++ b/packages/core/src/session-runtime.ts
@@ -48,9 +48,13 @@ export interface SessionRuntime {
   readonly modes: {
     getActive(): ModeDef;
     list(): ReadonlyArray<ModeDef>;
+    has(name: string): boolean;
     /** Post-turn mode hand-off (one mode handing back to another). Throws on an
      *  unknown name; run-turn guards the call. */
     setActive(name: string): void;
+    /** Mode active before the current one (or null) — surfaced onto the
+     *  ModeContext so a transient mode (goal) can revert to it. */
+    getPreviousActiveName(): string | null;
   };
   readonly compactors: { getActive(): CompactorDef | null };
   readonly cacheStrategies: { getActive(): CacheStrategyDef | null };

--- a/packages/mode-default/src/react-loop-gate.test.ts
+++ b/packages/mode-default/src/react-loop-gate.test.ts
@@ -219,6 +219,53 @@ describe('runReactLoop checkpoint gate', () => {
     expect(lastAssistantText(events)).toBe('v3');
   });
 
+  it('the injection budget is per idle-EPISODE: tool work resets it', async () => {
+    // Idle → inject → work → idle → inject → work → idle → inject → done.
+    // Three injections against maxInjections=2 — but never more than one per
+    // episode, so the budget (which exists to stop a no-progress wedge) must
+    // NOT trip. Before the reset, a long run died on its 3rd spread-out idle
+    // with "checkpoint budget exhausted" even though every nudge had worked.
+    const provider = new FakeProvider({
+      script: [
+        textReply('thinking 1'),
+        toolUseReply('work', { step: 1 }, 'w1'),
+        textReply('thinking 2'),
+        toolUseReply('work', { step: 2 }, 'w2'),
+        textReply('thinking 3'),
+        textReply('done'),
+      ],
+    });
+    const nudgeUnlessDone: TurnCheckpoint = {
+      name: 'nudge-unless-done',
+      gateOn: 'idle',
+      run: async (check): Promise<CheckpointResult> =>
+        check.candidateText === 'done'
+          ? { action: 'pass' }
+          : { action: 'inject', text: 'keep going' },
+    };
+    const session = gatedSession(provider, [nudgeUnlessDone], { maxInjections: 2 });
+    session.tools.register(
+      defineTool({
+        name: 'work',
+        description: '',
+        inputSchema: z.object({ step: z.number() }),
+        handler: () => 'ok',
+      }),
+    );
+
+    const events = await collectTurn(session, 'go');
+
+    // All three injections landed (the tool batches reset the budget)…
+    expect(
+      events.filter((e) => e.type === 'user_prompt' && e.origin?.kind === 'checkpoint'),
+    ).toHaveLength(3);
+    // …the run never hit the budget warning and finished naturally.
+    expect(
+      events.some((e) => e.type === 'error' && e.message.includes('checkpoint budget exhausted')),
+    ).toBe(false);
+    expect(lastAssistantText(events)).toBe('done');
+  });
+
   it('a crashing checkpoint fails OPEN with a visible warning', async () => {
     const provider = new FakeProvider({ script: [textReply('answer')] });
     const broken: TurnCheckpoint = {

--- a/packages/mode-goal/src/constants.ts
+++ b/packages/mode-goal/src/constants.ts
@@ -9,38 +9,13 @@ export const GOAL_COMPLETE_TOOL = 'goal_complete';
 export const GOAL_ABANDON_TOOL = 'goal_abandon';
 
 /**
- * Hard cap on autonomous iterations. Goal mode keeps re-prompting the model to
- * continue until it calls {@link GOAL_COMPLETE_TOOL}; this is the backstop that
- * guarantees the loop terminates even if the model never declares done. High
- * enough for a substantial multi-step task, low enough to bound a runaway.
- */
-export const GOAL_MAX_ITERATIONS = 150;
-
-/**
  * Consecutive iterations where the model emits NO tool calls and hasn't
- * completed. After this many we stop (a stall) rather than spin forever
- * nudging a model that has decided it's done without saying so.
+ * completed. After this many we treat the run as done-in-spirit (the model has
+ * clearly decided it's finished without saying so) and end the turn cleanly
+ * rather than spin forever nudging — this is goal mode's natural-termination
+ * mechanism, not a guardrail: the model is always nudged back to work first.
  */
 export const GOAL_MAX_NOOP_ITERATIONS = 3;
-
-/**
- * Cumulative token ceiling (full prompt — input + cacheRead + cacheCreation +
- * output — across the whole goal run). A second backstop alongside the
- * iteration cap: a few long-context iterations can burn a lot of tokens even
- * under the iteration limit. Generous; the iteration cap is usually the binding
- * guard.
- */
-export const GOAL_TOKEN_BUDGET = 4_000_000;
-
-/**
- * Max consecutive retryable provider errors before goal mode bails with a fatal
- * error. Goal mode runs unattended with auto-approval, so a sustained retryable
- * condition (429 / overloaded / transient 5xx / ECONNRESET) must NOT busy-loop
- * the provider — back off exponentially and give up after this many in a row.
- * The counter resets on any clean provider call, so a long run can still
- * recover from transient blips.
- */
-export const MAX_CONSECUTIVE_RETRIES = 6;
 
 /**
  * Layered on top of any user system prompt for the whole goal run. The framing
@@ -73,3 +48,10 @@ export const CONTINUE_NUDGE =
 export const STALL_NUDGE =
   `You have produced no tool calls for several turns. Either take a concrete next action toward the goal, ` +
   `or call \`${GOAL_COMPLETE_TOOL}\` (if done) / \`${GOAL_ABANDON_TOOL}\` (if blocked). Do not reply with only text again.`;
+
+/** Volatile steer when the stuck-loop detector notices a repetitive pattern.
+ *  Goal mode never aborts on repetition (unattended runs must not be killed by
+ *  a heuristic) — it steers instead. */
+export const STUCK_NUDGE_SUFFIX =
+  `If you are genuinely blocked and no different approach exists, call \`${GOAL_ABANDON_TOOL}\` ` +
+  `with the reason instead of retrying.`;

--- a/packages/mode-goal/src/goal-loop.ts
+++ b/packages/mode-goal/src/goal-loop.ts
@@ -3,7 +3,6 @@ import {
   type ModeContext,
   type MoxxyEvent,
   type PermissionResolver,
-  type ProviderSuccessInfo,
   type TurnCheckpoint,
 } from '@moxxy/sdk';
 
@@ -12,13 +11,12 @@ import {
   CONTINUE_NUDGE,
   GOAL_ABANDON_TOOL,
   GOAL_COMPLETE_TOOL,
-  GOAL_MAX_ITERATIONS,
   GOAL_MAX_NOOP_ITERATIONS,
   GOAL_MODE_NAME,
   GOAL_PLUGIN_ID,
   GOAL_SYSTEM_PROMPT,
-  GOAL_TOKEN_BUDGET,
   STALL_NUDGE,
+  STUCK_NUDGE_SUFFIX,
 } from './constants.js';
 
 // The retry back-off (and its test seam) lives in the SDK's shared ReAct
@@ -33,16 +31,28 @@ export { __setRetrySleepForTests } from '@moxxy/sdk';
  * keeps the model working autonomously across iterations until the model
  * explicitly calls `goal_complete` (success) or `goal_abandon` (blocked).
  *
- * The loop plumbing — bounded retry back-off, reactive compaction, stuck-loop
- * detection, abort handling — is the SDK's shared {@link runReactLoop}; goal
- * mode contributes only its POLICY:
+ * Goal mode is deliberately GUARDRAIL-FREE: the user asked for an outcome and
+ * opted into full autonomy, so nothing heuristic may kill the run mid-delivery.
+ * There is no iteration cap (unless the embedder set an explicit
+ * `ctx.maxIterations`), no token budget, and a stuck-loop trip steers the model
+ * instead of aborting. The ONLY ways a run ends:
  *
- *   - an idle checkpoint (`gateOn: 'idle'`): nudge the model with a volatile
- *     trailing prompt when it goes quiet, stop after
- *     {@link GOAL_MAX_NOOP_ITERATIONS} consecutive idle rounds
- *   - a cumulative token budget (`onProviderSuccess`)
- *   - terminal-tool detection after each batch (`onToolBatchEnd`)
- *   - goal-flavored wording for stuck/cap/error events
+ *   - the model calls `goal_complete` (verified success) or `goal_abandon`
+ *     (blocked, needs the user),
+ *   - the model goes idle {@link GOAL_MAX_NOOP_ITERATIONS} rounds in a row
+ *     despite nudges — it has decided it's done without saying so, so the run
+ *     ends cleanly as a soft completion,
+ *   - the user aborts (Esc / stop), or
+ *   - a genuinely fatal condition (un-compactable context overflow, provider
+ *     giving up after bounded retries).
+ *
+ * Goal mode is also ONE-SHOT (`transient: true` on the ModeDef): it arms for a
+ * single objective. When the run concludes as DONE — `goal_complete` or the
+ * idle soft-completion — the session hands back to the mode that was active
+ * before goal mode (via `ctx.requestModeSwitch`), so the user's next message is
+ * normal chat again. While the goal is UNFINISHED — `goal_abandon` (the model
+ * needs an answer to continue), a fatal error, or a user abort — the mode stays
+ * armed so the user's reply resumes the autonomous run.
  *
  * Tool calls are auto-approved for the whole run (the user opted into full
  * autonomy) by swapping in a resolver that replaces only the PROMPT path:
@@ -86,6 +96,17 @@ export async function* runGoalMode(ctx: ModeContext): AsyncIterable<MoxxyEvent> 
     permissions: autoApprove,
   };
 
+  // Hand the session back to whatever the user was in before arming goal mode
+  // — applied by the runner AFTER the turn drains, and only on clean
+  // completion. Called on the DONE terminals only (complete / idle
+  // soft-completion): an unfinished goal (abandon / fatal / abort) keeps the
+  // mode armed so the user's reply resumes the run.
+  const disarm = (): void => {
+    const previous = ctx.previousModeName;
+    const target = previous && previous !== GOAL_MODE_NAME ? previous : 'default';
+    ctx.requestModeSwitch?.(target);
+  };
+
   yield await ctx.emit({
     type: 'plugin_event',
     sessionId: ctx.sessionId,
@@ -93,21 +114,14 @@ export async function* runGoalMode(ctx: ModeContext): AsyncIterable<MoxxyEvent> 
     source: 'plugin',
     pluginId: GOAL_PLUGIN_ID,
     subtype: 'goal_started',
-    payload: { autoApprove: true, maxIterations: ctx.maxIterations ?? GOAL_MAX_ITERATIONS },
+    payload: { autoApprove: true, maxIterations: ctx.maxIterations ?? null },
   });
 
-  // Cumulative token budget across the whole run (alongside the iteration
-  // cap). Tally the FULL prompt of each call: Anthropic reports the cached
-  // portion separately (`inputTokens` is only the non-cached prefix), so on a
-  // long goal run — where the rolling cache breakpoint serves most of the
-  // prompt as cacheRead — counting input+output alone undercounts by a large
-  // factor and this backstop could be exceeded many times over before it
-  // trips.
-  let totalTokens = 0;
-
   // The model idled without calling goal_complete: nudge it back to work with
-  // a volatile trailing prompt (this call only — never appended to the log),
-  // and stop for good after GOAL_MAX_NOOP_ITERATIONS consecutive idle rounds.
+  // a volatile trailing prompt (this call only — never appended to the log).
+  // After GOAL_MAX_NOOP_ITERATIONS consecutive idle rounds the model has
+  // clearly decided it's done without declaring it — end the run cleanly as a
+  // soft completion (and disarm) rather than spin forever.
   const idleNudge: TurnCheckpoint = {
     name: 'goal-idle',
     gateOn: 'idle',
@@ -128,10 +142,12 @@ export async function* runGoalMode(ctx: ModeContext): AsyncIterable<MoxxyEvent> 
           turnId: ctx.turnId,
           source: 'system',
           content:
-            'Goal mode stopped: the model went idle without calling `goal_complete`. ' +
-            'It may believe the goal is done — review the work above, and send another message to continue if not.',
+            'Goal run ended: the model stopped working without calling `goal_complete` — ' +
+            'it likely considers the goal done. Review the work above; if something is ' +
+            'missing, describe it in your next message.',
           stopReason: 'end_turn',
         });
+        disarm();
         return { action: 'stop' };
       }
       return {
@@ -144,16 +160,28 @@ export async function* runGoalMode(ctx: ModeContext): AsyncIterable<MoxxyEvent> 
 
   yield* runReactLoop(goalCtx, {
     strategyName: GOAL_MODE_NAME,
-    defaultMaxIterations: GOAL_MAX_ITERATIONS,
+    // No iteration cap: a goal run ends via its terminals, never because a
+    // counter ran out mid-delivery. An explicit ctx.maxIterations (set by a
+    // programmatic embedder) still takes precedence inside runReactLoop.
+    defaultMaxIterations: Number.POSITIVE_INFINITY,
     errorPrefix: 'goal: ',
     checkpoints: [idleNudge],
-    // The idle checkpoint stops itself at GOAL_MAX_NOOP_ITERATIONS, before
-    // this backstop can trip — it exists so a future checkpoint bug degrades
-    // loudly instead of looping.
+    // The idle checkpoint stops itself at GOAL_MAX_NOOP_ITERATIONS consecutive
+    // idles, before this backstop can trip — it exists so a future checkpoint
+    // bug degrades loudly instead of looping. (The core resets the budget
+    // whenever the model does tool work, so spread-out idle rounds across a
+    // long run never exhaust it.)
     maxInjections: GOAL_MAX_NOOP_ITERATIONS,
     stuck: {
-      abortedResultMessage: 'goal mode aborted (stuck pattern) before this call ran',
+      // Never abort an unattended run on a repetition heuristic — the repeats
+      // are often legitimate (re-running a failing build between edits).
+      // Steer instead: visible warning + a volatile nudge on the next call.
+      action: 'nudge',
       nearHint: 'against the same target (only volatile args varied)',
+      nudgeText: ({ toolName, count, how }) =>
+        `You have called the tool \`${toolName}\` ${count} times ${how}. Repeating the same ` +
+        `call will not produce a different result. Step back, reassess, and take a DIFFERENT ` +
+        `next action toward the goal. ${STUCK_NUDGE_SUFFIX}`,
       extraOnStuck: ({ toolName, count, kind }) => [
         {
           type: 'plugin_event',
@@ -165,48 +193,6 @@ export async function* runGoalMode(ctx: ModeContext): AsyncIterable<MoxxyEvent> 
           payload: { tool: toolName, count, kind },
         },
       ],
-      fatalMessage: ({ toolName, count, how }) =>
-        `goal mode aborted — stuck pattern: tool "${toolName}" called ${count} times ${how}. ` +
-        `The model is looping on the same call; send another message to redirect it.`,
-    },
-    onProviderSuccess: async (loopCtx, info) => {
-      totalTokens += usageTotal(info);
-      if (totalTokens <= GOAL_TOKEN_BUDGET) return undefined;
-      // Persist the budget-exhausting call's assistant text before exiting,
-      // just like every productive iteration does. Otherwise the model's last
-      // words vanish from the log, so a resume ("continue from here") loses
-      // that context. We do NOT execute its tool calls — the run is stopping.
-      if (info.text || info.stopReason === 'end_turn' || info.toolUses.length === 0) {
-        await loopCtx.emit({
-          type: 'assistant_message',
-          sessionId: ctx.sessionId,
-          turnId: ctx.turnId,
-          source: 'model',
-          content: info.text,
-          stopReason: info.stopReason,
-        });
-      }
-      await loopCtx.emit({
-        type: 'plugin_event',
-        sessionId: ctx.sessionId,
-        turnId: ctx.turnId,
-        source: 'plugin',
-        pluginId: GOAL_PLUGIN_ID,
-        subtype: 'goal_budget_exhausted',
-        payload: { totalTokens, budget: GOAL_TOKEN_BUDGET, iteration: info.iteration },
-      });
-      await loopCtx.emit({
-        type: 'assistant_message',
-        sessionId: ctx.sessionId,
-        turnId: ctx.turnId,
-        source: 'system',
-        content:
-          `Goal mode stopped: token budget exhausted (${totalTokens.toLocaleString()} > ` +
-          `${GOAL_TOKEN_BUDGET.toLocaleString()}) before the goal was completed. ` +
-          `Send another message to continue from here.`,
-        stopReason: 'end_turn',
-      });
-      return { action: 'stop' };
     },
     onToolBatchEnd: async (loopCtx, { toolUses, iteration }) => {
       // Did this batch end the run? (goal_complete / goal_abandon, confirmed
@@ -244,6 +230,7 @@ export async function* runGoalMode(ctx: ModeContext): AsyncIterable<MoxxyEvent> 
           content: `✓ Goal complete — ${terminal.summary}${evidenceBlock}`,
           stopReason: 'end_turn',
         });
+        disarm();
         return { action: 'stop' };
       }
       if (terminal?.kind === 'abandon') {
@@ -266,14 +253,20 @@ export async function* runGoalMode(ctx: ModeContext): AsyncIterable<MoxxyEvent> 
           sessionId: ctx.sessionId,
           turnId: ctx.turnId,
           source: 'system',
-          content: `Goal abandoned — ${terminal.reason}${needs}`,
+          content:
+            `Goal abandoned — ${terminal.reason}${needs}\n\n` +
+            `Goal mode stays armed: your reply resumes the autonomous run.`,
           stopReason: 'end_turn',
         });
+        // Deliberately NOT disarming: the model needs something from the user
+        // and their reply should resume the autonomous run.
         return { action: 'stop' };
       }
       return undefined;
     },
     onMaxIterations: async (loopCtx, maxIterations) => {
+      // Only reachable when an embedder set an explicit ctx.maxIterations —
+      // goal mode itself is uncapped.
       await loopCtx.emit({
         type: 'plugin_event',
         sessionId: ctx.sessionId,
@@ -290,22 +283,11 @@ export async function* runGoalMode(ctx: ModeContext): AsyncIterable<MoxxyEvent> 
         source: 'system',
         kind: 'fatal',
         message:
-          `goal mode reached the iteration cap (${maxIterations}) without calling goal_complete. ` +
-          `Stopping to avoid an unbounded run; send another message to continue.`,
+          `goal mode reached the configured iteration cap (${maxIterations}) without calling ` +
+          `goal_complete. Send another message to continue.`,
       });
     },
   });
-}
-
-function usageTotal(info: ProviderSuccessInfo): number {
-  const usage = info.usage;
-  if (!usage) return 0;
-  return (
-    (usage.inputTokens ?? 0) +
-    (usage.cacheReadTokens ?? 0) +
-    (usage.cacheCreationTokens ?? 0) +
-    (usage.outputTokens ?? 0)
-  );
 }
 
 function composeSystemPrompts(user: string | undefined, layer: string): string {

--- a/packages/mode-goal/src/index.test.ts
+++ b/packages/mode-goal/src/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
-import { defineTool, type ProviderEvent } from '@moxxy/sdk';
+import { defineMode, definePlugin, defineTool, type ProviderEvent } from '@moxxy/sdk';
 import { collectTurn } from '@moxxy/core';
 import { FakeProvider, createFakeSession, textReply, toolUseReply } from '@moxxy/testing';
 
@@ -157,13 +157,17 @@ describe('goalMode end-to-end', () => {
     expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_completed')).toBe(false);
   });
 
-  it('emits a paired result for every request even when the stuck loop trips', async () => {
-    // The model hammers the same (name, input) until the detector trips. The
-    // stuck trip ends the turn before executeToolUses runs the final request —
-    // without synthesizing a result that request is orphaned (renders as a tool
-    // stuck "running" forever, flips to error only on the next user_prompt).
+  it('a stuck-loop trip steers the run instead of killing it (no guardrail abort)', async () => {
+    // The model hammers the same (name, input) well past the detector's
+    // threshold, then recovers and completes. Goal mode must surface the
+    // repetition (goal_stuck + a visible NON-fatal warning + a volatile nudge
+    // on the next call) but NEVER abort — the trip used to end the run with a
+    // fatal error mid-delivery.
     const provider = new FakeProvider({
-      script: Array.from({ length: 20 }, (_, i) => toolUseReply('loop', {}, `c${i}`)),
+      script: [
+        ...Array.from({ length: 12 }, (_, i) => toolUseReply('loop', {}, `c${i}`)),
+        toolUseReply('goal_complete', { summary: 'recovered and finished' }, 'gc-stuck'),
+      ],
     });
     const session = createFakeSession({ provider });
     session.pluginHost.registerStatic(goalModePlugin);
@@ -178,92 +182,34 @@ describe('goalMode end-to-end', () => {
     );
 
     const events = await collectTurn(session, 'spin');
-    expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_stuck')).toBe(true);
 
+    // The repetition was noticed and surfaced…
+    expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_stuck')).toBe(true);
+    const warn = events.find(
+      (e) => e.type === 'error' && e.kind === 'retryable' && e.message.includes('repetitive'),
+    );
+    expect(warn).toBeDefined();
+    // …but nothing fatal happened and the run completed.
+    expect(events.some((e) => e.type === 'error' && e.kind === 'fatal')).toBe(false);
+    expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_completed')).toBe(
+      true,
+    );
+    // Every request got a real result (the batch executed — nothing synthesized
+    // as aborted, no orphans).
     const requestedIds = new Set(
       events.filter((e) => e.type === 'tool_call_requested').map((e) => e.callId),
     );
     const resolvedIds = new Set(
       events.filter((e) => e.type === 'tool_result').map((e) => e.callId),
     );
-    const orphans = [...requestedIds].filter((id) => !resolvedIds.has(id));
-    expect(orphans).toEqual([]);
-  });
-
-  // u67-2: the cumulative token-budget backstop must stop the run (the exact
-  // unbounded-run failure the guard exists to prevent).
-  it('stops with goal_budget_exhausted when cumulative usage exceeds the budget', () => {
-    // A single reply whose usage blows past GOAL_TOKEN_BUDGET (4M). The budget
-    // check runs right after the provider call, before any tool work, so this
-    // trips on iteration 1.
-    const hugeUsage: ProviderEvent[] = [
-      { type: 'message_start', model: 'fake' },
-      { type: 'text_delta', delta: 'working...' },
-      {
-        type: 'message_end',
-        stopReason: 'end_turn',
-        usage: { inputTokens: 5_000_000, outputTokens: 0 },
-      },
-    ];
-    const provider = new FakeProvider({ script: [hugeUsage] });
-    const session = createFakeSession({ provider });
-    session.pluginHost.registerStatic(goalModePlugin);
-    session.modes.setActive(GOAL_MODE_NAME);
-
-    return collectTurn(session, 'do an expensive thing').then((events) => {
-      const exhausted = events.find(
-        (e) => e.type === 'plugin_event' && e.subtype === 'goal_budget_exhausted',
-      );
-      expect(exhausted).toBeDefined();
-      if (exhausted?.type !== 'plugin_event') throw new Error('expected goal_budget_exhausted');
-      expect((exhausted.payload as { budget: number }).budget).toBe(4_000_000);
-      // It did NOT falsely report completion, and a final system message tells
-      // the user how to continue.
-      expect(
-        events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_completed'),
-      ).toBe(false);
-      const finalMsg = events
-        .filter((e) => e.type === 'assistant_message' && e.source === 'system')
-        .pop();
-      if (finalMsg?.type !== 'assistant_message') throw new Error('expected final system message');
-      expect(finalMsg.content).toContain('token budget exhausted');
-    });
-  });
-
-  // u67-3: the budget-exhausting call's reasoning must still be persisted to the
-  // log before the budget exit, matching every other exit path (otherwise the
-  // final call's reasoning is silently dropped).
-  it('persists the budget-exhausting call reasoning before goal_budget_exhausted', () => {
-    const hugeUsageWithReasoning: ProviderEvent[] = [
-      { type: 'message_start', model: 'fake' },
-      { type: 'reasoning_delta', delta: 'I should think hard about this expensive task.' },
-      { type: 'reasoning_signature', signature: 'sig-1' },
-      { type: 'text_delta', delta: 'working...' },
-      {
-        type: 'message_end',
-        stopReason: 'end_turn',
-        usage: { inputTokens: 5_000_000, outputTokens: 0 },
-      },
-    ];
-    const provider = new FakeProvider({ script: [hugeUsageWithReasoning] });
-    const session = createFakeSession({ provider });
-    session.pluginHost.registerStatic(goalModePlugin);
-    session.modes.setActive(GOAL_MODE_NAME);
-
-    return collectTurn(session, 'do an expensive thing').then((events) => {
-      const reasoningIdx = events.findIndex((e) => e.type === 'reasoning_message');
-      const exhaustedIdx = events.findIndex(
-        (e) => e.type === 'plugin_event' && e.subtype === 'goal_budget_exhausted',
-      );
-      expect(reasoningIdx).toBeGreaterThanOrEqual(0);
-      expect(exhaustedIdx).toBeGreaterThanOrEqual(0);
-      // The reasoning_message lands BEFORE the budget exit (the bug dropped it).
-      expect(reasoningIdx).toBeLessThan(exhaustedIdx);
-      const reasoning = events[reasoningIdx];
-      if (reasoning?.type !== 'reasoning_message') throw new Error('expected reasoning_message');
-      expect(reasoning.content).toContain('think hard');
-      expect(reasoning.signature).toBe('sig-1');
-    });
+    expect([...requestedIds].filter((id) => !resolvedIds.has(id))).toEqual([]);
+    // The nudge rode the next provider call as a volatile trailing message.
+    const nudged = provider.received.some((req) =>
+      req.messages
+        .flatMap((m) => m.content)
+        .some((c) => 'text' in c && c.text.includes('Repeating the same call will not produce')),
+    );
+    expect(nudged).toBe(true);
   });
 
   // u67-2: the hard iteration cap must end the run with goal_max_iterations + a
@@ -386,8 +332,10 @@ describe('goalMode end-to-end', () => {
         sleeps += 1;
       });
       // The provider is stuck returning retryable errors forever. Without the
-      // cap this would re-hit the provider up to maxIterations (150) times with
+      // bounded retry budget this would re-hit the provider endlessly with
       // zero spacing — exactly the unattended busy-loop the guard prevents.
+      // (This is a PROVIDER-protection bound, not a goal guardrail: it fires
+      // only on consecutive provider failures, never on productive work.)
       const provider = new FakeProvider({
         script: Array.from({ length: 50 }, () => retryableErrorReply('rate limited')),
       });
@@ -506,72 +454,165 @@ describe('goalMode end-to-end', () => {
     });
   });
 
-  it('persists the budget-exhausting call assistant text before stopping', () => {
-    // The model produces real text on the call that blows the budget. That text
-    // must land in the log (source: 'model') so a resume keeps the context —
-    // it was silently dropped before the fix.
-    const hugeUsageWithText: ProviderEvent[] = [
-      { type: 'message_start', model: 'fake' },
-      { type: 'text_delta', delta: 'Here is my final analysis before stopping.' },
-      {
-        type: 'message_end',
-        stopReason: 'end_turn',
-        usage: { inputTokens: 5_000_000, outputTokens: 0 },
-      },
-    ];
-    const provider = new FakeProvider({ script: [hugeUsageWithText] });
-    const session = createFakeSession({ provider });
-    session.pluginHost.registerStatic(goalModePlugin);
-    session.modes.setActive(GOAL_MODE_NAME);
+  describe('no guardrails: nothing heuristic kills a goal run', () => {
+    it('runs past the old 150-iteration cap and still completes (uncapped by default)', async () => {
+      // 155 productive iterations (varied inputs dodge the stuck detector),
+      // then done. Under the old GOAL_MAX_ITERATIONS=150 cap this died with a
+      // fatal "iteration cap" error five rounds short of delivering.
+      const rounds = 155;
+      const provider = new FakeProvider({
+        script: [
+          ...Array.from({ length: rounds }, (_, i) => toolUseReply('work', { step: i }, `w${i}`)),
+          toolUseReply('goal_complete', { summary: 'went the distance' }, 'gc-long'),
+        ],
+      });
+      const session = createFakeSession({ provider });
+      session.pluginHost.registerStatic(goalModePlugin);
+      session.modes.setActive(GOAL_MODE_NAME);
+      session.tools.register(
+        defineTool({
+          name: 'work',
+          description: '',
+          inputSchema: z.object({ step: z.number() }),
+          handler: () => 'ok',
+        }),
+      );
 
-    return collectTurn(session, 'expensive').then((events) => {
-      // The model's own text was persisted…
-      const modelMsg = events.find(
-        (e) => e.type === 'assistant_message' && e.source === 'model',
+      const events = await collectTurn(session, 'a very long goal');
+
+      expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_completed')).toBe(
+        true,
       );
-      if (modelMsg?.type !== 'assistant_message') throw new Error('expected a model assistant_message');
-      expect(modelMsg.content).toContain('final analysis');
-      // …before the budget plugin_event (matching the reasoning ordering rule).
-      const modelIdx = events.indexOf(modelMsg);
-      const exhaustedIdx = events.findIndex(
-        (e) => e.type === 'plugin_event' && e.subtype === 'goal_budget_exhausted',
+      expect(
+        events.some((e) => e.type === 'error' && e.kind === 'fatal'),
+      ).toBe(false);
+      expect(provider.received.length).toBe(rounds + 1);
+    });
+
+    it('spread-out idle rounds never exhaust the checkpoint budget mid-run', async () => {
+      // Idle → nudged back to work → idle → nudged → … four idle EPISODES
+      // (more than maxInjections=3), each recovered by tool work, then done.
+      // Before the per-episode budget reset this run died on the 4th idle with
+      // "checkpoint budget exhausted".
+      const script: Array<ReadonlyArray<ProviderEvent>> = [];
+      for (let i = 0; i < 4; i++) {
+        script.push(textReply(`progress note ${i}`));
+        script.push(toolUseReply('work', { step: i }, `iw${i}`));
+      }
+      script.push(toolUseReply('goal_complete', { summary: 'finished after pauses' }, 'gc-idle'));
+      const provider = new FakeProvider({ script });
+      const session = createFakeSession({ provider });
+      session.pluginHost.registerStatic(goalModePlugin);
+      session.modes.setActive(GOAL_MODE_NAME);
+      session.tools.register(
+        defineTool({
+          name: 'work',
+          description: '',
+          inputSchema: z.object({ step: z.number() }),
+          handler: () => 'ok',
+        }),
       );
-      expect(exhaustedIdx).toBeGreaterThanOrEqual(0);
-      expect(modelIdx).toBeLessThan(exhaustedIdx);
+
+      const events = await collectTurn(session, 'goal with thinking pauses');
+
+      expect(
+        events.some((e) => e.type === 'error' && e.message.includes('checkpoint budget exhausted')),
+      ).toBe(false);
+      expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_stalled')).toBe(
+        false,
+      );
+      expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_completed')).toBe(
+        true,
+      );
     });
   });
 
-  it('counts cached prompt tokens toward the budget so the runaway guard trips', () => {
-    // Most of the prompt is served from cache (cacheRead) with a tiny live
-    // input. Counting input+output alone would leave totalTokens far under the
-    // 4M budget; including the cache fields trips it on iteration 1.
-    const cachedHeavyUsage: ProviderEvent[] = [
-      { type: 'message_start', model: 'fake' },
-      { type: 'text_delta', delta: 'working...' },
-      {
-        type: 'message_end',
-        stopReason: 'end_turn',
-        usage: {
-          inputTokens: 100,
-          outputTokens: 100,
-          cacheReadTokens: 5_000_000,
-          cacheCreationTokens: 0,
-        },
-      },
-    ];
-    const provider = new FakeProvider({ script: [cachedHeavyUsage] });
-    const session = createFakeSession({ provider });
-    session.pluginHost.registerStatic(goalModePlugin);
-    session.modes.setActive(GOAL_MODE_NAME);
+  describe('one-shot semantics: goal mode disarms itself when the goal concludes', () => {
+    /** A no-op mode to stand in for whatever the user was in before /goal. */
+    const priorModePlugin = definePlugin({
+      name: '@moxxy/testing/prior-mode',
+      modes: [
+        defineMode({
+          name: 'prior',
+          run: async function* () {
+            /* never driven in these tests */
+          },
+        }),
+      ],
+    });
 
-    return collectTurn(session, 'cached and expensive').then((events) => {
-      const exhausted = events.find(
-        (e) => e.type === 'plugin_event' && e.subtype === 'goal_budget_exhausted',
+    function armedSession(provider: FakeProvider) {
+      const session = createFakeSession({ provider });
+      // Register the prior mode FIRST (auto-activates), then arm goal — the
+      // registry records 'prior' as the previous mode, like a real /goal.
+      session.pluginHost.registerStatic(priorModePlugin);
+      session.pluginHost.registerStatic(goalModePlugin);
+      session.modes.setActive(GOAL_MODE_NAME);
+      return session;
+    }
+
+    it('reverts to the previous mode after goal_complete', async () => {
+      const provider = new FakeProvider({
+        script: [toolUseReply('goal_complete', { summary: 'done' }, 'gc-rev')],
+      });
+      const session = armedSession(provider);
+
+      await collectTurn(session, 'do it');
+
+      expect(session.modes.getActiveName()).toBe('prior');
+    });
+
+    it('reverts to the previous mode after an idle stall (soft completion)', async () => {
+      const provider = new FakeProvider({
+        script: [textReply('a'), textReply('b'), textReply('c')],
+      });
+      const session = armedSession(provider);
+
+      const events = await collectTurn(session, 'vague thing');
+
+      expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_stalled')).toBe(
+        true,
       );
-      expect(exhausted).toBeDefined();
-      if (exhausted?.type !== 'plugin_event') throw new Error('expected goal_budget_exhausted');
-      // totalTokens reflects the FULL prompt (input + cacheRead + output).
-      expect((exhausted.payload as { totalTokens: number }).totalTokens).toBe(5_000_200);
+      expect(session.modes.getActiveName()).toBe('prior');
+    });
+
+    it('stays armed after goal_abandon so the user reply resumes the run', async () => {
+      const provider = new FakeProvider({
+        script: [
+          toolUseReply('goal_abandon', { reason: 'need the API key', needsFromUser: 'the key' }, 'ga-1'),
+        ],
+      });
+      const session = armedSession(provider);
+
+      const events = await collectTurn(session, 'deploy it');
+
+      expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'goal_abandoned')).toBe(
+        true,
+      );
+      expect(session.modes.getActiveName()).toBe(GOAL_MODE_NAME);
+    });
+
+    it('stays armed after a user abort (the goal is unfinished)', async () => {
+      const ctrl = new AbortController();
+      const provider = new FakeProvider({
+        script: [toolUseReply('work', { step: 1 }, 'wa-1')],
+      });
+      const session = armedSession(provider);
+      session.tools.register(
+        defineTool({
+          name: 'work',
+          description: '',
+          inputSchema: z.object({ step: z.number() }),
+          handler: () => {
+            ctrl.abort();
+            return 'ok';
+          },
+        }),
+      );
+
+      await collectTurn(session, 'interrupt me', { signal: ctrl.signal });
+
+      expect(session.modes.getActiveName()).toBe(GOAL_MODE_NAME);
     });
   });
 });

--- a/packages/mode-goal/src/index.ts
+++ b/packages/mode-goal/src/index.ts
@@ -8,11 +8,16 @@ export { GOAL_MODE_NAME } from './constants.js';
 
 export const goalMode = defineMode({
   name: GOAL_MODE_NAME,
-  description: 'Autonomous goal loop: works across many turns until it calls goal_complete (tools auto-approved)',
+  description:
+    'Autonomous goal run: works until it calls goal_complete (tools auto-approved), then hands back to your previous mode',
   // Goal mode auto-approves tools and keeps working unattended, so channels
   // surface a persistent accent badge while it's active — the user must always
   // know the agent is driving itself.
   badge: { label: 'GOAL', tone: 'attention' },
+  // One-shot: armed per objective, disarms itself when the goal concludes,
+  // and is never persisted as the boot/category default — `/goal` once must
+  // not make every future session autonomous.
+  transient: true,
   run: runGoalMode,
 });
 

--- a/packages/plugin-cli/src/session/picker-handlers.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.ts
@@ -460,6 +460,17 @@ function handlePluginAction(id: string, deps: PickerHandlerDeps): void {
     const split = name.indexOf('::');
     const category = split >= 0 ? name.slice(0, split) : name;
     const contribution = split >= 0 ? name.slice(split + 2) : '';
+    // Transient modes (goal) arm per objective and disarm themselves — they
+    // can't be the standing default (boot would also refuse it).
+    if (
+      category === 'mode' &&
+      deps.session.modes.list().find((m) => m.name === contribution)?.transient
+    ) {
+      deps.setSystemNotice(
+        `"${contribution}" is a transient mode (armed per objective) and can't be the standing default`,
+      );
+      return;
+    }
     void (async () => {
       try {
         await admin.setCategoryDefault(category, contribution);
@@ -675,7 +686,10 @@ function handleModeSelected(id: string, deps: PickerHandlerDeps): void {
   try {
     deps.session.modes.setActive(id);
     deps.setSystemNotice(`mode → ${id}`);
-    void setCategoryDefault('mode', id).catch(() => undefined);
+    // Transient modes (goal) arm per objective and disarm themselves — never
+    // persist one as the standing default.
+    const def = deps.session.modes.list().find((m) => m.name === id);
+    if (!def?.transient) void setCategoryDefault('mode', id).catch(() => undefined);
   } catch (err) {
     deps.setSystemNotice(
       `failed to switch mode: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/plugin-cli/src/session/run-slash.test.ts
+++ b/packages/plugin-cli/src/session/run-slash.test.ts
@@ -75,11 +75,13 @@ describe('runSlash /goal', () => {
     return { deps, calls };
   }
 
-  it('switches to goal mode, forces yolo on, and starts work with the objective', () => {
+  it('switches to goal mode and starts work with the objective — no yolo flip', () => {
     const { deps, calls } = goalDeps();
     runSlash('/goal build the widget and make the tests pass', deps);
     expect(calls.setActive).toEqual(['goal']);
-    expect(calls.yolo).toEqual([true]);
+    // Goal mode auto-approves its own tool calls via a run-scoped resolver; a
+    // session-wide yolo flip would outlive the run (permission leak).
+    expect(calls.yolo).toEqual([]);
     expect(calls.submitted).toEqual(['build the widget and make the tests pass']);
   });
 
@@ -87,8 +89,17 @@ describe('runSlash /goal', () => {
     const { deps, calls } = goalDeps();
     runSlash('/goal', deps);
     expect(calls.setActive).toEqual(['goal']);
-    expect(calls.yolo).toEqual([true]);
+    expect(calls.yolo).toEqual([]);
     expect(calls.submitted).toEqual([]);
+  });
+
+  it('never persists goal as the category default (transient mode)', async () => {
+    const { setCategoryDefault } = await import('@moxxy/config');
+    vi.mocked(setCategoryDefault).mockClear();
+    const { deps } = goalDeps();
+    runSlash('/goal build the widget', deps);
+    // `/goal` once must not make every future session boot autonomous.
+    expect(setCategoryDefault).not.toHaveBeenCalled();
   });
 
   it('reports when goal mode is not registered', () => {
@@ -100,6 +111,43 @@ describe('runSlash /goal', () => {
     expect(calls.setActive).toEqual([]);
     expect(calls.submitted).toEqual([]);
     expect(calls.notices.some((n) => typeof n === 'string' && /not available/.test(n))).toBe(true);
+  });
+});
+
+describe('runSlash /mode — transient modes are never persisted as the default', () => {
+  function modeDeps() {
+    const calls = { setActive: [] as string[] };
+    const deps = {
+      ...baseDeps(),
+      session: {
+        id: 'sess-1',
+        commands: { get: () => undefined },
+        modes: {
+          list: () => [{ name: 'goal', transient: true }, { name: 'default' }],
+          setActive: (n: string) => calls.setActive.push(n),
+        },
+      },
+      setSystemNotice: () => undefined,
+    } as unknown as SlashDeps;
+    return { deps, calls };
+  }
+
+  it('/mode goal switches but does not persist (transient)', async () => {
+    const { setCategoryDefault } = await import('@moxxy/config');
+    vi.mocked(setCategoryDefault).mockClear();
+    const { deps, calls } = modeDeps();
+    runSlash('/mode goal', deps);
+    expect(calls.setActive).toEqual(['goal']);
+    expect(setCategoryDefault).not.toHaveBeenCalled();
+  });
+
+  it('/mode default switches AND persists (non-transient)', async () => {
+    const { setCategoryDefault } = await import('@moxxy/config');
+    vi.mocked(setCategoryDefault).mockClear();
+    const { deps, calls } = modeDeps();
+    runSlash('/mode default', deps);
+    expect(calls.setActive).toEqual(['default']);
+    expect(setCategoryDefault).toHaveBeenCalledWith('mode', 'default');
   });
 });
 

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -601,18 +601,23 @@ export function openPluginsPicker(deps: OpenPluginsPickerDeps): void {
 
 /**
  * `/goal <objective>` — the autonomous "deliver the outcome" entry point.
- * Switches to the `goal` mode (which keeps working, re-checking each round,
- * until the objective is verifiably delivered), turns on yolo so routine tool
- * calls don't interrupt the run, and — when an objective is given — starts work
+ * Arms the `goal` mode for ONE objective (it keeps working, re-checking each
+ * round, until the objective is verifiably delivered, then hands the session
+ * back to the previous mode) and — when an objective is given — starts work
  * immediately. Bare `/goal` just arms the mode and waits for the next message.
  * Interrupt anytime with Esc/Ctrl-C.
+ *
+ * Deliberately NOT persisted as the category default (goal is a transient
+ * mode — `/goal` once must not make every future session boot autonomous) and
+ * NO yolo flip: goal mode auto-approves its own tool calls internally via a
+ * scoped resolver, so a session-wide yolo toggle that outlives the run is
+ * both redundant and a permission leak.
  */
 function startGoal(deps: SlashDeps, arg: string): void {
   const objective = arg.trim();
   const GOAL_MODE = 'goal';
   // Missing mode: offer install-on-first-use when the catalog provides it
-  // (post-install the original /goal line re-runs); otherwise say so rather
-  // than silently arming yolo with no behavior change.
+  // (post-install the original /goal line re-runs); otherwise say so.
   if (!deps.session.modes.list().some((m) => m.name === GOAL_MODE)) {
     if (offerModeInstall(deps, GOAL_MODE, objective ? `/goal ${objective}` : '/goal')) return;
     deps.setSystemNotice('goal mode is not available (mode-goal plugin not loaded)');
@@ -620,18 +625,16 @@ function startGoal(deps: SlashDeps, arg: string): void {
   }
   try {
     deps.session.modes.setActive(GOAL_MODE);
-    void setCategoryDefault('mode', GOAL_MODE).catch(() => undefined);
   } catch (err) {
     deps.setSystemNotice(
       `failed to switch to goal mode: ${err instanceof Error ? err.message : String(err)}`,
     );
     return;
   }
-  deps.setYolo(() => true);
   deps.setSystemNotice(
     objective
-      ? '🎯 goal mode — tools auto-approved; working until the objective is delivered. Press Esc to stop.'
-      : '🎯 goal mode on — tools auto-approved. Send your objective as the next message (Esc stops).',
+      ? '🎯 goal run — tools auto-approved until the objective is delivered, then back to normal chat. Press Esc to stop.'
+      : '🎯 goal mode armed — tools auto-approved for the run. Send your objective as the next message (Esc stops).',
   );
   if (objective) deps.submitPrompt(objective);
 }
@@ -695,7 +698,9 @@ export function openModePicker(deps: SlashDeps, arg = ''): void {
       try {
         deps.session.modes.setActive(match.name);
         deps.setSystemNotice(`mode → ${match.name}`);
-        void setCategoryDefault('mode', match.name).catch(() => undefined);
+        // Transient modes (goal) arm per objective and disarm themselves —
+        // never persist one as the standing default.
+        if (!match.transient) void setCategoryDefault('mode', match.name).catch(() => undefined);
       } catch (err) {
         deps.setSystemNotice(
           `failed to switch mode: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -271,7 +271,10 @@ export {
   dispatchToolCall,
   executeToolUses,
   emitRequestsAndDetectStuck,
+  emitRequestsAndNudgeOnStuck,
   type StuckLoopReport,
+  type StuckNudgeReport,
+  type StuckTripInfo,
 } from './tool-dispatch.js';
 
 export type { TokenBudget, CompactContext, CompactorDef } from './compactor.js';

--- a/packages/sdk/src/mode.ts
+++ b/packages/sdk/src/mode.ts
@@ -143,10 +143,21 @@ export interface ModeContext {
    * Request the session switch its active mode AFTER this turn fully drains.
    * Used by terminal workflow modes (BMAD finishing its last phase) to hand
    * control back to a normal mode so the next message isn't trapped in the
-   * workflow. The switch is applied post-turn by the runner; an unknown /
-   * unregistered mode name is ignored. Absent in synthetic test contexts.
+   * workflow, and by {@link ModeDef.transient} modes (goal) to disarm
+   * themselves once their objective concludes. The switch is applied
+   * post-turn by the runner; an unknown / unregistered mode name is ignored.
+   * Absent in synthetic test contexts.
    */
   readonly requestModeSwitch?: (modeName: string) => void;
+  /**
+   * Name of the mode that was active before the current one (per the mode
+   * registry), when known. Lets a {@link ModeDef.transient} mode hand control
+   * back to whatever the user was in before arming it (`/goal` from research
+   * mode reverts to research, not blindly to default). Absent when the
+   * registry has no history (first mode of the session) or in synthetic test
+   * contexts — callers should fall back to `'default'`.
+   */
+  readonly previousModeName?: string;
   emit(event: EmittedEvent): Promise<MoxxyEvent>;
 }
 
@@ -233,6 +244,21 @@ export interface ModeDef {
    * more later) opt in the same way. See {@link isSelectableMode}.
    */
   readonly special?: ModeSpecial;
+  /**
+   * Marks a mode that arms for a SINGLE objective rather than becoming the
+   * session's standing behavior (goal mode). Uniformly across surfaces:
+   *
+   *   - it is never persisted as the category default (`plugins.mode.default`)
+   *     — `/goal` once must not make every future session boot autonomous;
+   *   - a persisted/config default naming it is refused at boot (the
+   *     protected default stays active instead);
+   *   - the mode itself is expected to hand control back (via
+   *     `ctx.requestModeSwitch`, typically to `ctx.previousModeName`) when
+   *     its objective concludes.
+   *
+   * Switching INTO it (picker, `/goal`, `setMode` RPC) still works normally.
+   */
+  readonly transient?: boolean;
   run(ctx: ModeContext): AsyncIterable<MoxxyEvent>;
 }
 

--- a/packages/sdk/src/mode/react-loop.ts
+++ b/packages/sdk/src/mode/react-loop.ts
@@ -8,8 +8,10 @@ import type { StopReason } from '../provider-utils.js';
 import { usageEventFields } from '../token-accounting.js';
 import {
   emitRequestsAndDetectStuck,
+  emitRequestsAndNudgeOnStuck,
   executeToolUses,
   type StuckLoopReport,
+  type StuckTripInfo,
 } from '../tool-dispatch.js';
 import { nextBackoffMs, sleepWithAbort } from './abort-backoff.js';
 import type { CheckpointResult, TurnCheckpoint } from './checkpoint.js';
@@ -91,7 +93,12 @@ export interface StopDirective {
 export interface ReactLoopOptions {
   /** Name stamped on `mode_iteration` events (e.g. `'default'`, `'goal'`). */
   readonly strategyName: string;
-  /** Iteration cap when the context doesn't supply one. Default 500. */
+  /**
+   * Iteration cap when the context doesn't supply one. Default 500. May be
+   * `Number.POSITIVE_INFINITY` for an uncapped loop (goal mode): the run then
+   * ends only via a terminal signal (checkpoint/hook stop, abort, fatal
+   * error) — an explicit `ctx.maxIterations` still takes precedence.
+   */
   readonly defaultMaxIterations?: number;
   /** Prefix for provider-error messages (goal mode uses `'goal: '`). */
   readonly errorPrefix?: string;
@@ -104,16 +111,34 @@ export interface ReactLoopOptions {
   /** Turn-end gates, run in declared order. Omit/empty → plain ReAct loop. */
   readonly checkpoints?: ReadonlyArray<TurnCheckpoint>;
   /**
-   * Hard cap on checkpoint `inject`/`retry` rounds per turn (default 3).
-   * When exhausted the turn ends with the model's answer as-is plus a
-   * visible warning — a permanently-failing gate degrades loudly instead of
-   * looping forever.
+   * Hard cap on checkpoint `inject`/`retry` rounds per idle EPISODE — i.e.
+   * consecutive gate rounds with no tool work between them; the count resets
+   * whenever a tool batch executes (default 3). When exhausted the turn ends
+   * with the model's answer as-is plus a visible warning — a
+   * permanently-failing gate degrades loudly instead of looping forever.
    */
   readonly maxInjections?: number;
   /** Clamp on injected feedback length in characters (default 16_384). */
   readonly maxInjectChars?: number;
-  /** Wording overrides for the stuck-loop abort; sensible defaults from `strategyName`. */
-  readonly stuck?: Partial<StuckLoopReport>;
+  /**
+   * Stuck-loop policy + wording overrides; sensible defaults from
+   * `strategyName`. `action` picks what a detector trip does:
+   *
+   *   - `'abort'` (default): fail the batch and end the turn with a fatal
+   *     error — the historical behavior, right for attended modes where the
+   *     user is present to redirect.
+   *   - `'nudge'`: never stop. The batch still executes (repeated calls are
+   *     usually legitimate work — re-running a failing build between edits),
+   *     a visible warning + `extraOnStuck` events are emitted, the detector
+   *     resets, and `nudgeText` (or a default) rides the next provider call
+   *     as a volatile steer. For unattended modes (goal) where a heuristic
+   *     must never kill the run.
+   */
+  readonly stuck?: Partial<StuckLoopReport> & {
+    readonly action?: 'abort' | 'nudge';
+    /** Volatile steer for `'nudge'` trips; default wording when omitted. */
+    readonly nudgeText?: (info: StuckTripInfo) => string;
+  };
   /**
    * Runs after compaction/elision, before the provider call. May return a
    * volatile user message to ride ONLY the next call (collab's inbox/pause
@@ -365,10 +390,25 @@ export async function* runReactLoop(
       if (directive?.action === 'stop') return;
     }
 
-    const stuck = yield* emitRequestsAndDetectStuck(ctx, toolUses, detector, stuckReport);
-    // A stuck trip kills the turn — it never reaches the checkpoint gate;
-    // gating a turn that is being aborted would just burn a checker run.
-    if (stuck) return;
+    if (opts.stuck?.action === 'nudge') {
+      const trip = yield* emitRequestsAndNudgeOnStuck(ctx, toolUses, detector, {
+        nearHint: stuckReport.nearHint,
+        warnMessage: (info) =>
+          `${opts.strategyName} loop noticed a repetitive pattern: tool "${info.toolName}" called ` +
+          `${info.count} times ${info.how} — steering the model to change approach (the run continues).`,
+        ...(stuckReport.extraOnStuck ? { extraOnStuck: stuckReport.extraOnStuck } : {}),
+      });
+      if (trip) {
+        const nudge = opts.stuck.nudgeText?.(trip) ?? defaultStuckNudge(trip);
+        // Ride the NEXT provider call; merge with anything already pending.
+        pendingVolatileText = pendingVolatileText ? `${pendingVolatileText}\n\n${nudge}` : nudge;
+      }
+    } else {
+      const stuck = yield* emitRequestsAndDetectStuck(ctx, toolUses, detector, stuckReport);
+      // A stuck trip kills the turn — it never reaches the checkpoint gate;
+      // gating a turn that is being aborted would just burn a checker run.
+      if (stuck) return;
+    }
 
     if (text || stopReason === 'end_turn' || toolUses.length === 0) {
       // A completion with no text, no tool uses, and a non-natural stop (e.g.
@@ -411,6 +451,13 @@ export async function* runReactLoop(
       continue;
     }
     consecutiveIdle = 0;
+    // The injection budget is per idle-EPISODE, not per turn: it exists to
+    // stop a permanently-failing gate from looping a turn that makes no
+    // progress. Once the model does real tool work again the episode is over —
+    // without this reset, a long unattended run died on its Nth *spread-out*
+    // idle round ("checkpoint budget exhausted") even though every earlier
+    // nudge had successfully put the model back to work.
+    injectionsUsed = 0;
 
     // Execute whenever the model requested tools, regardless of stopReason.
     // Providers vary in how reliably they report `stopReason: 'tool_use'`;
@@ -572,6 +619,14 @@ async function* runCheckpointGate(
     }
   }
   return { kind: 'end' };
+}
+
+function defaultStuckNudge(trip: StuckTripInfo): string {
+  return (
+    `You have called the tool \`${trip.toolName}\` ${trip.count} times ${trip.how}. ` +
+    `Repeating the same call will not produce a different result. Step back, reassess what ` +
+    `you learned from the previous attempts, and take a DIFFERENT next action or approach.`
+  );
 }
 
 function buildStuckReport(opts: ReactLoopOptions): StuckLoopReport {

--- a/packages/sdk/src/mode/stuck-loop.ts
+++ b/packages/sdk/src/mode/stuck-loop.ts
@@ -32,6 +32,13 @@ export interface StuckLoopDetector {
   readonly repeatThreshold: number;
   /** Record the call and report whether the loop guard should trip. */
   record(toolName: string, input: unknown): StuckSignal;
+  /**
+   * Clear both sliding windows. Used by the nudge (steer-don't-stop) stuck
+   * policy: after a trip is surfaced to the model, the detector starts a fresh
+   * episode — otherwise every subsequent call inside the still-full window
+   * would re-trip and re-nudge on each iteration.
+   */
+  reset(): void;
 }
 
 /**
@@ -101,6 +108,10 @@ export function createStuckLoopDetector(opts: LoopGuardSettings = {}): StuckLoop
         if (nearCount >= nearThreshold) return { stuck: true, count: nearCount, kind: 'near' };
       }
       return { stuck: false, count: Math.max(exactCount, nearCount), kind: 'exact' };
+    },
+    reset(): void {
+      recent.length = 0;
+      recentNear.length = 0;
     },
   };
 }

--- a/packages/sdk/src/tool-dispatch.test.ts
+++ b/packages/sdk/src/tool-dispatch.test.ts
@@ -9,7 +9,10 @@ import {
   dispatchToolCall,
   executeToolUses,
   emitRequestsAndDetectStuck,
+  emitRequestsAndNudgeOnStuck,
   type StuckLoopReport,
+  type StuckNudgeReport,
+  type StuckTripInfo,
 } from './tool-dispatch.js';
 
 /**
@@ -211,5 +214,79 @@ describe('emitRequestsAndDetectStuck — stuck trip', () => {
     );
     expect(stop).toBe(false);
     expect(events.filter((e) => e.type === 'tool_result')).toHaveLength(0);
+  });
+});
+
+describe('emitRequestsAndNudgeOnStuck — steer, never stop', () => {
+  const nudgeReport: StuckNudgeReport = {
+    nearHint: 'with nearly identical input',
+    warnMessage: ({ toolName, count }) => `repetitive: ${toolName} x${count}`,
+    extraOnStuck: ({ toolName }) => [
+      {
+        type: 'plugin_event',
+        sessionId: asSessionId('s1'),
+        turnId: asTurnId('t1'),
+        source: 'plugin',
+        pluginId: 'test' as never,
+        subtype: 'test_stuck',
+        payload: { toolName },
+      },
+    ],
+  };
+
+  function nudgeDetector(trip: StuckSignal): StuckLoopDetector & { resets: number } {
+    const d = {
+      resets: 0,
+      record: () => trip,
+      reset: () => {
+        d.resets += 1;
+      },
+    };
+    return d as unknown as StuckLoopDetector & { resets: number };
+  }
+
+  it('on a trip: warns (retryable, not fatal), emits extra events, resets the detector, and does NOT synthesize results', async () => {
+    const { ctx, events } = makeCtx();
+    const det = nudgeDetector({ stuck: true, kind: 'exact', count: 8 });
+    const trip = (await drain(
+      emitRequestsAndNudgeOnStuck(ctx, [tool], det, nudgeReport),
+    )) as StuckTripInfo | null;
+
+    // Trip info is returned for the loop's volatile nudge…
+    expect(trip).toEqual({ toolName: 'Read', count: 8, kind: 'exact', how: 'with identical input' });
+    // …the detector started a fresh episode…
+    expect(det.resets).toBe(1);
+    // …the request stands (the batch will execute — no synthesized results)…
+    expect(events.some((e) => e.type === 'tool_call_requested')).toBe(true);
+    expect(events.filter((e) => e.type === 'tool_result')).toHaveLength(0);
+    // …the warning is visible but NON-fatal, with the extra event before it.
+    const err = events.find((e) => e.type === 'error') as
+      | { kind: string; message: string }
+      | undefined;
+    expect(err?.kind).toBe('retryable');
+    expect(err?.message).toBe('repetitive: Read x8');
+    expect(events.some((e) => e.type === 'plugin_event' && e.subtype === 'test_stuck')).toBe(true);
+  });
+
+  it('a near trip uses the report nearHint wording', async () => {
+    const { ctx } = makeCtx();
+    const trip = (await drain(
+      emitRequestsAndNudgeOnStuck(
+        ctx,
+        [tool],
+        nudgeDetector({ stuck: true, kind: 'near', count: 5 }),
+        nudgeReport,
+      ),
+    )) as StuckTripInfo | null;
+    expect(trip?.how).toBe('with nearly identical input');
+  });
+
+  it('returns null and stays quiet when the detector does not trip', async () => {
+    const { ctx, events } = makeCtx();
+    const det = nudgeDetector({ stuck: false, kind: 'exact', count: 0 });
+    const trip = await drain(emitRequestsAndNudgeOnStuck(ctx, [tool], det, nudgeReport));
+    expect(trip).toBeNull();
+    expect(det.resets).toBe(0);
+    expect(events.filter((e) => e.type !== 'tool_call_requested')).toHaveLength(0);
   });
 });

--- a/packages/sdk/src/tool-dispatch.ts
+++ b/packages/sdk/src/tool-dispatch.ts
@@ -286,3 +286,80 @@ export async function* emitRequestsAndDetectStuck(
   }
   return false;
 }
+
+/** A stuck-detector trip, as surfaced to the nudge policy. */
+export interface StuckTripInfo {
+  readonly toolName: string;
+  readonly count: number;
+  readonly kind: StuckSignal['kind'];
+  /** Human phrasing of HOW it repeated ("with identical input" / the near hint). */
+  readonly how: string;
+}
+
+/** Wording + extra events for {@link emitRequestsAndNudgeOnStuck}. */
+export interface StuckNudgeReport {
+  /** Explanation for a `near` match (an `exact` match always reads
+   *  "with identical input"). */
+  readonly nearHint: string;
+  /** Build the visible (non-fatal) warning surfaced to the user on a trip. */
+  readonly warnMessage: (info: StuckTripInfo) => string;
+  /** Extra events to emit right before the warning — goal mode surfaces a
+   *  `goal_stuck` plugin_event here. */
+  readonly extraOnStuck?: StuckLoopReport['extraOnStuck'];
+}
+
+/**
+ * The steer-don't-stop counterpart of {@link emitRequestsAndDetectStuck}: emit
+ * a `tool_call_requested` per call and feed the detector, but a trip NEVER
+ * aborts the turn — the batch still executes (the repeated calls are usually
+ * legitimate work, e.g. re-running a failing build between edits). Instead the
+ * trip is surfaced as a visible warning + the report's extra events, the
+ * detector is reset (fresh episode — no re-trip on every subsequent call while
+ * the window is still full), and the trip info is returned so the loop can
+ * steer the model with a volatile nudge on its next provider call.
+ *
+ * Used by modes that must never kill an unattended run on a repetition
+ * heuristic (goal mode). Returns the first trip of the batch, or null.
+ */
+export async function* emitRequestsAndNudgeOnStuck(
+  ctx: ModeContext,
+  toolUses: ReadonlyArray<CollectedToolUse>,
+  detector: StuckLoopDetector,
+  report: StuckNudgeReport,
+): AsyncGenerator<MoxxyEvent, StuckTripInfo | null, unknown> {
+  let trip: StuckTripInfo | null = null;
+  for (const t of toolUses) {
+    yield await ctx.emit({
+      type: 'tool_call_requested',
+      sessionId: ctx.sessionId,
+      turnId: ctx.turnId,
+      source: 'model',
+      callId: asToolCallId(t.id),
+      name: t.name,
+      input: t.input,
+    });
+    const sig = detector.record(t.name, t.input);
+    if (!sig.stuck || trip) continue;
+    trip = {
+      toolName: t.name,
+      count: sig.count,
+      kind: sig.kind,
+      how: sig.kind === 'near' ? report.nearHint : 'with identical input',
+    };
+    detector.reset();
+    if (report.extraOnStuck) {
+      for (const e of report.extraOnStuck({ toolName: t.name, count: sig.count, kind: sig.kind })) {
+        yield await ctx.emit(e);
+      }
+    }
+    yield await ctx.emit({
+      type: 'error',
+      sessionId: ctx.sessionId,
+      turnId: ctx.turnId,
+      source: 'system',
+      kind: 'retryable',
+      message: report.warnMessage(trip),
+    });
+  }
+  return trip;
+}


### PR DESCRIPTION
## Why

Goal mode was failing at its one job — delivering value on request:

1. **Guardrails killed real runs mid-delivery.** The 150-iteration cap, the 4M token budget, and the stuck-loop **fatal abort** (whose near-repeat heuristic trips on a perfectly legitimate edit→build→test cycle — same `command` 10× in a 24-call window) all ended unattended runs before the objective was done. On top of that, a real bug: the checkpoint injection budget never reset within a turn, so the run died on its 4th *spread-out* idle round with "checkpoint budget exhausted" even though every earlier nudge had successfully put the model back to work.
2. **The mode never let go.** `/goal` persisted `goal` as the config-wide category default — every future session **booted** into an autonomous, auto-approving mode — and flipped session-wide yolo that nothing ever reverted. Desktop and mobile flipped `setAutoApprove(true)` the same way. After `goal_complete`, the next casual message launched another autonomous run.

## What

**No guardrails (goal mode only).** A goal run now ends ONLY via: `goal_complete`, `goal_abandon`, the idle-stall soft completion, user abort, or a genuinely fatal error (un-compactable overflow, provider giving up after bounded retries — those stay: they're provider protection, not heuristics).
- No iteration cap by default (an explicit `ctx.maxIterations` from an embedder is still honored); token budget removed.
- Stuck trips **steer instead of stop**: new `stuck.action: 'nudge'` policy in `runReactLoop` — the batch still executes, a visible non-fatal warning + `goal_stuck` event are emitted, the detector resets, and a volatile nudge rides the next provider call (with a `goal_abandon` escape hatch in the wording).
- Checkpoint injection budget is now **per idle-episode** (resets when a tool batch executes) — it bounds no-progress wedges, not long productive runs.

**One-shot semantics.** New `ModeDef.transient` flag; goal mode sets it.
- On `goal_complete` or idle-stall, the loop hands the session back via the pre-existing `ctx.requestModeSwitch` to the mode active before arming (new `ModeRegistry` previous-mode tracking + `ModeContext.previousModeName`). `/goal` from research mode reverts to research, not blindly to default.
- `goal_abandon` / fatal / user abort keep the mode **armed** — the model asked for something, so the user's reply resumes the autonomous run (the abandon message says so).
- `/goal` no longer persists the category default nor flips yolo; desktop + mobile no longer flip `setAutoApprove`. The run's own scoped resolver auto-approves (user `policyCheck` deny rules still consulted, unchanged).
- Transient modes are refused as boot defaults (protects users with a leftover `plugins.mode.default: goal` in config) and are never persisted by `/mode` or the pickers.

## Tests

- mode-goal: stuck-trip steers + completes (no orphans, nudge visible to the model), 155-iteration run past the old cap, spread-out idles never exhaust the budget, revert-on-complete / revert-on-stall / stay-armed-on-abandon / stay-armed-on-abort; token-budget tests removed with the feature.
- sdk: `emitRequestsAndNudgeOnStuck` unit coverage (warn-not-fatal, no synthesized results, detector reset, near-hint wording).
- mode-default gate: injection budget resets across idle episodes.
- core: `ModeRegistry` previous-mode tracking (incl. same-name re-arm).
- cli: transient mode refused as boot default; plugin-cli: `/goal` and `/mode` persistence guards.

Full gate green (build / typecheck / lint / test / check:deps); CLI smoke ok. `.ai/skills/add-a-mode` updated to the new conventions; TECH_DEBT ledger entry + a standing note recording the no-spend-ceiling decision.