### PR TITLE
feat(tui): /speak — read replies aloud via the active Synthesizer

### DIFF
--- a/.changeset/tui-read-aloud.md
+++ b/.changeset/tui-read-aloud.md
@@ -1,0 +1,16 @@
+---
+'@moxxy/plugin-cli': patch
+---
+
+TUI read-aloud: a `/speak` command that voices the assistant's reply through
+the session's active `Synthesizer`. Bare `/speak` speaks the last reply;
+`/speak on|off` toggles sticky auto-speak of each final reply (in-memory, per
+TUI session); `/speak stop` halts current playback. Synthesis reuses
+`@moxxy/channel-kit`'s transport-agnostic `synthesizeReply`/`toSpeech`, and a
+new `audio-play` helper plays the bytes through the platform's system player —
+`afplay` (macOS), `paplay`/`aplay`/`ffplay` (Linux), or PowerShell
+`Media.SoundPlayer`/`ffplay` (Windows) — presence-probed (cached) and
+SIGKILLed on abort so a second `/speak` or Ctrl+C stops playback. Read-aloud is
+best-effort: a missing synthesizer (nudges to `moxxy plugins install tts-local`
+/ `tts-openai`), TTS error, missing player, or non-zero exit all surface a
+subtle notice and never block input — replies always render as text.

--- a/packages/plugin-cli/package.json
+++ b/packages/plugin-cli/package.json
@@ -29,6 +29,7 @@
     }
   },
   "dependencies": {
+    "@moxxy/channel-kit": "workspace:*",
     "@moxxy/chat-model": "workspace:*",
     "@moxxy/config": "workspace:*",
     "@moxxy/core": "workspace:*",

--- a/packages/plugin-cli/src/audio-play.test.ts
+++ b/packages/plugin-cli/src/audio-play.test.ts
@@ -1,0 +1,215 @@
+import { EventEmitter } from 'node:events';
+import type { spawn } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  __resetAudioPlayerProbeForTest,
+  checkAudioPlaybackAvailable,
+  playAudio,
+  selectAudioPlayer,
+} from './audio-play.js';
+
+/** A controllable stand-in for a spawned player/probe child. `kill` emits a
+ *  `close` so an abort/timeout drives the play promise to resolution. */
+class FakeChild extends EventEmitter {
+  killed = false;
+  readonly killSignals: string[] = [];
+  cmd = '';
+  args: string[] = [];
+  kill(signal?: NodeJS.Signals | number): boolean {
+    this.killed = true;
+    this.killSignals.push(String(signal ?? 'SIGTERM'));
+    this.emit('close', null, signal ?? null);
+    return true;
+  }
+}
+
+/** Fake spawn that records every child so a test can drive its lifecycle. */
+function makeSpawn(onSpawn?: (child: FakeChild) => void): {
+  spawnImpl: typeof spawn;
+  children: FakeChild[];
+} {
+  const children: FakeChild[] = [];
+  const spawnImpl = ((cmd: string, args: string[]) => {
+    const child = new FakeChild();
+    child.cmd = cmd;
+    child.args = args;
+    children.push(child);
+    onSpawn?.(child);
+    return child;
+  }) as unknown as typeof spawn;
+  return { spawnImpl, children };
+}
+
+const flush = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+async function waitForChild(children: FakeChild[]): Promise<FakeChild> {
+  const start = Date.now();
+  while (children.length === 0) {
+    if (Date.now() - start > 2_000) throw new Error('player was never spawned');
+    await flush();
+  }
+  return children[0]!;
+}
+
+beforeEach(() => __resetAudioPlayerProbeForTest());
+afterEach(() => __resetAudioPlayerProbeForTest());
+
+describe('selectAudioPlayer — per-platform player pick', () => {
+  const all = () => true;
+
+  it('darwin picks afplay for WAV/MP3', async () => {
+    const r = await selectAudioPlayer('darwin', 'audio/wav', all);
+    expect(r).toMatchObject({ ok: true, command: 'afplay' });
+    const mp3 = await selectAudioPlayer('darwin', 'audio/mpeg', all);
+    expect(mp3).toMatchObject({ ok: true, command: 'afplay' });
+  });
+
+  it('darwin falls back to ffplay for OGG/Opus (afplay can’t decode it)', async () => {
+    const r = await selectAudioPlayer('darwin', 'audio/ogg', all);
+    expect(r).toMatchObject({ ok: true, command: 'ffplay' });
+    // afplay-only host + opus → nothing can play it.
+    const only = await selectAudioPlayer('darwin', 'audio/ogg', (c) => c === 'afplay');
+    expect(only).toEqual({ ok: false, reason: 'no-player' });
+  });
+
+  it('linux prefers paplay, then aplay (WAV only), then ffplay', async () => {
+    expect(await selectAudioPlayer('linux', 'audio/wav', all)).toMatchObject({
+      ok: true,
+      command: 'paplay',
+    });
+    // No paplay → aplay handles WAV.
+    expect(
+      await selectAudioPlayer('linux', 'audio/wav', (c) => c !== 'paplay'),
+    ).toMatchObject({ ok: true, command: 'aplay' });
+    // MP3 with no paplay → aplay can't (WAV only), so ffplay.
+    expect(
+      await selectAudioPlayer('linux', 'audio/mpeg', (c) => c !== 'paplay'),
+    ).toMatchObject({ ok: true, command: 'ffplay' });
+  });
+
+  it('win32 uses PowerShell for WAV, ffplay for other formats', async () => {
+    expect(await selectAudioPlayer('win32', 'audio/wav', all)).toMatchObject({
+      ok: true,
+      command: 'powershell',
+    });
+    expect(await selectAudioPlayer('win32', 'audio/mpeg', all)).toMatchObject({
+      ok: true,
+      command: 'ffplay',
+    });
+    // Non-WAV with no ffplay installed → nothing to play it.
+    expect(
+      await selectAudioPlayer('win32', 'audio/mpeg', (c) => c === 'powershell'),
+    ).toEqual({ ok: false, reason: 'no-player' });
+  });
+
+  it('ffplay is invoked headless + auto-exit', async () => {
+    const r = await selectAudioPlayer('linux', 'audio/mpeg', (c) => c === 'ffplay');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.buildArgs('/tmp/x.mp3')).toEqual([
+        '-nodisp',
+        '-autoexit',
+        '-loglevel',
+        'quiet',
+        '/tmp/x.mp3',
+      ]);
+    }
+  });
+});
+
+describe('playAudio', () => {
+  it('plays via the picked player and resolves ok on a clean exit', async () => {
+    const { spawnImpl, children } = makeSpawn();
+    const p = playAudio(new Uint8Array([1, 2, 3]), {
+      mimeType: 'audio/wav',
+      platform: 'darwin',
+      isAvailable: () => true,
+      spawnImpl,
+    });
+    const child = await waitForChild(children);
+    expect(child.cmd).toBe('afplay');
+    child.emit('close', 0);
+    expect(await p).toEqual({ ok: true, player: 'afplay' });
+  });
+
+  it('returns no-player when nothing is installed (never spawns)', async () => {
+    const { spawnImpl, children } = makeSpawn();
+    const result = await playAudio(new Uint8Array([1]), {
+      mimeType: 'audio/wav',
+      platform: 'linux',
+      isAvailable: () => false,
+      spawnImpl,
+    });
+    expect(result).toEqual({ ok: false, reason: 'no-player' });
+    expect(children).toHaveLength(0);
+  });
+
+  it('kills the player and reports aborted when the signal fires', async () => {
+    const { spawnImpl, children } = makeSpawn();
+    const controller = new AbortController();
+    const p = playAudio(new Uint8Array([1]), {
+      mimeType: 'audio/wav',
+      platform: 'darwin',
+      isAvailable: () => true,
+      spawnImpl,
+      signal: controller.signal,
+    });
+    const child = await waitForChild(children);
+    controller.abort();
+    expect(child.killed).toBe(true);
+    expect(child.killSignals).toContain('SIGKILL');
+    expect(await p).toEqual({ ok: false, reason: 'aborted' });
+  });
+
+  it('reports failed on a non-zero player exit', async () => {
+    const { spawnImpl, children } = makeSpawn();
+    const p = playAudio(new Uint8Array([1]), {
+      mimeType: 'audio/wav',
+      platform: 'darwin',
+      isAvailable: () => true,
+      spawnImpl,
+    });
+    const child = await waitForChild(children);
+    child.emit('close', 1);
+    const result = await p;
+    expect(result).toMatchObject({ ok: false, reason: 'failed' });
+  });
+
+  it('reports aborted (without spawning) when the signal is already aborted', async () => {
+    const { spawnImpl, children } = makeSpawn();
+    const result = await playAudio(new Uint8Array([1]), {
+      mimeType: 'audio/wav',
+      platform: 'darwin',
+      isAvailable: () => true,
+      spawnImpl,
+      signal: AbortSignal.abort(),
+    });
+    expect(result).toEqual({ ok: false, reason: 'aborted' });
+    expect(children).toHaveLength(0);
+  });
+});
+
+describe('checkAudioPlaybackAvailable — probe caching', () => {
+  it('probes each command once and caches the result', async () => {
+    const { spawnImpl, children } = makeSpawn((child) => {
+      // A successful spawn = the binary exists.
+      setImmediate(() => child.emit('spawn'));
+    });
+    const first = await checkAudioPlaybackAvailable({ platform: 'darwin', spawnImpl });
+    const second = await checkAudioPlaybackAvailable({ platform: 'darwin', spawnImpl });
+
+    expect(first).toMatchObject({ available: true, player: 'afplay' });
+    expect(second).toMatchObject({ available: true, player: 'afplay' });
+    // afplay is the first darwin candidate, so only it is probed — and the
+    // second call reuses the cached probe (no second spawn).
+    expect(children.map((c) => c.cmd)).toEqual(['afplay']);
+  });
+
+  it('reports unavailable when no player binary exists', async () => {
+    const { spawnImpl } = makeSpawn((child) => {
+      setImmediate(() => child.emit('error', Object.assign(new Error('ENOENT'), { code: 'ENOENT' })));
+    });
+    const result = await checkAudioPlaybackAvailable({ platform: 'linux', spawnImpl });
+    expect(result).toEqual({ available: false, player: null, platform: 'linux' });
+  });
+});

