### PR TITLE
Reuse the user's existing Claude Code sign-in

### DIFF
--- a/.changeset/bright-claude-cli.md
+++ b/.changeset/bright-claude-cli.md
@@ -1,5 +1,7 @@
 ---
 "@moxxy/plugin-provider-claude-code": patch
+"@moxxy/sdk": patch
+"@moxxy/cli": patch
 ---
 
 Stream Claude subscription turns through the installed Claude CLI instead of constructing the Anthropic API provider directly.

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { Session, silentLogger } from '@moxxy/core';
 import { definePlugin, defineProvider, defineTranscriber } from '@moxxy/sdk';
-import { buildPluginDoctorChecks, buildVoiceDoctorCheck } from './doctor.js';
+import { __setClaudeCommandRunner } from '@moxxy/plugin-provider-claude-code';
+import { buildClaudeProviderDoctorCheck, buildPluginDoctorChecks, buildVoiceDoctorCheck } from './doctor.js';
 
 function makeSession(): Session {
   const session = new Session({ cwd: '/tmp', logger: silentLogger });
@@ -88,6 +89,31 @@ describe('buildVoiceDoctorCheck', () => {
       status: 'warn',
       message: 'unavailable — ffmpeg is required for voice input',
     });
+  });
+});
+
+describe('buildClaudeProviderDoctorCheck', () => {
+  it('uses configured CLI auth instead of canonical API-key lookup', async () => {
+    process.env.CLAUDE_CODE_API_KEY = 'must-not-be-used';
+    const seen: string[] = [];
+    __setClaudeCommandRunner(async (executable) => {
+      seen.push(executable);
+      return { code: 0, stdout: '{"loggedIn":true}', stderr: '' };
+    });
+    await expect(buildClaudeProviderDoctorCheck({
+      plugins: { provider: { items: { 'claude-code': { config: { executable: '/Applications/Claude Code/bin/claude' } } } } },
+    })).resolves.toMatchObject({ status: 'ok', message: expect.stringMatching(/signed in/) });
+    expect(seen).toEqual(['/Applications/Claude Code/bin/claude']);
+    delete process.env.CLAUDE_CODE_API_KEY;
+  });
+
+  it('reports signed-out as a warning and missing binary as a failure', async () => {
+    __setClaudeCommandRunner(async () => ({ code: 0, stdout: '{"loggedIn":false}', stderr: '' }));
+    await expect(buildClaudeProviderDoctorCheck({})).resolves.toMatchObject({ status: 'warn' });
+    __setClaudeCommandRunner(async () => ({
+      code: 1, stdout: '', stderr: '', error: Object.assign(new Error('ENOENT'), { code: 'ENOENT' }),
+    }));
+    await expect(buildClaudeProviderDoctorCheck({})).resolves.toMatchObject({ status: 'fail' });
   });
 });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -7,6 +7,7 @@ import type { VaultStore } from '@moxxy/plugin-vault';
 import type { MemoryStore } from '@moxxy/plugin-memory';
 import { checkVoiceCaptureAvailable } from '@moxxy/plugin-cli';
 import { corePreflight, detectCoreInstall } from '@moxxy/plugin-self-update';
+import { checkClaudeCliAuth, resolveClaudeExecutable } from '@moxxy/plugin-provider-claude-code';
 import type { RequirementIssue } from '@moxxy/sdk';
 import type { RequirementCheck } from '@moxxy/sdk';
 import type { ParsedArgv } from '../argv.js';
@@ -148,6 +149,19 @@ async function runDoctorChecks(deps: DoctorChecksDeps): Promise<number> {
         id: `provider:${name}`,
         status: 'fail',
         message: `not registered (configured in provider.name or .fallbacks)`,
+      });
+      continue;
+    }
+    if (name === 'claude-code') {
+      const itemConfig = config.plugins?.provider?.items?.[name]?.config;
+      const executable = resolveClaudeExecutable(
+        itemConfig && typeof itemConfig === 'object' ? itemConfig as Record<string, unknown> : {},
+      );
+      const auth = await checkClaudeCliAuth(executable);
+      checks.push({
+        id: `provider:${name}`,
+        status: auth.state === 'signed-in' ? 'ok' : auth.state === 'missing' || auth.state === 'unsupported' ? 'fail' : 'warn',
+        message: auth.message,
       });
       continue;
     }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -94,6 +94,22 @@ export async function runDoctorCommand(argv: ParsedArgv): Promise<number> {
   }
 }
 
+export async function buildClaudeProviderDoctorCheck(config: MoxxyConfig): Promise<Check> {
+  const executable = resolveClaudeExecutable(
+    config.plugins?.provider?.items?.['claude-code']?.config ?? {},
+  );
+  const auth = await checkClaudeCliAuth(executable);
+  return {
+    id: 'provider:claude-code',
+    status: auth.state === 'signed-in'
+      ? 'ok'
+      : auth.state === 'missing' || auth.state === 'unsupported' || auth.state === 'error'
+        ? 'fail'
+        : 'warn',
+    message: auth.message,
+  };
+}
+
 interface DoctorChecksDeps {
   readonly session: Session;
   readonly config: MoxxyConfig;
@@ -153,16 +169,7 @@ async function runDoctorChecks(deps: DoctorChecksDeps): Promise<number> {
       continue;
     }
     if (name === 'claude-code') {
-      const itemConfig = config.plugins?.provider?.items?.[name]?.config;
-      const executable = resolveClaudeExecutable(
-        itemConfig && typeof itemConfig === 'object' ? itemConfig as Record<string, unknown> : {},
-      );
-      const auth = await checkClaudeCliAuth(executable);
-      checks.push({
-        id: `provider:${name}`,
-        status: auth.state === 'signed-in' ? 'ok' : auth.state === 'missing' || auth.state === 'unsupported' ? 'fail' : 'warn',
-        message: auth.message,
-      });
+      checks.push(await buildClaudeProviderDoctorCheck(config));
       continue;
     }
     const canonical = canonicalKey(name);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -13,7 +13,7 @@ import {
   resolveCatalogPackageName,
   INSTALLABLE_PLUGIN_CATALOG,
 } from '@moxxy/plugin-plugins-admin';
-import { applyInitConfig, setPluginEnabled } from '@moxxy/config';
+import { applyInitConfig, setPluginEnabled, type MoxxyConfig } from '@moxxy/config';
 import { renderLogo } from '../logo.js';
 import { cancel, isCancel, note, password } from '@clack/prompts';
 import { colors } from '../colors.js';
@@ -43,7 +43,7 @@ export async function runInitCommand(argv: ParsedArgv): Promise<number> {
   // `passphrasePrompt` (TTY only) swaps the vault's bare readline prompt for
   // a @clack/prompts step, so the first-run passphrase reads as part of the
   // setup wizard rather than an unstyled prompt before it.
-  const { session, vault, persistence } = await bootSessionWithConfig(argv, {
+  const { session, vault, config, persistence } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
     skipProviderActivation: true,
     ...(interactive ? { passphrasePrompt: promptVaultPassphrase } : {}),
@@ -59,7 +59,7 @@ export async function runInitCommand(argv: ParsedArgv): Promise<number> {
     if (!interactive) {
       return await runHeadlessInit(session, vault);
     }
-    return await runInteractiveInit(session, vault);
+    return await runInteractiveInit(session, vault, config);
   } finally {
     await closeSession(session, persistence);
   }
@@ -68,6 +68,7 @@ export async function runInitCommand(argv: ParsedArgv): Promise<number> {
 async function runInteractiveInit(
   session: import('@moxxy/core').Session,
   vault: import('@moxxy/plugin-vault').VaultStore,
+  config: MoxxyConfig,
 ): Promise<number> {
   // Logo first, so the whole flow reads as one screen: the (first-run only)
   // vault passphrase step and the wizard's `intro()` both render beneath it.
@@ -124,7 +125,7 @@ async function runInteractiveInit(
   // delegates install/key/OAuth to the same ProviderSetupView the TUI's
   // inline connect dialog drives (attached by setupSessionWithConfig; built
   // here as a fallback for boot paths that skipped it).
-  const providerSetup = session.providerSetup ?? buildProviderSetupView({ session, vault });
+  const providerSetup = session.providerSetup ?? buildProviderSetupView({ session, vault, config });
 
   const controller = {
     async saveApiKey(providerId: string, key: string): Promise<void> {

--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { MoxxyConfig } from '@moxxy/config';
+import type { Session } from '@moxxy/core';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { __setClaudeCommandRunner, claudeCodeProviderDef } from '@moxxy/plugin-provider-claude-code';
+import type { ParsedArgv } from '../argv.js';
+import { runLoginLogout, runLoginProvider, runLoginStatus } from './login.js';
+
+const writes: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  writes.length = 0;
+});
+
+function argv(): ParsedArgv {
+  return { positional: ['status', 'claude-code'], flags: {} } as ParsedArgv;
+}
+
+function session(): Session {
+  return {
+    providers: { list: () => [claudeCodeProviderDef] },
+    requirements: { setRuntime: vi.fn(), clearRuntime: vi.fn() },
+  } as unknown as Session;
+}
+
+function vault(): VaultStore {
+  return {
+    open: async () => undefined,
+    get: async () => null,
+    set: async () => undefined,
+  } as unknown as VaultStore;
+}
+
+async function renderStatus(
+  result: { code: number; stdout: string; stderr: string; error?: NodeJS.ErrnoException },
+  config: MoxxyConfig = {},
+): Promise<string> {
+  __setClaudeCommandRunner(async () => result);
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+    writes.push(String(chunk));
+    return true;
+  });
+  expect(await runLoginStatus(argv(), session(), vault(), config)).toBe(0);
+  return writes.join('');
+}
+
+describe('moxxy login status', () => {
+  it('renders a missing Claude executable', async () => {
+    const output = await renderStatus({
+      code: 1,
+      stdout: '',
+      stderr: '',
+      error: Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }),
+    });
+    expect(output).toContain('claude-code');
+    expect(output).toContain('missing');
+    expect(output).toContain('executable not found');
+  });
+
+  it('renders a signed-out Claude CLI', async () => {
+    const output = await renderStatus({ code: 0, stdout: '{"loggedIn":false}', stderr: '' });
+    expect(output).toContain('signed-out');
+    expect(output).toContain('installed but signed out');
+  });
+
+  it('passes a configured executable intact through login and logout', async () => {
+    const executable = '/Applications/Claude Code/bin/claude';
+    const seen: string[] = [];
+    __setClaudeCommandRunner(async (value, args) => {
+      seen.push(value);
+      return args[1] === 'logout'
+        ? { code: 0, stdout: '', stderr: '' }
+        : { code: 0, stdout: '{"loggedIn":true}', stderr: '' };
+    });
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    expect(await runLoginProvider(argv(), 'claude-code', session(), vault(), { executable })).toBe(0);
+    expect(await runLoginLogout('claude-code', session(), vault(), { executable })).toBe(0);
+    expect(seen).toEqual([executable, executable, executable]);
+  });
+
+  it('renders a signed-in account and passes the configured executable intact', async () => {
+    const executable = '/Applications/Claude Code/bin/claude';
+    const seen: string[] = [];
+    __setClaudeCommandRunner(async (value) => {
+      seen.push(value);
+      return { code: 0, stdout: '{"loggedIn":true,"email":"me@example.test"}', stderr: '' };
+    });
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      writes.push(String(chunk));
+      return true;
+    });
+    const config = {
+      plugins: { provider: { items: { 'claude-code': { config: { executable } } } } },
+    } satisfies MoxxyConfig;
+    expect(await runLoginStatus(argv(), session(), vault(), config)).toBe(0);
+    expect(writes.join('')).toContain('me@example.test');
+    expect(seen).toEqual([executable]);
+  });
+});

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -97,6 +97,13 @@ export async function runLoginCommand(argv: ParsedArgv): Promise<number> {
   return await loginProvider(argv, sub);
 }
 
+function providerAuthConfig(
+  config: MoxxyConfig,
+  providerName: string,
+): Readonly<Record<string, unknown>> {
+  return config.plugins?.provider?.items?.[providerName]?.config ?? {};
+}
+
 async function loginProvider(argv: ParsedArgv, providerName: string): Promise<number> {
   const { session, vault, config, persistence } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
@@ -110,7 +117,7 @@ async function loginProvider(argv: ParsedArgv, providerName: string): Promise<nu
   }
 }
 
