### PR TITLE
feat(providers): prefer native web search with browser fallback

### DIFF
--- a/.changeset/native-web-search.md
+++ b/.changeset/native-web-search.md
@@ -3,4 +3,4 @@
 "@moxxy/cli": minor
 ---
 
-Add provider-hosted web search capabilities with automatic Codex/Claude execution and a pluggable local browser fallback.
+Add provider-hosted web search capabilities with automatic Codex/Claude execution and an automatically installed, pluggable local browser fallback.

--- a/.changeset/native-web-search.md
+++ b/.changeset/native-web-search.md
@@ -1,0 +1,6 @@
+---
+"@moxxy/sdk": minor
+"@moxxy/cli": minor
+---
+
+Add provider-hosted web search capabilities with automatic Codex/Claude execution and a pluggable local browser fallback.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ The framework is developed by the agent it runs, backed by strict CI, adversaria
 | **Provider freedom** | Use built-in providers, subscription-backed CLIs, or register any compatible provider without rewriting the agent loop. |
 | **Type-safe extension** | The zero-runtime-dependency `@moxxy/sdk` gives plugin authors a small, typed public contract with full IDE support. |
 
+Capable Codex and Claude models use provider-hosted web search first. `@moxxy/plugin-browser` supplies a pluggable local fallback for models and accounts without that capability.
+
 Explore [features and channels](docs/features.md) for the complete capability map.
 
 ## Showcase

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The framework is developed by the agent it runs, backed by strict CI, adversaria
 | **Provider freedom** | Use built-in providers, subscription-backed CLIs, or register any compatible provider without rewriting the agent loop. |
 | **Type-safe extension** | The zero-runtime-dependency `@moxxy/sdk` gives plugin authors a small, typed public contract with full IDE support. |
 
-Capable Codex and Claude models use provider-hosted web search first. `@moxxy/plugin-browser` supplies a pluggable local fallback for models and accounts without that capability.
+Capable Codex and Claude models use provider-hosted web search first. Their provider packages automatically install the lightweight `@moxxy/plugin-browser` companion, which supplies a pluggable local fallback without downloading Playwright until interactive browsing is requested.
 
 Explore [features and channels](docs/features.md) for the complete capability map.
 

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -24,6 +24,11 @@ or recorded-on-purpose decision.
 
 ## Resolved ledger
 
+- [med, providers, RESOLVED 2026-07-23] Bracketed model variants such as
+  `claude-sonnet-4-6[1m]` no longer miss the catalog and inherit an unrelated
+  `models[0]` context window: `resolveModelContext` now resolves the exact base
+  descriptor before its last-resort fallback, with regression coverage.
+  `packages/sdk/src/compactor-helpers.ts`.
 - [high, modes, RESOLVED 2026-07-05] Goal mode killed its own runs and never let
   go: the iteration cap (150), a 4M token budget, and a stuck-loop FATAL abort
   (whose near-repeat heuristic trips on a legitimate edit→build→test cycle) all
@@ -408,12 +413,10 @@ or recorded-on-purpose decision.
   retry (`react-loop.ts` `isContextOverflowError`). Fixed one instance (Codex
   gpt-5.5/gpt-5.4 1M→400k) but the failure mode is latent for any future catalog
   drift; consider calibrating the effective window from real provider `usage` /
-  observed overflow rather than the static descriptor. Related: `resolveModelContext`
-  (`packages/sdk/src/compactor-helpers.ts`) still falls back to `models[0]` on an
-  exact-id miss (an unlisted/variant id like a `[1m]` suffix resolves the wrong
-  window), but the fallback is no longer SILENT — it emits a one-shot `console.warn`
-  deduped per (provider, requested id, fallback id). Remaining: calibrate the
-  *effective* window from observed usage/overflow rather than the static descriptor.
+  observed overflow rather than the static descriptor. `resolveModelContext`
+  now recognizes terminal bracket variants such as `[1m]`; genuinely unknown
+  ids still fall back to `models[0]` with a one-shot warning. Remaining: calibrate
+  the *effective* window from observed usage/overflow rather than the static descriptor.
 
 ## Channels, relay & HTTP
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,7 +69,7 @@ CLAUDE_CODE_EXECUTABLE=/absolute/path/to/claude moxxy doctor
 
 The default model is `claude-sonnet-4-6`. Select another model advertised by Moxxy with `--model` or the `plugins.provider.items.claude-code.model` setting.
 
-The provider is text-only by default. Native Claude tools are a separate opt-in setting, `config.mode: native-tools`, and should be paired with explicit `allowedTools` and, when needed, `permissionMode`. The Claude CLI owns and enforces native-tool permissions. Moxxy's `--allow-tools`, permission resolver, and isolators govern only Moxxy tools and do not override the Claude CLI.
+The provider uses a text transport and enables only Claude Code's native `WebSearch` by default. Set `config.webSearch: false` to disable it. Other native Claude tools are a separate opt-in setting, `config.mode: native-tools`, and should be paired with explicit `allowedTools` (include `WebSearch` there if desired) and, when needed, `permissionMode`. The Claude CLI owns and enforces native-tool permissions. Moxxy's `--allow-tools`, permission resolver, and isolators govern only Moxxy tools and do not override the Claude CLI.
 
 Interactive desktop and TUI sessions can launch sign-in. Headless channels and OS services cannot reliably complete browser or TTY authentication. Sign in once as the same OS user before starting the service, make sure that user's `PATH` or `CLAUDE_CODE_EXECUTABLE` reaches `claude`, then restart the service. Claude continues to own its authentication files; Moxxy does not copy them into its vault.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,6 +71,8 @@ The default model is `claude-sonnet-4-6`. Select another model advertised by Mox
 
 The provider uses a text transport and enables only Claude Code's native `WebSearch` by default. Set `config.webSearch: false` to disable it. Other native Claude tools are a separate opt-in setting, `config.mode: native-tools`, and should be paired with explicit `allowedTools` (include `WebSearch` there if desired) and, when needed, `permissionMode`. The Claude CLI owns and enforces native-tool permissions. Moxxy's `--allow-tools`, permission resolver, and isolators govern only Moxxy tools and do not override the Claude CLI.
 
+The Codex, Anthropic API, and Claude Code provider packages also install `@moxxy/plugin-browser` as a lightweight companion. It provides the local search adapter and `web_fetch`; Playwright remains optional and is downloaded only after an explicit interactive-browser install action. Because Claude Code is an opaque CLI text transport, its turns cannot dispatch the local Moxxy fallback when native `WebSearch` fails.
+
 Interactive desktop and TUI sessions can launch sign-in. Headless channels and OS services cannot reliably complete browser or TTY authentication. Sign in once as the same OS user before starting the service, make sure that user's `PATH` or `CLAUDE_CODE_EXECUTABLE` reaches `claude`, then restart the service. Claude continues to own its authentication files; Moxxy does not copy them into its vault.
 
 ## Keep Moxxy running

--- a/packages/plugin-browser/README.md
+++ b/packages/plugin-browser/README.md
@@ -6,7 +6,9 @@ Web access for moxxy in three tiers:
 - `web_fetch` safely reads a public HTTP(S) URL with SSRF checks, DNS pinning, redirect validation, byte limits, and abort handling.
 - `browser_session` drives a Playwright sidecar for interactive or JavaScript-heavy pages.
 
-Codex and the Anthropic API provider advertise hosted web search directly using their normal moxxy OAuth/API credentials. The `claude-code` provider uses the installed Claude CLI and enables only its native `WebSearch` tool in text mode by default. Install this plugin when a local fallback, direct page fetches, or an interactive browser is desired.
+Codex and the Anthropic API provider advertise hosted web search directly using their normal moxxy OAuth/API credentials. The `claude-code` provider uses the installed Claude CLI and enables only its native `WebSearch` tool in text mode by default. Those three provider packages install this plugin automatically, so the local adapter is ready when a provider participating in Moxxy tool calling needs it. Other providers can install it separately.
+
+The automatic install stays lightweight: Playwright is an optional peer with no install hook. Its package and browser engine are offered only when `browser_session` is used.
 
 ## Custom search adapter
 