--- a/packages/plugin-cli/src/audio-play.ts
+++ b/packages/plugin-cli/src/audio-play.ts
@@ -1,0 +1,399 @@
+import { Buffer } from 'node:buffer';
+import { spawn } from 'node:child_process';
+import { writeFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Play synthesized audio bytes through the platform's system audio player. This
+ * is the read-aloud counterpart to {@link file://./voice-input.ts} (which
+ * *captures* audio via ffmpeg): here we take the OGG/MP3/WAV a
+ * {@link @moxxy/sdk!Synthesizer} produced and hand it to a native player.
+ *
+ * The load-bearing guarantee mirrors the voice-reply path: NOTHING here throws
+ * into the UI. A missing player, an unsupported format, an abort, or a player
+ * that exits non-zero all resolve to a typed {@link PlayAudioResult}. The caller
+ * (the `/speak` machinery) renders text replies regardless, so a playback
+ * failure is always best-effort.
+ *
+ * ## Player matrix
+ *   - **darwin** — `afplay` (built into macOS; CoreAudio handles WAV/MP3/M4A/AAC
+ *     but not OGG/Opus), falling back to `ffplay` for OGG/Opus when present.
+ *   - **linux** — first available of `paplay` (PulseAudio), `aplay` (ALSA, WAV
+ *     only), then `ffplay -nodisp -autoexit -loglevel quiet` (universal).
+ *   - **win32** — PowerShell `Media.SoundPlayer` (WAV only), falling back to
+ *     `ffplay` for other formats when present.
+ *
+ * Playback is abortable: a second `/speak` (or `/speak stop`, or Ctrl+C) aborts
+ * the {@link AudioPlaybackOptions.signal}, which SIGKILLs the spawned player.
+ */
+
+/** How each supported player is invoked + which formats it can handle. */
+interface PlayerCandidate {
+  readonly command: string;
+  /** Args used to presence-probe the binary (a successful spawn proves it
+   *  exists; the exact flag is irrelevant since we resolve on `spawn`). */
+  readonly probeArgs: readonly string[];
+  buildArgs(file: string): string[];
+  /** Whether this player can voice the given mime type. */
+  supports(mimeType: string): boolean;
+}
+
+function isWavMime(mimeType: string): boolean {
+  return /wav/i.test(mimeType);
+}
+
+function isOggOpusWebmMime(mimeType: string): boolean {
+  return /(opus|ogg|webm)/i.test(mimeType);
+}
+
+const AFPLAY: PlayerCandidate = {
+  command: 'afplay',
+  probeArgs: ['-h'],
+  buildArgs: (file) => [file],
+  // CoreAudio decodes WAV/MP3/M4A/AAC/AIFF but not OGG/Opus/WebM.
+  supports: (mimeType) => !isOggOpusWebmMime(mimeType),
+};
+
+const FFPLAY: PlayerCandidate = {
+  command: 'ffplay',
+  probeArgs: ['-version'],
+  buildArgs: (file) => ['-nodisp', '-autoexit', '-loglevel', 'quiet', file],
+  supports: () => true,
+};
+
+const PAPLAY: PlayerCandidate = {
+  command: 'paplay',
+  probeArgs: ['--version'],
+  buildArgs: (file) => [file],
+  supports: () => true,
+};
+
+const APLAY: PlayerCandidate = {
+  command: 'aplay',
+  probeArgs: ['--version'],
+  buildArgs: (file) => ['-q', file],
+  supports: (mimeType) => isWavMime(mimeType),
+};
+
+const POWERSHELL: PlayerCandidate = {
+  command: 'powershell',
+  probeArgs: ['-NoProfile', '-Command', 'exit'],
+  // Media.SoundPlayer.PlaySync blocks until the WAV finishes, then exits — so a
+  // SIGKILL on abort stops playback. Temp filenames never contain a quote.
+  buildArgs: (file) => [
+    '-NoProfile',
+    '-Command',
+    `$p = New-Object Media.SoundPlayer '${file}'; $p.PlaySync();`,
+  ],
+  supports: (mimeType) => isWavMime(mimeType),
+};
+
+function playerCandidates(platform: NodeJS.Platform): readonly PlayerCandidate[] {
+  switch (platform) {
+    case 'darwin':
+      return [AFPLAY, FFPLAY];
+    case 'linux':
+      return [PAPLAY, APLAY, FFPLAY];
+    case 'win32':
+      return [POWERSHELL, FFPLAY];
+    default:
+      return [FFPLAY];
+  }
+}
+
+function probeArgsFor(command: string): readonly string[] {
+  for (const platform of ['darwin', 'linux', 'win32'] as const) {
+    const found = playerCandidates(platform).find((c) => c.command === command);
+    if (found) return found.probeArgs;
+  }
+  return ['-version'];
+}
+
+export type SelectAudioPlayerResult =
+  | { readonly ok: true; readonly command: string; buildArgs(file: string): string[] }
+  // `no-player`: no installed player on this platform can voice the format
+  // (ffplay is a universal fallback on every platform, so a format is never
+  // intrinsically unsupported — it just means nothing is installed).
+  | { readonly ok: false; readonly reason: 'no-player' };
+
+/**
+ * Pick the audio player for a platform + mime type. Walks the platform's
+ * ordered candidate list, keeps the ones that can voice the format, and returns
+ * the first that `isAvailable` confirms is installed. Pure but for the
+ * (injectable) availability probe, so the per-platform pick is unit-testable.
+ */
+export async function selectAudioPlayer(
+  platform: NodeJS.Platform,
+  mimeType: string,
+  isAvailable: (command: string) => boolean | Promise<boolean>,
+): Promise<SelectAudioPlayerResult> {
+  const supporting = playerCandidates(platform).filter((c) => c.supports(mimeType));
+  for (const candidate of supporting) {
+    if (await isAvailable(candidate.command)) {
+      return { ok: true, command: candidate.command, buildArgs: candidate.buildArgs };
+    }
+  }
+  return { ok: false, reason: 'no-player' };
+}
+
+// Process-cached player-presence probes (each probe spawns a subprocess;
+// caching keeps repeated /speak calls from re-probing every time). Tests reset
+// via `__resetAudioPlayerProbeForTest`. Unlike the ffmpeg probe we cache even
+// when a spawn is injected, so a caching test can assert one probe per command.
+const probeCache = new Map<string, Promise<boolean>>();
+
+/** Reset the cached player-presence probes (tests only). */
+export function __resetAudioPlayerProbeForTest(): void {
+  probeCache.clear();
+}
+
+function cachedProbe(command: string, spawnImpl?: typeof spawn): Promise<boolean> {
+  const cached = probeCache.get(command);
+  if (cached) return cached;
+  const probe = probePlayerPresent(command, probeArgsFor(command), spawnImpl ?? spawn);
+  probeCache.set(command, probe);
+  return probe;
+}
+
+function probePlayerPresent(
+  command: string,
+  probeArgs: readonly string[],
+  spawnImpl: typeof spawn,
+  timeoutMs = 1_500,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (v: boolean): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(v);
+    };
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawnImpl(command, [...probeArgs], { stdio: ['ignore', 'ignore', 'ignore'] });
+    } catch {
+      resolve(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      try {
+        if (!child.killed) child.kill('SIGKILL');
+      } catch {
+        /* ignore */
+      }
+      done(false);
+    }, timeoutMs);
+    timer.unref?.();
+    // A successful spawn is all "present" needs — kill immediately so a player
+    // probed with a throwaway flag can't linger.
+    child.once('spawn', () => {
+      try {
+        if (!child.killed) child.kill('SIGKILL');
+      } catch {
+        /* ignore */
+      }
+      done(true);
+    });
+    // ENOENT (or any pre-spawn failure) means the binary isn't on PATH.
+    child.once('error', () => done(false));
+    // A fake/tool that exits before we observe `spawn` still proved it ran.
+    child.once('close', () => done(true));
+  });
+}
+
+export interface AudioPlaybackAvailability {
+  readonly available: boolean;
+  /** The player command that would be used, or null when none is installed. */
+  readonly player: string | null;
+  readonly platform: NodeJS.Platform;
+}
+
+export interface AudioPlaybackAvailabilityOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly spawnImpl?: typeof spawn;
+  /** Injectable availability check (tests). Bypasses the cached spawn probe. */
+  readonly isAvailable?: (command: string) => boolean | Promise<boolean>;
+}
+
+/**
+ * Whether ANY audio player is installed for this platform (ignoring format).
+ * Powers the read-aloud readiness notice; the real format-aware pick happens in
+ * {@link playAudio}.
+ */
+export async function checkAudioPlaybackAvailable(
+  opts: AudioPlaybackAvailabilityOptions = {},
+): Promise<AudioPlaybackAvailability> {
+  const platform = opts.platform ?? process.platform;
+  const isAvailable = opts.isAvailable ?? ((command: string) => cachedProbe(command, opts.spawnImpl));
+  for (const candidate of playerCandidates(platform)) {
+    if (await isAvailable(candidate.command)) {
+      return { available: true, player: candidate.command, platform };
+    }
+  }
+  return { available: false, player: null, platform };
+}
+
+export type PlayAudioResult =
+  | { readonly ok: true; readonly player: string }
+  // `aborted`: the signal fired (user stopped, or a newer /speak superseded).
+  // `no-player`: no installed player can voice the format on this platform.
+  // `failed`: temp-write, spawn, timeout, or non-zero exit.
+  | {
+      readonly ok: false;
+      readonly reason: 'aborted' | 'no-player' | 'failed';
+      readonly error?: string;
+    };
+
+export interface AudioPlaybackOptions {
+  /** Mime type of `audio` (drives the player pick + temp-file extension). */
+  readonly mimeType: string;
+  readonly platform?: NodeJS.Platform;
+  /** Abort to stop playback (kills the spawned player). */
+  readonly signal?: AbortSignal;
+  /** Injectable spawn for tests (drives BOTH the presence probe and the player
+   *  child). */
+  readonly spawnImpl?: typeof spawn;
+  /** Injectable availability check (tests) — bypasses the probe so the player
+   *  pick is deterministic. */
+  readonly isAvailable?: (command: string) => boolean | Promise<boolean>;
+  /** Temp directory for the scratch audio file. Defaults to `os.tmpdir()`. */
+  readonly tmpDir?: string;
+  /** Hard ceiling on playback (a stuck player can't hang forever). Default 5m. */
+  readonly timeoutMs?: number;
+}
+
+/** A spoken reply is short (synthesizeReply caps speech text); 5 minutes is a
+ *  generous ceiling that still reaps a wedged player. */
+const DEFAULT_PLAYBACK_TIMEOUT_MS = 5 * 60_000;
+
+/**
+ * Play `audio` through the platform's system player. Writes the bytes to a temp
+ * file (cleaned up after), picks the player via {@link selectAudioPlayer}, and
+ * spawns it — SIGKILLing on abort. NEVER throws: every failure mode is a typed
+ * {@link PlayAudioResult}.
+ */
+export async function playAudio(
+  audio: Uint8Array,
+  opts: AudioPlaybackOptions,
+): Promise<PlayAudioResult> {
+  const platform = opts.platform ?? process.platform;
+  const spawnImpl = opts.spawnImpl ?? spawn;
+  const isAvailable =
+    opts.isAvailable ?? ((command: string) => cachedProbe(command, opts.spawnImpl));
+
+  if (opts.signal?.aborted) return { ok: false, reason: 'aborted' };
+
+  const selection = await selectAudioPlayer(platform, opts.mimeType, isAvailable);
+  if (!selection.ok) return { ok: false, reason: selection.reason };
+
+  let file: string;
+  try {
+    file = await writeTempAudio(audio, opts.mimeType, opts.tmpDir);
+  } catch (err) {
+    return { ok: false, reason: 'failed', error: errMessage(err) };
+  }
+
+  try {
+    return await spawnPlayer(
+      selection.command,
+      selection.buildArgs(file),
+      spawnImpl,
+      opts.signal,
+      opts.timeoutMs ?? DEFAULT_PLAYBACK_TIMEOUT_MS,
+    );
+  } finally {
+    void rm(file, { force: true }).catch(() => undefined);
+  }
+}
+
+function spawnPlayer(
+  command: string,
+  args: string[],
+  spawnImpl: typeof spawn,
+  signal: AbortSignal | undefined,
+  timeoutMs: number,
+): Promise<PlayAudioResult> {
+  return new Promise((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawnImpl(command, args, { stdio: ['ignore', 'ignore', 'ignore'] });
+    } catch (err) {
+      resolve({ ok: false, reason: 'failed', error: errMessage(err) });
+      return;
+    }
+    let settled = false;
+    let aborted = false;
+    const onAbort = (): void => {
+      aborted = true;
+      try {
+        if (!child.killed) child.kill('SIGKILL');
+      } catch {
+        /* ignore */
+      }
+    };
+    const done = (result: PlayAudioResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      resolve(result);
+    };
+    const timer = setTimeout(() => {
+      try {
+        if (!child.killed) child.kill('SIGKILL');
+      } catch {
+        /* ignore */
+      }
+      done({ ok: false, reason: 'failed', error: 'audio playback timed out' });
+    }, timeoutMs);
+    timer.unref?.();
+
+    if (signal) {
+      if (signal.aborted) onAbort();
+      else signal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    child.once('error', (err) => done({ ok: false, reason: 'failed', error: errMessage(err) }));
+    child.once('close', (code) => {
+      if (aborted) return done({ ok: false, reason: 'aborted' });
+      if (code === 0) return done({ ok: true, player: command });
+      return done({
+        ok: false,
+        reason: 'failed',
+        error: `${command} exited with code ${code ?? 'null'}`,
+      });
+    });
+  });
+}
+
+async function writeTempAudio(
+  audio: Uint8Array,
+  mimeType: string,
+  tmpDir?: string,
+): Promise<string> {
+  const dir = tmpDir ?? os.tmpdir();
+  const suffix = Math.random().toString(36).slice(2, 10);
+  const file = path.join(dir, `moxxy-speak-${process.pid}-${Date.now()}-${suffix}.${extForMime(mimeType)}`);
+  await writeFile(file, Buffer.from(audio));
+  return file;
+}
+
+/** Map an audio mime type to a file extension (players sniff by content, but a
+ *  sensible extension helps — and SoundPlayer requires `.wav`). */
+function extForMime(mimeType: string): string {
+  const m = (mimeType || '').toLowerCase();
+  if (m.includes('wav')) return 'wav';
+  if (m.includes('opus') || m.includes('ogg')) return 'ogg';
+  if (m.includes('mpeg') || m.includes('mp3')) return 'mp3';
+  if (m.includes('webm')) return 'webm';
+  if (m.includes('aac') || m.includes('m4a') || m.includes('mp4')) return 'm4a';
+  if (m.includes('flac')) return 'flac';
+  if (m.includes('aiff')) return 'aiff';
+  return 'audio';
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/plugin-cli/src/components/SlashCommands.tsx
+++ b/packages/plugin-cli/src/components/SlashCommands.tsx
@@ -64,6 +64,12 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<SlashCommand> = [
     argumentHint: '<goal>',
   },
   {
+    name: 'speak',
+    description: 'Read replies aloud via the active TTS voice — bare speaks the last reply, on/off auto-speaks, stop halts',
+    argumentHint: '[on|off|stop]',
+    aliases: ['say'],
+  },
+  {
     name: 'yolo',
     description: 'Toggle auto-approve mode — every tool call allowed without asking',
     aliases: ['auto-approve'],

--- a/packages/plugin-cli/src/index.ts
+++ b/packages/plugin-cli/src/index.ts
@@ -41,6 +41,16 @@ export {
   VOICE_CAPTURE_RUNTIME,
   type VoiceCaptureAvailabilityOptions,
 } from './voice-input.js';
+export {
+  checkAudioPlaybackAvailable,
+  playAudio,
+  selectAudioPlayer,
+  type AudioPlaybackAvailability,
+  type AudioPlaybackAvailabilityOptions,
+  type AudioPlaybackOptions,
+  type PlayAudioResult,
+  type SelectAudioPlayerResult,
+} from './audio-play.js';
 
 export const tuiChannelDef = defineChannel({
   name: 'tui',

--- a/packages/plugin-cli/src/session/SessionView.tsx
+++ b/packages/plugin-cli/src/session/SessionView.tsx
@@ -25,6 +25,7 @@ import { useTurnRunner } from './use-turn-runner.js';
 import { usePermissionQueue } from './use-permission-queue.js';
 import { useGlobalHotkeys } from './use-global-hotkeys.js';
 import { useVoiceInput } from './use-voice-input.js';
+import { useReadAloud } from './use-read-aloud.js';
 import { applyProviderModelSwitch, makePickerHandler } from './picker-handlers.js';
 import { runSlash } from './run-slash.js';
 import { OverlayOrNotice } from './OverlayOrNotice.js';
@@ -98,6 +99,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
   const permissions = usePermissionQueue(session, registerInteractiveResolver);
   const images = useImageAttachments((msg) => setSystemNotice(msg));
   const voice = useVoiceInput({ session, setSystemNotice });
+  // Read-aloud (`/speak`): synthesize + play assistant replies through the
+  // session's active Synthesizer. `onTurnComplete` (below) drives auto-speak.
+  const readAloud = useReadAloud({ session, setSystemNotice });
 
   // Keep the yolo flag in a ref so the permission handler closure
   // reads the latest value without re-registering.
@@ -109,6 +113,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
     session,
     resolveModel: () => activeModelOverride ?? model,
     stream,
+    // Auto-speak seam: when read-aloud is armed, speak the final reply once the
+    // turn completes. Reads the reply from session.log; never blocks input.
+    onTurnComplete: () => readAloud.onTurnComplete(),
   });
 
   const pendingPermission = permissions.pendingPermission;
@@ -262,9 +269,13 @@ export const SessionView: React.FC<SessionViewProps> = ({
   // here because the registry handlers are channel-agnostic.
   const performSessionAction = (action: 'new' | 'clear' | 'exit', notice?: string): void => {
     if (action === 'exit') {
+      readAloud.stop();
       exit();
       return;
     }
+    // Stop any read-aloud playback so a wiped/cleared session isn't still
+    // speaking the reply that just scrolled off.
+    readAloud.stop();
     clearTerminalScreen();
     stream.setEvents([]);
     stream.cancelStreamFlush();
@@ -340,6 +351,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
         queueRef: turn.queueRef,
         setQueueCount: turn.setQueueCount,
         performSessionAction,
+        runSpeak: (arg: string) => readAloud.handleCommand(arg),
         canSwitchSession: canSwitchSession ?? false,
         // `/collab` re-points the TUI onto the dedicated coordinator via the same
         // in-place switch machinery `/sessions` uses (so it needs the host's

--- a/packages/plugin-cli/src/session/read-aloud.test.ts
+++ b/packages/plugin-cli/src/session/read-aloud.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SynthesizeReplyResult, SynthesizerSource } from '@moxxy/channel-kit';
+import type { PlayAudioResult } from '../audio-play.js';
+import {
+  createReadAloud,
+  lastAssistantReply,
+  resolveSpeakCommand,
+  type ReadAloudSession,
+} from './read-aloud.js';
+
+/** Fake assistant_message events (only the fields read-aloud touches). */
+function messages(
+  entries: Array<{ seq: number; content: string; stopReason?: string }>,
+): ReadAloudSession['log'] {
+  const events = entries.map((e) => ({
+    type: 'assistant_message',
+    seq: e.seq,
+    content: e.content,
+    stopReason: e.stopReason ?? 'end_turn',
+  }));
+  return {
+    ofType: ((type: string) => (type === 'assistant_message' ? events : [])) as ReadAloudSession['log']['ofType'],
+  };
+}
+
+function fakeSession(opts: {
+  readonly hasSynth: boolean;
+  readonly log?: ReadAloudSession['log'];
+}): ReadAloudSession {
+  return {
+    synthesizers: {
+      tryGetActive: () => (opts.hasSynth ? ({} as unknown as ReturnType<SynthesizerSource['synthesizers']['tryGetActive']>) : null),
+    },
+    log: opts.log ?? messages([]),
+  };
+}
+
+const flush = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+describe('resolveSpeakCommand', () => {
+  it('bare /speak speaks the last reply when a synthesizer is active', () => {
+    expect(resolveSpeakCommand({ arg: '', autoSpeak: false, hasSynthesizer: true })).toEqual({
+      action: 'speak-last',
+    });
+  });
+
+  it('bare /speak nudges to install TTS when no synthesizer is active', () => {
+    const d = resolveSpeakCommand({ arg: '', autoSpeak: false, hasSynthesizer: false });
+    expect(d.action).toBe('notice');
+    if (d.action === 'notice') {
+      expect(d.reply).toMatch(/no active text-to-speech/i);
+      expect(d.reply).toMatch(/tts-local/);
+      expect(d.reply).toMatch(/tts-openai/);
+    }
+  });
+
+  it('on/off toggle sticky auto-speak; on with no synth still arms + hints', () => {
+    expect(resolveSpeakCommand({ arg: 'on', autoSpeak: false, hasSynthesizer: true })).toMatchObject({
+      action: 'auto-on',
+    });
+    const onNoSynth = resolveSpeakCommand({ arg: 'on', autoSpeak: false, hasSynthesizer: false });
+    expect(onNoSynth.action).toBe('auto-on');
+    if (onNoSynth.action === 'auto-on') expect(onNoSynth.reply).toMatch(/tts-local/);
+    expect(resolveSpeakCommand({ arg: 'off', autoSpeak: true, hasSynthesizer: true })).toMatchObject({
+      action: 'auto-off',
+    });
+  });
+
+  it('stop halts playback; status reports state; unknown → usage', () => {
+    expect(resolveSpeakCommand({ arg: 'stop', autoSpeak: true, hasSynthesizer: true })).toEqual({
+      action: 'stop',
+    });
+    const status = resolveSpeakCommand({ arg: 'status', autoSpeak: true, hasSynthesizer: true });
+    expect(status).toMatchObject({ action: 'notice' });
+    if (status.action === 'notice') expect(status.reply).toMatch(/ON/);
+    const bad = resolveSpeakCommand({ arg: 'louder', autoSpeak: false, hasSynthesizer: true });
+    expect(bad).toMatchObject({ action: 'notice' });
+    if (bad.action === 'notice') expect(bad.reply).toMatch(/usage/i);
+  });
+});
+
+describe('lastAssistantReply', () => {
+  it('returns the most recent end_turn reply with its seq', () => {
+    const log = messages([
+      { seq: 1, content: 'first' },
+      { seq: 3, content: 'tool round', stopReason: 'tool_use' },
+      { seq: 5, content: 'final answer' },
+    ]);
+    expect(lastAssistantReply(log)).toEqual({ content: 'final answer', seq: 5 });
+  });
+
+  it('skips empty and non-end_turn messages; null when none qualify', () => {
+    expect(lastAssistantReply(messages([{ seq: 2, content: '   ' }]))).toBeNull();
+    expect(
+      lastAssistantReply(messages([{ seq: 2, content: 'mid', stopReason: 'tool_use' }])),
+    ).toBeNull();
+  });
+});
+
+describe('createReadAloud — auto-speak trigger', () => {
+  function harness(opts: {
+    hasSynth: boolean;
+    log?: ReadAloudSession['log'];
+    synth?: SynthesizeReplyResult;
+    play?: PlayAudioResult;
+  }) {
+    const notices: Array<string | null> = [];
+    const synthesize = vi.fn(async () => opts.synth ?? { ok: true, audio: new Uint8Array([1]), mimeType: 'audio/wav' } as SynthesizeReplyResult);
+    const play = vi.fn(async () => opts.play ?? ({ ok: true, player: 'afplay' } as PlayAudioResult));
+    const controller = createReadAloud({
+      session: fakeSession({ hasSynth: opts.hasSynth, ...(opts.log ? { log: opts.log } : {}) }),
+      setSystemNotice: (n) => notices.push(n),
+      synthesize,
+      play,
+      platform: 'darwin',
+    });
+    return { controller, synthesize, play, notices };
+  }
+
+  it('is OFF by default — a completed turn does not speak', async () => {
+    const { controller, synthesize, play } = harness({ hasSynth: true, log: messages([{ seq: 5, content: 'hi' }]) });
+    controller.onTurnComplete();
+    await flush();
+    expect(synthesize).not.toHaveBeenCalled();
+    expect(play).not.toHaveBeenCalled();
+    expect(controller.autoSpeak).toBe(false);
+  });
+
+  it('once armed, speaks the final reply exactly once (deduped by seq)', async () => {
+    const { controller, synthesize, play } = harness({
+      hasSynth: true,
+      log: messages([{ seq: 5, content: 'final answer' }]),
+    });
+    controller.handleCommand('on');
+    expect(controller.autoSpeak).toBe(true);
+
+    controller.onTurnComplete();
+    await flush();
+    expect(synthesize).toHaveBeenCalledTimes(1);
+    expect(synthesize.mock.calls[0]![1]).toBe('final answer');
+    expect(play).toHaveBeenCalledTimes(1);
+
+    // Same turn / same reply → not re-spoken.
+    controller.onTurnComplete();
+    await flush();
+    expect(synthesize).toHaveBeenCalledTimes(1);
+  });
+
+  it('a synthesis failure never throws and never reaches the player', async () => {
+    const { controller, play, notices } = harness({
+      hasSynth: true,
+      log: messages([{ seq: 5, content: 'answer' }]),
+      synth: { ok: false, reason: 'failed', error: 'backend down' },
+    });
+    controller.handleCommand('on');
+    expect(() => controller.onTurnComplete()).not.toThrow();
+    await flush();
+    expect(play).not.toHaveBeenCalled();
+    expect(notices.some((n) => typeof n === 'string' && /synthesis failed/i.test(n))).toBe(true);
+  });
+
+  it('a player failure never throws; a no-player result nudges to install one', async () => {
+    const { controller, notices } = harness({
+      hasSynth: true,
+      log: messages([{ seq: 5, content: 'answer' }]),
+      play: { ok: false, reason: 'no-player' },
+    });
+    controller.handleCommand('on');
+    controller.onTurnComplete();
+    await flush();
+    expect(notices.some((n) => typeof n === 'string' && /no audio player/i.test(n))).toBe(true);
+  });
+});
+
+describe('createReadAloud — /speak command dispatch', () => {
+  it('bare /speak speaks the last reply through synth + player', async () => {
+    const notices: Array<string | null> = [];
+    const synthesize = vi.fn(async () => ({ ok: true, audio: new Uint8Array([1]), mimeType: 'audio/wav' }) as SynthesizeReplyResult);
+    const play = vi.fn(async () => ({ ok: true, player: 'afplay' }) as PlayAudioResult);
+    const controller = createReadAloud({
+      session: fakeSession({ hasSynth: true, log: messages([{ seq: 9, content: 'spoken reply' }]) }),
+      setSystemNotice: (n) => notices.push(n),
+      synthesize,
+      play,
+      platform: 'darwin',
+    });
+    controller.handleCommand('');
+    await flush();
+    expect(synthesize).toHaveBeenCalledTimes(1);
+    expect(synthesize.mock.calls[0]![1]).toBe('spoken reply');
+    expect(play).toHaveBeenCalledTimes(1);
+  });
+
+  it('bare /speak with no synthesizer shows the install nudge (no synth call)', async () => {
+    const notices: Array<string | null> = [];
+    const synthesize = vi.fn(async () => ({ ok: true, audio: new Uint8Array([1]), mimeType: 'audio/wav' }) as SynthesizeReplyResult);
+    const controller = createReadAloud({
+      session: fakeSession({ hasSynth: false, log: messages([{ seq: 9, content: 'reply' }]) }),
+      setSystemNotice: (n) => notices.push(n),
+      synthesize,
+      play: async () => ({ ok: true, player: 'afplay' }) as PlayAudioResult,
+    });
+    controller.handleCommand('');
+    await flush();
+    expect(synthesize).not.toHaveBeenCalled();
+    expect(notices.some((n) => typeof n === 'string' && /no active text-to-speech/i.test(n))).toBe(true);
+  });
+
+  it('/speak stop reports nothing playing when idle', () => {
+    const notices: Array<string | null> = [];
+    const controller = createReadAloud({
+      session: fakeSession({ hasSynth: true }),
+      setSystemNotice: (n) => notices.push(n),
+      synthesize: async () => ({ ok: true, audio: new Uint8Array([1]), mimeType: 'audio/wav' }) as SynthesizeReplyResult,
+      play: async () => ({ ok: true, player: 'afplay' }) as PlayAudioResult,
+    });
+    controller.handleCommand('stop');
+    expect(notices.some((n) => typeof n === 'string' && /nothing is playing/i.test(n))).toBe(true);
+  });
+});

--- a/packages/plugin-cli/src/session/read-aloud.ts
+++ b/packages/plugin-cli/src/session/read-aloud.ts
@@ -1,0 +1,286 @@
+import { synthesizeReply, type SynthesizeReplyResult, type SynthesizerSource } from '@moxxy/channel-kit';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import { playAudio, type AudioPlaybackOptions, type PlayAudioResult } from '../audio-play.js';
+
+/**
+ * Read-aloud machinery for the TUI: the `/speak` command + the auto-speak hook.
+ * It turns the assistant's final reply into speech through the session's active
+ * {@link @moxxy/sdk!Synthesizer} (via channel-kit's transport-agnostic
+ * {@link synthesizeReply}) and plays it through the system audio player (via
+ * {@link playAudio}).
+ *
+ * Text replies always render regardless — read-aloud is best-effort. Nothing
+ * here throws into the UI; every failure is surfaced as a subtle notice.
+ */
+
+/** Guidance shown when `/speak` (or auto-speak) has no synthesizer to voice. */
+export const READ_ALOUD_NO_SYNTH_HINT =
+  'Install a text-to-speech backend:\n' +
+  '  moxxy plugins install tts-local   (offline)\n' +
+  '  moxxy plugins install tts-openai';
+
+const NO_SYNTH_NOTICE = `read-aloud: no active text-to-speech backend.\n${READ_ALOUD_NO_SYNTH_HINT}`;
+
+export interface SpeakCommandInput {
+  /** The `/speak` argument: `''`, `on`, `off`, `stop`, `status`, or other. */
+  readonly arg: string;
+  /** Whether auto-speak is currently on. */
+  readonly autoSpeak: boolean;
+  /** Whether a synthesizer is active right now. */
+  readonly hasSynthesizer: boolean;
+}
+
+export type SpeakCommandDecision =
+  // Speak the last assistant reply now.
+  | { readonly action: 'speak-last' }
+  // Turn sticky auto-speak on/off. `reply` is the notice to show.
+  | { readonly action: 'auto-on'; readonly reply: string }
+  | { readonly action: 'auto-off'; readonly reply: string }
+  // Stop current playback.
+  | { readonly action: 'stop' }
+  // Just show a notice (status, usage, or the no-synthesizer nudge on a bare
+  // `/speak` that can't do anything).
+  | { readonly action: 'notice'; readonly reply: string };
+
+/**
+ * Resolve a `/speak` command line into an action + any notice. Pure, so the
+ * on/off/stop/bare parsing and the no-synthesizer nudge are unit-testable
+ * without React or a live session. Mirrors channel-kit's `resolveVoiceToggle`:
+ *   - bare `/speak` speaks the last reply (nudges to install TTS if none active);
+ *   - `on`/`off` toggle sticky auto-speak (turning `on` with no synthesizer
+ *     still arms the preference, appending an install hint, so replies start
+ *     speaking once a backend is installed);
+ *   - `stop` stops current playback;
+ *   - `status` reports the auto-speak state.
+ */
+export function resolveSpeakCommand(input: SpeakCommandInput): SpeakCommandDecision {
+  const arg = input.arg.trim().toLowerCase();
+  const hint = input.hasSynthesizer ? '' : `\n\n${READ_ALOUD_NO_SYNTH_HINT}`;
+
+  if (arg === '') {
+    if (!input.hasSynthesizer) return { action: 'notice', reply: NO_SYNTH_NOTICE };
+    return { action: 'speak-last' };
+  }
+  if (arg === 'stop') return { action: 'stop' };
+  if (arg === 'off') return { action: 'auto-off', reply: '🔇 read-aloud OFF.' };
+  if (arg === 'on') {
+    return {
+      action: 'auto-on',
+      reply: `🔊 read-aloud ON — I'll speak each final reply aloud.${hint}`,
+    };
+  }
+  if (arg === 'status') {
+    const state = input.autoSpeak ? 'ON' : 'OFF';
+    const note = input.autoSpeak ? hint : '';
+    return { action: 'notice', reply: `read-aloud auto-speak is ${state}.${note}` };
+  }
+  return {
+    action: 'notice',
+    reply: `read-aloud: unknown option "${input.arg.trim()}". Usage: /speak [on|off|stop|status]`,
+  };
+}
+
+/** The final assistant reply text in the log, or null. Picks the most recent
+ *  `assistant_message` that actually ended a turn (`stopReason: 'end_turn'`)
+ *  with non-empty content — intermediate tool-use messages aren't spoken. The
+ *  `seq` lets the auto-speak hook dedupe (don't re-speak an unchanged reply). */
+export function lastAssistantReply(
+  session: Pick<Session['log'], 'ofType'>,
+): { readonly content: string; readonly seq: number } | null {
+  const messages = session.ofType('assistant_message');
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]!;
+    if (m.stopReason === 'end_turn' && m.content.trim().length > 0) {
+      return { content: m.content, seq: m.seq };
+    }
+  }
+  return null;
+}
+
+/** The session slice the read-aloud controller needs. */
+export interface ReadAloudSession extends SynthesizerSource {
+  readonly log: Pick<Session['log'], 'ofType'>;
+}
+
+export interface ReadAloudDeps {
+  readonly session: ReadAloudSession;
+  readonly setSystemNotice: (notice: string | null) => void;
+  /** Injectable synth (tests). Defaults to channel-kit `synthesizeReply`. */
+  readonly synthesize?: (
+    session: SynthesizerSource,
+    text: string,
+    opts?: { readonly signal?: AbortSignal },
+  ) => Promise<SynthesizeReplyResult>;
+  /** Injectable player (tests). Defaults to `playAudio`. */
+  readonly play?: (audio: Uint8Array, opts: AudioPlaybackOptions) => Promise<PlayAudioResult>;
+  /** Platform override (tests / player selection). */
+  readonly platform?: NodeJS.Platform;
+}
+
+export interface ReadAloud {
+  /** Whether sticky auto-speak is on (in-memory, per TUI session). */
+  readonly autoSpeak: boolean;
+  /** Dispatch `/speak [on|off|stop|status]`. */
+  handleCommand(arg: string): void;
+  /** Called on turn completion — speaks the final reply when auto-speak is on
+   *  (and the reply is new). Never blocks the turn; never throws. */
+  onTurnComplete(): void;
+  /** Stop current playback (also invoked by session reset). */
+  stop(): void;
+  /** Abort any in-flight playback (unmount safety). */
+  dispose(): void;
+}
+
+/**
+ * Build the read-aloud controller. Plain object (no React) so the auto-speak
+ * trigger and command dispatch are unit-testable with a fake synthesizer +
+ * player. The hook {@link file://./use-read-aloud.ts} wraps this in a ref.
+ */
+export function createReadAloud(deps: ReadAloudDeps): ReadAloud {
+  const synthesize = deps.synthesize ?? synthesizeReply;
+  const play = deps.play ?? playAudio;
+  const notice = deps.setSystemNotice;
+
+  let autoSpeak = false;
+  // The AbortController for the in-flight playback. Starting a new speak (or
+  // stop/off/dispose) aborts it, so a second /speak stops the first.
+  let current: AbortController | null = null;
+  // seq of the last reply we spoke, so auto-speak doesn't re-voice a turn that
+  // produced no new final reply (e.g. an errored/aborted turn leaves the prior
+  // reply as the log's last one).
+  let lastSpokenSeq: number | null = null;
+
+  const abortCurrent = (): void => {
+    if (current) {
+      current.abort();
+      current = null;
+    }
+  };
+
+  const start = (text: string): void => {
+    abortCurrent();
+    const controller = new AbortController();
+    current = controller;
+    notice('🔊 speaking…');
+    void runSpeak(text, controller).finally(() => {
+      if (current === controller) current = null;
+    });
+  };
+
+  const runSpeak = async (text: string, controller: AbortController): Promise<void> => {
+    const isCurrent = (): boolean => current === controller;
+    const signal = controller.signal;
+
+    const synth = await synthesize(deps.session, text, { signal });
+    if (!synth.ok) {
+      if (signal.aborted) return;
+      if (synth.reason === 'no-synthesizer') return void notice(NO_SYNTH_NOTICE);
+      if (synth.reason === 'empty') return void notice('read-aloud: nothing to speak in that reply.');
+      return void notice(`read-aloud: synthesis failed${synth.error ? ` — ${synth.error}` : ''}.`);
+    }
+
+    const result = await play(synth.audio, {
+      mimeType: synth.mimeType,
+      signal,
+      ...(deps.platform ? { platform: deps.platform } : {}),
+    });
+    if (result.ok) {
+      // Clear the "speaking…" notice on a clean finish — but only if we're still
+      // the active speak (don't clobber a notice a newer action set).
+      if (isCurrent()) notice(null);
+      return;
+    }
+    switch (result.reason) {
+      case 'aborted':
+        return; // user stopped or a newer /speak superseded — stay quiet
+      case 'no-player':
+        return void notice(noPlayerNotice(deps.platform ?? process.platform));
+      default:
+        return void notice(
+          `read-aloud: playback failed${result.error ? ` — ${result.error}` : ''}.`,
+        );
+    }
+  };
+
+  const speakLast = (): void => {
+    const reply = lastAssistantReply(deps.session.log);
+    if (!reply) {
+      notice('read-aloud: no assistant reply to speak yet.');
+      return;
+    }
+    lastSpokenSeq = reply.seq;
+    start(reply.content);
+  };
+
+  return {
+    get autoSpeak() {
+      return autoSpeak;
+    },
+    handleCommand(arg: string) {
+      const hasSynthesizer = safeHasSynthesizer(deps.session);
+      const decision = resolveSpeakCommand({ arg, autoSpeak, hasSynthesizer });
+      switch (decision.action) {
+        case 'speak-last':
+          speakLast();
+          return;
+        case 'auto-on':
+          autoSpeak = true;
+          notice(decision.reply);
+          return;
+        case 'auto-off':
+          autoSpeak = false;
+          abortCurrent();
+          notice(decision.reply);
+          return;
+        case 'stop':
+          if (current) {
+            abortCurrent();
+            notice('read-aloud: stopped.');
+          } else {
+            notice('read-aloud: nothing is playing.');
+          }
+          return;
+        case 'notice':
+          notice(decision.reply);
+          return;
+      }
+    },
+    onTurnComplete() {
+      if (!autoSpeak) return;
+      const reply = lastAssistantReply(deps.session.log);
+      // No new final reply this turn (tool-only / errored / aborted) — don't
+      // re-speak the previous one.
+      if (!reply || reply.seq === lastSpokenSeq) return;
+      lastSpokenSeq = reply.seq;
+      start(reply.content);
+    },
+    stop() {
+      abortCurrent();
+    },
+    dispose() {
+      abortCurrent();
+    },
+  };
+}
+
+/** `tryGetActive` can throw on some sessions — treat any failure as "no synth". */
+function safeHasSynthesizer(session: SynthesizerSource): boolean {
+  try {
+    return session.synthesizers.tryGetActive() != null;
+  } catch {
+    return false;
+  }
+}
+
+function noPlayerNotice(platform: NodeJS.Platform): string {
+  switch (platform) {
+    case 'darwin':
+      return 'read-aloud: no audio player found (`afplay` ships with macOS — is it on PATH?).';
+    case 'linux':
+      return 'read-aloud: no audio player found. Install one of: paplay (pulseaudio-utils), aplay (alsa-utils), or ffplay (ffmpeg).';
+    case 'win32':
+      return 'read-aloud: no audio player available for this format on Windows (WAV plays via PowerShell; install ffmpeg for other formats).';
+    default:
+      return 'read-aloud: no audio player found — install ffmpeg (ffplay).';
+  }
+}

--- a/packages/plugin-cli/src/session/run-slash.test.ts
+++ b/packages/plugin-cli/src/session/run-slash.test.ts
@@ -236,6 +236,42 @@ describe('runSlash /sessions', () => {
   });
 });
 
