### PR TITLE
fix(tui): clarify Claude tool and skill activity

### DIFF
--- a/.changeset/steady-tui-activity.md
+++ b/.changeset/steady-tui-activity.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/sdk': patch
+'@moxxy/cli': patch
+---
+
+Keep text-only Claude turns honest and render clear, settled tool and skill activity in the TUI.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -24,6 +24,21 @@ or recorded-on-purpose decision.
 
 ## Resolved ledger
 
+- [med, tui/providers, RESOLVED 2026-07-23] Text-only models were still given
+  the lazy skill index, so Claude Code imitated `load_skill(...)` as assistant
+  text and ended the turn before doing the work. ReAct prompt composition now
+  advertises skills only to tool-capable models, letting Claude CLI keep its
+  native operation inside one busy turn. Tool/skill activity now tracks the
+  actual load/result state (rather than an open grouping scope), mutable fold
+  rows carry an explicit render revision, completed work loses its shimmer,
+  zero-count metadata is omitted, and nested Ink rows use compact branch guides.
+  `packages/sdk/src/mode/react-loop.ts`, `packages/chat-model/src/`,
+  `packages/plugin-cli/src/components/chat/`, `apps/desktop/src/chat/`.
+- [low, tui, RESOLVED 2026-07-23] Origin-bearing prompts now render in the TUI
+  as compact webhook/schedule/workflow/checkpoint activity markers, with the
+  full synthesized payload available through the existing Ctrl+O expansion,
+  instead of looking like a human-authored user prompt.
+  `packages/plugin-cli/src/components/chat/EventLine.tsx`.
 - [med, chat-ux, RESOLVED 2026-07-23] Desktop ignored the live registry's
   `ToolInfo.compact` metadata even though TUI already consumed it, so the same
   Read/Grep/Glob run became a compact activity trace in one surface and a stack
@@ -429,12 +444,6 @@ or recorded-on-purpose decision.
 
 ## Channels, relay & HTTP
 
