### PR TITLE
Make Claude subprocess failures safe and cancellable

### DIFF
--- a/.changeset/safe-claude-subprocesses.md
+++ b/.changeset/safe-claude-subprocesses.md
@@ -1,0 +1,5 @@
+---
+"@moxxy/plugin-provider-claude-code": patch
+---
+
+Make Claude CLI subprocess failures bounded, cancellable, and safely cleaned up.

--- a/packages/plugin-provider-claude-code/src/process.test.ts
+++ b/packages/plugin-provider-claude-code/src/process.test.ts
@@ -1,0 +1,208 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ClaudeProcessError, runClaudeProcess, type ClaudeProcessOptions, type ClaudeSpawnOptions } from './process.js';
+
+class ControlledChild extends EventEmitter {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly stdio = [this.stdin, this.stdout, this.stderr] as const;
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  readonly kills: NodeJS.Signals[] = [];
+
+  constructor(private readonly closeOn: NodeJS.Signals | undefined = 'SIGTERM') {
+    super();
+  }
+
+  kill(signal: NodeJS.Signals = 'SIGTERM'): boolean {
+    this.kills.push(signal);
+    if (signal === this.closeOn) this.close(null, signal);
+    return true;
+  }
+
+  close(code: number | null = 0, signal: NodeJS.Signals | null = null): void {
+    if (this.exitCode !== null || this.signalCode !== null) return;
+    this.exitCode = code;
+    this.signalCode = signal;
+    this.emit('close', code, signal);
+  }
+
+  asChild(): ChildProcessWithoutNullStreams {
+    return this as unknown as ChildProcessWithoutNullStreams;
+  }
+}
+
+const baseOptions: ClaudeProcessOptions = {
+  executable: 'claude',
+  model: 'claude-sonnet-4-6',
+  prompt: 'hello',
+  cwd: '/tmp',
+  nativeTools: false,
+  allowedTools: [],
+};
+
+function processWith(child: ControlledChild, overrides: Partial<ClaudeProcessOptions> = {}) {
+  return runClaudeProcess({ ...baseOptions, ...overrides, spawn: () => child.asChild() });
+}
+
+async function rejection(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+    throw new Error('expected rejection');
+  } catch (error) {
+    return error as Error;
+  }
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('runClaudeProcess lifecycle', () => {
+  it('removes nested Claude environment markers without mutating the parent environment', async () => {
+    const child = new ControlledChild();
+    let spawnOptions: ClaudeSpawnOptions | undefined;
+    const oldClaudeCode = process.env.CLAUDECODE;
+    const oldEntrypoint = process.env.CLAUDE_CODE_ENTRYPOINT;
+    process.env.CLAUDECODE = '1';
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+    try {
+      const lines = runClaudeProcess({
+        ...baseOptions,
+        spawn: (_file, _args, options) => {
+          spawnOptions = options;
+          return child.asChild();
+        },
+      });
+      const pending = lines.next();
+      child.close(0);
+      await pending;
+      expect(spawnOptions?.env.CLAUDECODE).toBeUndefined();
+      expect(spawnOptions?.env.CLAUDE_CODE_ENTRYPOINT).toBeUndefined();
+      expect(process.env.CLAUDECODE).toBe('1');
+      expect(process.env.CLAUDE_CODE_ENTRYPOINT).toBe('cli');
+    } finally {
+      if (oldClaudeCode === undefined) delete process.env.CLAUDECODE;
+      else process.env.CLAUDECODE = oldClaudeCode;
+      if (oldEntrypoint === undefined) delete process.env.CLAUDE_CODE_ENTRYPOINT;
+      else process.env.CLAUDE_CODE_ENTRYPOINT = oldEntrypoint;
+    }
+  });
+
+  it('cancels promptly with one abort error and leaves no timer or child alive', async () => {
+    vi.useFakeTimers();
+    const child = new ControlledChild();
+    const controller = new AbortController();
+    const lines = processWith(child, { signal: controller.signal });
+    const pending = lines.next();
+    controller.abort();
+    const error = await rejection(pending);
+    expect(error).toMatchObject({ failure: 'aborted' });
+    expect(child.kills).toEqual(['SIGTERM']);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(await lines.next()).toEqual({ done: true, value: undefined });
+  });
+
+  it('times out startup and clears all lifecycle timers', async () => {
+    vi.useFakeTimers();
+    const child = new ControlledChild();
+    const errorPromise = rejection(processWith(child, { startupTimeoutMs: 50 }).next());
+    await vi.advanceTimersByTimeAsync(50);
+    const error = await errorPromise;
+    expect(error).toMatchObject({ failure: 'startup_timeout' });
+    expect(child.kills).toEqual(['SIGTERM']);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('resets the idle timeout on every non-empty record', async () => {
+    vi.useFakeTimers();
+    const child = new ControlledChild();
+    const lines = processWith(child, { startupTimeoutMs: 100, idleTimeoutMs: 100 });
+    const first = lines.next();
+    await vi.advanceTimersByTimeAsync(90);
+    child.stdout.write('{"type":"system"}\n');
+    expect(await first).toMatchObject({ done: false });
+
+    const second = lines.next();
+    await vi.advanceTimersByTimeAsync(90);
+    child.stdout.write('{"type":"system"}\n');
+    expect(await second).toMatchObject({ done: false });
+
+    const timedOut = rejection(lines.next());
+    await vi.advanceTimersByTimeAsync(101);
+    expect(await timedOut).toMatchObject({ failure: 'idle_timeout' });
+    expect(child.kills).toEqual(['SIGTERM']);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('caps stderr and accepts a final unterminated record within the cap', async () => {
+    const child = new ControlledChild();
+    const lines = processWith(child, { maxStderrChars: 5, maxRecordChars: 20 });
+    const first = lines.next();
+    child.stderr.write('abcdefgh');
+    child.stdout.write('{"ok":true}');
+    child.close(7);
+    expect(await first).toEqual({ done: false, value: '{"ok":true}' });
+    expect(await lines.next()).toEqual({ done: true, value: { exitCode: 7, stderr: 'abcde' } });
+  });
+
+  it('rejects an oversized unterminated record as a protocol failure', async () => {
+    vi.useFakeTimers();
+    const child = new ControlledChild();
+    const lines = processWith(child, { maxRecordChars: 5 });
+    const pending = lines.next();
+    child.stdout.write('123456');
+    expect(await rejection(pending)).toMatchObject({ failure: 'protocol' });
+    expect(child.kills).toEqual(['SIGTERM']);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('escalates SIGTERM to SIGKILL once even when cleanup requests termination again', async () => {
+    vi.useFakeTimers();
+    const child = new ControlledChild('SIGKILL');
+    const controller = new AbortController();
+    const errorPromise = rejection(processWith(child, { signal: controller.signal }).next());
+    controller.abort();
+    await flush();
+    expect(child.kills).toEqual(['SIGTERM']);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(await errorPromise).toMatchObject({ failure: 'aborted' });
+    expect(child.kills).toEqual(['SIGTERM', 'SIGKILL']);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('terminates immediately when the consumer returns early', async () => {
+    vi.useFakeTimers();
+    const child = new ControlledChild();
+    const lines = processWith(child);
+    const first = lines.next();
+    child.stdout.write('record\n');
+    expect(await first).toEqual({ done: false, value: 'record' });
+    await lines.return({ exitCode: 0, stderr: '' });
+    expect(child.kills).toEqual(['SIGTERM']);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('leaves no child or timer after normal completion', async () => {
+    vi.useFakeTimers();
+    const child = new ControlledChild();
+    const lines = processWith(child);
+    const pending = lines.next();
+    child.close(0);
+    expect(await pending).toEqual({ done: true, value: { exitCode: 0, stderr: '' } });
+    expect(child.kills).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('preserves the typed process error identity', () => {
+    expect(new ClaudeProcessError('protocol', 'bad')).toBeInstanceOf(Error);
+  });
+});

--- a/packages/plugin-provider-claude-code/src/process.ts
+++ b/packages/plugin-provider-claude-code/src/process.ts
@@ -77,6 +77,7 @@ export async function* runClaudeProcess(
   let failure: Error | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
   let killTimer: ReturnType<typeof setTimeout> | undefined;
+  let terminationRequested = false;
   const startupTimeoutMs = positive(options.startupTimeoutMs, DEFAULT_STARTUP_TIMEOUT_MS);
   const idleTimeoutMs = positive(options.idleTimeoutMs, DEFAULT_IDLE_TIMEOUT_MS);
   const maxStderrChars = positive(options.maxStderrChars, DEFAULT_MAX_STDERR_CHARS);
@@ -93,10 +94,12 @@ export async function* runClaudeProcess(
     timer = undefined;
   };
   const terminate = (): void => {
-    if (child.exitCode !== null || child.signalCode !== null) return;
+    if (closed || child.exitCode !== null || child.signalCode !== null || terminationRequested) return;
+    terminationRequested = true;
     child.kill('SIGTERM');
     killTimer = setTimeout(() => {
-      if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+      killTimer = undefined;
+      if (!closed && child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
     }, KILL_GRACE_MS);
     killTimer.unref?.();
   };
@@ -158,10 +161,9 @@ export async function* runClaudeProcess(
     }
   });
 
-  const completion = new Promise<number>((resolve, reject) => {
+  const completion = new Promise<number>((resolve) => {
     child.once('error', (error) => {
       fail(error);
-      reject(error);
     });
     child.once('close', (code) => {
       closed = true;
@@ -180,9 +182,6 @@ export async function* runClaudeProcess(
       resolve(code ?? 1);
     });
   });
-  // A rejected completion is observed again in finally; prevent an early
-  // child 'error' event from becoming an unhandled rejection first.
-  void completion.catch(() => undefined);
 
   options.signal?.addEventListener('abort', onAbort, { once: true });
   if (options.signal?.aborted) onAbort();

--- a/packages/plugin-provider-claude-code/src/process.ts
+++ b/packages/plugin-provider-claude-code/src/process.ts
@@ -62,12 +62,7 @@ export async function* runClaudeProcess(
     stdio: ['pipe', 'pipe', 'pipe'], env: childOptions.env, cwd: childOptions.cwd,
   }));
 
-  let child: ChildProcessWithoutNullStreams;
-  try {
-    child = spawnImpl(options.executable, args, { env, cwd: options.cwd });
-  } catch (error) {
-    throw error;
-  }
+  const child = spawnImpl(options.executable, args, { env, cwd: options.cwd });
 
   const queue: QueueItem[] = [];
   let wake: (() => void) | undefined;

--- a/packages/plugin-provider-claude-code/src/process.ts
+++ b/packages/plugin-provider-claude-code/src/process.ts
@@ -1,5 +1,4 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
-import { createInterface } from 'node:readline';
 
 export interface ClaudeSpawnOptions {
   readonly env: NodeJS.ProcessEnv;
@@ -12,6 +11,15 @@ export type ClaudeSpawn = (
   options: ClaudeSpawnOptions,
 ) => ChildProcessWithoutNullStreams;
 
+export type ClaudeProcessFailure = 'aborted' | 'startup_timeout' | 'idle_timeout' | 'protocol';
+
+export class ClaudeProcessError extends Error {
+  constructor(readonly failure: ClaudeProcessFailure, message: string) {
+    super(message);
+    this.name = 'ClaudeProcessError';
+  }
+}
+
 export interface ClaudeProcessOptions {
   readonly executable: string;
   readonly model: string;
@@ -22,6 +30,10 @@ export interface ClaudeProcessOptions {
   readonly allowedTools: ReadonlyArray<string>;
   readonly signal?: AbortSignal;
   readonly spawn?: ClaudeSpawn;
+  readonly startupTimeoutMs?: number;
+  readonly idleTimeoutMs?: number;
+  readonly maxStderrChars?: number;
+  readonly maxRecordChars?: number;
 }
 
 export interface ClaudeProcessResult {
@@ -29,76 +41,186 @@ export interface ClaudeProcessResult {
   readonly stderr: string;
 }
 
-const MAX_STDERR_CHARS = 2048;
+const DEFAULT_STARTUP_TIMEOUT_MS = 30_000;
+const DEFAULT_IDLE_TIMEOUT_MS = 120_000;
+const DEFAULT_MAX_STDERR_CHARS = 2048;
+const DEFAULT_MAX_RECORD_CHARS = 64 * 1024;
+const KILL_GRACE_MS = 1_000;
+
+type QueueItem = { readonly line: string } | { readonly error: Error } | { readonly done: true };
 
 export async function* runClaudeProcess(
   options: ClaudeProcessOptions,
 ): AsyncGenerator<string, ClaudeProcessResult> {
-  const args = [
-    '--print',
-    '--verbose',
-    '--output-format',
-    'stream-json',
-    '--include-partial-messages',
-    '--model',
-    options.model,
-  ];
-  if (options.nativeTools) {
-    // Tool availability and permission grants are separate Claude CLI controls.
-    // Restrict availability first so ambient settings cannot expose additional tools.
-    args.push('--tools', ...(options.allowedTools.length > 0 ? options.allowedTools : ['']));
-    // Do not invent a permission mode: Claude CLI versions disagree on the
-    // accepted values (notably, some reject `default`). With no explicit
-    // provider setting, omitting the flag selects the CLI's safe default.
-    if (options.permissionMode) args.push('--permission-mode', options.permissionMode);
-    // Non-empty configured tools may run without an interactive approval prompt.
-    // Do not emit a valueless variadic flag for the explicit no-tools case.
-    if (options.allowedTools.length > 0) args.push('--allowedTools', ...options.allowedTools);
-  } else {
-    // Keep the original subscription transport text-only unless native tools
-    // were deliberately enabled in the provider item config.
-    args.splice(args.length - 2, 0, '--tools', '');
-  }
+  const args = buildArgs(options);
   const env = { ...process.env };
+  // Claude refuses nested interactive sessions. Moxxy is the parent here, not a
+  // nested Claude Code instance, even when it was launched from Claude Code.
+  delete env.CLAUDECODE;
+  delete env.CLAUDE_CODE_ENTRYPOINT;
   const spawnImpl = options.spawn ?? ((file, childArgs, childOptions) => spawn(file, [...childArgs], {
-    stdio: ['pipe', 'pipe', 'pipe'],
-    env: childOptions.env,
-    cwd: childOptions.cwd,
+    stdio: ['pipe', 'pipe', 'pipe'], env: childOptions.env, cwd: childOptions.cwd,
   }));
-  const child = spawnImpl(options.executable, args, { env, cwd: options.cwd });
-  const completion = waitForExit(child);
+
+  let child: ChildProcessWithoutNullStreams;
+  try {
+    child = spawnImpl(options.executable, args, { env, cwd: options.cwd });
+  } catch (error) {
+    throw error;
+  }
+
+  const queue: QueueItem[] = [];
+  let wake: (() => void) | undefined;
+  let stdout = '';
   let stderr = '';
-  child.stdin.on('error', () => undefined);
+  let closed = false;
+  let failure: Error | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let killTimer: ReturnType<typeof setTimeout> | undefined;
+  const startupTimeoutMs = positive(options.startupTimeoutMs, DEFAULT_STARTUP_TIMEOUT_MS);
+  const idleTimeoutMs = positive(options.idleTimeoutMs, DEFAULT_IDLE_TIMEOUT_MS);
+  const maxStderrChars = positive(options.maxStderrChars, DEFAULT_MAX_STDERR_CHARS);
+  const maxRecordChars = positive(options.maxRecordChars, DEFAULT_MAX_RECORD_CHARS);
+
+  const push = (item: QueueItem): void => {
+    queue.push(item);
+    const notify = wake;
+    wake = undefined;
+    notify?.();
+  };
+  const clearWatchdog = (): void => {
+    if (timer) clearTimeout(timer);
+    timer = undefined;
+  };
+  const terminate = (): void => {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    child.kill('SIGTERM');
+    killTimer = setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+    }, KILL_GRACE_MS);
+    killTimer.unref?.();
+  };
+  const fail = (error: Error): void => {
+    if (failure) return;
+    failure = error;
+    clearWatchdog();
+    terminate();
+    // Cancellation/failure is terminal: discard records received but not yet
+    // consumed so no text can be emitted after the single error event.
+    queue.length = 0;
+    push({ error });
+  };
+  const arm = (kind: 'startup' | 'idle'): void => {
+    clearWatchdog();
+    const delay = kind === 'startup' ? startupTimeoutMs : idleTimeoutMs;
+    timer = setTimeout(() => fail(new ClaudeProcessError(
+      kind === 'startup' ? 'startup_timeout' : 'idle_timeout',
+      kind === 'startup'
+        ? `Claude CLI did not produce a stream record within ${delay}ms`
+        : `Claude CLI stream was idle for ${delay}ms`,
+    )), delay);
+    timer.unref?.();
+  };
+  const onAbort = (): void => fail(new ClaudeProcessError('aborted', 'Claude CLI request aborted'));
+
+  child.stdin.on('error', (error) => {
+    // EPIPE commonly follows cancellation; the abort error is the useful one.
+    if (!failure) fail(error);
+  });
   child.stderr.setEncoding('utf8');
   child.stderr.on('data', (chunk: string) => {
-    if (stderr.length < MAX_STDERR_CHARS) stderr += chunk.slice(0, MAX_STDERR_CHARS - stderr.length);
+    if (stderr.length < maxStderrChars) stderr += chunk.slice(0, maxStderrChars - stderr.length);
+  });
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk: string) => {
+    if (failure) return;
+    stdout += chunk;
+    if (stdout.length > maxRecordChars && !stdout.includes('\n')) {
+      fail(new ClaudeProcessError('protocol', `Claude CLI emitted a stream record larger than ${maxRecordChars} characters`));
+      return;
+    }
+    let newline = stdout.indexOf('\n');
+    while (newline >= 0 && !failure) {
+      const line = stdout.slice(0, newline).replace(/\r$/, '');
+      stdout = stdout.slice(newline + 1);
+      if (line.length > maxRecordChars) {
+        fail(new ClaudeProcessError('protocol', `Claude CLI emitted a stream record larger than ${maxRecordChars} characters`));
+        return;
+      }
+      if (line.trim()) {
+        arm('idle');
+        push({ line });
+      }
+      newline = stdout.indexOf('\n');
+    }
+    if (stdout.length > maxRecordChars) {
+      fail(new ClaudeProcessError('protocol', `Claude CLI emitted a stream record larger than ${maxRecordChars} characters`));
+    }
   });
 
-  const abort = (): void => {
-    child.kill('SIGTERM');
-  };
-  if (options.signal?.aborted) abort();
-  options.signal?.addEventListener('abort', abort, { once: true });
+  const completion = new Promise<number>((resolve, reject) => {
+    child.once('error', (error) => {
+      fail(error);
+      reject(error);
+    });
+    child.once('close', (code) => {
+      closed = true;
+      clearWatchdog();
+      if (killTimer) clearTimeout(killTimer);
+      killTimer = undefined;
+      if (!failure && stdout.trim()) {
+        if (stdout.length > maxRecordChars) {
+          fail(new ClaudeProcessError('protocol', `Claude CLI emitted a stream record larger than ${maxRecordChars} characters`));
+        } else {
+          // A final JSON record need not end in a newline.
+          push({ line: stdout.replace(/\r$/, '') });
+        }
+      }
+      push({ done: true });
+      resolve(code ?? 1);
+    });
+  });
+  // A rejected completion is observed again in finally; prevent an early
+  // child 'error' event from becoming an unhandled rejection first.
+  void completion.catch(() => undefined);
 
-  child.stdin.end(options.prompt, 'utf8');
-  const lines = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  options.signal?.addEventListener('abort', onAbort, { once: true });
+  if (options.signal?.aborted) onAbort();
+  else arm('startup');
+  if (!failure) child.stdin.end(options.prompt, 'utf8');
+
   try {
-    for await (const line of lines) {
-      if (line.trim()) yield line;
+    while (true) {
+      if (queue.length === 0) await new Promise<void>((resolve) => { wake = resolve; });
+      const item = queue.shift();
+      if (!item) continue;
+      if ('error' in item) throw item.error;
+      if ('done' in item) break;
+      yield item.line;
     }
     const exitCode = await completion;
     return { exitCode, stderr: stderr.trim() };
   } finally {
-    options.signal?.removeEventListener('abort', abort);
-    lines.close();
-    if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
+    clearWatchdog();
+    options.signal?.removeEventListener('abort', onAbort);
+    terminate();
+    try { await completion; } catch { /* surfaced through the queue */ }
+    if (killTimer) clearTimeout(killTimer);
   }
 }
 
-function waitForExit(child: ChildProcessWithoutNullStreams): Promise<number> {
-  if (child.exitCode !== null) return Promise.resolve(child.exitCode);
-  return new Promise((resolve, reject) => {
-    child.once('error', reject);
-    child.once('close', (code) => resolve(code ?? 1));
-  });
+function buildArgs(options: ClaudeProcessOptions): string[] {
+  const args = ['--print', '--verbose', '--output-format', 'stream-json', '--include-partial-messages', '--model', options.model];
+  if (options.nativeTools) {
+    args.push('--tools', ...(options.allowedTools.length > 0 ? options.allowedTools : ['']));
+    if (options.permissionMode) args.push('--permission-mode', options.permissionMode);
+    if (options.allowedTools.length > 0) args.push('--allowedTools', ...options.allowedTools);
+  } else {
+    args.splice(args.length - 2, 0, '--tools', '');
+  }
+  return args;
+}
+
+function positive(value: number | undefined, fallback: number): number {
+  return value !== undefined && value > 0 ? value : fallback;
 }

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -1,4 +1,6 @@
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -11,6 +13,26 @@ import {
   claudeCodeProviderDef,
   createClaudeCodeClient,
 } from './index.js';
+
+class ControlledProviderChild extends EventEmitter {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  readonly kills: NodeJS.Signals[] = [];
+
+  kill(signal: NodeJS.Signals = 'SIGTERM'): boolean {
+    this.kills.push(signal);
+    this.signalCode = signal;
+    this.emit('close', null, signal);
+    return true;
+  }
+
+  asChild(): ChildProcessWithoutNullStreams {
+    return this as unknown as ChildProcessWithoutNullStreams;
+  }
+}
 
 const tempDirs: string[] = [];
 afterEach(async () => {
@@ -248,6 +270,58 @@ describe('claude-code provider definition', () => {
     for (const model of supported) expect((rejected[1] as { message: string }).message).toContain(model);
   });
 
+  it.each([
+    ['Not logged in. Authentication required', /signed out|authentication/i, false],
+    ['Rate limit exceeded (429)', /service failure.*rate limit/i, true],
+    ['Service temporarily unavailable', /service failure.*unavailable/i, true],
+  ] as const)('classifies CLI failure %s', async (detail, message, retryable) => {
+    const dir = await makeFakeClaude([
+      { type: 'result', subtype: 'error_during_execution', is_error: true, result: detail },
+    ]);
+    const events = await collect(createClaudeCodeClient({ executable: join(dir, 'claude') }).stream(textRequest()));
+    expect(events[1]).toMatchObject({ type: 'error', message: expect.stringMatching(message), retryable });
+    expect(events.filter((event) => event.type === 'error')).toHaveLength(1);
+  });
+
+  it('emits exactly one non-retryable error when a request is cancelled', async () => {
+    const child = new ControlledProviderChild();
+    const controller = new AbortController();
+    const eventsPromise = collect(createClaudeCodeClient({ spawn: () => child.asChild() }).stream({
+      ...textRequest(),
+      signal: controller.signal,
+    }));
+    controller.abort();
+    const events = await eventsPromise;
+    expect(events.filter((event) => event.type === 'error')).toEqual([{
+      type: 'error',
+      message: 'Claude CLI request aborted',
+      retryable: false,
+    }]);
+    expect(child.kills).toEqual(['SIGTERM']);
+  });
+
+  it('reports a missing executable and an unexpected exit as actionable non-retryable errors', async () => {
+    const missing = Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' });
+    const missingEvents = await collect(createClaudeCodeClient({
+      executable: '/missing/claude',
+      spawn: () => { throw missing; },
+    }).stream(textRequest()));
+    expect(missingEvents[1]).toMatchObject({
+      type: 'error',
+      message: expect.stringMatching(/executable not found.*npm install/i),
+      retryable: false,
+    });
+
+    const dir = await makeFailingClaude('unexpected local failure', 9);
+    const exitEvents = await collect(createClaudeCodeClient({ executable: join(dir, 'claude') }).stream(textRequest()));
+    expect(exitEvents[1]).toMatchObject({
+      type: 'error',
+      message: expect.stringContaining('unexpected local failure'),
+      retryable: false,
+    });
+    expect(exitEvents.filter((event) => event.type === 'error')).toHaveLength(1);
+  });
+
   it('surfaces a permission denial as a clear non-retryable error', async () => {
     const dir = await makeFakeClaude([
       { type: 'result', subtype: 'error_during_execution', is_error: true, result: 'Permission denied for Edit' },
@@ -364,6 +438,15 @@ function textRequest(): ProviderRequest {
       { role: 'user', content: [{ type: 'text', text: 'latest user' }] },
     ],
   };
+}
+
+async function makeFailingClaude(stderr: string, exitCode: number): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'moxxy-claude-test-'));
+  tempDirs.push(dir);
+  const executable = join(dir, 'claude');
+  await writeFile(executable, `#!/usr/bin/env node\nconsole.error(${JSON.stringify(stderr)});\nprocess.exit(${exitCode});\n`, 'utf8');
+  await chmod(executable, 0o755);
+  return dir;
 }
 
 async function makeFakeClaude(

--- a/packages/plugin-provider-claude-code/src/provider.ts
+++ b/packages/plugin-provider-claude-code/src/provider.ts
@@ -1,7 +1,7 @@
 import type { LLMProvider, ModelDescriptor, ProviderEvent, ProviderRequest } from '@moxxy/sdk';
 import { estimateTextTokens } from '@moxxy/sdk';
 import { CLAUDE_CODE_PROVIDER_ID } from './constants.js';
-import { runClaudeProcess, type ClaudeSpawn } from './process.js';
+import { ClaudeProcessError, runClaudeProcess, type ClaudeSpawn } from './process.js';
 import { createProtocolState, parseClaudeRecord, serializeClaudePrompt } from './protocol.js';
 
 export const CLAUDE_CODE_DEFAULT_MODEL = 'claude-sonnet-4-6';
@@ -50,6 +50,14 @@ export interface ClaudeCodeProviderConfig {
   readonly defaultModel?: string;
   /** Process test seam; production callers should leave this unset. */
   readonly spawn?: ClaudeSpawn;
+  /** Time allowed for the first stream record. Defaults to 30 seconds. */
+  readonly startupTimeoutMs?: number;
+  /** Maximum silence between stream records. Defaults to 120 seconds. */
+  readonly idleTimeoutMs?: number;
+  /** Maximum captured stderr characters. Defaults to 2048. */
+  readonly maxStderrChars?: number;
+  /** Maximum characters in one stdout stream-json record. Defaults to 64 KiB. */
+  readonly maxRecordChars?: number;
 }
 
 export class ClaudeCodeProvider implements LLMProvider {
@@ -63,6 +71,10 @@ export class ClaudeCodeProvider implements LLMProvider {
   private readonly allowedTools: ReadonlyArray<string>;
   private readonly cwd: string;
   private readonly spawn?: ClaudeSpawn;
+  private readonly startupTimeoutMs?: number;
+  private readonly idleTimeoutMs?: number;
+  private readonly maxStderrChars?: number;
+  private readonly maxRecordChars?: number;
 
   constructor(config: ClaudeCodeProviderConfig = {}) {
     this.executable = config.executable ?? 'claude';
@@ -72,6 +84,10 @@ export class ClaudeCodeProvider implements LLMProvider {
     this.allowedTools = config.allowedTools ?? [];
     this.cwd = config.cwd ?? process.cwd();
     if (config.spawn) this.spawn = config.spawn;
+    if (config.startupTimeoutMs) this.startupTimeoutMs = config.startupTimeoutMs;
+    if (config.idleTimeoutMs) this.idleTimeoutMs = config.idleTimeoutMs;
+    if (config.maxStderrChars) this.maxStderrChars = config.maxStderrChars;
+    if (config.maxRecordChars) this.maxRecordChars = config.maxRecordChars;
   }
 
   async *stream(req: ProviderRequest): AsyncIterable<ProviderEvent> {
@@ -101,19 +117,19 @@ export class ClaudeCodeProvider implements LLMProvider {
         ...(this.permissionMode ? { permissionMode: this.permissionMode } : {}),
         ...(req.signal ? { signal: req.signal } : {}),
         ...(this.spawn ? { spawn: this.spawn } : {}),
+        ...(this.startupTimeoutMs ? { startupTimeoutMs: this.startupTimeoutMs } : {}),
+        ...(this.idleTimeoutMs ? { idleTimeoutMs: this.idleTimeoutMs } : {}),
+        ...(this.maxStderrChars ? { maxStderrChars: this.maxStderrChars } : {}),
+        ...(this.maxRecordChars ? { maxRecordChars: this.maxRecordChars } : {}),
       });
       while (true) {
         const next = await lines.next();
         if (next.done) {
           if (next.value.exitCode !== 0 && !terminal) {
-            yield {
-              type: 'error',
-              message: claudeCliError(
-                model,
-                next.value.stderr || `Claude CLI exited with code ${next.value.exitCode}`,
-              ),
-              retryable: false,
-            };
+            yield classifyClaudeFailure(
+              model,
+              next.value.stderr || `Claude CLI exited unexpectedly with code ${next.value.exitCode}`,
+            );
             return;
           }
           break;
@@ -122,7 +138,7 @@ export class ClaudeCodeProvider implements LLMProvider {
           if (event.type === 'message_end') terminal = true;
           if (event.type === 'error') {
             terminal = true;
-            yield { ...event, message: claudeCliError(model, event.message) };
+            yield classifyClaudeFailure(model, event.message);
           } else {
             yield event;
           }
@@ -132,7 +148,15 @@ export class ClaudeCodeProvider implements LLMProvider {
         yield { type: 'error', message: 'Claude CLI ended without a terminal result record', retryable: false };
       }
     } catch (error) {
-      yield nonRetryableError(error);
+      if (error instanceof ClaudeProcessError) {
+        yield {
+          type: 'error',
+          message: error.message,
+          retryable: error.failure === 'startup_timeout' || error.failure === 'idle_timeout',
+        };
+      } else {
+        yield classifySpawnFailure(error, this.executable);
+      }
     }
   }
 
@@ -173,13 +197,44 @@ function assertTextOnlyRequest(req: ProviderRequest): void {
   }
 }
 
-function claudeCliError(model: string, detail: string): string {
-  if (/permission|denied|not allowed/i.test(detail)) {
-    return `Claude Code permission denied: ${detail}. ` +
-      'Review plugins.provider.items.claude-code.config.permissionMode and allowedTools.';
+function classifyClaudeFailure(model: string, detail: string): ProviderEvent {
+  if (/rate.?limit|too many requests|\b429\b|overload|temporar|unavailable|service error|\b5\d\d\b/i.test(detail)) {
+    return { type: 'error', message: `Claude Code service failure: ${detail}`, retryable: true };
   }
-  return `Claude Code rejected model "${model}": ${detail}. ` +
-    `Select a supported model: ${claudeCodeModels.map((candidate) => candidate.id).join(', ')}.`;
+  if (/not logged in|signed out|login required|authenticate|authentication|unauthorized|invalid.*(?:token|credential)|\b401\b/i.test(detail)) {
+    return {
+      type: 'error',
+      message: `Claude CLI is signed out or its authentication was rejected: ${detail}. Run \`moxxy login claude-code\` to sign in again.`,
+      retryable: false,
+    };
+  }
+  if (/permission|denied|not allowed|forbidden|\b403\b/i.test(detail)) {
+    return {
+      type: 'error',
+      message: `Claude Code permission denied: ${detail}. Review plugins.provider.items.claude-code.config.permissionMode and allowedTools.`,
+      retryable: false,
+    };
+  }
+  if (/model|unknown model|invalid model/i.test(detail)) {
+    return {
+      type: 'error',
+      message: `Claude Code rejected model "${model}": ${detail}. Select a supported model: ${claudeCodeModels.map((candidate) => candidate.id).join(', ')}.`,
+      retryable: false,
+    };
+  }
+  return { type: 'error', message: `Claude CLI failed: ${detail}`, retryable: false };
+}
+
+function classifySpawnFailure(error: unknown, executable: string): ProviderEvent {
+  const nodeError = error as NodeJS.ErrnoException;
+  if (nodeError?.code === 'ENOENT') {
+    return {
+      type: 'error',
+      message: `Claude CLI executable not found: ${executable}. Install it with \`npm install -g @anthropic-ai/claude-code\` or configure plugins.provider.items.claude-code.config.executable.`,
+      retryable: false,
+    };
+  }
+  return nonRetryableError(error);
 }
 
 function nonRetryableError(error: unknown): ProviderEvent {

--- a/packages/plugin-provider-claude-code/src/provider.ts
+++ b/packages/plugin-provider-claude-code/src/provider.ts
@@ -106,8 +106,9 @@ export class ClaudeCodeProvider implements LLMProvider {
 
     const state = createProtocolState();
     let terminal = false;
+    let lines: ReturnType<typeof runClaudeProcess> | undefined;
     try {
-      const lines = runClaudeProcess({
+      lines = runClaudeProcess({
         executable: this.executable,
         model,
         prompt,
@@ -135,13 +136,17 @@ export class ClaudeCodeProvider implements LLMProvider {
           break;
         }
         for (const event of parseClaudeRecord(next.value, state)) {
-          if (event.type === 'message_end') terminal = true;
+          if (event.type === 'message_end') {
+            terminal = true;
+            yield event;
+            return;
+          }
           if (event.type === 'error') {
             terminal = true;
             yield classifyClaudeFailure(model, event.message);
-          } else {
-            yield event;
+            return;
           }
+          yield event;
         }
       }
       if (!terminal) {
@@ -157,6 +162,8 @@ export class ClaudeCodeProvider implements LLMProvider {
       } else {
         yield classifySpawnFailure(error, this.executable);
       }
+    } finally {
+      await lines?.return({ exitCode: 0, stderr: '' });
     }
   }
 
@@ -198,8 +205,12 @@ function assertTextOnlyRequest(req: ProviderRequest): void {
 }
 
 function classifyClaudeFailure(model: string, detail: string): ProviderEvent {
-  if (/rate.?limit|too many requests|\b429\b|overload|temporar|unavailable|service error|\b5\d\d\b/i.test(detail)) {
-    return { type: 'error', message: `Claude Code service failure: ${detail}`, retryable: true };
+  if (/model|unknown model|invalid model/i.test(detail)) {
+    return {
+      type: 'error',
+      message: `Claude Code rejected model "${model}": ${detail}. Select a supported model: ${claudeCodeModels.map((candidate) => candidate.id).join(', ')}.`,
+      retryable: false,
+    };
   }
   if (/not logged in|signed out|login required|authenticate|authentication|unauthorized|invalid.*(?:token|credential)|\b401\b/i.test(detail)) {
     return {
@@ -215,12 +226,8 @@ function classifyClaudeFailure(model: string, detail: string): ProviderEvent {
       retryable: false,
     };
   }
-  if (/model|unknown model|invalid model/i.test(detail)) {
-    return {
-      type: 'error',
-      message: `Claude Code rejected model "${model}": ${detail}. Select a supported model: ${claudeCodeModels.map((candidate) => candidate.id).join(', ')}.`,
-      retryable: false,
-    };
+  if (/rate.?limit|too many requests|\b429\b|overload|temporar|unavailable|service error|\b5\d\d\b/i.test(detail)) {
+    return { type: 'error', message: `Claude Code service failure: ${detail}`, retryable: true };
   }
   return { type: 'error', message: `Claude CLI failed: ${detail}`, retryable: false };
 }


### PR DESCRIPTION
Harden the child lifecycle in the CLI-backed provider: forward `ProviderRequest.signal`, bound startup and idle time, cap stderr/protocol buffers, sanitize nested-session variables such as `CLAUDECODE`, and classify missing binaries, authentication failures, rate limits, model errors, permission denials, malformed output, and unexpected exits. Add focused subprocess tests alongside `provider.test.ts` following the timeout and error-event conventions used by the Codex and Anthropic providers.

### Acceptance criteria
- Cancelling a running turn terminates the Claude child and emits exactly one non-retryable aborted error with no later text or message-end event.
- A silent child is terminated after the configured idle timeout, while periodic stream records reset that timeout.
- Missing executable and signed-out failures contain commands the user can run to recover.
- Rate-limit or transient service failures are marked retryable; auth, model, protocol, and permission failures are not.
- Stderr and unterminated stdout records are capped so a broken child cannot grow memory without bound.
- Tests verify no child or timer remains active after success, failure, timeout, or cancellation.

_Task `tsk-e7073757-404` on the Companion board._