### PR TITLE
fix(scheduler): accept blank optional placeholders

### DIFF
--- a/.changeset/calm-clocks-accept.md
+++ b/.changeset/calm-clocks-accept.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/cli': patch
+---
+
+Allow scheduler tool calls to omit optional values with blank provider placeholders.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -24,6 +24,12 @@ or recorded-on-purpose decision.
 
 ## Resolved ledger
 
+- [med, scheduler, RESOLVED 2026-07-23] `schedule_create` rejected otherwise valid
+  recurring and one-shot tool calls when a provider serialized omitted optional
+  fields as blank strings. Its local trust-boundary schema now normalizes only
+  blank optional placeholders before enforcing the exactly-one-trigger invariant,
+  with captured-payload regressions through the real schedule store.
+  `packages/plugin-scheduler/src/tools.ts`.
 - [med, chat-ux, RESOLVED 2026-07-23] Desktop ignored the live registry's
   `ToolInfo.compact` metadata even though TUI already consumed it, so the same
   Read/Grep/Glob run became a compact activity trace in one surface and a stack

--- a/packages/plugin-scheduler/src/tools.test.ts
+++ b/packages/plugin-scheduler/src/tools.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { ToolContext, ToolDef } from '@moxxy/sdk';
-import { assertDefined } from '@moxxy/sdk';
+import { assertDefined, zodToJsonSchema } from '@moxxy/sdk';
 import { ScheduleStore } from './store.js';
 import { buildSchedulerTools } from './tools.js';
 