-async function runLoginProvider(
+export async function runLoginProvider(
   argv: ParsedArgv,
   providerName: string,
   session: Session,
@@ -203,7 +210,7 @@ async function loginStatus(argv: ParsedArgv): Promise<number> {
   }
 }
 
-async function runLoginStatus(
+export async function runLoginStatus(
   argv: ParsedArgv,
   session: Session,
   vault: VaultStore,
@@ -297,10 +304,11 @@ async function loginLogout(argv: ParsedArgv): Promise<number> {
   }
 }
 
-async function runLoginLogout(
+export async function runLoginLogout(
   providerName: string,
   session: Session,
   vault: VaultStore,
+  providerConfig: Readonly<Record<string, unknown>> = {},
 ): Promise<number> {
   await vault.open();
   const def = session.providers.list().find((d) => d.name === providerName);
@@ -314,15 +322,15 @@ async function runLoginLogout(
     );
     return 1;
   }
-  const ctx = buildProviderAuthContext(vault, { headless: true });
-  const removed = await def.auth.logout(ctx);
-  if (removed) {
+  const ctx = buildProviderAuthContext(vault, { headless: true, providerConfig });
+  const loggedOut = await def.auth.logout(ctx);
+  if (loggedOut) {
     session.requirements.clearRuntime(`auth:provider:${providerName}`);
     process.stdout.write(
-      `${colors.bold('logged out')}  ${colors.dim('OAuth credentials removed from the vault')}\n`,
+      `${colors.bold('logged out')}  ${colors.dim(`${providerName} sign-out completed`)}\n`,
     );
     return 0;
   }
-  process.stdout.write(colors.dim(`no stored credentials for ${providerName}`) + '\n');
+  process.stdout.write(colors.dim(`${providerName} was not signed in; no sign-out was needed`) + '\n');
   return 0;
 }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -165,10 +165,10 @@ async function runLoginProvider(
     const expires =
       result.expiresAt !== undefined
         ? `token expires ${new Date(result.expiresAt).toLocaleString()}`
-        : 'credentials stored';
+        : 'sign-in ready';
     const rows: Array<[string, string]> = [
       ['account', result.accountId ?? '(none)'],
-      ['token', expires],
+      ['auth', expires],
     ];
     const col = Math.max(...rows.map(([k]) => k.length));
     process.stdout.write(colors.bold('logged in') + '\n');
@@ -231,6 +231,13 @@ async function runLoginStatus(argv: ParsedArgv, session: Session, vault: VaultSt
       continue;
     }
     const status = await auth.status(ctx);
+    if (status?.authState && status.authState !== 'signed-in') {
+      process.stdout.write(
+        `${colors.bold(def.name)}  ${colors.dim(status.authState)}\n` +
+          `${' '.repeat(def.name.length)}  ${colors.dim(status.message ?? 'authentication is not ready')}\n`,
+      );
+      continue;
+    }
     if (!status) {
       process.stdout.write(
         `${colors.bold(def.name)}  ${colors.dim('not logged in')}\n` +

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -7,6 +7,7 @@ import { formatHelp } from './help-format.js';
 import type { ProviderDef } from '@moxxy/sdk';
 import type { Session } from '@moxxy/core';
 import type { VaultStore } from '@moxxy/plugin-vault';
+import type { MoxxyConfig } from '@moxxy/config';
 
 /**
  * `moxxy login` — generic OAuth driver. Walks the session's provider
@@ -97,13 +98,13 @@ export async function runLoginCommand(argv: ParsedArgv): Promise<number> {
 }
 
 async function loginProvider(argv: ParsedArgv, providerName: string): Promise<number> {
-  const { session, vault, persistence } = await bootSessionWithConfig(argv, {
+  const { session, vault, config, persistence } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
     skipProviderActivation: true,
     tolerateNoProvider: true,
   });
   try {
-    return await runLoginProvider(argv, providerName, session, vault);
+    return await runLoginProvider(argv, providerName, session, vault, providerAuthConfig(config, providerName));
   } finally {
     await closeSession(session, persistence);
   }
@@ -114,6 +115,7 @@ async function runLoginProvider(
   providerName: string,
   session: Session,
   vault: VaultStore,
+  providerConfig: Readonly<Record<string, unknown>> = {},
 ): Promise<number> {
   const def = session.providers.list().find((d) => d.name === providerName);
   if (!def) {
@@ -156,6 +158,7 @@ async function runLoginProvider(
       (!hasBoolFlag(argv, 'browser') && process.stdin.isTTY !== true));
   const ctx = buildProviderAuthContext(vault, {
     headless,
+    providerConfig,
     ...(stdinPrompts ? { promptMode: 'stdin' as const } : {}),
   });
 
@@ -188,21 +191,25 @@ async function runLoginProvider(
 }
 
 async function loginStatus(argv: ParsedArgv): Promise<number> {
-  const { session, vault, persistence } = await bootSessionWithConfig(argv, {
+  const { session, vault, config, persistence } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
     skipProviderActivation: true,
     tolerateNoProvider: true,
   });
   try {
-    return await runLoginStatus(argv, session, vault);
+    return await runLoginStatus(argv, session, vault, config);
   } finally {
     await closeSession(session, persistence);
   }
 }
 
-async function runLoginStatus(argv: ParsedArgv, session: Session, vault: VaultStore): Promise<number> {
+async function runLoginStatus(
+  argv: ParsedArgv,
+  session: Session,
+  vault: VaultStore,
+  config: MoxxyConfig,
+): Promise<number> {
   await vault.open();
-  const ctx = buildProviderAuthContext(vault, { headless: true });
   const filter = argv.positional[1];
 
   const oauthProviders = session.providers
@@ -230,6 +237,10 @@ async function runLoginStatus(argv: ParsedArgv, session: Session, vault: VaultSt
       );
       continue;
     }
+    const ctx = buildProviderAuthContext(vault, {
+      headless: true,
+      providerConfig: providerAuthConfig(config, def.name),
+    });
     const status = await auth.status(ctx);
     if (status?.authState && status.authState !== 'signed-in') {
       process.stdout.write(
@@ -274,13 +285,13 @@ async function loginLogout(argv: ParsedArgv): Promise<number> {
     );
     return 2;
   }
-  const { session, vault, persistence } = await bootSessionWithConfig(argv, {
+  const { session, vault, config, persistence } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
     skipProviderActivation: true,
     tolerateNoProvider: true,
   });
   try {
-    return await runLoginLogout(providerName, session, vault);
+    return await runLoginLogout(providerName, session, vault, providerAuthConfig(config, providerName));
   } finally {
     await closeSession(session, persistence);
   }

--- a/packages/cli/src/provider-credentials.test.ts
+++ b/packages/cli/src/provider-credentials.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { VaultStore, createStaticKeySource, deriveKey, generateSalt } from '@moxxy/plugin-vault';
+import { __setClaudeCommandRunner } from '@moxxy/plugin-provider-claude-code';
 import { resolveProviderCredentials } from './provider-credentials.js';
 
 let tmp: string;
@@ -18,6 +19,9 @@ beforeEach(async () => {
     filePath: path.join(tmp, 'vault.json'),
     keySource: createStaticKeySource(deriveKey('test', generateSalt())),
   });
+  __setClaudeCommandRunner(async () => ({
+    code: 0, stdout: JSON.stringify({ loggedIn: true }), stderr: '',
+  }));
 });
 
 afterEach(async () => {
@@ -88,12 +92,40 @@ describe('resolveProviderCredentials', () => {
     expect(cfg).toEqual({ executable: '/opt/bin/claude' });
   });
 
-  it('passes a stored claude-code token to the provider config', async () => {
+  it('preserves but neither reads nor forwards stored claude-code tokens', async () => {
     await vault.set('oauth/claude-code/access_token', 'stored-claude-token');
-    await vault.set('oauth/claude-code/client_id', 'claude-client');
-    await vault.set('oauth/claude-code/token_url', 'https://example.test/oauth/token');
     const cfg = await resolveProviderCredentials('claude-code', vault, { interactive: false });
-    expect(cfg.oauthToken).toBe('stored-claude-token');
+    expect(cfg).toEqual({ executable: 'claude' });
+    expect(await vault.get('oauth/claude-code/access_token')).toBe('stored-claude-token');
+  });
+
+  it('rejects activation when the CLI is signed out', async () => {
+    __setClaudeCommandRunner(async () => ({ code: 0, stdout: '{"loggedIn":false}', stderr: '' }));
+    await expect(resolveProviderCredentials('claude-code', vault, { interactive: false }))
+      .rejects.toThrow(/signed out/);
+  });
+
+  it('passes a configured executable path containing spaces as one value', async () => {
+    const seen: string[] = [];
+    __setClaudeCommandRunner(async (executable) => {
+      seen.push(executable);
+      return { code: 0, stdout: '{"loggedIn":true}', stderr: '' };
+    });
+    const executable = '/Applications/Claude Code/bin/claude';
+    const cfg = await resolveProviderCredentials('claude-code', vault, {
+      interactive: false, providerConfig: { executable },
+    });
+    expect(seen).toEqual([executable]);
+    expect(cfg.executable).toBe(executable);
+  });
+
+  it('rejects unsupported and failed auth-status commands', async () => {
+    __setClaudeCommandRunner(async () => ({ code: 1, stdout: '', stderr: 'unknown command auth' }));
+    await expect(resolveProviderCredentials('claude-code', vault, { interactive: false }))
+      .rejects.toThrow(/does not support/);
+    __setClaudeCommandRunner(async () => ({ code: 2, stdout: '', stderr: 'broken config' }));
+    await expect(resolveProviderCredentials('claude-code', vault, { interactive: false }))
+      .rejects.toThrow(/broken config/);
   });
 
   it('passes provider.config options through to the codex client config', async () => {

--- a/packages/cli/src/provider-credentials.ts
+++ b/packages/cli/src/provider-credentials.ts
@@ -7,9 +7,8 @@ import {
 } from '@moxxy/plugin-provider-openai-codex';
 import {
   CLAUDE_CODE_PROVIDER_ID,
-  CLAUDE_TOKEN_ENV_VARS,
-  ensureFreshClaudeTokens,
-  refreshClaudeAccessToken,
+  checkClaudeCliAuth,
+  resolveClaudeExecutable,
 } from '@moxxy/plugin-provider-claude-code';
 import { storedProviderApiKeyName } from '@moxxy/plugin-provider-admin';
 import { resolveProviderApiKey, type ResolveOptions } from './provider-keys.js';
@@ -17,10 +16,8 @@ import { resolveProviderApiKey, type ResolveOptions } from './provider-keys.js';
 /**
  * Provider-aware credential resolution. The existing API-key flow (vault →
  * env → prompt) is unchanged for all providers EXCEPT the subscription-OAuth
- * ones: `openai-codex` pulls a ChatGPT token bundle (under
- * `oauth/openai-codex/*`), and `claude-code` pulls a Claude bearer (vault
- * `oauth/claude-code/*` or a `CLAUDE_CODE_OAUTH_TOKEN` env var) — each
- * exposing the live token plus a refresh hook the provider uses on a 401.
+ * ones: `openai-codex` pulls a ChatGPT token bundle, while `claude-code`
+ * verifies the installed CLI and reuses its existing subscription sign-in.
  *
  * For runtime-registered providers (plugins.provider.items in the unified config) the stored
  * `envVar` override is honored: the lookup goes through the shared
@@ -56,31 +53,30 @@ export async function resolveProviderCredentials(
 }
 
 /**
- * The installed CLI is the primary authentication source, so activation must
- * also work with no moxxy credential at all. When moxxy has a token (from its
- * login flow or an env var), pass it to the provider; the provider supplies it
- * to the child through CLAUDE_CODE_OAUTH_TOKEN rather than command-line args.
+ * The installed CLI is the only authentication source. Activation probes its
+ * supported auth-status command and passes only executable/config options to
+ * the provider; legacy moxxy credentials are intentionally ignored.
  */
 async function resolveClaudeCode(
-  vault: VaultStore,
+  _vault: VaultStore,
   opts: ResolveOptions,
 ): Promise<Record<string, unknown>> {
   const config = { ...(opts.providerConfig ?? {}) };
-  const fresh = await ensureFreshClaudeTokens(vault);
-  if (fresh) {
-    return {
-      ...config,
-      oauthToken: fresh.accessToken,
-      ...(fresh.expiresAt !== undefined ? { oauthExpiresAt: fresh.expiresAt } : {}),
-      ...(fresh.canRefresh ? { oauthRefresh: () => refreshClaudeAccessToken(vault) } : {}),
-    };
+  const executable = resolveClaudeExecutable(config);
+  const status = await checkClaudeCliAuth(executable);
+  if (status.state !== 'signed-in') {
+    throw new MoxxyError({
+      code: status.state === 'signed-out' ? 'AUTH_NO_CREDENTIALS' : 'AUTH_INVALID',
+      message: status.message,
+      hint: status.state === 'signed-out'
+        ? 'Run `moxxy login claude-code` to sign in with your Claude subscription.'
+        : undefined,
+      context: { provider: CLAUDE_CODE_PROVIDER_ID, executable, state: status.state },
+    });
   }
-
-  for (const envVar of CLAUDE_TOKEN_ENV_VARS) {
-    const token = process.env[envVar];
-    if (token) return { ...config, oauthToken: token };
-  }
-  return config;
+  // Never read or forward legacy oauth/claude-code/* vault values. The child
+  // inherits the Claude CLI's own config/auth state.
+  return { ...config, executable };
 }
 
 async function resolveOAuthCodex(

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -193,7 +193,7 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
   // In-session provider onboarding (install / key entry / OAuth) — backs the
   // TUI's inline connect dialog and shares its implementation with the init
   // wizard. Attached after activation so readyProviders exists to mark into.
-  session.providerSetup = buildProviderSetupView({ session, vault });
+  session.providerSetup = buildProviderSetupView({ session, vault, config });
 
   // Apply the manifest's per-category defaults (mode/compactor/cacheStrategy/
   // workflowExecutor/viewRenderer/tunnelProvider) in one table-driven pass. A

--- a/packages/cli/src/setup/activate-provider.test.ts
+++ b/packages/cli/src/setup/activate-provider.test.ts
@@ -1,40 +1,58 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { Session, silentLogger } from '@moxxy/core';
-import { definePlugin, defineProvider } from '@moxxy/sdk';
+import { definePlugin, defineProvider, type ProviderDef } from '@moxxy/sdk';
+import {
+  __setClaudeCommandRunner,
+  claudeCodeProviderDef,
+} from '@moxxy/plugin-provider-claude-code';
 import { activateProvider } from './activate-provider.js';
+
+function testProvider(name = 'test-provider'): ProviderDef {
+  return defineProvider({
+    name,
+    models: [],
+    createClient: () => ({
+      name,
+      models: [],
+      stream: async function* () {},
+      countTokens: async () => 0,
+    }),
+  });
+}
+
+function makeSession(providers: ProviderDef[]): Session {
+  const session = new Session({ cwd: '/tmp', logger: silentLogger });
+  session.pluginHost.registerStatic(
+    definePlugin({ name: '@test/providers', providers }),
+  );
+  return session;
+}
+
+const vault = {
+  get: async () => null,
+  set: async () => undefined,
+} as never;
+
+const baseArgs = {
+  vault,
+  skipKeyPrompt: true,
+  progress: () => undefined,
+  logger: silentLogger,
+};
+
+afterEach(() => {
+  __setClaudeCommandRunner(async () => ({ code: 1, stdout: '', stderr: 'not configured' }));
+});
 
 describe('activateProvider', () => {
   it('marks provider auth as ready after credentials resolve and provider activates', async () => {
-    const session = new Session({ cwd: '/tmp', logger: silentLogger });
-    session.pluginHost.registerStatic(
-      definePlugin({
-        name: '@test/provider',
-        providers: [
-          defineProvider({
-            name: 'test-provider',
-            models: [],
-            createClient: () => ({
-              name: 'test-provider',
-              models: [],
-              stream: async function* () {},
-              countTokens: async () => 0,
-            }),
-          }),
-        ],
-      }),
-    );
+    const session = makeSession([testProvider()]);
 
     await activateProvider({
+      ...baseArgs,
       session,
       config: { plugins: { provider: { default: 'test-provider' } } },
-      vault: {
-        get: async () => null,
-        set: async () => undefined,
-      } as never,
       providerConfig: { apiKey: 'sk-test' },
-      skipKeyPrompt: true,
-      progress: () => undefined,
-      logger: silentLogger,
     });
 
     expect(
@@ -42,5 +60,64 @@ describe('activateProvider', () => {
         { kind: 'runtime', name: 'auth:provider:test-provider', state: 'ready' },
       ]),
     ).toEqual({ ready: true, issues: [] });
+  });
+
+  it('uses a fallback provider item config when probing activation', async () => {
+    const executable = '/Applications/Claude Code/bin/claude';
+    const seen: string[] = [];
+    __setClaudeCommandRunner(async (value) => {
+      seen.push(value);
+      return { code: 0, stdout: '{"loggedIn":true}', stderr: '' };
+    });
+    const session = makeSession([testProvider('unconfigured'), claudeCodeProviderDef]);
+
+    const result = await activateProvider({
+      ...baseArgs,
+      session,
+      config: {
+        plugins: {
+          provider: {
+            default: 'unconfigured',
+            fallbacks: ['claude-code'],
+            items: { 'claude-code': { config: { executable } } },
+          },
+        },
+      },
+      providerConfig: {},
+    });
+
+    expect(result.activated).toMatchObject({
+      name: 'claude-code',
+      cfg: { executable },
+    });
+    expect(seen).toEqual([executable]);
+  });
+
+  it('uses provider item config for readiness probes and runtime switching', async () => {
+    const executable = '/Applications/Claude Code/bin/claude';
+    const seen: string[] = [];
+    __setClaudeCommandRunner(async (value) => {
+      seen.push(value);
+      return { code: 0, stdout: '{"loggedIn":true}', stderr: '' };
+    });
+    const session = makeSession([testProvider(), claudeCodeProviderDef]);
+
+    const { credentialResolver } = await activateProvider({
+      ...baseArgs,
+      session,
+      config: {
+        plugins: {
+          provider: {
+            default: 'test-provider',
+            items: { 'claude-code': { config: { executable } } },
+          },
+        },
+      },
+      providerConfig: { apiKey: 'sk-test' },
+    });
+
+    expect(session.readyProviders.has('claude-code')).toBe(true);
+    await expect(credentialResolver('claude-code')).resolves.toMatchObject({ executable });
+    expect(seen).toEqual([executable, executable]);
   });
 });

--- a/packages/cli/src/setup/activate-provider.ts
+++ b/packages/cli/src/setup/activate-provider.ts
@@ -3,7 +3,7 @@ import type { MoxxyConfig } from '@moxxy/config';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { MoxxyError, type CredentialResolver } from '@moxxy/sdk';
 import { resolveProviderCredentials } from '../provider-credentials.js';
-import { providerDefault, providerSlot } from './resolve-plugins-tree.js';
+import { providerDefault, providerItem, providerSlot } from './resolve-plugins-tree.js';
 import type { BootStep } from './types.js';
 
 type Logger = {
@@ -51,6 +51,13 @@ export async function activateProvider(args: ActivateProviderArgs): Promise<Acti
   const candidates = [primaryProvider, ...fallbacks].filter(
     (c): c is string => typeof c === 'string' && c.length > 0,
   );
+  // The caller may overlay boot-time options onto the primary item's config.
+  // Every other path must still use that provider's own configured item rather
+  // than silently falling back to environment/default values.
+  const effectiveProviderConfig = (providerName: string): Record<string, unknown> =>
+    providerName === primaryProvider
+      ? providerConfig
+      : { ...(providerItem(config, providerName).config ?? {}) };
 
   let activated: { name: string; cfg: Record<string, unknown> } | null = null;
   let lastErr: unknown = null;
@@ -72,7 +79,7 @@ export async function activateProvider(args: ActivateProviderArgs): Promise<Acti
       const interactive = i === 0 && !skipKeyPrompt && process.stdin.isTTY === true;
       try {
         const resolved = await resolveProviderCredentials(candidate, vault, {
-          providerConfig: i === 0 ? providerConfig : {},
+          providerConfig: effectiveProviderConfig(candidate),
           interactive,
         });
         activated = { name: candidate, cfg: resolved };
@@ -124,7 +131,10 @@ export async function activateProvider(args: ActivateProviderArgs): Promise<Acti
   for (const p of session.providers.list()) {
     if (readyProviders.has(p.name)) continue;
     try {
-      await resolveProviderCredentials(p.name, vault, { interactive: false });
+      await resolveProviderCredentials(p.name, vault, {
+        interactive: false,
+        providerConfig: effectiveProviderConfig(p.name),
+      });
       readyProviders.add(p.name);
       session.requirements.setRuntime(`auth:provider:${p.name}`, 'ready');
     } catch {
@@ -140,7 +150,10 @@ export async function activateProvider(args: ActivateProviderArgs): Promise<Acti
   // createClient({}) and OAuth-backed providers (openai-codex) throw
   // "no credentials" on the next turn.
   const credentialResolver: CredentialResolver = async (providerName) =>
-    resolveProviderCredentials(providerName, vault, { interactive: false });
+    resolveProviderCredentials(providerName, vault, {
+      interactive: false,
+      providerConfig: effectiveProviderConfig(providerName),
+    });
   session.credentialResolver = credentialResolver;
 
   return { activated, credentialResolver };

--- a/packages/cli/src/setup/provider-setup.test.ts
+++ b/packages/cli/src/setup/provider-setup.test.ts
@@ -11,6 +11,10 @@ vi.mock('@moxxy/plugin-plugins-admin', async (importOriginal) => {
 });
 
 import { installPluginPackagePinned } from '@moxxy/plugin-plugins-admin';
+import {
+  __setClaudeCommandRunner,
+  claudeCodeProviderDef,
+} from '@moxxy/plugin-provider-claude-code';
 import { buildProviderSetupView } from './provider-setup.js';
 
 interface FakeDef {
@@ -107,6 +111,29 @@ describe('buildProviderSetupView', () => {
     expect(result).toEqual({ accountId: 'acct' });
     expect(lines).toEqual(['hello']);
     expect(session.readyProviders.has('oauthy')).toBe(true);
+  });
+
+  it('loginOAuth passes configured executables intact through wizard and channel auth contexts', async () => {
+    const executable = '/Applications/Claude Code/bin/claude';
+    const seen: string[] = [];
+    __setClaudeCommandRunner(async (value) => {
+      seen.push(value);
+      return { code: 0, stdout: '{"loggedIn":true}', stderr: '' };
+    });
+    const session = fakeSession([claudeCodeProviderDef as unknown as FakeDef]);
+    const config = {
+      plugins: { provider: { items: { 'claude-code': { config: { executable } } } } },
+    };
+    const view = buildProviderSetupView({
+      session: session as never,
+      vault: fakeVault() as never,
+      config: config as never,
+    });
+
+    await view.loginOAuth('claude-code');
+    await view.loginOAuth('claude-code', { write: () => undefined });
+
+    expect(seen).toEqual([executable, executable]);
   });
 
   it('loginOAuth threads opts.headless into the auth context (no-browser flow)', async () => {

--- a/packages/cli/src/setup/provider-setup.ts
+++ b/packages/cli/src/setup/provider-setup.ts
@@ -5,6 +5,7 @@ import {
   type ProviderConnectIo,
   type ProviderSetupView,
 } from '@moxxy/sdk';
+import type { MoxxyConfig } from '@moxxy/config';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import { installPluginPackagePinned, setPluginEnabled } from '@moxxy/plugin-plugins-admin';
 import { resolveProvider } from '../provision/provider-catalog.js';
@@ -16,6 +17,15 @@ import { cliVersion } from '../version.js';
 export interface BuildProviderSetupOptions {
   readonly session: Session;
   readonly vault: VaultStore;
+  /** Merged configuration used to construct the effective auth context for each provider. */
+  readonly config?: MoxxyConfig;
+}
+
+function providerAuthConfig(
+  config: MoxxyConfig | undefined,
+  providerId: string,
+): Readonly<Record<string, unknown>> {
+  return config?.plugins?.provider?.items?.[providerId]?.config ?? {};
 }
 
 /**
@@ -26,7 +36,7 @@ export interface BuildProviderSetupOptions {
  * provider activation in setup.ts; a RemoteSession never gets one.
  */
 export function buildProviderSetupView(opts: BuildProviderSetupOptions): ProviderSetupView {
-  const { session, vault } = opts;
+  const { session, vault, config } = opts;
 
   const registered = (providerId: string) =>
     session.providers.list().find((p) => p.name === providerId);
@@ -91,9 +101,10 @@ export function buildProviderSetupView(opts: BuildProviderSetupOptions): Provide
       // browser choice) AND the provider declared `supportsHeadless`. Defaults to
       // the interactive browser flow.
       const headless = opts?.headless === true;
+      const effectiveProviderConfig = providerAuthConfig(config, providerId);
       const ctx = io
-        ? channelAuthContext(vault, io, headless)
-        : buildProviderAuthContext(vault, { headless });
+        ? channelAuthContext(vault, io, headless, effectiveProviderConfig)
+        : buildProviderAuthContext(vault, { headless, providerConfig: effectiveProviderConfig });
       const result = await def.auth.login(ctx);
       markReady(providerId);
       return result;
@@ -112,9 +123,11 @@ function channelAuthContext(
   vault: VaultStore,
   io: ProviderConnectIo,
   headless = false,
+  providerConfig: Readonly<Record<string, unknown>> = {},
 ): ProviderAuthContext {
   return {
     headless,
+    providerConfig,
     write: io.write,
     ...(io.prompt ? { prompt: io.prompt } : {}),
     vault: {

--- a/packages/cli/src/wizard/auth-context.ts
+++ b/packages/cli/src/wizard/auth-context.ts
@@ -12,6 +12,8 @@ import { isCancel, password, text } from '@clack/prompts';
 
 export interface BuildAuthContextOptions {
   readonly headless: boolean;
+  /** Effective provider configuration, used by auth surfaces such as Claude CLI executable selection. */
+  readonly providerConfig?: Readonly<Record<string, unknown>>;
   /** Defaults to writing through `process.stdout`. Wizard hosts pass a clack-aware writer. */
   readonly write?: (chunk: string) => void;
   /**
@@ -46,6 +48,7 @@ export function buildProviderAuthContext(
         : clackPrompt;
   return {
     headless: opts.headless,
+    ...(opts.providerConfig ? { providerConfig: opts.providerConfig } : {}),
     write: opts.write ?? ((s) => process.stdout.write(s)),
     ...(prompt ? { prompt } : {}),
     vault: {

--- a/packages/plugin-provider-claude-code/src/constants.ts
+++ b/packages/plugin-provider-claude-code/src/constants.ts
@@ -1,46 +1,16 @@
-/**
- * Constants for the Claude subscription (Pro/Max) provider.
- *
- * These are the public Claude Code OAuth client parameters — the same values
- * the `claude` CLI uses — so a token minted here interoperates with one from
- * `claude setup-token`, and vice-versa. We never embed a client secret; the
- * flow is PKCE + an out-of-band (manual paste) authorization code.
- */
-
-/** Provider name in the registry / `/model` picker / `provider.name` config. */
+/** Provider name in the registry / model picker / provider config. */
 export const CLAUDE_CODE_PROVIDER_ID = 'claude-code';
 
-/** Human-readable upstream service, shown in `moxxy login` and the init wizard. */
-export const CLAUDE_CODE_SERVICE_NAME = 'Claude (Pro/Max subscription)';
+/** Human-readable upstream service, shown in login and setup surfaces. */
+export const CLAUDE_CODE_SERVICE_NAME = 'Claude Code subscription';
 
-export const CLAUDE_AUTHORIZE_URL = 'https://claude.ai/oauth/authorize';
-export const CLAUDE_TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token';
-export const CLAUDE_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
-/**
- * Out-of-band redirect: after consent, Anthropic shows the user a
- * `code#state` string to paste back into the terminal (no loopback server).
- */
-export const CLAUDE_REDIRECT_URI = 'https://console.anthropic.com/oauth/code/callback';
-export const CLAUDE_SCOPES = ['org:create_api_key', 'user:profile', 'user:inference'] as const;
+/** Optional executable override for login/status surfaces that do not carry provider config. */
+export const CLAUDE_CODE_EXECUTABLE_ENV = 'CLAUDE_CODE_EXECUTABLE';
 
-/**
- * `anthropic-beta` values sent with every request. `oauth-2025-04-20` is the
- * flag that makes the Messages API accept a subscription bearer token at all;
- * `claude-code-20250219` matches what the real CLI sends. Sent comma-joined.
- */
-export const CLAUDE_OAUTH_BETA = ['oauth-2025-04-20', 'claude-code-20250219'] as const;
+/** Supported Claude Code authentication commands. Arguments stay separate from the executable. */
+export const CLAUDE_AUTH_STATUS_ARGS = ['auth', 'status'] as const;
+export const CLAUDE_AUTH_LOGIN_ARGS = ['auth', 'login'] as const;
+export const CLAUDE_AUTH_LOGOUT_ARGS = ['auth', 'logout'] as const;
 
-/**
- * Required first system block. Claude rejects a subscription token unless the
- * system prompt leads with this exact identity line; moxxy's real system
- * prompt is appended as the following block. (Verified against the working
- * opencode / claude-code-router behaviour.)
- */
+/** Required identity line used by the CLI transport. */
 export const CLAUDE_CODE_SYSTEM = "You are Claude Code, Anthropic's official CLI for Claude.";
-
-/**
- * Env vars a pasted/CI token can arrive through. `CLAUDE_CODE_OAUTH_TOKEN` is
- * what `claude setup-token` documents; `ANTHROPIC_AUTH_TOKEN` is the
- * SDK-native bearer var. Checked in this order.
- */
-export const CLAUDE_TOKEN_ENV_VARS = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_AUTH_TOKEN'] as const;

--- a/packages/plugin-provider-claude-code/src/index.ts
+++ b/packages/plugin-provider-claude-code/src/index.ts
@@ -11,8 +11,7 @@ export const claudeCodeProviderDef = defineProvider({
   name: CLAUDE_CODE_PROVIDER_ID,
   models: claudeCodeModels,
   createClient: (config) => createClaudeCodeClient(config as ClaudeCodeProviderConfig),
-  // No validateKey: an OAuth bearer is validated by the request itself, and
-  // an interactive paste/sign-in already proves the token round-trips.
+  // No validateKey: readiness is reported by the installed Claude CLI.
   auth: {
     kind: 'oauth',
     serviceName: CLAUDE_CODE_SERVICE_NAME,
@@ -34,15 +33,17 @@ export {
   CLAUDE_CODE_PROVIDER_ID,
   CLAUDE_CODE_SERVICE_NAME,
   CLAUDE_CODE_SYSTEM,
-  CLAUDE_OAUTH_BETA,
-  CLAUDE_TOKEN_ENV_VARS,
+  CLAUDE_CODE_EXECUTABLE_ENV,
 } from './constants.js';
 export {
   claudeLogin,
   claudeLogout,
   claudeStatus,
-  ensureFreshClaudeTokens,
-  refreshClaudeAccessToken,
-  type FreshClaudeTokens,
+  checkClaudeCliAuth,
+  resolveClaudeExecutable,
+  type ClaudeCliAuthStatus,
+  type ClaudeCliAuthState,
+  type ClaudeCommandResult,
+  __setClaudeCommandRunner,
 } from './login.js';
 export { claudeCodeModels, createClaudeCodeClient, type ClaudeCodeProviderConfig } from './provider.js';

--- a/packages/plugin-provider-claude-code/src/login.test.ts
+++ b/packages/plugin-provider-claude-code/src/login.test.ts
@@ -1,444 +1,115 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { promises as fs } from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
-import { storeTokenSet, type OAuthVault } from '@moxxy/plugin-oauth';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
 import type { ProviderAuthContext } from '@moxxy/sdk';
-import { assertDefined } from '@moxxy/sdk';
-import { CLAUDE_CLIENT_ID, CLAUDE_TOKEN_URL } from './constants.js';
 import {
+  __setClaudeCommandRunner,
+  checkClaudeCliAuth,
   claudeLogin,
   claudeLogout,
   claudeStatus,
-  ensureFreshClaudeTokens,
-  refreshClaudeAccessToken,
-  __setClaudeFetch,
-  __setClaudeOpenBrowser,
-  __setClaudeSleep,
-  __setClaudeTimeoutMs,
+  resolveClaudeExecutable,
 } from './login.js';
 
-interface FakeVault extends OAuthVault {
-  readonly store: Map<string, string>;
-}
-
-function makeVault(): FakeVault {
+function ctx(): ProviderAuthContext {
   const store = new Map<string, string>();
   return {
-    store,
-    get: async (k) => store.get(k) ?? null,
-    set: async (k, v) => {
-      store.set(k, v);
-    },
-    delete: async (k) => store.delete(k),
-  };
-}
-
-function makeCtx(vault: OAuthVault, answers: string[]): ProviderAuthContext {
-  const queue = [...answers];
-  return {
-    vault,
     headless: false,
     write: () => {},
-    prompt: async () => queue.shift() ?? '',
+    vault: {
+      get: async (key) => store.get(key) ?? null,
+      set: async (key, value) => { store.set(key, value); },
+      delete: async (key) => store.delete(key),
+    },
   };
 }
 
-function jsonResponse(obj: unknown, status = 200): Response {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => obj,
-    text: async () => JSON.stringify(obj),
-  } as unknown as Response;
-}
-
-const META = { clientId: CLAUDE_CLIENT_ID, tokenUrl: CLAUDE_TOKEN_URL };
-
-// The refresh path takes a cross-process lockfile under `<moxxy home>/locks`;
-// point MOXXY_HOME at a temp dir so tests never touch the real ~/.moxxy.
-let moxxyHomeTmp: string;
-const priorMoxxyHome = process.env.MOXXY_HOME;
-beforeAll(async () => {
-  moxxyHomeTmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-claude-login-'));
-  process.env.MOXXY_HOME = moxxyHomeTmp;
-});
-afterAll(async () => {
-  if (priorMoxxyHome === undefined) delete process.env.MOXXY_HOME;
-  else process.env.MOXXY_HOME = priorMoxxyHome;
-  await fs.rm(moxxyHomeTmp, { recursive: true, force: true });
-});
+const ok = (stdout = '', code = 0) => Promise.resolve({ code, stdout, stderr: '' });
 
 beforeEach(() => {
-  __setClaudeOpenBrowser(async () => {});
-  __setClaudeSleep(async () => {}); // don't actually back off under test
-  __setClaudeTimeoutMs(50); // bound the hung-connection tests; default is 30s
-  __setClaudeFetch(async () => {
-    throw new Error('unexpected fetch — a test forgot to stub __setClaudeFetch');
-  });
+  delete process.env.CLAUDE_CODE_EXECUTABLE;
 });
-
-/**
- * A fetch that respects the `AbortSignal` exactly like the real one: it never
- * resolves on its own, so it only settles when the per-attempt deadline aborts
- * it (mirroring a half-open socket / black-holing proxy).
- */
-function hangingFetch(): typeof fetch {
-  return ((_url, init) =>
-    new Promise((_resolve, reject) => {
-      const signal = (init as { signal?: AbortSignal } | undefined)?.signal;
-      if (signal?.aborted) {
-        reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
-        return;
-      }
-      signal?.addEventListener('abort', () => {
-        reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
-      });
-    })) as typeof fetch;
-}
 
 afterAll(() => {
-  __setClaudeFetch(fetch);
-  __setClaudeTimeoutMs(30_000);
+  __setClaudeCommandRunner(async () => ({ code: 1, stdout: '', stderr: 'not configured' }));
 });
 
-describe('claudeLogin', () => {
-  it('stores a pasted `setup-token` verbatim, with no refresh token', async () => {
-    const vault = makeVault();
-    const res = await claudeLogin(makeCtx(vault, ['sk-ant-oat-PASTED']));
-    expect(vault.store.get('oauth/claude-code/access_token')).toBe('sk-ant-oat-PASTED');
-    expect(vault.store.has('oauth/claude-code/refresh_token')).toBe(false);
-    expect(res).toEqual({});
-  });
-
-  it('runs the out-of-band flow and exchanges the pasted code for tokens', async () => {
-    const vault = makeVault();
-    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
-    __setClaudeFetch(async (url, init) => {
-      calls.push({ url: String(url), body: JSON.parse(String(init?.body ?? '{}')) });
-      return jsonResponse({
-        access_token: 'access-1',
-        refresh_token: 'refresh-1',
-        expires_in: 3600,
-        token_type: 'Bearer',
-        account: { email_address: 'me@example.com' },
-      });
+describe('Claude CLI authentication', () => {
+  it('accepts an already authenticated CLI without invoking login', async () => {
+    const calls: string[][] = [];
+    __setClaudeCommandRunner(async (_exe, args) => {
+      calls.push([...args]);
+      return ok(JSON.stringify({ loggedIn: true, email: 'me@example.com' }));
     });
+    await expect(claudeLogin(ctx())).resolves.toEqual({ accountId: 'me@example.com' });
+    expect(calls).toEqual([['auth', 'status']]);
+  });
 
-    // First prompt empty => browser flow; second prompt => the auth code.
-    const res = await claudeLogin(makeCtx(vault, ['', 'AUTHCODE']));
-
-    expect(calls).toHaveLength(1);
-    const call0 = calls[0];
-    assertDefined(call0, 'one call asserted above');
-    expect(call0.url).toBe(CLAUDE_TOKEN_URL);
-    expect(call0.body).toMatchObject({
-      grant_type: 'authorization_code',
-      code: 'AUTHCODE',
-      client_id: CLAUDE_CLIENT_ID,
-      redirect_uri: 'https://console.anthropic.com/oauth/code/callback',
+  it('invokes the CLI login flow when signed out and verifies the result', async () => {
+    const calls: string[][] = [];
+    __setClaudeCommandRunner(async (_exe, args) => {
+      calls.push([...args]);
+      if (args[1] === 'login') return ok();
+      return ok(JSON.stringify({ loggedIn: calls.length > 2, account: 'subscriber@example.com' }));
     });
-    expect(typeof call0.body.code_verifier).toBe('string');
-    expect(vault.store.get('oauth/claude-code/access_token')).toBe('access-1');
-    expect(vault.store.get('oauth/claude-code/refresh_token')).toBe('refresh-1');
-    expect(vault.store.get('oauth/claude-code/extras')).toContain('me@example.com');
-    expect(res.accountId).toBe('me@example.com');
-  });
-
-  it('retries a transient 5xx from the token endpoint and then succeeds', async () => {
-    const vault = makeVault();
-    let calls = 0;
-    __setClaudeFetch(async () => {
-      calls++;
-      if (calls < 3) return jsonResponse({ error: { type: 'api_error', message: 'Internal server error' } }, 500);
-      return jsonResponse({ access_token: 'access-after-retry', token_type: 'Bearer', expires_in: 3600 });
-    });
-
-    const res = await claudeLogin(makeCtx(vault, ['', 'AUTHCODE']));
-
-    expect(calls).toBe(3); // two 500s, third attempt wins
-    expect(vault.store.get('oauth/claude-code/access_token')).toBe('access-after-retry');
-    expect(res.expiresAt).toBeGreaterThan(0);
-  });
-
-  it('does NOT retry a deterministic 4xx — surfaces it immediately', async () => {
-    const vault = makeVault();
-    let calls = 0;
-    __setClaudeFetch(async () => {
-      calls++;
-      return jsonResponse({ error: { type: 'invalid_request', message: 'invalid_grant' } }, 400);
-    });
-
-    await expect(claudeLogin(makeCtx(vault, ['', 'AUTHCODE']))).rejects.toThrow(/HTTP 400/);
-    expect(calls).toBe(1);
-  });
-
-  it('gives a transient-retry hint after exhausting attempts on persistent 5xx', async () => {
-    const vault = makeVault();
-    let calls = 0;
-    __setClaudeFetch(async () => {
-      calls++;
-      return jsonResponse({ error: { type: 'api_error', message: 'Internal server error' } }, 500);
-    });
-
-    await expect(claudeLogin(makeCtx(vault, ['', 'AUTHCODE']))).rejects.toThrow(/after 3 attempts/);
-    expect(calls).toBe(3);
-  });
-
-  it('splits a pasted `code#state` and rejects a mismatched state', async () => {
-    const vault = makeVault();
-    // The internally-generated state will never equal "WRONG", so this must throw.
-    await expect(claudeLogin(makeCtx(vault, ['', 'THECODE#WRONGSTATE']))).rejects.toThrow(/state/i);
-  });
-
-  it('omits expiresAt entirely for a pasted setup-token (no false "expired")', async () => {
-    const vault = makeVault();
-    const res = await claudeLogin(makeCtx(vault, ['sk-ant-oat-PASTED']));
-    // Absent expiry must be omitted, not collapsed to 0 (which reads as expired).
-    expect('expiresAt' in res).toBe(false);
-  });
-
-  it('omits expiresAt when the token response has no expires_in', async () => {
-    const vault = makeVault();
-    __setClaudeFetch(async () =>
-      jsonResponse({ access_token: 'access-noexp', refresh_token: 'r', token_type: 'Bearer' }),
-    );
-    const res = await claudeLogin(makeCtx(vault, ['', 'AUTHCODE']));
-    expect(res.accountId).toBeUndefined();
-    expect('expiresAt' in res).toBe(false);
-  });
-
-  it('treats a 200 with a non-JSON body as transient and retries', async () => {
-    const vault = makeVault();
-    let calls = 0;
-    __setClaudeFetch(async () => {
-      calls++;
-      if (calls < 2) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => {
-            throw new SyntaxError('Unexpected token < in JSON');
-          },
-          text: async () => '<html>captive portal</html>',
-        } as unknown as Response;
-      }
-      return jsonResponse({ access_token: 'recovered', token_type: 'Bearer', expires_in: 3600 });
-    });
-
-    const res = await claudeLogin(makeCtx(vault, ['', 'AUTHCODE']));
-    expect(calls).toBe(2); // bad 200 retried, second attempt wins
-    expect(vault.store.get('oauth/claude-code/access_token')).toBe('recovered');
-    expect(res.expiresAt).toBeGreaterThan(0);
-  });
-
-  it('surfaces a transient-retry hint when every 200 body is non-JSON', async () => {
-    const vault = makeVault();
-    let calls = 0;
-    __setClaudeFetch(async () => {
-      calls++;
-      return {
-        ok: true,
-        status: 200,
-        json: async () => {
-          throw new SyntaxError('Unexpected token < in JSON');
-        },
-        text: async () => '',
-      } as unknown as Response;
-    });
-    await expect(claudeLogin(makeCtx(vault, ['', 'AUTHCODE']))).rejects.toThrow(/after 3 attempts/);
-    expect(calls).toBe(3);
-  });
-
-  it('treats a 200 JSON primitive/array body as transient and retries', async () => {
-    const vault = makeVault();
-    let calls = 0;
-    __setClaudeFetch(async () => {
-      calls++;
-      if (calls < 2) return jsonResponse([] as unknown, 200); // array, not an object
-      return jsonResponse({ access_token: 'after-array', token_type: 'Bearer', expires_in: 3600 });
-    });
-    const res = await claudeLogin(makeCtx(vault, ['', 'AUTHCODE']));
-    expect(calls).toBe(2);
-    expect(res.expiresAt).toBeGreaterThan(0);
-  });
-
-  it('aborts a hung connection on the per-attempt deadline and retries', async () => {
-    const vault = makeVault();
-    const hang = hangingFetch();
-    let calls = 0;
-    __setClaudeFetch(async (url, init) => {
-      calls++;
-      // First attempt: a half-open socket that never responds — must be aborted
-      // by the deadline (not hang forever), reclassified as a transient, retried.
-      if (calls < 2) return hang(url, init);
-      return jsonResponse({ access_token: 'after-timeout', token_type: 'Bearer', expires_in: 3600 });
-    });
-
-    const res = await claudeLogin(makeCtx(vault, ['', 'AUTHCODE']));
-    expect(calls).toBe(2);
-    expect(vault.store.get('oauth/claude-code/access_token')).toBe('after-timeout');
-    expect(res.expiresAt).toBeGreaterThan(0);
-  });
-
-  it('surfaces the transient-retry hint when every attempt hangs past the deadline', async () => {
-    const vault = makeVault();
-    const hang = hangingFetch();
-    let calls = 0;
-    __setClaudeFetch((url, init) => {
-      calls++;
-      return hang(url, init);
-    });
-    await expect(claudeLogin(makeCtx(vault, ['', 'AUTHCODE']))).rejects.toThrow(/after 3 attempts/);
-    expect(calls).toBe(3);
-  });
-
-  it('refuses without a TTY prompt', async () => {
-    const vault = makeVault();
-    const ctx: ProviderAuthContext = { vault, headless: true, write: () => {} };
-    await expect(claudeLogin(ctx)).rejects.toThrow(/interactive terminal/i);
-  });
-});
-
-describe('token lifecycle', () => {
-  it('ensureFreshClaudeTokens returns null when nothing is stored', async () => {
-    expect(await ensureFreshClaudeTokens(makeVault())).toBeNull();
-  });
-
-  it('ensureFreshClaudeTokens returns a non-expired token without refreshing', async () => {
-    const vault = makeVault();
-    await storeTokenSet(
-      vault,
-      'claude-code',
-      { accessToken: 'a', refreshToken: 'r', expiresAt: Date.now() + 3_600_000, tokenType: 'Bearer' },
-      META,
-    );
-    // __setClaudeFetch is the throwing default — proving no refresh happens.
-    const fresh = await ensureFreshClaudeTokens(vault);
-    expect(fresh).toMatchObject({ accessToken: 'a', canRefresh: true });
-  });
-
-  it('ensureFreshClaudeTokens refreshes + persists when expired', async () => {
-    const vault = makeVault();
-    await storeTokenSet(
-      vault,
-      'claude-code',
-      { accessToken: 'old', refreshToken: 'r-old', expiresAt: Date.now() - 1000, tokenType: 'Bearer' },
-      META,
-    );
-    __setClaudeFetch(async (_url, init) => {
-      expect(JSON.parse(String(init?.body ?? '{}'))).toMatchObject({
-        grant_type: 'refresh_token',
-        refresh_token: 'r-old',
-      });
-      return jsonResponse({ access_token: 'new', refresh_token: 'r-new', expires_in: 3600, token_type: 'Bearer' });
-    });
-    const fresh = await ensureFreshClaudeTokens(vault);
-    expect(fresh?.accessToken).toBe('new');
-    // Rotated refresh token persisted before returning.
-    expect(vault.store.get('oauth/claude-code/refresh_token')).toBe('r-new');
-  });
-
-  it('coalesces concurrent refreshes — one IdP call, both consumers get the rotated token', async () => {
-    const vault = makeVault();
-    await storeTokenSet(
-      vault,
-      'claude-code',
-      { accessToken: 'old', refreshToken: 'r-old', expiresAt: Date.now() - 1000, tokenType: 'Bearer' },
-      META,
-    );
-    let refreshCalls = 0;
-    __setClaudeFetch(async () => {
-      refreshCalls++;
-      return jsonResponse({ access_token: 'new', refresh_token: 'r-new', expires_in: 3600, token_type: 'Bearer' });
-    });
-
-    const [a, b] = await Promise.all([
-      ensureFreshClaudeTokens(vault),
-      ensureFreshClaudeTokens(vault),
+    await expect(claudeLogin(ctx())).resolves.toEqual({ accountId: 'subscriber@example.com' });
+    expect(calls).toEqual([
+      ['auth', 'status'],
+      ['auth', 'login'],
+      ['auth', 'status'],
     ]);
-
-    // The single-use refresh_token must be burned exactly once; the loser of
-    // the race re-reads the winner's rotated bundle under the lock.
-    expect(refreshCalls).toBe(1);
-    expect(a?.accessToken).toBe('new');
-    expect(b?.accessToken).toBe('new');
-    expect(vault.store.get('oauth/claude-code/refresh_token')).toBe('r-new');
   });
 
-  it('recovers from invalid_grant by retrying once with the refresh_token another process rotated in', async () => {
-    const vault = makeVault();
-    await storeTokenSet(
-      vault,
-      'claude-code',
-      { accessToken: 'old', refreshToken: 'r-dead', expiresAt: Date.now() - 1000, tokenType: 'Bearer' },
-      META,
-    );
-    const attempted: string[] = [];
-    __setClaudeFetch(async (_url, init) => {
-      const body = JSON.parse(String(init?.body ?? '{}')) as { refresh_token?: string };
-      attempted.push(body.refresh_token ?? '');
-      if (body.refresh_token === 'r-dead') {
-        // Simulate the cross-process race: another moxxy already rotated the
-        // stored bundle, so OUR copy of the refresh token is single-use-spent.
-        vault.store.set('oauth/claude-code/refresh_token', 'r-fresh');
-        return jsonResponse({ error: 'invalid_grant' }, 400);
-      }
-      return jsonResponse({ access_token: 'new-2', refresh_token: 'r-next', expires_in: 3600, token_type: 'Bearer' });
+  it('keeps executable paths containing spaces as one spawn argument', async () => {
+    process.env.CLAUDE_CODE_EXECUTABLE = '/Applications/Claude Code/bin/claude';
+    const executables: string[] = [];
+    __setClaudeCommandRunner(async (exe) => {
+      executables.push(exe);
+      return ok('{"loggedIn":true}');
     });
-
-    const res = await refreshClaudeAccessToken(vault);
-
-    expect(attempted).toEqual(['r-dead', 'r-fresh']);
-    expect(res.token).toBe('new-2');
-    expect(vault.store.get('oauth/claude-code/refresh_token')).toBe('r-next');
+    await claudeLogin(ctx());
+    expect(executables).toEqual(['/Applications/Claude Code/bin/claude']);
+    expect(resolveClaudeExecutable({ executable: '/a path/claude' })).toBe('/a path/claude');
   });
 
-  it('does NOT retry an invalid_grant when the stored refresh_token is unchanged (true re-auth case)', async () => {
-    const vault = makeVault();
-    await storeTokenSet(
-      vault,
-      'claude-code',
-      { accessToken: 'old', refreshToken: 'r-revoked', expiresAt: Date.now() - 1000, tokenType: 'Bearer' },
-      META,
-    );
+  it('distinguishes a missing executable', async () => {
+    __setClaudeCommandRunner(async () => ({
+      code: 1, stdout: '', stderr: '', error: Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }),
+    }));
+    const status = await checkClaudeCliAuth('/missing/claude');
+    expect(status.state).toBe('missing');
+    expect(status.message).toMatch(/Install Claude Code/);
+  });
+
+  it('distinguishes signed-out and signed-in states', async () => {
+    __setClaudeCommandRunner(async () => ok('{"loggedIn":false}'));
+    await expect(claudeStatus(ctx())).resolves.toMatchObject({ authState: 'signed-out' });
+    __setClaudeCommandRunner(async () => ok('{"loggedIn":true,"email":"x@y.test"}'));
+    await expect(claudeStatus(ctx())).resolves.toMatchObject({ authState: 'signed-in', accountId: 'x@y.test' });
+  });
+
+  it('reports unsupported CLI versions actionably', async () => {
+    __setClaudeCommandRunner(async () => ({ code: 1, stdout: '', stderr: 'unknown command auth' }));
+    const status = await checkClaudeCliAuth();
+    expect(status.state).toBe('unsupported');
+    expect(status.message).toMatch(/Update Claude Code/);
+  });
+
+  it('surfaces command failures without treating them as signed-out', async () => {
+    __setClaudeCommandRunner(async () => ({ code: 2, stdout: '', stderr: 'config is corrupt' }));
+    const status = await checkClaudeCliAuth();
+    expect(status.state).toBe('error');
+    await expect(claudeLogin(ctx())).rejects.toThrow(/config is corrupt/);
+  });
+
+  it('logs out through the CLI without touching legacy vault entries', async () => {
+    const context = ctx();
+    await context.vault.set('oauth/claude-code/access_token', 'legacy-secret');
     let calls = 0;
-    __setClaudeFetch(async () => {
+    __setClaudeCommandRunner(async (_exe, args) => {
       calls++;
-      return jsonResponse({ error: 'invalid_grant' }, 400);
+      return args[1] === 'logout' ? ok() : ok('{"loggedIn":true}');
     });
-    await expect(refreshClaudeAccessToken(vault)).rejects.toThrow(/HTTP 400/);
-    expect(calls).toBe(1);
-  });
-
-  it('refreshClaudeAccessToken throws when no refresh_token is stored', async () => {
-    const vault = makeVault();
-    await storeTokenSet(vault, 'claude-code', { accessToken: 'a', tokenType: 'Bearer' }, META);
-    await expect(refreshClaudeAccessToken(vault)).rejects.toThrow(/refresh/i);
-  });
-
-  it('claudeStatus / claudeLogout report and clear stored creds', async () => {
-    const vault = makeVault();
-    const ctx = makeCtx(vault, []);
-    await storeTokenSet(
-      vault,
-      'claude-code',
-      { accessToken: 'a', expiresAt: Date.now() + 1000, tokenType: 'Bearer' },
-      { ...META, extras: { account_email: 'me@example.com' } },
-    );
-    const status = await claudeStatus(ctx);
-    expect(status).toMatchObject({ accountId: 'me@example.com' });
-    expect(await claudeLogout(ctx)).toBe(true);
-    expect(await claudeStatus(ctx)).toBeNull();
-  });
-
-  it('claudeStatus omits expiresAt for a stored setup-token (no false "expired")', async () => {
-    const vault = makeVault();
-    const ctx = makeCtx(vault, []);
-    // A pasted setup-token has no expiry — status must not surface 0/epoch.
-    await storeTokenSet(vault, 'claude-code', { accessToken: 'a', tokenType: 'Bearer' }, META);
-    const status = await claudeStatus(ctx);
-    expect(status).not.toBeNull();
-    expect('expiresAt' in (status as object)).toBe(false);
+    await expect(claudeLogout(context)).resolves.toBe(true);
+    expect(await context.vault.get('oauth/claude-code/access_token')).toBe('legacy-secret');
+    expect(calls).toBe(2);
   });
 });

--- a/packages/plugin-provider-claude-code/src/login.test.ts
+++ b/packages/plugin-provider-claude-code/src/login.test.ts
@@ -9,10 +9,11 @@ import {
   resolveClaudeExecutable,
 } from './login.js';
 
-function ctx(): ProviderAuthContext {
+function ctx(providerConfig?: Readonly<Record<string, unknown>>): ProviderAuthContext {
   const store = new Map<string, string>();
   return {
     headless: false,
+    ...(providerConfig ? { providerConfig } : {}),
     write: () => {},
     vault: {
       get: async (key) => store.get(key) ?? null,
@@ -58,16 +59,35 @@ describe('Claude CLI authentication', () => {
     ]);
   });
 
-  it('keeps executable paths containing spaces as one spawn argument', async () => {
-    process.env.CLAUDE_CODE_EXECUTABLE = '/Applications/Claude Code/bin/claude';
-    const executables: string[] = [];
-    __setClaudeCommandRunner(async (exe) => {
-      executables.push(exe);
-      return ok('{"loggedIn":true}');
+  it('uses a configured executable path containing spaces in every auth surface', async () => {
+    process.env.CLAUDE_CODE_EXECUTABLE = '/wrong/path/claude';
+    const executable = '/Applications/Claude Code/bin/claude';
+    const calls: Array<{ executable: string; args: readonly string[] }> = [];
+    __setClaudeCommandRunner(async (seenExecutable, args) => {
+      calls.push({ executable: seenExecutable, args });
+      return args[1] === 'logout' ? ok() : ok('{"loggedIn":true}');
     });
-    await claudeLogin(ctx());
-    expect(executables).toEqual(['/Applications/Claude Code/bin/claude']);
+    await claudeLogin(ctx({ executable }));
+    await claudeStatus(ctx({ executable }));
+    await claudeLogout(ctx({ executable }));
+    expect(calls.map((call) => call.executable)).toEqual([executable, executable, executable, executable]);
+    expect(calls.map((call) => call.args)).toEqual([
+      ['auth', 'status'],
+      ['auth', 'status'],
+      ['auth', 'status'],
+      ['auth', 'logout'],
+    ]);
     expect(resolveClaudeExecutable({ executable: '/a path/claude' })).toBe('/a path/claude');
+  });
+
+  it('does not accept signed-in JSON from a failed status command', async () => {
+    __setClaudeCommandRunner(async () => ({ code: 2, stdout: '{"loggedIn":true}', stderr: 'status failed' }));
+    await expect(checkClaudeCliAuth()).resolves.toMatchObject({ state: 'error' });
+  });
+
+  it('preserves signed-out JSON from a non-zero status command', async () => {
+    __setClaudeCommandRunner(async () => ({ code: 1, stdout: '{"loggedIn":false}', stderr: '' }));
+    await expect(checkClaudeCliAuth()).resolves.toMatchObject({ state: 'signed-out' });
   });
 
   it('distinguishes a missing executable', async () => {

--- a/packages/plugin-provider-claude-code/src/login.ts
+++ b/packages/plugin-provider-claude-code/src/login.ts
@@ -1,31 +1,4 @@
-/**
- * Claude subscription login + token lifecycle.
- *
- * Claude's OAuth is an out-of-band (manual code-paste) authorization-code +
- * PKCE flow whose token endpoint speaks JSON (not the form-encoded dialect
- * the framework's `exchangeCodeForToken` / `refreshAccessToken` assume), so
- * the HTTP exchange + refresh are implemented here. Everything else is reused
- * from `@moxxy/plugin-oauth`: PKCE, the auth-URL builder, the browser opener,
- * vault storage layout, and `parseTokenResponse`.
- */
-
-import {
-  buildAuthUrl,
-  clearStoredCreds,
-  computeCodeChallenge,
-  generateCodeVerifier,
-  generateState,
-  isAuthRejection,
-  isExpired,
-  openInBrowser,
-  parseTokenResponse,
-  readStoredCreds,
-  storeTokenSet,
-  withCredentialLock,
-  type OAuthVault,
-  type StoredCreds,
-  type TokenSet,
-} from '@moxxy/plugin-oauth';
+import { spawn, type SpawnOptions } from 'node:child_process';
 import { MoxxyError } from '@moxxy/sdk';
 import type {
   ProviderAuthContext,
@@ -33,394 +6,182 @@ import type {
   ProviderOAuthStatus,
 } from '@moxxy/sdk';
 import {
-  CLAUDE_AUTHORIZE_URL,
-  CLAUDE_CLIENT_ID,
+  CLAUDE_AUTH_LOGIN_ARGS,
+  CLAUDE_AUTH_LOGOUT_ARGS,
+  CLAUDE_AUTH_STATUS_ARGS,
+  CLAUDE_CODE_EXECUTABLE_ENV,
   CLAUDE_CODE_PROVIDER_ID,
-  CLAUDE_CODE_SERVICE_NAME,
-  CLAUDE_REDIRECT_URI,
-  CLAUDE_SCOPES,
-  CLAUDE_TOKEN_URL,
 } from './constants.js';
 
-const PASTE_PROMPT =
-  'Paste a token from `claude setup-token` (or press Enter to sign in via browser): ';
-const CODE_PROMPT = 'Paste the authorization code shown after you approve: ';
+export type ClaudeCliAuthState = 'signed-in' | 'signed-out' | 'missing' | 'unsupported' | 'error';
 
-/**
- * Drive an interactive Claude sign-in. Two ways in, both through one command:
- *   1. paste an existing `claude setup-token` token (stored verbatim), or
- *   2. press Enter to run the browser out-of-band authorization-code flow.
- * Needs `ctx.prompt` (a TTY); headless callers use `CLAUDE_CODE_OAUTH_TOKEN`.
- */
-export async function claudeLogin(ctx: ProviderAuthContext): Promise<ProviderOAuthResult> {
-  if (!ctx.prompt) {
-    throw new MoxxyError({
-      code: 'OAUTH_FLOW_NOT_SUPPORTED',
-      message: 'Claude sign-in needs an interactive terminal.',
-      hint:
-        'Run `claude setup-token` and set CLAUDE_CODE_OAUTH_TOKEN, or run ' +
-        '`moxxy login claude-code` in a terminal.',
-      context: { provider: CLAUDE_CODE_PROVIDER_ID },
-    });
+export interface ClaudeCliAuthStatus {
+  readonly state: ClaudeCliAuthState;
+  readonly executable: string;
+  readonly accountId?: string;
+  readonly message: string;
+}
+
+export interface ClaudeCommandResult {
+  readonly code: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly error?: NodeJS.ErrnoException;
+}
+
+type CommandRunner = (
+  executable: string,
+  args: readonly string[],
+  options?: { readonly inherit?: boolean },
+) => Promise<ClaudeCommandResult>;
+
+let runCommandImpl: CommandRunner = runCommand;
+/** Test seam. */
+export function __setClaudeCommandRunner(runner: CommandRunner): void {
+  runCommandImpl = runner;
+}
+
+/** Resolve the executable without involving a shell (paths containing spaces are safe). */
+export function resolveClaudeExecutable(config: Record<string, unknown> = {}): string {
+  const configured = config.executable;
+  if (typeof configured === 'string' && configured.trim()) return configured;
+  return process.env[CLAUDE_CODE_EXECUTABLE_ENV]?.trim() || 'claude';
+}
+
+/** Probe the installed CLI's supported, machine-readable authentication command. */
+export async function checkClaudeCliAuth(executable = resolveClaudeExecutable()): Promise<ClaudeCliAuthStatus> {
+  const result = await runCommandImpl(executable, CLAUDE_AUTH_STATUS_ARGS);
+  if (result.error?.code === 'ENOENT') {
+    return {
+      state: 'missing', executable,
+      message: `Claude CLI executable not found: ${executable}. Install Claude Code or set ${CLAUDE_CODE_EXECUTABLE_ENV}.`,
+    };
+  }
+  if (result.error) {
+    return { state: 'error', executable, message: `Could not run Claude CLI: ${result.error.message}` };
   }
 
-  const pasted = (await ctx.prompt(PASTE_PROMPT, { mask: true })).trim();
-  if (pasted) {
-    // A `setup-token` is a long-lived bearer with no refresh token; store it
-    // as-is. `isExpired` treats a missing expiry as non-expiring.
-    await storeTokenSet(
-      ctx.vault,
-      CLAUDE_CODE_PROVIDER_ID,
-      { accessToken: pasted, tokenType: 'Bearer' },
-      { clientId: CLAUDE_CLIENT_ID, tokenUrl: CLAUDE_TOKEN_URL },
-    );
-    ctx.write('\nStored your Claude token.\n');
-    return {};
+  const combined = `${result.stdout}\n${result.stderr}`.trim();
+  const parsed = parseStatusOutput(result.stdout);
+  if (parsed) {
+    if (parsed.loggedIn) {
+      return {
+        state: 'signed-in', executable,
+        ...(parsed.accountId ? { accountId: parsed.accountId } : {}),
+        message: `Claude CLI is signed in${parsed.accountId ? ` as ${parsed.accountId}` : ''}.`,
+      };
+    }
+    return { state: 'signed-out', executable, message: 'Claude CLI is installed but signed out. Run `moxxy login claude-code`.' };
   }
 
-  const verifier = generateCodeVerifier();
-  const challenge = computeCodeChallenge(verifier);
-  const state = generateState();
-  const authUrl = buildAuthUrl({
-    authUrl: CLAUDE_AUTHORIZE_URL,
-    clientId: CLAUDE_CLIENT_ID,
-    redirectUri: CLAUDE_REDIRECT_URI,
-    scopes: [...CLAUDE_SCOPES],
-    codeChallenge: challenge,
-    state,
-    extraAuthParams: { code: 'true' },
-  });
-
-  ctx.write(
-    `\nSign in to ${CLAUDE_CODE_SERVICE_NAME} to authorize moxxy.\n\n` +
-      `If your browser doesn't open automatically, paste this URL:\n\n  ${authUrl}\n\n` +
-      `After approving, copy the authorization code shown and paste it back here.\n` +
-      `(Anthropic's sign-in page sometimes shows "Internal server error" on the\n` +
-      ` first attempt — just click "Try again" and it goes through.)\n\n`,
-  );
-  try {
-    await openBrowserImpl(authUrl);
-  } catch {
-    // Non-fatal — the user can open the URL surfaced above by hand.
+  if (looksUnsupported(combined)) {
+    return {
+      state: 'unsupported', executable,
+      message: 'This Claude CLI version does not support `claude auth status`. Update Claude Code and try again.',
+    };
   }
+  if (result.code !== 0) {
+    return {
+      state: 'error', executable,
+      message: `Claude CLI auth status failed${combined ? `: ${combined}` : ` with exit code ${result.code}`}.`,
+    };
+  }
+  return {
+    state: 'unsupported', executable,
+    message: 'Claude CLI returned an unrecognized auth-status response. Update Claude Code and try again.',
+  };
+}
 
-  // The authorization code is a single-use, exchangeable credential — mask it
-  // so it doesn't echo into scrollback / screen-share, matching the token paste.
-  const entered = (await ctx.prompt(CODE_PROMPT, { mask: true })).trim();
-  if (!entered) {
+export async function claudeLogin(_ctx: ProviderAuthContext): Promise<ProviderOAuthResult> {
+  const executable = resolveClaudeExecutable();
+  let status = await checkClaudeCliAuth(executable);
+  if (status.state === 'signed-in') return status.accountId ? { accountId: status.accountId } : {};
+  if (status.state !== 'signed-out') throw authError(status);
+
+  const login = await runCommandImpl(executable, CLAUDE_AUTH_LOGIN_ARGS, { inherit: true });
+  if (login.error) throw authError({ state: login.error.code === 'ENOENT' ? 'missing' : 'error', executable, message: login.error.message });
+  if (login.code !== 0) {
     throw new MoxxyError({
       code: 'AUTH_DENIED',
-      message: 'No authorization code entered — sign-in cancelled.',
+      message: `Claude CLI login failed${login.stderr ? `: ${login.stderr.trim()}` : ` with exit code ${login.code}`}.`,
+      hint: 'Run `claude auth login` directly for more detail, then retry.',
       context: { provider: CLAUDE_CODE_PROVIDER_ID },
     });
   }
-  // Anthropic returns `code#state`, but often shows just the bare code, so the
-  // state check below is best-effort: it only fires when a state was pasted.
-  // The real CSRF/code-injection defense is PKCE — the `code_verifier` binds
-  // the code to this client session, so a foreign code fails the exchange.
-  const hash = entered.indexOf('#');
-  const code = hash >= 0 ? entered.slice(0, hash) : entered;
-  const returnedState = hash >= 0 ? entered.slice(hash + 1) : '';
-  if (returnedState && returnedState !== state) {
-    throw new MoxxyError({
-      code: 'AUTH_INVALID',
-      message: 'Authorization state mismatch — please run sign-in again.',
-      context: { provider: CLAUDE_CODE_PROVIDER_ID },
-    });
-  }
+  status = await checkClaudeCliAuth(executable);
+  if (status.state !== 'signed-in') throw authError(status);
+  return status.accountId ? { accountId: status.accountId } : {};
+}
 
-  const { tokenSet, accountEmail } = await exchangeClaudeCode(code, returnedState || state, verifier);
-  await persistClaudeTokens(ctx.vault, tokenSet, accountEmail);
-  ctx.write(`\nSigned in to Claude${accountEmail ? ` as ${accountEmail}` : ''}.\n`);
-  // Omit `expiresAt` when the credential never expires (setup-token paste, or a
-  // token response without `expires_in`). Surfacing `0` would read as "epoch =
-  // already expired" to the CLI status renderer, which only checks `!== undefined`.
+/** Log out the CLI account. Legacy moxxy vault values are deliberately untouched. */
+export async function claudeLogout(_ctx: ProviderAuthContext): Promise<boolean> {
+  const executable = resolveClaudeExecutable();
+  const before = await checkClaudeCliAuth(executable);
+  if (before.state !== 'signed-in') return false;
+  const result = await runCommandImpl(executable, CLAUDE_AUTH_LOGOUT_ARGS, { inherit: true });
+  if (result.error || result.code !== 0) {
+    throw new MoxxyError({ code: 'AUTH_INVALID', message: `Claude CLI logout failed${result.stderr ? `: ${result.stderr}` : '.'}` });
+  }
+  return true;
+}
+
+export async function claudeStatus(_ctx: ProviderAuthContext): Promise<ProviderOAuthStatus | null> {
+  const status = await checkClaudeCliAuth();
   return {
-    ...(accountEmail ? { accountId: accountEmail } : {}),
-    ...(tokenSet.expiresAt !== undefined ? { expiresAt: tokenSet.expiresAt } : {}),
+    accountId: status.accountId ?? null,
+    authState: status.state,
+    message: status.message,
   };
 }
 
-export async function claudeLogout(ctx: ProviderAuthContext): Promise<boolean> {
+function parseStatusOutput(output: string): { loggedIn: boolean; accountId?: string } | null {
   try {
-    return (await clearStoredCreds(ctx.vault, CLAUDE_CODE_PROVIDER_ID)) > 0;
+    const value = JSON.parse(output) as Record<string, unknown>;
+    const loggedIn = value.loggedIn ?? value.logged_in ?? value.authenticated;
+    if (typeof loggedIn !== 'boolean') return null;
+    const account = value.email ?? value.account ?? value.accountEmail ?? value.account_email;
+    return { loggedIn, ...(typeof account === 'string' && account ? { accountId: account } : {}) };
   } catch {
-    return false;
+    const text = output.trim();
+    if (/not logged in|signed out|not authenticated/i.test(text)) return { loggedIn: false };
+    if (/logged in|authenticated|signed in/i.test(text)) {
+      const email = text.match(/[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}/)?.[0];
+      return { loggedIn: true, ...(email ? { accountId: email } : {}) };
+    }
+    return null;
   }
 }
 
-export async function claudeStatus(ctx: ProviderAuthContext): Promise<ProviderOAuthStatus | null> {
-  const stored = await readStoredCreds(ctx.vault, CLAUDE_CODE_PROVIDER_ID);
-  if (!stored) return null;
-  return {
-    accountId: stored.extras.account_email ?? null,
-    // Omit when absent — a stored setup-token has no expiry, and `0` would be
-    // mis-rendered as "expired" (the CLI only treats `!== undefined` as set).
-    ...(stored.tokenSet.expiresAt !== undefined ? { expiresAt: stored.tokenSet.expiresAt } : {}),
-    vaultKey: `oauth/${CLAUDE_CODE_PROVIDER_ID}/*`,
-  };
+function looksUnsupported(text: string): boolean {
+  return /unknown (command|option)|invalid (command|option)|unrecognized (command|option)|not supported/i.test(text);
 }
 
-export interface FreshClaudeTokens {
-  readonly accessToken: string;
-  readonly expiresAt?: number;
-  /** True when a refresh_token is stored, so a 401 can be recovered. */
-  readonly canRefresh: boolean;
-}
-
-/**
- * Read the stored Claude creds, refreshing first if the access token is near
- * expiry and a refresh_token is available. Returns null when nothing is
- * stored. Persists rotated tokens BEFORE returning so a crash can't strand a
- * single-use refresh_token. The refresh itself is serialized per credential
- * (in-process + cross-process) and coalesces with concurrent refreshers.
- */
-export async function ensureFreshClaudeTokens(vault: OAuthVault): Promise<FreshClaudeTokens | null> {
-  const stored = await readStoredCreds(vault, CLAUDE_CODE_PROVIDER_ID);
-  if (!stored) return null;
-  const { tokenSet } = stored;
-  if (tokenSet.refreshToken && isExpired(tokenSet)) {
-    const refreshed = await refreshClaudeUnderLock(vault, stored);
-    return { accessToken: refreshed.accessToken, ...(refreshed.expiresAt !== undefined ? { expiresAt: refreshed.expiresAt } : {}), canRefresh: true };
-  }
-  return {
-    accessToken: tokenSet.accessToken,
-    ...(tokenSet.expiresAt !== undefined ? { expiresAt: tokenSet.expiresAt } : {}),
-    canRefresh: tokenSet.refreshToken !== undefined,
-  };
-}
-
-/**
- * Force a refresh of the stored Claude tokens and persist the rotated bundle.
- * Used as the provider's reactive 401 recovery. Throws if no refresh_token is
- * stored (e.g. a pasted `setup-token`).
- */
-export async function refreshClaudeAccessToken(
-  vault: OAuthVault,
-): Promise<{ token: string; expiresAt?: number }> {
-  const stored = await readStoredCreds(vault, CLAUDE_CODE_PROVIDER_ID);
-  if (!stored?.tokenSet.refreshToken) {
-    throw new MoxxyError({
-      code: 'AUTH_EXPIRED',
-      message: 'Claude token expired and no refresh_token is stored.',
-      hint: 'Run `moxxy login claude-code` again, or refresh `CLAUDE_CODE_OAUTH_TOKEN` via `claude setup-token`.',
-      context: { provider: CLAUDE_CODE_PROVIDER_ID },
-    });
-  }
-  const refreshed = await refreshClaudeUnderLock(vault, stored);
-  return { token: refreshed.accessToken, ...(refreshed.expiresAt !== undefined ? { expiresAt: refreshed.expiresAt } : {}) };
-}
-
-/**
- * Refresh + persist under the per-credential lock. Anthropic ROTATES the
- * refresh_token on every refresh and invalidates the previous one, so two
- * concurrent refreshes (a second consumer in this process, or another moxxy
- * process — TUI alongside a desktop runner) must not both burn the same
- * stored token. Under the lock we:
- *   1. re-read the vault — if someone else already rotated and the new access
- *      token is still fresh, reuse it (coalesce; no IdP call at all);
- *   2. otherwise refresh with the freshest stored refresh_token;
- *   3. on an invalid_grant-style rejection, re-read once more — if the
- *      on-disk refresh_token changed under us (another process won a race we
- *      couldn't see), retry ONCE with the fresher token before declaring
- *      re-auth necessary.
- */
-async function refreshClaudeUnderLock(vault: OAuthVault, baseline: StoredCreds): Promise<TokenSet> {
-  return withCredentialLock(`oauth-${CLAUDE_CODE_PROVIDER_ID}`, async () => {
-    const current = (await readStoredCreds(vault, CLAUDE_CODE_PROVIDER_ID)) ?? baseline;
-    if (current.tokenSet.accessToken !== baseline.tokenSet.accessToken && !isExpired(current.tokenSet)) {
-      return current.tokenSet;
-    }
-    const refreshToken = current.tokenSet.refreshToken ?? baseline.tokenSet.refreshToken;
-    if (!refreshToken) {
-      throw new MoxxyError({
-        code: 'AUTH_EXPIRED',
-        message: 'Claude token expired and no refresh_token is stored.',
-        hint: 'Run `moxxy login claude-code` again, or refresh `CLAUDE_CODE_OAUTH_TOKEN` via `claude setup-token`.',
-        context: { provider: CLAUDE_CODE_PROVIDER_ID },
-      });
-    }
-    const email = current.extras.account_email ?? baseline.extras.account_email;
-    try {
-      return await refreshAndPersist(vault, refreshToken, email);
-    } catch (err) {
-      if (isAuthRejection(err)) {
-        const latest = await readStoredCreds(vault, CLAUDE_CODE_PROVIDER_ID);
-        const latestRefresh = latest?.tokenSet.refreshToken;
-        if (latestRefresh && latestRefresh !== refreshToken) {
-          return refreshAndPersist(vault, latestRefresh, latest.extras.account_email ?? email);
-        }
-      }
-      throw err;
-    }
+function authError(status: ClaudeCliAuthStatus): MoxxyError {
+  return new MoxxyError({
+    code: status.state === 'signed-out' ? 'AUTH_NO_CREDENTIALS' : 'AUTH_INVALID',
+    message: status.message,
+    hint: status.state === 'signed-out' ? 'Run `moxxy login claude-code`.' : undefined,
+    context: { provider: CLAUDE_CODE_PROVIDER_ID, executable: status.executable, state: status.state },
   });
 }
 
-// --- internal HTTP (JSON dialect) -----------------------------------------
-
-interface ClaudeExchangeResult {
-  readonly tokenSet: TokenSet;
-  readonly accountEmail?: string;
-}
-
-/**
- * Anthropic's OAuth endpoints (both `claude.ai/oauth/authorize` and the token
- * endpoint) intermittently return a transient HTTP 500 — the *same* request
- * then succeeds on retry. So retry 5xx/429/network failures with a short
- * backoff before giving up. 4xx (bad/expired/already-used code, invalid_grant)
- * is deterministic and surfaced immediately, never retried.
- */
-const TOKEN_POST_MAX_ATTEMPTS = 3;
-const TOKEN_POST_BACKOFF_MS = [600, 1800] as const;
-/**
- * Per-attempt deadline on the token POST. Node's `fetch` has NO default
- * timeout, so a half-open TCP socket (server accepts but never responds — a
- * stalled edge node, a black-holing proxy, a captive portal that keeps the
- * connection alive) would hang the whole login/refresh indefinitely. Bound
- * each attempt; a timeout aborts the request and is classed as a transient
- * network error, so the retry loop tries again and ultimately surfaces the
- * "endpoint kept failing" hint instead of wedging forever.
- */
-const TOKEN_POST_TIMEOUT_MS = 30_000;
-
-/** Test seam so the exchange/refresh can run against a fake fetch. */
-let fetchImpl: typeof fetch = fetch;
-export function __setClaudeFetch(f: typeof fetch): void {
-  fetchImpl = f;
-}
-
-/** Test seam so the OOB login can run without launching a real browser. */
-let openBrowserImpl: (url: string) => Promise<void> = openInBrowser;
-export function __setClaudeOpenBrowser(f: (url: string) => Promise<void>): void {
-  openBrowserImpl = f;
-}
-
-/** Test seam so the retry backoff doesn't actually sleep under test. */
-let sleepImpl = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
-export function __setClaudeSleep(f: (ms: number) => Promise<void>): void {
-  sleepImpl = f;
-}
-
-/** Test seam to shrink the per-attempt network deadline (default {@link TOKEN_POST_TIMEOUT_MS}). */
-let timeoutMs = TOKEN_POST_TIMEOUT_MS;
-export function __setClaudeTimeoutMs(ms: number): void {
-  timeoutMs = ms;
-}
-
-async function exchangeClaudeCode(
-  code: string,
-  state: string,
-  verifier: string,
-): Promise<ClaudeExchangeResult> {
-  return postClaudeToken({
-    grant_type: 'authorization_code',
-    code,
-    state,
-    client_id: CLAUDE_CLIENT_ID,
-    redirect_uri: CLAUDE_REDIRECT_URI,
-    code_verifier: verifier,
+async function runCommand(
+  executable: string,
+  args: readonly string[],
+  options: { readonly inherit?: boolean } = {},
+): Promise<ClaudeCommandResult> {
+  return await new Promise((resolve) => {
+    const spawnOptions: SpawnOptions = options.inherit
+      ? { stdio: 'inherit' }
+      : { stdio: ['ignore', 'pipe', 'pipe'] };
+    const child = spawn(executable, [...args], spawnOptions);
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => { stdout += chunk; });
+    child.stderr?.on('data', (chunk: string) => { stderr += chunk; });
+    child.once('error', (error: NodeJS.ErrnoException) => resolve({ code: 1, stdout, stderr, error }));
+    child.once('close', (code) => resolve({ code: code ?? 1, stdout, stderr }));
   });
-}
-
-async function refreshAndPersist(
-  vault: OAuthVault,
-  refreshToken: string,
-  priorEmail: string | undefined,
-): Promise<TokenSet> {
-  const { tokenSet, accountEmail } = await postClaudeToken({
-    grant_type: 'refresh_token',
-    refresh_token: refreshToken,
-    client_id: CLAUDE_CLIENT_ID,
-  });
-  // Claude rotates the refresh_token on every refresh; if a response ever
-  // omits one, keep the prior so we don't lock ourselves out.
-  const merged: TokenSet = tokenSet.refreshToken
-    ? tokenSet
-    : { ...tokenSet, refreshToken };
-  await persistClaudeTokens(vault, merged, accountEmail ?? priorEmail);
-  return merged;
-}
-
-async function persistClaudeTokens(
-  vault: OAuthVault,
-  tokenSet: TokenSet,
-  accountEmail: string | undefined,
-): Promise<void> {
-  await storeTokenSet(vault, CLAUDE_CODE_PROVIDER_ID, tokenSet, {
-    clientId: CLAUDE_CLIENT_ID,
-    tokenUrl: CLAUDE_TOKEN_URL,
-    ...(accountEmail ? { extras: { account_email: accountEmail } } : {}),
-  });
-}
-
-async function postClaudeToken(body: Record<string, string>): Promise<ClaudeExchangeResult> {
-  let transient = '';
-  for (let attempt = 1; attempt <= TOKEN_POST_MAX_ATTEMPTS; attempt++) {
-    if (attempt > 1) await sleepImpl(TOKEN_POST_BACKOFF_MS[attempt - 2] ?? 1800);
-
-    let res: Response;
-    try {
-      res = await fetchImpl(CLAUDE_TOKEN_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-        body: JSON.stringify(body),
-        // Bound a hung connection so it surfaces as a retryable network error
-        // (TimeoutError) rather than blocking the login/refresh forever.
-        signal: AbortSignal.timeout(timeoutMs),
-      });
-    } catch (err) {
-      transient = `network error (${err instanceof Error ? err.message : String(err)})`;
-      continue;
-    }
-
-    if (res.ok) {
-      // A captive portal / proxy / misbehaving edge can return 200 with an HTML
-      // or empty body, or a JSON primitive/array. Treat any of these as a
-      // transient and retry rather than letting a raw SyntaxError escape the
-      // retry/classify path.
-      let parsed: unknown;
-      try {
-        parsed = await res.json();
-      } catch {
-        transient = 'HTTP 200 with non-JSON body';
-        continue;
-      }
-      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-        transient = 'HTTP 200 with malformed token response';
-        continue;
-      }
-      const json = parsed as Record<string, unknown>;
-      return { tokenSet: parseTokenResponse(json), ...extractAccountEmail(json) };
-    }
-
-    const text = await res.text().catch(() => '');
-    // Deterministic client errors: surface immediately, don't burn retries.
-    if (res.status < 500 && res.status !== 429) {
-      throw new MoxxyError({
-        code: res.status === 401 || res.status === 403 ? 'AUTH_DENIED' : 'AUTH_INVALID',
-        message: `Claude token endpoint returned HTTP ${res.status}: ${text.slice(0, 300)}`,
-        context: { provider: CLAUDE_CODE_PROVIDER_ID, status: res.status },
-      });
-    }
-    // 5xx / 429 — Anthropic-side flake; loop and try the same request again.
-    transient = `HTTP ${res.status}: ${text.slice(0, 200)}`;
-  }
-
-  throw new MoxxyError({
-    code: 'AUTH_INVALID',
-    message: `Claude token endpoint kept failing after ${TOKEN_POST_MAX_ATTEMPTS} attempts (last: ${transient}).`,
-    hint:
-      "Anthropic's OAuth endpoint is returning transient errors right now — " +
-      'wait a few seconds and run `moxxy login claude-code` again.',
-    context: { provider: CLAUDE_CODE_PROVIDER_ID },
-  });
-}
-
-function extractAccountEmail(json: Record<string, unknown>): { accountEmail?: string } {
-  const account = json.account;
-  if (account && typeof account === 'object') {
-    const email = (account as { email_address?: unknown }).email_address;
-    if (typeof email === 'string' && email) return { accountEmail: email };
-  }
-  return {};
 }

--- a/packages/plugin-provider-claude-code/src/login.ts
+++ b/packages/plugin-provider-claude-code/src/login.ts
@@ -63,15 +63,18 @@ export async function checkClaudeCliAuth(executable = resolveClaudeExecutable())
 
   const combined = `${result.stdout}\n${result.stderr}`.trim();
   const parsed = parseStatusOutput(result.stdout);
-  if (parsed) {
-    if (parsed.loggedIn) {
-      return {
-        state: 'signed-in', executable,
-        ...(parsed.accountId ? { accountId: parsed.accountId } : {}),
-        message: `Claude CLI is signed in${parsed.accountId ? ` as ${parsed.accountId}` : ''}.`,
-      };
-    }
+  // Claude uses a machine-readable signed-out response on supported versions.
+  // Preserve that state even if a CLI version chooses a non-zero exit for it,
+  // but never accept signed-in readiness from a failed command.
+  if (parsed && !parsed.loggedIn) {
     return { state: 'signed-out', executable, message: 'Claude CLI is installed but signed out. Run `moxxy login claude-code`.' };
+  }
+  if (parsed?.loggedIn && result.code === 0) {
+    return {
+      state: 'signed-in', executable,
+      ...(parsed.accountId ? { accountId: parsed.accountId } : {}),
+      message: `Claude CLI is signed in${parsed.accountId ? ` as ${parsed.accountId}` : ''}.`,
+    };
   }
 
   if (looksUnsupported(combined)) {
@@ -92,8 +95,8 @@ export async function checkClaudeCliAuth(executable = resolveClaudeExecutable())
   };
 }
 
-export async function claudeLogin(_ctx: ProviderAuthContext): Promise<ProviderOAuthResult> {
-  const executable = resolveClaudeExecutable();
+export async function claudeLogin(ctx: ProviderAuthContext): Promise<ProviderOAuthResult> {
+  const executable = resolveClaudeExecutable(ctx.providerConfig);
   let status = await checkClaudeCliAuth(executable);
   if (status.state === 'signed-in') return status.accountId ? { accountId: status.accountId } : {};
   if (status.state !== 'signed-out') throw authError(status);
@@ -114,8 +117,8 @@ export async function claudeLogin(_ctx: ProviderAuthContext): Promise<ProviderOA
 }
 
 /** Log out the CLI account. Legacy moxxy vault values are deliberately untouched. */
-export async function claudeLogout(_ctx: ProviderAuthContext): Promise<boolean> {
-  const executable = resolveClaudeExecutable();
+export async function claudeLogout(ctx: ProviderAuthContext): Promise<boolean> {
+  const executable = resolveClaudeExecutable(ctx.providerConfig);
   const before = await checkClaudeCliAuth(executable);
   if (before.state !== 'signed-in') return false;
   const result = await runCommandImpl(executable, CLAUDE_AUTH_LOGOUT_ARGS, { inherit: true });
@@ -125,8 +128,8 @@ export async function claudeLogout(_ctx: ProviderAuthContext): Promise<boolean> 
   return true;
 }
 
-export async function claudeStatus(_ctx: ProviderAuthContext): Promise<ProviderOAuthStatus | null> {
-  const status = await checkClaudeCliAuth();
+export async function claudeStatus(ctx: ProviderAuthContext): Promise<ProviderOAuthStatus | null> {
+  const status = await checkClaudeCliAuth(resolveClaudeExecutable(ctx.providerConfig));
   return {
     accountId: status.accountId ?? null,
     authState: status.state,

--- a/packages/plugin-provider-claude-code/src/process.ts
+++ b/packages/plugin-provider-claude-code/src/process.ts
@@ -15,8 +15,6 @@ export interface ClaudeProcessOptions {
   readonly executable: string;
   readonly model: string;
   readonly prompt: string;
-  /** Optional moxxy-managed bearer passed only in the child's environment. */
-  readonly oauthToken?: string;
   readonly signal?: AbortSignal;
   readonly spawn?: ClaudeSpawn;
 }
@@ -42,10 +40,7 @@ export async function* runClaudeProcess(
     '--model',
     options.model,
   ];
-  const env = {
-    ...process.env,
-    ...(options.oauthToken ? { CLAUDE_CODE_OAUTH_TOKEN: options.oauthToken } : {}),
-  };
+  const env = { ...process.env };
   const spawnImpl = options.spawn ?? ((file, childArgs, childOptions) => spawn(file, [...childArgs], {
     stdio: ['pipe', 'pipe', 'pipe'],
     env: childOptions.env,

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -62,25 +62,27 @@ describe('claude-code provider definition', () => {
     expect(input).not.toContain('oauth-secret');
   });
 
-  it('passes a moxxy-managed token to the child environment without exposing it in args', async () => {
+  it('does not inject a moxxy-managed Claude token into the child environment', async () => {
     let childEnv: NodeJS.ProcessEnv | undefined;
+    const prior = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
     const dir = await makeFakeClaude([
       { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } },
     ]);
-    const executable = join(dir, 'claude');
     const client = createClaudeCodeClient({
-      executable,
-      oauthToken: 'oauth-secret',
+      executable: join(dir, 'claude'),
       spawn: (file, args, options) => {
         childEnv = options.env;
         return spawn(file, [...args], { stdio: ['pipe', 'pipe', 'pipe'], env: options.env });
       },
     });
-
-    await collect(client.stream(textRequest()));
-    expect(childEnv?.CLAUDE_CODE_OAUTH_TOKEN).toBe('oauth-secret');
-    expect(await readFile(join(dir, 'args.json'), 'utf8')).not.toContain('oauth-secret');
-    expect(await readFile(join(dir, 'input.txt'), 'utf8')).not.toContain('oauth-secret');
+    try {
+      await collect(client.stream(textRequest()));
+      expect(childEnv?.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    } finally {
+      if (prior === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+      else process.env.CLAUDE_CODE_OAUTH_TOKEN = prior;
+    }
   });
 
   it('orders the identity, message-derived system text, and extra system text', async () => {

--- a/packages/plugin-provider-claude-code/src/provider.ts
+++ b/packages/plugin-provider-claude-code/src/provider.ts
@@ -25,10 +25,6 @@ export interface ClaudeCodeProviderConfig {
   readonly defaultModel?: string;
   /** Process test seam; production callers should leave this unset. */
   readonly spawn?: ClaudeSpawn;
-  /** Optional moxxy-managed bearer, supplied to the child through its environment. */
-  readonly oauthToken?: string;
-  readonly oauthExpiresAt?: number;
-  readonly oauthRefresh?: () => Promise<{ readonly token: string; readonly expiresAt?: number }>;
 }
 
 export class ClaudeCodeProvider implements LLMProvider {
@@ -37,17 +33,11 @@ export class ClaudeCodeProvider implements LLMProvider {
 
   private readonly executable: string;
   private readonly defaultModel: string;
-  private oauthToken?: string;
-  private oauthExpiresAt?: number;
-  private readonly oauthRefresh?: ClaudeCodeProviderConfig['oauthRefresh'];
   private readonly spawn?: ClaudeSpawn;
 
   constructor(config: ClaudeCodeProviderConfig = {}) {
     this.executable = config.executable ?? 'claude';
     this.defaultModel = config.defaultModel ?? DEFAULT_MODEL;
-    if (config.oauthToken) this.oauthToken = config.oauthToken;
-    if (config.oauthExpiresAt !== undefined) this.oauthExpiresAt = config.oauthExpiresAt;
-    if (config.oauthRefresh) this.oauthRefresh = config.oauthRefresh;
     if (config.spawn) this.spawn = config.spawn;
   }
 
@@ -67,12 +57,10 @@ export class ClaudeCodeProvider implements LLMProvider {
     const state = createProtocolState();
     let terminal = false;
     try {
-      await this.ensureFreshOauth();
       const lines = runClaudeProcess({
         executable: this.executable,
         model,
         prompt,
-        ...(this.oauthToken ? { oauthToken: this.oauthToken } : {}),
         ...(req.signal ? { signal: req.signal } : {}),
         ...(this.spawn ? { spawn: this.spawn } : {}),
       });
@@ -100,14 +88,6 @@ export class ClaudeCodeProvider implements LLMProvider {
     } catch (error) {
       yield nonRetryableError(error);
     }
-  }
-
-  private async ensureFreshOauth(): Promise<void> {
-    if (!this.oauthRefresh || this.oauthExpiresAt === undefined) return;
-    if (Date.now() + 60_000 < this.oauthExpiresAt) return;
-    const fresh = await this.oauthRefresh();
-    this.oauthToken = fresh.token;
-    this.oauthExpiresAt = fresh.expiresAt;
   }
 
   async countTokens(

--- a/packages/sdk/src/provider.ts
+++ b/packages/sdk/src/provider.ts
@@ -181,6 +181,8 @@ export interface ProviderVault {
  */
 export interface ProviderAuthContext {
   readonly vault: ProviderVault;
+  /** Effective per-provider configuration from `plugins.provider.items.<name>.config`. */
+  readonly providerConfig?: Readonly<Record<string, unknown>>;
   /**
    * True when there is no usable browser or interactive TTY. OAuth flows
    * should fall back to device-code (or equivalent) in this mode rather

--- a/packages/sdk/src/provider.ts
+++ b/packages/sdk/src/provider.ts
@@ -265,6 +265,10 @@ export interface ProviderOAuthStatus {
   readonly expiresAt?: number;
   /** Vault key the credentials are stored under (informational). */
   readonly vaultKey?: string;
+  /** Optional provider-specific state for keyless/external authentication. */
+  readonly authState?: string;
+  /** Actionable status detail shown by CLI and desktop surfaces. */
+  readonly message?: string;
 }
 
 export interface ProviderDef {


### PR DESCRIPTION
Rework `packages/plugin-provider-claude-code/src/login.ts`, `constants.ts`, and their tests so provider readiness is based on the installed Claude CLI and its supported auth-status/login commands rather than moxxy-minted or pasted bearer tokens. Update `packages/cli/src/provider-credentials.ts`, `provider-credentials.test.ts`, and `commands/doctor.ts` to resolve executable/config options for this keyless subscription provider and report binary/auth readiness through the existing setup and desktop OAuth-sign-in surfaces. Preserve old vault entries but stop reading or forwarding them.

### Acceptance criteria
- `moxxy login claude-code` succeeds when a fake `claude` reports an authenticated account and invokes the CLI's login flow when authentication is absent.
- `moxxy login status` distinguishes missing executable, signed-out, and signed-in states with actionable messages.
- `moxxy doctor` does not look for `CLAUDE_CODE_API_KEY` or classify `claude-code` as an API-key provider.
- Provider activation succeeds without any Claude credential stored in the moxxy vault when the CLI reports authenticated.
- Existing `oauth/claude-code/*` vault values are neither deleted nor sent to a network endpoint.
- CLI, login, and credential-resolution tests cover paths containing spaces, command failure, and unsupported CLI versions.

_Task `tsk-db611e5b-da1` on the Companion board._