### PR TITLE
Stream a text turn through the installed Claude CLI

### DIFF
--- a/.changeset/bright-claude-cli.md
+++ b/.changeset/bright-claude-cli.md
@@ -1,0 +1,5 @@
+---
+"@moxxy/plugin-provider-claude-code": patch
+---
+
+Stream Claude subscription turns through the installed Claude CLI instead of constructing the Anthropic API provider directly.

--- a/packages/cli/src/provider-credentials.test.ts
+++ b/packages/cli/src/provider-credentials.test.ts
@@ -78,6 +78,24 @@ describe('resolveProviderCredentials', () => {
     expect(cfg.apiKey).toBe('sk-canonical');
   });
 
+  it('activates claude-code without a vault token and preserves provider config', async () => {
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    const cfg = await resolveProviderCredentials('claude-code', vault, {
+      interactive: false,
+      providerConfig: { executable: '/opt/bin/claude' },
+    });
+    expect(cfg).toEqual({ executable: '/opt/bin/claude' });
+  });
+
+  it('passes a stored claude-code token to the provider config', async () => {
+    await vault.set('oauth/claude-code/access_token', 'stored-claude-token');
+    await vault.set('oauth/claude-code/client_id', 'claude-client');
+    await vault.set('oauth/claude-code/token_url', 'https://example.test/oauth/token');
+    const cfg = await resolveProviderCredentials('claude-code', vault, { interactive: false });
+    expect(cfg.oauthToken).toBe('stored-claude-token');
+  });
+
   it('passes provider.config options through to the codex client config', async () => {
     // Seed the OAuth bundle the codex resolver reads. client_id + token_url
     // are required setup-meta — readStoredCreds treats their absence as a

--- a/packages/cli/src/provider-credentials.ts
+++ b/packages/cli/src/provider-credentials.ts
@@ -33,7 +33,7 @@ export async function resolveProviderCredentials(
   opts: ResolveOptions = {},
 ): Promise<Record<string, unknown>> {
   if (providerName === 'openai-codex') return resolveOAuthCodex(vault, opts);
-  if (providerName === CLAUDE_CODE_PROVIDER_ID) return resolveClaudeCode(vault);
+  if (providerName === CLAUDE_CODE_PROVIDER_ID) return resolveClaudeCode(vault, opts);
   // The `local` provider (Ollama / LM Studio / llama.cpp / vLLM) authenticates
   // against nothing, so it must activate without a key — never prompting, never
   // throwing AUTH_NO_CREDENTIALS. Supply a harmless placeholder key (the OpenAI
@@ -56,32 +56,31 @@ export async function resolveProviderCredentials(
 }
 
 /**
- * Claude subscription credentials. Prefer the vault bundle written by
- * `moxxy login claude-code` (refreshed proactively when near expiry); fall
- * back to a `claude setup-token` env var for CI / non-interactive use. The
- * `oauthRefresh` hook is wired only when a refresh_token is actually stored.
+ * The installed CLI is the primary authentication source, so activation must
+ * also work with no moxxy credential at all. When moxxy has a token (from its
+ * login flow or an env var), pass it to the provider; the provider supplies it
+ * to the child through CLAUDE_CODE_OAUTH_TOKEN rather than command-line args.
  */
-async function resolveClaudeCode(vault: VaultStore): Promise<Record<string, unknown>> {
+async function resolveClaudeCode(
+  vault: VaultStore,
+  opts: ResolveOptions,
+): Promise<Record<string, unknown>> {
+  const config = { ...(opts.providerConfig ?? {}) };
   const fresh = await ensureFreshClaudeTokens(vault);
   if (fresh) {
     return {
+      ...config,
       oauthToken: fresh.accessToken,
       ...(fresh.expiresAt !== undefined ? { oauthExpiresAt: fresh.expiresAt } : {}),
       ...(fresh.canRefresh ? { oauthRefresh: () => refreshClaudeAccessToken(vault) } : {}),
     };
   }
+
   for (const envVar of CLAUDE_TOKEN_ENV_VARS) {
     const token = process.env[envVar];
-    if (token) return { oauthToken: token };
+    if (token) return { ...config, oauthToken: token };
   }
-  throw new MoxxyError({
-    code: 'AUTH_NO_CREDENTIALS',
-    message: 'No Claude subscription credentials found.',
-    hint:
-      'Run `moxxy login claude-code` to sign in with your Claude Pro/Max account, ' +
-      'or set CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token`.',
-    context: { provider: CLAUDE_CODE_PROVIDER_ID },
-  });
+  return config;
 }
 
 async function resolveOAuthCodex(

--- a/packages/mode-default/src/index.test.ts
+++ b/packages/mode-default/src/index.test.ts
@@ -58,6 +58,35 @@ describe('defaultMode end-to-end', () => {
     expect(last.stopReason).toBe('end_turn');
   });
 
+  it('omits registered tools when the active model does not support them', async () => {
+    const provider = new FakeProvider({
+      models: [{
+        id: 'text-only',
+        contextWindow: 200_000,
+        maxOutputTokens: 8000,
+        supportsTools: false,
+        supportsStreaming: true,
+      }],
+      script: [textReply('plain response')],
+    });
+    const session = sessionWith(provider);
+    session.tools.register(
+      defineTool({
+        name: 'registered_but_unsupported',
+        description: 'must not be sent to a text-only model',
+        inputSchema: z.object({}),
+        handler: () => 'unused',
+      }),
+    );
+
+    const events = await collectTurn(session, 'answer without tools');
+
+    expect(provider.received).toHaveLength(1);
+    expect(provider.received[0]?.tools).toBeUndefined();
+    const last = events.at(-1);
+    expect(last).toMatchObject({ type: 'assistant_message', content: 'plain response' });
+  });
+
   it('runs tool_use then continues loop with the result', async () => {
     const provider = new FakeProvider({
       script: [toolUseReply('echo', { msg: 'world' }, 'c1'), textReply('done: world')],

--- a/packages/plugin-provider-claude-code/src/index.ts
+++ b/packages/plugin-provider-claude-code/src/index.ts
@@ -1,14 +1,15 @@
 import { defineProvider, definePlugin } from '@moxxy/sdk';
-import { anthropicModels } from '@moxxy/plugin-provider-anthropic';
 import { CLAUDE_CODE_PROVIDER_ID, CLAUDE_CODE_SERVICE_NAME } from './constants.js';
-import { createClaudeCodeClient, type ClaudeCodeProviderConfig } from './provider.js';
+import {
+  claudeCodeModels,
+  createClaudeCodeClient,
+  type ClaudeCodeProviderConfig,
+} from './provider.js';
 import { claudeLogin, claudeLogout, claudeStatus } from './login.js';
 
 export const claudeCodeProviderDef = defineProvider({
   name: CLAUDE_CODE_PROVIDER_ID,
-  // Same Claude models as the API-key `anthropic` provider — it's the same
-  // Messages API, only the credential differs.
-  models: [...anthropicModels],
+  models: claudeCodeModels,
   createClient: (config) => createClaudeCodeClient(config as ClaudeCodeProviderConfig),
   // No validateKey: an OAuth bearer is validated by the request itself, and
   // an interactive paste/sign-in already proves the token round-trips.
@@ -44,4 +45,4 @@ export {
   refreshClaudeAccessToken,
   type FreshClaudeTokens,
 } from './login.js';
-export { createClaudeCodeClient, type ClaudeCodeProviderConfig } from './provider.js';
+export { claudeCodeModels, createClaudeCodeClient, type ClaudeCodeProviderConfig } from './provider.js';

--- a/packages/plugin-provider-claude-code/src/process.ts
+++ b/packages/plugin-provider-claude-code/src/process.ts
@@ -1,15 +1,22 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { createInterface } from 'node:readline';
 
+export interface ClaudeSpawnOptions {
+  readonly env: NodeJS.ProcessEnv;
+}
+
 export type ClaudeSpawn = (
   executable: string,
   args: ReadonlyArray<string>,
+  options: ClaudeSpawnOptions,
 ) => ChildProcessWithoutNullStreams;
 
 export interface ClaudeProcessOptions {
   readonly executable: string;
   readonly model: string;
   readonly prompt: string;
+  /** Optional moxxy-managed bearer passed only in the child's environment. */
+  readonly oauthToken?: string;
   readonly signal?: AbortSignal;
   readonly spawn?: ClaudeSpawn;
 }
@@ -35,10 +42,15 @@ export async function* runClaudeProcess(
     '--model',
     options.model,
   ];
-  const spawnImpl = options.spawn ?? ((file, childArgs) => spawn(file, [...childArgs], {
+  const env = {
+    ...process.env,
+    ...(options.oauthToken ? { CLAUDE_CODE_OAUTH_TOKEN: options.oauthToken } : {}),
+  };
+  const spawnImpl = options.spawn ?? ((file, childArgs, childOptions) => spawn(file, [...childArgs], {
     stdio: ['pipe', 'pipe', 'pipe'],
+    env: childOptions.env,
   }));
-  const child = spawnImpl(options.executable, args);
+  const child = spawnImpl(options.executable, args, { env });
   const completion = waitForExit(child);
   let stderr = '';
   child.stdin.on('error', () => undefined);

--- a/packages/plugin-provider-claude-code/src/process.ts
+++ b/packages/plugin-provider-claude-code/src/process.ts
@@ -1,0 +1,77 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { createInterface } from 'node:readline';
+
+export type ClaudeSpawn = (
+  executable: string,
+  args: ReadonlyArray<string>,
+) => ChildProcessWithoutNullStreams;
+
+export interface ClaudeProcessOptions {
+  readonly executable: string;
+  readonly model: string;
+  readonly prompt: string;
+  readonly signal?: AbortSignal;
+  readonly spawn?: ClaudeSpawn;
+}
+
+export interface ClaudeProcessResult {
+  readonly exitCode: number;
+  readonly stderr: string;
+}
+
+const MAX_STDERR_CHARS = 2048;
+
+export async function* runClaudeProcess(
+  options: ClaudeProcessOptions,
+): AsyncGenerator<string, ClaudeProcessResult> {
+  const args = [
+    '--print',
+    '--verbose',
+    '--output-format',
+    'stream-json',
+    '--include-partial-messages',
+    '--tools',
+    '',
+    '--model',
+    options.model,
+  ];
+  const spawnImpl = options.spawn ?? ((file, childArgs) => spawn(file, [...childArgs], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }));
+  const child = spawnImpl(options.executable, args);
+  const completion = waitForExit(child);
+  let stderr = '';
+  child.stdin.on('error', () => undefined);
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk: string) => {
+    if (stderr.length < MAX_STDERR_CHARS) stderr += chunk.slice(0, MAX_STDERR_CHARS - stderr.length);
+  });
+
+  const abort = (): void => {
+    child.kill('SIGTERM');
+  };
+  if (options.signal?.aborted) abort();
+  options.signal?.addEventListener('abort', abort, { once: true });
+
+  child.stdin.end(options.prompt, 'utf8');
+  const lines = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  try {
+    for await (const line of lines) {
+      if (line.trim()) yield line;
+    }
+    const exitCode = await completion;
+    return { exitCode, stderr: stderr.trim() };
+  } finally {
+    options.signal?.removeEventListener('abort', abort);
+    lines.close();
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
+  }
+}
+
+function waitForExit(child: ChildProcessWithoutNullStreams): Promise<number> {
+  if (child.exitCode !== null) return Promise.resolve(child.exitCode);
+  return new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code) => resolve(code ?? 1));
+  });
+}

--- a/packages/plugin-provider-claude-code/src/protocol.ts
+++ b/packages/plugin-provider-claude-code/src/protocol.ts
@@ -1,0 +1,137 @@
+import type { ProviderEvent, ProviderRequest } from '@moxxy/sdk';
+import { CLAUDE_CODE_SYSTEM } from './constants.js';
+
+interface ProtocolState {
+  started: boolean;
+  ended: boolean;
+  stopReason: 'end_turn' | 'max_tokens' | 'stop_sequence' | 'error';
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+export function serializeClaudePrompt(req: ProviderRequest): string {
+  const system: string[] = [CLAUDE_CODE_SYSTEM];
+  if (req.system) system.push(req.system);
+  const conversation: string[] = [];
+
+  for (const message of req.messages) {
+    const text: string[] = [];
+    for (const block of message.content) {
+      if (block.type !== 'text') {
+        throw new Error(`Claude CLI text transport does not support ${block.type} content`);
+      }
+      text.push(block.text);
+    }
+    if (message.role === 'system') system.push(text.join(''));
+    else conversation.push(`<${message.role}>\n${text.join('')}\n</${message.role}>`);
+  }
+
+  return `<system>\n${system.join('\n\n')}\n</system>\n\n${conversation.join('\n\n')}`;
+}
+
+export function createProtocolState(): ProtocolState {
+  return { started: false, ended: false, stopReason: 'end_turn' };
+}
+
+export function parseClaudeRecord(line: string, state: ProtocolState): ProviderEvent[] {
+  let value: unknown;
+  try {
+    value = JSON.parse(line);
+  } catch {
+    throw new Error('Claude CLI emitted malformed stream-json');
+  }
+  if (!isRecord(value) || typeof value.type !== 'string') {
+    throw new Error('Claude CLI emitted malformed stream-json record');
+  }
+
+  if (value.type === 'system') return [];
+  if (value.type === 'assistant') return parseAssistantRecord(value);
+  if (value.type === 'stream_event') return parseStreamEvent(value.event, state);
+  if (value.type === 'result') return parseResult(value, state);
+  throw new Error(`Claude CLI emitted unsupported stream-json record: ${value.type}`);
+}
+
+function parseAssistantRecord(record: Record<string, unknown>): ProviderEvent[] {
+  if (!isRecord(record.message) || !Array.isArray(record.message.content)) {
+    throw new Error('Claude CLI emitted malformed assistant record');
+  }
+  for (const block of record.message.content) {
+    if (!isRecord(block) || block.type !== 'text' || typeof block.text !== 'string') {
+      throw new Error('Claude CLI emitted unsupported assistant content');
+    }
+  }
+  // Partial text arrives through stream_event records; validating this envelope
+  // prevents a new native-tool block from being silently ignored.
+  return [];
+}
+
+function parseStreamEvent(raw: unknown, state: ProtocolState): ProviderEvent[] {
+  if (!isRecord(raw) || typeof raw.type !== 'string') {
+    throw new Error('Claude CLI emitted malformed stream event');
+  }
+  switch (raw.type) {
+    case 'message_start':
+      state.started = true;
+      return [];
+    case 'content_block_start': {
+      if (!isRecord(raw.content_block) || raw.content_block.type !== 'text') {
+        throw new Error('Claude CLI emitted unsupported non-text content block');
+      }
+      return [];
+    }
+    case 'content_block_delta': {
+      if (!isRecord(raw.delta) || raw.delta.type !== 'text_delta' || typeof raw.delta.text !== 'string') {
+        throw new Error('Claude CLI emitted unsupported content delta');
+      }
+      return [{ type: 'text_delta', delta: raw.delta.text }];
+    }
+    case 'content_block_stop':
+    case 'message_stop':
+      return [];
+    case 'message_delta': {
+      if (!isRecord(raw.delta)) throw new Error('Claude CLI emitted malformed message delta');
+      if (raw.delta.stop_reason != null) state.stopReason = mapStopReason(raw.delta.stop_reason);
+      if (isRecord(raw.usage) && typeof raw.usage.output_tokens === 'number') {
+        state.outputTokens = raw.usage.output_tokens;
+      }
+      return [];
+    }
+    case 'ping':
+      return [];
+    default:
+      throw new Error(`Claude CLI emitted unsupported stream event: ${raw.type}`);
+  }
+}
+
+function parseResult(record: Record<string, unknown>, state: ProtocolState): ProviderEvent[] {
+  if (state.ended) throw new Error('Claude CLI emitted more than one terminal result');
+  state.ended = true;
+  if (record.is_error === true || record.subtype !== 'success') {
+    const message = typeof record.result === 'string' ? record.result : 'Claude CLI request failed';
+    return [{ type: 'error', message, retryable: false }];
+  }
+
+  if (isRecord(record.usage)) {
+    const input = record.usage.input_tokens;
+    const output = record.usage.output_tokens;
+    if (typeof input === 'number') state.inputTokens = input;
+    if (typeof output === 'number') state.outputTokens = output;
+  }
+  const usage = state.inputTokens !== undefined && state.outputTokens !== undefined
+    ? { inputTokens: state.inputTokens, outputTokens: state.outputTokens }
+    : undefined;
+  return [{ type: 'message_end', stopReason: state.stopReason, ...(usage ? { usage } : {}) }];
+}
+
+function mapStopReason(value: unknown): ProtocolState['stopReason'] {
+  switch (value) {
+    case 'end_turn': return 'end_turn';
+    case 'max_tokens': return 'max_tokens';
+    case 'stop_sequence': return 'stop_sequence';
+    default: throw new Error(`Claude CLI emitted unsupported stop reason: ${String(value)}`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/plugin-provider-claude-code/src/protocol.ts
+++ b/packages/plugin-provider-claude-code/src/protocol.ts
@@ -11,7 +11,6 @@ interface ProtocolState {
 
 export function serializeClaudePrompt(req: ProviderRequest): string {
   const system: string[] = [CLAUDE_CODE_SYSTEM];
-  if (req.system) system.push(req.system);
   const conversation: string[] = [];
 
   for (const message of req.messages) {
@@ -25,6 +24,9 @@ export function serializeClaudePrompt(req: ProviderRequest): string {
     if (message.role === 'system') system.push(text.join(''));
     else conversation.push(`<${message.role}>\n${text.join('')}\n</${message.role}>`);
   }
+  // ProviderRequest.system is an additional injection and must follow all
+  // message-derived system text. The Claude identity remains first.
+  if (req.system) system.push(req.system);
 
   return `<system>\n${system.join('\n\n')}\n</system>\n\n${conversation.join('\n\n')}`;
 }

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -1,36 +1,114 @@
-import { describe, expect, it } from 'vitest';
-import { CLAUDE_CODE_SYSTEM, CLAUDE_OAUTH_BETA } from './constants.js';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ProviderEvent, ProviderRequest } from '@moxxy/sdk';
 import { claudeCodeProviderDef, createClaudeCodeClient } from './index.js';
+
+const tempDirs: string[] = [];
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
 
 describe('claude-code provider definition', () => {
   it('registers as an OAuth provider named claude-code with Claude models', () => {
     expect(claudeCodeProviderDef.name).toBe('claude-code');
     expect(claudeCodeProviderDef.auth?.kind).toBe('oauth');
-    expect(claudeCodeProviderDef.models.length).toBeGreaterThan(0);
-    expect(claudeCodeProviderDef.models.map((m) => m.id)).toContain('claude-sonnet-4-6');
+    expect(claudeCodeProviderDef.models.map((model) => model.id)).toContain('claude-sonnet-4-6');
   });
 
-  it('builds an OAuth-mode client that reports the claude-code name', () => {
-    const client = createClaudeCodeClient({ oauthToken: 'tok' });
-    expect(client.name).toBe('claude-code');
-    const inner = (client as unknown as { client: { apiKey: unknown; authToken: unknown } }).client;
-    expect(inner.apiKey).toBeNull();
-    expect(inner.authToken).toBe('tok');
+  it('streams text through a fake Claude executable with structured non-interactive arguments', async () => {
+    const dir = await makeFakeClaude([
+      { type: 'system', subtype: 'init' },
+      { type: 'stream_event', event: { type: 'message_start', message: {} } },
+      { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'text', text: '' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Hello ' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'world' } } },
+      { type: 'stream_event', event: { type: 'content_block_stop' } },
+      { type: 'stream_event', event: { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 2 } } },
+      { type: 'stream_event', event: { type: 'message_stop' } },
+      { type: 'result', subtype: 'success', is_error: false, result: 'Hello world', usage: { input_tokens: 8, output_tokens: 2 } },
+    ]);
+    const client = createClaudeCodeClient({ executable: join(dir, 'claude') });
+    const events = await collect(client.stream(textRequest()));
+
+    expect(events).toEqual([
+      { type: 'message_start', model: 'claude-sonnet-4-6' },
+      { type: 'text_delta', delta: 'Hello ' },
+      { type: 'text_delta', delta: 'world' },
+      { type: 'message_end', stopReason: 'end_turn', usage: { inputTokens: 8, outputTokens: 2 } },
+    ]);
+    const args = JSON.parse(await readFile(join(dir, 'args.json'), 'utf8')) as string[];
+    expect(args).toEqual(expect.arrayContaining([
+      '--print', '--verbose', '--output-format', 'stream-json', '--include-partial-messages', '--tools', '',
+    ]));
+    const input = await readFile(join(dir, 'input.txt'), 'utf8');
+    expect(input).toContain('system instructions');
+    expect(input).toContain('<user>\nprior user');
+    expect(input).toContain('<assistant>\nprior assistant');
+    expect(input).toContain('<user>\nlatest user');
+    expect(input).not.toContain('oauth-secret');
   });
 
-  it('forwards the OAuth beta headers and identity preamble to AnthropicProvider', () => {
-    // These two are load-bearing: a subscription token is rejected by the
-    // Messages API unless `anthropic-beta: oauth-2025-04-20` is sent and the
-    // system prompt leads with the exact CLAUDE_CODE_SYSTEM line. A silent
-    // drop/typo in the forwarding object compiles fine and only surfaces as a
-    // runtime 401/400 — pin the contract here.
-    const client = createClaudeCodeClient({ oauthToken: 'tok' });
-    const oauth = (
-      client as unknown as { oauth: { beta: ReadonlyArray<string>; systemPreamble?: string } }
-    ).oauth;
-    expect(oauth.beta).toEqual([...CLAUDE_OAUTH_BETA]);
-    expect(oauth.beta).toContain('oauth-2025-04-20');
-    expect(oauth.beta).toContain('claude-code-20250219');
-    expect(oauth.systemPreamble).toBe(CLAUDE_CODE_SYSTEM);
+  it('turns malformed and unsupported records into non-retryable errors', async () => {
+    for (const output of [['not json'], [JSON.stringify({ type: 'mystery' })]]) {
+      const dir = await makeFakeClaudeRaw(output);
+      const events = await collect(createClaudeCodeClient({ executable: join(dir, 'claude') }).stream(textRequest()));
+      expect(events[0]?.type).toBe('message_start');
+      expect(events[1]).toMatchObject({ type: 'error', retryable: false });
+    }
+  });
+
+  it('estimates tokens deterministically without spawning Claude', async () => {
+    let spawned = false;
+    const client = createClaudeCodeClient({ spawn: () => { spawned = true; throw new Error('should not spawn'); } });
+    const request = textRequest();
+    const first = await client.countTokens(request);
+    expect(await client.countTokens(request)).toBe(first);
+    expect(first).toBeGreaterThan(0);
+    expect(spawned).toBe(false);
   });
 });
+
+function textRequest(): ProviderRequest {
+  return {
+    model: 'claude-sonnet-4-6',
+    system: 'system instructions',
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'prior user' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'prior assistant' }] },
+      { role: 'user', content: [{ type: 'text', text: 'latest user' }] },
+    ],
+  };
+}
+
+async function makeFakeClaude(records: unknown[]): Promise<string> {
+  return makeFakeClaudeRaw(records.map((record) => JSON.stringify(record)));
+}
+
+async function makeFakeClaudeRaw(lines: string[]): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'moxxy-claude-test-'));
+  tempDirs.push(dir);
+  const executable = join(dir, 'claude');
+  const source = `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', () => {
+  fs.writeFileSync(path.join(__dirname, 'args.json'), JSON.stringify(process.argv.slice(2)));
+  fs.writeFileSync(path.join(__dirname, 'input.txt'), input);
+  for (const line of ${JSON.stringify(lines)}) console.log(line);
+});
+`;
+  await writeFile(executable, source, 'utf8');
+  await chmod(executable, 0o755);
+  return dir;
+}
+
+async function collect(stream: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const events: ProviderEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process';
 import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -11,10 +12,20 @@ afterEach(async () => {
 });
 
 describe('claude-code provider definition', () => {
-  it('registers as an OAuth provider named claude-code with Claude models', () => {
+  it('registers text-only Claude model capabilities', () => {
     expect(claudeCodeProviderDef.name).toBe('claude-code');
     expect(claudeCodeProviderDef.auth?.kind).toBe('oauth');
     expect(claudeCodeProviderDef.models.map((model) => model.id)).toContain('claude-sonnet-4-6');
+    for (const model of claudeCodeProviderDef.models) {
+      expect(model).toMatchObject({
+        supportsStreaming: true,
+        supportsTools: false,
+        supportsImages: false,
+        supportsDocuments: false,
+        supportsAudio: false,
+        supportsReasoning: false,
+      });
+    }
   });
 
   it('streams text through a fake Claude executable with structured non-interactive arguments', async () => {
@@ -48,6 +59,46 @@ describe('claude-code provider definition', () => {
     expect(input).toContain('<assistant>\nprior assistant');
     expect(input).toContain('<user>\nlatest user');
     expect(input).not.toContain('oauth-secret');
+  });
+
+  it('passes a moxxy-managed token to the child environment without exposing it in args', async () => {
+    let childEnv: NodeJS.ProcessEnv | undefined;
+    const dir = await makeFakeClaude([
+      { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } },
+    ]);
+    const executable = join(dir, 'claude');
+    const client = createClaudeCodeClient({
+      executable,
+      oauthToken: 'oauth-secret',
+      spawn: (file, args, options) => {
+        childEnv = options.env;
+        return spawn(file, [...args], { stdio: ['pipe', 'pipe', 'pipe'], env: options.env });
+      },
+    });
+
+    await collect(client.stream(textRequest()));
+    expect(childEnv?.CLAUDE_CODE_OAUTH_TOKEN).toBe('oauth-secret');
+    expect(await readFile(join(dir, 'args.json'), 'utf8')).not.toContain('oauth-secret');
+    expect(await readFile(join(dir, 'input.txt'), 'utf8')).not.toContain('oauth-secret');
+  });
+
+  it('orders the identity, message-derived system text, and extra system text', async () => {
+    const dir = await makeFakeClaude([
+      { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } },
+    ]);
+    const client = createClaudeCodeClient({ executable: join(dir, 'claude') });
+    const base = textRequest();
+    const request: ProviderRequest = {
+      ...base,
+      messages: [
+        { role: 'system', content: [{ type: 'text', text: 'message system' }] },
+        ...base.messages,
+      ],
+    };
+    await collect(client.stream(request));
+    const input = await readFile(join(dir, 'input.txt'), 'utf8');
+    expect(input.indexOf("You are Claude Code")).toBeLessThan(input.indexOf('message system'));
+    expect(input.indexOf('message system')).toBeLessThan(input.indexOf('system instructions'));
   });
 
   it('turns malformed and unsupported records into non-retryable errors', async () => {

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -3,6 +3,7 @@ import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
 import type { ProviderEvent, ProviderRequest } from '@moxxy/sdk';
 import { claudeCodeProviderDef, createClaudeCodeClient } from './index.js';
 
@@ -99,6 +100,33 @@ describe('claude-code provider definition', () => {
     const input = await readFile(join(dir, 'input.txt'), 'utf8');
     expect(input.indexOf("You are Claude Code")).toBeLessThan(input.indexOf('message system'));
     expect(input.indexOf('message system')).toBeLessThan(input.indexOf('system instructions'));
+  });
+
+  it('rejects capabilities that the text-only descriptors disable', async () => {
+    const spawn = () => { throw new Error('should not spawn'); };
+    const client = createClaudeCodeClient({ spawn });
+
+    const withTools = await collect(client.stream({
+      ...textRequest(),
+      tools: [{
+        name: 'lookup',
+        description: 'Look something up',
+        inputSchema: z.object({}),
+        handler: async () => 'unused',
+      }],
+    }));
+    expect(withTools[1]).toMatchObject({
+      type: 'error',
+      message: expect.stringContaining('does not support tools'),
+      retryable: false,
+    });
+
+    const withReasoning = await collect(client.stream({ ...textRequest(), reasoning: true }));
+    expect(withReasoning[1]).toMatchObject({
+      type: 'error',
+      message: expect.stringContaining('does not support reasoning'),
+      retryable: false,
+    });
   });
 
   it('turns malformed and unsupported records into non-retryable errors', async () => {

--- a/packages/plugin-provider-claude-code/src/provider.ts
+++ b/packages/plugin-provider-claude-code/src/provider.ts
@@ -1,34 +1,112 @@
-/**
- * The Claude subscription provider is the standard Anthropic Messages API
- * with a bearer (OAuth) credential instead of an API key, so it reuses
- * `AnthropicProvider` in OAuth mode rather than duplicating the streaming /
- * tool-call event handling. This module just stamps in the Claude-specific
- * constants (beta headers + the required identity preamble) and forwards the
- * resolved token + refresh callback.
- */
+import type { LLMProvider, ProviderEvent, ProviderRequest } from '@moxxy/sdk';
+import { estimateTextTokens } from '@moxxy/sdk';
+import { anthropicModels } from '@moxxy/plugin-provider-anthropic';
+import { CLAUDE_CODE_PROVIDER_ID } from './constants.js';
+import { runClaudeProcess, type ClaudeSpawn } from './process.js';
+import { createProtocolState, parseClaudeRecord, serializeClaudePrompt } from './protocol.js';
 
-import { AnthropicProvider } from '@moxxy/plugin-provider-anthropic';
-import { CLAUDE_CODE_PROVIDER_ID, CLAUDE_CODE_SYSTEM, CLAUDE_OAUTH_BETA } from './constants.js';
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
+const NON_TEXT_BLOCK_TOKENS = 256;
 
 export interface ClaudeCodeProviderConfig {
-  /** Claude Code OAuth access token (bearer). Resolved by the host. */
-  readonly oauthToken?: string;
-  /** Epoch-ms expiry of `oauthToken`, when known (drives proactive refresh). */
-  readonly oauthExpiresAt?: number;
-  /** Refresh callback wired by the host; omitted for non-refreshable tokens. */
-  readonly oauthRefresh?: () => Promise<{ readonly token: string; readonly expiresAt?: number }>;
+  /** Installed Claude Code executable. Defaults to the command resolved from PATH. */
+  readonly executable?: string;
   /** Optional default model override. */
   readonly defaultModel?: string;
+  /** Process test seam; production callers should leave this unset. */
+  readonly spawn?: ClaudeSpawn;
+  /** Legacy host credential fields are intentionally ignored; the CLI owns authentication. */
+  readonly oauthToken?: string;
+  readonly oauthExpiresAt?: number;
+  readonly oauthRefresh?: () => Promise<{ readonly token: string; readonly expiresAt?: number }>;
 }
 
-export function createClaudeCodeClient(config: ClaudeCodeProviderConfig = {}): AnthropicProvider {
-  return new AnthropicProvider({
-    name: CLAUDE_CODE_PROVIDER_ID,
-    oauthBeta: [...CLAUDE_OAUTH_BETA],
-    systemPreamble: CLAUDE_CODE_SYSTEM,
-    ...(config.oauthToken ? { oauthToken: config.oauthToken } : {}),
-    ...(config.oauthExpiresAt !== undefined ? { oauthExpiresAt: config.oauthExpiresAt } : {}),
-    ...(config.oauthRefresh ? { oauthRefresh: config.oauthRefresh } : {}),
-    ...(config.defaultModel ? { defaultModel: config.defaultModel } : {}),
-  });
+export class ClaudeCodeProvider implements LLMProvider {
+  readonly name = CLAUDE_CODE_PROVIDER_ID;
+  readonly models = anthropicModels;
+
+  private readonly executable: string;
+  private readonly defaultModel: string;
+  private readonly spawn?: ClaudeSpawn;
+
+  constructor(config: ClaudeCodeProviderConfig = {}) {
+    this.executable = config.executable ?? 'claude';
+    this.defaultModel = config.defaultModel ?? DEFAULT_MODEL;
+    if (config.spawn) this.spawn = config.spawn;
+  }
+
+  async *stream(req: ProviderRequest): AsyncIterable<ProviderEvent> {
+    const model = req.model || this.defaultModel;
+    yield { type: 'message_start', model };
+
+    let prompt: string;
+    try {
+      prompt = serializeClaudePrompt(req);
+    } catch (error) {
+      yield nonRetryableError(error);
+      return;
+    }
+
+    const state = createProtocolState();
+    let terminal = false;
+    try {
+      const lines = runClaudeProcess({
+        executable: this.executable,
+        model,
+        prompt,
+        ...(req.signal ? { signal: req.signal } : {}),
+        ...(this.spawn ? { spawn: this.spawn } : {}),
+      });
+      while (true) {
+        const next = await lines.next();
+        if (next.done) {
+          if (next.value.exitCode !== 0 && !terminal) {
+            yield {
+              type: 'error',
+              message: next.value.stderr || `Claude CLI exited with code ${next.value.exitCode}`,
+              retryable: false,
+            };
+            return;
+          }
+          break;
+        }
+        for (const event of parseClaudeRecord(next.value, state)) {
+          if (event.type === 'message_end' || event.type === 'error') terminal = true;
+          yield event;
+        }
+      }
+      if (!terminal) {
+        yield { type: 'error', message: 'Claude CLI ended without a terminal result record', retryable: false };
+      }
+    } catch (error) {
+      yield nonRetryableError(error);
+    }
+  }
+
+  async countTokens(
+    req: Pick<ProviderRequest, 'model' | 'messages' | 'system' | 'tools'>,
+  ): Promise<number> {
+    let text = req.system ?? '';
+    let nonTextBlocks = 0;
+    for (const message of req.messages) {
+      for (const block of message.content) {
+        if (block.type === 'text') text += block.text;
+        else nonTextBlocks += 1;
+      }
+    }
+    for (const tool of req.tools ?? []) text += tool.name + tool.description;
+    return estimateTextTokens(text) + nonTextBlocks * NON_TEXT_BLOCK_TOKENS;
+  }
+}
+
+export function createClaudeCodeClient(config: ClaudeCodeProviderConfig = {}): LLMProvider {
+  return new ClaudeCodeProvider(config);
+}
+
+function nonRetryableError(error: unknown): ProviderEvent {
+  return {
+    type: 'error',
+    message: error instanceof Error ? error.message : String(error),
+    retryable: false,
+  };
 }

--- a/packages/plugin-provider-claude-code/src/provider.ts
+++ b/packages/plugin-provider-claude-code/src/provider.ts
@@ -57,6 +57,7 @@ export class ClaudeCodeProvider implements LLMProvider {
 
     let prompt: string;
     try {
+      assertTextOnlyRequest(req);
       prompt = serializeClaudePrompt(req);
     } catch (error) {
       yield nonRetryableError(error);
@@ -127,6 +128,15 @@ export class ClaudeCodeProvider implements LLMProvider {
 
 export function createClaudeCodeClient(config: ClaudeCodeProviderConfig = {}): LLMProvider {
   return new ClaudeCodeProvider(config);
+}
+
+function assertTextOnlyRequest(req: ProviderRequest): void {
+  if (req.tools && req.tools.length > 0) {
+    throw new Error('Claude CLI text transport does not support tools');
+  }
+  if (req.reasoning) {
+    throw new Error('Claude CLI text transport does not support reasoning');
+  }
 }
 
 function nonRetryableError(error: unknown): ProviderEvent {

--- a/packages/plugin-provider-claude-code/src/provider.ts
+++ b/packages/plugin-provider-claude-code/src/provider.ts
@@ -1,4 +1,4 @@
-import type { LLMProvider, ProviderEvent, ProviderRequest } from '@moxxy/sdk';
+import type { LLMProvider, ModelDescriptor, ProviderEvent, ProviderRequest } from '@moxxy/sdk';
 import { estimateTextTokens } from '@moxxy/sdk';
 import { anthropicModels } from '@moxxy/plugin-provider-anthropic';
 import { CLAUDE_CODE_PROVIDER_ID } from './constants.js';
@@ -8,6 +8,16 @@ import { createProtocolState, parseClaudeRecord, serializeClaudePrompt } from '.
 const DEFAULT_MODEL = 'claude-sonnet-4-6';
 const NON_TEXT_BLOCK_TOKENS = 256;
 
+/** Claude CLI transport currently supports streaming plain text only. */
+export const claudeCodeModels: ReadonlyArray<ModelDescriptor> = anthropicModels.map((model) => ({
+  ...model,
+  supportsTools: false,
+  supportsImages: false,
+  supportsDocuments: false,
+  supportsAudio: false,
+  supportsReasoning: false,
+}));
+
 export interface ClaudeCodeProviderConfig {
   /** Installed Claude Code executable. Defaults to the command resolved from PATH. */
   readonly executable?: string;
@@ -15,7 +25,7 @@ export interface ClaudeCodeProviderConfig {
   readonly defaultModel?: string;
   /** Process test seam; production callers should leave this unset. */
   readonly spawn?: ClaudeSpawn;
-  /** Legacy host credential fields are intentionally ignored; the CLI owns authentication. */
+  /** Optional moxxy-managed bearer, supplied to the child through its environment. */
   readonly oauthToken?: string;
   readonly oauthExpiresAt?: number;
   readonly oauthRefresh?: () => Promise<{ readonly token: string; readonly expiresAt?: number }>;
@@ -23,15 +33,21 @@ export interface ClaudeCodeProviderConfig {
 
 export class ClaudeCodeProvider implements LLMProvider {
   readonly name = CLAUDE_CODE_PROVIDER_ID;
-  readonly models = anthropicModels;
+  readonly models = claudeCodeModels;
 
   private readonly executable: string;
   private readonly defaultModel: string;
+  private oauthToken?: string;
+  private oauthExpiresAt?: number;
+  private readonly oauthRefresh?: ClaudeCodeProviderConfig['oauthRefresh'];
   private readonly spawn?: ClaudeSpawn;
 
   constructor(config: ClaudeCodeProviderConfig = {}) {
     this.executable = config.executable ?? 'claude';
     this.defaultModel = config.defaultModel ?? DEFAULT_MODEL;
+    if (config.oauthToken) this.oauthToken = config.oauthToken;
+    if (config.oauthExpiresAt !== undefined) this.oauthExpiresAt = config.oauthExpiresAt;
+    if (config.oauthRefresh) this.oauthRefresh = config.oauthRefresh;
     if (config.spawn) this.spawn = config.spawn;
   }
 
@@ -50,10 +66,12 @@ export class ClaudeCodeProvider implements LLMProvider {
     const state = createProtocolState();
     let terminal = false;
     try {
+      await this.ensureFreshOauth();
       const lines = runClaudeProcess({
         executable: this.executable,
         model,
         prompt,
+        ...(this.oauthToken ? { oauthToken: this.oauthToken } : {}),
         ...(req.signal ? { signal: req.signal } : {}),
         ...(this.spawn ? { spawn: this.spawn } : {}),
       });
@@ -81,6 +99,14 @@ export class ClaudeCodeProvider implements LLMProvider {
     } catch (error) {
       yield nonRetryableError(error);
     }
+  }
+
+  private async ensureFreshOauth(): Promise<void> {
+    if (!this.oauthRefresh || this.oauthExpiresAt === undefined) return;
+    if (Date.now() + 60_000 < this.oauthExpiresAt) return;
+    const fresh = await this.oauthRefresh();
+    this.oauthToken = fresh.token;
+    this.oauthExpiresAt = fresh.expiresAt;
   }
 
   async countTokens(

--- a/packages/sdk/src/mode/collect-stream.ts
+++ b/packages/sdk/src/mode/collect-stream.ts
@@ -89,12 +89,22 @@ export async function collectProviderStream(
     volatileTailCount?: number;
   } = {},
 ): Promise<StreamResult> {
-  // Lazy tool gating (opt-in): send only always-on + loaded tool schemas, and
-  // index the rest in the system prompt. Runs BEFORE cache planning since it
-  // rewrites the system message and the tool list.
+  const descriptor = ctx.provider.models.find((model) => model.id === ctx.model);
+
+  // Tool schemas are useful only when both the caller requests them and the
+  // selected model advertises tool support. Keeping this gate in the shared
+  // collection path prevents normal ReAct turns from sending every registered
+  // tool to text-only providers. An unknown model retains the previous behavior
+  // so custom/dynamic model ids are not silently stripped of tools.
+  //
+  // Lazy tool gating (opt-in) then sends only always-on + loaded schemas and
+  // indexes the rest in the system prompt. It runs BEFORE cache planning since
+  // it rewrites the system message and the tool list.
   let effectiveMessages = messages;
   let toolList: ReadonlyArray<import('../tool.js').ToolDef> | undefined =
-    opts.includeTools === false ? undefined : ctx.tools.list();
+    opts.includeTools === false || descriptor?.supportsTools === false
+      ? undefined
+      : ctx.tools.list();
   if (ctx.lazyTools && toolList) {
     const gated = applyLazyTools(messages, toolList, ctx.log);
     effectiveMessages = gated.messages;
@@ -105,7 +115,6 @@ export async function collectProviderStream(
   // The strategy is provider-neutral (returns CacheHints); the provider
   // translates them (Anthropic → cache_control). Falls back to no hints when
   // no strategy is registered. The onBeforeProviderCall hook can still adjust.
-  const descriptor = ctx.provider.models.find((m) => m.id === ctx.model);
   const cacheHints = ctx.cacheStrategy
     ? ctx.cacheStrategy.plan(effectiveMessages, {
         model: ctx.model,


### PR DESCRIPTION
Replace the direct `AnthropicProvider` construction in `packages/plugin-provider-claude-code/src/provider.ts` with a subprocess-backed `LLMProvider`. Add small process/protocol modules under `packages/plugin-provider-claude-code/src/` that invoke `claude` in print/stream-json mode, serialize the moxxy system prompt and message history, parse assistant text and terminal result records, emit valid `ProviderEvent`s, and estimate tokens for `countTokens`. Keep process spawning injectable so `provider.test.ts` can use a fake executable without a subscription or network.

### Acceptance criteria
- A fake Claude executable receiving a text-only request produces `message_start`, streamed `text_delta`, and one terminal `message_end` through `createClaudeCodeClient`.
- The child arguments select non-interactive structured output and disable native tools for this initial slice.
- System instructions, prior user/assistant messages, and the latest user message are present in the child input without secrets being logged.
- Malformed or unsupported stream-json records produce a non-retryable provider error rather than crashing the runner.
- `countTokens` returns a deterministic estimate without calling the Anthropic API.
- `pnpm --filter @moxxy/plugin-provider-claude-code test`, typecheck, and build pass.

_Task `tsk-16021de2-bb3` on the Companion board._