### PR TITLE
Route Fable and Opus selections to Claude Code

### DIFF
--- a/.changeset/tidy-claude-code-model-routing.md
+++ b/.changeset/tidy-claude-code-model-routing.md
@@ -1,0 +1,6 @@
+---
+"@moxxy/plugin-provider-claude-code": patch
+"@moxxy/cli": patch
+---
+
+Advertise Claude Code subscription models independently, persist the pinned default during provisioning, and make rejected model selections actionable.

--- a/packages/cli/src/provision/provider-catalog.ts
+++ b/packages/cli/src/provision/provider-catalog.ts
@@ -1,3 +1,5 @@
+import { CLAUDE_CODE_DEFAULT_MODEL } from '@moxxy/plugin-provider-claude-code';
+
 /**
  * First-party provider catalog — the source of truth for `moxxy init` / `moxxy
  * provision` when picking a provider. Maps a provider **slug** (the contribution
@@ -50,6 +52,7 @@ export const PROVIDER_CATALOG: ReadonlyArray<ProviderCatalogEntry> = [
     description: 'Claude via a Claude Pro/Max OAuth token — no separate API key.',
     packageName: '@moxxy/plugin-provider-claude-code',
     auth: 'oauth',
+    defaultModel: CLAUDE_CODE_DEFAULT_MODEL,
   },
   {
     slug: 'openai-codex',

--- a/packages/cli/src/provision/provision.test.ts
+++ b/packages/cli/src/provision/provision.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import { CLAUDE_CODE_DEFAULT_MODEL } from '@moxxy/plugin-provider-claude-code';
 import { pinFirstPartySpec } from './pin.js';
+import { resolveProvider } from './provider-catalog.js';
 import { provision, type ProvisionEffects } from './provision.js';
 
 describe('pinFirstPartySpec', () => {
@@ -66,11 +68,26 @@ describe('provision', () => {
     expect(order).toEqual(['install:@moxxy/plugin-provider-openai@1.0.0', 'config']); // config last
   });
 
-  it('does not store a key for an oauth provider', async () => {
+  it('pins the exported Claude Code default and persists it in the provider item write', async () => {
+    expect(resolveProvider('claude-code')?.defaultModel).toBe(CLAUDE_CODE_DEFAULT_MODEL);
     const eff = makeEffects({ loadedProviderNames: new Set(['claude-code']) });
     const res = await provision({ provider: 'claude-code', key: 'should-ignore' }, eff);
+
     expect(eff.storeSecret).not.toHaveBeenCalled();
     expect(res.keyStored).toBe(false);
+    expect(eff.writeConfig).toHaveBeenCalledWith(expect.objectContaining({
+      providerSlug: 'claude-code',
+      model: CLAUDE_CODE_DEFAULT_MODEL,
+    }));
+  });
+
+  it.each(['claude-fable-5', 'claude-opus-4-8'])('persists an explicit %s selection', async (model) => {
+    const eff = makeEffects({ loadedProviderNames: new Set(['claude-code']) });
+    await provision({ provider: 'claude-code', model }, eff);
+    expect(eff.writeConfig).toHaveBeenCalledWith(expect.objectContaining({
+      providerSlug: 'claude-code',
+      model,
+    }));
   });
 
   it('installs accepted basics too (pinned)', async () => {

--- a/packages/cli/src/setup/activate-provider.test.ts
+++ b/packages/cli/src/setup/activate-provider.test.ts
@@ -1,6 +1,22 @@
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import {
+  loadConfig,
+  setCategoryDefault,
+  setProviderItemConfig,
+  setProviderModel,
+  type MoxxyConfig,
+} from '@moxxy/config';
 import { Session, silentLogger } from '@moxxy/core';
-import { definePlugin, defineProvider, type ProviderDef } from '@moxxy/sdk';
+import {
+  definePlugin,
+  defineProvider,
+  type ProviderDef,
+  type ProviderEvent,
+  type ProviderRequest,
+} from '@moxxy/sdk';
 import {
   __setClaudeCommandRunner,
   claudeCodeProviderDef,
@@ -28,6 +44,8 @@ function makeSession(providers: ProviderDef[]): Session {
   return session;
 }
 
+const tempDirs: string[] = [];
+
 const vault = {
   get: async () => null,
   set: async () => undefined,
@@ -40,8 +58,9 @@ const baseArgs = {
   logger: silentLogger,
 };
 
-afterEach(() => {
+afterEach(async () => {
   __setClaudeCommandRunner(async () => ({ code: 1, stdout: '', stderr: 'not configured' }));
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
 describe('activateProvider', () => {
@@ -61,6 +80,44 @@ describe('activateProvider', () => {
       ]),
     ).toEqual({ ready: true, issues: [] });
   });
+
+  it.each(['claude-fable-5', 'claude-opus-4-8'])(
+    'loads a persisted %s selection through production activation into the Claude child arguments',
+    async (model) => {
+      const home = await mkdtemp(join(tmpdir(), 'moxxy-claude-activation-'));
+      tempDirs.push(home);
+      const configPath = join(home, 'config.yaml');
+      const executable = await makeFakeClaude(home);
+
+      // Use the same comment-preserving writers as `moxxy provision`, then the
+      // real merged loader. This pins the persistence path rather than mocking
+      // ProvisionEffects.writeConfig or manually constructing createClient args.
+      await setCategoryDefault('provider', 'claude-code', { configPath });
+      await setProviderItemConfig('claude-code', { executable }, { configPath });
+      await setProviderModel('claude-code', model, { configPath });
+      const yaml = await readFile(configPath, 'utf8');
+      expect(yaml).toContain('claude-code:');
+      expect(yaml).toContain(`model: ${model}`);
+
+      const priorHome = process.env.MOXXY_HOME;
+      process.env.MOXXY_HOME = home;
+      let config: MoxxyConfig;
+      try {
+        ({ config } = await loadConfig({ cwd: home }));
+      } finally {
+        if (priorHome === undefined) delete process.env.MOXXY_HOME;
+        else process.env.MOXXY_HOME = priorHome;
+      }
+
+      __setClaudeCommandRunner(async () => ({ code: 0, stdout: '{"loggedIn":true}', stderr: '' }));
+      const session = makeSession([claudeCodeProviderDef]);
+      await activateProvider({ ...baseArgs, session, config, providerConfig: {} });
+      await collect(session.providers.getActive().stream({ ...textRequest(), model: '' }));
+
+      const args = JSON.parse(await readFile(join(home, 'args.json'), 'utf8')) as string[];
+      expect(args.slice(-2)).toEqual(['--model', model]);
+    },
+  );
 
   it('uses a fallback provider item config when probing activation', async () => {
     const executable = '/Applications/Claude Code/bin/claude';
@@ -121,3 +178,31 @@ describe('activateProvider', () => {
     expect(seen).toEqual([executable, executable]);
   });
 });
+
+function textRequest(): ProviderRequest {
+  return {
+    model: '',
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+  };
+}
+
+async function collect(stream: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const events: ProviderEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}
+
+async function makeFakeClaude(dir: string): Promise<string> {
+  const executable = join(dir, 'claude');
+  await writeFile(executable, `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+process.stdin.resume();
+process.stdin.on('end', () => {
+  fs.writeFileSync(path.join(__dirname, 'args.json'), JSON.stringify(process.argv.slice(2)));
+  console.log(JSON.stringify({ type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } }));
+});
+`, 'utf8');
+  await chmod(executable, 0o755);
+  return executable;
+}

--- a/packages/cli/src/setup/activate-provider.ts
+++ b/packages/cli/src/setup/activate-provider.ts
@@ -54,10 +54,16 @@ export async function activateProvider(args: ActivateProviderArgs): Promise<Acti
   // The caller may overlay boot-time options onto the primary item's config.
   // Every other path must still use that provider's own configured item rather
   // than silently falling back to environment/default values.
-  const effectiveProviderConfig = (providerName: string): Record<string, unknown> =>
-    providerName === primaryProvider
-      ? providerConfig
-      : { ...(providerItem(config, providerName).config ?? {}) };
+  const effectiveProviderConfig = (providerName: string): Record<string, unknown> => {
+    const item = providerItem(config, providerName);
+    const persisted = {
+      ...(item.config ?? {}),
+      ...(item.model ? { model: item.model } : {}),
+    };
+    return providerName === primaryProvider
+      ? { ...persisted, ...providerConfig }
+      : persisted;
+  };
 
   let activated: { name: string; cfg: Record<string, unknown> } | null = null;
   let lastErr: unknown = null;

--- a/packages/plugin-provider-claude-code/src/index.ts
+++ b/packages/plugin-provider-claude-code/src/index.ts
@@ -1,6 +1,7 @@
 import { defineProvider, definePlugin } from '@moxxy/sdk';
 import { CLAUDE_CODE_PROVIDER_ID, CLAUDE_CODE_SERVICE_NAME } from './constants.js';
 import {
+  CLAUDE_CODE_DEFAULT_MODEL,
   claudeCodeModels,
   createClaudeCodeClient,
   type ClaudeCodeProviderConfig,
@@ -10,7 +11,13 @@ import { claudeLogin, claudeLogout, claudeStatus } from './login.js';
 export const claudeCodeProviderDef = defineProvider({
   name: CLAUDE_CODE_PROVIDER_ID,
   models: claudeCodeModels,
-  createClient: (config) => createClaudeCodeClient(config as ClaudeCodeProviderConfig),
+  createClient: (config) => createClaudeCodeClient({
+    ...(config as ClaudeCodeProviderConfig),
+    defaultModel:
+      typeof (config as { model?: unknown }).model === 'string'
+        ? (config as { model: string }).model
+        : (config as ClaudeCodeProviderConfig).defaultModel ?? CLAUDE_CODE_DEFAULT_MODEL,
+  }),
   // No validateKey: readiness is reported by the installed Claude CLI.
   auth: {
     kind: 'oauth',
@@ -46,4 +53,9 @@ export {
   type ClaudeCommandResult,
   __setClaudeCommandRunner,
 } from './login.js';
-export { claudeCodeModels, createClaudeCodeClient, type ClaudeCodeProviderConfig } from './provider.js';
+export {
+  CLAUDE_CODE_DEFAULT_MODEL,
+  claudeCodeModels,
+  createClaudeCodeClient,
+  type ClaudeCodeProviderConfig,
+} from './provider.js';

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -5,7 +5,12 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import type { ProviderEvent, ProviderRequest } from '@moxxy/sdk';
-import { claudeCodeProviderDef, createClaudeCodeClient } from './index.js';
+import {
+  CLAUDE_CODE_DEFAULT_MODEL,
+  claudeCodeModels,
+  claudeCodeProviderDef,
+  createClaudeCodeClient,
+} from './index.js';
 
 const tempDirs: string[] = [];
 afterEach(async () => {
@@ -13,10 +18,19 @@ afterEach(async () => {
 });
 
 describe('claude-code provider definition', () => {
-  it('registers text-only Claude model capabilities', () => {
+  it('registers the exact Claude Code catalog, default, and text-only capabilities', () => {
     expect(claudeCodeProviderDef.name).toBe('claude-code');
     expect(claudeCodeProviderDef.auth?.kind).toBe('oauth');
-    expect(claudeCodeProviderDef.models.map((model) => model.id)).toContain('claude-sonnet-4-6');
+    expect(CLAUDE_CODE_DEFAULT_MODEL).toBe('claude-sonnet-4-6');
+    expect(claudeCodeProviderDef.models).toBe(claudeCodeModels);
+    expect(claudeCodeProviderDef.models.map((model) => model.id)).toEqual([
+      'claude-sonnet-4-6',
+      'claude-fable-5',
+      'claude-opus-4-8',
+      'claude-opus-4-7',
+      'claude-opus-4-6',
+      'claude-haiku-4-5-20251001',
+    ]);
     for (const model of claudeCodeProviderDef.models) {
       expect(model).toMatchObject({
         supportsStreaming: true,
@@ -60,6 +74,56 @@ describe('claude-code provider definition', () => {
     expect(input).toContain('<assistant>\nprior assistant');
     expect(input).toContain('<user>\nlatest user');
     expect(input).not.toContain('oauth-secret');
+  });
+
+  it.each(['claude-fable-5', 'claude-opus-4-8'])('passes the selected %s model as an exact structured argument', async (model) => {
+    const dir = await makeFakeClaude([
+      { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } },
+    ]);
+    const client = createClaudeCodeClient({ executable: join(dir, 'claude') });
+    await collect(client.stream({ ...textRequest(), model }));
+
+    const args = JSON.parse(await readFile(join(dir, 'args.json'), 'utf8')) as string[];
+    expect(args.slice(-2)).toEqual(['--model', model]);
+    expect(args.filter((arg) => arg === '--model')).toHaveLength(1);
+  });
+
+  it('uses the persisted provider-item model as its default selection', async () => {
+    const dir = await makeFakeClaude([
+      { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } },
+    ]);
+    const client = claudeCodeProviderDef.createClient({ model: 'claude-fable-5', executable: join(dir, 'claude') });
+    await collect(client.stream({ ...textRequest(), model: '' }));
+
+    const args = JSON.parse(await readFile(join(dir, 'args.json'), 'utf8')) as string[];
+    expect(args.slice(-2)).toEqual(['--model', 'claude-fable-5']);
+  });
+
+  it('returns actionable errors for locally unsupported and CLI-rejected models', async () => {
+    const supported = claudeCodeModels.map((model) => model.id);
+    const unsupported = await collect(createClaudeCodeClient({
+      spawn: () => { throw new Error('should not spawn'); },
+    }).stream({ ...textRequest(), model: 'claude-imaginary-9' }));
+    expect(unsupported[1]).toMatchObject({
+      type: 'error',
+      message: expect.stringContaining('claude-imaginary-9'),
+      retryable: false,
+    });
+    for (const model of supported) expect((unsupported[1] as { message: string }).message).toContain(model);
+
+    const dir = await makeFakeClaude([
+      { type: 'result', subtype: 'error_during_execution', is_error: true, result: 'Model is unavailable' },
+    ]);
+    const rejected = await collect(createClaudeCodeClient({ executable: join(dir, 'claude') }).stream({
+      ...textRequest(),
+      model: 'claude-fable-5',
+    }));
+    expect(rejected[1]).toMatchObject({
+      type: 'error',
+      message: expect.stringMatching(/Claude Code rejected model "claude-fable-5".*Model is unavailable/),
+      retryable: false,
+    });
+    for (const model of supported) expect((rejected[1] as { message: string }).message).toContain(model);
   });
 
   it('does not inject a moxxy-managed Claude token into the child environment', async () => {

--- a/packages/plugin-provider-claude-code/src/provider.ts
+++ b/packages/plugin-provider-claude-code/src/provider.ts
@@ -12,16 +12,25 @@ const NON_TEXT_BLOCK_TOKENS = 256;
  *
  * This is deliberately independent of the Anthropic API catalog: the CLI has
  * its own availability policy, and this adapter only preserves streamed text.
- * Optional capability flags are omitted rather than copied from the API
- * provider so hosts cannot route images, documents, tools, or reasoning here.
+ * Unsupported capabilities are explicit so every host sees the same text-only
+ * contract rather than relying on how it interprets absent optional flags.
  */
