### PR TITLE
refactor(providers): replace non-null assertions and deep optional chains with guards

### DIFF
--- a/.changeset/assert-sweep-providers.md
+++ b/.changeset/assert-sweep-providers.md
@@ -1,0 +1,20 @@
+---
+'@moxxy/plugin-provider-anthropic': patch
+'@moxxy/plugin-provider-claude-code': patch
+'@moxxy/plugin-provider-openai': patch
+'@moxxy/plugin-provider-openai-codex': patch
+'@moxxy/plugin-provider-xai': patch
+'@moxxy/plugin-embeddings-openai': patch
+'@moxxy/plugin-embeddings-transformers': patch
+'@moxxy/plugin-memory': patch
+'@moxxy/plugin-mcp': patch
+'@moxxy/plugin-browser': patch
+'@moxxy/plugin-view': patch
+'@moxxy/plugin-terminal': patch
+'@moxxy/plugin-collab': patch
+'@moxxy/plugin-stt-whisper': patch
+'@moxxy/plugin-stt-whisper-codex': patch
+'@moxxy/plugin-voice-admin': patch
+---
+
+Replace non-null assertions and depth-≥2 optional chains with explicit guards (`invariant`/`assertDefined` from `@moxxy/sdk`) across the provider, embeddings, memory, mcp, browser, view, terminal, collab, stt, and voice-admin plugins. Behavior-preserving: normal-absence paths (streaming heartbeats, optional hooks, best-effort cleanup) keep their silent skips; only impossible-by-construction absences now fail loudly at the assumption site.

--- a/packages/plugin-browser/src/browser-session.test.ts
+++ b/packages/plugin-browser/src/browser-session.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PassThrough } from 'node:stream';
-import { asSessionId, asToolCallId, asTurnId } from '@moxxy/sdk';
+import { asSessionId, asToolCallId, asTurnId, assertDefined } from '@moxxy/sdk';
 import type { ToolContext } from '@moxxy/sdk';
 import {
   browserSidecarCall,
@@ -98,7 +98,9 @@ describe('browser_session tool (sidecar protocol)', () => {
     );
     expect(out).toEqual({ url: 'https://example.com' });
     expect(receivedRequests).toHaveLength(1);
-    expect(receivedRequests[0]!.method).toBe('goto');
+    const first = receivedRequests[0];
+    assertDefined(first, 'receivedRequests has length 1');
+    expect(first.method).toBe('goto');
 
     await closeBrowserSidecar();
   });
@@ -130,7 +132,9 @@ describe('browser_session tool (sidecar protocol)', () => {
       baseCtx(),
     );
     expect(out).toBe(42);
-    expect((receivedRequests[0]!.params as { expression: string }).expression).toBe('1 + 41');
+    const first = receivedRequests[0];
+    assertDefined(first, 'sidecar received the eval request');
+    expect((first.params as { expression: string }).expression).toBe('1 + 41');
     await closeBrowserSidecar();
   });
 });

--- a/packages/plugin-browser/src/browser-session.ts
+++ b/packages/plugin-browser/src/browser-session.ts
@@ -2,7 +2,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { MoxxyError, defineTool, z } from '@moxxy/sdk';
+import { MoxxyError, assertDefined, defineTool, z } from '@moxxy/sdk';
 import { assertPublicUrl, SsrfBlockedError } from './ssrf-guard.js';
 
 /**
@@ -188,7 +188,8 @@ class Sidecar {
     // for install progress ("downloading chromium…") and other
     // human-readable status; callers wire `onStderr` to surface it.
     let stderrBuf = '';
-    this.child.stderr?.on?.('data', (chunk: string | Buffer) => {
+    const stderr = this.child.stderr;
+    if (stderr) stderr.on('data', (chunk: string | Buffer) => {
       stderrBuf += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
       let nl: number;
       while ((nl = stderrBuf.indexOf('\n')) !== -1) {
@@ -316,7 +317,9 @@ class Sidecar {
       });
       signal?.addEventListener('abort', onAbort, { once: true });
       try {
-        this.child!.stdin.write(JSON.stringify(req) + '\n');
+        const child = this.child;
+        assertDefined(child, 'sidecar child running (guarded via `if (!this.child) throw` at call() entry)');
+        child.stdin.write(JSON.stringify(req) + '\n');
       } catch (err) {
         this.pending.delete(id);
         cleanup();

--- a/packages/plugin-browser/src/html-extract.ts
+++ b/packages/plugin-browser/src/html-extract.ts
@@ -5,6 +5,8 @@
  * browser_session.
  */
 
+import { assertDefined } from '@moxxy/sdk';
+
 export interface ExtractOptions {
   selector?: string;
 }
@@ -119,7 +121,11 @@ function decodeEntities(s: string): string {
     '&nbsp;': ' ',
   };
   return s.replace(/&[a-zA-Z]+;|&#\d+;/g, (m) => {
-    if (m in map) return map[m as keyof typeof map]!;
+    if (m in map) {
+      const decoded = map[m as keyof typeof map];
+      assertDefined(decoded, `entity "${m}" is a known map key ("m in map" checked above)`);
+      return decoded;
+    }
     const numMatch = /^&#(\d+);$/.exec(m);
     if (numMatch) return String.fromCharCode(Number(numMatch[1]));
     return m;
@@ -139,12 +145,12 @@ function extractFirstTagBlock(html: string, selector: string): string | null {
       'i',
     );
     const match = re.exec(html);
-    return match ? match[2]! : null;
+    return match?.[2] ?? null;
   }
   const tag = selector.toLowerCase();
   const re = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'i');
   const match = re.exec(html);
-  return match ? match[1]! : null;
+  return match?.[1] ?? null;
 }
 
 function escapeReSelector(s: string): string {

--- a/packages/plugin-browser/src/sidecar.test.ts
+++ b/packages/plugin-browser/src/sidecar.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { enqueueLine } from './sidecar.js';
 import type { Reply } from './sidecar/types.js';
 
@@ -43,15 +44,19 @@ describe('sidecar request queue resilience', () => {
     // rejected instead of left waiting for its timeout.
     await enqueueLine(JSON.stringify({ id: 'real-id' }), out);
     expect(writes).toHaveLength(1);
-    expect(writes[0]!.id).toBe('real-id');
-    expect(writes[0]!.ok).toBe(false);
+    const write0 = writes[0];
+    assertDefined(write0, 'writes has length 1');
+    expect(write0.id).toBe('real-id');
+    expect(write0.ok).toBe(false);
   });
 
   it('falls back to "unknown" for wholly unparseable input', async () => {
     const writes: Reply[] = [];
     const out = (reply: Reply): void => void writes.push(reply);
     await enqueueLine('{not json', out);
-    expect(writes[0]!.id).toBe('unknown');
-    expect(writes[0]!.ok).toBe(false);
+    const write0 = writes[0];
+    assertDefined(write0, 'enqueueLine wrote a reply');
+    expect(write0.id).toBe('unknown');
+    expect(write0.ok).toBe(false);
   });
 });

--- a/packages/plugin-browser/src/ssrf-guard.ts
+++ b/packages/plugin-browser/src/ssrf-guard.ts
@@ -38,6 +38,18 @@ export function setSsrfDnsResolver(fn: DnsResolver | null): void {
   resolver = fn ?? defaultResolver;
 }
 
