### PR TITLE
Verify the flow across runner, desktop, and release gates

### DIFF
--- a/.changeset/verify-claude-cli-flow.md
+++ b/.changeset/verify-claude-cli-flow.md
@@ -1,0 +1,6 @@
+---
+"@moxxy/cli": patch
+"@moxxy/plugin-provider-claude-code": patch
+---
+
+Document and verify the installed Claude CLI subscription flow end to end, including opt-in live text/native-tool smoke coverage and clear desktop sign-in outcomes without handling subscription credentials.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,23 @@ Already running? Keep it current:
 moxxy update    # checks npm and upgrades in place (the TUI also nudges you when a new version ships)
 ```
 
-**Requirements:** Node.js ≥ 20.10 and an API key for a supported provider (Anthropic, OpenAI, or ChatGPT/Claude via OAuth). `moxxy --help` lists every command.
+**Requirements:** Node.js ≥ 20.10 and either an API key for a supported provider, ChatGPT OAuth, or an authenticated Claude Code installation for a Claude Pro/Max subscription. `moxxy --help` lists every command.
+
+### Claude Code subscription provider
+
+Install the official `claude` CLI and sign in (`claude auth login` or `moxxy login claude-code`), then choose `claude-code` during `moxxy init`. Moxxy uses the CLI's existing subscription session and never needs an `ANTHROPIC_API_KEY`. Check and recover the installation with:
+
+```sh
+claude auth status
+moxxy doctor
+moxxy login claude-code
+# custom/non-PATH install:
+CLAUDE_CODE_EXECUTABLE=/absolute/path/to/claude moxxy doctor
+```
+
+The default model is `claude-sonnet-4-6`; use `--model` or `plugins.provider.items.claude-code.model` to select another model advertised by moxxy. The provider is text-only by default. Native Claude tools are a separate opt-in provider setting (`config.mode: native-tools`) and should be paired with explicit `allowedTools` and, when needed, `permissionMode`. **Claude CLI owns and enforces those native-tool permissions**; moxxy's `--allow-tools`, permission resolver, and isolators govern only moxxy tools and do not override Claude's internal tools.
+
+Interactive desktop/TUI sessions can launch sign-in. Headless channels and OS services cannot complete browser/TTY authentication reliably: sign in once as the same OS user before installing/starting the service, ensure that user's `PATH` (or `CLAUDE_CODE_EXECUTABLE`) reaches `claude`, then restart the service. The CLI's auth files remain owned by Claude and are not copied into moxxy's vault.
 
 ---
 

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -394,6 +394,8 @@ or recorded-on-purpose decision.
 
 ## Providers & model catalogs
 
+- [note, provider-audit, 2026-07-06] Claude Code installed-CLI flow audited across setup, runner, desktop, and release gates. Live coverage now proves a subscription-backed streamed prompt plus an observable native-tool edit confined to a generated temporary git repository; desktop coverage pins missing-binary, cancelled, successful, and failed sign-in outcomes without credential echo. Remaining limitation is intentional: headless/services cannot reliably perform interactive Claude authentication and must reuse a same-OS-user login completed beforehand. Claude CLI—not moxxy's permission resolver—owns native-tool permission enforcement. `scripts/e2e-claude-cli-live.mjs`, `packages/desktop-host/src/provider-login.test.ts`, `apps/desktop/src/settings/shared/OAuthSignIn.test.tsx`.
+
 - [med] Codex reasoning isn't round-tripped (`toResponsesInput` drops the reasoning
   block); Anthropic multi-block thinking collapses to one round-trip block. Only
   Anthropic round-trips fully. `packages/plugin-provider-*/`.

--- a/apps/desktop/src/settings/shared/OAuthSignIn.test.tsx
+++ b/apps/desktop/src/settings/shared/OAuthSignIn.test.tsx
@@ -36,7 +36,7 @@ function fakeApi(): { api: MoxxyApi; emit: (event: string, payload: unknown) => 
 }
 
 describe('OAuthSignIn', () => {
-  it('fires the latest onSignedIn, not the one captured at mount', async () => {
+  it('reports successful CLI readiness and fires the latest onSignedIn', async () => {
     const { api, emit } = fakeApi();
     __setApiOverride(api);
     vi.spyOn(crypto, 'randomUUID').mockReturnValue('login-1' as `${string}-${string}-${string}-${string}-${string}`);
@@ -58,7 +58,56 @@ describe('OAuthSignIn', () => {
     // Login completes successfully.
     act(() => emit('provider.login.done', { loginId: 'login-1', code: 0 }));
 
+    expect(await screen.findByText('Signed in to codex.')).toBeTruthy();
     expect(v2).toHaveBeenCalledTimes(1);
     expect(v1).not.toHaveBeenCalled();
+  });
+
+  it('shows missing-binary diagnostics without exposing credential input', async () => {
+    const { api, emit } = fakeApi();
+    __setApiOverride(api);
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('login-missing' as `${string}-${string}-${string}-${string}-${string}`);
+    render(<OAuthSignIn provider="claude-code" />);
+
+    fireEvent.click(screen.getByText('Sign in with claude-code'));
+    act(() => emit('provider.login.output', {
+      loginId: 'login-missing',
+      text: 'Claude CLI executable not found: claude. Install Claude Code or set CLAUDE_CODE_EXECUTABLE.\n',
+    }));
+    act(() => emit('provider.login.done', { loginId: 'login-missing', code: 1 }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Sign-in did not complete');
+    expect(screen.getByText(/Claude CLI executable not found/)).toBeTruthy();
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('can cancel an in-progress Claude CLI sign-in and reports cancellation', async () => {
+    const { api } = fakeApi();
+    __setApiOverride(api);
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('login-cancel' as `${string}-${string}-${string}-${string}-${string}`);
+    render(<OAuthSignIn provider="claude-code" />);
+
+    fireEvent.click(screen.getByText('Sign in with claude-code'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel sign-in' }));
+
+    await waitFor(() => expect(api.invoke).toHaveBeenCalledWith(
+      'provider.login.cancel', { loginId: 'login-cancel' },
+    ));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Sign-in cancelled.');
+  });
+
+  it('reports a failed CLI sign-in and preserves diagnostic output', async () => {
+    const { api, emit } = fakeApi();
+    __setApiOverride(api);
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('login-failed' as `${string}-${string}-${string}-${string}-${string}`);
+    render(<OAuthSignIn provider="claude-code" />);
+
+    fireEvent.click(screen.getByText('Sign in with claude-code'));
+    act(() => emit('provider.login.output', { loginId: 'login-failed', text: 'Claude CLI login failed.\n' }));
+    act(() => emit('provider.login.done', { loginId: 'login-failed', code: 7 }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('exit 7');
+    expect(screen.getByText('Claude CLI login failed.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeTruthy();
   });
 });

--- a/apps/desktop/src/settings/shared/OAuthSignIn.tsx
+++ b/apps/desktop/src/settings/shared/OAuthSignIn.tsx
@@ -116,6 +116,22 @@ export function OAuthSignIn({
     }
   };
 
+  const cancel = async (): Promise<void> => {
+    const id = loginIdRef.current;
+    if (!id) return;
+    // Clear first so a late child exit cannot replace the explicit cancellation
+    // outcome, and so unmount does not send the credential-free cancel twice.
+    loginIdRef.current = null;
+    setPrompt(null);
+    try {
+      await api().invoke('provider.login.cancel', { loginId: id });
+      setError('Sign-in cancelled.');
+    } catch (e) {
+      setError(toErrorMessage(e));
+    }
+    setPhase('error');
+  };
+
   // claude-code's first prompt offers "paste a token OR press Enter for the
   // browser"; surface both, browser primary. The flag keys off the question
   // text the CLI sends, so it stays true to the actual flow.
@@ -173,9 +189,12 @@ export function OAuthSignIn({
       )}
 
       {phase === 'running' && !prompt && (
-        <p style={{ margin: 0, fontSize: 13, color: 'var(--color-text-muted)' }}>
-          Opening your browser — complete the sign-in there…
-        </p>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <p style={{ margin: 0, flex: 1, fontSize: 13, color: 'var(--color-text-muted)' }}>
+            Opening your browser — complete the sign-in there…
+          </p>
+          <Button onClick={() => void cancel()}>Cancel sign-in</Button>
+        </div>
       )}
 
       {error && (

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -75,7 +75,41 @@ Or run it without installing:
 npx @moxxy/cli init
 ```
 