--- a/packages/plugin-browser/README.md
+++ b/packages/plugin-browser/README.md
@@ -1,0 +1,27 @@
+# @moxxy/plugin-browser
+
+Web access for moxxy in three tiers:
+
+- `web_search` is a local fallback marked with `hosted: { type: 'web_search' }`. A capable provider replaces it with its server-side search; other providers execute the configured adapter.
+- `web_fetch` safely reads a public HTTP(S) URL with SSRF checks, DNS pinning, redirect validation, byte limits, and abort handling.
+- `browser_session` drives a Playwright sidecar for interactive or JavaScript-heavy pages.
+
+Codex and the Anthropic API provider advertise hosted web search directly using their normal moxxy OAuth/API credentials. The `claude-code` provider uses the installed Claude CLI and enables only its native `WebSearch` tool in text mode by default. Install this plugin when a local fallback, direct page fetches, or an interactive browser is desired.
+
+## Custom search adapter
+
+```ts
+import { buildBrowserPlugin, type WebSearchAdapter } from '@moxxy/plugin-browser';
+
+const adapter: WebSearchAdapter = {
+  name: 'internal-search',
+  async search({ query, maxResults }, ctx) {
+    // Honor ctx.signal and return at most maxResults source records.
+    return [{ title: query, url: 'https://example.com/' }].slice(0, maxResults);
+  },
+};
+
+export default buildBrowserPlugin({ webSearch: { adapter } });
+```
+
+The default fallback adapter uses DuckDuckGo's HTML endpoint through the same hardened fetch path as `web_fetch`.

--- a/packages/plugin-browser/package.json
+++ b/packages/plugin-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@moxxy/plugin-browser",
   "version": "0.31.0",
