### PR TITLE
feat(desktop): route the mic through the runner's active transcriber (local STT) with Codex fallback

### DIFF
--- a/.changeset/desktop-local-mic.md
+++ b/.changeset/desktop-local-mic.md
@@ -1,0 +1,34 @@
+---
+'@moxxy/desktop': minor
+'@moxxy/desktop-host': patch
+'@moxxy/desktop-ipc-contract': patch
+---
+
+feat(desktop): route the mic through the runner's active transcriber (local STT) with Codex fallback
+
+The desktop microphone was hardwired to the in-process Codex cloud transcriber.
+It now prefers the RUNNER's active transcriber — a runner-side STT plugin such
+as the local Whisper `@moxxy/plugin-stt-local` — so with that plugin installed
+and active the desktop mic transcribes **fully offline**. Without it, behavior
+is byte-identical to before.
+
+- `session.transcribe` (desktop-host IPC) tries the runner's active transcriber
+  first via the existing `Transcribe` runner RPC (`RemoteSession.transcribers.
+  tryGetActive()`, mirroring how `session.synthesize` routes TTS). It falls back
+  to the in-process Codex transcriber only when the runner reports **no active
+  transcriber**. An error from a *present-but-failing* runner transcriber (a
+  broken local model) surfaces to the user instead of silently falling through
+  to the cloud — "none active" and "failed" are distinguished.
+- `session.hasTranscriber` (the mic-affordance gate) is now true when EITHER the
+  runner reports an active transcriber (read off the existing
+  `SessionInfo.activeTranscriber` snapshot — no new RPC) OR the Codex OAuth vault
+  probe passes. Keyed on the ACTIVE transcriber so it stays in lockstep with the
+  transcribe routing.
+- `session.transcribe` gains an optional `workspaceId` (like `session.synthesize`)
+  so a background workspace's mic targets the right runner; the renderer is
+  unchanged and defaults to the active workspace.
+
+No runner-protocol change: the `Transcribe` RPC, its handler, and the
+`RemoteSession` transcriber proxy already existed and are unchanged, so
+`RUNNER_PROTOCOL_VERSION` is not bumped. The mic capture's `audio/x-moxxy-pcm16-
+24khz` (PCM16 24 kHz) mimeType flows through to whichever transcriber unchanged.

--- a/packages/desktop-host/src/ipc/session.test.ts
+++ b/packages/desktop-host/src/ipc/session.test.ts
@@ -35,7 +35,19 @@ vi.mock('electron', () => ({
   dialog: { showOpenDialog: async () => ({ canceled: true, filePaths: [] }) },
   BrowserWindow: { getFocusedWindow: () => null, getAllWindows: () => [] },
 }));
-vi.mock('../in-process-plugins', () => ({ buildInProcessPlugins: () => ({}) }));
+// Control the in-process (Codex) transcriber + vault the voice FALLBACK path
+// uses. getInProcessPlugins() caches the bag on first access, so the fake bag's
+// methods delegate to stable vi.fns each test configures — no cache reset needed.
+const { codexTranscribe, vaultGet } = vi.hoisted(() => ({
+  codexTranscribe: vi.fn(),
+  vaultGet: vi.fn(),
+}));
+vi.mock('../in-process-plugins', () => ({
+  buildInProcessPlugins: () => ({
+    vault: { get: vaultGet },
+    transcriber: { name: 'openai-codex', transcribe: codexTranscribe },
+  }),
+}));
 
 import type { CommandBus } from '@moxxy/desktop-ipc-contract/bus';
 import type { IpcCommandName, IpcEvents, SessionInfo } from '@moxxy/desktop-ipc-contract';
@@ -204,6 +216,125 @@ describe('session.runTurn handler', () => {
     } finally {
       drivers.delete('ws-inline');
     }
+  });
+});
+
+describe('session.transcribe / hasTranscriber fallback chain', () => {
+  const WS = 'ws-voice';
+  const AUDIO = 'AAAA'; // valid 3-byte base64
+  const MIME = 'audio/x-moxxy-pcm16-24khz'; // the desktop mic capture tag
+
+  // A pool whose single workspace's supervisor exposes the given fake remote
+  // (or null to model "not connected to a runner").
+  function makePool(remote: unknown): RunnerPool {
+    return {
+      activeWorkspaceId: () => WS,
+      get: (id: string) =>
+        id === WS ? ({ remote: () => remote } as unknown as RunnerSupervisor) : null,
+    } as unknown as RunnerPool;
+  }
+
+  function register(pool: RunnerPool): Map<string, Handler> {
+    const { bus, handlers } = fakeBus();
+    setActiveBus(bus);
+    registerSessionHandlers(pool);
+    return handlers;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes transcribe to the runner active transcriber (offline local STT), not Codex', async () => {
+    const runnerTranscribe = vi.fn(async () => ({ text: 'hello from the runner' }));
+    const remote = {
+      getInfo: () => ({ ...sessionInfo(WS), activeTranscriber: 'stt-local' }),
+      transcribers: { tryGetActive: () => ({ name: 'stt-local', transcribe: runnerTranscribe }) },
+    };
+    const handlers = register(makePool(remote));
+
+    await expect(
+      handlers.get('session.transcribe')!({ workspaceId: WS, audioBase64: AUDIO, mimeType: MIME }),
+    ).resolves.toBe('hello from the runner');
+    expect(runnerTranscribe).toHaveBeenCalledTimes(1);
+    // The mic's mimeType flows through to the runner transcriber unchanged.
+    expect(runnerTranscribe.mock.calls[0]![1]).toEqual({ mimeType: MIME });
+    expect(codexTranscribe).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the in-process Codex transcriber when the runner has none active', async () => {
+    codexTranscribe.mockResolvedValue({ text: 'from codex' });
+    const remote = {
+      getInfo: () => sessionInfo(WS), // activeTranscriber: null
+      transcribers: { tryGetActive: () => null },
+    };
+    const handlers = register(makePool(remote));
+
+    await expect(
+      handlers.get('session.transcribe')!({ workspaceId: WS, audioBase64: AUDIO, mimeType: MIME }),
+    ).resolves.toBe('from codex');
+    expect(codexTranscribe).toHaveBeenCalledTimes(1);
+    expect(codexTranscribe.mock.calls[0]![1]).toEqual({ mimeType: MIME });
+  });
+
+  it('falls back to Codex when not connected to a runner at all', async () => {
+    codexTranscribe.mockResolvedValue({ text: 'from codex, no runner' });
+    const handlers = register(makePool(null)); // supervisor.remote() → null
+
+    await expect(
+      handlers.get('session.transcribe')!({ workspaceId: WS, audioBase64: AUDIO }),
+    ).resolves.toBe('from codex, no runner');
+    expect(codexTranscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces an error from a present-but-failing runner transcriber (no silent Codex fallback)', async () => {
+    const runnerTranscribe = vi.fn(async () => {
+      throw new Error('whisper model missing');
+    });
+    const remote = {
+      getInfo: () => ({ ...sessionInfo(WS), activeTranscriber: 'stt-local' }),
+      transcribers: { tryGetActive: () => ({ name: 'stt-local', transcribe: runnerTranscribe }) },
+    };
+    const handlers = register(makePool(remote));
+
+    await expect(
+      handlers.get('session.transcribe')!({ workspaceId: WS, audioBase64: AUDIO }),
+    ).rejects.toThrow('whisper model missing');
+    // A broken local model must NOT quietly fall through to the cloud path.
+    expect(codexTranscribe).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed base64 payload at the handler boundary', async () => {
+    const handlers = register(makePool(null));
+    await expect(
+      handlers.get('session.transcribe')!({ audioBase64: 'not base64!!!' }),
+    ).rejects.toThrow(/base64/);
+    expect(codexTranscribe).not.toHaveBeenCalled();
+  });
+
+  it('hasTranscriber is true when the runner reports an active transcriber (no vault probe)', async () => {
+    const remote = { getInfo: () => ({ ...sessionInfo(WS), activeTranscriber: 'stt-local' }) };
+    const handlers = register(makePool(remote));
+
+    await expect(handlers.get('session.hasTranscriber')!()).resolves.toBe(true);
+    expect(vaultGet).not.toHaveBeenCalled();
+  });
+
+  it('hasTranscriber falls back to the Codex vault probe when the runner has none active', async () => {
+    vaultGet.mockResolvedValue('a-refresh-token');
+    const remote = { getInfo: () => sessionInfo(WS) }; // activeTranscriber: null
+    const handlers = register(makePool(remote));
+
+    await expect(handlers.get('session.hasTranscriber')!()).resolves.toBe(true);
+    expect(vaultGet).toHaveBeenCalledWith('oauth/openai-codex/refresh_token');
+  });
+
+  it('hasTranscriber is false when neither a runner transcriber nor Codex creds exist', async () => {
+    vaultGet.mockResolvedValue(null);
+    const remote = { getInfo: () => sessionInfo(WS) };
+    const handlers = register(makePool(remote));
+
+    await expect(handlers.get('session.hasTranscriber')!()).resolves.toBe(false);
   });
 });
 

--- a/packages/desktop-host/src/ipc/session.ts
+++ b/packages/desktop-host/src/ipc/session.ts
@@ -5,8 +5,11 @@
  * {@link SessionDriver} in the {@link drivers} registry; provider / mode
  * switches and slash commands talk straight to the {@link RemoteSession}
  * (then settle via {@link waitForSessionState}). Voice (hasTranscriber /
- * transcribe) is served by the in-process Codex transcriber rather than
- * a runner round-trip, mirroring the TUI's self-host setup.
+ * transcribe) prefers the RUNNER's active transcriber — a runner-side STT
+ * plugin (e.g. the local Whisper `@moxxy/plugin-stt-local`) so the desktop
+ * mic can transcribe fully offline — and falls back to the in-process Codex
+ * transcriber when the runner has none active (byte-identical to the pre-
+ * local-STT behavior, mirroring the TUI's self-host setup).
  *
  * Every command accepts an optional `workspaceId` and defaults to the
  * pool's active workspace so the renderer can target a background
@@ -255,13 +258,19 @@ export function registerSessionHandlers(pool: RunnerPool): void {
     }
   });
   handle('session.hasTranscriber', async () => {
-    // Voice is wired through the desktop's *in-process* Codex
-    // transcriber (mirrors the TUI's self-host setup: same vault,
-    // same plugin class). Affordance gating: probe the vault for
-    // ANY entry under the Codex OAuth namespace
-    // (`oauth/openai-codex/*`) — same key prefix the Codex login
-    // command writes to. If something's stored, the user has a
-    // login → show the mic.
+    // The mic affordance lights up when EITHER voice path can serve a
+    // transcribe:
+    //   1. the RUNNER has an active transcriber (a runner-side STT plugin such
+    //      as the local Whisper `@moxxy/plugin-stt-local`, adopted via the
+    //      `plugins.transcriber.default` config) — read straight off the
+    //      RemoteSession's info snapshot, no extra RPC; or
+    //   2. stored Codex OAuth creds exist for the in-process fallback path.
+    // Checking `activeTranscriber` (not the "any registered" `hasTranscriber`
+    // flag) keeps this in lockstep with `session.transcribe` below, which
+    // routes through `transcribers.tryGetActive()` — also keyed on the ACTIVE
+    // transcriber.
+    const remote = resolveSupervisor(pool)?.remote();
+    if (remote?.getInfo().activeTranscriber) return true;
     try {
       const { vault } = getInProcessPlugins();
       // Stored Codex creds are written under `oauth/openai-codex/...`
@@ -274,20 +283,33 @@ export function registerSessionHandlers(pool: RunnerPool): void {
       return false;
     }
   });
-  handle('session.transcribe', async ({ audioBase64, mimeType }) => {
-    // Run the transcribe through the in-process Codex transcriber —
-    // same plugin class, same vault, identical to the TUI's voice
-    // path. No round-trip through the runner socket needed (and no
-    // RemoteSession.setActive throw to work around).
-    const { transcriber } = getInProcessPlugins();
+  handle('session.transcribe', async ({ workspaceId, audioBase64, mimeType }) => {
     if (typeof audioBase64 !== 'string' || !BASE64_RE.test(audioBase64)) {
       throw new IpcError('invalid-payload', 'audioBase64 is not valid base64');
     }
     const audio = Buffer.from(audioBase64, 'base64');
-    const result = await transcriber.transcribe(
-      audio,
-      mimeType ? { mimeType } : undefined,
-    );
+    const opts = mimeType ? { mimeType } : undefined;
+    // Prefer the RUNNER's active transcriber (like `session.synthesize` routes
+    // TTS): a runner-side STT plugin (e.g. the local Whisper transcriber) lets
+    // the desktop mic transcribe fully offline. `tryGetActive()` returns the
+    // proxy when the runner reports an active transcriber, else null.
+    const runnerTranscriber = resolveSupervisor(pool, workspaceId)
+      ?.remote()
+      ?.transcribers.tryGetActive();
+    if (runnerTranscriber) {
+      // A PRESENT-but-failing runner transcriber (a broken local model) surfaces
+      // its error to the user — we deliberately do NOT silently fall back to the
+      // cloud Codex path here, which would mask the breakage. Only the "no
+      // active transcriber" case (tryGetActive() === null, handled below) falls
+      // back.
+      const result = await runnerTranscriber.transcribe(new Uint8Array(audio), opts);
+      return result.text;
+    }
+    // No active runner transcriber → in-process Codex transcriber: same plugin
+    // class, same vault, identical to the TUI's self-host voice path. This is
+    // byte-identical to the behavior before local-STT routing.
+    const { transcriber } = getInProcessPlugins();
+    const result = await transcriber.transcribe(audio, opts);
     return result.text;
   });
   handle('session.synthesize', async ({ workspaceId, text }) => {

--- a/packages/desktop-ipc-contract/src/commands.ts
+++ b/packages/desktop-ipc-contract/src/commands.ts
@@ -293,8 +293,9 @@ export interface IpcCommands {
     readonly notice?: string;
     readonly message?: string;
   }>;
-  /** True when the runner has an active transcriber plugin. UI uses
-   *  this to enable/disable the mic button. */
+  /** True when a voice transcribe can be served: the runner has an active
+   *  transcriber plugin (e.g. local Whisper), OR stored Codex OAuth creds back
+   *  the in-process fallback. UI uses this to enable/disable the mic button. */
   'session.hasTranscriber': () => Promise<boolean>;
   /** The globally-active collaboration (only one runs at a time), or inactive.
    *  Read from the single-flight lock file so it spans all workspaces' runners;
@@ -342,9 +343,13 @@ export interface IpcCommands {
   'collab.history': (args?: { limit?: number }) => Promise<
     ReadonlyArray<CollabRunSummary>
   >;
-  /** Forward an audio blob to the runner's active transcriber.
-   *  Audio must be base64-encoded; returns the recognised text. */
+  /** Transcribe an audio blob to text. Routes to the runner's active
+   *  transcriber first (offline local STT when a plugin like `stt-local` is
+   *  active) and falls back to the in-process Codex transcriber when the runner
+   *  has none. Audio must be base64-encoded; returns the recognised text.
+   *  `workspaceId` targets a specific workspace's runner (defaults to active). */
   'session.transcribe': (args: {
+    workspaceId?: string;
     audioBase64: string;
     mimeType?: string;
   }) => Promise<string>;

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -195,6 +195,7 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
   'provider.login.answer': z.object({ loginId, value: z.string().max(8192) }),
   'provider.login.cancel': z.object({ loginId }),
   'session.transcribe': z.object({
+    workspaceId: optionalWorkspace,
     audioBase64: base64,
     mimeType: z.string().max(128).optional(),
   }),