+describe('runSlash /speak', () => {
+  it('forwards the argument to runSpeak and clears the notice', () => {
+    const args: string[] = [];
+    const notices: Array<string | null> = [];
+    runSlash('/speak on', {
+      ...baseDeps(),
+      runSpeak: (a) => args.push(a),
+      setSystemNotice: (n) => notices.push(n),
+    } as unknown as SlashDeps);
+    expect(args).toEqual(['on']);
+    expect(notices).toContain(null);
+  });
+
+  it('bare /speak forwards an empty argument', () => {
+    const args: string[] = [];
+    runSlash('/speak', { ...baseDeps(), runSpeak: (a) => args.push(a) } as unknown as SlashDeps);
+    expect(args).toEqual(['']);
+  });
+
+  it('the /say alias forwards too', () => {
+    const args: string[] = [];
+    runSlash('/say stop', { ...baseDeps(), runSpeak: (a) => args.push(a) } as unknown as SlashDeps);
+    expect(args).toEqual(['stop']);
+  });
+
+  it('degrades to a notice when read-aloud is not wired', () => {
+    const notices: Array<string | null> = [];
+    runSlash('/speak on', {
+      ...baseDeps(),
+      runSpeak: undefined,
+      setSystemNotice: (n) => notices.push(n),
+    } as unknown as SlashDeps);
+    expect(notices.some((n) => typeof n === 'string' && /not available/.test(n))).toBe(true);
+  });
+});
+
 function baseDeps(): SlashDeps {
   return {
     session: {

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -44,6 +44,13 @@ export interface SlashDeps {
     packageName: string;
     spec: import('@moxxy/sdk').PluginSetupSpec;
   }) => void;
+  /**
+   * Dispatch `/speak [on|off|stop|status]` — synthesize + play assistant replies
+   * through the session's active Synthesizer. Owned by SessionView (holds the
+   * read-aloud controller with its auto-speak flag + in-flight playback). Absent
+   * on any host that doesn't wire read-aloud — `/speak` then degrades to a notice.
+   */
+  runSpeak?: (arg: string) => void;
 }
 
 export function runSlash(cmd: string, deps: SlashDeps): void {
@@ -157,6 +164,15 @@ export function runSlash(cmd: string, deps: SlashDeps): void {
     case 'channels':
       deps.setSystemNotice(null);
       deps.setOverlay({ kind: 'channels' });
+      return;
+    case 'speak':
+    case 'say':
+      if (!deps.runSpeak) {
+        deps.setSystemNotice('read-aloud is not available on this session');
+        return;
+      }
+      deps.setSystemNotice(null);
+      deps.runSpeak(args);
       return;
     case 'goal':
       return startGoal(deps, args);

--- a/packages/plugin-cli/src/session/use-read-aloud.ts
+++ b/packages/plugin-cli/src/session/use-read-aloud.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import { createReadAloud, type ReadAloud } from './read-aloud.js';
+
+export interface UseReadAloudOptions {
+  readonly session: Session;
+  readonly setSystemNotice: (notice: string | null) => void;
+}
+
+/**
+ * React wrapper around the {@link createReadAloud} controller. The controller
+ * holds the auto-speak flag + in-flight playback in plain fields (no React
+ * state) so the seam that speaks on turn completion reads the LATEST values;
+ * the UI surfaces playing/failure state through `setSystemNotice`. The session
+ * + notice setter are stable for the view's lifetime (BootShell re-mounts on a
+ * session switch), so the controller is built once.
+ */
+export function useReadAloud(opts: UseReadAloudOptions): ReadAloud {
+  const { session, setSystemNotice } = opts;
+  const ref = useRef<ReadAloud | null>(null);
+  if (ref.current === null) {
+    ref.current = createReadAloud({ session, setSystemNotice });
+  }
+  // Unmount safety: stop playback so the spawned player is signalled to quit
+  // and its temp file is cleaned up (TUI teardown / session switch / process
+  // exit mid-playback).
+  useEffect(() => {
+    return () => {
+      ref.current?.dispose();
+    };
+  }, []);
+  return ref.current;
+}

--- a/packages/plugin-cli/src/session/use-turn-runner.ts
+++ b/packages/plugin-cli/src/session/use-turn-runner.ts
@@ -16,6 +16,14 @@ export interface TurnRunnerOptions {
   /** Optional notice sink — used to warn the user when a large queue drain is
    *  split across turns rather than merged into one oversized prompt. */
   onNotice?: (msg: string) => void;
+  /**
+   * Fired once per turn that completes WITHOUT being aborted — the seam where
+   * the final assistant reply is known (mirrors the telegram/discord
+   * turn-runners' `onFinalReply`, but TUI-side). Powers auto-speak: the handler
+   * reads the final reply from `session.log` and speaks it. Best-effort — a
+   * throwing handler never breaks the turn lifecycle.
+   */
+  onTurnComplete?: () => void;
 }
 
 /** Cap how many queued messages merge into one follow-up turn, and the joined
@@ -96,6 +104,17 @@ export function useTurnRunner(opts: TurnRunnerOptions): TurnRunnerHandle {
         ...(attachments.length > 0 ? { attachments } : {}),
       })) {
         void _event;
+      }
+      // Turn finished without an abort/throw: fire the completion seam (the
+      // final assistant reply is now in session.log). Isolated in its own
+      // try/catch so an auto-speak failure can never break the turn — and
+      // skipped on abort so an interrupted turn is never spoken.
+      if (!controller.signal.aborted) {
+        try {
+          opts.onTurnComplete?.();
+        } catch {
+          /* read-aloud is best-effort; never surface into the turn */
+        }
       }
     } catch (err) {
       // surfaced via error events; nothing extra to do

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1676,6 +1676,9 @@ importers:
 
   packages/plugin-cli:
     dependencies:
+      '@moxxy/channel-kit':
+        specifier: workspace:*
+        version: link:../channel-kit
       '@moxxy/chat-model':
         specifier: workspace:*
         version: link:../chat-model


### PR DESCRIPTION
## `/speak` — read replies aloud (TUI)

The last voice piece: a `/speak` command in the terminal UI that synthesizes the
assistant's reply through the session's **active Synthesizer** and plays it
through the system audio player. Works on both self-hosted and runner-attached
sessions (RemoteSession proxies `synthesize` over RPC).

### UX / semantics
- **`/speak`** (bare) — speak the **last** assistant reply now.
- **`/speak on` / `off`** — sticky auto-speak of each final reply for this TUI
  session (in-memory, not persisted). Turning `on` with no synthesizer still
  arms the preference (so replies start speaking once a backend is installed)
  and appends an install hint.
- **`/speak stop`** — stop current playback. A second `/speak` also supersedes
  (aborts) the in-flight one; Ctrl+C / `/new` / `/clear` / unmount stop it too.
- **`/speak status`** — report the auto-speak state. Alias: `/say`.
- **No active synthesizer** → a notice pointing at
  `moxxy plugins install tts-local` (offline) or `tts-openai`.

Read-aloud is **best-effort and never blocks input**: a missing synthesizer,
TTS error, missing player, or non-zero exit all surface a subtle notice on the
existing status/notice strip (no new panels). **Replies always render as text**
regardless. Synthesis reuses `@moxxy/channel-kit`'s transport-agnostic
`synthesizeReply` + `toSpeech` (markdown→speech cleanup) — the same path the
Telegram/Discord voice replies use.

### Auto-speak seam
Hooked `useTurnRunner`'s completion point — a new `onTurnComplete` callback
fires **once per turn that finishes without an abort** (the TUI-side mirror of
the telegram/discord turn-runners' `onFinalReply`). SessionView routes it to the
read-aloud controller, which reads the final `assistant_message` (`end_turn`,
non-empty) from `session.log` and speaks it, **deduped by event `seq`** so an
errored/tool-only turn doesn't re-voice the previous reply. Aborted turns are
never spoken; the hook is isolated in its own try/catch so it can't break the
turn lifecycle.

### Player matrix (`src/audio-play.ts`)
| Platform | Players (in order) | Notes |
|---|---|---|
| **darwin** | `afplay` → `ffplay` | afplay = CoreAudio (WAV/MP3/M4A/AAC); OGG/Opus falls back to ffplay |
| **linux** | `paplay` → `aplay` → `ffplay` | aplay is WAV-only; ffplay `-nodisp -autoexit -loglevel quiet` is the universal fallback |
| **win32** | PowerShell `Media.SoundPlayer` → `ffplay` | SoundPlayer is WAV-only; other formats need ffplay |

Chosen binary is **presence-probed (cached per process)**, mirroring
`checkVoiceCaptureAvailable`; bytes are written to an `os.tmpdir()` temp file
(cleaned up after); the player is **SIGKILLed on abort**; spawn is injectable
for tests; every failure is a typed result — the helper **never throws into the
UI**.

### Tests
- `audio-play.test.ts` — per-platform player pick, ffplay headless args, probe
  caching (one spawn per command), abort→SIGKILL→`aborted`, non-zero→`failed`,
  already-aborted signal, missing-player result.
- `read-aloud.test.ts` — `resolveSpeakCommand` parsing (bare/on/off/stop/status/
  unknown) + no-synthesizer nudge, `lastAssistantReply` selection/dedupe, and
  the controller with a fake synthesizer + player: **off by default**, speaks the
  final reply **exactly once** (seq-deduped), synth/player failure never throws
  and never blocks (text unaffected).
- `run-slash.test.ts` — `/speak` + `/say` dispatch forwarding, degrade notice
  when read-aloud isn't wired.

### Manual verification (audible check per OS)
- [ ] **macOS**: install a TTS backend (`moxxy plugins install tts-local`), send
      a message, run `/speak` → hear the reply via `afplay`. Toggle `/speak on`,
      send another → auto-speaks. `/speak stop` mid-playback halts it.
- [ ] **Linux**: same, confirming `paplay`/`aplay`/`ffplay` fallback order.
- [ ] **Windows**: WAV reply via PowerShell SoundPlayer; non-WAV via ffplay.
- [ ] No synthesizer → notice points at `tts-local` / `tts-openai`; no crash.

### Gate
`pnpm build` ✓ (84/84) · `pnpm typecheck` ✓ (141/141) · `pnpm lint` ✓ (0 errors)
· `pnpm test` ✓ · `pnpm check:deps` ✓ (0 errors). One changeset
(`@moxxy/plugin-cli` patch). TECH_DEBT.md and the catalog untouched.