+const textOnlyCapabilities = {
+  supportsTools: false,
+  supportsStreaming: true,
+  supportsImages: false,
+  supportsDocuments: false,
+  supportsAudio: false,
+  supportsReasoning: false,
+} as const;
+
 export const claudeCodeModels: ReadonlyArray<ModelDescriptor> = [
-  { id: CLAUDE_CODE_DEFAULT_MODEL, contextWindow: 1_000_000, maxOutputTokens: 64_000, supportsTools: false, supportsStreaming: true },
-  { id: 'claude-fable-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: false, supportsStreaming: true },
-  { id: 'claude-opus-4-8', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: false, supportsStreaming: true },
-  { id: 'claude-opus-4-7', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: false, supportsStreaming: true },
-  { id: 'claude-opus-4-6', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: false, supportsStreaming: true },
-  { id: 'claude-haiku-4-5-20251001', contextWindow: 200_000, maxOutputTokens: 64_000, supportsTools: false, supportsStreaming: true },
+  { id: CLAUDE_CODE_DEFAULT_MODEL, contextWindow: 1_000_000, maxOutputTokens: 64_000, ...textOnlyCapabilities },
+  { id: 'claude-fable-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
+  { id: 'claude-opus-4-8', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
+  { id: 'claude-opus-4-7', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
+  { id: 'claude-opus-4-6', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
+  { id: 'claude-haiku-4-5-20251001', contextWindow: 200_000, maxOutputTokens: 64_000, ...textOnlyCapabilities },
 ];
 
 export interface ClaudeCodeProviderConfig {
@@ -90,8 +99,13 @@ export class ClaudeCodeProvider implements LLMProvider {
           break;
         }
         for (const event of parseClaudeRecord(next.value, state)) {
-          if (event.type === 'message_end' || event.type === 'error') terminal = true;
-          yield event;
+          if (event.type === 'message_end') terminal = true;
+          if (event.type === 'error') {
+            terminal = true;
+            yield { ...event, message: modelSelectionError(model, event.message) };
+          } else {
+            yield event;
+          }
         }
       }
       if (!terminal) {

--- a/packages/plugin-provider-claude-code/src/provider.ts
+++ b/packages/plugin-provider-claude-code/src/provider.ts
@@ -1,27 +1,35 @@
 import type { LLMProvider, ModelDescriptor, ProviderEvent, ProviderRequest } from '@moxxy/sdk';
 import { estimateTextTokens } from '@moxxy/sdk';
-import { anthropicModels } from '@moxxy/plugin-provider-anthropic';
 import { CLAUDE_CODE_PROVIDER_ID } from './constants.js';
 import { runClaudeProcess, type ClaudeSpawn } from './process.js';
 import { createProtocolState, parseClaudeRecord, serializeClaudePrompt } from './protocol.js';
 
-const DEFAULT_MODEL = 'claude-sonnet-4-6';
+export const CLAUDE_CODE_DEFAULT_MODEL = 'claude-sonnet-4-6';
 const NON_TEXT_BLOCK_TOKENS = 256;
 
-/** Claude CLI transport currently supports streaming plain text only. */
-export const claudeCodeModels: ReadonlyArray<ModelDescriptor> = anthropicModels.map((model) => ({
-  ...model,
-  supportsTools: false,
-  supportsImages: false,
-  supportsDocuments: false,
-  supportsAudio: false,
-  supportsReasoning: false,
-}));
+/**
+ * Models offered by Claude Code subscriptions through the installed CLI.
+ *
+ * This is deliberately independent of the Anthropic API catalog: the CLI has
+ * its own availability policy, and this adapter only preserves streamed text.
+ * Optional capability flags are omitted rather than copied from the API
+ * provider so hosts cannot route images, documents, tools, or reasoning here.
+ */
+export const claudeCodeModels: ReadonlyArray<ModelDescriptor> = [
+  { id: CLAUDE_CODE_DEFAULT_MODEL, contextWindow: 1_000_000, maxOutputTokens: 64_000, supportsTools: false, supportsStreaming: true },
+  { id: 'claude-fable-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: false, supportsStreaming: true },
+  { id: 'claude-opus-4-8', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: false, supportsStreaming: true },
+  { id: 'claude-opus-4-7', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: false, supportsStreaming: true },
+  { id: 'claude-opus-4-6', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: false, supportsStreaming: true },
+  { id: 'claude-haiku-4-5-20251001', contextWindow: 200_000, maxOutputTokens: 64_000, supportsTools: false, supportsStreaming: true },
+];
 
 export interface ClaudeCodeProviderConfig {
   /** Installed Claude Code executable. Defaults to the command resolved from PATH. */
   readonly executable?: string;
-  /** Optional default model override. */
+  /** Persisted provider-item model (`plugins.provider.items.claude-code.model`). */
+  readonly model?: string;
+  /** Optional default model override (kept for programmatic callers). */
   readonly defaultModel?: string;
   /** Process test seam; production callers should leave this unset. */
   readonly spawn?: ClaudeSpawn;
@@ -37,7 +45,7 @@ export class ClaudeCodeProvider implements LLMProvider {
 
   constructor(config: ClaudeCodeProviderConfig = {}) {
     this.executable = config.executable ?? 'claude';
-    this.defaultModel = config.defaultModel ?? DEFAULT_MODEL;
+    this.defaultModel = config.defaultModel ?? CLAUDE_CODE_DEFAULT_MODEL;
     if (config.spawn) this.spawn = config.spawn;
   }
 
@@ -47,6 +55,7 @@ export class ClaudeCodeProvider implements LLMProvider {
 
     let prompt: string;
     try {
+      assertSupportedModel(model);
       assertTextOnlyRequest(req);
       prompt = serializeClaudePrompt(req);
     } catch (error) {
@@ -70,7 +79,10 @@ export class ClaudeCodeProvider implements LLMProvider {
           if (next.value.exitCode !== 0 && !terminal) {
             yield {
               type: 'error',
-              message: next.value.stderr || `Claude CLI exited with code ${next.value.exitCode}`,
+              message: modelSelectionError(
+                model,
+                next.value.stderr || `Claude CLI exited with code ${next.value.exitCode}`,
+              ),
               retryable: false,
             };
             return;
@@ -110,6 +122,14 @@ export function createClaudeCodeClient(config: ClaudeCodeProviderConfig = {}): L
   return new ClaudeCodeProvider(config);
 }
 
+function assertSupportedModel(model: string): void {
+  if (claudeCodeModels.some((candidate) => candidate.id === model)) return;
+  throw new Error(
+    `Claude Code model "${model}" is not supported by this adapter. ` +
+    `Select a supported model: ${claudeCodeModels.map((candidate) => candidate.id).join(', ')}.`,
+  );
+}
+
 function assertTextOnlyRequest(req: ProviderRequest): void {
   if (req.tools && req.tools.length > 0) {
     throw new Error('Claude CLI text transport does not support tools');
@@ -117,6 +137,11 @@ function assertTextOnlyRequest(req: ProviderRequest): void {
   if (req.reasoning) {
     throw new Error('Claude CLI text transport does not support reasoning');
   }
+}
+
+function modelSelectionError(model: string, detail: string): string {
+  return `Claude Code rejected model "${model}": ${detail}. ` +
+    `Select a supported model: ${claudeCodeModels.map((candidate) => candidate.id).join(', ')}.`;
 }
 
 function nonRetryableError(error: unknown): ProviderEvent {


### PR DESCRIPTION
Give the CLI-backed provider an explicit supported-model catalog instead of inheriting API-only capabilities from `packages/plugin-provider-anthropic/src/provider.ts`. Update `packages/plugin-provider-claude-code/src/index.ts`, `provider.ts`, catalog tests, and `packages/cli/src/provision/provider-catalog.ts` so setup/model pickers expose subscription models such as `claude-fable-5` and `claude-opus-4-8`, persist the choice through `plugins.provider.items.claude-code.model`, and pass it to the child via Claude's model option.

### Acceptance criteria
- The init wizard and runtime model picker list Fable and Opus 4.8 for `claude-code`.
- Selecting either model persists it under `plugins.provider.items.claude-code.model` and the next child invocation receives that exact model selection.
- The provider no longer advertises image, document, reasoning, or other capabilities that the implemented CLI adapter cannot preserve.
- An unavailable or rejected model returns an actionable error naming the selected model and suggesting a supported selection.
- Provider and provisioning tests pin the advertised catalog, default model, persisted configuration, and generated child arguments.

_Task `tsk-5d71cc42-1f4` on the Companion board._