### PR DESCRIPTION
## What

The desktop microphone was hardwired to the **in-process Codex cloud transcriber**. It now prefers the **runner's active transcriber** — a runner-side STT plugin such as the local Whisper `@moxxy/plugin-stt-local` (merged in #438) — and falls back to Codex only when the runner has none active.

**With `@moxxy/plugin-stt-local` installed and set as the active transcriber, the desktop mic now transcribes fully offline. Without it, behavior is byte-identical to today.**

This completes the local-voice work: TTS already routed through the runner's synthesizer (`session.synthesize`); the mic now mirrors that for STT.

## Fallback-chain semantics (as shipped)

`session.transcribe`:

| Runner state | Behavior |
| --- | --- |
| Runner has an **active** transcriber (e.g. `stt-local`) | Transcribe on the runner via the `Transcribe` RPC (`RemoteSession.transcribers.tryGetActive()`). Fully offline when the plugin is local. |
| Runner has **no active** transcriber (or not connected) | Fall back to the in-process **Codex** transcriber (same vault + plugin class as the TUI's self-host voice path). |
| Runner's active transcriber is **present but throws** (broken local model, missing weights) | **Error surfaces to the user.** No silent fall-through to the cloud — "none active" and "failed" are distinguished. |

`session.hasTranscriber` (the mic-affordance gate) is true when **either**:
- the runner reports an **active** transcriber (read straight off the existing `SessionInfo.activeTranscriber` snapshot — **no new RPC**), **or**
- the Codex OAuth vault probe (`oauth/openai-codex/refresh_token`) passes.

It is keyed on the **active** transcriber (not the "any registered" `hasTranscriber` flag) so the affordance stays in lockstep with what `transcribe` will actually route to.

`session.transcribe` gains an optional `workspaceId` (like `session.synthesize`) so a background workspace's mic targets the right runner; the renderer is unchanged and defaults to the active workspace.

## Protocol change / version bump

**None.** The runner `Transcribe` RPC — `RunnerMethod.Transcribe`, `transcribeParamsSchema` (with the `MAX_TRANSCRIBE_AUDIO_B64_BYTES` = 32 MB base64 cap), `handleTranscribe`, its `server.ts` dispatch, and the `RemoteSession.transcribers` proxy (`transcribe()` works; `setActive()` still throws — switching stays runner-side) — **already existed and are unchanged**. This PR only wires the desktop IPC layer to use them. Therefore `RUNNER_PROTOCOL_VERSION` is **not** bumped and no floor lockstep change is needed. (The scout's premise that "`RemoteSession.transcribers.setActive` throwing means the desktop can't drive runner-side transcribers" was inaccurate — the `transcribe()` proxy has worked since the RPC's inception; the desktop simply never called it.)

## Audio format

The desktop mic capture decodes to raw PCM16 and stamps `audio/x-moxxy-pcm16-24khz` (`MOXXY_PCM16_24KHZ_MIME`) as the mimeType (MediaRecorder webm/opus is only the intermediate). That mimeType flows through `session.transcribe` -> the `Transcribe` RPC -> the transcriber unchanged. `stt-local`'s `decode.ts` explicitly handles this tag (int16 -> float32 -> resample), and the Codex path handles it too — so both endpoints work.

## Tests

- **Runner side (pre-existing, unchanged):** `protocol.test.ts` covers the `transcribe` schema round-trip + size cap; `integration.test.ts` exercises the full runner-transcriber proxy end-to-end over a real socket.
- **New — desktop fallback chain** (`packages/desktop-host/src/ipc/session.test.ts`, 8 new cases): runner-first routing (not Codex); fallback-on-none; fallback when not connected; **error surfaces on a present-but-failing runner transcriber (no silent Codex fallback)**; malformed-base64 rejection; `hasTranscriber` true on runner-active (no vault probe), true on Codex-vault fallback, and false when neither.

## Gate status

- `pnpm build` OK, `pnpm typecheck` OK, `pnpm lint` OK (0 errors), `pnpm check:deps` OK
- `pnpm test` OK for all touched packages. The only full-suite red is `@moxxy/isolator-subprocess`'s timing-sensitive cooperative-abort test — **unrelated to this change and green in isolation (23/23)**; it flakes under parallel-run CPU contention.

## Manual verify (not run here)

- Packaged desktop app (`verify-desktop-packaged`) with a **real microphone**.
- Install `@moxxy/plugin-stt-local`, set it as the active/default transcriber on the runner, download the model, and confirm the mic transcribes **fully offline** (no network).
- Confirm that with **no** runner transcriber but Codex creds present, the mic still works via the in-process path (byte-identical to today).
- Confirm a broken local model surfaces an error toast rather than silently transcribing via Codex.
