### PR TITLE
fix(desktop): make plugins-seed bundling script work on Windows runners

### DIFF
--- a/.changeset/fix-plugins-seed-windows-path.md
+++ b/.changeset/fix-plugins-seed-windows-path.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/desktop': patch
+---
+
+Fix the plugins-seed bundling script on Windows: resolve the repo root via `fileURLToPath` (the `url.pathname` form produced a doubled drive letter, `D:\D:\a\...`, crashing the desktop release job) and spawn pnpm/npm through the shell so their `.cmd` shims work on Windows runners.

--- a/apps/desktop/scripts/bundle-plugins-seed.mjs
+++ b/apps/desktop/scripts/bundle-plugins-seed.mjs
@@ -22,6 +22,7 @@ import { execFileSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /** On-demand plugins seeded into the desktop. Extend as batches unbundle. */
 const SEED_PLUGINS = [
@@ -63,12 +64,22 @@ const SEED_PLUGINS = [
  *  from local tarballs (usage-stats→core, oauth→vault, everything→sdk). */
 const CLOSURE = ['sdk', 'core', 'config', 'channel-kit', 'plugin-vault', 'plugin-tunnel-proxy', 'e2e', 'plugin-provider-openai-codex'];
 
-const repo = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+// fileURLToPath, NOT url.pathname — pathname on Windows is `/D:/a/...`, which
+// path.resolve prefixes with the drive again (`D:\D:\a\...`).
+const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 const seedDir = path.join(repo, 'apps/desktop/resources/plugins-seed');
 const tarDir = mkdtempSync(path.join(tmpdir(), 'moxxy-seed-tars-'));
 
+// On Windows pnpm/npm are .cmd shims Node refuses to spawn directly
+// (CVE-2024-27980) — route through the shell there, quoting spaced args.
+const isWin = process.platform === 'win32';
+const winArg = (a) => (/\s/.test(a) ? `"${a}"` : a);
 const run = (cmd, args, opts = {}) =>
-  execFileSync(cmd, args, { stdio: ['ignore', 'inherit', 'inherit'], ...opts });
+  execFileSync(cmd, isWin ? args.map(winArg) : args, {
+    stdio: ['ignore', 'inherit', 'inherit'],
+    shell: isWin,
+    ...opts,
+  });
 
 rmSync(seedDir, { recursive: true, force: true });
 mkdirSync(seedDir, { recursive: true });


### PR DESCRIPTION
## Problem

The desktop release job died on the Windows runner in the **Bundle plugins seed** step:

```
Error: ENOENT: no such file or directory, mkdir 'D:\D:\a\moxxy\moxxy\apps\desktop\resources\plugins-seed'
```

`bundle-plugins-seed.mjs` resolved the repo root from `new URL(import.meta.url).pathname`, which on Windows yields `/D:/a/...`; `path.resolve` treats that as drive-relative and prefixes the current drive again → `D:\D:\a\...`. This was the first Windows release since the seed step landed (#399), hence the late surfacing.

## Fix

- Resolve the repo root via `fileURLToPath(import.meta.url)` (same idiom as `scripts/build-app-bundle.mjs`, which already survives the Windows runner).
- Spawn `pnpm`/`npm` through the shell on Windows — they are `.cmd` shims there, which Node refuses to `execFileSync` directly (CVE-2024-27980), so the very next line would have failed with `EINVAL`. Args with spaces are quoted for cmd.exe; POSIX spawning is byte-for-byte unchanged.

## Verification

- Simulated the Windows resolution with `path.win32`: old code → `\D:\a\moxxy\moxxy` (drive-relative, becomes `D:\D:\...` at fs time); new code → `D:\a\moxxy\moxxy`. POSIX parity confirmed (`fileURLToPath === pathname` for POSIX file URLs).
- Ran the script end-to-end on macOS after a full `pnpm build` (84/84 tasks): 27 plugins + closure assembled, 269 packages installed, output path unchanged.
- `eslint` clean on the script.

Changeset bumps `@moxxy/desktop` (patch) so the next release cuts a desktop installer with the fixed step.