### PR TITLE
feat(identity): attribute the event log to a Principal

### DIFF
--- a/.changeset/enterprise-principal-identity.md
+++ b/.changeset/enterprise-principal-identity.md
@@ -1,0 +1,14 @@
+---
+'@moxxy/cli': minor
+'@moxxy/sdk': minor
+---
+
+Attribute the event log to a `Principal`, so a transcript records who acted.
+
+Until now events carried `source` (a category: user, model, tool, …) but no subject, which meant a transcript proved a machine did something rather than that a person did. Audit, role-based policy, and cost attribution all need the subject, and retrofitting it later is far more expensive than adding it now.
+
+`EventBase.actor` is a new optional field stamped on every appended event, and `AppContext.actor` exposes the same identity to lifecycle hooks so a policy or audit hook can answer "who is asking". The CLI attributes sessions to the local OS account (`os` issuer, worth exactly as much as local account separation); a channel that authenticates its users overrides it with `session.setPrincipal`.
+
+Runner protocol v11: `attach` carries an optional `principal`, so a thin client's work is attributed on the runner's authoritative log. Additive, so older clients keep working and their events stay unattributed. `moxxy doctor` reports the identity in force.
+
+The field is optional on purpose: the event log is append-only and persisted, so sessions recorded before this replay unattributed and must keep doing so. Treat absent as unattributed, never as an error.

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -7,6 +7,7 @@ import type { VaultStore } from '@moxxy/plugin-vault';
 import type { MemoryStore } from '@moxxy/plugin-memory';
 import { checkVoiceCaptureAvailable } from '@moxxy/plugin-cli';
 import { corePreflight, detectCoreInstall } from '@moxxy/plugin-self-update';
+import { formatPrincipal } from '@moxxy/sdk';
 import { hasProxy, redactProxyUrl } from '@moxxy/sdk/server';
 import type { ParsedArgv } from '../argv.js';
 import { setupSessionWithConfig } from '../setup.js';
@@ -244,6 +245,18 @@ async function runDoctorChecks(deps: DoctorChecksDeps): Promise<number> {
     id: 'embeddings',
     status: 'ok',
     message: `provider=${eProvider}${embedder?.model ? ` model=${embedder.model}` : ''}`,
+  });
+
+  // Identity. What every event in this session is attributed to, and how much
+  // that attribution is worth: `os` is only as strong as local account
+  // separation, which an operator reading an audit trail needs to know.
+  const actor = session.principal;
+  checks.push({
+    id: 'identity',
+    status: actor ? 'ok' : 'warn',
+    message: actor
+      ? `${formatPrincipal(actor)} (${actor.kind})`
+      : 'unattributed: events carry no actor',
   });
 
   // Network egress. The single most common "moxxy cannot reach the provider"

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -20,6 +20,7 @@ import {
 } from '@moxxy/plugin-plugins-admin';
 import { cliVersion } from './version.js';
 import { buildSessionConfigApplier } from './config-applier.js';
+import { resolveOsPrincipal } from '@moxxy/sdk/server';
 import { loadRawConfig, resolveConfigPlaceholders } from './setup/load-config.js';
 import { applyEgressSettings } from './setup/egress.js';
 import { selectEmbedder } from './setup/embedder.js';
@@ -112,6 +113,14 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
     // returns null for unknown names.
     secretResolver: (name) => vault.get(name),
   });
+
+  // Attribute everything this session appends to the local OS account. It is
+  // the FLOOR identity, worth exactly as much as local account separation,
+  // which is why it is issued as `os` rather than dressed up as something
+  // stronger. Set before any plugin registers or any hook fires, so no event
+  // can be appended unattributed. A channel that actually authenticates its
+  // users overrides it via `session.setPrincipal`.
+  session.setPrincipal(resolveOsPrincipal());
 
   // Build the builtin list first WITHOUT the config plugin so we can pass the
   // whole list to the ConfigApplier (used for hot-toggle of plugin enable/disable).

--- a/packages/core/src/events/factory.ts
+++ b/packages/core/src/events/factory.ts
@@ -4,6 +4,7 @@ import type {
   EventId,
   EmittedEvent,
   MoxxyEvent,
+  Principal,
   SessionId,
   TurnId,
 } from '@moxxy/sdk';
