### PR TITLE
feat(cli): offer browser vs no-browser choice for OAuth providers in init wizard

### DIFF
--- a/.changeset/add-gpt-5-6-models.md
+++ b/.changeset/add-gpt-5-6-models.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/plugin-provider-openai': minor
+'@moxxy/plugin-provider-openai-codex': minor
+---
+
+Add the GPT-5.6 model family (Sol, Terra, Luna; GA July 9 2026) to both the OpenAI API provider and the Codex (ChatGPT-plan) provider. API model ids `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` — flagship / balanced / fast-cheap — each a reasoning model with a 1,050,000-token window and 128k max output (Codex serves the same ids capped at the ChatGPT-plan ~400k window). The Codex default model moves to `gpt-5.6-sol`, matching OpenAI's own Codex default.

--- a/.changeset/init-oauth-no-browser-choice.md
+++ b/.changeset/init-oauth-no-browser-choice.md
@@ -1,0 +1,7 @@
+---
+'@moxxy/plugin-provider-openai-codex': minor
+'@moxxy/cli': minor
+'@moxxy/sdk': minor
+---
+
+`moxxy init`: let OAuth providers with a device-code flow (openai-codex) offer a browser vs. no-browser choice during the wizard, so a headless/remote box can sign in by pasting a URL + code instead of relying on a loopback browser that can't open. Providers advertise the capability via `ProviderAuthDescriptor.supportsHeadless`; `ProviderSetupView.loginOAuth` now accepts an optional `{ headless }`.

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -18,7 +18,7 @@ import { renderLogo } from '../logo.js';
 import { cancel, isCancel, note, password } from '@clack/prompts';
 import { colors } from '../colors.js';
 import type { ProviderAuthKind, SetupSelections } from '@moxxy/plugin-cli';
-import { MoxxyError, type ProviderDef } from '@moxxy/sdk';
+import type { ProviderDef } from '@moxxy/sdk';
 
 /**
  * Interactive first-time setup. Renders a @clack/prompts vertical stepper
@@ -174,10 +174,16 @@ async function runInteractiveInit(
     ): Promise<{ ok: true } | { ok: false; message: string }> {
       return await providerSetup.testKey(providerId, key);
     },
-    async loginOAuth(providerId: string): Promise<void> {
+    async loginOAuth(providerId: string, loginOpts?: { headless?: boolean }): Promise<void> {
       // No io → the shared view falls back to the clack/stdout auth context.
       // (We already bailed to runHeadlessInit when stdin wasn't a TTY.)
-      await providerSetup.loginOAuth(providerId);
+      // `loginOpts.headless` forces the no-browser/device-code flow when the
+      // user picked it (only offered for providers that support it).
+      await providerSetup.loginOAuth(providerId, undefined, loginOpts);
+    },
+    oauthSupportsHeadless(providerId: string): boolean {
+      const def = session.providers.list().find((p) => p.name === providerId);
+      return def?.auth?.kind === 'oauth' && def.auth.supportsHeadless === true;
     },
     async installPlugins(ids: ReadonlyArray<string>): Promise<void> {
       for (const id of ids) {

--- a/packages/cli/src/setup/provider-setup.test.ts
+++ b/packages/cli/src/setup/provider-setup.test.ts
@@ -108,4 +108,23 @@ describe('buildProviderSetupView', () => {
     expect(lines).toEqual(['hello']);
     expect(session.readyProviders.has('oauthy')).toBe(true);
   });
+
+  it('loginOAuth threads opts.headless into the auth context (no-browser flow)', async () => {
+    const seen: boolean[] = [];
+    const login = vi.fn(async (ctx: { headless: boolean }) => {
+      seen.push(ctx.headless);
+      return {};
+    });
+    const session = fakeSession([{ name: 'oauthy', auth: { kind: 'oauth', login }, models: [] }]);
+    const view = buildProviderSetupView({ session: session as never, vault: fakeVault() as never });
+
+    // Default (no opts) → interactive browser flow.
+    await view.loginOAuth('oauthy');
+    // Explicit headless → device-code flow.
+    await view.loginOAuth('oauthy', undefined, { headless: true });
+    // Explicit non-headless stays interactive.
+    await view.loginOAuth('oauthy', undefined, { headless: false });
+
+    expect(seen).toEqual([false, true, false]);
+  });
 });

--- a/packages/cli/src/setup/provider-setup.ts
+++ b/packages/cli/src/setup/provider-setup.ts
@@ -74,7 +74,7 @@ export function buildProviderSetupView(opts: BuildProviderSetupOptions): Provide
       markReady(providerId);
     },
 
-    loginOAuth: async (providerId, io) => {
+    loginOAuth: async (providerId, io, opts) => {
       const def = registered(providerId);
       if (!def || def.auth?.kind !== 'oauth') {
         throw new MoxxyError({
@@ -86,7 +86,14 @@ export function buildProviderSetupView(opts: BuildProviderSetupOptions): Provide
           context: { provider: providerId },
         });
       }
-      const ctx = io ? channelAuthContext(vault, io) : buildProviderAuthContext(vault, { headless: false });
+      // `headless` picks the no-browser (device-code) flow. It only lands here as
+      // `true` when the caller asked for it (e.g. the init wizard's browser-vs-no-
+      // browser choice) AND the provider declared `supportsHeadless`. Defaults to
+      // the interactive browser flow.
+      const headless = opts?.headless === true;
+      const ctx = io
+        ? channelAuthContext(vault, io, headless)
+        : buildProviderAuthContext(vault, { headless });
       const result = await def.auth.login(ctx);
       markReady(providerId);
       return result;
@@ -96,12 +103,18 @@ export function buildProviderSetupView(opts: BuildProviderSetupOptions): Provide
 
 /**
  * A `ProviderAuthContext` whose output/prompts route into a channel's own UI
- * (the TUI connect dialog) instead of clack/stdout. Never headless — the
- * channel IS the interactive surface, so browser-based flows stay available.
+ * (the TUI connect dialog) instead of clack/stdout. Defaults to non-headless —
+ * the channel is normally the interactive surface, so the browser flow stays
+ * available — but honours an explicit `headless` request (a channel on a
+ * browser-less box driving a device-code flow).
  */
