### PR TITLE
Allow subscription-backed coding tasks with native tools

### DIFF
--- a/.changeset/native-claude-code-tools.md
+++ b/.changeset/native-claude-code-tools.md
@@ -1,0 +1,6 @@
+---
+"@moxxy/plugin-provider-claude-code": minor
+"@moxxy/cli": patch
+---
+
+Add an opt-in native-tools mode for Claude Code subscription tasks, including workspace, permission-mode, and allowed-tool forwarding without duplicate moxxy tool dispatch.

--- a/packages/cli/src/provider-credentials.test.ts
+++ b/packages/cli/src/provider-credentials.test.ts
@@ -87,9 +87,19 @@ describe('resolveProviderCredentials', () => {
     delete process.env.ANTHROPIC_AUTH_TOKEN;
     const cfg = await resolveProviderCredentials('claude-code', vault, {
       interactive: false,
-      providerConfig: { executable: '/opt/bin/claude' },
+      providerConfig: {
+        executable: '/opt/bin/claude',
+        mode: 'native-tools',
+        permissionMode: 'acceptEdits',
+        allowedTools: ['Read', 'Edit'],
+      },
     });
-    expect(cfg).toEqual({ executable: '/opt/bin/claude' });
+    expect(cfg).toEqual({
+      executable: '/opt/bin/claude',
+      mode: 'native-tools',
+      permissionMode: 'acceptEdits',
+      allowedTools: ['Read', 'Edit'],
+    });
   });
 
   it('preserves but neither reads nor forwards stored claude-code tokens', async () => {

--- a/packages/cli/src/setup/activate-provider.test.ts
+++ b/packages/cli/src/setup/activate-provider.test.ts
@@ -152,6 +152,12 @@ describe('activateProvider', () => {
 
   it('uses provider item config for readiness probes and runtime switching', async () => {
     const executable = '/Applications/Claude Code/bin/claude';
+    const claudeConfig = {
+      executable,
+      mode: 'native-tools',
+      permissionMode: 'acceptEdits',
+      allowedTools: ['Read', 'Edit'],
+    };
     const seen: string[] = [];
     __setClaudeCommandRunner(async (value) => {
       seen.push(value);
@@ -166,7 +172,7 @@ describe('activateProvider', () => {
         plugins: {
           provider: {
             default: 'test-provider',
-            items: { 'claude-code': { config: { executable } } },
+            items: { 'claude-code': { config: claudeConfig } },
           },
         },
       },
@@ -174,7 +180,10 @@ describe('activateProvider', () => {
     });
 
     expect(session.readyProviders.has('claude-code')).toBe(true);
-    await expect(credentialResolver('claude-code')).resolves.toMatchObject({ executable });
+    await expect(credentialResolver('claude-code')).resolves.toMatchObject({
+      ...claudeConfig,
+      cwd: '/tmp',
+    });
     expect(seen).toEqual([executable, executable]);
   });
 });

--- a/packages/cli/src/setup/activate-provider.ts
+++ b/packages/cli/src/setup/activate-provider.ts
@@ -1,6 +1,7 @@
 import type { Session } from '@moxxy/core';
 import type { MoxxyConfig } from '@moxxy/config';
 import type { VaultStore } from '@moxxy/plugin-vault';
+import { CLAUDE_CODE_PROVIDER_ID } from '@moxxy/plugin-provider-claude-code';
 import { MoxxyError, type CredentialResolver } from '@moxxy/sdk';
 import { resolveProviderCredentials } from '../provider-credentials.js';
 import { providerDefault, providerItem, providerSlot } from './resolve-plugins-tree.js';
@@ -60,9 +61,14 @@ export async function activateProvider(args: ActivateProviderArgs): Promise<Acti
       ...(item.config ?? {}),
       ...(item.model ? { model: item.model } : {}),
     };
-    return providerName === primaryProvider
+    const effective = providerName === primaryProvider
       ? { ...persisted, ...providerConfig }
       : persisted;
+    // Provider clients do not receive the Session object, so explicitly carry
+    // the runner workspace into Claude Code activation and runtime switching.
+    return providerName === CLAUDE_CODE_PROVIDER_ID
+      ? { ...effective, cwd: session.cwd }
+      : effective;
   };
 
   let activated: { name: string; cfg: Record<string, unknown> } | null = null;

--- a/packages/plugin-provider-claude-code/src/process.ts
+++ b/packages/plugin-provider-claude-code/src/process.ts
@@ -44,9 +44,13 @@ export async function* runClaudeProcess(
     options.model,
   ];
   if (options.nativeTools) {
-    if (options.permissionMode) args.push('--permission-mode', options.permissionMode);
-    // An empty explicit allow-list means no tools, not unrestricted native tools.
-    args.push('--allowedTools', ...options.allowedTools);
+    // Tool availability and permission grants are separate Claude CLI controls.
+    // Restrict availability first so ambient settings cannot expose additional tools.
+    args.push('--tools', ...(options.allowedTools.length > 0 ? options.allowedTools : ['']));
+    args.push('--permission-mode', options.permissionMode ?? 'default');
+    // Non-empty configured tools may run without an interactive approval prompt.
+    // Do not emit a valueless variadic flag for the explicit no-tools case.
+    if (options.allowedTools.length > 0) args.push('--allowedTools', ...options.allowedTools);
   } else {
     // Keep the original subscription transport text-only unless native tools
     // were deliberately enabled in the provider item config.

--- a/packages/plugin-provider-claude-code/src/process.ts
+++ b/packages/plugin-provider-claude-code/src/process.ts
@@ -3,6 +3,7 @@ import { createInterface } from 'node:readline';
 
 export interface ClaudeSpawnOptions {
   readonly env: NodeJS.ProcessEnv;
+  readonly cwd: string;
 }
 
 export type ClaudeSpawn = (
@@ -15,6 +16,10 @@ export interface ClaudeProcessOptions {
   readonly executable: string;
   readonly model: string;
   readonly prompt: string;
+  readonly cwd: string;
+  readonly nativeTools: boolean;
+  readonly permissionMode?: string;
+  readonly allowedTools: ReadonlyArray<string>;
   readonly signal?: AbortSignal;
   readonly spawn?: ClaudeSpawn;
 }
@@ -35,17 +40,25 @@ export async function* runClaudeProcess(
     '--output-format',
     'stream-json',
     '--include-partial-messages',
-    '--tools',
-    '',
     '--model',
     options.model,
   ];
+  if (options.nativeTools) {
+    if (options.permissionMode) args.push('--permission-mode', options.permissionMode);
+    // An empty explicit allow-list means no tools, not unrestricted native tools.
+    args.push('--allowedTools', ...options.allowedTools);
+  } else {
+    // Keep the original subscription transport text-only unless native tools
+    // were deliberately enabled in the provider item config.
+    args.splice(args.length - 2, 0, '--tools', '');
+  }
   const env = { ...process.env };
   const spawnImpl = options.spawn ?? ((file, childArgs, childOptions) => spawn(file, [...childArgs], {
     stdio: ['pipe', 'pipe', 'pipe'],
     env: childOptions.env,
+    cwd: childOptions.cwd,
   }));
-  const child = spawnImpl(options.executable, args, { env });
+  const child = spawnImpl(options.executable, args, { env, cwd: options.cwd });
   const completion = waitForExit(child);
   let stderr = '';
   child.stdin.on('error', () => undefined);

--- a/packages/plugin-provider-claude-code/src/process.ts
+++ b/packages/plugin-provider-claude-code/src/process.ts
@@ -47,7 +47,10 @@ export async function* runClaudeProcess(
     // Tool availability and permission grants are separate Claude CLI controls.
     // Restrict availability first so ambient settings cannot expose additional tools.
     args.push('--tools', ...(options.allowedTools.length > 0 ? options.allowedTools : ['']));
-    args.push('--permission-mode', options.permissionMode ?? 'default');
+    // Do not invent a permission mode: Claude CLI versions disagree on the
+    // accepted values (notably, some reject `default`). With no explicit
+    // provider setting, omitting the flag selects the CLI's safe default.
+    if (options.permissionMode) args.push('--permission-mode', options.permissionMode);
     // Non-empty configured tools may run without an interactive approval prompt.
     // Do not emit a valueless variadic flag for the explicit no-tools case.
     if (options.allowedTools.length > 0) args.push('--allowedTools', ...options.allowedTools);

--- a/packages/plugin-provider-claude-code/src/protocol.ts
+++ b/packages/plugin-provider-claude-code/src/protocol.ts
@@ -4,6 +4,8 @@ import { CLAUDE_CODE_SYSTEM } from './constants.js';
 interface ProtocolState {
   started: boolean;
   ended: boolean;
+  /** Current streamed block. Native tool records are consumed by Claude itself. */
+  blockType?: 'text' | 'tool_use' | 'tool_result';
   stopReason: 'end_turn' | 'max_tokens' | 'stop_sequence' | 'error';
   inputTokens?: number;
   outputTokens?: number;
@@ -47,23 +49,31 @@ export function parseClaudeRecord(line: string, state: ProtocolState): ProviderE
   }
 
   if (value.type === 'system') return [];
-  if (value.type === 'assistant') return parseAssistantRecord(value);
+  if (value.type === 'assistant' || value.type === 'user') return parseMessageRecord(value);
   if (value.type === 'stream_event') return parseStreamEvent(value.event, state);
   if (value.type === 'result') return parseResult(value, state);
   throw new Error(`Claude CLI emitted unsupported stream-json record: ${value.type}`);
 }
 
-function parseAssistantRecord(record: Record<string, unknown>): ProviderEvent[] {
+function parseMessageRecord(record: Record<string, unknown>): ProviderEvent[] {
   if (!isRecord(record.message) || !Array.isArray(record.message.content)) {
     throw new Error('Claude CLI emitted malformed assistant record');
   }
   for (const block of record.message.content) {
-    if (!isRecord(block) || block.type !== 'text' || typeof block.text !== 'string') {
+    if (!isRecord(block) || typeof block.type !== 'string') {
+      throw new Error('Claude CLI emitted malformed assistant content');
+    }
+    if (block.type === 'text' && typeof block.text !== 'string') {
+      throw new Error('Claude CLI emitted malformed assistant text');
+    }
+    // tool_use/tool_result are internal CLI bookkeeping. Claude has already
+    // executed them; translating these records to ProviderEvents would make the
+    // moxxy dispatcher execute the same operation a second time.
+    if (block.type !== 'text' && block.type !== 'tool_use' && block.type !== 'tool_result') {
       throw new Error('Claude CLI emitted unsupported assistant content');
     }
   }
-  // Partial text arrives through stream_event records; validating this envelope
-  // prevents a new native-tool block from being silently ignored.
+  // Partial text arrives through stream_event records.
   return [];
 }
 
@@ -76,18 +86,32 @@ function parseStreamEvent(raw: unknown, state: ProtocolState): ProviderEvent[] {
       state.started = true;
       return [];
     case 'content_block_start': {
-      if (!isRecord(raw.content_block) || raw.content_block.type !== 'text') {
-        throw new Error('Claude CLI emitted unsupported non-text content block');
+      if (!isRecord(raw.content_block) || typeof raw.content_block.type !== 'string') {
+        throw new Error('Claude CLI emitted malformed content block');
       }
+      if (raw.content_block.type !== 'text' && raw.content_block.type !== 'tool_use' && raw.content_block.type !== 'tool_result') {
+        throw new Error('Claude CLI emitted unsupported content block');
+      }
+      state.blockType = raw.content_block.type;
       return [];
     }
     case 'content_block_delta': {
-      if (!isRecord(raw.delta) || raw.delta.type !== 'text_delta' || typeof raw.delta.text !== 'string') {
-        throw new Error('Claude CLI emitted unsupported content delta');
+      if (!isRecord(raw.delta) || typeof raw.delta.type !== 'string') {
+        throw new Error('Claude CLI emitted malformed content delta');
+      }
+      if (state.blockType !== 'text') {
+        // input_json_delta and tool result deltas describe work performed by the
+        // child and must not escape as moxxy tool events.
+        return [];
+      }
+      if (raw.delta.type !== 'text_delta' || typeof raw.delta.text !== 'string') {
+        throw new Error('Claude CLI emitted unsupported text delta');
       }
       return [{ type: 'text_delta', delta: raw.delta.text }];
     }
     case 'content_block_stop':
+      state.blockType = undefined;
+      return [];
     case 'message_stop':
       return [];
     case 'message_delta': {

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -76,6 +76,40 @@ describe('claude-code provider definition', () => {
     expect(input).not.toContain('oauth-secret');
   });
 
+  it('runs native tools in the configured workspace without emitting dispatcher tool events', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'moxxy-claude-workspace-'));
+    tempDirs.push(workspace);
+    const dir = await makeFakeClaude([
+      { type: 'assistant', message: { content: [{ type: 'tool_use', id: 'edit-1', name: 'Write', input: { file_path: 'done.txt' } }] } },
+      { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'tool_use', id: 'edit-1', name: 'Write' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: '{}' } } },
+      { type: 'stream_event', event: { type: 'content_block_stop' } },
+      { type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 'edit-1', content: 'ok' }] } },
+      { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'text', text: '' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Edited.' } } },
+      { type: 'result', subtype: 'success', is_error: false, result: 'Edited.', usage: { input_tokens: 4, output_tokens: 1 } },
+    ]);
+    const client = createClaudeCodeClient({
+      executable: join(dir, 'claude'),
+      mode: 'native-tools',
+      permissionMode: 'acceptEdits',
+      allowedTools: ['Read', 'Write'],
+      cwd: workspace,
+    });
+    const events = await collect(client.stream(textRequest()));
+
+    expect(events.filter((event) => event.type.startsWith('tool_use'))).toEqual([]);
+    expect(events.filter((event) => event.type === 'message_end')).toHaveLength(1);
+    expect(events).toContainEqual({ type: 'text_delta', delta: 'Edited.' });
+    expect(await readFile(join(dir, 'cwd.txt'), 'utf8')).toBe(await realpath(workspace));
+    const args = JSON.parse(await readFile(join(dir, 'args.json'), 'utf8')) as string[];
+    expect(args).toEqual(expect.arrayContaining([
+      '--permission-mode', 'acceptEdits', '--allowedTools', 'Read', 'Write',
+    ]));
+    expect(args).not.toContain('bypassPermissions');
+    expect(args).not.toEqual(expect.arrayContaining(['--tools', '']));
+  });
+
   it.each(['claude-fable-5', 'claude-opus-4-8'])('passes the selected %s model as an exact structured argument', async (model) => {
     const dir = await makeFakeClaude([
       { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } },
@@ -126,6 +160,23 @@ describe('claude-code provider definition', () => {
     for (const model of supported) expect((rejected[1] as { message: string }).message).toContain(model);
   });
 
+  it('surfaces a permission denial as a clear non-retryable error', async () => {
+    const dir = await makeFakeClaude([
+      { type: 'result', subtype: 'error_during_execution', is_error: true, result: 'Permission denied for Edit' },
+    ]);
+    const events = await collect(createClaudeCodeClient({
+      executable: join(dir, 'claude'),
+      mode: 'native-tools',
+      allowedTools: ['Read'],
+    }).stream(textRequest()));
+    expect(events[1]).toMatchObject({
+      type: 'error',
+      message: expect.stringMatching(/Claude Code permission denied.*Edit/i),
+      retryable: false,
+    });
+    expect(events.some((event) => event.type === 'message_end')).toBe(false);
+  });
+
   it('does not inject a moxxy-managed Claude token into the child environment', async () => {
     let childEnv: NodeJS.ProcessEnv | undefined;
     const prior = process.env.CLAUDE_CODE_OAUTH_TOKEN;
@@ -137,7 +188,7 @@ describe('claude-code provider definition', () => {
       executable: join(dir, 'claude'),
       spawn: (file, args, options) => {
         childEnv = options.env;
-        return spawn(file, [...args], { stdio: ['pipe', 'pipe', 'pipe'], env: options.env });
+        return spawn(file, [...args], { stdio: ['pipe', 'pipe', 'pipe'], env: options.env, cwd: options.cwd });
       },
     });
     try {
@@ -244,6 +295,7 @@ process.stdin.on('data', chunk => input += chunk);
 process.stdin.on('end', () => {
   fs.writeFileSync(path.join(__dirname, 'args.json'), JSON.stringify(process.argv.slice(2)));
   fs.writeFileSync(path.join(__dirname, 'input.txt'), input);
+  fs.writeFileSync(path.join(__dirname, 'cwd.txt'), process.cwd());
   for (const line of ${JSON.stringify(lines)}) console.log(line);
 });
 `;

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -88,7 +88,7 @@ describe('claude-code provider definition', () => {
       { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'text', text: '' } } },
       { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Edited.' } } },
       { type: 'result', subtype: 'success', is_error: false, result: 'Edited.', usage: { input_tokens: 4, output_tokens: 1 } },
-    ]);
+    ], { path: 'done.txt', content: 'edited by native tool\n' });
     const client = createClaudeCodeClient({
       executable: join(dir, 'claude'),
       mode: 'native-tools',
@@ -102,12 +102,29 @@ describe('claude-code provider definition', () => {
     expect(events.filter((event) => event.type === 'message_end')).toHaveLength(1);
     expect(events).toContainEqual({ type: 'text_delta', delta: 'Edited.' });
     expect(await readFile(join(dir, 'cwd.txt'), 'utf8')).toBe(await realpath(workspace));
+    expect(await readFile(join(workspace, 'done.txt'), 'utf8')).toBe('edited by native tool\n');
     const args = JSON.parse(await readFile(join(dir, 'args.json'), 'utf8')) as string[];
     expect(args).toEqual(expect.arrayContaining([
-      '--permission-mode', 'acceptEdits', '--allowedTools', 'Read', 'Write',
+      '--tools', 'Read', 'Write', '--permission-mode', 'acceptEdits', '--allowedTools', 'Read', 'Write',
     ]));
     expect(args).not.toContain('bypassPermissions');
     expect(args).not.toEqual(expect.arrayContaining(['--tools', '']));
+  });
+
+  it('uses a safe permission default and a valid no-tools invocation for an empty native allow-list', async () => {
+    const dir = await makeFakeClaude([
+      { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } },
+    ]);
+    await collect(createClaudeCodeClient({
+      executable: join(dir, 'claude'),
+      mode: 'native-tools',
+      allowedTools: [],
+    }).stream(textRequest()));
+
+    const args = JSON.parse(await readFile(join(dir, 'args.json'), 'utf8')) as string[];
+    expect(args).toEqual(expect.arrayContaining(['--tools', '', '--permission-mode', 'default']));
+    expect(args).not.toContain('--allowedTools');
+    expect(args).not.toContain('bypassPermissions');
   });
 
   it.each(['claude-fable-5', 'claude-opus-4-8'])('passes the selected %s model as an exact structured argument', async (model) => {
@@ -278,11 +295,17 @@ function textRequest(): ProviderRequest {
   };
 }
 
-async function makeFakeClaude(records: unknown[]): Promise<string> {
-  return makeFakeClaudeRaw(records.map((record) => JSON.stringify(record)));
+async function makeFakeClaude(
+  records: unknown[],
+  workspaceWrite?: { readonly path: string; readonly content: string },
+): Promise<string> {
+  return makeFakeClaudeRaw(records.map((record) => JSON.stringify(record)), workspaceWrite);
 }
 
-async function makeFakeClaudeRaw(lines: string[]): Promise<string> {
+async function makeFakeClaudeRaw(
+  lines: string[],
+  workspaceWrite?: { readonly path: string; readonly content: string },
+): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'moxxy-claude-test-'));
   tempDirs.push(dir);
   const executable = join(dir, 'claude');
@@ -296,6 +319,8 @@ process.stdin.on('end', () => {
   fs.writeFileSync(path.join(__dirname, 'args.json'), JSON.stringify(process.argv.slice(2)));
   fs.writeFileSync(path.join(__dirname, 'input.txt'), input);
   fs.writeFileSync(path.join(__dirname, 'cwd.txt'), process.cwd());
+  const workspaceWrite = ${JSON.stringify(workspaceWrite)};
+  if (workspaceWrite) fs.writeFileSync(path.join(process.cwd(), workspaceWrite.path), workspaceWrite.content);
   for (const line of ${JSON.stringify(lines)}) console.log(line);
 });
 `;

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -111,7 +111,7 @@ describe('claude-code provider definition', () => {
     expect(args).not.toEqual(expect.arrayContaining(['--tools', '']));
   });
 
-  it('uses a safe permission default and a valid no-tools invocation for an empty native allow-list', async () => {
+  it('leaves the safe permission default to Claude and uses a valid no-tools invocation for an empty native allow-list', async () => {
     const dir = await makeFakeClaude([
       { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } },
     ]);
@@ -122,7 +122,8 @@ describe('claude-code provider definition', () => {
     }).stream(textRequest()));
 
     const args = JSON.parse(await readFile(join(dir, 'args.json'), 'utf8')) as string[];
-    expect(args).toEqual(expect.arrayContaining(['--tools', '', '--permission-mode', 'default']));
+    expect(args).toEqual(expect.arrayContaining(['--tools', '']));
+    expect(args).not.toContain('--permission-mode');
     expect(args).not.toContain('--allowedTools');
     expect(args).not.toContain('bypassPermissions');
   });
@@ -316,8 +317,15 @@ let input = '';
 process.stdin.setEncoding('utf8');
 process.stdin.on('data', chunk => input += chunk);
 process.stdin.on('end', () => {
-  fs.writeFileSync(path.join(__dirname, 'args.json'), JSON.stringify(process.argv.slice(2)));
+  const args = process.argv.slice(2);
+  fs.writeFileSync(path.join(__dirname, 'args.json'), JSON.stringify(args));
   fs.writeFileSync(path.join(__dirname, 'input.txt'), input);
+  const permissionModeIndex = args.indexOf('--permission-mode');
+  if (permissionModeIndex >= 0 && !['acceptEdits', 'plan', 'dontAsk', 'bypassPermissions'].includes(args[permissionModeIndex + 1])) {
+    console.error('Invalid permission mode: ' + args[permissionModeIndex + 1]);
+    process.exitCode = 2;
+    return;
+  }
   fs.writeFileSync(path.join(__dirname, 'cwd.txt'), process.cwd());
   const workspaceWrite = ${JSON.stringify(workspaceWrite)};
   if (workspaceWrite) fs.writeFileSync(path.join(process.cwd(), workspaceWrite.path), workspaceWrite.content);

--- a/packages/plugin-provider-claude-code/src/provider.ts
+++ b/packages/plugin-provider-claude-code/src/provider.ts
@@ -38,6 +38,14 @@ export interface ClaudeCodeProviderConfig {
   readonly executable?: string;
   /** Persisted provider-item model (`plugins.provider.items.claude-code.model`). */
   readonly model?: string;
+  /** Transport mode. Native tools are opt-in; omitted defaults to text-only. */
+  readonly mode?: 'text' | 'native-tools';
+  /** Claude CLI permission mode. Unsafe modes are never selected by the adapter. */
+  readonly permissionMode?: 'default' | 'acceptEdits' | 'plan' | 'dontAsk' | 'bypassPermissions';
+  /** Optional allow-list of Claude native tool names. */
+  readonly allowedTools?: ReadonlyArray<string>;
+  /** Runner workspace. Supplied by CLI activation rather than user configuration. */
+  readonly cwd?: string;
   /** Optional default model override (kept for programmatic callers). */
   readonly defaultModel?: string;
   /** Process test seam; production callers should leave this unset. */
@@ -50,11 +58,19 @@ export class ClaudeCodeProvider implements LLMProvider {
 
   private readonly executable: string;
   private readonly defaultModel: string;
+  private readonly nativeTools: boolean;
+  private readonly permissionMode?: string;
+  private readonly allowedTools: ReadonlyArray<string>;
+  private readonly cwd: string;
   private readonly spawn?: ClaudeSpawn;
 
   constructor(config: ClaudeCodeProviderConfig = {}) {
     this.executable = config.executable ?? 'claude';
     this.defaultModel = config.defaultModel ?? CLAUDE_CODE_DEFAULT_MODEL;
+    this.nativeTools = config.mode === 'native-tools';
+    if (config.permissionMode) this.permissionMode = config.permissionMode;
+    this.allowedTools = config.allowedTools ?? [];
+    this.cwd = config.cwd ?? process.cwd();
     if (config.spawn) this.spawn = config.spawn;
   }
 
@@ -79,6 +95,10 @@ export class ClaudeCodeProvider implements LLMProvider {
         executable: this.executable,
         model,
         prompt,
+        cwd: this.cwd,
+        nativeTools: this.nativeTools,
+        allowedTools: this.allowedTools,
+        ...(this.permissionMode ? { permissionMode: this.permissionMode } : {}),
         ...(req.signal ? { signal: req.signal } : {}),
         ...(this.spawn ? { spawn: this.spawn } : {}),
       });
@@ -88,7 +108,7 @@ export class ClaudeCodeProvider implements LLMProvider {
           if (next.value.exitCode !== 0 && !terminal) {
             yield {
               type: 'error',
-              message: modelSelectionError(
+              message: claudeCliError(
                 model,
                 next.value.stderr || `Claude CLI exited with code ${next.value.exitCode}`,
               ),
@@ -102,7 +122,7 @@ export class ClaudeCodeProvider implements LLMProvider {
           if (event.type === 'message_end') terminal = true;
           if (event.type === 'error') {
             terminal = true;
-            yield { ...event, message: modelSelectionError(model, event.message) };
+            yield { ...event, message: claudeCliError(model, event.message) };
           } else {
             yield event;
           }
@@ -153,7 +173,11 @@ function assertTextOnlyRequest(req: ProviderRequest): void {
   }
 }
 
-function modelSelectionError(model: string, detail: string): string {
+function claudeCliError(model: string, detail: string): string {
+  if (/permission|denied|not allowed/i.test(detail)) {
+    return `Claude Code permission denied: ${detail}. ` +
+      'Review plugins.provider.items.claude-code.config.permissionMode and allowedTools.';
+  }
   return `Claude Code rejected model "${model}": ${detail}. ` +
     `Select a supported model: ${claudeCodeModels.map((candidate) => candidate.id).join(', ')}.`;
 }

--- a/packages/plugin-provider-claude-code/src/provider.ts
+++ b/packages/plugin-provider-claude-code/src/provider.ts
@@ -40,8 +40,8 @@ export interface ClaudeCodeProviderConfig {
   readonly model?: string;
   /** Transport mode. Native tools are opt-in; omitted defaults to text-only. */
   readonly mode?: 'text' | 'native-tools';
-  /** Claude CLI permission mode. Unsafe modes are never selected by the adapter. */
-  readonly permissionMode?: 'default' | 'acceptEdits' | 'plan' | 'dontAsk' | 'bypassPermissions';
+  /** Claude CLI permission mode. Omitted uses the CLI's safe default. */
+  readonly permissionMode?: 'acceptEdits' | 'plan' | 'dontAsk' | 'bypassPermissions';
   /** Optional allow-list of Claude native tool names. */
   readonly allowedTools?: ReadonlyArray<string>;
   /** Runner workspace. Supplied by CLI activation rather than user configuration. */


### PR DESCRIPTION
Add an explicit provider config mode in `packages/plugin-provider-claude-code/src/provider.ts` for Claude Code's native tools. Wire `plugins.provider.items.claude-code.config` through `packages/cli/src/provider-credentials.ts` and `setup/activate-provider.ts`, then launch the child in the runner's workspace with the configured Claude permission mode and allowed-tool restrictions. Consume internal tool-use/result stream records without converting them to moxxy `tool_use_*` events, which would execute operations twice.

### Acceptance criteria
- With native tools enabled, an integration test using a fake CLI observes the runner workspace as the child working directory and completes a file-edit task with one final assistant response.
- Internal Claude tool records are consumed without causing moxxy's tool dispatcher to execute duplicate calls.
- The adapter never selects a bypass-permissions mode implicitly; any unsafe Claude permission mode requires an explicit provider configuration value.
- A Claude permission denial is surfaced as a clear, non-retryable error rather than a successful empty response.
- With native tools disabled, the child receives a no-tools restriction and retains the text-only behavior from the first slice.
- Runtime provider switching reuses the saved executable, permission, and allowed-tool configuration.

_Task `tsk-3ae9d59d-3c6` on the Companion board._