### PR TITLE
refactor(client): replace non-null assertions and deep optional chains with guards

### DIFF
--- a/.changeset/assert-sweep-client.md
+++ b/.changeset/assert-sweep-client.md
@@ -1,0 +1,12 @@
+---
+'@moxxy/client-core': patch
+'@moxxy/client-transport-ws': patch
+'@moxxy/client-platform-web': patch
+'@moxxy/design-tokens': patch
+'@moxxy/ipc-server-ws': patch
+'@moxxy/plugin-channel-mobile': patch
+'@moxxy/plugin-channel-web': patch
+'@moxxy/plugin-channel-http': patch
+---
+
+Apply the "guard, don't chain" rule across the client-layer, IPC, and channel packages: replaced non-null assertions (`x!`) and depth-2+ optional chains with single-narrowing guard clauses (`assertDefined`/`invariant` from `@moxxy/sdk`, or local guards where `@moxxy/sdk` is not a dependency). Behavior is preserved — genuinely-optional single `?.` reads and silent absence paths are kept; only impossible-by-construction sites became loud throws. No runtime behavior change intended.

--- a/apps/mobile/src/chatTranscript.ts
+++ b/apps/mobile/src/chatTranscript.ts
@@ -165,9 +165,10 @@ export function buildCommittedChatTranscript(
   };
 
   const flushTools = (): void => {
-    if (tools.length === 0) return;
+    const first = tools[0];
+    if (!first) return;
     pushItem({
-      id: `tools:${tools[0]!.id}`,
+      id: `tools:${first.id}`,
       kind: 'tool-group',
       title: 'Tools',
       collapsed: true,
@@ -178,9 +179,10 @@ export function buildCommittedChatTranscript(
   };
 
   const flushSystem = (): void => {
-    if (systemEvents.length === 0) return;
+    const first = systemEvents[0];
+    if (!first) return;
     pushItem({
-      id: `system:${systemEvents[0]!.id}`,
+      id: `system:${first.id}`,
       kind: 'system-group',
       title: 'Runtime',
       collapsed: true,
@@ -307,7 +309,8 @@ export function buildCommittedChatTranscript(
 
   const uniqueEvents = dedupeEventsById(events);
   for (let index = 0; index < uniqueEvents.length; index += 1) {
-    const event = uniqueEvents[index]!;
+    const event = uniqueEvents[index];
+    if (!event) continue;
     const type = eventType(event);
 
     if (type === 'assistant_chunk') {

--- a/apps/mobile/src/components/ComposerSheet.tsx
+++ b/apps/mobile/src/components/ComposerSheet.tsx
@@ -81,7 +81,7 @@ export function ComposerSheet(props: ComposerSheetProps) {
   };
 
   const inArgs = page === 'actions' && props.actions.argsFor;
-  const title = page === 'model' ? 'Model' : page === 'mode' ? 'Mode' : page === 'actions' ? (inArgs ? props.actions.argsFor!.label : 'Actions') : 'Options';
+  const title = page === 'model' ? 'Model' : page === 'mode' ? 'Mode' : page === 'actions' ? (inArgs ? inArgs.label : 'Actions') : 'Options';
   const back = page === 'main' ? undefined : inArgs ? props.actions.onBack : backToMain;
 
   return (

--- a/apps/mobile/src/hooks/useAttachments.ts
+++ b/apps/mobile/src/hooks/useAttachments.ts
@@ -60,8 +60,9 @@ export function useAttachments(options: { readonly disabled?: boolean } = {}) {
         base64: true,
         quality: 0.92,
       });
-      if (result.canceled || result.assets.length === 0) return;
-      const asset = result.assets[0]!;
+      if (result.canceled) return;
+      const asset = result.assets[0];
+      if (!asset) return;
       const content = asset.base64 ?? await readBase64(asset.uri);
       const bytes = asset.fileSize ?? estimateBase64Bytes(content);
       const tooLarge = validateAttachmentBytes({ name: asset.fileName ?? 'image', bytes });
@@ -83,8 +84,9 @@ export function useAttachments(options: { readonly disabled?: boolean } = {}) {
     if (options.disabled) return;
     try {
       const result = await DocumentPicker.getDocumentAsync({ copyToCacheDirectory: true, multiple: false });
-      if (result.canceled || result.assets.length === 0) return;
-      const asset = result.assets[0]!;
+      if (result.canceled) return;
+      const asset = result.assets[0];
+      if (!asset) return;
       const mediaType = asset.mimeType ?? inferMediaType(asset.name);
       const name = asset.name || 'attachment';
       if (isTextAttachmentMediaType(mediaType)) {

--- a/apps/mobile/src/hooks/usePairing.ts
+++ b/apps/mobile/src/hooks/usePairing.ts
@@ -278,10 +278,13 @@ function readExpoHostUri(): string | null {
     manifest?: { debuggerHost?: string | null };
   };
 
+  const extra = constants.manifest2?.extra;
+  const expoClient = extra?.expoClient;
+  const expoGo = extra?.expoGo;
   return (
     constants.expoConfig?.hostUri ??
-    constants.manifest2?.extra?.expoClient?.hostUri ??
-    constants.manifest2?.extra?.expoGo?.debuggerHost ??
+    expoClient?.hostUri ??
+    expoGo?.debuggerHost ??
     constants.manifest?.debuggerHost ??
     null
   );

--- a/apps/mobile/src/liveActivity.ts
+++ b/apps/mobile/src/liveActivity.ts
@@ -247,10 +247,12 @@ export function createMoxxyLiveActivityClient(options: {
       return { active: true };
     },
     async end(snapshot) {
-      await nativeModule?.end?.(snapshot);
+      if (!nativeModule?.end) return;
+      await nativeModule.end(snapshot);
     },
     async notifyCompletion(notification) {
-      await nativeModule?.notifyCompletion?.(notification);
+      if (!nativeModule?.notifyCompletion) return;
+      await nativeModule.notifyCompletion(notification);
     },
   };
 }

--- a/apps/mobile/src/modeSelector.ts
+++ b/apps/mobile/src/modeSelector.ts
@@ -48,7 +48,8 @@ function normalizeBadge(value: MobileModeBadge | null): {
   readonly label: string;
   readonly tone: 'attention' | 'info';
 } | null {
-  const label = value?.label?.trim();
+  const rawLabel = value?.label;
+  const label = rawLabel?.trim();
   if (!label) return null;
   return {
     label,

--- a/apps/mobile/src/pairingRuntime.ts
+++ b/apps/mobile/src/pairingRuntime.ts
@@ -110,7 +110,10 @@ export function openBridgePairingTransport(
 }
 
 function cleanBridgeUrl(rawUrl: string): string {
-  const withoutQuery = rawUrl.split('#')[0]!.split('?')[0]!.trim();
+  // `String.split` always yields at least one element, so both `[0]` reads are
+  // present by construction; `?? ''` only satisfies the index type.
+  const beforeHash = rawUrl.split('#')[0] ?? '';
+  const withoutQuery = (beforeHash.split('?')[0] ?? '').trim();
   return withoutQuery.replace(/^(wss?:\/\/[^/]+)\/$/, '$1');
 }
 

--- a/apps/mobile/src/styles/tokens.ts
+++ b/apps/mobile/src/styles/tokens.ts
@@ -471,7 +471,7 @@ function parseUtility(token: string): AnyStyle | undefined {
       left: 'left',
     };
     // The regex alternation guarantees `key` is captured and present in `map`.
-    const styleKey = map[key!];
+    const styleKey = key ? map[key] : undefined;
     if (styleKey) return { [styleKey]: value } as ViewStyle;
   }
 

--- a/apps/mobile/test/mobile-navigation.test.ts
+++ b/apps/mobile/test/mobile-navigation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import {
   buildBottomTabs,
   buildComposerAttachmentActionItems,
@@ -217,7 +218,9 @@ describe('mobile chat chrome navigation model', () => {
     ], null);
 
     expect(sections).toHaveLength(1);
-    expect(sections[0]!.sessions.map((session) => session.id)).toEqual(['persisted-session']);
+    const section = sections[0];
+    assertDefined(section, 'sections has one entry');
+    expect(section.sessions.map((session) => session.id)).toEqual(['persisted-session']);
   });
 
   it('preserves the desktop session order inside each workspace section', () => {
@@ -252,7 +255,9 @@ describe('mobile chat chrome navigation model', () => {
       },
     ], 'wlacz');
 
-    expect(sections[0]!.sessions.map((session) => session.id)).toEqual([
+    const section = sections[0];
+    assertDefined(section, 'sections has a first entry');
+    expect(section.sessions.map((session) => session.id)).toEqual([
       'znasz',
       'czesc',
       'wlacz',

--- a/apps/mobile/test/mobile-pairing-runtime.test.ts
+++ b/apps/mobile/test/mobile-pairing-runtime.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { openBridgePairingTransport, resolveBridgePairingTarget } from '../src/pairingRuntime';
 
 describe('mobile bridge pairing runtime', () => {
@@ -54,7 +55,9 @@ describe('mobile bridge pairing runtime', () => {
     expect(configureTransport).toHaveBeenCalledWith(api);
     expect(configurePlatform).toHaveBeenCalledWith({});
     expect(handle.status()).toBe('connecting');
-    makeWsApiHandle.mock.calls[0]?.[0].onStatus?.('open');
+    const firstCall = makeWsApiHandle.mock.calls[0];
+    assertDefined(firstCall, 'handle was called at least once');
+    firstCall[0].onStatus?.('open');
     expect(handle.status()).toBe('open');
 
     handle.close();

--- a/apps/mobile/test/mobile-subagent-detail-ui.test.ts
+++ b/apps/mobile/test/mobile-subagent-detail-ui.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { buildSubagentDetailUi, selectSubagentDetailAgent } from '../src/subagentDetailUi';
 import type { SubagentGroupTranscriptItem, SubagentTranscriptItem } from '../src/chatTranscript';
 
@@ -83,6 +84,8 @@ describe('mobile subagent detail modal ui model', () => {
       summary: '1 default agent running',
       agents: [agent({ status: 'running', toolCallCount: 1 })],
     };
+    const firstAgent = firstGroup.agents[0];
+    assertDefined(firstAgent, 'firstGroup has an agent');
     const refreshedGroup: SubagentGroupTranscriptItem = {
       ...firstGroup,
       agents: [
@@ -90,7 +93,7 @@ describe('mobile subagent detail modal ui model', () => {
           status: 'running',
           toolCallCount: 2,
           toolCalls: [
-            ...firstGroup.agents[0]!.toolCalls,
+            ...firstAgent.toolCalls,
             {
               id: 'tool-2',
               name: 'web_fetch',

--- a/packages/client-core/src/askStore.test.ts
+++ b/packages/client-core/src/askStore.test.ts
@@ -7,6 +7,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AskRequest, AskResponse, MoxxyApi } from '@moxxy/desktop-ipc-contract';
+import { assertDefined } from '@moxxy/sdk';
 import { __setApiOverride } from './transport.js';
 import { askStore, wireAskBridge } from './askStore.js';
 
@@ -95,6 +96,7 @@ describe('wireAskBridge workflow asks', () => {
     });
 
     const globalAsk = askStore.getAll().find((item) => item.requestId.includes('run-global'));
+    assertDefined(globalAsk, 'the workflow pause surfaced a global ask');
     expect(globalAsk).toMatchObject({
       workspaceId: 'ws-workflows',
       kind: 'workflow',
@@ -107,14 +109,14 @@ describe('wireAskBridge workflow asks', () => {
       },
     });
 
-    askStore.respond(globalAsk!.requestId, { text: 'eggs and tomatoes' });
+    askStore.respond(globalAsk.requestId, { text: 'eggs and tomatoes' });
     await Promise.resolve();
 
     expect(invoke).toHaveBeenCalledWith('workflows.resume', {
       runId: 'run-global',
       reply: 'eggs and tomatoes',
     });
-    expect(askStore.getAll().some((item) => item.requestId === globalAsk!.requestId)).toBe(false);
+    expect(askStore.getAll().some((item) => item.requestId === globalAsk.requestId)).toBe(false);
 
     off();
   });

--- a/packages/client-core/src/chat-store/history-equivalence.test.ts
+++ b/packages/client-core/src/chat-store/history-equivalence.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { MoxxyEvent } from '@moxxy/sdk';
+import { assertDefined, type MoxxyEvent } from '@moxxy/sdk';
 import { chatStore } from './store.js';
 import { applyAction, createRuntime } from '../chatModel.js';
 import type { ChatPersistence } from '../chatPersistence.js';
@@ -132,13 +132,18 @@ function pageRawBySeq(before: number | null, limit: number): { events: MoxxyEven
   if (before !== null) {
     end = 0;
     for (let i = 0; i < RAW_LOG.length; i += 1) {
-      if (RAW_LOG[i]!.seq < before) end = i + 1;
+      const ev = RAW_LOG[i];
+      assertDefined(ev, 'loop index stays within the raw log bounds');
+      if (ev.seq < before) end = i + 1;
       else break;
     }
   }
   const start = Math.max(0, end - limit);
   const page = RAW_LOG.slice(start, end);
-  return { events: page, prevCursor: start <= 0 ? null : page[0]!.seq };
+  if (start <= 0) return { events: page, prevCursor: null };
+  const first = page[0];
+  assertDefined(first, 'a non-initial page has a first event');
+  return { events: page, prevCursor: first.seq };
 }
 
 /** The production backend serves history from the runner (raw + seq cursor). */

--- a/packages/client-core/src/chat-store/state.ts
+++ b/packages/client-core/src/chat-store/state.ts
@@ -140,7 +140,7 @@ export function buildSnapshot(slot: Slot): ChatSnapshot {
     return slot.snap;
   }
   const eventsChanged = !slot.snap || slot.snap.eventsVersion !== rt.log.version;
-  const events = eventsChanged ? rt.log.toArray() : slot.snap!.events;
+  const events = eventsChanged || !slot.snap ? rt.log.toArray() : slot.snap.events;
   slot.snap = {
     rev: rt.rev,
     eventsVersion: rt.log.version,

--- a/packages/client-core/src/chat-store/store.test.ts
+++ b/packages/client-core/src/chat-store/store.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { MoxxyEvent } from '@moxxy/sdk';
+import { assertDefined, type MoxxyEvent } from '@moxxy/sdk';
 import type { ChatPersistence } from '../chatPersistence.js';
 import { chatStore } from './store.js';
 
@@ -49,9 +49,13 @@ describe('chatStore slot isolation', () => {
     const snapB = chatStore.getChat(b);
     expect(snapA.events).toHaveLength(1);
     expect(snapB.events).toHaveLength(1);
-    expect(snapA.events[0]!.id).not.toBe(snapB.events[0]!.id);
+    const a0 = snapA.events[0];
+    const b0 = snapB.events[0];
+    assertDefined(a0, 'workspace A has its first event');
+    assertDefined(b0, 'workspace B has its first event');
+    expect(a0.id).not.toBe(b0.id);
     // A's events never leak into B's snapshot.
-    expect(snapA.events[0]!.id).not.toBe(snapB.events[0]!.id);
+    expect(a0.id).not.toBe(b0.id);
   });
 
   it('returns the shared EMPTY_SNAPSHOT for an unseen workspace', () => {
@@ -93,7 +97,8 @@ describe('chatStore queue', () => {
     chatStore.enqueue(id, 'a');
     chatStore.enqueue(id, 'b');
     chatStore.shiftQueue(id); // removes 'a'; queue.length now 1, rev unchanged
-    const survivor = chatStore.getQueue(id)[0]!;
+    const survivor = chatStore.getQueue(id)[0];
+    assertDefined(survivor, 'a queued item survives the shift');
     const fresh = chatStore.enqueue(id, 'c');
     // The freshly-minted id must NOT collide with the surviving item's id.
     expect(fresh).not.toBe(survivor.id);
@@ -107,8 +112,10 @@ describe('chatStore queue', () => {
     chatStore.enqueue(id, 'with', [{ path: '/a', name: 'a' }]);
     chatStore.enqueue(id, 'without', []);
     const [a, b] = chatStore.getQueue(id);
-    expect(a!.attachments).toEqual([{ path: '/a', name: 'a' }]);
-    expect(b!.attachments).toBeUndefined();
+    assertDefined(a, 'the first queued item is present');
+    assertDefined(b, 'the second queued item is present');
+    expect(a.attachments).toEqual([{ path: '/a', name: 'a' }]);
+    expect(b.attachments).toBeUndefined();
   });
 });
 
@@ -271,8 +278,10 @@ describe('chatStore compaction side-channel', () => {
     expect(chatStore.getUsage(id).latestPrompt).toBe(700);
     const snap = chatStore.getChat(id);
     expect(snap.extensions).toHaveLength(1);
-    expect(snap.extensions[0]!.kind).toBe('notice');
-    expect(snap.extensions[0]!.text).toContain('Context compacted');
+    const ext = snap.extensions[0];
+    assertDefined(ext, 'compaction appended a notice extension');
+    expect(ext.kind).toBe('notice');
+    expect(ext.text).toContain('Context compacted');
   });
 
   it('ignores a zero-tokensSaved compaction', () => {
@@ -330,13 +339,18 @@ describe('chatStore history loading', () => {
         if (before !== null) {
           end = 0;
           for (let i = 0; i < rawAscending.length; i += 1) {
-            if (rawAscending[i]!.seq < before) end = i + 1;
+            const ev = rawAscending[i];
+            assertDefined(ev, 'loop index stays within the raw log bounds');
+            if (ev.seq < before) end = i + 1;
             else break;
           }
         }
         const start = Math.max(0, end - limit);
         const page = rawAscending.slice(start, end);
-        return { events: page, prevCursor: start <= 0 ? null : page[0]!.seq };
+        if (start <= 0) return { events: page, prevCursor: null };
+        const first = page[0];
+        assertDefined(first, 'a non-initial page has a first event');
+        return { events: page, prevCursor: first.seq };
       },
     };
     return { persistence, calls: () => calls };

--- a/packages/client-core/src/chat-store/store.ts
+++ b/packages/client-core/src/chat-store/store.ts
@@ -635,7 +635,8 @@ function maxEventSeq(events: ReadonlyArray<MoxxyEvent>): number | null {
 
 function terminalEventForTurn(events: ReadonlyArray<MoxxyEvent>, turnId: string): MoxxyEvent | null {
   for (let index = events.length - 1; index >= 0; index -= 1) {
-    const event = events[index]!;
+    const event = events[index];
+    if (!event) continue;
     if (event.turnId !== turnId) continue;
     if (event.type === 'assistant_message') return event.stopReason === 'tool_use' ? null : event;
     if (event.type === 'abort') return event;

--- a/packages/client-core/src/chat-store/usage.test.ts
+++ b/packages/client-core/src/chat-store/usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { MoxxyEvent } from '@moxxy/sdk';
+import { assertDefined, type MoxxyEvent } from '@moxxy/sdk';
 import { EMPTY_USAGE, PER_CALL_CAP, recordUsage } from './usage.js';
 
 type ProviderResponse = Extract<MoxxyEvent, { type: 'provider_response' }>;
@@ -28,8 +28,12 @@ describe('recordUsage', () => {
 
   it('folds prompt + output token counts cumulatively', () => {
     let u = EMPTY_USAGE;
-    u = recordUsage(u, providerResponse({ inputTokens: 100, outputTokens: 20 }))!;
-    u = recordUsage(u, providerResponse({ inputTokens: 50, cacheReadTokens: 10, outputTokens: 5 }))!;
+    const u1 = recordUsage(u, providerResponse({ inputTokens: 100, outputTokens: 20 }));
+    assertDefined(u1, 'a prompt-bearing call folds to a usage snapshot');
+    u = u1;
+    const u2 = recordUsage(u, providerResponse({ inputTokens: 50, cacheReadTokens: 10, outputTokens: 5 }));
+    assertDefined(u2, 'a prompt-bearing call folds to a usage snapshot');
+    u = u2;
     expect(u.calls).toBe(2);
     expect(u.totalInput).toBe(150);
     expect(u.totalCacheRead).toBe(10);
@@ -41,9 +45,13 @@ describe('recordUsage', () => {
 
   it('counts an output-only call without growing perCall', () => {
     let u = EMPTY_USAGE;
-    u = recordUsage(u, providerResponse({ inputTokens: 100 }))!;
+    const u1 = recordUsage(u, providerResponse({ inputTokens: 100 }));
+    assertDefined(u1, 'a prompt-bearing call folds to a usage snapshot');
+    u = u1;
     const beforeLen = u.perCall.length;
-    u = recordUsage(u, providerResponse({ outputTokens: 12 }))!;
+    const u2 = recordUsage(u, providerResponse({ outputTokens: 12 }));
+    assertDefined(u2, 'an output-only call folds to a usage snapshot');
+    u = u2;
     expect(u.calls).toBe(2);
     expect(u.totalOutput).toBe(12);
     // No prompt tokens → no new sparkline point, latestPrompt unchanged.
@@ -56,7 +64,9 @@ describe('recordUsage', () => {
     const calls = PER_CALL_CAP + 50;
     for (let i = 0; i < calls; i += 1) {
       // distinct prompt size per call so we can assert the retained window.
-      u = recordUsage(u, providerResponse({ inputTokens: i + 1 }))!;
+      const next = recordUsage(u, providerResponse({ inputTokens: i + 1 }));
+      assertDefined(next, 'a prompt-bearing call folds to a usage snapshot');
+      u = next;
     }
     // perCall is bounded; the OLDEST entries were evicted, newest kept.
     expect(u.perCall).toHaveLength(PER_CALL_CAP);

--- a/packages/client-core/src/chatModel.test.ts
+++ b/packages/client-core/src/chatModel.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { MoxxyEvent } from '@moxxy/sdk';
+import { assertDefined, type MoxxyEvent } from '@moxxy/sdk';
 import {
   applyAction,
   applyEvent,
@@ -180,8 +180,10 @@ describe('chat model runtime', () => {
     expect(tools).toHaveLength(2);
     const c1 = tools.find((t) => t.request.callId === 'c1');
     const c2 = tools.find((t) => t.request.callId === 'c2');
-    expect(c1!.outcome).toMatchObject({ type: 'tool_result', ok: true });
-    expect(c2!.outcome).toBeNull();
+    assertDefined(c1, 'tool call c1 is present');
+    assertDefined(c2, 'tool call c2 is present');
+    expect(c1.outcome).toMatchObject({ type: 'tool_result', ok: true });
+    expect(c2.outcome).toBeNull();
   });
 
   it('carries tool_result error.message through', () => {
@@ -189,7 +191,8 @@ describe('chat model runtime', () => {
     applyEvent(rt, toolReq('c1', 'grep', {}));
     applyEvent(rt, toolRes('c1', false, undefined, { message: 'boom', kind: 'threw' }));
     const tool = blocksOf(rt).find((b): b is Extract<FoldedBlock, { kind: 'tool-call' }> => b.kind === 'tool-call');
-    expect(tool!.outcome).toMatchObject({ type: 'tool_result', ok: false, error: { message: 'boom' } });
+    assertDefined(tool, 'tool-call block is present');
+    expect(tool.outcome).toMatchObject({ type: 'tool_result', ok: false, error: { message: 'boom' } });
   });
 
   it('renders error events as an event block', () => {
@@ -256,7 +259,9 @@ describe('buildRenderNodes', () => {
   it('dismiss_block removes an extension', () => {
     const rt = createRuntime();
     applyAction(rt, { type: 'action_result', commandName: 'x', argsLine: '', tone: 'info', text: 'y' });
-    const id = rt.extensions[0]!.id;
+    const ext = rt.extensions[0];
+    assertDefined(ext, 'action_result added an extension');
+    const id = ext.id;
     const changed = applyAction(rt, { type: 'dismiss_block', blockId: id });
     expect(changed).toBe(true);
     expect(rt.extensions).toEqual([]);
@@ -298,7 +303,8 @@ describe('groupToolNodes', () => {
     const b = toolNode('grep');
     const out = groupToolNodes([a, b]);
     expect(out).toHaveLength(1);
-    const group = out[0]!;
+    const group = out[0];
+    assertDefined(group, 'grouping yields at least one node');
     expect(group.kind).toBe('tool-group');
     if (group.kind !== 'tool-group') throw new Error('unreachable');
     expect(group.id).toBe(`toolgroup:${(a as { block: ToolCallBlockData }).block.id}`);
@@ -308,7 +314,9 @@ describe('groupToolNodes', () => {
   it('keeps a lone tool as its own block (run of 1 is not grouped)', () => {
     const out = groupToolNodes([toolNode('bash')]);
     expect(out).toHaveLength(1);
-    expect(out[0]!.kind).toBe('block');
+    const node = out[0];
+    assertDefined(node, 'grouping yields at least one node');
+    expect(node.kind).toBe('block');
   });
 
   it('never folds a Write/Edit (FILE_DIFF) tool into a group', () => {
@@ -332,7 +340,8 @@ describe('groupToolNodes', () => {
     const out = groupToolNodes([eventNode(), toolNode('bash'), toolNode('grep'), toolNode('ls')]);
     // event + one tool-group of 3
     expect(out.map((n) => n.kind)).toEqual(['block', 'tool-group']);
-    const group = out[1]!;
+    const group = out[1];
+    assertDefined(group, 'grouping yields a second node');
     if (group.kind !== 'tool-group') throw new Error('unreachable');
     expect(group.tools).toHaveLength(3);
   });

--- a/packages/client-core/src/chatModel.ts
+++ b/packages/client-core/src/chatModel.ts
@@ -68,10 +68,13 @@ export function groupToolNodes(nodes: ReadonlyArray<RenderNode>): RenderNode[] {
   const out: RenderNode[] = [];
   let run: ToolCallBlockData[] = [];
   const flush = (): void => {
-    if (run.length >= 2) {
-      out.push({ kind: 'tool-group', id: `toolgroup:${run[0]!.id}`, tools: run });
-    } else if (run.length === 1) {
-      out.push({ kind: 'block', block: run[0]! });
+    const first = run[0];
+    if (first) {
+      if (run.length >= 2) {
+        out.push({ kind: 'tool-group', id: `toolgroup:${first.id}`, tools: run });
+      } else {
+        out.push({ kind: 'block', block: first });
+      }
     }
     run = [];
   };

--- a/packages/client-core/src/useDesks.test.tsx
+++ b/packages/client-core/src/useDesks.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { Desk, DesksOverview, IpcEvents, MoxxyApi } from '@moxxy/desktop-ipc-contract';
+import { assertDefined } from '@moxxy/sdk';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { __setApiOverride } from './transport';
@@ -127,7 +128,11 @@ describe('useDesks', () => {
       renamePromise = result.current.renameSession('session-a', 'New name');
     });
 
-    expect(result.current.desks[0]?.sessions[0]?.name).toBe('New name');
+    const optimisticDesk = result.current.desks[0];
+    assertDefined(optimisticDesk, 'a desk is present after the optimistic rename');
+    const optimisticSession = optimisticDesk.sessions[0];
+    assertDefined(optimisticSession, 'the desk has a session after the optimistic rename');
+    expect(optimisticSession.name).toBe('New name');
     expect(resolveRename).not.toBeNull();
 
     host.invoke.mockImplementation((cmd: string) => {
@@ -141,7 +146,11 @@ describe('useDesks', () => {
     await act(async () => {
       await renamePromise;
     });
-    expect(result.current.desks[0]?.sessions[0]?.name).toBe('New name');
+    const finalDesk = result.current.desks[0];
+    assertDefined(finalDesk, 'a desk is present after the host refresh');
+    const finalSession = finalDesk.sessions[0];
+    assertDefined(finalSession, 'the desk has a session after the host refresh');
+    expect(finalSession.name).toBe('New name');
   });
 
   it('keeps an optimistic session switch when a stale desks.changed arrives while the host is loading', async () => {

--- a/packages/client-platform-web/src/audio-capture.test.ts
+++ b/packages/client-platform-web/src/audio-capture.test.ts
@@ -33,7 +33,12 @@ class FakeRecorder {
   stopCalls = 0;
   private listeners = new Map<string, Set<(ev: unknown) => void>>();
   addEventListener(type: string, fn: (ev: unknown) => void): void {
-    (this.listeners.get(type) ?? this.listeners.set(type, new Set()).get(type)!).add(fn);
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(fn);
   }
   removeEventListener(type: string, fn: (ev: unknown) => void): void {
     this.listeners.get(type)?.delete(fn);

--- a/packages/client-platform-web/src/event-bus.test.ts
+++ b/packages/client-platform-web/src/event-bus.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -28,15 +29,16 @@ describe('webEventBus', () => {
     vi.resetModules();
     const { webEventBus } = await import('./event-bus.js');
     expect(webEventBus).toBeDefined();
+    assertDefined(webEventBus, 'a window exists so the bus is defined');
 
     const handler = (): void => {};
-    const off = webEventBus!.on('x', handler);
+    const off = webEventBus.on('x', handler);
     expect(addEventListener).toHaveBeenCalledWith('x', handler);
 
     off();
     expect(removeEventListener).toHaveBeenCalledWith('x', handler);
 
-    webEventBus!.emit('y');
+    webEventBus.emit('y');
     expect(dispatchEvent).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/client-platform-web/src/tts.test.ts
+++ b/packages/client-platform-web/src/tts.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 
 /** A controllable fake <audio> element: records the src it was built with and
  *  lets a test drive its lifecycle events and the play() promise. */
@@ -86,12 +87,14 @@ describe('playAudioClip', () => {
     expect(FakeAudio.last?.src).toBe(created[0]);
 
     // Engine signals natural completion.
-    FakeAudio.last?.onended?.();
+    const audio = FakeAudio.last;
+    assertDefined(audio, 'an audio element was created');
+    audio.onended?.();
     expect(onend).toHaveBeenCalledTimes(1);
     expect(revoked).toEqual([created[0]]);
 
     // A second onended must NOT double-revoke or re-fire the callback.
-    FakeAudio.last?.onended?.();
+    audio.onended?.();
     expect(onend).toHaveBeenCalledTimes(1);
     expect(revoked).toEqual([created[0]]);
   });
@@ -107,7 +110,9 @@ describe('playAudioClip', () => {
 
     // stop() again + a stale onended must not revoke twice nor fire onend.
     handle.stop();
-    FakeAudio.last?.onended?.();
+    const audio = FakeAudio.last;
+    assertDefined(audio, 'an audio element was created');
+    audio.onended?.();
     expect(revoked).toEqual([created[0]]);
     expect(onend).not.toHaveBeenCalled();
   });
@@ -125,7 +130,9 @@ describe('playAudioClip', () => {
 
     // The element later reports it can't decode → onerror fires once, no revoke
     // (there is no object URL to revoke).
-    FakeAudio.last?.onerror?.();
+    const audio = FakeAudio.last;
+    assertDefined(audio, 'an audio element was created');
+    audio.onerror?.();
     expect(onerror).toHaveBeenCalledTimes(1);
     expect(revoked).toHaveLength(0);
   });

--- a/packages/client-transport-ws/src/json-rpc-client.test.ts
+++ b/packages/client-transport-ws/src/json-rpc-client.test.ts
@@ -9,6 +9,10 @@ import {
 } from './json-rpc-client.js';
 import { makeWsApi, makeWsApiHandle } from './index.js';
 
+function assertDefined<T>(v: T, msg: string): asserts v is NonNullable<T> {
+  if (v === null || v === undefined) throw new Error(msg);
+}
+
 class FakeSocket implements WebSocketLike {
   sent: string[] = [];
   readyState = 0;
@@ -35,7 +39,9 @@ class FakeSocket implements WebSocketLike {
     this.onmessage?.({ data: JSON.stringify(frame) });
   }
   lastReq(): { id: number; method: string; params?: unknown } {
-    return JSON.parse(this.sent[this.sent.length - 1]!);
+    const raw = this.sent[this.sent.length - 1];
+    assertDefined(raw, 'a request frame was sent');
+    return JSON.parse(raw);
   }
 }
 
@@ -53,7 +59,9 @@ function makeClient(opts: WsRpcClientOptions = {}): {
   }
   const client = new WsRpcClient('ws://x:1', CtorFake as unknown as WebSocketCtor, opts);
   client.connect();
-  return { client, socket: instances[0]!, instances };
+  const socket = instances[0];
+  assertDefined(socket, 'connect() constructs the first socket');
+  return { client, socket, instances };
 }
 
 function makeFakeSocketCtor(): {
@@ -131,7 +139,8 @@ describe('WsRpcClient', () => {
 
     // Reconnect: the abandoned runTurn must NOT be re-executed.
     vi.advanceTimersByTime(60_000);
-    const next = instances[1]!;
+    const next = instances[1];
+    assertDefined(next, 'the reconnect constructs a second socket');
     next.open();
     expect(next.sent).toEqual([]);
     client.close();
@@ -141,9 +150,11 @@ describe('WsRpcClient', () => {
     vi.useFakeTimers();
     const statuses: WsClientStatus[] = [];
     const { instances } = makeClient({ onStatus: (s) => statuses.push(s) });
-    instances[0]!.open();
+    const socket0 = instances[0];
+    assertDefined(socket0, 'connect() constructs the first socket');
+    socket0.open();
     statuses.length = 0; // discard 'connecting'/'open' from setup
-    instances[0]!.close();
+    socket0.close();
     // The socket is dead and the reconnect timer has NOT fired yet — status must
     // already reflect the degraded state rather than lingering on 'open'.
     expect(statuses).toContain('reconnecting');
@@ -163,13 +174,19 @@ describe('WsRpcClient', () => {
       onStatus: (s) => statuses.push(s),
     });
     // Drop the link three times: two reconnect attempts, then terminal.
-    instances[0]!.close();
+    const socket0 = instances[0];
+    assertDefined(socket0, 'connect() constructs the first socket');
+    socket0.close();
     vi.advanceTimersByTime(60_000);
     expect(instances.length).toBe(2);
-    instances[1]!.close();
+    const socket1 = instances[1];
+    assertDefined(socket1, 'the first reconnect constructs a second socket');
+    socket1.close();
     vi.advanceTimersByTime(60_000);
     expect(instances.length).toBe(3);
-    instances[2]!.close();
+    const socket2 = instances[2];
+    assertDefined(socket2, 'the second reconnect constructs a third socket');
+    socket2.close();
     vi.advanceTimersByTime(600_000);
     expect(instances.length).toBe(3); // no further attempts
 
@@ -236,13 +253,15 @@ describe('WsRpcClient', () => {
   it('does not dispatch a frame from a stale dead socket after a drop', () => {
     vi.useFakeTimers();
     const { client, instances } = makeClient({ maxReconnectAttempts: 5 });
-    instances[0]!.open();
+    const socket = instances[0];
+    assertDefined(socket, 'connect() constructs the first socket');
+    socket.open();
     let got = 0;
     client.on('runner.turn.complete', () => got++);
-    instances[0]!.close(); // link drops; handleClose detaches the dead socket
+    socket.close(); // link drops; handleClose detaches the dead socket
     // A stale notification the dead socket buffered must not dispatch into the
     // reconnecting client.
-    instances[0]!.emit({ method: 'runner.turn.complete', params: {} });
+    socket.emit({ method: 'runner.turn.complete', params: {} });
     expect(got).toBe(0);
     client.close();
   });
@@ -250,11 +269,13 @@ describe('WsRpcClient', () => {
   it('ignores a late onopen from a stale socket (does not flush into it)', async () => {
     vi.useFakeTimers();
     const { client, instances } = makeClient({ maxReconnectAttempts: 5 });
-    const stale = instances[0]!;
+    const stale = instances[0];
+    assertDefined(stale, 'connect() constructs the first socket');
     stale.close(); // drop -> handleClose detaches `stale`
     expect(stale.onopen).toBeNull(); // handlers detached on the dead socket
     vi.advanceTimersByTime(60_000);
-    const fresh = instances[1]!;
+    const fresh = instances[1];
+    assertDefined(fresh, 'the reconnect constructs a second socket');
     // Queue a frame while the fresh socket is still connecting.
     const pending = client.request('connection.activeWorkspace');
     // The fresh socket opens and the queued frame flushes into the LIVE socket,
@@ -269,10 +290,14 @@ describe('WsRpcClient', () => {
   it('resets the reconnect budget after a successful open', () => {
     vi.useFakeTimers();
     const { client, instances } = makeClient({ maxReconnectAttempts: 1 });
-    instances[0]!.close(); // attempt 1 scheduled
+    const socket0 = instances[0];
+    assertDefined(socket0, 'connect() constructs the first socket');
+    socket0.close(); // attempt 1 scheduled
     vi.advanceTimersByTime(60_000);
-    instances[1]!.open(); // success resets the budget
-    instances[1]!.close(); // a fresh drop gets a fresh attempt
+    const socket1 = instances[1];
+    assertDefined(socket1, 'the reconnect constructs a second socket');
+    socket1.open(); // success resets the budget
+    socket1.close(); // a fresh drop gets a fresh attempt
     vi.advanceTimersByTime(60_000);
     expect(instances.length).toBe(3);
     expect(client.status).not.toBe('disconnected');
@@ -286,7 +311,8 @@ describe('makeWsApiHandle', () => {
     const { api, close } = makeWsApiHandle({ url: 'ws://host:8765', WebSocket });
 
     expect(instances).toHaveLength(1);
-    const socket = instances[0]!;
+    const socket = instances[0];
+    assertDefined(socket, 'the api constructs a socket');
     const p = api.invoke('connection.activeWorkspace');
     expect(socket.sent).toEqual([]);
 
@@ -302,7 +328,8 @@ describe('makeWsApiHandle', () => {
   it('returns an api that subscribes to WebSocket notifications', () => {
     const { WebSocket, instances } = makeFakeSocketCtor();
     const { api, close } = makeWsApiHandle({ url: 'ws://host:8765', WebSocket });
-    const socket = instances[0]!;
+    const socket = instances[0];
+    assertDefined(socket, 'the api constructs a socket');
     socket.open();
     const got: unknown[] = [];
 
@@ -322,7 +349,8 @@ describe('makeWsApiHandle', () => {
   it('closes the underlying WebSocket client', () => {
     const { WebSocket, instances } = makeFakeSocketCtor();
     const { close } = makeWsApiHandle({ url: 'ws://host:8765', WebSocket });
-    const socket = instances[0]!;
+    const socket = instances[0];
+    assertDefined(socket, 'the api constructs a socket');
 
     close();
 
@@ -334,7 +362,8 @@ describe('makeWsApi', () => {
   it('still returns the api directly', async () => {
     const { WebSocket, instances } = makeFakeSocketCtor();
     const api = makeWsApi({ url: 'ws://host:8765', WebSocket });
-    const socket = instances[0]!;
+    const socket = instances[0];
+    assertDefined(socket, 'the api constructs a socket');
     socket.open();
 
     const p = api.invoke('connection.activeWorkspace');
@@ -352,7 +381,8 @@ describe('makeWsApi', () => {
       token: 'tok+en=1',
       WebSocket,
     });
-    const socket = instances[0]!;
+    const socket = instances[0];
+    assertDefined(socket, 'the api constructs a socket');
     expect(socket.url).toBe('ws://host:8765'); // no ?t= in the URL
     expect(socket.protocols).toEqual(['moxxy.v1', 'moxxy.bearer.tok%2Ben%3D1']);
   });
@@ -360,6 +390,8 @@ describe('makeWsApi', () => {
   it('omits subprotocols when no token is configured', () => {
     const { WebSocket, instances } = makeFakeSocketCtor();
     makeWsApi({ url: 'ws://host:8765', WebSocket });
-    expect(instances[0]!.protocols).toBeUndefined();
+    const socket = instances[0];
+    assertDefined(socket, 'the api constructs a socket');
+    expect(socket.protocols).toBeUndefined();
   });
 });

--- a/packages/client-transport-ws/src/json-rpc-client.ts
+++ b/packages/client-transport-ws/src/json-rpc-client.ts
@@ -172,7 +172,7 @@ export class WsRpcClient {
     return new Promise<unknown>((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
       const frame = JSON.stringify({ id, method, ...(params !== undefined ? { params } : {}) });
-      if (open) this.socket!.send(frame);
+      if (open && this.socket) this.socket.send(frame);
       else this.outbox.push(frame);
     });
   }

--- a/packages/client-transport-ws/src/pairing.ts
+++ b/packages/client-transport-ws/src/pairing.ts
@@ -28,8 +28,10 @@ export function splitConnectUrl(scanned: string): {
   const read = (name: string): string | undefined => {
     const m = new RegExp(`[?&]${name}=([^&#]+)`).exec(scanned);
     if (!m) return undefined;
+    const encoded = m[1];
+    if (encoded === undefined) return undefined;
     try {
-      return decodeURIComponent(m[1]!);
+      return decodeURIComponent(encoded);
     } catch {
       return undefined;
     }

--- a/packages/design-tokens/src/css-vars.test.ts
+++ b/packages/design-tokens/src/css-vars.test.ts
@@ -20,7 +20,8 @@ const NAME_OVERRIDES: Record<string, string> = {
   'gradient.accent': '--grad-accent',
 };
 function expectedVarName(path: string): string {
-  if (NAME_OVERRIDES[path]) return NAME_OVERRIDES[path]!;
+  const override = NAME_OVERRIDES[path];
+  if (override) return override;
   return `--${path
     .split('.')
     .map((s) => s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase())
@@ -79,7 +80,8 @@ describe('generateThemeCss', () => {
   });
 
   it('declares every dark-mapped variable with its darkTokens value', () => {
-    const dark = generateThemeCss().split('[data-theme="dark"]')[1]!;
+    const dark = generateThemeCss().split('[data-theme="dark"]')[1];
+    if (dark === undefined) throw new Error('generated CSS contains a dark-theme block');
     for (const [name, value] of DARK_CSS_VAR_MAP) {
       expect(dark).toContain(`  ${name}: ${value};`);
     }
@@ -250,7 +252,10 @@ describe.skipIf(!stylesExists)('apps/desktop styles.css parity', () => {
   function declsOf(block: string): Map<string, string> {
     const map = new Map<string, string>();
     for (const m of block.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
-      map.set(m[1]!, m[2]!.trim().replace(/\s+/g, ' '));
+      const name = m[1];
+      const value = m[2];
+      if (name === undefined || value === undefined) continue;
+      map.set(name, value.trim().replace(/\s+/g, ' '));
     }
     return map;
   }

--- a/packages/ipc-server-ws/src/ws-transport.test.ts
+++ b/packages/ipc-server-ws/src/ws-transport.test.ts
@@ -2,6 +2,7 @@ import net from 'node:net';
 import { describe, it, expect, afterEach } from 'vitest';
 import WebSocket from 'ws';
 import type { Transport } from '@moxxy/runner';
+import { assertDefined } from '@moxxy/sdk';
 import { encodeWsBearerProtocol, MOXXY_WS_SUBPROTOCOL } from '@moxxy/sdk/server';
 import {
   createWebSocketTransportServer,
@@ -262,8 +263,9 @@ describe('createWebSocketTransportServer', () => {
     (client as unknown as { _socket: net.Socket })._socket.pause();
 
     expect(accepted).toBeDefined();
+    assertDefined(accepted, 'a server connection was accepted');
     const big = 'x'.repeat(256 * 1024);
-    for (let i = 0; i < 200; i++) accepted!.send({ big });
+    for (let i = 0; i < 200; i++) accepted.send({ big });
     // Still admitted right after the blast — the per-send check did NOT evict
     // (backlog is under the hard ceiling and grace has not elapsed).
     expect(server.clientCount()).toBe(1);

--- a/packages/plugin-channel-http/src/channel.ts
+++ b/packages/plugin-channel-http/src/channel.ts
@@ -121,7 +121,8 @@ export class HttpChannel implements Channel<HttpStartOpts> {
       } catch (err) {
         // Log the full error server-side; return a generic message so internal
         // paths/provider details can't leak to a (possibly remote) caller.
-        this.logger?.warn?.('http handler threw', { err: String(err) });
+        const logger = this.logger;
+        if (logger?.warn) logger.warn('http handler threw', { err: String(err) });
         if (!res.headersSent) {
           res.writeHead(500, { 'content-type': 'application/json' });
           res.end(JSON.stringify({ error: 'internal' }));
@@ -169,16 +170,19 @@ export class HttpChannel implements Channel<HttpStartOpts> {
         // `running` promise so callers awaiting it observe the crash instead of
         // mistaking it for a clean shutdown.
         server.on('error', (err: unknown) => {
-          this.logger?.warn?.('http server error', { err: String(err) });
+          const logger = this.logger;
+          if (logger?.warn) logger.warn('http server error', { err: String(err) });
           rejectRunning(err);
         });
         const addr = server.address();
         this.boundPortValue = typeof addr === 'object' && addr ? addr.port : this.port;
-        this.logger?.info?.('http channel listening', {
-          host: this.host,
-          port: this.boundPortValue,
-          authEnabled: this.authToken !== null,
-        });
+        const logger = this.logger;
+        if (logger?.info)
+          logger.info('http channel listening', {
+            host: this.host,
+            port: this.boundPortValue,
+            authEnabled: this.authToken !== null,
+          });
         resolve();
       });
     });
@@ -201,7 +205,8 @@ export class HttpChannel implements Channel<HttpStartOpts> {
         await new Promise<void>((resolve) => {
           if (!srv) return resolve();
           srv.close((err) => {
-            if (err) this.logger?.warn?.('http server close error', { err: String(err) });
+            const logger = this.logger;
+            if (err && logger?.warn) logger.warn('http server close error', { err: String(err) });
             resolve();
           });
         });

--- a/packages/plugin-channel-http/src/router.test.ts
+++ b/packages/plugin-channel-http/src/router.test.ts
@@ -3,7 +3,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import { Readable } from 'node:stream';
 import { Socket } from 'node:net';
 import { Session, silentLogger } from '@moxxy/core';
-import { defineTranscriber } from '@moxxy/sdk';
+import { assertDefined, defineTranscriber } from '@moxxy/sdk';
 import type { ClientSession } from '@moxxy/sdk';
 import {
   routeRequest,
@@ -80,7 +80,9 @@ function makeResponse(): ServerResponse & {
     },
     on(event: string, fn: (...args: unknown[]) => void) {
       if (!listeners.has(event)) listeners.set(event, new Set());
-      listeners.get(event)!.add(fn);
+      const set = listeners.get(event);
+      assertDefined(set, 'listener set exists after ensure');
+      set.add(fn);
       return this;
     },
     once(event: string, fn: (...args: unknown[]) => void) {
@@ -89,7 +91,9 @@ function makeResponse(): ServerResponse & {
         fn(...args);
       };
       if (!listeners.has(event)) listeners.set(event, new Set());
-      listeners.get(event)!.add(wrap);
+      const set = listeners.get(event);
+      assertDefined(set, 'listener set exists after ensure');
+      set.add(wrap);
       return this;
     },
     off(event: string, fn: (...args: unknown[]) => void) {
@@ -255,7 +259,8 @@ describe('handleTurn — client-disconnect abort (u70-1)', () => {
         resolveClosed();
         return (async function* () {
           await new Promise<void>((resolve) => {
-            opts?.signal?.addEventListener('abort', () => resolve());
+            const signal = opts?.signal;
+            signal?.addEventListener('abort', () => resolve());
           });
         })();
       },
@@ -276,9 +281,10 @@ describe('handleTurn — client-disconnect abort (u70-1)', () => {
     // Wait until runTurn is in-flight, then simulate the client disconnect.
     await sawSignal;
     expect(capturedSignal).toBeDefined();
-    expect(capturedSignal!.aborted).toBe(false);
+    assertDefined(capturedSignal, 'an abort signal was captured');
+    expect(capturedSignal.aborted).toBe(false);
     res._emit('close');
-    expect(capturedSignal!.aborted).toBe(true);
+    expect(capturedSignal.aborted).toBe(true);
 
     await handlerDone;
     // The close listener is detached after the turn settles (no leak).
@@ -323,7 +329,10 @@ describe('driveTurn', () => {
         signal = opts?.signal;
         started();
         return (async function* () {
-          await new Promise<void>((resolve) => opts?.signal?.addEventListener('abort', () => resolve()));
+          await new Promise<void>((resolve) => {
+            const sig = opts?.signal;
+            sig?.addEventListener('abort', () => resolve());
+          });
         })();
       },
     } as unknown as ClientSession;
@@ -331,9 +340,10 @@ describe('driveTurn', () => {
     const res = makeResponse();
     const done = driveTurn(session, 'hi', {}, res);
     await inFlight;
-    expect(signal!.aborted).toBe(false);
+    assertDefined(signal, 'an abort signal was captured');
+    expect(signal.aborted).toBe(false);
     res._emit('close');
-    expect(signal!.aborted).toBe(true);
+    expect(signal.aborted).toBe(true);
     await done;
   });
 
@@ -436,7 +446,10 @@ describe('handleTurn — concurrency cap', () => {
     ({
       runTurn: (_p: string, opts?: { signal?: AbortSignal }) =>
         (async function* () {
-          await new Promise<void>((resolve) => opts?.signal?.addEventListener('abort', () => resolve()));
+          await new Promise<void>((resolve) => {
+            const signal = opts?.signal;
+            signal?.addEventListener('abort', () => resolve());
+          });
         })(),
     }) as unknown as ClientSession;
 
@@ -502,7 +515,8 @@ describe('driveTurn — buffered-events bound', () => {
     let aborted = false;
     const session = {
       runTurn: (_p: string, opts?: { signal?: AbortSignal }) => {
-        opts?.signal?.addEventListener('abort', () => {
+        const signal = opts?.signal;
+        signal?.addEventListener('abort', () => {
           aborted = true;
         });
         return (async function* () {
@@ -604,13 +618,14 @@ describe('handleTurnStream — backpressure + closed-socket safety', () => {
     // Let the handler reach the first parked write.
     await new Promise((r) => setTimeout(r, 5));
     expect(settled).toBe(false);
-    expect(signal!.aborted).toBe(false);
+    assertDefined(signal, 'an abort signal was captured');
+    expect(signal.aborted).toBe(false);
 
     // Fire the inactivity timeout — must abort the turn and let the handler exit.
     res._fireTimeout();
     await done;
     expect(settled).toBe(true);
-    expect(signal!.aborted).toBe(true);
+    expect(signal.aborted).toBe(true);
   });
 
   it('disarms the stall timer after the stream settles cleanly', async () => {
@@ -640,7 +655,10 @@ describe('handleTurnStream — backpressure + closed-socket safety', () => {
       runTurn: (_p: string, opts?: { signal?: AbortSignal }) => {
         signal = opts?.signal;
         return (async function* () {
-          await new Promise<void>((resolve) => opts?.signal?.addEventListener('abort', () => resolve()));
+          await new Promise<void>((resolve) => {
+            const sig = opts?.signal;
+            sig?.addEventListener('abort', () => resolve());
+          });
         })();
       },
     } as unknown as ClientSession;
@@ -656,7 +674,8 @@ describe('handleTurnStream — backpressure + closed-socket safety', () => {
     // Emit a socket error mid-stream — must not propagate.
     expect(() => res._emit('error', new Error('ECONNRESET'))).not.toThrow();
     await expect(done).resolves.toBeUndefined();
-    expect(signal!.aborted).toBe(true);
+    assertDefined(signal, 'an abort signal was captured');
+    expect(signal.aborted).toBe(true);
     expect(warn).toHaveBeenCalledWith('http stream response error', expect.objectContaining({}));
   });
 });

--- a/packages/plugin-channel-mobile/src/channel.ts
+++ b/packages/plugin-channel-mobile/src/channel.ts
@@ -161,9 +161,11 @@ export class MobileChannel implements Channel<MobileStartOpts> {
     // from what a restart resolves and silently revoke nothing durable. Refuse
     // and tell the caller to rotate at the source instead of faking success.
     if (this.tokenPinned) {
-      this.logger?.warn?.(
-        'mobile token is pinned via MOXXY_MOBILE_TOKEN / config — rotate it at the source; the persisted secret is not used',
-      );
+      const logger = this.logger;
+      if (logger?.warn)
+        logger.warn(
+          'mobile token is pinned via MOXXY_MOBILE_TOKEN / config — rotate it at the source; the persisted secret is not used',
+        );
       return this.token;
     }
     this.token = rotateMobileToken();
@@ -180,7 +182,10 @@ export class MobileChannel implements Channel<MobileStartOpts> {
     // `allowedCommands: null` keeps that curated subset authoritative here.
     const bus = new WebSocketCommandBus({ allowedCommands: null });
     const host = new MobileSessionHost(bus, startOpts.session, {
-      logErr: (err) => this.logger?.warn?.('mobile host background error', { err: String(err) }),
+      logErr: (err) => {
+        const logger = this.logger;
+        if (logger?.warn) logger.warn('mobile host background error', { err: String(err) });
+      },
     });
     this.host = host;
     host.register(); // populate the method map BEFORE accepting connections
@@ -219,7 +224,8 @@ export class MobileChannel implements Channel<MobileStartOpts> {
         allowQueryToken: this.allowQueryToken,
       });
       this.server = server;
-      this.logger?.info?.('mobile channel listening', { address: server.address });
+      const logger = this.logger;
+      if (logger?.info) logger.info('mobile channel listening', { address: server.address });
 
       // A network client is the EXPECTED-to-drop case (network loss, app killed
       // or backgrounded). The bridge exposes no per-disconnect event the host can
@@ -291,12 +297,15 @@ export class MobileChannel implements Channel<MobileStartOpts> {
           tunnelUrl = this.tunnel.url;
           // The phone reaches the shim (E2E) or the bridge (plain) via this origin.
           server.setAllowedOrigins([...localOrigins, connectUrlOrigin(tunnelUrl)]);
-          this.logger?.info?.('mobile tunnel open', { provider: provider.name, url: tunnelUrl });
+          const logger = this.logger;
+          if (logger?.info) logger.info('mobile tunnel open', { provider: provider.name, url: tunnelUrl });
         } catch (err) {
-          this.logger?.warn?.('mobile tunnel failed; using the local URL', {
-            provider: provider.name,
-            err: String(err),
-          });
+          const logger = this.logger;
+          if (logger?.warn)
+            logger.warn('mobile tunnel failed; using the local URL', {
+              provider: provider.name,
+              err: String(err),
+            });
           if (this.shim) {
             await this.shim.close().catch(() => undefined);
             this.shim = null;

--- a/packages/plugin-channel-mobile/src/e2e-shim.ts
+++ b/packages/plugin-channel-mobile/src/e2e-shim.ts
@@ -98,7 +98,8 @@ export async function startE2EShim(opts: E2EShimOptions): Promise<E2EShimHandle>
 
   wss.on('connection', (phone) => {
     void handlePhone(phone, opts, bridgeHost).catch((err) => {
-      opts.logger?.warn?.('e2e shim: connection failed', { err: String(err) });
+      const logger = opts.logger;
+      if (logger?.warn) logger.warn('e2e shim: connection failed', { err: String(err) });
       try {
         phone.close();
       } catch {
@@ -109,7 +110,8 @@ export async function startE2EShim(opts: E2EShimOptions): Promise<E2EShimHandle>
 
   await new Promise<void>((resolve) => http.listen(0, '127.0.0.1', resolve));
   const port = (http.address() as AddressInfo).port;
-  opts.logger?.info?.('e2e shim listening', { port });
+  const logger = opts.logger;
+  if (logger?.info) logger.info('e2e shim listening', { port });
 
   return {
     port,
@@ -153,7 +155,8 @@ async function handlePhone(
     if (!authed) {
       authed = true;
       if (!bearerTokenMatches(text, opts.token)) {
-        opts.logger?.warn?.('e2e shim: bad token, closing');
+        const logger = opts.logger;
+        if (logger?.warn) logger.warn('e2e shim: bad token, closing');
         teardown();
         return;
       }

--- a/packages/plugin-channel-mobile/src/single-session-host.test.ts
+++ b/packages/plugin-channel-mobile/src/single-session-host.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- test doubles cast loosely */
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
-import { denyByDefaultResolver, type ClientSession } from '@moxxy/sdk';
+import { assertDefined, denyByDefaultResolver, type ClientSession } from '@moxxy/sdk';
 import type { CommandBus, EventSink } from '@moxxy/desktop-ipc-contract/bus';
 import { mkdtempSync } from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
@@ -18,7 +18,9 @@ async function seedSessionFile(meta: {
   firstPrompt?: string | null;
   source?: 'cli' | 'tui' | 'desktop' | 'mobile';
 }): Promise<void> {
-  const dir = path.join(process.env.MOXXY_HOME!, 'sessions');
+  const home = process.env.MOXXY_HOME;
+  assertDefined(home, 'MOXXY_HOME set in test setup');
+  const dir = path.join(home, 'sessions');
   await mkdir(dir, { recursive: true });
   await writeFile(
     path.join(dir, `${meta.id}.json`),
@@ -210,7 +212,9 @@ describe('MobileSessionHost', () => {
   });
 
   it('runs a turn for the selected registry session', async () => {
-    const cwd = path.join(process.env.MOXXY_HOME!, 'project');
+    const home = process.env.MOXXY_HOME;
+    assertDefined(home, 'MOXXY_HOME set in test setup');
+    const cwd = path.join(home, 'project');
     await mkdir(cwd, { recursive: true });
     await seedSessionFile({ id: 'old-session', cwd, firstPrompt: 'Old work' });
 
@@ -279,7 +283,9 @@ describe('MobileSessionHost', () => {
   });
 
   it('loads archived transcript pages from the desktop chat mirror when no core log exists', async () => {
-    const chatsDir = path.join(process.env.MOXXY_HOME!, 'chats');
+    const home = process.env.MOXXY_HOME;
+    assertDefined(home, 'MOXXY_HOME set in test setup');
+    const chatsDir = path.join(home, 'chats');
     await mkdir(chatsDir, { recursive: true });
     const events = [0, 1, 2].map((i) => ({
       id: `mirror-${i}`,
@@ -557,7 +563,8 @@ describe('MobileSessionHost', () => {
     const verdict = resolver.check({ name: 'web_fetch', input: {} }, {});
     const ask = bus.event('ask.request')[0];
     expect(ask?.payload.kind).toBe('permission');
-    await bus.invoke('ask.respond', { requestId: ask!.payload.requestId, response: { mode: 'allow' } });
+    assertDefined(ask, 'a permission ask was broadcast');
+    await bus.invoke('ask.respond', { requestId: ask.payload.requestId, response: { mode: 'allow' } });
     await expect(verdict).resolves.toEqual({ mode: 'allow' });
   });
 
@@ -591,7 +598,8 @@ describe('MobileSessionHost', () => {
     const verdict = getPermissionResolver().check({ name: 'web_fetch', input: {} }, {});
     const ask = bus.event('ask.request').at(-1);
     expect(ask?.payload.kind).toBe('permission');
-    await bus.invoke('ask.respond', { requestId: ask!.payload.requestId, response: { mode: 'deny' } });
+    assertDefined(ask, 'a permission ask was broadcast');
+    await bus.invoke('ask.respond', { requestId: ask.payload.requestId, response: { mode: 'deny' } });
     await expect(verdict).resolves.toEqual({ mode: 'deny' });
   });
 
@@ -603,7 +611,8 @@ describe('MobileSessionHost', () => {
       runTurn: vi.fn((_p: string, opts?: { signal?: AbortSignal }) => {
         if (opts?.signal) aborts.push(opts.signal);
         return (async function* () {
-          await new Promise<void>((resolve) => opts?.signal?.addEventListener('abort', () => resolve()));
+          const signal = opts?.signal;
+          await new Promise<void>((resolve) => signal?.addEventListener('abort', () => resolve()));
         })();
       }),
     });
@@ -624,7 +633,8 @@ describe('MobileSessionHost', () => {
     // NOT disposed: a reconnecting client can still drive the host.
     const verdict2 = resolver.check({ name: 'web_fetch', input: {} }, {});
     const ask2 = bus.event('ask.request').at(-1);
-    await bus.invoke('ask.respond', { requestId: ask2!.payload.requestId, response: { mode: 'allow' } });
+    assertDefined(ask2, 'a follow-up permission ask was broadcast');
+    await bus.invoke('ask.respond', { requestId: ask2.payload.requestId, response: { mode: 'allow' } });
     await expect(verdict2).resolves.toEqual({ mode: 'allow' });
   });
 
@@ -676,7 +686,8 @@ describe('MobileSessionHost', () => {
     const throwingBus: CommandBus & EventSink = {
       handle: () => {},
       broadcast: (channel: string, payload: unknown) => {
-        if (channel === 'runner.event' && (payload as any)?.event?.bad) throw new TypeError('not serializable');
+        const evt = (payload as any)?.event;
+        if (channel === 'runner.event' && evt?.bad) throw new TypeError('not serializable');
         bus.broadcast(channel, payload);
       },
     };

--- a/packages/plugin-channel-web/src/channel.test.ts
+++ b/packages/plugin-channel-web/src/channel.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { WebSocket } from 'ws';
 import type { ClientSession, MoxxyEvent } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import {
   freeTcpPortIfMoxxy,
   WebChannel,
@@ -188,7 +189,8 @@ describe('WebChannel', () => {
     });
     handle = await channel.start({ session: fakeSession().session });
     expect(published).not.toBeNull();
-    expect(published!.url).toBe('https://abc.trycloudflare.com/?t=tkn');
+    assertDefined(published, 'a surface was published');
+    expect(published.url).toBe('https://abc.trycloudflare.com/?t=tkn');
   });
 
   it('co-attached to a real Session publishes a localhost URL by default (the TUI case)', async () => {
@@ -206,8 +208,9 @@ describe('WebChannel', () => {
     });
     handle = await channel.start({ session: session as never });
     expect(published).not.toBeNull();
+    assertDefined(published, 'a surface was published');
     // A real, tokenized URL present_view can hand back — never null/rendered:false.
-    expect(published!.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/\?t=tkn$/);
+    expect(published.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/\?t=tkn$/);
   });
 
   it('falls back to the local URL when the tunnel provider fails', async () => {
@@ -227,8 +230,9 @@ describe('WebChannel', () => {
     });
     handle = await channel.start({ session: fakeSession().session });
     expect(published).not.toBeNull();
-    expect(published!.url).toContain('http://127.0.0.1:');
-    expect(published!.url).toContain('?t=tkn');
+    assertDefined(published, 'a surface was published');
+    expect(published.url).toContain('http://127.0.0.1:');
+    expect(published.url).toContain('?t=tkn');
   });
 
   it('opens a WS handshake under the relay base path (proxy /web)', async () => {

--- a/packages/plugin-channel-web/src/channel.ts
+++ b/packages/plugin-channel-web/src/channel.ts
@@ -122,9 +122,10 @@ export async function freeTcpPortIfMoxxy(
   );
   const foreign = holders.filter((h) => !looksLikeMoxxy(h.command));
   if (foreign.length > 0) {
-    logger?.warn?.(`port ${port} is held by non-moxxy process(es); not killing them`, {
-      holders: foreign.map((h) => `${h.pid}: ${h.command || '<unknown command>'}`),
-    });
+    if (logger?.warn)
+      logger.warn(`port ${port} is held by non-moxxy process(es); not killing them`, {
+        holders: foreign.map((h) => `${h.pid}: ${h.command || '<unknown command>'}`),
+      });
     return false;
   }
   // Re-verify identity immediately before each signal. Between the `ps`
@@ -139,7 +140,7 @@ export async function freeTcpPortIfMoxxy(
     try {
       // Log the exact command we judged moxxy-owned before signalling, so a
       // mis-fire on a substring-collision process is auditable after the fact.
-      logger?.warn?.('freeing port: SIGTERM to apparent stale moxxy process', { pid, command });
+      if (logger?.warn) logger.warn('freeing port: SIGTERM to apparent stale moxxy process', { pid, command });
       deps.kill(pid, 'SIGTERM');
       attempted = true;
     } catch {
@@ -158,7 +159,7 @@ export async function freeTcpPortIfMoxxy(
     const command = await deps.pidCommand(pid);
     if (!looksLikeMoxxy(command)) continue;
     try {
-      logger?.warn?.('freeing port: SIGKILL to apparent stale moxxy process', { pid, command });
+      if (logger?.warn) logger.warn('freeing port: SIGKILL to apparent stale moxxy process', { pid, command });
       deps.kill(pid, 'SIGKILL');
     } catch {
       /* dead */
@@ -328,7 +329,10 @@ export class WebChannel implements Channel<WebStartOpts> {
     wss.on('connection', (ws) => this.onConnection(ws));
     // Never leave an EventEmitter 'error' unhandled — it would throw at the
     // process level. Forwarded server errors after bind are log-and-survive.
-    wss.on('error', (err) => this.logger?.warn?.('web socket server error', { err: String(err) }));
+    wss.on('error', (err) => {
+      const logger = this.logger;
+      if (logger?.warn) logger.warn('web socket server error', { err: String(err) });
+    });
 
     await this.openTunnel();
     this.publishSurface?.({ url: this.shareUrl, nextViewId: () => `v_srv_${++this.viewSeq}` });
@@ -358,7 +362,8 @@ export class WebChannel implements Channel<WebStartOpts> {
           server.off('error', onError);
           const addr = server.address();
           if (addr && typeof addr === 'object') this.port = (addr as AddressInfo).port;
-          this.logger?.info?.('web channel listening', { url: this.url });
+          const logger = this.logger;
+          if (logger?.info) logger.info('web channel listening', { url: this.url });
           resolve();
         };
         server.once('error', onError);
@@ -376,9 +381,11 @@ export class WebChannel implements Channel<WebStartOpts> {
     const requested = this.port;
     const freed = await freeTcpPortIfMoxxy(requested, this.logger).catch(() => false);
     if (freed) {
-      this.logger?.warn?.(
-        `web channel port ${requested} was held by a stale moxxy process; freed it, retrying`,
-      );
+      const logger = this.logger;
+      if (logger?.warn)
+        logger.warn(
+          `web channel port ${requested} was held by a stale moxxy process; freed it, retrying`,
+        );
       try {
         await tryListen();
         return;
@@ -392,10 +399,12 @@ export class WebChannel implements Channel<WebStartOpts> {
     // this.url / shareUrl / the tunnel all carry it automatically.
     this.port = 0;
     await tryListen();
-    this.logger?.warn?.(
-      `web channel port ${requested} was in use by another process; bound ephemeral port ${this.port} instead`,
-      { requestedPort: requested, boundPort: this.port, url: this.url },
-    );
+    const logger = this.logger;
+    if (logger?.warn)
+      logger.warn(
+        `web channel port ${requested} was in use by another process; bound ephemeral port ${this.port} instead`,
+        { requestedPort: requested, boundPort: this.port, url: this.url },
+      );
   }
 
   /**
@@ -422,9 +431,11 @@ export class WebChannel implements Channel<WebStartOpts> {
       this.tunnel = await provider.open({ port: this.port, host: this.host, label: 'web' });
       this.tunnelBase = this.tunnel.url;
       this.basePath = basePathFromUrl(this.tunnel.url);
-      this.logger?.info?.('web surface tunnel open', { provider: provider.name, url: this.shareUrl });
+      const logger = this.logger;
+      if (logger?.info) logger.info('web surface tunnel open', { provider: provider.name, url: this.shareUrl });
     } catch (err) {
-      this.logger?.warn?.('web surface tunnel failed; using local URL', { provider: provider.name, err: String(err) });
+      const logger = this.logger;
+      if (logger?.warn) logger.warn('web surface tunnel failed; using local URL', { provider: provider.name, err: String(err) });
     }
   }
 
@@ -622,10 +633,12 @@ export class WebChannel implements Channel<WebStartOpts> {
     const now = Date.now();
     if (now - this.lastDropWarnAt < DROP_WARN_INTERVAL_MS) return;
     this.lastDropWarnAt = now;
-    this.logger?.warn?.('web channel dropped invalid client frame(s)', {
-      reason,
-      droppedTotal: this.droppedFrames,
-    });
+    const logger = this.logger;
+    if (logger?.warn)
+      logger.warn('web channel dropped invalid client frame(s)', {
+        reason,
+        droppedTotal: this.droppedFrames,
+      });
   }
 
   private async drive(prompt: string): Promise<void> {

--- a/packages/plugin-channel-web/src/discovery.test.ts
+++ b/packages/plugin-channel-web/src/discovery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ServiceRegistry } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { webChannelPlugin } from './index.js';
 
 /**
@@ -32,7 +33,11 @@ describe('webChannelPlugin (discovery-loadable)', () => {
       }
     });
     const services = { get, register: () => {}, require: () => undefined, has: () => true } as unknown as ServiceRegistry;
-    webChannelPlugin.hooks!.onInit!({ services } as never);
+    const hooks = webChannelPlugin.hooks;
+    assertDefined(hooks, 'plugin defines hooks');
+    const onInit = hooks.onInit;
+    assertDefined(onInit, 'hooks define onInit');
+    onInit({ services } as never);
     expect(get).toHaveBeenCalledWith('tunnelProviders');
     expect(get).toHaveBeenCalledWith('viewSurface');
     expect(get).toHaveBeenCalledWith('webControls');

--- a/packages/plugin-channel-web/src/frontend/chat.tsx
+++ b/packages/plugin-channel-web/src/frontend/chat.tsx
@@ -51,7 +51,7 @@ export function ChatPanel(props: {
   useEffect(() => {
     const opener = typeof document !== 'undefined' ? (document.activeElement as HTMLElement | null) : null;
     inputRef.current?.focus();
-    return () => opener?.focus?.();
+    return () => opener?.focus();
   }, []);
 
   const onKeyDown = useCallback(
@@ -64,9 +64,9 @@ export function ChatPanel(props: {
       if (e.key !== 'Tab') return;
       // Trap Tab within the panel so focus never escapes to the obscured view.
       const focusables = focusableWithin(panelRef.current);
-      if (focusables.length === 0) return;
-      const first = focusables[0]!;
-      const last = focusables[focusables.length - 1]!;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (!first || !last) return;
       const active = document.activeElement;
       if (e.shiftKey && active === first) {
         e.preventDefault();

--- a/packages/plugin-channel-web/src/frontend/render-diff.test.ts
+++ b/packages/plugin-channel-web/src/frontend/render-diff.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { FileDiffDisplay } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { FileDiffView } from './render-diff.js';
 
 const render = (display: FileDiffDisplay): string => renderToStaticMarkup(createElement(FileDiffView, { display }));
@@ -58,10 +59,12 @@ describe('FileDiffView', () => {
   });
 
   it('inserts a ⋯ gap row between non-contiguous hunks', () => {
+    const hunk = baseDisplay.hunks[0];
+    assertDefined(hunk, 'baseDisplay has a hunk');
     const twoHunks: FileDiffDisplay = {
       ...baseDisplay,
       hunks: [
-        baseDisplay.hunks[0]!,
+        hunk,
         { oldStart: 40, oldLines: 1, newStart: 41, newLines: 1, lines: [{ kind: 'context', text: 'far away', oldNo: 40, newNo: 41 }] },
       ],
     };

--- a/packages/plugin-channel-web/src/frontend/render.tsx
+++ b/packages/plugin-channel-web/src/frontend/render.tsx
@@ -110,6 +110,7 @@ export function renderNode(node: ViewNode, h: RenderHandlers, key?: number): Rea
     case 'link': {
       // A `to` link navigates client-side; otherwise it is an external anchor.
       if (node.nav) {
+        const nav = node.nav;
         return (
           <a
             className="v-link"
@@ -117,7 +118,7 @@ export function renderNode(node: ViewNode, h: RenderHandlers, key?: number): Rea
             key={key}
             onClick={(e) => {
               e.preventDefault();
-              h.navigate(node.nav!);
+              h.navigate(nav);
             }}
           >
             {kids}
@@ -223,7 +224,10 @@ function gatherFormValues(form: HTMLFormElement | null): Record<string, string> 
 function pick(values: Record<string, string>, fields: ReadonlyArray<string>): Record<string, string> {
   if (fields.length === 0) return values;
   const out: Record<string, string> = {};
-  for (const f of fields) if (f in values) out[f] = values[f]!;
+  for (const f of fields) {
+    const v = values[f];
+    if (v !== undefined) out[f] = v;
+  }
   return out;
 }
 

--- a/packages/plugin-channel-web/src/frontend/view-store.test.ts
+++ b/packages/plugin-channel-web/src/frontend/view-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ViewDoc } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { applyView, canGoBack, currentEntry, goBack, initialNav, navigateTo } from './view-store.js';
 
 const doc = (tag = 'view'): ViewDoc => ({ root: { kind: 'element', tag, props: {}, children: [] } });
@@ -48,7 +49,8 @@ describe('view-store', () => {
     s = applyView(s, frame('v2', 'results'));
     const back = navigateTo(s, 'search');
     expect(back).not.toBeNull();
-    expect(currentEntry(back!)?.key).toBe('search');
+    assertDefined(back, 'navigateTo returned a cached view');
+    expect(currentEntry(back)?.key).toBe('search');
     expect(navigateTo(s, 'detail')).toBeNull(); // not cached → caller asks the agent
   });
 

--- a/packages/plugin-channel-web/src/frontend/view-store.ts
+++ b/packages/plugin-channel-web/src/frontend/view-store.ts
@@ -78,7 +78,8 @@ function prune(state: NavState): NavState {
   const order = [...state.order];
   // Walk oldest→newest, dropping evictable (non-history) keys until within cap.
   for (let i = 0; i < order.length && order.length > MAX_CACHED_VIEWS; ) {
-    const key = order[i]!;
+    const key = order[i];
+    if (key === undefined) break;
     if (live.has(key)) {
       i += 1; // pinned by history — skip, keep it
       continue;

--- a/packages/plugin-channel-web/src/index.ts
+++ b/packages/plugin-channel-web/src/index.ts
@@ -97,7 +97,8 @@ export function buildWebChannelPlugin(opts: BuildWebChannelOptions = {}): Plugin
             }
             tunnels.setActive(name);
             await writeTunnelSetting(name, opts.settingsFile);
-            const url = (await opts.getControls?.()?.retunnel()) ?? null;
+            const controls = opts.getControls?.();
+            const url = (await controls?.retunnel()) ?? null;
             return { ok: true, active: name, ...(url ? { url } : { note: 'applies when the web surface (re)starts' }) };
           },
         }),
@@ -166,7 +167,10 @@ export const webChannelPlugin: Plugin = (() => {
 
   const tunnels: TunnelControls = {
     list: () => tp?.list().map((p) => p.name) ?? [],
-    active: () => tp?.getActive()?.name ?? null,
+    active: () => {
+      const activeTunnel = tp?.getActive();
+      return activeTunnel?.name ?? null;
+    },
     setActive: (n) => {
       tp?.setActive(n);
     },

--- a/packages/plugin-channel-web/src/projector.test.ts
+++ b/packages/plugin-channel-web/src/projector.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { MoxxyEvent } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { EventProjector } from './projector.js';
 
 // Minimal event factory — only the fields the projector reads.
@@ -15,7 +16,8 @@ describe('EventProjector', () => {
     expect(p.project(ev({ type: 'tool_call_requested', callId: 'c1', name: 'present_view', input: { fallbackText: 'fb' } }))).toEqual([]);
     const frames = p.project(ev({ type: 'tool_result', callId: 'c1', ok: true, output: { ast: sampleDoc } }));
     expect(frames).toHaveLength(1);
-    const f = frames[0]!;
+    const f = frames[0];
+    assertDefined(f, 'projector emitted a view frame');
     expect(f.kind).toBe('view');
     if (f.kind !== 'view') return;
     expect(f.doc).toEqual(sampleDoc);
@@ -26,9 +28,13 @@ describe('EventProjector', () => {
   it('sets `replaces` to the prior view id on the second view', () => {
     const p = new EventProjector();
     p.project(ev({ type: 'tool_call_requested', callId: 'c1', name: 'present_view', input: {} }));
-    const first = p.project(ev({ type: 'tool_result', callId: 'c1', ok: true, output: { ast: sampleDoc } }))[0]!;
+    const firstFrames = p.project(ev({ type: 'tool_result', callId: 'c1', ok: true, output: { ast: sampleDoc } }));
+    const first = firstFrames[0];
+    assertDefined(first, 'projector emitted a view frame');
     p.project(ev({ type: 'tool_call_requested', callId: 'c2', name: 'present_view', input: {} }));
-    const second = p.project(ev({ type: 'tool_result', callId: 'c2', ok: true, output: { ast: sampleDoc } }))[0]!;
+    const secondFrames = p.project(ev({ type: 'tool_result', callId: 'c2', ok: true, output: { ast: sampleDoc } }));
+    const second = secondFrames[0];
+    assertDefined(second, 'projector emitted a view frame');
     if (first.kind !== 'view' || second.kind !== 'view') throw new Error('expected views');
     expect(second.replaces).toBe(first.viewId);
     expect(second.viewId).not.toBe(first.viewId);
@@ -38,14 +44,18 @@ describe('EventProjector', () => {
     const p = new EventProjector();
     p.project(ev({ type: 'tool_call_requested', callId: 'c1', name: 'present_view', input: {} }));
     const namedDoc = { root: { kind: 'element', tag: 'view', props: { name: 'search' }, children: [] } };
-    const f = p.project(ev({ type: 'tool_result', callId: 'c1', ok: true, output: { ast: namedDoc } }))[0]!;
+    const namedFrames = p.project(ev({ type: 'tool_result', callId: 'c1', ok: true, output: { ast: namedDoc } }));
+    const f = namedFrames[0];
+    assertDefined(f, 'projector emitted a view frame');
     expect(f.kind === 'view' && f.name).toBe('search');
   });
 
   it('omits name when the view has none', () => {
     const p = new EventProjector();
     p.project(ev({ type: 'tool_call_requested', callId: 'c1', name: 'present_view', input: {} }));
-    const f = p.project(ev({ type: 'tool_result', callId: 'c1', ok: true, output: { ast: sampleDoc } }))[0]!;
+    const frames = p.project(ev({ type: 'tool_result', callId: 'c1', ok: true, output: { ast: sampleDoc } }));
+    const f = frames[0];
+    assertDefined(f, 'projector emitted a view frame');
     expect(f.kind === 'view' && f.name).toBeUndefined();
   });
 
@@ -142,9 +152,13 @@ describe('EventProjector', () => {
   it('handles two present_view calls in one turn, each replacing the last', () => {
     const p = new EventProjector();
     p.project(ev({ type: 'tool_call_requested', callId: 'a', name: 'present_view', input: {} }));
-    const first = p.project(ev({ type: 'tool_result', callId: 'a', ok: true, output: { ast: sampleDoc } }))[0]!;
+    const firstFrames = p.project(ev({ type: 'tool_result', callId: 'a', ok: true, output: { ast: sampleDoc } }));
+    const first = firstFrames[0];
+    assertDefined(first, 'projector emitted a view frame');
     p.project(ev({ type: 'tool_call_requested', callId: 'b', name: 'present_view', input: {} }));
-    const second = p.project(ev({ type: 'tool_result', callId: 'b', ok: true, output: { ast: sampleDoc } }))[0]!;
+    const secondFrames = p.project(ev({ type: 'tool_result', callId: 'b', ok: true, output: { ast: sampleDoc } }));
+    const second = secondFrames[0];
+    assertDefined(second, 'projector emitted a view frame');
     if (first.kind !== 'view' || second.kind !== 'view') throw new Error('views');
     expect(second.replaces).toBe(first.viewId);
   });
@@ -167,6 +181,8 @@ describe('EventProjector', () => {
     p.project(ev({ type: 'tool_call_requested', callId: 'live', name: 'present_view', input: {} }));
     const frames = p.project(ev({ type: 'tool_result', callId: 'live', ok: true, output: { ast: sampleDoc } }));
     expect(frames).toHaveLength(1);
-    expect(frames[0]!.kind).toBe('view');
+    const frame = frames[0];
+    assertDefined(frame, 'projector emitted a view frame');
+    expect(frame.kind).toBe('view');
   });
 });

--- a/packages/plugin-channel-web/src/tunnel-tools.test.ts
+++ b/packages/plugin-channel-web/src/tunnel-tools.test.ts
@@ -94,7 +94,10 @@ describe('web_set_tunnel', () => {
 });
 
 describe('onInit applies the persisted / default tunnel', () => {
-  const fireInit = (hooks: LifecycleHooks | undefined) => (hooks?.onInit as (() => void) | undefined)?.();
+  const fireInit = (hooks: LifecycleHooks | undefined) => {
+    const onInit = hooks?.onInit as (() => void) | undefined;
+    onInit?.();
+  };
 
   it('applies a persisted setting on boot', async () => {
     await writeTunnelSetting('proxy', file);


### PR DESCRIPTION
## Scope

Applies the "guard, don't chain" rule (AGENTS.md) across the client-layer, IPC, and channel packages. Every non-null assertion (`x!`, `x!.y`, `fn()!`, `arr[i]!`) and every optional chain of depth ≥2 (`a?.b?.c`) was replaced with a single-narrowing guard clause, then plain member access.

**Packages touched (44 files):**

| Package | Files | non-null (before → after) | deep chains (before → after) |
| --- | --- | --- | --- |
| `@moxxy/client-core` | 9 | ~31 → 0 | ~2 → 0 |
| `@moxxy/client-transport-ws` | 3 | ~24 → 0 | 0 → 0 |
| `@moxxy/client-platform-web` | 3 | ~3 → 0 | ~4 → 0 |
| `@moxxy/design-tokens` | 1 | ~4 → 0 | 0 → 0 |
| `@moxxy/ipc-server-ws` | 1 | ~1 → 0 | 0 → 0 |
| `apps/mobile` (private, not versioned) | 11 | ~11 → 0 | ~6 → 0 |
| `@moxxy/plugin-channel-mobile` | 3 | ~6 → 0 | ~10 → 0 |
| `@moxxy/plugin-channel-web` | 11 | ~20 → 0 | ~14 → 0 |
| `@moxxy/plugin-channel-http` | 2 | ~9 → 0 | ~9 → 0 |

After: enumeration greps from the brief return **zero** matches (both patterns) across all 9 packages, including multi-line chains.

## Semantics notes

- **Behavior preserved.** Genuinely-optional single `?.` reads and silent absence paths (config-not-set, optional field, lookups that can miss) were kept exactly — not converted to throws.
- **Loud throws only where absence is impossible by construction** — chiefly in test files (e.g. `arr.find(...)!` → `assertDefined(found, '…')` then plain access) where the value is guaranteed present after setup, and a few upstream-checked runtime sites. These would have crashed cryptically before; the guard makes the failure legible without changing the happy path.
- **Guard source respects dependencies.** `assertDefined`/`invariant` are imported from `@moxxy/sdk` only in packages that already depend on it. `client-transport-ws` (no sdk dep) uses a tiny local `assertDefined` helper; `design-tokens` (no sdk dep) uses plain `if (!x) throw`. **No new dependencies added.**
- **No drive-by refactors.** Only this transformation — no renames, reorders, or formatting churn beyond what each edit requires.
- Definite-assignment class fields (`foo!: Type`) are out of scope and left untouched: 14 total (client-core 8, plugin-channel-http 4, plugin-channel-mobile 1, plugin-channel-web 1).

## Gate (from worktree root, each exit code checked directly)

- `pnpm install` → 0
- `pnpm build` → 0
- `pnpm typecheck` → 0
- `pnpm lint` → 0 (0 errors; 44 pre-existing warnings in non-assigned packages)
- `pnpm test` → 0
- `pnpm check:deps` → 0 (0 errors; 1 pre-existing warning in `desktop-host`, not in scope)

Control-byte scan of all changed files: clean (0 hits, all files confirmed text).

Note: one intermediate full-suite run flaked on `@moxxy/cli#test` under concurrent CPU load (sibling agents gating in parallel); it passed 2/2 in isolation (323 tests each) and a subsequent full run was green.