-  "description": "Browser capabilities for moxxy: web_fetch (zero-deps light tier) + browser_session (Playwright sidecar for JS-heavy / interactive pages).",
+  "description": "Web capabilities for moxxy: pluggable web_search fallback, web_fetch, and a Playwright browser_session sidecar.",
   "keywords": [
     "moxxy",
     "agent",

--- a/packages/plugin-browser/src/companion-install.test.ts
+++ b/packages/plugin-browser/src/companion-install.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+interface PackageManifest {
+  readonly dependencies?: Readonly<Record<string, string>>;
+  readonly peerDependencies?: Readonly<Record<string, string>>;
+  readonly peerDependenciesMeta?: Readonly<Record<string, { readonly optional?: boolean }>>;
+  readonly scripts?: Readonly<Record<string, string>>;
+}
+
+function readManifest(packageDir: string): PackageManifest {
+  return JSON.parse(
+    readFileSync(new URL(`../../${packageDir}/package.json`, import.meta.url), 'utf8'),
+  ) as PackageManifest;
+}
+
+describe('native web-search provider companion install', () => {
+  it.each([
+    'plugin-provider-anthropic',
+    'plugin-provider-openai-codex',
+    'plugin-provider-claude-code',
+  ])('%s installs the local browser fallback', (packageDir) => {
+    expect(readManifest(packageDir).dependencies?.['@moxxy/plugin-browser']).toBe('workspace:*');
+  });
+
+  it('keeps the automatic fallback lightweight until interactive browsing is requested', () => {
+    const browser = readManifest('plugin-browser');
+    expect(browser.dependencies).not.toHaveProperty('playwright');
+    expect(browser.peerDependencies?.playwright).toBeDefined();
+    expect(browser.peerDependenciesMeta?.playwright?.optional).toBe(true);
+    expect(browser.scripts).not.toHaveProperty('postinstall');
+  });
+});

--- a/packages/plugin-browser/src/index.ts
+++ b/packages/plugin-browser/src/index.ts
@@ -1,9 +1,19 @@
 import { definePlugin } from '@moxxy/sdk';
 import { webFetchTool } from './web-fetch.js';
+import { buildWebSearchTool, type BuildWebSearchToolOptions } from './web-search.js';
 import { buildBrowserSessionTool, closeBrowserSidecar, type BrowserSessionDeps } from './browser-session.js';
 import { buildBrowserSurface } from './browser-surface.js';
 
 export { webFetchTool, htmlToPlainText, htmlToMarkdown } from './web-fetch.js';
+export {
+  buildWebSearchTool,
+  duckDuckGoHtmlAdapter,
+  parseDuckDuckGoHtml,
+  type BuildWebSearchToolOptions,
+  type WebSearchAdapter,
+  type WebSearchQuery,
+  type WebSearchResult,
+} from './web-search.js';
 export {
   buildBrowserSessionTool,
   browserSidecarCall,
@@ -13,13 +23,15 @@ export {
 } from './browser-session.js';
 export { buildBrowserSurface } from './browser-surface.js';
 
-export interface BuildBrowserPluginOptions extends BrowserSessionDeps {}
+export interface BuildBrowserPluginOptions extends BrowserSessionDeps {
+  readonly webSearch?: BuildWebSearchToolOptions;
+}
 
 export function buildBrowserPlugin(opts: BuildBrowserPluginOptions = {}) {
   return definePlugin({
     name: '@moxxy/plugin-browser',
     version: '0.0.0',
-    tools: [webFetchTool, buildBrowserSessionTool(opts)],
+    tools: [buildWebSearchTool(opts.webSearch), webFetchTool, buildBrowserSessionTool(opts)],
     surfaces: [buildBrowserSurface(opts)],
     hooks: {
       onShutdown: async () => {

--- a/packages/plugin-browser/src/web-search.test.ts
+++ b/packages/plugin-browser/src/web-search.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { buildWebSearchTool, parseDuckDuckGoHtml } from './web-search.js';
+
+describe('parseDuckDuckGoHtml', () => {
+  it('extracts, unwraps, and deduplicates result links with snippets', () => {
+    const html = `
+      <div class="result">
+        <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fnews&amp;rut=x">
+          Example &amp; News
+        </a>
+        <a class="result__snippet">A <b>fresh</b> result.</a>
+      </div>
+      <div class="result">
+        <a class="result__a" href="https://example.com/news">Duplicate</a>
+      </div>
+      <div class="result">
+        <a class='result__a' href='https://docs.example.org/page'>Docs</a>
+        <div class='result__snippet'>Useful docs.</div>
+      </div>`;
+
+    expect(parseDuckDuckGoHtml(html)).toEqual([
+      { title: 'Example & News', url: 'https://example.com/news', snippet: 'A fresh result.' },
+      { title: 'Docs', url: 'https://docs.example.org/page', snippet: 'Useful docs.' },
+    ]);
+  });
+});
+
+describe('web_search tool', () => {
+  it('declares provider-hosted web search while retaining its adapter handler as fallback', async () => {
+    const tool = buildWebSearchTool({
+      adapter: {
+        name: 'fixture',
+        search: async () => [{ title: 'Result', url: 'https://example.com/' }],
+      },
+    });
+    expect(tool.hosted).toEqual({ type: 'web_search' });
+    expect(tool.name).toBe('web_search');
+  });
+});

--- a/packages/plugin-browser/src/web-search.ts
+++ b/packages/plugin-browser/src/web-search.ts
@@ -1,0 +1,152 @@
+import { MoxxyError, defineTool, z, type ToolContext } from '@moxxy/sdk';
+import { htmlToPlainText } from './html-extract.js';
+import { webFetchTool } from './web-fetch.js';
+
+export interface WebSearchQuery {
+  readonly query: string;
+  readonly maxResults: number;
+}
+export interface WebSearchResult {
+  readonly title: string;
+  readonly url: string;
+  readonly snippet?: string;
+}
+
+/** Adapter seam for replacing the local fallback without changing the tool. */
+export interface WebSearchAdapter {
+  readonly name: string;
+  search(query: WebSearchQuery, ctx: ToolContext): Promise<ReadonlyArray<WebSearchResult>>;
+}
+
+export interface BuildWebSearchToolOptions {
+  readonly adapter?: WebSearchAdapter;
+}
+
+const outputSchema = z.object({
+  provider: z.string(),
+  query: z.string(),
+  results: z.array(
+    z.object({
+      title: z.string(),
+      url: z.string().url(),
+      snippet: z.string().optional(),
+    }),
+  ),
+});
+
+export function buildWebSearchTool(opts: BuildWebSearchToolOptions = {}) {
+  const adapter = opts.adapter ?? duckDuckGoHtmlAdapter;
+  return defineTool({
+    name: 'web_search',
+    description:
+      'Search the public web for current information and return source URLs with snippets. On models with provider-hosted web search this fallback is replaced automatically by the provider; otherwise it uses the configured local search adapter.',
+    inputSchema: z.object({
+      query: z.string().trim().min(1).max(1_000).describe('Search query.'),
+      maxResults: z.number().int().min(1).max(10).optional().default(5),
+    }).strict(),
+    outputSchema,
+    hosted: { type: 'web_search' },
+    permission: { action: 'prompt' },
+    isolation: {
+      capabilities: {
+        net: { mode: 'any' },
+        timeMs: 120_000,
+      },
+    },
+    compact: {
+      verb: 'Searching the web for',
+      noun: { one: 'query', other: 'queries' },
+      previewKey: 'query',
+    },
+    async handler({ query, maxResults }, ctx) {
+      const results = await adapter.search({ query, maxResults }, ctx);
+      return { provider: adapter.name, query, results: results.slice(0, maxResults) };
+    },
+  });
+}
+
+/**
+ * Zero-config fallback. It deliberately goes through web_fetch's SSRF guard,
+ * redirect validation, DNS pinning, byte cap, timeout, and parent abort signal.
+ */
+export const duckDuckGoHtmlAdapter: WebSearchAdapter = {
+  name: 'duckduckgo-html',
+  async search({ query, maxResults }, ctx) {
+    const url = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;
+    const response = await webFetchTool.handler(
+      {
+        url,
+        format: 'raw',
+        method: 'GET',
+        headers: { accept: 'text/html,application/xhtml+xml' },
+        maxBytes: 1_000_000,
+        timeoutMs: 20_000,
+      },
+      ctx,
+    );
+    if (typeof response !== 'string') {
+      throw new MoxxyError({
+        code: 'TOOL_ERROR',
+        message: 'web_search fallback returned a non-text response',
+      });
+    }
+    const separator = response.indexOf('\n\n');
+    const html = separator >= 0 ? response.slice(separator + 2) : response;
+    const results = parseDuckDuckGoHtml(html, maxResults);
+    if (results.length === 0) {
+      throw new MoxxyError({
+        code: 'TOOL_ERROR',
+        message: 'web_search fallback returned no parseable results (the search endpoint may be blocking automated traffic)',
+        hint: 'Use web_fetch/browser_session directly, or switch to a model with hosted web search.',
+      });
+    }
+    return results;
+  },
+};
+
+export function parseDuckDuckGoHtml(html: string, maxResults = 10): ReadonlyArray<WebSearchResult> {
+  const results: WebSearchResult[] = [];
+  const seen = new Set<string>();
+  const anchor = /<a\b(?=[^>]*\bclass=(?:"[^"]*\bresult__a\b[^"]*"|'[^']*\bresult__a\b[^']*'))[^>]*\bhref=(?:"([^"]+)"|'([^']+)')[^>]*>([\s\S]*?)<\/a>/gi;
+  let match: RegExpExecArray | null;
+  while (results.length < maxResults && (match = anchor.exec(html)) !== null) {
+    const rawHref = match[1] ?? match[2];
+    const rawTitle = match[3];
+    if (!rawHref || !rawTitle) continue;
+    const url = normalizeResultUrl(rawHref);
+    if (!url || seen.has(url)) continue;
+    const title = htmlToPlainText(rawTitle);
+    if (!title) continue;
+
+    const nextAnchor = html.slice(anchor.lastIndex).search(anchor);
+    const resultEnd = nextAnchor >= 0 ? anchor.lastIndex + nextAnchor : html.length;
+    const resultTail = html.slice(anchor.lastIndex, Math.min(resultEnd, anchor.lastIndex + 8_000));
+    const snippetMatch = /<(?:a|div)\b(?=[^>]*\bclass=(?:"[^"]*\bresult__snippet\b[^"]*"|'[^']*\bresult__snippet\b[^']*'))[^>]*>([\s\S]*?)<\/(?:a|div)>/i.exec(resultTail);
+    const snippet = snippetMatch?.[1] ? htmlToPlainText(snippetMatch[1]).slice(0, 1_000) : undefined;
+    seen.add(url);
+    results.push({ title, url, ...(snippet ? { snippet } : {}) });
+  }
+  return results;
+}
+
+function normalizeResultUrl(rawHref: string): string | null {
+  const decodedHref = rawHref.replaceAll('&amp;', '&');
+  let parsed: URL;
+  try {
+    parsed = new URL(decodedHref, 'https://html.duckduckgo.com');
+  } catch {
+    return null;
+  }
+  const redirected = parsed.hostname.endsWith('duckduckgo.com') && parsed.pathname === '/l/'
+    ? parsed.searchParams.get('uddg')
+    : null;
+  if (redirected) {
+    try {
+      parsed = new URL(redirected);
+    } catch {
+      return null;
+    }
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+  return parsed.toString();
+}

--- a/packages/plugin-plugins-admin/src/catalog.ts
+++ b/packages/plugin-plugins-admin/src/catalog.ts
@@ -110,8 +110,8 @@ export const INSTALLABLE_PLUGIN_CATALOG: ReadonlyArray<PluginCatalogEntry> = [
   },
   {
     id: 'browser',
-    label: 'Browser tools',
-    description: 'Playwright-driven browser_session tools (installs playwright on demand).',
+    label: 'Web & browser tools',
+    description: 'Local web_search fallback, web_fetch, and Playwright browser_session tools.',
     packageName: '@moxxy/plugin-browser',
     installSpec: '@moxxy/plugin-browser',
   },

--- a/packages/plugin-provider-anthropic/package.json
+++ b/packages/plugin-provider-anthropic/package.json
@@ -67,6 +67,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.40.0",
+    "@moxxy/plugin-browser": "workspace:*",
     "@moxxy/sdk": "workspace:*"
   },
   "devDependencies": {

--- a/packages/plugin-provider-anthropic/src/provider.test.ts
+++ b/packages/plugin-provider-anthropic/src/provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { assertDefined } from '@moxxy/sdk';
+import { assertDefined, defineTool, z } from '@moxxy/sdk';
 import { AnthropicProvider } from './provider.js';
 
 // A minimal fake Anthropic SDK client to drive the translator without HTTP.
@@ -17,6 +17,75 @@ function fakeAnthropic(stream: ReadonlyArray<unknown>): { messages: { stream: ()
 }
 
 describe('AnthropicProvider.stream', () => {
+  it('uses the Anthropic server web search tool and falls back to the client tool on a pre-stream 400', async () => {
+    const bodies: Array<{ tools?: Array<{ type?: string; name: string }> }> = [];
+    const fake = {
+      messages: {
+        stream: (body: { tools?: Array<{ type?: string; name: string }> }) => {
+          bodies.push(body);
+          if (bodies.length === 1) {
+            throw Object.assign(new Error('web_search is not enabled'), { status: 400 });
+          }
+          return (async function* () {
+            yield { type: 'message_start', message: { usage: { input_tokens: 1, output_tokens: 0 } } };
+            yield { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 1 } };
+            yield { type: 'message_stop' };
+          })();
+        },
+        countTokens: async () => ({ input_tokens: 1 }),
+      },
+    };
+    const fallback = defineTool({
+      name: 'web_search',
+      description: 'fallback search',
+      inputSchema: z.object({ query: z.string() }),
+      hosted: { type: 'web_search' },
+      handler: () => [],
+    });
+    const provider = new AnthropicProvider({ client: fake as never });
+
+    const events = [];
+    for await (const event of provider.stream({
+      model: 'claude-sonnet-4-6',
+      messages: [],
+      tools: [fallback],
+    })) events.push(event);
+
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]?.tools).toEqual([{ type: 'web_search_20250305', name: 'web_search' }]);
+    expect(bodies[1]?.tools).toEqual([
+      expect.objectContaining({ name: 'web_search', input_schema: expect.any(Object) }),
+    ]);
+    expect(events.some((event) => event.type === 'error')).toBe(false);
+    expect(events.at(-1)).toMatchObject({ type: 'message_end', stopReason: 'end_turn' });
+  });
+
+  it('renders streamed web-search citations as safe markdown links', async () => {
+    const fake = fakeAnthropic([
+      { type: 'message_start', message: { usage: { input_tokens: 1, output_tokens: 0 } } },
+      { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Current info' } },
+      {
+        type: 'content_block_delta',
+        delta: {
+          type: 'citations_delta',
+          citation: { title: 'Example [source]', url: 'https://example.com/fresh' },
+        },
+      },
+      { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 2 } },
+      { type: 'message_stop' },
+    ]);
+    const provider = new AnthropicProvider({ client: fake as never });
+    const events = [];
+    for await (const event of provider.stream({ model: 'claude-sonnet-4-6', messages: [] })) {
+      events.push(event);
+    }
+    const text = events
+      .filter((event) => event.type === 'text_delta')
+      .map((event) => (event as { delta: string }).delta)
+      .join('');
+    expect(text).toBe('Current info [Example \\[source\\]](https://example.com/fresh)');
+  });
+
   it('translates content_block_delta text into text_delta events', async () => {
     const fake = fakeAnthropic([
       { type: 'message_start', message: { usage: { input_tokens: 10, output_tokens: 0 } } },

--- a/packages/plugin-provider-anthropic/src/provider.ts
+++ b/packages/plugin-provider-anthropic/src/provider.ts
@@ -7,6 +7,7 @@ import type {
   StopReason,
   TokenUsage,
 } from '@moxxy/sdk';
+import { resolveProviderTools } from '@moxxy/sdk';
 
 type MessageStreamParams = Anthropic.Messages.MessageStreamParams;
 type MessageCountTokensParams = Anthropic.Messages.MessageCountTokensParams;
@@ -74,12 +75,12 @@ export interface AnthropicProviderConfig {
 // {type:'adaptive', display:'summarized'}`) — fable-5/opus-4-8/4-7/4-6 and sonnet-4-6
 // do; haiku-4-5 does not (effort/adaptive-thinking error there), so it stays off.
 export const anthropicModels: ReadonlyArray<ModelDescriptor> = [
-  { id: 'claude-fable-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
-  { id: 'claude-opus-4-8', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
-  { id: 'claude-opus-4-7', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
-  { id: 'claude-opus-4-6', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
-  { id: 'claude-sonnet-4-6', contextWindow: 1_000_000, maxOutputTokens: 64_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
-  { id: 'claude-haiku-4-5-20251001', contextWindow: 200_000, maxOutputTokens: 64_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true },
+  { id: 'claude-fable-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'claude-opus-4-8', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'claude-opus-4-7', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'claude-opus-4-6', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'claude-sonnet-4-6', contextWindow: 1_000_000, maxOutputTokens: 64_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'claude-haiku-4-5-20251001', contextWindow: 200_000, maxOutputTokens: 64_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, hostedTools: ['web_search'] },
 ];
 
 export class AnthropicProvider implements LLMProvider {
@@ -224,16 +225,20 @@ export class AnthropicProvider implements LLMProvider {
     }
 
     const { system, messages } = toAnthropicMessages(req.messages, { cacheMessageIndices });
-    const tools =
-      req.tools && req.tools.length > 0
-        ? toAnthropicTools(req.tools, { cacheLast: cacheTools })
-        : undefined;
+    const model = req.model || this.defaultModel;
+    const resolvedTools = resolveProviderTools(req.tools, this.models, model);
+    const tools = toAnthropicTools(resolvedTools.tools, { cacheLast: cacheTools });
+    const hostedTools = resolvedTools.hostedTools.map((tool) => {
+      if (tool.type === 'web_search') {
+        return { type: 'web_search_20250305' as const, name: 'web_search' as const };
+      }
+      return tool;
+    });
+    const requestTools = [...tools, ...hostedTools];
     // OAuth mode prepends the Claude Code identity preamble as the first
     // system block; apiKey mode keeps the prior string/cache-block behaviour.
     // req.system (hook-injected extra system text) is appended last.
     const systemParam = this.buildSystemParam(system, cacheSystem, req.system);
-    const model = req.model || this.defaultModel;
-
     // In OAuth mode refresh the bearer proactively when it's near expiry, so
     // we don't fire a request on a token we already knew was about to die.
     // Done BEFORE emitting message_start so a turn that never reaches the API
@@ -272,7 +277,7 @@ export class AnthropicProvider implements LLMProvider {
       max_tokens: maxTokens,
       system: systemParam as MessageStreamParams['system'],
       messages: messages as MessageStreamParams['messages'],
-      tools: tools as MessageStreamParams['tools'],
+      tools: requestTools as MessageStreamParams['tools'],
       ...(req.temperature !== undefined ? { temperature: req.temperature } : {}),
     };
 
@@ -292,6 +297,15 @@ export class AnthropicProvider implements LLMProvider {
       if (effort) body.output_config = { effort };
     }
 
+    const fallbackRequestBody: MessageStreamParams | null = hostedTools.length > 0
+      ? {
+          ...requestBody,
+          tools: req.tools && req.tools.length > 0
+            ? toAnthropicTools(req.tools, { cacheLast: cacheTools }) as MessageStreamParams['tools']
+            : undefined,
+        }
+      : null;
+
     // A genuine auth 401 arrives before any SSE body, so in OAuth mode we can
     // force a single refresh and replay the request. But `isUnauthorized()`
     // also matches a 401 surfaced MID-stream (token revoked during a long
@@ -310,6 +324,15 @@ export class AnthropicProvider implements LLMProvider {
           return;
         } catch (retryErr) {
           yield { type: 'error', ...toFriendlyError(retryErr, { provider: this.name }) };
+          return;
+        }
+      }
+      if (fallbackRequestBody && !progress.produced && isHostedWebSearchRejection(err)) {
+        try {
+          yield* this.streamOnce(fallbackRequestBody, req.signal);
+          return;
+        } catch (fallbackErr) {
+          yield { type: 'error', ...toFriendlyError(fallbackErr, { provider: this.name }) };
           return;
         }
       }
@@ -351,6 +374,7 @@ export class AnthropicProvider implements LLMProvider {
     // accumulates and flushes as a reasoning_signature at content_block_stop.
     const thinkingBlockIndices = new Set<number>();
     let pendingThinkingSig = '';
+    const emittedCitationUrls = new Set<string>();
     let stopReason: StopReason = 'end_turn';
     // Type as the SDK's `TokenUsage` (which carries the optional cache fields)
     // so cacheReadTokens/cacheCreationTokens are first-class on the accumulator
@@ -414,6 +438,14 @@ export class AnthropicProvider implements LLMProvider {
             if (!delta) break;
             if (delta.type === 'text_delta' && typeof delta.text === 'string') {
               yield { type: 'text_delta', delta: delta.text };
+            } else if (delta.type === 'citations_delta') {
+              const citation = delta.citation;
+              const url = citation?.url;
+              if (isPublicCitationUrl(url) && !emittedCitationUrls.has(url)) {
+                emittedCitationUrls.add(url);
+                const title = citation?.title?.trim() || 'source';
+                yield { type: 'text_delta', delta: ` [${escapeMarkdownLabel(title)}](${url})` };
+              }
             } else if (delta.type === 'thinking_delta' && typeof delta.thinking === 'string') {
               yield { type: 'reasoning_delta', delta: delta.thinking };
             } else if (delta.type === 'signature_delta' && typeof delta.signature === 'string') {
@@ -628,13 +660,14 @@ interface AnthropicStreamEvent {
   };
   index?: number;
   delta?: {
-    type?: 'text_delta' | 'input_json_delta' | 'thinking_delta' | 'signature_delta';
+    type?: 'text_delta' | 'input_json_delta' | 'thinking_delta' | 'signature_delta' | 'citations_delta';
     text?: string;
     partial_json?: string;
     /** thinking_delta payload (the summarized reasoning text). */
     thinking?: string;
     /** signature_delta payload (the thinking-block signature for round-trip). */
     signature?: string;
+    citation?: { url?: string; title?: string };
     stop_reason?: string;
   };
   usage?: {
@@ -707,4 +740,30 @@ function isUnauthorized(err: unknown): boolean {
   return typeof (err as { status?: unknown } | null | undefined)?.status === 'number'
     ? (err as { status: number }).status === 401
     : false;
+}
+
+function isHostedWebSearchRejection(err: unknown): boolean {
+  const candidate = err as { status?: unknown; message?: unknown; error?: { message?: unknown } } | null;
+  if (candidate?.status !== 400) return false;
+  const message = typeof candidate.message === 'string'
+    ? candidate.message
+    : typeof candidate.error?.message === 'string'
+      ? candidate.error.message
+      : '';
+  const normalized = message.toLowerCase();
+  return normalized.includes('web_search') || normalized.includes('web search');
+}
+
+function isPublicCitationUrl(value: string | undefined): value is string {
+  if (!value) return false;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function escapeMarkdownLabel(value: string): string {
+  return value.replaceAll('\\', '\\\\').replaceAll('[', '\\[').replaceAll(']', '\\]');
 }

--- a/packages/plugin-provider-claude-code/package.json
+++ b/packages/plugin-provider-claude-code/package.json
@@ -65,9 +65,10 @@
     }
   },
   "dependencies": {
-    "@moxxy/sdk": "workspace:*",
+    "@moxxy/plugin-browser": "workspace:*",
     "@moxxy/plugin-oauth": "workspace:*",
-    "@moxxy/plugin-provider-anthropic": "workspace:*"
+    "@moxxy/plugin-provider-anthropic": "workspace:*",
+    "@moxxy/sdk": "workspace:*"
   },
   "devDependencies": {
     "@moxxy/tsconfig": "workspace:*",

--- a/packages/plugin-provider-claude-code/src/process.ts
+++ b/packages/plugin-provider-claude-code/src/process.ts
@@ -26,6 +26,8 @@ export interface ClaudeProcessOptions {
   readonly prompt: string;
   readonly cwd: string;
   readonly nativeTools: boolean;
+  /** Enable only Claude Code's native WebSearch when nativeTools is false. */
+  readonly webSearch?: boolean;
   readonly permissionMode?: string;
   readonly allowedTools: ReadonlyArray<string>;
   readonly signal?: AbortSignal;
@@ -209,6 +211,8 @@ function buildArgs(options: ClaudeProcessOptions): string[] {
     args.push('--tools', ...(options.allowedTools.length > 0 ? options.allowedTools : ['']));
     if (options.permissionMode) args.push('--permission-mode', options.permissionMode);
     if (options.allowedTools.length > 0) args.push('--allowedTools', ...options.allowedTools);
+  } else if (options.webSearch) {
+    args.splice(args.length - 2, 0, '--tools', 'WebSearch', '--allowedTools', 'WebSearch');
   } else {
     args.splice(args.length - 2, 0, '--tools', '');
   }

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -51,7 +51,7 @@ describe('claude-code provider definition', () => {
     expect(resolved).toMatchObject({ mode: 'native-tools', cwd: '/session/workspace' });
   });
 
-  it('registers the exact Claude Code catalog, default, and text-only capabilities', () => {
+  it('registers the exact Claude Code catalog and its native web-search capability', () => {
     expect(claudeCodeProviderDef.name).toBe('claude-code');
     expect(claudeCodeProviderDef.auth?.kind).toBe('oauth');
     expect(CLAUDE_CODE_DEFAULT_MODEL).toBe('claude-sonnet-4-6');
@@ -72,6 +72,7 @@ describe('claude-code provider definition', () => {
         supportsDocuments: false,
         supportsAudio: false,
         supportsReasoning: false,
+        hostedTools: ['web_search'],
       });
     }
   });
@@ -100,7 +101,8 @@ describe('claude-code provider definition', () => {
     ]);
     const args = JSON.parse(await readFile(join(dir, 'args.json'), 'utf8')) as string[];
     expect(args).toEqual(expect.arrayContaining([
-      '--print', '--verbose', '--output-format', 'stream-json', '--include-partial-messages', '--tools', '',
+      '--print', '--verbose', '--output-format', 'stream-json', '--include-partial-messages',
+      '--tools', 'WebSearch', '--allowedTools', 'WebSearch',
     ]));
     const input = await readFile(join(dir, 'input.txt'), 'utf8');
     expect(input).toContain('system instructions');
@@ -108,6 +110,21 @@ describe('claude-code provider definition', () => {
     expect(input).toContain('<assistant>\nprior assistant');
     expect(input).toContain('<user>\nlatest user');
     expect(input).not.toContain('oauth-secret');
+  });
+
+  it('can disable native WebSearch without enabling any other Claude tools', async () => {
+    const dir = await makeFakeClaude([
+      { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } },
+    ]);
+    await collect(createClaudeCodeClient({
+      executable: join(dir, 'claude'),
+      webSearch: false,
+    }).stream(textRequest()));
+
+    const args = JSON.parse(await readFile(join(dir, 'args.json'), 'utf8')) as string[];
+    expect(args).toEqual(expect.arrayContaining(['--tools', '']));
+    expect(args).not.toContain('WebSearch');
+    expect(args).not.toContain('--allowedTools');
   });
 
   it('consumes streamed thinking blocks without exposing their deltas', async () => {

--- a/packages/plugin-provider-claude-code/src/provider.ts
+++ b/packages/plugin-provider-claude-code/src/provider.ts
@@ -22,6 +22,7 @@ const textOnlyCapabilities = {
   supportsDocuments: false,
   supportsAudio: false,
   supportsReasoning: false,
+  hostedTools: ['web_search'],
 } as const;
 
 export const claudeCodeModels: ReadonlyArray<ModelDescriptor> = [
@@ -40,6 +41,8 @@ export interface ClaudeCodeProviderConfig {
   readonly model?: string;
   /** Transport mode. Native tools are opt-in; omitted defaults to text-only. */
   readonly mode?: 'text' | 'native-tools';
+  /** Enable Claude Code's native WebSearch in text mode. Defaults to true. */
+  readonly webSearch?: boolean;
   /** Claude CLI permission mode. Omitted uses the CLI's safe default. */
   readonly permissionMode?: 'acceptEdits' | 'plan' | 'dontAsk' | 'bypassPermissions';
   /** Optional allow-list of Claude native tool names. */
@@ -67,6 +70,7 @@ export class ClaudeCodeProvider implements LLMProvider {
   private readonly executable: string;
   private readonly defaultModel: string;
   private readonly nativeTools: boolean;
+  private readonly webSearch: boolean;
   private readonly permissionMode?: string;
   private readonly allowedTools: ReadonlyArray<string>;
   private readonly cwd: string;
@@ -80,6 +84,7 @@ export class ClaudeCodeProvider implements LLMProvider {
     this.executable = config.executable ?? 'claude';
     this.defaultModel = config.defaultModel ?? CLAUDE_CODE_DEFAULT_MODEL;
     this.nativeTools = config.mode === 'native-tools';
+    this.webSearch = config.webSearch !== false;
     if (config.permissionMode) this.permissionMode = config.permissionMode;
     this.allowedTools = config.allowedTools ?? [];
     this.cwd = config.cwd ?? process.cwd();
@@ -114,6 +119,7 @@ export class ClaudeCodeProvider implements LLMProvider {
         prompt,
         cwd: this.cwd,
         nativeTools: this.nativeTools,
+        webSearch: this.webSearch,
         allowedTools: this.allowedTools,
         ...(this.permissionMode ? { permissionMode: this.permissionMode } : {}),
         ...(req.signal ? { signal: req.signal } : {}),

--- a/packages/plugin-provider-openai-codex/package.json
+++ b/packages/plugin-provider-openai-codex/package.json
@@ -65,8 +65,9 @@
     }
   },
   "dependencies": {
-    "@moxxy/sdk": "workspace:*",
-    "@moxxy/plugin-oauth": "workspace:*"
+    "@moxxy/plugin-browser": "workspace:*",
+    "@moxxy/plugin-oauth": "workspace:*",
+    "@moxxy/sdk": "workspace:*"
   },
   "devDependencies": {
     "@moxxy/tsconfig": "workspace:*",

--- a/packages/plugin-provider-openai-codex/src/models.ts
+++ b/packages/plugin-provider-openai-codex/src/models.ts
@@ -19,15 +19,15 @@ export const codexModels: ReadonlyArray<ModelDescriptor> = [
   // under the same ids the API uses (sol/terra/luna — no `-codex` variant).
   // Sol is OpenAI's default Codex model. The ChatGPT-plan window cap applies
   // here too, so keep them at 400k like the rest of this list.
-  { id: 'gpt-5.6-sol', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
-  { id: 'gpt-5.6-terra', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
-  { id: 'gpt-5.6-luna', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
-  { id: 'gpt-5.5', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
-  { id: 'gpt-5.4', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
-  { id: 'gpt-5.4-mini', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
-  { id: 'gpt-5.3-codex', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
-  { id: 'gpt-5.3-codex-spark', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
-  { id: 'gpt-5.2', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true },
+  { id: 'gpt-5.6-sol', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'gpt-5.6-terra', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'gpt-5.6-luna', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'gpt-5.5', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'gpt-5.4', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'gpt-5.4-mini', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'gpt-5.3-codex', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'gpt-5.3-codex-spark', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'gpt-5.2', contextWindow: 400_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
 ];
 
 // OpenAI's own Codex default moved to gpt-5.6-sol at GA (July 9, 2026); mirror

--- a/packages/plugin-provider-openai-codex/src/provider.test.ts
+++ b/packages/plugin-provider-openai-codex/src/provider.test.ts
@@ -6,7 +6,7 @@ import { CodexProvider } from './provider.js';
 import { CODEX_RESPONSES_URL } from './oauth.js';
 import type { CodexTokens } from './types.js';
 import type { ProviderEvent, ProviderRequest } from '@moxxy/sdk';
-import { assertDefined } from '@moxxy/sdk';
+import { assertDefined, defineTool, z } from '@moxxy/sdk';
 
 // The refresh path takes a cross-process lockfile under `<moxxy home>/locks`;
 // point MOXXY_HOME at a temp dir so tests never touch the real ~/.moxxy.
@@ -57,6 +57,38 @@ function baseRequest(over: Partial<ProviderRequest> = {}): ProviderRequest {
 }
 
 describe('CodexProvider.stream', () => {
+  it('uses hosted web search first and retries with the client fallback when the backend rejects it', async () => {
+    const bodies: Array<{ tools?: Array<{ type: string; name?: string }> }> = [];
+    const fakeFetch = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      bodies.push(JSON.parse(String(init?.body)) as { tools?: Array<{ type: string; name?: string }> });
+      if (bodies.length === 1) {
+        return new Response('{"error":"web_search is not enabled"}', { status: 400 });
+      }
+      return new Response(sseStream(['data: {"type":"response.completed"}\n\n']), { status: 200 });
+    });
+    const fallback = defineTool({
+      name: 'web_search',
+      description: 'fallback search',
+      inputSchema: z.object({ query: z.string() }),
+      hosted: { type: 'web_search' },
+      handler: () => [],
+    });
+    const provider = new CodexProvider({
+      tokens: makeTokens(),
+      fetch: fakeFetch as unknown as typeof fetch,
+    });
+
+    const events = await collect(provider.stream(baseRequest({ tools: [fallback] })));
+
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]?.tools).toEqual([{ type: 'web_search' }]);
+    expect(bodies[1]?.tools).toEqual([
+      expect.objectContaining({ type: 'function', name: 'web_search' }),
+    ]);
+    expect(events.some((event) => event.type === 'error')).toBe(false);
+    expect(events.at(-1)).toMatchObject({ type: 'message_end', stopReason: 'end_turn' });
+  });
+
   it('sends Bearer auth, ChatGPT-Account-Id, originator and User-Agent headers', async () => {
     const captured: { url?: string; init?: RequestInit } = {};
     const fakeFetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {

--- a/packages/plugin-provider-openai-codex/src/provider.ts
+++ b/packages/plugin-provider-openai-codex/src/provider.ts
@@ -4,7 +4,7 @@ import type {
   ProviderEvent,
   ProviderRequest,
 } from '@moxxy/sdk';
-import { classifyHttpStatus, estimateTextTokens } from '@moxxy/sdk';
+import { classifyHttpStatus, estimateTextTokens, resolveProviderTools } from '@moxxy/sdk';
 import { isAuthRejection, withCredentialLock } from '@moxxy/plugin-oauth';
 import { CODEX_RESPONSES_URL, refreshTokens } from './oauth.js';
 import { codexModels, DEFAULT_CODEX_MODEL } from './models.js';
@@ -138,16 +138,28 @@ export class CodexProvider implements LLMProvider {
     const emitReasoning = req.reasoning != null && req.reasoning !== false;
     const reqEffort = typeof req.reasoning === 'object' ? req.reasoning.effort : undefined;
     const reasoningEffort = reqEffort ?? this.reasoningEffort;
+    const resolvedTools = resolveProviderTools(req.tools, this.models, model);
+    const nativeRequest = { ...req, model, tools: resolvedTools.tools };
     // Pass the session id as the Responses prefix-cache key so repeated turns
     // in a session reuse the cached prefix (cheaper + faster). Codex DOES
     // support this even though the Chat-Completions providers ignore cacheHints.
     const body = toResponsesBody(
-      { ...req, model },
+      nativeRequest,
       {
         sessionHint: sessionId,
         ...(reasoningEffort ? { reasoningEffort } : {}),
+        ...(resolvedTools.hostedTools.length > 0 ? { hostedTools: resolvedTools.hostedTools } : {}),
       },
     );
+    const fallbackBody = resolvedTools.hostedTools.length > 0
+      ? toResponsesBody(
+          { ...req, model },
+          {
+            sessionHint: sessionId,
+            ...(reasoningEffort ? { reasoningEffort } : {}),
+          },
+        )
+      : null;
 
     // Internal idle watchdog: aborts the request if the backend stalls (accepts
     // the POST but never sends headers/body, or goes silent mid-stream) so the
@@ -209,10 +221,25 @@ export class CodexProvider implements LLMProvider {
         }
       }
 
+      let errorText: string | undefined;
+      if (!response.ok && fallbackBody) {
+        errorText = await readCappedText(response, MAX_ERROR_BODY_CHARS);
+        if (isHostedWebSearchRejection(response.status, errorText)) {
+          try {
+            armIdle();
+            response = await this.postCodex(fallbackBody, sessionId, signal);
+            errorText = undefined;
+          } catch (err) {
+            yield toErrorEvent(err);
+            return;
+          }
+        }
+      }
+
       if (!response.ok || !response.body) {
         // Cap the buffered error body: a hostile/broken backend could otherwise
         // stream a huge body that we'd hold in full and then put into a string.
-        const text = await readCappedText(response, MAX_ERROR_BODY_CHARS);
+        const text = errorText ?? await readCappedText(response, MAX_ERROR_BODY_CHARS);
         // Derive the retryable verdict from the SDK's status classifier so it
         // stays consistent with the rest of moxxy (429 + 5xx are retryable).
         const classified = classifyHttpStatus(response.status);
@@ -325,6 +352,12 @@ export class CodexProvider implements LLMProvider {
       }
     });
   }
+}
+
+function isHostedWebSearchRejection(status: number, body: string): boolean {
+  if (status !== 400) return false;
+  const normalized = body.toLowerCase();
+  return normalized.includes('web_search') || normalized.includes('web search');
 }
 
 function withAccountId(tokens: CodexTokens, accountId: string | undefined): CodexTokens {

--- a/packages/plugin-provider-openai-codex/src/translate.test.ts
+++ b/packages/plugin-provider-openai-codex/src/translate.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { defineTool, z } from '@moxxy/sdk';
 import { extractSystemText, toResponsesBody, toResponsesInput } from './translate.js';
 
 describe('toResponsesInput', () => {
@@ -91,5 +92,22 @@ describe('toResponsesBody', () => {
     const body = toResponsesBody({ ...req, maxTokens: 999, temperature: 0.5 });
     expect(body).not.toHaveProperty('max_output_tokens');
     expect(body).not.toHaveProperty('temperature');
+  });
+
+  it('serializes hosted web search beside ordinary function tools', () => {
+    const read = defineTool({
+      name: 'Read',
+      description: 'read',
+      inputSchema: z.object({ path: z.string() }),
+      handler: () => '',
+    });
+    const body = toResponsesBody(
+      { ...req, tools: [read] },
+      { hostedTools: [{ type: 'web_search' }] },
+    );
+    expect(body.tools).toEqual([
+      expect.objectContaining({ type: 'function', name: 'Read' }),
+      { type: 'web_search' },
+    ]);
   });
 });

--- a/packages/plugin-provider-openai-codex/src/translate.ts
+++ b/packages/plugin-provider-openai-codex/src/translate.ts
@@ -1,4 +1,10 @@
-import { zodToJsonSchema, type ProviderMessage, type ProviderRequest, type ToolDef } from '@moxxy/sdk';
+import {
+  zodToJsonSchema,
+  type HostedTool,
+  type ProviderMessage,
+  type ProviderRequest,
+  type ToolDef,
+} from '@moxxy/sdk';
 
 /**
  * Responses-API "input" item shape. We only emit the subset codex uses:
@@ -17,13 +23,15 @@ type ResponsesContent =
   | { type: 'input_image'; image_url: string }
   | { type: 'input_file'; filename?: string; file_data: string };
 
-interface ResponsesTool {
+interface ResponsesFunctionTool {
   type: 'function';
   name: string;
   description: string;
   parameters: unknown;
   strict?: boolean;
 }
+
+type ResponsesTool = ResponsesFunctionTool | { type: 'web_search' };
 
 export interface ResponsesBody {
   model: string;
@@ -142,7 +150,7 @@ export function toResponsesInput(messages: ReadonlyArray<ProviderMessage>): Resp
   return out;
 }
 
-export function toResponsesTools(tools: ReadonlyArray<ToolDef>): ResponsesTool[] {
+export function toResponsesTools(tools: ReadonlyArray<ToolDef>): ResponsesFunctionTool[] {
   return tools.map((t) => ({
     type: 'function' as const,
     name: t.name,
@@ -154,6 +162,7 @@ export function toResponsesTools(tools: ReadonlyArray<ToolDef>): ResponsesTool[]
 export interface BuildBodyOptions {
   readonly sessionHint?: string;
   readonly reasoningEffort?: 'low' | 'medium' | 'high';
+  readonly hostedTools?: ReadonlyArray<HostedTool>;
 }
 
 /**
@@ -216,7 +225,11 @@ export function toResponsesBody(req: ProviderRequest, opts: BuildBodyOptions = {
     reasoning: { effort: opts.reasoningEffort ?? 'medium', summary: 'auto' },
     include: ['reasoning.encrypted_content'],
   };
-  if (req.tools && req.tools.length > 0) body.tools = toResponsesTools(req.tools);
+  const tools: ResponsesTool[] = req.tools ? toResponsesTools(req.tools) : [];
+  for (const hosted of opts.hostedTools ?? []) {
+    if (hosted.type === 'web_search') tools.push({ type: 'web_search' });
+  }
+  if (tools.length > 0) body.tools = tools;
   if (opts.sessionHint) body.prompt_cache_key = opts.sessionHint;
   if (req.maxTokens !== undefined) noteMaxTokensUnsupported();
   if (req.temperature !== undefined) noteTemperatureUnsupported();

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -149,6 +149,7 @@ import type {
 
 - `zodToJsonSchema` converts a zod schema to JSON Schema for provider tool calls.
 - `isRetryableError` and `toFriendlyError` classify provider errors uniformly.
+- `resolveProviderTools` enables capabilities from `ModelDescriptor.hostedTools` and removes only matching client fallbacks marked with `ToolDef.hosted`.
 - `estimateContextTokens` and `runCompactionIfNeeded` are scaffolding for custom compactors.
 - `CachedEmbeddingProvider` wraps any `EmbeddingProvider` with on-disk caching.
 - `dispatchToolCall` invokes a tool through the full gating, permission, and isolation pipeline.
@@ -209,7 +210,13 @@ class MyLlmClient implements LLMProvider {
 }
 
 const MODELS = [
-  { id: 'flagship', contextWindow: 200_000, supportsTools: true, supportsStreaming: true },
+  {
+    id: 'flagship',
+    contextWindow: 200_000,
+    supportsTools: true,
+    supportsStreaming: true,
+    hostedTools: ['web_search'],
+  },
 ];
 
 export default definePlugin({

--- a/packages/sdk/src/compactor-helpers.test.ts
+++ b/packages/sdk/src/compactor-helpers.test.ts
@@ -466,6 +466,25 @@ describe('resolveModelContext', () => {
       warn.mockRestore();
     }
   });
+
+  it('resolves a bracketed context variant from its base descriptor instead of models[0]', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const ctx = makeCtx({
+        compactor: null,
+        model: 'claude-sonnet-4-6',
+        contextWindow: 1_000_000,
+        ctxModelId: 'claude-sonnet-4-6[1m]',
+      });
+      expect(resolveModelContext(ctx)).toEqual({
+        contextWindow: 1_000_000,
+        reserveForOutput: 0,
+      });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
 });
 
 describe('runElisionIfNeeded', () => {

--- a/packages/sdk/src/compactor-helpers.ts
+++ b/packages/sdk/src/compactor-helpers.ts
@@ -132,7 +132,15 @@ export function resolveModelContext(
   ctx: ModeContext,
 ): { readonly contextWindow: number; readonly reserveForOutput: number } | null {
   const exact = ctx.provider.models.find((m) => m.id === ctx.model);
-  const descriptor = exact ?? ctx.provider.models[0];
+  // Provider/admin model ids may carry a bracketed context variant (for
+  // example `claude-sonnet-4-6[1m]`). Prefer the matching base descriptor over
+  // the unrelated models[0] fallback; only strip a terminal bracket suffix so
+  // genuinely distinct dated/vendor ids are never conflated accidentally.
+  const baseId = ctx.model.replace(/\[[^\]]+\]$/, '');
+  const variant = baseId !== ctx.model
+    ? ctx.provider.models.find((model) => model.id === baseId)
+    : undefined;
+  const descriptor = exact ?? variant ?? ctx.provider.models[0];
   const contextWindow = descriptor?.contextWindow;
   if (!contextWindow || contextWindow <= 0) return null;
   // Signal (once) when the exact-id lookup missed and we fell back to the first
@@ -141,7 +149,7 @@ export function resolveModelContext(
   // for the whole session may calibrate against the wrong window with no other
   // trace. Deduped on (provider, requested id, fallback id) because this runs
   // once per loop iteration — an undeduped warn would spam every turn.
-  if (!exact && descriptor) {
+  if (!exact && !variant && descriptor) {
     warnModelFallbackOnce(ctx.provider.name, ctx.model, descriptor.id, contextWindow);
   }
   return { contextWindow, reserveForOutput: descriptor?.maxOutputTokens ?? 0 };

--- a/packages/sdk/src/define.ts
+++ b/packages/sdk/src/define.ts
@@ -9,7 +9,7 @@ import type { PermissionRule } from './permission.js';
 import type { Plugin, PluginSpec } from './plugin.js';
 import type { ProviderDef } from './provider.js';
 import type { SkillDef, SkillFrontmatter } from './skill.js';
-import type { ToolCompactPresentation, ToolContext, ToolDef } from './tool.js';
+import type { HostedTool, ToolCompactPresentation, ToolContext, ToolDef } from './tool.js';
 import type { ToolIsolationSpec } from './isolation.js';
 import type { TranscriberDef } from './transcriber.js';
 import type { SynthesizerDef } from './synthesizer.js';
@@ -42,6 +42,7 @@ export function defineTool<S extends z.ZodTypeAny, O = unknown>(spec: {
   inputSchema: S;
   inputJsonSchema?: unknown;
   outputSchema?: z.ZodType<O>;
+  hosted?: HostedTool;
   permission?: PermissionRule;
   handler: (input: z.output<S>, ctx: ToolContext) => Promise<O> | O;
   compact?: ToolCompactPresentation;
@@ -53,6 +54,7 @@ export function defineTool<S extends z.ZodTypeAny, O = unknown>(spec: {
     inputSchema: spec.inputSchema,
     inputJsonSchema: spec.inputJsonSchema,
     outputSchema: spec.outputSchema,
+    hosted: spec.hosted,
     permission: spec.permission,
     handler: spec.handler as (input: unknown, ctx: ToolContext) => Promise<unknown> | unknown,
     compact: spec.compact,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -96,6 +96,7 @@ export type {
 export type {
   ToolContext,
   ToolDef,
+  HostedTool,
   ToolCompactPresentation,
   BrokeredFs,
   BrokeredStat,
@@ -204,7 +205,17 @@ export type {
 // readRequestBody/bearerTokenMatches, channel-auth) are exported from the
 // './server' subpath, NOT the main barrel — they statically reach node:*
 // builtins and would break a browser/RN bundle. See ./server.ts.
-export { isRetryableError, toFriendlyError, zodToJsonSchema, estimateTextTokens, type StopReason } from './provider-utils.js';
+export {
+  isRetryableError,
+  toFriendlyError,
+  zodToJsonSchema,
+  estimateTextTokens,
+  type StopReason,
+} from './provider-utils.js';
+export {
+  resolveProviderTools,
+  type ResolvedProviderTools,
+} from './provider-tool-utils.js';
 export type { WriteFileAtomicOptions } from './fs-utils.js';
 export type { ChannelRunStatus } from './channel-status.js';
 export type { CrossProcessFireLock, CrossProcessFireLockOptions } from './cross-process-lock.js';

--- a/packages/sdk/src/provider-tool-utils.ts
+++ b/packages/sdk/src/provider-tool-utils.ts
@@ -1,0 +1,33 @@
+import type { ModelDescriptor } from './provider.js';
+import type { HostedTool, ToolDef } from './tool.js';
+
+export interface ResolvedProviderTools {
+  /** Client-executed tools that should still be serialized as function tools. */
+  readonly tools: ReadonlyArray<ToolDef>;
+  /** Provider-hosted tools that replace matching client fallbacks. */
+  readonly hostedTools: ReadonlyArray<HostedTool>;
+}
+
+/**
+ * Enable the active model's advertised hosted tools and remove only matching
+ * duplicate client fallbacks. Unknown model ids deliberately keep every local
+ * fallback: stale catalog data must never silently drop a callable tool.
+ */
+export function resolveProviderTools(
+  tools: ReadonlyArray<ToolDef> | undefined,
+  models: ReadonlyArray<ModelDescriptor>,
+  modelId: string,
+): ResolvedProviderTools {
+  const descriptor = models.find((model) => model.id === modelId);
+  const supported = new Set(descriptor?.hostedTools ?? []);
+  const clientTools: ToolDef[] = [];
+  const hostedTools: HostedTool[] = Array.from(supported, (type) => ({ type }));
+
+  for (const tool of tools ?? []) {
+    const hosted = tool.hosted;
+    if (!hosted || !supported.has(hosted.type)) {
+      clientTools.push(tool);
+    }
+  }
+  return { tools: clientTools, hostedTools };
+}

--- a/packages/sdk/src/provider-utils.test.ts
+++ b/packages/sdk/src/provider-utils.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { zodToJsonSchema } from './provider-utils.js';
+import { resolveProviderTools } from './provider-tool-utils.js';
+import { defineTool } from './define.js';
 
 /**
  * Regression coverage for the codex `/responses` 400 we hit when a tool's
@@ -90,5 +92,63 @@ describe('zodToJsonSchema', () => {
     expect(() => zodToJsonSchema(schema)).not.toThrow();
     const out = zodToJsonSchema(schema);
     expect(out).toBeDefined();
+  });
+});
+
+describe('resolveProviderTools', () => {
+  const webSearch = defineTool({
+    name: 'web_search',
+    description: 'fallback',
+    inputSchema: z.object({ query: z.string() }),
+    hosted: { type: 'web_search' },
+    handler: () => [],
+  });
+  const read = defineTool({
+    name: 'Read',
+    description: 'read',
+    inputSchema: z.object({ path: z.string() }),
+    handler: () => '',
+  });
+
+  it('replaces a marked fallback only when the exact model advertises the hosted tool', () => {
+    const resolved = resolveProviderTools(
+      [read, webSearch],
+      [
+        {
+          id: 'native-model',
+          contextWindow: 100,
+          supportsTools: true,
+          supportsStreaming: true,
+          hostedTools: ['web_search'],
+        },
+      ],
+      'native-model',
+    );
+    expect(resolved.tools.map((tool) => tool.name)).toEqual(['Read']);
+    expect(resolved.hostedTools).toEqual([{ type: 'web_search' }]);
+  });
+
+  it('enables a model capability even when no client fallback plugin is installed', () => {
+    const resolved = resolveProviderTools(
+      undefined,
+      [{
+        id: 'native-model',
+        contextWindow: 100,
+        supportsTools: true,
+        supportsStreaming: true,
+        hostedTools: ['web_search'],
+      }],
+      'native-model',
+    );
+    expect(resolved.tools).toEqual([]);
+    expect(resolved.hostedTools).toEqual([{ type: 'web_search' }]);
+  });
+
+  it('keeps the local fallback for unsupported and unknown models', () => {
+    const models = [
+      { id: 'plain-model', contextWindow: 100, supportsTools: true, supportsStreaming: true },
+    ];
+    expect(resolveProviderTools([webSearch], models, 'plain-model').tools).toEqual([webSearch]);
+    expect(resolveProviderTools([webSearch], models, 'catalog-drift').tools).toEqual([webSearch]);
   });
 });

--- a/packages/sdk/src/provider.ts
+++ b/packages/sdk/src/provider.ts
@@ -1,4 +1,4 @@
-import type { ToolDef } from './tool.js';
+import type { HostedTool, ToolDef } from './tool.js';
 
 export interface ProviderMessage {
   readonly role: 'system' | 'user' | 'assistant' | 'tool_result';
@@ -148,6 +148,13 @@ export interface ModelDescriptor {
    * for this model. When false, `ProviderRequest.reasoning` is ignored.
    */
   readonly supportsReasoning?: boolean;
+  /**
+   * Tools executed by the provider on behalf of this model (for example
+   * OpenAI Responses or Anthropic server tools). A matching client ToolDef
+   * may be replaced by the hosted implementation while retaining its handler
+   * as the fallback for other models/providers.
+   */
+  readonly hostedTools?: ReadonlyArray<HostedTool['type']>;
 }
 
 export interface LLMProvider {

--- a/packages/sdk/src/tool.ts
+++ b/packages/sdk/src/tool.ts
@@ -6,6 +6,16 @@ import type { SubagentSpawner } from './subagent.js';
 import type { ToolIsolationSpec } from './isolation.js';
 
 /**
+ * A tool the active model provider can execute on its own infrastructure.
+ *
+ * A ToolDef carrying this marker remains a normal client-side tool and is a
+ * fully functional fallback. When the active ModelDescriptor advertises the
+ * same hosted capability, providers omit the duplicate client definition and
+ * use their hosted equivalent. On other models the handler stays available.
+ */
+export type HostedTool = { readonly type: 'web_search' };
+
+/**
  * Capability-mediated filesystem operations injected by isolators that
  * support brokering. Handlers can opt in by checking `ctx.fs` at runtime
  * and using these instead of `node:fs`; the broker validates each call
@@ -175,6 +185,8 @@ export interface ToolDef {
    */
   readonly inputJsonSchema?: unknown;
   readonly outputSchema?: z.ZodTypeAny;
+  /** Optional provider-hosted equivalent. This handler remains the fallback. */
+  readonly hosted?: HostedTool;
   readonly permission?: PermissionRule;
   readonly handler: (input: unknown, ctx: ToolContext) => Promise<unknown> | unknown;
   /** Opt-in presentation hint. See `ToolCompactPresentation`. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2042,6 +2042,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.40.0
         version: 0.40.1(encoding@0.1.13)
+      '@moxxy/plugin-browser':
+        specifier: workspace:*
+        version: link:../plugin-browser
       '@moxxy/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -2073,6 +2076,9 @@ importers:
 
   packages/plugin-provider-claude-code:
     dependencies:
+      '@moxxy/plugin-browser':
+        specifier: workspace:*
+        version: link:../plugin-browser
       '@moxxy/plugin-oauth':
         specifier: workspace:*
         version: link:../plugin-oauth
@@ -2188,6 +2194,9 @@ importers:
 
   packages/plugin-provider-openai-codex:
     dependencies:
+      '@moxxy/plugin-browser':
+        specifier: workspace:*
+        version: link:../plugin-browser
       '@moxxy/plugin-oauth':
         specifier: workspace:*
         version: link:../plugin-oauth


### PR DESCRIPTION
## What

- add a provider-neutral hosted-tool capability and prefer native web search for Codex and Anthropic models
- enable Claude Code's native `WebSearch` tool by default in text mode, with an explicit opt-out
- add a pluggable `@moxxy/plugin-browser` search adapter as the local fallback for providers that participate in Moxxy tool calling
- install that lightweight fallback automatically with the Codex, Anthropic API, and Claude Code providers; Playwright remains optional and has no install hook
- preserve citations, document the credential/CLI requirements, and cover native rejection/fallback and companion-package guarantees with tests

## Why

Provider-hosted search avoids the CAPTCHA and anti-bot failures that frequently affect direct scraping. The automatically installed browser companion remains a fallback and extension point instead of being the primary path, without downloading a browser engine until interactive browsing is explicitly requested.

The Claude Code CLI is an opaque text transport, so it uses its own native `WebSearch`; Moxxy cannot inject its local tool fallback into that subprocess path. Codex OAuth and the Anthropic API do not require their CLIs to be installed.

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` (0 errors; existing warnings only)
- `pnpm test`
- `pnpm check:deps` (0 errors; existing orphan warning only)
- CLI help and plugin-list smokes
- packed-manifest check: all three providers ship `@moxxy/plugin-browser`; Playwright remains an optional peer
- live Codex smoke test without `@moxxy/plugin-browser`