-- [low] Origin-bearing `user_prompt` events (webhook/schedule/workflow triggers
-  and now the ReAct loop's checkpoint-gate injections, `origin.kind:
-  'checkpoint'`) render as a compact chip on desktop (`apps/desktop/…/
-  TriggerBlock.tsx`) but the TUI has no origin-aware rendering — trigger
-  payloads and mid-turn checkpoint feedback show as full user-style bubbles.
-  `packages/plugin-channel-tui`.
 - [low] Discord channel pairing is terminal-only: the DM code flow (bot DMs a
   one-time code → operator pastes it into `moxxy discord pair`) has no GUI
   completion path, so the desktop Channels panel can start the bot dedicated

--- a/apps/desktop/src/chat/SkillGroupView.tsx
+++ b/apps/desktop/src/chat/SkillGroupView.tsx
@@ -71,7 +71,10 @@ export function useActivityDisclosure(running: boolean): readonly [boolean, () =
   const touched = useRef(false);
   const wasRunning = useRef(running);
   useEffect(() => {
-    if (wasRunning.current && !running && !touched.current) setOpen(false);
+    if (!touched.current) {
+      if (wasRunning.current && !running) setOpen(false);
+      if (!wasRunning.current && running) setOpen(true);
+    }
     wasRunning.current = running;
   }, [running]);
   return [
@@ -85,16 +88,24 @@ export function useActivityDisclosure(running: boolean): readonly [boolean, () =
 
 export function SkillGroupView({ scope }: { readonly scope: SkillScope }): JSX.Element {
   const tools = collectTools(scope.children);
-  const running = !scope.closed || tools.some((tool) => statusOf(tool.outcome) === 'running');
+  const runningTools = tools.some((tool) => statusOf(tool.outcome) === 'running');
+  const running = scope.loading || runningTools;
   const [open, toggle] = useActivityDisclosure(running);
   const errors = tools.filter((tool) => statusOf(tool.outcome) === 'error').length;
   const meta = errors > 0 ? `${errors} failed` : tools.length > 0 ? `${tools.length}` : undefined;
+  const label = scope.loading
+    ? `Loading skill ${scope.skillEvent.name}…`
+    : scope.closed
+      ? `Used skill ${scope.skillEvent.name}`
+      : tools.length > 0
+        ? `Using skill ${scope.skillEvent.name}`
+        : `Loaded skill ${scope.skillEvent.name}`;
 
   return (
     <div className="activity-block" data-testid="block-skill">
       <ActivityRow
         icon="spark"
-        label={`${running ? 'Using' : 'Used'} skill ${scope.skillEvent.name}${running ? '…' : ''}`}
+        label={label}
         meta={meta}
         active={running}
         open={open}

--- a/apps/desktop/src/chat/Transcript.tsx
+++ b/apps/desktop/src/chat/Transcript.tsx
@@ -41,13 +41,20 @@ const MemoBlock = memo(
   function MemoBlock({
     block,
     onPreviewImage,
+    foldVersion: _foldVersion,
   }: {
     readonly block: FoldedBlock;
     readonly onPreviewImage?: (image: ImagePreviewItem) => void;
+    /** Mutable incremental-fold blocks need a scalar revision so memo sees
+     *  outcome/scope changes even when the object reference is stable. */
+    readonly foldVersion: number;
   }): JSX.Element | null {
     return <BlockView block={block} onPreviewImage={onPreviewImage} />;
   },
-  (a, b) => blocksEquivalent(a.block, b.block) && a.onPreviewImage === b.onPreviewImage,
+  (a, b) =>
+    a.foldVersion === b.foldVersion &&
+    blocksEquivalent(a.block, b.block) &&
+    a.onPreviewImage === b.onPreviewImage,
 );
 
 /** Row gutter — Virtuoso measures each item, so spacing rides on the row
@@ -88,10 +95,12 @@ function Row({
   node,
   workspaceId,
   onPreviewImage,
+  foldVersion,
 }: {
   readonly node: RenderNode;
   readonly workspaceId?: string;
   readonly onPreviewImage?: (image: ImagePreviewItem) => void;
+  readonly foldVersion: number;
 }): JSX.Element {
   return (
     <div style={ROW}>
@@ -100,7 +109,11 @@ function Row({
       ) : node.kind === 'tool-group' ? (
         <ToolGroupView tools={node.tools} />
       ) : (
-        <MemoBlock block={node.block} onPreviewImage={onPreviewImage} />
+        <MemoBlock
+          block={node.block}
+          onPreviewImage={onPreviewImage}
+          foldVersion={foldVersion}
+        />
       )}
     </div>
   );
@@ -151,6 +164,7 @@ export function Transcript({
     () => groupToolNodes(buildRenderNodes(events, extensions, foldRef.current ?? undefined, compactTools)),
     [events, extensions, compactTools],
   );
+  const foldVersion = foldRef.current?.version ?? events.length;
 
   const virtuosoRef = useRef<VirtuosoHandle>(null);
 
@@ -230,7 +244,12 @@ export function Transcript({
         {...(hasOlder && onReachedTop ? { startReached: onReachedTop } : {})}
         computeItemKey={(_i, node) => keyOf(node)}
         itemContent={(_i, node) => (
-          <Row node={node} workspaceId={workspaceId} onPreviewImage={onPreviewImage} />
+          <Row
+            node={node}
+            workspaceId={workspaceId}
+            onPreviewImage={onPreviewImage}
+            foldVersion={foldVersion}
+          />
         )}
         components={{
           Footer: () => (

--- a/packages/chat-model/src/pair-events.test.ts
+++ b/packages/chat-model/src/pair-events.test.ts
@@ -308,9 +308,17 @@ describe('pairToolEvents — skill grouping', () => {
   });
 
   it('suppresses the load_skill tool call and collapses it into the scope', () => {
+    const loadingBlocks = pairToolEvents([
+      toolRequest('ls1', 'load_skill', { name: 'pdf' }),
+      skillInvoked('sk1', 'pdf'),
+    ]);
+    const loadingScope = asScope(loadingBlocks[0]);
+    expect(loadingScope.loading).toBe(true);
+
     const blocks = pairToolEvents([
       toolRequest('ls1', 'load_skill', { name: 'pdf' }),
       skillInvoked('sk1', 'pdf'),
+      toolResult('ls1', 'loaded'),
       toolRequest('c1', 'bash'),
       toolResult('c1'),
     ]);
@@ -318,6 +326,7 @@ describe('pairToolEvents — skill grouping', () => {
     // The load_skill tool-call must NOT appear as its own block.
     expect(blocks).toHaveLength(1);
     const scope = asScope(blocks[0]);
+    expect(scope.loading).toBe(false);
     expect(scope.children).toHaveLength(1);
     expect(asToolCall(scope.children[0]).request.name).toBe('bash');
 
@@ -328,6 +337,7 @@ describe('pairToolEvents — skill grouping', () => {
       toolResult('ls1', 'loaded'),
     ]);
     const scope2 = asScope(withResult[0]);
+    expect(scope2.loading).toBe(false);
     expect(scope2.children).toHaveLength(0);
   });
 
@@ -600,7 +610,7 @@ describe('blocksEquivalent', () => {
     expect(blocksEquivalent(a, b)).toBe(true);
   });
 
-  it('skill-scope: differs when closed flag or child count differs', () => {
+  it('skill-scope: differs when loading/closed state or child count differs', () => {
     const sk = skillInvoked('sk1', 'pdf');
     const c1 = toolRequest('c1', 'bash');
     const r1 = toolResult('c1');
@@ -610,6 +620,17 @@ describe('blocksEquivalent', () => {
     expect(openScope.closed).toBe(false);
     expect(closedScope.closed).toBe(true);
     expect(blocksEquivalent(openScope, closedScope)).toBe(false);
+
+    const loadingScope = asScope(pairToolEvents([
+      toolRequest('load-1', 'load_skill', { name: 'pdf' }),
+      sk,
+    ])[0]);
+    const loadedScope = asScope(pairToolEvents([
+      toolRequest('load-1', 'load_skill', { name: 'pdf' }),
+      sk,
+      toolResult('load-1'),
+    ])[0]);
+    expect(blocksEquivalent(loadingScope, loadedScope)).toBe(false);
 
     const oneChild = asScope(pairToolEvents([sk, c1, r1])[0]);
     const twoChildren = asScope(

--- a/packages/chat-model/src/pair-events.ts
+++ b/packages/chat-model/src/pair-events.ts
@@ -351,6 +351,9 @@ export interface FoldState {
   // field). One map handles both kinds via structural typing.
   readonly callTargets: Map<string, CallTarget>;
   readonly suppressedCallIds: Set<string>;
+  /** load_skill calls hidden inside their resulting skill scope. The map lets
+   *  the matching result stop the scope header's loading animation. */
+  readonly suppressedSkillScopes: Map<string, SkillScopeBlock>;
   pendingLoadSkillCallId: string | null;
   openScope: SkillScopeBlock | null;
   // When an assistant_message lands mid-skill we close the current
@@ -381,6 +384,7 @@ export function createFoldState(compactByName: CompactToolMap = EMPTY_COMPACT_MA
     compactByName,
     callTargets: new Map<string, CallTarget>(),
     suppressedCallIds: new Set<string>(),
+    suppressedSkillScopes: new Map<string, SkillScopeBlock>(),
     pendingLoadSkillCallId: null,
     openScope: null,
     continuationSkillEvent: null,
@@ -418,6 +422,7 @@ export function stepFold(s: FoldState, e: MoxxyEvent): void {
   const closeOpenScope = (): void => {
     closeOpenLive();
     if (s.openScope) {
+      s.openScope.loading = false;
       s.openScope.closed = true;
       s.openScope = null;
     }
@@ -475,6 +480,7 @@ export function stepFold(s: FoldState, e: MoxxyEvent): void {
     // skill scope). Clearing it at the turn boundary stops a later turn that
     // happens to reuse a callId from having its tool_result silently dropped.
     s.suppressedCallIds.clear();
+    s.suppressedSkillScopes.clear();
     s.subagentGroup.current = null;
     // Subagents run to completion within the turn that dispatched them, so the
     // lookup map is a within-turn concern like callTargets. Clearing it bounds
@@ -492,9 +498,10 @@ export function stepFold(s: FoldState, e: MoxxyEvent): void {
     // both "load_skill(name=foo)" AND "◆ skill: foo".
     closeOpenScope();
     s.continuationSkillEvent = null;
-    if (s.pendingLoadSkillCallId) {
-      s.suppressedCallIds.add(s.pendingLoadSkillCallId);
-      removeBlockByCallId(s.pendingLoadSkillCallId);
+    const loadCallId = s.pendingLoadSkillCallId;
+    if (loadCallId) {
+      s.suppressedCallIds.add(loadCallId);
+      removeBlockByCallId(loadCallId);
       s.pendingLoadSkillCallId = null;
     }
     s.subagentGroup.current = null;
@@ -503,8 +510,10 @@ export function stepFold(s: FoldState, e: MoxxyEvent): void {
       id: e.id,
       skillEvent: e,
       children: [],
+      loading: loadCallId !== null,
       closed: false,
     };
+    if (loadCallId) s.suppressedSkillScopes.set(loadCallId, s.openScope);
     s.root.push(s.openScope);
     return;
   }
@@ -522,6 +531,7 @@ export function stepFold(s: FoldState, e: MoxxyEvent): void {
         id: `${s.continuationSkillEvent.id}:cont:${e.id}`,
         skillEvent: s.continuationSkillEvent,
         children: [],
+        loading: false,
         closed: false,
       };
       s.root.push(s.openScope);
@@ -553,7 +563,12 @@ export function stepFold(s: FoldState, e: MoxxyEvent): void {
     return;
   }
   if (e.type === 'tool_result') {
-    if (s.suppressedCallIds.has(e.callId)) return;
+    if (s.suppressedCallIds.has(e.callId)) {
+      const scope = s.suppressedSkillScopes.get(e.callId);
+      if (scope) scope.loading = false;
+      s.suppressedSkillScopes.delete(e.callId);
+      return;
+    }
     const target = s.callTargets.get(e.callId);
     if (target) {
       target.outcome = e;
@@ -561,7 +576,12 @@ export function stepFold(s: FoldState, e: MoxxyEvent): void {
     }
   }
   if (e.type === 'tool_call_denied') {
-    if (s.suppressedCallIds.has(e.callId)) return;
+    if (s.suppressedCallIds.has(e.callId)) {
+      const scope = s.suppressedSkillScopes.get(e.callId);
+      if (scope) scope.loading = false;
+      s.suppressedSkillScopes.delete(e.callId);
+      return;
+    }
     const target = s.callTargets.get(e.callId);
     if (target) {
       target.outcome = { type: 'denied', reason: e.reason };
@@ -894,6 +914,7 @@ export function blocksEquivalent(a: Block, b: Block): boolean {
     return true;
   }
   if (a.kind === 'skill-scope' && b.kind === 'skill-scope') {
+    if (a.loading !== b.loading) return false;
     if (a.closed !== b.closed) return false;
     if (a.children.length !== b.children.length) return false;
     for (let i = 0; i < a.children.length; i += 1) {

--- a/packages/chat-model/src/types.ts
+++ b/packages/chat-model/src/types.ts
@@ -150,6 +150,8 @@ export interface SkillScopeBlock {
   readonly id: string;
   readonly skillEvent: SkillInvokedEvent;
   children: Block[];
+  /** True only between the matching load_skill request and its result. */
+  loading: boolean;
   /**
    * A scope is "closed" once the turn ends (another user_prompt arrives
    * after it). Closed scopes collapse to a one-line summary by default;

--- a/packages/mode-default/src/index.test.ts
+++ b/packages/mode-default/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
-import { definePlugin, defineTool, type ProviderEvent } from '@moxxy/sdk';
+import { asSkillId, definePlugin, defineTool, type ProviderEvent } from '@moxxy/sdk';
 import { Session, autoAllowResolver, collectTurn, silentLogger } from '@moxxy/core';
 import { FakeProvider, textReply, toolUseReply, createFakeSession } from '@moxxy/testing';
 import { defaultModePlugin } from './index.js';
@@ -78,11 +78,30 @@ describe('defaultMode end-to-end', () => {
         handler: () => 'unused',
       }),
     );
+    session.skills.register({
+      id: asSkillId('web-research'),
+      path: '/test/web-research.md',
+      scope: 'project',
+      frontmatter: {
+        name: 'web-research',
+        description: 'Research current information on the web.',
+        triggers: ['latest news'],
+      },
+      body: 'Use web tools and cite sources.',
+    });
 
     const events = await collectTurn(session, 'answer without tools');
 
     expect(provider.received).toHaveLength(1);
     expect(provider.received[0]?.tools).toBeUndefined();
+    const systemText = provider.received[0]?.messages
+      .filter((message) => message.role === 'system')
+      .flatMap((message) => message.content)
+      .filter((block) => block.type === 'text')
+      .map((block) => block.text)
+      .join('\n') ?? '';
+    expect(systemText).not.toContain('Available skills');
+    expect(systemText).not.toContain('load_skill');
     const last = events.at(-1);
     expect(last).toMatchObject({ type: 'assistant_message', content: 'plain response' });
   });

--- a/packages/plugin-cli/src/components/ChatView.tsx
+++ b/packages/plugin-cli/src/components/ChatView.tsx
@@ -106,6 +106,7 @@ export const ChatView: React.FC<ChatViewProps> = ({
     settledRef.current = next;
   }
   const liveBlocks = blocks.slice(settledRef.current.length);
+  const renderVersion = foldRef.current?.version ?? events.length;
   return (
     <>
       <Static key={clearGenerationRef.current} items={settledRef.current}>
@@ -114,6 +115,7 @@ export const ChatView: React.FC<ChatViewProps> = ({
             key={block.id}
             block={block}
             expandToolOutputs={!!expandToolOutputs}
+            renderVersion={renderVersion}
           />
         )}
       </Static>
@@ -124,6 +126,7 @@ export const ChatView: React.FC<ChatViewProps> = ({
               key={b.id}
               block={b}
               expandToolOutputs={!!expandToolOutputs}
+              renderVersion={renderVersion}
             />
           ))}
           {streamingDelta && streamingDelta.trim() ? (

--- a/packages/plugin-cli/src/components/chat/BlockLine.test.ts
+++ b/packages/plugin-cli/src/components/chat/BlockLine.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  asEventId,
+  asSessionId,
+  asSkillId,
+  asTurnId,
+  type SkillInvokedEvent,
+} from '@moxxy/sdk';
+import type { SkillScopeBlock } from '@moxxy/chat-model';
+import { skillActivityPresentation } from './BlockLine.js';
+
+const skillEvent: SkillInvokedEvent = {
+  id: asEventId('skill-event'),
+  seq: 1,
+  ts: 1,
+  sessionId: asSessionId('session'),
+  turnId: asTurnId('turn'),
+  source: 'system',
+  type: 'skill_invoked',
+  skillId: asSkillId('web-research'),
+  name: 'web-research',
+  reason: 'load_skill_tool',
+};
+
+function scope(overrides: Partial<Pick<SkillScopeBlock, 'loading' | 'closed'>> = {}): SkillScopeBlock {
+  return {
+    kind: 'skill-scope',
+    id: 'scope',
+    skillEvent,
+    children: [],
+    loading: overrides.loading ?? false,
+    closed: overrides.closed ?? false,
+  };
+}
+
+describe('skillActivityPresentation', () => {
+  it('shimmers only while load_skill is pending', () => {
+    expect(skillActivityPresentation(scope({ loading: true }))).toEqual({
+      label: 'Loading skill web-research…',
+      meta: null,
+      active: true,
+    });
+    expect(skillActivityPresentation(scope())).toEqual({
+      label: 'Loaded skill web-research',
+      meta: null,
+      active: false,
+    });
+  });
+
+  it('omits zero tools and pluralizes non-zero tool counts', () => {
+    expect(skillActivityPresentation(scope(), 0).meta).toBeNull();
+    expect(skillActivityPresentation(scope(), 1)).toMatchObject({
+      label: 'Using skill web-research',
+      meta: '1 tool',
+    });
+    expect(skillActivityPresentation(scope({ closed: true }), 2)).toEqual({
+      label: 'Used skill web-research',
+      meta: '2 tools',
+      active: false,
+    });
+  });
+});

--- a/packages/plugin-cli/src/components/chat/BlockLine.tsx
+++ b/packages/plugin-cli/src/components/chat/BlockLine.tsx
@@ -21,15 +21,25 @@ export interface BlockLineProps {
   readonly block: Block;
   /** Global Ctrl+O toggle. Expands every live-tools block at once. */
   readonly expandToolOutputs: boolean;
+  /** Incremental-fold revision. Mutable block objects need this explicit
+   *  signal so React.memo observes outcome/scope changes. */
+  readonly renderVersion: number;
+  /** Child of a skill/activity group: use a compact branch guide and no blank row. */
+  readonly nested?: boolean;
 }
 
 export const BlockLine: React.FC<BlockLineProps> = memo(
-  function BlockLine({ block, expandToolOutputs }) {
+  function BlockLine({ block, expandToolOutputs, renderVersion, nested = false }) {
     if (block.kind === 'event')
       return <EventLine event={block.event} expandToolOutputs={expandToolOutputs} />;
     if (block.kind === 'tool-call') {
       return (
-        <ToolCallBlock request={block.request} outcome={block.outcome} expanded={expandToolOutputs} />
+        <ToolCallBlock
+          request={block.request}
+          outcome={block.outcome}
+          expanded={expandToolOutputs}
+          nested={nested}
+        />
       );
     }
     if (block.kind === 'subagent-group') {
@@ -39,12 +49,18 @@ export const BlockLine: React.FC<BlockLineProps> = memo(
       return <SubagentScopeView scope={block} />;
     }
     if (block.kind === 'live-tools') {
-      return <LiveToolBlock block={block} expanded={expandToolOutputs} />;
+      return <LiveToolBlock block={block} expanded={expandToolOutputs} nested={nested} />;
     }
     if (block.kind === 'collab') {
       return <CollabScopeView scope={block} />;
     }
-    return <SkillScopeView scope={block} expandToolOutputs={expandToolOutputs} />;
+    return (
+      <SkillScopeView
+        scope={block}
+        expandToolOutputs={expandToolOutputs}
+        renderVersion={renderVersion}
+      />
+    );
   },
   // Blocks are mutated in-place by `pairToolEvents` (tool outcome
   // arrives, scope closes, subagent counter ticks). Compare the
@@ -52,6 +68,8 @@ export const BlockLine: React.FC<BlockLineProps> = memo(
   // streaming-delta flush, an mcp poll) doesn't redraw every block.
   (prev, next) => {
     if (prev.expandToolOutputs !== next.expandToolOutputs) return false;
+    if (prev.nested !== next.nested) return false;
+    if (prev.renderVersion !== next.renderVersion) return false;
     return blocksEquivalent(prev.block, next.block);
   },
 );
@@ -63,30 +81,50 @@ export const BlockLine: React.FC<BlockLineProps> = memo(
 const SkillScopeView: React.FC<{
   scope: SkillScopeBlock;
   expandToolOutputs: boolean;
-}> = ({ scope, expandToolOutputs }) => {
+  renderVersion: number;
+}> = ({ scope, expandToolOutputs, renderVersion }) => {
   const childToolCount = countToolCalls(scope.children);
-  const nameLabel = truncate(scope.skillEvent.name, NAME_DISPLAY_MAX);
-  const callLabel = `${childToolCount} tool call${childToolCount === 1 ? '' : 's'}`;
-  const active = !scope.closed || scope.children.some(hasRunningTool);
-  const showChildren = active || expandToolOutputs;
-  const label = `${active ? 'Using' : 'Used'} skill ${nameLabel}${active ? '…' : ''}`;
+  const presentation = skillActivityPresentation(scope, childToolCount);
+  const runningTools = scope.children.some(hasRunningTool);
+  const showChildren = !scope.closed || runningTools || expandToolOutputs;
   return (
     <Box flexDirection="column" marginTop={1}>
       <Box>
         <Text dimColor>✦ </Text>
-        <ShimmerText text={label} active={active} />
-        <Text dimColor>{` · ${callLabel}${showChildren ? '' : '  ›'}`}</Text>
+        <ShimmerText text={presentation.label} active={presentation.active} />
+        {presentation.meta ? <Text dimColor>{` · ${presentation.meta}`}</Text> : null}
+        {!showChildren && childToolCount > 0 ? <Text dimColor>{'  ›'}</Text> : null}
       </Box>
       {showChildren ? (
         <Box flexDirection="column" marginLeft={2}>
           {scope.children.map((c) => (
-            <BlockLine key={c.id} block={c} expandToolOutputs={expandToolOutputs} />
+            <BlockLine
+              key={c.id}
+              block={c}
+              expandToolOutputs={expandToolOutputs}
+              renderVersion={renderVersion}
+              nested
+            />
           ))}
         </Box>
       ) : null}
     </Box>
   );
 };
+
+export function skillActivityPresentation(
+  scope: SkillScopeBlock,
+  childToolCount = countToolCalls(scope.children),
+): { readonly label: string; readonly meta: string | null; readonly active: boolean } {
+  const name = truncate(scope.skillEvent.name, NAME_DISPLAY_MAX);
+  const meta = childToolCount > 0
+    ? `${childToolCount} tool${childToolCount === 1 ? '' : 's'}`
+    : null;
+  if (scope.loading) return { label: `Loading skill ${name}…`, meta, active: true };
+  if (scope.closed) return { label: `Used skill ${name}`, meta, active: false };
+  if (childToolCount > 0) return { label: `Using skill ${name}`, meta, active: false };
+  return { label: `Loaded skill ${name}`, meta: null, active: false };
+}
 
 function hasRunningTool(block: Block): boolean {
   if (block.kind === 'tool-call') return block.outcome === null;

--- a/packages/plugin-cli/src/components/chat/EventLine.test.ts
+++ b/packages/plugin-cli/src/components/chat/EventLine.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { asEventId, asSessionId, asTurnId, type MoxxyEvent } from '@moxxy/sdk';
-import { collapseBlankLines, formatCompactionEvent } from './EventLine.js';
+import { collapseBlankLines, formatCompactionEvent, formatTriggerOrigin } from './EventLine.js';
 
 describe('formatCompactionEvent', () => {
   it('renders a compact, readable compaction summary', () => {
@@ -46,5 +46,14 @@ describe('collapseBlankLines', () => {
 
   it('leaves plain text unchanged', () => {
     expect(collapseBlankLines('hello world')).toBe('hello world');
+  });
+});
+
+describe('formatTriggerOrigin', () => {
+  it('uses compact origin-aware labels for machine and checkpoint prompts', () => {
+    expect(formatTriggerOrigin({ kind: 'webhook', name: 'github' })).toBe('Webhook received');
+    expect(formatTriggerOrigin({ kind: 'schedule', name: 'morning' })).toBe('Schedule fired');
+    expect(formatTriggerOrigin({ kind: 'workflow', name: 'release' })).toBe('Workflow ran');
+    expect(formatTriggerOrigin({ kind: 'checkpoint', name: 'verify' })).toBe('Checkpoint intervened');
   });
 });

--- a/packages/plugin-cli/src/components/chat/EventLine.tsx
+++ b/packages/plugin-cli/src/components/chat/EventLine.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Text } from 'ink';
-import type { MoxxyEvent } from '@moxxy/sdk';
+import type { MoxxyEvent, TriggerOrigin } from '@moxxy/sdk';
 import { Colors, Glyphs } from '../../theme.js';
 import { truncate } from '@moxxy/chat-model';
 import { AssistantBlock } from './AssistantBlock.js';
@@ -11,6 +11,22 @@ export const EventLine: React.FC<{ event: MoxxyEvent; expandToolOutputs?: boolea
 }) => {
   switch (event.type) {
     case 'user_prompt':
+      if (event.origin) {
+        return (
+          <Box flexDirection="column" marginTop={1}>
+            <Box>
+              <Text dimColor>{`${Glyphs.filled} ${formatTriggerOrigin(event.origin)} · `}</Text>
+              <Text>{event.origin.name}</Text>
+              {!expandToolOutputs ? <Text dimColor>{'  ›'}</Text> : null}
+            </Box>
+            {expandToolOutputs ? (
+              <Box marginLeft={2}>
+                <Text dimColor>{event.text}</Text>
+              </Box>
+            ) : null}
+          </Box>
+        );
+      }
       // System-injected context notes (e.g. the /vault reference) aren't user
       // input — render them as a compact dim note rather than the bold pinned
       // bar, so they don't dominate the transcript.
@@ -126,6 +142,17 @@ export const EventLine: React.FC<{ event: MoxxyEvent; expandToolOutputs?: boolea
       return null;
   }
 };
+
+const TRIGGER_VERBS: Record<TriggerOrigin['kind'], string> = {
+  webhook: 'Webhook received',
+  schedule: 'Schedule fired',
+  workflow: 'Workflow ran',
+  checkpoint: 'Checkpoint intervened',
+};
+
+export function formatTriggerOrigin(origin: TriggerOrigin): string {
+  return TRIGGER_VERBS[origin.kind];
+}
 
 /**
  * Display-only newline normalization for the user-prompt echo bar.

--- a/packages/plugin-cli/src/components/chat/LiveToolBlock.tsx
+++ b/packages/plugin-cli/src/components/chat/LiveToolBlock.tsx
@@ -32,8 +32,13 @@ export const LiveToolBlock: React.FC<{
   block: LiveToolBlockData;
   /** Global Ctrl+O toggle. */
   expanded: boolean;
-}> = ({ block, expanded }) => {
-  const inFlight = !block.closed || block.calls.some((call) => call.outcome === null);
+  /** Compact child row beneath a skill activity header. */
+  nested?: boolean;
+}> = ({ block, expanded, nested = false }) => {
+  // An aggregate may remain open for another adjacent compact call after the
+  // latest result settles. Animate actual pending work, not that grouping
+  // window, otherwise a completed read/search keeps shimmering indefinitely.
+  const inFlight = block.calls.some((call) => call.outcome === null);
   const showDetails = expanded || inFlight;
   const summary = buildCompactSummary(block.calls, inFlight);
   const latest = block.calls[block.calls.length - 1];
@@ -47,8 +52,9 @@ export const LiveToolBlock: React.FC<{
   }, 0);
 
   return (
-    <Box flexDirection="column" marginTop={1}>
+    <Box flexDirection="column" marginTop={nested ? 0 : 1}>
       <Box>
+        {nested ? <Text dimColor>└ </Text> : null}
         <Text dimColor>{latest ? toolGlyph(latest.request.name) : Glyphs.pending} </Text>
         <ShimmerText text={summary} active={inFlight} />
         {!showDetails ? <Text dimColor>{'  ›'}</Text> : null}
@@ -69,7 +75,7 @@ export const LiveToolBlock: React.FC<{
       {showDetails ? (
         <Box flexDirection="column" marginLeft={2}>
           {block.calls.map((c) => (
-            <ToolCallBlock key={c.id} request={c.request} outcome={c.outcome} />
+            <ToolCallBlock key={c.id} request={c.request} outcome={c.outcome} nested />
           ))}
         </Box>
       ) : null}

--- a/packages/plugin-cli/src/components/chat/ToolCallBlock.tsx
+++ b/packages/plugin-cli/src/components/chat/ToolCallBlock.tsx
@@ -15,7 +15,9 @@ export const ToolCallBlock: React.FC<{
   outcome: ToolResultEvent | { type: 'denied'; reason: string } | null;
   /** Global Ctrl+O toggle — expands result previews and full file diffs. */
   expanded?: boolean;
-}> = ({ request, outcome, expanded = false }) => {
+  /** Compact child row beneath a skill/live activity header. */
+  nested?: boolean;
+}> = ({ request, outcome, expanded = false, nested = false }) => {
   // A settled Write/Edit result renders as a full diff card (its own header,
   // summary, and changed slices) instead of the generic outcome line.
   if (isFileDiffResult(outcome)) {
@@ -34,17 +36,21 @@ export const ToolCallBlock: React.FC<{
           : 'err';
   const detail = truncate(formatToolActivity(request.name, request.input, status === 'pending'), NAME_DISPLAY_MAX + 70);
   return (
-    <Box flexDirection="column" marginTop={1}>
+    <Box flexDirection="column" marginTop={nested ? 0 : 1}>
       <Box>
-        <Text color={status === 'err' ? Colors.danger : undefined} dimColor={status !== 'err'}>
-          {status === 'err' ? '✗' : toolGlyph(request.name)}{' '}
+        {nested ? <Text dimColor>└ </Text> : null}
+        <Text
+          color={status === 'err' ? Colors.danger : status === 'ok' ? Colors.active : undefined}
+          dimColor={status === 'pending'}
+        >
+          {status === 'err' ? '✗' : status === 'ok' ? '✓' : toolGlyph(request.name)}{' '}
         </Text>
         <ShimmerText text={detail} active={status === 'pending'} />
         {status === 'err' ? <Text color={Colors.danger}> failed</Text> : null}
       </Box>
       {outcome && (expanded || status === 'err') ? (
-        <Box>
-          <Text dimColor>  └ </Text>
+        <Box marginLeft={nested ? 2 : 0}>
+          <Text dimColor>{nested ? '  ' : '  └ '}</Text>
           <OutcomeText outcome={outcome} />
         </Box>
       ) : null}

--- a/packages/plugin-cli/src/session/use-turn-runner.test.ts
+++ b/packages/plugin-cli/src/session/use-turn-runner.test.ts
@@ -51,6 +51,34 @@ function makeStream() {
 }
 
 describe('useTurnRunner force-send drain (u79-1)', () => {
+  it('keeps the turn busy until the provider iterator reaches its terminal result', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const session = {
+      runTurn: () => (async function* () {
+        await gate;
+      })(),
+    } as unknown as Parameters<typeof useTurnRunner>[0]['session'];
+
+    const handle = mountFreshHook({
+      session,
+      resolveModel: () => 'claude-opus-4-8',
+      stream: makeStream(),
+    });
+    const turnPromise = handle.runTurnWith('research this', []);
+
+    expect(handle.busyRef.current).toBe(true);
+    expect(handle.turnControllerRef.current).not.toBeNull();
+
+    release();
+    await turnPromise;
+
+    expect(handle.busyRef.current).toBe(false);
+    expect(handle.turnControllerRef.current).toBeNull();
+  });
+
   it('runs a mid-turn force-sent message alone after the in-flight turn', async () => {
     const runs: string[] = [];
     // Controllable gate so we can force-send WHILE the first turn is in flight.

--- a/packages/sdk/src/mode/react-loop.ts
+++ b/packages/sdk/src/mode/react-loop.ts
@@ -260,7 +260,16 @@ export async function* runReactLoop(
       return;
     }
 
-    const systemPrompt = buildSystemPromptWithSkills(ctx.systemPrompt, ctx.skills.list());
+    // A text-only provider cannot call `load_skill`. Advertising the lazy skill
+    // index anyway makes agent-shaped transports (notably Claude Code CLI)
+    // imitate the unavailable call as plain assistant text and then end the
+    // turn. Keep the base prompt, but only advertise lazy skills when the
+    // selected model can actually execute the loader. Unknown/dynamic model ids
+    // retain the historical tool-capable behavior, matching collect-stream's
+    // conservative capability fallback.
+    const descriptor = ctx.provider.models.find((candidate) => candidate.id === ctx.model);
+    const availableSkills = descriptor?.supportsTools === false ? [] : ctx.skills.list();
+    const systemPrompt = buildSystemPromptWithSkills(ctx.systemPrompt, availableSkills);
     const { messages, stablePrefixIndex } = projectMessages(ctx, {
       ...(systemPrompt ? { systemPrompt } : {}),
       ...(volatileText ? { trailingUserText: volatileText } : {}),


### PR DESCRIPTION
## What

- keep Claude Code turns locked and visibly thinking until the provider reaches a terminal response
- stop advertising moxxy lazy-skill tools to text-only providers that cannot call them
- render compact Ink-native skill and tool activity with clear loading, success, and failure states
- stop shimmer as soon as work settles and omit the meaningless 0 tool calls label
- keep TUI and desktop folded activity blocks fresh when their in-place state changes
- render non-interactive trigger prompts as compact activity rows

## Why

Claude Code uses native WebSearch internally and does not emit moxxy dispatcher tool events. The loop still advertised load_skill, so Claude could print a fake tool request as plain assistant text and end the turn, making the TUI look stuck or prematurely unlocked. Activity blocks also treated an open grouping window as active work, which left completed rows shimmering and displayed a misleading zero-call counter.

## Verification

- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm check:deps
- node packages/cli/dist/bin.js --help
- node packages/cli/dist/bin.js plugins list