### PR TITLE
refactor(desktop): replace non-null assertions and deep optional chains with guards

### DIFF
--- a/.changeset/assert-sweep-desktop.md
+++ b/.changeset/assert-sweep-desktop.md
@@ -1,0 +1,21 @@
+---
+'@moxxy/desktop': patch
+'fixture-recorder': patch
+'@moxxy/anonymizer': patch
+'@moxxy/chat-model': patch
+'@moxxy/desktop-host': patch
+'@moxxy/desktop-ipc-contract': patch
+---
+
+Replace non-null assertions (`x!`) and deep optional chains (`a?.b?.c`) with
+guard clauses across the desktop-group packages, per the "Guard, don't chain"
+rule. Behaviour is preserved: silent-absence paths keep their early return /
+single-level `?.` / fallback, while accesses that are impossible-by-construction
+(in-bounds loop indices, mandatory regex capture groups, class invariants,
+checked preconditions) now fail loudly at the assumption site via
+`assertDefined`/`invariant` instead of a cryptic downstream `undefined`.
+
+Browser-bundled code (`@moxxy/chat-model` and the desktop renderer) uses a small
+dependency-free local guard helper rather than importing the helpers from the
+`@moxxy/sdk` root barrel, which transitively pulls Node-only modules (`node:fs`)
+and cannot be bundled for the browser.

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -283,7 +283,11 @@ async function createWindow(): Promise<void> {
   }
 
   if (isDev) {
-    await mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL']!);
+    const rendererUrl = process.env['ELECTRON_RENDERER_URL'];
+    if (rendererUrl === undefined) {
+      throw new Error('ELECTRON_RENDERER_URL is set by electron-vite in dev mode');
+    }
+    await mainWindow.loadURL(rendererUrl);
     mainWindow.webContents.openDevTools({ mode: 'detach' });
   } else if (loopback) {
     // Prod: serve from the loopback http origin (Clerk-friendly secure
@@ -503,7 +507,11 @@ if (!gotSingleInstanceLock) {
   // resolves back to us; a packaged app registers via electron-builder's
   // `protocols` / CFBundleURLTypes.
   if (process.defaultApp && process.argv.length >= 2) {
-    app.setAsDefaultProtocolClient('moxxy', process.execPath, [path.resolve(process.argv[1]!)]);
+    const entryScript = process.argv[1];
+    if (entryScript === undefined) {
+      throw new Error('argv[1] is present when argv.length >= 2');
+    }
+    app.setAsDefaultProtocolClient('moxxy', process.execPath, [path.resolve(entryScript)]);
   } else {
     app.setAsDefaultProtocolClient('moxxy');
   }

--- a/apps/desktop/electron/main/shell-updater.ts
+++ b/apps/desktop/electron/main/shell-updater.ts
@@ -93,7 +93,8 @@ export async function installFullAppUpdate(opts: {
 
   opts.onProgress({ phase: 'download', message: 'Fetching installer…' });
   const check = await autoUpdater.checkForUpdates();
-  if (!check?.updateInfo?.version) {
+  const updateInfo = check?.updateInfo;
+  if (!updateInfo?.version) {
     throw new Error('No installer found for this release.');
   }
   await autoUpdater.downloadUpdate();

--- a/apps/desktop/electron/main/ws-bridge.test.ts
+++ b/apps/desktop/electron/main/ws-bridge.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import WebSocket from 'ws';
 import { splitConnectUrl } from '@moxxy/client-transport-ws';
 import { encodeWsBearerProtocol, MOXXY_WS_SUBPROTOCOL } from '@moxxy/sdk/server';
+import { assertDefined } from '@moxxy/sdk';
 import type { MobileGatewayStatus } from '@moxxy/desktop-ipc-contract';
 import {
   WebSocketCommandBus,
@@ -395,7 +396,8 @@ describe('MobileGatewayManager', () => {
       startSpy: () => fake.server,
     });
     // Wrap startWsBridge to delay the first resolve until we release the gate.
-    const original = rt.wsBridge!.startWsBridge as (b: unknown, o: unknown) => Promise<unknown>;
+    assertDefined(rt.wsBridge, 'ws bridge runtime');
+    const original = rt.wsBridge.startWsBridge as (b: unknown, o: unknown) => Promise<unknown>;
     (rt.wsBridge as { startWsBridge: unknown }).startWsBridge = async (
       bus: unknown,
       o: unknown,
@@ -508,7 +510,8 @@ describe('MobileGatewayManager — E2E proxy relay', () => {
     const lastOrigins = fake.originSets.at(-1) ?? [];
     expect(lastOrigins).toContain('https://uuid123.proxy.moxxy.ai');
     // The shipped mobile app parser recovers the token + fingerprint from the QR.
-    const parsed = splitConnectUrl(status.connectUrl!);
+    assertDefined(status.connectUrl, 'gateway connect url');
+    const parsed = splitConnectUrl(status.connectUrl);
     expect(parsed.token).toBe(status.token);
     expect(parsed.fingerprint).toBe('AGENT_FP');
   });
@@ -575,7 +578,8 @@ describe('QR ↔ mobile app round-trip', () => {
     expect(status.connectUrl).toBeTruthy();
 
     // The mobile app scans this exact string off the QR.
-    const parsed = splitConnectUrl(status.connectUrl!);
+    assertDefined(status.connectUrl, 'gateway connect url');
+    const parsed = splitConnectUrl(status.connectUrl);
     // The token round-trips intact…
     expect(parsed.token).toBe(status.token);
     // …and the bare gateway URL is a ws:// address with the bound port and the

--- a/apps/desktop/src/apps/AppCard.tsx
+++ b/apps/desktop/src/apps/AppCard.tsx
@@ -150,18 +150,18 @@ export function AppCard({
         </div>
       ) : state === 'installing' || installing ? (
         (() => {
-          const known = !!progress && progress.totalBytes > 0;
-          const pct = known
-            ? Math.round(Math.min(100, (progress!.receivedBytes / progress!.totalBytes) * 100))
+          const active = progress && progress.totalBytes > 0 ? progress : null;
+          const pct = active
+            ? Math.round(Math.min(100, (active.receivedBytes / active.totalBytes) * 100))
             : null;
-          const label = known
-            ? `Downloading ${mb(progress!.receivedBytes)} of ${mb(progress!.totalBytes)}`
+          const label = active
+            ? `Downloading ${mb(active.receivedBytes)} of ${mb(active.totalBytes)}`
             : 'Downloading…';
           return (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
               <div style={{ fontSize: 12, color: 'var(--color-text-dim)' }} aria-hidden>
-                {known
-                  ? `Downloading… ${mb(progress!.receivedBytes)} / ${mb(progress!.totalBytes)}`
+                {active
+                  ? `Downloading… ${mb(active.receivedBytes)} / ${mb(active.totalBytes)}`
                   : 'Downloading…'}
               </div>
               <div

--- a/apps/desktop/src/apps/anonymizer/ner/aggregate.ts
+++ b/apps/desktop/src/apps/anonymizer/ner/aggregate.ts
@@ -1,4 +1,5 @@
 import type { PiiCategory, PiiSpan } from '@moxxy/anonymizer';
+import { assertDefined } from '@/lib/assert';
 
 /** One per-token classification result from transformers.js (BIO-tagged). */
 export interface NerToken {
@@ -17,7 +18,13 @@ const TYPE_TO_CATEGORY: Readonly<Record<string, PiiCategory | undefined>> = {
 
 function parseLabel(entity: string): { bio: string; type: string } {
   const m = /^([BILUES])-(.+)$/.exec(entity);
-  if (m) return { bio: m[1]!, type: m[2]! };
+  if (m) {
+    const bio = m[1];
+    const type = m[2];
+    assertDefined(bio, 'BIO capture group is present when the label matches');
+    assertDefined(type, 'type capture group is present when the label matches');
+    return { bio, type };
+  }
   return { bio: 'B', type: entity };
 }
 
@@ -41,7 +48,9 @@ function escapeRegExp(s: string): string {
  *  chars. */
 function isBoundaryAt(text: string, i: number): boolean {
   if (i < 0 || i >= text.length) return true;
-  return !/[\p{L}\p{N}]/u.test(text[i]!);
+  const ch = text[i];
+  assertDefined(ch, 'char index within text bounds');
+  return !/[\p{L}\p{N}]/u.test(ch);
 }
 
 /** True when the half-open range `[start, end)` is bounded by non-word chars (or

--- a/apps/desktop/src/apps/anonymizer/ner/ner.worker.ts
+++ b/apps/desktop/src/apps/anonymizer/ner/ner.worker.ts
@@ -69,7 +69,8 @@ env.remotePathTemplate = '{model}/resolve/{revision}/';
 // `wasmPaths` is unset — setting it here, before the pipeline creates the ORT
 // session, defeats that fallback). Force single-threaded (no SharedArrayBuffer /
 // COOP-COEP) and no proxy worker so nothing tries to re-fetch a loader at runtime.
-const wasmBackend = env.backends?.onnx?.wasm;
+const onnxBackend = env.backends?.onnx;
+const wasmBackend = onnxBackend?.wasm;
 if (wasmBackend) {
   wasmBackend.wasmPaths = ortWasmBase();
   wasmBackend.numThreads = 1;
@@ -94,10 +95,11 @@ function getNer(): Promise<NerFn> {
 ctx.onmessage = (e: MessageEvent): void => {
   const msg = e.data as { type?: string; id?: number; text?: string };
   if (msg?.type !== 'infer' || typeof msg.text !== 'string') return;
+  const text = msg.text;
   void (async () => {
     try {
       const ner = await getNer();
-      const tokens = await ner(msg.text!);
+      const tokens = await ner(text);
       ctx.postMessage({ type: 'result', id: msg.id, tokens });
     } catch (err) {
       ctx.postMessage({

--- a/apps/desktop/src/apps/anonymizer/ner/useNer.test.tsx
+++ b/apps/desktop/src/apps/anonymizer/ner/useNer.test.tsx
@@ -11,6 +11,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { assertDefined } from '@moxxy/sdk';
 import { useNer } from './useNer';
 import type { NerToken } from './aggregate';
 
@@ -63,13 +64,15 @@ afterEach(() => {
 describe('useNer', () => {
   it('aggregates the worker reply into PII spans on the happy path', async () => {
     const { result } = renderHook(() => useNer());
-    const worker = FakeWorker.instances[0]!;
+    const worker = FakeWorker.instances[0];
+    assertDefined(worker, 'ner worker instance');
 
     let spans: readonly unknown[] = [];
     await act(async () => {
       const p = result.current.detectNames('Alice Smith met Bob');
       // The hook posts one infer request; answer it with two BIO tokens.
-      const req = worker.posted.at(-1)!;
+      const req = worker.posted.at(-1);
+      assertDefined(req, 'posted infer request');
       worker.reply(req.id, [
         { entity: 'B-PER', word: 'Alice', index: 0, score: 0.99 },
         { entity: 'I-PER', word: 'Smith', index: 1, score: 0.99 },
@@ -83,7 +86,8 @@ describe('useNer', () => {
 
   it('short-circuits detectNames after the worker dies (no leaked pending request)', async () => {
     const { result } = renderHook(() => useNer());
-    const worker = FakeWorker.instances[0]!;
+    const worker = FakeWorker.instances[0];
+    assertDefined(worker, 'ner worker instance');
 
     // The worker fails to load — the hook flips to `error` and drops the worker.
     await act(async () => {
@@ -106,7 +110,8 @@ describe('useNer', () => {
 
   it('returns [] for blank input without touching the worker', async () => {
     const { result } = renderHook(() => useNer());
-    const worker = FakeWorker.instances[0]!;
+    const worker = FakeWorker.instances[0];
+    assertDefined(worker, 'ner worker instance');
     let spans: readonly unknown[] = [{ sentinel: true }];
     await act(async () => {
       spans = await result.current.detectNames('   ');
@@ -136,7 +141,8 @@ describe('useNer', () => {
 
   it('settles in-flight requests to [] when the worker errors mid-flight', async () => {
     const { result } = renderHook(() => useNer());
-    const worker = FakeWorker.instances[0]!;
+    const worker = FakeWorker.instances[0];
+    assertDefined(worker, 'ner worker instance');
 
     let spans: readonly unknown[] | 'unsettled' = 'unsettled';
     const p = result.current.detectNames('Alice Smith met Bob').then((s) => {

--- a/apps/desktop/src/chat/AskSheet.test.tsx
+++ b/apps/desktop/src/chat/AskSheet.test.tsx
@@ -7,6 +7,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { AskRequest } from '@moxxy/desktop-ipc-contract';
+import { assertDefined } from '@moxxy/sdk';
 
 const respond = vi.fn();
 vi.mock('@moxxy/client-core', () => ({
@@ -52,7 +53,9 @@ describe('AskSheet — permission gate operability', () => {
 
   it('Escape denies (safe default) instead of leaving the turn parked', () => {
     const { container } = render(<AskSheet ask={permissionAsk} />);
-    fireEvent.keyDown(container.querySelector('[role="dialog"]')!, { key: 'Escape' });
+    const dialog = container.querySelector('[role="dialog"]');
+    assertDefined(dialog, 'permission dialog element');
+    fireEvent.keyDown(dialog, { key: 'Escape' });
     expect(respond).toHaveBeenCalledWith('r1', { mode: 'deny' });
   });
 
@@ -96,11 +99,12 @@ describe('AskSheet — approval gate operability', () => {
   });
 
   it('Escape never auto-confirms when the default option is destructive', () => {
+    assertDefined(approvalAsk.approval, 'approval payload');
     const dangerDefault: AskRequest = {
       ...approvalAsk,
       requestId: 'r3',
       approval: {
-        ...approvalAsk.approval!,
+        ...approvalAsk.approval,
         defaultOptionId: 'no',
         options: [
           { id: 'yes', label: 'Approve' },

--- a/apps/desktop/src/chat/AskSheet.tsx
+++ b/apps/desktop/src/chat/AskSheet.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, useCallback, useRef, useState } from 'react';
+import { assertDefined } from '@/lib/assert';
 import { summarizeArgs, oneLine } from '@moxxy/chat-model';
 import type { AskRequest, ApprovalRequest, ApprovalOption } from '@moxxy/desktop-ipc-contract';
 import { Icon } from '@moxxy/desktop-ui';
@@ -26,7 +27,8 @@ export function AskSheet({ ask }: { readonly ask: AskRequest }): JSX.Element {
 }
 
 function WorkflowSheet({ ask }: { readonly ask: AskRequest }): JSX.Element {
-  const workflow = ask.workflow!;
+  const workflow = ask.workflow;
+  assertDefined(workflow, 'WorkflowSheet is only rendered for a workflow ask');
   const [reply, setReply] = useState('');
   const send = (): void => askStore.respond(ask.requestId, { text: reply.trim() });
 
@@ -128,8 +130,10 @@ function ApprovalSheet({
     }
     askStore.respond(ask.requestId, { optionId: opt.id });
   };
-  const sendText = (): void =>
-    askStore.respond(ask.requestId, { optionId: textOption!.id, text: text.trim() });
+  const sendText = (): void => {
+    assertDefined(textOption, 'sendText is only reachable once a text option is selected');
+    askStore.respond(ask.requestId, { optionId: textOption.id, text: text.trim() });
+  };
 
   // Escape in the text sub-step backs out to the options; in the options view
   // it picks the default option only when that default is non-destructive (we

--- a/apps/desktop/src/chat/Transcript.test.tsx
+++ b/apps/desktop/src/chat/Transcript.test.tsx
@@ -171,7 +171,8 @@ describe('Transcript stick-to-bottom wiring', () => {
       />,
     );
 
-    act(() => captured.props?.atTopStateChange?.(true));
+    const onAtTop = captured.props?.atTopStateChange;
+    act(() => onAtTop?.(true));
     rerender(
       <Transcript
         events={[e1]}

--- a/apps/desktop/src/chat/Transcript.tsx
+++ b/apps/desktop/src/chat/Transcript.tsx
@@ -150,7 +150,8 @@ export function Transcript({
   // Changes on APPENDS only (new last row or streaming chunk) — stable
   // across upward-pagination prepends, so paging in history never fakes an
   // unread hint or flickers the jump button.
-  const lastKey = nodes.length > 0 ? keyOf(nodes[nodes.length - 1]!) : '';
+  const lastNode = nodes.length > 0 ? nodes[nodes.length - 1] : undefined;
+  const lastKey = lastNode ? keyOf(lastNode) : '';
   const newBelow = useNewContentBelow(atBottom, `${lastKey}:${streamingText.length}`);
 
   const jumpToLatest = useCallback(() => {

--- a/apps/desktop/src/chat/blocks/EventBlockView.test.tsx
+++ b/apps/desktop/src/chat/blocks/EventBlockView.test.tsx
@@ -8,6 +8,7 @@
 import { describe, expect, it } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { MoxxyEvent } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { EventBlockView } from './EventBlockView';
 
 function userPrompt(extra: Partial<MoxxyEvent>): MoxxyEvent {
@@ -36,7 +37,9 @@ describe('EventBlockView — ambient trigger marker', () => {
 
   it('reveals the full prompt when the marker is expanded', () => {
     render(<EventBlockView event={userPrompt({ origin: { kind: 'schedule', name: 'daily' } })} />);
-    fireEvent.click(screen.getByTestId('block-trigger').querySelector('button')!);
+    const triggerButton = screen.getByTestId('block-trigger').querySelector('button');
+    assertDefined(triggerButton, 'trigger expand button');
+    fireEvent.click(triggerButton);
     expect(screen.getByText(/PAYLOAD-BODY-12345/)).toBeTruthy();
   });
 

--- a/apps/desktop/src/chat/chat-surface/RenameWorkspaceModal.test.tsx
+++ b/apps/desktop/src/chat/chat-surface/RenameWorkspaceModal.test.tsx
@@ -5,6 +5,7 @@
  */
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { assertDefined } from '@moxxy/sdk';
 import { RenameWorkspaceModal } from './RenameWorkspaceModal';
 
 const desk = { id: 'd1', name: 'old name', cwd: '/tmp/work' };
@@ -31,7 +32,8 @@ describe('RenameWorkspaceModal — rejected rename', () => {
     );
     render(<RenameWorkspaceModal desk={desk} onSubmit={onSubmit} onClose={() => {}} />);
     fireEvent.change(screen.getByDisplayValue('old name'), { target: { value: 'new name' } });
-    const form = screen.getByRole('button', { name: /Renam/ }).closest('form')!;
+    const form = screen.getByRole('button', { name: /Renam/ }).closest('form');
+    assertDefined(form, 'rename form element');
     fireEvent.submit(form);
     fireEvent.submit(form);
     expect(onSubmit).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/chat/chat-surface/suggestions.ts
+++ b/apps/desktop/src/chat/chat-surface/suggestions.ts
@@ -1,4 +1,5 @@
 import type { MoxxyEvent } from '@moxxy/sdk';
+import { assertDefined } from '@/lib/assert';
 
 /** Hand-tuned starter prompts shown when the transcript is empty. */
 export const COLD_START_SUGGESTIONS: ReadonlyArray<string> = [
@@ -24,7 +25,8 @@ export const COLD_START_SUGGESTIONS: ReadonlyArray<string> = [
 export function deriveSuggestions(events: ReadonlyArray<MoxxyEvent>): ReadonlyArray<string> {
   if (events.length === 0) return COLD_START_SUGGESTIONS.slice(0, 3);
   for (let i = events.length - 1; i >= 0; i--) {
-    const e = events[i]!;
+    const e = events[i];
+    assertDefined(e, 'event index within bounds');
     if (e.type === 'assistant_message') {
       const topic = pickTopic(e.content);
       const list = ['Continue', 'Tell me more'];
@@ -54,12 +56,24 @@ function pickTopic(text: string): string | null {
   const last = trimmed.split(/[.!?]\s+/).filter(Boolean).pop() ?? trimmed;
   // 1. Backticked spans (almost always a thing — function, file, tool).
   const ticks = /`([^`]{2,60})`/.exec(last);
-  if (ticks) return ticks[1]!.trim();
+  if (ticks) {
+    const inner = ticks[1];
+    assertDefined(inner, 'backtick capture group is present when the pattern matches');
+    return inner.trim();
+  }
   // 2. Quoted spans.
   const quoted = /["“]([A-Za-z][^"”]{2,60})["”]/.exec(last);
-  if (quoted) return quoted[1]!.trim();
+  if (quoted) {
+    const inner = quoted[1];
+    assertDefined(inner, 'quoted capture group is present when the pattern matches');
+    return inner.trim();
+  }
   // 3. Sequences of Capitalised Words.
   const cap = /([A-Z][\w-]+(?:\s+[A-Z][\w-]+){0,4})/.exec(last);
-  if (cap) return cap[1]!.trim();
+  if (cap) {
+    const inner = cap[1];
+    assertDefined(inner, 'capitalised-words capture group is present when the pattern matches');
+    return inner.trim();
+  }
   return null;
 }

--- a/apps/desktop/src/chat/command-palette/ArgsForm.tsx
+++ b/apps/desktop/src/chat/command-palette/ArgsForm.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState } from 'react';
+import { assertDefined } from '@/lib/assert';
 import { Button, Icon, Modal, TextInput } from '@moxxy/desktop-ui';
 import { humanize } from './steppers';
 import type { ArgStep, CommandInfo } from './types';
@@ -26,7 +27,12 @@ export function ArgsForm({
   readonly onCancel: () => void;
 }): JSX.Element {
   const [values, setValues] = useState<string[]>(() => steps.map(() => ''));
-  const canRun = steps.every((_, i) => values[i]!.trim().length > 0) && !running;
+  const canRun =
+    steps.every((_, i) => {
+      const v = values[i];
+      assertDefined(v, 'values holds one entry per step');
+      return v.trim().length > 0;
+    }) && !running;
 
   return (
     <Modal title={humanize(command.name)} onClose={onCancel} width={520}>

--- a/apps/desktop/src/chat/composer/UsagePanel.tsx
+++ b/apps/desktop/src/chat/composer/UsagePanel.tsx
@@ -329,7 +329,13 @@ function CompRow({
 function Sparkline({ series }: { readonly series: ReadonlyArray<number> }): JSX.Element {
   const tail = series.slice(-44);
   const max = Math.max(...tail, 1);
-  const growing = tail.length >= 4 && tail[tail.length - 1]! > tail[0]! * 1.5;
+  const lastPoint = tail[tail.length - 1];
+  const firstPoint = tail[0];
+  const growing =
+    tail.length >= 4 &&
+    lastPoint !== undefined &&
+    firstPoint !== undefined &&
+    lastPoint > firstPoint * 1.5;
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 2 }}>
       <div style={{ flex: 1, display: 'flex', alignItems: 'flex-end', gap: 1, height: 22 }}>

--- a/apps/desktop/src/chat/useFocusTrap.ts
+++ b/apps/desktop/src/chat/useFocusTrap.ts
@@ -12,6 +12,7 @@
  * each re-implement (divergent) trap logic.
  */
 import { useEffect, type RefObject } from 'react';
+import { assertDefined } from '@/lib/assert';
 
 const FOCUSABLE =
   'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
@@ -54,8 +55,10 @@ export function useFocusTrap({ containerRef, initialFocusRef, onEscape }: FocusT
         e.preventDefault();
         return;
       }
-      const first = focusable[0]!;
-      const last = focusable[focusable.length - 1]!;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      assertDefined(first, 'first focusable element present when the list is non-empty');
+      assertDefined(last, 'last focusable element present when the list is non-empty');
       const activeInside = container.contains(document.activeElement);
       if (e.shiftKey) {
         if (!activeInside || document.activeElement === first) {

--- a/apps/desktop/src/collaborate/CollaboratePanel.a11y.test.tsx
+++ b/apps/desktop/src/collaborate/CollaboratePanel.a11y.test.tsx
@@ -13,6 +13,7 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { __setApiOverride } from '@moxxy/client-core';
+import { assertDefined } from '@moxxy/sdk';
 
 // A running collaboration whose board has one claimed item ("api.ts") — folded
 // by pairToolEvents into the task chip the TaskModal opens from. Built via
@@ -92,7 +93,8 @@ describe('CollaboratePanel TaskModal accessibility', () => {
     const labelledBy = dialog.getAttribute('aria-labelledby');
     expect(labelledBy).toBeTruthy();
     // The label target is the task title.
-    expect(document.getElementById(labelledBy!)?.textContent).toMatch(/api\.ts/i);
+    assertDefined(labelledBy, 'aria-labelledby target id');
+    expect(document.getElementById(labelledBy)?.textContent).toMatch(/api\.ts/i);
   });
 
   it('moves focus into the dialog on open (not left on the obscured trigger)', () => {

--- a/apps/desktop/src/collaborate/CollaboratePanel.tsx
+++ b/apps/desktop/src/collaborate/CollaboratePanel.tsx
@@ -168,7 +168,8 @@ export function CollaboratePanel({
     else await runCmd('collab_say', `${channel === 'all' ? 'all' : channel} ${body}`);
   };
 
-  const paused = collab?.control?.paused ?? false;
+  const control = collab?.control;
+  const paused = control?.paused ?? false;
 
   const visibleMessages = useMemo(
     () => (collab ? filterCollabMessages(collab.messages, channel) : []),

--- a/apps/desktop/src/collaborate/collab-view.ts
+++ b/apps/desktop/src/collaborate/collab-view.ts
@@ -6,6 +6,7 @@
  * unchanged; the panel imports these instead of declaring them inline.
  */
 import type { Block, CollaborationBlock, CollabMsgView } from '@moxxy/chat-model';
+import { invariant } from '@/lib/assert';
 
 /** Status-dot colour for an agent row in the left rail. */
 export function dotColor(status: string): string {
@@ -26,7 +27,8 @@ export function taskChipBg(status: string): string {
 /** The most recent `collab` block in a folded block list, or undefined. */
 export function latestCollab(blocks: ReadonlyArray<Block>): CollaborationBlock | undefined {
   for (let i = blocks.length - 1; i >= 0; i--) {
-    const b = blocks[i]!;
+    const b = blocks[i];
+    invariant(b !== undefined, 'block index within bounds');
     if (b.kind === 'collab') return b;
   }
   return undefined;

--- a/apps/desktop/src/focus/FocusWidget.test.tsx
+++ b/apps/desktop/src/focus/FocusWidget.test.tsx
@@ -23,6 +23,7 @@ import { act, cleanup, render, screen, fireEvent, waitFor, within } from '@testi
 import { __setApiOverride } from '@moxxy/client-core';
 import { askStore, chatStore } from '@moxxy/client-core';
 import type { MoxxyEvent } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import type { AskRequest, ThemePreference } from '@moxxy/desktop-ipc-contract';
 import { FocusWidget } from './FocusWidget';
 import { __resetThemeForTests } from '@/lib/useTheme';
@@ -389,7 +390,8 @@ describe('FocusWidget stages', () => {
       expect(spy.invokes.some((i) => i.channel === 'focus.dragStart')).toBe(true);
       const move = spy.invokes.find((i) => i.channel === 'focus.dragMove');
       expect(move).toBeTruthy();
-      expect(move!.args).toEqual({ screenX: 690, screenY: 470 });
+      assertDefined(move, 'focus.dragMove invoke');
+      expect(move.args).toEqual({ screenX: 690, screenY: 470 });
       expect(spy.invokes.some((i) => i.channel === 'focus.dragEnd')).toBe(true);
     });
     expect(spy.invokes.some((i) => i.channel === 'focus.moveBy')).toBe(false);
@@ -481,7 +483,8 @@ describe('FocusWidget bidirectional sync', () => {
     await waitFor(() => {
       const load = spy.invokes.find((i) => i.channel === 'chat.loadHistory');
       expect(load).toBeTruthy();
-      expect((load!.args as { workspaceId: string }).workspaceId).toBe('ws-test');
+      assertDefined(load, 'chat.loadHistory invoke');
+      expect((load.args as { workspaceId: string }).workspaceId).toBe('ws-test');
     });
     await waitFor(() => {
       expect(screen.getByText(/cached assistant answer/i)).toBeTruthy();
@@ -509,8 +512,9 @@ describe('FocusWidget bidirectional sync', () => {
     await waitFor(() => {
       const turnCall = spy.invokes.find((i) => i.channel === 'session.runTurn');
       expect(turnCall).toBeTruthy();
-      expect((turnCall!.args as { prompt: string }).prompt).toBe('hello from focus');
-      expect((turnCall!.args as { workspaceId: string }).workspaceId).toBe(
+      assertDefined(turnCall, 'session.runTurn invoke');
+      expect((turnCall.args as { prompt: string }).prompt).toBe('hello from focus');
+      expect((turnCall.args as { workspaceId: string }).workspaceId).toBe(
         'ws-test',
       );
     });
@@ -551,7 +555,8 @@ describe('FocusWidget bidirectional sync', () => {
     await waitFor(() => {
       const turnCall = spy.invokes.find((i) => i.channel === 'session.runTurn');
       expect(turnCall).toBeTruthy();
-      expect((turnCall!.args as { attachments?: ReadonlyArray<{ path: string; name: string }> }).attachments).toEqual([
+      assertDefined(turnCall, 'session.runTurn invoke');
+      expect((turnCall.args as { attachments?: ReadonlyArray<{ path: string; name: string }> }).attachments).toEqual([
         { path: '/tmp/moxxy-focus/screen.png', name: 'screen.png' },
       ]);
     });
@@ -620,7 +625,8 @@ describe('FocusWidget bidirectional sync', () => {
             ?.width === 900,
       );
       expect(update).toBeTruthy();
-      expect(update!.args).toMatchObject({ focusMiniTextSize: { width: 900, height: 700 } });
+      assertDefined(update, 'prefs.update invoke');
+      expect(update.args).toMatchObject({ focusMiniTextSize: { width: 900, height: 700 } });
     });
   });
 
@@ -761,7 +767,8 @@ describe('FocusWidget bidirectional sync', () => {
           (i.args as { width: number; height: number }).width >= 600,
       );
       expect(previewResize).toBeTruthy();
-      expect((previewResize!.args as { height: number }).height).toBeGreaterThanOrEqual(100);
+      assertDefined(previewResize, 'focus.resize preview invoke');
+      expect((previewResize.args as { height: number }).height).toBeGreaterThanOrEqual(100);
     });
   });
 
@@ -819,7 +826,8 @@ describe('FocusWidget bidirectional sync', () => {
           (i.args as { width: number; height: number }).width >= 400,
       );
       expect(previewResize).toBeTruthy();
-      expect((previewResize!.args as { height: number }).height).toBeGreaterThanOrEqual(100);
+      assertDefined(previewResize, 'focus.resize preview invoke');
+      expect((previewResize.args as { height: number }).height).toBeGreaterThanOrEqual(100);
     });
   });
 
@@ -888,7 +896,8 @@ describe('FocusWidget bidirectional sync', () => {
           (i.args as { width: number; height: number }).width >= 520,
       );
       expect(askResize).toBeTruthy();
-      expect((askResize!.args as { height: number }).height).toBeGreaterThanOrEqual(130);
+      assertDefined(askResize, 'focus.resize ask invoke');
+      expect((askResize.args as { height: number }).height).toBeGreaterThanOrEqual(130);
     });
 
     fireEvent.click(screen.getByRole('button', { name: /^allow$/i }));
@@ -896,7 +905,8 @@ describe('FocusWidget bidirectional sync', () => {
     await waitFor(() => {
       const respond = spy.invokes.find((i) => i.channel === 'ask.respond');
       expect(respond).toBeTruthy();
-      expect(respond!.args).toEqual({
+      assertDefined(respond, 'ask.respond invoke');
+      expect(respond.args).toEqual({
         requestId: 'ask-focus-toast',
         response: { mode: 'allow_session' },
       });
@@ -955,7 +965,8 @@ describe('FocusWidget bidirectional sync', () => {
     await waitFor(() => {
       const respond = spy.invokes.find((i) => i.channel === 'ask.respond');
       expect(respond).toBeTruthy();
-      expect(respond!.args).toEqual({
+      assertDefined(respond, 'ask.respond invoke');
+      expect(respond.args).toEqual({
         requestId: 'ask-focus-mini',
         response: { mode: 'allow_always' },
       });
@@ -992,7 +1003,8 @@ describe('FocusWidget bidirectional sync', () => {
           (i.args as { width: number; height: number }).width >= 600,
       );
       expect(askResize).toBeTruthy();
-      expect((askResize!.args as { height: number }).height).toBeGreaterThanOrEqual(210);
+      assertDefined(askResize, 'focus.resize ask invoke');
+      expect((askResize.args as { height: number }).height).toBeGreaterThanOrEqual(210);
     });
   });
 

--- a/apps/desktop/src/focus/useFocusAsk.ts
+++ b/apps/desktop/src/focus/useFocusAsk.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { assertDefined } from '@/lib/assert';
 import { oneLine, summarizeArgs } from '@moxxy/chat-model';
 import { askStore, useActiveAsk } from '@moxxy/client-core';
 import type { ApprovalOption, AskRequest } from '@moxxy/desktop-ipc-contract';
@@ -97,7 +98,8 @@ function buildApprovalPrompt(
   setTextOptionId: (id: string | null) => void,
   setText: (value: string) => void,
 ): FocusAskPrompt {
-  const approval = ask.approval!;
+  const approval = ask.approval;
+  assertDefined(approval, 'buildApprovalPrompt is only called for an approval ask');
   const textOption = textOptionId
     ? approval.options.find((option) => option.id === textOptionId) ?? null
     : null;
@@ -174,7 +176,8 @@ function buildWorkflowPrompt(
   text: string,
   setText: (value: string) => void,
 ): FocusAskPrompt {
-  const workflow = ask.workflow!;
+  const workflow = ask.workflow;
+  assertDefined(workflow, 'buildWorkflowPrompt is only called for a workflow ask');
   const body = [workflow.label, workflow.stepId].filter(Boolean).join(' · ');
 
   return {

--- a/apps/desktop/src/focus/useInactiveReplyPreview.ts
+++ b/apps/desktop/src/focus/useInactiveReplyPreview.ts
@@ -7,6 +7,7 @@ import {
   useSyncExternalStore,
 } from 'react';
 import { chatStore } from '@moxxy/client-core';
+import { assertDefined } from '@/lib/assert';
 
 export interface InactiveReplyPreview {
   readonly text: string;
@@ -59,7 +60,8 @@ function latestAssistantCandidate(workspaceId: string | null): AssistantPreviewC
     });
   }
   for (let i = snap.events.length - 1; i >= 0; i--) {
-    const event = snap.events[i]!;
+    const event = snap.events[i];
+    assertDefined(event, 'event index within bounds');
     if (event.type !== 'assistant_message' || !event.content.trim()) continue;
     return cachedCandidate(workspaceId, {
       key: `message:${event.id ?? event.turnId}:${event.content.length}`,

--- a/apps/desktop/src/focus/useLatestBlock.ts
+++ b/apps/desktop/src/focus/useLatestBlock.ts
@@ -7,6 +7,7 @@
 
 import { useSyncExternalStore } from 'react';
 import type { MoxxyEvent } from '@moxxy/sdk';
+import { assertDefined } from '@/lib/assert';
 import { chatStore } from '@moxxy/client-core';
 
 // ---- Types ---------------------------------------------------------------
@@ -63,7 +64,8 @@ function latestLineFromSnapshot(snap: {
 }): LatestBlock | null {
   if (snap.streamingText.trim()) return { who: 'assistant', text: snap.streamingText };
   for (let i = snap.events.length - 1; i >= 0; i--) {
-    const e = snap.events[i]!;
+    const e = snap.events[i];
+    assertDefined(e, 'event index within bounds');
     if (e.type === 'assistant_message' && e.content.trim()) {
       return { who: 'assistant', text: e.content };
     }

--- a/apps/desktop/src/lib/assert.ts
+++ b/apps/desktop/src/lib/assert.ts
@@ -1,0 +1,29 @@
+/**
+ * Local narrowing guards for the desktop renderer. The renderer is a browser
+ * bundle, and the `@moxxy/sdk` root barrel transitively pulls Node-only modules
+ * (`node:fs` via the JSON file store), so importing sdk's
+ * `assertDefined`/`invariant` from the barrel at runtime breaks the vite build.
+ * These are the same guard-don't-chain helpers, kept dependency-free so they
+ * bundle for the browser. Behaviour matches `@moxxy/sdk`.
+ */
+
+/**
+ * Runtime invariant: throws when `condition` is falsy, narrowing its type
+ * otherwise. State an assumption once, then dereference plainly.
+ */
+export function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(`Invariant violation: ${message}`);
+  }
+}
+
+/**
+ * Asserts `value` is neither `null` nor `undefined`, narrowing to `NonNullable<T>`.
+ * The guard-clause replacement for a non-null assertion (`x!`). Falsy-but-defined
+ * values (`0`, `''`, `false`) pass.
+ */
+export function assertDefined<T>(value: T, message: string): asserts value is NonNullable<T> {
+  if (value === null || value === undefined) {
+    throw new Error(`Expected a defined value: ${message}`);
+  }
+}

--- a/apps/desktop/src/lib/useTheme.ts
+++ b/apps/desktop/src/lib/useTheme.ts
@@ -95,8 +95,10 @@ export function useTheme(): void {
     const onChange = (): void => {
       if (pref === 'system') applyDom();
     };
-    mq?.addEventListener?.('change', onChange);
-    return () => mq?.removeEventListener?.('change', onChange);
+    if (mq) mq.addEventListener?.('change', onChange);
+    return () => {
+      if (mq) mq.removeEventListener?.('change', onChange);
+    };
   }, []);
 }
 

--- a/apps/desktop/src/onboarding/steps/ProviderStep.tsx
+++ b/apps/desktop/src/onboarding/steps/ProviderStep.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import { assertDefined } from '@/lib/assert';
 import { decodeError, toErrorMessage } from '@moxxy/client-core';
 import { api } from '@moxxy/client-core';
 import { retryWhileReconnecting } from '@moxxy/client-core';
@@ -45,7 +46,9 @@ export function ProviderStep({
       .then((list) => {
         if (cancelled || list.length === 0) return;
         setCatalog(list);
-        setProvider((cur) => (list.includes(cur) ? cur : list[0]!));
+        const first = list[0];
+        assertDefined(first, 'catalog has a first entry when non-empty');
+        setProvider((cur) => (list.includes(cur) ? cur : first));
       })
       .catch(() => {
         /* keep static fallback */

--- a/apps/desktop/src/settings/MobileTab.test.tsx
+++ b/apps/desktop/src/settings/MobileTab.test.tsx
@@ -10,6 +10,7 @@ import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { __setApiOverride } from '@moxxy/client-core';
 import type { MobileGatewayStatus } from '@moxxy/desktop-ipc-contract';
+import { assertDefined } from '@moxxy/sdk';
 import { MobileTab } from './MobileTab';
 
 interface IpcSpy {
@@ -99,7 +100,8 @@ describe('MobileTab', () => {
     await waitFor(() => {
       const call = spy.invokes.find((i) => i.channel === 'mobileGateway.setEnabled');
       expect(call).toBeTruthy();
-      expect((call!.args as { enabled: boolean }).enabled).toBe(true);
+      assertDefined(call, 'mobileGateway.setEnabled invoke');
+      expect((call.args as { enabled: boolean }).enabled).toBe(true);
     });
   });
 
@@ -111,7 +113,8 @@ describe('MobileTab', () => {
     await waitFor(() => {
       const img = screen.getByTestId('mobile-qr').querySelector('img');
       expect(img).toBeTruthy();
-      expect(img!.getAttribute('src')).toMatch(/^data:image\/svg\+xml/);
+      assertDefined(img, 'mobile QR img element');
+      expect(img.getAttribute('src')).toMatch(/^data:image\/svg\+xml/);
     });
     // No raw SVG is injected into the DOM (supply-chain hardening).
     expect(screen.getByTestId('mobile-qr').querySelector('svg')).toBeNull();

--- a/apps/desktop/src/settings/ProvidersTab.tsx
+++ b/apps/desktop/src/settings/ProvidersTab.tsx
@@ -393,7 +393,7 @@ function ConfigureProviderModal({
             >
               {REASONING_LEVELS.map((level) => (
                 <option key={level} value={level}>
-                  {level === 'off' ? 'Off' : level[0]!.toUpperCase() + level.slice(1)}
+                  {level === 'off' ? 'Off' : (level[0] ?? '').toUpperCase() + level.slice(1)}
                 </option>
               ))}
             </select>

--- a/apps/desktop/src/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/settings/SettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { assertDefined } from '@/lib/assert';
 import { useSettings } from '@moxxy/client-core';
 import { Skeleton, Icon } from '@moxxy/desktop-ui';
 import { SkillsView } from './SkillsView';
@@ -120,7 +121,9 @@ export function SettingsPanel({
   const [tab, setTab] = useState<Tab>('providers');
   const [query, setQuery] = useState('');
 
-  const active = TAB_DESCRIPTORS.find((d) => d.id === tab) ?? TAB_DESCRIPTORS[0]!;
+  const firstTab = TAB_DESCRIPTORS[0];
+  assertDefined(firstTab, 'TAB_DESCRIPTORS is a non-empty constant list');
+  const active = TAB_DESCRIPTORS.find((d) => d.id === tab) ?? firstTab;
   const ctx: TabContext = { s, query, setQuery };
 
   return (

--- a/apps/desktop/src/settings/UpdateSection.tsx
+++ b/apps/desktop/src/settings/UpdateSection.tsx
@@ -16,6 +16,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react';
+import { assertDefined } from '@/lib/assert';
 import { api } from '@moxxy/client-core';
 import { useAppUpdate } from '@moxxy/client-core';
 import { Section } from './settings-primitives';
@@ -134,7 +135,11 @@ export function UpdateSection(): JSX.Element {
               <button
                 type="button"
                 style={primaryBtn(false)}
-                onClick={() => void api().invoke('onboarding.openExternal', { url: check.releaseUrl! })}
+                onClick={() => {
+                  const url = check?.releaseUrl;
+                  assertDefined(url, 'release URL present when the manual-fallback button is shown');
+                  void api().invoke('onboarding.openExternal', { url });
+                }}
               >
                 Get it manually
               </button>

--- a/apps/desktop/src/settings/shared/useAgentTask.test.tsx
+++ b/apps/desktop/src/settings/shared/useAgentTask.test.tsx
@@ -13,6 +13,7 @@
 import { describe, expect, it, afterEach, vi } from 'vitest';
 import { act, cleanup, renderHook } from '@testing-library/react';
 import { __setApiOverride, chatStore } from '@moxxy/client-core';
+import { assertDefined } from '@moxxy/sdk';
 import { useAgentTask } from './useAgentTask';
 
 interface IpcSpy {
@@ -92,7 +93,8 @@ describe('useAgentTask', () => {
 
     const run = spy.invokes.find((i) => i.channel === 'session.runTurn');
     expect(run).toBeTruthy();
-    expect(run!.args).toEqual({ workspaceId: 'ws-test', prompt: 'PROMPT' });
+    assertDefined(run, 'session.runTurn invoke');
+    expect(run.args).toEqual({ workspaceId: 'ws-test', prompt: 'PROMPT' });
     expect(hide).toHaveBeenCalledWith('t-1');
     expect(result.current.phase).toBe('streaming');
 
@@ -160,7 +162,8 @@ describe('useAgentTask', () => {
     // abort it, not leave it consuming model tokens.
     const abort = spy.invokes.find((i) => i.channel === 'session.abortTurn');
     expect(abort).toBeTruthy();
-    expect((abort!.args as { turnId: string }).turnId).toBe('t-1');
+    assertDefined(abort, 'session.abortTurn invoke');
+    expect((abort.args as { turnId: string }).turnId).toBe('t-1');
   });
 
   it('does NOT abort a turn that already completed', async () => {
@@ -197,7 +200,8 @@ describe('useAgentTask', () => {
       expect(result.current.error).toMatch(/timed out/i);
       const abort = spy.invokes.find((i) => i.channel === 'session.abortTurn');
       expect(abort).toBeTruthy();
-      expect((abort!.args as { turnId: string }).turnId).toBe('t-1');
+      assertDefined(abort, 'session.abortTurn invoke');
+      expect((abort.args as { turnId: string }).turnId).toBe('t-1');
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/shell/ProfileView.tsx
+++ b/apps/desktop/src/shell/ProfileView.tsx
@@ -29,7 +29,8 @@ export function ProfileView({ tier, onClose }: Props): JSX.Element {
   const [confirmSignOut, setConfirmSignOut] = useState(false);
   const [busy, setBusy] = useState(false);
 
-  const email = user?.primaryEmailAddress?.emailAddress ?? null;
+  const primaryEmail = user?.primaryEmailAddress;
+  const email = primaryEmail?.emailAddress ?? null;
   const fullName =
     user?.fullName ?? email ?? prefs?.clerkDisplayName ?? 'Account';
   const joined = user?.createdAt ? new Date(user.createdAt) : null;

--- a/apps/desktop/src/shell/UpdateBanner.tsx
+++ b/apps/desktop/src/shell/UpdateBanner.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState } from 'react';
+import { assertDefined } from '@/lib/assert';
 import { api } from '@moxxy/client-core';
 import { useAppUpdate } from '@moxxy/client-core';
 
@@ -77,9 +78,11 @@ export function UpdateBanner(): JSX.Element | null {
           <button
             type="button"
             style={primaryBtn}
-            onClick={() =>
-              void api().invoke('onboarding.openExternal', { url: check.releaseUrl! })
-            }
+            onClick={() => {
+              const url = check?.releaseUrl;
+              assertDefined(url, 'release URL present when the manual-fallback button is shown');
+              void api().invoke('onboarding.openExternal', { url });
+            }}
           >
             Get it manually
           </button>

--- a/apps/desktop/src/shell/useMenuKeyboard.ts
+++ b/apps/desktop/src/shell/useMenuKeyboard.ts
@@ -67,7 +67,8 @@ export function useMenuKeyboard<T extends HTMLElement>(open: boolean): RefObject
       menu.removeEventListener('keydown', onKey);
       // Restore focus to the trigger when the menu closes (it's removed from
       // the DOM, so focus would otherwise fall back to <body>).
-      restoreRef.current?.focus?.();
+      const toRestore = restoreRef.current;
+      if (toRestore) toRestore.focus?.();
     };
   }, [open]);
 

--- a/apps/desktop/src/shell/useReducedMotion.ts
+++ b/apps/desktop/src/shell/useReducedMotion.ts
@@ -20,8 +20,10 @@ export function useReducedMotion(): boolean {
   return useSyncExternalStore(
     (cb) => {
       const mq = query();
-      mq?.addEventListener?.('change', cb);
-      return () => mq?.removeEventListener?.('change', cb);
+      if (mq) mq.addEventListener?.('change', cb);
+      return () => {
+        if (mq) mq.removeEventListener?.('change', cb);
+      };
     },
     () => !!query()?.matches,
     () => false,

--- a/apps/desktop/src/shell/workspace-sidebar/ProfilePill.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/ProfilePill.tsx
@@ -84,9 +84,10 @@ function ClerkProfilePill(): JSX.Element {
   // Treat a prior on-disk identity as "signed in" while Clerk is still
   // loading so returning users don't flash a "Sign in" prompt on launch.
   const showProfile = signedIn || (!isLoaded && !!prefs?.clerkUserId);
+  const primaryEmail = user?.primaryEmailAddress;
   const displayName =
     user?.fullName ??
-    user?.primaryEmailAddress?.emailAddress ??
+    primaryEmail?.emailAddress ??
     user?.username ??
     prefs?.clerkDisplayName ??
     'Account';
@@ -98,11 +99,13 @@ function ClerkProfilePill(): JSX.Element {
   // privateMetadata is server-only by Clerk's design and never reaches
   // the renderer.
   const claims = (sessionClaims ?? {}) as Record<string, unknown>;
+  const publicMeta = user?.publicMetadata as Record<string, unknown> | undefined;
+  const unsafeMeta = user?.unsafeMetadata as Record<string, unknown> | undefined;
   const tier = formatTier(
-    (user?.publicMetadata as Record<string, unknown> | undefined)?.accountType ??
+    publicMeta?.accountType ??
       claims['accountType'] ??
       claims['account_type'] ??
-      (user?.unsafeMetadata as Record<string, unknown> | undefined)?.accountType,
+      unsafeMeta?.accountType,
   );
   // Single-line profile row, no background — a top border separates it
   // from the workspace list above. Signed-out reads as a sign-in prompt;

--- a/apps/desktop/src/workflows/NodeInspector.test.tsx
+++ b/apps/desktop/src/workflows/NodeInspector.test.tsx
@@ -14,6 +14,7 @@
 import { useReducer } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { assertDefined } from '@moxxy/sdk';
 import { NodeInspector } from './NodeInspector';
 import {
   builderReducer,
@@ -112,7 +113,8 @@ describe('NodeInspector Args (JSON)', () => {
     fireEvent.change(argsField(), {
       target: { value: '{ "__proto__": { "polluted": true }, "constructor": { "x": 1 }, "safe": 2 }' },
     });
-    const last = committed[committed.length - 1]!;
+    const last = committed[committed.length - 1];
+    assertDefined(last, 'last committed args');
     expect(Object.keys(last)).toEqual(['safe']);
     // The global Object.prototype is never polluted by the committed value.
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
@@ -146,7 +148,8 @@ function switchNode(): BuilderNode {
 /** Host backed by the REAL builderReducer so set-case / rename actually apply. */
 function ReducerHarness({ initial }: { initial: BuilderState }): JSX.Element {
   const [state, dispatch] = useReducer(builderReducer, initial);
-  const node = state.nodes.find((n) => n.id === state.selected)!;
+  const node = state.nodes.find((n) => n.id === state.selected);
+  assertDefined(node, 'selected node');
   return <NodeInspector state={state} node={node} dispatch={dispatch} />;
 }
 

--- a/apps/desktop/src/workflows/WorkflowCanvas.tsx
+++ b/apps/desktop/src/workflows/WorkflowCanvas.tsx
@@ -559,7 +559,9 @@ function InsertNodeMenu({
   useEffect(() => {
     itemRefs.current[0]?.focus();
     const surface = restoreFocusRef.current;
-    return () => surface?.focus?.();
+    return () => {
+      if (surface) surface.focus?.();
+    };
   }, [restoreFocusRef]);
 
   const focusItem = (i: number): void => {

--- a/apps/desktop/src/workflows/WorkflowsPanel.test.tsx
+++ b/apps/desktop/src/workflows/WorkflowsPanel.test.tsx
@@ -15,6 +15,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { render, screen, fireEvent, waitFor, within, act, createEvent } from '@testing-library/react';
 import { __setApiOverride } from '@moxxy/client-core';
 import type { MoxxyApi, WorkflowSummary } from '@moxxy/desktop-ipc-contract';
+import { assertDefined } from '@moxxy/sdk';
 import { WorkflowsPanel } from './WorkflowsPanel';
 
 interface Spy {
@@ -249,7 +250,9 @@ describe('WorkflowsPanel — builder', () => {
     await screen.findByTestId('wf-node-skill');
     const picker = await screen.findByTestId('field-action');
     await waitFor(() => expect(picker.tagName).toBe('SELECT'));
-    expect(within(picker).getAllByRole('option')[0]!.textContent).toContain('Select a skill');
+    const firstOption = within(picker).getAllByRole('option')[0];
+    assertDefined(firstOption, 'first select option');
+    expect(firstOption.textContent).toContain('Select a skill');
   });
 
   it('keeps a saved-but-uninstalled skill selectable instead of rewriting it', async () => {

--- a/apps/desktop/src/workflows/canvas/canvas-graph.test.ts
+++ b/apps/desktop/src/workflows/canvas/canvas-graph.test.ts
@@ -6,6 +6,7 @@
  * disconnect-op routing be tested directly without rendering the canvas.
  */
 import { describe, expect, it, vi } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import type { BuilderAction, BuilderEdge, BuilderNode } from '@moxxy/workflows-builder';
 import {
   ANCHOR_OFFSET,
@@ -210,12 +211,13 @@ describe('topoOrder / topologySignature (re-tested at the source module)', () =>
     for (let i = 0; i < N; i++) {
       nodes.push(node(`n${i}`, i > 0 ? { needs: [`n${i - 1}`] } : {}));
     }
-    let order: ReturnType<typeof topoOrder>;
+    let order: ReturnType<typeof topoOrder> | undefined;
     expect(() => {
       order = topoOrder(nodes);
     }).not.toThrow();
     // The chain numbers 1..N in dependency order.
-    expect(order!.get('n0')).toBe(1);
-    expect(order!.get(`n${N - 1}`)).toBe(N);
+    assertDefined(order, 'topo order map');
+    expect(order.get('n0')).toBe(1);
+    expect(order.get(`n${N - 1}`)).toBe(N);
   });
 });

--- a/apps/desktop/src/workflows/canvas/canvas-graph.ts
+++ b/apps/desktop/src/workflows/canvas/canvas-graph.ts
@@ -9,6 +9,7 @@
  * `topoOrder`/`topologySignature` so its existing public surface is unchanged.
  */
 import type { BuilderAction, BuilderEdge, BuilderNode } from '@moxxy/workflows-builder';
+import { assertDefined } from '@/lib/assert';
 
 /** Step-node card width in world (pre-transform) units. */
 export const NODE_W = 200;
@@ -99,7 +100,8 @@ export function nodeAt(
 ): string | null {
   // Iterate in reverse so a node drawn on top wins when cards overlap.
   for (let i = nodes.length - 1; i >= 0; i--) {
-    const n = nodes[i]!;
+    const n = nodes[i];
+    assertDefined(n, 'node index within bounds');
     if (n.id === exclude) continue;
     if (p.x >= n.x && p.x <= n.x + NODE_W && p.y >= n.y && p.y <= n.y + NODE_H) return n.id;
   }
@@ -141,7 +143,8 @@ export function topoOrder(nodes: ReadonlyArray<BuilderNode>): Map<string, number
     const onStack = new Set<string>();
     const stack: Array<{ id: string; expanded: boolean }> = [{ id: root, expanded: false }];
     while (stack.length > 0) {
-      const frame = stack[stack.length - 1]!;
+      const frame = stack[stack.length - 1];
+      assertDefined(frame, 'stack is non-empty inside the while guard');
       const { id } = frame;
       if (depth.has(id)) {
         stack.pop();

--- a/apps/fixture-recorder/src/index.ts
+++ b/apps/fixture-recorder/src/index.ts
@@ -33,7 +33,7 @@ import { builtinToolsPlugin } from '@moxxy/tools-builtin';
 import { defaultModePlugin } from '@moxxy/mode-default';
 import { RecordedProvider } from '@moxxy/testing';
 import type { LLMProvider } from '@moxxy/sdk';
-import { definePlugin, defineProvider } from '@moxxy/sdk';
+import { assertDefined, definePlugin, defineProvider } from '@moxxy/sdk';
 
 interface Flags {
   prompt: string;
@@ -169,7 +169,8 @@ export function parseFlags(argv: ReadonlyArray<string>): Flags | { help: true } 
     verbose: false,
   };
   for (let i = 0; i < argv.length; i++) {
-    const a = argv[i]!;
+    const a = argv[i];
+    assertDefined(a, 'loop index is within the bounds of argv');
     // Consume the value following a value-bearing flag, rejecting a missing or
     // flag-shaped token so a typo (`--prompt --name x`) yields a clear
     // "requires a value" error instead of swallowing the next flag.

--- a/packages/anonymizer/src/assert.ts
+++ b/packages/anonymizer/src/assert.ts
@@ -1,0 +1,17 @@
+/**
+ * Local narrowing guard for this package. `@moxxy/anonymizer` intentionally has
+ * no `@moxxy/sdk` dependency (it also ships inside the offline desktop
+ * anonymizer app), so it can't import sdk's `assertDefined`. This is the same
+ * guard-don't-chain idea: fail loudly at the assumption site instead of a
+ * non-null assertion that hides it. It returns the value so it composes inline.
+ *
+ * Only `null`/`undefined` fail — falsy-but-defined values (`0`, `''`, `false`)
+ * pass. That matters here: several checksum weight tables legitimately contain
+ * `0`, so a truthiness test would wrongly reject them.
+ */
+export function required<T>(value: T, message: string): NonNullable<T> {
+  if (value === null || value === undefined) {
+    throw new Error(`Expected a defined value: ${message}`);
+  }
+  return value as NonNullable<T>;
+}

--- a/packages/anonymizer/src/detect.test.ts
+++ b/packages/anonymizer/src/detect.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { detect } from './detect.js';
+import { required } from './assert.js';
 
 describe('detect', () => {
   it('returns non-overlapping spans in document order', () => {
@@ -11,7 +12,9 @@ describe('detect', () => {
     ]);
     // ascending, non-overlapping
     for (let i = 1; i < spans.length; i++) {
-      expect(spans[i]!.start).toBeGreaterThanOrEqual(spans[i - 1]!.end);
+      const cur = required(spans[i], 'span at index i');
+      const prev = required(spans[i - 1], 'span at index i - 1');
+      expect(cur.start).toBeGreaterThanOrEqual(prev.end);
     }
   });
 
@@ -20,13 +23,14 @@ describe('detect', () => {
     const text = 'pay 4111-1111-1111-1111 now';
     const spans = detect(text, { categories: ['creditCard', 'phone'] });
     expect(spans).toHaveLength(1);
-    expect(spans[0]!.category).toBe('creditCard');
+    expect(required(spans[0], 'first detected span').category).toBe('creditCard');
   });
 
   it('offsets slice back to the matched value', () => {
     const text = 'contact John.Doe@example.com here';
     const [span] = detect(text);
-    expect(text.slice(span!.start, span!.end)).toBe(span!.value);
+    const found = required(span, 'detect returns at least one span');
+    expect(text.slice(found.start, found.end)).toBe(found.value);
   });
 
   it('merges extraSpans (e.g. NER) through overlap resolution', () => {
@@ -59,7 +63,9 @@ describe('detect', () => {
       ['org', 22, 25],
     ]);
     for (let i = 1; i < spans.length; i++) {
-      expect(spans[i]!.start).toBeGreaterThanOrEqual(spans[i - 1]!.end);
+      const cur = required(spans[i], 'span at index i');
+      const prev = required(spans[i - 1], 'span at index i - 1');
+      expect(cur.start).toBeGreaterThanOrEqual(prev.end);
     }
   });
 
@@ -77,7 +83,9 @@ describe('detect', () => {
     expect(Date.now() - t0).toBeLessThan(3_000);
     // Sorted + non-overlapping.
     for (let i = 1; i < spans.length; i++) {
-      expect(spans[i]!.start).toBeGreaterThanOrEqual(spans[i - 1]!.end);
+      const cur = required(spans[i], 'span at index i');
+      const prev = required(spans[i - 1], 'span at index i - 1');
+      expect(cur.start).toBeGreaterThanOrEqual(prev.end);
     }
   });
 });

--- a/packages/anonymizer/src/detect.ts
+++ b/packages/anonymizer/src/detect.ts
@@ -14,6 +14,7 @@ import {
 } from './dictionary.js';
 import type { DetectOptions, PiiCategory, PiiSpan, Region } from './types.js';
 import { ALL_REGIONS } from './types.js';
+import { required } from './assert.js';
 
 /**
  * Overlap-resolution priority. A 16-digit Luhn-valid card overlaps a phone
@@ -87,7 +88,8 @@ function lowerBoundByStart(kept: readonly PiiSpan[], start: number): number {
   let hi = kept.length;
   while (lo < hi) {
     const mid = (lo + hi) >>> 1;
-    if (kept[mid]!.start < start) lo = mid + 1;
+    const midSpan = required(kept[mid], 'binary-search midpoint is within kept bounds');
+    if (midSpan.start < start) lo = mid + 1;
     else hi = mid;
   }
   return lo;
@@ -117,7 +119,7 @@ function resolveOverlaps(spans: readonly PiiSpan[]): PiiSpan[] {
     // The only kept span that can overlap `span` is its left neighbour (the one
     // with the largest start below `span.end`); every earlier kept span ends at
     // or before that neighbour's start, so it cannot reach `span.start`.
-    const left = i > 0 ? kept[i - 1]! : null;
+    const left = i > 0 ? required(kept[i - 1], 'left neighbour is within kept bounds when i > 0') : null;
     const overlaps = left ? span.start < left.end && left.start < span.end : false;
     if (!overlaps) kept.splice(i, 0, span);
   }

--- a/packages/anonymizer/src/redact.ts
+++ b/packages/anonymizer/src/redact.ts
@@ -5,6 +5,7 @@
 
 import { detect } from './detect.js';
 import { shortHash } from './hash.js';
+import { required } from './assert.js';
 import type {
   PiiCategory,
   PiiSpan,
@@ -113,7 +114,7 @@ export function redact(text: string, opts: RedactOptions = {}): RedactResult {
   // ...then splice RIGHT-TO-LEFT so earlier offsets stay valid as we go.
   let out = text;
   for (let i = spans.length - 1; i >= 0; i--) {
-    const span = spans[i]!;
+    const span = required(spans[i], 'loop index is within spans bounds');
     out = out.slice(0, span.start) + replacements[i] + out.slice(span.end);
   }
 

--- a/packages/anonymizer/src/validators.ts
+++ b/packages/anonymizer/src/validators.ts
@@ -12,6 +12,8 @@
  * validators reject all-zeros explicitly via {@link notAllZeros}.
  */
 
+import { required } from './assert.js';
+
 /** Strip everything but ASCII digits. */
 export function digitsOnly(s: string): string {
   return s.replace(/[^0-9]/g, '');
@@ -34,7 +36,8 @@ function alnumValue(ch: string): number {
 /** Weighted sum of `digits` against `weights` (positionally aligned). */
 function weightedSum(digits: string, weights: readonly number[]): number {
   let sum = 0;
-  for (let i = 0; i < weights.length; i++) sum += (digits.charCodeAt(i) - 48) * weights[i]!;
+  for (let i = 0; i < weights.length; i++)
+    sum += (digits.charCodeAt(i) - 48) * required(weights[i], 'weight index within weights');
   return sum;
 }
 
@@ -233,9 +236,9 @@ export function isDowodOsobisty(m: string): boolean {
   if (!/^[A-Z]{3}\d{6}$/.test(s)) return false;
   let sum = 0;
   for (let i = 0; i < 9; i++) {
-    const v = alnumValue(s[i]!);
+    const v = alnumValue(required(s[i], 'char index within s'));
     if (Number.isNaN(v)) return false;
-    sum += v * DOWOD_WEIGHTS[i]!;
+    sum += v * required(DOWOD_WEIGHTS[i], 'weight index within DOWOD_WEIGHTS');
   }
   return sum % 10 === 0;
 }
@@ -248,9 +251,9 @@ export function isPlPassport(m: string): boolean {
   if (!/^[A-Z]{2}\d{7}$/.test(s)) return false;
   let sum = 0;
   for (let i = 0; i < 9; i++) {
-    const v = alnumValue(s[i]!);
+    const v = alnumValue(required(s[i], 'char index within s'));
     if (Number.isNaN(v)) return false;
-    sum += v * PL_PASSPORT_WEIGHTS[i]!;
+    sum += v * required(PL_PASSPORT_WEIGHTS[i], 'weight index within PL_PASSPORT_WEIGHTS');
   }
   return sum % 10 === 0;
 }
@@ -277,7 +280,7 @@ export function isUtr(m: string): boolean {
   const d = digitsOnly(m);
   if (d.length !== 10) return false;
   const sum = weightedSum(d.slice(1), UTR_WEIGHTS);
-  const expected = UTR_LOOKUP[sum % 11]!;
+  const expected = required(UTR_LOOKUP[sum % 11], 'UTR lookup index within range');
   return expected === d.charCodeAt(0) - 48;
 }
 
@@ -301,10 +304,10 @@ export function isVin(m: string): boolean {
   if (!/^[A-HJ-NPR-Z0-9]{17}$/.test(v)) return false;
   let sum = 0;
   for (let i = 0; i < 17; i++) {
-    const ch = v[i]!;
+    const ch = required(v[i], 'char index within v');
     const val = /\d/.test(ch) ? ch.charCodeAt(0) - 48 : VIN_TRANSLIT[ch];
     if (val == null) return false;
-    sum += val * VIN_WEIGHTS[i]!;
+    sum += val * required(VIN_WEIGHTS[i], 'weight index within VIN_WEIGHTS');
   }
   const remainder = sum % 11;
   const expected = remainder === 10 ? 'X' : String(remainder);

--- a/packages/chat-model/src/assert.ts
+++ b/packages/chat-model/src/assert.ts
@@ -1,0 +1,29 @@
+/**
+ * Local narrowing guards for this package. `@moxxy/chat-model` is bundled into
+ * the desktop renderer (a browser context), and the `@moxxy/sdk` root barrel
+ * transitively pulls Node-only modules (`node:fs` via the JSON file store), so a
+ * runtime import of sdk's `assertDefined`/`invariant` from the barrel breaks the
+ * browser build. These are the same guard-don't-chain helpers, kept dependency-
+ * free so they bundle for the browser. Behaviour matches `@moxxy/sdk`.
+ */
+
+/**
+ * Runtime invariant: throws when `condition` is falsy, narrowing its type
+ * otherwise. State an assumption once, then dereference plainly.
+ */
+export function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(`Invariant violation: ${message}`);
+  }
+}
+
+/**
+ * Asserts `value` is neither `null` nor `undefined`, narrowing to `NonNullable<T>`.
+ * The guard-clause replacement for a non-null assertion (`x!`). Falsy-but-defined
+ * values (`0`, `''`, `false`) pass.
+ */
+export function assertDefined<T>(value: T, message: string): asserts value is NonNullable<T> {
+  if (value === null || value === undefined) {
+    throw new Error(`Expected a defined value: ${message}`);
+  }
+}

--- a/packages/chat-model/src/incremental-fold.test.ts
+++ b/packages/chat-model/src/incremental-fold.test.ts
@@ -21,6 +21,7 @@ import {
   asSkillId,
   asToolCallId,
   asTurnId,
+  assertDefined,
   type AssistantMessageEvent,
   type MoxxyEvent,
   type PluginEvent,
@@ -291,7 +292,9 @@ describe('IncrementalFold — golden byte-identity vs pairToolEvents', () => {
       const events = seqDef.events();
       const fold = new IncrementalFold(seqDef.compact);
       for (let n = 0; n < events.length; n += 1) {
-        fold.push(events[n]!);
+        const event = events[n];
+        assertDefined(event, 'event at loop index within bounds');
+        fold.push(event);
         const incremental = fold.tree();
         const golden = pairToolEvents(events.slice(0, n + 1), seqDef.compact);
         expectByteIdentical(seqDef.name, n + 1, incremental, golden);
@@ -316,7 +319,9 @@ describe('IncrementalFold — golden byte-identity vs pairToolEvents', () => {
 
 describe('IncrementalFold.syncTo — append-only resync', () => {
   it('folds only the tail on a pure append (no rebuild)', () => {
-    const events = SEQUENCES.find((s) => s.name.startsWith('mixed'))!.events();
+    const mixedSeq = SEQUENCES.find((s) => s.name.startsWith('mixed'));
+    assertDefined(mixedSeq, 'mixed sequence present in SEQUENCES');
+    const events = mixedSeq.events();
     const fold = new IncrementalFold(compactMap);
     // Drive it the way a store would: re-sync to a growing snapshot each tick.
     for (let n = 1; n <= events.length; n += 1) {
@@ -329,19 +334,25 @@ describe('IncrementalFold.syncTo — append-only resync', () => {
   });
 
   it('rebuilds from scratch when the prefix is replaced (/clear → new session)', () => {
-    const first = SEQUENCES[0]!.events();
+    const firstSeq = SEQUENCES[0];
+    assertDefined(firstSeq, 'first sequence present');
+    const first = firstSeq.events();
     const fold = new IncrementalFold();
     fold.syncTo(first);
     expect(fold.tree()).toEqual(pairToolEvents(first));
     // A fresh, unrelated session: different event ids at the head.
-    const second = SEQUENCES[3]!.events();
+    const secondSeq = SEQUENCES[3];
+    assertDefined(secondSeq, 'fourth sequence present');
+    const second = secondSeq.events();
     const tree = fold.syncTo(second);
     expect(tree).toEqual(pairToolEvents(second));
     expect(fold.length).toBe(second.length);
   });
 
   it('rebuilds from scratch when older history is prepended (scroll-up)', () => {
-    const tail = SEQUENCES[0]!.events();
+    const tailSeq = SEQUENCES[0];
+    assertDefined(tailSeq, 'first sequence present');
+    const tail = tailSeq.events();
     const fold = new IncrementalFold();
     fold.syncTo(tail);
     // Older page prepended at the front: head id shifts → must rebuild.
@@ -352,7 +363,9 @@ describe('IncrementalFold.syncTo — append-only resync', () => {
   });
 
   it('rebuilds when the array shrinks below the high-water mark', () => {
-    const events = SEQUENCES.find((s) => s.name.startsWith('mixed'))!.events();
+    const mixedSeq = SEQUENCES.find((s) => s.name.startsWith('mixed'));
+    assertDefined(mixedSeq, 'mixed sequence present in SEQUENCES');
+    const events = mixedSeq.events();
     const fold = new IncrementalFold(compactMap);
     fold.syncTo(events);
     const shorter = events.slice(0, 3);
@@ -364,11 +377,15 @@ describe('IncrementalFold.syncTo — append-only resync', () => {
   it('stays correct when the tail event id is replaced in place', () => {
     // canExtend matches head+tail ids; a replaced TAIL is detected and the fold
     // rebuilds, so the tree stays byte-identical to a from-scratch fold.
-    const events = SEQUENCES[0]!.events();
+    const firstSeq = SEQUENCES[0];
+    assertDefined(firstSeq, 'first sequence present');
+    const events = firstSeq.events();
     const fold = new IncrementalFold();
     fold.syncTo(events);
     const swapped = events.slice();
-    swapped[swapped.length - 1] = { ...events[events.length - 1]!, id: asEventId('swapped-tail') };
+    const lastEvent = events[events.length - 1];
+    assertDefined(lastEvent, 'last event present');
+    swapped[swapped.length - 1] = { ...lastEvent, id: asEventId('swapped-tail') };
     const tree = fold.syncTo(swapped);
     expect(tree).toEqual(pairToolEvents(swapped));
   });
@@ -378,10 +395,13 @@ describe('IncrementalFold.syncTo — append-only resync', () => {
     // id was reused (a regression in the upstream log). The tail REFERENCE check
     // catches it: a different object at prefixLength-1 forces a rebuild, so the
     // fold reflects the rewritten content instead of folding stale.
-    const events = SEQUENCES[0]!.events();
+    const firstSeq = SEQUENCES[0];
+    assertDefined(firstSeq, 'first sequence present');
+    const events = firstSeq.events();
     const fold = new IncrementalFold();
     fold.syncTo(events);
-    const last = events[events.length - 1]!;
+    const last = events[events.length - 1];
+    assertDefined(last, 'last event present');
     const swapped = events.slice();
     // Same id, different object & content (assistant text changed).
     swapped[swapped.length - 1] =
@@ -398,20 +418,26 @@ describe('IncrementalFold.syncTo — append-only resync', () => {
     // not 'production' under vitest, so the dev check is live here.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
-      const events = SEQUENCES.find((s) => s.name.startsWith('mixed'))!.events();
+      const mixedSeq = SEQUENCES.find((s) => s.name.startsWith('mixed'));
+      assertDefined(mixedSeq, 'mixed sequence present in SEQUENCES');
+      const events = mixedSeq.events();
       const fold = new IncrementalFold(compactMap);
       fold.syncTo(events);
       // Rewrite an INTERIOR event's id (not head, not tail). Keep length and the
       // head/tail ids identical so ONLY the interior check can catch it.
       const mid = Math.floor(events.length / 2);
       const tampered = events.slice();
-      tampered[mid] = { ...events[mid]!, id: asEventId('interior-rewrite') };
+      const midEvent = events[mid];
+      assertDefined(midEvent, 'event at mid index present');
+      tampered[mid] = { ...midEvent, id: asEventId('interior-rewrite') };
       const tree = fold.syncTo(tampered);
       // Despite the head+tail looking like a pure append, the fold rebuilt and
       // is byte-identical to a from-scratch fold of the tampered prefix.
       expect(tree).toEqual(pairToolEvents(tampered, compactMap));
       expect(warn).toHaveBeenCalledOnce();
-      expect(String(warn.mock.calls[0]![0])).toContain('integrity check failed');
+      const firstCall = warn.mock.calls[0];
+      assertDefined(firstCall, 'console.warn called at least once');
+      expect(String(firstCall[0])).toContain('integrity check failed');
     } finally {
       warn.mockRestore();
     }
@@ -422,7 +448,9 @@ describe('IncrementalFold.syncTo — append-only resync', () => {
     // extending the array with new tail events keeps the interior hash valid.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
-      const events = SEQUENCES.find((s) => s.name.startsWith('long burst'))!.events();
+      const burstSeq = SEQUENCES.find((s) => s.name.startsWith('long burst'));
+      assertDefined(burstSeq, 'long burst sequence present in SEQUENCES');
+      const events = burstSeq.events();
       const fold = new IncrementalFold(compactMap);
       for (let n = 1; n <= events.length; n += 1) {
         const snapshot = events.slice(0, n);
@@ -444,7 +472,9 @@ describe('IncrementalFold — complexity (O(k) not O(k²) per turn)', () => {
     //   - naive re-fold (the bug): re-fold the whole prefix on  → k(k+1)/2
     //     every committed event
     // The wrapper below is the real stepFold, so both counts are exact.
-    const events = SEQUENCES.find((s) => s.name.startsWith('long burst'))!.events();
+    const burstSeq = SEQUENCES.find((s) => s.name.startsWith('long burst'));
+    assertDefined(burstSeq, 'long burst sequence present in SEQUENCES');
+    const events = burstSeq.events();
     const k = events.length;
 
     let incrementalSteps = 0;
@@ -459,7 +489,9 @@ describe('IncrementalFold — complexity (O(k) not O(k²) per turn)', () => {
     for (let n = 1; n <= k; n += 1) {
       const s = createFoldState(compactMap);
       for (let i = 0; i < n; i += 1) {
-        stepFold(s, events[i]!);
+        const event = events[i];
+        assertDefined(event, 'event at loop index within bounds');
+        stepFold(s, event);
         naiveSteps += 1;
       }
     }

--- a/packages/chat-model/src/log.test.ts
+++ b/packages/chat-model/src/log.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { ChunkedBlockLog } from './log.js';
 import { newBlockId } from './id.js';
 
@@ -60,10 +61,13 @@ describe('ChunkedBlockLog', () => {
     const before = log.version;
     const hit = log.findLast((x) => x.id === 'b');
     expect(hit).toBeDefined();
-    hit!.done = true;
+    assertDefined(hit, 'findLast locates item b');
+    hit.done = true;
     log.touch();
     expect(log.version).toBeGreaterThan(before);
-    expect(log.toArray().find((x) => x.id === 'b')!.done).toBe(true);
+    const found = log.toArray().find((x) => x.id === 'b');
+    assertDefined(found, 'item b present after touch');
+    expect(found.done).toBe(true);
   });
 
   it('mutateLast / setLast / last are no-ops on an empty log', () => {

--- a/packages/chat-model/src/log.ts
+++ b/packages/chat-model/src/log.ts
@@ -13,6 +13,8 @@
  * Generic over the element type so it can hold raw events, folded blocks,
  * or anything else a surface needs to stream + paginate.
  */
+import { assertDefined, invariant } from './assert.js';
+
 export class ChunkedBlockLog<T> {
   private readonly segments: T[][];
   private readonly segmentSize: number;
@@ -42,7 +44,9 @@ export class ChunkedBlockLog<T> {
   }
 
   private tailSegment(): T[] {
-    return this.segments[this.segments.length - 1]!;
+    const seg = this.segments[this.segments.length - 1];
+    assertDefined(seg, 'segments always holds at least one segment');
+    return seg;
   }
 
   /** Append one item. O(1) amortised. */
@@ -76,7 +80,9 @@ export class ChunkedBlockLog<T> {
   mutateLast(update: (item: T) => T): void {
     if (this.count === 0) return;
     const seg = this.tailSegment();
-    seg[seg.length - 1] = update(seg[seg.length - 1]!);
+    const last = seg[seg.length - 1];
+    assertDefined(last, 'tail segment is non-empty when count > 0');
+    seg[seg.length - 1] = update(last);
     this.rev += 1;
   }
 
@@ -108,9 +114,12 @@ export class ChunkedBlockLog<T> {
    */
   findLast(pred: (item: T) => boolean): T | undefined {
     for (let s = this.segments.length - 1; s >= 0; s -= 1) {
-      const seg = this.segments[s]!;
+      const seg = this.segments[s];
+      assertDefined(seg, 'segment index within bounds');
       for (let i = seg.length - 1; i >= 0; i -= 1) {
-        if (pred(seg[i]!)) return seg[i];
+        const item = seg[i];
+        invariant(item !== undefined, 'item index within segment bounds');
+        if (pred(item)) return item;
       }
     }
     return undefined;
@@ -127,7 +136,11 @@ export class ChunkedBlockLog<T> {
    * per change (memoise on `version`); prefer `tail(n)` for a window.
    */
   toArray(): T[] {
-    if (this.segments.length === 1) return this.segments[0]!.slice();
+    if (this.segments.length === 1) {
+      const only = this.segments[0];
+      assertDefined(only, 'single segment present when segments.length === 1');
+      return only.slice();
+    }
     return this.segments.flat();
   }
 
@@ -138,9 +151,12 @@ export class ChunkedBlockLog<T> {
     if (n >= this.count) return this.toArray();
     const out: T[] = [];
     for (let s = this.segments.length - 1; s >= 0 && out.length < n; s -= 1) {
-      const seg = this.segments[s]!;
+      const seg = this.segments[s];
+      assertDefined(seg, 'segment index within bounds');
       for (let i = seg.length - 1; i >= 0 && out.length < n; i -= 1) {
-        out.push(seg[i]!);
+        const item = seg[i];
+        invariant(item !== undefined, 'item index within segment bounds');
+        out.push(item);
       }
     }
     out.reverse();

--- a/packages/chat-model/src/markdown/inline.ts
+++ b/packages/chat-model/src/markdown/inline.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from '../assert.js';
 import type { InlineTok } from './types.js';
 
 /**
@@ -18,11 +19,19 @@ export function tokenizeInline(input: string): InlineTok[] {
     if (match[1]) {
       out.push({ kind: 'code', value: match[1].slice(1, -1) });
     } else if (match[2]) {
-      out.push({ kind: 'bold', value: match[3]! });
+      const value = match[3];
+      assertDefined(value, 'bold inner group is captured when the bold group matches');
+      out.push({ kind: 'bold', value });
     } else if (match[4]) {
-      out.push({ kind: 'italic', value: match[5]! });
+      const value = match[5];
+      assertDefined(value, 'italic inner group is captured when the italic group matches');
+      out.push({ kind: 'italic', value });
     } else if (match[6]) {
-      out.push({ kind: 'link', label: match[7]!, url: match[8]! });
+      const label = match[7];
+      const url = match[8];
+      assertDefined(label, 'link label group is captured when the link group matches');
+      assertDefined(url, 'link url group is captured when the link group matches');
+      out.push({ kind: 'link', label, url });
     }
     lastIdx = match.index + match[0].length;
   }

--- a/packages/chat-model/src/markdown/parse-blocks.ts
+++ b/packages/chat-model/src/markdown/parse-blocks.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from '../assert.js';
 import type { Align, Block } from './types.js';
 
 export function parseBlocks(src: string): Block[] {
@@ -5,7 +6,8 @@ export function parseBlocks(src: string): Block[] {
   const blocks: Block[] = [];
   let i = 0;
   while (i < lines.length) {
-    const line = lines[i]!;
+    const line = lines[i];
+    assertDefined(line, 'line index within bounds');
 
     // Fenced code block
     const fence = /^```(\w*)\s*$/.exec(line);
@@ -13,8 +15,11 @@ export function parseBlocks(src: string): Block[] {
       const lang = fence[1] || null;
       const body: string[] = [];
       i++;
-      while (i < lines.length && !/^```/.test(lines[i]!)) {
-        body.push(lines[i]!);
+      while (i < lines.length) {
+        const bodyLine = lines[i];
+        assertDefined(bodyLine, 'line index within bounds');
+        if (/^```/.test(bodyLine)) break;
+        body.push(bodyLine);
         i++;
       }
       i++; // skip closing fence
@@ -27,14 +32,18 @@ export function parseBlocks(src: string): Block[] {
     // the separator to distinguish real tables from prose that
     // happens to contain pipe characters.
     if (line.trim().startsWith('|') && i + 1 < lines.length) {
-      const sep = lines[i + 1]!;
+      const sep = lines[i + 1];
+      assertDefined(sep, 'separator line present when i + 1 < lines.length');
       if (isTableSeparator(sep)) {
         const header = parseTableCells(line);
         const aligns = parseTableAligns(sep);
         const rows: string[][] = [];
         i += 2;
-        while (i < lines.length && lines[i]!.trim().startsWith('|')) {
-          const cells = parseTableCells(lines[i]!);
+        while (i < lines.length) {
+          const row = lines[i];
+          assertDefined(row, 'line index within bounds');
+          if (!row.trim().startsWith('|')) break;
+          const cells = parseTableCells(row);
           if (cells.length === 0) break;
           // Pad / clamp to header length so the grid stays rectangular.
           while (cells.length < header.length) cells.push('');
@@ -49,8 +58,12 @@ export function parseBlocks(src: string): Block[] {
     // ATX heading
     const heading = /^(#{1,6})\s+(.*)$/.exec(line);
     if (heading) {
-      const level = Math.min(6, Math.max(1, heading[1]!.length)) as 1 | 2 | 3 | 4 | 5 | 6;
-      blocks.push({ kind: 'heading', level, text: heading[2]!.trim() });
+      const hashes = heading[1];
+      assertDefined(hashes, 'heading hash group is captured when the heading matches');
+      const text = heading[2];
+      assertDefined(text, 'heading text group is captured when the heading matches');
+      const level = Math.min(6, Math.max(1, hashes.length)) as 1 | 2 | 3 | 4 | 5 | 6;
+      blocks.push({ kind: 'heading', level, text: text.trim() });
       i++;
       continue;
     }
@@ -60,11 +73,15 @@ export function parseBlocks(src: string): Block[] {
       const ordered = /^\s*\d+\.\s+/.test(line);
       const items: string[] = [];
       while (i < lines.length) {
+        const cur = lines[i];
+        assertDefined(cur, 'line index within bounds');
         const m = ordered
-          ? /^\s*\d+\.\s+(.*)$/.exec(lines[i]!)
-          : /^\s*[-*+]\s+(.*)$/.exec(lines[i]!);
+          ? /^\s*\d+\.\s+(.*)$/.exec(cur)
+          : /^\s*[-*+]\s+(.*)$/.exec(cur);
         if (!m) break;
-        items.push(m[1]!.trim());
+        const item = m[1];
+        assertDefined(item, 'list item capture group is present when the item matches');
+        items.push(item.trim());
         i++;
       }
       blocks.push({ kind: 'list', ordered, items });
@@ -80,8 +97,10 @@ export function parseBlocks(src: string): Block[] {
 
     // Otherwise: paragraph — gather until blank/structural line
     const paraLines: string[] = [];
-    while (i < lines.length && lines[i]!.trim() !== '') {
-      const next = lines[i]!;
+    while (i < lines.length) {
+      const next = lines[i];
+      assertDefined(next, 'line index within bounds');
+      if (next.trim() === '') break;
       if (
         /^```/.test(next) ||
         /^#{1,6}\s+/.test(next) ||
@@ -93,11 +112,8 @@ export function parseBlocks(src: string): Block[] {
       // Mid-paragraph table: pipe row followed by a separator row.
       // Stop the paragraph here so the table check at the top of the
       // outer loop picks it up.
-      if (
-        next.trim().startsWith('|') &&
-        i + 1 < lines.length &&
-        isTableSeparator(lines[i + 1]!)
-      ) {
+      const nextLine = i + 1 < lines.length ? lines[i + 1] : undefined;
+      if (next.trim().startsWith('|') && nextLine !== undefined && isTableSeparator(nextLine)) {
         break;
       }
       paraLines.push(next);

--- a/packages/chat-model/src/pair-events.test.ts
+++ b/packages/chat-model/src/pair-events.test.ts
@@ -6,6 +6,7 @@ import {
   asSkillId,
   asToolCallId,
   asTurnId,
+  assertDefined,
   type AssistantMessageEvent,
   type MoxxyEvent,
   type PluginEvent,
@@ -171,7 +172,11 @@ const asSubagentGroup = (b: unknown): SubagentGroupBlock => {
 
 // Every projection folds even a lone agent into a group; unwrap to its first
 // member so the per-agent assertions below read naturally.
-const asSubagent = (b: unknown): SubagentBlock => asSubagentGroup(b).agents[0]!;
+const asSubagent = (b: unknown): SubagentBlock => {
+  const first = asSubagentGroup(b).agents[0];
+  assertDefined(first, 'subagent group has at least one agent');
+  return first;
+};
 
 describe('pairToolEvents — verbose tool pairing', () => {
   it('pairs a tool_call_requested with its tool_result into one settled block', () => {
@@ -249,7 +254,8 @@ describe('pairToolEvents — orphan tool call at a turn boundary', () => {
     const tc = asToolCall(blocks[0]);
     expect(tc.outcome).toMatchObject({ type: 'denied' });
     // The late result falls through to a generic event block.
-    const last = blocks[blocks.length - 1]!;
+    const last = blocks[blocks.length - 1];
+    assertDefined(last, 'blocks is non-empty');
     expect(last.kind).toBe('event');
   });
 });
@@ -273,7 +279,9 @@ describe('pairToolEvents — mid-turn checkpoint prompt is NOT a turn boundary',
   it('renders the injected feedback as an ordinary in-order block', () => {
     const blocks = pairToolEvents([userPrompt('go'), checkpointPrompt('feedback')]);
     expect(blocks).toHaveLength(2);
-    expect(blocks[1]!.kind).toBe('event');
+    const second = blocks[1];
+    assertDefined(second, 'second block present');
+    expect(second.kind).toBe('event');
   });
 });
 
@@ -341,7 +349,9 @@ describe('pairToolEvents — skill grouping', () => {
     expect(firstScope.children).toHaveLength(1);
     expect(isSettled(firstScope)).toBe(true);
 
-    expect(blocks[1]!.kind).toBe('event');
+    const second = blocks[1];
+    assertDefined(second, 'second block present');
+    expect(second.kind).toBe('event');
 
     const contScope = asScope(blocks[2]);
     // Continuation carries the SAME skill event through to the grouping.
@@ -433,7 +443,9 @@ describe('pairToolEvents — compact-tool live aggregation', () => {
     const live = asLive(blocks[0]);
     expect(live.closed).toBe(true);
     expect(isSettled(live)).toBe(true);
-    expect(blocks[1]!.kind).toBe('event');
+    const second = blocks[1];
+    assertDefined(second, 'second block present');
+    expect(second.kind).toBe('event');
   });
 });
 
@@ -512,9 +524,13 @@ describe('pairToolEvents — subagent lifecycle accretion', () => {
     expect(group.agentType).toBe('Explore');
     expect(group.agents).toHaveLength(2);
     // Each child accretes independently by childSessionId.
-    expect(group.agents[0]!.toolCallCount).toBe(1);
-    expect(group.agents[0]!.tokensUsed).toBe(1200);
-    expect(group.agents[1]!.tokensUsed).toBe(65300);
+    const agent0 = group.agents[0];
+    const agent1 = group.agents[1];
+    assertDefined(agent0, 'group has a first agent');
+    assertDefined(agent1, 'group has a second agent');
+    expect(agent0.toolCallCount).toBe(1);
+    expect(agent0.tokensUsed).toBe(1200);
+    expect(agent1.tokensUsed).toBe(65300);
     expect(isSettled(group)).toBe(true);
   });
 
@@ -555,26 +571,32 @@ describe('pairToolEvents — subagent lifecycle accretion', () => {
 describe('blocksEquivalent', () => {
   it('returns true for identical references (fast path)', () => {
     const [block] = pairToolEvents([toolRequest('c1', 'bash'), toolResult('c1')]);
-    expect(blocksEquivalent(block!, block!)).toBe(true);
+    assertDefined(block, 'first block present');
+    expect(blocksEquivalent(block, block)).toBe(true);
   });
 
   it('returns false across different kinds', () => {
     const tc = asToolCall(pairToolEvents([toolRequest('c1', 'bash')])[0]);
-    const ev = pairToolEvents([userPrompt('hi')])[0]!;
+    const ev = pairToolEvents([userPrompt('hi')])[0];
+    assertDefined(ev, 'event block present');
     expect(blocksEquivalent(tc, ev)).toBe(false);
   });
 
   it('tool-call: equivalent when request+outcome refs match, different when outcome changes', () => {
     const req = toolRequest('c1', 'bash');
     const res = toolResult('c1');
-    const pending = pairToolEvents([req])[0]!;
-    const settled = pairToolEvents([req, res])[0]!;
+    const pending = pairToolEvents([req])[0];
+    assertDefined(pending, 'pending block present');
+    const settled = pairToolEvents([req, res])[0];
+    assertDefined(settled, 'settled block present');
     // Same request ref, different outcome (null vs result) → not equivalent.
     expect(blocksEquivalent(pending, settled)).toBe(false);
 
     // Two independent folds of the same events: equal field refs → equivalent.
-    const a = pairToolEvents([req, res])[0]!;
-    const b = pairToolEvents([req, res])[0]!;
+    const a = pairToolEvents([req, res])[0];
+    assertDefined(a, 'block a present');
+    const b = pairToolEvents([req, res])[0];
+    assertDefined(b, 'block b present');
     expect(blocksEquivalent(a, b)).toBe(true);
   });
 
@@ -750,7 +772,9 @@ describe('pairToolEvents — subagent map bounded at the turn boundary', () => {
       subagentEvent('subagent_completed', { childSessionId: 'cs1', stopReason: 'end_turn', text: 'STALE' }),
     ]);
     const group = asSubagentGroup(blocks[0]);
-    expect(group.agents[0]!.finalPreview).toBe('first');
+    const agent0 = group.agents[0];
+    assertDefined(agent0, 'group has a first agent');
+    expect(agent0.finalPreview).toBe('first');
     // The stale event produced no new block (no matching started block post-clear).
     expect(blocks.filter((b) => b.kind === 'subagent-group')).toHaveLength(1);
   });
@@ -772,7 +796,11 @@ describe('blocksEquivalent — collab content edits + subagent stopReason', () =
     const b = foldCollab([start, open, edited]);
     expect(a.tasks).toHaveLength(1);
     expect(b.tasks).toHaveLength(1);
-    expect(a.tasks[0]!.status).toBe(b.tasks[0]!.status); // status unchanged
+    const aTask0 = a.tasks[0];
+    const bTask0 = b.tasks[0];
+    assertDefined(aTask0, 'block a has a first task');
+    assertDefined(bTask0, 'block b has a first task');
+    expect(aTask0.status).toBe(bTask0.status); // status unchanged
     // Content changed though — comparator must NOT skip the re-render.
     expect(blocksEquivalent(a, b)).toBe(false);
   });

--- a/packages/chat-model/src/pair-events.ts
+++ b/packages/chat-model/src/pair-events.ts
@@ -1,4 +1,5 @@
 import type { MoxxyEvent, PluginEvent, ToolCompactPresentation } from '@moxxy/sdk';
+import { assertDefined, invariant } from './assert.js';
 import { isFileDiffDisplay } from '@moxxy/sdk/tool-display';
 import type {
   Block,
@@ -682,7 +683,11 @@ function mixEventId(h: number, id: string): number {
  *  dev-only interior integrity check; never on the production path. */
 function hashEventIds(events: ReadonlyArray<MoxxyEvent>, upto: number): number {
   let h = FNV_BASIS;
-  for (let i = 0; i < upto; i += 1) h = mixEventId(h, events[i]!.id);
+  for (let i = 0; i < upto; i += 1) {
+    const event = events[i];
+    assertDefined(event, 'event index within bounds (upto <= events.length)');
+    h = mixEventId(h, event.id);
+  }
   return h >>> 0;
 }
 
@@ -753,7 +758,11 @@ export class IncrementalFold {
    */
   syncTo(events: ReadonlyArray<MoxxyEvent>): Block[] {
     if (this.canExtend(events)) {
-      for (let i = this.prefixLength; i < events.length; i += 1) this.push(events[i]!);
+      for (let i = this.prefixLength; i < events.length; i += 1) {
+        const event = events[i];
+        assertDefined(event, 'event index within bounds');
+        this.push(event);
+      }
       return this.state.root;
     }
     // The known prefix changed (or shrank): the carry is no longer valid, so
@@ -800,8 +809,11 @@ export class IncrementalFold {
   private canExtend(events: ReadonlyArray<MoxxyEvent>): boolean {
     if (this.prefixLength === 0) return true; // empty fold extends to anything
     if (events.length < this.prefixLength) return false; // shrank → rebuild
-    if (events[0]!.id !== this.headId) return false; // head shifted (prepend)
-    const tail = events[this.prefixLength - 1]!;
+    const first = events[0];
+    assertDefined(first, 'events is non-empty when prefixLength >= 1');
+    if (first.id !== this.headId) return false; // head shifted (prepend)
+    const tail = events[this.prefixLength - 1];
+    assertDefined(tail, 'tail event within bounds (events.length >= prefixLength >= 1)');
     if (tail.id !== this.tailId) return false; // tail id rewritten
     if (this.tailEvent !== null && tail !== this.tailEvent) return false; // tail object swapped
     if (FOLD_DEV_CHECKS && hashEventIds(events, this.prefixLength) !== (this.foldedHash >>> 0)) {
@@ -873,7 +885,11 @@ export function blocksEquivalent(a: Block, b: Block): boolean {
     if (a.agentType !== b.agentType) return false;
     if (a.agents.length !== b.agents.length) return false;
     for (let i = 0; i < a.agents.length; i += 1) {
-      if (!blocksEquivalent(a.agents[i]!, b.agents[i]!)) return false;
+      const aAgent = a.agents[i];
+      const bAgent = b.agents[i];
+      invariant(aAgent !== undefined, 'agent index within bounds');
+      invariant(bAgent !== undefined, 'agent index within bounds (equal lengths checked)');
+      if (!blocksEquivalent(aAgent, bAgent)) return false;
     }
     return true;
   }
@@ -881,7 +897,11 @@ export function blocksEquivalent(a: Block, b: Block): boolean {
     if (a.closed !== b.closed) return false;
     if (a.children.length !== b.children.length) return false;
     for (let i = 0; i < a.children.length; i += 1) {
-      if (!blocksEquivalent(a.children[i]!, b.children[i]!)) return false;
+      const aChild = a.children[i];
+      const bChild = b.children[i];
+      invariant(aChild !== undefined, 'child index within bounds');
+      invariant(bChild !== undefined, 'child index within bounds (equal lengths checked)');
+      if (!blocksEquivalent(aChild, bChild)) return false;
     }
     return true;
   }
@@ -913,8 +933,12 @@ export function blocksEquivalent(a: Block, b: Block): boolean {
     if (a.closed !== b.closed) return false;
     if (a.calls.length !== b.calls.length) return false;
     for (let i = 0; i < a.calls.length; i += 1) {
-      if (a.calls[i]!.outcome !== b.calls[i]!.outcome) return false;
-      if (a.calls[i]!.request !== b.calls[i]!.request) return false;
+      const aCall = a.calls[i];
+      const bCall = b.calls[i];
+      invariant(aCall !== undefined, 'call index within bounds');
+      invariant(bCall !== undefined, 'call index within bounds (equal lengths checked)');
+      if (aCall.outcome !== bCall.outcome) return false;
+      if (aCall.request !== bCall.request) return false;
     }
     return true;
   }

--- a/packages/desktop-host/src/app-update/manifest.test.ts
+++ b/packages/desktop-host/src/app-update/manifest.test.ts
@@ -7,6 +7,7 @@ import {
   parseManifest,
   verifyManifestSignature,
 } from './manifest';
+import { assertDefined } from '@moxxy/sdk';
 
 /** Produce a signed manifest for an ad-hoc Ed25519 keypair. */
 function signed(overrides: Partial<AppManifest> = {}): {
@@ -68,7 +69,8 @@ describe('verifyManifestSignature', () => {
     // …including after a parse round-trip (the published-manifest path).
     const parsed = parseManifest(JSON.stringify(manifest));
     expect(parsed?.files).toEqual(files);
-    expect(verifyManifestSignature(parsed!, publicKeyPem)).toBe(true);
+    assertDefined(parsed, 'parsed manifest');
+    expect(verifyManifestSignature(parsed, publicKeyPem)).toBe(true);
   });
 
   it('rejects when a per-file hash is tampered after signing', () => {
@@ -99,7 +101,8 @@ describe('verifyManifestSignature', () => {
     const reordered = parseManifest(
       JSON.stringify({ ...manifest, files: { 'a.js': 'a'.repeat(64), 'b.js': 'b'.repeat(64) } }),
     );
-    expect(verifyManifestSignature(reordered!, publicKeyPem)).toBe(true);
+    assertDefined(reordered, 'reordered manifest');
+    expect(verifyManifestSignature(reordered, publicKeyPem)).toBe(true);
   });
 
   it('round-trips a manifest carrying a signed runnerProtocol stamp', () => {
@@ -107,7 +110,8 @@ describe('verifyManifestSignature', () => {
     expect(verifyManifestSignature(manifest, publicKeyPem)).toBe(true);
     const parsed = parseManifest(JSON.stringify(manifest));
     expect(parsed?.runnerProtocol).toBe(4);
-    expect(verifyManifestSignature(parsed!, publicKeyPem)).toBe(true);
+    assertDefined(parsed, 'parsed manifest');
+    expect(verifyManifestSignature(parsed, publicKeyPem)).toBe(true);
   });
 
   it('rejects a downgrade that strips (or alters) the runnerProtocol stamp', () => {

--- a/packages/desktop-host/src/app-update/native-resolution.test.ts
+++ b/packages/desktop-host/src/app-update/native-resolution.test.ts
@@ -13,6 +13,7 @@ import path, { delimiter } from 'node:path';
 import os from 'node:os';
 
 import { setupNativeResolution } from './native-resolution';
+import { assertDefined } from '@moxxy/sdk';
 
 let tmp: string;
 let savedNodePath: string | undefined;
@@ -47,9 +48,9 @@ describe('setupNativeResolution', () => {
 
     expect(process.env.NODE_PATH).toBe(`/pre/existing${delimiter}${nm}`);
     // The pre-existing entry comes FIRST (append, not prepend).
-    expect(process.env.NODE_PATH!.indexOf('/pre/existing')).toBeLessThan(
-      process.env.NODE_PATH!.indexOf(nm),
-    );
+    const nodePath = process.env.NODE_PATH;
+    assertDefined(nodePath, 'NODE_PATH');
+    expect(nodePath.indexOf('/pre/existing')).toBeLessThan(nodePath.indexOf(nm));
   });
 
   it('leaves NODE_PATH untouched when no candidate node_modules dir exists', () => {

--- a/packages/desktop-host/src/app-update/stager.test.ts
+++ b/packages/desktop-host/src/app-update/stager.test.ts
@@ -16,6 +16,7 @@ import {
   readActiveVersion,
   type ShellInfo,
 } from './resolve';
+import { assertDefined } from '@moxxy/sdk';
 
 const SHELL: ShellInfo = { electron: '33.4.11', nodeAbi: '115' };
 const keys = generateKeyPairSync('ed25519');
@@ -438,7 +439,8 @@ describe('downloadAndStage hardening', () => {
     );
 
     const downloads = progress.filter((p) => p.phase === 'download' && p.received !== undefined);
-    const final = downloads.at(-1)!;
+    const final = downloads.at(-1);
+    assertDefined(final, 'final download progress event');
     expect(final.received).toBeGreaterThan(0);
     expect(final.total).toBe(final.received); // lands at exactly 100%
   });

--- a/packages/desktop-host/src/apps/discover.test.ts
+++ b/packages/desktop-host/src/apps/discover.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { discoverApps } from './discover';
+import { assertDefined } from '@moxxy/sdk';
 
 let root: string;
 
@@ -43,8 +44,10 @@ describe('discoverApps', () => {
     const { apps, skipped } = await discoverApps(root);
     expect(skipped).toEqual([]);
     expect(apps).toHaveLength(1);
-    expect(apps[0]!.manifest.id).toBe('demo');
-    expect(apps[0]!.dir).toBe(path.join(root, 'demo'));
+    const first = apps[0];
+    assertDefined(first, 'discovered app');
+    expect(first.manifest.id).toBe('demo');
+    expect(first.dir).toBe(path.join(root, 'demo'));
   });
 
   it('skips a folder whose manifest id != folder name (no masquerade)', async () => {

--- a/packages/desktop-host/src/attachments.test.ts
+++ b/packages/desktop-host/src/attachments.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, rm, unlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { buildAttachments, parseFileToText, persistImageBlob } from './attachments';
+import { assertDefined } from '@moxxy/sdk';
 
 /** Temp files persistImageBlob writes; cleaned up after each test. */
 const written: string[] = [];
@@ -201,7 +202,8 @@ describe('buildAttachments', () => {
     const input = await tmpFile('huge.log', big);
     const out = await buildAttachments([input]);
     expect(out).toHaveLength(1);
-    const att = out[0]!;
+    const att = out[0];
+    assertDefined(att, 'built attachment');
     expect(att.kind).toBe('file');
     expect(att.name).toBe('huge.log');
     // Only a preview is inlined, plus a note pointing at the original path.
@@ -222,7 +224,8 @@ describe('buildAttachments', () => {
     const input = await tmpFile('massive.log', Buffer.alloc(size, 0x41 /* 'A' */));
     const out = await buildAttachments([input]);
     expect(out).toHaveLength(1);
-    const att = out[0]!;
+    const att = out[0];
+    assertDefined(att, 'built attachment');
     expect(att.kind).toBe('file');
     // Only a small preview is inlined (8 KB head + note), never the whole file.
     expect(att.content.length).toBeLessThan(64 * 1024);

--- a/packages/desktop-host/src/attachments.ts
+++ b/packages/desktop-host/src/attachments.ts
@@ -27,6 +27,7 @@ import { mkdir, open, readFile, readdir, stat, unlink, writeFile } from 'node:fs
 import os from 'node:os';
 import path from 'node:path';
 import type { UserPromptAttachment } from '@moxxy/sdk';
+import { assertDefined } from '@moxxy/sdk';
 import { parseOfficeAsync } from 'officeparser';
 import { extractPdfText } from './pdf-text.js';
 
@@ -116,7 +117,8 @@ function rtfToText(buf: Buffer): string | null {
   const controlWord = /\\([a-z]+)(-?\d+)? ?/iy;
 
   for (let i = 0; i < rtf.length; i++) {
-    const ch = rtf[i]!;
+    const ch = rtf[i];
+    assertDefined(ch, 'char index within rtf bounds');
     if (ch === '{') {
       // Open a group. Decide if it's a skip group by peeking the destination
       // control word that (optionally after `\*`) starts it.
@@ -124,7 +126,8 @@ function rtfToText(buf: Buffer): string | null {
       const dest = groupDest.exec(rtf);
       starDest.lastIndex = i + 1;
       const isStar = starDest.test(rtf);
-      const skip = (dest !== null && RTF_SKIP_GROUPS.has(dest[1]!.toLowerCase())) || isStar;
+      const destWord = dest?.[1];
+      const skip = (destWord !== undefined && RTF_SKIP_GROUPS.has(destWord.toLowerCase())) || isStar;
       skipStack.push(Boolean(skip));
       continue;
     }
@@ -149,7 +152,9 @@ function rtfToText(buf: Buffer): string | null {
       controlWord.lastIndex = i;
       const m = controlWord.exec(rtf); // /y → matches only when anchored at `i`
       if (m) {
-        const word = m[1]!.toLowerCase();
+        const controlName = m[1];
+        assertDefined(controlName, 'control-word capture group is present');
+        const word = controlName.toLowerCase();
         if (!suppressed()) {
           if (word === 'par' || word === 'line' || word === 'sect') out += '\n';
           else if (word === 'tab') out += '\t';
@@ -196,7 +201,8 @@ function legacyDocToText(buf: Buffer): string | null {
     cur = '';
   };
   for (let i = 0; i < buf.length; i++) {
-    const b = buf[i]!;
+    const b = buf[i];
+    assertDefined(b, 'byte index within buf bounds');
     // Treat tab/newline/CR and printable ASCII (0x20–0x7e) + Latin-1 high range
     // (0xa0–0xfe) as text. The C1 control range (0x80–0x9f) is excluded so
     // stray control bytes don't get mapped into the recovered prose.

--- a/packages/desktop-host/src/channel-catalog.test.ts
+++ b/packages/desktop-host/src/channel-catalog.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ChannelDef } from '@moxxy/sdk';
 import { CHANNEL_CATALOG, listChannelCatalog, type ChannelCatalogEntry } from './channel-catalog';
+import { assertDefined } from '@moxxy/sdk';
 
 describe('CHANNEL_CATALOG', () => {
   it('pins the exact vault keys each channel plugin reads', () => {
@@ -112,8 +113,12 @@ async function defContract(id: string): Promise<{
   readonly requiredKeys: ReadonlyArray<string>;
   readonly hasRequestUrl: boolean;
 }> {
-  const mod = await PLUGIN_LOADERS[id]!();
-  const config = mod.default?.channels?.[0]?.config;
+  const loader = PLUGIN_LOADERS[id];
+  assertDefined(loader, `plugin loader for channel "${id}"`);
+  const mod = await loader();
+  const channels = mod.default?.channels;
+  const firstChannel = channels?.[0];
+  const config = firstChannel?.config;
   if (!config) throw new Error(`no ChannelDef.config for channel "${id}"`);
   const fields = new Map<string, FieldContract>(
     config.fields.map((f) => [f.vaultKey, { required: f.required === true, type: f.secret ? 'password' : 'text' }]),

--- a/packages/desktop-host/src/collab-supervisor.ts
+++ b/packages/desktop-host/src/collab-supervisor.ts
@@ -228,7 +228,8 @@ export async function startCollab(args: { cwd: string; goal: string }): Promise<
 export async function ensureCollabAttached(): Promise<void> {
   if (coordinator) return;
   const active = readActiveCollab();
-  const socket = active?.runnerSocket?.trim();
+  const runnerSocket = active?.runnerSocket;
+  const socket = runnerSocket?.trim();
   if (!active || !socket) return;
   if (!(await isRunnerUp(socket))) return;
   try {
@@ -322,7 +323,8 @@ export function stopAllCollab(): void {
 // coordinator WE spawned; a read-only attach holds no child.)
 process.once('exit', () => {
   try {
-    coordinator?.child?.kill('SIGTERM');
+    const child = coordinator?.child;
+    child?.kill('SIGTERM');
   } catch {
     /* ignore */
   }

--- a/packages/desktop-host/src/focus-mode-controller.ts
+++ b/packages/desktop-host/src/focus-mode-controller.ts
@@ -82,7 +82,7 @@ export function createFocusModeController(
 
   async function enterFocusMode(): Promise<void> {
     const mainWindow = await getOrEnsureMainWindow();
-    const wasFullscreen = Boolean(mainWindow?.isFullScreen?.());
+    const wasFullscreen = mainWindow ? Boolean(mainWindow.isFullScreen?.()) : false;
 
     await deps.showFocus();
     restoreFullscreen = wasFullscreen;

--- a/packages/desktop-host/src/ipc/anonymizer.ts
+++ b/packages/desktop-host/src/ipc/anonymizer.ts
@@ -26,6 +26,7 @@ import type { DeskStore } from '../desks';
 import { authorizeAttachments, rememberPickedAttachment } from '../attachment-authz';
 import { parseFileToText, parseBufferToText } from '../attachments.js';
 import { handle } from './shared';
+import { assertDefined } from '@moxxy/sdk';
 
 /** True when these bytes are a PDF (by `%PDF-` magic). */
 function looksLikePdf(buf: Buffer): boolean {
@@ -85,7 +86,8 @@ export function registerAnonymizerHandlers(pool: RunnerPool, desks: DeskStore): 
       ? await dialog.showOpenDialog(window, opts)
       : await dialog.showOpenDialog(opts);
     if (result.canceled || result.filePaths.length === 0) return null;
-    const picked = result.filePaths[0]!;
+    const picked = result.filePaths[0];
+    assertDefined(picked, 'a file path is present when filePaths is non-empty');
     // Remember the choice so the follow-up parseDocument is authorized even
     // though the file lives outside any workspace cwd.
     await rememberPickedAttachment(picked);

--- a/packages/desktop-host/src/ipc/desks.ts
+++ b/packages/desktop-host/src/ipc/desks.ts
@@ -13,6 +13,7 @@ import { dialog, BrowserWindow as BrowserWindowApi } from 'electron';
 import type { RunnerPool } from '../runner-pool';
 import { cwdForSession, type DeskStore } from '../desks';
 import { broadcastHostEvent } from '../event-bus';
+import { assertDefined } from '@moxxy/sdk';
 import { handle } from './shared';
 
 export function registerDesksHandlers(pool: RunnerPool, desks: DeskStore): void {
@@ -73,7 +74,9 @@ export function registerDesksHandlers(pool: RunnerPool, desks: DeskStore): void 
       ? await dialog.showOpenDialog(window, opts)
       : await dialog.showOpenDialog(opts);
     if (result.canceled || result.filePaths.length === 0) return null;
-    return result.filePaths[0]!;
+    const picked = result.filePaths[0];
+    assertDefined(picked, 'a folder path is present when filePaths is non-empty');
+    return picked;
   });
 }
 

--- a/packages/desktop-host/src/ipc/onboarding.ts
+++ b/packages/desktop-host/src/ipc/onboarding.ts
@@ -64,7 +64,9 @@ export function registerOnboardingHandlers(pool: RunnerPool): void {
     // declared auth kind (including OAuth ones like claude-code), so no list
     // here can drift. Fall back to the known built-in OAuth providers only
     // when the runner isn't reachable yet (early in onboarding).
-    const info = pool.active()?.remote()?.getInfo();
+    const active = pool.active();
+    const remote = active?.remote();
+    const info = remote?.getInfo();
     const known = info?.providers.find((p) => p.name === provider);
     if (known) return known.authKind;
     const OAUTH_FALLBACK = new Set(['openai-codex', 'claude-code']);

--- a/packages/desktop-host/src/ipc/prefs.test.ts
+++ b/packages/desktop-host/src/ipc/prefs.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { DesktopPrefs } from '@moxxy/desktop-ipc-contract';
 import { setActiveBus } from './shared';
 import { registerPrefsHandlers } from './prefs';
+import { assertDefined } from '@moxxy/sdk';
 
 const BASE: DesktopPrefs = {
   onboardingComplete: true,
@@ -69,12 +70,16 @@ describe('prefs IPC handlers', () => {
   });
 
   it('prefs.read returns the stored prefs (theme defaults to system)', async () => {
-    const prefs = (await handlers.get('prefs.read')!()) as DesktopPrefs;
+    const readHandler = handlers.get('prefs.read');
+    assertDefined(readHandler, 'prefs.read handler');
+    const prefs = (await readHandler()) as DesktopPrefs;
     expect(prefs).toEqual(BASE);
   });
 
   it('prefs.update merges and returns the patched prefs', async () => {
-    const next = (await handlers.get('prefs.update')!({
+    const updateHandler = handlers.get('prefs.update');
+    assertDefined(updateHandler, 'prefs.update handler');
+    const next = (await updateHandler({
       mobileGatewayEnabled: true,
     })) as DesktopPrefs;
     expect(next.mobileGatewayEnabled).toBe(true);
@@ -84,9 +89,13 @@ describe('prefs IPC handlers', () => {
   it('a theme patch persists and survives the nativeTheme sync outside electron', async () => {
     // In plain-node vitest the `electron` module is either missing or exports
     // a binary-path string with no `nativeTheme` — the handler must not throw.
-    const next = (await handlers.get('prefs.update')!({ theme: 'dark' })) as DesktopPrefs;
+    const updateHandler = handlers.get('prefs.update');
+    assertDefined(updateHandler, 'prefs.update handler');
+    const next = (await updateHandler({ theme: 'dark' })) as DesktopPrefs;
     expect(next.theme).toBe('dark');
-    const read = (await handlers.get('prefs.read')!()) as DesktopPrefs;
+    const readHandler = handlers.get('prefs.read');
+    assertDefined(readHandler, 'prefs.read handler');
+    const read = (await readHandler()) as DesktopPrefs;
     expect(read.theme).toBe('dark');
   });
 });

--- a/packages/desktop-host/src/ipc/scheduler.test.ts
+++ b/packages/desktop-host/src/ipc/scheduler.test.ts
@@ -10,6 +10,7 @@ import type { IpcCommandName } from '@moxxy/desktop-ipc-contract';
 import { ScheduleStore } from '@moxxy/plugin-scheduler';
 import { setActiveBus } from './shared';
 import { registerSchedulerHandlers } from './scheduler';
+import { assertDefined } from '@moxxy/sdk';
 
 type Handler = (...args: unknown[]) => Promise<unknown>;
 
@@ -49,7 +50,9 @@ describe('scheduler IPC handlers', () => {
       prompt: 'Write the morning summary',
       cron: '0 8 * * *',
     });
-    expect(await handlers.get('scheduler.list')!()).toEqual([
+    const listHandler = handlers.get('scheduler.list');
+    assertDefined(listHandler, 'scheduler.list handler');
+    expect(await listHandler()).toEqual([
       expect.objectContaining({ id: first.id, name: 'morning-summary' }),
     ]);
 
@@ -59,7 +62,7 @@ describe('scheduler IPC handlers', () => {
       cron: '0 18 * * *',
     });
 
-    expect(await handlers.get('scheduler.list')!()).toEqual([
+    expect(await listHandler()).toEqual([
       expect.objectContaining({ id: first.id, name: 'morning-summary' }),
       expect.objectContaining({ id: second.id, name: 'evening-summary' }),
     ]);
@@ -76,11 +79,17 @@ describe('scheduler IPC handlers', () => {
       cron: '0 9 * * 1',
     });
 
-    await expect(handlers.get('scheduler.setEnabled')!({
+    const setEnabledHandler = handlers.get('scheduler.setEnabled');
+    assertDefined(setEnabledHandler, 'scheduler.setEnabled handler');
+    await expect(setEnabledHandler({
       id: created.id,
       enabled: false,
     })).resolves.toEqual(expect.objectContaining({ id: created.id, enabled: false }));
-    await expect(handlers.get('scheduler.delete')!({ id: created.id })).resolves.toEqual({ deleted: true });
-    await expect(handlers.get('scheduler.list')!()).resolves.toEqual([]);
+    const deleteHandler = handlers.get('scheduler.delete');
+    assertDefined(deleteHandler, 'scheduler.delete handler');
+    await expect(deleteHandler({ id: created.id })).resolves.toEqual({ deleted: true });
+    const listHandler = handlers.get('scheduler.list');
+    assertDefined(listHandler, 'scheduler.list handler');
+    await expect(listHandler()).resolves.toEqual([]);
   });
 });

--- a/packages/desktop-host/src/ipc/session.test.ts
+++ b/packages/desktop-host/src/ipc/session.test.ts
@@ -58,6 +58,7 @@ import type { RunnerSupervisor } from '../runner-supervisor';
 import type { SessionDriver } from '../session-driver';
 import { desktopEventBus } from '../event-bus';
 import { __resetPickedAttachments } from '../attachment-authz';
+import { assertDefined } from '@moxxy/sdk';
 
 type Handler = (...args: unknown[]) => Promise<unknown>;
 
@@ -103,7 +104,9 @@ describe('session.info handler', () => {
     setActiveBus(bus);
     registerSessionHandlers(pool);
 
-    const result = handlers.get('session.info')!({ workspaceId: 'fresh-session' });
+    const infoHandler = handlers.get('session.info');
+    assertDefined(infoHandler, 'session.info handler');
+    const result = infoHandler({ workspaceId: 'fresh-session' });
     await Promise.resolve();
     supervisor = { remote: () => ({ getInfo: () => sessionInfo('fresh-session') }) };
     poolEmitter.emit('change', 'fresh-session');
@@ -130,7 +133,9 @@ describe('session.setModel handler', () => {
     setActiveBus(bus);
     registerSessionHandlers(pool);
 
-    await handlers.get('session.setModel')!({ workspaceId: 'ws-model', model: 'gpt-5.4' });
+    const setModelHandler = handlers.get('session.setModel');
+    assertDefined(setModelHandler, 'session.setModel handler');
+    await setModelHandler({ workspaceId: 'ws-model', model: 'gpt-5.4' });
 
     expect(events).toContainEqual({
       channel: 'session.model.changed',
@@ -157,7 +162,9 @@ describe('session.setAutoApprove handler', () => {
     registerSessionHandlers(pool);
 
     try {
-      await handlers.get('session.setAutoApprove')!({
+      const setAutoApproveHandler = handlers.get('session.setAutoApprove');
+      assertDefined(setAutoApproveHandler, 'session.setAutoApprove handler');
+      await setAutoApproveHandler({
         workspaceId: 'ws-auto',
         enabled: true,
       });
@@ -201,7 +208,9 @@ describe('session.runTurn handler', () => {
     registerSessionHandlers(pool);
 
     try {
-      await handlers.get('session.runTurn')!({
+      const runTurnHandler = handlers.get('session.runTurn');
+      assertDefined(runTurnHandler, 'session.runTurn handler');
+      await runTurnHandler({
         workspaceId: 'ws-inline',
         prompt: 'Przeanalizuj obraz',
         inlineAttachments,
@@ -253,12 +262,16 @@ describe('session.transcribe / hasTranscriber fallback chain', () => {
     };
     const handlers = register(makePool(remote));
 
+    const transcribeHandler = handlers.get('session.transcribe');
+    assertDefined(transcribeHandler, 'session.transcribe handler');
     await expect(
-      handlers.get('session.transcribe')!({ workspaceId: WS, audioBase64: AUDIO, mimeType: MIME }),
+      transcribeHandler({ workspaceId: WS, audioBase64: AUDIO, mimeType: MIME }),
     ).resolves.toBe('hello from the runner');
     expect(runnerTranscribe).toHaveBeenCalledTimes(1);
     // The mic's mimeType flows through to the runner transcriber unchanged.
-    expect(runnerTranscribe.mock.calls[0]![1]).toEqual({ mimeType: MIME });
+    const firstCall = runnerTranscribe.mock.calls[0];
+    assertDefined(firstCall, 'runner transcribe first call');
+    expect(firstCall[1]).toEqual({ mimeType: MIME });
     expect(codexTranscribe).not.toHaveBeenCalled();
   });
 
@@ -270,19 +283,25 @@ describe('session.transcribe / hasTranscriber fallback chain', () => {
     };
     const handlers = register(makePool(remote));
 
+    const transcribeHandler = handlers.get('session.transcribe');
+    assertDefined(transcribeHandler, 'session.transcribe handler');
     await expect(
-      handlers.get('session.transcribe')!({ workspaceId: WS, audioBase64: AUDIO, mimeType: MIME }),
+      transcribeHandler({ workspaceId: WS, audioBase64: AUDIO, mimeType: MIME }),
     ).resolves.toBe('from codex');
     expect(codexTranscribe).toHaveBeenCalledTimes(1);
-    expect(codexTranscribe.mock.calls[0]![1]).toEqual({ mimeType: MIME });
+    const firstCall = codexTranscribe.mock.calls[0];
+    assertDefined(firstCall, 'codex transcribe first call');
+    expect(firstCall[1]).toEqual({ mimeType: MIME });
   });
 
   it('falls back to Codex when not connected to a runner at all', async () => {
     codexTranscribe.mockResolvedValue({ text: 'from codex, no runner' });
     const handlers = register(makePool(null)); // supervisor.remote() → null
 
+    const transcribeHandler = handlers.get('session.transcribe');
+    assertDefined(transcribeHandler, 'session.transcribe handler');
     await expect(
-      handlers.get('session.transcribe')!({ workspaceId: WS, audioBase64: AUDIO }),
+      transcribeHandler({ workspaceId: WS, audioBase64: AUDIO }),
     ).resolves.toBe('from codex, no runner');
     expect(codexTranscribe).toHaveBeenCalledTimes(1);
   });
@@ -297,8 +316,10 @@ describe('session.transcribe / hasTranscriber fallback chain', () => {
     };
     const handlers = register(makePool(remote));
 
+    const transcribeHandler = handlers.get('session.transcribe');
+    assertDefined(transcribeHandler, 'session.transcribe handler');
     await expect(
-      handlers.get('session.transcribe')!({ workspaceId: WS, audioBase64: AUDIO }),
+      transcribeHandler({ workspaceId: WS, audioBase64: AUDIO }),
     ).rejects.toThrow('whisper model missing');
     // A broken local model must NOT quietly fall through to the cloud path.
     expect(codexTranscribe).not.toHaveBeenCalled();
@@ -306,8 +327,10 @@ describe('session.transcribe / hasTranscriber fallback chain', () => {
 
   it('rejects a malformed base64 payload at the handler boundary', async () => {
     const handlers = register(makePool(null));
+    const transcribeHandler = handlers.get('session.transcribe');
+    assertDefined(transcribeHandler, 'session.transcribe handler');
     await expect(
-      handlers.get('session.transcribe')!({ audioBase64: 'not base64!!!' }),
+      transcribeHandler({ audioBase64: 'not base64!!!' }),
     ).rejects.toThrow(/base64/);
     expect(codexTranscribe).not.toHaveBeenCalled();
   });
@@ -316,7 +339,9 @@ describe('session.transcribe / hasTranscriber fallback chain', () => {
     const remote = { getInfo: () => ({ ...sessionInfo(WS), activeTranscriber: 'stt-local' }) };
     const handlers = register(makePool(remote));
 
-    await expect(handlers.get('session.hasTranscriber')!()).resolves.toBe(true);
+    const hasTranscriberHandler = handlers.get('session.hasTranscriber');
+    assertDefined(hasTranscriberHandler, 'session.hasTranscriber handler');
+    await expect(hasTranscriberHandler()).resolves.toBe(true);
     expect(vaultGet).not.toHaveBeenCalled();
   });
 
@@ -325,7 +350,9 @@ describe('session.transcribe / hasTranscriber fallback chain', () => {
     const remote = { getInfo: () => sessionInfo(WS) }; // activeTranscriber: null
     const handlers = register(makePool(remote));
 
-    await expect(handlers.get('session.hasTranscriber')!()).resolves.toBe(true);
+    const hasTranscriberHandler = handlers.get('session.hasTranscriber');
+    assertDefined(hasTranscriberHandler, 'session.hasTranscriber handler');
+    await expect(hasTranscriberHandler()).resolves.toBe(true);
     expect(vaultGet).toHaveBeenCalledWith('oauth/openai-codex/refresh_token');
   });
 
@@ -334,7 +361,9 @@ describe('session.transcribe / hasTranscriber fallback chain', () => {
     const remote = { getInfo: () => sessionInfo(WS) };
     const handlers = register(makePool(remote));
 
-    await expect(handlers.get('session.hasTranscriber')!()).resolves.toBe(false);
+    const hasTranscriberHandler = handlers.get('session.hasTranscriber');
+    assertDefined(hasTranscriberHandler, 'session.hasTranscriber handler');
+    await expect(hasTranscriberHandler()).resolves.toBe(false);
   });
 });
 
@@ -374,12 +403,18 @@ describe('session.* attachment provenance', () => {
     await rm(CWD, { recursive: true, force: true });
   });
 
-  const invoke = (channel: string, args?: unknown): Promise<unknown> =>
-    provenanceHandlers.get(channel)!(args);
+  const invoke = (channel: string, args?: unknown): Promise<unknown> => {
+    const handler = provenanceHandlers.get(channel);
+    assertDefined(handler, `handler for ${channel}`);
+    return handler(args);
+  };
 
   /** The attachments `session.runTurn` forwarded to the driver after the gate. */
-  const forwardedAttachments = (): ReadonlyArray<unknown> =>
-    driverRunTurn.mock.calls[0]![2] as ReadonlyArray<unknown>;
+  const forwardedAttachments = (): ReadonlyArray<unknown> => {
+    const firstCall = driverRunTurn.mock.calls[0];
+    assertDefined(firstCall, 'driver runTurn first call');
+    return firstCall[2] as ReadonlyArray<unknown>;
+  };
 
   it('saveImageAttachment remembers its temp path so a later runTurn keeps the image', async () => {
     const saved = (await invoke('session.saveImageAttachment', {

--- a/packages/desktop-host/src/ipc/session.ts
+++ b/packages/desktop-host/src/ipc/session.ts
@@ -22,6 +22,7 @@ import type { RunnerPool } from '../runner-pool';
 import { authorizeAttachments, rememberPickedAttachment } from '../attachment-authz';
 import { persistImageBlob, previewImageAttachment } from '../attachments.js';
 import { broadcastHostEvent } from '../event-bus.js';
+import { assertDefined } from '@moxxy/sdk';
 import { getSessionModel, setSessionModel } from '../session-models.js';
 import {
   getInProcessPlugins,
@@ -360,7 +361,8 @@ export function registerSessionHandlers(pool: RunnerPool): void {
       ? await dialog.showOpenDialog(window, opts)
       : await dialog.showOpenDialog(opts);
     if (result.canceled || result.filePaths.length === 0) return null;
-    const picked = result.filePaths[0]!;
+    const picked = result.filePaths[0];
+    assertDefined(picked, 'a file path is present when filePaths is non-empty');
     // Remember the user's choice so the later runTurn that references it is
     // authorized even though it lives outside the workspace cwd.
     await rememberPickedAttachment(picked);

--- a/packages/desktop-host/src/ipc/sessions.test.ts
+++ b/packages/desktop-host/src/ipc/sessions.test.ts
@@ -22,6 +22,7 @@ import { DeskStore } from '../desks';
 import type { RunnerPool } from '../runner-pool';
 import { setActiveBus } from './shared';
 import { registerSessionsHandlers } from './sessions';
+import { assertDefined } from '@moxxy/sdk';
 
 type Handler = (...args: unknown[]) => Promise<unknown>;
 
@@ -93,7 +94,11 @@ afterEach(() => {
   rmSync(home, { recursive: true, force: true });
 });
 
-const invoke = (channel: string, args?: unknown): Promise<unknown> => handlers.get(channel)!(args);
+const invoke = (channel: string, args?: unknown): Promise<unknown> => {
+  const handler = handlers.get(channel);
+  assertDefined(handler, `handler for ${channel}`);
+  return handler(args);
+};
 
 describe('sessions.* handlers', () => {
   it('registers the full command set', () => {
@@ -149,7 +154,8 @@ describe('sessions.* handlers', () => {
     await invoke('sessions.remove', { id: desk.id });
     const overview = await desks.listSessions(desk.id);
     expect(overview.sessions).toHaveLength(1);
-    const fresh = overview.sessions[0]!;
+    const fresh = overview.sessions[0];
+    assertDefined(fresh, 'promoted replacement session');
     expect(fresh.id).not.toBe(desk.id);
     expect(calls).toContainEqual({ op: 'getOrCreate', id: fresh.id, cwd: cwdA });
     expect(calls).toContainEqual({ op: 'setActive', id: fresh.id });
@@ -161,6 +167,8 @@ describe('sessions.* handlers', () => {
       name: string;
     };
     expect(renamed.name).toBe('Deep dive');
-    expect((await desks.listSessions(desk.id)).sessions[0]!.name).toBe('Deep dive');
+    const [firstSession] = (await desks.listSessions(desk.id)).sessions;
+    assertDefined(firstSession, 'renamed session');
+    expect(firstSession.name).toBe('Deep dive');
   });
 });

--- a/packages/desktop-host/src/ipc/surfaces.test.ts
+++ b/packages/desktop-host/src/ipc/surfaces.test.ts
@@ -17,6 +17,7 @@ import type { IpcCommandName } from '@moxxy/desktop-ipc-contract';
 import type { RunnerPool } from '../runner-pool';
 import { setActiveBus } from './shared';
 import { registerSurfaceHandlers } from './surfaces';
+import { assertDefined } from '@moxxy/sdk';
 
 type Handler = (...args: unknown[]) => Promise<unknown>;
 
@@ -84,20 +85,26 @@ describe('registerSurfaceHandlers', () => {
   it('surface.list returns the session surfaces', async () => {
     const { session } = fakeSession();
     const handlers = register(fakePool(session));
-    const result = await handlers.get('surface.list')!({ workspaceId: 'ws1' });
+    const listHandler = handlers.get('surface.list');
+    assertDefined(listHandler, 'surface.list handler');
+    const result = await listHandler({ workspaceId: 'ws1' });
     expect(result).toEqual([{ id: 's1', kind: 'terminal' }]);
   });
 
   it('surface.list degrades to [] when no session is connected yet', async () => {
     const handlers = register(fakePool(null));
-    const result = await handlers.get('surface.list')!({ workspaceId: 'ws1' });
+    const listHandler = handlers.get('surface.list');
+    assertDefined(listHandler, 'surface.list handler');
+    const result = await listHandler({ workspaceId: 'ws1' });
     expect(result).toEqual([]);
   });
 
   it('surface.open forwards the kind and returns the open result', async () => {
     const { session, calls } = fakeSession();
     const handlers = register(fakePool(session));
-    const result = await handlers.get('surface.open')!({ workspaceId: 'ws1', kind: 'terminal' });
+    const openHandler = handlers.get('surface.open');
+    assertDefined(openHandler, 'surface.open handler');
+    const result = await openHandler({ workspaceId: 'ws1', kind: 'terminal' });
     expect(result).toEqual({ surfaceId: 's2' });
     expect(calls).toContainEqual({ op: 'openSurface', args: ['terminal'] });
   });
@@ -105,28 +112,36 @@ describe('registerSurfaceHandlers', () => {
   it('surface.input forwards surfaceId + message', async () => {
     const { session, calls } = fakeSession();
     const handlers = register(fakePool(session));
-    await handlers.get('surface.input')!({ workspaceId: 'ws1', surfaceId: 's2', message: { data: 'ls\n' } });
+    const inputHandler = handlers.get('surface.input');
+    assertDefined(inputHandler, 'surface.input handler');
+    await inputHandler({ workspaceId: 'ws1', surfaceId: 's2', message: { data: 'ls\n' } });
     expect(calls).toContainEqual({ op: 'inputSurface', args: ['s2', { data: 'ls\n' }] });
   });
 
   it('surface.resize forwards surfaceId + size', async () => {
     const { session, calls } = fakeSession();
     const handlers = register(fakePool(session));
-    await handlers.get('surface.resize')!({ workspaceId: 'ws1', surfaceId: 's2', size: { cols: 80, rows: 24 } });
+    const resizeHandler = handlers.get('surface.resize');
+    assertDefined(resizeHandler, 'surface.resize handler');
+    await resizeHandler({ workspaceId: 'ws1', surfaceId: 's2', size: { cols: 80, rows: 24 } });
     expect(calls).toContainEqual({ op: 'resizeSurface', args: ['s2', { cols: 80, rows: 24 }] });
   });
 
   it('surface.close forwards surfaceId', async () => {
     const { session, calls } = fakeSession();
     const handlers = register(fakePool(session));
-    await handlers.get('surface.close')!({ workspaceId: 'ws1', surfaceId: 's2' });
+    const closeHandler = handlers.get('surface.close');
+    assertDefined(closeHandler, 'surface.close handler');
+    await closeHandler({ workspaceId: 'ws1', surfaceId: 's2' });
     expect(calls).toContainEqual({ op: 'closeSurface', args: ['s2'] });
   });
 
   it('a mutating op throws when no session is connected (requireSession default)', async () => {
     const handlers = register(fakePool(null));
+    const openHandler = handlers.get('surface.open');
+    assertDefined(openHandler, 'surface.open handler');
     await expect(
-      handlers.get('surface.open')!({ workspaceId: 'ws1', kind: 'terminal' }),
+      openHandler({ workspaceId: 'ws1', kind: 'terminal' }),
     ).rejects.toThrow(/not connected/);
   });
 });

--- a/packages/desktop-host/src/ipc/webhooks.test.ts
+++ b/packages/desktop-host/src/ipc/webhooks.test.ts
@@ -10,6 +10,7 @@ import type { IpcCommandName } from '@moxxy/desktop-ipc-contract';
 import { WebhookStore } from '@moxxy/plugin-webhooks';
 import { setActiveBus } from './shared';
 import { registerWebhookHandlers } from './webhooks';
+import { assertDefined } from '@moxxy/sdk';
 
 type Handler = (...args: unknown[]) => Promise<unknown>;
 
@@ -56,12 +57,14 @@ describe('webhooks IPC handlers', () => {
     registerWebhookHandlers(store);
 
     const first = await store.create(triggerInput('github-push'));
-    expect(await handlers.get('webhooks.list')!()).toEqual([
+    const listHandler = handlers.get('webhooks.list');
+    assertDefined(listHandler, 'webhooks.list handler');
+    expect(await listHandler()).toEqual([
       expect.objectContaining({ id: first.id, name: 'github-push', localPath: `/webhook/${first.id}` }),
     ]);
 
     const second = await externalStore.create(triggerInput('stripe-charge'));
-    expect(await handlers.get('webhooks.list')!()).toEqual([
+    expect(await listHandler()).toEqual([
       expect.objectContaining({ id: first.id, name: 'github-push' }),
       expect.objectContaining({ id: second.id, name: 'stripe-charge' }),
     ]);
@@ -77,7 +80,9 @@ describe('webhooks IPC handlers', () => {
       verification: { type: 'bearer', secret: 'super-secret-token' },
     });
 
-    const listed = (await handlers.get('webhooks.list')!()) as Array<Record<string, unknown>>;
+    const listHandler = handlers.get('webhooks.list');
+    assertDefined(listHandler, 'webhooks.list handler');
+    const listed = (await listHandler()) as Array<Record<string, unknown>>;
     expect(JSON.stringify(listed)).not.toContain('super-secret-token');
   });
 
@@ -88,12 +93,18 @@ describe('webhooks IPC handlers', () => {
     registerWebhookHandlers(store);
     const created = await store.create(triggerInput('weekly-recap'));
 
+    const setEnabledHandler = handlers.get('webhooks.setEnabled');
+    assertDefined(setEnabledHandler, 'webhooks.setEnabled handler');
     await expect(
-      handlers.get('webhooks.setEnabled')!({ id: created.id, enabled: false }),
+      setEnabledHandler({ id: created.id, enabled: false }),
     ).resolves.toEqual(expect.objectContaining({ id: created.id, enabled: false }));
-    await expect(handlers.get('webhooks.delete')!({ id: created.id })).resolves.toEqual({
+    const deleteHandler = handlers.get('webhooks.delete');
+    assertDefined(deleteHandler, 'webhooks.delete handler');
+    await expect(deleteHandler({ id: created.id })).resolves.toEqual({
       deleted: true,
     });
-    await expect(handlers.get('webhooks.list')!()).resolves.toEqual([]);
+    const listHandler = handlers.get('webhooks.list');
+    assertDefined(listHandler, 'webhooks.list handler');
+    await expect(listHandler()).resolves.toEqual([]);
   });
 });

--- a/packages/desktop-host/src/node-manager.ts
+++ b/packages/desktop-host/src/node-manager.ts
@@ -364,7 +364,9 @@ async function verifyChecksum(
   const shasums = await fetchText(shasumsUrl);
   // Lines look like: "<sha256>  node-v22.12.0-darwin-arm64.tar.gz"
   const line = shasums.split(/\r?\n/).find((l) => l.trim().endsWith(` ${fileName}`) || l.trim().endsWith(`  ${fileName}`));
-  const expected = line?.trim().split(/\s+/)[0]?.toLowerCase();
+  const fields = line?.trim().split(/\s+/);
+  const firstField = fields?.[0];
+  const expected = firstField?.toLowerCase();
   if (!expected) throw new Error(`No checksum found for ${fileName}.`);
   const actual = (await sha256File(archivePath)).toLowerCase();
   if (actual !== expected) {

--- a/packages/desktop-host/src/onboarding.ts
+++ b/packages/desktop-host/src/onboarding.ts
@@ -48,7 +48,9 @@ async function readActiveProviderAt(moxxyDir: string): Promise<string | null> {
   try {
     const body = await readFile(path.join(moxxyDir, 'config.yaml'), 'utf8');
     const cfg = parseYaml(body) as { plugins?: { provider?: { default?: string } } } | null;
-    return cfg?.plugins?.provider?.default ?? null;
+    const plugins = cfg?.plugins;
+    const provider = plugins?.provider;
+    return provider?.default ?? null;
   } catch {
     return null;
   }

--- a/packages/desktop-host/src/provider-discovery.ts
+++ b/packages/desktop-host/src/provider-discovery.ts
@@ -83,7 +83,9 @@ async function readStoredProviders(): Promise<StoredProvidersConfig> {
         };
       };
     } | null;
-    const items = cfg?.plugins?.provider?.items ?? {};
+    const plugins = cfg?.plugins;
+    const provider = plugins?.provider;
+    const items = provider?.items ?? {};
     const providers: StoredProvider[] = [];
     for (const [name, item] of Object.entries(items)) {
       const c = item?.config;

--- a/packages/desktop-host/src/provider-login.test.ts
+++ b/packages/desktop-host/src/provider-login.test.ts
@@ -8,7 +8,7 @@
 
 import { EventEmitter } from 'node:events';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { encodeLoginPrompt } from '@moxxy/sdk';
+import { assertDefined, encodeLoginPrompt } from '@moxxy/sdk';
 
 const h = vi.hoisted(() => ({
   spawn: undefined as undefined | ((...args: unknown[]) => unknown),
@@ -23,7 +23,10 @@ vi.mock('electron', () => ({}));
 vi.mock('./cli-resolver', () => ({
   augmentedPaths: () => [],
   resolveMoxxyCli: () => ({ kind: 'direct', bin: '/fake/moxxy' }),
-  spawnCli: (...args: unknown[]) => h.spawn!(...args),
+  spawnCli: (...args: unknown[]) => {
+    assertDefined(h.spawn, 'spawn stub');
+    return h.spawn(...args);
+  },
 }));
 vi.mock('./send-event', () => ({
   sendEvent: (_w: unknown, channel: string, payload: Record<string, unknown>) =>

--- a/packages/desktop-host/src/security.test.ts
+++ b/packages/desktop-host/src/security.test.ts
@@ -13,6 +13,7 @@ import {
   installContentSecurityPolicy,
   lockDownNavigation,
 } from './security';
+import { assertDefined } from '@moxxy/sdk';
 
 describe('provider-name validation', () => {
   it('accepts well-formed slugs', () => {
@@ -65,7 +66,9 @@ describe('navigation lockdown', () => {
       },
       allows: (target) => {
         let prevented = false;
-        handlers.get('will-navigate')!({ preventDefault: () => (prevented = true) }, target);
+        const willNavigate = handlers.get('will-navigate');
+        assertDefined(willNavigate, 'will-navigate handler');
+        willNavigate({ preventDefault: () => (prevented = true) }, target);
         return !prevented;
       },
     };
@@ -368,7 +371,8 @@ describe('CSP injection gate', () => {
     const run = probe({ isDev: false, clerkPublishableKey: LIVE, loopbackOrigin: LOOPBACK });
     for (const url of ['file:///app/dist/index.html', `${LOOPBACK}/index.html`]) {
       const headers = run(url);
-      const csp = headers?.['Content-Security-Policy']?.[0] ?? '';
+      const cspHeader = headers?.['Content-Security-Policy'];
+      const csp = cspHeader?.[0] ?? '';
       expect(csp).toContain("default-src 'self'");
       // the live-key prod host folds in
       expect(csp).toContain('https://clerk.acme.com');

--- a/packages/desktop-host/src/self-signed-cert.ts
+++ b/packages/desktop-host/src/self-signed-cert.ts
@@ -31,6 +31,7 @@
 import { promises as fsp } from 'node:fs';
 import crypto from 'node:crypto';
 import path from 'node:path';
+import { assertDefined } from '@moxxy/sdk';
 
 /** The single public hostname the packaged renderer is served under. It is a
  *  subdomain of `moxxy.ai`, so a Clerk production key accepts its origin; the
@@ -79,9 +80,15 @@ function setOf(...items: Buffer[]): Buffer {
 
 function oid(dotted: string): Buffer {
   const parts = dotted.split('.').map(Number);
-  const body: number[] = [40 * parts[0]! + parts[1]!];
+  const first = parts[0];
+  const second = parts[1];
+  assertDefined(first, 'OID has a first arc');
+  assertDefined(second, 'OID has a second arc');
+  const body: number[] = [40 * first + second];
   for (let i = 2; i < parts.length; i++) {
-    let v = parts[i]!;
+    const arc = parts[i];
+    assertDefined(arc, 'OID arc index within bounds');
+    let v = arc;
     const stack: number[] = [v & 0x7f];
     v >>= 7;
     while (v > 0) {
@@ -111,7 +118,9 @@ export function derInteger(magnitude: Buffer): Buffer {
   let i = 0;
   while (i < m.length - 1 && m[i] === 0x00) i += 1;
   m = m.subarray(i);
-  if (m[0]! & 0x80) m = Buffer.concat([Buffer.from([0x00]), m]);
+  const firstByte = m[0];
+  assertDefined(firstByte, 'derInteger keeps at least one byte');
+  if (firstByte & 0x80) m = Buffer.concat([Buffer.from([0x00]), m]);
   return tlv(0x02, m);
 }
 
@@ -231,7 +240,9 @@ function normalizeFingerprint(fp: string | undefined | null): string | null {
   const b64 = /^sha256\/(.+)$/i.exec(s);
   if (b64) {
     try {
-      const hex = Buffer.from(b64[1]!, 'base64').toString('hex');
+      const encoded = b64[1];
+      assertDefined(encoded, 'sha256 fingerprint capture group is present');
+      const hex = Buffer.from(encoded, 'base64').toString('hex');
       return hex.length === 64 ? hex : null;
     } catch {
       return null;

--- a/packages/desktop-host/src/session-driver.test.ts
+++ b/packages/desktop-host/src/session-driver.test.ts
@@ -20,6 +20,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { Session, autoAllowResolver, silentLogger } from '@moxxy/core';
 import {
   asPluginId,
+  assertDefined,
   defineMode,
   definePlugin,
   defineProvider,
@@ -232,13 +233,16 @@ describe('SessionDriver approval-gate survival', () => {
     const { win, sent } = fakeWindow();
     const driver = new SessionDriver(remote, win, 'ws-ask');
 
-    const decision = captured.permission!.check(
+    assertDefined(captured.permission, 'captured permission resolver');
+    const decision = captured.permission.check(
       { name: 'Write', input: { file_path: 'out.txt' } },
       { toolDescription: 'write a file' },
     );
     await waitFor(() => sent.some((f) => f.channel === 'ask.request'));
 
-    const req = sent.find((f) => f.channel === 'ask.request')!.payload as AskRequest;
+    const askFrame = sent.find((f) => f.channel === 'ask.request');
+    assertDefined(askFrame, 'ask.request frame');
+    const req = askFrame.payload as AskRequest;
     answerAsk(req.requestId, { mode: 'allow_session' } as never);
 
     await expect(decision).resolves.toEqual({ mode: 'allow_session' });
@@ -376,7 +380,8 @@ describe('SessionDriver auto-approve', () => {
     const driver = new SessionDriver(remote, win, 'ws');
     driver.setAutoApprove(true);
 
-    const res = await captured.permission!.check({ name: 'Write', input: {} }, {});
+    assertDefined(captured.permission, 'captured permission resolver');
+    const res = await captured.permission.check({ name: 'Write', input: {} }, {});
 
     expect(res).toEqual({ mode: 'allow' });
     expect(sent.some((f) => f.channel === 'ask.request')).toBe(false);
@@ -389,7 +394,8 @@ describe('SessionDriver auto-approve', () => {
     const driver = new SessionDriver(remote, win, 'ws');
 
     // Don't answer — leave the ask parked, like a user still deciding.
-    const p = captured.permission!.check({ name: 'Write', input: {} }, {});
+    assertDefined(captured.permission, 'captured permission resolver');
+    const p = captured.permission.check({ name: 'Write', input: {} }, {});
     await waitFor(() => sent.some((f) => f.channel === 'ask.request'));
     expect(sent.some((f) => f.channel === 'ask.request')).toBe(true);
 
@@ -409,7 +415,9 @@ describe('SessionDriver info-changed forwarding', () => {
     fireInfoChanged();
     const frames = sent.filter((f) => f.channel === 'session.info.changed');
     expect(frames).toHaveLength(1);
-    expect(frames[0]!.payload).toEqual({ workspaceId: 'ws-1' });
+    const firstFrame = frames[0];
+    assertDefined(firstFrame, 'info.changed frame');
+    expect(firstFrame.payload).toEqual({ workspaceId: 'ws-1' });
 
     // After dispose the subscription is dropped — no more forwards.
     driver.dispose();

--- a/packages/desktop-host/src/skills.ts
+++ b/packages/desktop-host/src/skills.ts
@@ -8,6 +8,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { readFile, readdir, unlink } from 'node:fs/promises';
 import path from 'node:path';
 import { moxxyHome, writeFileAtomic } from '@moxxy/sdk/server';
+import { assertDefined } from '@moxxy/sdk';
 import type { SkillFile } from '@moxxy/desktop-ipc-contract';
 
 /** Pull the frontmatter `description` (cheap regex — no YAML dep) so the
@@ -17,8 +18,13 @@ async function readDescription(file: string): Promise<string | undefined> {
     const raw = await readFile(file, 'utf8');
     const fm = /^---\s*\n([\s\S]*?)\n---/.exec(raw);
     if (!fm) return undefined;
-    const m = /^description:\s*(.+)$/m.exec(fm[1]!);
-    return m ? m[1]!.trim().replace(/^["']|["']$/g, '') : undefined;
+    const frontmatter = fm[1];
+    assertDefined(frontmatter, 'frontmatter capture group is present when the fence matches');
+    const m = /^description:\s*(.+)$/m.exec(frontmatter);
+    if (!m) return undefined;
+    const value = m[1];
+    assertDefined(value, 'description capture group is present when the line matches');
+    return value.trim().replace(/^["']|["']$/g, '');
   } catch {
     return undefined;
   }

--- a/packages/desktop-host/src/vault-key.test.ts
+++ b/packages/desktop-host/src/vault-key.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import os from 'node:os';
 
 import { ensureDesktopVaultKey } from './vault-key';
+import { assertDefined } from '@moxxy/sdk';
 
 // moxxyPath resolves under ~/.moxxy via MOXXY_HOME / HOME; point it at a temp dir.
 let tmp: string;
@@ -23,10 +24,14 @@ afterEach(() => {
 });
 
 function keyPath(): string {
-  return path.join(process.env.MOXXY_HOME!, 'vault.key');
+  const home = process.env.MOXXY_HOME;
+  assertDefined(home, 'MOXXY_HOME');
+  return path.join(home, 'vault.key');
 }
 function vaultPath(): string {
-  return path.join(process.env.MOXXY_HOME!, 'vault.json');
+  const home = process.env.MOXXY_HOME;
+  assertDefined(home, 'MOXXY_HOME');
+  return path.join(home, 'vault.json');
 }
 
 describe('ensureDesktopVaultKey', () => {
@@ -39,14 +44,18 @@ describe('ensureDesktopVaultKey', () => {
   });
 
   it('does NOT overwrite an existing vault.key', () => {
-    mkdirSync(process.env.MOXXY_HOME!, { recursive: true });
+    const home = process.env.MOXXY_HOME;
+    assertDefined(home, 'MOXXY_HOME');
+    mkdirSync(home, { recursive: true });
     writeFileSync(keyPath(), 'existing-key\n');
     ensureDesktopVaultKey();
     expect(readFileSync(keyPath(), 'utf8')).toBe('existing-key\n');
   });
 
   it('does NOT seed when a vault.json already exists (keyed by keychain/passphrase)', () => {
-    mkdirSync(process.env.MOXXY_HOME!, { recursive: true });
+    const home = process.env.MOXXY_HOME;
+    assertDefined(home, 'MOXXY_HOME');
+    mkdirSync(home, { recursive: true });
     writeFileSync(vaultPath(), '{}');
     ensureDesktopVaultKey();
     expect(existsSync(keyPath())).toBe(false);

--- a/packages/desktop-ipc-contract/src/validation.ts
+++ b/packages/desktop-ipc-contract/src/validation.ts
@@ -10,6 +10,7 @@
  */
 
 import { z } from 'zod';
+import { assertDefined } from '@moxxy/sdk';
 import type { UserPromptAttachment } from '@moxxy/sdk';
 import type { IpcCommandName } from './index.js';
 
@@ -252,7 +253,8 @@ export const ipcInputSchemas: Partial<Record<IpcCommandName, z.ZodTypeAny>> = {
       .superRefine((entries, ctx) => {
         let total = 0;
         for (let i = 0; i < entries.length; i++) {
-          const e = entries[i]!;
+          const e = entries[i];
+          assertDefined(e, 'entry index is within the bounds of entries');
           // Binary kinds (image/document/audio) carry base64 bytes that get
           // decoded host-side / by the provider — a non-base64 string would
           // decode to garbage, so reject it here (text kinds carry UTF-8 and


### PR DESCRIPTION
## Scope

The "desktop" slice of the repo-wide assert sweep — Guard, don't chain. Packages:
`@moxxy/desktop` (apps/desktop), `@moxxy/desktop-host`, `@moxxy/desktop-ipc-contract`,
`@moxxy/chat-model`, `@moxxy/anonymizer`, `fixture-recorder`.

Only two transformations, applied purely locally to each expression:
1. Every non-null assertion (`x!`, `x!.y`, `fn()!`, `arr[i]!`) → a narrow-once guard, then plain access.
2. Every optional chain of depth ≥ 2 (`a?.b?.c`, `a?.b()?.c`) → narrowed to single-level reads / a guard.

## Counts (before → after)

**Non-null assertions eliminated (eslint `@typescript-eslint/no-non-null-assertion`, 244 → 0):**

| Package | before → after |
|---|---|
| `@moxxy/desktop` | 71 → 0 |
| `@moxxy/chat-model` | 73 → 0 |
| `@moxxy/desktop-host` | 77 → 0 |
| `@moxxy/anonymizer` | 21 → 0 |
| `@moxxy/desktop-ipc-contract` | 1 → 0 |
| `fixture-recorder` | 1 → 0 |

**Deep optional chains (depth ≥ 2) converted:** desktop-host 9, apps/desktop ~11 regions, chat-model 0.
Dozens of grep hits were two *independent* single-level chains on one line (`a?.x ?? b?.y`,
`[a?.id, b?.id]`, `a.control?.x === b.control?.x`) — correctly left as-is. A single `?.` on a
genuinely-optional read is preserved everywhere.

**Definite-assignment class fields (`foo!: T`, out of scope):** 0 across all six packages.

## Semantics

- **Silent-absence paths preserved exactly:** config/optional/lookup reads keep their early return,
  single `?.`, or `?? fallback` (e.g. `provider-discovery`/`onboarding` config reads, `node-manager`
  checksum lookup, `focus-mode`/`useTheme`/`useReducedMotion` DOM listeners).
- **Impossible-by-construction → loud throw (desired):** in-bounds loop indices, mandatory regex
  capture groups (`m[1]!` after `if (m)`), class invariants (`ChunkedBlockLog` segments always
  non-empty), and checked preconditions (`ask.workflow!` inside `WorkflowSheet`) now throw at the
  assumption site via `assertDefined` / `invariant` instead of propagating a cryptic `undefined`.

## Notable decisions

- **`anonymizer` has no `@moxxy/sdk` dep** → a tiny local `required()` returning-guard. It checks
  `=== undefined/null`, **not** falsiness, because the checksum weight tables legitimately contain `0`
  (a truthiness test would wrongly reject them).
- **Browser-bundle safety:** the `@moxxy/sdk` root barrel transitively imports `node:fs` (via the JSON
  file store), so a runtime import breaks the desktop renderer's vite build. Browser-bundled code
  (`@moxxy/chat-model` + the desktop renderer) uses a small dependency-free local guard helper
  (`src/assert.ts` / `src/lib/assert.ts`); type-only sdk imports are untouched.
- **TS7022 avoidance:** `assertDefined`'s `NonNullable<T>` self-references on the recursive `Block`
  type / the generic `T` in `ChunkedBlockLog`, so those specific sites use `invariant(x !== undefined, …)`
  (narrows via the type-guard, not `NonNullable<T>`).
- **Electron main entry (`electron/main/index.ts`)** uses plain `if (x === undefined) throw` guards
  rather than importing the sdk barrel — avoiding an eager barrel import in the main process
  (known boot-crash class).

## Gate (from worktree root, each exit code checked directly)

| command | exit |
|---|---|
| `pnpm install` | 0 |
| `pnpm build` | 0 |
| `pnpm typecheck` | 0 |
| `pnpm lint` | 0 (44 pre-existing warnings, 0 errors) |
| `pnpm test` | all six packages green |
| `pnpm check:deps` | 0 (1 pre-existing orphan warning) |

**Flake notes** (both proven unrelated to this change, both timing/load-induced):
- `@moxxy/client-platform-web` `tts.test.ts` (not in this slice) timed out under concurrent load in
  the gate run; passes **2/2 in isolation** (20/20 tests).
- `@moxxy/anonymizer` `redact.test.ts` "does not blow up quadratically" **passed in the gate run**, but
  fails under sustained local machine load. Controlled A/B: the **original `!` baseline also fails
  identically** (~12.3s) vs my code (~13.3s) against an 8s threshold that is idle-normally ~3-5s —
  a machine-throttling artifact, not a complexity regression (`required()` adds only O(1)-per-op).