### PR TITLE
feat(network): route outbound requests through a corporate proxy

### DIFF
--- a/.changeset/enterprise-egress-proxy.md
+++ b/.changeset/enterprise-egress-proxy.md
@@ -1,0 +1,12 @@
+---
+'@moxxy/cli': minor
+'@moxxy/sdk': minor
+---
+
+Support outbound HTTP proxies, so moxxy runs on networks that require one.
+
+Node's global `fetch` ignores `HTTPS_PROXY`, and every provider call goes through it, so on a proxied corporate network the first request failed with an opaque error and no setting fixed it. A global dispatcher is now installed at startup from `http_proxy` / `https_proxy` / `no_proxy`, with full `NO_PROXY` semantics (`*`, domain suffixes, port qualifiers, IPv6). `undici` is imported only when a proxy is actually configured.
+
+A new `network` config block can override the environment: `proxy: 'off'` forces direct connections, and a URL pins a proxy the user cannot route around by clearing their shell profile. `network.noProxy` merges with the environment's rules rather than replacing them.
+
+`moxxy doctor` reports the effective proxy (credentials masked) and warns when a proxy is in use without `NODE_EXTRA_CA_CERTS`, which is the usual cause of `UNABLE_TO_VERIFY_LEAF_SIGNATURE` behind a TLS-terminating proxy.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,30 @@ Provider keys such as `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` are detected auto
 | `MOXXY_NO_CORE_UPDATE=1` | Disables registration of Tier 2 core self-update tools. |
 | `MOXXY_FIXTURES` | Selects `record`, `replay`, or `passthrough` provider fixture mode for tests. |
 
+### Network egress
+
+Node's global `fetch` ignores proxy variables on its own, and every provider call goes through it. Moxxy installs a proxy dispatcher at startup so these take effect.
+
+| Variable | Effect |
+|---|---|
+| `https_proxy` / `HTTPS_PROXY` | Proxy for `https:` origins, which is every provider API. Lowercase wins if both are set. |
+| `http_proxy` / `HTTP_PROXY` | Proxy for `http:` origins. Deliberately not used as a fallback for `https:`. |
+| `no_proxy` / `NO_PROXY` | Comma or whitespace separated bypass rules. `*` bypasses everything; `.corp.example` covers the domain and its subdomains; `host:8081` restricts the rule to that port. |
+| `NODE_EXTRA_CA_CERTS` | Path to an extra CA bundle. Required when the proxy terminates TLS, otherwise requests fail with `UNABLE_TO_VERIFY_LEAF_SIGNATURE`. Node reads it at startup, so it must be set in the environment, not in config. |
+
+Run `moxxy doctor` to see which proxy is in force and whether an extra CA is configured. Proxy credentials are masked in all output.
+
+Config can override the environment, which is what a managed workstation wants:
+
+```yaml
+network:
+  # 'env' (default) reads the variables above; 'off' forces direct;
+  # a URL pins that proxy even if the user clears their shell profile.
+  proxy: http://proxy.corp.example:3128
+  # Merged with no_proxy from the environment, never replacing it.
+  noProxy: .corp.example,localhost
+```
+
 ### Channels
 
 | Variable | Effect |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@moxxy/sdk": "workspace:*",