-Requirements: Node.js 20.10 or later. An API key for a supported provider (Anthropic, OpenAI), or sign into ChatGPT via `moxxy login openai-codex`.
+Requirements: Node.js 20.10 or later. Use an API key for Anthropic/OpenAI, sign into ChatGPT with `moxxy login openai-codex`, or reuse an authenticated Claude Code Pro/Max subscription as described below.
+
+### Claude Code (Pro/Max subscription, no API key)
+
+1. Install the official Claude CLI so `claude` is on `PATH` (or set `CLAUDE_CODE_EXECUTABLE=/absolute/path/to/claude`).
+2. Run `claude auth login` or `moxxy login claude-code`, then confirm with `claude auth status` and `moxxy doctor`.
+3. Select `claude-code` in `moxxy init`. It defaults to `claude-sonnet-4-6`; override per run with `--model`, or persist `plugins.provider.items.claude-code.model`.
+
+The default transport disables Claude's internal tools. To opt into an isolated coding task, configure the provider item explicitly:
+
+```yaml
+plugins:
+  provider:
+    default: claude-code
+    items:
+      claude-code:
+        model: claude-sonnet-4-6
+        config:
+          mode: native-tools
+          permissionMode: acceptEdits
+          allowedTools: [Read, Write, Edit]
+```
+
+`allowedTools` and `permissionMode` are forwarded to and enforced by Claude CLI. Moxxy's permission resolver, `--allow-tools`, and isolators govern moxxy-registered tools only; they do **not** govern Claude's internal native tools. Claude also owns its login files—moxxy neither reads nor stores subscription credentials in its vault.
+
+Desktop and interactive CLI setup can start sign-in. Headless runners/services generally cannot complete browser or TTY authentication: authenticate first as the same OS account that runs the service, make `claude` available in that account's service `PATH` (or set the executable path), and restart it. Recovery commands are `claude auth status`, `claude auth login`, `moxxy login claude-code`, and `moxxy doctor`.
+
+Contributors with an authenticated subscription can run the opt-in, no-API-key smoke gate after `pnpm build`:
+
+```sh
+node scripts/e2e-claude-cli-live.mjs
+# optional: MOXXY_CLAUDE_E2E_MODEL=claude-opus-4-6 node scripts/e2e-claude-cli-live.mjs
+```
+
+It skips clearly when `claude` is missing or signed out, streams a real text prompt, and performs its native-tool assertion only inside a generated temporary git repository.
 
 ## Quickstart
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@moxxy/cli",
   "version": "0.30.0",