@@ -17,11 +18,16 @@ export function materializeEvent(
   partial: EmittedEvent,
   seq: number,
   now: () => number = Date.now,
+  principal?: Principal,
 ): MoxxyEvent {
   const base: Pick<EventBase, 'id' | 'seq' | 'ts'> = {
     id: newEventId(),
     seq,
     ts: partial.ts ?? now(),
   };
-  return { ...partial, ...base } as MoxxyEvent;
+  // An emitter that already named an actor keeps it: a channel serving several
+  // users on one session attributes per event, and must win over the log's
+  // session-wide default.
+  const actor = partial.actor ?? principal;
+  return { ...partial, ...base, ...(actor ? { actor } : {}) } as MoxxyEvent;
 }

--- a/packages/core/src/events/log.test.ts
+++ b/packages/core/src/events/log.test.ts
@@ -513,3 +513,67 @@ describe('EventLog indexed ofType/byTurn equal the naive filter (property test)'
 });
 
 type MoxxyEventForTest = { seq: number } & Record<string, unknown>;
+
+describe('principal attribution', () => {
+  const alice = { id: 'alice@host', kind: 'human', issuer: 'os' } as const;
+
+  it('stamps the session principal onto every appended event', async () => {
+    const log = new EventLog();
+    log.setPrincipal(alice);
+    const event = await log.append({
+      type: 'user_prompt',
+      sessionId: 's' as never,
+      turnId: 't' as never,
+      source: 'user',
+      text: 'hi',
+    });
+    expect(event.actor).toEqual(alice);
+  });
+
+  // Absent must stay absent: the log is append-only and persisted, so sessions
+  // recorded before identity existed replay unattributed and must keep doing so.
+  it('leaves events unattributed when no principal is set', async () => {
+    const log = new EventLog();
+    const event = await log.append({
+      type: 'user_prompt',
+      sessionId: 's' as never,
+      turnId: 't' as never,
+      source: 'user',
+      text: 'hi',
+    });
+    expect(event.actor).toBeUndefined();
+    expect('actor' in event).toBe(false);
+  });
+
+  // A channel serving several users on one session attributes per event, and
+  // that must win over the log's session-wide default.
+  it('lets an emitter-supplied actor win over the session default', async () => {
+    const log = new EventLog();
+    log.setPrincipal(alice);
+    const bob = { id: 'bob', kind: 'human', issuer: 'oidc' } as const;
+    const event = await log.append({
+      type: 'user_prompt',
+      sessionId: 's' as never,
+      turnId: 't' as never,
+      source: 'user',
+      text: 'hi',
+      actor: bob,
+    });
+    expect(event.actor).toEqual(bob);
+  });
+
+  it('re-attribution applies to later events only', async () => {
+    const log = new EventLog();
+    log.setPrincipal(alice);
+    const first = await log.append({
+      type: 'user_prompt', sessionId: 's' as never, turnId: 't' as never, source: 'user', text: 'a',
+    });
+    log.setPrincipal(undefined);
+    const second = await log.append({
+      type: 'user_prompt', sessionId: 's' as never, turnId: 't' as never, source: 'user', text: 'b',
+    });
+    expect(first.actor).toEqual(alice);
+    expect(second.actor).toBeUndefined();
+    expect(log.getPrincipal()).toBeUndefined();
+  });
+});

--- a/packages/core/src/events/log.ts
+++ b/packages/core/src/events/log.ts
@@ -4,6 +4,7 @@ import type {
   MoxxyEvent,
   MoxxyEventOfType,
   MoxxyEventType,
+  Principal,
   TurnId,
 } from '@moxxy/sdk';
 import { materializeEvent } from './factory.js';