+    "undici": "^6.26.0",
     "zod": "catalog:"
   },
   "optionalDependencies": {

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -28,6 +28,7 @@ import { runSecurityCommand } from './commands/security.js';
 import { runSelfUpdateCommand } from './commands/self-update.js';
 import { runUpdateCommand } from './commands/update.js';
 import { probeSession } from './setup.js';
+import { applyEgressSettings } from './setup/egress.js';
 import { renderLogo } from './logo.js';
 import { colors } from './colors.js';
 import { cliVersion } from './version.js';
@@ -111,6 +112,8 @@ const SECTIONS: ReadonlyArray<{ readonly title: string; readonly rows: ReadonlyA
       ['ANTHROPIC_API_KEY', 'default Anthropic provider key'],
       ['OPENAI_API_KEY', 'OpenAI provider key (and openai embeddings)'],
       ['MOXXY_HOME', 'override the ~/.moxxy data directory'],
+      ['HTTPS_PROXY | NO_PROXY', 'outbound proxy + bypass rules (see `moxxy doctor`)'],
+      ['NODE_EXTRA_CA_CERTS', 'extra CA bundle, needed when the proxy terminates TLS'],
       ['MOXXY_DEBUG=1', 'verbose error output + process diagnostics'],
       ['MOXXY_FIXTURES', 'record | replay — provider fixture mode (used by tests)'],
       ['MOXXY_VAULT_PASSPHRASE', 'headless vault passphrase (alt to keychain)'],
@@ -253,6 +256,14 @@ async function main(): Promise<number> {
   // rename) accumulate for the life of the install. Detached: pruning month-old
   // litter must never add latency to startup.
   void pruneStaleTempFiles([moxxyHome(), moxxyPath('sessions')]).catch(() => {});
+
+  // Route outbound requests through the environment's proxy before any command
+  // can reach the network. Config can override this later (session setup
+  // re-applies once it is loaded); doing the env-only pass here covers the
+  // commands that never load a config but still fetch, such as `update` and
+  // `plugins search`. A no-op when no proxy is set, and `undici` is only
+  // imported when there is one.
+  await applyEgressSettings();
 
   // Reaching this point means the (possibly overlaid) core code imported
   // cleanly, so commit any staged Tier-2 core patch. Best-effort — never

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -7,10 +7,12 @@ import type { VaultStore } from '@moxxy/plugin-vault';
 import type { MemoryStore } from '@moxxy/plugin-memory';
 import { checkVoiceCaptureAvailable } from '@moxxy/plugin-cli';
 import { corePreflight, detectCoreInstall } from '@moxxy/plugin-self-update';
+import { hasProxy, redactProxyUrl } from '@moxxy/sdk/server';
 import type { ParsedArgv } from '../argv.js';
 import { setupSessionWithConfig } from '../setup.js';
 import { closeSession } from '../setup/close-session.js';
 import { embedderSelection } from '../setup/resolve-plugins-tree.js';
+import { resolveEgressSettings } from '../setup/egress.js';
 import type { RegistrationResult } from '../setup/register-plugins.js';
 import { resolveProviderCredentials } from '../provider-credentials.js';
 import { colors } from '../colors.js';
@@ -244,11 +246,52 @@ async function runDoctorChecks(deps: DoctorChecksDeps): Promise<number> {
     message: `provider=${eProvider}${embedder?.model ? ` model=${embedder.model}` : ''}`,
   });
 
+  // Network egress. The single most common "moxxy cannot reach the provider"
+  // cause on a corporate host is a proxy that Node's global fetch ignores, so
+  // say plainly whether one is in force and whether a custom CA was supplied.
+  checks.push(buildEgressDoctorCheck(config));
+
   // Self-update — Tier-1 is always available if the plugin is loaded; Tier-2
   // (core patching) additionally needs git/pnpm + pinned source provenance.
   checks.push(await buildSelfUpdateDoctorCheck(session));
 
   return emit(checks, asJson);
+}
+
+/**
+ * Report the effective outbound-network posture: which proxy (if any) global
+ * `fetch` is routed through, and whether a custom CA bundle was supplied.
+ *
+ * `NODE_EXTRA_CA_CERTS` cannot be configured from inside the process (Node
+ * reads it at startup), so this reports rather than fixes. A TLS-terminating
+ * corporate proxy without it produces `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, which
+ * is otherwise a very unrewarding error to diagnose.
+ */
+export function buildEgressDoctorCheck(config: MoxxyConfig): Check {
+  const settings = resolveEgressSettings(config);
+  const ca = process.env.NODE_EXTRA_CA_CERTS;
+  const caNote = ca ? `, extra CA=${ca}` : '';
+
+  if (!hasProxy(settings)) {
+    const forcedOff = config.network?.proxy === 'off';
+    return {
+      id: 'network',
+      status: 'ok',
+      message: `direct${forcedOff ? ' (network.proxy=off)' : ''}${caNote}`,
+    };
+  }
+  const via = [
+    settings.httpsProxy ? `https via ${redactProxyUrl(settings.httpsProxy)}` : null,
+    settings.httpProxy ? `http via ${redactProxyUrl(settings.httpProxy)}` : null,
+  ]
+    .filter(Boolean)
+    .join(', ');
+  const bypass = settings.noProxy ? `, bypass=${settings.noProxy}` : '';
+  // A TLS-intercepting proxy without a trusted CA is the classic silent
+  // failure, so nudge toward it rather than waiting for the handshake error.
+  const status: Status = ca ? 'ok' : 'warn';
+  const hint = ca ? '' : ' (set NODE_EXTRA_CA_CERTS if the proxy terminates TLS)';
+  return { id: 'network', status, message: `${via}${bypass}${caNote}${hint}` };
 }
 
 export async function buildSelfUpdateDoctorCheck(session: Session): Promise<Check> {

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -21,6 +21,7 @@ import {
 import { cliVersion } from './version.js';
 import { buildSessionConfigApplier } from './config-applier.js';
 import { loadRawConfig, resolveConfigPlaceholders } from './setup/load-config.js';
+import { applyEgressSettings } from './setup/egress.js';
 import { selectEmbedder } from './setup/embedder.js';
 import { buildSession } from './setup/build-session.js';
 import { buildBuiltinsCore } from './setup/builtins.js';
@@ -83,6 +84,12 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
   // mcp_test_server) and the cache populates.
 
   const config = await resolveConfigPlaceholders(rawConfig, vault, logger);
+
+  // Re-resolve egress now that config is available. `bin.ts` already applied
+  // the environment's proxy before any command ran; this second pass is what
+  // lets a managed config pin (or forbid) a proxy the environment did not set.
+  // A no-op when the resolution is unchanged, which is the common case.
+  await applyEgressSettings(config);
 
   // Single source of truth for "is this package disabled?", seeded from the
   // merged config (project + user `plugins[name].enabled = false`). The

--- a/packages/cli/src/setup/egress.test.ts
+++ b/packages/cli/src/setup/egress.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { MoxxyConfig } from '@moxxy/config';
+import { applyEgressSettings, resetEgressForTests, resolveEgressSettings } from './egress.js';
+
+const PROXY_VARS = ['http_proxy', 'HTTP_PROXY', 'https_proxy', 'HTTPS_PROXY', 'no_proxy', 'NO_PROXY'];
+
+describe('resolveEgressSettings', () => {
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const key of PROXY_VARS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+  afterEach(() => {
+    for (const key of PROXY_VARS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it('uses the environment when config says nothing', () => {
+    process.env.HTTPS_PROXY = 'http://env:3128';
+    expect(resolveEgressSettings(undefined)).toEqual({ httpsProxy: 'http://env:3128' });
+  });
+
+  it('uses the environment for the explicit env mode', () => {
+    process.env.HTTPS_PROXY = 'http://env:3128';
+    const config = { network: { proxy: 'env' } } as MoxxyConfig;
+    expect(resolveEgressSettings(config).httpsProxy).toBe('http://env:3128');
+  });
+
+  // A managed workstation must be able to forbid a proxy the user exported.
+  it('forces direct on proxy=off even when the environment sets one', () => {
+    process.env.HTTPS_PROXY = 'http://env:3128';
+    const config = { network: { proxy: 'off' } } as MoxxyConfig;
+    expect(resolveEgressSettings(config)).toEqual({});
+  });
+
+  // The inverse: a user must not route around the corporate proxy by clearing
+  // their shell profile.
+  it('a configured proxy url overrides the environment for both schemes', () => {
+    process.env.HTTPS_PROXY = 'http://env:3128';
+    const config = { network: { proxy: 'http://managed:8080' } } as MoxxyConfig;
+    expect(resolveEgressSettings(config)).toMatchObject({
+      httpProxy: 'http://managed:8080',
+      httpsProxy: 'http://managed:8080',
+    });
+  });
+
+  // Pinning a proxy must never silently drop a bypass the host depended on.
+  it('merges config noProxy with the environment rather than replacing it', () => {
+    process.env.NO_PROXY = 'localhost';
+    const config = { network: { proxy: 'http://managed:8080', noProxy: '.corp.example' } } as MoxxyConfig;
+    expect(resolveEgressSettings(config).noProxy).toBe('localhost,.corp.example');
+  });
+
+  it('keeps the environment bypass rules in env mode', () => {
+    process.env.HTTPS_PROXY = 'http://env:3128';
+    process.env.NO_PROXY = 'localhost';
+    expect(resolveEgressSettings(undefined).noProxy).toBe('localhost');
+  });
+});
+
+describe('applyEgressSettings', () => {
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const key of PROXY_VARS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+    resetEgressForTests();
+  });
+  afterEach(() => {
+    for (const key of PROXY_VARS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+    resetEgressForTests();
+  });
+
+  it('reports no proxy on a clean environment', async () => {
+    expect(await applyEgressSettings()).toEqual({ enabled: false, reason: 'no proxy configured' });
+  });
+
+  // Boot applies env-only settings, session setup re-applies with config. The
+  // second call must not redo the work when nothing changed.
+  it('is a no-op when the resolution is unchanged', async () => {
+    await applyEgressSettings();
+    expect(await applyEgressSettings()).toBeNull();
+  });
+
+  it('re-applies when config changes the resolution', async () => {
+    await applyEgressSettings();
+    const config = { network: { proxy: 'http://managed:8080' } } as MoxxyConfig;
+    const status = await applyEgressSettings(config);
+    expect(status).not.toBeNull();
+    expect(status?.enabled).toBe(true);
+    expect(status?.httpsProxy).toBe('http://managed:8080/');
+  });
+});

--- a/packages/cli/src/setup/egress.ts
+++ b/packages/cli/src/setup/egress.ts
@@ -1,0 +1,69 @@
+// Values live on the Node-only subpath; the erased types ride the main barrel,
+// per the split documented in @moxxy/sdk/server.
+import { hasProxy, installEgressProxy, readProxyEnv } from '@moxxy/sdk/server';
+import type { EgressProxySettings, EgressStatus } from '@moxxy/sdk';
+import type { MoxxyConfig } from '@moxxy/config';
+
+/**
+ * Resolve the effective proxy settings from config layered over the
+ * environment.
+ *
+ * `network.proxy` precedence, and why:
+ *   - unset / `'env'`: the environment decides. The default, so a developer's
+ *     existing `HTTPS_PROXY` just works with no moxxy config at all.
+ *   - `'off'`:         direct, even when the environment says otherwise.
+ *   - a URL:           that proxy, even when the environment says otherwise.
+ *     A managed workstation needs this: a user must not be able to route around
+ *     the corporate proxy by clearing their shell profile.
+ *
+ * `network.noProxy` is MERGED with the environment's `no_proxy` rather than
+ * replacing it, so pinning a proxy in config never silently drops a bypass the
+ * host already depended on (an internal registry, a metadata endpoint).
+ */
+export function resolveEgressSettings(config?: MoxxyConfig): EgressProxySettings {
+  const env = readProxyEnv();
+  const mode = config?.network?.proxy;
+  const noProxy = mergeNoProxy(env.noProxy, config?.network?.noProxy);
+
+  if (mode === 'off') return {};
+  if (mode !== undefined && mode !== 'env') {
+    return { httpProxy: mode, httpsProxy: mode, ...(noProxy ? { noProxy } : {}) };
+  }
+  return { ...env, ...(noProxy ? { noProxy } : {}) };
+}
+
+function mergeNoProxy(fromEnv?: string, fromConfig?: string): string | undefined {
+  const parts = [fromEnv, fromConfig].filter((p): p is string => Boolean(p && p.trim()));
+  return parts.length > 0 ? parts.join(',') : undefined;
+}
+
+/**
+ * The settings currently installed on the global dispatcher, so a second call
+ * with an identical resolution is a no-op. Boot applies env-only settings
+ * before any command runs; session setup re-applies once the config is loaded,
+ * and only the second call does work when config actually overrides the env.
+ */
+let applied: string | null = null;
+
+/**
+ * Install (or re-install) the global proxy dispatcher. Idempotent and
+ * non-throwing: a bad proxy setting degrades to direct connections plus a
+ * warning, never a failed boot.
+ *
+ * Returns null when the resolved settings are already in force.
+ */
+export async function applyEgressSettings(config?: MoxxyConfig): Promise<EgressStatus | null> {
+  const settings = resolveEgressSettings(config);
+  const key = JSON.stringify(settings);
+  if (applied === key) return null;
+  // Nothing configured and nothing installed yet: record the no-op so the
+  // second (config-aware) call can still detect a real change.
+  applied = key;
+  if (!hasProxy(settings)) return { enabled: false, reason: 'no proxy configured' };
+  return await installEgressProxy(settings);
+}
+
+/** Test seam: forget what was installed so a suite can re-apply. */
+export function resetEgressForTests(): void {
+  applied = null;
+}

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -87,6 +87,26 @@ export const securityConfigSchema = z.object({
   strict: z.boolean().optional(),
 });
 
+/**
+ * Outbound network settings. Node's global `fetch` ignores `HTTPS_PROXY`, so
+ * without this every provider call fails on a network that requires a proxy.
+ */
+export const networkConfigSchema = z
+  .object({
+    /**
+     * `'env'` (the default) reads `http_proxy` / `https_proxy` / `no_proxy`
+     * from the environment. `'off'` forces direct connections even when those
+     * are set. A URL forces that proxy regardless of the environment, which is
+     * what a managed workstation wants so a user cannot unset it by clearing
+     * their shell profile.
+     */
+    proxy: z.union([z.enum(['env', 'off']), z.string().url()]).optional(),
+    /** Bypass rules applied to `proxy`, same syntax as `NO_PROXY`. Merged with
+     *  the environment's `no_proxy` rather than replacing it. */
+    noProxy: z.string().optional(),
+  })
+  .strict();
+
 export const embeddingsConfigSchema = z.object({
   /**
    * 'tfidf' (default, zero deps) | 'openai' (text-embedding-3-*)
@@ -177,6 +197,7 @@ export const moxxyConfigSchema = z.object({
     })
     .optional(),
   security: securityConfigSchema.optional(),
+  network: networkConfigSchema.optional(),
   channels: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
   permissions: permissionsConfigSchema.optional(),
   env: z.record(z.string(), z.string()).optional(),
@@ -209,6 +230,7 @@ export type ContextConfig = z.infer<typeof contextConfigSchema>;
 export type ElisionConfig = z.infer<typeof elisionConfigSchema>;
 export type WatcherMode = z.infer<typeof watcherModeSchema>;
 export type PermissionsConfig = z.infer<typeof permissionsConfigSchema>;
+export type NetworkConfig = z.infer<typeof networkConfigSchema>;
 export type EmbeddingsConfig = z.infer<typeof embeddingsConfigSchema>;
 export type SecurityConfig = z.infer<typeof securityConfigSchema>;
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -74,13 +74,20 @@
     "clean": "rm -rf dist .turbo"
   },
   "peerDependencies": {
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "undici": "^6.21.0"
   },
   "devDependencies": {
     "@moxxy/tsconfig": "workspace:*",
     "@moxxy/vitest-preset": "workspace:*",
     "typescript": "catalog:",
+    "undici": "^6.21.0",
     "vitest": "catalog:",
     "zod": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "undici": {
+      "optional": true
+    }
   }
 }

--- a/packages/sdk/src/egress.test.ts
+++ b/packages/sdk/src/egress.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  hasProxy,
+  installEgressProxy,
+  parseNoProxy,
+  readProxyEnv,
+  redactProxyUrl,
+  shouldBypassProxy,
+} from './egress.js';
+
+describe('readProxyEnv', () => {
+  it('reads uppercase and lowercase forms', () => {
+    expect(readProxyEnv({ HTTPS_PROXY: 'http://p:3128' })).toEqual({ httpsProxy: 'http://p:3128' });
+    expect(readProxyEnv({ https_proxy: 'http://p:3128' })).toEqual({ httpsProxy: 'http://p:3128' });
+  });
+
+  // Lowercase wins by convention (curl, requests, Go): a shell exporting both
+  // usually set the lowercase one deliberately and more recently.
+  it('prefers the lowercase form when both are set', () => {
+    const env = { https_proxy: 'http://lower:1', HTTPS_PROXY: 'http://upper:2' };
+    expect(readProxyEnv(env).httpsProxy).toBe('http://lower:1');
+  });
+
+  it('treats blank and whitespace values as unset', () => {
+    expect(readProxyEnv({ HTTPS_PROXY: '', HTTP_PROXY: '   ' })).toEqual({});
+  });
+
+  // A plaintext-only proxy declared via http_proxy must not silently swallow
+  // TLS traffic; https origins go direct instead of failing confusingly.
+  it('does not fall back to http_proxy for https origins', () => {
+    expect(readProxyEnv({ HTTP_PROXY: 'http://p:3128' })).toEqual({ httpProxy: 'http://p:3128' });
+  });
+});
+
+describe('parseNoProxy', () => {
+  it('splits on commas and whitespace, lowercases, and drops blanks', () => {
+    expect(parseNoProxy(' localhost, .Corp.Example  10.0.0.1 ,, ')).toEqual([
+      'localhost',
+      '.corp.example',
+      '10.0.0.1',
+    ]);
+  });
+
+  it('returns an empty list for undefined', () => {
+    expect(parseNoProxy(undefined)).toEqual([]);
+  });
+});
+
+describe('shouldBypassProxy', () => {
+  const bypass = (origin: string, rules: string): boolean =>
+    shouldBypassProxy(origin, parseNoProxy(rules));
+
+  it('bypasses everything on *', () => {
+    expect(bypass('https://api.anthropic.com', '*')).toBe(true);
+  });
+
+  it('matches an exact host on any port', () => {
+    expect(bypass('http://localhost:8080/x', 'localhost')).toBe(true);
+    expect(bypass('https://localhost', 'localhost')).toBe(true);
+    expect(bypass('https://notlocalhost', 'localhost')).toBe(false);
+  });
+
+  // A leading dot covers the apex too, matching curl. Getting this wrong sends
+  // internal traffic through the proxy, which is exactly what NO_PROXY exists
+  // to prevent.
+  it('matches subdomains and the apex for a dotted rule', () => {
+    expect(bypass('https://api.corp.example', '.corp.example')).toBe(true);
+    expect(bypass('https://corp.example', '.corp.example')).toBe(true);
+    expect(bypass('https://deep.api.corp.example', '.corp.example')).toBe(true);
+    expect(bypass('https://evilcorp.example', '.corp.example')).toBe(false);
+  });
+
+  it('treats *.domain the same as .domain', () => {
+    expect(bypass('https://api.corp.example', '*.corp.example')).toBe(true);
+  });
+
+  it('honours a port qualifier', () => {
+    expect(bypass('http://registry.internal:8081/x', 'registry.internal:8081')).toBe(true);
+    expect(bypass('http://registry.internal:9999/x', 'registry.internal:8081')).toBe(false);
+  });
+
+  it('resolves the implicit port from the scheme', () => {
+    expect(bypass('https://svc.internal/x', 'svc.internal:443')).toBe(true);
+    expect(bypass('http://svc.internal/x', 'svc.internal:80')).toBe(true);
+    expect(bypass('https://svc.internal/x', 'svc.internal:80')).toBe(false);
+  });
+
+  // `::1` must not be read as host ":" on port "1".
+  it('does not mistake an IPv6 literal for a host:port rule', () => {
+    expect(bypass('http://[::1]:7000/x', '::1')).toBe(true);
+  });
+
+  it('is case-insensitive on the host', () => {
+    expect(bypass('https://API.Corp.Example', '.corp.example')).toBe(true);
+  });
+
+  it('never bypasses with no rules, or on an unparseable origin', () => {
+    expect(bypass('https://api.anthropic.com', '')).toBe(false);
+    expect(shouldBypassProxy('not a url', ['*.corp.example'])).toBe(false);
+  });
+});
+
+describe('redactProxyUrl', () => {
+  it('masks embedded credentials', () => {
+    expect(redactProxyUrl('http://alice:hunter2@proxy.corp:3128')).toBe('http://***:***@proxy.corp:3128/');
+  });
+
+  it('leaves a credential-free url intact', () => {
+    expect(redactProxyUrl('http://proxy.corp:3128')).toBe('http://proxy.corp:3128/');
+  });
+
+  // Never echo something unparseable: it might be a secret pasted by mistake.
+  it('reveals nothing for an unparseable value', () => {
+    expect(redactProxyUrl('hunter2')).toBe('<invalid proxy url>');
+  });
+});
+
+describe('installEgressProxy', () => {
+  /**
+   * Stand-in for undici. Each agent reports its own label through the dispatch
+   * handler, so `routeOf` observes WHICH agent the router picked for an origin,
+   * which is the whole contract worth testing here.
+   */
+  const fakeUndici = () => {
+    let installed: { dispatch: (o: { origin?: string }, h: unknown) => boolean } | null = null;
+    const agent = (label: string) => ({
+      dispatch: (_o: unknown, h: { onPick?: (l: string) => void }) => {
+        h.onPick?.(label);
+        return true;
+      },
+      close: async () => {},
+      destroy: async () => {},
+    });
+    return {
+      routeOf: (origin: string): string => {
+        let picked = '';
+        installed!.dispatch({ origin }, {
+          onPick: (l: string) => {
+            picked = l;
+          },
+        });
+        return picked;
+      },
+      module: {
+        Agent: function Agent() {
+          return agent('direct');
+        } as never,
+        ProxyAgent: function ProxyAgent(o: { uri: string }) {
+          return agent(`proxy:${o.uri}`);
+        } as never,
+        setGlobalDispatcher: (d: never) => {
+          installed = d;
+        },
+      },
+    };
+  };
+
+  it('no-ops when no proxy is configured', async () => {
+    const status = await installEgressProxy({});
+    expect(status).toEqual({ enabled: false, reason: 'no proxy configured' });
+  });
+
+  it('reports and skips an unparseable proxy url instead of throwing', async () => {
+    const warn = vi.fn();
+    const status = await installEgressProxy({ httpsProxy: 'not a url' }, { warn });
+    expect(status.enabled).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('https_proxy is not a valid URL'));
+  });
+
+  // A proxy is configured but the dependency is missing: degrade to direct with
+  // a loud warning rather than a failed boot.
+  it('warns and degrades when undici cannot be loaded', async () => {
+    const warn = vi.fn();
+    const status = await installEgressProxy(
+      { httpsProxy: 'http://p:3128' },
+      { warn, loadUndici: () => Promise.reject(new Error('not installed')) },
+    );
+    expect(status.enabled).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('`undici` package is unavailable'));
+  });
+
+  it('installs a dispatcher and redacts credentials in the reported status', async () => {
+    const u = fakeUndici();
+    const status = await installEgressProxy(
+      { httpsProxy: 'http://bob:secret@p:3128', noProxy: 'localhost' },
+      { loadUndici: async () => u.module as never },
+    );
+    expect(status.enabled).toBe(true);
+    expect(status.httpsProxy).toBe('http://***:***@p:3128/');
+    expect(status.httpsProxy).not.toContain('secret');
+    expect(status.noProxy).toEqual(['localhost']);
+  });
+
+  it('routes https through the proxy and bypassed hosts direct', async () => {
+    const u = fakeUndici();
+    await installEgressProxy(
+      { httpsProxy: 'http://p:3128', noProxy: '.corp.example' },
+      { loadUndici: async () => u.module as never },
+    );
+    expect(u.routeOf('https://api.anthropic.com')).toBe('proxy:http://p:3128');
+    expect(u.routeOf('https://git.corp.example')).toBe('direct');
+  });
+
+  // Only http_proxy set: https origins must go direct, not through it.
+  it('sends https direct when only an http proxy is configured', async () => {
+    const u = fakeUndici();
+    await installEgressProxy(
+      { httpProxy: 'http://p:3128' },
+      { loadUndici: async () => u.module as never },
+    );
+    expect(u.routeOf('http://example.com')).toBe('proxy:http://p:3128');
+    expect(u.routeOf('https://example.com')).toBe('direct');
+  });
+});
+
+describe('hasProxy', () => {
+  it('is true when either proxy is set', () => {
+    expect(hasProxy({})).toBe(false);
+    expect(hasProxy({ noProxy: 'localhost' })).toBe(false);
+    expect(hasProxy({ httpProxy: 'http://p' })).toBe(true);
+    expect(hasProxy({ httpsProxy: 'http://p' })).toBe(true);
+  });
+});
+
+describe('shouldBypassProxy IPv6 port qualifiers', () => {
+  const bypass = (origin: string, rules: string): boolean =>
+    shouldBypassProxy(origin, parseNoProxy(rules));
+
+  // A port on an IPv6 address requires brackets, exactly as in a URL.
+  it('honours a bracketed IPv6 host:port rule', () => {
+    expect(bypass('http://[::1]:7000/x', '[::1]:7000')).toBe(true);
+    expect(bypass('http://[::1]:9999/x', '[::1]:7000')).toBe(false);
+  });
+
+  it('matches a bracketed IPv6 rule on any port', () => {
+    expect(bypass('http://[::1]:7000/x', '[::1]')).toBe(true);
+  });
+});

--- a/packages/sdk/src/egress.ts
+++ b/packages/sdk/src/egress.ts
@@ -1,0 +1,274 @@
+/**
+ * Outbound HTTP egress: corporate proxy support for everything moxxy fetches.
+ *
+ * Node's global `fetch` ignores `HTTPS_PROXY` entirely, and every provider
+ * reaches its API through it (`@anthropic-ai/sdk`, `openai`, and the plain
+ * `fetch` calls in tools). On a network that requires an outbound proxy that
+ * means the first provider call fails with an opaque network error and there is
+ * no setting that fixes it. Installing a global undici dispatcher is the only
+ * way to route global `fetch` through a proxy.
+ *
+ * `undici` is imported DYNAMICALLY and only when a proxy is actually configured,
+ * so `@moxxy/sdk` keeps zero hard runtime dependencies and a host with no proxy
+ * pays nothing. The package is a real dependency of `@moxxy/cli`.
+ *
+ * Not handled here, on purpose: a corporate TLS-terminating CA is Node's job,
+ * via `NODE_EXTRA_CA_CERTS=/path/to/ca.pem` in the environment before Node
+ * starts. There is no in-process equivalent, so the doctor surfaces whether it
+ * is set rather than pretending to configure it.
+ */
+
+/** Proxy inputs, already resolved from env and/or config. */
+export interface EgressProxySettings {
+  /** Proxy for `http:` origins. */
+  readonly httpProxy?: string;
+  /** Proxy for `https:` origins. */
+  readonly httpsProxy?: string;
+  /** Raw `NO_PROXY` value: comma/whitespace separated bypass rules. */
+  readonly noProxy?: string;
+}
+
+export interface EgressStatus {
+  /** True when a global dispatcher was installed. */
+  readonly enabled: boolean;
+  /** Credential-redacted proxy in use for `http:`, when set. */
+  readonly httpProxy?: string;
+  /** Credential-redacted proxy in use for `https:`, when set. */
+  readonly httpsProxy?: string;
+  /** Parsed bypass rules. */
+  readonly noProxy?: ReadonlyArray<string>;
+  /** Why nothing was installed, or why installation failed. */
+  readonly reason?: string;
+}
+
+/**
+ * Read proxy settings from an environment. Lowercase wins over uppercase, which
+ * is the de-facto convention (curl, requests, Go): a shell that exports both
+ * usually means the lowercase one was set deliberately and more recently.
+ *
+ * `http_proxy` is deliberately NOT used as a fallback for https origins. Some
+ * environments set only `http_proxy` for a plaintext-only proxy, and silently
+ * tunnelling TLS through it would fail confusingly rather than going direct.
+ */
+export function readProxyEnv(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): EgressProxySettings {
+  const pick = (lower: string, upper: string): string | undefined => {
+    const value = (env[lower] ?? env[upper] ?? '').trim();
+    return value.length > 0 ? value : undefined;
+  };
+  const httpProxy = pick('http_proxy', 'HTTP_PROXY');
+  const httpsProxy = pick('https_proxy', 'HTTPS_PROXY');
+  const noProxy = pick('no_proxy', 'NO_PROXY');
+  return {
+    ...(httpProxy ? { httpProxy } : {}),
+    ...(httpsProxy ? { httpsProxy } : {}),
+    ...(noProxy ? { noProxy } : {}),
+  };
+}
+
+/** Split a `NO_PROXY` value into normalized rules. Separators are commas and
+ *  whitespace; empty entries are dropped and matching is case-insensitive. */
+export function parseNoProxy(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(/[,\s]+/)
+    .map((rule) => rule.trim().toLowerCase())
+    .filter((rule) => rule.length > 0);
+}
+
+/**
+ * Whether `origin` bypasses the proxy under `rules` (already parsed by
+ * {@link parseNoProxy}).
+ *
+ * Follows the de-facto `NO_PROXY` convention rather than inventing one:
+ *   - `*` bypasses everything.
+ *   - a bare host matches that host exactly, on any port.
+ *   - a leading `.` or `*.` matches the domain and every subdomain, so
+ *     `.corp.example` covers `api.corp.example` AND `corp.example`.
+ *   - an entry carrying `:port` matches only that port; the origin's port is
+ *     resolved from the scheme when the URL omits it.
+ *
+ * A malformed origin never bypasses: failing closed here sends the request
+ * through the proxy, which an operator can observe, rather than silently
+ * leaking it direct.
+ */
+export function shouldBypassProxy(origin: string, rules: ReadonlyArray<string>): boolean {
+  if (rules.length === 0) return false;
+  if (rules.includes('*')) return true;
+
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch {
+    return false;
+  }
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  const port = url.port || (url.protocol === 'https:' ? '443' : '80');
+
+  for (const rule of rules) {
+    const { host: ruleHost, port: rulePort } = splitRule(rule);
+    if (rulePort !== undefined && rulePort !== port) continue;
+    if (ruleHost.length === 0) continue;
+
+    const suffix = ruleHost.startsWith('*.')
+      ? ruleHost.slice(1)
+      : ruleHost.startsWith('.')
+        ? ruleHost
+        : undefined;
+    if (suffix) {
+      // `.corp.example` covers the apex too, matching curl.
+      if (host === suffix.slice(1) || host.endsWith(suffix)) return true;
+      continue;
+    }
+    if (host === ruleHost) return true;
+  }
+  return false;
+}
+
+/**
+ * Split a bypass rule into host and optional port.
+ *
+ * A bare IPv6 literal contains colons of its own, so `::1` must not be read as
+ * host `:` on port `1`. As in a URL, a port qualifier on an IPv6 address
+ * requires brackets (`[::1]:7000`); an unbracketed rule with more than one
+ * colon is therefore an address, never a host:port pair.
+ */
+function splitRule(rule: string): { host: string; port?: string } {
+  if (rule.startsWith('[')) {
+    const end = rule.indexOf(']');
+    if (end === -1) return { host: rule.slice(1) };
+    const host = rule.slice(1, end);
+    const rest = rule.slice(end + 1);
+    return rest.startsWith(':') && /^\d+$/.test(rest.slice(1))
+      ? { host, port: rest.slice(1) }
+      : { host };
+  }
+  const first = rule.indexOf(':');
+  if (first === -1 || first !== rule.lastIndexOf(':')) return { host: rule };
+  const maybePort = rule.slice(first + 1);
+  return /^\d+$/.test(maybePort)
+    ? { host: rule.slice(0, first), port: maybePort }
+    : { host: rule };
+}
+
+/**
+ * A proxy URL with any embedded credentials masked, safe to log or show in
+ * `moxxy doctor`. Proxy URLs routinely carry `user:password@`, and this string
+ * ends up on terminals and in support pastes.
+ */
+export function redactProxyUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    if (!url.username && !url.password) return url.toString();
+    url.username = url.username ? '***' : '';
+    url.password = url.password ? '***' : '';
+    return url.toString();
+  } catch {
+    // Unparseable: reveal nothing rather than echoing a possible secret.
+    return '<invalid proxy url>';
+  }
+}
+
+/** True when at least one proxy is configured, i.e. there is work to do. */
+export function hasProxy(settings: EgressProxySettings): boolean {
+  return Boolean(settings.httpProxy ?? settings.httpsProxy);
+}
+
+interface UndiciModule {
+  readonly Agent: new (opts?: unknown) => UndiciDispatcher;
+  readonly ProxyAgent: new (opts: { uri: string }) => UndiciDispatcher;
+  readonly setGlobalDispatcher: (dispatcher: UndiciDispatcher) => void;
+}
+
+interface UndiciDispatcher {
+  dispatch(opts: { origin?: string | URL }, handler: unknown): boolean;
+  close(): Promise<void>;
+  destroy(): Promise<void>;
+}
+
+export interface InstallEgressProxyOptions {
+  /** Surface for the "configured but unusable" case. Defaults to stderr. */
+  readonly warn?: (message: string) => void;
+  /** Injectable module loader for tests. */
+  readonly loadUndici?: () => Promise<UndiciModule>;
+}
+
+/**
+ * Install a global dispatcher routing outbound requests through the configured
+ * proxy, honouring the bypass rules. No-ops (and reports why) when no proxy is
+ * configured, so this is safe to call unconditionally at boot.
+ *
+ * Never throws: a broken proxy setting must degrade to a loud warning plus
+ * direct connections, not a failed boot.
+ */
+export async function installEgressProxy(
+  settings: EgressProxySettings,
+  opts: InstallEgressProxyOptions = {},
+): Promise<EgressStatus> {
+  if (!hasProxy(settings)) return { enabled: false, reason: 'no proxy configured' };
+
+  const warn = opts.warn ?? ((m: string) => process.stderr.write(`[moxxy] ${m}\n`));
+  for (const [label, value] of [
+    ['http_proxy', settings.httpProxy],
+    ['https_proxy', settings.httpsProxy],
+  ] as const) {
+    if (value === undefined) continue;
+    try {
+      new URL(value);
+    } catch {
+      const reason = `${label} is not a valid URL; continuing without a proxy`;
+      warn(reason);
+      return { enabled: false, reason };
+    }
+  }
+
+  let undici: UndiciModule;
+  try {
+    undici = await (opts.loadUndici ?? defaultLoadUndici)();
+  } catch {
+    const reason =
+      'a proxy is configured but the `undici` package is unavailable; ' +
+      'outbound requests will bypass it and may fail';
+    warn(reason);
+    return { enabled: false, reason };
+  }
+
+  const rules = parseNoProxy(settings.noProxy);
+  const direct = new undici.Agent();
+  const httpProxy = settings.httpProxy ? new undici.ProxyAgent({ uri: settings.httpProxy }) : undefined;
+  const httpsProxy = settings.httpsProxy
+    ? new undici.ProxyAgent({ uri: settings.httpsProxy })
+    : undefined;
+
+  const route = (origin: string | URL | undefined): UndiciDispatcher => {
+    if (origin === undefined) return direct;
+    const href = typeof origin === 'string' ? origin : origin.href;
+    if (shouldBypassProxy(href, rules)) return direct;
+    const secure = href.startsWith('https:');
+    return (secure ? httpsProxy : httpProxy) ?? direct;
+  };
+
+  const all = [direct, httpProxy, httpsProxy].filter(Boolean) as UndiciDispatcher[];
+  const router: UndiciDispatcher = {
+    dispatch: (dispatchOpts, handler) => route(dispatchOpts.origin).dispatch(dispatchOpts, handler),
+    close: async () => {
+      await Promise.all(all.map((d) => d.close()));
+    },
+    destroy: async () => {
+      await Promise.all(all.map((d) => d.destroy()));
+    },
+  };
+  undici.setGlobalDispatcher(router);
+
+  return {
+    enabled: true,
+    ...(settings.httpProxy ? { httpProxy: redactProxyUrl(settings.httpProxy) } : {}),
+    ...(settings.httpsProxy ? { httpsProxy: redactProxyUrl(settings.httpsProxy) } : {}),
+    ...(rules.length > 0 ? { noProxy: rules } : {}),
+  };
+}
+
+async function defaultLoadUndici(): Promise<UndiciModule> {
+  return (await import('undici')) as unknown as UndiciModule;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -217,6 +217,11 @@ export {
   type ResolvedProviderTools,
 } from './provider-tool-utils.js';
 export type { WriteFileAtomicOptions } from './fs-utils.js';
+export type {
+  EgressProxySettings,
+  EgressStatus,
+  InstallEgressProxyOptions,
+} from './egress.js';
 export type { ChannelRunStatus } from './channel-status.js';
 export type { CrossProcessFireLock, CrossProcessFireLockOptions } from './cross-process-lock.js';
 export { createMutex, type Mutex } from './mutex.js';

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -26,6 +26,15 @@ export {
   PRIVATE_DIR_MODE,
   PRIVATE_FILE_MODE,
 } from './fs-utils.js';
+// Outbound proxy support for global `fetch` (dynamic `undici` import). Node-only.
+export {
+  installEgressProxy,
+  readProxyEnv,
+  parseNoProxy,
+  shouldBypassProxy,
+  redactProxyUrl,
+  hasProxy,
+} from './egress.js';
 // Cross-process "fire exactly once" lock (node:fs). Value lives here; its
 // options type is re-exported from the main barrel like other erased types.
 export { CrossProcessFireLock } from './cross-process-lock.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,6 +552,9 @@ importers:
       '@moxxy/sdk':
         specifier: workspace:*
         version: link:../sdk
+      undici:
+        specifier: ^6.26.0
+        version: 6.26.0
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -2910,6 +2913,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      undici:
+        specifier: ^6.21.0
+        version: 6.26.0
       vitest:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@24.12.3)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)


