### PR TITLE
feat(channel): iMessage channel via BlueBubbles (@moxxy/plugin-channel-imessage)

### DIFF
--- a/.changeset/imessage-channel.md
+++ b/.changeset/imessage-channel.md
@@ -1,0 +1,18 @@
+---
+'@moxxy/plugin-channel-imessage': minor
+'@moxxy/sdk': minor
+'@moxxy/cli': minor
+'@moxxy/plugin-plugins-admin': minor
+'@moxxy/desktop-host': minor
+---
+
+New iMessage channel (`moxxy imessage`): drive moxxy from iMessage via a
+localhost BlueBubbles server (macOS only). v1 sends text with the stock
+apple-script method and receives via the BlueBubbles socket.io `new-message`
+feed; 1:1 text chats only. Trust is a vault-stored server URL + password plus a
+JSON handle allow-list, with your own self-chat allowed via a separate owner-handle
+list; unknown senders are dropped silently and the channel's own echoes are
+filtered. Runs on a dedicated isolated runner with `sessionSource: 'imessage'`.
+Subcommands: `setup` (interactive wizard), `status`, `unpair`. Wires
+`'imessage'` into SDK `SESSION_SOURCES`, the plugins-admin install catalog, and
+the desktop channel catalog.

--- a/packages/cli/src/channel-hints.test.ts
+++ b/packages/cli/src/channel-hints.test.ts
@@ -11,6 +11,7 @@ describe('findCatalogEntryForChannel', () => {
     ['signal', '@moxxy/plugin-channel-signal'],
     ['whatsapp', '@moxxy/plugin-channel-whatsapp'],
     ['discord', '@moxxy/plugin-channel-discord'],
+    ['imessage', '@moxxy/plugin-channel-imessage'],
     ['web', '@moxxy/plugin-channel-web'],
     ['http', '@moxxy/plugin-channel-http'],
   ])('%s → %s', (command, packageName) => {
@@ -22,7 +23,7 @@ describe('findCatalogEntryForChannel', () => {
   });
 
   it('unknown names stay unknown', () => {
-    expect(findCatalogEntryForChannel('imessage')).toBeUndefined();
+    expect(findCatalogEntryForChannel('nonexistent-channel')).toBeUndefined();
     expect(findCatalogEntryForChannel('')).toBeUndefined();
   });
 

--- a/packages/cli/src/setup/builtin-requirements.generated.ts
+++ b/packages/cli/src/setup/builtin-requirements.generated.ts
@@ -22,6 +22,13 @@ export const BUILTIN_REQUIREMENTS: Readonly<
       "hint": "discord resolves the vault from the service registry for its bot token + pairing; @moxxy/plugin-vault must load first"
     }
   ],
