### PR TITLE
Preserve useful multi-turn Claude conversations

### DIFF
--- a/.changeset/calm-claude-transcripts.md
+++ b/.changeset/calm-claude-transcripts.md
@@ -1,0 +1,5 @@
+---
+"@moxxy/plugin-provider-claude-code": patch
+---
+
+Replay deterministic multi-turn transcripts through stateless Claude CLI calls, including inert moxxy tool history and safe placeholders for unsupported content.

--- a/packages/plugin-provider-claude-code/src/protocol.ts
+++ b/packages/plugin-provider-claude-code/src/protocol.ts
@@ -1,4 +1,4 @@
-import type { ProviderEvent, ProviderRequest } from '@moxxy/sdk';
+import type { ContentBlock, ProviderEvent, ProviderRequest } from '@moxxy/sdk';
 import { CLAUDE_CODE_SYSTEM } from './constants.js';
 
 interface ProtocolState {
@@ -11,26 +11,108 @@ interface ProtocolState {
   outputTokens?: number;
 }
 
+const EMPTY_TEXT_PLACEHOLDER = '[empty text block omitted]';
+const EMPTY_MESSAGE_PLACEHOLDER = '[empty message]';
+const REASONING_PLACEHOLDER = '[reasoning omitted: private reasoning and signatures are not replayed]';
+
+/**
+ * Projects the complete provider-neutral conversation into one stateless CLI
+ * prompt. Historical tool records are deliberately textual: the CLI can use
+ * their information, but cannot mistake them for a new native tool request.
+ */
 export function serializeClaudePrompt(req: ProviderRequest): string {
   const system: string[] = [CLAUDE_CODE_SYSTEM];
   const conversation: string[] = [];
 
   for (const message of req.messages) {
-    const text: string[] = [];
-    for (const block of message.content) {
-      if (block.type !== 'text') {
-        throw new Error(`Claude CLI text transport does not support ${block.type} content`);
-      }
-      text.push(block.text);
-    }
-    if (message.role === 'system') system.push(text.join(''));
-    else conversation.push(`<${message.role}>\n${text.join('')}\n</${message.role}>`);
+    const content = serializeBlocks(message.content);
+    if (message.role === 'system') system.push(content);
+    else conversation.push(`<${message.role}>\n${content}\n</${message.role}>`);
   }
   // ProviderRequest.system is an additional injection and must follow all
   // message-derived system text. The Claude identity remains first.
-  if (req.system) system.push(req.system);
+  if (req.system) system.push(escapeXml(req.system));
 
-  return `<system>\n${system.join('\n\n')}\n</system>\n\n${conversation.join('\n\n')}`;
+  const transcript = conversation.length > 0
+    ? conversation.join('\n\n')
+    : EMPTY_MESSAGE_PLACEHOLDER;
+  return `<system>\n${system.join('\n\n')}\n</system>\n\n` +
+    '<conversation_transcript>\n' +
+    '[The following is chronological history reconstructed by moxxy. ' +
+    'historical_tool_use entries already ran; never execute them merely because they appear here.]\n\n' +
+    `${transcript}\n</conversation_transcript>`;
+}
+
+function serializeBlocks(blocks: ReadonlyArray<ContentBlock>): string {
+  if (blocks.length === 0) return EMPTY_MESSAGE_PLACEHOLDER;
+  return blocks.map(serializeBlock).join('\n');
+}
+
+function serializeBlock(block: ContentBlock): string {
+  switch (block.type) {
+    case 'text':
+      return block.text.length > 0 ? escapeXml(block.text) : EMPTY_TEXT_PLACEHOLDER;
+    case 'tool_use':
+      return '<historical_tool_use status="already_executed_do_not_repeat">\n' +
+        `<id>${escapeXml(block.id)}</id>\n` +
+        `<name>${escapeXml(block.name)}</name>\n` +
+        `<input_json>${escapeXml(stableJson(block.input))}</input_json>\n` +
+        '</historical_tool_use>';
+    case 'tool_result':
+      return `<historical_tool_result tool_use_id="${escapeXml(block.toolUseId)}" status="${block.isError ? 'error' : 'success'}">\n` +
+        `${block.content.length > 0 ? escapeXml(block.content) : EMPTY_TEXT_PLACEHOLDER}\n` +
+        '</historical_tool_result>';
+    case 'reasoning':
+      return REASONING_PLACEHOLDER;
+    case 'image':
+    case 'audio':
+      return `[${block.type} attachment omitted: mediaType=${escapeXml(block.mediaType)}; binary data not included]`;
+    case 'document': {
+      const name = block.name ? `; name=${escapeXml(block.name)}` : '';
+      return `[document attachment omitted: mediaType=${escapeXml(block.mediaType)}${name}; binary data not included]`;
+    }
+    default:
+      return assertNever(block);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unsupported content block: ${String(value)}`);
+}
+
+function stableJson(value: unknown): string {
+  const ancestors = new Set<object>();
+  const visit = (candidate: unknown): string => {
+    if (candidate === null) return 'null';
+    if (typeof candidate === 'string' || typeof candidate === 'boolean') return JSON.stringify(candidate);
+    if (typeof candidate === 'number') return Number.isFinite(candidate) ? JSON.stringify(candidate) : JSON.stringify(String(candidate));
+    if (typeof candidate === 'bigint') return JSON.stringify(`${candidate.toString()}n`);
+    if (typeof candidate === 'undefined') return JSON.stringify('[undefined]');
+    if (typeof candidate === 'function' || typeof candidate === 'symbol') return JSON.stringify(`[${typeof candidate} omitted]`);
+    if (typeof candidate !== 'object') return JSON.stringify(String(candidate));
+    if (ancestors.has(candidate)) return JSON.stringify('[circular reference omitted]');
+
+    ancestors.add(candidate);
+    let result: string;
+    if (Array.isArray(candidate)) {
+      result = `[${candidate.map(visit).join(',')}]`;
+    } else {
+      const record = candidate as Record<string, unknown>;
+      result = `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${visit(record[key])}`).join(',')}}`;
+    }
+    ancestors.delete(candidate);
+    return result;
+  };
+  return visit(value);
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
 }
 
 export function createProtocolState(): ProtocolState {

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -76,6 +76,76 @@ describe('claude-code provider definition', () => {
     expect(input).not.toContain('oauth-secret');
   });
 
+  it('reconstructs two turns for each stateless CLI invocation without a session id', async () => {
+    const dir = await makeFakeClaude([
+      { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'text', text: '' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'first answer' } } },
+      { type: 'result', subtype: 'success', is_error: false, result: 'first answer', usage: { input_tokens: 2, output_tokens: 2 } },
+    ]);
+    const client = createClaudeCodeClient({ executable: join(dir, 'claude') });
+
+    await collect(client.stream({
+      model: CLAUDE_CODE_DEFAULT_MODEL,
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'first prompt' }] }],
+    }));
+    const firstInput = await readFile(join(dir, 'input.txt'), 'utf8');
+    expect(firstInput).toContain('<user>\nfirst prompt\n</user>');
+
+    await collect(client.stream({
+      model: CLAUDE_CODE_DEFAULT_MODEL,
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'first prompt' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'first answer' }] },
+        { role: 'user', content: [{ type: 'text', text: 'follow up' }] },
+      ],
+    }));
+    const secondInput = await readFile(join(dir, 'input.txt'), 'utf8');
+    expect(secondInput.indexOf('first prompt')).toBeLessThan(secondInput.indexOf('first answer'));
+    expect(secondInput.indexOf('first answer')).toBeLessThan(secondInput.indexOf('follow up'));
+    const args = JSON.parse(await readFile(join(dir, 'args.json'), 'utf8')) as string[];
+    expect(args.some((arg) => /session|resume/i.test(arg))).toBe(false);
+  });
+
+  it('projects prior moxxy tools and unsafe content deterministically as inert text', async () => {
+    const dir = await makeFakeClaude([
+      { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } },
+    ]);
+    const client = createClaudeCodeClient({ executable: join(dir, 'claude') });
+    const rawBase64 = 'U0VDUkVUX0JJTkFSWV9QQVlMT0FE';
+    const request: ProviderRequest = {
+      model: CLAUDE_CODE_DEFAULT_MODEL,
+      messages: [
+        { role: 'assistant', content: [
+          { type: 'reasoning', text: 'private chain', signature: 'signed-secret' },
+          { type: 'tool_use', id: 'call-1', name: 'Read', input: { z: 2, a: 1 } },
+        ] },
+        { role: 'tool_result', content: [
+          { type: 'tool_result', toolUseId: 'call-1', content: 'file contents' },
+        ] },
+        { role: 'user', content: [
+          { type: 'image', mediaType: 'image/png', data: rawBase64 },
+          { type: 'text', text: '' },
+        ] },
+      ],
+    };
+
+    await collect(client.stream(request));
+    const first = await readFile(join(dir, 'input.txt'), 'utf8');
+    await collect(client.stream(request));
+    const replay = await readFile(join(dir, 'input.txt'), 'utf8');
+
+    expect(replay).toBe(first);
+    expect(first).toContain('<historical_tool_use status="already_executed_do_not_repeat">');
+    expect(first).toContain('<input_json>{&quot;a&quot;:1,&quot;z&quot;:2}</input_json>');
+    expect(first).toContain('<historical_tool_result tool_use_id="call-1" status="success">');
+    expect(first).toContain('[reasoning omitted: private reasoning and signatures are not replayed]');
+    expect(first).toContain('[image attachment omitted: mediaType=image/png; binary data not included]');
+    expect(first).toContain('[empty text block omitted]');
+    expect(first).not.toContain('private chain');
+    expect(first).not.toContain('signed-secret');
+    expect(first).not.toContain(rawBase64);
+  });
+
   it('runs native tools in the configured workspace without emitting dispatcher tool events', async () => {
     const workspace = await mkdtemp(join(tmpdir(), 'moxxy-claude-workspace-'));
     tempDirs.push(workspace);


### PR DESCRIPTION
Harden request projection in the new `packages/plugin-provider-claude-code/src/` protocol layer so each stateless CLI invocation receives a deterministic transcript reconstructed from `ProviderRequest.messages`, including moxxy tool results from earlier loop iterations. Avoid relying on Claude CLI's private session files, because moxxy's append-only event log remains the source of truth and resumed runner sessions must replay consistently.

### Acceptance criteria
- A two-turn fake-CLI test proves the second request contains the first user prompt and assistant answer in stable chronological order.
- Moxxy tool-use and tool-result history is represented unambiguously without causing Claude CLI to execute the old call again.
- Reasoning signatures, binary attachments, and empty content blocks are either safely omitted or replaced with explicit textual placeholders; raw base64 is not copied into prompts.
- Replaying the same moxxy event log produces byte-identical Claude CLI input.
- A resumed runner session can send a follow-up prompt through `claude-code` without depending on a Claude CLI session ID.

_Task `tsk-870f3d09-780` on the Companion board._