### PR TITLE
refactor(cli): replace non-null assertions and deep optional chains with guards

### DIFF
--- a/.changeset/assert-sweep-cli.md
+++ b/.changeset/assert-sweep-cli.md
@@ -1,0 +1,17 @@
+---
+'@moxxy/cli': patch
+'@moxxy/config': patch
+'@moxxy/plugin-cli': patch
+'@moxxy/plugin-commands': patch
+'@moxxy/plugin-oauth': patch
+'@moxxy/plugin-plugins-admin': patch
+'@moxxy/plugin-provider-admin': patch
+'@moxxy/plugin-self-update': patch
+'@moxxy/plugin-vault': patch
+---
+
+Replace non-null assertions (`x!`) and deep optional chains (`a?.b?.c`) across
+the CLI package group with guard clauses. Impossible-by-construction reads now
+fail loudly via `assertDefined`/`invariant` with a stated reason; genuinely
+optional reads keep their silent path (single-level `?.` / early return /
+default). No behavior change on any reachable path.

--- a/packages/cli/src/argv.ts
+++ b/packages/cli/src/argv.ts
@@ -1,3 +1,5 @@
+import { assertDefined } from '@moxxy/sdk';
+
 export interface ParsedArgv {
   command: string;
   flags: Record<string, string | boolean>;
@@ -79,7 +81,8 @@ export function parseArgv(argv: ReadonlyArray<string>): ParsedArgv {
     return result;
   }
   let i = 0;
-  const first = argv[0]!;
+  const first = argv[0];
+  assertDefined(first, 'argv is non-empty (length checked above)');
   const looksLikeCommand = !first.startsWith('-');
   if (looksLikeCommand) {
     result.command = first;
@@ -88,7 +91,8 @@ export function parseArgv(argv: ReadonlyArray<string>): ParsedArgv {
 
   let endOfOptions = false;
   for (; i < argv.length; i++) {
-    const a = argv[i]!;
+    const a = argv[i];
+    assertDefined(a, 'i < argv.length within the loop');
     if (endOfOptions) {
       result.positional.push(a);
       continue;

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -138,8 +138,9 @@ async function runDoctorChecks(deps: DoctorChecksDeps): Promise<number> {
   }
 
   // Providers
-  const primary = config.plugins?.provider?.default ?? 'anthropic';
-  const fallbacks = config.plugins?.provider?.fallbacks ?? [];
+  const providerCfg = config.plugins?.provider;
+  const primary = providerCfg?.default ?? 'anthropic';
+  const fallbacks = providerCfg?.fallbacks ?? [];
   const providerNames = Array.from(new Set([primary, ...fallbacks]));
   for (const name of providerNames) {
     const def = session.providers.list().find((p) => p.name === name);
@@ -167,8 +168,12 @@ async function runDoctorChecks(deps: DoctorChecksDeps): Promise<number> {
       });
       continue;
     }
-    if (checkKeys && def.validateKey) {
-      const v = await tryCatch(() => def.validateKey!(key!));
+    const { validateKey } = def;
+    if (checkKeys && validateKey) {
+      // Capture the narrowed key/function as consts so the closure keeps the
+      // narrowing; call with `def` as receiver to preserve `this` semantics.
+      const resolvedKey = key;
+      const v = await tryCatch(() => validateKey.call(def, resolvedKey));
       if (!v.ok) {
         checks.push({
           id: `provider:${name}`,

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -148,9 +148,10 @@ async function runInteractiveInit(
       if (!session.modes.list().some((m) => m.name === selections.mode)) {
         const entry = findCatalogEntryForContribution('mode', selections.mode);
         if (entry) {
+          const pinVersion = cliVersion();
           await installPluginPackagePinned({
             packageName: entry.packageName,
-            ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
+            ...(pinVersion ? { cliVersion: pinVersion } : {}),
           });
           await setPluginEnabled(entry.packageName, true);
         }
@@ -180,11 +181,12 @@ async function runInteractiveInit(
       await providerSetup.loginOAuth(providerId);
     },
     async installPlugins(ids: ReadonlyArray<string>): Promise<void> {
+      const pinVersion = cliVersion();
       for (const id of ids) {
         const pkg = resolveCatalogPackageName(id);
         await installPluginPackagePinned({
           packageName: pkg,
-          ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
+          ...(pinVersion ? { cliVersion: pinVersion } : {}),
         });
         await setPluginEnabled(pkg, true);
       }
@@ -200,6 +202,7 @@ async function runInteractiveInit(
     description: e.description,
   }));
 
+  const wizardVersion = cliVersion();
   await runSetupWizard({
     providers,
     models,
@@ -208,7 +211,7 @@ async function runInteractiveInit(
     controller,
     authKinds,
     availablePlugins,
-    ...(cliVersion() ? { version: cliVersion()! } : {}),
+    ...(wizardVersion ? { version: wizardVersion } : {}),
   });
 
   // Plugin-declared setup steps (`package.json#moxxy.setup`): every installed

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -222,8 +222,8 @@ async function runLoginStatus(argv: ParsedArgv, session: Session, vault: VaultSt
   }
 
   for (const def of oauthProviders) {
-    const auth = def.auth!;
-    if (auth.kind !== 'oauth') continue;
+    const auth = def.auth;
+    if (auth?.kind !== 'oauth') continue;
     if (!auth.status) {
       process.stdout.write(
         `${colors.bold(def.name)}  ${colors.dim('status not reported by plugin')}\n`,

--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { MemoryType } from '@moxxy/plugin-memory';
+import { assertDefined } from '@moxxy/sdk';
 import { formatRelative, formatSize, groupByType, mapBounded, runMemoryCommand } from './memory.js';
 import type { ParsedArgv } from '../argv.js';
 
@@ -30,8 +31,10 @@ describe('groupByType', () => {
   it('omits empty groups', () => {
     const groups = groupByType([statOfType('fact'), statOfType('fact')]);
     expect(groups).toHaveLength(1);
-    expect(groups[0]![0]).toBe('fact');
-    expect(groups[0]![1]).toHaveLength(2);
+    const firstGroup = groups[0];
+    assertDefined(firstGroup, 'one group returned');
+    expect(firstGroup[0]).toBe('fact');
+    expect(firstGroup[1]).toHaveLength(2);
   });
 
   it('buckets an out-of-order (unmapped) type at the END, after the ordered groups', () => {

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -188,7 +188,9 @@ export async function mapBounded<T, R>(
   for (let i = 0; i < items.length; i += limit) {
     const chunk = items.slice(i, i + limit);
     const results = await Promise.all(chunk.map(fn));
-    for (let j = 0; j < results.length; j += 1) out[i + j] = results[j]!;
+    // Promise.all yields a dense array, so entries() visits every result —
+    // including a legitimately-undefined R — without an index assertion.
+    for (const [j, result] of results.entries()) out[i + j] = result;
   }
   return out;
 }

--- a/packages/cli/src/commands/onboard.test.ts
+++ b/packages/cli/src/commands/onboard.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { buildChannelChoices, catalogChannelEntry } from './onboard.js';
 
 describe('catalogChannelEntry', () => {
@@ -6,7 +7,8 @@ describe('catalogChannelEntry', () => {
     for (const name of ['discord', 'telegram', 'whatsapp', 'signal', 'slack']) {
       const entry = catalogChannelEntry(name);
       expect(entry, name).toBeDefined();
-      expect(entry!.provides).toEqual(
+      assertDefined(entry, `catalog entry for ${name}`);
+      expect(entry.provides).toEqual(
         expect.arrayContaining([{ category: 'channel', name }]),
       );
     }
@@ -31,8 +33,10 @@ describe('buildChannelChoices', () => {
 
   it('marks already-registered channels as installed', () => {
     const choices = buildChannelChoices(new Set(['telegram']));
-    const telegram = choices.find((c) => c.value === 'telegram')!;
-    const discord = choices.find((c) => c.value === 'discord')!;
+    const telegram = choices.find((c) => c.value === 'telegram');
+    assertDefined(telegram, 'telegram choice present');
+    const discord = choices.find((c) => c.value === 'discord');
+    assertDefined(discord, 'discord choice present');
     expect(telegram.installed).toBe(true);
     expect(telegram.hint).toMatch(/^installed · /);
     expect(discord.installed).toBe(false);
@@ -47,7 +51,8 @@ describe('buildChannelChoices', () => {
   });
 
   it('surfaces the WhatsApp ToS warning in its hint', () => {
-    const whatsapp = buildChannelChoices(new Set()).find((c) => c.value === 'whatsapp')!;
+    const whatsapp = buildChannelChoices(new Set()).find((c) => c.value === 'whatsapp');
+    assertDefined(whatsapp, 'whatsapp choice present');
     expect(whatsapp.hint).toMatch(/ToS|UNOFFICIAL/i);
   });
 });

--- a/packages/cli/src/commands/onboard.ts
+++ b/packages/cli/src/commands/onboard.ts
@@ -197,9 +197,10 @@ export async function runOnboardCommand(argv: ParsedArgv): Promise<number> {
     const s = spinner();
     s.start(`Installing ${picked.entry.packageName}…`);
     try {
+      const pinVersion = cliVersion();
       await installPluginPackagePinned({
         packageName: picked.entry.packageName,
-        ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
+        ...(pinVersion ? { cliVersion: pinVersion } : {}),
       });
       await setPluginEnabled(picked.entry.packageName, true);
       s.stop(`Installed ${picked.entry.packageName} ✓`);

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -199,10 +199,11 @@ async function runInstall(argv: ParsedArgv): Promise<number> {
     // Bare first-party specs pin to the CLI version (co-published via the
     // fixed changeset group); a pin that 404s retries latest with a warning.
     // Explicit --version/--ref specs pass through untouched.
+    const pinVersion = cliVersion();
     const result = await installPluginPackagePinned({
       packageName: spec,
       ...(resolved?.pinnedVersion ? { pinnedVersion: resolved.pinnedVersion } : {}),
-      ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
+      ...(pinVersion ? { cliVersion: pinVersion } : {}),
       onWarn: (msg) => process.stderr.write(colors.dim(msg) + '\n'),
     });
     if (resolved?.origin === 'signed' && resolved.pinnedVersion) {

--- a/packages/cli/src/commands/run-tui.ts
+++ b/packages/cli/src/commands/run-tui.ts
@@ -202,9 +202,10 @@ export async function runTuiWithBootstrap(
  */
 async function applyTuiPreferences(argv: ParsedArgv): Promise<void> {
   try {
+    const explicitPath = stringFlag(argv, 'config');
     const { config } = await loadConfig({
       cwd: process.cwd(),
-      ...(stringFlag(argv, 'config') ? { explicitPath: stringFlag(argv, 'config')! } : {}),
+      ...(explicitPath ? { explicitPath } : {}),
     });
     const tui = config.tui;
     if (!tui) return;
@@ -324,9 +325,10 @@ async function runSelfHostedTui(
   standalone: boolean,
 ): Promise<number> {
   if (process.stdin.isTTY) {
+    const explicitPath = stringFlag(argv, 'config');
     const { sources } = await loadConfig({
       cwd: process.cwd(),
-      ...(stringFlag(argv, 'config') ? { explicitPath: stringFlag(argv, 'config')! } : {}),
+      ...(explicitPath ? { explicitPath } : {}),
     });
     let needsInit = sources.length === 0;
     if (!needsInit) {
@@ -509,7 +511,8 @@ async function runSelfHostedTui(
   const attachOrSpawnCollab = async (goal?: string): Promise<ClientSession> => {
     if (!goal) {
       const active = readActiveCollab();
-      const runningSocket = active?.runnerSocket?.trim();
+      const activeSocket = active?.runnerSocket;
+      const runningSocket = activeSocket?.trim();
       if (runningSocket && (await isRunnerUp(runningSocket))) {
         return connectRemoteSession({ role: 'tui', socketPath: runningSocket, replay: 'full' });
       }

--- a/packages/cli/src/commands/schedule/handlers.ts
+++ b/packages/cli/src/commands/schedule/handlers.ts
@@ -1,5 +1,6 @@
 import { isValidCron, runSchedule } from '@moxxy/plugin-scheduler';
 import type { ScheduleStore } from '@moxxy/plugin-scheduler';
+import { assertDefined } from '@moxxy/sdk';
 import type { ParsedArgv } from '../../argv.js';
 import { colors } from '../../colors.js';
 import { setupSessionWithConfig } from '../../setup.js';
@@ -31,7 +32,14 @@ export async function listSchedules(store: ScheduleStore): Promise<number> {
   for (const s of all) {
     const status = s.enabled ? 'on' : 'off';
     const src = s.source === 'skill' ? `skill:${s.skillName}` : 'manual';
-    const trig = s.cron ? `cron "${s.cron}"` : `at ${new Date(s.runAt!).toISOString()}`;
+    let trig: string;
+    if (s.cron) {
+      trig = `cron "${s.cron}"`;
+    } else {
+      // scheduleEntrySchema requires cron or runAt, so a cron-less entry has one.
+      assertDefined(s.runAt, `schedule "${s.name}" has neither cron nor runAt`);
+      trig = `at ${new Date(s.runAt).toISOString()}`;
+    }
     process.stdout.write(
       `${colors.bold(s.name.padEnd(nameCol))}  ${colors.dim(status)}  ${colors.dim(trig)}\n` +
         `${' '.repeat(nameCol + 2)}${colors.dim(`id ${s.id} · ${src} · next ${fmtNext(s)}`)}\n` +
@@ -75,14 +83,17 @@ export async function addSchedule(store: ScheduleStore, argv: ParsedArgv): Promi
         '\n',
     );
   }
+  const timeZone = flag(argv, 'timezone');
+  const channel = flag(argv, 'channel');
+  const model = flag(argv, 'model');
   const created = await store.create({
     name,
     prompt,
     ...(cron ? { cron } : {}),
     ...(runAt !== undefined ? { runAt } : {}),
-    ...(flag(argv, 'timezone') ? { timeZone: flag(argv, 'timezone')! } : {}),
-    ...(flag(argv, 'channel') ? { channel: flag(argv, 'channel')! } : {}),
-    ...(flag(argv, 'model') ? { model: flag(argv, 'model')! } : {}),
+    ...(timeZone ? { timeZone } : {}),
+    ...(channel ? { channel } : {}),
+    ...(model ? { model } : {}),
   });
   process.stdout.write(
     `${colors.bold('created')}  ${colors.bold(created.name)}  ${colors.dim(created.id)}\n` +

--- a/packages/cli/src/commands/security.ts
+++ b/packages/cli/src/commands/security.ts
@@ -39,7 +39,8 @@ export async function runSecurityCommand(argv: ParsedArgv): Promise<number> {
 
   if (sub === 'status') {
     const enabled = config.security?.enabled ?? false;
-    const isolator = config.plugins?.isolator?.default ?? '(default: inproc)';
+    const isolatorSlot = config.plugins?.isolator;
+    const isolator = isolatorSlot?.default ?? '(default: inproc)';
     // 'warn' is the plugin-side default while security is enabled (grace
     // mode); surface it as such rather than pretending the ratchet is off.
     const ratchet = config.security?.thirdPartyRequireDeclaration ?? 'warn';
@@ -232,8 +233,10 @@ function formatCapabilities(caps: Readonly<Record<string, unknown>> | undefined)
   if (!caps) return '';
   const bits: string[] = [];
   const fs = caps.fs as { read?: ReadonlyArray<string>; write?: ReadonlyArray<string> } | undefined;
-  if (fs?.read?.length) bits.push(`fs:read(${fs.read.length})`);
-  if (fs?.write?.length) bits.push(`fs:write(${fs.write.length})`);
+  const fsRead = fs?.read;
+  const fsWrite = fs?.write;
+  if (fsRead?.length) bits.push(`fs:read(${fsRead.length})`);
+  if (fsWrite?.length) bits.push(`fs:write(${fsWrite.length})`);
   const net = caps.net as { mode?: string } | undefined;
   if (net?.mode) bits.push(`net:${net.mode}`);
   const env = caps.env as ReadonlyArray<string> | undefined;

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from '@moxxy/sdk';
 import type { ParsedArgv } from '../argv.js';
 import { colors } from '../colors.js';
 import { helpRequested, stringFlag } from '../argv-helpers.js';
@@ -167,8 +168,10 @@ async function runList(): Promise<number> {
   // Two-row entry per service: bold name + state badge on row 1, dim
   // description on row 2. Mirrors `moxxy channels` exactly.
   for (let i = 0; i < CATALOG.length; i += 1) {
-    const spec = CATALOG[i]!;
-    const status = statuses[i]!;
+    const spec = CATALOG[i];
+    const status = statuses[i];
+    assertDefined(spec, 'i < CATALOG.length within the loop');
+    assertDefined(status, 'statuses maps 1:1 over CATALOG');
     const badge = stateBadge(status);
     process.stdout.write(`${colors.bold(spec.id.padEnd(nameCol))}  ${badge}\n`);
     process.stdout.write(`${' '.repeat(nameCol + 2)}${colors.dim(spec.description)}\n`);

--- a/packages/cli/src/commands/sessions.ts
+++ b/packages/cli/src/commands/sessions.ts
@@ -1,5 +1,6 @@
 import { isCancel, select } from '@clack/prompts';
 import { deleteSession, readSessionIndex, type SessionMeta } from '@moxxy/core';
+import { assertDefined } from '@moxxy/sdk';
 import { WorkspaceRegistry } from '@moxxy/workspace-registry';
 import type { ParsedArgv } from '../argv.js';
 import { helpRequested, stringFlag } from '../argv-helpers.js';
@@ -157,13 +158,22 @@ export function resolveId(input: string, all: ReadonlyArray<SessionMeta>): strin
   // Numeric index into the list, 1-based to match `sessions list`.
   if (/^\d+$/.test(trimmed)) {
     const idx = Number.parseInt(trimmed, 10) - 1;
-    if (idx >= 0 && idx < all.length) return all[idx]!.id;
+    const byIndex = idx >= 0 && idx < all.length ? all[idx] : undefined;
+    if (byIndex) return byIndex.id;
   }
   if (all.some((m) => m.id === trimmed)) return trimmed;
   const suffix = all.filter((m) => m.id.endsWith(trimmed));
-  if (suffix.length === 1) return suffix[0]!.id;
+  if (suffix.length === 1) {
+    const only = suffix[0];
+    assertDefined(only, 'length === 1 guarantees an element');
+    return only.id;
+  }
   const prefix = all.filter((m) => m.id.startsWith(trimmed));
-  if (prefix.length === 1) return prefix[0]!.id;
+  if (prefix.length === 1) {
+    const only = prefix[0];
+    assertDefined(only, 'length === 1 guarantees an element');
+    return only.id;
+  }
   // Ambiguous or no match — return the raw input so the resume path
   // surfaces a clear "Session not found" with the user's typed string.
   return trimmed;

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -5,7 +5,7 @@ import {
   loadSkillUsage,
   silentLogger,
 } from '@moxxy/core';
-import { createMutex } from '@moxxy/sdk';
+import { assertDefined, createMutex } from '@moxxy/sdk';
 import { writeFileAtomic } from '@moxxy/sdk/server';
 import { BUILTIN_SKILLS_DIR_RESOLVED } from '../setup/builtin-skills-dir.js';
 import { promises as fs } from 'node:fs';
@@ -118,8 +118,10 @@ async function runAudit(argv: ParsedArgv): Promise<number> {
     }
     const groups = groupSimilarPrompts(entries);
     for (const group of groups) {
+      const first = group[0];
+      assertDefined(first, 'groupSimilarPrompts never emits an empty group');
       const header = group.length === 1 ? '' : colors.dim(`  · ${group.length} similar`);
-      process.stdout.write(`\n${colors.bold(truncate(group[0]!.originatingPrompt, 80))}${header}\n`);
+      process.stdout.write(`\n${colors.bold(truncate(first.originatingPrompt, 80))}${header}\n`);
       for (const e of group) {
         process.stdout.write(
           `  ${colors.dim(e.scope.padEnd(7))}  ${colors.bold(e.slug.padEnd(36))}  ${colors.dim(e.ts)}\n`,
@@ -237,11 +239,14 @@ export function groupSimilarPrompts(entries: ReadonlyArray<AuditEntry>): AuditEn
     const tokens = tokenize(entry.originatingPrompt);
     let placed = false;
     for (let i = 0; i < groups.length; i += 1) {
-      const groupTokens = groupTokenSets[i]!;
+      const group = groups[i];
+      const groupTokens = groupTokenSets[i];
+      assertDefined(group, 'i < groups.length within the loop');
+      assertDefined(groupTokens, 'groupTokenSets grows in lockstep with groups');
       let overlap = 0;
       for (const t of tokens) if (groupTokens.has(t)) overlap += 1;
       if (overlap >= 2) {
-        groups[i]!.push(entry);
+        group.push(entry);
         for (const t of tokens) groupTokens.add(t);
         placed = true;
         break;

--- a/packages/cli/src/config-applier.ts
+++ b/packages/cli/src/config-applier.ts
@@ -53,8 +53,10 @@ export function buildSessionConfigApplier(
     const applied: string[] = [];
     const pending: string[] = [];
 
-    const nextMode = next.plugins?.mode?.default;
-    if (nextMode !== last.plugins?.mode?.default) {
+    const nextModeCfg = next.plugins?.mode;
+    const lastModeCfg = last.plugins?.mode;
+    const nextMode = nextModeCfg?.default;
+    if (nextMode !== lastModeCfg?.default) {
       try {
         if (nextMode) session.modes.setActive(nextMode);
         applied.push('mode');
@@ -63,8 +65,10 @@ export function buildSessionConfigApplier(
       }
     }
 
-    const nextCompactor = next.plugins?.compactor?.default;
-    if (nextCompactor !== last.plugins?.compactor?.default) {
+    const nextCompactorCfg = next.plugins?.compactor;
+    const lastCompactorCfg = last.plugins?.compactor;
+    const nextCompactor = nextCompactorCfg?.default;
+    if (nextCompactor !== lastCompactorCfg?.default) {
       try {
         if (nextCompactor) session.compactors.setActive(nextCompactor);
         applied.push('compactor');
@@ -73,10 +77,12 @@ export function buildSessionConfigApplier(
       }
     }
 
-    const nextCacheStrategy = next.plugins?.cacheStrategy?.default;
+    const nextCacheCfg = next.plugins?.cacheStrategy;
+    const lastCacheCfg = last.plugins?.cacheStrategy;
+    const nextCacheStrategy = nextCacheCfg?.default;
     if (
       next.context?.caching !== last.context?.caching ||
-      nextCacheStrategy !== last.plugins?.cacheStrategy?.default
+      nextCacheStrategy !== lastCacheCfg?.default
     ) {
       try {
         if (next.context?.caching === false) session.cacheStrategies.setActive('none');
@@ -228,7 +234,8 @@ async function applyPluginToggles(
 }
 
 function effectiveEnabled(cfg: MoxxyConfig, name: string): boolean {
-  const entry = cfg.plugins?.packages?.[name];
+  const packages = cfg.plugins?.packages;
+  const entry = packages?.[name];
   if (!entry) return true; // default: enabled when not mentioned
   return entry.enabled !== false;
 }

--- a/packages/cli/src/logo.test.ts
+++ b/packages/cli/src/logo.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { LOGO_LINES, LOGO_WIDTH, WORDMARK_LINES } from '@moxxy/plugin-cli';
+import { assertDefined } from '@moxxy/sdk';
 import { colorsEnabled } from './colors.js';
 import { renderLogo } from './logo.js';
 
@@ -10,7 +11,9 @@ function strip(s: string): string {
 
 // First non-blank rendered line, ANSI stripped — the top of the mark.
 function firstLine(out: string): string {
-  return strip(out).split('\n').filter((l) => l.trim())[0]!;
+  const first = strip(out).split('\n').filter((l) => l.trim())[0];
+  assertDefined(first, 'rendered logo has at least one non-blank line');
+  return first;
 }
 
 describe('renderLogo', () => {

--- a/packages/cli/src/setup/activate-provider.ts
+++ b/packages/cli/src/setup/activate-provider.ts
@@ -1,7 +1,7 @@
 import type { Session } from '@moxxy/core';
 import type { MoxxyConfig } from '@moxxy/config';
 import type { VaultStore } from '@moxxy/plugin-vault';
-import { MoxxyError, type CredentialResolver } from '@moxxy/sdk';
+import { MoxxyError, assertDefined, type CredentialResolver } from '@moxxy/sdk';
 import { resolveProviderCredentials } from '../provider-credentials.js';
 import { providerDefault, providerSlot } from './resolve-plugins-tree.js';
 import type { BootStep } from './types.js';
@@ -59,7 +59,8 @@ export async function activateProvider(args: ActivateProviderArgs): Promise<Acti
     logger.info('skipping provider activation (skipProviderActivation set)');
   } else {
     for (let i = 0; i < candidates.length; i++) {
-      const candidate = candidates[i]!;
+      const candidate = candidates[i];
+      assertDefined(candidate, 'i < candidates.length within the loop');
       // A user-disabled provider (`plugins.provider.items.<name>.enabled:
       // false`, seeded into the registry before this walk) is never auto-activated —
       // fall through to the next candidate instead of failing on setActive.

--- a/packages/cli/src/setup/apply-plugins-tree.ts
+++ b/packages/cli/src/setup/apply-plugins-tree.ts
@@ -120,7 +120,8 @@ export function applyPluginsTree(session: Session, config: MoxxyConfig, logger: 
     // An *explicit* config default that's missing is a warning (likely a typo
     // or an uninstalled plugin the user named); a *built-in* default whose
     // providing plugin simply isn't installed is a silent skip.
-    let name = config.plugins?.[key]?.default;
+    const slot = config.plugins?.[key];
+    let name = slot?.default;
     let explicit = name !== undefined;
     // Caching is on by default (stable-prefix is the floor). `caching: false`
     // selects the no-op strategy regardless of the configured cacheStrategy.

--- a/packages/cli/src/setup/build-workflow-runner.ts
+++ b/packages/cli/src/setup/build-workflow-runner.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { createSubagentSpawner, type Session } from '@moxxy/core';
 import {
   asPluginId,
+  assertDefined,
   type EmittedEvent,
   type WorkflowRunResult,
 } from '@moxxy/sdk';
@@ -116,10 +117,11 @@ export function buildWorkflowRunner(args: {
       // surface the paused status to the caller. (In practice awaitInput is
       // gated at validate/save time, so this is a defense-in-depth guard.)
       if (result.status === 'paused') {
-        logger?.warn?.('workflows: run paused awaiting operator input; not delivering to inbox', {
-          workflow: input.name,
-          runId: result.runId,
-        });
+        if (logger?.warn)
+          logger.warn('workflows: run paused awaiting operator input; not delivering to inbox', {
+            workflow: input.name,
+            runId: result.runId,
+          });
         return result;
       }
       await deliverToInbox(entry.workflow, result, logger);
@@ -144,7 +146,8 @@ export function buildWorkflowRunner(args: {
     // workflow name: a resume drives the rest of the DAG (and delivers to the
     // inbox), so letting it race a concurrent runNow of the same workflow would
     // run two executions at once — doubling side effects and inbox deliveries.
-    const name = checkpoint?.workflow?.name;
+    const workflow = checkpoint?.workflow;
+    const name = workflow?.name;
     // A checkpoint with no identifiable workflow name (missing/corrupted/legacy)
     // can't be guarded by the in-flight set, so a resume would silently race a
     // concurrent runNow. Refuse rather than proceed unguarded.
@@ -204,14 +207,16 @@ export function buildWorkflowRunner(args: {
       // A still-paused result (a second awaitInput) is non-terminal — withhold it
       // exactly like runNow. A completed/failed result IS terminal: deliver it.
       if (result.status === 'paused') {
-        logger?.warn?.('workflows: run paused again awaiting operator input; not delivering to inbox', {
-          runId: result.runId,
-        });
+        if (logger?.warn)
+          logger.warn('workflows: run paused again awaiting operator input; not delivering to inbox', {
+            runId: result.runId,
+          });
         return result;
       }
       // Resolve the workflow name from the checkpoint for inbox delivery metadata.
-      // `checkpoint.workflow` is guaranteed by the `!name` guard above.
-      await deliverToInbox(checkpoint!.workflow, result, logger);
+      // `workflow` is guaranteed defined by the `!name` guard above (name derived from it).
+      assertDefined(workflow, 'checkpoint.workflow is defined when a run name resolved (guarded above)');
+      await deliverToInbox(workflow, result, logger);
       return result;
     } finally {
       inFlight.delete(name);
@@ -229,7 +234,8 @@ export function buildWorkflowRunner(args: {
  * terminal fallback matches runTurn's own resolution.
  */
 export function activeModel(session: Session): string {
-  return session.lastResolvedModel ?? safeActiveProvider(session)?.models[0]?.id ?? 'default';
+  const firstModel = safeActiveProvider(session)?.models[0];
+  return session.lastResolvedModel ?? firstModel?.id ?? 'default';
 }
 
 export function safeActiveProvider(session: Session): ReturnType<Session['providers']['getActive']> | null {
@@ -270,8 +276,9 @@ export async function deliverToInbox(
     const body = result.error ? `**error:** ${result.error}\n\n${result.output}` : result.output;
     await writeFileAtomic(file, header + body + '\n');
   } catch (err) {
-    logger?.warn?.('workflows: inbox delivery failed', {
-      err: err instanceof Error ? err.message : String(err),
-    });
+    if (logger?.warn)
+      logger.warn('workflows: inbox delivery failed', {
+        err: err instanceof Error ? err.message : String(err),
+      });
   }
 }

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -62,6 +62,7 @@ export interface BuiltinEntriesArgs {
  */
 export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
   const { session, rawConfig, vaultPlugin, viewSurface, webControls, setPluginEnabledLive, categoryLive } = args;
+  const version = cliVersion();
 
   // Publish the shared web-surface ref so the (discovery-loadable) view plugin
   // can read it in onInit — the same mutable ref the web channel writes via its
@@ -72,17 +73,21 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
   // discovery-loaded plugin (self-update) can read its own options in onInit.
   session.services.register(
     'getPluginOptions',
-    (pkg: string): Record<string, unknown> | undefined => rawConfig.plugins?.packages?.[pkg]?.options,
+    (pkg: string): Record<string, unknown> | undefined => {
+      const packages = rawConfig.plugins?.packages;
+      const entry = packages?.[pkg];
+      return entry?.options;
+    },
   );
   // The shared web-controls ref (written by the web channel, read by its
   // web_set_tunnel tool) + the configured default tunnel — for the
   // discovery-loadable web channel to resolve in onInit.
   session.services.register('webControls', webControls);
+  const webChannel = (rawConfig.channels as { web?: { tunnel?: unknown } } | undefined)?.web;
+  const webTunnel = webChannel?.tunnel;
   session.services.register(
     'webDefaultTunnel',
-    typeof (rawConfig.channels as { web?: { tunnel?: unknown } } | undefined)?.web?.tunnel === 'string'
-      ? (rawConfig.channels as { web?: { tunnel?: string } }).web!.tunnel
-      : undefined,
+    typeof webTunnel === 'string' ? webTunnel : undefined,
   );
 
   return [
@@ -146,7 +151,7 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
         setEnabled: setPluginEnabledLive,
         categories: categoryLive.categories,
         setCategoryDefault: categoryLive.setCategoryDefault,
-        ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
+        ...(version ? { cliVersion: version } : {}),
         // Lets install_plugin report the just-installed package's combined
         // capability surface (union of its tools' isolation declarations).
         toolIsolation: (name) => session.tools.get(name)?.isolation,

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -270,9 +270,10 @@ function wirePluginsAdminView(
       // enabled anyway).
       const packageName = entry?.packageName ?? packageNameFromSpec(spec);
       const before = buildPluginSnapshot(session);
+      const pinVersion = cliVersion();
       const { installed } = await installPluginPackagePinned({
         packageName: spec,
-        ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
+        ...(pinVersion ? { cliVersion: pinVersion } : {}),
         onWarn: (msg) => logger.warn(msg),
       });
       if (packageName) await persistPluginEnabled(packageName, true);
@@ -387,14 +388,14 @@ function buildSecuritySlice(
   // Tools without an `isolation` declaration pass through untouched (unless
   // `security.requireDeclaration` is set, or — for third-party packages —
   // `security.thirdPartyRequireDeclaration` warns/denies).
+  const isolatorCfg = rawConfig.plugins?.isolator;
+  const configuredIsolator = isolatorCfg?.default;
   const security = buildSecurityPlugin({
     config: {
       enabled: rawConfig.security?.enabled ?? false,
       // The default isolator now lives in the unified tree at
       // `plugins.isolator.default` (a registry kind like any other).
-      ...(rawConfig.plugins?.isolator?.default
-        ? { isolator: rawConfig.plugins.isolator.default }
-        : {}),
+      ...(configuredIsolator ? { isolator: configuredIsolator } : {}),
       ...(rawConfig.security?.perTool ? { perTool: rawConfig.security.perTool } : {}),
       ...(rawConfig.security?.perPlugin ? { perPlugin: rawConfig.security.perPlugin } : {}),
       ...(rawConfig.security?.requireDeclaration !== undefined

--- a/packages/cli/src/setup/plugins-admin-view.test.ts
+++ b/packages/cli/src/setup/plugins-admin-view.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { Session, silentLogger } from '@moxxy/core';
+import { assertDefined } from '@moxxy/sdk';
 import {
   buildVaultPlugin,
   createStaticKeySource,
@@ -73,9 +74,11 @@ describe('session.pluginsAdmin.install', () => {
 
     const admin = session.pluginsAdmin;
     expect(admin?.install).toBeDefined();
+    assertDefined(admin, 'pluginsAdmin view attached');
+    assertDefined(admin.install, 'install exposed on pluginsAdmin');
     // 'mode-goal' is not a catalog id today, so it resolves as a bare package
     // name; the closure passes it through to the pinned installer.
-    const res = await admin!.install!('@moxxy/mode-goal');
+    const res = await admin.install('@moxxy/mode-goal');
 
     expect(installPluginPackagePinned).toHaveBeenCalledWith(
       expect.objectContaining({ packageName: '@moxxy/mode-goal' }),
@@ -89,7 +92,10 @@ describe('session.pluginsAdmin.install', () => {
   it('skips the enable write for a git/path spec with no derivable package name', async () => {
     const session = buildFixture();
     vi.spyOn(session.pluginHost, 'reload').mockResolvedValue(undefined as never);
-    await session.pluginsAdmin!.install!('github:someone/some-plugin');
+    const admin = session.pluginsAdmin;
+    assertDefined(admin, 'pluginsAdmin view attached');
+    assertDefined(admin.install, 'install exposed on pluginsAdmin');
+    await admin.install('github:someone/some-plugin');
     expect(setPluginEnabled).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/setup/provider-setup.ts
+++ b/packages/cli/src/setup/provider-setup.ts
@@ -52,9 +52,10 @@ export function buildProviderSetupView(opts: BuildProviderSetupOptions): Provide
       // it registers on the host reload. Mirrors init's ensureProvider.
       const entry = resolveProvider(providerId);
       if (!entry) return false;
+      const pinVersion = cliVersion();
       await installPluginPackagePinned({
         packageName: entry.packageName,
-        ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
+        ...(pinVersion ? { cliVersion: pinVersion } : {}),
       });
       await setPluginEnabled(entry.packageName, true);
       await session.pluginHost.reload();

--- a/packages/cli/src/setup/register-plugins.ts
+++ b/packages/cli/src/setup/register-plugins.ts
@@ -44,12 +44,14 @@ export async function registerPlugins(
   opts: RegisterPluginsOptions = {},
 ): Promise<RegistrationResult> {
   const registered = new Set<string>();
+  const configuredPackages = config.plugins?.packages;
 
   const resolved = await resolveBuiltinRequirements(builtins, cwd);
   const ordered = toposortBuiltins(builtins, resolved);
   for (const { name, plugin } of ordered) {
     // A hand-edited config can't disable a kernel package — the floor stays.
-    if (config.plugins?.packages?.[name]?.enabled === false && !isCriticalPackage(name)) {
+    const pkgSettings = configuredPackages?.[name];
+    if (pkgSettings?.enabled === false && !isCriticalPackage(name)) {
       logger.info('skipping disabled plugin', { plugin: name });
       continue;
     }
@@ -88,7 +90,8 @@ export async function registerPlugins(
     });
     for (const manifest of manifests) {
       if (registered.has(manifest.packageName)) continue;
-      if (config.plugins?.packages?.[manifest.packageName]?.enabled === false) {
+      const manifestSettings = configuredPackages?.[manifest.packageName];
+      if (manifestSettings?.enabled === false) {
         logger.info('skipping disabled plugin', { plugin: manifest.packageName });
         continue;
       }

--- a/packages/cli/src/setup/resolve-plugins-tree.ts
+++ b/packages/cli/src/setup/resolve-plugins-tree.ts
@@ -40,7 +40,8 @@ export function providerSlot(config: MoxxyConfig): ProviderSlot {
  * (the caller then runs setup rather than pointing at a missing provider).
  */
 export function providerDefault(config: MoxxyConfig): string | undefined {
-  return config.plugins?.provider?.default;
+  const provider = config.plugins?.provider;
+  return provider?.default;
 }
 
 /** Per-item options (model/config) for a provider, defaulting to the active one. */
@@ -56,12 +57,14 @@ export function providerItem(config: MoxxyConfig, name?: string): ProviderItem {
  * built-in default (transcriber/synthesizer/channel) when unset.
  */
 export function categoryDefault(config: MoxxyConfig, key: PluginCategoryKey): string | undefined {
-  return config.plugins?.[key]?.default ?? BUILTIN_DEFAULTS[key];
+  const slot = config.plugins?.[key];
+  return slot?.default ?? BUILTIN_DEFAULTS[key];
 }
 
 /** Per-package settings from the install/enable ledger. */
 export function packageSettings(config: MoxxyConfig, pkg: string) {
-  return config.plugins?.packages?.[pkg];
+  const packages = config.plugins?.packages;
+  return packages?.[pkg];
 }
 
 /** Package names explicitly disabled (`enabled: false`) in the ledger. */

--- a/packages/cli/src/setup/wire-run-store.ts
+++ b/packages/cli/src/setup/wire-run-store.ts
@@ -1,6 +1,7 @@
 import { type FSWatcher, watch as fsWatch } from 'node:fs';
 import * as path from 'node:path';
 import { type Session } from '@moxxy/core';
+import { assertDefined } from '@moxxy/sdk';
 import type { CrossProcessFireLock, MoxxyEvent, Workflow } from '@moxxy/sdk';
 import { type ScheduleStore, isValidCron, isValidTimeZone } from '@moxxy/plugin-scheduler';
 import type { WorkflowStore } from '@moxxy/plugin-workflows';
@@ -33,7 +34,10 @@ export function detectAfterWorkflowCycles(
   for (const name of enabled.keys()) edges.set(name, []);
   for (const w of enabled.values()) {
     for (const dep of [w.on?.afterWorkflow ?? []].flat()) {
-      if (enabled.has(dep)) edges.get(dep)!.push(w.name);
+      // edges has an entry for exactly the enabled workflow names, so a defined
+      // lookup is equivalent to the prior `enabled.has(dep)` guard.
+      const depEdges = edges.get(dep);
+      if (depEdges) depEdges.push(w.name);
     }
   }
 
@@ -53,15 +57,24 @@ export function detectAfterWorkflowCycles(
     for (const w of edges.get(v) ?? []) {
       if (!index.has(w)) {
         visit(w);
-        lowlink.set(v, Math.min(lowlink.get(v)!, lowlink.get(w)!));
+        const lowV = lowlink.get(v);
+        const lowW = lowlink.get(w);
+        assertDefined(lowV, 'v has a lowlink (set on entry to visit)');
+        assertDefined(lowW, 'w has a lowlink after visit(w)');
+        lowlink.set(v, Math.min(lowV, lowW));
       } else if (onStack.has(w)) {
-        lowlink.set(v, Math.min(lowlink.get(v)!, index.get(w)!));
+        const lowV = lowlink.get(v);
+        const idxW = index.get(w);
+        assertDefined(lowV, 'v has a lowlink (set on entry to visit)');
+        assertDefined(idxW, 'w has an index (index.has(w) is true)');
+        lowlink.set(v, Math.min(lowV, idxW));
       }
     }
     if (lowlink.get(v) === index.get(v)) {
       const scc: string[] = [];
       for (;;) {
-        const w = stack.pop()!;
+        const w = stack.pop();
+        assertDefined(w, 'stack holds v (pushed on entry), so pop yields a node until we reach it');
         onStack.delete(w);
         scc.push(w);
         if (w === v) break;
@@ -93,11 +106,12 @@ export function applyAfterWorkflowCycleGuard(args: {
     const key = [...cycle].sort().join(' -> ');
     if (args.warned.has(key)) continue;
     args.warned.add(key);
-    args.logger?.warn?.(
-      `workflows: afterWorkflow trigger cycle detected (${cycle.join(' -> ')} -> ${cycle[0]}); ` +
-        'auto-refire is disabled for these workflows — run them manually or break the cycle',
-      { cycle: [...cycle] },
-    );
+    if (args.logger?.warn)
+      args.logger.warn(
+        `workflows: afterWorkflow trigger cycle detected (${cycle.join(' -> ')} -> ${cycle[0]}); ` +
+          'auto-refire is disabled for these workflows — run them manually or break the cycle',
+        { cycle: [...cycle] },
+      );
   }
 }
 
@@ -138,46 +152,52 @@ export async function fireAfterWorkflowDependents(args: {
       thisRunnerSessionId &&
       workflow.targetSessionId !== thisRunnerSessionId
     ) {
-      logger?.info?.(
-        'workflows: afterWorkflow dependent is pinned to another session; skipping (co-locate or use a schedule trigger)',
-        { workflow: workflow.name, after: completed, target: workflow.targetSessionId },
-      );
+      if (logger?.info)
+        logger.info(
+          'workflows: afterWorkflow dependent is pinned to another session; skipping (co-locate or use a schedule trigger)',
+          { workflow: workflow.name, after: completed, target: workflow.targetSessionId },
+        );
       continue;
     }
     if (disabled.has(workflow.name)) {
-      logger?.info?.('workflows: afterWorkflow auto-refire disabled by the cycle guard; skipping', {
-        workflow: workflow.name,
-        after: completed,
-      });
+      if (logger?.info)
+        logger.info('workflows: afterWorkflow auto-refire disabled by the cycle guard; skipping', {
+          workflow: workflow.name,
+          after: completed,
+        });
       continue;
     }
     if (nextChain.includes(workflow.name)) {
-      logger?.warn?.(
-        `workflows: refusing afterWorkflow re-fire — trigger cycle ` +
-          `(${[...nextChain, workflow.name].join(' -> ')}); "${workflow.name}" already ran in this chain`,
-        { workflow: workflow.name, chain: [...nextChain] },
-      );
+      if (logger?.warn)
+        logger.warn(
+          `workflows: refusing afterWorkflow re-fire — trigger cycle ` +
+            `(${[...nextChain, workflow.name].join(' -> ')}); "${workflow.name}" already ran in this chain`,
+          { workflow: workflow.name, chain: [...nextChain] },
+        );
       continue;
     }
     if (nextChain.length >= MAX_AFTER_WORKFLOW_CHAIN) {
-      logger?.warn?.(
-        `workflows: refusing afterWorkflow re-fire — chain depth cap of ${MAX_AFTER_WORKFLOW_CHAIN} ` +
-          `reached (${nextChain.join(' -> ')} -> ${workflow.name})`,
-        { workflow: workflow.name, chain: [...nextChain] },
-      );
+      if (logger?.warn)
+        logger.warn(
+          `workflows: refusing afterWorkflow re-fire — chain depth cap of ${MAX_AFTER_WORKFLOW_CHAIN} ` +
+            `reached (${nextChain.join(' -> ')} -> ${workflow.name})`,
+          { workflow: workflow.name, chain: [...nextChain] },
+        );
       continue;
     }
-    logger?.info?.('workflows: afterWorkflow trigger', {
-      workflow: workflow.name,
-      after: completed,
-      depth: nextChain.length,
-    });
-    await run({ name: workflow.name, trigger: `after:${completed}`, chain: nextChain }).catch((err) =>
-      logger?.warn?.('workflows: afterWorkflow run failed', {
+    if (logger?.info)
+      logger.info('workflows: afterWorkflow trigger', {
         workflow: workflow.name,
-        err: err instanceof Error ? err.message : String(err),
-      }),
-    );
+        after: completed,
+        depth: nextChain.length,
+      });
+    await run({ name: workflow.name, trigger: `after:${completed}`, chain: nextChain }).catch((err) => {
+      if (logger?.warn)
+        logger.warn('workflows: afterWorkflow run failed', {
+          workflow: workflow.name,
+          err: err instanceof Error ? err.message : String(err),
+        });
+    });
   }
 }
 
@@ -268,10 +288,11 @@ export function wireWorkflowTriggers(args: {
         claimed = true;
       }
       if (!claimed) {
-        logger?.info?.('workflows: fileChanged already claimed by another runner; skipping', {
-          workflow: name,
-          glob,
-        });
+        if (logger?.info)
+          logger.info('workflows: fileChanged already claimed by another runner; skipping', {
+            workflow: name,
+            glob,
+          });
         return;
       }
     }
@@ -321,21 +342,23 @@ export function wireWorkflowTriggers(args: {
           if (code === 'ERR_FEATURE_UNAVAILABLE_ON_PLATFORM') {
             try {
               watchers.push(fsWatch(base, { recursive: false }, onChange));
-              logger?.warn?.(
-                'workflows: recursive fileChanged watch unavailable on this platform (needs Node >=20 on Linux); ' +
-                  'watching the base directory non-recursively — nested-path changes will not fire',
-                { workflow: workflow.name, base, glob },
-              );
+              if (logger?.warn)
+                logger.warn(
+                  'workflows: recursive fileChanged watch unavailable on this platform (needs Node >=20 on Linux); ' +
+                    'watching the base directory non-recursively — nested-path changes will not fire',
+                  { workflow: workflow.name, base, glob },
+                );
               continue;
             } catch {
               // fall through to the generic warning below
             }
           }
-          logger?.warn?.('workflows: cannot watch path', {
-            workflow: workflow.name,
-            base,
-            err: err instanceof Error ? err.message : String(err),
-          });
+          if (logger?.warn)
+            logger.warn('workflows: cannot watch path', {
+              workflow: workflow.name,
+              base,
+              err: err instanceof Error ? err.message : String(err),
+            });
         }
       }
     }
@@ -376,22 +399,25 @@ export function wireWorkflowTriggers(args: {
         const timeZone =
           sched?.timeZone && isValidTimeZone(sched.timeZone) ? sched.timeZone : undefined;
         if (sched && sched.cron && !cron) {
-          logger?.warn?.('workflows: ignoring invalid cron expression', {
-            workflow: workflow.name,
-            cron: sched.cron,
-          });
+          if (logger?.warn)
+            logger.warn('workflows: ignoring invalid cron expression', {
+              workflow: workflow.name,
+              cron: sched.cron,
+            });
         }
         if (sched && sched.runAt !== undefined && runAt === undefined) {
-          logger?.warn?.('workflows: ignoring unparseable schedule.runAt', {
-            workflow: workflow.name,
-            runAt: sched.runAt,
-          });
+          if (logger?.warn)
+            logger.warn('workflows: ignoring unparseable schedule.runAt', {
+              workflow: workflow.name,
+              runAt: sched.runAt,
+            });
         }
         if (sched && sched.timeZone && !timeZone) {
-          logger?.warn?.('workflows: ignoring invalid schedule.timeZone (using system local)', {
-            workflow: workflow.name,
-            timeZone: sched.timeZone,
-          });
+          if (logger?.warn)
+            logger.warn('workflows: ignoring invalid schedule.timeZone (using system local)', {
+              workflow: workflow.name,
+              timeZone: sched.timeZone,
+            });
         }
         if (sched && (cron || runAt !== undefined)) {
           await scheduleStore.syncWorkflowSchedule(workflow.name, {
@@ -422,15 +448,17 @@ export function wireWorkflowTriggers(args: {
         // fileChanged / webhook triggers are recognized but auto-firing for them
         // is wired separately (fileChanged below; webhook is a follow-up).
         if (workflow.enabled && workflow.on?.webhook) {
-          logger?.warn?.('workflows: webhook triggers are not auto-fired yet; run on demand', {
-            workflow: workflow.name,
-          });
+          if (logger?.warn)
+            logger.warn('workflows: webhook triggers are not auto-fired yet; run on demand', {
+              workflow: workflow.name,
+            });
         }
       } catch (err) {
-        logger?.warn?.('workflows: failed to sync schedule for workflow; skipping', {
-          workflow: workflow.name,
-          err: err instanceof Error ? err.message : String(err),
-        });
+        if (logger?.warn)
+          logger.warn('workflows: failed to sync schedule for workflow; skipping', {
+            workflow: workflow.name,
+            err: err instanceof Error ? err.message : String(err),
+          });
       }
     }
     // Rebuild fs watchers too, so a workflow whose `on.fileChanged` trigger is
@@ -465,11 +493,12 @@ export function wireWorkflowTriggers(args: {
         run: runner.runNow,
         ...(logger ? { logger } : {}),
       });
-    })().catch((err) =>
-      logger?.warn?.('workflows: afterWorkflow dispatch failed', {
-        err: err instanceof Error ? err.message : String(err),
-      }),
-    );
+    })().catch((err) => {
+      if (logger?.warn)
+        logger.warn('workflows: afterWorkflow dispatch failed', {
+          err: err instanceof Error ? err.message : String(err),
+        });
+    });
   });
 
   return {

--- a/packages/cli/src/setup/workflows.test.ts
+++ b/packages/cli/src/setup/workflows.test.ts
@@ -3,7 +3,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterAll, describe, expect, it, vi } from 'vitest';
 import { Session, silentLogger } from '@moxxy/core';
-import { asPluginId, definePlugin, defineProvider, type EmittedEvent } from '@moxxy/sdk';
+import { asPluginId, assertDefined, definePlugin, defineProvider, type EmittedEvent } from '@moxxy/sdk';
 import { ScheduleStore } from '@moxxy/plugin-scheduler';
 import { WORKFLOWS_PLUGIN_NAME } from '@moxxy/plugin-workflows';
 import {
@@ -227,7 +227,9 @@ describe('detectAfterWorkflowCycles', () => {
   it('finds a mutual A<->B cycle', () => {
     const cycles = detectAfterWorkflowCycles([wf('a', { after: 'b' }), wf('b', { after: 'a' })]);
     expect(cycles).toHaveLength(1);
-    expect([...cycles[0]!].sort()).toEqual(['a', 'b']);
+    const firstCycle = cycles[0];
+    assertDefined(firstCycle, 'one cycle detected');
+    expect([...firstCycle].sort()).toEqual(['a', 'b']);
   });
 
   it('finds a self-loop', () => {
@@ -242,7 +244,9 @@ describe('detectAfterWorkflowCycles', () => {
       wf('tail', { after: 'c' }),
     ]);
     expect(cycles).toHaveLength(1);
-    expect([...cycles[0]!].sort()).toEqual(['a', 'b', 'c']);
+    const firstCycle = cycles[0];
+    assertDefined(firstCycle, 'one cycle detected');
+    expect([...firstCycle].sort()).toEqual(['a', 'b', 'c']);
   });
 
   it('reports nothing for linear chains or fan-out', () => {
@@ -424,10 +428,14 @@ describe('buildWorkflowsIntegration afterWorkflow wiring', () => {
     session.pluginHost.registerStatic(integration.plugin);
     await session.dispatcher.dispatchInit(session.appContext());
     try {
-      const result = await session.workflows!.run('paused-wf');
+      const workflows = session.workflows;
+      assertDefined(workflows, 'workflows view attached');
+      const result = await workflows.run('paused-wf');
       // The view maps the run result; a paused run must not look "ok+complete"
       // with an inbox file behind it.
-      const inboxDir = path.join(process.env.MOXXY_HOME!, 'inbox');
+      const moxxyHome = process.env.MOXXY_HOME;
+      assertDefined(moxxyHome, 'MOXXY_HOME set by test setup');
+      const inboxDir = path.join(moxxyHome, 'inbox');
       let inboxFiles: string[] = [];
       try {
         inboxFiles = await fs.readdir(inboxDir);
@@ -441,11 +449,12 @@ describe('buildWorkflowsIntegration afterWorkflow wiring', () => {
       // the operator UI can offer a reply box, and `resume` is wired.
       expect(result.status).toBe('paused');
       expect(result.runId).toBe('RUN1');
-      expect(typeof session.workflows!.resume).toBe('function');
+      expect(typeof workflows.resume).toBe('function');
       // Resuming a run with no checkpoint on disk fails fast: with no
       // identifiable workflow name the in-flight guard can't protect it, so the
       // runner refuses rather than proceeding unguarded (or hanging).
-      const resumed = await session.workflows!.resume!('UNKNOWN', 'reply');
+      assertDefined(workflows.resume, 'resume wired on the workflows view');
+      const resumed = await workflows.resume('UNKNOWN', 'reply');
       expect(resumed.ok).toBe(false);
       expect(resumed.error ?? '').toMatch(/no resumable run/);
     } finally {
@@ -485,7 +494,9 @@ describe('buildWorkflowsIntegration afterWorkflow wiring', () => {
       await fs.mkdir(watchedDir, { recursive: true });
 
       // Save a fileChanged workflow at runtime (the path onReady never saw).
-      await session.workflows!.save(
+      const workflows = session.workflows;
+      assertDefined(workflows, 'workflows view attached');
+      await workflows.save(
         [
           'name: on-touch',
           'description: fires on file change',

--- a/packages/cli/src/setup/workflows.ts
+++ b/packages/cli/src/setup/workflows.ts
@@ -128,26 +128,29 @@ export function buildWorkflowsIntegration(args: {
       void defaultWorkflowRunStore
         .sweepStale()
         .then((n) => {
-          if (n > 0) logger?.info?.('workflows: swept stale paused-run checkpoints', { count: n });
+          if (n > 0 && logger?.info)
+            logger.info('workflows: swept stale paused-run checkpoints', { count: n });
         })
-        .catch((err) =>
-          logger?.warn?.('workflows: checkpoint sweep failed', {
-            err: err instanceof Error ? err.message : String(err),
-          }),
-        );
+        .catch((err) => {
+          if (logger?.warn)
+            logger.warn('workflows: checkpoint sweep failed', {
+              err: err instanceof Error ? err.message : String(err),
+            });
+        });
       // Sweep stale `*.jsonl` run records too (every runWorkflow appends one and
       // nothing else removes them — over months of scheduled runs they grow
       // without bound and slow `/workflows inspect`). Distinct dir from the
       // checkpoint sweep above (`workflow-runs/*.jsonl`, not `.../active/*.json`).
       void sweepStaleRecords()
         .then((n) => {
-          if (n > 0) logger?.info?.('workflows: swept stale run records', { count: n });
+          if (n > 0 && logger?.info) logger.info('workflows: swept stale run records', { count: n });
         })
-        .catch((err) =>
-          logger?.warn?.('workflows: run-record sweep failed', {
-            err: err instanceof Error ? err.message : String(err),
-          }),
-        );
+        .catch((err) => {
+          if (logger?.warn)
+            logger.warn('workflows: run-record sweep failed', {
+              err: err instanceof Error ? err.message : String(err),
+            });
+        });
     },
   });
 

--- a/packages/cli/src/update/registry.test.ts
+++ b/packages/cli/src/update/registry.test.ts
@@ -73,7 +73,8 @@ describe('fetchLatest', () => {
     // shouldn't and returns null fail-soft.
     const fetchImpl = vi.fn((_url: string, init?: { signal?: AbortSignal }) => {
       return new Promise((_resolve, reject) => {
-        init?.signal?.addEventListener('abort', () => {
+        const signal = init?.signal;
+        signal?.addEventListener('abort', () => {
           abortSeen = true;
           reject(new Error('aborted'));
         });

--- a/packages/cli/src/wizard/auth-context.test.ts
+++ b/packages/cli/src/wizard/auth-context.test.ts
@@ -1,6 +1,7 @@
 import { PassThrough } from 'node:stream';
 import { describe, expect, it } from 'vitest';
 import type { VaultStore } from '@moxxy/plugin-vault';
+import { assertDefined } from '@moxxy/sdk';
 import { buildProviderAuthContext } from './auth-context.js';
 
 function fakeVault(): VaultStore {
@@ -21,9 +22,10 @@ describe('buildProviderAuthContext stdin prompt (u30-2)', () => {
       stdin,
     });
     expect(ctx.prompt).toBeTypeOf('function');
+    assertDefined(ctx.prompt, 'prompt exposed in stdin mode');
 
-    const a = ctx.prompt!('first?');
-    const b = ctx.prompt!('second?');
+    const a = ctx.prompt('first?');
+    const b = ctx.prompt('second?');
     stdin.write('alpha\n');
     stdin.write('bravo\n');
     expect(await a).toBe('alpha');
@@ -40,7 +42,8 @@ describe('buildProviderAuthContext stdin prompt (u30-2)', () => {
       write: () => {},
       stdin: stdin1,
     });
-    const p1 = ctx1.prompt!('token?');
+    assertDefined(ctx1.prompt, 'prompt exposed in stdin mode');
+    const p1 = ctx1.prompt('token?');
     stdin1.end(); // close stdin -> resolves pending read as '' (cancellation)
     expect(await p1).toBe('');
 
@@ -53,7 +56,8 @@ describe('buildProviderAuthContext stdin prompt (u30-2)', () => {
       write: () => {},
       stdin: stdin2,
     });
-    const p2 = ctx2.prompt!('token again?');
+    assertDefined(ctx2.prompt, 'prompt exposed in stdin mode');
+    const p2 = ctx2.prompt('token again?');
     stdin2.write('charlie\n');
     expect(await p2).toBe('charlie');
   });
@@ -70,7 +74,8 @@ describe('buildProviderAuthContext stdin prompt (u30-2)', () => {
       write: () => {},
       stdin: shared,
     });
-    const p1 = ctx1.prompt!('first?');
+    assertDefined(ctx1.prompt, 'prompt exposed in stdin mode');
+    const p1 = ctx1.prompt('first?');
     // Force ctx1 to create its reader (it does so lazily on first prompt).
     await new Promise((r) => setImmediate(r));
     // readline attaches a 'data' listener to the input stream while reading;
@@ -86,7 +91,8 @@ describe('buildProviderAuthContext stdin prompt (u30-2)', () => {
       write: () => {},
       stdin: shared,
     });
-    const p2 = ctx2.prompt!('second?');
+    assertDefined(ctx2.prompt, 'prompt exposed in stdin mode');
+    const p2 = ctx2.prompt('second?');
     await new Promise((r) => setImmediate(r));
 
     // The abandoned first prompt is resolved (not left hanging) ...
@@ -109,12 +115,13 @@ describe('buildProviderAuthContext stdin prompt (u30-2)', () => {
       stdin,
     });
     // First read consumes the line; write a second line before asking again.
-    const first = ctx.prompt!('q1?');
+    assertDefined(ctx.prompt, 'prompt exposed in stdin mode');
+    const first = ctx.prompt('q1?');
     stdin.write('one\n');
     expect(await first).toBe('one');
     stdin.write('two\n');
     // Give the 'line' event a tick to land in the queue.
     await new Promise((r) => setImmediate(r));
-    expect(await ctx.prompt!('q2?')).toBe('two');
+    expect(await ctx.prompt('q2?')).toBe('two');
   });
 });

--- a/packages/cli/src/wizard/plugin-setup-steps.ts
+++ b/packages/cli/src/wizard/plugin-setup-steps.ts
@@ -36,7 +36,8 @@ export interface PluginSetupStepsOptions {
  */
 export async function runPluginSetupSteps(opts: PluginSetupStepsOptions): Promise<void> {
   const all = await (opts.list ?? listPluginSetups)();
-  const targets = opts.only ? all.filter((e) => opts.only!.includes(e.packageName)) : all;
+  const only = opts.only;
+  const targets = only ? all.filter((e) => only.includes(e.packageName)) : all;
   if (targets.length === 0) return;
 
   for (const { packageName, setup } of targets) {

--- a/packages/cli/src/wizard/run-setup-wizard.ts
+++ b/packages/cli/src/wizard/run-setup-wizard.ts
@@ -11,6 +11,7 @@ import {
   select,
   spinner,
 } from '@clack/prompts';
+import { assertDefined } from '@moxxy/sdk';
 import {
   renderYaml,
   type ProviderAuthKind,
@@ -140,10 +141,12 @@ export async function runSetupWizard(opts: RunSetupWizardOptions): Promise<strin
     process.exit(1);
   }
 
+  const firstProviderOption = providerOptions[0];
+  assertDefined(firstProviderOption, 'providerOptions is non-empty (checked above)');
   const providerRaw = await select({
     message: 'Step 1 — Which provider do you want to use?',
     options: providerOptions,
-    initialValue: providerOptions[0]!.value,
+    initialValue: firstProviderOption.value,
   });
   const provider = guard(providerRaw);
 
@@ -191,10 +194,12 @@ export async function runSetupWizard(opts: RunSetupWizardOptions): Promise<strin
   // Step 3 — model (from the resolved provider's real models)
   let model: string | null = null;
   if (modelChoices.length > 0) {
+    const firstModelChoice = modelChoices[0];
+    assertDefined(firstModelChoice, 'modelChoices is non-empty (checked above)');
     const modelRaw = await select({
       message: `Step 3 — Default model for ${colors.bold(provider)}`,
       options: toOptions(modelChoices),
-      initialValue: modelChoices[0]!.id,
+      initialValue: firstModelChoice.id,
     });
     model = guard(modelRaw);
   }

--- a/packages/config/src/loader.test.ts
+++ b/packages/config/src/loader.test.ts
@@ -26,8 +26,11 @@ describe('loadConfig', () => {
       `export default { plugins: { provider: { default: 'anthropic', items: { anthropic: { model: 'sonnet' } } } } };`,
     );
     const result = await loadConfig({ cwd: tmp, skipUser: true });
-    expect(result.config.plugins?.provider?.default).toBe('anthropic');
-    expect(result.config.plugins?.provider?.items?.anthropic?.model).toBe('sonnet');
+    const provider = result.config.plugins?.provider;
+    expect(provider?.default).toBe('anthropic');
+    const providerItems = provider?.items;
+    const anthropicItem = providerItems?.anthropic;
+    expect(anthropicItem?.model).toBe('sonnet');
     expect(result.sources[0]?.scope).toBe('project');
   });
 
@@ -39,7 +42,8 @@ describe('loadConfig', () => {
       `export default { plugins: { mode: { default: 'default' } } };`,
     );
     const result = await loadConfig({ cwd: nested, skipUser: true });
-    expect(result.config.plugins?.mode?.default).toBe('default');
+    const mode = result.config.plugins?.mode;
+    expect(mode?.default).toBe('default');
   });
 
   it('honors explicitPath over upward search', async () => {
@@ -50,7 +54,8 @@ describe('loadConfig', () => {
     const custom = path.join(tmp, 'custom.config.js');
     await fs.writeFile(custom, `export default { plugins: { mode: { default: 'research' } } };`);
     const result = await loadConfig({ cwd: tmp, explicitPath: custom, skipUser: true });
-    expect(result.config.plugins?.mode?.default).toBe('research');
+    const mode = result.config.plugins?.mode;
+    expect(mode?.default).toBe('research');
     expect(result.sources[0]?.scope).toBe('explicit');
   });
 
@@ -78,7 +83,8 @@ describe('loadConfig', () => {
     const file = path.join(tmp, 'moxxy.config.mjs');
     await fs.writeFile(file, `export default { plugins: { mode: { default: 'default' } } };`);
     const first = await loadConfig({ cwd: tmp, skipUser: true });
-    expect(first.config.plugins?.mode?.default).toBe('default');
+    const firstMode = first.config.plugins?.mode;
+    expect(firstMode?.default).toBe('default');
 
     await fs.writeFile(file, `export default { plugins: { mode: { default: 'goal' } } };`);
     // Two reloads with no delay between them (same-ms risk).
@@ -86,8 +92,10 @@ describe('loadConfig', () => {
       loadConfig({ cwd: tmp, skipUser: true }),
       loadConfig({ cwd: tmp, skipUser: true }),
     ]);
-    expect(a.config.plugins?.mode?.default).toBe('goal');
-    expect(b.config.plugins?.mode?.default).toBe('goal');
+    const modeA = a.config.plugins?.mode;
+    expect(modeA?.default).toBe('goal');
+    const modeB = b.config.plugins?.mode;
+    expect(modeB?.default).toBe('goal');
   });
 
   it('resolves each .ts config\'s relative imports against ITS OWN dir (jiti cache keyed by cwd)', async () => {
@@ -112,8 +120,14 @@ describe('loadConfig', () => {
       const a = await loadConfig({ cwd: dirA, skipUser: true });
       const b = await loadConfig({ cwd: dirB, skipUser: true });
 
-      expect(a.config.plugins?.provider?.items?.x?.model).toBe('from-A');
-      expect(b.config.plugins?.provider?.items?.x?.model).toBe('from-B');
+      const providerA = a.config.plugins?.provider;
+      const itemsA = providerA?.items;
+      const itemXA = itemsA?.x;
+      expect(itemXA?.model).toBe('from-A');
+      const providerB = b.config.plugins?.provider;
+      const itemsB = providerB?.items;
+      const itemXB = itemsB?.x;
+      expect(itemXB?.model).toBe('from-B');
     } finally {
       await fs.rm(dirA, { recursive: true, force: true });
       await fs.rm(dirB, { recursive: true, force: true });

--- a/packages/config/src/loader.yaml.test.ts
+++ b/packages/config/src/loader.yaml.test.ts
@@ -27,16 +27,21 @@ describe('YAML config loading', () => {
 `,
     );
     const result = await loadConfig({ cwd: tmp, skipUser: true });
-    expect(result.config.plugins?.provider?.default).toBe('anthropic');
-    expect(result.config.plugins?.provider?.items?.anthropic?.model).toBe('claude-sonnet-4-6');
-    expect(result.config.plugins?.mode?.default).toBe('default');
+    const provider = result.config.plugins?.provider;
+    expect(provider?.default).toBe('anthropic');
+    const providerItems = provider?.items;
+    const anthropicItem = providerItems?.anthropic;
+    expect(anthropicItem?.model).toBe('claude-sonnet-4-6');
+    const mode = result.config.plugins?.mode;
+    expect(mode?.default).toBe('default');
     expect(result.sources[0]?.scope).toBe('project');
   });
 
   it('loads .yml extension too', async () => {
     await fs.writeFile(path.join(tmp, 'moxxy.config.yml'), `plugins:\n  mode:\n    default: research\n`);
     const result = await loadConfig({ cwd: tmp, skipUser: true });
-    expect(result.config.plugins?.mode?.default).toBe('research');
+    const mode = result.config.plugins?.mode;
+    expect(mode?.default).toBe('research');
   });
 
   it('walks upward to find a yaml config', async () => {
@@ -44,7 +49,8 @@ describe('YAML config loading', () => {
     await fs.mkdir(nested, { recursive: true });
     await fs.writeFile(path.join(tmp, 'moxxy.config.yaml'), `plugins:\n  mode:\n    default: default\n`);
     const result = await loadConfig({ cwd: nested, skipUser: true });
-    expect(result.config.plugins?.mode?.default).toBe('default');
+    const mode = result.config.plugins?.mode;
+    expect(mode?.default).toBe('default');
   });
 
   it('rejects a yaml config whose schema is invalid', async () => {
@@ -95,8 +101,11 @@ channels:
 `,
     );
     const result = await loadConfig({ cwd: tmp, skipUser: true });
-    expect(result.config.plugins?.embedder?.default).toBe('openai');
-    expect(result.config.plugins?.packages?.['@moxxy/plugin-browser']?.enabled).toBe(false);
+    const embedder = result.config.plugins?.embedder;
+    expect(embedder?.default).toBe('openai');
+    const packages = result.config.plugins?.packages;
+    const browserPkg = packages?.['@moxxy/plugin-browser'];
+    expect(browserPkg?.enabled).toBe(false);
     expect(result.config.channels?.['http']).toEqual({
       port: 8080,
       allowedTools: ['Read', 'Glob'],
@@ -131,8 +140,11 @@ channels:
       `plugins:\n  embedder:\n    items:\n      openai:\n        model: text-embedding-3-small\n`,
     );
     const result = await loadConfig({ cwd: tmp, skipUser: true });
-    expect(result.config.plugins?.embedder?.items?.openai?.model).toBe('text-embedding-3-small');
-    expect(result.config.plugins?.embedder?.default).toBeUndefined();
+    const embedder = result.config.plugins?.embedder;
+    const embedderItems = embedder?.items;
+    const openaiItem = embedderItems?.openai;
+    expect(openaiItem?.model).toBe('text-embedding-3-small');
+    expect(embedder?.default).toBeUndefined();
   });
 
   it('YAML at project level is overridden by .ts at same level (loader precedence)', async () => {
@@ -144,6 +156,7 @@ channels:
       `export default { plugins: { mode: { default: 'research' } } };`,
     );
     const result = await loadConfig({ cwd: tmp, skipUser: true });
-    expect(result.config.plugins?.mode?.default).toBe('default');
+    const mode = result.config.plugins?.mode;
+    expect(mode?.default).toBe('default');
   });
 });

--- a/packages/config/src/merge.test.ts
+++ b/packages/config/src/merge.test.ts
@@ -41,7 +41,8 @@ describe('mergeConfigs', () => {
   it('merges plugin-specific options deeply', () => {
     const a = { plugins: { p: { options: { a: 1, deep: { x: 1 } } } } };
     const b = { plugins: { p: { options: { b: 2, deep: { y: 2 } } } } };
-    expect(mergeConfigs(a, b).plugins?.p?.options).toEqual({
+    const pluginP = mergeConfigs(a, b).plugins?.p;
+    expect(pluginP?.options).toEqual({
       a: 1,
       b: 2,
       deep: { x: 1, y: 2 },

--- a/packages/config/src/plugin.test.ts
+++ b/packages/config/src/plugin.test.ts
@@ -240,9 +240,8 @@ describe('buildConfigPlugin runtime applier', () => {
     )) as { runtime: ConfigApplyResult };
     expect(out.runtime).toEqual({ applied: ['mode'], pending: ['provider.name'] });
     expect(seen).toHaveLength(1);
-    expect((seen[0] as { plugins?: { mode?: { default?: string } } }).plugins?.mode?.default).toBe(
-      'goal',
-    );
+    const seenMode = (seen[0] as { plugins?: { mode?: { default?: string } } }).plugins?.mode;
+    expect(seenMode?.default).toBe('goal');
   });
 
   it('config_set catches an applier throw and reports it as a reload-failed pending entry', async () => {
@@ -282,7 +281,9 @@ describe('buildConfigPlugin runtime applier', () => {
       return { applied: ['mode'], pending: [] };
     };
     const out = (await toolOf(pluginWith(applier), 'config_reload').handler({}, ctx)) as ConfigApplyResult;
-    expect(received?.plugins?.mode?.default).toBe('goal');
+    const receivedPlugins = received?.plugins;
+    const receivedMode = receivedPlugins?.mode;
+    expect(receivedMode?.default).toBe('goal');
     expect(out).toEqual({ applied: ['mode'], pending: [] });
   });
 

--- a/packages/config/src/plugins-tree-schema.test.ts
+++ b/packages/config/src/plugins-tree-schema.test.ts
@@ -16,7 +16,8 @@ describe('plugins-tree schema — reflector category', () => {
     const parsed = pluginsTreeSchema.parse({
       reflector: { default: 'default', items: { default: { window: 'session' } } },
     });
-    expect(parsed.reflector?.items?.default).toEqual({ window: 'session' });
+    const reflectorItems = parsed.reflector?.items;
+    expect(reflectorItems?.default).toEqual({ window: 'session' });
   });
 
   it('rejects an unknown key inside the reflector slot (.strict())', () => {

--- a/packages/config/src/user-config.ts
+++ b/packages/config/src/user-config.ts
@@ -159,7 +159,9 @@ export async function loadProviderItems(
     const parsed = parseYaml(raw) as {
       plugins?: { provider?: { items?: Record<string, ProviderItemState> } };
     } | null;
-    return parsed?.plugins?.provider?.items ?? {};
+    const plugins = parsed?.plugins;
+    const provider = plugins?.provider;
+    return provider?.items ?? {};
   } catch {
     return {};
   }

--- a/packages/plugin-cli/src/audio-play.test.ts
+++ b/packages/plugin-cli/src/audio-play.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events';
 import type { spawn } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import {
   __resetAudioPlayerProbeForTest,
   checkAudioPlaybackAvailable,
@@ -48,7 +49,9 @@ async function waitForChild(children: FakeChild[]): Promise<FakeChild> {
     if (Date.now() - start > 2_000) throw new Error('player was never spawned');
     await flush();
   }
-  return children[0]!;
+  const child = children[0];
+  assertDefined(child, 'loop exits only once a child was spawned');
+  return child;
 }
 
 beforeEach(() => __resetAudioPlayerProbeForTest());

--- a/packages/plugin-cli/src/components/SkillsPanel.test.ts
+++ b/packages/plugin-cli/src/components/SkillsPanel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { asSkillId, type Skill, type SkillScope } from '@moxxy/sdk';
+import { asSkillId, assertDefined, type Skill, type SkillScope } from '@moxxy/sdk';
 import { buildSkillRows } from './SkillsPanel.js';
 
 function skill(name: string, scope: SkillScope): Skill {
@@ -20,12 +20,16 @@ describe('buildSkillRows (SkillsPanel)', () => {
       skill('alpha', 'user'),
     ]);
     expect(rows.map((r) => r.name)).toEqual(['alpha', 'beta', 'zeta']);
-    expect(rows[0]!.description).toBe('does alpha');
+    const firstRow = rows[0];
+    assertDefined(firstRow, 'rows rendered');
+    expect(firstRow.description).toBe('does alpha');
   });
 
   it('threads a positive invocation count into row.used, keyed by skill name', () => {
     const rows = buildSkillRows([skill('deploy', 'user')], { deploy: 4 });
-    expect(rows[0]!.used).toBe(4);
+    const firstRow = rows[0];
+    assertDefined(firstRow, 'one row rendered');
+    expect(firstRow.used).toBe(4);
   });
 
   it('omits used for a zero/absent count (badge stays hidden)', () => {
@@ -34,12 +38,18 @@ describe('buildSkillRows (SkillsPanel)', () => {
       { deploy: 0 }, // recorded but never invoked; lint has no entry at all
     );
     const byName = Object.fromEntries(rows.map((r) => [r.name, r]));
-    expect(byName['deploy']!.used).toBeUndefined();
-    expect(byName['lint']!.used).toBeUndefined();
+    const deployRow = byName['deploy'];
+    assertDefined(deployRow, 'deploy row exists');
+    expect(deployRow.used).toBeUndefined();
+    const lintRow = byName['lint'];
+    assertDefined(lintRow, 'lint row exists');
+    expect(lintRow.used).toBeUndefined();
   });
 
   it('works with no usage map at all (all badges hidden)', () => {
     const rows = buildSkillRows([skill('deploy', 'user')]);
-    expect(rows[0]!.used).toBeUndefined();
+    const firstRow = rows[0];
+    assertDefined(firstRow, 'one row rendered');
+    expect(firstRow.used).toBeUndefined();
   });
 });

--- a/packages/plugin-cli/src/components/chat/StreamingPreview.test.ts
+++ b/packages/plugin-cli/src/components/chat/StreamingPreview.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 
 import { lastNonEmptyLineShown, tailForViewport } from './StreamingPreview.js';
 
@@ -23,8 +24,10 @@ function refShown(content: string, innerCols: number): string {
   const lines = content.split('\n');
   let line = '';
   for (let i = lines.length - 1; i >= 0; i -= 1) {
-    if (lines[i]!.trim()) {
-      line = lines[i]!;
+    const candidate = lines[i];
+    assertDefined(candidate, 'i < lines.length');
+    if (candidate.trim()) {
+      line = candidate;
       break;
     }
   }

--- a/packages/plugin-cli/src/components/prompt/parse-input.ts
+++ b/packages/plugin-cli/src/components/prompt/parse-input.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from '@moxxy/sdk';
 import type { Action } from './reducer.js';
 import { matchEscape } from './escape.js';
 
@@ -97,7 +98,8 @@ export function parseInputChunk(chunk: string, ctx: ParseCtx): string {
       i += PASTE_START.length;
       continue;
     }
-    const c = chunk[i]!;
+    const c = chunk[i];
+    assertDefined(c, 'i < chunk.length within the while loop');
     // Control bytes
     if (c === '\r' || c === '\n') {
       // Enter:
@@ -203,7 +205,8 @@ export function parseInputChunk(chunk: string, ctx: ParseCtx): string {
       } else if (action === 'shift-tab') {
         ctx.onShiftTab?.();
       } else if (action === 'command-hotkey' && matched.letter) {
-        ctx.commandHotkeys?.[matched.letter]?.();
+        const hotkey = ctx.commandHotkeys?.[matched.letter];
+        hotkey?.();
       }
       // action === 'noop' falls through here: consume `len` bytes (below)
       // and dispatch nothing — used for unrecognized terminal sequences so

--- a/packages/plugin-cli/src/components/prompt/reducer.ts
+++ b/packages/plugin-cli/src/components/prompt/reducer.ts
@@ -131,15 +131,15 @@ function isWordChar(c: string): boolean {
 
 function wordBackPos(buffer: string, cursor: number): number {
   let i = cursor;
-  while (i > 0 && !isWordChar(buffer[i - 1]!)) i -= 1;
-  while (i > 0 && isWordChar(buffer[i - 1]!)) i -= 1;
+  while (i > 0 && !isWordChar(buffer[i - 1] ?? '')) i -= 1;
+  while (i > 0 && isWordChar(buffer[i - 1] ?? '')) i -= 1;
   return i;
 }
 
 function wordForwardPos(buffer: string, cursor: number): number {
   let i = cursor;
-  while (i < buffer.length && !isWordChar(buffer[i]!)) i += 1;
-  while (i < buffer.length && isWordChar(buffer[i]!)) i += 1;
+  while (i < buffer.length && !isWordChar(buffer[i] ?? '')) i += 1;
+  while (i < buffer.length && isWordChar(buffer[i] ?? '')) i += 1;
   return i;
 }
 

--- a/packages/plugin-cli/src/context-estimate.ts
+++ b/packages/plugin-cli/src/context-estimate.ts
@@ -1,4 +1,5 @@
 import {
+  assertDefined,
   computeElisionState,
   conversationalStub,
   conversationalStubbed,
@@ -122,7 +123,8 @@ export function estimateContextTokens(
         chars += per(e);
         if (e.seq > guardSeq) guardSeq = e.seq;
       }
-      const last = fresh[fresh.length - 1]!;
+      const last = fresh[fresh.length - 1];
+      assertDefined(last, 'fresh is non-empty (entry.count < len when the prefix is intact)');
       cache.set(log, { count: len, firstId: entry.firstId, lastId: String(last.id), chars, guardSeq });
       return Math.ceil(chars / 4);
     }
@@ -166,8 +168,10 @@ function fullWalk(log: EventLogReader, per: (e: MoxxyEvent) => number): number {
     }
     chars += per(e);
   }
-  const first = events[0]!;
-  const last = events[events.length - 1]!;
+  const first = events[0];
+  const last = events[events.length - 1];
+  assertDefined(first, 'fullWalk only runs on a non-empty log (len === 0 returns earlier)');
+  assertDefined(last, 'fullWalk only runs on a non-empty log (len === 0 returns earlier)');
   cache.set(log, {
     count: events.length,
     firstId: String(first.id),

--- a/packages/plugin-cli/src/image-attachments.test.ts
+++ b/packages/plugin-cli/src/image-attachments.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import {
   detectPastedImagePath,
   extractImagePlaceholders,
@@ -25,8 +26,9 @@ describe('detectPastedImagePath', () => {
       delete process.env.HOME;
       const result = detectPastedImagePath('~/pics/shot.png');
       expect(result).not.toBeNull();
-      expect(path.isAbsolute(result!.absPath)).toBe(true);
-      expect(result!.absPath).toBe(path.join(homedir(), 'pics/shot.png'));
+      assertDefined(result, 'home-relative image path detected');
+      expect(path.isAbsolute(result.absPath)).toBe(true);
+      expect(result.absPath).toBe(path.join(homedir(), 'pics/shot.png'));
     } finally {
       if (prevHome === undefined) delete process.env.HOME;
       else process.env.HOME = prevHome;
@@ -85,7 +87,8 @@ describe('loadImageAttachment', () => {
   it('reads the file and returns a base64 attachment', async () => {
     const detected = detectPastedImagePath(imagePath);
     expect(detected).not.toBeNull();
-    const attachment = await loadImageAttachment(detected!);
+    assertDefined(detected, 'image path detected');
+    const attachment = await loadImageAttachment(detected);
     expect(attachment.kind).toBe('image');
     expect(attachment.mediaType).toBe('image/png');
     expect(attachment.name).toBe('tiny.png');

--- a/packages/plugin-cli/src/logo-data.ts
+++ b/packages/plugin-cli/src/logo-data.ts
@@ -4,6 +4,7 @@
  * the init wizard banner, and the TUI mount all show the same banner +
  * slogan during a single process.
  */
+import { assertDefined } from '@moxxy/sdk';
 
 /**
  * The moxxy mascot, rendered as grayscale ASCII art. Drawn dim-gray
@@ -129,7 +130,9 @@ let cachedSlogan: string | null = null;
  */
 export function pickSlogan(): string {
   if (cachedSlogan !== null) return cachedSlogan;
-  cachedSlogan = SLOGANS[Math.floor(Math.random() * SLOGANS.length)]!;
+  const picked = SLOGANS[Math.floor(Math.random() * SLOGANS.length)];
+  assertDefined(picked, 'random index is always within the non-empty SLOGANS pool');
+  cachedSlogan = picked;
   return cachedSlogan;
 }
 
@@ -176,7 +179,9 @@ export function pickExamples(n: number = 2): ReadonlyArray<string> {
   const out: string[] = [];
   for (let i = 0; i < n && pool.length > 0; i += 1) {
     const idx = Math.floor(Math.random() * pool.length);
-    out.push(pool[idx]!);
+    const example = pool[idx];
+    assertDefined(example, 'random index is always within the non-empty pool');
+    out.push(example);
     pool.splice(idx, 1);
   }
   cachedExamples = out;

--- a/packages/plugin-cli/src/session/helpers.ts
+++ b/packages/plugin-cli/src/session/helpers.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from '@moxxy/sdk';
 import type { ClientSession as Session, ModeBadge } from '@moxxy/sdk';
 import {
   BUILTIN_SLASH_COMMANDS,
@@ -96,7 +97,8 @@ export function deriveMcpServers(
   for (const t of tools) {
     const m = /^mcp__([a-z0-9-]+)__/.exec(t.name);
     if (!m) continue;
-    const server = m[1]!;
+    const server = m[1];
+    assertDefined(server, 'the mcp-tool regex has a required capture group');
     const list = grouped.get(server) ?? [];
     list.push(t.name);
     grouped.set(server, list);

--- a/packages/plugin-cli/src/session/picker-handlers.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.ts
@@ -1,4 +1,5 @@
 import {
+  assertDefined,
   isFirstPartyPackage,
   type ClientSession as Session,
   type PluginsAdminView,
@@ -128,11 +129,15 @@ function handleSettingSelected(id: string, deps: PickerHandlerDeps): void {
   void (async () => {
     try {
       const { config } = await loadConfig({ cwd: process.cwd() });
-      const value = knob.next!(config);
+      const next = knob.next;
+      const dotPath = knob.dotPath;
+      assertDefined(next, 'boolean/enum knobs always define a next() writer');
+      assertDefined(dotPath, 'boolean/enum knobs always define a dotPath');
+      const value = next(config);
       await setConfigValue({
         scope: 'user',
         cwd: process.cwd(),
-        path: knob.dotPath!,
+        path: dotPath,
         value,
       });
       const admin = deps.session.configAdmin;
@@ -166,7 +171,7 @@ function runPickerInstall(
   opts: { reopenPluginsPicker?: boolean; onSuccess?: () => void } = {},
 ): void {
   const admin = deps.session.pluginsAdmin;
-  const install = admin?.install?.bind(admin);
+  const install = admin?.install ? admin.install.bind(admin) : undefined;
   if (!install) {
     deps.setSystemNotice(`to install: run \`moxxy plugins install ${target}\``);
     return;
@@ -184,15 +189,22 @@ function runPickerInstall(
       // Loaded-package names BEFORE the install: the fallback way to learn
       // the installed package's name when the spec doesn't reveal it
       // (git/path installs) — whatever appears in `loaded()` afterwards is it.
-      const loadedBefore = new Set(admin?.loaded?.().map((p) => p.name) ?? []);
+      const loadedBefore = new Set(
+        admin?.loaded ? admin.loaded().map((p) => p.name) : [],
+      );
       const res = await install(target);
       const kinds = Object.entries(res.registered)
         .filter(([, names]) => names && names.length > 0)
-        .map(([kind, names]) => `${kind}: ${names!.join(', ')}`)
+        .map(([kind, names]) => {
+          assertDefined(names, 'filtered to entries with a non-empty names array above');
+          return `${kind}: ${names.join(', ')}`;
+        })
         .join('; ');
       const pkgName =
         packageNameFromSpec(res.installed) ??
-        deps.session.pluginsAdmin?.loaded?.().find((p) => !loadedBefore.has(p.name))?.name;
+        (admin?.loaded
+          ? admin.loaded().find((p) => !loadedBefore.has(p.name))?.name
+          : undefined);
       // THIRD-PARTY (outside the @moxxy scope): the capability surface must
       // be consented to before the plugin keeps running. The follow-up
       // (setup dialog, slash rerun) is deferred behind the `keep` choice.
@@ -267,10 +279,11 @@ async function runPostInstallFollowUp(
 ): Promise<void> {
   if (res.needsSetup) {
     const admin = deps.session.pluginsAdmin;
-    const pkg =
-      admin?.catalog().find((e) => e.id === target || e.packageName === target)?.packageName ??
-      target;
-    const spec = await admin?.setupSpec?.(pkg).catch(() => null);
+    const catalogEntry = admin?.catalog().find(
+      (e) => e.id === target || e.packageName === target,
+    );
+    const pkg = catalogEntry?.packageName ?? target;
+    const spec = admin?.setupSpec ? await admin.setupSpec(pkg).catch(() => null) : null;
     if (spec && deps.openPluginSetup) {
       deps.openPluginSetup({ packageName: pkg, spec, ...(onSuccess ? { then: onSuccess } : {}) });
       return; // dialog's `then` runs onSuccess after configuration
@@ -375,13 +388,17 @@ function handleInstallConsent(
 function handlePluginSetupPicked(id: string, deps: PickerHandlerDeps): void {
   const admin = deps.session.pluginsAdmin;
   if (!admin?.setupSpec || !deps.openPluginSetup) return;
+  // Capture the narrowed capabilities before the async closure: property
+  // narrowing from the guard above doesn't survive into the nested function.
+  const setupSpec = admin.setupSpec.bind(admin);
+  const openPluginSetup = deps.openPluginSetup;
   void (async () => {
-    const spec = await admin.setupSpec!(id).catch(() => null);
+    const spec = await setupSpec(id).catch(() => null);
     if (!spec) {
       deps.setSystemNotice(`${id} declares no setup step`);
       return;
     }
-    deps.openPluginSetup!({ packageName: id, spec });
+    openPluginSetup({ packageName: id, spec });
   })();
 }
 

--- a/packages/plugin-cli/src/session/provider-connect-flow.test.ts
+++ b/packages/plugin-cli/src/session/provider-connect-flow.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ProviderSetupView } from '@moxxy/sdk';
+import { assertDefined, type ProviderSetupView } from '@moxxy/sdk';
 import { createConnectFlow, type ConnectPhase } from './provider-connect-flow.js';
 
 function makeSetup(over: Partial<ProviderSetupView> = {}): ProviderSetupView {
@@ -135,8 +135,10 @@ describe('createConnectFlow — oauth', () => {
     const setup = makeSetup({
       authKind: () => 'oauth',
       loginOAuth: vi.fn(async (_id, io) => {
-        io!.write('open https://example.test/auth\n');
-        const code = await io!.prompt!('Paste the code:', { mask: true });
+        assertDefined(io, 'io passed to loginOAuth');
+        io.write('open https://example.test/auth\n');
+        assertDefined(io.prompt, 'io.prompt available');
+        const code = await io.prompt('Paste the code:', { mask: true });
         expect(code).toBe('the-code');
         return { accountId: 'me@example.test' };
       }),
@@ -174,7 +176,9 @@ describe('createConnectFlow — oauth', () => {
     const setup = makeSetup({
       authKind: () => 'oauth',
       loginOAuth: vi.fn(async (_id, io) => {
-        received = await io!.prompt!('Paste:', {});
+        assertDefined(io, 'io passed to loginOAuth');
+        assertDefined(io.prompt, 'io.prompt available');
+        received = await io.prompt('Paste:', {});
         throw new Error('cancelled');
       }),
     });

--- a/packages/plugin-cli/src/session/read-aloud.test.ts
+++ b/packages/plugin-cli/src/session/read-aloud.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import type { SynthesizeReplyResult, SynthesizerSource } from '@moxxy/channel-kit';
 import type { PlayAudioResult } from '../audio-play.js';
 import {
@@ -137,7 +138,9 @@ describe('createReadAloud — auto-speak trigger', () => {
     controller.onTurnComplete();
     await flush();
     expect(synthesize).toHaveBeenCalledTimes(1);
-    expect(synthesize.mock.calls[0]![1]).toBe('final answer');
+    const firstCall = synthesize.mock.calls[0];
+    assertDefined(firstCall, 'synthesize was called');
+    expect(firstCall[1]).toBe('final answer');
     expect(play).toHaveBeenCalledTimes(1);
 
     // Same turn / same reply → not re-spoken.
@@ -187,7 +190,9 @@ describe('createReadAloud — /speak command dispatch', () => {
     controller.handleCommand('');
     await flush();
     expect(synthesize).toHaveBeenCalledTimes(1);
-    expect(synthesize.mock.calls[0]![1]).toBe('spoken reply');
+    const firstCall = synthesize.mock.calls[0];
+    assertDefined(firstCall, 'synthesize was called');
+    expect(firstCall[1]).toBe('spoken reply');
     expect(play).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/plugin-cli/src/session/read-aloud.ts
+++ b/packages/plugin-cli/src/session/read-aloud.ts
@@ -1,4 +1,5 @@
 import { synthesizeReply, type SynthesizeReplyResult, type SynthesizerSource } from '@moxxy/channel-kit';
+import { assertDefined } from '@moxxy/sdk';
 import type { ClientSession as Session } from '@moxxy/sdk';
 import { playAudio, type AudioPlaybackOptions, type PlayAudioResult } from '../audio-play.js';
 
@@ -89,7 +90,8 @@ export function lastAssistantReply(
 ): { readonly content: string; readonly seq: number } | null {
   const messages = session.ofType('assistant_message');
   for (let i = messages.length - 1; i >= 0; i--) {
-    const m = messages[i]!;
+    const m = messages[i];
+    assertDefined(m, 'i in [0, messages.length) (loop bounds)');
     if (m.stopReason === 'end_turn' && m.content.trim().length > 0) {
       return { content: m.content, seq: m.seq };
     }

--- a/packages/plugin-cli/src/session/run-slash.test.ts
+++ b/packages/plugin-cli/src/session/run-slash.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { runSlash, type SlashDeps } from './run-slash.js';
 
 // run-slash.ts imports clearUsageStats/readSessionIndex from @moxxy/core and
@@ -230,8 +231,12 @@ describe('runSlash /sessions', () => {
     };
     expect(picker.kind).toBe('sessions');
     // "+ New session" first, then the two persisted ones; current marked.
-    expect(picker.options[0]!.id).toBe('__new__');
-    expect(picker.options.find((o) => o.id === 'sess-current')!.current).toBe(true);
+    const firstOption = picker.options[0];
+    assertDefined(firstOption, 'picker has a first option');
+    expect(firstOption.id).toBe('__new__');
+    const currentOption = picker.options.find((o) => o.id === 'sess-current');
+    assertDefined(currentOption, 'sess-current option exists');
+    expect(currentOption.current).toBe(true);
     expect(picker.options.map((o) => o.id)).toContain('sess-other');
   });
 });

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -373,6 +373,10 @@ export function openPluginSetupEntry(deps: SlashDeps, arg = ''): void {
     deps.setSystemNotice('plugin setup is not available on this session — run `moxxy init` instead');
     return;
   }
+  // Capture the narrowed capabilities before the async closure: property
+  // narrowing from the guard above doesn't survive into the nested function.
+  const setupSpec = admin.setupSpec.bind(admin);
+  const openPluginSetup = deps.openPluginSetup;
   const target = arg.trim();
   void (async () => {
     try {
@@ -380,19 +384,19 @@ export function openPluginSetupEntry(deps: SlashDeps, arg = ''): void {
         const pkg =
           admin.catalog().find((e) => e.id === target || e.packageName === target)?.packageName ??
           target;
-        const spec = await admin.setupSpec!(pkg);
+        const spec = await setupSpec(pkg);
         if (!spec) {
           deps.setSystemNotice(`${pkg} is not installed or declares no setup step`);
           return;
         }
-        deps.openPluginSetup!({ packageName: pkg, spec });
+        openPluginSetup({ packageName: pkg, spec });
         return;
       }
       // Bare /setup: list installed plugins that declare a setup step.
       const installed = admin.loaded().filter((pl) => pl.installed);
       const withSpecs: ListPickerOption[] = [];
       for (const pl of installed) {
-        const spec = await admin.setupSpec!(pl.name).catch(() => null);
+        const spec = await setupSpec(pl.name).catch(() => null);
         if (spec) {
           withSpecs.push({
             id: pl.name,

--- a/packages/plugin-cli/src/session/sessions-picker.test.ts
+++ b/packages/plugin-cli/src/session/sessions-picker.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import type { SessionMeta } from '@moxxy/core';
 import {
   buildSessionPickerOptions,
@@ -24,7 +25,9 @@ describe('buildSessionPickerOptions', () => {
 
   it('always leads with a "new session" entry', () => {
     const opts = buildSessionPickerOptions([], 'none', NOW);
-    expect(opts[0]!.id).toBe(NEW_SESSION_OPTION_ID);
+    const first = opts[0];
+    assertDefined(first, 'picker always has a first entry');
+    expect(first.id).toBe(NEW_SESSION_OPTION_ID);
     expect(opts).toHaveLength(1);
   });
 
@@ -34,8 +37,10 @@ describe('buildSessionPickerOptions', () => {
       'b',
       NOW,
     );
-    const a = opts.find((o) => o.id === 'a')!;
-    const b = opts.find((o) => o.id === 'b')!;
+    const a = opts.find((o) => o.id === 'a');
+    assertDefined(a, 'option a exists');
+    const b = opts.find((o) => o.id === 'b');
+    assertDefined(b, 'option b exists');
     expect(b.current).toBe(true);
     expect(b.badge).toBe('active');
     expect(a.current).toBeUndefined();
@@ -48,7 +53,8 @@ describe('buildSessionPickerOptions', () => {
       'other',
       NOW,
     );
-    const a = opts.find((o) => o.id === 'a')!;
+    const a = opts.find((o) => o.id === 'a');
+    assertDefined(a, 'option a exists');
     expect(a.label).toBe('fix the login bug');
     expect(a.description).toContain('7 ev');
     expect(a.description).toContain('gpt-test');
@@ -61,13 +67,17 @@ describe('buildSessionPickerOptions', () => {
       'other',
       NOW,
     );
-    expect(opts.find((o) => o.id === 'a')!.label).toBe('Login work');
+    const a = opts.find((o) => o.id === 'a');
+    assertDefined(a, 'option a exists');
+    expect(a.label).toBe('Login work');
   });
 
   it('truncates an over-long title to 60 chars with an ellipsis', () => {
     const long = 'x'.repeat(120);
     const opts = buildSessionPickerOptions([meta({ id: 'a', firstPrompt: long })], 'other', NOW);
-    const label = opts.find((o) => o.id === 'a')!.label;
+    const a = opts.find((o) => o.id === 'a');
+    assertDefined(a, 'option a exists');
+    const label = a.label;
     expect(label.length).toBe(60);
     expect(label.endsWith('…')).toBe(true);
   });
@@ -82,7 +92,8 @@ describe('buildSessionPickerOptions', () => {
       NOW,
     );
     expect(opts.find((o) => o.id === 'empty-other')).toBeUndefined();
-    const active = opts.find((o) => o.id === 'empty-active')!;
+    const active = opts.find((o) => o.id === 'empty-active');
+    assertDefined(active, 'empty ACTIVE session is kept');
     expect(active).toBeDefined();
     expect(active.label).toBe('(empty session)');
   });

--- a/packages/plugin-cli/src/session/settings-descriptors.test.ts
+++ b/packages/plugin-cli/src/session/settings-descriptors.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { moxxyConfigSchema, type MoxxyConfig } from '@moxxy/config';
 import { findKnob, SETTINGS_KNOBS } from './settings-descriptors.js';
 import { parseTuiKeyOverrides } from './helpers.js';
@@ -19,8 +20,10 @@ describe('SETTINGS_KNOBS', () => {
     const empty = {} as MoxxyConfig;
     for (const knob of SETTINGS_KNOBS) {
       if (knob.kind === 'link' || knob.kind === 'readonly') continue;
-      const value = knob.next!(empty);
-      const candidate = withPath(knob.dotPath!, value);
+      assertDefined(knob.next, `writable knob ${knob.id} has next`);
+      const value = knob.next(empty);
+      assertDefined(knob.dotPath, `writable knob ${knob.id} has dotPath`);
+      const candidate = withPath(knob.dotPath, value);
       const res = moxxyConfigSchema.safeParse(candidate);
       expect(res.success, `${knob.id} → ${knob.dotPath} = ${JSON.stringify(value)}`).toBe(true);
     }
@@ -28,25 +31,38 @@ describe('SETTINGS_KNOBS', () => {
 
   it('reasoning cycles off → on → on (high) → off', () => {
     const at = (r: unknown) => ({ context: { reasoning: r } }) as MoxxyConfig;
-    const knob = findKnob('reasoning')!;
-    expect(knob.next!({} as MoxxyConfig)).toBe(true);
-    expect(knob.next!(at(true))).toEqual({ effort: 'high' });
-    expect(knob.next!(at({ effort: 'high' }))).toBe(false);
+    const knob = findKnob('reasoning');
+    assertDefined(knob, 'reasoning knob exists');
+    assertDefined(knob.next, 'reasoning knob has next');
+    expect(knob.next({} as MoxxyConfig)).toBe(true);
+    expect(knob.next(at(true))).toEqual({ effort: 'high' });
+    expect(knob.next(at({ effort: 'high' }))).toBe(false);
     expect(knob.current({} as MoxxyConfig)).toBe('off');
     expect(knob.current(at(true))).toBe('on');
     expect(knob.current(at({ effort: 'high' }))).toBe('on (high)');
   });
 
   it('booleans toggle against their documented defaults', () => {
-    expect(findKnob('caching')!.next!({} as MoxxyConfig)).toBe(false); // default on
-    expect(findKnob('security')!.next!({} as MoxxyConfig)).toBe(true); // default off
-    expect(findKnob('tui-hints')!.next!({} as MoxxyConfig)).toBe(false); // default on
+    const cachingKnob = findKnob('caching');
+    assertDefined(cachingKnob, 'caching knob exists');
+    assertDefined(cachingKnob.next, 'caching knob has next');
+    expect(cachingKnob.next({} as MoxxyConfig)).toBe(false); // default on
+    const securityKnob = findKnob('security');
+    assertDefined(securityKnob, 'security knob exists');
+    assertDefined(securityKnob.next, 'security knob has next');
+    expect(securityKnob.next({} as MoxxyConfig)).toBe(true); // default off
+    const tuiHintsKnob = findKnob('tui-hints');
+    assertDefined(tuiHintsKnob, 'tui-hints knob exists');
+    assertDefined(tuiHintsKnob.next, 'tui-hints knob has next');
+    expect(tuiHintsKnob.next({} as MoxxyConfig)).toBe(false); // default on
   });
 
   it('theme cycles default ↔ mono', () => {
-    const knob = findKnob('tui-theme')!;
-    expect(knob.next!({} as MoxxyConfig)).toBe('mono');
-    expect(knob.next!({ tui: { theme: 'mono' } } as MoxxyConfig)).toBe('default');
+    const knob = findKnob('tui-theme');
+    assertDefined(knob, 'tui-theme knob exists');
+    assertDefined(knob.next, 'tui-theme knob has next');
+    expect(knob.next({} as MoxxyConfig)).toBe('mono');
+    expect(knob.next({ tui: { theme: 'mono' } } as MoxxyConfig)).toBe('default');
   });
 });
 

--- a/packages/plugin-cli/src/session/settings-descriptors.ts
+++ b/packages/plugin-cli/src/session/settings-descriptors.ts
@@ -81,8 +81,14 @@ export const SETTINGS_KNOBS: ReadonlyArray<SettingsKnob> = [
     description: 'turn-boundary elision of old tool output (default on)',
     kind: 'boolean',
     dotPath: 'context.elision.enabled',
-    current: (c) => onOff(c.context?.elision?.enabled, true),
-    next: (c) => !(c.context?.elision?.enabled ?? true),
+    current: (c) => {
+      const elision = c.context?.elision;
+      return onOff(elision?.enabled, true);
+    },
+    next: (c) => {
+      const elision = c.context?.elision;
+      return !(elision?.enabled ?? true);
+    },
   },
   {
     id: 'lazy-tools',
@@ -99,8 +105,14 @@ export const SETTINGS_KNOBS: ReadonlyArray<SettingsKnob> = [
     description: 'bail a turn early on repeated identical tool calls (default on)',
     kind: 'boolean',
     dotPath: 'context.loopGuard.enabled',
-    current: (c) => onOff(c.context?.loopGuard?.enabled, true),
-    next: (c) => !(c.context?.loopGuard?.enabled ?? true),
+    current: (c) => {
+      const loopGuard = c.context?.loopGuard;
+      return onOff(loopGuard?.enabled, true);
+    },
+    next: (c) => {
+      const loopGuard = c.context?.loopGuard;
+      return !(loopGuard?.enabled ?? true);
+    },
   },
   {
     id: 'security',

--- a/packages/plugin-cli/src/session/use-event-stream.test.ts
+++ b/packages/plugin-cli/src/session/use-event-stream.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { MoxxyEvent } from '@moxxy/sdk';
+import { assertDefined, type MoxxyEvent } from '@moxxy/sdk';
 
 // Drive the hook without a React renderer, mirroring use-turn-runner.test.ts:
 // persistent state/ref cells + a useEffect that runs its body synchronously, so
@@ -15,7 +15,8 @@ vi.mock('react', () => {
     if (!stateCells[i]) {
       stateCells[i] = { value: typeof init === 'function' ? (init as () => unknown)() : init };
     }
-    const cell = stateCells[i]!;
+    const cell = stateCells[i];
+    assertDefined(cell, 'cell created above');
     const setter = (next: unknown) => {
       cell.value = typeof next === 'function' ? (next as (p: unknown) => unknown)(cell.value) : next;
     };
@@ -24,7 +25,9 @@ vi.mock('react', () => {
   const useRef = (init: unknown) => {
     const i = refIdx++;
     if (!refCells[i]) refCells[i] = { current: init };
-    return refCells[i]!;
+    const refCell = refCells[i];
+    assertDefined(refCell, 'ref cell created above');
+    return refCell;
   };
   const useEffect = (fn: () => void | (() => void)) => {
     // Run the effect body now (mount). Ignore the returned cleanup.
@@ -73,7 +76,11 @@ function mount(session: Parameters<typeof useEventStream>[0]) {
 }
 
 // `events` is the first useState in the hook → stateCells[0].
-const renderedEvents = () => stateCells[0]!.value as ReadonlyArray<MoxxyEvent>;
+const renderedEvents = () => {
+  const firstCell = stateCells[0];
+  assertDefined(firstCell, 'events state cell exists after mount');
+  return firstCell.value as ReadonlyArray<MoxxyEvent>;
+};
 
 describe('seedFromLog', () => {
   it('returns the held events, dropping live-only chunk types', () => {

--- a/packages/plugin-cli/src/session/use-image-attachments.test.ts
+++ b/packages/plugin-cli/src/session/use-image-attachments.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 
 // Drive the hook without a React renderer by mocking react's useRef with a
 // deterministic, persistent implementation (mirrors use-turn-runner.test.ts).
@@ -10,7 +11,9 @@ vi.mock('react', () => ({
   useRef: (init: unknown) => {
     const i = refIdx++;
     if (!refCells[i]) refCells[i] = { current: init };
-    return refCells[i]!;
+    const refCell = refCells[i];
+    assertDefined(refCell, 'ref cell created above');
+    return refCell;
   },
 }));
 

--- a/packages/plugin-cli/src/session/use-turn-runner.test.ts
+++ b/packages/plugin-cli/src/session/use-turn-runner.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 
 // Drive the hook without a React renderer by mocking react's useState/useRef
 // with deterministic, persistent implementations. The hook is mounted ONCE
@@ -19,7 +20,8 @@ vi.mock('react', () => ({
     if (!stateCells[i]) {
       stateCells[i] = { value: typeof init === 'function' ? (init as () => unknown)() : init };
     }
-    const cell = stateCells[i]!;
+    const cell = stateCells[i];
+    assertDefined(cell, 'cell created above');
     const setter = (next: unknown) => {
       cell.value = typeof next === 'function' ? (next as (p: unknown) => unknown)(cell.value) : next;
     };
@@ -28,7 +30,9 @@ vi.mock('react', () => ({
   useRef: (init: unknown) => {
     const i = refIdx++;
     if (!refCells[i]) refCells[i] = { current: init };
-    return refCells[i]!;
+    const refCell = refCells[i];
+    assertDefined(refCell, 'ref cell created above');
+    return refCell;
   },
 }));
 

--- a/packages/plugin-cli/src/session/use-turn-runner.ts
+++ b/packages/plugin-cli/src/session/use-turn-runner.ts
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 import type React from 'react';
+import { assertDefined } from '@moxxy/sdk';
 import type { ClientSession as Session, UserPromptAttachment } from '@moxxy/sdk';
 import type { EventStreamHandle } from './use-event-stream.js';
 
@@ -146,10 +147,13 @@ export function useTurnRunner(opts: TurnRunnerOptions): TurnRunnerHandle {
         const batch: QueuedMessage[] = [];
         let chars = 0;
         while (queueRef.current.length > 0 && batch.length < MAX_DRAIN_MESSAGES) {
-          const next = queueRef.current[0]!;
+          const next = queueRef.current[0];
+          assertDefined(next, 'queue length > 0 (loop condition)');
           const projected = chars + next.text.length;
           if (batch.length > 0 && projected > MAX_DRAIN_CHARS) break;
-          batch.push(queueRef.current.shift()!);
+          const shifted = queueRef.current.shift();
+          assertDefined(shifted, 'queue length > 0 (loop condition, nothing shifted since the peek)');
+          batch.push(shifted);
           chars = projected;
         }
         const remaining = queueRef.current.length;
@@ -168,7 +172,8 @@ export function useTurnRunner(opts: TurnRunnerOptions): TurnRunnerHandle {
 
   const forceSendFirst = (): boolean => {
     if (queueRef.current.length === 0) return false;
-    const first = queueRef.current.shift()!;
+    const first = queueRef.current.shift();
+    assertDefined(first, 'length !== 0 checked immediately above');
     setQueueCount(queueRef.current.length);
     setPriority(first);
     return true;

--- a/packages/plugin-commands/src/index.ts
+++ b/packages/plugin-commands/src/index.ts
@@ -169,7 +169,8 @@ function safe<T>(fn: () => T): T | null {
 
 async function compactSession(session: unknown) {
   const s = session as CompactSessionShape;
-  const compactor = s.compactors?.getActive?.();
+  const compactors = s.compactors;
+  const compactor = compactors?.getActive ? compactors.getActive() : undefined;
   if (!compactor) return { kind: 'error' as const, message: 'no active compactor configured' };
 
   // Distinguish an empty log up front so we can keep the specific
@@ -183,7 +184,10 @@ async function compactSession(session: unknown) {
   const isEmpty =
     typeof knownLength === 'number'
       ? knownLength === 0
-      : (safe(() => s.log?.slice?.())?.length ?? 1) === 0;
+      : (safe(() => {
+          const log = s.log;
+          return log?.slice ? log.slice() : undefined;
+        })?.length ?? 1) === 0;
   if (isEmpty) {
     return { kind: 'text' as const, text: 'nothing to compact: event log is empty' };
   }
@@ -199,7 +203,11 @@ async function compactSession(session: unknown) {
   // Resolve model/window inside the guard too: a malformed/foreign provider
   // (e.g. one passed over the WS bridge) whose `.models` is a throwing getter
   // or a non-array would otherwise throw here, escaping the try/catch below.
-  const firstModel = safe(() => provider?.models?.[0]) ?? undefined;
+  const firstModel =
+    safe(() => {
+      const models = provider?.models;
+      return models?.[0];
+    }) ?? undefined;
   const model = firstModel?.id;
   const contextWindow = firstModel?.contextWindow;
 

--- a/packages/plugin-oauth/src/discovery.test.ts
+++ b/packages/plugin-oauth/src/discovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ServiceRegistry } from '@moxxy/sdk';
+import { assertDefined, type ServiceRegistry } from '@moxxy/sdk';
 import { oauthPlugin } from './index.js';
 
 /**
@@ -29,7 +29,10 @@ describe('oauthPlugin (discovery-loadable)', () => {
       has: () => true,
       register: () => {},
     } as unknown as ServiceRegistry;
-    oauthPlugin.hooks!.onInit!({ services } as never);
+    const hooks = oauthPlugin.hooks;
+    assertDefined(hooks, 'oauthPlugin declares hooks');
+    assertDefined(hooks.onInit, 'onInit hook declared');
+    hooks.onInit({ services } as never);
     expect(require).toHaveBeenCalledWith('vault');
   });
 });

--- a/packages/plugin-oauth/src/oauth/token-exchange.test.ts
+++ b/packages/plugin-oauth/src/oauth/token-exchange.test.ts
@@ -1,4 +1,4 @@
-import { MoxxyError } from '@moxxy/sdk';
+import { assertDefined, MoxxyError } from '@moxxy/sdk';
 import { describe, expect, it, vi } from 'vitest';
 import {
   exchangeCodeForToken,
@@ -38,8 +38,9 @@ describe('parseTokenResponse', () => {
     expect(set.tokenType).toBe('MAC');
     expect(set.idToken).toBe('idt');
     // expiresAt = now + expires_in*1000 (allow for the small wall-clock delta).
-    expect(set.expiresAt!).toBeGreaterThanOrEqual(before + 3600 * 1000);
-    expect(set.expiresAt!).toBeLessThanOrEqual(Date.now() + 3600 * 1000);
+    assertDefined(set.expiresAt, 'expiresAt computed from expires_in');
+    expect(set.expiresAt).toBeGreaterThanOrEqual(before + 3600 * 1000);
+    expect(set.expiresAt).toBeLessThanOrEqual(Date.now() + 3600 * 1000);
   });
 
   it('omits expiresAt when expires_in is absent', () => {
@@ -111,7 +112,9 @@ describe('refreshAccessToken', () => {
       text: async () => '',
     }));
     await refreshAccessToken(baseInput, spy as unknown as typeof fetch);
-    const body = (spy.mock.calls[0]![1] as RequestInit).body as string;
+    const firstCall = spy.mock.calls[0];
+    assertDefined(firstCall, 'fetch called once');
+    const body = (firstCall[1] as RequestInit).body as string;
     expect(body).toContain('grant_type=refresh_token');
     expect(body).toContain('refresh_token=old-rt');
     expect(body).toContain('client_id=cid');

--- a/packages/plugin-oauth/src/profile.test.ts
+++ b/packages/plugin-oauth/src/profile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { MoxxyError } from '@moxxy/sdk';
+import { assertDefined, MoxxyError } from '@moxxy/sdk';
 import {
   openaiDeviceFlow,
   pollUntil,
@@ -15,7 +15,10 @@ function newFakeVault(): OAuthVault & { dump(): Record<string, string> } {
   const store = new Map<string, string>();
   return {
     async get(key) {
-      return store.has(key) ? store.get(key)! : null;
+      if (!store.has(key)) return null;
+      const value = store.get(key);
+      assertDefined(value, 'store has the key');
+      return value;
     },
     async set(key, value) {
       store.set(key, value);
@@ -113,8 +116,9 @@ describe('storage extras round-trip', () => {
     });
     const stored = await readStoredCreds(vault, 'demo');
     expect(stored).not.toBeNull();
-    expect(stored!.extras).toEqual({ account_id: 'acct_123', team_slug: 'eng' });
-    expect(stored!.tokenSet.accessToken).toBe('AT');
+    assertDefined(stored, 'stored creds readable');
+    expect(stored.extras).toEqual({ account_id: 'acct_123', team_slug: 'eng' });
+    expect(stored.tokenSet.accessToken).toBe('AT');
   });
 
   it('returns an empty extras map when none were stored', async () => {
@@ -124,7 +128,8 @@ describe('storage extras round-trip', () => {
       tokenUrl: 'https://example.test/token',
     });
     const stored = await readStoredCreds(vault, 'demo');
-    expect(stored!.extras).toEqual({});
+    assertDefined(stored, 'stored creds readable');
+    expect(stored.extras).toEqual({});
   });
 });
 
@@ -188,7 +193,11 @@ describe('rfc8628DeviceFlow adapter', () => {
           { status: 200 },
         ),
     ];
-    globalThis.fetch = (async () => responses.shift()!()) as unknown as typeof fetch;
+    globalThis.fetch = (async () => {
+      const nextResponse = responses.shift();
+      assertDefined(nextResponse, 'scripted response remaining');
+      return nextResponse();
+    }) as unknown as typeof fetch;
     try {
       const state = { intervalMs: 5000 };
       const r1 = await adapter.poll(init, state);

--- a/packages/plugin-plugins-admin/src/capability-copy.ts
+++ b/packages/plugin-plugins-admin/src/capability-copy.ts
@@ -23,8 +23,10 @@ export interface CapabilitySurfaceRow {
  */
 export function describeCapabilitySurface(s: CapabilitySpec): ReadonlyArray<CapabilitySurfaceRow> {
   const rows: CapabilitySurfaceRow[] = [];
-  if (s.fs?.read?.length) rows.push({ label: 'Read files', value: s.fs.read.join(', ') });
-  if (s.fs?.write?.length) rows.push({ label: 'Write files', value: s.fs.write.join(', ') });
+  const fsRead = s.fs?.read;
+  if (fsRead?.length) rows.push({ label: 'Read files', value: fsRead.join(', ') });
+  const fsWrite = s.fs?.write;
+  if (fsWrite?.length) rows.push({ label: 'Write files', value: fsWrite.join(', ') });
   if (s.net) {
     rows.push({
       label: 'Network',

--- a/packages/plugin-plugins-admin/src/catalog.test.ts
+++ b/packages/plugin-plugins-admin/src/catalog.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import {
   applyGitRef,
   buildInstallSpec,
@@ -11,18 +12,19 @@ import {
 
 // A UI catalog entry (the action test exercises the `open` option, which is
 // UI-only). Pinning by kind keeps the test stable as catalog ordering changes.
-const entry = INSTALLABLE_PLUGIN_CATALOG.find((e) => e.kind === 'ui')!;
+const entry = INSTALLABLE_PLUGIN_CATALOG.find((e) => e.kind === 'ui');
+assertDefined(entry, 'catalog has a ui entry');
 
 describe('catalog: unbundled providers are installable', () => {
   it('lists the 6 API-key providers with bare-npm install specs', () => {
     for (const slug of ['anthropic', 'openai', 'google', 'xai', 'zai', 'local']) {
       const pkg = `@moxxy/plugin-provider-${slug}`;
       const e = resolveCatalogEntry(`provider-${slug}`);
-      expect(e, `provider-${slug} in catalog`).toBeDefined();
-      expect(e!.packageName).toBe(pkg);
+      assertDefined(e, `provider-${slug} in catalog`);
+      expect(e.packageName).toBe(pkg);
       // bare package name → npm latest (matches init/provision install-latest)
-      expect(e!.installSpec).toBe(pkg);
-      expect(e!.kind).toBeUndefined(); // not a UI plugin
+      expect(e.installSpec).toBe(pkg);
+      expect(e.kind).toBeUndefined(); // not a UI plugin
     }
   });
   it('resolves a provider by package name too', () => {

--- a/packages/plugin-plugins-admin/src/config.test.ts
+++ b/packages/plugin-plugins-admin/src/config.test.ts
@@ -40,8 +40,10 @@ describe('plugins-admin config', () => {
     const parsed = parse(readFileSync(configPath, 'utf8')) as {
       plugins?: { provider?: { default?: string }; mode?: { default?: string } };
     };
-    expect(parsed.plugins?.provider?.default).toBe('openai');
-    expect(parsed.plugins?.mode?.default).toBe('goal');
+    const provider = parsed.plugins?.provider;
+    expect(provider?.default).toBe('openai');
+    const mode = parsed.plugins?.mode;
+    expect(mode?.default).toBe('goal');
     await expect(setCategoryDefault('bogus', 'x', { configPath })).rejects.toThrow(
       /unknown plugin category/,
     );
@@ -56,8 +58,11 @@ describe('plugins-admin config', () => {
         compactor?: { default?: string };
       };
     };
-    expect(parsed.plugins?.packages?.['@moxxy/plugin-telegram']?.enabled).toBe(false);
-    expect(parsed.plugins?.compactor?.default).toBe('summarize');
+    const packages = parsed.plugins?.packages;
+    const telegramPkg = packages?.['@moxxy/plugin-telegram'];
+    expect(telegramPkg?.enabled).toBe(false);
+    const compactor = parsed.plugins?.compactor;
+    expect(compactor?.default).toBe('summarize');
   });
 
   // invariant 5: concurrent read-modify-write of the shared config.yaml must
@@ -96,7 +101,9 @@ describe('plugins-admin config', () => {
     };
     expect(parsed.systemPrompt).toBe('hello');
     expect(parsed.maxIterations).toBe(7);
-    expect(parsed.plugins?.packages?.['@moxxy/plugin-a']?.enabled).toBe(false);
+    const packages = parsed.plugins?.packages;
+    const pluginA = packages?.['@moxxy/plugin-a'];
+    expect(pluginA?.enabled).toBe(false);
   });
 
   it('clearPluginState keeps a sibling plugin entry', async () => {

--- a/packages/plugin-plugins-admin/src/pin.test.ts
+++ b/packages/plugin-plugins-admin/src/pin.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { pinFirstPartySpec } from './pin.js';
 import { installPluginPackagePinned } from './install.js';
 
@@ -63,7 +64,9 @@ describe('installPluginPackagePinned', () => {
       expect.objectContaining({ packageName: '@moxxy/plugin-x' }),
     );
     expect(onWarn).toHaveBeenCalledTimes(1);
-    expect(onWarn.mock.calls[0]![0]).toContain('@moxxy/plugin-x@9.9.9');
+    const firstWarnCall = onWarn.mock.calls[0];
+    assertDefined(firstWarnCall, 'onWarn was called exactly once (asserted above)');
+    expect(firstWarnCall[0]).toContain('@moxxy/plugin-x@9.9.9');
     expect(res.installed).toBe('@moxxy/plugin-x');
   });
 

--- a/packages/plugin-plugins-admin/src/registry.test.ts
+++ b/packages/plugin-plugins-admin/src/registry.test.ts
@@ -99,8 +99,10 @@ describe('verifyRegistryIndex / parseRegistryIndex', () => {
     expect(verifyRegistryIndex(bytes, sig, publicKeyPem)).toBe(true);
     const index = parseRegistryIndex(bytes);
     expect(index?.entries).toHaveLength(2);
-    expect(index?.entries[0]?.version).toBe('0.26.0');
-    expect(index?.entries[0]?.capabilities?.net).toEqual({
+    const firstEntry = index?.entries[0];
+    expect(firstEntry?.version).toBe('0.26.0');
+    const firstCapabilities = firstEntry?.capabilities;
+    expect(firstCapabilities?.net).toEqual({
       mode: 'allowlist',
       hosts: ['api.telegram.org'],
     });

--- a/packages/plugin-plugins-admin/src/search.test.ts
+++ b/packages/plugin-plugins-admin/src/search.test.ts
@@ -57,7 +57,7 @@ describe('searchInstallablePlugins', () => {
     const hangThenAbort: FetchLike = (_url, init) =>
       new Promise((_resolve, reject) => {
         seenSignal = init?.signal;
-        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+        seenSignal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
       });
     const ac = new AbortController();
     const p = searchInstallablePlugins('zzz-no-catalog-match', {

--- a/packages/plugin-provider-admin/src/configure.test.ts
+++ b/packages/plugin-provider-admin/src/configure.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { MoxxyError, type ProviderDef } from '@moxxy/sdk';
+import { assertDefined, MoxxyError, type ProviderDef } from '@moxxy/sdk';
 import { buildProviderAdminPluginWithApi, type ProviderRegistryLike } from './index.js';
 import { readProvidersConfig, upsertStoredProvider } from './store.js';
 import type { StoredProvider } from './types.js';
@@ -82,7 +82,8 @@ describe('buildProviderAdminPluginWithApi.configure', () => {
     const { api } = build();
     await api.configure('zai', { baseURL: 'https://new.example.com/v1' });
     const cfg = await readProvidersConfig(cfgPath);
-    const stored = cfg.providers.find((p) => p.name === 'zai')!;
+    const stored = cfg.providers.find((p) => p.name === 'zai');
+    assertDefined(stored, "stored provider 'zai' exists");
     expect(stored.baseURL).toBe('https://new.example.com/v1');
     // Untouched fields preserved.
     expect(stored.defaultModel).toBe('glm-4.6');
@@ -105,7 +106,8 @@ describe('buildProviderAdminPluginWithApi.configure', () => {
       defaultModel: 'glm-4.7',
       models: [{ id: 'glm-4.7', contextWindow: 256_000, supportsTools: true, supportsStreaming: true }],
     });
-    const stored = (await readProvidersConfig(cfgPath)).providers.find((p) => p.name === 'zai')!;
+    const stored = (await readProvidersConfig(cfgPath)).providers.find((p) => p.name === 'zai');
+    assertDefined(stored, "stored provider 'zai' exists");
     expect(stored.defaultModel).toBe('glm-4.7');
     expect(stored.models.map((m) => m.id)).toEqual(['glm-4.7']);
   });
@@ -115,13 +117,17 @@ describe('buildProviderAdminPluginWithApi.configure', () => {
     // Mirror the runtime: the entry is also live in the registry (onInit would
     // have registered it). configure() must replace() it, not register().
     const { plugin, api } = build();
-    await plugin.hooks!.onInit!({} as never);
+    const onInit = plugin.hooks?.onInit;
+    assertDefined(onInit, 'plugin registers onInit');
+    await onInit({} as never);
     expect(registry.defs.has('zai')).toBe(true);
 
     await api.configure('zai', { defaultModel: 'glm-4.5-air' });
-    const def = registry.defs.get('zai')!;
+    const def = registry.defs.get('zai');
+    assertDefined(def, "registry has a live 'zai' def");
     expect(def.models.find((m) => m.id === 'glm-4.5-air')).toBeTruthy();
-    const stored = (await readProvidersConfig(cfgPath)).providers.find((p) => p.name === 'zai')!;
+    const stored = (await readProvidersConfig(cfgPath)).providers.find((p) => p.name === 'zai');
+    assertDefined(stored, "stored provider 'zai' exists");
     expect(stored.defaultModel).toBe('glm-4.5-air');
   });
 
@@ -135,8 +141,11 @@ describe('buildProviderAdminPluginWithApi.configure', () => {
     const { plugin, api } = build(reg);
     // onInit registers + CLAIMS OWNERSHIP of 'zai' (so configure treats it as a
     // runtime-registered provider, not a reserved built-in).
-    await plugin.hooks!.onInit!({} as never);
-    const priorDef = reg.defs.get('zai')!;
+    const onInit = plugin.hooks?.onInit;
+    assertDefined(onInit, 'plugin registers onInit');
+    await onInit({} as never);
+    const priorDef = reg.defs.get('zai');
+    assertDefined(priorDef, "onInit registered 'zai'");
     expect(priorDef).toBeTruthy();
 
     // Read still works (file present), but the dir is read-only so the atomic
@@ -151,7 +160,8 @@ describe('buildProviderAdminPluginWithApi.configure', () => {
       await fs.chmod(tmpDir, 0o700);
     }
     // Disk is unchanged: still the seeded defaultModel.
-    const stored = (await readProvidersConfig(cfgPath)).providers.find((p) => p.name === 'zai')!;
+    const stored = (await readProvidersConfig(cfgPath)).providers.find((p) => p.name === 'zai');
+    assertDefined(stored, "stored provider 'zai' exists");
     expect(stored.defaultModel).toBe('glm-4.6');
   });
 });

--- a/packages/plugin-provider-admin/src/discovery.test.ts
+++ b/packages/plugin-provider-admin/src/discovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ServiceRegistry } from '@moxxy/sdk';
+import { assertDefined, type ServiceRegistry } from '@moxxy/sdk';
 import { providerAdminPlugin } from './index.js';
 
 /**
@@ -31,7 +31,9 @@ describe('providerAdminPlugin (discovery-loadable)', () => {
 
     // The inner onInit reads ~/.moxxy/providers.json (absent on CI → caught +
     // skipped); we only assert the service wiring here.
-    await providerAdminPlugin.hooks!.onInit!({ services } as never);
+    const onInit = providerAdminPlugin.hooks?.onInit;
+    assertDefined(onInit, 'plugin registers onInit');
+    await onInit({ services } as never);
 
     expect(get).toHaveBeenCalledWith('providers');
     expect(get).toHaveBeenCalledWith('resolveCredentials');

--- a/packages/plugin-provider-admin/src/index.test.ts
+++ b/packages/plugin-provider-admin/src/index.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import type { ProviderDef, ToolContext, ToolDef } from '@moxxy/sdk';
+import { assertDefined, type ProviderDef, type ToolContext, type ToolDef } from '@moxxy/sdk';
 import { buildProviderAdminPlugin, buildProviderAdminPluginWithApi, type ProviderRegistryLike } from './index.js';
 import { readProvidersConfig } from './store.js';
 
@@ -134,7 +134,9 @@ describe('provider_add', () => {
     expect(second.replaced).toBe(true);
     const cfg = await readProvidersConfig(cfgPath);
     expect(cfg.providers).toHaveLength(1);
-    expect(cfg.providers[0]!.defaultModel).toBe('glm-4.5-air');
+    const first = cfg.providers[0];
+    assertDefined(first, 'one provider stored');
+    expect(first.defaultModel).toBe('glm-4.5-air');
   });
 
   it('rejects when defaultModel is not in the models list', async () => {
@@ -147,7 +149,8 @@ describe('provider_add', () => {
   });
 
   it('rejects invalid slug shapes via inputSchema', () => {
-    const tool = tools.get('provider_add')!;
+    const tool = tools.get('provider_add');
+    assertDefined(tool, 'provider_add tool is registered');
     const bad = tool.inputSchema.safeParse({ ...zaiInput, name: 'NotASlug' });
     expect(bad.success).toBe(false);
   });
@@ -161,7 +164,8 @@ describe('provider_add', () => {
     const plugin = buildProviderAdminPlugin({ providerRegistry: withBuiltin, configPath: cfgPath });
     const guardedTools = new Map((plugin.tools ?? []).map((t) => [t.name, t]));
     const addBuiltin = (input: Record<string, unknown>): Promise<unknown> => {
-      const tool = guardedTools.get('provider_add')!;
+      const tool = guardedTools.get('provider_add');
+      assertDefined(tool, 'provider_add tool is registered');
       return Promise.resolve(tool.handler(tool.inputSchema.parse(input), {} as never));
     };
 
@@ -191,11 +195,17 @@ describe('provider_add', () => {
     const reg = new FakeRegistry();
     await seedStoredProviders(cfgPath, [zaiInput]);
     const plugin = buildProviderAdminPlugin({ providerRegistry: reg, configPath: cfgPath });
-    await plugin.hooks!.onInit!({} as never);
+    const onInit = plugin.hooks?.onInit;
+    assertDefined(onInit, 'plugin registers onInit');
+    await onInit({} as never);
     expect(reg.defs.has('zai')).toBe(true);
-    const priorDef = reg.defs.get('zai')!;
+    const priorDef = reg.defs.get('zai');
+    assertDefined(priorDef, "onInit registered 'zai'");
 
-    const addTool = plugin.tools!.find((t) => t.name === 'provider_add')!;
+    const pluginTools = plugin.tools;
+    assertDefined(pluginTools, 'plugin declares tools');
+    const addTool = pluginTools.find((t) => t.name === 'provider_add');
+    assertDefined(addTool, 'provider_add tool exists');
     await fs.chmod(tmpDir, 0o500);
     try {
       await expect(
@@ -219,7 +229,10 @@ describe('provider_add', () => {
     const reg = new FakeRegistry();
     await fs.writeFile(cfgPath, 'plugins:\n  provider:\n    items: {}\n', 'utf8');
     const plugin = buildProviderAdminPlugin({ providerRegistry: reg, configPath: cfgPath });
-    const addTool = plugin.tools!.find((t) => t.name === 'provider_add')!;
+    const pluginTools = plugin.tools;
+    assertDefined(pluginTools, 'plugin declares tools');
+    const addTool = pluginTools.find((t) => t.name === 'provider_add');
+    assertDefined(addTool, 'provider_add tool exists');
     await fs.chmod(tmpDir, 0o500);
     try {
       await expect(
@@ -250,8 +263,11 @@ describe('provider_add', () => {
       ],
     });
     const cfg = await readProvidersConfig(cfgPath);
-    expect(cfg.providers[0]!.models[0]).toMatchObject({ supportsDocuments: true });
-    const def = registry.defs.get('zai')!;
+    const first = cfg.providers[0];
+    assertDefined(first, 'one provider stored');
+    expect(first.models[0]).toMatchObject({ supportsDocuments: true });
+    const def = registry.defs.get('zai');
+    assertDefined(def, "registry has a live 'zai' def");
     expect(def.models[0]).toMatchObject({ supportsDocuments: true });
   });
 });
@@ -288,7 +304,8 @@ describe('provider_test', () => {
     ({ getSecret: async (name: string) => secrets[name] ?? null }) as unknown as ToolContext;
 
   function callTest(input: Record<string, unknown>, ctx: ToolContext): Promise<unknown> {
-    const tool = tools.get('provider_test')!;
+    const tool = tools.get('provider_test');
+    assertDefined(tool, 'provider_test tool is registered');
     const parsed = tool.inputSchema.parse(input);
     return Promise.resolve(tool.handler(parsed, ctx));
   }
@@ -330,7 +347,8 @@ describe('provider_test', () => {
   });
 
   it('does not accept a plaintext apiKey input (schema requires keyName)', () => {
-    const tool = tools.get('provider_test')!;
+    const tool = tools.get('provider_test');
+    assertDefined(tool, 'provider_test tool is registered');
     const bad = tool.inputSchema.safeParse({
       baseURL: 'https://api.deepseek.com',
       apiKey: 'sk-raw-key',
@@ -345,7 +363,8 @@ describe('provider_test', () => {
   });
 
   it('description asserts the vault-name contract', () => {
-    const tool = tools.get('provider_test')!;
+    const tool = tools.get('provider_test');
+    assertDefined(tool, 'provider_test tool is registered');
     expect(tool.description).toContain('vault');
     expect(tool.description).toMatch(/never enters the conversation/i);
     expect(tool.description).not.toMatch(/supplied API key/i);
@@ -369,7 +388,9 @@ describe('onInit logger guard', () => {
   it('warns through a conforming host logger', async () => {
     const warn = vi.fn();
     const plugin = buildProviderAdminPlugin({ providerRegistry: new ThrowingRegistry(), configPath: cfgPath });
-    await plugin.hooks!.onInit!({ logger: { warn } } as never);
+    const onInit = plugin.hooks?.onInit;
+    assertDefined(onInit, 'plugin registers onInit');
+    await onInit({ logger: { warn } } as never);
     expect(warn).toHaveBeenCalledWith(
       'provider-admin: failed to register "zai"',
       expect.any(Object),
@@ -378,13 +399,15 @@ describe('onInit logger guard', () => {
 
   it('ignores a non-conforming logger instead of crashing', async () => {
     const plugin = buildProviderAdminPlugin({ providerRegistry: new ThrowingRegistry(), configPath: cfgPath });
+    const onInit = plugin.hooks?.onInit;
+    assertDefined(onInit, 'plugin registers onInit');
     // `logger.warn` is a string, not a function — the guard must reject it
     // (a blanket cast would have called a non-function and thrown).
     await expect(
-      plugin.hooks!.onInit!({ logger: { warn: 'nope' } } as never),
+      onInit({ logger: { warn: 'nope' } } as never),
     ).resolves.toBeUndefined();
     // A ctx with no logger at all is likewise a clean no-op.
-    await expect(plugin.hooks!.onInit!({} as never)).resolves.toBeUndefined();
+    await expect(onInit({} as never)).resolves.toBeUndefined();
   });
 });
 
@@ -395,10 +418,15 @@ describe('onInit', () => {
     // Fresh registry — simulate a brand-new session pointing at the same store.
     const fresh = new FakeRegistry();
     const plugin = buildProviderAdminPlugin({ providerRegistry: fresh, configPath: cfgPath });
-    await plugin.hooks!.onInit!({} as never);
+    const onInit = plugin.hooks?.onInit;
+    assertDefined(onInit, 'plugin registers onInit');
+    await onInit({} as never);
     expect(fresh.defs.has('zai')).toBe(true);
-    const def = fresh.defs.get('zai')!;
-    expect(def.models[0]!.id).toBe('glm-4.6');
+    const def = fresh.defs.get('zai');
+    assertDefined(def, "registry has a live 'zai' def");
+    const firstModel = def.models[0];
+    assertDefined(firstModel, 'def has at least one model');
+    expect(firstModel.id).toBe('glm-4.6');
   });
 
   it('does not clobber a built-in when providers.json contains a colliding entry', async () => {
@@ -412,7 +440,9 @@ describe('onInit', () => {
     const builtinDef = { name: 'openai', models: [{ id: 'gpt-x', contextWindow: 1 }] } as unknown as ProviderDef;
     withBuiltin.register(builtinDef);
     const plugin = buildProviderAdminPlugin({ providerRegistry: withBuiltin, configPath: cfgPath });
-    await plugin.hooks!.onInit!({} as never);
+    const onInit = plugin.hooks?.onInit;
+    assertDefined(onInit, 'plugin registers onInit');
+    await onInit({} as never);
     // Built-in untouched...
     expect(withBuiltin.defs.get('openai')).toBe(builtinDef);
     // ...but the genuinely-new provider in the same file still got registered.
@@ -429,7 +459,10 @@ describe('built-in shadowing guard — production wiring order (registry empty a
     // Plugin built against an EMPTY registry (mirrors buildBuiltinsCore running
     // before registerPlugins() seeds the built-in defs).
     const plugin = buildProviderAdminPlugin({ providerRegistry: reg, configPath: cfgPath });
-    const addTool = plugin.tools!.find((t) => t.name === 'provider_add')!;
+    const pluginTools = plugin.tools;
+    assertDefined(pluginTools, 'plugin declares tools');
+    const addTool = pluginTools.find((t) => t.name === 'provider_add');
+    assertDefined(addTool, 'provider_add tool exists');
     // NOW the host registers the real built-in OpenAI def.
     const builtinDef = { name: 'openai', models: [{ id: 'gpt-x', contextWindow: 1 }] } as unknown as ProviderDef;
     reg.register(builtinDef);
@@ -462,11 +495,19 @@ describe('built-in shadowing guard — production wiring order (registry empty a
 describe('baseURL scheme/host hardening', () => {
   const addSchema = (): { safeParse: (i: unknown) => { success: boolean } } => {
     const plugin = buildProviderAdminPlugin({ providerRegistry: new FakeRegistry(), configPath: cfgPath });
-    return plugin.tools!.find((t) => t.name === 'provider_add')!.inputSchema as never;
+    const pluginTools = plugin.tools;
+    assertDefined(pluginTools, 'plugin declares tools');
+    const addTool = pluginTools.find((t) => t.name === 'provider_add');
+    assertDefined(addTool, 'provider_add tool exists');
+    return addTool.inputSchema as never;
   };
   const testSchema = (): { safeParse: (i: unknown) => { success: boolean } } => {
     const plugin = buildProviderAdminPlugin({ providerRegistry: new FakeRegistry(), configPath: cfgPath });
-    return plugin.tools!.find((t) => t.name === 'provider_test')!.inputSchema as never;
+    const pluginTools = plugin.tools;
+    assertDefined(pluginTools, 'plugin declares tools');
+    const testTool = pluginTools.find((t) => t.name === 'provider_test');
+    assertDefined(testTool, 'provider_test tool exists');
+    return testTool.inputSchema as never;
   };
 
   it('rejects non-https / dangerous baseURLs on provider_add', () => {
@@ -541,7 +582,10 @@ describe('per-name lock is bounded + serializes concurrent same-slug calls', () 
     const reg = new FakeRegistry();
     await fs.writeFile(cfgPath, 'plugins:\n  provider:\n    items: {}\n', 'utf8');
     const plugin = buildProviderAdminPlugin({ providerRegistry: reg, configPath: cfgPath });
-    const addTool = plugin.tools!.find((t) => t.name === 'provider_add')!;
+    const pluginTools = plugin.tools;
+    assertDefined(pluginTools, 'plugin declares tools');
+    const addTool = pluginTools.find((t) => t.name === 'provider_add');
+    assertDefined(addTool, 'provider_add tool exists');
     const fire = (defaultModel: string): Promise<unknown> =>
       Promise.resolve(
         addTool.handler(
@@ -570,8 +614,12 @@ describe('per-name lock is bounded + serializes concurrent same-slug calls', () 
     const reg = new FakeRegistry();
     await fs.writeFile(cfgPath, 'plugins:\n  provider:\n    items: {}\n', 'utf8');
     const plugin = buildProviderAdminPlugin({ providerRegistry: reg, configPath: cfgPath });
-    const addTool = plugin.tools!.find((t) => t.name === 'provider_add')!;
-    const removeTool = plugin.tools!.find((t) => t.name === 'provider_remove')!;
+    const pluginTools = plugin.tools;
+    assertDefined(pluginTools, 'plugin declares tools');
+    const addTool = pluginTools.find((t) => t.name === 'provider_add');
+    assertDefined(addTool, 'provider_add tool exists');
+    const removeTool = pluginTools.find((t) => t.name === 'provider_remove');
+    assertDefined(removeTool, 'provider_remove tool exists');
     for (let i = 0; i < 50; i++) {
       const name = `vendor-${i}`;
       await Promise.resolve(
@@ -598,7 +646,9 @@ describe('active-provider safety', () => {
         return { apiKey: 'k-for-' + name };
       },
     });
-    await plugin.hooks!.onInit!({} as never);
+    const onInit = plugin.hooks?.onInit;
+    assertDefined(onInit, 'plugin registers onInit');
+    await onInit({} as never);
     // Activate zai (mirrors the user selecting it). Drops no instance yet.
     reg.setActive('zai', { apiKey: 'k-for-zai' });
 
@@ -626,7 +676,9 @@ describe('active-provider safety', () => {
         return {};
       },
     });
-    await plugin.hooks!.onInit!({} as never);
+    const onInit = plugin.hooks?.onInit;
+    assertDefined(onInit, 'plugin registers onInit');
+    await onInit({} as never);
     reg.setActive('anthropic', {});
     await api.configure('zai', {
       defaultModel: 'glm-4.5-air',
@@ -639,9 +691,14 @@ describe('active-provider safety', () => {
     await seedStoredProviders(cfgPath, [zaiInput]);
     const reg = new FakeRegistry();
     const plugin = buildProviderAdminPlugin({ providerRegistry: reg, configPath: cfgPath });
-    await plugin.hooks!.onInit!({} as never);
+    const onInit = plugin.hooks?.onInit;
+    assertDefined(onInit, 'plugin registers onInit');
+    await onInit({} as never);
     reg.setActive('zai', {});
-    const removeTool = plugin.tools!.find((t) => t.name === 'provider_remove')!;
+    const pluginTools = plugin.tools;
+    assertDefined(pluginTools, 'plugin declares tools');
+    const removeTool = pluginTools.find((t) => t.name === 'provider_remove');
+    assertDefined(removeTool, 'provider_remove tool exists');
     const res = (await removeTool.handler(removeTool.inputSchema.parse({ name: 'zai' }), {} as never)) as {
       ok: boolean;
       removedActive: boolean;
@@ -659,7 +716,9 @@ describe('configure() patch validation (defense-in-depth)', () => {
     await seedStoredProviders(cfgPath, [zaiInput]);
     const reg = new FakeRegistry();
     const { plugin, api } = buildProviderAdminPluginWithApi({ providerRegistry: reg, configPath: cfgPath });
-    await plugin.hooks!.onInit!({} as never);
+    const onInit = plugin.hooks?.onInit;
+    assertDefined(onInit, 'plugin registers onInit');
+    await onInit({} as never);
     // file:// would flow straight into buildProviderDef + key-name derivation
     // without validation; configure() must reject it itself.
     const err = await api
@@ -667,7 +726,8 @@ describe('configure() patch validation (defense-in-depth)', () => {
       .catch((e) => e);
     expect(err).toBeTruthy();
     // Disk untouched.
-    const stored = (await readProvidersConfig(cfgPath)).providers.find((p) => p.name === 'zai')!;
+    const stored = (await readProvidersConfig(cfgPath)).providers.find((p) => p.name === 'zai');
+    assertDefined(stored, "stored provider 'zai' exists");
     expect(stored.baseURL).toBe(zaiInput.baseURL);
   });
 });

--- a/packages/plugin-provider-admin/src/store.test.ts
+++ b/packages/plugin-provider-admin/src/store.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { assertDefined } from '@moxxy/sdk';
 import {
   readProvidersConfig,
   removeStoredProvider,
@@ -58,7 +59,9 @@ describe('stored-provider tree store (plugins.provider.items)', () => {
     const updated: StoredProvider = { ...sampleEntry, defaultModel: 'glm-4.5-air' };
     const next = await upsertStoredProvider(updated, cfgPath);
     expect(next.providers).toHaveLength(1);
-    expect(next.providers[0]!.defaultModel).toBe('glm-4.5-air');
+    const first = next.providers[0];
+    assertDefined(first, 'one provider stored after upsert');
+    expect(first.defaultModel).toBe('glm-4.5-air');
   });
 
   it('upsert appends distinct entries', async () => {
@@ -132,7 +135,9 @@ describe('stored-provider tree store (plugins.provider.items)', () => {
       ].join('\n'),
     );
     const cfg = await readProvidersConfig(cfgPath);
-    expect(cfg.providers[0]!.models[0]).toMatchObject({
+    const first = cfg.providers[0];
+    assertDefined(first, 'legacy provider entry surfaced');
+    expect(first.models[0]).toMatchObject({
       id: 'm',
       contextWindow: 1000,
       supportsTools: true,

--- a/packages/plugin-self-update/src/discovery.test.ts
+++ b/packages/plugin-self-update/src/discovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ServiceRegistry } from '@moxxy/sdk';
+import { assertDefined, type ServiceRegistry } from '@moxxy/sdk';
 import { selfUpdatePlugin } from './index.js';
 
 /**
@@ -31,7 +31,10 @@ describe('selfUpdatePlugin (discovery-loadable)', () => {
       }
     });
     const services = { get, register: () => {}, require: () => undefined, has: () => true } as unknown as ServiceRegistry;
-    selfUpdatePlugin.hooks!.onInit!({ services } as never);
+    const hooks = selfUpdatePlugin.hooks;
+    assertDefined(hooks, 'selfUpdatePlugin declares hooks');
+    assertDefined(hooks.onInit, 'onInit hook declared');
+    hooks.onInit({ services } as never);
     expect(get).toHaveBeenCalledWith('pluginHost');
     expect(get).toHaveBeenCalledWith('registrySnapshot');
     expect(get).toHaveBeenCalledWith('appendEvent');

--- a/packages/plugin-self-update/src/index.test.ts
+++ b/packages/plugin-self-update/src/index.test.ts
@@ -3,7 +3,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
-import { asSessionId, asTurnId, type ToolContext, type ToolDef } from '@moxxy/sdk';
+import { asSessionId, assertDefined, asTurnId, type ToolContext, type ToolDef } from '@moxxy/sdk';
 import { buildSelfUpdatePlugin, type SelfUpdateDeps, type SkipInfo } from './index.js';
 import { readJournal } from './transaction.js';
 import { writeCoreJournal } from './core-update.js';
@@ -103,7 +103,9 @@ describe('self-update happy path', () => {
     const t = tools(host.deps());
     const ctx = makeCtx();
 
-    const begun = (await t.self_update_begin!.handler({ kind: 'plugin', name: 'greeter' }, ctx)) as {
+    const beginTool = t.self_update_begin;
+    assertDefined(beginTool, 'self_update_begin tool registered');
+    const begun = (await beginTool.handler({ kind: 'plugin', name: 'greeter' }, ctx)) as {
       txnId: string;
       existedBefore: boolean;
     };
@@ -111,14 +113,18 @@ describe('self-update happy path', () => {
 
     await writePlugin(moxxy, 'greeter', 'export default { name: "greeter" };\n');
 
-    const verified = (await t.self_update_verify!.handler({ txnId: begun.txnId }, ctx)) as {
+    const verifyTool = t.self_update_verify;
+    assertDefined(verifyTool, 'self_update_verify tool registered');
+    const verified = (await verifyTool.handler({ txnId: begun.txnId }, ctx)) as {
       ok: boolean;
       registered: Record<string, string[]>;
     };
     expect(verified.ok).toBe(true);
     expect(verified.registered.tools).toEqual(['greeter_tool']);
 
-    await t.self_update_apply!.handler({ txnId: begun.txnId }, ctx);
+    const applyTool = t.self_update_apply;
+    assertDefined(applyTool, 'self_update_apply tool registered');
+    await applyTool.handler({ txnId: begun.txnId }, ctx);
     expect((await readJournal(moxxy, begun.txnId)).state).toBe('committed');
   });
 });
@@ -130,12 +136,16 @@ describe('failed build / load auto-rollback + escalation', () => {
     const t = tools(host.deps());
     const ctx = makeCtx();
 
-    const begun = (await t.self_update_begin!.handler({ kind: 'plugin', name: 'oops' }, ctx)) as {
+    const beginTool = t.self_update_begin;
+    assertDefined(beginTool, 'self_update_begin tool registered');
+    const begun = (await beginTool.handler({ kind: 'plugin', name: 'oops' }, ctx)) as {
       txnId: string;
     };
     await writePlugin(moxxy, 'oops', 'BROKEN syntax (((\n');
 
-    const first = (await t.self_update_verify!.handler({ txnId: begun.txnId }, ctx)) as {
+    const verifyTool = t.self_update_verify;
+    assertDefined(verifyTool, 'self_update_verify tool registered');
+    const first = (await verifyTool.handler({ txnId: begun.txnId }, ctx)) as {
       ok: boolean;
       escalate: boolean;
     };
@@ -144,11 +154,11 @@ describe('failed build / load auto-rollback + escalation', () => {
     // New artifact is left in place so the model can fix it and retry.
     await expect(fs.access(path.join(moxxy, 'plugins', 'oops'))).resolves.toBeUndefined();
 
-    const second = (await t.self_update_verify!.handler({ txnId: begun.txnId }, ctx)) as { ok: boolean };
+    const second = (await verifyTool.handler({ txnId: begun.txnId }, ctx)) as { ok: boolean };
     expect(second.ok).toBe(false);
 
     // Third call hits the cap → escalate + clean up.
-    const third = (await t.self_update_verify!.handler({ txnId: begun.txnId }, ctx)) as {
+    const third = (await verifyTool.handler({ txnId: begun.txnId }, ctx)) as {
       ok: boolean;
       escalate: boolean;
     };
@@ -167,7 +177,9 @@ describe('failed build / load auto-rollback + escalation', () => {
     const ctx = makeCtx();
 
     await writePlugin(moxxy, 'mod', 'export default { name: "mod" };\n');
-    const begun = (await t.self_update_begin!.handler({ kind: 'plugin', name: 'mod' }, ctx)) as {
+    const beginTool = t.self_update_begin;
+    assertDefined(beginTool, 'self_update_begin tool registered');
+    const begun = (await beginTool.handler({ kind: 'plugin', name: 'mod' }, ctx)) as {
       txnId: string;
       existedBefore: boolean;
     };
@@ -175,10 +187,12 @@ describe('failed build / load auto-rollback + escalation', () => {
 
     // Break it, then verify three times. Each failure restores the good entry,
     // so subsequent verifies still re-break it first.
+    const verifyTool = t.self_update_verify;
+    assertDefined(verifyTool, 'self_update_verify tool registered');
     const breakAndVerify = async (): Promise<number> => {
       await writePlugin(moxxy, 'mod', 'BROKEN now\n');
       const before = host.reloads;
-      await t.self_update_verify!.handler({ txnId: begun.txnId }, ctx);
+      await verifyTool.handler({ txnId: begun.txnId }, ctx);
       return host.reloads - before;
     };
 
@@ -202,14 +216,18 @@ describe('failed build / load auto-rollback + escalation', () => {
     const good = 'export default { name: "bar" };\n';
     await writePlugin(moxxy, 'bar', good);
 
-    const begun = (await t.self_update_begin!.handler({ kind: 'plugin', name: 'bar' }, ctx)) as {
+    const beginTool = t.self_update_begin;
+    assertDefined(beginTool, 'self_update_begin tool registered');
+    const begun = (await beginTool.handler({ kind: 'plugin', name: 'bar' }, ctx)) as {
       txnId: string;
       existedBefore: boolean;
     };
     expect(begun.existedBefore).toBe(true);
 
     await writePlugin(moxxy, 'bar', 'BROKEN now\n');
-    const res = (await t.self_update_verify!.handler({ txnId: begun.txnId }, ctx)) as {
+    const verifyTool = t.self_update_verify;
+    assertDefined(verifyTool, 'self_update_verify tool registered');
+    const res = (await verifyTool.handler({ txnId: begun.txnId }, ctx)) as {
       ok: boolean;
       recovered: boolean;
     };
@@ -228,19 +246,23 @@ describe('tier-1 serialization', () => {
     const t = tools(host.deps());
     const ctx = makeCtx();
 
-    const first = (await t.self_update_begin!.handler({ kind: 'plugin', name: 'dup' }, ctx)) as {
+    const beginTool = t.self_update_begin;
+    assertDefined(beginTool, 'self_update_begin tool registered');
+    const first = (await beginTool.handler({ kind: 'plugin', name: 'dup' }, ctx)) as {
       txnId: string;
     };
     // Second begin on the SAME target must refuse (state is still 'open').
-    await expect(t.self_update_begin!.handler({ kind: 'plugin', name: 'dup' }, ctx)).rejects.toThrow(
+    await expect(beginTool.handler({ kind: 'plugin', name: 'dup' }, ctx)).rejects.toThrow(
       /already in progress/,
     );
     // A different target is unaffected.
-    await expect(t.self_update_begin!.handler({ kind: 'plugin', name: 'other' }, ctx)).resolves.toBeTruthy();
+    await expect(beginTool.handler({ kind: 'plugin', name: 'other' }, ctx)).resolves.toBeTruthy();
 
     // After the first is rolled back, a fresh begin on the same target is allowed.
-    await t.self_update_rollback!.handler({ txnId: first.txnId }, ctx);
-    await expect(t.self_update_begin!.handler({ kind: 'plugin', name: 'dup' }, ctx)).resolves.toBeTruthy();
+    const rollbackTool = t.self_update_rollback;
+    assertDefined(rollbackTool, 'self_update_rollback tool registered');
+    await rollbackTool.handler({ txnId: first.txnId }, ctx);
+    await expect(beginTool.handler({ kind: 'plugin', name: 'dup' }, ctx)).resolves.toBeTruthy();
   });
 });
 
@@ -251,14 +273,20 @@ describe('rollback', () => {
     const t = tools(host.deps());
     const ctx = makeCtx();
 
-    const begun = (await t.self_update_begin!.handler({ kind: 'plugin', name: 'temp' }, ctx)) as {
+    const beginTool = t.self_update_begin;
+    assertDefined(beginTool, 'self_update_begin tool registered');
+    const begun = (await beginTool.handler({ kind: 'plugin', name: 'temp' }, ctx)) as {
       txnId: string;
     };
     await writePlugin(moxxy, 'temp', 'export default { name: "temp" };\n');
-    await t.self_update_verify!.handler({ txnId: begun.txnId }, ctx);
+    const verifyTool = t.self_update_verify;
+    assertDefined(verifyTool, 'self_update_verify tool registered');
+    await verifyTool.handler({ txnId: begun.txnId }, ctx);
     expect(host.tools.has('temp_tool')).toBe(true);
 
-    await t.self_update_rollback!.handler({ txnId: begun.txnId, reason: 'not needed' }, ctx);
+    const rollbackTool = t.self_update_rollback;
+    assertDefined(rollbackTool, 'self_update_rollback tool registered');
+    await rollbackTool.handler({ txnId: begun.txnId, reason: 'not needed' }, ctx);
     await expect(fs.access(path.join(moxxy, 'plugins', 'temp'))).rejects.toBeTruthy();
     expect(host.tools.has('temp_tool')).toBe(false);
     expect((await readJournal(moxxy, begun.txnId)).state).toBe('rolled_back');
@@ -291,7 +319,8 @@ describe('rollback', () => {
     });
 
     const deps: SelfUpdateDeps = { ...new FakeHost(moxxy).deps(), coreUpdate: { fromUrl } };
-    const begin = tools(deps)['self_update_core_begin']!;
+    const begin = tools(deps)['self_update_core_begin'];
+    assertDefined(begin, 'self_update_core_begin tool registered');
     await expect(begin.handler({ packages: ['@moxxy/core'] }, makeCtx())).rejects.toThrow(
       /already in progress/,
     );

--- a/packages/plugin-self-update/src/verify.ts
+++ b/packages/plugin-self-update/src/verify.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
+import { assertDefined } from '@moxxy/sdk';
 import type { TxnTarget } from './transaction.js';
 
 /**
@@ -110,7 +111,9 @@ const PM_COMMANDS: Record<string, PmCommands> = {
  */
 function pmFor(pkg: PkgJson): PmCommands {
   const name = (pkg.packageManager ?? '').split('@')[0]?.trim().toLowerCase();
-  return (name && PM_COMMANDS[name]) || PM_COMMANDS.npm!;
+  const npmFallback = PM_COMMANDS.npm;
+  assertDefined(npmFallback, 'PM_COMMANDS always contains the npm entry');
+  return (name && PM_COMMANDS[name]) || npmFallback;
 }
 
 /**

--- a/packages/plugin-vault/src/command.test.ts
+++ b/packages/plugin-vault/src/command.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { asSessionId, type CommandDef, type EmittedEvent } from '@moxxy/sdk';
+import { asSessionId, assertDefined, type CommandDef, type EmittedEvent } from '@moxxy/sdk';
 import { buildVaultPlugin } from './index.js';
 import { createStaticKeySource } from './keysource.js';
 import { deriveKey, generateSalt } from './crypto.js';
@@ -64,7 +64,8 @@ describe('/vault command', () => {
 
     // Model-facing note injected into the log has the reference, not the value
     expect(appended).toHaveLength(1);
-    const note = appended[0]!;
+    const note = appended[0];
+    assertDefined(note, 'one note appended');
     expect(note.type).toBe('user_prompt');
     if (note.type !== 'user_prompt') throw new Error('expected user_prompt');
     expect(note.text).toContain('${vault:API_KEY}');

--- a/packages/plugin-vault/src/crypto.test.ts
+++ b/packages/plugin-vault/src/crypto.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assertDefined } from '@moxxy/sdk';
 import { decrypt, deriveKey, encrypt, generateSalt, randomCode } from './crypto.js';
 
 describe('crypto primitives', () => {
@@ -40,7 +41,9 @@ describe('crypto primitives', () => {
     for (let i = 0; i < 200; i++) {
       const code = randomCode(12);
       expect(code).toMatch(/^\d{12}$/);
-      leads.add(code[0]!);
+      const lead = code[0];
+      assertDefined(lead, '12-digit code has a leading char');
+      leads.add(lead);
     }
     // The old uint32 draw pinned every leading digit to '0' for digits >= 10.
     expect([...leads].some((d) => d !== '0')).toBe(true);
@@ -50,7 +53,10 @@ describe('crypto primitives', () => {
     // Chi-square-lite: the leading digit should spread across 0-9, not cluster.
     const counts = new Array(10).fill(0) as number[];
     for (let i = 0; i < 2000; i++) {
-      counts[Number(randomCode(6)[0])]! += 1;
+      const lead = Number(randomCode(6)[0]);
+      const count = counts[lead];
+      assertDefined(count, 'leading digit indexes the counts array');
+      counts[lead] = count + 1;
     }
     for (const c of counts) {
       // Expected ~200 per bucket; a wide tolerance still catches a stuck/biased draw.

--- a/packages/plugin-vault/src/placeholder.ts
+++ b/packages/plugin-vault/src/placeholder.ts
@@ -1,4 +1,4 @@
-import { MoxxyError } from '@moxxy/sdk';
+import { MoxxyError, assertDefined } from '@moxxy/sdk';
 import type { VaultStore } from './store.js';
 
 const PLACEHOLDER_RE = /\$\{vault:([A-Za-z0-9_.-]+)\}/g;
@@ -27,7 +27,11 @@ export async function resolveString(input: string, vault: VaultStore): Promise<s
   PLACEHOLDER_RE.lastIndex = 0;
   const names = new Set<string>();
   let m: RegExpExecArray | null;
-  while ((m = PLACEHOLDER_RE.exec(input))) names.add(m[1]!);
+  while ((m = PLACEHOLDER_RE.exec(input))) {
+    const name = m[1];
+    assertDefined(name, 'the vault placeholder regex has a required capture group');
+    names.add(name);
+  }
 
   const values = new Map<string, string>();
   for (const name of names) {

--- a/packages/plugin-vault/src/store.ts
+++ b/packages/plugin-vault/src/store.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'node:fs';
-import { createMutex, MoxxyError, type Mutex } from '@moxxy/sdk';
+import { assertDefined, createMutex, MoxxyError, type Mutex } from '@moxxy/sdk';
 import { writeFileAtomic } from '@moxxy/sdk/server';
 import { decrypt, encrypt, generateSalt, type EncryptedBlob } from './crypto.js';
 import type { MasterKeySource } from './keysource.js';
@@ -323,8 +323,10 @@ export class VaultStore {
    * recovery hint instead of crashing the caller with a cryptic crypto error.
    */
   private decryptEntry(name: string, entry: VaultEntry): string {
+    const masterKey = this.masterKey;
+    assertDefined(masterKey, 'decryptEntry is only reached after get() checks the vault is open');
     try {
-      return decrypt(entry, this.masterKey!);
+      return decrypt(entry, masterKey);
     } catch (err) {
       throw new MoxxyError({
         code: 'VAULT_CORRUPT',


### PR DESCRIPTION
## Scope

Assert-sweep for the CLI package group — replace non-null assertions (`x!`,
`x!.y`, `fn()!`, `arr[i]!`) and single optional chains of depth ≥2 (`a?.b?.c`)
with guard clauses, per the "Guard, don't chain" rule.

Packages touched (patch): `@moxxy/cli`, `@moxxy/config`, `@moxxy/plugin-cli`,
`@moxxy/plugin-commands`, `@moxxy/plugin-oauth`, `@moxxy/plugin-plugins-admin`,
`@moxxy/plugin-provider-admin`, `@moxxy/plugin-self-update`, `@moxxy/plugin-vault`.

## Counts (real sites fixed in this branch)

Most of the group was swept in an earlier pass on this branch; this PR completes
it. Sites resolved here:

| Package | non-null `!` | deep `?.` |
|---|---|---|
| plugin-cli | 18 | 10 |
| plugin-vault | 2 | 0 |
| plugin-self-update | 1 | 0 |
| plugin-plugins-admin | 1 (pin.test) | 0 |
| plugin-commands | 0 | 3 |
| cli / config / plugin-oauth / plugin-provider-admin | already clean | already clean |
| **total** | **22** | **13** |

plugin-cli breakdown — non-null: parse-input(1), reducer(4), helpers(1),
use-turn-runner(3), read-aloud(1), run-slash(3), picker-handlers(5); deep `?.`:
parse-input(1), picker-handlers(5), settings-descriptors(4).
plugin-commands deep `?.`: index.ts compactor / log-slice / provider-models.

Remaining `!`/`?.` grep hits are all confirmed false positives: definite-assignment
locals/fields (`let x!: T` — out of scope, 4 total), ASCII-art/jsdoc/string-literal
`!`, and lines with two *independent* single-level `?.` reads (e.g.
`a.x?.y !== b.x?.y`), which are not depth-≥2 chains and are kept.

Note: the mandated narrow grep misses `x!(` (assertion before a call) and
`arr[i]![j]` (assertion before a bracket) — a broader `[A-Za-z0-9_)\]]![^=]`
scan caught the run-slash.ts, picker-handlers.ts and pin.test.ts sites the narrow
grep skipped.

## Semantics notes (sites turned into loud throws — impossible-by-construction)

`assertDefined(...)` used where absence can't happen but TS can't see it:
- `parse-input.ts` `chunk[i]` (inside `while (i < chunk.length)`), `read-aloud.ts`
  `messages[i]` (loop bounds), `use-turn-runner.ts` queue peek/shift (guarded by
  `length > 0`), `helpers.ts`/`placeholder.ts` regex capture group 1 (required in
  the pattern), `verify.ts` `PM_COMMANDS.npm` (static literal key), `store.ts`
  `masterKey` (checked in the only caller, asserted before the `try` so a spurious
  throw can't be mis-caught as `VAULT_CORRUPT`), `picker-handlers.ts`
  `knob.next`/`knob.dotPath` (always set for boolean/enum knobs), `pin.test.ts`
  `mock.calls[0]` (asserted `toHaveBeenCalledTimes(1)` above).

Genuinely-optional reads keep their silent path (single-level `?.`, ternary, or
`?? default`) — no absence was converted to a throw:
- `commandHotkeys?.[letter]` call-if-present, `admin?.install`/`admin?.loaded`/
  `admin?.setupSpec`/`compactors?.getActive`/`log?.slice` capability probes
  (rewritten `x?.m ? x.m() : fallback`), `context?.elision?.enabled` etc. config
  reads (narrowed once into a local, then a single `?.`).
- `run-slash.ts` / `picker-handlers.ts` `/setup`: capture the guard-narrowed
  `setupSpec`/`openPluginSetup` into consts *before* the async closure (property
  narrowing doesn't survive into a nested function) instead of asserting inside.

`reducer.ts` word-boundary scans use `buffer[i] ?? ''` — the index is always
in-bounds under the `while` guard, so the fallback is unreachable and behavior is
identical (empty string is a non-word char).

## Gate (from worktree root, direct exit codes)

- `pnpm install` — 0
- `pnpm build` — 0 (85/85)
- `pnpm typecheck` — 0 (142/142)
- `pnpm lint` — 0 (0 errors; 44 pre-existing warnings in untouched packages)
- `pnpm test` — the only failure was `@moxxy/anonymizer` `redact.test.ts` "does not
  blow up quadratically" — a wall-clock assertion (`27284ms < 8000ms`) in a package
  outside this group's scope, flaking under concurrent CPU load (the test's own
  comment cites "slow shared CI runner + residual parallel-test contention"). Passed
  2/2 in isolation (989ms, 1451ms). Tests scoped to the 9 touched packages: 51/51 green.
- `pnpm check:deps` — 0 (0 errors; 1 pre-existing no-orphans warning)

Control-byte scan clean; all changed files are UTF-8/ASCII text.

Do not merge — parallel assert-sweep group.
