### PR TITLE
chore(tech-debt): backlog cleanup sweep (retire 9, refine 5)

### DIFF
--- a/.changeset/tech-debt-cleanup-jul05.md
+++ b/.changeset/tech-debt-cleanup-jul05.md
@@ -1,0 +1,15 @@
+---
+'@moxxy/cli': patch
+'@moxxy/sdk': patch
+'@moxxy/desktop': patch
+---
+
+Tech-debt backlog cleanup pass.
+
+- CLI: new `moxxy channels rotate-token <name>` verb wrapping the SDK-only `rotateChannelToken` (SECURITY.md's hardening checklist recommended rotation but nothing exposed it).
+- CLI: standalone `moxxy mobile` now stamps `MOXXY_SESSION_SOURCE=mobile` (via a declared `sessionSource` on the channel def) so the empty pre-first-prompt session is no longer mis-stamped `tui` and dropped from the mobile list.
+- SDK: `resolveModelContext` no longer SILENTLY falls back to the first model descriptor on an unrecognized model id — it emits a one-shot `console.warn` (deduped per provider/requested-id/fallback-id) so a wrong context-window calibration is observable.
+- Desktop: compile-time partition of the app-bridge method sets (`RENDERER_DISPATCHED_METHODS` vs the host `BridgeServices` map) so a mis-/un-classified method is now a `tsc` error rather than a runtime-test-only check.
+- Desktop: the keyless `local` provider no longer prompts for a non-existent API key in the Configure sheet.
+- Desktop: stop Vite emitting a ~21 MB orphan ONNX-Runtime wasm into `dist/assets/` on every bundle (the runtime loads ORT from `/ort/`; the emitted copy was dead); the real anonymizer wasm is untouched.
+- Desktop: added a drift guard that fails if the hand-mirrored channel catalog diverges from each plugin's `ChannelDef.config`.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -8,6 +8,17 @@ moment you see it. See AGENTS.md → "Tech debt is a standing job".
 entries were compacted away; what remains below is the currently-OPEN backlog as a
 scannable summary. Git history holds the full prior journal if you need it.
 
+**Cleanup pass 2026-07-05** — targeted backlog sweep (parallel fixes over disjoint
+subsystems). Retired: `moxxy channels rotate-token` CLI, compile-time `RENDERER_DISPATCHED_METHODS`
+partition, `moxxy mobile` session-source stamp, Vite orphan-ORT-wasm emit, `local`-provider
+key prompt, a channel-catalog drift guard, and mobile grab-bag cleanups (SafeAreaView, dead
+`ToolGroupUi` fields, unused `LargeHeader`); plus two VERIFIED-already-fixed (`provider.setEnabled`
+race now serialized by `configMutex`; one-shot commands drain via `closeSession()`) with
+regression tests added. Refined (narrowed, still open): `resolveModelContext` now warns on the
+`models[0]` fallback (calibration-from-usage still open); dropped-attachment notice, `FilesPane`
+repo-root, built-in-provider model editing, and the remaining mobile-misc items carry precise
+implementation paths. Full pre-PR gate green.
+
 Severity tags: `[critical]`/`[high]`/`[med]`/`[low]`, `[note]` = standing practice
 or recorded-on-purpose decision.
 
@@ -27,6 +38,56 @@ or recorded-on-purpose decision.
   objective, reverts to `ctx.previousModeName` on completion, refused as a
   boot/category default, and no channel flips session-wide approval anymore
   (the run's own scoped resolver auto-approves).
+- [low, cli/security-dx, RESOLVED 2026-07-05] `moxxy channels rotate-token <name>` now wraps
+  the SDK-only `rotateChannelToken` (SECURITY.md recommended rotation but no CLI exposed it):
+  a reserved verb rotates `~/.moxxy/<name>-token` (the mobile channel's file convention) as a
+  pure file op and prints a "clients must re-pair" notice.
+  `packages/cli/src/commands/channels.ts`, `packages/cli/src/bin.ts`.
+- [med, cli, RESOLVED 2026-07-05] One-shot commands (`-p`, `schedule run`, `doctor`, `login`,
+  `init`) draining persistence before exit — VERIFIED already handled: the shared
+  `closeSession()` (`flush()` → `settleWrites()` → `session.close()`) is awaited in each
+  command's `finally`, ahead of `bin.ts`'s `process.exit`. Stale entry; kept as a
+  regression-covered invariant. `packages/cli/src/setup/close-session.ts`.
+- [med, desktop/config, RESOLVED 2026-07-05] `provider.setEnabled` "lost update" race —
+  VERIFIED already fixed: the store moved off the stale `ipc/preferences.ts` pointer into
+  `@moxxy/config`, whose read-modify-write runs inside a module-level `configMutex`; added a
+  two-concurrent-toggles no-lost-update regression test.
+  `packages/config/src/user-config.ts`, `packages/config/src/user-config.test.ts`.
+- [med, apps, RESOLVED 2026-07-05] `RENDERER_DISPATCHED_METHODS` disjointness/exhaustiveness vs
+  the host `BridgeServices` map was runtime-test-only (drift compiled fine). Now compile-enforced:
+  `BridgeMethod = RendererDispatchedMethod | HostDispatchedMethod`, the renderer Set built from a
+  `Record<RendererDispatchedMethod, true>` table, `BridgeServices` a mapped type keyed by
+  `HostDispatchedMethod`, plus two equality guards (exhaustive over `keyof BridgeMethods` +
+  disjoint). Member lists unchanged; runtime tests kept as belt-and-suspenders.
+  `packages/desktop-app-sdk/src/bridge.ts`, `packages/desktop-app-sdk/src/index.ts`,
+  `packages/desktop-host/src/apps/bridge-host.ts`.
+- [low, mobile, RESOLVED 2026-07-05] Standalone `moxxy mobile` left `MOXXY_SESSION_SOURCE` unset,
+  so the runner's env heuristic stamped the empty pre-first-prompt session `'tui'` and dropped it
+  from the mobile list until its first prompt. Fixed by declaring `sessionSource:'mobile'` on
+  `mobileChannelDef` and making `applyDedicatedRunnerEnv` stamp a DECLARED source even for
+  non-dedicated channels (caller-pinned env still wins).
+  `packages/plugin-channel-mobile/src/index.ts`,
+  `packages/cli/src/commands/start-registered-channel.ts`.
+- [low, mobile, RESOLVED 2026-07-05] Mobile UI grab-bag: migrated `QrScannerSheet`'s deprecated
+  RN `SafeAreaView` to `react-native-safe-area-context`; removed dead `ToolGroupUi.accent`/`tint`
+  fields; deleted the unused `LargeHeader` component. `apps/mobile/src/components/QrScannerSheet.tsx`,
+  `apps/mobile/src/toolGroupUi.ts`, `apps/mobile/src/ui/kit.tsx`.
+- [med, desktop/vite-build, RESOLVED 2026-07-05] transformers.js's ORT glue
+  `new URL('…jsep.wasm', import.meta.url)` made Vite emit a ~21 MB ORPHAN wasm into `dist/assets/`
+  on every bundle (dead path — the NER worker sets `wasmPaths=/ort/`, so `locateFile` always wins).
+  Added an `ortWasmDropOrphan()` renderer plugin deleting the hashed `assets/` orphan in
+  `generateBundle`; the real `dist/ort/…jsep.wasm` copy (`writeBundle`, unhashed name, outside the
+  Rollup bundle) is untouched — verified in an isolated repro. `apps/desktop/electron.vite.config.ts`.
+- [low, desktop/local-provider, RESOLVED 2026-07-05] The desktop Configure sheet prompted for a
+  non-existent API key on the keyless `local` provider (core reports its placeholder-key authKind
+  as `api-key`). Added `providerNeedsNoKey()` (keyed off the canonical `local` slug) to show a
+  "no key needed" note instead of a key input. `apps/desktop/src/settings/ProvidersTab.tsx`.
+- [low, desktop-host/channel-catalog, RESOLVED 2026-07-05] The hand-mirrored `channel-catalog.ts`
+  had no test catching drift from the source of truth. Added a drift guard importing each channel
+  plugin's `ChannelDef` directly and asserting vault keys / required / secret-type / `hasWebhookUrl`
+  match (keyed by `vaultKey`) — silent drift now fails a test. (Removing the duplication via
+  `channels describe --json` remains a separate follow-up.)
+  `packages/desktop-host/src/channel-catalog.test.ts`.
 - [med, modes, RESOLVED 2026-07-05] Every ReAct-shaped mode duplicated ~250 lines
   of loop plumbing — `mode-default`, `mode-goal`, and the collab agent loop each
   carried a divergent copy of retry back-off / reactive compaction / stuck
@@ -194,10 +255,6 @@ or recorded-on-purpose decision.
 - [low, scale] `desks.changed` ships the full desk list (O(N) payload); a delta
   event (changed desk/session only) would cut cross-device payload to O(1). The
   projection-diff already suppresses per-event churn. `packages/desktop-host/src/sessions-watcher.ts`.
-- [low] Standalone `moxxy mobile` empty-session source: seeded `source:'mobile'`,
-  but the env-heuristic runner write can later stamp `tui`, dropping an empty
-  session from the list until its first prompt. Set `MOXXY_SESSION_SOURCE=mobile`
-  on the `moxxy mobile` runner to make it airtight. `packages/plugin-channel-mobile`.
 - [note] Stress-test multi-session with a desk's SECOND (UUID) session — the first
   session has id === desk id, which masks pool-key regressions. `packages/desktop-host`.
 - [low] TUI `/sessions` switcher only works in self-host/standalone mode (the TUI
@@ -288,14 +345,16 @@ or recorded-on-purpose decision.
   to the viewer). `packages/plugin-terminal/src/pty.ts`.
 - [low] Files pane polls IPC instead of streaming via the Surface protocol — promote
   to a real Surface if a third live pane appears. `apps/desktop/src/shell/surfaces/`.
-- [low] "Add to agent" on a git-changed file assumes cwd === repo root. `FilesPane.tsx`.
+- [low] "Add to agent" on a git-changed file assumes cwd === repo root: `git status`
+  paths are repo-root-relative, but `FilesPane` builds `absPath = cwd + relPath`, wrong
+  when the session cwd is a repo subdir (the same mismatch hits the diff viewer's
+  `confineDiffPath`). No repo-root is exposed to the renderer; the fix needs a new
+  `git.root` IPC (`ipc/git.ts` + contract). `apps/desktop/src/shell/surfaces/FilesPane.tsx`.
 - [low] Terminal tool completion is sentinel-heuristic; a structured exec channel
   would be cleaner. `packages/plugin-terminal/`.
 
 ## Desktop / apps & send-to-chat
 
-- [med] `RENDERER_DISPATCHED_METHODS` disjointness is a runtime test, not compile-time
-  — a type-level partition would make drift a compile error. `apps/desktop/src/bridge/`.
 - [med] `session.send` not reachable by sandboxed apps — the iframe runtime /
   postMessage↔IPC relay doesn't exist yet (only the built-in anonymizer path ships).
   `apps/desktop/src/apps/`.
@@ -311,20 +370,26 @@ or recorded-on-purpose decision.
 
 - [med] Polish NER recall unproven (cross-lingual transfer) — needs a real-Polish-doc
   eval harness or the `jiting/...hrl_onnx` fallback. `packages/anonymizer/`.
-- [med] Vite emits a ~21 MB orphan ORT wasm under `dist/assets/` (internal
-  `new URL(...)`) on every hot-update bundle — stop the emit via resolve alias /
-  `assetsInclude`. `apps/desktop/electron.vite.config.ts`.
 - [low] Crypto/secret checksums are structural-only (no crypto dep); no HIPAA
   Safe-Harbor profile; context window is a flat 48 chars. `packages/anonymizer/`.
 
 ## Desktop / attachments, settings, providers
 
-- [med] Dropped attachments are invisible — round-trip a notice when
-  `authorizeAttachments`/`buildAttachments` rejects/skips. `packages/desktop-host/src/ipc/`.
-- [med, consistency] `provider.setEnabled` is fire-and-forget read-merge-write — two
-  rapid cross-client toggles can lose one update. `packages/desktop-host/src/ipc/preferences.ts`.
-- [low] Configure sheet can't edit a built-in provider's models array; `local`
-  provider wizard prompts for a non-existent key (`auth.kind` should be `none`).
+- [med] Dropped attachments are invisible — two silent skip sites only `console.warn`:
+  `authorizeAttachments` (`ipc/session.ts`, sync, drops unauthorized-provenance paths; its
+  `dropped[]` is already available) and `buildAttachments` (`attachments.ts`, skips
+  oversized/binary/unextractable files) which runs ASYNC inside `session-driver.ts`'s
+  fire-and-forget pump AFTER the IPC `{turnId}` already returned. A user notice needs a
+  contract transport (a `droppedAttachments?` field on `RunTurnResult` and/or a
+  `skippedAttachments?` on `runner.turn.complete`), emission from `session-driver.ts`, and
+  renderer display — no generic notice channel exists to reuse (only `error{kind:'fatal'}`
+  renders, which would read as a turn failure).
+  `packages/desktop-host/src/{ipc/session.ts,attachments.ts,attachment-authz.ts}`.
+- [low] Configure sheet can't edit a built-in provider's models array — a genuine
+  feature, not a bug: provider-admin (`plugin-provider-admin`) intentionally throws
+  `CONFIG_INVALID` on `configure()` of a built-in (they are code, not stored config),
+  so exposing model-array editing needs new runner-side persistence for built-in
+  overrides. (The sibling `local`-wizard non-existent-key prompt is FIXED — see ledger.)
   `apps/desktop/src/settings/providers/`.
 
 ## Providers & model catalogs
@@ -342,9 +407,11 @@ or recorded-on-purpose decision.
   gpt-5.5/gpt-5.4 1M→400k) but the failure mode is latent for any future catalog
   drift; consider calibrating the effective window from real provider `usage` /
   observed overflow rather than the static descriptor. Related: `resolveModelContext`
-  (`packages/sdk/src/compactor-helpers.ts`) silently falls back to `models[0]` on an
-  exact-id miss, so an unlisted/variant model id (e.g. a `[1m]` suffix) resolves the
-  wrong window with no signal.
+  (`packages/sdk/src/compactor-helpers.ts`) still falls back to `models[0]` on an
+  exact-id miss (an unlisted/variant id like a `[1m]` suffix resolves the wrong
+  window), but the fallback is no longer SILENT — it emits a one-shot `console.warn`
+  deduped per (provider, requested id, fallback id). Remaining: calibrate the
+  *effective* window from observed usage/overflow rather than the static descriptor.
 
 ## Channels, relay & HTTP
 
@@ -362,13 +429,12 @@ or recorded-on-purpose decision.
   start — pairing from the desktop means run `moxxy discord pair`, then restart
   the channel. A `channels.confirmPairingCode` control-surface hook (status-file
   or IPC) would close both gaps. `packages/plugin-channel-discord`.
-- [low] Desktop channel catalog is now a MIRROR, not the only copy: each channel
-  self-describes its config on `ChannelDef.config` (`fields`/`vaultKey`/
-  `hasRequestUrl`/`runHint`), which the TUI `/channels` panel + `moxxy channels`
-  read from the live registry. The desktop `channel-catalog.ts` still hand-copies
-  it because the Electron main avoids booting plugin discovery; a
-  `moxxy channels describe --json` (or a drift test asserting the desktop catalog
-  matches each plugin's `def.config`) would remove the remaining duplication.
+- [low] Desktop channel catalog is a MIRROR: each channel self-describes its config on
+  `ChannelDef.config` (`fields`/`vaultKey`/`hasRequestUrl`/`runHint`), which the TUI
+  `/channels` panel + `moxxy channels` read from the live registry, but the desktop
+  `channel-catalog.ts` hand-copies it (the Electron main avoids booting plugin discovery).
+  A drift test now guards silent divergence (see ledger); the remaining follow-up is
+  REMOVING the duplication via a `moxxy channels describe --json` the desktop consumes.
   `packages/desktop-host/src/channel-catalog.ts`.
 - [low] Desktop-spawned channels are killed on app quit (a best-effort
   `process.once('exit')` SIGTERM in `channel-supervisor.ts`). The TUI/CLI surfaces
@@ -532,20 +598,19 @@ or recorded-on-purpose decision.
   `moxxy onboard` sidesteps it (single channel pick, pair-then-return), but a real
   fix needs either per-source resolver routing on the Session or a documented
   broker. Surfaced 2026-07-03 while building onboard.
-- [med] One-shot CLI commands (`-p`, `schedule run`, `doctor`, `login`, `init`) never
-  `close()` — drain persistence before exit. `packages/cli/`.
-- [low, security-dx] SECURITY.md's hardening checklist recommends rotating channel
-  tokens, but `rotateChannelToken` is SDK-only — no CLI wraps it. Consider
-  `moxxy channels rotate-token <name>`. `packages/sdk/src/channel-auth.ts`.
 
 ## Mobile UI (low-priority polish)
 
 - [med] Sending attachments while a turn is in flight is refused (inline payloads
   can't ride the path-based queue) — queue host-side if needed. `apps/mobile/`.
-- [low] Misc: theme flip can lag memoized rows (need a `themeVersion` counter);
-  `selectWorkspace`/`activeWorkspaceId` misnamed (they select a session); deprecated
-  `SafeAreaView`/`expo-blur` hard dep; `toolGroupUi` dead fields; unused `LargeHeader`;
-  header rename low-discoverability; composer-minimize overlay gesture not wired.
+- [low] Misc (remaining after 2026-07-05 cleanup): `selectWorkspace`/`activeWorkspaceId`
+  misnamed (they select a session) — BLOCKED, it's a shared
+  `client-core`/`desktop-ipc-contract` wire symbol, not mobile-local; `expo-blur` is a hard
+  dep but `BlurView` is actually used (not removable — revisit only if the glass surface is
+  dropped); theme flip could be reworked to a `themeVersion`-in-memo-deps model (today an
+  existing `key={scheme}` FlatList remount already re-resolves rows, so low value); header
+  rename low-discoverability; composer-minimize overlay gesture not wired. (SafeAreaView
+  migration, `toolGroupUi` dead fields, and the unused `LargeHeader` are FIXED — see ledger.)
 - [note] EAS build: `eas-build-post-install` runs `pnpm build` on the workspace
   closure; local repro needs wiping both `dist/` AND `*.tsbuildinfo`. `apps/mobile/eas.json`.
 

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -121,6 +121,46 @@ function ortWasmDevServer(): Plugin {
 }
 
 /**
+ * Vite plugin: drop the ORPHAN onnxruntime-web WASM that Vite's import-meta-url
+ * asset handling emits into `dist/assets/`.
+ *
+ * transformers.js dynamically imports onnxruntime-web's glue
+ * (`ort-wasm-simd-threaded.jsep.mjs`), which contains a
+ * `new URL('ort-wasm-simd-threaded.jsep.wasm', import.meta.url)` — emscripten's
+ * DEFAULT wasm path. Vite statically resolves that and emits a hashed ~21 MB copy
+ * into `dist/assets/` on EVERY bundle (and every hot-update). But that default is
+ * DEAD: the NER worker sets `env.backends.onnx.wasm.wasmPaths` (→ emscripten
+ * `locateFile`) to our locally-served `/ort/` base BEFORE the ORT session is
+ * created, so ORT loads the real binary from `dist/ort/` and never touches the
+ * `assets/` copy (the emscripten glue reads `Xa ??= locateFile ? locateFile(…) :
+ * new URL(…).href`, so with `wasmPaths` set the `new URL` branch is never taken).
+ * The emitted `assets/` file is therefore a pure orphan — delete it.
+ *
+ * This ONLY removes the orphan under `dist/assets/`. The REAL runtime binary lives
+ * at `dist/ort/ort-wasm-simd-threaded.jsep.wasm`, written by {@link ortWasmAssets}
+ * via a separate `writeBundle` file copy (NOT part of the Rollup bundle graph), so
+ * it is untouched. The anonymizer's on-device NER keeps loading ORT from `/ort/`
+ * exactly as before, and the moxxy-app-served model bundle is unaffected.
+ */
+function ortWasmDropOrphan(): Plugin {
+  // The orphan's hashed name: `ort-wasm-simd-threaded.jsep-<hash>.wasm` (the `-`
+  // after `jsep` is the asset hash separator — it never appears in the real,
+  // exact-named `dist/ort/…jsep.wasm`, which isn't in the bundle graph anyway).
+  const ORPHAN_RE = /(^|\/)ort-wasm-simd-threaded\.jsep-[^/]*\.wasm$/;
+  return {
+    name: 'moxxy-ort-wasm-drop-orphan',
+    apply: 'build',
+    generateBundle(_options, bundle): void {
+      for (const [fileName, chunk] of Object.entries(bundle)) {
+        if (chunk.type === 'asset' && ORPHAN_RE.test(fileName)) {
+          delete bundle[fileName];
+        }
+      }
+    },
+  };
+}
+
+/**
  * Workspace packages the main process imports at runtime. They MUST be
  * bundled INTO the main/preload output rather than left as bare
  * `require('@moxxy/…')` calls: electron-builder packs only `dist` /
@@ -213,7 +253,7 @@ export default defineConfig(({ mode }) => {
   },
   renderer: {
     root: '.',
-    plugins: [react(), ortWasmAssets(), ortWasmDevServer()],
+    plugins: [react(), ortWasmAssets(), ortWasmDevServer(), ortWasmDropOrphan()],
     resolve: {
       alias: {
         '@': path.resolve(__dirname, 'src'),

--- a/apps/desktop/src/settings/ProvidersTab.test.tsx
+++ b/apps/desktop/src/settings/ProvidersTab.test.tsx
@@ -131,6 +131,27 @@ describe('ProvidersTab', () => {
     );
   });
 
+  it('shows a "no key needed" note (not a key form) for the local provider', () => {
+    // The runner reports the local provider's authKind as 'api-key' (its def
+    // carries a placeholder key for the OpenAI SDK), but there is no real key
+    // to enter — the sheet must not prompt for one.
+    const local: ProviderEntry = {
+      name: 'local',
+      ready: false,
+      enabled: true,
+      active: false,
+      authKind: 'api-key',
+      kind: 'builtin',
+      keyName: 'LOCAL_API_KEY',
+    };
+    renderTab({ providers: [local] });
+    fireEvent.click(screen.getByRole('button', { name: /configure local/i }));
+    expect(screen.getByTestId('provider-no-key-note')).toBeTruthy();
+    expect(screen.queryByTestId('provider-key-input')).toBeNull();
+    // …and not the misleading "only the key is configurable" built-in note.
+    expect(screen.queryByText(/only the key is configurable/i)).toBeNull();
+  });
+
   it('offers a real sign-in (not a key form) for OAuth providers', () => {
     // The OAuthSignIn flow subscribes to provider.login.* on mount, so the
     // configure sheet needs a transport even though the buttons aren't clicked.

--- a/apps/desktop/src/settings/ProvidersTab.tsx
+++ b/apps/desktop/src/settings/ProvidersTab.tsx
@@ -60,6 +60,19 @@ function providerSupportsReasoning(p: ProviderRow): boolean {
   return p.supportsReasoning === true;
 }
 
+/**
+ * True for a provider that authenticates with NO API key — a local
+ * OpenAI-compatible server (Ollama, LM Studio, llama.cpp). The runner reports
+ * its `authKind` as `'api-key'` because the def carries a placeholder key for
+ * the OpenAI SDK, but there is no real credential to prompt for (the provider
+ * catalog's canonical auth is `'none'`). The built-in `local` provider's slug
+ * is forced on, so a name check is exact — mirrors the name-set the sibling
+ * onboarding step uses to tag OAuth providers. Without this the Configure sheet
+ * shows a key input for a key that does not exist. */
+function providerNeedsNoKey(p: ProviderRow): boolean {
+  return p.name === 'local';
+}
+
 export function ProvidersTab({
   providers,
   onToggle,
@@ -182,6 +195,7 @@ export function ProvidersTab({
 function subtitleFor(p: ProviderRow): string {
   if (!p.enabled) return 'Disabled · excluded from activation';
   if (p.ready) return 'Active · credentials resolved';
+  if (providerNeedsNoKey(p)) return 'Inactive · start a local server to connect';
   return p.authKind === 'oauth'
     ? 'Inactive · sign in to connect'
     : 'Inactive · add a key to use';
@@ -259,6 +273,15 @@ function ConfigureProviderModal({
               }}
             />
           </div>
+        ) : providerNeedsNoKey(provider) ? (
+          <p
+            data-testid="provider-no-key-note"
+            style={{ margin: 0, fontSize: 13, color: 'var(--color-text-muted)', lineHeight: 1.55 }}
+          >
+            Local servers need no API key — just point moxxy at a running OpenAI-compatible endpoint
+            (Ollama, LM Studio, llama.cpp). Set <code style={{ fontSize: 11.5 }}>LOCAL_MODEL_BASE_URL</code>{' '}
+            for a non-default endpoint, then start the server.
+          </p>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
             <label style={fieldLabelStyle}>
@@ -342,7 +365,7 @@ function ConfigureProviderModal({
           </div>
         )}
 
-        {!isAdmin && provider.authKind !== 'oauth' && (
+        {!isAdmin && provider.authKind !== 'oauth' && !providerNeedsNoKey(provider) && (
           <p style={{ margin: 0, fontSize: 12.5, color: 'var(--color-text-muted)', lineHeight: 1.5 }}>
             Built-in provider — endpoint and model list ship with moxxy; only the key is configurable.
           </p>

--- a/apps/mobile/src/components/QrScannerSheet.tsx
+++ b/apps/mobile/src/components/QrScannerSheet.tsx
@@ -1,5 +1,6 @@
 import { CameraView } from 'expo-camera';
-import { Pressable, SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import type { CameraPermissionState, PairingUiState } from '../pairingUi';
 import { useTheme } from '@/theme/ThemeProvider';
 import { MobileIcon } from './MobileIcon';

--- a/apps/mobile/src/toolGroupUi.ts
+++ b/apps/mobile/src/toolGroupUi.ts
@@ -1,8 +1,6 @@
 import type { ToolTranscriptItem } from './chatTranscript';
 
 export interface ToolGroupUi {
-  readonly accent: string;
-  readonly tint: string;
   readonly statusLabel: 'failed' | 'running' | 'ok';
   readonly summary: string;
   readonly pulse: boolean;
@@ -38,8 +36,6 @@ export function buildToolGroupUi(tools: ReadonlyArray<ToolTranscriptItem>): Tool
   const hasError = counts.error > 0;
   const hasRunning = counts.running > 0;
   return {
-    accent: hasError ? '#ef4444' : hasRunning ? '#ec4899' : '#16a34a',
-    tint: hasError ? '#fee2e2' : hasRunning ? '#fdf2f8' : '#ecfdf5',
     statusLabel: hasError ? 'failed' : hasRunning ? 'running' : 'ok',
     summary: [
       counts.ok > 0 ? `${counts.ok} ok` : '',

--- a/apps/mobile/src/ui/kit.tsx
+++ b/apps/mobile/src/ui/kit.tsx
@@ -352,34 +352,6 @@ export function Screen({
   );
 }
 
-/* ------------------------------------------------------------- LargeHeader */
-
-export function LargeHeader({
-  title,
-  subtitle,
-  right,
-}: {
-  readonly title: string;
-  readonly subtitle?: string;
-  readonly right?: ReactNode;
-}) {
-  return (
-    <View style={sx('flex-row items-end justify-between px-4 pb-2 pt-2', { gap: 12 })}>
-      <View style={sx('flex-1', { minWidth: 0 })}>
-        <Text style={sx('text-[30px] font-black text-text', { letterSpacing: -0.5 })} numberOfLines={1}>
-          {title}
-        </Text>
-        {subtitle ? (
-          <Text style={sx('mt-0.5 text-[14px] font-medium text-dim')} numberOfLines={1}>
-            {subtitle}
-          </Text>
-        ) : null}
-      </View>
-      {right ?? null}
-    </View>
-  );
-}
-
 /* ------------------------------------------------------------ DetailHeader */
 
 /** Header for a pushed (non-tab) screen: back chevron + title + optional right. */

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -73,6 +73,7 @@ const SECTIONS: ReadonlyArray<{ readonly title: string; readonly rows: ReadonlyA
       ['channels', 'list registered channels + their subcommands'],
       ['channels start|stop <name>', 'run a channel detached on its own runner (or stop it)'],
       ['channels status [name]', 'list the detached channels currently running'],
+      ['channels rotate-token <name>', "rotate a channel's persisted pairing secret (clients re-pair)"],
       ['channels <name>', 'start a channel by name in the foreground (same as `moxxy <name>`)'],
       ['channels <name> <sub>', 'invoke a channel-defined subcommand'],
       ['serve [--except <list>]', 'run every channel + background daemon in ONE process'],

--- a/packages/cli/src/commands/channels-control.test.ts
+++ b/packages/cli/src/commands/channels-control.test.ts
@@ -66,3 +66,38 @@ describe('moxxy channels stop', () => {
     expect(out).toContain('is not running');
   });
 });
+
+describe('moxxy channels rotate-token', () => {
+  it('rejects a missing channel name (exit 2)', async () => {
+    const code = await runChannelsCommand(argv('rotate-token'));
+    expect(code).toBe(2);
+  });
+
+  it('writes a fresh token file (0600) and tells clients to re-pair', async () => {
+    const file = path.join(home, 'mobile-token');
+    expect(fs.existsSync(file)).toBe(false);
+
+    const code = await runChannelsCommand(argv('rotate-token', 'mobile'));
+    expect(code).toBe(0);
+    expect(out).toContain('mobile');
+    expect(out).toContain('re-pair');
+
+    expect(fs.existsSync(file)).toBe(true);
+    const first = JSON.parse(fs.readFileSync(file, 'utf8')) as { token?: string };
+    expect(typeof first.token).toBe('string');
+    expect(first.token).toHaveLength(64); // 32 random bytes as hex
+    // 0600 — never world/group readable (secret material).
+    expect(fs.statSync(file).mode & 0o077).toBe(0);
+  });
+
+  it('replaces the previous secret on each rotation', async () => {
+    await runChannelsCommand(argv('rotate-token', 'mobile'));
+    const file = path.join(home, 'mobile-token');
+    const before = (JSON.parse(fs.readFileSync(file, 'utf8')) as { token: string }).token;
+
+    await runChannelsCommand(argv('rotate-token', 'mobile'));
+    const after = (JSON.parse(fs.readFileSync(file, 'utf8')) as { token: string }).token;
+
+    expect(after).not.toBe(before);
+  });
+});

--- a/packages/cli/src/commands/channels.ts
+++ b/packages/cli/src/commands/channels.ts
@@ -1,8 +1,11 @@
+import path from 'node:path';
 import type { ChannelDef, ChannelRunStatus, ChannelSubcommand } from '@moxxy/sdk';
 import {
   clearChannelStatus,
   liveChannelStatus,
   listLiveChannelStatuses,
+  moxxyHome,
+  rotateChannelToken,
   spawnDedicatedChannel,
   stopDedicatedChannel,
 } from '@moxxy/sdk/server';
@@ -20,6 +23,7 @@ import { colors } from '../colors.js';
  *  - `moxxy channels status [name]`         list the DETACHED channels currently running
  *  - `moxxy channels start <name>`          start a channel on its own detached runner
  *  - `moxxy channels stop <name>`           stop a detached channel
+ *  - `moxxy channels rotate-token <name>`   rotate a channel's persisted pairing secret
  *  - `moxxy channels <name>`                boot and run a channel by name (same as `moxxy <name>`)
  *  - `moxxy channels <name> --help`         show <name>'s description + subcommands (no boot)
  *  - `moxxy channels <name> <sub>`          invoke a channel-defined subcommand
@@ -49,6 +53,7 @@ export async function runChannelsCommand(argv: ParsedArgv): Promise<number> {
   if (name === 'status') return runStatus(argv.positional[1]);
   if (name === 'start') return runStart(argv);
   if (name === 'stop') return runStop(argv);
+  if (name === 'rotate-token') return runRotateToken(argv);
 
   // Channel-introspection paths (read def, list subcommands) only need
   // the registry — they don't run a turn, so they MUST NOT boot the
@@ -317,6 +322,33 @@ async function runStop(argv: ParsedArgv): Promise<number> {
     clearChannelStatus(channelName);
   }
   process.stdout.write(`${colors.bold(channelName)} ${colors.dim('stopped')}\n`);
+  return 0;
+}
+
+/**
+ * `moxxy channels rotate-token <name>` — replace the channel's persisted pairing
+ * secret (`~/.moxxy/<name>-token`, the file convention `resolveChannelToken`
+ * uses) with a fresh one. The old token stops authenticating, so every paired
+ * client must re-pair; a channel already running keeps the old token in memory
+ * until it is restarted. Pure file op — no session boot. A token supplied via
+ * env (`MOXXY_<NAME>_TOKEN`) or `channels.<name>.token` config takes precedence
+ * at resolve time and must be rotated at its source (see `rotateChannelToken`).
+ */
+async function runRotateToken(argv: ParsedArgv): Promise<number> {
+  const channelName = argv.positional[1];
+  if (!channelName) {
+    printError('usage: moxxy channels rotate-token <name>');
+    return 2;
+  }
+  const fileName = `${channelName}-token`;
+  rotateChannelToken({ fileName });
+  const file = path.join(moxxyHome(), fileName);
+  process.stdout.write(
+    `${colors.bold(channelName)} ${colors.dim('pairing token rotated')}\n` +
+      `  ${colors.dim(`new secret written to ${file}`)}\n` +
+      `  ${colors.dim('The old token no longer authenticates — every paired client must re-pair.')}\n` +
+      `  ${colors.dim(`Restart the channel (\`moxxy channels stop/start ${channelName}\`) for the new token to take effect.`)}\n`,
+  );
   return 0;
 }
 

--- a/packages/cli/src/commands/start-registered-channel.test.ts
+++ b/packages/cli/src/commands/start-registered-channel.test.ts
@@ -60,6 +60,16 @@ describe('applyDedicatedRunnerEnv', () => {
     expect(process.env.MOXXY_SESSION_SOURCE).toBeUndefined();
   });
 
+  it('stamps a declared sessionSource even when not dedicated (mobile)', () => {
+    const dedicated = applyDedicatedRunnerEnv('mobile', argv(), { sessionSource: 'mobile' });
+    // Non-dedicated: no runner socket / sticky session id are minted...
+    expect(dedicated).toBe(false);
+    expect(process.env.MOXXY_RUNNER_SOCKET).toBeUndefined();
+    expect(process.env.MOXXY_SESSION_ID).toBeUndefined();
+    // ...but the declared source is stamped so the runner records the right origin.
+    expect(process.env.MOXXY_SESSION_SOURCE).toBe('mobile');
+  });
+
   it('opts in via the --dedicated flag even when not declared', () => {
     applyDedicatedRunnerEnv('web', argv({ dedicated: true }), {});
     expect(process.env.MOXXY_RUNNER_SOCKET).toContain('channel-web');

--- a/packages/cli/src/commands/start-registered-channel.ts
+++ b/packages/cli/src/commands/start-registered-channel.ts
@@ -93,12 +93,22 @@ export async function startRegisteredChannel(
  * at runtime with `--dedicated` or `MOXXY_DEDICATED_RUNNER=1`. A caller that
  * already pinned the socket/session id/source (e.g. the desktop supervisor)
  * always wins — we only fill in what is unset.
+ *
+ * A declared `sessionSource` is stamped whether or not the channel runs
+ * dedicated: a NON-dedicated channel that self-hosts the runner (e.g. `mobile`)
+ * still owns its session and wants the right origin recorded, so its empty
+ * pre-first-prompt session isn't dropped by the runner's tui/desktop heuristic.
  */
 export function applyDedicatedRunnerEnv(
   name: string,
   argv: ParsedArgv,
   opts: DedicatedRunnerOpts,
 ): boolean {
+  // Stamp the declared source first — it's independent of dedication, and the
+  // caller-pinned env still wins via the unset guard.
+  if (!process.env.MOXXY_SESSION_SOURCE && opts.sessionSource) {
+    process.env.MOXXY_SESSION_SOURCE = opts.sessionSource;
+  }
   const dedicated =
     opts.dedicatedRunner === true ||
     hasBoolFlag(argv, 'dedicated') ||
@@ -112,9 +122,6 @@ export function applyDedicatedRunnerEnv(
   }
   if (!process.env.MOXXY_SESSION_ID) {
     process.env.MOXXY_SESSION_ID = `moxxy-channel-${name}`;
-  }
-  if (!process.env.MOXXY_SESSION_SOURCE && opts.sessionSource) {
-    process.env.MOXXY_SESSION_SOURCE = opts.sessionSource;
   }
   return true;
 }

--- a/packages/config/src/user-config.test.ts
+++ b/packages/config/src/user-config.test.ts
@@ -3,7 +3,12 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { parse as parseYaml } from 'yaml';
-import { applyInitConfig, setPluginEnabled } from './user-config.js';
+import {
+  applyInitConfig,
+  loadDisabledProviders,
+  setPluginEnabled,
+  setProviderEnabled,
+} from './user-config.js';
 import { moxxyConfigSchema } from './schema.js';
 
 let tmp: string;
@@ -109,5 +114,36 @@ describe('applyInitConfig', () => {
     );
     const raw = await fs.readFile(configPath, 'utf8');
     expect(raw).toContain('# my hand-written config');
+  });
+});
+
+describe('setProviderEnabled', () => {
+  it('serializes two concurrent toggles so neither update is lost', async () => {
+    // Two rapid cross-client toggles (e.g. desktop + mobile hitting the same
+    // runner) each read-merge-write config.yaml on DIFFERENT providers. Without
+    // the config writer's mutex the second read would see the pre-first-write
+    // snapshot and clobber the first provider's flag (last-writer-wins). The
+    // module-level `configMutex` makes the second reader see the first's result.
+    await Promise.all([
+      setProviderEnabled('openai', false, { configPath }),
+      setProviderEnabled('anthropic', false, { configPath }),
+    ]);
+
+    // Both landed: the file must reflect both disabled flags, not just one.
+    const parsed = (await readParsed()) as {
+      plugins: { provider: { items: Record<string, { enabled: boolean }> } };
+    };
+    expect(parsed.plugins.provider.items.openai).toEqual({ enabled: false });
+    expect(parsed.plugins.provider.items.anthropic).toEqual({ enabled: false });
+    expect([...(await loadDisabledProviders({ configPath }))].sort()).toEqual([
+      'anthropic',
+      'openai',
+    ]);
+  });
+
+  it('a later toggle overwrites the same provider flag deterministically', async () => {
+    await setProviderEnabled('openai', false, { configPath });
+    await setProviderEnabled('openai', true, { configPath });
+    expect(await loadDisabledProviders({ configPath })).toEqual([]);
   });
 });

--- a/packages/desktop-app-sdk/src/bridge.ts
+++ b/packages/desktop-app-sdk/src/bridge.ts
@@ -70,7 +70,42 @@ export interface BridgeMethods {
   };
 }
 
-export type BridgeMethod = keyof BridgeMethods;
+/**
+ * The renderer/host partition, at the type level. Every bridge method runs in
+ * exactly ONE place: the host RENDERER (a UI concern) or a MAIN-PROCESS service.
+ * Splitting {@link BridgeMethod} into these two disjoint halves turns a drift in
+ * the split — a method in BOTH sides, or in NEITHER — into a COMPILE error rather
+ * than a mere runtime-test failure (the guards below, the typed
+ * {@link RENDERER_DISPATCHED_METHODS} set, and the host's `BridgeServices` map all
+ * key off these types).
+ */
+
+/** Resolved in the host RENDERER (e.g. `session.send` prefills the active chat
+ *  composer); never reaches a main-process service. See
+ *  {@link RENDERER_DISPATCHED_METHODS}. */
+export type RendererDispatchedMethod = 'session.send';
+
+/** Backed by a MAIN-PROCESS service (native dialogs + document parsing + the
+ *  anonymizer engine); dispatched through `BridgeServices` in
+ *  `@moxxy/desktop-host`. */
+export type HostDispatchedMethod = 'documents.open' | 'documents.save' | 'anonymizer.detect';
+
+/** A bridge method: exactly one of the two dispatch halves above. */
+export type BridgeMethod = RendererDispatchedMethod | HostDispatchedMethod;
+
+type MethodsEqual<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+// Compile-time partition guards (mirror dispatchBridge's `_never` exhaustiveness
+// check, and are belt to the runtime tests' suspenders):
+//  - EXHAUSTIVE: the two halves cover every key of `BridgeMethods`, no more/less.
+//  - DISJOINT:   no method is classified as both renderer- and host-dispatched.
+// A method added to `BridgeMethods` but left unclassified — or listed on both
+// sides — fails to typecheck here.
+const _partitionIsExhaustive: MethodsEqual<keyof BridgeMethods, BridgeMethod> = true;
+const _partitionIsDisjoint: MethodsEqual<
+  Extract<RendererDispatchedMethod, HostDispatchedMethod>,
+  never
+> = true;
 
 /** Permission required for each bridge method — the single source the host gate
  *  checks. A method with no entry is host-internal and never app-callable. */
@@ -91,15 +126,22 @@ export const METHOD_PERMISSION: Readonly<Record<BridgeMethod, AppPermission>> = 
  *
  * INVARIANT: this set and the main-process `BridgeServices` keys are DISJOINT
  * and, together, cover every {@link BridgeMethod}. The SDK keeps one unified
- * method map; "where it runs" lives here.
+ * method map; "where it runs" lives here. Because the set is derived from a
+ * {@link RendererDispatchedMethod}-keyed table, it holds EXACTLY the
+ * renderer-dispatched methods — a missing or stray member is a compile error.
  */
-export const RENDERER_DISPATCHED_METHODS: ReadonlySet<BridgeMethod> = new Set<BridgeMethod>([
-  'session.send',
-]);
+const RENDERER_DISPATCHED_TABLE: Record<RendererDispatchedMethod, true> = {
+  'session.send': true,
+};
+export const RENDERER_DISPATCHED_METHODS: ReadonlySet<RendererDispatchedMethod> = new Set(
+  Object.keys(RENDERER_DISPATCHED_TABLE) as RendererDispatchedMethod[],
+);
 
 /** True when `method` is resolved in the renderer (not a main service). */
 export function isRendererDispatched(method: BridgeMethod): boolean {
-  return RENDERER_DISPATCHED_METHODS.has(method);
+  // `.has` is typed to the narrower `RendererDispatchedMethod`; widen for the
+  // membership test since any `BridgeMethod` is a valid probe.
+  return (RENDERER_DISPATCHED_METHODS as ReadonlySet<BridgeMethod>).has(method);
 }
 
 /** Tag on every bridge envelope so unrelated `message` events are ignored. */

--- a/packages/desktop-app-sdk/src/index.ts
+++ b/packages/desktop-app-sdk/src/index.ts
@@ -32,6 +32,8 @@ export {
   isBridgeRequest,
   isRendererDispatched,
   type BridgeMethod,
+  type RendererDispatchedMethod,
+  type HostDispatchedMethod,
   type BridgeMethods,
   type BridgeSpan,
   type BridgeRequest,

--- a/packages/desktop-host/src/apps/bridge-host.ts
+++ b/packages/desktop-host/src/apps/bridge-host.ts
@@ -30,24 +30,22 @@ import {
   type AppPermission,
   type BridgeMethod,
   type BridgeMethods,
+  type HostDispatchedMethod,
 } from '@moxxy/desktop-app-sdk';
 
 /** The host implementations behind each bridge method. The IPC layer provides
  *  these (native dialogs + main-process parsing + the anonymizer engine); the
  *  gate only calls one after the permission check passes.
  *
- *  INVARIANT: the keys here and `RENDERER_DISPATCHED_METHODS` (SDK) are DISJOINT
- *  and jointly cover every {@link BridgeMethod} — a method is EITHER a main
- *  service listed below OR renderer-dispatched, never both. */
-export interface BridgeServices {
-  'documents.open': () => Promise<BridgeMethods['documents.open']['result']>;
-  'documents.save': (
-    p: BridgeMethods['documents.save']['params'],
-  ) => Promise<BridgeMethods['documents.save']['result']>;
-  'anonymizer.detect': (
-    p: BridgeMethods['anonymizer.detect']['params'],
-  ) => Promise<BridgeMethods['anonymizer.detect']['result']>;
-}
+ *  Keyed by {@link HostDispatchedMethod} so the DISJOINT + EXHAUSTIVE invariant
+ *  with `RENDERER_DISPATCHED_METHODS` (SDK) is compile-enforced: every
+ *  host-dispatched method MUST have a service here, and a renderer-dispatched
+ *  method (e.g. `session.send`) CANNOT appear as a key. */
+export type BridgeServices = {
+  [M in HostDispatchedMethod]: (
+    params: BridgeMethods[M]['params'],
+  ) => Promise<BridgeMethods[M]['result']>;
+};
 
 export type BridgeDispatchResult =
   | { readonly ok: true; readonly result: unknown }
@@ -95,7 +93,9 @@ export async function dispatchBridge(
   try {
     switch (method) {
       case 'documents.open':
-        return { ok: true, result: await services['documents.open']() };
+        // `documents.open` takes no params (its map entry is `undefined`); the
+        // host service signature carries that `undefined` slot, so pass it.
+        return { ok: true, result: await services['documents.open'](undefined) };
       case 'documents.save':
         return {
           ok: true,

--- a/packages/desktop-host/src/channel-catalog.test.ts
+++ b/packages/desktop-host/src/channel-catalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { CHANNEL_CATALOG, listChannelCatalog } from './channel-catalog';
+import type { ChannelDef } from '@moxxy/sdk';
+import { CHANNEL_CATALOG, listChannelCatalog, type ChannelCatalogEntry } from './channel-catalog';
 
 describe('CHANNEL_CATALOG', () => {
   it('pins the exact vault keys each channel plugin reads', () => {
@@ -63,4 +64,98 @@ describe('CHANNEL_CATALOG', () => {
       if (c) expect(handled.has(c.kind)).toBe(true);
     }
   });
+});
+
+/**
+ * Drift guard against the ACTUAL plugin defs.
+ *
+ * The tests above pin the catalog to hardcoded expectations — but those
+ * expectations were hand-copied from the plugins too, so they can rot in
+ * lockstep with the catalog. This block instead imports each channel plugin's
+ * `ChannelDef` DIRECTLY from its package source (the single source of truth) and
+ * asserts the catalog still matches the LOAD-BEARING contract, keyed by
+ * `vaultKey` (where the secret actually lives): which vault keys exist, which are
+ * required, each field's secret/text type, and `hasWebhookUrl`. The desktop
+ * writes each field under `vaultKeys[field]` and the channel reads it from the
+ * vault by that exact key, so a vaultKey drift silently breaks the channel.
+ *
+ * It deliberately does NOT assert presentation the desktop and the plugin word
+ * differently — field option-names, labels, placeholders, help, runHint, connect
+ * copy: those have intentionally diverged and coupling them would be brittle
+ * without protecting anything load-bearing.
+ *
+ * Imports reach into each plugin's `src/index.ts` by relative path rather than by
+ * package name on purpose: desktop-host doesn't (and shouldn't) depend on the
+ * channel plugins, so this keeps the comparison honest without adding a heavy
+ * runtime dependency on grammy / baileys / discord.js. Test files are excluded
+ * from `tsconfig.json`, so the cross-package import doesn't affect the build.
+ */
+type PluginModule = { default?: { channels?: ReadonlyArray<ChannelDef> } };
+
+// Catalog id -> loader for the plugin whose `channels[0]` is the mirrored def.
+// Every id in CHANNEL_CATALOG MUST appear here (asserted below) so a new catalog
+// entry can't silently skip its drift check.
+const PLUGIN_LOADERS: Readonly<Record<string, () => Promise<PluginModule>>> = {
+  slack: () => import('../../plugin-channel-slack/src/index.ts'),
+  telegram: () => import('../../plugin-telegram/src/index.ts'),
+  signal: () => import('../../plugin-channel-signal/src/index.ts'),
+  whatsapp: () => import('../../plugin-channel-whatsapp/src/index.ts'),
+  discord: () => import('../../plugin-channel-discord/src/index.ts'),
+};
+
+type FieldContract = { readonly required: boolean; readonly type: 'password' | 'text' };
+
+/** The def's secret contract, keyed by vaultKey. */
+async function defContract(id: string): Promise<{
+  readonly fields: Map<string, FieldContract>;
+  readonly requiredKeys: ReadonlyArray<string>;
+  readonly hasRequestUrl: boolean;
+}> {
+  const mod = await PLUGIN_LOADERS[id]!();
+  const config = mod.default?.channels?.[0]?.config;
+  if (!config) throw new Error(`no ChannelDef.config for channel "${id}"`);
+  const fields = new Map<string, FieldContract>(
+    config.fields.map((f) => [f.vaultKey, { required: f.required === true, type: f.secret ? 'password' : 'text' }]),
+  );
+  return {
+    fields,
+    requiredKeys: config.fields.filter((f) => f.required === true).map((f) => f.vaultKey),
+    hasRequestUrl: config.hasRequestUrl === true,
+  };
+}
+
+/** The catalog entry's secret contract, keyed by vaultKey via its own name->key map. */
+function catalogContract(entry: ChannelCatalogEntry): Map<string, FieldContract> {
+  return new Map<string, FieldContract>(
+    entry.descriptor.configFields.map((f) => {
+      const vaultKey = entry.vaultKeys[f.name];
+      if (!vaultKey) throw new Error(`catalog field "${f.name}" has no vaultKeys entry`);
+      return [vaultKey, { required: f.required === true, type: f.type }];
+    }),
+  );
+}
+
+describe('channel-catalog drift guard (vs plugin defs)', () => {
+  it('has a drift check for every channel in the catalog', () => {
+    expect(Object.keys(PLUGIN_LOADERS).sort()).toEqual(Object.keys(CHANNEL_CATALOG).sort());
+  });
+
+  for (const [id, entry] of Object.entries(CHANNEL_CATALOG)) {
+    describe(id, () => {
+      it('vault keys, required flags and secret/text types match the plugin def', async () => {
+        const def = await defContract(id);
+        expect(catalogContract(entry)).toEqual(def.fields);
+      });
+
+      it('requiredKeys match the def’s required vault keys', async () => {
+        const def = await defContract(id);
+        expect([...entry.requiredKeys].sort()).toEqual([...def.requiredKeys].sort());
+      });
+
+      it('hasWebhookUrl matches the def’s hasRequestUrl', async () => {
+        const def = await defContract(id);
+        expect(entry.descriptor.hasWebhookUrl).toBe(def.hasRequestUrl);
+      });
+    });
+  }
 });

--- a/packages/plugin-channel-mobile/src/index.ts
+++ b/packages/plugin-channel-mobile/src/index.ts
@@ -41,6 +41,12 @@ export const mobileChannelDef = defineChannel({
   name: 'mobile',
   description:
     'WebSocket bridge for the moxxy mobile app (Expo) — serves the IPC contract backed by this session.',
+  // Unlike telegram/slack, mobile is NOT dedicated — it self-hosts the runner's
+  // single session. But `moxxy mobile` still owns that session, so stamp its
+  // origin explicitly: otherwise the runner's env-heuristic persistence records
+  // the empty pre-first-prompt session as `tui`, dropping it from the mobile
+  // list until the first prompt. The CLI honors this for the launched channel.
+  sessionSource: 'mobile',
   create: (deps) =>
     new MobileChannel({
       port: asNumber(deps.options?.port),

--- a/packages/sdk/src/compactor-helpers.test.ts
+++ b/packages/sdk/src/compactor-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   computeElisionState,
   estimateContextTokens,
   isContextOverflowError,
+  resolveModelContext,
   runCompactionIfNeeded,
   runElisionIfNeeded,
   runManualCompaction,
@@ -421,6 +422,48 @@ describe('isContextOverflowError', () => {
   it('does not match unrelated errors', () => {
     for (const msg of ['rate limit exceeded', 'network timeout', '500 internal server error', 'invalid api key']) {
       expect(isContextOverflowError(msg)).toBe(false);
+    }
+  });
+});
+
+describe('resolveModelContext', () => {
+  it('warns once on the models[0] fallback for an unlisted id, keeping the fallback window', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // ctx.model is an id the provider's catalog does not enumerate; the sole
+      // descriptor is 'listed-a'. Use a unique tuple so the module-level dedupe
+      // Set (shared across this file) isn't primed by another test.
+      const ctx = makeCtx({
+        compactor: null,
+        model: 'listed-a',
+        contextWindow: 321_000,
+        ctxModelId: 'unlisted-variant-1m',
+      });
+      const first = resolveModelContext(ctx);
+      const second = resolveModelContext(ctx);
+      // Return value is the models[0] fallback — the diagnostic changes nothing.
+      expect(first).toEqual({ contextWindow: 321_000, reserveForOutput: 0 });
+      expect(second).toEqual(first);
+      // Deduped on (provider, requested id, fallback id): one warn, not per call.
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = String(warn.mock.calls[0]?.[0]);
+      expect(msg).toContain('unlisted-variant-1m');
+      expect(msg).toContain('listed-a');
+      expect(msg).toContain('321000');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not warn when ctx.model matches a descriptor exactly', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const ctx = makeCtx({ compactor: null, model: 'exact-match-model', contextWindow: 128_000 });
+      const resolved = resolveModelContext(ctx);
+      expect(resolved).toEqual({ contextWindow: 128_000, reserveForOutput: 0 });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
     }
   });
 });

--- a/packages/sdk/src/compactor-helpers.ts
+++ b/packages/sdk/src/compactor-helpers.ts
@@ -131,10 +131,43 @@ function safeJsonLen(v: unknown): number {
 export function resolveModelContext(
   ctx: ModeContext,
 ): { readonly contextWindow: number; readonly reserveForOutput: number } | null {
-  const descriptor = ctx.provider.models.find((m) => m.id === ctx.model) ?? ctx.provider.models[0];
+  const exact = ctx.provider.models.find((m) => m.id === ctx.model);
+  const descriptor = exact ?? ctx.provider.models[0];
   const contextWindow = descriptor?.contextWindow;
   if (!contextWindow || contextWindow <= 0) return null;
+  // Signal (once) when the exact-id lookup missed and we fell back to the first
+  // descriptor: the resolved `contextWindow` is that of a DIFFERENT model than
+  // the session actually runs, so every proactive-compaction / elision decision
+  // for the whole session may calibrate against the wrong window with no other
+  // trace. Deduped on (provider, requested id, fallback id) because this runs
+  // once per loop iteration — an undeduped warn would spam every turn.
+  if (!exact && descriptor) {
+    warnModelFallbackOnce(ctx.provider.name, ctx.model, descriptor.id, contextWindow);
+  }
   return { contextWindow, reserveForOutput: descriptor?.maxOutputTokens ?? 0 };
+}
+
+// One-shot guard for the unlisted-model fallback warning above, keyed on the
+// (provider name, requested model id, fallback descriptor id) tuple so a
+// steady-state session logs the mismatch exactly once, not per iteration.
+const warnedModelFallbacks = new Set<string>();
+
+function warnModelFallbackOnce(
+  providerName: string,
+  requestedModel: string,
+  fallbackId: string,
+  contextWindow: number,
+): void {
+  const key = `${providerName}\u0000${requestedModel}\u0000${fallbackId}`;
+  if (warnedModelFallbacks.has(key)) return;
+  warnedModelFallbacks.add(key);
+  // `console.warn` matches the SDK's existing non-fatal diagnostic seam (see
+  // `resolveChannelToken`'s stale-token hint); there is no logger on ModeContext.
+  console.warn(
+    `[moxxy] model id "${requestedModel}" not found in provider "${providerName}" catalog; ` +
+      `falling back to descriptor "${fallbackId}" with contextWindow ${contextWindow} — ` +
+      `proactive compaction/elision may calibrate against the wrong window.`,
+  );
 }
 
 /**


### PR DESCRIPTION
## What

A targeted sweep of the `TECH_DEBT.md` backlog — parallel fixes over disjoint subsystems, then centrally verified. **9 items retired** to the Resolved ledger, **5 refined** (kept open with precise implementation paths).

**Retired (fixed):**
- **cli:** `moxxy channels rotate-token <name>` — new verb wrapping the SDK-only `rotateChannelToken` (SECURITY.md recommended rotation; nothing exposed it). +tests.
- **cli/mobile:** standalone `moxxy mobile` now stamps `MOXXY_SESSION_SOURCE=mobile` (declared `sessionSource` on the channel def; `applyDedicatedRunnerEnv` honors a declared source for non-dedicated channels) so the empty pre-first-prompt session is no longer mis-stamped `tui` and dropped from the list.
- **sdk:** `resolveModelContext` no longer *silently* falls back to `models[0]` on an unknown model id — one-shot `console.warn` (deduped per provider/requested-id/fallback-id) so a wrong context-window calibration is observable.
- **desktop:** compile-time partition of the app-bridge method sets (`RENDERER_DISPATCHED_METHODS` vs the host `BridgeServices` map) — a mis-/un-classified method is now a `tsc` error, not just a runtime-test miss. Member lists unchanged; runtime tests kept.
- **desktop:** keyless `local` provider no longer prompts for a non-existent API key in the Configure sheet.
- **desktop:** stop Vite emitting a ~21 MB orphan ONNX-Runtime wasm into `dist/assets/` every bundle (dead `new URL(...)` path — runtime loads ORT from `/ort/`); the real anonymizer wasm copy is untouched (verified in an isolated repro).
- **desktop-host:** drift guard that fails if the hand-mirrored channel catalog diverges from each plugin's `ChannelDef.config`.
- **mobile:** deprecated `SafeAreaView` migrated to `react-native-safe-area-context`; dead `ToolGroupUi.accent/tint` removed; unused `LargeHeader` deleted.

**Verified already-fixed (journal was stale) — added regression tests:**
- `provider.setEnabled` "lost update" race — already serialized by `@moxxy/config`'s `configMutex`.
- one-shot commands (`-p`, `schedule run`, `doctor`, `login`, `init`) draining persistence — already handled by the shared `closeSession()` awaited in each command's `finally`.

**Refined (kept open, with implementation paths in the journal):** `resolveModelContext` calibration-from-usage; dropped-attachment notice; `FilesPane` repo-root (needs `git.root` IPC); built-in-provider model editing; remaining mobile-misc.

## Why

`TECH_DEBT.md` is a living journal — retire on sight, keep the backlog honest. These were the self-contained, low-risk, fully-retirable items; deliberately deferred `[note]`/`[dormant]`/`[constraint]` decisions and large architectural items (node-gyp bump, channel→`SessionLike` retype, shared HTTP-server refactor, push-backed Live Activity) were left untouched.

## Verification

Full pre-PR gate green on the `development` base:
- `pnpm build` (84 tasks) · `typecheck` (141) · `lint` (0 errors) · `check:deps` (0 errors) — the lone dep-check + lint warnings are pre-existing (confirmed by revert).
- Tests: cli, sdk (33), config (8), desktop-app-sdk (3), desktop-host (49), plugin-channel-mobile (5), desktop (68), mobile (48) — all suites pass.
- Vite orphan-wasm fix validated in an isolated build repro; anonymizer `/ort/` path confirmed unaffected.