### PR TITLE
feat(audit): add a tamper-evident audit trail as a swappable block

### DIFF
--- a/.changeset/enterprise-audit-sink.md
+++ b/.changeset/enterprise-audit-sink.md
@@ -1,0 +1,16 @@
+---
+'@moxxy/cli': minor
+'@moxxy/sdk': minor
+---
+
+Add an audit trail: a tamper-evident record of what was done and for whom.
+
+`audit log` previously appeared in this codebase only in comments. What existed was the event log: the conversation, complete and local, with no retention, no export, no tamper evidence, and full of payloads nobody wants forwarded to a SIEM.
+
+`AuditSink` is a new swappable block, registered like every other, with a protected hash-chained local floor writing owner-only JSONL under `~/.moxxy/audit/`. Each record commits to its predecessor's hash, so removing or editing one breaks every hash after it. `moxxy security audit-log` verifies the chains and exits 1 on a break, so a scheduled compliance check can gate on it. Chaining is tamper-EVIDENT, not tamper-proof: it catches silent selective deletion, which is the realistic threat.
+
+Records are bounded and redacted at the projection boundary, so a single line is safe to forward. Prompt text is recorded only when `audit.includePromptText` is set; the SHA-256 always is, so a given prompt stays provable without the trail disclosing it. Tool inputs are redacted alongside a hash of the original.
+
+Off unless `audit.enabled` is set. A discovered plugin's sink is registered but never auto-activated: a sink's whole purpose is to send recorded actions elsewhere, so silent adoption would be an exfiltration path.
+
+Also new in `@moxxy/sdk`: `redactSecrets` / `redactSecretText`, which mask by value SHAPE as well as by field name, so a bearer token inside a Bash `command` is caught.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,31 @@ config:
 
 YAML configs are data and are never gated.
 
+### Audit trail
+
+Distinct from the event log. The event log is the conversation: complete, replayable, local. The audit trail is the receipt: bounded, redacted, hash-chained, and safe to forward off the machine.
+
+```yaml
+audit:
+  enabled: true          # off by default; a trail nobody asked for is a liability
+  sink: local            # the hash-chained floor; plugins can register others
+  includePromptText: false  # default: record only a prompt's length + SHA-256
+  retentionDays: 400
+```
+
+Records land in `~/.moxxy/audit/<YYYY-MM-DD>.jsonl`, owner-only. Each commits to the previous record's hash, so removing or editing one breaks every hash after it.
+
+```sh
+moxxy security audit-log               # verify every day's chain
+moxxy security audit-log 2026-07-27    # verify one day
+```
+
+Exit code 1 on a broken chain, so a scheduled check can gate on it.
+
+Chaining makes the trail tamper-**evident**, not tamper-proof: whoever can write the file can recompute the whole chain. It catches silent, selective deletion, which is the realistic threat. Genuine tamper-proofing needs the chain head somewhere the machine cannot rewrite, which is what a remote sink provides.
+
+Prompt text is not recorded by default. The SHA-256 always is, so a specific prompt can still be proven to be the audited one without the trail itself disclosing it. Tool inputs are recorded redacted, alongside a hash of the unredacted input.
+
 ### Network egress
 
 Node's global `fetch` ignores proxy variables on its own, and every provider call goes through it. Moxxy installs a proxy dispatcher at startup so these take effect.

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -70,7 +70,7 @@ export async function runDoctorCommand(argv: ParsedArgv): Promise<number> {
     return emit(checks, asJson);
   }
 