+/**
+ * Local presence guard for impossible-by-construction absences (a `String.split`
+ * first element, a matched regex's capture groups) that TS's index/capture types
+ * widen to `T | undefined`. This module deliberately imports NO non-builtin deps
+ * (see header) — the Playwright sidecar bundles it — so we cannot use
+ * `assertDefined` from `@moxxy/sdk`.
+ */
+function present<T>(value: T | undefined, why: string): T {
+  if (value === undefined) throw new Error(`ssrf-guard: unreachable — ${why}`);
+  return value;
+}
+
 function isBlockedIpv4(ip: string): boolean {
   const parts = ip.split('.').map((p) => Number(p));
   if (parts.length !== 4 || parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) return true;
@@ -54,7 +66,11 @@ function isBlockedIpv4(ip: string): boolean {
 }
 
 function isBlockedIpv6(ip: string): boolean {
-  const addr = ip.toLowerCase().replace(/^\[|\]$/g, '').split('%')[0]!; // strip zone id
+  // strip zone id
+  const addr = present(
+    ip.toLowerCase().replace(/^\[|\]$/g, '').split('%')[0],
+    'String.split always yields at least one element',
+  );
   if (addr === '::1' || addr === '::') return true; // loopback / unspecified
   if (addr.startsWith('fe80')) return true; // link-local
   if (addr.startsWith('fc') || addr.startsWith('fd')) return true; // unique-local fc00::/7
@@ -80,13 +96,13 @@ function extractEmbeddedV4(addr: string): string | null {
   // Dotted spelling: ::ffff:a.b.c.d, ::ffff:0:a.b.c.d, ::a.b.c.d, 64:ff9b::a.b.c.d
   const dotted = addr.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
   if (dotted && (addr.startsWith('::ffff:') || addr.startsWith('::') || addr.startsWith('64:ff9b:'))) {
-    return dotted[1]!;
+    return present(dotted[1], 'dotted regex matched and has a capture group');
   }
   // Hex spelling: the embedded v4 lives in the two trailing 16-bit groups.
   const hex = addr.match(/^(?:::ffff:|::ffff:0:|64:ff9b:(?::|.*:)|::)([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
   if (hex) {
-    const hi = parseInt(hex[1]!, 16);
-    const lo = parseInt(hex[2]!, 16);
+    const hi = parseInt(present(hex[1], 'hex regex matched and has capture group 1'), 16);
+    const lo = parseInt(present(hex[2], 'hex regex matched and has capture group 2'), 16);
     if (Number.isInteger(hi) && Number.isInteger(lo) && hi <= 0xffff && lo <= 0xffff) {
       return `${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`;
     }

--- a/packages/plugin-browser/src/web-fetch.test.ts
+++ b/packages/plugin-browser/src/web-fetch.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createPinnedLookup, htmlToMarkdown, htmlToPlainText, setWebFetchDnsResolver, webFetchTool } from './web-fetch.js';
-import { asSessionId, asToolCallId, asTurnId } from '@moxxy/sdk';
+import { asSessionId, asToolCallId, asTurnId, assertDefined } from '@moxxy/sdk';
 import type { ToolContext } from '@moxxy/sdk';
 
 const baseCtx = (): ToolContext => ({
@@ -264,7 +264,9 @@ describe('web_fetch DNS pinning (rebinding TOCTOU)', () => {
     // pinned answer, not a fresh (rebindable) one.
     expect(resolutions).toEqual(['example.com']);
     expect(inits).toHaveLength(1);
-    expect(inits[0]!.dispatcher).toBeDefined();
+    const init0 = inits[0];
+    assertDefined(init0, 'inits has length 1');
+    expect(init0.dispatcher).toBeDefined();
   });
 
   it('re-pins every redirect hop with that hop\'s own vetted address', async () => {
@@ -289,10 +291,14 @@ describe('web_fetch DNS pinning (rebinding TOCTOU)', () => {
     expect(out).toContain('arrived');
     expect(resolutions).toEqual(['a.example.com', 'b.example.com']);
     expect(inits).toHaveLength(2);
-    expect(inits[0]!.dispatcher).toBeDefined();
-    expect(inits[1]!.dispatcher).toBeDefined();
+    const init0 = inits[0];
+    const init1 = inits[1];
+    assertDefined(init0, 'inits has length 2');
+    assertDefined(init1, 'inits has length 2');
+    expect(init0.dispatcher).toBeDefined();
+    expect(init1.dispatcher).toBeDefined();
     // Each hop gets its OWN pinned dispatcher.
-    expect(inits[0]!.dispatcher).not.toBe(inits[1]!.dispatcher);
+    expect(init0.dispatcher).not.toBe(init1.dispatcher);
   });
 });
 

--- a/packages/plugin-browser/src/web-fetch.ts
+++ b/packages/plugin-browser/src/web-fetch.ts
@@ -1,7 +1,7 @@
 import { isIP } from 'node:net';
 import type { LookupFunction } from 'node:net';
 import { Agent } from 'undici';
-import { MoxxyError, defineTool, z } from '@moxxy/sdk';
+import { MoxxyError, assertDefined, defineTool, z } from '@moxxy/sdk';
 import { htmlToMarkdown, htmlToPlainText } from './html-extract.js';
 import {
   assertPublicUrl,
@@ -84,7 +84,11 @@ export function createPinnedLookup(addresses: ReadonlyArray<string>): LookupFunc
     }
     const all = addresses.map((address) => ({ address, family: isIP(address) }));
     if (options?.all) callback(null, all);
-    else callback(null, all[0]!.address, all[0]!.family);
+    else {
+      const first = all[0];
+      assertDefined(first, 'addresses is non-empty (length === 0 returned above)');
+      callback(null, first.address, first.family);
+    }
   };
   return lookup as unknown as LookupFunction;
 }
@@ -230,7 +234,9 @@ async function fetchFollowRedirects(
       throw err;
     }
     if (res.status >= 300 && res.status < 400 && res.headers.get('location')) {
-      const next = new URL(res.headers.get('location')!, current).toString();
+      const location = res.headers.get('location');
+      assertDefined(location, 'redirect (3xx) with a truthy Location header (checked above)');
+      const next = new URL(location, current).toString();
       current = next;
       // drain to avoid the connection leaking
       try { await res.body?.cancel(); } catch { /* ignore */ }

--- a/packages/plugin-collab/src/process-client.test.ts
+++ b/packages/plugin-collab/src/process-client.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { createCollaborationHub, type CollaborationHub } from './hub.js';
 import { COLLAB_ENV, getProcessHubClient, __resetProcessHubClient } from './process-client.js';
 import type { RosterEntry } from './hub-types.js';
+import { assertDefined } from '@moxxy/sdk';
 
 const roster: RosterEntry[] = [
   { id: 'backend', name: 'Backend', role: 'implementer', subtask: 'api' },
@@ -73,12 +74,13 @@ describe('getProcessHubClient', () => {
 
     const first = await getProcessHubClient();
     expect(first).not.toBeNull();
-    first!.close();
+    assertDefined(first, 'getProcessHubClient resolved and was asserted non-null above');
+    first.close();
     // Wait for the close to propagate through the transport before re-resolving.
-    for (let i = 0; i < 100 && !first!.isClosed; i++) {
+    for (let i = 0; i < 100 && !first.isClosed; i++) {
       await new Promise((r) => setTimeout(r, 5));
     }
-    expect(first!.isClosed).toBe(true);
+    expect(first.isClosed).toBe(true);
 
     // A dropped link must transparently re-establish on the next resolve. Retry
     // a few times to absorb the hub-side close lag (it frees the id on onClose).

--- a/packages/plugin-collab/src/state.test.ts
+++ b/packages/plugin-collab/src/state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { CollaborationState, pathsConflict } from './state.js';
 import type { CollabEvent, RosterEntry } from './hub-types.js';
+import { assertDefined } from '@moxxy/sdk';
 
 const roster: RosterEntry[] = [
   { id: 'architect', name: 'Architect', role: 'architect', subtask: 'design' },
@@ -236,7 +237,10 @@ describe('board file locks', () => {
     // Re-claim the SAME item with a different path — the old path must survive.
     const second = state.boardClaim('backend', ['src/b'], id);
     expect(second.ok).toBe(true);
-    if (second.ok) expect([...second.item.paths!].sort()).toEqual(['src/a', 'src/b']);
+    if (second.ok) {
+      assertDefined(second.item.paths, 'a successful claim always records the claimed paths');
+      expect([...second.item.paths].sort()).toEqual(['src/a', 'src/b']);
+    }
 
     // Another agent still cannot take src/a (its lock was not silently dropped).
     expect(state.boardClaim('tests', ['src/a']).ok).toBe(false);

--- a/packages/plugin-collab/src/state.ts
+++ b/packages/plugin-collab/src/state.ts
@@ -25,6 +25,7 @@ import type {
   RosterView,
 } from './hub-types.js';
 import type { BoardClaimResult } from './hub-protocol.js';
+import { assertDefined } from '@moxxy/sdk';
 
 export interface CollaborationStateOptions {
   readonly task: string;
@@ -164,7 +165,11 @@ export class CollaborationState {
 
   allDone(): boolean {
     const live = this.agentOrder
-      .map((id) => this.agents.get(id)!)
+      .map((id) => {
+        const agent = this.agents.get(id);
+        assertDefined(agent, 'agentOrder only ever holds live agent ids');
+        return agent;
+      })
       .filter((a) => a.status !== 'crashed' && a.status !== 'killed' && a.status !== 'failed');
     return live.length > 0 && live.every((a) => a.status === 'done');
   }
@@ -182,7 +187,11 @@ export class CollaborationState {
     return {
       self,
       task: this.task,
-      agents: this.agentOrder.map((id) => ({ ...this.agents.get(id)! })),
+      agents: this.agentOrder.map((id) => {
+        const agent = this.agents.get(id);
+        assertDefined(agent, 'agentOrder only ever holds live agent ids');
+        return { ...agent };
+      }),
       control: { ...this.control },
     };
   }
@@ -205,9 +214,16 @@ export class CollaborationState {
 
   doneSummaries(): ReadonlyArray<{ agentId: string; summary: string }> {
     return this.agentOrder
-      .map((id) => this.agents.get(id)!)
+      .map((id) => {
+        const agent = this.agents.get(id);
+        assertDefined(agent, 'agentOrder only ever holds live agent ids');
+        return agent;
+      })
       .filter((a) => a.status === 'done' && a.doneSummary)
-      .map((a) => ({ agentId: a.id, summary: a.doneSummary! }));
+      .map((a) => {
+        assertDefined(a.doneSummary, 'filtered to agents whose doneSummary is set');
+        return { agentId: a.id, summary: a.doneSummary };
+      });
   }
 
   // --- messaging ------------------------------------------------------------
@@ -297,7 +313,11 @@ export class CollaborationState {
   // --- task board + file locks ----------------------------------------------
 
   boardItems(): ReadonlyArray<BoardItem> {
-    return this.boardOrder.map((id) => ({ ...this.board.get(id)! }));
+    return this.boardOrder.map((id) => {
+      const item = this.board.get(id);
+      assertDefined(item, 'boardOrder only ever holds live board ids');
+      return { ...item };
+    });
   }
 
   boardAdd(by: string, title: string, detail?: string, paths?: ReadonlyArray<string>): BoardItem {
@@ -331,7 +351,8 @@ export class CollaborationState {
   /** Find the agent that already owns a path conflicting with any of `paths`. */
   private conflictingOwner(claimant: string, paths: ReadonlyArray<string>): string | null {
     for (const id of this.boardOrder) {
-      const item = this.board.get(id)!;
+      const item = this.board.get(id);
+      assertDefined(item, 'boardOrder only ever holds live board ids');
       if (!item.owner || item.owner === claimant || !item.paths) continue;
       if (item.status === 'done') continue; // released by completion
       for (const owned of item.paths) {
@@ -407,8 +428,16 @@ export class CollaborationState {
           (it): it is BoardItem => it !== undefined && it.owner === by,
         )
       : this.boardOrder
-          .map((id) => this.board.get(id)!)
-          .filter((it) => it.owner === by && it.paths && opts.paths?.some((p) => it.paths!.some((q) => pathsConflict(p, q))));
+          .map((id) => {
+            const item = this.board.get(id);
+            assertDefined(item, 'boardOrder only ever holds live board ids');
+            return item;
+          })
+          .filter((it) => {
+            if (it.owner !== by || !it.paths) return false;
+            const itPaths = it.paths;
+            return opts.paths?.some((p) => itPaths.some((q) => pathsConflict(p, q))) ?? false;
+          });
     for (const item of targets) {
       delete item.owner;
       item.updatedBy = by;
@@ -423,7 +452,8 @@ export class CollaborationState {
    *  any survivor that needs those paths. */
   private releaseAllFor(agentId: string): void {
     for (const id of this.boardOrder) {
-      const item = this.board.get(id)!;
+      const item = this.board.get(id);
+      assertDefined(item, 'boardOrder only ever holds live board ids');
       if (item.owner !== agentId) continue;
       delete item.owner;
       item.updatedBy = agentId;
@@ -435,7 +465,11 @@ export class CollaborationState {
   // --- contracts ------------------------------------------------------------
 
   contractList(): ReadonlyArray<ContractEntry> {
-    return this.contractOrder.map((id) => ({ ...this.contracts.get(id)! }));
+    return this.contractOrder.map((id) => {
+      const entry = this.contracts.get(id);
+      assertDefined(entry, 'contractOrder only ever holds live contract ids');
+      return { ...entry };
+    });
   }
 
   contractPublish(
@@ -475,7 +509,9 @@ export class CollaborationState {
       entry.pendingChange = { ...entry.pendingChange, acks: [...entry.pendingChange.acks, by] };
     }
     const required = new Set<string>([entry.owner, ...entry.consumers]);
-    const agreed = [...required].every((a) => entry.pendingChange!.acks.includes(a));
+    const pending = entry.pendingChange;
+    assertDefined(pending, 'pendingChange is guarded non-null at entry and only reassigned to a fresh object');
+    const agreed = [...required].every((a) => pending.acks.includes(a));
     return { entry: { ...entry }, agreed };
   }
 
@@ -496,8 +532,9 @@ export class CollaborationState {
     const authorized = by === entry.owner || this.roleOf(by) === 'architect';
     if (!authorized) return null;
     if (entry.pendingChange) {
+      const pending = entry.pendingChange;
       const required = new Set<string>([entry.owner, ...entry.consumers]);
-      const agreed = [...required].every((a) => entry.pendingChange!.acks.includes(a));
+      const agreed = [...required].every((a) => pending.acks.includes(a));
       if (!agreed) return null;
     }
     entry.spec = spec;

--- a/packages/plugin-embeddings-openai/src/embedder.test.ts
+++ b/packages/plugin-embeddings-openai/src/embedder.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type OpenAI from 'openai';
+import { assertDefined } from '@moxxy/sdk';
 import { OpenAIEmbedder } from './embedder.js';
 
 function fakeClient(responses: number[][][]): { embeddings: { create: ReturnType<typeof vi.fn> } } {
@@ -7,7 +8,9 @@ function fakeClient(responses: number[][][]): { embeddings: { create: ReturnType
   return {
     embeddings: {
       create: vi.fn(async () => {
-        const data = responses[call++]!.map((embedding, index) => ({ embedding, index }));
+        const response = responses[call++];
+        assertDefined(response, 'test provides a response for every create call');
+        const data = response.map((embedding, index) => ({ embedding, index }));
         return { data };
       }),
     },

--- a/packages/plugin-embeddings-transformers/src/embedder.test.ts
+++ b/packages/plugin-embeddings-transformers/src/embedder.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { TransformersEmbedder, type PipelineFactory } from './embedder.js';
 
 function stubFactory(vectors: number[][]): PipelineFactory & { calls: () => number } {
@@ -318,7 +319,9 @@ describe('TransformersEmbedder', () => {
     let receivedLen = -1;
     const factory: PipelineFactory = async () => async (input) => {
       const inputs = (Array.isArray(input) ? input : [input]) as string[];
-      receivedLen = inputs[0]!.length;
+      const firstInput = inputs[0];
+      assertDefined(firstInput, 'wrapped input array is non-empty by construction');
+      receivedLen = firstInput.length;
       return { tolist: () => inputs.map(() => [1]) };
     };
     const e = new TransformersEmbedder({ dimensions: 1, pipelineFactory: factory });

--- a/packages/plugin-mcp/src/admin/config-io.ts
+++ b/packages/plugin-mcp/src/admin/config-io.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'node:fs';
-import { createMutex } from '@moxxy/sdk';
+import { assertDefined, createMutex } from '@moxxy/sdk';
 import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { mcpStoredConfigRootSchema, mcpStoredServerSchema } from './config-schema.js';
 import type { McpStoredConfig, McpStoredServer } from './types.js';
@@ -90,7 +90,9 @@ export async function setServerDisabled(name: string, disabled: boolean): Promis
     const idx = cfg.servers.findIndex((s) => s.name === name);
     // Unknown name → same reference skips the write (mutateMcpConfig no-op).
     if (idx < 0) return { next: cfg, result: null };
-    const updated: McpStoredServer = { ...cfg.servers[idx]!, disabled };
+    const existing = cfg.servers[idx];
+    assertDefined(existing, `mcp server at index ${idx} must exist (findIndex matched name "${name}")`);
+    const updated: McpStoredServer = { ...existing, disabled };
     const nextServers = [...cfg.servers];
     nextServers[idx] = updated;
     return { next: { servers: nextServers }, result: updated };

--- a/packages/plugin-mcp/src/admin/index.ts
+++ b/packages/plugin-mcp/src/admin/index.ts
@@ -185,9 +185,10 @@ function buildMcpAdminPluginInternal(
             try {
               return await runtime.refreshServerCache(server);
             } catch (err) {
-              log?.warn?.(`mcp: failed to refresh cache for "${server.name}"`, {
-                err: err instanceof Error ? err.message : String(err),
-              });
+              if (log?.warn)
+                log.warn(`mcp: failed to refresh cache for "${server.name}"`, {
+                  err: err instanceof Error ? err.message : String(err),
+                });
               return null;
             }
           }),
@@ -200,9 +201,10 @@ function buildMcpAdminPluginInternal(
           try {
             runtime.attachServerLazy(entry);
           } catch (err) {
-            log?.warn?.(`mcp: failed to attach lazy stubs for "${entry.name}"`, {
-              err: err instanceof Error ? err.message : String(err),
-            });
+            if (log?.warn)
+              log.warn(`mcp: failed to attach lazy stubs for "${entry.name}"`, {
+                err: err instanceof Error ? err.message : String(err),
+              });
           }
         }
       },

--- a/packages/plugin-mcp/src/admin/runtime.test.ts
+++ b/packages/plugin-mcp/src/admin/runtime.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import type { McpClientLike, McpServerConfig, McpToolDescriptor } from '../types.js';
 import type { AdminToolRegistryLike, McpStoredServer } from './types.js';
 
@@ -162,7 +163,8 @@ describe('admin/runtime', () => {
       const registry = makeRegistry();
       const rt = createMcpRuntime(registry);
       rt.attachServerLazy(stored());
-      const handle = rt.runtimes.get('demo')!;
+      const handle = rt.runtimes.get('demo');
+      assertDefined(handle, "runtime 'demo' registered by attachServerLazy");
       // Closing before any tool runs must not connect or throw.
       await handle.client.close();
       expect(hoisted.connectCalls).toHaveLength(0);

--- a/packages/plugin-mcp/src/admin/runtime.ts
+++ b/packages/plugin-mcp/src/admin/runtime.ts
@@ -1,4 +1,4 @@
-import { MoxxyError } from '@moxxy/sdk';
+import { assertDefined, MoxxyError } from '@moxxy/sdk';
 import type { McpClientLike, McpServerConfig, McpToolDescriptor } from '../types.js';
 import { defaultClientFactory } from '../client.js';
 import { MCP_CONNECT_TIMEOUT_MS, withTimeout } from '../timeout.js';
@@ -115,7 +115,11 @@ export function createMcpRuntime(
    */
   const attachServerLazy: McpRuntime['attachServerLazy'] = (server) => {
     if (!registry) return { toolNames: [] };
-    if (runtimes.has(server.name)) return { toolNames: runtimes.get(server.name)!.toolNames };
+    if (runtimes.has(server.name)) {
+      const existing = runtimes.get(server.name);
+      assertDefined(existing, `runtime for "${server.name}" must exist (has() returned true)`);
+      return { toolNames: existing.toolNames };
+    }
     const descriptors = server.cachedTools ?? [];
     if (descriptors.length === 0) {
       return { toolNames: [] };

--- a/packages/plugin-mcp/src/admin/skill.test.ts
+++ b/packages/plugin-mcp/src/admin/skill.test.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { assertDefined } from '@moxxy/sdk';
 import type { Skill } from '@moxxy/sdk';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { McpServerConfig, McpToolDescriptor } from '../types.js';
@@ -22,20 +23,27 @@ function parseFrontmatter(raw: string): { fm: Record<string, unknown>; body: str
   const fm: Record<string, unknown> = {};
   const lines = fmText.split('\n');
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]!;
+    const line = lines[i];
+    assertDefined(line, 'frontmatter line present within bounds');
     if (!line.trim()) continue;
     const m = /^([A-Za-z0-9_-]+):\s*(.*)$/.exec(line);
     if (!m) throw new Error(`unparseable frontmatter line: ${JSON.stringify(line)}`);
     const [, key, val] = m;
+    assertDefined(key, 'regex capture group 1 present when the line matched');
     if (val) {
-      fm[key!] = val;
+      fm[key] = val;
     } else {
       const items: string[] = [];
-      while (i + 1 < lines.length && /^\s+-\s/.test(lines[i + 1]!)) {
+      while (i + 1 < lines.length) {
+        const next = lines[i + 1];
+        assertDefined(next, 'next frontmatter line present within bounds');
+        if (!/^\s+-\s/.test(next)) break;
         i++;
-        items.push(lines[i]!.replace(/^\s+-\s*/, '').replace(/^"(.*)"$/, '$1'));
+        const item = lines[i];
+        assertDefined(item, 'frontmatter sequence item present');
+        items.push(item.replace(/^\s+-\s*/, '').replace(/^"(.*)"$/, '$1'));
       }
-      fm[key!] = items;
+      fm[key] = items;
     }
   }
   return { fm, body };
@@ -73,10 +81,11 @@ describe('admin/skill (createMcpUsageSkillWriter)', () => {
     const write = createMcpUsageSkillWriter({ skillRegistry: registry, userSkillsDir: dir });
     const result = await write(server, DESCRIPTORS);
     expect(result).not.toBeNull();
-    expect(result!.skillName).toBe('acme-mcp');
-    expect(result!.path).toBe(join(dir, 'acme-mcp.md'));
+    assertDefined(result, 'write() returns a result for a fresh skill');
+    expect(result.skillName).toBe('acme-mcp');
+    expect(result.path).toBe(join(dir, 'acme-mcp.md'));
 
-    const raw = await readFile(result!.path, 'utf8');
+    const raw = await readFile(result.path, 'utf8');
     const { fm, body } = parseFrontmatter(raw);
     expect(fm.name).toBe('acme-mcp');
     expect(fm.description).toBe('Use the acme MCP server (2 tools).');
@@ -95,7 +104,8 @@ describe('admin/skill (createMcpUsageSkillWriter)', () => {
     const write = createMcpUsageSkillWriter({ skillRegistry: registry, userSkillsDir: dir });
     await write(server, DESCRIPTORS);
     expect(registry.registered).toHaveLength(1);
-    const skill = registry.registered[0]!;
+    const skill = registry.registered[0];
+    assertDefined(skill, 'first registered skill present');
     expect(skill.id).toBe('user/acme-mcp');
     expect(skill.scope).toBe('user');
     expect(skill.path).toBe(join(dir, 'acme-mcp.md'));
@@ -119,7 +129,8 @@ describe('admin/skill (createMcpUsageSkillWriter)', () => {
     const write = createMcpUsageSkillWriter({ skillRegistry: null, userSkillsDir: dir });
     const result = await write(server, DESCRIPTORS);
     expect(result).not.toBeNull();
-    const raw = await readFile(result!.path, 'utf8');
+    assertDefined(result, 'write() returns a result even with no registry');
+    const raw = await readFile(result.path, 'utf8');
     expect(raw).toContain('name: acme-mcp');
   });
 
@@ -131,7 +142,8 @@ describe('admin/skill (createMcpUsageSkillWriter)', () => {
     }));
     const write = createMcpUsageSkillWriter({ skillRegistry: null, userSkillsDir: dir });
     const result = await write(server, many);
-    const raw = await readFile(result!.path, 'utf8');
+    assertDefined(result, 'write() returns a result for a fresh skill');
+    const raw = await readFile(result.path, 'utf8');
     const { fm, body } = parseFrontmatter(raw);
     expect(fm.description).toBe('Use the acme MCP server (5 tools).');
     expect((fm['allowed-tools'] as string[])).toHaveLength(5);

--- a/packages/plugin-mcp/src/discovery.test.ts
+++ b/packages/plugin-mcp/src/discovery.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import type { ServiceRegistry } from '@moxxy/sdk';
 import { mcpAdminPlugin } from './index.js';
 
@@ -35,7 +36,11 @@ describe('mcpAdminPlugin (discovery-loadable)', () => {
 
     // The inner onInit reads ~/.moxxy/mcp.json (absent on CI → caught + skipped);
     // we only assert the service wiring here.
-    await mcpAdminPlugin.hooks!.onInit!({ services } as never);
+    const hooks = mcpAdminPlugin.hooks;
+    assertDefined(hooks, 'mcpAdminPlugin.hooks present');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'mcpAdminPlugin onInit hook present');
+    await onInit({ services } as never);
 
     expect(get).toHaveBeenCalledWith('tools');
     expect(get).toHaveBeenCalledWith('skills');

--- a/packages/plugin-mcp/src/index.test.ts
+++ b/packages/plugin-mcp/src/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { createMcpPlugin } from './index.js';
 import type { McpClientLike } from './types.js';
 
@@ -24,7 +25,11 @@ describe('createMcpPlugin', () => {
     });
     expect(plugin.name).toBe('@moxxy/plugin-mcp');
     expect(plugin.tools).toHaveLength(1);
-    expect(plugin.tools![0]!.name).toBe('mcp__demo__ping');
+    const tools = plugin.tools;
+    assertDefined(tools, 'plugin.tools present after createMcpPlugin');
+    const first = tools[0];
+    assertDefined(first, 'first mcp tool present');
+    expect(first.name).toBe('mcp__demo__ping');
   });
 
   it('aggregates tools across multiple servers', async () => {
@@ -36,7 +41,9 @@ describe('createMcpPlugin', () => {
       clientFactory: async () => fakeClient,
     });
     expect(plugin.tools).toHaveLength(2);
-    expect(plugin.tools!.map((t) => t.name)).toEqual(['mcp__a__ping', 'mcp__b__ping']);
+    const tools = plugin.tools;
+    assertDefined(tools, 'plugin.tools present after createMcpPlugin');
+    expect(tools.map((t) => t.name)).toEqual(['mcp__a__ping', 'mcp__b__ping']);
   });
 
   it('connects servers in parallel and bounds boot at the slowest, not the sum (u86-5)', async () => {
@@ -59,7 +66,9 @@ describe('createMcpPlugin', () => {
       clientFactory: async (s) => slowClient(s.name),
     });
     const elapsed = Date.now() - start;
-    expect(plugin.tools!.map((t) => t.name)).toEqual(['mcp__a__ping', 'mcp__b__ping']);
+    const tools = plugin.tools;
+    assertDefined(tools, 'plugin.tools present after createMcpPlugin');
+    expect(tools.map((t) => t.name)).toEqual(['mcp__a__ping', 'mcp__b__ping']);
     expect(elapsed).toBeLessThan(90); // < the ~100ms serial sum
   });
 
@@ -89,7 +98,9 @@ describe('createMcpPlugin', () => {
       servers: [{ name: 'a', command: 'noop' }, { name: 'b', command: 'noop' }],
       clientFactory: async () => c,
     });
-    await plugin.hooks?.onShutdown?.({} as never);
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'plugin.hooks registered by createMcpPlugin');
+    await hooks.onShutdown?.({} as never);
     expect(closed).toBe(2);
   });
 });

--- a/packages/plugin-mcp/src/wrap.test.ts
+++ b/packages/plugin-mcp/src/wrap.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { wrapMcpServerTools, wrapMcpServerToolsLazy } from './wrap.js';
 import type { McpClientLike, McpToolDescriptor } from './types.js';
-import { asSessionId, asToolCallId, asTurnId } from '@moxxy/sdk';
+import { asSessionId, asToolCallId, asTurnId, assertDefined } from '@moxxy/sdk';
 
 const baseCtx = () => ({
   sessionId: asSessionId('s'),
@@ -52,15 +52,19 @@ describe('wrapMcpServerTools', () => {
       client,
     });
     expect(tools).toHaveLength(2);
-    expect(tools[0]!.name).toBe('mcp__demo__fetch');
-    expect(tools[0]!.description).toBe('Fetch a URL');
-    expect(tools[0]!.inputJsonSchema).toEqual({
+    const t0 = tools[0];
+    assertDefined(t0, 'first wrapped mcp tool present');
+    const t1 = tools[1];
+    assertDefined(t1, 'second wrapped mcp tool present');
+    expect(t0.name).toBe('mcp__demo__fetch');
+    expect(t0.description).toBe('Fetch a URL');
+    expect(t0.inputJsonSchema).toEqual({
       type: 'object',
       properties: { url: { type: 'string' } },
       required: ['url'],
     });
-    expect(tools[1]!.name).toBe('mcp__demo__shell');
-    expect(tools[1]!.description).toContain('shell');
+    expect(t1.name).toBe('mcp__demo__shell');
+    expect(t1.description).toContain('shell');
   });
 
   it('routes tool invocations through callTool and stringifies the content', async () => {
@@ -69,7 +73,9 @@ describe('wrapMcpServerTools', () => {
       server: { name: 'demo', command: 'noop' },
       client,
     });
-    const result = await tools[0]!.handler({ url: 'https://x' }, baseCtx());
+    const first = tools[0];
+    assertDefined(first, 'wrapped mcp tool present');
+    const result = await first.handler({ url: 'https://x' }, baseCtx());
     expect(result).toBe('called fetch');
     expect(client.calls).toEqual([{ name: 'fetch', arguments: { url: 'https://x' } }]);
   });
@@ -84,7 +90,9 @@ describe('wrapMcpServerTools', () => {
       server: { name: 'demo', command: 'noop' },
       client,
     });
-    const result = await tools[0]!.handler({ url: 'https://x' }, baseCtx());
+    const first = tools[0];
+    assertDefined(first, 'wrapped mcp tool present');
+    const result = await first.handler({ url: 'https://x' }, baseCtx());
     expect(result).toBe('[error] no permission');
   });
 
@@ -95,7 +103,9 @@ describe('wrapMcpServerTools', () => {
       isError: false,
     } as never);
     const tools = await wrapMcpServerTools({ server: { name: 'demo', command: 'noop' }, client });
-    const result = await tools[0]!.handler({ url: 'x' }, baseCtx());
+    const first = tools[0];
+    assertDefined(first, 'wrapped mcp tool present');
+    const result = await first.handler({ url: 'x' }, baseCtx());
     expect(result).toBe('hello body');
   });
 
@@ -106,7 +116,9 @@ describe('wrapMcpServerTools', () => {
       isError: false,
     } as never);
     const tools = await wrapMcpServerTools({ server: { name: 'demo', command: 'noop' }, client });
-    const result = await tools[0]!.handler({ url: 'x' }, baseCtx());
+    const first = tools[0];
+    assertDefined(first, 'wrapped mcp tool present');
+    const result = await first.handler({ url: 'x' }, baseCtx());
     expect(result).toBe('[resource:file:///a.bin application/octet-stream]');
   });
 
@@ -117,7 +129,9 @@ describe('wrapMcpServerTools', () => {
       isError: false,
     } as never);
     const tools = await wrapMcpServerTools({ server: { name: 'demo', command: 'noop' }, client });
-    const result = await tools[0]!.handler({ url: 'x' }, baseCtx());
+    const first = tools[0];
+    assertDefined(first, 'wrapped mcp tool present');
+    const result = await first.handler({ url: 'x' }, baseCtx());
     expect(result).toBe('[image:image/png]');
   });
 
@@ -128,7 +142,9 @@ describe('wrapMcpServerTools', () => {
       client,
       toolNamePrefix: (s, t) => `x_${s}_${t}`,
     });
-    expect(tools[0]!.name).toBe('x_demo_fetch');
+    const first = tools[0];
+    assertDefined(first, 'wrapped mcp tool present');
+    expect(first.name).toBe('x_demo_fetch');
   });
 
   it('aborts when ctx.signal is fired', async () => {
@@ -140,14 +156,18 @@ describe('wrapMcpServerTools', () => {
     const controller = new AbortController();
     const ctx = { ...baseCtx(), signal: controller.signal };
     controller.abort();
-    await expect(tools[0]!.handler({ url: 'x' }, ctx)).rejects.toThrow(/aborted/);
+    const first = tools[0];
+    assertDefined(first, 'wrapped mcp tool present');
+    await expect(first.handler({ url: 'x' }, ctx)).rejects.toThrow(/aborted/);
   });
 
   it('rejects a missing required field WITHOUT calling the server', async () => {
     const client = makeFakeClient();
     const tools = await wrapMcpServerTools({ server: { name: 'demo', command: 'noop' }, client });
     // `fetch` declares required: ['url']; emit it missing.
-    const result = await tools[0]!.handler({}, baseCtx());
+    const first = tools[0];
+    assertDefined(first, 'wrapped mcp tool present');
+    const result = await first.handler({}, baseCtx());
     expect(result).toMatch(/invalid arguments.*missing required field "url"/);
     expect(client.calls).toHaveLength(0);
   });
@@ -155,7 +175,9 @@ describe('wrapMcpServerTools', () => {
   it('rejects a wrong primitive type WITHOUT calling the server', async () => {
     const client = makeFakeClient();
     const tools = await wrapMcpServerTools({ server: { name: 'demo', command: 'noop' }, client });
-    const result = await tools[0]!.handler({ url: 123 }, baseCtx());
+    const first = tools[0];
+    assertDefined(first, 'wrapped mcp tool present');
+    const result = await first.handler({ url: 123 }, baseCtx());
     expect(result).toMatch(/field "url" must be of type string/);
     expect(client.calls).toHaveLength(0);
   });
@@ -163,7 +185,9 @@ describe('wrapMcpServerTools', () => {
   it('forwards a well-formed call that satisfies the declared schema', async () => {
     const client = makeFakeClient();
     const tools = await wrapMcpServerTools({ server: { name: 'demo', command: 'noop' }, client });
-    const result = await tools[0]!.handler({ url: 'https://ok' }, baseCtx());
+    const first = tools[0];
+    assertDefined(first, 'wrapped mcp tool present');
+    const result = await first.handler({ url: 'https://ok' }, baseCtx());
     expect(result).toBe('called fetch');
     expect(client.calls).toEqual([{ name: 'fetch', arguments: { url: 'https://ok' } }]);
   });
@@ -172,7 +196,9 @@ describe('wrapMcpServerTools', () => {
     const client = makeFakeClient();
     const tools = await wrapMcpServerTools({ server: { name: 'demo', command: 'noop' }, client });
     // `shell` (tools[1]) declares only { type: 'object' } — anything passes.
-    const result = await tools[1]!.handler({ anything: ['goes'] }, baseCtx());
+    const second = tools[1];
+    assertDefined(second, 'second wrapped mcp tool present');
+    const result = await second.handler({ anything: ['goes'] }, baseCtx());
     expect(result).toBe('called shell');
   });
 });
@@ -189,7 +215,9 @@ describe('runMcpCallWithFallback (timeout + settle-once)', () => {
     vi.spyOn(client, 'callTool').mockImplementation(() => new Promise<never>(() => {}));
     const tools = await wrapMcpServerTools({ server: { name: 'demo', command: 'noop' }, client });
 
-    const promise = tools[0]!.handler({ url: 'x' }, baseCtx());
+    const first = tools[0];
+    assertDefined(first, 'wrapped mcp tool present');
+    const promise = first.handler({ url: 'x' }, baseCtx());
     // Attach the rejection assertion before advancing so the rejection is observed.
     const assertion = expect(promise).rejects.toThrow(/timed out/);
     await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
@@ -209,7 +237,9 @@ describe('runMcpCallWithFallback (timeout + settle-once)', () => {
     const controller = new AbortController();
     const ctx = { ...baseCtx(), signal: controller.signal };
 
-    const promise = tools[0]!.handler({ url: 'x' }, ctx);
+    const first = tools[0];
+    assertDefined(first, 'wrapped mcp tool present');
+    const promise = first.handler({ url: 'x' }, ctx);
     controller.abort();
     // The late resolution must NOT win or throw "already settled".
     resolveCall({ content: [{ type: 'text', text: 'too late' }], isError: false });
@@ -232,8 +262,10 @@ describe('wrapMcpServerToolsLazy', () => {
     });
     expect(getClient).not.toHaveBeenCalled(); // building does not connect
 
-    await tools[0]!.handler({ url: 'a' }, baseCtx());
-    await tools[0]!.handler({ url: 'b' }, baseCtx());
+    const first = tools[0];
+    assertDefined(first, 'wrapped mcp tool present');
+    await first.handler({ url: 'a' }, baseCtx());
+    await first.handler({ url: 'b' }, baseCtx());
     // Two invocations, but the lazy wrapper hands the same factory each time.
     // The connection caching itself is the factory's job; here we assert the
     // factory is invoked per call and the calls reach the client.
@@ -253,8 +285,10 @@ describe('wrapMcpServerToolsLazy', () => {
     });
     const controller = new AbortController();
     controller.abort();
+    const first = tools[0];
+    assertDefined(first, 'wrapped mcp tool present');
     await expect(
-      tools[0]!.handler({ url: 'x' }, { ...baseCtx(), signal: controller.signal }),
+      first.handler({ url: 'x' }, { ...baseCtx(), signal: controller.signal }),
     ).rejects.toThrow(/aborted/);
     expect(getClient).not.toHaveBeenCalled();
   });

--- a/packages/plugin-memory/src/consolidate-nudge.test.ts
+++ b/packages/plugin-memory/src/consolidate-nudge.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { LLMProvider, ProviderEvent } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { MemoryStore } from './store.js';
 import { buildMemoryConsolidatePlugin } from './consolidate.js';
 
@@ -54,18 +55,23 @@ describe('auto-consolidation nudge hook', () => {
     const store = new MemoryStore({ dir: tmp, embedder: null });
     await fillMemories(store, 5);
     const plugin = buildMemoryConsolidatePlugin(store, () => stubProvider, { autoNudgeThreshold: 3 });
-    const result = await plugin.hooks?.onBeforeProviderCall?.(baseReq('be terse'), ctx());
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'nudge plugin registers hooks');
+    const result = await hooks.onBeforeProviderCall?.(baseReq('be terse'), ctx());
     expect(result).toBeDefined();
-    expect(result!.system).toContain('be terse');
-    expect(result!.system).toContain('memory_consolidate');
-    expect(result!.system).toContain('5 entries');
+    assertDefined(result, 'the nudge fires above threshold');
+    expect(result.system).toContain('be terse');
+    expect(result.system).toContain('memory_consolidate');
+    expect(result.system).toContain('5 entries');
   });
 
   it('does NOT append a hint when memory count is below threshold', async () => {
     const store = new MemoryStore({ dir: tmp, embedder: null });
     await fillMemories(store, 2);
     const plugin = buildMemoryConsolidatePlugin(store, () => stubProvider, { autoNudgeThreshold: 10 });
-    const result = await plugin.hooks?.onBeforeProviderCall?.(baseReq(), ctx());
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'nudge plugin registers hooks');
+    const result = await hooks.onBeforeProviderCall?.(baseReq(), ctx());
     expect(result).toBeUndefined();
   });
 
@@ -73,8 +79,10 @@ describe('auto-consolidation nudge hook', () => {
     const store = new MemoryStore({ dir: tmp, embedder: null });
     await fillMemories(store, 5);
     const plugin = buildMemoryConsolidatePlugin(store, () => stubProvider, { autoNudgeThreshold: 3 });
-    const first = await plugin.hooks?.onBeforeProviderCall?.(baseReq(), ctx());
-    const second = await plugin.hooks?.onBeforeProviderCall?.(baseReq(), ctx());
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'nudge plugin registers hooks');
+    const first = await hooks.onBeforeProviderCall?.(baseReq(), ctx());
+    const second = await hooks.onBeforeProviderCall?.(baseReq(), ctx());
     expect(first).toBeDefined();
     expect(second).toBeUndefined();
   });
@@ -91,7 +99,9 @@ describe('auto-consolidation nudge hook', () => {
     await fillMemories(store, 30);
     const plugin = buildMemoryConsolidatePlugin(store, () => stubProvider);
     // 30 is not greater than 30 → no nudge
-    const result = await plugin.hooks?.onBeforeProviderCall?.(baseReq(), ctx());
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'nudge plugin registers hooks');
+    const result = await hooks.onBeforeProviderCall?.(baseReq(), ctx());
     expect(result).toBeUndefined();
   });
 

--- a/packages/plugin-memory/src/consolidate.test.ts
+++ b/packages/plugin-memory/src/consolidate.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { LLMProvider, ProviderEvent } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { MemoryStore } from './store.js';
 import { consolidateMemory, planConsolidation } from './consolidate.js';
 
@@ -108,7 +109,9 @@ describe('planConsolidation', () => {
     ];
     const plan = planConsolidation(entries, { tag: 'api' });
     expect(plan.clusters).toHaveLength(1);
-    expect(plan.clusters[0]!.members.sort()).toEqual(['a', 'b']);
+    const cluster = plan.clusters[0];
+    assertDefined(cluster, 'plan has one cluster');
+    expect(cluster.members.sort()).toEqual(['a', 'b']);
   });
 });
 

--- a/packages/plugin-memory/src/consolidate.ts
+++ b/packages/plugin-memory/src/consolidate.ts
@@ -1,5 +1,6 @@
 import {
   z,
+  assertDefined,
   defineTool,
   definePlugin,
   type LifecycleHooks,
@@ -46,8 +47,9 @@ export function planConsolidation(
   entries: ReadonlyArray<MemoryEntry>,
   opts: { tag?: string } = {},
 ): ConsolidatePlan {
-  const filtered = opts.tag
-    ? entries.filter((e) => (e.frontmatter.tags ?? []).includes(opts.tag!))
+  const tag = opts.tag;
+  const filtered = tag
+    ? entries.filter((e) => (e.frontmatter.tags ?? []).includes(tag))
     : entries;
   if (filtered.length < 2) {
     return { clusters: [], stable: filtered.map((e) => e.frontmatter.name) };
@@ -63,7 +65,8 @@ export function planConsolidation(
       tagless.push(e);
     } else {
       // Use the first tag as the cluster key (deterministic, simple)
-      const key = tags[0]!;
+      const key = tags[0];
+      assertDefined(key, 'tags is non-empty here (tags.length === 0 handled above)');
       const list = byTag.get(key) ?? [];
       list.push(e);
       byTag.set(key, list);
@@ -99,14 +102,18 @@ export function planConsolidation(
     if (members.length >= 2) {
       clusters.push({ key: `tag:${key}`, members: members.map((m) => m.frontmatter.name) });
     } else {
-      stable.push(members[0]!.frontmatter.name);
+      const only = members[0];
+      assertDefined(only, 'byTag lists always carry ≥1 member');
+      stable.push(only.frontmatter.name);
     }
   }
   for (const cluster of descClusters) {
     if (cluster.members.length >= 2) {
       clusters.push({ key: cluster.key, members: cluster.members.map((m) => m.frontmatter.name) });
     } else {
-      stable.push(cluster.members[0]!.frontmatter.name);
+      const only = cluster.members[0];
+      assertDefined(only, 'desc clusters are created with ≥1 member');
+      stable.push(only.frontmatter.name);
     }
   }
 
@@ -374,7 +381,7 @@ function extractJson(text: string): unknown {
   // Take the span from the first `{` to the last `}` in the response. Some
   // providers wrap the object in ```json ... ```, which we strip first.
   const fenced = /```(?:json)?\n?([\s\S]*?)```/.exec(text);
-  const candidate = fenced ? fenced[1]! : text;
+  const candidate = fenced?.[1] ?? text;
   const start = candidate.indexOf('{');
   const end = candidate.lastIndexOf('}');
   // `end <= start` (e.g. a stray `}` before the first `{`) means there's no

--- a/packages/plugin-memory/src/discovery.test.ts
+++ b/packages/plugin-memory/src/discovery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ServiceRegistry } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { memoryConsolidatePlugin } from './index.js';
 
 /**
@@ -26,7 +27,10 @@ describe('memoryConsolidatePlugin (discovery-loadable)', () => {
       has: () => true,
       register: () => {},
     } as unknown as ServiceRegistry;
-    memoryConsolidatePlugin.hooks!.onInit!({ services } as never);
+    const hooks = memoryConsolidatePlugin.hooks;
+    assertDefined(hooks, 'plugin defines hooks');
+    assertDefined(hooks.onInit, 'plugin defines an onInit hook');
+    hooks.onInit({ services } as never);
     expect(get).toHaveBeenCalledWith('memory');
     expect(get).toHaveBeenCalledWith('providers');
   });

--- a/packages/plugin-memory/src/index.ts
+++ b/packages/plugin-memory/src/index.ts
@@ -262,8 +262,10 @@ export const memoryPlugin: Plugin = (() => {
       onInit: async (ctx) => {
         embeddersReg =
           ctx.services.get<{ tryGetActive(): unknown }>('embedders') ?? null;
-        await base.hooks?.onInit?.(ctx);
-        await consolidate.hooks?.onInit?.(ctx);
+        const baseHooks = base.hooks;
+        if (baseHooks) await baseHooks.onInit?.(ctx);
+        const consolidateHooks = consolidate.hooks;
+        if (consolidateHooks) await consolidateHooks.onInit?.(ctx);
       },
       // A Plugin has a single onBeforeProviderCall, but this composed plugin
       // carries TWO: base's always-on user-model injection and consolidate's
@@ -271,9 +273,15 @@ export const memoryPlugin: Plugin = (() => {
       // block, the nudge appends its hint); either may return void to pass through.
       onBeforeProviderCall: async (req, ctx) => {
         let out: ProviderRequest | undefined;
-        const injected = await base.hooks?.onBeforeProviderCall?.(out ?? req, ctx);
+        const baseHooks = base.hooks;
+        const injected = baseHooks
+          ? await baseHooks.onBeforeProviderCall?.(out ?? req, ctx)
+          : undefined;
         if (injected) out = injected;
-        const nudged = await consolidate.hooks?.onBeforeProviderCall?.(out ?? req, ctx);
+        const consolidateHooks = consolidate.hooks;
+        const nudged = consolidateHooks
+          ? await consolidateHooks.onBeforeProviderCall?.(out ?? req, ctx)
+          : undefined;
         if (nudged) out = nudged;
         return out;
       },

--- a/packages/plugin-memory/src/stm.test.ts
+++ b/packages/plugin-memory/src/stm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { asPluginId, asSessionId, asToolCallId, asTurnId, type MoxxyEvent } from '@moxxy/sdk';
+import { asPluginId, asSessionId, asToolCallId, asTurnId, assertDefined, type MoxxyEvent } from '@moxxy/sdk';
 import { recentExchanges, summarizeSession } from './stm.js';
 
 const sid = asSessionId('s');
@@ -37,7 +37,9 @@ describe('recentExchanges', () => {
     ]);
     const recent = recentExchanges(log, 2);
     expect(recent.map((r) => r.source)).toEqual(['assistant', 'user']);
-    expect(recent[1]!.text).toBe('next');
+    const second = recent[1];
+    assertDefined(second, 'recentExchanges returns two exchanges');
+    expect(second.text).toBe('next');
   });
 
   it('ignores non-message events', () => {

--- a/packages/plugin-memory/src/store.test.ts
+++ b/packages/plugin-memory/src/store.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -68,16 +69,20 @@ describe('MemoryStore', () => {
     await store.save({ name: 'b', type: 'preference', description: 'B', body: '.' });
     const facts = await store.list('fact');
     expect(facts).toHaveLength(1);
-    expect(facts[0]!.frontmatter.name).toBe('a');
+    const fact = facts[0];
+    assertDefined(fact, 'facts has one entry');
+    expect(fact.frontmatter.name).toBe('a');
   });
 
   it('update preserves createdAt but bumps updatedAt', async () => {
     const store = newStore();
     await store.save({ name: 'foo', type: 'fact', description: 'd', body: 'orig' });
-    const first = (await store.get('foo'))!;
+    const first = await store.get('foo');
+    assertDefined(first, 'foo was just saved');
     await new Promise((r) => setTimeout(r, 10));
     await store.update('foo', { body: 'updated' });
-    const second = (await store.get('foo'))!;
+    const second = await store.get('foo');
+    assertDefined(second, 'foo still exists after update');
     expect(second.frontmatter.createdAt).toBe(first.frontmatter.createdAt);
     expect(second.frontmatter.updatedAt).not.toBe(first.frontmatter.updatedAt);
     expect(second.body).toBe('updated');
@@ -112,9 +117,13 @@ describe('MemoryStore', () => {
       body: 'All migrations target Postgres 16. Use `pg_dump` for backups.',
     });
     const matches = await store.recall('trpc endpoints');
-    expect(matches[0]!.entry.frontmatter.name).toBe('team-likes-trpc');
+    const topMatch = matches[0];
+    assertDefined(topMatch, 'recall returns a match');
+    expect(topMatch.entry.frontmatter.name).toBe('team-likes-trpc');
     const pg = await store.recall('postgres');
-    expect(pg[0]!.entry.frontmatter.name).toBe('prod-postgres');
+    const topPg = pg[0];
+    assertDefined(topPg, 'recall returns a match');
+    expect(topPg.entry.frontmatter.name).toBe('prod-postgres');
   });
 
   it('rejects invalid frontmatter at save time via the schema', async () => {

--- a/packages/plugin-memory/src/store/search.test.ts
+++ b/packages/plugin-memory/src/store/search.test.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { EmbeddingProvider, Mutex } from '@moxxy/sdk';
-import { createMutex } from '@moxxy/sdk';
+import { createMutex, assertDefined } from '@moxxy/sdk';
 import { rankByKeywords, recallVector } from './search.js';
 import { EmbeddingIndex } from '../embedding-cache.js';
 import type { MemoryEntry, MemoryType } from './types.js';
@@ -33,7 +33,9 @@ describe('rankByKeywords', () => {
     const e = entry('ci', 'continuous integration', 'deploy then deploy and deploy again');
     const ranked = rankByKeywords([e], 'deploy', 5);
     expect(ranked).toHaveLength(1);
-    expect(ranked[0]!.score).toBe(3);
+    const top = ranked[0];
+    assertDefined(top, 'rankByKeywords returns one ranked entry');
+    expect(top.score).toBe(3);
   });
 
   it('weights name and description hits above body-only hits', () => {
@@ -53,7 +55,9 @@ describe('rankByKeywords', () => {
     const both = entry('a', 'alpha beta', 'alpha beta gamma');
     const one = entry('b', 'just alpha', 'nothing else');
     const ranked = rankByKeywords([one, both], 'alpha beta', 5);
-    expect(ranked[0]!.entry.frontmatter.name).toBe('a');
+    const top = ranked[0];
+    assertDefined(top, 'rankByKeywords returns a ranked entry');
+    expect(top.entry.frontmatter.name).toBe('a');
   });
 
   it('drops zero-score entries and respects the limit', () => {
@@ -61,7 +65,9 @@ describe('rankByKeywords', () => {
     const miss = entry('y', 'unrelated', 'nothing relevant');
     const ranked = rankByKeywords([hit, miss], 'widget', 1);
     expect(ranked).toHaveLength(1);
-    expect(ranked[0]!.entry.frontmatter.name).toBe('x');
+    const top = ranked[0];
+    assertDefined(top, 'rankByKeywords returns one ranked entry');
+    expect(top.entry.frontmatter.name).toBe('x');
   });
 
   it('an empty query matches every entry with score 1', () => {

--- a/packages/plugin-memory/src/store/search.ts
+++ b/packages/plugin-memory/src/store/search.ts
@@ -1,4 +1,5 @@
 import type { EmbeddingProvider, Mutex } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { TfIdfEmbedder, cosineSimilarity, tokenize } from '../tfidf.js';
 import type { EmbeddingIndex } from '../embedding-cache.js';
 import type { MemoryEntry } from './types.js';
@@ -36,9 +37,13 @@ export async function recallVector(
       const cached: Array<ReadonlyArray<number> | null> = [];
       const misses: { index: number; text: string }[] = [];
       for (let i = 0; i < all.length; i++) {
-        const hit = index.lookup(all[i]!.frontmatter.name, corpus[i]!);
+        const entry = all[i];
+        const text = corpus[i];
+        assertDefined(entry, 'loop index i < all.length');
+        assertDefined(text, 'corpus is built 1:1 from all');
+        const hit = index.lookup(entry.frontmatter.name, text);
         cached.push(hit);
-        if (!hit) misses.push({ index: i, text: corpus[i]! });
+        if (!hit) misses.push({ index: i, text });
       }
       const queryIdx = misses.length;
       const toEmbed = [...misses.map((m) => m.text), query];
@@ -64,7 +69,11 @@ export async function recallVector(
       // future recall would read back a corrupt entry).
       for (const [j, m] of misses.entries()) {
         const v = fresh[j];
-        if (Array.isArray(v)) index.set(all[m.index]!.frontmatter.name, m.text, v);
+        if (Array.isArray(v)) {
+          const entry = all[m.index];
+          assertDefined(entry, 'm.index was recorded from the bounds-checked all[] loop');
+          index.set(entry.frontmatter.name, m.text, v);
+        }
       }
       index.prune(all.map((e) => e.frontmatter.name));
       await index.flush();
@@ -128,6 +137,8 @@ function rankCosine(
   }
   const ranked: RankedMemory[] = [];
   for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    assertDefined(entry, 'loop index i < entries.length');
     const vec = vectors[i];
     // cosineSimilarity silently truncates to the shorter vector, so a stale
     // cached vector or a provider quirk of the wrong dimensionality would
@@ -136,13 +147,13 @@ function rankCosine(
     // loudly instead of ranking it on a mismatched or absent basis.
     if (!Array.isArray(vec) || vec.length !== query.length) {
       console.warn(
-        `[plugin-memory] skipping '${entries[i]!.frontmatter.name}' in recall: ` +
+        `[plugin-memory] skipping '${entry.frontmatter.name}' in recall: ` +
           `vector dim ${Array.isArray(vec) ? vec.length : 'missing'} != query dim ${query.length} (cache/embedder drift)`,
       );
       continue;
     }
     const score = cosineSimilarity(vec, query);
-    if (score > 0) ranked.push({ entry: entries[i]!, score });
+    if (score > 0) ranked.push({ entry, score });
   }
   ranked.sort((a, b) => b.score - a.score);
   return ranked.slice(0, limit);

--- a/packages/plugin-memory/src/tfidf.test.ts
+++ b/packages/plugin-memory/src/tfidf.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { TfIdfEmbedder, cosineSimilarity, tokenize } from './tfidf.js';
 
 describe('tokenize', () => {
@@ -29,8 +30,12 @@ describe('TfIdfEmbedder', () => {
     e.fit(corpus);
     const vectors = await e.embed(corpus);
     expect(vectors).toHaveLength(3);
-    expect(vectors[0]!.length).toBeGreaterThan(0);
-    expect(vectors[0]!.length).toBe(vectors[1]!.length);
+    const v0 = vectors[0];
+    const v1 = vectors[1];
+    assertDefined(v0, 'embed returns a vector per corpus entry');
+    assertDefined(v1, 'embed returns a vector per corpus entry');
+    expect(v0.length).toBeGreaterThan(0);
+    expect(v0.length).toBe(v1.length);
   });
 
   it('ranks a relevant query higher than an irrelevant one', async () => {
@@ -42,11 +47,20 @@ describe('TfIdfEmbedder', () => {
     const e = new TfIdfEmbedder();
     e.fit([...corpus, 'what API style does the team use', 'database flavor in prod']);
     const v = await e.embed([...corpus, 'what API style does the team use']);
-    const queryVec = v[v.length - 1]!;
-    const scores = corpus.map((_, i) => cosineSimilarity(v[i]!, queryVec));
+    const queryVec = v[v.length - 1];
+    assertDefined(queryVec, 'embed returns the query vector last');
+    const scores = corpus.map((_, i) => {
+      const vi = v[i];
+      assertDefined(vi, 'embed returns a vector per corpus entry');
+      return cosineSimilarity(vi, queryVec);
+    });
     // tRPC entry should be most similar to "API style" query
-    expect(scores[0]).toBeGreaterThan(scores[1]!);
-    expect(scores[0]).toBeGreaterThan(scores[2]!);
+    const s1 = scores[1];
+    const s2 = scores[2];
+    assertDefined(s1, 'scores has an entry per corpus entry');
+    assertDefined(s2, 'scores has an entry per corpus entry');
+    expect(scores[0]).toBeGreaterThan(s1);
+    expect(scores[0]).toBeGreaterThan(s2);
   });
 
   it('cosineSimilarity returns 1 for identical normalized vectors', () => {

--- a/packages/plugin-memory/src/user-model.test.ts
+++ b/packages/plugin-memory/src/user-model.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ProviderRequest } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import {
   UserModelStore,
   userModelTool,
@@ -39,7 +40,9 @@ describe('parseUserModel / serializeUserModel', () => {
     const text = '## Identity\n\nAlex, a backend dev.\n\n## Preferences\n\nTerse replies.\n';
     const model = parseUserModel(text);
     expect(model.sections.map((s) => s.title)).toEqual(['Identity', 'Preferences']);
-    expect(model.sections[0]!.content).toBe('Alex, a backend dev.');
+    const identity = model.sections[0];
+    assertDefined(identity, 'parsed model has an Identity section');
+    expect(identity.content).toBe('Alex, a backend dev.');
     // serialize → parse is stable
     const reparsed = parseUserModel(serializeUserModel(model));
     expect(reparsed.sections).toEqual(model.sections);
@@ -132,11 +135,13 @@ describe('UserModelStore.load (mtime cache)', () => {
     const store = newStore();
     await store.update('identity', 'first', 'replace');
     const before = await store.load();
-    expect(before?.sections.find((s) => s.title === 'Identity')?.content).toBe('first');
+    assertDefined(before, 'store has content after update');
+    expect(before.sections.find((s) => s.title === 'Identity')?.content).toBe('first');
     await new Promise((r) => setTimeout(r, 10)); // ensure a distinct mtime
     await store.update('identity', 'second', 'replace');
     const after = await store.load();
-    expect(after?.sections.find((s) => s.title === 'Identity')?.content).toBe('second');
+    assertDefined(after, 'store has content after update');
+    expect(after.sections.find((s) => s.title === 'Identity')?.content).toBe('second');
   });
 
   it('picks up an out-of-band write with a newer mtime', async () => {
@@ -145,9 +150,9 @@ describe('UserModelStore.load (mtime cache)', () => {
     await store.load(); // prime the cache
     await new Promise((r) => setTimeout(r, 10));
     await fs.writeFile(modelPath(), '## Identity\n\nrewritten\n');
-    expect((await store.load())?.sections.find((s) => s.title === 'Identity')?.content).toBe(
-      'rewritten',
-    );
+    const loaded = await store.load();
+    assertDefined(loaded, 'store has content after an out-of-band write');
+    expect(loaded.sections.find((s) => s.title === 'Identity')?.content).toBe('rewritten');
   });
 });
 
@@ -171,23 +176,26 @@ describe('UserModelStore.update', () => {
     await store.update('preferences', 'terse', 'replace');
     await store.update('preferences', 'verbose', 'replace');
     const m = await store.load();
-    expect(m?.sections.find((s) => s.title === 'Preferences')?.content).toBe('verbose');
+    assertDefined(m, 'store has content after update');
+    expect(m.sections.find((s) => s.title === 'Preferences')?.content).toBe('verbose');
   });
 
   it('append adds to existing content on its own line', async () => {
     const store = newStore();
     await store.update('workflows', 'uses pnpm', 'replace');
     await store.update('workflows', 'rebases often', 'append');
-    const content = (await store.load())?.sections.find((s) => s.title === 'Workflows')?.content;
+    const loaded = await store.load();
+    assertDefined(loaded, 'store has content after update');
+    const content = loaded.sections.find((s) => s.title === 'Workflows')?.content;
     expect(content).toBe('uses pnpm\nrebases often');
   });
 
   it('append on an empty section behaves like replace', async () => {
     const store = newStore();
     await store.update('context', 'sole line', 'append');
-    expect((await store.load())?.sections.find((s) => s.title === 'Context')?.content).toBe(
-      'sole line',
-    );
+    const loaded = await store.load();
+    assertDefined(loaded, 'store has content after append');
+    expect(loaded.sections.find((s) => s.title === 'Context')?.content).toBe('sole line');
   });
 
   it('preserves an unknown section when a tool write touches a fixed one', async () => {
@@ -222,13 +230,15 @@ describe('UserModelStore.injectInto', () => {
     const store = newStore();
     await store.update('identity', 'Alex, backend dev', 'replace');
     const out = (await store.injectInto(req('BASE SYSTEM'))) as ProviderRequest;
-    expect(out.system!.startsWith(USER_MODEL_OPEN)).toBe(true);
+    const system = out.system;
+    assertDefined(system, 'injectInto returns a system prompt');
+    expect(system.startsWith(USER_MODEL_OPEN)).toBe(true);
     expect(out.system).toContain('## Identity\nAlex, backend dev');
     expect(out.system).toContain('</user-model>');
     expect(out.system).toContain('memory_update_user_model');
     // Original system prompt is retained, AFTER the block.
     expect(out.system).toContain('BASE SYSTEM');
-    expect(out.system!.indexOf(USER_MODEL_OPEN)).toBeLessThan(out.system!.indexOf('BASE SYSTEM'));
+    expect(system.indexOf(USER_MODEL_OPEN)).toBeLessThan(system.indexOf('BASE SYSTEM'));
   });
 
   it('injects even when req.system is undefined', async () => {
@@ -246,7 +256,9 @@ describe('UserModelStore.injectInto', () => {
     const second = await store.injectInto(first);
     expect(second).toBeUndefined();
     // Only one opening delimiter present.
-    expect(first.system!.match(/<user-model>/g)).toHaveLength(1);
+    const firstSystem = first.system;
+    assertDefined(firstSystem, 'first injection produced a system prompt');
+    expect(firstSystem.match(/<user-model>/g)).toHaveLength(1);
   });
 
   it('returns the request unchanged when parsing/reading throws', async () => {
@@ -264,8 +276,12 @@ describe('userModelTool', () => {
     const tool = userModelTool(newStore());
     expect(tool.name).toBe('memory_update_user_model');
     expect(tool.permission).toEqual({ action: 'prompt' });
-    expect(tool.isolation?.capabilities?.fs?.write).toEqual(['~/.moxxy/memory/**']);
-    expect(tool.isolation?.capabilities?.net).toEqual({ mode: 'none' });
+    const isolation = tool.isolation;
+    assertDefined(isolation, 'the tool declares an isolation policy');
+    const capabilities = isolation.capabilities;
+    assertDefined(capabilities, 'the isolation policy declares capabilities');
+    expect(capabilities.fs?.write).toEqual(['~/.moxxy/memory/**']);
+    expect(capabilities.net).toEqual({ mode: 'none' });
   });
 
   it('rejects an out-of-enum section and over-long content', () => {
@@ -289,7 +305,9 @@ describe('userModelTool', () => {
       {} as never,
     )) as { section: string; mode: string; path: string };
     expect(out.section).toBe('identity');
-    expect((await store.load())?.sections.find((s) => s.title === 'Identity')?.content).toBe('Alex');
+    const loaded = await store.load();
+    assertDefined(loaded, 'store has content after the tool write');
+    expect(loaded.sections.find((s) => s.title === 'Identity')?.content).toBe('Alex');
     const raw = await fs.readFile(modelPath(), 'utf8');
     expect(raw).toContain('<!-- moxxy user model');
   });

--- a/packages/plugin-memory/src/user-model.ts
+++ b/packages/plugin-memory/src/user-model.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import {
   z,
+  assertDefined,
   defineTool,
   createMutex,
   type Mutex,
@@ -94,7 +95,9 @@ export function parseUserModel(text: string): UserModel {
     if (m) {
       seenHeading = true;
       if (current) sections.push({ title: current.title, content: current.body.join('\n').trim() });
-      current = { title: m[1]!.trim(), body: [] };
+      const title = m[1];
+      assertDefined(title, 'HEADING_RE capture group 1 is present on any match');
+      current = { title: title.trim(), body: [] };
     } else if (!seenHeading) {
       preambleLines.push(line);
     } else if (current) {

--- a/packages/plugin-memory/src/vector-recall.test.ts
+++ b/packages/plugin-memory/src/vector-recall.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { EmbeddingProvider } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { MemoryStore } from './store.js';
 
 let tmp: string;
@@ -40,21 +41,27 @@ describe('MemoryStore vector recall (TF-IDF default)', () => {
     expect(store.embedderName).toBe('tfidf');
     await sampleCorpus(store);
     const matches = await store.recall('what API style does the team prefer');
-    expect(matches[0]!.entry.frontmatter.name).toBe('trpc-preference');
+    const top = matches[0];
+    assertDefined(top, 'recall returns a match');
+    expect(top.entry.frontmatter.name).toBe('trpc-preference');
   });
 
   it('vector recall ranks semantically relevant entries above incidental keyword matches', async () => {
     const store = new MemoryStore({ dir: tmp });
     await sampleCorpus(store);
     const matches = await store.recall('postgres database backups', { limit: 3 });
-    expect(matches[0]!.entry.frontmatter.name).toBe('postgres-prod');
+    const top = matches[0];
+    assertDefined(top, 'recall returns a match');
+    expect(top.entry.frontmatter.name).toBe('postgres-prod');
   });
 
   it('mode: "keyword" forces the legacy scorer', async () => {
     const store = new MemoryStore({ dir: tmp });
     await sampleCorpus(store);
     const matches = await store.recall('postgres', { mode: 'keyword' });
-    expect(matches[0]!.entry.frontmatter.name).toBe('postgres-prod');
+    const top = matches[0];
+    assertDefined(top, 'recall returns a match');
+    expect(top.entry.frontmatter.name).toBe('postgres-prod');
   });
 
   it('embedder: null disables vector entirely and forces keyword', async () => {
@@ -63,7 +70,9 @@ describe('MemoryStore vector recall (TF-IDF default)', () => {
     await sampleCorpus(store);
     const matches = await store.recall('database flavor in prod');
     // Falls through to keyword: "database" + "prod" only appear in postgres-prod
-    expect(matches[0]!.entry.frontmatter.name).toBe('postgres-prod');
+    const top = matches[0];
+    assertDefined(top, 'recall returns a match');
+    expect(top.entry.frontmatter.name).toBe('postgres-prod');
   });
 
   it('accepts a custom EmbeddingProvider via the constructor', async () => {
@@ -78,7 +87,9 @@ describe('MemoryStore vector recall (TF-IDF default)', () => {
     expect(store.embedderName).toBe('stub');
     await sampleCorpus(store);
     const matches = await store.recall('postgres');
-    expect(matches[0]!.entry.frontmatter.name).toBe('postgres-prod');
+    const top = matches[0];
+    assertDefined(top, 'recall returns a match');
+    expect(top.entry.frontmatter.name).toBe('postgres-prod');
   });
 
   it('returns empty list when corpus is empty', async () => {

--- a/packages/plugin-provider-anthropic/src/oauth-mode.test.ts
+++ b/packages/plugin-provider-anthropic/src/oauth-mode.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type Anthropic from '@anthropic-ai/sdk';
 import type { ProviderEvent } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { AnthropicProvider } from './provider.js';
 
 /** Build a fake Anthropic SDK client that records `messages.stream` args. */
@@ -66,13 +67,17 @@ describe('AnthropicProvider OAuth mode', () => {
       }),
     );
 
-    const sys = calls[0]!.system as Array<{ type: string; text: string }>;
+    const call0 = calls[0];
+    assertDefined(call0, 'a call was recorded');
+    const sys = call0.system as Array<{ type: string; text: string }>;
     expect(Array.isArray(sys)).toBe(true);
     expect(sys[0]).toEqual({
       type: 'text',
       text: "You are Claude Code, Anthropic's official CLI for Claude.",
     });
-    expect(sys[1]!.text).toBe('REAL SYSTEM');
+    const sysBlock1 = sys[1];
+    assertDefined(sysBlock1, 'system has a second block');
+    expect(sysBlock1.text).toBe('REAL SYSTEM');
     expect(out.at(-1)).toMatchObject({ type: 'message_end', stopReason: 'end_turn' });
   });
 
@@ -88,7 +93,9 @@ describe('AnthropicProvider OAuth mode', () => {
         ],
       }),
     );
-    expect(calls[0]!.system).toBe('REAL');
+    const call0 = calls[0];
+    assertDefined(call0, 'a call was recorded');
+    expect(call0.system).toBe('REAL');
   });
 
   it('delivers hook-injected req.system as an extra system block after the prompt', async () => {
@@ -104,7 +111,9 @@ describe('AnthropicProvider OAuth mode', () => {
         ],
       }),
     );
-    const sys = calls[0]!.system as Array<{ type: string; text: string }>;
+    const call0 = calls[0];
+    assertDefined(call0, 'a call was recorded');
+    const sys = call0.system as Array<{ type: string; text: string }>;
     expect(Array.isArray(sys)).toBe(true);
     expect(sys.map((b) => b.text)).toEqual(['BASE PROMPT', '[memory note] consider consolidating']);
   });
@@ -123,7 +132,9 @@ describe('AnthropicProvider OAuth mode', () => {
         ],
       }),
     );
-    const sys = calls[0]!.system as Array<{ type: string; text: string; cache_control?: unknown }>;
+    const call0 = calls[0];
+    assertDefined(call0, 'a call was recorded');
+    const sys = call0.system as Array<{ type: string; text: string; cache_control?: unknown }>;
     expect(sys[0]).toEqual({ type: 'text', text: 'BASE PROMPT', cache_control: { type: 'ephemeral' } });
     expect(sys[1]).toEqual({ type: 'text', text: 'VOLATILE NUDGE' });
   });
@@ -145,7 +156,9 @@ describe('AnthropicProvider OAuth mode', () => {
         ],
       }),
     );
-    const sys = calls[0]!.system as Array<{ type: string; text: string }>;
+    const call0 = calls[0];
+    assertDefined(call0, 'a call was recorded');
+    const sys = call0.system as Array<{ type: string; text: string }>;
     expect(sys.map((b) => b.text)).toEqual(['PREAMBLE', 'REAL SYSTEM', 'NUDGE']);
   });
 });

--- a/packages/plugin-provider-anthropic/src/oauth-refresh.test.ts
+++ b/packages/plugin-provider-anthropic/src/oauth-refresh.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type Anthropic from '@anthropic-ai/sdk';
 import type { ProviderEvent, ProviderRequest } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { AnthropicProvider } from './provider.js';
 
 /**
@@ -223,7 +224,9 @@ describe('AnthropicProvider OAuth token refresh', () => {
     expect(fake.streamCalls).toBe(1);
     const errors = out.filter((e): e is Extract<ProviderEvent, { type: 'error' }> => e.type === 'error');
     expect(errors).toHaveLength(1);
-    expect(errors[0]!.message).toContain('refresh endpoint down');
+    const err = errors[0];
+    assertDefined(err, 'one error event asserted above');
+    expect(err.message).toContain('refresh endpoint down');
     expect(out.filter((e) => e.type === 'message_end')).toHaveLength(0);
   });
 
@@ -248,7 +251,9 @@ describe('AnthropicProvider OAuth token refresh', () => {
     expect(fake.streamCalls).toBe(0);
     const errors = out.filter((e): e is Extract<ProviderEvent, { type: 'error' }> => e.type === 'error');
     expect(errors).toHaveLength(1);
-    expect(errors[0]!.message).toContain('proactive refresh failed');
+    const err = errors[0];
+    assertDefined(err, 'one error event asserted above');
+    expect(err.message).toContain('proactive refresh failed');
     // A failed proactive refresh emits NO message_start — the turn never opens,
     // so consumers pairing message_start/message_end see nothing dangling.
     expect(out.some((e) => e.type === 'message_start')).toBe(false);

--- a/packages/plugin-provider-anthropic/src/provider.test.ts
+++ b/packages/plugin-provider-anthropic/src/provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { AnthropicProvider } from './provider.js';
 
 // A minimal fake Anthropic SDK client to drive the translator without HTTP.
@@ -236,9 +237,13 @@ describe('AnthropicProvider.stream', () => {
     for await (const _ of p.stream({ model: 'claude-haiku-4-5-20251001', maxTokens: 5_000_000, messages: [] })) {
       void _;
     }
-    expect(calls[0]!.max_tokens).toBe(64_000);
+    const call0 = calls[0];
+    assertDefined(call0, 'first call recorded');
+    expect(call0.max_tokens).toBe(64_000);
     // No maxTokens → defaults to the descriptor ceiling.
     for await (const _ of p.stream({ model: 'claude-haiku-4-5-20251001', messages: [] })) void _;
-    expect(calls[1]!.max_tokens).toBe(64_000);
+    const call1 = calls[1];
+    assertDefined(call1, 'second call recorded');
+    expect(call1.max_tokens).toBe(64_000);
   });
 });

--- a/packages/plugin-provider-anthropic/src/provider.ts
+++ b/packages/plugin-provider-anthropic/src/provider.ts
@@ -518,7 +518,8 @@ export class AnthropicProvider implements LLMProvider {
         const s = stream as unknown as { abort?: () => void; controller?: { abort?: () => void } };
         try {
           s.abort?.();
-          s.controller?.abort?.();
+          const controller = s.controller;
+          if (controller) controller.abort?.();
         } catch {
           // Best-effort cleanup — a fake/partial stream may expose neither.
         }

--- a/packages/plugin-provider-anthropic/src/translate.test.ts
+++ b/packages/plugin-provider-anthropic/src/translate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
-import { defineTool } from '@moxxy/sdk';
+import { assertDefined, defineTool } from '@moxxy/sdk';
 import { toAnthropicMessages, toAnthropicTools } from './translate.js';
 
 describe('toAnthropicMessages', () => {
@@ -86,17 +86,28 @@ describe('toAnthropicMessages', () => {
       ],
       { cacheMessageIndices: new Set([2]) },
     );
-    const marked = messages[messages.length - 1]!.content[0]!;
+    const lastMsg = messages[messages.length - 1];
+    assertDefined(lastMsg, 'messages non-empty');
+    const marked = lastMsg.content[0];
+    assertDefined(marked, 'content non-empty');
     expect(marked.cache_control).toEqual({ type: 'ephemeral' });
     // Unhinted messages stay unmarked.
-    expect(messages[0]!.content[0]!.cache_control).toBeUndefined();
+    const firstMsg = messages[0];
+    assertDefined(firstMsg, 'messages non-empty');
+    const firstBlock = firstMsg.content[0];
+    assertDefined(firstBlock, 'content non-empty');
+    expect(firstBlock.cache_control).toBeUndefined();
   });
 
   it('adds no cache_control when no hints are given', () => {
     const { messages } = toAnthropicMessages([
       { role: 'user', content: [{ type: 'text', text: 'a' }] },
     ]);
-    expect(messages[0]!.content[0]!.cache_control).toBeUndefined();
+    const firstMsg = messages[0];
+    assertDefined(firstMsg, 'messages non-empty');
+    const firstBlock = firstMsg.content[0];
+    assertDefined(firstBlock, 'content non-empty');
+    expect(firstBlock.cache_control).toBeUndefined();
   });
 
   it('joins all text blocks of a multi-block system message (does not drop the rest)', () => {
@@ -119,7 +130,10 @@ describe('toAnthropicMessages', () => {
         content: [{ type: 'image', mediaType: 'image/tiff', data: 'AAAA' }],
       },
     ]);
-    const block = messages[0]!.content[0]!;
+    const firstMsg = messages[0];
+    assertDefined(firstMsg, 'messages non-empty');
+    const block = firstMsg.content[0];
+    assertDefined(block, 'content non-empty');
     expect(block.type).toBe('text');
     expect((block as { text: string }).text).toContain('image/tiff');
   });
@@ -131,7 +145,10 @@ describe('toAnthropicMessages', () => {
         content: [{ type: 'document', mediaType: 'application/zip', data: 'AAAA' }],
       },
     ]);
-    const block = messages[0]!.content[0]!;
+    const firstMsg = messages[0];
+    assertDefined(firstMsg, 'messages non-empty');
+    const block = firstMsg.content[0];
+    assertDefined(block, 'content non-empty');
     expect(block.type).toBe('text');
     expect((block as { text: string }).text).toContain('application/zip');
   });
@@ -147,8 +164,10 @@ describe('toAnthropicMessages', () => {
       },
     ]);
     // The reasoning block is dropped; only the visible answer survives.
-    expect(messages[0]!.content).toHaveLength(1);
-    expect(messages[0]!.content[0]).toMatchObject({ type: 'text', text: 'answer' });
+    const firstMsg = messages[0];
+    assertDefined(firstMsg, 'messages non-empty');
+    expect(firstMsg.content).toHaveLength(1);
+    expect(firstMsg.content[0]).toMatchObject({ type: 'text', text: 'answer' });
   });
 });
 

--- a/packages/plugin-provider-anthropic/src/translate.ts
+++ b/packages/plugin-provider-anthropic/src/translate.ts
@@ -1,5 +1,5 @@
 import type { ContentBlock, ProviderMessage, ToolDef } from '@moxxy/sdk';
-import { zodToJsonSchema } from '@moxxy/sdk';
+import { assertDefined, zodToJsonSchema } from '@moxxy/sdk';
 
 type CacheControl = { type: 'ephemeral' };
 
@@ -234,7 +234,9 @@ export function toAnthropicTools(
     input_schema: t.inputJsonSchema ?? zodToJsonSchema(t.inputSchema),
   })) as AnthropicToolDef[];
   if (opts.cacheLast && out.length > 0) {
-    out[out.length - 1]!.cache_control = { type: 'ephemeral' };
+    const last = out[out.length - 1];
+    assertDefined(last, 'out is non-empty (length > 0 checked above)');
+    last.cache_control = { type: 'ephemeral' };
   }
   return out;
 }

--- a/packages/plugin-provider-claude-code/src/login.test.ts
+++ b/packages/plugin-provider-claude-code/src/login.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { storeTokenSet, type OAuthVault } from '@moxxy/plugin-oauth';
 import type { ProviderAuthContext } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { CLAUDE_CLIENT_ID, CLAUDE_TOKEN_URL } from './constants.js';
 import {
   claudeLogin,
@@ -128,14 +129,16 @@ describe('claudeLogin', () => {
     const res = await claudeLogin(makeCtx(vault, ['', 'AUTHCODE']));
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]!.url).toBe(CLAUDE_TOKEN_URL);
-    expect(calls[0]!.body).toMatchObject({
+    const call0 = calls[0];
+    assertDefined(call0, 'one call asserted above');
+    expect(call0.url).toBe(CLAUDE_TOKEN_URL);
+    expect(call0.body).toMatchObject({
       grant_type: 'authorization_code',
       code: 'AUTHCODE',
       client_id: CLAUDE_CLIENT_ID,
       redirect_uri: 'https://console.anthropic.com/oauth/code/callback',
     });
-    expect(typeof calls[0]!.body.code_verifier).toBe('string');
+    expect(typeof call0.body.code_verifier).toBe('string');
     expect(vault.store.get('oauth/claude-code/access_token')).toBe('access-1');
     expect(vault.store.get('oauth/claude-code/refresh_token')).toBe('refresh-1');
     expect(vault.store.get('oauth/claude-code/extras')).toContain('me@example.com');

--- a/packages/plugin-provider-openai-codex/src/codex/sse-event-handler.test.ts
+++ b/packages/plugin-provider-openai-codex/src/codex/sse-event-handler.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { handleSseEvent } from './sse-event-handler.js';
 import type { PendingFunctionCall, ResponsesSseEvent } from './stream-types.js';
 
@@ -56,10 +57,13 @@ describe('handleSseEvent — hostile-stream bounds', () => {
       );
       if (result.terminal) break;
     }
-    expect(result?.terminal).toBe(true);
-    expect(result?.events?.[0]).toMatchObject({ type: 'error', retryable: false });
+    assertDefined(result, 'loop ran at least once');
+    expect(result.terminal).toBe(true);
+    expect(result.events?.[0]).toMatchObject({ type: 'error', retryable: false });
     // It bailed well before 20 * 2 MiB = 40 MiB accumulated (cap is 16 MiB).
-    expect(pending.get('fc1')!.args.length).toBeLessThanOrEqual(16 * 1024 * 1024);
+    const fc1 = pending.get('fc1');
+    assertDefined(fc1, 'seeded function call is pending');
+    expect(fc1.args.length).toBeLessThanOrEqual(16 * 1024 * 1024);
   });
 
   it('caps the number of concurrently-pending tool calls', () => {
@@ -78,8 +82,9 @@ describe('handleSseEvent — hostile-stream bounds', () => {
       );
       if (result.terminal) break;
     }
-    expect(result?.terminal).toBe(true);
-    expect(result?.events?.[0]).toMatchObject({ type: 'error', retryable: false });
+    assertDefined(result, 'loop ran at least once');
+    expect(result.terminal).toBe(true);
+    expect(result.events?.[0]).toMatchObject({ type: 'error', retryable: false });
     expect(pending.size).toBeLessThanOrEqual(1024);
   });
 });

--- a/packages/plugin-provider-openai-codex/src/codex/sse-event-handler.ts
+++ b/packages/plugin-provider-openai-codex/src/codex/sse-event-handler.ts
@@ -141,8 +141,10 @@ export function handleSseEvent(
   if (type === 'response.completed') {
     const usage = ev.response?.usage;
     const input = usage?.input_tokens ?? 0;
-    const cacheRead = usage?.input_tokens_details?.cached_tokens ?? 0;
-    const incomplete = ev.response?.incomplete_details?.reason;
+    const inputTokenDetails = usage?.input_tokens_details;
+    const cacheRead = inputTokenDetails?.cached_tokens ?? 0;
+    const incompleteDetails = ev.response?.incomplete_details;
+    const incomplete = incompleteDetails?.reason;
     let stopReason: StopReason = 'end_turn';
     if (incomplete === 'max_output_tokens') stopReason = 'max_tokens';
     else if (incomplete === 'stop_sequence') stopReason = 'stop_sequence';

--- a/packages/plugin-provider-openai-codex/src/codex/stream-consumer.test.ts
+++ b/packages/plugin-provider-openai-codex/src/codex/stream-consumer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ProviderEvent } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { consumeResponsesSse } from './stream-consumer.js';
 
 /**
@@ -13,7 +14,9 @@ function streamOf(chunks: ReadonlyArray<string>): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
     pull(controller) {
       if (i < chunks.length) {
-        controller.enqueue(enc.encode(chunks[i]!));
+        const chunk = chunks[i];
+        assertDefined(chunk, 'i < chunks.length checked above');
+        controller.enqueue(enc.encode(chunk));
         i += 1;
       } else {
         controller.close();

--- a/packages/plugin-provider-openai-codex/src/oauth.ts
+++ b/packages/plugin-provider-openai-codex/src/oauth.ts
@@ -6,6 +6,7 @@
  */
 
 import { Buffer } from 'node:buffer';
+import { assertDefined } from '@moxxy/sdk';
 import {
   buildAuthUrl,
   computeCodeChallenge,
@@ -92,7 +93,8 @@ export function parseJwtClaims(jwt: string): Record<string, unknown> | undefined
   if (typeof jwt !== 'string') return undefined;
   const parts = jwt.split('.');
   if (parts.length !== 3) return undefined;
-  const payload = parts[1]!;
+  const payload = parts[1];
+  assertDefined(payload, 'parts.length === 3 checked above');
   // Bound the decode: never allocate/parse an oversized payload segment.
   if (payload.length > MAX_JWT_SEGMENT_CHARS) return undefined;
   try {

--- a/packages/plugin-provider-openai-codex/src/provider.test.ts
+++ b/packages/plugin-provider-openai-codex/src/provider.test.ts
@@ -6,6 +6,7 @@ import { CodexProvider } from './provider.js';
 import { CODEX_RESPONSES_URL } from './oauth.js';
 import type { CodexTokens } from './types.js';
 import type { ProviderEvent, ProviderRequest } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 
 // The refresh path takes a cross-process lockfile under `<moxxy home>/locks`;
 // point MOXXY_HOME at a temp dir so tests never touch the real ~/.moxxy.
@@ -238,16 +239,20 @@ describe('CodexProvider.stream', () => {
 
     // Token endpoint must be hit before the Codex API call.
     expect(calls[0]?.url).toContain('/oauth/token');
-    expect(calls[1]?.url).toBe(CODEX_RESPONSES_URL);
-    expect((calls[1]?.init?.headers as Record<string, string>)['Authorization']).toBe('Bearer NEW_AT');
+    const codexCall = calls[1];
+    assertDefined(codexCall, 'codex API call recorded after the token call');
+    expect(codexCall.url).toBe(CODEX_RESPONSES_URL);
+    expect((codexCall.init?.headers as Record<string, string>)['Authorization']).toBe('Bearer NEW_AT');
 
     // onTokensRefreshed was called BEFORE the codex call went out.
     expect(persisted).toHaveLength(1);
-    expect(persisted[0]!.access).toBe('NEW_AT');
-    expect(persisted[0]!.refresh).toBe('NEW_RT');
+    const persisted0 = persisted[0];
+    assertDefined(persisted0, 'one persisted token set asserted above');
+    expect(persisted0.access).toBe('NEW_AT');
+    expect(persisted0.refresh).toBe('NEW_RT');
     // accountId is preserved from the prior token bundle even though the
     // refresh response doesn't re-issue an id_token.
-    expect(persisted[0]!.accountId).toBe('acct_test');
+    expect(persisted0.accountId).toBe('acct_test');
   });
 
   it('coalesces concurrent in-process refreshes — one token-endpoint call for two streams', async () => {
@@ -339,8 +344,10 @@ describe('CodexProvider.stream', () => {
 
     expect(attempted).toEqual(['RT', 'ROTATED_RT']);
     expect(persisted).toHaveLength(1);
-    expect(persisted[0]!.access).toBe('NEW_AT');
-    expect(persisted[0]!.refresh).toBe('NEW_RT');
+    const persisted0 = persisted[0];
+    assertDefined(persisted0, 'one persisted token set asserted above');
+    expect(persisted0.access).toBe('NEW_AT');
+    expect(persisted0.refresh).toBe('NEW_RT');
   });
 
   it('refreshes and replays once on a 401, then surfaces error on a second 401', async () => {
@@ -372,10 +379,10 @@ describe('CodexProvider.stream', () => {
     const err = events.find((e) => e.type === 'error') as
       | { type: 'error'; message: string; retryable?: boolean }
       | undefined;
-    expect(err).toBeDefined();
-    expect(err!.message).toMatch(/moxxy login openai-codex/);
-    expect(err!.message).toMatch(/re-authenticate/i);
-    expect(err!.retryable).toBe(false);
+    assertDefined(err, 'stream surfaced an error event');
+    expect(err.message).toMatch(/moxxy login openai-codex/);
+    expect(err.message).toMatch(/re-authenticate/i);
+    expect(err.retryable).toBe(false);
   });
 
   it('aborts a stalled request via the internal idle watchdog (no caller signal needed)', async () => {
@@ -414,10 +421,10 @@ describe('CodexProvider.stream', () => {
     });
     const events = await collect(provider.stream(baseRequest()));
     const err = events.find((e) => e.type === 'error') as { message: string } | undefined;
-    expect(err).toBeDefined();
+    assertDefined(err, 'stream surfaced an error event');
     // The message includes only a bounded slice of the body, not all 5 MiB.
-    expect(err!.message.length).toBeLessThan(4096);
-    expect(err!.message).toMatch(/returned 400/);
+    expect(err.message.length).toBeLessThan(4096);
+    expect(err.message).toMatch(/returned 400/);
   });
 
   it('countTokens does not stringify base64 payloads and stays bounded for a large image', async () => {

--- a/packages/plugin-provider-openai/src/provider.test.ts
+++ b/packages/plugin-provider-openai/src/provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { OpenAIProvider } from './provider.js';
 
 function fakeOpenAI(chunks: ReadonlyArray<unknown>): { chat: { completions: { create: () => Promise<AsyncIterable<unknown>> } } } {
@@ -434,9 +435,12 @@ describe('OpenAIProvider.stream', () => {
       events.push(e);
     }
     expect(events.some((e) => e.type === 'error')).toBe(false);
-    expect(captured?.messages?.map((m) => m.role)).toEqual(['system', 'system', 'user']);
-    expect(captured?.messages?.[0]).toMatchObject({ content: 'BASE PROMPT' });
-    expect(captured?.messages?.[1]).toMatchObject({ content: '[memory note] consider consolidating' });
+    assertDefined(captured, 'client captured the request body');
+    const capturedMessages = captured.messages;
+    assertDefined(capturedMessages, 'request has messages');
+    expect(capturedMessages.map((m) => m.role)).toEqual(['system', 'system', 'user']);
+    expect(capturedMessages[0]).toMatchObject({ content: 'BASE PROMPT' });
+    expect(capturedMessages[1]).toMatchObject({ content: '[memory note] consider consolidating' });
   });
 
   it('reports an overridden name + model catalog for runtime-registered vendors', () => {

--- a/packages/plugin-provider-openai/src/provider.ts
+++ b/packages/plugin-provider-openai/src/provider.ts
@@ -6,7 +6,7 @@ import type {
   ProviderRequest,
   StopReason,
 } from '@moxxy/sdk';
-import { estimateTextTokens, toFriendlyError } from '@moxxy/sdk';
+import { assertDefined, estimateTextTokens, toFriendlyError } from '@moxxy/sdk';
 import { toOpenAIMessages, toOpenAITools } from './translate.js';
 
 export interface OpenAIProviderConfig {
@@ -142,7 +142,12 @@ export class OpenAIProvider implements LLMProvider {
     // reordering the conversation.
     if (req.system) {
       let insertAt = 0;
-      while (insertAt < messages.length && messages[insertAt]!.role === 'system') insertAt += 1;
+      while (insertAt < messages.length) {
+        const msg = messages[insertAt];
+        assertDefined(msg, 'insertAt < messages.length');
+        if (msg.role !== 'system') break;
+        insertAt += 1;
+      }
       messages.splice(insertAt, 0, { role: 'system', content: req.system });
     }
     const tools = req.tools && req.tools.length > 0 ? toOpenAITools(req.tools) : undefined;

--- a/packages/plugin-provider-xai/src/index.test.ts
+++ b/packages/plugin-provider-xai/src/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { xaiPlugin, xaiProviderDef, grokModels } from './index.js';
 
 describe('@moxxy/plugin-provider-xai', () => {
@@ -40,8 +41,10 @@ describe('@moxxy/plugin-provider-xai', () => {
     // instead of pre-emptively elided.
     for (const m of grokModels) {
       expect(typeof m.maxOutputTokens, `${m.id} maxOutputTokens`).toBe('number');
-      expect(m.maxOutputTokens!, `${m.id} maxOutputTokens > 0`).toBeGreaterThan(0);
-      expect(m.maxOutputTokens!, `${m.id} maxOutputTokens <= contextWindow`).toBeLessThanOrEqual(m.contextWindow);
+      const maxOutputTokens = m.maxOutputTokens;
+      assertDefined(maxOutputTokens, `${m.id} maxOutputTokens is a number (asserted above)`);
+      expect(maxOutputTokens, `${m.id} maxOutputTokens > 0`).toBeGreaterThan(0);
+      expect(maxOutputTokens, `${m.id} maxOutputTokens <= contextWindow`).toBeLessThanOrEqual(m.contextWindow);
     }
   });
 

--- a/packages/plugin-stt-whisper-codex/src/index.test.ts
+++ b/packages/plugin-stt-whisper-codex/src/index.test.ts
@@ -19,6 +19,7 @@ import {
   MOXXY_PCM16_24KHZ_MIME,
   pcm16MonoToWav,
 } from './index.js';
+import { assertDefined } from '@moxxy/sdk';
 
 interface CapturedRequest {
   readonly req: IncomingMessage;
@@ -95,8 +96,9 @@ describe('CodexOAuthTranscriber', () => {
       });
       const def = plugin.transcribers?.[0];
       expect(def?.name).toBe('openai-codex-transcribe');
+      assertDefined(def, 'buildWhisperCodexPlugin always registers a transcriber');
 
-      const transcriber = def!.createClient({});
+      const transcriber = def.createClient({});
       const result = await transcriber.transcribe(new Uint8Array([1, 2, 3, 4]), {
         mimeType: 'audio/wav',
       });
@@ -336,9 +338,10 @@ describe('buildWhisperCodexPlugin createClient config merge', () => {
         sessionIdProvider: () => 'host-session',
       });
       const def = plugin.transcribers?.[0];
+      assertDefined(def, 'buildWhisperCodexPlugin always registers a transcriber');
 
       // Untrusted registry config attempts to shadow host-wired dependencies.
-      const transcriber = def!.createClient({
+      const transcriber = def.createClient({
         vault: evilVault,
         fetch: evilFetch,
       });
@@ -378,7 +381,8 @@ describe('buildWhisperCodexPlugin createClient config merge', () => {
         sessionIdProvider: () => 'host-session',
       });
       const def = plugin.transcribers?.[0];
-      const transcriber = def!.createClient({
+      assertDefined(def, 'buildWhisperCodexPlugin always registers a transcriber');
+      const transcriber = def.createClient({
         baseUrl: configServer.baseUrl,
         sessionIdProvider: () => 'config-session',
       });
@@ -563,7 +567,8 @@ describe('CodexOAuthTranscriber hardening', () => {
       expect((thrown as { code?: string }).code).toBe('PROVIDER_BAD_REQUEST');
       const cause = (thrown as { cause?: { message?: string } }).cause;
       // The full 50KB body must NOT be embedded verbatim in the cause.
-      expect(cause?.message?.length ?? 0).toBeLessThanOrEqual(500);
+      const causeMessage = cause?.message;
+      expect(causeMessage?.length ?? 0).toBeLessThanOrEqual(500);
       expect(cause?.message ?? '').not.toContain(secret);
     } finally {
       await server.close();

--- a/packages/plugin-stt-whisper/src/audio.ts
+++ b/packages/plugin-stt-whisper/src/audio.ts
@@ -6,7 +6,7 @@
  * them here keeps the wrapper plugins thin.
  */
 
-import { MOXXY_PCM16_24KHZ_MIME } from '@moxxy/sdk';
+import { assertDefined, MOXXY_PCM16_24KHZ_MIME } from '@moxxy/sdk';
 
 /** A custom MIME tag used by the TUI voice recorder to flag raw PCM16
  *  mono @ 24kHz bytes (ffmpeg's `-f s16le` output) so the transcriber
@@ -75,7 +75,9 @@ export function normalizeWhisperUpload(
   // Guard the runtime type so `.toLowerCase()` can't throw on hostile input —
   // anything non-string degrades to the default rather than crashing the path.
   const rawMime = typeof mimeType === 'string' ? mimeType : '';
-  const mt = (rawMime || 'audio/wav').toLowerCase().split(';')[0]!.trim();
+  const firstSegment = (rawMime || 'audio/wav').toLowerCase().split(';')[0];
+  assertDefined(firstSegment, 'String.split always yields at least one element');
+  const mt = firstSegment.trim();
   if (mt === MOXXY_PCM16_24KHZ_MIME) {
     return {
       bytes: pcm16MonoToWav(bytes, 24_000),

--- a/packages/plugin-stt-whisper/src/whisper.test.ts
+++ b/packages/plugin-stt-whisper/src/whisper.test.ts
@@ -4,6 +4,7 @@ import { APIError, APIConnectionError, APIUserAbortError } from 'openai';
 import { WhisperTranscriber } from './whisper.js';
 import { buildWhisperPlugin } from './index.js';
 import { MOXXY_PCM16_24KHZ_MIME, normalizeWhisperUpload, pcm16MonoToWav } from './audio.js';
+import { assertDefined } from '@moxxy/sdk';
 
 const fakeOpenAI = (impl: (req: unknown) => unknown): OpenAI =>
   ({
@@ -52,7 +53,9 @@ describe('WhisperTranscriber', () => {
     const client = { audio: { transcriptions: { create } } } as unknown as OpenAI;
     const t = new WhisperTranscriber({ client, language: 'pl' });
     await t.transcribe(new Uint8Array(), { mimeType: 'audio/ogg', prompt: 'jargon-list' });
-    const req = create.mock.calls[0]![0] as { language: string; prompt: string; response_format: string };
+    const call = create.mock.calls[0];
+    assertDefined(call, 'transcribe invokes the OpenAI create() exactly once');
+    const req = call[0] as { language: string; prompt: string; response_format: string };
     expect(req.language).toBe('pl');
     expect(req.prompt).toBe('jargon-list');
     expect(req.response_format).toBe('verbose_json');
@@ -63,7 +66,9 @@ describe('WhisperTranscriber', () => {
     const client = { audio: { transcriptions: { create } } } as unknown as OpenAI;
     const t = new WhisperTranscriber({ client, language: 'pl' });
     await t.transcribe(new Uint8Array(), { language: 'en' });
-    const req = create.mock.calls[0]![0] as { language: string };
+    const call = create.mock.calls[0];
+    assertDefined(call, 'transcribe invokes the OpenAI create() exactly once');
+    const req = call[0] as { language: string };
     expect(req.language).toBe('en');
   });
 
@@ -73,14 +78,19 @@ describe('WhisperTranscriber', () => {
     const t = new WhisperTranscriber({ client, model: 'gpt-4o-transcribe' });
     const out = await t.transcribe(new Uint8Array(), { mimeType: 'audio/wav' });
     expect(out.text).toBe('plain');
-    const req = create.mock.calls[0]![0] as { response_format?: string };
+    const call = create.mock.calls[0];
+    assertDefined(call, 'transcribe invokes the OpenAI create() exactly once');
+    const req = call[0] as { response_format?: string };
     expect(req.response_format).toBeUndefined();
   });
 
   it('plugin registers a transcriber whose createClient yields the right name', () => {
     const plugin = buildWhisperPlugin({});
     expect(plugin.transcribers).toHaveLength(1);
-    const def = plugin.transcribers![0]!;
+    const transcribers = plugin.transcribers;
+    assertDefined(transcribers, 'buildWhisperPlugin always registers transcribers');
+    const def = transcribers[0];
+    assertDefined(def, 'the plugin registers at least one transcriber');
     expect(def.name).toBe('openai-whisper-1');
     expect(def.displayName).toBe('OpenAI whisper-1');
     const inst = def.createClient({ apiKey: 'sk-test' });
@@ -95,7 +105,9 @@ describe('WhisperTranscriber', () => {
     const raw = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0]);
     await t.transcribe(raw, { mimeType: MOXXY_PCM16_24KHZ_MIME });
 
-    const req = create.mock.calls[0]![0] as { file: File };
+    const call = create.mock.calls[0];
+    assertDefined(call, 'transcribe invokes the OpenAI create() exactly once');
+    const req = call[0] as { file: File };
     expect(req.file.type).toBe('audio/wav');
     const header = new Uint8Array(await req.file.arrayBuffer());
     const ascii = (s: number, e: number): string =>
@@ -108,7 +120,11 @@ describe('WhisperTranscriber', () => {
 
   it('plugin honors a non-default model name', () => {
     const plugin = buildWhisperPlugin({ model: 'gpt-4o-mini-transcribe' });
-    expect(plugin.transcribers![0]!.name).toBe('openai-gpt-4o-mini-transcribe');
+    const transcribers = plugin.transcribers;
+    assertDefined(transcribers, 'buildWhisperPlugin always registers transcribers');
+    const def = transcribers[0];
+    assertDefined(def, 'the plugin registers at least one transcriber');
+    expect(def.name).toBe('openai-gpt-4o-mini-transcribe');
   });
 
   it('throws PROVIDER_UNKNOWN_RESPONSE when verbose_json lacks a string text', async () => {
@@ -180,7 +196,9 @@ describe('WhisperTranscriber', () => {
       mimeType: 123 as unknown as string,
     });
     expect(result.text).toBe('ok');
-    const req = create.mock.calls[0]![0] as { file: File };
+    const call = create.mock.calls[0];
+    assertDefined(call, 'transcribe invokes the OpenAI create() exactly once');
+    const req = call[0] as { file: File };
     // Defaults to the audio/wav fallback filename rather than crashing.
     expect(req.file.name).toBe('audio.wav');
   });

--- a/packages/plugin-terminal/src/index.test.ts
+++ b/packages/plugin-terminal/src/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { terminalPlugin } from './index.js';
 import { buildTerminalSurface, closeAllTerminals, getSharedTerminal } from './terminal.js';
 import type { TerminalProcess } from './pty.js';
+import { assertDefined } from '@moxxy/sdk';
 
 describe('plugin-terminal', () => {
   it('contributes a terminal surface and a terminal tool', () => {
@@ -12,12 +13,13 @@ describe('plugin-terminal', () => {
   it('terminal tool validates its input schema', () => {
     const tool = terminalPlugin.tools?.find((t) => t.name === 'terminal');
     expect(tool).toBeDefined();
+    assertDefined(tool, 'terminalPlugin always contributes a "terminal" tool');
     // A command is required; an empty object is rejected.
-    expect(tool!.inputSchema.safeParse({ command: 'ls -la' }).success).toBe(true);
-    expect(tool!.inputSchema.safeParse({}).success).toBe(false);
+    expect(tool.inputSchema.safeParse({ command: 'ls -la' }).success).toBe(true);
+    expect(tool.inputSchema.safeParse({}).success).toBe(false);
     // timeoutMs is bounded.
-    expect(tool!.inputSchema.safeParse({ command: 'x', timeoutMs: 5000 }).success).toBe(true);
-    expect(tool!.inputSchema.safeParse({ command: 'x', timeoutMs: -1 }).success).toBe(false);
+    expect(tool.inputSchema.safeParse({ command: 'x', timeoutMs: 5000 }).success).toBe(true);
+    expect(tool.inputSchema.safeParse({ command: 'x', timeoutMs: -1 }).success).toBe(false);
   });
 
   it('getSharedTerminal does not spawn a duplicate PTY under a concurrent create', async () => {

--- a/packages/plugin-terminal/src/terminal.ts
+++ b/packages/plugin-terminal/src/terminal.ts
@@ -142,7 +142,8 @@ export function buildTerminalSurface() {
             // A viewer/relay sending a wrong-shaped message (field rename,
             // numeric data, protocol skew) gets the keystroke silently dropped.
             // Log it so the "terminal ignores my input" symptom is diagnosable.
-            ctx.logger?.debug?.('terminal surface dropped unrecognized input', { type: msg.type });
+            const logger = ctx.logger;
+            if (logger) logger.debug?.('terminal surface dropped unrecognized input', { type: msg.type });
           }
         },
         resize: (size) => {
@@ -154,7 +155,8 @@ export function buildTerminalSurface() {
           if (isValidDimension(size.cols) && isValidDimension(size.rows)) {
             proc.resize(size.cols as number, size.rows as number);
           } else {
-            ctx.logger?.debug?.('terminal surface dropped malformed resize', { size });
+            const logger = ctx.logger;
+            if (logger) logger.debug?.('terminal surface dropped malformed resize', { size });
           }
         },
         close: () => {

--- a/packages/plugin-view/src/discovery.test.ts
+++ b/packages/plugin-view/src/discovery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ServiceRegistry } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { viewPlugin } from './index.js';
 
 /**
@@ -22,7 +23,11 @@ describe('viewPlugin (discovery-loadable)', () => {
           : undefined,
     );
     const services = { get, register: () => {}, require: () => undefined, has: () => true } as unknown as ServiceRegistry;
-    viewPlugin.hooks!.onInit!({ services } as never);
+    const hooks = viewPlugin.hooks;
+    assertDefined(hooks, 'plugin declares hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'plugin declares onInit');
+    onInit({ services } as never);
     expect(get).toHaveBeenCalledWith('viewRenderers');
     expect(get).toHaveBeenCalledWith('viewSurface');
   });

--- a/packages/plugin-view/src/index.test.ts
+++ b/packages/plugin-view/src/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ToolContext, ToolDef, ViewNode, ViewParseResult, ViewRendererDef } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { defaultViewRenderer } from '@moxxy/core';
 import { buildViewPlugin, type PresentViewResult } from './index.js';
 
@@ -54,7 +55,9 @@ describe('present_view tool', () => {
   it('returns errors for a bad spec without throwing', () => {
     const r = call(`<view><script>x</script></view>`);
     expect(r.ok).toBe(false);
-    expect(r.errors?.[0]?.message).toMatch(/unknown tag/);
+    const err = r.errors?.[0];
+    assertDefined(err, 'a failed parse reports at least one error');
+    expect(err.message).toMatch(/unknown tag/);
   });
 
   it('surfaces the url + viewId when a surface is attached', () => {
@@ -75,7 +78,9 @@ describe('present_view tool', () => {
     const t = toolOf(buildViewPlugin({ getRenderer: () => null }));
     const r = t.handler({ spec: `<view><text>hi</text></view>` }, ctx) as PresentViewResult;
     expect(r.ok).toBe(false);
-    expect(r.errors?.[0]?.message).toMatch(/no active view renderer/);
+    const err = r.errors?.[0];
+    assertDefined(err, 'a failed parse reports at least one error');
+    expect(err.message).toMatch(/no active view renderer/);
   });
 
   it('rejects an over-large AST (node-count ceiling) without serializing it', () => {
@@ -86,19 +91,22 @@ describe('present_view tool', () => {
     expect(r.ok).toBe(false);
     expect(r.rendered).toBe(false);
     expect(r.ast).toBeUndefined();
-    expect(r.errors?.[0]?.message).toMatch(/view too large/);
+    const err = r.errors?.[0];
+    assertDefined(err, 'a failed parse reports at least one error');
+    expect(err.message).toMatch(/view too large/);
   });
 
   it('does not throw (no stack overflow) on a pathologically deep AST', () => {
     // Deeper than any recursion limit; iterative counting + node cap must turn
     // this into a structured error, never a RangeError out of the handler.
     const t = toolOf(buildViewPlugin({ getRenderer: () => fixedRenderer(deepChain(200_000)) }));
-    let r: PresentViewResult;
+    let r: PresentViewResult | undefined;
     expect(() => {
       r = t.handler({ spec: '<view/>' }, ctx) as PresentViewResult;
     }).not.toThrow();
-    expect(r!.ok).toBe(false);
-    expect(r!.ast).toBeUndefined();
+    assertDefined(r, 'handler assigned r inside the non-throwing closure');
+    expect(r.ok).toBe(false);
+    expect(r.ast).toBeUndefined();
   });
 
   it('accepts an AST exactly at the ceiling', () => {
@@ -170,13 +178,16 @@ describe('present_view tool', () => {
       validate: () => [],
     };
     const t = toolOf(buildViewPlugin({ getRenderer: () => throwing }));
-    let r: PresentViewResult;
+    let r: PresentViewResult | undefined;
     expect(() => {
       r = t.handler({ spec: '<view/>' }, ctx) as PresentViewResult;
     }).not.toThrow();
-    expect(r!.ok).toBe(false);
-    expect(r!.rendered).toBe(false);
-    expect(r!.errors?.[0]?.message).toMatch(/renderer exploded/);
+    assertDefined(r, 'handler assigned r inside the non-throwing closure');
+    expect(r.ok).toBe(false);
+    expect(r.rendered).toBe(false);
+    const err = r.errors?.[0];
+    assertDefined(err, 'a failed parse reports at least one error');
+    expect(err.message).toMatch(/renderer exploded/);
   });
 
   it('rejects a malformed AST (missing root) with an honest message', () => {
@@ -189,13 +200,16 @@ describe('present_view tool', () => {
       validate: () => [],
     };
     const t = toolOf(buildViewPlugin({ getRenderer: () => malformed }));
-    let r: PresentViewResult;
+    let r: PresentViewResult | undefined;
     expect(() => {
       r = t.handler({ spec: '<view/>' }, ctx) as PresentViewResult;
     }).not.toThrow();
-    expect(r!.ok).toBe(false);
-    expect(r!.ast).toBeUndefined();
-    expect(r!.errors?.[0]?.message).toMatch(/malformed AST/);
+    assertDefined(r, 'handler assigned r inside the non-throwing closure');
+    expect(r.ok).toBe(false);
+    expect(r.ast).toBeUndefined();
+    const err = r.errors?.[0];
+    assertDefined(err, 'a failed parse reports at least one error');
+    expect(err.message).toMatch(/malformed AST/);
   });
 
   it('degrades when a custom renderer reports a failure with non-iterable errors', () => {
@@ -208,12 +222,15 @@ describe('present_view tool', () => {
       validate: () => [],
     };
     const t = toolOf(buildViewPlugin({ getRenderer: () => bad }));
-    let r: PresentViewResult;
+    let r: PresentViewResult | undefined;
     expect(() => {
       r = t.handler({ spec: '<view/>' }, ctx) as PresentViewResult;
     }).not.toThrow();
-    expect(r!.ok).toBe(false);
-    expect(r!.errors?.[0]?.message).toMatch(/parse failure/);
+    assertDefined(r, 'handler assigned r inside the non-throwing closure');
+    expect(r.ok).toBe(false);
+    const err = r.errors?.[0];
+    assertDefined(err, 'a failed parse reports at least one error');
+    expect(err.message).toMatch(/parse failure/);
   });
 
   it('short-circuits when the turn is already aborted', () => {
@@ -224,6 +241,8 @@ describe('present_view tool', () => {
     const r = t.handler({ spec: '<view><text>hi</text></view>' }, abortedCtx) as PresentViewResult;
     expect(r.ok).toBe(false);
     expect(r.rendered).toBe(false);
-    expect(r.errors?.[0]?.message).toMatch(/aborted/);
+    const err = r.errors?.[0];
+    assertDefined(err, 'an aborted call reports at least one error');
+    expect(err.message).toMatch(/aborted/);
   });
 });

--- a/packages/plugin-view/src/index.ts
+++ b/packages/plugin-view/src/index.ts
@@ -1,6 +1,7 @@
 import {
   defineTool,
   definePlugin,
+  assertDefined,
   z,
   type LifecycleHooks,
   type Plugin,
@@ -31,7 +32,8 @@ function countNodesBounded(root: ViewNode, limit: number): number {
   const stack: ViewNode[] = [root];
   let count = 0;
   while (stack.length > 0) {
-    const node = stack.pop()!;
+    const node = stack.pop();
+    assertDefined(node, 'stack is non-empty inside the while (stack.length > 0) loop');
     count++;
     if (count > limit) return count;
     if (node.kind === 'element') {
@@ -95,7 +97,8 @@ export function buildViewPlugin(opts: BuildViewPluginOptions, hooks?: LifecycleH
       // Short-circuit a cancelled turn before the heaviest work (parse + count
       // + AST serialization on a near-20k spec). ctx is optional only so unit
       // tests can call the handler bare; the registry always supplies it.
-      if (ctx?.signal?.aborted) {
+      const signal = ctx?.signal;
+      if (signal?.aborted) {
         return { ok: false, rendered: false, errors: [{ message: 'aborted' }] };
       }
       const renderer = opts.getRenderer();

--- a/packages/plugin-view/src/present-view.test.ts
+++ b/packages/plugin-view/src/present-view.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ToolContext, ToolDef } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { defaultViewRenderer } from '@moxxy/core';
 import { buildViewPlugin, type PresentViewResult, type ViewSurface } from './index.js';
 
@@ -50,10 +51,15 @@ describe('present_view — output', () => {
 
   it('reports no active renderer', () => {
     const plugin = buildViewPlugin({ getRenderer: () => null });
-    const t = plugin.tools!.find((x) => x.name === 'present_view')!;
+    const tools = plugin.tools;
+    assertDefined(tools, 'plugin declares tools');
+    const t = tools.find((x) => x.name === 'present_view');
+    assertDefined(t, 'plugin registers present_view');
     const r = run(t, '<view/>');
     expect(r.ok).toBe(false);
-    expect(r.errors?.[0]?.message).toMatch(/no active view renderer/);
+    const err = r.errors?.[0];
+    assertDefined(err, 'a failed parse reports at least one error');
+    expect(err.message).toMatch(/no active view renderer/);
   });
 
   it('without a surface: rendered=false, no url/viewId', () => {

--- a/packages/plugin-voice-admin/src/discovery.test.ts
+++ b/packages/plugin-voice-admin/src/discovery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ServiceRegistry } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { voiceAdminPlugin } from './index.js';
 
 function fakeSynths(active: string | null, names: string[]) {
@@ -36,13 +37,21 @@ describe('voiceAdminPlugin (discovery-loadable)', () => {
       has: () => true,
       register: () => {},
     } as unknown as ServiceRegistry;
-    voiceAdminPlugin.hooks!.onInit!({ services } as never);
+    const hooks = voiceAdminPlugin.hooks;
+    assertDefined(hooks, 'plugin declares hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'plugin declares onInit');
+    onInit({ services } as never);
 
-    const listVoices = voiceAdminPlugin.tools!.find((t) => t.name === 'list_voices')!;
+    const tools = voiceAdminPlugin.tools;
+    assertDefined(tools, 'plugin declares tools');
+    const listVoices = tools.find((t) => t.name === 'list_voices');
+    assertDefined(listVoices, 'plugin registers list_voices');
     const listed = await listVoices.handler({} as never, {} as never);
     expect(listed).toEqual({ active: 'eleven', available: ['system', 'eleven', 'openai'] });
 
-    const setVoice = voiceAdminPlugin.tools!.find((t) => t.name === 'set_voice')!;
+    const setVoice = tools.find((t) => t.name === 'set_voice');
+    assertDefined(setVoice, 'plugin registers set_voice');
     const set = await setVoice.handler({ synthesizer: 'openai' } as never, {} as never);
     expect(set).toEqual({ active: 'openai' });
     expect(synths.getActiveName()).toBe('openai');

--- a/packages/plugin-voice-admin/src/index.test.ts
+++ b/packages/plugin-voice-admin/src/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Session, silentLogger } from '@moxxy/core';
+import { assertDefined } from '@moxxy/sdk';
 import { buildVoiceAdminPlugin } from './index.js';
 
 /**
@@ -9,10 +10,11 @@ import { buildVoiceAdminPlugin } from './index.js';
 function tools(session: Session) {
   const plugin = buildVoiceAdminPlugin(session);
   const byName = new Map((plugin.tools ?? []).map((t) => [t.name, t]));
-  return {
-    listVoices: byName.get('list_voices')!,
-    setVoice: byName.get('set_voice')!,
-  };
+  const listVoices = byName.get('list_voices');
+  assertDefined(listVoices, 'plugin registers list_voices');
+  const setVoice = byName.get('set_voice');
+  assertDefined(setVoice, 'plugin registers set_voice');
+  return { listVoices, setVoice };
 }
 
 const ctx = { sessionId: 's', turnId: 't' } as never;


### PR DESCRIPTION
Part of the repo-wide assert-sweep ("Guard, don't chain"). Providers group: replaces every expression non-null assertion (`x!`) and every depth-≥2 optional chain with narrowing guards, using `invariant`/`assertDefined` from `@moxxy/sdk`.

## Scope (16 packages)

`plugin-provider-anthropic`, `plugin-provider-claude-code`, `plugin-provider-openai`, `plugin-provider-openai-codex`, `plugin-provider-xai`, `plugin-embeddings-openai`, `plugin-embeddings-transformers`, `plugin-memory`, `plugin-mcp`, `plugin-browser`, `plugin-view`, `plugin-terminal`, `plugin-collab`, `plugin-stt-whisper`, `plugin-stt-whisper-codex`, `plugin-voice-admin`

## Counts (grep-enumerated sites, before → after)

Non-null assertions (`x!` in expressions): 174 lines → **0**
| package | before | | package | before |
|---|---|---|---|---|
| provider-anthropic | 18 | | mcp | 39 |
| provider-claude-code | 3 | | browser | 18 |
| provider-openai | 1 | | view | 13 |
| provider-openai-codex | 13 | | terminal | 4 |
| provider-xai | 2 | | collab | 12 |
| embeddings-openai | 1 | | stt-whisper | 3 |
| embeddings-transformers | 1 | | stt-whisper-codex | 3 |
| memory | 38 | | voice-admin | 5 |

Plus ~9 sites the line-based grep missed (ternary `m ? m[1]! : null`, spread `{ ...map.get(id)! }`, `mock.calls[0]![0]`), found by file-skim and broadened greps — also fixed.

Deep optional chains (depth ≥2): 48 → **5 kept**, all verified grep false positives — two *independent* single-level `?.` on one line, not chains (`plugin-memory/store/io.test.ts:98`, `plugin-browser/browser-session.ts:398`, `plugin-view/index.ts:124`, `plugin-stt-whisper-codex/transcriber.ts:141,151`).

Definite-assignment declarations kept (out of scope per rule): 1 — `let release!: () => void` in `plugin-terminal/src/index.test.ts`; zero class fields.

## Semantics notes

**Preserved silent skips (normal-absence paths, NOT converted to throws):**
- Codex SSE parser reads of `response?.usage` / `incomplete_details` (heartbeats / partial payloads keep their `?? 0`/undefined fallbacks; narrowing locals only).
- Optional lifecycle hooks (`hooks?.onInit?.`, `onBeforeProviderCall?.`) in plugin-memory/plugin-mcp composition.
- Best-effort logging (`log?.warn?.`, `ctx.logger?.debug?.`) and stream-teardown cleanup (`s.controller?.abort?.()` in the Anthropic provider finally block).
- `plugin-browser/html-extract.ts` selector extraction: `match ? match[n]! : null` → `match?.[n] ?? null` (empty-string captures still returned).

**Converted to loud throws (`assertDefined`/`invariant`) — impossible-by-construction only:**
- Bounds-checked index reads (`while (i < arr.length)`, `split(';')[0]`, non-empty-checked `out[out.length - 1]`).
- Existence-checked map reads (`runtimes.has(name)` → `get(name)`, `m in map` → `map[m]`, collab order-arrays holding only live map keys).
- Regex non-optional capture groups inside an `if (match)` / length-3 `jwt.split('.')` guard.
- Test files: test-controlled fixtures (`calls[0]`, `plugin.tools`, found tools) assert-then-access with intent-identical failure modes.

No renames, no reordering, no drive-by refactors. One changeset with patch bumps for all 16 packages.

## Gate (from the worktree root, each exit code checked directly)

- `pnpm install` → 0
- `pnpm build` → 0 (85/85 tasks)
- `pnpm typecheck` → 0
- `pnpm lint` → 0
- `pnpm test` → 0 (no flakes, first run)
- `pnpm check:deps` → 0

Changed files scanned for NUL/control bytes (per-file `grep -P`, `tr`-based NUL count, and `file(1)`) — all clean text.