### PR TITLE
feat(config): system scope, lockable settings, and consent for executable configs

### DIFF
--- a/.changeset/enterprise-config-authority.md
+++ b/.changeset/enterprise-config-authority.md
@@ -1,0 +1,13 @@
+---
+'@moxxy/cli': minor
+---
+
+Add a system config scope, lockable settings, and consent for executable project configs.
+
+There was no layer above the user's own config, so an organisation could not state "security.enabled is true and you may not turn it off". A system scope (`/etc/moxxy/config.yaml`, `%PROGRAMDATA%\moxxy\config.yaml`, or `$MOXXY_SYSTEM_CONFIG`) now loads first, and its `locked: [...]` dot-paths are stripped from the user, project, and explicit layers before merging. It is YAML only: an executable file there would run as whoever starts moxxy.
+
+`moxxy.config.ts` is code, executed with your full privileges before the permission engine, the vault, or any isolator exists, and the project search walks upward, so entering a cloned repository ran its config silently. Moxxy now asks first and records approval against the file's content, so an edit asks again. Non-interactive runs skip an unapproved file rather than executing unreviewed code; `moxxy config trust` pre-approves one for daemons and container images, and a system config can set `config.allowExecutable: false` to forbid them outright.
+
+New commands: `moxxy config trust [file]`, `moxxy config trust --list`, `moxxy config untrust <file>`.
+
+**Behaviour change:** a project `moxxy.config.ts` that used to load silently now requires one-time approval. YAML configs are unaffected.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,59 @@ Provider keys such as `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` are detected auto
 | `MOXXY_NO_CORE_UPDATE=1` | Disables registration of Tier 2 core self-update tools. |
 | `MOXXY_FIXTURES` | Selects `record`, `replay`, or `passthrough` provider fixture mode for tests. |
 
+## Scopes and precedence
+
+Configuration is merged from four layers, highest authority first:
+
+| Scope | Location | Notes |
+|---|---|---|
+| system | `/etc/moxxy/config.yaml`, `%PROGRAMDATA%\moxxy\config.yaml`, or `$MOXXY_SYSTEM_CONFIG` | Operator-managed. YAML only, and the only layer that can lock keys. |
+| user | `~/.moxxy/config.yaml` | |
+| project | `moxxy.config.yaml` (or `.ts`) found by walking up from the working directory | |
+| explicit | `--config <path>` | |
+
+The system layer is YAML only on purpose: an executable file there would run as whoever starts moxxy, so a misconfigured `/etc/moxxy` would become a privilege-escalation path.
+
+### Locking settings a user must not change
+
+A system config can pin dot-paths. Every listed path is stripped from the user, project, and explicit layers before merging, and the attempt is reported on stderr.
+
+```yaml
+# /etc/moxxy/config.yaml
+security:
+  enabled: true
+network:
+  proxy: http://proxy.corp.example:3128
+locked:
+  - security.enabled
+  - network.proxy
+```
+
+Locking a parent (`network`) pins the whole subtree, not just the leaves already present.
+
+### Executable project configs
+
+`moxxy.config.ts` (and `.js`/`.mjs`/`.cjs`) is code, executed with your full privileges before the permission engine, the vault, or any isolator exists. Because the search walks up from the working directory, entering a cloned repository used to run its config silently.
+
+Moxxy now asks before running one, and remembers the approval against the file's **content**, so editing it asks again:
+
+```sh
+moxxy config trust                 # approve ./moxxy.config.ts
+moxxy config trust path/to/cfg.ts  # approve a specific file
+moxxy config trust --list          # what has been approved
+moxxy config untrust <file>        # withdraw approval
+```
+
+A non-interactive run has nobody to ask, so it skips the file rather than executing unreviewed code. Pre-approve with `moxxy config trust` when provisioning a daemon or a container image. To forbid executable configs entirely on a managed host:
+
+```yaml
+# /etc/moxxy/config.yaml
+config:
+  allowExecutable: false
+```
+
+YAML configs are data and are never gated.
+
 ### Network egress
 
 Node's global `fetch` ignores proxy variables on its own, and every provider call goes through it. Moxxy installs a proxy dispatcher at startup so these take effect.

--- a/packages/cli/src/argv.ts
+++ b/packages/cli/src/argv.ts
@@ -29,6 +29,7 @@ const BOOLEAN_FLAGS: ReadonlySet<string> = new Set([
   'status',
   'background',
   'allow-scripts',
+  'list',
 ]);
 
 /**

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,4 +1,12 @@
-import { loadConfig, setConfigValue, type ConfigScope } from '@moxxy/config';
+import * as path from 'node:path';
+import {
+  listTrustedConfigs,
+  loadConfig,
+  setConfigValue,
+  trustConfig,
+  untrustConfig,
+  type ConfigScope,
+} from '@moxxy/config';
 import type { ParsedArgv } from '../argv.js';
 import { stringFlag } from '../argv-helpers.js';
 import { printError } from '../errors.js';
@@ -16,6 +24,9 @@ const HELP = formatHelp({
         ['get <path>', 'print the merged value at a dot-path (JSON)'],
         ['set <path> <value>', 'set a value (JSON-parsed; bare words stay strings)'],
         ['path', 'print which config files are in effect'],
+        ['trust [file]', 'approve an executable config so it may run (default: ./moxxy.config.ts)'],
+        ['trust --list', 'show approved executable configs'],
+        ['untrust <file>', 'withdraw approval'],
       ],
     },
     {
@@ -109,6 +120,18 @@ export async function runConfigCommand(argv: ParsedArgv): Promise<number> {
         return 1;
       }
     }
+    case 'trust':
+      return await runTrust(argv);
+    case 'untrust': {
+      const target = path.resolve(argv.positional[1] ?? 'moxxy.config.ts');
+      const removed = await untrustConfig(target);
+      process.stdout.write(
+        removed
+          ? `withdrew approval for ${target}\n`
+          : colors.dim(`no approval on file for ${target}\n`),
+      );
+      return 0;
+    }
     case 'path': {
       const { sources } = await loadConfig({ cwd: process.cwd() });
       if (sources.length === 0) {
@@ -124,5 +147,41 @@ export async function runConfigCommand(argv: ParsedArgv): Promise<number> {
     default:
       process.stdout.write(HELP);
       return sub ? 2 : 0;
+  }
+}
+
+/**
+ * Approve an executable config so the loader may run it.
+ *
+ * The counterpart to the interactive prompt, for hosts that have nobody to ask:
+ * a daemon, a container image, a provisioning script. Approval is recorded
+ * against the file's CONTENT, so editing it revokes the approval by
+ * construction.
+ */
+async function runTrust(argv: ParsedArgv): Promise<number> {
+  if (argv.flags.list === true) {
+    const entries = await listTrustedConfigs();
+    if (entries.length === 0) {
+      process.stdout.write(colors.dim('no executable configs approved\n'));
+      return 0;
+    }
+    for (const entry of entries) {
+      process.stdout.write(
+        `${entry.path}\n  ${colors.dim(`sha256 ${entry.sha256.slice(0, 16)}…  ${entry.trustedAt}`)}\n`,
+      );
+    }
+    return 0;
+  }
+  const target = path.resolve(argv.positional[1] ?? 'moxxy.config.ts');
+  try {
+    const hash = await trustConfig(target);
+    process.stdout.write(
+      `approved ${target}\n` +
+        colors.dim(`  sha256 ${hash.slice(0, 16)}…  editing the file will ask again\n`),
+    );
+    return 0;
+  } catch (err) {
+    printError(err instanceof Error ? err.message : String(err));
+    return 1;
   }
 }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -13,6 +13,7 @@ import type { ParsedArgv } from '../argv.js';
 import { setupSessionWithConfig } from '../setup.js';
 import { closeSession } from '../setup/close-session.js';
 import { embedderSelection } from '../setup/resolve-plugins-tree.js';
