### PR TITLE
refactor(automation): replace non-null assertions and deep optional chains with guards

### DIFF
--- a/.changeset/assert-sweep-automation.md
+++ b/.changeset/assert-sweep-automation.md
@@ -1,0 +1,9 @@
+---
+'@moxxy/plugin-workflows': patch
+'@moxxy/workflows-builder': patch
+'@moxxy/plugin-scheduler': patch
+'@moxxy/plugin-webhooks': patch
+'@moxxy/plugin-usage-stats': patch
+---
+
+Replace non-null assertions and depth-2+ optional chains with guard clauses per the "Guard, don't chain" rule: `assertDefined`/`invariant` from `@moxxy/sdk` where absence is impossible by construction, narrow-once guards preserving silent paths where absence is a normal runtime path (optional loggers, optional layout, cache lookups). No behavior change on normal-absence paths.

--- a/packages/plugin-scheduler/src/cron.test.ts
+++ b/packages/plugin-scheduler/src/cron.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { isValidCron, isValidTimeZone, nextFireTime, parseCron } from './cron.js';
 
 describe('parseCron', () => {
@@ -57,30 +58,34 @@ describe('nextFireTime', () => {
     const after = new Date(2026, 4, 11, 8, 30, 0);
     const next = nextFireTime('0 9 * * *', after);
     expect(next).not.toBeNull();
-    expect(next!.getHours()).toBe(9);
-    expect(next!.getMinutes()).toBe(0);
-    expect(next!.getDate()).toBe(11);
+    assertDefined(next, 'nextFireTime resolves to a fire time');
+    expect(next.getHours()).toBe(9);
+    expect(next.getMinutes()).toBe(0);
+    expect(next.getDate()).toBe(11);
   });
 
   it('wraps to next day when already past', () => {
     const after = new Date(2026, 4, 11, 10, 0, 0);
     const next = nextFireTime('0 9 * * *', after);
-    expect(next!.getDate()).toBe(12);
-    expect(next!.getHours()).toBe(9);
+    assertDefined(next, 'nextFireTime resolves to a fire time');
+    expect(next.getDate()).toBe(12);
+    expect(next.getHours()).toBe(9);
   });
 
   it('every-15-min fires at the next quarter', () => {
     const after = new Date(2026, 4, 11, 10, 7, 0);
     const next = nextFireTime('*/15 * * * *', after);
-    expect(next!.getHours()).toBe(10);
-    expect(next!.getMinutes()).toBe(15);
+    assertDefined(next, 'nextFireTime resolves to a fire time');
+    expect(next.getHours()).toBe(10);
+    expect(next.getMinutes()).toBe(15);
   });
 
   it('every hour at minute 30 finds the next half-hour', () => {
     const after = new Date(2026, 4, 11, 10, 45, 0);
     const next = nextFireTime('30 * * * *', after);
-    expect(next!.getHours()).toBe(11);
-    expect(next!.getMinutes()).toBe(30);
+    assertDefined(next, 'nextFireTime resolves to a fire time');
+    expect(next.getHours()).toBe(11);
+    expect(next.getMinutes()).toBe(30);
   });
 
   it('returns null for impossible expressions', () => {
@@ -94,8 +99,9 @@ describe('nextFireTime', () => {
     // 2026-05-11 is a Monday. "9 AM on Sundays" -> next Sunday 2026-05-17
     const after = new Date(2026, 4, 11, 8, 0, 0);
     const next = nextFireTime('0 9 * * 0', after);
-    expect(next!.getDay()).toBe(0);
-    expect(next!.getDate()).toBe(17);
+    assertDefined(next, 'nextFireTime resolves to a fire time');
+    expect(next.getDay()).toBe(0);
+    expect(next.getDate()).toBe(17);
   });
 
   // u103-4: jumpToNextMonth must walk across a year boundary. From mid-year,
@@ -104,20 +110,22 @@ describe('nextFireTime', () => {
     const after = new Date(2026, 5, 15, 12, 0, 0); // mid-June 2026
     const next = nextFireTime('0 0 1 1 *', after);
     expect(next).not.toBeNull();
-    expect(next!.getFullYear()).toBe(2027);
-    expect(next!.getMonth()).toBe(0); // January
-    expect(next!.getDate()).toBe(1);
-    expect(next!.getHours()).toBe(0);
-    expect(next!.getMinutes()).toBe(0);
+    assertDefined(next, 'nextFireTime resolves to a fire time');
+    expect(next.getFullYear()).toBe(2027);
+    expect(next.getMonth()).toBe(0); // January
+    expect(next.getDate()).toBe(1);
+    expect(next.getHours()).toBe(0);
+    expect(next.getMinutes()).toBe(0);
   });
 
   it('jumps to the next valid month within the same year', () => {
     // From January, "midnight on the 1st of March" -> 2026-03-01.
     const after = new Date(2026, 0, 10, 0, 0, 0); // 2026-01-10
     const next = nextFireTime('0 0 1 3 *', after);
-    expect(next!.getFullYear()).toBe(2026);
-    expect(next!.getMonth()).toBe(2); // March
-    expect(next!.getDate()).toBe(1);
+    assertDefined(next, 'nextFireTime resolves to a fire time');
+    expect(next.getFullYear()).toBe(2026);
+    expect(next.getMonth()).toBe(2); // March
+    expect(next.getDate()).toBe(1);
   });
 
   // u103-4: vixie-cron OR semantics — when BOTH DOM and DOW are restricted,
@@ -128,8 +136,9 @@ describe('nextFireTime', () => {
     const after = new Date(2026, 5, 6, 0, 0, 0); // Sat 2026-06-06
     const next = nextFireTime('0 0 13 * 5', after);
     expect(next).not.toBeNull();
-    expect(next!.getDate()).toBe(12);
-    expect(next!.getDay()).toBe(5); // Friday
+    assertDefined(next, 'nextFireTime resolves to a fire time');
+    expect(next.getDate()).toBe(12);
+    expect(next.getDay()).toBe(5); // Friday
   });
 
   it('matches the 13th via the DOM arm even when it is not a Friday', () => {
@@ -138,8 +147,9 @@ describe('nextFireTime', () => {
     const after = new Date(2026, 5, 12, 0, 1, 0); // just past midnight Fri 06-12
     const next = nextFireTime('0 0 13 * 5', after);
     expect(next).not.toBeNull();
-    expect(next!.getDate()).toBe(13);
-    expect(next!.getDay()).toBe(6); // Saturday — matched purely via DOM
+    assertDefined(next, 'nextFireTime resolves to a fire time');
+    expect(next.getDate()).toBe(13);
+    expect(next.getDay()).toBe(6); // Saturday — matched purely via DOM
   });
 
   // Regression for u103-1: with an explicit IANA zone the cursor walk must
@@ -163,7 +173,8 @@ describe('nextFireTime', () => {
     const after = new Date(Date.UTC(2026, 4, 11, 0, 0, 0));
     const next = nextFireTime('0 9 * * *', after, 'America/New_York');
     expect(next).not.toBeNull();
-    const wc = wallClockInZone(next!, 'America/New_York');
+    assertDefined(next, 'nextFireTime resolves to a fire time');
+    const wc = wallClockInZone(next, 'America/New_York');
     expect(wc.hour).toBe(9);
     expect(wc.minute).toBe(0);
   });
@@ -172,7 +183,8 @@ describe('nextFireTime', () => {
     const after = new Date(Date.UTC(2026, 4, 11, 0, 0, 0));
     const next = nextFireTime('0 9 * * *', after, 'Asia/Tokyo');
     expect(next).not.toBeNull();
-    const wc = wallClockInZone(next!, 'Asia/Tokyo');
+    assertDefined(next, 'nextFireTime resolves to a fire time');
+    const wc = wallClockInZone(next, 'Asia/Tokyo');
     expect(wc.hour).toBe(9);
     expect(wc.minute).toBe(0);
   });
@@ -184,7 +196,8 @@ describe('nextFireTime', () => {
     const after = new Date(Date.UTC(2026, 2, 8, 0, 0, 0));
     const next = nextFireTime('30 2 * * *', after, 'America/New_York');
     expect(next).not.toBeNull();
-    const wc = wallClockInZone(next!, 'America/New_York');
+    assertDefined(next, 'nextFireTime resolves to a fire time');
+    const wc = wallClockInZone(next, 'America/New_York');
     expect(wc.hour).toBe(2);
     expect(wc.minute).toBe(30);
   });
@@ -211,7 +224,8 @@ describe('nextFireTime', () => {
     // Jan 31 exists — must resolve, not be short-circuited to null.
     const jan31 = nextFireTime('0 0 31 1 *', after, 'America/New_York');
     expect(jan31).not.toBeNull();
-    const wc = wallClockInZone(jan31!, 'America/New_York');
+    assertDefined(jan31, 'Jan 31 exists, so nextFireTime resolves');
+    const wc = wallClockInZone(jan31, 'America/New_York');
     expect(wc.hour).toBe(0);
   });
 
@@ -221,8 +235,9 @@ describe('nextFireTime', () => {
     const after = new Date(2028, 0, 1, 0, 0, 0);
     const next = nextFireTime('0 0 29 2 *', after);
     expect(next).not.toBeNull();
-    expect(next!.getMonth()).toBe(1); // February
-    expect(next!.getDate()).toBe(29);
+    assertDefined(next, 'Feb 29 in a leap year resolves');
+    expect(next.getMonth()).toBe(1); // February
+    expect(next.getDate()).toBe(29);
   });
 
   it('does NOT treat an impossible-DOM cron as impossible when DOW is restricted (OR-semantics)', () => {
@@ -231,7 +246,8 @@ describe('nextFireTime', () => {
     const after = new Date(2026, 0, 1, 0, 0, 0);
     const next = nextFireTime('0 0 30 2 5', after);
     expect(next).not.toBeNull();
-    expect(next!.getDay()).toBe(5); // matched via the Friday (DOW) arm
+    assertDefined(next, 'the Friday (DOW) arm makes this reachable');
+    expect(next.getDay()).toBe(5); // matched via the Friday (DOW) arm
   });
 
   // Worst case: a non-IANA timeZone must NOT throw a RangeError out of

--- a/packages/plugin-scheduler/src/cron.ts
+++ b/packages/plugin-scheduler/src/cron.ts
@@ -25,6 +25,8 @@
  * matches on EITHER. We follow that convention.
  */
 
+import { assertDefined } from '@moxxy/sdk';
+
 interface FieldSpec {
   readonly values: ReadonlySet<number>;
   readonly restricted: boolean;
@@ -67,8 +69,12 @@ function parseField(raw: string, range: FieldRange, fieldName: string): FieldSpe
       hi = range.max;
     } else if (rangePart.includes('-')) {
       const [a, b] = rangePart.split('-');
-      lo = toIntStrict(a!, fieldName);
-      hi = toIntStrict(b!, fieldName);
+      // A string containing '-' always splits into >= 2 parts, so both bounds
+      // are present by construction (empty strings are caught by toIntStrict).
+      assertDefined(a, 'range lower bound (rangePart contains "-")');
+      assertDefined(b, 'range upper bound (rangePart contains "-")');
+      lo = toIntStrict(a, fieldName);
+      hi = toIntStrict(b, fieldName);
     } else {
       lo = toIntStrict(rangePart, fieldName);
       hi = lo;
@@ -299,11 +305,15 @@ function decomposeInZone(d: Date, timeZone?: string): DateParts {
   const parts: Record<string, string> = {};
   for (const part of fmt.formatToParts(d)) parts[part.type] = part.value;
   const weekdayMap: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+  // The formatter is configured with `weekday: 'short'`, so formatToParts
+  // always emits a weekday part, so its presence is impossible by construction.
+  const weekday = parts.weekday;
+  assertDefined(weekday, 'formatToParts includes weekday (formatter sets weekday: short)');
   return {
     year: Number(parts.year),
     month: Number(parts.month),
     dom: Number(parts.day),
-    dow: weekdayMap[parts.weekday!] ?? 0,
+    dow: weekdayMap[weekday] ?? 0,
     hour: Number(parts.hour) % 24,
     minute: Number(parts.minute),
   };

--- a/packages/plugin-scheduler/src/index.ts
+++ b/packages/plugin-scheduler/src/index.ts
@@ -137,9 +137,12 @@ export function buildSchedulerPlugin(opts: BuildSchedulerPluginOptions): {
           try {
             await syncSkillSchedules(opts.skills, store);
           } catch (err) {
-            opts.logger?.warn?.('scheduler: initial skill sync failed', {
-              err: err instanceof Error ? err.message : String(err),
-            });
+            const log = opts.logger;
+            if (log?.warn) {
+              log.warn('scheduler: initial skill sync failed', {
+                err: err instanceof Error ? err.message : String(err),
+              });
+            }
           }
         }
         poller.start();
@@ -158,9 +161,12 @@ export function buildSchedulerPlugin(opts: BuildSchedulerPluginOptions): {
         try {
           await syncSkillSchedules(opts.skills, store);
         } catch (err) {
-          opts.logger?.warn?.('scheduler: skill sync after skill_created failed', {
-            err: err instanceof Error ? err.message : String(err),
-          });
+          const log = opts.logger;
+          if (log?.warn) {
+            log.warn('scheduler: skill sync after skill_created failed', {
+              err: err instanceof Error ? err.message : String(err),
+            });
+          }
         }
       },
     },

--- a/packages/plugin-scheduler/src/poller.test.ts
+++ b/packages/plugin-scheduler/src/poller.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { Skill, SkillRegistry } from '@moxxy/sdk';
-import { asSkillId } from '@moxxy/sdk';
+import { asSkillId, assertDefined } from '@moxxy/sdk';
 import { CrossProcessFireLock } from '@moxxy/sdk/server';
 import { FiringLock } from './firing-lock.js';
 import { isDue, nextCronFire, SchedulerPoller } from './poller.js';
@@ -118,8 +118,9 @@ describe('isDue', () => {
     expect(isDue(entry, now)).toBe(true);
     const next = nextCronFire(entry);
     expect(next).not.toBeNull();
+    assertDefined(next, 'nextCronFire resolves for this cron');
     // Agreement: the shown next-fire is <= now exactly because isDue is true.
-    expect(next!.getTime()).toBeLessThanOrEqual(now);
+    expect(next.getTime()).toBeLessThanOrEqual(now);
   });
 });
 
@@ -145,7 +146,9 @@ describe('SchedulerPoller integration', () => {
     });
     // Backdate so it's already due.
     const entries = await store.list();
-    await store.update(entries[0]!.id, { lastRunAt: Date.now() - 120_000 });
+    const entry = entries[0];
+    assertDefined(entry, 'the just-created schedule');
+    await store.update(entry.id, { lastRunAt: Date.now() - 120_000 });
 
     const calls: string[] = [];
     const poller = new SchedulerPoller({
@@ -163,8 +166,10 @@ describe('SchedulerPoller integration', () => {
     expect(calls).toEqual(['wake up']);
 
     const refreshed = await store.list();
-    expect(refreshed[0]!.lastRunAt).toBeDefined();
-    expect(refreshed[0]!.lastResult).toBe('ok');
+    const first = refreshed[0];
+    assertDefined(first, 'the fired schedule row');
+    expect(first.lastRunAt).toBeDefined();
+    expect(first.lastResult).toBe('ok');
 
     const { readdir } = await import('node:fs/promises');
     const files = await readdir(inboxDir);
@@ -174,7 +179,9 @@ describe('SchedulerPoller integration', () => {
   it('tickOnce counts a due schedule even when its store.update throws mid-run (u103-8)', async () => {
     await store.create({ name: 'minute', prompt: 'wake up', cron: '* * * * *' });
     const entries = await store.list();
-    await store.update(entries[0]!.id, { lastRunAt: Date.now() - 120_000 });
+    const entry = entries[0];
+    assertDefined(entry, 'the just-created schedule');
+    await store.update(entry.id, { lastRunAt: Date.now() - 120_000 });
 
     // Wrap the real store so list() still returns the due row but update()
     // throws — simulating a store-level failure during the run. The attempt
@@ -284,7 +291,9 @@ describe('SchedulerPoller integration', () => {
     // and race store.update.
     await store.create({ name: 'minute', prompt: 'wake up', cron: '* * * * *' });
     const entries = await store.list();
-    const id = entries[0]!.id;
+    const entry = entries[0];
+    assertDefined(entry, 'the just-created schedule');
+    const id = entry.id;
     await store.update(id, { lastRunAt: Date.now() - 120_000 });
 
     let active = 0;
@@ -304,7 +313,8 @@ describe('SchedulerPoller integration', () => {
     const firingLock = new FiringLock();
     const poller = new SchedulerPoller({ store, runner, inbox: { dir: inboxDir }, firingLock });
     const tools = buildSchedulerTools({ store, runner, inbox: { dir: inboxDir }, firingLock });
-    const runNow = tools.find((t) => t.name === 'schedule_run_now')!;
+    const runNow = tools.find((t) => t.name === 'schedule_run_now');
+    assertDefined(runNow, 'schedule_run_now tool is registered');
 
     // Fire both for the same entry at the same time.
     await Promise.all([
@@ -318,8 +328,10 @@ describe('SchedulerPoller integration', () => {
     // but strictly serialized — and the store ends in a consistent state.
     expect(runs).toBeGreaterThanOrEqual(1);
     const after = await store.list();
-    expect(after[0]!.lastResult).toBe('ok');
-    expect(after[0]!.lastRunAt).toBeDefined();
+    const first = after[0];
+    assertDefined(first, 'the fired schedule row');
+    expect(first.lastResult).toBe('ok');
+    expect(first.lastRunAt).toBeDefined();
   });
 
   it('one-shot fires once then disables itself', async () => {
@@ -335,12 +347,16 @@ describe('SchedulerPoller integration', () => {
     });
     await poller.tickOnce();
     const after = await store.list();
-    expect(after[0]!.enabled).toBe(false);
+    const afterFirst = after[0];
+    assertDefined(afterFirst, 'the one-shot row after firing');
+    expect(afterFirst.enabled).toBe(false);
 
     // Second tick must not fire it again.
     await poller.tickOnce();
     const stillOnce = await store.list();
-    expect(stillOnce[0]!.lastRunAt).toEqual(after[0]!.lastRunAt);
+    const stillOnceFirst = stillOnce[0];
+    assertDefined(stillOnceFirst, 'the one-shot row after the second tick');
+    expect(stillOnceFirst.lastRunAt).toEqual(afterFirst.lastRunAt);
   });
 
   it('records runner errors on lastResult/lastError', async () => {
@@ -350,7 +366,9 @@ describe('SchedulerPoller integration', () => {
       cron: '* * * * *',
     });
     const entries = await store.list();
-    await store.update(entries[0]!.id, { lastRunAt: Date.now() - 120_000 });
+    const entry = entries[0];
+    assertDefined(entry, 'the just-created schedule');
+    await store.update(entry.id, { lastRunAt: Date.now() - 120_000 });
 
     const poller = new SchedulerPoller({
       store,
@@ -363,8 +381,10 @@ describe('SchedulerPoller integration', () => {
     });
     await poller.tickOnce();
     const after = await store.list();
-    expect(after[0]!.lastResult).toBe('error');
-    expect(after[0]!.lastError).toContain('provider exploded');
+    const first = after[0];
+    assertDefined(first, 'the fired-with-error schedule row');
+    expect(first.lastResult).toBe('error');
+    expect(first.lastError).toContain('provider exploded');
   });
 
   // Regression for u103-2: skill edits/deletes must propagate on a tick,
@@ -405,8 +425,10 @@ describe('SchedulerPoller integration', () => {
     await poller.tickOnce();
     const stored = await store.list();
     expect(stored).toHaveLength(1);
-    expect(stored[0]!.cron).toBe('0 18 * * *');
-    expect(stored[0]!.prompt).toBe('second');
+    const first = stored[0];
+    assertDefined(first, 'the re-synced skill schedule');
+    expect(first.cron).toBe('0 18 * * *');
+    expect(first.prompt).toBe('second');
   });
 });
 
@@ -444,7 +466,9 @@ describe('SchedulerPoller multi-tenant (concurrent runners)', () => {
       ownerSessionId: 'runner-A',
     });
     const entries = await store.list();
-    await store.update(entries[0]!.id, { lastRunAt: Date.now() - 120_000 });
+    const entry = entries[0];
+    assertDefined(entry, 'the just-created schedule');
+    await store.update(entry.id, { lastRunAt: Date.now() - 120_000 });
 
     // The wrong runner (B) sees the due row but must NOT fire it.
     const b = countingRunner();
@@ -477,7 +501,9 @@ describe('SchedulerPoller multi-tenant (concurrent runners)', () => {
     const storeA = new ScheduleStore({ file });
     await storeA.create({ name: 'global-report', prompt: 'do XYZ', cron: '* * * * *' });
     const created = await storeA.list();
-    await storeA.update(created[0]!.id, { lastRunAt: Date.now() - 120_000 });
+    const createdFirst = created[0];
+    assertDefined(createdFirst, 'the owner-less schedule A created');
+    await storeA.update(createdFirst.id, { lastRunAt: Date.now() - 120_000 });
 
     // Runner B is a second process over the SAME shared file — it sees the same
     // due row. Both pre-read so each has the due entry cached, mimicking two
@@ -503,7 +529,9 @@ describe('SchedulerPoller multi-tenant (concurrent runners)', () => {
     const store = new ScheduleStore({ file: path.join(dir, 'schedules.json') });
     await store.create({ name: 'solo', prompt: 'go', cron: '* * * * *' });
     const entries = await store.list();
-    await store.update(entries[0]!.id, { lastRunAt: Date.now() - 120_000 });
+    const entry = entries[0];
+    assertDefined(entry, 'the just-created schedule');
+    await store.update(entry.id, { lastRunAt: Date.now() - 120_000 });
 
     const a = countingRunner();
     const poller = new SchedulerPoller({ store, runner: a.runner, inbox: { dir: inboxDir } });

--- a/packages/plugin-scheduler/src/poller.ts
+++ b/packages/plugin-scheduler/src/poller.ts
@@ -213,18 +213,24 @@ export class SchedulerPoller {
       try {
         await syncSkillSchedules(this.opts.skills, this.opts.store);
       } catch (err) {
-        this.opts.logger?.warn?.('scheduler: skill sync during tick failed', {
-          err: err instanceof Error ? err.message : String(err),
-        });
+        const log = this.opts.logger;
+        if (log?.warn) {
+          log.warn('scheduler: skill sync during tick failed', {
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
       }
     }
     let schedules: ReadonlyArray<ScheduleEntry>;
     try {
       schedules = await this.opts.store.list();
     } catch (err) {
-      this.opts.logger?.error?.('scheduler: failed to read store', {
-        err: err instanceof Error ? err.message : String(err),
-      });
+      const log = this.opts.logger;
+      if (log?.error) {
+        log.error('scheduler: failed to read store', {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
       return 0;
     }
     let attempted = 0;
@@ -236,10 +242,13 @@ export class SchedulerPoller {
       try {
         due = isDue(entry, now);
       } catch (err) {
-        this.opts.logger?.warn?.('scheduler: isDue failed; skipping entry', {
-          schedule: entry.name,
-          err: err instanceof Error ? err.message : String(err),
-        });
+        const log = this.opts.logger;
+        if (log?.warn) {
+          log.warn('scheduler: isDue failed; skipping entry', {
+            schedule: entry.name,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
         continue;
       }
       if (!due) continue;
@@ -281,10 +290,13 @@ export class SchedulerPoller {
           // A lock-dir error must not fire blind (that risks the N-times
           // multi-fire this guards). Skip this tick; the durable lastRunAt and
           // the next tick recover once the fs issue clears.
-          this.opts.logger?.warn?.('scheduler: fire-once claim failed; skipping', {
-            schedule: entry.name,
-            err: err instanceof Error ? err.message : String(err),
-          });
+          const log = this.opts.logger;
+          if (log?.warn) {
+            log.warn('scheduler: fire-once claim failed; skipping', {
+              schedule: entry.name,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          }
           continue;
         }
         if (!claimed) {
@@ -310,11 +322,14 @@ export class SchedulerPoller {
               runSchedule(entry, this.opts.runner, this.opts.store, this.opts.inbox),
             )
           : runSchedule(entry, this.opts.runner, this.opts.store, this.opts.inbox));
-        this.opts.logger?.info?.('scheduler: fired', {
-          schedule: entry.name,
-          ok: outcome.ok,
-          inbox: outcome.inboxPath,
-        });
+        const log = this.opts.logger;
+        if (log?.info) {
+          log.info('scheduler: fired', {
+            schedule: entry.name,
+            ok: outcome.ok,
+            inbox: outcome.inboxPath,
+          });
+        }
         onFired?.(entry, { ok: outcome.ok, text: outcome.text });
       } catch (err) {
         // A throw here is typically the post-run persist failing (the prompt
@@ -322,10 +337,13 @@ export class SchedulerPoller {
         // the entry's lastRunAt/disabled state did not advance — so surface it
         // as an error, not a warning. The firedKeys guard above stops the
         // re-fire it would otherwise cause.
-        this.opts.logger?.error?.('scheduler: run failed', {
-          schedule: entry.name,
-          err: err instanceof Error ? err.message : String(err),
-        });
+        const log = this.opts.logger;
+        if (log?.error) {
+          log.error('scheduler: run failed', {
+            schedule: entry.name,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
       }
     }
     // Reap expired cross-process markers so the lock dir can't grow without

--- a/packages/plugin-scheduler/src/reconcile.test.ts
+++ b/packages/plugin-scheduler/src/reconcile.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Skill, SkillRegistry } from '@moxxy/sdk';
-import { asSkillId } from '@moxxy/sdk';
+import { asSkillId, assertDefined } from '@moxxy/sdk';
 import { syncSkillSchedules } from './skill-sync.js';
 import { ScheduleStore } from './store.js';
 
@@ -103,7 +103,9 @@ describe('syncSkillSchedules — single batched write', () => {
     const rows = await store.list();
     const names = rows.map((r) => r.name).sort();
     expect(names).toEqual(['a', 'b', 'd', 'e', 'f', 'manual'].sort());
-    expect(rows.find((r) => r.name === 'a')!.prompt).toBe('new body a');
+    const rowA = rows.find((r) => r.name === 'a');
+    assertDefined(rowA, 'skill row "a" survives the reconcile');
+    expect(rowA.prompt).toBe('new body a');
     expect(rows.find((r) => r.name === 'manual')).toBeDefined();
   });
 

--- a/packages/plugin-scheduler/src/skill-sync.test.ts
+++ b/packages/plugin-scheduler/src/skill-sync.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { Skill, SkillRegistry } from '@moxxy/sdk';
-import { asSkillId } from '@moxxy/sdk';
+import { asSkillId, assertDefined } from '@moxxy/sdk';
 import { syncSkillSchedules } from './skill-sync.js';
 import { ScheduleStore } from './store.js';
 
@@ -49,9 +49,11 @@ describe('syncSkillSchedules', () => {
     expect(out.added).toBe(1);
     const stored = await store.list();
     expect(stored).toHaveLength(1);
-    expect(stored[0]!.source).toBe('skill');
-    expect(stored[0]!.skillName).toBe('briefing');
-    expect(stored[0]!.channel).toBe('telegram');
+    const first = stored[0];
+    assertDefined(first, 'first stored schedule (list has length 1)');
+    expect(first.source).toBe('skill');
+    expect(first.skillName).toBe('briefing');
+    expect(first.channel).toBe('telegram');
   });
 
   it('skips skills without a schedule block', async () => {
@@ -77,7 +79,8 @@ describe('syncSkillSchedules', () => {
   it('does not resurrect a skill schedule deleted through the shared schedule store', async () => {
     const reg = fakeRegistry([mkSkill('briefing', { cron: '0 9 * * *' })]);
     await syncSkillSchedules(reg, store);
-    const created = (await store.list())[0]!;
+    const created = (await store.list())[0];
+    assertDefined(created, 'the just-synced skill schedule');
 
     await expect(store.delete(created.id)).resolves.toBe(true);
     expect(await store.list()).toEqual([]);
@@ -105,8 +108,10 @@ describe('syncSkillSchedules', () => {
     const out = await syncSkillSchedules(reg, store);
     expect(out.updated).toBe(1);
     const stored = await store.list();
-    expect(stored[0]!.cron).toBe('0 18 * * *');
-    expect(stored[0]!.prompt).toBe('second body');
+    const first = stored[0];
+    assertDefined(first, 'first stored schedule after update');
+    expect(first.cron).toBe('0 18 * * *');
+    expect(first.prompt).toBe('second body');
   });
 
   it('refuses invalid cron expressions silently', async () => {

--- a/packages/plugin-scheduler/src/store.test.ts
+++ b/packages/plugin-scheduler/src/store.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { ScheduleStore } from './store.js';
 
 describe('ScheduleStore', () => {
@@ -31,9 +32,11 @@ describe('ScheduleStore', () => {
     const reloaded = new ScheduleStore({ file: path.join(dir, 'schedules.json') });
     const all = await reloaded.list();
     expect(all).toHaveLength(1);
-    expect(all[0]!.name).toBe('morning');
-    expect(all[0]!.cron).toBe('0 9 * * *');
-    expect(all[0]!.enabled).toBe(true);
+    const first = all[0];
+    assertDefined(first, 'first schedule (list has length 1)');
+    expect(first.name).toBe('morning');
+    expect(first.cron).toBe('0 9 * * *');
+    expect(first.enabled).toBe(true);
   });
 
   it('rejects schedules with neither cron nor runAt', async () => {
@@ -69,7 +72,8 @@ describe('ScheduleStore', () => {
   it('update merges patch into an entry', async () => {
     const created = await store.create({ name: 'a', prompt: 'p', cron: '0 9 * * *' });
     const updated = await store.update(created.id, { enabled: false });
-    expect(updated!.enabled).toBe(false);
+    assertDefined(updated, 'update of an existing id returns the entry');
+    expect(updated.enabled).toBe(false);
   });
 
   it('delete removes by id', async () => {
@@ -91,7 +95,8 @@ describe('ScheduleStore', () => {
       source: 'workflow',
       workflowName: 'daily-report',
     });
-    const created = (await store.list())[0]!;
+    const created = (await store.list())[0];
+    assertDefined(created, 'the just-synced workflow schedule');
 
     expect(await store.delete(created.id)).toBe(true);
     expect(await store.list()).toEqual([]);
@@ -129,11 +134,14 @@ describe('ScheduleStore', () => {
 
     // Replace the briefing skill schedule.
     const entries = await store.list();
-    const briefing = entries.find((e) => e.skillName === 'briefing')!;
+    const briefing = entries.find((e) => e.skillName === 'briefing');
+    assertDefined(briefing, 'the seeded briefing skill schedule');
     await store.update(briefing.id, { prompt: 'new prompt' });
 
     const after = await store.list();
     expect(after.map((s) => s.name).sort()).toEqual(['manual-one', 'other-skill', 'skill-old']);
-    expect(after.find((s) => s.skillName === 'briefing')!.prompt).toBe('new prompt');
+    const briefingAfter = after.find((s) => s.skillName === 'briefing');
+    assertDefined(briefingAfter, 'briefing schedule after update');
+    expect(briefingAfter.prompt).toBe('new prompt');
   });
 });

--- a/packages/plugin-scheduler/src/store.ts
+++ b/packages/plugin-scheduler/src/store.ts
@@ -1,5 +1,5 @@
 import { rename } from 'node:fs/promises';
-import { createJsonFileStore, type JsonFileStore } from '@moxxy/sdk';
+import { assertDefined, createJsonFileStore, type JsonFileStore } from '@moxxy/sdk';
 import { moxxyPath } from '@moxxy/sdk/server';
 import { ulid } from 'ulid';
 import { z } from 'zod';
@@ -159,24 +159,30 @@ export class ScheduleStore {
         const quarantine = `${file}.corrupt-${Date.now()}`;
         try {
           await rename(file, quarantine);
-          logger?.warn?.('scheduler: schedules file was corrupt; quarantined and reset', {
-            file,
-            quarantine,
-          });
+          if (logger?.warn) {
+            logger.warn('scheduler: schedules file was corrupt; quarantined and reset', {
+              file,
+              quarantine,
+            });
+          }
         } catch (err) {
-          logger?.warn?.('scheduler: schedules file was corrupt; failed to quarantine', {
-            file,
-            err: err instanceof Error ? err.message : String(err),
-          });
+          if (logger?.warn) {
+            logger.warn('scheduler: schedules file was corrupt; failed to quarantine', {
+              file,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          }
         }
         return [];
       },
       // Non-ENOENT read errors were previously swallowed to an empty store too.
       onReadError: (err) => {
-        logger?.warn?.('scheduler: failed to read schedules file; using empty set', {
-          file,
-          err: err instanceof Error ? err.message : String(err),
-        });
+        if (logger?.warn) {
+          logger.warn('scheduler: failed to read schedules file; using empty set', {
+            file,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
         return [];
       },
     });
@@ -219,8 +225,10 @@ export class ScheduleStore {
     await this.store.mutate((schedules) => {
       const idx = schedules.findIndex((s) => s.id === id);
       if (idx < 0) return schedules;
-      if (!isVisibleSchedule(schedules[idx]!)) return schedules;
-      const next = scheduleEntrySchema.parse({ ...schedules[idx], ...patch });
+      const existing = schedules[idx];
+      assertDefined(existing, 'findIndex returned an in-bounds index');
+      if (!isVisibleSchedule(existing)) return schedules;
+      const next = scheduleEntrySchema.parse({ ...existing, ...patch });
       schedules[idx] = next;
       updated = next;
       return schedules;
@@ -233,7 +241,8 @@ export class ScheduleStore {
     await this.store.mutate((schedules) => {
       const idx = schedules.findIndex((s) => s.id === id && isVisibleSchedule(s));
       if (idx < 0) return schedules;
-      const entry = schedules[idx]!;
+      const entry = schedules[idx];
+      assertDefined(entry, 'findIndex returned an in-bounds index');
       removed = true;
       if (entry.source === 'manual') {
         return schedules.filter((s) => s.id !== id);
@@ -293,7 +302,8 @@ export class ScheduleStore {
       //    positions in `next` since the remove pass reindexed it.
       const posInNext = new Map<string, number>();
       for (let i = 0; i < next.length; i += 1) {
-        const s = next[i]!;
+        const s = next[i];
+        assertDefined(s, 'loop index i is within next.length');
         if (s.source === 'skill' && s.skillName && !posInNext.has(s.skillName)) {
           posInNext.set(s.skillName, i);
         }
@@ -313,7 +323,8 @@ export class ScheduleStore {
           added += 1;
           continue;
         }
-        const current = next[idx]!;
+        const current = next[idx];
+        assertDefined(current, 'posInNext holds an in-bounds index into next');
         if (!isVisibleSchedule(current)) continue;
         const patch = {
           prompt: draft.prompt,

--- a/packages/plugin-scheduler/src/tools.test.ts
+++ b/packages/plugin-scheduler/src/tools.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { ToolContext, ToolDef } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { ScheduleStore } from './store.js';
 import { buildSchedulerTools } from './tools.js';
 
@@ -20,7 +21,9 @@ describe('schedule_create tool — input validation hardening', () => {
       store,
       runner: { runPrompt: async () => ({ text: 'ok' }) },
     });
-    create = tools.find((t) => t.name === 'schedule_create')!;
+    const found = tools.find((t) => t.name === 'schedule_create');
+    assertDefined(found, 'schedule_create tool is registered');
+    create = found;
   });
   afterEach(async () => {
     await rm(dir, { recursive: true, force: true });
@@ -72,8 +75,11 @@ describe('schedule target session (ownerSessionId routing)', () => {
       runner: { runPrompt: async () => ({ text: 'ok' }) },
       ...(ownerSessionId ? { ownerSessionId } : {}),
     });
-  const handler = (list: ReadonlyArray<ToolDef>, name: string): ToolDef['handler'] =>
-    list.find((t) => t.name === name)!.handler;
+  const handler = (list: ReadonlyArray<ToolDef>, name: string): ToolDef['handler'] => {
+    const tool = list.find((t) => t.name === name);
+    assertDefined(tool, `tool "${name}" is registered`);
+    return tool.handler;
+  };
 
   beforeEach(async () => {
     dir = await mkdtemp(path.join(tmpdir(), 'moxxy-sched-target-'));

--- a/packages/plugin-usage-stats/src/index.test.ts
+++ b/packages/plugin-usage-stats/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   asSessionId,
   asSkillId,
   asTurnId,
+  assertDefined,
   type AppContext,
   type EventLogReader,
   type MoxxyEvent,
@@ -69,7 +70,8 @@ function reader(events: ReadonlyArray<MoxxyEvent>): EventLogReader {
   // Faithfully model the real EventLog: `length` is a COUNT of held events,
   // while `slice(from)`/`at(seq)` are SEQ-addressed (translated through the
   // log's base). On a rebased mirror the held events' seqs start above 0.
-  const base = events.length > 0 ? events[0]!.seq : 0;
+  const first = events[0];
+  const base = first !== undefined ? first.seq : 0;
   return {
     length: events.length,
     at: (seq: number) => events[seq - base],
@@ -97,7 +99,8 @@ class FakeLog {
   private readonly clearListeners = new Set<() => void>();
   constructor(seed: ReadonlyArray<MoxxyEvent> = []) {
     this.events = [...seed];
-    this.base = seed.length > 0 ? seed[0]!.seq : 0;
+    const first = seed[0];
+    this.base = first !== undefined ? first.seq : 0;
   }
   get length() {
     return this.events.length;
@@ -165,12 +168,20 @@ describe('usage-stats plugin', () => {
     const plugin = buildUsageStatsPlugin({ statsPath });
     const events = [resp(0, 'opus', 100), resp(1, 'opus', 50)];
 
-    await plugin.hooks!.onInit!(ctxFor([])); // boots with empty log
-    await plugin.hooks!.onShutdown!(ctxFor(events));
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'onInit hook');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    await onInit(ctxFor([])); // boots with empty log
+    await onShutdown(ctxFor(events));
 
     const file = await loadUsageStats(statsPath);
-    expect(file.models['anthropic/opus']!.calls).toBe(2);
-    expect(file.models['anthropic/opus']!.inputTokens).toBe(150);
+    const opus = file.models['anthropic/opus'];
+    assertDefined(opus, 'anthropic/opus model stats');
+    expect(opus.calls).toBe(2);
+    expect(opus.inputTokens).toBe(150);
   });
 
   it('skips restored events on resume and folds only the live suffix', async () => {
@@ -178,21 +189,35 @@ describe('usage-stats plugin', () => {
     const liveSuffix = [resp(2, 'opus', 30)];
     const plugin = buildUsageStatsPlugin({ statsPath });
 
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'onInit hook');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
     // onInit fires after restored events are already seeded into the log.
-    await plugin.hooks!.onInit!(ctxFor(restored));
+    await onInit(ctxFor(restored));
     // onShutdown sees restored + live.
-    await plugin.hooks!.onShutdown!(ctxFor([...restored, ...liveSuffix]));
+    await onShutdown(ctxFor([...restored, ...liveSuffix]));
 
     const file = await loadUsageStats(statsPath);
     // Only the single live call (30 tokens) is counted — not the 3000 restored.
-    expect(file.models['anthropic/opus']!.calls).toBe(1);
-    expect(file.models['anthropic/opus']!.inputTokens).toBe(30);
+    const opus = file.models['anthropic/opus'];
+    assertDefined(opus, 'anthropic/opus model stats');
+    expect(opus.calls).toBe(1);
+    expect(opus.inputTokens).toBe(30);
   });
 
   it('writes nothing when no live events were produced', async () => {
     const plugin = buildUsageStatsPlugin({ statsPath });
-    await plugin.hooks!.onInit!(ctxFor([resp(0, 'opus', 100)]));
-    await plugin.hooks!.onShutdown!(ctxFor([resp(0, 'opus', 100)]));
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'onInit hook');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    await onInit(ctxFor([resp(0, 'opus', 100)]));
+    await onShutdown(ctxFor([resp(0, 'opus', 100)]));
     // No new events past the cursor → file never created.
     expect((await loadUsageStats(statsPath)).models).toEqual({});
   });
@@ -206,13 +231,21 @@ describe('usage-stats plugin', () => {
     const liveSuffix = [resp(103, 'opus', 30)];
     const plugin = buildUsageStatsPlugin({ statsPath });
 
-    await plugin.hooks!.onInit!(ctxFor(restored));
-    await plugin.hooks!.onShutdown!(ctxFor([...restored, ...liveSuffix]));
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'onInit hook');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    await onInit(ctxFor(restored));
+    await onShutdown(ctxFor([...restored, ...liveSuffix]));
 
     const file = await loadUsageStats(statsPath);
     // Only the single live call (30 tokens) — never the 7000 restored tokens.
-    expect(file.models['anthropic/opus']!.calls).toBe(1);
-    expect(file.models['anthropic/opus']!.inputTokens).toBe(30);
+    const opus = file.models['anthropic/opus'];
+    assertDefined(opus, 'anthropic/opus model stats');
+    expect(opus.calls).toBe(1);
+    expect(opus.inputTokens).toBe(30);
   });
 
   it('counts the post-/new (log clear/reset) suffix that restarts at seq 0', async () => {
@@ -225,16 +258,24 @@ describe('usage-stats plugin', () => {
     const plugin = buildUsageStatsPlugin({ statsPath });
     const log = new FakeLog([resp(100, 'opus', 1000), resp(101, 'opus', 2000)]);
 
-    await plugin.hooks!.onInit!(ctxForLog(log)); // boundary captured at seq 101
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'onInit hook');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    await onInit(ctxForLog(log)); // boundary captured at seq 101
     log.clear(); // /new — events emptied, base reset to 0, onClear fires
     log.push(resp(0, 'opus', 40), resp(1, 'opus', 60)); // post-/new live events
 
-    await plugin.hooks!.onShutdown!(ctxForLog(log));
+    await onShutdown(ctxForLog(log));
 
     const file = await loadUsageStats(statsPath);
     // Both post-/new calls counted (100 tokens) — not dropped as <= old boundary.
-    expect(file.models['anthropic/opus']!.calls).toBe(2);
-    expect(file.models['anthropic/opus']!.inputTokens).toBe(100);
+    const opus = file.models['anthropic/opus'];
+    assertDefined(opus, 'anthropic/opus model stats');
+    expect(opus.calls).toBe(2);
+    expect(opus.inputTokens).toBe(100);
   });
 
   it('isolates the cursor per session so concurrent sessions on one instance never clobber each other', async () => {
@@ -247,19 +288,27 @@ describe('usage-stats plugin', () => {
     const logA = new FakeLog([resp(0, 'opus', 1000)]); // A restored 1 event (seq 0)
     const logB = new FakeLog([]); // B is a fresh run
 
-    await plugin.hooks!.onInit!(ctxForLog(logA, sidA)); // A boundary = 0
-    await plugin.hooks!.onInit!(ctxForLog(logB, sidB)); // B boundary = null (would clobber A's scalar)
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'onInit hook');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    await onInit(ctxForLog(logA, sidA)); // A boundary = 0
+    await onInit(ctxForLog(logB, sidB)); // B boundary = null (would clobber A's scalar)
 
     logA.push(resp(1, 'opus', 5)); // A's single live call
     logB.push(resp(0, 'opus', 7)); // B's single live call
 
-    await plugin.hooks!.onShutdown!(ctxForLog(logA, sidA));
-    await plugin.hooks!.onShutdown!(ctxForLog(logB, sidB));
+    await onShutdown(ctxForLog(logA, sidA));
+    await onShutdown(ctxForLog(logB, sidB));
 
     const file = await loadUsageStats(statsPath);
     // A counts only its live call (5), B counts its only call (7) → 2 calls, 12.
-    expect(file.models['anthropic/opus']!.calls).toBe(2);
-    expect(file.models['anthropic/opus']!.inputTokens).toBe(12);
+    const opus = file.models['anthropic/opus'];
+    assertDefined(opus, 'anthropic/opus model stats');
+    expect(opus.calls).toBe(2);
+    expect(opus.inputTokens).toBe(12);
   });
 
   it('folds the whole log when onShutdown fires without a preceding onInit (cursor defaults to null)', async () => {
@@ -271,11 +320,17 @@ describe('usage-stats plugin', () => {
     const plugin = buildUsageStatsPlugin({ statsPath });
     const events = [resp(0, 'opus', 100), resp(1, 'opus', 50)];
 
-    await plugin.hooks!.onShutdown!(ctxFor(events)); // no onInit called
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    await onShutdown(ctxFor(events)); // no onInit called
 
     const file = await loadUsageStats(statsPath);
-    expect(file.models['anthropic/opus']!.calls).toBe(2);
-    expect(file.models['anthropic/opus']!.inputTokens).toBe(150);
+    const opus = file.models['anthropic/opus'];
+    assertDefined(opus, 'anthropic/opus model stats');
+    expect(opus.calls).toBe(2);
+    expect(opus.inputTokens).toBe(150);
   });
 
   it('onShutdown degrades to a no-op (resolves, writes nothing) when the reader throws', async () => {
@@ -296,7 +351,11 @@ describe('usage-stats plugin', () => {
     } as unknown as EventLogReader;
     const ctx = { sessionId: sid, cwd: '/tmp', log: hostile, env: {} } as AppContext;
 
-    await expect(plugin.hooks!.onShutdown!(ctx)).resolves.toBeUndefined();
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    await expect(onShutdown(ctx)).resolves.toBeUndefined();
     // Nothing folded → file never created.
     expect((await loadUsageStats(statsPath)).models).toEqual({});
   });
@@ -322,16 +381,24 @@ describe('usage-stats plugin', () => {
     } as unknown as EventLogReader;
     const initCtx = { sessionId: sid, cwd: '/tmp', log: throwingInit, env: {} } as AppContext;
 
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'onInit hook');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
     // onInit is synchronous; it must not throw despite ofType + onClear both
     // throwing. (`Promise.resolve` tolerates the sync void return.)
-    expect(() => plugin.hooks!.onInit!(initCtx)).not.toThrow();
+    expect(() => onInit(initCtx)).not.toThrow();
 
     // Now shut down with a healthy reader: null cursor folds the whole log.
-    await plugin.hooks!.onShutdown!(ctxFor([resp(0, 'opus', 10), resp(1, 'opus', 20)]));
+    await onShutdown(ctxFor([resp(0, 'opus', 10), resp(1, 'opus', 20)]));
 
     const file = await loadUsageStats(statsPath);
-    expect(file.models['anthropic/opus']!.calls).toBe(2);
-    expect(file.models['anthropic/opus']!.inputTokens).toBe(30);
+    const opus = file.models['anthropic/opus'];
+    assertDefined(opus, 'anthropic/opus model stats');
+    expect(opus.calls).toBe(2);
+    expect(opus.inputTokens).toBe(30);
   });
 
   it('onShutdown tears down the onClear listener even when the fold/merge path throws (no leak)', async () => {
@@ -357,9 +424,15 @@ describe('usage-stats plugin', () => {
     } as unknown as EventLogReader;
     const ctx = { sessionId: sid, cwd: '/tmp', log, env: {} } as AppContext;
 
-    await plugin.hooks!.onInit!(ctx); // registers the clear listener (ofType ok: empty log path)
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'onInit hook');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    await onInit(ctx); // registers the clear listener (ofType ok: empty log path)
     throwFromOfType = true; // now the fold path will throw on shutdown
-    await expect(plugin.hooks!.onShutdown!(ctx)).resolves.toBeUndefined();
+    await expect(onShutdown(ctx)).resolves.toBeUndefined();
     // Listener was unsubscribed despite the fold throwing → no leak.
     expect(unsubscribed).toBe(true);
   });
@@ -371,6 +444,10 @@ describe('usage-stats plugin', () => {
     // non-array — it must be swallowed by the same best-effort guard, resolving
     // the hook and writing nothing rather than crashing the timeboxed shutdown.
     const plugin = buildUsageStatsPlugin({ statsPath });
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
     for (const bogus of [42, null, 'nope', { length: 1 }] as unknown[]) {
       const garbageReader = {
         length: 1,
@@ -381,7 +458,7 @@ describe('usage-stats plugin', () => {
         toJSON: () => [],
       } as unknown as EventLogReader;
       const ctx = { sessionId: sid, cwd: '/tmp', log: garbageReader, env: {} } as AppContext;
-      await expect(plugin.hooks!.onShutdown!(ctx)).resolves.toBeUndefined();
+      await expect(onShutdown(ctx)).resolves.toBeUndefined();
     }
     // No call ever produced a fold-able array → file never created.
     expect((await loadUsageStats(statsPath)).models).toEqual({});
@@ -397,15 +474,21 @@ describe('usage-stats plugin', () => {
     const plugin = buildUsageStatsPlugin({ statsPath });
     const events = [resp(0, 'opus', 100)];
 
-    await expect(plugin.hooks!.onShutdown!(ctxFor(events))).resolves.toBeUndefined();
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    await expect(onShutdown(ctxFor(events))).resolves.toBeUndefined();
     // A repeat shutdown re-folds the same whole log (cursor still absent → null),
     // so it must not throw; the aggregate doubles, which is the documented
     // whole-log-fold default, asserted so a future guard change is deliberate.
-    await expect(plugin.hooks!.onShutdown!(ctxFor(events))).resolves.toBeUndefined();
+    await expect(onShutdown(ctxFor(events))).resolves.toBeUndefined();
 
     const file = await loadUsageStats(statsPath);
-    expect(file.models['anthropic/opus']!.calls).toBe(2);
-    expect(file.models['anthropic/opus']!.inputTokens).toBe(200);
+    const opus = file.models['anthropic/opus'];
+    assertDefined(opus, 'anthropic/opus model stats');
+    expect(opus.calls).toBe(2);
+    expect(opus.inputTokens).toBe(200);
   });
 
   it('a re-init of the same session id replaces (does not stack) the onClear listener', async () => {
@@ -419,12 +502,18 @@ describe('usage-stats plugin', () => {
     const plugin = buildUsageStatsPlugin({ statsPath });
     const log = new FakeLog([resp(0, 'opus', 10)]);
 
-    await plugin.hooks!.onInit!(ctxForLog(log));
-    await plugin.hooks!.onInit!(ctxForLog(log));
-    await plugin.hooks!.onInit!(ctxForLog(log));
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'onInit hook');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    await onInit(ctxForLog(log));
+    await onInit(ctxForLog(log));
+    await onInit(ctxForLog(log));
     expect(log.clearListenerCount).toBe(1); // replaced each time, never stacked
 
-    await plugin.hooks!.onShutdown!(ctxForLog(log));
+    await onShutdown(ctxForLog(log));
     expect(log.clearListenerCount).toBe(0); // fully torn down
   });
 
@@ -452,14 +541,22 @@ describe('usage-stats plugin', () => {
     } as unknown as EventLogReader;
     const initCtx = { sessionId: sid, cwd: '/tmp', log: onClearThrows, env: {} } as AppContext;
 
-    expect(() => plugin.hooks!.onInit!(initCtx)).not.toThrow();
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'onInit hook');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    expect(() => onInit(initCtx)).not.toThrow();
     // Shut down with restored prefix + one live call. The preserved boundary (102)
     // must exclude every restored response and include only the live one.
-    await plugin.hooks!.onShutdown!(ctxFor([...restored, resp(103, 'opus', 30)]));
+    await onShutdown(ctxFor([...restored, resp(103, 'opus', 30)]));
 
     const file = await loadUsageStats(statsPath);
-    expect(file.models['anthropic/opus']!.calls).toBe(1);
-    expect(file.models['anthropic/opus']!.inputTokens).toBe(30); // not 7030
+    const opus = file.models['anthropic/opus'];
+    assertDefined(opus, 'anthropic/opus model stats');
+    expect(opus.calls).toBe(1);
+    expect(opus.inputTokens).toBe(30); // not 7030
   });
 
   it('actually tears down the real onClear listener on shutdown (no leaked subscription)', async () => {
@@ -471,23 +568,31 @@ describe('usage-stats plugin', () => {
     const plugin = buildUsageStatsPlugin({ statsPath });
     const log = new FakeLog([resp(0, 'opus', 100)]);
 
-    await plugin.hooks!.onInit!(ctxForLog(log));
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'onInit hook');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    await onInit(ctxForLog(log));
     expect(log.clearListenerCount).toBe(1); // listener registered
 
     log.push(resp(1, 'opus', 50));
-    await plugin.hooks!.onShutdown!(ctxForLog(log));
+    await onShutdown(ctxForLog(log));
     expect(log.clearListenerCount).toBe(0); // torn down — no leak
 
     // A clear() now fires no plugin listener; a second shutdown sees an absent
     // cursor (null) and folds the (post-clear, empty) log → still no crash.
     log.clear();
-    await expect(plugin.hooks!.onShutdown!(ctxForLog(log))).resolves.toBeUndefined();
+    await expect(onShutdown(ctxForLog(log))).resolves.toBeUndefined();
 
     const file = await loadUsageStats(statsPath);
     // Only the first run's live call (50) — the restored 100 was excluded, and
     // the post-shutdown clear added nothing.
-    expect(file.models['anthropic/opus']!.calls).toBe(1);
-    expect(file.models['anthropic/opus']!.inputTokens).toBe(50);
+    const opus = file.models['anthropic/opus'];
+    assertDefined(opus, 'anthropic/opus model stats');
+    expect(opus.calls).toBe(1);
+    expect(opus.inputTokens).toBe(50);
   });
 });
 
@@ -497,15 +602,21 @@ describe('summarizeSkillEvents', () => {
       [skillInvoked(0, 'deploy', 1000), skillInvoked(1, 'deploy', 3000), skillInvoked(2, 'lint', 2000)],
       [],
     );
-    expect(delta['deploy']!.invocations).toBe(2);
-    expect(delta['deploy']!.lastInvokedAt).toBe(new Date(3000).toISOString());
-    expect(delta['lint']!.invocations).toBe(1);
+    const deploy = delta['deploy'];
+    assertDefined(deploy, 'deploy skill delta');
+    expect(deploy.invocations).toBe(2);
+    expect(deploy.lastInvokedAt).toBe(new Date(3000).toISOString());
+    const lint = delta['lint'];
+    assertDefined(lint, 'lint skill delta');
+    expect(lint.invocations).toBe(1);
   });
 
   it('records createdAt for a created-but-never-invoked skill (invocations 0)', () => {
     const delta = summarizeSkillEvents([], [skillCreated(0, 'fresh', 5000)]);
-    expect(delta['fresh']!.invocations).toBe(0);
-    expect(delta['fresh']!.createdAt).toBe(new Date(5000).toISOString());
+    const fresh = delta['fresh'];
+    assertDefined(fresh, 'fresh skill delta');
+    expect(fresh.invocations).toBe(0);
+    expect(fresh.createdAt).toBe(new Date(5000).toISOString());
   });
 
   it('is empty for no events', () => {
@@ -523,14 +634,24 @@ describe('usage-stats plugin — skill folding', () => {
       skillInvoked(3, 'lint', 3000),
     ];
 
-    await plugin.hooks!.onInit!(ctxFor([]));
-    await plugin.hooks!.onShutdown!(ctxFor(events));
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'onInit hook');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    await onInit(ctxFor([]));
+    await onShutdown(ctxFor(events));
 
     const file = await loadSkillUsage(skillUsagePath);
-    expect(file.skills['deploy']!.invocations).toBe(2);
-    expect(file.skills['deploy']!.createdAt).toBe(new Date(1000).toISOString());
-    expect(file.skills['deploy']!.lastInvokedAt).toBe(new Date(4000).toISOString());
-    expect(file.skills['lint']!.invocations).toBe(1);
+    const deploy = file.skills['deploy'];
+    assertDefined(deploy, 'deploy skill usage');
+    expect(deploy.invocations).toBe(2);
+    expect(deploy.createdAt).toBe(new Date(1000).toISOString());
+    expect(deploy.lastInvokedAt).toBe(new Date(4000).toISOString());
+    const lint = file.skills['lint'];
+    assertDefined(lint, 'lint skill usage');
+    expect(lint.invocations).toBe(1);
   });
 
   it('counts only the live skill suffix on resume (skips restored skill events)', async () => {
@@ -538,11 +659,19 @@ describe('usage-stats plugin — skill folding', () => {
     const live = [skillInvoked(2, 'deploy', 3000)];
     const plugin = buildUsageStatsPlugin({ statsPath, skillUsagePath });
 
-    await plugin.hooks!.onInit!(ctxFor(restored));
-    await plugin.hooks!.onShutdown!(ctxFor([...restored, ...live]));
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'onInit hook');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    await onInit(ctxFor(restored));
+    await onShutdown(ctxFor([...restored, ...live]));
 
     // Only the single live invocation is counted — not the 2 restored.
-    expect((await loadSkillUsage(skillUsagePath)).skills['deploy']!.invocations).toBe(1);
+    const deploy = (await loadSkillUsage(skillUsagePath)).skills['deploy'];
+    assertDefined(deploy, 'deploy skill usage');
+    expect(deploy.invocations).toBe(1);
   });
 
   it('folds skill usage even when the run produced no provider_response (no token early-return)', async () => {
@@ -551,18 +680,32 @@ describe('usage-stats plugin — skill folding', () => {
     const plugin = buildUsageStatsPlugin({ statsPath, skillUsagePath });
     const events = [skillInvoked(0, 'deploy', 1000)];
 
-    await plugin.hooks!.onInit!(ctxFor([]));
-    await plugin.hooks!.onShutdown!(ctxFor(events));
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'onInit hook');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    await onInit(ctxFor([]));
+    await onShutdown(ctxFor(events));
 
-    expect((await loadSkillUsage(skillUsagePath)).skills['deploy']!.invocations).toBe(1);
+    const deploy = (await loadSkillUsage(skillUsagePath)).skills['deploy'];
+    assertDefined(deploy, 'deploy skill usage');
+    expect(deploy.invocations).toBe(1);
     // No token usage was recorded (no provider_response events).
     expect((await loadUsageStats(statsPath)).models).toEqual({});
   });
 
   it('writes no skill usage file when the run exercised no skills', async () => {
     const plugin = buildUsageStatsPlugin({ statsPath, skillUsagePath });
-    await plugin.hooks!.onInit!(ctxFor([]));
-    await plugin.hooks!.onShutdown!(ctxFor([resp(0, 'opus', 100)]));
+    const hooks = plugin.hooks;
+    assertDefined(hooks, 'usage-stats plugin hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'onInit hook');
+    const onShutdown = hooks.onShutdown;
+    assertDefined(onShutdown, 'onShutdown hook');
+    await onInit(ctxFor([]));
+    await onShutdown(ctxFor([resp(0, 'opus', 100)]));
     // Empty skill delta → merge never touches disk.
     await expect(fs.access(skillUsagePath)).rejects.toThrow();
   });

--- a/packages/plugin-usage-stats/src/index.ts
+++ b/packages/plugin-usage-stats/src/index.ts
@@ -138,7 +138,7 @@ export function buildUsageStatsPlugin(opts: BuildUsageStatsPluginOptions = {}): 
           // An unsubscribe that throws must not block the merge below.
         }
         clearUnsubs.delete(ctx.sessionId);
-        const initMaxSeq = cursors.has(ctx.sessionId) ? cursors.get(ctx.sessionId)! : null;
+        const initMaxSeq = cursors.get(ctx.sessionId) ?? null;
         cursors.delete(ctx.sessionId);
         // Best-effort: a throwing reader or a failed fold degrades to "record
         // nothing for this run" rather than rejecting the hook (which the host

--- a/packages/plugin-webhooks/src/drain.ts
+++ b/packages/plugin-webhooks/src/drain.ts
@@ -88,9 +88,12 @@ export class WebhookDrainPoller {
     try {
       records = await this.opts.queue.listOwned(this.opts.ownerSessionId);
     } catch (err) {
-      this.opts.logger?.warn?.('webhooks: queue read failed', {
-        err: err instanceof Error ? err.message : String(err),
-      });
+      const logger = this.opts.logger;
+      if (logger?.warn) {
+        logger.warn('webhooks: queue read failed', {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
       return 0;
     }
     let fired = 0;
@@ -105,10 +108,13 @@ export class WebhookDrainPoller {
         await this.opts.dispatcher.fire(trigger, rec.prompt, rec.deliveryId);
         fired += 1;
       } catch (err) {
-        this.opts.logger?.warn?.('webhooks: drained delivery failed', {
-          trigger: trigger.name,
-          err: err instanceof Error ? err.message : String(err),
-        });
+        const logger = this.opts.logger;
+        if (logger?.warn) {
+          logger.warn('webhooks: drained delivery failed', {
+            trigger: trigger.name,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
       } finally {
         await this.opts.queue.remove(rec.id);
       }

--- a/packages/plugin-webhooks/src/filter.ts
+++ b/packages/plugin-webhooks/src/filter.ts
@@ -42,7 +42,11 @@ const REGEX_CACHE_MAX = 256;
  * can't grow it without limit.
  */
 function compileMatcher(source: string): RegExp | null {
-  if (regexCache.has(source)) return regexCache.get(source)!;
+  // has() proved the key is present, so get() can only return the stored
+  // `RegExp | null` (never the key-absent `undefined`). A cached `null`
+  // (uncompilable/over-long pattern, treated as "no match") is a valid value,
+  // so coalesce the impossible `undefined` rather than asserting non-null.
+  if (regexCache.has(source)) return regexCache.get(source) ?? null;
   let compiled: RegExp | null = null;
   if (source.length <= MAX_REGEX_SOURCE_LEN) {
     try {

--- a/packages/plugin-webhooks/src/index.ts
+++ b/packages/plugin-webhooks/src/index.ts
@@ -258,20 +258,23 @@ export function buildWebhooksPlugin(opts: BuildWebhooksPluginOptions): BuiltWebh
           } catch {
             /* fall back to the generic warning below */
           }
-          opts.logger?.warn?.(
-            'webhooks: binding a NON-LOOPBACK host — the unauthenticated POST surface is ' +
-              'reachable from other machines on the network',
-            {
-              host,
-              port,
-              ...(openAuth.length > 0
-                ? {
-                    unauthenticatedTriggers: openAuth.map((t) => t.name),
-                    severity: 'critical: any host on the network can fire these triggers',
-                  }
-                : {}),
-            },
-          );
+          const logger = opts.logger;
+          if (logger?.warn) {
+            logger.warn(
+              'webhooks: binding a NON-LOOPBACK host — the unauthenticated POST surface is ' +
+                'reachable from other machines on the network',
+              {
+                host,
+                port,
+                ...(openAuth.length > 0
+                  ? {
+                      unauthenticatedTriggers: openAuth.map((t) => t.name),
+                      severity: 'critical: any host on the network can fire these triggers',
+                    }
+                  : {}),
+              },
+            );
+          }
         }
         serverInstance = new WebhookServer({
           host,
@@ -289,11 +292,14 @@ export function buildWebhooksPlugin(opts: BuildWebhooksPluginOptions): BuiltWebh
           // every runner except the one that wins the shared listener port. Log
           // and carry on: this runner still drains its own handed-off deliveries
           // below. The agent can surface a genuine failure via webhook_status.
-          opts.logger?.warn?.('webhooks: listener failed to start', {
-            err: err instanceof Error ? err.message : String(err),
-            host,
-            port,
-          });
+          const logger = opts.logger;
+          if (logger?.warn) {
+            logger.warn('webhooks: listener failed to start', {
+              err: err instanceof Error ? err.message : String(err),
+              host,
+              port,
+            });
+          }
           serverInstance = null;
         }
 
@@ -317,13 +323,17 @@ export function buildWebhooksPlugin(opts: BuildWebhooksPluginOptions): BuiltWebh
           void startTunnel({ host, port })
             .then((t) => {
               tunnelHandle.current = t;
-              opts.logger?.info?.('webhooks: proxy tunnel restored on boot', { url: t.url });
+              const logger = opts.logger;
+              if (logger?.info) logger.info('webhooks: proxy tunnel restored on boot', { url: t.url });
             })
-            .catch((err) =>
-              opts.logger?.warn?.('webhooks: proxy tunnel restore failed', {
-                err: err instanceof Error ? err.message : String(err),
-              }),
-            );
+            .catch((err) => {
+              const logger = opts.logger;
+              if (logger?.warn) {
+                logger.warn('webhooks: proxy tunnel restore failed', {
+                  err: err instanceof Error ? err.message : String(err),
+                });
+              }
+            });
         }
       },
       onShutdown: () => stopAll(),

--- a/packages/plugin-webhooks/src/queue.test.ts
+++ b/packages/plugin-webhooks/src/queue.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm, readdir, stat, utimes } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { WebhookDeliveryQueue } from './queue.js';
 
 describe('WebhookDeliveryQueue', () => {
@@ -41,7 +42,9 @@ describe('WebhookDeliveryQueue', () => {
     await queue.enqueue(rec({ deliveryId: 'dup', prompt: 'newer' }));
     const owned = await queue.listOwned('runner-A');
     expect(owned).toHaveLength(1);
-    expect(owned[0]!.prompt).toBe('newer');
+    const first = owned[0];
+    assertDefined(first, 'first owned delivery');
+    expect(first.prompt).toBe('newer');
   });
 
   it('remove drops a drained record', async () => {

--- a/packages/plugin-webhooks/src/runner.test.ts
+++ b/packages/plugin-webhooks/src/runner.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { WebhookDispatcher } from './runner.js';
 import { WebhookStore, type WebhookTrigger } from './store.js';
 
@@ -85,7 +86,9 @@ describe('WebhookDispatcher inbox filenames (burst uniqueness)', () => {
 
     const out = await dispatcher.fire(trigger, 'x', '../../etc/passwd');
     // The written file stays inside the inbox dir (no traversal via the id).
-    expect(path.dirname(out.inboxPath!)).toBe(inbox);
+    const inboxPath = out.inboxPath;
+    assertDefined(inboxPath, 'inbox path written by fire');
+    expect(path.dirname(inboxPath)).toBe(inbox);
     const files = await readdir(inbox);
     expect(files).toHaveLength(1);
   });

--- a/packages/plugin-webhooks/src/runner.ts
+++ b/packages/plugin-webhooks/src/runner.ts
@@ -143,10 +143,13 @@ export class WebhookDispatcher {
         prompt,
         deliveryId,
       });
-      this.opts.logger?.info?.('webhooks: delivery handed off to owner runner', {
-        trigger: trigger.name,
-        owner,
-      });
+      const logger = this.opts.logger;
+      if (logger?.info) {
+        logger.info('webhooks: delivery handed off to owner runner', {
+          trigger: trigger.name,
+          owner,
+        });
+      }
       return { handled: 'enqueued', ownerSessionId: owner };
     }
     const outcome = await this.fire(trigger, prompt, deliveryId);
@@ -158,6 +161,9 @@ export class WebhookDispatcher {
     prompt: string,
     deliveryId: string | null,
   ): Promise<WebhookFireOutcome> {
+    // Best-effort logging: read the optional logger once and narrow each method
+    // at the call site, preserving the silent path when either is absent.
+    const logger = this.opts.logger;
     let result: WebhookPromptResult;
     try {
       result = await this.opts.runner.runPrompt({
@@ -174,10 +180,12 @@ export class WebhookDispatcher {
     try {
       inboxPath = await writeInbox(trigger, result, deliveryId, this.opts.inbox);
     } catch (err) {
-      this.opts.logger?.warn?.('webhooks: inbox write failed', {
-        trigger: trigger.name,
-        err: err instanceof Error ? err.message : String(err),
-      });
+      if (logger?.warn) {
+        logger.warn('webhooks: inbox write failed', {
+          trigger: trigger.name,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
 
     try {
@@ -186,10 +194,12 @@ export class WebhookDispatcher {
         ...(result.error ? { error: result.error } : {}),
       });
     } catch (err) {
-      this.opts.logger?.warn?.('webhooks: store update failed', {
-        trigger: trigger.name,
-        err: err instanceof Error ? err.message : String(err),
-      });
+      if (logger?.warn) {
+        logger.warn('webhooks: store update failed', {
+          trigger: trigger.name,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
 
     const outcome: WebhookFireOutcome = {
@@ -202,17 +212,21 @@ export class WebhookDispatcher {
     try {
       this.opts.onFired?.(trigger, outcome);
     } catch (err) {
-      this.opts.logger?.warn?.('webhooks: onFired hook threw', {
-        trigger: trigger.name,
-        err: err instanceof Error ? err.message : String(err),
-      });
+      if (logger?.warn) {
+        logger.warn('webhooks: onFired hook threw', {
+          trigger: trigger.name,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
 
-    this.opts.logger?.info?.('webhooks: fired', {
-      trigger: trigger.name,
-      ok: outcome.ok,
-      inbox: outcome.inboxPath,
-    });
+    if (logger?.info) {
+      logger.info('webhooks: fired', {
+        trigger: trigger.name,
+        ok: outcome.ok,
+        inbox: outcome.inboxPath,
+      });
+    }
     return outcome;
   }
 }

--- a/packages/plugin-webhooks/src/server.test.ts
+++ b/packages/plugin-webhooks/src/server.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { RateLimiter } from './rate-limit.js';
 import { WebhookDispatcher, type WebhookFireOutcome } from './runner.js';
 import { WebhookServer } from './server.js';
@@ -170,11 +171,13 @@ describe('WebhookServer', () => {
     // outcome (polls until present rather than guessing a fixed delay).
     await waitUntil(() => fired.length >= 1);
     expect(fired).toHaveLength(1);
-    expect(fired[0]!.outcome.ok).toBe(true);
+    const firstFired = fired[0];
+    assertDefined(firstFired, 'first fired delivery');
+    expect(firstFired.outcome.ok).toBe(true);
     // The header value is fenced as untrusted, so the operator text + the value
     // appear, just not as one verbatim run.
-    expect(fired[0]!.outcome.text).toContain('ran with prompt: New event:');
-    expect(fired[0]!.outcome.text).toContain('issues');
+    expect(firstFired.outcome.text).toContain('ran with prompt: New event:');
+    expect(firstFired.outcome.text).toContain('issues');
   });
 
   it('rejects a bad HMAC with 401 and does not fire', async () => {

--- a/packages/plugin-webhooks/src/server.ts
+++ b/packages/plugin-webhooks/src/server.ts
@@ -1,4 +1,5 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { assertDefined } from '@moxxy/sdk';
 import { readRequestBody } from '@moxxy/sdk/server';
 import { DeliveryDedupeCache } from './dedupe.js';
 import { shouldFire } from './filter.js';
@@ -83,9 +84,12 @@ export class WebhookServer {
 
     const server = createServer((req, res) => {
       this.handle(req, res).catch((err) => {
-        this.opts.logger?.warn?.('webhooks: handler threw', {
-          err: err instanceof Error ? err.message : String(err),
-        });
+        const logger = this.opts.logger;
+        if (logger?.warn) {
+          logger.warn('webhooks: handler threw', {
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
         if (!res.headersSent) {
           res.writeHead(500, { 'content-type': 'application/json' });
           res.end(JSON.stringify({ error: 'internal' }));
@@ -99,10 +103,13 @@ export class WebhookServer {
     await new Promise<void>((resolve, reject) => {
       server.once('error', reject);
       server.listen(this.opts.port, this.opts.host, () => {
-        this.opts.logger?.info?.('webhooks: listening', {
-          host: this.opts.host,
-          port: this.opts.port,
-        });
+        const logger = this.opts.logger;
+        if (logger?.info) {
+          logger.info('webhooks: listening', {
+            host: this.opts.host,
+            port: this.opts.port,
+          });
+        }
         resolve();
       });
     });
@@ -142,7 +149,10 @@ export class WebhookServer {
       res.end(JSON.stringify({ error: 'not_found' }));
       return;
     }
-    const triggerId = m[1]!;
+    const triggerId = m[1];
+    // Group 1 is a required capture in TRIGGER_PATH_RE; a successful exec (m is
+    // non-null here) guarantees it matched.
+    assertDefined(triggerId, 'webhook trigger id capture group');
     const trigger = await this.opts.store.get(triggerId);
     if (!trigger) {
       // Don't leak which IDs exist — same generic 404.
@@ -163,7 +173,8 @@ export class WebhookServer {
     // valid signature — is shed here with a cheap 429 instead of pinning the
     // single event loop on cryptographic + parse work for every replayed copy.
     if (this.rateLimiter && !this.rateLimiter.tryAcquire(trigger.id)) {
-      this.opts.logger?.warn?.('webhooks: rate limited', { trigger: trigger.name });
+      const logger = this.opts.logger;
+      if (logger?.warn) logger.warn('webhooks: rate limited', { trigger: trigger.name });
       res.writeHead(429, { 'content-type': 'application/json', 'retry-after': '1' });
       res.end(JSON.stringify({ error: 'rate_limited' }));
       return;
@@ -175,11 +186,14 @@ export class WebhookServer {
     } catch (err) {
       // Generic to the (pre-auth) client — don't echo the internal error or the
       // configured size limit. Detail goes to the server log only.
-      this.opts.logger?.warn?.('webhooks: rejected oversized body', {
-        trigger: trigger.name,
-        limit: this.maxBodyBytes,
-        err: err instanceof Error ? err.message : String(err),
-      });
+      const logger = this.opts.logger;
+      if (logger?.warn) {
+        logger.warn('webhooks: rejected oversized body', {
+          trigger: trigger.name,
+          limit: this.maxBodyBytes,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
       res.writeHead(413, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ error: 'payload_too_large' }));
       return;
@@ -191,10 +205,13 @@ export class WebhookServer {
       body,
     });
     if (!verdict.ok) {
-      this.opts.logger?.warn?.('webhooks: rejected delivery', {
-        trigger: trigger.name,
-        reason: verdict.reason,
-      });
+      const logger = this.opts.logger;
+      if (logger?.warn) {
+        logger.warn('webhooks: rejected delivery', {
+          trigger: trigger.name,
+          reason: verdict.reason,
+        });
+      }
       res.writeHead(401, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ error: 'verification_failed' }));
       return;
@@ -206,19 +223,25 @@ export class WebhookServer {
     // stays first so we never dedupe-record an unverified request.
     const idempKey = idempotencyKey(trigger, req.headers);
     if (idempKey && !this.dedupe.check(trigger.id, idempKey)) {
-      this.opts.logger?.info?.('webhooks: duplicate delivery, dropped', {
-        trigger: trigger.name,
-        key: idempKey,
-      });
+      const logger = this.opts.logger;
+      if (logger?.info) {
+        logger.info('webhooks: duplicate delivery, dropped', {
+          trigger: trigger.name,
+          key: idempKey,
+        });
+      }
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ status: 'duplicate' }));
       return;
     }
 
     if (!shouldFire(trigger.filters, { headers: req.headers, body })) {
-      this.opts.logger?.info?.('webhooks: filtered out, not firing', {
-        trigger: trigger.name,
-      });
+      const logger = this.opts.logger;
+      if (logger?.info) {
+        logger.info('webhooks: filtered out, not firing', {
+          trigger: trigger.name,
+        });
+      }
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ status: 'filtered' }));
       return;
@@ -242,10 +265,13 @@ export class WebhookServer {
     // trigger (or it's owner-less), and otherwise hands the delivery to the
     // owning runner via the shared queue. Errors are logged inside the dispatcher.
     void this.opts.dispatcher.route(trigger, prompt, idempKey).catch((err) => {
-      this.opts.logger?.warn?.('webhooks: route failed', {
-        trigger: trigger.name,
-        err: err instanceof Error ? err.message : String(err),
-      });
+      const logger = this.opts.logger;
+      if (logger?.warn) {
+        logger.warn('webhooks: route failed', {
+          trigger: trigger.name,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
     });
   }
 }

--- a/packages/plugin-webhooks/src/store.test.ts
+++ b/packages/plugin-webhooks/src/store.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { WebhookStore } from './store.js';
 
 describe('WebhookStore', () => {
@@ -41,8 +42,10 @@ describe('WebhookStore', () => {
     const reloaded = new WebhookStore({ file: path.join(dir, 'webhooks.json') });
     const all = await reloaded.list();
     expect(all).toHaveLength(1);
-    expect(all[0]!.name).toBe('gh-issues');
-    expect(all[0]!.fireCount).toBe(0);
+    const first = all[0];
+    assertDefined(first, 'first webhook');
+    expect(first.name).toBe('gh-issues');
+    expect(first.fireCount).toBe(0);
   });
 
   it('rejects duplicate names', async () => {
@@ -154,7 +157,9 @@ describe('WebhookStore', () => {
       expect(warning).toMatch(/\.corrupt-/);
       const sidecars = (await readdir(dir)).filter((f) => f.includes('.corrupt-'));
       expect(sidecars).toHaveLength(1);
-      expect(await readFile(path.join(dir, sidecars[0]!), 'utf8')).toBe(garbage);
+      const sidecar = sidecars[0];
+      assertDefined(sidecar, 'corrupt sidecar');
+      expect(await readFile(path.join(dir, sidecar), 'utf8')).toBe(garbage);
     });
 
     it('preserves a schema-mismatched file aside', async () => {
@@ -164,7 +169,9 @@ describe('WebhookStore', () => {
       expect(await store.loadWarning()).toMatch(/expected \{ version: 1/);
       const sidecars = (await readdir(dir)).filter((f) => f.includes('.corrupt-'));
       expect(sidecars).toHaveLength(1);
-      expect(await readFile(path.join(dir, sidecars[0]!), 'utf8')).toBe(bad);
+      const sidecar = sidecars[0];
+      assertDefined(sidecar, 'corrupt sidecar');
+      expect(await readFile(path.join(dir, sidecar), 'utf8')).toBe(bad);
     });
 
     it('keeps the corrupt copy recoverable after a subsequent write (no wipe)', async () => {
@@ -181,7 +188,9 @@ describe('WebhookStore', () => {
       // …but the original bytes survive in the .corrupt-* sidecar.
       const sidecars = (await readdir(dir)).filter((f) => f.includes('.corrupt-'));
       expect(sidecars).toHaveLength(1);
-      expect(await readFile(path.join(dir, sidecars[0]!), 'utf8')).toBe(original);
+      const sidecar = sidecars[0];
+      assertDefined(sidecar, 'corrupt sidecar');
+      expect(await readFile(path.join(dir, sidecar), 'utf8')).toBe(original);
       const live = JSON.parse(await readFile(file(), 'utf8')) as { triggers: Array<{ name: string }> };
       expect(live.triggers.map((t) => t.name)).toEqual(['fresh']);
     });
@@ -210,12 +219,16 @@ describe('WebhookStore', () => {
       expect(warning).toMatch(/1 trigger entry .*quarantined/);
       const sidecars = (await readdir(dir)).filter((f) => f.includes('.quarantine-'));
       expect(sidecars).toHaveLength(1);
-      const quarantined = JSON.parse(await readFile(path.join(dir, sidecars[0]!), 'utf8')) as {
+      const sidecar = sidecars[0];
+      assertDefined(sidecar, 'quarantine sidecar');
+      const quarantined = JSON.parse(await readFile(path.join(dir, sidecar), 'utf8')) as {
         entries: Array<{ index: number; entry: unknown; issues: string }>;
       };
       expect(quarantined.entries).toHaveLength(1);
-      expect(quarantined.entries[0]!.index).toBe(1);
-      expect(quarantined.entries[0]!.entry).toEqual(invalid);
+      const firstEntry = quarantined.entries[0];
+      assertDefined(firstEntry, 'first quarantined entry');
+      expect(firstEntry.index).toBe(1);
+      expect(firstEntry.entry).toEqual(invalid);
       // Quarantined entries survive a subsequent persist that drops them from the live file.
       await store.create({ name: 'another', prompt: 'x', allowedTools: [], verification: { type: 'none' } });
       const live = JSON.parse(await readFile(file(), 'utf8')) as { triggers: Array<{ name: string }> };

--- a/packages/plugin-webhooks/src/store.ts
+++ b/packages/plugin-webhooks/src/store.ts
@@ -1,5 +1,5 @@
 import { rename } from 'node:fs/promises';
-import { createJsonFileStore, type JsonFileStore } from '@moxxy/sdk';
+import { assertDefined, createJsonFileStore, type JsonFileStore } from '@moxxy/sdk';
 import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { ulid } from 'ulid';
 import { z } from 'zod';
@@ -302,7 +302,9 @@ export class WebhookStore {
     await this.store.mutate((triggers) => {
       const idx = triggers.findIndex((t) => t.id === id);
       if (idx < 0) return triggers;
-      const current = triggers[idx]!;
+      const current = triggers[idx];
+      // idx >= 0 here (the < 0 case returned above), so the element exists.
+      assertDefined(current, 'trigger at findIndex result');
       const next = webhookTriggerSchema.parse({
         ...current,
         lastFiredAt: Date.now(),
@@ -378,11 +380,14 @@ export class WebhookStore {
       `the webhook trigger store (${this.file}) ${reason}; the original file was preserved ` +
       `at ${preserved} and the store restarted empty. Previously configured triggers (and ` +
       'their secrets) are recoverable from that file — repair it by hand or recreate the triggers.';
-    this.logger?.error?.('webhooks: store file corrupt — preserved aside, starting empty', {
-      file: this.file,
-      preserved,
-      reason,
-    });
+    const logger = this.logger;
+    if (logger?.error) {
+      logger.error('webhooks: store file corrupt — preserved aside, starting empty', {
+        file: this.file,
+        preserved,
+        reason,
+      });
+    }
     return [];
   }
 
@@ -410,12 +415,15 @@ export class WebhookStore {
       `${invalid.length} trigger entr${invalid.length === 1 ? 'y' : 'ies'} in ${this.file} ` +
       `failed schema validation and ${invalid.length === 1 ? 'was' : 'were'} quarantined to ` +
       `${quarantine} (valid triggers were kept). Inspect that file to repair or recreate them.`;
-    this.logger?.error?.('webhooks: invalid trigger entries quarantined', {
-      file: this.file,
-      quarantine,
-      count: invalid.length,
-      issues: invalid.map((i) => ({ index: i.index, issues: i.issues })),
-    });
+    const logger = this.logger;
+    if (logger?.error) {
+      logger.error('webhooks: invalid trigger entries quarantined', {
+        file: this.file,
+        quarantine,
+        count: invalid.length,
+        issues: invalid.map((i) => ({ index: i.index, issues: i.issues })),
+      });
+    }
   }
 
 }

--- a/packages/plugin-webhooks/src/template.test.ts
+++ b/packages/plugin-webhooks/src/template.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { renderPrompt } from './template.js';
 import type { WebhookTrigger } from './store.js';
 
@@ -51,7 +52,9 @@ describe('renderPrompt', () => {
     expect(out.startsWith('Delivery to ')).toBe(true);
     const open = out.match(/\[untrusted-webhook-data ([a-z0-9]+):/);
     expect(open).not.toBeNull();
-    const nonce = open![1]!;
+    assertDefined(open, 'untrusted-webhook-data fence present');
+    const nonce = open[1];
+    assertDefined(nonce, 'fence nonce capture group');
     // The injected path text is enclosed by the per-render nonce fence, so its
     // forged `]` cannot close the real envelope.
     expect(out).toContain(`[/untrusted-webhook-data ${nonce}]`);
@@ -76,7 +79,9 @@ describe('renderPrompt', () => {
     expect(out).toContain(malicious);
     const open = out.match(/\[untrusted-webhook-data ([a-z0-9]+):/);
     expect(open).not.toBeNull();
-    const nonce = open![1]!;
+    assertDefined(open, 'untrusted-webhook-data fence present');
+    const nonce = open[1];
+    assertDefined(nonce, 'fence nonce capture group');
     // Closing fence carries the same per-render nonce the payload can't predict.
     expect(out).toContain(`[/untrusted-webhook-data ${nonce}]`);
     // A payload that forges a *different* nonce can't actually close the fence.
@@ -88,7 +93,10 @@ describe('renderPrompt', () => {
       path: '/',
       firedAt: new Date(0),
     });
-    const realNonce = forged.match(/\[untrusted-webhook-data ([a-z0-9]+):/)![1]!;
+    const forgedMatch = forged.match(/\[untrusted-webhook-data ([a-z0-9]+):/);
+    assertDefined(forgedMatch, 'forged fence present');
+    const realNonce = forgedMatch[1];
+    assertDefined(realNonce, 'forged fence nonce capture group');
     expect(realNonce).not.toBe('deadbeef');
     expect(forged).toContain(`[/untrusted-webhook-data ${realNonce}]`);
   });

--- a/packages/plugin-webhooks/src/tools.test.ts
+++ b/packages/plugin-webhooks/src/tools.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { ToolContext, ToolDef } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { WebhookConfigStore } from './config.js';
 import type { WebhookDispatcher } from './runner.js';
@@ -63,12 +64,15 @@ describe('webhook tools', () => {
       };
 
       expect(result.generatedSecret).not.toBeNull();
-      const { masked, path: secretPath } = result.generatedSecret!;
+      const generated = result.generatedSecret;
+      assertDefined(generated, 'generated secret present');
+      const { masked, path: secretPath } = generated;
       expect(masked).toMatch(/^[0-9a-f]{4}…$/);
 
       // The real secret lives in the trigger store (it must verify HMACs)…
       const trigger = await store.getByName('gh-events');
-      const verification = trigger!.verification;
+      assertDefined(trigger, 'trigger just created via webhook_create');
+      const verification = trigger.verification;
       if (verification.type !== 'hmac') throw new Error('expected hmac verification');
       const realSecret = verification.secret;
       expect(realSecret).toHaveLength(64);
@@ -105,18 +109,19 @@ describe('webhook tools', () => {
       const secret = (await readFile(result.generatedSecret.path, 'utf8')).trim();
 
       const trigger = await store.getByName('hmac-e2e');
+      assertDefined(trigger, 'trigger just created via webhook_create');
       const body = Buffer.from('{"hello":"world"}', 'utf8');
       const sig = `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
       expect(
         verifyDelivery({
-          verification: trigger!.verification,
+          verification: trigger.verification,
           headers: { 'x-signature': sig },
           body,
         }),
       ).toEqual({ ok: true });
       expect(
         verifyDelivery({
-          verification: trigger!.verification,
+          verification: trigger.verification,
           headers: { 'x-signature': 'sha256=deadbeef' },
           body,
         }).ok,

--- a/packages/plugin-workflows/src/command.test.ts
+++ b/packages/plugin-workflows/src/command.test.ts
@@ -21,8 +21,10 @@ function wf(name: string, steps: Array<Record<string, unknown>> = [{ id: 'a', pr
 function fakeStore(entries: Workflow[]): WorkflowCommandDeps['store'] {
   const byName = new Map(entries.map((w) => [w.name, w]));
   return {
-    get: async (name: string) =>
-      byName.has(name) ? { workflow: byName.get(name)!, path: `/tmp/${name}.yaml`, scope: 'user' } : undefined,
+    get: async (name: string) => {
+      const workflow = byName.get(name);
+      return workflow ? { workflow, path: `/tmp/${name}.yaml`, scope: 'user' } : undefined;
+    },
   } as unknown as WorkflowCommandDeps['store'];
 }
 

--- a/packages/plugin-workflows/src/draft.test.ts
+++ b/packages/plugin-workflows/src/draft.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { LLMProvider, ProviderEvent } from '@moxxy/sdk';
+import { assertDefined, type LLMProvider, type ProviderEvent } from '@moxxy/sdk';
 import { FakeProvider, textReply } from '@moxxy/testing';
 import { buildSystemPrompt, draftWorkflow } from './draft.js';
 
@@ -76,10 +76,14 @@ describe('draftWorkflow', () => {
     );
     expect(drafted.parse.ok).toBe(true);
     expect(drafted.parse.errors).toEqual([]);
-    expect(drafted.parse.workflow?.name).toBe('image-report-email');
-    expect(drafted.parse.workflow?.steps).toHaveLength(3);
-    expect(drafted.parse.workflow?.inputs?.recipient).toBeDefined();
-    expect(drafted.parse.workflow?.steps[2]?.tool).toBe('gmail_send');
+    const wf = drafted.parse.workflow;
+    assertDefined(wf, 'drafted workflow parsed ok');
+    expect(wf.name).toBe('image-report-email');
+    expect(wf.steps).toHaveLength(3);
+    expect(wf.inputs.recipient).toBeDefined();
+    const emailStep = wf.steps[2];
+    assertDefined(emailStep, 'third drafted step');
+    expect(emailStep.tool).toBe('gmail_send');
     expect(provider.received[0]?.maxTokens).toBe(4096);
     expect(drafted.truncated).toBe(false);
   });

--- a/packages/plugin-workflows/src/engine.ts
+++ b/packages/plugin-workflows/src/engine.ts
@@ -71,10 +71,13 @@ export async function runWorkflow(
   const result = await executor.run(workflow, deps);
   if (opts.recordDir !== null) {
     await writeRunRecord(workflow, result, startedAt, executor.name, deps, opts.recordDir ?? defaultRunRecordDir()).catch(
-      (err) =>
-        deps.logger?.warn?.('workflow: failed to write run record', {
-          error: err instanceof Error ? err.message : String(err),
-        }),
+      (err) => {
+        const logger = deps.logger;
+        if (logger?.warn)
+          logger.warn('workflow: failed to write run record', {
+            error: err instanceof Error ? err.message : String(err),
+          });
+      },
     );
   }
   return result;

--- a/packages/plugin-workflows/src/executor/context.ts
+++ b/packages/plugin-workflows/src/executor/context.ts
@@ -116,7 +116,8 @@ export function mergeVars(ctx: ExecutorContext, vars: Record<string, unknown> | 
   if (!vars) return;
   for (const [key, value] of Object.entries(vars)) {
     if (UNSAFE_VAR_KEYS.has(key)) {
-      ctx.deps.logger?.warn?.('workflow vars: dropping prototype-pollution key', { key });
+      const logger = ctx.deps.logger;
+      if (logger?.warn) logger.warn('workflow vars: dropping prototype-pollution key', { key });
       continue;
     }
     // Own-property assignment only (skips inherited keys that Object.entries

--- a/packages/plugin-workflows/src/executor/dag.test.ts
+++ b/packages/plugin-workflows/src/executor/dag.test.ts
@@ -1,5 +1,6 @@
 import {
   asSessionId,
+  assertDefined,
   type Skill,
   type SubagentResult,
   type SubagentSpec,
@@ -124,7 +125,10 @@ function makeHarness(overrides: Partial<WorkflowRunDeps> = {}, skills: Record<st
       },
     },
     lookup: {
-      skill: (n) => (skills[n] !== undefined ? fakeSkill(n, skills[n]!) : undefined),
+      skill: (n) => {
+        const body = skills[n];
+        return body !== undefined ? fakeSkill(n, body) : undefined;
+      },
       workflow: () => undefined,
     },
     signal: new AbortController().signal,
@@ -150,7 +154,8 @@ describe('dag executor', () => {
     );
     expect(result.ok).toBe(true);
     expect(result.steps.map((s) => s.status)).toEqual(['completed', 'completed']);
-    const analyze = h.specs.find((s) => s.label === 'analyze')!;
+    const analyze = h.specs.find((s) => s.label === 'analyze');
+    assertDefined(analyze, 'the analyze step spawned a subagent');
     expect(analyze.prompt).toBe('see OUT_fetch');
     expect(result.output).toBe('OUT_analyze'); // sink
   });
@@ -200,7 +205,9 @@ describe('dag executor', () => {
     expect(h.order.indexOf('fetch')).toBeLessThan(h.order.indexOf('check'));
     expect(h.order.indexOf('analyze')).toBeLessThan(h.order.indexOf('tool:send'));
     expect(h.order.indexOf('check')).toBeLessThan(h.order.indexOf('tool:send'));
-    expect(h.toolCalls[0]!.input).toEqual({ body: 'OUT_analyze|OUT_check' });
+    const sendCall = h.toolCalls[0];
+    assertDefined(sendCall, 'the send tool was called');
+    expect(sendCall.input).toEqual({ body: 'OUT_analyze|OUT_check' });
   });
 
   it('skips a step whose `when` is false but still runs its dependents', async () => {
@@ -232,7 +239,8 @@ describe('dag executor', () => {
       }),
       h.deps,
     );
-    const spec = h.specs[0]!;
+    const spec = h.specs[0];
+    assertDefined(spec, 'the skill step spawned a subagent');
     expect(spec.systemPrompt).toBe('RESEARCH PLAYBOOK');
     expect(spec.prompt).toBe('find news');
     expect(spec.allowedTools).toEqual(['Read']);
@@ -313,7 +321,9 @@ describe('dag executor', () => {
     );
     expect(result.ok).toBe(true);
     expect(attempts).toBe(2);
-    expect(result.steps[0]!.status).toBe('completed');
+    const first = result.steps[0];
+    assertDefined(first, 'first step result');
+    expect(first.status).toBe('completed');
   });
 
   // Retry contract (u117-3): `retries` is gated on `onError: 'retry'`. The three
@@ -341,7 +351,9 @@ describe('dag executor', () => {
     );
     expect(result.ok).toBe(false);
     expect(attempts).toBe(3); // 1 initial + 2 retries
-    expect(result.steps[0]!.status).toBe('failed');
+    const first = result.steps[0];
+    assertDefined(first, 'first step result');
+    expect(first.status).toBe('failed');
   });
 
   it('onError=fail runs exactly ONE attempt even with retries set', async () => {
@@ -365,7 +377,9 @@ describe('dag executor', () => {
     );
     expect(result.ok).toBe(false);
     expect(attempts).toBe(1); // retries ignored outside retry mode
-    expect(result.steps[0]!.status).toBe('failed');
+    const first = result.steps[0];
+    assertDefined(first, 'first step result');
+    expect(first.status).toBe('failed');
   });
 
   it('onError=continue runs exactly ONE attempt even with retries set', async () => {
@@ -409,7 +423,9 @@ describe('dag executor', () => {
       deps,
     );
     expect(result.ok).toBe(true);
-    expect(result.steps[0]!.output).toBe('OUT_i');
+    const first = result.steps[0];
+    assertDefined(first, 'first step result');
+    expect(first.output).toBe('OUT_i');
   });
 
   it('a hard failure breaks the rest of the wave (no later step runs or completes)', async () => {
@@ -468,8 +484,10 @@ describe('dag executor', () => {
     // The run fails loudly (does NOT report paused/completed) and names awaitInput.
     expect(result.ok).toBe(false);
     expect(result.status).toBe('failed');
-    expect(result.steps[0]!.status).toBe('failed');
-    expect(result.steps[0]!.error).toMatch(/awaitInput/i);
+    const first = result.steps[0];
+    assertDefined(first, 'first step result');
+    expect(first.status).toBe('failed');
+    expect(first.error).toMatch(/awaitInput/i);
     // No orphaned inner checkpoint left behind in the store.
     const leftover = (await readdir(dir)).filter((f) => f.endsWith('.json'));
     expect(leftover).toEqual([]);
@@ -517,7 +535,8 @@ describe('dag executor', () => {
       h.deps,
     );
     const completed = events.find((e) => e.subtype === 'workflow_completed');
-    expect((completed?.payload as { empty?: boolean })?.empty).toBeUndefined();
+    assertDefined(completed, 'workflow_completed event was emitted');
+    expect((completed.payload as { empty?: boolean }).empty).toBeUndefined();
   });
 
   it('pauses on awaitInput and resumes after operator reply', async () => {
@@ -541,10 +560,13 @@ describe('dag executor', () => {
     expect(events).toContain('workflow_step_awaiting_input');
     expect(events).toContain('workflow_paused');
 
-    const resumed = await resumeWorkflowRun(paused.runId!, 'cyberpunk city at night', h.deps, store);
+    const runId = paused.runId;
+    assertDefined(runId, 'a paused run reports its runId');
+    const resumed = await resumeWorkflowRun(runId, 'cyberpunk city at night', h.deps, store);
     expect(resumed.status).toBe('completed');
     expect(resumed.ok).toBe(true);
-    const go = h.specs.find((s) => s.label === 'go')!;
+    const go = h.specs.find((s) => s.label === 'go');
+    assertDefined(go, 'the go step spawned after resume');
     expect(go.prompt).toContain('FINAL_ask');
     await rm(dir, { recursive: true, force: true });
   });
@@ -565,8 +587,10 @@ describe('dag executor', () => {
       h.deps,
     );
     expect(paused.status).toBe('paused');
+    const runId = paused.runId;
+    assertDefined(runId, 'a paused run reports its runId');
     // Same emit spy drives the resume — assert ONE workflow_started total.
-    await resumeWorkflowRun(paused.runId!, 'reply', h.deps, store);
+    await resumeWorkflowRun(runId, 'reply', h.deps, store);
     expect(events.filter((e) => e === 'workflow_started')).toHaveLength(1);
     // workflow_resumed precedes any continued step-completed event.
     const resumedAt = events.indexOf('workflow_resumed');
@@ -605,21 +629,23 @@ describe('dag executor', () => {
     // PAUSED — checkpoint written, workflow_paused emitted with the prompt step + runId.
     expect(paused.status).toBe('paused');
     expect(paused.runId).toBeTruthy();
+    const runId = paused.runId;
+    assertDefined(runId, 'a paused run reports its runId');
     const pausedEvent = events.find((e) => e.subtype === 'workflow_paused');
-    expect(pausedEvent?.payload).toMatchObject({ runId: paused.runId, stepId: 'ask' });
+    expect(pausedEvent?.payload).toMatchObject({ runId, stepId: 'ask' });
     // The pending step's prompt is surfaced to the operator (awaiting_input preview).
     const awaiting = events.find((e) => e.subtype === 'workflow_step_awaiting_input');
     expect(awaiting?.payload).toMatchObject({ id: 'ask' });
-    expect(await store.load(paused.runId!)).not.toBeNull();
+    expect(await store.load(runId)).not.toBeNull();
 
     // RESUME with the operator reply → run COMPLETES (not paused/hung).
-    const resumed = await resumeWorkflowRun(paused.runId!, 'ship it', h.deps, store);
+    const resumed = await resumeWorkflowRun(runId, 'ship it', h.deps, store);
     expect(resumed.status).toBe('completed');
     expect(resumed.ok).toBe(true);
     // The downstream tool ran with the reply AND the pre-pause var.
     expect(h.toolCalls.find((c) => c.name === 'notify')?.input).toEqual({ to: '#ops', body: 'FINAL_Approve' });
     // The checkpoint is cleaned up once resumed (no orphaned paused run).
-    expect(await store.load(paused.runId!)).toBeNull();
+    expect(await store.load(runId)).toBeNull();
     await rm(dir, { recursive: true, force: true });
   });
 
@@ -648,7 +674,9 @@ describe('dag executor', () => {
     );
     expect(paused.status).toBe('paused');
 
-    const resumed = await resumeWorkflowRun(paused.runId!, 'go ahead', h.deps, store);
+    const runId = paused.runId;
+    assertDefined(runId, 'a paused run reports its runId');
+    const resumed = await resumeWorkflowRun(runId, 'go ahead', h.deps, store);
     expect(resumed.ok).toBe(true);
     expect(h.toolCalls.find((c) => c.name === 'notify')?.input).toEqual({ to: 'ops@example.com' });
     await rm(dir, { recursive: true, force: true });
@@ -701,10 +729,12 @@ describe('dag executor', () => {
     );
     expect(paused.status).toBe('paused');
 
+    const runId = paused.runId;
+    assertDefined(runId, 'a paused run reports its runId');
     const resumeDeps = { ...h.deps, spawner: slowContinue } as WorkflowRunDeps;
     const [a, b] = await Promise.all([
-      resumeWorkflowRun(paused.runId!, 'one', resumeDeps, countingStore),
-      resumeWorkflowRun(paused.runId!, 'two', resumeDeps, countingStore),
+      resumeWorkflowRun(runId, 'one', resumeDeps, countingStore),
+      resumeWorkflowRun(runId, 'two', resumeDeps, countingStore),
     ]);
     // Exactly one resume proceeded; the other was rejected by the in-flight lock.
     const oks = [a, b].filter((r) => r.ok);
@@ -736,7 +766,9 @@ describe('dag executor', () => {
     );
     expect(result.ok).toBe(true);
     // The safe key still merges…
-    expect(h.toolCalls[0]!.input).toEqual({ v: 'ok' });
+    const notifyCall = h.toolCalls[0];
+    assertDefined(notifyCall, 'the notify tool was called');
+    expect(notifyCall.input).toEqual({ v: 'ok' });
     // …but the prototype is not polluted.
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
     expect(Object.prototype.hasOwnProperty.call(Object.prototype, 'polluted')).toBe(false);
@@ -761,7 +793,9 @@ describe('dag executor', () => {
       h.deps,
     );
     expect(result.ok).toBe(true);
-    expect(h.toolCalls[0]!.input).toEqual({ to: 'ops@example.com' });
+    const notifyCall = h.toolCalls[0];
+    assertDefined(notifyCall, 'the notify tool was called');
+    expect(notifyCall.input).toEqual({ to: 'ops@example.com' });
   });
 
   it('condition skips the inactive branch', async () => {
@@ -821,7 +855,9 @@ describe('dag executor', () => {
       h.deps,
     );
     expect(result.ok).toBe(false);
-    expect(result.steps[0]!.status).toBe('failed');
+    const first = result.steps[0];
+    assertDefined(first, 'first step result');
+    expect(first.status).toBe('failed');
   });
 });
 
@@ -896,7 +932,8 @@ describe('dag executor — while-loop node', () => {
     const result = await dagExecutor.run(loopWf('loop-cap', 4), h.deps);
     expect(result.ok).toBe(true);
     expect(h.order.filter((o) => o === 'bump').length).toBe(4); // exactly maxIterations
-    const spin = result.steps.find((s) => s.id === 'spin')!;
+    const spin = result.steps.find((s) => s.id === 'spin');
+    assertDefined(spin, 'the spin step has a result');
     expect(spin.status).toBe('completed');
     expect(spin.output).toMatch(/max iterations \(4\)/);
   });
@@ -910,9 +947,11 @@ describe('dag executor — while-loop node', () => {
     } as Partial<WorkflowRunDeps>);
     const result = await dagExecutor.run(loopWf('loop-vars'), h.deps);
     expect(result.ok).toBe(true);
-    const condSpec = h.specs.find((s) => s.label === 'spin (condition)')!;
+    const condSpec = h.specs.find((s) => s.label === 'spin (condition)');
+    assertDefined(condSpec, 'the loop condition spawned a subagent');
     expect(condSpec.prompt).toContain('42'); // {{ vars.count }} rendered the body's var
-    const done = h.specs.find((s) => s.label === 'done')!;
+    const done = h.specs.find((s) => s.label === 'done');
+    assertDefined(done, 'the done step spawned a subagent');
     expect(done.prompt).toContain('42'); // downstream step also sees the var
   });
 
@@ -955,7 +994,8 @@ describe('dag executor — while-loop node', () => {
     const byId = Object.fromEntries(result.steps.map((s) => [s.id, s.status]));
     expect(byId.spin).toBe('completed');
     expect(byId.after).toBe('completed'); // downstream of the loop RUNS
-    const spin = result.steps.find((s) => s.id === 'spin')!;
+    const spin = result.steps.find((s) => s.id === 'spin');
+    assertDefined(spin, 'the spin step has a result');
     expect(spin.output).toMatch(/broke on error/);
   });
 
@@ -994,7 +1034,8 @@ describe('dag executor — while-loop node', () => {
     const byId = Object.fromEntries(result.steps.map((s) => [s.id, s.status]));
     expect(byId.spin).toBe('completed');
     expect(byId.after).toBe('completed');
-    const spin = result.steps.find((s) => s.id === 'spin')!;
+    const spin = result.steps.find((s) => s.id === 'spin');
+    assertDefined(spin, 'the spin step has a result');
     expect(spin.output).not.toMatch(/broke on error/); // it was not a break
   });
 
@@ -1031,7 +1072,8 @@ describe('dag executor — while-loop node', () => {
     // guard throws, failing the body step (onError=fail) → the body error
     // BREAKS the loop (loop returns ok), and the downstream step still runs.
     expect(result.ok).toBe(true);
-    const loopnest = result.steps.find((s) => s.id === 'loopnest')!;
+    const loopnest = result.steps.find((s) => s.id === 'loopnest');
+    assertDefined(loopnest, 'the loopnest step has a result');
     expect(loopnest.status).toBe('completed');
     expect(loopnest.output).toMatch(/broke on error/);
     expect(loopnest.output).toMatch(/depth exceeded/);

--- a/packages/plugin-workflows/src/executor/scheduler.ts
+++ b/packages/plugin-workflows/src/executor/scheduler.ts
@@ -1,4 +1,5 @@
 import {
+  assertDefined,
   type SessionId,
   type Workflow,
   type WorkflowRunDeps,
@@ -59,7 +60,8 @@ export async function runExecutorLoop(
       skippedSomething = false;
       for (const step of workflow.steps) {
         if (ctx.loopBodyIds.has(step.id)) continue; // owned by a loop
-        const st = ctx.states.get(step.id)!;
+        const st = ctx.states.get(step.id);
+        assertDefined(st, 'runExecutor initializes a state for every step');
         if (st.status !== 'pending') continue;
         if (!step.needs.every(settled)) continue;
         if (step.when == null) continue;
@@ -95,7 +97,8 @@ export async function runExecutorLoop(
     //    Loop-body steps are owned by their loop and never scheduled here.
     const ready = workflow.steps.filter((step) => {
       if (ctx.loopBodyIds.has(step.id)) return false;
-      const st = ctx.states.get(step.id)!;
+      const st = ctx.states.get(step.id);
+      assertDefined(st, 'runExecutor initializes a state for every step');
       return st.status === 'pending' && step.needs.every(settled);
     });
 
@@ -141,7 +144,8 @@ export async function runExecutorLoop(
       // subagent/tool calls and emitting completed events for steps that ran
       // after the run had logically failed.
       if (aborted) break;
-      const st = ctx.states.get(step.id)!;
+      const st = ctx.states.get(step.id);
+      assertDefined(st, 'runExecutor initializes a state for every step');
       st.startedAt = ctx.now();
       await deps.emit?.('workflow_step_started', {
         id: step.id,
@@ -151,6 +155,8 @@ export async function runExecutorLoop(
       st.endedAt = ctx.now();
 
       if (outcome.paused) {
+        const interactionAgentId = outcome.interactionAgentId;
+        assertDefined(interactionAgentId, 'a paused outcome always carries interactionAgentId');
         st.status = 'awaiting_input';
         st.output = outcome.output;
         await deps.emit?.('workflow_step_awaiting_input', {
@@ -169,7 +175,7 @@ export async function runExecutorLoop(
           // resume restores them (otherwise downstream `{{ vars.x }}` is lost).
           vars: ctx.vars,
           pendingStepId: step.id,
-          interactionAgentId: outcome.interactionAgentId!,
+          interactionAgentId,
           startedAt: ctx.now(),
         });
         await deps.emit?.('workflow_paused', {
@@ -342,7 +348,8 @@ async function resumeWorkflowRunInner(
   };
   mergeVars(ctx, checkpoint.vars);
 
-  const st = ctx.states.get(step.id)!;
+  const st = ctx.states.get(step.id);
+  assertDefined(st, 'the paused step has a restored state in the checkpoint');
   await deps.emit?.('workflow_resumed', { runId, stepId: step.id });
 
   if (typeof deps.spawner.continue !== 'function') {

--- a/packages/plugin-workflows/src/executor/state-serde.test.ts
+++ b/packages/plugin-workflows/src/executor/state-serde.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { Workflow } from '@moxxy/sdk';
+import { assertDefined, type Workflow } from '@moxxy/sdk';
 import type { SerializedStepState } from '../run-store.js';
 import type { ExecutorContext, StepState } from './context.js';
 import {
@@ -42,8 +42,12 @@ describe('state-serde', () => {
       bad: { status: 'failed', output: '', error: 'nope', startedAt: 0, endedAt: 1 },
     };
     const restored = restoreStates(raw);
-    expect('error' in restored.get('ok')!).toBe(false);
-    expect(restored.get('bad')!.error).toBe('nope');
+    const ok = restored.get('ok');
+    assertDefined(ok, 'restored map has the "ok" entry from raw');
+    expect('error' in ok).toBe(false);
+    const bad = restored.get('bad');
+    assertDefined(bad, 'restored map has the "bad" entry from raw');
+    expect(bad.error).toBe('nope');
   });
 
   it('buildStepResults maps pending → "skipped" and reports per-step status', () => {

--- a/packages/plugin-workflows/src/executor/state-serde.ts
+++ b/packages/plugin-workflows/src/executor/state-serde.ts
@@ -1,4 +1,5 @@
 import {
+  assertDefined,
   type Workflow,
   type WorkflowRunResult,
   type WorkflowRunStatus,
@@ -48,7 +49,8 @@ export function buildStepResults(
   states: Map<string, StepState>,
 ): WorkflowStepResult[] {
   return workflow.steps.map((step) => {
-    const st = states.get(step.id)!;
+    const st = states.get(step.id);
+    assertDefined(st, 'states has an entry for every workflow step');
     const status: WorkflowStepStatus =
       st.status === 'pending' ? 'skipped' : (st.status as WorkflowStepStatus);
     return {

--- a/packages/plugin-workflows/src/executor/steps.ts
+++ b/packages/plugin-workflows/src/executor/steps.ts
@@ -1,4 +1,5 @@
 import {
+  assertDefined,
   type SubagentSpec,
   type WorkflowRunDeps,
   type WorkflowStep,
@@ -41,11 +42,13 @@ export async function runStep(
       return await runStepOnce(step, scope, ctx);
     } catch (err) {
       lastError = err instanceof Error ? err.message : String(err);
-      ctx.deps.logger?.warn?.('workflow step attempt failed', {
-        step: step.id,
-        attempt: attempt + 1,
-        error: lastError,
-      });
+      const logger = ctx.deps.logger;
+      if (logger?.warn)
+        logger.warn('workflow step attempt failed', {
+          step: step.id,
+          attempt: attempt + 1,
+          error: lastError,
+        });
     }
   }
   return { ok: false, output: '', error: lastError };
@@ -110,7 +113,8 @@ async function runNestedWorkflow(
   opts: LoggerOpts,
 ): Promise<StepOutcome> {
   const { deps } = ctx;
-  const nested = deps.lookup.workflow(step.workflow!);
+  assertDefined(step.workflow, 'runNestedWorkflow is only invoked for workflow steps');
+  const nested = deps.lookup.workflow(step.workflow);
   if (!nested) throw new Error(`nested workflow "${step.workflow}" not found`);
   const depth = (deps.depth ?? 0) + 1;
   if (depth > MAX_NESTING_DEPTH) {
@@ -147,7 +151,10 @@ async function runNestedWorkflow(
 
 function buildUpstreamBlock(step: WorkflowStep, scope: TemplateScope): string {
   if (step.needs.length === 0) return '';
-  const parts = step.needs.map((id) => `### ${id}\n${scope.steps?.[id]?.output ?? ''}`);
+  const parts = step.needs.map((id) => {
+    const entry = scope.steps?.[id];
+    return `### ${id}\n${entry?.output ?? ''}`;
+  });
   return `\n\n## Upstream\n${parts.join('\n\n')}`;
 }
 
@@ -241,7 +248,8 @@ async function runLoopStep(
   ctx: ExecutorContext,
   opts: LoggerOpts,
 ): Promise<StepOutcome> {
-  const loop = step.loop!;
+  assertDefined(step.loop, 'runLoopStep is only invoked for loop steps');
+  const loop = step.loop;
   const max = loop.maxIterations;
   const bodySteps = loop.body
     .map((id) => ctx.workflow.steps.find((s) => s.id === id))
@@ -258,7 +266,8 @@ async function runLoopStep(
 
     // Each iteration runs the body fresh: reset state for re-runnable steps.
     for (const body of bodySteps) {
-      const bst = ctx.states.get(body.id)!;
+      const bst = ctx.states.get(body.id);
+      assertDefined(bst, 'loop body ids are real workflow steps with initialized state');
       bst.status = 'pending';
       bst.output = '';
       delete bst.error;
@@ -267,7 +276,8 @@ async function runLoopStep(
     for (const body of bodySteps) {
       if (ctx.deps.signal.aborted) return { ok: false, output: lastBodyOutput, error: 'aborted' };
       const bodyScope = buildScope(ctx, new Date(ctx.now()).toISOString());
-      const bst = ctx.states.get(body.id)!;
+      const bst = ctx.states.get(body.id);
+      assertDefined(bst, 'loop body ids are real workflow steps with initialized state');
       bst.startedAt = ctx.now();
       const outcome = await runStep(body, bodyScope, ctx);
       bst.endedAt = ctx.now();
@@ -295,11 +305,13 @@ async function runLoopStep(
           // body error), rather than failing the whole workflow. Use
           // `onError: continue` on a body step to swallow its error and keep
           // iterating instead.
-          ctx.deps.logger?.warn?.('workflow loop broke on body error', {
-            step: step.id,
-            body: body.id,
-            error: outcome.error,
-          });
+          const logger = ctx.deps.logger;
+          if (logger?.warn)
+            logger.warn('workflow loop broke on body error', {
+              step: step.id,
+              body: body.id,
+              error: outcome.error,
+            });
           return {
             ok: true,
             output:
@@ -330,7 +342,8 @@ async function runLoopStep(
 
   // Reached the iteration cap without the predicate saying stop. Finish
   // cleanly with a clear note — never hang.
-  ctx.deps.logger?.warn?.('workflow loop hit max iterations', { step: step.id, maxIterations: max });
+  const logger = ctx.deps.logger;
+  if (logger?.warn) logger.warn('workflow loop hit max iterations', { step: step.id, maxIterations: max });
   return {
     ok: true,
     output:

--- a/packages/plugin-workflows/src/loader.ts
+++ b/packages/plugin-workflows/src/loader.ts
@@ -94,11 +94,12 @@ async function loadDir(
     try {
       const st = await fs.stat(full);
       if (st.size > MAX_WORKFLOW_FILE_BYTES) {
-        logger?.warn?.('workflow: file too large, skipping', {
-          path: full,
-          size: st.size,
-          max: MAX_WORKFLOW_FILE_BYTES,
-        });
+        if (logger?.warn)
+          logger.warn('workflow: file too large, skipping', {
+            path: full,
+            size: st.size,
+            max: MAX_WORKFLOW_FILE_BYTES,
+          });
         continue;
       }
     } catch {
@@ -112,15 +113,16 @@ async function loadDir(
       // A file unlinked between readdir and readFile (concurrent `/workflows
       // rm`, or an atomic write's .tmp window) must not abort discovery of
       // every other workflow — skip it like an unparseable file.
-      logger?.warn?.('workflow: unreadable file, skipping', {
-        path: full,
-        error: err instanceof Error ? err.message : String(err),
-      });
+      if (logger?.warn)
+        logger.warn('workflow: unreadable file, skipping', {
+          path: full,
+          error: err instanceof Error ? err.message : String(err),
+        });
       continue;
     }
     const result = parseWorkflowYaml(raw);
     if (!result.ok || !result.workflow) {
-      logger?.warn?.('workflow: invalid file, skipping', { path: full, errors: result.errors });
+      if (logger?.warn) logger.warn('workflow: invalid file, skipping', { path: full, errors: result.errors });
       continue;
     }
     out.push({ workflow: result.workflow, path: full, scope });

--- a/packages/plugin-workflows/src/logic-response.ts
+++ b/packages/plugin-workflows/src/logic-response.ts
@@ -1,4 +1,5 @@
 import type { WorkflowLogicStepFormat, WorkflowStep } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 
 const PLAIN_PROMPT_MARKERS = [
   'odpowiedz wyłącznie zwykłym tekstem',
@@ -33,7 +34,10 @@ export function wantsPlainResponse(step: WorkflowStep): boolean {
 function stripJsonFence(raw: string): string {
   const trimmed = raw.trim();
   const fence = /^```(?:json)?\s*([\s\S]*?)```$/i.exec(trimmed);
-  return fence ? fence[1]!.trim() : trimmed;
+  if (!fence) return trimmed;
+  const body = fence[1];
+  assertDefined(body, 'a successful match guarantees capture group 1');
+  return body.trim();
 }
 
 function parseJsonObject(raw: string): Record<string, unknown> {

--- a/packages/plugin-workflows/src/schema.test.ts
+++ b/packages/plugin-workflows/src/schema.test.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from '@moxxy/sdk';
 import { describe, expect, it } from 'vitest';
 import { parseWorkflowYaml, serializeWorkflow, validateWorkflow } from './schema.js';
 
@@ -26,24 +27,30 @@ describe('workflow schema', () => {
   it('parses a valid workflow and applies defaults', () => {
     const r = parseWorkflowYaml(VALID);
     expect(r.ok).toBe(true);
-    const wf = r.workflow!;
+    const wf = r.workflow;
+    assertDefined(wf, 'parsed workflow');
     expect(wf.name).toBe('stock-digest');
     expect(wf.version).toBe(1);
     expect(wf.enabled).toBe(true);
     expect(wf.concurrency).toBe(4);
     expect(wf.steps).toHaveLength(3);
     // step-level defaults
-    expect(wf.steps[0]!.needs).toEqual([]);
-    expect(wf.steps[0]!.onError).toBe('fail');
-    expect(wf.steps[0]!.retries).toBe(0);
+    const first = wf.steps[0];
+    assertDefined(first, 'first step');
+    expect(first.needs).toEqual([]);
+    expect(first.onError).toBe('fail');
+    expect(first.retries).toBe(0);
   });
 
   it('round-trips through serialize → parse', () => {
-    const wf = parseWorkflowYaml(VALID).workflow!;
+    const wf = parseWorkflowYaml(VALID).workflow;
+    assertDefined(wf, 'parsed workflow');
     const reparsed = parseWorkflowYaml(serializeWorkflow(wf));
     expect(reparsed.ok).toBe(true);
-    expect(reparsed.workflow!.name).toBe(wf.name);
-    expect(reparsed.workflow!.steps).toHaveLength(3);
+    const rewf = reparsed.workflow;
+    assertDefined(rewf, 'reparsed workflow');
+    expect(rewf.name).toBe(wf.name);
+    expect(rewf.steps).toHaveLength(3);
   });
 
   it('accepts and preserves UI layout metadata for the visual builder', () => {
@@ -73,12 +80,20 @@ steps:
 `);
 
     expect(r.ok).toBe(true);
-    expect(r.workflow!.ui?.layout?.nodes.fetch).toEqual({ x: 120, y: 80 });
-    expect(r.workflow!.ui?.layout?.viewport).toEqual({ x: -40, y: 12, zoom: 0.85 });
+    const wf = r.workflow;
+    assertDefined(wf, 'parsed workflow');
+    const layout = wf.ui?.layout;
+    assertDefined(layout, 'ui layout');
+    expect(layout.nodes.fetch).toEqual({ x: 120, y: 80 });
+    expect(layout.viewport).toEqual({ x: -40, y: 12, zoom: 0.85 });
 
-    const reparsed = parseWorkflowYaml(serializeWorkflow(r.workflow!));
+    const reparsed = parseWorkflowYaml(serializeWorkflow(wf));
     expect(reparsed.ok).toBe(true);
-    expect(reparsed.workflow!.ui?.layout?.nodes.summarize).toEqual({ x: 420, y: 160 });
+    const rewf = reparsed.workflow;
+    assertDefined(rewf, 'reparsed workflow');
+    const relayout = rewf.ui?.layout;
+    assertDefined(relayout, 'reparsed ui layout');
+    expect(relayout.nodes.summarize).toEqual({ x: 420, y: 160 });
   });
 
   it('rejects a cycle in `needs`', () => {
@@ -203,7 +218,11 @@ steps:
       ],
     });
     expect(r.ok).toBe(true);
-    expect(r.workflow!.steps[1]!.then).toEqual(['heavy']);
+    const wf = r.workflow;
+    assertDefined(wf, 'parsed workflow');
+    const gate = wf.steps[1];
+    assertDefined(gate, 'second step');
+    expect(gate.then).toEqual(['heavy']);
   });
 
   it('rejects condition without then/else', () => {
@@ -239,7 +258,12 @@ steps:
       ],
     });
     expect(r.ok).toBe(true);
-    const loop = r.workflow!.steps[1]!.loop!;
+    const wf = r.workflow;
+    assertDefined(wf, 'parsed workflow');
+    const spin = wf.steps[1];
+    assertDefined(spin, 'second step');
+    const loop = spin.loop;
+    assertDefined(loop, 'loop action');
     expect(loop.body).toEqual(['work']);
     expect(loop.maxIterations).toBe(10); // default
   });
@@ -314,7 +338,11 @@ steps:
       steps: [{ id: 'ask', prompt: 'ask the operator', awaitInput: true }],
     });
     expect(r.ok).toBe(true);
-    expect(r.workflow?.steps[0]?.awaitInput).toBe(true);
+    const wf = r.workflow;
+    assertDefined(wf, 'parsed workflow');
+    const step = wf.steps[0];
+    assertDefined(step, 'first step');
+    expect(step.awaitInput).toBe(true);
   });
 
   it('accepts awaitInput on a skill step', () => {
@@ -324,7 +352,11 @@ steps:
       steps: [{ id: 'ask', skill: 'web-research', input: 'ask', awaitInput: true }],
     });
     expect(r.ok).toBe(true);
-    expect(r.workflow?.steps[0]?.awaitInput).toBe(true);
+    const wf = r.workflow;
+    assertDefined(wf, 'parsed workflow');
+    const step = wf.steps[0];
+    assertDefined(step, 'first step');
+    expect(step.awaitInput).toBe(true);
   });
 
   it('rejects awaitInput on a tool step', () => {

--- a/packages/plugin-workflows/src/schema.ts
+++ b/packages/plugin-workflows/src/schema.ts
@@ -1,4 +1,5 @@
 import type { Workflow } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { z } from 'zod';
 import { validateCondition } from './template.js';
@@ -161,10 +162,12 @@ const stepSchema = z
         path: ['skill'],
       });
     } else if (present.length > 1) {
+      const second = present[1];
+      assertDefined(second, 'present.length > 1 guarantees index 1 exists');
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: `step "${step.id}" has multiple actions (${present.join(', ')}); pick one`,
-        path: [present[1]!],
+        path: [second],
       });
     }
   });
@@ -327,7 +330,8 @@ export const workflowSchema = z
     for (const step of wf.steps) {
       const owner = bodyOwner.get(step.id);
       if (owner == null) continue;
-      const body = stepById.get(step.id)!;
+      const body = stepById.get(step.id);
+      assertDefined(body, 'stepById is built from wf.steps, so every step.id is a key');
 
       // FINDING 3: a condition/switch used AS a loop body has its branch
       // routing (then/else/cases) silently ignored — runLoopStep runs the body

--- a/packages/plugin-workflows/src/store.test.ts
+++ b/packages/plugin-workflows/src/store.test.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { assertDefined } from '@moxxy/sdk';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { validateWorkflow } from './schema.js';
 import { WorkflowStore } from './store.js';
@@ -19,7 +20,9 @@ afterEach(async () => {
 });
 
 function sample(name: string) {
-  return validateWorkflow({ name, description: 'x', steps: [{ id: 'a', prompt: 'go' }] }).workflow!;
+  const wf = validateWorkflow({ name, description: 'x', steps: [{ id: 'a', prompt: 'go' }] }).workflow;
+  assertDefined(wf, 'sample workflow is schema-valid by construction');
+  return wf;
 }
 
 describe('WorkflowStore CRUD', () => {
@@ -82,7 +85,9 @@ describe('WorkflowStore CRUD', () => {
 
   it('save without a rename leaves the file in place', async () => {
     await store.create(sample('keep'), 'user');
-    const before = (await store.get('keep'))!.path;
+    const kept = await store.get('keep');
+    assertDefined(kept, 'workflow "keep" was just created');
+    const before = kept.path;
     const after = await store.save(sample('keep'));
     expect(after.path).toBe(before);
   });

--- a/packages/plugin-workflows/src/store.ts
+++ b/packages/plugin-workflows/src/store.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
-import { createMutex, type Mutex, type Workflow } from '@moxxy/sdk';
+import { assertDefined, createMutex, type Mutex, type Workflow } from '@moxxy/sdk';
 import { writeFileAtomic } from '@moxxy/sdk/server';
 import {
   defaultProjectWorkflowsDir,
@@ -145,7 +145,8 @@ export class WorkflowStore {
       previousName != null && previousName !== workflow.name ? this.byName.get(previousName) : undefined;
     if (renamed && (renamed.scope === 'user' || renamed.scope === 'project')) {
       await fs.rm(renamed.path, { force: true });
-      this.byName.delete(previousName!);
+      assertDefined(previousName, 'renamed is only set when previousName != null');
+      this.byName.delete(previousName);
     }
 
     const existing = this.byName.get(workflow.name);

--- a/packages/plugin-workflows/src/template.ts
+++ b/packages/plugin-workflows/src/template.ts
@@ -7,6 +7,8 @@
  * surfaced at author time (`workflow_validate` / `workflow_create`).
  */
 
+import { assertDefined } from '@moxxy/sdk';
+
 export interface TemplateScope {
   /** Completed step outputs, keyed by step id. */
   readonly steps: Record<string, { readonly output: string }>;
@@ -62,7 +64,8 @@ export function renderTemplate(text: string, scope: TemplateScope, opts: RenderO
   return text.replace(REF_RE, (_match, ref: string) => {
     const value = resolveRef(ref.trim(), scope);
     if (value === undefined) {
-      opts.logger?.warn?.('workflow template: unresolved reference', { ref: ref.trim() });
+      const logger = opts.logger;
+      if (logger?.warn) logger.warn('workflow template: unresolved reference', { ref: ref.trim() });
       return '';
     }
     return stringifyValue(value);
@@ -102,11 +105,52 @@ type Atom =
   | { readonly kind: 'empty' | 'notEmpty'; readonly lhs: string };
 
 const ATOM_PATTERNS: ReadonlyArray<{ re: RegExp; build: (m: RegExpMatchArray) => Atom }> = [
-  { re: /^(.+?)\s+is\s+not\s+empty$/i, build: (m) => ({ kind: 'notEmpty', lhs: m[1]!.trim() }) },
-  { re: /^(.+?)\s+is\s+empty$/i, build: (m) => ({ kind: 'empty', lhs: m[1]!.trim() }) },
-  { re: /^(.+?)\s+contains\s+"(.*)"$/i, build: (m) => ({ kind: 'contains', lhs: m[1]!.trim(), literal: m[2]! }) },
-  { re: /^(.+?)\s+==\s+"(.*)"$/, build: (m) => ({ kind: 'eq', lhs: m[1]!.trim(), literal: m[2]! }) },
-  { re: /^(.+?)\s+!=\s+"(.*)"$/, build: (m) => ({ kind: 'neq', lhs: m[1]!.trim(), literal: m[2]! }) },
+  {
+    re: /^(.+?)\s+is\s+not\s+empty$/i,
+    build: (m) => {
+      const lhs = m[1];
+      assertDefined(lhs, 'condition atom regex guarantees capture group 1');
+      return { kind: 'notEmpty', lhs: lhs.trim() };
+    },
+  },
+  {
+    re: /^(.+?)\s+is\s+empty$/i,
+    build: (m) => {
+      const lhs = m[1];
+      assertDefined(lhs, 'condition atom regex guarantees capture group 1');
+      return { kind: 'empty', lhs: lhs.trim() };
+    },
+  },
+  {
+    re: /^(.+?)\s+contains\s+"(.*)"$/i,
+    build: (m) => {
+      const lhs = m[1];
+      const literal = m[2];
+      assertDefined(lhs, 'condition atom regex guarantees capture group 1');
+      assertDefined(literal, 'condition atom regex guarantees capture group 2');
+      return { kind: 'contains', lhs: lhs.trim(), literal };
+    },
+  },
+  {
+    re: /^(.+?)\s+==\s+"(.*)"$/,
+    build: (m) => {
+      const lhs = m[1];
+      const literal = m[2];
+      assertDefined(lhs, 'condition atom regex guarantees capture group 1');
+      assertDefined(literal, 'condition atom regex guarantees capture group 2');
+      return { kind: 'eq', lhs: lhs.trim(), literal };
+    },
+  },
+  {
+    re: /^(.+?)\s+!=\s+"(.*)"$/,
+    build: (m) => {
+      const lhs = m[1];
+      const literal = m[2];
+      assertDefined(lhs, 'condition atom regex guarantees capture group 1');
+      assertDefined(literal, 'condition atom regex guarantees capture group 2');
+      return { kind: 'neq', lhs: lhs.trim(), literal };
+    },
+  },
 ];
 
 /** Split `expr` on a top-level connective word, ignoring quoted regions. */

--- a/packages/plugin-workflows/src/tools.ts
+++ b/packages/plugin-workflows/src/tools.ts
@@ -1,5 +1,6 @@
 import {
   asPluginId,
+  assertDefined,
   defineTool,
   MoxxyError,
   z,
@@ -403,7 +404,8 @@ function validateTool(deps: WorkflowToolDeps): ToolDef {
         const r = parseWorkflowYaml(yaml);
         return { ok: r.ok, errors: r.errors };
       }
-      const entry = await deps.store.get(name!);
+      assertDefined(name, 'input schema refine requires yaml or name; yaml handled above');
+      const entry = await deps.store.get(name);
       if (!entry) return { ok: false, errors: [`no workflow named "${name}"`] };
       return { ok: true, errors: [] };
     },

--- a/packages/workflows-builder/src/assert.ts
+++ b/packages/workflows-builder/src/assert.ts
@@ -1,0 +1,14 @@
+/**
+ * Local copy of `@moxxy/sdk`'s `assertDefined`.
+ *
+ * This package is bundled into the desktop RENDERER (browser context); a value
+ * import from the `@moxxy/sdk` barrel would drag Node-only modules
+ * (`node:fs`, `node:os`, ...) into the browser bundle and break the vite
+ * build. Type-only sdk imports remain fine. Keep semantics identical to
+ * `packages/sdk/src/assert.ts`.
+ */
+export function assertDefined<T>(value: T, message: string): asserts value is NonNullable<T> {
+  if (value === null || value === undefined) {
+    throw new Error(`Expected a defined value: ${message}`);
+  }
+}

--- a/packages/workflows-builder/src/operations.test.ts
+++ b/packages/workflows-builder/src/operations.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from './assert.js';
 import {
   addStep,
   connectNeeds,
@@ -24,7 +25,9 @@ describe('addStep / removeStep', () => {
   it('adds a node, selects it, flips dirty', () => {
     const s = addStep(emptyState(), { kind: 'prompt', id: 'a' });
     expect(s.nodes).toHaveLength(1);
-    expect(s.nodes[0]!.id).toBe('a');
+    const first = s.nodes[0];
+    assertDefined(first, 'first node');
+    expect(first.id).toBe('a');
     expect(s.selected).toBe('a');
     expect(s.dirty).toBe(true);
   });
@@ -38,7 +41,9 @@ describe('addStep / removeStep', () => {
   it('wires `after` into a needs edge', () => {
     let s = addStep(emptyState(), { kind: 'prompt', id: 'a' });
     s = addStep(s, { kind: 'prompt', id: 'b', after: 'a' });
-    expect(s.nodes.find((n) => n.id === 'b')!.needs).toEqual(['a']);
+    const b = s.nodes.find((n) => n.id === 'b');
+    assertDefined(b, 'node b');
+    expect(b.needs).toEqual(['a']);
     expect(s.edges).toContainEqual(expect.objectContaining({ kind: 'needs', from: 'a', to: 'b' }));
   });
 
@@ -50,7 +55,9 @@ describe('addStep / removeStep', () => {
     s = setBranchTargets(s, 'c', 'then', ['b']);
     s = removeStep(s, 'b');
     expect(s.nodes.map((n) => n.id)).toEqual(['a', 'c']);
-    expect(s.nodes.find((n) => n.id === 'c')!.then).toEqual([]);
+    const c = s.nodes.find((n) => n.id === 'c');
+    assertDefined(c, 'node c');
+    expect(c.then).toEqual([]);
     expect(s.edges.some((e) => e.to === 'b')).toBe(false);
   });
 });
@@ -61,9 +68,13 @@ describe('needs edges', () => {
     s = connectNeeds(s, 'a', 'b');
     s = connectNeeds(s, 'a', 'b'); // dup ignored
     s = connectNeeds(s, 'b', 'b'); // self ignored
-    expect(s.nodes.find((n) => n.id === 'b')!.needs).toEqual(['a']);
+    const b1 = s.nodes.find((n) => n.id === 'b');
+    assertDefined(b1, 'node b');
+    expect(b1.needs).toEqual(['a']);
     s = disconnectNeeds(s, 'a', 'b');
-    expect(s.nodes.find((n) => n.id === 'b')!.needs).toEqual([]);
+    const b2 = s.nodes.find((n) => n.id === 'b');
+    assertDefined(b2, 'node b');
+    expect(b2.needs).toEqual([]);
   });
 
   it('refuses a connection that would create a cycle', () => {
@@ -75,7 +86,9 @@ describe('needs edges', () => {
     const before = s;
     s = connectNeeds(s, 'c', 'a');
     expect(s).toBe(before); // no-op, no cycle authored
-    expect(s.nodes.find((n) => n.id === 'a')!.needs).toEqual([]);
+    const a = s.nodes.find((n) => n.id === 'a');
+    assertDefined(a, 'node a');
+    expect(a.needs).toEqual([]);
     // the reverse direction (already implied) is fine and idempotent
     expect(wouldCreateCycle(s, 'a', 'c')).toBe(false);
   });
@@ -100,7 +113,9 @@ describe('branch targets', () => {
     expect(s.edges).toContainEqual(expect.objectContaining({ kind: 'case', from: 'sw', to: 'hi', caseId: 'high' }));
     expect(s.edges).toContainEqual(expect.objectContaining({ kind: 'default', from: 'sw', to: 'fb' }));
     s = removeSwitchCase(s, 'sw', 'low');
-    expect(s.nodes.find((n) => n.id === 'sw')!.cases).toEqual({ high: ['hi'] });
+    const sw = s.nodes.find((n) => n.id === 'sw');
+    assertDefined(sw, 'node sw');
+    expect(sw.cases).toEqual({ high: ['hi'] });
   });
 });
 
@@ -117,8 +132,14 @@ describe('loop node body + exit model', () => {
   it('setLoopBody scopes body steps to the loop via needs and derives loop-body edges', () => {
     let s = loopFixture();
     s = setLoopBody(s, 'loop', ['improve']);
-    expect(s.nodes.find((n) => n.id === 'loop')!.loop!.body).toEqual(['improve']);
-    expect(s.nodes.find((n) => n.id === 'improve')!.needs).toEqual(['loop']);
+    const loop = s.nodes.find((n) => n.id === 'loop');
+    assertDefined(loop, 'loop node');
+    const cfg = loop.loop;
+    assertDefined(cfg, 'loop config');
+    expect(cfg.body).toEqual(['improve']);
+    const improve = s.nodes.find((n) => n.id === 'improve');
+    assertDefined(improve, 'improve node');
+    expect(improve.needs).toEqual(['loop']);
     expect(s.edges).toContainEqual(expect.objectContaining({ kind: 'loop-body', from: 'loop', to: 'improve' }));
     // body step's needs:[loop] is NOT rendered as a plain needs edge.
     expect(s.edges.some((e) => e.kind === 'needs' && e.from === 'loop' && e.to === 'improve')).toBe(false);
@@ -128,15 +149,23 @@ describe('loop node body + exit model', () => {
     let s = loopFixture();
     s = setLoopBody(s, 'loop', ['improve']);
     s = setLoopBody(s, 'loop', []);
-    expect(s.nodes.find((n) => n.id === 'improve')!.needs).toEqual([]);
-    expect(s.nodes.find((n) => n.id === 'loop')!.loop!.body).toEqual([]);
+    const improve = s.nodes.find((n) => n.id === 'improve');
+    assertDefined(improve, 'improve node');
+    expect(improve.needs).toEqual([]);
+    const loop = s.nodes.find((n) => n.id === 'loop');
+    assertDefined(loop, 'loop node');
+    const cfg = loop.loop;
+    assertDefined(cfg, 'loop config');
+    expect(cfg.body).toEqual([]);
   });
 
   it('setLoopExit wires the single exit needs edge and re-points it', () => {
     let s = loopFixture();
     s = setLoopBody(s, 'loop', ['improve']);
     s = setLoopExit(s, 'loop', 'finish');
-    expect(loopExitTarget(s.nodes.find((n) => n.id === 'loop')!, s.nodes)).toBe('finish');
+    const loop = s.nodes.find((n) => n.id === 'loop');
+    assertDefined(loop, 'loop node');
+    expect(loopExitTarget(loop, s.nodes)).toBe('finish');
     expect(s.edges).toContainEqual(expect.objectContaining({ kind: 'loop-exit', from: 'loop', to: 'finish' }));
     // exactly one loop-exit edge per loop
     expect(s.edges.filter((e) => e.kind === 'loop-exit')).toHaveLength(1);
@@ -167,17 +196,23 @@ describe('loop node body + exit model', () => {
     s = connectNeeds(s, 'loop', 'tail'); // routed through setLoopExit → re-points
     expect(s.edges.filter((e) => e.kind === 'loop-exit')).toHaveLength(1);
     expect(s.edges).toContainEqual(expect.objectContaining({ kind: 'loop-exit', from: 'loop', to: 'tail' }));
-    expect(loopExitTarget(s.nodes.find((n) => n.id === 'loop')!, s.nodes)).toBe('tail');
+    const loop = s.nodes.find((n) => n.id === 'loop');
+    assertDefined(loop, 'loop node');
+    expect(loopExitTarget(loop, s.nodes)).toBe('tail');
     // the prior exit ('finish') lost its loop dependency entirely — so it can no
     // longer be mistaken for a second exit.
-    expect(s.nodes.find((n) => n.id === 'finish')!.needs).not.toContain('loop');
+    const finish = s.nodes.find((n) => n.id === 'finish');
+    assertDefined(finish, 'finish node');
+    expect(finish.needs).not.toContain('loop');
     // exactly one non-body node still depends on the loop (the chosen exit).
     const dependsOnLoop = s.nodes.filter(
       (n) => n.id !== 'improve' && n.needs.includes('loop'),
     );
     expect(dependsOnLoop.map((n) => n.id)).toEqual(['tail']);
     // body membership untouched.
-    expect(s.nodes.find((n) => n.id === 'improve')!.needs).toEqual(['loop']);
+    const improve = s.nodes.find((n) => n.id === 'improve');
+    assertDefined(improve, 'improve node');
+    expect(improve.needs).toEqual(['loop']);
   });
 
   it('refuses a loop-exit edge that would close a cycle', () => {
@@ -189,7 +224,9 @@ describe('loop node body + exit model', () => {
     const before = s;
     s = setLoopExit(s, 'loop', 'seed');
     expect(s).toBe(before); // no-op, cycle refused
-    expect(s.nodes.find((n) => n.id === 'seed')!.needs).not.toContain('loop');
+    const seed = s.nodes.find((n) => n.id === 'seed');
+    assertDefined(seed, 'seed node');
+    expect(seed.needs).not.toContain('loop');
     expect(s.edges.some((e) => e.kind === 'loop-exit')).toBe(false);
   });
 
@@ -210,21 +247,36 @@ describe('loop node body + exit model', () => {
     expect(wouldCreateCycle(s, 'loop', 'seed')).toBe(true);
     s = setLoopBody(s, 'loop', ['seed', 'improve']);
     // seed (the ancestor) is excluded; the legitimate member is kept.
-    expect(s.nodes.find((n) => n.id === 'loop')!.loop!.body).toEqual(['improve']);
+    const loop = s.nodes.find((n) => n.id === 'loop');
+    assertDefined(loop, 'loop node');
+    const cfg = loop.loop;
+    assertDefined(cfg, 'loop config');
+    expect(cfg.body).toEqual(['improve']);
     // seed did NOT gain needs:[loop] — the cycle was refused, not authored.
-    expect(s.nodes.find((n) => n.id === 'seed')!.needs).not.toContain('loop');
-    expect(s.nodes.find((n) => n.id === 'improve')!.needs).toContain('loop');
+    const seed = s.nodes.find((n) => n.id === 'seed');
+    assertDefined(seed, 'seed node');
+    expect(seed.needs).not.toContain('loop');
+    const improve = s.nodes.find((n) => n.id === 'improve');
+    assertDefined(improve, 'improve node');
+    expect(improve.needs).toContain('loop');
     // and no body member both depends on and is depended-on-by the loop.
-    const loop = s.nodes.find((n) => n.id === 'loop')!;
     expect(loop.needs).toEqual(['seed']); // loop still plainly downstream of seed
   });
 
   it('setLoopConfig clamps maxIterations to 1..50', () => {
     let s = loopFixture();
     s = setLoopConfig(s, 'loop', { maxIterations: 999, condition: 'good enough?' });
-    expect(s.nodes.find((n) => n.id === 'loop')!.loop!.maxIterations).toBe(50);
+    const loop1 = s.nodes.find((n) => n.id === 'loop');
+    assertDefined(loop1, 'loop node');
+    const cfg1 = loop1.loop;
+    assertDefined(cfg1, 'loop config');
+    expect(cfg1.maxIterations).toBe(50);
     s = setLoopConfig(s, 'loop', { maxIterations: 0 });
-    expect(s.nodes.find((n) => n.id === 'loop')!.loop!.maxIterations).toBe(1);
+    const loop2 = s.nodes.find((n) => n.id === 'loop');
+    assertDefined(loop2, 'loop node');
+    const cfg2 = loop2.loop;
+    assertDefined(cfg2, 'loop config');
+    expect(cfg2.maxIterations).toBe(1);
   });
 });
 
@@ -233,15 +285,19 @@ describe('updateNode / updateMeta / move / rename', () => {
     let s = addStep(emptyState(), { kind: 'prompt', id: 'a' });
     const edgesRef = s.edges;
     s = updateNode(s, 'a', { action: 'do the thing', label: 'Step A' });
-    expect(s.nodes[0]!.action).toBe('do the thing');
-    expect(s.nodes[0]!.label).toBe('Step A');
+    const first = s.nodes[0];
+    assertDefined(first, 'first node');
+    expect(first.action).toBe('do the thing');
+    expect(first.label).toBe('Step A');
     expect(s.edges).toBe(edgesRef);
   });
 
   it('clamps retries to 0..3', () => {
     let s = addStep(emptyState(), { kind: 'prompt', id: 'a' });
     s = updateNode(s, 'a', { retries: 9 });
-    expect(s.nodes[0]!.retries).toBe(3);
+    const first = s.nodes[0];
+    assertDefined(first, 'first node');
+    expect(first.retries).toBe(3);
   });
 
   it('moveNode updates position, keeps edges', () => {
@@ -265,8 +321,12 @@ describe('updateNode / updateMeta / move / rename', () => {
     s = setBranchTargets(s, 'c', 'then', ['old']);
     s = renameNode(s, 'old', 'fresh');
     expect(s.nodes.map((n) => n.id)).toContain('fresh');
-    expect(s.nodes.find((n) => n.id === 'c')!.then).toEqual(['fresh']);
-    expect(s.nodes.find((n) => n.id === 'fresh')!.needs).toEqual(['c']);
+    const c = s.nodes.find((n) => n.id === 'c');
+    assertDefined(c, 'node c');
+    expect(c.then).toEqual(['fresh']);
+    const fresh = s.nodes.find((n) => n.id === 'fresh');
+    assertDefined(fresh, 'node fresh');
+    expect(fresh.needs).toEqual(['c']);
   });
 
   it('renameNode rejects a schema-invalid id (spaces/punctuation) as a no-op', () => {
@@ -285,14 +345,18 @@ describe('updateNode / updateMeta / move / rename', () => {
     s = updateNode(s, 't', { args });
     // Mutating the caller's object must not retroactively edit the snapshot.
     args.count = 999;
-    expect(s.nodes.find((n) => n.id === 't')!.args).toEqual({ count: 1 });
+    const t = s.nodes.find((n) => n.id === 't');
+    assertDefined(t, 'node t');
+    expect(t.args).toEqual({ count: 1 });
   });
 });
 
 describe('uniqueId', () => {
   it('slugifies and de-dupes', () => {
     const s = addStep(emptyState(), { kind: 'prompt', id: 'my step' });
-    expect(s.nodes[0]!.id).toBe('my_step');
+    const first = s.nodes[0];
+    assertDefined(first, 'first node');
+    expect(first.id).toBe('my_step');
     expect(uniqueId(s, 'my step')).toBe('my_step_2');
   });
 });

--- a/packages/workflows-builder/src/operations.ts
+++ b/packages/workflows-builder/src/operations.ts
@@ -14,6 +14,7 @@
  */
 
 import type { WorkflowStepErrorMode } from '@moxxy/sdk';
+import { assertDefined } from './assert.js';
 import { deriveEdges } from './serialize.js';
 import {
   type BuilderLoop,
@@ -203,7 +204,8 @@ export function wouldCreateCycle(state: BuilderState, from: string, to: string):
   const stack = [from];
   const seen = new Set<string>();
   while (stack.length > 0) {
-    const id = stack.pop()!;
+    const id = stack.pop();
+    assertDefined(id, 'stack is non-empty (loop guard)');
     if (id === to) return true;
     if (seen.has(id)) continue;
     seen.add(id);

--- a/packages/workflows-builder/src/serialize.test.ts
+++ b/packages/workflows-builder/src/serialize.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { WorkflowStep } from '@moxxy/sdk';
+import { assertDefined } from './assert.js';
 import {
   addStep,
   emptyState,
@@ -43,13 +44,20 @@ describe('serialize → Workflow', () => {
     const { workflow, yaml } = serialize(s);
     expect(workflow.name).toBe('refine-draft');
     expect(workflow.steps).toHaveLength(4);
-    const loop = workflow.steps.find((st) => st.id === 'refine')!;
+    const loop = workflow.steps.find((st) => st.id === 'refine');
+    assertDefined(loop, 'refine step');
     expect(loop.loop).toEqual({ body: ['improve'], condition: 'Is the draft good enough?', maxIterations: 5 });
     // body + exit steps carry needs:[refine]
-    expect(workflow.steps.find((st) => st.id === 'improve')!.needs).toContain('refine');
-    expect(workflow.steps.find((st) => st.id === 'finish')!.needs).toContain('refine');
-    expect(workflow.ui?.layout?.nodes.first_draft).toBeDefined();
-    expect(workflow.ui?.layout?.viewport).toEqual({ x: 0, y: 0, zoom: 1 });
+    const improve = workflow.steps.find((st) => st.id === 'improve');
+    assertDefined(improve, 'improve step');
+    expect(improve.needs).toContain('refine');
+    const finish = workflow.steps.find((st) => st.id === 'finish');
+    assertDefined(finish, 'finish step');
+    expect(finish.needs).toContain('refine');
+    const layout = workflow.ui?.layout;
+    assertDefined(layout, 'ui layout');
+    expect(layout.nodes.first_draft).toBeDefined();
+    expect(layout.viewport).toEqual({ x: 0, y: 0, zoom: 1 });
     expect(yaml).toContain('name: refine-draft');
     expect(yaml).toContain('loop:');
   });
@@ -71,7 +79,8 @@ describe('serialize → Workflow', () => {
     const { yaml } = serialize(s);
     expect(yaml).toMatch(/prompt: \|/);
     const parsed = fromYaml(yaml) as { steps: Array<{ id: string; prompt?: string }> };
-    const draft = parsed.steps.find((st) => st.id === 'first_draft')!;
+    const draft = parsed.steps.find((st) => st.id === 'first_draft');
+    assertDefined(draft, 'first_draft step');
     expect(draft.prompt).toContain('Write a first draft');
     expect(draft.prompt).toContain('Keep it short.');
   });
@@ -84,7 +93,8 @@ describe('hydrate ← Workflow (round-trip)', () => {
     const re = hydrate(workflow);
 
     expect(re.nodes.map((n) => n.id).sort()).toEqual(['finish', 'first_draft', 'improve', 'refine']);
-    const loop = re.nodes.find((n) => n.id === 'refine')!;
+    const loop = re.nodes.find((n) => n.id === 'refine');
+    assertDefined(loop, 'refine node');
     expect(loop.kind).toBe('loop');
     expect(loop.loop).toEqual({ body: ['improve'], condition: 'Is the draft good enough?', maxIterations: 5 });
     // loop-body + single loop-exit edges survive the round-trip
@@ -92,7 +102,13 @@ describe('hydrate ← Workflow (round-trip)', () => {
     expect(re.edges.filter((e) => e.kind === 'loop-exit')).toHaveLength(1);
     expect(re.edges).toContainEqual(expect.objectContaining({ kind: 'loop-exit', from: 'refine', to: 'finish' }));
     // positions preserved from ui.layout
-    expect(re.nodes.find((n) => n.id === 'first_draft')!.x).toBe(workflow.ui!.layout!.nodes.first_draft!.x);
+    const firstDraftNode = re.nodes.find((n) => n.id === 'first_draft');
+    assertDefined(firstDraftNode, 'first_draft node');
+    const layout = workflow.ui?.layout;
+    assertDefined(layout, 'ui layout');
+    const laidOut = layout.nodes.first_draft;
+    assertDefined(laidOut, 'first_draft layout position');
+    expect(firstDraftNode.x).toBe(laidOut.x);
   });
 
   it('round-trips condition + switch branch edges', () => {
@@ -113,9 +129,13 @@ describe('hydrate ← Workflow (round-trip)', () => {
 
     const { workflow } = serialize(s);
     const re = hydrate(workflow);
-    expect(re.nodes.find((n) => n.id === 'gate')!.then).toEqual(['a']);
-    expect(re.nodes.find((n) => n.id === 'sw')!.cases).toEqual({ high: ['hi'], low: ['lo'] });
-    expect(re.nodes.find((n) => n.id === 'sw')!.default).toEqual(['fb']);
+    const gate = re.nodes.find((n) => n.id === 'gate');
+    assertDefined(gate, 'gate node');
+    expect(gate.then).toEqual(['a']);
+    const sw = re.nodes.find((n) => n.id === 'sw');
+    assertDefined(sw, 'sw node');
+    expect(sw.cases).toEqual({ high: ['hi'], low: ['lo'] });
+    expect(sw.default).toEqual(['fb']);
     expect(re.edges).toContainEqual(expect.objectContaining({ kind: 'then', from: 'gate', to: 'a' }));
     expect(re.edges).toContainEqual(expect.objectContaining({ kind: 'case', caseId: 'high', from: 'sw', to: 'hi' }));
   });
@@ -123,7 +143,11 @@ describe('hydrate ← Workflow (round-trip)', () => {
   it('hydrateYaml parses canonical YAML back into a canvas', () => {
     const { yaml } = serialize(refineFixture());
     const re = hydrateYaml(yaml);
-    expect(re.nodes.find((n) => n.id === 'refine')!.loop!.condition).toBe('Is the draft good enough?');
+    const refine = re.nodes.find((n) => n.id === 'refine');
+    assertDefined(refine, 'refine node');
+    const cfg = refine.loop;
+    assertDefined(cfg, 'refine loop config');
+    expect(cfg.condition).toBe('Is the draft good enough?');
     expect(re.dirty).toBe(false);
   });
 });
@@ -139,17 +163,25 @@ describe('auto-layout when ui.layout is absent', () => {
     // strip ui so hydrate must auto-layout
     const bare = { ...workflow, ui: undefined };
     const re = hydrate(bare);
-    const x = (id: string) => re.nodes.find((n) => n.id === id)!.x;
+    const x = (id: string) => {
+      const node = re.nodes.find((n) => n.id === id);
+      assertDefined(node, `node ${id}`);
+      return node.x;
+    };
     expect(x('a')).toBeLessThan(x('b'));
     expect(x('b')).toBeLessThan(x('c'));
   });
 
   it('autoLayout assigns increasing columns by depth', () => {
     const positions = autoLayout([step('a'), step('b', ['a']), step('c', ['a'])]);
-    expect(positions[0]!.x).toBeLessThan(positions[1]!.x);
+    const [p0, p1, p2] = positions;
+    assertDefined(p0, 'position 0');
+    assertDefined(p1, 'position 1');
+    assertDefined(p2, 'position 2');
+    expect(p0.x).toBeLessThan(p1.x);
     // b and c are siblings at the same depth → same column, stacked rows
-    expect(positions[1]!.x).toBe(positions[2]!.x);
-    expect(positions[1]!.y).not.toBe(positions[2]!.y);
+    expect(p1.x).toBe(p2.x);
+    expect(p1.y).not.toBe(p2.y);
   });
 });
 
@@ -190,7 +222,8 @@ describe('hydrateYaml hardening — malformed / hand-authored drafts', () => {
       ],
     } as unknown as import('@moxxy/sdk').Workflow;
     const re = hydrate(wf);
-    const node = re.nodes.find((n) => n.id === 'c')!;
+    const node = re.nodes.find((n) => n.id === 'c');
+    assertDefined(node, 'node c');
     // `then` was not an array → dropped, not spread into ['o','o','p','s'].
     expect(node.then).toBeUndefined();
     expect(node.else).toEqual(['ok']);
@@ -204,8 +237,12 @@ describe('hydrateYaml hardening — malformed / hand-authored drafts', () => {
     );
     expect(() => autoLayout(steps)).not.toThrow();
     const positions = autoLayout(steps);
+    const first = positions[0];
+    const last = positions[4999];
+    assertDefined(first, 'position 0');
+    assertDefined(last, 'position 4999');
     // depth strictly increases along the chain.
-    expect(positions[0]!.x).toBeLessThan(positions[4999]!.x);
+    expect(first.x).toBeLessThan(last.x);
   });
 });
 
@@ -234,8 +271,10 @@ describe('yaml codec edge cases', () => {
     const back = fromYaml(toYaml(value)) as typeof value;
     // The `|` block scalar keeps a trailing newline (clip chomping); the body
     // content — including every `#` — must be intact and uncorrupted.
-    expect(back.steps[0]!.prompt!.replace(/\n$/, '')).toBe(prompt);
+    const firstStep = back.steps[0];
+    assertDefined(firstStep, 'first step');
+    expect(firstStep.prompt.replace(/\n$/, '')).toBe(prompt);
     // A genuine trailing comment on a structural (non-block) line is still stripped.
-    expect(back.steps[0]!.after).toBe('plain');
+    expect(firstStep.after).toBe('plain');
   });
 });

--- a/packages/workflows-builder/src/serialize.ts
+++ b/packages/workflows-builder/src/serialize.ts
@@ -14,6 +14,7 @@
  */
 
 import type { Workflow, WorkflowStep, WorkflowUiLayout } from '@moxxy/sdk';
+import { assertDefined } from './assert.js';
 import type {
   BuilderEdge,
   BuilderLoop,
@@ -126,7 +127,8 @@ function nodeToStep(node: BuilderNode): WorkflowStep {
 
 /** Hydrate the canvas from a saved workflow object. */
 export function hydrate(workflow: Workflow): BuilderState {
-  const positions = workflow.ui?.layout?.nodes;
+  const layout = workflow.ui?.layout;
+  const positions = layout?.nodes;
   const autoPositions = positions ? undefined : autoLayout(workflow.steps);
   const nodes: BuilderNode[] = workflow.steps.map((step, idx) => {
     const pos = positions?.[step.id] ?? autoPositions?.[idx] ?? { x: 0, y: idx * NODE_GAP_Y };
@@ -143,7 +145,7 @@ export function hydrate(workflow: Workflow): BuilderState {
     ...(workflow.targetSessionId ? { targetSessionId: workflow.targetSessionId } : {}),
     ...(workflow.delivery ? { delivery: workflow.delivery } : {}),
   };
-  const viewport = workflow.ui?.layout?.viewport ?? DEFAULT_VIEWPORT;
+  const viewport = layout?.viewport ?? DEFAULT_VIEWPORT;
   return {
     meta,
     nodes,
@@ -365,7 +367,8 @@ export function autoLayout(steps: ReadonlyArray<WorkflowStep>): Array<{ x: numbe
     const stack: string[] = [start];
     const onStack = new Set<string>([start]);
     while (stack.length > 0) {
-      const id = stack[stack.length - 1]!;
+      const id = stack[stack.length - 1];
+      assertDefined(id, 'stack is non-empty (loop guard)');
       const needs = byId.get(id)?.needs ?? [];
       let pending: string | null = null;
       for (const n of needs) {

--- a/packages/workflows-builder/src/types.ts
+++ b/packages/workflows-builder/src/types.ts
@@ -9,6 +9,7 @@
  * import-cleanly under both the Electron renderer and the Expo (Hermes) bundle.
  */
 
+import { assertDefined } from './assert.js';
 import type {
   WorkflowDelivery,
   WorkflowInputSpec,
@@ -162,5 +163,7 @@ export const STEP_KINDS: ReadonlyArray<StepKindMeta> = [
 ];
 
 export function stepKindMeta(kind: StepKind): StepKindMeta {
-  return STEP_KINDS.find((k) => k.kind === kind) ?? STEP_KINDS[0]!;
+  const meta = STEP_KINDS.find((k) => k.kind === kind) ?? STEP_KINDS[0];
+  assertDefined(meta, 'STEP_KINDS is a non-empty constant array');
+  return meta;
 }

--- a/packages/workflows-builder/src/validation.ts
+++ b/packages/workflows-builder/src/validation.ts
@@ -10,6 +10,7 @@
  * that node id, everything else falls into {@link WORKFLOW_ERROR_KEY}.
  */
 
+import { assertDefined } from './assert.js';
 import type { BuilderState } from './types.js';
 import { WORKFLOW_ERROR_KEY } from './types.js';
 import { serialize } from './serialize.js';
@@ -100,11 +101,17 @@ export function mapErrorsToNodes(
   for (const issue of issues) {
     const mentioned = new Set<string>();
     const dup = DUP_RE.exec(issue);
-    if (dup && known.has(dup[1]!)) mentioned.add(dup[1]!);
+    if (dup) {
+      const dupId = dup[1];
+      assertDefined(dupId, 'DUP_RE has a mandatory capture group');
+      if (known.has(dupId)) mentioned.add(dupId);
+    }
     let m: RegExpExecArray | null;
     STEP_MENTION_RE.lastIndex = 0;
     while ((m = STEP_MENTION_RE.exec(issue))) {
-      if (known.has(m[1]!)) mentioned.add(m[1]!);
+      const stepId = m[1];
+      assertDefined(stepId, 'STEP_MENTION_RE has a mandatory capture group');
+      if (known.has(stepId)) mentioned.add(stepId);
     }
     if (mentioned.size === 0) {
       push(WORKFLOW_ERROR_KEY, issue);
@@ -112,7 +119,8 @@ export function mapErrorsToNodes(
       // Attribute to the FIRST named step (the one whose definition is wrong);
       // additional mentions are usually the unknown target the author must add.
       const [first] = [...mentioned];
-      push(first!, issue);
+      assertDefined(first, 'mentioned is non-empty in this branch');
+      push(first, issue);
     }
   }
   return out;

--- a/packages/workflows-builder/src/yaml.ts
+++ b/packages/workflows-builder/src/yaml.ts
@@ -11,6 +11,8 @@
  * own output and re-hydrate canonical YAML that the host returned.
  */
 
+import { assertDefined } from './assert.js';
+
 // ---------------------------------------------------------------------------
 // Emit
 // ---------------------------------------------------------------------------
@@ -67,7 +69,9 @@ function emitArray(arr: ReadonlyArray<unknown>, indent: number, out: string[]): 
       const first = out.length;
       emitMap(item as Record<string, unknown>, indent + 1, out);
       // Splice the dash onto the first emitted child line.
-      out[first] = `${pad}- ${out[first]!.slice((indent + 1) * 2)}`;
+      const firstLine = out[first];
+      assertDefined(firstLine, 'emitMap pushed at least one line for a non-empty map');
+      out[first] = `${pad}- ${firstLine.slice((indent + 1) * 2)}`;
     } else {
       out.push(`${pad}- ${emitScalar(item)}`);
     }
@@ -205,14 +209,21 @@ function findBareHash(line: string): number {
     const c = line[j];
     if (c === '"' && !inSingle) inDouble = !inDouble;
     else if (c === "'" && !inDouble) inSingle = !inSingle;
-    else if (c === '#' && !inSingle && !inDouble && j > 0 && /\s/.test(line[j - 1]!)) return j;
+    else if (c === '#' && !inSingle && !inDouble && j > 0) {
+      const prev = line[j - 1];
+      assertDefined(prev, 'j > 0 so line[j - 1] is a valid index');
+      if (/\s/.test(prev)) return j;
+    }
   }
   return -1;
 }
 
 function indentOf(line: string): number {
   const m = /^( *)/.exec(line);
-  return m ? m[1]!.length : 0;
+  if (!m) return 0;
+  const spaces = m[1];
+  assertDefined(spaces, 'leading-space capture is always present when the regex matches');
+  return spaces.length;
 }
 
 function isBlank(line: string): boolean {
@@ -221,9 +232,15 @@ function isBlank(line: string): boolean {
 
 function parseBlock(ctx: ParseCtx, minIndent: number): unknown {
   // Skip blanks, then dispatch on whether the first content line is a sequence.
-  while (ctx.i < ctx.lines.length && isBlank(ctx.lines[ctx.i]!)) ctx.i++;
+  while (ctx.i < ctx.lines.length) {
+    const blank = ctx.lines[ctx.i];
+    assertDefined(blank, 'ctx.i is within bounds');
+    if (!isBlank(blank)) break;
+    ctx.i++;
+  }
   if (ctx.i >= ctx.lines.length) return null;
-  const line = ctx.lines[ctx.i]!;
+  const line = ctx.lines[ctx.i];
+  assertDefined(line, 'ctx.i < ctx.lines.length (checked above)');
   const indent = indentOf(line);
   if (indent < minIndent) return null;
   return line.slice(indent).startsWith('- ') || line.slice(indent).trim() === '-'
@@ -235,7 +252,8 @@ function parseMap(ctx: ParseCtx, indent: number): Record<string, unknown> {
   enter(ctx);
   const obj: Record<string, unknown> = {};
   while (ctx.i < ctx.lines.length) {
-    const line = ctx.lines[ctx.i]!;
+    const line = ctx.lines[ctx.i];
+    assertDefined(line, 'ctx.i < ctx.lines.length (loop guard)');
     if (isBlank(line)) {
       ctx.i++;
       continue;
@@ -265,9 +283,16 @@ function parseMap(ctx: ParseCtx, indent: number): Record<string, unknown> {
 function parseChild(ctx: ParseCtx, parentIndent: number): unknown {
   // Peek the next non-blank line; if it's deeper, recurse, else the value is null.
   let j = ctx.i;
-  while (j < ctx.lines.length && isBlank(ctx.lines[j]!)) j++;
+  while (j < ctx.lines.length) {
+    const blank = ctx.lines[j];
+    assertDefined(blank, 'j is within bounds');
+    if (!isBlank(blank)) break;
+    j++;
+  }
   if (j >= ctx.lines.length) return null;
-  const ind = indentOf(ctx.lines[j]!);
+  const line = ctx.lines[j];
+  assertDefined(line, 'j < ctx.lines.length (checked above)');
+  const ind = indentOf(line);
   if (ind <= parentIndent) return null;
   ctx.i = j;
   return parseBlock(ctx, ind);
@@ -277,7 +302,8 @@ function parseSequence(ctx: ParseCtx, indent: number): unknown[] {
   enter(ctx);
   const arr: unknown[] = [];
   while (ctx.i < ctx.lines.length) {
-    const line = ctx.lines[ctx.i]!;
+    const line = ctx.lines[ctx.i];
+    assertDefined(line, 'ctx.i < ctx.lines.length (loop guard)');
     if (isBlank(line)) {
       ctx.i++;
       continue;
@@ -319,7 +345,8 @@ function parseBlockScalar(ctx: ParseCtx, parentIndent: number, fold: boolean, st
   const raw: Array<string | null> = [];
   let blockIndent = Infinity;
   while (ctx.i < ctx.lines.length) {
-    const line = ctx.lines[ctx.i]!;
+    const line = ctx.lines[ctx.i];
+    assertDefined(line, 'ctx.i < ctx.lines.length (loop guard)');
     if (isBlank(line)) {
       raw.push(null);
       ctx.i++;


### PR DESCRIPTION
## What

Assert-sweep for the automation cluster, per the AGENTS.md "Guard, don't chain" rule: every non-null assertion (`x!`) and every optional chain of depth >= 2 replaced with `invariant`/`assertDefined` guards (from `@moxxy/sdk`, #445) or narrow-once early returns.

Packages: `@moxxy/plugin-workflows`, `@moxxy/workflows-builder`, `@moxxy/plugin-scheduler`, `@moxxy/plugin-webhooks`, `@moxxy/plugin-usage-stats` — 48 files.

## Semantics

- Loud throws only where absence is impossible by construction (regex capture groups after successful match, map reads seeded from the same collection, bounds-checked indexes, schema-validated step ids, paused-outcome fields set alongside the pause flag). Each site's justification is one narrowing guard with a message.
- Every normal-absence path preserved exactly: optional loggers (`logger?.warn` behind a single guard), optional layout/output fallbacks, cache lookups. No behavior change on those paths.
- plugin-workflows detail: `dag.test.ts` included a site the line-grep missed (`skills[n]!` on a line also containing `!==`); caught by re-enumeration.

## Gate

`pnpm install` / `build` / `typecheck` / `lint` / `test` / `check:deps` — all exit 0 (direct exit codes, no pipes). The known `workflows.test.ts` fileChanged flake did not trigger. Changed files scanned for NUL/control bytes — clean.