### PR TITLE
feat(chat): redesign tool and skill activity traces

### DIFF
--- a/.changeset/quiet-activity-traces.md
+++ b/.changeset/quiet-activity-traces.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/cli': minor
+'@moxxy/desktop': minor
+---
+
+Redesign tool and skill activity as compact expandable traces with live shimmer feedback.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -24,6 +24,15 @@ or recorded-on-purpose decision.
 
 ## Resolved ledger
 
+- [med, chat-ux, RESOLVED 2026-07-23] Desktop ignored the live registry's
+  `ToolInfo.compact` metadata even though TUI already consumed it, so the same
+  Read/Grep/Glob run became a compact activity trace in one surface and a stack
+  of generic tool cards in the other. Desktop now feeds the serializable
+  metadata from `session.info` into the shared incremental fold (including the
+  extension-sliced path); both surfaces render the resulting tool/skill work as
+  compact, expandable activity rows and animate only active labels with a
+  reduced-motion-safe shimmer. `packages/client-core/src/chatModel.ts`,
+  `packages/plugin-cli/src/components/chat/`, `apps/desktop/src/chat/`.
 - [high, modes, RESOLVED 2026-07-05] Goal mode killed its own runs and never let
   go: the iteration cap (150), a 4M token budget, and a stuck-loop FATAL abort
   (whose near-repeat heuristic trips on a legitimate edit→build→test cycle) all

--- a/apps/desktop/src/chat/ActivityRow.test.tsx
+++ b/apps/desktop/src/chat/ActivityRow.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ActivityRow } from './ActivityRow';
+
+describe('ActivityRow', () => {
+  it('uses shimmer only while active and exposes disclosure state', () => {
+    const toggle = vi.fn();
+    const { rerender } = render(
+      <ActivityRow icon="search" label="Searching…" active open={false} onToggle={toggle} testId="activity" />,
+    );
+    const row = screen.getByTestId('activity');
+    expect(row).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByText('Searching…')).toHaveClass('activity-shimmer');
+    fireEvent.click(row);
+    expect(toggle).toHaveBeenCalledOnce();
+
+    rerender(<ActivityRow icon="search" label="Searched" open onToggle={toggle} testId="activity" />);
+    expect(row).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Searched')).not.toHaveClass('activity-shimmer');
+  });
+});

--- a/apps/desktop/src/chat/ActivityRow.tsx
+++ b/apps/desktop/src/chat/ActivityRow.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from 'react';
+import { Icon, type IconName } from '@moxxy/desktop-ui';
+
+/** Shared, deliberately quiet activity header used by tools and skills. */
+export function ActivityRow({
+  icon,
+  label,
+  meta,
+  active,
+  open,
+  onToggle,
+  testId,
+}: {
+  readonly icon: IconName;
+  readonly label: ReactNode;
+  readonly meta?: ReactNode;
+  readonly active?: boolean;
+  readonly open: boolean;
+  readonly onToggle: () => void;
+  readonly testId?: string;
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      className="activity-row"
+      onClick={onToggle}
+      aria-expanded={open}
+      data-testid={testId}
+      data-active={active ? 'true' : 'false'}
+    >
+      <span className="activity-row__icon" aria-hidden>
+        <Icon name={icon} size={18} />
+      </span>
+      <span className={`activity-row__label${active ? ' activity-shimmer' : ''}`}>{label}</span>
+      {meta ? <span className="activity-row__meta">{meta}</span> : null}
+      <span
+        className="activity-row__chevron"
+        aria-hidden
+        style={{ transform: open ? 'rotate(90deg)' : 'none' }}
+      >
+        <Icon name="chevron-right" size={14} />
+      </span>
+    </button>
+  );
+}