-  const { session, config, configSources, vault, memory, pluginRegistration, persistence } =
+  const { session, config, configSources, vault, memory, pluginRegistration, persistence, audit } =
     setupResult.value;
 
   try {
@@ -88,7 +88,7 @@ export async function runDoctorCommand(argv: ParsedArgv): Promise<number> {
   } finally {
     // Drain persistence + fire onShutdown hooks / stop the boot daemons so the
     // process exits promptly. Best-effort — never masks the doctor exit code.
-    await closeSession(session, persistence);
+    await closeSession(session, persistence, audit);
   }
 }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -43,7 +43,7 @@ export async function runInitCommand(argv: ParsedArgv): Promise<number> {
   // `passphrasePrompt` (TTY only) swaps the vault's bare readline prompt for
   // a @clack/prompts step, so the first-run passphrase reads as part of the
   // setup wizard rather than an unstyled prompt before it.
-  const { session, vault, config, persistence } = await bootSessionWithConfig(argv, {
+  const { session, vault, config, persistence, audit } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
     skipProviderActivation: true,
     ...(interactive ? { passphrasePrompt: promptVaultPassphrase } : {}),
@@ -61,7 +61,7 @@ export async function runInitCommand(argv: ParsedArgv): Promise<number> {
     }
     return await runInteractiveInit(session, vault, config);
   } finally {
-    await closeSession(session, persistence);
+    await closeSession(session, persistence, audit);
   }
 }
 

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -69,7 +69,7 @@ export async function runLoginCommand(argv: ParsedArgv): Promise<number> {
     // boot fails for any reason fall back to a generic help body.
     let session: Session | null = null;
     try {
-      const { session: s, persistence } = await bootSessionWithConfig(argv, {
+      const { session: s, persistence, audit } = await bootSessionWithConfig(argv, {
         skipKeyPrompt: true,
         skipProviderActivation: true,
         tolerateNoProvider: true,
@@ -80,7 +80,7 @@ export async function runLoginCommand(argv: ParsedArgv): Promise<number> {
       try {
         process.stdout.write(buildHelp(session));
       } finally {
-        await closeSession(s, persistence);
+        await closeSession(s, persistence, audit);
       }
       return sub ? 0 : 2;
     } catch {
@@ -105,7 +105,7 @@ function providerAuthConfig(
 }
 
 async function loginProvider(argv: ParsedArgv, providerName: string): Promise<number> {
-  const { session, vault, config, persistence } = await bootSessionWithConfig(argv, {
+  const { session, vault, config, persistence, audit } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
     skipProviderActivation: true,
     tolerateNoProvider: true,
@@ -113,7 +113,7 @@ async function loginProvider(argv: ParsedArgv, providerName: string): Promise<nu
   try {
     return await runLoginProvider(argv, providerName, session, vault, providerAuthConfig(config, providerName));
   } finally {
-    await closeSession(session, persistence);
+    await closeSession(session, persistence, audit);
   }
 }
 
@@ -198,7 +198,7 @@ export async function runLoginProvider(
 }
 
 async function loginStatus(argv: ParsedArgv): Promise<number> {
-  const { session, vault, config, persistence } = await bootSessionWithConfig(argv, {
+  const { session, vault, config, persistence, audit } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
     skipProviderActivation: true,
     tolerateNoProvider: true,
@@ -206,7 +206,7 @@ async function loginStatus(argv: ParsedArgv): Promise<number> {
   try {
     return await runLoginStatus(argv, session, vault, config);
   } finally {
-    await closeSession(session, persistence);
+    await closeSession(session, persistence, audit);
   }
 }
 
@@ -292,7 +292,7 @@ async function loginLogout(argv: ParsedArgv): Promise<number> {
     );
     return 2;
   }
-  const { session, vault, config, persistence } = await bootSessionWithConfig(argv, {
+  const { session, vault, config, persistence, audit } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
     skipProviderActivation: true,
     tolerateNoProvider: true,
@@ -300,7 +300,7 @@ async function loginLogout(argv: ParsedArgv): Promise<number> {
   try {
     return await runLoginLogout(providerName, session, vault, providerAuthConfig(config, providerName));
   } finally {
-    await closeSession(session, persistence);
+    await closeSession(session, persistence, audit);
   }
 }
 

--- a/packages/cli/src/commands/prompt.ts
+++ b/packages/cli/src/commands/prompt.ts
@@ -35,7 +35,7 @@ export async function runPromptCommand(argv: ParsedArgv): Promise<number> {
       ? createAllowListResolver(allowTools)
       : denyByDefaultResolver;
 
-  const { session, persistence } = await setupSessionWithConfig({
+  const { session, persistence, audit } = await setupSessionWithConfig({
     ...argvToSetupOptions(argv),
     resolver,
   });
@@ -77,7 +77,7 @@ export async function runPromptCommand(argv: ParsedArgv): Promise<number> {
     // Drain persistence (last event + final index row) then fire onShutdown
     // hooks / stop daemons so the process exits promptly. Best-effort — never
     // masks the command's exit code.
-    await closeSession(session, persistence);
+    await closeSession(session, persistence, audit);
   }
   return exitCode;
 }

--- a/packages/cli/src/commands/provision.ts
+++ b/packages/cli/src/commands/provision.ts
@@ -21,7 +21,7 @@ export async function runProvisionCommand(argv: ParsedArgv): Promise<number> {
     return 2;
   }
 
-  const { session, vault, persistence } = await bootSessionWithConfig(argv, {
+  const { session, vault, persistence, audit } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
     skipProviderActivation: true,
   });
@@ -57,7 +57,7 @@ export async function runProvisionCommand(argv: ParsedArgv): Promise<number> {
     process.stderr.write(`moxxy provision: ${err instanceof Error ? err.message : String(err)}\n`);
     return 1;
   } finally {
-    await closeSession(session, persistence);
+    await closeSession(session, persistence, audit);
   }
 }
 

--- a/packages/cli/src/commands/security.ts
+++ b/packages/cli/src/commands/security.ts
@@ -6,6 +6,7 @@ import { printError } from '../errors.js';
 import { colors } from '../colors.js';
 import { formatHelp } from './help-format.js';
 import type { AuditEntry } from '@moxxy/plugin-security';
+import { listAuditDays, verifyAuditDay } from '@moxxy/core';
 
 const HELP = formatHelp({
   title: 'moxxy security',
@@ -19,6 +20,8 @@ const HELP = formatHelp({
         ['audit --by-package', 'declared/total rollup per contributing plugin'],
         ['isolators', 'list available Isolator impls'],
         ['status', 'show enabled state, default isolator, and declaration/ratchet modes'],
+        ['audit-log', 'list days with an audit trail and verify each hash chain'],
+        ['audit-log <YYYY-MM-DD>', 'verify one day and print its record count + chain head'],
       ],
     },
   ],
@@ -30,6 +33,10 @@ export async function runSecurityCommand(argv: ParsedArgv): Promise<number> {
     process.stdout.write(HELP);
     return 0;
   }
+
+  // Reading the audit trail needs no session: the files are the source of
+  // truth, and booting one would append to the very trail being verified.
+  if (sub === 'audit-log') return await runAuditLog(argv);
 
   const { config, security } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,
@@ -240,4 +247,43 @@ function formatCapabilities(caps: Readonly<Record<string, unknown>> | undefined)
   if (env?.length) bits.push(`env(${env.length})`);
   if (typeof caps.timeMs === 'number') bits.push(`time:${caps.timeMs}ms`);
   return colors.dim(bits.join(' '));
+}
+
+/**
+ * Verify the local audit trail's hash chains.
+ *
+ * Chaining makes the trail tamper-EVIDENT, not tamper-proof: whoever can write
+ * the file can recompute the whole chain. What it catches is the realistic
+ * threat, silent selective deletion, and this command is how an operator
+ * actually checks. Exit code 1 on a broken chain so a cron job or a compliance
+ * check can gate on it.
+ */
+async function runAuditLog(argv: ParsedArgv): Promise<number> {
+  const requested = argv.positional[1];
+  const days = requested ? [requested] : await listAuditDays();
+  if (days.length === 0) {
+    process.stdout.write(
+      colors.dim('no audit trail found (enable it with `audit.enabled: true`)\n'),
+    );
+    return 0;
+  }
+
+  let broken = 0;
+  for (const day of days) {
+    const verdict = await verifyAuditDay(day);
+    if (verdict.ok) {
+      const head = verdict.head ? verdict.head.slice(0, 12) : '(empty)';
+      process.stdout.write(
+        `${colors.bold(day)}  ${String(verdict.count).padStart(6)} records  ` +
+          `${colors.dim(`head ${head}`)}\n`,
+      );
+      continue;
+    }
+    broken++;
+    process.stdout.write(
+      `${colors.bold(day)}  ${colors.red('CHAIN BROKEN')} at record ${verdict.brokenAt}\n` +
+        `  ${colors.dim(verdict.reason)}\n`,
+    );
+  }
+  return broken > 0 ? 1 : 0;
 }

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -44,6 +44,7 @@ import {
 } from './setup/resolve-plugins-tree.js';
 import { applySessionHeaderPreferences } from './setup/session-header-preferences.js';
 import { attachSessionPersistence } from './setup/persistence.js';
+import { attachAudit } from './setup/audit.js';
 import type { SetupOptions, SetupResult } from './setup/types.js';
 
 export type { BootStep, SetupOptions, SetupResult } from './setup/types.js';
@@ -299,6 +300,9 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
   progress({ kind: 'ready' });
 
   const persistence = attachSessionPersistence(session, opts.cwd, opts.disableSessionPersistence);
+  // Separate from persistence on purpose: the trail must survive an operator
+  // turning session persistence off, and it records a different, smaller thing.
+  const audit = attachAudit(session, config);
 
   // The memory plugin (when installed/enabled) published its store as the
   // 'memory' service during onInit; a slim boot without it leaves this
@@ -314,6 +318,7 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
     scheduler,
     webhooks,
     persistence,
+    audit,
     security,
     pluginRegistration,
   };

--- a/packages/cli/src/setup/audit.ts
+++ b/packages/cli/src/setup/audit.ts
@@ -1,0 +1,48 @@
+import {
+  attachAuditSink,
+  jsonlAuditSink,
+  pruneAuditDays,
+  type AuditHandle,
+  type Session,
+} from '@moxxy/core';
+import type { MoxxyConfig } from '@moxxy/config';
+
+/**
+ * Wire the audit trail for a session, when the operator asked for one.
+ *
+ * Off unless `audit.enabled` is set. An audit trail is a deliberate choice: it
+ * is another file holding sensitive material, and one nobody asked for is a
+ * liability rather than a control.
+ *
+ * Returns null when auditing is off, so callers can skip teardown entirely.
+ */
+export function attachAudit(session: Session, config: MoxxyConfig): AuditHandle | null {
+  const audit = config.audit;
+  if (!audit?.enabled) return null;
+
+  const name = audit.sink ?? jsonlAuditSink.name;
+  // Resolve through the session's registry so a plugin-provided sink (syslog,
+  // OTel, S3) is selectable by name exactly like every other block. Falling
+  // back to the floor rather than throwing keeps a typo from silently leaving
+  // an enabled trail unrecorded, and the floor is always present.
+  const sink = session.auditSinks.list().find((s) => s.name === name) ?? jsonlAuditSink;
+  if (sink.name !== name) {
+    session.logger.warn('audit sink not registered; using the local floor', {
+      requested: name,
+      using: sink.name,
+    });
+  }
+
+  const handle = attachAuditSink(session, sink, {
+    logger: session.logger,
+    ...(audit.includePromptText ? { includePromptText: true } : {}),
+  });
+
+  // Retention runs detached: pruning month-old files must not delay boot, and
+  // failing to prune is not a reason to refuse to audit.
+  if (audit.retentionDays !== undefined) {
+    void pruneAuditDays(audit.retentionDays).catch(() => {});
+  }
+
+  return handle;
+}

--- a/packages/cli/src/setup/close-session.ts
+++ b/packages/cli/src/setup/close-session.ts
@@ -1,4 +1,4 @@
-import type { EventStoreSession, Session } from '@moxxy/core';
+import type { AuditHandle, EventStoreSession, Session } from '@moxxy/core';
 
 /**
  * Cleanly tear down a one-shot CLI session so the process can exit promptly
@@ -31,6 +31,7 @@ import type { EventStoreSession, Session } from '@moxxy/core';
 export async function closeSession(
   session: Session,
   persistence?: EventStoreSession | null,
+  audit?: AuditHandle | null,
 ): Promise<void> {
   // Drain persistence FIRST so the last event + final index row are on disk
   // before the shutdown hook detaches the listener. Best-effort: a flush
@@ -39,5 +40,8 @@ export async function closeSession(
     await persistence.flush().catch(() => undefined);
     await persistence.settleWrites().catch(() => undefined);
   }
+  // Drain the audit queue too: writes are fire-and-forget so the turn is never
+  // blocked on the trail, which means the LAST record can still be in flight.
+  if (audit) await audit.close().catch(() => undefined);
   await session.close('cli-exit').catch(() => undefined);
 }

--- a/packages/cli/src/setup/types.ts
+++ b/packages/cli/src/setup/types.ts
@@ -1,4 +1,5 @@
 import type { ConfigSource } from './load-config.js';
+import type { AuditHandle } from '@moxxy/core';
 import type { EventStoreSession, Session } from '@moxxy/core';
 import type { PermissionResolver } from '@moxxy/sdk';
 import type { MoxxyConfig } from '@moxxy/config';
@@ -117,6 +118,8 @@ export interface SetupResult {
   };
   /** Active EventStore session handle. Null when `disableSessionPersistence` is set. */
   readonly persistence: EventStoreSession | null;
+  /** Audit-trail handle, or null when `audit.enabled` is off. */
+  readonly audit: AuditHandle | null;
   /** Security plugin handle. `audit()` lists every tool's isolation
    *  status; `registry` exposes the available `Isolator` impls. The
    *  plugin itself is a no-op until `security.enabled: true`. */

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -107,6 +107,30 @@ export const networkConfigSchema = z
   })
   .strict();
 
+/**
+ * The audit trail: a tamper-evident record of what was done and for whom,
+ * distinct from the event log (which is the conversation).
+ */
+export const auditConfigSchema = z
+  .object({
+    /** Off by default: an audit trail is a deliberate operator choice, and a
+     *  trail nobody asked for is just another file holding sensitive data. */
+    enabled: z.boolean().optional(),
+    /** Active sink name. Defaults to the protected local floor. */
+    sink: z.string().optional(),
+    /**
+     * Record prompt TEXT rather than only its length and SHA-256. Off by
+     * default: the trail proves what was done, and prompts carry business
+     * content that has no reason to leave the machine. The hash is recorded
+     * either way, so a given prompt can still be PROVEN to be the audited one.
+     */
+    includePromptText: z.boolean().optional(),
+    /** Delete local audit files older than this. Unset keeps them forever,
+     *  which is its own compliance problem. */
+    retentionDays: z.number().int().positive().optional(),
+  })
+  .strict();
+
 export const embeddingsConfigSchema = z.object({
   /**
    * 'tfidf' (default, zero deps) | 'openai' (text-embedding-3-*)
@@ -220,6 +244,7 @@ export const moxxyConfigSchema = z.object({
     .optional(),
   security: securityConfigSchema.optional(),
   network: networkConfigSchema.optional(),
+  audit: auditConfigSchema.optional(),
   channels: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
   permissions: permissionsConfigSchema.optional(),
   env: z.record(z.string(), z.string()).optional(),
@@ -253,6 +278,7 @@ export type ElisionConfig = z.infer<typeof elisionConfigSchema>;
 export type WatcherMode = z.infer<typeof watcherModeSchema>;
 export type PermissionsConfig = z.infer<typeof permissionsConfigSchema>;
 export type NetworkConfig = z.infer<typeof networkConfigSchema>;
+export type AuditConfig = z.infer<typeof auditConfigSchema>;
 export type EmbeddingsConfig = z.infer<typeof embeddingsConfigSchema>;
 export type SecurityConfig = z.infer<typeof securityConfigSchema>;
 

--- a/packages/core/src/audit/attach.ts
+++ b/packages/core/src/audit/attach.ts
@@ -1,0 +1,87 @@
+import type { AuditSinkDef, AuditSinkSession, MoxxyEvent } from '@moxxy/sdk';
+import type { Session } from '../session.js';
+import { createLogger, type Logger } from '../logger.js';
+import { projectAuditRecord, type AuditProjectionOptions } from './project.js';
+
+export interface AttachAuditOptions extends AuditProjectionOptions {
+  readonly logger?: Logger;
+}
+
+export interface AuditHandle {
+  /** Stop recording and flush. */
+  close(): Promise<void>;
+  /** True while writes are failing (the trail has a hole). */
+  readonly degraded: boolean;
+}
+
+/**
+ * Stream a session's auditable events into a sink.
+ *
+ * Deliberately a SEPARATE subscription from session persistence rather than a
+ * projection of it. The trail must survive an operator disabling session
+ * persistence, and it records a different, smaller thing: not the conversation,
+ * but who did what and whether it was allowed.
+ *
+ * Writes are fire-and-forget from the turn's perspective. Blocking a tool call
+ * on a slow audit sink would make the trail a liveness risk, and an agent that
+ * hangs because logging is slow is worse than one whose logging is behind. The
+ * queue below keeps records ORDERED despite that, which the hash chain requires.
+ */
+export function attachAuditSink(
+  session: Session,
+  sink: AuditSinkDef,
+  opts: AttachAuditOptions = {},
+): AuditHandle {
+  const logger = opts.logger ?? createLogger();
+  const sinkSession: AuditSinkSession = sink.open({ sessionId: session.id, cwd: session.cwd });
+
+  // Serialize writes: the chain is sequential, so overlapping appends would
+  // interleave positions. Also gives close() something to await.
+  let queue: Promise<void> = Promise.resolve();
+  let degraded = false;
+  let closed = false;
+
+  const unsubscribe = session.log.subscribe((event: MoxxyEvent) => {
+    if (closed) return;
+    const record = projectAuditRecord(event, opts);
+    if (!record) return;
+    queue = queue.then(async () => {
+      try {
+        const ok = await sinkSession.write(record);
+        if (!ok && !degraded) {
+          degraded = true;
+          // Warn ONCE per streak: an audit sink that fails usually keeps
+          // failing, and a warning per event would bury the turn's real output.
+          logger.warn('audit sink write failed; the trail has a gap', {
+            sink: sink.name,
+            sessionId: session.id,
+          });
+        } else if (ok && degraded) {
+          degraded = false;
+          logger.info('audit sink recovered', { sink: sink.name });
+        }
+      } catch (err) {
+        // A sink that throws violates its contract, but the turn must not care.
+        if (!degraded) {
+          degraded = true;
+          logger.warn('audit sink threw; the trail has a gap', {
+            sink: sink.name,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    });
+  });
+
+  return {
+    get degraded() {
+      return degraded;
+    },
+    close: async () => {
+      closed = true;
+      unsubscribe();
+      await queue;
+      await sinkSession.close();
+    },
+  };
+}

--- a/packages/core/src/audit/audit.test.ts
+++ b/packages/core/src/audit/audit.test.ts
@@ -1,0 +1,329 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { AuditRecord, MoxxyEvent, UnchainedAuditRecord } from '@moxxy/sdk';
+import { EventLog } from '../events/log.js';
+import { Session } from '../session.js';
+import { silentLogger } from '../logger.js';
+import { chainRecord, verifyChain } from './chain.js';
+import { projectAuditRecord } from './project.js';
+import {
+  appendAuditRecord,
+  auditDir,
+  jsonlAuditSink,
+  listAuditDays,
+  pruneAuditDays,
+  readAuditDay,
+  resetAuditHeadForTests,
+  verifyAuditDay,
+} from './jsonl-audit-sink.js';
+import { attachAuditSink } from './attach.js';
+
+const base = (over: Partial<UnchainedAuditRecord> = {}): UnchainedAuditRecord => ({
+  ts: 1_700_000_000_000,
+  sessionId: 's1' as never,
+  turnId: 't1' as never,
+  action: 'prompt',
+  eventType: 'user_prompt',
+  ...over,
+});
+
+describe('chainRecord / verifyChain', () => {
+  const chain = (n: number): AuditRecord[] => {
+    const out: AuditRecord[] = [];
+    let prev: string | null = null;
+    for (let i = 0; i < n; i++) {
+      const rec = chainRecord(base({ ts: 1_700_000_000_000 + i }), i, prev);
+      out.push(rec);
+      prev = rec.hash;
+    }
+    return out;
+  };
+
+  it('verifies an intact chain and reports its head', () => {
+    const records = chain(5);
+    const verdict = verifyChain(records);
+    expect(verdict.ok).toBe(true);
+    if (verdict.ok) {
+      expect(verdict.count).toBe(5);
+      expect(verdict.head).toBe(records[4]!.hash);
+    }
+  });
+
+  it('an empty chain is valid with a null head', () => {
+    const verdict = verifyChain([]);
+    expect(verdict).toEqual({ ok: true, count: 0, head: null });
+  });
+
+  // The realistic threat: someone quietly drops the one line recording what
+  // they did. Every later hash must stop matching.
+  it('detects a removed record', () => {
+    const records = chain(5);
+    const tampered = [...records.slice(0, 2), ...records.slice(3)];
+    const verdict = verifyChain(tampered);
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.brokenAt).toBe(2);
+  });
+
+  it('detects an altered record', () => {
+    const records = chain(3);
+    records[1] = { ...records[1]!, action: 'tool.result' };
+    const verdict = verifyChain(records);
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toContain('altered');
+  });
+
+  it('detects reordering', () => {
+    const records = chain(3);
+    const verdict = verifyChain([records[0]!, records[2]!, records[1]!]);
+    expect(verdict.ok).toBe(false);
+  });
+
+  // Two records with identical content but different key insertion order must
+  // hash identically, or verification breaks the moment one round-trips
+  // through a different serializer.
+  it('hashes independently of detail key order', () => {
+    const a = chainRecord(base({ detail: { alpha: 1, beta: 2 } }), 0, null);
+    const b = chainRecord(base({ detail: { beta: 2, alpha: 1 } }), 0, null);
+    expect(a.hash).toBe(b.hash);
+  });
+
+  it('a different actor produces a different hash', () => {
+    const a = chainRecord(base(), 0, null);
+    const b = chainRecord(
+      base({ actor: { id: 'alice', kind: 'human', issuer: 'os' } }),
+      0,
+      null,
+    );
+    expect(a.hash).not.toBe(b.hash);
+  });
+});
+
+describe('projectAuditRecord', () => {
+  const event = (over: Partial<MoxxyEvent>): MoxxyEvent =>
+    ({
+      id: 'e1',
+      seq: 0,
+      ts: 1,
+      sessionId: 's1',
+      turnId: 't1',
+      source: 'user',
+      ...over,
+    }) as MoxxyEvent;
+
+  it('skips conversation-only events', () => {
+    expect(projectAuditRecord(event({ type: 'assistant_chunk', text: 'hi' } as never))).toBeNull();
+    expect(projectAuditRecord(event({ type: 'provider_request' } as never))).toBeNull();
+  });
+
+  // A prompt's business content has no reason to leave the machine, but a
+  // specific prompt must still be provable against the trail.
+  it('records a prompt as length + hash, not text, by default', () => {
+    const rec = projectAuditRecord(event({ type: 'user_prompt', text: 'launch the missiles' } as never));
+    expect(rec?.detail?.chars).toBe(19);
+    expect(rec?.detail?.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(rec?.detail?.text).toBeUndefined();
+  });
+
+  it('records prompt text when the operator opts in, redacted', () => {
+    const rec = projectAuditRecord(
+      event({ type: 'user_prompt', text: 'use token ghp_ABCDEFGHIJKLMNOPQRST' } as never),
+      { includePromptText: true },
+    );
+    expect(rec?.detail?.text).toContain('[redacted]');
+    expect(rec?.detail?.text).not.toContain('ABCDEFGHIJKLMNOPQRST');
+  });
+
+  it('flags an ambient trigger, since no human typed it', () => {
+    const rec = projectAuditRecord(
+      event({
+        type: 'user_prompt',
+        text: 'go',
+        origin: { kind: 'webhook', name: 'deploy' },
+      } as never),
+    );
+    expect(rec?.detail?.origin).toBe('webhook:deploy');
+  });
+
+  // The carrier field is named `command`, so a key-name-only redactor prints
+  // the bearer token verbatim.
+  it('redacts secrets inside a tool input while keeping a provable hash', () => {
+    const rec = projectAuditRecord(
+      event({
+        type: 'tool_call_requested',
+        callId: 'c1',
+        name: 'bash',
+        input: { command: 'curl -H "Authorization: Bearer sk-ant-SECRETVALUE123456"' },
+      } as never),
+    );
+    expect(rec?.action).toBe('tool.request');
+    expect(String(rec?.detail?.input)).not.toContain('SECRETVALUE123456');
+    expect(String(rec?.detail?.input)).toContain('[redacted]');
+    expect(rec?.detail?.inputSha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('carries the actor through', () => {
+    const actor = { id: 'alice@host', kind: 'human', issuer: 'os' } as const;
+    const rec = projectAuditRecord(event({ type: 'user_prompt', text: 'x', actor } as never));
+    expect(rec?.actor).toEqual(actor);
+  });
+
+  it('records a denial with its reason', () => {
+    const rec = projectAuditRecord(
+      event({ type: 'tool_call_denied', callId: 'c1', decidedBy: 'policy', reason: 'blocked' } as never),
+    );
+    expect(rec?.action).toBe('tool.denied');
+    expect(rec?.detail?.reason).toBe('blocked');
+  });
+});
+
+describe('local audit sink', () => {
+  let home: string;
+  let prevHome: string | undefined;
+
+  beforeEach(async () => {
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-audit-'));
+    prevHome = process.env.MOXXY_HOME;
+    process.env.MOXXY_HOME = home;
+    resetAuditHeadForTests();
+  });
+
+  afterEach(async () => {
+    if (prevHome === undefined) delete process.env.MOXXY_HOME;
+    else process.env.MOXXY_HOME = prevHome;
+    resetAuditHeadForTests();
+    await fs.rm(home, { recursive: true, force: true });
+  });
+
+  const today = (): string => new Date().toISOString().slice(0, 10);
+
+  it('appends a verifiable chain', async () => {
+    for (let i = 0; i < 3; i++) expect(await appendAuditRecord(base())).toBe(true);
+    const verdict = await verifyAuditDay(today());
+    expect(verdict.ok).toBe(true);
+    expect(verdict.count).toBe(3);
+  });
+
+  it('writes the trail owner-only', async () => {
+    if (process.platform === 'win32') return;
+    await appendAuditRecord(base());
+    expect((await fs.stat(auditDir())).mode & 0o777).toBe(0o700);
+    const file = path.join(auditDir(), `${today()}.jsonl`);
+    expect((await fs.stat(file)).mode & 0o777).toBe(0o600);
+  });
+
+  // A restart (or a second moxxy process) must continue the day's chain rather
+  // than restarting at seq 0, which would look exactly like tampering.
+  it('resumes an existing day instead of forking the chain', async () => {
+    await appendAuditRecord(base());
+    await appendAuditRecord(base());
+    resetAuditHeadForTests();
+    await appendAuditRecord(base());
+
+    const records = await readAuditDay(today());
+    expect(records.map((r) => r.seq)).toEqual([0, 1, 2]);
+    expect(verifyChain(records).ok).toBe(true);
+  });
+
+  // The chain is sequential: two writers reading prevHash before either
+  // appends would both claim the same predecessor.
+  it('keeps the chain intact under concurrent appends', async () => {
+    await Promise.all(Array.from({ length: 20 }, () => appendAuditRecord(base())));
+    const verdict = await verifyAuditDay(today());
+    expect(verdict.ok).toBe(true);
+    expect(verdict.count).toBe(20);
+  });
+
+  it('a truncated final line does not stop the rest from being read', async () => {
+    await appendAuditRecord(base());
+    const file = path.join(auditDir(), `${today()}.jsonl`);
+    await fs.appendFile(file, '{"partial":', 'utf8');
+    expect((await readAuditDay(today())).length).toBe(1);
+  });
+
+  it('prunes days past the retention window and keeps the rest', async () => {
+    await appendAuditRecord(base());
+    const old = path.join(auditDir(), '2020-01-01.jsonl');
+    await fs.writeFile(old, '');
+    expect(await pruneAuditDays(30)).toEqual(['2020-01-01']);
+    expect(await listAuditDays()).toEqual([today()]);
+  });
+
+  it('treats a non-positive retention as "keep everything"', async () => {
+    await appendAuditRecord(base());
+    expect(await pruneAuditDays(0)).toEqual([]);
+    expect(await listAuditDays()).toHaveLength(1);
+  });
+});
+
+describe('attachAuditSink', () => {
+  let home: string;
+  let prevHome: string | undefined;
+
+  beforeEach(async () => {
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-audit-attach-'));
+    prevHome = process.env.MOXXY_HOME;
+    process.env.MOXXY_HOME = home;
+    resetAuditHeadForTests();
+  });
+  afterEach(async () => {
+    if (prevHome === undefined) delete process.env.MOXXY_HOME;
+    else process.env.MOXXY_HOME = prevHome;
+    resetAuditHeadForTests();
+    await fs.rm(home, { recursive: true, force: true });
+  });
+
+  it('records auditable events and ignores conversation', async () => {
+    const session = new Session({ cwd: '/tmp', logger: silentLogger, log: new EventLog() });
+    session.setPrincipal({ id: 'alice@host', kind: 'human', issuer: 'os' });
+    const handle = attachAuditSink(session, jsonlAuditSink, { logger: silentLogger });
+
+    await session.log.append({
+      type: 'user_prompt', sessionId: session.id, turnId: 't1' as never, source: 'user', text: 'hi',
+    });
+    await session.log.append({
+      type: 'assistant_chunk', sessionId: session.id, turnId: 't1' as never, source: 'model', text: 'yo',
+    } as never);
+    await handle.close();
+
+    const records = await readAuditDay(new Date().toISOString().slice(0, 10));
+    expect(records).toHaveLength(1);
+    expect(records[0]!.action).toBe('prompt');
+    expect(records[0]!.actor?.id).toBe('alice@host');
+  });
+
+  // A failing sink must degrade loudly, never take down the turn it records.
+  it('survives a sink that throws and reports itself degraded', async () => {
+    const session = new Session({ cwd: '/tmp', logger: silentLogger, log: new EventLog() });
+    const handle = attachAuditSink(
+      session,
+      {
+        name: 'exploding',
+        open: () => ({
+          write: () => Promise.reject(new Error('sink is down')),
+          close: async () => {},
+        }),
+      },
+      { logger: silentLogger },
+    );
+
+    await expect(
+      session.log.append({
+        type: 'user_prompt', sessionId: session.id, turnId: 't1' as never, source: 'user', text: 'hi',
+      }),
+    ).resolves.toBeDefined();
+    await handle.close();
+    expect(handle.degraded).toBe(true);
+  });
+
+  it('stops recording after close', async () => {
+    const session = new Session({ cwd: '/tmp', logger: silentLogger, log: new EventLog() });
+    const handle = attachAuditSink(session, jsonlAuditSink, { logger: silentLogger });
+    await handle.close();
+    await session.log.append({
+      type: 'user_prompt', sessionId: session.id, turnId: 't1' as never, source: 'user', text: 'after',
+    });
+    expect(await readAuditDay(new Date().toISOString().slice(0, 10))).toHaveLength(0);
+  });
+});

--- a/packages/core/src/audit/chain.ts
+++ b/packages/core/src/audit/chain.ts
@@ -1,0 +1,105 @@
+import { createHash } from 'node:crypto';
+import type { AuditRecord, UnchainedAuditRecord } from '@moxxy/sdk';
+
+/**
+ * Hash chaining, which is what makes the trail tamper-EVIDENT.
+ *
+ * A plain append-only file proves nothing: whoever can write it can rewrite it.
+ * Each record instead commits to its predecessor's hash, so removing or editing
+ * any record breaks every hash after it. That does not make the file
+ * tamper-PROOF (an attacker with write access can recompute the whole chain),
+ * and claiming otherwise would be dishonest. It makes silent, selective
+ * deletion detectable, which is the realistic threat: an operator or an agent
+ * quietly dropping the one line that recorded what they did.
+ *
+ * Genuine tamper-proofing needs the chain head published somewhere the local
+ * machine cannot rewrite, which is exactly what a remote sink provides. The
+ * local floor is the fallback, and it is honest about being one.
+ */
+
+/**
+ * Canonical serialization for hashing. Keys are emitted in a FIXED order rather
+ * than `JSON.stringify`'s insertion order, because two records with identical
+ * content but different key order must hash identically, or verification breaks
+ * the moment a record round-trips through a different serializer.
+ */
+function canonical(record: UnchainedAuditRecord, seq: number, prevHash: string | null): string {
+  return JSON.stringify([
+    seq,
+    record.ts,
+    record.sessionId,
+    record.turnId,
+    record.action,
+    record.eventType,
+    record.actor
+      ? [record.actor.issuer, record.actor.id, record.actor.kind]
+      : null,
+    // Detail is hashed via a stable key ordering too.
+    record.detail ? stableEntries(record.detail) : null,
+    prevHash,
+  ]);
+}
+
+function stableEntries(obj: Readonly<Record<string, unknown>>): Array<[string, unknown]> {
+  return Object.entries(obj)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => [k, v] as [string, unknown]);
+}
+
+/** Seal a record into the chain. */
+export function chainRecord(
+  record: UnchainedAuditRecord,
+  seq: number,
+  prevHash: string | null,
+): AuditRecord {
+  const hash = createHash('sha256').update(canonical(record, seq, prevHash)).digest('hex');
+  return { ...record, seq, prevHash, hash };
+}
+
+export type ChainVerdict =
+  | { readonly ok: true; readonly count: number; readonly head: string | null }
+  | {
+      readonly ok: false;
+      readonly count: number;
+      readonly brokenAt: number;
+      readonly reason: string;
+    };
+
+/**
+ * Verify a chain end to end. Reports the FIRST break rather than a list: after
+ * one broken link every later hash is unverifiable anyway, so enumerating them
+ * would be noise that hides where the damage starts.
+ */
+export function verifyChain(records: ReadonlyArray<AuditRecord>): ChainVerdict {
+  let prevHash: string | null = null;
+  for (let i = 0; i < records.length; i++) {
+    const record = records[i]!;
+    if (record.seq !== i) {
+      return {
+        ok: false,
+        count: records.length,
+        brokenAt: i,
+        reason: `expected seq ${i}, found ${record.seq} (records are missing or reordered)`,
+      };
+    }
+    if (record.prevHash !== prevHash) {
+      return {
+        ok: false,
+        count: records.length,
+        brokenAt: i,
+        reason: 'prevHash does not match the preceding record (a record was removed or altered)',
+      };
+    }
+    const expected: string = chainRecord(record, record.seq, record.prevHash).hash;
+    if (expected !== record.hash) {
+      return {
+        ok: false,
+        count: records.length,
+        brokenAt: i,
+        reason: 'record hash does not match its content (the record was altered)',
+      };
+    }
+    prevHash = record.hash;
+  }
+  return { ok: true, count: records.length, head: prevHash };
+}

--- a/packages/core/src/audit/jsonl-audit-sink.ts
+++ b/packages/core/src/audit/jsonl-audit-sink.ts
@@ -1,0 +1,184 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { ensurePrivateDir, ensurePrivateFile, moxxyPath } from '@moxxy/sdk/server';
+import {
+  defineAuditSink,
+  createMutex,
+  type AuditRecord,
+  type AuditSinkDef,
+  type AuditSinkSession,
+  type Mutex,
+  type UnchainedAuditRecord,
+} from '@moxxy/sdk';
+import { chainRecord, verifyChain, type ChainVerdict } from './chain.js';
+
+/**
+ * The protected local floor: one hash-chained JSONL per day under
+ * `~/.moxxy/audit/`.
+ *
+ * Daily files rather than per-session, because an auditor asks "what happened
+ * on the 14th", not "what happened in session 01J…". It also means the chain
+ * spans every session on that day, so deleting a whole session's records still
+ * breaks the chain.
+ *
+ * A local file can be rewritten wholesale by whoever can write it, so this is
+ * tamper-EVIDENT, not tamper-proof. It is the fallback for a machine with no
+ * remote sink configured, and it says so rather than overclaiming.
+ */
+
+export function auditDir(): string {
+  return moxxyPath('audit');
+}
+
+/** UTC day key, so records do not reshuffle across a DST boundary or when a
+ *  fleet spans time zones. */
+function dayKey(ts: number): string {
+  return new Date(ts).toISOString().slice(0, 10);
+}
+
+export function auditFileFor(ts: number): string {
+  return path.join(auditDir(), `${dayKey(ts)}.jsonl`);
+}
+
+/**
+ * Read one day's records. Malformed lines are SKIPPED rather than throwing, so
+ * a truncated final line (the process died mid-write) still lets the rest
+ * verify; the resulting seq gap is itself reported by {@link verifyChain}.
+ */
+export async function readAuditDay(day: string): Promise<AuditRecord[]> {
+  const file = path.join(auditDir(), `${day}.jsonl`);
+  let raw: string;
+  try {
+    raw = await fs.readFile(file, 'utf8');
+  } catch {
+    return [];
+  }
+  const out: AuditRecord[] = [];
+  for (const line of raw.split('\n')) {
+    if (line.trim().length === 0) continue;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (parsed && typeof parsed === 'object' && typeof (parsed as AuditRecord).hash === 'string') {
+        out.push(parsed as AuditRecord);
+      }
+    } catch {
+      /* truncated or corrupt line: the seq gap surfaces during verification */
+    }
+  }
+  return out;
+}
+
+/** Every day that has an audit file, oldest first. */
+export async function listAuditDays(): Promise<string[]> {
+  try {
+    const names = await fs.readdir(auditDir());
+    return names
+      .filter((n) => /^\d{4}-\d{2}-\d{2}\.jsonl$/.test(n))
+      .map((n) => n.slice(0, 10))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/** Verify one day's chain. */
+export async function verifyAuditDay(day: string): Promise<ChainVerdict> {
+  return verifyChain(await readAuditDay(day));
+}
+
+/**
+ * Drop audit files older than `retentionDays`. Returns the days removed.
+ * Retention is a policy decision the operator makes; keeping everything forever
+ * is its own compliance problem.
+ */
+export async function pruneAuditDays(retentionDays: number, now = Date.now()): Promise<string[]> {
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) return [];
+  const cutoff = dayKey(now - retentionDays * 24 * 60 * 60 * 1000);
+  const removed: string[] = [];
+  for (const day of await listAuditDays()) {
+    if (day >= cutoff) continue;
+    try {
+      await fs.rm(path.join(auditDir(), `${day}.jsonl`));
+      removed.push(day);
+    } catch {
+      /* best-effort */
+    }
+  }
+  return removed;
+}
+
+/**
+ * Appends are serialized per process. The chain is inherently sequential (each
+ * record commits to the previous hash), so two concurrent writers computing
+ * `prevHash` from the same snapshot would both claim the same predecessor and
+ * fork the chain.
+ */
+const writeMutex: Mutex = createMutex();
+
+/**
+ * Chain state, cached per day file so a busy session does not re-read the whole
+ * file per record. Rebuilt when the day rolls over.
+ */
+interface ChainHead {
+  readonly file: string;
+  seq: number;
+  hash: string | null;
+}
+
+let head: ChainHead | null = null;
+
+async function loadHead(file: string): Promise<ChainHead> {
+  if (head && head.file === file) return head;
+  // Resuming an existing day (a second moxxy process, or a restart) must
+  // continue that chain rather than starting a new one at seq 0.
+  const day = path.basename(file, '.jsonl');
+  const existing = await readAuditDay(day);
+  const last = existing[existing.length - 1];
+  head = { file, seq: last ? last.seq + 1 : 0, hash: last ? last.hash : null };
+  return head;
+}
+
+/** Test seam: forget the cached chain head. */
+export function resetAuditHeadForTests(): void {
+  head = null;
+}
+
+/**
+ * Seal a record at the next chain position and append it, all under ONE lock
+ * acquisition. Reserving the position and writing must be atomic: two writers
+ * that both read `prevHash` before either appends would commit to the same
+ * predecessor and fork the chain.
+ */
+export async function appendAuditRecord(record: UnchainedAuditRecord): Promise<boolean> {
+  return await writeMutex.run(async () => {
+    try {
+      await ensurePrivateDir(auditDir());
+      const file = auditFileFor(Date.now());
+      const current = await loadHead(file);
+      const sealed = chainRecord(record, current.seq, current.hash);
+      await ensurePrivateFile(file);
+      await fs.appendFile(file, JSON.stringify(sealed) + '\n', 'utf8');
+      current.seq += 1;
+      current.hash = sealed.hash;
+      return true;
+    } catch {
+      // Never throw into the turn being audited. Drop the cached head so the
+      // next attempt re-reads from disk instead of chaining onto a position
+      // that may not have been written; the caller reports the degradation.
+      head = null;
+      return false;
+    }
+  });
+}
+
+/** The floor sink: local, hash-chained, owner-only. */
+export const jsonlAuditSink: AuditSinkDef = defineAuditSink({
+  name: 'local',
+  description: 'hash-chained JSONL under ~/.moxxy/audit (tamper-evident, local only)',
+  open(): AuditSinkSession {
+    return {
+      write: (record) => appendAuditRecord(record),
+      close: async () => {},
+    };
+  },
+});

--- a/packages/core/src/audit/project.ts
+++ b/packages/core/src/audit/project.ts
@@ -1,0 +1,131 @@
+import { createHash } from 'node:crypto';
+import {
+  auditActionOf,
+  redactSecrets,
+  redactSecretText,
+  type MoxxyEvent,
+  type UnchainedAuditRecord,
+} from '@moxxy/sdk';
+
+/** How much redacted detail a record may carry. An audit trail is read by
+ *  humans and shipped to a SIEM, so a single record must stay small even when
+ *  the underlying tool input is a megabyte of file content. */
+const MAX_DETAIL_CHARS = 512;
+
+export interface AuditProjectionOptions {
+  /**
+   * Record prompt TEXT, not just its length and hash. Off by default: the
+   * trail's job is to prove what was done, and prompts routinely contain
+   * business content that has no business leaving the machine. The hash is
+   * still recorded either way, so a specific prompt can be PROVEN to be the one
+   * audited without the trail itself disclosing it.
+   */
+  readonly includePromptText?: boolean;
+}
+
+/**
+ * Project an event onto an audit record, or null when the event is
+ * conversation rather than something an auditor reviews.
+ *
+ * Everything that survives here is metadata or redacted, so the result is safe
+ * to forward off the machine without a second sanitising pass at the sink.
+ */
+export function projectAuditRecord(
+  event: MoxxyEvent,
+  opts: AuditProjectionOptions = {},
+): UnchainedAuditRecord | null {
+  const action = auditActionOf(event);
+  if (!action) return null;
+
+  const base = {
+    ts: event.ts,
+    sessionId: event.sessionId,
+    turnId: event.turnId,
+    action,
+    eventType: event.type,
+    ...(event.actor ? { actor: event.actor } : {}),
+  } as const;
+
+  const detail = detailOf(event, opts);
+  return detail ? { ...base, detail } : base;
+}
+
+function detailOf(
+  event: MoxxyEvent,
+  opts: AuditProjectionOptions,
+): Readonly<Record<string, unknown>> | undefined {
+  switch (event.type) {
+    case 'user_prompt':
+      return {
+        chars: event.text.length,
+        sha256: sha256(event.text),
+        ...(event.attachments?.length ? { attachments: event.attachments.length } : {}),
+        // An ambient trigger (webhook, schedule, workflow) means no human typed
+        // this, which is exactly the kind of thing an auditor is looking for.
+        ...(event.origin ? { origin: `${event.origin.kind}:${event.origin.name}` } : {}),
+        ...(opts.includePromptText ? { text: cap(redactSecretText(event.text)) } : {}),
+      };
+    case 'tool_call_requested':
+      return {
+        callId: event.callId,
+        tool: event.name,
+        // Both: the preview is what a human reads, the hash is what proves the
+        // input was not something else.
+        inputSha256: sha256(stableStringify(event.input)),
+        input: cap(stableStringify(redactSecrets(event.input))),
+        ...(event.skillContext ? { skill: event.skillContext } : {}),
+      };
+    case 'tool_call_approved':
+      return { callId: event.callId, decidedBy: event.decidedBy, mode: event.mode };
+    case 'tool_call_denied':
+      return { callId: event.callId, decidedBy: event.decidedBy, reason: cap(event.reason) };
+    case 'tool_result':
+      return {
+        callId: event.callId,
+        ok: event.ok,
+        ...(event.error ? { errorKind: event.error.kind, error: cap(event.error.message) } : {}),
+      };
+    case 'skill_invoked':
+      return { skill: event.name, reason: event.reason };
+    case 'skill_created':
+      // A skill the agent wrote for itself is durable new capability, so the
+      // path and scope matter more than the prompt that produced it.
+      return { skill: event.name, scope: event.scope, path: event.path };
+    case 'plugin_registered':
+    case 'plugin_unregistered':
+      return { plugin: event.pluginId };
+    case 'error':
+      return { message: cap(redactSecretText(event.message)) };
+    default:
+      return undefined;
+  }
+}
+
+function sha256(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+function cap(text: string): string {
+  return text.length <= MAX_DETAIL_CHARS ? text : `${text.slice(0, MAX_DETAIL_CHARS)}…`;
+}
+
+/**
+ * Deterministic JSON for hashing tool input: object keys are emitted sorted, so
+ * two structurally identical inputs hash the same regardless of key order.
+ * Falls back to a marker for values JSON cannot represent (cycles, BigInt)
+ * rather than throwing inside the audit path.
+ */
+function stableStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, (_key, v: unknown) => {
+      if (v === null || typeof v !== 'object' || Array.isArray(v)) return v;
+      return Object.fromEntries(
+        Object.entries(v as Record<string, unknown>).sort(([a], [b]) =>
+          a < b ? -1 : a > b ? 1 : 0,
+        ),
+      );
+    }) ?? 'undefined';
+  } catch {
+    return '[unserializable]';
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -125,3 +125,20 @@ export {
   createAllowListResolver,
 } from './permissions/resolvers.js';
 export { createLogger, silentLogger, type Logger, type LogLevel } from './logger.js';
+
+// Audit trail (see packages/core/src/audit).
+export { attachAuditSink, type AttachAuditOptions, type AuditHandle } from './audit/attach.js';
+export { chainRecord, verifyChain, type ChainVerdict } from './audit/chain.js';
+export { projectAuditRecord, type AuditProjectionOptions } from './audit/project.js';
+export {
+  auditDir,
+  auditFileFor,
+  appendAuditRecord,
+  jsonlAuditSink,
+  listAuditDays,
+  pruneAuditDays,
+  readAuditDay,
+  resetAuditHeadForTests,
+  verifyAuditDay,
+} from './audit/jsonl-audit-sink.js';
+export { AuditSinkRegistry } from './registries/audit-sinks.js';

--- a/packages/core/src/plugins/host-options.ts
+++ b/packages/core/src/plugins/host-options.ts
@@ -25,6 +25,7 @@ import type { EmbedderRegistry } from '../registries/embedders.js';
 import type { IsolatorRegistry } from '../registries/isolators.js';
 import type { WorkflowExecutorRegistry } from '../registries/workflow-executors.js';
 import type { EventStoreRegistry } from '../registries/event-stores.js';
+import type { AuditSinkRegistry } from '../registries/audit-sinks.js';
 import type { ReflectorRegistry } from '../registries/reflectors.js';
 import type { HookDispatcherImpl } from './lifecycle.js';
 import type { RequirementRegistry } from '../requirements.js';
@@ -49,6 +50,7 @@ export interface PluginHostOptions {
   readonly isolators: IsolatorRegistry;
   readonly workflowExecutors: WorkflowExecutorRegistry;
   readonly eventStores: EventStoreRegistry;
+  readonly auditSinks: AuditSinkRegistry;
   readonly reflectors: ReflectorRegistry;
   readonly requirements: RequirementRegistry;
   readonly dispatcher: HookDispatcherImpl;

--- a/packages/core/src/plugins/registry-kinds.test.ts
+++ b/packages/core/src/plugins/registry-kinds.test.ts
@@ -36,6 +36,7 @@ import { SynthesizerRegistry } from '../registries/synthesizers.js';
 import { EmbedderRegistry } from '../registries/embedders.js';
 import { IsolatorRegistry } from '../registries/isolators.js';
 import { WorkflowExecutorRegistry } from '../registries/workflow-executors.js';
+import { AuditSinkRegistry } from '../registries/audit-sinks.js';
 import { EventStoreRegistry } from '../registries/event-stores.js';
 import { ReflectorRegistry } from '../registries/reflectors.js';
 import { RequirementRegistry } from '../requirements.js';
@@ -88,6 +89,12 @@ const everyKindPlugin = definePlugin({
       readPage: async () => ({ events: [], prevCursor: null }),
     },
   ],
+  auditSinks: [
+    {
+      name: 'as-1',
+      open: () => ({ write: async () => true, close: async () => {} }),
+    },
+  ],
   reflectors: [{ name: 'refl-1', reflect: async () => [] }],
 });
 
@@ -110,6 +117,7 @@ function makeHost() {
     isolators: new IsolatorRegistry(),
     workflowExecutors: new WorkflowExecutorRegistry(),
     eventStores: new EventStoreRegistry(),
+    auditSinks: new AuditSinkRegistry(),
     reflectors: new ReflectorRegistry(),
   };
   const requirements = new RequirementRegistry({
@@ -150,6 +158,7 @@ function makeHost() {
     isolator: registries.isolators,
     workflowExecutor: registries.workflowExecutors,
     eventStore: registries.eventStores,
+    auditSink: registries.auditSinks,
     reflector: registries.reflectors,
   };
   return { host, byKind };

--- a/packages/core/src/plugins/registry-kinds.ts
+++ b/packages/core/src/plugins/registry-kinds.ts
@@ -16,6 +16,7 @@ import type {
   ViewRendererDef,
   TunnelProviderDef,
   WorkflowExecutorDef,
+  AuditSinkDef,
   EventStoreDef,
   ReflectorDef,
 } from '@moxxy/sdk';
@@ -45,6 +46,7 @@ export interface RegistryNameRecord {
   readonly isolatorNames: ReadonlyArray<string>;
   readonly workflowExecutorNames: ReadonlyArray<string>;
   readonly eventStoreNames: ReadonlyArray<string>;
+  readonly auditSinkNames: ReadonlyArray<string>;
   readonly reflectorNames: ReadonlyArray<string>;
 }
 
@@ -245,6 +247,18 @@ export const REGISTRY_KINDS: ReadonlyArray<RegistryKind<unknown>> = [
     register: (o, e: EventStoreDef) => o.eventStores.register(e),
     unregister: (o, n) => o.eventStores.unregister(n),
   } satisfies RegistryKind<EventStoreDef>,
+  {
+    kind: 'auditSink',
+    recordField: 'auditSinkNames',
+    defs: (p) => p.auditSinks ?? [],
+    nameOf: (a: AuditSinkDef) => a.name,
+    // Throw-on-duplicate `register`, and no auto-activation. A sink's entire
+    // purpose is to send recorded actions off the machine, so a discovered one
+    // becoming active on its own would be an exfiltration path wearing a
+    // compliance hat. The operator opts in via `audit.sink`.
+    register: (o, a: AuditSinkDef) => o.auditSinks.register(a),
+    unregister: (o, n) => o.auditSinks.unregister(n),
+  } satisfies RegistryKind<AuditSinkDef>,
   {
     kind: 'reflector',
     recordField: 'reflectorNames',

--- a/packages/core/src/registries/audit-sinks.ts
+++ b/packages/core/src/registries/audit-sinks.ts
@@ -1,0 +1,19 @@
+import type { AuditSinkDef } from '@moxxy/sdk';
+import { ActiveDefRegistry } from './active-def-registry.js';
+
+/**
+ * The single-active AuditSink registry. Core seeds the hash-chained local sink
+ * as a protected floor; uses throw-on-duplicate `register` (NOT override) so a
+ * discovered plugin's sink is added but never silently shadows the floor. The
+ * operator must `setActive` it by name.
+ *
+ * That opt-in IS the trust boundary, and more so here than for other blocks: an
+ * audit sink sees every recorded action and, unlike the event store, its whole
+ * purpose is to send them somewhere else. Silently adopting a discovered sink
+ * would be a data-exfiltration path wearing a compliance hat.
+ */
+export class AuditSinkRegistry extends ActiveDefRegistry<AuditSinkDef> {
+  constructor() {
+    super({ noun: 'AuditSink' });
+  }
+}

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -36,6 +36,8 @@ import { EmbedderRegistry } from './registries/embedders.js';
 import { IsolatorRegistry } from './registries/isolators.js';
 import { WorkflowExecutorRegistry } from './registries/workflow-executors.js';
 import { EventStoreRegistry } from './registries/event-stores.js';
+import { AuditSinkRegistry } from './registries/audit-sinks.js';
+import { jsonlAuditSink } from './audit/jsonl-audit-sink.js';
 import { ReflectorRegistry } from './registries/reflectors.js';
 import { ServiceRegistryImpl } from './registries/services.js';
 import { jsonlEventStore } from './sessions/jsonl-event-store.js';
@@ -139,6 +141,7 @@ export class Session implements ClientSession, SessionRuntime {
   readonly isolators: IsolatorRegistry;
   readonly workflowExecutors: WorkflowExecutorRegistry;
   readonly eventStores: EventStoreRegistry;
+  readonly auditSinks: AuditSinkRegistry;
   /**
    * The learning-loop block: watches finished turns and proposes memory/skill
    * improvements. NULLABLE — no core-seeded floor, so it stays empty until a
@@ -282,6 +285,12 @@ export class Session implements ClientSession, SessionRuntime {
     // Seed the built-in JSONL store as the protected floor — the storage backend
     // behind the event log always exists and can be swapped but never removed.
     this.eventStores.register(jsonlEventStore, { protected: true });
+    this.auditSinks = new AuditSinkRegistry();
+    // The hash-chained local sink is the protected floor. A discovered plugin's
+    // sink registers alongside it but never auto-activates: a sink's whole job
+    // is to send recorded actions somewhere else, so silent adoption would be
+    // an exfiltration path wearing a compliance hat.
+    this.auditSinks.register(jsonlAuditSink, { protected: true });
     // Reflectors are nullable — no core floor is seeded, so reflection stays off
     // until a reflector plugin registers one. Published on the service registry
     // so a discovery-loaded driver (the reflector plugin's own hooks) can resolve
@@ -335,6 +344,7 @@ export class Session implements ClientSession, SessionRuntime {
       isolators: this.isolators,
       workflowExecutors: this.workflowExecutors,
       eventStores: this.eventStores,
+      auditSinks: this.auditSinks,
       reflectors: this.reflectors,
       requirements: this.requirements,
       dispatcher: this.dispatcher,

--- a/packages/sdk/src/audit.ts
+++ b/packages/sdk/src/audit.ts
@@ -1,0 +1,128 @@
+import type { MoxxyEvent, MoxxyEventType } from './events.js';
+import type { SessionId, TurnId } from './ids.js';
+import type { Principal } from './principal.js';
+
+/**
+ * The audit trail: a tamper-evident record of what the agent did, who it acted
+ * for, and what was allowed or denied, in a form that can LEAVE the machine.
+ *
+ * Distinct from the event log, and the distinction is the whole point. The
+ * event log is the conversation: complete, replayable, local, and full of
+ * payloads nobody wants shipped to a SIEM. An audit record is the receipt:
+ * bounded, redacted, hash-chained, and self-attributing, so one line is
+ * meaningful on its own without replaying a session to interpret it.
+ *
+ * A swappable block like every other, mirroring `EventStoreDef`: core seeds a
+ * protected local floor, plugins register alternatives (syslog, OTel, S3,
+ * webhook), and the operator activates one by name.
+ */
+
+/** What kind of thing happened. Coarser than `MoxxyEventType` on purpose: an
+ *  auditor reasons about categories of action, not about the loop's internals. */
+export type AuditAction =
+  | 'prompt'
+  | 'tool.request'
+  | 'tool.approved'
+  | 'tool.denied'
+  | 'tool.result'
+  | 'skill.invoked'
+  | 'skill.created'
+  | 'plugin.registered'
+  | 'plugin.unregistered'
+  | 'abort'
+  | 'error'
+  | 'other';
+
+/**
+ * One record. Every field is either metadata or already-redacted, so the whole
+ * object is safe to forward.
+ */
+export interface AuditRecord {
+  /** Position in this sink's chain. Contiguous from 0; a gap is evidence. */
+  readonly seq: number;
+  readonly ts: number;
+  readonly sessionId: SessionId;
+  readonly turnId: TurnId;
+  readonly action: AuditAction;
+  /** The underlying event type, kept so a record can be traced back. */
+  readonly eventType: MoxxyEventType;
+  /**
+   * Who it was done for. Absent means unattributed, which is itself worth
+   * auditing: it says the surface could not establish an identity.
+   */
+  readonly actor?: Principal;
+  /** Bounded, redacted, action-specific detail. Never raw payloads. */
+  readonly detail?: Readonly<Record<string, unknown>>;
+  /** Hash of the previous record, or null for the first. */
+  readonly prevHash: string | null;
+  /** Hash over this record's own fields plus {@link prevHash}. */
+  readonly hash: string;
+}
+
+/** A record before the chain fields are computed. */
+export type UnchainedAuditRecord = Omit<AuditRecord, 'seq' | 'prevHash' | 'hash'>;
+
+export interface AuditSinkScope {
+  readonly sessionId: SessionId;
+  readonly cwd: string;
+}
+
+export interface AuditSinkSession {
+  /**
+   * Append one record.
+   *
+   * Takes an UNCHAINED record: sequencing and any tamper-evidence are the
+   * sink's own concern, because each sink has its own ordering. The local file
+   * chains by day; a syslog sink has no chain at all; a remote service assigns
+   * its own sequence. Handing every sink a pre-sealed `seq`/`hash` would be a
+   * lie for all but one of them.
+   *
+   * MUST NOT throw: a failing audit sink degrades loudly, it never takes down
+   * the turn it is recording. Report failure by returning false.
+   */
+  write(record: UnchainedAuditRecord): Promise<boolean>;
+  /** Flush anything buffered. Called on session close. */
+  close(): Promise<void>;
+}
+
+export interface AuditSinkDef {
+  readonly name: string;
+  readonly description?: string;
+  open(scope: AuditSinkScope): AuditSinkSession;
+}
+
+/** Freeze an audit-sink spec, mirroring the other `defineX` factories. */
+export function defineAuditSink(def: AuditSinkDef): AuditSinkDef {
+  return Object.freeze({ ...def });
+}
+
+/**
+ * Which event types produce an audit record, and under what category.
+ *
+ * Everything absent from this map is conversation, not audit: assistant text,
+ * reasoning, provider request/response, compaction, elision, mode iterations.
+ * They belong in the event log and would only bloat a trail an auditor has to
+ * read. Tool and permission traffic is what actually gets reviewed, so it is
+ * named precisely.
+ *
+ * An exhaustive map rather than a `default:` so adding an event type is a
+ * deliberate decision about whether it is auditable, not a silent 'other'.
+ */
+const AUDITED: Partial<Record<MoxxyEventType, AuditAction>> = {
+  user_prompt: 'prompt',
+  tool_call_requested: 'tool.request',
+  tool_call_approved: 'tool.approved',
+  tool_call_denied: 'tool.denied',
+  tool_result: 'tool.result',
+  skill_invoked: 'skill.invoked',
+  skill_created: 'skill.created',
+  plugin_registered: 'plugin.registered',
+  plugin_unregistered: 'plugin.unregistered',
+  abort: 'abort',
+  error: 'error',
+};
+
+/** The audit category for an event, or null when it is conversation only. */
+export function auditActionOf(event: MoxxyEvent): AuditAction | null {
+  return AUDITED[event.type] ?? null;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -47,6 +47,25 @@ export type { EventLogReader } from './log.js';
 export type { Principal } from './principal.js';
 export { samePrincipal, formatPrincipal } from './principal.js';
 
+// Audit trail: the tamper-evident receipt, distinct from the event log.
+export type {
+  AuditAction,
+  AuditRecord,
+  AuditSinkDef,
+  AuditSinkScope,
+  AuditSinkSession,
+  UnchainedAuditRecord,
+} from './audit.js';
+export { defineAuditSink, auditActionOf } from './audit.js';
+
+// Secret redaction for anything leaving the process.
+export {
+  isSecretKey,
+  redactSecrets,
+  redactSecretText,
+  REDACTED_PLACEHOLDER,
+} from './redact.js';
+
 export type {
   RunTurnOptions,
   SessionLogReader,

--- a/packages/sdk/src/plugin.ts
+++ b/packages/sdk/src/plugin.ts
@@ -17,6 +17,7 @@ import type { ViewRendererDef } from './view-renderer.js';
 import type { TunnelProviderDef } from './tunnel.js';
 import type { WorkflowExecutorDef } from './workflow.js';
 import type { EventStoreDef } from './event-store.js';
+import type { AuditSinkDef } from './audit.js';
 import type { ReflectorDef } from './reflector.js';
 
 export type PluginKind = 'tools' | 'provider' | 'mode' | 'compactor' | 'cache-strategy' | 'view-renderer' | 'tunnel-provider' | 'mcp' | 'cli' | 'channel' | 'surface' | 'hooks' | 'agent' | 'command' | 'transcriber' | 'synthesizer' | 'embedder' | 'isolator' | 'workflow-executor' | 'event-store' | 'reflector';
@@ -54,6 +55,9 @@ export interface PluginSpec {
    * boundary, since the store sees every event). See {@link EventStoreDef}.
    */
   readonly eventStores?: ReadonlyArray<EventStoreDef>;
+  /** Audit-trail sinks (syslog, OTel, S3, webhook). Registered alongside the
+   *  protected local floor; never auto-activated, see registry-kinds. */
+  readonly auditSinks?: ReadonlyArray<AuditSinkDef>;
   /**
    * Reflector backends — the learning-loop block that watches a finished turn
    * and *proposes* memory/skill improvements without silently writing. One

--- a/packages/sdk/src/redact.test.ts
+++ b/packages/sdk/src/redact.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { isSecretKey, redactSecretText, redactSecrets } from './redact.js';
+
+describe('isSecretKey', () => {
+  it('recognises the common secret-bearing field names', () => {
+    for (const key of ['apiKey', 'api_key', 'SECRET', 'authToken', 'privateKey', 'Authorization']) {
+      expect(isSecretKey(key)).toBe(true);
+    }
+  });
+
+  it('does not flag ordinary fields', () => {
+    for (const key of ['command', 'path', 'name', 'monkey']) expect(isSecretKey(key)).toBe(false);
+  });
+});
+
+describe('redactSecretText', () => {
+  // The motivating case: the carrier field is `command`, so key-name redaction
+  // alone prints the token verbatim.
+  it('masks a bearer token inside a shell command', () => {
+    const out = redactSecretText('curl -H "Authorization: Bearer sk-ant-api03-XYZ123456789" https://api');
+    expect(out).not.toContain('XYZ123456789');
+    expect(out).toContain('[redacted]');
+    // The attempt itself must stay visible: an auditor needs to see a header
+    // was sent, not just that something was hidden.
+    expect(out).toContain('curl');
+    expect(out.toLowerCase()).toContain('authorization');
+  });
+
+  it('masks vendor key formats wherever they appear', () => {
+    const cases: ReadonlyArray<[string, string]> = [
+      ['sk-ant-api03-ABCDEFGHIJKLMNOP', 'ABCDEFGHIJKLMNOP'],
+      ['ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'],
+      ['xoxb-1234567890-ABCDEFGH', 'ABCDEFGH'],
+      ['AKIAIOSFODNN7EXAMPLE', 'IOSFODNN7EXAMPLE'],
+      ['AIzaSyA1234567890abcdefghijklmnop', 'SyA1234567890abcdefghijklmnop'],
+    ];
+    for (const [input, secret] of cases) {
+      expect(redactSecretText(`value=${input}`)).not.toContain(secret);
+    }
+  });
+
+  it('masks a JWT', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NX0.SflKxwRJSMeKKF2QT4fwpMeJf36P';
+    expect(redactSecretText(`token ${jwt}`)).toContain('[redacted-jwt]');
+  });
+
+  it('masks credentials embedded in a URL', () => {
+    const out = redactSecretText('https://alice:hunter2@proxy.corp:3128/path');
+    expect(out).not.toContain('hunter2');
+    expect(out).toContain('proxy.corp');
+  });
+
+  it('masks KEY=value style assignments', () => {
+    const out = redactSecretText('export GITHUB_TOKEN=abcdef123456 && run');
+    expect(out).not.toContain('abcdef123456');
+    expect(out).toContain('GITHUB_TOKEN');
+  });
+
+  it('leaves ordinary text alone', () => {
+    const text = 'ls -la /home/alice && grep -r "monkey" src/';
+    expect(redactSecretText(text)).toBe(text);
+  });
+});
+
+describe('redactSecrets', () => {
+  it('drops the value of a secret-named field entirely', () => {
+    expect(redactSecrets({ apiKey: 'sk-whatever' })).toEqual({ apiKey: '[redacted]' });
+  });
+
+  it('scans ordinary string fields for secret shapes', () => {
+    const out = redactSecrets({ command: 'curl -H "Authorization: Bearer sk-ant-ABCDEFGH12345678"' });
+    expect(JSON.stringify(out)).not.toContain('ABCDEFGH12345678');
+  });
+
+  it('walks arrays and nested objects', () => {
+    const out = redactSecrets({ steps: [{ env: { TOKEN: 'ghp_ABCDEFGHIJKLMNOPQRSTUV' } }] });
+    expect(JSON.stringify(out)).not.toContain('ABCDEFGHIJKLMNOPQRSTUV');
+  });
+
+  it('bounds the walk so a pathological input cannot blow the stack', () => {
+    let deep: Record<string, unknown> = { apiKey: 'sk-deep' };
+    for (let i = 0; i < 500; i++) deep = { nested: deep };
+    expect(() => redactSecrets(deep)).not.toThrow();
+  });
+
+  it('passes non-objects through unchanged', () => {
+    expect(redactSecrets(42)).toBe(42);
+    expect(redactSecrets(null)).toBe(null);
+    expect(redactSecrets(undefined)).toBe(undefined);
+  });
+});

--- a/packages/sdk/src/redact.ts
+++ b/packages/sdk/src/redact.ts
@@ -1,0 +1,91 @@
+/**
+ * Secret redaction for anything that leaves the process: an audit record, a
+ * terminal prompt, a support paste.
+ *
+ * Two independent passes, because they catch different things and either alone
+ * leaves a real hole:
+ *
+ *   - by KEY NAME, for `{ apiKey: 'sk-…' }`, where the value is opaque.
+ *   - by VALUE SHAPE, for a secret embedded in an ordinary-looking field. The
+ *     motivating case is a Bash tool call: its `command` is not a secret-named
+ *     key, so a key-name pass alone prints
+ *     `curl -H "Authorization: Bearer sk-ant-…"` verbatim.
+ *
+ * Deliberately NOT a guarantee. A redactor that claims completeness invites
+ * treating redacted output as safe to publish; treat it as reducing accidental
+ * exposure, not as sanitisation.
+ */
+
+/** Field names whose VALUES are secret material regardless of shape. */
+const SECRET_KEY =
+  /(?:api[_-]?key|secret|token|password|passwd|passphrase|authorization|auth[_-]?token|bearer|credential|private[_-]?key|access[_-]?key)/i;
+
+/**
+ * Value shapes that are secrets wherever they appear. Ordered vendor prefixes
+ * first (precise, no false positives) then generic bearer/assignment forms.
+ *
+ * Each pattern keeps any leading context in a capture group so the replacement
+ * can preserve it: masking `Authorization: Bearer X` down to just `[redacted]`
+ * would lose the fact that a header was there at all, which matters when the
+ * point is auditing what was attempted.
+ */
+const SECRET_VALUE_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  // Vendor-issued key formats.
+  [/\b(sk-ant-)[A-Za-z0-9_-]{8,}/g, '$1[redacted]'],
+  [/\b(sk-)[A-Za-z0-9_-]{16,}/g, '$1[redacted]'],
+  [/\b(gh[pousr]_)[A-Za-z0-9]{16,}/g, '$1[redacted]'],
+  [/\b(xox[baprs]-)[A-Za-z0-9-]{8,}/g, '$1[redacted]'],
+  [/\b(AKIA)[0-9A-Z]{12,}/g, '$1[redacted]'],
+  [/\b(AIza)[A-Za-z0-9_-]{20,}/g, '$1[redacted]'],
+  // JWTs: three base64url segments.
+  [/\b(ey[A-Za-z0-9_-]{8,})\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g, 'eyJ[redacted-jwt]'],
+  // `Authorization: Bearer <anything>` in a header or a shell command.
+  [/\b(authorization\s*[:=]\s*(?:bearer|basic|token)\s+)\S+/gi, '$1[redacted]'],
+  [/\b(bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[redacted]'],
+  // `FOO_TOKEN=value` / `--api-key value` style assignments.
+  [
+    /\b([A-Za-z0-9_-]*(?:key|token|secret|password|passwd)[A-Za-z0-9_-]*\s*[:=]\s*)(?!\s)["']?[^\s"'&;|]{6,}["']?/gi,
+    '$1[redacted]',
+  ],
+  // Credentials embedded in a URL.
+  [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+:)[^\s@]+(@)/gi, '$1[redacted]$2'],
+];
+
+export const REDACTED_PLACEHOLDER = '[redacted]';
+
+/** True when a field name reads as secret-bearing. */
+export function isSecretKey(key: string): boolean {
+  return SECRET_KEY.test(key);
+}
+
+/**
+ * Mask secret-shaped substrings inside a free-text value. This is the pass that
+ * covers shell commands, URLs, and headers, where the carrier field has an
+ * innocuous name.
+ */
+export function redactSecretText(text: string): string {
+  let out = text;
+  for (const [pattern, replacement] of SECRET_VALUE_PATTERNS) {
+    out = out.replace(pattern, replacement);
+  }
+  return out;
+}
+
+/**
+ * Redact a structured value: secret-named fields lose their value entirely,
+ * every other string is scanned for secret-shaped content.
+ *
+ * `maxDepth` bounds the walk so a pathologically nested input cannot blow the
+ * stack; anything deeper is returned unredacted, which is why callers that
+ * accept untrusted shapes should also cap size before display.
+ */
+export function redactSecrets(value: unknown, maxDepth = 6, depth = 0): unknown {
+  if (typeof value === 'string') return redactSecretText(value);
+  if (depth >= maxDepth || value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map((v) => redactSecrets(v, maxDepth, depth + 1));
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    out[k] = SECRET_KEY.test(k) ? REDACTED_PLACEHOLDER : redactSecrets(v, maxDepth, depth + 1);
+  }
+  return out;
+}


### PR DESCRIPTION
Wave 5, and the last P0. Stacked on #470 → #469 → #468 → #467.

`audit log` appeared in this codebase only in comments. What existed was the event log: the conversation, complete and replayable, but local, with no retention, no export, no tamper evidence, and full of payloads nobody wants forwarded to a SIEM.

An audit record is a different artifact. It is the receipt: bounded, redacted, hash-chained, and self-attributing, so one line means something without replaying a session. That is what W3's decision to stamp the full Principal on every event was for, and this is where it pays off.

Design calls worth reviewing:

**`write` takes an unchained record.** Sequencing and tamper-evidence are each sink's own concern: the local file chains by day, syslog has no chain, a remote service assigns its own sequence. My first cut handed every sink a pre-sealed `seq`/`hash` and had the local sink re-seal at its own position, which silently produced a stale hash. Caught it before tests. Handing over an unchained record is the honest contract.

**Tamper-evident, not tamper-proof, and the code says so.** Whoever can write the file can recompute the whole chain. What chaining catches is silent selective deletion, which is the realistic threat: an operator or an agent quietly dropping the one line recording what they did. Real tamper-proofing needs the chain head somewhere the machine cannot rewrite, which is what a remote sink provides. I'd rather ship an honest control than an overclaimed one.

**Discovered sinks never auto-activate.** True of other blocks too, but load-bearing here: a sink's whole job is to send recorded actions elsewhere, so silent adoption would be an exfiltration path wearing a compliance hat.

**Prompt text is off by default.** The trail proves what was done; prompts carry business content with no reason to leave the machine. The SHA-256 is always recorded, so a specific prompt stays provable against the trail without the trail disclosing it.

**Writes are fire-and-forget but queued.** Blocking a tool call on a slow audit sink would make logging a liveness risk. An agent that hangs because logging is slow is worse than one whose logging is behind. The queue keeps chain order despite that.

Also lands `redactSecrets` / `redactSecretText` in the SDK, masking by value shape as well as field name. The motivating case is the one from the audit doc: a Bash `command` is not a secret-named key, so a key-name pass alone records `curl -H "Authorization: Bearer sk-ant-…"` verbatim. W10 will adopt the same helper for the TUI permission dialog.

Verified: full gate green (build, typecheck, lint 0 errors, check:deps 0 errors, all test tasks). 37 new tests covering chain verification against removal/alteration/reordering, key-order-independent hashing, concurrent appends, day resumption after restart, truncated-line tolerance, redaction, and a sink that throws.

`registry-kinds.test.ts` failed when I added the kind, which is the lockstep guard doing exactly its job: a new registry kind has to be exercised there too. Updated rather than exempted.