+import type { ConfigSource } from '../setup/load-config.js';
 import { resolveEgressSettings } from '../setup/egress.js';
 import type { RegistrationResult } from '../setup/register-plugins.js';
 import { resolveProviderCredentials } from '../provider-credentials.js';
@@ -94,7 +95,7 @@ export async function runDoctorCommand(argv: ParsedArgv): Promise<number> {
 interface DoctorChecksDeps {
   readonly session: Session;
   readonly config: MoxxyConfig;
-  readonly configSources: ReadonlyArray<{ scope: 'project' | 'user' | 'explicit'; path: string }>;
+  readonly configSources: ReadonlyArray<ConfigSource>;
   readonly vault: VaultStore;
   /** Undefined on a slim boot without the memory plugin installed. */
   readonly memory: MemoryStore | undefined;

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -23,6 +23,7 @@ import { buildSessionConfigApplier } from './config-applier.js';
 import { resolveOsPrincipal } from '@moxxy/sdk/server';
 import { loadRawConfig, resolveConfigPlaceholders } from './setup/load-config.js';
 import { applyEgressSettings } from './setup/egress.js';
+import { interactiveConfigTrustPrompt } from './setup/config-trust-prompt.js';
 import { selectEmbedder } from './setup/embedder.js';
 import { buildSession } from './setup/build-session.js';
 import { buildBuiltinsCore } from './setup/builtins.js';
@@ -62,10 +63,14 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
   const skipKeyPrompt = opts.skipKeyPrompt || opts.onProgress != null;
   const progress = opts.onProgress ?? ((): void => undefined);
 
+  // Executable project configs need consent before they run. A probe or any
+  // other non-interactive boot passes no prompt, and the loader then refuses to
+  // execute rather than silently running unreviewed code.
   const { rawConfig, sources } = await loadRawConfig({
     cwd: opts.cwd,
     configPath: opts.configPath,
     skipUser: opts.skipUserConfig,
+    trustPrompt: skipKeyPrompt ? undefined : interactiveConfigTrustPrompt(),
   });
   progress({ kind: 'config-loaded', sources: sources.length });
 

--- a/packages/cli/src/setup/config-trust-prompt.ts
+++ b/packages/cli/src/setup/config-trust-prompt.ts
@@ -1,0 +1,44 @@
+import * as readline from 'node:readline/promises';
+import type { ConfigTrustPrompt } from '@moxxy/config';
+import { colors } from '../colors.js';
+
+/**
+ * Interactive consent for executing an untrusted project config.
+ *
+ * `moxxy.config.{ts,js}` is code, executed with the user's full privileges
+ * before the permission engine, the vault, or any isolator exists, and the
+ * project search walks upward, so `git clone` + `cd` + `moxxy` used to run a
+ * stranger's code silently. This is the moment that stops.
+ *
+ * Returns null when there is nobody to ask (no TTY): the loader then refuses to
+ * execute the file rather than falling back to running it, and the operator
+ * pre-approves with `moxxy config trust`. Fail-closed is the only defensible
+ * default for arbitrary code execution.
+ */
+export function interactiveConfigTrustPrompt(): ConfigTrustPrompt | undefined {
+  if (!process.stdin.isTTY || !process.stderr.isTTY) return undefined;
+  return async ({ path, sha256 }) => {
+    // Prompt on stderr so a piped `moxxy -p "…" > out.txt` keeps stdout clean.
+    process.stderr.write(
+      '\n' +
+        colors.bold('This project wants to run code before moxxy starts.') +
+        '\n' +
+        `  ${path}\n` +
+        colors.dim(`  sha256 ${sha256.slice(0, 16)}…\n`) +
+        colors.dim('  Review it before approving. Approval is remembered for this exact\n') +
+        colors.dim('  content, so an edit will ask again.\n'),
+    );
+    const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+    try {
+      // `rl.question` never settles when stdin hits EOF mid-prompt, which would
+      // wedge boot. Race the close event and treat EOF as a refusal.
+      const answer = await Promise.race([
+        rl.question(`${colors.bold('Run it?')} [y/N] `),
+        new Promise<string>((resolve) => rl.once('close', () => resolve(''))),
+      ]);
+      return answer.trim().toLowerCase() === 'y';
+    } finally {
+      rl.close();
+    }
+  };
+}

--- a/packages/cli/src/setup/load-config.ts
+++ b/packages/cli/src/setup/load-config.ts
@@ -1,26 +1,39 @@
-import { loadConfig, type MoxxyConfig } from '@moxxy/config';
+import {
+  loadConfig,
+  type ConfigLoadScope,
+  type ConfigTrustPrompt,
+  type LockedOverride,
+  type MoxxyConfig,
+} from '@moxxy/config';
 import { containsPlaceholder, resolveValue, type VaultStore } from '@moxxy/plugin-vault';
 
 type InfoLogger = { info(msg: string, meta?: Record<string, unknown>): void };
 
-export type ConfigSource = { scope: 'project' | 'user' | 'explicit'; path: string };
+export type ConfigSource = { scope: ConfigLoadScope; path: string };
 
 export interface LoadedConfig {
   readonly rawConfig: MoxxyConfig;
   readonly sources: ReadonlyArray<ConfigSource>;
+  /** Locked dot-paths a lower layer tried to set and had stripped. */
+  readonly lockedOverrides: ReadonlyArray<LockedOverride>;
+  /** Executable configs found but not executed, with the reason. */
+  readonly skippedConfigs: ReadonlyArray<{ readonly path: string; readonly reason: string }>;
 }
 
 export async function loadRawConfig(opts: {
   cwd: string;
   configPath?: string | undefined;
   skipUser?: boolean | undefined;
+  /** Consent hook for an untrusted executable config; interactive surfaces only. */
+  trustPrompt?: ConfigTrustPrompt | undefined;
 }): Promise<LoadedConfig> {
-  const { config, sources } = await loadConfig({
+  const { config, sources, lockedOverrides, skipped } = await loadConfig({
     cwd: opts.cwd,
     explicitPath: opts.configPath,
     skipUser: opts.skipUser,
+    ...(opts.trustPrompt ? { trustPrompt: opts.trustPrompt } : {}),
   });
-  return { rawConfig: config, sources };
+  return { rawConfig: config, sources, lockedOverrides, skippedConfigs: skipped };
 }
 
 /** Resolve any `${vault:…}` placeholders against the user's open vault. */

--- a/packages/cli/src/setup/types.ts
+++ b/packages/cli/src/setup/types.ts
@@ -1,3 +1,4 @@
+import type { ConfigSource } from './load-config.js';
 import type { EventStoreSession, Session } from '@moxxy/core';
 import type { PermissionResolver } from '@moxxy/sdk';
 import type { MoxxyConfig } from '@moxxy/config';
@@ -98,7 +99,7 @@ export type BootStep =
 export interface SetupResult {
   readonly session: Session;
   readonly config: MoxxyConfig;
-  readonly configSources: ReadonlyArray<{ scope: 'project' | 'user' | 'explicit'; path: string }>;
+  readonly configSources: ReadonlyArray<ConfigSource>;
   readonly vault: VaultStore;
   /** The memory plugin's store ('memory' service); undefined on a slim boot without the plugin. */
   readonly memory: MemoryStore | undefined;

--- a/packages/config/src/config-trust.test.ts
+++ b/packages/config/src/config-trust.test.ts
@@ -1,0 +1,94 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  configTrustPath,
+  hashConfigFile,
+  isConfigTrusted,
+  listTrustedConfigs,
+  trustConfig,
+  untrustConfig,
+} from './config-trust.js';
+
+describe('config trust store', () => {
+  let home: string;
+  let project: string;
+  let configFile: string;
+  let prevHome: string | undefined;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'moxxy-trust-home-'));
+    project = await mkdtemp(join(tmpdir(), 'moxxy-trust-proj-'));
+    prevHome = process.env.MOXXY_HOME;
+    process.env.MOXXY_HOME = home;
+    configFile = join(project, 'moxxy.config.ts');
+    await writeFile(configFile, 'export default {}\n');
+  });
+
+  afterEach(async () => {
+    if (prevHome === undefined) delete process.env.MOXXY_HOME;
+    else process.env.MOXXY_HOME = prevHome;
+    await rm(home, { recursive: true, force: true });
+    await rm(project, { recursive: true, force: true });
+  });
+
+  it('starts untrusted', async () => {
+    expect(await isConfigTrusted(configFile)).toBe(false);
+  });
+
+  it('trusts a file and remembers it', async () => {
+    await trustConfig(configFile);
+    expect(await isConfigTrusted(configFile)).toBe(true);
+  });
+
+  // The whole point of hashing content: approval covers the file somebody read,
+  // so a later edit has to ask again. A path allow-list would silently
+  // re-authorize whatever gets written there.
+  it('revokes itself when the content changes', async () => {
+    await trustConfig(configFile);
+    await writeFile(configFile, 'export default { evil: true }\n');
+    expect(await isConfigTrusted(configFile)).toBe(false);
+  });
+
+  it('re-trusting supersedes the old hash rather than accumulating entries', async () => {
+    await trustConfig(configFile);
+    await writeFile(configFile, 'export default { v: 2 }\n');
+    await trustConfig(configFile);
+    const entries = await listTrustedConfigs();
+    expect(entries.filter((e) => e.path === configFile)).toHaveLength(1);
+    expect(await isConfigTrusted(configFile)).toBe(true);
+  });
+
+  it('untrust removes the approval and reports whether it did', async () => {
+    await trustConfig(configFile);
+    expect(await untrustConfig(configFile)).toBe(true);
+    expect(await isConfigTrusted(configFile)).toBe(false);
+    expect(await untrustConfig(configFile)).toBe(false);
+  });
+
+  it('refuses to trust a file it cannot read', async () => {
+    await expect(trustConfig(join(project, 'missing.ts'))).rejects.toThrow(/cannot read/);
+  });
+
+  // A store we cannot parse must read as "nothing is trusted", never as
+  // "everything is trusted".
+  it('treats a corrupt store as empty', async () => {
+    await trustConfig(configFile);
+    await writeFile(configTrustPath(), 'not json at all');
+    expect(await isConfigTrusted(configFile)).toBe(false);
+  });
+
+  it('hashes file content, and returns null for a missing file', async () => {
+    const hash = await hashConfigFile(configFile);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(await hashConfigFile(join(project, 'nope.ts'))).toBeNull();
+  });
+
+  it('stores the trust file owner-only', async () => {
+    if (process.platform === 'win32') return;
+    await trustConfig(configFile);
+    const { stat } = await import('node:fs/promises');
+    expect((await stat(configTrustPath())).mode & 0o777).toBe(0o600);
+  });
+});