--- a/apps/desktop/src/chat/ChatSurface.test.tsx
+++ b/apps/desktop/src/chat/ChatSurface.test.tsx
@@ -49,6 +49,7 @@ vi.mock('@moxxy/client-core', () => ({
     hasOlder: false,
     loadOlder: vi.fn(),
   }),
+  useActionCatalog: () => ({ loaded: true, skills: [], tools: [] }),
   useDesks: () => ({
     desks: [],
     activeId: null,

--- a/apps/desktop/src/chat/ChatSurface.tsx
+++ b/apps/desktop/src/chat/ChatSurface.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useChat } from '@moxxy/client-core';
+import { useActionCatalog, useChat } from '@moxxy/client-core';
 import { deskForWorkspace, useDesks } from '@moxxy/client-core';
 import type { ConnectionPhase } from '@moxxy/desktop-ipc-contract';
 import { Transcript } from './Transcript';
@@ -92,6 +92,7 @@ export function ChatSurface({
   disabledViewReason,
 }: ChatSurfaceProps): JSX.Element {
   const chat = useChat(workspaceId);
+  const actionCatalog = useActionCatalog(workspaceId);
   const desks = useDesks();
   const activeAsk = useActiveAsk(workspaceId);
   const ready = phase.phase === 'connected' && !sessionLoading && !chat.loading;
@@ -109,6 +110,16 @@ export function ChatSurface({
     if (!searchQuery) return chat.events;
     return filterEventsBySearch(chat.events, searchIndex, searchQuery);
   }, [chat.events, searchQuery, searchIndex]);
+  const compactTools = useMemo(() => {
+    const compact = new Map<
+      string,
+      NonNullable<(typeof actionCatalog.tools)[number]['compact']>
+    >();
+    for (const tool of actionCatalog.tools) {
+      if (tool.compact) compact.set(tool.name, tool.compact);
+    }
+    return compact;
+  }, [actionCatalog]);
 
   // Suggested-action chips are only shown when the composer is idle and the
   // transcript is non-empty. Compute them only then, and memoize on the event
@@ -186,6 +197,7 @@ export function ChatSurface({
             hasOlder={!searchQuery && chat.hasOlder}
             onReachedTop={chat.loadOlder}
             onPreviewImage={imagePreview.open}
+            compactTools={compactTools}
           />
         )}
       </div>

--- a/apps/desktop/src/chat/SkillGroupView.tsx
+++ b/apps/desktop/src/chat/SkillGroupView.tsx
@@ -1,24 +1,13 @@
-/**
- * Renders a chat-model `skill-scope` block — a skill activation plus the
- * tools it ran — as one collapsible group. Mirrors the assistant column
- * rhythm with a brand-pink spark avatar.
- *
- *   ┌── [spark] Skill · web-research · 9 ok                       ▾
- *   │     web_fetch { "url": "https://…" }
- *   │     ...
- *   └────
- */
-
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   isFileDiffResult,
-  oneLine,
-  summarizeArgs,
+  formatToolActivity,
   type Block as FoldedBlock,
   type ToolCallBlockData,
 } from '@moxxy/chat-model';
 import { isFileDiffDisplay, type FileDiffDisplay } from '@moxxy/sdk/tool-display';
-import { Icon } from '@moxxy/desktop-ui';
+import { Icon, type IconName } from '@moxxy/desktop-ui';
+import { ActivityRow } from './ActivityRow';
 import { FileDiffBlock } from './blocks/FileDiffBlock';
 import { preStyle, pretty } from './blocks/block-shared';
 
@@ -31,17 +20,24 @@ export interface ToolRowData {
   readonly outcome: ToolCallBlockData['outcome'];
 }
 
-/** Flatten a skill scope's children into tool rows — tool-calls plus the
- *  calls inside any live-tools aggregate. Non-tool children (rare; the
- *  fold keeps assistant text at root) are dropped from the row list. */
 function collectTools(children: ReadonlyArray<FoldedBlock>): ToolRowData[] {
   const out: ToolRowData[] = [];
-  for (const c of children) {
-    if (c.kind === 'tool-call') {
-      out.push({ id: c.id, name: c.request.name, input: c.request.input, outcome: c.outcome });
-    } else if (c.kind === 'live-tools') {
-      for (const call of c.calls) {
-        out.push({ id: call.id, name: call.request.name, input: call.request.input, outcome: call.outcome });
+  for (const child of children) {
+    if (child.kind === 'tool-call') {
+      out.push({
+        id: child.id,
+        name: child.request.name,
+        input: child.request.input,
+        outcome: child.outcome,
+      });
+    } else if (child.kind === 'live-tools') {
+      for (const call of child.calls) {
+        out.push({
+          id: call.id,
+          name: call.request.name,
+          input: call.request.input,
+          outcome: call.outcome,
+        });
       }
     }
   }
@@ -54,156 +50,95 @@ export function statusOf(outcome: ToolCallBlockData['outcome']): 'running' | 'ok
   return outcome.ok ? 'ok' : 'error';
 }
 
-export function SkillGroupView({ scope }: { readonly scope: SkillScope }): JSX.Element {
-  const [open, setOpen] = useState(false);
-  const tools = collectTools(scope.children);
-  const counts = tools.reduce<Record<string, number>>((acc, t) => {
-    const s = statusOf(t.outcome);
-    acc[s] = (acc[s] ?? 0) + 1;
-    return acc;
-  }, {});
-  const subtitle = Object.entries(counts)
-    .map(([k, v]) => `${v} ${k}`)
-    .join(' · ');
-
-  return (
-    <div data-testid="block-skill" style={{ alignSelf: 'stretch', display: 'flex', gap: 12, maxWidth: '92%' }}>
-      <Avatar />
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <button
-          type="button"
-          onClick={() => setOpen((v) => !v)}
-          aria-expanded={open}
-          style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '2px 0', width: '100%', textAlign: 'left' }}
-        >
-          <span style={{ fontWeight: 600, fontSize: 13.5 }}>
-            Skill
-            <span style={{ color: 'var(--color-text-dim)', fontWeight: 500, marginLeft: 6 }}>
-              · {scope.skillEvent.name}
-            </span>
-          </span>
-          <span className="mono" style={{ fontSize: 11, color: 'var(--color-text-dim)' }}>
-            {subtitle}
-          </span>
-          <span style={{ flex: 1 }} />
-          <span
-            aria-hidden
-            style={{
-              color: 'var(--color-text-dim)',
-              transform: open ? 'rotate(90deg)' : 'none',
-              transition: 'transform 120ms ease',
-              display: 'inline-flex',
-            }}
-          >
-            <Icon name="chevron-right" size={14} />
-          </span>
-        </button>
-        {!open && (
-          <div style={{ marginTop: 4, fontSize: 11, color: 'var(--color-text-dim)', fontStyle: 'italic' }}>
-            {scope.skillEvent.reason.replace(/_/g, ' ')}
-          </div>
-        )}
-        {open && (
-          <ul role="list" style={{ listStyle: 'none', margin: '6px 0 0', padding: 0 }}>
-            {tools.map((t) => (
-              <ToolRow key={t.id} tool={t} />
-            ))}
-          </ul>
-        )}
-      </div>
-    </div>
-  );
+export function iconForTool(name: string): IconName {
+  const normalized = name.toLowerCase();
+  if (normalized === 'read') return 'file';
+  if (normalized === 'grep' || normalized.includes('search')) return 'search';
+  if (normalized === 'glob') return 'folder';
+  if (normalized === 'bash' || normalized === 'exec' || normalized.includes('command')) return 'terminal';
+  return 'wrench';
 }
 
-function Avatar(): JSX.Element {
+/** Human-readable line matching the activity-list treatment in the reference. */
+export function toolActivityLabel(tool: Pick<ToolRowData, 'name' | 'input' | 'outcome'>): string {
+  return formatToolActivity(tool.name, tool.input, statusOf(tool.outcome) === 'running');
+}
+
+/** Starts expanded while work is live, then quietly collapses when it settles
+ * unless the user has explicitly chosen a state. */
+export function useActivityDisclosure(running: boolean): readonly [boolean, () => void] {
+  const [open, setOpen] = useState(running);
+  const touched = useRef(false);
+  const wasRunning = useRef(running);
+  useEffect(() => {
+    if (wasRunning.current && !running && !touched.current) setOpen(false);
+    wasRunning.current = running;
+  }, [running]);
+  return [
+    open,
+    () => {
+      touched.current = true;
+      setOpen((value) => !value);
+    },
+  ];
+}
+
+export function SkillGroupView({ scope }: { readonly scope: SkillScope }): JSX.Element {
+  const tools = collectTools(scope.children);
+  const running = !scope.closed || tools.some((tool) => statusOf(tool.outcome) === 'running');
+  const [open, toggle] = useActivityDisclosure(running);
+  const errors = tools.filter((tool) => statusOf(tool.outcome) === 'error').length;
+  const meta = errors > 0 ? `${errors} failed` : tools.length > 0 ? `${tools.length}` : undefined;
+
   return (
-    <span
-      aria-hidden
-      style={{
-        width: 34,
-        height: 34,
-        borderRadius: 10,
-        background: 'var(--color-primary-soft)',
-        color: 'var(--color-primary-strong)',
-        display: 'inline-flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        flexShrink: 0,
-      }}
-    >
-      <Icon name="spark" size={18} />
-    </span>
+    <div className="activity-block" data-testid="block-skill">
+      <ActivityRow
+        icon="spark"
+        label={`${running ? 'Using' : 'Used'} skill ${scope.skillEvent.name}${running ? '…' : ''}`}
+        meta={meta}
+        active={running}
+        open={open}
+        onToggle={toggle}
+      />
+      {open ? (
+        <ul className="activity-list" role="list">
+          {tools.map((tool) => <ToolRow key={tool.id} tool={tool} />)}
+        </ul>
+      ) : null}
+    </div>
   );
 }
 
 export function ToolRow({ tool }: { readonly tool: ToolRowData }): JSX.Element {
   const [open, setOpen] = useState(false);
-  // A settled Write/Edit inside a skill scope renders as a diff card.
   if (isFileDiffResult(tool.outcome)) {
     const display = (tool.outcome.output as { display: FileDiffDisplay }).display;
     if (isFileDiffDisplay(display)) {
-      return (
-        <li style={{ listStyle: 'none', marginTop: 4 }}>
-          <FileDiffBlock display={display} />
-        </li>
-      );
+      return <li className="activity-list__diff"><FileDiffBlock display={display} /></li>;
     }
   }
+
   const status = statusOf(tool.outcome);
-  const accent =
-    status === 'error' ? 'var(--color-red)' : status === 'ok' ? 'var(--color-green)' : 'var(--color-primary)';
-  const tint = status === 'error' ? 'var(--color-red-soft)' : status === 'ok' ? 'var(--color-green-soft)' : 'var(--color-primary-soft)';
-  const summary = summarizeArgs(tool.input);
-  const output = tool.outcome && tool.outcome.type === 'tool_result' ? tool.outcome.output : undefined;
-  const error =
-    tool.outcome === null
-      ? undefined
-      : tool.outcome.type === 'denied'
-        ? tool.outcome.reason
-        : tool.outcome.error?.message;
+  const output = tool.outcome?.type === 'tool_result' ? tool.outcome.output : undefined;
+  const error = tool.outcome === null
+    ? undefined
+    : tool.outcome.type === 'denied'
+      ? tool.outcome.reason
+      : tool.outcome.error?.message;
   return (
-    <li
-      style={{
-        background: tint,
-        border: '1px solid var(--color-card-border)',
-        borderLeft: `3px solid ${accent}`,
-        borderRadius: 10,
-        padding: '8px 10px',
-        marginTop: 4,
-        fontSize: 12.5,
-        fontFamily: 'var(--font-mono)',
-      }}
-    >
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        style={{ display: 'flex', width: '100%', alignItems: 'center', gap: 8, color: 'var(--color-text)', textAlign: 'left' }}
-      >
-        <span style={{ color: accent, fontWeight: 600 }}>[{status}]</span>
-        <span style={{ fontWeight: 600 }}>{tool.name}</span>
-        {summary && (
-          <span
-            style={{
-              flex: 1,
-              minWidth: 0,
-              color: 'var(--color-text-dim)',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}
-          >
-            {oneLine(summary)}
-          </span>
-        )}
+    <li className="activity-list__item" data-status={status}>
+      <button type="button" className="activity-detail-row" onClick={() => setOpen((value) => !value)} aria-expanded={open}>
+        <span className="activity-detail-row__icon" aria-hidden><Icon name={iconForTool(tool.name)} size={16} /></span>
+        <span className={`activity-detail-row__label${status === 'running' ? ' activity-shimmer' : ''}`}>{toolActivityLabel(tool)}</span>
+        {status === 'error' ? <span className="activity-detail-row__error">failed</span> : null}
       </button>
-      {open && (
-        <div style={{ marginTop: 8, display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {open ? (
+        <div className="activity-detail-row__body">
           <pre style={preStyle}>{pretty(tool.input)}</pre>
-          {output !== undefined && <pre style={preStyle}>{pretty(output)}</pre>}
-          {error && <pre style={{ ...preStyle, color: 'var(--color-red)' }}>{error}</pre>}
+          {output !== undefined ? <pre style={preStyle}>{pretty(output)}</pre> : null}
+          {error ? <pre style={{ ...preStyle, color: 'var(--color-red)' }}>{error}</pre> : null}
         </div>
-      )}
+      ) : null}
     </li>
   );
 }

--- a/apps/desktop/src/chat/ToolGroupView.tsx
+++ b/apps/desktop/src/chat/ToolGroupView.tsx
@@ -1,120 +1,67 @@
-/**
- * Renders a run of consecutive standalone tool calls (see
- * `chatModel.groupToolNodes`) as ONE collapsible "Tools · N" block — a wrench
- * avatar + status summary, expandable to each tool row. Mirrors
- * {@link SkillGroupView} so a burst of back-to-back Writes/fetches doesn't
- * stack into N separate top-level blocks, and reuses its ToolRow so an
- * expanded group looks identical to an expanded skill.
- */
+import {
+  buildCompactSummary,
+  compactPreviewLine,
+  type LiveToolBlockData,
+  type ToolCallBlockData,
+} from '@moxxy/chat-model';
+import { ActivityRow } from './ActivityRow';
+import { iconForTool, statusOf, ToolRow, useActivityDisclosure, type ToolRowData } from './SkillGroupView';
 
-import { useState } from 'react';
-import type { ToolCallBlockData } from '@moxxy/chat-model';
-import { Icon } from '@moxxy/desktop-ui';
-import { ToolRow, statusOf, type ToolRowData } from './SkillGroupView';
+function errorCount(rows: ReadonlyArray<ToolRowData>): number {
+  return rows.filter((row) => statusOf(row.outcome) === 'error').length;
+}
 
-export function ToolGroupView({
-  tools,
-}: {
-  readonly tools: ReadonlyArray<ToolCallBlockData>;
-}): JSX.Element {
-  const [open, setOpen] = useState(false);
-  const rows: ToolRowData[] = tools.map((t) => ({
-    id: t.id,
-    name: t.request.name,
-    input: t.request.input,
-    outcome: t.outcome,
+function ActivityToolList({ rows }: { readonly rows: ReadonlyArray<ToolRowData> }): JSX.Element {
+  return <ul className="activity-list" role="list">{rows.map((row) => <ToolRow key={row.id} tool={row} />)}</ul>;
+}
+
+export function ToolGroupView({ tools }: { readonly tools: ReadonlyArray<ToolCallBlockData> }): JSX.Element {
+  const rows: ToolRowData[] = tools.map((tool) => ({
+    id: tool.id,
+    name: tool.request.name,
+    input: tool.request.input,
+    outcome: tool.outcome,
   }));
-  const counts = rows.reduce<Record<string, number>>((acc, r) => {
-    const s = statusOf(r.outcome);
-    acc[s] = (acc[s] ?? 0) + 1;
-    return acc;
-  }, {});
-  const subtitle = Object.entries(counts)
-    .map(([k, v]) => `${v} ${k}`)
-    .join(' · ');
-  const running = rows.some((r) => statusOf(r.outcome) === 'running');
-  const errored = rows.some((r) => statusOf(r.outcome) === 'error');
-  const accent = errored
-    ? 'var(--color-red)'
-    : running
-      ? 'var(--color-primary)'
-      : 'var(--color-green)';
-  const tint = errored ? 'var(--color-red-soft)' : running ? 'var(--color-primary-soft)' : 'var(--color-green-soft)';
-
+  const running = rows.some((row) => statusOf(row.outcome) === 'running');
+  const [open, toggle] = useActivityDisclosure(running);
+  const errors = errorCount(rows);
   return (
-    <div data-testid="block-tool-group" style={{ alignSelf: 'stretch', display: 'flex', gap: 12, maxWidth: '92%' }}>
-      <span
-        aria-hidden
-        style={{
-          width: 34,
-          height: 34,
-          flexShrink: 0,
-          borderRadius: 10,
-          background: tint,
-          color: accent,
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Icon name="wrench" size={17} />
-      </span>
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <button
-          type="button"
-          onClick={() => setOpen((v) => !v)}
-          aria-expanded={open}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 8,
-            padding: '2px 0',
-            width: '100%',
-            textAlign: 'left',
-          }}
-        >
-          <span style={{ fontWeight: 600, fontSize: 13.5 }}>
-            Tools
-            <span style={{ color: 'var(--color-text-dim)', fontWeight: 500, marginLeft: 6 }}>
-              · {rows.length}
-            </span>
-          </span>
-          <span className="mono" style={{ fontSize: 11, color: 'var(--color-text-dim)' }}>
-            {subtitle}
-          </span>
-          <span style={{ flex: 1 }} />
-          {running && (
-            <span
-              aria-hidden
-              style={{
-                width: 6,
-                height: 6,
-                borderRadius: '50%',
-                background: accent,
-                animation: 'moxxy-thinking 1.1s ease-in-out infinite',
-              }}
-            />
-          )}
-          <span
-            aria-hidden
-            style={{
-              color: 'var(--color-text-dim)',
-              transform: open ? 'rotate(90deg)' : 'none',
-              transition: 'transform 120ms ease',
-              display: 'inline-flex',
-            }}
-          >
-            <Icon name="chevron-right" size={14} />
-          </span>
-        </button>
-        {open && (
-          <ul role="list" style={{ listStyle: 'none', margin: '6px 0 0', padding: 0 }}>
-            {rows.map((r) => (
-              <ToolRow key={r.id} tool={r} />
-            ))}
-          </ul>
-        )}
-      </div>
+    <div className="activity-block" data-testid="block-tool-group">
+      <ActivityRow
+        icon="wrench"
+        label={`${running ? 'Running' : 'Ran'} ${rows.length} tools${running ? '…' : ''}`}
+        meta={errors > 0 ? `${errors} failed` : undefined}
+        active={running}
+        open={open}
+        onToggle={toggle}
+      />
+      {open ? <ActivityToolList rows={rows} /> : null}
+    </div>
+  );
+}
+
+export function LiveToolGroupView({ block }: { readonly block: LiveToolBlockData }): JSX.Element {
+  const rows: ToolRowData[] = block.calls.map((call) => ({
+    id: call.id,
+    name: call.request.name,
+    input: call.request.input,
+    outcome: call.outcome,
+  }));
+  const running = !block.closed || rows.some((row) => statusOf(row.outcome) === 'running');
+  const [open, toggle] = useActivityDisclosure(running);
+  const errors = errorCount(rows);
+  const latest = block.calls.at(-1);
+  return (
+    <div className="activity-block" data-testid="block-live-tools">
+      <ActivityRow
+        icon={latest ? iconForTool(latest.request.name) : 'wrench'}
+        label={buildCompactSummary(block.calls, running)}
+        meta={errors > 0 ? `${errors} failed` : undefined}
+        active={running}
+        open={open}
+        onToggle={toggle}
+      />
+      {open ? <ActivityToolList rows={rows} /> : latest ? <div className="activity-preview">{compactPreviewLine(latest)}</div> : null}
     </div>
   );
 }

--- a/apps/desktop/src/chat/Transcript.tsx
+++ b/apps/desktop/src/chat/Transcript.tsx
@@ -1,7 +1,12 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import type { MoxxyEvent } from '@moxxy/sdk';
-import { blocksEquivalent, IncrementalFold, type Block as FoldedBlock } from '@moxxy/chat-model';
+import {
+  blocksEquivalent,
+  IncrementalFold,
+  type Block as FoldedBlock,
+  type CompactToolMap,
+} from '@moxxy/chat-model';
 import { buildRenderNodes, groupToolNodes, type Extension, type RenderNode } from '@moxxy/client-core';
 import { BlockView, StreamingAssistant } from './BlockView';
 import { ToolGroupView } from './ToolGroupView';
@@ -26,6 +31,8 @@ interface TranscriptProps {
   /** Fired when the user scrolls to the top edge — load the older page. */
   readonly onReachedTop?: () => void;
   readonly onPreviewImage?: (image: ImagePreviewItem) => void;
+  /** Presentation metadata advertised by the live tool registry. */
+  readonly compactTools?: CompactToolMap;
 }
 
 /** Memoised per-block so a streaming chunk (which only changes
@@ -121,6 +128,7 @@ export function Transcript({
   hasOlder,
   onReachedTop,
   onPreviewImage,
+  compactTools,
 }: TranscriptProps): JSX.Element {
   // Fold only when committed events / extensions change — never on a
   // streaming tick (the events array reference is stable across chunks). The
@@ -131,12 +139,17 @@ export function Transcript({
   // chaining degrades gracefully to the (identical) un-cached slow path when
   // IncrementalFold is unavailable.
   const foldRef = useRef<IncrementalFold | null>(null);
-  if (foldRef.current === null && typeof IncrementalFold === 'function') {
-    foldRef.current = new IncrementalFold();
+  const compactRef = useRef<CompactToolMap | undefined>(undefined);
+  if (
+    typeof IncrementalFold === 'function' &&
+    (foldRef.current === null || compactRef.current !== compactTools)
+  ) {
+    foldRef.current = new IncrementalFold(compactTools);
+    compactRef.current = compactTools;
   }
   const nodes = useMemo(
-    () => groupToolNodes(buildRenderNodes(events, extensions, foldRef.current ?? undefined)),
-    [events, extensions],
+    () => groupToolNodes(buildRenderNodes(events, extensions, foldRef.current ?? undefined, compactTools)),
+    [events, extensions, compactTools],
   );
 
   const virtuosoRef = useRef<VirtuosoHandle>(null);

--- a/apps/desktop/src/chat/blocks/BlockView.tsx
+++ b/apps/desktop/src/chat/blocks/BlockView.tsx
@@ -6,6 +6,7 @@ import { SubagentView } from './SubagentView';
 import { SubagentGroupView } from './SubagentGroupView';
 import { CollaborationCard } from './CollaborationCard';
 import type { ImagePreviewItem } from '../image-preview/types';
+import { LiveToolGroupView } from '../ToolGroupView';
 
 /**
  * One transcript block, rendered from the shared @moxxy/chat-model fold.
@@ -47,7 +48,7 @@ export function BlockView({
     case 'subagent-group':
       return <SubagentGroupView block={block} />;
     case 'live-tools':
-      return <LiveToolsBlock block={block} />;
+      return <LiveToolGroupView block={block} />;
     case 'collab':
       return <CollaborationCard block={block} />;
     default: {
@@ -57,25 +58,4 @@ export function BlockView({
       return null;
     }
   }
-}
-
-/** A live-tools aggregate renders each in-flight call as its own tool
- *  row — the fold keeps them grouped while the turn is still streaming. */
-function LiveToolsBlock({
-  block,
-}: {
-  readonly block: Extract<FoldedBlock, { kind: 'live-tools' }>;
-}): JSX.Element {
-  return (
-    <>
-      {block.calls.map((c) => (
-        <ToolBlock
-          key={c.id}
-          name={c.request.name}
-          input={c.request.input}
-          outcome={c.outcome}
-        />
-      ))}
-    </>
-  );
 }

--- a/apps/desktop/src/chat/blocks/ToolBlock.tsx
+++ b/apps/desktop/src/chat/blocks/ToolBlock.tsx
@@ -1,136 +1,41 @@
 import { useState } from 'react';
-import { isFileDiffResult, oneLine, summarizeArgs, type ToolCallBlockData } from '@moxxy/chat-model';
+import { isFileDiffResult, type ToolCallBlockData } from '@moxxy/chat-model';
 import { isFileDiffDisplay, type FileDiffDisplay } from '@moxxy/sdk/tool-display';
-import { Icon } from '@moxxy/desktop-ui';
+import { ActivityRow } from '../ActivityRow';
+import { iconForTool, statusOf, toolActivityLabel } from '../SkillGroupView';
 import { preStyle, pretty } from './block-shared';
 import { FileDiffBlock } from './FileDiffBlock';
 
-export function ToolBlock({
-  name,
-  input,
-  outcome,
-}: {
+export function ToolBlock({ name, input, outcome }: {
   readonly name: string;
   readonly input: unknown;
   readonly outcome: ToolCallBlockData['outcome'];
 }): JSX.Element {
   const [open, setOpen] = useState(false);
-  // A settled Write/Edit result renders as a diff card instead of raw JSON.
   if (isFileDiffResult(outcome)) {
     const display = (outcome.output as { display: FileDiffDisplay }).display;
     if (isFileDiffDisplay(display)) return <FileDiffBlock display={display} />;
   }
-  const status: 'running' | 'ok' | 'error' =
-    outcome === null
-      ? 'running'
-      : outcome.type === 'denied'
-        ? 'error'
-        : outcome.ok
-          ? 'ok'
-          : 'error';
-  const accent =
-    status === 'error'
-      ? 'var(--color-red)'
-      : status === 'ok'
-        ? 'var(--color-green)'
-        : 'var(--color-primary)';
-  const summary = summarizeArgs(input);
-  const output = outcome && outcome.type === 'tool_result' ? outcome.output : undefined;
-  const error =
-    outcome === null
-      ? undefined
-      : outcome.type === 'denied'
-        ? outcome.reason
-        : outcome.error?.message;
-  // A standalone (non-skill) tool call renders as its OWN top-level block,
-  // mirroring the Skill block's shape: a wrench avatar + a "Tool · <name>"
-  // header + status, expandable to the raw I/O. Same column rhythm as the
-  // Skill group, so an orphaned tool call sits at the same level — never a
-  // stray indented line.
-  const statusText = status === 'ok' ? 'ok' : status === 'error' ? 'failed' : 'running';
-  const tint =
-    status === 'error' ? 'var(--color-red-soft)' : status === 'ok' ? 'var(--color-green-soft)' : 'var(--color-primary-soft)';
+  const status = statusOf(outcome);
+  const output = outcome?.type === 'tool_result' ? outcome.output : undefined;
+  const error = outcome === null ? undefined : outcome.type === 'denied' ? outcome.reason : outcome.error?.message;
   return (
-    <div
-      data-testid="block-tool"
-      data-status={status}
-      style={{ alignSelf: 'stretch', display: 'flex', gap: 12, maxWidth: '92%' }}
-    >
-      <span
-        aria-hidden
-        style={{
-          width: 34,
-          height: 34,
-          flexShrink: 0,
-          borderRadius: 10,
-          background: tint,
-          color: accent,
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Icon name="wrench" size={17} />
-      </span>
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <button
-          type="button"
-          onClick={() => setOpen((v) => !v)}
-          aria-expanded={open}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 8,
-            padding: '2px 0',
-            width: '100%',
-            textAlign: 'left',
-          }}
-        >
-          <span style={{ fontWeight: 600, fontSize: 13.5 }}>
-            Tool
-            <span className="mono" style={{ color: 'var(--color-text-dim)', fontWeight: 500, marginLeft: 6 }}>
-              · {name}
-            </span>
-          </span>
-          <span className="mono" style={{ fontSize: 11, color: accent, fontWeight: 600 }}>
-            {statusText}
-          </span>
-          <span style={{ flex: 1 }} />
-          <span
-            aria-hidden
-            style={{
-              color: 'var(--color-text-dim)',
-              transform: open ? 'rotate(90deg)' : 'none',
-              transition: 'transform 120ms ease',
-              display: 'inline-flex',
-            }}
-          >
-            <Icon name="chevron-right" size={14} />
-          </span>
-        </button>
-        {!open && summary && (
-          <div
-            className="mono"
-            style={{
-              marginTop: 4,
-              fontSize: 11,
-              color: 'var(--color-text-dim)',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}
-          >
-            {oneLine(summary)}
-          </div>
-        )}
-        {open && (
-          <div style={{ marginTop: 6, display: 'flex', flexDirection: 'column', gap: 6 }}>
-            <pre style={preStyle}>{pretty(input)}</pre>
-            {output !== undefined && <pre style={preStyle}>{pretty(output)}</pre>}
-            {error && <pre style={{ ...preStyle, color: 'var(--color-red)' }}>{error}</pre>}
-          </div>
-        )}
-      </div>
+    <div className="activity-block" data-testid="block-tool" data-status={status}>
+      <ActivityRow
+        icon={iconForTool(name)}
+        label={toolActivityLabel({ name, input, outcome })}
+        meta={status === 'error' ? 'failed' : undefined}
+        active={status === 'running'}
+        open={open}
+        onToggle={() => setOpen((value) => !value)}
+      />
+      {open ? (
+        <div className="activity-detail-row__body activity-detail-row__body--root">
+          <pre style={preStyle}>{pretty(input)}</pre>
+          {output !== undefined ? <pre style={preStyle}>{pretty(output)}</pre> : null}
+          {error ? <pre style={{ ...preStyle, color: 'var(--color-red)' }}>{error}</pre> : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -363,6 +363,120 @@ code, kbd, pre, .mono { font-family: var(--font-mono); }
   100% { background-position: -200% 0; }
 }
 
+/* Tool/skill activity is intentionally transcript-like rather than card-like:
+ * one quiet icon + one sentence, with details indented beneath it. */
+.activity-block {
+  align-self: stretch;
+  width: min(92%, 920px);
+  color: var(--color-text-muted);
+}
+
+.activity-row,
+.activity-detail-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+  color: inherit;
+  text-align: left;
+}
+
+.activity-row {
+  gap: 9px;
+  min-height: 28px;
+  padding: 2px 0;
+  font-size: 13.5px;
+}
+
+.activity-row__icon,
+.activity-detail-row__icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-dim);
+}
+
+.activity-row__label,
+.activity-detail-row__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-row__label { font-weight: 520; }
+.activity-row__meta {
+  flex: 0 0 auto;
+  color: var(--color-text-dim);
+  font: 11px var(--font-mono);
+}
+.activity-row__chevron {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--color-text-dim);
+  transition: transform 120ms ease;
+}
+.activity-row:hover,
+.activity-detail-row:hover { color: var(--color-text); }
+
+.activity-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  margin: 4px 0 0 27px;
+  padding: 0;
+  list-style: none;
+}
+.activity-list__item,
+.activity-list__diff { min-width: 0; list-style: none; }
+.activity-detail-row {
+  gap: 8px;
+  min-height: 26px;
+  padding: 2px 0;
+  font-size: 12.5px;
+}
+.activity-detail-row__label { color: var(--color-text-dim); }
+.activity-detail-row:hover .activity-detail-row__label { color: var(--color-text-muted); }
+.activity-detail-row__error {
+  flex: 0 0 auto;
+  color: var(--color-red);
+  font: 11px var(--font-mono);
+}
+.activity-detail-row__body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 5px 0 8px 24px;
+}
+.activity-detail-row__body--root { margin-left: 27px; }
+.activity-preview {
+  overflow: hidden;
+  margin: 1px 0 0 27px;
+  color: var(--color-text-dim);
+  font: 11.5px var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* A moving luminance band reads as active work while keeping the row's muted
+ * palette. `prefers-reduced-motion` below collapses it to a static color. */
+.activity-shimmer {
+  color: transparent;
+  background: linear-gradient(
+    100deg,
+    var(--color-text-dim) 20%,
+    var(--color-text) 42%,
+    var(--color-text) 52%,
+    var(--color-text-dim) 74%
+  );
+  background-size: 240% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: moxxy-shimmer 1.8s linear infinite;
+}
+
 @keyframes moxxy-spin {
   to { transform: rotate(360deg); }
 }
@@ -533,6 +647,11 @@ code, kbd, pre, .mono { font-family: var(--font-mono); }
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+  }
+  .activity-shimmer {
+    color: var(--color-text-muted);
+    background: none;
+    -webkit-text-fill-color: currentColor;
   }
 }
 

--- a/packages/chat-model/src/format.test.ts
+++ b/packages/chat-model/src/format.test.ts
@@ -3,6 +3,7 @@ import {
   buildCompactSummary,
   compactPreviewLine,
   formatElapsed,
+  formatToolActivity,
   formatTokensK,
   summarizeArgs,
 } from './format.js';
@@ -117,13 +118,26 @@ describe('buildCompactSummary', () => {
       makeCall('Read', { verb: 'Reading', one: 'file', other: 'files' }, {}),
     ];
     // first verb keeps its casing; subsequent verbs are lowercased.
-    expect(buildCompactSummary(calls, false)).toBe('Reading 2 files, searching for 1 pattern');
+    expect(buildCompactSummary(calls, false)).toBe('Read 2 files, searched for 1 pattern');
   });
 
   it('appends an ellipsis only while in flight', () => {
     const calls = [makeCall('Read', { verb: 'Reading', one: 'file', other: 'files' }, {})];
     expect(buildCompactSummary(calls, true)).toBe('Reading 1 file…');
-    expect(buildCompactSummary(calls, false)).toBe('Reading 1 file');
+    expect(buildCompactSummary(calls, false)).toBe('Read 1 file');
+  });
+});
+
+describe('formatToolActivity', () => {
+  it('uses natural active and settled labels for common tools', () => {
+    expect(formatToolActivity('Read', { file_path: 'src/app.ts' }, true)).toBe('Reading src/app.ts');
+    expect(formatToolActivity('Read', { file_path: 'src/app.ts' }, false)).toBe('Read src/app.ts');
+    expect(formatToolActivity('Grep', { pattern: 'needle', cwd: 'src' }, false)).toBe('Searched for needle in src');
+    expect(formatToolActivity('Bash', { command: 'pnpm test' }, true)).toBe('Running pnpm test');
+  });
+
+  it('falls back to the tool name and compact argument summary', () => {
+    expect(formatToolActivity('custom_tool', { id: 42 }, false)).toBe('Ran custom_tool · id=42');
   });
 });
 

--- a/packages/chat-model/src/format.ts
+++ b/packages/chat-model/src/format.ts
@@ -73,6 +73,30 @@ function formatValue(v: unknown): string {
   }
 }
 
+function stringField(input: unknown, key: string): string | null {
+  if (!input || typeof input !== 'object') return null;
+  const value = (input as Record<string, unknown>)[key];
+  return typeof value === 'string' && value.trim() ? oneLine(value) : null;
+}
+
+/** Natural-language activity line shared by terminal and graphical channels. */
+export function formatToolActivity(name: string, input: unknown, running: boolean): string {
+  const normalized = name.toLowerCase();
+  if (normalized === 'read') return `${running ? 'Reading' : 'Read'} ${stringField(input, 'file_path') ?? 'file'}`;
+  if (normalized === 'grep') {
+    const pattern = stringField(input, 'pattern') ?? 'pattern';
+    const cwd = stringField(input, 'cwd');
+    return `${running ? 'Searching for' : 'Searched for'} ${pattern}${cwd ? ` in ${cwd}` : ''}`;
+  }
+  if (normalized === 'glob') return `${running ? 'Listing' : 'Listed'} ${stringField(input, 'pattern') ?? 'files'}`;
+  if (normalized === 'bash') return `${running ? 'Running' : 'Ran'} ${stringField(input, 'command') ?? 'command'}`;
+  if (normalized.includes('search')) {
+    return `${running ? 'Searching for' : 'Searched for'} ${stringField(input, 'query') ?? summarizeArgs(input)}`;
+  }
+  const summary = summarizeArgs(input);
+  return `${running ? 'Running' : 'Ran'} ${name}${summary ? ` · ${summary}` : ''}`;
+}
+
 /**
  * Color the `◆` indicator by where the call came from so a glance
  * across the scrollback shows which subsystem is active — MCP tools
@@ -101,7 +125,7 @@ import type { LiveToolCall } from './types.js';
  *
  * Tools with the same name share one phrase; counts plural-aware. The
  * trailing ellipsis is appended only while the block is still open (in
- * flight) — closed blocks read past-tense-ish without it.
+ * flight); known built-in verbs switch to past tense once it settles.
  */
 export function buildCompactSummary(
   calls: ReadonlyArray<LiveToolCall>,
@@ -127,13 +151,29 @@ export function buildCompactSummary(
   const phrases: string[] = [];
   let first = true;
   for (const g of groups.values()) {
-    const verb = first ? g.verb : g.verb.toLowerCase();
+    const stateVerb = inFlight ? g.verb : completedCompactVerb(g.verb);
+    const verb = first ? stateVerb : stateVerb.toLowerCase();
     const noun = g.count === 1 ? g.one : g.other;
     phrases.push(`${verb} ${g.count} ${noun}`);
     first = false;
   }
   const joined = phrases.join(', ');
   return inFlight ? `${joined}…` : joined;
+}
+
+/** Built-in compact verbs are gerunds; settled history reads more naturally in
+ * the past tense. Unknown/plugin-provided phrases are kept verbatim. */
+function completedCompactVerb(verb: string): string {
+  const known: Readonly<Record<string, string>> = {
+    Reading: 'Read',
+    'Searching for': 'Searched for',
+    'Searching the web for': 'Searched the web for',
+    Listing: 'Listed',
+    Waiting: 'Waited',
+    Writing: 'Wrote',
+    Editing: 'Edited',
+  };
+  return known[verb] ?? verb;
 }
 
 /**

--- a/packages/client-core/src/chatModel.test.ts
+++ b/packages/client-core/src/chatModel.test.ts
@@ -18,7 +18,7 @@ import {
   type FoldedBlock,
   type RenderNode,
 } from './chatModel.js';
-import type { ToolCallBlockData } from '@moxxy/chat-model';
+import { IncrementalFold, type CompactToolMap, type ToolCallBlockData } from '@moxxy/chat-model';
 
 let n = 0;
 function evt(type: MoxxyEvent['type'], extra: Record<string, unknown>): MoxxyEvent {
@@ -350,6 +350,45 @@ describe('groupToolNodes', () => {
     const out = groupToolNodes([toolNode('bash'), toolNode('grep'), extNode(), toolNode('ls'), toolNode('cat')]);
     // group(2) + ext + group(2)
     expect(out.map((n) => n.kind)).toEqual(['tool-group', 'ext', 'tool-group']);
+  });
+});
+
+describe('buildRenderNodes compact metadata', () => {
+  const compact: CompactToolMap = new Map([
+    ['Read', { verb: 'Reading', noun: { one: 'file', other: 'files' }, previewKey: 'file_path' }],
+  ]);
+
+  it('folds compact tools into one live activity block on the incremental fast path', () => {
+    const events = [
+      toolReq('read-1', 'Read', { file_path: 'a.ts' }),
+      toolReq('read-2', 'Read', { file_path: 'b.ts' }),
+    ];
+    const nodes = buildRenderNodes(events, [], new IncrementalFold(compact), compact);
+    expect(nodes).toHaveLength(1);
+    const node = nodes[0];
+    assertDefined(node, 'compact fold yields one node');
+    expect(node.kind).toBe('block');
+    if (node.kind !== 'block') throw new Error('unreachable');
+    expect(node.block.kind).toBe('live-tools');
+    if (node.block.kind !== 'live-tools') throw new Error('unreachable');
+    expect(node.block.calls).toHaveLength(2);
+  });
+
+  it('preserves compact folding when an extension forces the sliced path', () => {
+    const events = [toolReq('read-3', 'Read', { file_path: 'c.ts' })];
+    const extension: Extension = {
+      kind: 'notice',
+      id: 'notice-before',
+      afterCount: 0,
+      tone: 'info',
+      text: 'note',
+    };
+    const nodes = buildRenderNodes(events, [extension], undefined, compact);
+    expect(nodes.map((node) => node.kind)).toEqual(['ext', 'block']);
+    const blockNode = nodes[1];
+    assertDefined(blockNode, 'compact block follows extension');
+    if (blockNode.kind !== 'block') throw new Error('unreachable');
+    expect(blockNode.block.kind).toBe('live-tools');
   });
 });
 

--- a/packages/client-core/src/chatModel.ts
+++ b/packages/client-core/src/chatModel.ts
@@ -22,6 +22,7 @@ import {
   newBlockId,
   pairToolEvents,
   type Block as FoldedBlock,
+  type CompactToolMap,
   type IncrementalFold,
   type ToolCallBlockData,
 } from '@moxxy/chat-model';
@@ -370,6 +371,10 @@ export function buildRenderNodes(
    * slash-command results) are rare, so the fast path covers the common case.
    */
   fold?: IncrementalFold,
+  /** Compact tool metadata from the live session. Desktop/remote clients get
+   *  this through `session.info`; passing it here keeps their fold identical
+   *  to the TUI's registry-backed fold, including grouped Read/Grep/Glob runs. */
+  compactByName?: CompactToolMap,
 ): RenderNode[] {
   // Fast path: no extension cards → one contiguous fold over all events. Reuse
   // the caller's IncrementalFold so a freshly-committed event re-folds only the
@@ -384,7 +389,7 @@ export function buildRenderNodes(
   let cursor = 0;
   const foldSlice = (slice: ReadonlyArray<MoxxyEvent>): void => {
     if (slice.length === 0) return;
-    for (const block of pairToolEvents(slice)) out.push({ kind: 'block', block });
+    for (const block of pairToolEvents(slice, compactByName)) out.push({ kind: 'block', block });
   };
   for (const ext of sorted) {
     const at = Math.min(Math.max(ext.afterCount, 0), events.length);

--- a/packages/plugin-cli/src/components/chat/BlockLine.tsx
+++ b/packages/plugin-cli/src/components/chat/BlockLine.tsx
@@ -1,16 +1,15 @@
 import React, { memo } from 'react';
 import { Box, Text } from 'ink';
-import { Glyphs } from '../../theme.js';
 import { EventLine } from './EventLine.js';
 import { LiveToolBlock } from './LiveToolBlock.js';
 import { ToolCallBlock } from './ToolCallBlock.js';
 import { SubagentScopeView } from './SubagentScopeView.js';
 import { SubagentGroupView } from './SubagentGroupView.js';
 import { CollabScopeView } from './CollabScopeView.js';
+import { ShimmerText } from './ShimmerText.js';
 import {
   blocksEquivalent,
   countToolCalls,
-  DotColors,
   truncate,
   type Block,
   type SkillScopeBlock,
@@ -58,11 +57,8 @@ export const BlockLine: React.FC<BlockLineProps> = memo(
 );
 
 /**
- * Skill scopes always render expanded — child blocks (including any
- * live-tools aggregate inside) handle compaction themselves via the
- * global Ctrl+O toggle. The pre-existing "collapsed scope" treatment
- * was retired when live-tools blocks arrived; both achieved similar
- * visual compaction and having two toggles confused users.
+ * Active skills stay expanded so their work is visible. Once settled they
+ * collapse to one transcript-style row and follow the global Ctrl+O toggle.
  */
 const SkillScopeView: React.FC<{
   scope: SkillScopeBlock;
@@ -71,18 +67,30 @@ const SkillScopeView: React.FC<{
   const childToolCount = countToolCalls(scope.children);
   const nameLabel = truncate(scope.skillEvent.name, NAME_DISPLAY_MAX);
   const callLabel = `${childToolCount} tool call${childToolCount === 1 ? '' : 's'}`;
+  const active = !scope.closed || scope.children.some(hasRunningTool);
+  const showChildren = active || expandToolOutputs;
+  const label = `${active ? 'Using' : 'Used'} skill ${nameLabel}${active ? '…' : ''}`;
   return (
     <Box flexDirection="column" marginTop={1}>
       <Box>
-        <Text color={DotColors.skill}>{Glyphs.filled} </Text>
-        <Text bold>Skill</Text>
-        <Text dimColor>{` (${nameLabel} · ${callLabel})`}</Text>
+        <Text dimColor>✦ </Text>
+        <ShimmerText text={label} active={active} />
+        <Text dimColor>{` · ${callLabel}${showChildren ? '' : '  ›'}`}</Text>
       </Box>
-      <Box flexDirection="column" marginLeft={2}>
-        {scope.children.map((c) => (
-          <BlockLine key={c.id} block={c} expandToolOutputs={expandToolOutputs} />
-        ))}
-      </Box>
+      {showChildren ? (
+        <Box flexDirection="column" marginLeft={2}>
+          {scope.children.map((c) => (
+            <BlockLine key={c.id} block={c} expandToolOutputs={expandToolOutputs} />
+          ))}
+        </Box>
+      ) : null}
     </Box>
   );
 };
+
+function hasRunningTool(block: Block): boolean {
+  if (block.kind === 'tool-call') return block.outcome === null;
+  if (block.kind === 'live-tools') return block.calls.some((call) => call.outcome === null);
+  if (block.kind === 'skill-scope') return block.children.some(hasRunningTool);
+  return false;
+}

--- a/packages/plugin-cli/src/components/chat/LiveToolBlock.tsx
+++ b/packages/plugin-cli/src/components/chat/LiveToolBlock.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 import { Colors, Glyphs } from '../../theme.js';
-import { ToolCallBlock } from './ToolCallBlock.js';
+import { ToolCallBlock, toolGlyph } from './ToolCallBlock.js';
+import { ShimmerText } from './ShimmerText.js';
 import {
   buildCompactSummary,
   compactPreviewLine,
@@ -32,7 +33,8 @@ export const LiveToolBlock: React.FC<{
   /** Global Ctrl+O toggle. */
   expanded: boolean;
 }> = ({ block, expanded }) => {
-  const inFlight = !block.closed;
+  const inFlight = !block.closed || block.calls.some((call) => call.outcome === null);
+  const showDetails = expanded || inFlight;
   const summary = buildCompactSummary(block.calls, inFlight);
   const latest = block.calls[block.calls.length - 1];
   // Errors among the latest few calls get surfaced even when collapsed —
@@ -47,24 +49,24 @@ export const LiveToolBlock: React.FC<{
   return (
     <Box flexDirection="column" marginTop={1}>
       <Box>
-        <Text dimColor>{Glyphs.filled} </Text>
-        <Text>{summary}</Text>
-        {!expanded ? <Text dimColor>{' (ctrl+o to expand)'}</Text> : null}
+        <Text dimColor>{latest ? toolGlyph(latest.request.name) : Glyphs.pending} </Text>
+        <ShimmerText text={summary} active={inFlight} />
+        {!showDetails ? <Text dimColor>{'  ›'}</Text> : null}
       </Box>
-      {errorCount > 0 && !expanded ? (
+      {errorCount > 0 && !showDetails ? (
         <Box marginLeft={2}>
           <Text color={Colors.danger}>
             {errorCount} {errorCount === 1 ? 'call' : 'calls'} failed — press ctrl+o for detail
           </Text>
         </Box>
       ) : null}
-      {!expanded && latest ? (
+      {!showDetails && latest ? (
         <Box marginLeft={2}>
           <Text dimColor>└ </Text>
           <Text dimColor>{compactPreviewLine(latest)}</Text>
         </Box>
       ) : null}
-      {expanded ? (
+      {showDetails ? (
         <Box flexDirection="column" marginLeft={2}>
           {block.calls.map((c) => (
             <ToolCallBlock key={c.id} request={c.request} outcome={c.outcome} />

--- a/packages/plugin-cli/src/components/chat/ShimmerText.test.ts
+++ b/packages/plugin-cli/src/components/chat/ShimmerText.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { shimmerSlices } from './ShimmerText.js';
+
+describe('shimmerSlices', () => {
+  it('preserves the full text while the glow crosses it', () => {
+    for (let frame = 0; frame < 20; frame += 1) {
+      const slices = shimmerSlices('Reading files…', frame, 4);
+      expect(slices.before + slices.glow + slices.after).toBe('Reading files…');
+      expect(slices.glow.length).toBeLessThanOrEqual(4);
+    }
+  });
+
+  it('handles empty and short labels', () => {
+    expect(shimmerSlices('', 0)).toEqual({ before: '', glow: '', after: '' });
+    const short = shimmerSlices('ok', 5, 20);
+    expect(short.before + short.glow + short.after).toBe('ok');
+  });
+});

--- a/packages/plugin-cli/src/components/chat/ShimmerText.tsx
+++ b/packages/plugin-cli/src/components/chat/ShimmerText.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { Text } from 'ink';
+import { MOTION_ENABLED } from '../motion.js';
+
+export interface ShimmerSlices {
+  readonly before: string;
+  readonly glow: string;
+  readonly after: string;
+}
+
+/** Pure frame helper kept separate so the terminal animation is testable. */
+export function shimmerSlices(text: string, frame: number, width = 6): ShimmerSlices {
+  if (!text) return { before: '', glow: '', after: '' };
+  const safeWidth = Math.max(1, Math.min(width, text.length));
+  const start = (frame % (text.length + safeWidth)) - safeWidth;
+  const from = Math.max(0, start);
+  const to = Math.min(text.length, start + safeWidth);
+  return {
+    before: text.slice(0, from),
+    glow: to > from ? text.slice(from, to) : '',
+    after: text.slice(Math.max(from, to)),
+  };
+}
+
+/** ANSI approximation of the desktop luminance sweep: dim text with a small,
+ * moving bold window. Motion is skipped for pipes, NO_COLOR and reduced-motion. */
+export const ShimmerText: React.FC<{ readonly text: string; readonly active: boolean }> = ({ text, active }) => {
+  const [frame, setFrame] = useState(0);
+  useEffect(() => {
+    if (!active || !MOTION_ENABLED) return;
+    const timer = setInterval(() => setFrame((value) => value + 1), 90);
+    return () => clearInterval(timer);
+  }, [active]);
+
+  if (!active || !MOTION_ENABLED) return <Text dimColor>{text}</Text>;
+  const slices = shimmerSlices(text, frame);
+  return (
+    <Text>
+      <Text dimColor>{slices.before}</Text>
+      <Text bold>{slices.glow}</Text>
+      <Text dimColor>{slices.after}</Text>
+    </Text>
+  );
+};

--- a/packages/plugin-cli/src/components/chat/ToolCallBlock.tsx
+++ b/packages/plugin-cli/src/components/chat/ToolCallBlock.tsx
@@ -1,35 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Box, Text } from 'ink';
 import { isFileDiffDisplay, type FileDiffDisplay, type ToolCallRequestedEvent, type ToolResultEvent } from '@moxxy/sdk';
-import { Colors, Glyphs } from '../../theme.js';
-import { dotColorForTool, isFileDiffResult, oneLine, stringify, summarizeArgs, truncate } from '@moxxy/chat-model';
+import { Colors } from '../../theme.js';
+import { formatToolActivity, isFileDiffResult, oneLine, stringify, truncate } from '@moxxy/chat-model';
 import { FileDiffView } from './FileDiffView.js';
-import { MOTION_ENABLED } from '../motion.js';
-
-
-/**
- * Pulsing `●` for in-flight tool calls. Toggles between full color and
- * dim every ~500ms so the user can tell at a glance that work is still
- * happening — a static yellow dot was reading as "stuck" when a long
- * shell command was running. The trailing space lives outside the
- * dimmed Text so the dim ANSI attribute can't bleed onto the tool name
- * that follows (some terminals interpret the boundary loosely and the
- * whole row appeared to pulse).
- */
-const PendingBullet: React.FC = () => {
-  const [on, setOn] = useState(true);
-  useEffect(() => {
-    if (!MOTION_ENABLED) return; // static (non-blinking) dot for reduced-motion / non-TTY
-    const t = setInterval(() => setOn((v) => !v), 500);
-    return () => clearInterval(t);
-  }, []);
-  return (
-    <>
-      <Text color={Colors.busy} dimColor={!on}>{Glyphs.filled}</Text>
-      <Text> </Text>
-    </>
-  );
-};
+import { ShimmerText } from './ShimmerText.js';
 
 /** Cap displayed identifier length so an oversized MCP/skill name
  *  doesn't blow the header off the right edge of the terminal. */
@@ -38,7 +13,7 @@ const NAME_DISPLAY_MAX = 48;
 export const ToolCallBlock: React.FC<{
   request: ToolCallRequestedEvent;
   outcome: ToolResultEvent | { type: 'denied'; reason: string } | null;
-  /** Global Ctrl+O toggle — expands file-diff previews to their full set. */
+  /** Global Ctrl+O toggle — expands result previews and full file diffs. */
   expanded?: boolean;
 }> = ({ request, outcome, expanded = false }) => {
   // A settled Write/Edit result renders as a full diff card (its own header,
@@ -57,26 +32,17 @@ export const ToolCallBlock: React.FC<{
         : outcome.ok
           ? 'ok'
           : 'err';
-  const argSummary = summarizeArgs(request.input);
-  const nameLabel = truncate(request.name, NAME_DISPLAY_MAX);
-  const detail = argSummary ? `${nameLabel}, ${argSummary}` : nameLabel;
+  const detail = truncate(formatToolActivity(request.name, request.input, status === 'pending'), NAME_DISPLAY_MAX + 70);
   return (
     <Box flexDirection="column" marginTop={1}>
       <Box>
-        {status === 'pending' ? (
-          <PendingBullet />
-        ) : status === 'err' ? (
-          // Distinct glyph (✗), not color alone, so a failed call is
-          // distinguishable from a successful one in a no-color / colorblind
-          // terminal — the dots were otherwise an identical filled '●'.
-          <Text color={Colors.danger}>✗ </Text>
-        ) : (
-          <Text color={dotColorForTool(request.name)}>{Glyphs.filled} </Text>
-        )}
-        <Text bold>Tool</Text>
-        <Text dimColor>{` (${detail})`}</Text>
+        <Text color={status === 'err' ? Colors.danger : undefined} dimColor={status !== 'err'}>
+          {status === 'err' ? '✗' : toolGlyph(request.name)}{' '}
+        </Text>
+        <ShimmerText text={detail} active={status === 'pending'} />
+        {status === 'err' ? <Text color={Colors.danger}> failed</Text> : null}
       </Box>
-      {outcome ? (
+      {outcome && (expanded || status === 'err') ? (
         <Box>
           <Text dimColor>  └ </Text>
           <OutcomeText outcome={outcome} />
@@ -85,6 +51,14 @@ export const ToolCallBlock: React.FC<{
     </Box>
   );
 };
+
+export function toolGlyph(name: string): string {
+  const normalized = name.toLowerCase();
+  if (normalized === 'read' || normalized === 'glob') return '▱';
+  if (normalized === 'grep' || normalized.includes('search')) return '⌕';
+  if (normalized === 'bash' || normalized.includes('command')) return '›';
+  return '◇';
+}
 
 const OutcomeText: React.FC<{
   outcome: ToolResultEvent | { type: 'denied'; reason: string };


### PR DESCRIPTION
## What
- redesign desktop and Ink TUI tool/skill activity as compact, expandable traces
- add active shimmer feedback with reduced-motion and terminal capability fallbacks
- feed live compact tool metadata into the desktop shared chat fold
- add regression coverage, a release changeset, and retire the related chat UX debt item

## Why
Tool and skill work should remain readable during long turns without filling the transcript with generic cards, while active operations still need clear visual feedback.

## Verification
- pnpm build: 85/85 tasks
- pnpm typecheck: 141/141 tasks
- pnpm lint: 0 errors (43 existing warnings)
- pnpm test: 139/139 tasks plus 8 script tests
- pnpm check:deps: 0 errors (1 existing no-orphans warning)
- node packages/cli/dist/bin.js --help
- node packages/cli/dist/bin.js plugins list