-function channelAuthContext(vault: VaultStore, io: ProviderConnectIo): ProviderAuthContext {
+function channelAuthContext(
+  vault: VaultStore,
+  io: ProviderConnectIo,
+  headless = false,
+): ProviderAuthContext {
   return {
-    headless: false,
+    headless,
     write: io.write,
     ...(io.prompt ? { prompt: io.prompt } : {}),
     vault: {

--- a/packages/cli/src/wizard/run-setup-wizard.ts
+++ b/packages/cli/src/wizard/run-setup-wizard.ts
@@ -49,9 +49,18 @@ export interface SetupWizardController {
    * Drive the OAuth sign-in flow for a provider whose `authKind` is `'oauth'`.
    * Implementations should print their own progress (browser URL, device code,
    * etc.) and persist credentials to the vault. Throw on failure / user
-   * cancellation; the wizard offers a retry.
+   * cancellation; the wizard offers a retry. `opts.headless` requests the
+   * no-browser (device-code) flow — only passed when the provider reports
+   * {@link oauthSupportsHeadless}.
    */
-  loginOAuth?(providerId: string): Promise<void>;
+  loginOAuth?(providerId: string, opts?: { readonly headless?: boolean }): Promise<void>;
+  /**
+   * Whether this OAuth provider has a real no-browser (device-code / manual-URL)
+   * flow. When true the wizard offers the user a browser-vs-no-browser choice
+   * before signing in — useful on a headless box where a loopback browser flow
+   * can't complete. Absent / false → the wizard just runs the default flow.
+   */
+  oauthSupportsHeadless?(providerId: string): boolean;
   /**
    * Install + enable the chosen optional plugins (by catalog id / package name).
    * Best-effort: implementations should report per-plugin failures and continue.
@@ -182,7 +191,8 @@ export async function runSetupWizard(opts: RunSetupWizardOptions): Promise<strin
       );
       process.exit(1);
     }
-    await collectOAuth(provider, opts.controller.loginOAuth);
+    const supportsHeadless = opts.controller.oauthSupportsHeadless?.(provider) ?? false;
+    await collectOAuth(provider, opts.controller.loginOAuth, supportsHeadless);
     oauthCompleted.push(provider);
   } else {
     apiKeys[provider] = await collectKey(provider, opts.controller);
@@ -312,12 +322,37 @@ export async function runSetupWizard(opts: RunSetupWizardOptions): Promise<strin
 
 async function collectOAuth(
   providerId: string,
-  loginOAuth: (providerId: string) => Promise<void>,
+  loginOAuth: (providerId: string, opts?: { readonly headless?: boolean }) => Promise<void>,
+  supportsHeadless: boolean,
 ): Promise<void> {
+  // Providers with a device-code fallback let the user pick how to sign in. On
+  // a headless / remote box the loopback browser flow can't complete, so offer
+  // a no-browser path that just prints a URL + code to enter elsewhere.
+  let headless: boolean | undefined;
+  if (supportsHeadless) {
+    const choiceRaw = await select({
+      message: `Step 2 — How do you want to sign in to ${colors.bold(providerId)}?`,
+      options: [
+        {
+          value: 'browser',
+          label: 'Open a browser on this machine',
+          hint: 'loopback callback — for a local desktop',
+        },
+        {
+          value: 'no-browser',
+          label: 'No browser — show a URL + code to enter elsewhere',
+          hint: 'device-code flow — for a headless / remote box',
+        },
+      ],
+      initialValue: 'browser',
+    });
+    headless = guard(choiceRaw) === 'no-browser';
+  }
+  const loginOpts = headless === undefined ? undefined : { headless };
   while (true) {
     log.step(`Step 2 — Sign in to ${colors.bold(providerId)} (OAuth)`);
     try {
-      await loginOAuth(providerId);
+      await loginOAuth(providerId, loginOpts);
       log.success(`${providerId} sign-in complete`);
       return;
     } catch (err) {

--- a/packages/plugin-provider-openai-codex/src/index.ts
+++ b/packages/plugin-provider-openai-codex/src/index.ts
@@ -13,6 +13,9 @@ export const openaiCodexProviderDef = defineProvider({
   auth: {
     kind: 'oauth',
     serviceName: 'ChatGPT Pro/Plus',
+    // The codex profile carries a device-flow adapter, so `codexLogin` honours
+    // `ctx.headless` with a real no-browser flow — let hosts offer the choice.
+    supportsHeadless: true,
     login: codexLogin,
     logout: codexLogout,
     status: codexStatus,

--- a/packages/plugin-provider-openai-codex/src/models.ts
+++ b/packages/plugin-provider-openai-codex/src/models.ts
@@ -15,6 +15,13 @@ export const codexModels: ReadonlyArray<ModelDescriptor> = [
   // the proactive compactor's `estimatedTokens > 0.75 * contextWindow` gate
   // unreachable, so every overflow fell through to the reactive
   // compact-on-overflow retry. Keep these in step with the rest of the catalog.
+  // GPT-5.6 family (GA July 9, 2026): served to ChatGPT-Pro/Plus subscribers
+  // under the same ids the API uses (sol/terra/luna — no `-codex` variant).
+  // Sol is OpenAI's default Codex model. The ChatGPT-plan window cap applies
+  // here too, so keep them at 400k like the rest of this list.
+  { id: 'gpt-5.6-sol', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5.6-terra', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5.6-luna', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
   { id: 'gpt-5.5', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
   { id: 'gpt-5.4', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
   { id: 'gpt-5.4-mini', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
@@ -23,4 +30,6 @@ export const codexModels: ReadonlyArray<ModelDescriptor> = [
   { id: 'gpt-5.2', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
 ];
 
-export const DEFAULT_CODEX_MODEL = 'gpt-5.3-codex';
+// OpenAI's own Codex default moved to gpt-5.6-sol at GA (July 9, 2026); mirror
+// it so a ChatGPT-plan user who hasn't pinned a model gets the current flagship.
+export const DEFAULT_CODEX_MODEL = 'gpt-5.6-sol';

--- a/packages/plugin-provider-openai/src/provider.ts
+++ b/packages/plugin-provider-openai/src/provider.ts
@@ -63,7 +63,15 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 // (Responses-API only), so the flag mainly gates the config UI + effort there;
 // OpenAI-compatible reasoning backends (DeepSeek/z.ai/local) do stream it.
 export const openAIModels: ReadonlyArray<ModelDescriptor> = [
-  // GPT-5.5 family (released April 23, 2026): newest frontier class.
+  // GPT-5.6 family (GA July 9, 2026): three-tier frontier class, knowledge
+  // cutoff Feb 16, 2026. Sol = flagship, Terra = balanced, Luna = fast/cheap.
+  // All share the 1,050,000-token window and 128k max output; pick by cost:
+  // Sol $5/$30, Terra $2.50/$15, Luna $1/$6 per 1M in/out tokens.
+  { id: 'gpt-5.6-sol', contextWindow: 1_050_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5.6-terra', contextWindow: 1_050_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5.6-luna', contextWindow: 1_050_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+
+  // GPT-5.5 family (released April 23, 2026): prior frontier class.
   { id: 'gpt-5.5', contextWindow: 1_050_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
   { id: 'gpt-5.5-pro', contextWindow: 1_050_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
 

--- a/packages/sdk/src/provider.ts
+++ b/packages/sdk/src/provider.ts
@@ -234,6 +234,15 @@ export type ProviderAuthDescriptor =
       /** Human-readable name of the upstream service (e.g. "ChatGPT Pro/Plus"). */
       readonly serviceName?: string;
       /**
+       * True when `login` honours `ctx.headless` with a real no-browser
+       * (device-code / manual-URL) flow, so the host may offer the user a
+       * browser-vs-no-browser choice even on a TTY. When omitted/false the
+       * host only goes headless when it has to (no TTY) and never presents the
+       * choice, since forcing `headless` would just fail with
+       * "no headless flow".
+       */
+      readonly supportsHeadless?: boolean;
+      /**
        * Drive the OAuth flow and persist credentials. Throws on failure /
        * user cancellation; the host typically offers a retry prompt.
        */

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -444,10 +444,14 @@ export interface ProviderSetupView {
    * Drive the provider's OAuth flow. `io` routes the flow's output/prompts
    * into the calling channel's UI; when omitted the host's default terminal
    * prompting applies (the clack path `moxxy init`/`moxxy login` use).
+   * `opts.headless` forces the provider's no-browser (device-code) flow —
+   * only meaningful for providers whose auth descriptor declares
+   * `supportsHeadless`.
    */
   loginOAuth(
     providerId: string,
     io?: ProviderConnectIo,
+    opts?: { readonly headless?: boolean },
   ): Promise<{ readonly accountId?: string | null; readonly expiresAt?: number }>;
 }
 


### PR DESCRIPTION
This PR bundles two changes (per request).

## 1. `moxxy init`: browser vs. no-browser choice for OAuth providers

`moxxy init`'s OAuth step hardcoded the interactive loopback/browser flow (`buildProviderAuthContext(vault, { headless: false })`), so selecting `openai-codex (oauth)` on a headless/remote box always tried to open a browser that can't open. Now the wizard offers a **browser vs. no-browser (device-code)** choice for providers that support it.

- **`@moxxy/sdk`**: new `ProviderAuthDescriptor.supportsHeadless` capability flag; optional `{ headless }` bag on `ProviderSetupView.loginOAuth`.
- **`@moxxy/plugin-provider-openai-codex`**: declares `supportsHeadless: true` (it already ships a device-flow adapter).
- **`provider-setup.ts`**: `loginOAuth` threads `opts.headless` into the auth context instead of hardcoding `false`; `channelAuthContext` honours it too.
- **`run-setup-wizard.ts`**: when the provider reports `supportsHeadless`, Step 2 renders a select (browser / no-browser) and passes the choice through.
- **`init.ts`**: controller implements `oauthSupportsHeadless()` and forwards the choice; also retired a pre-existing unused-import lint warning.

Providers without a device flow show no choice — nobody hits a "no headless flow" dead-end. `moxxy login` already had `--browser`/`--no-browser`; this brings the same capability to the init wizard off a generic provider-advertised flag rather than a CLI-side branch table.

## 2. Add the GPT-5.6 model family (Sol, Terra, Luna)

GPT-5.6 went GA on 2026-07-09 across the OpenAI API and Codex. Added all three tiers to both provider catalogs using their exact API ids — there is **no separate `-codex` variant**; Codex serves the same ids (default `gpt-5.6-sol`).

| Tier | API id | Role | API window / max out | Price (in/out per 1M) |
|------|--------|------|----------------------|------------------------|
| Sol | `gpt-5.6-sol` | flagship | 1,050,000 / 128k | \$5 / \$30 |
| Terra | `gpt-5.6-terra` | balanced | 1,050,000 / 128k | \$2.50 / \$15 |
| Luna | `gpt-5.6-luna` | fast/cheap | 1,050,000 / 128k | \$1 / \$6 |

- **`@moxxy/plugin-provider-openai`**: all three added as reasoning models (1,050,000-token window, 128k output), newest-first at the top of the catalog.
- **`@moxxy/plugin-provider-openai-codex`**: same three ids, capped at the ChatGPT-plan ~400k window like the rest of that list; `DEFAULT_CODEX_MODEL` moves `gpt-5.3-codex` → `gpt-5.6-sol` to mirror OpenAI's own Codex default. Existing pins (`gpt-5.3-codex`, etc.) remain served.

Knowledge cutoff Feb 16 2026. Sources: [OpenAI GPT-5.6](https://openai.com/index/gpt-5-6/), [OpenAI API pricing](https://developers.openai.com/api/docs/pricing), [Codex models doc](https://learn.chatgpt.com/docs/models), [OpenRouter GPT-5.6 Sol](https://openrouter.ai/openai/gpt-5.6-sol).

## Verification

- Gate green from repo root: `pnpm build` (85 tasks), `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm test` (0 failures), `pnpm check:deps` (0 errors)
- Added a unit test asserting `loginOAuth` threads `{ headless }` into the auth context; existing OAuth/TUI-connect + both provider suites (openai 51, codex 61) still pass
- Runtime checks against built artifacts: `openai-codex` advertises `supportsHeadless: true` with a working device-flow adapter; both catalogs expose `gpt-5.6-{sol,terra,luna}` with the right windows and `DEFAULT_CODEX_MODEL = gpt-5.6-sol`; old models still present
- Not exercised: live network calls to the GPT-5.6 endpoints / the ChatGPT device-code round-trip (need a real account); the no-browser path reuses exactly what `moxxy login openai-codex --no-browser` already uses