@@ -14,12 +14,19 @@ describe('schedule_create tool — input validation hardening', () => {
   let store: ScheduleStore;
   let create: ToolDef;
 
+  const executeCreate = async (input: unknown): Promise<Record<string, unknown>> => {
+    const parsed = create.inputSchema.safeParse(input);
+    if (!parsed.success) throw parsed.error;
+    return (await create.handler(parsed.data, ctx)) as Record<string, unknown>;
+  };
+
   beforeEach(async () => {
     dir = await mkdtemp(path.join(tmpdir(), 'moxxy-sched-tools-'));
     store = new ScheduleStore({ file: path.join(dir, 'schedules.json') });
     const tools = buildSchedulerTools({
       store,
       runner: { runPrompt: async () => ({ text: 'ok' }) },
+      ownerSessionId: 'creator-session',
     });
     const found = tools.find((t) => t.name === 'schedule_create');
     assertDefined(found, 'schedule_create tool is registered');
@@ -42,6 +49,96 @@ describe('schedule_create tool — input validation hardening', () => {
   it('schema rejects supplying neither cron nor runAt', () => {
     const r = create.inputSchema.safeParse({ name: 'neither', prompt: 'x' });
     expect(r.success).toBe(false);
+  });
+
+  it('creates a recurring schedule from the blank placeholders emitted by openai-codex', async () => {
+    const out = await executeCreate({
+      name: 'daily-summary',
+      prompt: 'Prepare the daily summary',
+      channel: 'inbox',
+      model: 'gpt-5.5',
+      targetSessionId: '',
+      cron: '0 10 * * *',
+      runAt: '',
+      timeZone: 'Europe/Warsaw',
+    });
+
+    expect(out).toMatchObject({
+      cron: '0 10 * * *',
+      runAt: null,
+      targetSessionId: 'creator-session',
+    });
+    const entries = await store.list();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      cron: '0 10 * * *',
+      ownerSessionId: 'creator-session',
+      channel: 'inbox',
+      model: 'gpt-5.5',
+      timeZone: 'Europe/Warsaw',
+    });
+    expect(entries[0]?.runAt).toBeUndefined();
+  });
+
+  it('creates a one-shot schedule while dropping whitespace-only optional placeholders', async () => {
+    const runAt = '2030-08-01T10:00:00.000Z';
+    const out = await executeCreate({
+      name: 'one-shot',
+      prompt: 'Run once',
+      channel: '   ',
+      model: '',
+      targetSessionId: '  ',
+      cron: '\t',
+      runAt,
+      timeZone: ' ',
+    });
+
+    expect(out).toMatchObject({
+      cron: null,
+      runAt: Date.parse(runAt),
+      targetSessionId: 'creator-session',
+      channel: null,
+      model: null,
+      timeZone: null,
+    });
+    const entries = await store.list();
+    expect(entries[0]?.cron).toBeUndefined();
+    expect(entries[0]?.runAt).toBe(Date.parse(runAt));
+    expect(entries[0]?.ownerSessionId).toBe('creator-session');
+  });
+
+  it('rejects blank-only triggers after normalization', () => {
+    const r = create.inputSchema.safeParse({
+      name: 'blank-triggers',
+      prompt: 'x',
+      cron: ' ',
+      runAt: '\t',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('does not treat epoch zero as an empty runAt placeholder', () => {
+    const r = create.inputSchema.safeParse({
+      name: 'real-zero',
+      prompt: 'x',
+      cron: '0 9 * * *',
+      runAt: 0,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a non-empty invalid timestamp', () => {
+    const r = create.inputSchema.safeParse({
+      name: 'invalid-time',
+      prompt: 'x',
+      runAt: 'not-a-timestamp',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('keeps only name and prompt required in the provider JSON schema', () => {
+    const schema = zodToJsonSchema(create.inputSchema) as { required?: ReadonlyArray<string> };
+    expect(schema.required).toEqual(['name', 'prompt']);
   });
 
   it('handler rejects a non-IANA timeZone (would otherwise crash a tick)', async () => {

--- a/packages/plugin-scheduler/src/tools.ts
+++ b/packages/plugin-scheduler/src/tools.ts
@@ -13,25 +13,44 @@ import type { ScheduleEntry, ScheduleStore } from './store.js';
  */
 const SCHEDULES_STORE_GLOB = '~/.moxxy/schedules.json*';
 
-const cronOrTimestamp = z
+const blankStringToUndefined = (value: unknown): unknown =>
+  typeof value === 'string' && value.trim() === '' ? undefined : value;
+
+const optionalText = z.preprocess(blankStringToUndefined, z.string().min(1).optional());
+const optionalRunAt = z.preprocess(
+  blankStringToUndefined,
+  z
+    .union([
+      z.number().int(),
+      z.string().refine((value) => !Number.isNaN(Date.parse(value)), {
+        message: 'runAt must be an ISO timestamp or epoch-ms',
+      }),
+    ])
+    .optional(),
+);
+
+const scheduleCreateInputSchema = z
   .object({
-    cron: z.string().optional(),
-    runAt: z
-      .union([
-        z.number().int(),
-        z.string().refine((s) => !Number.isNaN(Date.parse(s)), {
-          message: 'runAt must be an ISO timestamp or epoch-ms',
-        }),
-      ])
-      .optional(),
-    timeZone: z.string().optional(),
+    name: z
+      .string()
+      .min(1)
+      .max(120)
+      .regex(/^[a-z0-9][a-z0-9-]*$/i, 'name must be slug-like (letters, digits, hyphens)'),
+    prompt: z.string().min(1),
+    channel: optionalText,
+    model: optionalText,
+    targetSessionId: optionalText.describe(
+      'Session id to fire this schedule in (where its run executes + displays). ' +
+        'Defaults to the session that created the schedule.',
+    ),
+    cron: optionalText,
+    runAt: optionalRunAt,
+    timeZone: optionalText,
   })
-  .refine((v) => !!v.cron || v.runAt !== undefined, {
+  .refine((value) => value.cron !== undefined || value.runAt !== undefined, {
     message: 'provide either `cron` or `runAt`',
   })
-  // Documented contract: exactly one of cron/runAt. Supplying both is
-  // rejected (otherwise the runAt is silently ignored in favor of the cron).
-  .refine((v) => !(v.cron && v.runAt !== undefined), {
+  .refine((value) => !(value.cron !== undefined && value.runAt !== undefined), {
     message: 'provide either `cron` or `runAt`, not both',
   });
 
@@ -97,32 +116,15 @@ export function buildSchedulerTools(deps: SchedulerToolDeps): ReadonlyArray<Tool
     defineTool({
       name: 'schedule_create',
       description:
-        'Create a scheduled prompt that fires on a cron (recurring) or a single timestamp ' +
-        '(one-shot). The prompt runs in an isolated session at fire time; the final ' +
+        'Create a scheduled prompt with exactly one trigger. For a recurring schedule, ' +
+        'set `cron` and omit `runAt` entirely. For a one-shot schedule, set `runAt` and ' +
+        'omit `cron` entirely. Never send an empty placeholder for the unused trigger. ' +
+        'The prompt runs in an isolated session at fire time; the final ' +
         "assistant message is appended to the user's inbox. Cron uses 5-field POSIX " +
         "syntax in the user's local timezone (override via `timeZone`). For Telegram or " +
         'other delivery, write the prompt to call the right send tool itself (e.g. ' +
         '"...then call telegram_send_message with the summary").',
-      inputSchema: z
-        .object({
-          name: z
-            .string()
-            .min(1)
-            .max(120)
-            .regex(/^[a-z0-9][a-z0-9-]*$/i, 'name must be slug-like (letters, digits, hyphens)'),
-          prompt: z.string().min(1),
-          channel: z.string().optional(),
-          model: z.string().optional(),
-          targetSessionId: z
-            .string()
-            .min(1)
-            .optional()
-            .describe(
-              'Session id to fire this schedule in (where its run executes + displays). ' +
-                'Defaults to the session that created the schedule.',
-            ),
-        })
-        .and(cronOrTimestamp),
+      inputSchema: scheduleCreateInputSchema,
       permission: { action: 'prompt' },
       isolation: {
         capabilities: {


### PR DESCRIPTION
## What

- normalize blank optional `schedule_create` placeholders locally before validation
- treat empty and whitespace-only `cron`, textual `runAt`, `targetSessionId`, `timeZone`, `channel`, and `model` values as omitted
- enforce exactly one real trigger after normalization while preserving `runAt: 0`
- clarify the tool description so providers omit the unused trigger
- cover the captured OpenAI Codex payload through the real `ScheduleStore`
- add a CLI patch changeset and close the regression in the resolved tech-debt ledger

## Why

OpenAI Codex can serialize omitted optional tool arguments as empty strings. The previous Zod schema treated those placeholders as supplied values, so a valid recurring schedule with `cron` was rejected as though it also contained `runAt`, and an empty `targetSessionId` failed identifier validation.

The normalization is intentionally scoped to `schedule_create`; empty strings may remain meaningful inputs for other tools.

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — all 140 tasks green; scheduler 85 tests, desktop 443 tests, CLI 326 tests
- `pnpm check:deps` — 0 errors, one existing `no-orphans` warning
- `node packages/cli/dist/bin.js --help`
- `node packages/cli/dist/bin.js plugins list`
- recurring and one-shot smoke creation followed by `schedule_list`
- manual desktop verification with the real provider payload that previously failed
