### PR TITLE
refactor(channels): replace non-null assertions and deep optional chains with guards

### DIFF
--- a/.changeset/assert-sweep-channels.md
+++ b/.changeset/assert-sweep-channels.md
@@ -1,0 +1,13 @@
+---
+'@moxxy/plugin-channel-discord': patch
+'@moxxy/plugin-channel-signal': patch
+'@moxxy/plugin-channel-slack': patch
+'@moxxy/plugin-channel-whatsapp': patch
+'@moxxy/plugin-telegram': patch
+---
+
+Replace non-null assertions (`x!`) and deep optional chains (`a?.b?.c`) in the
+channel plugins with guard clauses. Source sites that are impossible-by-construction
+now assert loudly via `assertDefined`/`invariant` from `@moxxy/sdk` instead of
+silently propagating `undefined`; inbound-message silent-drop gates are preserved
+exactly. No behavior change on the success path.

--- a/packages/plugin-channel-discord/src/approval.ts
+++ b/packages/plugin-channel-discord/src/approval.ts
@@ -28,10 +28,11 @@ export class DiscordApprovalResolver implements ApprovalResolver {
       // No bot wired up — best fallback is the request's defaultOptionId.
       return { optionId: request.defaultOptionId ?? request.options[0]?.id ?? 'approve' };
     }