-  "description": "moxxy command-line binary. Subcommand dispatcher consuming the moxxy SDK.",
+  "description": "moxxy command-line agent: TUI, one-shot prompts, setup, services, and API-key or installed-CLI subscription providers.",
   "keywords": [
     "moxxy",
     "agent",

--- a/packages/desktop-host/src/provider-login.test.ts
+++ b/packages/desktop-host/src/provider-login.test.ts
@@ -76,7 +76,7 @@ describe('provider-login relay', () => {
     expect((spawnArgs[2] as { stdio: unknown }).stdio).toEqual(['pipe', 'pipe', 'pipe']);
   });
 
-  it('relays plain stdout as output and markers as prompts', () => {
+  it('relays plain stdout as output and markers as masked prompts without credential echo', () => {
     startProviderLogin('idR', 'claude-code', fakeWindow);
     current.stdout.emit(
       'data',
@@ -88,6 +88,8 @@ describe('provider-login relay', () => {
       question: 'Paste:',
       mask: true,
     });
+    answerProviderLogin('idR', 'subscription-secret');
+    expect(events('provider.login.output').flatMap((event) => Object.values(event))).not.toContain('subscription-secret');
   });
 
   it('writes one stdin line per answer (stripping embedded newlines)', () => {
@@ -96,12 +98,22 @@ describe('provider-login relay', () => {
     expect(current.stdin.write).toHaveBeenCalledWith('token\n');
   });
 
-  it('emits done + onExit on a normal exit', () => {
+  it.each([
+    ['successful', 0],
+    ['failed', 7],
+  ])('emits done + onExit for a %s Claude CLI outcome', (_label, code) => {
     const onExit = vi.fn();
     startProviderLogin('id3', 'claude-code', fakeWindow, { onExit });
-    current.emit('exit', 0);
-    expect(events('provider.login.done')[0]).toEqual({ loginId: 'id3', code: 0 });
-    expect(onExit).toHaveBeenCalledWith(0);
+    current.emit('exit', code);
+    expect(events('provider.login.done')[0]).toEqual({ loginId: 'id3', code });
+    expect(onExit).toHaveBeenCalledWith(code);
+  });
+
+  it('relays missing-binary errors as diagnostics and a failed outcome', () => {
+    startProviderLogin('missing', 'claude-code', fakeWindow);
+    current.emit('error', Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' }));
+    expect(events('provider.login.output')[0]?.text).toMatch(/ENOENT/);
+    expect(events('provider.login.done')[0]).toEqual({ loginId: 'missing', code: -1 });
   });
 
   it('cancel kills the child and suppresses the done event', () => {

--- a/packages/plugin-provider-claude-code/package.json
+++ b/packages/plugin-provider-claude-code/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@moxxy/plugin-provider-claude-code",
   "version": "0.30.0",
-  "description": "Claude subscription (Pro/Max) LLMProvider plugin for moxxy. Talks to the standard Anthropic Messages API using a Claude Code OAuth token from `claude setup-token` or an in-app sign-in.",
+  "description": "Claude Pro/Max subscription provider for moxxy. Streams through the user's authenticated installed Claude CLI, with opt-in native-tool tasks and no Anthropic API key.",
   "keywords": [
     "moxxy",
     "agent",

--- a/packages/plugin-provider-claude-code/src/protocol.ts
+++ b/packages/plugin-provider-claude-code/src/protocol.ts
@@ -5,7 +5,7 @@ interface ProtocolState {
   started: boolean;
   ended: boolean;
   /** Current streamed block. Native tool records are consumed by Claude itself. */
-  blockType?: 'text' | 'tool_use' | 'tool_result';
+  blockType?: 'text' | 'thinking' | 'tool_use' | 'tool_result';
   stopReason: 'end_turn' | 'max_tokens' | 'stop_sequence' | 'error';
   inputTokens?: number;
   outputTokens?: number;
@@ -130,7 +130,9 @@ export function parseClaudeRecord(line: string, state: ProtocolState): ProviderE
     throw new Error('Claude CLI emitted malformed stream-json record');
   }
 
-  if (value.type === 'system') return [];
+  // Informational envelope records can appear between protocol events on newer
+  // Claude CLI versions. They carry no assistant content or terminal state.
+  if (value.type === 'system' || value.type === 'rate_limit_event') return [];
   if (value.type === 'assistant' || value.type === 'user') return parseMessageRecord(value);
   if (value.type === 'stream_event') return parseStreamEvent(value.event, state);
   if (value.type === 'result') return parseResult(value, state);

--- a/packages/plugin-provider-claude-code/src/protocol.ts
+++ b/packages/plugin-provider-claude-code/src/protocol.ts
@@ -150,10 +150,11 @@ function parseMessageRecord(record: Record<string, unknown>): ProviderEvent[] {
     if (block.type === 'text' && typeof block.text !== 'string') {
       throw new Error('Claude CLI emitted malformed assistant text');
     }
-    // tool_use/tool_result are internal CLI bookkeeping. Claude has already
-    // executed them; translating these records to ProviderEvents would make the
-    // moxxy dispatcher execute the same operation a second time.
-    if (block.type !== 'text' && block.type !== 'tool_use' && block.type !== 'tool_result') {
+    // Thinking stays private, while tool_use/tool_result are internal CLI
+    // bookkeeping that Claude has already executed. Translating any of these
+    // records to ProviderEvents would either expose private reasoning or make
+    // the moxxy dispatcher execute the same operation a second time.
+    if (block.type !== 'text' && block.type !== 'thinking' && block.type !== 'tool_use' && block.type !== 'tool_result') {
       throw new Error('Claude CLI emitted unsupported assistant content');
     }
   }
@@ -173,7 +174,7 @@ function parseStreamEvent(raw: unknown, state: ProtocolState): ProviderEvent[] {
       if (!isRecord(raw.content_block) || typeof raw.content_block.type !== 'string') {
         throw new Error('Claude CLI emitted malformed content block');
       }
-      if (raw.content_block.type !== 'text' && raw.content_block.type !== 'tool_use' && raw.content_block.type !== 'tool_result') {
+      if (raw.content_block.type !== 'text' && raw.content_block.type !== 'thinking' && raw.content_block.type !== 'tool_use' && raw.content_block.type !== 'tool_result') {
         throw new Error('Claude CLI emitted unsupported content block');
       }
       state.blockType = raw.content_block.type;

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -77,6 +77,47 @@ describe('claude-code provider definition', () => {
     expect(input).not.toContain('oauth-secret');
   });
 
+  it('consumes streamed thinking blocks without exposing their deltas', async () => {
+    const dir = await makeFakeClaude([
+      { type: 'stream_event', event: { type: 'message_start', message: {} } },
+      { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'thinking', thinking: '' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: 'private chain of thought' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'signature_delta', signature: 'private-signature' } } },
+      { type: 'stream_event', event: { type: 'content_block_stop' } },
+      { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'text', text: '' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Visible answer' } } },
+      { type: 'stream_event', event: { type: 'content_block_stop' } },
+      { type: 'result', subtype: 'success', is_error: false, result: 'Visible answer', usage: { input_tokens: 3, output_tokens: 2 } },
+    ]);
+    const events = await collect(createClaudeCodeClient({ executable: join(dir, 'claude') }).stream(textRequest()));
+
+    expect(events).toEqual([
+      { type: 'message_start', model: 'claude-sonnet-4-6' },
+      { type: 'text_delta', delta: 'Visible answer' },
+      { type: 'message_end', stopReason: 'end_turn', usage: { inputTokens: 3, outputTokens: 2 } },
+    ]);
+    expect(JSON.stringify(events)).not.toContain('private chain of thought');
+    expect(JSON.stringify(events)).not.toContain('private-signature');
+  });
+
+  it('accepts complete assistant records containing thinking blocks without exposing them', async () => {
+    const dir = await makeFakeClaude([
+      { type: 'assistant', message: { content: [
+        { type: 'thinking', thinking: 'private chain of thought', signature: 'private-signature' },
+        { type: 'text', text: 'Visible answer' },
+      ] } },
+      { type: 'result', subtype: 'success', is_error: false, result: 'Visible answer', usage: { input_tokens: 3, output_tokens: 2 } },
+    ]);
+    const events = await collect(createClaudeCodeClient({ executable: join(dir, 'claude') }).stream(textRequest()));
+
+    expect(events).toEqual([
+      { type: 'message_start', model: 'claude-sonnet-4-6' },
+      { type: 'message_end', stopReason: 'end_turn', usage: { inputTokens: 3, outputTokens: 2 } },
+    ]);
+    expect(JSON.stringify(events)).not.toContain('private chain of thought');
+    expect(JSON.stringify(events)).not.toContain('private-signature');
+  });
+
   it('reconstructs two turns for each stateless CLI invocation without a session id', async () => {
     const dir = await makeFakeClaude([
       { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'text', text: '' } } },

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -46,6 +46,7 @@ describe('claude-code provider definition', () => {
   it('streams text through a fake Claude executable with structured non-interactive arguments', async () => {
     const dir = await makeFakeClaude([
       { type: 'system', subtype: 'init' },
+      { type: 'rate_limit_event', rate_limit_info: { status: 'allowed' } },
       { type: 'stream_event', event: { type: 'message_start', message: {} } },
       { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'text', text: '' } } },
       { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Hello ' } } },

--- a/scripts/e2e-claude-cli-live.mjs
+++ b/scripts/e2e-claude-cli-live.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Opt-in live smoke test for the installed Claude CLI subscription provider.
+ *
+ * Unlike scripts/e2e-live.mjs, this consumes no ANTHROPIC_API_KEY: authentication
+ * is owned by the user's installed `claude` executable. The harness exits 0 with
+ * a clear SKIP when the binary is absent or signed out.
+ *
+ *   pnpm build
+ *   node scripts/e2e-claude-cli-live.mjs
+ *
+ * Override the executable/model with CLAUDE_CODE_EXECUTABLE and
+ * MOXXY_CLAUDE_E2E_MODEL. Both runs use generated temporary directories; the
+ * native-tool task runs only inside a freshly initialized temporary git repo.
+ */
+import { spawn } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const cliBin = join(repoRoot, 'packages', 'cli', 'dist', 'bin.js');
+const executable = process.env.CLAUDE_CODE_EXECUTABLE?.trim() || 'claude';
+const model = process.env.MOXXY_CLAUDE_E2E_MODEL?.trim() || 'claude-sonnet-4-6';
+const root = mkdtempSync(join(tmpdir(), 'moxxy-claude-live-'));
+const moxxyHome = join(root, 'moxxy-home');
+mkdirSync(moxxyHome);
+
+function run(command, args, options = {}) {
+  return new Promise((resolvePromise) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'], ...options });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk) => (stdout += chunk));
+    child.stderr?.on('data', (chunk) => (stderr += chunk));
+    child.once('error', (error) => resolvePromise({ code: 1, stdout, stderr, error }));
+    child.once('close', (code) => resolvePromise({ code: code ?? 1, stdout, stderr }));
+  });
+}
+
+function authIsSignedIn(stdout) {
+  try {
+    const parsed = JSON.parse(stdout);
+    return parsed.loggedIn === true || parsed.logged_in === true || parsed.authenticated === true;
+  } catch {
+    return /logged in|authenticated|signed in/i.test(stdout) && !/not logged in|signed out|not authenticated/i.test(stdout);
+  }
+}
+
+function eventsFrom(stdout) {
+  return stdout.split('\n').flatMap((line) => {
+    if (!line.trim()) return [];
+    try { return [JSON.parse(line)]; } catch { return []; }
+  });
+}
+
+function assistantText(events) {
+  return events.flatMap((event) => {
+    if (event.type === 'assistant_chunk' && typeof event.delta === 'string') return [event.delta];
+    if (event.type === 'assistant_message' && typeof event.content === 'string') return [event.content];
+    return [];
+  }).join('\n');
+}
+
+function writeConfig(workspace, nativeTools) {
+  const config = join(workspace, 'moxxy.config.yaml');
+  const native = nativeTools
+    ? "\n          mode: native-tools\n          permissionMode: acceptEdits\n          allowedTools:\n            - Write\n            - Edit"
+    : '';
+  writeFileSync(config, `plugins:\n  provider:\n    default: claude-code\n    items:\n      claude-code:\n        model: ${model}\n        config:\n          executable: ${JSON.stringify(executable)}${native}\n`);
+  return config;
+}
+
+async function runMoxxy(workspace, prompt, nativeTools = false) {
+  const config = writeConfig(workspace, nativeTools);
+  return run(process.execPath, [cliBin, '-p', prompt, '--model', model, '--output-format', 'stream-json', '--config', config], {
+    cwd: workspace,
+    env: { ...process.env, MOXXY_HOME: moxxyHome },
+  });
+}
+
+function assertTurn(label, result, predicate) {
+  const events = eventsFrom(result.stdout);
+  const errors = events.filter((event) => event.type === 'error');
+  const text = assistantText(events);
+  if (result.code !== 0 || errors.length > 0 || !predicate({ events, text })) {
+    throw new Error(`${label} failed (exit ${result.code}): ${errors.map((e) => e.message).join('; ') || result.stderr.trim() || 'assertion failed'}`);
+  }
+  console.log(`[PASS] ${label}`);
+  return { events, text };
+}
+
+async function main() {
+  const auth = await run(executable, ['auth', 'status']);
+  if (auth.error?.code === 'ENOENT') {
+    console.log(`[SKIP] Claude CLI not found (${executable}). Install Claude Code, then run \`claude auth login\`.`);
+    return;
+  }
+  if (!authIsSignedIn(auth.stdout)) {
+    console.log(`[SKIP] Claude CLI is installed but not signed in. Run \`${executable} auth login\` (or \`moxxy login claude-code\`) and retry.`);
+    return;
+  }
+  console.log(`moxxy Claude CLI live smoke — executable=${executable} model=${model}`);
+
+  const textWorkspace = join(root, 'text');
+  mkdirSync(textWorkspace);
+  const pong = await runMoxxy(textWorkspace, 'Reply with exactly PONG and nothing else.');
+  assertTurn('streamed subscription prompt', pong, ({ events, text }) =>
+    events.some((event) => event.type === 'assistant_chunk') && /PONG/i.test(text));
+
+  const taskRepo = join(root, 'task-repository');
+  mkdirSync(taskRepo);
+  const git = await run('git', ['init', '--quiet'], { cwd: taskRepo });
+  if (git.code !== 0) throw new Error(`could not initialize temporary task repository: ${git.stderr}`);
+  const marker = `CLAUDE-SMOKE-${Date.now()}`;
+  const task = await runMoxxy(
+    taskRepo,
+    `Use your native Write tool to create smoke-result.txt in the current repository containing exactly ${marker}. Then reply with exactly TASK COMPLETE.`,
+    true,
+  );
+  assertTurn('isolated native-tool repository task', task, ({ text }) => /TASK COMPLETE/i.test(text));
+  const changed = await run('git', ['status', '--porcelain', '--', 'smoke-result.txt'], { cwd: taskRepo });
+  const contents = readFileSync(join(taskRepo, 'smoke-result.txt'), 'utf8').trim();
+  if (!changed.stdout.trim() || contents !== marker) throw new Error('task did not create the expected observable repository change');
+  console.log('[PASS] observable file change in generated temporary repository');
+}
+
+main().catch((error) => {
+  console.error(`[FAIL] ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+}).finally(() => rmSync(root, { recursive: true, force: true }));


### PR DESCRIPTION
Add an opt-in live smoke path for a real installed Claude CLI, modeled on `scripts/e2e-live.mjs`, that runs a text prompt and an isolated temporary-repository task without consuming an Anthropic API key. Extend setup/runner integration coverage and the existing desktop provider-login tests (`packages/desktop-host/src/provider-login.test.ts`) to prove the generic UI reports CLI readiness and errors. Update `README.md`, `packages/cli/README.md`, package descriptions/changelogs, and `TECH_DEBT.md`; add the required changeset for the shipped CLI behavior.

### Acceptance criteria
- The opt-in smoke test skips clearly when `claude` is absent or signed out and passes a real streamed prompt when an authenticated subscription is available.
- The task smoke test operates only in a generated temporary repository and verifies an observable file change plus a final response.
- Desktop provider setup can initiate the Claude CLI sign-in flow and displays missing-binary, cancelled, successful, and failed outcomes without exposing credentials.
- Documentation explains prerequisites, model selection, native-tool configuration, permission ownership, headless/service limitations, and recovery commands.
- No documentation claims moxxy permissions govern Claude's internal native tools.
- A relevant open `TECH_DEBT.md` item is retired or the provider audit records any newly discovered limitation.
- Root build, typecheck, lint, tests, dependency-cruiser check, and the changeset requirement pass.

_Task `tsk-2385b278-c9e` on the Companion board._