### PR DESCRIPTION
Wave 2 of the enterprise roadmap. Stacked on #467, so review that first; the diff here is just the egress work.

Node's global `fetch` ignores `HTTPS_PROXY`, and every provider call goes through it. On a network that requires an outbound proxy the first request failed with an opaque error and there was no moxxy setting that fixed it, which made the product undeployable in most corporate environments. Grepping the whole repo for proxy support before this turned up exactly one hit: a string in an error message suggesting the user set `HTTPS_PROXY`, which nothing then read.

A global undici dispatcher now gets installed at startup. `NO_PROXY` semantics follow the de-facto convention rather than an invented one: `*` bypasses everything, a leading dot covers the domain and its subdomains including the apex (curl behaviour), `:port` restricts a rule, and a bare IPv6 literal isn't mistaken for `host:port` (brackets required for a port, same as a URL). `http_proxy` is deliberately not a fallback for https origins so a plaintext-only proxy can't silently swallow TLS.

On the new dependency: `undici` is the only way to proxy global `fetch`, since Node exposes no public `ProxyAgent`. It's imported dynamically and only when a proxy is actually configured, and it's an **optional peer** of `@moxxy/sdk` (real dependency of `@moxxy/cli`), so the SDK keeps its no-hard-deps rule from AGENTS.md and a host without a proxy pays nothing. Missing package or bad proxy URL degrades to direct plus a warning, never a failed boot.

The `network` config block exists so a managed workstation can pin a proxy the user can't route around by clearing their shell profile, and `network.noProxy` merges with the environment instead of replacing it (pinning must never silently drop a bypass the host depended on, e.g. an internal registry).

Note I used `ProxyAgent` plus my own routing rather than undici's `EnvHttpProxyAgent`, which does all of this natively: it's still marked experimental and prints a `[UNDICI-EHPA]` warning on every construction. Suppressing that would mean removing Node's default `warning` listener, which is too invasive for a library. Worth revisiting when it stabilises.

`NODE_EXTRA_CA_CERTS` is reported by `moxxy doctor`, not set: Node reads it at startup so there's no in-process equivalent. Doctor warns when a proxy is in use without it, since that's the usual cause of `UNABLE_TO_VERIFY_LEAF_SIGNATURE` behind a TLS-terminating proxy. Proxy credentials are masked everywhere they surface.

Egress allow-listing moved to the enterprise-profile wave, where the rest of the policy controls live.

Verified: full gate green (build, typecheck, lint 0 errors, check:deps 0 errors, all test tasks). 36 new tests covering NO_PROXY matching, credential redaction, dispatcher routing, and the config-over-env precedence.