+  "@moxxy/plugin-channel-imessage": [
+    {
+      "kind": "plugin",
+      "name": "@moxxy/plugin-vault",
+      "hint": "imessage resolves the vault from the service registry for its BlueBubbles server URL + password + handle allow-list; @moxxy/plugin-vault must load first"
+    }
+  ],
   "@moxxy/plugin-channel-signal": [
     {
       "kind": "plugin",

--- a/packages/desktop-host/src/channel-catalog.test.ts
+++ b/packages/desktop-host/src/channel-catalog.test.ts
@@ -101,6 +101,7 @@ const PLUGIN_LOADERS: Readonly<Record<string, () => Promise<PluginModule>>> = {
   signal: () => import('../../plugin-channel-signal/src/index.ts'),
   whatsapp: () => import('../../plugin-channel-whatsapp/src/index.ts'),
   discord: () => import('../../plugin-channel-discord/src/index.ts'),
+  imessage: () => import('../../plugin-channel-imessage/src/index.ts'),
 };
 
 type FieldContract = { readonly required: boolean; readonly type: 'password' | 'text' };

--- a/packages/desktop-host/src/channel-catalog.ts
+++ b/packages/desktop-host/src/channel-catalog.ts
@@ -193,6 +193,48 @@ export const CHANNEL_CATALOG: Readonly<Record<string, ChannelCatalogEntry>> = {
     vaultKeys: { botToken: 'discord_bot_token' },
     requiredKeys: ['discord_bot_token'],
   },
+  imessage: {
+    descriptor: {
+      id: 'imessage',
+      name: 'iMessage',
+      description:
+        'iMessage via a localhost BlueBubbles server on its own dedicated runner. macOS only: ' +
+        'install the BlueBubbles server on this Mac, sign in to Messages, set a password. ' +
+        'Allow-listed handles (and your own self-chat) drive the agent; text-only, 1:1 chats.',
+      docsUrl: 'https://bluebubbles.app',
+      configFields: [
+        {
+          name: 'serverUrl',
+          label: 'BlueBubbles server URL',
+          type: 'text',
+          required: true,
+          placeholder: 'http://localhost:1234',
+          help: 'The BlueBubbles server running on this Mac (default port 1234)',
+        },
+        {
+          name: 'password',
+          label: 'BlueBubbles server password',
+          type: 'password',
+          required: true,
+          help: 'The password set in the BlueBubbles app',
+        },
+      ],
+      hasWebhookUrl: false,
+      runHint:
+        'Install the BlueBubbles server on this Mac, sign in to Messages, set a password, then run `moxxy channels imessage setup` to add allowed handles.',
+      connect: {
+        kind: 'instructions',
+        title: 'Connect BlueBubbles',
+        steps: [
+          'Install the BlueBubbles server on this Mac from https://bluebubbles.app and sign in to Messages.',
+          'In the BlueBubbles app, set a server password and note the port (default 1234).',
+          'Run `moxxy channels imessage setup` and paste the URL + password, then add the handles allowed to talk to moxxy.',
+        ],
+      },
+    },
+    vaultKeys: { serverUrl: 'imessage_server_url', password: 'imessage_server_password' },
+    requiredKeys: ['imessage_server_url', 'imessage_server_password'],
+  },
 };
 
 /** Every catalog entry, in display order. */

--- a/packages/plugin-channel-imessage/package.json
+++ b/packages/plugin-channel-imessage/package.json
@@ -1,0 +1,96 @@
+{
+  "name": "@moxxy/plugin-channel-imessage",
+  "version": "0.0.0",
+  "description": "iMessage channel for moxxy via a localhost BlueBubbles server (macOS only). Sends text with the apple-script method and receives via the BlueBubbles socket.io feed, driving the Session from allow-listed handles (your own self-chat by default). Immutable chunked replies; autonomous allow-list permission model.",
+  "keywords": [
+    "moxxy",
+    "agent",
+    "channel",
+    "imessage",
+    "bluebubbles",
+    "bot"
+  ],
+  "homepage": "https://moxxy.ai",
+  "bugs": {
+    "url": "https://github.com/moxxy-ai/moxxy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moxxy-ai/moxxy.git",
+    "directory": "packages/plugin-channel-imessage"
+  },
+  "author": "Michal Makowski <michal.makowski97@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "moxxy": {
+    "plugin": {
+      "entry": "./dist/index.js",
+      "kind": "channel"
+    },
+    "requirements": [
+      {
+        "kind": "plugin",
+        "name": "@moxxy/plugin-vault",
+        "hint": "imessage resolves the vault from the service registry for its BlueBubbles server URL + password + handle allow-list; @moxxy/plugin-vault must load first"
+      }
+    ],
+    "setup": {
+      "title": "iMessage (BlueBubbles)",
+      "description": "macOS only. Install the BlueBubbles server (https://bluebubbles.app) on this Mac, sign in to Messages, and set a server password. Then paste the server URL (default http://localhost:1234) and the password below, and run `moxxy channels imessage setup` to add the handles allowed to talk to moxxy.",
+      "fields": [
+        {
+          "key": "serverUrl",
+          "label": "BlueBubbles server URL",
+          "kind": "text",
+          "vaultKey": "imessage_server_url",
+          "required": true,
+          "placeholder": "http://localhost:1234"
+        },
+        {
+          "key": "password",
+          "label": "BlueBubbles server password",
+          "kind": "secret",
+          "vaultKey": "imessage_server_password",
+          "required": true
+        }
+      ]
+    }
+  },
+  "dependencies": {
+    "@clack/prompts": "catalog:",
+    "@moxxy/channel-kit": "workspace:*",
+    "@moxxy/core": "workspace:*",
+    "@moxxy/plugin-vault": "workspace:*",
+    "@moxxy/sdk": "workspace:*",
+    "socket.io-client": "^4.8.1",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugin-channel-imessage/src/bluebubbles-client.ts
+++ b/packages/plugin-channel-imessage/src/bluebubbles-client.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from 'node:crypto';
+
+/**
+ * The BlueBubbles transport seam (the "sidecar" equivalent for iMessage).
+ *
+ * BlueBubbles is a native macOS app running a localhost Koa + socket.io server
+ * (default port 1234). We hit it directly over `http://127.0.0.1:1234`:
+ *  - inbound: a socket.io client subscribed to `new-message` (built-in
+ *    reconnection; no webhook lifecycle),
+ *  - outbound: `POST /api/v1/message/text` with `method: 'apple-script'`.
+ *
+ * Auth is a single password passed as a QUERY PARAM on every call (BlueBubbles
+ * never reads it from a header). There is no HMAC on the socket feed — pure
+ * localhost trust — so the consumer must stay bound to loopback.
+ *
+ * The channel drives this behind {@link BlueBubblesClientLike} so tests inject a
+ * fake and no socket.io / network is touched. `socket.io-client` is imported
+ * lazily inside {@link BlueBubblesClient.connect} so module load (and
+ * `isAvailable`) stays light.
+ */
+export interface BlueBubblesClientLike {
+  /** Best-effort reachability + auth probe; throws a friendly error on failure. */
+  ping(): Promise<void>;
+  /** Open the socket.io connection and begin emitting inbound messages. */
+  connect(): Promise<void>;
+  /** Subscribe to raw `new-message` payloads. Returns an unsubscribe fn. */
+  onMessage(listener: (raw: unknown) => void): () => void;
+  /**
+   * Send a text message. `tempGuid` correlates the send with its echoed
+   * `new-message`; the returned `guid` (when the server reports it) is the
+   * permanent id. Both feed the anti-echo set.
+   */
+  sendText(chatGuid: string, message: string): Promise<{ guid: string | null; tempGuid: string }>;
+  /** Tear down the socket. */
+  close(): void;
+}
+
+export interface BlueBubblesClientLogger {
+  debug?(msg: string, meta?: Record<string, unknown>): void;
+  info?(msg: string, meta?: Record<string, unknown>): void;
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+/** Minimal slice of a socket.io client the channel uses (keeps typing loose). */
+export interface SocketLike {
+  on(event: string, listener: (...args: unknown[]) => void): void;
+  close(): void;
+}
+
+export interface BlueBubblesClientOptions {
+  readonly serverUrl: string;
+  readonly password: string;
+  readonly logger?: BlueBubblesClientLogger;
+  /** Test seam: injectable fetch (defaults to global fetch). */
+  readonly fetchImpl?: typeof fetch;
+  /** Test seam: injectable socket factory (defaults to lazy socket.io-client). */
+  readonly socketFactory?: (opts: { url: string; password: string }) => Promise<SocketLike>;
+}
+
+/** A fresh per-send temp guid (correlates our send with its echoed message). */
+export function makeTempGuid(): string {
+  return `temp-${randomUUID()}`;
+}
+
+export class BlueBubblesClient implements BlueBubblesClientLike {
+  private readonly opts: BlueBubblesClientOptions;
+  private readonly base: string;
+  private socket: SocketLike | null = null;
+  private readonly messageListeners = new Set<(raw: unknown) => void>();
+
+  constructor(opts: BlueBubblesClientOptions) {
+    this.opts = opts;
+    // Normalize the base URL once (strip a trailing slash) so path joins are clean.
+    this.base = opts.serverUrl.trim().replace(/\/+$/, '');
+  }
+
+  async ping(): Promise<void> {
+    const doFetch = this.opts.fetchImpl ?? fetch;
+    let res: Response;
+    try {
+      res = await doFetch(this.apiUrl('/api/v1/ping'));
+    } catch (err) {
+      throw new Error(
+        `Cannot reach the BlueBubbles server at ${this.base}. Is it running on this Mac? ` +
+          `(${err instanceof Error ? err.message : String(err)})`,
+      );
+    }
+    if (res.status === 401 || res.status === 403) {
+      throw new Error(
+        'The BlueBubbles server rejected the password. Check the password in the BlueBubbles app matches the one stored for moxxy.',
+      );
+    }
+    // Any other HTTP response means something is listening — reachable enough.
+  }
+
+  async connect(): Promise<void> {
+    const factory = this.opts.socketFactory ?? ((o) => defaultSocketFactory(o));
+    const socket = await factory({ url: this.base, password: this.opts.password });
+    this.socket = socket;
+    socket.on('new-message', (...args: unknown[]) => {
+      const payload = args.length > 0 ? args[0] : undefined;
+      for (const listener of this.messageListeners) {
+        try {
+          listener(payload);
+        } catch (err) {
+          this.opts.logger?.warn?.('imessage: message listener threw', { err: String(err) });
+        }
+      }
+    });
+    socket.on('disconnect', (...args: unknown[]) => {
+      this.opts.logger?.debug?.('imessage: socket disconnected (auto-reconnecting)', {
+        reason: String(args.length > 0 ? args[0] : ''),
+      });
+    });
+  }
+
+  onMessage(listener: (raw: unknown) => void): () => void {
+    this.messageListeners.add(listener);
+    return () => this.messageListeners.delete(listener);
+  }
+
+  async sendText(
+    chatGuid: string,
+    message: string,
+  ): Promise<{ guid: string | null; tempGuid: string }> {
+    const doFetch = this.opts.fetchImpl ?? fetch;
+    const tempGuid = makeTempGuid();
+    const res = await doFetch(this.apiUrl('/api/v1/message/text'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ chatGuid, tempGuid, message, method: 'apple-script' }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      throw new Error(`BlueBubbles send failed (HTTP ${res.status})${detail ? `: ${detail}` : ''}`);
+    }
+    const guid = await extractGuid(res);
+    return { guid, tempGuid };
+  }
+
+  close(): void {
+    this.messageListeners.clear();
+    const socket = this.socket;
+    this.socket = null;
+    if (socket) {
+      try {
+        socket.close();
+      } catch (err) {
+        this.opts.logger?.warn?.('imessage: socket close threw', { err: String(err) });
+      }
+    }
+  }
+
+  /** Build an absolute API URL with the password query param appended. */
+  private apiUrl(path: string): string {
+    const url = new URL(this.base + path);
+    url.searchParams.set('password', this.opts.password);
+    return url.toString();
+  }
+}
+
+/** Read the sent message's permanent guid from the send response, if present. */
+async function extractGuid(res: Response): Promise<string | null> {
+  const body: unknown = await res.json().catch(() => null);
+  if (!body || typeof body !== 'object') return null;
+  const data = (body as { data?: unknown }).data;
+  if (!data || typeof data !== 'object') return null;
+  const guid = (data as { guid?: unknown }).guid;
+  return typeof guid === 'string' && guid.length > 0 ? guid : null;
+}
+
+/** Lazily import socket.io-client and open a connection to the BlueBubbles feed. */
+async function defaultSocketFactory(opts: { url: string; password: string }): Promise<SocketLike> {
+  const { io } = await import('socket.io-client');
+  const socket = io(opts.url, {
+    query: { password: opts.password },
+    transports: ['websocket'],
+    // BlueBubbles' socket.io has built-in reconnection; keep it on.
+    reconnection: true,
+  });
+  return socket as unknown as SocketLike;
+}

--- a/packages/plugin-channel-imessage/src/channel.test.ts
+++ b/packages/plugin-channel-imessage/src/channel.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { ImessageChannel } from './channel.js';
+import type { BlueBubblesClientLike } from './bluebubbles-client.js';
+import {
+  IMESSAGE_ALLOWED_HANDLES_KEY,
+  IMESSAGE_OWNER_HANDLES_KEY,
+  IMESSAGE_SERVER_PASSWORD_KEY,
+  IMESSAGE_SERVER_URL_KEY,
+} from './keys.js';
+import { MAX_INBOUND_TEXT_CHARS } from './schema.js';
+
+const OWNER = '+19998887777';
+const FRIEND = '+15550001111';
+const STRANGER = '+14440002222';
+const chatFor = (handle: string): string => `iMessage;-;${handle}`;
+
+function stubVault(seed: Record<string, string> = {}): VaultStore {
+  const map = new Map(Object.entries(seed));
+  return {
+    get: async (k: string) => map.get(k) ?? null,
+    set: async (k: string, v: string) => {
+      map.set(k, v);
+    },
+    has: async (k: string) => map.has(k),
+    delete: async (k: string) => map.delete(k),
+  } as unknown as VaultStore;
+}
+
+function makeFakeSession(opts: { hangTurns?: boolean } = {}) {
+  const listeners = new Set<(e: unknown) => void>();
+  const prompts: string[] = [];
+  let release: (() => void) | null = null;
+  const session = {
+    tools: { list: () => [{ name: 'Read' }, { name: 'Grep' }] },
+    transcribers: { tryGetActive: () => null },
+    setPermissionResolver: vi.fn(),
+    log: {
+      subscribe: (fn: (e: unknown) => void) => {
+        listeners.add(fn);
+        return () => listeners.delete(fn);
+      },
+    },
+    runTurn(prompt: string) {
+      prompts.push(prompt);
+      const hang = opts.hangTurns;
+      return (async function* () {
+        if (hang) {
+          await new Promise<void>((resolve) => {
+            release = resolve;
+          });
+        }
+      })();
+    },
+  };
+  return {
+    session: session as unknown as Session,
+    raw: session,
+    prompts,
+    releaseTurn: () => release?.(),
+  };
+}
+
+class FakeClient implements BlueBubblesClientLike {
+  sends: Array<{ chatGuid: string; message: string }> = [];
+  pinged = false;
+  connected = false;
+  closed = false;
+  private readonly listeners = new Set<(raw: unknown) => void>();
+  private n = 0;
+
+  async ping(): Promise<void> {
+    this.pinged = true;
+  }
+  async connect(): Promise<void> {
+    this.connected = true;
+  }
+  onMessage(listener: (raw: unknown) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+  async sendText(chatGuid: string, message: string): Promise<{ guid: string | null; tempGuid: string }> {
+    this.sends.push({ chatGuid, message });
+    const i = ++this.n;
+    return { guid: `guid-${i}`, tempGuid: `temp-${i}` };
+  }
+  close(): void {
+    this.closed = true;
+  }
+  /** Push one inbound `new-message` payload into the channel. */
+  receive(raw: unknown): void {
+    for (const listener of this.listeners) listener(raw);
+  }
+}
+
+function makeChannel(overrides: { vault?: VaultStore; hangTurns?: boolean; allowedTools?: string[] } = {}) {
+  const client = new FakeClient();
+  const fake = makeFakeSession({ ...(overrides.hangTurns ? { hangTurns: true } : {}) });
+  const channel = new ImessageChannel({
+    vault:
+      overrides.vault ??
+      stubVault({
+        [IMESSAGE_SERVER_URL_KEY]: 'http://localhost:1234',
+        [IMESSAGE_SERVER_PASSWORD_KEY]: 'secret',
+        [IMESSAGE_ALLOWED_HANDLES_KEY]: JSON.stringify([FRIEND]),
+        [IMESSAGE_OWNER_HANDLES_KEY]: JSON.stringify([OWNER]),
+      }),
+    ...(overrides.allowedTools ? { allowedTools: overrides.allowedTools } : {}),
+    clientFactory: () => client,
+  });
+  return { channel, client, fake };
+}
+
+const inbound = (opts: {
+  chatGuid: string;
+  text?: string;
+  isFromMe?: boolean;
+  sender?: string;
+  guid?: string;
+}): Record<string, unknown> => ({
+  guid: opts.guid ?? 'msg-1',
+  text: opts.text ?? 'hi',
+  isFromMe: opts.isFromMe ?? false,
+  ...(opts.sender ? { handle: { address: opts.sender } } : {}),
+  chats: [{ guid: opts.chatGuid }],
+});
+
+describe('ImessageChannel start()', () => {
+  it('pings, connects and swaps in the allow-list resolver on the session', async () => {
+    const { channel, client, fake } = makeChannel({ allowedTools: ['Read'] });
+    const handle = await channel.start({ session: fake.session });
+    expect(client.pinged).toBe(true);
+    expect(client.connected).toBe(true);
+    expect(fake.raw.setPermissionResolver).toHaveBeenCalledWith(channel.permissionResolver);
+    expect(channel.permissionResolver.name).toBe('imessage-allow-list');
+    await handle.stop();
+  });
+
+  it('throws a friendly error when the server is not configured', async () => {
+    const fake = makeFakeSession();
+    const channel = new ImessageChannel({ vault: stubVault(), clientFactory: () => new FakeClient() });
+    await expect(channel.start({ session: fake.session })).rejects.toThrow(/No BlueBubbles server configured/);
+  });
+});
+
+describe('inbound gating (every session-reaching path)', () => {
+  it('runs a turn for an allow-listed sender and replies to their chat', async () => {
+    const { channel, client, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+    client.receive(inbound({ chatGuid: chatFor(FRIEND), sender: FRIEND, text: 'hello moxxy' }));
+    await vi.waitFor(() => expect(fake.prompts).toEqual(['hello moxxy']));
+    await vi.waitFor(() => {
+      expect(client.sends.at(-1)).toEqual({ chatGuid: chatFor(FRIEND), message: '(no output)' });
+    });
+    await handle.stop();
+  });
+
+  it('silently drops senders that are not allow-listed', async () => {
+    const { channel, client, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+    client.receive(inbound({ chatGuid: chatFor(STRANGER), sender: STRANGER, text: 'let me in' }));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fake.prompts).toEqual([]);
+    expect(client.sends).toEqual([]); // no reply — a reply would leak the bot's existence
+    await handle.stop();
+  });
+
+  it('drops group messages (v1 is direct-message only)', async () => {
+    const { channel, client, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+    client.receive(inbound({ chatGuid: 'iMessage;+;chat123', sender: FRIEND, text: 'in a group' }));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fake.prompts).toEqual([]);
+    await handle.stop();
+  });
+
+  it('accepts the owner self-chat and replies into it', async () => {
+    const { channel, client, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+    client.receive(inbound({ chatGuid: chatFor(OWNER), isFromMe: true, text: 'remind me to stretch' }));
+    await vi.waitFor(() => expect(fake.prompts).toEqual(['remind me to stretch']));
+    await vi.waitFor(() => {
+      expect(client.sends.at(-1)).toEqual({ chatGuid: chatFor(OWNER), message: '(no output)' });
+    });
+    await handle.stop();
+  });
+
+  it("ignores the owner's outbound messages to other people (isFromMe foreign chat)", async () => {
+    const { channel, client, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+    client.receive(inbound({ chatGuid: chatFor(FRIEND), isFromMe: true, text: 'private chat' }));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fake.prompts).toEqual([]);
+    await handle.stop();
+  });
+
+  it('drops echoes of its own replies (loop protection)', async () => {
+    const { channel, client, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+
+    // One self-chat turn: the channel records its send ids (guid-1 / temp-1).
+    client.receive(inbound({ chatGuid: chatFor(OWNER), isFromMe: true, text: 'first', guid: 'in-1' }));
+    await vi.waitFor(() => expect(client.sends.length).toBe(1));
+
+    // BlueBubbles echoes our reply back as a new-message with our guid — must
+    // NOT trigger a turn (it would loop into itself in the self-chat).
+    client.receive(inbound({ chatGuid: chatFor(OWNER), isFromMe: true, text: '(no output)', guid: 'guid-1' }));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fake.prompts).toEqual(['first']);
+
+    // A genuinely new self-chat message still gets through.
+    client.receive(inbound({ chatGuid: chatFor(OWNER), isFromMe: true, text: 'second', guid: 'in-2' }));
+    await vi.waitFor(() => expect(fake.prompts).toEqual(['first', 'second']));
+    await handle.stop();
+  });
+
+  it('drops schema-invalid and oversized payloads without crashing', async () => {
+    const { channel, client, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+    client.receive(null);
+    client.receive('garbage');
+    client.receive({ guid: 'x' }); // no chats
+    client.receive(inbound({ chatGuid: chatFor(FRIEND), sender: FRIEND, text: 'x'.repeat(MAX_INBOUND_TEXT_CHARS + 1) }));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fake.prompts).toEqual([]);
+    // Still alive: a valid message afterwards works.
+    client.receive(inbound({ chatGuid: chatFor(FRIEND), sender: FRIEND, text: 'still alive?' }));
+    await vi.waitFor(() => expect(fake.prompts).toEqual(['still alive?']));
+    await handle.stop();
+  });
+
+  it('refuses overlapping turns with a busy reply (single-flight)', async () => {
+    const { channel, client, fake } = makeChannel({ hangTurns: true });
+    const handle = await channel.start({ session: fake.session });
+    client.receive(inbound({ chatGuid: chatFor(FRIEND), sender: FRIEND, text: 'long task' }));
+    await vi.waitFor(() => expect(fake.prompts).toEqual(['long task']));
+    client.receive(inbound({ chatGuid: chatFor(FRIEND), sender: FRIEND, text: 'impatient follow-up', guid: 'm2' }));
+    await vi.waitFor(() => {
+      expect(client.sends.some((s) => s.message.includes('still working'))).toBe(true);
+    });
+    expect(fake.prompts).toEqual(['long task']);
+    fake.releaseTurn();
+    await handle.stop();
+  });
+});
+
+describe('lifecycle', () => {
+  it('stop() closes the client and resolves running', async () => {
+    const { channel, client, fake } = makeChannel();
+    const handle = await channel.start({ session: fake.session });
+    await handle.stop('test');
+    expect(client.closed).toBe(true);
+    await expect(handle.running).resolves.toBeUndefined();
+  });
+});

--- a/packages/plugin-channel-imessage/src/channel.ts
+++ b/packages/plugin-channel-imessage/src/channel.ts
@@ -1,0 +1,352 @@
+import { newTurnId } from '@moxxy/core';
+import { TurnCoordinator, resolveSecret } from '@moxxy/channel-kit';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import type {
+  Channel,
+  ChannelHandle,
+  ChannelStartOptsBase,
+  MoxxyEvent,
+  PermissionResolver,
+} from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import {
+  IMESSAGE_ALLOWED_HANDLES_KEY,
+  IMESSAGE_OWNER_HANDLES_KEY,
+  IMESSAGE_SERVER_PASSWORD_ENV,
+  IMESSAGE_SERVER_PASSWORD_KEY,
+  IMESSAGE_SERVER_URL_ENV,
+  IMESSAGE_SERVER_URL_KEY,
+  normalizeHandle,
+  parseHandleList,
+} from './keys.js';
+import { gateInboundMessage } from './message-gate.js';
+import { buildImessagePermissionResolver } from './permission.js';
+import {
+  BlueBubblesClient,
+  type BlueBubblesClientLike,
+  type BlueBubblesClientOptions,
+} from './bluebubbles-client.js';
+import { runImessageTurn } from './channel/turn-runner.js';
+import { splitForImessage } from './channel/chunker.js';
+
+/** Bound on remembered own-send ids (guid + tempGuid) for the echo drop. */
+const MAX_SENT_IDS = 256;
+
+/** Rate limit for "dropped inbound message" warnings. */
+const DROP_WARN_INTERVAL_MS = 5_000;
+
+/** Message when the server URL / password isn't configured yet. */
+const NOT_CONFIGURED_MESSAGE =
+  'No BlueBubbles server configured. Run `moxxy channels imessage setup` (or set ' +
+  `${IMESSAGE_SERVER_URL_ENV} + ${IMESSAGE_SERVER_PASSWORD_ENV}).`;
+
+export interface ImessageChannelLogger {
+  debug?(msg: string, meta?: Record<string, unknown>): void;
+  info?(msg: string, meta?: Record<string, unknown>): void;
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+  error?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface ImessageStartOpts extends ChannelStartOptsBase {
+  readonly session: Session;
+  /** Override the autonomous tool allow-list at start. */
+  readonly allowedTools?: ReadonlyArray<string>;
+}
+
+export interface ImessageChannelOptions {
+  readonly vault: VaultStore;
+  /** Server URL override; beats env + vault. */
+  readonly serverUrl?: string;
+  /** Server password override; beats env + vault. */
+  readonly password?: string;
+  /** Tools the model may call autonomously. `['*']` allows every registered tool. */
+  readonly allowedTools?: ReadonlyArray<string>;
+  /** Extra allow-listed handles, merged with the vault allow-list. */
+  readonly allowedHandles?: ReadonlyArray<string>;
+  /** Extra owner handles (self-chat identities), merged with the vault list. */
+  readonly ownerHandles?: ReadonlyArray<string>;
+  readonly logger?: ImessageChannelLogger;
+  /** Test seam: build the BlueBubbles transport (production uses the real one). */
+  readonly clientFactory?: (opts: BlueBubblesClientOptions) => BlueBubblesClientLike;
+}
+
+export class ImessageChannel implements Channel<ImessageStartOpts> {
+  readonly name = 'imessage';
+  /**
+   * Installed on the session by the CLI dispatcher. Replaced in `start()` once
+   * the live tool registry is available for `['*']` expansion; until then it
+   * denies everything (safe default before start).
+   */
+  permissionResolver: PermissionResolver;
+
+  private readonly opts: ImessageChannelOptions;
+  private session: Session | null = null;
+  private model: string | undefined;
+
+  private client: BlueBubblesClientLike | null = null;
+  private readonly allowedHandles = new Set<string>();
+  private readonly ownerHandles = new Set<string>();
+
+  // Single-flight turn state + the bounded own-turn-id set the foreign-turn
+  // mirror gate filters on (invariant #8).
+  private readonly turns = new TurnCoordinator();
+  private lastChatGuid: string | null = null;
+  private logUnsub: (() => void) | null = null;
+
+  /**
+   * guid + tempGuid of messages WE sent. BlueBubbles emits `new-message` for
+   * the account's own sends too (our replies come back `isFromMe`), so any
+   * inbound whose id is in this set is an echo of ourselves and must be dropped
+   * (loop protection).
+   */
+  private readonly sentIds = new Set<string>();
+
+  private handle: ChannelHandle | null = null;
+  private runningSettled = false;
+  private resolveRunning: (() => void) | null = null;
+  private stopping = false;
+  private lastDropWarnAt = 0;
+
+  constructor(opts: ImessageChannelOptions) {
+    this.opts = opts;
+    // Pre-start: deny-all (replaced with the real allow-list resolver in start()).
+    this.permissionResolver = buildImessagePermissionResolver({
+      allowedTools: [],
+      allToolNames: [],
+      ...(opts.logger ? { logger: opts.logger } : {}),
+    });
+  }
+
+  async start(startOpts: ImessageStartOpts): Promise<ChannelHandle> {
+    if (this.handle) return this.handle;
+    this.session = startOpts.session;
+    this.model = startOpts.model;
+
+    // Config: explicit option → env → vault (shared channel-kit precedence).
+    const serverUrl =
+      this.opts.serverUrl ??
+      (await resolveSecret(this.opts.vault, {
+        envVar: IMESSAGE_SERVER_URL_ENV,
+        vaultKey: IMESSAGE_SERVER_URL_KEY,
+      }));
+    const password =
+      this.opts.password ??
+      (await resolveSecret(this.opts.vault, {
+        envVar: IMESSAGE_SERVER_PASSWORD_ENV,
+        vaultKey: IMESSAGE_SERVER_PASSWORD_KEY,
+      }));
+    if (!serverUrl || !password) throw new Error(NOT_CONFIGURED_MESSAGE);
+
+    // Allow-list (OTHER people) + owner handles (self-chat), from vault + options.
+    this.rebuildHandleSet(
+      this.allowedHandles,
+      parseHandleList(await this.opts.vault.get(IMESSAGE_ALLOWED_HANDLES_KEY)),
+      this.opts.allowedHandles,
+    );
+    this.rebuildHandleSet(
+      this.ownerHandles,
+      parseHandleList(await this.opts.vault.get(IMESSAGE_OWNER_HANDLES_KEY)),
+      this.opts.ownerHandles,
+    );
+
+    // Swap in the real autonomous allow-list resolver now that the tool registry
+    // is live (mirrors Signal; `['*']` expands here).
+    const allowedTools = startOpts.allowedTools ?? this.opts.allowedTools ?? [];
+    const allToolNames = this.session.tools.list().map((t) => t.name);
+    this.permissionResolver = buildImessagePermissionResolver({
+      allowedTools,
+      allToolNames,
+      ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+    });
+    this.session.setPermissionResolver(this.permissionResolver);
+
+    // Mirror-to-last-chat: post assistant prose for turns this channel did NOT
+    // initiate (a co-attached surface ran one) into the last chat served.
+    this.logUnsub = this.session.log.subscribe((event) => this.mirrorForeignTurn(event));
+
+    const running = new Promise<void>((resolve) => {
+      this.resolveRunning = resolve;
+    });
+
+    const client = this.makeClient({ serverUrl, password });
+    this.client = client;
+    try {
+      // Reachability + auth probe deferred to here (NOT isAvailable): surfaces a
+      // friendly error if the localhost BlueBubbles server isn't up.
+      await client.ping();
+      await client.connect();
+    } catch (err) {
+      this.logUnsub?.();
+      this.logUnsub = null;
+      this.client = null;
+      throw err;
+    }
+    client.onMessage((raw) => this.handleInbound(raw));
+
+    this.handle = {
+      running,
+      stop: async (reason = 'shutdown') => {
+        this.stopping = true;
+        // Abort the in-flight turn FIRST so the model loop stops the moment the
+        // operator asks to shut down. The autonomous allow-list resolver has no
+        // pending operator prompts, so there is nothing to abortAll.
+        this.turns.abort(reason);
+        this.logUnsub?.();
+        this.logUnsub = null;
+        const client = this.client;
+        this.client = null;
+        client?.close();
+        this.settleRunning();
+      },
+    };
+    this.opts.logger?.info?.('imessage: channel started', {
+      allowedHandles: this.allowedHandles.size,
+      ownerHandles: this.ownerHandles.size,
+    });
+    return this.handle;
+  }
+
+  // -------------------------------------------------------------------------
+  // Inbound
+  // -------------------------------------------------------------------------
+
+  /** Every inbound `new-message` funnels through the one gate. */
+  private handleInbound(raw: unknown): void {
+    if (this.stopping) return;
+    const verdict = gateInboundMessage(
+      {
+        ownerHandles: this.ownerHandles,
+        allowedHandles: this.allowedHandles,
+        isOwnSend: (id) => this.sentIds.has(id),
+      },
+      raw,
+    );
+    if (!verdict.ok) {
+      this.warnDrop(verdict.reason);
+      return;
+    }
+    this.dispatchInBackground(this.processMessage(verdict.chatGuid, verdict.text), 'new-message');
+  }
+
+  /** Busy gate, then one coordinated turn. */
+  private async processMessage(chatGuid: string, text: string): Promise<void> {
+    if (!this.session) return;
+    // Atomic single-flight guard (the coordinator claims the slot BEFORE any
+    // await); the turnId minted here is recorded as an own-turn id — that's what
+    // mirrorForeignTurn filters on (invariant #8).
+    const lease = this.turns.begin(newTurnId());
+    if (!lease) {
+      await this.sendText(chatGuid, 'I am still working on the previous prompt. One moment…');
+      return;
+    }
+    this.lastChatGuid = chatGuid;
+    try {
+      await runImessageTurn(
+        {
+          session: this.session,
+          send: (t) => this.sendText(chatGuid, t),
+          ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+        },
+        {
+          text,
+          ...(this.model ? { model: this.model } : {}),
+          controller: lease.controller,
+          turnId: lease.turnId,
+        },
+      );
+    } finally {
+      lease.end();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Outbound
+  // -------------------------------------------------------------------------
+
+  /** Send one message and record its ids for the echo drop. */
+  private async sendText(chatGuid: string, text: string): Promise<void> {
+    const client = this.client;
+    if (!client) throw new Error('imessage client is not connected');
+    const { guid, tempGuid } = await client.sendText(chatGuid, text);
+    this.recordSent(tempGuid);
+    if (guid) this.recordSent(guid);
+  }
+
+  private recordSent(id: string): void {
+    this.sentIds.add(id);
+    if (this.sentIds.size > MAX_SENT_IDS) {
+      const oldest = this.sentIds.values().next().value;
+      if (oldest !== undefined) this.sentIds.delete(oldest);
+    }
+  }
+
+  /**
+   * Post the assistant's prose for a turn this channel did not initiate.
+   * Skipped for our own turnIds (robust to async ordering / replay, invariant
+   * #8) and while a turn of ours is streaming via the chunked sender.
+   */
+  private mirrorForeignTurn(event: MoxxyEvent): void {
+    const text = this.turns.mirrorText(event);
+    if (text == null) return;
+    const chatGuid = this.lastChatGuid;
+    if (!chatGuid || !this.client) return;
+    void (async () => {
+      for (const part of splitForImessage(text)) {
+        await this.sendText(chatGuid, part);
+      }
+    })().catch((err) => {
+      this.opts.logger?.warn?.('imessage: mirror failed', { err: String(err) });
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Plumbing
+  // -------------------------------------------------------------------------
+
+  private makeClient(opts: { serverUrl: string; password: string }): BlueBubblesClientLike {
+    const clientOpts: BlueBubblesClientOptions = {
+      serverUrl: opts.serverUrl,
+      password: opts.password,
+      ...(this.opts.logger ? { logger: this.opts.logger } : {}),
+    };
+    const factory = this.opts.clientFactory ?? ((o) => new BlueBubblesClient(o));
+    return factory(clientOpts);
+  }
+
+  private rebuildHandleSet(
+    target: Set<string>,
+    fromVault: ReadonlyArray<string>,
+    fromOptions: ReadonlyArray<string> | undefined,
+  ): void {
+    target.clear();
+    for (const handle of fromVault) target.add(handle);
+    for (const handle of fromOptions ?? []) {
+      const normalized = normalizeHandle(handle);
+      if (normalized.length > 0) target.add(normalized);
+    }
+  }
+
+  /**
+   * Run a handler detached from the socket read loop (an inbound handler that
+   * awaited a whole turn would park delivery for its duration). Errors are
+   * logged here — nothing upstream awaits this promise.
+   */
+  private dispatchInBackground(work: Promise<void>, kind: string): void {
+    void work.catch((err) => {
+      this.opts.logger?.warn?.('imessage: handler failed', { kind, err: String(err) });
+    });
+  }
+
+  private warnDrop(reason: string): void {
+    const now = Date.now();
+    if (now - this.lastDropWarnAt < DROP_WARN_INTERVAL_MS) return;
+    this.lastDropWarnAt = now;
+    this.opts.logger?.debug?.('imessage: dropped inbound message', { reason });
+  }
+
+  private settleRunning(): void {
+    if (this.runningSettled) return;
+    this.runningSettled = true;
+    this.resolveRunning?.();
+  }
+}

--- a/packages/plugin-channel-imessage/src/channel/chunker.test.ts
+++ b/packages/plugin-channel-imessage/src/channel/chunker.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ChunkedSender,
+  IMESSAGE_CHUNK_HARD_LIMIT,
+  splitForImessage,
+  takeChunk,
+} from './chunker.js';
+
+describe('takeChunk', () => {
+  it('holds short text for the final flush', () => {
+    expect(takeChunk('hello world')).toBeNull();
+    expect(takeChunk('x'.repeat(1_500))).toBeNull();
+  });
+
+  it('splits at a paragraph boundary once past the soft limit', () => {
+    const text = 'a'.repeat(1_200) + '\n\n' + 'b'.repeat(600);
+    const taken = takeChunk(text);
+    expect(taken).not.toBeNull();
+    expect(taken?.chunk).toBe('a'.repeat(1_200));
+    expect(taken?.rest).toBe('b'.repeat(600));
+  });
+
+  it('falls back to newline, then word boundaries', () => {
+    const nl = 'a'.repeat(1_200) + '\n' + 'b'.repeat(600);
+    expect(takeChunk(nl)?.chunk).toBe('a'.repeat(1_200));
+    const word = 'a'.repeat(1_200) + ' ' + 'b'.repeat(600);
+    expect(takeChunk(word)?.chunk).toBe('a'.repeat(1_200));
+  });
+
+  it('never returns a chunk above the hard limit (hard cut when boundary-less)', () => {
+    const text = 'x'.repeat(IMESSAGE_CHUNK_HARD_LIMIT + 500);
+    const taken = takeChunk(text);
+    expect(taken).not.toBeNull();
+    expect(taken?.chunk.length).toBe(IMESSAGE_CHUNK_HARD_LIMIT);
+    expect(taken?.rest.length).toBe(500);
+  });
+
+  it('waits for more text when boundary-less but under the hard limit', () => {
+    expect(takeChunk('x'.repeat(1_800))).toBeNull();
+  });
+
+  it('ignores boundaries too early to form a meaningful chunk', () => {
+    const text = '\n\n' + 'x'.repeat(1_700);
+    expect(takeChunk(text)).toBeNull();
+  });
+});
+
+describe('splitForImessage', () => {
+  it('returns short text as a single message', () => {
+    expect(splitForImessage('hi')).toEqual(['hi']);
+  });
+
+  it('drops pure whitespace', () => {
+    expect(splitForImessage('   \n ')).toEqual([]);
+  });
+
+  it('splits long text into under-limit pieces', () => {
+    const paragraphs = Array.from({ length: 8 }, (_, i) => `${'p'.repeat(700)}${i}`).join('\n\n');
+    const parts = splitForImessage(paragraphs);
+    expect(parts.length).toBeGreaterThan(1);
+    for (const part of parts) expect(part.length).toBeLessThanOrEqual(IMESSAGE_CHUNK_HARD_LIMIT);
+    expect(parts.join('')).toContain('p'.repeat(700) + '7');
+  });
+});
+
+describe('ChunkedSender', () => {
+  function collector(): { sent: string[]; send: (t: string) => Promise<void> } {
+    const sent: string[] = [];
+    return {
+      sent,
+      send: async (t) => {
+        sent.push(t);
+      },
+    };
+  }
+
+  it('buffers below the soft limit and flushes once on finalize', async () => {
+    const { sent, send } = collector();
+    const sender = new ChunkedSender({ send });
+    sender.offer('Hello');
+    sender.offer('Hello world');
+    await sender.finalize('Hello world, done.');
+    expect(sent).toEqual(['Hello world, done.']);
+  });
+
+  it('streams paragraph chunks as the snapshot grows, then sends only the remainder', async () => {
+    const { sent, send } = collector();
+    const sender = new ChunkedSender({ send, limits: { softLimit: 20, hardLimit: 60 } });
+    sender.offer('first paragraph text\n\nsecond');
+    await sender.finalize('first paragraph text\n\nsecond part is done');
+    expect(sent).toEqual(['first paragraph text', 'second part is done']);
+  });
+
+  it('sends the empty-turn placeholder only when nothing was ever sent', async () => {
+    const { sent, send } = collector();
+    const sender = new ChunkedSender({ send });
+    await sender.finalize('   ', '(no output)');
+    expect(sent).toEqual(['(no output)']);
+  });
+
+  it('does not send the placeholder when chunks already went out', async () => {
+    const { sent, send } = collector();
+    const sender = new ChunkedSender({ send, limits: { softLimit: 5, hardLimit: 30 } });
+    sender.offer('streamed text already sent\n\nx');
+    await sender.finalize('', '(no output)');
+    expect(sent).toEqual(['streamed text already sent']);
+  });
+
+  it('re-sends the authoritative final text when it diverges from the streamed prefix', async () => {
+    const { sent, send } = collector();
+    const sender = new ChunkedSender({ send, limits: { softLimit: 10, hardLimit: 40 } });
+    sender.offer('streamed draft one\n\nmore text here');
+    await sender.finalize('a completely different final answer');
+    expect(sent[0]).toBe('streamed draft one');
+    expect(sent).toContain('a completely different final answer');
+  });
+
+  it('serializes sends in order', async () => {
+    const order: string[] = [];
+    const sender = new ChunkedSender({
+      send: async (t) => {
+        await new Promise((r) => setTimeout(r, 5));
+        order.push(t);
+      },
+      limits: { softLimit: 4, hardLimit: 12 },
+    });
+    sender.offer('one two\n\n');
+    sender.offer('one two\n\nthree four\n\n');
+    await sender.finalize('one two\n\nthree four\n\nfive');
+    expect(order).toEqual(['one two', 'three four', 'five']);
+  });
+});

--- a/packages/plugin-channel-imessage/src/channel/chunker.ts
+++ b/packages/plugin-channel-imessage/src/channel/chunker.ts
@@ -1,0 +1,144 @@
+/**
+ * Buffered chunked sends — iMessage's streaming strategy.
+ *
+ * WHY NOT FramePump edits: editing a sent iMessage requires the BlueBubbles
+ * Private API (a Helper bundle injected into Messages, which needs SIP disabled)
+ * — out of scope for v1's stock apple-script server. With apple-script every
+ * message is immutable once sent, so instead of "send once then edit" we buffer
+ * the streamed text and send coherent chunks: nothing goes out until a
+ * paragraph-aligned chunk is ready, and the remainder goes out once, at turn
+ * end. (Copied from the Signal channel's chunker, which faces the same
+ * immutable-message constraint.)
+ */
+
+/** Buffered text below this length is held for the final flush. */
+export const IMESSAGE_CHUNK_SOFT_LIMIT = 1_500;
+/**
+ * Never send a single message longer than this. iMessage itself allows long
+ * bodies, but clients render extremely long messages poorly; 2000 mirrors the
+ * Signal channel's cap for parity.
+ */
+export const IMESSAGE_CHUNK_HARD_LIMIT = 2_000;
+
+export interface ChunkLimits {
+  readonly softLimit?: number;
+  readonly hardLimit?: number;
+}
+
+/**
+ * If `text` has grown past the soft limit, split off one send-ready chunk at
+ * the best boundary (paragraph → line → word) at or below the hard limit.
+ * Returns null while the text should keep buffering.
+ */
+export function takeChunk(
+  text: string,
+  limits: ChunkLimits = {},
+): { chunk: string; rest: string } | null {
+  const soft = limits.softLimit ?? IMESSAGE_CHUNK_SOFT_LIMIT;
+  const hard = limits.hardLimit ?? IMESSAGE_CHUNK_HARD_LIMIT;
+  if (text.length <= soft) return null;
+  const window = text.slice(0, Math.min(text.length, hard));
+  // Prefer a paragraph break; a chunk that ends mid-sentence reads badly as a
+  // standalone message. Require the boundary to keep a meaningful chunk (≥ half
+  // the soft limit) so a leading blank line can't produce confetti.
+  const minCut = Math.floor(soft / 2);
+  for (const boundary of ['\n\n', '\n', ' ']) {
+    const at = window.lastIndexOf(boundary);
+    if (at >= minCut) {
+      return { chunk: window.slice(0, at).trimEnd(), rest: text.slice(at + boundary.length) };
+    }
+  }
+  if (text.length <= hard) return null; // no boundary yet — wait for more text
+  return { chunk: window, rest: text.slice(window.length) }; // pathological: hard cut
+}
+
+/** Split a final remainder into hard-limit-sized pieces at the best boundaries. */
+export function splitForImessage(text: string, limits: ChunkLimits = {}): string[] {
+  const hard = limits.hardLimit ?? IMESSAGE_CHUNK_HARD_LIMIT;
+  const parts: string[] = [];
+  let rest = text;
+  while (rest.length > hard) {
+    // Reuse takeChunk with soft==hard-ish so it only splits when forced.
+    const taken = takeChunk(rest, { softLimit: Math.floor(hard / 2), hardLimit: hard });
+    if (!taken) break;
+    if (taken.chunk) parts.push(taken.chunk);
+    rest = taken.rest;
+  }
+  const tail = rest.trim();
+  if (tail) parts.push(tail);
+  return parts;
+}
+
+export interface ChunkedSenderOptions {
+  /** Deliver one message. Errors should be handled by the caller-supplied fn
+   *  (log + swallow) — a failed chunk must never abort the turn. */
+  readonly send: (text: string) => Promise<void>;
+  readonly limits?: ChunkLimits;
+}
+
+/**
+ * Drives {@link takeChunk} over a GROWING renderer snapshot: `offer()` on every
+ * change (sends any ready chunk), `finalize()` at turn end (sends the
+ * remainder, or `emptyText` when the whole turn produced nothing). Sends are
+ * serialized on an internal queue so chunks can never interleave out of order.
+ */
+export class ChunkedSender {
+  private readonly opts: ChunkedSenderOptions;
+  /** The exact snapshot prefix already delivered (chunk boundaries included). */
+  private sentPrefix = '';
+  private sentAnything = false;
+  private queue: Promise<void> = Promise.resolve();
+
+  constructor(opts: ChunkedSenderOptions) {
+    this.opts = opts;
+  }
+
+  /** Called with the current full snapshot whenever it changes. */
+  offer(snapshot: string): void {
+    this.queue = this.queue.then(async () => {
+      // Streamed text only ever grows; if the snapshot diverged from what we
+      // already delivered (the final assistant_message rewrote history) hold
+      // everything for finalize(), which handles divergence explicitly.
+      if (!snapshot.startsWith(this.sentPrefix)) return;
+      let consumed = this.sentPrefix.length;
+      let taken = takeChunk(snapshot.slice(consumed), this.opts.limits);
+      while (taken) {
+        await this.deliver(taken.chunk);
+        consumed = snapshot.length - taken.rest.length;
+        this.sentPrefix = snapshot.slice(0, consumed);
+        taken = takeChunk(taken.rest, this.opts.limits);
+      }
+    });
+  }
+
+  /**
+   * Turn end: deliver whatever the final snapshot still owes. When the final
+   * text no longer extends what we already sent (a divergent final frame —
+   * rare), send the full final text so the user always receives the
+   * authoritative reply, accepting the duplication.
+   */
+  async finalize(snapshot: string, emptyText?: string): Promise<void> {
+    this.queue = this.queue.then(async () => {
+      const finalText = snapshot.trim();
+      if (!finalText) {
+        if (!this.sentAnything && emptyText) await this.deliver(emptyText);
+        return;
+      }
+      const remainder = snapshot.startsWith(this.sentPrefix)
+        ? snapshot.slice(this.sentPrefix.length)
+        : snapshot; // diverged: resend the authoritative text in full
+      for (const part of splitForImessage(remainder, this.opts.limits)) {
+        await this.deliver(part);
+      }
+      this.sentPrefix = snapshot;
+    });
+    await this.queue;
+  }
+
+  private async deliver(text: string): Promise<void> {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    this.sentAnything = true;
+    await this.opts.send(trimmed);
+  }
+}

--- a/packages/plugin-channel-imessage/src/channel/turn-runner.ts
+++ b/packages/plugin-channel-imessage/src/channel/turn-runner.ts
@@ -1,0 +1,82 @@
+import type { newTurnId } from '@moxxy/core';
+import { PlainTurnRenderer, driveTurn, subscribeTurn } from '@moxxy/channel-kit';
+import type { ClientSession as Session } from '@moxxy/sdk';
+import { ChunkedSender, type ChunkLimits } from './chunker.js';
+
+export interface TurnRunnerLogger {
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface RunImessageTurnDeps {
+  readonly session: Session;
+  /** Deliver one outbound message to the turn's reply target. Must swallow its
+   *  own transport errors (log + resolve) — a failed send never aborts the turn. */
+  readonly send: (text: string) => Promise<void>;
+  readonly chunkLimits?: ChunkLimits;
+  readonly logger?: TurnRunnerLogger;
+}
+
+export interface RunImessageTurnOptions {
+  readonly text: string;
+  readonly model?: string;
+  readonly controller: AbortController;
+  /** Pre-minted turn id; the channel records it as an own-turn id (invariant #8). */
+  readonly turnId: ReturnType<typeof newTurnId>;
+}
+
+/**
+ * Drive a single iMessage turn end-to-end: subscribe to THIS turn's events
+ * (filtered by turnId — `session.log` fans out to every listener, AGENTS.md
+ * invariant #8), stream the rendered snapshot through the buffered
+ * {@link ChunkedSender} (see chunker.ts for why iMessage gets chunked sends
+ * instead of FramePump edits — apple-script messages are immutable), run the
+ * turn, flush the final remainder, and unwind in `finally`. No typing indicator:
+ * that needs the BlueBubbles Private API, which v1 deliberately omits.
+ */
+export async function runImessageTurn(
+  deps: RunImessageTurnDeps,
+  opts: RunImessageTurnOptions,
+): Promise<void> {
+  const { session, send, logger } = deps;
+  const { text, model, controller, turnId } = opts;
+
+  const renderer = new PlainTurnRenderer();
+  const sender = new ChunkedSender({
+    send: async (t) => {
+      try {
+        await send(t);
+      } catch (err) {
+        logger?.warn?.('imessage: send failed', {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    ...(deps.chunkLimits ? { limits: deps.chunkLimits } : {}),
+  });
+
+  const unsubscribe = subscribeTurn(session, turnId, (event) => {
+    if (renderer.accept(event)) sender.offer(renderer.snapshot());
+  });
+
+  try {
+    await driveTurn(session, {
+      turnId,
+      prompt: text,
+      ...(model ? { model } : {}),
+      signal: controller.signal,
+    });
+    await sender.finalize(renderer.snapshot(), '(no output)');
+  } catch (err) {
+    logger?.warn?.('imessage: turn failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    // Surface the failure to the sender rather than going silent.
+    try {
+      await send(`Turn failed: ${err instanceof Error ? err.message : String(err)}`);
+    } catch {
+      /* best-effort */
+    }
+  } finally {
+    unsubscribe();
+  }
+}

--- a/packages/plugin-channel-imessage/src/index.ts
+++ b/packages/plugin-channel-imessage/src/index.ts
@@ -1,0 +1,273 @@
+import { defineChannel, definePlugin, type LifecycleHooks, type Plugin } from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { ImessageChannel, type ImessageChannelOptions } from './channel.js';
+import {
+  IMESSAGE_ALLOWED_HANDLES_KEY,
+  IMESSAGE_OWNER_HANDLES_KEY,
+  IMESSAGE_SERVER_PASSWORD_ENV,
+  IMESSAGE_SERVER_PASSWORD_KEY,
+  IMESSAGE_SERVER_URL_ENV,
+  IMESSAGE_SERVER_URL_KEY,
+  parseHandleList,
+} from './keys.js';
+import { runImessageWizard } from './setup-wizard.js';
+
+export {
+  ImessageChannel,
+  type ImessageChannelOptions,
+  type ImessageStartOpts,
+} from './channel.js';
+export { buildImessagePermissionResolver } from './permission.js';
+export {
+  BlueBubblesClient,
+  makeTempGuid,
+  type BlueBubblesClientLike,
+  type BlueBubblesClientOptions,
+  type SocketLike,
+} from './bluebubbles-client.js';
+export { gateInboundMessage, type GateState, type GateVerdict } from './message-gate.js';
+export { messageSchema, MAX_INBOUND_TEXT_CHARS, type ImessageMessage } from './schema.js';
+export {
+  ChunkedSender,
+  takeChunk,
+  splitForImessage,
+  IMESSAGE_CHUNK_SOFT_LIMIT,
+  IMESSAGE_CHUNK_HARD_LIMIT,
+} from './channel/chunker.js';
+export {
+  IMESSAGE_SERVER_URL_KEY,
+  IMESSAGE_SERVER_URL_ENV,
+  IMESSAGE_SERVER_PASSWORD_KEY,
+  IMESSAGE_SERVER_PASSWORD_ENV,
+  IMESSAGE_ALLOWED_HANDLES_KEY,
+  IMESSAGE_OWNER_HANDLES_KEY,
+  parseHandleList,
+  parseDmChatGuid,
+  normalizeHandle,
+  isHandle,
+  E164_RE,
+  EMAIL_RE,
+} from './keys.js';
+
+export interface BuildImessagePluginOptions {
+  /** Host-injected encrypted secret store (available immediately). */
+  readonly vault: VaultStore;
+}
+
+/**
+ * Build the iMessage channel plugin with a host-injected vault (mirrors the
+ * Signal/WhatsApp plugins' vault injection).
+ */
+export function buildImessagePlugin(opts: BuildImessagePluginOptions): Plugin {
+  return makeImessagePlugin(() => opts.vault);
+}
+
+/**
+ * Discovery-loadable default export: resolves the vault from the inter-plugin
+ * service registry in `onInit` (the vault plugin publishes `'vault'`). Requires
+ * `@moxxy/plugin-vault` to load first (declared in `package.json`
+ * `moxxy.requirements`).
+ */
+export const imessagePlugin: Plugin = (() => {
+  let resolved: VaultStore | null = null;
+  const getVault = (): VaultStore => {
+    if (!resolved) {
+      throw new Error(
+        '@moxxy/plugin-channel-imessage: the "vault" service is unavailable — @moxxy/plugin-vault must load first',
+      );
+    }
+    return resolved;
+  };
+  const hooks: LifecycleHooks = {
+    onInit: (ctx) => {
+      resolved = ctx.services.require<VaultStore>('vault');
+    },
+  };
+  return makeImessagePlugin(getVault, hooks);
+})();
+
+export default imessagePlugin;
+
+function readStringArray(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) return value.map((x) => String(x));
+  if (typeof value === 'string' && value.trim()) {
+    return value
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return undefined;
+}
+
+function envConfigured(): boolean {
+  const url = process.env[IMESSAGE_SERVER_URL_ENV];
+  const pass = process.env[IMESSAGE_SERVER_PASSWORD_ENV];
+  return typeof url === 'string' && url.trim().length > 0 && typeof pass === 'string' && pass.trim().length > 0;
+}
+
+function makeImessagePlugin(getVault: () => VaultStore, hooks?: LifecycleHooks): Plugin {
+  return definePlugin({
+    name: '@moxxy/plugin-channel-imessage',
+    version: '0.0.0',
+    ...(hooks ? { hooks } : {}),
+    channels: [
+      defineChannel({
+        name: 'imessage',
+        description:
+          'iMessage channel via a localhost BlueBubbles server (macOS only). Allow-listed handles (and your own self-chat) drive the agent; replies go out as buffered chunked sends.',
+        // A BlueBubbles server sees ALL the account owner's messages, so this
+        // channel runs on its own dedicated, isolated runner (separate socket +
+        // sticky session), like Signal — it keeps its own persistent history
+        // apart from the user's desktop/TUI work.
+        dedicatedRunner: true,
+        sessionSource: 'imessage',
+        config: {
+          fields: [
+            {
+              name: 'serverUrl',
+              label: 'BlueBubbles server URL',
+              vaultKey: IMESSAGE_SERVER_URL_KEY,
+              required: true,
+              secret: false,
+              placeholder: 'http://localhost:1234',
+              help: 'The BlueBubbles server running on this Mac (default port 1234)',
+            },
+            {
+              name: 'password',
+              label: 'BlueBubbles server password',
+              vaultKey: IMESSAGE_SERVER_PASSWORD_KEY,
+              required: true,
+              secret: true,
+              help: 'The password set in the BlueBubbles app (sent as a query param on every request)',
+            },
+          ],
+          hasRequestUrl: false,
+          runHint:
+            'Install the BlueBubbles server on this Mac, sign in to Messages, set a password, then run `moxxy channels imessage setup` to add allowed handles.',
+          connect: {
+            kind: 'instructions',
+            title: 'Connect BlueBubbles',
+            steps: [
+              'Install the BlueBubbles server on this Mac from https://bluebubbles.app and sign in to Messages.',
+              'In the BlueBubbles app, set a server password and note the port (default 1234).',
+              'Run `moxxy channels imessage setup` and paste the URL + password, then add the handles allowed to talk to moxxy.',
+            ],
+          },
+        },
+        create: (deps) => {
+          const options = deps.options;
+          const channelOpts: ImessageChannelOptions = {
+            vault: getVault(),
+            ...(typeof options?.['serverUrl'] === 'string' ? { serverUrl: options['serverUrl'] } : {}),
+            ...(typeof options?.['password'] === 'string' ? { password: options['password'] } : {}),
+            ...(() => {
+              const tools = readStringArray(options?.['allowedTools']);
+              return tools ? { allowedTools: tools } : {};
+            })(),
+            ...(() => {
+              const handles = readStringArray(options?.['allowedHandles']);
+              return handles ? { allowedHandles: handles } : {};
+            })(),
+            ...(() => {
+              const handles = readStringArray(options?.['ownerHandles']);
+              return handles ? { ownerHandles: handles } : {};
+            })(),
+            logger: deps.logger as never,
+          };
+          return new ImessageChannel(channelOpts);
+        },
+        isAvailable: async () => {
+          // Pure check — NO network probe (this runs on every `moxxy channels
+          // list` / `moxxy doctor`). The reachability ping is deferred to start().
+          if (process.platform !== 'darwin') {
+            return {
+              ok: false,
+              reason: 'iMessage requires macOS (a BlueBubbles server running on this Mac).',
+            };
+          }
+          // Env pair short-circuit (the vault may not be wired in a probe context).
+          if (envConfigured()) return { ok: true };
+          try {
+            const vault = getVault();
+            if ((await vault.has(IMESSAGE_SERVER_URL_KEY)) && (await vault.has(IMESSAGE_SERVER_PASSWORD_KEY))) {
+              return { ok: true };
+            }
+          } catch {
+            /* vault unavailable in a probe context — fall through */
+          }
+          return {
+            ok: false,
+            reason: 'No BlueBubbles server configured. Run `moxxy channels imessage setup`.',
+          };
+        },
+        interactiveCommand: 'setup',
+        subcommands: {
+          setup: {
+            description:
+              'Interactive setup: store the BlueBubbles server URL + password, the handle allow-list and your own self-chat handles, pick the tool allow-list, then start. Shown by default for `moxxy imessage` on a TTY.',
+            run: async (ctx) => {
+              if (process.stdin.isTTY !== true) {
+                // Headless: just start the channel (server must already be configured).
+                return ctx.startChannel();
+              }
+              return runImessageWizard(ctx);
+            },
+          },
+          status: {
+            description: 'Report platform / server-config / allow-list state as JSON.',
+            run: async (ctx) => {
+              const vault = ctx.deps.vault as VaultStore | undefined;
+              if (!vault) {
+                process.stderr.write('vault unavailable\n');
+                return 1;
+              }
+              const serverUrl =
+                process.env[IMESSAGE_SERVER_URL_ENV]?.trim() || (await vault.get(IMESSAGE_SERVER_URL_KEY));
+              const passwordSet =
+                (process.env[IMESSAGE_SERVER_PASSWORD_ENV]?.trim() ?? '').length > 0 ||
+                (await vault.has(IMESSAGE_SERVER_PASSWORD_KEY));
+              const allowedHandles = parseHandleList(await vault.get(IMESSAGE_ALLOWED_HANDLES_KEY));
+              const ownerHandles = parseHandleList(await vault.get(IMESSAGE_OWNER_HANDLES_KEY));
+              process.stdout.write(
+                JSON.stringify(
+                  {
+                    platform: process.platform,
+                    supported: process.platform === 'darwin',
+                    serverUrl: serverUrl || null,
+                    passwordSet,
+                    allowedHandles,
+                    ownerHandles,
+                  },
+                  null,
+                  2,
+                ) + '\n',
+              );
+              return 0;
+            },
+          },
+          unpair: {
+            description:
+              'Forget the stored BlueBubbles server URL + password and the handle allow-list. (The BlueBubbles app itself is untouched — uninstall or reset it there to fully disconnect.)',
+            run: async (ctx) => {
+              const vault = ctx.deps.vault as VaultStore | undefined;
+              if (!vault) {
+                process.stderr.write('vault unavailable\n');
+                return 1;
+              }
+              const removedUrl = await vault.delete(IMESSAGE_SERVER_URL_KEY);
+              await vault.delete(IMESSAGE_SERVER_PASSWORD_KEY);
+              await vault.delete(IMESSAGE_ALLOWED_HANDLES_KEY);
+              await vault.delete(IMESSAGE_OWNER_HANDLES_KEY);
+              process.stdout.write(
+                removedUrl
+                  ? 'unpaired (vault cleared). The BlueBubbles server app is untouched — reset it there to fully disconnect.\n'
+                  : 'no BlueBubbles server was configured\n',
+              );
+              return 0;
+            },
+          },
+        },
+      }),
+    ],
+  });
+}

--- a/packages/plugin-channel-imessage/src/keys.test.ts
+++ b/packages/plugin-channel-imessage/src/keys.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  E164_RE,
+  EMAIL_RE,
+  isHandle,
+  normalizeHandle,
+  parseDmChatGuid,
+  parseHandleList,
+} from './keys.js';
+
+describe('handle shapes', () => {
+  it('E164_RE accepts plausible numbers and rejects junk', () => {
+    expect(E164_RE.test('+15551234567')).toBe(true);
+    expect(E164_RE.test('+4915771234567')).toBe(true);
+    expect(E164_RE.test('15551234567')).toBe(false);
+    expect(E164_RE.test('+0155')).toBe(false);
+    expect(E164_RE.test('')).toBe(false);
+  });
+
+  it('EMAIL_RE accepts Apple-ID emails and rejects junk', () => {
+    expect(EMAIL_RE.test('friend@icloud.com')).toBe(true);
+    expect(EMAIL_RE.test('a.b+c@example.co.uk')).toBe(true);
+    expect(EMAIL_RE.test('not-an-email')).toBe(false);
+    expect(EMAIL_RE.test('two @spaces.com')).toBe(false);
+  });
+
+  it('isHandle recognises numbers and emails only', () => {
+    expect(isHandle('+15551234567')).toBe(true);
+    expect(isHandle('friend@icloud.com')).toBe(true);
+    expect(isHandle('bob')).toBe(false);
+    expect(isHandle('../../etc/passwd')).toBe(false);
+  });
+});
+
+describe('normalizeHandle', () => {
+  it('lowercases emails but preserves numbers', () => {
+    expect(normalizeHandle(' +15551234567 ')).toBe('+15551234567');
+    expect(normalizeHandle('  Friend@ICloud.com ')).toBe('friend@icloud.com');
+  });
+});
+
+describe('parseHandleList', () => {
+  it('parses a JSON array of numbers/emails', () => {
+    const raw = JSON.stringify(['+15551234567', 'Friend@iCloud.com']);
+    expect(parseHandleList(raw)).toEqual(['+15551234567', 'friend@icloud.com']);
+  });
+
+  it('fails closed on missing or corrupt values', () => {
+    expect(parseHandleList(null)).toEqual([]);
+    expect(parseHandleList(undefined)).toEqual([]);
+    expect(parseHandleList('')).toEqual([]);
+    expect(parseHandleList('not json')).toEqual([]);
+    expect(parseHandleList('"a string"')).toEqual([]);
+    expect(parseHandleList('{"a":1}')).toEqual([]);
+  });
+
+  it('drops entries that are neither E.164 nor email, and de-dupes', () => {
+    const raw = JSON.stringify(['+15551234567', 'bob', 42, '../../etc/passwd', '+15551234567']);
+    expect(parseHandleList(raw)).toEqual(['+15551234567']);
+  });
+});
+
+describe('parseDmChatGuid', () => {
+  it('parses a 1:1 chat guid', () => {
+    expect(parseDmChatGuid('iMessage;-;+15551234567')).toEqual({
+      service: 'iMessage',
+      handle: '+15551234567',
+    });
+    expect(parseDmChatGuid('SMS;-;Friend@iCloud.com')).toEqual({
+      service: 'SMS',
+      handle: 'friend@icloud.com',
+    });
+  });
+
+  it('rejects group guids (v1 is DM-only)', () => {
+    expect(parseDmChatGuid('iMessage;+;chat1234567890')).toBeNull();
+  });
+
+  it('rejects malformed / non-handle guids', () => {
+    expect(parseDmChatGuid(null)).toBeNull();
+    expect(parseDmChatGuid('')).toBeNull();
+    expect(parseDmChatGuid('iMessage;-;')).toBeNull();
+    expect(parseDmChatGuid('iMessage;-;not-a-handle')).toBeNull();
+    expect(parseDmChatGuid('iMessage;-;+1;extra')).toBeNull();
+  });
+});

--- a/packages/plugin-channel-imessage/src/keys.ts
+++ b/packages/plugin-channel-imessage/src/keys.ts
@@ -1,0 +1,109 @@
+/**
+ * Vault keys + pure handle helpers shared by the channel, its subcommands, and
+ * the interactive setup wizard. Kept in their own module (the signal/whatsapp
+ * `keys.ts` pattern) so wizard helpers can import them without pulling in the
+ * plugin's full index (or, worse, socket.io-client — which stays behind a lazy
+ * import in `bluebubbles-client.ts`).
+ *
+ * Note on custody: the BlueBubbles server (a native macOS app) holds the actual
+ * iMessage identity + message store. The moxxy vault only stores the localhost
+ * server URL, its password, and two JSON handle arrays — the allow-list of OTHER
+ * people who may drive the agent, and the owner's own handle(s) that enable
+ * texting moxxy from your own devices (the "self-chat").
+ */
+
+/** Vault key for the BlueBubbles server URL (e.g. http://localhost:1234). */
+export const IMESSAGE_SERVER_URL_KEY = 'imessage_server_url';
+/** Env override for the server URL — beats the vault (shared precedence). */
+export const IMESSAGE_SERVER_URL_ENV = 'MOXXY_IMESSAGE_SERVER_URL';
+/** Vault key for the BlueBubbles server password. */
+export const IMESSAGE_SERVER_PASSWORD_KEY = 'imessage_server_password';
+/** Env override for the server password — beats the vault. */
+export const IMESSAGE_SERVER_PASSWORD_ENV = 'MOXXY_IMESSAGE_SERVER_PASSWORD';
+/**
+ * Vault key for the allow-list: a JSON array of iMessage handles (E.164 phone
+ * numbers and/or Apple-ID emails) that OTHER people may use to drive the
+ * session. The owner's own handle is NOT listed here — it lives in
+ * {@link IMESSAGE_OWNER_HANDLES_KEY} so an inbound from a friend and an outbound
+ * from the owner stay distinguishable (never react to the owner's private
+ * conversations with allow-listed friends).
+ */
+export const IMESSAGE_ALLOWED_HANDLES_KEY = 'imessage_allowed_handles';
+/**
+ * Vault key for the owner's OWN handle(s): a JSON array of the account owner's
+ * E.164 numbers / Apple-ID emails. A message the account itself sent
+ * (`isFromMe`) drives a turn only when it lands in a 1:1 chat with one of these
+ * handles — i.e. the owner texting their own "self-chat" from any Apple device.
+ * Empty (the default) means self-chat is off and every `isFromMe` message is
+ * dropped (fail closed); the friend allow-list path is unaffected.
+ */
+export const IMESSAGE_OWNER_HANDLES_KEY = 'imessage_owner_handles';
+
+/** E.164 shape: `+` then 7–15 digits, no leading zero. */
+export const E164_RE = /^\+[1-9]\d{6,14}$/;
+
+/** Pragmatic email shape (Apple-ID handles). Deliberately loose but anchored. */
+export const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Whether a normalized string is a plausible iMessage handle. */
+export function isHandle(value: string): boolean {
+  return E164_RE.test(value) || EMAIL_RE.test(value);
+}
+
+/**
+ * Canonical handle for allow-list comparisons: trimmed, and lowercased when it
+ * is an email (Apple-ID handles are case-insensitive). Phone numbers are left
+ * as-is (they are already digits + `+`).
+ */
+export function normalizeHandle(raw: string): string {
+  const trimmed = raw.trim();
+  return trimmed.includes('@') ? trimmed.toLowerCase() : trimmed;
+}
+
+/**
+ * Parse a stored handle list. Returns `[]` for a missing OR corrupt value
+ * rather than throwing — a corrupt vault entry must degrade to "nobody extra is
+ * allowed" (fail closed), never crash the channel or silently allow. Non-string
+ * entries and entries that are neither an E.164 number nor an email are dropped.
+ */
+export function parseHandleList(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out = new Set<string>();
+  for (const entry of parsed) {
+    if (typeof entry !== 'string') continue;
+    const handle = normalizeHandle(entry);
+    if (isHandle(handle)) out.add(handle);
+  }
+  return [...out];
+}
+
+/**
+ * Parse the chat GUID BlueBubbles stamps on every message
+ * (`SERVICE;TYPE;IDENTIFIER`, e.g. `iMessage;-;+15551234567`). TYPE is `-` for a
+ * 1:1 chat and `+` for a group. Returns null for anything that is not a
+ * well-formed 1:1 GUID (groups included) so callers treat it as "not a DM" and
+ * drop it (v1 is direct-message only).
+ */
+export function parseDmChatGuid(
+  guid: string | null | undefined,
+): { readonly service: string; readonly handle: string } | null {
+  if (typeof guid !== 'string') return null;
+  const parts = guid.split(';');
+  if (parts.length !== 3) return null;
+  const [rawService, rawType, rawIdentifier] = parts;
+  if (rawService === undefined || rawType === undefined || rawIdentifier === undefined) return null;
+  const service = rawService.trim();
+  const type = rawType.trim();
+  const identifier = rawIdentifier.trim();
+  if (service.length === 0 || type !== '-' || identifier.length === 0) return null;
+  const handle = normalizeHandle(identifier);
+  if (!isHandle(handle)) return null;
+  return { service, handle };
+}

--- a/packages/plugin-channel-imessage/src/message-gate.test.ts
+++ b/packages/plugin-channel-imessage/src/message-gate.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { gateInboundMessage, type GateState } from './message-gate.js';
+import { MAX_INBOUND_TEXT_CHARS } from './schema.js';
+
+const OWNER = '+19998887777';
+const FRIEND = '+15550001111';
+const STRANGER = '+14440002222';
+
+const chatFor = (handle: string): string => `iMessage;-;${handle}`;
+
+function state(overrides: Partial<GateState> = {}): GateState {
+  return {
+    ownerHandles: new Set([OWNER]),
+    allowedHandles: new Set([FRIEND]),
+    isOwnSend: () => false,
+    ...overrides,
+  };
+}
+
+function msg(opts: {
+  chatGuid: string;
+  text?: string | null;
+  isFromMe?: boolean;
+  sender?: string;
+  guid?: string;
+  tempGuid?: string;
+}): Record<string, unknown> {
+  return {
+    guid: opts.guid ?? 'msg-1',
+    ...(opts.tempGuid ? { tempGuid: opts.tempGuid } : {}),
+    text: opts.text ?? 'hi',
+    isFromMe: opts.isFromMe ?? false,
+    ...(opts.sender ? { handle: { address: opts.sender } } : {}),
+    chats: [{ guid: opts.chatGuid }],
+  };
+}
+
+describe('gateInboundMessage', () => {
+  it('accepts an allow-listed sender text message and targets their chat', () => {
+    const v = gateInboundMessage(state(), msg({ chatGuid: chatFor(FRIEND), text: 'hi there', sender: FRIEND }));
+    expect(v).toEqual({ ok: true, chatGuid: chatFor(FRIEND), text: 'hi there' });
+  });
+
+  it("accepts the owner's own self-chat message (isFromMe in an owner chat)", () => {
+    const v = gateInboundMessage(state(), msg({ chatGuid: chatFor(OWNER), text: 'note to self', isFromMe: true }));
+    expect(v).toEqual({ ok: true, chatGuid: chatFor(OWNER), text: 'note to self' });
+  });
+
+  it('drops an isFromMe message in a FOREIGN chat (owner talking to others)', () => {
+    const v = gateInboundMessage(state(), msg({ chatGuid: chatFor(FRIEND), isFromMe: true }));
+    expect(v).toEqual({ ok: false, reason: 'own message in a foreign chat' });
+  });
+
+  it("drops the bot's OWN outbound echo by guid (loop protection)", () => {
+    const st = state({ isOwnSend: (id) => id === 'echo-guid' });
+    const v = gateInboundMessage(
+      st,
+      msg({ chatGuid: chatFor(OWNER), isFromMe: true, guid: 'echo-guid' }),
+    );
+    expect(v).toEqual({ ok: false, reason: 'own outbound echo (guid)' });
+  });
+
+  it("drops the bot's OWN outbound echo by tempGuid", () => {
+    const st = state({ isOwnSend: (id) => id === 'temp-xyz' });
+    const v = gateInboundMessage(
+      st,
+      msg({ chatGuid: chatFor(FRIEND), sender: FRIEND, guid: 'g2', tempGuid: 'temp-xyz' }),
+    );
+    expect(v).toEqual({ ok: false, reason: 'own outbound echo (tempGuid)' });
+  });
+
+  it('drops an un-allow-listed sender (silent — no reply)', () => {
+    const v = gateInboundMessage(state(), msg({ chatGuid: chatFor(STRANGER), sender: STRANGER }));
+    expect(v).toEqual({ ok: false, reason: 'sender not allow-listed' });
+  });
+
+  it('drops group messages (v1 is direct-message only)', () => {
+    const v = gateInboundMessage(state(), msg({ chatGuid: 'iMessage;+;chat123', sender: FRIEND }));
+    expect(v).toEqual({ ok: false, reason: 'not a 1:1 direct message' });
+  });
+
+  it('resolves the sender from the chat guid when the message has no handle', () => {
+    const v = gateInboundMessage(state(), msg({ chatGuid: chatFor(FRIEND) }));
+    expect(v).toEqual({ ok: true, chatGuid: chatFor(FRIEND), text: 'hi' });
+  });
+
+  it('drops self-chat when no owner handles are configured (fail closed)', () => {
+    const v = gateInboundMessage(
+      state({ ownerHandles: new Set() }),
+      msg({ chatGuid: chatFor(OWNER), isFromMe: true }),
+    );
+    expect(v).toEqual({ ok: false, reason: 'own message in a foreign chat' });
+  });
+
+  it('drops schema-invalid payloads without throwing', () => {
+    expect(gateInboundMessage(state(), null)).toEqual({ ok: false, reason: 'invalid message shape' });
+    expect(gateInboundMessage(state(), 'garbage')).toEqual({
+      ok: false,
+      reason: 'invalid message shape',
+    });
+    expect(gateInboundMessage(state(), { text: 'no guid', chats: [] })).toEqual({
+      ok: false,
+      reason: 'invalid message shape',
+    });
+  });
+
+  it('drops a message with no chat', () => {
+    expect(gateInboundMessage(state(), { guid: 'm', text: 'x' })).toEqual({
+      ok: false,
+      reason: 'message without a chat',
+    });
+  });
+
+  it('rejects oversized text at the schema boundary', () => {
+    const v = gateInboundMessage(
+      state(),
+      msg({ chatGuid: chatFor(FRIEND), sender: FRIEND, text: 'a'.repeat(MAX_INBOUND_TEXT_CHARS + 1) }),
+    );
+    expect(v).toEqual({ ok: false, reason: 'invalid message shape' });
+  });
+
+  it('drops empty / whitespace-only text', () => {
+    const v = gateInboundMessage(state(), msg({ chatGuid: chatFor(FRIEND), sender: FRIEND, text: '   ' }));
+    expect(v).toEqual({ ok: false, reason: 'no message text' });
+  });
+});

--- a/packages/plugin-channel-imessage/src/message-gate.ts
+++ b/packages/plugin-channel-imessage/src/message-gate.ts
@@ -1,0 +1,94 @@
+import { normalizeHandle, parseDmChatGuid } from './keys.js';
+import { messageSchema } from './schema.js';
+
+/**
+ * The single inbound gate every session-reaching path goes through (AGENTS.md:
+ * gate EVERY session-reaching path behind pairing; A8: zod-validate inbound
+ * before it touches the session). Pure — the channel feeds it the raw
+ * BlueBubbles `new-message` payload plus its identity/allow-list state and
+ * branches on the verdict.
+ *
+ * Order of checks (each is load-bearing, mirroring the WhatsApp gate):
+ *  1. shape-validate + size-cap the consumed fields (zod).
+ *  2. drop own echoes: BlueBubbles emits `new-message` for the account's OWN
+ *     sends too (our replies come back `isFromMe`), so without the sent-id check
+ *     the bot would answer itself in a loop — and a self-chat reply would be
+ *     mistaken for a fresh owner prompt.
+ *  3. direct messages only (v1): a group chat GUID is dropped — group fan-in
+ *     needs its own trust story.
+ *  4. drop `isFromMe` messages outside the owner's self-chat: those are the
+ *     owner talking to OTHER people from an Apple device — never a prompt. Only
+ *     `isFromMe` in a 1:1 chat with one of the owner's own handles drives a turn.
+ *  5. allow-list by normalized handle for inbound (non-`isFromMe`) messages.
+ *     Unauthorized senders are dropped SILENTLY — replying would leak the bot's
+ *     existence.
+ */
+
+export type GateVerdict =
+  | { readonly ok: false; readonly reason: string }
+  | { readonly ok: true; readonly chatGuid: string; readonly text: string };
+
+export interface GateState {
+  /** The owner's own normalized handle(s) — the self-chat identities. */
+  readonly ownerHandles: ReadonlySet<string>;
+  /** Normalized handles of OTHER people allowed to drive the session. */
+  readonly allowedHandles: ReadonlySet<string>;
+  /** True for a guid/tempGuid of THIS channel's own recent send (echo/loop protection). */
+  readonly isOwnSend: (id: string) => boolean;
+}
+
+export function gateInboundMessage(state: GateState, raw: unknown): GateVerdict {
+  const parsed = messageSchema.safeParse(raw);
+  if (!parsed.success) return drop('invalid message shape');
+  const message = parsed.data;
+
+  const chats = message.chats;
+  const firstChat = chats && chats.length > 0 ? chats[0] : undefined;
+  if (!firstChat) return drop('message without a chat');
+  const chatGuid = firstChat.guid;
+
+  // Own-echo drop FIRST — a reply we sent into a self-chat comes back isFromMe
+  // and would otherwise re-enter as an owner prompt (loop).
+  if (state.isOwnSend(message.guid)) return drop('own outbound echo (guid)');
+  const tempGuid = message.tempGuid;
+  if (tempGuid && state.isOwnSend(tempGuid)) return drop('own outbound echo (tempGuid)');
+
+  const dm = parseDmChatGuid(chatGuid);
+  if (!dm) return drop('not a 1:1 direct message');
+
+  if (message.isFromMe === true) {
+    // Same-account messages: only the owner's own self-chat is a prompt surface.
+    if (!state.ownerHandles.has(dm.handle)) {
+      return drop('own message in a foreign chat');
+    }
+  } else {
+    const senderHandle = resolveSender(message.handle, dm.handle);
+    if (!state.allowedHandles.has(senderHandle)) {
+      return drop('sender not allow-listed');
+    }
+  }
+
+  const text = typeof message.text === 'string' ? message.text.trim() : '';
+  if (text.length === 0) return drop('no message text');
+
+  return { ok: true, chatGuid, text };
+}
+
+/**
+ * The sender's handle for an inbound message: the message's own `handle`
+ * address when present, else the 1:1 chat's counterpart (they are the same
+ * party in a DM). Narrowed once, then plain access — no optional-chain depth.
+ */
+function resolveSender(
+  handle: { readonly address?: string | null } | null | undefined,
+  chatHandle: string,
+): string {
+  if (handle && typeof handle.address === 'string' && handle.address.length > 0) {
+    return normalizeHandle(handle.address);
+  }
+  return chatHandle;
+}
+
+function drop(reason: string): GateVerdict {
+  return { ok: false, reason };
+}

--- a/packages/plugin-channel-imessage/src/permission.ts
+++ b/packages/plugin-channel-imessage/src/permission.ts
@@ -1,0 +1,40 @@
+import { createAuditedAllowListResolver } from '@moxxy/channel-kit';
+import type { PermissionResolver } from '@moxxy/sdk';
+
+export interface ImessagePermissionLogger {
+  info?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+/**
+ * Build the iMessage channel's autonomous permission resolver.
+ *
+ * Like Signal and Slack (and unlike Telegram's inline-keyboard prompts), the
+ * iMessage channel runs hands-off: the operator declares trust upfront via
+ * `channels.imessage.allowedTools`, and any tool NOT in that list is denied.
+ * The trust check + `'*'` expansion + audit-on-auto-approve wiring is the shared
+ * {@link createAuditedAllowListResolver} from `@moxxy/channel-kit`; this wrapper
+ * binds it to the channel logger so every auto-approved call leaves a trail. An
+ * empty list denies everything (effectively read-only).
+ *
+ * Because this resolver decides synchronously (no deferred operator prompt), it
+ * has no pending-prompt state, so `stop()` has nothing to `abortAll` — aborting
+ * the in-flight turn is enough.
+ */
+export function buildImessagePermissionResolver(opts: {
+  allowedTools: ReadonlyArray<string>;
+  allToolNames: ReadonlyArray<string>;
+  logger?: ImessagePermissionLogger;
+}): PermissionResolver {
+  return createAuditedAllowListResolver({
+    name: 'imessage-allow-list',
+    allowedTools: opts.allowedTools,
+    allToolNames: opts.allToolNames,
+    onAutoApprove: (call, { wildcard }) => {
+      opts.logger?.info?.('imessage: auto-approved tool call', {
+        tool: call.name,
+        callId: call.callId,
+        wildcard,
+      });
+    },
+  });
+}

--- a/packages/plugin-channel-imessage/src/schema.test.ts
+++ b/packages/plugin-channel-imessage/src/schema.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_INBOUND_TEXT_CHARS, messageSchema } from './schema.js';
+
+describe('messageSchema', () => {
+  it('accepts a well-formed new-message payload', () => {
+    const parsed = messageSchema.safeParse({
+      guid: 'msg-1',
+      tempGuid: 'temp-abc',
+      text: 'hello',
+      isFromMe: false,
+      handle: { address: '+15551234567' },
+      chats: [{ guid: 'iMessage;-;+15551234567' }],
+      dateCreated: 1_700_000_000_000,
+      // an un-modeled extra passes through untouched
+      subject: null,
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.guid).toBe('msg-1');
+      expect(parsed.data.text).toBe('hello');
+    }
+  });
+
+  it('rejects a payload with no guid', () => {
+    expect(messageSchema.safeParse({ text: 'hi', chats: [] }).success).toBe(false);
+  });
+
+  it('rejects non-object payloads', () => {
+    expect(messageSchema.safeParse(null).success).toBe(false);
+    expect(messageSchema.safeParse('garbage').success).toBe(false);
+    expect(messageSchema.safeParse(42).success).toBe(false);
+  });
+
+  it('rejects a numeric text (wrong type)', () => {
+    expect(messageSchema.safeParse({ guid: 'm', text: 42 }).success).toBe(false);
+  });
+
+  it('rejects oversized text', () => {
+    const parsed = messageSchema.safeParse({
+      guid: 'm',
+      text: 'a'.repeat(MAX_INBOUND_TEXT_CHARS + 1),
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects a chat entry without a guid', () => {
+    expect(messageSchema.safeParse({ guid: 'm', chats: [{ chatIdentifier: 'x' }] }).success).toBe(
+      false,
+    );
+  });
+});

--- a/packages/plugin-channel-imessage/src/schema.ts
+++ b/packages/plugin-channel-imessage/src/schema.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+/**
+ * Zod validation for the BlueBubbles socket.io `new-message` payload — a
+ * serialized Message object. Every inbound message is validated + size-capped
+ * BEFORE any field reaches the session (channel invariant A8). Only the fields
+ * the channel consumes are typed; unknown extras pass through untouched so a
+ * newer BlueBubbles server doesn't fail validation, but nothing un-modeled is
+ * ever read.
+ */
+
+/** Cap on inbound prompt text we will forward to the model. */
+export const MAX_INBOUND_TEXT_CHARS = 16_000;
+
+/** A single participant handle on a chat / message (`{ address, ... }`). */
+export const handleSchema = z
+  .object({
+    address: z.string().min(1).max(256).nullable().optional(),
+  })
+  .passthrough();
+
+/** A chat the message belongs to. `guid` is `SERVICE;TYPE;IDENTIFIER`. */
+export const chatSchema = z
+  .object({
+    guid: z.string().min(1).max(256),
+  })
+  .passthrough();
+
+/**
+ * The serialized Message. `guid` is the stable per-message id (used for the
+ * anti-echo drop); `tempGuid` echoes back the value the sender chose for an
+ * apple-script send, so our own replies can be recognised even before their
+ * permanent guid is known.
+ */
+export const messageSchema = z
+  .object({
+    guid: z.string().min(1).max(256),
+    tempGuid: z.string().min(1).max(256).nullable().optional(),
+    text: z.string().max(MAX_INBOUND_TEXT_CHARS).nullable().optional(),
+    isFromMe: z.boolean().nullable().optional(),
+    handle: handleSchema.nullable().optional(),
+    chats: z.array(chatSchema).max(16).optional(),
+    dateCreated: z.number().nullable().optional(),
+  })
+  .passthrough();
+
+export type ImessageMessage = z.infer<typeof messageSchema>;

--- a/packages/plugin-channel-imessage/src/setup-wizard.ts
+++ b/packages/plugin-channel-imessage/src/setup-wizard.ts
@@ -1,0 +1,155 @@
+import { cancel, intro, isCancel, log, note, outro, password, text } from '@clack/prompts';
+import type { ChannelSubcommandContext } from '@moxxy/sdk';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import {
+  IMESSAGE_ALLOWED_HANDLES_KEY,
+  IMESSAGE_OWNER_HANDLES_KEY,
+  IMESSAGE_SERVER_PASSWORD_KEY,
+  IMESSAGE_SERVER_URL_KEY,
+  isHandle,
+  normalizeHandle,
+  parseHandleList,
+} from './keys.js';
+import { BlueBubblesClient } from './bluebubbles-client.js';
+
+const ANSI = process.stdout.isTTY && !process.env.NO_COLOR;
+const bold = (s: string): string => (ANSI ? `\x1b[1m${s}\x1b[22m` : s);
+const dim = (s: string): string => (ANSI ? `\x1b[2m${s}\x1b[22m` : s);
+
+/**
+ * Interactive iMessage (BlueBubbles) setup wizard (the channel's
+ * `interactiveCommand`).
+ *
+ * Walks the operator through:
+ *   1. the BlueBubbles server URL + password (stored in the vault),
+ *   2. a best-effort reachability check against that server,
+ *   3. the handle allow-list — who besides yourself may talk to the agent,
+ *   4. your own handle(s), so texting your own "self-chat" reaches moxxy,
+ *   5. the autonomous tool allow-list,
+ * then starts the channel.
+ */
+export async function runImessageWizard(ctx: ChannelSubcommandContext): Promise<number> {
+  const vault = ctx.deps.vault as VaultStore;
+  intro(bold('moxxy imessage setup'));
+
+  note(
+    'moxxy talks to iMessage through a BlueBubbles server running on THIS Mac.\n' +
+      'Install it from https://bluebubbles.app, sign in to Messages, and set a\n' +
+      'server password. This channel uses the stock apple-script send method — no\n' +
+      'SIP changes or Private API needed. v1 handles 1:1 text chats only.',
+    'how the iMessage channel works',
+  );
+
+  const existingUrl = await vault.get(IMESSAGE_SERVER_URL_KEY);
+  const serverUrl = await text({
+    message: 'BlueBubbles server URL',
+    placeholder: 'http://localhost:1234',
+    initialValue: existingUrl ?? 'http://localhost:1234',
+    validate: (v) => {
+      if (!v || !v.trim()) return 'required';
+      try {
+        // eslint-disable-next-line no-new
+        new URL(v.trim());
+        return undefined;
+      } catch {
+        return 'expected a URL, e.g. http://localhost:1234';
+      }
+    },
+  });
+  if (isCancel(serverUrl)) {
+    cancel('cancelled.');
+    return 0;
+  }
+  const url = String(serverUrl).trim();
+
+  const serverPassword = await password({
+    message: 'BlueBubbles server password',
+    validate: (v) => (v && v.length > 0 ? undefined : 'required'),
+  });
+  if (isCancel(serverPassword)) {
+    cancel('cancelled.');
+    return 0;
+  }
+  const pass = String(serverPassword);
+
+  await vault.set(IMESSAGE_SERVER_URL_KEY, url, ['imessage']);
+  await vault.set(IMESSAGE_SERVER_PASSWORD_KEY, pass, ['imessage']);
+  log.success('Stored the BlueBubbles server URL + password in the vault.');
+
+  // Best-effort reachability probe — the ping only uses fetch, no socket.
+  try {
+    await new BlueBubblesClient({ serverUrl: url, password: pass }).ping();
+    log.success('Reached the BlueBubbles server.');
+  } catch (err) {
+    log.warn(
+      `Could not reach the server yet: ${err instanceof Error ? err.message : String(err)}\n` +
+        'You can still finish setup — the channel will retry when it starts.',
+    );
+  }
+
+  const allowAnswer = await text({
+    message: 'Handles allowed to talk to moxxy (comma-separated E.164 numbers / Apple-ID emails)',
+    placeholder: '+15551234567, friend@icloud.com',
+    initialValue: parseHandleList(await vault.get(IMESSAGE_ALLOWED_HANDLES_KEY)).join(', '),
+  });
+  if (isCancel(allowAnswer)) {
+    cancel('cancelled.');
+    return 0;
+  }
+  const allowed = parseHandleInput(String(allowAnswer));
+  await vault.set(IMESSAGE_ALLOWED_HANDLES_KEY, JSON.stringify(allowed), ['imessage']);
+  log.success(
+    allowed.length > 0
+      ? `Allow-list saved (${allowed.length} handle(s)).`
+      : 'Allow-list cleared (no external senders allowed).',
+  );
+
+  note(
+    'To talk to moxxy from your OWN Apple devices (texting your "self-chat"),\n' +
+      'add your own iMessage handle(s) below. Leave blank to keep self-chat off —\n' +
+      "your outbound messages to other people are never treated as prompts.",
+    'your own handles (self-chat)',
+  );
+  const ownerAnswer = await text({
+    message: 'Your own handle(s) (comma-separated; blank to skip)',
+    placeholder: '+15559876543, you@icloud.com',
+    initialValue: parseHandleList(await vault.get(IMESSAGE_OWNER_HANDLES_KEY)).join(', '),
+  });
+  if (isCancel(ownerAnswer)) {
+    cancel('cancelled.');
+    return 0;
+  }
+  const owner = parseHandleInput(String(ownerAnswer));
+  await vault.set(IMESSAGE_OWNER_HANDLES_KEY, JSON.stringify(owner), ['imessage']);
+  log.success(
+    owner.length > 0 ? `Self-chat enabled for ${owner.length} handle(s).` : 'Self-chat left off.',
+  );
+
+  const allowToolsAnswer = await text({
+    message: 'Autonomous tool allow-list (comma-separated; "*" = all, blank = read-only)',
+    placeholder: 'Read, Grep, Glob',
+  });
+  if (isCancel(allowToolsAnswer)) {
+    cancel('cancelled.');
+    return 0;
+  }
+  const allowedTools = String(allowToolsAnswer)
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  log.info('Starting the channel. Press Ctrl+C to stop.');
+  outro(dim('handing off to the channel…'));
+  return ctx.startChannel({ allowedTools });
+}
+
+/** Split comma/whitespace-separated handle input, normalize, drop non-handles. */
+function parseHandleInput(raw: string): string[] {
+  const out = new Set<string>();
+  for (const token of raw.split(/[,\s]+/)) {
+    if (!token) continue;
+    const handle = normalizeHandle(token);
+    if (isHandle(handle)) out.add(handle);
+  }
+  return [...out];
+}

--- a/packages/plugin-channel-imessage/src/subcommands.test.ts
+++ b/packages/plugin-channel-imessage/src/subcommands.test.ts
@@ -1,0 +1,194 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VaultStore, createStaticKeySource, deriveKey, generateSalt } from '@moxxy/plugin-vault';
+import type { ChannelDef } from '@moxxy/sdk';
+import { buildImessagePlugin } from './index.js';
+import {
+  IMESSAGE_ALLOWED_HANDLES_KEY,
+  IMESSAGE_OWNER_HANDLES_KEY,
+  IMESSAGE_SERVER_PASSWORD_KEY,
+  IMESSAGE_SERVER_URL_KEY,
+} from './keys.js';
+
+let tmp: string;
+let vault: VaultStore;
+let def: ChannelDef;
+let writeOut: string[];
+let writeErr: string[];
+let origStdoutWrite: typeof process.stdout.write;
+let origStderrWrite: typeof process.stderr.write;
+const origPlatform = process.platform;
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-imsg-sub-'));
+  vault = new VaultStore({
+    filePath: path.join(tmp, 'vault.json'),
+    keySource: createStaticKeySource(deriveKey('test', generateSalt())),
+  });
+  const plugin = buildImessagePlugin({ vault });
+  const channels = plugin.channels ?? [];
+  def = channels[0] as ChannelDef;
+  writeOut = [];
+  writeErr = [];
+  origStdoutWrite = process.stdout.write.bind(process.stdout);
+  origStderrWrite = process.stderr.write.bind(process.stderr);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    writeOut.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    writeErr.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+    return true;
+  }) as typeof process.stderr.write;
+  vi.stubEnv('MOXXY_IMESSAGE_SERVER_URL', '');
+  vi.stubEnv('MOXXY_IMESSAGE_SERVER_PASSWORD', '');
+});
+
+afterEach(async () => {
+  process.stdout.write = origStdoutWrite;
+  process.stderr.write = origStderrWrite;
+  setPlatform(origPlatform);
+  vi.unstubAllEnvs();
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+function ctx(overrides: { startChannel?: () => Promise<number> } = {}) {
+  return {
+    deps: { cwd: tmp, vault, logger: undefined, options: {} },
+    args: { positional: [], flags: {} },
+    startChannel: overrides.startChannel ?? (async () => 0),
+    session: { setPermissionResolver: () => {} },
+  } as never;
+}
+
+describe('imessage ChannelDef shape', () => {
+  it('declares a dedicated runner with the imessage session source', () => {
+    expect(def.name).toBe('imessage');
+    expect(def.dedicatedRunner).toBe(true);
+    expect(def.sessionSource).toBe('imessage');
+    expect(def.interactiveCommand).toBe('setup');
+    expect(Object.keys(def.subcommands ?? {})).toEqual(
+      expect.arrayContaining(['setup', 'status', 'unpair']),
+    );
+    expect(Object.keys(def.subcommands ?? {})).not.toContain('pair');
+    expect(def.config?.fields.map((f) => f.vaultKey)).toEqual([
+      IMESSAGE_SERVER_URL_KEY,
+      IMESSAGE_SERVER_PASSWORD_KEY,
+    ]);
+    expect(def.config?.connect?.kind).toBe('instructions');
+    expect(def.config?.hasRequestUrl).toBeFalsy();
+    // The password field is the only secret; the URL is plain text.
+    const password = def.config?.fields.find((f) => f.vaultKey === IMESSAGE_SERVER_PASSWORD_KEY);
+    expect(password?.secret).toBe(true);
+  });
+});
+
+describe('isAvailable', () => {
+  it('is unavailable off macOS (never throws)', async () => {
+    setPlatform('linux');
+    const availability = await def.isAvailable?.({ cwd: tmp, vault });
+    expect(availability?.ok).toBe(false);
+    expect(availability?.reason).toMatch(/macOS/);
+  });
+
+  it('asks for configuration on macOS when nothing is stored', async () => {
+    setPlatform('darwin');
+    const availability = await def.isAvailable?.({ cwd: tmp, vault });
+    expect(availability?.ok).toBe(false);
+    expect(availability?.reason).toMatch(/imessage setup/);
+  });
+
+  it('is available on macOS with the env pair set', async () => {
+    setPlatform('darwin');
+    vi.stubEnv('MOXXY_IMESSAGE_SERVER_URL', 'http://localhost:1234');
+    vi.stubEnv('MOXXY_IMESSAGE_SERVER_PASSWORD', 'secret');
+    const availability = await def.isAvailable?.({ cwd: tmp, vault });
+    expect(availability).toEqual({ ok: true });
+  });
+
+  it('is available on macOS with the vault pair set', async () => {
+    setPlatform('darwin');
+    await vault.set(IMESSAGE_SERVER_URL_KEY, 'http://localhost:1234');
+    await vault.set(IMESSAGE_SERVER_PASSWORD_KEY, 'secret');
+    const availability = await def.isAvailable?.({ cwd: tmp, vault });
+    expect(availability).toEqual({ ok: true });
+  });
+});
+
+describe('imessage channel subcommands', () => {
+  it('`status` reports unconfigured state as JSON', async () => {
+    const code = await def.subcommands?.status?.run(ctx());
+    expect(code).toBe(0);
+    const parsed = JSON.parse(writeOut.join(''));
+    expect(parsed.serverUrl).toBeNull();
+    expect(parsed.passwordSet).toBe(false);
+    expect(parsed.allowedHandles).toEqual([]);
+    expect(parsed.ownerHandles).toEqual([]);
+    expect(parsed.supported).toBe(process.platform === 'darwin');
+  });
+
+  it('`status` surfaces the stored server + allow-list (never the password)', async () => {
+    await vault.set(IMESSAGE_SERVER_URL_KEY, 'http://localhost:1234');
+    await vault.set(IMESSAGE_SERVER_PASSWORD_KEY, 'super-secret');
+    await vault.set(IMESSAGE_ALLOWED_HANDLES_KEY, JSON.stringify(['+14440002222']));
+    await vault.set(IMESSAGE_OWNER_HANDLES_KEY, JSON.stringify(['+19998887777']));
+    const code = await def.subcommands?.status?.run(ctx());
+    expect(code).toBe(0);
+    const out = writeOut.join('');
+    expect(out).not.toContain('super-secret');
+    const parsed = JSON.parse(out);
+    expect(parsed.serverUrl).toBe('http://localhost:1234');
+    expect(parsed.passwordSet).toBe(true);
+    expect(parsed.allowedHandles).toEqual(['+14440002222']);
+    expect(parsed.ownerHandles).toEqual(['+19998887777']);
+  });
+
+  it('`unpair` clears server config + handle lists', async () => {
+    await vault.set(IMESSAGE_SERVER_URL_KEY, 'http://localhost:1234');
+    await vault.set(IMESSAGE_SERVER_PASSWORD_KEY, 'secret');
+    await vault.set(IMESSAGE_ALLOWED_HANDLES_KEY, JSON.stringify(['+14440002222']));
+    const code = await def.subcommands?.unpair?.run(ctx());
+    expect(code).toBe(0);
+    expect(writeOut.join('')).toContain('unpaired');
+    expect(await vault.get(IMESSAGE_SERVER_URL_KEY)).toBeNull();
+    expect(await vault.get(IMESSAGE_SERVER_PASSWORD_KEY)).toBeNull();
+    expect(await vault.get(IMESSAGE_ALLOWED_HANDLES_KEY)).toBeNull();
+  });
+
+  it('`unpair` is a no-op when nothing is configured', async () => {
+    const code = await def.subcommands?.unpair?.run(ctx());
+    expect(code).toBe(0);
+    expect(writeOut.join('')).toContain('no BlueBubbles server was configured');
+  });
+
+  it('`setup` starts the channel directly when headless', async () => {
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    try {
+      const startChannel = vi.fn(async () => 0);
+      const code = await def.subcommands?.setup?.run(ctx({ startChannel }));
+      expect(code).toBe(0);
+      expect(startChannel).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+    }
+  });
+
+  it('subcommands return 1 when the vault is unavailable', async () => {
+    const badCtx = {
+      deps: { cwd: tmp, vault: undefined, logger: undefined, options: {} },
+      args: { positional: [], flags: {} },
+      startChannel: async () => 0,
+      session: { setPermissionResolver: () => {} },
+    } as never;
+    const code = await def.subcommands?.status?.run(badCtx);
+    expect(code).toBe(1);
+    expect(writeErr.join('')).toContain('vault unavailable');
+  });
+});

--- a/packages/plugin-channel-imessage/tsconfig.json
+++ b/packages/plugin-channel-imessage/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/plugin-channel-imessage/vitest.config.ts
+++ b/packages/plugin-channel-imessage/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/packages/plugin-plugins-admin/src/catalog.ts
+++ b/packages/plugin-plugins-admin/src/catalog.ts
@@ -265,6 +265,15 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
     provides: [{ category: 'channel', name: 'discord' }],
   },
   {
+    id: 'imessage',
+    label: 'iMessage channel',
+    description:
+      'iMessage via a BlueBubbles server on a dedicated runner (macOS only; moxxy imessage).',
+    packageName: '@moxxy/plugin-channel-imessage',
+    installSpec: '@moxxy/plugin-channel-imessage',
+    provides: [{ category: 'channel', name: 'imessage' }],
+  },
+  {
     id: 'stt-whisper',
     label: 'Whisper voice input',
     description: 'Speech-to-text via the OpenAI Whisper API (Ctrl+R in the TUI).',

--- a/packages/sdk/src/event-store.ts
+++ b/packages/sdk/src/event-store.ts
@@ -25,6 +25,7 @@ export const SESSION_SOURCES = [
   'signal',
   'whatsapp',
   'discord',
+  'imessage',
 ] as const;
 
 /** Originating channel of a session (persisted into the meta sidecar). */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1429,6 +1429,46 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
 
+  packages/plugin-channel-imessage:
+    dependencies:
+      '@clack/prompts':
+        specifier: 'catalog:'
+        version: 1.4.0
+      '@moxxy/channel-kit':
+        specifier: workspace:*
+        version: link:../channel-kit
+      '@moxxy/core':
+        specifier: workspace:*
+        version: link:../core
+      '@moxxy/plugin-vault':
+        specifier: workspace:*
+        version: link:../plugin-vault
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      socket.io-client:
+        specifier: ^4.8.1
+        version: 4.8.3
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
+    devDependencies:
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
   packages/plugin-channel-mobile:
     dependencies:
       '@moxxy/core':
@@ -1811,7 +1851,7 @@ importers:
         version: link:../sdk
       openai:
         specifier: ^4.80.0
-        version: 4.104.0(encoding@0.1.13)(ws@8.20.0)(zod@3.25.76)
+        version: 4.104.0(encoding@0.1.13)(ws@8.21.0)(zod@3.25.76)
     devDependencies:
       '@moxxy/tsconfig':
         specifier: workspace:*
@@ -1979,7 +2019,7 @@ importers:
         version: link:../sdk
       openai:
         specifier: ^4.80.0
-        version: 4.104.0(encoding@0.1.13)(ws@8.20.0)(zod@3.25.76)
+        version: 4.104.0(encoding@0.1.13)(ws@8.21.0)(zod@3.25.76)
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -2128,7 +2168,7 @@ importers:
         version: link:../sdk
       openai:
         specifier: ^4.80.0
-        version: 4.104.0(encoding@0.1.13)(ws@8.20.0)(zod@3.25.76)
+        version: 4.104.0(encoding@0.1.13)(ws@8.21.0)(zod@3.25.76)
     devDependencies:
       '@moxxy/tsconfig':
         specifier: workspace:*
@@ -2349,7 +2389,7 @@ importers:
         version: link:../sdk
       openai:
         specifier: ^4.80.0
-        version: 4.104.0(encoding@0.1.13)(ws@8.20.0)(zod@3.25.76)
+        version: 4.104.0(encoding@0.1.13)(ws@8.21.0)(zod@3.25.76)
     devDependencies:
       '@moxxy/tsconfig':
         specifier: workspace:*
@@ -5734,6 +5774,9 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
@@ -7379,6 +7422,13 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  engine.io-client@6.6.6:
+    resolution: {integrity: sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
 
   enhanced-resolve@5.21.3:
     resolution: {integrity: sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==}
@@ -10833,6 +10883,14 @@ packages:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io-parser@4.2.6:
+    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+    engines: {node: '>=10.0.0'}
+
   socks-proxy-agent@7.0.0:
     resolution: {integrity: sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==}
     engines: {node: '>= 10'}
@@ -11922,6 +11980,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xcode@3.0.1:
     resolution: {integrity: sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==}
     engines: {node: '>=10.0.0'}
@@ -11944,6 +12014,10 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -15118,6 +15192,8 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@socket.io/component-emitter@3.1.2': {}
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -17276,6 +17352,20 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  engine.io-client@6.6.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.21.0
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  engine.io-parser@5.2.3: {}
 
   enhanced-resolve@5.21.3:
     dependencies:
@@ -20651,7 +20741,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.104.0(encoding@0.1.13)(ws@8.20.0)(zod@3.25.76):
+  openai@4.104.0(encoding@0.1.13)(ws@8.21.0)(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -20661,7 +20751,7 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:
-      ws: 8.20.0
+      ws: 8.21.0
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
@@ -21987,6 +22077,24 @@ snapshots:
 
   smol-toml@1.6.1: {}
 
+  socket.io-client@4.8.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-client: 6.6.6
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
@@ -23051,6 +23159,8 @@ snapshots:
 
   ws@8.20.0: {}
 
+  ws@8.21.0: {}
+
   xcode@3.0.1:
     dependencies:
       simple-plist: 1.3.1
@@ -23068,6 +23178,8 @@ snapshots:
   xmlbuilder@15.1.1: {}
 
   xmlchars@2.2.0: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   xxhash-wasm@1.1.0: {}
 


### PR DESCRIPTION
## What

Adds `@moxxy/plugin-channel-imessage` — a macOS-only iMessage channel backed by a localhost [BlueBubbles](https://bluebubbles.app) server. Built as a near-clone of the Signal channel, swapping the signal-cli sidecar for a BlueBubbles socket.io + REST client.

## Why

iMessage is the last major messenger moxxy couldn't reach on a Mac. BlueBubbles exposes a stable localhost API (socket.io `new-message` feed + `POST /api/v1/message/text`) with no ToS-violation / ban risk — the stock apple-script send method needs no SIP changes or Private API. This lets allow-listed contacts (and your own self-chat) drive the agent from iMessage, on its own dedicated isolated runner.

## v1 scope

- **Send:** `POST /api/v1/message/text` with `method: 'apple-script'`, a fresh `tempGuid` per send (password as a query param, per the BlueBubbles auth model).
- **Receive:** BlueBubbles socket.io `new-message` events (built-in reconnection; `socket.io-client` v4, lazily imported).
- **Trust:** vault-stored server URL + password + a JSON handle allow-list (E.164 numbers / Apple-ID emails). 1:1 DMs only. Unknown senders dropped silently.
- **Anti-echo:** bounded sent-`guid`/`tempGuid` set + `isFromMe`-in-foreign-chat drop + allow-list gate, in the WhatsApp gate ordering. Every session-reaching path goes through one pure gate.
- **Self-chat:** the owner's own handle(s) live in a separate `imessage_owner_handles` vault key (mirrors how Signal's allow-list sits outside `config.fields`). Only `isFromMe` in a 1:1 chat with an owner handle drives a turn; empty = fail-closed (self-chat off). This is what keeps "owner texts an allow-listed friend" from being mistaken for a prompt.
- **Replies:** immutable chunked sends (Signal's `ChunkedSender`, copied in — no FramePump; apple-script messages are immutable).
- **Runner:** dedicated runner, `sessionSource: 'imessage'`.
- **`isAvailable`:** pure (platform + config presence, no network); the reachability ping is deferred to `start()` with a friendly error.
- **Permission:** autonomous audited allow-list resolver (like Signal/Slack) — synchronous, so `stop()` only aborts the in-flight turn.
- **Subcommands:** `setup` (interactive @clack wizard; bails to `ctx.startChannel()` when not a TTY), `status`, `unpair`.

### Wiring outside the package

- `packages/sdk/src/event-store.ts` — `'imessage'` added to `SESSION_SOURCES`.
- `packages/plugin-plugins-admin/src/catalog.ts` — install-catalog entry with `provides: [{category:'channel', name:'imessage'}]`.
- `packages/desktop-host/src/channel-catalog.ts` — hand-list entry (+ the drift-guard test's `PLUGIN_LOADERS` map, required so the guard covers the new channel).
- `packages/cli/src/channel-hints.test.ts` — `imessage` moved from the "unknown" example to the known-channels list (it now resolves an install hint).
- `packages/cli/src/setup/builtin-requirements.generated.ts` — regenerated by the cli build.
- `moxxy.setup` block in the package `package.json`.
- Changeset bumps `@moxxy/plugin-channel-imessage`, `@moxxy/sdk`, `@moxxy/cli`, `@moxxy/plugin-plugins-admin`, `@moxxy/desktop-host` (all minor).

## Deferred (not built, no TODOs left)

BlueBubbles Private API send method; attachments / voice-note transcription; group chats; TOFU auto-pairing window; non-localhost / tunneled servers.

## Tests

New package: 66 unit tests across 6 files (keys parsing + fail-closed allow-list + handle/chat-GUID normalization; message-gate decisions incl. own-echo, `isFromMe` foreign chat, allow-list, self-chat, group drop; chunker behavior; zod schema rejection of malformed payloads; and the `start()` flow end-to-end against a mocked BlueBubbles client + fake session). No network in tests.

Gate: `pnpm install / build / typecheck / lint / check:deps` all exit 0. `pnpm test` is green except the known pre-existing `workflows.test.ts` "fileChanged … concurrent runners" flake under parallel load, which passes 29/29 when re-run in isolation.