@@ -25,6 +26,7 @@ export class EventLog implements EventLogReader {
   private readonly listeners = new Set<EventListener>();
   private readonly clearListeners = new Set<() => void>();
   private readonly now: () => number;
+  private principal: Principal | undefined;
   /**
    * Lazy secondary indexes so `ofType`/`byTurn` are O(matches) instead of an
    * O(n) full-array `filter` per call (these back hot paths: token-accounting's
@@ -135,8 +137,27 @@ export class EventLog implements EventLogReader {
     return [...this.events];
   }
 
+  /**
+   * Identity stamped onto every appended event. Set by whoever owns the surface
+   * (the CLI resolves the OS account; an authenticated channel resolves its
+   * token's subject), never guessed here.
+   */
+  setPrincipal(principal: Principal | undefined): void {
+    this.principal = principal;
+  }
+
+  /** The identity currently being attributed to, if any. */
+  getPrincipal(): Principal | undefined {
+    return this.principal;
+  }
+
   async append(partial: EmittedEvent): Promise<MoxxyEvent> {
-    const event = materializeEvent(partial, this.base + this.events.length, this.now);
+    const event = materializeEvent(
+      partial,
+      this.base + this.events.length,
+      this.now,
+      this.principal,
+    );
     this.events.push(event);
     this.indexEvent(event);
     // Snapshot listeners so a subscribe/unsubscribe during dispatch (e.g.,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -4,6 +4,7 @@ import type {
   EmittedEvent,
   LoopGuardSettings,
   MoxxyEvent,
+  Principal,
   RunTurnOptions,
   SessionId,
   SessionInfo,
@@ -388,6 +389,26 @@ export class Session implements ClientSession, SessionRuntime {
   }
 
   /**
+   * Attribute everything this session appends to `principal`.
+   *
+   * Set by whoever owns the surface and can actually vouch for the identity:
+   * the CLI resolves the OS account, an authenticated channel resolves its
+   * token's subject. Core never guesses one, because an identity core invented
+   * would be worth nothing to an auditor.
+   *
+   * Pass `undefined` to go back to unattributed, which is what a surface with
+   * no notion of a user should do rather than inventing a placeholder.
+   */
+  setPrincipal(principal: Principal | undefined): void {
+    this.log.setPrincipal(principal);
+  }
+
+  /** The identity this session currently attributes to, if any. */
+  get principal(): Principal | undefined {
+    return this.log.getPrincipal();
+  }
+
+  /**
    * `SessionLike.reset` — the authoritative `/new`. Clears the event log;
    * the log's clear listeners propagate the wipe to whatever observes it
    * (the persistence sidecar truncates its JSONL so `--resume` sees an
@@ -471,12 +492,17 @@ export class Session implements ClientSession, SessionRuntime {
     if (!this.envSnapshot) {
       this.envSnapshot = Object.freeze({ ...process.env });
     }
+    // Read the principal per call rather than caching it with `envSnapshot`:
+    // a channel can re-attribute mid-session (a second user pairs, a token
+    // rotates) and a hook must see the identity in force NOW.
+    const actor = this.log.getPrincipal();
     return {
       sessionId: this.id,
       cwd: this.cwd,
       log: this.log.asReader(),
       env: this.envSnapshot,
       services: this.services,
+      ...(actor ? { actor } : {}),
     };
   }
 

--- a/packages/runner/src/integration.test.ts
+++ b/packages/runner/src/integration.test.ts
@@ -1577,3 +1577,46 @@ describe('log completeness: stream-without-seal', () => {
     expect((sealed[0] as AssistantMessageEvent).content).toBe('final');
   });
 });
+
+describe('principal attribution over the wire (v11)', () => {
+  it('stamps an attaching client\'s principal onto the events it causes', async () => {
+    const { session, socketPath } = await serve(new FakeProvider({ script: [textReply('ok')] }));
+    const principal = { id: 'alice@laptop', kind: 'human', issuer: 'oidc' } as const;
+    const remote = await connectRemoteSession({ socketPath, role: 'test', principal });
+    remotes.push(remote);
+
+    for await (const _event of remote.runTurn('hello')) void _event;
+
+    const prompt = session.log.toJSON().find((e) => e.type === 'user_prompt');
+    expect(prompt?.actor).toEqual(principal);
+  });
+
+  // A thin client over the 0600 unix socket IS the same local user as the
+  // runner, so the default assertion is a statement of fact, not a claim.
+  it('defaults to the local OS account when the caller names no principal', async () => {
+    const { session, socketPath } = await serve(new FakeProvider({ script: [textReply('ok')] }));
+    const remote = await attach(socketPath);
+
+    for await (const _event of remote.runTurn('hello')) void _event;
+
+    const prompt = session.log.toJSON().find((e) => e.type === 'user_prompt');
+    expect(prompt?.actor?.issuer).toBe('os');
+    expect(prompt?.actor?.kind).toBe('human');
+  });
+
+  // The wire is a trust boundary: an oversized id or an unbounded claims bag
+  // would otherwise land verbatim in every persisted event.
+  it('rejects an over-long principal id at the schema', async () => {
+    const { socketPath } = await serve(new FakeProvider({ script: [textReply('ok')] }));
+    const transport = await connectUnixSocket(socketPath);
+    const peer = new JsonRpcPeer(transport);
+    await expect(
+      peer.request(RunnerMethod.Attach, {
+        protocolVersion: RUNNER_PROTOCOL_VERSION,
+        role: 'test',
+        principal: { id: 'x'.repeat(300), kind: 'human', issuer: 'os' },
+      }),
+    ).rejects.toThrow();
+    transport.close();
+  });
+});

--- a/packages/runner/src/protocol.ts
+++ b/packages/runner/src/protocol.ts
@@ -7,6 +7,7 @@ import type {
   PendingToolCall,
   PermissionContext,
   PermissionDecision,
+  Principal,
   OpenSurfaceResult,
   SessionInfo,
   SurfaceDataMessage,
@@ -143,11 +144,18 @@ import type {
  * transcript ever goes blank. (Additive — a v9 server simply lacks this one
  * method.)
  *
- * Every change v1→v10 has been ADDITIVE, so MIN_COMPATIBLE stays at 1: today's
+ * v11: `attach` accepts an optional `principal`, the identity the connection
+ * acts on behalf of. The runner stamps it onto every event that connection
+ * causes, so a shared session attributes each client's work instead of
+ * collapsing them into one anonymous stream, and an audit sink downstream gets
+ * self-attributing records. Older clients simply omit it and their events stay
+ * unattributed, exactly as before. (Additive: a v10 server ignores the key.)
+ *
+ * Every change v1→v11 has been ADDITIVE, so MIN_COMPATIBLE stays at 1: today's
  * server can serve any client back to v1, and any client v1+ can attach. Bump
  * MIN_COMPATIBLE to N only when landing a breaking change at version N.
  */
-export const RUNNER_PROTOCOL_VERSION = 10;
+export const RUNNER_PROTOCOL_VERSION = 11;
 
 /**
  * Lowest client protocol version this build's CORE session protocol is
@@ -302,6 +310,18 @@ export interface AttachParams {
   readonly sinceSeq?: number;
   /** Replay policy (v6). Older servers strip the key and replay in full. */
   readonly replay?: AttachReplay;
+  /**
+   * Identity this connection acts on behalf of (v11). The runner stamps it onto
+   * every event the connection causes, so a shared session records WHICH client
+   * did what instead of collapsing them all into one anonymous stream.
+   *
+   * Client-asserted, and only ever as trustworthy as the transport: over the
+   * 0600 unix socket the peer is already the same local user, so `os` is a
+   * statement of fact. A network-facing client must not be believed on this
+   * without its own authentication, which is why {@link Principal.issuer}
+   * travels with the id.
+   */
+  readonly principal?: Principal;
 }
 export interface AttachResult {
   readonly sessionId: string;
@@ -529,6 +549,20 @@ const attachmentSchema = z
   })
   .passthrough();
 