+    const decider = this.deciderFn;
     const id = `appr_${this.nextId++}`;
     return new Promise<ApprovalDecision>((resolve) => {
       this.pending.set(id, { id, request, resolve });
-      this.deciderFn!(id, request).catch((err) => {
+      decider(id, request).catch((err) => {
         this.pending.delete(id);
         resolve({
           optionId: request.defaultOptionId ?? request.options[0]?.id ?? 'cancel',

--- a/packages/plugin-channel-discord/src/channel/message-handler.ts
+++ b/packages/plugin-channel-discord/src/channel/message-handler.ts
@@ -1,4 +1,4 @@
-import type { ChannelHandle, ClientSession as Session } from '@moxxy/sdk';
+import { assertDefined, type ChannelHandle, type ClientSession as Session } from '@moxxy/sdk';
 import { gateInbound } from '../allow-list.js';
 import type { InboundMessage } from '../schema.js';
 import type { DiscordApprovalResolver } from '../approval.js';
@@ -130,7 +130,8 @@ export async function handleInboundMessage(
   if (text.startsWith('/')) {
     if (!state.session) return;
     const [head, ...rest] = text.split(/\s+/);
-    const reply = await runSlash(head!.slice(1), rest.join(' '), state.session, {
+    assertDefined(head, 'splitting a non-empty command string yields at least one token');
+    const reply = await runSlash(head.slice(1), rest.join(' '), state.session, {
       toggleYolo: cb.toggleYolo,
       voice: cb.voice,
       performSessionAction: (action, notice) =>

--- a/packages/plugin-channel-discord/src/channel/turn-runner.test.ts
+++ b/packages/plugin-channel-discord/src/channel/turn-runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { asTurnId, type MoxxyEvent } from '@moxxy/sdk';
+import { assertDefined, asTurnId, type MoxxyEvent } from '@moxxy/sdk';
 import type { ClientSession as Session } from '@moxxy/sdk';
 import type { SendableChannelLike, SentMessageLike } from './discord-like.js';
 import { TypingIndicator } from './typing-indicator.js';
@@ -91,7 +91,9 @@ describe('runDiscordTurn — send-once-then-edit streaming', () => {
     );
     // Exactly one streamed message; later frames are edits of it.
     expect(sends).toHaveLength(1);
-    expect(sends[0]!.startsWith('Hello')).toBe(true);
+    const firstSend = sends[0];
+    assertDefined(firstSend, 'a streamed frame was sent');
+    expect(firstSend.startsWith('Hello')).toBe(true);
     expect(edits.length).toBeGreaterThanOrEqual(1);
     expect(edits[edits.length - 1]).toBe('Hello, world. Done.');
   });
@@ -111,7 +113,8 @@ describe('runDiscordTurn — send-once-then-edit streaming', () => {
     );
     // First send is the streamed head; final tails arrive as extra sends.
     expect(sends.length).toBeGreaterThanOrEqual(3); // head + >=2 tails
-    const finalHead = edits[edits.length - 1]!;
+    const finalHead = edits[edits.length - 1];
+    assertDefined(finalHead, 'the final frame was edited in place');
     expect(finalHead.length).toBeLessThanOrEqual(1_900);
     // Reassembling head + tails recovers the whole final text.
     const reassembled = [finalHead, ...sends.slice(1)].join('\n');

--- a/packages/plugin-channel-discord/src/channel/turn-runner.ts
+++ b/packages/plugin-channel-discord/src/channel/turn-runner.ts
@@ -1,5 +1,5 @@
 import type { newTurnId } from '@moxxy/core';
-import type { ClientSession as Session } from '@moxxy/sdk';
+import { assertDefined, type ClientSession as Session } from '@moxxy/sdk';
 import { FramePump, driveTurn, subscribeTurn } from '@moxxy/channel-kit';
 import { DiscordTurnRenderer, splitForDiscord } from '../render.js';
 import type { ChannelLogger, SendableChannelLike, SentMessageLike } from './discord-like.js';
@@ -82,14 +82,18 @@ export async function runDiscordTurn(
     sink: {
       send: async (t, final) => {
         const parts = splitForDiscord(t);
-        const sent = await sendPart(parts[0]!);
+        const head = parts[0];
+        assertDefined(head, 'discord: FramePump never sinks empty text (emptyFinalText guarantees a part)');
+        const sent = await sendPart(head);
         if (final) for (const tail of parts.slice(1)) await sendPart(tail);
         return sent;
       },
       edit: async (message, t, final) => {
         const parts = splitForDiscord(t);
+        const head = parts[0];
+        assertDefined(head, 'discord: FramePump never sinks empty text (emptyFinalText guarantees a part)');
         try {
-          await message.edit(parts[0]!);
+          await message.edit(head);
         } catch (err) {
           logger?.warn('discord edit failed', { err: String(err) });
         }

--- a/packages/plugin-channel-discord/src/channel/typing-indicator.ts
+++ b/packages/plugin-channel-discord/src/channel/typing-indicator.ts
@@ -14,8 +14,9 @@ export class TypingIndicator {
   start(channel: SendableChannelLike): void {
     this.stop();
     if (!channel.sendTyping) return;
+    const sendTyping = channel.sendTyping;
     const ping = (): void => {
-      void channel.sendTyping?.()?.catch?.(() => undefined);
+      void sendTyping().catch(() => undefined);
     };
     ping();
     this.timer = setInterval(ping, REFRESH_MS);

--- a/packages/plugin-channel-discord/src/channel/voice-handler.test.ts
+++ b/packages/plugin-channel-discord/src/channel/voice-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ClientSession as Session } from '@moxxy/sdk';
+import { assertDefined, type ClientSession as Session } from '@moxxy/sdk';
 import type { InboundMessage } from '../schema.js';
 import { MAX_AUDIO_BYTES } from '../schema.js';
 import type { InboundContext } from './message-handler.js';
@@ -58,9 +58,11 @@ const okFetch = (bytes = 16) =>
 describe('pickAudioAttachment', () => {
   it('picks the first audio/* attachment and ignores others', () => {
     const msg = audioMsg();
+    const first = msg.attachments[0];
+    assertDefined(first, 'audioMsg seeds at least one attachment');
     expect(pickAudioAttachment(msg.attachments)?.contentType).toBe('audio/ogg');
-    expect(pickAudioAttachment([{ ...msg.attachments[0]!, contentType: 'image/png' }])).toBeNull();
-    expect(pickAudioAttachment([{ ...msg.attachments[0]!, contentType: null }])).toBeNull();
+    expect(pickAudioAttachment([{ ...first, contentType: 'image/png' }])).toBeNull();
+    expect(pickAudioAttachment([{ ...first, contentType: null }])).toBeNull();
   });
 });
 

--- a/packages/plugin-channel-discord/src/permission.ts
+++ b/packages/plugin-channel-discord/src/permission.ts
@@ -40,9 +40,10 @@ export class DiscordPermissionResolver implements PermissionResolver {
     if (!this.deciderFn) {
       return { mode: 'deny', reason: 'no decider attached (bot not running)' };
     }
+    const decider = this.deciderFn;
     const decision = await new Promise<PermissionDecision>((resolve) => {
       this.pending.set(call.callId, { callId: call.callId, call, ctx, resolve });
-      this.deciderFn!(call, ctx).catch((err) => {
+      decider(call, ctx).catch((err) => {
         this.pending.delete(call.callId);
         resolve({ mode: 'deny', reason: err instanceof Error ? err.message : String(err) });
       });

--- a/packages/plugin-channel-discord/src/render.ts
+++ b/packages/plugin-channel-discord/src/render.ts
@@ -1,4 +1,4 @@
-import type { MoxxyEvent } from '@moxxy/sdk';
+import { assertDefined, type MoxxyEvent } from '@moxxy/sdk';
 
 /**
  * Discord messages cap at 2000 chars; leave margin for the fence-reopen text a
@@ -222,7 +222,9 @@ function openFenceAt(text: string, idx: number, seed: string | null): string | n
   const fenceRe = /(?:^|\n)(```[^\n]*)/g;
   let m: RegExpExecArray | null;
   while ((m = fenceRe.exec(scan)) !== null) {
-    open = open === null ? m[1]! : null;
+    const fence = m[1];
+    assertDefined(fence, 'fenceRe has a mandatory capture group when it matches');
+    open = open === null ? fence : null;
   }
   return open;
 }

--- a/packages/plugin-channel-discord/src/schema.ts
+++ b/packages/plugin-channel-discord/src/schema.ts
@@ -68,7 +68,8 @@ export interface RawMessageLike {
 export function extractInboundMessage(msg: RawMessageLike): InboundMessage | null {
   const attachments: unknown[] = [];
   try {
-    for (const a of msg.attachments?.values?.() ?? []) {
+    const rawAttachments = msg.attachments;
+    for (const a of rawAttachments?.values ? rawAttachments.values() : []) {
       attachments.push({
         id: a?.id,
         url: a?.url,

--- a/packages/plugin-channel-discord/src/subcommands.test.ts
+++ b/packages/plugin-channel-discord/src/subcommands.test.ts
@@ -27,7 +27,7 @@ beforeEach(async () => {
     keySource: createStaticKeySource(deriveKey('test', generateSalt())),
   });
   const plugin = buildDiscordPlugin({ vault });
-  discordDef = plugin.channels![0]!;
+  discordDef = (plugin.channels ?? [])[0] as ChannelDef;
   writeOut = [];
   writeErr = [];
   origStdoutWrite = process.stdout.write.bind(process.stdout);
@@ -72,24 +72,24 @@ describe('discord ChannelDef', () => {
   });
 
   it('is unavailable without a token, available with one in the vault', async () => {
-    const unavailable = await discordDef.isAvailable!({ cwd: tmp, vault });
-    expect(unavailable.ok).toBe(false);
-    expect(unavailable.reason).toMatch(/MOXXY_DISCORD_TOKEN/);
+    const unavailable = await discordDef.isAvailable?.({ cwd: tmp, vault });
+    expect(unavailable?.ok).toBe(false);
+    expect(unavailable?.reason).toMatch(/MOXXY_DISCORD_TOKEN/);
     await vault.set(DISCORD_TOKEN_KEY, 'x'.repeat(24) + '.abcdef.' + 'y'.repeat(28));
-    const available = await discordDef.isAvailable!({ cwd: tmp, vault });
-    expect(available.ok).toBe(true);
+    const available = await discordDef.isAvailable?.({ cwd: tmp, vault });
+    expect(available?.ok).toBe(true);
   });
 });
 
 describe('discord channel subcommands (registered on ChannelDef)', () => {
   it('exposes setup, pair, unpair, status', () => {
-    expect(Object.keys(discordDef.subcommands!)).toEqual(
+    expect(Object.keys(discordDef.subcommands ?? {})).toEqual(
       expect.arrayContaining(['setup', 'pair', 'unpair', 'status']),
     );
   });
 
   it('`status` reports unconfigured vault state as JSON', async () => {
-    const code = await discordDef.subcommands!.status!.run(ctx());
+    const code = await discordDef.subcommands?.status?.run(ctx());
     expect(code).toBe(0);
     const parsed = JSON.parse(writeOut.join(''));
     expect(parsed).toEqual({
@@ -103,7 +103,7 @@ describe('discord channel subcommands (registered on ChannelDef)', () => {
     await vault.set(DISCORD_TOKEN_KEY, 'x'.repeat(24) + '.abcdef.' + 'y'.repeat(28));
     await vault.set(DISCORD_AUTHORIZED_USER_KEY, '987654321');
     await vault.set(DISCORD_ALLOWED_CHANNELS_KEY, serializeAllowedChannels(['123456789']));
-    const code = await discordDef.subcommands!.status!.run(ctx());
+    const code = await discordDef.subcommands?.status?.run(ctx());
     expect(code).toBe(0);
     const parsed = JSON.parse(writeOut.join(''));
     expect(parsed).toEqual({
@@ -115,7 +115,7 @@ describe('discord channel subcommands (registered on ChannelDef)', () => {
 
   it('`status` reports null (not junk) for a corrupt stored user id', async () => {
     await vault.set(DISCORD_AUTHORIZED_USER_KEY, 'not-a-snowflake');
-    const code = await discordDef.subcommands!.status!.run(ctx());
+    const code = await discordDef.subcommands?.status?.run(ctx());
     expect(code).toBe(0);
     const parsed = JSON.parse(writeOut.join(''));
     expect(parsed.authorizedUserId).toBeNull();
@@ -123,14 +123,14 @@ describe('discord channel subcommands (registered on ChannelDef)', () => {
 
   it('`unpair` clears the authorized user and reports', async () => {
     await vault.set(DISCORD_AUTHORIZED_USER_KEY, '111');
-    const code = await discordDef.subcommands!.unpair!.run(ctx());
+    const code = await discordDef.subcommands?.unpair?.run(ctx());
     expect(code).toBe(0);
     expect(writeOut.join('')).toContain('unpaired');
     expect(await vault.get(DISCORD_AUTHORIZED_USER_KEY)).toBeNull();
   });
 
   it('`unpair` is a no-op when nothing is paired', async () => {
-    const code = await discordDef.subcommands!.unpair!.run(ctx());
+    const code = await discordDef.subcommands?.unpair?.run(ctx());
     expect(code).toBe(0);
     expect(writeOut.join('')).toContain('no pairing was active');
   });
@@ -146,7 +146,7 @@ describe('discord channel subcommands (registered on ChannelDef)', () => {
       // assert that `pair` drives the in-process pairing flow (wires the
       // session's permission resolver) instead of delegating to startChannel.
       await expect(
-        discordDef.subcommands!.pair!.run(ctx({ startChannel, session: { setPermissionResolver } })),
+        discordDef.subcommands?.pair?.run(ctx({ startChannel, session: { setPermissionResolver } })),
       ).rejects.toThrow(/token/i);
       expect(setPermissionResolver).toHaveBeenCalledTimes(1);
       expect(startChannel).not.toHaveBeenCalled();
@@ -160,7 +160,7 @@ describe('discord channel subcommands (registered on ChannelDef)', () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
     try {
       const startChannel = vi.fn(async () => 0);
-      const code = await discordDef.subcommands!.pair!.run(ctx({ startChannel }));
+      const code = await discordDef.subcommands?.pair?.run(ctx({ startChannel }));
       expect(code).toBe(1);
       expect(startChannel).not.toHaveBeenCalled();
       expect(writeErr.join('')).toMatch(/TTY/);
@@ -175,7 +175,7 @@ describe('discord channel subcommands (registered on ChannelDef)', () => {
       args: { positional: [], flags: {} },
       startChannel: async () => 0,
     };
-    const code = await discordDef.subcommands!.status!.run(badCtx as never);
+    const code = await discordDef.subcommands?.status?.run(badCtx as never);
     expect(code).toBe(1);
     expect(writeErr.join('')).toContain('vault unavailable');
   });

--- a/packages/plugin-channel-signal/src/channel.test.ts
+++ b/packages/plugin-channel-signal/src/channel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ClientSession as Session } from '@moxxy/sdk';
+import { assertDefined, type ClientSession as Session } from '@moxxy/sdk';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { SignalChannel, type SignalRpcLike } from './channel.js';
 import { SIGNAL_ACCOUNT_KEY, SIGNAL_ALLOWED_SENDERS_KEY } from './keys.js';
@@ -332,7 +332,8 @@ describe('lifecycle', () => {
     expect(channel.requestUrl).toBe('sgnl://linkdevice?uuid=abc&pub_key=def');
     expect(channel.connected).toBe(false);
 
-    completeLink!({ account: OWNER });
+    assertDefined(completeLink, 'linkFactory captured the resolver during start()');
+    completeLink({ account: OWNER });
     await vi.waitFor(() => expect(channel.connected).toBe(true));
     expect(channel.requestUrl).toBeNull();
     expect(sidecarAccounts).toEqual([OWNER]);

--- a/packages/plugin-channel-signal/src/channel.ts
+++ b/packages/plugin-channel-signal/src/channel.ts
@@ -1,6 +1,6 @@
 import { newTurnId } from '@moxxy/core';
 import { TurnCoordinator, resolveSecret } from '@moxxy/channel-kit';
-import type { ClientSession as Session } from '@moxxy/sdk';
+import { assertDefined, type ClientSession as Session } from '@moxxy/sdk';
 import type {
   Channel,
   ChannelHandle,
@@ -252,7 +252,8 @@ export class SignalChannel implements Channel<SignalStartOpts> {
     const dedicated = startOpts.dedicated === true || process.env.MOXXY_DEDICATED_RUNNER === '1';
     if (isLinked) {
       this.linked = true;
-      await this.bootDaemon(binary, this.account!);
+      assertDefined(this.account, 'isLinked is only reached when this.account is set');
+      await this.bootDaemon(binary, this.account);
     } else if (startOpts.pair || dedicated) {
       await this.openLinkWindow(binary);
     } else {
@@ -401,7 +402,8 @@ export class SignalChannel implements Channel<SignalStartOpts> {
 
   /** A message from ANOTHER account — gate on the sender allow-list. */
   private handleDataMessage(envelope: SignalEnvelope): void {
-    const data = envelope.dataMessage!;
+    const data = envelope.dataMessage;
+    assertDefined(data, 'handleDataMessage is only called when envelope.dataMessage is present');
     const number = envelope.sourceNumber ?? null;
     const uuid = envelope.sourceUuid ?? null;
     const senderIds = [number, uuid, envelope.source ?? null]
@@ -429,7 +431,9 @@ export class SignalChannel implements Channel<SignalStartOpts> {
       this.warnDrop(`unauthorized sender (${senderIds[0] ?? 'unknown'})`);
       return;
     }
-    const target: SendTarget = { recipient: number ?? uuid ?? senderIds[0]! };
+    const [firstSender] = senderIds;
+    assertDefined(firstSender, 'senderIds is non-empty past the length gate above');
+    const target: SendTarget = { recipient: number ?? uuid ?? firstSender };
     this.dispatchInBackground(
       this.processMessage(target, data.message ?? null, data.attachments),
       'data-message',

--- a/packages/plugin-channel-signal/src/channel/chunker.test.ts
+++ b/packages/plugin-channel-signal/src/channel/chunker.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import {
   ChunkedSender,
   SIGNAL_CHUNK_HARD_LIMIT,
@@ -16,23 +17,29 @@ describe('takeChunk', () => {
     const text = 'a'.repeat(1_200) + '\n\n' + 'b'.repeat(600);
     const taken = takeChunk(text);
     expect(taken).not.toBeNull();
-    expect(taken!.chunk).toBe('a'.repeat(1_200));
-    expect(taken!.rest).toBe('b'.repeat(600));
+    assertDefined(taken, 'takeChunk splits past the soft limit');
+    expect(taken.chunk).toBe('a'.repeat(1_200));
+    expect(taken.rest).toBe('b'.repeat(600));
   });
 
   it('falls back to newline, then word boundaries', () => {
     const nl = 'a'.repeat(1_200) + '\n' + 'b'.repeat(600);
-    expect(takeChunk(nl)!.chunk).toBe('a'.repeat(1_200));
+    const takenNl = takeChunk(nl);
+    assertDefined(takenNl, 'newline boundary splits');
+    expect(takenNl.chunk).toBe('a'.repeat(1_200));
     const word = 'a'.repeat(1_200) + ' ' + 'b'.repeat(600);
-    expect(takeChunk(word)!.chunk).toBe('a'.repeat(1_200));
+    const takenWord = takeChunk(word);
+    assertDefined(takenWord, 'word boundary splits');
+    expect(takenWord.chunk).toBe('a'.repeat(1_200));
   });
 
   it('never returns a chunk above the hard limit (hard cut when boundary-less)', () => {
     const text = 'x'.repeat(SIGNAL_CHUNK_HARD_LIMIT + 500);
     const taken = takeChunk(text);
     expect(taken).not.toBeNull();
-    expect(taken!.chunk.length).toBe(SIGNAL_CHUNK_HARD_LIMIT);
-    expect(taken!.rest.length).toBe(500);
+    assertDefined(taken, 'boundary-less text hard-cuts');
+    expect(taken.chunk.length).toBe(SIGNAL_CHUNK_HARD_LIMIT);
+    expect(taken.rest.length).toBe(500);
   });
 
   it('waits for more text when boundary-less but under the hard limit', () => {

--- a/packages/plugin-channel-signal/src/jsonrpc.test.ts
+++ b/packages/plugin-channel-signal/src/jsonrpc.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { describe, expect, it, vi } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { SignalRpcClient, type RpcStream } from './jsonrpc.js';
 
 class FakeStream extends EventEmitter implements RpcStream {
@@ -17,7 +18,9 @@ class FakeStream extends EventEmitter implements RpcStream {
     this.emit('data', Buffer.from(raw, 'utf8'));
   }
   lastRequest(): { id: string; method: string; params: unknown } {
-    return JSON.parse(this.written.at(-1)!) as { id: string; method: string; params: unknown };
+    const last = this.written.at(-1);
+    assertDefined(last, 'lastRequest called after at least one write');
+    return JSON.parse(last) as { id: string; method: string; params: unknown };
   }
 }
 
@@ -58,8 +61,12 @@ describe('SignalRpcClient', () => {
     const client = new SignalRpcClient({ stream });
     const p1 = client.request('a');
     const p2 = client.request('b');
-    const id1 = JSON.parse(stream.written[0]!).id as string;
-    const id2 = JSON.parse(stream.written[1]!).id as string;
+    const raw1 = stream.written[0];
+    const raw2 = stream.written[1];
+    assertDefined(raw1, 'first request line was written');
+    assertDefined(raw2, 'second request line was written');
+    const id1 = JSON.parse(raw1).id as string;
+    const id2 = JSON.parse(raw2).id as string;
     const line1 = `{"jsonrpc":"2.0","id":"${id1}","result":1}\n`;
     const line2 = `{"jsonrpc":"2.0","id":"${id2}","result":2}\n`;
     const combined = line1 + line2;

--- a/packages/plugin-channel-signal/src/sidecar.test.ts
+++ b/packages/plugin-channel-signal/src/sidecar.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import type { RpcStream } from './jsonrpc.js';
 import {
   SignalSidecar,
@@ -65,8 +66,10 @@ describe('SignalSidecar lifecycle', () => {
     });
     const rpc = await sidecar.start();
     expect(spawned).not.toBeNull();
-    expect(spawned!.command).toBe('/opt/bin/signal-cli');
-    expect(spawned!.args).toEqual([
+    const capturedSpawn = spawned;
+    assertDefined(capturedSpawn, 'spawnFn was invoked during start()');
+    expect(capturedSpawn.command).toBe('/opt/bin/signal-cli');
+    expect(capturedSpawn.args).toEqual([
       '-a',
       '+15551234567',
       'daemon',

--- a/packages/plugin-channel-signal/src/sidecar.ts
+++ b/packages/plugin-channel-signal/src/sidecar.ts
@@ -367,14 +367,16 @@ export function startLinkProcess(opts: {
   let child: SpawnedProcess;
   let output = '';
 
-  let resolveUri: (uri: string) => void;
-  let rejectUri: (err: Error) => void;
+  // Defaulted no-ops the synchronous Promise executors below always overwrite;
+  // they let us dereference plainly instead of asserting definite assignment.
+  let resolveUri: (uri: string) => void = () => undefined;
+  let rejectUri: (err: Error) => void = () => undefined;
   const uri = new Promise<string>((resolve, reject) => {
     resolveUri = resolve;
     rejectUri = reject;
   });
-  let resolveCompleted: (r: { account: string | null }) => void;
-  let rejectCompleted: (err: Error) => void;
+  let resolveCompleted: (r: { account: string | null }) => void = () => undefined;
+  let rejectCompleted: (err: Error) => void = () => undefined;
   const completed = new Promise<{ account: string | null }>((resolve, reject) => {
     resolveCompleted = resolve;
     rejectCompleted = reject;
@@ -389,8 +391,8 @@ export function startLinkProcess(opts: {
     child = spawnFn(binary, ['link', '-n', opts.deviceName]);
   } catch (err) {
     const e = new Error(`failed to spawn ${binary} link: ${err instanceof Error ? err.message : String(err)}`);
-    rejectUri!(e);
-    rejectCompleted!(e);
+    rejectUri(e);
+    rejectCompleted(e);
     return { uri, completed, cancel: () => undefined };
   }
 
@@ -402,7 +404,7 @@ export function startLinkProcess(opts: {
       const m = LINK_URI_RE.exec(output);
       if (m?.[1]) {
         uriSettled = true;
-        resolveUri!(m[1]);
+        resolveUri(m[1]);
       }
     }
   };
@@ -412,14 +414,14 @@ export function startLinkProcess(opts: {
     const e = new Error(`signal-cli link failed to start: ${err.message}`);
     if (!uriSettled) {
       uriSettled = true;
-      rejectUri!(e);
+      rejectUri(e);
     }
-    rejectCompleted!(e);
+    rejectCompleted(e);
   });
   child.once('exit', (code) => {
     if (code === 0) {
       const account = ASSOCIATED_RE.exec(output)?.[1] ?? null;
-      resolveCompleted!({ account });
+      resolveCompleted({ account });
     } else {
       const tail = output.split('\n').slice(-4).join('\n').trim();
       const e = new Error(
@@ -428,9 +430,9 @@ export function startLinkProcess(opts: {
       );
       if (!uriSettled) {
         uriSettled = true;
-        rejectUri!(e);
+        rejectUri(e);
       }
-      rejectCompleted!(e);
+      rejectCompleted(e);
     }
   });
 

--- a/packages/plugin-channel-signal/src/subcommands.test.ts
+++ b/packages/plugin-channel-signal/src/subcommands.test.ts
@@ -23,7 +23,7 @@ beforeEach(async () => {
     keySource: createStaticKeySource(deriveKey('test', generateSalt())),
   });
   const plugin = buildSignalPlugin({ vault });
-  signalDef = plugin.channels![0]!;
+  signalDef = (plugin.channels ?? [])[0] as ChannelDef;
   writeOut = [];
   writeErr = [];
   origStdoutWrite = process.stdout.write.bind(process.stdout);
@@ -68,7 +68,7 @@ describe('signal ChannelDef shape', () => {
     expect(signalDef.dedicatedRunner).toBe(true);
     expect(signalDef.sessionSource).toBe('signal');
     expect(signalDef.interactiveCommand).toBe('setup');
-    expect(Object.keys(signalDef.subcommands!)).toEqual(
+    expect(Object.keys(signalDef.subcommands ?? {})).toEqual(
       expect.arrayContaining(['setup', 'pair', 'status', 'unpair']),
     );
     expect(signalDef.config?.fields.map((f) => f.vaultKey)).toEqual([SIGNAL_ACCOUNT_KEY]);
@@ -78,36 +78,36 @@ describe('signal ChannelDef shape', () => {
 
 describe('isAvailable', () => {
   it('returns an install hint (never throws) when signal-cli is missing', async () => {
-    const availability = await signalDef.isAvailable!({ cwd: tmp, vault });
-    expect(availability.ok).toBe(false);
-    expect(availability.reason).toMatch(/brew install signal-cli/);
+    const availability = await signalDef.isAvailable?.({ cwd: tmp, vault });
+    expect(availability?.ok).toBe(false);
+    expect(availability?.reason).toMatch(/brew install signal-cli/);
   });
 
   it('asks for an account once the binary exists', async () => {
     fsSync.writeFileSync(path.join(tmp, 'signal-cli'), '#!/bin/sh\n', { mode: 0o755 });
-    const availability = await signalDef.isAvailable!({ cwd: tmp, vault });
-    expect(availability.ok).toBe(false);
-    expect(availability.reason).toMatch(/signal setup/);
+    const availability = await signalDef.isAvailable?.({ cwd: tmp, vault });
+    expect(availability?.ok).toBe(false);
+    expect(availability?.reason).toMatch(/signal setup/);
   });
 
   it('is available with binary + env account', async () => {
     fsSync.writeFileSync(path.join(tmp, 'signal-cli'), '#!/bin/sh\n', { mode: 0o755 });
     vi.stubEnv('MOXXY_SIGNAL_ACCOUNT', '+15551234567');
-    const availability = await signalDef.isAvailable!({ cwd: tmp, vault });
+    const availability = await signalDef.isAvailable?.({ cwd: tmp, vault });
     expect(availability).toEqual({ ok: true });
   });
 
   it('is available with binary + vault account', async () => {
     fsSync.writeFileSync(path.join(tmp, 'signal-cli'), '#!/bin/sh\n', { mode: 0o755 });
     await vault.set(SIGNAL_ACCOUNT_KEY, '+15551234567');
-    const availability = await signalDef.isAvailable!({ cwd: tmp, vault });
+    const availability = await signalDef.isAvailable?.({ cwd: tmp, vault });
     expect(availability).toEqual({ ok: true });
   });
 });
 
 describe('signal channel subcommands', () => {
   it('`status` reports unconfigured state as JSON', async () => {
-    const code = await signalDef.subcommands!.status!.run(ctx());
+    const code = await signalDef.subcommands?.status?.run(ctx());
     expect(code).toBe(0);
     const parsed = JSON.parse(writeOut.join(''));
     expect(parsed).toEqual({
@@ -122,7 +122,7 @@ describe('signal channel subcommands', () => {
   it('`status` surfaces the stored account + allow-list', async () => {
     await vault.set(SIGNAL_ACCOUNT_KEY, '+15551234567');
     await vault.set(SIGNAL_ALLOWED_SENDERS_KEY, JSON.stringify(['+14440002222']));
-    const code = await signalDef.subcommands!.status!.run(ctx());
+    const code = await signalDef.subcommands?.status?.run(ctx());
     expect(code).toBe(0);
     const parsed = JSON.parse(writeOut.join(''));
     expect(parsed.account).toBe('+15551234567');
@@ -132,7 +132,7 @@ describe('signal channel subcommands', () => {
   it('`unpair` clears account + allow-list and points at the phone for full unlink', async () => {
     await vault.set(SIGNAL_ACCOUNT_KEY, '+15551234567');
     await vault.set(SIGNAL_ALLOWED_SENDERS_KEY, JSON.stringify(['+14440002222']));
-    const code = await signalDef.subcommands!.unpair!.run(ctx());
+    const code = await signalDef.subcommands?.unpair?.run(ctx());
     expect(code).toBe(0);
     expect(writeOut.join('')).toContain('unpaired');
     expect(writeOut.join('')).toContain('Linked Devices');
@@ -141,7 +141,7 @@ describe('signal channel subcommands', () => {
   });
 
   it('`unpair` is a no-op when nothing is configured', async () => {
-    const code = await signalDef.subcommands!.unpair!.run(ctx());
+    const code = await signalDef.subcommands?.unpair?.run(ctx());
     expect(code).toBe(0);
     expect(writeOut.join('')).toContain('no account was configured');
   });
@@ -151,7 +151,7 @@ describe('signal channel subcommands', () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
     try {
       const startChannel = vi.fn(async () => 0);
-      const code = await signalDef.subcommands!.pair!.run(ctx({ startChannel }));
+      const code = await signalDef.subcommands?.pair?.run(ctx({ startChannel }));
       expect(code).toBe(1);
       expect(startChannel).not.toHaveBeenCalled();
       expect(writeErr.join('')).toMatch(/TTY/);
@@ -170,7 +170,7 @@ describe('signal channel subcommands', () => {
       // hint before any process could spawn. We assert `pair` wires the
       // session's resolver (the in-process flow) instead of delegating.
       await expect(
-        signalDef.subcommands!.pair!.run(ctx({ startChannel, session: { setPermissionResolver } })),
+        signalDef.subcommands?.pair?.run(ctx({ startChannel, session: { setPermissionResolver } })),
       ).rejects.toThrow(/signal-cli not found/);
       expect(setPermissionResolver).toHaveBeenCalledTimes(1);
       expect(startChannel).not.toHaveBeenCalled();
@@ -184,7 +184,7 @@ describe('signal channel subcommands', () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
     try {
       const startChannel = vi.fn(async () => 0);
-      const code = await signalDef.subcommands!.setup!.run(ctx({ startChannel }));
+      const code = await signalDef.subcommands?.setup?.run(ctx({ startChannel }));
       expect(code).toBe(0);
       expect(startChannel).toHaveBeenCalledTimes(1);
     } finally {
@@ -199,7 +199,7 @@ describe('signal channel subcommands', () => {
       startChannel: async () => 0,
       session: { setPermissionResolver: () => {} },
     } as never;
-    const code = await signalDef.subcommands!.status!.run(badCtx);
+    const code = await signalDef.subcommands?.status?.run(badCtx);
     expect(code).toBe(1);
     expect(writeErr.join('')).toContain('vault unavailable');
   });

--- a/packages/plugin-channel-slack/src/subcommands.test.ts
+++ b/packages/plugin-channel-slack/src/subcommands.test.ts
@@ -26,7 +26,7 @@ beforeEach(async () => {
     keySource: createStaticKeySource(deriveKey('test', generateSalt())),
   });
   const plugin = buildSlackPlugin({ vault });
-  slackDef = plugin.channels![0]!;
+  slackDef = (plugin.channels ?? [])[0] as ChannelDef;
   writeOut = [];
   writeErr = [];
   origStdoutWrite = process.stdout.write.bind(process.stdout);
@@ -61,14 +61,14 @@ function ctx(overrides: { startChannel?: () => Promise<number> } = {}) {
 describe('slack channel subcommands (registered on ChannelDef)', () => {
   it('exposes setup, pair, status, unpair', () => {
     expect(slackDef.subcommands).toBeDefined();
-    expect(Object.keys(slackDef.subcommands!)).toEqual(
+    expect(Object.keys(slackDef.subcommands ?? {})).toEqual(
       expect.arrayContaining(['setup', 'pair', 'status', 'unpair']),
     );
     expect(slackDef.interactiveCommand).toBe('setup');
   });
 
   it('`status` reports unconfigured vault state as JSON', async () => {
-    const code = await slackDef.subcommands!.status!.run(ctx());
+    const code = await slackDef.subcommands?.status?.run(ctx());
     expect(code).toBe(0);
     const parsed = JSON.parse(writeOut.join(''));
     expect(parsed).toEqual({
@@ -86,7 +86,7 @@ describe('slack channel subcommands (registered on ChannelDef)', () => {
       SLACK_AUTHORIZED_KEY,
       JSON.stringify({ teamId: 'T1', channelId: 'C1' }),
     );
-    const code = await slackDef.subcommands!.status!.run(ctx());
+    const code = await slackDef.subcommands?.status?.run(ctx());
     expect(code).toBe(0);
     const parsed = JSON.parse(writeOut.join(''));
     expect(parsed).toEqual({
@@ -100,7 +100,7 @@ describe('slack channel subcommands (registered on ChannelDef)', () => {
   it('`status` honors env overrides for token/secret', async () => {
     process.env.MOXXY_SLACK_BOT_TOKEN = 'xoxb-env-token-abcdefghijkl';
     process.env.MOXXY_SLACK_SIGNING_SECRET = 'env-signing-secret-0123456789';
-    const code = await slackDef.subcommands!.status!.run(ctx());
+    const code = await slackDef.subcommands?.status?.run(ctx());
     expect(code).toBe(0);
     const parsed = JSON.parse(writeOut.join(''));
     expect(parsed.botTokenConfigured).toBe(true);
@@ -109,7 +109,7 @@ describe('slack channel subcommands (registered on ChannelDef)', () => {
 
   it('`status` reports null for a corrupt authorization record', async () => {
     await vault.set(SLACK_AUTHORIZED_KEY, 'not-json');
-    const code = await slackDef.subcommands!.status!.run(ctx());
+    const code = await slackDef.subcommands?.status?.run(ctx());
     expect(code).toBe(0);
     const parsed = JSON.parse(writeOut.join(''));
     expect(parsed.authorized).toBeNull();
@@ -117,14 +117,14 @@ describe('slack channel subcommands (registered on ChannelDef)', () => {
 
   it('`unpair` clears the authorization and reports', async () => {
     await vault.set(SLACK_AUTHORIZED_KEY, JSON.stringify({ teamId: 'T1' }));
-    const code = await slackDef.subcommands!.unpair!.run(ctx());
+    const code = await slackDef.subcommands?.unpair?.run(ctx());
     expect(code).toBe(0);
     expect(writeOut.join('')).toContain('unpaired');
     expect(await vault.get(SLACK_AUTHORIZED_KEY)).toBeNull();
   });
 
   it('`unpair` is a no-op when nothing is paired', async () => {
-    const code = await slackDef.subcommands!.unpair!.run(ctx());
+    const code = await slackDef.subcommands?.unpair?.run(ctx());
     expect(code).toBe(0);
     expect(writeOut.join('')).toContain('no pairing was active');
   });
@@ -134,7 +134,7 @@ describe('slack channel subcommands (registered on ChannelDef)', () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
     try {
       const startChannel = vi.fn(async () => 0);
-      const code = await slackDef.subcommands!.pair!.run(ctx({ startChannel }));
+      const code = await slackDef.subcommands?.pair?.run(ctx({ startChannel }));
       expect(code).toBe(1);
       expect(startChannel).not.toHaveBeenCalled();
       expect(writeErr.join('')).toMatch(/TTY/);
@@ -148,7 +148,7 @@ describe('slack channel subcommands (registered on ChannelDef)', () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
     try {
       const startChannel = vi.fn(async () => 0);
-      const code = await slackDef.subcommands!.setup!.run(ctx({ startChannel }));
+      const code = await slackDef.subcommands?.setup?.run(ctx({ startChannel }));
       expect(code).toBe(0);
       expect(startChannel).toHaveBeenCalledTimes(1);
     } finally {
@@ -163,27 +163,27 @@ describe('slack channel subcommands (registered on ChannelDef)', () => {
       startChannel: async () => 0,
       session: { setPermissionResolver: () => {} },
     } as never;
-    const code = await slackDef.subcommands!.status!.run(badCtx);
+    const code = await slackDef.subcommands?.status?.run(badCtx);
     expect(code).toBe(1);
     expect(writeErr.join('')).toContain('vault unavailable');
   });
 
   it('isAvailable gates on BOTH token and secret', async () => {
     // Neither set → unavailable, reason names both.
-    let avail = await slackDef.isAvailable!({ cwd: tmp, vault });
-    expect(avail.ok).toBe(false);
-    expect(avail.reason).toMatch(/bot token/);
-    expect(avail.reason).toMatch(/signing secret/);
+    let avail = await slackDef.isAvailable?.({ cwd: tmp, vault });
+    expect(avail?.ok).toBe(false);
+    expect(avail?.reason).toMatch(/bot token/);
+    expect(avail?.reason).toMatch(/signing secret/);
 
     // Only token → still unavailable, reason names the secret.
     await vault.set(SLACK_BOT_TOKEN_KEY, 'xoxb-1111-2222-abcdefghijklmnop');
-    avail = await slackDef.isAvailable!({ cwd: tmp, vault });
-    expect(avail.ok).toBe(false);
-    expect(avail.reason).toMatch(/signing secret/);
+    avail = await slackDef.isAvailable?.({ cwd: tmp, vault });
+    expect(avail?.ok).toBe(false);
+    expect(avail?.reason).toMatch(/signing secret/);
 
     // Both → available.
     await vault.set(SLACK_SIGNING_SECRET_KEY, '0123456789abcdef0123456789abcdef');
-    avail = await slackDef.isAvailable!({ cwd: tmp, vault });
-    expect(avail.ok).toBe(true);
+    avail = await slackDef.isAvailable?.({ cwd: tmp, vault });
+    expect(avail?.ok).toBe(true);
   });
 });

--- a/packages/plugin-channel-whatsapp/src/baileys-socket.ts
+++ b/packages/plugin-channel-whatsapp/src/baileys-socket.ts
@@ -23,13 +23,15 @@ export const openBaileysSocket: WhatsAppSocketFactory = async ({ storage, logger
     throw new Error('@whiskeysockets/baileys: could not resolve makeWASocket export');
   }
   const proto = baileys.proto ?? baileys.default?.proto;
+  const protoMessage = proto?.Message;
+  const appStateSyncKeyData = protoMessage?.AppStateSyncKeyData;
   const bridge: BaileysAuthBridge = {
     initAuthCreds: baileys.initAuthCreds,
     BufferJSON: baileys.BufferJSON,
-    ...(proto?.Message?.AppStateSyncKeyData
+    ...(appStateSyncKeyData
       ? {
           reviveAppStateSyncKey: (value: unknown) =>
-            proto.Message!.AppStateSyncKeyData!.fromObject(value as Record<string, unknown>),
+            appStateSyncKeyData.fromObject(value as Record<string, unknown>),
         }
       : {}),
   };

--- a/packages/plugin-channel-whatsapp/src/channel.test.ts
+++ b/packages/plugin-channel-whatsapp/src/channel.test.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Session, autoAllowResolver, silentLogger } from '@moxxy/core';
 import { FakeProvider, streamingTextReply } from '@moxxy/testing';
-import { definePlugin, defineProvider, defineTranscriber } from '@moxxy/sdk';
+import { assertDefined, definePlugin, defineProvider, defineTranscriber } from '@moxxy/sdk';
 import { defaultModePlugin } from '@moxxy/mode-default';
 import { VaultStore, createStaticKeySource, deriveKey, generateSalt } from '@moxxy/plugin-vault';
 import { WhatsAppChannel } from './channel.js';
@@ -218,7 +218,8 @@ describe('WhatsAppChannel.start', () => {
     const turnsBefore = provider.received.length;
 
     // Feed the channel's own last send back as an inbound (fromMe echo).
-    const lastOut = fake.sent[fake.sent.length - 1]!;
+    const lastOut = fake.sent[fake.sent.length - 1];
+    assertDefined(lastOut, 'the channel sent at least one message');
     // Reconstruct the outbound key id: the fake numbers them out-N; grab it via
     // a fresh send to learn the id shape isn't needed — echo by a known own id.
     fake.inbound({ key: { remoteJid: OWNER, fromMe: true, id: 'out-1' }, message: { conversation: lastOut.text } });

--- a/packages/plugin-channel-whatsapp/src/channel/turn-runner.ts
+++ b/packages/plugin-channel-whatsapp/src/channel/turn-runner.ts
@@ -1,6 +1,6 @@
 import type { newTurnId } from '@moxxy/core';
 import { FramePump, PlainTurnRenderer, driveTurn, subscribeTurn } from '@moxxy/channel-kit';
-import type { ClientSession as Session } from '@moxxy/sdk';
+import { assertDefined, type ClientSession as Session } from '@moxxy/sdk';
 import type { WaMessageKey, WhatsAppSocket } from '../socket.js';
 
 /**
@@ -116,8 +116,10 @@ export async function runWhatsAppTurn(
       send: async (t) => sendChunks(splitWhatsAppText(t)),
       edit: async (key, t, final) => {
         const chunks = splitWhatsAppText(t);
+        const head = chunks[0];
+        assertDefined(head, 'whatsapp: splitWhatsAppText always yields at least one chunk');
         try {
-          await socket.editText(jid, key, chunks[0]!);
+          await socket.editText(jid, key, head);
         } catch (err) {
           logger?.warn?.('whatsapp edit failed', { err: String(err), final });
           if (final) {

--- a/packages/plugin-channel-whatsapp/src/keys.ts
+++ b/packages/plugin-channel-whatsapp/src/keys.ts
@@ -33,7 +33,7 @@ export function normalizeJid(raw: string | null | undefined): string | null {
   const server = trimmed.slice(at + 1).toLowerCase();
   if (!/^[a-z0-9.-]+$/.test(server)) return null;
   // Strip the device (`:NN`) and legacy agent (`_N`) suffixes off the user part.
-  const user = trimmed.slice(0, at).split(':')[0]!.split('_')[0]!;
+  const user = (trimmed.slice(0, at).split(':')[0] ?? '').split('_')[0] ?? '';
   if (user.length === 0) return null;
   return `${user}@${server}`;
 }

--- a/packages/plugin-channel-whatsapp/src/permission.ts
+++ b/packages/plugin-channel-whatsapp/src/permission.ts
@@ -1,4 +1,5 @@
 import {
+  assertDefined,
   createDeferredPermissionResolver,
   type DeferredPermissionResolver,
   type PendingToolCall,
@@ -98,7 +99,8 @@ export function createWhatsAppPermissionController(): WhatsAppPermissionControll
       if (pending.length === 0) return false;
       const decision = parsePermissionReply(text);
       if (!decision) return false;
-      const prompt = pending.shift()!;
+      const prompt = pending.shift();
+      assertDefined(prompt, 'pending is non-empty past the length guard above');
       prompt.resolve(decision);
       return true;
     },

--- a/packages/plugin-channel-whatsapp/src/subcommands.test.ts
+++ b/packages/plugin-channel-whatsapp/src/subcommands.test.ts
@@ -30,7 +30,7 @@ beforeEach(async () => {
     filePath: path.join(tmp, 'vault.json'),
     keySource: createStaticKeySource(deriveKey('test', generateSalt())),
   });
-  def = buildWhatsAppPlugin({ vault }).channels![0]!;
+  def = (buildWhatsAppPlugin({ vault }).channels ?? [])[0] as ChannelDef;
   writeOut = [];
   writeErr = [];
   origOut = process.stdout.write.bind(process.stdout);
@@ -74,7 +74,7 @@ describe('whatsapp channel def', () => {
   });
 
   it('exposes setup, pair, status, unpair subcommands', () => {
-    expect(Object.keys(def.subcommands!)).toEqual(
+    expect(Object.keys(def.subcommands ?? {})).toEqual(
       expect.arrayContaining(['setup', 'pair', 'status', 'unpair']),
     );
   });
@@ -87,22 +87,22 @@ describe('whatsapp channel def', () => {
 
 describe('isAvailable (consent gate + link state)', () => {
   it('is unavailable without consent, naming the ToS risk', async () => {
-    const avail = await def.isAvailable!({ cwd: tmp, vault });
-    expect(avail.ok).toBe(false);
-    expect(avail.reason).toMatch(/ToS|acknowledg|ban/i);
+    const avail = await def.isAvailable?.({ cwd: tmp, vault });
+    expect(avail?.ok).toBe(false);
+    expect(avail?.reason).toMatch(/ToS|acknowledg|ban/i);
   });
 
   it('is unavailable-but-needs-pairing once consent is given', async () => {
     process.env[WHATSAPP_CONSENT_ENV] = 'yes';
-    const avail = await def.isAvailable!({ cwd: tmp, vault });
-    expect(avail.ok).toBe(false);
-    expect(avail.reason).toMatch(/pair/i);
+    const avail = await def.isAvailable?.({ cwd: tmp, vault });
+    expect(avail?.ok).toBe(false);
+    expect(avail?.reason).toMatch(/pair/i);
   });
 });
 
 describe('status subcommand', () => {
   it('reports needs-consent when nothing configured', async () => {
-    const code = await def.subcommands!.status!.run(ctx());
+    const code = await def.subcommands?.status?.run(ctx());
     expect(code).toBe(0);
     const parsed = JSON.parse(writeOut.join(''));
     expect(parsed.state).toBe('needs-consent');
@@ -112,7 +112,7 @@ describe('status subcommand', () => {
 
   it('reports needs-pairing after consent but before linking', async () => {
     await vault.set(WHATSAPP_CONSENT_KEY, 'acknowledged@2026-01-01T00:00:00.000Z');
-    const code = await def.subcommands!.status!.run(ctx());
+    const code = await def.subcommands?.status?.run(ctx());
     expect(code).toBe(0);
     const parsed = JSON.parse(writeOut.join(''));
     expect(parsed.state).toBe('needs-pairing');
@@ -123,7 +123,7 @@ describe('status subcommand', () => {
     await vault.set(WHATSAPP_CONSENT_KEY, 'yes');
     await vault.set(WHATSAPP_OWNER_JID_KEY, '15550000000@s.whatsapp.net');
     await vault.set(WHATSAPP_ALLOWED_JIDS_KEY, JSON.stringify(['15551111111@s.whatsapp.net']));
-    const code = await def.subcommands!.status!.run(ctx());
+    const code = await def.subcommands?.status?.run(ctx());
     expect(code).toBe(0);
     const parsed = JSON.parse(writeOut.join(''));
     expect(parsed.ownerJid).toBe('15550000000@s.whatsapp.net');
@@ -137,7 +137,7 @@ describe('status subcommand', () => {
       startChannel: async () => 0,
       session: { setPermissionResolver: () => {} },
     } as never;
-    const code = await def.subcommands!.status!.run(badCtx);
+    const code = await def.subcommands?.status?.run(badCtx);
     expect(code).toBe(1);
     expect(writeErr.join('')).toContain('vault unavailable');
   });
@@ -145,7 +145,7 @@ describe('status subcommand', () => {
 
 describe('unpair subcommand', () => {
   it('is a no-op when nothing is linked', async () => {
-    const code = await def.subcommands!.unpair!.run(ctx());
+    const code = await def.subcommands?.unpair?.run(ctx());
     expect(code).toBe(0);
     expect(writeOut.join('')).toContain('no linked account');
   });
@@ -157,7 +157,7 @@ describe('pair subcommand', () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
     try {
       const startChannel = vi.fn(async () => 0);
-      const code = await def.subcommands!.pair!.run(ctx({ startChannel }));
+      const code = await def.subcommands?.pair?.run(ctx({ startChannel }));
       expect(code).toBe(1);
       expect(startChannel).not.toHaveBeenCalled();
       expect(writeErr.join('')).toMatch(/TTY/);
@@ -173,7 +173,7 @@ describe('setup subcommand (headless)', () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
     try {
       const startChannel = vi.fn(async () => 0);
-      const code = await def.subcommands!.setup!.run(ctx({ startChannel }));
+      const code = await def.subcommands?.setup?.run(ctx({ startChannel }));
       expect(code).toBe(1);
       expect(startChannel).not.toHaveBeenCalled();
       expect(writeErr.join('')).toMatch(/acknowledg|ToS|ban/i);
@@ -188,7 +188,7 @@ describe('setup subcommand (headless)', () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
     try {
       const startChannel = vi.fn(async () => 0);
-      const code = await def.subcommands!.setup!.run(ctx({ startChannel }));
+      const code = await def.subcommands?.setup?.run(ctx({ startChannel }));
       expect(code).toBe(0);
       expect(startChannel).toHaveBeenCalledTimes(1);
     } finally {

--- a/packages/plugin-telegram/src/approval.ts
+++ b/packages/plugin-telegram/src/approval.ts
@@ -36,10 +36,11 @@ export class TelegramApprovalResolver implements ApprovalResolver {
       // headless behavior (run the plan as drafted).
       return { optionId: request.defaultOptionId ?? request.options[0]?.id ?? 'approve' };
     }
+    const decider = this.deciderFn;
     const id = `appr_${this.nextId++}`;
     return new Promise<ApprovalDecision>((resolve) => {
       this.pending.set(id, { id, request, resolve });
-      this.deciderFn!(id, request).catch((err) => {
+      decider(id, request).catch((err) => {
         this.pending.delete(id);
         resolve({
           optionId: request.defaultOptionId ?? request.options[0]?.id ?? 'cancel',

--- a/packages/plugin-telegram/src/channel/callback-handler.ts
+++ b/packages/plugin-telegram/src/channel/callback-handler.ts
@@ -45,7 +45,9 @@ export async function handleCallback(
   // resolve permission prompts, approve plans, and switch provider/model/mode,
   // so an unpaired chat's callbacks must be refused just like its messages
   // (inline-keyboard messages can be forwarded to arbitrary chats).
-  const chatId = ctx.chat?.id ?? ctx.callbackQuery?.message?.chat?.id;
+  const callbackMessage = ctx.callbackQuery?.message;
+  const callbackChat = callbackMessage?.chat;
+  const chatId = ctx.chat?.id ?? callbackChat?.id;
   if (chatId === undefined || !state.pairing.isAuthorized(chatId)) {
     try {
       await ctx.answerCallbackQuery({ text: 'This bot is paired with a different chat.' });

--- a/packages/plugin-telegram/src/channel/frame-pump.ts
+++ b/packages/plugin-telegram/src/channel/frame-pump.ts
@@ -1,5 +1,6 @@
 import type { Bot } from 'grammy';
 import { GrammyError } from 'grammy';
+import { assertDefined } from '@moxxy/sdk';
 import { FramePump as StreamPump } from '@moxxy/channel-kit';
 import { TurnRenderer, splitForTelegram } from '../render.js';
 import { composeFrame, stripHtml } from './html.js';
@@ -93,7 +94,9 @@ export class FramePump {
   private async sendFrame(chatId: number, text: string, final: boolean): Promise<number | null> {
     if (!this.bot) return null;
     const parts = splitForTelegram(text);
-    const sent = await this.safeSend(chatId, parts[0]!);
+    const head = parts[0];
+    assertDefined(head, 'telegram: FramePump never sinks empty text (emptyFinalText guarantees a part)');
+    const sent = await this.safeSend(chatId, head);
     if (final && parts.length > 1) {
       for (const tail of parts.slice(1)) {
         await this.safeSend(chatId, tail);
@@ -110,7 +113,9 @@ export class FramePump {
   ): Promise<void> {
     if (!this.bot) return;
     const parts = splitForTelegram(text);
-    await this.safeEdit(chatId, messageId, parts[0]!);
+    const head = parts[0];
+    assertDefined(head, 'telegram: FramePump never sinks empty text (emptyFinalText guarantees a part)');
+    await this.safeEdit(chatId, messageId, head);
     if (final && parts.length > 1) {
       for (const tail of parts.slice(1)) {
         await this.safeSend(chatId, tail);
@@ -125,8 +130,10 @@ export class FramePump {
    * the same edit forever.
    */
   async safeEdit(chatId: number, messageId: number, text: string): Promise<void> {
+    const bot = this.bot;
+    assertDefined(bot, 'safeEdit is only reached after a bot-null guard upstream');
     try {
-      await this.bot!.api.editMessageText(chatId, messageId, text, {
+      await bot.api.editMessageText(chatId, messageId, text, {
         parse_mode: 'HTML',
         link_preview_options: { is_disabled: true },
       });
@@ -135,7 +142,7 @@ export class FramePump {
       if (err instanceof GrammyError && err.description?.includes('not modified')) return;
       if (err instanceof GrammyError && /can't parse entities|Bad Request: can't parse/i.test(err.description ?? '')) {
         try {
-          await this.bot!.api.editMessageText(chatId, messageId, stripHtml(text));
+          await bot.api.editMessageText(chatId, messageId, stripHtml(text));
           return;
         } catch (plainErr) {
           if (plainErr instanceof GrammyError && plainErr.description?.includes('not modified')) return;
@@ -153,8 +160,10 @@ export class FramePump {
    * messageId for future edits.
    */
   async safeSend(chatId: number, text: string): Promise<number | null> {
+    const bot = this.bot;
+    assertDefined(bot, 'safeSend is only reached after a bot-null guard upstream');
     try {
-      const sent = await this.bot!.api.sendMessage(chatId, text, {
+      const sent = await bot.api.sendMessage(chatId, text, {
         parse_mode: 'HTML',
         link_preview_options: { is_disabled: true },
       });
@@ -162,7 +171,7 @@ export class FramePump {
     } catch (err) {
       if (err instanceof GrammyError && /can't parse entities|Bad Request: can't parse/i.test(err.description ?? '')) {
         try {
-          const sent = await this.bot!.api.sendMessage(chatId, stripHtml(text));
+          const sent = await bot.api.sendMessage(chatId, stripHtml(text));
           return sent.message_id;
         } catch (plainErr) {
           this.logger?.warn('sendMessage plain-fallback failed', { err: String(plainErr) });

--- a/packages/plugin-telegram/src/channel/slash-handler.ts
+++ b/packages/plugin-telegram/src/channel/slash-handler.ts
@@ -1,5 +1,5 @@
 import { type Bot, type Context, InlineKeyboard } from 'grammy';
-import { isSelectableMode } from '@moxxy/sdk';
+import { assertDefined, isSelectableMode } from '@moxxy/sdk';
 import type { ClientSession as Session } from '@moxxy/sdk';
 import { resolveVoiceToggle } from '@moxxy/channel-kit';
 
@@ -54,7 +54,8 @@ export async function runSlash(
   const session = state.session;
   if (!session) return;
   const [head, ...rest] = text.split(/\s+/);
-  const name = head!.slice(1);
+  assertDefined(head, 'String.split always yields at least one element');
+  const name = head.slice(1);
   const args = rest.join(' ');
 
   // 1) Shared registry dispatch.

--- a/packages/plugin-telegram/src/channel/voice-handler.test.ts
+++ b/packages/plugin-telegram/src/channel/voice-handler.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Context } from 'grammy';
 import { Session } from '@moxxy/core';
-import { defineTranscriber } from '@moxxy/sdk';
+import { assertDefined, defineTranscriber } from '@moxxy/sdk';
 import { handleVoiceMessage } from './voice-handler.js';
 
 const TOKEN = '1234567890:test-token';
@@ -103,7 +103,8 @@ describe('handleVoiceMessage', () => {
     );
     expect(getFile).toHaveBeenCalledWith('voice-1');
     expect(transcribe).toHaveBeenCalled();
-    const transcribeArgs = transcribe.mock.calls[0]!;
+    const transcribeArgs = transcribe.mock.calls[0];
+    assertDefined(transcribeArgs, 'transcribe was asserted called, so calls[0] exists');
     expect((transcribeArgs[1] as { mimeType: string }).mimeType).toBe('audio/ogg');
     expect(replies.some((r) => /heard:/.test(r) && /hello agent/.test(r))).toBe(true);
     expect(runUserTurn).toHaveBeenCalledWith(ctx, 99, 'hello agent');
@@ -322,7 +323,9 @@ describe('handleVoiceMessage', () => {
       baseDeps(),
       { runUserTurn, fetchAudio: okFetch(new Uint8Array([9])) },
     );
-    expect((transcribe.mock.calls[0]![1] as { mimeType: string }).mimeType).toBe('audio/mpeg');
+    const transcribeArgs = transcribe.mock.calls[0];
+    assertDefined(transcribeArgs, 'handleVoiceMessage transcribes the upload, so calls[0] exists');
+    expect((transcribeArgs[1] as { mimeType: string }).mimeType).toBe('audio/mpeg');
     expect(runUserTurn).toHaveBeenCalledWith(ctx, 99, 'recorded earlier');
   });
 });

--- a/packages/plugin-telegram/src/format.ts
+++ b/packages/plugin-telegram/src/format.ts
@@ -201,10 +201,10 @@ function parseCallout(stripped: string): ParsedCallout | null {
   const rest = nl === -1 ? '' : stripped.slice(nl + 1);
   const m = /^\[!(\w+)\]([+-]?)[ \t]*(.*)$/.exec(firstLine.trim());
   if (!m) return null;
-  const meta = CALLOUTS[m[1]!.toLowerCase()];
+  const meta = CALLOUTS[(m[1] ?? '').toLowerCase()];
   if (!meta) return null;
   const fold = m[2];
-  const title = m[3]!.trim() || meta.label;
+  const title = (m[3] ?? '').trim() || meta.label;
   return {
     header: `<b>${meta.emoji} ${title}</b>`,
     body: rest,
@@ -243,7 +243,7 @@ function isAllowedUrl(url: string): boolean {
   // RFC3986 scheme: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) ":".
   const m = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(trimmed);
   if (!m) return true; // no explicit scheme — relative/anchor/host-only link
-  return ALLOWED_URL_SCHEMES.has(m[1]!.toLowerCase());
+  return ALLOWED_URL_SCHEMES.has((m[1] ?? '').toLowerCase());
 }
 
 function escapeHtml(s: string): string {

--- a/packages/plugin-telegram/src/permission.ts
+++ b/packages/plugin-telegram/src/permission.ts
@@ -32,9 +32,10 @@ export class TelegramPermissionResolver implements PermissionResolver {
     if (!this.deciderFn) {
       return { mode: 'deny', reason: 'no decider attached (bot not running)' };
     }
+    const decider = this.deciderFn;
     const decision = await new Promise<PermissionDecision>((resolve) => {
       this.pending.set(call.callId, { callId: call.callId, call, ctx, resolve });
-      this.deciderFn!(call, ctx).catch((err) => {
+      decider(call, ctx).catch((err) => {
         this.pending.delete(call.callId);
         resolve({ mode: 'deny', reason: err instanceof Error ? err.message : String(err) });
       });

--- a/packages/plugin-telegram/src/render.test.ts
+++ b/packages/plugin-telegram/src/render.test.ts
@@ -241,7 +241,7 @@ describe('splitForTelegram', () => {
       if (html.slice(lastIndex, m.index).includes('<')) return false;
       lastIndex = re.lastIndex;
       const closing = m[1] === '/';
-      const name = m[2]!.toLowerCase();
+      const name = (m[2] ?? '').toLowerCase();
       if (m[0].endsWith('/>')) continue;
       if (closing) {
         if (stack.pop() !== name) return false;
@@ -253,7 +253,7 @@ describe('splitForTelegram', () => {
     if (stack.length !== 0) return false;
     // No truncated entity: every '&'-prefixed entity-looking run is `;`-terminated.
     for (const em of html.matchAll(/&[a-zA-Z0-9#]+/g)) {
-      const after = html[em.index! + em[0].length];
+      const after = html[(em.index ?? 0) + em[0].length];
       if (after !== ';') return false;
     }
     return true;

--- a/packages/plugin-telegram/src/render.ts
+++ b/packages/plugin-telegram/src/render.ts
@@ -1,5 +1,6 @@
 import type { MoxxyEvent } from '@moxxy/sdk';
 import {
+  assertDefined,
   fileDiffSummary,
   fileDiffVerb,
   isFileDiffDisplay,
@@ -398,10 +399,11 @@ class TagBoundaryIndex {
         const m = /^<\s*(\/?)\s*([a-zA-Z][a-zA-Z0-9-]*)/.exec(raw);
         if (m) {
           const closing = m[1] === '/';
-          const name = m[2]!.toLowerCase();
+          const name = (m[2] ?? '').toLowerCase();
           if (closing) {
             for (let s = stack.length - 1; s >= 0; s--) {
-              if (stack[s]!.name === name) {
+              const entry = stack[s];
+              if (entry?.name === name) {
                 stack.splice(s, 1);
                 break;
               }
@@ -439,14 +441,18 @@ class TagBoundaryIndex {
     let hi = this.checkPos.length - 1;
     while (lo < hi) {
       const mid = (lo + hi + 1) >> 1;
-      if (this.checkPos[mid]! <= idx) lo = mid;
+      const pos = this.checkPos[mid];
+      assertDefined(pos, 'binary-search mid is always a valid checkpoint index');
+      if (pos <= idx) lo = mid;
       else hi = mid - 1;
     }
     // Returns the checkpoint stack by reference — it is an immutable snapshot;
     // the only consumer that re-roots it (`new TagBoundaryIndex(.., carry)`)
     // copies via `seed.slice()` before mutating, so no probe can corrupt it.
+    const checkpointStack = this.checkStack[lo];
+    assertDefined(checkpointStack, 'binary-search lo is always a valid checkpoint index');
     return {
-      stack: this.checkStack[lo]!,
+      stack: checkpointStack,
       insideTag: inside,
     };
   }

--- a/packages/plugin-telegram/src/subcommands.test.ts
+++ b/packages/plugin-telegram/src/subcommands.test.ts
@@ -21,7 +21,7 @@ beforeEach(async () => {
     keySource: createStaticKeySource(deriveKey('test', generateSalt())),
   });
   const plugin = buildTelegramPlugin({ vault });
-  telegramDef = plugin.channels![0]!;
+  telegramDef = (plugin.channels ?? [])[0] as ChannelDef;
   writeOut = [];
   writeErr = [];
   origStdoutWrite = process.stdout.write.bind(process.stdout);
@@ -59,13 +59,13 @@ function ctx(
 describe('telegram channel subcommands (registered on ChannelDef)', () => {
   it('exposes pair, unpair, status', () => {
     expect(telegramDef.subcommands).toBeDefined();
-    expect(Object.keys(telegramDef.subcommands!)).toEqual(
+    expect(Object.keys(telegramDef.subcommands ?? {})).toEqual(
       expect.arrayContaining(['pair', 'unpair', 'status']),
     );
   });
 
   it('`status` reports unconfigured vault state as JSON', async () => {
-    const code = await telegramDef.subcommands!.status!.run(ctx());
+    const code = await telegramDef.subcommands?.status?.run(ctx());
     expect(code).toBe(0);
     const parsed = JSON.parse(writeOut.join(''));
     expect(parsed).toEqual({ tokenConfigured: false, authorizedChatId: null });
@@ -74,7 +74,7 @@ describe('telegram channel subcommands (registered on ChannelDef)', () => {
   it('`status` surfaces stored token + authorized chat', async () => {
     await vault.set('telegram_bot_token', '1234567890:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi');
     await vault.set('telegram_authorized_chat_id', '987654321');
-    const code = await telegramDef.subcommands!.status!.run(ctx());
+    const code = await telegramDef.subcommands?.status?.run(ctx());
     expect(code).toBe(0);
     const parsed = JSON.parse(writeOut.join(''));
     expect(parsed).toEqual({ tokenConfigured: true, authorizedChatId: 987654321 });
@@ -83,7 +83,7 @@ describe('telegram channel subcommands (registered on ChannelDef)', () => {
   it('`status` reports null (not NaN) for a corrupt stored chat id', async () => {
     await vault.set('telegram_bot_token', '1234567890:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi');
     await vault.set('telegram_authorized_chat_id', 'not-a-number');
-    const code = await telegramDef.subcommands!.status!.run(ctx());
+    const code = await telegramDef.subcommands?.status?.run(ctx());
     expect(code).toBe(0);
     const parsed = JSON.parse(writeOut.join(''));
     // A bare Number('not-a-number') would be NaN → serialized to null, masking
@@ -93,14 +93,14 @@ describe('telegram channel subcommands (registered on ChannelDef)', () => {
 
   it('`unpair` clears the authorized chat and reports', async () => {
     await vault.set('telegram_authorized_chat_id', '111');
-    const code = await telegramDef.subcommands!.unpair!.run(ctx());
+    const code = await telegramDef.subcommands?.unpair?.run(ctx());
     expect(code).toBe(0);
     expect(writeOut.join('')).toContain('unpaired');
     expect(await vault.get('telegram_authorized_chat_id')).toBeNull();
   });
 
   it('`unpair` is a no-op when nothing is paired', async () => {
-    const code = await telegramDef.subcommands!.unpair!.run(ctx());
+    const code = await telegramDef.subcommands?.unpair?.run(ctx());
     expect(code).toBe(0);
     expect(writeOut.join('')).toContain('no pairing was active');
   });
@@ -117,7 +117,7 @@ describe('telegram channel subcommands (registered on ChannelDef)', () => {
       // flow (wires the session's permission resolver) instead of
       // delegating to `startChannel`.
       await expect(
-        telegramDef.subcommands!.pair!.run(ctx({ startChannel, session: { setPermissionResolver } })),
+        telegramDef.subcommands?.pair?.run(ctx({ startChannel, session: { setPermissionResolver } })),
       ).rejects.toThrow(/token/i);
       expect(setPermissionResolver).toHaveBeenCalledTimes(1);
       expect(startChannel).not.toHaveBeenCalled();
@@ -131,7 +131,7 @@ describe('telegram channel subcommands (registered on ChannelDef)', () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
     try {
       const startChannel = vi.fn(async () => 0);
-      const code = await telegramDef.subcommands!.pair!.run(ctx({ startChannel }));
+      const code = await telegramDef.subcommands?.pair?.run(ctx({ startChannel }));
       expect(code).toBe(1);
       expect(startChannel).not.toHaveBeenCalled();
       expect(writeErr.join('')).toMatch(/TTY/);
@@ -146,7 +146,7 @@ describe('telegram channel subcommands (registered on ChannelDef)', () => {
       args: { positional: [], flags: {} },
       startChannel: async () => 0,
     };
-    const code = await telegramDef.subcommands!.status!.run(badCtx);
+    const code = await telegramDef.subcommands?.status?.run(badCtx);
     expect(code).toBe(1);
     expect(writeErr.join('')).toContain('vault unavailable');
   });


### PR DESCRIPTION
## Scope

The "channels" slice of the repo-wide **Guard, don't chain** assert-sweep (AGENTS.md). In the assigned packages, every non-null assertion (`x!`, `x!.y`, `arr[i]!`) and every optional chain of depth ≥2 is replaced with a guard clause: `assertDefined`/`invariant` (from `@moxxy/sdk`) where absence is impossible-by-construction, or a behavior-preserving early return / single-level `?.` / `?? fallback` where absence is a normal runtime path.

Packages (all `@moxxy/sdk`-dependent, so guards import cleanly):

- `@moxxy/plugin-channel-discord`
- `@moxxy/plugin-channel-signal`
- `@moxxy/plugin-channel-slack`
- `@moxxy/plugin-channel-whatsapp`
- `@moxxy/plugin-telegram`

`@moxxy/plugin-channel-imessage` was authored under the rule already — enumeration found zero in-scope sites, so it is unchanged (no bump).

## Per-package site counts (non-null assertions + deep chains → 0 remaining)

| package | non-null sites removed | `assertDefined`/`invariant` added | notes |
|---|---|---|---|
| discord | ~18 | 7 | source guards + test `!`→`?.` |
| signal | ~24 | 12 | inbound-drop paths untouched |
| slack | ~11 | 0 | all in the test file (`!`→`?.`); source had no in-scope sites |
| whatsapp | ~15 | 3 | JID normalizer keeps `null`-on-bad-input |
| telegram | ~28 | 9 | incl. `isAllowedUrl`, FramePump |

After the sweep, the enumeration greps report **zero** non-null assertions across all six packages. Remaining `?.`-chain grep hits are all either the `logger?.method?.()` optional-logger idiom (both object and method optional by design — genuinely optional, kept), two separate single-level `?.` reads on one line, or test-file `subcommands?.status?.run()` chains whose own `expect()` fails loudly.

Definite-assignment class fields (`foo!: Type`, out of scope): **0** across all six packages.

## Semantics notes (load-bearing paths preserved)

- **Silent inbound-drop gates preserved exactly** — never converted to throws: signal `handleDataMessage` unauthorized-sender `warnDrop(...); return;`, discord `extractInboundMessage` attachments falling back to `[]`, whatsapp `normalizeJid` returning `null` on malformed input.
- **Security DENY/fallback preserved**: every `this.deciderFn!` was hoisted to a local *after* its existing `if (!this.deciderFn) return { mode: 'deny' | defaultOption }` guard — no new throw on the missing-decider path.
- **`isAllowedUrl` stays fail-closed**: `m[1]!` -> `(m[1] ?? '')`, so a missing scheme capture yields `has('')` = `false` = URL rejected.
- **Loud throws only where impossible-by-construction**: regex mandatory capture groups, `String.split(...)[0]` (always >=1 element), post-`length`-guard `Array.shift()`, binary-search indices within bounds, `parts[0]` from a splitter that guarantees a chunk. Each `assertDefined` message states the invariant. The old `!` would have thrown a cryptic `TypeError` at the same point.

## Gate (from worktree root, each exit code checked directly)

| command | exit |
|---|---|
| `pnpm install` | 0 |
| `pnpm build` | 0 |
| `pnpm typecheck` | 0 |
| `pnpm lint` | 0 |
| `pnpm test` | 0 |
| `pnpm check:deps` | 0 |

No flakes observed. Changed files scanned for NUL/control bytes (grep + Python UTF-8/control-char validation): all 35 clean.

Do not merge — part of a coordinated multi-group sweep.