--- a/packages/config/src/config-trust.ts
+++ b/packages/config/src/config-trust.ts
@@ -1,0 +1,127 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { moxxyPath, PRIVATE_FILE_MODE, writeFileAtomic } from '@moxxy/sdk/server';
+import { createMutex, type Mutex } from '@moxxy/sdk';
+
+/**
+ * Trust store for EXECUTABLE project configs.
+ *
+ * `moxxy.config.{ts,js,mjs,cjs}` is not data, it is code that the loader
+ * executes with the user's full privileges before the permission engine, the
+ * vault, or any isolator exists. Combined with the loader's upward walk, that
+ * means `git clone` + `cd` + `moxxy` runs a stranger's code. Developers clone
+ * untrusted repositories constantly, so this is the largest local-execution
+ * hole in the product.
+ *
+ * The fix is consent, keyed to CONTENT rather than to a path: what a user
+ * approved is the file they read, so editing it must ask again. Same model as
+ * `direnv allow` and VS Code's workspace trust, and for the same reason: a path
+ * allow-list silently re-authorizes whatever gets written there later.
+ *
+ * YAML configs are pure data and never pass through here.
+ */
+
+export interface TrustEntry {
+  readonly path: string;
+  /** SHA-256 of the file's bytes at the moment consent was given. */
+  readonly sha256: string;
+  readonly trustedAt: string;
+}
+
+interface TrustFile {
+  readonly version: 1;
+  readonly entries: ReadonlyArray<TrustEntry>;
+}
+
+const TRUST_VERSION = 1;
+
+export function configTrustPath(): string {
+  return moxxyPath('trusted-configs.json');
+}
+
+/** Content hash of a config file, or null when it cannot be read. */
+export async function hashConfigFile(filePath: string): Promise<string | null> {
+  try {
+    const bytes = await fs.readFile(filePath);
+    return createHash('sha256').update(bytes).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
+async function readTrustFile(): Promise<TrustFile> {
+  try {
+    const raw = await fs.readFile(configTrustPath(), 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      (parsed as TrustFile).version === TRUST_VERSION &&
+      Array.isArray((parsed as TrustFile).entries)
+    ) {
+      const entries = (parsed as TrustFile).entries.filter(
+        (e): e is TrustEntry =>
+          typeof e?.path === 'string' && typeof e?.sha256 === 'string' && e.sha256.length === 64,
+      );
+      return { version: TRUST_VERSION, entries };
+    }
+  } catch {
+    /* missing or malformed */
+  }
+  // A store we cannot parse must not be read as "everything is trusted".
+  return { version: TRUST_VERSION, entries: [] };
+}
+
+/**
+ * Whether this exact file CONTENT has been approved. An edited config returns
+ * false even though its path is on file, which is the point.
+ */
+export async function isConfigTrusted(filePath: string): Promise<boolean> {
+  const hash = await hashConfigFile(filePath);
+  if (!hash) return false;
+  const { entries } = await readTrustFile();
+  return entries.some((e) => e.path === filePath && e.sha256 === hash);
+}
+
+// Whole-file read-modify-write, so concurrent trusts would clobber each other.
+const trustMutex: Mutex = createMutex();
+
+/** Record consent for this file's current content. Returns the stored hash. */
+export async function trustConfig(filePath: string): Promise<string> {
+  const hash = await hashConfigFile(filePath);
+  if (!hash) throw new Error(`cannot read config to trust it: ${filePath}`);
+  await trustMutex.run(async () => {
+    const { entries } = await readTrustFile();
+    const next: TrustEntry[] = [
+      // One entry per path: a re-trust supersedes the hash we approved before.
+      ...entries.filter((e) => e.path !== filePath),
+      { path: filePath, sha256: hash, trustedAt: new Date().toISOString() },
+    ];
+    await writeFileAtomic(
+      configTrustPath(),
+      JSON.stringify({ version: TRUST_VERSION, entries: next }, null, 2) + '\n',
+      { mode: PRIVATE_FILE_MODE },
+    );
+  });
+  return hash;
+}
+
+/** Withdraw consent for a path. Returns whether anything was removed. */
+export async function untrustConfig(filePath: string): Promise<boolean> {
+  return await trustMutex.run(async () => {
+    const { entries } = await readTrustFile();
+    const next = entries.filter((e) => e.path !== filePath);
+    if (next.length === entries.length) return false;
+    await writeFileAtomic(
+      configTrustPath(),
+      JSON.stringify({ version: TRUST_VERSION, entries: next }, null, 2) + '\n',
+      { mode: PRIVATE_FILE_MODE },
+    );
+    return true;
+  });
+}
+
+/** Every recorded consent, for `moxxy config trust --list`. */
+export async function listTrustedConfigs(): Promise<ReadonlyArray<TrustEntry>> {
+  return (await readTrustFile()).entries;
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,5 +1,26 @@
 export { defineConfig } from './define.js';
-export { loadConfig, type LoadConfigOptions, type LoadedConfig } from './loader.js';
+export {
+  loadConfig,
+  type ConfigLoadScope,
+  type ConfigTrustPrompt,
+  type LoadConfigOptions,
+  type LoadedConfig,
+} from './loader.js';
+export {
+  configTrustPath,
+  hashConfigFile,
+  isConfigTrusted,
+  listTrustedConfigs,
+  trustConfig,
+  untrustConfig,
+  type TrustEntry,
+} from './config-trust.js';
+export {
+  lockedKeysOf,
+  stripLockedKeys,
+  systemConfigCandidates,
+  type LockedOverride,
+} from './system-scope.js';
 export { mergeConfigs } from './merge.js';
 export {
   buildConfigPlugin,

--- a/packages/config/src/loader.test.ts
+++ b/packages/config/src/loader.test.ts
@@ -4,6 +4,12 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { loadConfig } from './loader.js';
 
+// These cases exercise the EXECUTABLE-config loading machinery itself (jiti,
+// the ESM module-registry cache-buster, per-cwd resolution), so they stand in
+// for a user who already approved the file. Consent is covered separately in
+// the "executable-config consent" block below.
+const approve = async (): Promise<boolean> => true;
+
 let tmp: string;
 
 beforeEach(async () => {
@@ -15,7 +21,7 @@ afterEach(async () => {
 
 describe('loadConfig', () => {
   it('returns empty config when no file is found', async () => {
-    const result = await loadConfig({ cwd: tmp, skipUser: true });
+    const result = await loadConfig({ cwd: tmp, skipUser: true, trustPrompt: approve });
     expect(result.config).toEqual({});
     expect(result.sources).toEqual([]);
   });
@@ -25,7 +31,7 @@ describe('loadConfig', () => {
       path.join(tmp, 'moxxy.config.js'),
       `export default { plugins: { provider: { default: 'anthropic', items: { anthropic: { model: 'sonnet' } } } } };`,
     );
-    const result = await loadConfig({ cwd: tmp, skipUser: true });
+    const result = await loadConfig({ cwd: tmp, skipUser: true, trustPrompt: approve });
     expect(result.config.plugins?.provider?.default).toBe('anthropic');
     expect(result.config.plugins?.provider?.items?.anthropic?.model).toBe('sonnet');
     expect(result.sources[0]?.scope).toBe('project');
@@ -38,7 +44,7 @@ describe('loadConfig', () => {
       path.join(tmp, 'moxxy.config.js'),
       `export default { plugins: { mode: { default: 'default' } } };`,
     );
-    const result = await loadConfig({ cwd: nested, skipUser: true });
+    const result = await loadConfig({ cwd: nested, skipUser: true, trustPrompt: approve });
     expect(result.config.plugins?.mode?.default).toBe('default');
   });
 
@@ -49,7 +55,7 @@ describe('loadConfig', () => {
     );
     const custom = path.join(tmp, 'custom.config.js');
     await fs.writeFile(custom, `export default { plugins: { mode: { default: 'research' } } };`);
-    const result = await loadConfig({ cwd: tmp, explicitPath: custom, skipUser: true });
+    const result = await loadConfig({ cwd: tmp, explicitPath: custom, skipUser: true, trustPrompt: approve });
     expect(result.config.plugins?.mode?.default).toBe('research');
     expect(result.sources[0]?.scope).toBe('explicit');
   });
@@ -59,7 +65,7 @@ describe('loadConfig', () => {
       path.join(tmp, 'moxxy.config.js'),
       `export default { plugins: { provider: { default: 42 } } };`,
     );
-    await expect(loadConfig({ cwd: tmp, skipUser: true })).rejects.toThrow(/Invalid moxxy config/);
+    await expect(loadConfig({ cwd: tmp, skipUser: true, trustPrompt: approve })).rejects.toThrow(/Invalid moxxy config/);
   });
 
   it('rejects a config with no default export', async () => {
@@ -67,7 +73,7 @@ describe('loadConfig', () => {
       path.join(tmp, 'moxxy.config.js'),
       `export const config = {};`,
     );
-    await expect(loadConfig({ cwd: tmp, skipUser: true })).rejects.toThrow(/default-export/);
+    await expect(loadConfig({ cwd: tmp, skipUser: true, trustPrompt: approve })).rejects.toThrow(/default-export/);
   });
 
   it('reloads a rewritten .mjs config freshly even on rapid successive loads', async () => {
@@ -77,14 +83,14 @@ describe('loadConfig', () => {
     // stale cached module. Use .mjs so it goes through importJsConfig, not jiti.
     const file = path.join(tmp, 'moxxy.config.mjs');
     await fs.writeFile(file, `export default { plugins: { mode: { default: 'default' } } };`);
-    const first = await loadConfig({ cwd: tmp, skipUser: true });
+    const first = await loadConfig({ cwd: tmp, skipUser: true, trustPrompt: approve });
     expect(first.config.plugins?.mode?.default).toBe('default');
 
     await fs.writeFile(file, `export default { plugins: { mode: { default: 'goal' } } };`);
     // Two reloads with no delay between them (same-ms risk).
     const [a, b] = await Promise.all([
-      loadConfig({ cwd: tmp, skipUser: true }),
-      loadConfig({ cwd: tmp, skipUser: true }),
+      loadConfig({ cwd: tmp, skipUser: true, trustPrompt: approve }),
+      loadConfig({ cwd: tmp, skipUser: true, trustPrompt: approve }),
     ]);
     expect(a.config.plugins?.mode?.default).toBe('goal');
     expect(b.config.plugins?.mode?.default).toBe('goal');
@@ -109,8 +115,8 @@ describe('loadConfig', () => {
         `import { marker } from './marker';\nexport default { plugins: { provider: { default: 'x', items: { x: { model: marker } } } } };`,
       );
 
-      const a = await loadConfig({ cwd: dirA, skipUser: true });
-      const b = await loadConfig({ cwd: dirB, skipUser: true });
+      const a = await loadConfig({ cwd: dirA, skipUser: true, trustPrompt: approve });
+      const b = await loadConfig({ cwd: dirB, skipUser: true, trustPrompt: approve });
 
       expect(a.config.plugins?.provider?.items?.x?.model).toBe('from-A');
       expect(b.config.plugins?.provider?.items?.x?.model).toBe('from-B');
@@ -118,5 +124,150 @@ describe('loadConfig', () => {
       await fs.rm(dirA, { recursive: true, force: true });
       await fs.rm(dirB, { recursive: true, force: true });
     }
+  });
+});
+
+describe('system scope, locked keys, and executable-config consent', () => {
+  let home: string;
+  let project: string;
+  let sysDir: string;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(async () => {
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-sys-home-'));
+    project = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-sys-proj-'));
+    sysDir = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-sys-etc-'));
+    for (const k of ['MOXXY_HOME', 'MOXXY_SYSTEM_CONFIG']) saved[k] = process.env[k];
+    process.env.MOXXY_HOME = home;
+    delete process.env.MOXXY_SYSTEM_CONFIG;
+  });
+
+  afterEach(async () => {
+    for (const k of ['MOXXY_HOME', 'MOXXY_SYSTEM_CONFIG']) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    await Promise.all(
+      [home, project, sysDir].map((d) => fs.rm(d, { recursive: true, force: true })),
+    );
+  });
+
+  const writeSystem = async (yaml: string): Promise<string> => {
+    const p = path.join(sysDir, 'config.yaml');
+    await fs.writeFile(p, yaml);
+    process.env.MOXXY_SYSTEM_CONFIG = p;
+    return p;
+  };
+
+  it('loads the system scope and reports it as a source', async () => {
+    await writeSystem('maxIterations: 7\n');
+    const { config, sources } = await loadConfig({ cwd: project });
+    expect(config.maxIterations).toBe(7);
+    expect(sources.some((s) => s.scope === 'system')).toBe(true);
+  });
+
+  // The guarantee the whole scope exists for: a user cannot turn off what the
+  // operator pinned.
+  it('a locked key survives a user config trying to override it', async () => {
+    await writeSystem('security:\n  enabled: true\nlocked:\n  - security.enabled\n');
+    await fs.writeFile(path.join(home, 'config.yaml'), 'security:\n  enabled: false\n');
+
+    const warnings: string[] = [];
+    const { config, lockedOverrides } = await loadConfig({
+      cwd: project,
+      warn: (m) => warnings.push(m),
+    });
+
+    expect(config.security?.enabled).toBe(true);
+    expect(lockedOverrides).toEqual([{ key: 'security.enabled', scope: 'user' }]);
+    expect(warnings.join('\n')).toContain('security.enabled');
+  });
+
+  it('a locked key survives a project config too', async () => {
+    await writeSystem('network:\n  proxy: http://corp:3128\nlocked:\n  - network.proxy\n');
+    await fs.writeFile(path.join(project, 'moxxy.config.yaml'), 'network:\n  proxy: "off"\n');
+    const { config } = await loadConfig({ cwd: project, warn: () => {} });
+    expect(config.network?.proxy).toBe('http://corp:3128');
+  });
+
+  it('unlocked keys still merge normally from lower layers', async () => {
+    await writeSystem('security:\n  enabled: true\nlocked:\n  - security.enabled\n');
+    await fs.writeFile(path.join(home, 'config.yaml'), 'maxIterations: 42\n');
+    const { config } = await loadConfig({ cwd: project });
+    expect(config.maxIterations).toBe(42);
+    expect(config.security?.enabled).toBe(true);
+  });
+
+  // The hole this closes: cd into a cloned repo and its config executes.
+  it('refuses to execute an untrusted project config when nobody can be asked', async () => {
+    await fs.writeFile(
+      path.join(project, 'moxxy.config.ts'),
+      'export default { maxIterations: 99 }\n',
+    );
+    const warnings: string[] = [];
+    const { config, skipped } = await loadConfig({ cwd: project, warn: (m) => warnings.push(m) });
+
+    expect(config.maxIterations).toBeUndefined();
+    expect(skipped).toHaveLength(1);
+    expect(warnings.join('\n')).toContain('moxxy config trust');
+  });
+
+  it('executes it once approved through the prompt, and remembers the approval', async () => {
+    const cfgPath = path.join(project, 'moxxy.config.ts');
+    await fs.writeFile(cfgPath, 'export default { maxIterations: 99 }\n');
+
+    let asked = 0;
+    const first = await loadConfig({
+      cwd: project,
+      trustPrompt: async () => {
+        asked++;
+        return true;
+      },
+    });
+    expect(first.config.maxIterations).toBe(99);
+
+    // Second load must not ask again.
+    const second = await loadConfig({ cwd: project });
+    expect(second.config.maxIterations).toBe(99);
+    expect(asked).toBe(1);
+  });
+
+  it('a declined prompt skips the file rather than throwing', async () => {
+    await fs.writeFile(path.join(project, 'moxxy.config.ts'), 'export default { maxIterations: 99 }\n');
+    const { config, skipped } = await loadConfig({
+      cwd: project,
+      trustPrompt: async () => false,
+      warn: () => {},
+    });
+    expect(config.maxIterations).toBeUndefined();
+    expect(skipped[0]?.reason).toBe('not approved');
+  });
+
+  it('the system config can forbid executable configs outright', async () => {
+    await writeSystem('config:\n  allowExecutable: false\n');
+    await fs.writeFile(path.join(project, 'moxxy.config.ts'), 'export default { maxIterations: 99 }\n');
+    const { config, skipped } = await loadConfig({
+      cwd: project,
+      // Even an approving prompt must not get a say once policy says no.
+      trustPrompt: async () => true,
+      warn: () => {},
+    });
+    expect(config.maxIterations).toBeUndefined();
+    expect(skipped[0]?.reason).toContain('disabled by the system config');
+  });
+
+  // YAML is data, so it was never the risk and must not gain friction.
+  it('never gates a YAML project config', async () => {
+    await fs.writeFile(path.join(project, 'moxxy.config.yaml'), 'maxIterations: 12\n');
+    const { config, skipped } = await loadConfig({ cwd: project });
+    expect(config.maxIterations).toBe(12);
+    expect(skipped).toEqual([]);
+  });
+
+  it('skipSystem ignores the machine-wide layer', async () => {
+    await writeSystem('maxIterations: 7\n');
+    const { config, sources } = await loadConfig({ cwd: project, skipSystem: true });
+    expect(config.maxIterations).toBeUndefined();
+    expect(sources.some((s) => s.scope === 'system')).toBe(false);
   });
 });

--- a/packages/config/src/loader.ts
+++ b/packages/config/src/loader.ts
@@ -4,16 +4,51 @@ import { pathToFileURL } from 'node:url';
 import { moxxyHome } from '@moxxy/sdk/server';
 import { mergeConfigs } from './merge.js';
 import { moxxyConfigSchema, type MoxxyConfig } from './schema.js';
+import { hashConfigFile, isConfigTrusted, trustConfig } from './config-trust.js';
+import {
+  lockedKeysOf,
+  stripLockedKeys,
+  systemConfigCandidates,
+  type LockedOverride,
+} from './system-scope.js';
+
+/** Layers `loadConfig` reads, highest-authority first. Distinct from
+ *  config-writer's `ConfigScope`: the system layer is operator-managed and is
+ *  never a write target. */
+export type ConfigLoadScope = 'system' | 'project' | 'user' | 'explicit';
+
+/**
+ * Asked to approve executing a project config whose content has not been
+ * trusted before. Returning false (or omitting the callback) skips the file.
+ *
+ * Only wired on interactive surfaces. A headless run has nobody to ask, so it
+ * refuses rather than executing unreviewed code, and the operator pre-approves
+ * with `moxxy config trust`.
+ */
+export type ConfigTrustPrompt = (info: {
+  readonly path: string;
+  readonly sha256: string;
+}) => Promise<boolean>;
 
 export interface LoadConfigOptions {
   readonly cwd: string;
   readonly explicitPath?: string;
   readonly skipUser?: boolean;
+  /** Skip the machine-wide scope (tests, and `--no-system-config`). */
+  readonly skipSystem?: boolean;
+  /** Consent hook for an untrusted executable config. */
+  readonly trustPrompt?: ConfigTrustPrompt;
+  /** Where refusals and locked-key overrides are surfaced. Defaults to stderr. */
+  readonly warn?: (message: string) => void;
 }
 
 export interface LoadedConfig {
   readonly config: MoxxyConfig;
-  readonly sources: ReadonlyArray<{ scope: 'project' | 'user' | 'explicit'; path: string }>;
+  readonly sources: ReadonlyArray<{ scope: ConfigLoadScope; path: string }>;
+  /** Locked dot-paths a lower layer tried to set and had stripped. */
+  readonly lockedOverrides: ReadonlyArray<LockedOverride>;
+  /** Executable configs that were found but NOT executed, and why. */
+  readonly skipped: ReadonlyArray<{ readonly path: string; readonly reason: string }>;
 }
 
 const CONFIG_NAMES = [
@@ -38,58 +73,139 @@ const USER_CONFIG_NAMES = [
 export const MAX_CONFIG_SEARCH_DEPTH = 12;
 
 export async function loadConfig(opts: LoadConfigOptions): Promise<LoadedConfig> {
-  const sources: Array<{ scope: 'project' | 'user' | 'explicit'; path: string }> = [];
-  const configs: MoxxyConfig[] = [];
+  const sources: Array<{ scope: ConfigLoadScope; path: string }> = [];
+  const skipped: Array<{ path: string; reason: string }> = [];
+  const warn = opts.warn ?? ((m: string) => process.stderr.write(`[moxxy] ${m}\n`));
+
+  // The system scope loads FIRST and is the only layer allowed to lock keys.
+  // Everything below it is pruned against that list before merging.
+  let system: MoxxyConfig | undefined;
+  let systemPath: string | undefined;
+  if (!opts.skipSystem) {
+    systemPath = await findFirstExisting(systemConfigCandidates());
+    if (systemPath) {
+      system = await loadOne(systemPath);
+      sources.push({ scope: 'system', path: systemPath });
+    }
+  }
+  const locked = lockedKeysOf(system);
+  // A system config can forbid executing project configs outright, which is
+  // what a managed workstation wants: only data, never code.
+  const allowExecutable = system?.config?.allowExecutable ?? true;
+
+  const lower: Array<{ scope: ConfigLoadScope; path: string; config: MoxxyConfig }> = [];
 
   if (!opts.skipUser) {
     const userPath = await findFile(moxxyHome(), USER_CONFIG_NAMES);
     if (userPath) {
-      const cfg = await loadOne(userPath);
-      configs.push(cfg);
-      sources.push({ scope: 'user', path: userPath });
+      const loaded = await loadGuarded(userPath, { allowExecutable, opts, warn, skipped });
+      if (loaded) lower.push({ scope: 'user', path: userPath, config: loaded });
     }
   }
 
   if (opts.explicitPath) {
-    const cfg = await loadOne(opts.explicitPath);
-    configs.push(cfg);
-    sources.push({ scope: 'explicit', path: opts.explicitPath });
+    const loaded = await loadGuarded(opts.explicitPath, { allowExecutable, opts, warn, skipped });
+    if (loaded) lower.push({ scope: 'explicit', path: opts.explicitPath, config: loaded });
   } else {
     const projectPath = await findUpward(opts.cwd, CONFIG_NAMES);
     if (projectPath) {
-      warnIfAncestorExecutableConfig(projectPath, opts.cwd);
-      const cfg = await loadOne(projectPath);
-      configs.push(cfg);
-      sources.push({ scope: 'project', path: projectPath });
+      const loaded = await loadGuarded(projectPath, { allowExecutable, opts, warn, skipped });
+      if (loaded) lower.push({ scope: 'project', path: projectPath, config: loaded });
     }
   }
 
-  return { config: mergeConfigs(...configs), sources };
+  const lockedOverrides: LockedOverride[] = [];
+  const configs: MoxxyConfig[] = system ? [system] : [];
+  for (const layer of lower) {
+    const pruned = stripLockedKeys(layer.config, locked, layer.scope);
+    lockedOverrides.push(...pruned.overrides);
+    configs.push(pruned.config);
+    sources.push({ scope: layer.scope, path: layer.path });
+  }
+  for (const override of lockedOverrides) {
+    warn(
+      `ignoring ${override.scope} config override of "${override.key}": ` +
+        `locked by the system config${systemPath ? ` (${systemPath})` : ''}`,
+    );
+  }
+
+  return { config: mergeConfigs(...configs), sources, lockedOverrides, skipped };
 }
 
-const EXECUTABLE_CONFIG_EXTS = new Set(['.ts', '.tsx', '.js', '.mjs', '.cjs']);
-
-function isUnderDir(filePath: string, dir: string): boolean {
-  const rel = path.relative(path.resolve(dir), path.resolve(filePath));
-  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+interface GuardContext {
+  readonly allowExecutable: boolean;
+  readonly opts: LoadConfigOptions;
+  readonly warn: (message: string) => void;
+  readonly skipped: Array<{ path: string; reason: string }>;
 }
 
 /**
- * The project-config upward walk resolves and then EXECUTES the first matching
- * config above cwd. An ancestor (e.g. a shared home/temp parent or an untrusted
- * outer repo) can therefore plant a config whose code runs with full process
- * privileges. We keep the documented upward-walk behavior but surface the exact
- * absolute path on stderr before running an ancestor *executable* config, so the
- * operator can see what is about to execute. Non-executable YAML and at/under-cwd
- * configs are silent (no new trust boundary widened).
+ * Load a config, gating EXECUTABLE ones behind policy and consent.
+ *
+ * The loader resolves and then runs `.ts`/`.js` configs with full process
+ * privileges, before the permission engine, the vault, or any isolator exists.
+ * Because the project search also walks upward, `git clone` + `cd` + `moxxy`
+ * used to execute a stranger's code with no signal at all. Consent is keyed to
+ * file CONTENT, so editing a trusted config asks again: what was approved is
+ * the file somebody read.
+ *
+ * Returns undefined when the file was not executed, in which case the caller
+ * simply proceeds with the remaining layers. Refusing a layer is always safer
+ * than running unreviewed code, so every failure path here skips.
  */
-function warnIfAncestorExecutableConfig(filePath: string, cwd: string): void {
-  if (!EXECUTABLE_CONFIG_EXTS.has(path.extname(filePath))) return;
-  if (isUnderDir(filePath, cwd)) return;
-  console.warn(
-    `[moxxy] executing project config from an ancestor directory: ${path.resolve(filePath)}`,
-  );
+async function loadGuarded(
+  filePath: string,
+  ctx: GuardContext,
+): Promise<MoxxyConfig | undefined> {
+  if (!EXECUTABLE_CONFIG_EXTS.has(path.extname(filePath))) return await loadOne(filePath);
+
+  const resolved = path.resolve(filePath);
+  if (!ctx.allowExecutable) {
+    const reason = 'executable configs are disabled by the system config';
+    ctx.warn(`skipping ${resolved}: ${reason}`);
+    ctx.skipped.push({ path: resolved, reason });
+    return undefined;
+  }
+  if (await isConfigTrusted(resolved)) return await loadOne(filePath);
+
+  const sha256 = await hashConfigFile(resolved);
+  if (!sha256) {
+    const reason = 'cannot read the file to establish trust';
+    ctx.warn(`skipping ${resolved}: ${reason}`);
+    ctx.skipped.push({ path: resolved, reason });
+    return undefined;
+  }
+  if (ctx.opts.trustPrompt && (await ctx.opts.trustPrompt({ path: resolved, sha256 }))) {
+    await trustConfig(resolved);
+    return await loadOne(filePath);
+  }
+  // No prompt available means a headless run, which has nobody to ask. Refuse
+  // rather than execute unreviewed code; `moxxy config trust` pre-approves it.
+  const reason = ctx.opts.trustPrompt
+    ? 'not approved'
+    : 'untrusted executable config and no interactive prompt available; ' +
+      `approve it with \`moxxy config trust ${resolved}\``;
+  ctx.warn(`skipping ${resolved}: ${reason}`);
+  ctx.skipped.push({ path: resolved, reason });
+  return undefined;
 }
+
+async function findFirstExisting(candidates: ReadonlyArray<string>): Promise<string | undefined> {
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      /* try the next */
+    }
+  }
+  return undefined;
+}
+
+// Superseded the ancestor-only stderr warning that used to live here: consent
+// now gates EVERY executable config, at or above cwd, so a narrower warning for
+// the ancestor case would only add noise to a path that already asks.
+const EXECUTABLE_CONFIG_EXTS = new Set(['.ts', '.tsx', '.js', '.mjs', '.cjs']);
 
 async function loadOne(filePath: string): Promise<MoxxyConfig> {
   const ext = path.extname(filePath);

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -175,7 +175,29 @@ export const contextConfigSchema = z.object({
     .optional(),
 });
 
+/** Settings governing how config itself is loaded. */
+export const configLoadingSchema = z
+  .object({
+    /**
+     * Whether `moxxy.config.{ts,js,mjs,cjs}` may be EXECUTED. Those files are
+     * code, run with the user's full privileges before the permission engine or
+     * any isolator exists. Default true (with trust-on-first-use consent); a
+     * managed host sets false so only YAML data is ever loaded.
+     */
+    allowExecutable: z.boolean().optional(),
+  })
+  .strict();
+
 export const moxxyConfigSchema = z.object({
+  /**
+   * Dot-paths this layer pins, e.g. `['security.enabled', 'network.proxy']`.
+   * Honored ONLY from the system scope: every listed path is stripped from the
+   * user, project, and explicit layers before merging, so a managed setting
+   * cannot be turned off further down. Ignored anywhere else, since a user
+   * config locking keys against itself is meaningless.
+   */
+  locked: z.array(z.string()).optional(),
+  config: configLoadingSchema.optional(),
   /**
    * The unified plugins manifest — the single source of truth for what's
    * installed/enabled (`plugins.packages`) and the active default per category

--- a/packages/config/src/system-scope.test.ts
+++ b/packages/config/src/system-scope.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import type { MoxxyConfig } from './schema.js';
+import { lockedKeysOf, stripLockedKeys, systemConfigCandidates } from './system-scope.js';
+
+describe('systemConfigCandidates', () => {
+  it('honours an explicit override above the conventional paths', () => {
+    expect(systemConfigCandidates({ MOXXY_SYSTEM_CONFIG: '/opt/moxxy.yaml' }, 'linux')).toEqual([
+      '/opt/moxxy.yaml',
+    ]);
+  });
+
+  it('falls back to /etc on posix', () => {
+    expect(systemConfigCandidates({}, 'darwin')).toEqual([
+      '/etc/moxxy/config.yaml',
+      '/etc/moxxy/config.yml',
+    ]);
+  });
+
+  it('uses PROGRAMDATA on windows', () => {
+    const found = systemConfigCandidates({ PROGRAMDATA: 'C:\\ProgramData' }, 'win32');
+    expect(found[0]).toContain('moxxy');
+    expect(found).toHaveLength(2);
+  });
+
+  it('yields nothing on windows without PROGRAMDATA rather than guessing', () => {
+    expect(systemConfigCandidates({}, 'win32')).toEqual([]);
+  });
+});
+
+describe('lockedKeysOf', () => {
+  it('reads the declared dot-paths', () => {
+    const cfg = { locked: ['security.enabled', 'network.proxy'] } as MoxxyConfig;
+    expect(lockedKeysOf(cfg)).toEqual(['security.enabled', 'network.proxy']);
+  });
+
+  it('is empty for a config that declares none', () => {
+    expect(lockedKeysOf({} as MoxxyConfig)).toEqual([]);
+    expect(lockedKeysOf(undefined)).toEqual([]);
+  });
+
+  it('drops non-string entries', () => {
+    const cfg = { locked: ['ok', 42, ''] } as unknown as MoxxyConfig;
+    expect(lockedKeysOf(cfg)).toEqual(['ok']);
+  });
+});
+
+describe('stripLockedKeys', () => {
+  it('removes a locked leaf and reports the attempt', () => {
+    const user = { security: { enabled: false, strict: true } } as MoxxyConfig;
+    const { config, overrides } = stripLockedKeys(user, ['security.enabled'], 'user');
+    expect(config.security).toEqual({ strict: true });
+    expect(overrides).toEqual([{ key: 'security.enabled', scope: 'user' }]);
+  });
+
+  // Locking a whole subtree must take the siblings with it, otherwise a user
+  // layer keeps contributing under a parent the operator meant to pin whole.
+  it('removes a locked subtree entirely', () => {
+    const user = { network: { proxy: 'http://mine:1', noProxy: 'x' } } as MoxxyConfig;
+    const { config } = stripLockedKeys(user, ['network'], 'project');
+    expect(config.network).toBeUndefined();
+  });
+
+  it('prunes a parent left empty by the strip', () => {
+    const user = { security: { enabled: false } } as MoxxyConfig;
+    const { config } = stripLockedKeys(user, ['security.enabled'], 'user');
+    expect('security' in config).toBe(false);
+  });
+
+  it('reports nothing when the layer never set the locked key', () => {
+    const user = { maxIterations: 5 } as MoxxyConfig;
+    const { config, overrides } = stripLockedKeys(user, ['security.enabled'], 'user');
+    expect(overrides).toEqual([]);
+    expect(config).toEqual(user);
+  });
+
+  it('does not mutate its input', () => {
+    const user = { security: { enabled: false } } as MoxxyConfig;
+    stripLockedKeys(user, ['security.enabled'], 'user');
+    expect(user.security?.enabled).toBe(false);
+  });
+
+  it('is a no-op with no locked keys', () => {
+    const user = { security: { enabled: false } } as MoxxyConfig;
+    expect(stripLockedKeys(user, [], 'user').config).toBe(user);
+  });
+
+  // A missing intermediate must not throw the whole load.
+  it('tolerates a dot-path whose parent is absent or not an object', () => {
+    const user = { maxIterations: 5 } as MoxxyConfig;
+    expect(() => stripLockedKeys(user, ['a.b.c', 'maxIterations.deep'], 'user')).not.toThrow();
+  });
+});

--- a/packages/config/src/system-scope.ts
+++ b/packages/config/src/system-scope.ts
@@ -1,0 +1,122 @@
+import * as path from 'node:path';
+import type { MoxxyConfig } from './schema.js';
+
+/**
+ * The SYSTEM configuration scope: settings an operator installs on a machine
+ * that a user cannot override.
+ *
+ * Before this there was no layer above the user's own config, so an
+ * organisation could not state "security.enabled is true and you may not turn
+ * it off". Precedence also ran the wrong way for a managed host: a repo-local
+ * `moxxy.config.ts` beat the user's own settings, and nothing beat either.
+ *
+ * Resolution order (first hit wins):
+ *   1. `$MOXXY_SYSTEM_CONFIG`: an explicit path, for tests and for hosts whose
+ *      configuration management puts it somewhere else.
+ *   2. `/etc/moxxy/config.yaml` (POSIX) or `%PROGRAMDATA%\moxxy\config.yaml`
+ *      (Windows), the conventional location for machine-wide settings.
+ *
+ * YAML ONLY, deliberately. An executable system config would run as whoever
+ * starts moxxy, so a file that is writable by a non-admin (a mis-set
+ * `/etc/moxxy`) would become a straightforward privilege-escalation path. Data
+ * cannot do that.
+ */
+export function systemConfigCandidates(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+  platform: string = process.platform,
+): ReadonlyArray<string> {
+  const explicit = (env.MOXXY_SYSTEM_CONFIG ?? '').trim();
+  if (explicit.length > 0) return [explicit];
+  if (platform === 'win32') {
+    const base = env.PROGRAMDATA ?? env.ProgramData;
+    if (!base) return [];
+    return [
+      path.join(base, 'moxxy', 'config.yaml'),
+      path.join(base, 'moxxy', 'config.yml'),
+    ];
+  }
+  return ['/etc/moxxy/config.yaml', '/etc/moxxy/config.yml'];
+}
+
+/**
+ * Dot-path into a config object, e.g. `security.enabled`. Returns undefined for
+ * a path that does not resolve, without throwing on a missing intermediate.
+ */
+function getPath(obj: unknown, segments: ReadonlyArray<string>): unknown {
+  let cursor: unknown = obj;
+  for (const segment of segments) {
+    if (cursor === null || typeof cursor !== 'object') return undefined;
+    cursor = (cursor as Record<string, unknown>)[segment];
+  }
+  return cursor;
+}
+
+/** Whether a dot-path is present as an own property chain. */
+function hasPath(obj: unknown, segments: ReadonlyArray<string>): boolean {
+  let cursor: unknown = obj;
+  for (const segment of segments) {
+    if (cursor === null || typeof cursor !== 'object') return false;
+    if (!Object.prototype.hasOwnProperty.call(cursor, segment)) return false;
+    cursor = (cursor as Record<string, unknown>)[segment];
+  }
+  return true;
+}
+
+/** Remove a dot-path, pruning objects that become empty. */
+function deletePath(obj: Record<string, unknown>, segments: ReadonlyArray<string>): void {
+  const [head, ...rest] = segments;
+  if (head === undefined) return;
+  if (rest.length === 0) {
+    delete obj[head];
+    return;
+  }
+  const child = obj[head];
+  if (child === null || typeof child !== 'object' || Array.isArray(child)) return;
+  deletePath(child as Record<string, unknown>, rest);
+  if (Object.keys(child as Record<string, unknown>).length === 0) delete obj[head];
+}
+
+export interface LockedOverride {
+  /** The dot-path a lower layer tried to set. */
+  readonly key: string;
+  /** Which layer attempted it. */
+  readonly scope: string;
+}
+
+/**
+ * Strip every locked dot-path from a lower-precedence layer, returning the
+ * pruned copy plus what was removed.
+ *
+ * Stripping BEFORE the merge rather than re-asserting the system value after it
+ * is what makes the guarantee hold for nested objects: a later
+ * `mergeConfigs` pass deep-merges key by key, so re-asserting only the locked
+ * leaf would still let a user layer contribute siblings under the same parent
+ * that the operator meant to pin whole.
+ *
+ * Attempts are reported rather than silently dropped, so an operator can see a
+ * managed setting being fought and a user can see why their edit did nothing.
+ */
+export function stripLockedKeys(
+  config: MoxxyConfig,
+  locked: ReadonlyArray<string>,
+  scope: string,
+): { readonly config: MoxxyConfig; readonly overrides: ReadonlyArray<LockedOverride> } {
+  if (locked.length === 0) return { config, overrides: [] };
+  const clone = structuredClone(config) as Record<string, unknown>;
+  const overrides: LockedOverride[] = [];
+  for (const key of locked) {
+    const segments = key.split('.').filter((s) => s.length > 0);
+    if (segments.length === 0) continue;
+    if (!hasPath(clone, segments)) continue;
+    overrides.push({ key, scope });
+    deletePath(clone, segments);
+  }
+  return { config: clone as MoxxyConfig, overrides };
+}
+
+/** The locked dot-paths declared by a system config, if any. */
+export function lockedKeysOf(config: MoxxyConfig | undefined): ReadonlyArray<string> {
+  const value = getPath(config, ['locked']);
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === 'string' && v.length > 0);
+}


### PR DESCRIPTION
Wave 4, the last of the config-side P0 work. Stacked on #469 → #468 → #467.

Three related gaps in who decides what moxxy does.

**No authority above the user.** Nothing could pin a setting. Worse, precedence ran backwards for a managed host: a repo-local config beat the user's own settings, and nothing beat either. A system scope now loads first (`/etc/moxxy/config.yaml`, `%PROGRAMDATA%\moxxy\config.yaml`, `$MOXXY_SYSTEM_CONFIG`), YAML only. An executable file there would run as whoever starts moxxy, so a `/etc/moxxy` writable by a non-admin would become a straight privilege-escalation path.

**Locked keys are stripped, not re-asserted.** This matters and is easy to get wrong: `mergeConfigs` is a deep key-by-key walk, so re-asserting the system value after merging would still let a user layer contribute siblings under a parent the operator meant to pin whole. Stripping before the merge is what makes locking a subtree actually lock the subtree. Attempts are reported rather than silently dropped, so an operator sees a managed setting being fought and a user sees why their edit did nothing.

**Executable config consent.** `moxxy.config.ts` is code, run with full privileges before the permission engine, the vault, or any isolator exists, and the search walks upward, so `git clone` + `cd` + `moxxy` executed a stranger's code with no signal. Consent is keyed to file **content**, not path: what someone approved is the file they read, and a path allow-list would silently re-authorize whatever gets written there later. Same model as `direnv allow`.

Non-interactive runs skip an unapproved file rather than executing it. Fail-closed is the only defensible default for arbitrary code execution, and `moxxy config trust` covers daemons and container images.

**This is a behaviour change worth calling out in review:** a project `moxxy.config.ts` that used to load silently now needs one-time approval, and `docs/configuration.md` documents `.ts` as the primary form, so this will be visible. YAML is untouched. Seven existing loader tests failed on this and I gave them an explicit approving prompt rather than weakening the gate: their subject is the jiti / ESM-cache / per-cwd loading machinery, so they legitimately stand in for a user who already approved.

I also removed `warnIfAncestorExecutableConfig`. Consent now gates every executable config, so an ancestor-only warning is noise on a path that already asks.

Verified: full gate green (build, typecheck, lint 0 errors, check:deps 0 errors, all test tasks). 32 new tests across the trust store, locked-key stripping, and loader end-to-end.

One note on flakiness: mid-verification `cli setup/workflows.test.ts > "a fileChanged edit runs the workflow ONCE across two concurrent runners"` timed out under parallel load. I stashed this branch and reproduced the same failure on a clean baseline, so it is a pre-existing environment-sensitive flake, not a regression here. Probably worth its own look.