+/**
+ * Trust-boundary schema for an attaching client's asserted identity (v11).
+ * Bounded on every field: this crosses a socket and lands verbatim in the event
+ * log, so an unbounded id or an unbounded claims bag would let a client bloat
+ * every persisted event. Unknown keys are stripped rather than passed through.
+ */
+export const principalSchema = z.object({
+  id: z.string().min(1).max(256),
+  kind: z.union([z.literal('human'), z.literal('service')]),
+  issuer: z.string().min(1).max(64),
+  displayName: z.string().max(256).optional(),
+  claims: z.record(z.string().max(64), z.string().max(1024)).optional(),
+});
+
 export const attachParamsSchema = z.object({
   protocolVersion: z.number(),
   role: z.string(),
@@ -540,6 +574,7 @@ export const attachParamsSchema = z.object({
       z.object({ tail: z.number().int().positive() }),
     ])
     .optional(),
+  principal: principalSchema.optional(),
 });
 
 export const runTurnParamsSchema = z.object({

--- a/packages/runner/src/remote-session.ts
+++ b/packages/runner/src/remote-session.ts
@@ -13,6 +13,7 @@ import type {
   PendingToolCall,
   PermissionResolver,
   PermissionsClientView,
+  Principal,
   ProvidersClientView,
   RequirementsClientView,
   RunTurnOptions,
@@ -31,6 +32,7 @@ import type {
   TurnId,
 } from '@moxxy/sdk';
 import { sleepWithAbort } from '@moxxy/sdk';
+import { resolveOsPrincipal } from '@moxxy/sdk/server';
 import { JsonRpcPeer } from './jsonrpc.js';
 import {
   makeProvidersView,
@@ -134,6 +136,13 @@ export interface RemoteSessionOptions {
    * ignores the option and replays in full, which is still correct.
    */
   readonly replay?: AttachReplay;
+  /**
+   * Identity this client acts on behalf of (protocol v11). Defaults to the
+   * local OS account, which is exactly what the 0600 unix socket already
+   * proves. A surface that authenticates its users (an HTTP or chat channel)
+   * passes the subject it verified instead.
+   */
+  readonly principal?: Principal;
   /** Inject a transport (tests). Defaults to a unix-socket connection. */
   readonly transport?: Transport;
   /**
@@ -353,13 +362,25 @@ export class RemoteSession implements ClientSession {
     return new Set(this.info?.readyProviders ?? []);
   }
 
-  /** Handshake. Resolves once history has been replayed into the mirror. */
-  async attach(role: string, sinceSeq: number, replay?: AttachReplay): Promise<void> {
+  /**
+   * Handshake. Resolves once history has been replayed into the mirror.
+   *
+   * `principal` (v11) is the identity this client acts on behalf of; the runner
+   * stamps it onto the events this connection causes. A pre-v11 runner ignores
+   * the key, so passing it is always safe.
+   */
+  async attach(
+    role: string,
+    sinceSeq: number,
+    replay?: AttachReplay,
+    principal?: Principal,
+  ): Promise<void> {
     const result = await this.peer.request<AttachResult>(RunnerMethod.Attach, {
       protocolVersion: RUNNER_PROTOCOL_VERSION,
       role,
       sinceSeq,
       ...(replay ? { replay } : {}),
+      ...(principal ? { principal } : {}),
     });
     this.info = result.info;
     // Record the server's protocol so version-gated methods can degrade
@@ -624,7 +645,16 @@ export async function connectRemoteSession(
     (await connectWithRetry(socketPath, opts.connectRetries ?? 5));
   const session = new RemoteSession(transport);
   try {
-    await session.attach(opts.role ?? 'client', opts.sinceSeq ?? 0, opts.replay);
+    // Default the identity to the local OS account: a thin client over the
+    // 0600 unix socket is by construction the same local user as the runner, so
+    // asserting it is a statement of fact rather than a claim to be verified.
+    // A caller with a stronger issuer (an authenticated channel) passes its own.
+    await session.attach(
+      opts.role ?? 'client',
+      opts.sinceSeq ?? 0,
+      opts.replay,
+      opts.principal ?? resolveOsPrincipal(),
+    );
     return session;
   } catch (err) {
     await maybeRecoverFromMismatch(err, socketPath, opts);

--- a/packages/runner/src/server.ts
+++ b/packages/runner/src/server.ts
@@ -11,6 +11,7 @@ import type {
   PermissionContext,
   PermissionDecision,
   PermissionResolver,
+  Principal,
   TurnId,
   UserPromptAttachment,
 } from '@moxxy/sdk';
@@ -76,6 +77,8 @@ interface ConnectedClient {
   attached: boolean;
   handlesPermission: boolean;
   handlesApproval: boolean;
+  /** Identity this connection asserted at attach (v11), if any. */
+  principal?: Principal;
   /** Turns this client started - aborted if it disconnects. */
   readonly turns: Set<TurnId>;
 }
@@ -272,6 +275,16 @@ export class RunnerServer {
     }
     client.role = params.role;
     client.attached = true;
+    // v11: attribute this connection's work. The session is shared, so the LAST
+    // attach wins for events that follow, which is correct for the common case
+    // (one client, or several clients that are the same local user over the
+    // 0600 socket) and is what makes a transcript say who ran a turn. Per-turn
+    // attribution for genuinely multi-user surfaces belongs to the channel that
+    // authenticates them, which can stamp `actor` on the events it emits.
+    if (params.principal) {
+      client.principal = params.principal;
+      this.session.setPrincipal(params.principal);
+    }
     // Replay per the client's `replay` policy (v6; default 'full'). The start
     // seq is announced via `replay.start` BEFORE the loop so the client can
     // rebase its (empty) mirror — its `ingest` accepts only the next-expected

--- a/packages/sdk/src/events.ts
+++ b/packages/sdk/src/events.ts
@@ -1,4 +1,5 @@
 import type { EventId, PluginId, SessionId, SkillId, ToolCallId, TurnId } from './ids.js';
+import type { Principal } from './principal.js';
 
 export type EventSource = 'user' | 'model' | 'tool' | 'plugin' | 'system' | 'compactor';
 
@@ -10,6 +11,23 @@ export interface EventBase {
   readonly turnId: TurnId;
   readonly causationId?: EventId;
   readonly source: EventSource;
+  /**
+   * Who the action was taken on behalf of. `source` is a CATEGORY (user, model,
+   * tool, …); this is the SUBJECT, and without it a transcript proves a machine
+   * did something rather than that a person did.
+   *
+   * Stamped on EVERY event, not only turn boundaries, and carrying the whole
+   * principal rather than a reference. That repeats ~55 bytes per event, which
+   * is small against an envelope that already carries three ULIDs, and it buys
+   * the property an audit sink needs: a single record is self-attributing, so
+   * shipping one line to a SIEM requires no fold and no join. This is the same
+   * trade CloudTrail and the Kubernetes audit log make.
+   *
+   * OPTIONAL because the log is append-only and persisted: sessions recorded
+   * before identity existed replay with no actor, and must keep replaying.
+   * Treat absent as "unattributed", never as an error.
+   */
+  readonly actor?: Principal;
 }
 
 export interface UserPromptAttachment {

--- a/packages/sdk/src/hooks.ts
+++ b/packages/sdk/src/hooks.ts
@@ -3,6 +3,7 @@ import type { EventLogReader } from './log.js';
 import type { PendingToolCall } from './permission.js';
 import type { ProviderRequest } from './provider.js';
 import type { SessionId, TurnId } from './ids.js';
+import type { Principal } from './principal.js';
 import type { ServiceRegistry } from './services.js';
 
 export interface AppContext {
@@ -10,6 +11,13 @@ export interface AppContext {
   readonly cwd: string;
   readonly log: EventLogReader;
   readonly env: Readonly<Record<string, string | undefined>>;
+  /**
+   * Who the session is attributed to, when the surface could establish it.
+   * This is what lets a policy or audit hook answer "who is asking" instead of
+   * only "what is being asked". Absent means unattributed: a hook that gates on
+   * identity must fail closed on `undefined` rather than assuming an admin.
+   */
+  readonly actor?: Principal;
   /**
    * Inter-plugin service registry — publish a service in `onInit` for sibling
    * plugins to consume in theirs. See {@link ServiceRegistry}.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -42,6 +42,11 @@ export type {
 
 export type { EventLogReader } from './log.js';
 
+// Identity. The type + pure helpers ride the main barrel; the OS resolver needs
+// `node:os` and is exported from `@moxxy/sdk/server`.
+export type { Principal } from './principal.js';
+export { samePrincipal, formatPrincipal } from './principal.js';
+
 export type {
   RunTurnOptions,
   SessionLogReader,

--- a/packages/sdk/src/principal-os.ts
+++ b/packages/sdk/src/principal-os.ts
@@ -1,0 +1,48 @@
+import { hostname, userInfo } from 'node:os';
+import type { Principal } from './principal.js';
+
+/**
+ * The local OS account, as a {@link Principal}.
+ *
+ * This is the FLOOR identity: it is what the TUI and other local surfaces
+ * attribute to when no stronger issuer (a channel token, an OIDC assertion) is
+ * available. Its trust is exactly the trust of local account separation, which
+ * is why {@link Principal.issuer} says `os` rather than pretending to more.
+ *
+ * The id is `user@host` because a bare username is ambiguous the moment
+ * transcripts from several machines reach one audit sink.
+ */
+export function resolveOsPrincipal(): Principal {
+  const user = safeUsername();
+  const host = safeHostname();
+  return {
+    id: host ? `${user}@${host}` : user,
+    kind: 'human',
+    issuer: 'os',
+    displayName: user,
+  };
+}
+
+/**
+ * `userInfo()` throws when the uid has no passwd entry, which happens in
+ * distroless containers and some CI images. An unattributed session is worse
+ * than a coarse one, so fall back rather than fail.
+ */
+function safeUsername(): string {
+  try {
+    const name = userInfo().username.trim();
+    if (name.length > 0) return name;
+  } catch {
+    /* fall through */
+  }
+  const fromEnv = (process.env.USER ?? process.env.USERNAME ?? '').trim();
+  return fromEnv.length > 0 ? fromEnv : 'unknown';
+}
+
+function safeHostname(): string {
+  try {
+    return hostname().trim();
+  } catch {
+    return '';
+  }
+}

--- a/packages/sdk/src/principal.test.ts
+++ b/packages/sdk/src/principal.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { formatPrincipal, samePrincipal, type Principal } from './principal.js';
+import { resolveOsPrincipal } from './principal-os.js';
+
+const alice: Principal = { id: 'alice', kind: 'human', issuer: 'os' };
+
+describe('samePrincipal', () => {
+  // An id is only unique inside its issuer's namespace. Collapsing that would
+  // let a weakly-issued identity impersonate a strongly-issued one of the same
+  // name, which is the whole reason `issuer` exists.
+  it('requires the issuer to match, not just the id', () => {
+    expect(samePrincipal(alice, { ...alice, issuer: 'oidc' })).toBe(false);
+    expect(samePrincipal(alice, { ...alice, displayName: 'Alice A.' })).toBe(true);
+  });
+
+  it('treats undefined as unattributed, not as a wildcard', () => {
+    expect(samePrincipal(undefined, alice)).toBe(false);
+    expect(samePrincipal(alice, undefined)).toBe(false);
+    expect(samePrincipal(undefined, undefined)).toBe(true);
+  });
+});
+
+describe('formatPrincipal', () => {
+  it('renders issuer:id, never the display name', () => {
+    expect(formatPrincipal({ ...alice, displayName: 'Alice A.' })).toBe('os:alice');
+  });
+
+  it('names the absent case explicitly', () => {
+    expect(formatPrincipal(undefined)).toBe('unattributed');
+  });
+});
+
+describe('resolveOsPrincipal', () => {
+  it('issues a human principal scoped to the host', () => {
+    const p = resolveOsPrincipal();
+    expect(p.kind).toBe('human');
+    expect(p.issuer).toBe('os');
+    expect(p.id.length).toBeGreaterThan(0);
+    expect(p.displayName).toBeTruthy();
+  });
+
+  // A bare username collides the moment transcripts from several machines land
+  // in one audit sink.
+  it('qualifies the id with the hostname', () => {
+    expect(resolveOsPrincipal().id).toContain('@');
+  });
+});

--- a/packages/sdk/src/principal.ts
+++ b/packages/sdk/src/principal.ts
@@ -1,0 +1,60 @@
+/**
+ * Who an action was taken on behalf of.
+ *
+ * Until this existed the event log recorded `source` (a CATEGORY: user, model,
+ * tool, plugin, system, compactor) but never a subject, so a transcript proved
+ * that a machine did something, not that a person did. That makes audit,
+ * role-based policy, and cost attribution impossible to build on top, and all
+ * three are table stakes for a shared or managed deployment.
+ *
+ * A `Principal` is deliberately small and provider-neutral: the identity blocks
+ * that will issue it (OS user, channel bearer token, OAuth/OIDC subject, a
+ * GitHub App installation) agree on this shape and nothing more.
+ */
+export interface Principal {
+  /**
+   * Stable identifier within {@link issuer}'s namespace. Only meaningful when
+   * paired with the issuer: `alice` from `os` and `alice` from `oidc` are not
+   * the same subject, so consumers comparing identities must compare both.
+   */
+  readonly id: string;
+  /**
+   * `human` when a person is behind the action, `service` for an unattended
+   * runner (a schedule, a webhook, a CI job). The distinction matters to policy:
+   * "a human approved this" is a different claim from "a daemon did it".
+   */
+  readonly kind: 'human' | 'service';
+  /**
+   * What vouched for the identity: `os`, `channel-token`, `oauth`, or the name
+   * of the plugin that resolved it. Records HOW MUCH the identity is worth. An
+   * `os` principal is only as trustworthy as local account separation; an
+   * `oidc` one carries a verified assertion.
+   */
+  readonly issuer: string;
+  /** Human-readable label for surfaces. Never used for comparison. */
+  readonly displayName?: string;
+  /**
+   * Additional verified attributes (email, groups, tenant). Kept flat and
+   * stringly-typed so it survives JSON round-trips through the event log and
+   * the runner wire protocol without a schema per issuer.
+   */
+  readonly claims?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Whether two principals denote the same subject. Compares issuer AND id: an id
+ * is only unique inside its issuer's namespace (see {@link Principal.id}).
+ */
+export function samePrincipal(a: Principal | undefined, b: Principal | undefined): boolean {
+  if (!a || !b) return a === b;
+  return a.issuer === b.issuer && a.id === b.id;
+}
+
+/**
+ * Compact `issuer:id` label for logs and status lines. Deliberately NOT the
+ * display name: an audit line has to be unambiguous, and display names are
+ * neither unique nor stable.
+ */
+export function formatPrincipal(principal: Principal | undefined): string {
+  return principal ? `${principal.issuer}:${principal.id}` : 'unattributed';
+}

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -26,6 +26,9 @@ export {
   PRIVATE_DIR_MODE,
   PRIVATE_FILE_MODE,
 } from './fs-utils.js';
+// The local OS account as a Principal (node:os). The type and its pure helpers
+// ride the main barrel.
+export { resolveOsPrincipal } from './principal-os.js';
 // Outbound proxy support for global `fetch` (dynamic `undici` import). Node-only.
 export {
   installEgressProxy,


### PR DESCRIPTION
Wave 3, and the one the rest of the enterprise work depends on. Stacked on #468 (which is stacked on #467).

Events carried `source` (a category: user, model, tool, …) but no subject, so a transcript proved a machine did something rather than that a person did. Audit, RBAC, and cost attribution all need the subject. I put this before the audit sink deliberately: retrofitting identity under a built audit trail is much more expensive than adding it first.

Two design calls worth arguing about:

**`actor` is optional.** The log is append-only and persisted. Sessions recorded before this exist on disk and must keep replaying, so absent has to mean "unattributed", never an error. Anything gating on identity fails closed on `undefined`.

**The full principal is stamped per event, not a reference resolved from a turn boundary.** That repeats ~55 bytes against an envelope already carrying three ULIDs. In exchange a single record is self-attributing, so an audit sink can ship one line to a SIEM with no fold and no join. CloudTrail and the k8s audit log make the same trade, and W5 is going to want exactly that property.

The CLI issues the local OS account as `os`. That is worth precisely what local account separation is worth and it says so, rather than dressing up as something stronger. An emitter-supplied `actor` beats the session default so a channel serving multiple users can attribute per event.

Protocol v11 is additive (`MIN_COMPATIBLE` stays at 1). The principal is bounded at the zod schema because it crosses a socket and lands verbatim in every persisted event, so an unbounded id or claims bag would let a client bloat the log. A thin client over the 0600 unix socket defaults to the OS account, which that socket already proves.

This is also the hook W13 (SSO/SAML GitHub) plugs into: an enterprise identity plugin supplies both the outbound credential and the `Principal` on the audit trail, so one sign-in answers both "can I reach it" and "who ran this".

Verified: full gate green (build, typecheck, lint 0 errors, check:deps 0 errors, all test tasks). New coverage for the issuer-scoped identity comparison, absent-stays-absent, emitter-over-session precedence, re-attribution applying only forward, and three runner integration tests over a real socket (explicit principal, OS default, oversized id rejected at the boundary).

One self-inflicted bug worth noting since it nearly produced a vacuous test: my first integration test called `await remote.runTurn(...)`, but `runTurn` is an async generator, so nothing ran and `actor` was undefined for the right reason by accident. Fixed to consume the stream.